### PR TITLE
winmd-inspect: query the metadata via an interactive shell or a SQL script

### DIFF
--- a/Sources/winmd-inspect/Query.swift
+++ b/Sources/winmd-inspect/Query.swift
@@ -1,31 +1,45 @@
 // Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
+internal import class Foundation.FileHandle
 internal import struct Foundation.Data
 
 internal import ArgumentParser
-internal import SQL
 internal import WinMD
 
-/// The `query` subcommand: run a SQL query against a metadata database.
+/// The `query` subcommand: run a SQL script against a metadata database, or —
+/// given no script — open an interactive SQL shell over it (the `Shell`).
 ///
-/// The parsed `SELECT` is handed to the database-agnostic `Engine`, which plans
-/// and executes it over the WinMD database adapted as a `SQL.Catalog`: a
-/// relation, a foreign-key join (`ON child.fk = parent.rowid`), or a list join
-/// (`ON child.parent = parent.rowid`). The engine yields typed `Value` records;
-/// this renders each as a tab-separated line. There is no bespoke predicate,
-/// planner, or join here — the engine owns all of it.
+/// A script argument is one or many `;`-separated statements streamed through
+/// `Statements(of:)` and run one at a time by `Shell.execute`: each `SELECT`
+/// prints its rows tab-separated and each `CREATE VIEW` is visible to later
+/// statements. With no argument, `query` opens the `sqlite3`-style shell, whose
+/// statements stream through `Statements(reading: readLine)` to end of input — a
+/// terminal drives it interactively, a pipe or redirect feeds it identically
+/// (`winmd-inspect query db < file` is the `sqlite3 db < file` analogue). No
+/// terminal detection: `readLine()` is cross-platform. Both are a literal
+/// `for`-in over the statement stream. The interactive/redirected path reports
+/// a statement's own error (`error: …`) to stderr and keeps reading, with only
+/// `.quit`'s `Shell.Stop` breaking the loop; the explicit-argument batch stays
+/// fail-fast, propagating a statement error (only `.quit`'s `Stop` is caught, to
+/// end cleanly).
 internal struct Query: ParsableCommand {
   internal static var configuration: CommandConfiguration {
     CommandConfiguration(commandName: "query",
-                         abstract: "Query the database with SQL.")
+                         abstract: "Query the database with SQL, or open a "
+                                 + "shell.")
   }
 
-  @Argument(help: "The SQL query to run against the database.")
-  internal var sql: String
-
+  // The database is the required positional and must be declared before the
+  // optional `sql`: ArgumentParser binds positionals in declaration order, so
+  // with `sql` first, `query db` would bind `db` to `sql` and report the
+  // database missing — making the omit-SQL shell form unreachable.
   @OptionGroup
   internal var options: InspectOptions
+
+  @Argument(help: ArgumentHelp("The SQL script to run; omit it to read one "
+                             + "from stdin or open an interactive shell."))
+  internal var sql: String?
 
   internal func run() throws {
     // The caller owns the mapping; it must outlive the database, which is a
@@ -34,34 +48,38 @@ internal struct Query: ParsableCommand {
                         options: .alwaysMapped)
     let database = try Database(data.span.bytes)
 
-    let statement = try Statement(parsing: sql)
-
-    // The engine plans and executes over the WinMD database adapted as a
-    // catalog, returning the projected, filtered, and ordered rows as typed
-    // values.
-    let rows = switch statement {
-    case let .select(query):
-      try Engine.run(query, database.storage)
-    case .create:
-      throw ValidationError("CREATE VIEW is not a query; the query "
-                            + "subcommand runs a single SELECT")
-    }
-    for row in rows {
-      print(row.map(Query.render).joined(separator: "\t"))
-    }
-  }
-
-  /// Renders a typed cell value to its display string: text verbatim, an
-  /// integer as its decimal spelling, a `NULL` as the empty string (the way
-  /// `sqlite3`'s list mode shows it).
-  private static func render(_ value: Value) -> String {
-    switch value {
-    case .null:
-      ""
-    case let .integer(integer):
-      "\(integer)"
-    case let .text(text):
-      text
+    // An argument runs as a `;`-separated batch; with none, the shell streams
+    // statements from stdin, which `readLine()` reads from a terminal and a
+    // pipe alike. Either way the iteration is a literal `for`-in over a
+    // `Statements` stream, and each statement runs through `Shell.attempt`,
+    // which applies the run's error policy: the batch (`strict`) propagates a
+    // statement error to fail fast, while the shell reports it and keeps
+    // reading. `.quit`'s `Shell.Stop` is caught either way to end cleanly. The
+    // policy lives in `attempt` so `.read` inherits it too.
+    let storage = database.storage
+    var shell = Shell(storage, strict: sql != nil)
+    if let sql {
+      do {
+        for statement in Statements(of: sql) { try shell.attempt(statement) }
+      } catch is Shell.Stop {}
+    } else {
+      note("winmd-inspect — .help for commands, .quit to leave")
+      for statement in Statements(reading: { readLine() }) {
+        do {
+          try shell.attempt(statement)
+        } catch is Shell.Stop {
+          break
+        }
+      }
     }
   }
+
+}
+
+/// Writes `message` and a newline to stderr — the shell's diagnostics (the
+/// interactive banner, a statement's `error: …`, a `.read` fault) kept off
+/// stdout so a piped run's TSV output stays clean. Shared by the `query` loop
+/// and `Shell.read` so every diagnostic lands on the same stream.
+internal func note(_ message: String) {
+  FileHandle.standardError.write(Data((message + "\n").utf8))
 }

--- a/Sources/winmd-inspect/Shell.swift
+++ b/Sources/winmd-inspect/Shell.swift
@@ -1,0 +1,362 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+internal import SQL
+internal import WinMD
+
+internal import class Foundation.FileHandle
+internal import struct Foundation.Data
+internal import struct Foundation.URL
+
+// MARK: - Metacommand
+
+/// A `.`-meta-command — one of the shell's verbs that is not a SQL statement.
+///
+/// A statement whose leading token begins with `.` is a meta-command;
+/// `Shell.execute` looks up the `Metacommand` type whose `spelling` matches that
+/// token and runs it against the shell. Each command is one self-contained type:
+/// the compiler enforces the `spelling`/`init`/`execute` trio, so adding a
+/// command later is a new conformer plus one line in `Shell.commands`. Anything
+/// that is not a `.`-statement is SQL.
+internal protocol Metacommand {
+  /// The leading token this command answers to, including the `.` — e.g.
+  /// `".read"`.
+  static var spelling: String { get }
+
+  /// Builds the command from `arguments`, the rest of the statement after the
+  /// spelling token.
+  init(_ arguments: Substring)
+
+  /// Runs the command against `shell`. A throw aborts the statement; `Quit`
+  /// throws the loop's stop sentinel.
+  func execute(against shell: inout Shell) throws
+}
+
+/// `.tables` — list the database's relations.
+internal struct Tables: Metacommand {
+  internal static let spelling = ".tables"
+
+  internal init(_ arguments: Substring) {}
+
+  internal func execute(against shell: inout Shell) throws {
+    let relations = shell.session.storage.relations
+    for index in 0 ..< relations.count { print("  \(relations[index])") }
+  }
+}
+
+/// `.help` — print the command summary.
+internal struct Help: Metacommand {
+  internal static let spelling = ".help"
+
+  internal init(_ arguments: Substring) {}
+
+  internal func execute(against shell: inout Shell) throws {
+    print(Shell.help)
+  }
+}
+
+/// `.quit` — leave the shell. `execute` throws `Shell.Stop`, the sentinel the
+/// loop catches to break.
+internal struct Quit: Metacommand {
+  internal static let spelling = ".quit"
+
+  internal init(_ arguments: Substring) {}
+
+  internal func execute(against shell: inout Shell) throws {
+    throw Shell.Stop()
+  }
+}
+
+/// `.read <path>` — run a file of `;`-separated SQL statements.
+internal struct Read: Metacommand {
+  internal static let spelling = ".read"
+
+  /// The file path, the rest of the statement after `.read`.
+  internal let path: String
+
+  internal init(_ arguments: Substring) {
+    path = arguments.trimmed
+  }
+
+  internal func execute(against shell: inout Shell) throws {
+    guard !path.isEmpty else { throw Shell.MetaError.unknown(Read.spelling) }
+    try shell.read(path)
+  }
+}
+
+// MARK: - Shell
+
+/// The interactive `query` shell — a `sqlite3`-style REPL — driving a `Session`.
+///
+/// `Shell` is a context-holding value, not a static namespace: it owns the
+/// mutable `session` (the catalog state) and is the single place execution
+/// lives. `execute(_:)` runs one yielded `Statements` element: a statement whose
+/// first token begins with `.` is a `Metacommand` looked up in `commands` and
+/// run; anything else is a SQL statement run through `Session.run` — a `CREATE
+/// VIEW` registers, a `SELECT` returns rows — whose rows the shell prints,
+/// without singling out `CREATE VIEW`. The streaming (`Statements`), the
+/// per-statement execution (`execute(_:)`), and the driving (the `for`-in in
+/// `Query.run` and `.read`) are three separate pieces — there is no loop
+/// abstraction. It is `~Escapable` because the `Session` it holds borrows the
+/// database's `Storage`.
+internal struct Shell: ~Escapable {
+  /// The shell's mutable catalog state.
+  internal var session: Session
+
+  /// Whether a statement fault ends the run (an explicit batch) or is reported
+  /// to stderr and skipped (the interactive/redirected shell). `.read` inherits
+  /// it through `attempt`, so an included script applies the same policy as its
+  /// text fed on stdin.
+  private let strict: Bool
+
+  /// Opens a shell over `storage`, starting from an empty session. `strict`
+  /// defaults to the forgiving shell policy; an explicit batch passes `true`.
+  @_lifetime(borrow storage)
+  internal init(_ storage: borrowing WinMD.Storage, strict: Bool = false) {
+    session = Session(storage, [:])
+    self.strict = strict
+  }
+
+  /// The registry of meta-commands — `execute(_:)` matches a leading `.`-token
+  /// against each type's `spelling`. Adding a command is one line here. It is
+  /// computed so the metatype array (not `Sendable`) is not a shared mutable
+  /// global.
+  private static var commands: Array<any Metacommand.Type> {
+    [Tables.self, Help.self, Quit.self, Read.self]
+  }
+
+  /// The command summary `.help` prints.
+  internal static let help = """
+    .tables           list the database's tables
+    .read <path>      run a file of `;`-separated SQL statements
+    .help             show this help
+    .quit             leave the shell
+    <sql>             run a SQL statement (trailing `;` optional)
+    """
+
+  /// The sentinel `Quit.execute` throws to stop the loop — caught by the
+  /// driving `for`-in, never surfaced to the user.
+  internal struct Stop: Error {}
+
+  /// A fault a meta-command raises.
+  internal enum MetaError: Error, Equatable {
+    /// An unrecognised or malformed `.`-command (the offending token).
+    case unknown(String)
+  }
+
+  // MARK: - Execute
+
+  /// Runs one yielded `statement` against the session.
+  ///
+  /// A statement whose leading token begins with `.` is a meta-command: the
+  /// matching `Metacommand` type is built from the rest of the statement and
+  /// run; an unknown `.`-token is a `MetaError.unknown`. Anything else is a SQL
+  /// statement, run through `Session.run` — a `CREATE VIEW` registers, a `SELECT`
+  /// yields rows — and its rows print tab-separated. The shell does not single
+  /// out `CREATE VIEW`: it just runs the statement and prints what comes back.
+  internal mutating func execute(_ statement: String) throws {
+    guard statement.first == "." else {
+      for row in try session.run(statement.statement) {
+        print(row.map(\.display).joined(separator: "\t"))
+      }
+      return
+    }
+    let spelling = statement.prefix { !$0.isWhitespace }
+    let arguments = statement.dropFirst(spelling.count)
+    guard let command =
+        Shell.commands.first(where: { $0.spelling == spelling })
+    else { throw MetaError.unknown(statement) }
+    try command.init(arguments).execute(against: &self)
+  }
+
+  /// Runs one statement under the run's error policy — the single place that
+  /// policy lives, so the top-level driver and `.read` cannot diverge. `.quit`'s
+  /// `Stop` always propagates (ending the session); any other fault propagates
+  /// when `strict` (an explicit batch aborts) and is otherwise reported to
+  /// stderr and swallowed so the driver reads on.
+  internal mutating func attempt(_ statement: String) throws {
+    do {
+      try execute(statement)
+    } catch let error where !(error is Stop) {
+      if strict { throw error }
+      note("error: \(error)")
+    }
+  }
+
+  /// Runs the `;`-separated SQL statements in the file at `path` — the `.read`
+  /// meta-command (the `sqlite3` analogue).
+  ///
+  /// Each statement runs through `attempt`, so the included file applies the
+  /// run's own policy: an explicit batch fails fast on the first fault, while
+  /// the interactive/redirected shell reports it and reads on — an included
+  /// script behaves exactly like its text fed on stdin. `.quit`'s `Stop`
+  /// propagates in both, ending the session. A missing or unreadable file
+  /// throws, which the caller's own `attempt` then treats the same way.
+  internal mutating func read(_ path: String) throws {
+    let data = try Data(contentsOf: URL(fileURLWithPath: path))
+    let text = String(decoding: data, as: UTF8.self)
+    for statement in Statements(of: text) { try attempt(statement) }
+  }
+}
+
+// MARK: - Statements
+
+/// The statement stream a `for`-in drives — the input's statements yielded one
+/// at a time from a line source.
+///
+/// `Statements` is a `Sequence` over a *line source* (a `() -> String?` — either
+/// `readLine` for stdin, or the lines of a `String` for the argument and
+/// `.read`). Its iterator reads lines and yields either a whole `.`-prefixed
+/// meta statement, or a SQL statement accumulated across lines until a
+/// terminating `;`. This is the `;`-accumulation the old loop did, lifted into
+/// an ordinary iterator so the driving is a literal `for`-in.
+internal struct Statements: Sequence {
+  /// The line source — `readLine` for stdin, or a closure over a string's
+  /// lines for the argument and `.read`.
+  private let lines: () -> String?
+
+  /// Streams statements read line-by-line from `lines`.
+  internal init(reading lines: @escaping () -> String?) {
+    self.lines = lines
+  }
+
+  /// Streams the statements of `text`, reading its lines.
+  internal init(of text: String) {
+    var lines = text.split(separator: "\n", omittingEmptySubsequences: false)
+                    .map(String.init)
+                    .makeIterator()
+    self.lines = { lines.next() }
+  }
+
+  internal func makeIterator() -> Iterator {
+    Iterator(lines)
+  }
+
+  /// The statement iterator — the `;`-accumulator over the line source.
+  internal struct Iterator: IteratorProtocol {
+    /// The line source the iterator pulls from.
+    private let lines: () -> String?
+
+    /// The SQL accumulated across lines, not yet closed by a `;`.
+    private var pending: String
+
+    internal init(_ lines: @escaping () -> String?) {
+      self.lines = lines
+      pending = ""
+    }
+
+    /// The next statement, or `nil` at end of input.
+    ///
+    /// A `.`-meta line (when no statement is pending) yields whole. Otherwise
+    /// lines accumulate until a `;` closes a statement, which yields; a trailing
+    /// unterminated statement yields at end of input — the closing `;` is
+    /// optional, so a one-shot query or a file without a final terminator runs
+    /// its last statement.
+    internal mutating func next() -> String? {
+      while true {
+        // Drain any completed statement already accumulated.
+        if let semicolon = Iterator.terminator(in: pending) {
+          let statement = String(pending[..<semicolon]).trimmed
+          pending = String(pending[pending.index(after: semicolon)...])
+          guard statement.isEmpty else { return statement }
+          continue
+        }
+        guard let line = lines() else {
+          // End of input: flush a final unterminated statement (the closing
+          // `;` is optional), then clear `pending` so the next call stops.
+          let statement = pending.trimmed
+          pending = ""
+          return statement.isEmpty ? nil : statement
+        }
+        // A `.`-meta line yields whole when no statement is pending — a
+        // whitespace-only spacer line before it is nothing, so drop it rather
+        // than gluing the meta line onto it.
+        if pending.trimmed.isEmpty, line.trimmed.first == "." {
+          pending = ""
+          return line.trimmed
+        }
+        pending += pending.isEmpty ? line : "\n" + line
+      }
+    }
+
+    /// The index in `text` of the first `;` that terminates a statement — one
+    /// outside a single-quoted string literal — or `nil` when there is none
+    /// (including when `text` trails off inside a literal whose closing quote
+    /// has not arrived yet). A `;` inside `'…'` is data, not a terminator, so
+    /// the split matches what the SQL lexer scans (`''` is an escaped quote).
+    private static func terminator(in text: String) -> String.Index? {
+      var index = text.startIndex
+      var quoted = false
+      while index < text.endIndex {
+        let character = text[index]
+        if quoted {
+          // A doubled `''` is an escaped quote: consume it and stay inside the
+          // literal. A lone `'` closes the literal.
+          if character == "'" {
+            let next = text.index(after: index)
+            if next < text.endIndex, text[next] == "'" {
+              index = next
+            } else {
+              quoted = false
+            }
+          }
+        } else if character == "'" {
+          quoted = true
+        } else if character == ";" {
+          return index
+        }
+        index = text.index(after: index)
+      }
+      return nil
+    }
+  }
+}
+
+// MARK: - Session
+
+extension Session {
+  /// Runs one SQL `statement` against the session, returning the rows a
+  /// `SELECT` yields — or none for a `CREATE VIEW`, which registers its `View`
+  /// (the key case-folded, the way the catalog resolves it) instead. `CREATE
+  /// VIEW` is an ordinary statement here, not a special case; the shell prints
+  /// whatever rows come back.
+  internal mutating func run(_ statement: String)
+      throws -> Array<Array<Value>> {
+    switch try Statement(parsing: statement) {
+    case let .create(name, view):
+      register(name, view)
+      return []
+    case let .select(query):
+      return try Engine.run(query, self)
+    }
+  }
+}
+
+// MARK: - Helpers
+
+extension StringProtocol {
+  /// This text with leading and trailing whitespace removed — a stdlib-only
+  /// trim (no Foundation `CharacterSet`).
+  internal var trimmed: String {
+    String(drop { $0.isWhitespace }.reversed()
+               .drop { $0.isWhitespace }.reversed())
+  }
+
+  /// This statement with a single trailing `;` removed — the trailing `;` a
+  /// query statement may carry is optional.
+  internal var statement: String {
+    hasSuffix(";") ? String(dropLast()) : String(self)
+  }
+}
+
+extension Value {
+  /// This typed cell's display string — a `NULL` as the empty string, the way
+  /// `sqlite3`'s list mode shows it.
+  internal var display: String {
+    switch self {
+    case .null:                 ""
+    case let .integer(integer): "\(integer)"
+    case let .text(text):       text
+    }
+  }
+}

--- a/Tests/winmd-inspectTests/DatabaseSQLTests.swift
+++ b/Tests/winmd-inspectTests/DatabaseSQLTests.swift
@@ -8,6 +8,12 @@ import Testing
 import SQL
 @testable import WinMD
 
+import struct Foundation.Data
+import struct Foundation.URL
+import class Foundation.FileManager
+import struct Foundation.UUID
+import func Foundation.NSTemporaryDirectory
+
 /// Coverage of the per-table decoded virtual columns the WinMD → SQL adapter
 /// exposes: `guid` on `CustomAttribute`, `ReturnType` on `MethodDef`, and
 /// `ParamType` on `Param`. Rather than map a `.winmd` file, the tests assemble a
@@ -344,6 +350,113 @@ struct DatabaseSQLTests {
         [.text("IMyInterface"),
          .text("0C733A30-2A1C-11CE-ADE5-00AA0044773D")],
       ])
+    }
+  }
+
+  @Test("a script's CREATE VIEW is visible to a later statement's SELECT")
+  func scriptSession() throws {
+    // The batch driver threads one shared `Session` across every statement, so a
+    // `CREATE VIEW` registered by one statement is visible to a later `SELECT`.
+    // `execute` prints rather than returning rows, so this drives the shared
+    // statement path directly — `Shell.execute` over the same session — to
+    // register the view (the `CREATE VIEW` branch), then resolves a `SELECT`
+    // naming it through the session's views, the exact session state the batch
+    // threads.
+    try DatabaseSQLTests.with { catalog in
+      var shell = Shell(catalog)
+      try shell.execute("CREATE VIEW names AS SELECT TypeName FROM TypeDef")
+      #expect(shell.session.views.keys.contains("names"))
+      let rows = try DatabaseSQLTests.run(
+          "SELECT TypeName FROM names", shell.session.views, catalog)
+      #expect(rows == [[.text("IMyInterface")], [.text("INotGuid")]])
+    }
+  }
+
+  @Test("execute routes a `.`-token to its meta-command")
+  func executeMeta() throws {
+    // The leading-token dispatch matches `.tables` to `Tables`, which lists the
+    // storage's relations; the fixture's catalog vends them, so `execute`
+    // succeeds. A SQL statement takes the parse path instead — exercised by
+    // `scriptSession` — and `.quit` throws the loop's `Stop` sentinel.
+    try DatabaseSQLTests.with { catalog in
+      var shell = Shell(catalog)
+      try shell.execute(".tables")
+      #expect(throws: Shell.Stop.self) { try shell.execute(".quit") }
+    }
+  }
+
+  @Test("execute rejects an unknown or empty-argument `.`-command")
+  func executeUnknown() {
+    // An unrecognised `.`-token is `MetaError.unknown`, and a `.read` with no
+    // path executes to the same unknown fault — the empty-argument guard the
+    // `Read` command carries.
+    DatabaseSQLTests.with { catalog in
+      var shell = Shell(catalog)
+      #expect(throws: Shell.MetaError.unknown(".bogus")) {
+        try shell.execute(".bogus")
+      }
+      #expect(throws: Shell.MetaError.unknown(".read")) {
+        try shell.execute(".read")
+      }
+    }
+  }
+
+  @Test("a `.quit` inside a `.read` file leaves the shell, not just the file")
+  func readPropagatesQuit() throws {
+    // `.read` drives the same statement stream, but a `.quit` in the file must
+    // throw `Stop` past the file reader so the whole session ends — the help's
+    // promise — not merely the included file. The statement after the `.quit`
+    // never runs; that the read throws `Stop` is the observable evidence.
+    let path = NSTemporaryDirectory()
+             + "winmd-inspect-\(UUID().uuidString).sql"
+    try Data(".quit\nSELECT TypeName FROM TypeDef;\n".utf8)
+        .write(to: URL(fileURLWithPath: path))
+    defer { try? FileManager.default.removeItem(atPath: path) }
+    DatabaseSQLTests.with { catalog in
+      var shell = Shell(catalog)
+      #expect(throws: Shell.Stop.self) {
+        try shell.execute(".read \(path)")
+      }
+    }
+  }
+
+  @Test("a `.read` fault fails an explicit batch fast")
+  func readFailsFastInBatch() throws {
+    // A `strict` shell (an explicit batch) lets an included file's fault
+    // propagate, so the run aborts rather than pressing on against a partially
+    // applied session. The bad `SELECT` is the file's only statement here; that
+    // `.read` throws is the evidence the batch would fail.
+    let path = NSTemporaryDirectory()
+             + "winmd-inspect-\(UUID().uuidString).sql"
+    try Data("SELECT Name FROM NoSuchTable;\n".utf8)
+        .write(to: URL(fileURLWithPath: path))
+    defer { try? FileManager.default.removeItem(atPath: path) }
+    DatabaseSQLTests.with { catalog in
+      var shell = Shell(catalog, strict: true)
+      #expect(throws: (any Error).self) {
+        try shell.execute(".read \(path)")
+      }
+    }
+  }
+
+  @Test("a `.read` fault is reported and skipped in shell mode")
+  func readContinuesInShell() throws {
+    // A forgiving shell (the interactive/redirected path) reports a statement's
+    // fault and reads on, so an included file behaves like its text on stdin: a
+    // bad statement does not skip the file's later valid ones. `.read` must not
+    // throw here, and the CREATE VIEW after the bad SELECT must still register.
+    let path = NSTemporaryDirectory()
+             + "winmd-inspect-\(UUID().uuidString).sql"
+    try Data("""
+      SELECT Name FROM NoSuchTable;
+      CREATE VIEW ok AS SELECT TypeName FROM TypeDef;
+
+      """.utf8).write(to: URL(fileURLWithPath: path))
+    defer { try? FileManager.default.removeItem(atPath: path) }
+    DatabaseSQLTests.with { catalog in
+      var shell = Shell(catalog)
+      #expect(throws: Never.self) { try shell.execute(".read \(path)") }
+      #expect(shell.session.views.keys.contains("ok"))
     }
   }
 

--- a/Tests/winmd-inspectTests/QueryTests.swift
+++ b/Tests/winmd-inspectTests/QueryTests.swift
@@ -1,0 +1,27 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+
+internal import ArgumentParser
+
+@testable import winmd_inspect
+
+struct QueryTests {
+  @Test("the database is the first positional; SQL is optional and follows it")
+  func optionalSQLFollowsDatabase() throws {
+    // `query <db>` with no SQL must bind `db` to the database and leave `sql`
+    // nil — the stdin/shell form. Were `sql` declared first, ArgumentParser
+    // would bind `db` to `sql` and report the database missing, so this parse
+    // would throw. The database is parsed as a path; no file need exist.
+    let shell = try Query.parse(["fixture.winmd"])
+    #expect(shell.sql == nil)
+    #expect(shell.options.database.url.lastPathComponent == "fixture.winmd")
+
+    // With a SQL argument, the database still binds first and `sql` takes the
+    // second positional.
+    let scripted = try Query.parse(["fixture.winmd", "SELECT 1"])
+    #expect(scripted.sql == "SELECT 1")
+    #expect(scripted.options.database.url.lastPathComponent == "fixture.winmd")
+  }
+}

--- a/Tests/winmd-inspectTests/ShellTests.swift
+++ b/Tests/winmd-inspectTests/ShellTests.swift
@@ -1,0 +1,108 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+
+@testable import winmd_inspect
+
+import SQL
+
+struct ShellTests {
+  @Test("each meta-command answers to its `.`-prefixed spelling")
+  func spellings() {
+    // The leading-token dispatch matches a `.`-token against each `Metacommand`
+    // type's `spelling`; these are the tokens `execute` routes on.
+    #expect(Tables.spelling == ".tables")
+    #expect(Help.spelling == ".help")
+    #expect(Quit.spelling == ".quit")
+    #expect(Read.spelling == ".read")
+  }
+
+  @Test("`.read` parses its trailing path, trimming surrounding whitespace")
+  func read() {
+    // `Read.init` takes the rest of the statement after the spelling token and
+    // trims it to the path; the stream has already split off `.read`.
+    #expect(Read(" foo.sql").path == "foo.sql")
+    #expect(Read("  spaced.sql ").path == "spaced.sql")
+    // No argument leaves an empty path — `execute` rejects it as unknown.
+    #expect(Read("").path.isEmpty)
+  }
+
+  @Test("a `;`-separated script streams into trimmed, non-empty statements")
+  func stream() {
+    // The `Statements` stream is the load-bearing part of a batch run: trailing
+    // `;`, whitespace, and blank statements (a `;;`) are dropped, each statement
+    // trimmed, and a `.`-meta line yields whole.
+    let script = """
+      CREATE VIEW a AS SELECT 1;
+        SELECT 2 ;
+      ;
+      .tables
+      """
+    #expect(Array(Statements(of: script))
+            == ["CREATE VIEW a AS SELECT 1", "SELECT 2", ".tables"])
+    #expect(Array(Statements(of: "")).isEmpty)
+    #expect(Array(Statements(of: "   \n  ")).isEmpty)
+  }
+
+  @Test("the statement stream accumulates a SQL statement across lines")
+  func streamMultiline() {
+    // A SQL statement may span lines, accumulating until a `;` closes it; an
+    // unterminated trailing statement still yields at end of input — the
+    // closing `;` is optional, so a one-shot query keeps its last statement.
+    let script = """
+      SELECT 1,
+             2;
+      SELECT 3
+      """
+    #expect(Array(Statements(of: script))
+            == ["SELECT 1,\n       2", "SELECT 3"])
+  }
+
+  @Test("a `;` inside a string literal does not terminate the statement")
+  func streamStringLiteral() {
+    // The splitter must not cut a statement at a `;` that lives inside a
+    // single-quoted literal — that `;` is data the SQL lexer scans, not a
+    // terminator. A doubled `''` is an escaped quote, so it stays in the
+    // literal; the run keeps streaming across an unterminated literal until it
+    // closes. Otherwise the splitter rejects queries the parser handles.
+    #expect(Array(Statements(of: "SELECT ';' AS s FROM TypeDef;"))
+            == ["SELECT ';' AS s FROM TypeDef"])
+    #expect(Array(Statements(of: "SELECT ';a' AS a; SELECT 2;"))
+            == ["SELECT ';a' AS a", "SELECT 2"])
+    #expect(Array(Statements(of: "SELECT 'a;''b;' AS s;"))
+            == ["SELECT 'a;''b;' AS s"])
+    #expect(Array(Statements(of: "SELECT 'x;\n y;' AS s;"))
+            == ["SELECT 'x;\n y;' AS s"])
+  }
+
+  @Test("a whitespace-only spacer line before a `.`-command is dropped")
+  func streamSpacerBeforeMeta() {
+    // A blank line carrying spaces before a meta-command must not glue onto it:
+    // a whitespace-only `pending` counts as nothing, so the `.`-line still
+    // yields whole and a following statement stays a separate statement —
+    // otherwise the meta-command swallows the SQL as its arguments.
+    #expect(Array(Statements(of: "SELECT 1;\n   \n.tables\nSELECT 2;"))
+            == ["SELECT 1", ".tables", "SELECT 2"])
+  }
+
+  @Test("a streamed CREATE VIEW statement parses and registers a view")
+  func register() throws {
+    // A batch run runs each streamed statement through `execute`, whose `CREATE
+    // VIEW` branch parses and registers it. A `Database` (a full PE image) is
+    // awkward to assemble in memory — the WinMD fixtures all work over
+    // `Storage`, not `Database` — so the end-to-end file run is not exercised
+    // here. The file IO + stream is covered by `stream`, and this asserts a
+    // statement a batch would yield parses to a `CREATE VIEW` and registers,
+    // the exact work `execute` performs for that branch.
+    var views = Dictionary<String, View>()
+    for sql in Statements(of: "CREATE VIEW v AS SELECT TypeName FROM TypeDef;") {
+      guard case let .create(name, view) = try Statement(parsing: sql) else {
+        Issue.record("not a CREATE VIEW")
+        return
+      }
+      views[name.lowercased()] = view
+    }
+    #expect(views.keys.contains("v"))
+  }
+}


### PR DESCRIPTION
This pull request introduces a new interactive SQL shell to the `winmd-inspect` tool, significantly enhancing its usability by adding a `sqlite3`-style REPL and support for SQL script execution, including meta-commands (like `.tables`, `.read`, `.help`, and `.quit`). The implementation is modular, separating shell logic, statement streaming, and session management. Comprehensive tests are added to ensure correct shell and meta-command behavior.

**Shell and Meta-command Implementation:**
- Added a new `Shell.swift` module implementing an interactive SQL shell with support for meta-commands (`.tables`, `.read`, `.help`, `.quit`), script execution, and multi-statement batches. The shell streams statements from either a script or stdin, dispatching meta-commands and SQL statements appropriately.

**Enhancements to Query Command:**
- Refactored the `Query` command to support both batch SQL script execution and interactive shell mode, replacing the previous single-statement execution. The command now streams and executes statements, handles shell lifecycle, and prints an interactive banner to stderr. [[1]](diffhunk://#diff-18faad7c0e5648c6a8354dd72204a68cb674d3a7ec5a7fde805a3c6d7b5350c4R4-R32) [[2]](diffhunk://#diff-18faad7c0e5648c6a8354dd72204a68cb674d3a7ec5a7fde805a3c6d7b5350c4L37-R67)

**Testing:**
- Added a new `ShellTests.swift` file to test meta-command spellings, `.read` argument parsing, statement streaming (including multi-line and trimmed statements), and view registration.
- Added new tests to `DatabaseSQLTests.swift` to verify session state across scripts, meta-command dispatch, and error handling for unknown or malformed meta-commands.

These changes collectively provide a robust, scriptable, and interactive SQL environment for inspecting WinMD databases, closely mirroring the behavior of `sqlite3`.