### PR TITLE
WinMD: internalise `CPE`

### DIFF
--- a/Sources/WinMD/CIL.swift
+++ b/Sources/WinMD/CIL.swift
@@ -5,8 +5,10 @@
  * SPDX-License-Identifier: BSD-3-Clause
  **/
 
-import CPE
 import Foundation
+
+@_implementationOnly
+import CPE
 
 private var CIL_METADATA_SIGNATURE: UInt32 { 0x424a5342 }
 

--- a/Sources/WinMD/DOSFile.swift
+++ b/Sources/WinMD/DOSFile.swift
@@ -5,8 +5,10 @@
  * SPDX-License-Identifier: BSD-3-Clause
  **/
 
-import CPE
 import Foundation
+
+@_implementationOnly
+import CPE
 
 internal struct DOSFile {
   internal let data: Data

--- a/Sources/WinMD/PEFile.swift
+++ b/Sources/WinMD/PEFile.swift
@@ -5,8 +5,10 @@
  * SPDX-License-Identifier: BSD-3-Clause
  **/
 
-import CPE
 import Foundation
+
+@_implementationOnly
+import CPE
 
 internal struct PEFile {
   internal let data: Data


### PR DESCRIPTION
The `CPE` module is not meant to be exposed to users.  It is a set of
definitions required to deal with the PE/COFF binary file format.  Mark
all the imports of the module as `@_implementationOnly`.