### PR TITLE
SQL: add a BITAND built-in scalar function

### DIFF
--- a/Sources/SQL/Function.swift
+++ b/Sources/SQL/Function.swift
@@ -40,10 +40,14 @@ public struct Routines: Sendable {
       }
   }
 
-  /// The function named `name`, or `nil` if no such function is registered —
-  /// the name folded to lower case, like every other SQL identifier.
+  /// The function named `name`, folded to lower case like every other SQL
+  /// identifier, or `nil` if neither a built-in nor a registered function bears
+  /// it. An engine built-in resolves AHEAD of a registered function of the same
+  /// name: an unqualified scalar call can never shadow a built-in. (A future
+  /// PATH / search-order mechanism — à la DB2 or PostgreSQL — would let a
+  /// qualified call reach a user's redefinition.)
   public func function(named name: String) -> Scalar? {
-    functions[name.lowercased()]
+    Routines.builtins[name.lowercased()] ?? functions[name.lowercased()]
   }
 
   /// A copy of these routines with `function` bound to `name` (folded to lower
@@ -53,6 +57,29 @@ public struct Routines: Sendable {
     var functions = self.functions
     functions[name.lowercased()] = function
     return Routines(functions)
+  }
+
+  /// The engine's built-in scalar functions, available to every `Routines` —
+  /// even the empty one — and resolved ahead of a registered function of the
+  /// same name (see `function(named:)`), so an unqualified call always reaches
+  /// the built-in. `BITAND` is the portable, standards-compliant spelling
+  /// (Oracle's) of a bitwise AND, an operation ISO SQL and this grammar
+  /// otherwise lack; it is a built-in so any dialect gets it without registering
+  /// a closure.
+  private static let builtins: Dictionary<String, Scalar> = ["bitand": bitand]
+
+  /// `BITAND(x, y)` — the bitwise AND of two integers. A NULL argument yields
+  /// NULL (SQL null propagation); a non-integer argument is `SQLError.argument`
+  /// and the wrong arity `SQLError.arity`.
+  private static let bitand: Scalar = { arguments in
+    guard arguments.count == 2 else { throw .arity(2, arguments.count) }
+    if case .null = arguments[0] { return .null }
+    if case .null = arguments[1] { return .null }
+    guard case let .integer(x) = arguments[0],
+        case let .integer(y) = arguments[1] else {
+      throw .argument("BITAND requires integer arguments")
+    }
+    return .integer(x & y)
   }
 }
 

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -1098,6 +1098,38 @@ struct EngineFunctionTests {
     #expect(rows == [[.text("ALICE")]])
   }
 
+  @Test("the built-in BITAND yields the bitwise AND of two integers")
+  func bitand() throws {
+    // BITAND is an engine built-in: `routines()` never registers it, yet the
+    // call resolves and folds case-insensitively. 12 & 10 = 8; 6 & 3 = 2.
+    #expect(try functionRun("SELECT BITAND(12, 10) FROM People WHERE Id = 1")
+            == [[.integer(8)]])
+    #expect(try functionRun("SELECT bitand(6, 3) FROM People WHERE Id = 1")
+            == [[.integer(2)]])
+  }
+
+  @Test("BITAND rejects the wrong arity and non-integer arguments")
+  func bitandFaults() throws {
+    #expect(throws: SQLError.arity(2, 1)) {
+      try functionRun("SELECT BITAND(1) FROM People WHERE Id = 1")
+    }
+    #expect(throws: SQLError.argument("BITAND requires integer arguments")) {
+      try functionRun("SELECT BITAND('a', 1) FROM People WHERE Id = 1")
+    }
+  }
+
+  @Test("a registered function cannot shadow the built-in BITAND")
+  func bitandNotShadowed() throws {
+    // A built-in resolves ahead of a registered function of the same name, so
+    // an unqualified `BITAND` is always the built-in, not the user's closure.
+    let user = Routines().registering("bitand") { _ throws(SQLError) in
+      .integer(-1)
+    }
+    let query = try parse("SELECT BITAND(6, 3) FROM People WHERE Id = 1")
+    let rows = try Engine.run(query, people(), user)
+    #expect(rows == [[.integer(2)]])
+  }
+
   @Test("routine names colliding only by case merge without trapping")
   func collision() throws {
     // "tag" and "TAG" fold to one name; the registry merges them (the later-


### PR DESCRIPTION
This pull request enhances the SQL engine by introducing a built-in `BITAND` scalar function, ensuring it is always available and cannot be shadowed by user-defined functions. Comprehensive tests are added to verify correct behavior, error handling, and precedence of built-ins over registered functions.

**Built-in Functionality:**

* Added a built-in `BITAND` scalar function to the `Routines` struct, providing a portable, standards-compliant bitwise AND operation for integers. This function is always available and resolves before any user-registered function with the same name. (`Sources/SQL/Function.swift`) [[1]](diffhunk://#diff-c2a824b19cb7761a8c6ab76d4d4cb9cc4ffd627966f6138baa92cd2219777331L43-R50) [[2]](diffhunk://#diff-c2a824b19cb7761a8c6ab76d4d4cb9cc4ffd627966f6138baa92cd2219777331R61-R83)

**Testing and Validation:**

* Added tests to verify that `BITAND` computes the correct bitwise AND for integer arguments, is case-insensitive, and is available even without explicit registration. (`Tests/SQLTests/EngineTests.swift`)
* Added tests to ensure `BITAND` properly handles incorrect arity and non-integer arguments by raising appropriate errors. (`Tests/SQLTests/EngineTests.swift`)
* Added a test to confirm that a user-registered function named `BITAND` cannot shadow the built-in, ensuring the built-in always takes precedence. (`Tests/SQLTests/EngineTests.swift`)