### PR TITLE
WinMD: extract `TableIndex`

### DIFF
--- a/Sources/WinMD/CILTables.swift
+++ b/Sources/WinMD/CILTables.swift
@@ -23,47 +23,6 @@ internal protocol Table {
   init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int])
 }
 
-enum TableIndex {
-  case string
-  case guid
-  case blob
-  case simple(Table.Type)
-  case coded(ObjectIdentifier)
-}
-
-extension TableIndex: Hashable {
-  static func == (_ lhs: TableIndex, _ rhs: TableIndex) -> Bool {
-    switch (lhs, rhs) {
-    case (.string, .string):
-      return true
-    case (.guid, .guid):
-      return true
-    case (.blob, .blob):
-      return true
-    case let (.simple(LHSTable), .simple(RHSTable)) where LHSTable == RHSTable:
-      return true
-    case let (.coded(LHSSet), .coded(RHSSet)) where LHSSet == RHSSet:
-      return true
-    default: return false
-    }
-  }
-
-  func hash(into hasher: inout Hasher) {
-    switch self {
-    case .string:
-      hasher.combine(3)
-    case .guid:
-      hasher.combine(2)
-    case .blob:
-      hasher.combine(1)
-    case let .simple(table):
-      hasher.combine(ObjectIdentifier(table))
-    case let .coded(index):
-      index.hash(into: &hasher)
-    }
-  }
-}
-
 extension Dictionary where Key == TableIndex, Value == Int {
   internal subscript(_ table: Table.Type) -> Int? {
     get { return self[.simple(table)] }

--- a/Sources/WinMD/TableIndex.swift
+++ b/Sources/WinMD/TableIndex.swift
@@ -1,0 +1,47 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+enum TableIndex {
+  case string
+  case guid
+  case blob
+  case simple(Table.Type)
+  case coded(ObjectIdentifier)
+}
+
+extension TableIndex: Hashable {
+  static func == (_ lhs: TableIndex, _ rhs: TableIndex) -> Bool {
+    switch (lhs, rhs) {
+    case (.string, .string):
+      return true
+    case (.guid, .guid):
+      return true
+    case (.blob, .blob):
+      return true
+    case let (.simple(LHSTable), .simple(RHSTable)) where LHSTable == RHSTable:
+      return true
+    case let (.coded(LHSSet), .coded(RHSSet)) where LHSSet == RHSSet:
+      return true
+    default: return false
+    }
+  }
+
+  func hash(into hasher: inout Hasher) {
+    switch self {
+    case .string:
+      hasher.combine(3)
+    case .guid:
+      hasher.combine(2)
+    case .blob:
+      hasher.combine(1)
+    case let .simple(table):
+      hasher.combine(ObjectIdentifier(table))
+    case let .coded(index):
+      index.hash(into: &hasher)
+    }
+  }
+}


### PR DESCRIPTION
Extract the `TableIndex` type into a separate file to prepare to split
up the tables and to introduce a `Row` concept.