### PR TITLE
WinMD: add some decoding helpers for `CodedIndex`

### DIFF
--- a/Sources/WinMD/CodedIndex.swift
+++ b/Sources/WinMD/CodedIndex.swift
@@ -14,6 +14,20 @@ internal protocol CodedIndex: Hashable {
   init(rawValue: Int)
 }
 
+extension CodedIndex {
+  internal static var mask: Int {
+    (1 << (64 - (Self.tables.count - 1).leadingZeroBitCount)) - 1
+  }
+
+  internal var tag: Int {
+    self.rawValue & Self.mask
+  }
+
+  internal var row: Int {
+    self.rawValue >> Self.mask.nonzeroBitCount
+  }
+}
+
 internal struct HasConstant: CodedIndex {
   public static var tables: [TableBase.Type] {
     return [


### PR DESCRIPTION
A `CodedIndex` encodes a discriminator in the low log(n) bits of the
`CodedIndex` and the row index in the high (16 - log(n) bits if the
tables are small or 32 - log(n) bits if the tables are large).  We
compute the mask for the discriminator by computing the number of bits
required to discriminate between the tables associated with the
`CodedIndex` and use that to extract the tag and the row index.