### PR TITLE
WinMD: make the tables publicly visible

### DIFF
--- a/Sources/WinMD/CILTables.swift
+++ b/Sources/WinMD/CILTables.swift
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata {
-  internal enum Tables {
+  public enum Tables {
   }
 }
 

--- a/Sources/WinMD/Tables/Assembly.swift
+++ b/Sources/WinMD/Tables/Assembly.swift
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
-internal final class Assembly: Table {
+public final class Assembly: Table {
   public static var number: Int { 32 }
 
   /// Record Layout
@@ -15,7 +15,7 @@ internal final class Assembly: Table {
   ///   PublicKey (Blob Heap Index)
   ///   Name (String Heap Index)
   ///   Culture (String Heap Index)
-  static let columns: [Column] = [
+  public static let columns: [Column] = [
     Column(name: "HashAlgId", type: .constant(4)),
     Column(name: "MajorVersion", type: .constant(2)),
     Column(name: "MinorVersion", type: .constant(2)),
@@ -27,8 +27,8 @@ internal final class Assembly: Table {
     Column(name: "Culture", type: .index(.heap(.string))),
   ]
 
-  let rows: UInt32
-  let data: ArraySlice<UInt8>
+  public let rows: UInt32
+  public let data: ArraySlice<UInt8>
 
   public required init(rows: UInt32, data: ArraySlice<UInt8>) {
     self.rows = rows

--- a/Sources/WinMD/Tables/AssemblyOS.swift
+++ b/Sources/WinMD/Tables/AssemblyOS.swift
@@ -2,21 +2,21 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
-internal final class AssemblyOS: Table {
+public final class AssemblyOS: Table {
   public static var number: Int { 34 }
 
   /// Record Layout
   ///   OSPlatformID (4-byte constant)
   ///   OSMajorVersion (4-byte constant)
   ///   OSMinorVersion (4-byte constant)
-  static let columns: [Column] = [
+  public static let columns: [Column] = [
     Column(name: "OSPlatformID", type: .constant(4)),
     Column(name: "OSMajorVersion", type: .constant(4)),
     Column(name: "OSMinorVersion", type: .constant(4)),
   ]
 
-  let rows: UInt32
-  let data: ArraySlice<UInt8>
+  public let rows: UInt32
+  public let data: ArraySlice<UInt8>
 
   public required init(rows: UInt32, data: ArraySlice<UInt8>) {
     self.rows = rows

--- a/Sources/WinMD/Tables/AssemblyProcessor.swift
+++ b/Sources/WinMD/Tables/AssemblyProcessor.swift
@@ -2,17 +2,17 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
-internal final class AssemblyProcessor: Table {
+public final class AssemblyProcessor: Table {
   public static var number: Int { 33 }
 
   /// Record Layout
   ///   Processor (4-byte constant)
-  static let columns: [Column] = [
+  public static let columns: [Column] = [
     Column(name: "Processor", type: .constant(4)),
   ]
 
-  let rows: UInt32
-  let data: ArraySlice<UInt8>
+  public let rows: UInt32
+  public let data: ArraySlice<UInt8>
 
   public required init(rows: UInt32, data: ArraySlice<UInt8>) {
     self.rows = rows

--- a/Sources/WinMD/Tables/AssemblyRef.swift
+++ b/Sources/WinMD/Tables/AssemblyRef.swift
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
-internal final class AssemblyRef: Table {
+public final class AssemblyRef: Table {
   public static var number: Int { 35 }
 
   /// Record Layout
@@ -15,7 +15,7 @@ internal final class AssemblyRef: Table {
   ///   Name (String Heap Index)
   ///   Culutre (String Heap Index)
   ///   HashValue (Blob Heap Index)
-  static let columns: [Column] = [
+  public static let columns: [Column] = [
     Column(name: "MajorVersion", type: .constant(2)),
     Column(name: "MinorVersion", type: .constant(2)),
     Column(name: "BuildNumber", type: .constant(2)),
@@ -27,8 +27,8 @@ internal final class AssemblyRef: Table {
     Column(name: "HashValue", type: .index(.heap(.blob))),
   ]
 
-  let rows: UInt32
-  let data: ArraySlice<UInt8>
+  public let rows: UInt32
+  public let data: ArraySlice<UInt8>
 
   public required init(rows: UInt32, data: ArraySlice<UInt8>) {
     self.rows = rows

--- a/Sources/WinMD/Tables/AssemblyRefOS.swift
+++ b/Sources/WinMD/Tables/AssemblyRefOS.swift
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
-internal final class AssemblyRefOS: Table {
+public final class AssemblyRefOS: Table {
   public static var number: Int { 37 }
 
   /// Record Layout
@@ -10,15 +10,15 @@ internal final class AssemblyRefOS: Table {
   ///   OSMajorVersion (4-byte constant)
   ///   OSMinorVersion (4-byte constant)
   ///   AssemblyRef (AssemblyRef Index)
-  static let columns: [Column] = [
+  public static let columns: [Column] = [
     Column(name: "OSPlatformId", type: .constant(4)),
     Column(name: "OSMajorVersion", type: .constant(4)),
     Column(name: "OSMinorVersion", type: .constant(4)),
     Column(name: "AssemblyRef", type: .index(.simple(AssemblyRef.self))),
   ]
 
-  let rows: UInt32
-  let data: ArraySlice<UInt8>
+  public let rows: UInt32
+  public let data: ArraySlice<UInt8>
 
   public required init(rows: UInt32, data: ArraySlice<UInt8>) {
     self.rows = rows

--- a/Sources/WinMD/Tables/AssemblyRefProcessor.swift
+++ b/Sources/WinMD/Tables/AssemblyRefProcessor.swift
@@ -2,19 +2,19 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
-internal final class AssemblyRefProcessor: Table {
+public final class AssemblyRefProcessor: Table {
   public static var number: Int { 36 }
 
   /// Record Layout
   ///   Processor (4-byte constant)
   ///   AssemblyRef (AssemblyRef Index)
-  static let columns: [Column] = [
+  public static let columns: [Column] = [
     Column(name: "Processor", type: .constant(4)),
     Column(name: "AssemblyRef", type: .index(.simple(AssemblyRef.self))),
   ]
 
-  let rows: UInt32
-  let data: ArraySlice<UInt8>
+  public let rows: UInt32
+  public let data: ArraySlice<UInt8>
 
   public required init(rows: UInt32, data: ArraySlice<UInt8>) {
     self.rows = rows

--- a/Sources/WinMD/Tables/ClassLayout.swift
+++ b/Sources/WinMD/Tables/ClassLayout.swift
@@ -2,21 +2,21 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
-internal final class ClassLayout: Table {
+public final class ClassLayout: Table {
   public static var number: Int { 15 }
 
   /// Record Layout
   ///   PackingSize (2-byte constant)
   ///   ClassSize (4-byte constant)
   ///   Parent (TypeDef Index)
-  static let columns: [Column] = [
+  public static let columns: [Column] = [
     Column(name: "PackingSize", type: .constant(2)),
     Column(name: "ClassSize", type: .constant(4)),
     Column(name: "Parent", type: .index(.simple(TypeDef.self))),
   ]
 
-  let rows: UInt32
-  let data: ArraySlice<UInt8>
+  public let rows: UInt32
+  public let data: ArraySlice<UInt8>
 
   public required init(rows: UInt32, data: ArraySlice<UInt8>) {
     self.rows = rows

--- a/Sources/WinMD/Tables/Constant.swift
+++ b/Sources/WinMD/Tables/Constant.swift
@@ -2,22 +2,22 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
-internal final class Constant: Table {
+public final class Constant: Table {
   public static var number: Int { 11 }
 
   /// Record Layout
   ///   Type (1-byte, 1-byte padding zero)
   ///   Parent (HasConstant Coded Index)
   ///   Value (Blob Heap Index)
-  static let columns: [Column] = [
+  public static let columns: [Column] = [
     Column(name: "Type", type: .constant(1)),
     Column(name: StaticString(), type: .constant(1)),
     Column(name: "Parent", type: .index(.coded(HasConstant.self))),
     Column(name: "Value", type: .index(.heap(.blob))),
   ]
 
-  let rows: UInt32
-  let data: ArraySlice<UInt8>
+  public let rows: UInt32
+  public let data: ArraySlice<UInt8>
 
   public required init( rows: UInt32, data: ArraySlice<UInt8>) {
     self.rows = rows

--- a/Sources/WinMD/Tables/CustomAttribute.swift
+++ b/Sources/WinMD/Tables/CustomAttribute.swift
@@ -2,21 +2,21 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
-internal final class CustomAttribute: Table {
+public final class CustomAttribute: Table {
   public static var number: Int { 12 }
 
   /// Record Layout
   ///   Parent (HasCustomAttribute Coded Index)
   ///   Type (CustomAttributeType Coded Index)
   ///   Value (Blob Heap Index)
-  static let columns: [Column] = [
+  public static let columns: [Column] = [
     Column(name: "Parent", type: .index(.coded(HasCustomAttribute.self))),
     Column(name: "Type", type: .index(.coded(CustomAttributeType.self))),
     Column(name: "Value", type: .index(.heap(.blob))),
   ]
 
-  let rows: UInt32
-  let data: ArraySlice<UInt8>
+  public let rows: UInt32
+  public let data: ArraySlice<UInt8>
 
   public required init(rows: UInt32, data: ArraySlice<UInt8>) {
     self.rows = rows

--- a/Sources/WinMD/Tables/DeclSecurity.swift
+++ b/Sources/WinMD/Tables/DeclSecurity.swift
@@ -2,21 +2,21 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
-internal final class DeclSecurity: Table {
+public final class DeclSecurity: Table {
   public static var number: Int { 14 }
 
   /// Record Layout
   ///   Action (2-byte value)
   ///   Parent (HasDeclSecurity Coded Index)
   ///   PermissionSet (Blob Heap Index)
-  static let columns: [Column] = [
+  public static let columns: [Column] = [
     Column(name: "Action", type: .constant(2)),
     Column(name: "Parent", type: .index(.coded(HasDeclSecurity.self))),
     Column(name: "PermissionSet", type: .index(.heap(.blob))),
   ]
 
-  let rows: UInt32
-  let data: ArraySlice<UInt8>
+  public let rows: UInt32
+  public let data: ArraySlice<UInt8>
 
   public init(rows: UInt32, data: ArraySlice<UInt8>) {
     self.rows = rows

--- a/Sources/WinMD/Tables/EventDef.swift
+++ b/Sources/WinMD/Tables/EventDef.swift
@@ -2,21 +2,21 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
-internal final class EventDef: Table {
+public final class EventDef: Table {
   public static var number: Int { 20 }
 
   /// Record Layout
   ///   EventFlags (2-byte bitmask EventAttributes)
   ///   Name (String Heap Index)
   ///   EventType (TypeDefOrRef Coded Index)
-  static let columns: [Column] = [
+  public static let columns: [Column] = [
     Column(name: "EventFlags", type: .constant(2)),
     Column(name: "Name", type: .index(.heap(.string))),
     Column(name: "EventType", type: .index(.coded(TypeDefOrRef.self)))
   ]
 
-  let rows: UInt32
-  let data: ArraySlice<UInt8>
+  public let rows: UInt32
+  public let data: ArraySlice<UInt8>
 
   public required init(rows: UInt32, data: ArraySlice<UInt8>) {
     self.rows = rows

--- a/Sources/WinMD/Tables/EventMap.swift
+++ b/Sources/WinMD/Tables/EventMap.swift
@@ -2,19 +2,19 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
-internal final class EventMap: Table {
+public final class EventMap: Table {
   public static var number: Int { 18 }
 
   /// Record Layout
   ///   Parent (TypeDef Index)
   ///   EventList (Event Index)
-  static let columns: [Column] = [
+  public static let columns: [Column] = [
     Column(name: "Parent", type: .index(.simple(TypeDef.self))),
     Column(name: "EventList", type: .index(.simple(EventDef.self))),
   ]
 
-  let rows: UInt32
-  let data: ArraySlice<UInt8>
+  public let rows: UInt32
+  public let data: ArraySlice<UInt8>
 
   public required init(rows: UInt32, data: ArraySlice<UInt8>) {
     self.rows = rows

--- a/Sources/WinMD/Tables/ExportedType.swift
+++ b/Sources/WinMD/Tables/ExportedType.swift
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
-internal final class ExportedType: Table {
+public final class ExportedType: Table {
   public static var number: Int { 39 }
 
   /// Record Layout
@@ -11,7 +11,7 @@ internal final class ExportedType: Table {
   ///   TypeName (String Heap Index)
   ///   TypeNamespace (String Heap Index)
   ///   Implementation (Implementation Coded Index)
-  static let columns: [Column] = [
+  public static let columns: [Column] = [
     Column(name: "Flags", type: .constant(4)),
     Column(name: "TypeDefId", type: .constant(4)),
     Column(name: "TypeName", type: .index(.heap(.string))),
@@ -19,8 +19,8 @@ internal final class ExportedType: Table {
     Column(name: "Implementation", type: .index(.coded(Implementation.self))),
   ]
 
-  let rows: UInt32
-  let data: ArraySlice<UInt8>
+  public let rows: UInt32
+  public let data: ArraySlice<UInt8>
 
   public required init(rows: UInt32, data: ArraySlice<UInt8>) {
     self.rows = rows

--- a/Sources/WinMD/Tables/FieldDef.swift
+++ b/Sources/WinMD/Tables/FieldDef.swift
@@ -2,21 +2,21 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
-internal final class FieldDef: Table {
+public final class FieldDef: Table {
   public static var number: Int { 4 }
 
   /// Record Layout
   ///   Flags (2-byte bitmask of FieldAttributes)
   ///   Name (String Heap Index)
   ///   Signature (Blob Heap Index)
-  static let columns: [Column] = [
+  public static let columns: [Column] = [
     Column(name: "Flags", type: .constant(2)),
     Column(name: "Name", type: .index(.heap(.string))),
     Column(name: "Signature", type: .index(.heap(.blob))),
   ]
 
-  let rows: UInt32
-  let data: ArraySlice<UInt8>
+  public let rows: UInt32
+  public let data: ArraySlice<UInt8>
 
   public required init(rows: UInt32, data: ArraySlice<UInt8>) {
     self.rows = rows

--- a/Sources/WinMD/Tables/FieldLayout.swift
+++ b/Sources/WinMD/Tables/FieldLayout.swift
@@ -2,19 +2,19 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
-internal final class FieldLayout: Table {
+public final class FieldLayout: Table {
   public static var number: Int { 16 }
 
   /// Record Layout
   ///   Offset (4-byte constant)
   ///   Field (Field Index)
-  static let columns: [Column] = [
+  public static let columns: [Column] = [
     Column(name: "Offset", type: .constant(4)),
     Column(name: "Field", type: .index(.simple(FieldDef.self))),
   ]
 
-  let rows: UInt32
-  let data: ArraySlice<UInt8>
+  public let rows: UInt32
+  public let data: ArraySlice<UInt8>
 
   public required init(rows: UInt32, data: ArraySlice<UInt8>) {
     self.rows = rows

--- a/Sources/WinMD/Tables/FieldMarshal.swift
+++ b/Sources/WinMD/Tables/FieldMarshal.swift
@@ -2,19 +2,19 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
-internal final class FieldMarshal: Table {
+public final class FieldMarshal: Table {
   public static var number: Int { 13 }
 
   /// Record Layout
   ///   Parent (HasFieldMarshal Coded Index)
   ///   NativeType (Blob Heap Index)
-  static let columns: [Column] = [
+  public static let columns: [Column] = [
     Column(name: "Parent", type: .index(.coded(HasFieldMarshal.self))),
     Column(name: "NativeType", type: .index(.heap(.blob))),
   ]
 
-  let rows: UInt32
-  let data: ArraySlice<UInt8>
+  public let rows: UInt32
+  public let data: ArraySlice<UInt8>
 
   public required init(rows: UInt32, data: ArraySlice<UInt8>) {
     self.rows = rows

--- a/Sources/WinMD/Tables/FieldRVA.swift
+++ b/Sources/WinMD/Tables/FieldRVA.swift
@@ -2,19 +2,19 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
-internal final class FieldRVA: Table {
+public final class FieldRVA: Table {
   public static var number: Int { 29 }
 
   /// Record Layout
   ///   RVA (4-byte constant)
   ///   Field (Field Index)
-  static let columns: [Column] = [
+  public static let columns: [Column] = [
     Column(name: "RVA", type: .constant(4)),
     Column(name: "Field", type: .index(.simple(FieldDef.self))),
   ]
 
-  let rows: UInt32
-  let data: ArraySlice<UInt8>
+  public let rows: UInt32
+  public let data: ArraySlice<UInt8>
 
   public init(rows: UInt32, data: ArraySlice<UInt8>) {
     self.rows = rows

--- a/Sources/WinMD/Tables/File.swift
+++ b/Sources/WinMD/Tables/File.swift
@@ -2,21 +2,21 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
-internal final class File: Table {
+public final class File: Table {
   public static var number: Int { 38 }
 
   /// Record Layout
   ///   Flags (4-byte bitmask of FileAttributes)
   ///   Name (String Heap Index)
   ///   HashValue (Blob Heap Index)
-  static let columns: [Column] = [
+  public static let columns: [Column] = [
     Column(name: "Flags", type: .constant(4)),
     Column(name: "Name", type: .index(.heap(.string))),
     Column(name: "HashValue", type: .index(.heap(.blob))),
   ]
 
-  let rows: UInt32
-  let data: ArraySlice<UInt8>
+  public let rows: UInt32
+  public let data: ArraySlice<UInt8>
 
   public required init(rows: UInt32, data: ArraySlice<UInt8>) {
     self.rows = rows

--- a/Sources/WinMD/Tables/GenericParam.swift
+++ b/Sources/WinMD/Tables/GenericParam.swift
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
-internal final class GenericParam: Table {
+public final class GenericParam: Table {
   public static var number: Int { 42 }
 
   /// Record Layout
@@ -10,15 +10,15 @@ internal final class GenericParam: Table {
   ///   Flags (2-byte bitmask of GenericParamAttributes)
   ///   Owner (TypeOrMethodDef Coded Index)
   ///   Name (String Heap Index)
-  static let columns: [Column] = [
+  public static let columns: [Column] = [
     Column(name: "Number", type: .constant(2)),
     Column(name: "Flags", type: .constant(2)),
     Column(name: "Owner", type: .index(.coded(TypeOrMethodDef.self))),
     Column(name: "Name", type: .index(.heap(.string))),
   ]
 
-  let rows: UInt32
-  let data: ArraySlice<UInt8>
+  public let rows: UInt32
+  public let data: ArraySlice<UInt8>
 
   public required init(rows: UInt32, data: ArraySlice<UInt8>) {
     self.rows = rows

--- a/Sources/WinMD/Tables/GenericParamConstraint.swift
+++ b/Sources/WinMD/Tables/GenericParamConstraint.swift
@@ -2,19 +2,19 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
-internal final class GenericParamConstraint: Table {
+public final class GenericParamConstraint: Table {
   public static var number: Int { 44 }
 
   /// Record Layout
   ///   Owner (GenericParam Index)
   ///   Constraint (TypeDefOrRef Coded Index)
-  static let columns: [Column] = [
+  public static let columns: [Column] = [
     Column(name: "Owner", type: .index(.simple(GenericParam.self))),
     Column(name: "Constraint", type: .index(.coded(TypeDefOrRef.self))),
   ]
 
-  let rows: UInt32
-  let data: ArraySlice<UInt8>
+  public let rows: UInt32
+  public let data: ArraySlice<UInt8>
 
   public required init(rows: UInt32, data: ArraySlice<UInt8>) {
     self.rows = rows

--- a/Sources/WinMD/Tables/ImplMap.swift
+++ b/Sources/WinMD/Tables/ImplMap.swift
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
-internal final class ImplMap: Table {
+public final class ImplMap: Table {
   public static var number: Int { 28 }
 
   /// Record Layout
@@ -10,15 +10,15 @@ internal final class ImplMap: Table {
   ///   MemberForwarded (MemberForwarded Coded Index)
   ///   ImportName (String Heap Index)
   ///   ImportScope (ModuleRef Index)
-  static let columns: [Column] = [
+  public static let columns: [Column] = [
     Column(name: "MappingFlags", type: .constant(2)),
     Column(name: "MemberForwarded", type: .index(.coded(MemberForwarded.self))),
     Column(name: "ImportName", type: .index(.heap(.string))),
     Column(name: "ImportScope", type: .index(.simple(ModuleRef.self))),
   ]
 
-  let rows: UInt32
-  let data: ArraySlice<UInt8>
+  public let rows: UInt32
+  public let data: ArraySlice<UInt8>
 
   public required init(rows: UInt32, data: ArraySlice<UInt8>) {
     self.rows = rows

--- a/Sources/WinMD/Tables/InterfaceImpl.swift
+++ b/Sources/WinMD/Tables/InterfaceImpl.swift
@@ -2,19 +2,19 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
-internal final class InterfaceImpl: Table {
+public final class InterfaceImpl: Table {
   public static var number: Int { 9 }
 
   /// Record Layout
   ///   Class (TypeDef Index)
   ///   Interface (TypeDefOrRef Coded Index)
-  static let columns: [Column] = [
+  public static let columns: [Column] = [
     Column(name: "Class", type: .index(.simple(TypeDef.self))),
     Column(name: "Interface", type: .index(.coded(TypeDefOrRef.self))),
   ]
 
-  let rows: UInt32
-  let data: ArraySlice<UInt8>
+  public let rows: UInt32
+  public let data: ArraySlice<UInt8>
 
   public required init(rows: UInt32, data: ArraySlice<UInt8>) {
     self.rows = rows

--- a/Sources/WinMD/Tables/ManifestResource.swift
+++ b/Sources/WinMD/Tables/ManifestResource.swift
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
-internal final class ManifestResource: Table {
+public final class ManifestResource: Table {
   public static var number: Int { 40 }
 
   /// Record Layout
@@ -10,15 +10,15 @@ internal final class ManifestResource: Table {
   ///   Flags (4-byte bitmask of ManifestResourceAttributes)
   ///   Name (String Heap Index)
   ///   Implementation (Implementation Coded Index)
-  static let columns: [Column] = [
+  public static let columns: [Column] = [
     Column(name: "Offset", type: .constant(4)),
     Column(name: "Flags", type: .constant(4)),
     Column(name: "Name", type: .index(.heap(.string))),
     Column(name: "Implementation", type: .index(.coded(Implementation.self))),
   ]
 
-  let rows: UInt32
-  let data: ArraySlice<UInt8>
+  public let rows: UInt32
+  public let data: ArraySlice<UInt8>
 
   public required init(rows: UInt32, data: ArraySlice<UInt8>) {
     self.rows = rows

--- a/Sources/WinMD/Tables/MemberRef.swift
+++ b/Sources/WinMD/Tables/MemberRef.swift
@@ -2,21 +2,21 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
-internal final class MemberRef: Table {
+public final class MemberRef: Table {
   public static var number: Int { 10 }
 
   /// Record Layout
   ///   Class (MemberRefParent Coded Index)
   ///   Name (String Heap Index)
   ///   Signature (Blob Heap Index)
-  static let columns: [Column] = [
+  public static let columns: [Column] = [
     Column(name: "Class", type: .index(.coded(MemberRefParent.self))),
     Column(name: "Name", type: .index(.heap(.string))),
     Column(name: "Signature", type: .index(.heap(.blob))),
   ]
 
-  let rows: UInt32
-  let data: ArraySlice<UInt8>
+  public let rows: UInt32
+  public let data: ArraySlice<UInt8>
 
   public required init(rows: UInt32, data: ArraySlice<UInt8>) {
     self.rows = rows

--- a/Sources/WinMD/Tables/MethodDef.swift
+++ b/Sources/WinMD/Tables/MethodDef.swift
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
-internal final class MethodDef: Table {
+public final class MethodDef: Table {
   public static var number: Int { 6 }
 
   /// Record Layout
@@ -12,7 +12,7 @@ internal final class MethodDef: Table {
   ///   Name (String Heap Index)
   ///   Signature (Blob Heap Index)
   ///   ParamList (Param Index)
-  static let columns: [Column] = [
+  public static let columns: [Column] = [
     Column(name: "RVA", type: .constant(4)),
     Column(name: "ImplFlags", type: .constant(2)),
     Column(name: "Flags", type: .constant(2)),
@@ -21,8 +21,8 @@ internal final class MethodDef: Table {
     Column(name: "ParamList", type: .index(.simple(Param.self))),
   ]
 
-  let rows: UInt32
-  let data: ArraySlice<UInt8>
+  public let rows: UInt32
+  public let data: ArraySlice<UInt8>
 
   public required init(rows: UInt32, data: ArraySlice<UInt8>) {
     self.rows = rows

--- a/Sources/WinMD/Tables/MethodImpl.swift
+++ b/Sources/WinMD/Tables/MethodImpl.swift
@@ -2,21 +2,21 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
-internal final class MethodImpl: Table {
+public final class MethodImpl: Table {
   public static var number: Int { 25 }
 
   /// Record Layout
   ///   Class (TypeDef Index)
   ///   MethodBody (MethodDefOrRef Coded Index)
   ///   MethodDeclaration (MethodDefOrRef Coded Index)
-  static let columns: [Column] = [
+  public static let columns: [Column] = [
     Column(name: "Class", type: .index(.simple(TypeDef.self))),
     Column(name: "MethodBody", type: .index(.coded(MethodDefOrRef.self))),
     Column(name: "MethodDeclaration", type: .index(.coded(MethodDefOrRef.self))),
   ]
 
-  let rows: UInt32
-  let data: ArraySlice<UInt8>
+  public let rows: UInt32
+  public let data: ArraySlice<UInt8>
 
   public required init(rows: UInt32, data: ArraySlice<UInt8>) {
     self.rows = rows

--- a/Sources/WinMD/Tables/MethodSemantics.swift
+++ b/Sources/WinMD/Tables/MethodSemantics.swift
@@ -2,21 +2,21 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
-internal final class MethodSemantics: Table {
+public final class MethodSemantics: Table {
   public static var number: Int { 24 }
 
   /// Record Layout
   ///   Semantics (2-byte bitmask of MethodSemanticsAttributes)
   ///   Method (MethodDef Index)
   ///   Association (HasSemantics Coded Index)
-  static let columns: [Column] = [
+  public static let columns: [Column] = [
     Column(name: "Semantics", type: .constant(2)),
     Column(name: "Method", type: .index(.simple(MethodDef.self))),
     Column(name: "Association", type: .index(.coded(HasSemantics.self))),
   ]
 
-  let rows: UInt32
-  let data: ArraySlice<UInt8>
+  public let rows: UInt32
+  public let data: ArraySlice<UInt8>
 
   public required init(rows: UInt32, data: ArraySlice<UInt8>) {
     self.rows = rows

--- a/Sources/WinMD/Tables/MethodSpec.swift
+++ b/Sources/WinMD/Tables/MethodSpec.swift
@@ -2,19 +2,19 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
-internal final class MethodSpec: Table {
+public final class MethodSpec: Table {
   public static var number: Int { 43 }
 
   /// Record Layout
   ///   Method (MethodDefOrRef Coded Index)
   ///   Instantiation (Blob Heap Index)
-  static let columns: [Column] = [
+  public static let columns: [Column] = [
     Column(name: "Method", type: .index(.coded(MethodDefOrRef.self))),
     Column(name: "Instantiation", type: .index(.heap(.blob))),
   ]
 
-  let rows: UInt32
-  let data: ArraySlice<UInt8>
+  public let rows: UInt32
+  public let data: ArraySlice<UInt8>
 
   public init(rows: UInt32, data: ArraySlice<UInt8>) {
     self.rows = rows

--- a/Sources/WinMD/Tables/Module.swift
+++ b/Sources/WinMD/Tables/Module.swift
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
-internal final class Module: Table {
+public final class Module: Table {
   public static var number: Int { 0 }
 
   /// Record Layout
@@ -11,7 +11,7 @@ internal final class Module: Table {
   ///   Mvid (Module Version ID) (GUID Heap Index)
   ///   EncId (GUID Heap Index, reserved, MBZ)
   ///   EncBaseId (GUID Heap Index, reserved, MBZ)
-  static let columns: [Column] = [
+  public static let columns: [Column] = [
     Column(name: "Generation", type: .constant(2)),
     Column(name: "Name", type: .index(.heap(.string))),
     Column(name: "Mvid", type: .index(.heap(.guid))),
@@ -19,8 +19,8 @@ internal final class Module: Table {
     Column(name: "EncBaseId", type: .index(.heap(.guid))),
   ]
 
-  let rows: UInt32
-  let data: ArraySlice<UInt8>
+  public let rows: UInt32
+  public let data: ArraySlice<UInt8>
 
   public init(rows: UInt32, data: ArraySlice<UInt8>) {
     self.rows = rows

--- a/Sources/WinMD/Tables/ModuleRef.swift
+++ b/Sources/WinMD/Tables/ModuleRef.swift
@@ -2,17 +2,17 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
-internal final class ModuleRef: Table {
+public final class ModuleRef: Table {
   public static var number: Int { 26 }
 
   /// Record Layout
   ///   Name (String Heap Index)
-  static let columns: [Column] = [
+  public static let columns: [Column] = [
     Column(name: "Name", type: .index(.heap(.string))),
   ]
 
-  let rows: UInt32
-  let data: ArraySlice<UInt8>
+  public let rows: UInt32
+  public let data: ArraySlice<UInt8>
 
   public init(rows: UInt32, data: ArraySlice<UInt8>) {
     self.rows = rows

--- a/Sources/WinMD/Tables/NestedClass.swift
+++ b/Sources/WinMD/Tables/NestedClass.swift
@@ -2,19 +2,19 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
-internal final class NestedClass: Table {
+public final class NestedClass: Table {
   public static var number: Int { 41 }
 
   /// Record Layout
   ///   NestedClass (TypeDef Index)
   ///   EnclosingClass (TypeDef Index)
-  static let columns: [Column] = [
+  public static let columns: [Column] = [
     Column(name: "NestedClass", type: .index(.simple(TypeDef.self))),
     Column(name: "EnclosingClass", type: .index(.simple(TypeDef.self))),
   ]
 
-  let rows: UInt32
-  let data: ArraySlice<UInt8>
+  public let rows: UInt32
+  public let data: ArraySlice<UInt8>
 
   public required init(rows: UInt32, data: ArraySlice<UInt8>) {
     self.rows = rows

--- a/Sources/WinMD/Tables/Param.swift
+++ b/Sources/WinMD/Tables/Param.swift
@@ -2,21 +2,21 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
-internal final class Param: Table {
+public final class Param: Table {
   public static var number: Int { 8 }
 
   /// Record Layout
   ///   Flags (2-byte bitmask of ParamAttributes)
   ///   Sequence (2-byte constant)
   ///   Name (String Heap Index)
-  static let columns: [Column] = [
+  public static let columns: [Column] = [
     Column(name: "Flags", type: .constant(2)),
     Column(name: "Sequence", type: .constant(2)),
     Column(name: "Name", type: .index(.heap(.string))),
   ]
 
-  let rows: UInt32
-  let data: ArraySlice<UInt8>
+  public let rows: UInt32
+  public let data: ArraySlice<UInt8>
 
   public init(rows: UInt32, data: ArraySlice<UInt8>) {
     self.rows = rows

--- a/Sources/WinMD/Tables/PropertyDef.swift
+++ b/Sources/WinMD/Tables/PropertyDef.swift
@@ -2,21 +2,21 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
-internal final class PropertyDef: Table {
+public final class PropertyDef: Table {
   public static var number: Int { 23 }
 
   /// Record Layout
   ///   Flags (2-byte bitmask of PropertyAttributes)
   ///   Name (String Heap Index)
   ///   Type (Blob Heap Index)
-  static let columns: [Column] = [
+  public static let columns: [Column] = [
     Column(name: "Flags", type: .constant(2)),
     Column(name: "Name", type: .index(.heap(.string))),
     Column(name: "Type", type: .index(.heap(.blob))),
   ]
 
-  let rows: UInt32
-  let data: ArraySlice<UInt8>
+  public let rows: UInt32
+  public let data: ArraySlice<UInt8>
 
   public required init(rows: UInt32, data: ArraySlice<UInt8>) {
     self.rows = rows

--- a/Sources/WinMD/Tables/PropertyMap.swift
+++ b/Sources/WinMD/Tables/PropertyMap.swift
@@ -2,19 +2,19 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
-internal final class PropertyMap: Table {
+public final class PropertyMap: Table {
   public static var number: Int { 21 }
 
   /// Record Layout
   ///   Parent (TypeDef Index)
   ///   PropertyList (Property Index)
-  static let columns: [Column] = [
+  public static let columns: [Column] = [
     Column(name: "Parent", type: .index(.simple(TypeDef.self))),
     Column(name: "PropertyList", type: .index(.simple(PropertyDef.self))),
   ]
 
-  let rows: UInt32
-  let data: ArraySlice<UInt8>
+  public let rows: UInt32
+  public let data: ArraySlice<UInt8>
 
   public required init(rows: UInt32, data: ArraySlice<UInt8>) {
     self.rows = rows

--- a/Sources/WinMD/Tables/StandAloneSig.swift
+++ b/Sources/WinMD/Tables/StandAloneSig.swift
@@ -2,17 +2,17 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
-internal final class StandAloneSig: Table {
+public final class StandAloneSig: Table {
   public static var number: Int { 17 }
 
   /// Record Layout
   ///   Signature (Blob Heap Index)
-  static let columns: [Column] = [
+  public static let columns: [Column] = [
     Column(name: "Signature", type: .index(.heap(.blob))),
   ]
 
-  let rows: UInt32
-  let data: ArraySlice<UInt8>
+  public let rows: UInt32
+  public let data: ArraySlice<UInt8>
 
   public required init(rows: UInt32, data: ArraySlice<UInt8>) {
     self.rows = rows

--- a/Sources/WinMD/Tables/TypeDef.swift
+++ b/Sources/WinMD/Tables/TypeDef.swift
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
-internal final class TypeDef: Table {
+public final class TypeDef: Table {
   public static var number: Int { 2 }
 
   /// Record Layout
@@ -12,7 +12,7 @@ internal final class TypeDef: Table {
   ///   Extends (TypeDefOrRef Coded Index)
   ///   FieldList (Field Index)
   ///   MethodList (MethodDef Index)
-  static let columns: [Column] = [
+  public static let columns: [Column] = [
     Column(name: "Flags", type: .constant(4)),
     Column(name: "TypeName", type: .index(.heap(.string))),
     Column(name: "TypeNamespace", type: .index(.heap(.string))),
@@ -21,8 +21,8 @@ internal final class TypeDef: Table {
     Column(name: "MethodList", type: .index(.simple(MethodDef.self))),
   ]
 
-  let rows: UInt32
-  let data: ArraySlice<UInt8>
+  public let rows: UInt32
+  public let data: ArraySlice<UInt8>
 
   public required init(rows: UInt32, data: ArraySlice<UInt8>) {
     self.rows = rows

--- a/Sources/WinMD/Tables/TypeRef.swift
+++ b/Sources/WinMD/Tables/TypeRef.swift
@@ -2,21 +2,21 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
-internal final class TypeRef: Table {
+public final class TypeRef: Table {
   public static var number: Int { 1 }
 
   /// Record Layout
   ///   ResolutionScope (ResolutionScope Coded Index)
   ///   TypeName (String Heap Index)
   ///   TypeNamespace (String Heap Index)
-  static let columns: [Column] = [
+  public static let columns: [Column] = [
     Column(name: "ResolutionScope", type: .index(.coded(ResolutionScope.self))),
     Column(name: "TypeName", type: .index(.heap(.string))),
     Column(name: "TypeNamespace", type: .index(.heap(.string))),
   ]
 
-  let rows: UInt32
-  let data: ArraySlice<UInt8>
+  public let rows: UInt32
+  public let data: ArraySlice<UInt8>
 
   public init(rows: UInt32, data: ArraySlice<UInt8>) {
     self.rows = rows

--- a/Sources/WinMD/Tables/TypeSpec.swift
+++ b/Sources/WinMD/Tables/TypeSpec.swift
@@ -2,17 +2,17 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
-internal final class TypeSpec: Table {
+public final class TypeSpec: Table {
   public static var number: Int { 27 }
 
   /// Record Layout
   ///   Signature (Blob Heap Index)
-  static let columns: [Column] = [
+  public static let columns: [Column] = [
     Column(name: "Signature", type: .index(.heap(.blob))),
   ]
 
-  let rows: UInt32
-  let data: ArraySlice<UInt8>
+  public let rows: UInt32
+  public let data: ArraySlice<UInt8>
 
   public required init(rows: UInt32, data: ArraySlice<UInt8>) {
     self.rows = rows


### PR DESCRIPTION
Expose the table schema and fields publicly.  This allows iteration of
the tables outside of the module.  This is intended to support
separation of the parsing/processing of the metadata and generation of
the bindings.