### PR TITLE
WinMD: add a convenience initializer for heaps/streams

### DIFF
--- a/Sources/WinMD/BlobsHeap.swift
+++ b/Sources/WinMD/BlobsHeap.swift
@@ -9,6 +9,13 @@ internal struct BlobsHeap {
     self.data = data
   }
 
+  public init?(from assembly: Assembly) {
+    guard let stream = assembly.Metadata.stream(named: Metadata.Stream.Blob) else {
+      return nil
+    }
+    self.init(data: stream)
+  }
+
   public subscript(offset: Int) -> ArraySlice<UInt8> {
     let begin: ArraySlice<UInt8>.Index
     let end: ArraySlice<UInt8>.Index

--- a/Sources/WinMD/Database.swift
+++ b/Sources/WinMD/Database.swift
@@ -31,15 +31,8 @@ public class Database {
     print("Streams: \(metadata.Streams)")
     metadata.StreamHeaders.forEach { print("  - \($0)") }
 
-    if let TableStream = metadata.stream(named: Metadata.Stream.Tables),
-        let BlobStream = metadata.stream(named: Metadata.Stream.Blob),
-        let GUIDStream = metadata.stream(named: Metadata.Stream.GUID),
-        let StringsStream = metadata.stream(named: Metadata.Stream.Strings) {
-      let tables = TablesStream(data: TableStream)
-      let _ = StringsHeap(data: StringsStream)
-      let _ = GUIDHeap(data: GUIDStream)
-      let _ = BlobsHeap(data: BlobStream)
-
+    if let tables = TablesStream(from: self.cil), let _ = BlobsHeap(from: self.cil),
+        let _ = StringsHeap(from: self.cil), let _ = GUIDHeap(from: self.cil) {
       print("MajorVersion: \(String(tables.MajorVersion, radix: 16))")
       print("MinorVersion: \(String(tables.MinorVersion, radix: 16))")
       print("Tables:")

--- a/Sources/WinMD/GUIDHeap.swift
+++ b/Sources/WinMD/GUIDHeap.swift
@@ -12,6 +12,13 @@ internal struct GUIDHeap {
     self.data = data
   }
 
+  public init?(from assembly: Assembly) {
+    guard let stream = assembly.Metadata.stream(named: Metadata.Stream.GUID) else {
+      return nil
+    }
+    self.init(data: stream)
+  }
+
   public subscript(index: Int) -> UUID {
     UUID(uuid: data.withUnsafeBytes {
       $0.load(fromByteOffset: MemoryLayout<uuid_t>.stride * (index - 1), as: uuid_t.self)

--- a/Sources/WinMD/StringsHeap.swift
+++ b/Sources/WinMD/StringsHeap.swift
@@ -9,6 +9,13 @@ internal struct StringsHeap {
     self.data = data
   }
 
+  public init?(from assembly: Assembly) {
+    guard let stream = assembly.Metadata.stream(named: Metadata.Stream.Strings) else {
+      return nil
+    }
+    self.init(data: stream)
+  }
+
   public subscript(offset: Int) -> String {
     let index = data.index(data.startIndex, offsetBy: offset)
     return data[index...].withUnsafeBytes {

--- a/Sources/WinMD/TablesStream.swift
+++ b/Sources/WinMD/TablesStream.swift
@@ -19,6 +19,13 @@ internal struct TablesStream {
     self.data = data
   }
 
+  public init?(from assembly: Assembly) {
+    guard let stream = assembly.Metadata.stream(named: Metadata.Stream.Tables) else {
+      return nil
+    }
+    self.init(data: stream)
+  }
+
   public var MajorVersion: UInt8 {
     return self.data[4, UInt8.self]
   }


### PR DESCRIPTION
Add a convenience initializer allowing constructing the heaps from the
assembly.  This is meant to make the use of the data stream more
ergonomic.