### PR TITLE
winmd-inspect: print the database location

### DIFF
--- a/Sources/winmd-inspect/main.swift
+++ b/Sources/winmd-inspect/main.swift
@@ -21,7 +21,7 @@ struct Inspect: ParsableCommand {
 
   func run() throws {
     // "C:\\Windows\\System32\\WinMetadata\\Windows.Foundation.winmd"
-    print("inspect: \(self.database)")
+    print("Database: \(self.database.url.path)")
     if let database = try? WinMD.Database(at: self.database.url) {
       database.dump()
     }


### PR DESCRIPTION
Display the database location before dumping the database.