### PR TITLE
WinMD: make dynamic member lookup public

### DIFF
--- a/Sources/WinMD/Iteration.swift
+++ b/Sources/WinMD/Iteration.swift
@@ -46,7 +46,7 @@ public struct Record: IteratorProtocol {
   /// in the record data.  Because the CIL database is a compressed database of
   /// tables which encodes everything as integers, the return type is always an
   /// integer.  This may be a value or an index into another table (or index).
-  internal subscript(dynamicMember field: String) -> Int {
+  public subscript(dynamicMember field: String) -> Int {
     guard let (offset, size) = self.layout[field] else {
       fatalError("Unknown field \(field)")
     }


### PR DESCRIPTION
This increases the visibility for the dynamic member lookup on the
`Record`, permitting external users to access fields.  Eventually,
this will enable the generation of bindings outside of the library
itself.