### PR TITLE
SQL: support FROM-less SELECT over a single row

### DIFF
--- a/Sources/SQL/AST.swift
+++ b/Sources/SQL/AST.swift
@@ -53,15 +53,24 @@ public indirect enum Query: Hashable, Sendable {
 
 /// A `SELECT` query: a projection over one relation or a chain of joins, with an
 /// optional predicate and ordering.
+///
+/// `from` is optional: a FROM-less `SELECT <expr-list>` yields exactly one row
+/// whose columns are the evaluated projection expressions, the standard SQL
+/// way to compute a scalar (`SELECT 1 + 1`). A FROM-less select carries no
+/// joins, and its projection may not be a `SELECT *` — there is no relation to
+/// expand — nor a bare-column reference; only literals, calls, and arithmetic
+/// over them resolve against the empty row.
 public struct Select: Hashable, Sendable {
   /// The columns the query yields.
   public let projection: Projection
 
-  /// The primary relation the query scans.
-  public let from: Relation
+  /// The primary relation the query scans, or `nil` for a FROM-less `SELECT`
+  /// that projects over a single empty row.
+  public let from: Relation?
 
   /// The joins applied to `from`, in source order — `from JOIN joins[0] JOIN
-  /// joins[1] …`, a left-deep chain. Empty for a single-relation query.
+  /// joins[1] …`, a left-deep chain. Empty for a single-relation query and for
+  /// a FROM-less one.
   public let joins: Array<Join>
 
   /// The row filter, if any.
@@ -70,7 +79,7 @@ public struct Select: Hashable, Sendable {
   /// The ordering applied to the result, if any.
   public let order: Order?
 
-  public init(projection: Projection, from: Relation,
+  public init(projection: Projection, from: Relation?,
               joins: Array<Join> = [], predicate: Predicate? = nil,
               order: Order? = nil) {
     self.projection = projection
@@ -80,12 +89,13 @@ public struct Select: Hashable, Sendable {
     self.order = order
   }
 
-  /// The name of the primary relation.
+  /// The name of the primary relation, or the empty string for a FROM-less
+  /// `SELECT`.
   ///
   /// Retained for single-relation consumers that only ever name one table; it
   /// reads the `from` relation's name.
   public var table: String {
-    from.name
+    from?.name ?? ""
   }
 }
 

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -79,7 +79,11 @@ public enum Engine {
       throws(SQLError) -> Int {
     switch select.projection {
     case .all:
-      var width = try resolve(select.from, catalog).schema.width
+      // `SELECT *` spans the relations in scope; a FROM-less arm has none.
+      guard let relation = select.from else {
+        throw .named("SELECT * with no FROM")
+      }
+      var width = try resolve(relation, catalog).schema.width
       for join in select.joins {
         try width += resolve(join.relation, catalog).schema.width
       }
@@ -117,19 +121,30 @@ public enum Engine {
   internal static func compile<C: Catalog & ~Escapable>(_ select: Select,
                                                         _ catalog: borrowing C)
       throws(SQLError) -> Plan {
-    let from = try resolve(select.from, catalog)
+    guard let relation = select.from else {
+      // A FROM-less select projects expressions over a single row; a `WHERE`,
+      // `ORDER BY`, or `JOIN` has no relation to apply to. The parser never
+      // produces that shape, but a direct `Select(from: nil, …)` can, so reject
+      // it rather than silently ignore the clause.
+      guard select.joins.isEmpty, select.predicate == nil,
+          select.order == nil else {
+        throw .unsupported("a WHERE, ORDER BY, or JOIN requires a FROM clause")
+      }
+      return try scalar(select.projection)
+    }
+    let from = try resolve(relation, catalog)
 
     guard !select.joins.isEmpty else {
       var filter: Filter? = nil
       if let predicate = select.predicate {
-        filter = try from.schema.lower(predicate, in: select.from)
+        filter = try from.schema.lower(predicate, in: relation)
       }
       var order: (column: Int, ascending: Bool)? = nil
       if let clause = select.order {
-        order = try from.schema.order(clause, in: select.from)
+        order = try from.schema.order(clause, in: relation)
       }
       let projection =
-          try from.schema.terms(select.projection, in: select.from)
+          try from.schema.terms(select.projection, in: relation)
 
       // The referenced ordinals, in slot order: slot `i` is `ordinals[i]`.
       let ordinals = referenced(projection, filter, order)
@@ -149,7 +164,7 @@ public enum Engine {
       try joined.append(resolve(join.relation, catalog))
     }
 
-    var relations = [(select.from, from.schema)]
+    var relations = [(relation, from.schema)]
     for index in select.joins.indices {
       relations.append((select.joins[index].relation, joined[index].schema))
     }
@@ -220,6 +235,28 @@ public enum Engine {
     return shape(chain, projection.map { $0.remapped(through: slot) },
                  predicate.map { $0.remapped(through: slot) },
                  order.map { (slot[$0.column]!, $0.ascending) })
+  }
+
+  /// Compiles a scalar (FROM-less) `SELECT <expr-list>` into `Project(single)`
+  /// — the projection evaluated against the one empty row the `single` leaf
+  /// yields.
+  ///
+  /// The projection resolves against an empty schema (no columns), so only
+  /// literals, scalar calls, and arithmetic over them lower; a `SELECT *` has no
+  /// relation to expand and a bare-column reference no column to bind, each
+  /// faulting (`SQLError.column` for a column, `SQLError.unsupported` for `*`).
+  /// The terms hold no slots, so the `single` row's empty record carries every
+  /// value the projection needs.
+  private static func scalar(_ projection: Projection)
+      throws(SQLError) -> Plan {
+    guard case .all = projection else {
+      let schema = Schema(width: 0, extent: 0, names: [], virtuals: [])
+      let terms = try schema.terms(projection, in: Relation(name: ""))
+      return .project(terms, .single)
+    }
+    // `SELECT *` names every column of the relations in scope; a FROM-less query
+    // has none, so there is nothing to expand.
+    throw .unsupported("SELECT * requires a FROM clause")
   }
 
   /// A relation resolved for compilation: its name-resolution `schema` and a
@@ -335,6 +372,8 @@ public enum Engine {
                                                          _ bindings: Bindings)
       throws(SQLError) -> Plan {
     switch plan {
+    case .single:
+      plan
     case .scan:
       plan
     case let .derived(name, plan, ordinals, seek):

--- a/Sources/SQL/Error.swift
+++ b/Sources/SQL/Error.swift
@@ -93,6 +93,11 @@ public enum SQLError: Error, Hashable, Sendable {
   /// columns of every arm must align — carrying the first arm's width and the
   /// offending arm's.
   case arity(Int, Int)
+  /// A query uses a construct the engine does not support in the shape given — a
+  /// `SELECT *` with no `FROM`, or a `WHERE`/`ORDER BY`/`JOIN` on a FROM-less
+  /// select (which projects only expressions over a single row); the string
+  /// describes it.
+  case unsupported(String)
 }
 
 extension SQLError: CustomStringConvertible {
@@ -138,6 +143,8 @@ extension SQLError: CustomStringConvertible {
     case let .arity(expected, found):
       "UNION arms project differing column counts: "
           + "expected \(expected), found \(found)"
+    case let .unsupported(detail):
+      "unsupported query: \(detail)"
     }
   }
 }
@@ -166,6 +173,11 @@ extension SQLError {
   ///   (a scalar function's rejected argument).
   /// - `42804` (datatype mismatch) is the non-integer arithmetic operand — a
   ///   type error at evaluation rather than a value-range fault.
+  /// - Class `SS` — the implementation-defined class this engine squats on
+  ///   (SwiftSQL) for a condition with no standard ISO code — `SS001`, a query
+  ///   shape the engine does not support (a FROM-less `SELECT *`, or a clause
+  ///   with no `FROM`). ISO leaves classes whose first character is `5`–`9` or
+  ///   `I`–`Z` implementation-defined, so `SS` is a safe squat.
   public var sqlstate: String {
     switch self {
     case let .state(code, _):
@@ -195,6 +207,9 @@ extension SQLError {
       "22012"
     case .magnitude:
       "22003"
+    // Class SS — SwiftSQL, this engine's implementation-defined conditions.
+    case .unsupported:
+      "SS001"
     }
   }
 

--- a/Sources/SQL/Operator.swift
+++ b/Sources/SQL/Operator.swift
@@ -101,6 +101,10 @@ internal struct Record: Row, Hashable {
 /// named and its referenced ordinals carried for the executor to re-resolve and
 /// materialise.
 internal indirect enum Plan {
+  /// The single-row leaf of a FROM-less `SELECT`: it yields exactly one empty
+  /// record (no slots), the row a scalar projection (`SELECT 1 + 1`) computes
+  /// its expressions against.
+  case single
   /// A leaf over the relation `name`: its `ordinals` (defining its slots), over
   /// the seek's row range when present (else the whole relation).
   case scan(name: String, ordinals: Array<Int>, seek: Range<Int>?)
@@ -171,6 +175,10 @@ extension Plan {
   /// nest rewrite recurse into a multi-relation chain.
   internal var slots: Int? {
     switch self {
+    case .single:
+      // The single empty row has no slots — a FROM-less projection reads only
+      // constants and calls over them, never a slot of this row.
+      0
     case let .scan(_, ordinals, _):
       ordinals.count
     case let .derived(_, _, ordinals, _):
@@ -216,6 +224,10 @@ internal func execute<C: Catalog & ~Escapable>(_ plan: Plan,
                                                _ bindings: Bindings)
     throws(SQLError) -> Array<Record> {
   switch plan {
+  case .single:
+    // The FROM-less single row: one record with no cells, the source a scalar
+    // projection evaluates its constant/call expressions against.
+    [Record([])]
   case let .scan(name, ordinals, seek):
     try materialise(name, ordinals, seek, catalog)
   case let .derived(_, source, ordinals, seek):

--- a/Sources/SQL/Parser.swift
+++ b/Sources/SQL/Parser.swift
@@ -10,7 +10,7 @@
 /// create         := CREATE VIEW identifier
 ///                   ['(' identifier (',' identifier)* ')'] AS query
 /// query          := select (UNION [ALL] select)*
-/// select         := SELECT projection FROM relation (join)* [where] [order]
+/// select         := SELECT projection [FROM relation (join)* [where] [order]]
 /// relation       := identifier [AS identifier]
 /// join           := JOIN relation ON column '=' column
 /// projection     := '*' | column (',' column)*
@@ -182,10 +182,16 @@ internal struct Parser: ~Escapable {
   }
 
   /// Parses a `SELECT` query.
+  ///
+  /// `FROM` is optional: a FROM-less `SELECT <expr-list>` projects over a single
+  /// empty row (the standard way to compute a scalar, `SELECT 1 + 1`), and so
+  /// admits no relation, joins, `WHERE`, or `ORDER BY` to follow.
   private mutating func select() throws(SQLError) -> Select {
     try expect(.select)
     let projection = try projection()
-    try expect(.from)
+    guard try match(.from) else {
+      return Select(projection: projection, from: nil)
+    }
     let from = try relation()
 
     var joins = Array<Join>()

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -963,7 +963,7 @@ private func derived(_ plan: Plan) -> Plan? {
     derived(left) ?? derived(right)
   case let .union(left, right, _):
     derived(left) ?? derived(right)
-  case .scan, .join:
+  case .single, .scan, .join:
     nil
   }
 }
@@ -985,7 +985,7 @@ private func seeks(_ plan: Plan) -> Bool {
     seeks(left) || seeks(right)
   case let .union(left, right, _):
     seeks(left) || seeks(right)
-  case .join:
+  case .single, .join:
     false
   }
 }
@@ -1008,7 +1008,7 @@ private func filters(_ plan: Plan) -> Bool {
     filters(left) || filters(right)
   case let .union(left, right, _):
     filters(left) || filters(right)
-  case .scan, .join:
+  case .single, .scan, .join:
     false
   }
 }
@@ -1580,5 +1580,126 @@ struct EngineArithmeticTests {
     // is evaluated per row on the WHERE side too.
     let rows = try run("SELECT Name FROM People WHERE Age + 1 = 26")
     #expect(rows == [[.text("Bob")], [.text("Eve")]])
+  }
+}
+
+// MARK: - Scalar (FROM-less) SELECT tests
+
+struct EngineScalarSelectTests {
+  @Test("a FROM-less literal yields exactly one row")
+  func literal() throws {
+    // No relation, so the projection runs against a single empty row; the
+    // catalog is never consulted for a table.
+    let rows = try run("SELECT 42")
+    #expect(rows == [[.integer(42)]])
+  }
+
+  @Test("a FROM-less arithmetic computes a scalar")
+  func arithmetic() throws {
+    let rows = try run("SELECT 1 + 1")
+    #expect(rows == [[.integer(2)]])
+  }
+
+  @Test("FROM-less arithmetic honours precedence")
+  func precedence() throws {
+    let rows = try run("SELECT 2 + 3 * 4")
+    #expect(rows == [[.integer(14)]])
+  }
+
+  @Test("a FROM-less multi-column projection yields one row of each value")
+  func multiColumn() throws {
+    let rows = try run("SELECT 1, 2, 3")
+    #expect(rows == [[.integer(1), .integer(2), .integer(3)]])
+  }
+
+  @Test("a FROM-less projection mixes text and integer expressions")
+  func mixed() throws {
+    let rows = try run("SELECT 'x', 10 / 2")
+    #expect(rows == [[.text("x"), .integer(5)]])
+  }
+
+  @Test("a FROM-less scalar call evaluates against the single row")
+  func call() throws {
+    let rows = try functionRun("SELECT add(40, 2)")
+    #expect(rows == [[.integer(42)]])
+  }
+
+  @Test("a NULL-yielding FROM-less expression projects NULL")
+  func null() throws {
+    // The bare literal NULL is not in the grammar, but a NULL arises from a
+    // function returning it; `nothing` yields NULL for the single row.
+    let routines: Routines = ["nothing": { _ in .null }]
+    let rows = try Engine.run(parse("SELECT nothing()"), people(), routines)
+    #expect(rows == [[.null]])
+  }
+
+  @Test("a FROM-less SELECT * is rejected — no relation to expand")
+  func star() throws {
+    #expect(throws: SQLError.unsupported("SELECT * requires a FROM clause")) {
+      try run("SELECT *")
+    }
+  }
+
+  @Test("a FROM-less bare column is rejected — no column to bind")
+  func column() throws {
+    #expect(throws: SQLError.column("Name")) {
+      try run("SELECT Name")
+    }
+  }
+
+  @Test("a directly-built FROM-less select with clauses is rejected")
+  func clauses() throws {
+    // The parser never builds a FROM-less select carrying a WHERE, ORDER BY, or
+    // JOIN, but `Select.init` is public, so a direct `Select(from: nil, …)` can.
+    // The engine must reject it rather than silently drop the clause — a false
+    // predicate would otherwise still return the scalar row.
+    let fault =
+        SQLError.unsupported("a WHERE, ORDER BY, or JOIN requires a FROM clause")
+    let filtered = try EngineScalarSelectTests.select(
+        "SELECT 1 FROM People WHERE Id = 99")
+    #expect(throws: fault) {
+      try Engine.run(.select(Select(projection: filtered.projection,
+                                    from: nil,
+                                    predicate: filtered.predicate)), people())
+    }
+    let ordered =
+        try EngineScalarSelectTests.select("SELECT Id FROM People ORDER BY Id")
+    #expect(throws: fault) {
+      try Engine.run(.select(Select(projection: ordered.projection, from: nil,
+                                    order: ordered.order)), people())
+    }
+    let joined = try EngineScalarSelectTests.select(
+        "SELECT Id FROM People JOIN Pets ON Pets.Owner = People.Id")
+    #expect(throws: fault) {
+      try Engine.run(.select(Select(projection: joined.projection, from: nil,
+                                    joins: joined.joins)), people())
+    }
+  }
+
+  /// The `Select` of a parsed single-`SELECT` query — for building the FROM-less
+  /// shapes the parser will not, by re-homing a clause onto a `from: nil` select.
+  private static func select(_ text: String) throws -> Select {
+    guard case let .select(select) = try parse(text) else {
+      throw SQLError.incomplete(expected: "a SELECT")
+    }
+    return select
+  }
+
+  @Test("a FROM-less arm of a UNION combines with a FROM arm")
+  func union() throws {
+    // Both arms project one integer column; the FROM-less arm contributes its
+    // single computed row, deduplicating against the People ages.
+    let rows = try Engine.run(parse("""
+        SELECT 100 UNION ALL SELECT Age FROM People WHERE Id = 1
+        """), people())
+    #expect(rows == [[.integer(100)], [.integer(30)]])
+  }
+
+  @Test("an existing SELECT … FROM … query is unaffected")
+  func regression() throws {
+    // The FROM-optional grammar leaves a normal query parsing and running
+    // exactly as before.
+    let rows = try run("SELECT Name FROM People WHERE Id = 1")
+    #expect(rows == [[.text("Alice")]])
   }
 }

--- a/Tests/SQLTests/ErrorTests.swift
+++ b/Tests/SQLTests/ErrorTests.swift
@@ -70,6 +70,15 @@ struct SQLStateTests {
         SQLError.operand("operands must be integers").sqlstate == "42804")
   }
 
+  @Test("an engine-specific condition reports the SwiftSQL SS class")
+  func unsupported() {
+    // Engine-specific faults with no standard ISO code squat on the
+    // implementation-defined `SS` (SwiftSQL) class rather than borrow a
+    // standard one.
+    #expect(SQLError.unsupported("SELECT * requires a FROM clause").sqlstate
+            == "SS001")
+  }
+
   @Test(".state round-trips its code and message")
   func passthrough() {
     let error = SQLError.state("40001", "serialization failure")

--- a/Tests/SQLTests/ParserTests.swift
+++ b/Tests/SQLTests/ParserTests.swift
@@ -400,10 +400,13 @@ struct ErrorTests {
     }
   }
 
-  @Test("rejects input ending after the projection")
+  @Test("rejects a FROM keyword with no following relation")
   func unexpectedEnd() {
+    // FROM is now optional, so `SELECT *` parses as a FROM-less projection (the
+    // engine rejects a `*` with no relation). A bare FROM with no relation,
+    // though, ends the input where a relation is required.
     #expect(throws: SQLError.self) {
-      _ = try Statement(parsing: "SELECT *")
+      _ = try Statement(parsing: "SELECT * FROM")
     }
   }
 
@@ -542,6 +545,58 @@ struct ArithmeticTests {
     #expect(select.predicate
                 == .comparison(left: sum, op: .equal,
                                right: .literal(.integer(26))))
+  }
+}
+
+// MARK: - Scalar (FROM-less) SELECT
+
+struct ScalarSelectTests {
+  @Test("parses a FROM-less SELECT with no relation")
+  func bare() throws {
+    let select = try parseSelect("SELECT 1")
+    #expect(select.from == nil)
+    #expect(select.joins.isEmpty)
+    #expect(select.predicate == nil)
+    #expect(select.order == nil)
+    #expect(select.projection
+                == .expressions([Projected(expression: .literal(.integer(1)))]))
+  }
+
+  @Test("parses a FROM-less arithmetic projection")
+  func arithmetic() throws {
+    let select = try parseSelect("SELECT 1 + 1")
+    let sum = Expression.binary(.add, .literal(.integer(1)),
+                                .literal(.integer(1)))
+    #expect(select.from == nil)
+    #expect(select.projection == .expressions([Projected(expression: sum)]))
+  }
+
+  @Test("parses a FROM-less multi-column projection")
+  func multiColumn() throws {
+    let select = try parseSelect("SELECT 1, 2")
+    #expect(select.from == nil)
+    #expect(select.projection == .expressions([
+      Projected(expression: .literal(.integer(1))),
+      Projected(expression: .literal(.integer(2))),
+    ]))
+  }
+
+  @Test("a FROM-less alias names the projected column")
+  func aliased() throws {
+    let select = try parseSelect("SELECT 1 + 1 AS two")
+    let sum = Expression.binary(.add, .literal(.integer(1)),
+                                .literal(.integer(1)))
+    #expect(select.projection
+                == .expressions([Projected(expression: sum, alias: "two")]))
+  }
+
+  @Test("a FROM-less query admits no trailing WHERE")
+  func noWhere() {
+    // With FROM absent there is no relation to filter, so a WHERE that follows
+    // is trailing input rather than a clause.
+    #expect(throws: SQLError.self) {
+      _ = try Statement(parsing: "SELECT 1 WHERE 1 = 1")
+    }
   }
 }
 


### PR DESCRIPTION
Make FROM optional in the SELECT grammar. A FROM-less SELECT <expr-list> yields exactly one row whose columns are the evaluated projection expressions — the standard way to compute a scalar, SELECT 1 + 1.

Select.from becomes optional; the parser stops after the projection when no FROM follows. The engine compiles a FROM-less select to Project over a new single leaf that yields one empty record, the projection resolving against an empty schema so only literals, scalar calls, and arithmetic over them lower — a SELECT * (no relation to expand) and a bare-column reference each fault. Column names follow the existing projection-naming rules (alias, else the expression's derived name).