### PR TITLE
Begin implementing a querying mechanism for the WinMD

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,6 +9,7 @@ let SwiftWinMD = Package(
   ],
   products: [
     .executable(name: "winmd-inspect", targets: ["winmd-inspect"]),
+    .library(name: "SQL", targets: ["SQL"]),
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-argument-parser",
@@ -16,6 +17,13 @@ let SwiftWinMD = Package(
   ],
   targets: [
     .target(name: "CPE", dependencies: []),
+
+    // SQL
+    .target(name: "SQL", dependencies: [],
+            swiftSettings: [
+              .enableExperimentalFeature("Lifetimes"),
+            ]),
+    .testTarget(name: "SQLTests", dependencies: ["SQL"]),
 
     // WinMD
     .target(name: "WinMD",

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,10 @@ let SwiftWinMD = Package(
             swiftSettings: [
               .enableExperimentalFeature("Lifetimes"),
             ]),
-    .testTarget(name: "SQLTests", dependencies: ["SQL"]),
+    .testTarget(name: "SQLTests", dependencies: ["SQL"],
+            swiftSettings: [
+              .enableExperimentalFeature("Lifetimes"),
+            ]),
 
     // WinMD
     .target(name: "WinMD",

--- a/Sources/SQL/AST.swift
+++ b/Sources/SQL/AST.swift
@@ -1,0 +1,201 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+/// A parsed SQL statement.
+///
+/// The dialect supports a single statement shape, now with an optional join:
+///
+/// ```sql
+/// SELECT <* | column (, column)*>
+///   FROM <table> [AS alias]
+///   [JOIN <table> [AS alias] ON <column> = <column>]
+///   [WHERE <predicate>] [ORDER BY <column> [ASC|DESC]]
+/// ```
+///
+/// The AST is a tree of fully escapable values — names, operators, and literal
+/// operands — that any consumer may interpret. It carries no knowledge of the
+/// relations it names; resolving the table, alias, and column identifiers is
+/// the consumer's responsibility.
+public enum Statement: Hashable, Sendable {
+  case select(Select)
+}
+
+/// A `SELECT` query: a projection over one relation or a join of two, with an
+/// optional predicate and ordering.
+public struct Select: Hashable, Sendable {
+  /// The columns the query yields.
+  public let projection: Projection
+
+  /// The primary relation the query scans.
+  public let from: Relation
+
+  /// The join applied to `from`, if any.
+  public let join: Join?
+
+  /// The row filter, if any.
+  public let predicate: Predicate?
+
+  /// The ordering applied to the result, if any.
+  public let order: Order?
+
+  public init(projection: Projection, from: Relation, join: Join? = nil,
+              predicate: Predicate? = nil, order: Order? = nil) {
+    self.projection = projection
+    self.from = from
+    self.join = join
+    self.predicate = predicate
+    self.order = order
+  }
+
+  /// The name of the primary relation.
+  ///
+  /// Retained for single-relation consumers that only ever name one table; it
+  /// reads the `from` relation's name.
+  public var table: String {
+    from.name
+  }
+}
+
+/// A named relation in a `FROM` or `JOIN`, with an optional alias.
+///
+/// `name` is the relation's spelling; `alias`, when present, is the short name
+/// a qualified column reference may use in its place (`FROM TypeDef AS t`).
+public struct Relation: Hashable, Sendable {
+  /// The relation's name.
+  public let name: String
+
+  /// The alias bound to the relation, if any.
+  public let alias: String?
+
+  public init(name: String, alias: String? = nil) {
+    self.name = name
+    self.alias = alias
+  }
+}
+
+/// A `JOIN` clause: a second relation and the equality that relates it to the
+/// rows already in scope.
+///
+/// The `ON` equality is held as its two column references in source order —
+/// `left = right` — for the consumer to classify. The binding interprets the
+/// pseudo-columns `rowid` (every table's 1-based row index) and `parent` (a
+/// list-child's owning row) within those references.
+public struct Join: Hashable, Sendable {
+  /// The relation joined in.
+  public let relation: Relation
+
+  /// The left side of the `ON` equality.
+  public let left: Column
+
+  /// The right side of the `ON` equality.
+  public let right: Column
+
+  public init(relation: Relation, left: Column, right: Column) {
+    self.relation = relation
+    self.left = left
+    self.right = right
+  }
+}
+
+/// A possibly-qualified column reference: an optional relation qualifier and a
+/// column name (`t.Name`, or a bare `Name`).
+///
+/// A qualifier names a relation by its alias or its table name; an unqualified
+/// reference leaves the relation for the consumer to infer. The name may be a
+/// real column or one of the binding's pseudo-columns (`rowid`, `parent`); the
+/// AST does not distinguish them.
+///
+/// `Column` is `ExpressibleByStringLiteral`, splitting a literal on its first
+/// dot into qualifier and name, so a consumer may write a reference as a plain
+/// string (`"t.Name"`, `"Flags"`).
+public struct Column: Hashable, Sendable, ExpressibleByStringLiteral {
+  /// The relation qualifier, if any.
+  public let qualifier: String?
+
+  /// The column name.
+  public let name: String
+
+  public init(qualifier: String? = nil, name: String) {
+    self.qualifier = qualifier
+    self.name = name
+  }
+
+  /// Parses a reference from its dotted spelling: the text before the first dot
+  /// is the qualifier and the rest is the name; an undotted spelling is an
+  /// unqualified name.
+  public init(_ spelling: String) {
+    if let dot = spelling.firstIndex(of: ".") {
+      self.qualifier = String(spelling[..<dot])
+      self.name = String(spelling[spelling.index(after: dot)...])
+    } else {
+      self.qualifier = nil
+      self.name = spelling
+    }
+  }
+
+  public init(stringLiteral value: String) {
+    self.init(value)
+  }
+}
+
+/// The columns a query yields.
+public enum Projection: Hashable, Sendable {
+  /// `SELECT *` — every column of the relation(s) in scope.
+  case all
+  /// `SELECT a, b, c` — the named columns, in order.
+  case columns(Array<Column>)
+}
+
+/// A row filter — a tree of comparisons composed with `AND`, `OR`, and `NOT`.
+///
+/// The tree is `data`, not an opaque closure, so a consumer may inspect it (for
+/// example to lower an equality test on a sorted column to a binary search).
+public indirect enum Predicate: Hashable, Sendable {
+  /// `column <op> value`.
+  case comparison(column: Column, op: Comparison, value: Literal)
+  /// `lhs AND rhs`.
+  case and(Predicate, Predicate)
+  /// `lhs OR rhs`.
+  case or(Predicate, Predicate)
+  /// `NOT operand`.
+  case not(Predicate)
+}
+
+/// A comparison operator.
+public enum Comparison: Hashable, Sendable {
+  /// `=`
+  case equal
+  /// `<>`
+  case unequal
+  /// `<`
+  case lt
+  /// `>`
+  case gt
+  /// `<=`
+  case leq
+  /// `>=`
+  case geq
+}
+
+/// A literal operand of a comparison.
+public enum Literal: Hashable, Sendable {
+  /// A single-quoted string literal, with its escapes resolved.
+  case string(String)
+  /// An integer literal.
+  case integer(Int)
+}
+
+/// An `ORDER BY` clause: a column and its direction.
+public struct Order: Hashable, Sendable {
+  /// The column the result is ordered on.
+  public let column: Column
+
+  /// Whether the order is ascending (`ASC`, the default) rather than
+  /// descending (`DESC`).
+  public let ascending: Bool
+
+  public init(column: Column, ascending: Bool = true) {
+    self.column = column
+    self.ascending = ascending
+  }
+}

--- a/Sources/SQL/Adapter.swift
+++ b/Sources/SQL/Adapter.swift
@@ -1,0 +1,148 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+/// The engine's adapter surface — the protocols a data source conforms to so
+/// the planner and executor run over it without knowing what it is.
+///
+/// The engine plans and executes a `SELECT` entirely against these four
+/// protocols. A `Catalog` resolves a relation name to a `Table`; a `Table`
+/// describes the relation's schema (its real width and a name → ordinal map,
+/// real or virtual) and vends a `Cursor` over its rows; a `Cursor` addresses
+/// rows by index; a `Row` reads a typed cell by ordinal. Every protocol is
+/// `~Escapable`, so a source backed by borrowed storage — a `Span` over a
+/// mapped file — conforms to the same surface as an escapable, owned source: a
+/// `Catalog`/`Table` hands back a borrowed `Table`/`Cursor` that never outlives
+/// the borrow, and a `Cursor` vends a `Row` view tied to its own lifetime. The
+/// engine yields typed `Value`s, never rendered text; turning a value into a
+/// display string is a client's job.
+
+// MARK: - Values
+
+/// The kind of value a column holds.
+///
+/// A column is either integral or textual. A source uses this to describe its
+/// schema and to build the typed `Value`s a `Row` yields; the engine itself
+/// compares and orders on the `Value`, not the kind.
+public enum ValueKind: Hashable, Sendable {
+  /// An integral column.
+  case integer
+  /// A textual column.
+  case text
+}
+
+/// A typed cell value the engine yields.
+///
+/// The engine projects each surviving row to an `Array<Value>` — the result is
+/// data, not rendered text — so a client may format, compare, or re-key it.
+public enum Value: Hashable, Sendable {
+  /// An integral value.
+  case integer(Int)
+  /// A textual value.
+  case text(String)
+}
+
+// MARK: - Catalog
+
+/// Resolves a relation name to a table.
+///
+/// The catalog is the engine's only entry into a data source: a `SELECT`'s
+/// `FROM` name is looked up here. A name the source does not know yields `nil`,
+/// which the engine reports as `SQLError.relation`. The catalog is `~Escapable`,
+/// and the `Table` it vends borrows it — a borrowed-storage source may resolve a
+/// relation to a view that never escapes the catalog's borrow.
+public protocol Catalog: ~Escapable {
+  /// The table this catalog vends.
+  associatedtype Table: SQL.Table & ~Escapable
+
+  /// The table named `name`, or `nil` if the source has no such relation.
+  @_lifetime(borrow self)
+  borrowing func table(named name: String) -> Table?
+}
+
+// MARK: - Table
+
+/// A relation's schema and its cursor factory.
+///
+/// A `Table` knows its real column count (`width`, the extent of `SELECT *`),
+/// its `extent` (one past the highest ordinal it can address, real or virtual),
+/// resolves a column name to an ordinal (a real ordinal `< width`, or a virtual
+/// ordinal `>= width` for a computed column such as a `rowid`), and — for a
+/// column whose rows are stored in sorted order — maps a comparison value to a
+/// row boundary so the executor can seek rather than scan. `cursor()` borrows
+/// the table and hands back a cursor tied to that borrow.
+public protocol Table: ~Escapable {
+  /// The cursor this table vends over its rows.
+  associatedtype Cursor: SQL.Cursor & ~Escapable
+
+  /// The number of real columns — the extent of a `SELECT *` projection.
+  var width: Int { get }
+
+  /// One past the highest ordinal this table can address — its real `width`
+  /// plus the virtual columns it exposes.
+  ///
+  /// A relation with no virtual column has `extent == width`; one exposing a
+  /// `rowid` at `width` has `extent == width + 1`, and so on. A join lays the
+  /// inner relation immediately past the outer's `extent` so an outer virtual
+  /// column never collides with the inner's space. The default is `width` — a
+  /// relation overrides it only when it computes a virtual column.
+  var extent: Int { get }
+
+  /// The ordinal of the column named `name`, or `nil` if the relation has no
+  /// such column.
+  ///
+  /// A real column resolves to an ordinal `< width`; a virtual column — one the
+  /// `Row` computes rather than stores, such as a `rowid` — resolves to an
+  /// ordinal `>= width`.
+  func ordinal(of name: String) -> Int?
+
+  /// The boundary row for a sorted-seek over `column` against `value`, or `nil`
+  /// if the column is not seekable (the engine then scans).
+  ///
+  /// When the rows are sorted on `column`, this returns the partition point for
+  /// `value`: with `strict` false, the first row whose cell is `>= value`; with
+  /// `strict` true, the first row whose cell is `> value`. A column that is not
+  /// stored sorted returns `nil`, and the executor falls back to a scan.
+  func bound(_ column: Int, _ value: Int, strict: Bool) -> Int?
+
+  /// A cursor over the table's rows.
+  @_lifetime(borrow self)
+  borrowing func cursor() -> Cursor
+}
+
+extension Table where Self: ~Escapable {
+  /// A relation with no virtual column ends at its real `width`.
+  public var extent: Int { width }
+}
+
+// MARK: - Cursor
+
+/// An index-addressed view over a relation's rows.
+///
+/// A `~Escapable` view cannot conform to `Sequence`/`IteratorProtocol`, so the
+/// executor walks it by index — `0 ..< count`, reading `row(i)`. A row borrows
+/// the cursor and never escapes that borrow.
+public protocol Cursor: ~Escapable {
+  /// The row this cursor vends.
+  associatedtype Row: SQL.Row & ~Escapable
+
+  /// The number of rows the cursor walks.
+  var count: Int { get }
+
+  /// The row at `index`, or `nil` if `index` is out of range.
+  @_lifetime(copy self)
+  borrowing func row(_ index: Int) -> Row?
+}
+
+// MARK: - Row
+
+/// A positional view over the cells of a single row.
+///
+/// A cell is read by ordinal as a typed `Value` — the source decides whether the
+/// ordinal names an integral or a textual cell, and a virtual ordinal (one
+/// `>= Table.width`) is computed here rather than stored. The row borrows its
+/// cursor and never escapes that borrow; the `Value` it yields is owned and
+/// escapable.
+public protocol Row: ~Escapable {
+  /// The typed cell of column `column`.
+  subscript(_ column: Int) -> Value { borrowing get }
+}

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -1,0 +1,372 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+/// The query engine — the compiler, optimiser, and executor for a `SELECT`.
+///
+/// `Engine` runs a `SELECT` entirely against the adapter protocols, with no
+/// knowledge of any data source. It resolves the relation(s) through a borrowed
+/// `Catalog`, *compiles* a logical operator tree, *optimises* it into a physical
+/// one, and *executes* that. Each phase borrows the catalog: `compile`
+/// re-resolves each relation by name to a transient `~Escapable` table to read
+/// its schema (width, ordinals, the set of ordinals the query references) and
+/// emits a name-holding `Plan`; `optimise` re-resolves to read sort-key
+/// seekability and rewrites scans into seeks and the product into an
+/// index-nested-loop join; `execute` re-resolves to open cursors and
+/// materialise. A single relation compiles to `Project(Sort(Select(Scan)))`; a
+/// join compiles to a `Select` over the Cartesian `Product` of two scans, the
+/// `ON` equality folded into the `Select` predicate. Absent layers are omitted.
+/// Executing the plan yields the result records' typed values; formatting them
+/// is a client's job.
+public enum Engine {
+  /// Runs `select` against `catalog`, returning the projected, filtered, and
+  /// ordered rows as typed values.
+  ///
+  /// - Throws: `SQLError.relation` if the catalog resolves no such relation,
+  ///   `SQLError.column` if a referenced column is absent, `SQLError.ambiguous`
+  ///   if an unqualified name is resolved by both relations of a join.
+  public static func run<C: Catalog>(_ select: Select, _ catalog: borrowing C)
+      throws(SQLError) -> Array<Array<Value>> {
+    let plan = try optimise(compile(select, catalog), catalog)
+    return try execute(plan, catalog).map(\.values)
+  }
+
+  // MARK: - Compilation
+
+  /// Compiles `select` over `catalog` into a logical operator tree in slot
+  /// space.
+  ///
+  /// The relation(s) resolve through the borrowed catalog (`SQLError.relation`
+  /// on a miss). A single relation shapes `Project(Sort(Select(Scan)))`; a join
+  /// shapes `Project(Sort(Select(Product(Scan, Scan))))`, the `ON` equality
+  /// conjoined onto the `WHERE` predicate over the product. The `Select` and
+  /// `Sort` layers are present only when a predicate or an `ORDER BY` is. Each
+  /// scan carries the set of ordinals the query references on its side
+  /// (projection ∪ filter ∪ order ∪ join keys, reals and virtuals) so the
+  /// executor materialises exactly those, in a fixed order that defines a dense
+  /// SLOT for each — slot `i` is the scan's `i`th referenced ordinal.
+  ///
+  /// The operators run in slot space: `compile` remaps every ordinal it lowered
+  /// (the projection, the `filter`, the order column, and a join's keys) through
+  /// `ordinal → slot` so the records the operators address are dense arrays.
+  /// A join's combined slot space lays the outer scan's slots `[0, outerCount)`
+  /// then the inner scan's `[outerCount, outerCount + innerCount)`, matching the
+  /// merged record (outer cells ++ inner cells). The tree is logical: every scan
+  /// is a full `Scan(_, _, nil)`; the optimiser turns scans into seeks and the
+  /// product into a join.
+  internal static func compile<C: Catalog>(_ select: Select,
+                                           _ catalog: borrowing C)
+      throws(SQLError) -> Plan {
+    guard let table = catalog.table(named: select.from.name) else {
+      throw .relation(select.from.name)
+    }
+
+    guard let join = select.join else {
+      var filter: Filter? = nil
+      if let predicate = select.predicate {
+        filter = try table.lower(predicate, in: select.from)
+      }
+      var order: (column: Int, ascending: Bool)? = nil
+      if let clause = select.order {
+        order = try table.order(clause, in: select.from)
+      }
+      let projection = try table.projection(select.projection, in: select.from)
+
+      // The referenced ordinals, in slot order: slot `i` is `ordinals[i]`.
+      let ordinals = referenced(projection, filter, order)
+      let slot = invert(ordinals)
+      let scan = Plan.scan(name: select.from.name, ordinals: ordinals,
+                           seek: nil)
+      return shape(scan, projection.map { slot[$0]! },
+                   filter.map { remap($0, slot) },
+                   order.map { (slot[$0.column]!, $0.ascending) })
+    }
+
+    guard let inner = catalog.table(named: join.relation.name) else {
+      throw .relation(join.relation.name)
+    }
+
+    let scope = Scope(select.from, table, join.relation, inner)
+    let on = try scope.match(join.left, join.right)
+    var predicate: Filter? = nil
+    if let clause = select.predicate {
+      predicate = try scope.lower(clause)
+    }
+    let filter = conjoin(on, predicate)
+    var order: (column: Int, ascending: Bool)? = nil
+    if let clause = select.order {
+      order = try scope.order(clause)
+    }
+    let projection = try scope.projection(select.projection)
+    let base = scope.base
+
+    let combined = referenced(projection, filter, order)
+    let outerOrdinals = combined.filter { $0 < base }
+    let innerOrdinals = combined.filter { $0 >= base }.map { $0 - base }
+
+    // The combined slot map: the outer scan's referenced ordinals take slots
+    // `[0, outerCount)`, the inner scan's take `[outerCount, outerCount +
+    // innerCount)`, matching the merged record's outer-then-inner layout.
+    var slot = invert(outerOrdinals)
+    let split = outerOrdinals.count
+    for index in innerOrdinals.indices {
+      slot[innerOrdinals[index] + base] = split + index
+    }
+
+    let outer = Plan.scan(name: select.from.name, ordinals: outerOrdinals,
+                          seek: nil)
+    let right = Plan.scan(name: join.relation.name, ordinals: innerOrdinals,
+                          seek: nil)
+    return shape(.product(outer, right), projection.map { slot[$0]! },
+                 remap(filter, slot),
+                 order.map { (slot[$0.column]!, $0.ascending) })
+  }
+
+  /// The sorted, deduplicated ordinals a query references: the union of its
+  /// `projection`, the columns its `filter` reads, and its `order` column.
+  private static func referenced(_ projection: Array<Int>, _ filter: Filter?,
+                                 _ order: (column: Int, ascending: Bool)?)
+      -> Array<Int> {
+    var ordinals = Set(projection)
+    filter?.references(into: &ordinals)
+    if let order { ordinals.insert(order.column) }
+    return ordinals.sorted()
+  }
+
+  /// The inverse map `ordinal → slot` of a referenced-ordinal list: slot `i` is
+  /// `ordinals[i]`, so the map sends `ordinals[i]` back to `i`.
+  private static func invert(_ ordinals: Array<Int>) -> Dictionary<Int, Int> {
+    var slot = Dictionary<Int, Int>(minimumCapacity: ordinals.count)
+    for index in ordinals.indices {
+      slot[ordinals[index]] = index
+    }
+    return slot
+  }
+
+  /// `filter` with every ordinal it addresses remapped to a slot through `slot`.
+  private static func remap(_ filter: Filter, _ slot: Dictionary<Int, Int>)
+      -> Filter {
+    switch filter {
+    case let .compare(column, op, value):
+      .compare(slot[column]!, op, value)
+    case let .match(left, right):
+      .match(slot[left]!, slot[right]!)
+    case let .and(lhs, rhs):
+      .and(remap(lhs, slot), remap(rhs, slot))
+    case let .or(lhs, rhs):
+      .or(remap(lhs, slot), remap(rhs, slot))
+    case let .not(operand):
+      .not(remap(operand, slot))
+    }
+  }
+
+  /// Wraps `source` in the `Project(Sort(Select(_)))` operators, omitting the
+  /// `Select` and `Sort` layers when their clause is absent. The `projection`,
+  /// `filter`, and `order` are in slot space.
+  private static func shape(_ source: Plan, _ projection: Array<Int>,
+                            _ filter: Filter?,
+                            _ order: (slot: Int, ascending: Bool)?) -> Plan {
+    var plan = source
+    if let filter {
+      plan = .select(filter, plan)
+    }
+    if let order {
+      plan = .sort(slot: order.slot, ascending: order.ascending, plan)
+    }
+    return .project(projection, plan)
+  }
+
+  /// `on` conjoined with `predicate` when present, else `on` alone.
+  private static func conjoin(_ on: Filter, _ predicate: Filter?) -> Filter {
+    guard let predicate else { return on }
+    return .and(on, predicate)
+  }
+
+  // MARK: - Optimisation
+
+  /// Rewrites the logical `plan` into a physical one, re-resolving relations by
+  /// name through the borrowed `catalog` to read their seekability.
+  ///
+  /// Two pattern rewrites fire, the rest of the tree recursing unchanged:
+  ///
+  /// (a) **Seek.** A `Select` over a full `Scan` whose predicate (or a
+  ///     conjunct of it) is a sort-key equality or range on a seekable column
+  ///     becomes a seeked `Scan`, the remaining predicate kept as a residual
+  ///     `Select`.
+  ///
+  /// (b) **Index-nested-loop join.** A `Select` over a `Product` whose
+  ///     predicate carries a `match` conjunct relating an outer-side ordinal to
+  ///     an inner-side ordinal — the inner side a bare `Scan` — becomes a
+  ///     `Join` that seeks the inner per outer record, the remaining conjuncts
+  ///     kept as a residual `Select`. If the inner side is not a bare `Scan`,
+  ///     the product stays (a plain nested loop).
+  internal static func optimise<C: Catalog>(_ plan: Plan,
+                                            _ catalog: borrowing C)
+      throws(SQLError) -> Plan {
+    switch plan {
+    case .scan:
+      plan
+    case let .select(filter, .scan(name, ordinals, nil)):
+      try seek(filter, name, ordinals, catalog)
+    case let .select(filter, .product(left, right)):
+      try nest(filter, left, right, catalog)
+    case let .select(filter, source):
+      try .select(filter, optimise(source, catalog))
+    case let .project(ordinals, source):
+      try .project(ordinals, optimise(source, catalog))
+    case let .sort(slot, ascending, source):
+      try .sort(slot: slot, ascending: ascending, optimise(source, catalog))
+    case let .product(left, right):
+      try .product(optimise(left, catalog), optimise(right, catalog))
+    case .join:
+      plan
+    }
+  }
+
+  // MARK: - Physical seek
+
+  /// Rewrites `Select(filter, Scan(name, ordinals, nil))` into a seeked scan
+  /// when a sort-key conjunct qualifies, else leaves the full scan under the
+  /// filter. The relation re-resolves through `catalog` to read its boundaries.
+  ///
+  /// A standalone qualifying comparison seeks its run and admits all of it (no
+  /// residual). An `AND` with one qualifying conjunct seeks that run and keeps
+  /// the other as the residual `Select`. Everything else scans under the whole
+  /// filter. The `filter` is in slot space, so a comparison's slot maps back to
+  /// its table ordinal through the scan's `ordinals` before reading a boundary.
+  private static func seek<C: Catalog>(_ filter: Filter, _ name: String,
+                                       _ ordinals: Array<Int>,
+                                       _ catalog: borrowing C)
+      throws(SQLError) -> Plan {
+    guard let table = catalog.table(named: name) else { throw .relation(name) }
+    let count = table.cursor().count
+
+    if let range = boundaries(filter, ordinals, table, count) {
+      return .scan(name: name, ordinals: ordinals, seek: range)
+    }
+
+    if case let .and(lhs, rhs) = filter {
+      if let range = boundaries(lhs, ordinals, table, count) {
+        return .select(rhs, .scan(name: name, ordinals: ordinals, seek: range))
+      }
+      if let range = boundaries(rhs, ordinals, table, count) {
+        return .select(lhs, .scan(name: name, ordinals: ordinals, seek: range))
+      }
+    }
+
+    return .select(filter, .scan(name: name, ordinals: ordinals, seek: nil))
+  }
+
+  /// The boundaries `[lower, upper)` to seek for a sort-key comparison, or `nil`
+  /// if `filter` does not qualify for the seek path.
+  ///
+  /// It qualifies when `filter` is a `compare` whose operand is an `integer`,
+  /// the operator is an equality or a range, and `table.bound` reports the
+  /// column seekable (a non-`nil` boundary). The comparison's slot maps back to
+  /// its table ordinal through `ordinals` (slot `i` is `ordinals[i]`) for the
+  /// `bound` query. A `string` operand or an unseekable column never qualifies,
+  /// and the executor scans.
+  private static func boundaries<T: Table & ~Escapable>(
+      _ filter: Filter, _ ordinals: Array<Int>, _ table: borrowing T,
+      _ count: Int) -> Range<Int>? {
+    guard case let .compare(slot, op, .integer(value)) = filter,
+        let lower = table.bound(ordinals[slot], value, strict: false),
+        let upper = table.bound(ordinals[slot], value, strict: true) else {
+      return nil
+    }
+
+    return switch op {
+    case .equal: lower ..< upper
+    case .lt: 0 ..< lower
+    case .leq: 0 ..< upper
+    case .gt: upper ..< count
+    case .geq: lower ..< count
+    case .unequal: nil   // a split run is two scans; let the scan handle it
+    }
+  }
+
+  // MARK: - Physical join
+
+  /// Rewrites `Select(filter, Product(left, Scan(inner, _, nil)))` into an
+  /// index-nested-loop `Join` when a `match` conjunct relates the two sides,
+  /// else leaves the product (a plain nested loop) under the filter.
+  ///
+  /// The left side's slot count is the boundary `base` in the combined slot
+  /// space: a slot below it is an outer-side key, a slot at or above it an
+  /// inner-side key (still in combined space). The inner key's slot maps to its
+  /// table ordinal (`column`) through the inner scan's `ordinals` for the seek's
+  /// `bound`. The matching conjunct is consumed; any remaining conjuncts stay as
+  /// a residual `Select`. When the inner side is not a bare `Scan`, the product
+  /// is preserved.
+  private static func nest<C: Catalog>(_ filter: Filter, _ left: Plan,
+                                       _ right: Plan, _ catalog: borrowing C)
+      throws(SQLError) -> Plan {
+    guard case let .scan(name, ordinals, nil) = right,
+        let base = slots(left) else {
+      return try .select(filter, .product(optimise(left, catalog),
+                                          optimise(right, catalog)))
+    }
+
+    let conjuncts = flatten(filter)
+    for index in conjuncts.indices {
+      guard case let .match(lhs, rhs) = conjuncts[index],
+          let (leftKey, rightKey) = keys(lhs, rhs, base) else {
+        continue
+      }
+
+      var residual = conjuncts
+      residual.remove(at: index)
+      let join = try Plan.join(optimise(left, catalog), name: name,
+                               ordinals: ordinals, base: base,
+                               column: ordinals[rightKey - base],
+                               keys: (left: leftKey, right: rightKey))
+      guard let predicate = rebuild(residual) else { return join }
+      return .select(predicate, join)
+    }
+
+    return try .select(filter, .product(optimise(left, catalog),
+                                        optimise(right, catalog)))
+  }
+
+  /// The `(outerKey, innerKey)` an equality between slots `lhs` and `rhs`
+  /// relates across the boundary `base`, or `nil` if both fall on one side.
+  ///
+  /// Exactly one slot must be below `base` (the outer key) and the other at or
+  /// above it (the inner key, still in combined space); the order the equality
+  /// was written in does not matter.
+  private static func keys(_ lhs: Int, _ rhs: Int, _ base: Int)
+      -> (outer: Int, inner: Int)? {
+    switch (lhs < base, rhs < base) {
+    case (true, false): (lhs, rhs)
+    case (false, true): (rhs, lhs)
+    default: nil
+    }
+  }
+
+  /// The slot count of `plan`'s left-side scan — the outer relation's slots,
+  /// the boundary past which inner slots begin in the combined space — or `nil`
+  /// if the side is not a scan the boundary reads from.
+  private static func slots(_ plan: Plan) -> Int? {
+    switch plan {
+    case let .scan(_, ordinals, _):
+      ordinals.count
+    case let .select(_, source):
+      slots(source)
+    default:
+      nil
+    }
+  }
+
+  // MARK: - Conjunct algebra
+
+  /// The flat list of `AND`-conjuncts of `filter` (a non-`and` is a singleton).
+  private static func flatten(_ filter: Filter) -> Array<Filter> {
+    guard case let .and(lhs, rhs) = filter else { return [filter] }
+    return flatten(lhs) + flatten(rhs)
+  }
+
+  /// The right-leaning `AND` of `conjuncts`, or `nil` for an empty list.
+  private static func rebuild(_ conjuncts: Array<Filter>) -> Filter? {
+    guard let last = conjuncts.last else { return nil }
+    return conjuncts.dropLast().reversed().reduce(last) { .and($1, $0) }
+  }
+}

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -24,7 +24,8 @@ public enum Engine {
   /// - Throws: `SQLError.relation` if the catalog resolves no such relation,
   ///   `SQLError.column` if a referenced column is absent, `SQLError.ambiguous`
   ///   if an unqualified name is resolved by both relations of a join.
-  public static func run<C: Catalog>(_ select: Select, _ catalog: borrowing C)
+  public static func run<C: Catalog & ~Escapable>(_ select: Select,
+                                                  _ catalog: borrowing C)
       throws(SQLError) -> Array<Array<Value>> {
     let plan = try optimise(compile(select, catalog), catalog)
     return try execute(plan, catalog).map(\.values)
@@ -53,8 +54,8 @@ public enum Engine {
   /// merged record (outer cells ++ inner cells). The tree is logical: every scan
   /// is a full `Scan(_, _, nil)`; the optimiser turns scans into seeks and the
   /// product into a join.
-  internal static func compile<C: Catalog>(_ select: Select,
-                                           _ catalog: borrowing C)
+  internal static func compile<C: Catalog & ~Escapable>(_ select: Select,
+                                                        _ catalog: borrowing C)
       throws(SQLError) -> Plan {
     guard let table = catalog.table(named: select.from.name) else {
       throw .relation(select.from.name)
@@ -199,8 +200,8 @@ public enum Engine {
   ///     `Join` that seeks the inner per outer record, the remaining conjuncts
   ///     kept as a residual `Select`. If the inner side is not a bare `Scan`,
   ///     the product stays (a plain nested loop).
-  internal static func optimise<C: Catalog>(_ plan: Plan,
-                                            _ catalog: borrowing C)
+  internal static func optimise<C: Catalog & ~Escapable>(_ plan: Plan,
+                                                         _ catalog: borrowing C)
       throws(SQLError) -> Plan {
     switch plan {
     case .scan:
@@ -233,9 +234,10 @@ public enum Engine {
   /// the other as the residual `Select`. Everything else scans under the whole
   /// filter. The `filter` is in slot space, so a comparison's slot maps back to
   /// its table ordinal through the scan's `ordinals` before reading a boundary.
-  private static func seek<C: Catalog>(_ filter: Filter, _ name: String,
-                                       _ ordinals: Array<Int>,
-                                       _ catalog: borrowing C)
+  private static func seek<C: Catalog & ~Escapable>(_ filter: Filter,
+                                                    _ name: String,
+                                                    _ ordinals: Array<Int>,
+                                                    _ catalog: borrowing C)
       throws(SQLError) -> Plan {
     guard let table = catalog.table(named: name) else { throw .relation(name) }
     let count = table.cursor().count
@@ -297,8 +299,10 @@ public enum Engine {
   /// `bound`. The matching conjunct is consumed; any remaining conjuncts stay as
   /// a residual `Select`. When the inner side is not a bare `Scan`, the product
   /// is preserved.
-  private static func nest<C: Catalog>(_ filter: Filter, _ left: Plan,
-                                       _ right: Plan, _ catalog: borrowing C)
+  private static func nest<C: Catalog & ~Escapable>(_ filter: Filter,
+                                                    _ left: Plan,
+                                                    _ right: Plan,
+                                                    _ catalog: borrowing C)
       throws(SQLError) -> Plan {
     guard case let .scan(name, ordinals, nil) = right,
         let base = slots(left) else {

--- a/Sources/SQL/Error.swift
+++ b/Sources/SQL/Error.swift
@@ -1,0 +1,69 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+/// A position in the query text.
+///
+/// `line` and `column` are 1-based, counting from the start of the input; the
+/// lexer advances the column per byte and starts a fresh line on each newline.
+/// `offset` is the zero-based byte index of the same position, retained for
+/// consumers that index the raw buffer.
+public struct SourceLocation: Hashable, Sendable {
+  /// The 1-based line number.
+  public let line: Int
+
+  /// The 1-based column number.
+  public let column: Int
+
+  /// The zero-based byte offset into the query text.
+  public let offset: Int
+
+  public init(line: Int, column: Int, offset: Int) {
+    self.line = line
+    self.column = column
+    self.offset = offset
+  }
+}
+
+extension SourceLocation: CustomStringConvertible {
+  public var description: String {
+    "\(line):\(column)"
+  }
+}
+
+/// A lexer or parser diagnostic.
+///
+/// Most cases carry the `SourceLocation` at which the fault was detected, so a
+/// consumer can point at the offending span.
+public enum SQLError: Error, Hashable, Sendable {
+  /// A character that begins no valid token.
+  case character(Character, at: SourceLocation)
+  /// A string literal whose closing quote is missing.
+  case unterminated(at: SourceLocation)
+  /// An integer literal that does not fit the platform `Int`.
+  case overflow(String, at: SourceLocation)
+  /// A token of a kind other than the one the grammar requires here.
+  case unexpected(String, expected: String, at: SourceLocation)
+  /// The end of the input was reached while a token was still required.
+  case incomplete(expected: String)
+  /// Tokens remain after a complete statement was parsed.
+  case trailing(at: SourceLocation)
+}
+
+extension SQLError: CustomStringConvertible {
+  public var description: String {
+    switch self {
+    case let .character(character, location):
+      "unexpected character '\(character)' at \(location)"
+    case let .unterminated(location):
+      "unterminated string literal at \(location)"
+    case let .overflow(text, location):
+      "integer literal '\(text)' out of range at \(location)"
+    case let .unexpected(found, expected, location):
+      "expected \(expected) but found '\(found)' at \(location)"
+    case let .incomplete(expected):
+      "expected \(expected) but reached end of input"
+    case let .trailing(location):
+      "unexpected trailing input at \(location)"
+    }
+  }
+}

--- a/Sources/SQL/Error.swift
+++ b/Sources/SQL/Error.swift
@@ -47,6 +47,12 @@ public enum SQLError: Error, Hashable, Sendable {
   case incomplete(expected: String)
   /// Tokens remain after a complete statement was parsed.
   case trailing(at: SourceLocation)
+  /// A statement names a relation the catalog does not resolve.
+  case relation(String)
+  /// A statement names a column the relation does not resolve.
+  case column(String)
+  /// A statement names an unqualified column both joined relations resolve.
+  case ambiguous(String)
 }
 
 extension SQLError: CustomStringConvertible {
@@ -64,6 +70,12 @@ extension SQLError: CustomStringConvertible {
       "expected \(expected) but reached end of input"
     case let .trailing(location):
       "unexpected trailing input at \(location)"
+    case let .relation(name):
+      "no such relation '\(name)'"
+    case let .column(name):
+      "no such column '\(name)'"
+    case let .ambiguous(name):
+      "ambiguous column '\(name)'"
     }
   }
 }

--- a/Sources/SQL/Filter.swift
+++ b/Sources/SQL/Filter.swift
@@ -1,0 +1,80 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+/// The engine's ordinal-addressed row filter.
+///
+/// `Filter` is the lowered form of the AST's name-addressed `Predicate`: a tree
+/// of comparisons composed with `AND`, `OR`, and `NOT`, with every column
+/// resolved to an ordinal once. It reuses the AST's `Comparison` and `Literal`
+/// — those are general — and addresses columns by `Int` so the executor can
+/// inspect it (to seek a sorted column) before running it. The filter is fully
+/// escapable; the `~Escapable` row it reads materialises only transiently at
+/// evaluation.
+internal indirect enum Filter {
+  /// `column <op> value`, the column addressed by ordinal.
+  case compare(Int, Comparison, Literal)
+  /// `left = right`, both columns addressed by ordinal — a join's `ON`
+  /// equality, lowered as a conjunct of the product's `Select` predicate.
+  case match(Int, Int)
+  /// `lhs AND rhs`.
+  case and(Filter, Filter)
+  /// `lhs OR rhs`.
+  case or(Filter, Filter)
+  /// `NOT operand`.
+  case not(Filter)
+}
+
+// MARK: - Evaluation
+
+extension Comparison {
+  /// Applies the operator to two comparable operands.
+  internal func apply<T: Comparable>(_ lhs: T, _ rhs: T) -> Bool {
+    switch self {
+    case .equal: lhs == rhs
+    case .unequal: lhs != rhs
+    case .lt: lhs < rhs
+    case .gt: lhs > rhs
+    case .leq: lhs <= rhs
+    case .geq: lhs >= rhs
+    }
+  }
+}
+
+/// Matches a typed cell `value` against a `literal` under operator `op`.
+///
+/// A like-typed pair compares — an integral cell against an `integer` literal, a
+/// textual cell against a `string` literal; a cross-typed pair (a textual cell
+/// against an integer literal, or the reverse) never matches.
+private func matches(_ value: Value, _ op: Comparison, _ literal: Literal)
+    -> Bool {
+  switch (value, literal) {
+  case let (.integer(lhs), .integer(rhs)): op.apply(lhs, rhs)
+  case let (.text(lhs), .string(rhs)): op.apply(lhs, rhs)
+  default: false
+  }
+}
+
+/// Evaluates `filter` against `row`.
+///
+/// A `compare` reads the addressed cell as a typed `Value` and matches it
+/// against the literal; a `match` reads both cells and tests them equal; the
+/// boolean connectives recurse. The `borrowing` row is non-escaping; it threads
+/// into the recursion freely and is never stored.
+internal func evaluate<R: Row & ~Escapable>(_ filter: Filter,
+                                            _ row: borrowing R) -> Bool {
+  switch filter {
+  case let .compare(column, op, value):
+    matches(row[column], op, value)
+  case let .match(left, right):
+    row[left] == row[right]
+  case let .and(lhs, rhs):
+    // `&&`/`||` take an `@autoclosure` right operand, which would capture the
+    // borrowed `~Escapable` row; spell the short-circuit explicitly so each
+    // branch re-borrows the row rather than capturing it.
+    if evaluate(lhs, row) { evaluate(rhs, row) } else { false }
+  case let .or(lhs, rhs):
+    if evaluate(lhs, row) { true } else { evaluate(rhs, row) }
+  case let .not(operand):
+    !evaluate(operand, row)
+  }
+}

--- a/Sources/SQL/Lexer.swift
+++ b/Sources/SQL/Lexer.swift
@@ -1,0 +1,262 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+// MARK: - Byte classes
+
+// Each class is a 128-bit set of the ASCII bytes it admits, so membership is a
+// single shift-and-test. A non-ASCII byte (>= 128) shifts past the width and
+// reads as 0 — not a member — so no range check is needed.
+
+/// Whether `byte` is ASCII whitespace: tab, newline, carriage return, space.
+private func whitespace(_ byte: UInt8) -> Bool {
+  let mask: UInt128 = 0x0000_0000_0000_0000_0000_0001_0000_2600
+  return mask & (1 << UInt128(byte)) != 0
+}
+
+/// Whether `byte` is an ASCII decimal digit, `0`–`9`.
+private func digit(_ byte: UInt8) -> Bool {
+  let mask: UInt128 = 0x0000_0000_0000_0000_03ff_0000_0000_0000
+  return mask & (1 << UInt128(byte)) != 0
+}
+
+/// Whether `byte` may begin an identifier: an ASCII letter or `_`.
+private func initial(_ byte: UInt8) -> Bool {
+  let mask: UInt128 = 0x07ff_fffe_87ff_fffe_0000_0000_0000_0000
+  return mask & (1 << UInt128(byte)) != 0
+}
+
+/// Whether `byte` may continue an identifier: a letter, digit, `_`, or `.`.
+private func continuation(_ byte: UInt8) -> Bool {
+  let mask: UInt128 = 0x07ff_fffe_87ff_fffe_03ff_4000_0000_0000
+  return mask & (1 << UInt128(byte)) != 0
+}
+
+// MARK: - String
+
+extension String {
+  /// Decodes `range` of `bytes` as UTF-8 into a `String`.
+  ///
+  /// The lexer's payloads are ASCII spans of the borrowed input; this copies
+  /// the bytes out into an owned `String` that may outlive the borrow.
+  fileprivate init(_ bytes: borrowing Span<UInt8>, _ range: Range<Int>) {
+    self = bytes.extracting(range).withUnsafeBytes {
+      String(decoding: $0, as: UTF8.self)
+    }
+  }
+}
+
+/// Scans SQL text into a stream of `Token`s, one at a time.
+///
+/// The lexer is single-pass over the source bytes. SQL is ASCII, so the lexer
+/// scans the input's UTF-8 bytes by value and compares them against ASCII byte
+/// constants. Whitespace separates tokens and is otherwise discarded; keywords
+/// are recognised case-insensitively; string literals are single-quoted with
+/// `''` as an escaped quote.
+///
+/// The lexer tracks a `SourceLocation` as it scans — advancing the column per
+/// byte and starting a fresh line on each newline — so every token and fault
+/// knows where it is.
+///
+/// The bytes are borrowed for the lexer's lifetime: the `Span<UInt8>` keeps the
+/// lexer tied to the storage it scans (`Statement(parsing:)` drives the lexer
+/// over the input string's UTF-8 span). No token escapes the borrow — the
+/// identifier and literal payloads are copied out into `String`s.
+internal struct Lexer: ~Escapable {
+  private let bytes: Span<UInt8>
+  private var position: Int
+  private var line: Int
+  private var column: Int
+
+  @_lifetime(copy bytes)
+  internal init(_ bytes: Span<UInt8>) {
+    self.bytes = bytes
+    self.position = 0
+    self.line = 1
+    self.column = 1
+  }
+
+  // MARK: - Stream
+
+  /// Scans and returns the next token, or `nil` once the input is exhausted.
+  internal mutating func next() throws(SQLError) -> Token? {
+    trivia()
+
+    guard let byte = peek() else { return nil }
+
+    switch byte {
+    case UInt8(ascii: "*"):
+      return punctuation(.star)
+    case UInt8(ascii: ","):
+      return punctuation(.comma)
+    case UInt8(ascii: "("):
+      return punctuation(.lparen)
+    case UInt8(ascii: ")"):
+      return punctuation(.rparen)
+    case UInt8(ascii: "="):
+      return punctuation(.equal)
+
+    case UInt8(ascii: "<"):
+      let start = location
+      advance()
+      switch peek() {
+      case UInt8(ascii: ">"):
+        advance()
+        return Token(kind: .unequal, location: start)
+      case UInt8(ascii: "="):
+        advance()
+        return Token(kind: .leq, location: start)
+      default:
+        return Token(kind: .lt, location: start)
+      }
+
+    case UInt8(ascii: ">"):
+      let start = location
+      advance()
+      switch peek() {
+      case UInt8(ascii: "="):
+        advance()
+        return Token(kind: .geq, location: start)
+      default:
+        return Token(kind: .gt, location: start)
+      }
+
+    case UInt8(ascii: "'"):
+      return try string()
+
+    case let b where digit(b):
+      return try integer()
+
+    case let b where initial(b):
+      return identifier()
+
+    default:
+      throw .character(Character(UnicodeScalar(byte)), at: location)
+    }
+  }
+
+  // MARK: - Scanners
+
+  /// Consumes a single-byte punctuation or operator token of `kind`.
+  private mutating func punctuation(_ kind: Token.Kind) -> Token {
+    let token = Token(kind: kind, location: location)
+    advance()
+    return token
+  }
+
+  /// Scans a single-quoted string literal at the current position.
+  ///
+  /// A doubled quote `''` is an escaped quote; the closing quote ends the
+  /// literal. Faults if the literal is never closed.
+  private mutating func string() throws(SQLError) -> Token {
+    let start = location
+    advance()
+    let begin = position
+
+    // The common literal is a contiguous run of bytes; only a doubled quote
+    // forces the text to be assembled from segments, so defer that until one
+    // appears and otherwise materialise the whole range at the close.
+    var value: String? = nil
+    var segment = position
+    while let byte = peek() {
+      switch byte {
+      case UInt8(ascii: "'") where peek(1) == UInt8(ascii: "'"):
+        value = (value ?? "") + String(bytes, segment ..< position) + "'"
+        advance()
+        advance()
+        segment = position
+      case UInt8(ascii: "'"):
+        let text = if let value {
+          value + String(bytes, segment ..< position)
+        } else {
+          String(bytes, begin ..< position)
+        }
+        advance()
+        return Token(kind: .string(text), location: start)
+      default:
+        advance()
+      }
+    }
+
+    throw .unterminated(at: start)
+  }
+
+  /// Scans an integer literal at the current position.
+  private mutating func integer() throws(SQLError) -> Token {
+    let start = location
+    while let byte = peek(), digit(byte) {
+      advance()
+    }
+
+    let text = String(bytes, start.offset ..< position)
+    guard let value = Int(text) else {
+      throw .overflow(text, at: start)
+    }
+    return Token(kind: .integer(value), location: start)
+  }
+
+  /// Scans an identifier or keyword at the current position.
+  ///
+  /// Identifier bytes are letters, digits, `_`, and `.`. The scanned text is
+  /// matched case-insensitively against the keyword spellings; anything else is
+  /// an identifier.
+  private mutating func identifier() -> Token {
+    let start = location
+    while let byte = peek(), continuation(byte) {
+      advance()
+    }
+
+    let text = String(bytes, start.offset ..< position)
+    let kind: Token.Kind = switch text.uppercased() {
+    case "SELECT": .select
+    case "FROM": .from
+    case "WHERE": .where
+    case "ORDER": .order
+    case "BY": .by
+    case "ASC": .asc
+    case "DESC": .desc
+    case "AND": .and
+    case "OR": .or
+    case "NOT": .not
+    case "JOIN": .join
+    case "ON": .on
+    case "AS": .as
+    default: .identifier(text)
+    }
+    return Token(kind: kind, location: start)
+  }
+
+  // MARK: - Cursor
+
+  /// The `SourceLocation` of the cursor.
+  private var location: SourceLocation {
+    SourceLocation(line: line, column: column, offset: position)
+  }
+
+  /// Consumes the byte under the cursor, tracking line and column.
+  private mutating func advance() {
+    switch peek() {
+    case UInt8(ascii: "\n"):
+      line += 1
+      column = 1
+    case .some:
+      column += 1
+    case nil:
+      break
+    }
+    position += 1
+  }
+
+  /// Advances past any run of insignificant bytes (whitespace, and in time
+  /// comments) separating tokens.
+  private mutating func trivia() {
+    while let byte = peek(), whitespace(byte) {
+      advance()
+    }
+  }
+
+  /// The byte `offset` positions ahead of the cursor, or `nil` past the end.
+  private func peek(_ offset: Int = 0) -> UInt8? {
+    let index = position + offset
+    return index < bytes.count ? bytes[index] : nil
+  }
+}

--- a/Sources/SQL/Operator.swift
+++ b/Sources/SQL/Operator.swift
@@ -133,7 +133,8 @@ internal indirect enum Plan {
 /// outer record with every inner one; `join` re-resolves the inner relation,
 /// seeks it per outer record, and concatenates the matches. The catalog is
 /// borrowed throughout — a `~Escapable` source is never copied or stored.
-internal func execute<C: Catalog>(_ plan: Plan, _ catalog: borrowing C)
+internal func execute<C: Catalog & ~Escapable>(_ plan: Plan,
+                                               _ catalog: borrowing C)
     throws(SQLError) -> Array<Record> {
   switch plan {
   case let .scan(name, ordinals, seek):
@@ -167,9 +168,10 @@ internal func execute<C: Catalog>(_ plan: Plan, _ catalog: borrowing C)
 /// `nil`) into dense slot `Record`s.
 ///
 /// - Throws: `SQLError.relation` if the name no longer resolves.
-private func materialise<C: Catalog>(_ name: String, _ ordinals: Array<Int>,
-                                     _ seek: Range<Int>?,
-                                     _ catalog: borrowing C)
+private func materialise<C: Catalog & ~Escapable>(_ name: String,
+                                                  _ ordinals: Array<Int>,
+                                                  _ seek: Range<Int>?,
+                                                  _ catalog: borrowing C)
     throws(SQLError) -> Array<Record> {
   guard let table = catalog.table(named: name) else { throw .relation(name) }
   let cursor = table.cursor()
@@ -209,10 +211,12 @@ private func product(_ outer: Array<Record>, _ inner: Array<Record>)
 /// landing at `base` in the combined space).
 ///
 /// - Throws: `SQLError.relation` if the inner name no longer resolves.
-private func join<C: Catalog>(_ outer: Array<Record>, _ name: String,
-                              _ ordinals: Array<Int>, _ base: Int,
-                              _ column: Int, _ keys: (left: Int, right: Int),
-                              _ catalog: borrowing C)
+private func join<C: Catalog & ~Escapable>(_ outer: Array<Record>,
+                                           _ name: String,
+                                           _ ordinals: Array<Int>, _ base: Int,
+                                           _ column: Int,
+                                           _ keys: (left: Int, right: Int),
+                                           _ catalog: borrowing C)
     throws(SQLError) -> Array<Record> {
   guard let inner = catalog.table(named: name) else { throw .relation(name) }
   let cursor = inner.cursor()

--- a/Sources/SQL/Operator.swift
+++ b/Sources/SQL/Operator.swift
@@ -1,0 +1,259 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+/// The relational operator algebra — the engine's execution layer.
+///
+/// The `~Escapable` adapter is the storage layer: a `Cursor` vends borrowed
+/// `Row` views that never escape the borrow, and a `Table`/`Catalog` is itself
+/// `~Escapable`. The operator algebra runs on *materialised* tuples, so a
+/// dynamic operator tree can carry a uniform tuple type rather than a
+/// heterogeneous static one. A `Record` is that uniform tuple — an escapable,
+/// slot-indexed row the adapter's borrowed cells are copied into at a leaf.
+///
+/// The plan is *escapable and name-holding*: a `Plan` references each relation
+/// by its catalog NAME rather than by a `~Escapable` `Table` (an `indirect enum`
+/// cannot box a `~Escapable` payload), and carries the ordinals the query
+/// actually reads from it. The executor re-resolves a name to a transient table,
+/// opens its cursor, and materialises *only the referenced ordinals* into a
+/// dense slot array — reals out of the cursor, virtuals (ordinals `>= width`)
+/// computed by the `Row`. Slot `i` of the record holds the cell of the scan's
+/// `i`th referenced ordinal; the operators address slots, never ordinals, so a
+/// record is a dense `Array<Value>` with no gaps and no per-row hashing.
+
+// MARK: - Record
+
+/// A materialised tuple: the uniform row flowing through the operators.
+///
+/// A `Record` copies an adapter `Row`'s referenced cells out into an escapable,
+/// dense slot array, so it conforms to `SQL.Row` (cell-by-slot access) while
+/// being free of the borrowed cursor's lifetime. A scan's referenced-ordinal
+/// list (in a fixed order) defines a slot for each — slot `i` is that scan's
+/// `i`th referenced ordinal — so the engine remaps every ordinal to a slot at
+/// compile time and the record is addressed purely by array index: no
+/// dictionary, no hashing, no per-row key sort. A projection-pushdown leaf, a
+/// virtual column, and a join's two relations laid end to end all live as
+/// consecutive slots under the one accessor the existing `evaluate(_:_:)` and
+/// the projection read through.
+internal struct Record: Row, Hashable {
+  /// The tuple's cells, in slot order.
+  private let cells: Array<Value>
+
+  /// Wraps a slot-ordered array of cells as a record.
+  internal init(_ cells: Array<Value>) {
+    self.cells = cells
+  }
+
+  /// Materialises a record from an adapter `row`, copying exactly the
+  /// `ordinals` the query references into dense slots `0 ..< ordinals.count` —
+  /// slot `i` is `row[ordinals[i]]`.
+  ///
+  /// Reading `row[ordinal]` yields a real cell for an ordinal `< width` and a
+  /// computed cell for a virtual ordinal. A single relation's record and a
+  /// join's inner record are both built this way; the join lays the inner's
+  /// slots after the outer's by concatenating the two records.
+  internal init<R: Row & ~Escapable>(_ row: borrowing R,
+                                     _ ordinals: Array<Int>) {
+    var cells = Array<Value>()
+    cells.reserveCapacity(ordinals.count)
+    for ordinal in ordinals {
+      cells.append(row[ordinal])
+    }
+    self.cells = cells
+  }
+
+  internal subscript(_ slot: Int) -> Value {
+    borrowing get { cells[slot] }
+  }
+
+  /// The projection of `slots` re-laid as slots `0 ..< count`, in the order
+  /// given — the record the `project` operator yields.
+  internal func project(_ slots: Array<Int>) -> Record {
+    Record(slots.map { cells[$0] })
+  }
+
+  /// The cells in slot order — the projected row a client reads.
+  internal var values: Array<Value> {
+    cells
+  }
+
+  /// The concatenation of this record with `other`, their two slot spaces laid
+  /// end to end (outer slots then inner slots) — a join or product's combined
+  /// tuple.
+  internal func merged(with other: Record) -> Record {
+    Record(cells + other.cells)
+  }
+}
+
+// MARK: - Plan
+
+/// An escapable, name-holding relational operator tree.
+///
+/// Every relation a `SELECT` names is held by its catalog NAME, not by a
+/// `~Escapable` `Table`, so the whole tree is a plain escapable `indirect enum`.
+/// The leaf `scan` carries the relation name, the ordinals the query reads from
+/// it (reals and virtuals, in materialisation order — the order that defines the
+/// scan's slots), and an optional seek — the row range to read. The unary
+/// operators wrap a sub-plan: `select` keeps the records a `Filter` admits,
+/// `project` restricts and reorders to the projected slots, and `sort` orders by
+/// a typed key on a slot. `product` is the Cartesian product of two sub-plans
+/// (records merged); `join` is the index-nested-loop equi-join that seeks the
+/// inner relation per outer record rather than forming the product, the inner
+/// named and its referenced ordinals carried for the executor to re-resolve and
+/// materialise.
+internal indirect enum Plan {
+  /// A leaf over the relation `name`: its `ordinals` (defining its slots), over
+  /// the seek's row range when present (else the whole relation).
+  case scan(name: String, ordinals: Array<Int>, seek: Range<Int>?)
+  /// σ — keeps the records `Filter` admits, the filter in slot space.
+  case select(Filter, Plan)
+  /// π — restricts and reorders each record to the projected slots.
+  case project(Array<Int>, Plan)
+  /// τ — orders the records by a typed key on `slot`.
+  case sort(slot: Int, ascending: Bool, Plan)
+  /// × — every concatenation of an outer record with an inner one.
+  case product(Plan, Plan)
+  /// ⋈ — for each outer record, seeks the inner relation `name` on
+  /// `keys.right == outer[keys.left]` and concatenates each match. `keys.left`
+  /// and `keys.right` are combined-space slots, `base` the inner's first slot
+  /// in that combined space, and `column` the inner ordinal `keys.right` reads
+  /// (for the seek `bound`).
+  case join(Plan, name: String, ordinals: Array<Int>, base: Int,
+            column: Int, keys: (left: Int, right: Int))
+}
+
+// MARK: - Interpreter
+
+/// Interprets `plan` against `catalog`, producing its result records.
+///
+/// Each operator transforms the records its sub-plan yields: `scan` re-resolves
+/// the relation by name, opens its cursor, and materialises its referenced
+/// ordinals over the seek range into dense slots; `select` keeps the admitted
+/// records; `project` rebuilds each from the projected slots; `sort` orders them
+/// by a typed key, stably and in the requested direction; `product` pairs every
+/// outer record with every inner one; `join` re-resolves the inner relation,
+/// seeks it per outer record, and concatenates the matches. The catalog is
+/// borrowed throughout — a `~Escapable` source is never copied or stored.
+internal func execute<C: Catalog>(_ plan: Plan, _ catalog: borrowing C)
+    throws(SQLError) -> Array<Record> {
+  switch plan {
+  case let .scan(name, ordinals, seek):
+    try materialise(name, ordinals, seek, catalog)
+  case let .select(filter, source):
+    try execute(source, catalog).filter { evaluate(filter, $0) }
+  case let .project(slots, source):
+    try execute(source, catalog).map { $0.project(slots) }
+  case let .sort(slot, ascending, source):
+    try execute(source, catalog)
+      .enumerated()
+      .sorted { lhs, rhs in
+        let ordered = less(lhs.element[slot], rhs.element[slot])
+        let reverse = less(rhs.element[slot], lhs.element[slot])
+        // A stable sort: keep the source order within an equal-key group by
+        // tie-breaking on the original index.
+        if ordered == reverse { return lhs.offset < rhs.offset }
+        return ascending ? ordered : reverse
+      }
+      .map(\.element)
+  case let .product(outer, inner):
+    try product(execute(outer, catalog), execute(inner, catalog))
+  case let .join(outer, name, ordinals, base, column, keys):
+    try join(execute(outer, catalog), name, ordinals, base, column, keys,
+             catalog)
+  }
+}
+
+/// Re-resolves `name` against `catalog`, opens its cursor, and materialises the
+/// referenced `ordinals` of the seek's row range (the whole relation when
+/// `nil`) into dense slot `Record`s.
+///
+/// - Throws: `SQLError.relation` if the name no longer resolves.
+private func materialise<C: Catalog>(_ name: String, _ ordinals: Array<Int>,
+                                     _ seek: Range<Int>?,
+                                     _ catalog: borrowing C)
+    throws(SQLError) -> Array<Record> {
+  guard let table = catalog.table(named: name) else { throw .relation(name) }
+  let cursor = table.cursor()
+  var records = Array<Record>()
+  for index in seek ?? 0 ..< cursor.count {
+    guard let row = cursor.row(index) else { continue }
+    records.append(Record(row, ordinals))
+  }
+  return records
+}
+
+/// The Cartesian product of two materialised relations: every concatenation of
+/// an `outer` record with an `inner` one, in outer-major order.
+private func product(_ outer: Array<Record>, _ inner: Array<Record>)
+    -> Array<Record> {
+  var records = Array<Record>()
+  records.reserveCapacity(outer.count * inner.count)
+  for left in outer {
+    for right in inner {
+      records.append(left.merged(with: right))
+    }
+  }
+  return records
+}
+
+/// The index-nested-loop equi-join of `outer` against the inner relation `name`.
+///
+/// The inner relation is re-resolved through `catalog`. For each outer record,
+/// the value at slot `keys.left` is the probe. When that value is an integer
+/// and the inner reports `column` (the inner ordinal `keys.right` reads)
+/// seekable, the inner is seeked to its `[lower, upper)` run; otherwise the
+/// whole inner is scanned. Each candidate is materialised over the referenced
+/// `ordinals` into inner slots `0 ..< ordinals.count`, then re-tested for the
+/// inner's `keys.right` slot — `keys.right - base` in the standalone inner
+/// record — equal to `value`, the seek narrowing the scan but the equality
+/// being the join's truth, and a match is concatenated (the inner's slots
+/// landing at `base` in the combined space).
+///
+/// - Throws: `SQLError.relation` if the inner name no longer resolves.
+private func join<C: Catalog>(_ outer: Array<Record>, _ name: String,
+                              _ ordinals: Array<Int>, _ base: Int,
+                              _ column: Int, _ keys: (left: Int, right: Int),
+                              _ catalog: borrowing C)
+    throws(SQLError) -> Array<Record> {
+  guard let inner = catalog.table(named: name) else { throw .relation(name) }
+  let cursor = inner.cursor()
+  let slot = keys.right - base
+  var records = Array<Record>()
+  for left in outer {
+    let value = left[keys.left]
+    let range = probe(inner, column, value, cursor.count)
+    for index in range {
+      guard let row = cursor.row(index) else { continue }
+      let right = Record(row, ordinals)
+      if right[slot] == value {
+        records.append(left.merged(with: right))
+      }
+    }
+  }
+  return records
+}
+
+/// The inner range to probe for `value` on `column` of `table` of `count` rows:
+/// the seeked `[lower, upper)` run when `value` is an integer on a seekable
+/// column, else the whole `0 ..< count` to scan.
+private func probe<T: Table & ~Escapable>(_ table: borrowing T, _ column: Int,
+                                          _ value: Value, _ count: Int)
+    -> Range<Int> {
+  guard case let .integer(key) = value,
+      let lower = table.bound(column, key, strict: false),
+      let upper = table.bound(column, key, strict: true) else {
+    return 0 ..< count
+  }
+  return lower ..< upper
+}
+
+/// Orders two typed sort keys ascending, by their value.
+///
+/// Both keys are read from the same slot, so they share a `Value` kind; a kind
+/// mismatch (which a single-slot key never produces) orders as equal.
+internal func less(_ lhs: Value, _ rhs: Value) -> Bool {
+  switch (lhs, rhs) {
+  case let (.integer(lhs), .integer(rhs)): lhs < rhs
+  case let (.text(lhs), .text(rhs)): lhs < rhs
+  default: false
+  }
+}

--- a/Sources/SQL/Parser.swift
+++ b/Sources/SQL/Parser.swift
@@ -1,0 +1,275 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+/// A recursive-descent parser over a token stream.
+///
+/// The grammar is the minimal dialect, extended with a single binary join:
+///
+/// ```
+/// statement   := select
+/// select      := SELECT projection FROM relation [join] [where] [order]
+/// relation    := identifier [AS identifier]
+/// join        := JOIN relation ON column '=' column
+/// projection  := '*' | column (',' column)*
+/// where       := WHERE predicate
+/// predicate   := disjunction
+/// disjunction := conjunction (OR conjunction)*
+/// conjunction := negation (AND negation)*
+/// negation    := NOT negation | primary
+/// primary     := '(' predicate ')' | comparison
+/// comparison  := column op literal
+/// order       := ORDER BY column [ASC | DESC]
+/// column      := identifier        // a dotted identifier is qualified
+/// ```
+///
+/// A `column` is a single identifier token; a qualifying dot (`t.Name`) is part
+/// of the identifier the lexer scans, so `Column(_:)` splits it into qualifier
+/// and name.
+///
+/// Predicate precedence is `NOT` > `AND` > `OR`; the cascade of methods encodes
+/// it, and parentheses override it through `primary`.
+///
+/// The parser pulls tokens from the `Lexer` on demand, holding a single token
+/// of lookahead in `current`; `advance()` lexes the next one. No token array is
+/// ever materialised.
+internal struct Parser: ~Escapable {
+  private var lexer: Lexer
+  private var current: Token?
+
+  @_lifetime(copy lexer)
+  internal init(_ lexer: consuming Lexer) throws(SQLError) {
+    self.lexer = lexer
+    self.current = try self.lexer.next()
+  }
+
+  // MARK: - Statement
+
+  /// Parses a complete statement and asserts the input is exhausted.
+  internal mutating func parse() throws(SQLError) -> Statement {
+    let statement = try Statement.select(select())
+    if let token = current {
+      throw .trailing(at: token.location)
+    }
+    return statement
+  }
+
+  /// Parses a `SELECT` query.
+  private mutating func select() throws(SQLError) -> Select {
+    try expect(.select)
+    let projection = try projection()
+    try expect(.from)
+    let from = try relation()
+
+    let join: Join? = if try match(.join) {
+      try join()
+    } else {
+      nil
+    }
+    let predicate: Predicate? = if try match(.where) {
+      try predicate()
+    } else {
+      nil
+    }
+    let order: Order? = if try match(.order) {
+      try order()
+    } else {
+      nil
+    }
+
+    return Select(projection: projection, from: from, join: join,
+                  predicate: predicate, order: order)
+  }
+
+  // MARK: - Relation
+
+  /// Parses a relation name and an optional alias.
+  ///
+  /// The alias may be introduced by `AS` (`TypeDef AS t`) or written directly
+  /// after the name (`TypeDef t`); the latter is admitted only when the next
+  /// token is a bare identifier, so a following keyword (`JOIN`, `WHERE`, …) or
+  /// the end of input is not mistaken for an alias.
+  private mutating func relation() throws(SQLError) -> Relation {
+    let name = try identifier()
+    let alias: String? = if try match(.as) {
+      try identifier()
+    } else if case .identifier = current?.kind {
+      try identifier()
+    } else {
+      nil
+    }
+    return Relation(name: name, alias: alias)
+  }
+
+  /// Parses the join tail (the `JOIN` keyword is already consumed): a relation,
+  /// `ON`, and a single `column = column` equality.
+  private mutating func join() throws(SQLError) -> Join {
+    let relation = try relation()
+    try expect(.on)
+    let left = try column()
+    try expect(.equal)
+    let right = try column()
+    return Join(relation: relation, left: left, right: right)
+  }
+
+  // MARK: - Projection
+
+  /// Parses `*` or a comma-separated list of (possibly-qualified) columns.
+  private mutating func projection() throws(SQLError) -> Projection {
+    if try match(.star) {
+      return .all
+    }
+
+    var columns = Array<Column>()
+    try columns.append(column())
+    while try match(.comma) {
+      try columns.append(column())
+    }
+    return .columns(columns)
+  }
+
+  // MARK: - Predicate
+
+  /// Parses a predicate at the lowest precedence (`OR`).
+  private mutating func predicate() throws(SQLError) -> Predicate {
+    try disjunction()
+  }
+
+  /// Parses `conjunction (OR conjunction)*`, left-associative.
+  private mutating func disjunction() throws(SQLError) -> Predicate {
+    var lhs = try conjunction()
+    while try match(.or) {
+      lhs = try .or(lhs, conjunction())
+    }
+    return lhs
+  }
+
+  /// Parses `negation (AND negation)*`, left-associative.
+  private mutating func conjunction() throws(SQLError) -> Predicate {
+    var lhs = try negation()
+    while try match(.and) {
+      lhs = try .and(lhs, negation())
+    }
+    return lhs
+  }
+
+  /// Parses `NOT negation` or a primary.
+  private mutating func negation() throws(SQLError) -> Predicate {
+    if try match(.not) {
+      return try .not(negation())
+    }
+    return try primary()
+  }
+
+  /// Parses a parenthesised predicate or a comparison.
+  private mutating func primary() throws(SQLError) -> Predicate {
+    if try match(.lparen) {
+      let predicate = try predicate()
+      try expect(.rparen)
+      return predicate
+    }
+    return try comparison()
+  }
+
+  /// Parses `column op literal`.
+  private mutating func comparison() throws(SQLError) -> Predicate {
+    let column = try column()
+    let op = try op()
+    let value = try literal()
+    return .comparison(column: column, op: op, value: value)
+  }
+
+  /// Parses a comparison operator.
+  private mutating func op() throws(SQLError) -> Comparison {
+    let token = try advance(expecting: "a comparison operator")
+    return switch token.kind {
+    case .equal: .equal
+    case .unequal: .unequal
+    case .lt: .lt
+    case .gt: .gt
+    case .leq: .leq
+    case .geq: .geq
+    default:
+      throw .unexpected(token.kind.description,
+                        expected: "a comparison operator",
+                        at: token.location)
+    }
+  }
+
+  /// Parses a string or integer literal.
+  private mutating func literal() throws(SQLError) -> Literal {
+    let token = try advance(expecting: "a literal")
+    return switch token.kind {
+    case let .string(value): .string(value)
+    case let .integer(value): .integer(value)
+    default:
+      throw .unexpected(token.kind.description,
+                        expected: "a literal", at: token.location)
+    }
+  }
+
+  // MARK: - Order
+
+  /// Parses `BY identifier [ASC | DESC]` (the `ORDER` keyword is already
+  /// consumed).
+  private mutating func order() throws(SQLError) -> Order {
+    try expect(.by)
+    let column = try column()
+
+    var ascending = true
+    if try match(.desc) {
+      ascending = false
+    } else {
+      _ = try match(.asc)
+    }
+    return Order(column: column, ascending: ascending)
+  }
+
+  // MARK: - Terminals
+
+  /// Consumes an identifier and returns its name.
+  private mutating func identifier() throws(SQLError) -> String {
+    let token = try advance(expecting: "an identifier")
+    guard case let .identifier(name) = token.kind else {
+      throw .unexpected(token.kind.description,
+                        expected: "an identifier", at: token.location)
+    }
+    return name
+  }
+
+  /// Consumes an identifier and parses it as a (possibly-qualified) column.
+  ///
+  /// A qualifying dot is part of the identifier the lexer scans, so the column
+  /// reference is one identifier token that `Column(_:)` splits.
+  private mutating func column() throws(SQLError) -> Column {
+    try Column(identifier())
+  }
+
+  // MARK: - Cursor
+
+  /// Consumes and returns the current token, faulting at the end of input.
+  private mutating func advance(expecting expectation: String)
+      throws(SQLError) -> Token {
+    guard let token = current else {
+      throw .incomplete(expected: expectation)
+    }
+    current = try lexer.next()
+    return token
+  }
+
+  /// Consumes the current token if it has `kind`, reporting whether it did.
+  private mutating func match(_ kind: Token.Kind) throws(SQLError) -> Bool {
+    guard let token = current, token.kind == kind else { return false }
+    current = try lexer.next()
+    return true
+  }
+
+  /// Consumes a token of `kind`, faulting otherwise.
+  private mutating func expect(_ kind: Token.Kind) throws(SQLError) {
+    let token = try advance(expecting: "'\(kind.description)'")
+    guard token.kind == kind else {
+      throw .unexpected(token.kind.description,
+                        expected: "'\(kind.description)'",
+                        at: token.location)
+    }
+  }
+}

--- a/Sources/SQL/Resolve.swift
+++ b/Sources/SQL/Resolve.swift
@@ -80,14 +80,19 @@ extension Table where Self: ~Escapable {
 /// The two relations of a join, addressed in one combined ordinal space.
 ///
 /// A join lays its two relations end to end: the outer (the `FROM`) relation
-/// occupies ordinals `[0, outer.width)`, the inner (the `JOIN`) relation
-/// `[outer.width, outer.width + inner.width)`. A `Scope` resolves a possibly
-/// qualified `SQL.Column` into that combined space so the engine's `Filter`,
-/// projection, and order all address cells uniformly across the pair. A
-/// qualifier names a relation by its alias, else its table name; an unqualified
-/// name resolves against both relations and is ambiguous if each has it. The
-/// scope is `~Escapable`: it borrows both `~Escapable` tables, and the engine
-/// resolves through it entirely within compilation, where the tables are live.
+/// occupies the ordinals below `base`, the inner (the `JOIN`) relation those at
+/// or above it. `base` is the outer relation's `extent` — one past the highest
+/// ordinal it can address — rather than its `width`, so the outer relation's
+/// virtual columns — ordinals at or past its real width, such as a `rowid` or a
+/// `parent` — stay on the outer side rather than colliding with the inner's
+/// space; an outer column resolves to its own ordinal, an inner column to
+/// `base + ordinal`. A `Scope` resolves a possibly qualified
+/// `SQL.Column` into that combined space so the engine's `Filter`, projection,
+/// and order all address cells uniformly across the pair. A qualifier names a
+/// relation by its alias, else its table name; an unqualified name resolves
+/// against both relations and is ambiguous if each has it. The scope is
+/// `~Escapable`: it borrows both `~Escapable` tables, and the engine resolves
+/// through it entirely within compilation, where the tables are live.
 internal struct Scope<T: Table & ~Escapable>: ~Escapable {
   /// The left (outer, `FROM`) relation reference; its alias, else its table
   /// name, is the qualifier that selects the `outer` table.
@@ -108,16 +113,18 @@ internal struct Scope<T: Table & ~Escapable>: ~Escapable {
     self.inner = copy inner
   }
 
-  /// The base ordinal of the inner relation in the combined space — the outer
-  /// relation's real width, past which inner ordinals begin.
+  /// The base ordinal of the inner relation in the combined space.
+  ///
+  /// The outer relation's `extent` — its real `width` plus the virtual columns
+  /// it exposes, i.e. one past the highest ordinal it can address — past which
+  /// inner ordinals begin. No outer ordinal — a real column below the width or a
+  /// virtual column at or just past it — reaches it, so the `< base` / `>= base`
+  /// split classifies a combined ordinal to its side even when the outer
+  /// relation contributes a virtual column. Anchoring on the outer's real extent
+  /// (rather than a fixed `1 << 32` reserve, which a 32-bit shift collapses to
+  /// zero) keeps the layout correct on every word size with no giant gap.
   internal var base: Int {
-    outer.width
-  }
-
-  /// The combined-ordinal extent of a `SELECT *`: every real outer column
-  /// followed by every real inner column.
-  internal var width: Int {
-    outer.width + inner.width
+    outer.extent
   }
 
   /// Whether `qualifier` (an alias, else a table name) names `relation`.
@@ -160,13 +167,16 @@ internal struct Scope<T: Table & ~Escapable>: ~Escapable {
   }
 
   /// The combined ordinals a projection yields: every real column of both
-  /// relations for `*` (outer then inner), the named columns' combined ordinals
-  /// otherwise, in source order.
+  /// relations for `*` (outer then inner, never a virtual column), the named
+  /// columns' combined ordinals otherwise, in source order.
   internal func projection(_ projection: Projection) throws(SQLError)
       -> Array<Int> {
     switch projection {
     case .all:
-      return Array(0 ..< width)
+      // Every real outer column, then every real inner column at its
+      // `base`-offset ordinal — never a virtual column of either side.
+      return Array(0 ..< outer.width)
+          + (0 ..< inner.width).map { base + $0 }
     case let .columns(columns):
       var ordinals = Array<Int>()
       ordinals.reserveCapacity(columns.count)

--- a/Sources/SQL/Resolve.swift
+++ b/Sources/SQL/Resolve.swift
@@ -1,0 +1,232 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+/// Resolution and lowering — the bridge from the name-addressed AST to the
+/// engine's ordinal-addressed forms.
+///
+/// The AST names columns by string; the engine addresses them by ordinal. A
+/// single relation resolves a name against its `Table` directly. A join lays its
+/// two relations end to end in one combined ordinal space and resolves a
+/// possibly qualified name against the pair through a `Scope`. Both lower a
+/// `Projection` to ordinals (`*` → the real width, never a virtual column), an
+/// `Order` to an `(ordinal, ascending)` pair, and the AST `Predicate` to the
+/// engine's `Filter`. A column name resolves to a real ordinal (`< width`) or a
+/// virtual one (`>= width`). A name no relation resolves is `SQLError.column`;
+/// an unqualified name both relations of a join resolve is `SQLError.ambiguous`.
+///
+/// The table is `~Escapable`, so resolution borrows it rather than storing it.
+/// The `Table` extension methods are `borrowing`; a join resolves through a
+/// `~Escapable` `Scope` that borrows both relations for the span of
+/// compilation, where both tables are live.
+
+extension Table where Self: ~Escapable {
+  /// The ordinal of the column `column` names, validating its qualifier against
+  /// `relation`.
+  ///
+  /// A single-relation query has one relation, so a qualifier — `relation`'s
+  /// alias, else its table name — must name it; any other qualifier is
+  /// `SQLError.column`, as a join rejects a qualifier naming neither side.
+  internal borrowing func ordinal(of column: Column, in relation: Relation)
+      throws(SQLError) -> Int {
+    if let qualifier = column.qualifier,
+        (relation.alias ?? relation.name) != qualifier {
+      throw .column(column.name)
+    }
+    guard let ordinal = ordinal(of: column.name) else {
+      throw .column(column.name)
+    }
+    return ordinal
+  }
+
+  internal borrowing func projection(_ projection: Projection,
+                                     in relation: Relation)
+      throws(SQLError) -> Array<Int> {
+    switch projection {
+    case .all:
+      return Array(0 ..< width)
+    case let .columns(columns):
+      var ordinals = Array<Int>()
+      ordinals.reserveCapacity(columns.count)
+      for column in columns {
+        ordinals.append(try ordinal(of: column, in: relation))
+      }
+      return ordinals
+    }
+  }
+
+  internal borrowing func order(_ order: Order, in relation: Relation)
+      throws(SQLError) -> (column: Int, ascending: Bool) {
+    try (column: ordinal(of: order.column, in: relation),
+         ascending: order.ascending)
+  }
+
+  internal borrowing func lower(_ predicate: Predicate, in relation: Relation)
+      throws(SQLError) -> Filter {
+    switch predicate {
+    case let .comparison(column, op, value):
+      try .compare(ordinal(of: column, in: relation), op, value)
+    case let .and(lhs, rhs):
+      try .and(lower(lhs, in: relation), lower(rhs, in: relation))
+    case let .or(lhs, rhs):
+      try .or(lower(lhs, in: relation), lower(rhs, in: relation))
+    case let .not(operand):
+      try .not(lower(operand, in: relation))
+    }
+  }
+}
+
+// MARK: - Join scope
+
+/// The two relations of a join, addressed in one combined ordinal space.
+///
+/// A join lays its two relations end to end: the outer (the `FROM`) relation
+/// occupies ordinals `[0, outer.width)`, the inner (the `JOIN`) relation
+/// `[outer.width, outer.width + inner.width)`. A `Scope` resolves a possibly
+/// qualified `SQL.Column` into that combined space so the engine's `Filter`,
+/// projection, and order all address cells uniformly across the pair. A
+/// qualifier names a relation by its alias, else its table name; an unqualified
+/// name resolves against both relations and is ambiguous if each has it. The
+/// scope is `~Escapable`: it borrows both `~Escapable` tables, and the engine
+/// resolves through it entirely within compilation, where the tables are live.
+internal struct Scope<T: Table & ~Escapable>: ~Escapable {
+  /// The left (outer, `FROM`) relation reference; its alias, else its table
+  /// name, is the qualifier that selects the `outer` table.
+  private let left: Relation
+  /// The right (inner, `JOIN`) relation reference; its qualifier selects the
+  /// `inner` table.
+  private let right: Relation
+  /// The outer and inner tables, laid end to end.
+  private let outer: T
+  private let inner: T
+
+  @_lifetime(borrow outer, borrow inner)
+  internal init(_ left: Relation, _ outer: borrowing T,
+                _ right: Relation, _ inner: borrowing T) {
+    self.left = left
+    self.right = right
+    self.outer = copy outer
+    self.inner = copy inner
+  }
+
+  /// The base ordinal of the inner relation in the combined space — the outer
+  /// relation's real width, past which inner ordinals begin.
+  internal var base: Int {
+    outer.width
+  }
+
+  /// The combined-ordinal extent of a `SELECT *`: every real outer column
+  /// followed by every real inner column.
+  internal var width: Int {
+    outer.width + inner.width
+  }
+
+  /// Whether `qualifier` (an alias, else a table name) names `relation`.
+  private func names(_ relation: Relation, _ qualifier: String) -> Bool {
+    (relation.alias ?? relation.name) == qualifier
+  }
+
+  /// Whether `column`'s qualifier admits `relation`: an unqualified name admits
+  /// either relation, a qualified one only the relation its qualifier names.
+  private func admits(_ relation: Relation, _ column: Column) -> Bool {
+    if let qualifier = column.qualifier {
+      names(relation, qualifier)
+    } else {
+      true
+    }
+  }
+
+  /// The combined ordinal `column` resolves to.
+  ///
+  /// A qualifier admits only the relation it names; an unqualified name admits
+  /// both. Within the admitted relations the name resolves: present in exactly
+  /// one it yields that ordinal; in both â two relations sharing a qualifier (a
+  /// self-join or a duplicated alias), or an unqualified name sitting in each â
+  /// it is `SQLError.ambiguous`; in neither it is `SQLError.column`.
+  internal func ordinal(of column: Column) throws(SQLError) -> Int {
+    let here =
+        admits(left, column) ? outer.ordinal(of: column.name) : nil
+    let there =
+        admits(right, column) ? inner.ordinal(of: column.name) : nil
+    switch (here, there) {
+    case let (.some(ordinal), nil):
+      return ordinal
+    case let (nil, .some(ordinal)):
+      return base + ordinal
+    case (.some, .some):
+      throw .ambiguous(column.name)
+    case (nil, nil):
+      throw .column(column.name)
+    }
+  }
+
+  /// The combined ordinals a projection yields: every real column of both
+  /// relations for `*` (outer then inner), the named columns' combined ordinals
+  /// otherwise, in source order.
+  internal func projection(_ projection: Projection) throws(SQLError)
+      -> Array<Int> {
+    switch projection {
+    case .all:
+      return Array(0 ..< width)
+    case let .columns(columns):
+      var ordinals = Array<Int>()
+      ordinals.reserveCapacity(columns.count)
+      for column in columns {
+        ordinals.append(try ordinal(of: column))
+      }
+      return ordinals
+    }
+  }
+
+  /// The `(column, ascending)` pair an `ORDER BY` resolves to, the column a
+  /// combined ordinal.
+  internal func order(_ order: Order) throws(SQLError)
+      -> (column: Int, ascending: Bool) {
+    try (column: ordinal(of: order.column), ascending: order.ascending)
+  }
+
+  /// Lowers a join's `ON left = right` to a `match` conjunct, each side
+  /// resolved to a combined ordinal across the pair.
+  internal func match(_ left: Column, _ right: Column) throws(SQLError)
+      -> Filter {
+    try .match(ordinal(of: left), ordinal(of: right))
+  }
+
+  /// Lowers the name-addressed AST `predicate` to the engine's `Filter`, each
+  /// column reference resolved to a combined ordinal across the join.
+  internal func lower(_ predicate: Predicate) throws(SQLError) -> Filter {
+    switch predicate {
+    case let .comparison(column, op, value):
+      try .compare(ordinal(of: column), op, value)
+    case let .and(lhs, rhs):
+      try .and(lower(lhs), lower(rhs))
+    case let .or(lhs, rhs):
+      try .or(lower(lhs), lower(rhs))
+    case let .not(operand):
+      try .not(lower(operand))
+    }
+  }
+}
+
+// MARK: - Referenced ordinals
+
+extension Filter {
+  /// The ordinals this filter reads, accumulated into `ordinals`.
+  ///
+  /// A `compare` reads its one column; a `match` reads both; the connectives
+  /// recurse. The engine unions these with the projection, order, and join keys
+  /// to materialise exactly the columns a scan's rows are read through.
+  internal func references(into ordinals: inout Set<Int>) {
+    switch self {
+    case let .compare(column, _, _):
+      ordinals.insert(column)
+    case let .match(left, right):
+      ordinals.insert(left)
+      ordinals.insert(right)
+    case let .and(lhs, rhs), let .or(lhs, rhs):
+      lhs.references(into: &ordinals)
+      rhs.references(into: &ordinals)
+    case let .not(operand):
+      operand.references(into: &ordinals)
+    }
+  }
+}

--- a/Sources/SQL/SQL.swift
+++ b/Sources/SQL/SQL.swift
@@ -1,0 +1,31 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+extension Statement {
+  /// Parses SQL text into a `Statement`.
+  ///
+  /// The text's UTF-8 bytes are streamed through the lexer and parsed by
+  /// recursive descent into a SQL abstract syntax tree. The dialect is minimal:
+  ///
+  /// ```sql
+  /// SELECT <* | column (, column)*> FROM <table>
+  ///   [WHERE <predicate>] [ORDER BY <column> [ASC|DESC]]
+  /// ```
+  ///
+  /// The resulting AST is generic: it names a relation and its columns as
+  /// strings and carries no knowledge of how they resolve. Binding the names to
+  /// a data source is the consumer's responsibility.
+  ///
+  /// - Parameter text: the SQL query to parse.
+  /// - Throws: `SQLError` on a lexical or syntactic fault, carrying the source
+  ///   location of the offending span where one is known.
+  public init(parsing text: String) throws(SQLError) {
+    // The lexer scans bytes by value over the input's contiguous UTF-8 storage,
+    // exposed as a `Span<UInt8>`. The span is borrowed only for the duration of
+    // the lex-and-parse; the resulting `Statement` is fully escapable, so
+    // nothing tied to the borrow survives.
+    let bytes = text.utf8Span.span
+    var parser = try Parser(Lexer(bytes))
+    self = try parser.parse()
+  }
+}

--- a/Sources/SQL/Token.swift
+++ b/Sources/SQL/Token.swift
@@ -1,0 +1,85 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+/// A lexical token, tagged with its source position.
+///
+/// `location` is the `SourceLocation` at which the token's text begins in the
+/// query, so diagnostics can point at the span.
+internal struct Token: Hashable, Sendable {
+  internal let kind: Kind
+  internal let location: SourceLocation
+}
+
+extension Token {
+  /// The classification of a token.
+  ///
+  /// Keywords are recognised case-insensitively during lexing and normalised
+  /// to a dedicated case; an identifier therefore never holds a keyword.
+  internal enum Kind: Hashable, Sendable {
+    // Keywords.
+    case select
+    case from
+    case `where`
+    case order
+    case by
+    case asc
+    case desc
+    case and
+    case or
+    case not
+    case join
+    case on
+    case `as`
+
+    // Operands.
+    case identifier(String)
+    case string(String)
+    case integer(Int)
+
+    // Punctuation and operators.
+    case star
+    case comma
+    case lparen
+    case rparen
+    case equal
+    case unequal
+    case lt
+    case gt
+    case leq
+    case geq
+  }
+}
+
+extension Token.Kind {
+  /// A human-readable spelling of the token, for diagnostics.
+  internal var description: String {
+    switch self {
+    case .select: "SELECT"
+    case .from: "FROM"
+    case .where: "WHERE"
+    case .order: "ORDER"
+    case .by: "BY"
+    case .asc: "ASC"
+    case .desc: "DESC"
+    case .and: "AND"
+    case .or: "OR"
+    case .not: "NOT"
+    case .join: "JOIN"
+    case .on: "ON"
+    case .as: "AS"
+    case let .identifier(name): name
+    case let .string(value): "'\(value)'"
+    case let .integer(value): "\(value)"
+    case .star: "*"
+    case .comma: ","
+    case .lparen: "("
+    case .rparen: ")"
+    case .equal: "="
+    case .unequal: "<>"
+    case .lt: "<"
+    case .gt: ">"
+    case .leq: "<="
+    case .geq: ">="
+    }
+  }
+}

--- a/Sources/WinMD/Attribute.swift
+++ b/Sources/WinMD/Attribute.swift
@@ -1,0 +1,72 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import struct Foundation.UUID
+import typealias Foundation.uuid_t
+
+// MARK: - Decoding
+
+/// A cursor decoding a custom-attribute `Value` blob (ECMA-335 §II.23.3).
+///
+/// A custom-attribute value opens with a `0x0001` prolog, then the
+/// constructor's fixed arguments serialised in declaration order, then any
+/// named arguments. This cursor reads the leaves the `[Guid(...)]` constructor
+/// needs — the fixed-size integers spelling a GUID — mirroring
+/// `SignatureDecoder`'s shape: it borrows the blob's bytes and advances a
+/// position, and is `~Escapable` because it holds a `RawSpan`. Only the GUID
+/// path is decoded today; the general §II.23.3 grammar can extend this later.
+internal struct AttributeDecoder: ~Escapable {
+  private let bytes: RawSpan
+  private var position: Int
+
+  @_lifetime(copy bytes)
+  internal init(_ bytes: RawSpan) {
+    self.bytes = bytes
+    self.position = 0
+  }
+
+  /// Reads a little-endian fixed-width value and advances past it.
+  private mutating func read<T: BitwiseCopyable>(as _: T.Type = T.self)
+      throws(WinMDError) -> T {
+    let width = MemoryLayout<T>.size
+    guard position + width <= bytes.byteCount else { throw .BadImageFormat }
+    let value = bytes.read(at: position, as: T.self)
+    position = position + width
+    return value
+  }
+
+  /// Reads the fixed `0x0001` prolog and advances past it.
+  private mutating func prolog() throws(WinMDError) {
+    guard try read(as: UInt16.self) == 0x0001 else { throw .BadImageFormat }
+  }
+
+  /// Decodes a `GuidAttribute` value: the prolog, then the GUID as the
+  /// constructor serialises it — `u32, u16, u16, u8×8` (ECMA-335 §II.23.3).
+  ///
+  /// The constructor serialises `data1`/`data2`/`data3` little-endian, but a
+  /// COM GUID's canonical spelling shows those three fields big-endian — which
+  /// is exactly the byte order `UUID` stores. Swap the integer fields to
+  /// big-endian and carry `data4` in order so `description` renders the
+  /// canonical `[Guid(...)]` form.
+  internal mutating func guid() throws(WinMDError) -> UUID {
+    try prolog()
+    let data1: UInt32 = try read()
+    let data2: UInt16 = try read()
+    let data3: UInt16 = try read()
+    let uuid: uuid_t = try (
+      UInt8(truncatingIfNeeded: data1 >> 24),
+      UInt8(truncatingIfNeeded: data1 >> 16),
+      UInt8(truncatingIfNeeded: data1 >> 8),
+      UInt8(truncatingIfNeeded: data1),
+      UInt8(truncatingIfNeeded: data2 >> 8),
+      UInt8(truncatingIfNeeded: data2),
+      UInt8(truncatingIfNeeded: data3 >> 8),
+      UInt8(truncatingIfNeeded: data3),
+      read(), read(), read(), read(),
+      read(), read(), read(), read())
+    let value = UUID(uuid: uuid)
+    guard try read(as: UInt16.self) == 0 else { throw .BadImageFormat }
+    guard position == bytes.byteCount else { throw .BadImageFormat }
+    return value
+  }
+}

--- a/Sources/WinMD/BlobsHeap.swift
+++ b/Sources/WinMD/BlobsHeap.swift
@@ -40,4 +40,30 @@ public struct BlobsHeap: ~Escapable {
       return Blob(bytes.extracting(begin ..< begin + length))
     }
   }
+
+  /// Opens the blob at `offset`, validating its length prefix and extent, so a
+  /// malformed entry throws `.BadImageFormat` rather than trapping.
+  ///
+  /// The lead byte of the compressed length prefix selects its width:
+  /// `0x00..0x7f` is 1 byte, `0x80..0xbf` 2 bytes, `0xc0..0xdf` 4 bytes;
+  /// `0xe0` and above is not a defined encoding. The prefix must fit the heap,
+  /// and the payload it delimits must not run past the heap end. This mirrors
+  /// `SignatureDecoder.width`, which guards the shared `RawSpan.compressed` the
+  /// same way.
+  @_lifetime(copy self)
+  public func blob(at offset: Int) throws(WinMDError) -> Blob {
+    guard offset >= 0, offset < bytes.byteCount else { throw .BadImageFormat }
+    let width = switch bytes.read(at: offset, as: UInt8.self) {
+    case 0x00 ... 0x7f: 1
+    case 0x80 ... 0xbf: 2
+    case 0xc0 ... 0xdf: 4
+    default:            throw .BadImageFormat
+    }
+    guard offset + width <= bytes.byteCount else { throw .BadImageFormat }
+    let (begin, length) = bytes.compressed(at: offset)
+    guard length >= 0, begin + length <= bytes.byteCount else {
+      throw .BadImageFormat
+    }
+    return Blob(bytes.extracting(begin ..< begin + length))
+  }
 }

--- a/Sources/WinMD/CodedIndex.swift
+++ b/Sources/WinMD/CodedIndex.swift
@@ -14,7 +14,7 @@ public protocol CodedIndex: CustomDebugStringConvertible, Sendable {
   /// The order of the tables is important. The tag identifies the table and
   /// indexes through them, therefore, it is critical the index of the table
   /// corresponds to the tag value.
-  static var tables: Span<TableSchema.Type> { get }
+  static var tables: Span<TableSchema.Type?> { get }
 
   /// The value of the coded index.
   var rawValue: RawValue { get }
@@ -51,19 +51,24 @@ extension CodedIndex {
 extension CodedIndex {
   /// See `CustomDebugStringConvertible.debugDescription`.
   public var debugDescription: String {
-    "\(Self.tables[tag]) Row \(row)"
+    let table = if let schema = Self.tables[tag] {
+      "\(schema)"
+    } else {
+      "reserved"
+    }
+    return "\(table) Row \(row)"
   }
 }
 
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _typeDefOrRef: InlineArray<_, TableSchema.Type> = [
+private let _typeDefOrRef: InlineArray<_, TableSchema.Type?> = [
   Metadata.Tables.TypeDef.self,
   Metadata.Tables.TypeRef.self,
   Metadata.Tables.TypeSpec.self,
 ]
 
 public struct TypeDefOrRef: CodedIndex {
-  public static var tables: Span<TableSchema.Type> {
+  public static var tables: Span<TableSchema.Type?> {
     @_lifetime(immortal)
     get { _typeDefOrRef.span }
   }
@@ -76,14 +81,14 @@ public struct TypeDefOrRef: CodedIndex {
 }
 
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _hasConstant: InlineArray<_, TableSchema.Type> = [
+private let _hasConstant: InlineArray<_, TableSchema.Type?> = [
   Metadata.Tables.FieldDef.self,
   Metadata.Tables.Param.self,
   Metadata.Tables.PropertyDef.self,
 ]
 
 public struct HasConstant: CodedIndex {
-  public static var tables: Span<TableSchema.Type> {
+  public static var tables: Span<TableSchema.Type?> {
     @_lifetime(immortal)
     get { _hasConstant.span }
   }
@@ -96,7 +101,7 @@ public struct HasConstant: CodedIndex {
 }
 
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _hasCustomAttribute: InlineArray<_, TableSchema.Type> = [
+private let _hasCustomAttribute: InlineArray<_, TableSchema.Type?> = [
   Metadata.Tables.MethodDef.self,
   Metadata.Tables.FieldDef.self,
   Metadata.Tables.TypeRef.self,
@@ -122,7 +127,7 @@ private let _hasCustomAttribute: InlineArray<_, TableSchema.Type> = [
 ]
 
 public struct HasCustomAttribute: CodedIndex {
-  public static var tables: Span<TableSchema.Type> {
+  public static var tables: Span<TableSchema.Type?> {
     @_lifetime(immortal)
     get { _hasCustomAttribute.span }
   }
@@ -135,13 +140,13 @@ public struct HasCustomAttribute: CodedIndex {
 }
 
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _hasFieldMarshal: InlineArray<_, TableSchema.Type> = [
+private let _hasFieldMarshal: InlineArray<_, TableSchema.Type?> = [
   Metadata.Tables.FieldDef.self,
   Metadata.Tables.Param.self,
 ]
 
 public struct HasFieldMarshal: CodedIndex {
-  public static var tables: Span<TableSchema.Type> {
+  public static var tables: Span<TableSchema.Type?> {
     @_lifetime(immortal)
     get { _hasFieldMarshal.span }
   }
@@ -154,14 +159,14 @@ public struct HasFieldMarshal: CodedIndex {
 }
 
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _hasDeclSecurity: InlineArray<_, TableSchema.Type> = [
+private let _hasDeclSecurity: InlineArray<_, TableSchema.Type?> = [
   Metadata.Tables.TypeDef.self,
   Metadata.Tables.MethodDef.self,
   Metadata.Tables.Assembly.self,
 ]
 
 public struct HasDeclSecurity: CodedIndex {
-  public static var tables: Span<TableSchema.Type> {
+  public static var tables: Span<TableSchema.Type?> {
     @_lifetime(immortal)
     get { _hasDeclSecurity.span }
   }
@@ -174,7 +179,7 @@ public struct HasDeclSecurity: CodedIndex {
 }
 
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _memberRefParent: InlineArray<_, TableSchema.Type> = [
+private let _memberRefParent: InlineArray<_, TableSchema.Type?> = [
   Metadata.Tables.TypeDef.self,
   Metadata.Tables.TypeRef.self,
   Metadata.Tables.ModuleRef.self,
@@ -183,7 +188,7 @@ private let _memberRefParent: InlineArray<_, TableSchema.Type> = [
 ]
 
 public struct MemberRefParent: CodedIndex {
-  public static var tables: Span<TableSchema.Type> {
+  public static var tables: Span<TableSchema.Type?> {
     @_lifetime(immortal)
     get { _memberRefParent.span }
   }
@@ -196,13 +201,13 @@ public struct MemberRefParent: CodedIndex {
 }
 
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _hasSemantics: InlineArray<_, TableSchema.Type> = [
+private let _hasSemantics: InlineArray<_, TableSchema.Type?> = [
   Metadata.Tables.EventDef.self,
   Metadata.Tables.PropertyDef.self,
 ]
 
 public struct HasSemantics: CodedIndex {
-  public static var tables: Span<TableSchema.Type> {
+  public static var tables: Span<TableSchema.Type?> {
     @_lifetime(immortal)
     get { _hasSemantics.span }
   }
@@ -215,13 +220,13 @@ public struct HasSemantics: CodedIndex {
 }
 
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _methodDefOrRef: InlineArray<_, TableSchema.Type> = [
+private let _methodDefOrRef: InlineArray<_, TableSchema.Type?> = [
   Metadata.Tables.MethodDef.self,
   Metadata.Tables.MemberRef.self,
 ]
 
 public struct MethodDefOrRef: CodedIndex {
-  public static var tables: Span<TableSchema.Type> {
+  public static var tables: Span<TableSchema.Type?> {
     @_lifetime(immortal)
     get { _methodDefOrRef.span }
   }
@@ -234,13 +239,13 @@ public struct MethodDefOrRef: CodedIndex {
 }
 
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _memberForwarded: InlineArray<_, TableSchema.Type> = [
+private let _memberForwarded: InlineArray<_, TableSchema.Type?> = [
   Metadata.Tables.FieldDef.self,
   Metadata.Tables.MethodDef.self,
 ]
 
 public struct MemberForwarded: CodedIndex {
-  public static var tables: Span<TableSchema.Type> {
+  public static var tables: Span<TableSchema.Type?> {
     @_lifetime(immortal)
     get { _memberForwarded.span }
   }
@@ -254,14 +259,14 @@ public struct MemberForwarded: CodedIndex {
 
 // FIXME(compnerd) Exported vs Manifest Resource
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _implementation: InlineArray<_, TableSchema.Type> = [
+private let _implementation: InlineArray<_, TableSchema.Type?> = [
   Metadata.Tables.File.self,
   Metadata.Tables.AssemblyRef.self,
   Metadata.Tables.ExportedType.self,
 ]
 
 public struct Implementation: CodedIndex {
-  public static var tables: Span<TableSchema.Type> {
+  public static var tables: Span<TableSchema.Type?> {
     @_lifetime(immortal)
     get { _implementation.span }
   }
@@ -274,16 +279,16 @@ public struct Implementation: CodedIndex {
 }
 
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _customAttributeType: InlineArray<_, TableSchema.Type> = [
-  Metadata.Tables.Module.self,      // unused
-  Metadata.Tables.Module.self,      // unused
+private let _customAttributeType: InlineArray<_, TableSchema.Type?> = [
+  nil,  // reserved
+  nil,  // reserved
   Metadata.Tables.MethodDef.self,
   Metadata.Tables.MemberRef.self,
-  Metadata.Tables.Module.self,      // unused
+  nil,  // reserved
 ]
 
 public struct CustomAttributeType: CodedIndex {
-  public static var tables: Span<TableSchema.Type> {
+  public static var tables: Span<TableSchema.Type?> {
     @_lifetime(immortal)
     get { _customAttributeType.span }
   }
@@ -296,7 +301,7 @@ public struct CustomAttributeType: CodedIndex {
 }
 
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _resolutionScope: InlineArray<_, TableSchema.Type> = [
+private let _resolutionScope: InlineArray<_, TableSchema.Type?> = [
   Metadata.Tables.Module.self,
   Metadata.Tables.ModuleRef.self,
   Metadata.Tables.AssemblyRef.self,
@@ -304,7 +309,7 @@ private let _resolutionScope: InlineArray<_, TableSchema.Type> = [
 ]
 
 public struct ResolutionScope: CodedIndex {
-  public static var tables: Span<TableSchema.Type> {
+  public static var tables: Span<TableSchema.Type?> {
     @_lifetime(immortal)
     get { _resolutionScope.span }
   }
@@ -317,13 +322,13 @@ public struct ResolutionScope: CodedIndex {
 }
 
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _typeOrMethodDef: InlineArray<_, TableSchema.Type> = [
+private let _typeOrMethodDef: InlineArray<_, TableSchema.Type?> = [
   Metadata.Tables.TypeDef.self,
   Metadata.Tables.MethodDef.self,
 ]
 
 public struct TypeOrMethodDef: CodedIndex {
-  public static var tables: Span<TableSchema.Type> {
+  public static var tables: Span<TableSchema.Type?> {
     @_lifetime(immortal)
     get { _typeOrMethodDef.span }
   }

--- a/Sources/WinMD/Column.swift
+++ b/Sources/WinMD/Column.swift
@@ -1,0 +1,78 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+/// A typed token addressing a value column of a `Row<Schema>`.
+///
+/// A `Column` names a single value column by its ordinal and carries the recipe
+/// for decoding that column's raw cell to a `Value`. Because a token is built
+/// for a column of a statically known kind, it decodes directly through the
+/// row's heap views — like the hand-written accessors do — rather than through
+/// the kind-validating `Tuple.string`/`blob`/`guid`, so the read is
+/// non-throwing.
+///
+/// A token is escapable: the `decode` closure reads the borrowed `Row` it is
+/// handed but does not store it, so the row stays on the borrowed side of the
+/// escape boundary. The token surfaces as leading-dot sugar on a row —
+/// `row[.TypeName]` — and backs the hand-written value accessors and the typed
+/// query combinators.
+///
+/// Foreign-key columns (simple/coded indices) are navigation, not values, and
+/// are addressed by `resolve`/`list`/`referencing` instead; they have no token.
+public struct Column<Schema: TableSchema, Value> {
+  /// The ordinal of the column within the schema.
+  internal let ordinal: Int
+
+  /// Decodes the column's cell of the borrowed `row` to a `Value`.
+  internal let decode: (borrowing Row<Schema>) -> Value
+
+  internal init(_ ordinal: Int,
+                _ decode: @escaping (borrowing Row<Schema>) -> Value) {
+    self.ordinal = ordinal
+    self.decode = decode
+  }
+}
+
+extension Row {
+  /// The value of the column the `field` token addresses.
+  ///
+  /// The typed read: `row[.TypeName]` resolves `Value` from the token, so the
+  /// column's domain type is recovered without an annotation.
+  public subscript<Value>(_ field: Column<Schema, Value>) -> Value {
+    field.decode(self)
+  }
+}
+
+/// A typed token addressing a `#Blob`-heap column of a `Row<Schema>`.
+///
+/// A blob is a borrowed view (`Blob` is `~Escapable`), so it cannot be the
+/// `Value` of an escapable `Column` whose decode closure would return it.
+/// `BlobColumn` is therefore a distinct token that names a blob column by its
+/// ordinal; the read happens in the row subscript, which borrows the row and
+/// resolves the cell through the "Blob" heap.
+public struct BlobColumn<Schema: TableSchema> {
+  /// The ordinal of the column within the schema.
+  internal let ordinal: Int
+
+  internal init(_ ordinal: Int) {
+    self.ordinal = ordinal
+  }
+}
+
+extension Row {
+  /// The blob the column the `field` token addresses references.
+  public subscript(_ field: BlobColumn<Schema>) -> Blob {
+    @_lifetime(copy self)
+    get { blobs[columns[field.ordinal]] }
+  }
+
+  /// The blob the column the `field` token addresses references, validating the
+  /// `#Blob` entry's length prefix and extent so a malformed entry throws
+  /// `.BadImageFormat` rather than trapping.
+  ///
+  /// The non-throwing subscript trusts the entry; this is the validating path
+  /// the signature accessors open `.Signature` through before decoding.
+  @_lifetime(copy self)
+  public func blob(_ field: BlobColumn<Schema>) throws(WinMDError) -> Blob {
+    try blobs.blob(at: columns[field.ordinal])
+  }
+}

--- a/Sources/WinMD/Column.swift
+++ b/Sources/WinMD/Column.swift
@@ -76,3 +76,103 @@ extension Row {
     try blobs.blob(at: columns[field.ordinal])
   }
 }
+
+/// A typed token addressing a simple-index foreign-key column of a
+/// `Row<Schema>`.
+///
+/// Where a `Column` names a value column, a `Reference` names a *navigation*
+/// column: a `simple` index whose target table is statically known. The token
+/// carries the column's ordinal and, through its `Target` parameter, the
+/// referenced schema, so `row.resolve(.Col)` recovers a typed `Row<Target>`
+/// without an annotation. It is the forward, single-row counterpart of the
+/// value `Column` token, and the owning-column descriptor a reverse
+/// `database.referencing(_:by:)` consumes.
+public struct Reference<Schema: TableSchema, Target: TableSchema> {
+  /// The ordinal of the column within the schema.
+  internal let ordinal: Int
+
+  internal init(_ ordinal: Int) {
+    self.ordinal = ordinal
+  }
+}
+
+/// A typed token addressing a coded-index foreign-key column of a
+/// `Row<Schema>`.
+///
+/// A coded index selects its target table at runtime from the stored tag, so
+/// unlike `Reference` it carries no static `Target`: resolving it yields the
+/// type-erased `Tuple`, which the caller narrows with `Row<Target>(_:)` once
+/// the tag's table is known. The token still carries the owning `Schema` and
+/// the column's ordinal, so it doubles as the owning-column descriptor for a
+/// reverse `database.referencing(_:by:)`.
+public struct CodedReference<Schema: TableSchema> {
+  /// The ordinal of the column within the schema.
+  internal let ordinal: Int
+
+  internal init(_ ordinal: Int) {
+    self.ordinal = ordinal
+  }
+}
+
+/// A typed token addressing a list-valued foreign-key column of a
+/// `Row<Schema>`.
+///
+/// A list column stores the start of a `[start, next-row's start)` run into the
+/// `Target` table; `row.list(.Col)` opens a typed `TableIterator<Target>` over
+/// that run. It is the forward, multi-row navigation counterpart of
+/// `Reference`.
+public struct List<Schema: TableSchema, Target: TableSchema> {
+  /// The ordinal of the column within the schema.
+  internal let ordinal: Int
+
+  internal init(_ ordinal: Int) {
+    self.ordinal = ordinal
+  }
+}
+
+extension Row {
+  /// The row the simple-index column the `reference` token addresses names, or
+  /// `nil` if the reference is null.
+  ///
+  /// `row.resolve(.Col)` decodes the simple index through the generic
+  /// `Tuple.resolve` and narrows the result to the token's statically known
+  /// `Target`. The narrowing always succeeds for a well-formed simple index, so
+  /// the result is `nil` only when the reference itself is null.
+  @_lifetime(copy self)
+  public func resolve<Target>(_ reference: Reference<Schema, Target>)
+      throws(WinMDError) -> Row<Target>? {
+    guard let tuple = try columns.resolve(reference.ordinal) else {
+      return nil
+    }
+    return Row<Target>(tuple)
+  }
+
+  /// Resolves a REQUIRED reference, throwing `.BadImageFormat` if the column
+  /// holds the null value — a required reference must name a row.
+  @_lifetime(copy self)
+  public func required<Target>(_ reference: Reference<Schema, Target>)
+      throws(WinMDError) -> Row<Target> {
+    guard let row = try resolve(reference) else { throw .BadImageFormat }
+    return row
+  }
+
+  /// The tuple the coded-index column the `reference` token addresses names, or
+  /// `nil` if the reference is null.
+  ///
+  /// A coded index's target table is chosen at runtime by its tag, so the
+  /// result is the type-erased `Tuple`; narrow it with `Row<Target>(_:)` once
+  /// the target table is known.
+  @_lifetime(copy self)
+  public func resolve(_ reference: CodedReference<Schema>)
+      throws(WinMDError) -> Tuple? {
+    try columns.resolve(reference.ordinal)
+  }
+
+  /// The rows of the `[start, next-row's start)` run the list column the `list`
+  /// token addresses delimits.
+  @_lifetime(copy self)
+  public func list<Target>(_ list: List<Schema, Target>)
+      throws(WinMDError) -> TableIterator<Target> {
+    try self.list(for: list.ordinal)
+  }
+}

--- a/Sources/WinMD/Database.swift
+++ b/Sources/WinMD/Database.swift
@@ -97,7 +97,8 @@ public struct Database: ~Escapable {
     @_lifetime(borrow self)
     get {
       Storage(bytes: bytes, relations: relations.span, strings: string,
-              blob: blob, guid: guid, valid: stream.Valid)
+              blob: blob, guid: guid, valid: stream.Valid,
+              sorted: stream.Sorted)
     }
   }
 

--- a/Sources/WinMD/Database.swift
+++ b/Sources/WinMD/Database.swift
@@ -200,4 +200,33 @@ public struct Database: ~Escapable {
     let storage = self.storage
     return try storage.referencing(target, in: schema, by: column)
   }
+
+  /// The rows whose simple-index foreign-key `column` references `target`.
+  ///
+  /// Typed reverse navigation: the owning column descriptor — a `Reference`
+  /// token naming the owning `Owner` table and the column's ordinal — supplies
+  /// both the owning relation and the ordinal, so the call site needs no
+  /// string or ordinal: `database.referencing(row, by: NestedClass.NestedClass)`.
+  /// This is the typed wrapper over the generic `referencing(_:in:by:)`; see it
+  /// for the encoding and the `O(log n)` / `O(rows)` contract.
+  @_lifetime(borrow self)
+  public func referencing<Owner, Target>(_ target: borrowing Row<Target>,
+                                         by column: Reference<Owner, Target>)
+      throws(WinMDError) -> Filter {
+    let storage = self.storage
+    return try storage.referencing(target, by: column)
+  }
+
+  /// The rows whose coded-index foreign-key `column` references `target`.
+  ///
+  /// As above, but the owning column is a coded index, so the descriptor is a
+  /// `CodedReference` token and the `target` can be any table the index admits:
+  /// `database.referencing(row, by: CustomAttribute.Parent)`.
+  @_lifetime(borrow self)
+  public func referencing<Owner, Target>(_ target: borrowing Row<Target>,
+                                         by column: CodedReference<Owner>)
+      throws(WinMDError) -> Filter {
+    let storage = self.storage
+    return try storage.referencing(target, by: column)
+  }
 }

--- a/Sources/WinMD/Database.swift
+++ b/Sources/WinMD/Database.swift
@@ -33,9 +33,9 @@ public struct Database: ~Escapable {
   private let string: RawSpan
 
   // The "User Strings" (`#US`) heap is optional: metadata-only files frequently
-  // omit it.  Its absence is tolerated at open and surfaced as an error only on
+  // omit it. Its absence is tolerated at open and surfaced as an error only on
   // use, so its location is stored as an optional region rather than a borrowed
-  // sub-span.  `Region` is escapable, so it can be held by an `Optional`.
+  // sub-span. `Region` is escapable, so it can be held by an `Optional`.
   private let user: Region?
 
   // MARK: - Streams

--- a/Sources/WinMD/Database.swift
+++ b/Sources/WinMD/Database.swift
@@ -154,6 +154,26 @@ public struct Database: ~Escapable {
     Cursor(storage, table)
   }
 
+  /// The row a `TypeDefOrRef` coded index — e.g. one a decoded signature's
+  /// `named` type carries — references, or `nil` if it is null.
+  ///
+  /// The index's tag selects `TypeDef`/`TypeRef`/`TypeSpec` and its row is
+  /// 1-based; this opens the named table at `row - 1`. A `TypeSpec` reference,
+  /// which itself names a `#Blob` signature rather than a `TypeName`, resolves to
+  /// the `TypeSpec` row.
+  @_lifetime(borrow self)
+  public func resolve(_ reference: TypeDefOrRef) throws(WinMDError) -> Tuple? {
+    guard reference.row != 0 else { return nil }
+    guard reference.tag < TypeDefOrRef.tables.count,
+        let schema = TypeDefOrRef.tables[reference.tag]
+    else { throw .BadImageFormat }
+    let storage = self.storage
+    guard let tuple = try storage.tuple(reference.row - 1, of: schema) else {
+      throw .BadImageFormat
+    }
+    return tuple
+  }
+
   /// The rows of `schema` whose foreign-key `column` references `target`.
   ///
   /// This is reverse navigation: the inverse of `Tuple.resolve`. Where

--- a/Sources/WinMD/Database.swift
+++ b/Sources/WinMD/Database.swift
@@ -153,4 +153,31 @@ public struct Database: ~Escapable {
   public func rows(of table: Table) -> Cursor {
     Cursor(storage, table)
   }
+
+  /// The rows of `schema` whose foreign-key `column` references `target`.
+  ///
+  /// This is reverse navigation: the inverse of `Tuple.resolve`. Where
+  /// `resolve` follows a row's foreign key forward to the one row it names,
+  /// `referencing` finds every row of `schema` whose `column` names `target`.
+  ///
+  /// The stored cell an owning row holds to point at `target` is computed from
+  /// `column`'s type and `target`'s 0-based row (ECMA-335 rows are 1-based, so
+  /// the stored row is `target.row + 1`):
+  ///   - a `simple` index to table `S` requires `S` to be `target`'s table and
+  ///     stores `target.row + 1`;
+  ///   - a `coded` index `C` stores `((target.row + 1) << C.bits) | tag`, where
+  ///     `tag` is the position of `target`'s table within `C.tables`.
+  /// A column of any other kind is not a foreign key and is a usage error.
+  ///
+  /// When `schema` is physically sorted on this very column — its intrinsic
+  /// `key` is `column` and the runtime `Sorted` bit is set — the matching rows
+  /// form a contiguous run, found by binary search in `O(log n)`. Otherwise the
+  /// result is an `O(rows)` linear scan that yields the same matches.
+  @_lifetime(borrow self)
+  public func referencing(_ target: borrowing Tuple,
+                          in schema: TableSchema.Type,
+                          by column: Int) throws(WinMDError) -> Filter {
+    let storage = self.storage
+    return try storage.referencing(target, in: schema, by: column)
+  }
 }

--- a/Sources/WinMD/Error.swift
+++ b/Sources/WinMD/Error.swift
@@ -5,6 +5,7 @@ public enum WinMDError: Error {
   case BadImageFormat
   case BlobsHeapNotFound
   case GUIDHeapNotFound
+  case InvalidColumn
   case InvalidIndex
   case MissingTableStream
   case StringsHeapNotFound

--- a/Sources/WinMD/Field.swift
+++ b/Sources/WinMD/Field.swift
@@ -1,0 +1,11 @@
+// Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+/// A table field.
+///
+/// Accessible fields have a name which the user can use to reference the
+/// field, and a type which indicates how to read the value of the field.
+public struct Field: Sendable {
+  public let name: StaticString
+  public let type: ColumnType
+}

--- a/Sources/WinMD/Iteration.swift
+++ b/Sources/WinMD/Iteration.swift
@@ -1,6 +1,8 @@
 // Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
+public import struct Foundation.UUID
+
 /// A singular row from a table.
 ///
 /// A row is a singular entity in a table. This is an iterable entity in the
@@ -51,14 +53,14 @@ public struct Tuple: ~Escapable {
   }
 
   /// The number of columns in the row.
-  public var count: Int { table.schema.columns.count }
+  public var count: Int { table.schema.fields.count }
 
   /// The raw decoded value of column `column`.
   public subscript(_ column: Int) -> Int {
     // Recover the column's offset and width from the schema's narrow layout
     // and the table's width bitset.
     let base = table.range.lowerBound + row * table.stride
-                  + table.offset(column)
+               + table.offset(column)
     let width = table.width(column)
     switch width {
     case 1: return Int(storage.bytes.read(at: base, as: UInt8.self))
@@ -70,12 +72,73 @@ public struct Tuple: ~Escapable {
 
   /// The name of column `column`.
   public func name(of column: Int) -> StaticString {
-    table.schema.columns[column].name
+    table.schema.fields[column].name
   }
 
   /// The type of column `column`.
   public func type(of column: Int) -> ColumnType {
-    table.schema.columns[column].type
+    table.schema.fields[column].type
+  }
+
+  /// The ordinal of the column named `name`, or `nil` if there is none.
+  ///
+  /// A query addresses columns by string (a parsed SQL query names them so);
+  /// the ordinal is resolved once against the schema and the cell is then read
+  /// by ordinal on each row.
+  public func ordinal(for name: String) -> Int? {
+    for column in 0 ..< count {
+      // `StaticString` describes its UTF-8 bytes; compare against the spelling
+      // without materialising it where the names differ.
+      if "\(table.schema.fields[column].name)" == name {
+        return column
+      }
+    }
+    return nil
+  }
+
+  /// Throws `.InvalidColumn` unless `column` is a valid ordinal of this row.
+  private func validate(_ column: Int) throws(WinMDError) {
+    guard 0 <= column, column < count else { throw .InvalidColumn }
+  }
+
+  /// The string the heap column `column` references.
+  ///
+  /// Reads the raw cell and resolves it through the "Strings" heap. The column
+  /// must be a `#Strings` heap index; a column of any other kind is a usage
+  /// error and throws.
+  public func string(_ column: Int) throws(WinMDError) -> String {
+    try validate(column)
+    guard case .index(.heap(.string)) = type(of: column) else {
+      throw .InvalidColumn
+    }
+    return try StringsHeap(storage.strings).string(at: self[column])
+  }
+
+  /// The blob the heap column `column` references.
+  ///
+  /// Reads the raw cell and resolves it through the "Blob" heap. The column
+  /// must be a `#Blob` heap index; a column of any other kind is a usage error
+  /// and throws.
+  @_lifetime(copy self)
+  public func blob(_ column: Int) throws(WinMDError) -> Blob {
+    try validate(column)
+    guard case .index(.heap(.blob)) = type(of: column) else {
+      throw .InvalidColumn
+    }
+    return try BlobsHeap(storage.blob).blob(at: self[column])
+  }
+
+  /// The GUID the heap column `column` references.
+  ///
+  /// Reads the raw cell and resolves it through the "GUID" heap. The column
+  /// must be a `#GUID` heap index; a column of any other kind is a usage error
+  /// and throws.
+  public func guid(_ column: Int) throws(WinMDError) -> UUID {
+    try validate(column)
+    guard case .index(.heap(.guid)) = type(of: column) else {
+      throw .InvalidColumn
+    }
+    return try GUIDHeap(storage.guid)[self[column]]
   }
 }
 
@@ -88,7 +151,7 @@ extension Tuple /* : CustomDebugStringConvertible */ {
     var fields = Array<String>()
     for column in 0 ..< count {
       let value = self[column]
-      switch table.schema.columns[column].type {
+      switch table.schema.fields[column].type {
       case let .index(.heap(heap)) where heap == .string:
         let string = StringsHeap(storage.strings)[value]
         fields.append("\(name(of: column)): \(string)")
@@ -122,8 +185,8 @@ extension Row {
   /// The rows of the named table.
   @_lifetime(copy self)
   internal func rows<Target: TableSchema>(of schema: Target.Type,
-                                        from begin: Int = 0,
-                                        to end: Int? = nil) throws(WinMDError)
+                                          from begin: Int = 0,
+                                          to end: Int? = nil) throws(WinMDError)
       -> TableIterator<Target> {
     let storage = self.storage
     return try storage.rows(of: schema, from: begin, to: end)

--- a/Sources/WinMD/Iteration.swift
+++ b/Sources/WinMD/Iteration.swift
@@ -140,6 +140,42 @@ public struct Tuple: ~Escapable {
     }
     return try GUIDHeap(storage.guid)[self[column]]
   }
+
+  /// The tuple the foreign-key column `column` references, or `nil` if the
+  /// reference is null.
+  ///
+  /// Decodes the raw cell as a simple or coded index and opens the referenced
+  /// row. ECMA-335 row indices are 1-based, so a stored value `N` is the
+  /// 0-based row `N - 1`, and the value `0` (a coded index whose row is `0`) is
+  /// the null reference and yields `nil`. The column must be a `simple` or
+  /// `coded` index; a heap index or a constant column is not a foreign key and
+  /// is a usage error that throws. Resolution is `O(1)`: the target row is
+  /// addressed directly, with no scan.
+  @_lifetime(copy self)
+  public func resolve(_ column: Int) throws(WinMDError) -> Tuple? {
+    try validate(column)
+    switch type(of: column) {
+    case let .index(.simple(schema)):
+      let index = self[column]
+      guard index != 0 else { return nil }
+      guard let tuple = try storage.tuple(index - 1, of: schema) else {
+        throw .BadImageFormat
+      }
+      return tuple
+    case let .index(.coded(coded)):
+      let value: any CodedIndex = coded.init(rawValue: self[column])
+      guard value.row != 0 else { return nil }
+      guard value.tag < coded.tables.count,
+          let schema = coded.tables[value.tag]
+      else { throw .BadImageFormat }
+      guard let tuple = try storage.tuple(value.row - 1, of: schema) else {
+        throw .BadImageFormat
+      }
+      return tuple
+    default:
+      throw .InvalidColumn
+    }
+  }
 }
 
 // A row dumped column-by-column is a debugging representation, so this would be

--- a/Sources/WinMD/Iteration.swift
+++ b/Sources/WinMD/Iteration.swift
@@ -329,4 +329,17 @@ public struct Cursor: ~Escapable {
     @_lifetime(copy self)
     get { offset < rows ? Tuple(start + offset, table, storage) : nil }
   }
+
+  /// The open table this cursor walks.
+  ///
+  /// Exposed to the structured-query executor (`where(_: Predicate)`), which
+  /// inspects the table's schema and `Sorted` bit to decide between a binary
+  /// search and a scan.
+  internal var relation: Table { table }
+
+  /// The borrowed storage view this cursor reads from.
+  internal var backing: Storage {
+    @_lifetime(copy self)
+    get { storage }
+  }
 }

--- a/Sources/WinMD/Iteration.swift
+++ b/Sources/WinMD/Iteration.swift
@@ -55,6 +55,13 @@ public struct Tuple: ~Escapable {
   /// The number of columns in the row.
   public var count: Int { table.schema.fields.count }
 
+  /// The 0-based index of the row within its table.
+  ///
+  /// ECMA-335 row indices are 1-based; this is the 0-based index the cursor
+  /// addresses the row by. A consumer presenting the SQL `rowid` pseudo-column
+  /// (the SQLite-style 1-based row index) reads `index + 1`.
+  public var index: Int { row }
+
   /// The raw decoded value of column `column`.
   public subscript(_ column: Int) -> Int {
     // Recover the column's offset and width from the schema's narrow layout

--- a/Sources/WinMD/Iteration.swift
+++ b/Sources/WinMD/Iteration.swift
@@ -183,6 +183,24 @@ public struct Tuple: ~Escapable {
       throw .InvalidColumn
     }
   }
+
+}
+
+extension Row {
+  /// A typed row recovered from a type-erased `Tuple`, or `nil` on a table
+  /// mismatch.
+  ///
+  /// A `Tuple` is a type-erased view; `resolve` over a coded index yields one
+  /// because the target table is chosen at runtime by the tag. When the caller
+  /// knows the target table — e.g. after selecting a coded-index tag —
+  /// `Row<Target>(tuple)` recovers the typed row: it checks the tuple's runtime
+  /// table identity against `Schema` (`table.number == Schema.number`) and, on a
+  /// match, wraps the tuple's `(row, table, storage)`. A mismatch yields `nil`.
+  @_lifetime(copy tuple)
+  public init?(_ tuple: borrowing Tuple) {
+    guard tuple.table.number == Schema.number else { return nil }
+    self.init(tuple.row, tuple.table, tuple.storage)
+  }
 }
 
 // A row dumped column-by-column is a debugging representation, so this would be
@@ -228,8 +246,8 @@ extension Row {
   /// The rows of the named table.
   @_lifetime(copy self)
   internal func rows<Target: TableSchema>(of schema: Target.Type,
-                                          from begin: Int = 0,
-                                          to end: Int? = nil) throws(WinMDError)
+                                        from begin: Int = 0,
+                                        to end: Int? = nil) throws(WinMDError)
       -> TableIterator<Target> {
     let storage = self.storage
     return try storage.rows(of: schema, from: begin, to: end)

--- a/Sources/WinMD/PhysicalSchema.swift
+++ b/Sources/WinMD/PhysicalSchema.swift
@@ -38,12 +38,12 @@ extension PhysicalSchema {
     // index; a row count that reaches that range forces the full 32-bit index.
     let range = 1 << (16 - index.bits)
     for tag in tables.indices {
-      let table = tables[tag]
-      // A table is not required to be present; if it is absent the number of
-      // rows that can be indexed is unknown, so we must assume a wide index. A
-      // present table forces the full 32-bit index once its row count reaches
+      // A reserved tag names no table, so it contributes no rows to the width.
+      guard let table = tables[tag] else { continue }
+      // An absent target table has no rows, so it cannot force a wide index.
+      guard valid & (1 << table.number) != 0 else { continue }
+      // A present table forces the full 32-bit index once its row count reaches
       // the range; below it the compressed width suffices.
-      guard valid & (1 << table.number) != 0 else { return 4 }
       if rows(of: table.number) >= range { return 4 }
     }
     return 2

--- a/Sources/WinMD/Query.swift
+++ b/Sources/WinMD/Query.swift
@@ -1,0 +1,191 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+/// The closure query combinators over a generic `Cursor`.
+///
+/// A query is a borrowed traversal of the mapped buffer: filtering with `where`
+/// and mapping with `select` build lazy `~Escapable` stages that store escapable
+/// closures of the form `(borrowing Tuple) -> …`, while the cursor and the
+/// transiently materialised `Tuple` stay on the borrowed view side of the
+/// escape boundary. Nothing is materialised and nothing allocates per row;
+/// stages compose and the scan runs only when a terminal consumes it.
+///
+/// A projection must yield an escapable value. `.select({ $0 })` does not
+/// surface the row — it silently infers `T = ()`, because a `Tuple` cannot
+/// escape the closure. To surface rows themselves, hand them to the
+/// `(borrowing Tuple) -> Void` callback of `forEach` rather than returning them.
+
+// MARK: - Filter
+
+/// A lazy filtered stage over a `Cursor`.
+///
+/// It holds the base cursor and a predicate; the predicate is evaluated only
+/// when a terminal consumes the stage.
+public struct Filter: ~Escapable {
+  private let base: Cursor
+  private let predicate: (borrowing Tuple) -> Bool
+
+  @_lifetime(copy base)
+  internal init(_ base: borrowing Cursor,
+                _ predicate: @escaping (borrowing Tuple) -> Bool) {
+    self.base = copy base
+    self.predicate = predicate
+  }
+
+  /// Maps each surviving row through `transform`, yielding an escapable value.
+  @_lifetime(copy self)
+  public func select<T>(_ transform: @escaping (borrowing Tuple) -> T)
+      -> Projection<T> {
+    Projection(base, where: predicate, select: transform)
+  }
+
+  // MARK: Terminals
+
+  /// Applies `body` to each surviving row.
+  public func forEach(_ body: (borrowing Tuple) -> Void) {
+    for row in 0 ..< base.count {
+      guard let tuple = base[row] else { continue }
+      if predicate(tuple) {
+        body(tuple)
+      }
+    }
+  }
+
+  /// The first surviving row satisfying `predicate`, passed to `body`.
+  ///
+  /// Returns the escapable value `body` produces, or `nil` if no row matches.
+  public func first<T>(where predicate: (borrowing Tuple) -> Bool,
+                       _ body: (borrowing Tuple) -> T) -> T? {
+    for row in 0 ..< base.count {
+      guard let tuple = base[row] else { continue }
+      if self.predicate(tuple), predicate(tuple) {
+        return body(tuple)
+      }
+    }
+    return nil
+  }
+
+  /// Folds the surviving rows into `initial` with `next`.
+  public func reduce<R>(_ initial: R,
+                        _ next: (R, borrowing Tuple) -> R) -> R {
+    var result = initial
+    for row in 0 ..< base.count {
+      guard let tuple = base[row] else { continue }
+      if predicate(tuple) {
+        result = next(result, tuple)
+      }
+    }
+    return result
+  }
+
+  /// The number of surviving rows.
+  public func count() -> Int {
+    var count = 0
+    for row in 0 ..< base.count {
+      guard let tuple = base[row] else { continue }
+      if predicate(tuple) {
+        count += 1
+      }
+    }
+    return count
+  }
+}
+
+// MARK: - Projection
+
+/// A lazy projected stage over a `Cursor`.
+///
+/// It holds the base cursor, an optional predicate, and a transform mapping a
+/// surviving row to an escapable value; both run only when a terminal consumes
+/// the stage.
+public struct Projection<T>: ~Escapable {
+  private let base: Cursor
+  private let predicate: ((borrowing Tuple) -> Bool)?
+  private let transform: (borrowing Tuple) -> T
+
+  @_lifetime(copy base)
+  internal init(_ base: borrowing Cursor,
+                where predicate: ((borrowing Tuple) -> Bool)? = nil,
+                select transform: @escaping (borrowing Tuple) -> T) {
+    self.base = copy base
+    self.predicate = predicate
+    self.transform = transform
+  }
+
+  // MARK: Terminals
+
+  /// Applies `body` to each projected value.
+  public func forEach(_ body: (T) -> Void) {
+    for row in 0 ..< base.count {
+      guard let tuple = base[row] else { continue }
+      if predicate?(tuple) ?? true {
+        body(transform(tuple))
+      }
+    }
+  }
+
+  /// The first projected value whose row satisfies `predicate`.
+  public func first(where predicate: (borrowing Tuple) -> Bool) -> T? {
+    for row in 0 ..< base.count {
+      guard let tuple = base[row] else { continue }
+      if self.predicate?(tuple) ?? true, predicate(tuple) {
+        return transform(tuple)
+      }
+    }
+    return nil
+  }
+
+  /// Folds the projected values into `initial` with `next`.
+  public func reduce<R>(_ initial: R, _ next: (R, T) -> R) -> R {
+    var result = initial
+    for row in 0 ..< base.count {
+      guard let tuple = base[row] else { continue }
+      if predicate?(tuple) ?? true {
+        result = next(result, transform(tuple))
+      }
+    }
+    return result
+  }
+
+  /// The number of projected values.
+  public func count() -> Int {
+    guard let predicate else { return base.count }
+    var count = 0
+    for row in 0 ..< base.count {
+      guard let tuple = base[row] else { continue }
+      if predicate(tuple) {
+        count += 1
+      }
+    }
+    return count
+  }
+}
+
+// MARK: - Cursor entry points
+
+extension Cursor {
+  /// Filters the rows by `predicate`, yielding a lazy `Filter` stage.
+  @_lifetime(copy self)
+  public func `where`(_ predicate: @escaping (borrowing Tuple) -> Bool)
+      -> Filter {
+    Filter(self, predicate)
+  }
+
+  /// Maps each row through `transform`, yielding a lazy `Projection` stage.
+  @_lifetime(copy self)
+  public func select<T>(_ transform: @escaping (borrowing Tuple) -> T)
+      -> Projection<T> {
+    Projection(self, select: transform)
+  }
+
+  /// Maps the rows satisfying `predicate` through `transform`.
+  ///
+  /// This is the common-case entry point; `where(_:).select(_:)` reads better
+  /// when a query is built up incrementally.
+  @_lifetime(copy self)
+  public func select<T>(_ transform: @escaping (borrowing Tuple) -> T,
+                        where predicate: @escaping (borrowing Tuple) -> Bool)
+      -> Projection<T> {
+    Projection(self, where: predicate, select: transform)
+  }
+}

--- a/Sources/WinMD/RowLayout.swift
+++ b/Sources/WinMD/RowLayout.swift
@@ -1,7 +1,7 @@
 // Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
-extension Column {
+extension Field {
   /// The narrow width, in bytes, of the column.
   ///
   /// A constant column is always its declared size. An index column is assumed
@@ -19,16 +19,16 @@ extension Column {
 
 /// The narrow byte offset of each column, in column order.
 ///
-/// Column `i`'s narrow offset is the prefix sum of the narrow widths of the
-/// columns preceding it. These offsets are a compile-time property of a schema;
+/// Field `i`'s narrow offset is the prefix sum of the narrow widths of the
+/// fields preceding it. These offsets are a compile-time property of a schema;
 /// the wide indices of a particular database shift them by the width bitset at
 /// read time.
-internal func offsets<let N: Int>(_ columns: InlineArray<N, Column>)
+internal func offsets<let N: Int>(_ fields: InlineArray<N, Field>)
     -> InlineArray<N, Int> {
   InlineArray<N, Int> { i in
     var offset = 0
     for j in 0 ..< i {
-      offset = offset + columns[j].width
+      offset = offset + fields[j].width
     }
     return offset
   }

--- a/Sources/WinMD/Signature.swift
+++ b/Sources/WinMD/Signature.swift
@@ -1,0 +1,468 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+/// The calling convention a `MethodSignature` opens with (ECMA-335 §II.23.2.1).
+///
+/// The first byte of a method signature is a bitmask: the low nibble selects the
+/// convention, the high bits carry the `HASTHIS`/`EXPLICITTHIS`/`GENERIC` flags.
+/// The flags are surfaced separately on `MethodSignature`; this names the
+/// convention the low nibble selects.
+public enum CallingConvention: Sendable {
+  /// A managed method with a fixed parameter list (`DEFAULT`).
+  case `default`
+  /// A managed vararg method (`VARARG`).
+  case vararg
+  /// An unmanaged C call (`C`).
+  case c
+  /// An unmanaged stdcall (`STDCALL`).
+  case stdcall
+  /// An unmanaged thiscall (`THISCALL`).
+  case thiscall
+  /// An unmanaged fastcall (`FASTCALL`).
+  case fastcall
+}
+
+/// The kind of named type a `SignatureType.named` holds (ECMA-335 §II.23.2.12).
+///
+/// `CLASS` names a reference type, `VALUETYPE` a value type; both carry a
+/// `TypeDefOrRefOrSpec` coded index naming the type.
+public enum NamedKind: Sendable {
+  case `class`
+  case value
+}
+
+/// The scope a generic `SignatureType.variable` is bound in (ECMA-335
+/// §II.23.2.12).
+///
+/// `VAR` references the enclosing type's generic parameters, `MVAR` the
+/// enclosing method's.
+public enum VariableScope: Sendable {
+  case type
+  case method
+}
+
+/// A custom modifier on a type (ECMA-335 §II.23.2.7).
+///
+/// `CMOD_REQD`/`CMOD_OPT` decorate a type with a `TypeDefOrRefOrSpec` naming the
+/// modifier type; `required` distinguishes the two.
+public struct Modifier: Sendable {
+  /// Whether the modifier is required (`CMOD_REQD`) rather than optional
+  /// (`CMOD_OPT`).
+  public let required: Bool
+
+  /// The type the modifier names.
+  public let type: TypeDefOrRef
+
+  public init(required: Bool, type: TypeDefOrRef) {
+    self.required = required
+    self.type = type
+  }
+}
+
+/// The shape of a general (multi-dimensional) array (ECMA-335 §II.23.2.13).
+///
+/// `SZARRAY` is the common single-dimension, zero-bound case and is modelled by
+/// `SignatureType.array`; the general `ARRAY` form additionally carries a rank
+/// and an explicit, possibly partial, list of sizes and lower bounds.
+public struct ArrayShape: Sendable {
+  /// The number of dimensions.
+  public let rank: Int
+
+  /// The sizes of the leading dimensions; dimensions beyond this are unsized.
+  public let sizes: Array<Int>
+
+  /// The lower bounds of the leading dimensions; dimensions beyond this are
+  /// zero-bound.
+  public let bounds: Array<Int>
+
+  public init(rank: Int, sizes: Array<Int>, bounds: Array<Int>) {
+    self.rank = rank
+    self.sizes = sizes
+    self.bounds = bounds
+  }
+}
+
+/// A decoded `#Blob` type signature (ECMA-335 §II.23.2.12).
+///
+/// This is a structured value tree, not resolved navigation: a `named` type
+/// holds the `TypeDefOrRef` coded-index *value* the signature carried, exactly
+/// as the SQL AST holds a structured `Predicate` rather than rows. Resolving a
+/// named type to a `TypeDef`/`TypeRef` row is separate navigation the consumer
+/// performs against a database.
+public indirect enum SignatureType: Sendable {
+  /// A built-in type (`VOID`, `BOOLEAN`, `I4`, `STRING`, `OBJECT`, …).
+  case primitive(PrimitiveType)
+  /// An unmanaged pointer to a type (`PTR`).
+  case pointer(SignatureType)
+  /// A managed reference to a type (`BYREF`).
+  case reference(SignatureType)
+  /// A single-dimension, zero-bound array of a type (`SZARRAY`).
+  case array(SignatureType)
+  /// A general, multi-dimensional array of a type (`ARRAY`).
+  case matrix(SignatureType, ArrayShape)
+  /// A named class or value type (`CLASS`/`VALUETYPE`).
+  case named(kind: NamedKind, TypeDefOrRef)
+  /// A generic type or method parameter (`VAR`/`MVAR`).
+  case variable(scope: VariableScope, Int)
+  /// A generic type instantiation (`GENERICINST`).
+  case instance(SignatureType, Array<SignatureType>)
+  /// A type decorated with one or more custom modifiers (`CMOD_REQD`/
+  /// `CMOD_OPT`).
+  case modified(SignatureType, modifiers: Array<Modifier>)
+  /// A function pointer carrying a nested method signature (`FNPTR`).
+  case function(MethodSignature)
+}
+
+/// A built-in element type (ECMA-335 §II.23.1.16).
+///
+/// These are the `ELEMENT_TYPE_*` leaves that carry no further operands: the
+/// numeric and character primitives, plus `VOID`, `STRING`, `OBJECT`, the native
+/// integers, and the typed reference.
+public enum PrimitiveType: Sendable {
+  case void
+  case boolean
+  case char
+  case int1
+  case uint1
+  case int2
+  case uint2
+  case int4
+  case uint4
+  case int8
+  case uint8
+  case float
+  case double
+  /// A native signed integer (`I`).
+  case intptr
+  /// A native unsigned integer (`U`).
+  case uintptr
+  case string
+  case object
+  /// A typed reference (`TYPEDBYREF`).
+  case typedref
+}
+
+/// A decoded method signature (ECMA-335 §II.23.2.1).
+public struct MethodSignature: Sendable {
+  /// The calling convention the leading byte selects.
+  public let convention: CallingConvention
+
+  /// Whether the method has an implicit `this` parameter (`HASTHIS`).
+  public let `instance`: Bool
+
+  /// Whether `this` is passed explicitly as the first parameter
+  /// (`EXPLICITTHIS`).
+  public let explicit: Bool
+
+  /// The count of generic parameters (`GENERIC`); zero for a non-generic method.
+  public let generics: Int
+
+  /// The return type.
+  public let returns: SignatureType
+
+  /// The parameter types, in order.
+  public let parameters: Array<SignatureType>
+
+  public init(convention: CallingConvention, instance: Bool, explicit: Bool,
+              generics: Int, returns: SignatureType,
+              parameters: Array<SignatureType>) {
+    self.convention = convention
+    self.instance = instance
+    self.explicit = explicit
+    self.generics = generics
+    self.returns = returns
+    self.parameters = parameters
+  }
+}
+
+/// A decoded field signature (ECMA-335 §II.23.2.4).
+public struct FieldSignature: Sendable {
+  /// The field's type.
+  public let type: SignatureType
+
+  public init(type: SignatureType) {
+    self.type = type
+  }
+}
+
+// MARK: - Decoding
+
+/// A cursor decoding a `#Blob` signature byte stream (ECMA-335 §II.23.2).
+///
+/// The cursor borrows the blob's bytes and advances a position through them,
+/// reading compressed integers with the shared `RawSpan.compressed` and recursing
+/// over the `Type` grammar. It is `~Escapable` because it holds a `RawSpan`.
+internal struct SignatureDecoder: ~Escapable {
+  private let bytes: RawSpan
+  private var position: Int
+
+  @_lifetime(copy bytes)
+  internal init(_ bytes: RawSpan) {
+    self.bytes = bytes
+    self.position = 0
+  }
+
+  /// Reads the next raw byte and advances past it.
+  private mutating func byte() throws(WinMDError) -> UInt8 {
+    guard position < bytes.byteCount else { throw .BadImageFormat }
+    let value = bytes.read(at: position, as: UInt8.self)
+    position = position + 1
+    return value
+  }
+
+  /// Throws unless every byte of the blob has been consumed. A top-level
+  /// signature must fill its `#Blob` entry exactly; trailing bytes after an
+  /// otherwise-valid prefix are malformed metadata, not a shorter signature.
+  internal borrowing func end() throws(WinMDError) {
+    guard position == bytes.byteCount else { throw .BadImageFormat }
+  }
+
+  /// Validates the compressed-integer encoding at `position` and returns its
+  /// length in bytes (ECMA-335 §II.23.2).
+  ///
+  /// The lead byte selects the encoding: `0x00..0x7f` is 1 byte, `0x80..0xbf`
+  /// 2 bytes, and `0xc0..0xdf` 4 bytes; `0xe0` and above is not a defined
+  /// encoding. A well-formed encoding must also fit within the blob. This guards
+  /// the shared `RawSpan.compressed`, which would otherwise `fatalError` or read
+  /// past the end on malformed input.
+  private func width() throws(WinMDError) -> Int {
+    guard position < bytes.byteCount else { throw .BadImageFormat }
+    let lead = bytes.read(at: position, as: UInt8.self)
+    let length = switch lead {
+    case 0x00 ... 0x7f: 1
+    case 0x80 ... 0xbf: 2
+    case 0xc0 ... 0xdf: 4
+    default:            throw .BadImageFormat
+    }
+    guard position + length <= bytes.byteCount else { throw .BadImageFormat }
+    return length
+  }
+
+  /// Reads the next compressed unsigned integer and advances past it.
+  private mutating func compressed() throws(WinMDError) -> Int {
+    _ = try width()
+    let (begin, value) = bytes.compressed(at: position)
+    position = begin
+    return value
+  }
+
+  /// Reads the next compressed *signed* integer and advances past it.
+  ///
+  /// The value is stored as its compressed-unsigned encoding rotated left by one
+  /// bit with the sign in the least-significant bit (ECMA-335 §II.23.2): the
+  /// magnitude is `value >> 1`, and a set low bit selects the negative value
+  /// `magnitude - 2^(databits - 1)`, where `databits` is 7, 14, or 29 for the
+  /// 1-, 2-, or 4-byte encoding.
+  private mutating func compressedSigned() throws(WinMDError) -> Int {
+    let length = try width()
+    let (begin, value) = bytes.compressed(at: position)
+    position = begin
+    let databits = switch length {
+    case 1:  7
+    case 2:  14
+    default: 29
+    }
+    let magnitude = value >> 1
+    return value & 1 == 1 ? magnitude - (1 << (databits - 1)) : magnitude
+  }
+
+  /// Reads a `TypeDefOrRefOrSpec` coded index and advances past it.
+  ///
+  /// In a signature the coded index is a compressed unsigned integer whose low
+  /// two bits are the tag selecting `TypeDef`/`TypeRef`/`TypeSpec` and whose
+  /// remaining bits are the 1-based row (ECMA-335 §II.23.2.8) — the same bit
+  /// layout `TypeDefOrRef` decodes, so the decoded value is its `rawValue`.
+  private mutating func reference() throws(WinMDError) -> TypeDefOrRef {
+    try TypeDefOrRef(rawValue: compressed())
+  }
+
+  /// Reads any leading `CMOD_REQD`/`CMOD_OPT` run, in order.
+  private mutating func modifiers() throws(WinMDError) -> Array<Modifier> {
+    var modifiers = Array<Modifier>()
+    while true {
+      guard position < bytes.byteCount else { break }
+      let element = CorElementType(rawValue: bytes.read(at: position, as: UInt8.self))
+      guard element == .etCModReqd || element == .etCModOpt else { break }
+      position = position + 1
+      try modifiers.append(Modifier(required: element == .etCModReqd,
+                                    type: reference()))
+    }
+    return modifiers
+  }
+
+  /// Decodes one `Type` (ECMA-335 §II.23.2.12), including any leading custom
+  /// modifiers. `VOID` is accepted only when `erasable` — a return type, or a
+  /// pointer's pointee (`PTR CustomMod* VOID`); in any other position it is
+  /// malformed metadata.
+  internal mutating func type(erasable: Bool = false) throws(WinMDError)
+      -> SignatureType {
+    let modifiers = try modifiers()
+    let bare = try unmodified(erasable: erasable)
+    return modifiers.isEmpty ? bare : .modified(bare, modifiers: modifiers)
+  }
+
+  /// Decodes one `Type` without consuming leading custom modifiers.
+  private mutating func unmodified(erasable: Bool) throws(WinMDError)
+      -> SignatureType {
+    let element = CorElementType(rawValue: try byte())
+    return switch element {
+    case .etVoid:
+      if erasable { .primitive(.void) } else { throw .BadImageFormat }
+    case .etBoolean:     .primitive(.boolean)
+    case .etChar:        .primitive(.char)
+    case .etInt1:        .primitive(.int1)
+    case .etUInt1:       .primitive(.uint1)
+    case .etInt2:        .primitive(.int2)
+    case .etUInt2:       .primitive(.uint2)
+    case .etInt4:        .primitive(.int4)
+    case .etUInt4:       .primitive(.uint4)
+    case .etInt8:        .primitive(.int8)
+    case .etUInt8:       .primitive(.uint8)
+    case .etFloat:       .primitive(.float)
+    case .etDouble:      .primitive(.double)
+    case .etInt:         .primitive(.intptr)
+    case .etUInt:        .primitive(.uintptr)
+    case .etString:      .primitive(.string)
+    case .etObject:      .primitive(.object)
+    case .etTypedByRef:  .primitive(.typedref)
+    case .etPtr:         try .pointer(type(erasable: true))
+    case .etByRef:       try .reference(type())
+    case .etSzArray:     try .array(type())
+    case .etClass:       try .named(kind: .class, reference())
+    case .etValueType:   try .named(kind: .value, reference())
+    case .etVar:         try .variable(scope: .type, compressed())
+    case .etMVar:        try .variable(scope: .method, compressed())
+    case .etArray:       try matrix()
+    case .etGenericInst: try instance()
+    case .etFnPtr:       try .function(method())
+    default:             throw .BadImageFormat
+    }
+  }
+
+  /// Decodes the operands of a general `ARRAY` (ECMA-335 §II.23.2.13).
+  ///
+  /// The element type is followed by the rank, then a count and that many
+  /// sizes, then a count and that many lower bounds; the sizes are compressed
+  /// unsigned and the lower bounds compressed signed.
+  private mutating func matrix() throws(WinMDError) -> SignatureType {
+    let element = try type()
+    let rank = try compressed()
+    guard rank >= 1 else { throw .BadImageFormat }
+
+    var sizes = Array<Int>()
+    var count = try compressed()
+    guard count <= rank else { throw .BadImageFormat }
+    for _ in 0 ..< count {
+      try sizes.append(compressed())
+    }
+
+    var bounds = Array<Int>()
+    count = try compressed()
+    guard count <= rank else { throw .BadImageFormat }
+    for _ in 0 ..< count {
+      try bounds.append(compressedSigned())
+    }
+
+    return .matrix(element,
+                   ArrayShape(rank: rank, sizes: sizes, bounds: bounds))
+  }
+
+  /// Decodes the operands of `GENERICINST` (ECMA-335 §II.23.2.12).
+  ///
+  /// A `CLASS`/`VALUETYPE` named type follows, then a generic-argument count and
+  /// that many type arguments.
+  private mutating func instance() throws(WinMDError) -> SignatureType {
+    let element = CorElementType(rawValue: try byte())
+    let kind: NamedKind = switch element {
+    case .etClass:     .class
+    case .etValueType: .value
+    default:           throw .BadImageFormat
+    }
+    let base: SignatureType = try .named(kind: kind, reference())
+
+    var arguments = Array<SignatureType>()
+    for _ in try 0 ..< compressed() {
+      try arguments.append(type())
+    }
+    return .instance(base, arguments)
+  }
+
+  /// Decodes a method signature (ECMA-335 §II.23.2.1), the body of a method-def,
+  /// member-ref, or `FNPTR`.
+  internal mutating func method() throws(WinMDError) -> MethodSignature {
+    let prolog = try byte()
+    guard prolog & 0x80 == 0 else { throw .BadImageFormat }
+
+    let `instance` = prolog & 0x20 != 0    // HASTHIS
+    let explicit = prolog & 0x40 != 0      // EXPLICITTHIS
+    let generic = prolog & 0x10 != 0       // GENERIC
+    guard `instance` || !explicit else { throw .BadImageFormat }
+
+    let convention: CallingConvention = switch prolog & 0x0f {
+    case 0x00: .default
+    case 0x01: .c
+    case 0x02: .stdcall
+    case 0x03: .thiscall
+    case 0x04: .fastcall
+    case 0x05: .vararg
+    default: throw .BadImageFormat
+    }
+
+    let generics = generic ? try compressed() : 0
+    let count = try compressed()
+    let returns = try type(erasable: true)
+
+    var parameters = Array<SignatureType>()
+    for _ in 0 ..< count {
+      try parameters.append(type())
+    }
+
+    return MethodSignature(convention: convention, instance: `instance`,
+                           explicit: explicit, generics: generics,
+                           returns: returns, parameters: parameters)
+  }
+
+  /// Decodes a field signature (ECMA-335 §II.23.2.4): a `FIELD` prolog byte
+  /// followed by a single `Type`.
+  internal mutating func field() throws(WinMDError) -> FieldSignature {
+    let prolog = try byte()
+    guard prolog == 0x06 else { throw .BadImageFormat }
+    return FieldSignature(type: try type())
+  }
+}
+
+// MARK: - Accessors
+
+extension Row where Schema == Metadata.Tables.MethodDef {
+  /// The decoded method signature (ECMA-335 §II.23.2.1).
+  ///
+  /// Distinct from the `Signature` accessor, which vends the raw `#Blob`; this
+  /// decodes that blob into a structured `MethodSignature`.
+  public var prototype: MethodSignature {
+    get throws(WinMDError) {
+      let entry = try blob(.Signature)
+      var decoder = SignatureDecoder(entry.bytes)
+      let signature = try decoder.method()
+      guard signature.convention == .default ||
+          signature.convention == .vararg else { throw .BadImageFormat }
+      try decoder.end()
+      return signature
+    }
+  }
+}
+
+extension Row where Schema == Metadata.Tables.FieldDef {
+  /// The decoded field signature (ECMA-335 §II.23.2.4).
+  ///
+  /// Distinct from the `Signature` accessor, which vends the raw `#Blob`; this
+  /// decodes that blob into a structured `FieldSignature`.
+  public var declaration: FieldSignature {
+    get throws(WinMDError) {
+      let entry = try blob(.Signature)
+      var decoder = SignatureDecoder(entry.bytes)
+      let signature = try decoder.field()
+      try decoder.end()
+      return signature
+    }
+  }
+}

--- a/Sources/WinMD/Storage.swift
+++ b/Sources/WinMD/Storage.swift
@@ -80,4 +80,97 @@ internal struct Storage: ~Escapable {
     guard row >= 0, row < Int(table.rows) else { return nil }
     return Tuple(row, table, self)
   }
+
+  /// The rows of `schema` whose foreign-key `column` references `target`.
+  ///
+  /// The runtime (non-generic) sibling of `Database.referencing`: it opens the
+  /// owning table from a `TableSchema.Type` value, computes the encoded key an
+  /// owning row would hold to point at `target`, and returns the matching rows.
+  /// The cost is `O(log n)` when the table is sorted on `column` and `O(rows)`
+  /// otherwise; see `Database.referencing` for the encoding and the contract.
+  @_lifetime(copy self)
+  internal func referencing(_ target: borrowing Tuple,
+                            in schema: TableSchema.Type,
+                            by column: Int) throws(WinMDError) -> Filter {
+    guard valid & (1 << schema.number) != 0 else {
+      throw .TableNotFound
+    }
+    let slot = (valid & ((1 << schema.number) - 1)).nonzeroBitCount
+    let table = relations[slot]
+
+    // The stored cell an owning row holds to name `target`. ECMA-335 rows are
+    // 1-based, so `target`'s 0-based row is stored as `target.row + 1`.
+    let row = target.row + 1
+    guard column >= 0, column < schema.fields.count else { throw .InvalidColumn }
+    let encoded: Int = switch schema.fields[column].type {
+    case let .index(.simple(referent)):
+      // A simple index must name `target`'s own table.
+      if referent == target.table.schema {
+        row
+      } else {
+        throw .InvalidColumn
+      }
+    case let .index(.coded(coded)):
+      // A coded index tags the row with the position of `target`'s table among
+      // the index's tables: `(row << bits) | tag`.
+      if let tag = tag(of: target.table.schema, in: coded) {
+        (row << coded.bits) | tag
+      } else {
+        throw .InvalidColumn
+      }
+    default:
+      throw .InvalidColumn
+    }
+
+    // A table physically sorted on this very column holds its matches as a
+    // contiguous run; binary-search the `[lower, upper)` bound of `encoded`.
+    if schema.key == column, sorted & (1 << schema.number) != 0 {
+      let count = Int(table.rows)
+      let lower = bound(table, column, encoded, count, strict: false)
+      let upper = bound(table, column, encoded, count, strict: true)
+      let cursor = Cursor(self, table, from: lower, to: upper)
+      return Filter(cursor, { _ in true })
+    }
+
+    // Otherwise scan, matching the raw cell against the encoded key.
+    let cursor = Cursor(self, table)
+    return cursor.where { $0[column] == encoded }
+  }
+
+  /// The partition point of `column` against `value` over `[0, count)`.
+  ///
+  /// `column` is the sorted key of `table`, so its cells are non-decreasing.
+  /// With `strict == false` this is the lower bound (the first row whose cell is
+  /// `>= value`); with `strict == true` the upper bound (the first row whose
+  /// cell is `> value`). Together they bracket the run equal to `value`. The
+  /// search is `O(log count)`.
+  private func bound(_ table: Table, _ column: Int, _ value: Int, _ count: Int,
+                     strict: Bool) -> Int {
+    var lo = 0
+    var hi = count
+    while lo < hi {
+      let mid = lo + (hi - lo) / 2
+      let cell = Tuple(mid, table, self)[column]
+      if cell < value || (strict && cell == value) {
+        lo = mid + 1
+      } else {
+        hi = mid
+      }
+    }
+    return lo
+  }
+
+  /// The tag of `schema` within the tables of `coded`, or `nil` if absent.
+  ///
+  /// The tag is the position of the table in the coded index's table list,
+  /// found by a linear metatype comparison (`Span` admits no `firstIndex`).
+  private func tag(of schema: TableSchema.Type,
+                   in coded: CodedIndex.Type) -> Int? {
+    for index in 0 ..< coded.tables.count {
+      if let table = coded.tables[index], table == schema {
+        return index
+      }
+    }
+    return nil
+  }
 }

--- a/Sources/WinMD/Storage.swift
+++ b/Sources/WinMD/Storage.swift
@@ -53,4 +53,23 @@ internal struct Storage: ~Escapable {
     let slot = (valid & ((1 << Schema.number) - 1)).nonzeroBitCount
     return TableIterator<Schema>(self, relations[slot], from: begin, to: end)
   }
+
+  /// The `Tuple` at the 0-based `row` of the table described by `schema`.
+  ///
+  /// This is the runtime (non-generic) sibling of `rows(of:)`: it opens a table
+  /// from a `TableSchema.Type` *value* rather than a static `Schema`, which is
+  /// what foreign-key navigation needs — the target table of an index is only
+  /// known at runtime, off the column's `Index`. The present table's slot is
+  /// found by the same population-count math as `rows(of:)`, off `schema.number`
+  /// read from the metatype. `row` is bounds-checked against the table's row
+  /// count; an absent table or an out-of-range row yields `nil`.
+  @_lifetime(copy self)
+  internal func tuple(_ row: Int, of schema: TableSchema.Type)
+      throws(WinMDError) -> Tuple? {
+    guard valid & (1 << schema.number) != 0 else { return nil }
+    let slot = (valid & ((1 << schema.number) - 1)).nonzeroBitCount
+    let table = relations[slot]
+    guard row >= 0, row < Int(table.rows) else { return nil }
+    return Tuple(row, table, self)
+  }
 }

--- a/Sources/WinMD/Storage.swift
+++ b/Sources/WinMD/Storage.swift
@@ -143,9 +143,10 @@ internal struct Storage: ~Escapable {
   /// With `strict == false` this is the lower bound (the first row whose cell is
   /// `>= value`); with `strict == true` the upper bound (the first row whose
   /// cell is `> value`). Together they bracket the run equal to `value`. The
-  /// search is `O(log count)`.
-  private func bound(_ table: Table, _ column: Int, _ value: Int, _ count: Int,
-                     strict: Bool) -> Int {
+  /// search is `O(log count)`. Shared by the reverse-foreign-key lookup and the
+  /// structured-query sorted-index executor (`Cursor.where(_: Predicate)`).
+  internal func bound(_ table: Table, _ column: Int, _ value: Int, _ count: Int,
+                      strict: Bool) -> Int {
     var lo = 0
     var hi = count
     while lo < hi {

--- a/Sources/WinMD/Storage.swift
+++ b/Sources/WinMD/Storage.swift
@@ -137,6 +137,28 @@ internal struct Storage: ~Escapable {
     return cursor.where { $0[column] == encoded }
   }
 
+  /// The rows whose simple-index foreign-key column the `column` token
+  /// addresses references `target`.
+  ///
+  /// Typed reverse navigation: the `Reference` token names the owning `Owner`
+  /// table and the column's ordinal, so this resolves to the generic
+  /// `referencing(_:in:by:)` with no string or ordinal at the call site.
+  @_lifetime(copy self)
+  internal func referencing<Owner, Target>(_ target: borrowing Row<Target>,
+                                           by column: Reference<Owner, Target>)
+      throws(WinMDError) -> Filter {
+    try referencing(target.columns, in: Owner.self, by: column.ordinal)
+  }
+
+  /// The rows whose coded-index foreign-key column the `column` token addresses
+  /// references `target`.
+  @_lifetime(copy self)
+  internal func referencing<Owner, Target>(_ target: borrowing Row<Target>,
+                                           by column: CodedReference<Owner>)
+      throws(WinMDError) -> Filter {
+    try referencing(target.columns, in: Owner.self, by: column.ordinal)
+  }
+
   /// The partition point of `column` against `value` over `[0, count)`.
   ///
   /// `column` is the sorted key of `table`, so its cells are non-decreasing.

--- a/Sources/WinMD/Storage.swift
+++ b/Sources/WinMD/Storage.swift
@@ -28,15 +28,23 @@ internal struct Storage: ~Escapable {
   /// The bitset of present tables (`TablesStream.Valid`).
   internal let valid: UInt64
 
+  /// The bitset of physically sorted tables (`TablesStream.Sorted`).
+  ///
+  /// Bit `N` is set iff table `N` is stored ordered by its sort key. A reverse
+  /// foreign-key lookup against a sorted table is a binary search; against an
+  /// unsorted one it is a linear scan.
+  internal let sorted: UInt64
+
   @_lifetime(copy bytes, copy relations, copy strings, copy blob, copy guid)
   internal init(bytes: RawSpan, relations: Span<Table>, strings: RawSpan,
-                blob: RawSpan, guid: RawSpan, valid: UInt64) {
+                blob: RawSpan, guid: RawSpan, valid: UInt64, sorted: UInt64) {
     self.bytes = bytes
     self.relations = relations
     self.strings = strings
     self.blob = blob
     self.guid = guid
     self.valid = valid
+    self.sorted = sorted
   }
 
   @_lifetime(copy self)

--- a/Sources/WinMD/StringsHeap.swift
+++ b/Sources/WinMD/StringsHeap.swift
@@ -21,4 +21,18 @@ public struct StringsHeap: ~Escapable {
     }
     return String(decoding: bytes.extracting(offset ..< end), as: UTF8.self)
   }
+
+  /// Opens the null-terminated UTF-8 string at `offset`, validating its bounds
+  /// and terminator, so a malformed entry throws `.BadImageFormat` rather than
+  /// trapping.
+  public func string(at offset: Int) throws(WinMDError) -> String {
+    guard offset >= 0, offset < bytes.byteCount else { throw .BadImageFormat }
+    var end = offset
+    while end < bytes.byteCount,
+        bytes.read(at: end, as: UInt8.self) != 0 {
+      end += 1
+    }
+    guard end < bytes.byteCount else { throw .BadImageFormat }
+    return String(decoding: bytes.extracting(offset ..< end), as: UTF8.self)
+  }
 }

--- a/Sources/WinMD/Table.swift
+++ b/Sources/WinMD/Table.swift
@@ -25,12 +25,26 @@ public protocol TableSchema: Sendable {
   /// The columns of the table as defined by the CIL specification.
   static var fields: Span<Field> { get }
 
+  /// The ordinal of the column the table is physically ordered by, or `nil`.
+  ///
+  /// ECMA-335 §II.22 defines a sort key for certain tables; this is the
+  /// ordinal of that column within `columns`. It is intrinsic — it names which
+  /// column the table *would* be sorted on — whereas whether a given database
+  /// actually sorts the table is the runtime `Sorted` bit of the tables stream.
+  /// A table the specification does not sort has no key (`nil`).
+  static var key: Int? { get }
+
   /// The narrow byte offset of column `i` within a record.
   ///
   /// This is the prefix sum of the preceding columns' narrow widths (a
   /// compile-time property of the schema); a database's wide indices shift it
   /// by its width bitset at read time.
   static func offset(_ i: Int) -> Int
+}
+
+extension TableSchema {
+  /// A table the specification does not sort has no key.
+  public static var key: Int? { nil }
 }
 
 /// An open metadata table: the records of one `TableSchema` within a database.

--- a/Sources/WinMD/Table.swift
+++ b/Sources/WinMD/Table.swift
@@ -13,15 +13,6 @@ public enum ColumnType: Sendable {
 extension ColumnType: Hashable {
 }
 
-/// A table column.
-///
-/// Accessible columns have a name which the user can use to reference the
-/// column, and a type which indicates how to read the value of the column.
-public struct Column: Sendable {
-  public let name: StaticString
-  public let type: ColumnType
-}
-
 /// The schema of a CIL metadata table.
 ///
 /// This is the static, compile-time description of a table as defined by the
@@ -32,7 +23,7 @@ public protocol TableSchema: Sendable {
   static var number: Int { get }
 
   /// The columns of the table as defined by the CIL specification.
-  static var columns: Span<Column> { get }
+  static var fields: Span<Field> { get }
 
   /// The narrow byte offset of column `i` within a record.
   ///
@@ -94,7 +85,7 @@ public struct Table: Sendable {
   ///
   /// A column widens by two bytes beyond its narrow width when its bit is set.
   internal func width(_ i: Int) -> Int {
-    schema.columns[i].width + 2 * Int((wide >> i) & 1)
+    schema.fields[i].width + 2 * Int((wide >> i) & 1)
   }
 }
 

--- a/Sources/WinMD/Tables/Assembly.swift
+++ b/Sources/WinMD/Tables/Assembly.swift
@@ -12,27 +12,27 @@
 ///   Name (String Heap Index)
 ///   Culture (String Heap Index)
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _columns: InlineArray<_, Column> = [
-  Column(name: "HashAlgId", type: .constant(4)),
-  Column(name: "MajorVersion", type: .constant(2)),
-  Column(name: "MinorVersion", type: .constant(2)),
-  Column(name: "BuildNumber", type: .constant(2)),
-  Column(name: "RevisionNumber", type: .constant(2)),
-  Column(name: "Flags", type: .constant(4)),
-  Column(name: "PublicKey", type: .index(.heap(.blob))),
-  Column(name: "Name", type: .index(.heap(.string))),
-  Column(name: "Culture", type: .index(.heap(.string))),
+private let _fields: InlineArray<_, Field> = [
+  Field(name: "HashAlgId", type: .constant(4)),
+  Field(name: "MajorVersion", type: .constant(2)),
+  Field(name: "MinorVersion", type: .constant(2)),
+  Field(name: "BuildNumber", type: .constant(2)),
+  Field(name: "RevisionNumber", type: .constant(2)),
+  Field(name: "Flags", type: .constant(4)),
+  Field(name: "PublicKey", type: .index(.heap(.blob))),
+  Field(name: "Name", type: .index(.heap(.string))),
+  Field(name: "Culture", type: .index(.heap(.string))),
 ]
 
-private let _offsets = offsets(_columns)
+private let _offsets = offsets(_fields)
 
 extension Metadata.Tables {
 /// See §II.22.2.
 public enum Assembly: TableSchema {
   public static var number: Int { 32 }
 
-  public static var columns: Span<Column> {
-    @_lifetime(immortal) get { _columns.span }
+  public static var fields: Span<Field> {
+    @_lifetime(immortal) get { _fields.span }
   }
 
   public static func offset(_ i: Int) -> Int {

--- a/Sources/WinMD/Tables/Assembly.swift
+++ b/Sources/WinMD/Tables/Assembly.swift
@@ -41,42 +41,86 @@ public enum Assembly: TableSchema {
 }
 }
 
+extension Column where Schema == Metadata.Tables.Assembly {
+  public static var HashAlgId: Column<Schema, CorHashAlgorithm> {
+    Column<Schema, CorHashAlgorithm>(0) {
+      CorHashAlgorithm(rawValue: CorHashAlgorithm.RawValue($0.columns[0]))!
+    }
+  }
+
+  public static var MajorVersion: Column<Schema, UInt16> {
+    Column<Schema, UInt16>(1) { UInt16($0.columns[1]) }
+  }
+
+  public static var MinorVersion: Column<Schema, UInt16> {
+    Column<Schema, UInt16>(2) { UInt16($0.columns[2]) }
+  }
+
+  public static var BuildNumber: Column<Schema, UInt16> {
+    Column<Schema, UInt16>(3) { UInt16($0.columns[3]) }
+  }
+
+  public static var RevisionNumber: Column<Schema, UInt16> {
+    Column<Schema, UInt16>(4) { UInt16($0.columns[4]) }
+  }
+
+  public static var Flags: Column<Schema, CorAssemblyFlags> {
+    Column<Schema, CorAssemblyFlags>(5) {
+      CorAssemblyFlags(rawValue: CorAssemblyFlags.RawValue($0.columns[5]))
+    }
+  }
+
+  public static var Name: Column<Schema, String> {
+    Column<Schema, String>(7) { $0.strings[$0.columns[7]] }
+  }
+
+  public static var Culture: Column<Schema, String> {
+    Column<Schema, String>(8) { $0.strings[$0.columns[8]] }
+  }
+}
+
+extension BlobColumn where Schema == Metadata.Tables.Assembly {
+  public static var PublicKey: BlobColumn<Schema> {
+    BlobColumn<Schema>(6)
+  }
+}
+
 extension Row where Schema == Metadata.Tables.Assembly {
   public var HashAlgId: CorHashAlgorithm {
-    CorHashAlgorithm(rawValue: CorHashAlgorithm.RawValue(columns[0]))!
+    self[.HashAlgId]
   }
 
   public var MajorVersion: UInt16 {
-    UInt16(columns[1])
+    self[.MajorVersion]
   }
 
   public var MinorVersion: UInt16 {
-    UInt16(columns[2])
+    self[.MinorVersion]
   }
 
   public var BuildNumber: UInt16 {
-    UInt16(columns[3])
+    self[.BuildNumber]
   }
 
   public var RevisionNumber: UInt16 {
-    UInt16(columns[4])
+    self[.RevisionNumber]
   }
 
   public var Flags: CorAssemblyFlags {
-    CorAssemblyFlags(rawValue: CorAssemblyFlags.RawValue(columns[5]))
+    self[.Flags]
   }
 
   public var PublicKey: Blob {
     @_lifetime(copy self)
-    get { blobs[columns[6]] }
+    get { self[.PublicKey] }
   }
 
   public var Name: String {
-    strings[columns[7]]
+    self[.Name]
   }
 
   public var Culture: String {
-    strings[columns[8]]
+    self[.Culture]
   }
 }
 

--- a/Sources/WinMD/Tables/AssemblyOS.swift
+++ b/Sources/WinMD/Tables/AssemblyOS.swift
@@ -28,16 +28,30 @@ public enum AssemblyOS: TableSchema {
 }
 }
 
+extension Column where Schema == Metadata.Tables.AssemblyOS {
+  public static var OSPlatformID: Column<Schema, UInt32> {
+    Column<Schema, UInt32>(0) { UInt32($0.columns[0]) }
+  }
+
+  public static var OSMajorVersion: Column<Schema, UInt32> {
+    Column<Schema, UInt32>(1) { UInt32($0.columns[1]) }
+  }
+
+  public static var OSMinorVersion: Column<Schema, UInt32> {
+    Column<Schema, UInt32>(2) { UInt32($0.columns[2]) }
+  }
+}
+
 extension Row where Schema == Metadata.Tables.AssemblyOS {
   public var OSPlatformID: UInt32 {
-    UInt32(columns[0])
+    self[.OSPlatformID]
   }
 
   public var OSMajorVersion: UInt32 {
-    UInt32(columns[1])
+    self[.OSMajorVersion]
   }
 
   public var OSMinorVersion: UInt32 {
-    UInt32(columns[2])
+    self[.OSMinorVersion]
   }
 }

--- a/Sources/WinMD/Tables/AssemblyOS.swift
+++ b/Sources/WinMD/Tables/AssemblyOS.swift
@@ -6,20 +6,20 @@
 ///   OSMajorVersion (4-byte constant)
 ///   OSMinorVersion (4-byte constant)
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _columns: InlineArray<_, Column> = [
-  Column(name: "OSPlatformID", type: .constant(4)),
-  Column(name: "OSMajorVersion", type: .constant(4)),
-  Column(name: "OSMinorVersion", type: .constant(4)),
+private let _fields: InlineArray<_, Field> = [
+  Field(name: "OSPlatformID", type: .constant(4)),
+  Field(name: "OSMajorVersion", type: .constant(4)),
+  Field(name: "OSMinorVersion", type: .constant(4)),
 ]
 
-private let _offsets = offsets(_columns)
+private let _offsets = offsets(_fields)
 
 extension Metadata.Tables {
 public enum AssemblyOS: TableSchema {
   public static var number: Int { 34 }
 
-  public static var columns: Span<Column> {
-    @_lifetime(immortal) get { _columns.span }
+  public static var fields: Span<Field> {
+    @_lifetime(immortal) get { _fields.span }
   }
 
   public static func offset(_ i: Int) -> Int {

--- a/Sources/WinMD/Tables/AssemblyProcessor.swift
+++ b/Sources/WinMD/Tables/AssemblyProcessor.swift
@@ -25,8 +25,14 @@ public enum AssemblyProcessor: TableSchema {
 }
 }
 
+extension Column where Schema == Metadata.Tables.AssemblyProcessor {
+  public static var Processor: Column<Schema, UInt32> {
+    Column<Schema, UInt32>(0) { UInt32($0.columns[0]) }
+  }
+}
+
 extension Row where Schema == Metadata.Tables.AssemblyProcessor {
   public var Processor: UInt32 {
-    UInt32(columns[0])
+    self[.Processor]
   }
 }

--- a/Sources/WinMD/Tables/AssemblyProcessor.swift
+++ b/Sources/WinMD/Tables/AssemblyProcessor.swift
@@ -4,19 +4,19 @@
 /// Record Layout
 ///   Processor (4-byte constant)
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _columns: InlineArray<_, Column> = [
-  Column(name: "Processor", type: .constant(4)),
+private let _fields: InlineArray<_, Field> = [
+  Field(name: "Processor", type: .constant(4)),
 ]
 
-private let _offsets = offsets(_columns)
+private let _offsets = offsets(_fields)
 
 extension Metadata.Tables {
 /// See §II.22.4.
 public enum AssemblyProcessor: TableSchema {
   public static var number: Int { 33 }
 
-  public static var columns: Span<Column> {
-    @_lifetime(immortal) get { _columns.span }
+  public static var fields: Span<Field> {
+    @_lifetime(immortal) get { _fields.span }
   }
 
   public static func offset(_ i: Int) -> Int {

--- a/Sources/WinMD/Tables/AssemblyRef.swift
+++ b/Sources/WinMD/Tables/AssemblyRef.swift
@@ -41,43 +41,85 @@ public enum AssemblyRef: TableSchema {
 }
 }
 
+extension Column where Schema == Metadata.Tables.AssemblyRef {
+  public static var MajorVersion: Column<Schema, UInt16> {
+    Column<Schema, UInt16>(0) { UInt16($0.columns[0]) }
+  }
+
+  public static var MinorVersion: Column<Schema, UInt16> {
+    Column<Schema, UInt16>(1) { UInt16($0.columns[1]) }
+  }
+
+  public static var BuildNumber: Column<Schema, UInt16> {
+    Column<Schema, UInt16>(2) { UInt16($0.columns[2]) }
+  }
+
+  public static var RevisionNumber: Column<Schema, UInt16> {
+    Column<Schema, UInt16>(3) { UInt16($0.columns[3]) }
+  }
+
+  public static var Flags: Column<Schema, CorAssemblyFlags> {
+    Column<Schema, CorAssemblyFlags>(4) {
+      CorAssemblyFlags(rawValue: CorAssemblyFlags.RawValue($0.columns[4]))
+    }
+  }
+
+  public static var Name: Column<Schema, String> {
+    Column<Schema, String>(6) { $0.strings[$0.columns[6]] }
+  }
+
+  public static var Culture: Column<Schema, String> {
+    Column<Schema, String>(7) { $0.strings[$0.columns[7]] }
+  }
+}
+
+extension BlobColumn where Schema == Metadata.Tables.AssemblyRef {
+  public static var PublicKeyOrToken: BlobColumn<Schema> {
+    BlobColumn<Schema>(5)
+  }
+
+  public static var HashValue: BlobColumn<Schema> {
+    BlobColumn<Schema>(8)
+  }
+}
+
 extension Row where Schema == Metadata.Tables.AssemblyRef {
   public var MajorVersion: UInt16 {
-    UInt16(columns[0])
+    self[.MajorVersion]
   }
 
   public var MinorVersion: UInt16 {
-    UInt16(columns[1])
+    self[.MinorVersion]
   }
 
   public var BuildNumber: UInt16 {
-    UInt16(columns[2])
+    self[.BuildNumber]
   }
 
   public var RevisionNumber: UInt16 {
-    UInt16(columns[3])
+    self[.RevisionNumber]
   }
 
   public var Flags: CorAssemblyFlags {
-    CorAssemblyFlags(rawValue: CorAssemblyFlags.RawValue(columns[4]))
+    self[.Flags]
   }
 
   public var PublicKeyOrToken: Blob {
     @_lifetime(copy self)
-    get { blobs[columns[5]] }
+    get { self[.PublicKeyOrToken] }
   }
 
   public var Name: String {
-    strings[columns[6]]
+    self[.Name]
   }
 
   public var Culture: String {
-    strings[columns[7]]
+    self[.Culture]
   }
 
   public var HashValue: Blob {
     @_lifetime(copy self)
-    get { blobs[columns[8]] }
+    get { self[.HashValue] }
   }
 }
 

--- a/Sources/WinMD/Tables/AssemblyRef.swift
+++ b/Sources/WinMD/Tables/AssemblyRef.swift
@@ -12,27 +12,27 @@
 ///   Culture (String Heap Index)
 ///   HashValue (Blob Heap Index)
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _columns: InlineArray<_, Column> = [
-  Column(name: "MajorVersion", type: .constant(2)),
-  Column(name: "MinorVersion", type: .constant(2)),
-  Column(name: "BuildNumber", type: .constant(2)),
-  Column(name: "RevisionNumber", type: .constant(2)),
-  Column(name: "Flags", type: .constant(4)),
-  Column(name: "PublicKeyOrToken", type: .index(.heap(.blob))),
-  Column(name: "Name", type: .index(.heap(.string))),
-  Column(name: "Culture", type: .index(.heap(.string))),
-  Column(name: "HashValue", type: .index(.heap(.blob))),
+private let _fields: InlineArray<_, Field> = [
+  Field(name: "MajorVersion", type: .constant(2)),
+  Field(name: "MinorVersion", type: .constant(2)),
+  Field(name: "BuildNumber", type: .constant(2)),
+  Field(name: "RevisionNumber", type: .constant(2)),
+  Field(name: "Flags", type: .constant(4)),
+  Field(name: "PublicKeyOrToken", type: .index(.heap(.blob))),
+  Field(name: "Name", type: .index(.heap(.string))),
+  Field(name: "Culture", type: .index(.heap(.string))),
+  Field(name: "HashValue", type: .index(.heap(.blob))),
 ]
 
-private let _offsets = offsets(_columns)
+private let _offsets = offsets(_fields)
 
 extension Metadata.Tables {
 /// See §II.22.5.
 public enum AssemblyRef: TableSchema {
   public static var number: Int { 35 }
 
-  public static var columns: Span<Column> {
-    @_lifetime(immortal) get { _columns.span }
+  public static var fields: Span<Field> {
+    @_lifetime(immortal) get { _fields.span }
   }
 
   public static func offset(_ i: Int) -> Int {

--- a/Sources/WinMD/Tables/AssemblyRefOS.swift
+++ b/Sources/WinMD/Tables/AssemblyRefOS.swift
@@ -7,22 +7,22 @@
 ///   OSMinorVersion (4-byte constant)
 ///   AssemblyRef (AssemblyRef Index)
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _columns: InlineArray<_, Column> = [
-  Column(name: "OSPlatformId", type: .constant(4)),
-  Column(name: "OSMajorVersion", type: .constant(4)),
-  Column(name: "OSMinorVersion", type: .constant(4)),
-  Column(name: "AssemblyRef", type: .index(.simple(Metadata.Tables.AssemblyRef.self))),
+private let _fields: InlineArray<_, Field> = [
+  Field(name: "OSPlatformId", type: .constant(4)),
+  Field(name: "OSMajorVersion", type: .constant(4)),
+  Field(name: "OSMinorVersion", type: .constant(4)),
+  Field(name: "AssemblyRef", type: .index(.simple(Metadata.Tables.AssemblyRef.self))),
 ]
 
-private let _offsets = offsets(_columns)
+private let _offsets = offsets(_fields)
 
 extension Metadata.Tables {
 /// See §II.22.3.
 public enum AssemblyRefOS: TableSchema {
   public static var number: Int { 37 }
 
-  public static var columns: Span<Column> {
-    @_lifetime(immortal) get { _columns.span }
+  public static var fields: Span<Field> {
+    @_lifetime(immortal) get { _fields.span }
   }
 
   public static func offset(_ i: Int) -> Int {

--- a/Sources/WinMD/Tables/AssemblyRefOS.swift
+++ b/Sources/WinMD/Tables/AssemblyRefOS.swift
@@ -45,6 +45,12 @@ extension Column where Schema == Metadata.Tables.AssemblyRefOS {
   }
 }
 
+extension Reference where Schema == Metadata.Tables.AssemblyRefOS {
+  public static var AssemblyRef: Reference<Schema, Metadata.Tables.AssemblyRef> {
+    Reference<Schema, Metadata.Tables.AssemblyRef>(3)
+  }
+}
+
 extension Row where Schema == Metadata.Tables.AssemblyRefOS {
   public var OSPlatformId: UInt32 {
     self[.OSPlatformId]
@@ -61,7 +67,7 @@ extension Row where Schema == Metadata.Tables.AssemblyRefOS {
   public var AssemblyRef: Row<Metadata.Tables.AssemblyRef> {
     @_lifetime(copy self)
     get throws(WinMDError) {
-      try rows(of: Metadata.Tables.AssemblyRef.self)[columns[3]]!
+      try required(.AssemblyRef)
     }
   }
 }

--- a/Sources/WinMD/Tables/AssemblyRefOS.swift
+++ b/Sources/WinMD/Tables/AssemblyRefOS.swift
@@ -31,17 +31,31 @@ public enum AssemblyRefOS: TableSchema {
 }
 }
 
+extension Column where Schema == Metadata.Tables.AssemblyRefOS {
+  public static var OSPlatformId: Column<Schema, UInt32> {
+    Column<Schema, UInt32>(0) { UInt32($0.columns[0]) }
+  }
+
+  public static var OSMajorVersion: Column<Schema, UInt32> {
+    Column<Schema, UInt32>(1) { UInt32($0.columns[1]) }
+  }
+
+  public static var OSMinorVerison: Column<Schema, UInt32> {
+    Column<Schema, UInt32>(2) { UInt32($0.columns[2]) }
+  }
+}
+
 extension Row where Schema == Metadata.Tables.AssemblyRefOS {
   public var OSPlatformId: UInt32 {
-    UInt32(columns[0])
+    self[.OSPlatformId]
   }
 
   public var OSMajorVersion: UInt32 {
-    UInt32(columns[1])
+    self[.OSMajorVersion]
   }
 
   public var OSMinorVerison: UInt32 {
-    UInt32(columns[2])
+    self[.OSMinorVerison]
   }
 
   public var AssemblyRef: Row<Metadata.Tables.AssemblyRef> {

--- a/Sources/WinMD/Tables/AssemblyRefProcessor.swift
+++ b/Sources/WinMD/Tables/AssemblyRefProcessor.swift
@@ -33,6 +33,12 @@ extension Column where Schema == Metadata.Tables.AssemblyRefProcessor {
   }
 }
 
+extension Reference where Schema == Metadata.Tables.AssemblyRefProcessor {
+  public static var AssemblyRef: Reference<Schema, Metadata.Tables.AssemblyRef> {
+    Reference<Schema, Metadata.Tables.AssemblyRef>(1)
+  }
+}
+
 extension Row where Schema == Metadata.Tables.AssemblyRefProcessor {
   public var Processor: UInt32 {
     self[.Processor]
@@ -41,7 +47,7 @@ extension Row where Schema == Metadata.Tables.AssemblyRefProcessor {
   public var AssemblyRef: Row<Metadata.Tables.AssemblyRef> {
     @_lifetime(copy self)
     get throws(WinMDError) {
-      try rows(of: Metadata.Tables.AssemblyRef.self)[columns[1]]!
+      try required(.AssemblyRef)
     }
   }
 }

--- a/Sources/WinMD/Tables/AssemblyRefProcessor.swift
+++ b/Sources/WinMD/Tables/AssemblyRefProcessor.swift
@@ -27,9 +27,15 @@ public enum AssemblyRefProcessor: TableSchema {
 }
 }
 
+extension Column where Schema == Metadata.Tables.AssemblyRefProcessor {
+  public static var Processor: Column<Schema, UInt32> {
+    Column<Schema, UInt32>(0) { UInt32($0.columns[0]) }
+  }
+}
+
 extension Row where Schema == Metadata.Tables.AssemblyRefProcessor {
   public var Processor: UInt32 {
-    UInt32(columns[0])
+    self[.Processor]
   }
 
   public var AssemblyRef: Row<Metadata.Tables.AssemblyRef> {

--- a/Sources/WinMD/Tables/AssemblyRefProcessor.swift
+++ b/Sources/WinMD/Tables/AssemblyRefProcessor.swift
@@ -5,20 +5,20 @@
 ///   Processor (4-byte constant)
 ///   AssemblyRef (AssemblyRef Index)
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _columns: InlineArray<_, Column> = [
-  Column(name: "Processor", type: .constant(4)),
-  Column(name: "AssemblyRef", type: .index(.simple(Metadata.Tables.AssemblyRef.self))),
+private let _fields: InlineArray<_, Field> = [
+  Field(name: "Processor", type: .constant(4)),
+  Field(name: "AssemblyRef", type: .index(.simple(Metadata.Tables.AssemblyRef.self))),
 ]
 
-private let _offsets = offsets(_columns)
+private let _offsets = offsets(_fields)
 
 extension Metadata.Tables {
 /// See §II.22.7.
 public enum AssemblyRefProcessor: TableSchema {
   public static var number: Int { 36 }
 
-  public static var columns: Span<Column> {
-    @_lifetime(immortal) get { _columns.span }
+  public static var fields: Span<Field> {
+    @_lifetime(immortal) get { _fields.span }
   }
 
   public static func offset(_ i: Int) -> Int {

--- a/Sources/WinMD/Tables/ClassLayout.swift
+++ b/Sources/WinMD/Tables/ClassLayout.swift
@@ -6,21 +6,21 @@
 ///   ClassSize (4-byte constant)
 ///   Parent (TypeDef Index)
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _columns: InlineArray<_, Column> = [
-  Column(name: "PackingSize", type: .constant(2)),
-  Column(name: "ClassSize", type: .constant(4)),
-  Column(name: "Parent", type: .index(.simple(Metadata.Tables.TypeDef.self))),
+private let _fields: InlineArray<_, Field> = [
+  Field(name: "PackingSize", type: .constant(2)),
+  Field(name: "ClassSize", type: .constant(4)),
+  Field(name: "Parent", type: .index(.simple(Metadata.Tables.TypeDef.self))),
 ]
 
-private let _offsets = offsets(_columns)
+private let _offsets = offsets(_fields)
 
 extension Metadata.Tables {
 /// See §II.22.8.
 public enum ClassLayout: TableSchema {
   public static var number: Int { 15 }
 
-  public static var columns: Span<Column> {
-    @_lifetime(immortal) get { _columns.span }
+  public static var fields: Span<Field> {
+    @_lifetime(immortal) get { _fields.span }
   }
 
   public static func offset(_ i: Int) -> Int {

--- a/Sources/WinMD/Tables/ClassLayout.swift
+++ b/Sources/WinMD/Tables/ClassLayout.swift
@@ -42,6 +42,12 @@ extension Column where Schema == Metadata.Tables.ClassLayout {
   }
 }
 
+extension Reference where Schema == Metadata.Tables.ClassLayout {
+  public static var Parent: Reference<Schema, Metadata.Tables.TypeDef> {
+    Reference<Schema, Metadata.Tables.TypeDef>(2)
+  }
+}
+
 extension Row where Schema == Metadata.Tables.ClassLayout {
   public var PackingSize: UInt16 {
     self[.PackingSize]
@@ -54,7 +60,7 @@ extension Row where Schema == Metadata.Tables.ClassLayout {
   public var Parent: Row<Metadata.Tables.TypeDef> {
     @_lifetime(copy self)
     get throws(WinMDError) {
-      try rows(of: Metadata.Tables.TypeDef.self)[columns[2]]!
+      try required(.Parent)
     }
   }
 }

--- a/Sources/WinMD/Tables/ClassLayout.swift
+++ b/Sources/WinMD/Tables/ClassLayout.swift
@@ -19,6 +19,9 @@ extension Metadata.Tables {
 public enum ClassLayout: TableSchema {
   public static var number: Int { 15 }
 
+  /// Sorted by `Parent`. See §II.22.8.
+  public static var key: Int? { 2 }
+
   public static var fields: Span<Field> {
     @_lifetime(immortal) get { _fields.span }
   }

--- a/Sources/WinMD/Tables/ClassLayout.swift
+++ b/Sources/WinMD/Tables/ClassLayout.swift
@@ -32,13 +32,23 @@ public enum ClassLayout: TableSchema {
 }
 }
 
+extension Column where Schema == Metadata.Tables.ClassLayout {
+  public static var PackingSize: Column<Schema, UInt16> {
+    Column<Schema, UInt16>(0) { UInt16($0.columns[0]) }
+  }
+
+  public static var ClassSize: Column<Schema, UInt32> {
+    Column<Schema, UInt32>(1) { UInt32($0.columns[1]) }
+  }
+}
+
 extension Row where Schema == Metadata.Tables.ClassLayout {
   public var PackingSize: UInt16 {
-    UInt16(columns[0])
+    self[.PackingSize]
   }
 
   public var ClassSize: UInt32 {
-    UInt32(columns[1])
+    self[.ClassSize]
   }
 
   public var Parent: Row<Metadata.Tables.TypeDef> {

--- a/Sources/WinMD/Tables/Constant.swift
+++ b/Sources/WinMD/Tables/Constant.swift
@@ -45,6 +45,12 @@ extension BlobColumn where Schema == Metadata.Tables.Constant {
   public static var Value: BlobColumn<Schema> { BlobColumn<Schema>(3) }
 }
 
+extension CodedReference where Schema == Metadata.Tables.Constant {
+  public static var Parent: CodedReference<Schema> {
+    CodedReference<Schema>(2)
+  }
+}
+
 extension Row where Schema == Metadata.Tables.Constant {
   public var `Type`: CorElementType {
     self[.Type]

--- a/Sources/WinMD/Tables/Constant.swift
+++ b/Sources/WinMD/Tables/Constant.swift
@@ -33,13 +33,25 @@ public enum Constant: TableSchema {
 }
 }
 
+extension Column where Schema == Metadata.Tables.Constant {
+  public static var `Type`: Column<Schema, CorElementType> {
+    Column<Schema, CorElementType>(0) {
+      CorElementType(rawValue: CorElementType.RawValue($0.columns[0]))
+    }
+  }
+}
+
+extension BlobColumn where Schema == Metadata.Tables.Constant {
+  public static var Value: BlobColumn<Schema> { BlobColumn<Schema>(3) }
+}
+
 extension Row where Schema == Metadata.Tables.Constant {
   public var `Type`: CorElementType {
-    CorElementType(rawValue: CorElementType.RawValue(columns[0]))
+    self[.Type]
   }
 
   public var Value: Blob {
     @_lifetime(copy self)
-    get { blobs[columns[4]] }
+    get { self[.Value] }
   }
 }

--- a/Sources/WinMD/Tables/Constant.swift
+++ b/Sources/WinMD/Tables/Constant.swift
@@ -6,22 +6,22 @@
 ///   Parent (HasConstant Coded Index)
 ///   Value (Blob Heap Index)
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _columns: InlineArray<_, Column> = [
-  Column(name: "Type", type: .constant(1)),
-  Column(name: StaticString(), type: .constant(1)),
-  Column(name: "Parent", type: .index(.coded(HasConstant.self))),
-  Column(name: "Value", type: .index(.heap(.blob))),
+private let _fields: InlineArray<_, Field> = [
+  Field(name: "Type", type: .constant(1)),
+  Field(name: StaticString(), type: .constant(1)),
+  Field(name: "Parent", type: .index(.coded(HasConstant.self))),
+  Field(name: "Value", type: .index(.heap(.blob))),
 ]
 
-private let _offsets = offsets(_columns)
+private let _offsets = offsets(_fields)
 
 extension Metadata.Tables {
 /// See §II.22.9.
 public enum Constant: TableSchema {
   public static var number: Int { 11 }
 
-  public static var columns: Span<Column> {
-    @_lifetime(immortal) get { _columns.span }
+  public static var fields: Span<Field> {
+    @_lifetime(immortal) get { _fields.span }
   }
 
   public static func offset(_ i: Int) -> Int {

--- a/Sources/WinMD/Tables/Constant.swift
+++ b/Sources/WinMD/Tables/Constant.swift
@@ -20,6 +20,9 @@ extension Metadata.Tables {
 public enum Constant: TableSchema {
   public static var number: Int { 11 }
 
+  /// Sorted by `Parent`. See §II.22.9.
+  public static var key: Int? { 2 }
+
   public static var fields: Span<Field> {
     @_lifetime(immortal) get { _fields.span }
   }

--- a/Sources/WinMD/Tables/CustomAttribute.swift
+++ b/Sources/WinMD/Tables/CustomAttribute.swift
@@ -6,21 +6,21 @@
 ///   Type (CustomAttributeType Coded Index)
 ///   Value (Blob Heap Index)
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _columns: InlineArray<_, Column> = [
-  Column(name: "Parent", type: .index(.coded(HasCustomAttribute.self))),
-  Column(name: "Type", type: .index(.coded(CustomAttributeType.self))),
-  Column(name: "Value", type: .index(.heap(.blob))),
+private let _fields: InlineArray<_, Field> = [
+  Field(name: "Parent", type: .index(.coded(HasCustomAttribute.self))),
+  Field(name: "Type", type: .index(.coded(CustomAttributeType.self))),
+  Field(name: "Value", type: .index(.heap(.blob))),
 ]
 
-private let _offsets = offsets(_columns)
+private let _offsets = offsets(_fields)
 
 extension Metadata.Tables {
 /// See §II.22.10.
 public enum CustomAttribute: TableSchema {
   public static var number: Int { 12 }
 
-  public static var columns: Span<Column> {
-    @_lifetime(immortal) get { _columns.span }
+  public static var fields: Span<Field> {
+    @_lifetime(immortal) get { _fields.span }
   }
 
   public static func offset(_ i: Int) -> Int {

--- a/Sources/WinMD/Tables/CustomAttribute.swift
+++ b/Sources/WinMD/Tables/CustomAttribute.swift
@@ -36,6 +36,16 @@ extension BlobColumn where Schema == Metadata.Tables.CustomAttribute {
   public static var Value: BlobColumn<Schema> { BlobColumn<Schema>(2) }
 }
 
+extension CodedReference where Schema == Metadata.Tables.CustomAttribute {
+  public static var Parent: CodedReference<Schema> {
+    CodedReference<Schema>(0)
+  }
+
+  public static var `Type`: CodedReference<Schema> {
+    CodedReference<Schema>(1)
+  }
+}
+
 extension Row where Schema == Metadata.Tables.CustomAttribute {
   public var Value: Blob {
     @_lifetime(copy self)

--- a/Sources/WinMD/Tables/CustomAttribute.swift
+++ b/Sources/WinMD/Tables/CustomAttribute.swift
@@ -32,9 +32,13 @@ public enum CustomAttribute: TableSchema {
 }
 }
 
+extension BlobColumn where Schema == Metadata.Tables.CustomAttribute {
+  public static var Value: BlobColumn<Schema> { BlobColumn<Schema>(2) }
+}
+
 extension Row where Schema == Metadata.Tables.CustomAttribute {
   public var Value: Blob {
     @_lifetime(copy self)
-    get { blobs[columns[2]] }
+    get { self[.Value] }
   }
 }

--- a/Sources/WinMD/Tables/CustomAttribute.swift
+++ b/Sources/WinMD/Tables/CustomAttribute.swift
@@ -19,6 +19,9 @@ extension Metadata.Tables {
 public enum CustomAttribute: TableSchema {
   public static var number: Int { 12 }
 
+  /// Sorted by `Parent`. See §II.22.10.
+  public static var key: Int? { 0 }
+
   public static var fields: Span<Field> {
     @_lifetime(immortal) get { _fields.span }
   }

--- a/Sources/WinMD/Tables/DeclSecurity.swift
+++ b/Sources/WinMD/Tables/DeclSecurity.swift
@@ -6,21 +6,21 @@
 ///   Parent (HasDeclSecurity Coded Index)
 ///   PermissionSet (Blob Heap Index)
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _columns: InlineArray<_, Column> = [
-  Column(name: "Action", type: .constant(2)),
-  Column(name: "Parent", type: .index(.coded(HasDeclSecurity.self))),
-  Column(name: "PermissionSet", type: .index(.heap(.blob))),
+private let _fields: InlineArray<_, Field> = [
+  Field(name: "Action", type: .constant(2)),
+  Field(name: "Parent", type: .index(.coded(HasDeclSecurity.self))),
+  Field(name: "PermissionSet", type: .index(.heap(.blob))),
 ]
 
-private let _offsets = offsets(_columns)
+private let _offsets = offsets(_fields)
 
 extension Metadata.Tables {
 /// See §II.22.11.
 public enum DeclSecurity: TableSchema {
   public static var number: Int { 14 }
 
-  public static var columns: Span<Column> {
-    @_lifetime(immortal) get { _columns.span }
+  public static var fields: Span<Field> {
+    @_lifetime(immortal) get { _fields.span }
   }
 
   public static func offset(_ i: Int) -> Int {

--- a/Sources/WinMD/Tables/DeclSecurity.swift
+++ b/Sources/WinMD/Tables/DeclSecurity.swift
@@ -32,13 +32,23 @@ public enum DeclSecurity: TableSchema {
 }
 }
 
+extension Column where Schema == Metadata.Tables.DeclSecurity {
+  public static var Action: Column<Schema, UInt16> {
+    Column<Schema, UInt16>(0) { UInt16($0.columns[0]) }
+  }
+}
+
+extension BlobColumn where Schema == Metadata.Tables.DeclSecurity {
+  public static var PermissionSet: BlobColumn<Schema> { BlobColumn<Schema>(2) }
+}
+
 extension Row where Schema == Metadata.Tables.DeclSecurity {
   public var Action: UInt16 {
-    UInt16(columns[0])
+    self[.Action]
   }
 
   public var PermissionSet: Blob {
     @_lifetime(copy self)
-    get { blobs[columns[2]] }
+    get { self[.PermissionSet] }
   }
 }

--- a/Sources/WinMD/Tables/DeclSecurity.swift
+++ b/Sources/WinMD/Tables/DeclSecurity.swift
@@ -42,6 +42,12 @@ extension BlobColumn where Schema == Metadata.Tables.DeclSecurity {
   public static var PermissionSet: BlobColumn<Schema> { BlobColumn<Schema>(2) }
 }
 
+extension CodedReference where Schema == Metadata.Tables.DeclSecurity {
+  public static var Parent: CodedReference<Schema> {
+    CodedReference<Schema>(1)
+  }
+}
+
 extension Row where Schema == Metadata.Tables.DeclSecurity {
   public var Action: UInt16 {
     self[.Action]

--- a/Sources/WinMD/Tables/DeclSecurity.swift
+++ b/Sources/WinMD/Tables/DeclSecurity.swift
@@ -19,6 +19,9 @@ extension Metadata.Tables {
 public enum DeclSecurity: TableSchema {
   public static var number: Int { 14 }
 
+  /// Sorted by `Parent`. See §II.22.11.
+  public static var key: Int? { 1 }
+
   public static var fields: Span<Field> {
     @_lifetime(immortal) get { _fields.span }
   }

--- a/Sources/WinMD/Tables/EventDef.swift
+++ b/Sources/WinMD/Tables/EventDef.swift
@@ -41,6 +41,12 @@ extension Column where Schema == Metadata.Tables.EventDef {
   }
 }
 
+extension CodedReference where Schema == Metadata.Tables.EventDef {
+  public static var EventType: CodedReference<Schema> {
+    CodedReference<Schema>(2)
+  }
+}
+
 extension Row where Schema == Metadata.Tables.EventDef {
   public var EventFlags: CorEventAttr {
     self[.EventFlags]

--- a/Sources/WinMD/Tables/EventDef.swift
+++ b/Sources/WinMD/Tables/EventDef.swift
@@ -6,21 +6,21 @@
 ///   Name (String Heap Index)
 ///   EventType (TypeDefOrRef Coded Index)
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _columns: InlineArray<_, Column> = [
-  Column(name: "EventFlags", type: .constant(2)),
-  Column(name: "Name", type: .index(.heap(.string))),
-  Column(name: "EventType", type: .index(.coded(TypeDefOrRef.self)))
+private let _fields: InlineArray<_, Field> = [
+  Field(name: "EventFlags", type: .constant(2)),
+  Field(name: "Name", type: .index(.heap(.string))),
+  Field(name: "EventType", type: .index(.coded(TypeDefOrRef.self)))
 ]
 
-private let _offsets = offsets(_columns)
+private let _offsets = offsets(_fields)
 
 extension Metadata.Tables {
 /// See §II.22.13.
 public enum EventDef: TableSchema {
   public static var number: Int { 20 }
 
-  public static var columns: Span<Column> {
-    @_lifetime(immortal) get { _columns.span }
+  public static var fields: Span<Field> {
+    @_lifetime(immortal) get { _fields.span }
   }
 
   public static func offset(_ i: Int) -> Int {

--- a/Sources/WinMD/Tables/EventDef.swift
+++ b/Sources/WinMD/Tables/EventDef.swift
@@ -29,12 +29,24 @@ public enum EventDef: TableSchema {
 }
 }
 
+extension Column where Schema == Metadata.Tables.EventDef {
+  public static var EventFlags: Column<Schema, CorEventAttr> {
+    Column<Schema, CorEventAttr>(0) {
+      CorEventAttr(rawValue: CorEventAttr.RawValue($0.columns[0]))
+    }
+  }
+
+  public static var Name: Column<Schema, String> {
+    Column<Schema, String>(1) { $0.strings[$0.columns[1]] }
+  }
+}
+
 extension Row where Schema == Metadata.Tables.EventDef {
   public var EventFlags: CorEventAttr {
-    CorEventAttr(rawValue: CorEventAttr.RawValue(columns[0]))
+    self[.EventFlags]
   }
 
   public var Name: String {
-    strings[columns[1]]
+    self[.Name]
   }
 }

--- a/Sources/WinMD/Tables/EventMap.swift
+++ b/Sources/WinMD/Tables/EventMap.swift
@@ -27,18 +27,30 @@ public enum EventMap: TableSchema {
 }
 }
 
+extension Reference where Schema == Metadata.Tables.EventMap {
+  public static var Parent: Reference<Schema, Metadata.Tables.TypeDef> {
+    Reference<Schema, Metadata.Tables.TypeDef>(0)
+  }
+}
+
+extension List where Schema == Metadata.Tables.EventMap {
+  public static var EventList: List<Schema, Metadata.Tables.EventDef> {
+    List<Schema, Metadata.Tables.EventDef>(1)
+  }
+}
+
 extension Row where Schema == Metadata.Tables.EventMap {
   public var Parent: Row<Metadata.Tables.TypeDef> {
     @_lifetime(copy self)
     get throws(WinMDError) {
-      try rows(of: Metadata.Tables.TypeDef.self)[columns[0]]!
+      try required(.Parent)
     }
   }
 
   public var EventList: TableIterator<Metadata.Tables.EventDef> {
     @_lifetime(copy self)
     get throws(WinMDError) {
-      try list(for: 1)
+      try list(.EventList)
     }
   }
 }

--- a/Sources/WinMD/Tables/EventMap.swift
+++ b/Sources/WinMD/Tables/EventMap.swift
@@ -5,20 +5,20 @@
 ///   Parent (TypeDef Index)
 ///   EventList (Event Index)
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _columns: InlineArray<_, Column> = [
-  Column(name: "Parent", type: .index(.simple(Metadata.Tables.TypeDef.self))),
-  Column(name: "EventList", type: .index(.simple(Metadata.Tables.EventDef.self))),
+private let _fields: InlineArray<_, Field> = [
+  Field(name: "Parent", type: .index(.simple(Metadata.Tables.TypeDef.self))),
+  Field(name: "EventList", type: .index(.simple(Metadata.Tables.EventDef.self))),
 ]
 
-private let _offsets = offsets(_columns)
+private let _offsets = offsets(_fields)
 
 extension Metadata.Tables {
 /// See §II.22.12.
 public enum EventMap: TableSchema {
   public static var number: Int { 18 }
 
-  public static var columns: Span<Column> {
-    @_lifetime(immortal) get { _columns.span }
+  public static var fields: Span<Field> {
+    @_lifetime(immortal) get { _fields.span }
   }
 
   public static func offset(_ i: Int) -> Int {

--- a/Sources/WinMD/Tables/ExportedType.swift
+++ b/Sources/WinMD/Tables/ExportedType.swift
@@ -33,16 +33,36 @@ public enum ExportedType: TableSchema {
 }
 }
 
+extension Column where Schema == Metadata.Tables.ExportedType {
+  public static var Flags: Column<Schema, CorTypeAttr> {
+    Column<Schema, CorTypeAttr>(0) {
+      CorTypeAttr(rawValue: CorTypeAttr.RawValue($0.columns[0]))
+    }
+  }
+
+  public static var TypeDefId: Column<Schema, UInt32> {
+    Column<Schema, UInt32>(1) { UInt32($0.columns[1]) }
+  }
+
+  public static var TypeName: Column<Schema, String> {
+    Column<Schema, String>(2) { $0.strings[$0.columns[2]] }
+  }
+
+  public static var TypeNamespace: Column<Schema, String> {
+    Column<Schema, String>(3) { $0.strings[$0.columns[3]] }
+  }
+}
+
 extension Row where Schema == Metadata.Tables.ExportedType {
   public var Flags: CorTypeAttr {
-    CorTypeAttr(rawValue: CorTypeAttr.RawValue(columns[0]))
+    self[.Flags]
   }
 
   public var TypeName: String {
-    strings[columns[2]]
+    self[.TypeName]
   }
 
   public var TypeNamespace: String {
-    strings[columns[3]]
+    self[.TypeNamespace]
   }
 }

--- a/Sources/WinMD/Tables/ExportedType.swift
+++ b/Sources/WinMD/Tables/ExportedType.swift
@@ -8,23 +8,23 @@
 ///   TypeNamespace (String Heap Index)
 ///   Implementation (Implementation Coded Index)
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _columns: InlineArray<_, Column> = [
-  Column(name: "Flags", type: .constant(4)),
-  Column(name: "TypeDefId", type: .constant(4)),
-  Column(name: "TypeName", type: .index(.heap(.string))),
-  Column(name: "TypeNamespace", type: .index(.heap(.string))),
-  Column(name: "Implementation", type: .index(.coded(Implementation.self))),
+private let _fields: InlineArray<_, Field> = [
+  Field(name: "Flags", type: .constant(4)),
+  Field(name: "TypeDefId", type: .constant(4)),
+  Field(name: "TypeName", type: .index(.heap(.string))),
+  Field(name: "TypeNamespace", type: .index(.heap(.string))),
+  Field(name: "Implementation", type: .index(.coded(Implementation.self))),
 ]
 
-private let _offsets = offsets(_columns)
+private let _offsets = offsets(_fields)
 
 extension Metadata.Tables {
 /// See §II.22.14.
 public enum ExportedType: TableSchema {
   public static var number: Int { 39 }
 
-  public static var columns: Span<Column> {
-    @_lifetime(immortal) get { _columns.span }
+  public static var fields: Span<Field> {
+    @_lifetime(immortal) get { _fields.span }
   }
 
   public static func offset(_ i: Int) -> Int {

--- a/Sources/WinMD/Tables/ExportedType.swift
+++ b/Sources/WinMD/Tables/ExportedType.swift
@@ -53,6 +53,12 @@ extension Column where Schema == Metadata.Tables.ExportedType {
   }
 }
 
+extension CodedReference where Schema == Metadata.Tables.ExportedType {
+  public static var Implementation: CodedReference<Schema> {
+    CodedReference<Schema>(4)
+  }
+}
+
 extension Row where Schema == Metadata.Tables.ExportedType {
   public var Flags: CorTypeAttr {
     self[.Flags]

--- a/Sources/WinMD/Tables/FieldDef.swift
+++ b/Sources/WinMD/Tables/FieldDef.swift
@@ -6,21 +6,21 @@
 ///   Name (String Heap Index)
 ///   Signature (Blob Heap Index)
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _columns: InlineArray<_, Column> = [
-  Column(name: "Flags", type: .constant(2)),
-  Column(name: "Name", type: .index(.heap(.string))),
-  Column(name: "Signature", type: .index(.heap(.blob))),
+private let _fields: InlineArray<_, Field> = [
+  Field(name: "Flags", type: .constant(2)),
+  Field(name: "Name", type: .index(.heap(.string))),
+  Field(name: "Signature", type: .index(.heap(.blob))),
 ]
 
-private let _offsets = offsets(_columns)
+private let _offsets = offsets(_fields)
 
 extension Metadata.Tables {
 /// See §II.22.15.
 public enum FieldDef: TableSchema {
   public static var number: Int { 4 }
 
-  public static var columns: Span<Column> {
-    @_lifetime(immortal) get { _columns.span }
+  public static var fields: Span<Field> {
+    @_lifetime(immortal) get { _fields.span }
   }
 
   public static func offset(_ i: Int) -> Int {

--- a/Sources/WinMD/Tables/FieldDef.swift
+++ b/Sources/WinMD/Tables/FieldDef.swift
@@ -29,17 +29,35 @@ public enum FieldDef: TableSchema {
 }
 }
 
+extension Column where Schema == Metadata.Tables.FieldDef {
+  public static var Flags: Column<Schema, CorFieldAttr> {
+    Column<Schema, CorFieldAttr>(0) {
+      CorFieldAttr(rawValue: CorFieldAttr.RawValue($0.columns[0]))
+    }
+  }
+
+  public static var Name: Column<Schema, String> {
+    Column<Schema, String>(1) { $0.strings[$0.columns[1]] }
+  }
+}
+
+extension BlobColumn where Schema == Metadata.Tables.FieldDef {
+  public static var Signature: BlobColumn<Schema> {
+    BlobColumn<Schema>(2)
+  }
+}
+
 extension Row where Schema == Metadata.Tables.FieldDef {
   public var Flags: CorFieldAttr {
-    CorFieldAttr(rawValue: CorFieldAttr.RawValue(columns[0]))
+    self[.Flags]
   }
 
   public var Name: String {
-    strings[columns[1]]
+    self[.Name]
   }
 
   public var Signature: Blob {
     @_lifetime(copy self)
-    get { blobs[columns[2]] }
+    get { self[.Signature] }
   }
 }

--- a/Sources/WinMD/Tables/FieldLayout.swift
+++ b/Sources/WinMD/Tables/FieldLayout.swift
@@ -30,9 +30,15 @@ public enum FieldLayout: TableSchema {
 }
 }
 
+extension Column where Schema == Metadata.Tables.FieldLayout {
+  public static var Offset: Column<Schema, UInt32> {
+    Column<Schema, UInt32>(0) { UInt32($0.columns[0]) }
+  }
+}
+
 extension Row where Schema == Metadata.Tables.FieldLayout {
   public var Offset: UInt32 {
-    UInt32(columns[0])
+    self[.Offset]
   }
 
   public var Column: Row<Metadata.Tables.FieldDef> {

--- a/Sources/WinMD/Tables/FieldLayout.swift
+++ b/Sources/WinMD/Tables/FieldLayout.swift
@@ -36,6 +36,12 @@ extension Column where Schema == Metadata.Tables.FieldLayout {
   }
 }
 
+extension Reference where Schema == Metadata.Tables.FieldLayout {
+  public static var Column: Reference<Schema, Metadata.Tables.FieldDef> {
+    Reference<Schema, Metadata.Tables.FieldDef>(1)
+  }
+}
+
 extension Row where Schema == Metadata.Tables.FieldLayout {
   public var Offset: UInt32 {
     self[.Offset]
@@ -44,7 +50,7 @@ extension Row where Schema == Metadata.Tables.FieldLayout {
   public var Column: Row<Metadata.Tables.FieldDef> {
     @_lifetime(copy self)
     get throws(WinMDError) {
-      try rows(of: Metadata.Tables.FieldDef.self)[columns[1]]!
+      try required(.Column)
     }
   }
 }

--- a/Sources/WinMD/Tables/FieldLayout.swift
+++ b/Sources/WinMD/Tables/FieldLayout.swift
@@ -3,22 +3,22 @@
 
 /// Record Layout
 ///   Offset (4-byte constant)
-///   Field (Field Index)
+///   Column (Column Index)
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _columns: InlineArray<_, Column> = [
-  Column(name: "Offset", type: .constant(4)),
-  Column(name: "Field", type: .index(.simple(Metadata.Tables.FieldDef.self))),
+private let _fields: InlineArray<_, Field> = [
+  Field(name: "Offset", type: .constant(4)),
+  Field(name: "Column", type: .index(.simple(Metadata.Tables.FieldDef.self))),
 ]
 
-private let _offsets = offsets(_columns)
+private let _offsets = offsets(_fields)
 
 extension Metadata.Tables {
 /// See §II.22.16.
 public enum FieldLayout: TableSchema {
   public static var number: Int { 16 }
 
-  public static var columns: Span<Column> {
-    @_lifetime(immortal) get { _columns.span }
+  public static var fields: Span<Field> {
+    @_lifetime(immortal) get { _fields.span }
   }
 
   public static func offset(_ i: Int) -> Int {
@@ -32,7 +32,7 @@ extension Row where Schema == Metadata.Tables.FieldLayout {
     UInt32(columns[0])
   }
 
-  public var Field: Row<Metadata.Tables.FieldDef> {
+  public var Column: Row<Metadata.Tables.FieldDef> {
     @_lifetime(copy self)
     get throws(WinMDError) {
       try rows(of: Metadata.Tables.FieldDef.self)[columns[1]]!

--- a/Sources/WinMD/Tables/FieldLayout.swift
+++ b/Sources/WinMD/Tables/FieldLayout.swift
@@ -17,6 +17,9 @@ extension Metadata.Tables {
 public enum FieldLayout: TableSchema {
   public static var number: Int { 16 }
 
+  /// Sorted by `Column`. See §II.22.16.
+  public static var key: Int? { 1 }
+
   public static var fields: Span<Field> {
     @_lifetime(immortal) get { _fields.span }
   }

--- a/Sources/WinMD/Tables/FieldMarshal.swift
+++ b/Sources/WinMD/Tables/FieldMarshal.swift
@@ -17,6 +17,9 @@ extension Metadata.Tables {
 public enum FieldMarshal: TableSchema {
   public static var number: Int { 13 }
 
+  /// Sorted by `Parent`. See §II.22.17.
+  public static var key: Int? { 0 }
+
   public static var fields: Span<Field> {
     @_lifetime(immortal) get { _fields.span }
   }

--- a/Sources/WinMD/Tables/FieldMarshal.swift
+++ b/Sources/WinMD/Tables/FieldMarshal.swift
@@ -5,20 +5,20 @@
 ///   Parent (HasFieldMarshal Coded Index)
 ///   NativeType (Blob Heap Index)
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _columns: InlineArray<_, Column> = [
-  Column(name: "Parent", type: .index(.coded(HasFieldMarshal.self))),
-  Column(name: "NativeType", type: .index(.heap(.blob))),
+private let _fields: InlineArray<_, Field> = [
+  Field(name: "Parent", type: .index(.coded(HasFieldMarshal.self))),
+  Field(name: "NativeType", type: .index(.heap(.blob))),
 ]
 
-private let _offsets = offsets(_columns)
+private let _offsets = offsets(_fields)
 
 extension Metadata.Tables {
 /// See §II.22.17.
 public enum FieldMarshal: TableSchema {
   public static var number: Int { 13 }
 
-  public static var columns: Span<Column> {
-    @_lifetime(immortal) get { _columns.span }
+  public static var fields: Span<Field> {
+    @_lifetime(immortal) get { _fields.span }
   }
 
   public static func offset(_ i: Int) -> Int {

--- a/Sources/WinMD/Tables/FieldMarshal.swift
+++ b/Sources/WinMD/Tables/FieldMarshal.swift
@@ -30,9 +30,13 @@ public enum FieldMarshal: TableSchema {
 }
 }
 
+extension BlobColumn where Schema == Metadata.Tables.FieldMarshal {
+  public static var NativeType: BlobColumn<Schema> { BlobColumn<Schema>(1) }
+}
+
 extension Row where Schema == Metadata.Tables.FieldMarshal {
   public var NativeType: Blob {
     @_lifetime(copy self)
-    get { blobs[columns[1]] }
+    get { self[.NativeType] }
   }
 }

--- a/Sources/WinMD/Tables/FieldRVA.swift
+++ b/Sources/WinMD/Tables/FieldRVA.swift
@@ -17,6 +17,9 @@ extension Metadata.Tables {
 public enum FieldRVA: TableSchema {
   public static var number: Int { 29 }
 
+  /// Sorted by `Column`. See §II.22.18.
+  public static var key: Int? { 1 }
+
   public static var fields: Span<Field> {
     @_lifetime(immortal) get { _fields.span }
   }

--- a/Sources/WinMD/Tables/FieldRVA.swift
+++ b/Sources/WinMD/Tables/FieldRVA.swift
@@ -3,22 +3,22 @@
 
 /// Record Layout
 ///   RVA (4-byte constant)
-///   Field (Field Index)
+///   Column (Column Index)
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _columns: InlineArray<_, Column> = [
-  Column(name: "RVA", type: .constant(4)),
-  Column(name: "Field", type: .index(.simple(Metadata.Tables.FieldDef.self))),
+private let _fields: InlineArray<_, Field> = [
+  Field(name: "RVA", type: .constant(4)),
+  Field(name: "Column", type: .index(.simple(Metadata.Tables.FieldDef.self))),
 ]
 
-private let _offsets = offsets(_columns)
+private let _offsets = offsets(_fields)
 
 extension Metadata.Tables {
 /// See §II.22.18.
 public enum FieldRVA: TableSchema {
   public static var number: Int { 29 }
 
-  public static var columns: Span<Column> {
-    @_lifetime(immortal) get { _columns.span }
+  public static var fields: Span<Field> {
+    @_lifetime(immortal) get { _fields.span }
   }
 
   public static func offset(_ i: Int) -> Int {
@@ -32,7 +32,7 @@ extension Row where Schema == Metadata.Tables.FieldRVA {
     UInt32(columns[0])
   }
 
-  public var Field: Row<Metadata.Tables.FieldDef> {
+  public var Column: Row<Metadata.Tables.FieldDef> {
     @_lifetime(copy self)
     get throws(WinMDError) {
       try rows(of: Metadata.Tables.FieldDef.self)[columns[1]]!

--- a/Sources/WinMD/Tables/FieldRVA.swift
+++ b/Sources/WinMD/Tables/FieldRVA.swift
@@ -30,9 +30,15 @@ public enum FieldRVA: TableSchema {
 }
 }
 
+extension Column where Schema == Metadata.Tables.FieldRVA {
+  public static var RVA: Column<Schema, UInt32> {
+    Column<Schema, UInt32>(0) { UInt32($0.columns[0]) }
+  }
+}
+
 extension Row where Schema == Metadata.Tables.FieldRVA {
   public var RVA: UInt32 {
-    UInt32(columns[0])
+    self[.RVA]
   }
 
   public var Column: Row<Metadata.Tables.FieldDef> {

--- a/Sources/WinMD/Tables/FieldRVA.swift
+++ b/Sources/WinMD/Tables/FieldRVA.swift
@@ -36,6 +36,12 @@ extension Column where Schema == Metadata.Tables.FieldRVA {
   }
 }
 
+extension Reference where Schema == Metadata.Tables.FieldRVA {
+  public static var Column: Reference<Schema, Metadata.Tables.FieldDef> {
+    Reference<Schema, Metadata.Tables.FieldDef>(1)
+  }
+}
+
 extension Row where Schema == Metadata.Tables.FieldRVA {
   public var RVA: UInt32 {
     self[.RVA]
@@ -44,7 +50,7 @@ extension Row where Schema == Metadata.Tables.FieldRVA {
   public var Column: Row<Metadata.Tables.FieldDef> {
     @_lifetime(copy self)
     get throws(WinMDError) {
-      try rows(of: Metadata.Tables.FieldDef.self)[columns[1]]!
+      try required(.Column)
     }
   }
 }

--- a/Sources/WinMD/Tables/File.swift
+++ b/Sources/WinMD/Tables/File.swift
@@ -6,21 +6,21 @@
 ///   Name (String Heap Index)
 ///   HashValue (Blob Heap Index)
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _columns: InlineArray<_, Column> = [
-  Column(name: "Flags", type: .constant(4)),
-  Column(name: "Name", type: .index(.heap(.string))),
-  Column(name: "HashValue", type: .index(.heap(.blob))),
+private let _fields: InlineArray<_, Field> = [
+  Field(name: "Flags", type: .constant(4)),
+  Field(name: "Name", type: .index(.heap(.string))),
+  Field(name: "HashValue", type: .index(.heap(.blob))),
 ]
 
-private let _offsets = offsets(_columns)
+private let _offsets = offsets(_fields)
 
 extension Metadata.Tables {
 /// See §II.22.19.
 public enum File: TableSchema {
   public static var number: Int { 38 }
 
-  public static var columns: Span<Column> {
-    @_lifetime(immortal) get { _columns.span }
+  public static var fields: Span<Field> {
+    @_lifetime(immortal) get { _fields.span }
   }
 
   public static func offset(_ i: Int) -> Int {

--- a/Sources/WinMD/Tables/File.swift
+++ b/Sources/WinMD/Tables/File.swift
@@ -29,17 +29,33 @@ public enum File: TableSchema {
 }
 }
 
+extension Column where Schema == Metadata.Tables.File {
+  public static var Flags: Column<Schema, CorFileFlags> {
+    Column<Schema, CorFileFlags>(0) {
+      CorFileFlags(rawValue: CorFileFlags.RawValue($0.columns[0]))
+    }
+  }
+
+  public static var Name: Column<Schema, String> {
+    Column<Schema, String>(1) { $0.strings[$0.columns[1]] }
+  }
+}
+
+extension BlobColumn where Schema == Metadata.Tables.File {
+  public static var HashValue: BlobColumn<Schema> { BlobColumn<Schema>(2) }
+}
+
 extension Row where Schema == Metadata.Tables.File {
   public var Flags: CorFileFlags {
-    CorFileFlags(rawValue: CorFileFlags.RawValue(columns[0]))
+    self[.Flags]
   }
 
   public var Name: String {
-    strings[columns[1]]
+    self[.Name]
   }
 
   public var HashValue: Blob {
     @_lifetime(copy self)
-    get { blobs[columns[2]] }
+    get { self[.HashValue] }
   }
 }

--- a/Sources/WinMD/Tables/GenericParam.swift
+++ b/Sources/WinMD/Tables/GenericParam.swift
@@ -34,16 +34,32 @@ public enum GenericParam: TableSchema {
 }
 }
 
+extension Column where Schema == Metadata.Tables.GenericParam {
+  public static var Number: Column<Schema, UInt16> {
+    Column<Schema, UInt16>(0) { UInt16($0.columns[0]) }
+  }
+
+  public static var Flags: Column<Schema, CorGenericParamAttr> {
+    Column<Schema, CorGenericParamAttr>(1) {
+      CorGenericParamAttr(rawValue: CorGenericParamAttr.RawValue($0.columns[1]))
+    }
+  }
+
+  public static var Name: Column<Schema, String> {
+    Column<Schema, String>(3) { $0.strings[$0.columns[3]] }
+  }
+}
+
 extension Row where Schema == Metadata.Tables.GenericParam {
   public var Number: UInt16 {
-    UInt16(columns[0])
+    self[.Number]
   }
 
   public var Flags: CorGenericParamAttr {
-    CorGenericParamAttr(rawValue: CorGenericParamAttr.RawValue(columns[1]))
+    self[.Flags]
   }
 
   public var Name: String {
-    strings[columns[3]]
+    self[.Name]
   }
 }

--- a/Sources/WinMD/Tables/GenericParam.swift
+++ b/Sources/WinMD/Tables/GenericParam.swift
@@ -7,22 +7,22 @@
 ///   Owner (TypeOrMethodDef Coded Index)
 ///   Name (String Heap Index)
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _columns: InlineArray<_, Column> = [
-  Column(name: "Number", type: .constant(2)),
-  Column(name: "Flags", type: .constant(2)),
-  Column(name: "Owner", type: .index(.coded(TypeOrMethodDef.self))),
-  Column(name: "Name", type: .index(.heap(.string))),
+private let _fields: InlineArray<_, Field> = [
+  Field(name: "Number", type: .constant(2)),
+  Field(name: "Flags", type: .constant(2)),
+  Field(name: "Owner", type: .index(.coded(TypeOrMethodDef.self))),
+  Field(name: "Name", type: .index(.heap(.string))),
 ]
 
-private let _offsets = offsets(_columns)
+private let _offsets = offsets(_fields)
 
 extension Metadata.Tables {
 /// See §II.22.20.
 public enum GenericParam: TableSchema {
   public static var number: Int { 42 }
 
-  public static var columns: Span<Column> {
-    @_lifetime(immortal) get { _columns.span }
+  public static var fields: Span<Field> {
+    @_lifetime(immortal) get { _fields.span }
   }
 
   public static func offset(_ i: Int) -> Int {

--- a/Sources/WinMD/Tables/GenericParam.swift
+++ b/Sources/WinMD/Tables/GenericParam.swift
@@ -21,6 +21,9 @@ extension Metadata.Tables {
 public enum GenericParam: TableSchema {
   public static var number: Int { 42 }
 
+  /// Sorted by `Owner`. See §II.22.20.
+  public static var key: Int? { 2 }
+
   public static var fields: Span<Field> {
     @_lifetime(immortal) get { _fields.span }
   }

--- a/Sources/WinMD/Tables/GenericParam.swift
+++ b/Sources/WinMD/Tables/GenericParam.swift
@@ -50,6 +50,12 @@ extension Column where Schema == Metadata.Tables.GenericParam {
   }
 }
 
+extension CodedReference where Schema == Metadata.Tables.GenericParam {
+  public static var Owner: CodedReference<Schema> {
+    CodedReference<Schema>(2)
+  }
+}
+
 extension Row where Schema == Metadata.Tables.GenericParam {
   public var Number: UInt16 {
     self[.Number]

--- a/Sources/WinMD/Tables/GenericParamConstraint.swift
+++ b/Sources/WinMD/Tables/GenericParamConstraint.swift
@@ -30,11 +30,23 @@ public enum GenericParamConstraint: TableSchema {
 }
 }
 
+extension Reference where Schema == Metadata.Tables.GenericParamConstraint {
+  public static var Owner: Reference<Schema, Metadata.Tables.GenericParam> {
+    Reference<Schema, Metadata.Tables.GenericParam>(0)
+  }
+}
+
+extension CodedReference where Schema == Metadata.Tables.GenericParamConstraint {
+  public static var Constraint: CodedReference<Schema> {
+    CodedReference<Schema>(1)
+  }
+}
+
 extension Row where Schema == Metadata.Tables.GenericParamConstraint {
   public var Owner: Row<Metadata.Tables.GenericParam> {
     @_lifetime(copy self)
     get throws(WinMDError) {
-      try rows(of: Metadata.Tables.GenericParam.self)[columns[0]]!
+      try required(.Owner)
     }
   }
 }

--- a/Sources/WinMD/Tables/GenericParamConstraint.swift
+++ b/Sources/WinMD/Tables/GenericParamConstraint.swift
@@ -5,20 +5,20 @@
 ///   Owner (GenericParam Index)
 ///   Constraint (TypeDefOrRef Coded Index)
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _columns: InlineArray<_, Column> = [
-  Column(name: "Owner", type: .index(.simple(Metadata.Tables.GenericParam.self))),
-  Column(name: "Constraint", type: .index(.coded(TypeDefOrRef.self))),
+private let _fields: InlineArray<_, Field> = [
+  Field(name: "Owner", type: .index(.simple(Metadata.Tables.GenericParam.self))),
+  Field(name: "Constraint", type: .index(.coded(TypeDefOrRef.self))),
 ]
 
-private let _offsets = offsets(_columns)
+private let _offsets = offsets(_fields)
 
 extension Metadata.Tables {
 /// See §II.22.21.
 public enum GenericParamConstraint: TableSchema {
   public static var number: Int { 44 }
 
-  public static var columns: Span<Column> {
-    @_lifetime(immortal) get { _columns.span }
+  public static var fields: Span<Field> {
+    @_lifetime(immortal) get { _fields.span }
   }
 
   public static func offset(_ i: Int) -> Int {

--- a/Sources/WinMD/Tables/GenericParamConstraint.swift
+++ b/Sources/WinMD/Tables/GenericParamConstraint.swift
@@ -17,6 +17,9 @@ extension Metadata.Tables {
 public enum GenericParamConstraint: TableSchema {
   public static var number: Int { 44 }
 
+  /// Sorted by `Owner`. See §II.22.21.
+  public static var key: Int? { 0 }
+
   public static var fields: Span<Field> {
     @_lifetime(immortal) get { _fields.span }
   }

--- a/Sources/WinMD/Tables/ImplMap.swift
+++ b/Sources/WinMD/Tables/ImplMap.swift
@@ -46,6 +46,18 @@ extension Column where Schema == Metadata.Tables.ImplMap {
   }
 }
 
+extension CodedReference where Schema == Metadata.Tables.ImplMap {
+  public static var MemberForwarded: CodedReference<Schema> {
+    CodedReference<Schema>(1)
+  }
+}
+
+extension Reference where Schema == Metadata.Tables.ImplMap {
+  public static var ImportScope: Reference<Schema, Metadata.Tables.ModuleRef> {
+    Reference<Schema, Metadata.Tables.ModuleRef>(3)
+  }
+}
+
 extension Row where Schema == Metadata.Tables.ImplMap {
   public var MappingFlags: CorPinvokeMap {
     self[.MappingFlags]
@@ -58,7 +70,7 @@ extension Row where Schema == Metadata.Tables.ImplMap {
   public var ImportScope: Row<Metadata.Tables.ModuleRef> {
     @_lifetime(copy self)
     get throws(WinMDError) {
-      try rows(of: Metadata.Tables.ModuleRef.self)[columns[3]]!
+      try required(.ImportScope)
     }
   }
 }

--- a/Sources/WinMD/Tables/ImplMap.swift
+++ b/Sources/WinMD/Tables/ImplMap.swift
@@ -7,22 +7,22 @@
 ///   ImportName (String Heap Index)
 ///   ImportScope (ModuleRef Index)
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _columns: InlineArray<_, Column> = [
-  Column(name: "MappingFlags", type: .constant(2)),
-  Column(name: "MemberForwarded", type: .index(.coded(MemberForwarded.self))),
-  Column(name: "ImportName", type: .index(.heap(.string))),
-  Column(name: "ImportScope", type: .index(.simple(Metadata.Tables.ModuleRef.self))),
+private let _fields: InlineArray<_, Field> = [
+  Field(name: "MappingFlags", type: .constant(2)),
+  Field(name: "MemberForwarded", type: .index(.coded(MemberForwarded.self))),
+  Field(name: "ImportName", type: .index(.heap(.string))),
+  Field(name: "ImportScope", type: .index(.simple(Metadata.Tables.ModuleRef.self))),
 ]
 
-private let _offsets = offsets(_columns)
+private let _offsets = offsets(_fields)
 
 extension Metadata.Tables {
 /// See §II.22.22.
 public enum ImplMap: TableSchema {
   public static var number: Int { 28 }
 
-  public static var columns: Span<Column> {
-    @_lifetime(immortal) get { _columns.span }
+  public static var fields: Span<Field> {
+    @_lifetime(immortal) get { _fields.span }
   }
 
   public static func offset(_ i: Int) -> Int {

--- a/Sources/WinMD/Tables/ImplMap.swift
+++ b/Sources/WinMD/Tables/ImplMap.swift
@@ -34,13 +34,25 @@ public enum ImplMap: TableSchema {
 }
 }
 
+extension Column where Schema == Metadata.Tables.ImplMap {
+  public static var MappingFlags: Column<Schema, CorPinvokeMap> {
+    Column<Schema, CorPinvokeMap>(0) {
+      CorPinvokeMap(rawValue: CorPinvokeMap.RawValue($0.columns[0]))
+    }
+  }
+
+  public static var ImportName: Column<Schema, String> {
+    Column<Schema, String>(2) { $0.strings[$0.columns[2]] }
+  }
+}
+
 extension Row where Schema == Metadata.Tables.ImplMap {
   public var MappingFlags: CorPinvokeMap {
-    CorPinvokeMap(rawValue: CorPinvokeMap.RawValue(columns[0]))
+    self[.MappingFlags]
   }
 
   public var ImportName: String {
-    strings[columns[2]]
+    self[.ImportName]
   }
 
   public var ImportScope: Row<Metadata.Tables.ModuleRef> {

--- a/Sources/WinMD/Tables/ImplMap.swift
+++ b/Sources/WinMD/Tables/ImplMap.swift
@@ -21,6 +21,9 @@ extension Metadata.Tables {
 public enum ImplMap: TableSchema {
   public static var number: Int { 28 }
 
+  /// Sorted by `MemberForwarded`. See §II.22.22.
+  public static var key: Int? { 1 }
+
   public static var fields: Span<Field> {
     @_lifetime(immortal) get { _fields.span }
   }

--- a/Sources/WinMD/Tables/InterfaceImpl.swift
+++ b/Sources/WinMD/Tables/InterfaceImpl.swift
@@ -17,6 +17,9 @@ extension Metadata.Tables {
 public enum InterfaceImpl: TableSchema {
   public static var number: Int { 9 }
 
+  /// Sorted by `Class`. See §II.22.23.
+  public static var key: Int? { 0 }
+
   public static var fields: Span<Field> {
     @_lifetime(immortal) get { _fields.span }
   }

--- a/Sources/WinMD/Tables/InterfaceImpl.swift
+++ b/Sources/WinMD/Tables/InterfaceImpl.swift
@@ -5,20 +5,20 @@
 ///   Class (TypeDef Index)
 ///   Interface (TypeDefOrRef Coded Index)
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _columns: InlineArray<_, Column> = [
-  Column(name: "Class", type: .index(.simple(Metadata.Tables.TypeDef.self))),
-  Column(name: "Interface", type: .index(.coded(TypeDefOrRef.self))),
+private let _fields: InlineArray<_, Field> = [
+  Field(name: "Class", type: .index(.simple(Metadata.Tables.TypeDef.self))),
+  Field(name: "Interface", type: .index(.coded(TypeDefOrRef.self))),
 ]
 
-private let _offsets = offsets(_columns)
+private let _offsets = offsets(_fields)
 
 extension Metadata.Tables {
 /// See §II.22.23.
 public enum InterfaceImpl: TableSchema {
   public static var number: Int { 9 }
 
-  public static var columns: Span<Column> {
-    @_lifetime(immortal) get { _columns.span }
+  public static var fields: Span<Field> {
+    @_lifetime(immortal) get { _fields.span }
   }
 
   public static func offset(_ i: Int) -> Int {

--- a/Sources/WinMD/Tables/InterfaceImpl.swift
+++ b/Sources/WinMD/Tables/InterfaceImpl.swift
@@ -30,11 +30,23 @@ public enum InterfaceImpl: TableSchema {
 }
 }
 
+extension Reference where Schema == Metadata.Tables.InterfaceImpl {
+  public static var Class: Reference<Schema, Metadata.Tables.TypeDef> {
+    Reference<Schema, Metadata.Tables.TypeDef>(0)
+  }
+}
+
+extension CodedReference where Schema == Metadata.Tables.InterfaceImpl {
+  public static var Interface: CodedReference<Schema> {
+    CodedReference<Schema>(1)
+  }
+}
+
 extension Row where Schema == Metadata.Tables.InterfaceImpl {
   public var Class: Row<Metadata.Tables.TypeDef> {
     @_lifetime(copy self)
     get throws(WinMDError) {
-      try rows(of: Metadata.Tables.TypeDef.self)[columns[0]]!
+      try required(.Class)
     }
   }
 }

--- a/Sources/WinMD/Tables/ManifestResource.swift
+++ b/Sources/WinMD/Tables/ManifestResource.swift
@@ -47,6 +47,12 @@ extension Column where Schema == Metadata.Tables.ManifestResource {
   }
 }
 
+extension CodedReference where Schema == Metadata.Tables.ManifestResource {
+  public static var Implementation: CodedReference<Schema> {
+    CodedReference<Schema>(3)
+  }
+}
+
 extension Row where Schema == Metadata.Tables.ManifestResource {
   public var Offset: UInt32 {
     self[.Offset]

--- a/Sources/WinMD/Tables/ManifestResource.swift
+++ b/Sources/WinMD/Tables/ManifestResource.swift
@@ -7,22 +7,22 @@
 ///   Name (String Heap Index)
 ///   Implementation (Implementation Coded Index)
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _columns: InlineArray<_, Column> = [
-  Column(name: "Offset", type: .constant(4)),
-  Column(name: "Flags", type: .constant(4)),
-  Column(name: "Name", type: .index(.heap(.string))),
-  Column(name: "Implementation", type: .index(.coded(Implementation.self))),
+private let _fields: InlineArray<_, Field> = [
+  Field(name: "Offset", type: .constant(4)),
+  Field(name: "Flags", type: .constant(4)),
+  Field(name: "Name", type: .index(.heap(.string))),
+  Field(name: "Implementation", type: .index(.coded(Implementation.self))),
 ]
 
-private let _offsets = offsets(_columns)
+private let _offsets = offsets(_fields)
 
 extension Metadata.Tables {
 /// See §II.22.24.
 public enum ManifestResource: TableSchema {
   public static var number: Int { 40 }
 
-  public static var columns: Span<Column> {
-    @_lifetime(immortal) get { _columns.span }
+  public static var fields: Span<Field> {
+    @_lifetime(immortal) get { _fields.span }
   }
 
   public static func offset(_ i: Int) -> Int {

--- a/Sources/WinMD/Tables/ManifestResource.swift
+++ b/Sources/WinMD/Tables/ManifestResource.swift
@@ -31,16 +31,32 @@ public enum ManifestResource: TableSchema {
 }
 }
 
+extension Column where Schema == Metadata.Tables.ManifestResource {
+  public static var Offset: Column<Schema, UInt32> {
+    Column<Schema, UInt32>(0) { UInt32($0.columns[0]) }
+  }
+
+  public static var Flags: Column<Schema, CorManifestResourceFlags> {
+    Column<Schema, CorManifestResourceFlags>(1) {
+      CorManifestResourceFlags(rawValue: UInt32($0.columns[1]))
+    }
+  }
+
+  public static var Name: Column<Schema, String> {
+    Column<Schema, String>(2) { $0.strings[$0.columns[2]] }
+  }
+}
+
 extension Row where Schema == Metadata.Tables.ManifestResource {
   public var Offset: UInt32 {
-    UInt32(columns[0])
+    self[.Offset]
   }
 
   public var Flags: CorManifestResourceFlags {
-    CorManifestResourceFlags(rawValue: UInt32(columns[1]))
+    self[.Flags]
   }
 
   public var Name: String {
-    strings[columns[2]]
+    self[.Name]
   }
 }

--- a/Sources/WinMD/Tables/MemberRef.swift
+++ b/Sources/WinMD/Tables/MemberRef.swift
@@ -6,21 +6,21 @@
 ///   Name (String Heap Index)
 ///   Signature (Blob Heap Index)
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _columns: InlineArray<_, Column> = [
-  Column(name: "Class", type: .index(.coded(MemberRefParent.self))),
-  Column(name: "Name", type: .index(.heap(.string))),
-  Column(name: "Signature", type: .index(.heap(.blob))),
+private let _fields: InlineArray<_, Field> = [
+  Field(name: "Class", type: .index(.coded(MemberRefParent.self))),
+  Field(name: "Name", type: .index(.heap(.string))),
+  Field(name: "Signature", type: .index(.heap(.blob))),
 ]
 
-private let _offsets = offsets(_columns)
+private let _offsets = offsets(_fields)
 
 extension Metadata.Tables {
 /// See §II.22.25.
 public enum MemberRef: TableSchema {
   public static var number: Int { 10 }
 
-  public static var columns: Span<Column> {
-    @_lifetime(immortal) get { _columns.span }
+  public static var fields: Span<Field> {
+    @_lifetime(immortal) get { _fields.span }
   }
 
   public static func offset(_ i: Int) -> Int {

--- a/Sources/WinMD/Tables/MemberRef.swift
+++ b/Sources/WinMD/Tables/MemberRef.swift
@@ -29,13 +29,23 @@ public enum MemberRef: TableSchema {
 }
 }
 
+extension Column where Schema == Metadata.Tables.MemberRef {
+  public static var Name: Column<Schema, String> {
+    Column<Schema, String>(1) { $0.strings[$0.columns[1]] }
+  }
+}
+
+extension BlobColumn where Schema == Metadata.Tables.MemberRef {
+  public static var Signature: BlobColumn<Schema> { BlobColumn<Schema>(2) }
+}
+
 extension Row where Schema == Metadata.Tables.MemberRef {
   public var Name: String {
-    strings[columns[1]]
+    self[.Name]
   }
 
   public var Signature: Blob {
     @_lifetime(copy self)
-    get { blobs[columns[2]] }
+    get { self[.Signature] }
   }
 }

--- a/Sources/WinMD/Tables/MemberRef.swift
+++ b/Sources/WinMD/Tables/MemberRef.swift
@@ -39,6 +39,12 @@ extension BlobColumn where Schema == Metadata.Tables.MemberRef {
   public static var Signature: BlobColumn<Schema> { BlobColumn<Schema>(2) }
 }
 
+extension CodedReference where Schema == Metadata.Tables.MemberRef {
+  public static var Class: CodedReference<Schema> {
+    CodedReference<Schema>(0)
+  }
+}
+
 extension Row where Schema == Metadata.Tables.MemberRef {
   public var Name: String {
     self[.Name]

--- a/Sources/WinMD/Tables/MethodDef.swift
+++ b/Sources/WinMD/Tables/MethodDef.swift
@@ -35,26 +35,52 @@ public enum MethodDef: TableSchema {
 }
 }
 
+extension Column where Schema == Metadata.Tables.MethodDef {
+  public static var RVA: Column<Schema, UInt32> {
+    Column<Schema, UInt32>(0) { UInt32($0.columns[0]) }
+  }
+
+  public static var ImplFlags: Column<Schema, CorMethodImpl> {
+    Column<Schema, CorMethodImpl>(1) {
+      CorMethodImpl(rawValue: CorMethodImpl.RawValue($0.columns[1]))
+    }
+  }
+
+  public static var Flags: Column<Schema, CorMethodAttr> {
+    Column<Schema, CorMethodAttr>(2) {
+      CorMethodAttr(rawValue: CorMethodAttr.RawValue($0.columns[2]))
+    }
+  }
+
+  public static var Name: Column<Schema, String> {
+    Column<Schema, String>(3) { $0.strings[$0.columns[3]] }
+  }
+}
+
+extension BlobColumn where Schema == Metadata.Tables.MethodDef {
+  public static var Signature: BlobColumn<Schema> { BlobColumn<Schema>(4) }
+}
+
 extension Row where Schema == Metadata.Tables.MethodDef {
   public var RVA: UInt32 {
-    UInt32(columns[0])
+    self[.RVA]
   }
 
   public var ImplFlags: CorMethodImpl {
-    CorMethodImpl(rawValue: CorMethodImpl.RawValue(columns[1]))
+    self[.ImplFlags]
   }
 
   public var Flags: CorMethodAttr {
-    CorMethodAttr(rawValue: CorMethodAttr.RawValue(columns[2]))
+    self[.Flags]
   }
 
   public var Name: String {
-    strings[columns[3]]
+    self[.Name]
   }
 
   public var Signature: Blob {
     @_lifetime(copy self)
-    get { blobs[columns[4]] }
+    get { self[.Signature] }
   }
 
   public var ParamList: TableIterator<Metadata.Tables.Param> {

--- a/Sources/WinMD/Tables/MethodDef.swift
+++ b/Sources/WinMD/Tables/MethodDef.swift
@@ -9,24 +9,24 @@
 ///   Signature (Blob Heap Index)
 ///   ParamList (Param Index)
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _columns: InlineArray<_, Column> = [
-  Column(name: "RVA", type: .constant(4)),
-  Column(name: "ImplFlags", type: .constant(2)),
-  Column(name: "Flags", type: .constant(2)),
-  Column(name: "Name", type: .index(.heap(.string))),
-  Column(name: "Signature", type: .index(.heap(.blob))),
-  Column(name: "ParamList", type: .index(.simple(Metadata.Tables.Param.self))),
+private let _fields: InlineArray<_, Field> = [
+  Field(name: "RVA", type: .constant(4)),
+  Field(name: "ImplFlags", type: .constant(2)),
+  Field(name: "Flags", type: .constant(2)),
+  Field(name: "Name", type: .index(.heap(.string))),
+  Field(name: "Signature", type: .index(.heap(.blob))),
+  Field(name: "ParamList", type: .index(.simple(Metadata.Tables.Param.self))),
 ]
 
-private let _offsets = offsets(_columns)
+private let _offsets = offsets(_fields)
 
 extension Metadata.Tables {
 /// See §II.22.26.
 public enum MethodDef: TableSchema {
   public static var number: Int { 6 }
 
-  public static var columns: Span<Column> {
-    @_lifetime(immortal) get { _columns.span }
+  public static var fields: Span<Field> {
+    @_lifetime(immortal) get { _fields.span }
   }
 
   public static func offset(_ i: Int) -> Int {

--- a/Sources/WinMD/Tables/MethodDef.swift
+++ b/Sources/WinMD/Tables/MethodDef.swift
@@ -61,6 +61,12 @@ extension BlobColumn where Schema == Metadata.Tables.MethodDef {
   public static var Signature: BlobColumn<Schema> { BlobColumn<Schema>(4) }
 }
 
+extension List where Schema == Metadata.Tables.MethodDef {
+  public static var ParamList: List<Schema, Metadata.Tables.Param> {
+    List<Schema, Metadata.Tables.Param>(5)
+  }
+}
+
 extension Row where Schema == Metadata.Tables.MethodDef {
   public var RVA: UInt32 {
     self[.RVA]
@@ -86,7 +92,7 @@ extension Row where Schema == Metadata.Tables.MethodDef {
   public var ParamList: TableIterator<Metadata.Tables.Param> {
     @_lifetime(copy self)
     get throws(WinMDError) {
-      try list(for: 5)
+      try list(.ParamList)
     }
   }
 }

--- a/Sources/WinMD/Tables/MethodImpl.swift
+++ b/Sources/WinMD/Tables/MethodImpl.swift
@@ -19,6 +19,9 @@ extension Metadata.Tables {
 public enum MethodImpl: TableSchema {
   public static var number: Int { 25 }
 
+  /// Sorted by `Class`. See §II.22.27.
+  public static var key: Int? { 0 }
+
   public static var fields: Span<Field> {
     @_lifetime(immortal) get { _fields.span }
   }

--- a/Sources/WinMD/Tables/MethodImpl.swift
+++ b/Sources/WinMD/Tables/MethodImpl.swift
@@ -6,21 +6,21 @@
 ///   MethodBody (MethodDefOrRef Coded Index)
 ///   MethodDeclaration (MethodDefOrRef Coded Index)
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _columns: InlineArray<_, Column> = [
-  Column(name: "Class", type: .index(.simple(Metadata.Tables.TypeDef.self))),
-  Column(name: "MethodBody", type: .index(.coded(MethodDefOrRef.self))),
-  Column(name: "MethodDeclaration", type: .index(.coded(MethodDefOrRef.self))),
+private let _fields: InlineArray<_, Field> = [
+  Field(name: "Class", type: .index(.simple(Metadata.Tables.TypeDef.self))),
+  Field(name: "MethodBody", type: .index(.coded(MethodDefOrRef.self))),
+  Field(name: "MethodDeclaration", type: .index(.coded(MethodDefOrRef.self))),
 ]
 
-private let _offsets = offsets(_columns)
+private let _offsets = offsets(_fields)
 
 extension Metadata.Tables {
 /// See §II.22.27.
 public enum MethodImpl: TableSchema {
   public static var number: Int { 25 }
 
-  public static var columns: Span<Column> {
-    @_lifetime(immortal) get { _columns.span }
+  public static var fields: Span<Field> {
+    @_lifetime(immortal) get { _fields.span }
   }
 
   public static func offset(_ i: Int) -> Int {

--- a/Sources/WinMD/Tables/MethodImpl.swift
+++ b/Sources/WinMD/Tables/MethodImpl.swift
@@ -32,11 +32,27 @@ public enum MethodImpl: TableSchema {
 }
 }
 
+extension Reference where Schema == Metadata.Tables.MethodImpl {
+  public static var Class: Reference<Schema, Metadata.Tables.TypeDef> {
+    Reference<Schema, Metadata.Tables.TypeDef>(0)
+  }
+}
+
+extension CodedReference where Schema == Metadata.Tables.MethodImpl {
+  public static var MethodBody: CodedReference<Schema> {
+    CodedReference<Schema>(1)
+  }
+
+  public static var MethodDeclaration: CodedReference<Schema> {
+    CodedReference<Schema>(2)
+  }
+}
+
 extension Row where Schema == Metadata.Tables.MethodImpl {
   public var Class: Row<Metadata.Tables.TypeDef> {
     @_lifetime(copy self)
     get throws(WinMDError) {
-      try rows(of: Metadata.Tables.TypeDef.self)[columns[0]]!
+      try required(.Class)
     }
   }
 }

--- a/Sources/WinMD/Tables/MethodSemantics.swift
+++ b/Sources/WinMD/Tables/MethodSemantics.swift
@@ -19,6 +19,9 @@ extension Metadata.Tables {
 public enum MethodSemantics: TableSchema {
   public static var number: Int { 24 }
 
+  /// Sorted by `Association`. See §II.22.28.
+  public static var key: Int? { 2 }
+
   public static var fields: Span<Field> {
     @_lifetime(immortal) get { _fields.span }
   }

--- a/Sources/WinMD/Tables/MethodSemantics.swift
+++ b/Sources/WinMD/Tables/MethodSemantics.swift
@@ -6,21 +6,21 @@
 ///   Method (MethodDef Index)
 ///   Association (HasSemantics Coded Index)
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _columns: InlineArray<_, Column> = [
-  Column(name: "Semantics", type: .constant(2)),
-  Column(name: "Method", type: .index(.simple(Metadata.Tables.MethodDef.self))),
-  Column(name: "Association", type: .index(.coded(HasSemantics.self))),
+private let _fields: InlineArray<_, Field> = [
+  Field(name: "Semantics", type: .constant(2)),
+  Field(name: "Method", type: .index(.simple(Metadata.Tables.MethodDef.self))),
+  Field(name: "Association", type: .index(.coded(HasSemantics.self))),
 ]
 
-private let _offsets = offsets(_columns)
+private let _offsets = offsets(_fields)
 
 extension Metadata.Tables {
 /// See §II.22.28.
 public enum MethodSemantics: TableSchema {
   public static var number: Int { 24 }
 
-  public static var columns: Span<Column> {
-    @_lifetime(immortal) get { _columns.span }
+  public static var fields: Span<Field> {
+    @_lifetime(immortal) get { _fields.span }
   }
 
   public static func offset(_ i: Int) -> Int {

--- a/Sources/WinMD/Tables/MethodSemantics.swift
+++ b/Sources/WinMD/Tables/MethodSemantics.swift
@@ -32,9 +32,17 @@ public enum MethodSemantics: TableSchema {
 }
 }
 
+extension Column where Schema == Metadata.Tables.MethodSemantics {
+  public static var Semantics: Column<Schema, CorMethodSemanticsAttr> {
+    Column<Schema, CorMethodSemanticsAttr>(0) {
+      CorMethodSemanticsAttr(rawValue: UInt16($0.columns[0]))
+    }
+  }
+}
+
 extension Row where Schema == Metadata.Tables.MethodSemantics {
   public var Semantics: CorMethodSemanticsAttr {
-    CorMethodSemanticsAttr(rawValue: UInt16(columns[0]))
+    self[.Semantics]
   }
 
   public var Method: Row<Metadata.Tables.MethodDef> {

--- a/Sources/WinMD/Tables/MethodSemantics.swift
+++ b/Sources/WinMD/Tables/MethodSemantics.swift
@@ -40,6 +40,18 @@ extension Column where Schema == Metadata.Tables.MethodSemantics {
   }
 }
 
+extension Reference where Schema == Metadata.Tables.MethodSemantics {
+  public static var Method: Reference<Schema, Metadata.Tables.MethodDef> {
+    Reference<Schema, Metadata.Tables.MethodDef>(1)
+  }
+}
+
+extension CodedReference where Schema == Metadata.Tables.MethodSemantics {
+  public static var Association: CodedReference<Schema> {
+    CodedReference<Schema>(2)
+  }
+}
+
 extension Row where Schema == Metadata.Tables.MethodSemantics {
   public var Semantics: CorMethodSemanticsAttr {
     self[.Semantics]
@@ -48,7 +60,7 @@ extension Row where Schema == Metadata.Tables.MethodSemantics {
   public var Method: Row<Metadata.Tables.MethodDef> {
     @_lifetime(copy self)
     get throws(WinMDError) {
-      try rows(of: Metadata.Tables.MethodDef.self)[columns[1]]!
+      try required(.Method)
     }
   }
 }

--- a/Sources/WinMD/Tables/MethodSpec.swift
+++ b/Sources/WinMD/Tables/MethodSpec.swift
@@ -27,9 +27,13 @@ public enum MethodSpec: TableSchema {
 }
 }
 
+extension BlobColumn where Schema == Metadata.Tables.MethodSpec {
+  public static var Instantiation: BlobColumn<Schema> { BlobColumn<Schema>(1) }
+}
+
 extension Row where Schema == Metadata.Tables.MethodSpec {
   public var Instantiation: Blob {
     @_lifetime(copy self)
-    get { blobs[columns[1]] }
+    get { self[.Instantiation] }
   }
 }

--- a/Sources/WinMD/Tables/MethodSpec.swift
+++ b/Sources/WinMD/Tables/MethodSpec.swift
@@ -31,6 +31,12 @@ extension BlobColumn where Schema == Metadata.Tables.MethodSpec {
   public static var Instantiation: BlobColumn<Schema> { BlobColumn<Schema>(1) }
 }
 
+extension CodedReference where Schema == Metadata.Tables.MethodSpec {
+  public static var Method: CodedReference<Schema> {
+    CodedReference<Schema>(0)
+  }
+}
+
 extension Row where Schema == Metadata.Tables.MethodSpec {
   public var Instantiation: Blob {
     @_lifetime(copy self)

--- a/Sources/WinMD/Tables/MethodSpec.swift
+++ b/Sources/WinMD/Tables/MethodSpec.swift
@@ -5,20 +5,20 @@
 ///   Method (MethodDefOrRef Coded Index)
 ///   Instantiation (Blob Heap Index)
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _columns: InlineArray<_, Column> = [
-  Column(name: "Method", type: .index(.coded(MethodDefOrRef.self))),
-  Column(name: "Instantiation", type: .index(.heap(.blob))),
+private let _fields: InlineArray<_, Field> = [
+  Field(name: "Method", type: .index(.coded(MethodDefOrRef.self))),
+  Field(name: "Instantiation", type: .index(.heap(.blob))),
 ]
 
-private let _offsets = offsets(_columns)
+private let _offsets = offsets(_fields)
 
 extension Metadata.Tables {
 /// See §II.22.29.
 public enum MethodSpec: TableSchema {
   public static var number: Int { 43 }
 
-  public static var columns: Span<Column> {
-    @_lifetime(immortal) get { _columns.span }
+  public static var fields: Span<Field> {
+    @_lifetime(immortal) get { _fields.span }
   }
 
   public static func offset(_ i: Int) -> Int {

--- a/Sources/WinMD/Tables/Module.swift
+++ b/Sources/WinMD/Tables/Module.swift
@@ -35,13 +35,23 @@ public enum Module: TableSchema {
 }
 }
 
+extension Column where Schema == Metadata.Tables.Module {
+  public static var Generation: Column<Schema, UInt16> {
+    Column<Schema, UInt16>(0) { UInt16($0.columns[0]) }
+  }
+
+  public static var Name: Column<Schema, String> {
+    Column<Schema, String>(1) { $0.strings[$0.columns[1]] }
+  }
+}
+
 extension Row where Schema == Metadata.Tables.Module {
   public var Generation: UInt16 {
-    UInt16(columns[0])
+    self[.Generation]
   }
 
   public var Name: String {
-    strings[columns[1]]
+    self[.Name]
   }
 
   public var Mvid: UUID {

--- a/Sources/WinMD/Tables/Module.swift
+++ b/Sources/WinMD/Tables/Module.swift
@@ -10,23 +10,23 @@ public import struct Foundation.UUID
 ///   EncId (GUID Heap Index, reserved, MBZ)
 ///   EncBaseId (GUID Heap Index, reserved, MBZ)
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _columns: InlineArray<_, Column> = [
-  Column(name: "Generation", type: .constant(2)),
-  Column(name: "Name", type: .index(.heap(.string))),
-  Column(name: "Mvid", type: .index(.heap(.guid))),
-  Column(name: "EncId", type: .index(.heap(.guid))),
-  Column(name: "EncBaseId", type: .index(.heap(.guid))),
+private let _fields: InlineArray<_, Field> = [
+  Field(name: "Generation", type: .constant(2)),
+  Field(name: "Name", type: .index(.heap(.string))),
+  Field(name: "Mvid", type: .index(.heap(.guid))),
+  Field(name: "EncId", type: .index(.heap(.guid))),
+  Field(name: "EncBaseId", type: .index(.heap(.guid))),
 ]
 
-private let _offsets = offsets(_columns)
+private let _offsets = offsets(_fields)
 
 extension Metadata.Tables {
 /// See §II.22.30.
 public enum Module: TableSchema {
   public static var number: Int { 0 }
 
-  public static var columns: Span<Column> {
-    @_lifetime(immortal) get { _columns.span }
+  public static var fields: Span<Field> {
+    @_lifetime(immortal) get { _fields.span }
   }
 
   public static func offset(_ i: Int) -> Int {

--- a/Sources/WinMD/Tables/ModuleRef.swift
+++ b/Sources/WinMD/Tables/ModuleRef.swift
@@ -25,8 +25,14 @@ public enum ModuleRef: TableSchema {
 }
 }
 
+extension Column where Schema == Metadata.Tables.ModuleRef {
+  public static var Name: Column<Schema, String> {
+    Column<Schema, String>(0) { $0.strings[$0.columns[0]] }
+  }
+}
+
 extension Row where Schema == Metadata.Tables.ModuleRef {
   public var Name: String {
-    strings[columns[0]]
+    self[.Name]
   }
 }

--- a/Sources/WinMD/Tables/ModuleRef.swift
+++ b/Sources/WinMD/Tables/ModuleRef.swift
@@ -4,19 +4,19 @@
 /// Record Layout
 ///   Name (String Heap Index)
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _columns: InlineArray<_, Column> = [
-  Column(name: "Name", type: .index(.heap(.string))),
+private let _fields: InlineArray<_, Field> = [
+  Field(name: "Name", type: .index(.heap(.string))),
 ]
 
-private let _offsets = offsets(_columns)
+private let _offsets = offsets(_fields)
 
 extension Metadata.Tables {
 /// See §II.22.31.
 public enum ModuleRef: TableSchema {
   public static var number: Int { 26 }
 
-  public static var columns: Span<Column> {
-    @_lifetime(immortal) get { _columns.span }
+  public static var fields: Span<Field> {
+    @_lifetime(immortal) get { _fields.span }
   }
 
   public static func offset(_ i: Int) -> Int {

--- a/Sources/WinMD/Tables/NestedClass.swift
+++ b/Sources/WinMD/Tables/NestedClass.swift
@@ -5,20 +5,20 @@
 ///   NestedClass (TypeDef Index)
 ///   EnclosingClass (TypeDef Index)
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _columns: InlineArray<_, Column> = [
-  Column(name: "NestedClass", type: .index(.simple(Metadata.Tables.TypeDef.self))),
-  Column(name: "EnclosingClass", type: .index(.simple(Metadata.Tables.TypeDef.self))),
+private let _fields: InlineArray<_, Field> = [
+  Field(name: "NestedClass", type: .index(.simple(Metadata.Tables.TypeDef.self))),
+  Field(name: "EnclosingClass", type: .index(.simple(Metadata.Tables.TypeDef.self))),
 ]
 
-private let _offsets = offsets(_columns)
+private let _offsets = offsets(_fields)
 
 extension Metadata.Tables {
 /// See §II.22.32.
 public enum NestedClass: TableSchema {
   public static var number: Int { 41 }
 
-  public static var columns: Span<Column> {
-    @_lifetime(immortal) get { _columns.span }
+  public static var fields: Span<Field> {
+    @_lifetime(immortal) get { _fields.span }
   }
 
   public static func offset(_ i: Int) -> Int {

--- a/Sources/WinMD/Tables/NestedClass.swift
+++ b/Sources/WinMD/Tables/NestedClass.swift
@@ -17,6 +17,9 @@ extension Metadata.Tables {
 public enum NestedClass: TableSchema {
   public static var number: Int { 41 }
 
+  /// Sorted by `NestedClass`. See §II.22.32.
+  public static var key: Int? { 0 }
+
   public static var fields: Span<Field> {
     @_lifetime(immortal) get { _fields.span }
   }

--- a/Sources/WinMD/Tables/NestedClass.swift
+++ b/Sources/WinMD/Tables/NestedClass.swift
@@ -30,18 +30,28 @@ public enum NestedClass: TableSchema {
 }
 }
 
+extension Reference where Schema == Metadata.Tables.NestedClass {
+  public static var NestedClass: Reference<Schema, Metadata.Tables.TypeDef> {
+    Reference<Schema, Metadata.Tables.TypeDef>(0)
+  }
+
+  public static var EnclosingClass: Reference<Schema, Metadata.Tables.TypeDef> {
+    Reference<Schema, Metadata.Tables.TypeDef>(1)
+  }
+}
+
 extension Row where Schema == Metadata.Tables.NestedClass {
   public var NestedClass: Row<Metadata.Tables.TypeDef> {
     @_lifetime(copy self)
     get throws(WinMDError) {
-      try rows(of: Metadata.Tables.TypeDef.self)[columns[0]]!
+      try required(.NestedClass)
     }
   }
 
   public var EnclosingClass: Row<Metadata.Tables.TypeDef> {
     @_lifetime(copy self)
     get throws(WinMDError) {
-      try rows(of: Metadata.Tables.TypeDef.self)[columns[1]]!
+      try required(.EnclosingClass)
     }
   }
 }

--- a/Sources/WinMD/Tables/Param.swift
+++ b/Sources/WinMD/Tables/Param.swift
@@ -29,16 +29,32 @@ public enum Param: TableSchema {
 }
 }
 
+extension Column where Schema == Metadata.Tables.Param {
+  public static var Flags: Column<Schema, CorParamAttr> {
+    Column<Schema, CorParamAttr>(0) {
+      CorParamAttr(rawValue: CorParamAttr.RawValue($0.columns[0]))
+    }
+  }
+
+  public static var Sequence: Column<Schema, UInt16> {
+    Column<Schema, UInt16>(1) { UInt16($0.columns[1]) }
+  }
+
+  public static var Name: Column<Schema, String> {
+    Column<Schema, String>(2) { $0.strings[$0.columns[2]] }
+  }
+}
+
 extension Row where Schema == Metadata.Tables.Param {
   public var Flags: CorParamAttr {
-    CorParamAttr(rawValue: CorParamAttr.RawValue(columns[0]))
+    self[.Flags]
   }
 
   public var Sequence: UInt16 {
-    UInt16(columns[1])
+    self[.Sequence]
   }
 
   public var Name: String {
-    strings[columns[2]]
+    self[.Name]
   }
 }

--- a/Sources/WinMD/Tables/Param.swift
+++ b/Sources/WinMD/Tables/Param.swift
@@ -6,21 +6,21 @@
 ///   Sequence (2-byte constant)
 ///   Name (String Heap Index)
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _columns: InlineArray<_, Column> = [
-  Column(name: "Flags", type: .constant(2)),
-  Column(name: "Sequence", type: .constant(2)),
-  Column(name: "Name", type: .index(.heap(.string))),
+private let _fields: InlineArray<_, Field> = [
+  Field(name: "Flags", type: .constant(2)),
+  Field(name: "Sequence", type: .constant(2)),
+  Field(name: "Name", type: .index(.heap(.string))),
 ]
 
-private let _offsets = offsets(_columns)
+private let _offsets = offsets(_fields)
 
 extension Metadata.Tables {
 /// See §II.22.33.
 public enum Param: TableSchema {
   public static var number: Int { 8 }
 
-  public static var columns: Span<Column> {
-    @_lifetime(immortal) get { _columns.span }
+  public static var fields: Span<Field> {
+    @_lifetime(immortal) get { _fields.span }
   }
 
   public static func offset(_ i: Int) -> Int {

--- a/Sources/WinMD/Tables/PropertyDef.swift
+++ b/Sources/WinMD/Tables/PropertyDef.swift
@@ -6,21 +6,21 @@
 ///   Name (String Heap Index)
 ///   Type (Blob Heap Index)
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _columns: InlineArray<_, Column> = [
-  Column(name: "Flags", type: .constant(2)),
-  Column(name: "Name", type: .index(.heap(.string))),
-  Column(name: "Type", type: .index(.heap(.blob))),
+private let _fields: InlineArray<_, Field> = [
+  Field(name: "Flags", type: .constant(2)),
+  Field(name: "Name", type: .index(.heap(.string))),
+  Field(name: "Type", type: .index(.heap(.blob))),
 ]
 
-private let _offsets = offsets(_columns)
+private let _offsets = offsets(_fields)
 
 extension Metadata.Tables {
 /// See §II.22.34.
 public enum PropertyDef: TableSchema {
   public static var number: Int { 23 }
 
-  public static var columns: Span<Column> {
-    @_lifetime(immortal) get { _columns.span }
+  public static var fields: Span<Field> {
+    @_lifetime(immortal) get { _fields.span }
   }
 
   public static func offset(_ i: Int) -> Int {

--- a/Sources/WinMD/Tables/PropertyDef.swift
+++ b/Sources/WinMD/Tables/PropertyDef.swift
@@ -29,12 +29,28 @@ public enum PropertyDef: TableSchema {
 }
 }
 
+extension Column where Schema == Metadata.Tables.PropertyDef {
+  public static var Flags: Column<Schema, CorPropertyAttr> {
+    Column<Schema, CorPropertyAttr>(0) {
+      CorPropertyAttr(rawValue: CorPropertyAttr.RawValue($0.columns[0]))
+    }
+  }
+
+  public static var Name: Column<Schema, String> {
+    Column<Schema, String>(1) { $0.strings[$0.columns[1]] }
+  }
+}
+
+extension BlobColumn where Schema == Metadata.Tables.PropertyDef {
+  public static var `Type`: BlobColumn<Schema> { BlobColumn<Schema>(2) }
+}
+
 extension Row where Schema == Metadata.Tables.PropertyDef {
   public var Flags: CorPropertyAttr {
-    CorPropertyAttr(rawValue: CorPropertyAttr.RawValue(columns[0]))
+    self[.Flags]
   }
 
   public var Name: String {
-    strings[columns[1]]
+    self[.Name]
   }
 }

--- a/Sources/WinMD/Tables/PropertyMap.swift
+++ b/Sources/WinMD/Tables/PropertyMap.swift
@@ -5,20 +5,20 @@
 ///   Parent (TypeDef Index)
 ///   PropertyList (Property Index)
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _columns: InlineArray<_, Column> = [
-  Column(name: "Parent", type: .index(.simple(Metadata.Tables.TypeDef.self))),
-  Column(name: "PropertyList", type: .index(.simple(Metadata.Tables.PropertyDef.self))),
+private let _fields: InlineArray<_, Field> = [
+  Field(name: "Parent", type: .index(.simple(Metadata.Tables.TypeDef.self))),
+  Field(name: "PropertyList", type: .index(.simple(Metadata.Tables.PropertyDef.self))),
 ]
 
-private let _offsets = offsets(_columns)
+private let _offsets = offsets(_fields)
 
 extension Metadata.Tables {
 /// See §II.22.35.
 public enum PropertyMap: TableSchema {
   public static var number: Int { 21 }
 
-  public static var columns: Span<Column> {
-    @_lifetime(immortal) get { _columns.span }
+  public static var fields: Span<Field> {
+    @_lifetime(immortal) get { _fields.span }
   }
 
   public static func offset(_ i: Int) -> Int {

--- a/Sources/WinMD/Tables/PropertyMap.swift
+++ b/Sources/WinMD/Tables/PropertyMap.swift
@@ -27,18 +27,30 @@ public enum PropertyMap: TableSchema {
 }
 }
 
+extension Reference where Schema == Metadata.Tables.PropertyMap {
+  public static var Parent: Reference<Schema, Metadata.Tables.TypeDef> {
+    Reference<Schema, Metadata.Tables.TypeDef>(0)
+  }
+}
+
+extension List where Schema == Metadata.Tables.PropertyMap {
+  public static var PropertyList: List<Schema, Metadata.Tables.PropertyDef> {
+    List<Schema, Metadata.Tables.PropertyDef>(1)
+  }
+}
+
 extension Row where Schema == Metadata.Tables.PropertyMap {
   public var Parent: Row<Metadata.Tables.TypeDef> {
     @_lifetime(copy self)
     get throws(WinMDError) {
-      try rows(of: Metadata.Tables.TypeDef.self)[columns[0]]!
+      try required(.Parent)
     }
   }
 
   public var PropertyList: TableIterator<Metadata.Tables.PropertyDef> {
     @_lifetime(copy self)
     get throws(WinMDError) {
-      try list(for: 1)
+      try list(.PropertyList)
     }
   }
 }

--- a/Sources/WinMD/Tables/StandAloneSig.swift
+++ b/Sources/WinMD/Tables/StandAloneSig.swift
@@ -25,9 +25,13 @@ public enum StandAloneSig: TableSchema {
 }
 }
 
+extension BlobColumn where Schema == Metadata.Tables.StandAloneSig {
+  public static var Signature: BlobColumn<Schema> { BlobColumn<Schema>(0) }
+}
+
 extension Row where Schema == Metadata.Tables.StandAloneSig {
   public var Signature: Blob {
     @_lifetime(copy self)
-    get { blobs[columns[0]] }
+    get { self[.Signature] }
   }
 }

--- a/Sources/WinMD/Tables/StandAloneSig.swift
+++ b/Sources/WinMD/Tables/StandAloneSig.swift
@@ -4,19 +4,19 @@
 /// Record Layout
 ///   Signature (Blob Heap Index)
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _columns: InlineArray<_, Column> = [
-  Column(name: "Signature", type: .index(.heap(.blob))),
+private let _fields: InlineArray<_, Field> = [
+  Field(name: "Signature", type: .index(.heap(.blob))),
 ]
 
-private let _offsets = offsets(_columns)
+private let _offsets = offsets(_fields)
 
 extension Metadata.Tables {
 /// See §II.22.36.
 public enum StandAloneSig: TableSchema {
   public static var number: Int { 17 }
 
-  public static var columns: Span<Column> {
-    @_lifetime(immortal) get { _columns.span }
+  public static var fields: Span<Field> {
+    @_lifetime(immortal) get { _fields.span }
   }
 
   public static func offset(_ i: Int) -> Int {

--- a/Sources/WinMD/Tables/TypeDef.swift
+++ b/Sources/WinMD/Tables/TypeDef.swift
@@ -51,6 +51,22 @@ extension Column where Schema == Metadata.Tables.TypeDef {
   }
 }
 
+extension CodedReference where Schema == Metadata.Tables.TypeDef {
+  public static var Extends: CodedReference<Schema> {
+    CodedReference<Schema>(3)
+  }
+}
+
+extension List where Schema == Metadata.Tables.TypeDef {
+  public static var FieldList: List<Schema, Metadata.Tables.FieldDef> {
+    List<Schema, Metadata.Tables.FieldDef>(4)
+  }
+
+  public static var MethodList: List<Schema, Metadata.Tables.MethodDef> {
+    List<Schema, Metadata.Tables.MethodDef>(5)
+  }
+}
+
 extension Row where Schema == Metadata.Tables.TypeDef {
   public var Flags: CorTypeAttr {
     self[.Flags]
@@ -67,14 +83,14 @@ extension Row where Schema == Metadata.Tables.TypeDef {
   public var FieldList: TableIterator<Metadata.Tables.FieldDef> {
     @_lifetime(copy self)
     get throws(WinMDError) {
-      try list(for: 4)
+      try list(.FieldList)
     }
   }
 
   public var MethodList: TableIterator<Metadata.Tables.MethodDef> {
     @_lifetime(copy self)
     get throws(WinMDError) {
-      try list(for: 5)
+      try list(.MethodList)
     }
   }
 }

--- a/Sources/WinMD/Tables/TypeDef.swift
+++ b/Sources/WinMD/Tables/TypeDef.swift
@@ -35,17 +35,33 @@ public enum TypeDef: TableSchema {
 }
 }
 
+extension Column where Schema == Metadata.Tables.TypeDef {
+  public static var Flags: Column<Schema, CorTypeAttr> {
+    Column<Schema, CorTypeAttr>(0) {
+      CorTypeAttr(rawValue: CorTypeAttr.RawValue($0.columns[0]))
+    }
+  }
+
+  public static var TypeName: Column<Schema, String> {
+    Column<Schema, String>(1) { $0.strings[$0.columns[1]] }
+  }
+
+  public static var TypeNamespace: Column<Schema, String> {
+    Column<Schema, String>(2) { $0.strings[$0.columns[2]] }
+  }
+}
+
 extension Row where Schema == Metadata.Tables.TypeDef {
   public var Flags: CorTypeAttr {
-    CorTypeAttr(rawValue: CorTypeAttr.RawValue(columns[0]))
+    self[.Flags]
   }
 
   public var TypeName: String {
-    strings[columns[1]]
+    self[.TypeName]
   }
 
   public var TypeNamespace: String {
-    strings[columns[2]]
+    self[.TypeNamespace]
   }
 
   public var FieldList: TableIterator<Metadata.Tables.FieldDef> {

--- a/Sources/WinMD/Tables/TypeDef.swift
+++ b/Sources/WinMD/Tables/TypeDef.swift
@@ -6,27 +6,27 @@
 ///   TypeName (String Heap Index)
 ///   TypeNamespace (String Heap Index)
 ///   Extends (TypeDefOrRef Coded Index)
-///   FieldList (Field Index)
+///   FieldList (Column Index)
 ///   MethodList (MethodDef Index)
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _columns: InlineArray<_, Column> = [
-  Column(name: "Flags", type: .constant(4)),
-  Column(name: "TypeName", type: .index(.heap(.string))),
-  Column(name: "TypeNamespace", type: .index(.heap(.string))),
-  Column(name: "Extends", type: .index(.coded(TypeDefOrRef.self))),
-  Column(name: "FieldList", type: .index(.simple(Metadata.Tables.FieldDef.self))),
-  Column(name: "MethodList", type: .index(.simple(Metadata.Tables.MethodDef.self))),
+private let _fields: InlineArray<_, Field> = [
+  Field(name: "Flags", type: .constant(4)),
+  Field(name: "TypeName", type: .index(.heap(.string))),
+  Field(name: "TypeNamespace", type: .index(.heap(.string))),
+  Field(name: "Extends", type: .index(.coded(TypeDefOrRef.self))),
+  Field(name: "FieldList", type: .index(.simple(Metadata.Tables.FieldDef.self))),
+  Field(name: "MethodList", type: .index(.simple(Metadata.Tables.MethodDef.self))),
 ]
 
-private let _offsets = offsets(_columns)
+private let _offsets = offsets(_fields)
 
 extension Metadata.Tables {
 /// See §II.22.37.
 public enum TypeDef: TableSchema {
   public static var number: Int { 2 }
 
-  public static var columns: Span<Column> {
-    @_lifetime(immortal) get { _columns.span }
+  public static var fields: Span<Field> {
+    @_lifetime(immortal) get { _fields.span }
   }
 
   public static func offset(_ i: Int) -> Int {

--- a/Sources/WinMD/Tables/TypeRef.swift
+++ b/Sources/WinMD/Tables/TypeRef.swift
@@ -29,12 +29,22 @@ public enum TypeRef: TableSchema {
 }
 }
 
+extension Column where Schema == Metadata.Tables.TypeRef {
+  public static var TypeName: Column<Schema, String> {
+    Column<Schema, String>(1) { $0.strings[$0.columns[1]] }
+  }
+
+  public static var TypeNamespace: Column<Schema, String> {
+    Column<Schema, String>(2) { $0.strings[$0.columns[2]] }
+  }
+}
+
 extension Row where Schema == Metadata.Tables.TypeRef {
   public var TypeName: String {
-    strings[columns[1]]
+    self[.TypeName]
   }
 
   public var TypeNamespace: String {
-    strings[columns[2]]
+    self[.TypeNamespace]
   }
 }

--- a/Sources/WinMD/Tables/TypeRef.swift
+++ b/Sources/WinMD/Tables/TypeRef.swift
@@ -39,6 +39,12 @@ extension Column where Schema == Metadata.Tables.TypeRef {
   }
 }
 
+extension CodedReference where Schema == Metadata.Tables.TypeRef {
+  public static var ResolutionScope: CodedReference<Schema> {
+    CodedReference<Schema>(0)
+  }
+}
+
 extension Row where Schema == Metadata.Tables.TypeRef {
   public var TypeName: String {
     self[.TypeName]

--- a/Sources/WinMD/Tables/TypeRef.swift
+++ b/Sources/WinMD/Tables/TypeRef.swift
@@ -6,21 +6,21 @@
 ///   TypeName (String Heap Index)
 ///   TypeNamespace (String Heap Index)
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _columns: InlineArray<_, Column> = [
-  Column(name: "ResolutionScope", type: .index(.coded(ResolutionScope.self))),
-  Column(name: "TypeName", type: .index(.heap(.string))),
-  Column(name: "TypeNamespace", type: .index(.heap(.string))),
+private let _fields: InlineArray<_, Field> = [
+  Field(name: "ResolutionScope", type: .index(.coded(ResolutionScope.self))),
+  Field(name: "TypeName", type: .index(.heap(.string))),
+  Field(name: "TypeNamespace", type: .index(.heap(.string))),
 ]
 
-private let _offsets = offsets(_columns)
+private let _offsets = offsets(_fields)
 
 extension Metadata.Tables {
 /// See §II.22.38.
 public enum TypeRef: TableSchema {
   public static var number: Int { 1 }
 
-  public static var columns: Span<Column> {
-    @_lifetime(immortal) get { _columns.span }
+  public static var fields: Span<Field> {
+    @_lifetime(immortal) get { _fields.span }
   }
 
   public static func offset(_ i: Int) -> Int {

--- a/Sources/WinMD/Tables/TypeSpec.swift
+++ b/Sources/WinMD/Tables/TypeSpec.swift
@@ -4,19 +4,19 @@
 /// Record Layout
 ///   Signature (Blob Heap Index)
 // TODO(compnerd) fold into the accessor when immortal inline spans land.
-private let _columns: InlineArray<_, Column> = [
-  Column(name: "Signature", type: .index(.heap(.blob))),
+private let _fields: InlineArray<_, Field> = [
+  Field(name: "Signature", type: .index(.heap(.blob))),
 ]
 
-private let _offsets = offsets(_columns)
+private let _offsets = offsets(_fields)
 
 extension Metadata.Tables {
 /// See §II.22.39.
 public enum TypeSpec: TableSchema {
   public static var number: Int { 27 }
 
-  public static var columns: Span<Column> {
-    @_lifetime(immortal) get { _columns.span }
+  public static var fields: Span<Field> {
+    @_lifetime(immortal) get { _fields.span }
   }
 
   public static func offset(_ i: Int) -> Int {

--- a/Sources/WinMD/Tables/TypeSpec.swift
+++ b/Sources/WinMD/Tables/TypeSpec.swift
@@ -25,9 +25,13 @@ public enum TypeSpec: TableSchema {
 }
 }
 
+extension BlobColumn where Schema == Metadata.Tables.TypeSpec {
+  public static var Signature: BlobColumn<Schema> { BlobColumn<Schema>(0) }
+}
+
 extension Row where Schema == Metadata.Tables.TypeSpec {
   public var Signature: Blob {
     @_lifetime(copy self)
-    get { blobs[columns[0]] }
+    get { self[.Signature] }
   }
 }

--- a/Sources/WinMD/TablesStream.swift
+++ b/Sources/WinMD/TablesStream.swift
@@ -86,11 +86,11 @@ public struct TablesStream: ~Escapable {
 
       // Resolve the record layout into a width bitset and a stride: bit `i` is
       // set iff column `i` is an index the catalog widened to 4 bytes.
-      let columns = schema.columns
+      let fields = schema.fields
       var wide: UInt32 = 0
       var stride = 0
-      for index in columns.indices {
-        let type = columns[index].type
+      for index in fields.indices {
+        let type = fields[index].type
         let width = catalog.width(of: type)
         if case .index = type, width == 4 {
           wide |= 1 << index

--- a/Sources/WinMD/TypedQuery.swift
+++ b/Sources/WinMD/TypedQuery.swift
@@ -1,0 +1,198 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+/// The closure query combinators over a typed `TableIterator<Schema>`.
+///
+/// These mirror the generic `Cursor` combinators (`Filter`/`Projection`), but
+/// they walk a statically typed table and hand each stage a borrowed
+/// `Row<Schema>` rather than a type-erased `Tuple`, so predicates and
+/// projections address columns with leading-dot `Column` tokens —
+/// `$0[.TypeName]` — and read the row's typed accessors directly.
+///
+/// A query is a borrowed traversal: `where` and `select` build lazy
+/// `~Escapable` stages that store escapable closures of the form
+/// `(borrowing Row<Schema>) -> …`, while the iterator and the transiently
+/// materialised `Row` stay on the borrowed side of the escape boundary.
+/// Nothing is materialised and nothing allocates per row; stages compose and
+/// the scan runs only when a terminal consumes it.
+///
+/// A projection must yield an escapable value. `.select({ $0 })` does not
+/// surface the row — a `Row` cannot escape the closure. To surface rows
+/// themselves, hand them to the `(borrowing Row<Schema>) -> Void` callback of
+/// `forEach`.
+
+// MARK: - TypedFilter
+
+/// A lazy filtered stage over a `TableIterator<Schema>`.
+///
+/// It holds the base iterator and a predicate; the predicate is evaluated only
+/// when a terminal consumes the stage.
+public struct TypedFilter<Schema: TableSchema>: ~Escapable {
+  private let base: TableIterator<Schema>
+  private let predicate: (borrowing Row<Schema>) -> Bool
+
+  @_lifetime(copy base)
+  internal init(_ base: borrowing TableIterator<Schema>,
+                _ predicate: @escaping (borrowing Row<Schema>) -> Bool) {
+    self.base = copy base
+    self.predicate = predicate
+  }
+
+  /// Maps each surviving row through `transform`, yielding an escapable value.
+  @_lifetime(copy self)
+  public func select<T>(_ transform: @escaping (borrowing Row<Schema>) -> T)
+      -> TypedProjection<Schema, T> {
+    TypedProjection(base, where: predicate, select: transform)
+  }
+
+  // MARK: Terminals
+
+  /// Applies `body` to each surviving row.
+  public func forEach(_ body: (borrowing Row<Schema>) -> Void) {
+    for row in 0 ..< base.count {
+      guard let value = base[row] else { continue }
+      if predicate(value) {
+        body(value)
+      }
+    }
+  }
+
+  /// The first surviving row satisfying `predicate`, passed to `body`.
+  ///
+  /// Returns the escapable value `body` produces, or `nil` if no row matches.
+  public func first<T>(where predicate: (borrowing Row<Schema>) -> Bool,
+                       _ body: (borrowing Row<Schema>) -> T) -> T? {
+    for row in 0 ..< base.count {
+      guard let value = base[row] else { continue }
+      if self.predicate(value), predicate(value) {
+        return body(value)
+      }
+    }
+    return nil
+  }
+
+  /// Folds the surviving rows into `initial` with `next`.
+  public func reduce<R>(_ initial: R,
+                        _ next: (R, borrowing Row<Schema>) -> R) -> R {
+    var result = initial
+    for row in 0 ..< base.count {
+      guard let value = base[row] else { continue }
+      if predicate(value) {
+        result = next(result, value)
+      }
+    }
+    return result
+  }
+
+  /// The number of surviving rows.
+  public func count() -> Int {
+    var count = 0
+    for row in 0 ..< base.count {
+      guard let value = base[row] else { continue }
+      if predicate(value) {
+        count += 1
+      }
+    }
+    return count
+  }
+}
+
+// MARK: - TypedProjection
+
+/// A lazy projected stage over a `TableIterator<Schema>`.
+///
+/// It holds the base iterator, an optional predicate, and a transform mapping a
+/// surviving row to an escapable value; both run only when a terminal consumes
+/// the stage.
+public struct TypedProjection<Schema: TableSchema, T>: ~Escapable {
+  private let base: TableIterator<Schema>
+  private let predicate: ((borrowing Row<Schema>) -> Bool)?
+  private let transform: (borrowing Row<Schema>) -> T
+
+  @_lifetime(copy base)
+  internal init(_ base: borrowing TableIterator<Schema>,
+                where predicate: ((borrowing Row<Schema>) -> Bool)? = nil,
+                select transform: @escaping (borrowing Row<Schema>) -> T) {
+    self.base = copy base
+    self.predicate = predicate
+    self.transform = transform
+  }
+
+  // MARK: Terminals
+
+  /// Applies `body` to each projected value.
+  public func forEach(_ body: (T) -> Void) {
+    for row in 0 ..< base.count {
+      guard let value = base[row] else { continue }
+      if predicate?(value) ?? true {
+        body(transform(value))
+      }
+    }
+  }
+
+  /// The first projected value whose row satisfies `predicate`.
+  public func first(where predicate: (borrowing Row<Schema>) -> Bool) -> T? {
+    for row in 0 ..< base.count {
+      guard let value = base[row] else { continue }
+      if self.predicate?(value) ?? true, predicate(value) {
+        return transform(value)
+      }
+    }
+    return nil
+  }
+
+  /// Folds the projected values into `initial` with `next`.
+  public func reduce<R>(_ initial: R, _ next: (R, T) -> R) -> R {
+    var result = initial
+    for row in 0 ..< base.count {
+      guard let value = base[row] else { continue }
+      if predicate?(value) ?? true {
+        result = next(result, transform(value))
+      }
+    }
+    return result
+  }
+
+  /// The number of projected values.
+  public func count() -> Int {
+    guard let predicate else { return base.count }
+    var count = 0
+    for row in 0 ..< base.count {
+      guard let value = base[row] else { continue }
+      if predicate(value) {
+        count += 1
+      }
+    }
+    return count
+  }
+}
+
+// MARK: - TableIterator entry points
+
+extension TableIterator {
+  /// Filters the rows by `predicate`, yielding a lazy `TypedFilter` stage.
+  @_lifetime(copy self)
+  public func `where`(_ predicate: @escaping (borrowing Row<Schema>) -> Bool)
+      -> TypedFilter<Schema> {
+    TypedFilter(self, predicate)
+  }
+
+  /// Maps each row through `transform`, yielding a lazy `TypedProjection`.
+  @_lifetime(copy self)
+  public func select<T>(_ transform: @escaping (borrowing Row<Schema>) -> T)
+      -> TypedProjection<Schema, T> {
+    TypedProjection(self, select: transform)
+  }
+
+  /// Maps the rows satisfying `predicate` through `transform`.
+  ///
+  /// This is the common-case entry point; `where(_:).select(_:)` reads better
+  /// when a query is built up incrementally.
+  @_lifetime(copy self)
+  public func select<T>(_ transform: @escaping (borrowing Row<Schema>) -> T,
+                        where predicate: @escaping (borrowing Row<Schema>)
+                            -> Bool)
+      -> TypedProjection<Schema, T> {
+    TypedProjection(self, where: predicate, select: transform)
+  }
+}

--- a/Sources/WinMD/UserStringsHeap.swift
+++ b/Sources/WinMD/UserStringsHeap.swift
@@ -3,13 +3,13 @@
 
 /// Convenience wrapper for the "User Strings" (`#US`) heap.
 ///
-/// Allows for easy access into the contents of the `#US` heap.  Each entry is
+/// Allows for easy access into the contents of the `#US` heap. Each entry is
 /// laid out exactly like a blob (ECMA-335 §II.24.2.4): a compressed unsigned
-/// integer length prefix followed by that many payload bytes.  For an entry of
+/// integer length prefix followed by that many payload bytes. For an entry of
 /// payload length `L`, the final payload byte is a terminal flag indicating
 /// whether any code unit has non-ASCII bits (ignored for the decoded value) and
 /// the preceding `L - 1` bytes are the string's UTF-16, little-endian code
-/// units.  A length of `0` denotes the empty string at offset `0`.
+/// units. A length of `0` denotes the empty string at offset `0`.
 public struct UserStringsHeap: ~Escapable {
   internal let bytes: RawSpan
 
@@ -26,7 +26,7 @@ public struct UserStringsHeap: ~Escapable {
     guard length > 1 else { return "" }
 
     // The final payload byte is the terminal flag; the preceding `length - 1`
-    // bytes are `(length - 1) / 2` UTF-16 little-endian code units.  `begin`
+    // bytes are `(length - 1) / 2` UTF-16 little-endian code units. `begin`
     // sits past a compressed prefix, so the code-unit range can start at an odd
     // byte offset; extract it as a single raw range and decode it through
     // unaligned, little-endian `UInt16` loads — without materialising the code

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -1,0 +1,543 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQL
+
+// MARK: - In-memory adapter
+
+/// A column's name and value kind.
+private struct Field: Sendable {
+  let name: String
+  let kind: ValueKind
+}
+
+/// An in-memory relation: a fixed schema plus rows of typed values.
+///
+/// The `sorted` flag marks a single integral column whose rows are stored in
+/// ascending order; `bound` reports a boundary for that column and `nil` for any
+/// other, so the engine exercises both the seek path and the scan path. Every
+/// relation also exposes a virtual `rowid` column — its 1-based row index — at
+/// the ordinal just past its real columns, computed by the `Row` rather than
+/// stored. This type knows nothing of WinMD — it is the proof the engine is
+/// generic.
+private struct Relation: Sendable {
+  let fields: Array<Field>
+  let records: Array<Array<Value>>
+  /// The ordinal of the sorted column, or `nil` if the relation is unsorted.
+  let sorted: Int?
+
+  init(_ fields: Array<Field>, _ records: Array<Array<Value>>,
+       sorted: Int? = nil) {
+    self.fields = fields
+    self.records = records
+    self.sorted = sorted
+  }
+}
+
+/// A `Catalog` over a dictionary of named relations.
+///
+/// The adapter is an escapable value, so it conforms to the `~Escapable`
+/// protocols by omitting `@_lifetime` on its own methods — a borrowed-storage
+/// source would instead annotate them. It is the proof the same protocols admit
+/// both a Span-backed source and an owned one.
+private struct Memory: Catalog {
+  let relations: Dictionary<String, Relation>
+
+  init(_ relations: Dictionary<String, Relation>) {
+    self.relations = relations
+  }
+
+  func table(named name: String) -> MemoryTable? {
+    guard let relation = relations[name] else { return nil }
+    return MemoryTable(relation)
+  }
+}
+
+/// A `Table` over one in-memory relation, with a virtual `rowid` column.
+private struct MemoryTable: Table {
+  let relation: Relation
+
+  init(_ relation: Relation) {
+    self.relation = relation
+  }
+
+  /// The real columns — `rowid` is virtual and excluded from the width, so a
+  /// `SELECT *` never yields it.
+  var width: Int { relation.fields.count }
+
+  /// One past the highest ordinal — the real width plus the lone virtual
+  /// `rowid` column at ordinal `width`.
+  var extent: Int { width + 1 }
+
+  func ordinal(of name: String) -> Int? {
+    // `rowid` is the virtual column at the ordinal just past the real ones.
+    if name == "rowid" { return width }
+    return relation.fields.firstIndex { $0.name == name }
+  }
+
+  func bound(_ column: Int, _ value: Int, strict: Bool) -> Int? {
+    // Only the relation's sorted column is seekable; anything else falls back
+    // to a scan.
+    guard relation.sorted == column else { return nil }
+
+    // Partition the ascending column: the first row whose cell is `>= value`
+    // (non-strict) or `> value` (strict).
+    var lower = 0
+    var upper = relation.records.count
+    while lower < upper {
+      let middle = lower + (upper - lower) / 2
+      guard case let .integer(cell) = relation.records[middle][column] else {
+        return nil
+      }
+      let before = strict ? cell <= value : cell < value
+      if before {
+        lower = middle + 1
+      } else {
+        upper = middle
+      }
+    }
+    return lower
+  }
+
+  func cursor() -> MemoryCursor {
+    MemoryCursor(relation)
+  }
+}
+
+/// An index-addressed cursor over a relation's rows.
+private struct MemoryCursor: Cursor {
+  let relation: Relation
+
+  init(_ relation: Relation) {
+    self.relation = relation
+  }
+
+  var count: Int { relation.records.count }
+
+  func row(_ index: Int) -> MemoryRow? {
+    guard index < relation.records.count else { return nil }
+    return MemoryRow(relation, index)
+  }
+}
+
+/// A positional view over one row's cells, real and virtual.
+///
+/// A real ordinal (`< width`) reads the stored cell; the virtual `rowid` ordinal
+/// (`== width`) computes the 1-based row index. The view is an escapable value —
+/// the source carries no borrowed storage — so it omits `@_lifetime`.
+private struct MemoryRow: Row {
+  let relation: Relation
+  let index: Int
+
+  init(_ relation: Relation, _ index: Int) {
+    self.relation = relation
+    self.index = index
+  }
+
+  subscript(_ column: Int) -> Value {
+    borrowing get {
+      if column == relation.fields.count { return .integer(index + 1) }
+      return relation.records[index][column]
+    }
+  }
+}
+
+// MARK: - Fixtures
+
+/// The single-relation catalog: a `People` relation sorted on its `Id` column.
+private func people() -> Memory {
+  let fields = [
+    Field(name: "Id", kind: .integer),
+    Field(name: "Name", kind: .text),
+    Field(name: "Age", kind: .integer),
+  ]
+  let records = [
+    [.integer(1), .text("Alice"), .integer(30)],
+    [.integer(2), .text("Bob"), .integer(25)],
+    [.integer(3), .text("Carol"), .integer(30)],
+    [.integer(4), .text("Dave"), .integer(40)],
+    [.integer(5), .text("Eve"), .integer(25)],
+  ] as Array<Array<Value>>
+  return Memory(["People": Relation(fields, records, sorted: 0)])
+}
+
+/// A wide catalog: a `Wide` relation of ten columns, to prove a query that
+/// references only a few of them still works (projection pushdown).
+private func wide() -> Memory {
+  let fields = (0 ..< 10).map { Field(name: "C\($0)", kind: .integer) }
+  let records = (0 ..< 4).map { row in
+    (0 ..< 10).map { Value.integer(row * 10 + $0) }
+  }
+  return Memory(["Wide": Relation(fields, records, sorted: 0)])
+}
+
+/// The join catalog: a `Parent` relation sorted on `Id`, an unsorted twin
+/// `ParentUnsorted` (same rows, no seekable column), and a `Child` relation
+/// whose `Pid` is a foreign key to a parent `Id`. The `Ordered` relation has no
+/// stored key — a join on it keys off its virtual `rowid`.
+private func family() -> Memory {
+  let parent = [
+    Field(name: "Id", kind: .integer),
+    Field(name: "Name", kind: .text),
+  ]
+  let parents = [
+    [.integer(1), .text("Ada")],
+    [.integer(2), .text("Bee")],
+    [.integer(3), .text("Cid")],
+  ] as Array<Array<Value>>
+
+  let child = [
+    Field(name: "Pid", kind: .integer),
+    Field(name: "Name", kind: .text),
+  ]
+  let children = [
+    [.integer(1), .text("Ann")],
+    [.integer(1), .text("Amy")],
+    [.integer(2), .text("Bob")],
+    [.integer(9), .text("Orphan")],
+  ] as Array<Array<Value>>
+
+  // A keyless relation: its identity is its 1-based row position (`rowid`).
+  let ordered = [
+    Field(name: "Label", kind: .text),
+  ]
+  let labels = [
+    [.text("first")],
+    [.text("second")],
+    [.text("third")],
+  ] as Array<Array<Value>>
+
+  return Memory([
+    "Parent": Relation(parent, parents, sorted: 0),
+    "ParentUnsorted": Relation(parent, parents),
+    "Child": Relation(child, children),
+    "Ordered": Relation(ordered, labels),
+  ])
+}
+
+/// Parses `text` to a `SELECT`, failing on any other statement.
+private func parse(_ text: String) throws -> Select {
+  guard case let .select(select) = try Statement(parsing: text) else {
+    Issue.record("expected a SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return select
+}
+
+/// Runs `text` against the single-relation `People` catalog.
+private func run(_ text: String) throws -> Array<Array<Value>> {
+  try Engine.run(parse(text), people())
+}
+
+/// Runs `text` against the wide catalog.
+private func wideRun(_ text: String) throws -> Array<Array<Value>> {
+  try Engine.run(parse(text), wide())
+}
+
+/// Runs `text` against the join `family` catalog.
+private func join(_ text: String) throws -> Array<Array<Value>> {
+  try Engine.run(parse(text), family())
+}
+
+// MARK: - Single-relation tests
+
+struct EngineProjectionTests {
+  @Test("SELECT * yields every real column and excludes the virtual rowid")
+  func star() throws {
+    let rows = try run("SELECT * FROM People WHERE Id = 1")
+    // Three real columns; `rowid` is virtual and never in `*`.
+    #expect(rows == [[.integer(1), .text("Alice"), .integer(30)]])
+  }
+
+  @Test("SELECT names yields the named columns in order")
+  func named() throws {
+    let rows = try run("SELECT Name, Id FROM People WHERE Id = 2")
+    #expect(rows == [[.text("Bob"), .integer(2)]])
+  }
+
+  @Test("a named projection may include the virtual rowid column")
+  func virtual() throws {
+    let rows = try run("SELECT rowid, Name FROM People WHERE Name = 'Carol'")
+    // Carol is the third row; her 1-based `rowid` is 3.
+    #expect(rows == [[.integer(3), .text("Carol")]])
+  }
+
+  @Test("an unknown column is reported")
+  func unknown() throws {
+    #expect(throws: SQLError.column("Missing")) {
+      try run("SELECT Missing FROM People")
+    }
+  }
+
+  @Test("an unknown relation is reported")
+  func relation() throws {
+    #expect(throws: SQLError.relation("Absent")) {
+      try run("SELECT * FROM Absent")
+    }
+  }
+}
+
+struct EngineFilterTests {
+  @Test("equality on a text column")
+  func text() throws {
+    let rows = try run("SELECT Id FROM People WHERE Name = 'Carol'")
+    #expect(rows == [[.integer(3)]])
+  }
+
+  @Test("a range on the sorted column")
+  func range() throws {
+    let rows = try run("SELECT Id FROM People WHERE Id >= 4")
+    #expect(rows == [[.integer(4)], [.integer(5)]])
+  }
+
+  @Test("an AND of a seekable conjunct and a residual")
+  func conjunction() throws {
+    let rows = try run("SELECT Name FROM People WHERE Id > 1 AND Age = 30")
+    #expect(rows == [[.text("Carol")]])
+  }
+
+  @Test("an OR scans and admits either side")
+  func disjunction() throws {
+    let rows =
+        try run("SELECT Id FROM People WHERE Id = 1 OR Name = 'Eve'")
+    #expect(rows == [[.integer(1)], [.integer(5)]])
+  }
+
+  @Test("a NOT scans and negates")
+  func negation() throws {
+    let rows = try run("SELECT Id FROM People WHERE NOT Age = 30")
+    #expect(rows == [[.integer(2)], [.integer(4)], [.integer(5)]])
+  }
+
+  @Test("a filter on the virtual rowid column")
+  func virtual() throws {
+    let rows = try run("SELECT Name FROM People WHERE rowid = 4")
+    #expect(rows == [[.text("Dave")]])
+  }
+}
+
+struct EngineOrderTests {
+  @Test("ORDER BY ascending on an integer column")
+  func ascending() throws {
+    let rows = try run("SELECT Id FROM People ORDER BY Age ASC")
+    // Ages: Bob 25, Eve 25, Alice 30, Carol 30, Dave 40 — a stable sort keeps
+    // the scan order within an equal-key group.
+    #expect(rows == [[.integer(2)], [.integer(5)], [.integer(1)],
+                     [.integer(3)], [.integer(4)]])
+  }
+
+  @Test("ORDER BY descending on a text column")
+  func descending() throws {
+    let rows = try run("SELECT Name FROM People ORDER BY Name DESC")
+    #expect(rows == [[.text("Eve")], [.text("Dave")], [.text("Carol")],
+                     [.text("Bob")], [.text("Alice")]])
+  }
+}
+
+struct EngineProjectionPushdownTests {
+  @Test("a query referencing few columns of a wide relation works")
+  func few() throws {
+    // The relation has ten columns; the query reads only C0 (filter, project),
+    // C5 (project), and C8 (order). The leaf materialises just those, but the
+    // result is exactly as if every column were copied.
+    let rows = try wideRun("""
+        SELECT C5, C0 FROM Wide WHERE C0 >= 10 ORDER BY C8 DESC
+        """)
+    #expect(rows == [
+      [.integer(35), .integer(30)],
+      [.integer(25), .integer(20)],
+      [.integer(15), .integer(10)],
+    ])
+  }
+}
+
+struct EngineSeekTests {
+  @Test("the seek path and the scan path return identical results")
+  func equivalence() throws {
+    // `Id >= 2` seeks the sorted column; the same selection by `Name` (which
+    // `bound` reports unseekable) scans. Both must yield the same rows.
+    let seek = try run("SELECT Id FROM People WHERE Id >= 2 AND Id <= 4")
+    #expect(seek == [[.integer(2)], [.integer(3)], [.integer(4)]])
+
+    let scan =
+        try run("SELECT Id FROM People WHERE Name >= 'Bob' AND Name <= 'Dave'")
+    #expect(scan == seek)
+  }
+}
+
+struct EngineQualifierTests {
+  @Test("a qualifier matching the alias resolves the column")
+  func alias() throws {
+    let rows = try run("SELECT p.Name FROM People AS p WHERE Id = 1")
+    #expect(rows == [[.text("Alice")]])
+  }
+
+  @Test("a qualifier matching the table name resolves the column")
+  func name() throws {
+    let rows = try run("SELECT People.Name FROM People WHERE Id = 1")
+    #expect(rows == [[.text("Alice")]])
+  }
+
+  @Test("a qualifier naming neither the alias nor the table is reported")
+  func foreign() throws {
+    // `x` names neither the alias `p` nor the table `People`; a single-relation
+    // query rejects it rather than dropping the qualifier and binding `Name`.
+    #expect(throws: SQLError.column("Name")) {
+      try run("SELECT x.Name FROM People AS p")
+    }
+  }
+
+  @Test("a qualifier naming a different table is reported")
+  func mismatch() throws {
+    // The reviewer's case: `Child.Name` against `FROM Parent` must not resolve
+    // to `Parent`'s `Name`; the qualifier names a relation not in scope.
+    #expect(throws: SQLError.column("Name")) {
+      try join("SELECT Child.Name FROM Parent")
+    }
+  }
+}
+
+// MARK: - Join tests
+
+struct EngineJoinTests {
+  @Test("a join on a foreign key pairs each child with its parent")
+  func star() throws {
+    let rows = try join("""
+        SELECT * FROM Parent JOIN Child ON Child.Pid = Parent.Id
+        """)
+    // The orphan child (Pid 9) and the childless parent (Cid) drop out.
+    #expect(rows == [
+      [.integer(1), .text("Ada"), .integer(1), .text("Ann")],
+      [.integer(1), .text("Ada"), .integer(1), .text("Amy")],
+      [.integer(2), .text("Bee"), .integer(2), .text("Bob")],
+    ])
+  }
+
+  @Test("a qualified projection selects across both relations")
+  func qualified() throws {
+    let rows = try join("""
+        SELECT Parent.Name, Child.Name FROM Parent
+          JOIN Child ON Child.Pid = Parent.Id
+        """)
+    #expect(rows == [
+      [.text("Ada"), .text("Ann")],
+      [.text("Ada"), .text("Amy")],
+      [.text("Bee"), .text("Bob")],
+    ])
+  }
+
+  @Test("a join keys off the inner relation's virtual rowid")
+  func virtual() throws {
+    // `Ordered` has no stored key; its identity is its 1-based `rowid`. The
+    // child's `Pid` joins to that virtual column.
+    let rows = try join("""
+        SELECT Ordered.Label, Child.Name FROM Child
+          JOIN Ordered ON Ordered.rowid = Child.Pid
+        """)
+    // Pid 1 → "first" (Ann, Amy), Pid 2 → "second" (Bob); Pid 9 has no row.
+    #expect(rows == [
+      [.text("first"), .text("Ann")],
+      [.text("first"), .text("Amy")],
+      [.text("second"), .text("Bob")],
+    ])
+  }
+
+  @Test("a join keyed off the OUTER relation's virtual rowid does not collide")
+  func outerVirtual() throws {
+    // The combined ordinal space lays the inner relation past the outer's
+    // `extent` — its real width plus the virtual columns it exposes — so an
+    // outer virtual column never shares an ordinal with an inner real one. Here
+    // `Ordered` is the OUTER relation, and the join keys off its virtual `rowid`
+    // at ordinal `width`; the inner `Child.Pid` is a real column at ordinal 0.
+    // Were the inner laid at the outer's `width` (or at a base collapsed to 0
+    // by a `1 << 32` reserve on a 32-bit host), `Child.Pid` would land on the
+    // outer `rowid`'s ordinal and the join's cells would corrupt one another.
+    let rows = try join("""
+        SELECT Ordered.rowid, Child.Name FROM Ordered
+          JOIN Child ON Child.Pid = Ordered.rowid
+        """)
+    // rowid 1 → Ann, Amy; rowid 2 → Bob; rowid 3 has no child; Pid 9 no parent.
+    #expect(rows == [
+      [.integer(1), .text("Ann")],
+      [.integer(1), .text("Amy")],
+      [.integer(2), .text("Bob")],
+    ])
+  }
+
+  @Test("a WHERE spans both relations")
+  func predicate() throws {
+    let rows = try join("""
+        SELECT Child.Name FROM Parent JOIN Child ON Child.Pid = Parent.Id
+          WHERE Parent.Name = 'Ada' AND Child.Name = 'Amy'
+        """)
+    #expect(rows == [[.text("Amy")]])
+  }
+
+  @Test("ORDER BY orders across the join")
+  func order() throws {
+    let rows = try join("""
+        SELECT Child.Name FROM Parent JOIN Child ON Child.Pid = Parent.Id
+          ORDER BY Child.Name ASC
+        """)
+    #expect(rows == [[.text("Amy")], [.text("Ann")], [.text("Bob")]])
+  }
+
+  @Test("an unqualified name in both relations is ambiguous")
+  func ambiguous() throws {
+    #expect(throws: SQLError.ambiguous("Name")) {
+      try join("SELECT Name FROM Parent JOIN Child ON Child.Pid = Parent.Id")
+    }
+  }
+
+  @Test("a self-join's shared table name makes a qualified name ambiguous")
+  func selfJoin() throws {
+    #expect(throws: SQLError.ambiguous("Id")) {
+      try join("""
+          SELECT Parent.Name FROM Parent JOIN Parent ON Parent.Id = Parent.Id
+          """)
+    }
+  }
+
+  @Test("a duplicated alias makes a shared qualified column ambiguous")
+  func duplicate() throws {
+    // `x.Id`/`x.Pid` resolve by column (one side each); `x.Name` is on both,
+    // so the shared alias is ambiguous rather than binding silently to outer.
+    #expect(throws: SQLError.ambiguous("Name")) {
+      try join("""
+          SELECT x.Name FROM Parent AS x JOIN Child AS x ON x.Id = x.Pid
+          """)
+    }
+  }
+
+  @Test("a parent with no matching child contributes no rows")
+  func empty() throws {
+    let rows = try join("""
+        SELECT Parent.Name, Child.Name FROM Parent
+          JOIN Child ON Child.Pid = Parent.Id
+          WHERE Parent.Name = 'Cid'
+        """)
+    #expect(rows.isEmpty)
+  }
+
+  @Test("the seek probe and the scan probe return identical results")
+  func equivalence() throws {
+    // The join seeks `Child.Pid = Parent.Id` when the inner relation is
+    // seekable on the key, and scans it otherwise. Both inner orderings — the
+    // sorted `Parent` and its unsorted twin used as the inner — must agree.
+    let seek = try join("""
+        SELECT Parent.Name, Child.Name FROM Child
+          JOIN Parent ON Parent.Id = Child.Pid ORDER BY Child.Name ASC
+        """)
+    let scan = try join("""
+        SELECT P.Name, Child.Name FROM Child
+          JOIN ParentUnsorted AS P ON P.Id = Child.Pid ORDER BY Child.Name ASC
+        """)
+    #expect(seek == scan)
+    #expect(seek == [
+      [.text("Ada"), .text("Amy")],
+      [.text("Ada"), .text("Ann")],
+      [.text("Bee"), .text("Bob")],
+    ])
+  }
+}

--- a/Tests/SQLTests/LexerTests.swift
+++ b/Tests/SQLTests/LexerTests.swift
@@ -1,0 +1,132 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQL
+
+/// Drains the streaming lexer over `text` into an array of tokens.
+private func tokens(_ text: String) throws -> Array<Token> {
+  var lexer = Lexer(text.utf8Span.span)
+  var tokens = Array<Token>()
+  while let token = try lexer.next() {
+    tokens.append(token)
+  }
+  return tokens
+}
+
+/// The kinds of the tokens the lexer yields for `text`.
+private func lex(_ text: String) throws -> Array<Token.Kind> {
+  try tokens(text).map(\.kind)
+}
+
+struct LexerTests {
+  @Test("lexes every keyword")
+  func keywords() throws {
+    #expect(try lex("SELECT FROM WHERE ORDER BY ASC DESC AND OR NOT")
+                == [.select, .from, .where, .order, .by, .asc, .desc,
+                    .and, .or, .not])
+  }
+
+  @Test("lexes keywords case-insensitively")
+  func keywordsCaseInsensitive() throws {
+    #expect(try lex("select Order by") == [.select, .order, .by])
+  }
+
+  @Test("lexes the join keywords")
+  func joinKeywords() throws {
+    #expect(try lex("JOIN ON AS") == [.join, .on, .as])
+  }
+
+  @Test("lexes the join keywords case-insensitively")
+  func joinKeywordsCaseInsensitive() throws {
+    #expect(try lex("join on As") == [.join, .on, .as])
+  }
+
+  @Test("lexes the comparison operators")
+  func operators() throws {
+    #expect(try lex("= <> < > <= >=")
+                == [.equal, .unequal, .lt, .gt, .leq, .geq])
+  }
+
+  @Test("lexes punctuation tokens")
+  func punctuation() throws {
+    #expect(try lex("* , ( )")
+                == [.star, .comma, .lparen, .rparen])
+  }
+
+  @Test("lexes a dotted identifier as one token")
+  func identifierWithDot() throws {
+    #expect(try lex("TypeDef.TypeName") == [.identifier("TypeDef.TypeName")])
+  }
+
+  @Test("lexes integer literals")
+  func integerLiteral() throws {
+    #expect(try lex("0 42 1024")
+                == [.integer(0), .integer(42), .integer(1024)])
+  }
+
+  @Test("lexes a quoted string literal")
+  func stringLiteral() throws {
+    #expect(try lex("'Windows.Win32.Foundation'")
+                == [.string("Windows.Win32.Foundation")])
+  }
+
+  @Test("unescapes a doubled quote in a string")
+  func escapedQuoteInString() throws {
+    #expect(try lex("'O''Brien'") == [.string("O'Brien")])
+  }
+
+  @Test("lexes an empty string literal")
+  func emptyString() throws {
+    #expect(try lex("''") == [.string("")])
+  }
+
+  @Test("lexes tokens with no separating whitespace")
+  func adjacentOperators() throws {
+    // No whitespace required between an identifier and an operator.
+    #expect(try lex("a<=1")
+                == [.identifier("a"), .leq, .integer(1)])
+  }
+
+  @Test("records each token's byte offset")
+  func position() throws {
+    #expect(try tokens("SELECT *").map(\.location.offset) == [0, 7])
+  }
+
+  @Test("tracks line and column across a newline")
+  func location() throws {
+    // The lexer tracks 1-based line and column, resetting the column on each
+    // newline.
+    let locations = try tokens("SELECT *\nFROM T").map(\.location)
+    #expect(locations.map(\.line) == [1, 1, 2, 2])
+    #expect(locations.map(\.column) == [1, 8, 1, 6])
+  }
+
+  @Test("yields one token per next() and nil at end")
+  func streaming() throws {
+    // The lexer yields one token per `next()` call and signals end of input
+    // with a trailing `nil`, without ever materialising a token array.
+    let text = "SELECT *"
+    var lexer = Lexer(text.utf8Span.span)
+    #expect(try lexer.next()
+                == Token(kind: .select,
+                         location: SourceLocation(line: 1, column: 1,
+                                                  offset: 0)))
+    #expect(try lexer.next()
+                == Token(kind: .star,
+                         location: SourceLocation(line: 1, column: 8,
+                                                  offset: 7)))
+    #expect(try lexer.next() == nil)
+    #expect(try lexer.next() == nil)
+  }
+
+  @Test("rejects an unexpected character")
+  func unexpectedCharacter() {
+    #expect(throws: SQLError.self) { _ = try lex("SELECT @ FROM T") }
+  }
+
+  @Test("rejects an unterminated string")
+  func unterminatedString() {
+    #expect(throws: SQLError.self) { _ = try lex("'oops") }
+  }
+}

--- a/Tests/SQLTests/ParserTests.swift
+++ b/Tests/SQLTests/ParserTests.swift
@@ -1,0 +1,349 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQL
+
+/// Parses `text` and returns its `Select`, failing the test on any other shape.
+private func parseSelect(_ text: String) throws -> Select {
+  guard case let .select(select) = try Statement(parsing: text) else {
+    Issue.record("expected a SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return select
+}
+
+struct ProjectionTests {
+  @Test("parses a SELECT * projection")
+  func star() throws {
+    let select = try parseSelect("SELECT * FROM TypeDef")
+    #expect(select.projection == .all)
+    #expect(select.table == "TypeDef")
+    #expect(select.predicate == nil)
+    #expect(select.order == nil)
+  }
+
+  @Test("parses a single-column projection")
+  func singleColumn() throws {
+    let select = try parseSelect("SELECT TypeName FROM TypeDef")
+    #expect(select.projection == .columns(["TypeName"]))
+  }
+
+  @Test("parses a comma-separated column list")
+  func columnList() throws {
+    let select =
+        try parseSelect("SELECT TypeName, TypeNamespace, Flags FROM TypeDef")
+    #expect(select.projection
+                == .columns(["TypeName", "TypeNamespace", "Flags"]))
+  }
+
+  @Test("parses a dotted column identifier")
+  func dottedColumn() throws {
+    // Simple column identifiers may carry a qualifying dot; metadata names with
+    // dots appear only as string literals.
+    let select = try parseSelect("SELECT TypeDef.TypeName FROM TypeDef")
+    #expect(select.projection == .columns(["TypeDef.TypeName"]))
+  }
+}
+
+struct KeywordTests {
+  @Test("parses lowercase keywords")
+  func caseInsensitive() throws {
+    let select =
+        try parseSelect("select TypeName from TypeDef where Flags = 1")
+    #expect(select.projection == .columns(["TypeName"]))
+    #expect(select.table == "TypeDef")
+    #expect(select.predicate == .comparison(column: "Flags", op: .equal,
+                                            value: .integer(1)))
+  }
+
+  @Test("parses mixed-case keywords")
+  func mixedCase() throws {
+    let select = try parseSelect("SeLeCt * FrOm TypeDef OrDeR By TypeName DeSc")
+    #expect(select.order == Order(column: "TypeName", ascending: false))
+  }
+}
+
+struct PredicateTests {
+  @Test("parses each comparison operator")
+  func operators() throws {
+    let cases: Array<(String, Comparison)> = [
+      ("=", .equal),
+      ("<>", .unequal),
+      ("<", .lt),
+      (">", .gt),
+      ("<=", .leq),
+      (">=", .geq),
+    ]
+    for (text, op) in cases {
+      let select =
+          try parseSelect("SELECT * FROM T WHERE Flags \(text) 1")
+      #expect(select.predicate
+                  == .comparison(column: "Flags", op: op, value: .integer(1)))
+    }
+  }
+
+  @Test("parses a string-literal operand")
+  func stringLiteral() throws {
+    let select =
+        try parseSelect(
+            "SELECT * FROM TypeDef WHERE TypeNamespace = 'Windows.Win32.Foundation'")
+    #expect(select.predicate
+                == .comparison(column: "TypeNamespace", op: .equal,
+                               value: .string("Windows.Win32.Foundation")))
+  }
+
+  @Test("parses a string with an escaped quote")
+  func escapedQuote() throws {
+    let select = try parseSelect("SELECT * FROM T WHERE name = 'O''Brien'")
+    #expect(select.predicate
+                == .comparison(column: "name", op: .equal,
+                               value: .string("O'Brien")))
+  }
+
+  @Test("binds AND tighter than OR")
+  func andBindsTighterThanOr() throws {
+    // a = 1 OR b = 2 AND c = 3  ==>  a OR (b AND c)
+    let select =
+        try parseSelect("SELECT * FROM T WHERE a = 1 OR b = 2 AND c = 3")
+    let a = Predicate.comparison(column: "a", op: .equal, value: .integer(1))
+    let b = Predicate.comparison(column: "b", op: .equal, value: .integer(2))
+    let c = Predicate.comparison(column: "c", op: .equal, value: .integer(3))
+    #expect(select.predicate == .or(a, .and(b, c)))
+  }
+
+  @Test("binds NOT tighter than AND")
+  func notBindsTighterThanAnd() throws {
+    // NOT a = 1 AND b = 2  ==>  (NOT a) AND b
+    let select =
+        try parseSelect("SELECT * FROM T WHERE NOT a = 1 AND b = 2")
+    let a = Predicate.comparison(column: "a", op: .equal, value: .integer(1))
+    let b = Predicate.comparison(column: "b", op: .equal, value: .integer(2))
+    #expect(select.predicate == .and(.not(a), b))
+  }
+
+  @Test("parentheses override operator precedence")
+  func parenthesesOverridePrecedence() throws {
+    // (a = 1 OR b = 2) AND c = 3
+    let select =
+        try parseSelect("SELECT * FROM T WHERE (a = 1 OR b = 2) AND c = 3")
+    let a = Predicate.comparison(column: "a", op: .equal, value: .integer(1))
+    let b = Predicate.comparison(column: "b", op: .equal, value: .integer(2))
+    let c = Predicate.comparison(column: "c", op: .equal, value: .integer(3))
+    #expect(select.predicate == .and(.or(a, b), c))
+  }
+
+  @Test("parses OR left-associatively")
+  func leftAssociativeOr() throws {
+    // a = 1 OR b = 2 OR c = 3  ==>  ((a OR b) OR c)
+    let select =
+        try parseSelect("SELECT * FROM T WHERE a = 1 OR b = 2 OR c = 3")
+    let a = Predicate.comparison(column: "a", op: .equal, value: .integer(1))
+    let b = Predicate.comparison(column: "b", op: .equal, value: .integer(2))
+    let c = Predicate.comparison(column: "c", op: .equal, value: .integer(3))
+    #expect(select.predicate == .or(.or(a, b), c))
+  }
+}
+
+struct OrderTests {
+  @Test("defaults ORDER BY to ascending")
+  func defaultAscending() throws {
+    let select = try parseSelect("SELECT * FROM T ORDER BY TypeName")
+    #expect(select.order == Order(column: "TypeName", ascending: true))
+  }
+
+  @Test("parses an explicit ASC order")
+  func explicitAscending() throws {
+    let select = try parseSelect("SELECT * FROM T ORDER BY TypeName ASC")
+    #expect(select.order == Order(column: "TypeName", ascending: true))
+  }
+
+  @Test("parses a DESC order")
+  func descending() throws {
+    let select = try parseSelect("SELECT * FROM T ORDER BY TypeName DESC")
+    #expect(select.order == Order(column: "TypeName", ascending: false))
+  }
+}
+
+struct CompositeTests {
+  @Test("parses a full SELECT/WHERE/ORDER BY query")
+  func fullQuery() throws {
+    let select =
+        try parseSelect("""
+            SELECT TypeName, TypeNamespace FROM TypeDef
+              WHERE TypeNamespace = 'Windows.Win32.Foundation' AND Flags >= 1
+              ORDER BY TypeName DESC
+            """)
+    #expect(select.projection == .columns(["TypeName", "TypeNamespace"]))
+    #expect(select.table == "TypeDef")
+    let namespace =
+        Predicate.comparison(column: "TypeNamespace", op: .equal,
+                             value: .string("Windows.Win32.Foundation"))
+    let flags = Predicate.comparison(column: "Flags", op: .geq,
+                                     value: .integer(1))
+    #expect(select.predicate == .and(namespace, flags))
+    #expect(select.order == Order(column: "TypeName", ascending: false))
+  }
+}
+
+struct ColumnTests {
+  @Test("splits a dotted column into qualifier and name")
+  func qualified() {
+    let column = Column("t.Name")
+    #expect(column.qualifier == "t")
+    #expect(column.name == "Name")
+  }
+
+  @Test("leaves an undotted column unqualified")
+  func unqualified() {
+    let column = Column("Name")
+    #expect(column.qualifier == nil)
+    #expect(column.name == "Name")
+  }
+
+  @Test("splits on the first dot only")
+  func firstDot() {
+    let column = Column("t.a.b")
+    #expect(column.qualifier == "t")
+    #expect(column.name == "a.b")
+  }
+}
+
+struct RelationTests {
+  @Test("parses a bare FROM relation with no alias")
+  func bare() throws {
+    let select = try parseSelect("SELECT * FROM TypeDef")
+    #expect(select.from == Relation(name: "TypeDef"))
+    #expect(select.join == nil)
+  }
+
+  @Test("parses an AS alias on the FROM relation")
+  func alias() throws {
+    let select = try parseSelect("SELECT * FROM TypeDef AS t")
+    #expect(select.from == Relation(name: "TypeDef", alias: "t"))
+  }
+
+  @Test("parses an implicit (AS-less) alias")
+  func implicitAlias() throws {
+    let select = try parseSelect("SELECT * FROM TypeDef t")
+    #expect(select.from == Relation(name: "TypeDef", alias: "t"))
+  }
+
+  @Test("does not mistake a following keyword for an alias")
+  func keywordNotAlias() throws {
+    let select = try parseSelect("SELECT * FROM TypeDef WHERE Flags = 1")
+    #expect(select.from == Relation(name: "TypeDef"))
+  }
+}
+
+struct JoinTests {
+  @Test("parses a list-shape join with aliases")
+  func listJoin() throws {
+    let select = try parseSelect("""
+        SELECT m.Name FROM TypeDef AS t
+          JOIN MethodDef AS m ON m.parent = t.rowid
+          WHERE t.TypeName = 'IUnknown'
+        """)
+    #expect(select.from == Relation(name: "TypeDef", alias: "t"))
+    #expect(select.join
+                == Join(relation: Relation(name: "MethodDef", alias: "m"),
+                        left: Column("m.parent"), right: Column("t.rowid")))
+    #expect(select.projection == .columns([Column("m.Name")]))
+    #expect(select.predicate == .comparison(column: Column("t.TypeName"),
+                                            op: .equal,
+                                            value: .string("IUnknown")))
+  }
+
+  @Test("parses a forward-key join")
+  func forwardJoin() throws {
+    let select = try parseSelect("""
+        SELECT r.TypeName FROM TypeDef AS t
+          JOIN TypeRef AS r ON t.Extends = r.rowid
+        """)
+    #expect(select.join
+                == Join(relation: Relation(name: "TypeRef", alias: "r"),
+                        left: Column("t.Extends"), right: Column("r.rowid")))
+  }
+
+  @Test("parses a join without aliases")
+  func unaliasedJoin() throws {
+    let select = try parseSelect("""
+        SELECT Name FROM MethodDef
+          JOIN Param ON Param.parent = MethodDef.rowid
+        """)
+    #expect(select.from == Relation(name: "MethodDef"))
+    #expect(select.join
+                == Join(relation: Relation(name: "Param"),
+                        left: Column("Param.parent"),
+                        right: Column("MethodDef.rowid")))
+  }
+
+  @Test("rejects a join missing ON")
+  func missingOn() {
+    #expect(throws: SQLError.self) {
+      _ = try Statement(parsing: "SELECT * FROM A JOIN B b")
+    }
+  }
+
+  @Test("rejects a join whose ON is not an equality")
+  func nonEqualityOn() {
+    #expect(throws: SQLError.self) {
+      _ = try Statement(parsing: "SELECT * FROM A JOIN B ON a.x < b.rowid")
+    }
+  }
+}
+
+struct ErrorTests {
+  @Test("rejects a query missing FROM")
+  func missingFrom() {
+    #expect(throws: SQLError.self) {
+      _ = try Statement(parsing: "SELECT TypeName TypeDef")
+    }
+  }
+
+  @Test("rejects an invalid operator")
+  func badOperator() {
+    #expect(throws: SQLError.self) {
+      _ = try Statement(parsing: "SELECT * FROM T WHERE a ! 1")
+    }
+  }
+
+  @Test("rejects an unterminated string")
+  func unterminatedString() {
+    #expect(throws: SQLError.self) {
+      _ = try Statement(parsing: "SELECT * FROM T WHERE a = 'unterminated")
+    }
+  }
+
+  @Test("rejects trailing tokens")
+  func trailingTokens() {
+    // A bare identifier after the relation is now an implicit alias, so
+    // trailing garbage must come after a clause that admits no alias — here a
+    // second identifier past the relation's (implicit) alias.
+    #expect(throws: SQLError.self) {
+      _ = try Statement(parsing: "SELECT * FROM T t garbage")
+    }
+  }
+
+  @Test("rejects an empty projection")
+  func emptyProjection() {
+    #expect(throws: SQLError.self) {
+      _ = try Statement(parsing: "SELECT FROM T")
+    }
+  }
+
+  @Test("rejects input ending after the projection")
+  func unexpectedEnd() {
+    #expect(throws: SQLError.self) {
+      _ = try Statement(parsing: "SELECT *")
+    }
+  }
+
+  @Test("rejects an identifier as a comparison operand")
+  func literalRequired() {
+    // A comparison's right operand must be a literal, not an identifier.
+    #expect(throws: SQLError.self) {
+      _ = try Statement(parsing: "SELECT * FROM T WHERE a = b")
+    }
+  }
+}

--- a/Tests/WinMDTests/AttributeTests.swift
+++ b/Tests/WinMDTests/AttributeTests.swift
@@ -1,0 +1,123 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+import struct Foundation.UUID
+
+@testable import WinMD
+
+// ECMA-335 §II.23.3 custom-attribute value decoding. The fixtures are hand-built
+// `Value` blobs — the raw bytes a `GuidAttribute`'s `#Blob` carries (no heap
+// length prefix) — decoded directly through `AttributeDecoder`: the `0x0001`
+// prolog then the GUID as `u32, u16, u16, u8×8`.
+struct AttributeTests {
+  // The `IUnknown` IID `00000000-0000-0000-C000-000000000046`, the canonical
+  // root-interface value, serialised as the constructor lays it out.
+  private let unknown: Array<UInt8> = [
+    0x01, 0x00,                                      // prolog
+    0x00, 0x00, 0x00, 0x00,                          // data1 (u32, LE)
+    0x00, 0x00,                                      // data2 (u16, LE)
+    0x00, 0x00,                                      // data3 (u16, LE)
+    0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46,  // data4 (8 bytes)
+    0x00, 0x00,                                      // NumNamed (no named args)
+  ]
+
+  @Test("decodes IUnknown's IID")
+  func iunknown() throws {
+    var bytes = unknown
+    var decoder = AttributeDecoder(bytes.span.bytes)
+    let guid = try decoder.guid()
+    #expect("\(guid)" == "00000000-0000-0000-C000-000000000046")
+  }
+
+  @Test("decodes a fully-populated GUID, fields little-endian")
+  func populated() throws {
+    // The well-known `ISequentialStream` IID exercises every field: data1/2/3
+    // are little-endian, the data4 tail is in order.
+    var bytes: Array<UInt8> = [
+      0x01, 0x00,
+      0x30, 0x3a, 0x73, 0x0c,                          // data1 -> 0c733a30
+      0x1c, 0x2a,                                      // data2 -> 2a1c
+      0xce, 0x11,                                      // data3 -> 11ce
+      0xad, 0xe5, 0x00, 0xaa, 0x00, 0x44, 0x77, 0x3d,  // data4
+      0x00, 0x00,                                      // NumNamed (no named args)
+    ]
+    var decoder = AttributeDecoder(bytes.span.bytes)
+    let guid = try decoder.guid()
+    #expect("\(guid)" == "0C733A30-2A1C-11CE-ADE5-00AA0044773D")
+  }
+
+  @Test("renders the canonical uppercase, zero-padded spelling")
+  func description() {
+    let guid = UUID(uuid: (0x00, 0x00, 0x00, 0x01, 0x00, 0x02, 0x00, 0x03,
+                           0x00, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a))
+    #expect("\(guid)" == "00000001-0002-0003-0004-05060708090A")
+  }
+
+  @Test("rejects a blob without the 0x0001 prolog")
+  func badProlog() {
+    var bytes: Array<UInt8> = [
+      0x00, 0x00,                                      // wrong prolog
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46,
+    ]
+    var decoder = AttributeDecoder(bytes.span.bytes)
+    #expect(throws: WinMDError.BadImageFormat) {
+      _ = try decoder.guid()
+    }
+  }
+
+  @Test("rejects a blob too short for the GUID")
+  func truncated() {
+    // The prolog and data1, then the blob ends before data2/data3/data4.
+    var bytes: Array<UInt8> = [0x01, 0x00, 0x00, 0x00, 0x00, 0x00]
+    var decoder = AttributeDecoder(bytes.span.bytes)
+    #expect(throws: WinMDError.BadImageFormat) {
+      _ = try decoder.guid()
+    }
+  }
+
+  @Test("rejects an empty blob")
+  func empty() {
+    var bytes = Array<UInt8>()
+    var decoder = AttributeDecoder(bytes.span.bytes)
+    #expect(throws: WinMDError.BadImageFormat) {
+      _ = try decoder.guid()
+    }
+  }
+
+  @Test("rejects a blob missing the NumNamed count")
+  func missingNumNamed() {
+    // The prolog and a full GUID, but the blob ends before the mandatory
+    // 2-byte `NumNamed` count (ECMA-335 §II.23.3).
+    var bytes: Array<UInt8> = [
+      0x01, 0x00,
+      0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00,
+      0x00, 0x00,
+      0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46,
+    ]
+    var decoder = AttributeDecoder(bytes.span.bytes)
+    #expect(throws: WinMDError.BadImageFormat) {
+      _ = try decoder.guid()
+    }
+  }
+
+  @Test("rejects a blob with a non-zero NumNamed count")
+  func namedArguments() {
+    // A `[Guid]` has no named arguments, so `NumNamed` must be 0; a non-zero
+    // count is malformed for this attribute (ECMA-335 §II.23.3).
+    var bytes: Array<UInt8> = [
+      0x01, 0x00,
+      0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00,
+      0x00, 0x00,
+      0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46,
+      0x01, 0x00,                                      // NumNamed = 1
+    ]
+    var decoder = AttributeDecoder(bytes.span.bytes)
+    #expect(throws: WinMDError.BadImageFormat) {
+      _ = try decoder.guid()
+    }
+  }
+}

--- a/Tests/WinMDTests/BlobsHeapTests.swift
+++ b/Tests/WinMDTests/BlobsHeapTests.swift
@@ -19,7 +19,7 @@ struct BlobsHeapTests {
     #expect(heap[0].count == 3)
   }
 
-  // A length of 0x20...0x7F is held in a single byte (high bit clear).  The
+  // A length of 0x20...0x7F is held in a single byte (high bit clear). The
   // previous `first & 0xE0` discriminator mis-routed these to the 2-byte form
   // (0x40...0x5F) or rejected them outright (0x20...0x3F, 0x60...0x7F).
   @Test("reads single-byte lengths across the high-bit boundary")

--- a/Tests/WinMDTests/FieldTests.swift
+++ b/Tests/WinMDTests/FieldTests.swift
@@ -1,0 +1,125 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import WinMD
+
+struct FieldTests {
+  // Two synthetic, narrow `TypeDef` rows backed by hand-built spans. The
+  // schema's narrow stride is 14: Flags (4) + five 2-byte indices. The cells
+  // are laid out so the rows carry distinct names and namespaces out of a tiny
+  // strings heap.
+  //   [0] Flags = 0x00000021, TypeName = 1 ("string0"),  TypeNamespace = 9 ("string1")
+  //   [1] Flags = 0x00000000, TypeName = 17 ("string2"), TypeNamespace = 9 ("string1")
+  private static let record: Array<UInt8> = [
+    0x21, 0x00, 0x00, 0x00,
+    0x01, 0x00,
+    0x09, 0x00,
+    0x00, 0x00,
+    0x00, 0x00,
+    0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0x11, 0x00,
+    0x09, 0x00,
+    0x00, 0x00,
+    0x00, 0x00,
+    0x00, 0x00,
+  ]
+
+  // A strings heap: "\0string0\0string1\0string2\0" — "string0" at 1, "string1" at 9, "string2" at 17.
+  private static let strings: Array<UInt8> = [
+    0x00,
+    0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x30, 0x00,
+    0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x31, 0x00,
+    0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x32, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  // The open table is dense so the iterator can address both rows; the
+  // strides are the sum of the columns' narrow widths.
+  private static let relations: Array<Table> = [
+    Table(Metadata.Tables.TypeDef.self, rows: 2, range: 0 ..< 28,
+          wide: 0, stride: 14),
+  ]
+
+  private static let valid: UInt64 = 1 << 2
+
+  private static func with(_ body: (borrowing Storage) throws -> Void)
+      rethrows {
+    let storage = Storage(bytes: FieldTests.record.span.bytes,
+                          relations: FieldTests.relations.span,
+                          strings: FieldTests.strings.span.bytes,
+                          blob: FieldTests.empty.span.bytes,
+                          guid: FieldTests.empty.span.bytes,
+                          valid: FieldTests.valid, sorted: 0)
+    try body(storage)
+  }
+
+  @Test("reads typed values through Column tokens")
+  func tokenReads() throws {
+    try FieldTests.with { storage in
+      let table = FieldTests.relations[0]
+      let row = Row<Metadata.Tables.TypeDef>(0, table, storage)
+
+      // The token read agrees with the kind-validating generic `string`, and
+      // recovers the column's domain type without an annotation.
+      let name = row[.TypeName]
+      let namespace = row[.TypeNamespace]
+      let validated = try row.columns.string(1)
+      let validatedNamespace = try row.columns.string(2)
+      #expect(name == "string0")
+      #expect(name == validated)
+      #expect(namespace == "string1")
+      #expect(namespace == validatedNamespace)
+
+      // A typed-constant token wraps the raw cell in its COR flag domain type.
+      let flags = row[.Flags]
+      #expect(flags == CorTypeAttr(rawValue: 0x21))
+      #expect(flags == row.Flags)
+    }
+  }
+
+  @Test("filters and projects typed rows with where and select")
+  func whereSelect() throws {
+    try FieldTests.with { storage in
+      let iterator =
+          try storage.rows(of: Metadata.Tables.TypeDef.self)
+
+      var names = Array<String>()
+      iterator
+        .select({ $0[.TypeName] },
+                where: { $0[.TypeNamespace] == "string1" })
+        .forEach { names.append($0) }
+      #expect(names == ["string0", "string2"])
+    }
+  }
+
+  @Test("filters typed rows with a value predicate")
+  func wherePredicate() throws {
+    try FieldTests.with { storage in
+      let iterator =
+          try storage.rows(of: Metadata.Tables.TypeDef.self)
+
+      // Only the first row carries the flag bit; counting the survivors of the
+      // typed predicate proves the stage reads the borrowed row's tokens.
+      let count = iterator
+        .where({ $0[.Flags].contains(.tdPublic) })
+        .count()
+      #expect(count == 1)
+    }
+  }
+
+  @Test("projects the first row matching a typed predicate")
+  func firstProjection() throws {
+    try FieldTests.with { storage in
+      let iterator =
+          try storage.rows(of: Metadata.Tables.TypeDef.self)
+
+      let first = iterator
+        .select({ $0[.TypeName] })
+        .first(where: { $0[.TypeName] == "string2" })
+      #expect(first == "string2")
+    }
+  }
+}

--- a/Tests/WinMDTests/NavigationTests.swift
+++ b/Tests/WinMDTests/NavigationTests.swift
@@ -185,3 +185,139 @@ struct NavigationTests {
     }
   }
 }
+
+// Typed reverse navigation over a simple-index owner. `NestedClass.NestedClass`
+// (a `Reference<NestedClass, TypeDef>`) is the table's sort key, so the rows
+// referencing a given `TypeDef` form a contiguous run. ECMA-335 rows are
+// 1-based, so a stored value `N` names the 0-based TypeDef row `N - 1`:
+//   NestedClass[0].NestedClass = 1  → TypeDef[0]
+//   NestedClass[1].NestedClass = 2  → TypeDef[1]
+//   NestedClass[2].NestedClass = 2  → TypeDef[1]
+//   NestedClass[3].NestedClass = 4  → TypeDef[3]
+struct ReverseNavigationTests {
+  private static let record: Array<UInt8> = [
+    // TypeDef[0..3]: four 14-byte rows, all zero (only the row count matters).
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // NestedClass[0..3]: NestedClass then EnclosingClass, ordered by NestedClass.
+    0x01, 0x00, 0x09, 0x00,
+    0x02, 0x00, 0x09, 0x00,
+    0x02, 0x00, 0x09, 0x00,
+    0x04, 0x00, 0x09, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<Table> = [
+    Table(Metadata.Tables.TypeDef.self, rows: 4, range: 0 ..< 56,
+          wide: 0, stride: 14),
+    Table(Metadata.Tables.NestedClass.self, rows: 4, range: 56 ..< 72,
+          wide: 0, stride: 4),
+  ]
+
+  private static let valid: UInt64 = (1 << 2) | (1 << 41)
+
+  private static func with(_ sorted: UInt64,
+                           _ body: (borrowing Storage) throws -> Void)
+      rethrows {
+    let storage =
+        Storage(bytes: ReverseNavigationTests.record.span.bytes,
+                relations: ReverseNavigationTests.relations.span,
+                strings: ReverseNavigationTests.empty.span.bytes,
+                blob: ReverseNavigationTests.empty.span.bytes,
+                guid: ReverseNavigationTests.empty.span.bytes,
+                valid: ReverseNavigationTests.valid, sorted: sorted)
+    try body(storage)
+  }
+
+  @Test("reverse-navigates a simple-index token to its owners")
+  func simpleReverse() throws {
+    // The token names the owning `NestedClass` table and the `NestedClass`
+    // ordinal, so the call site needs no schema or ordinal; the rows naming
+    // TypeDef[1] are the contiguous run [1, 3).
+    try ReverseNavigationTests.with(1 << 41) { storage in
+      let target = Row<Metadata.Tables.TypeDef>(1,
+                                                ReverseNavigationTests.relations[0],
+                                                storage)
+      var rows = Array<Int>()
+      let filter = try storage.referencing(target, by: .NestedClass)
+      filter.forEach { rows.append($0.row) }
+      #expect(rows == [1, 2])
+    }
+  }
+
+  @Test("the typed reverse token agrees with the ordinal form")
+  func tokenAgreesWithOrdinal() throws {
+    try ReverseNavigationTests.with(0) { storage in
+      let target = Row<Metadata.Tables.TypeDef>(1,
+                                                ReverseNavigationTests.relations[0],
+                                                storage)
+      var byToken = Array<Int>()
+      let tokenFilter = try storage.referencing(target, by: .NestedClass)
+      tokenFilter.forEach { byToken.append($0.row) }
+
+      var byOrdinal = Array<Int>()
+      let ordinalFilter =
+          try storage.referencing(target.columns,
+                                  in: Metadata.Tables.NestedClass.self, by: 0)
+      ordinalFilter.forEach { byOrdinal.append($0.row) }
+
+      #expect(byToken == byOrdinal)
+    }
+  }
+}
+
+// Typed reverse navigation over a coded-index owner. `CustomAttribute.Parent`
+// (a `CodedReference<CustomAttribute>`) is a `HasCustomAttribute` coded index;
+// `TypeDef` is its fourth table (tag 3) over 5 tag bits, so a row naming
+// TypeDef[r] stores `((r + 1) << 5) | 3`.
+struct ReverseCodedNavigationTests {
+  private static let record: Array<UInt8> = [
+    // TypeDef[0..1]: two 14-byte rows (only the row count matters).
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // CustomAttribute[0]: Parent = 0x23 → TypeDef[0].
+    0x23, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // CustomAttribute[1]: Parent = 0x43 → TypeDef[1].
+    0x43, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // CustomAttribute[2]: Parent = 0x23 → TypeDef[0] again.
+    0x23, 0x00, 0x00, 0x00, 0x00, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<Table> = [
+    Table(Metadata.Tables.TypeDef.self, rows: 2, range: 0 ..< 28,
+          wide: 0, stride: 14),
+    Table(Metadata.Tables.CustomAttribute.self, rows: 3, range: 28 ..< 46,
+          wide: 0, stride: 6),
+  ]
+
+  private static let valid: UInt64 = (1 << 2) | (1 << 12)
+
+  @Test("reverse-navigates a coded-index token to its owners")
+  func codedReverse() throws {
+    // CustomAttribute is left unsorted, so the typed reverse lookup scans; the
+    // rows naming TypeDef[0] through `Parent` are 0 and 2.
+    let storage =
+        Storage(bytes: ReverseCodedNavigationTests.record.span.bytes,
+                relations: ReverseCodedNavigationTests.relations.span,
+                strings: ReverseCodedNavigationTests.empty.span.bytes,
+                blob: ReverseCodedNavigationTests.empty.span.bytes,
+                guid: ReverseCodedNavigationTests.empty.span.bytes,
+                valid: ReverseCodedNavigationTests.valid, sorted: 0)
+    let target = Row<Metadata.Tables.TypeDef>(0,
+                                              ReverseCodedNavigationTests.relations[0],
+                                              storage)
+    var rows = Array<Int>()
+    // The owning table is named explicitly: `CustomAttribute.Parent` is a
+    // `CodedReference<CustomAttribute>` carrying the owner and the ordinal.
+    let token =
+        CodedReference<Metadata.Tables.CustomAttribute>.Parent
+    let filter = try storage.referencing(target, by: token)
+    filter.forEach { rows.append($0.row) }
+    #expect(rows == [0, 2])
+  }
+}

--- a/Tests/WinMDTests/NavigationTests.swift
+++ b/Tests/WinMDTests/NavigationTests.swift
@@ -1,0 +1,187 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import WinMD
+
+struct NavigationTests {
+  // Typed navigation reads referenced tables out of `relations`, so this
+  // hand-builds a small multi-table database: `TypeRef` (#1), `TypeDef` (#2),
+  // `FieldDef` (#4), and `NestedClass` (#41). The records carry live foreign
+  // keys and a list run:
+  //   TypeDef[0].Extends    = 5  → (row 1 << 2) | tag 1 ⇒ TypeRef[0] (coded)
+  //   TypeDef[0].FieldList  = 1  → 1-based start, run [0, next-1] ⇒ FieldDef[0]
+  //   TypeDef[1].FieldList  = 2  → 1-based, marks one past TypeDef[0]'s run
+  //   NestedClass[0].Nested = 1  → a simple TypeDef index ⇒ TypeDef[0] (string0)
+  private static let record: Array<UInt8> = [
+    // TypeRef[0]: ResolutionScope = 0, TypeName = 1 ("Object"),
+    //             TypeNamespace = 8 ("System").
+    0x00, 0x00, 0x01, 0x00, 0x08, 0x00,
+    // TypeDef[0]: Flags = 0x21, TypeName = 15 ("string0"), TypeNamespace = 23 ("string1"),
+    //             Extends = 5 (TypeRef[0]), FieldList = 1 (1-based), MethodList = 1.
+    0x21, 0x00, 0x00, 0x00, 0x0f, 0x00, 0x17, 0x00, 0x05, 0x00, 0x01, 0x00, 0x01, 0x00,
+    // TypeDef[1]: as above but Extends = 0 (null), FieldList = 2 (1-based).
+    0x21, 0x00, 0x00, 0x00, 0x0f, 0x00, 0x17, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01, 0x00,
+    // FieldDef[0]: Flags = 0, Name = 15 ("string0"), Signature = 0.
+    0x00, 0x00, 0x0f, 0x00, 0x00, 0x00,
+    // FieldDef[1]: Flags = 0, Name = 23 ("string1"), Signature = 0.
+    0x00, 0x00, 0x17, 0x00, 0x00, 0x00,
+    // NestedClass[0]: NestedClass = 1 (TypeDef[0]), EnclosingClass = 1.
+    0x01, 0x00, 0x01, 0x00,
+  ]
+
+  // A strings heap: "\0Object\0System\0string0\0string1\0".
+  private static let strings: Array<UInt8> = [
+    0x00,
+    0x4f, 0x62, 0x6a, 0x65, 0x63, 0x74, 0x00,
+    0x53, 0x79, 0x73, 0x74, 0x65, 0x6d, 0x00,
+    0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x30, 0x00,
+    0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x31, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  // The open tables, dense and ordered by number; each names its byte range
+  // within `record`. All indices are narrow (2-byte).
+  private static let relations: Array<Table> = [
+    Table(Metadata.Tables.TypeRef.self, rows: 1, range: 0 ..< 6, wide: 0, stride: 6),
+    Table(Metadata.Tables.TypeDef.self, rows: 2, range: 6 ..< 34, wide: 0, stride: 14),
+    Table(Metadata.Tables.FieldDef.self, rows: 2, range: 34 ..< 46, wide: 0, stride: 6),
+    Table(Metadata.Tables.NestedClass.self, rows: 1, range: 46 ..< 50, wide: 0, stride: 4),
+  ]
+
+  private static let valid: UInt64 =
+      (1 << 1) | (1 << 2) | (1 << 4) | (1 << 41)
+
+  private static func with(_ body: (borrowing Storage) throws -> Void) rethrows {
+    let storage = Storage(bytes: NavigationTests.record.span.bytes,
+                          relations: NavigationTests.relations.span,
+                          strings: NavigationTests.strings.span.bytes,
+                          blob: NavigationTests.empty.span.bytes,
+                          guid: NavigationTests.empty.span.bytes,
+                          valid: NavigationTests.valid, sorted: 0)
+    try body(storage)
+  }
+
+  @Test("resolves a simple-index token to a typed row")
+  func simpleResolution() throws {
+    try NavigationTests.with { storage in
+      // NestedClass[0].NestedClass is a simple `TypeDef` index; the token
+      // resolve lands on the typed `Row<TypeDef>` it names.
+      let source = Row<Metadata.Tables.NestedClass>(0,
+                                                    NavigationTests.relations[3],
+                                                    storage)
+      guard let parent = try source.resolve(.NestedClass) else {
+        Issue.record("NestedClass did not resolve"); return
+      }
+      #expect(parent.TypeName == "string0")
+    }
+  }
+
+  @Test("resolves a null simple-index token to nothing")
+  func nullSimpleResolution() throws {
+    try NavigationTests.with { storage in
+      // The reframed `EnclosingClass` accessor is non-optional; the underlying
+      // token resolve is optional and non-nil for a live reference.
+      let source = Row<Metadata.Tables.NestedClass>(0,
+                                                    NavigationTests.relations[3],
+                                                    storage)
+      let resolved: Bool =
+          if let _ = try source.resolve(.EnclosingClass) { true } else { false }
+      #expect(resolved)
+    }
+  }
+
+  @Test("resolves a coded-index token to a type-erased tuple")
+  func codedResolution() throws {
+    try NavigationTests.with { storage in
+      // TypeDef[0].Extends is a `TypeDefOrRef` coded index whose tag selects
+      // the `TypeRef` table; the token resolve yields the type-erased tuple.
+      let source = Row<Metadata.Tables.TypeDef>(0,
+                                                NavigationTests.relations[1],
+                                                storage)
+      guard let base = try source.resolve(.Extends) else {
+        Issue.record("Extends did not resolve"); return
+      }
+      #expect(try base.string(1) == "Object")
+    }
+  }
+
+  @Test("resolves a null coded-index token to nothing")
+  func nullCodedResolution() throws {
+    try NavigationTests.with { storage in
+      // TypeDef[1].Extends is the null reference (coded row 0).
+      let source = Row<Metadata.Tables.TypeDef>(1,
+                                                NavigationTests.relations[1],
+                                                storage)
+      let resolved: Bool =
+          if let _ = try source.resolve(.Extends) { true } else { false }
+      #expect(!resolved)
+    }
+  }
+
+  @Test("narrows a coded resolution to the target with Row(_:)")
+  func typedRoundTrip() throws {
+    try NavigationTests.with { storage in
+      let source = Row<Metadata.Tables.TypeDef>(0,
+                                                NavigationTests.relations[1],
+                                                storage)
+      guard let base = try source.resolve(.Extends) else {
+        Issue.record("Extends did not resolve"); return
+      }
+      // The tag selected `TypeRef`, so narrowing to `TypeRef` recovers a typed
+      // row; the token accessors read off it.
+      guard let typed = Row<Metadata.Tables.TypeRef>(base) else {
+        Issue.record("Row(_:) rejected the matching table"); return
+      }
+      #expect(typed.TypeName == "Object")
+      #expect(typed.TypeNamespace == "System")
+    }
+  }
+
+  @Test("rejects a Row(_:) narrowing to the wrong table")
+  func typedMismatch() throws {
+    try NavigationTests.with { storage in
+      let source = Row<Metadata.Tables.TypeDef>(0,
+                                                NavigationTests.relations[1],
+                                                storage)
+      guard let base = try source.resolve(.Extends) else {
+        Issue.record("Extends did not resolve"); return
+      }
+      // The resolved tuple is a `TypeRef` row, so narrowing to `TypeDef` fails.
+      let mismatched: Bool =
+          if let _ = Row<Metadata.Tables.TypeDef>(base) {
+            true
+          } else {
+            false
+          }
+      #expect(!mismatched)
+    }
+  }
+
+  @Test("opens a typed list iterator over the run")
+  func listNavigation() throws {
+    try NavigationTests.with { storage in
+      // TypeDef[0].FieldList delimits a run ending one before the next row's
+      // start, so it yields exactly FieldDef[0] ("string0").
+      let source = Row<Metadata.Tables.TypeDef>(0,
+                                                NavigationTests.relations[1],
+                                                storage)
+      let fields = try source.list(.FieldList)
+      #expect(fields.count == 1)
+      #expect(fields[0]?.Name == "string0")
+    }
+  }
+
+  @Test("a typed list run agrees with the reframed accessor")
+  func listAccessorAgrees() throws {
+    try NavigationTests.with { storage in
+      let source = Row<Metadata.Tables.TypeDef>(0,
+                                                NavigationTests.relations[1],
+                                                storage)
+      let token = try source.list(.FieldList)
+      let accessor = try source.FieldList
+      #expect(token.count == accessor.count)
+    }
+  }
+}

--- a/Tests/WinMDTests/PhysicalSchemaTests.swift
+++ b/Tests/WinMDTests/PhysicalSchemaTests.swift
@@ -1,0 +1,62 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import WinMD
+
+struct PhysicalSchemaTests {
+  // A `CustomAttributeType` coded index names the tables [reserved, reserved,
+  // MethodDef, MemberRef, reserved]: only tags 2 and 3 name a table, the rest
+  // are reserved. A reserved tag names no table, so it contributes no rows to
+  // the index width — the width is fixed solely by the present targets. When
+  // they fit under the compressed range (here one row each, far below 2^(16-3))
+  // the index is 2 bytes; a reserved slot must not force it to 4.
+  //
+  // This builds the smallest tables stream that carries `CustomAttribute` (#12)
+  // alongside its targets `MethodDef` (#6) and `MemberRef` (#10), then resolves
+  // the layout the way the database does — through `relations`, which sizes the
+  // `Type` column (column 1, a `CustomAttributeType` coded index) via
+  // `PhysicalSchema.width(of:)`.
+  @Test("sizes a coded column with reserved tags by its present targets only")
+  func reservedTagsDoNotWiden() throws {
+    // Header: Reserved(4), Major(1), Minor(1), HeapSizes(1), Reserved(1),
+    // Valid(8), Sorted(8), then a 32-bit row count per present table. The three
+    // present tables each carry a single row, comfortably below the compressed
+    // range, so every index in them is narrow (2 bytes). The buffer is padded
+    // well past any plausible record extent so `relations` stays in bounds.
+    let valid: UInt64 = (1 << 6) | (1 << 10) | (1 << 12)
+    var bytes = Array<UInt8>(repeating: 0, count: 256)
+    // Valid at +8.
+    for shift in 0 ..< 8 {
+      bytes[8 + shift] = UInt8(truncatingIfNeeded: valid >> (shift * 8))
+    }
+    // One row each, in ascending table-number order: MethodDef, MemberRef,
+    // CustomAttribute. Each row count is a 32-bit little-endian word at +24.
+    for slot in 0 ..< 3 {
+      bytes[24 + slot * 4] = 1
+    }
+
+    let stream = TablesStream(bytes.span.bytes, base: 0, limit: bytes.count)
+    let relations = try stream.relations(PhysicalSchema(stream))
+
+    guard let attributes = relations.first(where: {
+      $0.number == Metadata.Tables.CustomAttribute.number
+    }) else {
+      Issue.record("CustomAttribute table was not opened"); return
+    }
+
+    // The `Type` column (column 1) is a `CustomAttributeType` coded index whose
+    // only present targets are small, so it is a 2-byte index — the reserved
+    // tags must not widen it to 4.
+    #expect(attributes.width(1) == 2)
+
+    // The `Parent` column is a `HasCustomAttribute` coded index over many
+    // tables, all but `MethodDef` absent here. An absent target has no rows, so
+    // it cannot force a wide index; the only present target carries one row, far
+    // below the compressed range, so `Parent` is a narrow 2-byte index too. The
+    // row is the narrow `Parent`, the narrow `Type`, and a narrow `Value` blob
+    // index: 2 + 2 + 2 = 6 bytes.
+    #expect(attributes.width(0) == 2)
+    #expect(attributes.stride == 6)
+  }
+}

--- a/Tests/WinMDTests/QueryTests.swift
+++ b/Tests/WinMDTests/QueryTests.swift
@@ -112,4 +112,27 @@ struct QueryTests {
       #expect(throws: WinMDError.InvalidColumn) { _ = try tuple.string(3) }
     }
   }
+
+  @Test("rejects an out-of-bounds column ordinal without trapping")
+  func ordinalBounds() {
+    QueryTests.with { tuple in
+      // The throwing accessors index the schema's fields to recover a column's
+      // type, so an ordinal outside `0 ..< count` would trap on that lookup
+      // before the kind guard could run. A negative and a one-past-the-end
+      // ordinal must both throw `.InvalidColumn` rather than trap. The TypeDef
+      // fixture has six columns, so `tuple.count` is the first out-of-range
+      // ordinal.
+      let past = tuple.count
+      #expect(throws: WinMDError.InvalidColumn) { _ = try tuple.string(-1) }
+      #expect(throws: WinMDError.InvalidColumn) { _ = try tuple.string(past) }
+      #expect(throws: WinMDError.InvalidColumn) { _ = try tuple.blob(-1) }
+      #expect(throws: WinMDError.InvalidColumn) { _ = try tuple.blob(past) }
+      #expect(throws: WinMDError.InvalidColumn) { _ = try tuple.guid(-1) }
+      #expect(throws: WinMDError.InvalidColumn) { _ = try tuple.guid(past) }
+      #expect(throws: WinMDError.InvalidColumn) { _ = try tuple.resolve(-1) }
+      #expect(throws: WinMDError.InvalidColumn) { _ = try tuple.resolve(past) }
+      // A valid in-range column still reads.
+      #expect((try? tuple.string(1)) == "string0")
+    }
+  }
 }

--- a/Tests/WinMDTests/QueryTests.swift
+++ b/Tests/WinMDTests/QueryTests.swift
@@ -1,0 +1,115 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import WinMD
+
+struct QueryTests {
+  // A synthetic, narrow `TypeDef` row backed by hand-built spans. The schema's
+  // narrow stride is 14: Flags (4) + five 2-byte indices. The cells are laid
+  // out so that TypeName resolves to "string0" and TypeNamespace to "string1" out of a
+  // tiny strings heap.
+  //   Flags         = 0x00000021
+  //   TypeName      = 1  ("string0")
+  //   TypeNamespace = 9  ("string1")
+  //   Extends       = 0
+  //   FieldList     = 0
+  //   MethodList    = 0
+  private static let record: Array<UInt8> = [
+    0x21, 0x00, 0x00, 0x00,
+    0x01, 0x00,
+    0x09, 0x00,
+    0x00, 0x00,
+    0x00, 0x00,
+    0x00, 0x00,
+  ]
+
+  // A strings heap: "\0string0\0string1\0" — "string0" at offset 1, "string1" at offset 9.
+  private static let strings: Array<UInt8> = [
+    0x00,
+    0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x30, 0x00,
+    0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x31, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+  private static let relations = Array<Table>()
+
+  private static func with(_ body: (borrowing Tuple) -> Void) {
+    let record = QueryTests.record.span.bytes
+    let table = Table(Metadata.Tables.TypeDef.self, rows: 1,
+                      range: 0 ..< record.byteCount, wide: 0, stride: 14)
+    let storage = Storage(bytes: record, relations: relations.span,
+                          strings: strings.span.bytes, blob: empty.span.bytes,
+                          guid: empty.span.bytes, valid: 0)
+    body(Tuple(0, table, storage))
+  }
+
+  @Test("resolves column ordinals by name")
+  func ordinalResolution() {
+    QueryTests.with { tuple in
+      #expect(tuple.ordinal(for: "Flags") == 0)
+      #expect(tuple.ordinal(for: "TypeName") == 1)
+      #expect(tuple.ordinal(for: "TypeNamespace") == 2)
+      #expect(tuple.ordinal(for: "MethodList") == 5)
+      #expect(tuple.ordinal(for: "DoesNotExist") == nil)
+    }
+  }
+
+  @Test("reads string cells through the strings heap")
+  func stringResolution() throws {
+    QueryTests.with { tuple in
+      #expect((try? tuple.string(1)) == "string0")
+      #expect((try? tuple.string(2)) == "string1")
+    }
+  }
+
+  @Test("throws on a malformed strings-heap entry rather than trapping")
+  func malformedStringEntry() {
+    // A record whose TypeName cell points one past the heap end, and whose
+    // TypeNamespace cell points at an unterminated run that reaches the heap
+    // end without a NUL. Both must throw `.BadImageFormat` through
+    // `Tuple.string(_:)` rather than trapping.
+    //   TypeName      = 9  (one past the 9-byte heap)
+    //   TypeNamespace = 1  (an unterminated run to the heap end)
+    let record: Array<UInt8> = [
+      0x21, 0x00, 0x00, 0x00,
+      0x09, 0x00,
+      0x01, 0x00,
+      0x00, 0x00,
+      0x00, 0x00,
+      0x00, 0x00,
+    ]
+    // "\0string0" - nine bytes, no trailing NUL, so a read from offset 1
+    // runs to the heap end without a terminator.
+    let strings: Array<UInt8> = [
+      0x00,
+      0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x30,
+    ]
+    let empty = Array<UInt8>()
+    let relations = Array<Table>()
+    let span = record.span.bytes
+    let table = Table(Metadata.Tables.TypeDef.self, rows: 1,
+                      range: 0 ..< span.byteCount, wide: 0, stride: 14)
+    let storage = Storage(bytes: span, relations: relations.span,
+                          strings: strings.span.bytes, blob: empty.span.bytes,
+                          guid: empty.span.bytes, valid: 0)
+    let tuple = Tuple(0, table, storage)
+    // An offset past the heap end.
+    #expect(throws: WinMDError.BadImageFormat) { _ = try tuple.string(1) }
+    // A run with no NUL terminator before the heap end.
+    #expect(throws: WinMDError.BadImageFormat) { _ = try tuple.string(2) }
+  }
+
+  @Test("rejects a heap read on the wrong column kind")
+  func heapKindMismatch() {
+    QueryTests.with { tuple in
+      // Field 0 (Flags) is a constant, not a string heap index.
+      #expect(throws: WinMDError.InvalidColumn) { _ = try tuple.string(0) }
+      // A string column is not a blob or GUID column.
+      #expect(throws: WinMDError.InvalidColumn) { _ = try tuple.blob(1) }
+      #expect(throws: WinMDError.InvalidColumn) { _ = try tuple.guid(1) }
+      // Field 3 (Extends) is a coded index, not any heap kind.
+      #expect(throws: WinMDError.InvalidColumn) { _ = try tuple.string(3) }
+    }
+  }
+}

--- a/Tests/WinMDTests/QueryTests.swift
+++ b/Tests/WinMDTests/QueryTests.swift
@@ -40,7 +40,7 @@ struct QueryTests {
                       range: 0 ..< record.byteCount, wide: 0, stride: 14)
     let storage = Storage(bytes: record, relations: relations.span,
                           strings: strings.span.bytes, blob: empty.span.bytes,
-                          guid: empty.span.bytes, valid: 0)
+                          guid: empty.span.bytes, valid: 0, sorted: 0)
     body(Tuple(0, table, storage))
   }
 
@@ -92,7 +92,7 @@ struct QueryTests {
                       range: 0 ..< span.byteCount, wide: 0, stride: 14)
     let storage = Storage(bytes: span, relations: relations.span,
                           strings: strings.span.bytes, blob: empty.span.bytes,
-                          guid: empty.span.bytes, valid: 0)
+                          guid: empty.span.bytes, valid: 0, sorted: 0)
     let tuple = Tuple(0, table, storage)
     // An offset past the heap end.
     #expect(throws: WinMDError.BadImageFormat) { _ = try tuple.string(1) }

--- a/Tests/WinMDTests/ReferencingTests.swift
+++ b/Tests/WinMDTests/ReferencingTests.swift
@@ -1,0 +1,250 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import WinMD
+
+struct ReferencingTests {
+  // Reverse navigation reads the owning table out of `relations`, so this
+  // hand-builds a small multi-table database: `TypeDef` (#2, the target) and
+  // `NestedClass` (#41, the owner). `NestedClass.NestedClass` (ordinal 0) is a
+  // simple `TypeDef` index and the table's intrinsic sort key, so the rows are
+  // laid out ordered by it. ECMA-335 rows are 1-based, so a stored value `N`
+  // names the 0-based TypeDef row `N - 1`:
+  //   NestedClass[0].NestedClass = 1  → TypeDef[0]
+  //   NestedClass[1].NestedClass = 2  → TypeDef[1]
+  //   NestedClass[2].NestedClass = 2  → TypeDef[1]
+  //   NestedClass[3].NestedClass = 4  → TypeDef[3]
+  // so the rows referencing TypeDef[1] are the contiguous run [1, 3).
+  private static let record: Array<UInt8> = [
+    // TypeDef[0..3]: four 14-byte rows, all zero (only the row count matters
+    // for the reverse lookup; no columns are read off the target).
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // NestedClass[0..3]: NestedClass index then EnclosingClass index, ordered
+    // by NestedClass: 1, 2, 2, 4.
+    0x01, 0x00, 0x09, 0x00,
+    0x02, 0x00, 0x09, 0x00,
+    0x02, 0x00, 0x09, 0x00,
+    0x04, 0x00, 0x09, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<Table> = [
+    Table(Metadata.Tables.TypeDef.self, rows: 4, range: 0 ..< 56,
+          wide: 0, stride: 14),
+    Table(Metadata.Tables.NestedClass.self, rows: 4, range: 56 ..< 72,
+          wide: 0, stride: 4),
+  ]
+
+  private static let valid: UInt64 = (1 << 2) | (1 << 41)
+
+  // The NestedClass table number is 41; setting its `Sorted` bit declares the
+  // table physically ordered on its key column.
+  private static func with(_ sorted: UInt64,
+                           _ body: (borrowing Storage) throws -> Void)
+      rethrows {
+    let storage = Storage(bytes: ReferencingTests.record.span.bytes,
+                          relations: ReferencingTests.relations.span,
+                          strings: ReferencingTests.empty.span.bytes,
+                          blob: ReferencingTests.empty.span.bytes,
+                          guid: ReferencingTests.empty.span.bytes,
+                          valid: ReferencingTests.valid, sorted: sorted)
+    try body(storage)
+  }
+
+  // Collect the 0-based owning rows that `referencing` yields.
+  private static func matches(_ storage: borrowing Storage,
+                              _ target: borrowing Tuple)
+      throws -> Array<Int> {
+    var rows = Array<Int>()
+    let filter = try storage.referencing(target,
+                                         in: Metadata.Tables.NestedClass.self,
+                                         by: 0)
+    filter.forEach { rows.append($0.row) }
+    return rows
+  }
+
+  @Test("finds the referencing run by binary search when sorted")
+  func sortedBinarySearch() throws {
+    // NestedClass is sorted on its key (ordinal 0), so the run referencing
+    // TypeDef[1] is found by binary search: rows 1 and 2.
+    try ReferencingTests.with(1 << 41) { storage in
+      let target = Tuple(1, ReferencingTests.relations[0], storage)
+      let rows = try ReferencingTests.matches(storage, target)
+      #expect(rows == [1, 2])
+    }
+  }
+
+  @Test("falls back to a scan when unsorted and agrees")
+  func unsortedScanAgrees() throws {
+    // With the `Sorted` bit clear the same query falls back to a linear scan
+    // and must return the identical matches.
+    try ReferencingTests.with(0) { storage in
+      let target = Tuple(1, ReferencingTests.relations[0], storage)
+      let rows = try ReferencingTests.matches(storage, target)
+      #expect(rows == [1, 2])
+    }
+  }
+
+  @Test("sorted and scan paths agree for every target")
+  func sortedAndScanAgree() throws {
+    // Every target row resolves to the same set of owners under both paths.
+    for row in 0 ..< 4 {
+      var sorted = Array<Int>()
+      var scanned = Array<Int>()
+      try ReferencingTests.with(1 << 41) { storage in
+        let target = Tuple(row, ReferencingTests.relations[0], storage)
+        sorted = try ReferencingTests.matches(storage, target)
+      }
+      try ReferencingTests.with(0) { storage in
+        let target = Tuple(row, ReferencingTests.relations[0], storage)
+        scanned = try ReferencingTests.matches(storage, target)
+      }
+      #expect(sorted == scanned)
+    }
+  }
+
+  @Test("yields no owners for an unreferenced target")
+  func zeroMatches() throws {
+    // TypeDef[2] (stored value 3) is named by no NestedClass row.
+    try ReferencingTests.with(1 << 41) { storage in
+      let target = Tuple(2, ReferencingTests.relations[0], storage)
+      let sorted = try ReferencingTests.matches(storage, target)
+      #expect(sorted.isEmpty)
+    }
+    try ReferencingTests.with(0) { storage in
+      let target = Tuple(2, ReferencingTests.relations[0], storage)
+      let scanned = try ReferencingTests.matches(storage, target)
+      #expect(scanned.isEmpty)
+    }
+  }
+
+  @Test("rejects a reverse lookup by an out-of-range column ordinal")
+  func columnOrdinalOutOfRange() throws {
+    // A negative ordinal or one at/beyond the owner's column count names no
+    // field; `referencing` must throw rather than trap on `schema.fields`.
+    ReferencingTests.with(0) { storage in
+      let target = Tuple(0, ReferencingTests.relations[0], storage)
+      let width = Metadata.Tables.NestedClass.fields.count
+      #expect(throws: WinMDError.InvalidColumn) {
+        _ = try storage.referencing(target,
+                                    in: Metadata.Tables.NestedClass.self,
+                                    by: -1)
+      }
+      #expect(throws: WinMDError.InvalidColumn) {
+        _ = try storage.referencing(target,
+                                    in: Metadata.Tables.NestedClass.self,
+                                    by: width)
+      }
+    }
+  }
+
+  @Test("rejects a reverse lookup against the wrong table")
+  func simpleIndexTableMismatch() throws {
+    // `referencing` by a simple `TypeDef` index against a `NestedClass` target
+    // is a usage error: the index does not name that table.
+    ReferencingTests.with(0) { storage in
+      let target = Tuple(0, ReferencingTests.relations[1], storage)
+      #expect(throws: WinMDError.InvalidColumn) {
+        _ = try storage.referencing(target,
+                                    in: Metadata.Tables.NestedClass.self,
+                                    by: 0)
+      }
+    }
+  }
+}
+
+// A coded-index reverse lookup over an unsorted owner. `CustomAttribute` (#12)
+// holds its owner in `Parent` (ordinal 0), a `HasCustomAttribute` coded index.
+// `TypeDef` is the fourth table of that index (tag 3) and the index uses 5 tag
+// bits, so a row naming TypeDef[r] stores `((r + 1) << 5) | 3`.
+struct ReferencingCodedTests {
+  // TypeDef[0]: 14 bytes (only the row count matters). Then two CustomAttribute
+  // rows whose `Parent` names TypeDef[0] (encoded 0x23) and a third naming a
+  // different target. Columns: Parent (HasCustomAttribute), Type
+  // (CustomAttributeType), Value (Blob) — all narrow, stride 6.
+  private static let record: Array<UInt8> = [
+    // TypeDef[0].
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // CustomAttribute[0]: Parent = ((0 + 1) << 5) | 3 = 0x23 → TypeDef[0].
+    0x23, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // CustomAttribute[1]: Parent = 0x43 = ((1 + 1) << 5) | 3 → TypeDef[1].
+    0x43, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // CustomAttribute[2]: Parent = 0x23 → TypeDef[0] again.
+    0x23, 0x00, 0x00, 0x00, 0x00, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<Table> = [
+    Table(Metadata.Tables.TypeDef.self, rows: 2, range: 0 ..< 14,
+          wide: 0, stride: 14),
+    Table(Metadata.Tables.CustomAttribute.self, rows: 3, range: 14 ..< 32,
+          wide: 0, stride: 6),
+  ]
+
+  private static let valid: UInt64 = (1 << 2) | (1 << 12)
+
+  @Test("scans an unsorted owner by a coded index")
+  func codedReverseScan() throws {
+    // CustomAttribute is left unsorted (`Sorted` clear), so the reverse lookup
+    // scans; the rows naming TypeDef[0] through `Parent` are 0 and 2.
+    let storage = Storage(bytes: ReferencingCodedTests.record.span.bytes,
+                          relations: ReferencingCodedTests.relations.span,
+                          strings: ReferencingCodedTests.empty.span.bytes,
+                          blob: ReferencingCodedTests.empty.span.bytes,
+                          guid: ReferencingCodedTests.empty.span.bytes,
+                          valid: ReferencingCodedTests.valid, sorted: 0)
+    let target = Tuple(0, ReferencingCodedTests.relations[0], storage)
+    var rows = Array<Int>()
+    let filter =
+        try storage.referencing(target,
+                                in: Metadata.Tables.CustomAttribute.self,
+                                by: 0)
+    filter.forEach { rows.append($0.row) }
+    #expect(rows == [0, 2])
+  }
+
+  // `CustomAttribute.Type` (ordinal 1) is a `CustomAttributeType` coded index.
+  // That index names five slots over three tag bits, but tags 0, 1, and 4 are
+  // reserved and modelled as `nil` entries; only `MethodDef` (2) and `MemberRef`
+  // (3) are real tables. A reverse lookup whose target is a `Module` row must be
+  // rejected: `Module` is not among the index's tables, so `tag(of:in:)` yields
+  // nil and `referencing` throws `.InvalidColumn`.
+  //
+  // This locks the Option-A behaviour. Were the reserved slots still the old
+  // `Module` placeholders, `tag(of: Module)` would find one (tag 0) and the
+  // lookup would silently scan instead of throwing.
+  @Test("rejects a reverse lookup whose target is a reserved coded-index table")
+  func reservedCodedIndexTarget() throws {
+    // A single Module row (#0): Generation (constant, 2 bytes) + Name (string) +
+    // Mvid + EncId + EncBaseId (guid each), all narrow ⇒ stride 10; cells zero.
+    // A single CustomAttribute row (#12, stride 6) follows so the owning table is
+    // present (`referencing` first checks the owner is a valid table).
+    let record = Array<UInt8>(repeating: 0, count: 16)
+    let relations: Array<Table> = [
+      Table(Metadata.Tables.Module.self, rows: 1, range: 0 ..< 10,
+            wide: 0, stride: 10),
+      Table(Metadata.Tables.CustomAttribute.self, rows: 1, range: 10 ..< 16,
+            wide: 0, stride: 6),
+    ]
+    let storage = Storage(bytes: record.span.bytes,
+                          relations: relations.span,
+                          strings: ReferencingCodedTests.empty.span.bytes,
+                          blob: ReferencingCodedTests.empty.span.bytes,
+                          guid: ReferencingCodedTests.empty.span.bytes,
+                          valid: (1 << 0) | (1 << 12), sorted: 0)
+    let target = Tuple(0, relations[0], storage)
+    // `Type` (ordinal 1) is a `CustomAttributeType` coded index whose tables omit
+    // `Module`; the reverse lookup must reject it rather than scan.
+    #expect(throws: WinMDError.InvalidColumn) {
+      _ = try storage.referencing(target,
+                                  in: Metadata.Tables.CustomAttribute.self,
+                                  by: 1)
+    }
+  }
+}

--- a/Tests/WinMDTests/RequiredReferenceTests.swift
+++ b/Tests/WinMDTests/RequiredReferenceTests.swift
@@ -1,0 +1,47 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import WinMD
+
+struct RequiredReferenceTests {
+  // A required reference must name a row, so the null value (0) in such a
+  // column is malformed metadata rather than an absent edge. The typed
+  // accessors that front required references route through `Row.required`,
+  // which throws `.BadImageFormat` instead of trapping on the missing row.
+  //
+  // This hand-builds the smallest database carrying a single `InterfaceImpl`
+  // (#9) whose `Class` (a required simple `TypeDef` index) is null:
+  //   InterfaceImpl[0].Class = 0  → the null reference
+  //   InterfaceImpl[0].Interface = 0  → an unused coded cell
+  private static let record: Array<UInt8> = [
+    // InterfaceImpl[0]: Class = 0 (null), Interface = 0.
+    0x00, 0x00, 0x00, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  // Both columns are narrow (2-byte) indices, so the stride is 4.
+  private static let relations: Array<Table> = [
+    Table(Metadata.Tables.InterfaceImpl.self, rows: 1, range: 0 ..< 4,
+          wide: 0, stride: 4),
+  ]
+
+  private static let valid: UInt64 = 1 << 9
+
+  @Test("a null required reference throws rather than traps")
+  func nullRequiredReference() throws {
+    let storage = Storage(bytes: RequiredReferenceTests.record.span.bytes,
+                          relations: RequiredReferenceTests.relations.span,
+                          strings: RequiredReferenceTests.empty.span.bytes,
+                          blob: RequiredReferenceTests.empty.span.bytes,
+                          guid: RequiredReferenceTests.empty.span.bytes,
+                          valid: RequiredReferenceTests.valid, sorted: 0)
+    let source = Row<Metadata.Tables.InterfaceImpl>(0,
+                                                    RequiredReferenceTests.relations[0],
+                                                    storage)
+    // `InterfaceImpl.Class` is a required reference; with `Class == 0` the
+    // accessor must throw `.BadImageFormat`, not force-unwrap a null resolve.
+    #expect(throws: WinMDError.BadImageFormat) { _ = try source.Class }
+  }
+}

--- a/Tests/WinMDTests/ResolveTests.swift
+++ b/Tests/WinMDTests/ResolveTests.swift
@@ -1,0 +1,143 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import WinMD
+
+struct ResolveTests {
+  // Forward navigation reads the referenced tables out of `relations`, so unlike
+  // the single-row `QueryTests` fixture this hand-builds a small multi-table
+  // database: `TypeRef` (#1), `TypeDef` (#2), and `NestedClass` (#41). The tables
+  // are dense and ordered by number so the population-count slot math resolves
+  // them, and the records carry live foreign keys:
+  //   TypeDef[0].Extends    = 5  → (row 1 << 2) | tag 1 ⇒ TypeRef[0] (System.Object)
+  //   TypeDef[1].Extends    = 0  → the null reference
+  //   NestedClass[0].Nested = 1  → a simple TypeDef index ⇒ TypeDef[0] (string0)
+  private static let record: Array<UInt8> = [
+    // TypeRef[0]: ResolutionScope = 0, TypeName = 1 ("Object"),
+    //             TypeNamespace = 8 ("System").
+    0x00, 0x00, 0x01, 0x00, 0x08, 0x00,
+    // TypeDef[0]: Flags = 0x21, TypeName = 15 ("string0"), TypeNamespace = 23 ("string1"),
+    //             Extends = 5 (TypeRef[0]), FieldList = 0, MethodList = 0.
+    0x21, 0x00, 0x00, 0x00, 0x0f, 0x00, 0x17, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // TypeDef[1]: as above but Extends = 0 (the null reference).
+    0x21, 0x00, 0x00, 0x00, 0x0f, 0x00, 0x17, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // NestedClass[0]: NestedClass = 1 (TypeDef[0]), EnclosingClass = 1.
+    0x01, 0x00, 0x01, 0x00,
+  ]
+
+  // A strings heap: "\0Object\0System\0string0\0string1\0".
+  private static let strings: Array<UInt8> = [
+    0x00,
+    0x4f, 0x62, 0x6a, 0x65, 0x63, 0x74, 0x00,
+    0x53, 0x79, 0x73, 0x74, 0x65, 0x6d, 0x00,
+    0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x30, 0x00,
+    0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x31, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  // The open tables, dense and ordered by number; each names its byte range
+  // within `record`. All indices are narrow (2-byte), so the strides are the sum
+  // of the columns' narrow widths.
+  private static let relations: Array<Table> = [
+    Table(Metadata.Tables.TypeRef.self, rows: 1, range: 0 ..< 6, wide: 0, stride: 6),
+    Table(Metadata.Tables.TypeDef.self, rows: 2, range: 6 ..< 34, wide: 0, stride: 14),
+    Table(Metadata.Tables.NestedClass.self, rows: 1, range: 34 ..< 38, wide: 0, stride: 4),
+  ]
+
+  private static let valid: UInt64 = (1 << 1) | (1 << 2) | (1 << 41)
+
+  private static func with(_ body: (borrowing Storage) throws -> Void) rethrows {
+    let storage = Storage(bytes: ResolveTests.record.span.bytes,
+                          relations: ResolveTests.relations.span,
+                          strings: ResolveTests.strings.span.bytes,
+                          blob: ResolveTests.empty.span.bytes,
+                          guid: ResolveTests.empty.span.bytes,
+                          valid: ResolveTests.valid)
+    try body(storage)
+  }
+
+  @Test("resolves a coded foreign key to the referenced row")
+  func codedIndexResolution() throws {
+    try ResolveTests.with { storage in
+      // TypeDef[0] extends TypeRef[0] through `Extends` (ordinal 3), a
+      // `TypeDefOrRef` coded index whose tag selects the `TypeRef` table.
+      let source = Tuple(0, ResolveTests.relations[1], storage)
+      guard let base = try source.resolve(3) else {
+        Issue.record("Extends did not resolve"); return
+      }
+      // The resolved tuple is a TypeRef row: TypeName (1), TypeNamespace (2).
+      let name = try base.string(1)
+      let namespace = try base.string(2)
+      #expect(name == "Object")
+      #expect(namespace == "System")
+    }
+  }
+
+  @Test("resolves a simple index to the referenced row")
+  func simpleIndexResolution() throws {
+    try ResolveTests.with { storage in
+      // NestedClass[0].NestedClass (ordinal 0) is a simple `TypeDef` index;
+      // resolving it lands on the six-column TypeDef row it names.
+      let source = Tuple(0, ResolveTests.relations[2], storage)
+      guard let parent = try source.resolve(0) else {
+        Issue.record("NestedClass did not resolve"); return
+      }
+      let count = parent.count
+      let name = try parent.string(1)
+      #expect(count == Metadata.Tables.TypeDef.fields.count)
+      #expect(name == "string0")
+    }
+  }
+
+  @Test("resolves a null reference to nothing")
+  func nullReference() throws {
+    try ResolveTests.with { storage in
+      // TypeDef[1].Extends is the null reference (coded row 0), so it resolves
+      // to nothing.
+      let source = Tuple(1, ResolveTests.relations[1], storage)
+      let resolved: Bool = if let _ = try source.resolve(3) { true } else { false }
+      #expect(!resolved)
+    }
+  }
+
+  @Test("rejects resolving a non-foreign-key column")
+  func columnKindMismatch() throws {
+    ResolveTests.with { storage in
+      let source = Tuple(0, ResolveTests.relations[1], storage)
+      // Flags (ordinal 0) is a constant and TypeName (ordinal 1) is a string
+      // heap index; neither is a foreign key.
+      #expect(throws: WinMDError.InvalidColumn) { _ = try source.resolve(0) }
+      #expect(throws: WinMDError.InvalidColumn) { _ = try source.resolve(1) }
+    }
+  }
+
+  // A single TypeDef row whose `Extends` (ordinal 3, a `TypeDefOrRef` coded
+  // index) carries an out-of-range tag. `TypeDefOrRef` names three tables and
+  // uses two tag bits, so tag 3 is an unused bit pattern: `(1 << 2) | 3 = 7`
+  // encodes a non-null row (1) with `tag == coded.tables.count`.
+  private static let malformed: Array<UInt8> = [
+    // TypeDef[0]: Flags (4 bytes) = 0, TypeName = 0, TypeNamespace = 0,
+    //             Extends = 7, FieldList = 0, MethodList = 0.
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00,
+  ]
+
+  @Test("rejects a coded foreign key whose tag is out of range")
+  func codedIndexBadTag() throws {
+    let relations: Array<Table> = [
+      Table(Metadata.Tables.TypeDef.self, rows: 1, range: 0 ..< 14,
+            wide: 0, stride: 14),
+    ]
+    let storage = Storage(bytes: ResolveTests.malformed.span.bytes,
+                          relations: relations.span,
+                          strings: ResolveTests.empty.span.bytes,
+                          blob: ResolveTests.empty.span.bytes,
+                          guid: ResolveTests.empty.span.bytes,
+                          valid: 1 << 2)
+    let source = Tuple(0, relations[0], storage)
+    // `Extends` names a non-null row through tag 3, which selects no table; the
+    // resolve must throw rather than trap on the out-of-bounds table lookup.
+    #expect(throws: WinMDError.BadImageFormat) { _ = try source.resolve(3) }
+  }
+}

--- a/Tests/WinMDTests/ResolveTests.swift
+++ b/Tests/WinMDTests/ResolveTests.swift
@@ -141,6 +141,98 @@ struct ResolveTests {
     #expect(throws: WinMDError.BadImageFormat) { _ = try source.resolve(3) }
   }
 
+  @Test("rejects a TypeDefOrRef reference whose tag is out of range")
+  func resolveBadTag() throws {
+    // A signature can carry a `TypeDefOrRef` directly (not decoded out of a row's
+    // coded-index cell), and `Database.resolve(_:)` selects its target table by
+    // tag. `TypeDefOrRef` names three tables across two tag bits, so tag 3 is the
+    // unused pattern: `(1 << 2) | 3 = 7` is a non-null row (1) with tag 3.
+    let reference = TypeDefOrRef(rawValue: (1 << 2) | 3)
+    #expect(reference.row != 0)
+    #expect(reference.tag == TypeDefOrRef.tables.count)
+
+    let storage = Storage(bytes: ResolveTests.malformed.span.bytes,
+                          relations: ResolveTests.relations.span,
+                          strings: ResolveTests.strings.span.bytes,
+                          blob: ResolveTests.empty.span.bytes,
+                          guid: ResolveTests.empty.span.bytes,
+                          valid: ResolveTests.valid, sorted: 0)
+    // `Database.resolve(_:)`'s body, against an in-memory storage: the tag guard
+    // must reject the reference rather than trap on `TypeDefOrRef.tables[tag]`.
+    #expect(throws: WinMDError.BadImageFormat) {
+      guard reference.row != 0 else { return }
+      guard reference.tag < TypeDefOrRef.tables.count,
+          let schema = TypeDefOrRef.tables[reference.tag]
+      else { throw WinMDError.BadImageFormat }
+      _ = try storage.tuple(reference.row - 1, of: schema)
+    }
+  }
+
+  // `CustomAttributeType` is the one coded index with in-range reserved tags:
+  // it names five slots across three tag bits, but tags 0, 1, and 4 are reserved
+  // (modelled as `nil` table entries) and only 2 (`MethodDef`) and 3
+  // (`MemberRef`) are real. A `CustomAttribute` row (#12) whose `Type` (ordinal
+  // 1) carries a reserved tag must be rejected, not resolved to a stray table.
+  //
+  // CustomAttribute[0]: Parent = 0, Type = the coded cell under test, Value = 0;
+  // each cell a narrow (2-byte) index, so the stride is 6.
+  private static func attribute(_ type: Int) -> Array<UInt8> {
+    [0x00, 0x00, UInt8(type & 0xff), UInt8(type >> 8), 0x00, 0x00]
+  }
+
+  // A single MethodDef row (#6) so a valid tag-2 reference has a table to land
+  // on. The narrow stride is RVA (4) + ImplFlags (2) + Flags (2) + Name (2) +
+  // Signature (2) + ParamList (2) = 14; all cells zero.
+  private static let methodRow =
+      Array<UInt8>(repeating: 0, count: 14)
+
+  @Test("rejects a CustomAttributeType with a reserved tag")
+  func customAttributeReservedTag() throws {
+    // `Type` = `(1 << CustomAttributeType.bits) | 0`: row 1, tag 0 — reserved.
+    let reserved = (1 << CustomAttributeType.bits) | 0
+    let record = ResolveTests.attribute(reserved)
+    let relations: Array<Table> = [
+      Table(Metadata.Tables.CustomAttribute.self, rows: 1, range: 0 ..< 6,
+            wide: 0, stride: 6),
+    ]
+    let storage = Storage(bytes: record.span.bytes,
+                          relations: relations.span,
+                          strings: ResolveTests.empty.span.bytes,
+                          blob: ResolveTests.empty.span.bytes,
+                          guid: ResolveTests.empty.span.bytes,
+                          valid: 1 << 12, sorted: 0)
+    let source = Tuple(0, relations[0], storage)
+    // `Type` (ordinal 1) names a non-null row through a reserved tag; the resolve
+    // must throw rather than treat the reserved slot as a real table.
+    #expect(throws: WinMDError.BadImageFormat) { _ = try source.resolve(1) }
+  }
+
+  @Test("resolves a CustomAttributeType with a valid tag")
+  func customAttributeValidTag() throws {
+    // `Type` = `(1 << CustomAttributeType.bits) | 2`: row 1, tag 2 — `MethodDef`.
+    let valid = (1 << CustomAttributeType.bits) | 2
+    let record = ResolveTests.attribute(valid) + ResolveTests.methodRow
+    let relations: Array<Table> = [
+      // MethodDef (#6) before CustomAttribute (#12): relations are ordered by
+      // table number, so the lower-numbered table's row range comes first.
+      Table(Metadata.Tables.MethodDef.self, rows: 1, range: 6 ..< 20,
+            wide: 0, stride: 14),
+      Table(Metadata.Tables.CustomAttribute.self, rows: 1, range: 0 ..< 6,
+            wide: 0, stride: 6),
+    ]
+    let storage = Storage(bytes: record.span.bytes,
+                          relations: relations.span,
+                          strings: ResolveTests.empty.span.bytes,
+                          blob: ResolveTests.empty.span.bytes,
+                          guid: ResolveTests.empty.span.bytes,
+                          valid: (1 << 6) | (1 << 12), sorted: 0)
+    let source = Tuple(0, relations[1], storage)
+    guard let target = try source.resolve(1) else {
+      Issue.record("Type did not resolve"); return
+    }
+    #expect(target.count == Metadata.Tables.MethodDef.fields.count)
+  }
+
   // A single NestedClass row (#41) whose `NestedClass` (ordinal 0, a simple
   // `TypeDef` index) names row 999 — non-null but far past the single TypeDef
   // row. `storage.tuple` returns nil for the out-of-range row; resolution must
@@ -207,6 +299,35 @@ struct ResolveTests {
     // Non-null coded row, in-range tag, but the named TypeRef row does not exist;
     // `storage.tuple` returns nil and resolution must throw.
     #expect(throws: WinMDError.BadImageFormat) { _ = try source.resolve(3) }
+  }
+
+  @Test("rejects a TypeDefOrRef reference whose row is out of range")
+  func resolveOutOfRange() throws {
+    // A `TypeDefOrRef` carried in a signature with tag 1 (`TypeRef`) but row 999:
+    // `(999 << 2) | 1`. `Database.resolve(_:)`'s tag guard passes (the tag names
+    // a real table) but the row is past the one TypeRef row.
+    let reference = TypeDefOrRef(rawValue: (999 << 2) | 1)
+    #expect(reference.row == 999)
+    #expect(reference.tag < TypeDefOrRef.tables.count)
+
+    let storage = Storage(bytes: ResolveTests.record.span.bytes,
+                          relations: ResolveTests.relations.span,
+                          strings: ResolveTests.strings.span.bytes,
+                          blob: ResolveTests.empty.span.bytes,
+                          guid: ResolveTests.empty.span.bytes,
+                          valid: ResolveTests.valid, sorted: 0)
+    // `Database.resolve(_:)`'s body against an in-memory storage: the tag guard
+    // admits the reference, but the out-of-range row makes `storage.tuple` return
+    // nil, which must be surfaced as a malformed image.
+    #expect(throws: WinMDError.BadImageFormat) {
+      guard reference.row != 0 else { return }
+      guard reference.tag < TypeDefOrRef.tables.count,
+          let schema = TypeDefOrRef.tables[reference.tag]
+      else { throw WinMDError.BadImageFormat }
+      guard let _ = try storage.tuple(reference.row - 1, of: schema) else {
+        throw WinMDError.BadImageFormat
+      }
+    }
   }
 
   @Test("rejects a simple foreign key whose target table is absent")

--- a/Tests/WinMDTests/ResolveTests.swift
+++ b/Tests/WinMDTests/ResolveTests.swift
@@ -54,7 +54,7 @@ struct ResolveTests {
                           strings: ResolveTests.strings.span.bytes,
                           blob: ResolveTests.empty.span.bytes,
                           guid: ResolveTests.empty.span.bytes,
-                          valid: ResolveTests.valid)
+                          valid: ResolveTests.valid, sorted: 0)
     try body(storage)
   }
 
@@ -134,10 +134,170 @@ struct ResolveTests {
                           strings: ResolveTests.empty.span.bytes,
                           blob: ResolveTests.empty.span.bytes,
                           guid: ResolveTests.empty.span.bytes,
-                          valid: 1 << 2)
+                          valid: 1 << 2, sorted: 0)
     let source = Tuple(0, relations[0], storage)
     // `Extends` names a non-null row through tag 3, which selects no table; the
     // resolve must throw rather than trap on the out-of-bounds table lookup.
     #expect(throws: WinMDError.BadImageFormat) { _ = try source.resolve(3) }
+  }
+
+  // A single NestedClass row (#41) whose `NestedClass` (ordinal 0, a simple
+  // `TypeDef` index) names row 999 — non-null but far past the single TypeDef
+  // row. `storage.tuple` returns nil for the out-of-range row; resolution must
+  // surface that as a malformed image rather than as "no relationship".
+  @Test("rejects a simple foreign key whose row is out of range")
+  func simpleIndexOutOfRange() throws {
+    // TypeDef[0] (the target table) before NestedClass[0] (the source): the
+    // relations are ordered by table number. The NestedClass row points its
+    // `NestedClass` simple index at row 999, well past the one TypeDef row.
+    let row = 999
+    let record: Array<UInt8> = [
+      // NestedClass[0]: NestedClass = 999 (out of range), EnclosingClass = 0.
+      UInt8(row & 0xff), UInt8(row >> 8), 0x00, 0x00,
+      // TypeDef[0]: a 14-byte row, all zero (only the row count matters).
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00,
+    ]
+    let relations: Array<Table> = [
+      Table(Metadata.Tables.TypeDef.self, rows: 1, range: 4 ..< 18,
+            wide: 0, stride: 14),
+      Table(Metadata.Tables.NestedClass.self, rows: 1, range: 0 ..< 4,
+            wide: 0, stride: 4),
+    ]
+    let storage = Storage(bytes: record.span.bytes,
+                          relations: relations.span,
+                          strings: ResolveTests.empty.span.bytes,
+                          blob: ResolveTests.empty.span.bytes,
+                          guid: ResolveTests.empty.span.bytes,
+                          valid: (1 << 2) | (1 << 41), sorted: 0)
+    let source = Tuple(0, relations[1], storage)
+    // The index is non-null (so it is not the null-FK case) but out of range, so
+    // `storage.tuple` returns nil; resolution must throw rather than report no
+    // relationship.
+    #expect(throws: WinMDError.BadImageFormat) { _ = try source.resolve(0) }
+  }
+
+  @Test("rejects a coded foreign key whose row is out of range")
+  func codedIndexOutOfRange() throws {
+    // TypeDef[0].Extends (ordinal 3, a `TypeDefOrRef` coded index) names a
+    // non-null row through tag 1 (`TypeRef`), but row 999 is far past the single
+    // TypeRef row. Encoding: `(999 << 2) | 1`.
+    let row = (999 << 2) | 1
+    let record: Array<UInt8> = [
+      // TypeRef[0]: ResolutionScope, TypeName, TypeNamespace — all zero.
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      // TypeDef[0]: Flags (4) = 0, TypeName = 0, TypeNamespace = 0,
+      //             Extends = row, FieldList = 0, MethodList = 0.
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      UInt8(row & 0xff), UInt8(row >> 8), 0x00, 0x00, 0x00, 0x00,
+    ]
+    let relations: Array<Table> = [
+      Table(Metadata.Tables.TypeRef.self, rows: 1, range: 0 ..< 6,
+            wide: 0, stride: 6),
+      Table(Metadata.Tables.TypeDef.self, rows: 1, range: 6 ..< 20,
+            wide: 0, stride: 14),
+    ]
+    let storage = Storage(bytes: record.span.bytes,
+                          relations: relations.span,
+                          strings: ResolveTests.empty.span.bytes,
+                          blob: ResolveTests.empty.span.bytes,
+                          guid: ResolveTests.empty.span.bytes,
+                          valid: (1 << 1) | (1 << 2), sorted: 0)
+    let source = Tuple(0, relations[1], storage)
+    // Non-null coded row, in-range tag, but the named TypeRef row does not exist;
+    // `storage.tuple` returns nil and resolution must throw.
+    #expect(throws: WinMDError.BadImageFormat) { _ = try source.resolve(3) }
+  }
+
+  @Test("rejects a simple foreign key whose target table is absent")
+  func simpleIndexAbsentTable() throws {
+    // A NestedClass row (#41) whose `NestedClass` (ordinal 0, a simple `TypeDef`
+    // index) names a non-null row, but the `TypeDef` table (#2) is absent from
+    // the `Valid` mask. A dangling foreign-key target is a malformed image, not a
+    // missing user-requested table, so resolution must throw `.BadImageFormat`
+    // (not `.TableNotFound`).
+    let record: Array<UInt8> = [
+      // NestedClass[0]: NestedClass = 1 (non-null), EnclosingClass = 0.
+      0x01, 0x00, 0x00, 0x00,
+    ]
+    let relations: Array<Table> = [
+      Table(Metadata.Tables.NestedClass.self, rows: 1, range: 0 ..< 4,
+            wide: 0, stride: 4),
+    ]
+    let storage = Storage(bytes: record.span.bytes,
+                          relations: relations.span,
+                          strings: ResolveTests.empty.span.bytes,
+                          blob: ResolveTests.empty.span.bytes,
+                          guid: ResolveTests.empty.span.bytes,
+                          valid: 1 << 41, sorted: 0)
+    let source = Tuple(0, relations[0], storage)
+    // The index is non-null, but its target `TypeDef` table is absent; resolution
+    // must surface that as a malformed image.
+    #expect(throws: WinMDError.BadImageFormat) { _ = try source.resolve(0) }
+  }
+
+  @Test("rejects a coded foreign key whose target table is absent")
+  func codedIndexAbsentTable() throws {
+    // TypeDef[0].Extends (ordinal 3, a `TypeDefOrRef` coded index) names a
+    // non-null row through tag 1 (`TypeRef`), but the `TypeRef` table (#1) is
+    // absent from the `Valid` mask. Encoding: `(1 << 2) | 1 = 5`.
+    let record: Array<UInt8> = [
+      // TypeDef[0]: Flags (4) = 0, TypeName = 0, TypeNamespace = 0,
+      //             Extends = 5, FieldList = 0, MethodList = 0.
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x05, 0x00, 0x00, 0x00, 0x00, 0x00,
+    ]
+    let relations: Array<Table> = [
+      Table(Metadata.Tables.TypeDef.self, rows: 1, range: 0 ..< 14,
+            wide: 0, stride: 14),
+    ]
+    let storage = Storage(bytes: record.span.bytes,
+                          relations: relations.span,
+                          strings: ResolveTests.empty.span.bytes,
+                          blob: ResolveTests.empty.span.bytes,
+                          guid: ResolveTests.empty.span.bytes,
+                          valid: 1 << 2, sorted: 0)
+    let source = Tuple(0, relations[0], storage)
+    // Non-null coded row, in-range tag, but the named `TypeRef` table is absent;
+    // resolution must throw rather than report no relationship.
+    #expect(throws: WinMDError.BadImageFormat) { _ = try source.resolve(3) }
+  }
+
+  @Test("rejects a TypeDefOrRef reference whose target table is absent")
+  func resolveAbsentTable() throws {
+    // A `TypeDefOrRef` carried in a signature with tag 1 (`TypeRef`) and row 1:
+    // `(1 << 2) | 1`. `Database.resolve(_:)`'s tag guard passes (the tag names a
+    // real table), but the `TypeRef` table is absent from the `Valid` mask.
+    let reference = TypeDefOrRef(rawValue: (1 << 2) | 1)
+    #expect(reference.row == 1)
+    #expect(reference.tag < TypeDefOrRef.tables.count)
+
+    let record: Array<UInt8> = [
+      // TypeDef[0]: a 14-byte row, all zero (only the row count matters).
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00,
+    ]
+    let relations: Array<Table> = [
+      Table(Metadata.Tables.TypeDef.self, rows: 1, range: 0 ..< 14,
+            wide: 0, stride: 14),
+    ]
+    let storage = Storage(bytes: record.span.bytes,
+                          relations: relations.span,
+                          strings: ResolveTests.empty.span.bytes,
+                          blob: ResolveTests.empty.span.bytes,
+                          guid: ResolveTests.empty.span.bytes,
+                          valid: 1 << 2, sorted: 0)
+    // `Database.resolve(_:)`'s body against an in-memory storage: the tag guard
+    // admits the reference, but the absent target table makes `storage.tuple`
+    // return nil, which must be surfaced as a malformed image.
+    #expect(throws: WinMDError.BadImageFormat) {
+      guard reference.row != 0 else { return }
+      guard reference.tag < TypeDefOrRef.tables.count,
+          let schema = TypeDefOrRef.tables[reference.tag]
+      else { throw WinMDError.BadImageFormat }
+      guard let _ = try storage.tuple(reference.row - 1, of: schema) else {
+        throw WinMDError.BadImageFormat
+      }
+    }
   }
 }

--- a/Tests/WinMDTests/SignatureTests.swift
+++ b/Tests/WinMDTests/SignatureTests.swift
@@ -1,0 +1,799 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import WinMD
+
+// The element-type opcodes the fixtures use, by their ECMA-335 §II.23.1.16
+// values, so the byte arrays read as the spec spells them.
+private let DEFAULT: UInt8 = 0x00
+private let HASTHIS: UInt8 = 0x20
+private let EXPLICITTHIS: UInt8 = 0x40
+private let FIELD: UInt8 = 0x06
+private let VOID: UInt8 = 0x01
+private let I4: UInt8 = 0x08
+private let U4: UInt8 = 0x09
+private let STRING: UInt8 = 0x0e
+private let PTR: UInt8 = 0x0f
+private let BYREF: UInt8 = 0x10
+private let VALUETYPE: UInt8 = 0x11
+private let CLASS: UInt8 = 0x12
+private let ARRAY: UInt8 = 0x14
+private let SZARRAY: UInt8 = 0x1d
+private let CMOD_OPT: UInt8 = 0x20
+
+// A `TypeDefOrRefOrSpec` coded index, compressed: low two bits the tag, the
+// rest the 1-based row. `TypeRef[0]` is `(1 << 2) | 1 == 5`.
+private let typeref0: UInt8 = 0x05
+
+// ECMA-335 §II.23.2 signature decoding. The fixtures are hand-built signature
+// blobs — the raw `#Blob` bytes, without the heap length prefix — decoded
+// directly through `SignatureDecoder`; the accessor tests additionally wrap a
+// signature in a one-blob `#Blob` heap and reach it through a `Row`.
+struct SignatureTests {
+  @Test("decodes (i4, string) -> void")
+  func methodPrimitives() throws {
+    var bytes = [DEFAULT, 0x02, VOID, I4, STRING]
+    var decoder = SignatureDecoder(bytes.span.bytes)
+    let signature = try decoder.method()
+
+    #expect(signature.convention == .default)
+    #expect(!signature.instance)
+    #expect(signature.generics == 0)
+    guard case .primitive(.void) = signature.returns else {
+      Issue.record("return not void"); return
+    }
+    #expect(signature.parameters.count == 2)
+    guard case .primitive(.int4) = signature.parameters[0],
+        case .primitive(.string) = signature.parameters[1] else {
+      Issue.record("parameters not (i4, string)"); return
+    }
+  }
+
+  @Test("decodes the HASTHIS instance flag")
+  func methodInstance() throws {
+    var bytes = [HASTHIS | DEFAULT, 0x00, VOID]
+    var decoder = SignatureDecoder(bytes.span.bytes)
+    let signature = try decoder.method()
+    #expect(signature.instance)
+    #expect(signature.parameters.isEmpty)
+  }
+
+  @Test("decodes a pointer parameter")
+  func pointerParameter() throws {
+    var bytes = [DEFAULT, 0x01, VOID, PTR, I4]
+    var decoder = SignatureDecoder(bytes.span.bytes)
+    let signature = try decoder.method()
+    guard case let .pointer(pointee) = signature.parameters[0],
+        case .primitive(.int4) = pointee else {
+      Issue.record("parameter not i4*"); return
+    }
+  }
+
+  @Test("decodes a byref parameter")
+  func byrefParameter() throws {
+    var bytes = [DEFAULT, 0x01, VOID, BYREF, U4]
+    var decoder = SignatureDecoder(bytes.span.bytes)
+    let signature = try decoder.method()
+    guard case let .reference(referent) = signature.parameters[0],
+        case .primitive(.uint4) = referent else {
+      Issue.record("parameter not ref u4"); return
+    }
+  }
+
+  @Test("decodes an SZARRAY return")
+  func arrayReturn() throws {
+    var bytes = [DEFAULT, 0x00, SZARRAY, I4]
+    var decoder = SignatureDecoder(bytes.span.bytes)
+    let signature = try decoder.method()
+    guard case let .array(element) = signature.returns,
+        case .primitive(.int4) = element else {
+      Issue.record("return not i4[]"); return
+    }
+  }
+
+  @Test("decodes a CLASS parameter via a coded index")
+  func namedParameter() throws {
+    var bytes = [DEFAULT, 0x01, VOID, CLASS, typeref0]
+    var decoder = SignatureDecoder(bytes.span.bytes)
+    let signature = try decoder.method()
+    guard case let .named(kind, reference) = signature.parameters[0] else {
+      Issue.record("parameter not a named type"); return
+    }
+    #expect(kind == .class)
+    // `TypeRef[0]`: tag 1 (the second of TypeDef/TypeRef/TypeSpec), row 1.
+    #expect(reference.tag == 1)
+    #expect(reference.row == 1)
+  }
+
+  @Test("decodes a custom-modified parameter")
+  func modifiedParameter() throws {
+    // `const`-modified value type: CMOD_OPT TypeRef[0], then VALUETYPE TypeRef[0].
+    var bytes = [DEFAULT, 0x01, VOID, CMOD_OPT, typeref0, VALUETYPE, typeref0]
+    var decoder = SignatureDecoder(bytes.span.bytes)
+    let signature = try decoder.method()
+    guard case let .modified(base, modifiers) = signature.parameters[0] else {
+      Issue.record("parameter not modified"); return
+    }
+    #expect(modifiers.count == 1)
+    #expect(!modifiers[0].required)
+    #expect(modifiers[0].type.tag == 1)
+    guard case .named(.value, _) = base else {
+      Issue.record("modified base not a value type"); return
+    }
+  }
+
+  @Test("decodes a field signature")
+  func field() throws {
+    var bytes = [FIELD, I4]
+    var decoder = SignatureDecoder(bytes.span.bytes)
+    let signature = try decoder.field()
+    guard case .primitive(.int4) = signature.type else {
+      Issue.record("field not i4"); return
+    }
+  }
+
+  @Test("rejects an unknown element type")
+  func malformed() {
+    var bytes = [DEFAULT, 0x00, 0xff]
+    var decoder = SignatureDecoder(bytes.span.bytes)
+    #expect(throws: WinMDError.BadImageFormat) { _ = try decoder.method() }
+  }
+
+  @Test("rejects an unsupported calling convention")
+  func unsupportedConvention() {
+    // The prolog's low nibble names the calling convention (ECMA-335 §II.23.2.1);
+    // 0x09 and 0x0f are not defined values, so the decoder must reject them rather
+    // than silently treating them as the DEFAULT convention.
+    var nine = [0x09 as UInt8, 0x00, VOID]
+    var nineDecoder = SignatureDecoder(nine.span.bytes)
+    #expect(throws: WinMDError.BadImageFormat) { _ = try nineDecoder.method() }
+
+    var fifteen = [0x0f as UInt8, 0x00, VOID]
+    var fifteenDecoder = SignatureDecoder(fifteen.span.bytes)
+    #expect(throws: WinMDError.BadImageFormat) { _ = try fifteenDecoder.method() }
+  }
+
+  @Test("rejects a truncated signature")
+  func truncated() {
+    var bytes = [DEFAULT, 0x01, VOID]    // missing the parameter
+    var decoder = SignatureDecoder(bytes.span.bytes)
+    #expect(throws: WinMDError.BadImageFormat) { _ = try decoder.method() }
+  }
+
+  @Test("rejects an invalid compressed-integer lead byte")
+  func compressedLeadByte() {
+    // The parameter count is a compressed integer; `0xe0` is `111xxxxx`, not a
+    // defined encoding, so decoding must fault rather than read past the blob.
+    var bytes = [DEFAULT, 0xe0, VOID]
+    var decoder = SignatureDecoder(bytes.span.bytes)
+    #expect(throws: WinMDError.BadImageFormat) { _ = try decoder.method() }
+  }
+
+  @Test("rejects a compressed integer running off the blob end")
+  func compressedTruncated() {
+    // `0x80` opens a 2-byte encoding but no second byte follows; `0xc0` opens a
+    // 4-byte one with only one byte left. Either must fault, not crash.
+    var two = [DEFAULT, 0x80]
+    var twoDecoder = SignatureDecoder(two.span.bytes)
+    #expect(throws: WinMDError.BadImageFormat) { _ = try twoDecoder.method() }
+
+    var four = [DEFAULT, 0xc0]
+    var fourDecoder = SignatureDecoder(four.span.bytes)
+    #expect(throws: WinMDError.BadImageFormat) { _ = try fourDecoder.method() }
+  }
+
+  @Test("decodes a multidimensional ARRAY's negative lower bound")
+  func matrixNegativeBound() throws {
+    // `i4[*]` returning from a method: rank 1, no explicit sizes, one lower
+    // bound of -3 (compressed signed `0x7b`, ECMA-335 §II.23.2).
+    var bytes = [DEFAULT, 0x00, ARRAY, I4, 0x01, 0x00, 0x01, 0x7b]
+    var decoder = SignatureDecoder(bytes.span.bytes)
+    let signature = try decoder.method()
+    guard case let .matrix(element, shape) = signature.returns,
+        case .primitive(.int4) = element else {
+      Issue.record("return not an i4 matrix"); return
+    }
+    #expect(shape.rank == 1)
+    #expect(shape.sizes.isEmpty)
+    #expect(shape.bounds == [-3])
+  }
+
+  @Test("decodes a multidimensional ARRAY's 4-byte negative lower bound")
+  func matrixWideNegativeBound() throws {
+    // A lower bound whose magnitude exceeds 2^13 needs the 4-byte compressed
+    // signed form, which carries 29 payload bits (5 in the lead byte + 24
+    // following), so the negative correction subtracts 2^28. The bound -16384
+    // (magnitude 16384 > 2^13) encodes rotated to value 536838145, i.e. the
+    // 4-byte big-endian word `0xdf 0xff 0x80 0x01` (ECMA-335 §II.23.2). A
+    // 28-bit correction would decode it 2^27 (134217728) too high.
+    var bytes =
+        [DEFAULT, 0x00, ARRAY, I4, 0x01, 0x00, 0x01, 0xdf, 0xff, 0x80, 0x01]
+    var decoder = SignatureDecoder(bytes.span.bytes)
+    let signature = try decoder.method()
+    guard case let .matrix(element, shape) = signature.returns,
+        case .primitive(.int4) = element else {
+      Issue.record("return not an i4 matrix"); return
+    }
+    #expect(shape.rank == 1)
+    #expect(shape.sizes.isEmpty)
+    #expect(shape.bounds == [-16384])
+  }
+
+  @Test("rejects an ARRAY with more sizes than its rank")
+  func matrixTooManySizes() {
+    // ECMA-335 §II.23.2.13 constrains `NumSizes` to `<= Rank`. Here rank is 1 but
+    // NumSizes is 2 (two sizes, no lower bounds) — the decoder must reject it.
+    var bytes = [DEFAULT, 0x00, ARRAY, I4, 0x01, 0x02, 0x01, 0x02, 0x00]
+    var decoder = SignatureDecoder(bytes.span.bytes)
+    #expect(throws: WinMDError.BadImageFormat) { _ = try decoder.method() }
+  }
+
+  @Test("rejects an ARRAY with more lower bounds than its rank")
+  func matrixTooManyBounds() {
+    // Likewise `NumLoBounds` must be `<= Rank`. Rank is 1 but NumLoBounds is 2
+    // (no sizes, two bounds) — the decoder must reject it.
+    var bytes = [DEFAULT, 0x00, ARRAY, I4, 0x01, 0x00, 0x02, 0x01, 0x02]
+    var decoder = SignatureDecoder(bytes.span.bytes)
+    #expect(throws: WinMDError.BadImageFormat) { _ = try decoder.method() }
+  }
+
+  @Test("decodes a well-formed ARRAY at its rank's limits")
+  func matrixWellFormed() throws {
+    // Rank 2 with NumSizes 2 and NumLoBounds 2 — both at the rank limit — decodes
+    // to a 2x3 matrix lower-bounded at (0, 1).
+    var bytes =
+        [DEFAULT, 0x00, ARRAY, I4, 0x02, 0x02, 0x02, 0x03, 0x02, 0x00, 0x02]
+    var decoder = SignatureDecoder(bytes.span.bytes)
+    let signature = try decoder.method()
+    guard case let .matrix(element, shape) = signature.returns,
+        case .primitive(.int4) = element else {
+      Issue.record("return not an i4 matrix"); return
+    }
+    #expect(shape.rank == 2)
+    #expect(shape.sizes == [2, 3])
+    #expect(shape.bounds == [0, 1])
+  }
+
+  @Test("rejects a zero-rank ARRAY")
+  func matrixZeroRank() {
+    // ECMA-335 §II.23.2.13 requires `Rank >= 1`. Here rank is 0 (with no sizes
+    // and no lower bounds); both `<= Rank` guards pass vacuously, so the rank
+    // guard itself must reject it.
+    var bytes = [DEFAULT, 0x00, ARRAY, I4, 0x00, 0x00, 0x00]
+    var decoder = SignatureDecoder(bytes.span.bytes)
+    #expect(throws: WinMDError.BadImageFormat) { _ = try decoder.method() }
+  }
+
+  @Test("rejects EXPLICITTHIS without HASTHIS")
+  func methodExplicitWithoutInstance() {
+    // ECMA-335 §II.23.2.1: EXPLICITTHIS (0x40) is only valid alongside HASTHIS
+    // (0x20). A prolog of 0x40 alone — explicit but not instance — is malformed.
+    var bytes = [EXPLICITTHIS | DEFAULT, 0x00, VOID]
+    var decoder = SignatureDecoder(bytes.span.bytes)
+    #expect(throws: WinMDError.BadImageFormat) { _ = try decoder.method() }
+  }
+
+  @Test("decodes EXPLICITTHIS alongside HASTHIS")
+  func methodExplicitInstance() throws {
+    // A prolog of 0x60 sets both HASTHIS and EXPLICITTHIS, which is well-formed.
+    var bytes = [EXPLICITTHIS | HASTHIS | DEFAULT, 0x00, VOID]
+    var decoder = SignatureDecoder(bytes.span.bytes)
+    let signature = try decoder.method()
+    #expect(signature.instance)
+    #expect(signature.explicit)
+  }
+
+  // MARK: - Accessors through a Row
+
+  // A `MethodDef` row whose `Signature` cell (ordinal 4) is the heap offset 0;
+  // the blob heap there holds `DEFAULT, 0, VOID` — `() -> void`. The other cells
+  // are zero. The narrow stride is RVA (4) + ImplFlags (2) + Flags (2) + three
+  // 2-byte indices = 14.
+  private static let method: Array<UInt8> = [
+    0x00, 0x00, 0x00, 0x00,    // RVA
+    0x00, 0x00,                // ImplFlags
+    0x00, 0x00,                // Flags
+    0x00, 0x00,                // Name
+    0x00, 0x00,                // Signature (heap offset 0)
+    0x00, 0x00,                // ParamList
+  ]
+
+  // A blob heap: a single blob at offset 0, length-prefixed.
+  private static let methodBlob: Array<UInt8> = [0x03, DEFAULT, 0x00, VOID]
+
+  // A `FieldDef` row whose `Signature` cell (ordinal 2) is the heap offset 0.
+  // The narrow stride is Flags (2) + two 2-byte indices = 6.
+  private static let fieldRecord: Array<UInt8> = [
+    0x00, 0x00,                // Flags
+    0x00, 0x00,                // Name
+    0x00, 0x00,                // Signature (heap offset 0)
+  ]
+
+  // A blob heap holding `FIELD, I4`, length-prefixed.
+  private static let fieldBlob: Array<UInt8> = [0x02, FIELD, I4]
+
+  private static let empty = Array<UInt8>()
+
+  @Test("decodes a MethodDef signature through the row accessor")
+  func methodAccessor() throws {
+    let relations =
+        [Table(Metadata.Tables.MethodDef.self, rows: 1, range: 0 ..< 14,
+               wide: 0, stride: 14)]
+    let storage = Storage(bytes: SignatureTests.method.span.bytes,
+                          relations: relations.span,
+                          strings: SignatureTests.empty.span.bytes,
+                          blob: SignatureTests.methodBlob.span.bytes,
+                          guid: SignatureTests.empty.span.bytes,
+                          valid: 1 << 6, sorted: 0)
+    let rows = try storage.rows(of: Metadata.Tables.MethodDef.self)
+    let signature = try rows[0]!.prototype
+    guard case .primitive(.void) = signature.returns else {
+      Issue.record("return not void"); return
+    }
+    #expect(signature.parameters.isEmpty)
+  }
+
+  @Test("decodes a FieldDef signature through the row accessor")
+  func fieldAccessor() throws {
+    let relations =
+        [Table(Metadata.Tables.FieldDef.self, rows: 1, range: 0 ..< 6,
+               wide: 0, stride: 6)]
+    let storage = Storage(bytes: SignatureTests.fieldRecord.span.bytes,
+                          relations: relations.span,
+                          strings: SignatureTests.empty.span.bytes,
+                          blob: SignatureTests.fieldBlob.span.bytes,
+                          guid: SignatureTests.empty.span.bytes,
+                          valid: 1 << 4, sorted: 0)
+    let rows = try storage.rows(of: Metadata.Tables.FieldDef.self)
+    let signature = try rows[0]!.declaration
+    guard case .primitive(.int4) = signature.type else {
+      Issue.record("field not i4"); return
+    }
+  }
+
+  // A field signature whose prolog is `FIELD | GENERIC` (`0x16`): the `GENERIC`
+  // high bit is a method-signature flag, invalid on a field, whose first byte
+  // must be exactly `0x06` (ECMA-335 §II.23.2.4). The masked check accepted it;
+  // the exact check rejects it.
+  private static let fieldGenericBlob: Array<UInt8> = [0x02, 0x16, I4]
+
+  // A field signature whose prolog is `FIELD | HASTHIS` (`0x26`): the `HASTHIS`
+  // high bit is likewise a method-signature flag, invalid on a field.
+  private static let fieldHasThisBlob: Array<UInt8> = [0x02, 0x26, I4]
+
+  @Test("rejects a field signature whose prolog carries the GENERIC flag")
+  func fieldGenericProlog() throws {
+    let relations =
+        [Table(Metadata.Tables.FieldDef.self, rows: 1, range: 0 ..< 6,
+               wide: 0, stride: 6)]
+    let storage = Storage(bytes: SignatureTests.fieldRecord.span.bytes,
+                          relations: relations.span,
+                          strings: SignatureTests.empty.span.bytes,
+                          blob: SignatureTests.fieldGenericBlob.span.bytes,
+                          guid: SignatureTests.empty.span.bytes,
+                          valid: 1 << 4, sorted: 0)
+    let rows = try storage.rows(of: Metadata.Tables.FieldDef.self)
+    #expect(throws: WinMDError.BadImageFormat) { _ = try rows[0]!.declaration }
+  }
+
+  @Test("rejects a field signature whose prolog carries the HASTHIS flag")
+  func fieldHasThisProlog() throws {
+    let relations =
+        [Table(Metadata.Tables.FieldDef.self, rows: 1, range: 0 ..< 6,
+               wide: 0, stride: 6)]
+    let storage = Storage(bytes: SignatureTests.fieldRecord.span.bytes,
+                          relations: relations.span,
+                          strings: SignatureTests.empty.span.bytes,
+                          blob: SignatureTests.fieldHasThisBlob.span.bytes,
+                          guid: SignatureTests.empty.span.bytes,
+                          valid: 1 << 4, sorted: 0)
+    let rows = try storage.rows(of: Metadata.Tables.FieldDef.self)
+    #expect(throws: WinMDError.BadImageFormat) { _ = try rows[0]!.declaration }
+  }
+
+  // A blob holding a valid `DEFAULT, 0, VOID` method signature followed by a
+  // stray byte; the top-level accessor must consume the whole blob and reject
+  // the trailing byte as malformed metadata, not silently ignore it.
+  private static let methodTrailingBlob: Array<UInt8> =
+      [0x04, DEFAULT, 0x00, VOID, 0xff]
+
+  // A blob with a valid `FIELD, I4` field signature followed by a stray byte.
+  private static let fieldTrailingBlob: Array<UInt8> =
+      [0x03, FIELD, I4, 0xff]
+
+  @Test("rejects a method signature with trailing bytes")
+  func methodTrailingBytes() throws {
+    let relations =
+        [Table(Metadata.Tables.MethodDef.self, rows: 1, range: 0 ..< 14,
+               wide: 0, stride: 14)]
+    let storage = Storage(bytes: SignatureTests.method.span.bytes,
+                          relations: relations.span,
+                          strings: SignatureTests.empty.span.bytes,
+                          blob: SignatureTests.methodTrailingBlob.span.bytes,
+                          guid: SignatureTests.empty.span.bytes,
+                          valid: 1 << 6, sorted: 0)
+    let rows = try storage.rows(of: Metadata.Tables.MethodDef.self)
+    #expect(throws: WinMDError.BadImageFormat) { _ = try rows[0]!.prototype }
+  }
+
+  @Test("rejects a field signature with trailing bytes")
+  func fieldTrailingBytes() throws {
+    let relations =
+        [Table(Metadata.Tables.FieldDef.self, rows: 1, range: 0 ..< 6,
+               wide: 0, stride: 6)]
+    let storage = Storage(bytes: SignatureTests.fieldRecord.span.bytes,
+                          relations: relations.span,
+                          strings: SignatureTests.empty.span.bytes,
+                          blob: SignatureTests.fieldTrailingBlob.span.bytes,
+                          guid: SignatureTests.empty.span.bytes,
+                          valid: 1 << 4, sorted: 0)
+    let rows = try storage.rows(of: Metadata.Tables.FieldDef.self)
+    #expect(throws: WinMDError.BadImageFormat) { _ = try rows[0]!.declaration }
+  }
+
+  // A method blob whose prolog sets the reserved high bit `0x80`: the only
+  // valid prolog bits are the low-nibble convention plus GENERIC/HASTHIS/
+  // EXPLICITTHIS (ECMA-335 §II.23.2.1), so the reserved bit is malformed.
+  private static let reservedPrologBlob: Array<UInt8> =
+      [0x03, 0x80, 0x00, VOID]
+
+  // Method blobs whose prolog's low nibble names a non-method convention —
+  // FIELD (0x06), LOCAL_SIG (0x07), PROPERTY (0x08); a `MethodSignature` opens
+  // only with a method convention, so each is malformed.
+  private static let fieldConventionBlob: Array<UInt8> =
+      [0x03, 0x06, 0x00, VOID]
+  private static let localConventionBlob: Array<UInt8> =
+      [0x03, 0x07, 0x00, VOID]
+  private static let propertyConventionBlob: Array<UInt8> =
+      [0x03, 0x08, 0x00, VOID]
+
+  @Test("rejects a method prolog with the reserved high bit set")
+  func reservedProlog() throws {
+    let relations =
+        [Table(Metadata.Tables.MethodDef.self, rows: 1, range: 0 ..< 14,
+               wide: 0, stride: 14)]
+    let storage = Storage(bytes: SignatureTests.method.span.bytes,
+                          relations: relations.span,
+                          strings: SignatureTests.empty.span.bytes,
+                          blob: SignatureTests.reservedPrologBlob.span.bytes,
+                          guid: SignatureTests.empty.span.bytes,
+                          valid: 1 << 6, sorted: 0)
+    let rows = try storage.rows(of: Metadata.Tables.MethodDef.self)
+    #expect(throws: WinMDError.BadImageFormat) { _ = try rows[0]!.prototype }
+  }
+
+  @Test("rejects a method prolog naming the FIELD convention")
+  func fieldConvention() throws {
+    let relations =
+        [Table(Metadata.Tables.MethodDef.self, rows: 1, range: 0 ..< 14,
+               wide: 0, stride: 14)]
+    let storage = Storage(bytes: SignatureTests.method.span.bytes,
+                          relations: relations.span,
+                          strings: SignatureTests.empty.span.bytes,
+                          blob: SignatureTests.fieldConventionBlob.span.bytes,
+                          guid: SignatureTests.empty.span.bytes,
+                          valid: 1 << 6, sorted: 0)
+    let rows = try storage.rows(of: Metadata.Tables.MethodDef.self)
+    #expect(throws: WinMDError.BadImageFormat) { _ = try rows[0]!.prototype }
+  }
+
+  @Test("rejects a method prolog naming the LOCAL_SIG convention")
+  func localConvention() throws {
+    let relations =
+        [Table(Metadata.Tables.MethodDef.self, rows: 1, range: 0 ..< 14,
+               wide: 0, stride: 14)]
+    let storage = Storage(bytes: SignatureTests.method.span.bytes,
+                          relations: relations.span,
+                          strings: SignatureTests.empty.span.bytes,
+                          blob: SignatureTests.localConventionBlob.span.bytes,
+                          guid: SignatureTests.empty.span.bytes,
+                          valid: 1 << 6, sorted: 0)
+    let rows = try storage.rows(of: Metadata.Tables.MethodDef.self)
+    #expect(throws: WinMDError.BadImageFormat) { _ = try rows[0]!.prototype }
+  }
+
+  @Test("rejects a method prolog naming the PROPERTY convention")
+  func propertyConvention() throws {
+    let relations =
+        [Table(Metadata.Tables.MethodDef.self, rows: 1, range: 0 ..< 14,
+               wide: 0, stride: 14)]
+    let storage = Storage(bytes: SignatureTests.method.span.bytes,
+                          relations: relations.span,
+                          strings: SignatureTests.empty.span.bytes,
+                          blob: SignatureTests.propertyConventionBlob.span.bytes,
+                          guid: SignatureTests.empty.span.bytes,
+                          valid: 1 << 6, sorted: 0)
+    let rows = try storage.rows(of: Metadata.Tables.MethodDef.self)
+    #expect(throws: WinMDError.BadImageFormat) { _ = try rows[0]!.prototype }
+  }
+
+  // MARK: - The signature accessors validate the #Blob entry
+
+  // A blob heap whose entry at offset 0 opens with a length-prefix lead byte
+  // `0xe0` — `111xxxxx`, not a defined compressed encoding (ECMA-335 §II.23.2).
+  // Opening it must throw, not trap reading a nonsense length.
+  private static let badPrefixBlob: Array<UInt8> = [0xe0, DEFAULT, 0x00, VOID]
+
+  // A blob heap whose entry's length prefix (`0x7f` — 1 byte, value 127) runs
+  // far past the 1-byte payload actually present, so the delimited extent
+  // exceeds the heap. Opening it must throw, not read out of bounds.
+  private static let longPrefixBlob: Array<UInt8> = [0x7f, DEFAULT]
+
+  @Test("rejects a #Blob signature entry with an invalid length-prefix lead")
+  func methodAccessorBadPrefix() throws {
+    let relations =
+        [Table(Metadata.Tables.MethodDef.self, rows: 1, range: 0 ..< 14,
+               wide: 0, stride: 14)]
+    let storage = Storage(bytes: SignatureTests.method.span.bytes,
+                          relations: relations.span,
+                          strings: SignatureTests.empty.span.bytes,
+                          blob: SignatureTests.badPrefixBlob.span.bytes,
+                          guid: SignatureTests.empty.span.bytes,
+                          valid: 1 << 6, sorted: 0)
+    let rows = try storage.rows(of: Metadata.Tables.MethodDef.self)
+    #expect(throws: WinMDError.BadImageFormat) { _ = try rows[0]!.prototype }
+  }
+
+  @Test("rejects a #Blob signature entry whose length runs past the heap")
+  func methodAccessorLongPrefix() throws {
+    let relations =
+        [Table(Metadata.Tables.MethodDef.self, rows: 1, range: 0 ..< 14,
+               wide: 0, stride: 14)]
+    let storage = Storage(bytes: SignatureTests.method.span.bytes,
+                          relations: relations.span,
+                          strings: SignatureTests.empty.span.bytes,
+                          blob: SignatureTests.longPrefixBlob.span.bytes,
+                          guid: SignatureTests.empty.span.bytes,
+                          valid: 1 << 6, sorted: 0)
+    let rows = try storage.rows(of: Metadata.Tables.MethodDef.self)
+    #expect(throws: WinMDError.BadImageFormat) { _ = try rows[0]!.prototype }
+  }
+
+  @Test("rejects a #Blob field entry with an invalid length-prefix lead")
+  func fieldAccessorBadPrefix() throws {
+    let relations =
+        [Table(Metadata.Tables.FieldDef.self, rows: 1, range: 0 ..< 6,
+               wide: 0, stride: 6)]
+    let storage = Storage(bytes: SignatureTests.fieldRecord.span.bytes,
+                          relations: relations.span,
+                          strings: SignatureTests.empty.span.bytes,
+                          blob: SignatureTests.badPrefixBlob.span.bytes,
+                          guid: SignatureTests.empty.span.bytes,
+                          valid: 1 << 4, sorted: 0)
+    let rows = try storage.rows(of: Metadata.Tables.FieldDef.self)
+    #expect(throws: WinMDError.BadImageFormat) { _ = try rows[0]!.declaration }
+  }
+
+  @Test("rejects a #Blob field entry whose length runs past the heap")
+  func fieldAccessorLongPrefix() throws {
+    let relations =
+        [Table(Metadata.Tables.FieldDef.self, rows: 1, range: 0 ..< 6,
+               wide: 0, stride: 6)]
+    let storage = Storage(bytes: SignatureTests.fieldRecord.span.bytes,
+                          relations: relations.span,
+                          strings: SignatureTests.empty.span.bytes,
+                          blob: SignatureTests.longPrefixBlob.span.bytes,
+                          guid: SignatureTests.empty.span.bytes,
+                          valid: 1 << 4, sorted: 0)
+    let rows = try storage.rows(of: Metadata.Tables.FieldDef.self)
+    #expect(throws: WinMDError.BadImageFormat) { _ = try rows[0]!.declaration }
+  }
+
+  @Test("a well-formed #Blob signature entry still decodes through the accessor")
+  func methodAccessorWellFormed() throws {
+    let relations =
+        [Table(Metadata.Tables.MethodDef.self, rows: 1, range: 0 ..< 14,
+               wide: 0, stride: 14)]
+    let storage = Storage(bytes: SignatureTests.method.span.bytes,
+                          relations: relations.span,
+                          strings: SignatureTests.empty.span.bytes,
+                          blob: SignatureTests.methodBlob.span.bytes,
+                          guid: SignatureTests.empty.span.bytes,
+                          valid: 1 << 6, sorted: 0)
+    let rows = try storage.rows(of: Metadata.Tables.MethodDef.self)
+    let signature = try rows[0]!.prototype
+    guard case .primitive(.void) = signature.returns else {
+      Issue.record("return not void"); return
+    }
+    #expect(signature.parameters.isEmpty)
+  }
+
+  // MARK: - VOID is positional
+
+  // A method blob `DEFAULT, count 1, I4 return, VOID parameter`: VOID names the
+  // absent type, legal only as a return or a pointer's pointee (ECMA-335
+  // §II.23.2.12), so a standalone VOID parameter is malformed metadata.
+  private static let voidParameterBlob: Array<UInt8> =
+      [0x04, DEFAULT, 0x01, I4, VOID]
+
+  // A field blob `FIELD, VOID`: a field can never have the absent type.
+  private static let voidFieldBlob: Array<UInt8> = [0x02, FIELD, VOID]
+
+  // A method blob `DEFAULT, count 0, VOID return`: VOID is legal as a return.
+  private static let voidReturnBlob: Array<UInt8> =
+      [0x03, DEFAULT, 0x00, VOID]
+
+  // A method blob `DEFAULT, count 1, I4 return, PTR VOID parameter`: `void*`
+  // (PVOID/LPVOID) stays legal — VOID is the pointee of a PTR.
+  private static let voidPointerBlob: Array<UInt8> =
+      [0x05, DEFAULT, 0x01, I4, PTR, VOID]
+
+  @Test("rejects a VOID method parameter")
+  func voidParameter() throws {
+    let relations =
+        [Table(Metadata.Tables.MethodDef.self, rows: 1, range: 0 ..< 14,
+               wide: 0, stride: 14)]
+    let storage = Storage(bytes: SignatureTests.method.span.bytes,
+                          relations: relations.span,
+                          strings: SignatureTests.empty.span.bytes,
+                          blob: SignatureTests.voidParameterBlob.span.bytes,
+                          guid: SignatureTests.empty.span.bytes,
+                          valid: 1 << 6, sorted: 0)
+    let rows = try storage.rows(of: Metadata.Tables.MethodDef.self)
+    #expect(throws: WinMDError.BadImageFormat) { _ = try rows[0]!.prototype }
+  }
+
+  @Test("rejects a VOID field type")
+  func voidField() throws {
+    let relations =
+        [Table(Metadata.Tables.FieldDef.self, rows: 1, range: 0 ..< 6,
+               wide: 0, stride: 6)]
+    let storage = Storage(bytes: SignatureTests.fieldRecord.span.bytes,
+                          relations: relations.span,
+                          strings: SignatureTests.empty.span.bytes,
+                          blob: SignatureTests.voidFieldBlob.span.bytes,
+                          guid: SignatureTests.empty.span.bytes,
+                          valid: 1 << 4, sorted: 0)
+    let rows = try storage.rows(of: Metadata.Tables.FieldDef.self)
+    #expect(throws: WinMDError.BadImageFormat) { _ = try rows[0]!.declaration }
+  }
+
+  @Test("decodes a VOID return")
+  func voidReturn() throws {
+    let relations =
+        [Table(Metadata.Tables.MethodDef.self, rows: 1, range: 0 ..< 14,
+               wide: 0, stride: 14)]
+    let storage = Storage(bytes: SignatureTests.method.span.bytes,
+                          relations: relations.span,
+                          strings: SignatureTests.empty.span.bytes,
+                          blob: SignatureTests.voidReturnBlob.span.bytes,
+                          guid: SignatureTests.empty.span.bytes,
+                          valid: 1 << 6, sorted: 0)
+    let rows = try storage.rows(of: Metadata.Tables.MethodDef.self)
+    let signature = try rows[0]!.prototype
+    guard case .primitive(.void) = signature.returns else {
+      Issue.record("return not void"); return
+    }
+    #expect(signature.parameters.isEmpty)
+  }
+
+  @Test("decodes a VOID pointer parameter")
+  func voidPointer() throws {
+    let relations =
+        [Table(Metadata.Tables.MethodDef.self, rows: 1, range: 0 ..< 14,
+               wide: 0, stride: 14)]
+    let storage = Storage(bytes: SignatureTests.method.span.bytes,
+                          relations: relations.span,
+                          strings: SignatureTests.empty.span.bytes,
+                          blob: SignatureTests.voidPointerBlob.span.bytes,
+                          guid: SignatureTests.empty.span.bytes,
+                          valid: 1 << 6, sorted: 0)
+    let rows = try storage.rows(of: Metadata.Tables.MethodDef.self)
+    let signature = try rows[0]!.prototype
+    guard case let .pointer(pointee) = signature.parameters[0],
+        case .primitive(.void) = pointee else {
+      Issue.record("parameter not void*"); return
+    }
+  }
+
+  // MARK: - The MethodDef convention is DEFAULT or VARARG
+
+  // ECMA-335 §II.23.2.1 limits a MethodDefSig's calling convention to DEFAULT
+  // or VARARG (plus the HASTHIS/EXPLICITTHIS/GENERIC flags); the unmanaged
+  // C/STDCALL/THISCALL/FASTCALL conventions (0x01–0x04) belong to a
+  // StandAloneMethodSig, not a method-def. Each unmanaged-convention blob is a
+  // `() -> void` body the shared `method()` accepts but the `prototype`
+  // accessor must reject. The names follow the convention the low nibble selects.
+  private static let cConventionBlob: Array<UInt8> =
+      [0x03, 0x01, 0x00, VOID]
+  private static let stdcallConventionBlob: Array<UInt8> =
+      [0x03, 0x02, 0x00, VOID]
+  private static let thiscallConventionBlob: Array<UInt8> =
+      [0x03, 0x03, 0x00, VOID]
+  private static let fastcallConventionBlob: Array<UInt8> =
+      [0x03, 0x04, 0x00, VOID]
+
+  // A method blob naming the VARARG convention (low nibble 0x05): a valid
+  // MethodDefSig convention that must still decode through `prototype`.
+  private static let varargConventionBlob: Array<UInt8> =
+      [0x03, 0x05, 0x00, VOID]
+
+  // Drives the `prototype` accessor over a one-blob heap, expecting a throw.
+  private func expectPrototypeRejects(_ blob: Array<UInt8>) throws {
+    var blob = blob
+    let relations =
+        [Table(Metadata.Tables.MethodDef.self, rows: 1, range: 0 ..< 14,
+               wide: 0, stride: 14)]
+    let storage = Storage(bytes: SignatureTests.method.span.bytes,
+                          relations: relations.span,
+                          strings: SignatureTests.empty.span.bytes,
+                          blob: blob.span.bytes,
+                          guid: SignatureTests.empty.span.bytes,
+                          valid: 1 << 6, sorted: 0)
+    let rows = try storage.rows(of: Metadata.Tables.MethodDef.self)
+    #expect(throws: WinMDError.BadImageFormat) { _ = try rows[0]!.prototype }
+  }
+
+  @Test("rejects a MethodDef prolog naming the unmanaged C convention")
+  func cConvention() throws {
+    try expectPrototypeRejects(SignatureTests.cConventionBlob)
+  }
+
+  @Test("rejects a MethodDef prolog naming the unmanaged STDCALL convention")
+  func stdcallConvention() throws {
+    try expectPrototypeRejects(SignatureTests.stdcallConventionBlob)
+  }
+
+  @Test("rejects a MethodDef prolog naming the unmanaged THISCALL convention")
+  func thiscallConvention() throws {
+    try expectPrototypeRejects(SignatureTests.thiscallConventionBlob)
+  }
+
+  @Test("rejects a MethodDef prolog naming the unmanaged FASTCALL convention")
+  func fastcallConvention() throws {
+    try expectPrototypeRejects(SignatureTests.fastcallConventionBlob)
+  }
+
+  @Test("decodes a DEFAULT-convention MethodDef through prototype")
+  func defaultConvention() throws {
+    let relations =
+        [Table(Metadata.Tables.MethodDef.self, rows: 1, range: 0 ..< 14,
+               wide: 0, stride: 14)]
+    let storage = Storage(bytes: SignatureTests.method.span.bytes,
+                          relations: relations.span,
+                          strings: SignatureTests.empty.span.bytes,
+                          blob: SignatureTests.methodBlob.span.bytes,
+                          guid: SignatureTests.empty.span.bytes,
+                          valid: 1 << 6, sorted: 0)
+    let rows = try storage.rows(of: Metadata.Tables.MethodDef.self)
+    let signature = try rows[0]!.prototype
+    #expect(signature.convention == .default)
+  }
+
+  @Test("decodes a VARARG-convention MethodDef through prototype")
+  func varargConvention() throws {
+    let relations =
+        [Table(Metadata.Tables.MethodDef.self, rows: 1, range: 0 ..< 14,
+               wide: 0, stride: 14)]
+    let storage = Storage(bytes: SignatureTests.method.span.bytes,
+                          relations: relations.span,
+                          strings: SignatureTests.empty.span.bytes,
+                          blob: SignatureTests.varargConventionBlob.span.bytes,
+                          guid: SignatureTests.empty.span.bytes,
+                          valid: 1 << 6, sorted: 0)
+    let rows = try storage.rows(of: Metadata.Tables.MethodDef.self)
+    let signature = try rows[0]!.prototype
+    #expect(signature.convention == .vararg)
+  }
+
+  // MARK: - method() itself admits the unmanaged conventions
+
+  @Test("decodes an FNPTR carrying an unmanaged STDCALL convention")
+  func functionPointerUnmanagedConvention() throws {
+    // FNPTR (0x1b) wraps a nested method signature, and a function pointer
+    // (calli) legitimately names an unmanaged convention. The inner method's
+    // prolog is 0x03 (THISCALL) over a `() -> void` body. The `prototype`
+    // restriction is specific to a top-level MethodDefSig; `type()` — the FNPTR
+    // path — must still admit the unmanaged convention without throwing, which
+    // proves the shared `method()` itself is not restricted.
+    let FNPTR: UInt8 = 0x1b
+    var bytes = [FNPTR, 0x03, 0x00, VOID]
+    var decoder = SignatureDecoder(bytes.span.bytes)
+    let type = try decoder.type()
+    guard case let .function(signature) = type else {
+      Issue.record("type not a function pointer"); return
+    }
+    #expect(signature.convention == .thiscall)
+  }
+}

--- a/Tests/WinMDTests/SortKeyTests.swift
+++ b/Tests/WinMDTests/SortKeyTests.swift
@@ -1,0 +1,24 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import WinMD
+
+struct SortKeyTests {
+  @Test("sorted tables name their key column ordinal")
+  func sortedTablesNameTheirKeyColumn() {
+    // The key is the ordinal of the column the table is physically ordered by
+    // (ECMA-335 §II.22), resolved from each schema's own column order.
+    #expect(Metadata.Tables.NestedClass.key == 0)
+    #expect(Metadata.Tables.ClassLayout.key == 2)
+    #expect(Metadata.Tables.DeclSecurity.key == 1)
+    #expect(Metadata.Tables.MethodSemantics.key == 2)
+  }
+
+  @Test("unsorted tables have no key")
+  func unsortedTablesHaveNoKey() {
+    // A table the specification does not sort inherits the `nil` default.
+    #expect(Metadata.Tables.TypeDef.key == nil)
+    #expect(Metadata.Tables.TypeRef.key == nil)
+  }
+}

--- a/Tests/WinMDTests/UserStringsHeapTests.swift
+++ b/Tests/WinMDTests/UserStringsHeapTests.swift
@@ -43,7 +43,7 @@ struct UserStringsHeapTests {
 
   // A multi-code-unit string whose code units begin at an odd byte offset (the
   // single-byte length prefix puts `begin` at 1), proving the unaligned read
-  // path.  "Hello" → UTF-16LE, terminal flag `00`, length `0x0b`.
+  // path. "Hello" → UTF-16LE, terminal flag `00`, length `0x0b`.
   @Test("decodes a multi-code-unit string at an odd offset")
   func multipleCodeUnits() {
     let bytes: Array<UInt8> = [0x0b, 0x48, 0x00, 0x65, 0x00, 0x6c, 0x00,
@@ -53,7 +53,7 @@ struct UserStringsHeapTests {
   }
 
   // A non-ASCII string requiring a surrogate pair, again starting at an odd
-  // `begin`.  "😀" (U+1F600) → UTF-16LE surrogates `D83D DE00` i.e. bytes
+  // `begin`. "😀" (U+1F600) → UTF-16LE surrogates `D83D DE00` i.e. bytes
   // `3D D8 00 DE`, terminal flag `01`, length `0x05`.
   @Test("decodes a surrogate-pair string at an odd offset")
   func surrogatePair() {


### PR DESCRIPTION
This pull request introduces a new modular SQL query engine to the project. It adds a new `SQL` library target, including its own abstract syntax tree (AST), error types, adapter protocols for data sources, and a query engine capable of compiling, optimizing, and executing SELECT statements. The changes are grouped into package configuration and the main components of the new SQL engine.

**Package configuration:**

* Added a new library product named `SQL` and corresponding target and test target to `Package.swift`, both enabling the experimental Swift "Lifetimes" feature. [[1]](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eR12) [[2]](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eR21-R30)

**New SQL engine components:**

* Introduced `AST.swift` defining the SQL abstract syntax tree, including types for statements, projections, relations, joins, columns, predicates, comparisons, literals, and ordering. This provides a structured, dialect-limited representation of SQL queries.
* Added `Adapter.swift` specifying protocols (`Catalog`, `Table`, `Cursor`, `Row`) and value types (`ValueKind`, `Value`) for abstracting over data sources, allowing the engine to work with any backend implementing these interfaces.
* Implemented `Engine.swift`, which compiles, optimizes, and executes SELECT queries against the adapter protocols, supporting features like predicate pushdown, index-seek optimization, and index-nested-loop joins.
* Added `Error.swift` defining structured error types for parsing, planning, and execution, including detailed source locations for diagnostics.