### PR TITLE
WinMD: adopt `OrderedDictionary`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,14 +8,20 @@ let SwiftWinMD = Package(
     .executable(name: "winmd-inspect", targets: ["winmd-inspect"]),
   ],
   dependencies: [
-    .package(url: "http://github.com/apple/swift-argument-parser", from: "0.3.2"),
+    .package(url: "http://github.com/apple/swift-argument-parser",
+             from: "0.3.2"),
+    .package(url: "https://github.com/apple/swift-collections.git",
+             .upToNextMinor(from: "1.0.0")),
   ],
   targets: [
     .target(name: "CPE", dependencies: []),
 
     // WinMD
     .target(name: "WinMD",
-            dependencies: ["CPE"],
+            dependencies: [
+              "CPE",
+              .product(name: "OrderedCollections", package: "swift-collections"),
+            ],
             swiftSettings: [
               .unsafeFlags([
                 "-Xfrontend", "-validate-tbd-against-ir=none",


### PR DESCRIPTION
This uses `OrderedDictionary` rather than `Dictionary` with a custom
sort method.  This allows a slightly more efficient implementation of
the column traversal.