### PR TITLE
wire up SQL to `winmd-inspect`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -51,5 +51,14 @@ let SwiftWinMD = Package(
             swiftSettings: [
               .enableExperimentalFeature("Lifetimes"),
             ]),
+    .testTarget(name: "winmd-inspectTests",
+            dependencies: [
+              "winmd-inspect",
+              "SQL",
+              "WinMD",
+            ],
+            swiftSettings: [
+              .enableExperimentalFeature("Lifetimes"),
+            ]),
   ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -44,6 +44,7 @@ let SwiftWinMD = Package(
     // winmd-inspect
     .executableTarget(name: "winmd-inspect",
             dependencies: [
+              "SQL",
               "WinMD",
               .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ],

--- a/Package.swift
+++ b/Package.swift
@@ -2,63 +2,63 @@
 
 import PackageDescription
 
-let SwiftWinMD = Package(
-  name: "SwiftWinMD",
-  platforms: [
-    .macOS(.v26),
-  ],
-  products: [
-    .executable(name: "winmd-inspect", targets: ["winmd-inspect"]),
-    .library(name: "SQL", targets: ["SQL"]),
-  ],
-  dependencies: [
-    .package(url: "https://github.com/apple/swift-argument-parser",
-             from: "1.5.0"),
-  ],
-  targets: [
-    .target(name: "CPE", dependencies: []),
-
-    // SQL
-    .target(name: "SQL", dependencies: [],
-            swiftSettings: [
-              .enableExperimentalFeature("Lifetimes"),
-            ]),
-    .testTarget(name: "SQLTests", dependencies: ["SQL"],
-            swiftSettings: [
-              .enableExperimentalFeature("Lifetimes"),
-            ]),
-
-    // WinMD
-    .target(name: "WinMD",
-            dependencies: [
-              "CPE",
+let _ =
+    Package(name: "SwiftWinMD",
+            platforms: [
+              .macOS(.v26),
             ],
-            swiftSettings: [
-              .enableExperimentalFeature("Lifetimes"),
-            ]),
-    .testTarget(name: "WinMDTests", dependencies: ["WinMD"],
-            swiftSettings: [
-              .enableExperimentalFeature("Lifetimes"),
-            ]),
+            products: [
+              .executable(name: "winmd-inspect", targets: ["winmd-inspect"]),
+              .library(name: "SQL", targets: ["SQL"]),
+            ],
+            dependencies: [
+              .package(url: "https://github.com/apple/swift-argument-parser",
+                       from: "1.5.0"),
+            ],
+            targets: [
+              .target(name: "CPE", dependencies: []),
 
-    // winmd-inspect
-    .executableTarget(name: "winmd-inspect",
-            dependencies: [
-              "SQL",
-              "WinMD",
-              .product(name: "ArgumentParser", package: "swift-argument-parser"),
-            ],
-            swiftSettings: [
-              .enableExperimentalFeature("Lifetimes"),
-            ]),
-    .testTarget(name: "winmd-inspectTests",
-            dependencies: [
-              "winmd-inspect",
-              "SQL",
-              "WinMD",
-            ],
-            swiftSettings: [
-              .enableExperimentalFeature("Lifetimes"),
-            ]),
-  ]
-)
+              // SQL
+              .target(name: "SQL", dependencies: [],
+                      swiftSettings: [
+                        .enableExperimentalFeature("Lifetimes"),
+                      ]),
+              .testTarget(name: "SQLTests", dependencies: ["SQL"],
+                          swiftSettings: [
+                            .enableExperimentalFeature("Lifetimes"),
+                          ]),
+
+              // WinMD
+              .target(name: "WinMD",
+                      dependencies: [
+                        "CPE",
+                      ],
+                      swiftSettings: [
+                        .enableExperimentalFeature("Lifetimes"),
+                      ]),
+              .testTarget(name: "WinMDTests", dependencies: ["WinMD"],
+                          swiftSettings: [
+                            .enableExperimentalFeature("Lifetimes"),
+                          ]),
+
+              // winmd-inspect
+              .executableTarget(name: "winmd-inspect",
+                                dependencies: [
+                                  "SQL",
+                                  "WinMD",
+                                  .product(name: "ArgumentParser",
+                                           package: "swift-argument-parser"),
+                                ],
+                                swiftSettings: [
+                                  .enableExperimentalFeature("Lifetimes"),
+                                ]),
+              .testTarget(name: "winmd-inspectTests",
+                          dependencies: [
+                            "winmd-inspect",
+                            "SQL",
+                            "WinMD",
+                          ],
+                          swiftSettings: [
+                            .enableExperimentalFeature("Lifetimes"),
+                          ]),
+            ])

--- a/Sources/WinMD/Database.swift
+++ b/Sources/WinMD/Database.swift
@@ -92,8 +92,10 @@ public struct Database: ~Escapable {
   ///
   /// The row cursors only read out of the backing buffer and the open tables,
   /// so they carry this trivial view rather than the whole `Database` and avoid
-  /// retaining the relations buffer on every copy.
-  internal var storage: Storage {
+  /// retaining the relations buffer on every copy. `package` so the SQL-engine
+  /// adapter, which conforms `Storage` to the engine's `Catalog`, opens it from
+  /// the database.
+  package var storage: Storage {
     @_lifetime(borrow self)
     get {
       Storage(bytes: bytes, relations: relations.span, strings: string,

--- a/Sources/WinMD/Iteration.swift
+++ b/Sources/WinMD/Iteration.swift
@@ -334,8 +334,8 @@ public struct Cursor: ~Escapable {
   private let rows: Int
 
   @_lifetime(copy storage)
-  internal init(_ storage: Storage, _ table: Table,
-                from row: Int = 0, to count: Int? = nil) {
+  package init(_ storage: Storage, _ table: Table,
+               from row: Int = 0, to count: Int? = nil) {
     self.storage = storage
     self.table = table
     self.rows = (count ?? Int(table.rows)) - row
@@ -359,11 +359,12 @@ public struct Cursor: ~Escapable {
   ///
   /// Exposed to the structured-query executor (`where(_: Predicate)`), which
   /// inspects the table's schema and `Sorted` bit to decide between a binary
-  /// search and a scan.
-  internal var relation: Table { table }
+  /// search and a scan, and to the SQL-engine adapter, which reads the table's
+  /// schema to describe the relation.
+  package var relation: Table { table }
 
   /// The borrowed storage view this cursor reads from.
-  internal var backing: Storage {
+  package var backing: Storage {
     @_lifetime(copy self)
     get { storage }
   }

--- a/Sources/WinMD/Storage.swift
+++ b/Sources/WinMD/Storage.swift
@@ -9,12 +9,16 @@
 /// and release the relations buffer on every cursor copy — they carry this
 /// trivial view: a `Span<Table>` into the relations plus the read spans. The
 /// existing `~Escapable` lifetime dependency keeps it sound.
-internal struct Storage: ~Escapable {
+///
+/// It is `package`-scoped (along with the members the query scan reads) so the
+/// SQL-engine adapter, which conforms it to the engine's `Catalog`, reaches it
+/// across the module boundary.
+package struct Storage: ~Escapable {
   /// The backing buffer.
   internal let bytes: RawSpan
 
   /// The open tables of the database, borrowed from `Database.relations`.
-  internal let relations: Span<Table>
+  package let relations: Span<Table>
 
   /// The "Strings" (`#Strings`) heap.
   internal let strings: RawSpan
@@ -26,17 +30,17 @@ internal struct Storage: ~Escapable {
   internal let guid: RawSpan
 
   /// The bitset of present tables (`TablesStream.Valid`).
-  internal let valid: UInt64
+  package let valid: UInt64
 
   /// The bitset of physically sorted tables (`TablesStream.Sorted`).
   ///
   /// Bit `N` is set iff table `N` is stored ordered by its sort key. A reverse
   /// foreign-key lookup against a sorted table is a binary search; against an
   /// unsorted one it is a linear scan.
-  internal let sorted: UInt64
+  package let sorted: UInt64
 
   @_lifetime(copy bytes, copy relations, copy strings, copy blob, copy guid)
-  internal init(bytes: RawSpan, relations: Span<Table>, strings: RawSpan,
+  package init(bytes: RawSpan, relations: Span<Table>, strings: RawSpan,
                 blob: RawSpan, guid: RawSpan, valid: UInt64, sorted: UInt64) {
     self.bytes = bytes
     self.relations = relations
@@ -165,10 +169,11 @@ internal struct Storage: ~Escapable {
   /// With `strict == false` this is the lower bound (the first row whose cell is
   /// `>= value`); with `strict == true` the upper bound (the first row whose
   /// cell is `> value`). Together they bracket the run equal to `value`. The
-  /// search is `O(log count)`. Shared by the reverse-foreign-key lookup and the
-  /// structured-query sorted-index executor (`Cursor.where(_: Predicate)`).
-  internal func bound(_ table: Table, _ column: Int, _ value: Int, _ count: Int,
-                      strict: Bool) -> Int {
+  /// search is `O(log count)`. Shared by the reverse-foreign-key lookup, the
+  /// structured-query sorted-index executor (`Cursor.where(_: Predicate)`), and
+  /// the SQL-engine adapter's seekable-column `bound`.
+  package func bound(_ table: Table, _ column: Int, _ value: Int, _ count: Int,
+                     strict: Bool) -> Int {
     var lo = 0
     var hi = count
     while lo < hi {

--- a/Sources/WinMD/Table.swift
+++ b/Sources/WinMD/Table.swift
@@ -56,7 +56,10 @@ extension TableSchema {
 /// recovered from the schema's narrow offsets and this bitset on demand.
 public struct Table: Sendable {
   /// The schema this table is an instance of.
-  internal let schema: TableSchema.Type
+  ///
+  /// `package` so the SQL-engine adapter reads the table's columns, sort key,
+  /// and number to describe the relation across the module boundary.
+  package let schema: TableSchema.Type
 
   /// The set of columns the catalog resolved to a wide (4-byte) index.
   ///
@@ -68,7 +71,7 @@ public struct Table: Sendable {
   internal let stride: Int
 
   /// The number of records in the table.
-  internal let rows: UInt32
+  package let rows: UInt32
 
   /// The absolute byte range of the records within the backing buffer.
   ///
@@ -76,7 +79,7 @@ public struct Table: Sendable {
   /// them within `Database.bytes`.
   internal let range: Range<Int>
 
-  internal var number: Int { schema.number }
+  package var number: Int { schema.number }
 
   internal init(_ schema: TableSchema.Type, rows: UInt32,
                 range: Range<Int>, wide: UInt32, stride: Int) {

--- a/Sources/winmd-inspect/Database+SQL.swift
+++ b/Sources/winmd-inspect/Database+SQL.swift
@@ -1,0 +1,322 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+internal import SQL
+internal import WinMD
+
+/// The WinMD → SQL-engine adapter.
+///
+/// The engine plans and executes a `SELECT` against four protocols — `Catalog`,
+/// `Table`, `Cursor`, `Row` — knowing nothing of WinMD. This file makes a WinMD
+/// database one of those sources, directly: `WinMD.Storage` is the engine's
+/// `Catalog`, with the relation, cursor, and row views layered over WinMD's own
+/// `~Escapable` scan types. `Storage` carries all a scan reads — the open
+/// tables, the heaps, and the present/sorted bitsets — so no escapable
+/// descriptor and no raw pointers are needed: a borrowed `Storage` *is* the
+/// catalog, and the borrowed views it vends never outlive it.
+///
+/// Two virtual columns sit past a relation's real fields, at ordinals outside
+/// the `SELECT *` range so a `*` never projects them: `rowid` (the SQLite-style
+/// 1-based row index) and `parent` (a list-child's owning parent's `rowid`).
+/// `rowid` enables foreign-key joins — an FK is a real column holding a
+/// `rowid` — and `parent` enables list joins — a list-child relates to its
+/// owner through its run rather than a stored key.
+
+// MARK: - Catalog
+
+extension WinMD.Storage: SQL.Catalog {
+  /// The relation named `name`, resolved case-insensitively against the open
+  /// tables' schema names.
+  ///
+  /// A `WinMD.Table`'s description is its schema name (e.g. "TypeDef"); a name
+  /// the database has no table for yields `nil`, which the engine reports as
+  /// `SQLError.relation`.
+  @_lifetime(borrow self)
+  internal borrowing func table(named name: String) -> WinMDRelation? {
+    for index in 0 ..< relations.count {
+      if relations[index].description.caseInsensitiveCompare(name)
+          == .orderedSame {
+        return WinMDRelation(self, relations[index])
+      }
+    }
+    return nil
+  }
+}
+
+// MARK: - Table
+
+/// A `SQL.Table` over one open WinMD table.
+///
+/// Its real columns are the table's fields; two virtual columns follow, at
+/// ordinals `width` (`rowid`) and `width + 1` (`parent`), past the `SELECT *`
+/// extent. A real cell is typed from its field's `ColumnType`: a `#Strings`
+/// index is `.text`, every other column (a constant, a foreign-key index,
+/// another heap) is `.integer`. A seek is available on `rowid` (a dense 1-based
+/// index, trivially monotonic), on `parent` over a list-child (whose owning
+/// run is monotonic in row order), and on the table's intrinsic sort key when
+/// the database physically sorts the table.
+internal struct WinMDRelation: SQL.Table, ~Escapable {
+  /// The borrowed storage the relation reads from.
+  private let storage: WinMD.Storage
+
+  /// The open WinMD table this relation wraps.
+  private let table: WinMD.Table
+
+  @_lifetime(borrow storage)
+  internal init(_ storage: borrowing WinMD.Storage, _ table: WinMD.Table) {
+    self.storage = copy storage
+    self.table = table
+  }
+
+  /// The number of real columns — the extent of a `SELECT *` projection. The
+  /// `rowid` and `parent` virtual columns sit past it.
+  internal var width: Int {
+    table.schema.fields.count
+  }
+
+  /// One past the highest ordinal this relation can address — its real `width`
+  /// plus the two virtual columns (`rowid` and `parent`) it exposes.
+  internal var extent: Int {
+    parent + 1
+  }
+
+  /// The ordinal of the `rowid` virtual column — the first ordinal past the
+  /// real fields.
+  private var rowid: Int {
+    width
+  }
+
+  /// The ordinal of the `parent` virtual column — one past `rowid`.
+  private var parent: Int {
+    width + 1
+  }
+
+  internal func ordinal(of name: String) -> Int? {
+    for column in 0 ..< table.schema.fields.count
+        where "\(table.schema.fields[column].name)"
+                  .caseInsensitiveCompare(name) == .orderedSame {
+      return column
+    }
+    if name.caseInsensitiveCompare("rowid") == .orderedSame {
+      return rowid
+    }
+    if name.caseInsensitiveCompare("parent") == .orderedSame {
+      return parent
+    }
+    return nil
+  }
+
+  internal func bound(_ column: Int, _ value: Int, strict: Bool) -> Int? {
+    let count = Int(table.rows)
+
+    // `rowid` is a dense 1-based index, so the rows are stored in `rowid` order
+    // by construction; the boundary for a value is the value itself (less one
+    // for a non-strict `>= value`), clamped to the row count.
+    if column == rowid {
+      let index = strict ? value : value - 1
+      return min(max(index, 0), count)
+    }
+
+    // `parent` over a list-child is monotonic in row order — a parent owns a
+    // contiguous run of children — so binary-search the rows for the boundary
+    // against the computed parent `rowid`.
+    if column == parent, let link = WinMDRelation.Link(storage, table) {
+      return owners(link, value, count, strict: strict)
+    }
+
+    // A real column is seekable only when it is the table's intrinsic sort key
+    // and this database physically sorts the table; otherwise the engine scans.
+    guard table.schema.key == column,
+        storage.sorted & (1 << table.number) != 0 else {
+      return nil
+    }
+    return storage.bound(table, column, value, count, strict: strict)
+  }
+
+  /// The partition point of the child rows against a parent `rowid` `value`.
+  ///
+  /// A child row's `parent` is the 1-based row of its owning parent. The owners
+  /// are non-decreasing across the child rows (a parent's run precedes the
+  /// next), so the boundary is found by binary search: with `strict` false the
+  /// first child whose owner is `>= value`, with `strict` true the first whose
+  /// owner is `> value`.
+  private func owners(_ link: WinMDRelation.Link, _ value: Int, _ count: Int,
+                      strict: Bool) -> Int {
+    var lo = 0
+    var hi = count
+    while lo < hi {
+      let mid = lo + (hi - lo) / 2
+      let owner = storage.owner(of: mid, link)
+      if owner < value || (strict && owner == value) {
+        lo = mid + 1
+      } else {
+        hi = mid
+      }
+    }
+    return lo
+  }
+
+  @_lifetime(borrow self)
+  internal borrowing func cursor() -> WinMDCursor {
+    WinMDCursor(storage, table, WinMDRelation.Link(storage, table))
+  }
+}
+
+// MARK: - List navigation
+
+extension WinMDRelation {
+  /// A list-child's link to its owning parent: the parent's open table and the
+  /// ordinal of the parent's list column (the column whose run names this
+  /// child's rows).
+  internal struct Link {
+    /// The parent's open table.
+    internal let parent: WinMD.Table
+    /// The ordinal of the parent's list column.
+    internal let column: Int
+
+    /// The list link for `child`, or `nil` if `child` is not a list-child of
+    /// any of the schema's list relationships.
+    ///
+    /// The five list relationships are the inverse of the schemas' `List`
+    /// tokens: `TypeDef.FieldList`(4)→FieldDef, `TypeDef.MethodList`(5)→
+    /// MethodDef, `MethodDef.ParamList`(5)→Param, `EventMap.EventList`(1)→
+    /// EventDef, `PropertyMap.PropertyList`(1)→PropertyDef. The parent's open
+    /// table is looked up by name among the database's relations; an absent
+    /// parent (a database without the owning table) is no link.
+    internal init?(_ storage: borrowing WinMD.Storage,
+                   _ child: borrowing WinMD.Table) {
+      for index in Self.lists.indices
+          where Self.lists[index].child
+                    .caseInsensitiveCompare(child.description) == .orderedSame {
+        for relation in 0 ..< storage.relations.count
+            where storage.relations[relation].description
+                      .caseInsensitiveCompare(Self.lists[index].parent)
+                          == .orderedSame {
+          self.parent = storage.relations[relation]
+          self.column = Self.lists[index].column
+          return
+        }
+      }
+      return nil
+    }
+
+    /// The list-child → (parent, list column) map — the inverse of the schemas'
+    /// `List` tokens. A relation is matched by its schema name (`description`).
+    private static let lists:
+        InlineArray<_, (child: String, parent: String, column: Int)> = [
+      (child: "FieldDef", parent: "TypeDef", column: 4),
+      (child: "MethodDef", parent: "TypeDef", column: 5),
+      (child: "Param", parent: "MethodDef", column: 5),
+      (child: "EventDef", parent: "EventMap", column: 1),
+      (child: "PropertyDef", parent: "PropertyMap", column: 1),
+    ]
+  }
+}
+
+extension WinMD.Storage {
+  /// The 1-based `rowid` of the parent that owns the child row at `row`.
+  ///
+  /// A parent at row `p` owns the children `[parent[col] - 1, next[col] - 1)`,
+  /// the runs partitioning the child rows in parent order. Binary-search the
+  /// parent rows for the one whose run contains `row`: the last parent whose
+  /// 0-based run start is `<= row`. The parent's 1-based `rowid` is `p + 1`.
+  internal func owner(of row: Int, _ link: WinMDRelation.Link) -> Int {
+    let cursor = WinMD.Cursor(copy self, link.parent)
+    var lo = 0
+    var hi = cursor.count
+    while lo < hi {
+      let mid = lo + (hi - lo) / 2
+      // The parent's list cell is the 1-based start of its child run; less one
+      // is the run's 0-based start.
+      let start = (cursor[mid]?[link.column] ?? 0) - 1
+      if start <= row {
+        lo = mid + 1
+      } else {
+        hi = mid
+      }
+    }
+    return lo
+  }
+}
+
+// MARK: - Cursor
+
+/// A `SQL.Cursor` over the rows of one open WinMD table.
+///
+/// It wraps WinMD's own `~Escapable` `Cursor` and carries the relation's list
+/// link, so the rows it vends can compute the `parent` virtual column.
+internal struct WinMDCursor: SQL.Cursor, ~Escapable {
+  /// The borrowed storage the cursor reads from.
+  private let storage: WinMD.Storage
+
+  /// WinMD's scan over the table's rows.
+  private let cursor: WinMD.Cursor
+
+  /// The relation's list link, when it is a list-child.
+  private let link: WinMDRelation.Link?
+
+  @_lifetime(borrow storage)
+  internal init(_ storage: borrowing WinMD.Storage, _ table: WinMD.Table,
+               _ link: WinMDRelation.Link?) {
+    self.storage = copy storage
+    self.cursor = WinMD.Cursor(copy storage, table)
+    self.link = link
+  }
+
+  internal var count: Int {
+    cursor.count
+  }
+
+  @_lifetime(copy self)
+  internal borrowing func row(_ index: Int) -> WinMDRow? {
+    guard let tuple = cursor[index] else { return nil }
+    return WinMDRow(tuple, storage, link)
+  }
+}
+
+// MARK: - Row
+
+/// A `SQL.Row` over one WinMD row.
+///
+/// A cell is read by ordinal as a typed `Value`: a real ordinal (`< count`)
+/// reads the WinMD cell — a `#Strings` heap index resolves through the heap as
+/// `.text`, every other column is `.integer`; `rowid` is the 1-based row index
+/// 1-based row index; the `parent` virtual ordinal is the owning parent row's
+/// 1-based `rowid` (zero for a row no parent owns).
+internal struct WinMDRow: SQL.Row, ~Escapable {
+  /// The WinMD row this view reads.
+  private let tuple: WinMD.Tuple
+
+  /// The borrowed storage the parent navigation reads from.
+  private let storage: WinMD.Storage
+
+  /// The relation's list link, when it is a list-child.
+  private let link: WinMDRelation.Link?
+
+  @_lifetime(copy tuple, copy storage)
+  internal init(_ tuple: borrowing WinMD.Tuple,
+                _ storage: borrowing WinMD.Storage,
+                _ link: WinMDRelation.Link?) {
+    self.tuple = copy tuple
+    self.storage = copy storage
+    self.link = link
+  }
+
+  internal subscript(_ column: Int) -> Value {
+    borrowing get {
+      // The real fields are `[0, count)`; `rowid` is `count`, `parent` is
+      // `count + 1`.
+      if column == tuple.count {
+        return .integer(tuple.index + 1)
+      }
+      if column == tuple.count + 1 {
+        guard let link else { return .integer(0) }
+        return .integer(storage.owner(of: tuple.index, link))
+      }
+      if case .index(.heap(.string)) = tuple.type(of: column) {
+        return .text((try? tuple.string(column)) ?? "")
+      }
+      return .integer(tuple[column])
+    }
+  }
+}

--- a/Sources/winmd-inspect/Inspect.swift
+++ b/Sources/winmd-inspect/Inspect.swift
@@ -77,6 +77,7 @@ struct Inspect: ParsableCommand {
                          subcommands: [
                            Dump.self,
                            PrintNamespaces.self,
+                           Query.self,
                          ])
   }
 

--- a/Sources/winmd-inspect/Query.swift
+++ b/Sources/winmd-inspect/Query.swift
@@ -1,0 +1,61 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+internal import struct Foundation.Data
+
+internal import ArgumentParser
+internal import SQL
+internal import WinMD
+
+/// The `query` subcommand: run a SQL query against a metadata database.
+///
+/// The parsed `SELECT` is handed to the database-agnostic `Engine`, which plans
+/// and executes it over the WinMD database adapted as a `SQL.Catalog`: a
+/// relation, a foreign-key join (`ON child.fk = parent.rowid`), or a list join
+/// (`ON child.parent = parent.rowid`). The engine yields typed `Value` records;
+/// this renders each as a tab-separated line. There is no bespoke predicate,
+/// planner, or join here — the engine owns all of it.
+internal struct Query: ParsableCommand {
+  internal static var configuration: CommandConfiguration {
+    CommandConfiguration(commandName: "query",
+                         abstract: "Query the database with SQL.")
+  }
+
+  @Argument(help: "The SQL query to run against the database.")
+  internal var sql: String
+
+  @OptionGroup
+  internal var options: InspectOptions
+
+  internal func run() throws {
+    // The caller owns the mapping; it must outlive the database, which is a
+    // borrowed view over it.
+    let data = try Data(contentsOf: options.database.url,
+                        options: .alwaysMapped)
+    let database = try Database(data.span.bytes)
+
+    let statement = try Statement(parsing: sql)
+
+    // The engine plans and executes over the WinMD database adapted as a
+    // catalog, returning the projected, filtered, and ordered rows as typed
+    // values.
+    let rows = switch statement {
+    case let .select(select):
+      try Engine.run(select, database.storage)
+    }
+    for row in rows {
+      print(row.map(Query.render).joined(separator: "\t"))
+    }
+  }
+
+  /// Renders a typed cell value to its display string: text verbatim, an
+  /// integer as its decimal spelling.
+  private static func render(_ value: Value) -> String {
+    switch value {
+    case let .integer(integer):
+      "\(integer)"
+    case let .text(text):
+      text
+    }
+  }
+}

--- a/Tests/winmd-inspectTests/AdapterTests.swift
+++ b/Tests/winmd-inspectTests/AdapterTests.swift
@@ -1,0 +1,239 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+
+@testable import winmd_inspect
+
+import SQL
+@testable import WinMD
+
+/// End-to-end coverage of the WinMD → SQL-engine adapter.
+///
+/// Rather than map a `.winmd` file, the tests assemble a tiny store in memory —
+/// `TypeDef` (#2), `MethodDef` (#6), `NestedClass` (#41), and `EventMap` (#18)
+/// — and drive a parsed `SELECT` through `Engine.run` over the `WinMD.Storage`
+/// catalog, asserting the typed `Value` rows the engine yields. They exercise a
+/// single-relation projection / filter / order with the `rowid` virtual column
+/// and a sorted-key seek, a foreign-key join on `rowid`, a list join on the
+/// `parent` virtual column, and a real `Parent` column shadowing that
+/// pseudo-column.
+struct AdapterTests {
+  // TypeDef[0..1] (14-byte narrow rows), MethodDef[0..2] (14-byte rows), and
+  // NestedClass[0..1] (4-byte rows), packed back to back. ECMA-335 rows are
+  // 1-based, so a stored index `N` names the 0-based row `N - 1`.
+  //
+  //   TypeDef[0]: Flags=0x21 TypeName="Alpha" TypeNamespace="NS" MethodList=1
+  //   TypeDef[1]: Flags=0x10 TypeName="Beta"  TypeNamespace="NS" MethodList=3
+  //   so TypeDef[0] owns MethodDef[0,1] and TypeDef[1] owns MethodDef[2].
+  //
+  //   MethodDef[0]: Name="m0"  MethodDef[1]: Name="m1"  MethodDef[2]: Name="m2"
+  //
+  //   NestedClass[0]: NestedClass=1 EnclosingClass=2   (→ TypeDef[0], Alpha)
+  //   NestedClass[1]: NestedClass=2 EnclosingClass=1   (→ TypeDef[1], Beta)
+  //
+  // `NestedClass` is laid out ascending by its key column (ordinal 0): 1, 2.
+  //
+  //   EventMap[0]: Parent=1 EventList=1   (→ TypeDef[0], Alpha)
+  //   EventMap[1]: Parent=2 EventList=1   (→ TypeDef[1], Beta)
+  //
+  // `EventMap` carries a *real* `Parent` field (a TypeDef index), so its name
+  // must shadow the virtual `parent` pseudo-column.
+  private static let bytes: Array<UInt8> = [
+    // TypeDef[0]: Flags, TypeName=1, TypeNamespace=12, Extends, FieldList,
+    // MethodList=1.
+    0x21, 0x00, 0x00, 0x00, 0x01, 0x00, 0x0c, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+    // TypeDef[1]: Flags, TypeName=7, TypeNamespace=12, Extends, FieldList,
+    // MethodList=3.
+    0x10, 0x00, 0x00, 0x00, 0x07, 0x00, 0x0c, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x03, 0x00,
+    // MethodDef[0]: RVA, ImplFlags, Flags, Name=15, Signature, ParamList.
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x0f, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // MethodDef[1]: Name=18.
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x12, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // MethodDef[2]: Name=21.
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x15, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // NestedClass[0..1]: NestedClass index then EnclosingClass index.
+    0x01, 0x00, 0x02, 0x00,
+    0x02, 0x00, 0x01, 0x00,
+    // EventMap[0..1]: Parent (TypeDef index) then EventList (EventDef index).
+    0x01, 0x00, 0x01, 0x00,
+    0x02, 0x00, 0x01, 0x00,
+  ]
+
+  // "\0Alpha\0Beta\0NS\0m0\0m1\0m2\0": Alpha@1, Beta@7, NS@12, m0@15, m1@18,
+  // m2@21.
+  private static let strings: Array<UInt8> = [
+    0x00,
+    0x41, 0x6c, 0x70, 0x68, 0x61, 0x00,
+    0x42, 0x65, 0x74, 0x61, 0x00,
+    0x4e, 0x53, 0x00,
+    0x6d, 0x30, 0x00,
+    0x6d, 0x31, 0x00,
+    0x6d, 0x32, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 2, range: 0 ..< 28,
+          wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.MethodDef.self, rows: 3, range: 28 ..< 70,
+          wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.NestedClass.self, rows: 2, range: 70 ..< 78,
+          wide: 0, stride: 4),
+    WinMD.Table(Metadata.Tables.EventMap.self, rows: 2, range: 78 ..< 86,
+          wide: 0, stride: 4),
+  ]
+
+  // NestedClass (#41) is physically sorted on its key column.
+  private static let sorted: UInt64 = 1 << 41
+  private static let valid: UInt64 =
+      (1 << 2) | (1 << 6) | (1 << 18) | (1 << 41)
+
+  /// Runs `body` over a `Storage` catalog bound to the assembled metadata.
+  private static func with(_ body: (borrowing Storage) throws -> Void)
+      rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: empty.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: sorted)
+    try body(storage)
+  }
+
+  /// Plans and runs `query` through the engine over the catalog.
+  private static func run(_ query: String, _ catalog: borrowing Storage)
+      throws -> Array<Array<Value>> {
+    let statement = try Statement(parsing: query)
+    guard case let .select(select) = statement else {
+      Issue.record("not a SELECT")
+      return []
+    }
+    return try Engine.run(select, catalog)
+  }
+
+  @Test("projects, filters, and orders a single relation")
+  func singleRelation() throws {
+    // The string columns project as text, the constant as an integer; the
+    // WHERE keeps both rows (both are in "NS"), and ORDER BY TypeName sorts
+    // Alpha < Beta. `SELECT *` is the two real string heaps plus the constant
+    // and the three index columns — never `rowid` or `parent`.
+    try AdapterTests.with { catalog in
+      let rows = try AdapterTests.run(
+          "SELECT TypeName, Flags FROM TypeDef "
+          + "WHERE TypeNamespace = 'NS' ORDER BY TypeName", catalog)
+      #expect(rows == [
+        [.text("Alpha"), .integer(0x21)],
+        [.text("Beta"), .integer(0x10)],
+      ])
+    }
+  }
+
+  @Test("excludes rowid and parent from SELECT *")
+  func star() throws {
+    // `SELECT *` projects exactly the real fields: a TypeDef has six. Neither
+    // the `rowid` nor the `parent` virtual column appears.
+    try AdapterTests.with { catalog in
+      let rows = try AdapterTests.run("SELECT * FROM TypeDef ORDER BY rowid",
+                                      catalog)
+      #expect(rows.count == 2)
+      #expect(rows[0].count == 6)
+      #expect(rows[0] == [
+        .integer(0x21), .text("Alpha"), .text("NS"),
+        .integer(0), .integer(0), .integer(1),
+      ])
+    }
+  }
+
+  @Test("vends the rowid virtual column 1-based")
+  func rowid() throws {
+    try AdapterTests.with { catalog in
+      let rows = try AdapterTests.run(
+          "SELECT rowid, TypeName FROM TypeDef ORDER BY rowid", catalog)
+      #expect(rows == [
+        [.integer(1), .text("Alpha")],
+        [.integer(2), .text("Beta")],
+      ])
+    }
+  }
+
+  @Test("seeks a sorted key rather than scanning")
+  func seek() throws {
+    // NestedClass is sorted on its key column, so an equality on it takes the
+    // engine's seek path; the one row whose NestedClass index is 2 survives.
+    try AdapterTests.with { catalog in
+      let rows = try AdapterTests.run(
+          "SELECT NestedClass, EnclosingClass FROM NestedClass "
+          + "WHERE NestedClass = 2", catalog)
+      #expect(rows == [[.integer(2), .integer(1)]])
+    }
+  }
+
+  @Test("joins through a foreign key on rowid")
+  func foreignKeyJoin() throws {
+    // The FK `NestedClass.NestedClass` holds a TypeDef rowid; the engine joins
+    // each NestedClass row to its TypeDef and projects the resolved name.
+    try AdapterTests.with { catalog in
+      let rows = try AdapterTests.run(
+          "SELECT NestedClass.EnclosingClass, TypeDef.TypeName "
+          + "FROM NestedClass JOIN TypeDef "
+          + "ON NestedClass.NestedClass = TypeDef.rowid "
+          + "ORDER BY NestedClass.EnclosingClass", catalog)
+      #expect(rows == [
+        [.integer(1), .text("Beta")],
+        [.integer(2), .text("Alpha")],
+      ])
+    }
+  }
+
+  @Test("joins a list child to its owner on parent")
+  func listJoin() throws {
+    // The `parent` virtual column relates each MethodDef to the TypeDef whose
+    // MethodList run owns it: MethodDef[0,1] → TypeDef[0] (Alpha), MethodDef[2]
+    // → TypeDef[1] (Beta). The join seeks TypeDef on its `rowid` per method.
+    try AdapterTests.with { catalog in
+      let rows = try AdapterTests.run(
+          "SELECT MethodDef.Name, TypeDef.TypeName "
+          + "FROM MethodDef JOIN TypeDef "
+          + "ON MethodDef.parent = TypeDef.rowid "
+          + "ORDER BY MethodDef.Name", catalog)
+      #expect(rows == [
+        [.text("m0"), .text("Alpha")],
+        [.text("m1"), .text("Alpha")],
+        [.text("m2"), .text("Beta")],
+      ])
+    }
+  }
+
+  @Test("resolves a real Parent column over the parent pseudo-column")
+  func realParentShadowsPseudo() throws {
+    // EventMap carries a real `Parent` field — a TypeDef index — so the name
+    // must resolve to that foreign key, not the virtual `parent` (which is 0
+    // for a table no list owns). EventMap[0].Parent=1, EventMap[1].Parent=2.
+    try AdapterTests.with { catalog in
+      let rows = try AdapterTests.run(
+          "SELECT Parent FROM EventMap ORDER BY rowid", catalog)
+      #expect(rows == [[.integer(1)], [.integer(2)]])
+    }
+  }
+
+  @Test("joins through a real Parent foreign key on rowid")
+  func realParentJoin() throws {
+    // The real `EventMap.Parent` FK holds a TypeDef rowid; the join resolves
+    // each EventMap row to its TypeDef: Parent=1 → Alpha, Parent=2 → Beta.
+    try AdapterTests.with { catalog in
+      let rows = try AdapterTests.run(
+          "SELECT EventMap.Parent, TypeDef.TypeName "
+          + "FROM EventMap JOIN TypeDef "
+          + "ON EventMap.Parent = TypeDef.rowid "
+          + "ORDER BY EventMap.Parent", catalog)
+      #expect(rows == [
+        [.integer(1), .text("Alpha")],
+        [.integer(2), .text("Beta")],
+      ])
+    }
+  }
+}


### PR DESCRIPTION
This pull request adds SQL query support to the `winmd-inspect` tool by integrating a SQL engine adapter for WinMD metadata databases. It exposes internal types and members across the `WinMD` module boundary to enable the SQL engine to interact directly with the database, and introduces a new `query` subcommand that allows users to run arbitrary SQL `SELECT` statements against a WinMD database. The main changes are grouped as follows:

**SQL Engine Integration and Adapter:**

* Added `Sources/winmd-inspect/Database+SQL.swift`, implementing a WinMD-to-SQL engine adapter by conforming `WinMD.Storage` to the SQL engine's `Catalog` protocol and providing bridging types for `Table`, `Cursor`, and `Row`. This enables the SQL engine to plan and execute queries directly on WinMD databases.

* Updated access levels for several types and members in `Sources/WinMD/Storage.swift`, `Sources/WinMD/Database.swift`, `Sources/WinMD/Iteration.swift`, and `Sources/WinMD/Table.swift` from `internal` to `package`, so the SQL engine adapter can access required data structures and methods across module boundaries. [[1]](diffhunk://#diff-69a40a1a1da46f9bc8b41b3630b08db17a620015fc1c958f810f754148896757L12-R21) [[2]](diffhunk://#diff-69a40a1a1da46f9bc8b41b3630b08db17a620015fc1c958f810f754148896757L29-R43) [[3]](diffhunk://#diff-69a40a1a1da46f9bc8b41b3630b08db17a620015fc1c958f810f754148896757L168-R175) [[4]](diffhunk://#diff-25dad0bb7e43617f3ad5eee056f7a1d3bd33af75dedb0e63f54219fd6ad187a9L95-R98) [[5]](diffhunk://#diff-efa9ab7eb150f41c8ea0ba92f3a1c841510bc698e3ded3e477f1e435b95b5325L337-R337) [[6]](diffhunk://#diff-efa9ab7eb150f41c8ea0ba92f3a1c841510bc698e3ded3e477f1e435b95b5325L362-R367) [[7]](diffhunk://#diff-06d9c26acbb0d7b5a9f0a54829f70f2fdd6a2a283b502d9a320bd3e93c93ca73L59-R62) [[8]](diffhunk://#diff-06d9c26acbb0d7b5a9f0a54829f70f2fdd6a2a283b502d9a320bd3e93c93ca73L71-R82)

**New Query Subcommand:**

* Added `Sources/winmd-inspect/Query.swift` to implement the new `query` subcommand, which parses and executes SQL queries against the WinMD database using the SQL engine and prints the results as tab-separated values.

* Registered the new `Query` subcommand in the command-line tool by updating the `Inspect` command configuration.

**Build System Updates:**

* Updated `Package.swift` to add the `SQL` dependency to the `winmd-inspect` target, and added a new test target for `winmd-inspectTests`. [[1]](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eL5-R6) [[2]](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eR47-R64)

These changes collectively enable powerful, database-agnostic SQL queries over WinMD metadata, greatly enhancing the inspection and analysis capabilities of the tool.