### PR TITLE
CI: add the ability to track code coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,37 @@
+name: coverage
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  coverage:
+    runs-on: windows-latest
+
+    strategy:
+      matrix:
+         - branch: development
+           tag: DEVELOPMENT-SNAPSHOT-2021-06-12-a
+
+    steps:
+      - uses: compnerd/gha-setup-swift@main
+        with:
+          tag: ${{ matrix.tag }}
+          branch: ${{ matrix.branch }}
+
+      - uses: actions/checkout@v2
+      - name: Build
+        run: swift build -v
+      - name: Run tests
+        run: swift test -v --enable-code-coverage
+      - name: Process Coverage Information
+        run: llvm-cov export -format lcov -ignore-filename-regex ".build|Tests" -instr-profile .build\x86_64-unknown-windows-msvc\debug\codecov\default.profdata .build\x86_64-unknown-windows-msvc\debug\SwiftWinMDPackageTests.xctest > coverage.lcov
+      - uses: codecov/codecov-action@v1.5.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.lcov


### PR DESCRIPTION
Introduce an additional GHA job to perform code coverage analysis.  This
would integrate with codecov.io, tracking testing coverage over time.