### PR TITLE
Documentation

### DIFF
--- a/Documentation/DatabaseModel.md
+++ b/Documentation/DatabaseModel.md
@@ -1,0 +1,148 @@
+# The WinMD Database Model
+
+A Windows Metadata (`.winmd`) file stores CLI metadata in the PE/COFF container
+defined by ECMA-335. The file is **raw, offset-addressable data wrapped in a
+stack of nested envelopes**: each layer is a `(offset, size)` region inside the
+one above it, and reaching the metadata means unwrapping the envelopes in order.
+This document describes that on-disk model and the types in this library that
+parse it. For the conceptual framing — how this library projects a read-only
+relational model onto the innermost layer — see
+[RelationalModel.md](RelationalModel.md).
+
+The relational projection sits only on the **tables stream and the heaps** (the
+innermost envelope, described below). Everything above that — the DOS stub, the
+PE image, the CLI header, the metadata root — is pure envelope unwrapping with no
+relational character at all.
+
+## Physical container
+
+A `.winmd` is a PE image. Reaching the metadata is a chain of offset lookups —
+each envelope yielding the next — and every layer is parsed as a zero-copy
+`~Escapable` borrowed view (a `RawSpan`) into the caller's byte buffer rather
+than being copied out:
+
+1. **MS-DOS stub** → `DOSFile` (`DOSFile.swift`). Validates the `MZ` signature
+   and yields the embedded PE image at `e_lfanew`.
+2. **PE/COFF headers and sections** → `PEFile` (`PEFile.swift`). Exposes the data
+   directories and section headers; section headers translate a relative virtual
+   address (RVA) to a file offset.
+3. **CLI header** (`IMAGE_COR20_HEADER`) → data directory entry 14, parsed by
+   `Assembly` (`CIL.swift`). It points at the metadata root.
+4. **Metadata root** → `MetadataRoot` (`CIL.swift`). Begins with the `BSJB`
+   signature (`0x424A5342`), a version string, and a list of **stream headers**.
+
+## Streams
+
+The metadata root carries a handful of named streams (`StreamHeader`,
+`Metadata.Stream`), each a `(offset, size)` region of the metadata blob:
+
+| Stream | Contents | Type |
+| --- | --- | --- |
+| `#~` | The tables stream: table headers followed by packed records | `TablesStream` |
+| `#Strings` | NUL-terminated UTF-8 strings, referenced by byte offset | `StringsHeap` |
+| `#US` | User strings (UTF-16) | — |
+| `#GUID` | A packed array of 16-byte GUIDs, referenced by 1-based index | `GUIDHeap` |
+| `#Blob` | Length-prefixed byte blobs, referenced by byte offset | `BlobsHeap` |
+
+The three heaps are out-of-line storage: a column does not hold a string or blob,
+it holds an **index** into the relevant heap.
+
+- `StringsHeap[offset]` decodes a NUL-terminated UTF-8 string starting at
+  `offset`.
+- `BlobsHeap[offset]` reads a compressed length prefix (1, 2, or 4 bytes,
+  selected by the top bits of the first byte) and returns the following bytes as
+  a `Blob` (a `~Escapable` `RawSpan` view — no copy).
+- `GUIDHeap[index]` returns the `index`-th GUID; the index is 1-based, with 0
+  meaning "none".
+
+## The tables stream (`#~`)
+
+`TablesStream` (`TablesStream.swift`) parses the heart of the database. Its
+header is:
+
+```
+uint32  Reserved
+uint8   MajorVersion
+uint8   MinorVersion
+uint8   HeapSizes        ; bit 0/1/2 → #Strings/#GUID/#Blob index is 4 bytes (else 2)
+uint8   Reserved
+uint64  Valid            ; bitvector: which table numbers are present
+uint64  Sorted           ; bitvector: which tables are sorted
+uint32  Rows[]           ; one row count per present table, in table-number order
+uint8   Tables[]         ; the packed records of every present table, concatenated
+```
+
+`Valid.nonzeroBitCount` gives the number of present tables, hence the length of
+`Rows[]`. The record data for the tables follows immediately, one table after
+another in ascending table-number order.
+
+## Columns and indices
+
+Each table's schema is a list of `Field`s (`Table.swift`), exposed through the
+schema's `fields` accessor. A field's `ColumnType` is either:
+
+- `.constant(n)` — an inline integer of `n` bytes; or
+- `.index(Index)` — a reference, where `Index` is one of:
+  - `.heap(.string | .blob | .guid)` — an index into a heap;
+  - `.simple(TableSchema.Type)` — a row number into one specific table (a
+    foreign key);
+  - `.coded(CodedIndex.Type)` — a tagged-union foreign key across several
+    tables, with a table discriminator packed into the low bits and the row
+    number in the rest (`CodedIndex` in `CodedIndex.swift`).
+
+The **width** of an index column is not fixed by the spec — it is 2 bytes when
+the largest thing it can address fits, else 4. `PhysicalSchema`
+(`PhysicalSchema.swift`) computes every index width from `HeapSizes`, the `Valid`
+bitvector, and the row counts. This is the database's *physical schema*, exposed
+as `Database.catalog`.
+
+## How the library models it
+
+The library *projects* a read-only relational model onto the tables stream and
+heaps (see [RelationalModel.md](RelationalModel.md)). None of the types below
+materialise a database; each is a view that interprets the raw bytes in place:
+
+- **`TableSchema`** — the static, compile-time logical schema of a table: its
+  number and `fields`. The ~40 types in `Sources/WinMD/Tables/` are
+  uninstantiable markers conforming to it (e.g. `Metadata.Tables.MethodDef`).
+- **`PhysicalSchema`** — an immutable value holding the resolved physical schema
+  (all index/column byte widths). Resolved once when the database is opened and
+  exposed as `Database.catalog`.
+- **`Table`** — an immutable value describing an *open* table: a schema, a
+  `TupleDescriptor`, the row count, and the table's absolute byte `range`. The
+  present tables are opened once at database open.
+- **`TupleDescriptor`** (`TupleDescriptor.swift`) — a row's physical layout: each
+  column's precomputed byte offset (pre-summed) and width, plus the row
+  `stride`. Computed once per open table.
+- **`Row<Schema>`** — a cursor over a borrowed view: a row index that decodes a
+  cell on demand by arithmetic against the descriptor — `range + row * stride +
+  offset[i]`, a zero-copy unaligned `RawSpan` load. No allocation, no copy.
+- **`TableIterator<Schema>`** — a (table) scan over a table's rows, yielding a
+  typed `Row` cursor for each.
+- **`Database`** (`Database.swift`) — the entry point, and itself a `~Escapable`
+  borrowed view over the caller's byte buffer (a `RawSpan`): it does not own or
+  copy the bytes. It exposes `catalog` (the physical schema) and the open
+  tables; `rows(of:)` returns a typed iterator, `tables` lists the open tables,
+  and the heaps resolve indices to their contents.
+
+## Design principles
+
+- **Everything is a view.** Every level — `Database`, DOS stub, PE image,
+  streams, heaps, blobs, rows — is a `~Escapable` borrowed view (a `RawSpan`)
+  sharing the lifetime of a single byte buffer. The format is entirely
+  offset-addressable, so nothing is ever re-materialised; the library reads the
+  bytes in place rather than constructing a database from them. This holds
+  literally in the type system: `Database` does not own or copy the buffer,
+  and reads are zero-copy unaligned `RawSpan` loads at absolute byte offsets. The
+  caller owns the mapping and keeps it alive — `winmd-inspect` memory-maps the
+  file with `Data(contentsOf:options: .alwaysMapped)` and constructs
+  `Database(data.span.bytes)`, a `RawSpan` straight over the mapping. The read
+  path is zero-copy from the file all the way through to each record.
+- **Zero allocation on the hot path.** Schema layout is resolved once per table
+  at open. Reading a row constructs only a small cursor value and decodes
+  exactly the columns that are touched.
+- **Resolve once.** The catalog (index widths) and each table's row descriptor
+  are invariant for the file's lifetime and are computed a single time when the
+  database is opened, not on each access.
+- **O(1) column access.** Column offsets are pre-summed so locating a column is a
+  constant array lookup rather than a walk over preceding columns.

--- a/Documentation/QueryModel.md
+++ b/Documentation/QueryModel.md
@@ -1,0 +1,231 @@
+# Query Model
+
+The query model is how a caller reads and relates the metadata: scanning a
+relation, filtering and projecting its rows, and following foreign keys between
+relations. It builds directly on the [relational model](RelationalModel.md) —
+relations (`Table`), rows (`Row`/`Tuple`), foreign keys (`Index`/`CodedIndex`),
+and out-of-line heaps — and inherits the zero-copy, zero-allocation guarantees
+of the [database model](DatabaseModel.md).
+
+The primary use is *ad-hoc selection*: pick a subset of the API surface (a
+namespace, a set of types and their members). There are two front-ends, sharing
+the same underlying `~Escapable` scan and navigation primitives but otherwise
+independent:
+
+- **Textual SQL**, driven by `winmd-inspect query`, runs through a standalone
+  relational engine — a SQL parser, a logical operator compiler, an optimiser,
+  and an executor — over the WinMD database adapted to the engine's source
+  protocols.
+- **Swift combinators** — `where`/`select` over a borrowed row, and the
+  `resolve`/`list`/`referencing` foreign-key navigators — are used
+  programmatically, reading the WinMD views directly without going through the
+  SQL engine.
+
+## Layering
+
+Three layers keep the textual surface decoupled from any data source:
+
+- A standalone, **generic `SQL` module** — a lexer and parser producing a SQL
+  abstract syntax tree, plus the operator algebra (compiler, optimiser,
+  executor) that runs a `SELECT` against a set of adapter protocols. It knows
+  nothing of WinMD: it plans and executes entirely against `Catalog`, `Table`,
+  `Cursor`, and `Row`, never importing `WinMD`, and is reusable on its own.
+- The **WinMD module** — cursors, typed rows, and foreign-key navigation. It is
+  SQL-agnostic: it never imports the `SQL` module and is fully usable through
+  the Swift combinators alone.
+- **`winmd-inspect`** binds the two: `Database+SQL.swift` makes a WinMD database
+  conform to the `SQL` engine's source protocols, and the `query` subcommand
+  parses the input, runs it on the engine, and renders the resulting values.
+
+## The escape boundary
+
+The model is organised around one principle: a boundary between the borrowed
+*view* layer and the escapable *query* layer.
+
+- The **view layer** — `Database`, `Cursor`, `Tuple`, `Row`, and the engine's
+  `~Escapable` adapter (`Catalog`/`Table`/`Cursor`/`Row`) — is borrowed,
+  zero-copy windows over the mapped buffer; they carry `@_lifetime`
+  dependencies and cannot be stored, collected, or outlive the buffer.
+- The **query layer** — the SQL AST, the operator `Plan`, the engine's
+  materialised `Record`, and the WinMD predicate/projection closures — is fully
+  escapable. The `Plan` references each relation by its catalog *name* rather
+  than by a `~Escapable` `Table` (an `indirect enum` cannot box a `~Escapable`
+  payload); a WinMD closure has the form `(borrowing Tuple) -> Value`. Either
+  may *read* a borrowed row, but the type system forbids *storing* one
+  (`lifetime-dependent value escapes its scope`).
+
+Queries therefore compose, parse, and plan freely on the escapable side; the
+`~Escapable` views materialise only transiently, at execution, inside a borrow.
+The engine copies exactly the referenced cells out of a borrowed row into an
+escapable, slot-indexed `Record` at each scan leaf, so the operator tree runs
+on owned tuples while every lifetime concern stays confined to the view layer.
+
+## Relations and cursors
+
+A relation is opened as a cursor:
+
+- `database.rows(of: table)` — a *generic* cursor yielding `Tuple`, addressing
+  columns by ordinal (`tuple[3]`), or resolving a name to an ordinal once with
+  `tuple.ordinal(for: "TypeNamespace")` and reading by that ordinal.
+- `database.rows(of: TypeDef.self)` — a *typed* cursor yielding `Row<Schema>`,
+  addressing columns by a `Column<Schema, Value>` token (`row[.TypeName]`, with
+  value-type inference and per-schema autocomplete). This is the surface for
+  code that knows the table at compile time.
+
+(Key paths are unavailable — `KeyPath<Root, Value>` requires `Root: Escapable`,
+which the row views are not — so the typed column reference is the `Column`
+token.)
+
+The SQL engine does not run on either of these directly; it runs on the adapter
+protocols (below), which the WinMD database conforms to.
+
+## Textual SQL (the engine)
+
+The generic `SQL` module lexes and parses the text into a SQL AST — a relation,
+a projection (named columns or `*`), an optional predicate tree of
+`column · comparison · operand` nodes composed with `AND`/`OR`/`NOT`, an
+optional `JOIN … ON`, and an optional `ORDER BY`:
+
+```sql
+SELECT TypeName, TypeNamespace FROM TypeDef
+ WHERE TypeNamespace = 'Windows.Win32.Foundation'
+```
+
+`winmd-inspect query` hands the parsed `SELECT` to the database-agnostic
+`Engine`, which runs entirely against four adapter protocols a data source
+conforms to: a `Catalog` resolves a relation name to a `Table`; a `Table`
+reports its schema (real `width`, a name → ordinal map, and a `bound` for a
+sorted-seek) and vends a `Cursor`; a `Cursor` addresses rows by index; a `Row`
+reads a typed cell by ordinal. Every protocol is `~Escapable`, so a
+borrowed-storage source — a WinMD database over a mapped file — conforms to the
+same surface as an owned one. The engine yields typed `Value`s, never rendered
+text; `winmd-inspect` formats each into a tab-separated line.
+
+The engine runs the `SELECT` in three phases, each re-resolving relations by
+name through the borrowed catalog:
+
+1. **Compile.** It reads each relation's schema and shapes a logical operator
+   `Plan` in slot space: a single relation becomes
+   `Project(Sort(Select(Scan)))`; a join becomes the same over the Cartesian
+   `Product` of two scans, the `ON` equality conjoined onto the `WHERE`
+   predicate. Each `Scan` carries the relation name and exactly the ordinals the
+   query references (projection ∪ filter ∪ order ∪ join keys), in a fixed order
+   that defines a dense slot for each — *projection pushdown*, so a record is a
+   gap-free `Array<Value>` the operators address by slot.
+
+2. **Optimise.** Two pattern rewrites turn the logical tree physical. A `Select`
+   over a full `Scan` whose predicate is (or conjoins) a sort-key equality or
+   range on a *seekable* column becomes a **seeked scan** — the column's
+   `[lower, upper)` run found through the `Table.bound` partition point — with
+   any remaining predicate kept as a residual `Select`. A `Select` over a
+   `Product` whose predicate relates an outer ordinal to an inner one becomes an
+   **index-nested-loop join**: for each outer record, the inner relation is
+   seeked (via `bound`) to the matching run rather than the whole product being
+   formed.
+
+3. **Execute.** The executor re-resolves each relation, opens its cursor, and
+   materialises the referenced ordinals of each (seeked or full) row range into
+   dense `Record` slots — reals out of the cursor, virtual columns computed by
+   the row. `select` keeps the admitted records, `project` reorders to the
+   projected slots, `sort` orders by a typed key, and `join` seeks the inner per
+   outer record and concatenates the matches. The result is an array of typed
+   `Value` rows.
+
+### Joins over foreign keys and lists
+
+The WinMD adapter exposes two **virtual columns** past each relation's real
+fields, at ordinals outside the `SELECT *` range so a `*` never projects them:
+
+- `rowid` — the SQLite-style 1-based row index. A foreign key is a real column
+  holding a target row's `rowid`, so an equi-join over it is an ordinary FK
+  join — the child's foreign-key column against the parent's `rowid`:
+  `SELECT i.Interface FROM InterfaceImpl i JOIN TypeDef t ON i.Class = t.rowid`,
+  where `InterfaceImpl.Class` is a simple index into `TypeDef`.
+- `parent` — a list-child's owning parent's `rowid`. A list relationship (a
+  parent's run of children, e.g. `TypeDef.MethodList → MethodDef`) is not a
+  stored key, so the child relates to its owner through the computed `parent`
+  column against the parent's `rowid`:
+  `SELECT m.Name FROM TypeDef t JOIN MethodDef m ON m.parent = t.rowid`.
+
+A *coded* index column (e.g. `TypeDef.Extends`, a `TypeDefOrRef`) exposes its
+raw encoded value — the packed row-plus-tag token — not a bare row id, so
+relating it to a target table's `rowid` must be spelled out explicitly.
+
+A real column always takes precedence over a same-named pseudo-column, as in
+SQLite: a table that has its own `Parent` field (`EventMap`, `PropertyMap`,
+`ClassLayout`, …) resolves `Parent` to that real foreign key, so the virtual
+`parent` reaches only the list-child tables that have no real `Parent` field.
+
+Both virtual columns are seekable — `rowid` is dense and monotonic, `parent` is
+monotonic over a list-child's runs — so the engine's index-nested-loop join
+seeks them through the same `bound` path it uses for an intrinsic sort key. The
+adapter, not the engine, knows that a WinMD foreign key or list run *is* a join;
+the engine sees only seekable columns and equi-join predicates.
+
+## Swift combinators (programmatic)
+
+In Swift, a query filters with `where` and maps with `select`, written as
+closures over a borrowed row — an ordinary expression that bypasses the SQL
+engine entirely:
+
+```swift
+database.rows(of: TypeDef.self)
+  .select({ $0[.TypeName] },
+          where: { $0[.TypeNamespace] == "Windows.Win32.Foundation" })
+  .forEach { print($0) }
+```
+
+`select(_:where:)` is the common-case entry point; chained
+`where(_:).select(_:)` reads better when built up incrementally. A closure is
+general but opaque — every `where` is an `O(rows)` scan — so the sorted-index
+and join optimisations apply only to the SQL engine, which inspects a structured
+plan rather than running a closure per row.
+
+### Consumption
+
+Because a `~Escapable` view cannot conform to `Sequence` and a filtered cursor's
+count is unknown without scanning, combinator results are consumed through
+**callback terminals** — `forEach`, `first(where:)`, `reduce`, `count` — never a
+materialised array of rows. A projection yields escapable values; to surface
+rows themselves, they are handed to a `(borrowing Tuple) -> Void` callback. (The
+SQL engine, by contrast, materialises owned `Record`s and returns an array of
+typed `Value` rows.)
+
+### Navigation (foreign keys)
+
+A column whose type is an `Index` or `CodedIndex` is a foreign key; navigation
+is expressed on the typed row through the `Reference`, `CodedReference`, and
+`List` tokens:
+
+- **Forward, single** — `row.resolve(.Parent)` follows a simple index to the
+  typed `Row<Target>?` it names; `row.resolve(.Extends)` follows a coded index
+  to a type-erased `Tuple?` (its target table chosen at runtime by the tag),
+  which `Row<Target>(_:)` narrows once the target is known. `O(1)`.
+- **Forward, list** — `row.list(.FieldList)` yields a cursor over the
+  `[start, next-row's start)` run-length range. `O(1)` to open.
+- **Reverse** — `database.referencing(row, by: CustomAttribute.Parent)` yields
+  a `Filter` matching the rows whose foreign key targets this row. When the
+  owning relation is `Sorted` on that column (the tables-stream `Sorted`
+  bitvector), this is a binary search, `O(log n)`; otherwise a linear scan, and
+  it says so.
+
+Heap columns read through their tokens: a `#Strings` or `#GUID` column through
+the `Column` value token (`row[.TypeName]`), a `#Blob` column through the
+`BlobColumn` token (`row[token]`, or `row.blob(token)` for the validating
+read). The SQL engine reaches the same foreign-key and list joins through the
+adapter's `rowid`/`parent` virtual columns described above.
+
+## Complexity
+
+| Operation | Cost |
+| --- | --- |
+| scan / closure filter | `O(rows)` |
+| SQL equality/range on a seekable column | `O(log rows)` + run length |
+| SQL index-nested-loop join (seekable key) | `O(outer · log inner)` + matches |
+| forward foreign key (simple / coded / list) | `O(1)` |
+| reverse foreign key | `O(log rows)` when `Sorted`, else `O(rows)` |
+| heap resolution | `O(payload)` |
+
+The combinator path never materialises a relation or allocates per row; a query
+is a borrowed traversal of the mapped buffer. The SQL engine materialises only
+the referenced cells of surviving rows into slot records, never a whole table.

--- a/Documentation/RelationalModel.md
+++ b/Documentation/RelationalModel.md
@@ -1,0 +1,115 @@
+# The Relational Model, Applied to WinMD
+
+A `.winmd` file is **raw, offset-addressable data wrapped in a stack of nested
+envelopes** — an MS-DOS stub around a PE/COFF image around a CLI header around a
+metadata root around a set of streams (see
+[DatabaseModel.md](DatabaseModel.md)). At the bottom of that stack sit a tables
+stream and a few heaps whose shape happens to be exactly that of a fixed set of
+relations: a statically known schema, rows addressed by index, and cross-table
+references that behave like foreign keys.
+
+This library **projects a relational model onto those bytes** as a lens for
+access. It does *not* turn the file into a database. There is no storage engine
+underneath: nothing is loaded, inserted, indexed, or materialised. Every type —
+`Database` included — is fundamentally a **`~Escapable` borrowed view over the
+raw underlying bytes** (a `RawSpan`), interpreting them in place without owning
+or copying them. The relational vocabulary used throughout the code (`Database`,
+catalog, row descriptor, cursor, foreign key) is a well-understood way to
+*structure access*, not a claim that a relational substrate exists.
+
+Rather than invent a vocabulary, then, this library borrows the concepts that
+the SQL relational model has settled on over decades and applies them as a
+reading lens. This document names those concepts and shows how each maps onto
+the code.
+
+> **The model is a projection, not the substrate.** The substrate is
+> envelope-wrapped metadata; the relational model is how this library *reads*
+> it. Keep that distinction in mind for every mapping below — "table", "row",
+> and "catalog" describe how access is organised, not what is stored.
+
+## Why the lens fits
+
+The tables-stream-and-heaps layer of a WinMD file — the innermost envelope, once
+all the PE/CLI wrapping is unwound — has the shape of a relational database,
+minus the parts that exist to support mutation:
+
+- The schema is **fixed and known at compile time** (ECMA-335 §II.22). There is
+  no DDL, no user-defined tables.
+- The file is a **sealed, read-only snapshot**: no transactions, no concurrency
+  control, no logging, no mutation. Once opened, nothing changes — so derived
+  structures (catalog, layouts) never need invalidation.
+- Every column is **fixed-width within a given database**. There is no
+  null bitmap and no variable-length row walking: row *r* of a table
+  begins at `r * stride`, and column *i* sits at a constant offset within it.
+  This is simpler than a general engine's slotted page — a table is just a
+  packed array of fixed-width rows.
+
+These simplifications mean the *access path* reduces to its essentials: resolve
+the catalog once, build a row descriptor per table, and hand out cursors. There
+is no engine to speak of — only arithmetic over a buffer. The relational terms
+below name the steps of that arithmetic, not components of a running database.
+
+## Concept map
+
+| Relational concept | WinMD / ECMA-335 | This library |
+| --- | --- | --- |
+| Logical schema (the catalog's table/column definitions) | The table definitions in ECMA-335 §II.22 — table number and column descriptors | `TableSchema` (`Table.swift`); the ~40 marker types in `Sources/WinMD/Tables/` |
+| Physical schema / the catalog (system metadata describing the schema) | Resolved index/column byte widths, derived from the `Valid` bitvector, row counts, and `HeapSizes` | `PhysicalSchema` (`PhysicalSchema.swift`), exposed as `Database.catalog` |
+| The catalog resolved once at open | Resolved once when the database is opened | `Database.catalog`, computed in `Database.init` |
+| Row descriptor (precomputes each column's byte offset) | The byte offset and width of each column, pre-summed, plus the row stride | `TupleDescriptor` (`TupleDescriptor.swift`) |
+| A table / open relation | One table's rows within the file | `Table` (the immutable value in `Table.swift`) |
+| A row / cursor (an offset into the buffer + the shared descriptor) | A row addressed by index into the table's packed rows | `Row<Schema>` (`Iteration.swift`) |
+| A (table) scan | Iterating a table's rows | `TableIterator<Schema>` |
+| Foreign key | Simple index (one target table) and coded index (a tagged-union FK across several tables) | `Index.simple` / `Index.coded`; `CodedIndex` |
+| Out-of-line storage, referenced by offset | The `#Strings`, `#Blob`, and `#GUID` heaps | `StringsHeap`, `BlobsHeap`, `GUIDHeap` |
+| Read-only snapshot (no transactions, no concurrency control, no logging) | The sealed file | the absence of any mutation path |
+
+## How the pieces play together
+
+**Resolve the catalog once.** Opening a `Database` borrows the caller-owned byte
+buffer (a `RawSpan`), unwraps the envelopes down to the metadata, locates the
+streams, and resolves the physical schema into a `PhysicalSchema` value —
+exposed as `Database.catalog`. The catalog is invariant for the file's lifetime,
+so it is resolved once in the initialiser and never rebuilt. "Opening"
+materialises nothing: a `Database` is a `~Escapable` borrowed view over the
+buffer, not a constructed copy of it. The caller owns and keeps the buffer
+alive; see the zero-copy principle in [DatabaseModel.md](DatabaseModel.md).
+
+**Resolve a row descriptor per table.** With the catalog in hand, each
+present table is *opened* into a `Table` value. At that moment its
+`TupleDescriptor` is computed once: the column widths are resolved against the
+catalog and pre-summed into offsets, so that locating column *i* is a constant
+array lookup rather than a walk over the preceding columns. The value holds the
+schema, the descriptor, the row count, and the table's absolute byte range.
+
+**Hand out cursors, not copies.** A `Row<Schema>` is a cursor: a row index over
+a borrowed view of the buffer. Constructing one allocates nothing and copies
+nothing. Reading column *i* computes `range + row * stride + offset[i]` and reads
+the cell straight from the shared buffer as a zero-copy unaligned `RawSpan` load.
+The `Schema` type parameter is a phantom — it carries no data, but lets the typed
+per-table accessors (`row.Name`, `row.Flags`, …) be checked at compile time while
+the runtime path stays schema-erased.
+
+**Resolve foreign keys by following indices.** A column typed as a simple or
+coded index holds a row number into another table (the coded case packs a
+table discriminator into the low bits). Resolving it is a catalog lookup for the
+target table followed by a cursor at that row — a foreign-key join, done
+lazily on access.
+
+## The shape this produces
+
+Because the format is read-only and fixed-width, and because the library only
+*reads* it rather than backing it with an engine, there is no machinery for the
+things that make a real relational database complex. What remains is the
+irreducible access path — offset arithmetic over the envelope-wrapped bytes,
+dressed in relational terms:
+
+```
+borrow buffer → resolve catalog (once)
+              → open each table, resolve its row descriptor (once each)
+              → iterate / index → cursors (zero alloc, O(1) column access)
+              → follow indices → cursors into other tables
+```
+
+See [DatabaseModel.md](DatabaseModel.md) for the concrete on-disk format and the
+types that parse it.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Swift/WinMD
 
-An ECMA 335 parser in Swift
+An ECMA-335 metadata reader in Swift
 
 <p align="center">
   <a href="https://github.com/compnerd/swift-winmd/actions?query=workflow%3Awindows">
@@ -11,20 +11,67 @@ An ECMA 335 parser in Swift
   </a>
 </p>
 
-[Windows Metadata](https://docs.microsoft.com/en-us/uwp/winrt-cref/winmd-files) provides the necessary metadata for Windows APIs to enable generating bindings for different languages.  In order to generate the bindings, one must be able to process the metadata.  [Swift/WinMD](https://github.com/compnerd/swift-winmd) provides an implementation of such a parser in Swift.
+[Windows Metadata](https://docs.microsoft.com/en-us/uwp/winrt-cref/winmd-files) provides the necessary metadata for Windows APIs to enable generating bindings for different languages.  In order to generate the bindings, one must be able to process the metadata.  [Swift/WinMD](https://github.com/compnerd/swift-winmd) provides an implementation of such a reader in Swift.
+
+Beyond parsing, the library projects the metadata as a read-only relational
+database. Its tables stream and heaps are read as a fixed set of relations with
+rows, foreign keys, and out-of-line heaps, all as zero-copy `~Escapable`
+borrowed views over the caller's bytes. That database can be **queried** in two
+ways: a typed Swift combinator surface (`where`/`select` over a borrowed row,
+with `resolve`/`list`/`referencing` foreign-key navigation), and textual SQL run
+through a small, self-contained relational engine.
+
+The SQL engine is a standalone, WinMD-agnostic module: a lexer and parser for a
+minimal `SELECT` dialect, plus an operator algebra (a compiler, an optimiser,
+and an executor) that plans and runs a query against four adapter
+protocols — `Catalog`, `Table`, `Cursor`, and `Row` — knowing nothing of any
+particular data source. `winmd-inspect` adapts the WinMD database to those
+protocols, exposing each table's rows along with two virtual columns — a
+`rowid` (the 1-based row index) and a `parent` (a list-child's owning row) — so
+that foreign-key and parent/child list relationships become ordinary equi-joins
+the engine can plan and seek.
+
+The `winmd-inspect` command-line tool exposes the reader through its `dump`,
+`print-namespaces`, and `query` subcommands:
+
+```
+winmd-inspect <file.winmd> dump
+winmd-inspect <file.winmd> print-namespaces
+winmd-inspect <file.winmd> query \
+    "SELECT TypeName, TypeNamespace FROM TypeDef \
+       WHERE TypeNamespace = 'Windows.Win32.Foundation'"
+```
+
+The `query` subcommand parses the SQL, hands the parsed `SELECT` to the engine,
+and renders each resulting row as a tab-separated line.
 
 ## Build Requirements
 
-- Swift 5.5 or newer
+- A Swift 6.4 development toolchain
 
-## Debugging
+The package uses `RawSpan`, `Span`, and `InlineArray` along with the experimental
+`Lifetimes` feature, which the package enables for you; no additional flags are
+required.
 
-### Debugging on Windows
+When building on an Apple platform, the macOS 26 SDK is required.
 
-For debugging the Swift application code, it is easier to debug using LLDB and
-DWARF.  In such a case, you will need to build the application as follows to
-enable the debug information:
+Build it with the Swift Package Manager:
 
-```cmd
-swift build -Xlinker -debug:dwarf
 ```
+swift build
+swift test
+```
+
+The package vends a `winmd-inspect` executable and a reusable `SQL` library.
+
+## Documentation
+
+The on-disk format and the design of the library are described in the
+[`Documentation`](Documentation) directory:
+
+- [`DatabaseModel.md`](Documentation/DatabaseModel.md) — the on-disk WinMD/ECMA-335
+  format and the types used to parse it.
+- [`RelationalModel.md`](Documentation/RelationalModel.md) — the read-only relational
+  projection the library is modelled on.
+- [`QueryModel.md`](Documentation/QueryModel.md) — selecting, filtering, and
+  navigating the metadata through textual SQL and typed Swift combinators.


### PR DESCRIPTION
This pull request adds comprehensive documentation for the WinMD database and query models. The new documents explain both the physical storage model and the query mechanisms, including SQL and Swift combinators, with details on performance, layering, and navigation. These additions clarify how the library interprets, exposes, and queries WinMD metadata in a zero-copy, zero-allocation manner.

**Database Model Documentation:**
* Added `DatabaseModel.md` describing the on-disk WinMD structure, stream types, index encoding, and the library’s zero-copy, view-based design principles.

**Query Model Documentation:**
* Added `QueryModel.md` detailing how queries are expressed and executed, covering both SQL and Swift combinator approaches, the layering between modules, foreign key navigation, and complexity guarantees.