### PR TITLE
WinMD: improve raw data handling and cleanup the `DOSFile` interface

### DIFF
--- a/Sources/WinMD/CIL.swift
+++ b/Sources/WinMD/CIL.swift
@@ -35,7 +35,7 @@ internal struct Assembly {
 
       let begin: Data.Index = Data.Index(LA)
       let end: Data.Index = pe.data.index(begin, offsetBy: Int(Size))
-      return pe.data[begin ..< end]
+      return Data(pe.data[begin ..< end])
     }
 
     // CLI Header

--- a/Sources/WinMD/DOSFile.swift
+++ b/Sources/WinMD/DOSFile.swift
@@ -11,21 +11,42 @@ import Foundation
 import CPE
 
 internal struct DOSFile {
-  internal let data: Data
+  internal let data: [UInt8]
 
-  public var Header: IMAGE_DOS_HEADER {
-    return data.withUnsafeBytes {
-      return $0.bindMemory(to: IMAGE_DOS_HEADER.self).baseAddress!.pointee
+  public init(from data: [UInt8]) throws {
+    // NOTE: We initialize the properties before validating the input to avoid
+    // duplicating the logic to extract the header or converting the validation
+    // into a static method.
+    self.data = data
+
+    // Must have enough data to even contain a DOS stub.
+    guard self.data.count >= MemoryLayout<IMAGE_DOS_HEADER>.size else {
+      throw WinMDError.BadImageFormat
+    }
+
+    // Bad signature? Not a DOS file.
+    guard self.Header.e_magic == IMAGE_DOS_SIGNATURE else {
+      throw WinMDError.BadImageFormat
+    }
+
+    // The LFA of the PE signature (if there is one) must be within the file's
+    // bounds.
+    guard self.Header.e_lfanew < self.data.count else {
+      throw WinMDError.BadImageFormat
     }
   }
 
-  public func validate() throws {
-    guard data.count > MemoryLayout<IMAGE_DOS_HEADER>.size else {
-      throw WinMDError.BadImageFormat
+  /// The raw MS-DOS stub image header.
+  public var Header: IMAGE_DOS_HEADER {
+    return self.data.withUnsafeBytes {
+      $0.bindMemory(to: IMAGE_DOS_HEADER.self)[0]
     }
+  }
 
-    guard Header.e_magic == IMAGE_DOS_SIGNATURE else {
-      throw WinMDError.BadImageFormat
-    }
+  /// The complete contents of the file excluding the MS-DOS stub. Returns a
+  /// slice to help avoid excess copying.  This unwraps the MS-DOS stub
+  /// envelope on a PE/COFF file.
+  public var NewExecutable: ArraySlice<UInt8> {
+    return self.data[numericCast(self.Header.e_lfanew)...]
   }
 }

--- a/Sources/WinMD/Database.swift
+++ b/Sources/WinMD/Database.swift
@@ -12,20 +12,19 @@ public class Database {
   private let pe: PEFile
   private let cil: Assembly
 
-  private init(data: Data) throws {
-    dos = DOSFile(data: data)
-    try dos.validate()
-
-    pe = PEFile(from: dos)
-    try pe.validate()
-
-    cil = try Assembly(from: pe)
+  private init(data: [UInt8]) throws {
+    self.dos = try DOSFile(from: data)
+    self.pe = try PEFile(from: self.dos)
+    self.cil = try Assembly(from: self.pe)
     try cil.validate()
   }
 
   public convenience init(at path: URL) throws {
-    let buffer: Data = try NSData(contentsOf: path, options: .alwaysMapped) as Data
-    try self.init(data: buffer)
+    // Although it is inconvenient to read data from a file without using
+    // `Data`, once the data has been read, it is usually easier to work with a
+    // byte array representation.  Unfortunately, this conversion is likely to
+    // incur a pointless copy.
+    try self.init(data: Array(Data(contentsOf: path, options: .alwaysMapped)))
   }
 
   public func dump() {


### PR DESCRIPTION
- Have `Database` convert the read `Data` to an `Array<UInt8>` for
  easier handling.
- Make `DOSFile`'s initializer throwing and factor the `validate()`
  method into it.
- Add validation of the `e_lfanew` value.
- Added documentation comments for all of `DOSFile`.

Co-Authored By: Saleem Abdulrasool <compnerd@compnerd.org>