### PR TITLE
winmd-inspect: more stringent handling of path arguments

### DIFF
--- a/Sources/winmd-inspect/FileURL.swift
+++ b/Sources/winmd-inspect/FileURL.swift
@@ -1,0 +1,46 @@
+/**
+ * Copyright © 2021 Gwynne Raskind <gwynne@darkrainfall.org>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+import struct Foundation.URL
+import struct Foundation.URLResourceKey
+
+import ArgumentParser
+
+/// Simplistic wrapper for processing a file URL as an argument.
+internal struct FileURL: ExpressibleByArgument {
+  /// The file URL.
+  public let url: URL
+
+  /// See `ExpressibleByArgument.init?(argument:)`.
+  public init?(argument: String) {
+    self.url = .init(fileURLWithPath: argument)
+  }
+
+  /// A trivial existence check. Returns `false` on any error. Same caveats as
+  /// `FileManager.fileExists(atPath:)`.
+  ///
+  /// NOTE: this is not safe against TOCTOU
+  public var existsOnDisk: Bool {
+    return (try? self.url.checkResourceIsReachable()) ?? false
+  }
+
+  /// A trivial "is a directory" check. Returns `false` on any error, which is
+  /// not terribly helpful.
+  ///
+  /// NOTE: this is not safe against TOCTOU
+  public var isDirectory: Bool {
+    return (try? self.url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
+  }
+
+  /// A trivial "is a plain file" check. Returns `false` on any error, which is
+  /// not terribly helpful.
+  ///
+  /// NOTE: this is not safe against TOCTOU
+  public var isRegularFile: Bool {
+    return (try? self.url.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile) ?? false
+  }
+}

--- a/Sources/winmd-inspect/main.swift
+++ b/Sources/winmd-inspect/main.swift
@@ -10,12 +10,18 @@ import WinMD
 
 struct Inspect: ParsableCommand {
   @Argument
-  var database: String
+  var database: FileURL
+
+  func validate() throws {
+    guard self.database.existsOnDisk && self.database.isRegularFile else {
+      throw ValidationError("Database must be an existing file.")
+    }
+  }
 
   func run() throws {
     // "C:\\Windows\\System32\\WinMetadata\\Windows.Foundation.winmd"
     print("inspect: \(self.database)")
-    if let database = try? WinMD.Database(atPath: self.database) {
+    if let database = try? WinMD.Database(at: self.database.url) {
       database.dump()
     }
   }


### PR DESCRIPTION
- Add a simplistic wrapper for parsing a file URL as an @Argument.
- Validate that the input database exists and refers to a plain file.

Co-authored By: Saleem Abdulrasool <compnerd@compnerd.org>