### PR TITLE
WinMD: re-implement iteration support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,8 +10,6 @@ let SwiftWinMD = Package(
   dependencies: [
     .package(url: "http://github.com/apple/swift-argument-parser",
              .upToNextMinor(from: "1.0.0")),
-    .package(url: "https://github.com/apple/swift-collections.git",
-             .upToNextMinor(from: "1.0.0")),
   ],
   targets: [
     .target(name: "CPE", dependencies: []),
@@ -20,7 +18,6 @@ let SwiftWinMD = Package(
     .target(name: "WinMD",
             dependencies: [
               "CPE",
-              .product(name: "OrderedCollections", package: "swift-collections"),
             ],
             swiftSettings: [
               .unsafeFlags([

--- a/Sources/WinMD/Database.swift
+++ b/Sources/WinMD/Database.swift
@@ -5,9 +5,27 @@ import struct Foundation.Data
 import struct Foundation.URL
 
 public class Database {
+  public typealias Heaps =
+      (blob: BlobsHeap, guid: GUIDHeap, string: StringsHeap)
+
   public let dos: DOSFile
   public let pe: PEFile
   public let cil: Assembly
+
+  public private(set) lazy var stream: Result<TablesStream, Error> =
+      Result { try TablesStream(from: self.cil) }
+  public private(set) lazy var decoder: Result<DatabaseDecoder, Error> =
+      Result { try DatabaseDecoder(self.stream.get()) }
+
+  public private(set) lazy var blobs: Result<BlobsHeap, Error> =
+      Result { try BlobsHeap(from: self.cil) }
+  public private(set) lazy var guids: Result<GUIDHeap, Error> =
+      Result { try GUIDHeap(from: self.cil) }
+  public private(set) lazy var strings: Result<StringsHeap, Error> =
+      Result { try StringsHeap(from: self.cil) }
+
+  public lazy var tables: Result<[WinMD.Table], Error> =
+      Result { try self.stream.get().Tables }
 
   private init(data: [UInt8]) throws {
     self.dos = try DOSFile(from: data)
@@ -21,5 +39,14 @@ public class Database {
     // byte array representation.  Unfortunately, this conversion is likely to
     // incur a pointless copy.
     try self.init(data: Array(Data(contentsOf: path, options: .alwaysMapped)))
+  }
+
+  public func rows<Table: WinMD.Table>(of table: Table.Type) throws -> TableIterator<Table> {
+    guard let table = try tables.get().first(where: { $0 is Table }) as? Table else {
+      throw WinMDError.TableNotFound
+    }
+    let heaps: Heaps =
+        try (blob: blobs.get(), guid: guids.get(), string: strings.get())
+    return try TableIterator<Table>(table, decoder.get(), heaps)
   }
 }

--- a/Sources/WinMD/Error.swift
+++ b/Sources/WinMD/Error.swift
@@ -8,4 +8,5 @@ public enum WinMDError: Error {
   case InvalidIndex
   case MissingTableStream
   case StringsHeapNotFound
+  case TableNotFound
 }

--- a/Sources/WinMD/Iteration.swift
+++ b/Sources/WinMD/Iteration.swift
@@ -1,145 +1,84 @@
 // Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
-import OrderedCollections
-
 /// A singular record from a table.
 ///
 /// A record, or colloquailly a row, is a singular entity in a table.  This is
 /// an iterable entity in the record collection of a table.
-@dynamicMemberLookup
-public struct Record: IteratorProtocol {
-  public typealias Element = Self
+public struct Record<Table: WinMD.Table> {
+  internal let row: [Int]
+  internal let heaps: Database.Heaps
 
-  private let table: Table
-  private let layout: OrderedDictionary<String, (Int, Int)>
-  private let stride: Int
-  private var cursor: Int
-
-  private let heaps: RecordReader.HeapRefs?
-
-  @usableFromInline
-  internal init(table: Table, layout: OrderedDictionary<String, (Int, Int)>,
-                stride: Int, row cursor: Int, heaps: RecordReader.HeapRefs?) {
-    self.table = table
-    self.layout = layout
-    self.stride = stride
-    self.cursor = cursor
+  internal init(_ row: [Int], _ heaps: Database.Heaps) {
+    self.row = row
     self.heaps = heaps
   }
-
-  /// See `IteratorProtocol.next`
-  public mutating func next() -> Self.Element? {
-    if self.cursor < self.table.rows {
-      // XXX(compnerd) Why is this `defer`-ed?
-      defer { self.cursor = self.cursor + 1 }
-      return Self(table: self.table, layout: self.layout, stride: self.stride,
-                  row: self.cursor, heaps: self.heaps)
-    }
-    return nil
-  }
-
-  /// Access a field ("column") of the record.
-  ///
-  /// A field of the record, or colloquially a column, is accessed by name in
-  /// practice.  The name is used to identify the offset and stride of the field
-  /// in the record data.  Because the CIL database is a compressed database of
-  /// tables which encodes everything as integers, the return type is always an
-  /// integer.  This may be a value or an index into another table (or index).
-  public subscript(dynamicMember field: String) -> Int {
-    guard let (offset, size) = self.layout[field] else {
-      fatalError("Unknown field \(field)")
-    }
-
-    let begin: ArraySlice<UInt8>.Index =
-        self.table.data.index(self.table.data.startIndex,
-                              offsetBy: self.cursor * self.stride)
-    let end: ArraySlice<UInt8>.Index =
-        self.table.data.index(begin, offsetBy: self.stride)
-    let data: ArraySlice<UInt8> = self.table.data[begin ..< end]
-
-    switch size {
-    case 1: return Int(data[offset, UInt8.self])
-    case 2: return Int(data[offset, UInt16.self])
-    case 4: return Int(data[offset, UInt32.self])
-    default:
-      fatalError("Unsupported size \(size)")
-    }
-  }
-}
-
-/// The names of the fields of a record for a given table.
-internal func fields(of table: Table) -> [StaticString] {
-  return fields(of: type(of: table))
-}
-
-/// The names of the fields of a record for a given table.
-internal func fields(of table: Table.Type) -> [StaticString] {
-  return table.columns.lazy.map { $0.name }
 }
 
 extension Record: CustomDebugStringConvertible {
-  /// See `CustomDebugStringConvertible.debugDescription`.
   public var debugDescription: String {
-    let columns: [Column] = type(of: self.table).columns
-    return self.layout.enumerated().map {
-      switch columns[$0.0].type {
+    return row.enumerated().map { (column, value) in
+      switch Table.columns[column].type {
       case let .index(.heap(heap)) where heap == .string:
-        let index = self[dynamicMember: $0.1.0]
-        if let strings = self.heaps?.string {
-          return "\($0.1.0): \(strings[index])"
-        } else {
-          return "\($0.1.0): \(index)"
-        }
+        return "\(Table.columns[column].name): \(heaps.string[value])"
       default:
-        return "\($0.1.0): \(self[dynamicMember: $0.1.0])"
+        return "\(Table.columns[column].name): \(value)"
       }
     }.joined(separator: ", ")
   }
 }
 
-/// A collection of records from a table.
+/// Iterator for a `Table`
 ///
-/// Decodes and provides a set of records which can be iterated.  This requires
-/// the database compression state to be able to decode the table data.
-public struct RecordReader: Sequence {
-  public typealias HeapRefs = (blob: BlobsHeap, guid: GUIDHeap, string: StringsHeap)
-
-  public typealias Iterator = Record
+/// Provides a way to iterate a given table in a type-safe manner.  It decodes a
+/// particular table to provide access to the records.  This requires an instance
+/// of a `DatabaseDecoder` to be able to decompress the table and records.
+public struct TableIterator<Table: WinMD.Table>: IteratorProtocol, Sequence {
+  public typealias Element = Record<Table>
 
   private let decoder: DatabaseDecoder
-  public let heaps: HeapRefs?
+  private let table: Table
+  private let heaps: Database.Heaps
 
-  public private(set) var table: Table?
-  public private(set) var layout: OrderedDictionary<String, (Int, Int)>?
-  public private(set) var stride: Int?
+  private var cursor: Int
 
-  public init(decoder: DatabaseDecoder, heaps: HeapRefs? = nil) {
+  public init(_ table: Table, _ decoder: DatabaseDecoder,
+              _ heaps: Database.Heaps, from row: Int = 0) {
     self.decoder = decoder
+    self.table = table
     self.heaps = heaps
+    self.cursor = row
   }
 
-  public mutating func rows(_ table: Table) -> Self {
-    var scan: Int = 0
+  /// See `IteratorProtocol.next`
+  public mutating func next() -> Self.Element? {
+    guard self.cursor < self.table.rows else { return nil }
 
-    self.table = table
-    self.layout = OrderedDictionary<String, (Int, Int)>(uniqueKeysWithValues: Array<(String, (Int, Int))>(type(of: table).columns.map {
+    defer { self.cursor = self.cursor + 1}
+
+    var scan: Int = 0
+    let layout: [(Int, Int)] = Table.columns.map {
       let width = decoder.width(of: $0.type)
       defer { scan = scan + width }
-      return (String(describing: $0.name), (scan, width))
-    }))
-    self.stride = scan
-
-    return self
-  }
-
-  /// See `Sequence.makeIterator()`.
-  @inlinable
-  public __consuming func makeIterator() -> Self.Iterator {
-    guard let table = table, let layout = layout, let stride = stride else {
-      fatalError("Table not read")
+      return (scan, width)
     }
-    return Self.Iterator(table: table, layout: layout, stride: stride, row: 0,
-                         heaps: self.heaps)
+
+    let begin: ArraySlice<UInt8>.Index =
+        self.table.data.index(self.table.data.startIndex,
+                              offsetBy: self.cursor * scan)
+    let end: ArraySlice<UInt8>.Index =
+        self.table.data.index(begin, offsetBy: scan)
+    let data: ArraySlice<UInt8> = self.table.data[begin ..< end]
+
+    let record: [Int] = layout.map { (offset, size) in
+      switch size {
+      case 1: return Int(data[offset, UInt8.self])
+      case 2: return Int(data[offset, UInt16.self])
+      case 4: return Int(data[offset, UInt32.self])
+      default: fatalError("unsupported column size '\(size)'")
+      }
+    }
+
+    return Record<Table>(record, self.heaps)
   }
 }

--- a/Sources/WinMD/Tables/TypeDef.swift
+++ b/Sources/WinMD/Tables/TypeDef.swift
@@ -30,3 +30,9 @@ public final class TypeDef: Table {
   }
 }
 }
+
+extension Record where Table == Metadata.Tables.TypeDef {
+  public var TypeNamespace: String {
+    self.heaps.string[self.row[2]]
+  }
+}


### PR DESCRIPTION
This massively cleans up the iteration support in WinMD by rethinking through
the implementation.  It massively simplifies the iteration process by hoisting
the `RecordReader` constructor into `Database`.  Instead a new `TableIterator`
type implements the `IteratorProtocol` for a given `Table`.  By passing along
the type information for the table, we can hoist the table processing operation
into the iterator element type construction (i.e. the `next` operation).  This
allows us to strip the element down to a pre-processed array of `Int` and the
heap references.  The element itself can also preserve type information,
allowing type-safe access to the fields on a per-table basis.