### PR TITLE
Tests: add some tests for WinMD

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,6 +12,8 @@ let SwiftWinMD = Package(
   ],
   targets: [
     .target(name: "CPE", dependencies: []),
+
+    // WinMD
     .target(name: "WinMD",
             dependencies: ["CPE"],
             swiftSettings: [
@@ -19,6 +21,9 @@ let SwiftWinMD = Package(
                 "-Xfrontend", "-validate-tbd-against-ir=none",
               ]),
             ]),
+    .testTarget(name: "WinMDTests", dependencies: ["WinMD"]),
+
+    // winmd-inspect
     .target(name: "winmd-inspect",
             dependencies: [
               "WinMD",

--- a/Tests/WinMDTests/CodedIndexTests.swift
+++ b/Tests/WinMDTests/CodedIndexTests.swift
@@ -1,0 +1,29 @@
+// Copyright (c) 2021 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3
+
+import XCTest
+@testable import WinMD
+
+extension CodedIndex {
+  fileprivate static var descriminatorBitWidth: Int {
+    Self.mask.nonzeroBitCount
+  }
+}
+
+final class CodedIndexTest: XCTestCase {
+  func testCodedIndexWidths() {
+    XCTAssertEqual(TypeDefOrRef.descriminatorBitWidth, 2)
+    XCTAssertEqual(HasConstant.descriminatorBitWidth, 2)
+    XCTAssertEqual(HasCustomAttribute.descriminatorBitWidth, 5)
+    XCTAssertEqual(HasFieldMarshal.descriminatorBitWidth, 1)
+    XCTAssertEqual(HasDeclSecurity.descriminatorBitWidth, 2)
+    XCTAssertEqual(MemberRefParent.descriminatorBitWidth, 3)
+    XCTAssertEqual(HasSemantics.descriminatorBitWidth, 1)
+    XCTAssertEqual(MethodDefOrRef.descriminatorBitWidth, 1)
+    XCTAssertEqual(MemberForwarded.descriminatorBitWidth, 1)
+    XCTAssertEqual(Implementation.descriminatorBitWidth, 2)
+    XCTAssertEqual(CustomAttributeType.descriminatorBitWidth, 3)
+    XCTAssertEqual(ResolutionScope.descriminatorBitWidth, 2)
+    XCTAssertEqual(TypeOrMethodDef.descriminatorBitWidth, 1)
+  }
+}


### PR DESCRIPTION
This adds a validation that the descriminators for the coded indices are
correct.