### PR TITLE
WinMD: promote `CodedIndex` to a type

### DIFF
--- a/Sources/WinMD/CodedIndex.swift
+++ b/Sources/WinMD/CodedIndex.swift
@@ -1,0 +1,159 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ **/
+
+internal protocol CodedIndex: Hashable {
+  static var tables: [Table.Type] { get }
+}
+
+internal struct HasConstant: CodedIndex {
+  public static var tables: [Table.Type] {
+    return [
+      Metadata.Tables.Param.self,
+      Metadata.Tables.Field.self,
+      Metadata.Tables.Property.self,
+    ]
+  }
+}
+
+internal struct HasCustomAttribute: CodedIndex {
+  public static var tables: [Table.Type] {
+    return [
+      Metadata.Tables.MethodDef.self,
+      Metadata.Tables.MemberRef.self,
+    ]
+  }
+}
+
+internal struct CustomAttributeType: CodedIndex {
+  public static var tables: [Table.Type] {
+    return [
+      Metadata.Tables.MethodDef.self,
+      Metadata.Tables.MemberRef.self,
+    ]
+  }
+}
+
+internal struct HasDeclSecurity: CodedIndex {
+  public static var tables: [Table.Type] {
+    return [
+      Metadata.Tables.TypeDef.self,
+      Metadata.Tables.MethodDef.self,
+      Metadata.Tables.Assembly.self,
+    ]
+  }
+}
+
+internal struct TypeDefOrRef: CodedIndex {
+  public static var tables: [Table.Type] {
+    return [
+      Metadata.Tables.TypeDef.self,
+      Metadata.Tables.TypeRef.self,
+      Metadata.Tables.TypeSpec.self,
+    ]
+  }
+}
+
+// FIXME(compnerd) Exported vs Manifest Resource
+internal struct Implementation: CodedIndex {
+  public static var tables: [Table.Type] {
+    return [
+      Metadata.Tables.File.self,
+      Metadata.Tables.ExportedType.self,
+      Metadata.Tables.AssemblyRef.self,
+    ]
+  }
+}
+
+internal struct HasFieldMarshal: CodedIndex {
+  public static var tables: [Table.Type] {
+    return [
+      Metadata.Tables.Field.self,
+      Metadata.Tables.Param.self,
+    ]
+  }
+}
+
+internal struct TypeOrMethodDef: CodedIndex {
+  public static var tables: [Table.Type] {
+    return [
+      Metadata.Tables.TypeDef.self,
+      Metadata.Tables.MethodDef.self,
+    ]
+  }
+}
+
+internal struct MemberForwarded: CodedIndex {
+  public static var tables: [Table.Type] {
+    return [
+      Metadata.Tables.Field.self,
+      Metadata.Tables.MethodDef.self,
+    ]
+  }
+}
+
+internal struct MemberRefParent: CodedIndex {
+  public static var tables: [Table.Type] {
+    return [
+      Metadata.Tables.MethodDef.self,
+      Metadata.Tables.ModuleRef.self,
+      Metadata.Tables.TypeDef.self,
+      Metadata.Tables.TypeRef.self,
+      Metadata.Tables.TypeSpec.self,
+    ]
+  }
+}
+
+internal struct HasSemantics: CodedIndex {
+  public static var tables: [Table.Type] {
+    return [
+      Metadata.Tables.Event.self,
+      Metadata.Tables.Property.self,
+    ]
+  }
+}
+
+internal struct MethodDefOrRef: CodedIndex {
+  public static var tables: [Table.Type] {
+    return [
+      Metadata.Tables.MethodDef.self,
+      Metadata.Tables.MemberRef.self,
+    ]
+  }
+}
+
+internal struct ResolutionScope: CodedIndex {
+  public static var tables: [Table.Type] {
+    return [
+      Metadata.Tables.Module.self,
+      Metadata.Tables.ModuleRef.self,
+      Metadata.Tables.AssemblyRef.self,
+      Metadata.Tables.TypeRef.self,
+    ]
+  }
+}

--- a/Sources/WinMD/TablesStream.swift
+++ b/Sources/WinMD/TablesStream.swift
@@ -102,12 +102,26 @@ internal struct TablesStream {
 }
 
 extension TablesStream {
+  internal var StringIndexSize: Int {
+    (HeapSizes >> 0) & 1 == 1 ? 4 : 2
+  }
+
+  internal var GUIDIndexSize: Int {
+    (HeapSizes >> 1) & 1 == 1 ? 4 : 2
+  }
+
+  internal var BlobIndexSize: Int {
+    (HeapSizes >> 2) & 1 == 1 ? 4 : 2
+  }
+}
+
+extension TablesStream {
   private func strides(tables: UInt64, rows: [UInt32]) -> [TableIndex:Int] {
     var strides: [TableIndex:Int] = [:]
 
-    func IndexSize(for set: [Table.Type]) -> Int {
-      let TagLength = (set.count - 1).nonzeroBitCount
-      return set.map {
+    func TableIndexSize<T: CodedIndex>(_ index: T.Type) -> Int {
+      let TagLength = (index.tables.count - 1).nonzeroBitCount
+      return index.tables.map {
         let count = rows[(tables & ((1 << $0.number) - 1)).nonzeroBitCount]
         let range = 1 << (16 - TagLength)
         return count < range
@@ -130,34 +144,20 @@ extension TablesStream {
     }
 
     // Coded Indices
-    strides[.coded(HasConstant)] = IndexSize(for: HasConstantTables)
-    strides[.coded(HasCustomAttribute)] = IndexSize(for: HasCustomAttributeTables)
-    strides[.coded(CustomAttributeType)] = IndexSize(for: CustomAttributeTypeTables)
-    strides[.coded(HasDeclSecurity)] = IndexSize(for: HasDeclSecurityTables)
-    strides[.coded(TypeDefOrRef)] = IndexSize(for: TypeDefOrRefTables)
-    strides[.coded(Implementation)] = IndexSize(for: ImplementationTables)
-    strides[.coded(HasFieldMarshal)] = IndexSize(for: HasFieldMarshalTables)
-    strides[.coded(TypeOrMethodDef)] = IndexSize(for: TypeOrMethodDefTables)
-    strides[.coded(MemberForwarded)] = IndexSize(for: MemberForwardedTables)
-    strides[.coded(MemberRefParent)] = IndexSize(for: MemberRefParentTables)
-    strides[.coded(HasSemantics)] = IndexSize(for: HasSemanticsTables)
-    strides[.coded(MethodDefOrRef)] = IndexSize(for: MethodDefOrRefTables)
-    strides[.coded(ResolutionScope)] = IndexSize(for: ResolutionScopeTables)
+    strides[HasConstant] = TableIndexSize(HasConstant.self)
+    strides[HasCustomAttribute] = TableIndexSize(HasCustomAttribute.self)
+    strides[CustomAttributeType] = TableIndexSize(CustomAttributeType.self)
+    strides[HasDeclSecurity] = TableIndexSize(HasDeclSecurity.self)
+    strides[TypeDefOrRef] = TableIndexSize(TypeDefOrRef.self)
+    strides[Implementation] = TableIndexSize(Implementation.self)
+    strides[HasFieldMarshal] = TableIndexSize(HasFieldMarshal.self)
+    strides[TypeOrMethodDef] = TableIndexSize(TypeOrMethodDef.self)
+    strides[MemberForwarded] = TableIndexSize(MemberForwarded.self)
+    strides[MemberRefParent] = TableIndexSize(MemberRefParent.self)
+    strides[HasSemantics] = TableIndexSize(HasSemantics.self)
+    strides[MethodDefOrRef] = TableIndexSize(MethodDefOrRef.self)
+    strides[ResolutionScope] = TableIndexSize(ResolutionScope.self)
 
     return strides
-  }
-}
-
-extension TablesStream {
-  internal var StringIndexSize: Int {
-    (HeapSizes >> 0) & 1 == 1 ? 4 : 2
-  }
-
-  internal var GUIDIndexSize: Int {
-    (HeapSizes >> 1) & 1 == 1 ? 4 : 2
-  }
-
-  internal var BlobIndexSize: Int {
-    (HeapSizes >> 2) & 1 == 1 ? 4 : 2
   }
 }


### PR DESCRIPTION
This creates a proper type to model a `CodedIndex`.  Doing so results in
an easier to read implementation for the computation of the size of the
stride of an entry.