### PR TITLE
WinMD: replace heap refs with database in iteration

### DIFF
--- a/Sources/WinMD/Database.swift
+++ b/Sources/WinMD/Database.swift
@@ -41,12 +41,11 @@ public class Database {
     try self.init(data: Array(Data(contentsOf: path, options: .alwaysMapped)))
   }
 
-  public func rows<Table: WinMD.Table>(of table: Table.Type) throws -> TableIterator<Table> {
+  public func rows<Table: WinMD.Table>(of table: Table.Type) throws
+      -> TableIterator<Table> {
     guard let table = try tables.get().first(where: { $0 is Table }) as? Table else {
       throw WinMDError.TableNotFound
     }
-    let heaps: Heaps =
-        try (blob: blobs.get(), guid: guids.get(), string: strings.get())
-    return try TableIterator<Table>(table, heaps, decoder.get())
+    return TableIterator<Table>(self, table)
   }
 }

--- a/Sources/WinMD/Table.swift
+++ b/Sources/WinMD/Table.swift
@@ -41,8 +41,9 @@ public protocol Table: AnyObject {
 }
 
 extension Table {
-  public subscript(_ row: Int, _ decoder: DatabaseDecoder,
-                   _ heaps: Database.Heaps) -> Record<Self> {
+  public subscript(_ row: Int, _ database: Database) -> Record<Self> {
+    let decoder = try! database.decoder.get()
+
     var scan: Int = 0
     let layout: [(Int, Int)] = Self.columns.map {
       let width = decoder.width(of: $0.type)
@@ -64,6 +65,6 @@ extension Table {
       }
     }
 
-    return Record<Self>(record, heaps)
+    return Record<Self>(record, database)
   }
 }

--- a/Sources/WinMD/Tables/TypeDef.swift
+++ b/Sources/WinMD/Tables/TypeDef.swift
@@ -33,6 +33,8 @@ public final class TypeDef: Table {
 
 extension Record where Table == Metadata.Tables.TypeDef {
   public var TypeNamespace: String {
-    self.heaps.string[self.columns[2]]
+    get throws {
+      try self.database.strings.get()[self[2]]
+    }
   }
 }

--- a/Sources/WinMD/Tables/TypeDef.swift
+++ b/Sources/WinMD/Tables/TypeDef.swift
@@ -34,7 +34,7 @@ public final class TypeDef: Table {
 extension Record where Table == Metadata.Tables.TypeDef {
   public var TypeNamespace: String {
     get throws {
-      try self.database.strings.get()[self[2]]
+      try self.database.strings.get()[self.columns[2]]
     }
   }
 }

--- a/Sources/winmd-inspect/main.swift
+++ b/Sources/winmd-inspect/main.swift
@@ -21,17 +21,11 @@ struct Dump: ParsableCommand {
     print("MajorVersion: \(String(stream.MajorVersion, radix: 16))")
     print("MinorVersion: \(String(stream.MinorVersion, radix: 16))")
 
-#if HAVE_GENERIC_TABLE_ITERATION
-    let heaps: Database.Heaps =
-        try (blob: database.blobs.get(), guid: database.guids.get(),
-             string: database.strings.get())
-#endif
-
     print("Tables:")
     for table in try database.tables.get() {
       print("  - \(table)")
 #if HAVE_GENERIC_TABLE_ITERATION
-      for row in try TableIterator(table, heaps, database.decoder.get()) {
+      for row in try TableIterator(database, table) {
         print("    - \(row)")
       }
 #endif
@@ -52,8 +46,8 @@ struct PrintNamespaces: ParsableCommand {
 
     var namespaces: Set<String> = []
     for row in try database.rows(of: Metadata.Tables.TypeDef.self) {
-      if !row.TypeNamespace.isEmpty {
-        namespaces.insert(row.TypeNamespace)
+      if let namespace = try? row.TypeNamespace {
+        namespaces.insert(namespace)
       }
     }
 


### PR DESCRIPTION
Provide a reference to the database to the iterator.  This is needed
since the iterator requires the ability to inspect not only the current
table but other tables in the database in order to compute runs which
have have a foreign key constraint that needs to inspect the maximal
count for the foreign table.