### PR TITLE
WinMD: add typed accessors for Table records

### DIFF
--- a/Sources/WinMD/AssemblyVersion.swift
+++ b/Sources/WinMD/AssemblyVersion.swift
@@ -1,0 +1,30 @@
+// Copyright © 2022 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+internal struct AssemblyVersion {
+  let MajorVersion: UInt16
+  let MinorVersion: UInt16
+  let BuildNumber: UInt16
+  let RevisionNumber: UInt16
+
+  internal init(_ major: UInt16, _ minor: UInt16, _ build: UInt16,
+                _ patch: UInt16) {
+    self.MajorVersion = major
+    self.MinorVersion = minor
+    self.BuildNumber = build
+    self.RevisionNumber = patch
+  }
+
+  internal init(_ value: UInt64) {
+    self.MajorVersion = UInt16((value >>  0) & 0xffff)
+    self.MinorVersion = UInt16((value >> 16) & 0xffff)
+    self.BuildNumber = UInt16((value >> 32) & 0xffff)
+    self.RevisionNumber = UInt16((value >> 48) & 0xffff)
+  }
+}
+
+extension AssemblyVersion: CustomStringConvertible {
+  internal var description: String {
+    "\(MajorVersion).\(MinorVersion).\(BuildNumber).\(RevisionNumber)"
+  }
+}

--- a/Sources/WinMD/CILFlags.swift
+++ b/Sources/WinMD/CILFlags.swift
@@ -718,6 +718,13 @@ public struct CorPinvokeMap: OptionSet {
   }
 }
 
+/// Contains values that describe the hash algorithm.  See §II.23.1.1.
+public enum CorHashAlgorithm: UInt32 {
+  case none = 0x0000
+  case md5  = 0x8003
+  case sha1 = 0x8004
+}
+
 /// Contains values that describe the metadata applied to an assembly
 /// compilation.  See §II.23.1.2.
 public struct CorAssemblyFlags: OptionSet {

--- a/Sources/WinMD/Database.swift
+++ b/Sources/WinMD/Database.swift
@@ -70,11 +70,13 @@ public class Database {
 
   // MARK - subscripting
 
-  public func rows<Table: WinMD.Table>(of table: Table.Type) throws
+  public func rows<Table: WinMD.Table>(of table: Table.Type,
+                                       from begin: Int = 0,
+                                       to end: Int? = nil) throws
       -> TableIterator<Table> {
     guard let table = try tables.first(where: { $0 is Table }) as? Table else {
       throw WinMDError.TableNotFound
     }
-    return TableIterator<Table>(self, table)
+    return TableIterator<Table>(self, table, from: begin, to: end)
   }
 }

--- a/Sources/WinMD/Table.swift
+++ b/Sources/WinMD/Table.swift
@@ -65,6 +65,6 @@ extension Table {
       }
     }
 
-    return Record<Self>(row, record, database)
+    return Record<Self>(row, record, database, self)
   }
 }

--- a/Sources/WinMD/Tables/Assembly.swift
+++ b/Sources/WinMD/Tables/Assembly.swift
@@ -37,3 +37,53 @@ public final class Assembly: Table {
   }
 }
 }
+
+extension Record where Table == Metadata.Tables.Assembly {
+  public var HashAlgId: CorHashAlgorithm {
+    .init(rawValue: CorHashAlgorithm.RawValue(self.columns[0]))!
+  }
+
+  public var MajorVersion: UInt16 {
+    UInt16(self.columns[1])
+  }
+
+  public var MinorVersion: UInt16 {
+    UInt16(self.columns[2])
+  }
+
+  public var BuildNumber: UInt16 {
+    UInt16(self.columns[3])
+  }
+
+  public var RevisionNumber: UInt16 {
+    UInt16(self.columns[4])
+  }
+
+  public var Flags: CorAssemblyFlags {
+    .init(rawValue: CorAssemblyFlags.RawValue(self.columns[5]))
+  }
+
+  public var PublicKey: Blob {
+    get throws {
+      try self.database.blobs[self.columns[6]]
+    }
+  }
+
+  public var Name: String {
+    get throws {
+      try self.database.strings[self.columns[7]]
+    }
+  }
+
+  public var Culture: String {
+    get throws {
+      try self.database.strings[self.columns[8]]
+    }
+  }
+}
+
+extension Record where Table == Metadata.Tables.Assembly {
+  internal var Version: AssemblyVersion  {
+    AssemblyVersion(MajorVersion, MinorVersion, BuildNumber, RevisionNumber)
+  }
+}

--- a/Sources/WinMD/Tables/AssemblyOS.swift
+++ b/Sources/WinMD/Tables/AssemblyOS.swift
@@ -24,3 +24,17 @@ public final class AssemblyOS: Table {
   }
 }
 }
+
+extension Record where Table == Metadata.Tables.AssemblyOS {
+  public var OSPlatformID: UInt32 {
+    UInt32(self.columns[0])
+  }
+
+  public var OSMajorVersion: UInt32 {
+    UInt32(self.columns[1])
+  }
+
+  public var OSMinorVersion: UInt32 {
+    UInt32(self.columns[2])
+  }
+}

--- a/Sources/WinMD/Tables/AssemblyProcessor.swift
+++ b/Sources/WinMD/Tables/AssemblyProcessor.swift
@@ -21,3 +21,9 @@ public final class AssemblyProcessor: Table {
   }
 }
 }
+
+extension Record where Table == Metadata.Tables.AssemblyProcessor {
+  public var Processor: UInt32 {
+    UInt32(self.columns[0])
+  }
+}

--- a/Sources/WinMD/Tables/AssemblyRef.swift
+++ b/Sources/WinMD/Tables/AssemblyRef.swift
@@ -37,3 +37,55 @@ public final class AssemblyRef: Table {
   }
 }
 }
+
+extension Record where Table == Metadata.Tables.AssemblyRef {
+  public var MajorVersion: UInt16 {
+    UInt16(self.columns[0])
+  }
+
+  public var MinorVersion: UInt16 {
+    UInt16(self.columns[1])
+  }
+
+  public var BuildNumber: UInt16 {
+    UInt16(self.columns[2])
+  }
+
+  public var RevisionNumber: UInt16 {
+    UInt16(self.columns[3])
+  }
+
+  public var Flags: CorAssemblyFlags {
+    .init(rawValue: CorAssemblyFlags.RawValue(self.columns[4]))
+  }
+
+  public var PublicKeyOrToken: Blob {
+    get throws {
+      try self.database.blobs[self.columns[5]]
+    }
+  }
+
+  public var Name: String {
+    get throws {
+      try self.database.strings[self.columns[6]]
+    }
+  }
+
+  public var Culture: String {
+    get throws {
+      try self.database.strings[self.columns[7]]
+    }
+  }
+
+  public var HashValue: Blob {
+    get throws {
+      try self.database.blobs[self.columns[8]]
+    }
+  }
+}
+
+extension Record where Table == Metadata.Tables.AssemblyRef {
+  internal var Version: AssemblyVersion  {
+    AssemblyVersion(MajorVersion, MinorVersion, BuildNumber, RevisionNumber)
+  }
+}

--- a/Sources/WinMD/Tables/AssemblyRefOS.swift
+++ b/Sources/WinMD/Tables/AssemblyRefOS.swift
@@ -27,3 +27,23 @@ public final class AssemblyRefOS: Table {
   }
 }
 }
+
+extension Record where Table == Metadata.Tables.AssemblyRefOS {
+  public var OSPlatformId: UInt32 {
+    UInt32(self.columns[0])
+  }
+
+  public var OSMajorVersion: UInt32 {
+    UInt32(self.columns[1])
+  }
+
+  public var OSMinorVerison: UInt32 {
+    UInt32(self.columns[2])
+  }
+
+  public var AssemblyRef: Record<Metadata.Tables.AssemblyRef> {
+    get throws {
+      try self.database.rows(of: Metadata.Tables.AssemblyRef.self)[self.columns[3]]!
+    }
+  }
+}

--- a/Sources/WinMD/Tables/AssemblyRefProcessor.swift
+++ b/Sources/WinMD/Tables/AssemblyRefProcessor.swift
@@ -23,3 +23,15 @@ public final class AssemblyRefProcessor: Table {
   }
 }
 }
+
+extension Record where Table == Metadata.Tables.AssemblyRefProcessor {
+  public var Processor: UInt32 {
+    UInt32(self.columns[0])
+  }
+
+  public var AssemblyRef: Record<Metadata.Tables.AssemblyRef> {
+    get throws {
+      try self.database.rows(of: Metadata.Tables.AssemblyRef.self)[self.columns[1]]!
+    }
+  }
+}

--- a/Sources/WinMD/Tables/ClassLayout.swift
+++ b/Sources/WinMD/Tables/ClassLayout.swift
@@ -25,3 +25,19 @@ public final class ClassLayout: Table {
   }
 }
 }
+
+extension Record where Table == Metadata.Tables.ClassLayout {
+  public var PackingSize: UInt16 {
+    UInt16(self.columns[0])
+  }
+
+  public var ClassSize: UInt32 {
+    UInt32(self.columns[1])
+  }
+
+  public var Parent: Record<Metadata.Tables.TypeDef> {
+    get throws {
+      try self.database.rows(of: Metadata.Tables.TypeDef.self)[self.columns[2]]!
+    }
+  }
+}

--- a/Sources/WinMD/Tables/Constant.swift
+++ b/Sources/WinMD/Tables/Constant.swift
@@ -26,3 +26,15 @@ public final class Constant: Table {
   }
 }
 }
+
+extension Record where Table == Metadata.Tables.Constant {
+  public var `Type`: CorElementType {
+    .init(rawValue: CorElementType.RawValue(columns[0]))
+  }
+
+  public var Value: Blob {
+    get throws {
+      try self.database.blobs[self.columns[4]]
+    }
+  }
+}

--- a/Sources/WinMD/Tables/CustomAttribute.swift
+++ b/Sources/WinMD/Tables/CustomAttribute.swift
@@ -25,3 +25,11 @@ public final class CustomAttribute: Table {
   }
 }
 }
+
+extension Record where Table == Metadata.Tables.CustomAttribute {
+  public var Value: Blob {
+    get throws {
+      try self.database.blobs[self.columns[2]]
+    }
+  }
+}

--- a/Sources/WinMD/Tables/DeclSecurity.swift
+++ b/Sources/WinMD/Tables/DeclSecurity.swift
@@ -25,3 +25,15 @@ public final class DeclSecurity: Table {
   }
 }
 }
+
+extension Record where Table == Metadata.Tables.DeclSecurity {
+  public var Action: UInt16 {
+    UInt16(self.columns[0])
+  }
+
+  public var PermissionSet: Blob {
+    get throws {
+      try self.database.blobs[self.columns[2]]
+    }
+  }
+}

--- a/Sources/WinMD/Tables/EventDef.swift
+++ b/Sources/WinMD/Tables/EventDef.swift
@@ -25,3 +25,15 @@ public final class EventDef: Table {
   }
 }
 }
+
+extension Record where Table == Metadata.Tables.EventDef {
+  public var EventFlags: CorEventAttr {
+    .init(rawValue: CorEventAttr.RawValue(self.columns[0]))
+  }
+
+  public var Name: String {
+    get throws {
+      try self.database.strings[self.columns[1]]
+    }
+  }
+}

--- a/Sources/WinMD/Tables/EventMap.swift
+++ b/Sources/WinMD/Tables/EventMap.swift
@@ -23,3 +23,17 @@ public final class EventMap: Table {
   }
 }
 }
+
+extension Record where Table == Metadata.Tables.EventMap {
+  public var Parent: Record<Metadata.Tables.TypeDef> {
+    get throws {
+      try self.database.rows(of: Metadata.Tables.TypeDef.self)[self.columns[0]]!
+    }
+  }
+
+  public var EventList: TableIterator<Metadata.Tables.EventDef> {
+    get throws {
+      try list(for: 1)
+    }
+  }
+}

--- a/Sources/WinMD/Tables/ExportedType.swift
+++ b/Sources/WinMD/Tables/ExportedType.swift
@@ -29,3 +29,21 @@ public final class ExportedType: Table {
   }
 }
 }
+
+extension Record where Table == Metadata.Tables.ExportedType {
+  public var Flags: CorTypeAttr {
+    .init(rawValue: CorTypeAttr.RawValue(self.columns[0]))
+  }
+
+  public var TypeName: String {
+    get throws {
+      try self.database.strings[self.columns[2]]
+    }
+  }
+
+  public var TypeNamespace: String {
+    get throws {
+      try self.database.strings[self.columns[3]]
+    }
+  }
+}

--- a/Sources/WinMD/Tables/FieldDef.swift
+++ b/Sources/WinMD/Tables/FieldDef.swift
@@ -25,3 +25,21 @@ public final class FieldDef: Table {
   }
 }
 }
+
+extension Record where Table == Metadata.Tables.FieldDef {
+  public var Flags: CorFieldAttr {
+    .init(rawValue: CorFieldAttr.RawValue(self.columns[0]))
+  }
+
+  public var Name: String {
+    get throws {
+      try self.database.strings[self.columns[1]]
+    }
+  }
+
+  public var Signature: Blob {
+    get throws {
+      try self.database.blobs[self.columns[2]]
+    }
+  }
+}

--- a/Sources/WinMD/Tables/FieldLayout.swift
+++ b/Sources/WinMD/Tables/FieldLayout.swift
@@ -23,3 +23,15 @@ public final class FieldLayout: Table {
   }
 }
 }
+
+extension Record where Table == Metadata.Tables.FieldLayout {
+  public var Offset: UInt32 {
+    UInt32(self.columns[0])
+  }
+
+  public var Field: Record<Metadata.Tables.FieldDef> {
+    get throws {
+      try self.database.rows(of: Metadata.Tables.FieldDef.self)[self.columns[1]]!
+    }
+  }
+}

--- a/Sources/WinMD/Tables/FieldMarshal.swift
+++ b/Sources/WinMD/Tables/FieldMarshal.swift
@@ -23,3 +23,11 @@ public final class FieldMarshal: Table {
   }
 }
 }
+
+extension Record where Table == Metadata.Tables.FieldMarshal {
+  public var NativeType: Blob {
+    get throws {
+      try self.database.blobs[self.columns[1]]
+    }
+  }
+}

--- a/Sources/WinMD/Tables/FieldRVA.swift
+++ b/Sources/WinMD/Tables/FieldRVA.swift
@@ -23,3 +23,15 @@ public final class FieldRVA: Table {
   }
 }
 }
+
+extension Record where Table == Metadata.Tables.FieldRVA {
+  public var RVA: UInt32 {
+    UInt32(self.columns[0])
+  }
+
+  public var Field: Record<Metadata.Tables.FieldDef> {
+    get throws {
+      try self.database.rows(of: Metadata.Tables.FieldDef.self)[self.columns[1]]!
+    }
+  }
+}

--- a/Sources/WinMD/Tables/File.swift
+++ b/Sources/WinMD/Tables/File.swift
@@ -25,3 +25,21 @@ public final class File: Table {
   }
 }
 }
+
+extension Record where Table == Metadata.Tables.File {
+  public var Flags: CorFileFlags {
+    .init(rawValue: CorFileFlags.RawValue(self.columns[0]))
+  }
+
+  public var Name: String {
+    get throws {
+      try self.database.strings[self.columns[1]]
+    }
+  }
+
+  public var HashValue: Blob {
+    get throws {
+      try self.database.blobs[self.columns[2]]
+    }
+  }
+}

--- a/Sources/WinMD/Tables/GenericParam.swift
+++ b/Sources/WinMD/Tables/GenericParam.swift
@@ -27,3 +27,19 @@ public final class GenericParam: Table {
   }
 }
 }
+
+extension Record where Table == Metadata.Tables.GenericParam {
+  public var Number: UInt16 {
+    UInt16(self.columns[0])
+  }
+
+  public var Flags: CorGenericParamAttr {
+    .init(rawValue: CorGenericParamAttr.RawValue(self.columns[1]))
+  }
+
+  public var Name: String {
+    get throws {
+      try self.database.strings[self.columns[3]]
+    }
+  }
+}

--- a/Sources/WinMD/Tables/GenericParamConstraint.swift
+++ b/Sources/WinMD/Tables/GenericParamConstraint.swift
@@ -23,3 +23,11 @@ public final class GenericParamConstraint: Table {
   }
 }
 }
+
+extension Record where Table == Metadata.Tables.GenericParamConstraint {
+  public var Owner: Record<Metadata.Tables.GenericParam> {
+    get throws {
+      try self.database.rows(of: Metadata.Tables.GenericParam.self)[self.columns[0]]!
+    }
+  }
+}

--- a/Sources/WinMD/Tables/ImplMap.swift
+++ b/Sources/WinMD/Tables/ImplMap.swift
@@ -27,3 +27,21 @@ public final class ImplMap: Table {
   }
 }
 }
+
+extension Record where Table == Metadata.Tables.ImplMap {
+  public var MappingFlags: CorPinvokeMap {
+    .init(rawValue: CorPinvokeMap.RawValue(self.columns[0]))
+  }
+
+  public var ImportName: String {
+    get throws {
+      try self.database.strings[self.columns[2]]
+    }
+  }
+
+  public var ImportScope: Record<Metadata.Tables.ModuleRef> {
+    get throws {
+      try self.database.rows(of: Metadata.Tables.ModuleRef.self)[self.columns[3]]!
+    }
+  }
+}

--- a/Sources/WinMD/Tables/InterfaceImpl.swift
+++ b/Sources/WinMD/Tables/InterfaceImpl.swift
@@ -23,3 +23,11 @@ public final class InterfaceImpl: Table {
   }
 }
 }
+
+extension Record where Table == Metadata.Tables.InterfaceImpl {
+  public var Class: Record<Metadata.Tables.TypeDef> {
+    get throws {
+      try self.database.rows(of: Metadata.Tables.TypeDef.self)[self.columns[0]]!
+    }
+  }
+}

--- a/Sources/WinMD/Tables/ManifestResource.swift
+++ b/Sources/WinMD/Tables/ManifestResource.swift
@@ -27,3 +27,19 @@ public final class ManifestResource: Table {
   }
 }
 }
+
+extension Record where Table == Metadata.Tables.ManifestResource {
+  public var Offset: UInt32 {
+    UInt32(self.columns[0])
+  }
+
+  public var Flags: CorManifestResourceFlags {
+    .init(rawValue: CorManifestResourceFlags.RawValue(self.columns[1]))
+  }
+
+  public var Name: String {
+    get throws {
+      try self.database.strings[self.columns[2]]
+    }
+  }
+}

--- a/Sources/WinMD/Tables/MemberRef.swift
+++ b/Sources/WinMD/Tables/MemberRef.swift
@@ -25,3 +25,17 @@ public final class MemberRef: Table {
   }
 }
 }
+
+extension Record where Table == Metadata.Tables.MemberRef {
+  public var Name: String {
+    get throws {
+      try self.database.strings[self.columns[1]]
+    }
+  }
+
+  public var Signature: Blob {
+    get throws {
+      try self.database.blobs[self.columns[2]]
+    }
+  }
+}

--- a/Sources/WinMD/Tables/MethodDef.swift
+++ b/Sources/WinMD/Tables/MethodDef.swift
@@ -31,3 +31,35 @@ public final class MethodDef: Table {
   }
 }
 }
+
+extension Record where Table == Metadata.Tables.MethodDef {
+  public var RVA: UInt32 {
+    UInt32(self.columns[0])
+  }
+
+  public var ImplFlags: CorMethodImpl {
+    .init(rawValue: CorMethodImpl.RawValue(self.columns[1]))
+  }
+
+  public var Flags: CorMethodAttr {
+    .init(rawValue: CorMethodAttr.RawValue(self.columns[2]))
+  }
+
+  public var Name: String {
+    get throws {
+      try self.database.strings[self.columns[3]]
+    }
+  }
+
+  public var Signature: Blob {
+    get throws {
+      try self.database.blobs[self.columns[4]]
+    }
+  }
+
+  public var ParamList: TableIterator<Metadata.Tables.Param> {
+    get throws {
+      try list(for: 5)
+    }
+  }
+}

--- a/Sources/WinMD/Tables/MethodImpl.swift
+++ b/Sources/WinMD/Tables/MethodImpl.swift
@@ -25,3 +25,11 @@ public final class MethodImpl: Table {
   }
 }
 }
+
+extension Record where Table == Metadata.Tables.MethodImpl {
+  public var Class: Record<Metadata.Tables.TypeDef> {
+    get throws {
+      try self.database.rows(of: Metadata.Tables.TypeDef.self)[self.columns[0]]!
+    }
+  }
+}

--- a/Sources/WinMD/Tables/MethodSemantics.swift
+++ b/Sources/WinMD/Tables/MethodSemantics.swift
@@ -25,3 +25,15 @@ public final class MethodSemantics: Table {
   }
 }
 }
+
+extension Record where Table == Metadata.Tables.MethodSemantics {
+  public var Semantics: CorMethodSemanticsAttr {
+    .init(rawValue: CorMethodSemanticsAttr.RawValue(self.columns[0]))
+  }
+
+  public var Method: Record<Metadata.Tables.MethodDef> {
+    get throws {
+      try self.database.rows(of: Metadata.Tables.MethodDef.self)[self.columns[1]]!
+    }
+  }
+}

--- a/Sources/WinMD/Tables/MethodSpec.swift
+++ b/Sources/WinMD/Tables/MethodSpec.swift
@@ -23,3 +23,11 @@ public final class MethodSpec: Table {
   }
 }
 }
+
+extension Record where Table == Metadata.Tables.MethodSpec {
+  public var Instantiation: Blob {
+    get throws {
+      try self.database.blobs[self.columns[1]]
+    }
+  }
+}

--- a/Sources/WinMD/Tables/Module.swift
+++ b/Sources/WinMD/Tables/Module.swift
@@ -1,6 +1,8 @@
 // Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
+import struct Foundation.UUID
+
 extension Metadata.Tables {
 /// See §II.22.30.
 public final class Module: Table {
@@ -28,4 +30,34 @@ public final class Module: Table {
     self.data = data
   }
 }
+}
+
+extension Record where Table == Metadata.Tables.Module {
+  public var Generation: UInt16 {
+    UInt16(self.columns[0])
+  }
+
+  public var Name: String {
+    get throws {
+      try self.database.strings[self.columns[1]]
+    }
+  }
+
+  public var Mvid: UUID {
+    get throws {
+      try self.database.guids[self.columns[2]]
+    }
+  }
+
+  public var EncId: UUID {
+    get throws {
+      try self.database.guids[self.columns[3]]
+    }
+  }
+
+  public var EncBaseId: UUID {
+    get throws {
+      try self.database.guids[self.columns[4]]
+    }
+  }
 }

--- a/Sources/WinMD/Tables/ModuleRef.swift
+++ b/Sources/WinMD/Tables/ModuleRef.swift
@@ -21,3 +21,11 @@ public final class ModuleRef: Table {
   }
 }
 }
+
+extension Record where Table == Metadata.Tables.ModuleRef {
+  public var Name: String {
+    get throws {
+      try self.database.strings[self.columns[0]]
+    }
+  }
+}

--- a/Sources/WinMD/Tables/NestedClass.swift
+++ b/Sources/WinMD/Tables/NestedClass.swift
@@ -23,3 +23,17 @@ public final class NestedClass: Table {
   }
 }
 }
+
+extension Record where Table == Metadata.Tables.NestedClass {
+  public var NestedClass: Record<Metadata.Tables.TypeDef> {
+    get throws {
+      try self.database.rows(of: Metadata.Tables.TypeDef.self)[self.columns[0]]!
+    }
+  }
+
+  public var EnclosingClass: Record<Metadata.Tables.TypeDef> {
+    get throws {
+      try self.database.rows(of: Metadata.Tables.TypeDef.self)[self.columns[1]]!
+    }
+  }
+}

--- a/Sources/WinMD/Tables/Param.swift
+++ b/Sources/WinMD/Tables/Param.swift
@@ -25,3 +25,19 @@ public final class Param: Table {
   }
 }
 }
+
+extension Record where Table == Metadata.Tables.Param {
+  public var Flags: CorParamAttr {
+    .init(rawValue: CorParamAttr.RawValue(self.columns[0]))
+  }
+
+  public var Sequence: UInt16 {
+    UInt16(self.columns[1])
+  }
+
+  public var Name: String {
+    get throws {
+      try self.database.strings[self.columns[2]]
+    }
+  }
+}

--- a/Sources/WinMD/Tables/PropertyDef.swift
+++ b/Sources/WinMD/Tables/PropertyDef.swift
@@ -25,3 +25,15 @@ public final class PropertyDef: Table {
   }
 }
 }
+
+extension Record where Table == Metadata.Tables.PropertyDef {
+  public var Flags: CorPropertyAttr {
+    .init(rawValue: CorPropertyAttr.RawValue(self.columns[0]))
+  }
+
+  public var Name: String {
+    get throws {
+      try self.database.strings[self.columns[1]]
+    }
+  }
+}

--- a/Sources/WinMD/Tables/PropertyMap.swift
+++ b/Sources/WinMD/Tables/PropertyMap.swift
@@ -23,3 +23,17 @@ public final class PropertyMap: Table {
   }
 }
 }
+
+extension Record where Table == Metadata.Tables.PropertyMap {
+  public var Parent: Record<Metadata.Tables.TypeDef> {
+    get throws {
+      try self.database.rows(of: Metadata.Tables.TypeDef.self)[self.columns[0]]!
+    }
+  }
+
+  public var PropertyList: TableIterator<Metadata.Tables.PropertyDef> {
+    get throws {
+      try list(for: 1)
+    }
+  }
+}

--- a/Sources/WinMD/Tables/StandAloneSig.swift
+++ b/Sources/WinMD/Tables/StandAloneSig.swift
@@ -21,3 +21,11 @@ public final class StandAloneSig: Table {
   }
 }
 }
+
+extension Record where Table == Metadata.Tables.StandAloneSig {
+  public var Signature: Blob {
+    get throws {
+      try self.database.blobs[self.columns[0]]
+    }
+  }
+}

--- a/Sources/WinMD/Tables/TypeDef.swift
+++ b/Sources/WinMD/Tables/TypeDef.swift
@@ -33,9 +33,31 @@ public final class TypeDef: Table {
 }
 
 extension Record where Table == Metadata.Tables.TypeDef {
+  public var Flags: CorTypeAttr {
+    .init(rawValue: CorTypeAttr.RawValue(self.columns[0]))
+  }
+
+  public var TypeName: String {
+    get throws {
+      try self.database.strings[self.columns[1]]
+    }
+  }
+
   public var TypeNamespace: String {
     get throws {
       try self.database.strings[self.columns[2]]
+    }
+  }
+
+  public var FieldList: TableIterator<Metadata.Tables.FieldDef> {
+    get throws {
+      try list(for: 4)
+    }
+  }
+
+  public var MethodList: TableIterator<Metadata.Tables.MethodDef> {
+    get throws {
+      try list(for: 5)
     }
   }
 }

--- a/Sources/WinMD/Tables/TypeRef.swift
+++ b/Sources/WinMD/Tables/TypeRef.swift
@@ -25,3 +25,17 @@ public final class TypeRef: Table {
   }
 }
 }
+
+extension Record where Table == Metadata.Tables.TypeRef {
+  public var TypeName: String {
+    get throws {
+      try self.database.strings[self.columns[1]]
+    }
+  }
+
+  public var TypeNamespace: String {
+    get throws {
+      try self.database.strings[self.columns[2]]
+    }
+  }
+}

--- a/Sources/WinMD/Tables/TypeSpec.swift
+++ b/Sources/WinMD/Tables/TypeSpec.swift
@@ -21,3 +21,11 @@ public final class TypeSpec: Table {
   }
 }
 }
+
+extension Record where Table == Metadata.Tables.TypeSpec {
+  public var Signature: Blob {
+    get throws {
+      try self.database.blobs[self.columns[0]]
+    }
+  }
+}


### PR DESCRIPTION
This adds the basic typed accessors (non-coded-index) for the record specialised to each table type.  This aids in accessing a record column from a given table in the database.