### PR TITLE
winmd-inspect: clean up structure of the command

### DIFF
--- a/Sources/winmd-inspect/main.swift
+++ b/Sources/winmd-inspect/main.swift
@@ -4,56 +4,70 @@
 import ArgumentParser
 import WinMD
 
-private func dump(database: WinMD.Database) throws {
-  guard let tables = TablesStream(from: database.cil) else {
-    throw ValidationError("No tables stream found.")
-  }
-  guard let blobs = BlobsHeap(from: database.cil) else {
-    throw ValidationError("No blobs heap found.")
-  }
-  guard let strings = StringsHeap(from: database.cil) else {
-    throw ValidationError("No strings heap found.")
-  }
-  guard let guids = GUIDHeap(from: database.cil) else {
-    throw ValidationError("No GUID heap found.")
+struct Dump: ParsableCommand {
+  static var configuration: CommandConfiguration {
+    CommandConfiguration(abstract: "Dump the contents of a WinMD file.")
   }
 
-  let decoder = DatabaseDecoder(tables)
-  var reader = RecordReader(decoder: decoder,
-                            heaps: RecordReader.HeapRefs(blob: blobs,
-                                                          guid: guids,
-                                                          string: strings))
+  @OptionGroup
+  var options: InspectOptions
 
-  print("MajorVersion: \(String(tables.MajorVersion, radix: 16))")
-  print("MinorVersion: \(String(tables.MinorVersion, radix: 16))")
-  print("Tables:")
-  tables.forEach {
-    print("  - \($0)")
-    for record in reader.rows($0) {
-      print("    - \(record)")
+  func run() throws {
+    print("Database: \(options.database.url.path)")
+    if let database = try? Database(at: options.database.url) {
+      guard let tables = TablesStream(from: database.cil) else {
+        throw ValidationError("No tables stream found.")
+      }
+      guard let blobs = BlobsHeap(from: database.cil) else {
+        throw ValidationError("No blobs heap found.")
+      }
+      guard let strings = StringsHeap(from: database.cil) else {
+        throw ValidationError("No strings heap found.")
+      }
+      guard let guids = GUIDHeap(from: database.cil) else {
+        throw ValidationError("No GUID heap found.")
+      }
+
+      let decoder = DatabaseDecoder(tables)
+      var reader = RecordReader(decoder: decoder,
+                                heaps: RecordReader.HeapRefs(blob: blobs,
+                                                              guid: guids,
+                                                              string: strings))
+
+      print("MajorVersion: \(String(tables.MajorVersion, radix: 16))")
+      print("MinorVersion: \(String(tables.MinorVersion, radix: 16))")
+      print("Tables:")
+      tables.forEach {
+        print("  - \($0)")
+        for record in reader.rows($0) {
+          print("    - \(record)")
+        }
+      }
     }
   }
 }
 
-@main
-struct Inspect: ParsableCommand {
+struct InspectOptions: ParsableArguments {
+  // "C:\\Windows\\System32\\WinMetadata\\Windows.Foundation.winmd"
   @Argument
   var database: FileURL
+}
 
-  @Flag
-  var dump: Bool = false
-
-  func validate() throws {
-    guard self.database.existsOnDisk && self.database.isRegularFile else {
-      throw ValidationError("Database must be an existing file.")
-    }
+@main
+struct Inspect: ParsableCommand {
+  static var configuration: CommandConfiguration {
+    CommandConfiguration(abstract: "Windows Metadata File Inspection Utility",
+                         subcommands: [
+                           Dump.self,
+                         ])
   }
 
-  func run() throws {
-    // "C:\\Windows\\System32\\WinMetadata\\Windows.Foundation.winmd"
-    print("Database: \(self.database.url.path)")
-    if let database = try? WinMD.Database(at: self.database.url) {
-      if dump { try winmd_inspect.dump(database: database) }
+  @OptionGroup
+  var options: InspectOptions
+
+  func validate() throws {
+    guard options.database.existsOnDisk && options.database.isRegularFile else {
+      throw ValidationError("Database must be an existing file.")
     }
   }
 }


### PR DESCRIPTION
The inspection tool is meant to be a "swiss army knife" for WinMD files.
It should allow you to inspect various aspects (e.g. identify all the
types contained within the WinMD "database") in addition to dump.
Change the tool to use the sub-command style, providing the following
(hypothetical) interface:

~~~
> winmd-inspect Win32.winmd dump
...
> winmd-inspect Win32.winmd typdefs
...
> winmd-inspect Win32.winmd types
...
~~~