### PR TITLE
winmd-inspect: clean up the help description (NFC)

### DIFF
--- a/Sources/winmd-inspect/main.swift
+++ b/Sources/winmd-inspect/main.swift
@@ -50,7 +50,7 @@ struct Dump: ParsableCommand {
 
 struct PrintNamespaces: ParsableCommand {
   static var configuration: CommandConfiguration {
-    CommandConfiguration(abstract: "Print namespaces referenced in the databse")
+    CommandConfiguration(abstract: "Print namespaces referenced in the database.")
   }
 
   @OptionGroup


### PR DESCRIPTION
Homogenise the help message output for the sub-commands.