### PR TITLE
WinMD: convert failable initializers to throwing

### DIFF
--- a/Sources/WinMD/BlobsHeap.swift
+++ b/Sources/WinMD/BlobsHeap.swift
@@ -11,9 +11,9 @@ public struct BlobsHeap {
     self.data = data
   }
 
-  public init?(from assembly: Assembly) {
+  public init(from assembly: Assembly) throws {
     guard let stream = assembly.Metadata.stream(named: Metadata.Stream.Blob) else {
-      return nil
+      throw WinMDError.BlobsHeapNotFound
     }
     self.init(data: stream)
   }

--- a/Sources/WinMD/Error.swift
+++ b/Sources/WinMD/Error.swift
@@ -3,5 +3,9 @@
 
 public enum WinMDError: Error {
   case BadImageFormat
+  case BlobsHeapNotFound
+  case GUIDHeapNotFound
   case InvalidIndex
+  case MissingTableStream
+  case StringsHeapNotFound
 }

--- a/Sources/WinMD/GUIDHeap.swift
+++ b/Sources/WinMD/GUIDHeap.swift
@@ -11,9 +11,9 @@ public struct GUIDHeap {
     self.data = data
   }
 
-  public init?(from assembly: Assembly) {
+  public init(from assembly: Assembly) throws {
     guard let stream = assembly.Metadata.stream(named: Metadata.Stream.GUID) else {
-      return nil
+      throw WinMDError.GUIDHeapNotFound
     }
     self.init(data: stream)
   }

--- a/Sources/WinMD/StringsHeap.swift
+++ b/Sources/WinMD/StringsHeap.swift
@@ -11,9 +11,9 @@ public struct StringsHeap {
     self.data = data
   }
 
-  public init?(from assembly: Assembly) {
+  public init(from assembly: Assembly) throws {
     guard let stream = assembly.Metadata.stream(named: Metadata.Stream.Strings) else {
-      return nil
+      throw WinMDError.StringsHeapNotFound
     }
     self.init(data: stream)
   }

--- a/Sources/WinMD/TablesStream.swift
+++ b/Sources/WinMD/TablesStream.swift
@@ -26,9 +26,9 @@ public struct TablesStream {
     self.data = data
   }
 
-  public init?(from assembly: Assembly) {
+  public init(from assembly: Assembly) throws {
     guard let stream = assembly.Metadata.stream(named: Metadata.Stream.Tables) else {
-      return nil
+      throw WinMDError.MissingTableStream
     }
     self.init(data: stream)
   }

--- a/Sources/winmd-inspect/main.swift
+++ b/Sources/winmd-inspect/main.swift
@@ -7,18 +7,10 @@ import WinMD
 private func open(_ path: FileURL) throws -> (Database, DatabaseDecoder, TablesStream, RecordReader) {
   let database = try Database(at: path.url)
 
-  guard let tables = TablesStream(from: database.cil) else {
-    throw ValidationError("No tables stream found.")
-  }
-  guard let blobs = BlobsHeap(from: database.cil) else {
-    throw ValidationError("No blobs heap found.")
-  }
-  guard let strings = StringsHeap(from: database.cil) else {
-    throw ValidationError("No strings heap found.")
-  }
-  guard let guids = GUIDHeap(from: database.cil) else {
-    throw ValidationError("No GUID heap found.")
-  }
+  let tables = try TablesStream(from: database.cil)
+  let blobs = try BlobsHeap(from: database.cil)
+  let strings = try StringsHeap(from: database.cil)
+  let guids = try GUIDHeap(from: database.cil)
 
   let decoder = DatabaseDecoder(tables)
   let reader = RecordReader(decoder: decoder,


### PR DESCRIPTION
This changes the heap constructors from failable to throwing to allow future
wrapping of the constructor into `Result` types.