### PR TITLE
WinMD: be more careful about failures in accessing data

### DIFF
--- a/Sources/WinMD/CILTables.swift
+++ b/Sources/WinMD/CILTables.swift
@@ -7,8 +7,8 @@ extension Metadata {
 }
 
 extension Metadata.Tables {
-  static func forEach(_ body: (Table.Type) -> Void) {
-    [
+  static func forEach(_ body: (Table.Type) throws -> Void) rethrows {
+    try [
       Assembly.self,
       AssemblyOS.self,
       AssemblyProcessor.self,

--- a/Sources/winmd-inspect/main.swift
+++ b/Sources/winmd-inspect/main.swift
@@ -38,7 +38,7 @@ struct Dump: ParsableCommand {
     print("MajorVersion: \(String(tables.MajorVersion, radix: 16))")
     print("MinorVersion: \(String(tables.MinorVersion, radix: 16))")
     print("Tables:")
-    tables.forEach {
+    try tables.forEach {
       print("  - \($0)")
       for record in reader.rows($0) {
         print("    - \(record)")


### PR DESCRIPTION
This adds more checking to the data handling for reading tables.
Because the input is technically untrusted, we should be more careful
about invalid accesses.  This relies on newer language features, but
given that we are still in the process of designing this library, it is
safe to assume that we can use nearly the latest release of the
toolchain.