### PR TITLE
WinMD: sink the table data extraction into Table

### DIFF
--- a/Sources/WinMD/Database.swift
+++ b/Sources/WinMD/Database.swift
@@ -47,6 +47,6 @@ public class Database {
     }
     let heaps: Heaps =
         try (blob: blobs.get(), guid: guids.get(), string: strings.get())
-    return try TableIterator<Table>(table, decoder.get(), heaps)
+    return try TableIterator<Table>(table, heaps, decoder.get())
   }
 }

--- a/Sources/WinMD/Iteration.swift
+++ b/Sources/WinMD/Iteration.swift
@@ -36,49 +36,24 @@ extension Record: CustomDebugStringConvertible {
 public struct TableIterator<Table: WinMD.Table>: IteratorProtocol, Sequence {
   public typealias Element = Record<Table>
 
-  private let decoder: DatabaseDecoder
   private let table: Table
   private let heaps: Database.Heaps
+  private let decoder: DatabaseDecoder
 
   private var cursor: Int
 
-  public init(_ table: Table, _ decoder: DatabaseDecoder,
-              _ heaps: Database.Heaps, from row: Int = 0) {
-    self.decoder = decoder
+  public init(_ table: Table, _ heaps: Database.Heaps,
+              _ decoder: DatabaseDecoder, from row: Int = 0) {
     self.table = table
     self.heaps = heaps
+    self.decoder = decoder
     self.cursor = row
   }
 
   /// See `IteratorProtocol.next`
   public mutating func next() -> Self.Element? {
     guard self.cursor < self.table.rows else { return nil }
-
     defer { self.cursor = self.cursor + 1}
-
-    var scan: Int = 0
-    let layout: [(Int, Int)] = Table.columns.map {
-      let width = decoder.width(of: $0.type)
-      defer { scan = scan + width }
-      return (scan, width)
-    }
-
-    let begin: ArraySlice<UInt8>.Index =
-        self.table.data.index(self.table.data.startIndex,
-                              offsetBy: self.cursor * scan)
-    let end: ArraySlice<UInt8>.Index =
-        self.table.data.index(begin, offsetBy: scan)
-    let data: ArraySlice<UInt8> = self.table.data[begin ..< end]
-
-    let record: [Int] = layout.map { (offset, size) in
-      switch size {
-      case 1: return Int(data[offset, UInt8.self])
-      case 2: return Int(data[offset, UInt16.self])
-      case 4: return Int(data[offset, UInt32.self])
-      default: fatalError("unsupported column size '\(size)'")
-      }
-    }
-
-    return Record<Table>(record, self.heaps)
+    return self.table[cursor, decoder, heaps]
   }
 }

--- a/Sources/winmd-inspect/main.swift
+++ b/Sources/winmd-inspect/main.swift
@@ -31,7 +31,7 @@ struct Dump: ParsableCommand {
     for table in try database.tables.get() {
       print("  - \(table)")
 #if HAVE_GENERIC_TABLE_ITERATION
-      for row in try TableIterator(table, database.decoder.get(), heaps) {
+      for row in try TableIterator(table, heaps, database.decoder.get()) {
         print("    - \(row)")
       }
 #endif


### PR DESCRIPTION
This restructures the table iteration to sink the table data processing into the
`Table` type.  Beyond localizing the data interpretation to the type that owns
the data, this will enable future changes to extend the table indexing.