### PR TITLE
WinMD: reduce Foundation imports

### DIFF
--- a/Sources/WinMD/CIL.swift
+++ b/Sources/WinMD/CIL.swift
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  **/
 
-import Foundation
-
 @_implementationOnly
 import CPE
 

--- a/Sources/WinMD/CILTables.swift
+++ b/Sources/WinMD/CILTables.swift
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  **/
 
-import Foundation
-
 extension Dictionary where Key == TableIndex, Value == Int {
   internal subscript(_ table: TableBase.Type) -> Int? {
     get { return self[.simple(table)] }

--- a/Sources/WinMD/DOSFile.swift
+++ b/Sources/WinMD/DOSFile.swift
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  **/
 
-import Foundation
-
 @_implementationOnly
 import CPE
 

--- a/Sources/WinMD/Database.swift
+++ b/Sources/WinMD/Database.swift
@@ -5,7 +5,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  **/
 
-import Foundation
+import struct Foundation.Data
+import struct Foundation.URL
 
 public class Database {
   private let dos: DOSFile

--- a/Sources/WinMD/GUIDHeap.swift
+++ b/Sources/WinMD/GUIDHeap.swift
@@ -5,7 +5,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  **/
 
-import Foundation
+import struct Foundation.UUID
+import typealias Foundation.uuid_t
 
 internal struct GUIDHeap {
   let data: ArraySlice<UInt8>

--- a/Sources/WinMD/PEFile.swift
+++ b/Sources/WinMD/PEFile.swift
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  **/
 
-import Foundation
-
 @_implementationOnly
 import CPE
 

--- a/Sources/WinMD/StringsHeap.swift
+++ b/Sources/WinMD/StringsHeap.swift
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  **/
 
-import Foundation
-
 internal struct StringsHeap {
   let data: ArraySlice<UInt8>
 

--- a/Sources/WinMD/TablesStream.swift
+++ b/Sources/WinMD/TablesStream.swift
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  **/
 
-import Foundation
-
 /// Tables Stream
 ///     uint32_t Reserved           ; +0 [0]
 ///      uint8_t MajorVersion       ; +4


### PR DESCRIPTION
The Foundation library is used specifically for `UUID`, `uuid_t` to
handle the GUID heap, `Data` to load the contents of the winmd source
file, and `URL` to handle the file system reference to the source file.
Remove the now unnecessary imports of Foundation.