### PR TITLE
CLI: repair the input model

### DIFF
--- a/Sources/winmd-inspect/Query.swift
+++ b/Sources/winmd-inspect/Query.swift
@@ -74,7 +74,19 @@ internal struct Query: ParsableCommand {
       } catch is Shell.Stop {}
     } else {
       note("winmd-inspect — .help for commands, .quit to leave")
-      for statement in Statements(reading: { readLine() }) {
+      // The interactive shell prompts like `sqlite3` before each read: the
+      // primary prompt for a fresh statement, the continuation prompt while a
+      // statement is mid-accumulation (unterminated) — the cue that tells the
+      // user the shell is still waiting for the closing `;`. Both go to stderr,
+      // like the banner and diagnostics, so a piped run's stdout (the TSV rows)
+      // stays clean. Only this branch passes a hook; the batch and `.read`
+      // never prompt. No terminal detection: prompting on stderr is harmless if
+      // input is redirected, and `readLine()` is the cross-platform reader.
+      let statements =
+          Statements(reading: { readLine() },
+                     prompt: { pending in prompt(pending ? "   ...> "
+                                                         : "winmd> ") })
+      for statement in statements {
         do {
           try shell.attempt(statement)
         } catch is Shell.Stop {
@@ -92,4 +104,11 @@ internal struct Query: ParsableCommand {
 /// and `Shell.read` so every diagnostic lands on the same stream.
 internal func note(_ message: String) {
   FileHandle.standardError.write(Data((message + "\n").utf8))
+}
+
+/// Writes `text` to stderr with no trailing newline — the interactive shell's
+/// prompt, which sits before the line the user types. On stderr like `note`, so
+/// a piped run's stdout (the TSV rows) stays clean.
+internal func prompt(_ text: String) {
+  FileHandle.standardError.write(Data(text.utf8))
 }

--- a/Sources/winmd-inspect/Query.swift
+++ b/Sources/winmd-inspect/Query.swift
@@ -30,12 +30,16 @@ internal struct Query: ParsableCommand {
                                  + "shell.")
   }
 
-  // The database is the required positional and must be declared before the
-  // optional `sql`: ArgumentParser binds positionals in declaration order, so
-  // with `sql` first, `query db` would bind `db` to `sql` and report the
-  // database missing — making the omit-SQL shell form unreachable.
-  @OptionGroup
-  internal var options: InspectOptions
+  // `sql` is declared before the `<database>` group so a trailing script binds
+  // to it. The database is not a positional of `query` itself: it leads the
+  // command line — `winmd-inspect <database> query …` — as the root's
+  // positional, which ArgumentParser propagates into this subcommand's shared
+  // `InspectOptions`. With the group declared first, that propagated positional
+  // swallows a trailing `<sql>` and reports it "unexpected"; declaring `sql`
+  // first lets the script bind while the database still arrives by propagation.
+  @Argument(help: ArgumentHelp("The SQL script to run; omit it to read one "
+                             + "from stdin or open an interactive shell."))
+  internal var sql: String?
 
   @Option(name: .customShort("I"),
           help: ArgumentHelp("A directory searched before the built-in "
@@ -44,9 +48,8 @@ internal struct Query: ParsableCommand {
                            + ".<ext>`); repeatable, the last directory wins."))
   internal var search: Array<String> = []
 
-  @Argument(help: ArgumentHelp("The SQL script to run; omit it to read one "
-                             + "from stdin or open an interactive shell."))
-  internal var sql: String?
+  @OptionGroup
+  internal var options: InspectOptions
 
   internal func run() throws {
     // The caller owns the mapping; it must outlive the database, which is a

--- a/Sources/winmd-inspect/Shell.swift
+++ b/Sources/winmd-inspect/Shell.swift
@@ -512,21 +512,33 @@ internal struct Statements: Sequence {
   /// lines for the argument and `.read`.
   private let lines: () -> String?
 
-  /// Streams statements read line-by-line from `lines`.
-  internal init(reading lines: @escaping () -> String?) {
+  /// A hook called before each line is read, told whether a statement is
+  /// pending (a mid-accumulation, unterminated statement). The interactive
+  /// shell passes one to emit its primary/continuation prompt; the argument and
+  /// `.read` paths leave it `nil` so a batch never prompts.
+  private let prompt: ((Bool) -> Void)?
+
+  /// Streams statements read line-by-line from `lines`, optionally calling
+  /// `prompt` before each read with whether a statement is pending — the
+  /// interactive shell's prompt hook.
+  internal init(reading lines: @escaping () -> String?,
+                prompt: ((Bool) -> Void)? = nil) {
     self.lines = lines
+    self.prompt = prompt
   }
 
-  /// Streams the statements of `text`, reading its lines.
+  /// Streams the statements of `text`, reading its lines. A batch never
+  /// prompts, so it has no prompt hook.
   internal init(of text: String) {
     var lines = text.split(separator: "\n", omittingEmptySubsequences: false)
                     .map(String.init)
                     .makeIterator()
     self.lines = { lines.next() }
+    prompt = nil
   }
 
   internal func makeIterator() -> Iterator {
-    Iterator(lines)
+    Iterator(lines, prompt)
   }
 
   /// The statement iterator — the `;`-accumulator over the line source.
@@ -534,11 +546,17 @@ internal struct Statements: Sequence {
     /// The line source the iterator pulls from.
     private let lines: () -> String?
 
+    /// The prompt hook, called before each read with whether a statement is
+    /// pending; `nil` for a batch, which never prompts.
+    private let prompt: ((Bool) -> Void)?
+
     /// The SQL accumulated across lines, not yet closed by a `;`.
     private var pending: String
 
-    internal init(_ lines: @escaping () -> String?) {
+    internal init(_ lines: @escaping () -> String?,
+                  _ prompt: ((Bool) -> Void)?) {
       self.lines = lines
+      self.prompt = prompt
       pending = ""
     }
 
@@ -558,6 +576,10 @@ internal struct Statements: Sequence {
           guard statement.isEmpty else { return statement }
           continue
         }
+        // Prompt before the read (the interactive shell only): a pending,
+        // unterminated statement asks for its continuation; an empty one asks
+        // for a fresh statement. A batch's hook is `nil`, so it never prompts.
+        prompt?(!pending.trimmed.isEmpty)
         guard let line = lines() else {
           // End of input: flush a final unterminated statement (the closing
           // `;` is optional), then clear `pending` so the next call stops.

--- a/Tests/winmd-inspectTests/QueryTests.swift
+++ b/Tests/winmd-inspectTests/QueryTests.swift
@@ -3,25 +3,75 @@
 
 import Testing
 
-internal import ArgumentParser
+import ArgumentParser
+
+import class Foundation.FileManager
+import struct Foundation.Data
+import struct Foundation.UUID
 
 @testable import winmd_inspect
 
 struct QueryTests {
-  @Test("the database is the first positional; SQL is optional and follows it")
-  func optionalSQLFollowsDatabase() throws {
-    // `query <db>` with no SQL must bind `db` to the database and leave `sql`
-    // nil — the stdin/shell form. Were `sql` declared first, ArgumentParser
-    // would bind `db` to `sql` and report the database missing, so this parse
-    // would throw. The database is parsed as a path; no file need exist.
-    let shell = try Query.parse(["fixture.winmd"])
-    #expect(shell.sql == nil)
-    #expect(shell.options.database.url.lastPathComponent == "fixture.winmd")
+  /// Runs `body` with the path of a fresh, empty regular file that exists for
+  /// the call and is removed after. The root's `validate` (run on every parse)
+  /// requires the database to be an existing regular file, so a parse test
+  /// binds a real path rather than a made-up one.
+  private static func withDatabase(_ body: (String) throws -> Void) rethrows {
+    // A fresh per-call directory keeps the filename `fixture.winmd` (the parses
+    // assert its `lastPathComponent`) while a `UUID` isolates concurrently
+    // running tests — swift-testing runs them in parallel, so a shared path
+    // would race a peer's cleanup.
+    let manager = FileManager.default
+    let directory =
+        manager.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    try? manager.createDirectory(at: directory,
+                                 withIntermediateDirectories: true)
+    defer { try? manager.removeItem(at: directory) }
+    let url = directory.appendingPathComponent("fixture.winmd")
+    manager.createFile(atPath: url.path, contents: Data())
+    try body(url.path)
+  }
 
-    // With a SQL argument, the database still binds first and `sql` takes the
-    // second positional.
-    let scripted = try Query.parse(["fixture.winmd", "SELECT 1"])
-    #expect(scripted.sql == "SELECT 1")
-    #expect(scripted.options.database.url.lastPathComponent == "fixture.winmd")
+  @Test("the database leads the command line; SQL is an optional positional")
+  func databaseLeadsSQL() throws {
+    try QueryTests.withDatabase { database in
+      // The database leads the command line as the root's positional — the
+      // subcommand comes after it — and is propagated into the subcommand's
+      // `InspectOptions`. `<db> query` with no script opens the shell, so `sql`
+      // is nil.
+      let shell = try #require(try Inspect.parseAsRoot([database, "query"])
+                                   as? Query)
+      #expect(shell.sql == nil)
+      #expect(shell.options.database.url.lastPathComponent == "fixture.winmd")
+
+      // `<db> query '<sql>'` runs the script: the trailing positional binds to
+      // `sql` (declared before the database group), the database still leading.
+      // Were the group declared first, the propagated database would swallow the
+      // script and ArgumentParser would report it "unexpected".
+      let scripted =
+          try #require(try Inspect.parseAsRoot([database, "query", "SELECT 1"])
+                           as? Query)
+      #expect(scripted.sql == "SELECT 1")
+      #expect(scripted.options.database.url.lastPathComponent
+                  == "fixture.winmd")
+
+      // A `dump` reads the same leading database — one positional, before the
+      // verb, for every subcommand.
+      let dumped = try #require(try Inspect.parseAsRoot([database, "dump"])
+                                    as? Dump)
+      #expect(dumped.options.database.url.lastPathComponent == "fixture.winmd")
+    }
+  }
+
+  @Test("the leading database is validated to be an existing file")
+  func validatesDatabase() throws {
+    // The root validates the leading `<database>` before dispatching, so a
+    // non-existent path fails the parse whichever subcommand follows.
+    #expect(throws: (any Error).self) {
+      _ = try Inspect.parseAsRoot(["does-not-exist.winmd", "query"])
+    }
+    #expect(throws: (any Error).self) {
+      _ = try Inspect.parseAsRoot(["does-not-exist.winmd", "dump"])
+    }
   }
 }

--- a/Tests/winmd-inspectTests/ShellTests.swift
+++ b/Tests/winmd-inspectTests/ShellTests.swift
@@ -101,6 +101,49 @@ struct ShellTests {
             == ["SELECT 1", ".tables", "SELECT 2"])
   }
 
+  @Test("the reading stream prompts primary then continuation while pending")
+  func promptAccumulates() {
+    // The interactive shell's prompt hook is called before each line read, told
+    // whether a statement is pending (mid-accumulation, unterminated). A fresh
+    // statement asks for the primary prompt (`false`); an unterminated one asks
+    // for the continuation (`true`) — the cue that the shell still awaits the
+    // `;`. Here a two-line statement (no `;` on the first line) prompts primary
+    // before its first line, continuation before its second (the statement is
+    // pending), then — once the `;` yields it and clears `pending` — primary
+    // again before the end-of-input read that ends the stream.
+    var script = ["SELECT 1", "FROM Module;"].makeIterator()
+    var pending = Array<Bool>()
+    let statements =
+        Statements(reading: { script.next() },
+                   prompt: { pending.append($0) })
+    #expect(Array(statements) == ["SELECT 1\nFROM Module"])
+    #expect(pending == [false, true, false])
+  }
+
+  @Test("a fresh statement each line prompts primary, never continuation")
+  func promptFresh() {
+    // Each self-terminating statement (its own `;`) leaves nothing pending, so
+    // every prompt before a read is the primary — a `.`-meta line likewise. The
+    // final read past the last line sees nothing pending too.
+    var script = ["SELECT 1;", ".tables", "SELECT 2;"].makeIterator()
+    var pending = Array<Bool>()
+    let statements =
+        Statements(reading: { script.next() },
+                   prompt: { pending.append($0) })
+    #expect(Array(statements) == ["SELECT 1", ".tables", "SELECT 2"])
+    #expect(pending.allSatisfy { $0 == false })
+  }
+
+  @Test("the batch stream carries no prompt hook and never prompts")
+  func batchIsQuiet() {
+    // `Statements(of:)` is the argument/`.read` path; it takes no prompt hook,
+    // so a batch run never prompts. Draining a multi-statement script drives
+    // the same accumulation the interactive stream does, with no prompt to
+    // observe — the assertion is that it streams correctly with no hook at all.
+    #expect(Array(Statements(of: "SELECT 1\nFROM Module;\nSELECT 2"))
+            == ["SELECT 1\nFROM Module", "SELECT 2"])
+  }
+
   @Test("the bundled views are the four COM-interface views")
   func bundled() {
     // The parse-and-register path a `CREATE VIEW` reuses; the four bundled


### PR DESCRIPTION
This pull request updates the handling of command-line arguments and interactive shell prompts in the `winmd-inspect` tool, improving both user experience and test coverage. The main changes clarify how the SQL script and database arguments are parsed, add interactive prompts that mimic `sqlite3`, and enhance test reliability by ensuring the database file exists during tests.

**Command-line parsing and shell prompt improvements:**

* The `Query` command now declares the optional `sql` argument before the database option group, ensuring that a trailing SQL script binds correctly and the database is always parsed as the leading positional argument. This change also updates the associated documentation and tests. [[1]](diffhunk://#diff-18faad7c0e5648c6a8354dd72204a68cb674d3a7ec5a7fde805a3c6d7b5350c4L33-R42) [[2]](diffhunk://#diff-18faad7c0e5648c6a8354dd72204a68cb674d3a7ec5a7fde805a3c6d7b5350c4L47-R52)
* The interactive shell now prompts the user before each line, showing a primary prompt for new statements and a continuation prompt for unterminated statements, both sent to stderr to avoid polluting output. The prompt logic is encapsulated in a new `prompt` function. [[1]](diffhunk://#diff-18faad7c0e5648c6a8354dd72204a68cb674d3a7ec5a7fde805a3c6d7b5350c4L74-R89) [[2]](diffhunk://#diff-18faad7c0e5648c6a8354dd72204a68cb674d3a7ec5a7fde805a3c6d7b5350c4R108-R114)
* The `Statements` sequence now accepts an optional prompt hook, which is called before each line read to indicate whether a statement is pending. This enables the interactive shell to display appropriate prompts, while batch/scripted runs remain silent. [[1]](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425L515-R559) [[2]](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425R579-R582)

**Testing improvements:**

* Tests for argument parsing now create and clean up a real temporary database file, ensuring that the root validator (which requires an existing file) passes. This eliminates race conditions and makes tests more robust.
* New tests verify that the prompt hook behaves as expected in interactive and batch modes, confirming that prompts are shown only in the shell and not during script execution.