### PR TITLE
Update swift.yml

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -14,9 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - branch: swift-5.5-release
-            tag: 5.5-RELEASE
-
           - branch: swift-5.6.2-release
             tag: 5.6.2-RELEASE
 


### PR DESCRIPTION
Drop support for the 5.5 train.  The updated SDK and the included lld do not play well together.  Use the lastest 3 trains instead.