### PR TITLE
SQL: skip comments as lexer trivia

### DIFF
--- a/Sources/SQL/Error.swift
+++ b/Sources/SQL/Error.swift
@@ -43,8 +43,9 @@ public enum SQLError: Error, Hashable, Sendable {
   case state(String, String)
   /// A character that begins no valid token.
   case character(Character, at: SourceLocation)
-  /// A string literal whose closing quote is missing.
-  case unterminated(at: SourceLocation)
+  /// A delimited construct whose closing delimiter is missing — the `String`
+  /// names what was left open (a string literal, a block comment, …).
+  case unterminated(String, at: SourceLocation)
   /// An integer literal that does not fit the platform `Int`.
   case overflow(String, at: SourceLocation)
   /// A token of a kind other than the one the grammar requires here.
@@ -119,8 +120,8 @@ extension SQLError: CustomStringConvertible {
       message
     case let .character(character, location):
       "unexpected character '\(character)' at \(location)"
-    case let .unterminated(location):
-      "unterminated string literal at \(location)"
+    case let .unterminated(what, location):
+      "unterminated \(what) at \(location)"
     case let .overflow(text, location):
       "integer literal '\(text)' out of range at \(location)"
     case let .unexpected(found, expected, location):

--- a/Sources/SQL/Lexer.swift
+++ b/Sources/SQL/Lexer.swift
@@ -49,11 +49,17 @@ extension String {
 ///
 /// The lexer is single-pass over the source bytes. SQL is ASCII, so the lexer
 /// scans the input's UTF-8 bytes by value and compares them against ASCII byte
-/// constants. Whitespace separates tokens and is otherwise discarded; keywords
-/// are recognised case-insensitively; string literals are single-quoted with
-/// `''` as an escaped quote; a double-quoted delimited identifier (`""` an
-/// escaped quote) spells a name — a reserved word or otherwise — as an
-/// identifier verbatim.
+/// constants. Whitespace and comments separate tokens and are otherwise
+/// discarded; keywords are recognised case-insensitively; string literals are
+/// single-quoted with `''` as an escaped quote; a double-quoted delimited
+/// identifier (`""` an escaped quote) spells a name — a reserved word or
+/// otherwise — as an identifier verbatim.
+///
+/// Two comment forms are skipped as trivia (ISO 9075 §5.2 `<comment>`): a `--`
+/// simple comment runs to the end of the line, and a `/* … */` bracketed
+/// comment spans to its closing `*/`. A `--` shares its lead byte with the `-`
+/// subtraction operator and `/*` with the `/` division operator, so each opens
+/// a comment only when its second byte confirms it.
 ///
 /// The lexer tracks a `SourceLocation` as it scans — advancing the column per
 /// byte and starting a fresh line on each newline — so every token and fault
@@ -81,7 +87,7 @@ internal struct Lexer: ~Escapable {
 
   /// Scans and returns the next token, or `nil` once the input is exhausted.
   internal mutating func next() throws(SQLError) -> Token? {
-    trivia()
+    try trivia()
 
     guard let byte = peek() else { return nil }
 
@@ -191,7 +197,7 @@ internal struct Lexer: ~Escapable {
       }
     }
 
-    throw .unterminated(at: start)
+    throw .unterminated("string literal", at: start)
   }
 
   /// Scans a double-quoted delimited identifier at the current position.
@@ -233,7 +239,7 @@ internal struct Lexer: ~Escapable {
       }
     }
 
-    throw .unterminated(at: start)
+    throw .unterminated("delimited identifier", at: start)
   }
 
   /// Scans a bound-parameter placeholder `:name` at the current position.
@@ -333,12 +339,60 @@ internal struct Lexer: ~Escapable {
     position += 1
   }
 
-  /// Advances past any run of insignificant bytes (whitespace, and in time
-  /// comments) separating tokens.
-  private mutating func trivia() {
-    while let byte = peek(), whitespace(byte) {
+  /// Advances past any run of insignificant bytes — whitespace and comments —
+  /// separating tokens.
+  ///
+  /// Whitespace and the two comment forms may interleave freely, so this loops
+  /// until the cursor rests on a byte that begins a token (or the input ends).
+  private mutating func trivia() throws(SQLError) {
+    while let byte = peek() {
+      switch byte {
+      case let b where whitespace(b):
+        advance()
+      case UInt8(ascii: "-") where peek(1) == UInt8(ascii: "-"):
+        simple()
+      case UInt8(ascii: "/") where peek(1) == UInt8(ascii: "*"):
+        try block()
+      default:
+        return
+      }
+    }
+  }
+
+  /// Skips a `--` simple comment: from the `--` to the next newline, or to the
+  /// end of input if none follows.
+  ///
+  /// The terminating newline is left for `trivia()` to consume as ordinary
+  /// whitespace, so its line/column bookkeeping stays with `advance()`. An
+  /// unterminated `--` comment at end of input is not a fault.
+  private mutating func simple() {
+    advance()
+    advance()
+    while let byte = peek(), byte != UInt8(ascii: "\n") {
       advance()
     }
+  }
+
+  /// Skips a `/* … */` bracketed comment: from the `/*` to the matching `*/`.
+  ///
+  /// Bracketed comments do not nest — ISO 9075 does not require nesting, and
+  /// the common interpretation stops at the first `*/`. Newlines within the
+  /// comment advance the line counter through `advance()`. A comment left open
+  /// at end of input is unterminated and faults.
+  private mutating func block() throws(SQLError) {
+    let start = location
+    advance()
+    advance()
+    while let byte = peek() {
+      if byte == UInt8(ascii: "*"), peek(1) == UInt8(ascii: "/") {
+        advance()
+        advance()
+        return
+      }
+      advance()
+    }
+
+    throw .unterminated("block comment", at: start)
   }
 
   /// The byte `offset` positions ahead of the cursor, or `nil` past the end.

--- a/Sources/winmd-inspect/Shell.swift
+++ b/Sources/winmd-inspect/Shell.swift
@@ -727,33 +727,40 @@ internal struct Statements: Sequence {
     /// without a final terminator runs its last statement.
     internal mutating func next() -> String? {
       while true {
-        // Drain any completed statement already accumulated.
+        // Drain any completed statement already accumulated. A chunk that is
+        // only trivia — whitespace and comments, e.g. a `-- note` between two
+        // `;` — carries no statement, so skip it rather than hand the parser
+        // empty input.
         if let semicolon = Iterator.terminator(in: pending) {
           let statement = String(pending[..<semicolon]).trimmed
           pending = String(pending[pending.index(after: semicolon)...])
-          guard statement.isEmpty else { return statement }
+          guard Iterator.trivial(statement) else { return statement }
           continue
         }
         // Prompt before the read (the interactive shell only): a pending,
-        // unterminated statement asks for its continuation; an empty one asks
-        // for a fresh statement. A batch's hook is `nil`, so it never prompts.
-        prompt?(!pending.trimmed.isEmpty)
+        // unterminated statement asks for its continuation; an empty or
+        // trivia-only one asks for a fresh statement. A batch's hook is `nil`,
+        // so it never prompts.
+        prompt?(!Iterator.trivial(pending))
         guard let line = lines() else {
           // End of input: flush a final unterminated statement (the closing
-          // `;` is optional), then clear `pending` so the next call stops.
+          // `;` is optional), then clear `pending` so the next call stops. A
+          // trivia-only tail (a trailing or standalone `-- comment`) is nothing
+          // to run, so it ends the stream rather than reaching the parser.
           let statement = pending.trimmed
           pending = ""
-          return statement.isEmpty ? nil : statement
+          return Iterator.trivial(statement) ? nil : statement
         }
         // A `.`-meta line yields whole when no statement is pending — a
-        // whitespace-only spacer line before it is nothing, so drop it rather
-        // than gluing the meta line onto it. `.template` alone carries a single-
+        // whitespace-only or comment-only line before it is trivia, so drop it
+        // rather than glue the meta line onto it (a `-- note` before `.tables`
+        // must not turn the meta into SQL). `.template` alone carries a single-
         // quoted (possibly multiline) body: when ITS quote is left open, keep
         // accumulating raw lines until the quote closes, then yield the whole
         // block as one statement. Every other meta yields whole, so an
         // apostrophe in an argument — a `.read /tmp/O'Brien.sql` path — is data,
         // not an unterminated literal that would swallow the following lines.
-        if pending.trimmed.isEmpty, line.trimmed.first == "." {
+        if Iterator.trivial(pending), line.trimmed.first == "." {
           let meta = line.trimmed
           let spelling = meta.prefix { !$0.isWhitespace }
           guard spelling == Template.spelling, Iterator.open(in: meta) else {
@@ -784,61 +791,169 @@ internal struct Statements: Sequence {
     }
 
     /// The index in `text` of the first `;` that terminates a statement — one
-    /// outside a single-quoted string literal — or `nil` when there is none
-    /// (including when `text` trails off inside a literal whose closing quote
-    /// has not arrived yet). A `;` inside `'…'` is data, not a terminator, so
-    /// the split matches what the SQL lexer scans (`''` is an escaped quote).
+    /// outside a string literal, a delimited identifier, and a comment — or
+    /// `nil` when there is none (including when `text` trails off inside an
+    /// unclosed `'…'` or `"…"`). A `;` inside `'…'`, `"…"`, `--`, or `/* … */`
+    /// is data, not a terminator, so the split matches what the SQL lexer
+    /// scans.
     ///
-    /// It runs the same single-scan quote tracking `open(in:)` does — advancing
-    /// through `'…'` (a doubled `''` an escaped quote) — and returns the first
-    /// unquoted `;`, so both share one notion of what a literal is.
+    /// It runs the shared `scan`, as `open(in:)` does, so both agree on what a
+    /// literal, an identifier, and a comment are.
     private static func terminator(in text: String) -> String.Index? {
       var index = text.startIndex
-      var quoted = false
+      var enclosure = Enclosure.none
       while index < text.endIndex {
-        if Iterator.scan(text, &index, &quoted) { continue }
-        if !quoted, text[index] == ";" { return index }
+        if Iterator.scan(text, &index, &enclosure) { continue }
+        if enclosure == .none, text[index] == ";" { return index }
         index = text.index(after: index)
       }
       return nil
     }
 
-    /// Whether `text` ends inside an unclosed single-quoted literal — the shared
-    /// quote-state scan lifted out so the multiline meta accumulation and
-    /// `terminator(in:)` reuse one implementation. A doubled `''` is an escaped
-    /// quote (it stays inside the literal); a lone `'` toggles. `false` when
-    /// every `'` is balanced, so the line stands complete.
+    /// Whether `text` ends inside an unclosed single-quoted literal — a
+    /// QUOTE-ONLY scan for `.template` body accumulation. Unlike the SQL
+    /// `terminator` scan it does NOT skip comments or track delimited
+    /// identifiers: a `.template` line is meta-command text, not SQL, so a
+    /// `--`, `/*`, or `"` in its name or body is data, and only a `'…'` (a
+    /// doubled `''` escaped) opens or closes the body. `false` when every `'`
+    /// is balanced, so the line stands complete.
     private static func open(in text: String) -> Bool {
       var index = text.startIndex
       var quoted = false
       while index < text.endIndex {
-        if Iterator.scan(text, &index, &quoted) { continue }
+        let character = text[index]
+        if quoted {
+          if character == "'" {
+            let next = text.index(after: index)
+            if next < text.endIndex, text[next] == "'" {
+              index = text.index(after: next)
+              continue
+            }
+            quoted = false
+          }
+        } else if character == "'" {
+          quoted = true
+        }
         index = text.index(after: index)
       }
       return quoted
     }
 
-    /// Advances the quote state at `index` in `text`: enters a literal on an
-    /// opening `'`, and inside one consumes a doubled `''` as an escaped quote
-    /// (skipping both) or closes on a lone `'`. Returns `true` when it already
-    /// advanced `index` past the pair (the caller must not step again), `false`
-    /// when `index` still points at the character to consider — the single point
-    /// both scans agree on what a single-quoted literal is.
+    /// The literal/identifier the scan is currently inside — none, a single-
+    /// quoted string, or a double-quoted delimited identifier. A comment or a
+    /// `;` terminator is recognised only in `.none`; inside a string or an
+    /// identifier those bytes are data, exactly as the lexer treats them.
+    private enum Enclosure: Equatable { case none, string, identifier }
+
+    /// Advances the `enclosure` state at `index` in `text`. In `.none` it
+    /// enters a string on `'` or a delimited identifier on `"`, and otherwise
+    /// skips a `--` or `/* … */` comment; inside a string or identifier it
+    /// consumes a doubled `''`/`""` as an escaped quote (skipping both) or
+    /// closes on a lone one. Returns `true` when it already advanced `index` (a
+    /// skipped pair or comment — the caller must not step again), `false` when
+    /// `index` still points at the character to consider. This is the SQL scan
+    /// `terminator(in:)` runs; `.template` meta text uses the quote-only
+    /// `open(in:)` instead, since `--`/`"` there are data, not SQL.
     private static func scan(_ text: String, _ index: inout String.Index,
-                             _ quoted: inout Bool) -> Bool {
+                             _ enclosure: inout Enclosure) -> Bool {
       let character = text[index]
-      if quoted {
+      switch enclosure {
+      case .string:
         guard character == "'" else { return false }
         let next = text.index(after: index)
         if next < text.endIndex, text[next] == "'" {
           index = text.index(after: next)
           return true
         }
-        quoted = false
-      } else if character == "'" {
-        quoted = true
+        enclosure = .none
+      case .identifier:
+        guard character == "\"" else { return false }
+        let next = text.index(after: index)
+        if next < text.endIndex, text[next] == "\"" {
+          index = text.index(after: next)
+          return true
+        }
+        enclosure = .none
+      case .none:
+        if character == "'" {
+          enclosure = .string
+        } else if character == "\"" {
+          enclosure = .identifier
+        } else if character == "-", let end = Iterator.simple(text, index) {
+          // A `--` line comment: skip to (not past) its newline, which the
+          // caller advances over as ordinary text. A `;` inside it is not a
+          // terminator, matching the lexer's trivia.
+          index = end
+          return true
+        } else if character == "/", let (end, _) = Iterator.block(text, index) {
+          // A `/* … */` block comment (or an unterminated `/*` run to the end):
+          // skipped whole, so a `;` inside it is not a terminator either.
+          index = end
+          return true
+        }
       }
       return false
+    }
+
+    /// The index of the newline ending a `--` line comment begun at `index` (or
+    /// `endIndex`), or `nil` when `index` begins no comment (no second `-`).
+    private static func simple(_ text: String, _ index: String.Index)
+        -> String.Index? {
+      let second = text.index(after: index)
+      guard second < text.endIndex, text[second] == "-" else { return nil }
+      var cursor = text.index(after: second)
+      while cursor < text.endIndex, text[cursor] != "\n" {
+        cursor = text.index(after: cursor)
+      }
+      return cursor
+    }
+
+    /// Whether `text` carries no statement — only whitespace and comments, so
+    /// it lexes to no token. Such a fragment (a trailing or standalone comment,
+    /// or a blank chunk between two `;`) must not be handed to the parser,
+    /// which would reject it as empty input.
+    private static func trivial(_ text: String) -> Bool {
+      var index = text.startIndex
+      while index < text.endIndex {
+        let character = text[index]
+        if character == "-", let end = Iterator.simple(text, index) {
+          index = end
+        } else if character == "/", let comment = Iterator.block(text, index) {
+          // An unterminated block comment is NOT trivia: the fragment must
+          // reach the parser so the lexer reports the missing `*/`, rather than
+          // being silently dropped. A closed comment is skipped.
+          guard comment.closed else { return false }
+          index = comment.end
+        } else if character.isWhitespace {
+          index = text.index(after: index)
+        } else {
+          return false
+        }
+      }
+      return true
+    }
+
+    /// The end of a `/* … */` block comment begun at `index` and whether it
+    /// closed: the index just past its `*/` with `closed` true, or `endIndex`
+    /// with `closed` false when unterminated; `nil` when `index` begins no
+    /// comment (no `*` after the `/`). The `closed` flag lets `trivial` keep an
+    /// unclosed comment non-trivial so its error still reaches the parser,
+    /// while `scan` consumes either way.
+    private static func block(_ text: String, _ index: String.Index)
+        -> (end: String.Index, closed: Bool)? {
+      let second = text.index(after: index)
+      guard second < text.endIndex, text[second] == "*" else { return nil }
+      var cursor = text.index(after: second)
+      while cursor < text.endIndex {
+        if text[cursor] == "*" {
+          let close = text.index(after: cursor)
+          if close < text.endIndex, text[close] == "/" {
+            return (text.index(after: close), true)
+          }
+        }
+        cursor = text.index(after: cursor)
+      }
+      return (cursor, false)
     }
   }
 }

--- a/Tests/SQLTests/ErrorTests.swift
+++ b/Tests/SQLTests/ErrorTests.swift
@@ -29,7 +29,8 @@ struct SQLStateTests {
   @Test("a syntax error reports 42601")
   func syntax() {
     #expect(SQLError.character("@", at: here).sqlstate == "42601")
-    #expect(SQLError.unterminated(at: here).sqlstate == "42601")
+    #expect(SQLError.unterminated("string literal", at: here).sqlstate
+                == "42601")
     #expect(
         SQLError.unexpected("X", expected: "Y", at: here).sqlstate == "42601")
     #expect(SQLError.incomplete(expected: "Z").sqlstate == "42601")

--- a/Tests/SQLTests/LexerTests.swift
+++ b/Tests/SQLTests/LexerTests.swift
@@ -173,6 +173,50 @@ struct LexerTests {
     #expect(throws: SQLError.self) { _ = try lex("\"oops") }
   }
 
+  @Test("skips a line comment between tokens")
+  func lineComment() throws {
+    #expect(try lex("SELECT -- pick a star\n*")
+                == [.select, .star])
+  }
+
+  @Test("skips a line comment at end of input")
+  func lineCommentAtEnd() throws {
+    // An unterminated `--` comment at EOF is not a fault.
+    #expect(try lex("SELECT * -- trailing") == [.select, .star])
+  }
+
+  @Test("skips a block comment spanning a newline")
+  func blockComment() throws {
+    #expect(try lex("SELECT /* a\n block */ *") == [.select, .star])
+  }
+
+  @Test("skips a block comment between tokens on one line")
+  func blockCommentInline() throws {
+    #expect(try lex("SELECT /* star */ *") == [.select, .star])
+  }
+
+  @Test("lexes a lone minus and slash as operators")
+  func loneOperators() throws {
+    // A single `-` or `/` is still an operator; only `--` and `/*` begin a
+    // comment.
+    #expect(try lex("a - 1 / 2")
+                == [.identifier("a"), .minus, .integer(1), .slash,
+                    .integer(2)])
+  }
+
+  @Test("rejects an unterminated block comment")
+  func unterminatedBlockComment() {
+    #expect(throws: SQLError.self) { _ = try lex("SELECT /* oops") }
+  }
+
+  @Test("tracks line and column across a block comment")
+  func commentLocation() throws {
+    // Newlines inside a block comment still advance the line counter.
+    let locations = try tokens("SELECT /* a\nb */ *").map(\.location)
+    #expect(locations.map(\.line) == [1, 2])
+    #expect(locations.map(\.column) == [1, 6])
+  }
+
   @Test("scans a bound-parameter placeholder")
   func parameter() throws {
     #expect(try lex("WHERE a = :pid")

--- a/Tests/winmd-inspectTests/ShellTests.swift
+++ b/Tests/winmd-inspectTests/ShellTests.swift
@@ -181,6 +181,69 @@ struct ShellTests {
             == ["SELECT 'x;\n y;' AS s"])
   }
 
+  @Test("a `;` inside a comment does not terminate the statement")
+  func streamComment() {
+    // Now that the lexer skips comments, the splitter must too: a `;` inside a
+    // `--` line comment or a `/* … */` block comment is not a terminator, or a
+    // valid script would be cut mid-comment before the lexer could skip it.
+    #expect(Array(Statements(of: "SELECT 1 -- ; note\n; SELECT 2;"))
+            == ["SELECT 1 -- ; note", "SELECT 2"])
+    #expect(Array(Statements(of: "SELECT /* ; */ 1;"))
+            == ["SELECT /* ; */ 1"])
+    #expect(Array(Statements(of: "SELECT /* a;\n b; */ 1; SELECT 2;"))
+            == ["SELECT /* a;\n b; */ 1", "SELECT 2"])
+    // A `--` comment stops at its newline, so the following statement still
+    // terminates rather than being swallowed by the comment; the comment text
+    // simply travels with that statement (the lexer skips it at parse).
+    #expect(Array(Statements(of: "SELECT 1; -- trailing\nSELECT 2;"))
+            == ["SELECT 1", "-- trailing\nSELECT 2"])
+  }
+
+  @Test("a trivia-only fragment is not yielded as a statement")
+  func streamTriviaOnly() {
+    // A chunk that is only whitespace and comments carries no statement, so it
+    // is dropped rather than handed to the parser as empty input — a trailing
+    // or standalone comment, or a comment between terminators.
+    #expect(Array(Statements(of: "SELECT 1; -- trailing")) == ["SELECT 1"])
+    #expect(Array(Statements(of: "-- just a comment")).isEmpty)
+    #expect(Array(Statements(of: "/* a block */")).isEmpty)
+    #expect(Array(Statements(of: "SELECT 1; -- note\n; SELECT 2;"))
+            == ["SELECT 1", "SELECT 2"])
+  }
+
+  @Test("an unterminated block comment is yielded, not dropped")
+  func streamUnterminatedComment() {
+    // A CLOSED comment is trivia, but an unclosed `/*` is not: the fragment
+    // must reach the parser so the lexer's unterminated-block-comment error
+    // surfaces on a batch/`.read`/EOF path rather than being silently
+    // swallowed.
+    #expect(Array(Statements(of: "/* missing close")) == ["/* missing close"])
+    #expect(Array(Statements(of: "SELECT 1; /* missing close"))
+            == ["SELECT 1", "/* missing close"])
+  }
+
+  @Test("a `;` or comment inside a delimited identifier is data")
+  func streamDelimitedIdentifier() {
+    // A double-quoted delimited identifier is tracked like a string literal, so
+    // `--`, `/* */`, and `;` inside `"…"` are data — not a comment or a
+    // terminator — and the real terminator after it is still found.
+    #expect(Array(Statements(of: "SELECT \"--\" AS c;"))
+            == ["SELECT \"--\" AS c"])
+    #expect(Array(Statements(of: "SELECT \"a;b\" AS c;"))
+            == ["SELECT \"a;b\" AS c"])
+    #expect(Array(Statements(of: "SELECT \"/* x */\" AS c;"))
+            == ["SELECT \"/* x */\" AS c"])
+  }
+
+  @Test("a comment before a meta-command does not turn it into SQL")
+  func streamCommentBeforeMeta() {
+    // A comment-only pending is trivia, so a following `.`-meta line is still
+    // recognised as a meta-command rather than glued onto the comment and sent
+    // through SQL parsing.
+    #expect(Array(Statements(of: "-- note\n.tables")) == [".tables"])
+    #expect(Array(Statements(of: "/* note */\n.read a.sql")) == [".read a.sql"])
+  }
+
   @Test("an open-quote `.`-meta accumulates raw lines into one statement")
   func streamOpenQuoteMeta() {
     // A `.`-meta whose single-quoted string is still open is a multiline meta:
@@ -220,6 +283,22 @@ struct ShellTests {
     let statements = Array(Statements(reading: { lines.next() }))
     #expect(statements.count == 2)
     #expect(statements[0] == ".template t 'first\n  ; second\nthird'")
+    #expect(statements[1] == "SELECT 1")
+  }
+
+  @Test("a `.template` name starting with -- still accumulates its body")
+  func streamTemplateDashName() {
+    // The `.template` name is the first token; when it starts with `--`, the
+    // meta accumulation must NOT treat the rest of the line as a comment (it is
+    // meta text, not SQL) — the open single quote still opens a multiline body.
+    let script = """
+      .template --swift 'line one
+      line two'
+      SELECT 1;
+      """
+    let statements = Array(Statements(of: script))
+    #expect(statements.count == 2)
+    #expect(statements[0] == ".template --swift 'line one\nline two'")
     #expect(statements[1] == "SELECT 1")
   }
 


### PR DESCRIPTION
Add both ISO 9075 §5.2 comment forms to the lexer, skipped as trivia (no token): a `--` simple comment to the next newline or end of input, and a `/* … */` bracketed comment to its closing `*/`, spanning lines. Block comments do not nest — the core-standard interpretation.

`trivia()` becomes a loop interleaving whitespace and comments, dispatched by a confirming second byte: `-` opens a comment only when the next byte is `-`, and `/` only when the next is `*`, so a lone `-`/`/` still lexes as `.minus`/ `.slash`. Two scanners — `simple()` (to a newline, left for the trivia loop to consume as whitespace) and `block()` — route through `advance()` so line/column tracking stays correct across skipped comments, including newlines inside a block. An unterminated `--` at end of input is benign; an unterminated `/*` faults. `next()` and `trivia()` are now `throws(SQLError)`.

`SQLError.unterminated` now carries what was left open (a `String`), so an unterminated block comment reports "unterminated block comment …" rather than the misleading string-literal wording; `string()` passes "string literal".

Tests: LexerTests covers a line comment between tokens and at EOF, a block comment spanning a newline and inline, the lone `-`/`/` regression, an unterminated block comment, and line/column tracking across a block comment.