### PR TITLE
winmd-inspect: use `@main`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,11 @@ let SwiftWinMD = Package(
             dependencies: [
               "WinMD",
               .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ],
+            swiftSettings: [
+              .unsafeFlags([
+                "-parse-as-library",
+              ]),
             ]),
   ]
 )

--- a/Sources/winmd-inspect/main.swift
+++ b/Sources/winmd-inspect/main.swift
@@ -8,6 +8,7 @@
 import ArgumentParser
 import WinMD
 
+@main
 struct Inspect: ParsableCommand {
   @Argument
   var database: FileURL
@@ -26,5 +27,3 @@ struct Inspect: ParsableCommand {
     }
   }
 }
-
-Inspect.main()


### PR DESCRIPTION
Use `@main` decoration rather than explicitly invoking `main`.  This is
purely syntactic sugar, but is more idiomatic for Swift.