### PR TITLE
WinMD: rename `Table` to `TableBase`, add new `Table`

### DIFF
--- a/Sources/WinMD/CILTables.swift
+++ b/Sources/WinMD/CILTables.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension Dictionary where Key == TableIndex, Value == Int {
-  internal subscript(_ table: Table.Type) -> Int? {
+  internal subscript(_ table: TableBase.Type) -> Int? {
     get { return self[.simple(table)] }
     set { self[.simple(table)] = newValue }
   }
@@ -29,8 +29,8 @@ func stride<RecordLayout>(of layout: RecordLayout) -> Int {
 }
 
 extension Metadata.Tables {
-  static func forEach(_ body: (Table.Type) -> Void) {
-    _ = Array<Table.Type>([
+  static func forEach(_ body: (TableBase.Type) -> Void) {
+    _ = Array<TableBase.Type>([
       Assembly.self,
       AssemblyOS.self,
       AssemblyProcessor.self,

--- a/Sources/WinMD/CodedIndex.swift
+++ b/Sources/WinMD/CodedIndex.swift
@@ -6,11 +6,11 @@
  **/
 
 internal protocol CodedIndex: Hashable {
-  static var tables: [Table.Type] { get }
+  static var tables: [TableBase.Type] { get }
 }
 
 internal struct HasConstant: CodedIndex {
-  public static var tables: [Table.Type] {
+  public static var tables: [TableBase.Type] {
     return [
       Metadata.Tables.Param.self,
       Metadata.Tables.FieldDef.self,
@@ -20,7 +20,7 @@ internal struct HasConstant: CodedIndex {
 }
 
 internal struct HasCustomAttribute: CodedIndex {
-  public static var tables: [Table.Type] {
+  public static var tables: [TableBase.Type] {
     return [
       Metadata.Tables.MethodDef.self,
       Metadata.Tables.MemberRef.self,
@@ -29,7 +29,7 @@ internal struct HasCustomAttribute: CodedIndex {
 }
 
 internal struct CustomAttributeType: CodedIndex {
-  public static var tables: [Table.Type] {
+  public static var tables: [TableBase.Type] {
     return [
       Metadata.Tables.MethodDef.self,
       Metadata.Tables.MemberRef.self,
@@ -38,7 +38,7 @@ internal struct CustomAttributeType: CodedIndex {
 }
 
 internal struct HasDeclSecurity: CodedIndex {
-  public static var tables: [Table.Type] {
+  public static var tables: [TableBase.Type] {
     return [
       Metadata.Tables.TypeDef.self,
       Metadata.Tables.MethodDef.self,
@@ -48,7 +48,7 @@ internal struct HasDeclSecurity: CodedIndex {
 }
 
 internal struct TypeDefOrRef: CodedIndex {
-  public static var tables: [Table.Type] {
+  public static var tables: [TableBase.Type] {
     return [
       Metadata.Tables.TypeDef.self,
       Metadata.Tables.TypeRef.self,
@@ -59,7 +59,7 @@ internal struct TypeDefOrRef: CodedIndex {
 
 // FIXME(compnerd) Exported vs Manifest Resource
 internal struct Implementation: CodedIndex {
-  public static var tables: [Table.Type] {
+  public static var tables: [TableBase.Type] {
     return [
       Metadata.Tables.File.self,
       Metadata.Tables.ExportedType.self,
@@ -69,7 +69,7 @@ internal struct Implementation: CodedIndex {
 }
 
 internal struct HasFieldMarshal: CodedIndex {
-  public static var tables: [Table.Type] {
+  public static var tables: [TableBase.Type] {
     return [
       Metadata.Tables.FieldDef.self,
       Metadata.Tables.Param.self,
@@ -78,7 +78,7 @@ internal struct HasFieldMarshal: CodedIndex {
 }
 
 internal struct TypeOrMethodDef: CodedIndex {
-  public static var tables: [Table.Type] {
+  public static var tables: [TableBase.Type] {
     return [
       Metadata.Tables.TypeDef.self,
       Metadata.Tables.MethodDef.self,
@@ -87,7 +87,7 @@ internal struct TypeOrMethodDef: CodedIndex {
 }
 
 internal struct MemberForwarded: CodedIndex {
-  public static var tables: [Table.Type] {
+  public static var tables: [TableBase.Type] {
     return [
       Metadata.Tables.FieldDef.self,
       Metadata.Tables.MethodDef.self,
@@ -96,7 +96,7 @@ internal struct MemberForwarded: CodedIndex {
 }
 
 internal struct MemberRefParent: CodedIndex {
-  public static var tables: [Table.Type] {
+  public static var tables: [TableBase.Type] {
     return [
       Metadata.Tables.MethodDef.self,
       Metadata.Tables.ModuleRef.self,
@@ -108,7 +108,7 @@ internal struct MemberRefParent: CodedIndex {
 }
 
 internal struct HasSemantics: CodedIndex {
-  public static var tables: [Table.Type] {
+  public static var tables: [TableBase.Type] {
     return [
       Metadata.Tables.EventDef.self,
       Metadata.Tables.PropertyDef.self,
@@ -117,7 +117,7 @@ internal struct HasSemantics: CodedIndex {
 }
 
 internal struct MethodDefOrRef: CodedIndex {
-  public static var tables: [Table.Type] {
+  public static var tables: [TableBase.Type] {
     return [
       Metadata.Tables.MethodDef.self,
       Metadata.Tables.MemberRef.self,
@@ -126,7 +126,7 @@ internal struct MethodDefOrRef: CodedIndex {
 }
 
 internal struct ResolutionScope: CodedIndex {
-  public static var tables: [Table.Type] {
+  public static var tables: [TableBase.Type] {
     return [
       Metadata.Tables.Module.self,
       Metadata.Tables.ModuleRef.self,

--- a/Sources/WinMD/Table.swift
+++ b/Sources/WinMD/Table.swift
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  **/
 
-internal protocol Table {
+internal protocol TableBase {
   /// The CIL defined table number.
   static var number: Int { get }
 
@@ -20,4 +20,13 @@ internal protocol Table {
 
   /// Constructs a new table model.
   init(from data: ArraySlice<UInt8>, rows: UInt32, strides: [TableIndex:Int])
+}
+
+internal protocol Table: TableBase, CustomStringConvertible {
+}
+
+extension Table {
+  internal var description: String {
+    "\(String(describing: Self.self)): rows: \(self.rows), stride: \(self.stride) bytes, data: \(self.data.count) bytes"
+  }
 }

--- a/Sources/WinMD/TableIndex.swift
+++ b/Sources/WinMD/TableIndex.swift
@@ -9,7 +9,7 @@ enum TableIndex {
   case string
   case guid
   case blob
-  case simple(Table.Type)
+  case simple(TableBase.Type)
   case coded(ObjectIdentifier)
 }
 

--- a/Sources/WinMD/TablesStream.swift
+++ b/Sources/WinMD/TablesStream.swift
@@ -55,11 +55,11 @@ internal struct TablesStream {
     }
   }
 
-  public var Tables: [Table] {
+  public var Tables: [TableBase] {
     let valid: UInt64 = Valid
     let rows: [UInt32] = Rows
 
-    var tables: [Table] = []
+    var tables: [TableBase] = []
     tables.reserveCapacity(valid.nonzeroBitCount)
 
     let strides: [TableIndex:Int] = self.strides(tables: valid, rows: rows)


### PR DESCRIPTION
Introduce a `TableBase` to relinquish the name `Table`.  This will be
used subsequently to introduce a new type which has additional
constraints to enable iteration of the table.