### PR TITLE
winmd-inspect: bundle the COM-interface views and render them via Mustache

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# The bundled synthesis resources are read verbatim — the Mustache template's
+# line endings flow straight into the generated source, and the render tests
+# assert that output byte-for-byte. Force LF on checkout so a Windows working
+# copy does not convert them to CRLF (which diverges the rendered output from
+# the LF the tests, and the toolchain, expect). Swift sources and docs follow
+# for consistency.
+*.swift    text eol=lf
+*.sql      text eol=lf
+*.mustache text eol=lf
+*.lang     text eol=lf
+*.md       text eol=lf

--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,8 @@ let _ =
             dependencies: [
               .package(url: "https://github.com/apple/swift-argument-parser",
                        from: "1.5.0"),
+              .package(url: "https://github.com/hummingbird-project/swift-mustache",
+                       from: "2.0.0"),
             ],
             targets: [
               .target(name: "CPE", dependencies: []),
@@ -58,9 +60,16 @@ let _ =
                                   "WinMDSynthesis",
                                   .product(name: "ArgumentParser",
                                            package: "swift-argument-parser"),
+                                  .product(name: "Mustache",
+                                           package: "swift-mustache"),
+                                ],
+                                resources: [
+                                  .copy("Resources"),
                                 ],
                                 swiftSettings: [
                                   .enableExperimentalFeature("Lifetimes"),
+                                  .enableUpcomingFeature(
+                                      "InternalImportsByDefault"),
                                 ]),
               .testTarget(name: "winmd-inspectTests",
                           dependencies: [

--- a/Sources/WinMDSynthesis/Decode.swift
+++ b/Sources/WinMDSynthesis/Decode.swift
@@ -3,44 +3,121 @@
 
 import WinMD
 
-/// The per-dialect decode functions, emitting the Swift type spelling as text.
+/// The target-specific strings the decode composes a type spelling from.
+///
+/// The composition ALGORITHM — how a pointer wraps its pointee, how a generic
+/// reads `Base<Args…>`, how a `const` void-pointer collapses to a raw pointer —
+/// is language-neutral and lives in the decode functions; only the literal
+/// spellings those functions emit are target-specific. `Dialect` carries every
+/// such string, so the same algorithm retargets to another language by handing
+/// it a different `Dialect` (built, in the tool, from the loaded language spec).
+///
+/// A `nil` primitive spelling falls back to the primitive's neutral name, so an
+/// incomplete dialect still decodes without trapping.
+public struct Dialect: Sendable {
+  /// The primitive leaf spellings, keyed by neutral name (`void`, `i4`,
+  /// `string`, …). A missing key falls back to the neutral name itself.
+  public let primitives: Dictionary<String, String>
+
+  /// The pointer spellings: the `typed` prefixes (`UnsafeMutablePointer`/
+  /// `UnsafePointer`) a non-`void` pointee wraps into, and the `untyped`
+  /// spellings (`UnsafeMutableRawPointer`/`UnsafeRawPointer`) a `void` pointer
+  /// collapses to — each in a mutable and a `const` form.
+  public let pointer: (typed: (mutable: String, constant: String),
+                       untyped: (mutable: String, constant: String))
+
+  /// The optional marker (`?`) an inner pointer slot carries.
+  public let optional: String
+
+  /// The generic delimiters (`<`/`>`).
+  public let generic: (open: String, close: String)
+
+  /// The `VAR`/`MVAR` generic-parameter scope prefixes (`T`/`M`).
+  public let variable: (type: String, method: String)
+
+  /// The spelling an unresolvable named type (and a function pointer) degrades
+  /// to (`UnsafeMutableRawPointer`).
+  public let opaque: String
+
+  /// The `System.Guid` classification names — an `iid`, or a `clsid` for a
+  /// `clsid`/`classid`-rooted parameter name.
+  public let guid: (iid: String, clsid: String)
+
+  /// The projection of a resolved CLR `Identity` to the target's own spelling
+  /// (`Windows.Win32.Foundation.HRESULT` → `HRESULT`, …).
+  public let known: Dictionary<Identity, String>
+
+  /// Escapes a spelled identifier that collides with a target keyword — the same
+  /// rule the render's `ESCAPE` applies to declaration names, applied here to a
+  /// named type's simple name so a `protocol`/`repeat`-named type spells
+  /// compilably. A non-keyword identifier returns unchanged.
+  public let escape: @Sendable (String) -> String
+
+  public init(primitives: Dictionary<String, String>,
+              pointer: (typed: (mutable: String, constant: String),
+                        untyped: (mutable: String, constant: String)),
+              optional: String,
+              generic: (open: String, close: String),
+              variable: (type: String, method: String),
+              opaque: String,
+              guid: (iid: String, clsid: String),
+              known: Dictionary<Identity, String>,
+              escape: @escaping @Sendable (String) -> String) {
+    self.primitives = primitives
+    self.pointer = pointer
+    self.optional = optional
+    self.generic = generic
+    self.variable = variable
+    self.opaque = opaque
+    self.guid = guid
+    self.known = known
+    self.escape = escape
+  }
+}
+
+/// The per-dialect decode functions, emitting a target type spelling as text.
 ///
 /// The views + templates path renders text, so the type mapping is a pure
-/// function from a decoded `SignatureType` to its Swift spelling — ABI-faithful
-/// rules serving as the synthesis oracle. A named type resolves through the
-/// injected `Resolver`
-/// table (the metaschema's component-schema mapping) and a well-known table to
-/// the `COM` module's spelling; `System.Guid` decodes to `IID`/`CLSID` by a
-/// parameter-name hint; pointers, references, and arrays decode to the
-/// `Unsafe*Pointer` family; the primitives to the `C*` typealias set. This is
-/// the decode-function tier: a registered closure per primitive, composed
-/// declaratively by the type structure.
+/// function from a decoded `SignatureType` (and a `Dialect`) to its spelling —
+/// ABI-faithful rules serving as the synthesis oracle. A named type resolves
+/// through the injected `Resolver` table (the metaschema's component-schema
+/// mapping) and the dialect's well-known table to the target module's spelling;
+/// `System.Guid` decodes to `IID`/`CLSID` by a parameter-name hint; pointers,
+/// references, and arrays decode to the pointer family; the primitives to the
+/// dialect's leaf table. This is the decode-function tier: the type structure
+/// composes the dialect's strings declaratively.
 extension SignatureType {
-  /// The Swift type spelling of `self`, resolving named types through
+  /// The type spelling of `self` in `dialect`, resolving named types through
   /// `resolver` and disambiguating a `System.Guid` by the `parameter`-name hint.
-  public func decode(parameter: String? = nil,
-                     with resolver: Resolver) -> String {
+  public func decode(parameter: String? = nil, with resolver: Resolver,
+                     dialect: Dialect) -> String {
     switch self {
     case let .primitive(primitive):
-      primitive.spelling
+      primitive.spelling(dialect)
     case let .pointer(pointee):
-      pointee.spelling(parameter: parameter, const: false, with: resolver)
+      pointee.spelling(parameter: parameter, const: false, with: resolver,
+                       dialect: dialect)
     case let .reference(referent):
-      referent.spelling(parameter: parameter, const: false, with: resolver)
+      referent.spelling(parameter: parameter, const: false, with: resolver,
+                        dialect: dialect)
     case let .array(element):
-      element.spelling(parameter: parameter, const: false, with: resolver)
+      element.spelling(parameter: parameter, const: false, with: resolver,
+                       dialect: dialect)
     case let .matrix(element, _):
-      element.spelling(parameter: parameter, const: false, with: resolver)
+      element.spelling(parameter: parameter, const: false, with: resolver,
+                       dialect: dialect)
     case let .named(kind, reference):
-      reference.spelling(kind: kind, parameter: parameter, with: resolver)
+      reference.spelling(kind: kind, parameter: parameter, with: resolver,
+                         dialect: dialect)
     case let .variable(scope, index):
-      "\(scope.prefix)\(index)"
+      "\(scope.prefix(dialect))\(index)"
     case let .instance(base, arguments):
-      base.specialized(by: arguments, parameter: parameter, with: resolver)
+      base.specialized(by: arguments, parameter: parameter, with: resolver,
+                       dialect: dialect)
     case let .modified(inner, _):
-      inner.decode(parameter: parameter, with: resolver)
+      inner.decode(parameter: parameter, with: resolver, dialect: dialect)
     case .function:
-      "UnsafeMutableRawPointer"
+      dialect.opaque
     }
   }
 }
@@ -48,33 +125,39 @@ extension SignatureType {
 // MARK: - Primitives
 
 extension PrimitiveType {
-  /// The Swift spelling of a built-in element type: the `C*` typealiases, the
-  /// opaque pointer for `object`/`typedref`, and the WinRT `HSTRING` for
-  /// `System.String` (`ELEMENT_TYPE_STRING`) — a WinMD `String` is an `HSTRING`
-  /// handle at the ABI, not a `PCWSTR` buffer. `PWSTR`/`PCWSTR` arrive as
-  /// pointer/named metadata, never `ELEMENT_TYPE_STRING`, so they decode through
-  /// those paths instead.
-  fileprivate var spelling: String {
+  /// The neutral dialect key of a built-in element type — the key the dialect's
+  /// primitive table maps to a spelling.
+  ///
+  /// `ELEMENT_TYPE_STRING` is the WinRT `String` — an `HSTRING` handle, not a
+  /// `PCWSTR` buffer (which arrives as pointer/named metadata, never
+  /// `ELEMENT_TYPE_STRING`, so it decodes through those paths instead).
+  fileprivate var key: String {
     switch self {
-    case .void:     "Void"
-    case .boolean:  "CBool"
-    case .char:     "Unicode.UTF16.CodeUnit"
-    case .int1:     "CChar"
-    case .uint1:    "CUnsignedChar"
-    case .int2:     "CShort"
-    case .uint2:    "CUnsignedShort"
-    case .int4:     "CInt"
-    case .uint4:    "CUnsignedInt"
-    case .int8:     "CLongLong"
-    case .uint8:    "CUnsignedLongLong"
-    case .float:    "CFloat"
-    case .double:   "CDouble"
-    case .intptr:   "Int"
-    case .uintptr:  "UInt"
-    case .string:   "HSTRING"
-    case .object:   "UnsafeMutableRawPointer"
-    case .typedref: "UnsafeMutableRawPointer"
+    case .void:     "void"
+    case .boolean:  "bool"
+    case .char:     "char"
+    case .int1:     "i1"
+    case .uint1:    "u1"
+    case .int2:     "i2"
+    case .uint2:    "u2"
+    case .int4:     "i4"
+    case .uint4:    "u4"
+    case .int8:     "i8"
+    case .uint8:    "u8"
+    case .float:    "f4"
+    case .double:   "f8"
+    case .intptr:   "iptr"
+    case .uintptr:  "uptr"
+    case .string:   "string"
+    case .object:   "object"
+    case .typedref: "typedref"
     }
+  }
+
+  /// The `dialect` spelling of a built-in element type — its primitive-table
+  /// entry, or (absent one) the neutral key as a fallback.
+  fileprivate func spelling(_ dialect: Dialect) -> String {
+    dialect.primitives[key] ?? key
   }
 }
 
@@ -84,7 +167,7 @@ extension SignatureType {
   /// Decodes a pointer/reference/array to a pointer over its decoded pointee,
   /// where `self` is the pointee.
   ///
-  /// `void*` collapses to `UnsafeMutableRawPointer` (or `UnsafeRawPointer` when
+  /// `void*` collapses to the mutable raw pointer (or the const raw pointer when
   /// `const`). A pointer-to-pointer keeps an *optional* inner element so a
   /// caller can pass a null inner slot: a `void**` (including `const void **`)
   /// is a pointer to an optional raw pointer (immutable when the inner `void`
@@ -92,33 +175,42 @@ extension SignatureType {
   /// Otherwise a non-`void` pointee decodes as `Unsafe{Mutable}Pointer<Pointee>`,
   /// mutable unless a `const` modifier marks the pointee.
   fileprivate func spelling(parameter: String?, const: Bool,
-                            with resolver: Resolver) -> String {
+                            with resolver: Resolver,
+                            dialect: Dialect) -> String {
     switch self {
     case .primitive(.void):
-      const ? "UnsafeRawPointer" : "UnsafeMutableRawPointer"
+      const ? dialect.pointer.untyped.constant : dialect.pointer.untyped.mutable
     case .pointer(.primitive(.void)):
-      wrap("UnsafeMutableRawPointer?", const: const)
+      wrap(dialect.pointer.untyped.mutable + dialect.optional, const: const,
+           dialect: dialect)
     case let .pointer(.modified(.primitive(.void), modifiers)):
-      wrap(modifiers.constant(with: resolver) ? "UnsafeRawPointer?"
-                                              : "UnsafeMutableRawPointer?",
-           const: const)
+      wrap((modifiers.constant(with: resolver)
+              ? dialect.pointer.untyped.constant
+              : dialect.pointer.untyped.mutable) + dialect.optional,
+           const: const, dialect: dialect)
     case .pointer:
       // A non-`void` pointer-to-pointer: the inner pointer slot is itself
       // nullable, so mark the decoded element optional (as the `void**` cases).
-      wrap(decode(parameter: parameter, with: resolver) + "?", const: const)
+      wrap(decode(parameter: parameter, with: resolver, dialect: dialect)
+               + dialect.optional,
+           const: const, dialect: dialect)
     case let .modified(inner, modifiers):
       inner.spelling(parameter: parameter,
                      const: modifiers.constant(with: resolver),
-                     with: resolver)
+                     with: resolver, dialect: dialect)
     default:
-      wrap(decode(parameter: parameter, with: resolver), const: const)
+      wrap(decode(parameter: parameter, with: resolver, dialect: dialect),
+           const: const, dialect: dialect)
     }
   }
 }
 
-/// Wraps an already-decoded `pointee` spelling in `Unsafe{Mutable}Pointer<…>`.
-private func wrap(_ pointee: String, const: Bool) -> String {
-  "\(const ? "UnsafePointer" : "UnsafeMutablePointer")<\(pointee)>"
+/// Wraps an already-decoded `pointee` spelling in the dialect's typed-pointer
+/// family (`Unsafe{Mutable}Pointer<…>`).
+private func wrap(_ pointee: String, const: Bool, dialect: Dialect) -> String {
+  let prefix = const ? dialect.pointer.typed.constant
+                     : dialect.pointer.typed.mutable
+  return "\(prefix)\(dialect.generic.open)\(pointee)\(dialect.generic.close)"
 }
 
 extension Array where Element == Modifier {
@@ -135,58 +227,50 @@ extension Array where Element == Modifier {
 }
 
 /// The `System.Runtime.CompilerServices.IsConst` modopt a `const` pointee
-/// carries — the sole custom modifier the decode treats as `const`.
+/// carries — the sole custom modifier the decode treats as `const`. This is an
+/// ABI marker, not a target spelling, so it stays fixed across dialects.
 private let kIsConst =
     Identity(namespace: "System.Runtime.CompilerServices", name: "IsConst")
 
 // MARK: - Named types
 
 extension TypeDefOrRef {
-  /// The Swift spelling of the named type `self` references, resolved through
-  /// `resolver` and the well-known table.
+  /// The `dialect` spelling of the named type `self` references, resolved
+  /// through `resolver` and the dialect's well-known table.
   ///
   /// A resolved `System.Guid` renders as `IID`/`CLSID` by the parameter-name
   /// hint; otherwise the `Identity` is looked up in the well-known table
   /// (`HRESULT`, `BOOL`, …), a miss rendering the type's own simple name. An
-  /// unresolvable reference renders an opaque pointer.
+  /// unresolvable reference renders the dialect's opaque pointer.
   fileprivate func spelling(kind: NamedKind, parameter: String?,
-                            with resolver: Resolver) -> String {
+                            with resolver: Resolver,
+                            dialect: Dialect) -> String {
     guard let identity = resolver.resolve(self, kind: kind) else {
-      return kOpaque
+      return dialect.opaque
     }
     if identity == kGuid {
-      return classification(parameter)
+      return classification(parameter, dialect: dialect)
     }
-    return kWellKnown[identity] ?? identity.name
+    // A named type's simple name is a bare identifier that may collide with a
+    // target keyword (`protocol`, `repeat`); escape it as the render escapes a
+    // declaration name. A well-known spelling is curated and never a keyword.
+    return dialect.known[identity] ?? dialect.escape(identity.name)
   }
 }
-
-/// The opaque pointer an unresolvable type degrades to — and that a generic
-/// over such a base degrades to, rather than emit a meaningless
-/// `UnsafeMutableRawPointer<…>`.
-private let kOpaque = "UnsafeMutableRawPointer"
 
 /// The `System.Guid` identity that decodes to `IID`/`CLSID`.
 private let kGuid = Identity(namespace: "System", name: "Guid")
 
-/// Classifies a `System.Guid` parameter as `IID` or `CLSID` by its name: a
-/// `clsid`/`classid`-rooted name is a `CLSID`, everything else an `IID`; the
-/// default, absent a hint, is `IID`.
-private func classification(_ parameter: String?) -> String {
-  guard let parameter else { return "IID" }
+/// Classifies a `System.Guid` parameter as the dialect's `CLSID`/`IID` by its
+/// name: a `clsid`/`classid`-rooted name is a `CLSID`, everything else an `IID`;
+/// the default, absent a hint, is `IID`.
+private func classification(_ parameter: String?, dialect: Dialect) -> String {
+  guard let parameter else { return dialect.guid.iid }
   let lowercased = parameter.lowercased()
   return lowercased.contains("clsid") || lowercased.contains("classid")
-      ? "CLSID"
-      : "IID"
+      ? dialect.guid.clsid
+      : dialect.guid.iid
 }
-
-/// The well-known projection of resolved CLR types to `COM` module symbols.
-private let kWellKnown: Dictionary<Identity, String> = [
-  Identity(namespace: "Windows.Win32.Foundation", name: "HRESULT"):
-      "HRESULT",
-  Identity(namespace: "Windows.Win32.Foundation", name: "BOOL"):
-      "BOOL",
-]
 
 // MARK: - Structural cases
 
@@ -195,32 +279,37 @@ extension SignatureType {
   /// `Base<Args…>`.
   ///
   /// A CLR generic definition's `TypeName` carries an arity suffix (e.g.
-  /// `IReference``1`); it is stripped before composing the Swift generic so the
+  /// `IReference``1`); it is stripped before composing the generic so the
   /// spelling reads `IReference<…>`, not `IReference``1<…>`. The `parameter`-name
   /// hint flows to the arguments as well, so a `System.Guid` argument of a
   /// parameter named `clsid` spells `CLSID` rather than the default `IID`.
   fileprivate func specialized(by arguments: Array<SignatureType>,
-                               parameter: String?,
-                               with resolver: Resolver) -> String {
-    let base = decode(parameter: parameter, with: resolver)
+                               parameter: String?, with resolver: Resolver,
+                               dialect: Dialect) -> String {
+    let base = decode(parameter: parameter, with: resolver, dialect: dialect)
     // An unresolved base (e.g. a TypeSpec with no identity) decodes to the
-    // opaque pointer; a generic over it is meaningless Swift, so degrade to that
+    // opaque pointer; a generic over it is meaningless, so degrade to that
     // opaque pointer rather than emit `UnsafeMutableRawPointer<…>`.
-    guard base != kOpaque else { return base }
-    let name = base.prefix { $0 != "`" }
+    guard base != dialect.opaque else { return base }
+    // Strip the CLR arity suffix, THEN escape the base identifier: the full
+    // `Foo``1` never matches a keyword, so a keyword base (`protocol``1`) must
+    // be escaped after the strip, not before, to spell `` `protocol`<…> ``.
+    let name = dialect.escape(String(base.prefix { $0 != "`" }))
     let arguments = arguments
-        .map { $0.decode(parameter: parameter, with: resolver) }
+        .map { $0.decode(parameter: parameter, with: resolver,
+                         dialect: dialect) }
         .joined(separator: ", ")
-    return "\(name)<\(arguments)>"
+    return "\(name)\(dialect.generic.open)\(arguments)\(dialect.generic.close)"
   }
 }
 
 extension VariableScope {
-  /// The `T`/`M` placeholder prefix for a `VAR`/`MVAR` generic parameter scope.
-  fileprivate var prefix: String {
+  /// The `T`/`M` placeholder prefix for a `VAR`/`MVAR` generic parameter scope,
+  /// as `dialect` spells it.
+  fileprivate func prefix(_ dialect: Dialect) -> String {
     switch self {
-    case .type:   "T"
-    case .method: "M"
+    case .type:   dialect.variable.type
+    case .method: dialect.variable.method
     }
   }
 }

--- a/Sources/winmd-inspect/Database+SQL.swift
+++ b/Sources/winmd-inspect/Database+SQL.swift
@@ -22,16 +22,19 @@ internal import WinMD
 /// `width`: `rowid` enables foreign-key joins — an FK is a real column holding a
 /// `rowid`.
 ///
-/// Three tables expose a further per-table virtual column that decodes
-/// WinMD-specific data, at ordinals `width + 1` onward: `ReturnType` on
-/// `MethodDef` (the decoded type spelling of the signature's return), `ParamType`
-/// on `Param` (the decoded type spelling of the parameter, navigated through its
-/// owning method's signature), and `guid` on `CustomAttribute` (the UUID its
-/// `Value` blob names, or `NULL` when the blob is not GUID-shaped — the
-/// `interfaces` view navigates to a type's `GuidAttribute` and selects this
-/// codec to spell its IID). The extras are keyed by the relation's schema name;
-/// they are computed in `WinMDRow` and, being decoded rather than stored, are
-/// never seekable.
+/// One table exposes a further per-table virtual column that decodes
+/// WinMD-specific data, at ordinals `width + 1` onward: `guid` on
+/// `CustomAttribute` (the UUID its `Value` blob names, or `NULL` when the blob is
+/// not GUID-shaped — the `interfaces` view navigates to a type's `GuidAttribute`
+/// and selects this codec to spell its IID). The extras are keyed by the
+/// relation's schema name; they are computed in `WinMDRow` and, being decoded
+/// rather than stored, are never seekable.
+///
+/// Type spellings are *not* virtual columns: they are language-specific, so the
+/// adapter — the neutral conceptual layer — does not bake them. The render spells
+/// a return/parameter at render time through the free `decodedReturn`/
+/// `decodedParameter` functions, which navigate a method/parameter's signature
+/// and apply a target `Dialect`.
 ///
 /// Past the extras sit a relation's join keys, at ordinals `width + 1 + extras`
 /// onward — the columns a view equi-joins across. A list-owned table leads the
@@ -77,14 +80,14 @@ extension WinMD.Storage: SQL.Catalog {
 ///
 /// The shell lets a session define views (`CREATE VIEW`) and query them. A
 /// `Session` borrows the base `storage` and carries the escapable `views` the
-/// session has registered, and a `CREATE VIEW` `register`s another.
-/// `table(named:)` delegates to the storage, while `view(named:)` resolves the
-/// views case-insensitively (relation names resolve case-insensitively
-/// elsewhere), so a registered view shadows a base table of the same name. It is
-/// the single state model and does no console I/O; `Shell` drives it. It mirrors
-/// the `~Escapable`/`@_lifetime(borrow …)` + `copy storage` pattern of
-/// `WinMDRelation`, vending the storage's own `WinMDRelation` so the engine plans
-/// over the same source.
+/// session has registered — seeded at `init` with the bundled COM-interface
+/// views — and a `CREATE VIEW` `register`s another. `table(named:)` delegates to
+/// the storage, while `view(named:)` resolves the views case-insensitively
+/// (relation names resolve case-insensitively elsewhere), so a registered view
+/// shadows a base table of the same name. It is the single state model and does
+/// no console I/O; `Shell` drives it. It mirrors the `~Escapable`/`@_lifetime(
+/// borrow …)` + `copy storage` pattern of `WinMDRelation`, vending the storage's
+/// own `WinMDRelation` so the engine plans over the same source.
 internal struct Session: SQL.Catalog, ~Escapable {
   /// The borrowed base storage the session's tables read from.
   internal let storage: WinMD.Storage
@@ -92,8 +95,18 @@ internal struct Session: SQL.Catalog, ~Escapable {
   /// The views the session has registered, keyed case-folded.
   internal var views: Dictionary<String, View>
 
+  /// Opens a session over `storage`, seeding the bundled COM-interface views —
+  /// or, where a `-I` `search` directory shadows or adds one, its view.
+  @_lifetime(borrow storage)
+  internal init(_ storage: borrowing WinMD.Storage,
+                search: Array<String> = []) {
+    self.storage = copy storage
+    self.views = Session.bundled(search: search)
+  }
+
   /// Opens a session over `storage` with an explicit `views` set — the seam a
-  /// test drives to register a custom or overriding view set.
+  /// test drives to register a custom or overriding view set without the
+  /// bundled seed.
   @_lifetime(borrow storage)
   internal init(_ storage: borrowing WinMD.Storage,
                 _ views: Dictionary<String, View>) {
@@ -123,7 +136,7 @@ internal struct Session: SQL.Catalog, ~Escapable {
 ///
 /// Its real columns are the table's fields; the virtual columns follow, past the
 /// `SELECT *` extent: `rowid` at `width`, then the table's per-table decoded
-/// extras (`ReturnType`/`ParamType`/`guid`) at `width + 1` onward, then the join
+/// extras (`guid`) at `width + 1` onward, then the join
 /// keys — `parent` (on a list-owned table only) leading the coded-index join
 /// keys. A real cell is typed from its field's `ColumnType`: a `#Strings` index
 /// is `.text`, every other column (a constant, a foreign-key index, another
@@ -292,12 +305,11 @@ extension WinMDRelation {
   /// and `ordinal(of:)` derive from (keyed by the table's schema name, through
   /// the shared `extras(of:)` core).
   ///
-  /// Three tables decode a WinMD-specific column past `rowid`: `MethodDef` a
-  /// `ReturnType` (the signature's decoded return), `Param` a `ParamType` (the
-  /// parameter's decoded type), and `CustomAttribute` a `guid` (the GUID its
-  /// `Value` blob names, for the `GuidAttribute` rows the `interfaces` view
-  /// selects). Every other table exposes only `rowid` and `parent`, so it has
-  /// no extras. `WinMDRow.extras` computes the same list by the same keying.
+  /// One table decodes a WinMD-specific column past `rowid`: `CustomAttribute` a
+  /// `guid` (the GUID its `Value` blob names, for the `GuidAttribute` rows the
+  /// `interfaces` view selects). Every other table exposes only `rowid` and
+  /// `parent`, so it has no extras. `WinMDRow.extras` computes the same list by
+  /// the same keying.
   internal var extras: Array<String> {
     WinMDRelation.extras(of: table.description)
   }
@@ -309,8 +321,6 @@ extension WinMDRelation {
   /// extras.
   internal static func extras(of schema: String) -> Array<String> {
     switch schema {
-    case "MethodDef":       ["ReturnType"]
-    case "Param":           ["ParamType"]
     case "CustomAttribute": ["guid"]
     default:                Array<String>()
     }
@@ -502,7 +512,7 @@ internal struct WinMDCursor: SQL.Cursor, ~Escapable {
 /// reads the WinMD cell — a `#Strings` heap index resolves through the heap as
 /// `.text`, every other column is `.integer`; `rowid` (`count`) is the 1-based
 /// row index; a per-table extra ordinal (`count + 1` onward) decodes the table's
-/// WinMD-specific column (`ReturnType`/`ParamType`/`guid`); and the join keys
+/// WinMD-specific column (`guid`); and the join keys
 /// follow the extras — on a list-owned table the `parent` ordinal is the owning
 /// parent row's 1-based `rowid` (zero for a row no parent owns) and the
 /// coded-index join keys follow it, while on a non-list table the coded-index
@@ -578,8 +588,6 @@ internal struct WinMDRow: SQL.Row, ~Escapable {
   /// such extra — is SQL `NULL`.
   private func extra(_ index: Int) -> Value {
     switch (schema, index) {
-    case ("MethodDef", 0):       returns()
-    case ("Param", 0):           parameter()
     case ("CustomAttribute", 0): guid()
     default:                     .null
     }
@@ -632,57 +640,86 @@ internal struct WinMDRow: SQL.Row, ~Escapable {
     }
     return .text("\(uuid)")
   }
+}
 
-  /// The `ReturnType` extra of a `MethodDef` row — the decoded type spelling of
-  /// the signature's return, or SQL `NULL` when the signature does not decode.
-  private func returns() -> Value {
-    guard let row = Row<Metadata.Tables.MethodDef>(tuple),
-        let signature = try? row.prototype else {
-      return .null
-    }
-    guard let resolver = try? Resolver(of: signature, with: storage) else {
-      return .null
-    }
-    return .text(signature.returns.decode(with: resolver))
-  }
+// MARK: - Signature decode
 
-  /// The `ParamType` extra of a `Param` row — the decoded type spelling of the
-  /// parameter, navigated through its owning method's signature.
-  ///
-  /// The `Param.Sequence` cell is the 1-based parameter position; `Sequence == 0`
-  /// is the return pseudo-parameter and `Sequence > parameters.count` is out of
-  /// range, both SQL `NULL`. The owning `MethodDef` is the `parent` virtual
-  /// column's row, opened through the list `link`.
-  private func parameter() -> Value {
-    guard let link,
-        let sequence = tuple.ordinal(for: "Sequence") else { return .null }
-    let position = tuple[sequence]
-    // The owning `MethodDef` is the `parent` virtual column's row (its 1-based
-    // `rowid`), opened positionally through the list link's parent table. An
-    // owner of zero is no parent (malformed/partial metadata: an empty
-    // `MethodDef` table, or a first `ParamList` past this row), so the
-    // parameter is unowned and yields SQL `NULL` rather than indexing a
-    // negative row through the cursor.
-    let owner = storage.owner(of: tuple.index, link)
-    guard owner != 0 else { return .null }
-    let cursor = WinMD.Cursor(storage, link.parent)
-    guard let method = cursor[owner - 1],
-        let row = Row<Metadata.Tables.MethodDef>(method),
-        let signature = try? row.prototype else {
-      return .null
+extension WinMD.Storage {
+  /// The open table whose schema name is `schema`, resolved case-insensitively
+  /// against the database's relations — the signature decode's table lookup, the
+  /// same keying `WinMDRelation.Link` uses to find a list parent.
+  internal borrowing func opened(_ schema: String) -> WinMD.Table? {
+    for index in 0 ..< relations.count
+        where relations[index].description
+                  .caseInsensitiveCompare(schema) == .orderedSame {
+      return relations[index]
     }
-    // `Sequence == 0` is the return parameter; `Sequence == N` is the 1-based
-    // `parameters[N - 1]`. Anything outside that range yields SQL `NULL`.
-    guard position >= 1, position <= signature.parameters.count else {
-      return .null
-    }
-    guard let resolver = try? Resolver(of: signature, with: storage) else {
-      return .null
-    }
-    // The parameter's own `Name` is the `System.Guid` `IID`/`CLSID` hint; for
-    // any other type the decoder ignores it, so passing it is always safe.
-    let name = tuple.ordinal(for: "Name").flatMap { try? tuple.string($0) }
-    return .text(signature.parameters[position - 1]
-        .decode(parameter: name, with: resolver))
+    return nil
   }
+}
+
+/// The decoded type spelling of the return of the `MethodDef` at 1-based
+/// `method` `rowid`, in `dialect`, or `nil` when the row or its signature does
+/// not decode.
+///
+/// This is the signature-navigation the adapter once baked as the `ReturnType`
+/// virtual column, relocated so the render can spell a return at render time
+/// with a target `Dialect`: it opens the `MethodDef` row, decodes its
+/// `prototype` signature, builds a `Resolver` over the borrowed `storage`, and
+/// decodes the return. `nil` mirrors the old NULL — an absent row, an
+/// undecodable signature, or an unresolvable one.
+internal func decodedReturn(of method: Int, in storage: borrowing WinMD.Storage,
+                            dialect: Dialect) -> String? {
+  guard let table = storage.opened("MethodDef") else { return nil }
+  let cursor = WinMD.Cursor(copy storage, table)
+  guard let tuple = cursor[method - 1],
+      let row = Row<Metadata.Tables.MethodDef>(tuple),
+      let signature = try? row.prototype,
+      let resolver = try? Resolver(of: signature, with: storage) else {
+    return nil
+  }
+  return signature.returns.decode(with: resolver, dialect: dialect)
+}
+
+/// The decoded type spelling of the `Param` at 1-based `parameter` `rowid`, in
+/// `dialect`, navigated through its owning method's signature — or `nil` when it
+/// does not decode.
+///
+/// This is the signature-navigation the adapter once baked as the `ParamType`
+/// virtual column, relocated so the render can spell a parameter at render time.
+/// The `Param.Sequence` cell is the 1-based parameter position: `Sequence == 0`
+/// is the return pseudo-parameter and `Sequence > parameters.count` is out of
+/// range, both `nil`. The owning `MethodDef` is found through the `Param` list
+/// link — an owner of zero is no parent (malformed/partial metadata), so the
+/// parameter is unowned and yields `nil` rather than indexing a negative row.
+/// The parameter's own `Name` is the `System.Guid` `IID`/`CLSID` hint; for any
+/// other type the decoder ignores it, so threading it is always safe.
+internal func decodedParameter(of parameter: Int,
+                               in storage: borrowing WinMD.Storage,
+                               dialect: Dialect) -> String? {
+  guard let table = storage.opened("Param") else { return nil }
+  let params = WinMD.Cursor(copy storage, table)
+  guard let param = params[parameter - 1],
+      let sequence = param.ordinal(for: "Sequence"),
+      let link = WinMDRelation.Link(storage, table) else {
+    return nil
+  }
+  let position = param[sequence]
+  let owner = storage.owner(of: parameter - 1, link)
+  guard owner != 0 else { return nil }
+  let methods = WinMD.Cursor(copy storage, link.parent)
+  guard let method = methods[owner - 1],
+      let row = Row<Metadata.Tables.MethodDef>(method),
+      let signature = try? row.prototype else {
+    return nil
+  }
+  guard position >= 1, position <= signature.parameters.count else {
+    return nil
+  }
+  guard let resolver = try? Resolver(of: signature, with: storage) else {
+    return nil
+  }
+  let name = param.ordinal(for: "Name").flatMap { try? param.string($0) }
+  return signature.parameters[position - 1]
+      .decode(parameter: name, with: resolver, dialect: dialect)
 }

--- a/Sources/winmd-inspect/Language.swift
+++ b/Sources/winmd-inspect/Language.swift
@@ -1,0 +1,196 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+internal import SQL
+internal import WinMDSynthesis
+
+/// A target-language spec — the language- and convention-specific knowledge the
+/// render pipeline needs, kept OUT of the binary.
+///
+/// The generic engine and the render orchestration know only WinMD and SQL; what
+/// makes the output *Swift* (its reserved words, how one escapes, the no-value
+/// return spelling, the COM-root base, and the type spellings a signature decodes
+/// to) is data, loaded from a bundled `Resources/Languages/<language>.lang`
+/// resource — e.g. `swift.lang` — named for the language, which a template selects
+/// through its `{{! language: <name> }}` directive and a user may shadow through
+/// `-I`. Retargeting the generator to Rust or C is then a new spec beside a new
+/// template, not a code change.
+///
+/// The spec surfaces to the render queries as the `ESCAPE` scalar UDF
+/// (keyword-escape an identifier), and to the render's Swift decode as a
+/// `Dialect` — the type spellings a `SignatureType` composes into a spelling. The
+/// no-value return is the spec's `void` spelling, tested against a decoded return
+/// (`returned(_:)`), so the render omits the return clause when the return is
+/// absent.
+///
+/// The file is line-oriented: blank lines and `#`-comments are ignored; every
+/// other line is `key value`, the value being the rest of the line after the
+/// first whitespace (possibly empty). Recognised keys: `escape-prefix`/
+/// `escape-suffix` (the delimiters wrapped around an escaped identifier), `void`
+/// (the spelling a no-value return decodes to), `root` (the default base a COM
+/// root inherits), `keyword` (one reserved word, repeated), `type <name>
+/// <spelling>` (a primitive leaf's spelling, keyed by neutral name), the pointer
+/// conventions (`pointer-mutable`/`pointer-const`/`rawpointer-mutable`/
+/// `rawpointer-const`/`optional`/`generic-open`/`generic-close`/`var-type`/
+/// `var-method`/`opaque`), the `System.Guid` names (`guid-iid`/`guid-clsid`), and
+/// `wellknown <namespace.name> <spelling>`. An unknown key is ignored.
+internal struct Language: Sendable {
+  /// The delimiters wrapped around a keyword identifier — Swift's backticks, or
+  /// (say) an empty prefix with a `_` suffix.
+  private let prefix: String
+  private let suffix: String
+
+  /// The decoded spelling of a no-value return (`Void` in Swift); a method whose
+  /// return equals it emits no return clause.
+  private let void: String
+
+  /// The base a COM root defaults to when it implements no interface (`IUnknown`
+  /// in COM); an interface whose own name is `root` inherits nothing, so the COM
+  /// root itself does not inherit itself.
+  internal let root: String
+
+  /// The reserved words `escape(_:)` wraps.
+  private let keywords: Set<String>
+
+  /// The primitive leaf spellings, keyed by neutral name (`void`, `i4`, …) — the
+  /// `type` lines, fed to the `Dialect`.
+  private let types: Dictionary<String, String>
+
+  /// The type-composition conventions — the pointer family, delimiters, scope
+  /// prefixes, the opaque spelling, and the `System.Guid` names — the `Dialect`
+  /// composes a spelling from, keyed by their `.lang` key.
+  private let conventions: Dictionary<String, String>
+
+  /// The well-known projection of a `namespace.name` identity to its spelling —
+  /// the `wellknown` lines, fed to the `Dialect`.
+  private let wellKnown: Dictionary<String, String>
+
+  /// The identity spec — no keywords, no `void`/`root` conventions, no type data
+  /// — so a template with no accompanying `.lang` renders every identifier and
+  /// return verbatim, applies no root default, and (through `dialect`) decodes a
+  /// primitive to its neutral name.
+  internal init() {
+    prefix = ""
+    suffix = ""
+    void = ""
+    root = ""
+    keywords = []
+    types = [:]
+    conventions = [:]
+    wellKnown = [:]
+  }
+
+  /// Parses a `.lang` resource, ignoring blank lines and `#`-comments and
+  /// reading each remaining line as a `key value` pair.
+  internal init(parsing text: String) {
+    var prefix = "", suffix = "", void = "", root = ""
+    var keywords = Set<String>()
+    var types = Dictionary<String, String>()
+    var conventions = Dictionary<String, String>()
+    var wellKnown = Dictionary<String, String>()
+    for line in text.split(whereSeparator: \.isNewline) {
+      let trimmed = String(line).trimmed
+      guard !trimmed.isEmpty, !trimmed.hasPrefix("#") else { continue }
+      let key = trimmed.prefix { !$0.isWhitespace }
+      let value = trimmed[key.endIndex...].trimmed
+      switch key {
+      case "escape-prefix": prefix = value
+      case "escape-suffix": suffix = value
+      case "void":          void = value
+      case "root":          root = value
+      case "keyword":       keywords.insert(value)
+      case "type":
+        // A `type <name> <spelling>` line: the neutral name then its spelling.
+        let name = value.prefix { !$0.isWhitespace }
+        types[String(name)] = value[name.endIndex...].trimmed
+      case "wellknown":
+        // A `wellknown <namespace.name> <spelling>` line.
+        let identity = value.prefix { !$0.isWhitespace }
+        wellKnown[String(identity)] = value[identity.endIndex...].trimmed
+      case "pointer-mutable", "pointer-const", "rawpointer-mutable",
+           "rawpointer-const", "optional", "generic-open", "generic-close",
+           "var-type", "var-method", "opaque", "guid-iid", "guid-clsid":
+        conventions[String(key)] = value
+      default:              break
+      }
+    }
+    self.prefix = prefix
+    self.suffix = suffix
+    self.void = void
+    self.root = root
+    self.keywords = keywords
+    self.types = types
+    self.conventions = conventions
+    self.wellKnown = wellKnown
+  }
+
+  /// The target-source spelling of `identifier`: itself, or wrapped in the
+  /// escape delimiters when it collides with a reserved keyword.
+  internal func escape(_ identifier: String) -> String {
+    keywords.contains(identifier) ? "\(prefix)\(identifier)\(suffix)" : identifier
+  }
+
+  /// The value-carrying return type a method spells, or `nil` for a no-value
+  /// return — the `void` spelling, or an undecoded (empty) return. The render
+  /// omits the return clause when it is absent.
+  internal func returned(_ type: String) -> String? {
+    type.isEmpty || type == void ? nil : type
+  }
+
+  /// The `WinMDSynthesis.Dialect` this spec builds — the type spellings and
+  /// conventions the render's decode composes a signature's spelling from.
+  ///
+  /// A convention absent from the spec falls back to its neutral name (a `type`)
+  /// or the empty string (a delimiter/prefix), so the identity `Language` still
+  /// yields a usable, non-trapping dialect. The well-known table parses each
+  /// `namespace.name` key into an `Identity` by splitting off the last `.`-
+  /// segment as the simple name.
+  internal var dialect: Dialect {
+    var known = Dictionary<Identity, String>()
+    for (identity, spelling) in wellKnown {
+      guard let dot = identity.lastIndex(of: ".") else {
+        known[Identity(namespace: "", name: identity)] = spelling
+        continue
+      }
+      let namespace = String(identity[..<dot])
+      let name = String(identity[identity.index(after: dot)...])
+      known[Identity(namespace: namespace, name: name)] = spelling
+    }
+    let language = self
+    return Dialect(
+        primitives: types,
+        pointer: (typed: (mutable: conventions["pointer-mutable"] ?? "",
+                          constant: conventions["pointer-const"] ?? ""),
+                  untyped: (mutable: conventions["rawpointer-mutable"] ?? "",
+                            constant: conventions["rawpointer-const"] ?? "")),
+        optional: conventions["optional"] ?? "",
+        generic: (open: conventions["generic-open"] ?? "",
+                  close: conventions["generic-close"] ?? ""),
+        variable: (type: conventions["var-type"] ?? "",
+                   method: conventions["var-method"] ?? ""),
+        opaque: conventions["opaque"] ?? "",
+        guid: (iid: conventions["guid-iid"] ?? "",
+               clsid: conventions["guid-clsid"] ?? ""),
+        known: known,
+        escape: { language.escape($0) })
+  }
+
+  /// The spec's render UDFs — just `ESCAPE(identifier)` — for the routines the
+  /// render binds its queries with. `ESCAPE` wraps a keyword identifier (and
+  /// passes a NULL through); the no-value return is decided in Swift now (the
+  /// render tests a decoded return against `returned(_:)`), so it needs no UDF.
+  internal var routines: Routines {
+    let language = self
+    let escape: Scalar = { arguments in
+      guard arguments.count == 1 else {
+        throw .argument("ESCAPE takes one argument")
+      }
+      if case .null = arguments[0] { return .null }
+      guard case let .text(identifier) = arguments[0] else {
+        throw .argument("ESCAPE requires a text argument")
+      }
+      return .text(language.escape(identifier))
+    }
+    return ["escape": escape]
+  }
+}

--- a/Sources/winmd-inspect/Query.swift
+++ b/Sources/winmd-inspect/Query.swift
@@ -37,6 +37,13 @@ internal struct Query: ParsableCommand {
   @OptionGroup
   internal var options: InspectOptions
 
+  @Option(name: .customShort("I"),
+          help: ArgumentHelp("A directory searched before the built-in "
+                           + "resources for query, view, and template files "
+                           + "(`<dir>/{Render,Queries,Templates}/<name>"
+                           + ".<ext>`); repeatable, the last directory wins."))
+  internal var search: Array<String> = []
+
   @Argument(help: ArgumentHelp("The SQL script to run; omit it to read one "
                              + "from stdin or open an interactive shell."))
   internal var sql: String?
@@ -57,7 +64,7 @@ internal struct Query: ParsableCommand {
     // reading. `.quit`'s `Shell.Stop` is caught either way to end cleanly. The
     // policy lives in `attempt` so `.read` inherits it too.
     let storage = database.storage
-    var shell = Shell(storage, strict: sql != nil)
+    var shell = Shell(storage, strict: sql != nil, search: search)
     if let sql {
       do {
         for statement in Statements(of: sql) { try shell.attempt(statement) }

--- a/Sources/winmd-inspect/Resources/Languages/swift.lang
+++ b/Sources/winmd-inspect/Resources/Languages/swift.lang
@@ -1,0 +1,106 @@
+# The Swift target spec, selected by a template's `{{! language: swift }}`
+# directive: the escape delimiters, the no-value return spelling, the COM-root
+# base, the reserved words an identifier is escaped against, and the type
+# spellings a signature decodes to (the primitive leaves, the pointer family, the
+# delimiters, and the well-known projections). The render's ESCAPE UDF and its
+# type Dialect read it, so this — not the binary — carries what is Swift-specific.
+# A `-I` directory's `Languages/swift.lang` shadows it.
+escape-prefix `
+escape-suffix `
+void Void
+root IUnknown
+
+# The primitive leaf spellings, keyed by neutral name. `ELEMENT_TYPE_STRING` is
+# the WinRT `String` — an `HSTRING` handle, not a `PCWSTR` buffer.
+type void Void
+type bool CBool
+type char Unicode.UTF16.CodeUnit
+type i1 CChar
+type u1 CUnsignedChar
+type i2 CShort
+type u2 CUnsignedShort
+type i4 CInt
+type u4 CUnsignedInt
+type i8 CLongLong
+type u8 CUnsignedLongLong
+type f4 CFloat
+type f8 CDouble
+type iptr Int
+type uptr UInt
+type string HSTRING
+type object UnsafeMutableRawPointer
+type typedref UnsafeMutableRawPointer
+
+# The type-composition conventions: the pointer family, the generic delimiters,
+# the optional marker, the generic-variable scope prefixes, the opaque spelling
+# an unresolvable type degrades to, and the `System.Guid` classification names.
+pointer-mutable UnsafeMutablePointer
+pointer-const UnsafePointer
+rawpointer-mutable UnsafeMutableRawPointer
+rawpointer-const UnsafeRawPointer
+optional ?
+generic-open <
+generic-close >
+var-type T
+var-method M
+opaque UnsafeMutableRawPointer
+guid-iid IID
+guid-clsid CLSID
+
+# The well-known projection of resolved CLR types to `COM` module symbols.
+wellknown Windows.Win32.Foundation.HRESULT HRESULT
+wellknown Windows.Win32.Foundation.BOOL BOOL
+keyword Any
+keyword as
+keyword associatedtype
+keyword await
+keyword break
+keyword case
+keyword catch
+keyword class
+keyword continue
+keyword default
+keyword defer
+keyword deinit
+keyword do
+keyword else
+keyword enum
+keyword extension
+keyword fallthrough
+keyword false
+keyword fileprivate
+keyword for
+keyword func
+keyword guard
+keyword if
+keyword import
+keyword in
+keyword init
+keyword inout
+keyword internal
+keyword is
+keyword let
+keyword nil
+keyword operator
+keyword precedencegroup
+keyword private
+keyword protocol
+keyword public
+keyword repeat
+keyword rethrows
+keyword return
+keyword self
+keyword Self
+keyword static
+keyword struct
+keyword subscript
+keyword super
+keyword switch
+keyword throw
+keyword throws
+keyword true
+keyword try
+keyword typealias
+keyword var
+keyword where
+keyword while

--- a/Sources/winmd-inspect/Resources/Queries/bases.sql
+++ b/Sources/winmd-inspect/Resources/Queries/bases.sql
@@ -1,0 +1,16 @@
+CREATE VIEW bases AS
+SELECT
+  b.TypeName AS base
+FROM
+  InterfaceImpl i
+  JOIN TypeRef b ON i.Interface_TypeRef = b.rowid
+WHERE
+  i.Class = :parent
+UNION
+SELECT
+  d.TypeName AS base
+FROM
+  InterfaceImpl i
+  JOIN TypeDef d ON i.Interface_TypeDef = d.rowid
+WHERE
+  i.Class = :parent

--- a/Sources/winmd-inspect/Resources/Queries/interfaces.sql
+++ b/Sources/winmd-inspect/Resources/Queries/interfaces.sql
@@ -1,0 +1,45 @@
+CREATE VIEW interfaces AS
+SELECT
+  t.rowid,
+  t.TypeNamespace,
+  t.TypeName,
+  c.guid AS iid
+FROM
+  TypeDef t
+  JOIN CustomAttribute c ON c.Parent_TypeDef = t.rowid
+  JOIN MemberRef r ON c.Type_MemberRef = r.rowid
+  JOIN TypeRef g ON r.Class_TypeRef = g.rowid
+WHERE
+  g.TypeNamespace = 'Windows.Win32.Foundation.Metadata'
+  AND g.TypeName = 'GuidAttribute'
+  AND BITAND(t.Flags, 32) = 32
+UNION
+SELECT
+  t.rowid,
+  t.TypeNamespace,
+  t.TypeName,
+  c.guid AS iid
+FROM
+  TypeDef t
+  JOIN CustomAttribute c ON c.Parent_TypeDef = t.rowid
+  JOIN MethodDef m ON c.Type_MethodDef = m.rowid
+  JOIN TypeDef g ON m.parent = g.rowid
+WHERE
+  g.TypeNamespace = 'Windows.Win32.Foundation.Metadata'
+  AND g.TypeName = 'GuidAttribute'
+  AND BITAND(t.Flags, 32) = 32
+UNION
+SELECT
+  t.rowid,
+  t.TypeNamespace,
+  t.TypeName,
+  c.guid AS iid
+FROM
+  TypeDef t
+  JOIN CustomAttribute c ON c.Parent_TypeDef = t.rowid
+  JOIN MemberRef r ON c.Type_MemberRef = r.rowid
+  JOIN TypeDef g ON r.Class_TypeDef = g.rowid
+WHERE
+  g.TypeNamespace = 'Windows.Win32.Foundation.Metadata'
+  AND g.TypeName = 'GuidAttribute'
+  AND BITAND(t.Flags, 32) = 32

--- a/Sources/winmd-inspect/Resources/Queries/methods.sql
+++ b/Sources/winmd-inspect/Resources/Queries/methods.sql
@@ -1,0 +1,8 @@
+CREATE VIEW methods AS
+SELECT
+  rowid,
+  Name
+FROM
+  MethodDef
+WHERE
+  parent = :parent

--- a/Sources/winmd-inspect/Resources/Queries/params.sql
+++ b/Sources/winmd-inspect/Resources/Queries/params.sql
@@ -1,0 +1,9 @@
+CREATE VIEW params AS
+SELECT
+  rowid,
+  Name,
+  Sequence
+FROM
+  Param
+WHERE
+  parent = :parent

--- a/Sources/winmd-inspect/Resources/Render/bases.sql
+++ b/Sources/winmd-inspect/Resources/Render/bases.sql
@@ -1,0 +1,4 @@
+SELECT
+  ESCAPE(base) AS base
+FROM
+  bases

--- a/Sources/winmd-inspect/Resources/Render/interfaces.sql
+++ b/Sources/winmd-inspect/Resources/Render/interfaces.sql
@@ -1,0 +1,10 @@
+SELECT
+  rowid,
+  TypeNamespace,
+  ESCAPE(TypeName) AS TypeName,
+  iid
+FROM
+  interfaces
+WHERE
+  TypeName = :name
+  OR '*' = :name

--- a/Sources/winmd-inspect/Resources/Render/methods.sql
+++ b/Sources/winmd-inspect/Resources/Render/methods.sql
@@ -1,0 +1,5 @@
+SELECT
+  rowid,
+  ESCAPE(Name) AS Name
+FROM
+  methods

--- a/Sources/winmd-inspect/Resources/Render/params.sql
+++ b/Sources/winmd-inspect/Resources/Render/params.sql
@@ -1,0 +1,6 @@
+SELECT
+  rowid,
+  ESCAPE(Name) AS Name,
+  Sequence
+FROM
+  params

--- a/Sources/winmd-inspect/Resources/Templates/com.mustache
+++ b/Sources/winmd-inspect/Resources/Templates/com.mustache
@@ -1,0 +1,7 @@
+{{! language: swift }}
+@com(interface: "{{{iid}}}")
+public protocol {{{name}}}{{#base}}: {{{.}}}{{/base}} {
+{{#methods}}
+    func {{{name}}}({{#params}}_ {{{name}}}: {{{type}}}{{^last}}, {{/last}}{{/params}}){{#returns}} -> {{{.}}}{{/returns}}
+{{/methods}}
+}

--- a/Sources/winmd-inspect/Shell.swift
+++ b/Sources/winmd-inspect/Shell.swift
@@ -1,10 +1,13 @@
 // Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
+internal import Mustache
 internal import SQL
 internal import WinMD
+internal import WinMDSynthesis
 
-internal import class Foundation.FileHandle
+internal import class Foundation.Bundle
+internal import class Foundation.FileManager
 internal import struct Foundation.Data
 internal import struct Foundation.URL
 
@@ -84,6 +87,36 @@ internal struct Read: Metacommand {
   }
 }
 
+/// `.render <interface> <template>` — render a COM interface (or `*` for every
+/// interface) through a bundled Mustache template.
+internal struct Render: Metacommand {
+  internal static let spelling = ".render"
+
+  /// The interface to render, or `*` for every interface.
+  internal let interface: String
+
+  /// The template to render it through.
+  internal let template: String
+
+  internal init(_ arguments: Substring) {
+    let fields = arguments.split(whereSeparator: \.isWhitespace)
+    if fields.count == 2 {
+      interface = String(fields[0])
+      template = String(fields[1])
+    } else {
+      interface = ""
+      template = ""
+    }
+  }
+
+  internal func execute(against shell: inout Shell) throws {
+    guard !interface.isEmpty, !template.isEmpty else {
+      throw Shell.MetaError.unknown(Render.spelling)
+    }
+    print(try shell.render(interface, template: template))
+  }
+}
+
 // MARK: - Shell
 
 /// The interactive `query` shell — a `sqlite3`-style REPL — driving a `Session`.
@@ -109,12 +142,21 @@ internal struct Shell: ~Escapable {
   /// text fed on stdin.
   private let strict: Bool
 
-  /// Opens a shell over `storage`, starting from an empty session. `strict`
-  /// defaults to the forgiving shell policy; an explicit batch passes `true`.
+  /// The `-I` override directories, tried before the package bundle when a
+  /// query, view, or template resource is loaded — a later directory shadows an
+  /// earlier one and the bundle (the last `-I` wins).
+  private let search: Array<String>
+
+  /// Opens a shell over `storage`, seeding the session's bundled views.
+  /// `strict` defaults to the forgiving shell policy; an explicit batch passes
+  /// `true`. `search` is the `-I` override directories, tried before the
+  /// bundle.
   @_lifetime(borrow storage)
-  internal init(_ storage: borrowing WinMD.Storage, strict: Bool = false) {
-    session = Session(storage, [:])
+  internal init(_ storage: borrowing WinMD.Storage, strict: Bool = false,
+                search: Array<String> = []) {
+    session = Session(storage, search: search)
     self.strict = strict
+    self.search = search
   }
 
   /// The registry of meta-commands — `execute(_:)` matches a leading `.`-token
@@ -122,16 +164,17 @@ internal struct Shell: ~Escapable {
   /// computed so the metatype array (not `Sendable`) is not a shared mutable
   /// global.
   private static var commands: Array<any Metacommand.Type> {
-    [Tables.self, Help.self, Quit.self, Read.self]
+    [Tables.self, Help.self, Quit.self, Read.self, Render.self]
   }
 
   /// The command summary `.help` prints.
   internal static let help = """
-    .tables           list the database's tables
-    .read <path>      run a file of `;`-separated SQL statements
-    .help             show this help
-    .quit             leave the shell
-    <sql>             run a SQL statement (trailing `;` optional)
+    .tables                 list the database's tables
+    .read <path>            run a file of `;`-separated SQL statements
+    .render <iface> <tmpl>  render an interface (or `*`) through a template
+    .help                   show this help
+    .quit                   leave the shell
+    <sql>                   run a SQL statement (trailing `;` optional)
     """
 
   /// The sentinel `Quit.execute` throws to stop the loop — caught by the
@@ -142,6 +185,18 @@ internal struct Shell: ~Escapable {
   internal enum MetaError: Error, Equatable {
     /// An unrecognised or malformed `.`-command (the offending token).
     case unknown(String)
+  }
+
+  /// A fault `.render` raises that is not already a `SQLError`.
+  internal enum RenderError: Error, Equatable {
+    /// No interface in the `interfaces` view bears the requested name.
+    case interface(String)
+    /// No template resource of the requested name resolved — neither a `-I`
+    /// directory's `Templates/<name>.mustache` nor the bundled one.
+    case template(String)
+    /// No render-query resource of the requested name resolved — neither a `-I`
+    /// directory's `Render/<name>.sql` nor the bundled one.
+    case query(String)
   }
 
   // MARK: - Execute
@@ -197,6 +252,248 @@ internal struct Shell: ~Escapable {
     let text = String(decoding: data, as: UTF8.self)
     for statement in Statements(of: text) { try attempt(statement) }
   }
+
+  // MARK: - Render
+
+  /// Renders the interface named `interface`, or every interface for `*`,
+  /// through the named Mustache template.
+  ///
+  /// The data tier is the session's bundled views, read through the
+  /// bundled `Resources/Render/*.sql` queries (not Swift literals): the
+  /// `interfaces` query selects the one named interface, or every
+  /// interface for `*` (its `WHERE TypeName = :name OR '*' = :name`), then
+  /// for each its `methods` bound by the interface's `rowid`, each
+  /// method's `params` bound by the method's `rowid`, and its `bases`
+  /// bound by the interface's `rowid`. The presentation tier is the named
+  /// template loaded from `Resources/Templates`. A single interface that
+  /// no view names raises `RenderError.interface`; a missing template
+  /// resource raises `RenderError.template`.
+  ///
+  /// The base inheritance is derived through the `bases` view (the interface's
+  /// `InterfaceImpl` rows navigated to their base type names); a rootless
+  /// interface defaults to the spec's COM `root`, save the root interface
+  /// itself, which inherits nothing. Identifier escaping and the no-value return
+  /// come from the template's language spec (`ESCAPE`/`RETURNS`), not the binary.
+  internal borrowing func render(_ interface: String,
+                                 template: String) throws -> String {
+    // The template names its own target language through a leading `{{! language:
+    // <name> }}` directive; stripping it yields the body and loads the matching
+    // spec, whose render UDFs (`ESCAPE`, `RETURNS`) make identifier escaping and
+    // the no-value return the queries' concern, not the binary's.
+    var body = try Shell.template(named: template, search: search)
+    let language = Shell.language(declaredIn: &body, search: search)
+    let routines = language.routines
+    // The type spellings are decoded at render time from the spec's `Dialect`:
+    // the adapter is language-neutral, so the render — not the binary's WinMD →
+    // SQL layer — spells a return/parameter, navigating the signature with the
+    // free `decodedReturn`/`decodedParameter` functions.
+    let dialect = language.dialect
+    // The rows to render come straight from the bundled selection query, bound
+    // by `:name`: it returns the one named interface, or — for `*` — every one
+    // (`WHERE TypeName = :name OR '*' = :name`). Choosing which rows to emit is
+    // the query's job, so render just iterates whatever it returns.
+    let selection =
+        try Shell.select(Shell.query(named: "interfaces", search: search))
+    let interfaces = try Engine.run(selection, session, routines,
+                                    bindings: ["name": .text(interface)])
+    guard interface == "*" || !interfaces.isEmpty else {
+      throw RenderError.interface(interface)
+    }
+
+    let mustache = try MustacheTemplate(string: body)
+    var sources = Array<String>()
+    sources.reserveCapacity(interfaces.count)
+    for found in interfaces {
+      let rowid = found[0]
+      // The interface's methods, bound by its rowid; each row is its `rowid`
+      // then its escaped `Name`. The type spellings are no longer projected —
+      // the render decodes them from the signature with the spec's `Dialect`.
+      let plan = try Shell.select(Shell.query(named: "methods",
+                                              search: search))
+      let rows = try Engine.run(plan, session, routines,
+                                bindings: ["parent": rowid])
+      var methods = Array<Dictionary<String, Any>>()
+      methods.reserveCapacity(rows.count)
+      for method in rows {
+        // Each method's parameters, bound by the method's rowid; each row is its
+        // `rowid`, escaped `Name`, and `Sequence`. The return pseudo-parameter
+        // (`Sequence == 0`) is dropped — only the real parameters spell the
+        // requirement's arguments — and the rest decode their type at render
+        // time from the parameter's own signature position.
+        let selection = try Shell.select(Shell.query(named: "params",
+                                                     search: search))
+        let params = try Engine.run(selection, session, routines,
+                                    bindings: ["parent": method[0]])
+        var parameters = Array<Dictionary<String, Any>>()
+        for parameter in params where parameter[2] != .integer(0) {
+          let type = decodedParameter(of: parameter[0].integer,
+                                      in: session.storage, dialect: dialect)
+          parameters.append([
+            "name": parameter[1].text,
+            "type": type ?? "",
+            "last": false,
+          ])
+        }
+        // The trailing parameter's `last` flag drives the template's
+        // `{{^last}}, {{/last}}` comma separation, omitting the final comma.
+        if !parameters.isEmpty {
+          parameters[parameters.count - 1]["last"] = true
+        }
+        var entry: Dictionary<String, Any> = [
+          "name": method[1].text,
+          "params": parameters,
+        ]
+        // The return, decoded at render time; a no-value return (the spec's
+        // `void` spelling, or an undecodable return) leaves `returns` absent, so
+        // the template's `{{#returns}}` clause renders nothing.
+        let returned = decodedReturn(of: method[0].integer, in: session.storage,
+                                     dialect: dialect)
+        if let returned, let clause = language.returned(returned) {
+          entry["returns"] = clause
+        }
+        methods.append(entry)
+      }
+      // The interface's base, via the `bases` view bound by its rowid. A
+      // rootless interface defaults to the spec's COM root, except the root
+      // interface itself — which inherits nothing, so it never becomes its own
+      // base; an empty `root` applies no default.
+      let lineage =
+          try Shell.select(Shell.query(named: "bases", search: search))
+      let bases = try Engine.run(lineage, session, routines,
+                                 bindings: ["parent": rowid])
+      let base: String? = if let inherited = bases.first {
+        inherited[0].text
+      } else if language.root.isEmpty || found[2].text == language.root {
+        nil
+      } else {
+        language.root
+      }
+      var context: Dictionary<String, Any> = [
+        "name": found[2].text,
+        "iid": found[3].text,
+        "namespace": found[1].text,
+        "methods": methods,
+      ]
+      // An absent `base` skips the template's `{{#base}}` inheritance clause.
+      if let base { context["base"] = base }
+      sources.append(mustache.render(context))
+    }
+    return sources.joined(separator: "\n")
+  }
+
+  /// The text of the Mustache template named `name`, loaded through the search
+  /// path (a `-I` directory's `Templates/<name>.mustache`) then the bundled
+  /// `Resources/Templates/<name>.mustache`.
+  ///
+  /// The render's presentation tier is a named resource, not a literal: `com`
+  /// is the one bundled template (the `@com` protocol shape), and adding a
+  /// target later is dropping in another `.mustache` beside it — or shadowing
+  /// one through a `-I` directory — no code change. A name no search directory
+  /// and no bundle resolves raises `RenderError.template`.
+  ///
+  /// The `com` template emits the `@com` protocol style: a leading `{{! language:
+  /// swift }}` directive naming its spec, the `@com(interface:)` attribute, `public
+  /// protocol <name>` with an optional `: <base>` clause, and one
+  /// four-space-indented `func` requirement per method — each parameter `_
+  /// <name>: <type>`, comma-separated through the parameters' `last` flag, and an
+  /// optional ` -> <returns>` clause. Each optional is driven off the value's
+  /// presence (`{{#base}}`/`{{#returns}}`). Its interpolations are triple-mustache
+  /// (`{{{…}}}`, raw) rather than double: the output is Swift source, not HTML, so
+  /// the type spellings' angle brackets (`UnsafePointer<…>`) must not be escaped.
+  private static func template(named name: String,
+                               search: Array<String>) throws -> String {
+    guard let url = resource(name, "mustache", kind: "Templates",
+                             search: search)
+    else { throw RenderError.template(name) }
+    let data = try Data(contentsOf: url)
+    return String(decoding: data, as: UTF8.self)
+  }
+
+  /// The text of the render query named `name`, loaded through the search path
+  /// (a `-I` directory's `Render/<name>.sql`) then the bundled
+  /// `Resources/Render/<name>.sql`.
+  ///
+  /// The render's data tier — the `SELECT`s that read the bundled views — is
+  /// resource data, not Swift literals: each is a `Render/<name>.sql` loaded by
+  /// name (a `-I` directory's copy shadowing the bundle's), the same way the
+  /// template is. A name no search directory and no bundle resolves is a
+  /// packaging error, raised as `RenderError.query`.
+  private static func query(named name: String,
+                            search: Array<String>) throws -> String {
+    guard let url = resource(name, "sql", kind: "Render", search: search)
+    else { throw RenderError.query(name) }
+    let data = try Data(contentsOf: url)
+    return String(decoding: data, as: UTF8.self)
+  }
+
+  /// Parses `text` as a `SELECT`, returning its `SQL.Query`.
+  ///
+  /// The render's queries are static, well-formed `SELECT`s, so a parse failure
+  /// or a non-`SELECT` is a programming error; it surfaces as the thrown error.
+  /// The return type is spelled `SQL.Query` — the module's own `Query` is the
+  /// `ParsableCommand` subcommand, not the SQL AST.
+  private static func select(_ text: String) throws -> SQL.Query {
+    guard case let .select(query) = try Statement(parsing: text) else {
+      throw SQLError.incomplete(expected: "a SELECT")
+    }
+    return query
+  }
+
+  /// The target-language spec a template body declares, consuming its leading
+  /// `{{! language: <name> }}` directive.
+  ///
+  /// A template is written for a target language, and it names that language in a
+  /// leading Mustache-comment directive so the association is the template
+  /// author's, in data — not a mapping compiled into the binary. This strips the
+  /// directive line from `body` (leaving a clean template) and loads
+  /// `<name>.lang`; a body with no directive keeps its text and gets the identity
+  /// `Language` (no escaping, no conventions).
+  private static func language(declaredIn body: inout String,
+                               search: Array<String>) -> Language {
+    guard let newline = body.firstIndex(where: \.isNewline) else {
+      return Language()
+    }
+    let directive = body[..<newline].trimmed
+    let opening = "{{! language:", closing = "}}"
+    guard directive.hasPrefix(opening), directive.hasSuffix(closing) else {
+      return Language()
+    }
+    let name =
+        directive.dropFirst(opening.count).dropLast(closing.count).trimmed
+    body = String(body[body.index(after: newline)...])
+    return Shell.language(named: name, search: search)
+  }
+
+  /// The target-language spec named `name`, loaded through the search path (a
+  /// `-I` directory's `Languages/<name>.lang`) then the bundled
+  /// `Resources/Languages/<name>.lang`. A name no search directory and no bundle
+  /// resolves gives the identity `Language`, so a template may declare a language
+  /// with no spec (or none at all) and still render — verbatim.
+  private static func language(named name: String,
+                              search: Array<String>) -> Language {
+    guard let url = resource(name, "lang", kind: "Languages", search: search),
+        let data = try? Data(contentsOf: url) else {
+      return Language()
+    }
+    return Language(parsing: String(decoding: data, as: UTF8.self))
+  }
+}
+
+/// Locates resource `<name>.<ext>` of the given `kind` (`Render`, `Queries`,
+/// or `Templates`), preferring a user override: the search directories are
+/// tried last-first as `<dir>/<kind>/<name>.<ext>` (so a later `-I` wins over
+/// an earlier one), then the package bundle's `Resources/<kind>/<name>.<ext>`.
+/// `nil` when none has it.
+private func resource(_ name: String, _ ext: String, kind: String,
+                      search: Array<String>) -> URL? {
+  for directory in search.reversed() {
+    let path = "\(directory)/\(kind)/\(name).\(ext)"
+    if FileManager.default.fileExists(atPath: path) {
+      return URL(fileURLWithPath: path)
+    }
+  }
+  return Bundle.module.url(forResource: name, withExtension: ext,
+                           subdirectory: "Resources/\(kind)")
 }
 
 // MARK: - Statements
@@ -332,6 +629,84 @@ extension Session {
   }
 }
 
+// MARK: - Bundled views
+
+extension Session {
+  /// The session's built-in views, keyed case-folded — the union of the bundled
+  /// query resources and any a `-I` search directory adds, each parsed the way
+  /// a `CREATE VIEW` line registers, so a test (or the session's seed) can
+  /// build the dictionary without driving the shell.
+  ///
+  /// This is the general seed operation: gather the view names from the bundled
+  /// query set (`Resources/Queries/*.sql`) and every search directory's
+  /// `Queries/*.sql`, then for each name load the first search directory that
+  /// has it (else the bundle), parse it as a `CREATE VIEW`, and register it —
+  /// so a `-I` directory both shadows an existing view and adds a new one. The
+  /// four COM-interface views are the one bundled set, so adding a query later
+  /// is dropping in another `.sql` beside them (or under a `-I` directory) — no
+  /// code change. The views are order-independent (none references another), so
+  /// the enumeration order does not matter.
+  ///
+  /// These views denormalise a COM interface for rendering: an `interfaces`
+  /// view that navigates each `TypeDef` to its `GuidAttribute` IID across the
+  /// coded-index join keys — `TypeDef` ← `CustomAttribute.Parent_TypeDef`,
+  /// then `CustomAttribute.Type_MemberRef` → `MemberRef`, then
+  /// `MemberRef.Class_TypeRef` → `TypeRef`, filtered to the `GuidAttribute`
+  /// declaring type, projecting `CustomAttribute.guid` as the `iid` — a
+  /// `methods` view of one interface's methods, a `params` view of one
+  /// method's parameters, and a `bases` view of one interface's base type. The
+  /// latter three carry a uniform `:parent` param — the owning row's `rowid` —
+  /// so a render can walk interface → methods → params, binding each level's
+  /// `rowid` to the next's `:parent`, and look up the interface's base by its
+  /// `rowid`.
+  ///
+  /// The `bases` view navigates the interface's single `InterfaceImpl` row
+  /// (whose simple `Class` index is the interface's 1-based `rowid`) to its
+  /// base type's simple name, projecting `TypeRef.TypeName` as `base`. The
+  /// `Class` column is a *simple* `TypeDef` index — it stores the `rowid`
+  /// directly, so the predicate is `i.Class = :parent` (there is no decoded
+  /// `Class_TypeDef` join key — `WinMDRelation.keys` derives keys only for
+  /// *coded* indices). `Interface` is the coded `TypeDefOrRef`, so its decoded
+  /// `Interface_TypeRef` key equi-joins the base `TypeRef`. Both arms of the
+  /// coded index resolve, `UNION`ed: a cross-file base through
+  /// `Interface_TypeRef` (a `TypeRef`) and a same-file base through
+  /// `Interface_TypeDef` (a `TypeDef` in this module).
+  ///
+  /// A query resource is static, well-formed SQL, so a parse failure is a
+  /// programming error rather than user input; it is silently skipped here (the
+  /// view simply does not register).
+  internal static func bundled(search: Array<String> = [])
+      -> Dictionary<String, View> {
+    // The view names to seed: those bundled, plus any a search directory adds.
+    var names = Set<String>()
+    for url in Bundle.module.urls(forResourcesWithExtension: "sql",
+                                  subdirectory: "Resources/Queries") ?? [] {
+      // `urls(forResourcesWithExtension:)` vends `NSURL` on non-Darwin
+      // Foundation, whose path API differs; bridge it to `URL`.
+      names.insert((url as URL).deletingPathExtension().lastPathComponent)
+    }
+    for directory in search {
+      let path = "\(directory)/Queries"
+      let files =
+          (try? FileManager.default.contentsOfDirectory(atPath: path)) ?? []
+      for file in files where file.hasSuffix(".sql") {
+        names.insert(String(file.dropLast(4)))
+      }
+    }
+    // Each name loads from the first search dir that has it, else the bundle.
+    var views = Dictionary<String, View>()
+    for name in names {
+      guard let url = resource(name, "sql", kind: "Queries", search: search),
+            let data = try? Data(contentsOf: url) else { continue }
+      let text = String(decoding: data, as: UTF8.self).trimmed.statement
+      if case let .create(view, definition)? = try? Statement(parsing: text) {
+        views[view.lowercased()] = definition
+      }
+    }
+    return views
+  }
+}
+
 // MARK: - Helpers
 
 extension StringProtocol {
@@ -358,5 +733,19 @@ extension Value {
     case let .integer(integer): "\(integer)"
     case let .text(text):       text
     }
+  }
+
+  /// This cell's `text`, the empty string for any non-text cell — the render
+  /// only ever reads `.text` columns (names, types, the IID), so a non-text
+  /// cell is a NULL the caller has already filtered.
+  internal var text: String {
+    if case let .text(text) = self { text } else { "" }
+  }
+
+  /// This cell's `integer`, zero for any non-integer cell — the render reads a
+  /// `rowid`/`Sequence` `.integer` column to navigate a signature, so a
+  /// non-integer cell is a NULL the query guarantees never appears there.
+  internal var integer: Int {
+    if case let .integer(integer) = self { integer } else { 0 }
   }
 }

--- a/Tests/WinMDSynthesisTests/DecodeTests.swift
+++ b/Tests/WinMDSynthesisTests/DecodeTests.swift
@@ -5,10 +5,50 @@ import Testing
 @testable import WinMDSynthesis
 @testable import WinMD
 
+/// The Swift `Dialect` the decode tests spell against — the same strings the
+/// bundled `swift.lang` carries, so the assertions read the exact Swift spellings
+/// as before the decode was parameterised by a dialect.
+extension Dialect {
+  static var swift: Dialect {
+    Dialect(
+        primitives: [
+          "void": "Void", "bool": "CBool", "char": "Unicode.UTF16.CodeUnit",
+          "i1": "CChar", "u1": "CUnsignedChar", "i2": "CShort",
+          "u2": "CUnsignedShort", "i4": "CInt", "u4": "CUnsignedInt",
+          "i8": "CLongLong", "u8": "CUnsignedLongLong", "f4": "CFloat",
+          "f8": "CDouble", "iptr": "Int", "uptr": "UInt", "string": "HSTRING",
+          "object": "UnsafeMutableRawPointer",
+          "typedref": "UnsafeMutableRawPointer",
+        ],
+        pointer: (typed: (mutable: "UnsafeMutablePointer",
+                          constant: "UnsafePointer"),
+                  untyped: (mutable: "UnsafeMutableRawPointer",
+                            constant: "UnsafeRawPointer")),
+        optional: "?",
+        generic: (open: "<", close: ">"),
+        variable: (type: "T", method: "M"),
+        opaque: "UnsafeMutableRawPointer",
+        guid: (iid: "IID", clsid: "CLSID"),
+        known: [
+          Identity(namespace: "Windows.Win32.Foundation", name: "HRESULT"):
+              "HRESULT",
+          Identity(namespace: "Windows.Win32.Foundation", name: "BOOL"):
+              "BOOL",
+        ],
+        escape: { keyword in
+          ["class", "default", "in", "protocol", "repeat"].contains(keyword)
+              ? "`\(keyword)`" : keyword
+        })
+  }
+}
+
 struct DecodeTests {
   // A resolver that resolves nothing; the pure cases never consult it, and the
   // named cases are exercised end-to-end by the synthesizer's golden tests.
   private var resolver: Resolver { Resolver([:]) }
+
+  // The Swift dialect every case spells against.
+  private var dialect: Dialect { .swift }
 
   @Test("a primitive decodes to its C typealias spelling")
   func primitives() {
@@ -30,32 +70,35 @@ struct DecodeTests {
       (.string, "HSTRING"),
     ]
     for (primitive, spelling) in cases {
-      #expect(SignatureType.primitive(primitive).decode(with: resolver)
-                  == spelling)
+      #expect(SignatureType.primitive(primitive)
+                  .decode(with: resolver, dialect: dialect) == spelling)
     }
   }
 
   @Test("a pointer wraps its decoded pointee")
   func pointers() {
-    #expect(SignatureType.pointer(.primitive(.void)).decode(with: resolver)
+    #expect(SignatureType.pointer(.primitive(.void))
+                .decode(with: resolver, dialect: dialect)
                 == "UnsafeMutableRawPointer")
-    #expect(SignatureType.pointer(.primitive(.int4)).decode(with: resolver)
+    #expect(SignatureType.pointer(.primitive(.int4))
+                .decode(with: resolver, dialect: dialect)
                 == "UnsafeMutablePointer<CInt>")
     #expect(SignatureType.pointer(.pointer(.primitive(.void)))
-                .decode(with: resolver)
+                .decode(with: resolver, dialect: dialect)
                 == "UnsafeMutablePointer<UnsafeMutableRawPointer?>")
     // A UTF-16 buffer (a `PWSTR`-shaped char pointer) stays a pointer — the
     // `HSTRING` mapping is for `ELEMENT_TYPE_STRING`, not for char pointers.
-    #expect(SignatureType.pointer(.primitive(.char)).decode(with: resolver)
+    #expect(SignatureType.pointer(.primitive(.char))
+                .decode(with: resolver, dialect: dialect)
                 == "UnsafeMutablePointer<Unicode.UTF16.CodeUnit>")
   }
 
   @Test("a generic variable decodes to a T/M-prefixed placeholder")
   func variables() {
-    #expect(SignatureType.variable(scope: .type, 0).decode(with: resolver)
-                == "T0")
-    #expect(SignatureType.variable(scope: .method, 2).decode(with: resolver)
-                == "M2")
+    #expect(SignatureType.variable(scope: .type, 0)
+                .decode(with: resolver, dialect: dialect) == "T0")
+    #expect(SignatureType.variable(scope: .method, 2)
+                .decode(with: resolver, dialect: dialect) == "M2")
   }
 
   @Test("only an IsConst custom modifier marks a pointee const")
@@ -74,13 +117,15 @@ struct DecodeTests {
     // `*modopt(IsConst) int` decodes to a `const` pointer.
     let immutable = SignatureType.modified(.primitive(.int4),
         modifiers: [Modifier(required: false, type: marker)])
-    #expect(SignatureType.pointer(immutable).decode(with: resolver)
+    #expect(SignatureType.pointer(immutable)
+                .decode(with: resolver, dialect: dialect)
                 == "UnsafePointer<CInt>")
 
     // A non-`IsConst` modifier leaves the pointer mutable.
     let mutable = SignatureType.modified(.primitive(.int4),
         modifiers: [Modifier(required: false, type: other)])
-    #expect(SignatureType.pointer(mutable).decode(with: resolver)
+    #expect(SignatureType.pointer(mutable)
+                .decode(with: resolver, dialect: dialect)
                 == "UnsafeMutablePointer<CInt>")
   }
 
@@ -95,7 +140,8 @@ struct DecodeTests {
     // `IReference`1<int>` composes the Swift generic without the arity suffix.
     let instance = SignatureType.instance(.named(kind: .class, reference),
                                           [.primitive(.int4)])
-    #expect(instance.decode(with: resolver) == "IReference<CInt>")
+    #expect(instance.decode(with: resolver, dialect: dialect)
+                == "IReference<CInt>")
   }
 
   @Test("a generic over an unresolved base degrades to the opaque pointer")
@@ -105,7 +151,36 @@ struct DecodeTests {
     let base = TypeDefOrRef(rawValue: 1)
     let instance = SignatureType.instance(.named(kind: .class, base),
                                           [.primitive(.int4)])
-    #expect(instance.decode(with: Resolver([:])) == "UnsafeMutableRawPointer")
+    #expect(instance.decode(with: Resolver([:]), dialect: dialect)
+                == "UnsafeMutableRawPointer")
+  }
+
+  @Test("a named type whose simple name is a keyword is escaped")
+  func keywordNamedType() {
+    // A metadata type whose simple name collides with a target keyword
+    // (`protocol`, `repeat`, …) spells escaped, like a declaration name, so a
+    // parameter or return of that type still compiles.
+    let reference = TypeDefOrRef(rawValue: 1)
+    let resolver = Resolver([
+      reference.rawValue: Identity(namespace: "NS", name: "protocol"),
+    ])
+    #expect(SignatureType.named(kind: .class, reference)
+                .decode(with: resolver, dialect: dialect) == "`protocol`")
+  }
+
+  @Test("a generic base is escaped after its CLR arity is stripped")
+  func keywordGenericBase() {
+    // The generic definition's name carries the arity suffix (`protocol``1`),
+    // so it matches no keyword until the suffix is stripped; the base must be
+    // escaped after the strip, not before, or it spells `protocol<CInt>`.
+    let base = TypeDefOrRef(rawValue: 1)
+    let resolver = Resolver([
+      base.rawValue: Identity(namespace: "NS", name: "protocol`1"),
+    ])
+    let instance = SignatureType.instance(.named(kind: .class, base),
+                                          [.primitive(.int4)])
+    #expect(instance.decode(with: resolver, dialect: dialect)
+                == "`protocol`<CInt>")
   }
 
   @Test("a generic argument keeps the parameter-name class-ID hint")
@@ -121,10 +196,12 @@ struct DecodeTests {
                                            [.named(kind: .value, guid)])
 
     // The `clsid` hint reaches the `System.Guid` argument…
-    #expect(reference.decode(parameter: "clsid", with: resolver)
+    #expect(reference.decode(parameter: "clsid", with: resolver,
+                             dialect: dialect)
                 == "IReference<CLSID>")
     // …and absent a hint it defaults to `IID`.
-    #expect(reference.decode(with: resolver) == "IReference<IID>")
+    #expect(reference.decode(with: resolver, dialect: dialect)
+                == "IReference<IID>")
   }
 
   @Test("a non-void pointer-to-pointer keeps the optional inner slot")
@@ -139,19 +216,19 @@ struct DecodeTests {
 
     // `int **` → pointer to an *optional* mutable pointer.
     #expect(SignatureType.pointer(.pointer(.primitive(.int4)))
-                .decode(with: resolver)
+                .decode(with: resolver, dialect: dialect)
                 == "UnsafeMutablePointer<UnsafeMutablePointer<CInt>?>")
 
     // `const int **` → the inner pointer is immutable, the slot still optional.
     let constInt = SignatureType.pointer(.pointer(
         .modified(.primitive(.int4),
                   modifiers: [Modifier(required: false, type: marker)])))
-    #expect(constInt.decode(with: resolver)
+    #expect(constInt.decode(with: resolver, dialect: dialect)
                 == "UnsafeMutablePointer<UnsafePointer<CInt>?>")
 
     // `IFoo **` → pointer to an *optional* typed pointer.
     #expect(SignatureType.pointer(.pointer(.named(kind: .class, foo)))
-                .decode(with: resolver)
+                .decode(with: resolver, dialect: dialect)
                 == "UnsafeMutablePointer<UnsafeMutablePointer<IFoo>?>")
   }
 
@@ -166,7 +243,8 @@ struct DecodeTests {
     // `void * const *` decodes to a pointer to an immutable raw pointer.
     let immutable = SignatureType.modified(.pointer(.primitive(.void)),
         modifiers: [Modifier(required: false, type: marker)])
-    #expect(SignatureType.pointer(immutable).decode(with: resolver)
+    #expect(SignatureType.pointer(immutable)
+                .decode(with: resolver, dialect: dialect)
                 == "UnsafePointer<UnsafeMutableRawPointer?>")
   }
 
@@ -183,7 +261,8 @@ struct DecodeTests {
     let inner = SignatureType.pointer(
         .modified(.primitive(.void),
                   modifiers: [Modifier(required: false, type: marker)]))
-    #expect(SignatureType.pointer(inner).decode(with: resolver)
+    #expect(SignatureType.pointer(inner)
+                .decode(with: resolver, dialect: dialect)
                 == "UnsafeMutablePointer<UnsafeRawPointer?>")
   }
 }

--- a/Tests/winmd-inspectTests/DatabaseSQLTests.swift
+++ b/Tests/winmd-inspectTests/DatabaseSQLTests.swift
@@ -7,6 +7,7 @@ import Testing
 
 import SQL
 @testable import WinMD
+import WinMDSynthesis
 
 import struct Foundation.Data
 import struct Foundation.URL
@@ -14,9 +15,47 @@ import class Foundation.FileManager
 import struct Foundation.UUID
 import func Foundation.NSTemporaryDirectory
 
-/// Coverage of the per-table decoded virtual columns the WinMD → SQL adapter
-/// exposes: `guid` on `CustomAttribute`, `ReturnType` on `MethodDef`, and
-/// `ParamType` on `Param`. Rather than map a `.winmd` file, the tests assemble a
+/// The Swift `Dialect` the render-time signature decode spells against — the same
+/// strings the bundled `swift.lang` carries, so the helper assertions read the
+/// exact Swift spellings the old `ReturnType`/`ParamType` virtual columns did.
+extension Dialect {
+  static var swift: Dialect {
+    Dialect(
+        primitives: [
+          "void": "Void", "bool": "CBool", "char": "Unicode.UTF16.CodeUnit",
+          "i1": "CChar", "u1": "CUnsignedChar", "i2": "CShort",
+          "u2": "CUnsignedShort", "i4": "CInt", "u4": "CUnsignedInt",
+          "i8": "CLongLong", "u8": "CUnsignedLongLong", "f4": "CFloat",
+          "f8": "CDouble", "iptr": "Int", "uptr": "UInt", "string": "HSTRING",
+          "object": "UnsafeMutableRawPointer",
+          "typedref": "UnsafeMutableRawPointer",
+        ],
+        pointer: (typed: (mutable: "UnsafeMutablePointer",
+                          constant: "UnsafePointer"),
+                  untyped: (mutable: "UnsafeMutableRawPointer",
+                            constant: "UnsafeRawPointer")),
+        optional: "?",
+        generic: (open: "<", close: ">"),
+        variable: (type: "T", method: "M"),
+        opaque: "UnsafeMutableRawPointer",
+        guid: (iid: "IID", clsid: "CLSID"),
+        known: [
+          Identity(namespace: "Windows.Win32.Foundation", name: "HRESULT"):
+              "HRESULT",
+          Identity(namespace: "Windows.Win32.Foundation", name: "BOOL"):
+              "BOOL",
+        ],
+        escape: { keyword in
+          ["class", "default", "in", "protocol", "repeat"].contains(keyword)
+              ? "`\(keyword)`" : keyword
+        })
+  }
+}
+
+/// Coverage of the WinMD → SQL adapter's decoded `guid` virtual column on
+/// `CustomAttribute` and the render-time signature decode (`decodedReturn`/
+/// `decodedParameter`), which the adapter no longer bakes as `ReturnType`/
+/// `ParamType` columns. Rather than map a `.winmd` file, the tests assemble a
 /// tiny COM
 /// interface in memory — a `TypeDef` carrying a `GuidAttribute` (through the
 /// `CustomAttribute` → `MemberRef` → `TypeRef` chain), a `MethodDef` whose
@@ -25,7 +64,8 @@ import func Foundation.NSTemporaryDirectory
 /// parameters), and an `InterfaceImpl` row naming the base `IInspectable`
 /// `TypeRef` (so the `bases` view derives the interface's base) — and drive a
 /// parsed `SELECT` through `Engine.run` over the `WinMD.Storage` catalog,
-/// asserting the decoded `Value`s the engine yields.
+/// asserting the decoded `Value`s the engine yields (or the spellings the render
+/// decode composes).
 struct DatabaseSQLTests {
   // The records of seven narrow (all-index 2-byte) tables, packed back to back
   // in table-number order. ECMA-335 rows are 1-based, so a stored index `N`
@@ -52,6 +92,10 @@ struct DatabaseSQLTests {
   //                the rowid directly, so 1)=IMyInterface;
   //                Interface=TypeDefOrRef(TypeRef row 2)=(2<<2)|1=9 — names the
   //                base `IInspectable`, so the `bases` view derives it.
+  //   InterfaceImpl[1]: Class=1=IMyInterface; Interface=TypeDefOrRef(TypeDef
+  //                row 2)=(2<<2)|0=8 — a second base, `INotGuid`, defined in the
+  //                SAME file, so `Interface_TypeRef` is NULL and `bases` must
+  //                resolve it through the `Interface_TypeDef` UNION arm.
   //   MemberRef[0]: Class=MemberRefParent(TypeRef row 1)=(1<<3)|1=9 — the ctor
   //                whose declaring type is the `GuidAttribute` TypeRef.
   //   CustomAttribute[0]: Parent=HasCustomAttribute(TypeDef row 1)=(1<<5)|3=35,
@@ -77,6 +121,8 @@ struct DatabaseSQLTests {
     0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
     // InterfaceImpl[0]
     0x01, 0x00, 0x09, 0x00,
+    // InterfaceImpl[1]
+    0x01, 0x00, 0x08, 0x00,
     // MemberRef[0]
     0x09, 0x00, 0x00, 0x00, 0x00, 0x00,
     // CustomAttribute[0]
@@ -128,11 +174,11 @@ struct DatabaseSQLTests {
                 wide: 0, stride: 14),
     WinMD.Table(Metadata.Tables.Param.self, rows: 3, range: 54 ..< 72,
                 wide: 0, stride: 6),
-    WinMD.Table(Metadata.Tables.InterfaceImpl.self, rows: 1, range: 72 ..< 76,
+    WinMD.Table(Metadata.Tables.InterfaceImpl.self, rows: 2, range: 72 ..< 80,
                 wide: 0, stride: 4),
-    WinMD.Table(Metadata.Tables.MemberRef.self, rows: 1, range: 76 ..< 82,
+    WinMD.Table(Metadata.Tables.MemberRef.self, rows: 1, range: 80 ..< 86,
                 wide: 0, stride: 6),
-    WinMD.Table(Metadata.Tables.CustomAttribute.self, rows: 1, range: 82 ..< 88,
+    WinMD.Table(Metadata.Tables.CustomAttribute.self, rows: 1, range: 86 ..< 92,
                 wide: 0, stride: 6),
   ]
 
@@ -183,6 +229,70 @@ struct DatabaseSQLTests {
     return try Engine.run(select, Session(catalog, views))
   }
 
+  /// Plans and runs `query` through the engine over a `Session` catalog
+  /// overlaying `views` on the storage, with `bindings` resolving any `:name`
+  /// parameter (a view's correlated-subquery predicate binds from these).
+  private static func run(_ query: String,
+                          _ views: Dictionary<String, View>,
+                          _ catalog: borrowing Storage,
+                          _ bindings: Bindings)
+      throws -> Array<Array<Value>> {
+    let statement = try Statement(parsing: query)
+    guard case let .select(select) = statement else {
+      Issue.record("not a SELECT")
+      return []
+    }
+    return try Engine.run(select, Session(catalog, views), Routines(),
+                          bindings: bindings)
+  }
+
+  @Test("the bundled `interfaces` view yields the IID-carrying TypeDef")
+  func bundledInterfaces() throws {
+    // The `interfaces` view navigates each `TypeDef` to its `GuidAttribute` IID
+    // across the coded-index join keys (`TypeDef` ← `CustomAttribute` →
+    // `MemberRef` → `TypeRef`), projecting the decoded `CustomAttribute.guid` as
+    // `iid`; the only IID-carrying type is `IMyInterface`, whose `iid` is the
+    // well-known value.
+    try DatabaseSQLTests.with { catalog in
+      let rows = try DatabaseSQLTests.run(
+          "SELECT TypeName, iid FROM interfaces", Session.bundled(), catalog)
+      #expect(rows == [
+        [.text("IMyInterface"),
+         .text("0C733A30-2A1C-11CE-ADE5-00AA0044773D")],
+      ])
+    }
+  }
+
+  @Test("the bundled `methods` view yields a method bound by its parent rowid")
+  func bundledMethods() throws {
+    // `IMyInterface` is `TypeDef` rowid 1, which owns `MethodDef` rowid 1;
+    // binding `:parent` to the interface's rowid yields the method's `rowid` and
+    // `Name` (the type is no longer a column — the render decodes it).
+    try DatabaseSQLTests.with { catalog in
+      let rows = try DatabaseSQLTests.run(
+          "SELECT rowid, Name FROM methods", Session.bundled(), catalog,
+          ["parent": .integer(1)])
+      #expect(rows == [[.integer(1), .text("MyMethod")]])
+    }
+  }
+
+  @Test("the bundled `params` view yields params bound by their method rowid")
+  func bundledParams() throws {
+    // `MethodDef` rowid 1 owns the three `Param` rows; binding `:parent` to it
+    // yields each parameter's `rowid`, `Name`, and `Sequence` (the type is no
+    // longer a column — the render navigates from these and decodes it).
+    try DatabaseSQLTests.with { catalog in
+      let rows = try DatabaseSQLTests.run(
+          "SELECT rowid, Name, Sequence FROM params", Session.bundled(),
+          catalog, ["parent": .integer(1)])
+      #expect(rows == [
+        [.integer(1), .text(""), .integer(0)],
+        [.integer(2), .text("first"), .integer(1)],
+        [.integer(3), .text(""), .integer(2)],
+      ])
+    }
+  }
+
   @Test("a registered view is queryable through the session catalog")
   func sessionView() throws {
     // `CREATE VIEW guids …` registers a view over `CustomAttribute`'s decoded
@@ -213,17 +323,70 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("a view over a decoded extra joins through the session catalog")
-  func sessionViewMethod() throws {
-    // A view over `MethodDef`'s decoded `ReturnType` extra resolves and yields
-    // the decoded return spelling, proving the session catalog vends the same
-    // storage-backed relation the engine plans over.
+  @Test("the render decode spells a method's return from its signature")
+  func decodedReturnHelper() {
+    // The render decodes a return at render time (not through a virtual column):
+    // `MethodDef` rowid 1's signature `void Method(i4, string)` decodes its
+    // return to `Void`.
+    DatabaseSQLTests.with { catalog in
+      #expect(decodedReturn(of: 1, in: catalog, dialect: .swift) == "Void")
+    }
+  }
+
+  @Test("the `interfaces` view excludes a type with no GuidAttribute")
+  func interfacesViewExcludes() throws {
+    // `INotGuid` (TypeDef row 2) carries no `GuidAttribute`, so the view's
+    // navigation finds no matching `CustomAttribute` chain for it: it does not
+    // appear, leaving only `IMyInterface`.
     try DatabaseSQLTests.with { catalog in
-      let (name, view) = try DatabaseSQLTests.create(
-          "CREATE VIEW returns AS SELECT Name, ReturnType FROM MethodDef")
       let rows = try DatabaseSQLTests.run(
-          "SELECT Name, ReturnType FROM returns", [name: view], catalog)
-      #expect(rows == [[.text("MyMethod"), .text("Void")]])
+          "SELECT TypeName FROM interfaces", Session.bundled(), catalog)
+      #expect(rows == [[.text("IMyInterface")]])
+    }
+  }
+
+  @Test("the `interfaces` view resolves a same-module MethodDef-ctor IID")
+  func interfacesViewSameModuleMethodDefCtor() throws {
+    // When `GuidAttribute` is defined in the same file, a type's
+    // `CustomAttribute.Type` names the attribute's `.ctor` directly as a
+    // `MethodDef` (not a cross-module `MemberRef`), so the `MemberRef` chains
+    // find nothing: the view's `Type_MethodDef → MethodDef.parent → TypeDef`
+    // arm navigates it instead. `IThing` carries such an attribute, so the view
+    // resolves its IID.
+    try SameModuleGuidFixture.with { catalog in
+      let rows = try DatabaseSQLTests.run(
+          "SELECT iid FROM interfaces WHERE TypeName = 'IThing'",
+          Session.bundled(), catalog)
+      #expect(rows == [[.text("0C733A30-2A1C-11CE-ADE5-00AA0044773D")]])
+    }
+  }
+
+  @Test("the `interfaces` view resolves a same-module MemberRef-ctor IID")
+  func interfacesViewSameModuleMemberRefCtor() throws {
+    // A same-file constructor can also be encoded as a `MemberRef` whose
+    // `Class` points back at the in-file `GuidAttribute` `TypeDef`, so the
+    // decoded key is `Class_TypeDef`, not `Class_TypeRef`, and the cross-module
+    // `MemberRef → TypeRef` arm drops it. The view's third arm,
+    // `Type_MemberRef → MemberRef.Class_TypeDef → TypeDef`, resolves it —
+    // `IOther` carries such an attribute.
+    try SameModuleGuidFixture.with { catalog in
+      let rows = try DatabaseSQLTests.run(
+          "SELECT iid FROM interfaces WHERE TypeName = 'IOther'",
+          Session.bundled(), catalog)
+      #expect(rows == [[.text("0C733A30-2A1C-11CE-ADE5-00AA0044773D")]])
+    }
+  }
+
+  @Test("the `interfaces` view excludes a GuidAttribute-carrying non-interface")
+  func interfacesViewExcludesNonInterface() throws {
+    // `CThing` is a coclass — a `TypeDef` carrying a `GuidAttribute` yet whose
+    // `Flags` clear the `tdInterface` (0x20) bit. Not every GUID-bearing type
+    // is a COM interface, so the view's `BITAND(t.Flags, 32) = 32` filter drops
+    // it, leaving only the interfaces `IThing` and `IOther`.
+    try SameModuleGuidFixture.with { catalog in
+      let rows = try DatabaseSQLTests.run(
+          "SELECT TypeName FROM interfaces", Session.bundled(), catalog)
+      #expect(rows == [[.text("IThing")], [.text("IOther")]])
     }
   }
 
@@ -251,46 +414,178 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("vends a MethodDef's decoded ReturnType")
-  func returnType() throws {
-    // The signature `void Method(i4, string)` decodes its return to `Void`.
-    try DatabaseSQLTests.with { catalog in
-      let rows = try DatabaseSQLTests.run(
-          "SELECT Name, ReturnType FROM MethodDef", catalog)
-      #expect(rows == [[.text("MyMethod"), .text("Void")]])
+  @Test("the render decode spells a MethodDef's return")
+  func returnType() {
+    // The signature `void Method(i4, string)` decodes its return to `Void`, the
+    // render-time decode replacing the old `ReturnType` virtual column.
+    DatabaseSQLTests.with { catalog in
+      #expect(decodedReturn(of: 1, in: catalog, dialect: .swift) == "Void")
     }
   }
 
-  @Test("vends each Param's decoded ParamType, NULL for the return parameter")
-  func paramType() throws {
-    // The `Sequence == 0` return pseudo-parameter decodes to NULL; the two real
-    // parameters decode to the signature's `i4` (`CInt`) and `string`
-    // (`HSTRING`).
-    try DatabaseSQLTests.with { catalog in
-      let rows = try DatabaseSQLTests.run(
-          "SELECT Sequence, ParamType FROM Param ORDER BY Sequence", catalog)
-      #expect(rows == [
-        [.integer(0), .null],
-        [.integer(1), .text("CInt")],
-        [.integer(2), .text("HSTRING")],
-      ])
+  @Test("the render decode spells each Param, nil for the return parameter")
+  func paramType() {
+    // The `Sequence == 0` return pseudo-parameter (`Param` rowid 1) decodes to
+    // `nil`; the two real parameters (rowids 2 and 3) decode to the signature's
+    // `i4` (`CInt`) and `string` (`HSTRING`) — the render-time decode replacing
+    // the old `ParamType` virtual column.
+    DatabaseSQLTests.with { catalog in
+      #expect(decodedParameter(of: 1, in: catalog, dialect: .swift) == nil)
+      #expect(decodedParameter(of: 2, in: catalog, dialect: .swift) == "CInt")
+      #expect(decodedParameter(of: 3, in: catalog, dialect: .swift)
+                  == "HSTRING")
     }
   }
 
-  @Test("excludes the return parameter through a ParamType filter")
-  func paramTypeNotNull() throws {
-    // A guard on `ParamType IS NOT NULL` drops the `Sequence == 0` return row,
-    // leaving the two real parameters.
+  @Test("the bundled `bases` view yields the interface's derived bases")
+  func bundledBases() throws {
+    // `IMyInterface` is `TypeDef` rowid 1; binding `:parent` to its rowid
+    // navigates `InterfaceImpl.Class = :parent`, and the view UNIONs both arms
+    // of the `Interface` coded index: the cross-file `IInspectable` reached
+    // through `Interface_TypeRef` → `TypeRef`, and the same-file `INotGuid`
+    // reached through `Interface_TypeDef` → `TypeDef`.
     try DatabaseSQLTests.with { catalog in
       let rows = try DatabaseSQLTests.run(
-          "SELECT ParamType FROM Param WHERE ParamType IS NOT NULL "
-          + "ORDER BY Sequence", catalog)
-      #expect(rows == [
-        [.text("CInt")],
-        [.text("HSTRING")],
-      ])
+          "SELECT base FROM bases", Session.bundled(), catalog,
+          ["parent": .integer(1)])
+      #expect(rows == [[.text("IInspectable")], [.text("INotGuid")]])
     }
   }
+
+  @Test("the bundled `bases` view is empty for a rootless interface")
+  func bundledBasesRoot() throws {
+    // `INotGuid` is `TypeDef` rowid 2 and has no `InterfaceImpl` row, so the
+    // view yields no base — the render's `IUnknown` default path.
+    try DatabaseSQLTests.with { catalog in
+      let rows = try DatabaseSQLTests.run(
+          "SELECT base FROM bases", Session.bundled(), catalog,
+          ["parent": .integer(2)])
+      #expect(rows.isEmpty)
+    }
+  }
+
+  @Test("renders the fixture interface's `@com` protocol from the views")
+  func render() throws {
+    // The render joins the bundled views — `interfaces` → `methods` → `params`
+    // → `bases` — and the Mustache template into the `@com` protocol source.
+    // The fixture is `IMyInterface` with the well-known IID and the single
+    // `MyMethod`, whose signature decodes to `void Method(i4, string)`: two real
+    // parameters (`first: CInt` and the unnamed `string`) and a `Void` return
+    // (so no return clause). The base is derived through the `bases` view from
+    // the interface's `InterfaceImpl` row — `IInspectable`, not the `IUnknown`
+    // default.
+    try DatabaseSQLTests.with { catalog in
+      let shell = Shell(catalog)
+      let rendered = try shell.render("IMyInterface", template: "com")
+      #expect(rendered == """
+        @com(interface: "0C733A30-2A1C-11CE-ADE5-00AA0044773D")
+        public protocol IMyInterface: IInspectable {
+            func MyMethod(_ first: CInt, _ : \
+        HSTRING)
+        }
+
+        """)
+    }
+  }
+
+  @Test("renders the `IUnknown` default for a rootless interface")
+  func renderRoot() throws {
+    // A `bases`-empty interface (no `InterfaceImpl` row) falls back to the
+    // `IUnknown` COM-root convention. The fixture's only IID-carrying type has
+    // an `InterfaceImpl`, so this overrides `bases` with a never-matching view
+    // (a `Class` no row holds), exercising the default branch while still
+    // rendering `IMyInterface` from the other views.
+    try DatabaseSQLTests.with { catalog in
+      var shell = Shell(catalog)
+      let query = """
+        CREATE VIEW bases AS SELECT b.TypeName AS base FROM InterfaceImpl i
+        JOIN TypeRef b ON i.Interface_TypeRef = b.rowid
+        WHERE i.Class = :parent AND i.Class = 0
+        """
+      let (name, view) = try DatabaseSQLTests.create(query)
+      shell.session.register(name, view)
+      let rendered = try shell.render("IMyInterface", template: "com")
+      #expect(rendered.contains("public protocol IMyInterface: IUnknown {"))
+    }
+  }
+
+  @Test("the root interface renders with no base, not self-inheritance")
+  func renderRootInterface() throws {
+    // When the rendered interface is the COM root itself (`IUnknown`), it
+    // implements nothing, so `bases` is empty. The root default must not then
+    // make it its own base — `public protocol IUnknown: IUnknown` is invalid
+    // Swift and would block rendering a winmd that defines the root. The render
+    // omits the inheritance clause entirely.
+    try RootInterfaceFixture.with { catalog in
+      let shell = Shell(catalog)
+      let rendered = try shell.render("IUnknown", template: "com")
+      #expect(rendered.contains("public protocol IUnknown {"))
+      #expect(!rendered.contains("IUnknown:"))
+    }
+  }
+
+  @Test("a keyword base interface name is escaped in the inheritance clause")
+  func renderKeywordBase() throws {
+    // A base whose `TypeName` is a Swift keyword (`protocol`, `repeat`, …) must
+    // be escaped in the `: <base>` clause, exactly as the interface, method, and
+    // parameter names are — otherwise `public protocol IMyInterface: protocol`
+    // would not compile. Overriding `bases` to yield a keyword base drives the
+    // render's `ESCAPE(base)`.
+    try DatabaseSQLTests.with { catalog in
+      var shell = Shell(catalog)
+      let query = """
+        CREATE VIEW bases AS
+        SELECT 'protocol' AS base FROM TypeDef WHERE rowid = :parent
+        """
+      let (name, view) = try DatabaseSQLTests.create(query)
+      shell.session.register(name, view)
+      let rendered = try shell.render("IMyInterface", template: "com")
+      #expect(rendered.contains("public protocol IMyInterface: `protocol` {"))
+    }
+  }
+
+  @Test("an unknown interface name raises a clear render error")
+  func renderUnknown() {
+    DatabaseSQLTests.with { catalog in
+      let shell = Shell(catalog)
+      #expect(throws: Shell.RenderError.interface("IMissing")) {
+        try shell.render("IMissing", template: "com")
+      }
+    }
+  }
+
+  @Test("execute routes `.render <iface> <tmpl>` to the render command")
+  func renderCommand() throws {
+    // The leading-token dispatch matches `.render` to `Render`, which renders
+    // the named interface through the named template (here the fixture's
+    // `IMyInterface` through `com`, so `execute` succeeds). Anything but two
+    // fields `execute` rejects as unknown — the `Render` command's guard — so a
+    // no-argument `.render` and a one-argument `.render IMyInterface` (missing
+    // template) both throw.
+    try DatabaseSQLTests.with { catalog in
+      var shell = Shell(catalog)
+      try shell.execute(".render IMyInterface com")
+      #expect(throws: Shell.MetaError.unknown(".render")) {
+        try shell.execute(".render")
+      }
+      #expect(throws: Shell.MetaError.unknown(".render")) {
+        try shell.execute(".render IMyInterface")
+      }
+    }
+  }
+
+  @Test("`*` renders every interface in the views")
+  func renderAll() throws {
+    // `*` drops the name filter and loops every interface; this fixture's
+    // `interfaces` view holds only `IMyInterface` (the IID-carrying type), so
+    // the sweep emits its protocol — exercising the no-filter `*` path.
+    try DatabaseSQLTests.with { catalog in
+      let shell = Shell(catalog)
+      let rendered = try shell.render("*", template: "com")
+      #expect(rendered.contains("public protocol IMyInterface"))
+    }
+  }
+
 
   @Test("a coded-index join key decodes to the target's rowid")
   func codedKeyResolves() throws {
@@ -355,13 +650,13 @@ struct DatabaseSQLTests {
 
   @Test("a script's CREATE VIEW is visible to a later statement's SELECT")
   func scriptSession() throws {
-    // The batch driver threads one shared `Session` across every statement, so a
-    // `CREATE VIEW` registered by one statement is visible to a later `SELECT`.
-    // `execute` prints rather than returning rows, so this drives the shared
-    // statement path directly — `Shell.execute` over the same session — to
-    // register the view (the `CREATE VIEW` branch), then resolves a `SELECT`
-    // naming it through the session's views, the exact session state the batch
-    // threads.
+    // The batch driver seeds the bundled views and threads one shared `Session`
+    // across every statement, so a `CREATE VIEW` registered by one statement is
+    // visible to a later `SELECT`. `execute` prints rather than returning rows,
+    // so this drives the shared statement path directly — `Shell.execute` over
+    // the same session — to register the view (the `CREATE VIEW` branch), then
+    // resolves a `SELECT` naming it through the session's views, the exact
+    // session state the batch threads.
     try DatabaseSQLTests.with { catalog in
       var shell = Shell(catalog)
       try shell.execute("CREATE VIEW names AS SELECT TypeName FROM TypeDef")
@@ -460,6 +755,24 @@ struct DatabaseSQLTests {
     }
   }
 
+  @Test("a script SELECTing a bundled view sees it through the seeded session")
+  func scriptBundledView() throws {
+    // The `script` runner seeds `Session.bundled()`, so a statement may name a
+    // bundled view (here `interfaces`) with no explicit `CREATE VIEW` — the gap
+    // the old one-shot path (an empty view set) could not span. The session
+    // core resolves `interfaces` through the seeded catalog to the only
+    // IID-carrying type.
+    try DatabaseSQLTests.with { catalog in
+      let views = Session.bundled()
+      let rows = try DatabaseSQLTests.run(
+          "SELECT TypeName, iid FROM interfaces", views, catalog)
+      #expect(rows == [
+        [.text("IMyInterface"),
+         .text("0C733A30-2A1C-11CE-ADE5-00AA0044773D")],
+      ])
+    }
+  }
+
   @Test("a coded-index join key admits one key per candidate target table")
   func codedKeyEnumeration() {
     // `CustomAttribute.Parent` is `HasCustomAttribute`, which admits 22 target
@@ -478,39 +791,106 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("an unowned Param's ParamType is NULL and does not trap")
-  func paramTypeUnowned() throws {
+  @Test("an unowned Param's render decode is nil and does not trap")
+  func paramTypeUnowned() {
     // A `Param` no `MethodDef` run owns — the `MethodDef` table is present but
-    // has zero rows, so its owner resolves to 0 — decodes to SQL NULL rather
-    // than indexing the negative row `owner - 1` through the parent cursor.
-    try UnownedParamFixture.with { catalog in
-      let rows = try DatabaseSQLTests.run(
-          "SELECT ParamType FROM Param", catalog)
-      #expect(rows == [[.null]])
+    // has zero rows, so its owner resolves to 0 — decodes to `nil` rather than
+    // indexing the negative row `owner - 1` through the parent cursor.
+    UnownedParamFixture.with { catalog in
+      #expect(decodedParameter(of: 1, in: catalog, dialect: .swift) == nil)
     }
   }
 
   @Test("a System.Guid Param decodes to CLSID or IID by its Name")
-  func paramTypeGuidClassification() throws {
+  func paramTypeGuidClassification() {
     // The signature `void Method(Guid, Guid)` names `System.Guid` parameters;
-    // the decoder classifies each by the `Param.Name` hint — `clsid` yields
-    // `CLSID`, an unrelated name (`iid`) yields the default `IID`.
-    try GuidParamFixture.with { catalog in
-      let rows = try DatabaseSQLTests.run(
-          "SELECT Name, ParamType FROM Param WHERE ParamType IS NOT NULL "
-          + "ORDER BY Sequence", catalog)
-      #expect(rows == [
-        [.text("clsid"), .text("CLSID")],
-        [.text("iid"), .text("IID")],
-      ])
+    // the render decode classifies each by the `Param.Name` hint — `clsid`
+    // (rowid 2) yields `CLSID`, `iid` (rowid 3) yields the default `IID`.
+    GuidParamFixture.with { catalog in
+      #expect(decodedParameter(of: 2, in: catalog, dialect: .swift) == "CLSID")
+      #expect(decodedParameter(of: 3, in: catalog, dialect: .swift) == "IID")
+    }
+  }
+
+  @Test("a `-I` directory's template shadows the bundled one")
+  func searchTemplateOverride() throws {
+    // A `-I` directory's `Templates/com.mustache` is loaded in place of the
+    // bundled template, so the render emits the override's text.
+    let root = NSTemporaryDirectory() + "winmd-inspect-\(UUID().uuidString)"
+    let templates = root + "/Templates"
+    try FileManager.default.createDirectory(atPath: templates,
+                                            withIntermediateDirectories: true)
+    try Data("OVERRIDDEN {{name}}".utf8)
+        .write(to: URL(fileURLWithPath: templates + "/com.mustache"))
+    defer { try? FileManager.default.removeItem(atPath: root) }
+    try DatabaseSQLTests.with { catalog in
+      let shell = Shell(catalog, search: [root])
+      let rendered = try shell.render("IMyInterface", template: "com")
+      #expect(rendered.contains("OVERRIDDEN"))
+    }
+  }
+
+  @Test("a `-I` directory's view joins the bundled ones in the seed")
+  func searchViewAddition() throws {
+    // A `-I` directory's `Queries/extra.sql` adds its view to the seed, while
+    // the bundled views (here `interfaces`) remain — the union.
+    let root = NSTemporaryDirectory() + "winmd-inspect-\(UUID().uuidString)"
+    let queries = root + "/Queries"
+    try FileManager.default.createDirectory(atPath: queries,
+                                            withIntermediateDirectories: true)
+    try Data("CREATE VIEW extra AS SELECT TypeName FROM TypeDef".utf8)
+        .write(to: URL(fileURLWithPath: queries + "/extra.sql"))
+    defer { try? FileManager.default.removeItem(atPath: root) }
+    let views = Session.bundled(search: [root])
+    #expect(views.keys.contains("extra"))
+    #expect(views.keys.contains("interfaces"))
+  }
+
+  @Test("a search directory without a match falls back to the bundle")
+  func searchFallsBackToBundle() throws {
+    // A `-I` directory that holds no matching resource leaves the render on the
+    // bundled template and views, so the normal `@com` protocol still renders.
+    let root = NSTemporaryDirectory() + "winmd-inspect-\(UUID().uuidString)"
+    try FileManager.default.createDirectory(atPath: root,
+                                            withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(atPath: root) }
+    try DatabaseSQLTests.with { catalog in
+      let shell = Shell(catalog, search: [root])
+      let rendered = try shell.render("IMyInterface", template: "com")
+      #expect(rendered.contains("public protocol IMyInterface"))
+    }
+  }
+
+  @Test("with two `-I` directories the last one wins")
+  func searchLastWins() throws {
+    // Both directories carry a `Templates/com.mustache`; the render must use the
+    // LAST `-I`'s copy, so a later directory overrides an earlier one.
+    let first = NSTemporaryDirectory() + "winmd-inspect-\(UUID().uuidString)"
+    let last = NSTemporaryDirectory() + "winmd-inspect-\(UUID().uuidString)"
+    for (root, tag) in [(first, "FIRST"), (last, "LAST")] {
+      let templates = root + "/Templates"
+      try FileManager.default.createDirectory(atPath: templates,
+                                              withIntermediateDirectories: true)
+      try Data("\(tag) {{name}}".utf8)
+          .write(to: URL(fileURLWithPath: templates + "/com.mustache"))
+    }
+    defer {
+      try? FileManager.default.removeItem(atPath: first)
+      try? FileManager.default.removeItem(atPath: last)
+    }
+    try DatabaseSQLTests.with { catalog in
+      let shell = Shell(catalog, search: [first, last])
+      let rendered = try shell.render("IMyInterface", template: "com")
+      #expect(rendered.contains("LAST"))
+      #expect(!rendered.contains("FIRST"))
     }
   }
 }
 
 /// A fixture whose `Param` row is owned by no `MethodDef` run: the `MethodDef`
 /// table is present (so the list link resolves to it) but has zero rows, so the
-/// owner of the lone `Param` resolves to 0. `SELECT ParamType FROM Param` must
-/// then yield SQL NULL rather than index a negative `MethodDef` row.
+/// owner of the lone `Param` resolves to 0. `decodedParameter` must then yield
+/// `nil` rather than index a negative `MethodDef` row.
 private enum UnownedParamFixture {
   // Two narrow tables packed back to back. `MethodDef` contributes no records
   // (zero rows); `Param` contributes one.
@@ -543,7 +923,7 @@ private enum UnownedParamFixture {
 }
 
 /// A fixture whose method takes two `System.Guid` parameters — one named
-/// `clsid`, one named `iid` — so the `ParamType` decode exercises the
+/// `clsid`, one named `iid` — so the render decode exercises the
 /// `Param.Name` classification hint: a `clsid`-rooted name spells `CLSID`, any
 /// other Guid parameter the default `IID`.
 private enum GuidParamFixture {
@@ -605,6 +985,211 @@ private enum GuidParamFixture {
   ]
 
   private static let valid: UInt64 = (1 << 1) | (1 << 6) | (1 << 8)
+
+  /// Runs `body` over a `Storage` catalog bound to the assembled metadata.
+  static func with(_ body: (borrowing Storage) throws -> Void) rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+}
+
+/// A fixture whose `GuidAttribute` is defined in the same file, so a type's
+/// `CustomAttribute.Type` names its in-file `.ctor` rather than a cross-module
+/// `MemberRef → TypeRef`: the `interfaces` view must reach the IID through one
+/// of its same-module arms. Both same-file encodings appear — the constructor as
+/// a bare `MethodDef` (`IThing`) and as a `MemberRef` whose `Class` points back
+/// at the in-file `TypeDef` (`IOther`) — alongside a GUID-bearing non-interface
+/// (`CThing`) exercising the `tdInterface` filter.
+private enum SameModuleGuidFixture {
+  // Five narrow (all-index 2-byte) tables packed back to back in table-number
+  // order; the empty `TypeRef` is present (so the view's cross-module arm plans)
+  // but contributes no rows. A stored index `N` names the 0-based row `N - 1`; a
+  // coded index is `(row << bits) | tag`.
+  //
+  //   TypeDef[0]:  Flags=0, TypeName="GuidAttribute"(35),
+  //                TypeNamespace="Windows.Win32.Foundation.Metadata"(1),
+  //                MethodList=1 — the in-file attribute, owning its `.ctor`
+  //                MethodDef[0]; the arms' owning `TypeDef` `g`.
+  //   TypeDef[1]:  Flags=0x21, TypeName="IThing"(52), TypeNamespace="NS"(49),
+  //                MethodList=2 — an interface whose attribute names the ctor
+  //                directly as a `MethodDef` (the `Type_MethodDef` arm).
+  //   TypeDef[2]:  Flags=0, TypeName="CThing"(59), TypeNamespace="NS"(49),
+  //                MethodList=2 — a coclass (tdInterface clear) also carrying
+  //                the `GuidAttribute`, so the view's flag filter excludes it.
+  //   TypeDef[3]:  Flags=0x21, TypeName="IOther"(66), TypeNamespace="NS"(49),
+  //                MethodList=2 — an interface whose attribute names the ctor as
+  //                a `MemberRef` into the in-file `TypeDef` (the `Class_TypeDef`
+  //                arm).
+  //   MethodDef[0]: Name=0, Signature=0, ParamList=1 — the `GuidAttribute`
+  //                `.ctor`, owned by TypeDef[0] (so its `parent` is rowid 1).
+  //   MemberRef[0]: Class=MemberRefParent(TypeDef row 1)=(1<<3)|0=8 — the ctor
+  //                reference whose declaring class is the in-file `GuidAttribute`
+  //                `TypeDef`, so `Class_TypeDef` (not `Class_TypeRef`) decodes.
+  //   CustomAttribute[0]: Parent=HasCustomAttribute(TypeDef row 2)=(2<<5)|3=67,
+  //                Type=CustomAttributeType(MethodDef row 1)=(1<<3)|2=10,
+  //                Value=blob[1] — `IThing`'s in-file GUID (MethodDef ctor).
+  //   CustomAttribute[1]: Parent=HasCustomAttribute(TypeDef row 3)=(3<<5)|3=99,
+  //                Type=CustomAttributeType(MethodDef row 1)=(1<<3)|2=10,
+  //                Value=blob[1] — `CThing`'s in-file GUID.
+  //   CustomAttribute[2]: Parent=HasCustomAttribute(TypeDef row 4)=(4<<5)|3=131,
+  //                Type=CustomAttributeType(MemberRef row 1)=(1<<3)|3=11,
+  //                Value=blob[1] — `IOther`'s in-file GUID (MemberRef ctor).
+  private static let bytes: Array<UInt8> = [
+    // TypeDef[0] — GuidAttribute
+    0x00, 0x00, 0x00, 0x00, 0x23, 0x00, 0x01, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+    // TypeDef[1] — IThing
+    0x21, 0x00, 0x00, 0x00, 0x34, 0x00, 0x31, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x02, 0x00,
+    // TypeDef[2] — CThing
+    0x00, 0x00, 0x00, 0x00, 0x3b, 0x00, 0x31, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x02, 0x00,
+    // TypeDef[3] — IOther
+    0x21, 0x00, 0x00, 0x00, 0x42, 0x00, 0x31, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x02, 0x00,
+    // MethodDef[0] — .ctor
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+    // MemberRef[0]
+    0x08, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // CustomAttribute[0..2]
+    0x43, 0x00, 0x0a, 0x00, 0x01, 0x00,
+    0x63, 0x00, 0x0a, 0x00, 0x01, 0x00,
+    0x83, 0x00, 0x0b, 0x00, 0x01, 0x00,
+  ]
+
+  // "\0Windows.Win32.Foundation.Metadata\0GuidAttribute\0NS\0IThing\0CThing\0
+  // IOther\0": GuidNamespace@1, GuidName@35, NS@49, IThing@52, CThing@59,
+  // IOther@66.
+  private static let strings: Array<UInt8> = [
+    0x00,
+    0x57, 0x69, 0x6e, 0x64, 0x6f, 0x77, 0x73, 0x2e, 0x57, 0x69, 0x6e, 0x33,
+    0x32, 0x2e, 0x46, 0x6f, 0x75, 0x6e, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e,
+    0x2e, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x00,
+    0x47, 0x75, 0x69, 0x64, 0x41, 0x74, 0x74, 0x72, 0x69, 0x62, 0x75, 0x74,
+    0x65, 0x00,
+    0x4e, 0x53, 0x00,
+    0x49, 0x54, 0x68, 0x69, 0x6e, 0x67, 0x00,
+    0x43, 0x54, 0x68, 0x69, 0x6e, 0x67, 0x00,
+    0x49, 0x4f, 0x74, 0x68, 0x65, 0x72, 0x00,
+  ]
+
+  // A `#Blob` heap: offset 0 is the reserved empty blob; offset 1 is the 20-byte
+  // `GuidAttribute` value (prolog 0x0001, the GUID as `u32, u16, u16, u8×8`,
+  // then NumNamed 0), preceded by its length 0x14. The GUID is the well-known
+  // `0C733A30-2A1C-11CE-ADE5-00AA0044773D`.
+  private static let blob: Array<UInt8> = [
+    0x00,
+    0x14, 0x01, 0x00, 0x30, 0x3a, 0x73, 0x0c, 0x1c, 0x2a, 0xce, 0x11,
+    0xad, 0xe5, 0x00, 0xaa, 0x00, 0x44, 0x77, 0x3d, 0x00, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 0, range: 0 ..< 0,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 4, range: 0 ..< 56,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.MethodDef.self, rows: 1, range: 56 ..< 70,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.MemberRef.self, rows: 1, range: 70 ..< 76,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.CustomAttribute.self, rows: 3, range: 76 ..< 94,
+                wide: 0, stride: 6),
+  ]
+
+  private static let valid: UInt64 =
+      (1 << 1) | (1 << 2) | (1 << 6) | (1 << 10) | (1 << 12)
+
+  /// Runs `body` over a `Storage` catalog bound to the assembled metadata.
+  static func with(_ body: (borrowing Storage) throws -> Void) rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+}
+
+/// A fixture whose sole interface is the COM root `IUnknown` itself — an
+/// in-file `GuidAttribute`-carrying `TypeDef` with no `InterfaceImpl` — so
+/// `bases` is empty and the render must omit the inheritance clause rather than
+/// make `IUnknown` inherit itself.
+private enum RootInterfaceFixture {
+  // Four narrow (all-index 2-byte) tables packed back to back in table-number
+  // order; the empty `TypeRef` and `MemberRef` are present so the `interfaces`
+  // view's cross-module arms plan. A stored index `N` names the 0-based row
+  // `N - 1`; a coded index is `(row << bits) | tag`.
+  //
+  //   TypeDef[0]:  Flags=0, TypeName="GuidAttribute"(35),
+  //                TypeNamespace="Windows.Win32.Foundation.Metadata"(1),
+  //                MethodList=1 — the in-file attribute, owning its `.ctor`.
+  //   TypeDef[1]:  Flags=0x21, TypeName="IUnknown"(52), TypeNamespace="NS"(49),
+  //                MethodList=2 — the COM root interface, carrying the
+  //                `GuidAttribute` yet implementing nothing (no `InterfaceImpl`).
+  //   MethodDef[0]: Name=0, Signature=0, ParamList=1 — the `GuidAttribute`
+  //                `.ctor`, owned by TypeDef[0].
+  //   CustomAttribute[0]: Parent=HasCustomAttribute(TypeDef row 2)=(2<<5)|3=67,
+  //                Type=CustomAttributeType(MethodDef row 1)=(1<<3)|2=10,
+  //                Value=blob[1] — `IUnknown`'s in-file GUID.
+  private static let bytes: Array<UInt8> = [
+    // TypeDef[0] — GuidAttribute
+    0x00, 0x00, 0x00, 0x00, 0x23, 0x00, 0x01, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+    // TypeDef[1] — IUnknown
+    0x21, 0x00, 0x00, 0x00, 0x34, 0x00, 0x31, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x02, 0x00,
+    // MethodDef[0] — .ctor
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+    // CustomAttribute[0]
+    0x43, 0x00, 0x0a, 0x00, 0x01, 0x00,
+  ]
+
+  // "\0Windows.Win32.Foundation.Metadata\0GuidAttribute\0NS\0IUnknown\0":
+  // GuidNamespace@1, GuidName@35, NS@49, IUnknown@52.
+  private static let strings: Array<UInt8> = [
+    0x00,
+    0x57, 0x69, 0x6e, 0x64, 0x6f, 0x77, 0x73, 0x2e, 0x57, 0x69, 0x6e, 0x33,
+    0x32, 0x2e, 0x46, 0x6f, 0x75, 0x6e, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e,
+    0x2e, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x00,
+    0x47, 0x75, 0x69, 0x64, 0x41, 0x74, 0x74, 0x72, 0x69, 0x62, 0x75, 0x74,
+    0x65, 0x00,
+    0x4e, 0x53, 0x00,
+    0x49, 0x55, 0x6e, 0x6b, 0x6e, 0x6f, 0x77, 0x6e, 0x00,
+  ]
+
+  // A `#Blob` heap: offset 0 is the reserved empty blob; offset 1 is the 20-byte
+  // `GuidAttribute` value (prolog 0x0001, the GUID, then NumNamed 0), preceded
+  // by its length 0x14. The GUID is the well-known
+  // `0C733A30-2A1C-11CE-ADE5-00AA0044773D`.
+  private static let blob: Array<UInt8> = [
+    0x00,
+    0x14, 0x01, 0x00, 0x30, 0x3a, 0x73, 0x0c, 0x1c, 0x2a, 0xce, 0x11,
+    0xad, 0xe5, 0x00, 0xaa, 0x00, 0x44, 0x77, 0x3d, 0x00, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 0, range: 0 ..< 0,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 2, range: 0 ..< 28,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.MethodDef.self, rows: 1, range: 28 ..< 42,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.InterfaceImpl.self, rows: 0, range: 42 ..< 42,
+                wide: 0, stride: 4),
+    WinMD.Table(Metadata.Tables.MemberRef.self, rows: 0, range: 42 ..< 42,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.CustomAttribute.self, rows: 1, range: 42 ..< 48,
+                wide: 0, stride: 6),
+  ]
+
+  private static let valid: UInt64 =
+      (1 << 1) | (1 << 2) | (1 << 6) | (1 << 9) | (1 << 10) | (1 << 12)
 
   /// Runs `body` over a `Storage` catalog bound to the assembled metadata.
   static func with(_ body: (borrowing Storage) throws -> Void) rethrows {

--- a/Tests/winmd-inspectTests/ShellTests.swift
+++ b/Tests/winmd-inspectTests/ShellTests.swift
@@ -6,6 +6,8 @@ import Testing
 @testable import winmd_inspect
 
 import SQL
+import WinMDSynthesis
+import WinMD
 
 struct ShellTests {
   @Test("each meta-command answers to its `.`-prefixed spelling")
@@ -16,6 +18,7 @@ struct ShellTests {
     #expect(Help.spelling == ".help")
     #expect(Quit.spelling == ".quit")
     #expect(Read.spelling == ".read")
+    #expect(Render.spelling == ".render")
   }
 
   @Test("`.read` parses its trailing path, trimming surrounding whitespace")
@@ -26,6 +29,18 @@ struct ShellTests {
     #expect(Read("  spaced.sql ").path == "spaced.sql")
     // No argument leaves an empty path — `execute` rejects it as unknown.
     #expect(Read("").path.isEmpty)
+  }
+
+  @Test("`.render` parses its interface and template arguments")
+  func render() {
+    // `Render.init` splits the rest of the statement into interface then
+    // template; both are required, so anything but two fields leaves them empty
+    // and `execute` rejects it.
+    let render = Render(" IFoo com ")
+    #expect(render.interface == "IFoo")
+    #expect(render.template == "com")
+    #expect(Render("IFoo").interface.isEmpty)
+    #expect(Render("").template.isEmpty)
   }
 
   @Test("a `;`-separated script streams into trimmed, non-empty statements")
@@ -86,6 +101,14 @@ struct ShellTests {
             == ["SELECT 1", ".tables", "SELECT 2"])
   }
 
+  @Test("the bundled views are the four COM-interface views")
+  func bundled() {
+    // The parse-and-register path a `CREATE VIEW` reuses; the four bundled
+    // views register under their case-folded names.
+    let views = Session.bundled()
+    #expect(Set(views.keys) == ["interfaces", "methods", "params", "bases"])
+  }
+
   @Test("a streamed CREATE VIEW statement parses and registers a view")
   func register() throws {
     // A batch run runs each streamed statement through `execute`, whose `CREATE
@@ -104,5 +127,68 @@ struct ShellTests {
       views[name.lowercased()] = view
     }
     #expect(views.keys.contains("v"))
+  }
+
+  @Test("a language spec parses its escape, void, root, keyword, and type keys")
+  func languageParses() {
+    let swift = Language(parsing: """
+      # a comment
+      escape-prefix `
+      escape-suffix `
+      void Void
+      root IUnknown
+      keyword class
+      keyword in
+
+      keyword default
+      type i4 CInt
+      type string HSTRING
+      pointer-mutable UnsafeMutablePointer
+      generic-open <
+      generic-close >
+      opaque UnsafeMutableRawPointer
+      wellknown Windows.Win32.Foundation.HRESULT HRESULT
+      """)
+    // A keyword identifier is wrapped in the escape delimiters; the match is
+    // exact, so a name merely containing a keyword is spelled verbatim.
+    #expect(swift.escape("class") == "`class`")
+    #expect(swift.escape("in") == "`in`")
+    #expect(swift.escape("classname") == "classname")
+    #expect(swift.escape("MyMethod") == "MyMethod")
+    // A value-carrying return passes through; the `void` spelling is `nil`.
+    #expect(swift.returned("CInt") == "CInt")
+    #expect(swift.returned("Void") == nil)
+    #expect(swift.returned("") == nil)
+    // The COM root is the parsed default base.
+    #expect(swift.root == "IUnknown")
+    // The type keys feed the `Dialect`: a couple of primitives, the pointer
+    // family, and the well-known projection map through.
+    let dialect = swift.dialect
+    #expect(SignatureType.primitive(.int4)
+                .decode(with: Resolver([:]), dialect: dialect) == "CInt")
+    #expect(SignatureType.pointer(.primitive(.int4))
+                .decode(with: Resolver([:]), dialect: dialect)
+                == "UnsafeMutablePointer<CInt>")
+    let hresult = TypeDefOrRef(rawValue: 1)
+    let resolver = Resolver([
+      hresult.rawValue: Identity(namespace: "Windows.Win32.Foundation",
+                                 name: "HRESULT"),
+    ])
+    #expect(SignatureType.named(kind: .value, hresult)
+                .decode(with: resolver, dialect: dialect) == "HRESULT")
+  }
+
+  @Test("the identity spec escapes nothing and applies no conventions")
+  func languageIdentity() {
+    // A template that declares no language (or names a spec with no resource)
+    // gets the identity `Language`: every identifier and return is verbatim, no
+    // root default applies, and its `Dialect` falls a primitive back to its
+    // neutral name (empty maps ⇒ no crash).
+    let identity = Language()
+    #expect(identity.escape("class") == "class")
+    #expect(identity.returned("Void") == "Void")
+    #expect(identity.root.isEmpty)
+    #expect(SignatureType.primitive(.int4)
+                .decode(with: Resolver([:]), dialect: identity.dialect) == "i4")
   }
 }


### PR DESCRIPTION
This pull request introduces a new `.render` metacommand to the `winmd-inspect` shell, enabling the rendering of COM interfaces using Mustache templates. It also refactors the session initialization to seed with bundled SQL views and adds a resource-driven approach for queries and templates, making the system extensible without code changes. The main themes are the addition of templated rendering functionality, resource-driven data and presentation layers, and improved session/view management.

**Templated COM Interface Rendering:**

- Added the `.render <interface> <template>` metacommand, which renders a specified COM interface (or all, with `*`) using a Mustache template. This includes error handling for missing interfaces, templates, or queries. (`Sources/winmd-inspect/Shell.swift` [[1]](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425R86-R115) [[2]](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425L125-R162) [[3]](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425R178-R189) [[4]](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425R243-R388)
- Integrated the `swift-mustache` library for template rendering and updated package dependencies accordingly. (`Package.swift` [[1]](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eR18-R19) [[2]](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eR63-R72); `Sources/winmd-inspect/Shell.swift` [[3]](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425R4-R8)
- Added a sample Mustache template for COM interfaces in `Resources/Templates/com.mustache`.

**Resource-driven Data and Presentation:**

- Queries for interfaces, methods, parameters, and bases are now loaded from SQL files in `Resources/Queries` and `Resources/Render`, making it easy to add or modify queries without code changes. [[1]](diffhunk://#diff-6700830baa43bbfe31704ed04df19604f23d48ffe95bde7289b2802cf7c2f43eR1-R8) [[2]](diffhunk://#diff-bb700bd55844a3ba21f517cb0e68f9b3acef63360d6bc422c93f15b2d1a8c2aaR1-R14) [[3]](diffhunk://#diff-b158dbdb697a2501c89fb91637d0263c017ad1b649f622af1374098d2cbc5b6dR1-R9) [[4]](diffhunk://#diff-979bc39b6d7b98eb173abdd71dcfd834c151d7129d718ae852bd6e9b011a7523R1-R8) [[5]](diffhunk://#diff-cc151a1efaac512abcb1b2832d163951aaa596a5045b2f4a672c269393f7878eR1-R4) [[6]](diffhunk://#diff-ce2ac28435b32b1679f91a37cc87a5019f7c23fc89b7f5a240c6e02bff9d6b8bR1-R10) [[7]](diffhunk://#diff-c726a3671d08367cc914e18edea5c1098fa22b4b69b26b55152856294780a0f9R1-R6) [[8]](diffhunk://#diff-511d7ae33a63c7ca1af3330b1785351a486b951b447f72554e11f21d9be7bce5R1-R5)
- The shell loads templates and queries at runtime from resources, raising clear errors if a required resource is missing. (`Sources/winmd-inspect/Shell.swift` [Sources/winmd-inspect/Shell.swiftR243-R388](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425R243-R388))

**Session and View Management Improvements:**

- The `Session` struct now seeds itself with bundled views at initialization, and a helper method enumerates and registers all bundled SQL views. (`Sources/winmd-inspect/Database+SQL.swift` [[1]](diffhunk://#diff-00c23dbc7bd1be8eeecff6ea9793bf2edb96d28a3156717fe70457c790678513L80-R104); `Sources/winmd-inspect/Shell.swift` [[2]](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425L112-R146) [[3]](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425R524-R580)
- Updated the shell’s help text and command registration to include `.render`. (`Sources/winmd-inspect/Shell.swift` [Sources/winmd-inspect/Shell.swiftL125-R162](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425L125-R162))

**Helpers and Minor Additions:**

- Added a convenience property to extract the text value from SQL cells, simplifying template context construction. (`Sources/winmd-inspect/Shell.swift` [Sources/winmd-inspect/Shell.swiftR608-R614](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425R608-R614))

Overall, these changes make the shell more flexible and extensible for COM interface code generation, with a clear separation between data, presentation, and logic.