### PR TITLE
CPE: make more portable, add missing copyright

### DIFF
--- a/Sources/CPE/include/CPE.h
+++ b/Sources/CPE/include/CPE.h
@@ -1,3 +1,9 @@
+/**
+ * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All Rights Reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
 
 #ifndef CPE_CPE_h
 #define CPE_CPE_h

--- a/Sources/CPE/include/module.modulemap
+++ b/Sources/CPE/include/module.modulemap
@@ -1,3 +1,0 @@
-module CPE {
-  header "CPE.h"
-}

--- a/Sources/CPE/shims.c
+++ b/Sources/CPE/shims.c
@@ -4,3 +4,5 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  **/
+
+extern unsigned _;


### PR DESCRIPTION
Add a missing copyright header to CPE.h.  C does not permit an empty
translation unit.  Add a single declaration to the translation unit to
ensure that the translation unit is portable.