### PR TITLE
SQL: admit views as first-class relations

### DIFF
--- a/Sources/SQL/Adapter.swift
+++ b/Sources/SQL/Adapter.swift
@@ -41,22 +41,64 @@ public enum Value: Hashable, Sendable {
   case text(String)
 }
 
+// MARK: - View
+
+/// A named `SELECT` registered as a first-class relation.
+///
+/// A view is a stored query the engine resolves wherever a base table is: its
+/// `select` is the query that produces the rows, and `columns` names the
+/// relation's columns in projection order — column `i` is the `i`th projected
+/// value of `select`. A view is fully escapable data — no borrowed storage — so
+/// it sits beside the `~Escapable` base tables in the same catalog namespace; a
+/// catalog vends one through `view(named:)`. The engine compiles a view's
+/// `select` into a sub-plan and splices it in where the view is named, the
+/// outer query addressing the view's columns by their ordinal in `columns`. A
+/// view carries no virtual column, so its `extent` is its `columns` count.
+public struct View: Hashable, Sendable {
+  /// The query the view stands for.
+  public let select: Select
+
+  /// The view's column names, in projection order — column `i` is the `i`th
+  /// projected value of `select`.
+  public let columns: Array<String>
+
+  public init(select: Select, columns: Array<String>) {
+    self.select = select
+    self.columns = columns
+  }
+}
+
 // MARK: - Catalog
 
-/// Resolves a relation name to a table.
+/// Resolves a relation name to a table or a view.
 ///
 /// The catalog is the engine's only entry into a data source: a `SELECT`'s
-/// `FROM` name is looked up here. A name the source does not know yields `nil`,
-/// which the engine reports as `SQLError.relation`. The catalog is `~Escapable`,
-/// and the `Table` it vends borrows it — a borrowed-storage source may resolve a
-/// relation to a view that never escapes the catalog's borrow.
+/// `FROM` name is looked up here. A name the source does not know as either a
+/// table or a view yields `nil` from both, which the engine reports as
+/// `SQLError.relation`. The catalog is `~Escapable`, and the `Table` it vends
+/// borrows it — a borrowed-storage source may resolve a relation to a view that
+/// never escapes the catalog's borrow. A view, by contrast, is escapable data:
+/// a catalog that registers none returns `nil` from the default `view(named:)`.
 public protocol Catalog: ~Escapable {
   /// The table this catalog vends.
   associatedtype Table: SQL.Table & ~Escapable
 
-  /// The table named `name`, or `nil` if the source has no such relation.
+  /// The table named `name`, or `nil` if the source has no such base relation.
   @_lifetime(borrow self)
   borrowing func table(named name: String) -> Table?
+
+  /// The view named `name`, or `nil` if the source registers no such view.
+  ///
+  /// The engine resolves a `FROM`/`JOIN` name against the views first: a name a
+  /// catalog registers as a view shadows a base table of the same name. The
+  /// default registers no view, so a source without stored queries need not
+  /// implement it.
+  borrowing func view(named name: String) -> View?
+}
+
+extension Catalog where Self: ~Escapable {
+  /// A catalog with no stored queries registers no view.
+  public borrowing func view(named name: String) -> View? { nil }
 }
 
 // MARK: - Table
@@ -76,6 +118,24 @@ public protocol Table: ~Escapable {
 
   /// The number of real columns — the extent of a `SELECT *` projection.
   var width: Int { get }
+
+  /// The real column names, in ordinal order — column `i` of `names` is the
+  /// name of the real column at ordinal `i`.
+  ///
+  /// A relation knows its own column names; the engine reads them to lift a
+  /// base table's resolution onto an escapable `Schema` so a join may resolve a
+  /// view against a base table uniformly. The virtual columns (`rowid`,
+  /// `parent`) are not in `names`; they resolve through `ordinal(of:)`.
+  var names: Array<String> { get }
+
+  /// The virtual column names, in ordinal order — virtual `i` of `virtuals`
+  /// sits at ordinal `width + i`.
+  ///
+  /// A virtual column is computed by the `Row` rather than stored (a `rowid`, a
+  /// `parent`); naming them lets the engine lift resolution onto an escapable
+  /// `Schema`. The default is empty — a relation overrides it only when it
+  /// computes a virtual column, and then its `extent` is `width + virtuals.count`.
+  var virtuals: Array<String> { get }
 
   /// One past the highest ordinal this table can address — its real `width`
   /// plus the virtual columns it exposes.
@@ -112,6 +172,9 @@ public protocol Table: ~Escapable {
 extension Table where Self: ~Escapable {
   /// A relation with no virtual column ends at its real `width`.
   public var extent: Int { width }
+
+  /// A relation exposes no virtual column by default.
+  public var virtuals: Array<String> { [] }
 }
 
 // MARK: - Cursor

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -57,36 +57,32 @@ public enum Engine {
   internal static func compile<C: Catalog & ~Escapable>(_ select: Select,
                                                         _ catalog: borrowing C)
       throws(SQLError) -> Plan {
-    guard let table = catalog.table(named: select.from.name) else {
-      throw .relation(select.from.name)
-    }
+    let from = try resolve(select.from, catalog)
 
     guard let join = select.join else {
       var filter: Filter? = nil
       if let predicate = select.predicate {
-        filter = try table.lower(predicate, in: select.from)
+        filter = try from.schema.lower(predicate, in: select.from)
       }
       var order: (column: Int, ascending: Bool)? = nil
       if let clause = select.order {
-        order = try table.order(clause, in: select.from)
+        order = try from.schema.order(clause, in: select.from)
       }
-      let projection = try table.projection(select.projection, in: select.from)
+      let projection =
+          try from.schema.projection(select.projection, in: select.from)
 
       // The referenced ordinals, in slot order: slot `i` is `ordinals[i]`.
       let ordinals = referenced(projection, filter, order)
       let slot = invert(ordinals)
-      let scan = Plan.scan(name: select.from.name, ordinals: ordinals,
-                           seek: nil)
+      let scan = from.leaf(ordinals)
       return shape(scan, projection.map { slot[$0]! },
                    filter.map { remap($0, slot) },
                    order.map { (slot[$0.column]!, $0.ascending) })
     }
 
-    guard let inner = catalog.table(named: join.relation.name) else {
-      throw .relation(join.relation.name)
-    }
+    let inner = try resolve(join.relation, catalog)
 
-    let scope = Scope(select.from, table, join.relation, inner)
+    let scope = Scope(select.from, from.schema, join.relation, inner.schema)
     let on = try scope.match(join.left, join.right)
     var predicate: Filter? = nil
     if let clause = select.predicate {
@@ -101,25 +97,61 @@ public enum Engine {
     let base = scope.base
 
     let combined = referenced(projection, filter, order)
-    let outerOrdinals = combined.filter { $0 < base }
-    let innerOrdinals = combined.filter { $0 >= base }.map { $0 - base }
+    let head = combined.filter { $0 < base }
+    let tail = combined.filter { $0 >= base }.map { $0 - base }
 
-    // The combined slot map: the outer scan's referenced ordinals take slots
-    // `[0, outerCount)`, the inner scan's take `[outerCount, outerCount +
-    // innerCount)`, matching the merged record's outer-then-inner layout.
-    var slot = invert(outerOrdinals)
-    let split = outerOrdinals.count
-    for index in innerOrdinals.indices {
-      slot[innerOrdinals[index] + base] = split + index
+    // The combined slot map: the outer scan's referenced ordinals take the
+    // leading slots `[0, head.count)`, the inner scan's take the trailing slots
+    // `[head.count, head.count + tail.count)`, matching the merged record's
+    // outer-then-inner layout.
+    var slot = invert(head)
+    let split = head.count
+    for index in tail.indices {
+      slot[tail[index] + base] = split + index
     }
 
-    let outer = Plan.scan(name: select.from.name, ordinals: outerOrdinals,
-                          seek: nil)
-    let right = Plan.scan(name: join.relation.name, ordinals: innerOrdinals,
-                          seek: nil)
+    let outer = from.leaf(head)
+    let right = inner.leaf(tail)
     return shape(.product(outer, right), projection.map { slot[$0]! },
                  remap(filter, slot),
                  order.map { (slot[$0.column]!, $0.ascending) })
+  }
+
+  /// A relation resolved for compilation: its name-resolution `schema` and a
+  /// `leaf` factory that, given the ordinals the query references on its side,
+  /// builds the leaf `Plan` — a `scan` for a base table, a `derived` over the
+  /// view's compiled sub-plan for a view.
+  private struct Resolved {
+    let schema: Schema
+    let leaf: (Array<Int>) -> Plan
+  }
+
+  /// Resolves a `Relation` against `catalog` to its schema and leaf factory.
+  ///
+  /// A view shadows a base table of the same name: the catalog is consulted for
+  /// a view first, its `select` compiled to a sub-plan and wrapped in a
+  /// `derived` leaf; otherwise a base table resolves and scans. A name neither
+  /// resolves is `SQLError.relation`.
+  private static func resolve<C: Catalog & ~Escapable>(_ relation: Relation,
+                                                       _ catalog: borrowing C)
+      throws(SQLError) -> Resolved {
+    if let view = catalog.view(named: relation.name) {
+      let plan = try optimise(compile(view.select, catalog), catalog)
+      let schema = view.schema()
+      return Resolved(schema: schema) { ordinals in
+        .derived(name: relation.name, plan: plan, ordinals: ordinals,
+                 seek: nil)
+      }
+    }
+
+    guard let table = catalog.table(named: relation.name) else {
+      throw .relation(relation.name)
+    }
+    let schema = table.schema()
+    let name = relation.name
+    return Resolved(schema: schema) { ordinals in
+      .scan(name: name, ordinals: ordinals, seek: nil)
+    }
   }
 
   /// The sorted, deduplicated ordinals a query references: the union of its
@@ -205,6 +237,10 @@ public enum Engine {
       throws(SQLError) -> Plan {
     switch plan {
     case .scan:
+      plan
+    case .derived:
+      // A view's sub-plan is optimised when the view is compiled; a derived
+      // leaf carries no sort key, so it scans its result as is.
       plan
     case let .select(filter, .scan(name, ordinals, nil)):
       try seek(filter, name, ordinals, catalog)

--- a/Sources/SQL/Operator.swift
+++ b/Sources/SQL/Operator.swift
@@ -104,6 +104,13 @@ internal indirect enum Plan {
   /// A leaf over the relation `name`: its `ordinals` (defining its slots), over
   /// the seek's row range when present (else the whole relation).
   case scan(name: String, ordinals: Array<Int>, seek: Range<Int>?)
+  /// A leaf over a view: the view's compiled sub-`plan` produces its full-width
+  /// rows (its columns at slots `0 ..< columns.count`), of which `ordinals`
+  /// (slots into those columns) define this leaf's slots, over the seek's row
+  /// range when present. A view exposes no virtual column and no sort key, so
+  /// `ordinals` index its columns directly and a seek is never planned into it.
+  case derived(name: String, plan: Plan, ordinals: Array<Int>,
+               seek: Range<Int>?)
   /// σ — keeps the records `Filter` admits, the filter in slot space.
   case select(Filter, Plan)
   /// π — restricts and reorders each record to the projected slots.
@@ -139,6 +146,8 @@ internal func execute<C: Catalog & ~Escapable>(_ plan: Plan,
   switch plan {
   case let .scan(name, ordinals, seek):
     try materialise(name, ordinals, seek, catalog)
+  case let .derived(_, source, ordinals, seek):
+    try derive(source, ordinals, seek, catalog)
   case let .select(filter, source):
     try execute(source, catalog).filter { evaluate(filter, $0) }
   case let .project(slots, source):
@@ -181,6 +190,23 @@ private func materialise<C: Catalog & ~Escapable>(_ name: String,
     records.append(Record(row, ordinals))
   }
   return records
+}
+
+/// Executes a view's sub-`plan` against `catalog` and re-lays each resulting
+/// record to the referenced `ordinals` (slots into the view's columns) over the
+/// seek's row range (the whole result when `nil`).
+///
+/// The sub-plan yields full-width view records — its columns at slots
+/// `0 ..< columns.count`; this projects each to the `ordinals` the outer query
+/// reads, in the slot order the outer scan expects (slot `i` is `ordinals[i]`).
+private func derive<C: Catalog & ~Escapable>(_ plan: Plan,
+                                             _ ordinals: Array<Int>,
+                                             _ seek: Range<Int>?,
+                                             _ catalog: borrowing C)
+    throws(SQLError) -> Array<Record> {
+  let rows = try execute(plan, catalog)
+  let range = seek ?? 0 ..< rows.count
+  return range.map { rows[$0].project(ordinals) }
 }
 
 /// The Cartesian product of two materialised relations: every concatenation of

--- a/Sources/SQL/Resolve.swift
+++ b/Sources/SQL/Resolve.swift
@@ -4,29 +4,28 @@
 /// Resolution and lowering — the bridge from the name-addressed AST to the
 /// engine's ordinal-addressed forms.
 ///
-/// The AST names columns by string; the engine addresses them by ordinal. A
-/// single relation resolves a name against its `Table` directly. A join lays its
-/// two relations end to end in one combined ordinal space and resolves a
-/// possibly qualified name against the pair through a `Scope`. Both lower a
-/// `Projection` to ordinals (`*` → the real width, never a virtual column), an
-/// `Order` to an `(ordinal, ascending)` pair, and the AST `Predicate` to the
-/// engine's `Filter`. A column name resolves to a real ordinal (`< width`) or a
-/// virtual one (`>= width`). A name no relation resolves is `SQLError.column`;
-/// an unqualified name both relations of a join resolve is `SQLError.ambiguous`.
-///
-/// The table is `~Escapable`, so resolution borrows it rather than storing it.
-/// The `Table` extension methods are `borrowing`; a join resolves through a
-/// `~Escapable` `Scope` that borrows both relations for the span of
-/// compilation, where both tables are live.
+/// The AST names columns by string; the engine addresses them by ordinal.
+/// Resolution reads only a relation's schema — its `width`, its `extent`, and
+/// its name → ordinal map — never its live cursor, so it runs over an escapable
+/// `Schema` (lifted off a base `Table` or a compiled `View`) rather than the
+/// `~Escapable` source. A single relation resolves a name against one `Schema`.
+/// A join lays its two relations end to end in one combined ordinal space and
+/// resolves a possibly qualified name against the pair through a `Scope`. Both
+/// lower a `Projection` to ordinals (`*` → the real width, never a virtual
+/// column), an `Order` to an `(ordinal, ascending)` pair, and the AST
+/// `Predicate` to the engine's `Filter`. A column name resolves to a real
+/// ordinal (`< width`) or a virtual one (`>= width`). A name no relation
+/// resolves is `SQLError.column`; an unqualified name both relations of a join
+/// resolve is `SQLError.ambiguous`.
 
-extension Table where Self: ~Escapable {
+extension Schema {
   /// The ordinal of the column `column` names, validating its qualifier against
   /// `relation`.
   ///
   /// A single-relation query has one relation, so a qualifier — `relation`'s
   /// alias, else its table name — must name it; any other qualifier is
   /// `SQLError.column`, as a join rejects a qualifier naming neither side.
-  internal borrowing func ordinal(of column: Column, in relation: Relation)
+  internal func ordinal(of column: Column, in relation: Relation)
       throws(SQLError) -> Int {
     if let qualifier = column.qualifier,
         (relation.alias ?? relation.name) != qualifier {
@@ -38,8 +37,7 @@ extension Table where Self: ~Escapable {
     return ordinal
   }
 
-  internal borrowing func projection(_ projection: Projection,
-                                     in relation: Relation)
+  internal func projection(_ projection: Projection, in relation: Relation)
       throws(SQLError) -> Array<Int> {
     switch projection {
     case .all:
@@ -48,19 +46,19 @@ extension Table where Self: ~Escapable {
       var ordinals = Array<Int>()
       ordinals.reserveCapacity(columns.count)
       for column in columns {
-        ordinals.append(try ordinal(of: column, in: relation))
+        try ordinals.append(ordinal(of: column, in: relation))
       }
       return ordinals
     }
   }
 
-  internal borrowing func order(_ order: Order, in relation: Relation)
+  internal func order(_ order: Order, in relation: Relation)
       throws(SQLError) -> (column: Int, ascending: Bool) {
     try (column: ordinal(of: order.column, in: relation),
          ascending: order.ascending)
   }
 
-  internal borrowing func lower(_ predicate: Predicate, in relation: Relation)
+  internal func lower(_ predicate: Predicate, in relation: Relation)
       throws(SQLError) -> Filter {
     switch predicate {
     case let .comparison(column, op, value):
@@ -86,31 +84,29 @@ extension Table where Self: ~Escapable {
 /// virtual columns — ordinals at or past its real width, such as a `rowid` or a
 /// `parent` — stay on the outer side rather than colliding with the inner's
 /// space; an outer column resolves to its own ordinal, an inner column to
-/// `base + ordinal`. A `Scope` resolves a possibly qualified
-/// `SQL.Column` into that combined space so the engine's `Filter`, projection,
-/// and order all address cells uniformly across the pair. A qualifier names a
-/// relation by its alias, else its table name; an unqualified name resolves
-/// against both relations and is ambiguous if each has it. The scope is
-/// `~Escapable`: it borrows both `~Escapable` tables, and the engine resolves
-/// through it entirely within compilation, where the tables are live.
-internal struct Scope<T: Table & ~Escapable>: ~Escapable {
+/// `base + ordinal`. A `Scope` resolves a possibly qualified `SQL.Column` into
+/// that combined space so the engine's `Filter`, projection, and order all
+/// address cells uniformly across the pair. A qualifier names a relation by its
+/// alias, else its table name; an unqualified name resolves against both
+/// relations and is ambiguous if each has it. Resolution reads only schemas, so
+/// the scope is escapable data over the two relations' `Schema`s.
+internal struct Scope {
   /// The left (outer, `FROM`) relation reference; its alias, else its table
-  /// name, is the qualifier that selects the `outer` table.
+  /// name, is the qualifier that selects the `outer` schema.
   private let left: Relation
   /// The right (inner, `JOIN`) relation reference; its qualifier selects the
-  /// `inner` table.
+  /// `inner` schema.
   private let right: Relation
-  /// The outer and inner tables, laid end to end.
-  private let outer: T
-  private let inner: T
+  /// The outer and inner schemas, laid end to end.
+  private let outer: Schema
+  private let inner: Schema
 
-  @_lifetime(borrow outer, borrow inner)
-  internal init(_ left: Relation, _ outer: borrowing T,
-                _ right: Relation, _ inner: borrowing T) {
+  internal init(_ left: Relation, _ outer: Schema,
+                _ right: Relation, _ inner: Schema) {
     self.left = left
     self.right = right
-    self.outer = copy outer
-    self.inner = copy inner
+    self.outer = outer
+    self.inner = inner
   }
 
   /// The base ordinal of the inner relation in the combined space.
@@ -120,9 +116,7 @@ internal struct Scope<T: Table & ~Escapable>: ~Escapable {
   /// inner ordinals begin. No outer ordinal — a real column below the width or a
   /// virtual column at or just past it — reaches it, so the `< base` / `>= base`
   /// split classifies a combined ordinal to its side even when the outer
-  /// relation contributes a virtual column. Anchoring on the outer's real extent
-  /// (rather than a fixed `1 << 32` reserve, which a 32-bit shift collapses to
-  /// zero) keeps the layout correct on every word size with no giant gap.
+  /// relation contributes a virtual column.
   internal var base: Int {
     outer.extent
   }
@@ -146,8 +140,8 @@ internal struct Scope<T: Table & ~Escapable>: ~Escapable {
   ///
   /// A qualifier admits only the relation it names; an unqualified name admits
   /// both. Within the admitted relations the name resolves: present in exactly
-  /// one it yields that ordinal; in both â two relations sharing a qualifier (a
-  /// self-join or a duplicated alias), or an unqualified name sitting in each â
+  /// one it yields that ordinal; in both — two relations sharing a qualifier (a
+  /// self-join or a duplicated alias), or an unqualified name sitting in each —
   /// it is `SQLError.ambiguous`; in neither it is `SQLError.column`.
   internal func ordinal(of column: Column) throws(SQLError) -> Int {
     let here =
@@ -181,7 +175,7 @@ internal struct Scope<T: Table & ~Escapable>: ~Escapable {
       var ordinals = Array<Int>()
       ordinals.reserveCapacity(columns.count)
       for column in columns {
-        ordinals.append(try ordinal(of: column))
+        try ordinals.append(ordinal(of: column))
       }
       return ordinals
     }

--- a/Sources/SQL/Schema.swift
+++ b/Sources/SQL/Schema.swift
@@ -1,0 +1,75 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+/// A relation's name-resolution surface, lifted off the live data source.
+///
+/// Compilation resolves a column name to an ordinal, classifies a projection,
+/// and lowers a predicate using only a relation's `width`, its `extent`, and its
+/// name → ordinal map — never its `bound` seekability or its `cursor`, which the
+/// optimiser and executor re-read from the live source by name. A `Schema` is
+/// that escapable resolution surface, pure data: a base `Table` projects to one
+/// (its real `names` below `width`, its `virtuals` at and past it), and a
+/// compiled `View` projects to one too (its `columns` in projection order, no
+/// virtual column). Lifting resolution onto a `Schema` lets a join resolve a
+/// base table against a view uniformly — the two live sources need not share a
+/// type, only a schema.
+internal struct Schema {
+  /// The real columns — the extent of a `SELECT *` projection.
+  internal let width: Int
+
+  /// One past the highest ordinal the relation can address — its real `width`
+  /// plus any virtual columns. A view exposes none, so its `extent` is `width`.
+  internal let extent: Int
+
+  /// The real column names at their ordinals `0 ..< width`.
+  private let names: Array<String>
+
+  /// The virtual column names at their ordinals `width ..< extent` — virtual
+  /// `i` sits at ordinal `width + i`. A view supplies none.
+  private let virtuals: Array<String>
+
+  internal init(width: Int, extent: Int, names: Array<String>,
+                virtuals: Array<String>) {
+    self.width = width
+    self.extent = extent
+    self.names = names
+    self.virtuals = virtuals
+  }
+
+  /// The ordinal of the column named `name`, or `nil` if absent.
+  ///
+  /// A real column resolves against `names` to an ordinal `< width`; a virtual
+  /// column resolves against `virtuals` to its ordinal `width + i`. The real
+  /// lookup wins, so a relation never hides a real column behind a virtual name.
+  /// The match is case-insensitive, as a metadata source's column names are
+  /// (`TypeName`, `rowid`); a schema never carries two names differing only in
+  /// case, so the match stays unambiguous.
+  internal func ordinal(of name: String) -> Int? {
+    let folded = name.lowercased()
+    for index in names.indices where names[index].lowercased() == folded {
+      return index
+    }
+    for index in virtuals.indices where virtuals[index].lowercased() == folded {
+      return width + index
+    }
+    return nil
+  }
+}
+
+extension Table where Self: ~Escapable {
+  /// The resolution schema of this base table: its real `names` below `width`,
+  /// its `virtuals` at and past it, with `width`/`extent` gating a `SELECT *`
+  /// and the join split exactly as the table reports them.
+  internal borrowing func schema() -> Schema {
+    Schema(width: width, extent: extent, names: names, virtuals: virtuals)
+  }
+}
+
+extension View {
+  /// The resolution schema of this view: its columns in projection order, no
+  /// virtual column.
+  internal func schema() -> Schema {
+    Schema(width: columns.count, extent: columns.count, names: columns,
+           virtuals: [])
+  }
+}

--- a/Sources/winmd-inspect/Database+SQL.swift
+++ b/Sources/winmd-inspect/Database+SQL.swift
@@ -74,6 +74,22 @@ internal struct WinMDRelation: SQL.Table, ~Escapable {
     table.schema.fields.count
   }
 
+  /// The real column names, in ordinal order — the schema's field names.
+  internal var names: Array<String> {
+    var names = Array<String>()
+    names.reserveCapacity(table.schema.fields.count)
+    for index in 0 ..< table.schema.fields.count {
+      names.append("\(table.schema.fields[index].name)")
+    }
+    return names
+  }
+
+  /// The virtual column names, in ordinal order — `rowid` at `width`, `parent`
+  /// at `width + 1`.
+  internal var virtuals: Array<String> {
+    ["rowid", "parent"]
+  }
+
   /// One past the highest ordinal this relation can address — its real `width`
   /// plus the two virtual columns (`rowid` and `parent`) it exposes.
   internal var extent: Int {

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -43,14 +43,21 @@ private struct Relation: Sendable {
 /// both a Span-backed source and an owned one.
 private struct Memory: Catalog {
   let relations: Dictionary<String, Relation>
+  let views: Dictionary<String, View>
 
-  init(_ relations: Dictionary<String, Relation>) {
+  init(_ relations: Dictionary<String, Relation>,
+       views: Dictionary<String, View> = [:]) {
     self.relations = relations
+    self.views = views
   }
 
   func table(named name: String) -> MemoryTable? {
     guard let relation = relations[name] else { return nil }
     return MemoryTable(relation)
+  }
+
+  func view(named name: String) -> View? {
+    views[name]
   }
 }
 
@@ -65,6 +72,12 @@ private struct MemoryTable: Table {
   /// The real columns — `rowid` is virtual and excluded from the width, so a
   /// `SELECT *` never yields it.
   var width: Int { relation.fields.count }
+
+  /// The real column names, in ordinal order.
+  var names: Array<String> { relation.fields.map(\.name) }
+
+  /// The lone virtual `rowid` column at ordinal `width`.
+  var virtuals: Array<String> { ["rowid"] }
 
   /// One past the highest ordinal — the real width plus the lone virtual
   /// `rowid` column at ordinal `width`.
@@ -216,6 +229,32 @@ private func family() -> Memory {
   ])
 }
 
+/// The view catalog: the `family` relations plus two registered views — `Adults`
+/// (a single-relation projection over `Parent`) and `Pairs` (a projection over
+/// the `Parent`/`Child` foreign-key join). A view is queried like a table, and
+/// `Pairs` proves a view whose definition is itself a join.
+private func views() throws -> Memory {
+  // SELECT Id, Name FROM Parent WHERE Id >= 2 — exposed as columns Key, Label.
+  let adults = try View(select: select("""
+      SELECT Id, Name FROM Parent WHERE Id >= 2
+      """), columns: ["Key", "Label"])
+
+  // SELECT Parent.Name, Child.Name FROM Parent JOIN Child ON … — a view over a
+  // join, its two projected columns exposed as Parent and Kid.
+  let pairs = try View(select: select("""
+      SELECT Parent.Name, Child.Name FROM Parent
+        JOIN Child ON Child.Pid = Parent.Id
+      """), columns: ["Parent", "Kid"])
+
+  let catalog = family()
+  return Memory(catalog.relations, views: ["Adults": adults, "Pairs": pairs])
+}
+
+/// Parses `text` to a `SELECT`, failing on any other statement.
+private func select(_ text: String) throws -> Select {
+  try parse(text)
+}
+
 /// Parses `text` to a `SELECT`, failing on any other statement.
 private func parse(_ text: String) throws -> Select {
   guard case let .select(select) = try Statement(parsing: text) else {
@@ -231,13 +270,18 @@ private func run(_ text: String) throws -> Array<Array<Value>> {
 }
 
 /// Runs `text` against the wide catalog.
-private func wideRun(_ text: String) throws -> Array<Array<Value>> {
+private func wide(_ text: String) throws -> Array<Array<Value>> {
   try Engine.run(parse(text), wide())
 }
 
 /// Runs `text` against the join `family` catalog.
 private func join(_ text: String) throws -> Array<Array<Value>> {
   try Engine.run(parse(text), family())
+}
+
+/// Runs `text` against the view catalog.
+private func view(_ text: String) throws -> Array<Array<Value>> {
+  try Engine.run(parse(text), views())
 }
 
 // MARK: - Single-relation tests
@@ -341,7 +385,7 @@ struct EngineProjectionPushdownTests {
     // The relation has ten columns; the query reads only C0 (filter, project),
     // C5 (project), and C8 (order). The leaf materialises just those, but the
     // result is exactly as if every column were copied.
-    let rows = try wideRun("""
+    let rows = try wide("""
         SELECT C5, C0 FROM Wide WHERE C0 >= 10 ORDER BY C8 DESC
         """)
     #expect(rows == [
@@ -539,5 +583,138 @@ struct EngineJoinTests {
       [.text("Ada"), .text("Ann")],
       [.text("Bee"), .text("Bob")],
     ])
+  }
+}
+
+// MARK: - View tests
+
+struct EngineViewTests {
+  @Test("a view resolves and queries like a table")
+  func table() throws {
+    // `SELECT * FROM Adults` runs the view's `SELECT Id, Name FROM Parent
+    // WHERE Id >= 2`, exposing the columns as `Key`/`Label`.
+    let rows = try view("SELECT * FROM Adults")
+    #expect(rows == [
+      [.integer(2), .text("Bee")],
+      [.integer(3), .text("Cid")],
+    ])
+  }
+
+  @Test("a projection over a view selects the view's columns by name")
+  func projection() throws {
+    let rows = try view("SELECT Label FROM Adults")
+    #expect(rows == [[.text("Bee")], [.text("Cid")]])
+  }
+
+  @Test("a WHERE over a view filters its rows")
+  func filter() throws {
+    let rows = try view("SELECT Label FROM Adults WHERE Key = 3")
+    #expect(rows == [[.text("Cid")]])
+  }
+
+  @Test("an ORDER BY over a view orders its rows")
+  func order() throws {
+    let rows = try view("SELECT Label FROM Adults ORDER BY Label DESC")
+    #expect(rows == [[.text("Cid")], [.text("Bee")]])
+  }
+
+  @Test("a view whose definition is a join resolves and queries")
+  func join() throws {
+    // `Pairs` denormalises the `Parent`/`Child` foreign-key join; querying it
+    // runs the inner join and exposes its two columns as `Parent`/`Kid`.
+    let rows = try view("SELECT * FROM Pairs")
+    #expect(rows == [
+      [.text("Ada"), .text("Ann")],
+      [.text("Ada"), .text("Amy")],
+      [.text("Bee"), .text("Bob")],
+    ])
+  }
+
+  @Test("a projection and filter over a join view selects across its columns")
+  func joinProjection() throws {
+    let rows = try view("SELECT Kid FROM Pairs WHERE Parent = 'Ada'")
+    #expect(rows == [[.text("Ann")], [.text("Amy")]])
+  }
+
+  @Test("an unknown column of a view is reported")
+  func unknown() throws {
+    #expect(throws: SQLError.column("Missing")) {
+      try view("SELECT Missing FROM Adults")
+    }
+  }
+
+  @Test("a view's definition is optimised — its seekable predicate seeks")
+  func optimised() throws {
+    // `Adults` is `SELECT Id, Name FROM Parent WHERE Id >= 2`, and `Parent` is
+    // sorted on `Id`, so the view's sub-plan must seek that run rather than
+    // scanning under a `Select`. Compile and optimise an outer query over the
+    // view and inspect the `.derived` leaf: its sub-plan must reach a seeked
+    // `.scan` (a non-nil seek) and carry no `.select` over a raw scan.
+    let catalog = try views()
+    let plan = try Engine.optimise(
+        Engine.compile(parse("SELECT Key, Label FROM Adults"), catalog),
+        catalog)
+    let sub = try #require(derived(plan))
+    #expect(seeks(sub))
+    #expect(!filters(sub))
+  }
+}
+
+/// The sub-plan of the first `.derived` leaf reachable from `plan`, or `nil`.
+private func derived(_ plan: Plan) -> Plan? {
+  switch plan {
+  case let .derived(_, sub, _, _):
+    sub
+  case let .select(_, source):
+    derived(source)
+  case let .project(_, source):
+    derived(source)
+  case let .sort(_, _, source):
+    derived(source)
+  case let .product(left, right):
+    derived(left) ?? derived(right)
+  case .scan, .join:
+    nil
+  }
+}
+
+/// Whether `plan` reaches a `.scan` carrying a non-nil seek.
+private func seeks(_ plan: Plan) -> Bool {
+  switch plan {
+  case let .scan(_, _, seek):
+    seek != nil
+  case let .select(_, source):
+    seeks(source)
+  case let .project(_, source):
+    seeks(source)
+  case let .sort(_, _, source):
+    seeks(source)
+  case let .derived(_, sub, _, _):
+    seeks(sub)
+  case let .product(left, right):
+    seeks(left) || seeks(right)
+  case .join:
+    false
+  }
+}
+
+/// Whether `plan` wraps a raw (unseeked) `.scan` in a `.select` — the
+/// un-optimised shape the fix eliminates from a view's sub-plan.
+private func filters(_ plan: Plan) -> Bool {
+  switch plan {
+  case .select(_, .scan(_, _, nil)):
+    true
+  case let .select(_, source):
+    filters(source)
+  case let .project(_, source):
+    filters(source)
+  case let .sort(_, _, source):
+    filters(source)
+  case let .derived(_, sub, _, _):
+    filters(sub)
+  case let .product(left, right):
+    filters(left) || filters(right)
+  case .scan, .join:
+    false
   }
 }


### PR DESCRIPTION
A view is a named SELECT the engine resolves wherever a base table is. Resolution reads only a relation's name -> ordinal map, its width, and its extent -- never the live cursor -- so lift it off the ~Escapable Table onto an escapable Schema, derivable from either a base Table (its real names below the width, its virtual columns at and past it) or a compiled View (its columns in projection order). A join's Scope then resolves a base table against a view uniformly: the two live sources need not share a type, only a schema.

Add a View value (a stored Select plus its column names) and a Catalog view(named:) hook defaulting to none, so a source without stored queries is unchanged. compile resolves a FROM/JOIN name to a view first, recursively compiling the view's Select into a sub-plan spliced under a new derived leaf; the executor runs that sub-plan and re-lays each row to the ordinals the outer query reads. A view carries no virtual column and no sort key, so it is never seeked and an INLJ never folds it as the inner side -- it scans.

Widen Table with names/virtuals (the latter defaulting empty) so the engine can build a base table's schema as pure data without capturing the ~Escapable table in an escaping closure. The WinMD and in-memory adapters report theirs. The Scope keeps its left/right qualifier gate and its (here, there) ambiguity resolution; lifting it onto Schema preserves the seek and index-nested-loop hardening untouched.