### PR TITLE
WinMD: convert `Data` to `ArraySlice<UInt8>`

### DIFF
--- a/Sources/WinMD/CILTables.swift
+++ b/Sources/WinMD/CILTables.swift
@@ -17,10 +17,10 @@ internal protocol Table {
   var rows: Int { get }
 
   /// The data backing the table model.
-  var data: Data { get }
+  var data: ArraySlice<UInt8> { get }
 
   /// Constructs a new table model.
-  init(from data: Data, rows: UInt32, strides: [TableIndex:Int])
+  init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int])
 }
 
 enum TableIndex {
@@ -102,11 +102,11 @@ internal struct Assembly: Table {
   let layout: RecordLayout
   let stride: Int
   let rows: Int
-  let data: Data
+  let data: ArraySlice<UInt8>
 
   public static var number: Int { 32 }
 
-  public init(from data: Data, rows: UInt32, strides: [TableIndex:Int]) {
+  public init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int]) {
     self.layout = (4, 2, 2, 2, 2, 4, strides[.blob]!, strides[.string]!, strides[.string]!)
     self.stride = WinMD.stride(of: self.layout)
 
@@ -125,11 +125,11 @@ internal struct AssemblyOS: Table {
   let layout: RecordLayout
   let stride: Int
   let rows: Int
-  let data: Data
+  let data: ArraySlice<UInt8>
 
   public static var number: Int { 34 }
 
-  public init(from data: Data, rows: UInt32, strides: [TableIndex:Int]) {
+  public init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int]) {
     self.layout = (4, 4, 4)
     self.stride = WinMD.stride(of: self.layout)
 
@@ -146,11 +146,11 @@ internal struct AssemblyProcessor: Table {
   let layout: RecordLayout
   let stride: Int
   let rows: Int
-  let data: Data
+  let data: ArraySlice<UInt8>
 
   public static var number: Int { 33 }
 
-  public init(from data: Data, rows: UInt32, strides: [TableIndex:Int]) {
+  public init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int]) {
     self.layout = (4)
     self.stride = 4
 
@@ -175,11 +175,11 @@ internal struct AssemblyRef: Table {
   let layout: RecordLayout
   let stride: Int
   let rows: Int
-  let data: Data
+  let data: ArraySlice<UInt8>
 
   public static var number: Int { 35 }
 
-  public init(from data: Data, rows: UInt32, strides: [TableIndex:Int]) {
+  public init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int]) {
     self.layout = (2, 2, 2, 2, 4, strides[.blob]!, strides[.string]!, strides[.string]!, strides[.blob]!)
     self.stride = WinMD.stride(of: self.layout)
 
@@ -199,11 +199,11 @@ internal struct AssemblyRefOS: Table {
   let layout: RecordLayout
   let stride: Int
   let rows: Int
-  let data: Data
+  let data: ArraySlice<UInt8>
 
   public static var number: Int { 37 }
 
-  public init(from data: Data, rows: UInt32, strides: [TableIndex:Int]) {
+  public init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int]) {
     self.layout = (4, 4, 4, strides[AssemblyRef.self]!)
     self.stride = WinMD.stride(of: self.layout)
 
@@ -221,11 +221,11 @@ internal struct AssemblyRefProcessor: Table {
   let layout: RecordLayout
   let stride: Int
   let rows: Int
-  let data: Data
+  let data: ArraySlice<UInt8>
 
   public static var number: Int { 36 }
 
-  public init(from data: Data, rows: UInt32, strides: [TableIndex:Int]) {
+  public init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int]) {
     self.layout = (4, strides[AssemblyRef.self]!)
     self.stride = WinMD.stride(of: self.layout)
 
@@ -244,11 +244,11 @@ internal struct ClassLayout: Table {
   let layout: RecordLayout
   let stride: Int
   let rows: Int
-  let data: Data
+  let data: ArraySlice<UInt8>
 
   public static var number: Int { 15 }
 
-  public init(from data: Data, rows: UInt32, strides: [TableIndex:Int]) {
+  public init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int]) {
     self.layout = (2, 4, strides[TypeDef.self]!)
     self.stride = WinMD.stride(of: self.layout)
 
@@ -267,11 +267,11 @@ internal struct Constant: Table {
   let layout: RecordLayout
   let stride: Int
   let rows: Int
-  let data: Data
+  let data: ArraySlice<UInt8>
 
   public static var number: Int { 11 }
 
-  public init(from data: Data, rows: UInt32, strides: [TableIndex:Int]) {
+  public init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int]) {
     self.layout = (1, 1, strides[HasConstant.self]!, strides[.blob]!)
     self.stride = WinMD.stride(of: self.layout)
 
@@ -290,11 +290,11 @@ internal struct CustomAttribute: Table {
   let layout: RecordLayout
   let stride: Int
   let rows: Int
-  let data: Data
+  let data: ArraySlice<UInt8>
 
   public static var number: Int { 12 }
 
-  public init(from data: Data, rows: UInt32, strides: [TableIndex:Int]) {
+  public init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int]) {
     self.layout = (strides[HasCustomAttribute.self]!, strides[CustomAttributeType.self]!, strides[.blob]!)
     self.stride = WinMD.stride(of: self.layout)
 
@@ -313,11 +313,11 @@ internal struct DeclSecurity: Table {
   let layout: RecordLayout
   let stride: Int
   let rows: Int
-  let data: Data
+  let data: ArraySlice<UInt8>
 
   public static var number: Int { 14 }
 
-  public init(from data: Data, rows: UInt32, strides: [TableIndex:Int]) {
+  public init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int]) {
     self.layout = (2, strides[HasDeclSecurity.self]!, strides[.blob]!)
     self.stride = WinMD.stride(of: self.layout)
 
@@ -335,11 +335,11 @@ internal struct EventMap: Table {
   let layout: RecordLayout
   let stride: Int
   let rows: Int
-  let data: Data
+  let data: ArraySlice<UInt8>
 
   public static var number: Int { 18 }
 
-  public init(from data: Data, rows: UInt32, strides: [TableIndex:Int]) {
+  public init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int]) {
     self.layout = (strides[TypeDef.self]!, strides[EventDef.self]!)
     self.stride = WinMD.stride(of: self.layout)
 
@@ -358,11 +358,11 @@ internal struct EventDef: Table {
   let layout: RecordLayout
   let stride: Int
   let rows: Int
-  let data: Data
+  let data: ArraySlice<UInt8>
 
   public static var number: Int { 20 }
 
-  public init(from data: Data, rows: UInt32, strides: [TableIndex:Int]) {
+  public init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int]) {
     self.layout = (2, strides[.string]!, strides[TypeDefOrRef.self]!)
     self.stride = WinMD.stride(of: self.layout)
 
@@ -383,11 +383,11 @@ internal struct ExportedType: Table {
   let layout: RecordLayout
   let stride: Int
   let rows: Int
-  let data: Data
+  let data: ArraySlice<UInt8>
 
   public static var number: Int { 39 }
 
-  public init(from data: Data, rows: UInt32, strides: [TableIndex:Int]) {
+  public init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int]) {
     self.layout = (4, 4, strides[.string]!, strides[.string]!, strides[Implementation.self]!)
     self.stride = WinMD.stride(of: self.layout)
 
@@ -406,11 +406,11 @@ internal struct FieldDef: Table {
   let layout: RecordLayout
   let stride: Int
   let rows: Int
-  let data: Data
+  let data: ArraySlice<UInt8>
 
   public static var number: Int { 4 }
 
-  public init(from data: Data, rows: UInt32, strides: [TableIndex:Int]) {
+  public init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int]) {
     self.layout = (2, strides[.string]!, strides[.blob]!)
     self.stride = WinMD.stride(of: self.layout)
 
@@ -428,11 +428,11 @@ internal struct FieldLayout: Table {
   let layout: RecordLayout
   let stride: Int
   let rows: Int
-  let data: Data
+  let data: ArraySlice<UInt8>
 
   public static var number: Int { 16 }
 
-  public init(from data: Data, rows: UInt32, strides: [TableIndex:Int]) {
+  public init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int]) {
     self.layout = (4, strides[FieldDef.self]!)
     self.stride = WinMD.stride(of: self.layout)
 
@@ -450,11 +450,11 @@ internal struct FieldMarshal: Table {
   let layout: RecordLayout
   let stride: Int
   let rows: Int
-  let data: Data
+  let data: ArraySlice<UInt8>
 
   public static var number: Int { 13 }
 
-  public init(from data: Data, rows: UInt32, strides: [TableIndex:Int]) {
+  public init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int]) {
     self.layout = (strides[HasFieldMarshal.self]!, strides[.blob]!)
     self.stride = WinMD.stride(of: self.layout)
 
@@ -472,11 +472,11 @@ internal struct FieldRVA: Table {
   let layout: RecordLayout
   let stride: Int
   let rows: Int
-  let data: Data
+  let data: ArraySlice<UInt8>
 
   public static var number: Int { 29 }
 
-  public init(from data: Data, rows: UInt32, strides: [TableIndex:Int]) {
+  public init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int]) {
     self.layout = (4, strides[FieldDef.self]!)
     self.stride = WinMD.stride(of: self.layout)
 
@@ -495,11 +495,11 @@ internal struct File: Table {
   let layout: RecordLayout
   let stride: Int
   let rows: Int
-  let data: Data
+  let data: ArraySlice<UInt8>
 
   public static var number: Int { 38 }
 
-  public init(from data: Data, rows: UInt32, strides: [TableIndex:Int]) {
+  public init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int]) {
     self.layout = (4, strides[.string]!, strides[.blob]!)
     self.stride = WinMD.stride(of: self.layout)
 
@@ -519,11 +519,11 @@ internal struct GenericParam: Table {
   let layout: RecordLayout
   let stride: Int
   let rows: Int
-  let data: Data
+  let data: ArraySlice<UInt8>
 
   public static var number: Int { 42 }
 
-  public init(from data: Data, rows: UInt32, strides: [TableIndex:Int]) {
+  public init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int]) {
     self.layout = (2, 2, strides[TypeOrMethodDef.self]!, strides[.string]!)
     self.stride = WinMD.stride(of: self.layout)
 
@@ -541,11 +541,11 @@ internal struct GenericParamConstraint: Table {
   let layout: RecordLayout
   let stride: Int
   let rows: Int
-  let data: Data
+  let data: ArraySlice<UInt8>
 
   public static var number: Int { 44 }
 
-  public init(from data: Data, rows: UInt32, strides: [TableIndex:Int]) {
+  public init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int]) {
     self.layout = (strides[GenericParam.self]!, strides[TypeDefOrRef.self]!)
     self.stride = WinMD.stride(of: self.layout)
 
@@ -565,11 +565,11 @@ internal struct ImplMap: Table {
   let layout: RecordLayout
   let stride: Int
   let rows: Int
-  let data: Data
+  let data: ArraySlice<UInt8>
 
   public static var number: Int { 28 }
 
-  public init(from data: Data, rows: UInt32, strides: [TableIndex:Int]) {
+  public init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int]) {
     self.layout = (2, strides[MemberForwarded.self]!, strides[.string]!, strides[ModuleRef.self]!)
     self.stride = WinMD.stride(of: self.layout)
 
@@ -587,11 +587,11 @@ internal struct InterfaceImpl: Table {
   let layout: RecordLayout
   let stride: Int
   let rows: Int
-  let data: Data
+  let data: ArraySlice<UInt8>
 
   public static var number: Int { 9 }
 
-  public init(from data: Data, rows: UInt32, strides: [TableIndex:Int]) {
+  public init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int]) {
     self.layout = (strides[TypeDef.self]!, strides[TypeDefOrRef.self]!)
     self.stride = WinMD.stride(of: self.layout)
 
@@ -611,11 +611,11 @@ internal struct ManifestResource: Table {
   let layout: RecordLayout
   let stride: Int
   let rows: Int
-  let data: Data
+  let data: ArraySlice<UInt8>
 
   public static var number: Int { 40 }
 
-  public init(from data: Data, rows: UInt32, strides: [TableIndex:Int]) {
+  public init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int]) {
     self.layout = (4, 4, strides[.string]!, strides[Implementation.self]!)
     self.stride = WinMD.stride(of: self.layout)
 
@@ -634,11 +634,11 @@ internal struct MemberRef: Table {
   let layout: RecordLayout
   let stride: Int
   let rows: Int
-  let data: Data
+  let data: ArraySlice<UInt8>
 
   public static var number: Int { 10 }
 
-  public init(from data: Data, rows: UInt32, strides: [TableIndex:Int]) {
+  public init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int]) {
     self.layout = (strides[MemberRefParent.self]!, strides[.string]!, strides[.blob]!)
     self.stride = WinMD.stride(of: self.layout)
 
@@ -660,11 +660,11 @@ internal struct MethodDef: Table {
   let layout: RecordLayout
   let stride: Int
   let rows: Int
-  let data: Data
+  let data: ArraySlice<UInt8>
 
   public static var number: Int { 6 }
 
-  public init(from data: Data, rows: UInt32, strides: [TableIndex:Int]) {
+  public init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int]) {
     self.layout = (4, 2, 2, strides[.string]!, strides[.blob]!, strides[Param.self]!)
     self.stride = WinMD.stride(of: self.layout)
 
@@ -683,11 +683,11 @@ internal struct MethodImpl: Table {
   let layout: RecordLayout
   let stride: Int
   let rows: Int
-  let data: Data
+  let data: ArraySlice<UInt8>
 
   public static var number: Int { 25 }
 
-  public init(from data: Data, rows: UInt32, strides: [TableIndex:Int]) {
+  public init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int]) {
     self.layout = (strides[TypeDef.self]!, strides[MethodDefOrRef.self]!, strides[MethodDefOrRef.self]!)
     self.stride = WinMD.stride(of: self.layout)
 
@@ -706,11 +706,11 @@ internal struct MethodSemantics: Table {
   let layout: RecordLayout
   let stride: Int
   let rows: Int
-  let data: Data
+  let data: ArraySlice<UInt8>
 
   public static var number: Int { 24 }
 
-  public init(from data: Data, rows: UInt32, strides: [TableIndex:Int]) {
+  public init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int]) {
     self.layout = (2, strides[MethodDef.self]!, strides[HasSemantics.self]!)
     self.stride = WinMD.stride(of: self.layout)
 
@@ -728,11 +728,11 @@ internal struct MethodSpec: Table {
   let layout: RecordLayout
   let stride: Int
   let rows: Int
-  let data: Data
+  let data: ArraySlice<UInt8>
 
   public static var number: Int { 43 }
 
-  public init(from data: Data, rows: UInt32, strides: [TableIndex:Int]) {
+  public init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int]) {
     self.layout = (strides[MethodDefOrRef.self]!, strides[.blob]!)
     self.stride = WinMD.stride(of: self.layout)
 
@@ -753,11 +753,11 @@ internal struct Module: Table {
   let layout: RecordLayout
   let stride: Int
   let rows: Int
-  let data: Data
+  let data: ArraySlice<UInt8>
 
   public static var number: Int { 0 }
 
-  public init(from data: Data, rows: UInt32, strides: [TableIndex:Int]) {
+  public init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int]) {
     self.layout = (2, strides[.string]!, strides[.guid]!, strides[.guid]!, strides[.guid]!)
     self.stride = WinMD.stride(of: self.layout)
 
@@ -774,11 +774,11 @@ internal struct ModuleRef: Table {
   let layout: RecordLayout
   let stride: Int
   let rows: Int
-  let data: Data
+  let data: ArraySlice<UInt8>
 
   public static var number: Int { 26 }
 
-  public init(from data: Data, rows: UInt32, strides: [TableIndex:Int]) {
+  public init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int]) {
     self.layout = (strides[.string]!)
     self.stride = strides[.string]!
 
@@ -796,11 +796,11 @@ internal struct NestedClass: Table {
   let layout: RecordLayout
   let stride: Int
   let rows: Int
-  let data: Data
+  let data: ArraySlice<UInt8>
 
   public static var number: Int { 41 }
 
-  public init(from data: Data, rows: UInt32, strides: [TableIndex:Int]) {
+  public init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int]) {
     self.layout = (strides[TypeDef.self]!, strides[TypeDef.self]!)
     self.stride = WinMD.stride(of: self.layout)
 
@@ -819,11 +819,11 @@ internal struct Param: Table {
   let layout: RecordLayout
   let stride: Int
   let rows: Int
-  let data: Data
+  let data: ArraySlice<UInt8>
 
   public static var number: Int { 8 }
 
-  public init(from data: Data, rows: UInt32, strides: [TableIndex:Int]) {
+  public init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int]) {
     self.layout = (2, 2, strides[.string]!)
     self.stride = WinMD.stride(of: self.layout)
 
@@ -842,11 +842,11 @@ internal struct PropertyDef: Table {
   let layout: RecordLayout
   let stride: Int
   let rows: Int
-  let data: Data
+  let data: ArraySlice<UInt8>
 
   public static var number: Int { 23 }
 
-  public init(from data: Data, rows: UInt32, strides: [TableIndex:Int]) {
+  public init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int]) {
     self.layout = (2, strides[.string]!, strides[.blob]!)
     self.stride = WinMD.stride(of: self.layout)
 
@@ -864,11 +864,11 @@ internal struct PropertyMap: Table {
   let layout: RecordLayout
   let stride: Int
   let rows: Int
-  let data: Data
+  let data: ArraySlice<UInt8>
 
   public static var number: Int { 21 }
 
-  public init(from data: Data, rows: UInt32, strides: [TableIndex:Int]) {
+  public init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int]) {
     self.layout = (strides[TypeDef.self]!, strides[PropertyDef.self]!)
     self.stride = WinMD.stride(of: self.layout)
 
@@ -885,11 +885,11 @@ internal struct StandAloneSig: Table {
   let layout: RecordLayout
   let stride: Int
   let rows: Int
-  let data: Data
+  let data: ArraySlice<UInt8>
 
   public static var number: Int { 17 }
 
-  public init(from data: Data, rows: UInt32, strides: [TableIndex:Int]) {
+  public init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int]) {
     self.layout = (strides[.blob]!)
     self.stride = strides[.blob]!
 
@@ -911,11 +911,11 @@ internal struct TypeDef: Table {
   let layout: RecordLayout
   let stride: Int
   let rows: Int
-  let data: Data
+  let data: ArraySlice<UInt8>
 
   public static var number: Int { 2 }
 
-  public init(from data: Data, rows: UInt32, strides: [TableIndex:Int]) {
+  public init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int]) {
     self.layout = (4, strides[.string]!, strides[.string]!, strides[TypeDefOrRef.self]!, strides[FieldDef.self]!, strides[MethodDef.self]!)
     self.stride = WinMD.stride(of: self.layout)
 
@@ -934,11 +934,11 @@ internal struct TypeRef: Table {
   let layout: RecordLayout
   let stride: Int
   let rows: Int
-  let data: Data
+  let data: ArraySlice<UInt8>
 
   public static var number: Int { 1 }
 
-  public init(from data: Data, rows: UInt32, strides: [TableIndex:Int]) {
+  public init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int]) {
     self.layout = (strides[ResolutionScope.self]!, strides[.string]!, strides[.string]!)
     self.stride = WinMD.stride(of: self.layout)
 
@@ -955,11 +955,11 @@ internal struct TypeSpec: Table {
   let layout: RecordLayout
   let stride: Int
   let rows: Int
-  let data: Data
+  let data: ArraySlice<UInt8>
 
   public static var number: Int { 27 }
 
-  public init(from data: Data, rows: UInt32, strides: [TableIndex:Int]) {
+  public init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int]) {
     self.layout = (strides[.blob]!)
     self.stride = strides[.blob]!
 

--- a/Sources/WinMD/Data+Extensions.swift
+++ b/Sources/WinMD/Data+Extensions.swift
@@ -17,3 +17,14 @@ extension Data {
     }[0]
   }
 }
+
+extension ArraySlice where Element == UInt8 {
+  internal func read<T>(offset: Self.Index) -> T {
+    let begin: Self.Index = self.index(self.startIndex, offsetBy: offset)
+    let end: Self.Index = self.index(begin, offsetBy: MemoryLayout<T>.stride)
+    return Array<T>(unsafeUninitializedCapacity: 1) {
+      self.copyBytes(to: $0, from: begin ..< end)
+      $1 = 1
+    }[0]
+  }
+}

--- a/Sources/WinMD/GUIDHeap.swift
+++ b/Sources/WinMD/GUIDHeap.swift
@@ -8,9 +8,9 @@
 import Foundation
 
 internal struct GUIDHeap {
-  let data: Data
+  let data: ArraySlice<UInt8>
 
-  public init(data: Data) {
+  public init(data: ArraySlice<UInt8>) {
     self.data = data
   }
 

--- a/Sources/WinMD/PEFile.swift
+++ b/Sources/WinMD/PEFile.swift
@@ -44,8 +44,8 @@ internal struct PEFile {
 
       return Array<IMAGE_SECTION_HEADER>(unsafeUninitializedCapacity: NumberOfSections) {
         let nbytes: Int = NumberOfSections * MemoryLayout<IMAGE_SECTION_HEADER>.size
-        let begin: Data.Index = data.index(data.startIndex, offsetBy: Offset)
-        let end: Data.Index = data.index(begin, offsetBy: nbytes)
+        let begin: ArraySlice<UInt8>.Index = data.index(data.startIndex, offsetBy: Offset)
+        let end: ArraySlice<UInt8>.Index = data.index(begin, offsetBy: nbytes)
         data.copyBytes(to: $0, from: begin ..< end)
         $1 = NumberOfSections
       }
@@ -56,8 +56,8 @@ internal struct PEFile {
 
       return Array<IMAGE_SECTION_HEADER>(unsafeUninitializedCapacity: NumberOfSections) {
         let nbytes: Int = NumberOfSections * MemoryLayout<IMAGE_SECTION_HEADER>.size
-        let begin: Data.Index = data.index(data.startIndex, offsetBy: Offset)
-        let end: Data.Index = data.index(begin, offsetBy: nbytes)
+        let begin: ArraySlice<UInt8>.Index = data.index(data.startIndex, offsetBy: Offset)
+        let end: ArraySlice<UInt8>.Index = data.index(begin, offsetBy: nbytes)
         data.copyBytes(to: $0, from: begin ..< end)
         $1 = NumberOfSections
       }

--- a/Sources/WinMD/StringsHeap.swift
+++ b/Sources/WinMD/StringsHeap.swift
@@ -8,9 +8,9 @@
 import Foundation
 
 internal struct StringsHeap {
-  let data: Data
+  let data: ArraySlice<UInt8>
 
-  public init(data: Data) {
+  public init(data: ArraySlice<UInt8>) {
     self.data = data
   }
 

--- a/Sources/WinMD/TablesStream.swift
+++ b/Sources/WinMD/TablesStream.swift
@@ -18,9 +18,9 @@ import Foundation
 ///     uint32_t Rows[]             ; +24
 ///      uint8_t Tables[]
 internal struct TablesStream {
-  private let data: Data
+  private let data: ArraySlice<UInt8>
 
-  public init(data: Data) {
+  public init(data: ArraySlice<UInt8>) {
     self.data = data
   }
 
@@ -47,8 +47,8 @@ internal struct TablesStream {
   public var Rows: [UInt32] {
     let tables: Int = Valid.nonzeroBitCount
     let nbytes: Int = tables * MemoryLayout<UInt32>.size
-    let begin: Data.Index = data.index(data.startIndex, offsetBy: 24)
-    let end: Data.Index = data.index(begin, offsetBy: nbytes)
+    let begin: ArraySlice<UInt8>.Index = data.index(data.startIndex, offsetBy: 24)
+    let end: ArraySlice<UInt8>.Index = data.index(begin, offsetBy: nbytes)
     return Array<UInt32>(unsafeUninitializedCapacity: tables) {
       data.copyBytes(to: $0, from: begin ..< end)
       $1 = tables


### PR DESCRIPTION
This updates the interfaces to `ArraySlice<UInt8>` across the
interfaces.  Although this completely destroys the rendering of the
dumped database, this will enable further development which does not
rely on `Data`.