### PR TITLE
WinMD: inline validation into construction of `CIL`

### DIFF
--- a/Sources/WinMD/Database.swift
+++ b/Sources/WinMD/Database.swift
@@ -16,7 +16,6 @@ public class Database {
     self.dos = try DOSFile(from: data)
     self.pe = try PEFile(from: self.dos)
     self.cil = try Assembly(from: self.pe)
-    try cil.validate()
   }
 
   public convenience init(at path: URL) throws {


### PR DESCRIPTION
This cleans up the construction of the CIL assembly from the PE file.
Inline the validation and use an extension for PE to get the contents of
a data directory entry.