### PR TITLE
WinMD: move data reading into an internal extension

### DIFF
--- a/Sources/WinMD/CIL.swift
+++ b/Sources/WinMD/CIL.swift
@@ -106,16 +106,6 @@ internal struct Assembly {
   }
 }
 
-fileprivate func read<T: FixedWidthInteger>(_ data: Data, offset: Data.Index) -> T {
-  var value: T = 0
-  withUnsafeMutableBytes(of: &value) {
-    let begin: Data.Index = data.index(data.startIndex, offsetBy: offset)
-    let end: Data.Index = data.index(begin, offsetBy: $0.count)
-    data.copyBytes(to: $0, from: begin ..< end)
-  }
-  return value
-}
-
 private var CIL_METADATA_SIGNATURE: DWORD { 0x424a5342 }
 
 /// Stream Header
@@ -126,11 +116,11 @@ internal struct StreamHeader {
   internal let data: Data
 
   public var Offset: UInt32 {
-    return read(data, offset: 0)
+    return data.read(offset: 0)
   }
 
   public var Size: UInt32 {
-    return read(data, offset: 4)
+    return data.read(offset: 4)
   }
 
   public var Name: String {
@@ -162,23 +152,23 @@ internal struct Metadata {
   internal let data: Data
 
   public var Signature: UInt32 {
-    return read(data, offset: 0)
+    return data.read(offset: 0)
   }
 
   public var MajorVersion: UInt16 {
-    return read(data, offset: 4)
+    return data.read(offset: 4)
   }
 
   public var MinorVersion: UInt16 {
-    return read(data, offset: 6)
+    return data.read(offset: 6)
   }
 
   public var Reserved: UInt32 {
-    return read(data, offset: 8)
+    return data.read(offset: 8)
   }
 
   public var Length: UInt32 {
-    return read(data, offset: 12)
+    return data.read(offset: 12)
   }
 
   public var Version: String {
@@ -193,7 +183,7 @@ internal struct Metadata {
   }
 
   public var Streams: UInt16 {
-    return read(data, offset: 18 + Int(Length))
+    return data.read(offset: 18 + Int(Length))
   }
 
   public var StreamHeaders: [StreamHeader] {
@@ -316,23 +306,23 @@ internal struct MetadataTablesStream {
   internal let data: Data
 
   public var MajorVersion: UInt8 {
-    return read(data, offset: 4)
+    return data.read(offset: 4)
   }
 
   public var MinorVersion: UInt8 {
-    return read(data, offset: 5)
+    return data.read(offset: 5)
   }
 
   public var HeapOffsetSizes: UInt8 {
-    return read(data, offset: 6)
+    return data.read(offset: 6)
   }
 
   public var Valid: UInt64 {
-    return read(data, offset: 8)
+    return data.read(offset: 8)
   }
 
   public var Sorted: UInt64 {
-    return read(data, offset: 16)
+    return data.read(offset: 16)
   }
 
   public var Rows: [DWORD] {

--- a/Sources/WinMD/Data+Extensions.swift
+++ b/Sources/WinMD/Data+Extensions.swift
@@ -27,39 +27,15 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  **/
 
-import WinSDK
 import Foundation
 
-public class Database {
-  private let dos: DOSFile
-  private let pe: PEFile
-  private let cil: Assembly
-
-  private init(data: Data) throws {
-    dos = DOSFile(data: data)
-    try dos.validate()
-
-    pe = PEFile(from: dos)
-    try pe.validate()
-
-    cil = try Assembly(from: pe)
-    try cil.validate()
-  }
-
-  public convenience init(at path: URL) throws {
-    let buffer: Data = try NSData(contentsOf: path, options: .alwaysMapped) as Data
-    try self.init(data: buffer)
-  }
-
-  public convenience init(atPath path: String) throws {
-    try self.init(at: URL(fileURLWithPath: path))
-  }
-
-  public func dump() {
-    guard case let .success(metadata) = cil.Metadata else { return }
-
-    print("Version: \(metadata.Version)")
-    print("Streams: \(metadata.Streams)")
-    _ = metadata.StreamHeaders.map { print($0) }
+extension Data {
+  internal func read<T>(offset: Data.Index) -> T {
+    let begin: Data.Index = self.index(self.startIndex, offsetBy: offset)
+    let end: Data.Index = self.index(begin, offsetBy: MemoryLayout<T>.stride)
+    return Array<T>(unsafeUninitializedCapacity: 1) {
+      self.copyBytes(to: $0, from: begin ..< end)
+      $1 = 1
+    }[0]
   }
 }

--- a/Sources/winmd-inspect/main.swift
+++ b/Sources/winmd-inspect/main.swift
@@ -30,5 +30,6 @@
 import Foundation
 import WinMD
 
-let database: WinMD.Database? =
-    try! WinMD.Database(atPath: "C:\\Windows\\System32\\WinMetadata\\Windows.Foundation.winmd")
+if let database = try? WinMD.Database(atPath: "C:\\Windows\\System32\\WinMetadata\\Windows.Foundation.winmd") {
+  database.dump()
+}


### PR DESCRIPTION
Use some more clever tricks to create a non-mutating read that is
generic as an extension to `Data`.