### PR TITLE
SQL: add LIMIT/OFFSET row limiting to SELECT

### DIFF
--- a/Sources/SQL/AST.swift
+++ b/Sources/SQL/AST.swift
@@ -10,6 +10,7 @@
 ///   FROM <table> [AS alias]
 ///   (JOIN <table> [AS alias] ON <column> = <column>)*
 ///   [WHERE <predicate>] [ORDER BY <column> [ASC|DESC]]
+///   [OFFSET <skip> ROWS] [FETCH {FIRST | NEXT} <count> ROWS ONLY]
 /// ```
 ///
 /// The AST is a tree of fully escapable values — names, operators, and literal
@@ -91,7 +92,7 @@ public indirect enum Query: Hashable, Sendable {
 }
 
 /// A `SELECT` query: a projection over one relation or a chain of joins, with an
-/// optional predicate and ordering.
+/// optional predicate, ordering, and row limit.
 ///
 /// `from` is optional: a FROM-less `SELECT <expr-list>` yields exactly one row
 /// whose columns are the evaluated projection expressions, the standard SQL
@@ -118,14 +119,18 @@ public struct Select: Hashable, Sendable {
   /// The ordering applied to the result, if any.
   public let order: Order?
 
+  /// The row limit applied to the (ordered) result, if any.
+  public let limit: Limit?
+
   public init(projection: Projection, from: Relation?,
               joins: Array<Join> = [], predicate: Predicate? = nil,
-              order: Order? = nil) {
+              order: Order? = nil, limit: Limit? = nil) {
     self.projection = projection
     self.from = from
     self.joins = joins
     self.predicate = predicate
     self.order = order
+    self.limit = limit
   }
 
   /// The name of the primary relation, or the empty string for a FROM-less
@@ -350,5 +355,30 @@ public struct Order: Hashable, Sendable {
   public init(column: Column, ascending: Bool = true) {
     self.column = column
     self.ascending = ascending
+  }
+}
+
+/// A row-limiting clause — the standard `OFFSET <n> ROWS FETCH { FIRST | NEXT }
+/// <n> ROWS ONLY` — pairing an optional leading skip with an optional cap.
+///
+/// It applies to the ordered result — after `WHERE` and `ORDER BY`, but before
+/// the projection, so a row outside the page is never projected: skip the first
+/// `offset` rows, then take at most `count`. The two ISO clauses are independent
+/// — an `OFFSET` written without a `FETCH` leaves `count` `nil` (no cap, every
+/// row after the skip), and a `FETCH` without an `OFFSET` caps from the start
+/// (`offset` `0`). Both counts are non-negative; a `count` of `0` yields no rows
+/// and an `offset` past the end yields none.
+public struct Limit: Hashable, Sendable {
+  /// The greatest number of rows the result yields, or `nil` for no cap — an
+  /// `OFFSET` written without a `FETCH`.
+  public let count: Int?
+
+  /// The number of leading rows skipped before the count applies — `0` when no
+  /// `OFFSET` was written.
+  public let offset: Int
+
+  public init(count: Int?, offset: Int = 0) {
+    self.count = count
+    self.offset = offset
   }
 }

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -396,16 +396,26 @@ public enum Engine {
       throws(SQLError) -> Plan {
     guard let relation = select.from else {
       // A FROM-less select projects expressions over a single row; a `WHERE`,
-      // `ORDER BY`, or `JOIN` has no relation to apply to. The parser never
-      // produces that shape, but a direct `Select(from: nil, …)` can, so reject
-      // it rather than silently ignore the clause.
+      // `ORDER BY`, `OFFSET`/`FETCH`, or `JOIN` has no relation to apply to. The
+      // parser never produces that shape, but a direct `Select(from: nil, …)`
+      // can, so reject it rather than silently ignore the clause.
       guard select.joins.isEmpty, select.predicate == nil,
-          select.order == nil else {
-        throw .unsupported("a WHERE, ORDER BY, or JOIN requires a FROM clause")
+          select.order == nil, select.limit == nil else {
+        throw .unsupported(
+            "a WHERE, ORDER BY, OFFSET/FETCH, or JOIN requires a FROM clause")
       }
       return try scalar(select.projection)
     }
     let from = try resolve(relation, catalog, ctes)
+
+    if let limit = select.limit {
+      // The parser yields only non-negative counts (a `-` is its own token), but
+      // a direct `Limit(count:offset:)` may carry negatives the executor's skip
+      // and take would trap on. Reject them as a query error rather than crash.
+      guard limit.offset >= 0, (limit.count ?? 0) >= 0 else {
+        throw .unsupported("OFFSET and FETCH row counts must be non-negative")
+      }
+    }
 
     guard !select.joins.isEmpty else {
       var filter: Filter? = nil
@@ -425,7 +435,8 @@ public enum Engine {
       let scan = from.leaf(ordinals)
       return shape(scan, projection.map { $0.remapped(through: slot) },
                    filter.map { $0.remapped(through: slot) },
-                   order.map { (slot[$0.column]!, $0.ascending) })
+                   order.map { (slot[$0.column]!, $0.ascending) },
+                   select.limit)
     }
 
     // Resolve every joined relation and lay all relations — the FROM relation
@@ -507,7 +518,8 @@ public enum Engine {
 
     return shape(chain, projection.map { $0.remapped(through: slot) },
                  predicate.map { $0.remapped(through: slot) },
-                 order.map { (slot[$0.column]!, $0.ascending) })
+                 order.map { (slot[$0.column]!, $0.ascending) },
+                 select.limit)
   }
 
   /// Compiles a scalar (FROM-less) `SELECT <expr-list>` into `Project(single)`
@@ -625,12 +637,19 @@ public enum Engine {
     return slot
   }
 
-  /// Wraps `source` in the `Project(Sort(Select(_)))` operators, omitting the
-  /// `Select` and `Sort` layers when their clause is absent. The `projection`,
-  /// `filter`, and `order` are in slot space.
+  /// Wraps `source` in the `Project(Limit(Sort(Select(_))))` operators, omitting
+  /// each layer when its clause is absent. The `projection`, `filter`, and
+  /// `order` are in slot space.
+  ///
+  /// The row `limit` sits BELOW the projection — after `WHERE` and `ORDER BY`,
+  /// but before the select list is evaluated. A row outside the requested page
+  /// is dropped by the limit before its projection runs, so a projection that
+  /// could throw (`SELECT 1 / 0 … FETCH FIRST 0 ROWS ONLY`) never evaluates for
+  /// a discarded row and the query returns the documented empty page.
   private static func shape(_ source: Plan, _ projection: Array<Term>,
                             _ filter: Filter?,
-                            _ order: (slot: Int, ascending: Bool)?) -> Plan {
+                            _ order: (slot: Int, ascending: Bool)?,
+                            _ limit: Limit?) -> Plan {
     var plan = source
     if let filter {
       plan = .select(filter, plan)
@@ -638,7 +657,7 @@ public enum Engine {
     if let order {
       plan = .sort(slot: order.slot, ascending: order.ascending, plan)
     }
-    return .project(projection, plan)
+    return .project(projection, plan.capped(limit: limit))
   }
 
   // MARK: - Optimisation
@@ -710,6 +729,11 @@ public enum Engine {
       // preserving this node's own `all`.
       try .union(optimise(left, catalog, ctes, bindings),
                  optimise(right, catalog, ctes, bindings), all: all)
+    case let .limit(count, offset, source):
+      // A `limit` is a transparent wrapper — optimise its source and re-cap;
+      // the cap itself has no seek or join to rewrite.
+      try .limit(count: count, offset: offset,
+                 optimise(source, catalog, ctes, bindings))
     }
   }
 
@@ -999,6 +1023,12 @@ extension Plan {
       try .product(left.pushdown(), right.pushdown())
     case let .union(left, right, all):
       try .union(left.pushdown(), right.pushdown(), all: all)
+    case let .limit(count, offset, source):
+      // A `limit` is the outermost operator, so no `WHERE` conjunct ever reaches
+      // it to push down; it recurses transparently, its source pushed as usual.
+      // A filter must never cross it — capping before or after a filter yields
+      // different rows — and none can, since the cap sits above the projection.
+      try .limit(count: count, offset: offset, source.pushdown())
     }
   }
 

--- a/Sources/SQL/Lexer.swift
+++ b/Sources/SQL/Lexer.swift
@@ -51,7 +51,9 @@ extension String {
 /// scans the input's UTF-8 bytes by value and compares them against ASCII byte
 /// constants. Whitespace separates tokens and is otherwise discarded; keywords
 /// are recognised case-insensitively; string literals are single-quoted with
-/// `''` as an escaped quote.
+/// `''` as an escaped quote; a double-quoted delimited identifier (`""` an
+/// escaped quote) spells a name — a reserved word or otherwise — as an
+/// identifier verbatim.
 ///
 /// The lexer tracks a `SourceLocation` as it scans — advancing the column per
 /// byte and starting a fresh line on each newline — so every token and fault
@@ -129,6 +131,9 @@ internal struct Lexer: ~Escapable {
     case UInt8(ascii: "'"):
       return try string()
 
+    case UInt8(ascii: "\""):
+      return try delimited()
+
     case UInt8(ascii: ":"):
       return try parameter()
 
@@ -181,6 +186,48 @@ internal struct Lexer: ~Escapable {
         }
         advance()
         return Token(kind: .string(text), location: start)
+      default:
+        advance()
+      }
+    }
+
+    throw .unterminated(at: start)
+  }
+
+  /// Scans a double-quoted delimited identifier at the current position.
+  ///
+  /// A delimited identifier spells a name a bare identifier cannot: a reserved
+  /// word used as a column (`"Offset"`, which `ManifestResource` and
+  /// `FieldLayout` declare), or a spelling outside the identifier bytes. Its
+  /// text is taken verbatim and case-sensitively — never matched against the
+  /// keywords — so it is a `quoted` token, distinct from a bare `identifier` so
+  /// the parser keeps a dot in it as part of the name rather than a qualifier; a
+  /// doubled quote `""` is an escaped quote, mirroring a string literal's `''`.
+  /// Faults if unclosed.
+  private mutating func delimited() throws(SQLError) -> Token {
+    let start = location
+    advance()
+    let begin = position
+
+    // As with a string literal, defer assembling the text from segments until a
+    // doubled quote appears, and otherwise materialise the whole run at close.
+    var value: String? = nil
+    var segment = position
+    while let byte = peek() {
+      switch byte {
+      case UInt8(ascii: "\"") where peek(1) == UInt8(ascii: "\""):
+        value = (value ?? "") + String(bytes, segment ..< position) + "\""
+        advance()
+        advance()
+        segment = position
+      case UInt8(ascii: "\""):
+        let text = if let value {
+          value + String(bytes, segment ..< position)
+        } else {
+          String(bytes, begin ..< position)
+        }
+        advance()
+        return Token(kind: .quoted(text), location: start)
       default:
         advance()
       }
@@ -243,6 +290,11 @@ internal struct Lexer: ~Escapable {
     case "BY": .by
     case "ASC": .asc
     case "DESC": .desc
+    case "OFFSET": .offset
+    case "FETCH": .fetch
+    case "FIRST", "NEXT": .first
+    case "ROW", "ROWS": .rows
+    case "ONLY": .only
     case "AND": .and
     case "OR": .or
     case "NOT": .not

--- a/Sources/SQL/Operator.swift
+++ b/Sources/SQL/Operator.swift
@@ -144,6 +144,14 @@ internal indirect enum Plan {
   /// appends the trailing arm. Both sides yield rows of the same width — the
   /// result columns of the first arm.
   case union(Plan, Plan, all: Bool)
+  /// A row cap on its `source`'s output: skips the first `offset` records then
+  /// takes at most `count` of the rest, in the source's order. It sits over the
+  /// sort/select but BELOW the projection, so it caps the ordered rows before
+  /// the select list is evaluated — a row outside the page is never projected
+  /// (a projection that could throw does not run for it). It neither reorders
+  /// nor reshapes the rows, a transparent wrapper the pushdown and optimise
+  /// passes recurse through.
+  case limit(count: Int?, offset: Int, Plan)
 }
 
 extension Plan {
@@ -159,6 +167,10 @@ extension Plan {
       terms.count
     case let .union(left, _, _):
       left.width
+    case let .limit(_, _, source):
+      // A `limit` caps rows without reshaping them, so it is as wide as its
+      // source.
+      source.width
     default:
       // `compile` always tops an arm with a `project`; nothing else reaches a
       // view's sub-plan root. Measuring nil would mask a width mismatch, so a
@@ -200,9 +212,21 @@ extension Plan {
       // Both sides yield rows of the same width — the result columns — so the
       // union's width is its left side's.
       left.slots
+    case let .limit(_, _, source):
+      // A `limit` caps rows without reshaping them, so it spans the same slots
+      // as its source.
+      source.slots
     default:
       nil
     }
+  }
+
+  /// This plan capped by `limit` — wrapped in a `limit` operator when one is
+  /// present, else returned unchanged. `shape` caps the sorted/selected rows
+  /// with this and then projects, so the cap sits below the projection.
+  internal func capped(limit: Limit?) -> Plan {
+    guard let limit else { return self }
+    return .limit(count: limit.count, offset: limit.offset, self)
   }
 }
 
@@ -218,7 +242,8 @@ extension Plan {
 /// outer record with every inner one; `join` re-resolves the inner relation,
 /// seeks it per outer record, and concatenates the matches; `union` runs its
 /// two sides — each with its own union semantics — and concatenates their rows,
-/// deduplicating the whole row unless `all`.
+/// deduplicating the whole row unless `all`; `limit` skips the first `offset` of
+/// its source's rows then takes at most `count`.
 /// The catalog is borrowed throughout — a `~Escapable` source is never copied
 /// or stored.
 internal func execute<C: Catalog & ~Escapable>(_ plan: Plan,
@@ -268,7 +293,27 @@ internal func execute<C: Catalog & ~Escapable>(_ plan: Plan,
              base, column, keys, filter, catalog, ctes, routines, bindings)
   case let .union(left, right, all):
     try union(left, right, all, catalog, ctes, routines, bindings)
+  case let .limit(count, offset, source):
+    limited(try execute(source, catalog, ctes, routines, bindings),
+            count, offset)
   }
+}
+
+/// Caps `records` to at most `count` rows after skipping the first `offset`, in
+/// their existing (ordered) order.
+///
+/// A `nil` `count` is no cap — every row after the skip (an `OFFSET` without a
+/// `FETCH`). An `offset` at or past the end yields no rows; a `count` reaching
+/// past the remaining rows takes all of them. Both are non-negative, so the skip
+/// and the take never index before the start. The take is a `prefix` of the
+/// skipped slice rather than an `offset + count` bound, so a `count` near
+/// `Int.max` caps the slice instead of overflowing.
+private func limited(_ records: Array<Record>, _ count: Int?, _ offset: Int)
+    -> Array<Record> {
+  guard offset < records.count else { return [] }
+  let tail = records[offset...]
+  guard let count else { return Array(tail) }
+  return Array(tail.prefix(count))
 }
 
 /// Concatenates the rows of `left` followed by `right`, deduplicating the whole

--- a/Sources/SQL/Parser.swift
+++ b/Sources/SQL/Parser.swift
@@ -13,7 +13,8 @@
 /// cte            := identifier ['(' identifier (',' identifier)* ')']
 ///                   AS '(' query ')'
 /// query          := select (UNION [ALL] select)*
-/// select         := SELECT projection [FROM relation (join)* [where] [order]]
+/// select         := SELECT projection
+///                   [FROM relation (join)* [where] [order] [limit]]
 /// relation       := identifier [AS identifier]
 /// join           := JOIN relation ON column '=' column
 /// projection     := '*' | column (',' column)*
@@ -29,7 +30,10 @@
 /// multiplicative := factor (('*' | '/') factor)*
 /// factor         := '(' expression ')' | literal | call | column
 /// order          := ORDER BY column [ASC | DESC]
+/// limit          := [OFFSET integer ROWS]
+///                   [FETCH (FIRST | NEXT) [integer] ROWS ONLY]
 /// column         := identifier        // a dotted identifier is qualified
+/// identifier     := word | '"' … '"'  // a delimited identifier is verbatim
 /// ```
 ///
 /// Arithmetic precedence is `*` `/` > `+` `-`, both levels left-associative; the
@@ -238,7 +242,7 @@ internal struct Parser: ~Escapable {
   ///
   /// `FROM` is optional: a FROM-less `SELECT <expr-list>` projects over a single
   /// empty row (the standard way to compute a scalar, `SELECT 1 + 1`), and so
-  /// admits no relation, joins, `WHERE`, or `ORDER BY` to follow.
+  /// admits no relation, joins, `WHERE`, `ORDER BY`, or `LIMIT` to follow.
   private mutating func select() throws(SQLError) -> Select {
     try expect(.select)
     let projection = try projection()
@@ -261,9 +265,10 @@ internal struct Parser: ~Escapable {
     } else {
       nil
     }
+    let limit = try rowLimit()
 
     return Select(projection: projection, from: from, joins: joins,
-                  predicate: predicate, order: order)
+                  predicate: predicate, order: order, limit: limit)
   }
 
   // MARK: - Relation
@@ -278,12 +283,22 @@ internal struct Parser: ~Escapable {
     let name = try identifier()
     let alias: String? = if try match(.as) {
       try identifier()
-    } else if case .identifier = current?.kind {
+    } else if isName(current?.kind) {
       try identifier()
     } else {
       nil
     }
     return Relation(name: name, alias: alias)
+  }
+
+  /// Whether `kind` begins an identifier — a bare or a delimited name — the
+  /// token an optional (`AS`-less) relation alias may start with, so a following
+  /// keyword or the end of input is not mistaken for an alias.
+  private func isName(_ kind: Token.Kind?) -> Bool {
+    switch kind {
+    case .identifier, .quoted: true
+    default: false
+    }
   }
 
   /// Parses the join tail (the `JOIN` keyword is already consumed): a relation,
@@ -401,9 +416,12 @@ internal struct Parser: ~Escapable {
       return .literal(.integer(value))
     }
 
-    let name = try identifier()
+    let ident = try name()
     guard try match(.lparen) else {
-      return .column(Column(name))
+      // A delimited name is a verbatim column (a dot in it is part of the name);
+      // a bare one may be a qualified reference that `Column(_:)` splits.
+      return .column(ident.quoted ? Column(name: ident.text)
+                                  : Column(ident.text))
     }
 
     var arguments = Array<Expression>()
@@ -414,7 +432,7 @@ internal struct Parser: ~Escapable {
       }
     }
     try expect(.rparen)
-    return .call(name: name, arguments: arguments)
+    return .call(name: ident.text, arguments: arguments)
   }
 
   // MARK: - Predicate
@@ -545,24 +563,88 @@ internal struct Parser: ~Escapable {
     return Order(column: column, ascending: ascending)
   }
 
+  // MARK: - Row limiting
+
+  /// Parses the standard row-limiting tail — `[OFFSET n ROWS] [FETCH { FIRST |
+  /// NEXT } [n] ROWS ONLY]` — into a `Limit`, or `nil` when neither clause is
+  /// present.
+  ///
+  /// The two ISO clauses are independent: an `OFFSET` without a `FETCH` skips
+  /// rows with no cap (`count` `nil`), a `FETCH` without an `OFFSET` caps from
+  /// the start. `ROW` and `ROWS` are interchangeable, as are `FIRST` and `NEXT`,
+  /// and the `FETCH` count defaults to `1` when omitted (`FETCH FIRST ROW
+  /// ONLY`). Both counts are non-negative integer literals; a bare or negative
+  /// spelling is not one (the lexer scans a `-` as its own token), so it faults
+  /// as any other misplaced token would.
+  private mutating func rowLimit() throws(SQLError) -> Limit? {
+    let offset: Int
+    if try match(.offset) {
+      offset = try count()
+      try expect(.rows)
+    } else {
+      offset = 0
+    }
+
+    let cap: Int?
+    if try match(.fetch) {
+      try expect(.first)
+      cap = if case .integer = current?.kind { try count() } else { 1 }
+      try expect(.rows)
+      try expect(.only)
+    } else {
+      cap = nil
+    }
+
+    guard offset != 0 || cap != nil else { return nil }
+    return Limit(count: cap, offset: offset)
+  }
+
   // MARK: - Terminals
 
-  /// Consumes an identifier and returns its name.
-  private mutating func identifier() throws(SQLError) -> String {
+  /// Consumes a non-negative integer literal and returns its value — an
+  /// `OFFSET` skip or a `FETCH` row count.
+  private mutating func count() throws(SQLError) -> Int {
+    let token = try advance(expecting: "an integer")
+    guard case let .integer(value) = token.kind else {
+      throw .unexpected(token.kind.description,
+                        expected: "an integer", at: token.location)
+    }
+    return value
+  }
+
+  /// Consumes an identifier — bare or delimited — as its text and whether it was
+  /// delimited (double-quoted). A delimited name is verbatim, so a caller
+  /// building a column keeps a dot in it as part of the name rather than a
+  /// qualifier.
+  private mutating func name() throws(SQLError) -> (text: String, quoted: Bool) {
     let token = try advance(expecting: "an identifier")
-    guard case let .identifier(name) = token.kind else {
+    switch token.kind {
+    case let .identifier(text):
+      return (text, false)
+    case let .quoted(text):
+      return (text, true)
+    default:
       throw .unexpected(token.kind.description,
                         expected: "an identifier", at: token.location)
     }
-    return name
   }
 
-  /// Consumes an identifier and parses it as a (possibly-qualified) column.
+  /// Consumes an identifier — bare or delimited — and returns its name. Callers
+  /// that name a relation, alias, or CTE take the text alone; the delimited flag
+  /// matters only where a dot could be a qualifier (`column`).
+  private mutating func identifier() throws(SQLError) -> String {
+    try name().text
+  }
+
+  /// Consumes an identifier and parses it as a column reference.
   ///
-  /// A qualifying dot is part of the identifier the lexer scans, so the column
-  /// reference is one identifier token that `Column(_:)` splits.
+  /// A bare identifier's qualifying dot is part of the one token the lexer
+  /// scans, so `Column(_:)` splits it (`t.Name` → qualifier `t`, name `Name`). A
+  /// delimited identifier is verbatim, so a dot in it belongs to an unqualified
+  /// name (`"a.b"` is the column `a.b`, not `a`.`b`).
   private mutating func column() throws(SQLError) -> Column {
-    try Column(identifier())
+    let ident = try name()
+    return ident.quoted ? Column(name: ident.text) : Column(ident.text)
   }
 
   // MARK: - Cursor

--- a/Sources/SQL/Token.swift
+++ b/Sources/SQL/Token.swift
@@ -26,6 +26,11 @@ extension Token {
     case by
     case asc
     case desc
+    case offset
+    case fetch
+    case first
+    case rows
+    case only
     case and
     case or
     case not
@@ -41,6 +46,9 @@ extension Token {
 
     // Operands.
     case identifier(String)
+    /// A delimited (double-quoted) identifier — a name taken verbatim, so unlike
+    /// a bare `identifier` a dot in it is part of the name, not a qualifier.
+    case quoted(String)
     case string(String)
     case integer(Int)
     /// A bound parameter placeholder `:name`, holding the parameter's name.
@@ -76,6 +84,11 @@ extension Token.Kind {
     case .by: "BY"
     case .asc: "ASC"
     case .desc: "DESC"
+    case .offset: "OFFSET"
+    case .fetch: "FETCH"
+    case .first: "FIRST"
+    case .rows: "ROWS"
+    case .only: "ONLY"
     case .and: "AND"
     case .or: "OR"
     case .not: "NOT"
@@ -89,6 +102,7 @@ extension Token.Kind {
     case .with: "WITH"
     case .recursive: "RECURSIVE"
     case let .identifier(name): name
+    case let .quoted(name): "\"\(name)\""
     case let .string(value): "'\(value)'"
     case let .integer(value): "\(value)"
     case let .parameter(name): ":\(name)"

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -1178,6 +1178,8 @@ private func derived(_ plan: Plan) -> Plan? {
     derived(left) ?? derived(right)
   case let .union(left, right, _):
     derived(left) ?? derived(right)
+  case let .limit(_, _, source):
+    derived(source)
   case .single, .scan, .join:
     nil
   }
@@ -1204,6 +1206,8 @@ private func seeks(_ plan: Plan) -> Bool {
     seeks(outer)
   case let .union(left, right, _):
     seeks(left) || seeks(right)
+  case let .limit(_, _, source):
+    seeks(source)
   case .single:
     false
   }
@@ -1227,6 +1231,8 @@ private func filters(_ plan: Plan) -> Bool {
     filters(left) || filters(right)
   case let .union(left, right, _):
     filters(left) || filters(right)
+  case let .limit(_, _, source):
+    filters(source)
   case .single, .scan, .join:
     false
   }
@@ -1253,6 +1259,8 @@ private func pushed(_ plan: Plan) -> Bool {
     pushed(sub)
   case let .union(left, right, _):
     pushed(left) || pushed(right)
+  case let .limit(_, _, source):
+    pushed(source)
   case .single, .scan:
     false
   }
@@ -1270,6 +1278,8 @@ private func floats(_ plan: Plan) -> Bool {
     floats(source)
   case let .derived(_, sub, _, _):
     floats(sub)
+  case let .limit(_, _, source):
+    floats(source)
   default:
     false
   }
@@ -1286,6 +1296,8 @@ private func joins(_ plan: Plan) -> Bool {
   case let .project(_, source):
     joins(source)
   case let .sort(_, _, source):
+    joins(source)
+  case let .limit(_, _, source):
     joins(source)
   case let .derived(_, sub, _, _):
     joins(sub)
@@ -1310,6 +1322,8 @@ private func residual(_ plan: Plan) -> Bool {
   case let .project(_, source):
     residual(source)
   case let .sort(_, _, source):
+    residual(source)
+  case let .limit(_, _, source):
     residual(source)
   case let .derived(_, sub, _, _):
     residual(sub)
@@ -1416,6 +1430,8 @@ private func injected(_ plan: Plan) -> Bool {
   case let .project(_, source):
     injected(source)
   case let .sort(_, _, source):
+    injected(source)
+  case let .limit(_, _, source):
     injected(source)
   case let .derived(_, sub, _, _):
     injected(sub)
@@ -2884,12 +2900,14 @@ struct EngineScalarSelectTests {
 
   @Test("a directly-built FROM-less select with clauses is rejected")
   func clauses() throws {
-    // The parser never builds a FROM-less select carrying a WHERE, ORDER BY, or
-    // JOIN, but `Select.init` is public, so a direct `Select(from: nil, …)` can.
-    // The engine must reject it rather than silently drop the clause — a false
-    // predicate would otherwise still return the scalar row.
+    // The parser never builds a FROM-less select carrying a WHERE, ORDER BY,
+    // OFFSET/FETCH, or JOIN, but `Select.init` is public, so a direct
+    // `Select(from: nil, …)` can. The engine must reject it rather than
+    // silently drop the clause — a false predicate would otherwise still
+    // return the scalar row.
     let fault =
-        SQLError.unsupported("a WHERE, ORDER BY, or JOIN requires a FROM clause")
+        SQLError.unsupported(
+            "a WHERE, ORDER BY, OFFSET/FETCH, or JOIN requires a FROM clause")
     let filtered = try EngineScalarSelectTests.select(
         "SELECT 1 FROM People WHERE Id = 99")
     #expect(throws: fault) {
@@ -2902,6 +2920,12 @@ struct EngineScalarSelectTests {
     #expect(throws: fault) {
       try Engine.run(.select(Select(projection: ordered.projection, from: nil,
                                     order: ordered.order)), people())
+    }
+    let limited = try EngineScalarSelectTests.select(
+        "SELECT Id FROM People FETCH FIRST 1 ROW ONLY")
+    #expect(throws: fault) {
+      try Engine.run(.select(Select(projection: limited.projection, from: nil,
+                                    limit: limited.limit)), people())
     }
     let joined = try EngineScalarSelectTests.select(
         "SELECT Id FROM People JOIN Pets ON Pets.Owner = People.Id")
@@ -3021,7 +3045,7 @@ struct EngineWithTests {
   func arity() throws {
     #expect(throws: SQLError.columns(expected: 2, got: 1)) {
       try statement("""
-          WITH a (only) AS (SELECT Id, Name FROM Parent) SELECT only FROM a
+          WITH a (x) AS (SELECT Id, Name FROM Parent) SELECT x FROM a
           """, family())
     }
   }

--- a/Tests/SQLTests/LexerTests.swift
+++ b/Tests/SQLTests/LexerTests.swift
@@ -58,6 +58,14 @@ struct LexerTests {
     #expect(try lex("with Recursive") == [.with, .recursive])
   }
 
+  @Test("lexes the row-limiting keywords")
+  func rowLimitKeywords() throws {
+    #expect(try lex("OFFSET FETCH FIRST ROWS ONLY")
+                == [.offset, .fetch, .first, .rows, .only])
+    // ROW is a synonym of ROWS, and NEXT of FIRST.
+    #expect(try lex("ROW NEXT") == [.rows, .first])
+  }
+
   @Test("lexes the comparison operators")
   func operators() throws {
     #expect(try lex("= <> < > <= >=")
@@ -95,6 +103,20 @@ struct LexerTests {
   @Test("lexes an empty string literal")
   func emptyString() throws {
     #expect(try lex("''") == [.string("")])
+  }
+
+  @Test("lexes a delimited identifier verbatim")
+  func delimitedIdentifier() throws {
+    // A double-quoted name is a `quoted` token, case-preserved and never a
+    // keyword — distinct from a bare identifier so a dot in it is kept.
+    #expect(try lex("\"Offset\"") == [.quoted("Offset")])
+    #expect(try lex("\"select\"") == [.quoted("select")])
+    #expect(try lex("\"a.b\"") == [.quoted("a.b")])
+  }
+
+  @Test("unescapes a doubled quote in a delimited identifier")
+  func escapedQuoteInIdentifier() throws {
+    #expect(try lex("\"a\"\"b\"") == [.quoted("a\"b")])
   }
 
   @Test("lexes tokens with no separating whitespace")
@@ -144,6 +166,11 @@ struct LexerTests {
   @Test("rejects an unterminated string")
   func unterminatedString() {
     #expect(throws: SQLError.self) { _ = try lex("'oops") }
+  }
+
+  @Test("rejects an unterminated delimited identifier")
+  func unterminatedIdentifier() {
+    #expect(throws: SQLError.self) { _ = try lex("\"oops") }
   }
 
   @Test("scans a bound-parameter placeholder")

--- a/Tests/SQLTests/LimitTests.swift
+++ b/Tests/SQLTests/LimitTests.swift
@@ -1,0 +1,312 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQL
+
+// MARK: - In-memory adapter
+
+/// An in-memory relation: a fixed schema plus rows of typed values.
+///
+/// The `sorted` flag marks a single integral column whose rows are stored in
+/// ascending order; `bound` reports a boundary for that column and `nil` for
+/// any other, so a `FETCH` after a seekable `WHERE` still exercises the cap.
+/// This harness knows nothing of WinMD — it is a self-contained fixture for the
+/// row-limiting (`OFFSET`/`FETCH`) tests, deliberately independent of
+/// `EngineTests.swift` so the two files reconcile cleanly.
+private struct LimitRelation: Sendable {
+  let names: Array<String>
+  let records: Array<Array<Value>>
+  /// The ordinal of the sorted column, or `nil` if the relation is unsorted.
+  let sorted: Int?
+
+  init(_ names: Array<String>, _ records: Array<Array<Value>>,
+       sorted: Int? = nil) {
+    self.names = names
+    self.records = records
+    self.sorted = sorted
+  }
+}
+
+/// A `Catalog` over a dictionary of named relations.
+private struct LimitMemory: Catalog {
+  let relations: Dictionary<String, LimitRelation>
+
+  init(_ relations: Dictionary<String, LimitRelation>) {
+    self.relations = relations
+  }
+
+  func table(named name: String) -> LimitTable? {
+    guard let relation = relations[name] else { return nil }
+    return LimitTable(relation)
+  }
+}
+
+/// A `Table` over one in-memory relation.
+private struct LimitTable: Table {
+  let relation: LimitRelation
+
+  init(_ relation: LimitRelation) {
+    self.relation = relation
+  }
+
+  var width: Int { relation.names.count }
+
+  var names: Array<String> { relation.names }
+
+  func ordinal(of name: String) -> Int? {
+    relation.names.firstIndex(of: name)
+  }
+
+  func bound(_ column: Int, _ value: Int, strict: Bool) -> Int? {
+    guard column == relation.sorted else { return nil }
+    var lower = 0
+    var upper = relation.records.count
+    while lower < upper {
+      let middle = lower + (upper - lower) / 2
+      guard case let .integer(cell) = relation.records[middle][column] else {
+        return nil
+      }
+      let before = strict ? cell <= value : cell < value
+      if before {
+        lower = middle + 1
+      } else {
+        upper = middle
+      }
+    }
+    return lower
+  }
+
+  func cursor() -> LimitCursor {
+    LimitCursor(relation)
+  }
+}
+
+/// An index-addressed cursor over a relation's rows.
+private struct LimitCursor: Cursor {
+  let relation: LimitRelation
+
+  init(_ relation: LimitRelation) {
+    self.relation = relation
+  }
+
+  var count: Int { relation.records.count }
+
+  func row(_ index: Int) -> LimitRow? {
+    guard index < relation.records.count else { return nil }
+    return LimitRow(relation, index)
+  }
+}
+
+/// A positional view over one row's cells.
+private struct LimitRow: Row {
+  let relation: LimitRelation
+  let index: Int
+
+  init(_ relation: LimitRelation, _ index: Int) {
+    self.relation = relation
+    self.index = index
+  }
+
+  subscript(_ column: Int) -> Value {
+    borrowing get { relation.records[index][column] }
+  }
+}
+
+// MARK: - Fixtures
+
+/// A `People` relation of five rows, sorted ascending on its `Id` column.
+private func people() -> LimitMemory {
+  let records = [
+    [.integer(1), .text("Alice"), .integer(30)],
+    [.integer(2), .text("Bob"), .integer(25)],
+    [.integer(3), .text("Carol"), .integer(30)],
+    [.integer(4), .text("Dave"), .integer(40)],
+    [.integer(5), .text("Eve"), .integer(25)],
+  ] as Array<Array<Value>>
+  return LimitMemory(["People": LimitRelation(["Id", "Name", "Age"], records,
+                                              sorted: 0)])
+}
+
+/// A `Block` relation whose columns include `Offset` — a real WinMD column name
+/// (`ManifestResource` and `FieldLayout` both declare one) — to prove the
+/// reserved word `OFFSET` is still reachable as a column via a delimited
+/// identifier (`"Offset"`).
+private func blocks() -> LimitMemory {
+  let records = [
+    [.integer(1), .integer(100)],
+    [.integer(2), .integer(200)],
+    [.integer(3), .integer(300)],
+  ] as Array<Array<Value>>
+  return LimitMemory(["Block": LimitRelation(["Id", "Offset"], records)])
+}
+
+// MARK: - Helpers
+
+/// Parses `text` to a query, failing on any other statement.
+private func parse(_ text: String) throws -> Query {
+  guard case let .select(query) = try Statement(parsing: text) else {
+    Issue.record("expected a SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return query
+}
+
+/// Runs `text` against the `People` catalog, yielding the projected rows.
+private func run(_ text: String) throws -> Array<Array<Value>> {
+  try Engine.run(parse(text), people())
+}
+
+// MARK: - Tests
+
+struct LimitTests {
+  @Test("FETCH FIRST n ROWS ONLY caps the row count")
+  func caps() throws {
+    let rows = try run("SELECT Id FROM People FETCH FIRST 3 ROWS ONLY")
+    #expect(rows == [[.integer(1)], [.integer(2)], [.integer(3)]])
+  }
+
+  @Test("FETCH FIRST 0 ROWS ONLY yields no rows")
+  func zero() throws {
+    #expect(try run("SELECT Id FROM People FETCH FIRST 0 ROWS ONLY") == [])
+  }
+
+  @Test("FETCH with an omitted count takes one row")
+  func defaultsToOne() throws {
+    // The ISO `FETCH FIRST ROW ONLY` — no count — takes a single row.
+    #expect(try run("SELECT Id FROM People FETCH FIRST ROW ONLY")
+            == [[.integer(1)]])
+  }
+
+  @Test("ROW and ROWS, FIRST and NEXT, are interchangeable")
+  func synonyms() throws {
+    // `ROW`/`ROWS` and `FIRST`/`NEXT` are ISO synonyms — the singular and the
+    // `NEXT` spelling parse to the same clause as the plural `FIRST` form.
+    let canonical = try run("SELECT Id FROM People FETCH FIRST 1 ROWS ONLY")
+    #expect(try run("SELECT Id FROM People FETCH NEXT 1 ROW ONLY") == canonical)
+    #expect(canonical == [[.integer(1)]])
+  }
+
+  @Test("OFFSET n ROWS then FETCH skips then caps")
+  func offset() throws {
+    let rows =
+        try run("SELECT Id FROM People OFFSET 1 ROWS FETCH NEXT 2 ROWS ONLY")
+    #expect(rows == [[.integer(2)], [.integer(3)]])
+  }
+
+  @Test("OFFSET 0 ROWS is the same as no OFFSET")
+  func zeroOffset() throws {
+    let rows =
+        try run("SELECT Id FROM People OFFSET 0 ROWS FETCH NEXT 2 ROWS ONLY")
+    let bare = try run("SELECT Id FROM People FETCH FIRST 2 ROWS ONLY")
+    #expect(rows == bare)
+    #expect(rows == [[.integer(1)], [.integer(2)]])
+  }
+
+  @Test("OFFSET without a FETCH skips with no cap")
+  func offsetOnly() throws {
+    // An `OFFSET` written without a `FETCH` returns every row after the skip.
+    let rows = try run("SELECT Id FROM People OFFSET 3 ROWS")
+    #expect(rows == [[.integer(4)], [.integer(5)]])
+  }
+
+  @Test("FETCH after ORDER BY takes the top-N in sorted order")
+  func afterOrder() throws {
+    // Ordered by Age ascending, ties by source order (a stable sort): Bob(25),
+    // Eve(25), Alice(30), Carol(30), Dave(40). The FETCH caps the ORDERED
+    // result, so it takes the two lowest ages rather than the first two rows.
+    let rows =
+        try run("SELECT Name FROM People ORDER BY Age FETCH FIRST 2 ROWS ONLY")
+    #expect(rows == [[.text("Bob")], [.text("Eve")]])
+  }
+
+  @Test("OFFSET then FETCH after ORDER BY skips into the sorted result")
+  func offsetAfterOrder() throws {
+    // Descending by Id: Eve, Dave, Carol, Bob, Alice — skip 1, take 2.
+    let rows = try run("""
+        SELECT Name FROM People
+          ORDER BY Id DESC OFFSET 1 ROWS FETCH NEXT 2 ROWS ONLY
+        """)
+    #expect(rows == [[.text("Dave")], [.text("Carol")]])
+  }
+
+  @Test("OFFSET past the end yields no rows")
+  func offsetPastEnd() throws {
+    #expect(try run("SELECT Id FROM People OFFSET 5 ROWS") == [])
+    #expect(try run("SELECT Id FROM People OFFSET 10 ROWS") == [])
+  }
+
+  @Test("a FETCH larger than the result yields every row")
+  func largerThanResult() throws {
+    let all = try run("SELECT Id FROM People")
+    #expect(try run("SELECT Id FROM People FETCH FIRST 100 ROWS ONLY") == all)
+  }
+
+  @Test("FETCH caps rows admitted by a seekable WHERE")
+  func afterWhere() throws {
+    // `Id >= 2` seeks to rows 2…5; the FETCH then caps that run to two rows.
+    let rows =
+        try run("SELECT Id FROM People WHERE Id >= 2 FETCH FIRST 2 ROWS ONLY")
+    #expect(rows == [[.integer(2)], [.integer(3)]])
+  }
+
+  @Test("a reserved-word column is reachable via a delimited identifier")
+  func offsetColumn() throws {
+    // `OFFSET` is a reserved word, so a relation's `Offset` column is reached
+    // by the standard delimited identifier `"Offset"`. It selects, orders, and
+    // coexists with a genuine OFFSET/FETCH row-limiting clause.
+    let catalog = blocks()
+    #expect(try Engine.run(parse("SELECT \"Offset\" FROM Block"), catalog)
+            == [[.integer(100)], [.integer(200)], [.integer(300)]])
+    #expect(try Engine.run(parse("""
+        SELECT "Offset" FROM Block
+          ORDER BY "Offset" DESC OFFSET 1 ROWS FETCH NEXT 1 ROWS ONLY
+        """), catalog) == [[.integer(200)]])
+  }
+
+  @Test("the row limit applies before a discarded row's projection")
+  func beforeProjection() throws {
+    // The cap sits below the projection, so a select list that would throw —
+    // `1 / 0` — never runs for a row outside the page: FETCH 0 and an OFFSET
+    // past the end return empty rather than dividing.
+    #expect(try run("SELECT 1 / 0 FROM People FETCH FIRST 0 ROWS ONLY") == [])
+    #expect(try run("SELECT 1 / 0 FROM People OFFSET 10 ROWS") == [])
+    // A page that DOES admit a row still evaluates the projection (and throws),
+    // confirming the guard is the empty page, not a skipped projection.
+    #expect(throws: SQLError.self) {
+      try run("SELECT 1 / 0 FROM People FETCH FIRST 1 ROW ONLY")
+    }
+  }
+
+  @Test("a directly-built negative OFFSET or FETCH is rejected")
+  func rejectsNegative() throws {
+    // The parser cannot spell a negative count, but a direct `Limit` can — the
+    // executor's skip and take would trap on it, so the engine rejects it as a
+    // query error instead.
+    guard case let .select(base) = try parse("SELECT Id FROM People") else {
+      Issue.record("expected a single SELECT")
+      return
+    }
+    let fault =
+        SQLError.unsupported("OFFSET and FETCH row counts must be non-negative")
+    let negativeOffset = Select(projection: base.projection, from: base.from,
+                                limit: Limit(count: 1, offset: -1))
+    #expect(throws: fault) { try Engine.run(.select(negativeOffset), people()) }
+    let negativeCount = Select(projection: base.projection, from: base.from,
+                               limit: Limit(count: -1))
+    #expect(throws: fault) { try Engine.run(.select(negativeCount), people()) }
+  }
+
+  @Test("a near-maximal FETCH after an OFFSET does not overflow")
+  func saturates() throws {
+    // A `count` near `Int.max` plus a positive `offset` would overflow an
+    // `offset + count` bound; capping by a prefix of the skipped slice returns
+    // the remaining rows rather than trapping.
+    let rows = try run("""
+        SELECT Id FROM People
+          OFFSET 1 ROWS FETCH NEXT 9223372036854775807 ROWS ONLY
+        """)
+    #expect(rows == [[.integer(2)], [.integer(3)],
+                     [.integer(4)], [.integer(5)]])
+  }
+}

--- a/Tests/SQLTests/ParserTests.swift
+++ b/Tests/SQLTests/ParserTests.swift
@@ -6,7 +6,7 @@ import Testing
 
 /// Parses `text` and returns its `Select`, failing the test on any other shape
 /// — a non-`SELECT` statement, or a `UNION` of several selects.
-private func parseSelect(_ text: String) throws -> Select {
+private func parse(select text: String) throws -> Select {
   guard case let .select(.select(select)) = try Statement(parsing: text) else {
     Issue.record("expected a single SELECT statement")
     throw SQLError.incomplete(expected: "a SELECT statement")
@@ -17,7 +17,7 @@ private func parseSelect(_ text: String) throws -> Select {
 struct ProjectionTests {
   @Test("parses a SELECT * projection")
   func star() throws {
-    let select = try parseSelect("SELECT * FROM TypeDef")
+    let select = try parse(select: "SELECT * FROM TypeDef")
     #expect(select.projection == .all)
     #expect(select.table == "TypeDef")
     #expect(select.predicate == nil)
@@ -26,14 +26,14 @@ struct ProjectionTests {
 
   @Test("parses a single-column projection")
   func singleColumn() throws {
-    let select = try parseSelect("SELECT TypeName FROM TypeDef")
+    let select = try parse(select: "SELECT TypeName FROM TypeDef")
     #expect(select.projection == .columns(["TypeName"]))
   }
 
   @Test("parses a comma-separated column list")
   func columnList() throws {
     let select =
-        try parseSelect("SELECT TypeName, TypeNamespace, Flags FROM TypeDef")
+        try parse(select: "SELECT TypeName, TypeNamespace, Flags FROM TypeDef")
     #expect(select.projection
                 == .columns(["TypeName", "TypeNamespace", "Flags"]))
   }
@@ -42,8 +42,19 @@ struct ProjectionTests {
   func dottedColumn() throws {
     // Simple column identifiers may carry a qualifying dot; metadata names with
     // dots appear only as string literals.
-    let select = try parseSelect("SELECT TypeDef.TypeName FROM TypeDef")
+    let select = try parse(select: "SELECT TypeDef.TypeName FROM TypeDef")
     #expect(select.projection == .columns(["TypeDef.TypeName"]))
+  }
+
+  @Test("parses a delimited column identifier as one unqualified name")
+  func delimitedColumn() throws {
+    // A delimited identifier is verbatim: a dot in it is part of the name,
+    // not a qualifier as in the bare dotted form above.
+    let dotted = try parse(select: "SELECT \"a.b\" FROM T")
+    #expect(dotted.projection == .columns([Column(name: "a.b")]))
+    // A quoted reserved word is likewise a plain, unqualified column name.
+    let offset = try parse(select: "SELECT \"Offset\" FROM T")
+    #expect(offset.projection == .columns([Column(name: "Offset")]))
   }
 }
 
@@ -51,7 +62,7 @@ struct KeywordTests {
   @Test("parses lowercase keywords")
   func caseInsensitive() throws {
     let select =
-        try parseSelect("select TypeName from TypeDef where Flags = 1")
+        try parse(select: "select TypeName from TypeDef where Flags = 1")
     #expect(select.projection == .columns(["TypeName"]))
     #expect(select.table == "TypeDef")
     #expect(select.predicate == .comparison(left: .column("Flags"), op: .equal,
@@ -60,7 +71,8 @@ struct KeywordTests {
 
   @Test("parses mixed-case keywords")
   func mixedCase() throws {
-    let select = try parseSelect("SeLeCt * FrOm TypeDef OrDeR By TypeName DeSc")
+    let select =
+        try parse(select: "SeLeCt * FrOm TypeDef OrDeR By TypeName DeSc")
     #expect(select.order == Order(column: "TypeName", ascending: false))
   }
 }
@@ -78,7 +90,7 @@ struct PredicateTests {
     ]
     for (text, op) in cases {
       let select =
-          try parseSelect("SELECT * FROM T WHERE Flags \(text) 1")
+          try parse(select: "SELECT * FROM T WHERE Flags \(text) 1")
       #expect(select.predicate
                   == .comparison(left: .column("Flags"), op: op,
                                  right: .literal(.integer(1))))
@@ -87,9 +99,9 @@ struct PredicateTests {
 
   @Test("parses a string-literal operand")
   func stringLiteral() throws {
-    let select =
-        try parseSelect(
-            "SELECT * FROM TypeDef WHERE TypeNamespace = 'Windows.Win32.Foundation'")
+    let text =
+        "SELECT * FROM TypeDef WHERE TypeNamespace = 'Windows.Win32.Foundation'"
+    let select = try parse(select: text)
     let value = Expression.literal(.string("Windows.Win32.Foundation"))
     #expect(select.predicate
                 == .comparison(left: .column("TypeNamespace"), op: .equal,
@@ -98,7 +110,7 @@ struct PredicateTests {
 
   @Test("parses a string with an escaped quote")
   func escapedQuote() throws {
-    let select = try parseSelect("SELECT * FROM T WHERE name = 'O''Brien'")
+    let select = try parse(select: "SELECT * FROM T WHERE name = 'O''Brien'")
     #expect(select.predicate
                 == .comparison(left: .column("name"), op: .equal,
                                right: .literal(.string("O'Brien"))))
@@ -106,7 +118,7 @@ struct PredicateTests {
 
   @Test("parses a function call as a comparison operand")
   func functionOperand() throws {
-    let select = try parseSelect("SELECT * FROM T WHERE upper(Name) = 'X'")
+    let select = try parse(select: "SELECT * FROM T WHERE upper(Name) = 'X'")
     let call = Expression.call(name: "upper", arguments: [.column("Name")])
     #expect(select.predicate
                 == .comparison(left: call, op: .equal,
@@ -117,7 +129,7 @@ struct PredicateTests {
   func andBindsTighterThanOr() throws {
     // a = 1 OR b = 2 AND c = 3  ==>  a OR (b AND c)
     let select =
-        try parseSelect("SELECT * FROM T WHERE a = 1 OR b = 2 AND c = 3")
+        try parse(select: "SELECT * FROM T WHERE a = 1 OR b = 2 AND c = 3")
     let a = Predicate.comparison(left: .column("a"), op: .equal,
                                  right: .literal(.integer(1)))
     let b = Predicate.comparison(left: .column("b"), op: .equal,
@@ -131,7 +143,7 @@ struct PredicateTests {
   func notBindsTighterThanAnd() throws {
     // NOT a = 1 AND b = 2  ==>  (NOT a) AND b
     let select =
-        try parseSelect("SELECT * FROM T WHERE NOT a = 1 AND b = 2")
+        try parse(select: "SELECT * FROM T WHERE NOT a = 1 AND b = 2")
     let a = Predicate.comparison(left: .column("a"), op: .equal,
                                  right: .literal(.integer(1)))
     let b = Predicate.comparison(left: .column("b"), op: .equal,
@@ -143,7 +155,7 @@ struct PredicateTests {
   func parenthesesOverridePrecedence() throws {
     // (a = 1 OR b = 2) AND c = 3
     let select =
-        try parseSelect("SELECT * FROM T WHERE (a = 1 OR b = 2) AND c = 3")
+        try parse(select: "SELECT * FROM T WHERE (a = 1 OR b = 2) AND c = 3")
     let a = Predicate.comparison(left: .column("a"), op: .equal,
                                  right: .literal(.integer(1)))
     let b = Predicate.comparison(left: .column("b"), op: .equal,
@@ -155,19 +167,19 @@ struct PredicateTests {
 
   @Test("parses IS NULL")
   func isNull() throws {
-    let select = try parseSelect("SELECT * FROM T WHERE Note IS NULL")
+    let select = try parse(select: "SELECT * FROM T WHERE Note IS NULL")
     #expect(select.predicate == .null(.column("Note"), negated: false))
   }
 
   @Test("parses IS NOT NULL")
   func isNotNull() throws {
-    let select = try parseSelect("SELECT * FROM T WHERE Note IS NOT NULL")
+    let select = try parse(select: "SELECT * FROM T WHERE Note IS NOT NULL")
     #expect(select.predicate == .null(.column("Note"), negated: true))
   }
 
   @Test("parses IS NULL over a function-call operand")
   func isNullCall() throws {
-    let select = try parseSelect("SELECT * FROM T WHERE iid(Id) IS NULL")
+    let select = try parse(select: "SELECT * FROM T WHERE iid(Id) IS NULL")
     let call = Expression.call(name: "iid", arguments: [.column("Id")])
     #expect(select.predicate == .null(call, negated: false))
   }
@@ -183,7 +195,7 @@ struct PredicateTests {
   func leftAssociativeOr() throws {
     // a = 1 OR b = 2 OR c = 3  ==>  ((a OR b) OR c)
     let select =
-        try parseSelect("SELECT * FROM T WHERE a = 1 OR b = 2 OR c = 3")
+        try parse(select: "SELECT * FROM T WHERE a = 1 OR b = 2 OR c = 3")
     let a = Predicate.comparison(left: .column("a"), op: .equal,
                                  right: .literal(.integer(1)))
     let b = Predicate.comparison(left: .column("b"), op: .equal,
@@ -197,19 +209,19 @@ struct PredicateTests {
 struct OrderTests {
   @Test("defaults ORDER BY to ascending")
   func defaultAscending() throws {
-    let select = try parseSelect("SELECT * FROM T ORDER BY TypeName")
+    let select = try parse(select: "SELECT * FROM T ORDER BY TypeName")
     #expect(select.order == Order(column: "TypeName", ascending: true))
   }
 
   @Test("parses an explicit ASC order")
   func explicitAscending() throws {
-    let select = try parseSelect("SELECT * FROM T ORDER BY TypeName ASC")
+    let select = try parse(select: "SELECT * FROM T ORDER BY TypeName ASC")
     #expect(select.order == Order(column: "TypeName", ascending: true))
   }
 
   @Test("parses a DESC order")
   func descending() throws {
-    let select = try parseSelect("SELECT * FROM T ORDER BY TypeName DESC")
+    let select = try parse(select: "SELECT * FROM T ORDER BY TypeName DESC")
     #expect(select.order == Order(column: "TypeName", ascending: false))
   }
 }
@@ -218,7 +230,7 @@ struct CompositeTests {
   @Test("parses a full SELECT/WHERE/ORDER BY query")
   func fullQuery() throws {
     let select =
-        try parseSelect("""
+        try parse(select: """
             SELECT TypeName, TypeNamespace FROM TypeDef
               WHERE TypeNamespace = 'Windows.Win32.Foundation' AND Flags >= 1
               ORDER BY TypeName DESC
@@ -261,26 +273,26 @@ struct ColumnTests {
 struct RelationTests {
   @Test("parses a bare FROM relation with no alias")
   func bare() throws {
-    let select = try parseSelect("SELECT * FROM TypeDef")
+    let select = try parse(select: "SELECT * FROM TypeDef")
     #expect(select.from == Relation(name: "TypeDef"))
     #expect(select.joins.isEmpty)
   }
 
   @Test("parses an AS alias on the FROM relation")
   func alias() throws {
-    let select = try parseSelect("SELECT * FROM TypeDef AS t")
+    let select = try parse(select: "SELECT * FROM TypeDef AS t")
     #expect(select.from == Relation(name: "TypeDef", alias: "t"))
   }
 
   @Test("parses an implicit (AS-less) alias")
   func implicitAlias() throws {
-    let select = try parseSelect("SELECT * FROM TypeDef t")
+    let select = try parse(select: "SELECT * FROM TypeDef t")
     #expect(select.from == Relation(name: "TypeDef", alias: "t"))
   }
 
   @Test("does not mistake a following keyword for an alias")
   func keywordNotAlias() throws {
-    let select = try parseSelect("SELECT * FROM TypeDef WHERE Flags = 1")
+    let select = try parse(select: "SELECT * FROM TypeDef WHERE Flags = 1")
     #expect(select.from == Relation(name: "TypeDef"))
   }
 }
@@ -288,7 +300,7 @@ struct RelationTests {
 struct JoinTests {
   @Test("parses a list-shape join with aliases")
   func listJoin() throws {
-    let select = try parseSelect("""
+    let select = try parse(select: """
         SELECT m.Name FROM TypeDef AS t
           JOIN MethodDef AS m ON m.parent = t.rowid
           WHERE t.TypeName = 'IUnknown'
@@ -306,7 +318,7 @@ struct JoinTests {
 
   @Test("parses a forward-key join")
   func forwardJoin() throws {
-    let select = try parseSelect("""
+    let select = try parse(select: """
         SELECT r.TypeName FROM TypeDef AS t
           JOIN TypeRef AS r ON t.Extends = r.rowid
         """)
@@ -318,7 +330,7 @@ struct JoinTests {
 
   @Test("parses a join without aliases")
   func unaliasedJoin() throws {
-    let select = try parseSelect("""
+    let select = try parse(select: """
         SELECT Name FROM MethodDef
           JOIN Param ON Param.parent = MethodDef.rowid
         """)
@@ -332,7 +344,7 @@ struct JoinTests {
 
   @Test("parses a chain of two joins in source order")
   func chainedJoins() throws {
-    let select = try parseSelect("""
+    let select = try parse(select: """
         SELECT Param.Name FROM TypeDef AS t
           JOIN MethodDef AS m ON m.parent = t.rowid
           JOIN Param ON Param.parent = m.rowid
@@ -414,7 +426,7 @@ struct ErrorTests {
   func columnOperands() throws {
     // Either operand may be an expression, so a column-vs-column predicate is
     // valid SQL (`a = b`), not an error.
-    let select = try parseSelect("SELECT * FROM T WHERE a = b")
+    let select = try parse(select: "SELECT * FROM T WHERE a = b")
     #expect(select.predicate
                 == .comparison(left: .column("a"), op: .equal,
                                right: .column("b")))
@@ -426,13 +438,13 @@ struct ErrorTests {
 struct ExpressionTests {
   @Test("a bare-column list stays the simpler columns projection")
   func columns() throws {
-    let select = try parseSelect("SELECT a, b FROM T")
+    let select = try parse(select: "SELECT a, b FROM T")
     #expect(select.projection == .columns(["a", "b"]))
   }
 
   @Test("a function call yields an expression projection")
   func call() throws {
-    let select = try parseSelect("SELECT guid(Name) FROM T")
+    let select = try parse(select: "SELECT guid(Name) FROM T")
     #expect(select.projection
                 == .expressions([
                   Projected(expression: .call(name: "guid",
@@ -442,7 +454,7 @@ struct ExpressionTests {
 
   @Test("an aliased column yields an expression projection")
   func alias() throws {
-    let select = try parseSelect("SELECT Name AS label FROM T")
+    let select = try parse(select: "SELECT Name AS label FROM T")
     #expect(select.projection
                 == .expressions([
                   Projected(expression: .column("Name"), alias: "label")
@@ -451,7 +463,7 @@ struct ExpressionTests {
 
   @Test("a call takes literal and nested-call arguments")
   func arguments() throws {
-    let select = try parseSelect("SELECT f(1, g(x), 'lit') FROM T")
+    let select = try parse(select: "SELECT f(1, g(x), 'lit') FROM T")
     #expect(select.projection
                 == .expressions([
                   Projected(expression:
@@ -465,7 +477,7 @@ struct ExpressionTests {
 
   @Test("a zero-argument call parses")
   func nullary() throws {
-    let select = try parseSelect("SELECT now() FROM T")
+    let select = try parse(select: "SELECT now() FROM T")
     #expect(select.projection
                 == .expressions([
                   Projected(expression: .call(name: "now", arguments: []))
@@ -479,7 +491,7 @@ struct ArithmeticTests {
   /// The lone projected expression of a single-item projection, failing on any
   /// other shape.
   private func expression(_ text: String) throws -> Expression {
-    let select = try parseSelect(text)
+    let select = try parse(select: text)
     guard case let .expressions(items) = select.projection,
         items.count == 1 else {
       Issue.record("expected a single expression projection")
@@ -540,7 +552,7 @@ struct ArithmeticTests {
 
   @Test("arithmetic parses on either side of a comparison")
   func predicate() throws {
-    let select = try parseSelect("SELECT * FROM T WHERE Age + 1 = 26")
+    let select = try parse(select: "SELECT * FROM T WHERE Age + 1 = 26")
     let sum = Expression.binary(.add, .column("Age"), .literal(.integer(1)))
     #expect(select.predicate
                 == .comparison(left: sum, op: .equal,
@@ -553,7 +565,7 @@ struct ArithmeticTests {
 struct ScalarSelectTests {
   @Test("parses a FROM-less SELECT with no relation")
   func bare() throws {
-    let select = try parseSelect("SELECT 1")
+    let select = try parse(select: "SELECT 1")
     #expect(select.from == nil)
     #expect(select.joins.isEmpty)
     #expect(select.predicate == nil)
@@ -564,7 +576,7 @@ struct ScalarSelectTests {
 
   @Test("parses a FROM-less arithmetic projection")
   func arithmetic() throws {
-    let select = try parseSelect("SELECT 1 + 1")
+    let select = try parse(select: "SELECT 1 + 1")
     let sum = Expression.binary(.add, .literal(.integer(1)),
                                 .literal(.integer(1)))
     #expect(select.from == nil)
@@ -573,7 +585,7 @@ struct ScalarSelectTests {
 
   @Test("parses a FROM-less multi-column projection")
   func multiColumn() throws {
-    let select = try parseSelect("SELECT 1, 2")
+    let select = try parse(select: "SELECT 1, 2")
     #expect(select.from == nil)
     #expect(select.projection == .expressions([
       Projected(expression: .literal(.integer(1))),
@@ -583,7 +595,7 @@ struct ScalarSelectTests {
 
   @Test("a FROM-less alias names the projected column")
   func aliased() throws {
-    let select = try parseSelect("SELECT 1 + 1 AS two")
+    let select = try parse(select: "SELECT 1 + 1 AS two")
     let sum = Expression.binary(.add, .literal(.integer(1)),
                                 .literal(.integer(1)))
     #expect(select.projection


### PR DESCRIPTION
Add the standard `LIMIT count [OFFSET skip]` clause, capping and skipping rows of a query's (ordered) result — the top-N and paging primitive that metadata querying leans on.

The lexer recognises `LIMIT`/`OFFSET` as keywords (Token, Lexer). The AST gains a `Limit` value (`count` + `offset`, defaulting to no skip) on `Select`, and the grammar parses an optional trailing `LIMIT` — a count with an optional `OFFSET` — after `ORDER BY` (AST, Parser, keeping the EBNF block whitespace-aligned).

The plan gains a `.limit(count:offset:_:)` node wrapping its source, handled in `width`, `slots`, and `execute` — the `limited()` helper drops the first `offset` rows and takes the next `count` (Operator). `compile` wraps the shaped plan in `.limit` OUTSIDE the sort and projection via `capped()`, so a `LIMIT` caps the ORDER BY's result rather than the scan; `optimise` and the selection pushdown recurse through `.limit` transparently, and no filter is pushed across it (a pushed predicate would change which rows the cap keeps). The FROM-less guard now rejects a stray `LIMIT` alongside WHERE/ORDER BY/JOIN (Engine).

`LimitTests` covers caps, `LIMIT 0`, `LIMIT`+`OFFSET`, `OFFSET 0`, top-N after an ascending and a descending `ORDER BY`, an `OFFSET` past the end, a `LIMIT` wider than the result, and a `LIMIT` after a seekable `WHERE`. The exhaustive `Plan` walkers in EngineTests recurse through the new case, and the FROM-less rejection test exercises the `LIMIT` arm.