### PR TITLE
WinMD: remove unused error cases

### DIFF
--- a/Sources/WinMD/Error.swift
+++ b/Sources/WinMD/Error.swift
@@ -7,7 +7,4 @@
 
 public enum WinMDError: Error {
   case BadImageFormat
-
-  case invalidStream
-  case tableNotFound
 }


### PR DESCRIPTION
Remove the currently unused error cases, they can be restored when
needed.