### PR TITLE
SQL: perform some textbook optimizations over query plans

### DIFF
--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -490,11 +490,16 @@ public enum Engine {
   /// through `ordinals` (slot `i` is `ordinals[i]`) for the `bound` query. A
   /// `string` operand or an unseekable column never qualifies, and the executor
   /// scans.
-  private static func boundaries<T: Table & ~Escapable>(_ filter: Filter,
-                                                        _ ordinals: Array<Int>,
-                                                        _ table: borrowing T,
-                                                        _ count: Int,
-                                                        _ bindings: Bindings)
+  ///
+  /// The hash-join executor reuses this over a pushed inner filter's conjuncts
+  /// to seek the inner by a seekable conjunct before bucketing, so a
+  /// seekable/contradictory inner filter reads few or no inner rows — hence it is
+  /// `internal` rather than private to `seek`.
+  internal static func boundaries<T: Table & ~Escapable>(_ filter: Filter,
+                                                         _ ordinals: Array<Int>,
+                                                         _ table: borrowing T,
+                                                         _ count: Int,
+                                                         _ bindings: Bindings)
       -> Range<Int>? {
     guard let (slot, op, value) = comparison(filter, bindings),
         let lower = table.bound(ordinals[slot], value, strict: false),

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -40,7 +40,8 @@ public enum Engine {
                                                   _ routines: Routines = [:],
                                                   bindings: Bindings = [:])
       throws(SQLError) -> Array<Array<Value>> {
-    let plan = try optimise(compile(query, catalog), catalog, bindings)
+    let logical = try compile(query, catalog).pushdown()
+    let plan = try optimise(logical, catalog, bindings)
     return try execute(plan, catalog, routines, bindings).map(\.values)
   }
 
@@ -415,9 +416,12 @@ public enum Engine {
   ///
   /// A standalone qualifying comparison seeks its run and admits all of it (no
   /// residual). An `AND` with one qualifying conjunct seeks that run and keeps
-  /// the other as the residual `Select`. Everything else scans under the whole
-  /// filter. The `filter` is in slot space, so a comparison's slot maps back to
-  /// its table ordinal through the scan's `ordinals` before reading a boundary.
+  /// the other as the residual `Select` — but ONLY when that residual is safe,
+  /// since seeking narrows the scan and a throwing residual would then raise
+  /// over just the sought run, suppressing a throw the un-seeked scan owes on a
+  /// skipped row. Everything else scans under the whole filter. The `filter` is
+  /// in slot space, so a comparison's slot maps back to its table ordinal
+  /// through the scan's `ordinals` before reading a boundary.
   private static func seek<C: Catalog & ~Escapable>(_ filter: Filter,
                                                     _ name: String,
                                                     _ ordinals: Array<Int>,
@@ -431,11 +435,20 @@ public enum Engine {
       return .scan(name: name, ordinals: ordinals, seek: range)
     }
 
+    // Seek by one conjunct only when the OTHER — the residual, then run over
+    // just the sought run — is safe. Seeking narrows the scan, so a residual
+    // that can throw would raise only on the rows the seek kept, suppressing a
+    // throw the un-seeked scan owes on a skipped row: `(1 / x) = 0 AND id < 0`
+    // over an id-sorted table (an empty id < 0 run) must still raise the
+    // division rather than seek past it, as must a grouped `… AND (… AND id <
+    // 0)` the left fold rebuilds so a seekable `id < 0` is the top-level RHS.
     if case let .and(lhs, rhs) = filter {
-      if let range = boundaries(lhs, ordinals, table, count, bindings) {
+      if rhs.safe,
+          let range = boundaries(lhs, ordinals, table, count, bindings) {
         return .select(rhs, .scan(name: name, ordinals: ordinals, seek: range))
       }
-      if let range = boundaries(rhs, ordinals, table, count, bindings) {
+      if lhs.safe,
+          let range = boundaries(rhs, ordinals, table, count, bindings) {
         return .select(lhs, .scan(name: name, ordinals: ordinals, seek: range))
       }
     }
@@ -513,23 +526,46 @@ public enum Engine {
   /// index-nested-loop `Join` when a `match` conjunct relates the two sides,
   /// else leaves the product (a plain nested loop) under the filter.
   ///
+  /// The inner side is a bare `Scan(inner, _, nil)`, or that scan under a pushed
+  /// single-relation filter — `Select(inner-filter, Scan(inner, _, nil))`, the
+  /// shape selection pushdown leaves when a `WHERE` conjunct references only the
+  /// joined-in relation. Either way the join folds in the scan; the pushed
+  /// filter is preserved so the joined-in relation's non-key predicate still
+  /// rides the `Join` path rather than degrading to a residual product.
+  ///
   /// The left side's slot count is the boundary `base` in the combined slot
   /// space: a slot below it is an outer-side key, a slot at or above it an
   /// inner-side key (still in combined space). The inner key's slot maps to its
-  /// table ordinal (`column`) through the inner scan's `ordinals` for the seek's
-  /// `bound`. The matching conjunct is consumed; any remaining conjuncts stay as
-  /// a residual `Select`. When the inner side is not a bare `Scan`, the product
-  /// is preserved.
+  /// table ordinal (`column`) through the inner scan's `ordinals` for the
+  /// seek's `bound`. The matching conjunct is consumed; any remaining conjuncts
+  /// stay as a residual `Select`. The pushed inner filter rides on the `Join`
+  /// node itself — in the inner's OWN 0-based standalone slot space, the space it
+  /// already lives in on the inner scan — so the executor applies it WHILE
+  /// materialising inner rows (before bucketing / as part of the inner scan),
+  /// rather than lifting it into the residual to run after the join. Applying it
+  /// during materialisation means a pair forms only when the filter holds, so it
+  /// still gates a later unsafe residual conjunct (the pushdown barrier having
+  /// kept the safe inner filter ahead of any unsafe conjunct). When the inner
+  /// side is neither shape, the product is preserved.
   private static func nest<C: Catalog & ~Escapable>(_ filter: Filter,
                                                     _ left: Plan,
                                                     _ right: Plan,
                                                     _ catalog: borrowing C,
                                                     _ bindings: Bindings)
       throws(SQLError) -> Plan {
-    guard case let .scan(name, ordinals, nil) = right,
-        let base = left.slots else {
-      return try .select(filter, .product(optimise(left, catalog, bindings),
-                                          optimise(right, catalog, bindings)))
+    let inner: (name: String, ordinals: Array<Int>, filter: Filter?)?
+    switch right {
+    case let .scan(name, ordinals, nil):
+      inner = (name, ordinals, nil)
+    case let .select(pushed, .scan(name, ordinals, nil)):
+      inner = (name, ordinals, pushed)
+    default:
+      inner = nil
+    }
+
+    guard let inner, let base = left.slots else {
+      return try gated(filter, .product(optimise(left, catalog, bindings),
+                                        optimise(right, catalog, bindings)))
     }
 
     let conjuncts = filter.conjuncts
@@ -541,16 +577,53 @@ public enum Engine {
 
       var residual = conjuncts
       residual.remove(at: index)
-      let join = try Plan.join(optimise(left, catalog, bindings), name: name,
-                               ordinals: ordinals, base: base,
-                               column: ordinals[rightKey - base],
-                               keys: (left: leftKey, right: rightKey))
+      // The pushed inner filter stays in the inner's 0-based standalone slot
+      // space and rides on the `Join` node, applied while the executor
+      // materialises the inner (before bucketing / as part of the inner scan) —
+      // NOT lifted into the residual to run after the join. It is always safe and
+      // the pushdown barrier kept it ahead of any unsafe conjunct, so applying it
+      // during materialisation still gates a later unsafe residual (a pair forms
+      // only when the filter holds), without letting that conjunct throw first
+      // (`Parent.Name = 'nope' AND (1 / Child.x) = 0`, the false name excluding
+      // the row before the division runs).
+      let join = try Plan.join(optimise(left, catalog, bindings),
+                               name: inner.name, ordinals: inner.ordinals,
+                               base: base,
+                               column: inner.ordinals[rightKey - base],
+                               keys: (left: leftKey, right: rightKey),
+                               filter: inner.filter)
       guard let predicate = residual.conjunction else { return join }
       return .select(predicate, join)
     }
 
-    return try .select(filter, .product(optimise(left, catalog, bindings),
-                                        optimise(right, catalog, bindings)))
+    return try gated(filter, .product(optimise(left, catalog, bindings),
+                                      optimise(right, catalog, bindings)))
+  }
+
+  /// A `product` under `filter` for a join `nest` cannot fold into a `Join`,
+  /// keeping the ON `match` conjuncts as a SEPARATE inner gate below the rest —
+  /// `Select(rest, Select(match, product))`. Because `evaluate(.and)` does not
+  /// short-circuit, folding the match into one `AND` with the WHERE would, for a
+  /// pair whose NULL join key makes the match UNKNOWN, still evaluate a throwing
+  /// WHERE (`(1 / A.x) = 0`) — a pair the join forms no row for. Gating on the
+  /// match first drops that pair before the WHERE runs, as the `Select(match,
+  /// product)` did before `distribute` folded the match into the conjuncts for
+  /// `nest` to find. When there is no match, `rest` is the whole filter and this
+  /// is the plain `Select(filter, product)`.
+  private static func gated(_ filter: Filter, _ product: Plan) -> Plan {
+    var matches = Array<Filter>()
+    var rest = Array<Filter>()
+    for conjunct in filter.conjuncts {
+      if case .match = conjunct {
+        matches.append(conjunct)
+      } else {
+        rest.append(conjunct)
+      }
+    }
+    var plan = product
+    if let gate = matches.conjunction { plan = .select(gate, plan) }
+    if let predicate = rest.conjunction { plan = .select(predicate, plan) }
+    return plan
   }
 
   /// The `(outerKey, innerKey)` an equality between slots `lhs` and `rhs`
@@ -568,4 +641,263 @@ public enum Engine {
     }
   }
 
+}
+
+// MARK: - Selection pushdown
+
+extension Plan {
+  /// Pushes each `WHERE` conjunct that references a single relation's slots down
+  /// to just above that relation's leaf, before the join/product chain folds it
+  /// in — so a relation is filtered as it is read rather than after the whole
+  /// product is formed.
+  ///
+  /// `compile` leaves the `WHERE` as one `select` atop the left-deep chain, so a
+  /// join runs on unfiltered inputs. This pass descends the chain: a conjunct
+  /// whose slots all fall in one relation's contiguous slot run rides down to
+  /// that relation's leaf as a `select` over its `scan`/`derived`, where the
+  /// seek and nest rewrites can then act on it; a conjunct spanning two
+  /// relations (a residual, an `OR` across sides) stays at the level whose two
+  /// children it straddles. A conjunct over a `derived` view's output columns is
+  /// pushed INTO the view's sub-plan — its outer slot mapped back through the
+  /// view's projection to the sub-plan slot the column reads — recursing below
+  /// the view's own joins. A `union` pushes into every arm. The pass is a pure
+  /// logical rewrite; `optimise` runs after it and still sees the `select`s the
+  /// seek and nest rewrites match.
+  internal func pushdown() throws(SQLError) -> Plan {
+    switch self {
+    case .single, .scan, .join:
+      self
+    case let .derived(name, sub, ordinals, seek):
+      try .derived(name: name, plan: sub.pushdown(), ordinals: ordinals,
+                   seek: seek)
+    case let .select(filter, source):
+      try source.pushdown().distribute(filter.conjuncts)
+    case let .project(terms, source):
+      try .project(terms, source.pushdown())
+    case let .sort(slot, ascending, source):
+      try .sort(slot: slot, ascending: ascending, source.pushdown())
+    case let .product(left, right):
+      try .product(left.pushdown(), right.pushdown())
+    case let .union(left, right, all):
+      try .union(left.pushdown(), right.pushdown(), all: all)
+    }
+  }
+
+  /// Places each of `conjuncts` as deep in the already-pushed `self` as the
+  /// slots it reads allow, wrapping the level whose children a conjunct straddles
+  /// in a residual `select`.
+  ///
+  /// At a `product`, `left.slots` is the boundary: a conjunct entirely below it
+  /// belongs to the left child and rides down; one entirely at or above it
+  /// belongs to the right child, rebased into that child's own slot space; one
+  /// straddling the boundary — or reading no slots, or able to throw when
+  /// evaluated (a division or scalar call) — stays here. A
+  /// `select` (a join's `ON` match, whose
+  /// two sides straddle every boundary) is transparent — the conjuncts descend
+  /// through it into the product beneath. At a `derived` leaf the conjuncts push
+  /// into the view; at a base `scan` they land directly above it. Any conjunct
+  /// that cannot descend is re-conjoined as a `select` at this level.
+  private func distribute(_ conjuncts: Array<Filter>)
+      throws(SQLError) -> Plan {
+    switch self {
+    case let .product(left, right):
+      guard let base = left.slots else {
+        return residual(conjuncts)
+      }
+      var here = Array<Filter>()
+      var down = Array<Filter>()
+      var over = Array<Filter>()
+      var barrier = false
+      for (index, conjunct) in conjuncts.enumerated() {
+        let slots = conjunct.slots
+        // A conjunct stays here — at the product level, run per pair, in the
+        // order the `AND` chain wrote — when a preceding conjunct was unsafe
+        // (`barrier`), when it reads no slots (e.g. `(1 / 0) = 0`, where
+        // `allSatisfy` is vacuously true), when evaluating it can throw (a
+        // division or scalar call, e.g. `(1 / A.x) = 0`), or when it is nullable
+        // (reads a slot, so a NULL there makes it UNKNOWN) and a LATER conjunct
+        // is unsafe. Riding a throwing conjunct down would raise while scanning a
+        // child even when the join's other side is empty; riding a safe conjunct
+        // PAST an earlier unsafe one would filter its rows before the unsafe one
+        // runs, suppressing a throw the left-to-right `AND` owes (`(1 / A.x) = 0
+        // AND A.x <> 0`, `A.x = 0`, on a matching pair). Because the evaluator's
+        // `AND` does not short-circuit, riding a nullable conjunct BELOW a later
+        // unsafe one likewise suppresses a throw: the un-pushed `AND` runs the
+        // later conjunct even for the UNKNOWN row, but the pushed conjunct drops
+        // that row first (`A.x = 1 AND (1 / B.y) = 0`, `A.x` NULL and `B.y = 0`).
+        // Only a safe single-relation conjunct with no unsafe predecessor — and,
+        // if nullable, no unsafe successor — rides down.
+        let hazard =
+            conjunct.nullable && conjuncts[(index + 1)...].contains { !$0.safe }
+        if barrier || slots.isEmpty || !conjunct.safe || hazard {
+          here.append(conjunct)
+        } else if slots.allSatisfy({ $0 < base }) {
+          down.append(conjunct)
+        } else if slots.allSatisfy({ $0 >= base }) {
+          over.append(conjunct)
+        } else {
+          here.append(conjunct)
+        }
+        // An unsafe conjunct bars every later conjunct from riding past it.
+        if !conjunct.safe { barrier = true }
+      }
+      let product =
+          Plan.product(try left.distribute(down),
+                       try right.distribute(over.map { $0.shifted(by: base) }))
+      return product.residual(here)
+    case let .select(match, source):
+      // A join's `ON` match straddles both sides, so it never captures a
+      // single-relation conjunct. Fold it in with the descending conjuncts so
+      // the product carries one `Select([match, spanning…], Product)`: `nest`
+      // finds the match to form the `Join` and keeps any spanning residual above
+      // it. Wrapping it outside instead — `Select(match, source.distribute(…))`
+      // — would leave `Select(match, Select(spanning, Product))`, whose match is
+      // no longer adjacent to the product, so `nest` could not fold it.
+      return try source.distribute(match.conjuncts + conjuncts)
+    case .derived:
+      return try into(conjuncts)
+    default:
+      return residual(conjuncts)
+    }
+  }
+
+  /// Pushes `conjuncts` INTO this `derived` view's sub-plan, below its own
+  /// projection and joins, mapping each conjunct's outer slot (a slot into the
+  /// leaf's `ordinals`, i.e. a view output column) back to the sub-plan slot the
+  /// column reads.
+  ///
+  /// A view's sub-plan is `Project(terms, body)` (or a `union` of such), so an
+  /// output column `ordinals[slot]` is `terms[ordinals[slot]]`. A conjunct
+  /// pushes in only when every slot it reads maps to a bare `.slot` term — a
+  /// plain column of the body; a conjunct over a computed column (a call or
+  /// arithmetic) cannot rebase and stays as a `select` on the derived leaf. A
+  /// `union` sub-plan admits a conjunct only when every arm's projection admits
+  /// it — the arms are combined, so a conjunct that cannot push into one arm
+  /// must stay outside them all. The admitted conjuncts, still in the view's
+  /// OUTPUT slot space, push in through `inject`, which rebases each against the
+  /// projection it lands under — PER ARM for a union, since the arms map the
+  /// same output column to DIFFERENT body slots; the rest wrap the leaf.
+  ///
+  /// The partition carries the SAME ordering barrier `distribute`'s product loop
+  /// has: a conjunct stays `outer` — on the derived leaf, run in the `AND`
+  /// chain's order — when a preceding conjunct was unsafe (`barrier`), when it is
+  /// itself unsafe (a division or scalar call), when it is nullable and a LATER
+  /// conjunct is unsafe, or when the view's projection cannot admit it; only a
+  /// safe conjunct with no unsafe predecessor — and, if nullable, no unsafe
+  /// successor — pushes in. An unsafe conjunct bars every later one from riding
+  /// into the view: pushing a later conjunct past it would let the view seek and
+  /// drop the row before the unsafe outer conjunct runs, suppressing a throw the
+  /// left-to-right `AND` owes (`(1 / x) = 0 AND x = 1` over a view whose `x` is
+  /// sorted, the `x = 1` seek dropping the `x = 0` row before the outer division
+  /// raises). Symmetrically a nullable conjunct pushed BELOW a later unsafe one
+  /// suppresses a throw: the non-short-circuiting `AND` runs the later conjunct
+  /// even for the UNKNOWN row, but the injected conjunct drops that row first
+  /// (`x = 1 AND (1 / y) = 0`, `x` NULL and `y = 0`).
+  private func into(_ conjuncts: Array<Filter>) throws(SQLError) -> Plan {
+    guard case let .derived(name, plan, ordinals, seek) = self else {
+      return residual(conjuncts)
+    }
+    var inner = Array<Filter>()
+    var outer = Array<Filter>()
+    var barrier = false
+    for (index, conjunct) in conjuncts.enumerated() {
+      // A nullable conjunct (reads a slot, so a NULL there makes it UNKNOWN) must
+      // also stay outer when a LATER conjunct is unsafe: the evaluator's `AND`
+      // does not short-circuit, so the un-pushed query runs the later conjunct
+      // even for the UNKNOWN row, but injecting this one into the view would seek
+      // or filter that row away first — suppressing a throw the left-to-right
+      // `AND` owes (`x = 1 AND (1 / y) = 0` over a view exposing `x`/`y`, `x`
+      // NULL and `y = 0`).
+      let hazard =
+          conjunct.nullable && conjuncts[(index + 1)...].contains { !$0.safe }
+      if barrier || !conjunct.safe || hazard
+          || !plan.pushable(conjunct, ordinals) {
+        outer.append(conjunct)
+      } else {
+        inner.append(conjunct)
+      }
+      // An unsafe conjunct bars every later conjunct from riding past it.
+      if !conjunct.safe { barrier = true }
+    }
+    let sub = inner.isEmpty ? plan : try plan.inject(inner, ordinals)
+    let leaf = Plan.derived(name: name, plan: sub, ordinals: ordinals,
+                            seek: seek)
+    return leaf.residual(outer)
+  }
+
+  /// Whether `conjunct` (in this view's OUTPUT slot space, its slots indices
+  /// into `ordinals`) can push below this sub-plan's projection.
+  ///
+  /// A `project` admits it when every slot it reads maps to a bare `.slot` term
+  /// of the body — the `rebase` helper produces a mapping; a computed column
+  /// (call or arithmetic) has none. A `union` admits it only when EVERY arm
+  /// does — the arms are combined, so a conjunct pushable into one but not
+  /// another cannot descend into any and must stay outside. Anything else does
+  /// not admit it.
+  private func pushable(_ conjunct: Filter, _ ordinals: Array<Int>) -> Bool {
+    switch self {
+    case let .project(terms, _):
+      // A conjunct pushes below the projection only when every projected term is
+      // safe: pushing it filters rows before the projection runs, so a throwing
+      // term — a division or scalar call, even one the conjunct does not read —
+      // would be skipped for the filtered rows, suppressing a raise `derive`
+      // owes by evaluating every column of every view row.
+      terms.allSatisfy(\.safe) && rebase(conjunct, ordinals) != nil
+    case let .union(left, right, _):
+      left.pushable(conjunct, ordinals) && right.pushable(conjunct, ordinals)
+    default:
+      false
+    }
+  }
+
+  /// This view sub-plan with `conjuncts` (in the view's OUTPUT slot space)
+  /// pushed below its projection, each rebased into the body slots the
+  /// projection it lands under reads.
+  ///
+  /// For a `union` each arm rebases the conjuncts against ITS OWN projection —
+  /// the same output column sits at different body slots across arms, so a
+  /// single pre-rebased filter cannot serve them all; the rebase must happen per
+  /// arm. `pushable` has already vetted every conjunct against every arm, so the
+  /// per-arm `rebase` is guaranteed non-nil.
+  private func inject(_ conjuncts: Array<Filter>, _ ordinals: Array<Int>)
+      throws(SQLError) -> Plan {
+    switch self {
+    case let .project(terms, body):
+      try .project(terms,
+                   body.distribute(conjuncts.map { rebase($0, ordinals)! }))
+    case let .union(left, right, all):
+      try .union(left.inject(conjuncts, ordinals),
+                 right.inject(conjuncts, ordinals), all: all)
+    default:
+      // A view sub-plan is always a `project` (or a `union` of them); anything
+      // else keeps the conjuncts as an outer `select` rather than dropping them.
+      residual(conjuncts)
+    }
+  }
+
+  /// `conjunct` rebased from a `derived` leaf's OUTPUT slot space into this
+  /// projection sub-plan's body slot space, or `nil` if any slot it reads is a
+  /// computed view column (not a bare `.slot` projection term) and so cannot be
+  /// pushed in.
+  ///
+  /// Slot `s` of the leaf reads view column `ordinals[s]`, whose value is the
+  /// projection term `terms[ordinals[s]]`; the conjunct pushes in only when that
+  /// term is a bare `.slot(body)`, in which case `s` maps to `body`. Shared by
+  /// `pushable` (the non-nil check) and `inject` (the rebased value).
+  private func rebase(_ conjunct: Filter, _ ordinals: Array<Int>) -> Filter? {
+    guard case let .project(terms, _) = self else { return nil }
+    var map = Dictionary<Int, Int>(minimumCapacity: conjunct.slots.count)
+    for slot in conjunct.slots {
+      guard case let .slot(body) = terms[ordinals[slot]] else { return nil }
+      map[slot] = body
+    }
+    return conjunct.remapped(through: map)
+  }
+
+  /// This plan wrapped in a `select` of `conjuncts`, or unchanged for an empty
+  /// list — the residual placement of conjuncts that descend no further.
+  private func residual(_ conjuncts: Array<Filter>) -> Plan {
+    guard let filter = conjuncts.conjunction else { return self }
+    return .select(filter, self)
+  }
 }

--- a/Sources/SQL/Filter.swift
+++ b/Sources/SQL/Filter.swift
@@ -99,6 +99,17 @@ extension Term {
       .binary(op, lhs.remapped(through: slot), rhs.remapped(through: slot))
     }
   }
+
+  /// Whether evaluating this term cannot throw — it is a bare slot read or a
+  /// constant. A `binary` arithmetic (`/` raises on a zero divisor) or an
+  /// `apply` (a scalar function may raise) is NOT known safe, whatever its
+  /// operands.
+  internal var safe: Bool {
+    switch self {
+    case .slot, .constant: true
+    case .apply, .binary: false
+    }
+  }
 }
 
 extension Filter {
@@ -129,13 +140,87 @@ extension Filter {
     guard case let .and(lhs, rhs) = self else { return [self] }
     return lhs.conjuncts + rhs.conjuncts
   }
+
+  /// The set of slots this filter addresses — the slot form of
+  /// `references(into:)`, used by selection pushdown to decide which relation a
+  /// conjunct belongs to.
+  internal var slots: Set<Int> {
+    var slots = Set<Int>()
+    references(into: &slots)
+    return slots
+  }
+
+  /// This filter with each slot `s` shifted to `s - offset` — the remap that
+  /// rebases a conjunct from combined slot space into a right-hand child's own
+  /// slot space (whose first slot is `offset`).
+  internal func shifted(by offset: Int) -> Filter {
+    var map = Dictionary<Int, Int>(minimumCapacity: slots.count)
+    for slot in slots { map[slot] = slot - offset }
+    return remapped(through: map)
+  }
+
+  /// Whether evaluating this filter cannot throw — every term it reads is a bare
+  /// slot or a constant. Selection pushdown keeps a filter that is NOT safe at
+  /// the product level (evaluated per pair), so a division or scalar-call
+  /// predicate raises only when a pair exists — never on an empty product it
+  /// would have skipped had it stayed above the join.
+  internal var safe: Bool {
+    switch self {
+    case let .compare(lhs, _, rhs): lhs.safe && rhs.safe
+    case let .bound(term, _, _): term.safe
+    case .match: true
+    case let .null(term, _): term.safe
+    case let .and(lhs, rhs): lhs.safe && rhs.safe
+    case let .or(lhs, rhs): lhs.safe && rhs.safe
+    case let .not(operand): operand.safe
+    }
+  }
+
+  /// Whether evaluating this filter can be UNKNOWN — it reads at least one slot
+  /// (a NULL cell there makes a comparison against it UNKNOWN) or compares against
+  /// a run-time `:parameter` (which may be unbound or bound to NULL, likewise
+  /// UNKNOWN). Only a filter over constants alone is definite. Selection pushdown
+  /// must not ride a nullable conjunct below a join or into a view when a LATER
+  /// conjunct is unsafe: the evaluator's `AND` does not short-circuit, so the
+  /// un-pushed query evaluates the later conjunct even when this one is UNKNOWN —
+  /// pushing this one down would drop the UNKNOWN row before the later conjunct
+  /// runs, suppressing a throw the left-to-right `AND` owes (`A.x = 1 AND (1 /
+  /// B.y) = 0`, `A.x` NULL and `B.y = 0` on a matching pair; or `1 = :missing AND
+  /// (1 / y) = 0` over a view, `:missing` unbound — slotless yet UNKNOWN).
+  internal var nullable: Bool {
+    !slots.isEmpty || parameterised
+  }
+
+  /// Whether this filter compares against a run-time `:parameter` — a `.bound`
+  /// anywhere in it. Such a predicate reads no slot yet can be UNKNOWN, because
+  /// the parameter may be unbound (or bound to NULL), so `nullable` counts it
+  /// even when `slots` is empty.
+  private var parameterised: Bool {
+    switch self {
+    case .bound: true
+    case .compare, .match, .null: false
+    case let .and(lhs, rhs): lhs.parameterised || rhs.parameterised
+    case let .or(lhs, rhs): lhs.parameterised || rhs.parameterised
+    case let .not(operand): operand.parameterised
+    }
+  }
 }
 
 extension Array where Element == Filter {
-  /// The right-leaning `AND` of these conjuncts, or `nil` for an empty list.
+  /// The left-leaning `AND` of these conjuncts, or `nil` for an empty list —
+  /// `[a, b, c]` folds to `(a AND b) AND c`, matching the parser's own
+  /// association.
+  ///
+  /// The left fold is deliberate: `seek` only inspects a top-level `AND`'s two
+  /// immediate children, so a trailing sort-key comparison must remain the
+  /// immediate right operand to be seekable. A right-leaning rebuild (`a AND (b
+  /// AND c)`) would bury it under a nested `AND` and defeat the seek — so when
+  /// pushdown flattens a filter through `conjuncts` and rebuilds it here, the
+  /// association it restores is the parser's, keeping a seekable conjunct
+  /// visible.
   internal var conjunction: Filter? {
-    guard let last else { return nil }
-    return dropLast().reversed().reduce(last) { .and($1, $0) }
+    guard let first else { return nil }
+    return dropFirst().reduce(first) { .and($0, $1) }
   }
 }
 

--- a/Sources/SQL/Operator.swift
+++ b/Sources/SQL/Operator.swift
@@ -371,20 +371,25 @@ private func product(_ outer: Array<Record>, _ inner: Array<Record>)
   return records
 }
 
-/// The index-nested-loop equi-join of `outer` against the inner relation `name`.
+/// The equi-join of `outer` against the inner relation `name`, seeking the
+/// inner per outer record when its key `column` is seekable and hashing it once
+/// otherwise.
 ///
-/// The inner relation is re-resolved through `catalog`. For each outer record,
-/// the value at slot `keys.left` is the probe. When that value is an integer
-/// and the inner reports `column` (the inner ordinal `keys.right` reads)
-/// seekable, the inner is seeked to its `[lower, upper)` run; otherwise the
-/// whole inner is scanned. Each candidate is materialised over the referenced
-/// `ordinals` into inner slots `0 ..< ordinals.count`; a candidate is admitted
-/// only when the pushed inner `filter` (in the inner's standalone slot space)
-/// also holds — applied WHILE the inner row is materialised, so a filtered inner
-/// row is never paired — then re-tested for the inner's `keys.right` slot —
-/// `keys.right - base` in the standalone inner record — equal to `value`, the
-/// seek narrowing the scan but the equality being the join's truth, and a match
-/// is concatenated (the inner's slots landing at `base` in the combined space).
+/// The inner relation is re-resolved through `catalog`. When the inner reports
+/// `column` (the inner ordinal `keys.right` reads) seekable, each outer record's
+/// key seeks the inner's `[lower, upper)` run — an index-nested loop, cheap
+/// because the seek narrows the scan. When it is NOT seekable, a per-outer scan
+/// would read the whole inner once per outer record (O(n·m)); instead the inner
+/// is scanned ONCE into a hash map keyed by its join value, and each outer
+/// record probes it in O(1). Both strategies materialise a candidate over the
+/// referenced `ordinals` into inner slots `0 ..< ordinals.count`, admit it only
+/// when the pushed inner `filter` (in the inner's standalone slot space) also
+/// holds — applied WHILE the inner row is materialised, so a filtered inner row
+/// is never paired or bucketed — key on the inner's `keys.right` slot —
+/// `keys.right - base` in the standalone inner record — and concatenate a match
+/// (the inner's slots landing at `base` in the combined space). A NULL key joins
+/// to nothing under both, and both preserve outer-major order, the inner matches
+/// in cursor order within each outer.
 ///
 /// - Throws: `SQLError.relation` if the inner name no longer resolves.
 private func join<C: Catalog & ~Escapable>(_ outer: Array<Record>,
@@ -398,6 +403,11 @@ private func join<C: Catalog & ~Escapable>(_ outer: Array<Record>,
                                            _ bindings: Bindings)
     throws(SQLError) -> Array<Record> {
   guard let inner = catalog.table(named: name) else { throw .relation(name) }
+  guard seekable(inner, column) else {
+    return try hashed(outer, inner, ordinals, base, keys, filter, routines,
+                      bindings)
+  }
+
   let cursor = inner.cursor()
   let slot = keys.right - base
   var records = Array<Record>()
@@ -420,6 +430,108 @@ private func join<C: Catalog & ~Escapable>(_ outer: Array<Record>,
     }
   }
   return records
+}
+
+/// The hash equi-join of `outer` against `inner`: the inner scanned once into a
+/// value → records map keyed on its join column, then each outer record probed
+/// in O(1).
+///
+/// The inner is materialised over `ordinals` into standalone slots, its key the
+/// slot `keys.right - base`; a NULL-keyed inner record joins to nothing and is
+/// never bucketed. Each bucket keeps its rows in cursor order, so probing an
+/// outer record in outer order yields the same outer-major, inner-cursor-order
+/// result the seek path does. An outer NULL key probes nothing.
+///
+/// A pushed inner `filter` (in the inner's standalone slot space) is applied
+/// DURING this scan, before a row is bucketed: the inner is SEEKED by the
+/// filter's seekable conjunct — `Engine.boundaries` over each conjunct, the same
+/// boundary logic the scan seek uses, mapping a slot back to its table column
+/// through `ordinals` — so a seekable/contradictory inner filter reads few or no
+/// inner rows rather than scanning the whole table; when no conjunct is seekable
+/// the whole inner scans. Each read row is then admitted only when the whole
+/// `filter` holds, so a filtered inner row is never bucketed or paired.
+///
+/// An outer with no non-null key has no probe that can match — an empty outer
+/// has no probes at all, and a NULL key joins to nothing — so no match can
+/// result; return before scanning and bucketing the inner rather than reading
+/// every inner row to answer nothing. The nested-loop path this replaces read
+/// zero inner rows for such an outer, and a selective or contradictory outer
+/// WHERE (`… WHERE key IS NULL`, or one pruning every row) must not force a full
+/// scan of a large unseekable inner.
+private func hashed<T: Table & ~Escapable>(_ outer: Array<Record>,
+                                           _ inner: borrowing T,
+                                           _ ordinals: Array<Int>, _ base: Int,
+                                           _ keys: (left: Int, right: Int),
+                                           _ filter: Filter?,
+                                           _ routines: Routines,
+                                           _ bindings: Bindings)
+    throws(SQLError) -> Array<Record> {
+  guard outer.contains(where: {
+    if case .null = $0[keys.left] { false } else { true }
+  }) else { return [] }
+
+  let cursor = inner.cursor()
+  let slot = keys.right - base
+  // Seek the inner by the pushed filter's seekable conjunct, so a
+  // seekable/contradictory inner filter reads few or no rows; scan the whole
+  // inner when the filter has none (or when there is no filter).
+  let range = seek(filter, ordinals, inner, cursor.count, bindings)
+  var buckets = Dictionary<Value, Array<Record>>()
+  for index in range {
+    guard let row = cursor.row(index) else { continue }
+    let right = Record(row, ordinals)
+    // Apply the whole pushed filter before bucketing — a filtered inner row is
+    // never a join candidate.
+    if let filter,
+        try evaluate(filter, right, routines, bindings) != true { continue }
+    let key = right[slot]
+    if case .null = key { continue }
+    buckets[key, default: Array<Record>()].append(right)
+  }
+
+  var records = Array<Record>()
+  for left in outer {
+    let value = left[keys.left]
+    if case .null = value { continue }
+    for right in buckets[value] ?? [] {
+      records.append(left.merged(with: right))
+    }
+  }
+  return records
+}
+
+/// The inner row range the hash join scans and buckets: the `[lower, upper)`
+/// seeked by `filter`'s first seekable conjunct — `Engine.boundaries` over each,
+/// mapping a slot to its table column through `ordinals` — else the whole
+/// `0 ..< count` when no conjunct qualifies (or there is no filter).
+private func seek<T: Table & ~Escapable>(_ filter: Filter?,
+                                         _ ordinals: Array<Int>,
+                                         _ inner: borrowing T, _ count: Int,
+                                         _ bindings: Bindings) -> Range<Int> {
+  guard let filter else { return 0 ..< count }
+  for conjunct in filter.conjuncts {
+    if let range =
+        Engine.boundaries(conjunct, ordinals, inner, count, bindings) {
+      return range
+    }
+  }
+  return 0 ..< count
+}
+
+/// Whether the inner `column` of `table` can be seeked — the executor probes it
+/// per outer record — as opposed to needing a hash build.
+///
+/// A seekable column reports a boundary for a valid key; an unseekable one
+/// reports `nil`. The probe key must be a VALID one: a decoded coded-index join
+/// key is 1-based and reports `nil` for the null reference `0`, so probing with
+/// `0` would misclassify a seekable coded-index column as unseekable and force a
+/// hash build even for a selective join. `1` — the least valid key — answers for
+/// every seekable column (`rowid`, list `parent`, a sorted key, a coded-index
+/// key); its value is otherwise irrelevant, since this is only a capability
+/// check (the join loop seeks with the real outer key).
+private func seekable<T: Table & ~Escapable>(_ table: borrowing T,
+                                             _ column: Int) -> Bool {
+  table.bound(column, 1, strict: false) != nil
 }
 
 /// The inner range to probe for `value` on `column` of `table` of `count` rows:

--- a/Sources/SQL/Operator.swift
+++ b/Sources/SQL/Operator.swift
@@ -235,6 +235,12 @@ internal func execute<C: Catalog & ~Escapable>(_ plan: Plan,
     try materialise(name, ordinals, seek, catalog)
   case let .derived(_, source, ordinals, seek):
     try derive(source, ordinals, seek, catalog, routines, bindings)
+  case let .select(filter, .product(outer, inner)):
+    // Fuse a residual product with its filter: stream each pair through the
+    // predicate rather than materialising the whole cross product first.
+    try sift(execute(outer, catalog, routines, bindings),
+             execute(inner, catalog, routines, bindings), filter, routines,
+             bindings)
   case let .select(filter, source):
     try admitted(execute(source, catalog, routines, bindings), filter,
                  routines, bindings)
@@ -366,6 +372,32 @@ private func product(_ outer: Array<Record>, _ inner: Array<Record>)
   for left in outer {
     for right in inner {
       records.append(left.merged(with: right))
+    }
+  }
+  return records
+}
+
+/// The Cartesian product of `outer` and `inner` filtered row by row by
+/// `filter` — the fused product-under-select, streamed.
+///
+/// A residual (non-equi) `product` under a `select` would otherwise materialise
+/// the whole `outer.count * inner.count` cross product and only then filter it,
+/// a memory blowup quadratic in the inputs. Here each pair is merged, tested,
+/// and kept or dropped in turn, so only the surviving rows — not the full
+/// product — are ever held. The order is identical to filtering the eager
+/// product: outer-major, each admitted inner in its own order. A pair the
+/// `filter` evaluates to `true` under three-valued logic is kept; UNKNOWN and
+/// `false` both drop, exactly as `admitted`.
+private func sift(_ outer: Array<Record>, _ inner: Array<Record>,
+                  _ filter: Filter, _ routines: Routines, _ bindings: Bindings)
+    throws(SQLError) -> Array<Record> {
+  var records = Array<Record>()
+  for left in outer {
+    for right in inner {
+      let record = left.merged(with: right)
+      if try evaluate(filter, record, routines, bindings) == true {
+        records.append(record)
+      }
     }
   }
   return records

--- a/Sources/SQL/Operator.swift
+++ b/Sources/SQL/Operator.swift
@@ -129,9 +129,12 @@ internal indirect enum Plan {
   /// `keys.right == outer[keys.left]` and concatenates each match. `keys.left`
   /// and `keys.right` are combined-space slots, `base` the inner's first slot
   /// in that combined space, and `column` the inner ordinal `keys.right` reads
-  /// (for the seek `bound`).
+  /// (for the seek `bound`). `filter` is a single-relation predicate pushed onto
+  /// the inner — in the inner's OWN 0-based standalone slot space — applied WHILE
+  /// each inner row is materialised, so an inner row that fails it is never
+  /// paired.
   case join(Plan, name: String, ordinals: Array<Int>, base: Int,
-            column: Int, keys: (left: Int, right: Int))
+            column: Int, keys: (left: Int, right: Int), filter: Filter?)
   /// ∪ — the rows of the `left` sub-plan followed by the `right`'s, in source
   /// order. With `all` the duplicates are kept (`UNION ALL`); without it the
   /// whole-row duplicates of the combined rows are removed, the first occurrence
@@ -191,7 +194,7 @@ extension Plan {
       } else {
         nil
       }
-    case let .join(outer, _, ordinals, _, _, _):
+    case let .join(outer, _, ordinals, _, _, _, _):
       outer.slots.map { $0 + ordinals.count }
     case let .union(left, _, _):
       // Both sides yield rows of the same width — the result columns — so the
@@ -253,9 +256,9 @@ internal func execute<C: Catalog & ~Escapable>(_ plan: Plan,
   case let .product(outer, inner):
     try product(execute(outer, catalog, routines, bindings),
                 execute(inner, catalog, routines, bindings))
-  case let .join(outer, name, ordinals, base, column, keys):
+  case let .join(outer, name, ordinals, base, column, keys, filter):
     try join(execute(outer, catalog, routines, bindings), name, ordinals,
-             base, column, keys, catalog)
+             base, column, keys, filter, catalog, routines, bindings)
   case let .union(left, right, all):
     try union(left, right, all, catalog, routines, bindings)
   }
@@ -375,11 +378,13 @@ private func product(_ outer: Array<Record>, _ inner: Array<Record>)
 /// and the inner reports `column` (the inner ordinal `keys.right` reads)
 /// seekable, the inner is seeked to its `[lower, upper)` run; otherwise the
 /// whole inner is scanned. Each candidate is materialised over the referenced
-/// `ordinals` into inner slots `0 ..< ordinals.count`, then re-tested for the
-/// inner's `keys.right` slot — `keys.right - base` in the standalone inner
-/// record — equal to `value`, the seek narrowing the scan but the equality
-/// being the join's truth, and a match is concatenated (the inner's slots
-/// landing at `base` in the combined space).
+/// `ordinals` into inner slots `0 ..< ordinals.count`; a candidate is admitted
+/// only when the pushed inner `filter` (in the inner's standalone slot space)
+/// also holds — applied WHILE the inner row is materialised, so a filtered inner
+/// row is never paired — then re-tested for the inner's `keys.right` slot —
+/// `keys.right - base` in the standalone inner record — equal to `value`, the
+/// seek narrowing the scan but the equality being the join's truth, and a match
+/// is concatenated (the inner's slots landing at `base` in the combined space).
 ///
 /// - Throws: `SQLError.relation` if the inner name no longer resolves.
 private func join<C: Catalog & ~Escapable>(_ outer: Array<Record>,
@@ -387,7 +392,10 @@ private func join<C: Catalog & ~Escapable>(_ outer: Array<Record>,
                                            _ ordinals: Array<Int>, _ base: Int,
                                            _ column: Int,
                                            _ keys: (left: Int, right: Int),
-                                           _ catalog: borrowing C)
+                                           _ filter: Filter?,
+                                           _ catalog: borrowing C,
+                                           _ routines: Routines,
+                                           _ bindings: Bindings)
     throws(SQLError) -> Array<Record> {
   guard let inner = catalog.table(named: name) else { throw .relation(name) }
   let cursor = inner.cursor()
@@ -402,6 +410,10 @@ private func join<C: Catalog & ~Escapable>(_ outer: Array<Record>,
     for index in range {
       guard let row = cursor.row(index) else { continue }
       let right = Record(row, ordinals)
+      // A pushed inner filter is applied as each candidate materialises, before
+      // it can pair — an inner row it rejects joins to nothing.
+      if let filter,
+          try evaluate(filter, right, routines, bindings) != true { continue }
       if right[slot] == value {
         records.append(left.merged(with: right))
       }

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -1298,6 +1298,32 @@ private func joins(_ plan: Plan) -> Bool {
   }
 }
 
+/// Whether `plan` reaches a `.select` standing directly over a `.product` — the
+/// residual product-under-select the streaming path fuses and filters row by
+/// row rather than materialising whole.
+private func residual(_ plan: Plan) -> Bool {
+  switch plan {
+  case .select(_, .product):
+    true
+  case let .select(_, source):
+    residual(source)
+  case let .project(_, source):
+    residual(source)
+  case let .sort(_, _, source):
+    residual(source)
+  case let .derived(_, sub, _, _):
+    residual(sub)
+  case let .product(left, right):
+    residual(left) || residual(right)
+  case let .join(outer, _, _, _, _, _, _):
+    residual(outer)
+  case let .union(left, right, _):
+    residual(left) || residual(right)
+  case .single, .scan:
+    false
+  }
+}
+
 // MARK: - Selection-pushdown tests
 
 /// A join catalog whose inner `Child` relation tallies its row reads, plus a
@@ -2132,6 +2158,96 @@ struct EngineHashJoinTests {
   }
 }
 
+// MARK: - Streaming-product tests
+
+struct EngineStreamingProductTests {
+  @Test("a join whose inner is a view leaves a residual product-under-select")
+  func shape() throws {
+    // The nest rewrite folds a bare scan into an index-nested join, but the
+    // inner here is the `Adults` VIEW (a `derived` leaf), so nest cannot fire
+    // and the level stays a `select` over a `product` — the shape the streaming
+    // executor fuses.
+    let catalog = try views()
+    let select = try parse("""
+        SELECT Child.Name, Adults.Label FROM Child
+          JOIN Adults ON Adults.Key = Child.Pid
+        """)
+    let plan =
+        try Engine.optimise(Engine.compile(select, catalog).pushdown(),
+                            catalog, [:])
+    #expect(residual(plan))
+  }
+
+  @Test("the streamed product filters row by row to the right rows")
+  func correctness() throws {
+    // `Adults` is Parent rows with Id >= 2 (Key 2 → Bee, 3 → Cid); only the
+    // child whose Pid equals a Key survives — Bob (Pid 2) against Bee.
+    let catalog = try views()
+    let rows = try Engine.run(parse("""
+        SELECT Child.Name, Adults.Label FROM Child
+          JOIN Adults ON Adults.Key = Child.Pid
+        """), catalog)
+    #expect(rows == [[.text("Bob"), .text("Bee")]])
+  }
+
+  @Test("the streamed product equals the eager product filtered")
+  func equivalence() throws {
+    // Cross the two inputs by hand — every child paired with every adult in
+    // outer-major order — and keep the pairs the ON equality admits. The fused
+    // streaming operator must yield exactly this, in this order.
+    let catalog = try views()
+    let children = try Engine.run(parse("SELECT Name, Pid FROM Child"), catalog)
+    let adults = try Engine.run(parse("SELECT Label, Key FROM Adults"), catalog)
+
+    var eager = Array<Array<Value>>()
+    for child in children {
+      for adult in adults where child[1] == adult[1] {
+        eager.append([child[0], adult[0]])
+      }
+    }
+
+    let streamed = try Engine.run(parse("""
+        SELECT Child.Name, Adults.Label FROM Child
+          JOIN Adults ON Adults.Key = Child.Pid
+        """), catalog)
+    #expect(streamed == eager)
+  }
+
+  @Test("a residual product with UNKNOWN pairs drops them")
+  func unknown() throws {
+    // A NULL-keyed pair evaluates the ON equality to UNKNOWN, which the fused
+    // filter drops exactly as `admitted` would — no NULL child reaches a match.
+    let child = [
+      Field(name: "Pid", kind: .integer),
+      Field(name: "Name", kind: .text),
+    ]
+    let children = [
+      [.integer(2), .text("Bob")],
+      [.null, .text("Nobody")],
+    ] as Array<Array<Value>>
+    let adults = try View(query: select("""
+        SELECT Id, Name FROM Base WHERE Id >= 2
+        """), columns: ["Key", "Label"])
+    let base = [
+      Field(name: "Id", kind: .integer),
+      Field(name: "Name", kind: .text),
+    ]
+    let bases = [
+      [.integer(2), .text("Bee")],
+      [.integer(3), .text("Cid")],
+    ] as Array<Array<Value>>
+    let catalog = Memory([
+      "Child": Relation(child, children),
+      "Base": Relation(base, bases, sorted: 0),
+    ], views: ["Adults": adults])
+    let rows = try Engine.run(parse("""
+        SELECT Child.Name, Adults.Label FROM Child
+          JOIN Adults ON Adults.Key = Child.Pid
+        """), catalog)
+    #expect(rows == [[.text("Bob"), .text("Bee")]])
+  }
+}
+
 // MARK: - Scalar-function tests
 
 /// Routines with two demonstration scalar functions: `upper`, which folds a
@@ -2822,4 +2938,5 @@ struct EngineScalarSelectTests {
     #expect(rows == [[.text("Alice")]])
   }
 }
+
 

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -50,13 +50,26 @@ private struct Relation: Sendable {
   /// rejects.
   let coded: Int?
 
+  /// A shared tally the cursor bumps on each row read, or `nil` when a fixture
+  /// does not instrument its reads — the proof selection pushdown and hash join
+  /// materialise fewer rows.
+  let counter: Counter?
+
   init(_ fields: Array<Field>, _ records: Array<Array<Value>>,
-       sorted: Int? = nil, coded: Int? = nil) {
+       sorted: Int? = nil, coded: Int? = nil, counter: Counter? = nil) {
     self.fields = fields
     self.records = records
     self.sorted = sorted
     self.coded = coded
+    self.counter = counter
   }
+}
+
+/// A mutable tally of the rows a cursor reads, shared by reference so a test can
+/// inspect it after a run. Tests run serially, so the unchecked `Sendable` is
+/// sound.
+private final class Counter: @unchecked Sendable {
+  var reads = 0
 }
 
 /// A `Catalog` over a dictionary of named relations.
@@ -180,6 +193,7 @@ private struct MemoryCursor: Cursor {
 
   func row(_ index: Int) -> MemoryRow? {
     guard index < relation.records.count else { return nil }
+    relation.counter?.reads += 1
     return MemoryRow(relation, index)
   }
 }
@@ -1184,9 +1198,13 @@ private func seeks(_ plan: Plan) -> Bool {
     seeks(sub)
   case let .product(left, right):
     seeks(left) || seeks(right)
+  case let .join(outer, _, _, _, _, _, _):
+    // A pushed-down key seeks the join's OUTER leaf, so a seek can live inside
+    // the join rather than only atop a bare scan.
+    seeks(outer)
   case let .union(left, right, _):
     seeks(left) || seeks(right)
-  case .single, .join:
+  case .single:
     false
   }
 }
@@ -1211,6 +1229,641 @@ private func filters(_ plan: Plan) -> Bool {
     filters(left) || filters(right)
   case .single, .scan, .join:
     false
+  }
+}
+
+/// Whether a single-relation filter rides below a `join` or `product` boundary —
+/// the shape selection pushdown produces (a `.select` or a seeked `.scan` inside
+/// a join's outer operand or a product's arm), as opposed to a `WHERE` left
+/// floating atop the whole chain.
+private func pushed(_ plan: Plan) -> Bool {
+  switch plan {
+  case let .join(outer, _, _, _, _, _, _):
+    seeks(outer) || floats(outer) || pushed(outer)
+  case let .product(left, right):
+    seeks(left) || floats(left) || pushed(left) || seeks(right)
+        || floats(right) || pushed(right)
+  case let .select(_, source):
+    pushed(source)
+  case let .project(_, source):
+    pushed(source)
+  case let .sort(_, _, source):
+    pushed(source)
+  case let .derived(_, sub, _, _):
+    pushed(sub)
+  case let .union(left, right, _):
+    pushed(left) || pushed(right)
+  case .single, .scan:
+    false
+  }
+}
+
+/// Whether `plan` is (or reaches through unary operators) a `.select` — a filter
+/// standing over a source.
+private func floats(_ plan: Plan) -> Bool {
+  switch plan {
+  case .select:
+    true
+  case let .project(_, source):
+    floats(source)
+  case let .sort(_, _, source):
+    floats(source)
+  case let .derived(_, sub, _, _):
+    floats(sub)
+  default:
+    false
+  }
+}
+
+/// Whether `plan` reaches a `.join` node — the index-nested-loop/hash join path,
+/// as opposed to a residual `.product` filtered by the ON predicate.
+private func joins(_ plan: Plan) -> Bool {
+  switch plan {
+  case .join:
+    true
+  case let .select(_, source):
+    joins(source)
+  case let .project(_, source):
+    joins(source)
+  case let .sort(_, _, source):
+    joins(source)
+  case let .derived(_, sub, _, _):
+    joins(sub)
+  case let .product(left, right):
+    joins(left) || joins(right)
+  case let .union(left, right, _):
+    joins(left) || joins(right)
+  case .single, .scan:
+    false
+  }
+}
+
+// MARK: - Selection-pushdown tests
+
+/// A join catalog whose inner `Child` relation tallies its row reads, plus a
+/// view `Kin` over the `Parent`/`Child` join — to prove a `WHERE` over the view
+/// prunes the join's inputs BEFORE the join runs rather than after.
+private func counted() throws -> (catalog: Memory, reads: Counter) {
+  let reads = Counter()
+  let parent = [
+    Field(name: "Id", kind: .integer),
+    Field(name: "Name", kind: .text),
+  ]
+  let parents = [
+    [.integer(1), .text("Ada")],
+    [.integer(2), .text("Bee")],
+    [.integer(3), .text("Cid")],
+  ] as Array<Array<Value>>
+
+  let child = [
+    Field(name: "Pid", kind: .integer),
+    Field(name: "Kid", kind: .text),
+  ]
+  let children = [
+    [.integer(1), .text("Ann")],
+    [.integer(1), .text("Amy")],
+    [.integer(2), .text("Bob")],
+    [.integer(3), .text("Cody")],
+  ] as Array<Array<Value>>
+
+  let kin = try View(query: select("""
+      SELECT Parent.Name, Child.Kid FROM Parent
+        JOIN Child ON Child.Pid = Parent.Id
+      """), columns: ["Name", "Kid"])
+  let catalog =
+      Memory([
+        "Parent": Relation(parent, parents, sorted: 0),
+        "Child": Relation(child, children, counter: reads),
+      ], views: ["Kin": kin])
+  return (catalog, reads)
+}
+
+/// A catalog for pushing a filter through a UNION view's arms: two relations
+/// whose shared output column `Key` sits at DIFFERENT body ordinals — `Alpha`
+/// has it first (sorted, so seekable), `Beta` last (unsorted) — exposed by a
+/// `Both` view as one column. A `WHERE Key = ?` over the view must rebase PER
+/// arm (each arm maps `Key` to its own body slot), pushing below every arm's
+/// projection and seeking inside the `Alpha` arm.
+private func spanned() throws -> Memory {
+  let alpha = [
+    Field(name: "Key", kind: .integer),
+    Field(name: "Tag", kind: .text),
+  ]
+  let alphas = [
+    [.integer(1), .text("a1")],
+    [.integer(2), .text("a2")],
+    [.integer(3), .text("a3")],
+  ] as Array<Array<Value>>
+
+  let beta = [
+    Field(name: "Tag", kind: .text),
+    Field(name: "Key", kind: .integer),
+  ]
+  let betas = [
+    [.text("b1"), .integer(1)],
+    [.text("b2"), .integer(2)],
+  ] as Array<Array<Value>>
+
+  // Arm 1 projects Alpha.Key (body slot 0, seekable) then Tag; arm 2 projects
+  // Beta.Key (body slot 1, unseekable) then Tag — the same output `Key` at
+  // differing body slots.
+  let both = try View(query: select("""
+      SELECT Key, Tag FROM Alpha UNION ALL SELECT Key, Tag FROM Beta
+      """), columns: ["Key", "Tag"])
+  return Memory([
+    "Alpha": Relation(alpha, alphas, sorted: 0),
+    "Beta": Relation(beta, betas),
+  ], views: ["Both": both])
+}
+
+/// Whether `plan` reaches a `.union` every arm of which carries a filter pushed
+/// below its projection — a seeked scan or a `.select` over its scan inside each
+/// arm's body, the per-arm rebase this fix enables.
+private func injected(_ plan: Plan) -> Bool {
+  switch plan {
+  case let .union(left, right, _):
+    (seeks(left) || floats(left)) && (seeks(right) || floats(right))
+  case let .select(_, source):
+    injected(source)
+  case let .project(_, source):
+    injected(source)
+  case let .sort(_, _, source):
+    injected(source)
+  case let .derived(_, sub, _, _):
+    injected(sub)
+  case let .product(left, right):
+    injected(left) || injected(right)
+  case let .join(outer, _, _, _, _, _, _):
+    injected(outer)
+  case .single, .scan:
+    false
+  }
+}
+
+struct EnginePushdownTests {
+  @Test("a single-relation WHERE conjunct rides below the join")
+  func placement() throws {
+    // `WHERE Parent.Name = 'Ada'` references only the outer relation, so it
+    // pushes to the Parent leaf inside the join rather than filtering the whole
+    // product afterwards — `pushed` sees a filter within the join's outer.
+    let catalog = family()
+    let select = try parse("""
+        SELECT Child.Name FROM Parent JOIN Child ON Child.Pid = Parent.Id
+          WHERE Parent.Name = 'Ada'
+        """)
+    let plan =
+        try Engine.optimise(Engine.compile(select, catalog).pushdown(),
+                            catalog, [:])
+    #expect(pushed(plan))
+  }
+
+  @Test("pushdown down a seekable outer key seeks that leaf inside the join")
+  func seeked() throws {
+    // `WHERE Parent.Id = 2` is seekable; pushed to the Parent leaf it becomes a
+    // seek inside the join's outer, not a scan-then-filter atop the product.
+    let catalog = family()
+    let select = try parse("""
+        SELECT Child.Name FROM Parent JOIN Child ON Child.Pid = Parent.Id
+          WHERE Parent.Id = 2
+        """)
+    let plan =
+        try Engine.optimise(Engine.compile(select, catalog).pushdown(),
+                            catalog, [:])
+    #expect(seeks(plan))
+    #expect(pushed(plan))
+  }
+
+  @Test("a trailing seekable conjunct survives a rebuilt three-term AND")
+  func seekable() throws {
+    // Pushdown flattens a single-table filter through `conjuncts` and rebuilds
+    // it via `conjunction`. A right-leaning rebuild would bury the trailing
+    // `Id = 5` under a nested AND, hidden from `seek` (which inspects only a
+    // top-level AND's two immediate children); the left-leaning rebuild keeps it
+    // the immediate RHS, as the parser produced it, so the sort-key seek
+    // survives the three-term AND.
+    let catalog = Memory([
+      "T": Relation([
+        Field(name: "Name", kind: .text),
+        Field(name: "Age", kind: .integer),
+        Field(name: "Id", kind: .integer),
+      ], [
+        [.text("a"), .integer(1), .integer(5)],
+        [.text("b"), .integer(2), .integer(6)],
+      ] as Array<Array<Value>>, sorted: 2),
+    ])
+    let select = try parse("""
+        SELECT Name FROM T WHERE Name <> 'x' AND Age > 0 AND Id = 5
+        """)
+    let plan =
+        try Engine.optimise(Engine.compile(select, catalog).pushdown(),
+                            catalog, [:])
+    #expect(seeks(plan))
+  }
+
+  @Test("a seekable conjunct grouped after an unsafe one does not bypass its throw")
+  func grouped() throws {
+    // The left fold rebuilds `(1 / x) = 0 AND (name <> 'z' AND id < 0)` — parsed
+    // as `A AND (B AND C)` — into `((A AND B) AND C)`, promoting the seekable
+    // `id < 0` to the top-level RHS `seek` inspects. On an id-sorted table whose
+    // `id < 0` run is empty, seeking that run drops every row before the earlier
+    // `(1 / x) = 0` division runs, suppressing the throw the scan owes. `seek`
+    // seeks a conjunct only when the residual is safe, so the unsafe division
+    // residual bars the seek: the plan scans, and it raises.
+    let catalog = Memory([
+      "T": Relation([
+        Field(name: "x", kind: .integer),
+        Field(name: "name", kind: .text),
+        Field(name: "id", kind: .integer),
+      ], [
+        [.integer(0), .text("a"), .integer(5)],
+      ] as Array<Array<Value>>, sorted: 2),
+    ])
+    let select = try parse("""
+        SELECT id FROM T WHERE (1 / x) = 0 AND (name <> 'z' AND id < 0)
+        """)
+
+    // The unsafe `(1 / x) = 0` residual bars the `id < 0` seek — the plan scans.
+    let plan =
+        try Engine.optimise(Engine.compile(select, catalog).pushdown(),
+                            catalog, [:])
+    #expect(!seeks(plan))
+
+    // …and the scan raises the division rather than seeking past the empty run.
+    #expect(throws: SQLError.self) {
+      _ = try Engine.run(select, catalog)
+    }
+  }
+
+  @Test("pushdown preserves the join's result")
+  func correctness() throws {
+    // The pushed plan must return exactly the un-pushed join's rows.
+    let rows = try join("""
+        SELECT Child.Name FROM Parent JOIN Child ON Child.Pid = Parent.Id
+          WHERE Parent.Name = 'Ada'
+        """)
+    #expect(rows == [[.text("Ann")], [.text("Amy")]])
+  }
+
+  @Test("a non-key predicate on the joined-in relation still uses the join")
+  func inner() throws {
+    // `WHERE Parent.Name <> 'zz'` references only the joined-in `Parent`, so
+    // pushdown wraps that inner leaf as `Select(_, Scan(Parent))` before the
+    // join folds it in. `nest` must look through that pushed filter and still
+    // form a `Join` — not fall back to a residual product filtered by the ON
+    // predicate (O(left × filtered-right)).
+    let catalog = family()
+    let select = try parse("""
+        SELECT Child.Name, Parent.Name FROM Child
+          JOIN Parent ON Parent.Id = Child.Pid WHERE Parent.Name <> 'zz'
+        """)
+    let plan =
+        try Engine.optimise(Engine.compile(select, catalog).pushdown(),
+                            catalog, [:])
+    #expect(joins(plan))
+
+    // …and it returns the correct rows: every child with a matching parent,
+    // the joined-in predicate keeping all of them (no parent is named 'zz').
+    let rows = try join("""
+        SELECT Child.Name, Parent.Name FROM Child
+          JOIN Parent ON Parent.Id = Child.Pid WHERE Parent.Name <> 'zz'
+        """)
+    #expect(rows == [
+      [.text("Ann"), .text("Ada")],
+      [.text("Amy"), .text("Ada")],
+      [.text("Bob"), .text("Bee")],
+    ])
+  }
+
+  @Test("a spanning WHERE leaves the join path with a residual above it")
+  func spanning() throws {
+    // `WHERE Parent.Name <> Child.Name` references BOTH joined relations, so it
+    // descends no further than the product and stays as a residual. The ON
+    // match must remain adjacent to the product — folded in with the spanning
+    // conjunct — so `nest` still finds it and forms a `Join`, keeping the
+    // spanning predicate as a `Select` ABOVE the join rather than degrading to a
+    // filtered Cartesian `product`.
+    let catalog = family()
+    let select = try parse("""
+        SELECT Child.Name, Parent.Name FROM Parent
+          JOIN Child ON Child.Pid = Parent.Id WHERE Parent.Name <> Child.Name
+        """)
+    let plan =
+        try Engine.optimise(Engine.compile(select, catalog).pushdown(),
+                            catalog, [:])
+    #expect(joins(plan))
+    #expect(floats(plan))
+
+    // …and it returns the join's rows filtered by the spanning predicate: every
+    // matched pair survives, none sharing a name across the two relations.
+    let rows = try join("""
+        SELECT Child.Name, Parent.Name FROM Parent
+          JOIN Child ON Child.Pid = Parent.Id WHERE Parent.Name <> Child.Name
+        """)
+    #expect(rows == [
+      [.text("Ann"), .text("Ada")],
+      [.text("Amy"), .text("Ada")],
+      [.text("Bob"), .text("Bee")],
+    ])
+  }
+
+  @Test("a WHERE over a join view prunes its rows before the join runs")
+  func view() throws {
+    // `Kin` is the Parent/Child join; `WHERE Name = 'Ada'` over it must push
+    // INTO the view's sub-plan and prune Parent to Ada before joining, so the
+    // join probes the inner `Child` for only ONE outer parent — not all three.
+    let (culled, pruned) = try counted()
+    let rows = try Engine.run(parse("SELECT Kid FROM Kin WHERE Name = 'Ada'"),
+                              culled)
+    #expect(rows == [[.text("Ann")], [.text("Amy")]])
+
+    // The un-pushed baseline: the same view with no `WHERE` runs the join over
+    // every parent, probing the four-row inner once per parent — twelve reads.
+    let (whole, full) = try counted()
+    _ = try Engine.run(parse("SELECT Kid FROM Kin"), whole)
+    #expect(full.reads == 12)
+
+    // Pushed, the join probes the inner for Ada alone — one parent's four-row
+    // inner scan — a third of the baseline's reads.
+    #expect(pruned.reads == 4)
+  }
+
+  @Test("the pushed view result matches the unfiltered view filtered late")
+  func equivalence() throws {
+    // Running the view then filtering must agree with the pushed plan.
+    let (catalog, _) = try counted()
+    let all = try Engine.run(parse("SELECT Name, Kid FROM Kin"), catalog)
+    let culled = all.filter { $0[0] == .text("Ada") }.map { [$0[1]] }
+    let filtered =
+        try Engine.run(parse("SELECT Kid FROM Kin WHERE Name = 'Ada'"), catalog)
+    #expect(filtered == culled)
+  }
+
+  @Test("a slotless predicate stays above the join and skips an empty product")
+  func slotless() throws {
+    // `WHERE (1 / 0) = 0` reads no slots, so it must stay at the product level
+    // and run per pair — not ride down to the left input. `B` is empty, so the
+    // join's product is empty and the throwing expression is never evaluated;
+    // the query returns no rows. Pushed to the left, it would run once per left
+    // row and raise `SQLError.divide`.
+    let catalog = Memory([
+      "A": Relation([Field(name: "x", kind: .integer)],
+                    [[.integer(1)]] as Array<Array<Value>>),
+      "B": Relation([Field(name: "y", kind: .integer)],
+                    [] as Array<Array<Value>>),
+    ])
+    let rows = try Engine.run(parse("""
+        SELECT A.x FROM A JOIN B ON A.x = B.y WHERE (1 / 0) = 0
+        """), catalog)
+    #expect(rows.isEmpty)
+  }
+
+  @Test("a throwing single-side predicate stays above the join, skips an empty product")
+  func hazardous() throws {
+    // `WHERE (1 / A.x) = 0` reads only `A`'s slot but CAN throw (division), so —
+    // like a slotless throwing predicate — it must stay at the product level, not
+    // ride down to `A`. `B` is empty, so the product is empty and the division is
+    // never evaluated; the query returns no rows. Pushed to `A` (x = 0) it would
+    // divide by zero and raise `SQLError.divide`.
+    let catalog = Memory([
+      "A": Relation([Field(name: "x", kind: .integer)],
+                    [[.integer(0)]] as Array<Array<Value>>),
+      "B": Relation([Field(name: "y", kind: .integer)],
+                    [] as Array<Array<Value>>),
+    ])
+    let rows = try Engine.run(parse("""
+        SELECT A.x FROM A JOIN B ON A.x = B.y WHERE (1 / A.x) = 0
+        """), catalog)
+    #expect(rows.isEmpty)
+  }
+
+  @Test("an unsafe conjunct bars a later safe one from suppressing its throw")
+  func barrier() throws {
+    // `WHERE (1 / A.x) = 0 AND A.x <> 0`: left-to-right, the division runs first
+    // and raises on the matching pair (`A.x = 0` joined to `B.y = 0`). The safe
+    // `A.x <> 0` must NOT ride down to `A` — doing so would drop the row before
+    // the division runs, silently returning no rows. The earlier unsafe conjunct
+    // is an ordering barrier, so the query raises as the un-pushed `AND` would.
+    let catalog = Memory([
+      "A": Relation([Field(name: "x", kind: .integer)],
+                    [[.integer(0)]] as Array<Array<Value>>),
+      "B": Relation([Field(name: "y", kind: .integer)],
+                    [[.integer(0)]] as Array<Array<Value>>),
+    ])
+    #expect(throws: SQLError.self) {
+      _ = try Engine.run(parse("""
+          SELECT A.x FROM A JOIN B ON A.x = B.y WHERE (1 / A.x) = 0 AND A.x <> 0
+          """), catalog)
+    }
+  }
+
+  @Test("a lifted inner filter keeps its place before a later unsafe residual")
+  func lifted() throws {
+    // `WHERE Parent.Name = 'nope' AND (1 / Child.x) = 0`: left-to-right, the
+    // false `Parent.Name` check short-circuits before the division on the
+    // matching pair (Child.x = 0). `Parent.Name = 'nope'` is a single-side inner
+    // filter that nest lifts out of the join — it must stay BEFORE the unsafe
+    // division in the residual, not be appended after it, or the division runs
+    // first and raises. The matching Parent is named 'other', so the row is
+    // excluded with no throw.
+    let catalog = Memory([
+      "Child": Relation([Field(name: "Pid", kind: .integer),
+                         Field(name: "x", kind: .integer)],
+                        [[.integer(1), .integer(0)]] as Array<Array<Value>>),
+      "Parent": Relation([Field(name: "Id", kind: .integer),
+                          Field(name: "Name", kind: .text)],
+                         [[.integer(1), .text("other")]]
+                             as Array<Array<Value>>),
+    ])
+    let rows = try Engine.run(parse("""
+        SELECT Child.x FROM Child JOIN Parent ON Parent.Id = Child.Pid
+          WHERE Parent.Name = 'nope' AND (1 / Child.x) = 0
+        """), catalog)
+    #expect(rows.isEmpty)
+  }
+
+  @Test("a WHERE over a UNION view pushes into every arm's projection")
+  func union() throws {
+    // `Both` unions `Alpha` and `Beta`, whose shared `Key` output column sits at
+    // DIFFERING body slots. `WHERE Key = 2` must rebase PER ARM — the union root
+    // fails a single pre-rebased filter — pushing below each arm's projection
+    // and seeking the sorted `Alpha` arm.
+    let catalog = try spanned()
+    let select = try parse("SELECT Tag FROM Both WHERE Key = 2")
+    let plan =
+        try Engine.optimise(Engine.compile(select, catalog).pushdown(),
+                            catalog, [:])
+    #expect(injected(plan))
+    #expect(seeks(plan))
+
+    // …and the rows are exactly the union filtered late: `a2` from Alpha and
+    // `b2` from Beta.
+    let rows = try Engine.run(select, catalog)
+    #expect(rows == [[.text("a2")], [.text("b2")]])
+  }
+
+  @Test("a view's throwing projection term is not suppressed by a pushed filter")
+  func throwingView() throws {
+    // The view projects `1 / z`, which raises on the `z = 0` row. `derive`
+    // evaluates every projected column for every view row, so `SELECT id FROM V
+    // WHERE id <> 0` raises even though `id <> 0` would exclude that row —
+    // pushing `id <> 0` below the view's Project would filter the row first and
+    // silently skip the division, so a view whose projection can throw is never
+    // pushed into.
+    let t = [Field(name: "id", kind: .integer),
+             Field(name: "z", kind: .integer)]
+    let rows = [[.integer(0), .integer(0)]] as Array<Array<Value>>
+    let view = try View(query: select("SELECT id, 1 / z FROM T"),
+                        columns: ["id", "q"])
+    let catalog = Memory(["T": Relation(t, rows)], views: ["V": view])
+    #expect(throws: SQLError.self) {
+      _ = try Engine.run(parse("SELECT id FROM V WHERE id <> 0"), catalog)
+    }
+  }
+
+  @Test("an unsafe outer conjunct bars a later push into a view")
+  func gated() throws {
+    // `V` is `SELECT x FROM T` with `T.x` sorted and a single `x = 0` row.
+    // `SELECT x FROM V WHERE (1 / x) = 0 AND x = 1`: left-to-right, the division
+    // runs on the `x = 0` row and raises. The safe seekable `x = 1` must NOT push
+    // into the view past the earlier unsafe `(1 / x) = 0` — doing so would SEEK
+    // the view (`T.x` sorted) to `x = 1`, dropping the `x = 0` row before the
+    // outer division ever runs, silently returning no rows. The unsafe outer
+    // conjunct is an ordering barrier, so the query raises as the un-pushed `AND`
+    // would.
+    let t = [Field(name: "x", kind: .integer)]
+    let rows = [[.integer(0)]] as Array<Array<Value>>
+    let view = try View(query: select("SELECT x FROM T"), columns: ["x"])
+    let catalog = Memory(["T": Relation(t, rows, sorted: 0)],
+                         views: ["V": view])
+    #expect(throws: SQLError.self) {
+      _ = try Engine.run(parse("SELECT x FROM V WHERE (1 / x) = 0 AND x = 1"),
+                         catalog)
+    }
+  }
+
+  @Test("a nullable conjunct is not pushed below a later unsafe conjunct")
+  func nullable() throws {
+    // `WHERE A.x = 1 AND (1 / B.y) = 0`: the evaluator's `AND` does not short-
+    // circuit, so on the matching pair (A.x NULL, B.y = 0) the UNKNOWN left
+    // still runs the right, and the division raises. The safe `A.x = 1`
+    // references a slot, so a NULL there makes it UNKNOWN — pushing it to `A`'s
+    // scan would drop the A.x-NULL row before the join, so the later unsafe
+    // `(1 / B.y) = 0` never runs and the throw the `AND` owes is suppressed. A
+    // nullable conjunct must NOT ride past a LATER unsafe conjunct, so `A.x = 1`
+    // stays a product-level residual and the query raises.
+    let catalog = Memory([
+      "A": Relation([Field(name: "x", kind: .integer),
+                     Field(name: "k", kind: .integer)],
+                    [[.null, .integer(0)]] as Array<Array<Value>>),
+      "B": Relation([Field(name: "y", kind: .integer),
+                     Field(name: "k", kind: .integer)],
+                    [[.integer(0), .integer(0)]] as Array<Array<Value>>),
+    ])
+    let select = try parse("""
+        SELECT A.x FROM A JOIN B ON A.k = B.k
+          WHERE A.x = 1 AND (1 / B.y) = 0
+        """)
+
+    // `A.x = 1` is nullable and precedes the unsafe division, so it is NOT
+    // pushed to the `A` leaf — it floats at the product level.
+    let plan =
+        try Engine.optimise(Engine.compile(select, catalog).pushdown(),
+                            catalog, [:])
+    #expect(!pushed(plan))
+    #expect(floats(plan))
+
+    // …and the query raises rather than silently dropping the row.
+    #expect(throws: SQLError.self) {
+      _ = try Engine.run(select, catalog)
+    }
+  }
+
+  @Test("a nullable conjunct is not pushed into a view below a later unsafe one")
+  func nullableView() throws {
+    // `V` exposes safe columns `x` and `y`. `SELECT x FROM V WHERE x = 1 AND
+    // (1 / y) = 0`: the `AND` does not short-circuit, so on the (x NULL, y = 0)
+    // row the UNKNOWN left still runs the division, which raises. Pushing the
+    // nullable `x = 1` into the view would drop the x-NULL row before the outer
+    // division runs, suppressing the throw. A nullable conjunct must NOT be
+    // injected past a LATER unsafe outer conjunct, so `x = 1` stays outer and
+    // the query raises.
+    let t = [Field(name: "x", kind: .integer),
+             Field(name: "y", kind: .integer)]
+    let rows = [[.null, .integer(0)]] as Array<Array<Value>>
+    let view = try View(query: select("SELECT x, y FROM T"),
+                        columns: ["x", "y"])
+    let catalog = Memory(["T": Relation(t, rows)], views: ["V": view])
+    let select = try parse("SELECT x FROM V WHERE x = 1 AND (1 / y) = 0")
+
+    // `x = 1` is nullable and precedes the unsafe division, so it is NOT
+    // injected into the view — it floats above the derived leaf.
+    let plan =
+        try Engine.optimise(Engine.compile(select, catalog).pushdown(),
+                            catalog, [:])
+    #expect(floats(plan))
+
+    // …and the query raises rather than silently dropping the row.
+    #expect(throws: SQLError.self) {
+      _ = try Engine.run(select, catalog)
+    }
+  }
+
+  @Test("a slotless bound conjunct is not pushed into a view below a later unsafe one")
+  func boundView() throws {
+    // A `.bound` predicate compares against a run-time `:parameter` and reads no
+    // slot, yet it is UNKNOWN when the parameter is unbound (or bound to NULL).
+    // `SELECT x FROM V WHERE 1 = :missing AND (1 / y) = 0` with `:missing`
+    // unbound: the outer `AND` does not short-circuit, so on the (y = 0) row the
+    // UNKNOWN left still runs the division, which raises. Injecting the slotless
+    // `1 = :missing` into the view would drop every row first, suppressing the
+    // throw. A bound conjunct is nullable despite reading no slot, so it stays
+    // outer and the query raises.
+    let t = [Field(name: "x", kind: .integer),
+             Field(name: "y", kind: .integer)]
+    let rows = [[.integer(1), .integer(0)]] as Array<Array<Value>>
+    let view = try View(query: select("SELECT x, y FROM T"),
+                        columns: ["x", "y"])
+    let catalog = Memory(["T": Relation(t, rows)], views: ["V": view])
+    let select = try parse("SELECT x FROM V WHERE 1 = :missing AND (1 / y) = 0")
+
+    // `1 = :missing` is a slotless bound predicate, hence nullable; it precedes
+    // the unsafe division, so it is NOT injected into the view — it floats above
+    // the derived leaf.
+    let plan =
+        try Engine.optimise(Engine.compile(select, catalog).pushdown(),
+                            catalog, [:])
+    #expect(floats(plan))
+
+    // …and the query raises rather than silently dropping the row.
+    #expect(throws: SQLError.self) {
+      _ = try Engine.run(select, catalog)
+    }
+  }
+
+  @Test("a throwing WHERE is not evaluated for a pair an UNKNOWN ON rejects")
+  func gatedMatch() throws {
+    // `A JOIN V ON A.k = V.k WHERE (1 / A.x) = 0` where `V` is a derived view,
+    // so `nest` cannot fold the product into a `Join`. On the `A` row with a
+    // NULL `k` and `x = 0`, the ON match is UNKNOWN — the join forms no pair for
+    // it — but `evaluate(.and)` does not short-circuit, so folding the match and
+    // WHERE into one AND would evaluate `(1 / 0)` and raise. Keeping the match a
+    // separate inner gate drops that pair before the WHERE runs, so the query
+    // does not raise: the matched `x = 1` row fails `(1 / 1) = 0`, leaving no
+    // rows.
+    let a = [Field(name: "x", kind: .integer), Field(name: "k", kind: .integer)]
+    let catalog = Memory([
+      "A": Relation(a, [[.integer(1), .integer(1)],
+                        [.integer(0), .null]] as Array<Array<Value>>),
+      "T": Relation([Field(name: "k", kind: .integer)],
+                    [[.integer(1)]] as Array<Array<Value>>),
+    ], views: ["V": try View(query: select("SELECT k FROM T"),
+                             columns: ["k"])])
+    let select =
+        try parse("SELECT A.x FROM A JOIN V ON A.k = V.k WHERE (1 / A.x) = 0")
+
+    // The UNKNOWN-ON pair (A.k NULL) is dropped by the match gate before the
+    // division runs, so the query returns rows rather than raising.
+    #expect(try Engine.run(select, catalog) == [])
   }
 }
 
@@ -1904,3 +2557,4 @@ struct EngineScalarSelectTests {
     #expect(rows == [[.text("Alice")]])
   }
 }
+

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -1302,7 +1302,9 @@ private func joins(_ plan: Plan) -> Bool {
 
 /// A join catalog whose inner `Child` relation tallies its row reads, plus a
 /// view `Kin` over the `Parent`/`Child` join — to prove a `WHERE` over the view
-/// prunes the join's inputs BEFORE the join runs rather than after.
+/// prunes the join's inputs BEFORE the join runs rather than after. The counter
+/// rides the `Parent` relation (sorted on `Id`), so a pushed seekable key reads
+/// fewer of its rows regardless of the inner join strategy.
 private func counted() throws -> (catalog: Memory, reads: Counter) {
   let reads = Counter()
   let parent = [
@@ -1327,13 +1329,13 @@ private func counted() throws -> (catalog: Memory, reads: Counter) {
   ] as Array<Array<Value>>
 
   let kin = try View(query: select("""
-      SELECT Parent.Name, Child.Kid FROM Parent
+      SELECT Parent.Id, Parent.Name, Child.Kid FROM Parent
         JOIN Child ON Child.Pid = Parent.Id
-      """), columns: ["Name", "Kid"])
+      """), columns: ["Key", "Name", "Kid"])
   let catalog =
       Memory([
-        "Parent": Relation(parent, parents, sorted: 0),
-        "Child": Relation(child, children, counter: reads),
+        "Parent": Relation(parent, parents, sorted: 0, counter: reads),
+        "Child": Relation(child, children),
       ], views: ["Kin": kin])
   return (catalog, reads)
 }
@@ -1568,33 +1570,32 @@ struct EnginePushdownTests {
 
   @Test("a WHERE over a join view prunes its rows before the join runs")
   func view() throws {
-    // `Kin` is the Parent/Child join; `WHERE Name = 'Ada'` over it must push
-    // INTO the view's sub-plan and prune Parent to Ada before joining, so the
-    // join probes the inner `Child` for only ONE outer parent — not all three.
+    // `Kin` is the Parent/Child join; `WHERE Key = 2` over it must push INTO the
+    // view's sub-plan and seek Parent to the single matching row before joining,
+    // so only that parent's rows are read — not the whole relation.
     let (culled, pruned) = try counted()
-    let rows = try Engine.run(parse("SELECT Kid FROM Kin WHERE Name = 'Ada'"),
+    let rows = try Engine.run(parse("SELECT Kid FROM Kin WHERE Key = 2"),
                               culled)
-    #expect(rows == [[.text("Ann")], [.text("Amy")]])
+    #expect(rows == [[.text("Bob")]])
 
-    // The un-pushed baseline: the same view with no `WHERE` runs the join over
-    // every parent, probing the four-row inner once per parent — twelve reads.
+    // The un-pushed baseline: the same view with no `WHERE` reads every parent
+    // row — three.
     let (whole, full) = try counted()
     _ = try Engine.run(parse("SELECT Kid FROM Kin"), whole)
-    #expect(full.reads == 12)
+    #expect(full.reads == 3)
 
-    // Pushed, the join probes the inner for Ada alone — one parent's four-row
-    // inner scan — a third of the baseline's reads.
-    #expect(pruned.reads == 4)
+    // Pushed, the seek reads the one matching parent — a single row.
+    #expect(pruned.reads == 1)
   }
 
   @Test("the pushed view result matches the unfiltered view filtered late")
   func equivalence() throws {
     // Running the view then filtering must agree with the pushed plan.
     let (catalog, _) = try counted()
-    let all = try Engine.run(parse("SELECT Name, Kid FROM Kin"), catalog)
-    let culled = all.filter { $0[0] == .text("Ada") }.map { [$0[1]] }
+    let all = try Engine.run(parse("SELECT Key, Kid FROM Kin"), catalog)
+    let culled = all.filter { $0[0] == .integer(2) }.map { [$0[1]] }
     let filtered =
-        try Engine.run(parse("SELECT Kid FROM Kin WHERE Name = 'Ada'"), catalog)
+        try Engine.run(parse("SELECT Kid FROM Kin WHERE Key = 2"), catalog)
     #expect(filtered == culled)
   }
 
@@ -1864,6 +1865,270 @@ struct EnginePushdownTests {
     // The UNKNOWN-ON pair (A.k NULL) is dropped by the match gate before the
     // division runs, so the query returns rows rather than raising.
     #expect(try Engine.run(select, catalog) == [])
+  }
+}
+
+// MARK: - Hash-join tests
+
+/// A join catalog whose inner `Parent` is UNSORTED (so its join key is not
+/// seekable and the executor hashes it) and tallies its row reads — to prove the
+/// hash build scans the inner exactly once rather than once per outer record.
+private func hashable() -> (catalog: Memory, reads: Counter) {
+  let reads = Counter()
+  let parent = [
+    Field(name: "Id", kind: .integer),
+    Field(name: "Name", kind: .text),
+  ]
+  let parents = [
+    [.integer(1), .text("Ada")],
+    [.integer(2), .text("Bee")],
+    [.integer(3), .text("Cid")],
+  ] as Array<Array<Value>>
+
+  let child = [
+    Field(name: "Pid", kind: .integer),
+    Field(name: "Kid", kind: .text),
+  ]
+  let children = [
+    [.integer(1), .text("Ann")],
+    [.integer(1), .text("Amy")],
+    [.integer(2), .text("Bob")],
+    [.integer(9), .text("Orphan")],
+  ] as Array<Array<Value>>
+
+  let catalog = Memory([
+    "Parent": Relation(parent, parents, counter: reads),
+    "Child": Relation(child, children),
+  ])
+  return (catalog, reads)
+}
+
+struct EngineHashJoinTests {
+  @Test("a hash join over an unsorted inner scans it exactly once")
+  func single() throws {
+    // `Parent` is unsorted, so its `Id` is not seekable and the join hashes it.
+    // Four outer children probe the map, but the inner is read only three times
+    // — its row count — not twelve (once per outer).
+    let (catalog, reads) = hashable()
+    let rows = try Engine.run(parse("""
+        SELECT Child.Kid, Parent.Name FROM Child
+          JOIN Parent ON Parent.Id = Child.Pid
+        """), catalog)
+    #expect(rows == [
+      [.text("Ann"), .text("Ada")],
+      [.text("Amy"), .text("Ada")],
+      [.text("Bob"), .text("Bee")],
+    ])
+    #expect(reads.reads == 3)
+  }
+
+  @Test("a coded-index inner key seeks rather than hashing the whole inner")
+  func coded() throws {
+    // The join strategy is chosen by probing the inner key for seekability. A
+    // decoded coded-index column is 1-based and rejects the null reference `0`,
+    // so probing with `0` would call it unseekable and hash every inner row;
+    // probing with a valid `1` finds it seekable, so a selective join seeks the
+    // coded run instead. `Attribute.Parent` is such a column (stored raw
+    // `(rowid << 2) | tag`, decoded to a rowid), and one `Type` (Id 6) probes it.
+    let reads = Counter()
+    let type = [Field(name: "Id", kind: .integer)]
+    let types = [[.integer(6)]] as Array<Array<Value>>
+    let attribute = [
+      Field(name: "Parent", kind: .integer),
+      Field(name: "Name", kind: .text),
+    ]
+    let attributes = [
+      [.integer(0), .text("null-ref")],
+      [.integer(4), .text("td1")],
+      [.integer(8), .text("td2")],
+      [.integer(16), .text("td4")],
+      [.integer(20), .text("td5")],
+      [.integer(24), .text("td6")],
+    ] as Array<Array<Value>>
+    let catalog = Memory([
+      "Type": Relation(type, types),
+      "Attribute": Relation(attribute, attributes, coded: 0, counter: reads),
+    ])
+    let rows = try Engine.run(parse("""
+        SELECT Attribute.Name FROM Type
+          JOIN Attribute ON Attribute.Parent = Type.Id
+        """), catalog)
+    #expect(rows == [[.text("td6")]])
+    // Seeked: only the `Parent = 6` run (the single `td6` row) is read, not all
+    // six. Before the fix — probing seekability with `0` — the coded column
+    // tested unseekable and the join hashed, reading every attribute row.
+    #expect(reads.reads == 1)
+  }
+
+  @Test("an empty outer skips the hash build of an unseekable inner")
+  func empty() throws {
+    // A contradictory outer WHERE prunes every `Child`, so the outer is empty
+    // and no probe can match. The inner `Parent` is unsorted (unseekable), so
+    // the join would hash it — but with no probes the build is pointless. The
+    // empty-outer short-circuit returns before scanning, so ZERO inner rows are
+    // read; the nested-loop path this replaced already read none for an empty
+    // outer, and a large unseekable inner must not be fully scanned to answer
+    // nothing.
+    let (catalog, reads) = hashable()
+    let rows = try Engine.run(parse("""
+        SELECT Child.Kid, Parent.Name FROM Child
+          JOIN Parent ON Parent.Id = Child.Pid WHERE Child.Pid < 0
+        """), catalog)
+    #expect(rows.isEmpty)
+    #expect(reads.reads == 0)
+  }
+
+  @Test("an all-NULL-key outer skips the hash build of an unseekable inner")
+  func allNull() throws {
+    // The outer is NON-empty but every `Child.Pid` is NULL (a `WHERE Pid IS
+    // NULL` keeps only the null-keyed rows), and a NULL key joins to nothing —
+    // so no probe can match. The inner `Parent` is unsorted (unseekable), so the
+    // join would hash it; but with no non-null probe the build is pointless. The
+    // no-probe guard returns before scanning, so ZERO inner rows are read — the
+    // nested-loop path this replaced read none for an all-null outer too.
+    let reads = Counter()
+    let parent = [
+      Field(name: "Id", kind: .integer),
+      Field(name: "Name", kind: .text),
+    ]
+    let parents = [
+      [.integer(1), .text("Ada")],
+      [.integer(2), .text("Bee")],
+    ] as Array<Array<Value>>
+    let child = [
+      Field(name: "Pid", kind: .integer),
+      Field(name: "Kid", kind: .text),
+    ]
+    let children = [
+      [.integer(1), .text("Ann")],
+      [.null, .text("Nemo")],
+      [.null, .text("Nobody")],
+    ] as Array<Array<Value>>
+    let catalog = Memory([
+      "Parent": Relation(parent, parents, counter: reads),
+      "Child": Relation(child, children),
+    ])
+    let rows = try Engine.run(parse("""
+        SELECT Child.Kid, Parent.Name FROM Child
+          JOIN Parent ON Parent.Id = Child.Pid WHERE Child.Pid IS NULL
+        """), catalog)
+    #expect(rows.isEmpty)
+    #expect(reads.reads == 0)
+  }
+
+  @Test("the hash probe and the seek probe return identical results")
+  func equivalence() throws {
+    // The sorted `Parent` seeks; its unsorted twin hashes. Both inner orderings
+    // must agree — the hash preserves the seek path's outer-major, inner-cursor
+    // order.
+    let seek = try join("""
+        SELECT Parent.Name, Child.Name FROM Child
+          JOIN Parent ON Parent.Id = Child.Pid
+        """)
+    let hash = try join("""
+        SELECT P.Name, Child.Name FROM Child
+          JOIN ParentUnsorted AS P ON P.Id = Child.Pid
+        """)
+    #expect(hash == seek)
+    #expect(hash == [
+      [.text("Ada"), .text("Ann")],
+      [.text("Ada"), .text("Amy")],
+      [.text("Bee"), .text("Bob")],
+    ])
+  }
+
+  @Test("a hash join emits matches outer-major in inner cursor order")
+  func order() throws {
+    // The unsorted twin forces the hash path. Without an ORDER BY the result
+    // must be outer-major (each child in scan order), and a bucket's inner rows
+    // in the inner's cursor order — exactly the nested loop's order.
+    let forced = try join("""
+        SELECT Child.Name, P.Name FROM Child
+          JOIN ParentUnsorted AS P ON P.Id = Child.Pid
+        """)
+    #expect(forced == [
+      [.text("Ann"), .text("Ada")],
+      [.text("Amy"), .text("Ada")],
+      [.text("Bob"), .text("Bee")],
+    ])
+  }
+
+  @Test("a NULL key joins to nothing under the hash path")
+  func null() throws {
+    // The child with a NULL foreign key is the outer row; a NULL key hashes to
+    // nothing, and a NULL inner key is never bucketed. `Parent` here is unsorted
+    // so the join hashes.
+    let parent = [
+      Field(name: "Id", kind: .integer),
+      Field(name: "Name", kind: .text),
+    ]
+    let parents = [
+      [.integer(1), .text("Ada")],
+      [.integer(2), .text("Bee")],
+    ] as Array<Array<Value>>
+    let child = [
+      Field(name: "Pid", kind: .integer),
+      Field(name: "Name", kind: .text),
+    ]
+    let children = [
+      [.integer(1), .text("Ann")],
+      [.null, .text("Nobody")],
+      [.integer(2), .text("Bob")],
+    ] as Array<Array<Value>>
+    let catalog = Memory([
+      "Parent": Relation(parent, parents),
+      "Child": Relation(child, children),
+    ])
+    let rows = try Engine.run(parse("""
+        SELECT Child.Name, Parent.Name FROM Child
+          JOIN Parent ON Parent.Id = Child.Pid
+        """), catalog)
+    #expect(rows == [
+      [.text("Ann"), .text("Ada")],
+      [.text("Bob"), .text("Bee")],
+    ])
+  }
+
+  @Test("a seekable inner filter seeks the hash inner rather than scanning it")
+  func filtered() throws {
+    // `Parent.Code` (the join key) is unseekable, so the join hashes the inner;
+    // `Parent.Id` is sorted (seekable and ordered). `Child JOIN Parent ON
+    // Parent.Code = Child.Code WHERE Parent.Id < 0` pushes `Parent.Id < 0` onto
+    // the inner. Applied DURING inner materialisation, that contradictory
+    // seekable filter seeks the inner to an empty run — every `Id` is positive —
+    // so ZERO Parent rows are read and the query returns []. Before the fix the
+    // filter rode the residual ABOVE the join, so the whole inner was scanned and
+    // bucketed (three reads) before the filter matched none of it.
+    let reads = Counter()
+    let parent = [
+      Field(name: "Id", kind: .integer),
+      Field(name: "Code", kind: .integer),
+    ]
+    let parents = [
+      [.integer(1), .integer(10)],
+      [.integer(2), .integer(20)],
+      [.integer(3), .integer(30)],
+    ] as Array<Array<Value>>
+    let child = [
+      Field(name: "Code", kind: .integer),
+      Field(name: "Kid", kind: .text),
+    ]
+    let children = [
+      [.integer(10), .text("Ann")],
+      [.integer(20), .text("Bob")],
+    ] as Array<Array<Value>>
+    // `Parent` is sorted on `Id` (column 0), so `Id` seeks but the join key
+    // `Code` (column 1) does not — forcing the hash path.
+    let catalog = Memory([
+      "Parent": Relation(parent, parents, sorted: 0, counter: reads),
+      "Child": Relation(child, children),
+    ])
+    let rows = try Engine.run(parse("""
+        SELECT Child.Kid, Parent.Id FROM Child
+          JOIN Parent ON Parent.Code = Child.Code WHERE Parent.Id < 0
+        """), catalog)
+    #expect(rows.isEmpty)
+    #expect(reads.reads == 0)
   }
 }
 


### PR DESCRIPTION
This pull request introduces a significant optimization to the SQL engine by implementing selection (filter) pushdown and improving the execution of joins and products. The main changes include a new logical rewrite pass that pushes WHERE filters as close as possible to data sources, and a more efficient execution of filtered products and joins. These changes improve query performance and memory usage, especially for complex queries involving joins and filters.

The most important changes are:

**Selection Pushdown Optimization:**
- Added a `pushdown()` method to the `Plan` type that pushes each WHERE conjunct (filter condition) down to just above the relevant relation’s leaf in the query plan, ensuring relations are filtered as early as possible. This includes logic for distributing conjuncts, rebasing filters into derived views, and handling unions.
- Modified the main query execution path in `Engine.swift` to call the new `pushdown()` method after compiling the logical plan, before optimization.

**Filter Utilities:**
- Added `slots` and `shifted(by:)` computed properties/methods to `Filter`, which help selection pushdown determine which relation a filter applies to and to rebase slot references as needed.

**Efficient Product Execution:**
- Added a new `sift` function for executing a filtered product (Cartesian product under a filter) in a streaming fashion, avoiding materializing the full cross product in memory. The executor now fuses a residual product with its filter, only keeping rows that pass the filter. [[1]](diffhunk://#diff-90b051b6c59d5ca6612ebe0500cd6ccfecdec8f79c3c79167986ee4298fd0737R235-R240) [[2]](diffhunk://#diff-90b051b6c59d5ca6612ebe0500cd6ccfecdec8f79c3c79167986ee4298fd0737L371-R418)

**Join Execution Improvements:**
- Refactored join execution to select between index-nested-loop and hash join strategies based on whether the inner table’s join column is seekable. If not seekable, the inner table is scanned once into a hash map for efficient probing. [[1]](diffhunk://#diff-90b051b6c59d5ca6612ebe0500cd6ccfecdec8f79c3c79167986ee4298fd0737R429-R432) [[2]](diffhunk://#diff-90b051b6c59d5ca6612ebe0500cd6ccfecdec8f79c3c79167986ee4298fd0737R453-R499)

These changes together make the SQL engine more efficient and scalable, especially for queries with complex WHERE clauses and joins.