### PR TITLE
SQL: expression enhancements

### DIFF
--- a/Sources/SQL/AST.swift
+++ b/Sources/SQL/AST.swift
@@ -144,6 +144,48 @@ public enum Projection: Hashable, Sendable {
   case all
   /// `SELECT a, b, c` — the named columns, in order.
   case columns(Array<Column>)
+  /// `SELECT f(a), b` — projected expressions, in order, each an optional
+  /// alias over a scalar `Expression` (a bare column, a literal, or a call to a
+  /// registered scalar function). The parser emits this only when a projection
+  /// carries a function call or an alias; a list of bare columns stays the
+  /// simpler `columns` case.
+  case expressions(Array<Projected>)
+}
+
+/// One projected expression with an optional output alias.
+///
+/// A bare column projects as `Expression.column`; `f(a) AS x` carries the call
+/// and the alias `x`. The alias names the output column for a downstream
+/// consumer (a view's column, a template field); the engine yields positional
+/// rows and does not itself use the alias.
+public struct Projected: Hashable, Sendable {
+  /// The expression the column yields.
+  public let expression: Expression
+
+  /// The output alias, if any.
+  public let alias: String?
+
+  public init(expression: Expression, alias: String? = nil) {
+    self.expression = expression
+    self.alias = alias
+  }
+}
+
+/// A scalar expression — a value computed per row.
+///
+/// An expression is a bare column reference, a literal constant, or a call to a
+/// registered scalar function over argument expressions. The engine resolves a
+/// `column` to an ordinal, evaluates a `call` through the routines, and
+/// yields a typed `Value`. This is the layer the per-dialect decode functions
+/// (`guid`, `ret_type`, …) plug into: each is a registered scalar function the
+/// projection calls.
+public indirect enum Expression: Hashable, Sendable {
+  /// A bare column reference, resolved to an ordinal.
+  case column(Column)
+  /// A literal constant.
+  case literal(Literal)
+  /// A call to the named scalar function over its arguments, in order.
+  case call(name: String, arguments: Array<Expression>)
 }
 
 /// A row filter — a tree of comparisons composed with `AND`, `OR`, and `NOT`.
@@ -151,8 +193,9 @@ public enum Projection: Hashable, Sendable {
 /// The tree is `data`, not an opaque closure, so a consumer may inspect it (for
 /// example to lower an equality test on a sorted column to a binary search).
 public indirect enum Predicate: Hashable, Sendable {
-  /// `column <op> value`.
-  case comparison(column: Column, op: Comparison, value: Literal)
+  /// `left <op> right` — each operand a scalar `Expression` (a column, a
+  /// literal, or a call to a registered scalar function).
+  case comparison(left: Expression, op: Comparison, right: Expression)
   /// `lhs AND rhs`.
   case and(Predicate, Predicate)
   /// `lhs OR rhs`.

--- a/Sources/SQL/AST.swift
+++ b/Sources/SQL/AST.swift
@@ -196,6 +196,10 @@ public indirect enum Predicate: Hashable, Sendable {
   /// `left <op> right` — each operand a scalar `Expression` (a column, a
   /// literal, or a call to a registered scalar function).
   case comparison(left: Expression, op: Comparison, right: Expression)
+  /// `left <op> :parameter` — the left a scalar `Expression`, the operand
+  /// resolved at run time from the engine's bindings (the correlated-subquery
+  /// primitive a child view keys on the parent's value).
+  case bound(left: Expression, op: Comparison, parameter: String)
   /// `lhs AND rhs`.
   case and(Predicate, Predicate)
   /// `lhs OR rhs`.

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -303,9 +303,11 @@ public enum Engine {
   /// its table ordinal through `ordinals` (slot `i` is `ordinals[i]`) for the
   /// `bound` query. A `string` operand or an unseekable column never qualifies,
   /// and the executor scans.
-  private static func boundaries<T: Table & ~Escapable>(
-      _ filter: Filter, _ ordinals: Array<Int>, _ table: borrowing T,
-      _ count: Int) -> Range<Int>? {
+  private static func boundaries<T: Table & ~Escapable>(_ filter: Filter,
+                                                        _ ordinals: Array<Int>,
+                                                        _ table: borrowing T,
+                                                        _ count: Int)
+      -> Range<Int>? {
     guard case let .compare(slot, op, .integer(value)) = filter,
         let lower = table.bound(ordinals[slot], value, strict: false),
         let upper = table.bound(ordinals[slot], value, strict: true) else {

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -26,10 +26,11 @@ public enum Engine {
   ///   if an unqualified name is resolved by both relations of a join.
   public static func run<C: Catalog & ~Escapable>(_ select: Select,
                                                   _ catalog: borrowing C,
-                                                  _ routines: Routines = [:])
+                                                  _ routines: Routines = [:],
+                                                  bindings: Bindings = [:])
       throws(SQLError) -> Array<Array<Value>> {
-    let plan = try optimise(compile(select, catalog), catalog)
-    return try execute(plan, catalog, routines).map(\.values)
+    let plan = try optimise(compile(select, catalog), catalog, bindings)
+    return try execute(plan, catalog, routines, bindings).map(\.values)
   }
 
   // MARK: - Compilation
@@ -137,7 +138,7 @@ public enum Engine {
                                                        _ catalog: borrowing C)
       throws(SQLError) -> Resolved {
     if let view = catalog.view(named: relation.name) {
-      let plan = try optimise(compile(view.select, catalog), catalog)
+      let plan = try compile(view.select, catalog)
       let schema = view.schema()
       return Resolved(schema: schema) { ordinals in
         .derived(name: relation.name, plan: plan, ordinals: ordinals,
@@ -202,6 +203,8 @@ public enum Engine {
     switch filter {
     case let .compare(lhs, op, rhs):
       .compare(remap(lhs, slot), op, remap(rhs, slot))
+    case let .bound(term, op, parameter):
+      .bound(remap(term, slot), op, parameter)
     case let .match(left, right):
       .match(slot[left]!, slot[right]!)
     case let .and(lhs, rhs):
@@ -238,7 +241,8 @@ public enum Engine {
   // MARK: - Optimisation
 
   /// Rewrites the logical `plan` into a physical one, re-resolving relations by
-  /// name through the borrowed `catalog` to read their seekability.
+  /// name through the borrowed `catalog` for their seekability and a bound key
+  /// through `bindings` so it seeks like a literal.
   ///
   /// Two pattern rewrites fire, the rest of the tree recursing unchanged:
   ///
@@ -254,27 +258,32 @@ public enum Engine {
   ///     kept as a residual `Select`. If the inner side is not a bare `Scan`,
   ///     the product stays (a plain nested loop).
   internal static func optimise<C: Catalog & ~Escapable>(_ plan: Plan,
-                                                         _ catalog: borrowing C)
+                                                         _ catalog: borrowing C,
+                                                         _ bindings: Bindings)
       throws(SQLError) -> Plan {
     switch plan {
     case .scan:
       plan
-    case .derived:
-      // A view's sub-plan is optimised when the view is compiled; a derived
-      // leaf carries no sort key, so it scans its result as is.
-      plan
+    case let .derived(name, plan, ordinals, seek):
+      // Optimise the view's sub-plan with the bindings so a bound predicate
+      // inside the view seeks; the derived leaf itself carries no sort key, so
+      // the outer query still scans its result as is.
+      try .derived(name: name, plan: optimise(plan, catalog, bindings),
+                   ordinals: ordinals, seek: seek)
     case let .select(filter, .scan(name, ordinals, nil)):
-      try seek(filter, name, ordinals, catalog)
+      try seek(filter, name, ordinals, catalog, bindings)
     case let .select(filter, .product(left, right)):
-      try nest(filter, left, right, catalog)
+      try nest(filter, left, right, catalog, bindings)
     case let .select(filter, source):
-      try .select(filter, optimise(source, catalog))
+      try .select(filter, optimise(source, catalog, bindings))
     case let .project(ordinals, source):
-      try .project(ordinals, optimise(source, catalog))
+      try .project(ordinals, optimise(source, catalog, bindings))
     case let .sort(slot, ascending, source):
-      try .sort(slot: slot, ascending: ascending, optimise(source, catalog))
+      try .sort(slot: slot, ascending: ascending,
+                optimise(source, catalog, bindings))
     case let .product(left, right):
-      try .product(optimise(left, catalog), optimise(right, catalog))
+      try .product(optimise(left, catalog, bindings),
+                   optimise(right, catalog, bindings))
     case .join:
       plan
     }
@@ -294,20 +303,21 @@ public enum Engine {
   private static func seek<C: Catalog & ~Escapable>(_ filter: Filter,
                                                     _ name: String,
                                                     _ ordinals: Array<Int>,
-                                                    _ catalog: borrowing C)
+                                                    _ catalog: borrowing C,
+                                                    _ bindings: Bindings)
       throws(SQLError) -> Plan {
     guard let table = catalog.table(named: name) else { throw .relation(name) }
     let count = table.cursor().count
 
-    if let range = boundaries(filter, ordinals, table, count) {
+    if let range = boundaries(filter, ordinals, table, count, bindings) {
       return .scan(name: name, ordinals: ordinals, seek: range)
     }
 
     if case let .and(lhs, rhs) = filter {
-      if let range = boundaries(lhs, ordinals, table, count) {
+      if let range = boundaries(lhs, ordinals, table, count, bindings) {
         return .select(rhs, .scan(name: name, ordinals: ordinals, seek: range))
       }
-      if let range = boundaries(rhs, ordinals, table, count) {
+      if let range = boundaries(rhs, ordinals, table, count, bindings) {
         return .select(lhs, .scan(name: name, ordinals: ordinals, seek: range))
       }
     }
@@ -315,22 +325,43 @@ public enum Engine {
     return .select(filter, .scan(name: name, ordinals: ordinals, seek: nil))
   }
 
+  /// The seekable `(slot, op, integer)` of `filter`: a `compare` against an
+  /// integer literal, or a `bound` whose parameter resolves to an integer in
+  /// `bindings`. A string operand, an unbound or non-integer parameter, or a
+  /// non-comparison does not qualify, and the relation scans.
+  private static func comparison(_ filter: Filter, _ bindings: Bindings)
+      -> (Int, Comparison, Int)? {
+    switch filter {
+    case let .compare(.slot(slot), op, .constant(.integer(value))):
+      (slot, op, value)
+    case let .bound(.slot(slot), op, parameter):
+      if case let .integer(value)? = bindings[parameter] {
+        (slot, op, value)
+      } else {
+        nil
+      }
+    default:
+      nil
+    }
+  }
+
   /// The boundaries `[lower, upper)` to seek for a sort-key comparison, or `nil`
   /// if `filter` does not qualify for the seek path.
   ///
-  /// It qualifies when `filter` is a `compare` whose operand is an `integer`,
-  /// the operator is an equality or a range, and `table.bound` reports the
-  /// column seekable (a non-`nil` boundary). The comparison's slot maps back to
-  /// its table ordinal through `ordinals` (slot `i` is `ordinals[i]`) for the
-  /// `bound` query. A `string` operand or an unseekable column never qualifies,
-  /// and the executor scans.
+  /// It qualifies when `filter` is a sort-key equality or range whose operand
+  /// is an integer — a literal, or a bound parameter resolved from `bindings`
+  /// so a correlated child seeks on its parent key — and `table.bound` reports
+  /// the column seekable (a non-`nil` boundary). The comparison's slot maps
+  /// back to its table ordinal through `ordinals` (slot `i` is `ordinals[i]`)
+  /// for the `bound` query. A `string` operand or an unseekable column never
+  /// qualifies, and the executor scans.
   private static func boundaries<T: Table & ~Escapable>(_ filter: Filter,
                                                         _ ordinals: Array<Int>,
                                                         _ table: borrowing T,
-                                                        _ count: Int)
+                                                        _ count: Int,
+                                                        _ bindings: Bindings)
       -> Range<Int>? {
-    guard case let .compare(.slot(slot), op, .constant(.integer(value)))
-        = filter,
+    guard let (slot, op, value) = comparison(filter, bindings),
         let lower = table.bound(ordinals[slot], value, strict: false),
         let upper = table.bound(ordinals[slot], value, strict: true) else {
       return nil
@@ -362,12 +393,13 @@ public enum Engine {
   private static func nest<C: Catalog & ~Escapable>(_ filter: Filter,
                                                     _ left: Plan,
                                                     _ right: Plan,
-                                                    _ catalog: borrowing C)
+                                                    _ catalog: borrowing C,
+                                                    _ bindings: Bindings)
       throws(SQLError) -> Plan {
     guard case let .scan(name, ordinals, nil) = right,
         let base = slots(left) else {
-      return try .select(filter, .product(optimise(left, catalog),
-                                          optimise(right, catalog)))
+      return try .select(filter, .product(optimise(left, catalog, bindings),
+                                          optimise(right, catalog, bindings)))
     }
 
     let conjuncts = flatten(filter)
@@ -379,7 +411,7 @@ public enum Engine {
 
       var residual = conjuncts
       residual.remove(at: index)
-      let join = try Plan.join(optimise(left, catalog), name: name,
+      let join = try Plan.join(optimise(left, catalog, bindings), name: name,
                                ordinals: ordinals, base: base,
                                column: ordinals[rightKey - base],
                                keys: (left: leftKey, right: rightKey))
@@ -387,8 +419,8 @@ public enum Engine {
       return .select(predicate, join)
     }
 
-    return try .select(filter, .product(optimise(left, catalog),
-                                        optimise(right, catalog)))
+    return try .select(filter, .product(optimise(left, catalog, bindings),
+                                        optimise(right, catalog, bindings)))
   }
 
   /// The `(outerKey, innerKey)` an equality between slots `lhs` and `rhs`

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -25,10 +25,11 @@ public enum Engine {
   ///   `SQLError.column` if a referenced column is absent, `SQLError.ambiguous`
   ///   if an unqualified name is resolved by both relations of a join.
   public static func run<C: Catalog & ~Escapable>(_ select: Select,
-                                                  _ catalog: borrowing C)
+                                                  _ catalog: borrowing C,
+                                                  _ routines: Routines = [:])
       throws(SQLError) -> Array<Array<Value>> {
     let plan = try optimise(compile(select, catalog), catalog)
-    return try execute(plan, catalog).map(\.values)
+    return try execute(plan, catalog, routines).map(\.values)
   }
 
   // MARK: - Compilation
@@ -69,13 +70,13 @@ public enum Engine {
         order = try from.schema.order(clause, in: select.from)
       }
       let projection =
-          try from.schema.projection(select.projection, in: select.from)
+          try from.schema.terms(select.projection, in: select.from)
 
       // The referenced ordinals, in slot order: slot `i` is `ordinals[i]`.
       let ordinals = referenced(projection, filter, order)
       let slot = invert(ordinals)
       let scan = from.leaf(ordinals)
-      return shape(scan, projection.map { slot[$0]! },
+      return shape(scan, projection.map { remap($0, slot) },
                    filter.map { remap($0, slot) },
                    order.map { (slot[$0.column]!, $0.ascending) })
     }
@@ -93,7 +94,7 @@ public enum Engine {
     if let clause = select.order {
       order = try scope.order(clause)
     }
-    let projection = try scope.projection(select.projection)
+    let projection = try scope.terms(select.projection)
     let base = scope.base
 
     let combined = referenced(projection, filter, order)
@@ -112,7 +113,7 @@ public enum Engine {
 
     let outer = from.leaf(head)
     let right = inner.leaf(tail)
-    return shape(.product(outer, right), projection.map { slot[$0]! },
+    return shape(.product(outer, right), projection.map { remap($0, slot) },
                  remap(filter, slot),
                  order.map { (slot[$0.column]!, $0.ascending) })
   }
@@ -154,12 +155,17 @@ public enum Engine {
     }
   }
 
-  /// The sorted, deduplicated ordinals a query references: the union of its
-  /// `projection`, the columns its `filter` reads, and its `order` column.
-  private static func referenced(_ projection: Array<Int>, _ filter: Filter?,
+  /// The sorted, deduplicated ordinals a query references: the union of the
+  /// ordinals its `projection` terms read, the columns its `filter` reads, and
+  /// its `order` column. The projection terms hold ordinals at this stage; a
+  /// scalar call's arguments contribute their read ordinals too.
+  private static func referenced(_ projection: Array<Term>, _ filter: Filter?,
                                  _ order: (column: Int, ascending: Bool)?)
       -> Array<Int> {
-    var ordinals = Set(projection)
+    var ordinals = Set<Int>()
+    for term in projection {
+      term.references(into: &ordinals)
+    }
     filter?.references(into: &ordinals)
     if let order { ordinals.insert(order.column) }
     return ordinals.sorted()
@@ -175,12 +181,27 @@ public enum Engine {
     return slot
   }
 
+  /// `term` with every ordinal it reads remapped to a slot through `slot`: a
+  /// `.slot` holding an ordinal becomes the same slot, a constant is unchanged,
+  /// a call recurses into its arguments.
+  private static func remap(_ term: Term, _ slot: Dictionary<Int, Int>)
+      -> Term {
+    switch term {
+    case let .slot(ordinal):
+      .slot(slot[ordinal]!)
+    case .constant:
+      term
+    case let .apply(name, arguments):
+      .apply(name: name, arguments: arguments.map { remap($0, slot) })
+    }
+  }
+
   /// `filter` with every ordinal it addresses remapped to a slot through `slot`.
   private static func remap(_ filter: Filter, _ slot: Dictionary<Int, Int>)
       -> Filter {
     switch filter {
-    case let .compare(column, op, value):
-      .compare(slot[column]!, op, value)
+    case let .compare(lhs, op, rhs):
+      .compare(remap(lhs, slot), op, remap(rhs, slot))
     case let .match(left, right):
       .match(slot[left]!, slot[right]!)
     case let .and(lhs, rhs):
@@ -195,7 +216,7 @@ public enum Engine {
   /// Wraps `source` in the `Project(Sort(Select(_)))` operators, omitting the
   /// `Select` and `Sort` layers when their clause is absent. The `projection`,
   /// `filter`, and `order` are in slot space.
-  private static func shape(_ source: Plan, _ projection: Array<Int>,
+  private static func shape(_ source: Plan, _ projection: Array<Term>,
                             _ filter: Filter?,
                             _ order: (slot: Int, ascending: Bool)?) -> Plan {
     var plan = source
@@ -308,7 +329,8 @@ public enum Engine {
                                                         _ table: borrowing T,
                                                         _ count: Int)
       -> Range<Int>? {
-    guard case let .compare(slot, op, .integer(value)) = filter,
+    guard case let .compare(.slot(slot), op, .constant(.integer(value)))
+        = filter,
         let lower = table.bound(ordinals[slot], value, strict: false),
         let upper = table.bound(ordinals[slot], value, strict: true) else {
       return nil

--- a/Sources/SQL/Error.swift
+++ b/Sources/SQL/Error.swift
@@ -53,6 +53,11 @@ public enum SQLError: Error, Hashable, Sendable {
   case column(String)
   /// A statement names an unqualified column both joined relations resolve.
   case ambiguous(String)
+  /// A statement calls a scalar function the routines do not resolve.
+  case function(String)
+  /// A scalar function rejects its arguments (the wrong count, or a value it
+  /// cannot map); the string describes the fault.
+  case argument(String)
 }
 
 extension SQLError: CustomStringConvertible {
@@ -76,6 +81,10 @@ extension SQLError: CustomStringConvertible {
       "no such column '\(name)'"
     case let .ambiguous(name):
       "ambiguous column '\(name)'"
+    case let .function(name):
+      "no such function '\(name)'"
+    case let .argument(detail):
+      "invalid function argument: \(detail)"
     }
   }
 }

--- a/Sources/SQL/Filter.swift
+++ b/Sources/SQL/Filter.swift
@@ -11,8 +11,9 @@
 /// escapable; the `~Escapable` row it reads materialises only transiently at
 /// evaluation.
 internal indirect enum Filter {
-  /// `column <op> value`, the column addressed by ordinal.
-  case compare(Int, Comparison, Literal)
+  /// `left <op> right`, both operands lowered to ordinal-addressed terms (a
+  /// slot, a constant, or a scalar-function call).
+  case compare(Term, Comparison, Term)
   /// `left = right`, both columns addressed by ordinal — a join's `ON`
   /// equality, lowered as a conjunct of the product's `Select` predicate.
   case match(Int, Int)
@@ -22,6 +23,89 @@ internal indirect enum Filter {
   case or(Filter, Filter)
   /// `NOT operand`.
   case not(Filter)
+}
+
+// MARK: - Terms
+
+/// The engine's ordinal-addressed scalar expression.
+///
+/// `Term` is the lowered form of the AST's name-addressed `Expression`: a slot
+/// reference (a column resolved to its slot in a record), a constant, or a call
+/// to a registered scalar function over argument terms. A projection lowers each
+/// projected expression to a `Term` the executor evaluates per record against
+/// the routines; a bare-column projection lowers to a `.slot`, so the simple
+/// path stays a plain slot read.
+internal indirect enum Term {
+  /// The cell at `slot` of the record.
+  case slot(Int)
+  /// A constant value.
+  case constant(Value)
+  /// A call to the named scalar function over its argument terms, in order.
+  case apply(name: String, arguments: Array<Term>)
+}
+
+extension Term {
+  /// The slots this term reads, accumulated into `slots`.
+  ///
+  /// A `slot` reads itself; a `constant` reads none; an `apply` reads the union
+  /// of its arguments. A projection unions these with the filter and order so a
+  /// scan materialises exactly the cells the projection's functions consume.
+  internal func references(into slots: inout Set<Int>) {
+    switch self {
+    case let .slot(slot):
+      slots.insert(slot)
+    case .constant:
+      break
+    case let .apply(_, arguments):
+      for argument in arguments {
+        argument.references(into: &slots)
+      }
+    }
+  }
+}
+
+/// The literal `literal` as a typed `Value`.
+internal func value(of literal: Literal) -> Value {
+  switch literal {
+  case let .integer(integer): .integer(integer)
+  case let .string(string): .text(string)
+  }
+}
+
+/// Evaluates `term` against `row` through `routines`, yielding a typed value.
+///
+/// A `slot` reads the row's cell; a `constant` is itself; an `apply` looks the
+/// function up in the routines (`SQLError.function` on a miss), evaluates its
+/// arguments, and applies it. The `borrowing` row is non-escaping — a term runs
+/// over a materialised projection record or a predicate's borrowed cursor row.
+internal func evaluate<R: Row & ~Escapable>(_ term: Term, _ row: borrowing R,
+                                            _ routines: Routines)
+    throws(SQLError) -> Value {
+  switch term {
+  case let .slot(slot):
+    row[slot]
+  case let .constant(value):
+    value
+  case let .apply(name, arguments):
+    try apply(name, arguments, row, routines)
+  }
+}
+
+/// Resolves `name` in `routines` and applies it to its evaluated `arguments`.
+private func apply<R: Row & ~Escapable>(_ name: String,
+                                        _ arguments: Array<Term>,
+                                        _ row: borrowing R,
+                                        _ routines: Routines)
+    throws(SQLError) -> Value {
+  guard let function = routines.function(named: name) else {
+    throw .function(name)
+  }
+  var values = Array<Value>()
+  values.reserveCapacity(arguments.count)
+  for argument in arguments {
+    try values.append(evaluate(argument, row, routines))
+  }
+  return try function(values)
 }
 
 // MARK: - Evaluation
@@ -40,41 +124,43 @@ extension Comparison {
   }
 }
 
-/// Matches a typed cell `value` against a `literal` under operator `op`.
+/// Matches two typed values under operator `op`.
 ///
-/// A like-typed pair compares — an integral cell against an `integer` literal, a
-/// textual cell against a `string` literal; a cross-typed pair (a textual cell
-/// against an integer literal, or the reverse) never matches.
-private func matches(_ value: Value, _ op: Comparison, _ literal: Literal)
-    -> Bool {
-  switch (value, literal) {
+/// A like-typed pair compares — two integers or two strings; a cross-typed pair
+/// (an integer against a string, or the reverse) never matches.
+private func matches(_ lhs: Value, _ op: Comparison, _ rhs: Value) -> Bool {
+  switch (lhs, rhs) {
   case let (.integer(lhs), .integer(rhs)): op.apply(lhs, rhs)
-  case let (.text(lhs), .string(rhs)): op.apply(lhs, rhs)
+  case let (.text(lhs), .text(rhs)): op.apply(lhs, rhs)
   default: false
   }
 }
 
-/// Evaluates `filter` against `row`.
+/// Evaluates `filter` against `row`, resolving scalar calls through `routines`.
 ///
-/// A `compare` reads the addressed cell as a typed `Value` and matches it
-/// against the literal; a `match` reads both cells and tests them equal; the
-/// boolean connectives recurse. The `borrowing` row is non-escaping; it threads
-/// into the recursion freely and is never stored.
+/// A `compare` evaluates both operand terms and matches them; a `match` reads
+/// both cells and tests them equal; the boolean connectives recurse. The
+/// `borrowing` row is non-escaping; it threads into the recursion freely and is
+/// never stored.
 internal func evaluate<R: Row & ~Escapable>(_ filter: Filter,
-                                            _ row: borrowing R) -> Bool {
+                                            _ row: borrowing R,
+                                            _ routines: Routines)
+    throws(SQLError) -> Bool {
   switch filter {
-  case let .compare(column, op, value):
-    matches(row[column], op, value)
+  case let .compare(lhs, op, rhs):
+    try matches(evaluate(lhs, row, routines), op, evaluate(rhs, row, routines))
   case let .match(left, right):
     row[left] == row[right]
   case let .and(lhs, rhs):
     // `&&`/`||` take an `@autoclosure` right operand, which would capture the
     // borrowed `~Escapable` row; spell the short-circuit explicitly so each
     // branch re-borrows the row rather than capturing it.
-    if evaluate(lhs, row) { evaluate(rhs, row) } else { false }
+    if try evaluate(lhs, row, routines) { try evaluate(rhs, row, routines) }
+    else { false }
   case let .or(lhs, rhs):
-    if evaluate(lhs, row) { true } else { evaluate(rhs, row) }
+    if try evaluate(lhs, row, routines) { true }
+    else { try evaluate(rhs, row, routines) }
   case let .not(operand):
-    !evaluate(operand, row)
+    try !evaluate(operand, row, routines)
   }
 }

--- a/Sources/SQL/Filter.swift
+++ b/Sources/SQL/Filter.swift
@@ -1,19 +1,28 @@
 // Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
+/// A query's parameter bindings: each `:name` parameter mapped to the value
+/// bound for this run — the operand a `bound` filter resolves, and the key the
+/// seek planner reads.
+public typealias Bindings = Dictionary<String, Value>
+
 /// The engine's ordinal-addressed row filter.
 ///
 /// `Filter` is the lowered form of the AST's name-addressed `Predicate`: a tree
 /// of comparisons composed with `AND`, `OR`, and `NOT`, with every column
-/// resolved to an ordinal once. It reuses the AST's `Comparison` and `Literal`
-/// — those are general — and addresses columns by `Int` so the executor can
-/// inspect it (to seek a sorted column) before running it. The filter is fully
+/// resolved to a slot once. Each comparison operand is a `Term` — a slot, a
+/// constant, or a scalar call — so the executor can still seek a sorted column
+/// off a bare slot before running it. The filter is fully
 /// escapable; the `~Escapable` row it reads materialises only transiently at
 /// evaluation.
 internal indirect enum Filter {
   /// `left <op> right`, both operands lowered to ordinal-addressed terms (a
   /// slot, a constant, or a scalar-function call).
   case compare(Term, Comparison, Term)
+  /// `left <op> :parameter`, the left a term and the operand resolved at run
+  /// time from the engine's bindings — the lowered form of a correlated
+  /// subquery's parent-keyed predicate.
+  case bound(Term, Comparison, String)
   /// `left = right`, both columns addressed by ordinal — a join's `ON`
   /// equality, lowered as a conjunct of the product's `Select` predicate.
   case match(Int, Int)
@@ -136,31 +145,54 @@ private func matches(_ lhs: Value, _ op: Comparison, _ rhs: Value) -> Bool {
   }
 }
 
-/// Evaluates `filter` against `row`, resolving scalar calls through `routines`.
+/// Evaluates `filter` against `row` under three-valued logic, resolving scalar
+/// calls through `routines` and any bound parameter from `bindings`.
 ///
-/// A `compare` evaluates both operand terms and matches them; a `match` reads
-/// both cells and tests them equal; the boolean connectives recurse. The
-/// `borrowing` row is non-escaping; it threads into the recursion freely and is
-/// never stored.
+/// The result is `true`, `false`, or `nil` — SQL's UNKNOWN. A `compare`
+/// evaluates both operand terms and matches them; a `bound` matches the left
+/// term against the parameter's bound value, but an unbound or absent parameter
+/// UNKNOWN (`nil`), not `false` — a missing binding cannot be inverted into a
+/// match by `NOT`. A `match` reads both cells and tests them equal; `AND` and
+/// `OR` follow Kleene logic (`false` dominates `AND`, `true` dominates `OR`,
+/// UNKNOWN otherwise) and `NOT` maps UNKNOWN to itself. The executor admits a
+/// row only when the whole predicate is `true` (its `== true` gate), so UNKNOWN
+/// and `false` both reject. The `borrowing` row is non-escaping; it threads
+/// into the recursion freely and is never stored.
 internal func evaluate<R: Row & ~Escapable>(_ filter: Filter,
                                             _ row: borrowing R,
-                                            _ routines: Routines)
-    throws(SQLError) -> Bool {
+                                            _ routines: Routines,
+                                            _ bindings: Bindings)
+    throws(SQLError) -> Bool? {
   switch filter {
   case let .compare(lhs, op, rhs):
     try matches(evaluate(lhs, row, routines), op, evaluate(rhs, row, routines))
+  case let .bound(term, op, parameter):
+    if let operand = bindings[parameter] {
+      try matches(evaluate(term, row, routines), op, operand)
+    } else {
+      nil
+    }
   case let .match(left, right):
     row[left] == row[right]
   case let .and(lhs, rhs):
     // `&&`/`||` take an `@autoclosure` right operand, which would capture the
-    // borrowed `~Escapable` row; spell the short-circuit explicitly so each
-    // branch re-borrows the row rather than capturing it.
-    if try evaluate(lhs, row, routines) { try evaluate(rhs, row, routines) }
-    else { false }
+    // borrowed `~Escapable` row; spell each connective explicitly so a branch
+    // re-borrows the row rather than capturing it. Kleene `AND`: `false`
+    // dominates, an UNKNOWN left yields `false` only against a `false` right.
+    switch try evaluate(lhs, row, routines, bindings) {
+    case false?: false
+    case true?: try evaluate(rhs, row, routines, bindings)
+    case nil: try evaluate(rhs, row, routines, bindings) == false ? false : nil
+    }
   case let .or(lhs, rhs):
-    if try evaluate(lhs, row, routines) { true }
-    else { try evaluate(rhs, row, routines) }
+    // Kleene `OR`: `true` dominates, an UNKNOWN left yields `true` only against
+    // a `true` right.
+    switch try evaluate(lhs, row, routines, bindings) {
+    case true?: true
+    case false?: try evaluate(rhs, row, routines, bindings)
+    case nil: try evaluate(rhs, row, routines, bindings) == true ? true : nil
+    }
   case let .not(operand):
-    try !evaluate(operand, row, routines)
+    try evaluate(operand, row, routines, bindings).map { !$0 }
   }
 }

--- a/Sources/SQL/Function.swift
+++ b/Sources/SQL/Function.swift
@@ -1,0 +1,66 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+/// A named scalar function — a per-row computation over typed values.
+///
+/// A scalar function takes its arguments already evaluated to typed `Value`s
+/// (the engine evaluates each argument expression against the row first) and
+/// returns one `Value`. This is the signature the per-dialect decode functions
+/// (`guid`, `ret_type`, `span_type`, …) take: each is a pure mapping from cell
+/// values to a cell value, registered by name and called from a projection or a
+/// predicate. A function that cannot map its arguments throws `SQLError`.
+public typealias Scalar =
+    @Sendable (_ arguments: Array<Value>) throws(SQLError) -> Value
+
+/// The catalog of named scalar functions the engine resolves a call against.
+///
+/// A `SELECT` projection or predicate may call a function by name; the engine
+/// looks it up here and applies it to its evaluated arguments. `Routines` is
+/// escapable, immutable data — a `[name: Scalar]` map built once and threaded
+/// through compilation and execution beside the catalog. A name the routines do
+/// not know is `SQLError.function` at evaluation. This is the one non-data tier
+/// of synthesis: composing existing functions is free, but a new decode
+/// primitive is a registered closure.
+public struct Routines: Sendable {
+  /// The registered functions, keyed by their case-folded (lower-cased) name.
+  private let functions: Dictionary<String, Scalar>
+
+  /// Empty routines — every call faults until a function is registered.
+  public init() {
+    self.functions = [:]
+  }
+
+  /// Routines over a `name → function` map; each name folds to lower case so a
+  /// call resolves by the SQL identifier rule. Two names differing only by case
+  /// merge (the later-sorting original spelling wins) instead of trapping.
+  public init(_ functions: Dictionary<String, Scalar>) {
+    self.functions = functions.sorted { $0.key < $1.key }
+      .reduce(into: Dictionary<String, Scalar>()) {
+        $0[$1.key.lowercased()] = $1.value
+      }
+  }
+
+  /// The function named `name`, or `nil` if no such function is registered —
+  /// the name folded to lower case, like every other SQL identifier.
+  public func function(named name: String) -> Scalar? {
+    functions[name.lowercased()]
+  }
+
+  /// A copy of these routines with `function` bound to `name` (folded to lower
+  /// case), the binding shadowing any existing one.
+  public func registering(_ name: String, _ function: @escaping Scalar)
+      -> Routines {
+    var functions = self.functions
+    functions[name.lowercased()] = function
+    return Routines(functions)
+  }
+}
+
+extension Routines: ExpressibleByDictionaryLiteral {
+  /// Builds routines from a `name: function` dictionary literal — an empty
+  /// literal `[:]` is the empty routines, `["upper": …]` registers inline.
+  /// A repeated key keeps the last; `init(_:)` then case-folds the names.
+  public init(dictionaryLiteral elements: (String, Scalar)...) {
+    self.init(Dictionary(elements, uniquingKeysWith: { _, last in last }))
+  }
+}

--- a/Sources/SQL/Lexer.swift
+++ b/Sources/SQL/Lexer.swift
@@ -123,6 +123,9 @@ internal struct Lexer: ~Escapable {
     case UInt8(ascii: "'"):
       return try string()
 
+    case UInt8(ascii: ":"):
+      return try parameter()
+
     case let b where digit(b):
       return try integer()
 
@@ -178,6 +181,24 @@ internal struct Lexer: ~Escapable {
     }
 
     throw .unterminated(at: start)
+  }
+
+  /// Scans a bound-parameter placeholder `:name` at the current position.
+  ///
+  /// The leading `:` is consumed; an identifier must follow (a letter or `_`
+  /// then identifier continuations), else the `:` begins no valid token.
+  private mutating func parameter() throws(SQLError) -> Token {
+    let start = location
+    advance()
+    guard let byte = peek(), initial(byte) else {
+      throw .character(":", at: start)
+    }
+    let begin = position
+    while let byte = peek(), continuation(byte) {
+      advance()
+    }
+    return Token(kind: .parameter(String(bytes, begin ..< position)),
+                 location: start)
   }
 
   /// Scans an integer literal at the current position.

--- a/Sources/SQL/Operator.swift
+++ b/Sources/SQL/Operator.swift
@@ -144,21 +144,22 @@ internal indirect enum Plan {
 /// borrowed throughout — a `~Escapable` source is never copied or stored.
 internal func execute<C: Catalog & ~Escapable>(_ plan: Plan,
                                                _ catalog: borrowing C,
-                                               _ routines: Routines)
+                                               _ routines: Routines,
+                                               _ bindings: Bindings)
     throws(SQLError) -> Array<Record> {
   switch plan {
   case let .scan(name, ordinals, seek):
     try materialise(name, ordinals, seek, catalog)
   case let .derived(_, source, ordinals, seek):
-    try derive(source, ordinals, seek, catalog, routines)
+    try derive(source, ordinals, seek, catalog, routines, bindings)
   case let .select(filter, source):
-    try admitted(execute(source, catalog, routines), filter, routines)
+    try admitted(execute(source, catalog, routines, bindings), filter,
+                 routines, bindings)
   case let .project(terms, source):
-    try execute(source, catalog, routines).map { record throws(SQLError) in
-      try project(terms, record, routines)
-    }
+    try execute(source, catalog, routines, bindings)
+      .map { record throws(SQLError) in try project(terms, record, routines) }
   case let .sort(slot, ascending, source):
-    try execute(source, catalog, routines)
+    try execute(source, catalog, routines, bindings)
       .enumerated()
       .sorted { lhs, rhs in
         let ordered = less(lhs.element[slot], rhs.element[slot])
@@ -170,11 +171,11 @@ internal func execute<C: Catalog & ~Escapable>(_ plan: Plan,
       }
       .map(\.element)
   case let .product(outer, inner):
-    try product(execute(outer, catalog, routines),
-                execute(inner, catalog, routines))
+    try product(execute(outer, catalog, routines, bindings),
+                execute(inner, catalog, routines, bindings))
   case let .join(outer, name, ordinals, base, column, keys):
-    try join(execute(outer, catalog, routines), name, ordinals, base, column,
-             keys, catalog)
+    try join(execute(outer, catalog, routines, bindings), name, ordinals,
+             base, column, keys, catalog)
   }
 }
 
@@ -190,13 +191,15 @@ private func project(_ terms: Array<Term>, _ record: Record,
   return Record(cells)
 }
 
-/// Keeps the `records` the `filter` admits — those it evaluates to `true`,
-/// resolving scalar calls through `routines`.
+/// Keeps the `records` the `filter` admits — those it evaluates to `true` under
+/// three-valued logic (UNKNOWN and `false` both reject), resolving scalar calls
+/// through `routines` and parameters from `bindings`.
 private func admitted(_ records: Array<Record>, _ filter: Filter,
-                      _ routines: Routines) throws(SQLError) -> Array<Record> {
+                      _ routines: Routines, _ bindings: Bindings)
+    throws(SQLError) -> Array<Record> {
   var kept = Array<Record>()
   for record in records {
-    if try evaluate(filter, record, routines) {
+    if try evaluate(filter, record, routines, bindings) == true {
       kept.append(record)
     }
   }
@@ -234,9 +237,10 @@ private func derive<C: Catalog & ~Escapable>(_ plan: Plan,
                                              _ ordinals: Array<Int>,
                                              _ seek: Range<Int>?,
                                              _ catalog: borrowing C,
-                                             _ routines: Routines)
+                                             _ routines: Routines,
+                                             _ bindings: Bindings)
     throws(SQLError) -> Array<Record> {
-  let rows = try execute(plan, catalog, routines)
+  let rows = try execute(plan, catalog, routines, bindings)
   let range = seek ?? 0 ..< rows.count
   return range.map { rows[$0].project(ordinals) }
 }

--- a/Sources/SQL/Operator.swift
+++ b/Sources/SQL/Operator.swift
@@ -113,8 +113,10 @@ internal indirect enum Plan {
                seek: Range<Int>?)
   /// σ — keeps the records `Filter` admits, the filter in slot space.
   case select(Filter, Plan)
-  /// π — restricts and reorders each record to the projected slots.
-  case project(Array<Int>, Plan)
+  /// π — evaluates each projected `Term` (a slot read, a constant, or a scalar
+  /// call) against the record, in order, to the output row. A bare-column
+  /// projection is a list of `.slot` terms, so the simple path is a reorder.
+  case project(Array<Term>, Plan)
   /// τ — orders the records by a typed key on `slot`.
   case sort(slot: Int, ascending: Bool, Plan)
   /// × — every concatenation of an outer record with an inner one.
@@ -141,19 +143,22 @@ internal indirect enum Plan {
 /// seeks it per outer record, and concatenates the matches. The catalog is
 /// borrowed throughout — a `~Escapable` source is never copied or stored.
 internal func execute<C: Catalog & ~Escapable>(_ plan: Plan,
-                                               _ catalog: borrowing C)
+                                               _ catalog: borrowing C,
+                                               _ routines: Routines)
     throws(SQLError) -> Array<Record> {
   switch plan {
   case let .scan(name, ordinals, seek):
     try materialise(name, ordinals, seek, catalog)
   case let .derived(_, source, ordinals, seek):
-    try derive(source, ordinals, seek, catalog)
+    try derive(source, ordinals, seek, catalog, routines)
   case let .select(filter, source):
-    try execute(source, catalog).filter { evaluate(filter, $0) }
-  case let .project(slots, source):
-    try execute(source, catalog).map { $0.project(slots) }
+    try admitted(execute(source, catalog, routines), filter, routines)
+  case let .project(terms, source):
+    try execute(source, catalog, routines).map { record throws(SQLError) in
+      try project(terms, record, routines)
+    }
   case let .sort(slot, ascending, source):
-    try execute(source, catalog)
+    try execute(source, catalog, routines)
       .enumerated()
       .sorted { lhs, rhs in
         let ordered = less(lhs.element[slot], rhs.element[slot])
@@ -165,11 +170,37 @@ internal func execute<C: Catalog & ~Escapable>(_ plan: Plan,
       }
       .map(\.element)
   case let .product(outer, inner):
-    try product(execute(outer, catalog), execute(inner, catalog))
+    try product(execute(outer, catalog, routines),
+                execute(inner, catalog, routines))
   case let .join(outer, name, ordinals, base, column, keys):
-    try join(execute(outer, catalog), name, ordinals, base, column, keys,
-             catalog)
+    try join(execute(outer, catalog, routines), name, ordinals, base, column,
+             keys, catalog)
   }
+}
+
+/// Evaluates each projected `term` against `record` through `routines` to the
+/// output row, in order — slot `i` of the result is `terms[i]`.
+private func project(_ terms: Array<Term>, _ record: Record,
+                     _ routines: Routines) throws(SQLError) -> Record {
+  var cells = Array<Value>()
+  cells.reserveCapacity(terms.count)
+  for term in terms {
+    try cells.append(evaluate(term, record, routines))
+  }
+  return Record(cells)
+}
+
+/// Keeps the `records` the `filter` admits — those it evaluates to `true`,
+/// resolving scalar calls through `routines`.
+private func admitted(_ records: Array<Record>, _ filter: Filter,
+                      _ routines: Routines) throws(SQLError) -> Array<Record> {
+  var kept = Array<Record>()
+  for record in records {
+    if try evaluate(filter, record, routines) {
+      kept.append(record)
+    }
+  }
+  return kept
 }
 
 /// Re-resolves `name` against `catalog`, opens its cursor, and materialises the
@@ -202,9 +233,10 @@ private func materialise<C: Catalog & ~Escapable>(_ name: String,
 private func derive<C: Catalog & ~Escapable>(_ plan: Plan,
                                              _ ordinals: Array<Int>,
                                              _ seek: Range<Int>?,
-                                             _ catalog: borrowing C)
+                                             _ catalog: borrowing C,
+                                             _ routines: Routines)
     throws(SQLError) -> Array<Record> {
-  let rows = try execute(plan, catalog)
+  let rows = try execute(plan, catalog, routines)
   let range = seek ?? 0 ..< rows.count
   return range.map { rows[$0].project(ordinals) }
 }

--- a/Sources/SQL/Parser.swift
+++ b/Sources/SQL/Parser.swift
@@ -227,13 +227,19 @@ internal struct Parser: ~Escapable {
     return try comparison()
   }
 
-  /// Parses `expression op expression`.
+  /// Parses `expression op (expression | :parameter)`.
   ///
   /// Either operand may be a column, a literal, or a scalar-function call, so a
-  /// predicate can filter on a decoded value (`WHERE guid(Id) = '…'`).
+  /// predicate can filter on a decoded value (`WHERE guid(Id) = '…'`). A
+  /// `:parameter` right operand binds the comparison to a value resolved at run
+  /// time from the engine's bindings — the correlated-subquery primitive.
   private mutating func comparison() throws(SQLError) -> Predicate {
     let left = try expression()
     let op = try op()
+    if case let .parameter(name) = current?.kind {
+      _ = try advance(expecting: "a parameter")
+      return .bound(left: left, op: op, parameter: name)
+    }
     let right = try expression()
     return .comparison(left: left, op: op, right: right)
   }

--- a/Sources/SQL/Parser.swift
+++ b/Sources/SQL/Parser.swift
@@ -113,18 +113,75 @@ internal struct Parser: ~Escapable {
 
   // MARK: - Projection
 
-  /// Parses `*` or a comma-separated list of (possibly-qualified) columns.
+  /// Parses `*` or a comma-separated list of projected items, each an
+  /// expression with an optional `AS` alias.
+  ///
+  /// A list of bare columns with no alias collapses to the simpler `columns`
+  /// projection (the backward-compatible path); a list carrying any function
+  /// call or alias is the richer `expressions` projection.
   private mutating func projection() throws(SQLError) -> Projection {
     if try match(.star) {
       return .all
     }
 
-    var columns = Array<Column>()
-    try columns.append(column())
+    var items = Array<Projected>()
+    try items.append(projected())
     while try match(.comma) {
-      try columns.append(column())
+      try items.append(projected())
+    }
+
+    // Collapse a plain column list (no calls, no aliases) to `columns`.
+    var columns = Array<Column>()
+    for item in items {
+      guard item.alias == nil, case let .column(column) = item.expression else {
+        return .expressions(items)
+      }
+      columns.append(column)
     }
     return .columns(columns)
+  }
+
+  /// Parses one projected item: an expression and an optional `AS alias`.
+  private mutating func projected() throws(SQLError) -> Projected {
+    let expression = try expression()
+    let alias: String? = if try match(.as) {
+      try identifier()
+    } else {
+      nil
+    }
+    return Projected(expression: expression, alias: alias)
+  }
+
+  /// Parses a scalar expression: a string/integer literal, a function call
+  /// (`name(args)`), or a bare (possibly-qualified) column.
+  ///
+  /// A function call is an identifier immediately followed by `(`; an identifier
+  /// not so followed is a column. The arguments are a comma-separated list of
+  /// expressions, possibly empty.
+  private mutating func expression() throws(SQLError) -> Expression {
+    if case let .string(value) = current?.kind {
+      _ = try advance(expecting: "a literal")
+      return .literal(.string(value))
+    }
+    if case let .integer(value) = current?.kind {
+      _ = try advance(expecting: "a literal")
+      return .literal(.integer(value))
+    }
+
+    let name = try identifier()
+    guard try match(.lparen) else {
+      return .column(Column(name))
+    }
+
+    var arguments = Array<Expression>()
+    if current?.kind != .rparen {
+      try arguments.append(expression())
+      while try match(.comma) {
+        try arguments.append(expression())
+      }
+    }
+    try expect(.rparen)
+    return .call(name: name, arguments: arguments)
   }
 
   // MARK: - Predicate
@@ -170,12 +227,15 @@ internal struct Parser: ~Escapable {
     return try comparison()
   }
 
-  /// Parses `column op literal`.
+  /// Parses `expression op expression`.
+  ///
+  /// Either operand may be a column, a literal, or a scalar-function call, so a
+  /// predicate can filter on a decoded value (`WHERE guid(Id) = '…'`).
   private mutating func comparison() throws(SQLError) -> Predicate {
-    let column = try column()
+    let left = try expression()
     let op = try op()
-    let value = try literal()
-    return .comparison(column: column, op: op, value: value)
+    let right = try expression()
+    return .comparison(left: left, op: op, right: right)
   }
 
   /// Parses a comparison operator.

--- a/Sources/SQL/Resolve.swift
+++ b/Sources/SQL/Resolve.swift
@@ -37,18 +37,49 @@ extension Schema {
     return ordinal
   }
 
-  internal func projection(_ projection: Projection, in relation: Relation)
-      throws(SQLError) -> Array<Int> {
+  /// The projected terms of `projection`, addressed by ordinal: a `*` or a
+  /// bare-column list yields one `.slot(ordinal)` per column; an expression list
+  /// lowers each expression to a term. The terms hold ordinals, which the
+  /// engine remaps to slots after gathering the referenced ones.
+  internal func terms(_ projection: Projection, in relation: Relation)
+      throws(SQLError) -> Array<Term> {
     switch projection {
     case .all:
-      return Array(0 ..< width)
+      return (0 ..< width).map { .slot($0) }
     case let .columns(columns):
-      var ordinals = Array<Int>()
-      ordinals.reserveCapacity(columns.count)
+      var terms = Array<Term>()
+      terms.reserveCapacity(columns.count)
       for column in columns {
-        try ordinals.append(ordinal(of: column, in: relation))
+        try terms.append(.slot(ordinal(of: column, in: relation)))
       }
-      return ordinals
+      return terms
+    case let .expressions(projected):
+      var terms = Array<Term>()
+      terms.reserveCapacity(projected.count)
+      for item in projected {
+        try terms.append(term(item.expression, in: relation))
+      }
+      return terms
+    }
+  }
+
+  /// Lowers a scalar `expression` to an ordinal-addressed `Term`: a column to a
+  /// `.slot(ordinal)`, a literal to a `.constant`, a call to an `.apply` over
+  /// its lowered arguments.
+  internal func term(_ expression: Expression, in relation: Relation)
+      throws(SQLError) -> Term {
+    switch expression {
+    case let .column(column):
+      return try .slot(ordinal(of: column, in: relation))
+    case let .literal(literal):
+      return .constant(value(of: literal))
+    case let .call(name, arguments):
+      var lowered = Array<Term>()
+      lowered.reserveCapacity(arguments.count)
+      for argument in arguments {
+        try lowered.append(term(argument, in: relation))
+      }
+      return .apply(name: name, arguments: lowered)
     }
   }
 
@@ -61,8 +92,8 @@ extension Schema {
   internal func lower(_ predicate: Predicate, in relation: Relation)
       throws(SQLError) -> Filter {
     switch predicate {
-    case let .comparison(column, op, value):
-      try .compare(ordinal(of: column, in: relation), op, value)
+    case let .comparison(left, op, right):
+      try .compare(term(left, in: relation), op, term(right, in: relation))
     case let .and(lhs, rhs):
       try .and(lower(lhs, in: relation), lower(rhs, in: relation))
     case let .or(lhs, rhs):
@@ -160,24 +191,49 @@ internal struct Scope {
     }
   }
 
-  /// The combined ordinals a projection yields: every real column of both
-  /// relations for `*` (outer then inner, never a virtual column), the named
-  /// columns' combined ordinals otherwise, in source order.
-  internal func projection(_ projection: Projection) throws(SQLError)
-      -> Array<Int> {
+  /// The combined-ordinal projected terms: every real column of both relations
+  /// for `*` (outer then inner, never a virtual column) as `.slot` terms, a
+  /// bare-column list as `.slot` terms at their combined ordinals, an expression
+  /// list as lowered terms — in source order.
+  internal func terms(_ projection: Projection) throws(SQLError)
+      -> Array<Term> {
     switch projection {
     case .all:
       // Every real outer column, then every real inner column at its
       // `base`-offset ordinal — never a virtual column of either side.
-      return Array(0 ..< outer.width)
-          + (0 ..< inner.width).map { base + $0 }
+      return (0 ..< outer.width).map { .slot($0) }
+          + (0 ..< inner.width).map { .slot(base + $0) }
     case let .columns(columns):
-      var ordinals = Array<Int>()
-      ordinals.reserveCapacity(columns.count)
+      var terms = Array<Term>()
+      terms.reserveCapacity(columns.count)
       for column in columns {
-        try ordinals.append(ordinal(of: column))
+        try terms.append(.slot(ordinal(of: column)))
       }
-      return ordinals
+      return terms
+    case let .expressions(projected):
+      var terms = Array<Term>()
+      terms.reserveCapacity(projected.count)
+      for item in projected {
+        try terms.append(term(item.expression))
+      }
+      return terms
+    }
+  }
+
+  /// Lowers a scalar `expression` to a combined-ordinal `Term`.
+  internal func term(_ expression: Expression) throws(SQLError) -> Term {
+    switch expression {
+    case let .column(column):
+      return try .slot(ordinal(of: column))
+    case let .literal(literal):
+      return .constant(value(of: literal))
+    case let .call(name, arguments):
+      var lowered = Array<Term>()
+      lowered.reserveCapacity(arguments.count)
+      for argument in arguments {
+        try lowered.append(term(argument))
+      }
+      return .apply(name: name, arguments: lowered)
     }
   }
 
@@ -199,8 +255,8 @@ internal struct Scope {
   /// column reference resolved to a combined ordinal across the join.
   internal func lower(_ predicate: Predicate) throws(SQLError) -> Filter {
     switch predicate {
-    case let .comparison(column, op, value):
-      try .compare(ordinal(of: column), op, value)
+    case let .comparison(left, op, right):
+      try .compare(term(left), op, term(right))
     case let .and(lhs, rhs):
       try .and(lower(lhs), lower(rhs))
     case let .or(lhs, rhs):
@@ -216,13 +272,14 @@ internal struct Scope {
 extension Filter {
   /// The ordinals this filter reads, accumulated into `ordinals`.
   ///
-  /// A `compare` reads its one column; a `match` reads both; the connectives
-  /// recurse. The engine unions these with the projection, order, and join keys
-  /// to materialise exactly the columns a scan's rows are read through.
+  /// A `compare` reads both operand terms, a `match` both columns; the
+  /// connectives recurse. The engine unions these with the projection, order,
+  /// and join keys to materialise exactly the columns a scan's rows read.
   internal func references(into ordinals: inout Set<Int>) {
     switch self {
-    case let .compare(column, _, _):
-      ordinals.insert(column)
+    case let .compare(lhs, _, rhs):
+      lhs.references(into: &ordinals)
+      rhs.references(into: &ordinals)
     case let .match(left, right):
       ordinals.insert(left)
       ordinals.insert(right)

--- a/Sources/SQL/Resolve.swift
+++ b/Sources/SQL/Resolve.swift
@@ -94,6 +94,8 @@ extension Schema {
     switch predicate {
     case let .comparison(left, op, right):
       try .compare(term(left, in: relation), op, term(right, in: relation))
+    case let .bound(left, op, parameter):
+      try .bound(term(left, in: relation), op, parameter)
     case let .and(lhs, rhs):
       try .and(lower(lhs, in: relation), lower(rhs, in: relation))
     case let .or(lhs, rhs):
@@ -257,6 +259,8 @@ internal struct Scope {
     switch predicate {
     case let .comparison(left, op, right):
       try .compare(term(left), op, term(right))
+    case let .bound(left, op, parameter):
+      try .bound(term(left), op, parameter)
     case let .and(lhs, rhs):
       try .and(lower(lhs), lower(rhs))
     case let .or(lhs, rhs):
@@ -272,14 +276,17 @@ internal struct Scope {
 extension Filter {
   /// The ordinals this filter reads, accumulated into `ordinals`.
   ///
-  /// A `compare` reads both operand terms, a `match` both columns; the
-  /// connectives recurse. The engine unions these with the projection, order,
-  /// and join keys to materialise exactly the columns a scan's rows read.
+  /// A `compare` reads both operand terms, a `bound` its left term, a `match`
+  /// both columns; the connectives recurse. The engine unions these with the
+  /// projection, order, and join keys to materialise exactly the columns a
+  /// scan's rows are read through.
   internal func references(into ordinals: inout Set<Int>) {
     switch self {
     case let .compare(lhs, _, rhs):
       lhs.references(into: &ordinals)
       rhs.references(into: &ordinals)
+    case let .bound(term, _, _):
+      term.references(into: &ordinals)
     case let .match(left, right):
       ordinals.insert(left)
       ordinals.insert(right)

--- a/Sources/SQL/Token.swift
+++ b/Sources/SQL/Token.swift
@@ -35,6 +35,8 @@ extension Token {
     case identifier(String)
     case string(String)
     case integer(Int)
+    /// A bound parameter placeholder `:name`, holding the parameter's name.
+    case parameter(String)
 
     // Punctuation and operators.
     case star
@@ -70,6 +72,7 @@ extension Token.Kind {
     case let .identifier(name): name
     case let .string(value): "'\(value)'"
     case let .integer(value): "\(value)"
+    case let .parameter(name): ":\(name)"
     case .star: "*"
     case .comma: ","
     case .lparen: "("

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -717,3 +717,117 @@ private func filters(_ plan: Plan) -> Bool {
     false
   }
 }
+
+// MARK: - Scalar-function tests
+
+/// Routines with two demonstration scalar functions: `upper`, which folds a
+/// text cell to upper case, and `add`, which sums two integer cells. These
+/// stand in for the per-dialect decode functions a synthesis projection calls.
+private func routines() -> Routines {
+  Routines()
+    .registering("upper") { arguments throws(SQLError) in
+      guard case let .text(text) = arguments.first else {
+        throw .argument("upper expects one text argument")
+      }
+      return .text(text.uppercased())
+    }
+    .registering("add") { arguments throws(SQLError) in
+      guard arguments.count == 2,
+          case let .integer(lhs) = arguments[0],
+          case let .integer(rhs) = arguments[1] else {
+        throw .argument("add expects two integer arguments")
+      }
+      return .integer(lhs + rhs)
+    }
+}
+
+/// Runs `text` against the `People` catalog through the demonstration routines.
+private func functionRun(_ text: String) throws -> Array<Array<Value>> {
+  try Engine.run(parse(text), people(), routines())
+}
+
+struct EngineFunctionTests {
+  @Test("a registered function projects over a column")
+  func projection() throws {
+    let rows = try functionRun("SELECT upper(Name) FROM People WHERE Id = 1")
+    #expect(rows == [[.text("ALICE")]])
+  }
+
+  @Test("a function projects beside a bare column")
+  func mixed() throws {
+    let rows =
+        try functionRun("SELECT Id, upper(Name) FROM People WHERE Id = 3")
+    #expect(rows == [[.integer(3), .text("CAROL")]])
+  }
+
+  @Test("a function takes more than one column argument")
+  func multiple() throws {
+    let rows = try functionRun("SELECT add(Id, Age) FROM People WHERE Id = 2")
+    // Bob: Id 2 + Age 25 = 27.
+    #expect(rows == [[.integer(27)]])
+  }
+
+  @Test("a function takes a literal argument")
+  func literal() throws {
+    let rows = try functionRun("SELECT add(Id, 100) FROM People WHERE Id = 4")
+    #expect(rows == [[.integer(104)]])
+  }
+
+  @Test("a function call nests another function call")
+  func nested() throws {
+    let rows =
+        try functionRun("SELECT add(add(Id, 1), Age) FROM People WHERE Id = 5")
+    // Eve: (5 + 1) + 25 = 31.
+    #expect(rows == [[.integer(31)]])
+  }
+
+  @Test("an unregistered function is reported")
+  func unknown() throws {
+    #expect(throws: SQLError.function("missing")) {
+      try functionRun("SELECT missing(Name) FROM People")
+    }
+  }
+
+  @Test("a function rejecting its arguments reports the fault")
+  func invalid() throws {
+    #expect(throws: SQLError.argument("upper expects one text argument")) {
+      try functionRun("SELECT upper(Id) FROM People WHERE Id = 1")
+    }
+  }
+
+  @Test("a function call resolves its name case-insensitively")
+  func folded() throws {
+    // `upper` is registered; the natural SQL spelling UPPER resolves to it, as
+    // table and column identifiers do.
+    let rows = try functionRun("SELECT UPPER(Name) FROM People WHERE Id = 1")
+    #expect(rows == [[.text("ALICE")]])
+  }
+
+  @Test("routine names colliding only by case merge without trapping")
+  func collision() throws {
+    // "tag" and "TAG" fold to one name; the registry merges them (the later-
+    // sorting original spelling wins) instead of trapping on the duplicate.
+    let lower: Scalar = { _ in .text("lower") }
+    let upper: Scalar = { _ in .text("upper") }
+    let routines: Routines = ["tag": lower, "TAG": upper]
+    let query = try parse("SELECT tag(Name) FROM People WHERE Id = 1")
+    let rows = try Engine.run(query, people(), routines)
+    #expect(rows == [[.text("lower")]])
+  }
+
+  @Test("a predicate filters on a scalar function call")
+  func predicate() throws {
+    // The documented contract: a predicate may call a registered function;
+    // `upper(Name) = 'ALICE'` decodes the column before comparing.
+    let rows =
+        try functionRun("SELECT Id FROM People WHERE upper(Name) = 'ALICE'")
+    #expect(rows == [[.integer(1)]])
+  }
+
+  @Test("a predicate compares a function result to an integer")
+  func arithmetic() throws {
+    let rows =
+        try functionRun("SELECT Name FROM People WHERE add(Id, 10) = 12")
+    #expect(rows == [[.text("Bob")]])
+  }
+}

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -651,9 +651,8 @@ struct EngineViewTests {
     // view and inspect the `.derived` leaf: its sub-plan must reach a seeked
     // `.scan` (a non-nil seek) and carry no `.select` over a raw scan.
     let catalog = try views()
-    let plan = try Engine.optimise(
-        Engine.compile(parse("SELECT Key, Label FROM Adults"), catalog),
-        catalog)
+    let select = try parse("SELECT Key, Label FROM Adults")
+    let plan = try Engine.optimise(Engine.compile(select, catalog), catalog)
     let sub = try #require(derived(plan))
     #expect(seeks(sub))
     #expect(!filters(sub))

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -246,8 +246,15 @@ private func views() throws -> Memory {
         JOIN Child ON Child.Pid = Parent.Id
       """), columns: ["Parent", "Kid"])
 
+  // SELECT Id, Name FROM Parent WHERE Id = :id — a parameterized view whose
+  // bound key seeks inside its sub-plan when :id is supplied.
+  let picked = try View(select: select("""
+      SELECT Id, Name FROM Parent WHERE Id = :id
+      """), columns: ["Key", "Label"])
+
   let catalog = family()
-  return Memory(catalog.relations, views: ["Adults": adults, "Pairs": pairs])
+  return Memory(catalog.relations,
+                views: ["Adults": adults, "Pairs": pairs, "Picked": picked])
 }
 
 /// Parses `text` to a `SELECT`, failing on any other statement.
@@ -652,7 +659,8 @@ struct EngineViewTests {
     // `.scan` (a non-nil seek) and carry no `.select` over a raw scan.
     let catalog = try views()
     let select = try parse("SELECT Key, Label FROM Adults")
-    let plan = try Engine.optimise(Engine.compile(select, catalog), catalog)
+    let plan = try Engine.optimise(Engine.compile(select, catalog), catalog,
+                                   [:])
     let sub = try #require(derived(plan))
     #expect(seeks(sub))
     #expect(!filters(sub))
@@ -829,5 +837,128 @@ struct EngineFunctionTests {
     let rows =
         try functionRun("SELECT Name FROM People WHERE add(Id, 10) = 12")
     #expect(rows == [[.text("Bob")]])
+  }
+}
+
+// MARK: - Bound-parameter / correlated-subquery tests
+
+/// Runs `text` against the `family` catalog with the given parameter bindings.
+private func boundRun(_ text: String, _ bindings: Bindings)
+    throws -> Array<Array<Value>> {
+  try Engine.run(parse(text), family(), Routines(), bindings: bindings)
+}
+
+struct EngineBoundTests {
+  @Test("a bound parameter filters rows by an outer value")
+  func filter() throws {
+    // The child relation keyed on a bound parent id — the section primitive: a
+    // template renders an interface's methods by binding the interface key and
+    // running the child query.
+    let rows = try boundRun("SELECT Name FROM Child WHERE Pid = :pid",
+                            ["pid": .integer(1)])
+    #expect(rows == [[.text("Ann")], [.text("Amy")]])
+  }
+
+  @Test("a bound text parameter compares against a text column")
+  func text() throws {
+    let rows = try boundRun("SELECT Id FROM Parent WHERE Name = :who",
+                            ["who": .text("Bee")])
+    #expect(rows == [[.integer(2)]])
+  }
+
+  @Test("an unbound parameter admits no row")
+  func unbound() throws {
+    let rows = try boundRun("SELECT Name FROM Child WHERE Pid = :pid", [:])
+    #expect(rows.isEmpty)
+  }
+
+  @Test("a bound parameter conjoined with another predicate")
+  func conjunction() throws {
+    let rows = try boundRun("""
+        SELECT Name FROM Child WHERE Pid = :pid AND Name = 'Amy'
+        """, ["pid": .integer(1)])
+    #expect(rows == [[.text("Amy")]])
+  }
+
+  @Test("a correlated section runs a child query per outer row")
+  func correlated() throws {
+    // The relational shape of a template's nested section: the outer query
+    // yields the parents; for each, the child query is re-run with the parent's
+    // key bound, producing that parent's children — exactly an interface →
+    // methods expansion.
+    let catalog = family()
+    let parents = try Engine.run(parse("SELECT Id, Name FROM Parent"), catalog)
+    let query = try parse("SELECT Name FROM Child WHERE Pid = :pid")
+
+    var sections = Array<(parent: String, children: Array<String>)>()
+    for parent in parents {
+      let key = parent[0]
+      let children = try Engine.run(query, catalog, Routines(),
+                                    bindings: ["pid": key])
+      guard case let .text(name) = parent[1] else { continue }
+      sections.append((name, children.map { row in
+        guard case let .text(child) = row[0] else { return "" }
+        return child
+      }))
+    }
+
+    #expect(sections.count == 3)
+    #expect(sections[0].parent == "Ada")
+    #expect(sections[0].children == ["Ann", "Amy"])
+    #expect(sections[1].parent == "Bee")
+    #expect(sections[1].children == ["Bob"])
+    #expect(sections[2].parent == "Cid")
+    #expect(sections[2].children.isEmpty)
+  }
+
+  @Test("an unbound parameter under NOT still admits no rows")
+  func negated() throws {
+    // A missing binding is UNKNOWN, not false; NOT preserves UNKNOWN rather
+    // than inverting it into a match, so the predicate admits nothing.
+    let rows = try boundRun("SELECT Name FROM Child WHERE NOT Pid = :pid", [:])
+    #expect(rows.isEmpty)
+  }
+
+  @Test("a bound parameter under NOT inverts the match")
+  func inverted() throws {
+    let rows = try boundRun("SELECT Name FROM Child WHERE NOT Pid = :pid",
+                            ["pid": .integer(1)])
+    #expect(rows == [[.text("Bob")], [.text("Orphan")]])
+  }
+
+  @Test("a bound key plans a seek when its value is known")
+  func seek() throws {
+    // Parent is sorted on Id; with `:id` bound the planner resolves it and
+    // seeks the run rather than scanning and filtering the whole relation.
+    let select = try parse("SELECT Name FROM Parent WHERE Id = :id")
+    let catalog = family()
+    let plan = try Engine.optimise(Engine.compile(select, catalog), catalog,
+                                   ["id": .integer(2)])
+    #expect(seeks(plan))
+    #expect(!filters(plan))
+  }
+
+  @Test("an unbound key cannot seek and scans under the filter")
+  func scan() throws {
+    let select = try parse("SELECT Name FROM Parent WHERE Id = :id")
+    let catalog = family()
+    let plan = try Engine.optimise(Engine.compile(select, catalog), catalog,
+                                   [:])
+    #expect(!seeks(plan))
+    #expect(filters(plan))
+  }
+
+  @Test("a bound key inside a view seeks when its parameter is supplied")
+  func nested() throws {
+    // A parameterized view (`… WHERE Id = :id` over sorted Parent): the bound
+    // key seeks inside the view's sub-plan rather than scanning it once :id is
+    // supplied, so a reusable view is as fast as the inlined query.
+    let select = try parse("SELECT Key, Label FROM Picked")
+    let catalog = try views()
+    let plan = try Engine.optimise(Engine.compile(select, catalog), catalog,
+                                   ["id": .integer(2)])
+    let sub = try #require(derived(plan))
+    #expect(seeks(sub))
+    #expect(!filters(sub))
   }
 }

--- a/Tests/SQLTests/LexerTests.swift
+++ b/Tests/SQLTests/LexerTests.swift
@@ -129,4 +129,15 @@ struct LexerTests {
   func unterminatedString() {
     #expect(throws: SQLError.self) { _ = try lex("'oops") }
   }
+
+  @Test("scans a bound-parameter placeholder")
+  func parameter() throws {
+    #expect(try lex("WHERE a = :pid")
+                == [.where, .identifier("a"), .equal, .parameter("pid")])
+  }
+
+  @Test("rejects a colon not followed by an identifier")
+  func bareColon() {
+    #expect(throws: SQLError.self) { _ = try lex("SELECT : FROM T") }
+  }
 }

--- a/Tests/SQLTests/ParserTests.swift
+++ b/Tests/SQLTests/ParserTests.swift
@@ -53,8 +53,8 @@ struct KeywordTests {
         try parseSelect("select TypeName from TypeDef where Flags = 1")
     #expect(select.projection == .columns(["TypeName"]))
     #expect(select.table == "TypeDef")
-    #expect(select.predicate == .comparison(column: "Flags", op: .equal,
-                                            value: .integer(1)))
+    #expect(select.predicate == .comparison(left: .column("Flags"), op: .equal,
+                                            right: .literal(.integer(1))))
   }
 
   @Test("parses mixed-case keywords")
@@ -79,7 +79,8 @@ struct PredicateTests {
       let select =
           try parseSelect("SELECT * FROM T WHERE Flags \(text) 1")
       #expect(select.predicate
-                  == .comparison(column: "Flags", op: op, value: .integer(1)))
+                  == .comparison(left: .column("Flags"), op: op,
+                                 right: .literal(.integer(1))))
     }
   }
 
@@ -88,17 +89,27 @@ struct PredicateTests {
     let select =
         try parseSelect(
             "SELECT * FROM TypeDef WHERE TypeNamespace = 'Windows.Win32.Foundation'")
+    let value = Expression.literal(.string("Windows.Win32.Foundation"))
     #expect(select.predicate
-                == .comparison(column: "TypeNamespace", op: .equal,
-                               value: .string("Windows.Win32.Foundation")))
+                == .comparison(left: .column("TypeNamespace"), op: .equal,
+                               right: value))
   }
 
   @Test("parses a string with an escaped quote")
   func escapedQuote() throws {
     let select = try parseSelect("SELECT * FROM T WHERE name = 'O''Brien'")
     #expect(select.predicate
-                == .comparison(column: "name", op: .equal,
-                               value: .string("O'Brien")))
+                == .comparison(left: .column("name"), op: .equal,
+                               right: .literal(.string("O'Brien"))))
+  }
+
+  @Test("parses a function call as a comparison operand")
+  func functionOperand() throws {
+    let select = try parseSelect("SELECT * FROM T WHERE upper(Name) = 'X'")
+    let call = Expression.call(name: "upper", arguments: [.column("Name")])
+    #expect(select.predicate
+                == .comparison(left: call, op: .equal,
+                               right: .literal(.string("X"))))
   }
 
   @Test("binds AND tighter than OR")
@@ -106,9 +117,12 @@ struct PredicateTests {
     // a = 1 OR b = 2 AND c = 3  ==>  a OR (b AND c)
     let select =
         try parseSelect("SELECT * FROM T WHERE a = 1 OR b = 2 AND c = 3")
-    let a = Predicate.comparison(column: "a", op: .equal, value: .integer(1))
-    let b = Predicate.comparison(column: "b", op: .equal, value: .integer(2))
-    let c = Predicate.comparison(column: "c", op: .equal, value: .integer(3))
+    let a = Predicate.comparison(left: .column("a"), op: .equal,
+                                 right: .literal(.integer(1)))
+    let b = Predicate.comparison(left: .column("b"), op: .equal,
+                                 right: .literal(.integer(2)))
+    let c = Predicate.comparison(left: .column("c"), op: .equal,
+                                 right: .literal(.integer(3)))
     #expect(select.predicate == .or(a, .and(b, c)))
   }
 
@@ -117,8 +131,10 @@ struct PredicateTests {
     // NOT a = 1 AND b = 2  ==>  (NOT a) AND b
     let select =
         try parseSelect("SELECT * FROM T WHERE NOT a = 1 AND b = 2")
-    let a = Predicate.comparison(column: "a", op: .equal, value: .integer(1))
-    let b = Predicate.comparison(column: "b", op: .equal, value: .integer(2))
+    let a = Predicate.comparison(left: .column("a"), op: .equal,
+                                 right: .literal(.integer(1)))
+    let b = Predicate.comparison(left: .column("b"), op: .equal,
+                                 right: .literal(.integer(2)))
     #expect(select.predicate == .and(.not(a), b))
   }
 
@@ -127,9 +143,12 @@ struct PredicateTests {
     // (a = 1 OR b = 2) AND c = 3
     let select =
         try parseSelect("SELECT * FROM T WHERE (a = 1 OR b = 2) AND c = 3")
-    let a = Predicate.comparison(column: "a", op: .equal, value: .integer(1))
-    let b = Predicate.comparison(column: "b", op: .equal, value: .integer(2))
-    let c = Predicate.comparison(column: "c", op: .equal, value: .integer(3))
+    let a = Predicate.comparison(left: .column("a"), op: .equal,
+                                 right: .literal(.integer(1)))
+    let b = Predicate.comparison(left: .column("b"), op: .equal,
+                                 right: .literal(.integer(2)))
+    let c = Predicate.comparison(left: .column("c"), op: .equal,
+                                 right: .literal(.integer(3)))
     #expect(select.predicate == .and(.or(a, b), c))
   }
 
@@ -138,9 +157,12 @@ struct PredicateTests {
     // a = 1 OR b = 2 OR c = 3  ==>  ((a OR b) OR c)
     let select =
         try parseSelect("SELECT * FROM T WHERE a = 1 OR b = 2 OR c = 3")
-    let a = Predicate.comparison(column: "a", op: .equal, value: .integer(1))
-    let b = Predicate.comparison(column: "b", op: .equal, value: .integer(2))
-    let c = Predicate.comparison(column: "c", op: .equal, value: .integer(3))
+    let a = Predicate.comparison(left: .column("a"), op: .equal,
+                                 right: .literal(.integer(1)))
+    let b = Predicate.comparison(left: .column("b"), op: .equal,
+                                 right: .literal(.integer(2)))
+    let c = Predicate.comparison(left: .column("c"), op: .equal,
+                                 right: .literal(.integer(3)))
     #expect(select.predicate == .or(.or(a, b), c))
   }
 }
@@ -176,11 +198,11 @@ struct CompositeTests {
             """)
     #expect(select.projection == .columns(["TypeName", "TypeNamespace"]))
     #expect(select.table == "TypeDef")
-    let namespace =
-        Predicate.comparison(column: "TypeNamespace", op: .equal,
-                             value: .string("Windows.Win32.Foundation"))
-    let flags = Predicate.comparison(column: "Flags", op: .geq,
-                                     value: .integer(1))
+    let value = Expression.literal(.string("Windows.Win32.Foundation"))
+    let namespace = Predicate.comparison(left: .column("TypeNamespace"),
+                                         op: .equal, right: value)
+    let flags = Predicate.comparison(left: .column("Flags"), op: .geq,
+                                     right: .literal(.integer(1)))
     #expect(select.predicate == .and(namespace, flags))
     #expect(select.order == Order(column: "TypeName", ascending: false))
   }
@@ -249,9 +271,9 @@ struct JoinTests {
                 == Join(relation: Relation(name: "MethodDef", alias: "m"),
                         left: Column("m.parent"), right: Column("t.rowid")))
     #expect(select.projection == .columns([Column("m.Name")]))
-    #expect(select.predicate == .comparison(column: Column("t.TypeName"),
-                                            op: .equal,
-                                            value: .string("IUnknown")))
+    let value = Expression.literal(.string("IUnknown"))
+    #expect(select.predicate == .comparison(left: .column("t.TypeName"),
+                                            op: .equal, right: value))
   }
 
   @Test("parses a forward-key join")
@@ -339,11 +361,65 @@ struct ErrorTests {
     }
   }
 
-  @Test("rejects an identifier as a comparison operand")
-  func literalRequired() {
-    // A comparison's right operand must be a literal, not an identifier.
-    #expect(throws: SQLError.self) {
-      _ = try Statement(parsing: "SELECT * FROM T WHERE a = b")
-    }
+  @Test("parses a column on either side of a comparison")
+  func columnOperands() throws {
+    // Either operand may be an expression, so a column-vs-column predicate is
+    // valid SQL (`a = b`), not an error.
+    let select = try parseSelect("SELECT * FROM T WHERE a = b")
+    #expect(select.predicate
+                == .comparison(left: .column("a"), op: .equal,
+                               right: .column("b")))
+  }
+}
+
+// MARK: - Expression projections
+
+struct ExpressionTests {
+  @Test("a bare-column list stays the simpler columns projection")
+  func columns() throws {
+    let select = try parseSelect("SELECT a, b FROM T")
+    #expect(select.projection == .columns(["a", "b"]))
+  }
+
+  @Test("a function call yields an expression projection")
+  func call() throws {
+    let select = try parseSelect("SELECT guid(Name) FROM T")
+    #expect(select.projection
+                == .expressions([
+                  Projected(expression: .call(name: "guid",
+                                              arguments: [.column("Name")]))
+                ]))
+  }
+
+  @Test("an aliased column yields an expression projection")
+  func alias() throws {
+    let select = try parseSelect("SELECT Name AS label FROM T")
+    #expect(select.projection
+                == .expressions([
+                  Projected(expression: .column("Name"), alias: "label")
+                ]))
+  }
+
+  @Test("a call takes literal and nested-call arguments")
+  func arguments() throws {
+    let select = try parseSelect("SELECT f(1, g(x), 'lit') FROM T")
+    #expect(select.projection
+                == .expressions([
+                  Projected(expression:
+                    .call(name: "f", arguments: [
+                      .literal(.integer(1)),
+                      .call(name: "g", arguments: [.column("x")]),
+                      .literal(.string("lit")),
+                    ]))
+                ]))
+  }
+
+  @Test("a zero-argument call parses")
+  func nullary() throws {
+    let select = try parseSelect("SELECT now() FROM T")
+    #expect(select.projection
+                == .expressions([
+                  Projected(expression: .call(name: "now", arguments: []))
+                ]))
   }
 }


### PR DESCRIPTION
This pull request introduces significant enhancements to the SQL engine's support for scalar expressions, function calls, and parameter binding. The changes add a robust system for handling projected expressions (including function calls and aliases), support for named scalar functions, and runtime-bound parameters in predicates. The codebase is refactored to handle these new capabilities throughout parsing, planning, and execution.

**Support for Scalar Expressions and Function Calls:**
- Added `Expression` and `Projected` types to the AST, allowing projections to include function calls and aliases, not just bare columns. The parser now emits `expressions` when a projection contains function calls or aliases. (`Sources/SQL/AST.swift` [Sources/SQL/AST.swiftR147-R188](diffhunk://#diff-44ae278469f8cb8537a5e8997ce917320e10f66a7fb199bcf35bc353ab154f08R147-R188))
- Introduced the `Term` type as the lowered, slot-addressed form of an expression, and implemented evaluation logic for terms, including function application through registered routines. (`Sources/SQL/Filter.swift` [[1]](diffhunk://#diff-66f69cc14663ff59f1854b7179f51accad89aa0a7e6731e6880d344908ac4facR31-R110) [[2]](diffhunk://#diff-66f69cc14663ff59f1854b7179f51accad89aa0a7e6731e6880d344908ac4facL57-R185)
- Extended the engine to carry `Routines` (the function registry) through compilation and execution, and to evaluate function calls in projections and predicates. (`Sources/SQL/Engine.swift` [[1]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L28-R32) [[2]](diffhunk://#diff-c2a824b19cb7761a8c6ab76d4d4cb9cc4ffd627966f6138baa92cd2219777331R1-R51)

**Parameter Binding and Predicate Enhancements:**
- Added support for predicates that compare a column to a runtime parameter (e.g., `column = :param`), including parsing, lowering, and evaluation. (`Sources/SQL/AST.swift` [[1]](diffhunk://#diff-44ae278469f8cb8537a5e8997ce917320e10f66a7fb199bcf35bc353ab154f08R198-R201) `Sources/SQL/Filter.swift` [[2]](diffhunk://#diff-66f69cc14663ff59f1854b7179f51accad89aa0a7e6731e6880d344908ac4facR16-R19) [[3]](diffhunk://#diff-66f69cc14663ff59f1854b7179f51accad89aa0a7e6731e6880d344908ac4facL57-R185)
- Updated the lexer to recognize parameter tokens (e.g., `:name`). (`Sources/SQL/Lexer.swift` [[1]](diffhunk://#diff-3a41d2f1d12fb42c8cf94decbe20e627053820a0d629708ea2b1ec942a3c087fR126-R128) [[2]](diffhunk://#diff-3a41d2f1d12fb42c8cf94decbe20e627053820a0d629708ea2b1ec942a3c087fR186-R203)

**Execution Plan and Error Handling Refactoring:**
- Refactored execution plans and the engine to use `Term` (not just slot ordinals) in projections, enabling evaluation of expressions and function calls per row. (`Sources/SQL/Operator.swift` [[1]](diffhunk://#diff-90b051b6c59d5ca6612ebe0500cd6ccfecdec8f79c3c79167986ee4298fd0737L116-R119) `Sources/SQL/Engine.swift` [[2]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L72-R79) [[3]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L96-R97) [[4]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L115-R116) [[5]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L157-R168) [[6]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060R184-R206) [[7]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L198-R221)
- Added new error cases for unknown functions and invalid function arguments, with descriptive error messages. (`Sources/SQL/Error.swift` [[1]](diffhunk://#diff-fabb0e55432d1f4932fcc44ed65501e0499e9ae032e5559384617eff30049944R56-R60) [[2]](diffhunk://#diff-fabb0e55432d1f4932fcc44ed65501e0499e9ae032e5559384617eff30049944R84-R87)

**Summary of Most Important Changes:**

**1. Scalar Expressions and Function Calls**
- Added `Expression`, `Projected`, and `Term` types to represent and evaluate scalar expressions, function calls, and aliases in projections. (`Sources/SQL/AST.swift` [[1]](diffhunk://#diff-44ae278469f8cb8537a5e8997ce917320e10f66a7fb199bcf35bc353ab154f08R147-R188) `Sources/SQL/Filter.swift` [[2]](diffhunk://#diff-66f69cc14663ff59f1854b7179f51accad89aa0a7e6731e6880d344908ac4facR31-R110)
- Introduced the `Routines` registry for named scalar functions, and integrated function lookup and application into the engine. (`Sources/SQL/Function.swift` [[1]](diffhunk://#diff-c2a824b19cb7761a8c6ab76d4d4cb9cc4ffd627966f6138baa92cd2219777331R1-R51) `Sources/SQL/Engine.swift` [[2]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L28-R32)

**2. Parameter Binding in Predicates**
- Added support for bound parameters in predicates (e.g., `column = :param`), including parsing, lowering, and evaluation with runtime bindings. (`Sources/SQL/AST.swift` [[1]](diffhunk://#diff-44ae278469f8cb8537a5e8997ce917320e10f66a7fb199bcf35bc353ab154f08R198-R201) `Sources/SQL/Filter.swift` [[2]](diffhunk://#diff-66f69cc14663ff59f1854b7179f51accad89aa0a7e6731e6880d344908ac4facR16-R19) [[3]](diffhunk://#diff-66f69cc14663ff59f1854b7179f51accad89aa0a7e6731e6880d344908ac4facL57-R185) `Sources/SQL/Lexer.swift` [[4]](diffhunk://#diff-3a41d2f1d12fb42c8cf94decbe20e627053820a0d629708ea2b1ec942a3c087fR126-R128) [[5]](diffhunk://#diff-3a41d2f1d12fb42c8cf94decbe20e627053820a0d629708ea2b1ec942a3c087fR186-R203)

**3. Execution Plan Refactoring**
- Refactored execution plans and engine internals to use `Term` arrays for projections, supporting evaluation of complex expressions per row. (`Sources/SQL/Operator.swift` [[1]](diffhunk://#diff-90b051b6c59d5ca6612ebe0500cd6ccfecdec8f79c3c79167986ee4298fd0737L116-R119) `Sources/SQL/Engine.swift` [[2]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L72-R79) [[3]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L96-R97) [[4]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L115-R116) [[5]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L157-R168) [[6]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060R184-R206) [[7]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L198-R221)

**4. Error Handling Improvements**
- Added new error types and messages for missing functions and invalid function arguments, improving diagnostics for function evaluation failures. (`Sources/SQL/Error.swift` [[1]](diffhunk://#diff-fabb0e55432d1f4932fcc44ed65501e0499e9ae032e5559384617eff30049944R56-R60) [[2]](diffhunk://#diff-fabb0e55432d1f4932fcc44ed65501e0499e9ae032e5559384617eff30049944R84-R87)

**5. Lexer Enhancements**
- Updated the lexer to recognize and tokenize parameter placeholders (e.g., `:param`). (`Sources/SQL/Lexer.swift` [[1]](diffhunk://#diff-3a41d2f1d12fb42c8cf94decbe20e627053820a0d629708ea2b1ec942a3c087fR126-R128) [[2]](diffhunk://#diff-3a41d2f1d12fb42c8cf94decbe20e627053820a0d629708ea2b1ec942a3c087fR186-R203)

These changes collectively enable the SQL engine to evaluate complex projections, support user-defined and built-in scalar functions, and handle parameterized queries, greatly expanding its expressiveness and flexibility.