### PR TITLE
WinMD: forward `forEach` over the tables in `TableStream`

### DIFF
--- a/Sources/WinMD/Database.swift
+++ b/Sources/WinMD/Database.swift
@@ -35,7 +35,9 @@ public class Database {
       print("MajorVersion: \(String(tables.MajorVersion, radix: 16))")
       print("MinorVersion: \(String(tables.MinorVersion, radix: 16))")
       print("Tables:")
-      tables.Tables.forEach { print("  - \($0)") }
+      tables.forEach {
+        print("  - \($0)")
+      }
     }
   }
 }

--- a/Sources/WinMD/TablesStream.swift
+++ b/Sources/WinMD/TablesStream.swift
@@ -83,6 +83,12 @@ internal struct TablesStream {
 }
 
 extension TablesStream {
+  public func forEach(_ body: (TableBase) throws -> Void) rethrows {
+    return try self.Tables.forEach(body)
+  }
+}
+
+extension TablesStream {
   internal var StringIndexSize: Int {
     (HeapSizes >> 0) & 1 == 1 ? 4 : 2
   }


### PR DESCRIPTION
The `TableStream` is meant to be the set of tables in the database.
Simply forward `forEach` to the underlying `Tables` property.