### PR TITLE
SQL: support CTEs

### DIFF
--- a/Sources/SQL/AST.swift
+++ b/Sources/SQL/AST.swift
@@ -24,6 +24,45 @@ public enum Statement: Hashable, Sendable {
   /// projection). A consumer registers the `View` under `name` in a catalog so
   /// a later `SELECT … FROM name` resolves it.
   case create(name: String, view: View)
+  /// A `WITH [RECURSIVE] cte (, cte)* query`: the common table expressions
+  /// `ctes`, in source order, scoping the trailing `query`. Each `CTE` binds a
+  /// named relation the `query` — and a later `CTE` — may name; the engine
+  /// materialises them in order into an overlay catalog the `query` runs
+  /// against.
+  case with(ctes: Array<CTE>, query: Query)
+}
+
+/// A common table expression — a query bound to a name for the duration of the
+/// enclosing statement.
+///
+/// `name` is the relation name the trailing query (and a later `CTE`) resolves
+/// against; `columns` names its columns in projection order — explicit from a
+/// `(c, …)` list, else inferred from the query's first arm exactly as a view's
+/// are. A `recursive` CTE names itself in its own `query` (which must be a
+/// `UNION` of an anchor and a recursive arm); a non-recursive one does not. The
+/// CTE is fully escapable data — the engine materialises its `query` into an
+/// in-memory relation and resolves the name to it.
+public struct CTE: Hashable, Sendable {
+  /// The relation name the CTE binds.
+  public let name: String
+
+  /// The CTE's column names, in projection order.
+  public let columns: Array<String>
+
+  /// The query the CTE stands for.
+  public let query: Query
+
+  /// Whether the CTE is recursive — a `WITH RECURSIVE` member that may name
+  /// itself in its own `query`.
+  public let recursive: Bool
+
+  public init(name: String, columns: Array<String>, query: Query,
+              recursive: Bool) {
+    self.name = name
+    self.columns = columns
+    self.query = query
+    self.recursive = recursive
+  }
 }
 
 /// A query: one `SELECT`, or several combined left-associatively with `UNION`.

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -40,9 +40,143 @@ public enum Engine {
                                                   _ routines: Routines = [:],
                                                   bindings: Bindings = [:])
       throws(SQLError) -> Array<Array<Value>> {
-    let logical = try compile(query, catalog).pushdown()
-    let plan = try optimise(logical, catalog, bindings)
-    return try execute(plan, catalog, routines, bindings).map(\.values)
+    try run(query, catalog, [:], routines, bindings)
+  }
+
+  /// Runs `query` against `catalog` with the common table expressions `ctes` in
+  /// scope (empty for a query with no `WITH`), the resolution phases consulting
+  /// `ctes` before the base catalog.
+  internal static func run<C: Catalog & ~Escapable>(_ query: Query,
+                                                    _ catalog: borrowing C,
+                                                    _ ctes: CTEs,
+                                                    _ routines: Routines,
+                                                    _ bindings: Bindings)
+      throws(SQLError) -> Array<Array<Value>> {
+    let logical = try compile(query, catalog, ctes).pushdown()
+    let plan = try optimise(logical, catalog, ctes, bindings)
+    return try execute(plan, catalog, ctes, routines, bindings).map(\.values)
+  }
+
+  /// Runs a `Statement` against `catalog`, returning its result rows.
+  ///
+  /// A `select` runs its query directly; a `with` materialises its common table
+  /// expressions, in source order, into the `CTEs` the trailing query resolves
+  /// against (see `with`). A `create` defines a view rather than producing
+  /// rows, so it is not runnable and faults with `SQLError.statement`.
+  public static func run<C: Catalog & ~Escapable>(_ statement: Statement,
+                                                  _ catalog: borrowing C,
+                                                  _ routines: Routines = [:],
+                                                  bindings: Bindings = [:])
+      throws(SQLError) -> Array<Array<Value>> {
+    switch statement {
+    case let .select(query):
+      try run(query, catalog, [:], routines, bindings)
+    case let .with(ctes, query):
+      try with(ctes, query, catalog, routines, bindings)
+    case .create:
+      throw .statement("CREATE VIEW defines a view rather than producing rows")
+    }
+  }
+
+  // MARK: - WITH
+
+  /// Materialises the common table expressions `ctes`, in source order, into
+  /// the `CTEs` map and runs the trailing `query` against the base `catalog`
+  /// with that map in scope.
+  ///
+  /// Each CTE materialises against the base `catalog` plus every EARLIER CTE,
+  /// so a CTE may name one defined before it (chained CTEs); a CTE name shadows
+  /// a base relation of the same name (the resolver consults the map first). A
+  /// recursive CTE — one that names itself in its own query — iterates a
+  /// fixpoint (see `fixpoint`); every other CTE, including one a `WITH
+  /// RECURSIVE` marks recursive but which does not reference itself, runs its
+  /// query once and captures its rows. The fully materialised relations then
+  /// resolve the trailing query, run through the same `routines` and
+  /// `bindings`.
+  ///
+  /// Each CTE's body must project exactly the arity its column list declares —
+  /// the resolver advertises `cte.columns.count` columns, so a body of a
+  /// different width would index out of bounds when a later query reads it. The
+  /// body's width is known once it compiles (a `SELECT *` resolves its extent
+  /// against the relations in scope), so its compiled `Plan.width` is checked
+  /// against the declared count BEFORE the CTE materialises — regardless of how
+  /// many rows the body yields. A body filtered to zero rows still faults with
+  /// `SQLError.columns`, where a per-row check would pass it through vacuously.
+  internal static func with<C: Catalog & ~Escapable>(_ ctes: Array<CTE>,
+                                                     _ query: Query,
+                                                     _ catalog: borrowing C,
+                                                     _ routines: Routines,
+                                                     _ bindings: Bindings)
+      throws(SQLError) -> Array<Array<Value>> {
+    var relations = CTEs()
+    for cte in ctes {
+      // A query name repeated in the list (case-insensitively) would silently
+      // shadow the earlier binding in `relations`, so reject it rather than
+      // overwrite — a typo in a multi-CTE query must not change the result.
+      guard relations[cte.name.lowercased()] == nil else {
+        throw .redefinition(cte.name)
+      }
+      // A CTE that names itself iterates a fixpoint; every other one — a
+      // non-recursive CTE, or one a `WITH RECURSIVE` marks recursive but which
+      // does not reference itself — runs its query once. Each resolves against
+      // the base catalog plus the CTEs done so far, its body's compiled width
+      // checked against the declared columns first.
+      let rows: Array<Array<Value>>
+      if cte.recursive && recursive(cte) {
+        rows = try fixpoint(cte, catalog, relations, routines, bindings)
+      } else {
+        let width = try compile(cte.query, catalog, relations).width
+        guard width == cte.columns.count else {
+          throw .columns(expected: cte.columns.count, got: width)
+        }
+        rows = try run(cte.query, catalog, relations, routines, bindings)
+      }
+      relations[cte.name.lowercased()] =
+          Materialised(columns: cte.columns, rows: rows)
+    }
+    return try run(query, catalog, relations, routines, bindings)
+  }
+
+  /// Whether `cte` actually references itself — the test the fixpoint routing
+  /// turns on, distinct from the syntactic `recursive` flag a `WITH RECURSIVE`
+  /// stamps on every member.
+  ///
+  /// The parser marks each member of a `WITH RECURSIVE` list recursive whether
+  /// or not it names itself, but only a self-referential CTE has a recursive arm
+  /// to iterate; running a non-self-referential one through the fixpoint would
+  /// re-evaluate an arm that never reads the CTE, repeating its rows without end
+  /// (a `UNION ALL`) or needlessly (a `UNION`). A CTE is recursive in truth when
+  /// its recursive arm — the right member of the top-level `UNION`, the one the
+  /// fixpoint compiles with the CTE bound — names `cte.name` in a `FROM`/`JOIN`.
+  /// The anchor is the base case, compiled with the name NOT in scope, so a
+  /// `FROM <name>` there reads a base relation of that name, not the CTE.
+  /// Scanning the anchor too would misroute `WITH RECURSIVE Parent(Id) AS
+  /// (SELECT Id FROM Parent UNION ALL SELECT Id FROM Extra)` — whose anchor
+  /// merely reads the same-named base — into the fixpoint.
+  private static func recursive(_ cte: CTE) -> Bool {
+    guard case let .union(_, arm, _) = cte.query else { return false }
+    return references(arm, cte.name.lowercased())
+  }
+
+  /// Whether `select` names the relation `name` (case-folded) in its `FROM` or
+  /// any `JOIN`.
+  private static func references(_ select: Select, _ name: String) -> Bool {
+    if select.from?.name.lowercased() == name { return true }
+    return select.joins.contains { $0.relation.name.lowercased() == name }
+  }
+
+  /// Evaluates a recursive `cte` to a fixpoint over `catalog` with the earlier
+  /// `ctes` in scope.
+  ///
+  /// Not yet implemented — the fixpoint loop lands in a later phase; a recursive
+  /// CTE faults until then.
+  internal static func fixpoint<C: Catalog & ~Escapable>(_ cte: CTE,
+                                                         _ catalog: borrowing C,
+                                                         _ ctes: CTEs,
+                                                         _ routines: Routines,
+                                                         _ bindings: Bindings)
+      throws(SQLError) -> Array<Array<Value>> {
+    throw .statement("recursive WITH is not yet supported")
   }
 
   // MARK: - Compilation
@@ -59,24 +193,27 @@ public enum Engine {
   /// count as the chain's first `SELECT` — the result columns — else
   /// `SQLError.arity`.
   internal static func compile<C: Catalog & ~Escapable>(_ query: Query,
-                                                        _ catalog: borrowing C)
+                                                        _ catalog: borrowing C,
+                                                        _ ctes: CTEs = [:])
       throws(SQLError) -> Plan {
     guard case let .union(left, select, all) = query else {
-      return try compile(query.first, catalog)
+      return try compile(query.first, catalog, ctes)
     }
 
-    let width = try arity(query.first, catalog)
-    let count = try arity(select, catalog)
+    let width = try arity(query.first, catalog, ctes)
+    let count = try arity(select, catalog, ctes)
     guard count == width else { throw .arity(width, count) }
-    return try .union(compile(left, catalog), compile(.select(select), catalog),
-                      all: all)
+    return try .union(compile(left, catalog, ctes),
+                      compile(.select(select), catalog, ctes), all: all)
   }
 
   /// The number of result columns `select` projects — the extent of a `*` over
   /// its relations, else the count of its projected items — for the `UNION`
-  /// arity check. The relations resolve through the borrowed `catalog`.
+  /// arity check. The relations resolve through the borrowed `catalog`, the
+  /// `ctes` consulted first.
   private static func arity<C: Catalog & ~Escapable>(_ select: Select,
-                                                     _ catalog: borrowing C)
+                                                     _ catalog: borrowing C,
+                                                     _ ctes: CTEs)
       throws(SQLError) -> Int {
     switch select.projection {
     case .all:
@@ -84,9 +221,9 @@ public enum Engine {
       guard let relation = select.from else {
         throw .named("SELECT * with no FROM")
       }
-      var width = try resolve(relation, catalog).schema.width
+      var width = try resolve(relation, catalog, ctes).schema.width
       for join in select.joins {
-        try width += resolve(join.relation, catalog).schema.width
+        try width += resolve(join.relation, catalog, ctes).schema.width
       }
       return width
     case let .columns(columns):
@@ -120,7 +257,8 @@ public enum Engine {
   /// `Scan(_, _, nil)`; the optimiser turns scans into seeks and each product
   /// into a join.
   internal static func compile<C: Catalog & ~Escapable>(_ select: Select,
-                                                        _ catalog: borrowing C)
+                                                        _ catalog: borrowing C,
+                                                        _ ctes: CTEs = [:])
       throws(SQLError) -> Plan {
     guard let relation = select.from else {
       // A FROM-less select projects expressions over a single row; a `WHERE`,
@@ -133,7 +271,7 @@ public enum Engine {
       }
       return try scalar(select.projection)
     }
-    let from = try resolve(relation, catalog)
+    let from = try resolve(relation, catalog, ctes)
 
     guard !select.joins.isEmpty else {
       var filter: Filter? = nil
@@ -162,7 +300,7 @@ public enum Engine {
     var joined = Array<Resolved>()
     joined.reserveCapacity(select.joins.count)
     for join in select.joins {
-      try joined.append(resolve(join.relation, catalog))
+      try joined.append(resolve(join.relation, catalog, ctes))
     }
 
     var relations = [(relation, from.schema)]
@@ -269,12 +407,25 @@ public enum Engine {
     let leaf: (Array<Int>) -> Plan
   }
 
-  /// Resolves a `Relation` against `catalog` to its schema and leaf factory.
+  /// Resolves a `Relation` against `catalog` and the in-scope `ctes` to its
+  /// schema and leaf factory.
   ///
-  /// A view shadows a base table of the same name: the catalog is consulted for
-  /// a view first, its `select` compiled to a sub-plan and wrapped in a
-  /// `derived` leaf; otherwise a base table resolves and scans. A name neither
-  /// resolves is `SQLError.relation`.
+  /// A common table expression shadows a base relation of the same name:
+  /// `ctes` is consulted first, a CTE resolving to its materialised schema and
+  /// a `scan` leaf (the executor materialises its records from the rows). Else
+  /// a view shadows a base table — its `select` compiled to a sub-plan in a
+  /// `derived` leaf — and finally a base table scans. A name none resolves is
+  /// `SQLError.relation`.
+  ///
+  /// A view's body compiles OUTSIDE the statement's CTE scope — with an empty
+  /// CTE map, not the caller's `ctes` — so a stored view means exactly what it
+  /// was registered to mean regardless of the `WITH` a caller wraps around it. A
+  /// name that IS a statement CTE has already resolved above (a CTE shadows a
+  /// view, as it shadows a base table), so a name reaching the view branch is
+  /// genuinely a view; letting its body see the caller's CTEs would let an
+  /// unrelated statement-local `WITH Parent AS …` reach into a view whose own
+  /// `FROM Parent` must mean the base relation. The view's `FROM`/`JOIN` names
+  /// therefore resolve against the base catalog (and other views) alone.
   ///
   /// A view's `columns` must name exactly one column per value its query
   /// projects, or the view's schema would let a query index past a sub-plan row.
@@ -282,26 +433,33 @@ public enum Engine {
   /// this is the backstop for a `SELECT *` view, whose width is known only here,
   /// after the sub-plan compiles — a mismatch is `SQLError.columns`.
   private static func resolve<C: Catalog & ~Escapable>(_ relation: Relation,
-                                                       _ catalog: borrowing C)
+                                                       _ catalog: borrowing C,
+                                                       _ ctes: CTEs)
       throws(SQLError) -> Resolved {
-    if let view = catalog.view(named: relation.name) {
-      let plan = try compile(view.query, catalog)
+    let name = relation.name
+    if let cte = ctes[name.lowercased()] {
+      let schema = cte.schema()
+      return Resolved(schema: schema) { ordinals in
+        .scan(name: name, ordinals: ordinals, seek: nil)
+      }
+    }
+
+    if let view = catalog.view(named: name) {
+      let plan = try compile(view.query, catalog, [:])
       let projected = plan.width
       guard view.columns.count == projected else {
         throw .columns(expected: projected, got: view.columns.count)
       }
       let schema = view.schema()
       return Resolved(schema: schema) { ordinals in
-        .derived(name: relation.name, plan: plan, ordinals: ordinals,
-                 seek: nil)
+        .derived(name: name, plan: plan, ordinals: ordinals, seek: nil)
       }
     }
 
-    guard let table = catalog.table(named: relation.name) else {
-      throw .relation(relation.name)
+    guard let table = catalog.table(named: name) else {
+      throw .relation(name)
     }
     let schema = table.schema()
-    let name = relation.name
     return Resolved(schema: schema) { ordinals in
       .scan(name: name, ordinals: ordinals, seek: nil)
     }
@@ -372,6 +530,16 @@ public enum Engine {
                                                          _ catalog: borrowing C,
                                                          _ bindings: Bindings)
       throws(SQLError) -> Plan {
+    try optimise(plan, catalog, [:], bindings)
+  }
+
+  /// Rewrites `plan` into a physical one with the in-scope `ctes` (consulted
+  /// before the base `catalog` for seekability) and `bindings`.
+  internal static func optimise<C: Catalog & ~Escapable>(_ plan: Plan,
+                                                         _ catalog: borrowing C,
+                                                         _ ctes: CTEs,
+                                                         _ bindings: Bindings)
+      throws(SQLError) -> Plan {
     switch plan {
     case .single:
       plan
@@ -380,31 +548,34 @@ public enum Engine {
     case let .derived(name, plan, ordinals, seek):
       // Optimise the view's sub-plan with the bindings so a bound predicate
       // inside the view seeks; the derived leaf itself carries no sort key, so
-      // the outer query still scans its result as is.
-      try .derived(name: name, plan: optimise(plan, catalog, bindings),
+      // the outer query still scans its result as is. The sub-plan resolves
+      // OUTSIDE the statement's CTE scope (an empty CTE map, matching the empty
+      // scope it compiled under) — a view means what it was registered to mean,
+      // never seeing a caller's `WITH`.
+      try .derived(name: name, plan: optimise(plan, catalog, [:], bindings),
                    ordinals: ordinals, seek: seek)
     case let .select(filter, .scan(name, ordinals, nil)):
-      try seek(filter, name, ordinals, catalog, bindings)
+      try seek(filter, name, ordinals, catalog, ctes, bindings)
     case let .select(filter, .product(left, right)):
-      try nest(filter, left, right, catalog, bindings)
+      try nest(filter, left, right, catalog, ctes, bindings)
     case let .select(filter, source):
-      try .select(filter, optimise(source, catalog, bindings))
+      try .select(filter, optimise(source, catalog, ctes, bindings))
     case let .project(ordinals, source):
-      try .project(ordinals, optimise(source, catalog, bindings))
+      try .project(ordinals, optimise(source, catalog, ctes, bindings))
     case let .sort(slot, ascending, source):
       try .sort(slot: slot, ascending: ascending,
-                optimise(source, catalog, bindings))
+                optimise(source, catalog, ctes, bindings))
     case let .product(left, right):
-      try .product(optimise(left, catalog, bindings),
-                   optimise(right, catalog, bindings))
+      try .product(optimise(left, catalog, ctes, bindings),
+                   optimise(right, catalog, ctes, bindings))
     case .join:
       plan
     case let .union(left, right, all):
       // Optimise each side with the same bindings so a bound predicate inside an
       // arm seeks; the union itself merely concatenates and deduplicates,
       // preserving this node's own `all`.
-      try .union(optimise(left, catalog, bindings),
-                 optimise(right, catalog, bindings), all: all)
+      try .union(optimise(left, catalog, ctes, bindings),
+                 optimise(right, catalog, ctes, bindings), all: all)
     }
   }
 
@@ -426,8 +597,14 @@ public enum Engine {
                                                     _ name: String,
                                                     _ ordinals: Array<Int>,
                                                     _ catalog: borrowing C,
+                                                    _ ctes: CTEs,
                                                     _ bindings: Bindings)
       throws(SQLError) -> Plan {
+    // A materialised CTE relation stores no sort key, so it is never seekable —
+    // leave the scan under the whole filter.
+    guard ctes[name.lowercased()] == nil else {
+      return .select(filter, .scan(name: name, ordinals: ordinals, seek: nil))
+    }
     guard let table = catalog.table(named: name) else { throw .relation(name) }
     let count = table.cursor().count
 
@@ -556,6 +733,7 @@ public enum Engine {
                                                     _ left: Plan,
                                                     _ right: Plan,
                                                     _ catalog: borrowing C,
+                                                    _ ctes: CTEs,
                                                     _ bindings: Bindings)
       throws(SQLError) -> Plan {
     let inner: (name: String, ordinals: Array<Int>, filter: Filter?)?
@@ -569,8 +747,9 @@ public enum Engine {
     }
 
     guard let inner, let base = left.slots else {
-      return try gated(filter, .product(optimise(left, catalog, bindings),
-                                        optimise(right, catalog, bindings)))
+      return try gated(filter,
+                       .product(optimise(left, catalog, ctes, bindings),
+                                optimise(right, catalog, ctes, bindings)))
     }
 
     let conjuncts = filter.conjuncts
@@ -591,7 +770,7 @@ public enum Engine {
       // only when the filter holds), without letting that conjunct throw first
       // (`Parent.Name = 'nope' AND (1 / Child.x) = 0`, the false name excluding
       // the row before the division runs).
-      let join = try Plan.join(optimise(left, catalog, bindings),
+      let join = try Plan.join(optimise(left, catalog, ctes, bindings),
                                name: inner.name, ordinals: inner.ordinals,
                                base: base,
                                column: inner.ordinals[rightKey - base],
@@ -601,8 +780,9 @@ public enum Engine {
       return .select(predicate, join)
     }
 
-    return try gated(filter, .product(optimise(left, catalog, bindings),
-                                      optimise(right, catalog, bindings)))
+    return try gated(filter,
+                     .product(optimise(left, catalog, ctes, bindings),
+                              optimise(right, catalog, ctes, bindings)))
   }
 
   /// A `product` under `filter` for a join `nest` cannot fold into a `Join`,

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -116,11 +116,29 @@ public enum Engine {
       guard relations[cte.name.lowercased()] == nil else {
         throw .redefinition(cte.name)
       }
+      // A `WITH RECURSIVE` member's recursive reference must be its FINAL UNION
+      // arm — the engine's model is anchor members then ONE recursive arm. A
+      // reference to the CTE's own name in an EARLIER arm resolves against the
+      // base scope (the CTE is not in scope outside the recursive arm), so a
+      // same-named base or view is a valid seed; but with no such base/view the
+      // reference can only be a misplaced recursive arm — recursion before the
+      // final arm, or a second recursive arm — a shape the engine does not
+      // support. Reject it rather than silently read a same-named base or fail
+      // obscurely as an unresolved relation. This covers BOTH routings below (a
+      // non-recursive final arm still reaches the run-once branch).
+      if cte.recursive, case let .union(anchor, _, _) = cte.query,
+          references(anchor, cte.name.lowercased()),
+          case nil = catalog.table(named: cte.name),
+          case nil = catalog.view(named: cte.name) {
+        throw .unsupported(
+            "recursive WITH references the CTE outside its final UNION arm")
+      }
       // A CTE that names itself iterates a fixpoint; every other one — a
       // non-recursive CTE, or one a `WITH RECURSIVE` marks recursive but which
       // does not reference itself — runs its query once. Each resolves against
-      // the base catalog plus the CTEs done so far, its body's compiled width
-      // checked against the declared columns first.
+      // the base catalog plus the CTEs done so far. A recursive CTE checks the
+      // arity of both its arms internally (see `fixpoint`); a non-recursive one
+      // checks its body's compiled width here.
       let rows: Array<Array<Value>>
       if cte.recursive && recursive(cte) {
         rows = try fixpoint(cte, catalog, relations, routines, bindings)
@@ -158,6 +176,19 @@ public enum Engine {
     return references(arm, cte.name.lowercased())
   }
 
+  /// Whether `query` names the relation `name` (case-folded) in ANY member's
+  /// `FROM`/`JOIN` — walking the left-associative `UNION` chain and each arm.
+  /// Used to spot a self-reference lurking in a recursive body's anchor;
+  /// `recursive` itself inspects only the recursive arm.
+  private static func references(_ query: Query, _ name: String) -> Bool {
+    switch query {
+    case let .select(select):
+      references(select, name)
+    case let .union(left, select, _):
+      references(left, name) || references(select, name)
+    }
+  }
+
   /// Whether `select` names the relation `name` (case-folded) in its `FROM` or
   /// any `JOIN`.
   private static func references(_ select: Select, _ name: String) -> Bool {
@@ -165,18 +196,121 @@ public enum Engine {
     return select.joins.contains { $0.relation.name.lowercased() == name }
   }
 
+  /// The greatest number of fixpoint iterations a recursive CTE may take before
+  /// the engine concludes it does not terminate and throws
+  /// `SQLError.recursion`.
+  internal static let kRecursionCap = 10_000
+
   /// Evaluates a recursive `cte` to a fixpoint over `catalog` with the earlier
-  /// `ctes` in scope.
+  /// `ctes` in scope, returning every produced row.
   ///
-  /// Not yet implemented — the fixpoint loop lands in a later phase; a recursive
-  /// CTE faults until then.
+  /// A recursive CTE's query is a `UNION` of an ANCHOR (its left arm, itself a
+  /// query) and a RECURSIVE arm (its right `SELECT`, which names the CTE). The
+  /// anchor evaluates once — with the CTE name NOT yet bound — to seed `result`
+  /// and the `working` set. Each iteration then binds the CTE name to ONLY the
+  /// `working` rows (the SQL semantics — the recursive arm sees just the
+  /// previous step's output) and runs the recursive arm; the rows it produces
+  /// extend `result` and become the next `working` set. A `UNION ALL` keeps
+  /// every produced row; a `UNION` keeps only rows not seen before (a whole-row
+  /// `seen` set), and a step that adds nothing new is the fixpoint. The
+  /// `kRecursionCap` guards a non-terminating CTE with `SQLError.recursion`.
+  ///
+  /// A non-`UNION` recursive query has no recursive arm to iterate, so it runs
+  /// once like a non-recursive CTE — its compiled width validated the same way
+  /// before it materialises, so a non-`UNION` body binding rows of a width other
+  /// than the column list (e.g. a base relation of the CTE's own name) faults
+  /// with `SQLError.columns` rather than trapping on a later read.
+  ///
+  /// The anchor and the recursive arm are each validated against
+  /// `cte.columns.count` by their compiled `Plan.width` BEFORE any rows bind
+  /// under the declared columns: the loop binds `working` as a `Materialised`
+  /// of `cte.columns`, so an arm narrower or wider than the column list — a
+  /// two-column anchor under a three-column list, or a recursive arm of a width
+  /// differing from the anchor's — would trap in `Materialised.record` when the
+  /// next iteration reads it. Checking the compiled width faults with
+  /// `SQLError.columns` regardless of how many rows an arm yields, so even a
+  /// `SELECT *` arm filtered to zero rows is caught. The anchor compiles with
+  /// the CTE name NOT in scope (it does not reference itself); the recursive
+  /// arm compiles with the name bound to `cte.columns`, the schema it reads.
   internal static func fixpoint<C: Catalog & ~Escapable>(_ cte: CTE,
                                                          _ catalog: borrowing C,
                                                          _ ctes: CTEs,
                                                          _ routines: Routines,
                                                          _ bindings: Bindings)
       throws(SQLError) -> Array<Array<Value>> {
-    throw .statement("recursive WITH is not yet supported")
+    guard case let .union(anchor, recursive, all) = cte.query else {
+      // A non-`UNION` recursive query runs once, but still binds under
+      // `cte.columns`, so validate its compiled width here too — the check the
+      // anchor and arm get. A body naming a base relation of the CTE's own name
+      // (`WITH RECURSIVE Parent(x,y,z) AS (SELECT * FROM Parent)`) would else
+      // bind narrow base rows under the wider list and trap on a later read.
+      let width = try compile(cte.query, catalog, ctes).width
+      guard width == cte.columns.count else {
+        throw .columns(expected: cte.columns.count, got: width)
+      }
+      return try run(cte.query, catalog, ctes, routines, bindings)
+    }
+
+    // A misplaced recursive reference in the anchor (a same-named base/view is
+    // absent) was already rejected in `with`, before routing here, so the anchor
+    // is a genuine base case by this point.
+
+    // Validate the anchor's compiled width against the declared columns BEFORE
+    // it seeds the working set: the loop binds `working` under `cte.columns` as
+    // a `Materialised`, so an anchor narrower than the column list — a
+    // two-column `Parent` under `t(a, b, c)` — would trap when the recursive
+    // arm reads the absent ordinal, rather than surfacing `SQLError.columns`.
+    // The anchor is the base case and does not reference the CTE, so its width
+    // resolves with the name not yet in scope.
+    let width = try compile(anchor, catalog, ctes).width
+    guard width == cte.columns.count else {
+      throw .columns(expected: cte.columns.count, got: width)
+    }
+
+    // The recursive arm compiles with the CTE name bound to `cte.columns` — the
+    // schema every iteration reads it under — so its width resolves too (a
+    // `SELECT *` arm spans that schema). Checking it here catches a mismatch
+    // even when the arm is filtered to zero rows in every iteration.
+    var probe = ctes
+    probe[cte.name.lowercased()] =
+        Materialised(columns: cte.columns, rows: [])
+    let arm = try compile(.select(recursive), catalog, probe).width
+    guard arm == cte.columns.count else {
+      throw .columns(expected: cte.columns.count, got: arm)
+    }
+
+    // The anchor seeds the result and the working set, the CTE name not yet in
+    // scope (the anchor is the base case, which does not reference itself). A
+    // bare `UNION` dedups the seed exactly as it dedups an iteration's rows —
+    // duplicate anchor rows collapse to their first occurrence — while `UNION
+    // ALL` keeps every anchor row.
+    let anchored = try run(anchor, catalog, ctes, routines, bindings)
+    var seen = Set<Array<Value>>()
+    var result = all ? anchored
+                     : anchored.filter { seen.insert($0).inserted }
+    var working = result
+
+    var iterations = 0
+    while !working.isEmpty {
+      iterations += 1
+      guard iterations <= kRecursionCap else { throw .recursion(cte.name) }
+
+      // Bind the CTE name to ONLY the previous step's output and run the
+      // recursive arm against the base catalog plus the earlier CTEs.
+      var scope = ctes
+      scope[cte.name.lowercased()] =
+          Materialised(columns: cte.columns, rows: working)
+      let produced =
+          try run(.select(recursive), catalog, scope, routines, bindings)
+
+      var next = Array<Array<Value>>()
+      for row in produced where all || seen.insert(row).inserted {
+        next.append(row)
+      }
+      result += next
+      working = next
+    }
+    return result
   }
 
   // MARK: - Compilation

--- a/Sources/SQL/Error.swift
+++ b/Sources/SQL/Error.swift
@@ -89,6 +89,10 @@ public enum SQLError: Error, Hashable, Sendable {
   /// `Schema.ordinal(of:)` performs, so the shadowed column would be
   /// unreachable; the string is the offending name.
   case duplicate(String)
+  /// A `WITH` list binds the same query name twice (case-insensitively), so the
+  /// later definition would silently shadow the earlier; the string is the
+  /// repeated name.
+  case redefinition(String)
   /// A `UNION` combines two `SELECT`s of differing column counts — the result
   /// columns of every arm must align — carrying the first arm's width and the
   /// offending arm's.
@@ -98,6 +102,14 @@ public enum SQLError: Error, Hashable, Sendable {
   /// select (which projects only expressions over a single row); the string
   /// describes it.
   case unsupported(String)
+  /// A statement cannot be run as a query — a `CREATE VIEW` defines a view
+  /// rather than producing rows, or a malformed `WITH` member; the string
+  /// describes the fault.
+  case statement(String)
+  /// A recursive common table expression did not reach a fixpoint within the
+  /// iteration cap (`kRecursionCap`) — it produces rows without end. The string
+  /// is the offending CTE's name.
+  case recursion(String)
 }
 
 extension SQLError: CustomStringConvertible {
@@ -140,11 +152,17 @@ extension SQLError: CustomStringConvertible {
           + "expected \(expected), got \(got)"
     case let .duplicate(name):
       "duplicate view column '\(name)'"
+    case let .redefinition(name):
+      "WITH query name '\(name)' specified more than once"
     case let .arity(expected, found):
       "UNION arms project differing column counts: "
           + "expected \(expected), found \(found)"
     case let .unsupported(detail):
       "unsupported query: \(detail)"
+    case let .statement(detail):
+      "statement is not runnable as a query: \(detail)"
+    case let .recursion(name):
+      "recursive CTE '\(name)' did not terminate"
     }
   }
 }
@@ -176,8 +194,11 @@ extension SQLError {
   /// - Class `SS` — the implementation-defined class this engine squats on
   ///   (SwiftSQL) for a condition with no standard ISO code — `SS001`, a query
   ///   shape the engine does not support (a FROM-less `SELECT *`, or a clause
-  ///   with no `FROM`). ISO leaves classes whose first character is `5`–`9` or
-  ///   `I`–`Z` implementation-defined, so `SS` is a safe squat.
+  ///   with no `FROM`), `SS002`, a statement that is not runnable as a query
+  ///   (a `CREATE VIEW`, or a malformed `WITH` member), and `SS003`, a recursive
+  ///   CTE that did not reach a fixpoint within the iteration cap. ISO leaves
+  ///   classes whose first character is `5`–`9` or `I`–`Z`
+  ///   implementation-defined, so `SS` is a safe squat.
   public var sqlstate: String {
     switch self {
     case let .state(code, _):
@@ -194,6 +215,8 @@ extension SQLError {
       "42702"
     case .duplicate:
       "42701"
+    case .redefinition:
+      "42712"
     case .function:
       "42883"
     // Class 22 — data exception.
@@ -210,6 +233,10 @@ extension SQLError {
     // Class SS — SwiftSQL, this engine's implementation-defined conditions.
     case .unsupported:
       "SS001"
+    case .statement:
+      "SS002"
+    case .recursion:
+      "SS003"
     }
   }
 

--- a/Sources/SQL/Lexer.swift
+++ b/Sources/SQL/Lexer.swift
@@ -253,6 +253,8 @@ internal struct Lexer: ~Escapable {
     case "NULL": .null
     case "UNION": .union
     case "ALL": .all
+    case "WITH": .with
+    case "RECURSIVE": .recursive
     default: .identifier(text)
     }
     return Token(kind: kind, location: start)

--- a/Sources/SQL/Materialised.swift
+++ b/Sources/SQL/Materialised.swift
@@ -1,0 +1,63 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+/// The common table expressions in scope, keyed case-folded — the materialised
+/// relations the engine resolves a `WITH`'s names against.
+///
+/// It is threaded alongside the borrowed base catalog through every resolution
+/// phase: when the engine resolves a relation name, it consults `CTEs` first (a
+/// CTE name shadows a base table or view of the same name), and a CTE leaf
+/// materialises its records from the `Materialised` rows rather than opening a
+/// base cursor. An empty `CTEs` is the default — a query with no `WITH` resolves
+/// exactly as before. Threading escapable data sidesteps wrapping the borrowed
+/// `~Escapable` base catalog in a unifying overlay type.
+internal typealias CTEs = Dictionary<String, Materialised>
+
+/// An escapable, in-engine relation over `(columns, rows)`.
+///
+/// A `Materialised` is fully owned data — a common table expression's query run
+/// to a fixed set of rows, named by its columns — that the engine resolves a
+/// CTE name to. It is escapable, so it sits beside the `~Escapable` base
+/// catalog without the lifetime machinery a borrowed source needs: the engine
+/// threads a `Dictionary<String, Materialised>` of the in-scope CTEs alongside
+/// the borrowed base catalog, consulting it first when it resolves a name, and
+/// builds the leaf records directly from `rows` rather than opening a cursor.
+///
+/// It exposes the universal `rowid` virtual column at `width`, so a CTE
+/// resolves columns exactly as a base relation does (a real column below
+/// `width`, the `rowid` at `width`).
+internal struct Materialised: Hashable, Sendable {
+  /// The relation's column names, in ordinal order.
+  internal let columns: Array<String>
+
+  /// The relation's rows, each a positional array of typed values.
+  internal let rows: Array<Array<Value>>
+
+  internal init(columns: Array<String>, rows: Array<Array<Value>>) {
+    self.columns = columns
+    self.rows = rows
+  }
+
+  /// The real column count — the extent of a `SELECT *`.
+  internal var width: Int { columns.count }
+
+  /// One past the highest ordinal — the real width plus the lone virtual
+  /// `rowid` column at `width`.
+  internal var extent: Int { width + 1 }
+
+  /// The resolution schema of this relation: its columns below `width`, a
+  /// virtual `rowid` at `width`.
+  internal func schema() -> Schema {
+    Schema(width: width, extent: extent, names: columns, virtuals: ["rowid"])
+  }
+
+  /// The record for the row at `index`, materialising the referenced `ordinals`
+  /// into dense slots — a real ordinal (`< width`) reads the stored cell, the
+  /// virtual `rowid` ordinal (`== width`) the 1-based row index.
+  internal func record(_ index: Int, _ ordinals: Array<Int>) -> Record {
+    let cells = rows[index]
+    return Record(ordinals.map {
+      $0 == width ? .integer(index + 1) : cells[$0]
+    })
+  }
+}

--- a/Sources/SQL/Operator.swift
+++ b/Sources/SQL/Operator.swift
@@ -223,6 +223,7 @@ extension Plan {
 /// or stored.
 internal func execute<C: Catalog & ~Escapable>(_ plan: Plan,
                                                _ catalog: borrowing C,
+                                               _ ctes: CTEs,
                                                _ routines: Routines,
                                                _ bindings: Bindings)
     throws(SQLError) -> Array<Record> {
@@ -232,23 +233,23 @@ internal func execute<C: Catalog & ~Escapable>(_ plan: Plan,
     // projection evaluates its constant/call expressions against.
     [Record([])]
   case let .scan(name, ordinals, seek):
-    try materialise(name, ordinals, seek, catalog)
+    try materialise(name, ordinals, seek, catalog, ctes)
   case let .derived(_, source, ordinals, seek):
     try derive(source, ordinals, seek, catalog, routines, bindings)
   case let .select(filter, .product(outer, inner)):
     // Fuse a residual product with its filter: stream each pair through the
     // predicate rather than materialising the whole cross product first.
-    try sift(execute(outer, catalog, routines, bindings),
-             execute(inner, catalog, routines, bindings), filter, routines,
+    try sift(execute(outer, catalog, ctes, routines, bindings),
+             execute(inner, catalog, ctes, routines, bindings), filter, routines,
              bindings)
   case let .select(filter, source):
-    try admitted(execute(source, catalog, routines, bindings), filter,
+    try admitted(execute(source, catalog, ctes, routines, bindings), filter,
                  routines, bindings)
   case let .project(terms, source):
-    try execute(source, catalog, routines, bindings)
+    try execute(source, catalog, ctes, routines, bindings)
       .map { record throws(SQLError) in try project(terms, record, routines) }
   case let .sort(slot, ascending, source):
-    try execute(source, catalog, routines, bindings)
+    try execute(source, catalog, ctes, routines, bindings)
       .enumerated()
       .sorted { lhs, rhs in
         let ordered = less(lhs.element[slot], rhs.element[slot])
@@ -260,13 +261,13 @@ internal func execute<C: Catalog & ~Escapable>(_ plan: Plan,
       }
       .map(\.element)
   case let .product(outer, inner):
-    try product(execute(outer, catalog, routines, bindings),
-                execute(inner, catalog, routines, bindings))
+    try product(execute(outer, catalog, ctes, routines, bindings),
+                execute(inner, catalog, ctes, routines, bindings))
   case let .join(outer, name, ordinals, base, column, keys, filter):
-    try join(execute(outer, catalog, routines, bindings), name, ordinals,
-             base, column, keys, filter, catalog, routines, bindings)
+    try join(execute(outer, catalog, ctes, routines, bindings), name, ordinals,
+             base, column, keys, filter, catalog, ctes, routines, bindings)
   case let .union(left, right, all):
-    try union(left, right, all, catalog, routines, bindings)
+    try union(left, right, all, catalog, ctes, routines, bindings)
   }
 }
 
@@ -282,11 +283,12 @@ internal func execute<C: Catalog & ~Escapable>(_ plan: Plan,
 private func union<C: Catalog & ~Escapable>(_ left: Plan, _ right: Plan,
                                             _ all: Bool,
                                             _ catalog: borrowing C,
+                                            _ ctes: CTEs,
                                             _ routines: Routines,
                                             _ bindings: Bindings)
     throws(SQLError) -> Array<Record> {
-  let rows = try execute(left, catalog, routines, bindings)
-      + execute(right, catalog, routines, bindings)
+  let rows = try execute(left, catalog, ctes, routines, bindings)
+      + execute(right, catalog, ctes, routines, bindings)
   guard !all else { return rows }
 
   var records = Array<Record>()
@@ -324,16 +326,24 @@ private func admitted(_ records: Array<Record>, _ filter: Filter,
   return kept
 }
 
-/// Re-resolves `name` against `catalog`, opens its cursor, and materialises the
-/// referenced `ordinals` of the seek's row range (the whole relation when
-/// `nil`) into dense slot `Record`s.
+/// Materialises the referenced `ordinals` of the relation `name` over the
+/// seek's row range (the whole relation when `nil`) into dense slot `Record`s.
 ///
-/// - Throws: `SQLError.relation` if the name no longer resolves.
+/// A common table expression `name` (in `ctes`, consulted first — a CTE shadows
+/// a base relation) materialises its records directly from the in-engine
+/// `Materialised` rows; else the base relation re-resolves through `catalog`,
+/// its cursor opened.
+///
+/// - Throws: `SQLError.relation` if the name resolves to neither.
 private func materialise<C: Catalog & ~Escapable>(_ name: String,
                                                   _ ordinals: Array<Int>,
                                                   _ seek: Range<Int>?,
-                                                  _ catalog: borrowing C)
+                                                  _ catalog: borrowing C,
+                                                  _ ctes: CTEs)
     throws(SQLError) -> Array<Record> {
+  if let cte = ctes[name.lowercased()] {
+    return (seek ?? 0 ..< cte.rows.count).map { cte.record($0, ordinals) }
+  }
   guard let table = catalog.table(named: name) else { throw .relation(name) }
   let cursor = table.cursor()
   var records = Array<Record>()
@@ -351,6 +361,12 @@ private func materialise<C: Catalog & ~Escapable>(_ name: String,
 /// The sub-plan yields full-width view records — its columns at slots
 /// `0 ..< columns.count`; this projects each to the `ordinals` the outer query
 /// reads, in the slot order the outer scan expects (slot `i` is `ordinals[i]`).
+///
+/// The sub-plan runs OUTSIDE the statement's CTE scope — an empty CTE map, the
+/// same scope it compiled and optimised under — so a caller's `WITH` never
+/// reaches into a stored view's body: a view's own `FROM`/`JOIN` names resolve
+/// to base relations (and other views), never to a statement-local CTE that
+/// happens to share a name.
 private func derive<C: Catalog & ~Escapable>(_ plan: Plan,
                                              _ ordinals: Array<Int>,
                                              _ seek: Range<Int>?,
@@ -358,7 +374,7 @@ private func derive<C: Catalog & ~Escapable>(_ plan: Plan,
                                              _ routines: Routines,
                                              _ bindings: Bindings)
     throws(SQLError) -> Array<Record> {
-  let rows = try execute(plan, catalog, routines, bindings)
+  let rows = try execute(plan, catalog, [:], routines, bindings)
   let range = seek ?? 0 ..< rows.count
   return range.map { rows[$0].project(ordinals) }
 }
@@ -403,27 +419,26 @@ private func sift(_ outer: Array<Record>, _ inner: Array<Record>,
   return records
 }
 
-/// The equi-join of `outer` against the inner relation `name`, seeking the
-/// inner per outer record when its key `column` is seekable and hashing it once
-/// otherwise.
+/// The equi-join of `outer` against the inner relation `name`, resolved through
+/// `ctes` first then `catalog`, seeking or hashing the inner as its shape allows.
 ///
-/// The inner relation is re-resolved through `catalog`. When the inner reports
-/// `column` (the inner ordinal `keys.right` reads) seekable, each outer record's
-/// key seeks the inner's `[lower, upper)` run — an index-nested loop, cheap
-/// because the seek narrows the scan. When it is NOT seekable, a per-outer scan
-/// would read the whole inner once per outer record (O(n·m)); instead the inner
-/// is scanned ONCE into a hash map keyed by its join value, and each outer
-/// record probes it in O(1). Both strategies materialise a candidate over the
-/// referenced `ordinals` into inner slots `0 ..< ordinals.count`, admit it only
-/// when the pushed inner `filter` (in the inner's standalone slot space) also
-/// holds — applied WHILE the inner row is materialised, so a filtered inner row
-/// is never paired or bucketed — key on the inner's `keys.right` slot —
-/// `keys.right - base` in the standalone inner record — and concatenate a match
+/// A materialised CTE inner has no sort key, so it is scanned in full and joined
+/// by the equality on its `keys.right` slot (`joined`). A base relation that
+/// reports `column` (the inner ordinal `keys.right` reads) seekable is sought per
+/// outer record — an index-nested loop, cheap because the seek narrows the scan;
+/// one that is NOT seekable is scanned ONCE into a hash map keyed by its join
+/// value and each outer record probes it in O(1) (`hashed`), rather than reading
+/// the whole inner once per outer record. Every strategy materialises a candidate
+/// over the referenced `ordinals` into inner slots `0 ..< ordinals.count`, admits
+/// it only when the pushed inner `filter` (in the inner's standalone slot space)
+/// also holds — applied WHILE the inner row is materialised, so a filtered inner
+/// row is never paired or bucketed — keys on the inner's `keys.right` slot
+/// (`keys.right - base` in the standalone inner record), and concatenates a match
 /// (the inner's slots landing at `base` in the combined space). A NULL key joins
-/// to nothing under both, and both preserve outer-major order, the inner matches
-/// in cursor order within each outer.
+/// to nothing, and every path preserves outer-major order, the inner matches in
+/// cursor order within each outer.
 ///
-/// - Throws: `SQLError.relation` if the inner name no longer resolves.
+/// - Throws: `SQLError.relation` if the inner name resolves to neither.
 private func join<C: Catalog & ~Escapable>(_ outer: Array<Record>,
                                            _ name: String,
                                            _ ordinals: Array<Int>, _ base: Int,
@@ -431,9 +446,26 @@ private func join<C: Catalog & ~Escapable>(_ outer: Array<Record>,
                                            _ keys: (left: Int, right: Int),
                                            _ filter: Filter?,
                                            _ catalog: borrowing C,
+                                           _ ctes: CTEs,
                                            _ routines: Routines,
                                            _ bindings: Bindings)
     throws(SQLError) -> Array<Record> {
+  // A materialised CTE inner has no sort key, so it is scanned in full and the
+  // equality on its `keys.right` slot is the join's truth — the same probe a
+  // base relation falls back to when its key is unseekable. A pushed inner
+  // filter (in the inner's standalone slot space) is applied as each record
+  // materialises, before it can pair — mirroring the base seek/hash paths — so a
+  // filtered CTE row is never joined.
+  if let cte = ctes[name.lowercased()] {
+    var inner = Array<Record>()
+    for index in 0 ..< cte.rows.count {
+      let right = cte.record(index, ordinals)
+      if let filter,
+          try evaluate(filter, right, routines, bindings) != true { continue }
+      inner.append(right)
+    }
+    return joined(outer, inner, base, keys)
+  }
   guard let inner = catalog.table(named: name) else { throw .relation(name) }
   guard seekable(inner, column) else {
     return try hashed(outer, inner, ordinals, base, keys, filter, routines,
@@ -526,6 +558,25 @@ private func hashed<T: Table & ~Escapable>(_ outer: Array<Record>,
     let value = left[keys.left]
     if case .null = value { continue }
     for right in buckets[value] ?? [] {
+      records.append(left.merged(with: right))
+    }
+  }
+  return records
+}
+
+/// The equi-join of `outer` against a fully materialised `inner` record set:
+/// for each outer record whose `keys.left` value is non-NULL, every inner row
+/// whose `keys.right` slot (`keys.right - base` in the standalone inner record)
+/// equals it, the pair concatenated. The plain nested-loop a CTE inner takes.
+private func joined(_ outer: Array<Record>, _ inner: Array<Record>,
+                    _ base: Int, _ keys: (left: Int, right: Int))
+    -> Array<Record> {
+  let slot = keys.right - base
+  var records = Array<Record>()
+  for left in outer {
+    let value = left[keys.left]
+    if case .null = value { continue }
+    for right in inner where right[slot] == value {
       records.append(left.merged(with: right))
     }
   }

--- a/Sources/SQL/Parser.swift
+++ b/Sources/SQL/Parser.swift
@@ -6,9 +6,12 @@
 /// The grammar is the minimal dialect, extended with a chain of joins:
 ///
 /// ```
-/// statement      := query | create
+/// statement      := with | query | create
 /// create         := CREATE VIEW identifier
 ///                   ['(' identifier (',' identifier)* ')'] AS query
+/// with           := WITH [RECURSIVE] cte (',' cte)* query
+/// cte            := identifier ['(' identifier (',' identifier)* ')']
+///                   AS '(' query ')'
 /// query          := select (UNION [ALL] select)*
 /// select         := SELECT projection [FROM relation (join)* [where] [order]]
 /// relation       := identifier [AS identifier]
@@ -57,18 +60,100 @@ internal struct Parser: ~Escapable {
 
   /// Parses a complete statement and asserts the input is exhausted.
   ///
-  /// A leading `CREATE` selects the `CREATE VIEW` form; anything else is a
-  /// `query` — a `SELECT` or a `UNION` of several.
+  /// A leading `CREATE` selects the `CREATE VIEW` form; a leading `WITH` the
+  /// common-table-expression form; anything else is a `query` — a `SELECT` or a
+  /// `UNION` of several.
   internal mutating func parse() throws(SQLError) -> Statement {
-    let statement = if current?.kind == .create {
-      try create()
-    } else {
-      try Statement.select(query())
+    let statement = switch current?.kind {
+    case .create: try create()
+    case .with: try with()
+    default: try Statement.select(query())
     }
     if let token = current {
       throw .trailing(at: token.location)
     }
     return statement
+  }
+
+  /// Parses `WITH [RECURSIVE] cte (, cte)* query` (the leading `WITH` is the
+  /// next token).
+  ///
+  /// The `RECURSIVE` keyword, when present, marks every CTE of the list
+  /// recursive — the SQL standard scopes it to the whole `WITH`, not a single
+  /// member — so a member that names itself is admitted. The CTEs parse in
+  /// source order, each scoping the trailing query; the query is the same
+  /// `select (UNION …)*` form a bare statement is.
+  private mutating func with() throws(SQLError) -> Statement {
+    try expect(.with)
+    let recursive = try match(.recursive)
+
+    var ctes = Array<CTE>()
+    try ctes.append(cte(recursive: recursive))
+    while try match(.comma) {
+      try ctes.append(cte(recursive: recursive))
+    }
+    return try .with(ctes: ctes, query: query())
+  }
+
+  /// Parses one `cte := identifier ['(' identifier (, identifier)* ')'] AS '('
+  /// query ')'`, binding it `recursive` per the enclosing `WITH`.
+  ///
+  /// An explicit `(c, …)` list names the CTE's columns; absent one, the names
+  /// are inferred from the query's first arm, exactly as a view's are — the same
+  /// arity, naming, and case-insensitive uniqueness rules `columns(_:_:)`
+  /// applies.
+  private mutating func cte(recursive: Bool) throws(SQLError) -> CTE {
+    let name = try identifier()
+    let explicit = try names()
+    try expect(.as)
+    try expect(.lparen)
+    let query = try query()
+    try expect(.rparen)
+    return try CTE(name: name, columns: columns(explicit, query),
+                   query: query, recursive: recursive)
+  }
+
+  /// Parses an optional parenthesised column-name list `'(' identifier (,
+  /// identifier)* ')'`, returning the names, or `nil` when no `(` follows.
+  ///
+  /// Shared by a `CREATE VIEW`'s and a CTE's explicit column list.
+  private mutating func names() throws(SQLError) -> Array<String>? {
+    guard try match(.lparen) else { return nil }
+    var columns = Array<String>()
+    try columns.append(identifier())
+    while try match(.comma) {
+      try columns.append(identifier())
+    }
+    try expect(.rparen)
+    return columns
+  }
+
+  /// Resolves a relation's column names from an `explicit` list (when given) or
+  /// the `query`'s first arm, applying the view/CTE naming rules.
+  ///
+  /// An explicit list must name exactly one column per projected value when the
+  /// first arm's arity is statically known — a `.columns`/`.expressions`
+  /// projection, but not a `SELECT *`, whose width is known only at resolution —
+  /// else `SQLError.columns`. Absent a list, the names are inferred from the
+  /// projection (`infer`). The final names — explicit or inferred — must be
+  /// case-insensitively unique, matching `Schema.ordinal(of:)`'s resolution, or
+  /// the shadowed column would be unreachable (`SQLError.duplicate`).
+  private func columns(_ explicit: Array<String>?, _ query: Query)
+      throws(SQLError) -> Array<String> {
+    if let explicit, let arity = arity(query.first.projection),
+        explicit.count != arity {
+      throw .columns(expected: arity, got: explicit.count)
+    }
+    let columns: Array<String> = if let explicit {
+      explicit
+    } else {
+      try infer(query.first.projection)
+    }
+    var seen = Set<String>()
+    for column in columns where !seen.insert(column.lowercased()).inserted {
+      throw .duplicate(column)
+    }
+    return columns
   }
 
   /// Parses `select (UNION [ALL] select)*`, left-associative.
@@ -91,50 +176,18 @@ internal struct Parser: ~Escapable {
   ///
   /// An explicit `(col, col, …)` list names the view's columns; absent one, the
   /// names are inferred from the FIRST arm's projection (the ISO rule for a
-  /// union's result columns). A projection whose names cannot be inferred — a
-  /// `SELECT *`, or an unaliased non-column expression — faults with
-  /// `SQLError.named`. An explicit list that does not name exactly one column
-  /// per projected value, when the first arm's arity is statically known (a
-  /// `.columns` or `.expressions` projection, but not a `SELECT *`), faults with
-  /// `SQLError.columns`; a `SELECT *` view's width is checked by the engine at
-  /// resolution instead. The final names — explicit or inferred — must be
-  /// case-insensitively unique, matching `Schema.ordinal(of:)`'s resolution; a
-  /// collision faults with `SQLError.duplicate`.
+  /// union's result columns) — the naming, arity, and uniqueness rules
+  /// `columns(_:_:)` applies, shared with a CTE's column list.
   private mutating func create() throws(SQLError) -> Statement {
     try expect(.create)
     try expect(.view)
     let name = try identifier()
-
-    var explicit: Array<String>? = nil
-    if try match(.lparen) {
-      var columns = Array<String>()
-      try columns.append(identifier())
-      while try match(.comma) {
-        try columns.append(identifier())
-      }
-      try expect(.rparen)
-      explicit = columns
-    }
-
+    let explicit = try names()
     try expect(.as)
     let query = try query()
-    let columns: Array<String>
-    if let explicit {
-      if let arity = arity(query.first.projection), explicit.count != arity {
-        throw .columns(expected: arity, got: explicit.count)
-      }
-      columns = explicit
-    } else {
-      columns = try infer(query.first.projection)
-    }
-    // A view's columns must be case-insensitively unique — explicit or
-    // inferred — to match the resolution `Schema.ordinal(of:)` performs; a
-    // collision would shadow the later column and make it unreachable.
-    var seen = Set<String>()
-    for column in columns where !seen.insert(column.lowercased()).inserted {
-      throw .duplicate(column)
-    }
-    return .create(name: name, view: View(query: query, columns: columns))
+    return try .create(name: name,
+                       view: View(query: query,
+                                  columns: columns(explicit, query)))
   }
 
   /// The number of values `projection` projects, or `nil` when it is not

--- a/Sources/SQL/SQL.swift
+++ b/Sources/SQL/SQL.swift
@@ -8,6 +8,7 @@ extension Statement {
   /// recursive descent into a SQL abstract syntax tree. The dialect is minimal:
   ///
   /// ```sql
+  /// [WITH [RECURSIVE] cte (, cte)*]
   /// SELECT <* | column (, column)*> FROM <table>
   ///   [WHERE <predicate>] [ORDER BY <column> [ASC|DESC]]
   ///   (UNION [ALL] SELECT …)*

--- a/Sources/SQL/Schema.swift
+++ b/Sources/SQL/Schema.swift
@@ -22,11 +22,11 @@ internal struct Schema {
   internal let extent: Int
 
   /// The real column names at their ordinals `0 ..< width`.
-  private let names: Array<String>
+  internal let names: Array<String>
 
   /// The virtual column names at their ordinals `width ..< extent` — virtual
   /// `i` sits at ordinal `width + i`. A view supplies none.
-  private let virtuals: Array<String>
+  internal let virtuals: Array<String>
 
   internal init(width: Int, extent: Int, names: Array<String>,
                 virtuals: Array<String>) {

--- a/Sources/SQL/Token.swift
+++ b/Sources/SQL/Token.swift
@@ -36,6 +36,8 @@ extension Token {
     case null
     case union
     case all
+    case with
+    case recursive
 
     // Operands.
     case identifier(String)
@@ -84,6 +86,8 @@ extension Token.Kind {
     case .null: "NULL"
     case .union: "UNION"
     case .all: "ALL"
+    case .with: "WITH"
+    case .recursive: "RECURSIVE"
     case let .identifier(name): name
     case let .string(value): "'\(value)'"
     case let .integer(value): "\(value)"

--- a/Sources/winmd-inspect/Shell.swift
+++ b/Sources/winmd-inspect/Shell.swift
@@ -862,6 +862,8 @@ extension Session {
       return []
     case let .select(query):
       return try Engine.run(query, self, bindings: bindings)
+    case .with:
+      throw SQLError.unsupported("WITH is not yet executable")
     }
   }
 }

--- a/Sources/winmd-inspect/Shell.swift
+++ b/Sources/winmd-inspect/Shell.swift
@@ -850,20 +850,23 @@ extension Session {
   /// VIEW` is an ordinary statement here, not a special case; the shell prints
   /// whatever rows come back.
   ///
-  /// `bindings` resolve a `SELECT`'s `:name` parameters — the shell threads its
-  /// `.bind` bindings through here, so a parameterized query typed at the prompt
-  /// finds its values. A `CREATE VIEW` ignores them: it stores the view's text,
-  /// binding only when a later `SELECT` reads it.
+  /// `bindings` resolve a `:name` parameter of a `SELECT` or a `WITH` — the
+  /// shell threads its `.bind` bindings through here, so a parameterized query
+  /// typed at the prompt finds its values, whether the parameter sits in a plain
+  /// `SELECT` or in a `WITH`'s body or trailing query. A `CREATE VIEW` ignores
+  /// them: it stores the view's text, binding only when a later `SELECT` reads
+  /// it.
   internal mutating func run(_ statement: String, bindings: Bindings = [:])
       throws -> Array<Array<Value>> {
-    switch try Statement(parsing: statement) {
+    let parsed = try Statement(parsing: statement)
+    switch parsed {
     case let .create(name, view):
       register(name, view)
       return []
     case let .select(query):
       return try Engine.run(query, self, bindings: bindings)
     case .with:
-      throw SQLError.unsupported("WITH is not yet executable")
+      return try Engine.run(parsed, self, bindings: bindings)
     }
   }
 }

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -2939,4 +2939,240 @@ struct EngineScalarSelectTests {
   }
 }
 
+// MARK: - WITH (non-recursive) tests
 
+/// Parses `text` to a statement and runs it against `catalog`.
+private func statement<C: Catalog & ~Escapable>(_ text: String,
+                                                _ catalog: borrowing C)
+    throws -> Array<Array<Value>> {
+  try Engine.run(Statement(parsing: text), catalog)
+}
+
+struct EngineWithTests {
+  @Test("a non-recursive CTE materialises as an inline view")
+  func inline() throws {
+    // The CTE `adults` is materialised once and the trailing query reads it
+    // like a table — the inline-view shape of a non-recursive WITH.
+    let rows = try statement("""
+        WITH adults (Key, Label) AS (SELECT Id, Name FROM Parent WHERE Id >= 2)
+          SELECT Label FROM adults
+        """, family())
+    #expect(rows == [[.text("Bee")], [.text("Cid")]])
+  }
+
+  @Test("a CTE infers its columns and filters on them")
+  func inferred() throws {
+    let rows = try statement("""
+        WITH grown AS (SELECT Id, Name FROM Parent)
+          SELECT Name FROM grown WHERE Id = 3
+        """, family())
+    #expect(rows == [[.text("Cid")]])
+  }
+
+  @Test("a later CTE reads an earlier one (chained CTEs)")
+  func chained() throws {
+    // `b` resolves `a` — the resolver consults the CTEs materialised so far, so
+    // a later member sees an earlier one.
+    let rows = try statement("""
+        WITH a (Id, Name) AS (SELECT Id, Name FROM Parent WHERE Id >= 2),
+             b (Who) AS (SELECT Name FROM a WHERE Id = 3)
+          SELECT Who FROM b
+        """, family())
+    #expect(rows == [[.text("Cid")]])
+  }
+
+  @Test("a CTE shadows a base relation of the same name")
+  func shadow() throws {
+    // `Parent` is a base relation; the CTE of the same name shadows it, so the
+    // trailing query reads the CTE's rows, not the base table's.
+    let rows = try statement("""
+        WITH Parent (Id, Name) AS (SELECT Id, Name FROM Parent WHERE Id = 1)
+          SELECT Name FROM Parent
+        """, family())
+    #expect(rows == [[.text("Ada")]])
+  }
+
+  @Test("the trailing query joins a CTE against a base relation")
+  func joinBase() throws {
+    // The CTE `kids` joins to the base `Parent` on the foreign key — proving a
+    // materialised relation and a base one combine in one query.
+    let rows = try statement("""
+        WITH kids (Pid, Kid) AS (SELECT Pid, Name FROM Child)
+          SELECT Parent.Name, kids.Kid FROM Parent
+            JOIN kids ON kids.Pid = Parent.Id
+        """, family())
+    #expect(rows == [
+      [.text("Ada"), .text("Ann")],
+      [.text("Ada"), .text("Amy")],
+      [.text("Bee"), .text("Bob")],
+    ])
+  }
+
+  @Test("a CTE's rowid virtual column resolves")
+  func rowid() throws {
+    let rows = try statement("""
+        WITH a (Tag) AS (SELECT Name FROM Parent)
+          SELECT rowid, Tag FROM a WHERE rowid = 2
+        """, family())
+    #expect(rows == [[.integer(2), .text("Bee")]])
+  }
+
+  @Test("a CTE column list of the wrong arity is rejected at parse")
+  func arity() throws {
+    #expect(throws: SQLError.columns(expected: 2, got: 1)) {
+      try statement("""
+          WITH a (only) AS (SELECT Id, Name FROM Parent) SELECT only FROM a
+          """, family())
+    }
+  }
+
+  @Test("an unknown column of a CTE is reported")
+  func unknown() throws {
+    #expect(throws: SQLError.column("Missing")) {
+      try statement("""
+          WITH a (Id) AS (SELECT Id FROM Parent) SELECT Missing FROM a
+          """, family())
+    }
+  }
+
+  @Test("a CTE whose body is a UNION materialises both arms")
+  func union() throws {
+    let rows = try statement("""
+        WITH both (Tag) AS (SELECT Tag FROM Left UNION SELECT Tag FROM Right)
+          SELECT Tag FROM both
+        """, tags())
+    #expect(rows == [[.text("a")], [.text("shared")], [.text("b")]])
+  }
+
+  @Test("a CTE column list wider than its SELECT * body is rejected, not trapped")
+  func widthMismatch() throws {
+    // `Parent` is a two-column relation, but the column list declares three
+    // names; the `SELECT *` body's width is known only after it compiles, so
+    // the declared arity is checked against the body's compiled width, faulting
+    // with `SQLError.columns` rather than trapping when a later read indexes a
+    // cell the row does not have.
+    #expect(throws: SQLError.columns(expected: 3, got: 2)) {
+      try statement("""
+          WITH a (x, y, z) AS (SELECT * FROM Parent) SELECT x FROM a
+          """, family())
+    }
+  }
+
+  @Test("a zero-row SELECT * CTE body of the wrong arity is rejected")
+  func zeroRowWidthMismatch() throws {
+    // `Parent` is a two-column relation, but the column list declares three
+    // names. The body `WHERE Id < 0` yields no rows, so a per-row check would
+    // pass it through vacuously and register `a` with a three-column schema
+    // over a two-column body; the trailing `SELECT z` then reads an ordinal the
+    // body never projects. The body's compiled width is checked against the
+    // declared arity BEFORE materialising, regardless of the row count, so the
+    // mismatch faults with `SQLError.columns` rather than silently returning
+    // data.
+    #expect(throws: SQLError.columns(expected: 3, got: 2)) {
+      try statement("""
+          WITH a (x, y, z) AS (SELECT * FROM Parent WHERE Id < 0)
+            SELECT z FROM a
+            UNION SELECT 99 AS z FROM Parent WHERE Id = 1
+          """, family())
+    }
+  }
+
+  @Test("a WITH list rejects a case-insensitively duplicate query name")
+  func duplicateName() throws {
+    // Two CTEs share a name (`a` and `A`), so the second would silently
+    // overwrite the first in the materialised scope — a typo in a multi-CTE
+    // query changing the result. The duplicate is rejected before materialising.
+    #expect(throws: SQLError.redefinition("A")) {
+      try statement("""
+          WITH a (x) AS (SELECT Id FROM Parent),
+               A (x) AS (SELECT Id FROM Parent)
+            SELECT x FROM a
+          """, family())
+    }
+  }
+
+  @Test("a WHERE pushed onto a joined-in CTE filters its rows before the join")
+  func joinPushedFilter() throws {
+    // `kids` is joined to `Parent` on the foreign key, and a single-relation
+    // `WHERE kids.Kid = 'Amy'` is pushed onto the CTE inner; only the matching
+    // CTE row may join, so a CTE row with any other `Kid` is excluded rather than
+    // paired.
+    let rows = try statement("""
+        WITH kids (Pid, Kid) AS (SELECT Pid, Name FROM Child)
+          SELECT Parent.Name, kids.Kid FROM Parent
+            JOIN kids ON kids.Pid = Parent.Id
+            WHERE kids.Kid = 'Amy'
+        """, family())
+    #expect(rows == [[.text("Ada"), .text("Amy")]])
+  }
+
+  @Test("a statement CTE does not leak into a registered view's body")
+  func viewScoping() throws {
+    // `Adults` is a view over the base `Parent`; a statement-local
+    // `WITH Parent (Id) AS …` must NOT reach into the view's stored body, so
+    // `SELECT Id FROM Adults` still reads the base `Parent`'s ids — a view means
+    // what it was registered to mean regardless of the caller's WITH. Were the
+    // caller's CTEs threaded into the view body, `Adults`'s `FROM Parent` would
+    // bind to the CTE and the query would return `99`.
+    let adults =
+        try View(query: select("SELECT Id FROM Parent"), columns: ["Id"])
+    let catalog = Memory(family().relations, views: ["Adults": adults])
+    let rows = try statement("""
+        WITH Parent (Id) AS (SELECT 99 AS Id FROM Parent WHERE Id = 1)
+          SELECT Id FROM Adults
+        """, catalog)
+    #expect(rows == [[.integer(1)], [.integer(2)], [.integer(3)]])
+  }
+
+  @Test("a top-level FROM a CTE still resolves to the CTE, not the base relation")
+  func topLevelCTEShadowsBase() throws {
+    // The complement of `viewScoping`: at the STATEMENT level a CTE that names a
+    // base relation still shadows it, so a trailing `FROM Parent` reads the CTE
+    // — the scoping fix narrows only a view's body, never the statement query.
+    let adults =
+        try View(query: select("SELECT Id FROM Parent"), columns: ["Id"])
+    let catalog = Memory(family().relations, views: ["Adults": adults])
+    let rows = try statement("""
+        WITH Parent (Id) AS (SELECT 99 AS Id FROM Parent WHERE Id = 1)
+          SELECT Id FROM Parent
+        """, catalog)
+    #expect(rows == [[.integer(99)]])
+  }
+
+  @Test("a WITH RECURSIVE arm that never names the CTE runs once, not to a cap")
+  func nonSelfReferentialUnionAll() throws {
+    // Every member of a `WITH RECURSIVE` list is syntactically marked recursive,
+    // but neither arm of this UNION ALL reads `a`, so it is not recursive in
+    // truth: it runs once, yielding exactly its two rows, rather than re-running
+    // an arm that adds nothing new until the recursion cap fires.
+    let rows = try statement("""
+        WITH RECURSIVE a (n) AS (
+          SELECT 1 AS n FROM Extra UNION ALL SELECT 2 AS n FROM Extra
+        )
+        SELECT n FROM a
+        """, tags())
+    #expect(rows == [[.integer(1)], [.integer(2)]])
+  }
+
+  @Test("a WITH RECURSIVE whose anchor reads a same-named base is not recursive")
+  func anchorReadsSameNamedBase() throws {
+    // The CTE `Parent` shares a base relation's name; only the ANCHOR reads that
+    // base (the CTE is not in scope there), while the recursive arm reads
+    // `Extra` and never names the CTE. Self-reference is detected in the arm
+    // alone, so this is NOT routed through the fixpoint: the two arms materialise
+    // once (UNION ALL) instead of the arm re-running to the recursion cap.
+    let catalog = Memory([
+      "Parent": Relation([Field(name: "Id", kind: .integer)],
+                         [[.integer(1)], [.integer(2)]] as Array<Array<Value>>),
+      "Extra": Relation([Field(name: "Id", kind: .integer)],
+                        [[.integer(3)]] as Array<Array<Value>>),
+    ])
+    let rows = try statement("""
+        WITH RECURSIVE Parent (Id) AS (
+          SELECT Id FROM Parent UNION ALL SELECT Id FROM Extra
+        )
+        SELECT Id FROM Parent
+        """, catalog)
+    #expect(rows == [[.integer(1)], [.integer(2)], [.integer(3)]])
+  }
+}

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -3176,3 +3176,303 @@ struct EngineWithTests {
     #expect(rows == [[.integer(1)], [.integer(2)], [.integer(3)]])
   }
 }
+
+// MARK: - WITH RECURSIVE tests
+
+/// A one-row seed catalog: a `Seed` relation of a single row, the FROM-less
+/// `SELECT 1` the dialect lacks expressed as `SELECT 1 FROM Seed`. It also
+/// carries an `Edge(Src, Dst)` relation for a transitive-closure test.
+private func seed() -> Memory {
+  let one = [Field(name: "One", kind: .integer)]
+  let seedRows = [[.integer(1)]] as Array<Array<Value>>
+
+  let edge = [
+    Field(name: "Src", kind: .integer),
+    Field(name: "Dst", kind: .integer),
+  ]
+  // 1 -> 2 -> 3 -> 4, a simple chain whose closure is every reachable pair.
+  let edges = [
+    [.integer(1), .integer(2)],
+    [.integer(2), .integer(3)],
+    [.integer(3), .integer(4)],
+  ] as Array<Array<Value>>
+
+  return Memory([
+    "Seed": Relation(one, seedRows),
+    "Edge": Relation(edge, edges),
+  ])
+}
+
+/// Routines with an `inc` scalar — `inc(n) = n + 1` — standing in for the `+`
+/// the dialect lacks, so a recursive counter can advance.
+private func counting() -> Routines {
+  Routines().registering("inc") { arguments throws(SQLError) in
+    guard case let .integer(n) = arguments.first else {
+      throw .argument("inc expects one integer argument")
+    }
+    return .integer(n + 1)
+  }
+}
+
+struct EngineRecursiveTests {
+  @Test("a recursive counter enumerates 1..5")
+  func counter() throws {
+    // The canonical recursive CTE: seed with 1, then inc(n) while n < 5. The
+    // anchor reads the one-row Seed; the recursive arm names the CTE `c`.
+    let query = try Statement(parsing: """
+        WITH RECURSIVE c (n) AS (
+          SELECT 1 AS n FROM Seed
+          UNION ALL
+          SELECT inc(n) AS n FROM c WHERE n < 5
+        )
+        SELECT n FROM c
+        """)
+    let rows = try Engine.run(query, seed(), counting())
+    #expect(rows == [[.integer(1)], [.integer(2)], [.integer(3)],
+                     [.integer(4)], [.integer(5)]])
+  }
+
+  @Test("a recursive counter runs through Engine.run(_:statement:)")
+  func statement() throws {
+    let rows = try Engine.run(Statement(parsing: """
+        WITH RECURSIVE c (n) AS (
+          SELECT 1 AS n FROM Seed
+          UNION ALL
+          SELECT inc(n) AS n FROM c WHERE n < 3
+        )
+        SELECT n FROM c
+        """), seed(), counting())
+    #expect(rows == [[.integer(1)], [.integer(2)], [.integer(3)]])
+  }
+
+  @Test("a non-UNION recursive CTE validates its compiled width")
+  func nonUnionWidthMismatch() throws {
+    // A `WITH RECURSIVE` member whose body is not a UNION runs once, but must
+    // still match its declared arity. Here the body resolves `Parent` against
+    // the base relation of the same name (two columns) under a three-column
+    // list; the non-UNION path validates the compiled width and faults rather
+    // than binding narrow rows that trap when the trailing `SELECT z` reads the
+    // absent ordinal.
+    #expect(throws: SQLError.columns(expected: 3, got: 2)) {
+      _ = try Engine.run(Statement(parsing: """
+          WITH RECURSIVE Parent (x, y, z) AS (SELECT * FROM Parent)
+            SELECT z FROM Parent
+          """), family())
+    }
+  }
+
+  @Test("a recursive CTE with more than one recursive arm is rejected")
+  func multipleRecursiveArms() throws {
+    // The body has TWO self-referential arms; the engine models one anchor plus
+    // one recursive arm, so the earlier recursive arm would land in the anchor
+    // (compiled with the CTE not in scope). Reject it with a clear `unsupported`
+    // diagnostic rather than failing obscurely as an unresolved relation.
+    let query = try Statement(parsing: """
+        WITH RECURSIVE c (n) AS (
+          SELECT 1 AS n FROM Seed
+          UNION ALL SELECT inc(n) AS n FROM c WHERE n < 3
+          UNION ALL SELECT inc(n) AS n FROM c WHERE n < 5
+        )
+        SELECT n FROM c
+        """)
+    #expect(throws: SQLError.unsupported(
+        "recursive WITH references the CTE outside its final UNION arm")) {
+      _ = try Engine.run(query, seed(), counting())
+    }
+  }
+
+  @Test("a recursive reference before the final UNION arm is rejected")
+  func recursiveArmBeforeFinal() throws {
+    // The self-reference (`FROM Parent`) is a MIDDLE arm and the final arm is
+    // non-recursive, so the recursive-arm check (which inspects the final arm)
+    // sees no recursion and the CTE would take the run-once path — compiling the
+    // middle `FROM Parent` against a same-named base (silently wrong) or, with
+    // none, an unresolved relation. With no same-named base/view it is rejected
+    // as an unsupported recursive shape.
+    let query = try Statement(parsing: """
+        WITH RECURSIVE Parent (Id) AS (
+          SELECT 1 AS Id FROM Seed
+          UNION ALL SELECT inc(Id) AS Id FROM Parent WHERE Id < 3
+          UNION ALL SELECT 99 AS Id FROM Seed
+        )
+        SELECT Id FROM Parent
+        """)
+    #expect(throws: SQLError.unsupported(
+        "recursive WITH references the CTE outside its final UNION arm")) {
+      _ = try Engine.run(query, seed(), counting())
+    }
+  }
+
+  @Test("a recursive CTE whose anchor reads a same-named base still evaluates")
+  func anchorShadowsBase() throws {
+    // `Parent` intentionally shadows a base relation of the same name: the anchor
+    // `SELECT Id FROM Parent` reads the BASE (the CTE is not in scope for the
+    // base case), seeding the recursion, while the right arm's `FROM Parent` is
+    // the true self-reference. The multiple-recursive-arm guard must NOT reject
+    // this — the anchor's reference resolves to an existing base relation, so it
+    // is a valid seed, not a misplaced recursive arm.
+    let catalog = Memory([
+      "Parent": Relation([Field(name: "Id", kind: .integer)],
+                         [[.integer(1)]] as Array<Array<Value>>),
+    ])
+    let rows = try Engine.run(Statement(parsing: """
+        WITH RECURSIVE Parent (Id) AS (
+          SELECT Id FROM Parent
+          UNION ALL SELECT inc(Id) AS Id FROM Parent WHERE Id < 5
+        )
+        SELECT Id FROM Parent
+        """), catalog, counting())
+    #expect(rows == [[.integer(1)], [.integer(2)], [.integer(3)],
+                     [.integer(4)], [.integer(5)]])
+  }
+
+  @Test("a recursive CTE whose anchor reads a same-named view still evaluates")
+  func anchorShadowsView() throws {
+    // Like `anchorShadowsBase`, but the same-named seed is a registered VIEW,
+    // not a base table: the anchor `SELECT id FROM v` resolves to the view (the
+    // CTE is not in scope for the base case), and the right arm is the true
+    // self-reference. The guard must accept a view seed as well as a table.
+    let view = try View(query: select("SELECT Id FROM Parent"), columns: ["id"])
+    let catalog = Memory([
+      "Parent": Relation([Field(name: "Id", kind: .integer)],
+                         [[.integer(1)]] as Array<Array<Value>>),
+    ], views: ["v": view])
+    let rows = try Engine.run(Statement(parsing: """
+        WITH RECURSIVE v (id) AS (
+          SELECT id FROM v
+          UNION ALL SELECT inc(id) AS id FROM v WHERE id < 5
+        )
+        SELECT id FROM v
+        """), catalog, counting())
+    #expect(rows == [[.integer(1)], [.integer(2)], [.integer(3)],
+                     [.integer(4)], [.integer(5)]])
+  }
+
+  @Test("UNION dedups rows a UNION ALL recursion would repeat")
+  func dedup() throws {
+    // The recursive arm re-derives n from 1 without a guard's monotonic bound,
+    // but a bare UNION dedups whole rows, so the fixpoint is the distinct set
+    // 1..4 reached and nothing new thereafter — it terminates where UNION ALL
+    // would loop. inc advances; the WHERE caps the run, and UNION drops dupes.
+    let query = try Statement(parsing: """
+        WITH RECURSIVE c (n) AS (
+          SELECT 1 AS n FROM Seed
+          UNION
+          SELECT inc(n) AS n FROM c WHERE n < 4
+        )
+        SELECT n FROM c
+        """)
+    let rows = try Engine.run(query, seed(), counting())
+    #expect(rows == [[.integer(1)], [.integer(2)], [.integer(3)],
+                     [.integer(4)]])
+  }
+
+  @Test("a bare UNION dedups duplicate anchor seed rows")
+  func anchorDedup() throws {
+    // The anchor is itself a UNION ALL that yields `1` twice, so the seed
+    // carries a duplicate; the recursive arm (`n < 1`) adds nothing new. A bare
+    // outer UNION dedups the seed exactly as it dedups an iteration step, so the
+    // duplicate anchor rows collapse to the single distinct row `1` rather than
+    // leaking both into the result.
+    let query = try Statement(parsing: """
+        WITH RECURSIVE c (n) AS (
+          SELECT 1 AS n FROM Seed
+          UNION ALL
+          SELECT 1 AS n FROM Seed
+          UNION
+          SELECT inc(n) AS n FROM c WHERE n < 1
+        )
+        SELECT n FROM c
+        """)
+    let rows = try Engine.run(query, seed(), counting())
+    #expect(rows == [[.integer(1)]])
+  }
+
+  @Test("a transitive-closure self-join reaches every descendant")
+  func closure() throws {
+    // The closure of the edge chain 1->2->3->4: seed with the direct edges,
+    // then extend each known reach (Src, Dst) by an edge out of Dst. The
+    // recursive arm joins the CTE to the base Edge relation.
+    let query = try Statement(parsing: """
+        WITH RECURSIVE reach (Src, Dst) AS (
+          SELECT Src, Dst FROM Edge
+          UNION ALL
+          SELECT reach.Src, Edge.Dst FROM reach
+            JOIN Edge ON Edge.Src = reach.Dst
+        )
+        SELECT Src, Dst FROM reach ORDER BY Src ASC
+        """)
+    let rows = try Engine.run(query, seed())
+    // Direct: (1,2)(2,3)(3,4); extended: (1,3)(2,4); further: (1,4).
+    let pairs = rows.map { row -> (Int, Int) in
+      guard case let .integer(a) = row[0], case let .integer(b) = row[1]
+      else { return (0, 0) }
+      return (a, b)
+    }
+    #expect(Set(pairs.map { "\($0.0)-\($0.1)" }) == [
+      "1-2", "2-3", "3-4", "1-3", "2-4", "1-4",
+    ])
+  }
+
+  @Test("a recursive arm of the wrong width faults, not traps, before rebinding")
+  func widthMismatch() throws {
+    // `Edge` is a two-column relation, but the column list declares three
+    // names; the anchor's `SELECT *` compiles to a two-wide plan the fixpoint
+    // would bind under the three-column schema, so the recursive arm's read of
+    // the absent third ordinal would trap in `Materialised.record`. The
+    // anchor's compiled width is checked against the declared arity BEFORE it
+    // seeds the working set, so the fault surfaces as `SQLError.columns` rather
+    // than a trap.
+    let query = try Statement(parsing: """
+        WITH RECURSIVE t (a, b, c) AS (
+          SELECT * FROM Edge
+          UNION ALL
+          SELECT a, b, c FROM t WHERE a < 0
+        )
+        SELECT a FROM t
+        """)
+    #expect(throws: SQLError.columns(expected: 3, got: 2)) {
+      try Engine.run(query, seed())
+    }
+  }
+
+  @Test("a zero-row SELECT * anchor of the wrong width faults, not passes")
+  func zeroRowWidthMismatch() throws {
+    // `Edge` is a two-column relation, but the column list declares three
+    // names. The anchor `WHERE Src < 0` yields no rows, so a per-row check
+    // would seed nothing to validate and bind the CTE under a three-column
+    // schema; the recursive arm's read of the absent third ordinal would then
+    // trap. The anchor's compiled width is checked against the declared arity
+    // BEFORE it seeds the working set, regardless of how many rows it produces,
+    // so the fault surfaces as `SQLError.columns`.
+    let query = try Statement(parsing: """
+        WITH RECURSIVE t (a, b, c) AS (
+          SELECT * FROM Edge WHERE Src < 0
+          UNION ALL
+          SELECT a, b, c FROM t WHERE a < 0
+        )
+        SELECT a FROM t
+        """)
+    #expect(throws: SQLError.columns(expected: 3, got: 2)) {
+      try Engine.run(query, seed())
+    }
+  }
+
+  @Test("a runaway recursion is capped with SQLError.recursion")
+  func runaway() throws {
+    // inc(n) with no terminating WHERE produces an unbounded sequence of new
+    // rows; UNION ALL keeps every one, so the fixpoint is never reached and the
+    // cap fires.
+    let query = try Statement(parsing: """
+        WITH RECURSIVE c (n) AS (
+          SELECT 1 AS n FROM Seed
+          UNION ALL
+          SELECT inc(n) AS n FROM c
+        )
+        SELECT n FROM c
+        """)
+    #expect(throws: SQLError.recursion("c")) {
+      try Engine.run(query, seed(), counting())
+    }
+  }
+}

--- a/Tests/SQLTests/ErrorTests.swift
+++ b/Tests/SQLTests/ErrorTests.swift
@@ -77,6 +77,9 @@ struct SQLStateTests {
     // standard one.
     #expect(SQLError.unsupported("SELECT * requires a FROM clause").sqlstate
             == "SS001")
+    #expect(SQLError.statement("CREATE VIEW is not a query").sqlstate
+            == "SS002")
+    #expect(SQLError.recursion("loop").sqlstate == "SS003")
   }
 
   @Test(".state round-trips its code and message")

--- a/Tests/SQLTests/LexerTests.swift
+++ b/Tests/SQLTests/LexerTests.swift
@@ -48,6 +48,16 @@ struct LexerTests {
     #expect(try lex("is null") == [.is, .null])
   }
 
+  @Test("lexes the WITH-clause keywords")
+  func withKeywords() throws {
+    #expect(try lex("WITH RECURSIVE") == [.with, .recursive])
+  }
+
+  @Test("lexes the WITH-clause keywords case-insensitively")
+  func withKeywordsCaseInsensitive() throws {
+    #expect(try lex("with Recursive") == [.with, .recursive])
+  }
+
   @Test("lexes the comparison operators")
   func operators() throws {
     #expect(try lex("= <> < > <= >=")

--- a/Tests/SQLTests/ParserTests.swift
+++ b/Tests/SQLTests/ParserTests.swift
@@ -797,3 +797,126 @@ struct UnionTests {
     #expect(view.query == .union(.select(left), right, all: false))
   }
 }
+
+// MARK: - WITH / CTE tests
+
+/// Parses `text` and returns its `(ctes, query)`, failing on any other shape.
+private func parseWith(_ text: String) throws -> (Array<CTE>, Query) {
+  guard case let .with(ctes, query) = try Statement(parsing: text) else {
+    Issue.record("expected a WITH statement")
+    throw SQLError.incomplete(expected: "a WITH statement")
+  }
+  return (ctes, query)
+}
+
+struct WithTests {
+  @Test("parses a single non-recursive CTE and its trailing query")
+  func single() throws {
+    let (ctes, query) = try parseWith("""
+        WITH a AS (SELECT x FROM t) SELECT x FROM a
+        """)
+    #expect(ctes.count == 1)
+    #expect(ctes[0].name == "a")
+    #expect(ctes[0].columns == ["x"])
+    #expect(ctes[0].recursive == false)
+    #expect(ctes[0].query
+                == .select(Select(projection: .columns(["x"]),
+                                  from: Relation(name: "t"))))
+    #expect(query == .select(Select(projection: .columns(["x"]),
+                                    from: Relation(name: "a"))))
+  }
+
+  @Test("infers a CTE's columns from its query's projection")
+  func inferred() throws {
+    let (ctes, _) = try parseWith("""
+        WITH a AS (SELECT p, q FROM t) SELECT p FROM a
+        """)
+    #expect(ctes[0].columns == ["p", "q"])
+  }
+
+  @Test("an explicit column list names a CTE's columns")
+  func explicit() throws {
+    let (ctes, _) = try parseWith("""
+        WITH a (k, v) AS (SELECT p, q FROM t) SELECT k FROM a
+        """)
+    #expect(ctes[0].columns == ["k", "v"])
+  }
+
+  @Test("parses several comma-separated CTEs in source order")
+  func chain() throws {
+    let (ctes, query) = try parseWith("""
+        WITH a AS (SELECT x FROM t), b AS (SELECT y FROM a) SELECT y FROM b
+        """)
+    #expect(ctes.map(\.name) == ["a", "b"])
+    #expect(ctes[1].query
+                == .select(Select(projection: .columns(["y"]),
+                                  from: Relation(name: "a"))))
+    #expect(query == .select(Select(projection: .columns(["y"]),
+                                    from: Relation(name: "b"))))
+  }
+
+  @Test("RECURSIVE marks every CTE of the list recursive")
+  func recursive() throws {
+    let (ctes, _) = try parseWith("""
+        WITH RECURSIVE a (n) AS (SELECT n FROM seed UNION ALL SELECT n FROM a)
+          SELECT n FROM a
+        """)
+    #expect(ctes[0].recursive == true)
+    #expect(ctes[0].columns == ["n"])
+    guard case .union = ctes[0].query else {
+      Issue.record("expected the recursive CTE's query to be a UNION")
+      return
+    }
+  }
+
+  @Test("a CTE's query may itself be a UNION")
+  func union() throws {
+    let (ctes, _) = try parseWith("""
+        WITH a AS (SELECT x FROM t UNION SELECT y FROM u) SELECT x FROM a
+        """)
+    let left = Select(projection: .columns(["x"]), from: Relation(name: "t"))
+    let right = Select(projection: .columns(["y"]), from: Relation(name: "u"))
+    #expect(ctes[0].query == .union(.select(left), right, all: false))
+  }
+
+  @Test("recognises lowercase with and recursive keywords")
+  func caseInsensitive() throws {
+    let (ctes, query) = try parseWith("""
+        with recursive a (n) as (select n from a) select n from a
+        """)
+    #expect(ctes[0].name == "a")
+    #expect(ctes[0].recursive == true)
+    #expect(query == .select(Select(projection: .columns(["n"]),
+                                    from: Relation(name: "a"))))
+  }
+
+  @Test("an explicit list of the wrong arity is rejected")
+  func arity() throws {
+    #expect(throws: SQLError.columns(expected: 2, got: 3)) {
+      _ = try parseWith("""
+          WITH a (x, y, z) AS (SELECT p, q FROM t) SELECT x FROM a
+          """)
+    }
+  }
+
+  @Test("a CTE naming two columns that collide by case is rejected")
+  func duplicate() throws {
+    #expect(throws: SQLError.duplicate("X")) {
+      _ = try parseWith("WITH a (x, X) AS (SELECT p, q FROM t) SELECT x FROM a")
+    }
+  }
+
+  @Test("a CTE projecting an un-nameable column with no list is rejected")
+  func unnamed() throws {
+    #expect(throws: SQLError.named("SELECT *")) {
+      _ = try parseWith("WITH a AS (SELECT * FROM t) SELECT x FROM a")
+    }
+  }
+
+  @Test("a CTE missing its parenthesised query is rejected")
+  func missingParen() throws {
+    #expect(throws: SQLError.self) {
+      _ = try parseWith("WITH a AS SELECT x FROM t SELECT x FROM a")
+    }
+  }
+}

--- a/Tests/winmd-inspectTests/DatabaseSQLTests.swift
+++ b/Tests/winmd-inspectTests/DatabaseSQLTests.swift
@@ -696,6 +696,35 @@ struct DatabaseSQLTests {
     }
   }
 
+  @Test("a `.bind` value threads into a WITH statement's parameterized body")
+  func bindThreadsIntoWith() throws {
+    // A `:name` in a `WITH` body must bind from the shell's `.bind` values the
+    // same way a plain `SELECT`'s does — `Session.run` forwards `bindings` to
+    // the WITH arm. Binding `:name` to a `TypeName` the fixture carries, then
+    // running a `WITH` whose CTE filters `WHERE TypeName = :name`, returns the
+    // one matching row. An unbound `:name` is UNKNOWN, so it admits nothing —
+    // the same behaviour the plain-SELECT arm exhibits.
+    try DatabaseSQLTests.with { catalog in
+      var shell = Shell(catalog)
+      try shell.execute(".bind name 'IMyInterface'")
+      let query = """
+          WITH t (n) AS (SELECT TypeName FROM TypeDef WHERE TypeName = :name)
+            SELECT n FROM t
+          """
+      let rows = try shell.session.run(query, bindings: shell.bindings)
+      #expect(rows == [[.text("IMyInterface")]])
+      // Rebinding to the other fixture type matches only it — the binding, not a
+      // default empty map, resolves the WITH body's parameter.
+      try shell.execute(".bind name 'INotGuid'")
+      let others = try shell.session.run(query, bindings: shell.bindings)
+      #expect(others == [[.text("INotGuid")]])
+      // An unbound parameter is UNKNOWN, so the predicate admits no row.
+      try shell.execute(".bind name")
+      let unbound = try shell.session.run(query, bindings: shell.bindings)
+      #expect(unbound.isEmpty)
+    }
+  }
+
   @Test("a `.template` registers an inline body that shadows a file lookup")
   func templateRegisters() throws {
     // `.template` stores its body in the shell's `templates`, and


### PR DESCRIPTION
This pull request adds support for SQL common table expressions (CTEs), including both non-recursive and recursive CTEs, to the query engine. It introduces new AST types to represent CTEs, extends the engine to compile and execute queries with CTEs, and implements correct scoping and fixpoint evaluation for recursive CTEs. The changes also ensure that CTEs shadow base relations and views, and add new error types for statement execution and recursion limits.

**Support for Common Table Expressions (CTEs):**

- Added a new `Statement.with` case and a `CTE` struct to the AST to represent CTEs and their properties, including support for recursive CTEs. (`Sources/SQL/AST.swift`)
- Extended the engine to compile and execute queries with CTEs, including correct scoping, materialization, and shadowing rules. (`Sources/SQL/Engine.swift`) [[1]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L43-R174) [[2]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L61-R221) [[3]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L122-R256) [[4]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L135-R269) [[5]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L164-R298) [[6]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L271-L303)
- Implemented fixpoint evaluation for recursive CTEs, with a recursion cap to prevent non-terminating queries. (`Sources/SQL/Engine.swift`)

**Query Planning and Optimization:**

- Updated the query planner and optimizer to handle CTEs, ensuring that CTEs are consulted before views and tables during resolution, and that CTEs are not seekable. (`Sources/SQL/Engine.swift`) [[1]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060R518-R527) [[2]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L383-R560) [[3]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060R579-R586) [[4]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060R675-R682) [[5]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L532-R704)

**Error Handling Enhancements:**

- Added new error types to signal when a statement cannot be run as a query (e.g., `CREATE VIEW`), and when a recursive CTE exceeds the iteration cap. (`Sources/SQL/Error.swift`)