### PR TITLE
WinMD: remove extraneous use of `self.`

### DIFF
--- a/Sources/WinMD/Tables/Assembly.swift
+++ b/Sources/WinMD/Tables/Assembly.swift
@@ -40,44 +40,44 @@ public final class Assembly: Table {
 
 extension Record where Table == Metadata.Tables.Assembly {
   public var HashAlgId: CorHashAlgorithm {
-    .init(rawValue: CorHashAlgorithm.RawValue(self.columns[0]))!
+    .init(rawValue: CorHashAlgorithm.RawValue(columns[0]))!
   }
 
   public var MajorVersion: UInt16 {
-    UInt16(self.columns[1])
+    UInt16(columns[1])
   }
 
   public var MinorVersion: UInt16 {
-    UInt16(self.columns[2])
+    UInt16(columns[2])
   }
 
   public var BuildNumber: UInt16 {
-    UInt16(self.columns[3])
+    UInt16(columns[3])
   }
 
   public var RevisionNumber: UInt16 {
-    UInt16(self.columns[4])
+    UInt16(columns[4])
   }
 
   public var Flags: CorAssemblyFlags {
-    .init(rawValue: CorAssemblyFlags.RawValue(self.columns[5]))
+    .init(rawValue: CorAssemblyFlags.RawValue(columns[5]))
   }
 
   public var PublicKey: Blob {
     get throws {
-      try self.database.blobs[self.columns[6]]
+      try database.blobs[columns[6]]
     }
   }
 
   public var Name: String {
     get throws {
-      try self.database.strings[self.columns[7]]
+      try database.strings[columns[7]]
     }
   }
 
   public var Culture: String {
     get throws {
-      try self.database.strings[self.columns[8]]
+      try database.strings[columns[8]]
     }
   }
 }

--- a/Sources/WinMD/Tables/AssemblyOS.swift
+++ b/Sources/WinMD/Tables/AssemblyOS.swift
@@ -27,14 +27,14 @@ public final class AssemblyOS: Table {
 
 extension Record where Table == Metadata.Tables.AssemblyOS {
   public var OSPlatformID: UInt32 {
-    UInt32(self.columns[0])
+    UInt32(columns[0])
   }
 
   public var OSMajorVersion: UInt32 {
-    UInt32(self.columns[1])
+    UInt32(columns[1])
   }
 
   public var OSMinorVersion: UInt32 {
-    UInt32(self.columns[2])
+    UInt32(columns[2])
   }
 }

--- a/Sources/WinMD/Tables/AssemblyProcessor.swift
+++ b/Sources/WinMD/Tables/AssemblyProcessor.swift
@@ -24,6 +24,6 @@ public final class AssemblyProcessor: Table {
 
 extension Record where Table == Metadata.Tables.AssemblyProcessor {
   public var Processor: UInt32 {
-    UInt32(self.columns[0])
+    UInt32(columns[0])
   }
 }

--- a/Sources/WinMD/Tables/AssemblyRef.swift
+++ b/Sources/WinMD/Tables/AssemblyRef.swift
@@ -40,46 +40,46 @@ public final class AssemblyRef: Table {
 
 extension Record where Table == Metadata.Tables.AssemblyRef {
   public var MajorVersion: UInt16 {
-    UInt16(self.columns[0])
+    UInt16(columns[0])
   }
 
   public var MinorVersion: UInt16 {
-    UInt16(self.columns[1])
+    UInt16(columns[1])
   }
 
   public var BuildNumber: UInt16 {
-    UInt16(self.columns[2])
+    UInt16(columns[2])
   }
 
   public var RevisionNumber: UInt16 {
-    UInt16(self.columns[3])
+    UInt16(columns[3])
   }
 
   public var Flags: CorAssemblyFlags {
-    .init(rawValue: CorAssemblyFlags.RawValue(self.columns[4]))
+    .init(rawValue: CorAssemblyFlags.RawValue(columns[4]))
   }
 
   public var PublicKeyOrToken: Blob {
     get throws {
-      try self.database.blobs[self.columns[5]]
+      try database.blobs[columns[5]]
     }
   }
 
   public var Name: String {
     get throws {
-      try self.database.strings[self.columns[6]]
+      try database.strings[columns[6]]
     }
   }
 
   public var Culture: String {
     get throws {
-      try self.database.strings[self.columns[7]]
+      try self.database.strings[columns[7]]
     }
   }
 
   public var HashValue: Blob {
     get throws {
-      try self.database.blobs[self.columns[8]]
+      try self.database.blobs[columns[8]]
     }
   }
 }

--- a/Sources/WinMD/Tables/AssemblyRefOS.swift
+++ b/Sources/WinMD/Tables/AssemblyRefOS.swift
@@ -30,20 +30,20 @@ public final class AssemblyRefOS: Table {
 
 extension Record where Table == Metadata.Tables.AssemblyRefOS {
   public var OSPlatformId: UInt32 {
-    UInt32(self.columns[0])
+    UInt32(columns[0])
   }
 
   public var OSMajorVersion: UInt32 {
-    UInt32(self.columns[1])
+    UInt32(columns[1])
   }
 
   public var OSMinorVerison: UInt32 {
-    UInt32(self.columns[2])
+    UInt32(columns[2])
   }
 
   public var AssemblyRef: Record<Metadata.Tables.AssemblyRef> {
     get throws {
-      try self.database.rows(of: Metadata.Tables.AssemblyRef.self)[self.columns[3]]!
+      try database.rows(of: Metadata.Tables.AssemblyRef.self)[columns[3]]!
     }
   }
 }

--- a/Sources/WinMD/Tables/AssemblyRefProcessor.swift
+++ b/Sources/WinMD/Tables/AssemblyRefProcessor.swift
@@ -26,12 +26,12 @@ public final class AssemblyRefProcessor: Table {
 
 extension Record where Table == Metadata.Tables.AssemblyRefProcessor {
   public var Processor: UInt32 {
-    UInt32(self.columns[0])
+    UInt32(columns[0])
   }
 
   public var AssemblyRef: Record<Metadata.Tables.AssemblyRef> {
     get throws {
-      try self.database.rows(of: Metadata.Tables.AssemblyRef.self)[self.columns[1]]!
+      try database.rows(of: Metadata.Tables.AssemblyRef.self)[columns[1]]!
     }
   }
 }

--- a/Sources/WinMD/Tables/ClassLayout.swift
+++ b/Sources/WinMD/Tables/ClassLayout.swift
@@ -28,16 +28,16 @@ public final class ClassLayout: Table {
 
 extension Record where Table == Metadata.Tables.ClassLayout {
   public var PackingSize: UInt16 {
-    UInt16(self.columns[0])
+    UInt16(columns[0])
   }
 
   public var ClassSize: UInt32 {
-    UInt32(self.columns[1])
+    UInt32(columns[1])
   }
 
   public var Parent: Record<Metadata.Tables.TypeDef> {
     get throws {
-      try self.database.rows(of: Metadata.Tables.TypeDef.self)[self.columns[2]]!
+      try database.rows(of: Metadata.Tables.TypeDef.self)[columns[2]]!
     }
   }
 }

--- a/Sources/WinMD/Tables/Constant.swift
+++ b/Sources/WinMD/Tables/Constant.swift
@@ -34,7 +34,7 @@ extension Record where Table == Metadata.Tables.Constant {
 
   public var Value: Blob {
     get throws {
-      try self.database.blobs[self.columns[4]]
+      try database.blobs[columns[4]]
     }
   }
 }

--- a/Sources/WinMD/Tables/CustomAttribute.swift
+++ b/Sources/WinMD/Tables/CustomAttribute.swift
@@ -29,7 +29,7 @@ public final class CustomAttribute: Table {
 extension Record where Table == Metadata.Tables.CustomAttribute {
   public var Value: Blob {
     get throws {
-      try self.database.blobs[self.columns[2]]
+      try database.blobs[columns[2]]
     }
   }
 }

--- a/Sources/WinMD/Tables/DeclSecurity.swift
+++ b/Sources/WinMD/Tables/DeclSecurity.swift
@@ -28,12 +28,12 @@ public final class DeclSecurity: Table {
 
 extension Record where Table == Metadata.Tables.DeclSecurity {
   public var Action: UInt16 {
-    UInt16(self.columns[0])
+    UInt16(columns[0])
   }
 
   public var PermissionSet: Blob {
     get throws {
-      try self.database.blobs[self.columns[2]]
+      try database.blobs[columns[2]]
     }
   }
 }

--- a/Sources/WinMD/Tables/EventDef.swift
+++ b/Sources/WinMD/Tables/EventDef.swift
@@ -28,12 +28,12 @@ public final class EventDef: Table {
 
 extension Record where Table == Metadata.Tables.EventDef {
   public var EventFlags: CorEventAttr {
-    .init(rawValue: CorEventAttr.RawValue(self.columns[0]))
+    .init(rawValue: CorEventAttr.RawValue(columns[0]))
   }
 
   public var Name: String {
     get throws {
-      try self.database.strings[self.columns[1]]
+      try database.strings[columns[1]]
     }
   }
 }

--- a/Sources/WinMD/Tables/EventMap.swift
+++ b/Sources/WinMD/Tables/EventMap.swift
@@ -27,7 +27,7 @@ public final class EventMap: Table {
 extension Record where Table == Metadata.Tables.EventMap {
   public var Parent: Record<Metadata.Tables.TypeDef> {
     get throws {
-      try self.database.rows(of: Metadata.Tables.TypeDef.self)[self.columns[0]]!
+      try database.rows(of: Metadata.Tables.TypeDef.self)[columns[0]]!
     }
   }
 

--- a/Sources/WinMD/Tables/ExportedType.swift
+++ b/Sources/WinMD/Tables/ExportedType.swift
@@ -32,18 +32,18 @@ public final class ExportedType: Table {
 
 extension Record where Table == Metadata.Tables.ExportedType {
   public var Flags: CorTypeAttr {
-    .init(rawValue: CorTypeAttr.RawValue(self.columns[0]))
+    .init(rawValue: CorTypeAttr.RawValue(columns[0]))
   }
 
   public var TypeName: String {
     get throws {
-      try self.database.strings[self.columns[2]]
+      try database.strings[columns[2]]
     }
   }
 
   public var TypeNamespace: String {
     get throws {
-      try self.database.strings[self.columns[3]]
+      try database.strings[columns[3]]
     }
   }
 }

--- a/Sources/WinMD/Tables/FieldDef.swift
+++ b/Sources/WinMD/Tables/FieldDef.swift
@@ -28,18 +28,18 @@ public final class FieldDef: Table {
 
 extension Record where Table == Metadata.Tables.FieldDef {
   public var Flags: CorFieldAttr {
-    .init(rawValue: CorFieldAttr.RawValue(self.columns[0]))
+    .init(rawValue: CorFieldAttr.RawValue(columns[0]))
   }
 
   public var Name: String {
     get throws {
-      try self.database.strings[self.columns[1]]
+      try database.strings[columns[1]]
     }
   }
 
   public var Signature: Blob {
     get throws {
-      try self.database.blobs[self.columns[2]]
+      try database.blobs[columns[2]]
     }
   }
 }

--- a/Sources/WinMD/Tables/FieldLayout.swift
+++ b/Sources/WinMD/Tables/FieldLayout.swift
@@ -26,12 +26,12 @@ public final class FieldLayout: Table {
 
 extension Record where Table == Metadata.Tables.FieldLayout {
   public var Offset: UInt32 {
-    UInt32(self.columns[0])
+    UInt32(columns[0])
   }
 
   public var Field: Record<Metadata.Tables.FieldDef> {
     get throws {
-      try self.database.rows(of: Metadata.Tables.FieldDef.self)[self.columns[1]]!
+      try database.rows(of: Metadata.Tables.FieldDef.self)[columns[1]]!
     }
   }
 }

--- a/Sources/WinMD/Tables/FieldMarshal.swift
+++ b/Sources/WinMD/Tables/FieldMarshal.swift
@@ -27,7 +27,7 @@ public final class FieldMarshal: Table {
 extension Record where Table == Metadata.Tables.FieldMarshal {
   public var NativeType: Blob {
     get throws {
-      try self.database.blobs[self.columns[1]]
+      try database.blobs[columns[1]]
     }
   }
 }

--- a/Sources/WinMD/Tables/FieldRVA.swift
+++ b/Sources/WinMD/Tables/FieldRVA.swift
@@ -26,12 +26,12 @@ public final class FieldRVA: Table {
 
 extension Record where Table == Metadata.Tables.FieldRVA {
   public var RVA: UInt32 {
-    UInt32(self.columns[0])
+    UInt32(columns[0])
   }
 
   public var Field: Record<Metadata.Tables.FieldDef> {
     get throws {
-      try self.database.rows(of: Metadata.Tables.FieldDef.self)[self.columns[1]]!
+      try database.rows(of: Metadata.Tables.FieldDef.self)[columns[1]]!
     }
   }
 }

--- a/Sources/WinMD/Tables/File.swift
+++ b/Sources/WinMD/Tables/File.swift
@@ -28,18 +28,18 @@ public final class File: Table {
 
 extension Record where Table == Metadata.Tables.File {
   public var Flags: CorFileFlags {
-    .init(rawValue: CorFileFlags.RawValue(self.columns[0]))
+    .init(rawValue: CorFileFlags.RawValue(columns[0]))
   }
 
   public var Name: String {
     get throws {
-      try self.database.strings[self.columns[1]]
+      try database.strings[columns[1]]
     }
   }
 
   public var HashValue: Blob {
     get throws {
-      try self.database.blobs[self.columns[2]]
+      try database.blobs[columns[2]]
     }
   }
 }

--- a/Sources/WinMD/Tables/GenericParam.swift
+++ b/Sources/WinMD/Tables/GenericParam.swift
@@ -30,16 +30,16 @@ public final class GenericParam: Table {
 
 extension Record where Table == Metadata.Tables.GenericParam {
   public var Number: UInt16 {
-    UInt16(self.columns[0])
+    UInt16(columns[0])
   }
 
   public var Flags: CorGenericParamAttr {
-    .init(rawValue: CorGenericParamAttr.RawValue(self.columns[1]))
+    .init(rawValue: CorGenericParamAttr.RawValue(columns[1]))
   }
 
   public var Name: String {
     get throws {
-      try self.database.strings[self.columns[3]]
+      try database.strings[columns[3]]
     }
   }
 }

--- a/Sources/WinMD/Tables/GenericParamConstraint.swift
+++ b/Sources/WinMD/Tables/GenericParamConstraint.swift
@@ -27,7 +27,7 @@ public final class GenericParamConstraint: Table {
 extension Record where Table == Metadata.Tables.GenericParamConstraint {
   public var Owner: Record<Metadata.Tables.GenericParam> {
     get throws {
-      try self.database.rows(of: Metadata.Tables.GenericParam.self)[self.columns[0]]!
+      try database.rows(of: Metadata.Tables.GenericParam.self)[columns[0]]!
     }
   }
 }

--- a/Sources/WinMD/Tables/ImplMap.swift
+++ b/Sources/WinMD/Tables/ImplMap.swift
@@ -30,18 +30,18 @@ public final class ImplMap: Table {
 
 extension Record where Table == Metadata.Tables.ImplMap {
   public var MappingFlags: CorPinvokeMap {
-    .init(rawValue: CorPinvokeMap.RawValue(self.columns[0]))
+    .init(rawValue: CorPinvokeMap.RawValue(columns[0]))
   }
 
   public var ImportName: String {
     get throws {
-      try self.database.strings[self.columns[2]]
+      try database.strings[columns[2]]
     }
   }
 
   public var ImportScope: Record<Metadata.Tables.ModuleRef> {
     get throws {
-      try self.database.rows(of: Metadata.Tables.ModuleRef.self)[self.columns[3]]!
+      try database.rows(of: Metadata.Tables.ModuleRef.self)[columns[3]]!
     }
   }
 }

--- a/Sources/WinMD/Tables/InterfaceImpl.swift
+++ b/Sources/WinMD/Tables/InterfaceImpl.swift
@@ -27,7 +27,7 @@ public final class InterfaceImpl: Table {
 extension Record where Table == Metadata.Tables.InterfaceImpl {
   public var Class: Record<Metadata.Tables.TypeDef> {
     get throws {
-      try self.database.rows(of: Metadata.Tables.TypeDef.self)[self.columns[0]]!
+      try database.rows(of: Metadata.Tables.TypeDef.self)[columns[0]]!
     }
   }
 }

--- a/Sources/WinMD/Tables/ManifestResource.swift
+++ b/Sources/WinMD/Tables/ManifestResource.swift
@@ -30,16 +30,16 @@ public final class ManifestResource: Table {
 
 extension Record where Table == Metadata.Tables.ManifestResource {
   public var Offset: UInt32 {
-    UInt32(self.columns[0])
+    UInt32(columns[0])
   }
 
   public var Flags: CorManifestResourceFlags {
-    .init(rawValue: CorManifestResourceFlags.RawValue(self.columns[1]))
+    .init(rawValue: CorManifestResourceFlags.RawValue(columns[1]))
   }
 
   public var Name: String {
     get throws {
-      try self.database.strings[self.columns[2]]
+      try database.strings[columns[2]]
     }
   }
 }

--- a/Sources/WinMD/Tables/MemberRef.swift
+++ b/Sources/WinMD/Tables/MemberRef.swift
@@ -29,13 +29,13 @@ public final class MemberRef: Table {
 extension Record where Table == Metadata.Tables.MemberRef {
   public var Name: String {
     get throws {
-      try self.database.strings[self.columns[1]]
+      try database.strings[columns[1]]
     }
   }
 
   public var Signature: Blob {
     get throws {
-      try self.database.blobs[self.columns[2]]
+      try database.blobs[columns[2]]
     }
   }
 }

--- a/Sources/WinMD/Tables/MethodDef.swift
+++ b/Sources/WinMD/Tables/MethodDef.swift
@@ -34,26 +34,26 @@ public final class MethodDef: Table {
 
 extension Record where Table == Metadata.Tables.MethodDef {
   public var RVA: UInt32 {
-    UInt32(self.columns[0])
+    UInt32(columns[0])
   }
 
   public var ImplFlags: CorMethodImpl {
-    .init(rawValue: CorMethodImpl.RawValue(self.columns[1]))
+    .init(rawValue: CorMethodImpl.RawValue(columns[1]))
   }
 
   public var Flags: CorMethodAttr {
-    .init(rawValue: CorMethodAttr.RawValue(self.columns[2]))
+    .init(rawValue: CorMethodAttr.RawValue(columns[2]))
   }
 
   public var Name: String {
     get throws {
-      try self.database.strings[self.columns[3]]
+      try database.strings[columns[3]]
     }
   }
 
   public var Signature: Blob {
     get throws {
-      try self.database.blobs[self.columns[4]]
+      try database.blobs[columns[4]]
     }
   }
 

--- a/Sources/WinMD/Tables/MethodImpl.swift
+++ b/Sources/WinMD/Tables/MethodImpl.swift
@@ -29,7 +29,7 @@ public final class MethodImpl: Table {
 extension Record where Table == Metadata.Tables.MethodImpl {
   public var Class: Record<Metadata.Tables.TypeDef> {
     get throws {
-      try self.database.rows(of: Metadata.Tables.TypeDef.self)[self.columns[0]]!
+      try database.rows(of: Metadata.Tables.TypeDef.self)[columns[0]]!
     }
   }
 }

--- a/Sources/WinMD/Tables/MethodSemantics.swift
+++ b/Sources/WinMD/Tables/MethodSemantics.swift
@@ -28,12 +28,12 @@ public final class MethodSemantics: Table {
 
 extension Record where Table == Metadata.Tables.MethodSemantics {
   public var Semantics: CorMethodSemanticsAttr {
-    .init(rawValue: CorMethodSemanticsAttr.RawValue(self.columns[0]))
+    .init(rawValue: CorMethodSemanticsAttr.RawValue(columns[0]))
   }
 
   public var Method: Record<Metadata.Tables.MethodDef> {
     get throws {
-      try self.database.rows(of: Metadata.Tables.MethodDef.self)[self.columns[1]]!
+      try database.rows(of: Metadata.Tables.MethodDef.self)[columns[1]]!
     }
   }
 }

--- a/Sources/WinMD/Tables/MethodSpec.swift
+++ b/Sources/WinMD/Tables/MethodSpec.swift
@@ -27,7 +27,7 @@ public final class MethodSpec: Table {
 extension Record where Table == Metadata.Tables.MethodSpec {
   public var Instantiation: Blob {
     get throws {
-      try self.database.blobs[self.columns[1]]
+      try database.blobs[columns[1]]
     }
   }
 }

--- a/Sources/WinMD/Tables/Module.swift
+++ b/Sources/WinMD/Tables/Module.swift
@@ -34,30 +34,30 @@ public final class Module: Table {
 
 extension Record where Table == Metadata.Tables.Module {
   public var Generation: UInt16 {
-    UInt16(self.columns[0])
+    UInt16(columns[0])
   }
 
   public var Name: String {
     get throws {
-      try self.database.strings[self.columns[1]]
+      try database.strings[columns[1]]
     }
   }
 
   public var Mvid: UUID {
     get throws {
-      try self.database.guids[self.columns[2]]
+      try database.guids[columns[2]]
     }
   }
 
   public var EncId: UUID {
     get throws {
-      try self.database.guids[self.columns[3]]
+      try database.guids[columns[3]]
     }
   }
 
   public var EncBaseId: UUID {
     get throws {
-      try self.database.guids[self.columns[4]]
+      try database.guids[columns[4]]
     }
   }
 }

--- a/Sources/WinMD/Tables/ModuleRef.swift
+++ b/Sources/WinMD/Tables/ModuleRef.swift
@@ -25,7 +25,7 @@ public final class ModuleRef: Table {
 extension Record where Table == Metadata.Tables.ModuleRef {
   public var Name: String {
     get throws {
-      try self.database.strings[self.columns[0]]
+      try database.strings[columns[0]]
     }
   }
 }

--- a/Sources/WinMD/Tables/NestedClass.swift
+++ b/Sources/WinMD/Tables/NestedClass.swift
@@ -27,13 +27,13 @@ public final class NestedClass: Table {
 extension Record where Table == Metadata.Tables.NestedClass {
   public var NestedClass: Record<Metadata.Tables.TypeDef> {
     get throws {
-      try self.database.rows(of: Metadata.Tables.TypeDef.self)[self.columns[0]]!
+      try database.rows(of: Metadata.Tables.TypeDef.self)[columns[0]]!
     }
   }
 
   public var EnclosingClass: Record<Metadata.Tables.TypeDef> {
     get throws {
-      try self.database.rows(of: Metadata.Tables.TypeDef.self)[self.columns[1]]!
+      try database.rows(of: Metadata.Tables.TypeDef.self)[columns[1]]!
     }
   }
 }

--- a/Sources/WinMD/Tables/Param.swift
+++ b/Sources/WinMD/Tables/Param.swift
@@ -28,16 +28,16 @@ public final class Param: Table {
 
 extension Record where Table == Metadata.Tables.Param {
   public var Flags: CorParamAttr {
-    .init(rawValue: CorParamAttr.RawValue(self.columns[0]))
+    .init(rawValue: CorParamAttr.RawValue(columns[0]))
   }
 
   public var Sequence: UInt16 {
-    UInt16(self.columns[1])
+    UInt16(columns[1])
   }
 
   public var Name: String {
     get throws {
-      try self.database.strings[self.columns[2]]
+      try database.strings[columns[2]]
     }
   }
 }

--- a/Sources/WinMD/Tables/PropertyDef.swift
+++ b/Sources/WinMD/Tables/PropertyDef.swift
@@ -28,12 +28,12 @@ public final class PropertyDef: Table {
 
 extension Record where Table == Metadata.Tables.PropertyDef {
   public var Flags: CorPropertyAttr {
-    .init(rawValue: CorPropertyAttr.RawValue(self.columns[0]))
+    .init(rawValue: CorPropertyAttr.RawValue(columns[0]))
   }
 
   public var Name: String {
     get throws {
-      try self.database.strings[self.columns[1]]
+      try database.strings[columns[1]]
     }
   }
 }

--- a/Sources/WinMD/Tables/PropertyMap.swift
+++ b/Sources/WinMD/Tables/PropertyMap.swift
@@ -27,7 +27,7 @@ public final class PropertyMap: Table {
 extension Record where Table == Metadata.Tables.PropertyMap {
   public var Parent: Record<Metadata.Tables.TypeDef> {
     get throws {
-      try self.database.rows(of: Metadata.Tables.TypeDef.self)[self.columns[0]]!
+      try database.rows(of: Metadata.Tables.TypeDef.self)[columns[0]]!
     }
   }
 

--- a/Sources/WinMD/Tables/StandAloneSig.swift
+++ b/Sources/WinMD/Tables/StandAloneSig.swift
@@ -25,7 +25,7 @@ public final class StandAloneSig: Table {
 extension Record where Table == Metadata.Tables.StandAloneSig {
   public var Signature: Blob {
     get throws {
-      try self.database.blobs[self.columns[0]]
+      try database.blobs[columns[0]]
     }
   }
 }

--- a/Sources/WinMD/Tables/TypeDef.swift
+++ b/Sources/WinMD/Tables/TypeDef.swift
@@ -34,18 +34,18 @@ public final class TypeDef: Table {
 
 extension Record where Table == Metadata.Tables.TypeDef {
   public var Flags: CorTypeAttr {
-    .init(rawValue: CorTypeAttr.RawValue(self.columns[0]))
+    .init(rawValue: CorTypeAttr.RawValue(columns[0]))
   }
 
   public var TypeName: String {
     get throws {
-      try self.database.strings[self.columns[1]]
+      try database.strings[columns[1]]
     }
   }
 
   public var TypeNamespace: String {
     get throws {
-      try self.database.strings[self.columns[2]]
+      try database.strings[columns[2]]
     }
   }
 

--- a/Sources/WinMD/Tables/TypeRef.swift
+++ b/Sources/WinMD/Tables/TypeRef.swift
@@ -29,13 +29,13 @@ public final class TypeRef: Table {
 extension Record where Table == Metadata.Tables.TypeRef {
   public var TypeName: String {
     get throws {
-      try self.database.strings[self.columns[1]]
+      try database.strings[columns[1]]
     }
   }
 
   public var TypeNamespace: String {
     get throws {
-      try self.database.strings[self.columns[2]]
+      try database.strings[columns[2]]
     }
   }
 }

--- a/Sources/WinMD/Tables/TypeSpec.swift
+++ b/Sources/WinMD/Tables/TypeSpec.swift
@@ -25,7 +25,7 @@ public final class TypeSpec: Table {
 extension Record where Table == Metadata.Tables.TypeSpec {
   public var Signature: Blob {
     get throws {
-      try self.database.blobs[self.columns[0]]
+      try database.blobs[columns[0]]
     }
   }
 }


### PR DESCRIPTION
This reduces the line width which aids in readability.