### PR TITLE
winmd-inspect: re-home the render's signature decode onto WinMD.Storage

### DIFF
--- a/Sources/winmd-inspect/Database+SQL.swift
+++ b/Sources/winmd-inspect/Database+SQL.swift
@@ -32,9 +32,9 @@ internal import WinMD
 ///
 /// Type spellings are *not* virtual columns: they are language-specific, so the
 /// adapter — the neutral conceptual layer — does not bake them. The render spells
-/// a return/parameter at render time through the free `decodedReturn`/
-/// `decodedParameter` functions, which navigate a method/parameter's signature
-/// and apply a target `Dialect`.
+/// a return/parameter at render time through the `WinMD.Storage`
+/// `decode(return:in:)`/`decode(parameter:for:)` methods, which navigate a
+/// method/parameter's signature and apply a target `Dialect`.
 ///
 /// Past the extras sit a relation's join keys, at ordinals `width + 1 + extras`
 /// onward — the columns a view equi-joins across. A list-owned table leads the
@@ -715,70 +715,70 @@ extension WinMD.Storage {
     }
     return nil
   }
-}
 
-/// The decoded type spelling of the return of the `MethodDef` at 1-based
-/// `method` `rowid`, in `dialect`, or `nil` when the row or its signature does
-/// not decode.
-///
-/// This is the signature-navigation the adapter once baked as the `ReturnType`
-/// virtual column, relocated so the render can spell a return at render time
-/// with a target `Dialect`: it opens the `MethodDef` row, decodes its
-/// `prototype` signature, builds a `Resolver` over the borrowed `storage`, and
-/// decodes the return. `nil` mirrors the old NULL — an absent row, an
-/// undecodable signature, or an unresolvable one.
-internal func decodedReturn(of method: Int, in storage: borrowing WinMD.Storage,
-                            dialect: Dialect) -> String? {
-  guard let table = storage.opened("MethodDef") else { return nil }
-  let cursor = WinMD.Cursor(copy storage, table)
-  guard let tuple = cursor[method - 1],
-      let row = Row<Metadata.Tables.MethodDef>(tuple),
-      let signature = try? row.prototype,
-      let resolver = try? Resolver(of: signature, with: storage) else {
-    return nil
+  /// The decoded type spelling of the return of the `MethodDef` at 1-based
+  /// `method` `rowid`, in `dialect`, or `nil` when the row or its signature
+  /// does not decode.
+  ///
+  /// This is the signature-navigation the adapter once baked as the
+  /// `ReturnType` virtual column, relocated so the render can spell a return at
+  /// render time with a target `Dialect`: it opens the `MethodDef` row, decodes
+  /// its `prototype` signature, builds a `Resolver` over the storage, and
+  /// decodes the return. `nil` mirrors the old NULL — an absent row, an
+  /// undecodable signature, or an unresolvable one.
+  internal borrowing func decode(return method: Int,
+                                 in dialect: Dialect) -> String? {
+    guard let table = opened("MethodDef") else { return nil }
+    let cursor = WinMD.Cursor(copy self, table)
+    guard let tuple = cursor[method - 1],
+        let row = Row<Metadata.Tables.MethodDef>(tuple),
+        let signature = try? row.prototype,
+        let resolver = try? Resolver(of: signature, with: self) else {
+      return nil
+    }
+    return signature.returns.decode(with: resolver, dialect: dialect)
   }
-  return signature.returns.decode(with: resolver, dialect: dialect)
-}
 
-/// The decoded type spelling of the `Param` at 1-based `parameter` `rowid`, in
-/// `dialect`, navigated through its owning method's signature — or `nil` when it
-/// does not decode.
-///
-/// This is the signature-navigation the adapter once baked as the `ParamType`
-/// virtual column, relocated so the render can spell a parameter at render time.
-/// The `Param.Sequence` cell is the 1-based parameter position: `Sequence == 0`
-/// is the return pseudo-parameter and `Sequence > parameters.count` is out of
-/// range, both `nil`. The owning `MethodDef` is found through the `Param` list
-/// link — an owner of zero is no parent (malformed/partial metadata), so the
-/// parameter is unowned and yields `nil` rather than indexing a negative row.
-/// The parameter's own `Name` is the `System.Guid` `IID`/`CLSID` hint; for any
-/// other type the decoder ignores it, so threading it is always safe.
-internal func decodedParameter(of parameter: Int,
-                               in storage: borrowing WinMD.Storage,
-                               dialect: Dialect) -> String? {
-  guard let table = storage.opened("Param") else { return nil }
-  let params = WinMD.Cursor(copy storage, table)
-  guard let param = params[parameter - 1],
-      let sequence = param.ordinal(for: "Sequence"),
-      let link = WinMDRelation.Link(storage, table) else {
-    return nil
+  /// The decoded type spelling of the `Param` at 1-based `parameter` `rowid`, in
+  /// `dialect`, navigated through its owning method's signature — or `nil` when
+  /// it does not decode.
+  ///
+  /// This is the signature-navigation the adapter once baked as the `ParamType`
+  /// virtual column, relocated so the render can spell a parameter at render
+  /// time. The `Param.Sequence` cell is the 1-based parameter position:
+  /// `Sequence == 0` is the return pseudo-parameter and `Sequence >
+  /// parameters.count` is out of range, both `nil`. The owning `MethodDef` is
+  /// found through the `Param` list link — an owner of zero is no parent
+  /// (malformed/partial metadata), so the parameter is unowned and yields `nil`
+  /// rather than indexing a negative row. The parameter's own `Name` is the
+  /// `System.Guid` `IID`/`CLSID` hint; for any other type the decoder ignores
+  /// it, so threading it is always safe.
+  internal borrowing func decode(parameter: Int,
+                                 for dialect: Dialect) -> String? {
+    guard let table = opened("Param") else { return nil }
+    let params = WinMD.Cursor(copy self, table)
+    guard let param = params[parameter - 1],
+        let sequence = param.ordinal(for: "Sequence"),
+        let link = WinMDRelation.Link(self, table) else {
+      return nil
+    }
+    let position = param[sequence]
+    let origin = owner(of: parameter - 1, link)
+    guard origin != 0 else { return nil }
+    let methods = WinMD.Cursor(copy self, link.parent)
+    guard let method = methods[origin - 1],
+        let row = Row<Metadata.Tables.MethodDef>(method),
+        let signature = try? row.prototype else {
+      return nil
+    }
+    guard position >= 1, position <= signature.parameters.count else {
+      return nil
+    }
+    guard let resolver = try? Resolver(of: signature, with: self) else {
+      return nil
+    }
+    let name = param.ordinal(for: "Name").flatMap { try? param.string($0) }
+    return signature.parameters[position - 1]
+        .decode(parameter: name, with: resolver, dialect: dialect)
   }
-  let position = param[sequence]
-  let owner = storage.owner(of: parameter - 1, link)
-  guard owner != 0 else { return nil }
-  let methods = WinMD.Cursor(copy storage, link.parent)
-  guard let method = methods[owner - 1],
-      let row = Row<Metadata.Tables.MethodDef>(method),
-      let signature = try? row.prototype else {
-    return nil
-  }
-  guard position >= 1, position <= signature.parameters.count else {
-    return nil
-  }
-  guard let resolver = try? Resolver(of: signature, with: storage) else {
-    return nil
-  }
-  let name = param.ordinal(for: "Name").flatMap { try? param.string($0) }
-  return signature.parameters[position - 1]
-      .decode(parameter: name, with: resolver, dialect: dialect)
 }

--- a/Sources/winmd-inspect/Shell.swift
+++ b/Sources/winmd-inspect/Shell.swift
@@ -286,7 +286,7 @@ internal struct Shell: ~Escapable {
     // The type spellings are decoded at render time from the spec's `Dialect`:
     // the adapter is language-neutral, so the render — not the binary's WinMD →
     // SQL layer — spells a return/parameter, navigating the signature with the
-    // free `decodedReturn`/`decodedParameter` functions.
+    // storage's `decode(return:in:)`/`decode(parameter:for:)` methods.
     let dialect = language.dialect
     // The rows to render come straight from the bundled selection query, bound
     // by `:name`: it returns the one named interface, or — for `*` — every one
@@ -326,8 +326,8 @@ internal struct Shell: ~Escapable {
                                     bindings: ["parent": method[0]])
         var parameters = Array<Dictionary<String, Any>>()
         for parameter in params where parameter[2] != .integer(0) {
-          let type = decodedParameter(of: parameter[0].integer,
-                                      in: session.storage, dialect: dialect)
+          let type = session.storage.decode(parameter: parameter[0].integer,
+                                            for: dialect)
           parameters.append([
             "name": parameter[1].text,
             "type": type ?? "",
@@ -346,8 +346,8 @@ internal struct Shell: ~Escapable {
         // The return, decoded at render time; a no-value return (the spec's
         // `void` spelling, or an undecodable return) leaves `returns` absent, so
         // the template's `{{#returns}}` clause renders nothing.
-        let returned = decodedReturn(of: method[0].integer, in: session.storage,
-                                     dialect: dialect)
+        let returned = session.storage.decode(return: method[0].integer,
+                                              in: dialect)
         if let returned, let clause = language.returned(returned) {
           entry["returns"] = clause
         }

--- a/Tests/winmd-inspectTests/DatabaseSQLTests.swift
+++ b/Tests/winmd-inspectTests/DatabaseSQLTests.swift
@@ -53,8 +53,8 @@ extension Dialect {
 }
 
 /// Coverage of the WinMD → SQL adapter's decoded `guid` virtual column on
-/// `CustomAttribute` and the render-time signature decode (`decodedReturn`/
-/// `decodedParameter`), which the adapter no longer bakes as `ReturnType`/
+/// `CustomAttribute` and the render-time signature decode (`decode(return:in:)`/
+/// `decode(parameter:for:)`), which the adapter no longer bakes as `ReturnType`/
 /// `ParamType` columns. Rather than map a `.winmd` file, the tests assemble a
 /// tiny COM
 /// interface in memory — a `TypeDef` carrying a `GuidAttribute` (through the
@@ -324,12 +324,12 @@ struct DatabaseSQLTests {
   }
 
   @Test("the render decode spells a method's return from its signature")
-  func decodedReturnHelper() {
+  func decodesReturn() {
     // The render decodes a return at render time (not through a virtual column):
     // `MethodDef` rowid 1's signature `void Method(i4, string)` decodes its
     // return to `Void`.
     DatabaseSQLTests.with { catalog in
-      #expect(decodedReturn(of: 1, in: catalog, dialect: .swift) == "Void")
+      #expect(catalog.decode(return: 1, in: .swift) == "Void")
     }
   }
 
@@ -419,7 +419,7 @@ struct DatabaseSQLTests {
     // The signature `void Method(i4, string)` decodes its return to `Void`, the
     // render-time decode replacing the old `ReturnType` virtual column.
     DatabaseSQLTests.with { catalog in
-      #expect(decodedReturn(of: 1, in: catalog, dialect: .swift) == "Void")
+      #expect(catalog.decode(return: 1, in: .swift) == "Void")
     }
   }
 
@@ -430,9 +430,9 @@ struct DatabaseSQLTests {
     // `i4` (`CInt`) and `string` (`HSTRING`) — the render-time decode replacing
     // the old `ParamType` virtual column.
     DatabaseSQLTests.with { catalog in
-      #expect(decodedParameter(of: 1, in: catalog, dialect: .swift) == nil)
-      #expect(decodedParameter(of: 2, in: catalog, dialect: .swift) == "CInt")
-      #expect(decodedParameter(of: 3, in: catalog, dialect: .swift)
+      #expect(catalog.decode(parameter: 1, for: .swift) == nil)
+      #expect(catalog.decode(parameter: 2, for: .swift) == "CInt")
+      #expect(catalog.decode(parameter: 3, for: .swift)
                   == "HSTRING")
     }
   }
@@ -797,7 +797,7 @@ struct DatabaseSQLTests {
     // has zero rows, so its owner resolves to 0 — decodes to `nil` rather than
     // indexing the negative row `owner - 1` through the parent cursor.
     UnownedParamFixture.with { catalog in
-      #expect(decodedParameter(of: 1, in: catalog, dialect: .swift) == nil)
+      #expect(catalog.decode(parameter: 1, for: .swift) == nil)
     }
   }
 
@@ -807,8 +807,8 @@ struct DatabaseSQLTests {
     // the render decode classifies each by the `Param.Name` hint — `clsid`
     // (rowid 2) yields `CLSID`, `iid` (rowid 3) yields the default `IID`.
     GuidParamFixture.with { catalog in
-      #expect(decodedParameter(of: 2, in: catalog, dialect: .swift) == "CLSID")
-      #expect(decodedParameter(of: 3, in: catalog, dialect: .swift) == "IID")
+      #expect(catalog.decode(parameter: 2, for: .swift) == "CLSID")
+      #expect(catalog.decode(parameter: 3, for: .swift) == "IID")
     }
   }
 
@@ -889,8 +889,8 @@ struct DatabaseSQLTests {
 
 /// A fixture whose `Param` row is owned by no `MethodDef` run: the `MethodDef`
 /// table is present (so the list link resolves to it) but has zero rows, so the
-/// owner of the lone `Param` resolves to 0. `decodedParameter` must then yield
-/// `nil` rather than index a negative `MethodDef` row.
+/// owner of the lone `Param` resolves to 0. `decode(parameter:for:)` must then
+/// yield `nil` rather than index a negative `MethodDef` row.
 private enum UnownedParamFixture {
   // Two narrow tables packed back to back. `MethodDef` contributes no records
   // (zero rows); `Param` contributes one.


### PR DESCRIPTION
The render spelled a return/parameter through two free functions, `decodedReturn(of:in:dialect:)` and `decodedParameter(of:in:dialect:)`, each taking the `WinMD.Storage` to navigate as an explicit `in storage:` parameter. Both are really operations ON a storage, and their compound names break the single-word rule for functions.

Re-home them as `borrowing` methods on `WinMD.Storage` — `decode(return:in:)` and `decode(parameter:for:)` — beside the existing `opened(_:)`, so `self` is the storage the navigation reads and the base name is the single word `decode`. The bodies are unchanged but for `storage` becoming `self` (and the shadowing `owner` local renamed `origin`); the render's two call sites and the `DatabaseSQLTests` coverage move to `session.storage.decode(…)` / `catalog.decode(…)`. No behavior change.