### PR TITLE
WinMD: change `DOSFile`, `PEFile`, and `Assembly` to public

### DIFF
--- a/Sources/WinMD/CIL.swift
+++ b/Sources/WinMD/CIL.swift
@@ -1,7 +1,6 @@
 // Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
-@_implementationOnly
 import CPE
 
 private var CIL_METADATA_SIGNATURE: UInt32 { 0x424a5342 }
@@ -22,7 +21,7 @@ extension PEFile {
   }
 }
 
-internal struct Assembly {
+public struct Assembly {
   private let header: ArraySlice<UInt8>
   private let metadata: ArraySlice<UInt8>
 
@@ -63,7 +62,7 @@ internal struct Assembly {
 ///     uint32_t Offset     ; +0
 ///     uint32_t Size       ; +4
 ///      uint8_t Name[]     ; +8
-internal struct StreamHeader {
+public struct StreamHeader {
   internal let data: ArraySlice<UInt8>
 
   public var Offset: UInt32 {
@@ -102,7 +101,7 @@ extension StreamHeader: CustomDebugStringConvertible {
 ///     uint16_t Flags                  ; +16 + Length
 ///     uint16_t Streams                ; +18 + Length
 ///              StreamHeaders[Streams] ; +20 + Length
-internal struct MetadataRoot {
+public struct MetadataRoot {
   private let data: ArraySlice<UInt8>
 
   public init(data: ArraySlice<UInt8>) {
@@ -186,11 +185,11 @@ extension MetadataRoot {
   }
 }
 
-internal enum Metadata {
+public enum Metadata {
 }
 
 extension Metadata {
-  internal enum Stream: String {
+  public enum Stream: String {
     case Tables = "#~"
     case Strings = "#Strings"
     case Blob = "#Blob"

--- a/Sources/WinMD/DOSFile.swift
+++ b/Sources/WinMD/DOSFile.swift
@@ -1,10 +1,9 @@
 // Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
-@_implementationOnly
 import CPE
 
-internal struct DOSFile {
+public struct DOSFile {
   internal let data: [UInt8]
 
   public init(from data: [UInt8]) throws {

--- a/Sources/WinMD/Database.swift
+++ b/Sources/WinMD/Database.swift
@@ -5,9 +5,9 @@ import struct Foundation.Data
 import struct Foundation.URL
 
 public class Database {
-  private let dos: DOSFile
-  private let pe: PEFile
-  private let cil: Assembly
+  public let dos: DOSFile
+  public let pe: PEFile
+  public let cil: Assembly
 
   private init(data: [UInt8]) throws {
     self.dos = try DOSFile(from: data)

--- a/Sources/WinMD/PEFile.swift
+++ b/Sources/WinMD/PEFile.swift
@@ -1,10 +1,9 @@
 // Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
-@_implementationOnly
 import CPE
 
-internal struct PEFile {
+public struct PEFile {
   internal let data: ArraySlice<UInt8>
 
   public var Header32: IMAGE_NT_HEADERS32 {


### PR DESCRIPTION
This exposes those types, and subsequently makes `CPE` public as the
interfaces are exposed as public fields.  This is the first step towards
splitting WinMD into a parsing library.  This is intended to help split
a generator from the core library.