### PR TITLE
winmd-inspect: rename the ESCAPE render UDF to SANITIZE

### DIFF
--- a/Documentation/SynthesisModel.md
+++ b/Documentation/SynthesisModel.md
@@ -106,7 +106,7 @@ layer relies on:
   binding a parent row's key into a child query is how the render walks a
   one-to-many relationship one level at a time.
 - **Registered scalar functions** (`Routines`, `Sources/SQL/Function.swift`) —
-  the engine's extension point. The render binds the target-language `ESCAPE`
+  the engine's extension point. The render binds the target-language `SANITIZE`
   UDF (below) here, so keyword-escaping is a value a query projects rather than
   logic in the binary.
 
@@ -246,16 +246,16 @@ template names its target with a leading `{{! language: <name> }}` directive tha
 selects a bundled `Resources/Languages/<name>.lang` spec (e.g. `swift.lang`): the
 reserved words, the escape delimiters, the no-value-return spelling, the COM-root
 base, and the type spellings a signature decodes to. The spec surfaces to the
-render as the `ESCAPE(identifier)` UDF (keyword-escape a synthesized name) and as
+render as the `SANITIZE(identifier)` UDF (keyword-escape a synthesized name) and as
 a `Dialect` — the type-spelling table (plus the same keyword escape) the render's
 `SignatureType` decode composes with, so a named type whose simple name is a
 keyword spells escaped just as a declaration name does. A language rule is data,
 not a branch in the binary; retargeting to Rust or C is a new template and spec,
 no code change.
 
-1. Run `interfaces` for every interface's `rowid`, namespace, `ESCAPE`d name, and
+1. Run `interfaces` for every interface's `rowid`, namespace, `SANITIZE`d name, and
    `iid`, then keep the one whose name matches (or all of them for `*`).
-2. Bind that `rowid` as `:parent` and run `methods` (each `Name` `ESCAPE`d) and
+2. Bind that `rowid` as `:parent` and run `methods` (each `Name` `SANITIZE`d) and
    decode each method's return type from its signature with the `Dialect`,
    omitting the clause when it is the spec's no-value `void`; then bind *its*
    `rowid` as `:parent` and run `params` — the correlated walk down the

--- a/Sources/winmd-inspect/Language.swift
+++ b/Sources/winmd-inspect/Language.swift
@@ -16,7 +16,7 @@ internal import WinMDSynthesis
 /// `-I`. Retargeting the generator to Rust or C is then a new spec beside a new
 /// template, not a code change.
 ///
-/// The spec surfaces to the render queries as the `ESCAPE` scalar UDF
+/// The spec surfaces to the render queries as the `SANITIZE` scalar UDF
 /// (keyword-escape an identifier), and to the render's Swift decode as a
 /// `Dialect` — the type spellings a `SignatureType` composes into a spelling. The
 /// no-value return is the spec's `void` spelling, tested against a decoded return
@@ -175,22 +175,26 @@ internal struct Language: Sendable {
         escape: { language.escape($0) })
   }
 
-  /// The spec's render UDFs — just `ESCAPE(identifier)` — for the routines the
-  /// render binds its queries with. `ESCAPE` wraps a keyword identifier (and
+  /// The spec's render UDFs — just `SANITIZE(identifier)` — for the routines the
+  /// render binds its queries with. `SANITIZE` wraps a keyword identifier (and
   /// passes a NULL through); the no-value return is decided in Swift now (the
   /// render tests a decoded return against `returned(_:)`), so it needs no UDF.
+  ///
+  /// The UDF is spelled `SANITIZE`, not `ESCAPE`, to steer clear of the ISO-SQL
+  /// reserved word `ESCAPE` (§8.5, the escape-character clause of a `LIKE`
+  /// predicate) should `LIKE` ever be added to the engine.
   internal var routines: Routines {
     let language = self
-    let escape: Scalar = { arguments in
+    let sanitize: Scalar = { arguments in
       guard arguments.count == 1 else {
-        throw .argument("ESCAPE takes one argument")
+        throw .argument("SANITIZE takes one argument")
       }
       if case .null = arguments[0] { return .null }
       guard case let .text(identifier) = arguments[0] else {
-        throw .argument("ESCAPE requires a text argument")
+        throw .argument("SANITIZE requires a text argument")
       }
       return .text(language.escape(identifier))
     }
-    return ["escape": escape]
+    return ["sanitize": sanitize]
   }
 }

--- a/Sources/winmd-inspect/Resources/Languages/swift.lang
+++ b/Sources/winmd-inspect/Resources/Languages/swift.lang
@@ -2,7 +2,7 @@
 # directive: the escape delimiters, the no-value return spelling, the COM-root
 # base, the reserved words an identifier is escaped against, and the type
 # spellings a signature decodes to (the primitive leaves, the pointer family, the
-# delimiters, and the well-known projections). The render's ESCAPE UDF and its
+# delimiters, and the well-known projections). The render's SANITIZE UDF and its
 # type Dialect read it, so this — not the binary — carries what is Swift-specific.
 # A `-I` directory's `Languages/swift.lang` shadows it.
 escape-prefix `

--- a/Sources/winmd-inspect/Resources/Render/bases.sql
+++ b/Sources/winmd-inspect/Resources/Render/bases.sql
@@ -1,4 +1,4 @@
 SELECT
-  ESCAPE(base) AS base
+  SANITIZE(base) AS base
 FROM
   bases

--- a/Sources/winmd-inspect/Resources/Render/interfaces.sql
+++ b/Sources/winmd-inspect/Resources/Render/interfaces.sql
@@ -1,7 +1,7 @@
 SELECT
   rowid,
   TypeNamespace,
-  ESCAPE(TypeName) AS TypeName,
+  SANITIZE(TypeName) AS TypeName,
   iid
 FROM
   interfaces

--- a/Sources/winmd-inspect/Resources/Render/methods.sql
+++ b/Sources/winmd-inspect/Resources/Render/methods.sql
@@ -1,5 +1,5 @@
 SELECT
   rowid,
-  ESCAPE(Name) AS Name
+  SANITIZE(Name) AS Name
 FROM
   methods

--- a/Sources/winmd-inspect/Resources/Render/params.sql
+++ b/Sources/winmd-inspect/Resources/Render/params.sql
@@ -1,6 +1,6 @@
 SELECT
   rowid,
-  ESCAPE(Name) AS Name,
+  SANITIZE(Name) AS Name,
   Sequence
 FROM
   params

--- a/Sources/winmd-inspect/Shell.swift
+++ b/Sources/winmd-inspect/Shell.swift
@@ -406,14 +406,16 @@ internal struct Shell: ~Escapable {
   /// The base inheritance is derived through the `bases` view (the interface's
   /// `InterfaceImpl` rows navigated to their base type names); a rootless
   /// interface defaults to the spec's COM `root`, save the root interface
-  /// itself, which inherits nothing. Identifier escaping and the no-value return
-  /// come from the template's language spec (`ESCAPE`/`RETURNS`), not the binary.
+  /// itself, which inherits nothing. Identifier escaping comes from the
+  /// template's language spec (the `SANITIZE` UDF), and the no-value return is
+  /// decided in Swift (`returned(_:)`) — neither is baked into the binary.
   internal borrowing func render(_ interface: String,
                                  template: String) throws -> String {
     // The template names its own target language through a leading `{{! language:
     // <name> }}` directive; stripping it yields the body and loads the matching
-    // spec, whose render UDFs (`ESCAPE`, `RETURNS`) make identifier escaping and
-    // the no-value return the queries' concern, not the binary's.
+    // spec, whose render UDF (`SANITIZE`) makes identifier escaping the
+    // queries' concern, not the binary's — while the no-value return is decided
+    // in Swift.
     // `self.` disambiguates the `template(named:)` accessor from the `template`
     // parameter that names the one to load.
     var body = try self.template(named: template, search: search)

--- a/Tests/winmd-inspectTests/DatabaseSQLTests.swift
+++ b/Tests/winmd-inspectTests/DatabaseSQLTests.swift
@@ -530,7 +530,7 @@ struct DatabaseSQLTests {
     // be escaped in the `: <base>` clause, exactly as the interface, method, and
     // parameter names are — otherwise `public protocol IMyInterface: protocol`
     // would not compile. Overriding `bases` to yield a keyword base drives the
-    // render's `ESCAPE(base)`.
+    // render's `SANITIZE(base)`.
     try DatabaseSQLTests.with { catalog in
       var shell = Shell(catalog)
       let query = """


### PR DESCRIPTION
The render pipeline registers a scalar UDF that maps an identifier to a valid target-language spelling — wrapping a reserved keyword in the spec's escape delimiters (Swift's backticks) and passing everything else (and NULL) through untouched. It was spelled ESCAPE.

ESCAPE is an ISO-SQL reserved word: in a `LIKE <pattern> ESCAPE <char>` predicate (§8.5) it introduces the escape character. Should LIKE ever be added to the engine, a UDF named ESCAPE would collide with the keyword. Rename it pre-emptively, while it is cheap, as a standards-hygiene win.

The new name is SANITIZE — it describes the behaviour (sanitise a name into a valid target-language identifier) and is not an ISO-SQL reserved word, so it cannot clash with a future keyword. This is a purely nominal change: the function's behaviour, and therefore the rendered output, is unchanged.

Updated the UDF registration and its diagnostics, the four bundled render `.sql` call sites (interfaces/bases/methods/params), the doc comment in swift.lang, a test comment, and the stale render doc comments in Shell.swift — which additionally claimed a RETURNS UDF that does not exist (the no-value return is decided in Swift via `returned(_:)`, not a UDF); corrected to describe only SANITIZE.