### PR TITLE
WinMD: clean up some document comments

### DIFF
--- a/Sources/WinMD/BlobsHeap.swift
+++ b/Sources/WinMD/BlobsHeap.swift
@@ -1,6 +1,9 @@
 // Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
+/// Conveiniece wrapper for the "Blobs" heap.
+///
+/// Allows for easy access into the contents of the "Blobs" heap.
 public struct BlobsHeap {
   let data: ArraySlice<UInt8>
 

--- a/Sources/WinMD/StringsHeap.swift
+++ b/Sources/WinMD/StringsHeap.swift
@@ -1,6 +1,9 @@
 // Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
+/// Convenience wrapper for the "Strings" heap.
+///
+/// Allows for easy access into the contents of the "Strings" heap.
 public struct StringsHeap {
   let data: ArraySlice<UInt8>
 

--- a/Sources/WinMD/TablesStream.swift
+++ b/Sources/WinMD/TablesStream.swift
@@ -4,6 +4,7 @@
 /// Tables Stream
 ///
 /// The layout of the tables stream is as follows:
+///
 ///     uint32_t Reserved           ; +0 [0]
 ///      uint8_t MajorVersion       ; +4
 ///      uint8_t MinorVersion       ; +5


### PR DESCRIPTION
This cleans up the rendering of the doc comments and adds a couple of
trivial doc comments on convenience interfaces.