### PR TITLE
WinMD: extract `Table`

### DIFF
--- a/Sources/WinMD/CILTables.swift
+++ b/Sources/WinMD/CILTables.swift
@@ -7,22 +7,6 @@
 
 import Foundation
 
-internal protocol Table {
-  /// The CIL defined table number.
-  static var number: Int { get }
-
-  /// The stride of a single row.
-  var stride: Int { get }
-  /// The number of rows in the table.
-  var rows: Int { get }
-
-  /// The data backing the table model.
-  var data: ArraySlice<UInt8> { get }
-
-  /// Constructs a new table model.
-  init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int])
-}
-
 extension Dictionary where Key == TableIndex, Value == Int {
   internal subscript(_ table: Table.Type) -> Int? {
     get { return self[.simple(table)] }

--- a/Sources/WinMD/Table.swift
+++ b/Sources/WinMD/Table.swift
@@ -1,0 +1,23 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+internal protocol Table {
+  /// The CIL defined table number.
+  static var number: Int { get }
+
+  /// The stride of a single row.
+  var stride: Int { get }
+
+  /// The number of rows in the table.
+  var rows: Int { get }
+
+  /// The data backing the table model.
+  var data: ArraySlice<UInt8> { get }
+
+  /// Constructs a new table model.
+  init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int])
+}


### PR DESCRIPTION
Extract the `Table` protocol from the definition of the explicit tables
themselves.