### PR TITLE
WinMD: add some references for constants

### DIFF
--- a/Sources/WinMD/CILFlags.swift
+++ b/Sources/WinMD/CILFlags.swift
@@ -1,7 +1,7 @@
 // Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
-/// Contains values that indicate type metadata.
+/// Contains values that indicate type metadata.  See §II.23.1.15.
 public struct CorTypeAttr: OptionSet {
   public typealias RawValue = UInt32
 
@@ -156,7 +156,7 @@ public struct CorTypeAttr: OptionSet {
   }
 }
 
-/// Contains values that describe metadata about a field.
+/// Contains values that describe metadata about a field.  See §II.23.1.5.
 public struct CorFieldAttr: OptionSet {
   public typealias RawValue = UInt16
 
@@ -253,7 +253,8 @@ public struct CorFieldAttr: OptionSet {
   }
 }
 
-/// Contains values that describe method implementation features.
+/// Contains values that describe method implementation features.  See
+/// §II.23.1.11.
 public struct CorMethodImpl: OptionSet {
   public typealias RawValue = UInt16
 
@@ -336,7 +337,7 @@ public struct CorMethodImpl: OptionSet {
   }
 }
 
-/// Contains values that describe the features of a method.
+/// Contains values that describe the features of a method.  See §II.23.1.10.
 public struct CorMethodAttr: OptionSet {
   public typealias RawValue = UInt16
 
@@ -456,7 +457,8 @@ public struct CorMethodAttr: OptionSet {
   }
 }
 
-/// Contains values that describe the metadata of a method parameter.
+/// Contains values that describe the metadata of a method parameter.  See
+/// §II.23.1.13.
 public struct CorParamAttr: OptionSet {
   public typealias RawValue = UInt16
 
@@ -498,7 +500,7 @@ public struct CorParamAttr: OptionSet {
   }
 }
 
-/// Contains values that describe the metadata of an event.
+/// Contains values that describe the metadata of an event.  See §II.23.1.4.
 public struct CorEventAttr: OptionSet {
   public typealias RawValue = UInt16
 
@@ -524,7 +526,7 @@ public struct CorEventAttr: OptionSet {
   }
 }
 
-/// Contains values that describe the metadata of a property.
+/// Contains values that describe the metadata of a property.  See §II.23.1.14.
 public struct CorPropertyAttr: OptionSet {
   public typealias RawValue = UInt16
 
@@ -559,7 +561,7 @@ public struct CorPropertyAttr: OptionSet {
 }
 
 /// Contains values that describe the relationship between a method and an
-/// associated property or event.
+/// associated property or event.  See §II.23.1.12.
 public struct CorMethodSemanticsAttr: OptionSet {
   public typealias RawValue = UInt16
 
@@ -596,7 +598,7 @@ public struct CorMethodSemanticsAttr: OptionSet {
   }
 }
 
-/// Specifies options for a PInvoke call.
+/// Specifies options for a PInvoke call.  See §II.23.1.8.
 public struct CorPinvokeMap: OptionSet {
   public typealias RawValue = UInt16
 
@@ -717,7 +719,7 @@ public struct CorPinvokeMap: OptionSet {
 }
 
 /// Contains values that describe the metadata applied to an assembly
-/// compilation.
+/// compilation.  See §II.23.1.2.
 public struct CorAssemblyFlags: OptionSet {
   public typealias RawValue = UInt16
 
@@ -811,7 +813,7 @@ public struct CorAssemblyFlags: OptionSet {
 }
 
 /// Contains values that describe the type of file defined in a call to
-/// `IMetaDataAssemblyEmit::DefineFile`.
+/// `IMetaDataAssemblyEmit::DefineFile`.  See §II.23.1.6.
 public struct CorFileFlags: OptionSet {
   public typealias RawValue = UInt16
 
@@ -831,7 +833,8 @@ public struct CorFileFlags: OptionSet {
   }
 }
 
-/// Indicates the visibility of resources encoded in an assembly manifest.
+/// Indicates the visibility of resources encoded in an assembly manifest.  See
+/// §II.23.1.9.
 public struct CorManifestResourceFlags: OptionSet {
   public typealias RawValue = UInt32
 
@@ -856,7 +859,7 @@ public struct CorManifestResourceFlags: OptionSet {
 }
 
 /// Contains values that describe the `Type` parameters for generic types, as
-/// used in calls to `IMetaDataEmit2::DefineGenericParam`.
+/// used in calls to `IMetaDataEmit2::DefineGenericParam`.  See §II.23.1.7.
 public struct CorGenericParamAttr: OptionSet {
   public typealias RawValue = UInt16
 
@@ -909,7 +912,7 @@ public struct CorGenericParamAttr: OptionSet {
 }
 
 /// Specifies a common language runtime `Type`, a type modifier, or information
-/// about a type in a metadata type signature.
+/// about a type in a metadata type signature.  See §II.23.1.16.
 public struct CorElementType: OptionSet {
   public typealias RawValue = UInt8
 

--- a/Sources/WinMD/Tables/Assembly.swift
+++ b/Sources/WinMD/Tables/Assembly.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
+/// See §II.22.2.
 public final class Assembly: Table {
   public static var number: Int { 32 }
 

--- a/Sources/WinMD/Tables/AssemblyProcessor.swift
+++ b/Sources/WinMD/Tables/AssemblyProcessor.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
+/// See §II.22.4.
 public final class AssemblyProcessor: Table {
   public static var number: Int { 33 }
 

--- a/Sources/WinMD/Tables/AssemblyRef.swift
+++ b/Sources/WinMD/Tables/AssemblyRef.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
+/// See §II.22.5.
 public final class AssemblyRef: Table {
   public static var number: Int { 35 }
 

--- a/Sources/WinMD/Tables/AssemblyRefOS.swift
+++ b/Sources/WinMD/Tables/AssemblyRefOS.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
+/// See §II.22.3.
 public final class AssemblyRefOS: Table {
   public static var number: Int { 37 }
 

--- a/Sources/WinMD/Tables/AssemblyRefProcessor.swift
+++ b/Sources/WinMD/Tables/AssemblyRefProcessor.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
+/// See §II.22.7.
 public final class AssemblyRefProcessor: Table {
   public static var number: Int { 36 }
 

--- a/Sources/WinMD/Tables/ClassLayout.swift
+++ b/Sources/WinMD/Tables/ClassLayout.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
+/// See §II.22.8.
 public final class ClassLayout: Table {
   public static var number: Int { 15 }
 

--- a/Sources/WinMD/Tables/Constant.swift
+++ b/Sources/WinMD/Tables/Constant.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
+/// See §II.22.9.
 public final class Constant: Table {
   public static var number: Int { 11 }
 

--- a/Sources/WinMD/Tables/CustomAttribute.swift
+++ b/Sources/WinMD/Tables/CustomAttribute.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
+/// See §II.22.10.
 public final class CustomAttribute: Table {
   public static var number: Int { 12 }
 

--- a/Sources/WinMD/Tables/DeclSecurity.swift
+++ b/Sources/WinMD/Tables/DeclSecurity.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
+/// See §II.22.11.
 public final class DeclSecurity: Table {
   public static var number: Int { 14 }
 

--- a/Sources/WinMD/Tables/EventDef.swift
+++ b/Sources/WinMD/Tables/EventDef.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
+/// See §II.22.13.
 public final class EventDef: Table {
   public static var number: Int { 20 }
 

--- a/Sources/WinMD/Tables/EventMap.swift
+++ b/Sources/WinMD/Tables/EventMap.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
+/// See §II.22.12.
 public final class EventMap: Table {
   public static var number: Int { 18 }
 

--- a/Sources/WinMD/Tables/ExportedType.swift
+++ b/Sources/WinMD/Tables/ExportedType.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
+/// See §II.22.14.
 public final class ExportedType: Table {
   public static var number: Int { 39 }
 

--- a/Sources/WinMD/Tables/FieldDef.swift
+++ b/Sources/WinMD/Tables/FieldDef.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
+/// See §II.22.15.
 public final class FieldDef: Table {
   public static var number: Int { 4 }
 

--- a/Sources/WinMD/Tables/FieldLayout.swift
+++ b/Sources/WinMD/Tables/FieldLayout.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
+/// See §II.22.16.
 public final class FieldLayout: Table {
   public static var number: Int { 16 }
 

--- a/Sources/WinMD/Tables/FieldMarshal.swift
+++ b/Sources/WinMD/Tables/FieldMarshal.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
+/// See §II.22.17.
 public final class FieldMarshal: Table {
   public static var number: Int { 13 }
 

--- a/Sources/WinMD/Tables/FieldRVA.swift
+++ b/Sources/WinMD/Tables/FieldRVA.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
+/// See §II.22.18.
 public final class FieldRVA: Table {
   public static var number: Int { 29 }
 

--- a/Sources/WinMD/Tables/File.swift
+++ b/Sources/WinMD/Tables/File.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
+/// See §II.22.19.
 public final class File: Table {
   public static var number: Int { 38 }
 

--- a/Sources/WinMD/Tables/GenericParam.swift
+++ b/Sources/WinMD/Tables/GenericParam.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
+/// See §II.22.20.
 public final class GenericParam: Table {
   public static var number: Int { 42 }
 

--- a/Sources/WinMD/Tables/GenericParamConstraint.swift
+++ b/Sources/WinMD/Tables/GenericParamConstraint.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
+/// See §II.22.21.
 public final class GenericParamConstraint: Table {
   public static var number: Int { 44 }
 

--- a/Sources/WinMD/Tables/ImplMap.swift
+++ b/Sources/WinMD/Tables/ImplMap.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
+/// See §II.22.22.
 public final class ImplMap: Table {
   public static var number: Int { 28 }
 

--- a/Sources/WinMD/Tables/InterfaceImpl.swift
+++ b/Sources/WinMD/Tables/InterfaceImpl.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
+/// See §II.22.23.
 public final class InterfaceImpl: Table {
   public static var number: Int { 9 }
 

--- a/Sources/WinMD/Tables/ManifestResource.swift
+++ b/Sources/WinMD/Tables/ManifestResource.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
+/// See §II.22.24.
 public final class ManifestResource: Table {
   public static var number: Int { 40 }
 

--- a/Sources/WinMD/Tables/MemberRef.swift
+++ b/Sources/WinMD/Tables/MemberRef.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
+/// See §II.22.25.
 public final class MemberRef: Table {
   public static var number: Int { 10 }
 

--- a/Sources/WinMD/Tables/MethodDef.swift
+++ b/Sources/WinMD/Tables/MethodDef.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
+/// See §II.22.26.
 public final class MethodDef: Table {
   public static var number: Int { 6 }
 

--- a/Sources/WinMD/Tables/MethodImpl.swift
+++ b/Sources/WinMD/Tables/MethodImpl.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
+/// See §II.22.27.
 public final class MethodImpl: Table {
   public static var number: Int { 25 }
 

--- a/Sources/WinMD/Tables/MethodSemantics.swift
+++ b/Sources/WinMD/Tables/MethodSemantics.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
+/// See §II.22.28.
 public final class MethodSemantics: Table {
   public static var number: Int { 24 }
 

--- a/Sources/WinMD/Tables/MethodSpec.swift
+++ b/Sources/WinMD/Tables/MethodSpec.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
+/// See §II.22.29.
 public final class MethodSpec: Table {
   public static var number: Int { 43 }
 

--- a/Sources/WinMD/Tables/Module.swift
+++ b/Sources/WinMD/Tables/Module.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
+/// See §II.22.30.
 public final class Module: Table {
   public static var number: Int { 0 }
 

--- a/Sources/WinMD/Tables/ModuleRef.swift
+++ b/Sources/WinMD/Tables/ModuleRef.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
+/// See §II.22.31.
 public final class ModuleRef: Table {
   public static var number: Int { 26 }
 

--- a/Sources/WinMD/Tables/NestedClass.swift
+++ b/Sources/WinMD/Tables/NestedClass.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
+/// See §II.22.32.
 public final class NestedClass: Table {
   public static var number: Int { 41 }
 

--- a/Sources/WinMD/Tables/Param.swift
+++ b/Sources/WinMD/Tables/Param.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
+/// See §II.22.33.
 public final class Param: Table {
   public static var number: Int { 8 }
 

--- a/Sources/WinMD/Tables/PropertyDef.swift
+++ b/Sources/WinMD/Tables/PropertyDef.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
+/// See §II.22.34.
 public final class PropertyDef: Table {
   public static var number: Int { 23 }
 

--- a/Sources/WinMD/Tables/PropertyMap.swift
+++ b/Sources/WinMD/Tables/PropertyMap.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
+/// See §II.22.35.
 public final class PropertyMap: Table {
   public static var number: Int { 21 }
 

--- a/Sources/WinMD/Tables/StandAloneSig.swift
+++ b/Sources/WinMD/Tables/StandAloneSig.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
+/// See §II.22.36.
 public final class StandAloneSig: Table {
   public static var number: Int { 17 }
 

--- a/Sources/WinMD/Tables/TypeDef.swift
+++ b/Sources/WinMD/Tables/TypeDef.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
+/// See §II.22.37.
 public final class TypeDef: Table {
   public static var number: Int { 2 }
 

--- a/Sources/WinMD/Tables/TypeRef.swift
+++ b/Sources/WinMD/Tables/TypeRef.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
+/// See §II.22.38.
 public final class TypeRef: Table {
   public static var number: Int { 1 }
 

--- a/Sources/WinMD/Tables/TypeSpec.swift
+++ b/Sources/WinMD/Tables/TypeSpec.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Metadata.Tables {
+/// See §II.22.39.
 public final class TypeSpec: Table {
   public static var number: Int { 27 }
 


### PR DESCRIPTION
Add some references to the corresponding specification sections to ease mapping the definition to the specification.