### PR TITLE
SQL: report SQLSTATE errors

### DIFF
--- a/Sources/SQL/Error.swift
+++ b/Sources/SQL/Error.swift
@@ -35,6 +35,12 @@ extension SourceLocation: CustomStringConvertible {
 /// Most cases carry the `SourceLocation` at which the fault was detected, so a
 /// consumer can point at the offending span.
 public enum SQLError: Error, Hashable, Sendable {
+  /// An error carrying an explicit ISO SQLSTATE and message, for a fault whose
+  /// code the raiser knows but which no semantic case models. The first string
+  /// is the 5-character class+subclass code (e.g. `"42601"`); the second is the
+  /// human-readable message. This is the passthrough that lets a caller surface
+  /// any SQLSTATE without extending the enum.
+  case state(String, String)
   /// A character that begins no valid token.
   case character(Character, at: SourceLocation)
   /// A string literal whose closing quote is missing.
@@ -58,11 +64,16 @@ public enum SQLError: Error, Hashable, Sendable {
   /// A scalar function rejects its arguments (the wrong count, or a value it
   /// cannot map); the string describes the fault.
   case argument(String)
-  /// A binary arithmetic expression cannot be evaluated — a non-integer (text)
-  /// operand, or a division by zero (standard SQL raises rather than yielding a
-  /// value); the string describes the fault. A NULL operand is not a fault: it
-  /// propagates to a NULL result.
-  case arithmetic(String)
+  /// A binary arithmetic expression applies to a non-integer (text) operand —
+  /// the operands must be integers, not a silent coercion; the string describes
+  /// the fault. A NULL operand is not a fault: it propagates to a NULL result.
+  case operand(String)
+  /// A binary arithmetic expression divides by zero — standard SQL raises rather
+  /// than yielding a value.
+  case divide
+  /// A binary arithmetic expression's integer result exceeds the platform `Int`
+  /// — reported rather than trapped; the string describes the fault.
+  case magnitude(String)
   /// A `CREATE VIEW` projects a column whose name cannot be inferred — a
   /// `SELECT *`, or an unaliased non-column expression — and no explicit column
   /// list names it; the string describes the offending projection.
@@ -87,6 +98,8 @@ public enum SQLError: Error, Hashable, Sendable {
 extension SQLError: CustomStringConvertible {
   public var description: String {
     switch self {
+    case let .state(_, message):
+      message
     case let .character(character, location):
       "unexpected character '\(character)' at \(location)"
     case let .unterminated(location):
@@ -109,7 +122,11 @@ extension SQLError: CustomStringConvertible {
       "no such function '\(name)'"
     case let .argument(detail):
       "invalid function argument: \(detail)"
-    case let .arithmetic(detail):
+    case let .operand(detail):
+      "invalid arithmetic: \(detail)"
+    case .divide:
+      "invalid arithmetic: division by zero"
+    case let .magnitude(detail):
       "invalid arithmetic: \(detail)"
     case let .named(detail):
       "view column cannot be named: \(detail)"
@@ -122,5 +139,69 @@ extension SQLError: CustomStringConvertible {
       "UNION arms project differing column counts: "
           + "expected \(expected), found \(found)"
     }
+  }
+}
+
+// MARK: - SQLSTATE
+
+extension SQLError {
+  /// The ISO SQLSTATE for this error: a 5-character string whose first two
+  /// characters are the class and whose last three are the subclass. Every case
+  /// maps to a code, so any `SQLError` exposes one.
+  ///
+  /// The codes draw on ISO/IEC 9075-2 Annex B (SQLSTATE class values) and, where
+  /// ISO leaves the subclass implementation-defined, the de-facto PostgreSQL
+  /// assignments:
+  ///
+  /// - Class `42` — syntax error or access rule violation — covers the
+  ///   lexer/parser faults (`42601` syntax error), the undefined-object faults
+  ///   (`42P01` table, `42703` column, `42883` function), and the name-collision
+  ///   faults (`42702` ambiguous, `42701` duplicate). `42P01` is a PostgreSQL
+  ///   subclass; ISO itself leaves the `42` subclass implementation-defined, so
+  ///   this is a deliberate choice noted alongside `42703`/`42883`, which are
+  ///   likewise PostgreSQL subclasses on the same class.
+  /// - Class `22` — data exception — covers the value faults: `22003` numeric
+  ///   value out of range (the out-of-range integer literal and the arithmetic
+  ///   overflow), `22012` division by zero, and `22023` invalid parameter value
+  ///   (a scalar function's rejected argument).
+  /// - `42804` (datatype mismatch) is the non-integer arithmetic operand — a
+  ///   type error at evaluation rather than a value-range fault.
+  public var sqlstate: String {
+    switch self {
+    case let .state(code, _):
+      code
+    // Class 42 — syntax error or access rule violation.
+    case .character, .unterminated, .unexpected, .incomplete, .trailing,
+         .named, .columns, .arity:
+      "42601"
+    case .relation:
+      "42P01"
+    case .column:
+      "42703"
+    case .ambiguous:
+      "42702"
+    case .duplicate:
+      "42701"
+    case .function:
+      "42883"
+    // Class 22 — data exception.
+    case .overflow:
+      "22003"
+    case .argument:
+      "22023"
+    case .operand:
+      "42804"
+    case .divide:
+      "22012"
+    case .magnitude:
+      "22003"
+    }
+  }
+
+  /// The human-readable message for this error — the same text as
+  /// `description`. Paired with `sqlstate`, it gives every error a uniform
+  /// `(sqlstate, message)` surface.
+  public var message: String {
+    description
   }
 }

--- a/Sources/SQL/Filter.swift
+++ b/Sources/SQL/Filter.swift
@@ -192,14 +192,15 @@ extension Arithmetic {
   ///
   /// Both operands must be integers: `integer ∘ integer` is an integer, with `/`
   /// integer division. A NULL on either side propagates — the result is NULL,
-  /// not a fault. A division by zero is `SQLError.arithmetic`, as standard SQL
+  /// not a fault. A division by zero is `SQLError.divide`, as standard SQL
   /// raises rather than yielding a value; a non-integer (text) operand is a
-  /// `SQLError.arithmetic` type error rather than a silent coercion.
+  /// `SQLError.operand` type error rather than a silent coercion; an integer
+  /// result past the `Int` boundary is `SQLError.magnitude`.
   internal func apply(_ lhs: Value, _ rhs: Value) throws(SQLError) -> Value {
     if case .null = lhs { return .null }
     if case .null = rhs { return .null }
     guard case let .integer(lhs) = lhs, case let .integer(rhs) = rhs else {
-      throw .arithmetic("operands must be integers")
+      throw .operand("operands must be integers")
     }
     // Report overflow rather than trap: operands are parsed literals or column
     // values that can reach the `Int` boundary (`Int.max + 1`, `Int.min / -1`),
@@ -209,10 +210,10 @@ extension Arithmetic {
     case .add: lhs.addingReportingOverflow(rhs)
     case .subtract: lhs.subtractingReportingOverflow(rhs)
     case .multiply: lhs.multipliedReportingOverflow(by: rhs)
-    case .divide where rhs == 0: throw .arithmetic("division by zero")
+    case .divide where rhs == 0: throw .divide
     case .divide: lhs.dividedReportingOverflow(by: rhs)
     }
-    guard !outcome.overflow else { throw .arithmetic("integer overflow") }
+    guard !outcome.overflow else { throw .magnitude("integer overflow") }
     return .integer(outcome.partialValue)
   }
 }

--- a/Sources/SQL/Function.swift
+++ b/Sources/SQL/Function.swift
@@ -69,10 +69,13 @@ public struct Routines: Sendable {
   private static let builtins: Dictionary<String, Scalar> = ["bitand": bitand]
 
   /// `BITAND(x, y)` — the bitwise AND of two integers. A NULL argument yields
-  /// NULL (SQL null propagation); a non-integer argument is `SQLError.argument`
-  /// and the wrong arity `SQLError.arity`.
+  /// NULL (SQL null propagation); the wrong argument count or a non-integer
+  /// argument is `SQLError.argument` (a function-argument fault — not
+  /// `SQLError.arity`, which is the UNION column-count mismatch).
   private static let bitand: Scalar = { arguments in
-    guard arguments.count == 2 else { throw .arity(2, arguments.count) }
+    guard arguments.count == 2 else {
+      throw .argument("BITAND takes two arguments")
+    }
     if case .null = arguments[0] { return .null }
     if case .null = arguments[1] { return .null }
     guard case let .integer(x) = arguments[0],

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -1536,7 +1536,7 @@ struct EngineArithmeticTests {
 
   @Test("division by zero faults")
   func divideByZero() throws {
-    #expect(throws: SQLError.arithmetic("division by zero")) {
+    #expect(throws: SQLError.divide) {
       try run("SELECT Id / 0 FROM People WHERE Id = 1")
     }
   }
@@ -1545,10 +1545,10 @@ struct EngineArithmeticTests {
   func overflow() throws {
     // `Int.max + 1` and a multiply past the boundary report overflow as a
     // `SQLError` rather than trapping (and aborting) the process.
-    #expect(throws: SQLError.arithmetic("integer overflow")) {
+    #expect(throws: SQLError.magnitude("integer overflow")) {
       try run("SELECT 9223372036854775807 + 1 FROM People WHERE Id = 1")
     }
-    #expect(throws: SQLError.arithmetic("integer overflow")) {
+    #expect(throws: SQLError.magnitude("integer overflow")) {
       try run("SELECT 9223372036854775807 * 2 FROM People WHERE Id = 1")
     }
   }
@@ -1567,7 +1567,7 @@ struct EngineArithmeticTests {
 
   @Test("a text operand faults as a type error")
   func textOperand() throws {
-    #expect(throws: SQLError.arithmetic("operands must be integers")) {
+    #expect(throws: SQLError.operand("operands must be integers")) {
       try run("SELECT Name + 1 FROM People WHERE Id = 1")
     }
   }

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -1108,9 +1108,11 @@ struct EngineFunctionTests {
             == [[.integer(2)]])
   }
 
-  @Test("BITAND rejects the wrong arity and non-integer arguments")
+  @Test("BITAND reports a function-argument fault, not a UNION arity error")
   func bitandFaults() throws {
-    #expect(throws: SQLError.arity(2, 1)) {
+    // The wrong argument count is a function-argument fault (`.argument`), not
+    // `.arity` — whose message is the UNION column-count mismatch.
+    #expect(throws: SQLError.argument("BITAND takes two arguments")) {
       try functionRun("SELECT BITAND(1) FROM People WHERE Id = 1")
     }
     #expect(throws: SQLError.argument("BITAND requires integer arguments")) {

--- a/Tests/SQLTests/ErrorTests.swift
+++ b/Tests/SQLTests/ErrorTests.swift
@@ -1,0 +1,87 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQL
+
+/// A throwaway location for cases that carry one.
+private let here = SourceLocation(line: 1, column: 1, offset: 0)
+
+@Suite("SQLSTATE")
+struct SQLStateTests {
+  @Test("an undefined column reports 42703")
+  func column() {
+    #expect(SQLError.column("Missing").sqlstate == "42703")
+  }
+
+  @Test("an integer overflow reports 22003")
+  func magnitude() {
+    #expect(SQLError.magnitude("integer overflow").sqlstate == "22003")
+    // The lexer's out-of-range literal is the same data exception.
+    #expect(SQLError.overflow("99", at: here).sqlstate == "22003")
+  }
+
+  @Test("a division by zero reports 22012")
+  func divide() {
+    #expect(SQLError.divide.sqlstate == "22012")
+  }
+
+  @Test("a syntax error reports 42601")
+  func syntax() {
+    #expect(SQLError.character("@", at: here).sqlstate == "42601")
+    #expect(SQLError.unterminated(at: here).sqlstate == "42601")
+    #expect(
+        SQLError.unexpected("X", expected: "Y", at: here).sqlstate == "42601")
+    #expect(SQLError.incomplete(expected: "Z").sqlstate == "42601")
+    #expect(SQLError.trailing(at: here).sqlstate == "42601")
+    #expect(SQLError.named("SELECT *").sqlstate == "42601")
+    #expect(SQLError.columns(expected: 2, got: 3).sqlstate == "42601")
+    #expect(SQLError.arity(1, 2).sqlstate == "42601")
+  }
+
+  @Test("an undefined relation reports 42P01")
+  func relation() {
+    #expect(SQLError.relation("Absent").sqlstate == "42P01")
+  }
+
+  @Test("an ambiguous column reports 42702")
+  func ambiguous() {
+    #expect(SQLError.ambiguous("Name").sqlstate == "42702")
+  }
+
+  @Test("a duplicate column reports 42701")
+  func duplicate() {
+    #expect(SQLError.duplicate("Name").sqlstate == "42701")
+  }
+
+  @Test("an undefined function reports 42883")
+  func function() {
+    #expect(SQLError.function("missing").sqlstate == "42883")
+  }
+
+  @Test("a rejected function argument reports 22023")
+  func argument() {
+    #expect(SQLError.argument("bad").sqlstate == "22023")
+  }
+
+  @Test("a non-integer arithmetic operand reports 42804")
+  func operand() {
+    #expect(
+        SQLError.operand("operands must be integers").sqlstate == "42804")
+  }
+
+  @Test(".state round-trips its code and message")
+  func passthrough() {
+    let error = SQLError.state("40001", "serialization failure")
+    #expect(error.sqlstate == "40001")
+    #expect(error.message == "serialization failure")
+    #expect(error.description == "serialization failure")
+  }
+
+  @Test("message equals description for a semantic case")
+  func message() {
+    let error = SQLError.column("Missing")
+    #expect(error.message == error.description)
+    #expect(error.message == "no such column 'Missing'")
+  }
+}


### PR DESCRIPTION
This pull request refactors SQL error handling to provide more precise error reporting and better alignment with the ISO SQLSTATE standard. The changes introduce new error cases for arithmetic faults, add a passthrough error for arbitrary SQLSTATE codes, and expose standardized SQLSTATE codes and messages for all errors. Tests and documentation are updated to reflect these improvements.

**Error handling enhancements:**

* Added a new `.state(String, String)` case to `SQLError` for surfacing arbitrary SQLSTATE codes and messages, allowing passthrough of unmodeled SQL errors.
* Refactored arithmetic error handling in `SQLError`:
  * Split the previous `.arithmetic` case into `.operand` (type errors), `.divide` (division by zero), and `.magnitude` (integer overflow), providing more granular error types.
  * Updated error descriptions and usages throughout the codebase to use the new cases. [[1]](diffhunk://#diff-fabb0e55432d1f4932fcc44ed65501e0499e9ae032e5559384617eff30049944L112-R129) [[2]](diffhunk://#diff-66f69cc14663ff59f1854b7179f51accad89aa0a7e6731e6880d344908ac4facL195-R203) [[3]](diffhunk://#diff-66f69cc14663ff59f1854b7179f51accad89aa0a7e6731e6880d344908ac4facL212-R216) [[4]](diffhunk://#diff-e8174e88eb2a0c88c2b70fa00f7eb5e2a81461462b190ccadef1bfc5ad2a18b2L1539-R1541) [[5]](diffhunk://#diff-e8174e88eb2a0c88c2b70fa00f7eb5e2a81461462b190ccadef1bfc5ad2a18b2L1548-R1553) [[6]](diffhunk://#diff-e8174e88eb2a0c88c2b70fa00f7eb5e2a81461462b190ccadef1bfc5ad2a18b2L1570-R1572)

**SQLSTATE standardization:**

* Added a `sqlstate` computed property to `SQLError`, mapping every error to a standardized 5-character SQLSTATE code, following ISO/IEC 9075-2 and PostgreSQL conventions.
* Added a `message` property to provide a uniform human-readable message for each error.

**Documentation and test updates:**

* Updated documentation and comments to clarify error semantics and the distinction between argument faults and arity mismatches. [[1]](diffhunk://#diff-c2a824b19cb7761a8c6ab76d4d4cb9cc4ffd627966f6138baa92cd2219777331L72-R78) [[2]](diffhunk://#diff-e8174e88eb2a0c88c2b70fa00f7eb5e2a81461462b190ccadef1bfc5ad2a18b2L1111-R1115)
* Updated existing tests to use the new error cases and messages, ensuring correct behavior and error reporting. [[1]](diffhunk://#diff-e8174e88eb2a0c88c2b70fa00f7eb5e2a81461462b190ccadef1bfc5ad2a18b2L1539-R1541) [[2]](diffhunk://#diff-e8174e88eb2a0c88c2b70fa00f7eb5e2a81461462b190ccadef1bfc5ad2a18b2L1548-R1553) [[3]](diffhunk://#diff-e8174e88eb2a0c88c2b70fa00f7eb5e2a81461462b190ccadef1bfc5ad2a18b2L1570-R1572)
* Added a new test suite (`ErrorTests.swift`) to verify SQLSTATE mappings and error message consistency.