### PR TITLE
SQL: support NULL and multi-way joins

### DIFF
--- a/Sources/SQL/AST.swift
+++ b/Sources/SQL/AST.swift
@@ -200,6 +200,11 @@ public indirect enum Predicate: Hashable, Sendable {
   /// resolved at run time from the engine's bindings (the correlated-subquery
   /// primitive a child view keys on the parent's value).
   case bound(left: Expression, op: Comparison, parameter: String)
+  /// `operand IS NULL`, or `IS NOT NULL` when `negated` — a definite test of
+  /// whether the operand evaluates to `NULL` (never itself UNKNOWN), the way a
+  /// nullable column — an absent decoded attribute — is filtered (`WHERE iid IS
+  /// NOT NULL`).
+  case null(Expression, negated: Bool)
   /// `lhs AND rhs`.
   case and(Predicate, Predicate)
   /// `lhs OR rhs`.

--- a/Sources/SQL/AST.swift
+++ b/Sources/SQL/AST.swift
@@ -3,12 +3,12 @@
 
 /// A parsed SQL statement.
 ///
-/// The dialect supports a single statement shape, now with an optional join:
+/// The dialect supports a single statement shape, with zero or more joins:
 ///
 /// ```sql
 /// SELECT <* | column (, column)*>
 ///   FROM <table> [AS alias]
-///   [JOIN <table> [AS alias] ON <column> = <column>]
+///   (JOIN <table> [AS alias] ON <column> = <column>)*
 ///   [WHERE <predicate>] [ORDER BY <column> [ASC|DESC]]
 /// ```
 ///
@@ -20,7 +20,7 @@ public enum Statement: Hashable, Sendable {
   case select(Select)
 }
 
-/// A `SELECT` query: a projection over one relation or a join of two, with an
+/// A `SELECT` query: a projection over one relation or a chain of joins, with an
 /// optional predicate and ordering.
 public struct Select: Hashable, Sendable {
   /// The columns the query yields.
@@ -29,8 +29,9 @@ public struct Select: Hashable, Sendable {
   /// The primary relation the query scans.
   public let from: Relation
 
-  /// The join applied to `from`, if any.
-  public let join: Join?
+  /// The joins applied to `from`, in source order — `from JOIN joins[0] JOIN
+  /// joins[1] …`, a left-deep chain. Empty for a single-relation query.
+  public let joins: Array<Join>
 
   /// The row filter, if any.
   public let predicate: Predicate?
@@ -38,11 +39,12 @@ public struct Select: Hashable, Sendable {
   /// The ordering applied to the result, if any.
   public let order: Order?
 
-  public init(projection: Projection, from: Relation, join: Join? = nil,
-              predicate: Predicate? = nil, order: Order? = nil) {
+  public init(projection: Projection, from: Relation,
+              joins: Array<Join> = [], predicate: Predicate? = nil,
+              order: Order? = nil) {
     self.projection = projection
     self.from = from
-    self.join = join
+    self.joins = joins
     self.predicate = predicate
     self.order = order
   }

--- a/Sources/SQL/Adapter.swift
+++ b/Sources/SQL/Adapter.swift
@@ -33,8 +33,14 @@ public enum ValueKind: Hashable, Sendable {
 /// A typed cell value the engine yields.
 ///
 /// The engine projects each surviving row to an `Array<Value>` — the result is
-/// data, not rendered text — so a client may format, compare, or re-key it.
+/// data, not rendered text — so a client may format, compare, or re-key it. A
+/// cell may also be `null` — SQL's absent value, distinct from any integer or
+/// text, unordered and unequal to everything (itself included) — which a source
+/// yields for a column that has no value in a row (a decoded attribute that does
+/// not apply), and which a comparison evaluates under three-valued logic.
 public enum Value: Hashable, Sendable {
+  /// SQL `NULL` — the absence of a value.
+  case null
   /// An integral value.
   case integer(Int)
   /// A textual value.

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -13,17 +13,17 @@
 /// seekability and rewrites scans into seeks and the product into an
 /// index-nested-loop join; `execute` re-resolves to open cursors and
 /// materialise. A single relation compiles to `Project(Sort(Select(Scan)))`; a
-/// join compiles to a `Select` over the Cartesian `Product` of two scans, the
-/// `ON` equality folded into the `Select` predicate. Absent layers are omitted.
-/// Executing the plan yields the result records' typed values; formatting them
-/// is a client's job.
+/// chain of joins compiles to a left-deep tree of `Product`s, each level's `ON`
+/// equality a `Select` over its product, with the `WHERE` wrapping the whole
+/// chain. Absent layers are omitted. Executing the plan yields the result
+/// records' typed values; formatting them is a client's job.
 public enum Engine {
   /// Runs `select` against `catalog`, returning the projected, filtered, and
   /// ordered rows as typed values.
   ///
   /// - Throws: `SQLError.relation` if the catalog resolves no such relation,
   ///   `SQLError.column` if a referenced column is absent, `SQLError.ambiguous`
-  ///   if an unqualified name is resolved by both relations of a join.
+  ///   if an unqualified name is resolved by more than one relation of a chain.
   public static func run<C: Catalog & ~Escapable>(_ select: Select,
                                                   _ catalog: borrowing C,
                                                   _ routines: Routines = [:],
@@ -39,29 +39,31 @@ public enum Engine {
   /// space.
   ///
   /// The relation(s) resolve through the borrowed catalog (`SQLError.relation`
-  /// on a miss). A single relation shapes `Project(Sort(Select(Scan)))`; a join
-  /// shapes `Project(Sort(Select(Product(Scan, Scan))))`, the `ON` equality
-  /// conjoined onto the `WHERE` predicate over the product. The `Select` and
+  /// on a miss). A single relation shapes `Project(Sort(Select(Scan)))`; a chain
+  /// of joins shapes a left-deep tree, each join level a `Select(match,
+  /// Product(chain, Scan))` on that join's `ON` equality, with the `WHERE`
+  /// wrapped outside as `Project(Sort(Select(where, chain)))`. The `Select` and
   /// `Sort` layers are present only when a predicate or an `ORDER BY` is. Each
   /// scan carries the set of ordinals the query references on its side
-  /// (projection ∪ filter ∪ order ∪ join keys, reals and virtuals) so the
+  /// (projection ∪ every match ∪ filter ∪ order, reals and virtuals) so the
   /// executor materialises exactly those, in a fixed order that defines a dense
   /// SLOT for each — slot `i` is the scan's `i`th referenced ordinal.
   ///
   /// The operators run in slot space: `compile` remaps every ordinal it lowered
-  /// (the projection, the `filter`, the order column, and a join's keys) through
-  /// `ordinal → slot` so the records the operators address are dense arrays.
-  /// A join's combined slot space lays the outer scan's slots `[0, outerCount)`
-  /// then the inner scan's `[outerCount, outerCount + innerCount)`, matching the
-  /// merged record (outer cells ++ inner cells). The tree is logical: every scan
-  /// is a full `Scan(_, _, nil)`; the optimiser turns scans into seeks and the
-  /// product into a join.
+  /// (the projection, the `filter`, the order column, and each join's keys)
+  /// through `ordinal → slot` so the records the operators address are dense
+  /// arrays. The combined slot space lays the relations end to end in chain
+  /// order — relation `i`'s referenced ordinals take a contiguous slot run after
+  /// every earlier relation's — matching the merged record (each relation's
+  /// cells concatenated in order). The tree is logical: every scan is a full
+  /// `Scan(_, _, nil)`; the optimiser turns scans into seeks and each product
+  /// into a join.
   internal static func compile<C: Catalog & ~Escapable>(_ select: Select,
                                                         _ catalog: borrowing C)
       throws(SQLError) -> Plan {
     let from = try resolve(select.from, catalog)
 
-    guard let join = select.join else {
+    guard !select.joins.isEmpty else {
       var filter: Filter? = nil
       if let predicate = select.predicate {
         filter = try from.schema.lower(predicate, in: select.from)
@@ -82,40 +84,85 @@ public enum Engine {
                    order.map { (slot[$0.column]!, $0.ascending) })
     }
 
-    let inner = try resolve(join.relation, catalog)
+    // Resolve every joined relation and lay all relations — the FROM relation
+    // first, then each joined one in source order — end to end in one combined
+    // ordinal space.
+    var joined = Array<Resolved>()
+    joined.reserveCapacity(select.joins.count)
+    for join in select.joins {
+      try joined.append(resolve(join.relation, catalog))
+    }
 
-    let scope = Scope(select.from, from.schema, join.relation, inner.schema)
-    let on = try scope.match(join.left, join.right)
+    var relations = [(select.from, from.schema)]
+    for index in select.joins.indices {
+      relations.append((select.joins[index].relation, joined[index].schema))
+    }
+    let scope = Scope(relations)
+
+    // Each join's ON equality lowers to a `match` at its own chain level,
+    // resolved against only the prefix already in scope plus the relation that
+    // join introduces — the FROM relation and joins `0…index` — never a
+    // relation joined later. Since `Scope` lays relations at cumulative offsets
+    // from 0, a prefix scope yields the same global combined ordinals as the
+    // full-chain scope, so the match ordinals remap through `slot` as before;
+    // resolving against the prefix rejects a reference to a not-yet-joined
+    // relation (`SQLError.column`) and judges ambiguity only within the prefix.
+    // The WHERE and ORDER lower against the whole chain, which legitimately
+    // sees every relation.
+    var matches = Array<Filter>()
+    matches.reserveCapacity(select.joins.count)
+    for index in select.joins.indices {
+      let prefix = Scope(Array(relations[0 ... index + 1]))
+      let join = select.joins[index]
+      try matches.append(prefix.match(join.left, join.right))
+    }
     var predicate: Filter? = nil
     if let clause = select.predicate {
       predicate = try scope.lower(clause)
     }
-    let filter = conjoin(on, predicate)
     var order: (column: Int, ascending: Bool)? = nil
     if let clause = select.order {
       order = try scope.order(clause)
     }
     let projection = try scope.terms(select.projection)
-    let base = scope.base
 
-    let combined = referenced(projection, filter, order)
-    let head = combined.filter { $0 < base }
-    let tail = combined.filter { $0 >= base }.map { $0 - base }
+    // The combined referenced ordinals — projection ∪ every match ∪ WHERE ∪
+    // order — packed per relation in chain order: relation i's referenced
+    // ordinals take a contiguous slot run after every earlier relation's,
+    // building the combined-ordinal → slot map and each relation's leaf ordinals.
+    var references = Set<Int>()
+    for term in projection { term.references(into: &references) }
+    for match in matches { match.references(into: &references) }
+    predicate?.references(into: &references)
+    if let order { references.insert(order.column) }
+    let combined = references.sorted()
 
-    // The combined slot map: the outer scan's referenced ordinals take the
-    // leading slots `[0, head.count)`, the inner scan's take the trailing slots
-    // `[head.count, head.count + tail.count)`, matching the merged record's
-    // outer-then-inner layout.
-    var slot = invert(head)
-    let split = head.count
-    for index in tail.indices {
-      slot[tail[index] + base] = split + index
+    var slot = Dictionary<Int, Int>(minimumCapacity: combined.count)
+    var locals = Array<Array<Int>>()
+    var packed = 0
+    for (offset, extent) in scope.layout {
+      let local = combined.compactMap {
+        offset <= $0 && $0 < offset + extent ? $0 - offset : nil
+      }
+      for index in local.indices {
+        slot[offset + local[index]] = packed + index
+      }
+      locals.append(local)
+      packed += local.count
     }
 
-    let outer = from.leaf(head)
-    let right = inner.leaf(tail)
-    return shape(.product(outer, right), projection.map { remap($0, slot) },
-                 remap(filter, slot),
+    // The left-deep chain: starting from the FROM relation's leaf, each join
+    // folds in the next relation's scan as a `Select` on that join's match over
+    // their product. The optimiser turns each `Select`-over-`Product` level into
+    // an index-nested-loop join.
+    let seed = from.leaf(locals[0])
+    let chain = select.joins.indices.reduce(seed) { chain, index in
+      .select(remap(matches[index], slot),
+              .product(chain, joined[index].leaf(locals[index + 1])))
+    }
+
+    return shape(chain, projection.map { remap($0, slot) },
+                 predicate.map { remap($0, slot) },
                  order.map { (slot[$0.column]!, $0.ascending) })
   }
 
@@ -232,12 +279,6 @@ public enum Engine {
       plan = .sort(slot: order.slot, ascending: order.ascending, plan)
     }
     return .project(projection, plan)
-  }
-
-  /// `on` conjoined with `predicate` when present, else `on` alone.
-  private static func conjoin(_ on: Filter, _ predicate: Filter?) -> Filter {
-    guard let predicate else { return on }
-    return .and(on, predicate)
   }
 
   // MARK: - Optimisation
@@ -440,15 +481,30 @@ public enum Engine {
     }
   }
 
-  /// The slot count of `plan`'s left-side scan — the outer relation's slots,
-  /// the boundary past which inner slots begin in the combined space — or `nil`
-  /// if the side is not a scan the boundary reads from.
+  /// The combined-space slot count of `plan` — the boundary past which a newly
+  /// joined relation's slots begin — or `nil` if a side's width is not known.
+  ///
+  /// A scan or a derived view's width is its referenced-ordinal count; a
+  /// `select` is as wide as its source; a `product` is the sum of its sides and
+  /// a `join` the sum of its outer side and the inner's referenced ordinals — so
+  /// a left-deep chain of products or joins measures correctly, letting the
+  /// nest rewrite recurse into a multi-relation chain.
   private static func slots(_ plan: Plan) -> Int? {
     switch plan {
     case let .scan(_, ordinals, _):
       ordinals.count
+    case let .derived(_, _, ordinals, _):
+      ordinals.count
     case let .select(_, source):
       slots(source)
+    case let .product(left, right):
+      if let left = slots(left), let right = slots(right) {
+        left + right
+      } else {
+        nil
+      }
+    case let .join(outer, _, ordinals, _, _, _):
+      slots(outer).map { $0 + ordinals.count }
     default:
       nil
     }

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -207,6 +207,8 @@ public enum Engine {
       .bound(remap(term, slot), op, parameter)
     case let .match(left, right):
       .match(slot[left]!, slot[right]!)
+    case let .null(term, negated):
+      .null(remap(term, slot), negated: negated)
     case let .and(lhs, rhs):
       .and(remap(lhs, slot), remap(rhs, slot))
     case let .or(lhs, rhs):

--- a/Sources/SQL/Filter.swift
+++ b/Sources/SQL/Filter.swift
@@ -26,6 +26,9 @@ internal indirect enum Filter {
   /// `left = right`, both columns addressed by ordinal — a join's `ON`
   /// equality, lowered as a conjunct of the product's `Select` predicate.
   case match(Int, Int)
+  /// `term IS NULL`, or `IS NOT NULL` when `negated` — the lowered form of the
+  /// AST's `null`, a definite two-valued test (never UNKNOWN).
+  case null(Term, negated: Bool)
   /// `lhs AND rhs`.
   case and(Filter, Filter)
   /// `lhs OR rhs`.
@@ -133,12 +136,15 @@ extension Comparison {
   }
 }
 
-/// Matches two typed values under operator `op`.
+/// Matches two typed values under operator `op`, under three-valued logic.
 ///
-/// A like-typed pair compares — two integers or two strings; a cross-typed pair
-/// (an integer against a string, or the reverse) never matches.
-private func matches(_ lhs: Value, _ op: Comparison, _ rhs: Value) -> Bool {
+/// A `NULL` on either side is UNKNOWN (`nil`): `NULL` is unordered and unequal
+/// to everything, itself included, so no comparison against it is ever true or
+/// false. A like-typed non-null pair compares — two integers or two strings; a
+/// cross-typed pair (an integer against a string, or the reverse) never matches.
+private func matches(_ lhs: Value, _ op: Comparison, _ rhs: Value) -> Bool? {
   switch (lhs, rhs) {
+  case (.null, _), (_, .null): nil
   case let (.integer(lhs), .integer(rhs)): op.apply(lhs, rhs)
   case let (.text(lhs), .text(rhs)): op.apply(lhs, rhs)
   default: false
@@ -149,11 +155,14 @@ private func matches(_ lhs: Value, _ op: Comparison, _ rhs: Value) -> Bool {
 /// calls through `routines` and any bound parameter from `bindings`.
 ///
 /// The result is `true`, `false`, or `nil` — SQL's UNKNOWN. A `compare`
-/// evaluates both operand terms and matches them; a `bound` matches the left
-/// term against the parameter's bound value, but an unbound or absent parameter
-/// UNKNOWN (`nil`), not `false` — a missing binding cannot be inverted into a
-/// match by `NOT`. A `match` reads both cells and tests them equal; `AND` and
-/// `OR` follow Kleene logic (`false` dominates `AND`, `true` dominates `OR`,
+/// evaluates both operand terms and matches them — a `NULL` operand making the
+/// comparison UNKNOWN; a `bound` matches the left term against the parameter's
+/// bound value, but an unbound or absent parameter is UNKNOWN (`nil`), not
+/// `false` — a missing binding cannot be inverted into a match by `NOT`. A
+/// `match` tests both cells equal under the same three-valued rule, so a `NULL`
+/// join key matches nothing; a `null` is a definite test of whether its term
+/// is `NULL` (`true`/`false`, never UNKNOWN), negated for `IS NOT NULL`. `AND`
+/// and `OR` follow Kleene logic (`false` dominates `AND`, `true` dominates `OR`,
 /// UNKNOWN otherwise) and `NOT` maps UNKNOWN to itself. The executor admits a
 /// row only when the whole predicate is `true` (its `== true` gate), so UNKNOWN
 /// and `false` both reject. The `borrowing` row is non-escaping; it threads
@@ -173,7 +182,9 @@ internal func evaluate<R: Row & ~Escapable>(_ filter: Filter,
       nil
     }
   case let .match(left, right):
-    row[left] == row[right]
+    matches(row[left], .equal, row[right])
+  case let .null(term, negated):
+    try (evaluate(term, row, routines) == .null) != negated
   case let .and(lhs, rhs):
     // `&&`/`||` take an `@autoclosure` right operand, which would capture the
     // borrowed `~Escapable` row; spell each connective explicitly so a branch

--- a/Sources/SQL/Lexer.swift
+++ b/Sources/SQL/Lexer.swift
@@ -241,6 +241,8 @@ internal struct Lexer: ~Escapable {
     case "JOIN": .join
     case "ON": .on
     case "AS": .as
+    case "IS": .is
+    case "NULL": .null
     default: .identifier(text)
     }
     return Token(kind: kind, location: start)

--- a/Sources/SQL/Operator.swift
+++ b/Sources/SQL/Operator.swift
@@ -286,6 +286,9 @@ private func join<C: Catalog & ~Escapable>(_ outer: Array<Record>,
   var records = Array<Record>()
   for left in outer {
     let value = left[keys.left]
+    // A NULL key equi-joins to nothing — NULL is unequal to every value,
+    // itself included — so it contributes no pair and need not probe.
+    if case .null = value { continue }
     let range = probe(inner, column, value, cursor.count)
     for index in range {
       guard let row = cursor.row(index) else { continue }
@@ -314,10 +317,17 @@ private func probe<T: Table & ~Escapable>(_ table: borrowing T, _ column: Int,
 
 /// Orders two typed sort keys ascending, by their value.
 ///
-/// Both keys are read from the same slot, so they share a `Value` kind; a kind
-/// mismatch (which a single-slot key never produces) orders as equal.
+/// `NULL` sorts before every non-null value — consistently first in ascending
+/// order, last in descending — so a nullable sort key holds a stable, total
+/// position rather than tying with every value (which is not a strict ordering
+/// and leaves the rest unsorted). Otherwise both keys share a `Value` kind, as
+/// they are read from the same slot, and compare by value; a kind mismatch a
+/// single-slot key never produces orders as equal.
 internal func less(_ lhs: Value, _ rhs: Value) -> Bool {
   switch (lhs, rhs) {
+  case (.null, .null): false
+  case (.null, _): true
+  case (_, .null): false
   case let (.integer(lhs), .integer(rhs)): lhs < rhs
   case let (.text(lhs), .text(rhs)): lhs < rhs
   default: false

--- a/Sources/SQL/Parser.swift
+++ b/Sources/SQL/Parser.swift
@@ -17,7 +17,7 @@
 /// conjunction := negation (AND negation)*
 /// negation    := NOT negation | primary
 /// primary     := '(' predicate ')' | comparison
-/// comparison  := column op literal
+/// comparison  := expression (op (expression | param) | IS [NOT] NULL)
 /// order       := ORDER BY column [ASC | DESC]
 /// column      := identifier        // a dotted identifier is qualified
 /// ```
@@ -227,14 +227,21 @@ internal struct Parser: ~Escapable {
     return try comparison()
   }
 
-  /// Parses `expression op (expression | :parameter)`.
+  /// Parses `expression (op (expression | :parameter) | IS [NOT] NULL)`.
   ///
   /// Either operand may be a column, a literal, or a scalar-function call, so a
   /// predicate can filter on a decoded value (`WHERE guid(Id) = '…'`). A
   /// `:parameter` right operand binds the comparison to a value resolved at run
-  /// time from the engine's bindings — the correlated-subquery primitive.
+  /// time from the engine's bindings — the correlated-subquery primitive. An
+  /// `IS NULL` (or `IS NOT NULL`) tail tests the left expression for `NULL`
+  /// rather than comparing it — the way a nullable column is filtered.
   private mutating func comparison() throws(SQLError) -> Predicate {
     let left = try expression()
+    if try match(.is) {
+      let negated = try match(.not)
+      try expect(.null)
+      return .null(left, negated: negated)
+    }
     let op = try op()
     if case let .parameter(name) = current?.kind {
       _ = try advance(expecting: "a parameter")

--- a/Sources/SQL/Parser.swift
+++ b/Sources/SQL/Parser.swift
@@ -3,11 +3,11 @@
 
 /// A recursive-descent parser over a token stream.
 ///
-/// The grammar is the minimal dialect, extended with a single binary join:
+/// The grammar is the minimal dialect, extended with a chain of joins:
 ///
 /// ```
 /// statement   := select
-/// select      := SELECT projection FROM relation [join] [where] [order]
+/// select      := SELECT projection FROM relation (join)* [where] [order]
 /// relation    := identifier [AS identifier]
 /// join        := JOIN relation ON column '=' column
 /// projection  := '*' | column (',' column)*
@@ -60,10 +60,9 @@ internal struct Parser: ~Escapable {
     try expect(.from)
     let from = try relation()
 
-    let join: Join? = if try match(.join) {
-      try join()
-    } else {
-      nil
+    var joins = Array<Join>()
+    while try match(.join) {
+      try joins.append(join())
     }
     let predicate: Predicate? = if try match(.where) {
       try predicate()
@@ -76,7 +75,7 @@ internal struct Parser: ~Escapable {
       nil
     }
 
-    return Select(projection: projection, from: from, join: join,
+    return Select(projection: projection, from: from, joins: joins,
                   predicate: predicate, order: order)
   }
 

--- a/Sources/SQL/Resolve.swift
+++ b/Sources/SQL/Resolve.swift
@@ -110,103 +110,95 @@ extension Schema {
 
 // MARK: - Join scope
 
-/// The two relations of a join, addressed in one combined ordinal space.
+/// The relations of a join chain, addressed in one combined ordinal space.
 ///
-/// A join lays its two relations end to end: the outer (the `FROM`) relation
-/// occupies the ordinals below `base`, the inner (the `JOIN`) relation those at
-/// or above it. `base` is the outer relation's `extent` — one past the highest
-/// ordinal it can address — rather than its `width`, so the outer relation's
-/// virtual columns — ordinals at or past its real width, such as a `rowid` or a
-/// `parent` — stay on the outer side rather than colliding with the inner's
-/// space; an outer column resolves to its own ordinal, an inner column to
-/// `base + ordinal`. A `Scope` resolves a possibly qualified `SQL.Column` into
-/// that combined space so the engine's `Filter`, projection, and order all
-/// address cells uniformly across the pair. A qualifier names a relation by its
-/// alias, else its table name; an unqualified name resolves against both
-/// relations and is ambiguous if each has it. Resolution reads only schemas, so
-/// the scope is escapable data over the two relations' `Schema`s.
+/// A join chain lays its relations end to end: relation `i` occupies the
+/// combined ordinals `[offset_i, offset_i + extent_i)`, where `offset_i` is the
+/// sum of the `extent`s of the relations before it. Using each relation's
+/// `extent` — its real `width` plus the virtual columns it exposes — rather than
+/// its `width` keeps a relation's virtual columns (a `rowid`, a `parent`) on its
+/// own side rather than colliding with the next relation's space. A `Scope`
+/// resolves a possibly qualified `SQL.Column` into that combined space so the
+/// engine's `Filter`, projection, and order all address cells uniformly across
+/// the chain. A qualifier names a relation by its alias, else its table name; an
+/// unqualified name resolves against every relation and is ambiguous if more
+/// than one resolves it — as is a qualified name two relations share an alias or
+/// table name for (a self-join or a duplicated alias). Resolution reads only
+/// schemas, so the scope is escapable data over the relations' `Schema`s.
 internal struct Scope {
-  /// The left (outer, `FROM`) relation reference; its alias, else its table
-  /// name, is the qualifier that selects the `outer` schema.
-  private let left: Relation
-  /// The right (inner, `JOIN`) relation reference; its qualifier selects the
-  /// `inner` schema.
-  private let right: Relation
-  /// The outer and inner schemas, laid end to end.
-  private let outer: Schema
-  private let inner: Schema
-
-  internal init(_ left: Relation, _ outer: Schema,
-                _ right: Relation, _ inner: Schema) {
-    self.left = left
-    self.right = right
-    self.outer = outer
-    self.inner = inner
+  /// One relation of the chain: its reference (for qualifier matching), its
+  /// name-resolution schema, and its base offset in the combined space.
+  private struct Member {
+    let relation: Relation
+    let schema: Schema
+    let offset: Int
   }
 
-  /// The base ordinal of the inner relation in the combined space.
-  ///
-  /// The outer relation's `extent` — its real `width` plus the virtual columns
-  /// it exposes, i.e. one past the highest ordinal it can address — past which
-  /// inner ordinals begin. No outer ordinal — a real column below the width or a
-  /// virtual column at or just past it — reaches it, so the `< base` / `>= base`
-  /// split classifies a combined ordinal to its side even when the outer
-  /// relation contributes a virtual column.
-  internal var base: Int {
-    outer.extent
-  }
+  private let members: Array<Member>
 
-  /// Whether `qualifier` (an alias, else a table name) names `relation`.
-  private func names(_ relation: Relation, _ qualifier: String) -> Bool {
-    (relation.alias ?? relation.name) == qualifier
-  }
-
-  /// Whether `column`'s qualifier admits `relation`: an unqualified name admits
-  /// either relation, a qualified one only the relation its qualifier names.
-  private func admits(_ relation: Relation, _ column: Column) -> Bool {
-    if let qualifier = column.qualifier {
-      names(relation, qualifier)
-    } else {
-      true
+  /// Builds a scope over `relations` — the `FROM` relation first, then each
+  /// joined relation in source order — laying each past the previous one's
+  /// `extent`.
+  internal init(_ relations: Array<(Relation, Schema)>) {
+    var members = Array<Member>()
+    members.reserveCapacity(relations.count)
+    var offset = 0
+    for (relation, schema) in relations {
+      members.append(Member(relation: relation, schema: schema, offset: offset))
+      offset += schema.extent
     }
+    self.members = members
+  }
+
+  /// The combined-space base offset and extent of each relation, in chain order
+  /// — the layout the engine packs referenced ordinals against.
+  internal var layout: Array<(offset: Int, extent: Int)> {
+    members.map { ($0.offset, $0.schema.extent) }
+  }
+
+  /// Whether `column`'s qualifier admits `member`: an unqualified name admits
+  /// every relation, a qualified one only a relation its qualifier (an alias,
+  /// else a table name) names.
+  private func admits(_ member: Member, _ column: Column) -> Bool {
+    guard let qualifier = column.qualifier else { return true }
+    return (member.relation.alias ?? member.relation.name) == qualifier
   }
 
   /// The combined ordinal `column` resolves to.
   ///
-  /// A qualifier admits only the relation it names; an unqualified name admits
-  /// both. Within the admitted relations the name resolves: present in exactly
-  /// one it yields that ordinal; in both — two relations sharing a qualifier (a
-  /// self-join or a duplicated alias), or an unqualified name sitting in each —
-  /// it is `SQLError.ambiguous`; in neither it is `SQLError.column`.
+  /// The name resolves against every admitted relation: present in exactly one
+  /// it yields that relation's `offset` plus the local ordinal; present in more
+  /// than one — an unqualified name in several relations, or a qualified name
+  /// two relations share a name for — it is `SQLError.ambiguous`; in none it is
+  /// `SQLError.column`.
   internal func ordinal(of column: Column) throws(SQLError) -> Int {
-    let here =
-        admits(left, column) ? outer.ordinal(of: column.name) : nil
-    let there =
-        admits(right, column) ? inner.ordinal(of: column.name) : nil
-    switch (here, there) {
-    case let (.some(ordinal), nil):
-      return ordinal
-    case let (nil, .some(ordinal)):
-      return base + ordinal
-    case (.some, .some):
-      throw .ambiguous(column.name)
-    case (nil, nil):
-      throw .column(column.name)
+    var resolved: Int? = nil
+    for member in members where admits(member, column) {
+      guard let local = member.schema.ordinal(of: column.name) else { continue }
+      if resolved != nil { throw .ambiguous(column.name) }
+      resolved = member.offset + local
     }
+    guard let resolved else { throw .column(column.name) }
+    return resolved
   }
 
-  /// The combined-ordinal projected terms: every real column of both relations
-  /// for `*` (outer then inner, never a virtual column) as `.slot` terms, a
+  /// The combined-ordinal projected terms: every real column of every relation
+  /// for `*` (in chain order, never a virtual column) as `.slot` terms, a
   /// bare-column list as `.slot` terms at their combined ordinals, an expression
   /// list as lowered terms — in source order.
   internal func terms(_ projection: Projection) throws(SQLError)
       -> Array<Term> {
     switch projection {
     case .all:
-      // Every real outer column, then every real inner column at its
-      // `base`-offset ordinal — never a virtual column of either side.
-      return (0 ..< outer.width).map { .slot($0) }
-          + (0 ..< inner.width).map { .slot(base + $0) }
+      // Every real column of every relation, at its combined ordinal — in chain
+      // order, never a virtual column of any relation.
+      var terms = Array<Term>()
+      for member in members {
+        for ordinal in 0 ..< member.schema.width {
+          terms.append(.slot(member.offset + ordinal))
+        }
+      }
+      return terms
     case let .columns(columns):
       var terms = Array<Term>()
       terms.reserveCapacity(columns.count)
@@ -249,14 +241,14 @@ internal struct Scope {
   }
 
   /// Lowers a join's `ON left = right` to a `match` conjunct, each side
-  /// resolved to a combined ordinal across the pair.
+  /// resolved to a combined ordinal across the chain.
   internal func match(_ left: Column, _ right: Column) throws(SQLError)
       -> Filter {
     try .match(ordinal(of: left), ordinal(of: right))
   }
 
   /// Lowers the name-addressed AST `predicate` to the engine's `Filter`, each
-  /// column reference resolved to a combined ordinal across the join.
+  /// column reference resolved to a combined ordinal across the chain.
   internal func lower(_ predicate: Predicate) throws(SQLError) -> Filter {
     switch predicate {
     case let .comparison(left, op, right):

--- a/Sources/SQL/Resolve.swift
+++ b/Sources/SQL/Resolve.swift
@@ -96,6 +96,8 @@ extension Schema {
       try .compare(term(left, in: relation), op, term(right, in: relation))
     case let .bound(left, op, parameter):
       try .bound(term(left, in: relation), op, parameter)
+    case let .null(expression, negated):
+      try .null(term(expression, in: relation), negated: negated)
     case let .and(lhs, rhs):
       try .and(lower(lhs, in: relation), lower(rhs, in: relation))
     case let .or(lhs, rhs):
@@ -261,6 +263,8 @@ internal struct Scope {
       try .compare(term(left), op, term(right))
     case let .bound(left, op, parameter):
       try .bound(term(left), op, parameter)
+    case let .null(expression, negated):
+      try .null(term(expression), negated: negated)
     case let .and(lhs, rhs):
       try .and(lower(lhs), lower(rhs))
     case let .or(lhs, rhs):
@@ -290,6 +294,8 @@ extension Filter {
     case let .match(left, right):
       ordinals.insert(left)
       ordinals.insert(right)
+    case let .null(term, _):
+      term.references(into: &ordinals)
     case let .and(lhs, rhs), let .or(lhs, rhs):
       lhs.references(into: &ordinals)
       rhs.references(into: &ordinals)

--- a/Sources/SQL/Token.swift
+++ b/Sources/SQL/Token.swift
@@ -30,6 +30,8 @@ extension Token {
     case join
     case on
     case `as`
+    case `is`
+    case null
 
     // Operands.
     case identifier(String)
@@ -69,6 +71,8 @@ extension Token.Kind {
     case .join: "JOIN"
     case .on: "ON"
     case .as: "AS"
+    case .is: "IS"
+    case .null: "NULL"
     case let .identifier(name): name
     case let .string(value): "'\(value)'"
     case let .integer(value): "\(value)"

--- a/Sources/winmd-inspect/Query.swift
+++ b/Sources/winmd-inspect/Query.swift
@@ -49,9 +49,12 @@ internal struct Query: ParsableCommand {
   }
 
   /// Renders a typed cell value to its display string: text verbatim, an
-  /// integer as its decimal spelling.
+  /// integer as its decimal spelling, a `NULL` as the empty string (the way
+  /// `sqlite3`'s list mode shows it).
   private static func render(_ value: Value) -> String {
     switch value {
+    case .null:
+      ""
     case let .integer(integer):
       "\(integer)"
     case let .text(text):

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -257,6 +257,50 @@ private func views() throws -> Memory {
                 views: ["Adults": adults, "Pairs": pairs, "Picked": picked])
 }
 
+/// A catalog with NULL cells: a `Maybe` relation whose `Note` text column is
+/// `NULL` in some rows, to exercise three-valued comparison and `IS [NOT] NULL`.
+private func nullable() -> Memory {
+  let fields = [
+    Field(name: "Id", kind: .integer),
+    Field(name: "Note", kind: .text),
+  ]
+  let records = [
+    [.integer(1), .text("alpha")],
+    [.integer(2), .null],
+    [.integer(3), .text("gamma")],
+    [.integer(4), .null],
+  ] as Array<Array<Value>>
+  return Memory(["Maybe": Relation(fields, records)])
+}
+
+/// The null-key join catalog: a `Parent` sorted on `Id` and a `Child` one of
+/// whose foreign keys is `NULL`, to prove a `NULL` join key matches nothing.
+private func nullableKeys() -> Memory {
+  let parent = [
+    Field(name: "Id", kind: .integer),
+    Field(name: "Name", kind: .text),
+  ]
+  let parents = [
+    [.integer(1), .text("Ada")],
+    [.integer(2), .text("Bee")],
+  ] as Array<Array<Value>>
+
+  let child = [
+    Field(name: "Pid", kind: .integer),
+    Field(name: "Name", kind: .text),
+  ]
+  let children = [
+    [.integer(1), .text("Ann")],
+    [.null, .text("Nobody")],
+    [.integer(2), .text("Bob")],
+  ] as Array<Array<Value>>
+
+  return Memory([
+    "Parent": Relation(parent, parents, sorted: 0),
+    "Child": Relation(child, children),
+  ])
+}
+
 /// Parses `text` to a `SELECT`, failing on any other statement.
 private func select(_ text: String) throws -> Select {
   try parse(text)
@@ -289,6 +333,11 @@ private func join(_ text: String) throws -> Array<Array<Value>> {
 /// Runs `text` against the view catalog.
 private func view(_ text: String) throws -> Array<Array<Value>> {
   try Engine.run(parse(text), views())
+}
+
+/// Runs `text` against the nullable `Maybe` catalog.
+private func nullable(_ text: String) throws -> Array<Array<Value>> {
+  try Engine.run(parse(text), nullable())
 }
 
 // MARK: - Single-relation tests
@@ -837,6 +886,74 @@ struct EngineFunctionTests {
     let rows =
         try functionRun("SELECT Name FROM People WHERE add(Id, 10) = 12")
     #expect(rows == [[.text("Bob")]])
+  }
+}
+
+// MARK: - NULL tests
+
+struct EngineNullTests {
+  @Test("IS NULL admits only the NULL rows")
+  func isNull() throws {
+    let rows = try nullable("SELECT Id FROM Maybe WHERE Note IS NULL")
+    #expect(rows == [[.integer(2)], [.integer(4)]])
+  }
+
+  @Test("IS NOT NULL admits only the non-NULL rows")
+  func isNotNull() throws {
+    let rows = try nullable("SELECT Id FROM Maybe WHERE Note IS NOT NULL")
+    #expect(rows == [[.integer(1)], [.integer(3)]])
+  }
+
+  @Test("a comparison against a NULL cell is UNKNOWN and rejects")
+  func comparison() throws {
+    // For the NULL rows (2, 4) `Note = 'alpha'` is UNKNOWN, not false, so they
+    // are not admitted; only the row whose Note equals 'alpha' survives.
+    let rows = try nullable("SELECT Id FROM Maybe WHERE Note = 'alpha'")
+    #expect(rows == [[.integer(1)]])
+  }
+
+  @Test("NOT of a NULL comparison stays UNKNOWN and rejects")
+  func negated() throws {
+    // The NULL rows are UNKNOWN; NOT UNKNOWN is UNKNOWN, so they still reject —
+    // only the non-null, non-'alpha' row survives.
+    let rows = try nullable("SELECT Id FROM Maybe WHERE NOT Note = 'alpha'")
+    #expect(rows == [[.integer(3)]])
+  }
+
+  @Test("a NULL cell projects as a NULL value")
+  func projection() throws {
+    let rows = try nullable("SELECT Note FROM Maybe WHERE Id = 2")
+    #expect(rows == [[.null]])
+  }
+
+  @Test("ORDER BY ascending sorts NULL keys first, then by value")
+  func orderAscending() throws {
+    // NULL holds a stable position — first in ascending order — so the non-null
+    // notes still sort among themselves ('alpha' before 'gamma') rather than
+    // tying with the nulls and leaving the order undefined.
+    let rows = try nullable("SELECT Id FROM Maybe ORDER BY Note ASC")
+    #expect(rows == [[.integer(2)], [.integer(4)], [.integer(1)], [.integer(3)]])
+  }
+
+  @Test("ORDER BY descending sorts NULL keys last")
+  func orderDescending() throws {
+    let rows = try nullable("SELECT Id FROM Maybe ORDER BY Note DESC")
+    #expect(rows == [[.integer(3)], [.integer(1)], [.integer(2)], [.integer(4)]])
+  }
+
+  @Test("a NULL outer join key matches no inner row")
+  func join() throws {
+    // The child with a NULL foreign key is the outer row; a NULL key equi-joins
+    // to nothing, so it contributes no pair — `Parent` is sorted, so the inner
+    // is seeked and the NULL key is skipped before probing.
+    let rows = try Engine.run(parse("""
+        SELECT Child.Name, Parent.Name FROM Child
+          JOIN Parent ON Parent.Id = Child.Pid
+        """), nullableKeys())
+    #expect(rows == [
+      [.text("Ann"), .text("Ada")],
+      [.text("Bob"), .text("Bee")],
+    ])
   }
 }
 

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -301,6 +301,93 @@ private func nullableKeys() -> Memory {
   ])
 }
 
+/// A three-level catalog for multi-way joins: `House` → `Room` → `Item`, each
+/// child carrying a foreign key to its parent's `Id`. `House` and `Room` are
+/// sorted on `Id`, so a join keyed on `Id` seeks; `Item` is unsorted and scans.
+private func lineage() -> Memory {
+  let house = [
+    Field(name: "Id", kind: .integer),
+    Field(name: "House", kind: .text),
+  ]
+  let houses = [
+    [.integer(1), .text("Burrow")],
+    [.integer(2), .text("Manor")],
+  ] as Array<Array<Value>>
+
+  let room = [
+    Field(name: "Id", kind: .integer),
+    Field(name: "Hid", kind: .integer),
+    Field(name: "Room", kind: .text),
+  ]
+  let rooms = [
+    [.integer(1), .integer(1), .text("Kitchen")],
+    [.integer(2), .integer(1), .text("Attic")],
+    [.integer(3), .integer(2), .text("Hall")],
+  ] as Array<Array<Value>>
+
+  let item = [
+    Field(name: "Rid", kind: .integer),
+    Field(name: "Item", kind: .text),
+  ]
+  let items = [
+    [.integer(1), .text("Kettle")],
+    [.integer(1), .text("Pot")],
+    [.integer(3), .text("Banner")],
+    [.integer(9), .text("Lost")],
+  ] as Array<Array<Value>>
+
+  return Memory([
+    "House": Relation(house, houses, sorted: 0),
+    "Room": Relation(room, rooms, sorted: 0),
+    "Item": Relation(item, items),
+  ])
+}
+
+/// A chain whose first join's `ON` uses an unqualified column that is unique in
+/// the prefix it resolves against but shared by a relation joined only later.
+///
+/// `Author(Aid, Code)` sorted on `Aid`; `Book(Bid, Aid)` sorted on `Aid`;
+/// `Sale(Sid, Code)`. The first join `Author JOIN Book ON Code = Book.Aid` reads
+/// the unqualified `Code`, which only `Author` carries within the prefix
+/// `{Author, Book}` — yet `Sale`, joined afterwards, also exposes `Code`.
+/// Resolving the match against the prefix binds `Code` unambiguously; resolving
+/// it against the whole chain would (wrongly) see `Code` in two relations and
+/// report `SQLError.ambiguous`.
+private func shared() -> Memory {
+  let author = [
+    Field(name: "Aid", kind: .integer),
+    Field(name: "Code", kind: .integer),
+  ]
+  let authors = [
+    [.integer(1), .integer(10)],
+    [.integer(2), .integer(20)],
+  ] as Array<Array<Value>>
+
+  let book = [
+    Field(name: "Bid", kind: .integer),
+    Field(name: "Aid", kind: .integer),
+  ]
+  let books = [
+    [.integer(100), .integer(10)],
+    [.integer(101), .integer(20)],
+  ] as Array<Array<Value>>
+
+  let sale = [
+    Field(name: "Sid", kind: .integer),
+    Field(name: "Code", kind: .integer),
+  ]
+  let sales = [
+    [.integer(100), .integer(900)],
+    [.integer(101), .integer(901)],
+  ] as Array<Array<Value>>
+
+  return Memory([
+    "Author": Relation(author, authors, sorted: 0),
+    "Book": Relation(book, books, sorted: 1),
+    "Sale": Relation(sale, sales),
+  ])
+}
+
 /// Parses `text` to a `SELECT`, failing on any other statement.
 private func select(_ text: String) throws -> Select {
   try parse(text)
@@ -338,6 +425,16 @@ private func view(_ text: String) throws -> Array<Array<Value>> {
 /// Runs `text` against the nullable `Maybe` catalog.
 private func nullable(_ text: String) throws -> Array<Array<Value>> {
   try Engine.run(parse(text), nullable())
+}
+
+/// Runs `text` against the three-level `lineage` catalog.
+private func lineage(_ text: String) throws -> Array<Array<Value>> {
+  try Engine.run(parse(text), lineage())
+}
+
+/// Runs `text` against the `shared`-column chain catalog.
+private func shared(_ text: String) throws -> Array<Array<Value>> {
+  try Engine.run(parse(text), shared())
 }
 
 // MARK: - Single-relation tests
@@ -638,6 +735,117 @@ struct EngineJoinTests {
       [.text("Ada"), .text("Amy")],
       [.text("Ada"), .text("Ann")],
       [.text("Bee"), .text("Bob")],
+    ])
+  }
+}
+
+// MARK: - Multi-way join tests
+
+struct EngineMultiJoinTests {
+  @Test("a three-relation chain joins across two foreign keys")
+  func chain() throws {
+    let rows = try lineage("""
+        SELECT House.House, Room.Room, Item.Item FROM House
+          JOIN Room ON Room.Hid = House.Id
+          JOIN Item ON Item.Rid = Room.Id
+        """)
+    // Burrow's Kitchen holds the Kettle and Pot; its Attic is empty. Manor's
+    // Hall holds the Banner. The item with no room (Rid 9) drops out.
+    #expect(rows == [
+      [.text("Burrow"), .text("Kitchen"), .text("Kettle")],
+      [.text("Burrow"), .text("Kitchen"), .text("Pot")],
+      [.text("Manor"), .text("Hall"), .text("Banner")],
+    ])
+  }
+
+  @Test("a chain seeks each inner relation keyed on its sorted column")
+  func seeked() throws {
+    // Walking the chain the other way: `Item` is the outer scan, and both inner
+    // relations are seeked on their sorted `Id` — the multi-way nest rewrite
+    // turning every `Select`-over-`Product` level into an index-nested loop.
+    let rows = try lineage("""
+        SELECT Item.Item, Room.Room, House.House FROM Item
+          JOIN Room ON Room.Id = Item.Rid
+          JOIN House ON House.Id = Room.Hid
+        """)
+    #expect(rows == [
+      [.text("Kettle"), .text("Kitchen"), .text("Burrow")],
+      [.text("Pot"), .text("Kitchen"), .text("Burrow")],
+      [.text("Banner"), .text("Hall"), .text("Manor")],
+    ])
+  }
+
+  @Test("a WHERE filters across a three-relation chain")
+  func filtered() throws {
+    let rows = try lineage("""
+        SELECT Item.Item FROM House
+          JOIN Room ON Room.Hid = House.Id
+          JOIN Item ON Item.Rid = Room.Id
+          WHERE House.House = 'Burrow' AND Item.Item = 'Pot'
+        """)
+    #expect(rows == [[.text("Pot")]])
+  }
+
+  @Test("an unqualified name in more than one relation of a chain is ambiguous")
+  func ambiguous() throws {
+    // `Id` sits in both `House` and `Room`; across the chain it resolves in more
+    // than one relation, so an unqualified reference is ambiguous.
+    #expect(throws: SQLError.ambiguous("Id")) {
+      try lineage("""
+          SELECT Id FROM House
+            JOIN Room ON Room.Hid = House.Id
+            JOIN Item ON Item.Rid = Room.Id
+          """)
+    }
+  }
+
+  @Test("an early ON referencing a not-yet-joined relation is rejected")
+  func premature() throws {
+    // The first join's `ON` qualifies a column with `Item`, a relation joined
+    // only LATER. Resolving the match against just the prefix — `House` and
+    // `Room` — the qualifier names no relation in scope, so the query is
+    // rejected (`SQLError.column`) rather than resolving `Item`'s slot from a
+    // product that does not yet contain it and trapping or indexing wrong.
+    #expect(throws: SQLError.column("Rid")) {
+      try lineage("""
+          SELECT House.House FROM House
+            JOIN Room ON Item.Rid = House.Id
+            JOIN Item ON Item.Rid = Room.Id
+          """)
+    }
+  }
+
+  @Test("a valid early ON whose columns are all in its prefix runs")
+  func prefixed() throws {
+    // Each `ON` references only the prefix it resolves against, so the whole
+    // chain compiles and runs — mirroring `chain`, which the prefix-scope fix
+    // leaves unchanged.
+    let rows = try lineage("""
+        SELECT House.House, Room.Room, Item.Item FROM House
+          JOIN Room ON Room.Hid = House.Id
+          JOIN Item ON Item.Rid = Room.Id
+        """)
+    #expect(rows == [
+      [.text("Burrow"), .text("Kitchen"), .text("Kettle")],
+      [.text("Burrow"), .text("Kitchen"), .text("Pot")],
+      [.text("Manor"), .text("Hall"), .text("Banner")],
+    ])
+  }
+
+  @Test("an unqualified early-ON column a later relation shares is not ambiguous")
+  func disambiguated() throws {
+    // The first join's `ON` reads unqualified `Code`, unique within its prefix
+    // `{Author, Book}` even though `Sale` — joined only later — also carries a
+    // `Code`. Resolving the match against the prefix binds it; resolving against
+    // the whole chain would see two `Code`s and report `SQLError.ambiguous`.
+    let rows = try shared("""
+        SELECT Author.Aid, Book.Bid, Sale.Code FROM Author
+          JOIN Book ON Code = Book.Aid
+          JOIN Sale ON Sale.Sid = Book.Bid
+        """)
+    #expect(rows == [
+      [.integer(1), .integer(100), .integer(900)],
+      [.integer(2), .integer(101), .integer(901)],
     ])
   }
 }

--- a/Tests/SQLTests/LexerTests.swift
+++ b/Tests/SQLTests/LexerTests.swift
@@ -42,6 +42,12 @@ struct LexerTests {
     #expect(try lex("join on As") == [.join, .on, .as])
   }
 
+  @Test("lexes the NULL-test keywords")
+  func nullKeywords() throws {
+    #expect(try lex("IS NOT NULL") == [.is, .not, .null])
+    #expect(try lex("is null") == [.is, .null])
+  }
+
   @Test("lexes the comparison operators")
   func operators() throws {
     #expect(try lex("= <> < > <= >=")

--- a/Tests/SQLTests/ParserTests.swift
+++ b/Tests/SQLTests/ParserTests.swift
@@ -262,7 +262,7 @@ struct RelationTests {
   func bare() throws {
     let select = try parseSelect("SELECT * FROM TypeDef")
     #expect(select.from == Relation(name: "TypeDef"))
-    #expect(select.join == nil)
+    #expect(select.joins.isEmpty)
   }
 
   @Test("parses an AS alias on the FROM relation")
@@ -293,9 +293,10 @@ struct JoinTests {
           WHERE t.TypeName = 'IUnknown'
         """)
     #expect(select.from == Relation(name: "TypeDef", alias: "t"))
-    #expect(select.join
-                == Join(relation: Relation(name: "MethodDef", alias: "m"),
-                        left: Column("m.parent"), right: Column("t.rowid")))
+    #expect(select.joins == [
+      Join(relation: Relation(name: "MethodDef", alias: "m"),
+           left: Column("m.parent"), right: Column("t.rowid")),
+    ])
     #expect(select.projection == .columns([Column("m.Name")]))
     let value = Expression.literal(.string("IUnknown"))
     #expect(select.predicate == .comparison(left: .column("t.TypeName"),
@@ -308,9 +309,10 @@ struct JoinTests {
         SELECT r.TypeName FROM TypeDef AS t
           JOIN TypeRef AS r ON t.Extends = r.rowid
         """)
-    #expect(select.join
-                == Join(relation: Relation(name: "TypeRef", alias: "r"),
-                        left: Column("t.Extends"), right: Column("r.rowid")))
+    #expect(select.joins == [
+      Join(relation: Relation(name: "TypeRef", alias: "r"),
+           left: Column("t.Extends"), right: Column("r.rowid")),
+    ])
   }
 
   @Test("parses a join without aliases")
@@ -320,10 +322,27 @@ struct JoinTests {
           JOIN Param ON Param.parent = MethodDef.rowid
         """)
     #expect(select.from == Relation(name: "MethodDef"))
-    #expect(select.join
-                == Join(relation: Relation(name: "Param"),
-                        left: Column("Param.parent"),
-                        right: Column("MethodDef.rowid")))
+    #expect(select.joins == [
+      Join(relation: Relation(name: "Param"),
+           left: Column("Param.parent"),
+           right: Column("MethodDef.rowid")),
+    ])
+  }
+
+  @Test("parses a chain of two joins in source order")
+  func chainedJoins() throws {
+    let select = try parseSelect("""
+        SELECT Param.Name FROM TypeDef AS t
+          JOIN MethodDef AS m ON m.parent = t.rowid
+          JOIN Param ON Param.parent = m.rowid
+        """)
+    #expect(select.from == Relation(name: "TypeDef", alias: "t"))
+    #expect(select.joins == [
+      Join(relation: Relation(name: "MethodDef", alias: "m"),
+           left: Column("m.parent"), right: Column("t.rowid")),
+      Join(relation: Relation(name: "Param"),
+           left: Column("Param.parent"), right: Column("m.rowid")),
+    ])
   }
 
   @Test("rejects a join missing ON")

--- a/Tests/SQLTests/ParserTests.swift
+++ b/Tests/SQLTests/ParserTests.swift
@@ -152,6 +152,32 @@ struct PredicateTests {
     #expect(select.predicate == .and(.or(a, b), c))
   }
 
+  @Test("parses IS NULL")
+  func isNull() throws {
+    let select = try parseSelect("SELECT * FROM T WHERE Note IS NULL")
+    #expect(select.predicate == .null(.column("Note"), negated: false))
+  }
+
+  @Test("parses IS NOT NULL")
+  func isNotNull() throws {
+    let select = try parseSelect("SELECT * FROM T WHERE Note IS NOT NULL")
+    #expect(select.predicate == .null(.column("Note"), negated: true))
+  }
+
+  @Test("parses IS NULL over a function-call operand")
+  func isNullCall() throws {
+    let select = try parseSelect("SELECT * FROM T WHERE iid(Id) IS NULL")
+    let call = Expression.call(name: "iid", arguments: [.column("Id")])
+    #expect(select.predicate == .null(call, negated: false))
+  }
+
+  @Test("rejects IS without NULL")
+  func isWithoutNull() {
+    #expect(throws: SQLError.self) {
+      _ = try Statement(parsing: "SELECT * FROM T WHERE Note IS 1")
+    }
+  }
+
   @Test("parses OR left-associatively")
   func leftAssociativeOr() throws {
     // a = 1 OR b = 2 OR c = 3  ==>  ((a OR b) OR c)


### PR DESCRIPTION
This pull request significantly extends the SQL engine's support for queries involving multiple joins and improves handling of SQL `NULL` values, both in the AST and during execution. It also updates the parser and internal logic to support a chain of joins and adds precise handling for `IS NULL`/`IS NOT NULL` predicates, ensuring correct three-valued logic throughout query evaluation.

**Major improvements:**

*Support for multiple joins:*
- The AST, parser, and engine now support a chain of zero or more joins in `SELECT` statements, instead of just a single optional join. This includes changes to the `Select` struct (now with a `joins: [Join]` property), parser logic, and engine plan compilation to handle left-deep join trees. [[1]](diffhunk://#diff-44ae278469f8cb8537a5e8997ce917320e10f66a7fb199bcf35bc353ab154f08L6-R11) [[2]](diffhunk://#diff-44ae278469f8cb8537a5e8997ce917320e10f66a7fb199bcf35bc353ab154f08L23-R23) [[3]](diffhunk://#diff-44ae278469f8cb8537a5e8997ce917320e10f66a7fb199bcf35bc353ab154f08L32-R47) [[4]](diffhunk://#diff-6c11b53db7442865204eb0deb0f35640964bb2e9f54779311e62ae0b206f19d2L6-R10) [[5]](diffhunk://#diff-6c11b53db7442865204eb0deb0f35640964bb2e9f54779311e62ae0b206f19d2L63-R65) [[6]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L16-R26) [[7]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L42-R66) [[8]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L85-R155)

*Improved handling of SQL NULL values:*
- Introduced a `Value.null` case and corresponding logic throughout the engine, including a new `Predicate.null` AST case and a `Filter.null` for definite `IS NULL`/`IS NOT NULL` checks. The engine now correctly implements SQL's three-valued logic for comparisons and join keys, ensuring that `NULL` is not equal to anything, including itself. [[1]](diffhunk://#diff-44ae278469f8cb8537a5e8997ce917320e10f66a7fb199bcf35bc353ab154f08R205-R209) [[2]](diffhunk://#diff-5e2790ab4729e595cad0e69349d0ab7aaef73c324a6a97c21588aab1ab1f017cL36-R43) [[3]](diffhunk://#diff-66f69cc14663ff59f1854b7179f51accad89aa0a7e6731e6880d344908ac4facR29-R31) [[4]](diffhunk://#diff-66f69cc14663ff59f1854b7179f51accad89aa0a7e6731e6880d344908ac4facL136-R147) [[5]](diffhunk://#diff-66f69cc14663ff59f1854b7179f51accad89aa0a7e6731e6880d344908ac4facL152-R165) [[6]](diffhunk://#diff-66f69cc14663ff59f1854b7179f51accad89aa0a7e6731e6880d344908ac4facL176-R187) [[7]](diffhunk://#diff-90b051b6c59d5ca6612ebe0500cd6ccfecdec8f79c3c79167986ee4298fd0737R289-R291)

*Parser and grammar updates:*
- The SQL grammar and parser have been updated to support a chain of joins in the `SELECT` syntax, and to parse `IS [NOT] NULL` predicates as part of comparisons. [[1]](diffhunk://#diff-6c11b53db7442865204eb0deb0f35640964bb2e9f54779311e62ae0b206f19d2L6-R10) [[2]](diffhunk://#diff-6c11b53db7442865204eb0deb0f35640964bb2e9f54779311e62ae0b206f19d2L20-R20) [[3]](diffhunk://#diff-3a41d2f1d12fb42c8cf94decbe20e627053820a0d629708ea2b1ec942a3c087fR244-R245) [[4]](diffhunk://#diff-6c11b53db7442865204eb0deb0f35640964bb2e9f54779311e62ae0b206f19d2L63-R65)

*Plan compilation and slot mapping:*
- The engine's plan compilation logic has been refactored to handle multiple joins, building a left-deep tree of products and select nodes, and to correctly map slot spaces across all joined relations. [[1]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L85-R155) [[2]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060R247-R248) [[3]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L441-R497)

These changes collectively make the SQL engine more robust and standards-compliant, especially for queries involving complex joins and `NULL` value semantics.