### PR TITLE
WinMD: make more types public

### DIFF
--- a/Sources/WinMD/BlobsHeap.swift
+++ b/Sources/WinMD/BlobsHeap.swift
@@ -1,7 +1,7 @@
 // Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
-internal struct BlobsHeap {
+public struct BlobsHeap {
   let data: ArraySlice<UInt8>
 
   public init(data: ArraySlice<UInt8>) {

--- a/Sources/WinMD/CodedIndex.swift
+++ b/Sources/WinMD/CodedIndex.swift
@@ -6,7 +6,7 @@
 /// The tagged-union is formed by encoding the descriminator in the bottom
 /// log(n) bits and the index in the remaining bits.  The raw value is either
 /// 16-bits if all the tables use a 16-bit index or 32-bit otherwise.
-internal protocol CodedIndex {
+public protocol CodedIndex {
   /// The tables that the `CodedIndex` descriminates across.
   ///
   /// The order of the tables is important.  The tag identifies the table and

--- a/Sources/WinMD/Compression.swift
+++ b/Sources/WinMD/Compression.swift
@@ -7,7 +7,7 @@
 /// provides the context for the decompression of the database. The compression
 /// state is expensive to compute, and this simply serves as a cache for the
 /// data.
-internal class DatabaseDecoder {
+public class DatabaseDecoder {
   public private(set) var strides: [Index:Int] = [:]
 
   public init(_ stream: TablesStream) {

--- a/Sources/WinMD/GUIDHeap.swift
+++ b/Sources/WinMD/GUIDHeap.swift
@@ -4,7 +4,7 @@
 import struct Foundation.UUID
 import typealias Foundation.uuid_t
 
-internal struct GUIDHeap {
+public struct GUIDHeap {
   let data: ArraySlice<UInt8>
 
   public init(data: ArraySlice<UInt8>) {

--- a/Sources/WinMD/Index.swift
+++ b/Sources/WinMD/Index.swift
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 /// Identifies the well-known heap.
-internal enum Heap {
+public enum Heap {
   /// The blob heap.
   case blob
 
@@ -14,7 +14,7 @@ internal enum Heap {
 }
 
 /// A foreign-key index.
-internal enum Index {
+public enum Index {
   /// Index into a well known heap.
   case heap(Heap)
 

--- a/Sources/WinMD/Iteration.swift
+++ b/Sources/WinMD/Iteration.swift
@@ -8,7 +8,7 @@ import OrderedCollections
 /// A record, or colloquailly a row, is a singular entity in a table.  This is
 /// an iterable entity in the record collection of a table.
 @dynamicMemberLookup
-internal struct Record: IteratorProtocol {
+public struct Record: IteratorProtocol {
   public typealias Element = Self
 
   private let table: Table
@@ -18,6 +18,7 @@ internal struct Record: IteratorProtocol {
 
   private let heaps: RecordReader.HeapRefs?
 
+  @usableFromInline
   internal init(table: Table, layout: OrderedDictionary<String, (Int, Int)>,
                 stride: Int, row cursor: Int, heaps: RecordReader.HeapRefs?) {
     self.table = table
@@ -101,24 +102,24 @@ extension Record: CustomDebugStringConvertible {
 ///
 /// Decodes and provides a set of records which can be iterated.  This requires
 /// the database compression state to be able to decode the table data.
-internal struct RecordReader: Sequence {
-  internal typealias HeapRefs = (blob: BlobsHeap, guid: GUIDHeap, string: StringsHeap)
+public struct RecordReader: Sequence {
+  public typealias HeapRefs = (blob: BlobsHeap, guid: GUIDHeap, string: StringsHeap)
 
   public typealias Iterator = Record
 
   private let decoder: DatabaseDecoder
-  private let heaps: HeapRefs?
+  public let heaps: HeapRefs?
 
-  private var table: Table?
-  private var layout: OrderedDictionary<String, (Int, Int)>?
-  private var stride: Int?
+  public private(set) var table: Table?
+  public private(set) var layout: OrderedDictionary<String, (Int, Int)>?
+  public private(set) var stride: Int?
 
-  internal init(decoder: DatabaseDecoder, heaps: HeapRefs? = nil) {
+  public init(decoder: DatabaseDecoder, heaps: HeapRefs? = nil) {
     self.decoder = decoder
     self.heaps = heaps
   }
 
-  internal mutating func rows(_ table: Table) -> Self {
+  public mutating func rows(_ table: Table) -> Self {
     var scan: Int = 0
 
     self.table = table

--- a/Sources/WinMD/StringsHeap.swift
+++ b/Sources/WinMD/StringsHeap.swift
@@ -1,7 +1,7 @@
 // Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
-internal struct StringsHeap {
+public struct StringsHeap {
   let data: ArraySlice<UInt8>
 
   public init(data: ArraySlice<UInt8>) {

--- a/Sources/WinMD/Table.swift
+++ b/Sources/WinMD/Table.swift
@@ -17,13 +17,13 @@ extension ColumnType: Hashable {
 /// 
 /// Accessible columns have a name which the user can use to reference the
 /// column, and a type which indicates how to read the value of the column.
-internal struct Column {
+public struct Column {
   let name: StaticString
   let type: ColumnType
 }
 
 /// CIL Table Representation
-internal protocol Table: AnyObject {
+public protocol Table: AnyObject {
   /// The CIL defined table number.
   static var number: Int { get }
 

--- a/Sources/WinMD/TablesStream.swift
+++ b/Sources/WinMD/TablesStream.swift
@@ -11,7 +11,7 @@
 ///     uint64_t Sorted             ; +16
 ///     uint32_t Rows[]             ; +24
 ///      uint8_t Tables[]
-internal struct TablesStream {
+public struct TablesStream {
   private let data: ArraySlice<UInt8>
 
   public init(data: ArraySlice<UInt8>) {


### PR DESCRIPTION
This exposes the previously internal types to allow moving the dumping
of the database into the tooling rather than as a core library function.
This doesn't need to be part of the parsing library functionality.