### PR TITLE
WinMD: not all tables are required for a CodedIndex

### DIFF
--- a/Sources/WinMD/TablesStream.swift
+++ b/Sources/WinMD/TablesStream.swift
@@ -104,6 +104,7 @@ extension TablesStream {
     func TableIndexSize<T: CodedIndex>(_ index: T.Type) -> Int {
       let TagLength = (index.tables.count - 1).nonzeroBitCount
       return index.tables.map {
+        guard Valid & (1 << $0.number) == (1 << $0.number) else { return true }
         let count = rows[(tables & ((1 << $0.number) - 1)).nonzeroBitCount]
         let range = 1 << (16 - TagLength)
         return count < range


### PR DESCRIPTION
A CodedIndex may be able to reference a table which is not present.  In
such a case, the expectation is that the table will never be indexed.
Assume that the count is always compressible.