### PR TITLE
SQL: view generation

### DIFF
--- a/Sources/SQL/AST.swift
+++ b/Sources/SQL/AST.swift
@@ -19,6 +19,11 @@
 public enum Statement: Hashable, Sendable {
   /// A `SELECT` query — one `SELECT`, or several combined with `UNION`.
   case select(Query)
+  /// A `CREATE VIEW name AS query`: the view's `name` and the `View` it binds
+  /// — the stored `query` and the column names (explicit or inferred from the
+  /// projection). A consumer registers the `View` under `name` in a catalog so
+  /// a later `SELECT … FROM name` resolves it.
+  case create(name: String, view: View)
 }
 
 /// A query: one `SELECT`, or several combined left-associatively with `UNION`.
@@ -37,7 +42,7 @@ public indirect enum Query: Hashable, Sendable {
 
   /// The first `SELECT` of the query — the leftmost arm, reached by descending
   /// the left-associative chain. Its projection names the result columns (the
-  /// ISO rule).
+  /// ISO rule), so a `CREATE VIEW` infers a union's columns from it.
   public var first: Select {
     switch self {
     case let .select(select): select

--- a/Sources/SQL/AST.swift
+++ b/Sources/SQL/AST.swift
@@ -17,7 +17,33 @@
 /// relations it names; resolving the table, alias, and column identifiers is
 /// the consumer's responsibility.
 public enum Statement: Hashable, Sendable {
+  /// A `SELECT` query — one `SELECT`, or several combined with `UNION`.
+  case select(Query)
+}
+
+/// A query: one `SELECT`, or several combined left-associatively with `UNION`.
+///
+/// A bare `SELECT` is the `select` case; `a UNION b UNION c` nests left —
+/// `union(union(select(a), b, all:), c, all:)` — so the arms read in source
+/// order. `UNION` removes duplicate result rows; `UNION ALL` (`all` true) keeps
+/// them. Every arm must project the same number of columns, and the result
+/// columns are the FIRST arm's projection (the ISO rule).
+public indirect enum Query: Hashable, Sendable {
+  /// A single `SELECT`.
   case select(Select)
+  /// A `UNION` (or `UNION ALL` when `all`) of a query and a further `SELECT`,
+  /// the new arm appended on the right so the chain reads left to right.
+  case union(Query, Select, all: Bool)
+
+  /// The first `SELECT` of the query — the leftmost arm, reached by descending
+  /// the left-associative chain. Its projection names the result columns (the
+  /// ISO rule).
+  public var first: Select {
+    switch self {
+    case let .select(select): select
+    case let .union(query, _, _): query.first
+    }
+  }
 }
 
 /// A `SELECT` query: a projection over one relation or a chain of joins, with an

--- a/Sources/SQL/Adapter.swift
+++ b/Sources/SQL/Adapter.swift
@@ -49,27 +49,28 @@ public enum Value: Hashable, Sendable {
 
 // MARK: - View
 
-/// A named `SELECT` registered as a first-class relation.
+/// A named query registered as a first-class relation.
 ///
 /// A view is a stored query the engine resolves wherever a base table is: its
-/// `select` is the query that produces the rows, and `columns` names the
-/// relation's columns in projection order — column `i` is the `i`th projected
-/// value of `select`. A view is fully escapable data — no borrowed storage — so
-/// it sits beside the `~Escapable` base tables in the same catalog namespace; a
-/// catalog vends one through `view(named:)`. The engine compiles a view's
-/// `select` into a sub-plan and splices it in where the view is named, the
-/// outer query addressing the view's columns by their ordinal in `columns`. A
-/// view carries no virtual column, so its `extent` is its `columns` count.
+/// `query` is the `SELECT` — or `UNION` of several — that produces the rows,
+/// and `columns` names the relation's columns in projection order — column `i`
+/// is the `i`th projected value of the query's first arm. A view is fully
+/// escapable data — no borrowed storage — so it sits beside the `~Escapable`
+/// base tables in the same catalog namespace; a catalog vends one through
+/// `view(named:)`. The engine compiles a view's `query` into a sub-plan and
+/// splices it in where the view is named, the outer query addressing the view's
+/// columns by their ordinal in `columns`. A view carries no virtual column, so
+/// its `extent` is its `columns` count.
 public struct View: Hashable, Sendable {
   /// The query the view stands for.
-  public let select: Select
+  public let query: Query
 
   /// The view's column names, in projection order — column `i` is the `i`th
-  /// projected value of `select`.
+  /// projected value of the query's first arm.
   public let columns: Array<String>
 
-  public init(select: Select, columns: Array<String>) {
-    self.select = select
+  public init(query: Query, columns: Array<String>) {
+    self.query = query
     self.columns = columns
   }
 }

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -135,8 +135,8 @@ public enum Engine {
       let ordinals = referenced(projection, filter, order)
       let slot = invert(ordinals)
       let scan = from.leaf(ordinals)
-      return shape(scan, projection.map { remap($0, slot) },
-                   filter.map { remap($0, slot) },
+      return shape(scan, projection.map { $0.remapped(through: slot) },
+                   filter.map { $0.remapped(through: slot) },
                    order.map { (slot[$0.column]!, $0.ascending) })
     }
 
@@ -213,12 +213,12 @@ public enum Engine {
     // an index-nested-loop join.
     let seed = from.leaf(locals[0])
     let chain = select.joins.indices.reduce(seed) { chain, index in
-      .select(remap(matches[index], slot),
+      .select(matches[index].remapped(through: slot),
               .product(chain, joined[index].leaf(locals[index + 1])))
     }
 
-    return shape(chain, projection.map { remap($0, slot) },
-                 predicate.map { remap($0, slot) },
+    return shape(chain, projection.map { $0.remapped(through: slot) },
+                 predicate.map { $0.remapped(through: slot) },
                  order.map { (slot[$0.column]!, $0.ascending) })
   }
 
@@ -248,7 +248,7 @@ public enum Engine {
       throws(SQLError) -> Resolved {
     if let view = catalog.view(named: relation.name) {
       let plan = try compile(view.query, catalog)
-      let projected = width(plan)
+      let projected = plan.width
       guard view.columns.count == projected else {
         throw .columns(expected: projected, got: view.columns.count)
       }
@@ -266,26 +266,6 @@ public enum Engine {
     let name = relation.name
     return Resolved(schema: schema) { ordinals in
       .scan(name: name, ordinals: ordinals, seek: nil)
-    }
-  }
-
-  /// The number of values a compiled `plan` projects — its output column count.
-  ///
-  /// `compile` shapes every arm as `Project(…)`, so the projected width is the
-  /// `project`'s term count; a `union` is as wide as its (left) arm, every arm
-  /// aligned by the arity check. This measures a view's sub-plan against its
-  /// declared `columns` so the view never claims a width its rows lack.
-  private static func width(_ plan: Plan) -> Int {
-    switch plan {
-    case let .project(terms, _):
-      terms.count
-    case let .union(left, _, _):
-      width(left)
-    default:
-      // `compile` always tops an arm with a `project`; nothing else reaches a
-      // view's sub-plan root. Measuring nil would mask a width mismatch, so a
-      // zero (which never equals a non-empty column list) surfaces it.
-      0
     }
   }
 
@@ -313,42 +293,6 @@ public enum Engine {
       slot[ordinals[index]] = index
     }
     return slot
-  }
-
-  /// `term` with every ordinal it reads remapped to a slot through `slot`: a
-  /// `.slot` holding an ordinal becomes the same slot, a constant is unchanged,
-  /// a call recurses into its arguments.
-  private static func remap(_ term: Term, _ slot: Dictionary<Int, Int>)
-      -> Term {
-    switch term {
-    case let .slot(ordinal):
-      .slot(slot[ordinal]!)
-    case .constant:
-      term
-    case let .apply(name, arguments):
-      .apply(name: name, arguments: arguments.map { remap($0, slot) })
-    }
-  }
-
-  /// `filter` with every ordinal it addresses remapped to a slot through `slot`.
-  private static func remap(_ filter: Filter, _ slot: Dictionary<Int, Int>)
-      -> Filter {
-    switch filter {
-    case let .compare(lhs, op, rhs):
-      .compare(remap(lhs, slot), op, remap(rhs, slot))
-    case let .bound(term, op, parameter):
-      .bound(remap(term, slot), op, parameter)
-    case let .match(left, right):
-      .match(slot[left]!, slot[right]!)
-    case let .null(term, negated):
-      .null(remap(term, slot), negated: negated)
-    case let .and(lhs, rhs):
-      .and(remap(lhs, slot), remap(rhs, slot))
-    case let .or(lhs, rhs):
-      .or(remap(lhs, slot), remap(rhs, slot))
-    case let .not(operand):
-      .not(remap(operand, slot))
-    }
   }
 
   /// Wraps `source` in the `Project(Sort(Select(_)))` operators, omitting the
@@ -532,12 +476,12 @@ public enum Engine {
                                                     _ bindings: Bindings)
       throws(SQLError) -> Plan {
     guard case let .scan(name, ordinals, nil) = right,
-        let base = slots(left) else {
+        let base = left.slots else {
       return try .select(filter, .product(optimise(left, catalog, bindings),
                                           optimise(right, catalog, bindings)))
     }
 
-    let conjuncts = flatten(filter)
+    let conjuncts = filter.conjuncts
     for index in conjuncts.indices {
       guard case let .match(lhs, rhs) = conjuncts[index],
           let (leftKey, rightKey) = keys(lhs, rhs, base) else {
@@ -550,7 +494,7 @@ public enum Engine {
                                ordinals: ordinals, base: base,
                                column: ordinals[rightKey - base],
                                keys: (left: leftKey, right: rightKey))
-      guard let predicate = rebuild(residual) else { return join }
+      guard let predicate = residual.conjunction else { return join }
       return .select(predicate, join)
     }
 
@@ -573,50 +517,4 @@ public enum Engine {
     }
   }
 
-  /// The combined-space slot count of `plan` — the boundary past which a newly
-  /// joined relation's slots begin — or `nil` if a side's width is not known.
-  ///
-  /// A scan or a derived view's width is its referenced-ordinal count; a
-  /// `select` is as wide as its source; a `product` is the sum of its sides and
-  /// a `join` the sum of its outer side and the inner's referenced ordinals — so
-  /// a left-deep chain of products or joins measures correctly, letting the
-  /// nest rewrite recurse into a multi-relation chain.
-  private static func slots(_ plan: Plan) -> Int? {
-    switch plan {
-    case let .scan(_, ordinals, _):
-      ordinals.count
-    case let .derived(_, _, ordinals, _):
-      ordinals.count
-    case let .select(_, source):
-      slots(source)
-    case let .product(left, right):
-      if let left = slots(left), let right = slots(right) {
-        left + right
-      } else {
-        nil
-      }
-    case let .join(outer, _, ordinals, _, _, _):
-      slots(outer).map { $0 + ordinals.count }
-    case let .union(left, _, _):
-      // Both sides yield rows of the same width — the result columns — so the
-      // union's width is its left side's.
-      slots(left)
-    default:
-      nil
-    }
-  }
-
-  // MARK: - Conjunct algebra
-
-  /// The flat list of `AND`-conjuncts of `filter` (a non-`and` is a singleton).
-  private static func flatten(_ filter: Filter) -> Array<Filter> {
-    guard case let .and(lhs, rhs) = filter else { return [filter] }
-    return flatten(lhs) + flatten(rhs)
-  }
-
-  /// The right-leaning `AND` of `conjuncts`, or `nil` for an empty list.
-  private static func rebuild(_ conjuncts: Array<Filter>) -> Filter? {
-    guard let last = conjuncts.last else { return nil }
-    return conjuncts.dropLast().reversed().reduce(last) { .and($1, $0) }
-  }
 }

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -237,11 +237,21 @@ public enum Engine {
   /// a view first, its `select` compiled to a sub-plan and wrapped in a
   /// `derived` leaf; otherwise a base table resolves and scans. A name neither
   /// resolves is `SQLError.relation`.
+  ///
+  /// A view's `columns` must name exactly one column per value its query
+  /// projects, or the view's schema would let a query index past a sub-plan row.
+  /// The parser checks this whenever the projection's arity is statically known;
+  /// this is the backstop for a `SELECT *` view, whose width is known only here,
+  /// after the sub-plan compiles — a mismatch is `SQLError.columns`.
   private static func resolve<C: Catalog & ~Escapable>(_ relation: Relation,
                                                        _ catalog: borrowing C)
       throws(SQLError) -> Resolved {
     if let view = catalog.view(named: relation.name) {
       let plan = try compile(view.query, catalog)
+      let projected = width(plan)
+      guard view.columns.count == projected else {
+        throw .columns(expected: projected, got: view.columns.count)
+      }
       let schema = view.schema()
       return Resolved(schema: schema) { ordinals in
         .derived(name: relation.name, plan: plan, ordinals: ordinals,
@@ -256,6 +266,26 @@ public enum Engine {
     let name = relation.name
     return Resolved(schema: schema) { ordinals in
       .scan(name: name, ordinals: ordinals, seek: nil)
+    }
+  }
+
+  /// The number of values a compiled `plan` projects — its output column count.
+  ///
+  /// `compile` shapes every arm as `Project(…)`, so the projected width is the
+  /// `project`'s term count; a `union` is as wide as its (left) arm, every arm
+  /// aligned by the arity check. This measures a view's sub-plan against its
+  /// declared `columns` so the view never claims a width its rows lack.
+  private static func width(_ plan: Plan) -> Int {
+    switch plan {
+    case let .project(terms, _):
+      terms.count
+    case let .union(left, _, _):
+      width(left)
+    default:
+      // `compile` always tops an arm with a `project`; nothing else reaches a
+      // view's sub-plan root. Measuring nil would mask a width mismatch, so a
+      // zero (which never equals a non-empty column list) surfaces it.
+      0
     }
   }
 

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -18,22 +18,78 @@
 /// chain. Absent layers are omitted. Executing the plan yields the result
 /// records' typed values; formatting them is a client's job.
 public enum Engine {
-  /// Runs `select` against `catalog`, returning the projected, filtered, and
+  /// Runs `query` against `catalog`, returning the projected, filtered, and
   /// ordered rows as typed values.
+  ///
+  /// A bare `SELECT` runs as before; a `UNION` runs each arm through the same
+  /// compile/optimise/execute with the SAME `bindings` and `routines`, then
+  /// concatenates the rows in source order — `UNION ALL` keeps every row, a
+  /// bare `UNION` removes whole-row duplicates (first occurrence kept). The
+  /// plan is binary and mirrors the left-associative chain, so each
+  /// `UNION`/`UNION ALL` honours its own flag — `(A UNION B) UNION ALL C` dedups
+  /// `A ∪ B` before appending `C`. The result columns are the first arm's
+  /// projection (the ISO rule); each arm keeps its own `ORDER BY`, applied
+  /// before the union.
   ///
   /// - Throws: `SQLError.relation` if the catalog resolves no such relation,
   ///   `SQLError.column` if a referenced column is absent, `SQLError.ambiguous`
-  ///   if an unqualified name is resolved by more than one relation of a chain.
-  public static func run<C: Catalog & ~Escapable>(_ select: Select,
+  ///   if an unqualified name is resolved by more than one relation of a chain,
+  ///   `SQLError.arity` if a `UNION`'s arms project differing column counts.
+  public static func run<C: Catalog & ~Escapable>(_ query: Query,
                                                   _ catalog: borrowing C,
                                                   _ routines: Routines = [:],
                                                   bindings: Bindings = [:])
       throws(SQLError) -> Array<Array<Value>> {
-    let plan = try optimise(compile(select, catalog), catalog, bindings)
+    let plan = try optimise(compile(query, catalog), catalog, bindings)
     return try execute(plan, catalog, routines, bindings).map(\.values)
   }
 
   // MARK: - Compilation
+
+  /// Compiles `query` over `catalog` into a logical operator tree.
+  ///
+  /// A single `SELECT` compiles as itself; a `UNION` compiles recursively into a
+  /// BINARY `union` plan that mirrors the left-associative `Query`:
+  /// `compile(.union(left, select, all))` is `.union(compile(left),
+  /// compile(.select(select)), all)`. Each node carries its OWN `all`, so the
+  /// executor honours every `UNION`/`UNION ALL` distinctly — `(A UNION B) UNION
+  /// ALL C` dedups `A ∪ B` before appending `C`, rather than treating the whole
+  /// chain by the trailing arm's flag. The new arm must project the same column
+  /// count as the chain's first `SELECT` — the result columns — else
+  /// `SQLError.arity`.
+  internal static func compile<C: Catalog & ~Escapable>(_ query: Query,
+                                                        _ catalog: borrowing C)
+      throws(SQLError) -> Plan {
+    guard case let .union(left, select, all) = query else {
+      return try compile(query.first, catalog)
+    }
+
+    let width = try arity(query.first, catalog)
+    let count = try arity(select, catalog)
+    guard count == width else { throw .arity(width, count) }
+    return try .union(compile(left, catalog), compile(.select(select), catalog),
+                      all: all)
+  }
+
+  /// The number of result columns `select` projects — the extent of a `*` over
+  /// its relations, else the count of its projected items — for the `UNION`
+  /// arity check. The relations resolve through the borrowed `catalog`.
+  private static func arity<C: Catalog & ~Escapable>(_ select: Select,
+                                                     _ catalog: borrowing C)
+      throws(SQLError) -> Int {
+    switch select.projection {
+    case .all:
+      var width = try resolve(select.from, catalog).schema.width
+      for join in select.joins {
+        try width += resolve(join.relation, catalog).schema.width
+      }
+      return width
+    case let .columns(columns):
+      return columns.count
+    case let .expressions(items):
+      return items.count
+    }
+  }
 
   /// Compiles `select` over `catalog` into a logical operator tree in slot
   /// space.
@@ -185,7 +241,7 @@ public enum Engine {
                                                        _ catalog: borrowing C)
       throws(SQLError) -> Resolved {
     if let view = catalog.view(named: relation.name) {
-      let plan = try compile(view.select, catalog)
+      let plan = try compile(view.query, catalog)
       let schema = view.schema()
       return Resolved(schema: schema) { ordinals in
         .derived(name: relation.name, plan: plan, ordinals: ordinals,
@@ -329,6 +385,12 @@ public enum Engine {
                    optimise(right, catalog, bindings))
     case .join:
       plan
+    case let .union(left, right, all):
+      // Optimise each side with the same bindings so a bound predicate inside an
+      // arm seeks; the union itself merely concatenates and deduplicates,
+      // preserving this node's own `all`.
+      try .union(optimise(left, catalog, bindings),
+                 optimise(right, catalog, bindings), all: all)
     }
   }
 
@@ -505,6 +567,10 @@ public enum Engine {
       }
     case let .join(outer, _, ordinals, _, _, _):
       slots(outer).map { $0 + ordinals.count }
+    case let .union(left, _, _):
+      // Both sides yield rows of the same width — the result columns — so the
+      // union's width is its left side's.
+      slots(left)
     default:
       nil
     }

--- a/Sources/SQL/Error.swift
+++ b/Sources/SQL/Error.swift
@@ -58,6 +58,10 @@ public enum SQLError: Error, Hashable, Sendable {
   /// A scalar function rejects its arguments (the wrong count, or a value it
   /// cannot map); the string describes the fault.
   case argument(String)
+  /// A `UNION` combines two `SELECT`s of differing column counts — the result
+  /// columns of every arm must align — carrying the first arm's width and the
+  /// offending arm's.
+  case arity(Int, Int)
 }
 
 extension SQLError: CustomStringConvertible {
@@ -85,6 +89,9 @@ extension SQLError: CustomStringConvertible {
       "no such function '\(name)'"
     case let .argument(detail):
       "invalid function argument: \(detail)"
+    case let .arity(expected, found):
+      "UNION arms project differing column counts: "
+          + "expected \(expected), found \(found)"
     }
   }
 }

--- a/Sources/SQL/Error.swift
+++ b/Sources/SQL/Error.swift
@@ -58,6 +58,21 @@ public enum SQLError: Error, Hashable, Sendable {
   /// A scalar function rejects its arguments (the wrong count, or a value it
   /// cannot map); the string describes the fault.
   case argument(String)
+  /// A `CREATE VIEW` projects a column whose name cannot be inferred — a
+  /// `SELECT *`, or an unaliased non-column expression — and no explicit column
+  /// list names it; the string describes the offending projection.
+  case named(String)
+  /// A `CREATE VIEW`'s explicit column list does not match the view query's
+  /// output width — the list must name exactly one column per projected value —
+  /// carrying the `expected` query arity and the `got` list count. Caught at
+  /// parse when the projection's arity is known, and as an engine backstop when
+  /// a view (a `SELECT *` whose width is known only at resolution) is compiled.
+  case columns(expected: Int, got: Int)
+  /// A `CREATE VIEW` names two columns that collide — supplied explicitly or
+  /// inferred from the projection — under the case-insensitive resolution
+  /// `Schema.ordinal(of:)` performs, so the shadowed column would be
+  /// unreachable; the string is the offending name.
+  case duplicate(String)
   /// A `UNION` combines two `SELECT`s of differing column counts — the result
   /// columns of every arm must align — carrying the first arm's width and the
   /// offending arm's.
@@ -89,6 +104,13 @@ extension SQLError: CustomStringConvertible {
       "no such function '\(name)'"
     case let .argument(detail):
       "invalid function argument: \(detail)"
+    case let .named(detail):
+      "view column cannot be named: \(detail)"
+    case let .columns(expected, got):
+      "view column list count does not match the query: "
+          + "expected \(expected), got \(got)"
+    case let .duplicate(name):
+      "duplicate view column '\(name)'"
     case let .arity(expected, found):
       "UNION arms project differing column counts: "
           + "expected \(expected), found \(found)"

--- a/Sources/SQL/Filter.swift
+++ b/Sources/SQL/Filter.swift
@@ -76,6 +76,61 @@ extension Term {
   }
 }
 
+extension Term {
+  /// This term with every ordinal it reads remapped to a slot through `slot`: a
+  /// `.slot` holding an ordinal becomes the same slot, a constant is unchanged,
+  /// a call recurses into its arguments.
+  internal func remapped(through slot: Dictionary<Int, Int>) -> Term {
+    switch self {
+    case let .slot(ordinal):
+      .slot(slot[ordinal]!)
+    case .constant:
+      self
+    case let .apply(name, arguments):
+      .apply(name: name,
+             arguments: arguments.map { $0.remapped(through: slot) })
+    }
+  }
+}
+
+extension Filter {
+  /// This filter with every ordinal it addresses remapped to a slot through
+  /// `slot`.
+  internal func remapped(through slot: Dictionary<Int, Int>) -> Filter {
+    switch self {
+    case let .compare(lhs, op, rhs):
+      .compare(lhs.remapped(through: slot), op, rhs.remapped(through: slot))
+    case let .bound(term, op, parameter):
+      .bound(term.remapped(through: slot), op, parameter)
+    case let .match(left, right):
+      .match(slot[left]!, slot[right]!)
+    case let .null(term, negated):
+      .null(term.remapped(through: slot), negated: negated)
+    case let .and(lhs, rhs):
+      .and(lhs.remapped(through: slot), rhs.remapped(through: slot))
+    case let .or(lhs, rhs):
+      .or(lhs.remapped(through: slot), rhs.remapped(through: slot))
+    case let .not(operand):
+      .not(operand.remapped(through: slot))
+    }
+  }
+
+  /// The flat list of `AND`-conjuncts of this filter (a non-`and` is a
+  /// singleton).
+  internal var conjuncts: Array<Filter> {
+    guard case let .and(lhs, rhs) = self else { return [self] }
+    return lhs.conjuncts + rhs.conjuncts
+  }
+}
+
+extension Array where Element == Filter {
+  /// The right-leaning `AND` of these conjuncts, or `nil` for an empty list.
+  internal var conjunction: Filter? {
+    guard let last else { return nil }
+    return dropLast().reversed().reduce(last) { .and($1, $0) }
+  }
+}
+
 /// The literal `literal` as a typed `Value`.
 internal func value(of literal: Literal) -> Value {
   switch literal {

--- a/Sources/SQL/Lexer.swift
+++ b/Sources/SQL/Lexer.swift
@@ -243,6 +243,8 @@ internal struct Lexer: ~Escapable {
     case "AS": .as
     case "IS": .is
     case "NULL": .null
+    case "UNION": .union
+    case "ALL": .all
     default: .identifier(text)
     }
     return Token(kind: kind, location: start)

--- a/Sources/SQL/Lexer.swift
+++ b/Sources/SQL/Lexer.swift
@@ -228,6 +228,8 @@ internal struct Lexer: ~Escapable {
 
     let text = String(bytes, start.offset ..< position)
     let kind: Token.Kind = switch text.uppercased() {
+    case "CREATE": .create
+    case "VIEW": .view
     case "SELECT": .select
     case "FROM": .from
     case "WHERE": .where

--- a/Sources/SQL/Operator.swift
+++ b/Sources/SQL/Operator.swift
@@ -128,6 +128,15 @@ internal indirect enum Plan {
   /// (for the seek `bound`).
   case join(Plan, name: String, ordinals: Array<Int>, base: Int,
             column: Int, keys: (left: Int, right: Int))
+  /// ∪ — the rows of the `left` sub-plan followed by the `right`'s, in source
+  /// order. With `all` the duplicates are kept (`UNION ALL`); without it the
+  /// whole-row duplicates of the combined rows are removed, the first occurrence
+  /// preserved (`UNION`). The node is binary and mirrors the left-associative
+  /// `Query` chain, so each `UNION`/`UNION ALL` honours its OWN `all`: a `UNION`
+  /// nested under a `UNION ALL` dedups its own pair before the outer node
+  /// appends the trailing arm. Both sides yield rows of the same width — the
+  /// result columns of the first arm.
+  case union(Plan, Plan, all: Bool)
 }
 
 // MARK: - Interpreter
@@ -140,8 +149,11 @@ internal indirect enum Plan {
 /// records; `project` rebuilds each from the projected slots; `sort` orders them
 /// by a typed key, stably and in the requested direction; `product` pairs every
 /// outer record with every inner one; `join` re-resolves the inner relation,
-/// seeks it per outer record, and concatenates the matches. The catalog is
-/// borrowed throughout — a `~Escapable` source is never copied or stored.
+/// seeks it per outer record, and concatenates the matches; `union` runs its
+/// two sides — each with its own union semantics — and concatenates their rows,
+/// deduplicating the whole row unless `all`.
+/// The catalog is borrowed throughout — a `~Escapable` source is never copied
+/// or stored.
 internal func execute<C: Catalog & ~Escapable>(_ plan: Plan,
                                                _ catalog: borrowing C,
                                                _ routines: Routines,
@@ -176,7 +188,36 @@ internal func execute<C: Catalog & ~Escapable>(_ plan: Plan,
   case let .join(outer, name, ordinals, base, column, keys):
     try join(execute(outer, catalog, routines, bindings), name, ordinals,
              base, column, keys, catalog)
+  case let .union(left, right, all):
+    try union(left, right, all, catalog, routines, bindings)
   }
+}
+
+/// Concatenates the rows of `left` followed by `right`, deduplicating the whole
+/// combined row — first occurrence kept — unless `all` (`UNION ALL`, every row
+/// kept).
+///
+/// Each side runs through the same `catalog`, `routines`, and `bindings`, so a
+/// bound parameter threads into every arm alike. A side may itself be a `union`,
+/// and it executes with its OWN semantics first — a `UNION` nested under a
+/// `UNION ALL` dedups its pair before the outer node appends `right`. A `Record`
+/// is `Hashable`, so `UNION`'s dedup keys on the materialised row.
+private func union<C: Catalog & ~Escapable>(_ left: Plan, _ right: Plan,
+                                            _ all: Bool,
+                                            _ catalog: borrowing C,
+                                            _ routines: Routines,
+                                            _ bindings: Bindings)
+    throws(SQLError) -> Array<Record> {
+  let rows = try execute(left, catalog, routines, bindings)
+      + execute(right, catalog, routines, bindings)
+  guard !all else { return rows }
+
+  var records = Array<Record>()
+  var seen = Set<Record>()
+  for record in rows where seen.insert(record).inserted {
+    records.append(record)
+  }
+  return records
 }
 
 /// Evaluates each projected `term` against `record` through `routines` to the

--- a/Sources/SQL/Operator.swift
+++ b/Sources/SQL/Operator.swift
@@ -139,6 +139,62 @@ internal indirect enum Plan {
   case union(Plan, Plan, all: Bool)
 }
 
+extension Plan {
+  /// The number of values this plan projects — its output column count.
+  ///
+  /// `compile` shapes every arm as `Project(…)`, so the projected width is the
+  /// `project`'s term count; a `union` is as wide as its (left) arm, every arm
+  /// aligned by the arity check. This measures a view's sub-plan against its
+  /// declared `columns` so the view never claims a width its rows lack.
+  internal var width: Int {
+    switch self {
+    case let .project(terms, _):
+      terms.count
+    case let .union(left, _, _):
+      left.width
+    default:
+      // `compile` always tops an arm with a `project`; nothing else reaches a
+      // view's sub-plan root. Measuring nil would mask a width mismatch, so a
+      // zero (which never equals a non-empty column list) surfaces it.
+      0
+    }
+  }
+
+  /// The combined-space slot count of this plan — the boundary past which a
+  /// newly joined relation's slots begin — or `nil` if a side's width is not
+  /// known.
+  ///
+  /// A scan or a derived view's width is its referenced-ordinal count; a
+  /// `select` is as wide as its source; a `product` is the sum of its sides and
+  /// a `join` the sum of its outer side and the inner's referenced ordinals — so
+  /// a left-deep chain of products or joins measures correctly, letting the
+  /// nest rewrite recurse into a multi-relation chain.
+  internal var slots: Int? {
+    switch self {
+    case let .scan(_, ordinals, _):
+      ordinals.count
+    case let .derived(_, _, ordinals, _):
+      ordinals.count
+    case let .select(_, source):
+      source.slots
+    case let .product(left, right):
+      if let left = left.slots, let right = right.slots {
+        left + right
+      } else {
+        nil
+      }
+    case let .join(outer, _, ordinals, _, _, _):
+      outer.slots.map { $0 + ordinals.count }
+    case let .union(left, _, _):
+      // Both sides yield rows of the same width — the result columns — so the
+      // union's width is its left side's.
+      left.slots
+    default:
+      nil
+    }
+  }
+}
+
 // MARK: - Interpreter
 
 /// Interprets `plan` against `catalog`, producing its result records.

--- a/Sources/SQL/Parser.swift
+++ b/Sources/SQL/Parser.swift
@@ -6,7 +6,9 @@
 /// The grammar is the minimal dialect, extended with a chain of joins:
 ///
 /// ```
-/// statement   := query
+/// statement   := query | create
+/// create      := CREATE VIEW identifier ['(' identifier (',' identifier)* ')']
+///                  AS query
 /// query       := select (UNION [ALL] select)*
 /// select      := SELECT projection FROM relation (join)* [where] [order]
 /// relation    := identifier [AS identifier]
@@ -47,9 +49,14 @@ internal struct Parser: ~Escapable {
 
   /// Parses a complete statement and asserts the input is exhausted.
   ///
-  /// A statement is a `query` — a `SELECT` or a `UNION` of several.
+  /// A leading `CREATE` selects the `CREATE VIEW` form; anything else is a
+  /// `query` — a `SELECT` or a `UNION` of several.
   internal mutating func parse() throws(SQLError) -> Statement {
-    let statement = try Statement.select(query())
+    let statement = if current?.kind == .create {
+      try create()
+    } else {
+      try Statement.select(query())
+    }
     if let token = current {
       throw .trailing(at: token.location)
     }
@@ -69,6 +76,101 @@ internal struct Parser: ~Escapable {
       query = try .union(query, select(), all: all)
     }
     return query
+  }
+
+  /// Parses `CREATE VIEW identifier ['(' identifier (, identifier)* ')'] AS
+  /// query` (the leading `CREATE` is the next token).
+  ///
+  /// An explicit `(col, col, …)` list names the view's columns; absent one, the
+  /// names are inferred from the FIRST arm's projection (the ISO rule for a
+  /// union's result columns). A projection whose names cannot be inferred — a
+  /// `SELECT *`, or an unaliased non-column expression — faults with
+  /// `SQLError.named`. An explicit list that does not name exactly one column
+  /// per projected value, when the first arm's arity is statically known (a
+  /// `.columns` or `.expressions` projection, but not a `SELECT *`), faults with
+  /// `SQLError.columns`; a `SELECT *` view's width is checked by the engine at
+  /// resolution instead. The final names — explicit or inferred — must be
+  /// case-insensitively unique, matching `Schema.ordinal(of:)`'s resolution; a
+  /// collision faults with `SQLError.duplicate`.
+  private mutating func create() throws(SQLError) -> Statement {
+    try expect(.create)
+    try expect(.view)
+    let name = try identifier()
+
+    var explicit: Array<String>? = nil
+    if try match(.lparen) {
+      var columns = Array<String>()
+      try columns.append(identifier())
+      while try match(.comma) {
+        try columns.append(identifier())
+      }
+      try expect(.rparen)
+      explicit = columns
+    }
+
+    try expect(.as)
+    let query = try query()
+    let columns: Array<String>
+    if let explicit {
+      if let arity = arity(query.first.projection), explicit.count != arity {
+        throw .columns(expected: arity, got: explicit.count)
+      }
+      columns = explicit
+    } else {
+      columns = try infer(query.first.projection)
+    }
+    // A view's columns must be case-insensitively unique — explicit or
+    // inferred — to match the resolution `Schema.ordinal(of:)` performs; a
+    // collision would shadow the later column and make it unreachable.
+    var seen = Set<String>()
+    for column in columns where !seen.insert(column.lowercased()).inserted {
+      throw .duplicate(column)
+    }
+    return .create(name: name, view: View(query: query, columns: columns))
+  }
+
+  /// The number of values `projection` projects, or `nil` when it is not
+  /// statically known — a `SELECT *`, whose width depends on the relations it is
+  /// resolved against. A `.columns` or `.expressions` projection has a fixed
+  /// item count.
+  private func arity(_ projection: Projection) -> Int? {
+    switch projection {
+    case .all:
+      nil
+    case let .columns(columns):
+      columns.count
+    case let .expressions(items):
+      items.count
+    }
+  }
+
+  /// Infers a view's column names from its `projection`.
+  ///
+  /// A `columns` projection yields each reference's name (the qualifier
+  /// dropped); an `expressions` projection yields each item's alias, or — for a
+  /// bare column with no alias — the column's name; a non-column expression with
+  /// no alias, and a `SELECT *`, have no inferable name and fault with
+  /// `SQLError.named`.
+  private func infer(_ projection: Projection) throws(SQLError)
+      -> Array<String> {
+    switch projection {
+    case .all:
+      throw .named("SELECT *")
+    case let .columns(columns):
+      return columns.map(\.name)
+    case let .expressions(items):
+      var names = Array<String>()
+      for item in items {
+        if let alias = item.alias {
+          names.append(alias)
+        } else if case let .column(column) = item.expression {
+          names.append(column.name)
+        } else {
+          throw .named("an unaliased expression")
+        }
+      }
+      return names
+    }
   }
 
   /// Parses a `SELECT` query.

--- a/Sources/SQL/Parser.swift
+++ b/Sources/SQL/Parser.swift
@@ -6,7 +6,8 @@
 /// The grammar is the minimal dialect, extended with a chain of joins:
 ///
 /// ```
-/// statement   := select
+/// statement   := query
+/// query       := select (UNION [ALL] select)*
 /// select      := SELECT projection FROM relation (join)* [where] [order]
 /// relation    := identifier [AS identifier]
 /// join        := JOIN relation ON column '=' column
@@ -45,12 +46,29 @@ internal struct Parser: ~Escapable {
   // MARK: - Statement
 
   /// Parses a complete statement and asserts the input is exhausted.
+  ///
+  /// A statement is a `query` — a `SELECT` or a `UNION` of several.
   internal mutating func parse() throws(SQLError) -> Statement {
-    let statement = try Statement.select(select())
+    let statement = try Statement.select(query())
     if let token = current {
       throw .trailing(at: token.location)
     }
     return statement
+  }
+
+  /// Parses `select (UNION [ALL] select)*`, left-associative.
+  ///
+  /// The leading `SELECT` is the seed `Query`; each `UNION` (optionally `ALL`)
+  /// folds the next `SELECT` onto the right, so `a UNION b UNION c` reads in
+  /// source order. `UNION ALL` keeps duplicate rows; a bare `UNION` removes
+  /// them — the distinction the engine honours.
+  private mutating func query() throws(SQLError) -> Query {
+    var query = try Query.select(select())
+    while try match(.union) {
+      let all = try match(.all)
+      query = try .union(query, select(), all: all)
+    }
+    return query
   }
 
   /// Parses a `SELECT` query.

--- a/Sources/SQL/SQL.swift
+++ b/Sources/SQL/SQL.swift
@@ -10,6 +10,7 @@ extension Statement {
   /// ```sql
   /// SELECT <* | column (, column)*> FROM <table>
   ///   [WHERE <predicate>] [ORDER BY <column> [ASC|DESC]]
+  ///   (UNION [ALL] SELECT …)*
   /// ```
   ///
   /// The resulting AST is generic: it names a relation and its columns as

--- a/Sources/SQL/Token.swift
+++ b/Sources/SQL/Token.swift
@@ -32,6 +32,8 @@ extension Token {
     case `as`
     case `is`
     case null
+    case union
+    case all
 
     // Operands.
     case identifier(String)
@@ -73,6 +75,8 @@ extension Token.Kind {
     case .as: "AS"
     case .is: "IS"
     case .null: "NULL"
+    case .union: "UNION"
+    case .all: "ALL"
     case let .identifier(name): name
     case let .string(value): "'\(value)'"
     case let .integer(value): "\(value)"

--- a/Sources/SQL/Token.swift
+++ b/Sources/SQL/Token.swift
@@ -17,6 +17,8 @@ extension Token {
   /// to a dedicated case; an identifier therefore never holds a keyword.
   internal enum Kind: Hashable, Sendable {
     // Keywords.
+    case create
+    case view
     case select
     case from
     case `where`
@@ -60,6 +62,8 @@ extension Token.Kind {
   /// A human-readable spelling of the token, for diagnostics.
   internal var description: String {
     switch self {
+    case .create: "CREATE"
+    case .view: "VIEW"
     case .select: "SELECT"
     case .from: "FROM"
     case .where: "WHERE"

--- a/Sources/winmd-inspect/Query.swift
+++ b/Sources/winmd-inspect/Query.swift
@@ -40,8 +40,11 @@ internal struct Query: ParsableCommand {
     // catalog, returning the projected, filtered, and ordered rows as typed
     // values.
     let rows = switch statement {
-    case let .select(select):
-      try Engine.run(select, database.storage)
+    case let .select(query):
+      try Engine.run(query, database.storage)
+    case .create:
+      throw ValidationError("CREATE VIEW is not a query; the query "
+                            + "subcommand runs a single SELECT")
     }
     for row in rows {
       print(row.map(Query.render).joined(separator: "\t"))

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -907,6 +907,30 @@ struct EngineViewTests {
     }
   }
 
+  @Test("a SELECT * view over-declaring its columns is rejected at resolution")
+  func wideStar() throws {
+    // `Parent` is two columns wide, but the view declares three. A `SELECT *`
+    // has no statically known arity, so the parser admits the list; the engine
+    // catches the mismatch at resolution rather than indexing past a row.
+    let star = try View(query: select("SELECT * FROM Parent"),
+                        columns: ["a", "b", "c"])
+    let catalog = Memory(family().relations, views: ["Star": star])
+    #expect(throws: SQLError.columns(expected: 2, got: 3)) {
+      try Engine.run(parse("SELECT a FROM Star"), catalog)
+    }
+  }
+
+  @Test("a SELECT * view whose explicit list matches the width resolves")
+  func matchedStar() throws {
+    // The same `SELECT *` view declared with the right number of columns
+    // resolves and queries — the backstop passes the well-formed view through.
+    let star = try View(query: select("SELECT * FROM Parent"),
+                        columns: ["a", "b"])
+    let catalog = Memory(family().relations, views: ["Star": star])
+    let rows = try Engine.run(parse("SELECT b FROM Star WHERE a = 1"), catalog)
+    #expect(rows == [[.text("Ada")]])
+  }
+
   @Test("a view's definition is optimised — its seekable predicate seeks")
   func optimised() throws {
     // `Adults` is `SELECT Id, Name FROM Parent WHERE Id >= 2`, and `Parent` is

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -235,20 +235,20 @@ private func family() -> Memory {
 /// `Pairs` proves a view whose definition is itself a join.
 private func views() throws -> Memory {
   // SELECT Id, Name FROM Parent WHERE Id >= 2 — exposed as columns Key, Label.
-  let adults = try View(select: select("""
+  let adults = try View(query: select("""
       SELECT Id, Name FROM Parent WHERE Id >= 2
       """), columns: ["Key", "Label"])
 
   // SELECT Parent.Name, Child.Name FROM Parent JOIN Child ON … — a view over a
   // join, its two projected columns exposed as Parent and Kid.
-  let pairs = try View(select: select("""
+  let pairs = try View(query: select("""
       SELECT Parent.Name, Child.Name FROM Parent
         JOIN Child ON Child.Pid = Parent.Id
       """), columns: ["Parent", "Kid"])
 
   // SELECT Id, Name FROM Parent WHERE Id = :id — a parameterized view whose
   // bound key seeks inside its sub-plan when :id is supplied.
-  let picked = try View(select: select("""
+  let picked = try View(query: select("""
       SELECT Id, Name FROM Parent WHERE Id = :id
       """), columns: ["Key", "Label"])
 
@@ -388,18 +388,18 @@ private func shared() -> Memory {
   ])
 }
 
-/// Parses `text` to a `SELECT`, failing on any other statement.
-private func select(_ text: String) throws -> Select {
+/// Parses `text` to a query, failing on any other statement.
+private func select(_ text: String) throws -> Query {
   try parse(text)
 }
 
-/// Parses `text` to a `SELECT`, failing on any other statement.
-private func parse(_ text: String) throws -> Select {
-  guard case let .select(select) = try Statement(parsing: text) else {
+/// Parses `text` to a query, failing on any other statement.
+private func parse(_ text: String) throws -> Query {
+  guard case let .select(query) = try Statement(parsing: text) else {
     Issue.record("expected a SELECT statement")
     throw SQLError.incomplete(expected: "a SELECT statement")
   }
-  return select
+  return query
 }
 
 /// Runs `text` against the single-relation `People` catalog.
@@ -937,6 +937,8 @@ private func derived(_ plan: Plan) -> Plan? {
     derived(source)
   case let .product(left, right):
     derived(left) ?? derived(right)
+  case let .union(left, right, _):
+    derived(left) ?? derived(right)
   case .scan, .join:
     nil
   }
@@ -956,6 +958,8 @@ private func seeks(_ plan: Plan) -> Bool {
   case let .derived(_, sub, _, _):
     seeks(sub)
   case let .product(left, right):
+    seeks(left) || seeks(right)
+  case let .union(left, right, _):
     seeks(left) || seeks(right)
   case .join:
     false
@@ -977,6 +981,8 @@ private func filters(_ plan: Plan) -> Bool {
   case let .derived(_, sub, _, _):
     filters(sub)
   case let .product(left, right):
+    filters(left) || filters(right)
+  case let .union(left, right, _):
     filters(left) || filters(right)
   case .scan, .join:
     false
@@ -1285,5 +1291,129 @@ struct EngineBoundTests {
     let sub = try #require(derived(plan))
     #expect(seeks(sub))
     #expect(!filters(sub))
+  }
+}
+
+// MARK: - UNION tests
+
+/// A three-relation catalog for `UNION`: `Left` and `Right` each hold a single
+/// `Tag` text column, sharing the value `shared` so a union across them proves
+/// cross-relation dedup; the values are otherwise distinct. `Extra` repeats the
+/// `a` already in `Left`, so a trailing `UNION ALL Extra` keeps it a second
+/// time — proving an inner `UNION`'s dedup survives an outer `UNION ALL`.
+private func tags() -> Memory {
+  let fields = [Field(name: "Tag", kind: .text)]
+  let left = [
+    [.text("a")],
+    [.text("shared")],
+  ] as Array<Array<Value>>
+  let right = [
+    [.text("shared")],
+    [.text("b")],
+  ] as Array<Array<Value>>
+  let extra = [
+    [.text("a")],
+  ] as Array<Array<Value>>
+  return Memory([
+    "Left": Relation(fields, left),
+    "Right": Relation(fields, right),
+    "Extra": Relation(fields, extra),
+  ])
+}
+
+struct EngineUnionTests {
+  @Test("UNION removes whole-row duplicates, keeping the first occurrence")
+  func dedup() throws {
+    // People's Age repeats (30 for Alice and Carol, 25 for Bob and Eve); a
+    // UNION of the relation with itself collapses every duplicate row.
+    let rows = try Engine.run(parse("""
+        SELECT Age FROM People UNION SELECT Age FROM People
+        """), people())
+    #expect(rows == [[.integer(30)], [.integer(25)], [.integer(40)]])
+  }
+
+  @Test("UNION ALL keeps every row of every arm in source order")
+  func all() throws {
+    let rows = try Engine.run(parse("""
+        SELECT Age FROM People UNION ALL SELECT Age FROM People
+        """), people())
+    let ages = [30, 25, 30, 40, 25].map { Value.integer($0) }
+    #expect(rows == (ages + ages).map { [$0] })
+  }
+
+  @Test("a UNION across two relations of matching arity merges and dedups")
+  func merge() throws {
+    let rows = try Engine.run(parse("""
+        SELECT Tag FROM Left UNION SELECT Tag FROM Right
+        """), tags())
+    // `shared` appears in both arms but survives once, first occurrence kept.
+    #expect(rows == [[.text("a")], [.text("shared")], [.text("b")]])
+  }
+
+  @Test("a UNION ALL across two relations keeps the shared row twice")
+  func mergeAll() throws {
+    let rows = try Engine.run(parse("""
+        SELECT Tag FROM Left UNION ALL SELECT Tag FROM Right
+        """), tags())
+    #expect(rows == [
+      [.text("a")],
+      [.text("shared")],
+      [.text("shared")],
+      [.text("b")],
+    ])
+  }
+
+  @Test("an inner UNION dedups before a trailing UNION ALL appends its arm")
+  func nestedAll() throws {
+    // (Left UNION Right) UNION ALL Extra. The inner UNION dedups `shared`
+    // across Left and Right to one row — `a, shared, b` — and the outer UNION
+    // ALL then appends Extra's `a` WITHOUT deduplicating, so `a` recurs. A
+    // chain flattened to the trailing `all` would instead keep both copies of
+    // `shared`; honouring each node's own flag keeps exactly one.
+    let rows = try Engine.run(parse("""
+        SELECT Tag FROM Left UNION SELECT Tag FROM Right
+          UNION ALL SELECT Tag FROM Extra
+        """), tags())
+    #expect(rows == [
+      [.text("a")],
+      [.text("shared")],
+      [.text("b")],
+      [.text("a")],
+    ])
+  }
+
+  @Test("a UNION of arms projecting differing column counts is rejected")
+  func arity() throws {
+    #expect(throws: SQLError.arity(1, 2)) {
+      try Engine.run(parse("""
+          SELECT Id FROM People UNION SELECT Id, Name FROM People
+          """), people())
+    }
+  }
+
+  @Test("a view defined as a UNION resolves and queries")
+  func view() throws {
+    let both = try View(query: select("""
+        SELECT Tag FROM Left UNION SELECT Tag FROM Right
+        """), columns: ["Tag"])
+    let catalog = Memory(tags().relations, views: ["Both": both])
+    let rows = try Engine.run(parse("SELECT Tag FROM Both"), catalog)
+    #expect(rows == [[.text("a")], [.text("shared")], [.text("b")]])
+  }
+
+  @Test("a bound parameter threads into every arm of a UNION")
+  func bound() throws {
+    // Both arms key on the same `:pid`; the binding reaches each alike, so the
+    // union is the parent's children drawn from two queries over the relation.
+    let rows = try Engine.run(parse("""
+        SELECT Name FROM Child WHERE Pid = :pid
+          UNION ALL SELECT Name FROM Child WHERE Pid = :pid
+        """), family(), Routines(), bindings: ["pid": .integer(1)])
+    #expect(rows == [
+      [.text("Ann")],
+      [.text("Amy")],
+      [.text("Ann")],
+      [.text("Amy")],
+    ])
   }
 }

--- a/Tests/SQLTests/ParserTests.swift
+++ b/Tests/SQLTests/ParserTests.swift
@@ -470,6 +470,144 @@ struct ExpressionTests {
   }
 }
 
+// MARK: - CREATE VIEW
+
+/// Parses `text` and returns its `(name, view)`, failing on any other shape.
+private func parseCreate(_ text: String) throws -> (String, View) {
+  guard case let .create(name, view) = try Statement(parsing: text) else {
+    Issue.record("expected a CREATE VIEW statement")
+    throw SQLError.incomplete(expected: "a CREATE VIEW statement")
+  }
+  return (name, view)
+}
+
+struct CreateViewTests {
+  @Test("infers a view's columns from a bare-column projection")
+  func inferred() throws {
+    let (name, view) = try parseCreate("CREATE VIEW v AS SELECT a, b FROM t")
+    #expect(name == "v")
+    #expect(view.columns == ["a", "b"])
+    #expect(view.query == .select(Select(projection: .columns(["a", "b"]),
+                                         from: Relation(name: "t"))))
+  }
+
+  @Test("drops a qualifier when inferring a column name")
+  func qualified() throws {
+    let (_, view) = try parseCreate("CREATE VIEW v AS SELECT t.a FROM t")
+    #expect(view.columns == ["a"])
+  }
+
+  @Test("takes an explicit column list over the projection")
+  func explicit() throws {
+    let (name, view) =
+        try parseCreate("CREATE VIEW v (x, y) AS SELECT a, b FROM t")
+    #expect(name == "v")
+    #expect(view.columns == ["x", "y"])
+  }
+
+  @Test("rejects an explicit list wider than the projection")
+  func tooWide() {
+    // (a, b) names two columns over a one-value projection — the view would
+    // claim a column its rows lack.
+    #expect(throws: SQLError.columns(expected: 1, got: 2)) {
+      _ = try Statement(parsing: "CREATE VIEW v (a, b) AS SELECT id FROM t")
+    }
+  }
+
+  @Test("rejects an explicit list narrower than the projection")
+  func tooNarrow() {
+    // (a) names one column over a two-value projection — the projected `name`
+    // would have no view column.
+    #expect(throws: SQLError.columns(expected: 2, got: 1)) {
+      _ = try Statement(parsing: "CREATE VIEW v (a) AS SELECT id, name FROM t")
+    }
+  }
+
+  @Test("accepts an explicit list matching the projection arity")
+  func matched() throws {
+    let (_, view) =
+        try parseCreate("CREATE VIEW v (a, b) AS SELECT id, name FROM t")
+    #expect(view.columns == ["a", "b"])
+  }
+
+  @Test("defers a SELECT * view's column-count check to the engine")
+  func starExplicit() throws {
+    // A `SELECT *` has no statically known arity, so the parser admits any
+    // explicit list; the engine validates it against the relation at
+    // resolution.
+    let (_, view) =
+        try parseCreate("CREATE VIEW v (a, b) AS SELECT * FROM t")
+    #expect(view.columns == ["a", "b"])
+  }
+
+  @Test("infers a column name from an expression's alias")
+  func aliased() throws {
+    let (_, view) =
+        try parseCreate("CREATE VIEW v AS SELECT guid(Id) AS iid FROM t")
+    #expect(view.columns == ["iid"])
+  }
+
+  @Test("infers a bare column's name in an expression projection")
+  func mixed() throws {
+    // A projection carrying any alias is the richer expressions form; a bare
+    // column in it still infers to its own name.
+    let (_, view) =
+        try parseCreate("CREATE VIEW v AS SELECT Name, guid(Id) AS iid FROM t")
+    #expect(view.columns == ["Name", "iid"])
+  }
+
+  @Test("parses lowercase CREATE VIEW keywords")
+  func caseInsensitive() throws {
+    let (name, view) =
+        try parseCreate("create view v as select a from t")
+    #expect(name == "v")
+    #expect(view.columns == ["a"])
+  }
+
+  @Test("rejects a SELECT * view with no explicit columns")
+  func star() {
+    #expect(throws: SQLError.self) {
+      _ = try Statement(parsing: "CREATE VIEW v AS SELECT * FROM t")
+    }
+  }
+
+  @Test("rejects an unaliased expression with no explicit columns")
+  func unnamed() {
+    #expect(throws: SQLError.self) {
+      _ = try Statement(parsing: "CREATE VIEW v AS SELECT guid(Id) FROM t")
+    }
+  }
+
+  @Test("rejects an explicit duplicate column name")
+  func duplicateExplicit() {
+    #expect(throws: SQLError.duplicate("x")) {
+      _ = try Statement(parsing: "CREATE VIEW v (x, x) AS SELECT a, b FROM t")
+    }
+  }
+
+  @Test("rejects a case-insensitive explicit duplicate column name")
+  func duplicateExplicitFolded() {
+    #expect(throws: SQLError.duplicate("x")) {
+      _ = try Statement(parsing: "CREATE VIEW v (X, x) AS SELECT a, b FROM t")
+    }
+  }
+
+  @Test("rejects an inferred duplicate column name")
+  func duplicateInferred() {
+    #expect(throws: SQLError.duplicate("Name")) {
+      _ = try Statement(
+          parsing: "CREATE VIEW v AS SELECT t.Name, u.Name FROM t "
+              + "JOIN u ON t.Id = u.Id")
+    }
+  }
+
+  @Test("accepts a distinct inferred column list")
+  func distinctInferred() throws {
+    let (_, view) = try parseCreate("CREATE VIEW v AS SELECT a, b FROM t")
+    #expect(view.columns == ["a", "b"])
+  }
+}
+
 // MARK: - UNION
 
 /// Parses `text` and returns its `Query`, failing on any other statement shape.
@@ -514,5 +652,18 @@ struct UnionTests {
     let left = Select(projection: .columns(["a"]), from: Relation(name: "t"))
     let right = Select(projection: .columns(["b"]), from: Relation(name: "u"))
     #expect(query == .union(.select(left), right, all: true))
+  }
+
+  @Test("a CREATE VIEW over a UNION stores the query and the first arm's names")
+  func view() throws {
+    let (name, view) = try parseCreate(
+        "CREATE VIEW v AS SELECT a, b FROM t UNION SELECT c, d FROM u")
+    let left = Select(projection: .columns(["a", "b"]),
+                      from: Relation(name: "t"))
+    let right = Select(projection: .columns(["c", "d"]),
+                       from: Relation(name: "u"))
+    #expect(name == "v")
+    #expect(view.columns == ["a", "b"])
+    #expect(view.query == .union(.select(left), right, all: false))
   }
 }

--- a/Tests/SQLTests/ParserTests.swift
+++ b/Tests/SQLTests/ParserTests.swift
@@ -4,10 +4,11 @@
 import Testing
 @testable import SQL
 
-/// Parses `text` and returns its `Select`, failing the test on any other shape.
+/// Parses `text` and returns its `Select`, failing the test on any other shape
+/// — a non-`SELECT` statement, or a `UNION` of several selects.
 private func parseSelect(_ text: String) throws -> Select {
-  guard case let .select(select) = try Statement(parsing: text) else {
-    Issue.record("expected a SELECT statement")
+  guard case let .select(.select(select)) = try Statement(parsing: text) else {
+    Issue.record("expected a single SELECT statement")
     throw SQLError.incomplete(expected: "a SELECT statement")
   }
   return select
@@ -466,5 +467,52 @@ struct ExpressionTests {
                 == .expressions([
                   Projected(expression: .call(name: "now", arguments: []))
                 ]))
+  }
+}
+
+// MARK: - UNION
+
+/// Parses `text` and returns its `Query`, failing on any other statement shape.
+private func parseQuery(_ text: String) throws -> Query {
+  guard case let .select(query) = try Statement(parsing: text) else {
+    Issue.record("expected a SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return query
+}
+
+struct UnionTests {
+  @Test("parses UNION into a deduplicating union of two selects")
+  func union() throws {
+    let query = try parseQuery("SELECT a FROM t UNION SELECT b FROM u")
+    let left = Select(projection: .columns(["a"]), from: Relation(name: "t"))
+    let right = Select(projection: .columns(["b"]), from: Relation(name: "u"))
+    #expect(query == .union(.select(left), right, all: false))
+  }
+
+  @Test("parses UNION ALL into a duplicate-keeping union")
+  func all() throws {
+    let query = try parseQuery("SELECT a FROM t UNION ALL SELECT b FROM u")
+    let left = Select(projection: .columns(["a"]), from: Relation(name: "t"))
+    let right = Select(projection: .columns(["b"]), from: Relation(name: "u"))
+    #expect(query == .union(.select(left), right, all: true))
+  }
+
+  @Test("nests a chain of UNIONs left-associatively in source order")
+  func chain() throws {
+    let query = try parseQuery(
+        "SELECT a FROM t UNION SELECT b FROM u UNION ALL SELECT c FROM v")
+    let a = Select(projection: .columns(["a"]), from: Relation(name: "t"))
+    let b = Select(projection: .columns(["b"]), from: Relation(name: "u"))
+    let c = Select(projection: .columns(["c"]), from: Relation(name: "v"))
+    #expect(query == .union(.union(.select(a), b, all: false), c, all: true))
+  }
+
+  @Test("recognises lowercase union and all keywords")
+  func caseInsensitive() throws {
+    let query = try parseQuery("select a from t union all select b from u")
+    let left = Select(projection: .columns(["a"]), from: Relation(name: "t"))
+    let right = Select(projection: .columns(["b"]), from: Relation(name: "u"))
+    #expect(query == .union(.select(left), right, all: true))
   }
 }


### PR DESCRIPTION
This pull request adds support for SQL `UNION` queries and `CREATE VIEW` statements, expanding the SQL dialect and execution engine. It introduces a new `Query` type to represent both single `SELECT` statements and left-associative `UNION` chains, updates the parser and AST to handle these constructs, and ensures that the engine compiles, optimizes, and executes them correctly. Error handling is enhanced to cover ambiguous view column names and mismatched `UNION` arm arities.

**SQL Syntax and Parsing Enhancements:**
- Added parsing and AST support for `UNION` and `UNION ALL` in queries, allowing chaining of multiple `SELECT` statements (`Query` type, parser changes, lexer and token updates). [[1]](diffhunk://#diff-44ae278469f8cb8537a5e8997ce917320e10f66a7fb199bcf35bc353ab154f08R20-R51) [[2]](diffhunk://#diff-3a41d2f1d12fb42c8cf94decbe20e627053820a0d629708ea2b1ec942a3c087fR248-R249) [[3]](diffhunk://#diff-6c11b53db7442865204eb0deb0f35640964bb2e9f54779311e62ae0b206f19d2L9-R12) [[4]](diffhunk://#diff-6c11b53db7442865204eb0deb0f35640964bb2e9f54779311e62ae0b206f19d2R51-R143) [[5]](diffhunk://#diff-6bee202b401e2acfe37621d278f23fdbf5efbea53383a92e7057b79b73efcfedR20-R21) [[6]](diffhunk://#diff-6bee202b401e2acfe37621d278f23fdbf5efbea53383a92e7057b79b73efcfedR37-R38) [[7]](diffhunk://#diff-6bee202b401e2acfe37621d278f23fdbf5efbea53383a92e7057b79b73efcfedR65-R66)
- Implemented parsing for `CREATE VIEW` statements, supporting optional explicit column lists and inferring column names from the first arm of the query. [[1]](diffhunk://#diff-6c11b53db7442865204eb0deb0f35640964bb2e9f54779311e62ae0b206f19d2L9-R12) [[2]](diffhunk://#diff-6c11b53db7442865204eb0deb0f35640964bb2e9f54779311e62ae0b206f19d2R51-R143)

**AST and Data Model Updates:**
- Introduced the `Query` enum to represent either a single `SELECT` or a left-associative `UNION` chain, and updated the `View` struct to store a `Query` instead of just a `Select`. [[1]](diffhunk://#diff-44ae278469f8cb8537a5e8997ce917320e10f66a7fb199bcf35bc353ab154f08R20-R51) [[2]](diffhunk://#diff-5e2790ab4729e595cad0e69349d0ab7aaef73c324a6a97c21588aab1ab1f017cL52-R73)
- Updated the `Statement` enum to include both `select(Query)` and `create(name:view:)` cases.

**Execution Engine and Operator Changes:**
- Extended the engine to compile, optimize, and execute `UNION` queries, ensuring all arms have matching column counts and handling deduplication for `UNION` vs. `UNION ALL`. [[1]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L21-R106) [[2]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060R401-R421) [[3]](diffhunk://#diff-90b051b6c59d5ca6612ebe0500cd6ccfecdec8f79c3c79167986ee4298fd0737R131-R135) [[4]](diffhunk://#diff-90b051b6c59d5ca6612ebe0500cd6ccfecdec8f79c3c79167986ee4298fd0737L143-R151) [[5]](diffhunk://#diff-90b051b6c59d5ca6612ebe0500cd6ccfecdec8f79c3c79167986ee4298fd0737R186-R213)
- Updated plan and slot calculation logic to support the new `union` operator.

**Error Handling Improvements:**
- Added new error cases for ambiguous or unnameable view columns (`.named`) and mismatched `UNION` arm arities (`.arity`), with descriptive messages. [[1]](diffhunk://#diff-fabb0e55432d1f4932fcc44ed65501e0499e9ae032e5559384617eff30049944R61-R68) [[2]](diffhunk://#diff-fabb0e55432d1f4932fcc44ed65501e0499e9ae032e5559384617eff30049944R96-R100)

**Documentation and Comments:**
- Updated grammar and code comments to reflect the new SQL constructs and clarify behavior for column name inference and error cases. [[1]](diffhunk://#diff-6c11b53db7442865204eb0deb0f35640964bb2e9f54779311e62ae0b206f19d2L9-R12) [[2]](diffhunk://#diff-9c710d8f0b00a639527009bcd7279118a251fa7e6bb1311ef84211d1c504bca2R13)

These changes collectively make the SQL engine more expressive and standards-compliant, supporting complex queries and reusable views.