### PR TITLE
SQL: add binary arithmetic operators to expressions

### DIFF
--- a/Sources/SQL/AST.swift
+++ b/Sources/SQL/AST.swift
@@ -219,6 +219,25 @@ public indirect enum Expression: Hashable, Sendable {
   case literal(Literal)
   /// A call to the named scalar function over its arguments, in order.
   case call(name: String, arguments: Array<Expression>)
+  /// `lhs <op> rhs` — a binary arithmetic expression over two sub-expressions,
+  /// the engine evaluating it per row to a typed `Value`.
+  case binary(Arithmetic, Expression, Expression)
+}
+
+/// A binary arithmetic operator.
+///
+/// The four standard operators over integers; `*` `/` bind tighter than `+`
+/// `-`, and all four are left-associative — the precedence the parser's
+/// climbing grammar encodes and parentheses override.
+public enum Arithmetic: Hashable, Sendable {
+  /// `+`
+  case add
+  /// `-`
+  case subtract
+  /// `*`
+  case multiply
+  /// `/` — integer division.
+  case divide
 }
 
 /// A row filter — a tree of comparisons composed with `AND`, `OR`, and `NOT`.

--- a/Sources/SQL/Error.swift
+++ b/Sources/SQL/Error.swift
@@ -58,6 +58,11 @@ public enum SQLError: Error, Hashable, Sendable {
   /// A scalar function rejects its arguments (the wrong count, or a value it
   /// cannot map); the string describes the fault.
   case argument(String)
+  /// A binary arithmetic expression cannot be evaluated — a non-integer (text)
+  /// operand, or a division by zero (standard SQL raises rather than yielding a
+  /// value); the string describes the fault. A NULL operand is not a fault: it
+  /// propagates to a NULL result.
+  case arithmetic(String)
   /// A `CREATE VIEW` projects a column whose name cannot be inferred — a
   /// `SELECT *`, or an unaliased non-column expression — and no explicit column
   /// list names it; the string describes the offending projection.
@@ -104,6 +109,8 @@ extension SQLError: CustomStringConvertible {
       "no such function '\(name)'"
     case let .argument(detail):
       "invalid function argument: \(detail)"
+    case let .arithmetic(detail):
+      "invalid arithmetic: \(detail)"
     case let .named(detail):
       "view column cannot be named: \(detail)"
     case let .columns(expected, got):

--- a/Sources/SQL/Filter.swift
+++ b/Sources/SQL/Filter.swift
@@ -54,6 +54,9 @@ internal indirect enum Term {
   case constant(Value)
   /// A call to the named scalar function over its argument terms, in order.
   case apply(name: String, arguments: Array<Term>)
+  /// `lhs <op> rhs` — a binary arithmetic over two operand terms, the lowered
+  /// form of the AST's `Expression.binary`.
+  case binary(Arithmetic, Term, Term)
 }
 
 extension Term {
@@ -72,6 +75,9 @@ extension Term {
       for argument in arguments {
         argument.references(into: &slots)
       }
+    case let .binary(_, lhs, rhs):
+      lhs.references(into: &slots)
+      rhs.references(into: &slots)
     }
   }
 }
@@ -89,6 +95,8 @@ extension Term {
     case let .apply(name, arguments):
       .apply(name: name,
              arguments: arguments.map { $0.remapped(through: slot) })
+    case let .binary(op, lhs, rhs):
+      .binary(op, lhs.remapped(through: slot), rhs.remapped(through: slot))
     }
   }
 }
@@ -155,6 +163,8 @@ internal func evaluate<R: Row & ~Escapable>(_ term: Term, _ row: borrowing R,
     value
   case let .apply(name, arguments):
     try apply(name, arguments, row, routines)
+  case let .binary(op, lhs, rhs):
+    try op.apply(evaluate(lhs, row, routines), evaluate(rhs, row, routines))
   }
 }
 
@@ -176,6 +186,36 @@ private func apply<R: Row & ~Escapable>(_ name: String,
 }
 
 // MARK: - Evaluation
+
+extension Arithmetic {
+  /// Applies the operator to two typed operands, yielding a typed `Value`.
+  ///
+  /// Both operands must be integers: `integer ∘ integer` is an integer, with `/`
+  /// integer division. A NULL on either side propagates — the result is NULL,
+  /// not a fault. A division by zero is `SQLError.arithmetic`, as standard SQL
+  /// raises rather than yielding a value; a non-integer (text) operand is a
+  /// `SQLError.arithmetic` type error rather than a silent coercion.
+  internal func apply(_ lhs: Value, _ rhs: Value) throws(SQLError) -> Value {
+    if case .null = lhs { return .null }
+    if case .null = rhs { return .null }
+    guard case let .integer(lhs) = lhs, case let .integer(rhs) = rhs else {
+      throw .arithmetic("operands must be integers")
+    }
+    // Report overflow rather than trap: operands are parsed literals or column
+    // values that can reach the `Int` boundary (`Int.max + 1`, `Int.min / -1`),
+    // and Swift's `+`/`-`/`*`/`/` would trap — aborting the process — instead of
+    // surfacing a `SQLError`.
+    let outcome: (partialValue: Int, overflow: Bool) = switch self {
+    case .add: lhs.addingReportingOverflow(rhs)
+    case .subtract: lhs.subtractingReportingOverflow(rhs)
+    case .multiply: lhs.multipliedReportingOverflow(by: rhs)
+    case .divide where rhs == 0: throw .arithmetic("division by zero")
+    case .divide: lhs.dividedReportingOverflow(by: rhs)
+    }
+    guard !outcome.overflow else { throw .arithmetic("integer overflow") }
+    return .integer(outcome.partialValue)
+  }
+}
 
 extension Comparison {
   /// Applies the operator to two comparable operands.

--- a/Sources/SQL/Lexer.swift
+++ b/Sources/SQL/Lexer.swift
@@ -86,6 +86,12 @@ internal struct Lexer: ~Escapable {
     switch byte {
     case UInt8(ascii: "*"):
       return punctuation(.star)
+    case UInt8(ascii: "+"):
+      return punctuation(.plus)
+    case UInt8(ascii: "-"):
+      return punctuation(.minus)
+    case UInt8(ascii: "/"):
+      return punctuation(.slash)
     case UInt8(ascii: ","):
       return punctuation(.comma)
     case UInt8(ascii: "("):

--- a/Sources/SQL/Parser.swift
+++ b/Sources/SQL/Parser.swift
@@ -6,24 +6,32 @@
 /// The grammar is the minimal dialect, extended with a chain of joins:
 ///
 /// ```
-/// statement   := query | create
-/// create      := CREATE VIEW identifier ['(' identifier (',' identifier)* ')']
-///                  AS query
-/// query       := select (UNION [ALL] select)*
-/// select      := SELECT projection FROM relation (join)* [where] [order]
-/// relation    := identifier [AS identifier]
-/// join        := JOIN relation ON column '=' column
-/// projection  := '*' | column (',' column)*
-/// where       := WHERE predicate
-/// predicate   := disjunction
-/// disjunction := conjunction (OR conjunction)*
-/// conjunction := negation (AND negation)*
-/// negation    := NOT negation | primary
-/// primary     := '(' predicate ')' | comparison
-/// comparison  := expression (op (expression | param) | IS [NOT] NULL)
-/// order       := ORDER BY column [ASC | DESC]
-/// column      := identifier        // a dotted identifier is qualified
+/// statement      := query | create
+/// create         := CREATE VIEW identifier
+///                   ['(' identifier (',' identifier)* ')'] AS query
+/// query          := select (UNION [ALL] select)*
+/// select         := SELECT projection FROM relation (join)* [where] [order]
+/// relation       := identifier [AS identifier]
+/// join           := JOIN relation ON column '=' column
+/// projection     := '*' | column (',' column)*
+/// where          := WHERE predicate
+/// predicate      := disjunction
+/// disjunction    := conjunction (OR conjunction)*
+/// conjunction    := negation (AND negation)*
+/// negation       := NOT negation | primary
+/// primary        := '(' predicate ')' | comparison
+/// comparison     := expression (op (expression | param) | IS [NOT] NULL)
+/// expression     := additive
+/// additive       := multiplicative (('+' | '-') multiplicative)*
+/// multiplicative := factor (('*' | '/') factor)*
+/// factor         := '(' expression ')' | literal | call | column
+/// order          := ORDER BY column [ASC | DESC]
+/// column         := identifier        // a dotted identifier is qualified
 /// ```
+///
+/// Arithmetic precedence is `*` `/` > `+` `-`, both levels left-associative; the
+/// cascade of `additive`/`multiplicative` encodes it, and parentheses override
+/// it through `factor`.
 ///
 /// A `column` is a single identifier token; a qualifying dot (`t.Name`) is part
 /// of the identifier the lexer scans, so `Column(_:)` splits it into qualifier
@@ -271,13 +279,60 @@ internal struct Parser: ~Escapable {
     return Projected(expression: expression, alias: alias)
   }
 
-  /// Parses a scalar expression: a string/integer literal, a function call
-  /// (`name(args)`), or a bare (possibly-qualified) column.
-  ///
-  /// A function call is an identifier immediately followed by `(`; an identifier
-  /// not so followed is a column. The arguments are a comma-separated list of
-  /// expressions, possibly empty.
+  /// Parses a scalar expression at the lowest arithmetic precedence (`+` `-`).
   private mutating func expression() throws(SQLError) -> Expression {
+    try additive()
+  }
+
+  /// Parses `multiplicative (('+' | '-') multiplicative)*`, left-associative.
+  private mutating func additive() throws(SQLError) -> Expression {
+    var lhs = try multiplicative()
+    while true {
+      let op: Arithmetic? = if try match(.plus) {
+        .add
+      } else if try match(.minus) {
+        .subtract
+      } else {
+        nil
+      }
+      guard let op else { break }
+      lhs = try .binary(op, lhs, multiplicative())
+    }
+    return lhs
+  }
+
+  /// Parses `factor (('*' | '/') factor)*`, left-associative — `*` and `/` bind
+  /// tighter than `+` and `-`.
+  private mutating func multiplicative() throws(SQLError) -> Expression {
+    var lhs = try factor()
+    while true {
+      let op: Arithmetic? = if try match(.star) {
+        .multiply
+      } else if try match(.slash) {
+        .divide
+      } else {
+        nil
+      }
+      guard let op else { break }
+      lhs = try .binary(op, lhs, factor())
+    }
+    return lhs
+  }
+
+  /// Parses an arithmetic factor: a parenthesised expression, a string/integer
+  /// literal, a function call (`name(args)`), or a bare (possibly-qualified)
+  /// column.
+  ///
+  /// Parentheses override the precedence the cascade encodes. A function call is
+  /// an identifier immediately followed by `(`; an identifier not so followed is
+  /// a column. The arguments are a comma-separated list of expressions, possibly
+  /// empty.
+  private mutating func factor() throws(SQLError) -> Expression {
+    if try match(.lparen) {
+      let expression = try expression()
+      try expect(.rparen)
+      return expression
+    }
     if case let .string(value) = current?.kind {
       _ = try advance(expecting: "a literal")
       return .literal(.string(value))
@@ -337,13 +392,28 @@ internal struct Parser: ~Escapable {
   }
 
   /// Parses a parenthesised predicate or a comparison.
+  ///
+  /// A leading `(` is ambiguous: it opens either a parenthesised predicate
+  /// (`(a = 1 AND b = 2)`) or the parenthesised left operand of a comparison
+  /// (`(Age + 1) = 26`, where `factor` consumes the `(expression)`). The
+  /// comparison is tried first; if it fails, the group was a predicate, so the
+  /// parser rewinds to the saved lexer and lookahead token and parses it as one.
   private mutating func primary() throws(SQLError) -> Predicate {
-    if try match(.lparen) {
-      let predicate = try predicate()
-      try expect(.rparen)
-      return predicate
+    guard current?.kind == .lparen else {
+      return try comparison()
     }
-    return try comparison()
+    let lexer = self.lexer
+    let token = self.current
+    do {
+      return try comparison()
+    } catch {
+      self.lexer = lexer
+      self.current = token
+    }
+    try expect(.lparen)
+    let predicate = try predicate()
+    try expect(.rparen)
+    return predicate
   }
 
   /// Parses `expression (op (expression | :parameter) | IS [NOT] NULL)`.

--- a/Sources/SQL/Resolve.swift
+++ b/Sources/SQL/Resolve.swift
@@ -80,6 +80,8 @@ extension Schema {
         try lowered.append(term(argument, in: relation))
       }
       return .apply(name: name, arguments: lowered)
+    case let .binary(op, lhs, rhs):
+      return try .binary(op, term(lhs, in: relation), term(rhs, in: relation))
     }
   }
 
@@ -230,6 +232,8 @@ internal struct Scope {
         try lowered.append(term(argument))
       }
       return .apply(name: name, arguments: lowered)
+    case let .binary(op, lhs, rhs):
+      return try .binary(op, term(lhs), term(rhs))
     }
   }
 

--- a/Sources/SQL/Token.swift
+++ b/Sources/SQL/Token.swift
@@ -46,6 +46,9 @@ extension Token {
 
     // Punctuation and operators.
     case star
+    case plus
+    case minus
+    case slash
     case comma
     case lparen
     case rparen
@@ -86,6 +89,9 @@ extension Token.Kind {
     case let .integer(value): "\(value)"
     case let .parameter(name): ":\(name)"
     case .star: "*"
+    case .plus: "+"
+    case .minus: "-"
+    case .slash: "/"
     case .comma: ","
     case .lparen: "("
     case .rparen: ")"

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -1441,3 +1441,110 @@ struct EngineUnionTests {
     ])
   }
 }
+
+// MARK: - Arithmetic tests
+
+struct EngineArithmeticTests {
+  @Test("literal arithmetic evaluates over a row")
+  func literal() throws {
+    // One row of `People` drives the projection; the value is the same for each,
+    // and `Id = 1` selects exactly one.
+    let rows = try run("SELECT 2 + 3 FROM People WHERE Id = 1")
+    #expect(rows == [[.integer(5)]])
+  }
+
+  @Test("multiplication binds tighter than addition")
+  func precedence() throws {
+    let rows = try run("SELECT 2 + 3 * 4 FROM People WHERE Id = 1")
+    #expect(rows == [[.integer(14)]])
+  }
+
+  @Test("parentheses override precedence")
+  func grouping() throws {
+    let rows = try run("SELECT (2 + 3) * 4 FROM People WHERE Id = 1")
+    #expect(rows == [[.integer(20)]])
+  }
+
+  @Test("subtraction and division are left-associative")
+  func associativity() throws {
+    // (20 - 5) - 3 = 12, not 20 - (5 - 3) = 18; (100 / 5) / 2 = 10.
+    let difference = try run("SELECT 20 - 5 - 3 FROM People WHERE Id = 1")
+    #expect(difference == [[.integer(12)]])
+    let quotient = try run("SELECT 100 / 5 / 2 FROM People WHERE Id = 1")
+    #expect(quotient == [[.integer(10)]])
+  }
+
+  @Test("integer division truncates")
+  func integerDivision() throws {
+    let rows = try run("SELECT 7 / 2 FROM People WHERE Id = 1")
+    #expect(rows == [[.integer(3)]])
+  }
+
+  @Test("arithmetic over a column computes per row")
+  func column() throws {
+    let rows = try run("SELECT Age + 1 FROM People WHERE Id = 2")
+    // Bob's Age is 25; 25 + 1 = 26.
+    #expect(rows == [[.integer(26)]])
+  }
+
+  @Test("arithmetic mixes columns and a function call")
+  func mixed() throws {
+    let rows = try functionRun("SELECT add(Id, 1) * 10 FROM People WHERE Id = 3")
+    // Carol: (3 + 1) * 10 = 40.
+    #expect(rows == [[.integer(40)]])
+  }
+
+  @Test("a NULL operand propagates to a NULL result")
+  func nullPropagation() throws {
+    // `Note` is NULL for row 2; `Id + Note` mixes a present integer with a NULL,
+    // so the whole expression is NULL rather than a fault.
+    let rows = try nullable("SELECT Id + Note FROM Maybe WHERE Id = 2")
+    #expect(rows == [[.null]])
+  }
+
+  @Test("division by zero faults")
+  func divideByZero() throws {
+    #expect(throws: SQLError.arithmetic("division by zero")) {
+      try run("SELECT Id / 0 FROM People WHERE Id = 1")
+    }
+  }
+
+  @Test("arithmetic overflow faults instead of trapping")
+  func overflow() throws {
+    // `Int.max + 1` and a multiply past the boundary report overflow as a
+    // `SQLError` rather than trapping (and aborting) the process.
+    #expect(throws: SQLError.arithmetic("integer overflow")) {
+      try run("SELECT 9223372036854775807 + 1 FROM People WHERE Id = 1")
+    }
+    #expect(throws: SQLError.arithmetic("integer overflow")) {
+      try run("SELECT 9223372036854775807 * 2 FROM People WHERE Id = 1")
+    }
+  }
+
+  @Test("a parenthesised expression opens a predicate")
+  func parenthesisedExpression() throws {
+    // `(Age + 1)` is the grouped left operand of the comparison, not a predicate
+    // group; it matches Dave (40 + 1 = 41). A leading `(` no longer forces a
+    // predicate-group parse.
+    let matched = try run("SELECT Id FROM People WHERE (Age + 1) = 41")
+    #expect(matched == [[.integer(4)]])
+    // A grouped expression works before `IS NULL` too; `Id + 1` is never NULL.
+    let none = try run("SELECT Id FROM People WHERE (Id + 1) IS NULL")
+    #expect(none.isEmpty)
+  }
+
+  @Test("a text operand faults as a type error")
+  func textOperand() throws {
+    #expect(throws: SQLError.arithmetic("operands must be integers")) {
+      try run("SELECT Name + 1 FROM People WHERE Id = 1")
+    }
+  }
+
+  @Test("arithmetic in a predicate filters rows")
+  func predicate() throws {
+    // `Age + 1 = 26` holds for everyone aged 25 (Bob and Eve); the arithmetic
+    // is evaluated per row on the WHERE side too.
+    let rows = try run("SELECT Name FROM People WHERE Age + 1 = 26")
+    #expect(rows == [[.text("Bob")], [.text("Eve")]])
+  }
+}

--- a/Tests/SQLTests/ParserTests.swift
+++ b/Tests/SQLTests/ParserTests.swift
@@ -470,6 +470,81 @@ struct ExpressionTests {
   }
 }
 
+// MARK: - Arithmetic expressions
+
+struct ArithmeticTests {
+  /// The lone projected expression of a single-item projection, failing on any
+  /// other shape.
+  private func expression(_ text: String) throws -> Expression {
+    let select = try parseSelect(text)
+    guard case let .expressions(items) = select.projection,
+        items.count == 1 else {
+      Issue.record("expected a single expression projection")
+      throw SQLError.incomplete(expected: "an expression projection")
+    }
+    return items[0].expression
+  }
+
+  @Test("parses each arithmetic operator")
+  func operators() throws {
+    let cases: Array<(String, Arithmetic)> = [
+      ("+", .add),
+      ("-", .subtract),
+      ("*", .multiply),
+      ("/", .divide),
+    ]
+    for (text, op) in cases {
+      let parsed = try expression("SELECT 1 \(text) 2 FROM T")
+      #expect(parsed
+                  == .binary(op, .literal(.integer(1)), .literal(.integer(2))))
+    }
+  }
+
+  @Test("multiplication binds tighter than addition")
+  func precedence() throws {
+    // 2 + 3 * 4  ==>  2 + (3 * 4)
+    let parsed = try expression("SELECT 2 + 3 * 4 FROM T")
+    let product = Expression.binary(.multiply, .literal(.integer(3)),
+                                    .literal(.integer(4)))
+    #expect(parsed == .binary(.add, .literal(.integer(2)), product))
+  }
+
+  @Test("parentheses override precedence")
+  func grouping() throws {
+    // (2 + 3) * 4  ==>  (2 + 3) * 4
+    let parsed = try expression("SELECT (2 + 3) * 4 FROM T")
+    let sum = Expression.binary(.add, .literal(.integer(2)),
+                                .literal(.integer(3)))
+    #expect(parsed == .binary(.multiply, sum, .literal(.integer(4))))
+  }
+
+  @Test("addition is left-associative")
+  func leftAssociative() throws {
+    // 1 - 2 - 3  ==>  (1 - 2) - 3
+    let parsed = try expression("SELECT 1 - 2 - 3 FROM T")
+    let left = Expression.binary(.subtract, .literal(.integer(1)),
+                                 .literal(.integer(2)))
+    #expect(parsed == .binary(.subtract, left, .literal(.integer(3))))
+  }
+
+  @Test("arithmetic combines columns and calls")
+  func operands() throws {
+    let parsed = try expression("SELECT add(Id, 1) * 10 FROM T")
+    let call = Expression.call(name: "add",
+                               arguments: [.column("Id"), .literal(.integer(1))])
+    #expect(parsed == .binary(.multiply, call, .literal(.integer(10))))
+  }
+
+  @Test("arithmetic parses on either side of a comparison")
+  func predicate() throws {
+    let select = try parseSelect("SELECT * FROM T WHERE Age + 1 = 26")
+    let sum = Expression.binary(.add, .column("Age"), .literal(.integer(1)))
+    #expect(select.predicate
+                == .comparison(left: sum, op: .equal,
+                               right: .literal(.integer(26))))
+  }
+}
+
 // MARK: - CREATE VIEW
 
 /// Parses `text` and returns its `(name, view)`, failing on any other shape.


### PR DESCRIPTION
Extend the Expression grammar with the four standard arithmetic operators +, -, *, and /, parsed by a precedence-climbing cascade where * and / bind tighter than + and - and both levels are left-associative, with parentheses overriding. The operators lower to a new Term.binary case the executor evaluates per row.

Semantics over the integer/text/null Value: integer op integer yields an integer (/ is integer division); a NULL operand on either side propagates to a NULL result; division by zero and a non-integer (text) operand each raise a new SQLError.arithmetic fault rather than coercing.