### PR TITLE
WinMD: record the current row in a `Record`

### DIFF
--- a/Sources/WinMD/Iteration.swift
+++ b/Sources/WinMD/Iteration.swift
@@ -6,10 +6,12 @@
 /// A record, or colloquailly a row, is a singular entity in a table.  This is
 /// an iterable entity in the record collection of a table.
 public struct Record<Table: WinMD.Table> {
+  internal let row: Int
   internal let columns: [Int]
   internal let database: Database
 
-  internal init(_ columns: [Int], _ database: Database) {
+  internal init(_ row: Int, _ columns: [Int], _ database: Database) {
+    self.row = row
     self.columns = columns
     self.database = database
   }

--- a/Sources/WinMD/Table.swift
+++ b/Sources/WinMD/Table.swift
@@ -65,6 +65,6 @@ extension Table {
       }
     }
 
-    return Record<Self>(record, database)
+    return Record<Self>(row, record, database)
   }
 }


### PR DESCRIPTION
Preserve the knowledge of the current cursor position in `Record`.  This
will be required subsequently for computing the ranges for `FieldList`
and `MethodList` when appropriate.