### PR TITLE
SQL: add BOOLEAN and BLOB value types

### DIFF
--- a/Sources/SQL/Adapter.swift
+++ b/Sources/SQL/Adapter.swift
@@ -20,14 +20,18 @@
 
 /// The kind of value a column holds.
 ///
-/// A column is either integral or textual. A source uses this to describe its
-/// schema and to build the typed `Value`s a `Row` yields; the engine itself
-/// compares and orders on the `Value`, not the kind.
+/// A column is integral, textual, truth-valued, or binary. A source uses this
+/// to describe its schema and to build the typed `Value`s a `Row` yields; the
+/// engine itself compares and orders on the `Value`, not the kind.
 public enum ValueKind: Hashable, Sendable {
   /// An integral column.
   case integer
   /// A textual column.
   case text
+  /// A truth-valued column — `TRUE` or `FALSE`; its UNKNOWN is `NULL`.
+  case boolean
+  /// A binary column — an uninterpreted byte string.
+  case blob
 }
 
 /// A typed cell value the engine yields.
@@ -45,6 +49,13 @@ public enum Value: Hashable, Sendable {
   case integer(Int)
   /// A textual value.
   case text(String)
+  /// A truth value — `TRUE` or `FALSE`. Its UNKNOWN is the existing `null`; a
+  /// boolean cell is never a fourth truth value, and orders `false < true`.
+  case boolean(Bool)
+  /// A binary value — an uninterpreted byte string. Two blobs compare by byte
+  /// equality (`=`/`<>`) and lexicographic order (`<`/`>`/`<=`/`>=`), both free
+  /// from `Array<UInt8>: Comparable`.
+  case blob(Array<UInt8>)
 }
 
 // MARK: - View

--- a/Sources/SQL/Filter.swift
+++ b/Sources/SQL/Filter.swift
@@ -315,19 +315,45 @@ extension Comparison {
     case .geq: lhs >= rhs
     }
   }
+
+  /// Applies the operator to two byte strings: `=`/`<>` is byte equality and
+  /// the ordering relations are lexicographic (memcmp) order over the bytes.
+  ///
+  /// `Array` is not `Comparable` — only `Equatable` when its element is — so a
+  /// blob cannot ride the generic `apply`. Equality is `==`; order derives from
+  /// `lexicographicallyPrecedes` (strict `<`): `>` reverses the operands, and
+  /// `<=`/`>=` are the strict order OR equality.
+  internal func apply(_ lhs: Array<UInt8>, _ rhs: Array<UInt8>) -> Bool {
+    switch self {
+    case .equal: lhs == rhs
+    case .unequal: lhs != rhs
+    case .lt: lhs.lexicographicallyPrecedes(rhs)
+    case .gt: rhs.lexicographicallyPrecedes(lhs)
+    case .leq: !rhs.lexicographicallyPrecedes(lhs)
+    case .geq: !lhs.lexicographicallyPrecedes(rhs)
+    }
+  }
 }
 
 /// Matches two typed values under operator `op`, under three-valued logic.
 ///
 /// A `NULL` on either side is UNKNOWN (`nil`): `NULL` is unordered and unequal
 /// to everything, itself included, so no comparison against it is ever true or
-/// false. A like-typed non-null pair compares — two integers or two strings; a
-/// cross-typed pair (an integer against a string, or the reverse) never matches.
+/// false. A like-typed non-null pair compares — two integers, two strings, two
+/// booleans (`false < true`), or two blobs (byte equality, lexicographic
+/// order); a cross-typed pair (an integer against a string) never matches.
 private func matches(_ lhs: Value, _ op: Comparison, _ rhs: Value) -> Bool? {
   switch (lhs, rhs) {
   case (.null, _), (_, .null): nil
   case let (.integer(lhs), .integer(rhs)): op.apply(lhs, rhs)
   case let (.text(lhs), .text(rhs)): op.apply(lhs, rhs)
+  // `Bool` is not `Comparable`, so compare on its truth ordinal — `false` is
+  // `0`, `true` is `1` — which orders `false < true` and equates like values.
+  case let (.boolean(lhs), .boolean(rhs)):
+    op.apply(lhs ? 1 : 0, rhs ? 1 : 0)
+  // `Array` is not `Comparable`, so `=`/`<>` is byte equality and the ordering
+  // relations are lexicographic (memcmp) order over the bytes.
+  case let (.blob(lhs), .blob(rhs)): op.apply(lhs, rhs)
   default: false
   }
 }

--- a/Sources/SQL/Operator.swift
+++ b/Sources/SQL/Operator.swift
@@ -646,6 +646,8 @@ internal func less(_ lhs: Value, _ rhs: Value) -> Bool {
   case (_, .null): false
   case let (.integer(lhs), .integer(rhs)): lhs < rhs
   case let (.text(lhs), .text(rhs)): lhs < rhs
+  case let (.boolean(lhs), .boolean(rhs)): !lhs && rhs
+  case let (.blob(lhs), .blob(rhs)): lhs.lexicographicallyPrecedes(rhs)
   default: false
   }
 }

--- a/Sources/winmd-inspect/Shell.swift
+++ b/Sources/winmd-inspect/Shell.swift
@@ -974,7 +974,24 @@ extension Value {
     case .null:                 ""
     case let .integer(integer): "\(integer)"
     case let .text(text):       text
+    case let .boolean(boolean): boolean ? "TRUE" : "FALSE"
+    // A blob renders as a lowercase-hex `x'…'` literal — lowercase `x` and
+    // digits, an empty blob as `x''` — the way `sqlite3` shows a BLOB cell.
+    case let .blob(bytes):      "x'" + Value.hex(bytes) + "'"
     }
+  }
+
+  /// `bytes` as a lowercase-hex string — each byte two lowercase nibbles, high
+  /// nibble first, so a byte's width is fixed and its leading zero is kept.
+  private static func hex(_ bytes: Array<UInt8>) -> String {
+    let digits = Array("0123456789abcdef")
+    var hex = ""
+    hex.reserveCapacity(bytes.count * 2)
+    for byte in bytes {
+      hex.append(digits[Int(byte >> 4)])
+      hex.append(digits[Int(byte & 0x0f)])
+    }
+    return hex
   }
 
   /// This cell's `text`, the empty string for any non-text cell — the render

--- a/Tests/SQLTests/ValueTypeTests.swift
+++ b/Tests/SQLTests/ValueTypeTests.swift
@@ -1,0 +1,120 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQL
+
+// MARK: - Harness
+
+/// A one-cell row that yields a fixed `Value` at slot `0` — the minimal `Row`
+/// that drives the comparison choke point (`matches`, reached through
+/// `evaluate`) over a `boolean` or `blob` cell without a whole relation.
+///
+/// The source carries no borrowed storage, so it omits `@_lifetime`.
+private struct Cell: Row {
+  let value: Value
+
+  init(_ value: Value) {
+    self.value = value
+  }
+
+  subscript(_ column: Int) -> Value {
+    borrowing get { value }
+  }
+}
+
+/// Evaluates `cell op constant` through the engine's three-valued comparison —
+/// `true`, `false`, or `nil` (UNKNOWN) — the path a real `WHERE` takes.
+private func compare(_ cell: Value, _ op: Comparison,
+                     _ constant: Value) -> Bool? {
+  try! evaluate(.compare(.slot(0), op, .constant(constant)),
+                Cell(cell), Routines(), [:])
+}
+
+// MARK: - Boolean
+
+@Suite("BOOLEAN value type")
+private struct BooleanTests {
+  @Test("false orders before true")
+  func ordering() {
+    #expect(compare(.boolean(false), .lt, .boolean(true)) == true)
+    #expect(compare(.boolean(true), .lt, .boolean(false)) == false)
+    #expect(compare(.boolean(false), .lt, .boolean(false)) == false)
+    #expect(compare(.boolean(true), .gt, .boolean(false)) == true)
+  }
+
+  @Test("like booleans compare equal")
+  func equality() {
+    #expect(compare(.boolean(true), .equal, .boolean(true)) == true)
+    #expect(compare(.boolean(true), .equal, .boolean(false)) == false)
+    #expect(compare(.boolean(false), .unequal, .boolean(true)) == true)
+  }
+
+  @Test("the boundary relations follow the false < true order")
+  func boundaries() {
+    #expect(compare(.boolean(false), .leq, .boolean(false)) == true)
+    #expect(compare(.boolean(false), .leq, .boolean(true)) == true)
+    #expect(compare(.boolean(true), .leq, .boolean(false)) == false)
+    #expect(compare(.boolean(true), .geq, .boolean(true)) == true)
+    #expect(compare(.boolean(false), .geq, .boolean(true)) == false)
+  }
+}
+
+// MARK: - Blob
+
+@Suite("BLOB value type")
+private struct BlobTests {
+  @Test("like blobs compare by byte equality")
+  func equality() {
+    #expect(compare(.blob([0x53, 0x51, 0x4c]), .equal,
+                    .blob([0x53, 0x51, 0x4c])) == true)
+    #expect(compare(.blob([0x53, 0x51, 0x4c]), .equal,
+                    .blob([0x53, 0x51])) == false)
+    #expect(compare(.blob([]), .equal, .blob([])) == true)
+    #expect(compare(.blob([0x00]), .unequal, .blob([])) == true)
+  }
+
+  @Test("blobs order lexicographically — memcmp over the bytes")
+  func ordering() {
+    // A byte difference decides: `0x01` < `0x02`.
+    #expect(compare(.blob([0x01]), .lt, .blob([0x02])) == true)
+    #expect(compare(.blob([0x02]), .lt, .blob([0x01])) == false)
+    // A proper prefix orders before the longer string.
+    #expect(compare(.blob([0x01]), .lt, .blob([0x01, 0x00])) == true)
+    #expect(compare(.blob([]), .lt, .blob([0x00])) == true)
+    // A high byte outweighs a longer tail.
+    #expect(compare(.blob([0x02]), .gt, .blob([0x01, 0xff])) == true)
+  }
+
+  @Test("the boundary relations follow the lexicographic order")
+  func boundaries() {
+    #expect(compare(.blob([0x01]), .leq, .blob([0x01])) == true)
+    #expect(compare(.blob([0x01]), .leq, .blob([0x02])) == true)
+    #expect(compare(.blob([0x02]), .leq, .blob([0x01])) == false)
+    #expect(compare(.blob([0x02]), .geq, .blob([0x01])) == true)
+    #expect(compare(.blob([0x01]), .geq, .blob([0x02])) == false)
+  }
+}
+
+// MARK: - Cross-type
+
+@Suite("cross-type comparison")
+private struct CrossTypeTests {
+  @Test("unlike types never match — no coercion")
+  func mismatch() {
+    // Every non-null cross-type pair falls to the switch's `default: false`.
+    #expect(compare(.boolean(true), .equal, .integer(1)) == false)
+    #expect(compare(.integer(1), .equal, .boolean(true)) == false)
+    #expect(compare(.boolean(false), .equal, .integer(0)) == false)
+    #expect(compare(.blob([0x41]), .equal, .text("A")) == false)
+    #expect(compare(.text("A"), .equal, .blob([0x41])) == false)
+    #expect(compare(.blob([0x01]), .lt, .integer(2)) == false)
+    #expect(compare(.boolean(true), .lt, .text("z")) == false)
+  }
+
+  @Test("a NULL operand is UNKNOWN, not false")
+  func null() {
+    #expect(compare(.boolean(true), .equal, .null) == nil)
+    #expect(compare(.blob([0x01]), .lt, .null) == nil)
+  }
+}

--- a/Tests/winmd-inspectTests/ValueDisplayTests.swift
+++ b/Tests/winmd-inspectTests/ValueDisplayTests.swift
@@ -1,0 +1,39 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+
+@testable import winmd_inspect
+
+import SQL
+
+// MARK: - Boolean
+
+@Suite("BOOLEAN display")
+private struct BooleanDisplayTests {
+  @Test("a boolean renders as TRUE or FALSE")
+  func spelling() {
+    #expect(Value.boolean(true).display == "TRUE")
+    #expect(Value.boolean(false).display == "FALSE")
+  }
+}
+
+// MARK: - Blob
+
+@Suite("BLOB display")
+private struct BlobDisplayTests {
+  @Test("a blob renders as a lowercase-hex x'…' literal")
+  func hex() {
+    #expect(Value.blob([0x53, 0x51, 0x4c]).display == "x'53514c'")
+  }
+
+  @Test("hex is lowercase and keeps a byte's leading zero")
+  func lowercaseAndPadding() {
+    #expect(Value.blob([0x00, 0x0f, 0xab, 0xff]).display == "x'000fabff'")
+  }
+
+  @Test("an empty blob renders as x''")
+  func empty() {
+    #expect(Value.blob([]).display == "x''")
+  }
+}


### PR DESCRIPTION
Extend the engine's `Value`/`ValueKind` with a truth value and a byte string, the two remaining SQL scalar types the adapter surface lacked. A boolean carries `TRUE`/`FALSE`, its UNKNOWN the existing `NULL` — no fourth truth value — and orders `false < true`; a blob is an uninterpreted `Array<UInt8>` (not Foundation `Data`) comparing by byte equality (`=`/`<>`) and lexicographic memcmp order (`< > <= >=`).

The comparison choke point (`matches`) gains a like-typed arm for each: `Bool` is not `Comparable`, so a boolean rides `apply` on its truth ordinal (`false` → 0, `true` → 1); `Array` is not `Comparable` either, so a blob takes a dedicated `Comparison.apply` overload built from `==` and `lexicographicallyPrecedes`. A cross-typed pair still falls to `default: false` — no coercion — and a `NULL` operand stays UNKNOWN. The sort helper `less` gains matching ordering arms so a single-slot sort over a boolean or blob column orders rather than ties.

The shell's `Value.display` renders a boolean as `TRUE`/`FALSE` and a blob as a lowercase-hex `x'…'` literal (`x''` when empty), the way `sqlite3` shows them.

Grammar literals (`X'…'`, `TRUE`/`FALSE`) are deferred; this is the value-type plumbing only.