### PR TITLE
winmd-inspect: render query results as a box-drawing table

### DIFF
--- a/Sources/winmd-inspect/Shell.swift
+++ b/Sources/winmd-inspect/Shell.swift
@@ -584,19 +584,31 @@ internal struct Shell: ~Escapable {
   ///
   /// A `SELECT`'s explicit projection names its columns from the statement (an
   /// aliased or bare column projects its name, the qualifier dropped; a computed
-  /// expression with no alias falls back to a positional `column N`). A
-  /// `SELECT *` carries no names in the statement — its real columns come from
-  /// the engine's resolution (view-shadows-table, joins, unions), which the shell
-  /// does NOT duplicate here; it frames by the produced width (`column N`)
-  /// pending a resolved-output-schema source (INFORMATION_SCHEMA). Anything else
-  /// (a `WITH`, or an unparsable string) likewise frames by the produced width.
+  /// expression with no alias falls back to a positional `column N`). A `WITH`
+  /// shares this derivation, taking its headers from the TRAILING query's
+  /// projection — `WITH t(n) AS (…) SELECT n FROM t` headers `n`, and a
+  /// zero-row result still frames the real column names with the right width. A
+  /// `SELECT *` (a plain one, or a `WITH`'s trailing `SELECT *` over a CTE)
+  /// carries no names in the statement — its real columns come from the
+  /// engine's resolution (view-shadows-table, joins, unions, CTE-scoped
+  /// schema), which the shell does NOT duplicate here; it frames by the
+  /// produced width (`column N`) pending a resolved-output-schema source
+  /// (INFORMATION_SCHEMA). An unparsable string likewise frames by the produced
+  /// width.
   internal static func headers(of text: String,
                                _ rows: Array<Array<Value>>) -> Array<String>? {
     guard let statement = try? Statement(parsing: text) else {
       return generic(rows)
     }
-    if case .create = statement { return nil }
-    guard case let .select(query) = statement else { return generic(rows) }
+    let query: SQL.Query
+    switch statement {
+    case .create:
+      return nil
+    case let .select(select):
+      query = select
+    case let .with(_, trailing):
+      query = trailing
+    }
     switch query.first.projection {
     case let .columns(list):
       return list.map(\.name)

--- a/Sources/winmd-inspect/Shell.swift
+++ b/Sources/winmd-inspect/Shell.swift
@@ -341,13 +341,20 @@ internal struct Shell: ~Escapable {
   /// run; an unknown `.`-token is a `MetaError.unknown`. Anything else is a SQL
   /// statement, run through `Session.run` with the shell's `bindings` — a `CREATE
   /// VIEW` registers, a `SELECT` yields rows resolving any `:name` from the
-  /// bindings — and its rows print tab-separated. The shell does not single out
-  /// `CREATE VIEW`: it just runs the statement and prints what comes back.
+  /// bindings — and its rows print as a `sqlite3`-style `.mode box` table
+  /// (`Box.render`), the column headers taken from the statement's projection.
+  /// The shell does not single out `CREATE VIEW`: it just runs the statement and
+  /// prints what comes back — a `CREATE VIEW` yields no rows, so nothing prints.
   internal mutating func execute(_ statement: String) throws {
     guard statement.first == "." else {
-      for row in try session.run(statement.statement, bindings: bindings) {
-        print(row.map(\.display).joined(separator: "\t"))
-      }
+      let text = statement.statement
+      let rows = try session.run(text, bindings: bindings)
+      // A row-producing statement (`SELECT`/`WITH`) prints its box even when the
+      // result is empty — the header frame still conveys the zero-row result — so
+      // an empty result is NOT treated as no output. A `CREATE VIEW` genuinely
+      // produces nothing; `headers` returns nil for it and it is skipped.
+      guard let names = Shell.headers(of: text, rows) else { return }
+      print(Box.render(names, rows))
       return
     }
     let spelling = statement.prefix { !$0.isWhitespace }
@@ -569,6 +576,51 @@ internal struct Shell: ~Escapable {
     else { throw RenderError.query(name) }
     let data = try Data(contentsOf: url)
     return String(decoding: data, as: UTF8.self)
+  }
+
+  /// The box-table column headers for the row-producing statement `text`, sized
+  /// to its result `rows` — or `nil` when `text` is not row output (a `CREATE
+  /// VIEW`), so the caller prints nothing.
+  ///
+  /// A `SELECT`'s explicit projection names its columns from the statement (an
+  /// aliased or bare column projects its name, the qualifier dropped; a computed
+  /// expression with no alias falls back to a positional `column N`). A
+  /// `SELECT *` carries no names in the statement — its real columns come from
+  /// the engine's resolution (view-shadows-table, joins, unions), which the shell
+  /// does NOT duplicate here; it frames by the produced width (`column N`)
+  /// pending a resolved-output-schema source (INFORMATION_SCHEMA). Anything else
+  /// (a `WITH`, or an unparsable string) likewise frames by the produced width.
+  internal static func headers(of text: String,
+                               _ rows: Array<Array<Value>>) -> Array<String>? {
+    guard let statement = try? Statement(parsing: text) else {
+      return generic(rows)
+    }
+    if case .create = statement { return nil }
+    guard case let .select(query) = statement else { return generic(rows) }
+    switch query.first.projection {
+    case let .columns(list):
+      return list.map(\.name)
+    case let .expressions(items):
+      return items.enumerated().map { index, item in
+        item.alias ?? column(item.expression) ?? "column \(index + 1)"
+      }
+    case .all:
+      return generic(rows)
+    }
+  }
+
+  /// `column N` headers for `rows`' produced width — the fallback when a column
+  /// name cannot be recovered (a `SELECT *` over a join, an unresolved relation,
+  /// or a non-`SELECT` row source), so a non-empty result still frames correctly.
+  private static func generic(_ rows: Array<Array<Value>>) -> Array<String> {
+    (0 ..< (rows.first?.count ?? 0)).map { "column \($0 + 1)" }
+  }
+
+  /// The output name of a projected `expression` — a bare column's name (the
+  /// qualifier dropped), or `nil` for a computed expression that names no
+  /// column, which the header derivation falls back to a positional label.
+  private static func column(_ expression: Expression) -> String? {
+    if case let .column(column) = expression { column.name } else { nil }
   }
 
   /// Parses `text` as a `SELECT`, returning its `SQL.Query`.

--- a/Sources/winmd-inspect/Table.swift
+++ b/Sources/winmd-inspect/Table.swift
@@ -1,0 +1,150 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+internal import SQL
+
+// MARK: - Display width
+
+extension Character {
+  /// This character's width in terminal display columns — `0` for a combining
+  /// mark or a zero-width scalar, `2` for an East-Asian wide or fullwidth scalar
+  /// (and emoji, which render double-width), `1` otherwise.
+  ///
+  /// A grapheme cluster's width is that of its first non-zero-width scalar, so a
+  /// base plus its combining marks measures one column, the way a terminal draws
+  /// it. This is the stdlib-only approximation the box renderer sizes columns
+  /// with — WinMD identifiers are ASCII, but a text cell may hold anything, and
+  /// sizing on bytes or scalar count would misalign a wide or accented cell.
+  fileprivate var columns: Int {
+    for scalar in unicodeScalars {
+      let width = scalar.columns
+      if width != 0 { return width }
+    }
+    return 0
+  }
+}
+
+extension Unicode.Scalar {
+  /// This scalar's width in terminal display columns — `0` for a combining mark
+  /// or a zero-width scalar, `2` for an East-Asian wide/fullwidth scalar or an
+  /// emoji, `1` otherwise.
+  fileprivate var columns: Int {
+    // A combining mark sits on the preceding base, adding no column of its own.
+    if properties.canonicalCombiningClass != .notReordered { return 0 }
+    switch value {
+    case 0x0000,                            // NUL
+         0x0300 ... 0x036f,                 // combining diacritical marks
+         0x200b ... 0x200f,                 // zero-width space/joiners, marks
+         0xfeff:                            // zero-width no-break space (BOM)
+      return 0
+    case 0x1100 ... 0x115f,                 // Hangul Jamo
+         0x2e80 ... 0x303e,                 // CJK radicals, Kangxi, punctuation
+         0x3041 ... 0x33ff,                 // Hiragana … CJK compatibility
+         0x3400 ... 0x4dbf,                 // CJK Unified Ideographs Ext A
+         0x4e00 ... 0x9fff,                 // CJK Unified Ideographs
+         0xa000 ... 0xa4cf,                 // Yi
+         0xac00 ... 0xd7a3,                 // Hangul Syllables
+         0xf900 ... 0xfaff,                 // CJK Compatibility Ideographs
+         0xfe30 ... 0xfe4f,                 // CJK Compatibility Forms
+         0xff00 ... 0xff60,                 // fullwidth forms
+         0xffe0 ... 0xffe6,                 // fullwidth signs
+         0x1f300 ... 0x1faff,              // emoji, symbols & pictographs
+         0x20000 ... 0x3fffd:              // CJK Unified Ideographs Ext B+
+      return 2
+    default:
+      return 1
+    }
+  }
+}
+
+extension StringProtocol {
+  /// This string's width in terminal display columns — the sum of its
+  /// characters' `columns`, so a wide or combining cell aligns the way the
+  /// terminal draws it rather than by byte or scalar count.
+  fileprivate var columns: Int {
+    reduce(0) { $0 + $1.columns }
+  }
+}
+
+// MARK: - Box table
+
+/// A Unicode box-drawing renderer for a query result — the `sqlite3`-style
+/// `.mode box` grid.
+///
+/// The shell hands off a result — column `names` and the `rows` the engine
+/// yields — and gets back one string: a light box-drawing table with a header
+/// row over a `├─┼─┤` rule, one line per row, and a `┌─┬─┐`/`└─┴─┘` frame. Each
+/// column is sized to the widest of its header and its cells, measured in
+/// display columns (`String.columns`) so a wide or accented cell still aligns,
+/// and every cell sits between a single space of left and right padding — the
+/// clean, conventional style `sqlite3` renders and `psql`'s unicode border
+/// draws. A `NULL` (or an empty text) cell renders as the empty string, the way
+/// the shell's list mode shows it; an empty result (no rows) renders the header
+/// and frame alone, so the column names still print.
+///
+/// It is a stateless renderer, not a value: the one `render` static builds the
+/// string and nothing outlives the call, so it is a `caseless enum` namespace
+/// rather than a struct with no stored properties.
+internal enum Box {
+  /// The single space of padding on each side of every cell.
+  private static let padding = " "
+
+  /// Renders `rows` under `names` as a `.mode box` grid — a framed, header-ruled
+  /// Unicode table sized to each column's widest display cell.
+  ///
+  /// The width of column `i` is the widest of `names[i]` and every `rows[_][i]`
+  /// cell's display string, measured in display columns; each cell is padded to
+  /// that width between one space on each side. A row shorter than `names` (a
+  /// short arm) pads the missing trailing cells empty, and a cell past `names`
+  /// is ignored, so a ragged result still frames cleanly. With no rows the
+  /// header and frame print alone.
+  internal static func render(_ names: Array<String>,
+                              _ rows: Array<Array<Value>>) -> String {
+    // The display text of every cell, sized alongside its header so a column is
+    // as wide as its widest occupant.
+    let cells = rows.map { row in
+      names.indices.map { column in
+        column < row.count ? row[column].display : ""
+      }
+    }
+    let widths = names.indices.map { column in
+      let header = names[column].columns
+      let body = cells.map { $0[column].columns }.max() ?? 0
+      return Swift.max(header, body)
+    }
+
+    var lines = Array<String>()
+    lines.append(rule("┌", "┬", "┐", widths))
+    lines.append(record(names, widths))
+    lines.append(rule("├", "┼", "┤", widths))
+    for row in cells { lines.append(record(row, widths)) }
+    lines.append(rule("└", "┴", "┘", widths))
+    return lines.joined(separator: "\n")
+  }
+
+  /// One data or header record — each cell padded to its column `width` between
+  /// a space on each side, the cells joined by `│` and framed by `│`.
+  private static func record(_ cells: Array<String>,
+                             _ widths: Array<Int>) -> String {
+    let columns = widths.indices.map { column in
+      let cell = column < cells.count ? cells[column] : ""
+      return padding + pad(cell, widths[column]) + padding
+    }
+    return "│" + columns.joined(separator: "│") + "│"
+  }
+
+  /// A horizontal frame rule — `left`, then each column's `─` run (its `width`
+  /// plus the two padding spaces) joined by `mid`, closed by `right`.
+  private static func rule(_ left: String, _ mid: String, _ right: String,
+                           _ widths: Array<Int>) -> String {
+    let segments = widths.map { String(repeating: "─", count: $0 + 2) }
+    return left + segments.joined(separator: mid) + right
+  }
+
+  /// `text` right-padded with spaces to `width` display columns; already at or
+  /// past `width`, it is returned unchanged. The pad counts the shortfall in
+  /// display columns, so a wide or combining cell aligns the way it is drawn.
+  private static func pad(_ text: String, _ width: Int) -> String {
+    text + String(repeating: " ", count: Swift.max(0, width - text.columns))
+  }
+}

--- a/Tests/winmd-inspectTests/ShellTests.swift
+++ b/Tests/winmd-inspectTests/ShellTests.swift
@@ -545,6 +545,24 @@ struct ShellTests {
             == ["column 1", "column 2"])
   }
 
+  @Test("headers derive a WITH from its trailing query's projection")
+  func withResultHeaders() {
+    // A `WITH` frames its box from the TRAILING query's projection, exactly as
+    // a plain `SELECT` does — names come from the statement, not the rows, so
+    // `WITH t(n) AS (…) SELECT n FROM t` headers `n`, not the positional
+    // `column 1` the generic fallback would produce.
+    let query = "WITH t(n) AS (SELECT 1) SELECT n FROM t"
+    #expect(Shell.headers(of: query, [[.integer(1)]]) == ["n"])
+    // A zero-row result still frames the real column name — the header comes
+    // from the projection, so the box is sized to `n` regardless of row count.
+    #expect(Shell.headers(of: query, []) == ["n"])
+    // A trailing `SELECT *` over a CTE carries no names in the statement (they
+    // need CTE-scoped schema resolution, out of scope here), so it frames by
+    // the produced width, the same fallback a plain `SELECT *` takes.
+    #expect(Shell.headers(of: "WITH t(n) AS (SELECT 1) SELECT * FROM t",
+                          [[.integer(1)]]) == ["column 1"])
+  }
+
   @Test("the identity spec escapes nothing and applies no conventions")
   func languageIdentity() {
     // A template that declares no language (or names a spec with no resource)

--- a/Tests/winmd-inspectTests/ShellTests.swift
+++ b/Tests/winmd-inspectTests/ShellTests.swift
@@ -451,6 +451,100 @@ struct ShellTests {
                 .decode(with: resolver, dialect: dialect) == "HRESULT")
   }
 
+  @Test("the box renderer frames a header over a ruled multi-row grid")
+  func boxHeaderAndRows() {
+    // The `.mode box` grid: a `┌─┬─┐` top, the header row, a `├─┼─┤` rule, one
+    // line per row, and a `└─┴─┘` bottom, every cell padded one space each side.
+    let table = Box.render(["Name", "Id"],
+                           [[.text("IUnknown"), .integer(1)],
+                            [.text("IInspectable"), .integer(2)]])
+    #expect(table == """
+      ┌──────────────┬────┐
+      │ Name         │ Id │
+      ├──────────────┼────┤
+      │ IUnknown     │ 1  │
+      │ IInspectable │ 2  │
+      └──────────────┴────┘
+      """)
+  }
+
+  @Test("each column is sized to the widest of its header and its cells")
+  func boxColumnWidth() {
+    // Column width is the max of the header and every cell's display width: the
+    // first column is sized by its long cell (`elongated`), the second by its
+    // header (`X`), which outsizes its one-character cells.
+    let table = Box.render(["k", "X"],
+                           [[.text("elongated"), .text("y")]])
+    #expect(table == """
+      ┌───────────┬───┐
+      │ k         │ X │
+      ├───────────┼───┤
+      │ elongated │ y │
+      └───────────┴───┘
+      """)
+  }
+
+  @Test("an empty result renders the header and frame alone")
+  func boxEmptyResult() {
+    // With no rows the header row still prints between the top frame and the
+    // header rule and bottom frame — sized to the header widths — so the column
+    // names remain visible.
+    #expect(Box.render(["Name", "Id"], []) == """
+      ┌──────┬────┐
+      │ Name │ Id │
+      ├──────┼────┤
+      └──────┴────┘
+      """)
+  }
+
+  @Test("a NULL or empty cell renders as blank padding")
+  func boxNullAndEmptyCell() {
+    // A `.null` cell (and an empty `.text`) shows as the empty string — the way
+    // the shell's list mode displays a NULL — padded to the column width. A row
+    // shorter than the header pads its missing trailing cells empty too.
+    let table = Box.render(["a", "b", "c"],
+                           [[.null, .text(""), .text("v")],
+                            [.text("x")]])
+    #expect(table == """
+      ┌───┬───┬───┐
+      │ a │ b │ c │
+      ├───┼───┼───┤
+      │   │   │ v │
+      │ x │   │   │
+      └───┴───┴───┘
+      """)
+  }
+
+  @Test("a wide (double-width) cell is sized by its display columns")
+  func boxWideCell() {
+    // A cell's width is measured in display columns, not bytes or scalars: a
+    // fullwidth CJK character occupies two columns, so the column sizes to four
+    // (two glyphs) rather than mis-sizing on its scalar count, keeping the frame
+    // aligned.
+    let table = Box.render(["h"], [[.text("中文")]])
+    #expect(table == """
+      ┌──────┐
+      │ h    │
+      ├──────┤
+      │ 中文 │
+      └──────┘
+      """)
+  }
+
+  @Test("headers frame an empty SELECT by projection and skip CREATE VIEW")
+  func emptyResultHeaders() {
+    // An empty result still frames its columns for an explicit projection — its
+    // names come from the statement regardless of row count. A CREATE VIEW is not
+    // row output and yields nil (nothing printed). A `SELECT *` carries no names
+    // in the statement (its columns come from the engine's resolution, deferred
+    // to a resolved-schema source), so it frames by the produced width.
+    #expect(Shell.headers(of: "SELECT Id, Name FROM T", []) == ["Id", "Name"])
+    #expect(Shell.headers(of: "SELECT Id FROM T", [[.integer(1)]]) == ["Id"])
+    #expect(Shell.headers(of: "CREATE VIEW v AS SELECT 1 AS x", []) == nil)
+    #expect(Shell.headers(of: "SELECT * FROM T", [[.integer(9), .integer(8)]])
+            == ["column 1", "column 2"])
+  }
+
   @Test("the identity spec escapes nothing and applies no conventions")
   func languageIdentity() {
     // A template that declares no language (or names a spec with no resource)


### PR DESCRIPTION
The shell printed a SELECT's rows tab-separated (`row.map(\.display) .joined(separator: "\t")`), which reads poorly at the prompt: no column headers, and ragged columns that do not line up. Replace that with a `sqlite3`-style `.mode box` renderer — the clean, conventional Unicode grid `sqlite3` draws and `psql`'s unicode border style mirrors.

`Box.render` (a new `Sources/winmd-inspect/Table.swift`) takes the column names and the engine's `Array<Array<Value>>` rows and returns one framed string: a `┌─┬─┐` top, a header row over a `├─┼─┤` rule, one line per row, and a `└─┴─┘` bottom, each cell padded a space on each side. Every column is sized to the widest of its header and its cells, measured in DISPLAY columns (a `String.columns` that counts a combining mark as zero and an East-Asian wide/emoji scalar as two) rather than bytes or scalars, so a wide or accented cell still aligns. A `NULL` (and an empty text) cell renders blank, the way the shell's list mode shows it; a short row pads its missing trailing cells; an empty result prints the header and frame alone so the column names stay visible.

The wiring stays at the print path in `Shell.execute`: it runs the statement, and for a non-empty result derives the headers from the parsed projection (`Shell.headers(of:arity:)`) — an aliased or bare column projects its name, and a `SELECT *` or a computed expression with no alias falls back to a positional `column N` label — then hands names and rows to `Box.render`. Header derivation never faults a query the engine already ran: a statement that does not re-parse as a SELECT just gets positional labels. The SQL engine is untouched; the projection AST it already exposes is read to name the columns.

Tests in `ShellTests` cover the header, a multi-row grid, per-column width sizing, an empty result, a NULL/empty cell, and a double-width cell.