### PR TITLE
WinMD: reduce some usage of `DWORD`

### DIFF
--- a/Sources/WinMD/CIL.swift
+++ b/Sources/WinMD/CIL.swift
@@ -30,7 +30,7 @@
 import WinSDK
 import Foundation
 
-private var CIL_METADATA_SIGNATURE: DWORD { 0x424a5342 }
+private var CIL_METADATA_SIGNATURE: UInt32 { 0x424a5342 }
 
 internal struct Assembly {
   private let header: Data
@@ -47,7 +47,7 @@ internal struct Assembly {
   }
 
   public init(from pe: PEFile) throws {
-    func data(VA: DWORD, Size: DWORD) throws -> Data {
+    func data(VA: UInt32, Size: UInt32) throws -> Data {
       let sections = pe.Sections.containing(rva: VA)
       guard sections.count == 1, let LA = sections.first?.offset(from: VA) else {
         throw WinMDError.BadImageFormat

--- a/Sources/WinMD/PEFile.swift
+++ b/Sources/WinMD/PEFile.swift
@@ -101,7 +101,7 @@ internal struct PEFile {
 }
 
 extension Array where Array.Element == IMAGE_SECTION_HEADER {
-  internal func containing(rva: DWORD) -> [IMAGE_SECTION_HEADER] {
+  internal func containing(rva: UInt32) -> [IMAGE_SECTION_HEADER] {
     return self.filter {
       rva >= $0.VirtualAddress && rva < $0.VirtualAddress + $0.Misc.VirtualSize
     }
@@ -109,7 +109,7 @@ extension Array where Array.Element == IMAGE_SECTION_HEADER {
 }
 
 extension IMAGE_SECTION_HEADER {
-  internal func offset(from rva: DWORD) -> DWORD {
+  internal func offset(from rva: UInt32) -> UInt32 {
     return rva - self.VirtualAddress + self.PointerToRawData
   }
 }


### PR DESCRIPTION
This reduces the dependency on `WinSDK`.