### PR TITLE
winmd-inspect: enhance shell for bind and template input

### DIFF
--- a/Sources/winmd-inspect/Query.swift
+++ b/Sources/winmd-inspect/Query.swift
@@ -23,6 +23,13 @@ internal import WinMD
 /// `.quit`'s `Shell.Stop` breaking the loop; the explicit-argument batch stays
 /// fail-fast, propagating a statement error (only `.quit`'s `Stop` is caught, to
 /// end cleanly).
+///
+/// The shell threads its `.bind` bindings into every SQL statement, so a
+/// parameterized query (`WHERE col = :name`) resolves its `:name` at the prompt.
+/// A `.template <name> '<body>'` defines a Mustache template inline: its body is
+/// a single-quoted (possibly multiline) literal the statement stream accumulates
+/// while its quote stays open, so `.end`, `;`, and `{{…}}` inside the body are
+/// data, not terminators — only a literal `'` needs doubling.
 internal struct Query: ParsableCommand {
   internal static var configuration: CommandConfiguration {
     CommandConfiguration(commandName: "query",

--- a/Sources/winmd-inspect/Shell.swift
+++ b/Sources/winmd-inspect/Shell.swift
@@ -192,6 +192,45 @@ internal struct Render: Metacommand {
   }
 }
 
+/// `.template <name> '<body>'` — define a Mustache template inline as a single-
+/// quoted (possibly multiline) string literal, then render through it.
+///
+/// A template is usually a file; this lets one be written at the prompt with no
+/// file and no magic terminator. `arguments` is `<name> '<body>'`: the name is
+/// the first whitespace-delimited token, the body the single-quoted literal that
+/// follows — from the first `'` to its matching close, with `''` unescaped to a
+/// literal `'`. Because the body is quote-delimited DATA, `.end`, `;`, `{{…}}`,
+/// and `"` all appear verbatim; only a literal `'` needs doubling. The stream's
+/// open-quote accumulation (`Statements`) hands the whole multiline block here as
+/// one statement. `execute` stores the body in the shell's `templates`, so a
+/// later `.render <iface> <name>` renders through it (shadowing a file); the body
+/// still declares its language with a leading `{{! language: … }}` directive, the
+/// same as a file template.
+internal struct Template: Metacommand {
+  internal static let spelling = ".template"
+
+  /// The template name — the first whitespace-delimited token of `arguments`.
+  internal let name: String
+
+  /// The template body — the single-quoted literal after the name, `''`
+  /// unescaped to a literal `'`. Empty when no quoted literal follows the name.
+  internal let body: String
+
+  internal init(_ arguments: Substring) {
+    let text = arguments.trimmed
+    let split = text.firstIndex(where: \.isWhitespace)
+    name = String(split.map { text[..<$0] } ?? text[...])
+    let rest = split.map { text[$0...].trimmed } ?? ""
+    body = unquote(rest)
+  }
+
+  internal func execute(against shell: inout Shell) throws {
+    guard !name.isEmpty else { throw Shell.MetaError.unknown(Template.spelling) }
+    shell.templates[name] = body
+    note("defined template \(name)")
+  }
+}
+
 // MARK: - Shell
 
 /// The interactive `query` shell — a `sqlite3`-style REPL — driving a `Session`.
@@ -219,6 +258,11 @@ internal struct Shell: ~Escapable {
   /// :name`) resolves. Empty initially; a `CREATE VIEW` ignores them, binding
   /// only when a later `SELECT` reads the view.
   internal var bindings: Bindings = [:]
+
+  /// The inline templates `.template` has defined, keyed by name. Empty
+  /// initially; `template(named:)` returns one when present, so an inline
+  /// template shadows a `-I` directory's file and the bundle for the session.
+  internal var templates: Dictionary<String, String> = [:]
 
   /// Whether a statement fault ends the run (an explicit batch) or is reported
   /// to stderr and skipped (the interactive/redirected shell). `.read` inherits
@@ -248,7 +292,8 @@ internal struct Shell: ~Escapable {
   /// computed so the metatype array (not `Sendable`) is not a shared mutable
   /// global.
   private static var commands: Array<any Metacommand.Type> {
-    [Tables.self, Help.self, Quit.self, Read.self, Render.self, Bind.self]
+    [Tables.self, Help.self, Quit.self, Read.self, Render.self, Bind.self,
+     Template.self]
   }
 
   /// The command summary `.help` prints.
@@ -257,6 +302,9 @@ internal struct Shell: ~Escapable {
     .read <path>            run a file of `;`-separated SQL statements
     .render <iface> <tmpl>  render an interface (or `*`) through a template
     .bind <name> <value>    bind a `:name` parameter (no value clears it)
+    .template <name> '…'    define an inline Mustache template (multiline
+                            single-quoted; `''` for a literal quote; declare
+                            the language with a leading `{{! language: … }}`)
     .help                   show this help
     .quit                   leave the shell
     <sql>                   run a SQL statement (trailing `;` optional)
@@ -366,7 +414,9 @@ internal struct Shell: ~Escapable {
     // <name> }}` directive; stripping it yields the body and loads the matching
     // spec, whose render UDFs (`ESCAPE`, `RETURNS`) make identifier escaping and
     // the no-value return the queries' concern, not the binary's.
-    var body = try Shell.template(named: template, search: search)
+    // `self.` disambiguates the `template(named:)` accessor from the `template`
+    // parameter that names the one to load.
+    var body = try self.template(named: template, search: search)
     let language = Shell.language(declaredIn: &body, search: search)
     let routines = language.routines
     // The type spellings are decoded at render time from the spec's `Dialect`:
@@ -467,15 +517,18 @@ internal struct Shell: ~Escapable {
     return sources.joined(separator: "\n")
   }
 
-  /// The text of the Mustache template named `name`, loaded through the search
-  /// path (a `-I` directory's `Templates/<name>.mustache`) then the bundled
-  /// `Resources/Templates/<name>.mustache`.
+  /// The text of the Mustache template named `name` — an inline template
+  /// `.template` registered when `templates` carries one, else loaded through the
+  /// search path (a `-I` directory's `Templates/<name>.mustache`) then the
+  /// bundled `Resources/Templates/<name>.mustache`.
   ///
-  /// The render's presentation tier is a named resource, not a literal: `com`
-  /// is the one bundled template (the `@com` protocol shape), and adding a
-  /// target later is dropping in another `.mustache` beside it — or shadowing
-  /// one through a `-I` directory — no code change. A name no search directory
-  /// and no bundle resolves raises `RenderError.template`.
+  /// An inline template shadows a file of the same name, so `.template com '…'`
+  /// overrides the bundled `com` for the session. Otherwise the render's
+  /// presentation tier is a named resource, not a literal: `com` is the one
+  /// bundled template (the `@com` protocol shape), and adding a target later is
+  /// dropping in another `.mustache` beside it — or shadowing one through a `-I`
+  /// directory — no code change. A name no inline template, search directory, and
+  /// bundle resolves raises `RenderError.template`.
   ///
   /// The `com` template emits the `@com` protocol style: a leading `{{! language:
   /// swift }}` directive naming its spec, the `@com(interface:)` attribute, `public
@@ -486,8 +539,9 @@ internal struct Shell: ~Escapable {
   /// presence (`{{#base}}`/`{{#returns}}`). Its interpolations are triple-mustache
   /// (`{{{…}}}`, raw) rather than double: the output is Swift source, not HTML, so
   /// the type spellings' angle brackets (`UnsafePointer<…>`) must not be escaped.
-  private static func template(named name: String,
-                               search: Array<String>) throws -> String {
+  internal borrowing func template(named name: String,
+                                   search: Array<String>) throws -> String {
+    if let inline = templates[name] { return inline }
     guard let url = resource(name, "mustache", kind: "Templates",
                              search: search)
     else { throw RenderError.template(name) }
@@ -593,6 +647,16 @@ private func resource(_ name: String, _ ext: String, kind: String,
 /// meta statement, or a SQL statement accumulated across lines until a
 /// terminating `;`. This is the `;`-accumulation the old loop did, lifted into
 /// an ordinary iterator so the driving is a literal `for`-in.
+///
+/// A `.`-meta whose single-quoted string is still OPEN (an unbalanced `'`) is
+/// the one exception to the whole-line rule: it accumulates subsequent RAW lines
+/// verbatim until the quote closes, yielding the whole block as one statement —
+/// the shape `.template <name> '<body>'` takes, a Mustache template written
+/// inline as a multiline single-quoted literal. Because the body is
+/// quote-delimited DATA, `.end`, `;`, and `{{…}}` inside it are verbatim, never
+/// a terminator; only a literal `'` needs doubling. The open-quote test is the
+/// same quote scan `terminator(in:)` runs (`''` an escaped quote), shared as
+/// `open(in:)`.
 internal struct Statements: Sequence {
   /// The line source — `readLine` for stdin, or a closure over a string's
   /// lines for the argument and `.read`.
@@ -648,11 +712,17 @@ internal struct Statements: Sequence {
 
     /// The next statement, or `nil` at end of input.
     ///
-    /// A `.`-meta line (when no statement is pending) yields whole. Otherwise
-    /// lines accumulate until a `;` closes a statement, which yields; a trailing
-    /// unterminated statement yields at end of input — the closing `;` is
-    /// optional, so a one-shot query or a file without a final terminator runs
-    /// its last statement.
+    /// A `.`-meta line (when no statement is pending) yields whole — unless its
+    /// single-quoted string is still OPEN (an unbalanced `'`), in which case it
+    /// begins a multiline meta whose subsequent RAW lines accumulate verbatim
+    /// (joined with `\n`, no `;`-splitting, no per-line `.`-meta handling) until
+    /// the quote closes, and the whole block yields as ONE statement; the inline
+    /// `.template <name> '<body>'` command is that shape, so `.end`, `;`, and
+    /// `{{…}}` inside the body are data, never a terminator. Otherwise lines
+    /// accumulate until a `;` closes a statement, which yields; a trailing
+    /// unterminated statement (or an unterminated multiline meta) yields at end
+    /// of input — the closing `;` is optional, so a one-shot query or a file
+    /// without a final terminator runs its last statement.
     internal mutating func next() -> String? {
       while true {
         // Drain any completed statement already accumulated.
@@ -675,13 +745,40 @@ internal struct Statements: Sequence {
         }
         // A `.`-meta line yields whole when no statement is pending — a
         // whitespace-only spacer line before it is nothing, so drop it rather
-        // than gluing the meta line onto it.
+        // than gluing the meta line onto it. `.template` alone carries a single-
+        // quoted (possibly multiline) body: when ITS quote is left open, keep
+        // accumulating raw lines until the quote closes, then yield the whole
+        // block as one statement. Every other meta yields whole, so an
+        // apostrophe in an argument — a `.read /tmp/O'Brien.sql` path — is data,
+        // not an unterminated literal that would swallow the following lines.
         if pending.trimmed.isEmpty, line.trimmed.first == "." {
-          pending = ""
-          return line.trimmed
+          let meta = line.trimmed
+          let spelling = meta.prefix { !$0.isWhitespace }
+          guard spelling == Template.spelling, Iterator.open(in: meta) else {
+            pending = ""
+            return meta
+          }
+          return accumulate(meta)
         }
         pending += pending.isEmpty ? line : "\n" + line
       }
+    }
+
+    /// Accumulates the `.template` block whose single-quoted body is open,
+    /// starting from `meta` (its first, trimmed line), reading RAW lines
+    /// verbatim (joined with `\n`, no `;`-splitting, no per-line `.`-meta
+    /// handling) until the quote closes, then yielding the whole block as one
+    /// statement. End of input before the quote closes flushes what was
+    /// captured — the closing `'` is as optional as a trailing `;`.
+    private mutating func accumulate(_ meta: String) -> String {
+      var block = meta
+      while Iterator.open(in: block) {
+        prompt?(true)
+        guard let line = lines() else { break }
+        block += "\n" + line
+      }
+      pending = ""
+      return block
     }
 
     /// The index in `text` of the first `;` that terminates a statement — one
@@ -689,30 +786,57 @@ internal struct Statements: Sequence {
     /// (including when `text` trails off inside a literal whose closing quote
     /// has not arrived yet). A `;` inside `'…'` is data, not a terminator, so
     /// the split matches what the SQL lexer scans (`''` is an escaped quote).
+    ///
+    /// It runs the same single-scan quote tracking `open(in:)` does — advancing
+    /// through `'…'` (a doubled `''` an escaped quote) — and returns the first
+    /// unquoted `;`, so both share one notion of what a literal is.
     private static func terminator(in text: String) -> String.Index? {
       var index = text.startIndex
       var quoted = false
       while index < text.endIndex {
-        let character = text[index]
-        if quoted {
-          // A doubled `''` is an escaped quote: consume it and stay inside the
-          // literal. A lone `'` closes the literal.
-          if character == "'" {
-            let next = text.index(after: index)
-            if next < text.endIndex, text[next] == "'" {
-              index = next
-            } else {
-              quoted = false
-            }
-          }
-        } else if character == "'" {
-          quoted = true
-        } else if character == ";" {
-          return index
-        }
+        if Iterator.scan(text, &index, &quoted) { continue }
+        if !quoted, text[index] == ";" { return index }
         index = text.index(after: index)
       }
       return nil
+    }
+
+    /// Whether `text` ends inside an unclosed single-quoted literal — the shared
+    /// quote-state scan lifted out so the multiline meta accumulation and
+    /// `terminator(in:)` reuse one implementation. A doubled `''` is an escaped
+    /// quote (it stays inside the literal); a lone `'` toggles. `false` when
+    /// every `'` is balanced, so the line stands complete.
+    private static func open(in text: String) -> Bool {
+      var index = text.startIndex
+      var quoted = false
+      while index < text.endIndex {
+        if Iterator.scan(text, &index, &quoted) { continue }
+        index = text.index(after: index)
+      }
+      return quoted
+    }
+
+    /// Advances the quote state at `index` in `text`: enters a literal on an
+    /// opening `'`, and inside one consumes a doubled `''` as an escaped quote
+    /// (skipping both) or closes on a lone `'`. Returns `true` when it already
+    /// advanced `index` past the pair (the caller must not step again), `false`
+    /// when `index` still points at the character to consider — the single point
+    /// both scans agree on what a single-quoted literal is.
+    private static func scan(_ text: String, _ index: inout String.Index,
+                             _ quoted: inout Bool) -> Bool {
+      let character = text[index]
+      if quoted {
+        guard character == "'" else { return false }
+        let next = text.index(after: index)
+        if next < text.endIndex, text[next] == "'" {
+          index = text.index(after: next)
+          return true
+        }
+        quoted = false
+      } else if character == "'" {
+        quoted = true
+      }
+      return false
     }
   }
 }

--- a/Sources/winmd-inspect/Shell.swift
+++ b/Sources/winmd-inspect/Shell.swift
@@ -87,6 +87,81 @@ internal struct Read: Metacommand {
   }
 }
 
+/// The body of the single-quoted literal `text` opens with — from its first
+/// `'` to the matching close, with a doubled `''` unescaped to one `'`. The
+/// empty string when `text` does not open with a `'`. A run past the close (a
+/// `'` not doubled) ends the body; any text after it is ignored.
+internal func unquote(_ text: String) -> String {
+  guard text.first == "'" else { return "" }
+  var body = ""
+  var index = text.index(after: text.startIndex)
+  while index < text.endIndex {
+    let character = text[index]
+    if character == "'" {
+      let next = text.index(after: index)
+      // A doubled `''` is one literal `'`; a lone `'` closes the body.
+      guard next < text.endIndex, text[next] == "'" else { break }
+      body.append("'")
+      index = text.index(after: next)
+      continue
+    }
+    body.append(character)
+    index = text.index(after: index)
+  }
+  return body
+}
+
+/// `.bind <name> <value>` — bind (or clear) a `:name` parameter the shell
+/// threads into every SQL statement it runs.
+///
+/// A parameterized query typed at the prompt (`WHERE col = :name`) needs its
+/// `:name` bound, which the shell has no other way to supply; `.bind` fills that
+/// gap. `arguments` is `<name> <value>`: the name is the first
+/// whitespace-delimited token, the value the trimmed remainder, typed as an
+/// `.integer` when it parses as an `Int`, else `.text` (a surrounding pair of
+/// single quotes stripped and a doubled `''` unescaped to one `'`, so
+/// `.bind s 'O''Hare'` binds the text `O'Hare`). A `.bind` with a name and no
+/// value removes that binding.
+internal struct Bind: Metacommand {
+  internal static let spelling = ".bind"
+
+  /// The parameter name — the first whitespace-delimited token of `arguments`.
+  internal let name: String
+
+  /// The value to bind, typed from the trimmed remainder — an `.integer` when it
+  /// parses as an `Int`, else `.text` (a surrounding single-quote pair stripped
+  /// and `''` unescaped to one `'`). `nil` when no value follows the name, which
+  /// clears the binding.
+  internal let value: Value?
+
+  internal init(_ arguments: Substring) {
+    let text = arguments.trimmed
+    let split = text.firstIndex(where: \.isWhitespace)
+    name = String(split.map { text[..<$0] } ?? text[...])
+    let remainder = split.map { text[$0...].trimmed } ?? ""
+    value = if remainder.isEmpty {
+      nil
+    } else if let integer = Int(remainder) {
+      .integer(integer)
+    } else if remainder.first == "'" {
+      .text(unquote(remainder))
+    } else {
+      .text(remainder)
+    }
+  }
+
+  internal func execute(against shell: inout Shell) throws {
+    guard !name.isEmpty else { throw Shell.MetaError.unknown(Bind.spelling) }
+    if let value {
+      shell.bindings[name] = value
+      note("bound :\(name) = \(value.display)")
+    } else {
+      shell.bindings[name] = nil
+      note("cleared :\(name)")
+    }
+  }
+}
+
 /// `.render <interface> <template>` — render a COM interface (or `*` for every
 /// interface) through a bundled Mustache template.
 internal struct Render: Metacommand {
@@ -127,7 +202,10 @@ internal struct Render: Metacommand {
 /// first token begins with `.` is a `Metacommand` looked up in `commands` and
 /// run; anything else is a SQL statement run through `Session.run` — a `CREATE
 /// VIEW` registers, a `SELECT` returns rows — whose rows the shell prints,
-/// without singling out `CREATE VIEW`. The streaming (`Statements`), the
+/// without singling out `CREATE VIEW`. The shell threads its `bindings` (set by
+/// `.bind`) into every SQL statement, so a parameterized query typed at the
+/// prompt (`WHERE col = :name`) resolves its `:name` from them. The streaming
+/// (`Statements`), the
 /// per-statement execution (`execute(_:)`), and the driving (the `for`-in in
 /// `Query.run` and `.read`) are three separate pieces — there is no loop
 /// abstraction. It is `~Escapable` because the `Session` it holds borrows the
@@ -135,6 +213,12 @@ internal struct Render: Metacommand {
 internal struct Shell: ~Escapable {
   /// The shell's mutable catalog state.
   internal var session: Session
+
+  /// The `:name` parameters `.bind` has set, threaded into every SQL statement
+  /// the shell runs so a parameterized query typed at the prompt (`WHERE col =
+  /// :name`) resolves. Empty initially; a `CREATE VIEW` ignores them, binding
+  /// only when a later `SELECT` reads the view.
+  internal var bindings: Bindings = [:]
 
   /// Whether a statement fault ends the run (an explicit batch) or is reported
   /// to stderr and skipped (the interactive/redirected shell). `.read` inherits
@@ -164,7 +248,7 @@ internal struct Shell: ~Escapable {
   /// computed so the metatype array (not `Sendable`) is not a shared mutable
   /// global.
   private static var commands: Array<any Metacommand.Type> {
-    [Tables.self, Help.self, Quit.self, Read.self, Render.self]
+    [Tables.self, Help.self, Quit.self, Read.self, Render.self, Bind.self]
   }
 
   /// The command summary `.help` prints.
@@ -172,6 +256,7 @@ internal struct Shell: ~Escapable {
     .tables                 list the database's tables
     .read <path>            run a file of `;`-separated SQL statements
     .render <iface> <tmpl>  render an interface (or `*`) through a template
+    .bind <name> <value>    bind a `:name` parameter (no value clears it)
     .help                   show this help
     .quit                   leave the shell
     <sql>                   run a SQL statement (trailing `;` optional)
@@ -206,12 +291,13 @@ internal struct Shell: ~Escapable {
   /// A statement whose leading token begins with `.` is a meta-command: the
   /// matching `Metacommand` type is built from the rest of the statement and
   /// run; an unknown `.`-token is a `MetaError.unknown`. Anything else is a SQL
-  /// statement, run through `Session.run` — a `CREATE VIEW` registers, a `SELECT`
-  /// yields rows — and its rows print tab-separated. The shell does not single
-  /// out `CREATE VIEW`: it just runs the statement and prints what comes back.
+  /// statement, run through `Session.run` with the shell's `bindings` — a `CREATE
+  /// VIEW` registers, a `SELECT` yields rows resolving any `:name` from the
+  /// bindings — and its rows print tab-separated. The shell does not single out
+  /// `CREATE VIEW`: it just runs the statement and prints what comes back.
   internal mutating func execute(_ statement: String) throws {
     guard statement.first == "." else {
-      for row in try session.run(statement.statement) {
+      for row in try session.run(statement.statement, bindings: bindings) {
         print(row.map(\.display).joined(separator: "\t"))
       }
       return
@@ -639,14 +725,19 @@ extension Session {
   /// (the key case-folded, the way the catalog resolves it) instead. `CREATE
   /// VIEW` is an ordinary statement here, not a special case; the shell prints
   /// whatever rows come back.
-  internal mutating func run(_ statement: String)
+  ///
+  /// `bindings` resolve a `SELECT`'s `:name` parameters — the shell threads its
+  /// `.bind` bindings through here, so a parameterized query typed at the prompt
+  /// finds its values. A `CREATE VIEW` ignores them: it stores the view's text,
+  /// binding only when a later `SELECT` reads it.
+  internal mutating func run(_ statement: String, bindings: Bindings = [:])
       throws -> Array<Array<Value>> {
     switch try Statement(parsing: statement) {
     case let .create(name, view):
       register(name, view)
       return []
     case let .select(query):
-      return try Engine.run(query, self)
+      return try Engine.run(query, self, bindings: bindings)
     }
   }
 }

--- a/Tests/winmd-inspectTests/DatabaseSQLTests.swift
+++ b/Tests/winmd-inspectTests/DatabaseSQLTests.swift
@@ -696,6 +696,37 @@ struct DatabaseSQLTests {
     }
   }
 
+  @Test("a `.template` registers an inline body that shadows a file lookup")
+  func templateRegisters() throws {
+    // `.template` stores its body in the shell's `templates`, and
+    // `template(named:)` returns it (unescaped) when present — an inline
+    // template shadows the `-I`/bundle resolution. Registering `com` (the one
+    // bundled template) with an inline body proves the shadow: the resolver
+    // returns the inline text, not the bundled file.
+    try DatabaseSQLTests.with { catalog in
+      var shell = Shell(catalog)
+      try shell.execute(".template com 'inline: it''s {{name}}'")
+      #expect(shell.templates["com"] == "inline: it's {{name}}")
+      // The resolver returns the inline body verbatim, shadowing the bundle.
+      #expect(try shell.template(named: "com", search: []) ==
+              "inline: it's {{name}}")
+    }
+  }
+
+  @Test("a `.render` through an inline template renders the interface")
+  func templateRenders() throws {
+    // The end-to-end pipeline: define an inline template, then `.render` an
+    // interface through it. The fixture's `IMyInterface` renders through a
+    // minimal inline template (no language directive — the identity language
+    // leaves the body verbatim), proving the inline template feeds the render.
+    try DatabaseSQLTests.with { catalog in
+      var shell = Shell(catalog)
+      try shell.execute(".template mine 'interface {{name}}'")
+      let rendered = try shell.render("IMyInterface", template: "mine")
+      #expect(rendered == "interface IMyInterface")
+    }
+  }
+
   @Test("execute routes a `.`-token to its meta-command")
   func executeMeta() throws {
     // The leading-token dispatch matches `.tables` to `Tables`, which lists the

--- a/Tests/winmd-inspectTests/DatabaseSQLTests.swift
+++ b/Tests/winmd-inspectTests/DatabaseSQLTests.swift
@@ -667,6 +667,35 @@ struct DatabaseSQLTests {
     }
   }
 
+  @Test("a `.bind` value threads into a later parameterized SELECT")
+  func bindThreadsIntoQuery() throws {
+    // `.bind` stores a `:name` in the shell's `bindings`, which `execute`'s SQL
+    // path forwards to `Session.run(_, bindings:)`. Binding `:name` to a
+    // `TypeName` the fixture carries, then running `WHERE TypeName = :name`
+    // through the session with those bindings, returns the one matching row —
+    // the exact thread `execute` performs. An unbound `:name` is UNKNOWN, so it
+    // admits no row.
+    try DatabaseSQLTests.with { catalog in
+      var shell = Shell(catalog)
+      try shell.execute(".bind name 'IMyInterface'")
+      #expect(shell.bindings["name"] == .text("IMyInterface"))
+      let query = "SELECT TypeName FROM TypeDef WHERE TypeName = :name"
+      let rows = try shell.session.run(query, bindings: shell.bindings)
+      #expect(rows == [[.text("IMyInterface")]])
+      // The other fixture type does not match the binding, so it is excluded.
+      try shell.execute(".bind name 'INotGuid'")
+      let others = try shell.session.run(query, bindings: shell.bindings)
+      #expect(others == [[.text("INotGuid")]])
+      // Clearing the binding (a `.bind` with no value) unbinds `:name`. An
+      // unbound parameter is UNKNOWN, not a value, so the predicate admits no
+      // row — the same query now yields nothing rather than matching a type.
+      try shell.execute(".bind name")
+      #expect(shell.bindings["name"] == nil)
+      let unbound = try shell.session.run(query, bindings: shell.bindings)
+      #expect(unbound.isEmpty)
+    }
+  }
+
   @Test("execute routes a `.`-token to its meta-command")
   func executeMeta() throws {
     // The leading-token dispatch matches `.tables` to `Tables`, which lists the

--- a/Tests/winmd-inspectTests/ShellTests.swift
+++ b/Tests/winmd-inspectTests/ShellTests.swift
@@ -20,6 +20,7 @@ struct ShellTests {
     #expect(Read.spelling == ".read")
     #expect(Render.spelling == ".render")
     #expect(Bind.spelling == ".bind")
+    #expect(Template.spelling == ".template")
   }
 
   @Test("`.read` parses its trailing path, trimming surrounding whitespace")
@@ -65,6 +66,26 @@ struct ShellTests {
     #expect(Bind(" n").name == "n")
     #expect(Bind(" n").value == nil)
     #expect(Bind("  ").name.isEmpty)
+  }
+
+  @Test("`.template` parses its name and unquotes the single-quoted body")
+  func template() {
+    // `Template.init` takes the name (the first whitespace token) then the
+    // single-quoted literal that follows, from its first `'` to the matching
+    // close, `''` unescaped to one `'`.
+    let simple = Template("t 'hello'")
+    #expect(simple.name == "t")
+    #expect(simple.body == "hello")
+    // A `''` inside the body round-trips to one `'`.
+    #expect(Template("t 'it''s'").body == "it's")
+    // The body is data: `.end`, `;`, `{{…}}`, and `\"` are all verbatim.
+    #expect(Template("t '.end; {{x}} \"q\"'").body == ".end; {{x}} \"q\"")
+    // A multiline literal keeps its newlines; the stream has already handed the
+    // whole block over as one statement.
+    #expect(Template("t 'a\nb'").body == "a\nb")
+    // A name with no quoted literal leaves an empty body.
+    #expect(Template("t").name == "t")
+    #expect(Template("t").body.isEmpty)
   }
 
   @Test("a `;`-separated script streams into trimmed, non-empty statements")
@@ -113,6 +134,67 @@ struct ShellTests {
             == ["SELECT 'a;''b;' AS s"])
     #expect(Array(Statements(of: "SELECT 'x;\n y;' AS s;"))
             == ["SELECT 'x;\n y;' AS s"])
+  }
+
+  @Test("an open-quote `.`-meta accumulates raw lines into one statement")
+  func streamOpenQuoteMeta() {
+    // A `.`-meta whose single-quoted string is still open is a multiline meta:
+    // the stream accumulates raw lines verbatim (joined with `\n`) until the
+    // quote closes, then yields the whole block as ONE statement — the inline
+    // `.template <name> '<body>'` shape. Because the body is quote-delimited
+    // DATA, a `.end` line and a `;` INSIDE it do NOT terminate the block (no
+    // sentinel collision), and the following `SELECT 1;` stays a separate
+    // statement. A `''` in the body is left verbatim in the meta (the command's
+    // `init` unescapes it), so the whole literal round-trips.
+    let script = """
+      .template t '{{! language: swift }}
+      protocol {{name}} {
+      .end is data; not a terminator; it''s fine
+      }'
+      SELECT 1;
+      """
+    let statements = Array(Statements(of: script))
+    #expect(statements.count == 2)
+    #expect(statements[0] == """
+      .template t '{{! language: swift }}
+      protocol {{name}} {
+      .end is data; not a terminator; it''s fine
+      }'
+      """)
+    #expect(statements[1] == "SELECT 1")
+  }
+
+  @Test("an open-quote meta with a trailing-line close still yields one block")
+  func streamOpenQuoteReading() {
+    // Fed line-by-line (the interactive/`reading:` path), the same accumulation
+    // holds: the closing `'` arriving on its own trailing line still yields the
+    // whole `.template` block as one statement, and the following `SELECT 1`
+    // stays separate. End-of-input flushes even without the trailing statement.
+    var lines = ["  .template t 'first", "  ; second", "third'",
+                 "SELECT 1"].makeIterator()
+    let statements = Array(Statements(reading: { lines.next() }))
+    #expect(statements.count == 2)
+    #expect(statements[0] == ".template t 'first\n  ; second\nthird'")
+    #expect(statements[1] == "SELECT 1")
+  }
+
+  @Test("an unclosed open-quote meta flushes at end of input")
+  func streamOpenQuoteUnterminated() {
+    // End of input before the quote closes flushes what was captured — the
+    // closing `'` is as optional as a trailing `;`.
+    #expect(Array(Statements(of: ".template t 'unterminated\nbody"))
+            == [".template t 'unterminated\nbody"])
+  }
+
+  @Test("only `.template` accumulates on an open quote; other metas yield whole")
+  func streamOpenQuoteTemplateOnly() {
+    // The open-quote accumulation is `.template`'s alone. An apostrophe in
+    // another meta-command's argument — the path in `.read /tmp/O'Brien.sql` —
+    // is data, not an unterminated literal: the `.read` yields whole and the
+    // following statement stays separate, rather than being swallowed as more
+    // of the path.
+    #expect(Array(Statements(of: ".read /tmp/O'Brien.sql\nSELECT 1;"))
+            == [".read /tmp/O'Brien.sql", "SELECT 1"])
   }
 
   @Test("a whitespace-only spacer line before a `.`-command is dropped")

--- a/Tests/winmd-inspectTests/ShellTests.swift
+++ b/Tests/winmd-inspectTests/ShellTests.swift
@@ -19,6 +19,7 @@ struct ShellTests {
     #expect(Quit.spelling == ".quit")
     #expect(Read.spelling == ".read")
     #expect(Render.spelling == ".render")
+    #expect(Bind.spelling == ".bind")
   }
 
   @Test("`.read` parses its trailing path, trimming surrounding whitespace")
@@ -41,6 +42,29 @@ struct ShellTests {
     #expect(render.template == "com")
     #expect(Render("IFoo").interface.isEmpty)
     #expect(Render("").template.isEmpty)
+  }
+
+  @Test("`.bind` parses its name and types its value")
+  func bind() {
+    // `Bind.init` takes the name (the first whitespace token) and the trimmed
+    // remainder as the value, typed: an `Int`-parsable value is an `.integer`,
+    // else `.text` with a surrounding single-quote pair stripped and a doubled
+    // `''` unescaped to one `'`.
+    #expect(Bind(" n 42").name == "n")
+    #expect(Bind(" n 42").value == .integer(42))
+    #expect(Bind(" s hello").value == .text("hello"))
+    #expect(Bind(" s 'hello world' ").value == .text("hello world"))
+    // A quoted numeral stays text — the quotes force the `.text` reading over
+    // the `Int` parse.
+    #expect(Bind("s '42'").value == .text("42"))
+    // A doubled `''` inside the quotes is one literal `'`, so the advertised
+    // single-quoted form binds an apostrophe rather than storing two quotes —
+    // otherwise `WHERE Name = :name` never matches a row holding `O'Hare`.
+    #expect(Bind("s 'O''Hare'").value == .text("O'Hare"))
+    // A name with no value clears the binding — `value` is nil.
+    #expect(Bind(" n").name == "n")
+    #expect(Bind(" n").value == nil)
+    #expect(Bind("  ").name.isEmpty)
   }
 
   @Test("a `;`-separated script streams into trimmed, non-empty statements")


### PR DESCRIPTION
This pull request adds two major new features to the `winmd-inspect` shell: support for binding named SQL parameters at the prompt using a new `.bind` command, and the ability to define inline Mustache templates interactively with a new `.template` command. It also refactors the shell to thread parameter bindings into every SQL statement and allows inline templates to shadow file-based templates. Additionally, the statement parser is enhanced to support multiline meta-commands, notably for the new `.template` feature.

**New shell features:**

* Added `.bind <name> <value>` command to bind or clear named SQL parameters (`:name`) for use in parameterized queries typed at the prompt. These bindings are threaded into every SQL statement the shell runs. [[1]](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425R90-R139) [[2]](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425L130-R246) [[3]](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425L642-R859) [[4]](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425L209-R347) [[5]](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425R255-R265) [[6]](diffhunk://#diff-18faad7c0e5648c6a8354dd72204a68cb674d3a7ec5a7fde805a3c6d7b5350c4R26-R32)
* Added `.template <name> '<body>'` command to define an inline Mustache template as a single-quoted (possibly multiline) string literal. Inline templates can be rendered later and shadow file-based templates for the session. [[1]](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425R170-R232) [[2]](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425L130-R246) [[3]](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425L384-R530) [[4]](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425L403-R543)

**Shell and statement parsing improvements:**

* Enhanced the statement parser to support multiline meta-commands whose single-quoted string is open, accumulating lines verbatim until the quote closes. This allows `.template` bodies to include any content, including `;`, `.end`, and Mustache tags, without premature termination. [[1]](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425R649-R658) [[2]](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425L565-R724) [[3]](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425L592-R834)
* Updated help text and command registration to include the new `.bind` and `.template` commands.

**Template resolution changes:**

* Refactored template resolution so that inline templates defined via `.template` take precedence over file-based and bundled templates when rendering. [[1]](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425L384-R530) [[2]](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425L403-R543)

These changes make the shell more powerful and flexible for interactive use, especially when working with parameterized queries and custom template rendering.