### PR TITLE
WinMD: use effectful subscripts to validte GUIDHeap indicies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,7 @@ An ECMA 335 parser in Swift
 
 ## Build Requirements
 
-- Swift 5.4 or newer
-
-This project requires Swift 5.4 or newer as it requires Swift Package Manager, which is only available since 5.4 on Windows.  This ensures that we have the same supported language on all platforms.  However, the CI only tests on 5.5 or newer due to improvements in the packaging.
+- Swift 5.5 or newer
 
 ## Debugging
 

--- a/Sources/WinMD/Error.swift
+++ b/Sources/WinMD/Error.swift
@@ -3,4 +3,5 @@
 
 public enum WinMDError: Error {
   case BadImageFormat
+  case InvalidIndex
 }

--- a/Sources/WinMD/GUIDHeap.swift
+++ b/Sources/WinMD/GUIDHeap.swift
@@ -19,9 +19,12 @@ internal struct GUIDHeap {
   }
 
   public subscript(index: Int) -> UUID {
-    UUID(uuid: data.withUnsafeBytes {
-      $0.load(fromByteOffset: MemoryLayout<uuid_t>.stride * (index - 1), as: uuid_t.self)
-    })
+    get throws {
+      guard index > 0 else { throw WinMDError.InvalidIndex }
+      return UUID(uuid: data.withUnsafeBytes {
+        $0.load(fromByteOffset: MemoryLayout<uuid_t>.stride * (index - 1), as: uuid_t.self)
+      })
+    }
   }
 }
 

--- a/Tests/WinMDTests/GUIDHeapTests.swift
+++ b/Tests/WinMDTests/GUIDHeapTests.swift
@@ -1,0 +1,21 @@
+// Copyright (c) 2021 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3
+
+import XCTest
+@testable import WinMD
+
+final class GUIDHeapTests: XCTestCase {
+  static let heap: [UInt8] = [
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+    0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+  ]
+
+  func testSubscript() {
+    let guids = GUIDHeap(data: GUIDHeapTests.heap[...])
+    XCTAssertThrowsError(try guids[0]) { error in
+      XCTAssertEqual(error as? WinMDError, .InvalidIndex)
+    }
+    XCTAssertEqual(try guids[1],
+                   UUID(uuid: (0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f)))
+  }
+}


### PR DESCRIPTION
The GUIDHeap expects 1-based indicies, which we now ensure by raising
an error if the index is <= 0.