### PR TITLE
winmd-inspect: hoist GUID decode into a scalar UDF over a BLOB column

### DIFF
--- a/Sources/SQL/Function.swift
+++ b/Sources/SQL/Function.swift
@@ -59,6 +59,14 @@ public struct Routines: Sendable {
     return Routines(functions)
   }
 
+  /// These routines overlaid with `other`'s — a caller composing two routine
+  /// sources (e.g. a target-language spec's UDFs and a data source's domain
+  /// UDFs). A name `other` also binds shadows this one's; names are already
+  /// case-folded on both sides.
+  public func merging(_ other: Routines) -> Routines {
+    Routines(functions.merging(other.functions) { _, last in last })
+  }
+
   /// The engine's built-in scalar functions, available to every `Routines` —
   /// even the empty one — and resolved ahead of a registered function of the
   /// same name (see `function(named:)`), so an unqualified call always reaches

--- a/Sources/WinMD/Attribute.swift
+++ b/Sources/WinMD/Attribute.swift
@@ -73,6 +73,18 @@ internal struct AttributeDecoder: ~Escapable {
 
 // MARK: - GuidAttribute value
 
+/// The UUID a `GuidAttribute` `CustomAttribute` value blob names, decoding the
+/// raw `bytes` as an ECMA-335 §II.23.3 `GuidAttribute` value.
+///
+/// This is the escapable, value → value form of `Tuple.iid(_:)`: a caller that
+/// has already copied a `CustomAttribute.Value` blob out of the borrowed scan
+/// (the SQL adapter's `.blob` cell) decodes it here, without a `Tuple`. A blob
+/// that is not a GUID-shaped `GuidAttribute` value throws.
+public func iid(decoding bytes: Array<UInt8>) throws(WinMDError) -> UUID {
+  var decoder = AttributeDecoder(bytes.span.bytes)
+  return try decoder.guid()
+}
+
 extension Tuple {
   /// The UUID a `GuidAttribute` `CustomAttribute` row's `Value` blob names, by
   /// decoding the `#Blob` heap cell at `column` as an ECMA-335 §II.23.3
@@ -91,7 +103,6 @@ extension Tuple {
     for i in 0 ..< blob.count {
       bytes.append(blob.load(at: i, as: UInt8.self))
     }
-    var decoder = AttributeDecoder(bytes.span.bytes)
-    return try decoder.guid()
+    return try WinMD.iid(decoding: bytes)
   }
 }

--- a/Sources/winmd-inspect/Database+SQL.swift
+++ b/Sources/winmd-inspect/Database+SQL.swift
@@ -22,22 +22,19 @@ internal import WinMD
 /// `width`: `rowid` enables foreign-key joins — an FK is a real column holding a
 /// `rowid`.
 ///
-/// One table exposes a further per-table virtual column that decodes
-/// WinMD-specific data, at ordinals `width + 1` onward: `guid` on
-/// `CustomAttribute` (the UUID its `Value` blob names, or `NULL` when the blob is
-/// not GUID-shaped — the `interfaces` view navigates to a type's `GuidAttribute`
-/// and selects this codec to spell its IID). The extras are keyed by the
-/// relation's schema name; they are computed in `WinMDRow` and, being decoded
-/// rather than stored, are never seekable.
-///
-/// Type spellings are *not* virtual columns: they are language-specific, so the
-/// adapter — the neutral conceptual layer — does not bake them. The render spells
-/// a return/parameter at render time through the `WinMD.Storage`
+/// WinMD-specific decodes are *not* virtual columns. A real `#Blob` cell is
+/// surfaced as a `.blob` (its raw heap bytes), and the decode is a scalar UDF
+/// over it: the `GUID` UDF takes a `CustomAttribute.Value` blob and returns the
+/// UUID it names as text, or `NULL` when the blob is not GUID-shaped — the
+/// `interfaces` view selects `GUID(c.Value)` to spell a type's IID. Type
+/// spellings likewise are not virtual columns: they are language-specific, so
+/// the adapter — the neutral conceptual layer — does not bake them. The render
+/// spells a return/parameter at render time through the `WinMD.Storage`
 /// `decode(return:in:)`/`decode(parameter:for:)` methods, which navigate a
 /// method/parameter's signature and apply a target `Dialect`.
 ///
-/// Past the extras sit a relation's join keys, at ordinals `width + 1 + extras`
-/// onward — the columns a view equi-joins across. A list-owned table leads the
+/// Past `rowid` sit a relation's join keys, at ordinals `width + 1` onward —
+/// the columns a view equi-joins across. A list-owned table leads the
 /// group with `parent` (the list-child's owning parent's `rowid`), which enables
 /// list joins — a list-child relates to its owner through its run rather than a
 /// stored key — and a non-list table simply has no `parent` column. The
@@ -130,20 +127,56 @@ internal struct Session: SQL.Catalog, ~Escapable {
   }
 }
 
+// MARK: - WinMD scalar UDFs
+
+extension Session {
+  /// The WinMD-domain scalar UDFs a query resolves against — the decode
+  /// primitives the adapter surfaces over its `.blob` columns rather than
+  /// baking as decoded virtual columns.
+  ///
+  /// The one entry is `GUID(blob)`, which decodes a `CustomAttribute.Value`
+  /// blob to the UUID it names; the bundled `interfaces` view selects it to
+  /// spell a type's IID. These are escapable, value → value functions — no
+  /// borrowed storage — so they thread through the interactive `Session.run`
+  /// and merge into the render's language routines uniformly.
+  internal static var routines: Routines {
+    ["guid": Session.guid]
+  }
+
+  /// `GUID(blob)` — the UUID a `GuidAttribute` `CustomAttribute` value blob
+  /// names, as its canonical text, or `NULL` when the blob is not GUID-shaped.
+  ///
+  /// A pure per-row codec, the value → value form of the WinMD `iid` decode:
+  /// the `interfaces` view applies it only to the rows it has already navigated
+  /// to a `GuidAttribute`, so a non-GUID blob simply yields `NULL` (preserving
+  /// the old `guid` virtual column's NULL-on-mismatch behaviour). A NULL
+  /// argument propagates to NULL; a non-blob argument is `SQLError.argument`.
+  private static let guid: Scalar = { arguments in
+    guard arguments.count == 1 else {
+      throw .argument("GUID takes one argument")
+    }
+    if case .null = arguments[0] { return .null }
+    guard case let .blob(bytes) = arguments[0] else {
+      throw .argument("GUID requires a blob argument")
+    }
+    guard let uuid = try? WinMD.iid(decoding: bytes) else { return .null }
+    return .text("\(uuid)")
+  }
+}
+
 // MARK: - Table
 
 /// A `SQL.Table` over one open WinMD table.
 ///
 /// Its real columns are the table's fields; the virtual columns follow, past the
-/// `SELECT *` extent: `rowid` at `width`, then the table's per-table decoded
-/// extras (`guid`) at `width + 1` onward, then the join
-/// keys — `parent` (on a list-owned table only) leading the coded-index join
-/// keys. A real cell is typed from its field's `ColumnType`: a `#Strings` index
-/// is `.text`, every other column (a constant, a foreign-key index, another
-/// heap) is `.integer`. A seek is available on `rowid` (a dense 1-based index,
-/// trivially monotonic), on `parent` over a list-child (whose owning run is
-/// monotonic in row order), and on the table's intrinsic sort key when the
-/// database physically sorts the table; the decoded extras are not seekable.
+/// `SELECT *` extent: `rowid` at `width`, then the join keys — `parent` (on a
+/// list-owned table only) leading the coded-index join keys. A real cell is
+/// typed from its field's `ColumnType`: a `#Strings` index is `.text`, a
+/// `#Blob` index is a `.blob`, every other column (a constant, a foreign-key
+/// index, another heap) is `.integer`. A seek is available on `rowid` (a dense
+/// 1-based index, trivially monotonic), on `parent` over a list-child (whose
+/// owning run is monotonic in row order), and on the table's intrinsic sort key
+/// when the database physically sorts the table.
 internal struct WinMDRelation: SQL.Table, ~Escapable {
   /// The borrowed storage the relation reads from.
   private let storage: WinMD.Storage
@@ -173,24 +206,22 @@ internal struct WinMDRelation: SQL.Table, ~Escapable {
     return names
   }
 
-  /// The virtual column names, in ordinal order — `rowid` at `width`, this
-  /// table's decoded extras at `width + 1` onward, then its join keys: `parent`
-  /// (on a list-owned table only) leading the coded-index join keys.
+  /// The virtual column names, in ordinal order — `rowid` at `width`, then its
+  /// join keys: `parent` (on a list-owned table only) leading the coded-index
+  /// join keys.
   internal var virtuals: Array<String> {
     let parent = WinMDRelation.Link(storage, table) == nil ? [] : ["parent"]
     return ["rowid"] // the universal identity, at `width`
-        + extras // decoded codec columns
         + parent // the list-ownership key, present only on a list-owned table
         + keys.map(\.name) // coded-index join keys
   }
 
   /// One past the highest ordinal this relation can address — its real `width`
-  /// plus the universal `rowid`, this table's decoded extras, and its join keys
-  /// (`parent` when list-owned, then the coded-index join keys).
+  /// plus the universal `rowid` and its join keys (`parent` when list-owned,
+  /// then the coded-index join keys).
   internal var extent: Int {
     width // real fields
         + 1 // `rowid`
-        + extras.count // decoded codec columns
         + (WinMDRelation.Link(storage, table) == nil ? 0 : 1) // `parent`
         + keys.count // coded-index join keys
   }
@@ -202,12 +233,12 @@ internal struct WinMDRelation: SQL.Table, ~Escapable {
   }
 
   /// The ordinal of the `parent` virtual column on a list-owned table — the
-  /// first join-key ordinal, past `rowid` and the decoded extras — or `nil` when
-  /// the table owns no list (it then has no `parent` column).
+  /// first join-key ordinal, immediately past `rowid` — or `nil` when the table
+  /// owns no list (it then has no `parent` column).
   private var parent: Int? {
     WinMDRelation.Link(storage, table) == nil
         ? nil
-        : width + 1 + extras.count
+        : width + 1
   }
 
   internal func ordinal(of name: String) -> Int? {
@@ -219,16 +250,10 @@ internal struct WinMDRelation: SQL.Table, ~Escapable {
     if name.caseInsensitiveCompare("rowid") == .orderedSame {
       return rowid
     }
-    // The decoded extras follow `rowid`: extra `i` sits at `rowid + 1 + i`.
-    let extras = self.extras
-    for index in extras.indices
-        where extras[index].caseInsensitiveCompare(name) == .orderedSame {
-      return rowid + 1 + index
-    }
-    // The join keys follow the extras. `parent` (on a list-owned table) leads
+    // The join keys follow `rowid`. `parent` (on a list-owned table) leads
     // them; the coded-index join keys follow at `parent + 1` onward (or, on a
     // non-list table, at the first join-key ordinal).
-    let base = rowid + 1 + extras.count
+    let base = rowid + 1
     if let parent, name.caseInsensitiveCompare("parent") == .orderedSame {
       return parent
     }
@@ -314,12 +339,12 @@ internal struct WinMDRelation: SQL.Table, ~Escapable {
   /// The coded-index join `Key` exposed at ordinal `column`, or `nil` when
   /// `column` is not one of this table's coded-index join keys.
   ///
-  /// The coded-index join keys occupy the ordinals past `rowid`, the decoded
-  /// extras, and — on a list-owned table — the `parent` key, in the order
-  /// `keys` exposes them; this maps `column` back through that layout, the
-  /// inverse of `ordinal(of:)`'s coded-index-key arm.
+  /// The coded-index join keys occupy the ordinals past `rowid` and — on a
+  /// list-owned table — the `parent` key, in the order `keys` exposes them;
+  /// this maps `column` back through that layout, the inverse of
+  /// `ordinal(of:)`'s coded-index-key arm.
   private func key(for column: Int) -> Key? {
-    let base = rowid + 1 + extras.count
+    let base = rowid + 1
     let lead = parent == nil ? base : base + 1
     let index = column - lead
     let all = keys
@@ -353,36 +378,6 @@ internal struct WinMDRelation: SQL.Table, ~Escapable {
   @_lifetime(borrow self)
   internal borrowing func cursor() -> WinMDCursor {
     WinMDCursor(storage, table, WinMDRelation.Link(storage, table))
-  }
-}
-
-// MARK: - Per-table extras
-
-extension WinMDRelation {
-  /// The decoded extra virtual column names of this relation's table, in
-  /// ordinal order — the single source of truth `virtuals`, `extent`, `parent`,
-  /// and `ordinal(of:)` derive from (keyed by the table's schema name, through
-  /// the shared `extras(of:)` core).
-  ///
-  /// One table decodes a WinMD-specific column past `rowid`: `CustomAttribute` a
-  /// `guid` (the GUID its `Value` blob names, for the `GuidAttribute` rows the
-  /// `interfaces` view selects). Every other table exposes only `rowid` and
-  /// `parent`, so it has no extras. `WinMDRow.extras` computes the same list by
-  /// the same keying.
-  internal var extras: Array<String> {
-    WinMDRelation.extras(of: table.description)
-  }
-
-  /// The decoded extra virtual column names of the table named `schema`, keyed
-  /// by its schema name — the shared core `WinMDRelation.extras` and
-  /// `WinMDRow.extras` both derive from, so a row (which carries only its
-  /// schema name) and a relation (which carries the open table) yield the same
-  /// extras.
-  internal static func extras(of schema: String) -> Array<String> {
-    switch schema {
-    case "CustomAttribute": ["guid"]
-    default:                Array<String>()
-    }
   }
 }
 
@@ -559,7 +554,7 @@ internal struct WinMDCursor: SQL.Cursor, ~Escapable {
   @_lifetime(copy self)
   internal borrowing func row(_ index: Int) -> WinMDRow? {
     guard let tuple = cursor[index] else { return nil }
-    return WinMDRow(tuple, storage, link, cursor.relation.description)
+    return WinMDRow(tuple, storage, link)
   }
 }
 
@@ -569,15 +564,15 @@ internal struct WinMDCursor: SQL.Cursor, ~Escapable {
 ///
 /// A cell is read by ordinal as a typed `Value`: a real ordinal (`< count`)
 /// reads the WinMD cell — a `#Strings` heap index resolves through the heap as
-/// `.text`, every other column is `.integer`; `rowid` (`count`) is the 1-based
-/// row index; a per-table extra ordinal (`count + 1` onward) decodes the table's
-/// WinMD-specific column (`guid`); and the join keys
-/// follow the extras — on a list-owned table the `parent` ordinal is the owning
-/// parent row's 1-based `rowid` (zero for a row no parent owns) and the
-/// coded-index join keys follow it, while on a non-list table the coded-index
-/// join keys follow the extras directly. A coded-index join-key ordinal decodes
-/// a coded-index cell to the target's 1-based `rowid`, or SQL `NULL` when the
-/// cell points elsewhere or is null.
+/// `.text`, a `#Blob` heap index as an owning `.blob` (the raw heap payload,
+/// for a scalar UDF such as `GUID` to decode), every other column `.integer`;
+/// `rowid` (`count`) is the 1-based row index; and the join keys follow it — on
+/// a list-owned table the `parent` ordinal is the owning parent row's 1-based
+/// `rowid` (zero for a row no parent owns) and the coded-index join keys follow
+/// it, while on a non-list table the coded-index join keys follow `rowid`
+/// directly. A coded-index join-key ordinal decodes a coded-index cell to the
+/// target's 1-based `rowid`, or SQL `NULL` when the cell points elsewhere or is
+/// null.
 internal struct WinMDRow: SQL.Row, ~Escapable {
   /// The WinMD row this view reads.
   private let tuple: WinMD.Tuple
@@ -588,67 +583,46 @@ internal struct WinMDRow: SQL.Row, ~Escapable {
   /// The relation's list link, when it is a list-child.
   private let link: WinMDRelation.Link?
 
-  /// The relation's schema name — the key for this table's decoded extras
-  /// (`WinMD.Tuple` does not expose its table's name, so it is carried in).
-  private let schema: String
-
   @_lifetime(copy tuple, copy storage)
   internal init(_ tuple: borrowing WinMD.Tuple,
                 _ storage: borrowing WinMD.Storage,
-                _ link: WinMDRelation.Link?, _ schema: String) {
+                _ link: WinMDRelation.Link?) {
     self.tuple = copy tuple
     self.storage = copy storage
     self.link = link
-    self.schema = schema
   }
 
   internal subscript(_ column: Int) -> Value {
     borrowing get {
-      // The real fields are `[0, count)`; `rowid` is `count`, the decoded extras
-      // are `count + 1` onward, then the join keys.
+      // The real fields are `[0, count)`; `rowid` is `count`, then the join
+      // keys follow it.
       if column == tuple.count {
         return .integer(tuple.index + 1)
       }
       if column > tuple.count {
-        // Past `rowid`: the decoded extras occupy `[0, extras.count)` of the
-        // virtual range, then the join keys. On a list-owned table `parent`
-        // leads the join keys (the owning parent's 1-based `rowid`, zero for a
-        // row no parent owns) and the coded-index join keys follow it; on a
-        // non-list table the coded-index join keys follow the extras directly.
-        let extras = self.extras.count
+        // Past `rowid`: the join keys. On a list-owned table `parent` leads
+        // them (the owning parent's 1-based `rowid`, zero for a row no parent
+        // owns) and the coded-index join keys follow it; on a non-list table
+        // the coded-index join keys follow `rowid` directly.
         let virtual = column - (tuple.count + 1)
-        if virtual < extras { return extra(virtual) }
-        let key = virtual - extras
-        guard let link else { return self.key(key) }
-        return key == 0
+        guard let link else { return self.key(virtual) }
+        return virtual == 0
             ? .integer(storage.owner(of: tuple.index, link))
-            : self.key(key - 1)
+            : self.key(virtual - 1)
       }
       if case .index(.heap(.string)) = tuple.type(of: column) {
         return .text((try? tuple.string(column)) ?? "")
       }
+      if case .index(.heap(.blob)) = tuple.type(of: column) {
+        guard let blob = try? tuple.blob(column) else { return .null }
+        var bytes = Array<UInt8>()
+        bytes.reserveCapacity(blob.count)
+        for i in 0 ..< blob.count {
+          bytes.append(blob.load(at: i, as: UInt8.self))
+        }
+        return .blob(bytes)
+      }
       return .integer(tuple[column])
-    }
-  }
-
-  /// The decoded extra virtual column names of this row's table, in ordinal
-  /// order — the schema-keyed sibling of `WinMDRelation.extras`, so a row
-  /// (which carries only its schema name) derives the same extras a relation
-  /// does from the open table (both through the shared
-  /// `WinMDRelation.extras(of:)` core).
-  private var extras: Array<String> {
-    WinMDRelation.extras(of: schema)
-  }
-
-  /// The decoded value of this table's `index`th extra virtual column.
-  ///
-  /// The extras are keyed by the table's schema name (the same keying `extras`
-  /// exposes); each decodes its WinMD-specific cell. An out-of-range index — no
-  /// such extra — is SQL `NULL`.
-  private func extra(_ index: Int) -> Value {
-    switch (schema, index) {
-    case ("CustomAttribute", 0): guid()
-    default:                     .null
     }
   }
 
@@ -683,21 +657,6 @@ internal struct WinMDRow: SQL.Row, ~Escapable {
     let value = key.kind.init(rawValue: tuple[key.column])
     guard value.tag == key.tag, value.row != 0 else { return .null }
     return .integer(value.row)
-  }
-
-  /// The `guid` extra of a `CustomAttribute` row — the UUID its `Value` blob
-  /// names, decoded as an ECMA-335 §II.23.3 `GuidAttribute` value, or SQL
-  /// `NULL` when the blob is not GUID-shaped.
-  ///
-  /// A pure per-row codec: the `interfaces` view selects it only on the rows it
-  /// has already navigated to a `GuidAttribute`, so a non-Guid attribute's
-  /// non-GUID blob simply yields `NULL`.
-  private func guid() -> Value {
-    guard let column = tuple.ordinal(for: "Value"),
-        let uuid = try? tuple.iid(column) else {
-      return .null
-    }
-    return .text("\(uuid)")
   }
 }
 

--- a/Sources/winmd-inspect/Resources/Queries/interfaces.sql
+++ b/Sources/winmd-inspect/Resources/Queries/interfaces.sql
@@ -3,7 +3,7 @@ SELECT
   t.rowid,
   t.TypeNamespace,
   t.TypeName,
-  c.guid AS iid
+  GUID(c.Value) AS iid
 FROM
   TypeDef t
   JOIN CustomAttribute c ON c.Parent_TypeDef = t.rowid
@@ -18,7 +18,7 @@ SELECT
   t.rowid,
   t.TypeNamespace,
   t.TypeName,
-  c.guid AS iid
+  GUID(c.Value) AS iid
 FROM
   TypeDef t
   JOIN CustomAttribute c ON c.Parent_TypeDef = t.rowid
@@ -33,7 +33,7 @@ SELECT
   t.rowid,
   t.TypeNamespace,
   t.TypeName,
-  c.guid AS iid
+  GUID(c.Value) AS iid
 FROM
   TypeDef t
   JOIN CustomAttribute c ON c.Parent_TypeDef = t.rowid

--- a/Sources/winmd-inspect/Shell.swift
+++ b/Sources/winmd-inspect/Shell.swift
@@ -420,7 +420,10 @@ internal struct Shell: ~Escapable {
     // parameter that names the one to load.
     var body = try self.template(named: template, search: search)
     let language = Shell.language(declaredIn: &body, search: search)
-    let routines = language.routines
+    // The queries resolve against both the target-language spec's UDFs
+    // (`SANITIZE`) and the WinMD-domain UDFs (`GUID`) — the `interfaces` view
+    // spells its `iid` through `GUID(c.Value)`.
+    let routines = language.routines.merging(Session.routines)
     // The type spellings are decoded at render time from the spec's `Dialect`:
     // the adapter is language-neutral, so the render — not the binary's WinMD →
     // SQL layer — spells a return/parameter, navigating the signature with the
@@ -866,9 +869,9 @@ extension Session {
       register(name, view)
       return []
     case let .select(query):
-      return try Engine.run(query, self, bindings: bindings)
+      return try Engine.run(query, self, Session.routines, bindings: bindings)
     case .with:
-      return try Engine.run(parsed, self, bindings: bindings)
+      return try Engine.run(parsed, self, Session.routines, bindings: bindings)
     }
   }
 }

--- a/Tests/winmd-inspectTests/DatabaseSQLTests.swift
+++ b/Tests/winmd-inspectTests/DatabaseSQLTests.swift
@@ -52,8 +52,9 @@ extension Dialect {
   }
 }
 
-/// Coverage of the WinMD → SQL adapter's decoded `guid` virtual column on
-/// `CustomAttribute` and the render-time signature decode (`decode(return:in:)`/
+/// Coverage of the WinMD → SQL adapter's `GUID` scalar UDF over a
+/// `CustomAttribute.Value` `.blob` column and the render-time signature decode
+/// (`decode(return:in:)`/
 /// `decode(parameter:for:)`), which the adapter no longer bakes as `ReturnType`/
 /// `ParamType` columns. Rather than map a `.winmd` file, the tests assemble a
 /// tiny COM
@@ -203,7 +204,7 @@ struct DatabaseSQLTests {
       Issue.record("not a SELECT")
       return []
     }
-    return try Engine.run(select, catalog)
+    return try Engine.run(select, catalog, Session.routines)
   }
 
   /// Parses `query` as a `CREATE VIEW`, returning its case-folded name and view.
@@ -226,7 +227,7 @@ struct DatabaseSQLTests {
       Issue.record("not a SELECT")
       return []
     }
-    return try Engine.run(select, Session(catalog, views))
+    return try Engine.run(select, Session(catalog, views), Session.routines)
   }
 
   /// Plans and runs `query` through the engine over a `Session` catalog
@@ -242,7 +243,7 @@ struct DatabaseSQLTests {
       Issue.record("not a SELECT")
       return []
     }
-    return try Engine.run(select, Session(catalog, views), Routines(),
+    return try Engine.run(select, Session(catalog, views), Session.routines,
                           bindings: bindings)
   }
 
@@ -250,9 +251,8 @@ struct DatabaseSQLTests {
   func bundledInterfaces() throws {
     // The `interfaces` view navigates each `TypeDef` to its `GuidAttribute` IID
     // across the coded-index join keys (`TypeDef` ← `CustomAttribute` →
-    // `MemberRef` → `TypeRef`), projecting the decoded `CustomAttribute.guid` as
-    // `iid`; the only IID-carrying type is `IMyInterface`, whose `iid` is the
-    // well-known value.
+    // `MemberRef` → `TypeRef`), projecting `GUID(c.Value)` as `iid`; the only
+    // IID-carrying type is `IMyInterface`, whose `iid` is the well-known value.
     try DatabaseSQLTests.with { catalog in
       let rows = try DatabaseSQLTests.run(
           "SELECT TypeName, iid FROM interfaces", Session.bundled(), catalog)
@@ -295,15 +295,16 @@ struct DatabaseSQLTests {
 
   @Test("a registered view is queryable through the session catalog")
   func sessionView() throws {
-    // `CREATE VIEW guids …` registers a view over `CustomAttribute`'s decoded
-    // `guid` extra; a `SELECT … FROM guids` then resolves it through the session
-    // catalog and yields the view's rows. The fixture's single
-    // `CustomAttribute` is the `GuidAttribute`, so its `guid` is the well-known
-    // value.
+    // `CREATE VIEW guids …` registers a view decoding `CustomAttribute.Value`
+    // through the `GUID` UDF; a `SELECT … FROM guids` then resolves it through
+    // the session catalog and yields the view's rows. The fixture's single
+    // `CustomAttribute` is the `GuidAttribute`, so its `GUID(Value)` is the
+    // well-known value.
     try DatabaseSQLTests.with { catalog in
       let (name, view) = try DatabaseSQLTests.create(
           "CREATE VIEW guids AS "
-          + "SELECT guid FROM CustomAttribute WHERE guid IS NOT NULL")
+          + "SELECT GUID(Value) AS guid FROM CustomAttribute "
+          + "WHERE GUID(Value) IS NOT NULL")
       let rows = try DatabaseSQLTests.run(
           "SELECT guid FROM guids", [name: view], catalog)
       #expect(rows == [[.text("0C733A30-2A1C-11CE-ADE5-00AA0044773D")]])
@@ -390,23 +391,22 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("vends a CustomAttribute's decoded guid")
+  @Test("the GUID UDF decodes a CustomAttribute's Value blob")
   func guid() throws {
-    // The `guid` extra decodes the `GuidAttribute`'s `Value` blob to the
-    // well-known UUID as text; the fixture's sole `CustomAttribute` is that
-    // attribute.
+    // The `GUID` UDF decodes the `GuidAttribute`'s `Value` blob (surfaced as a
+    // real `.blob` column) to the well-known UUID as text; the fixture's sole
+    // `CustomAttribute` is that attribute.
     try DatabaseSQLTests.with { catalog in
       let rows = try DatabaseSQLTests.run(
-          "SELECT guid FROM CustomAttribute", catalog)
+          "SELECT GUID(Value) FROM CustomAttribute", catalog)
       #expect(rows == [[.text("0C733A30-2A1C-11CE-ADE5-00AA0044773D")]])
     }
   }
 
-  @Test("excludes the decoded extras from SELECT *")
+  @Test("excludes the virtual columns from SELECT *")
   func star() throws {
     // `SELECT *` projects exactly the six real `TypeDef` fields — neither
-    // `rowid`, `parent`, nor any decoded extra appears — for each of the two
-    // fixture types.
+    // `rowid` nor `parent` appears — for each of the two fixture types.
     try DatabaseSQLTests.with { catalog in
       let rows = try DatabaseSQLTests.run("SELECT * FROM TypeDef", catalog)
       #expect(rows.count == 2)
@@ -633,12 +633,13 @@ struct DatabaseSQLTests {
   @Test("a coded-index join key joins a CustomAttribute to its owning TypeDef")
   func codedKeyJoin() throws {
     // Joining `CustomAttribute` to `TypeDef` on the decoded `Parent_TypeDef`
-    // key against the `TypeDef`'s rowid pairs the `GuidAttribute` row (carrying
-    // the decoded `guid`) with the `IMyInterface` type it decorates, end to end
+    // key against the `TypeDef`'s rowid pairs the `GuidAttribute` row (its
+    // `GUID(Value)` IID) with the `IMyInterface` type it decorates, end to end
     // across the coded index.
     try DatabaseSQLTests.with { catalog in
       let rows = try DatabaseSQLTests.run(
-          "SELECT TypeDef.TypeName, CustomAttribute.guid FROM CustomAttribute "
+          "SELECT TypeDef.TypeName, GUID(CustomAttribute.Value) "
+          + "FROM CustomAttribute "
           + "JOIN TypeDef ON CustomAttribute.Parent_TypeDef = TypeDef.rowid",
           catalog)
       #expect(rows == [


### PR DESCRIPTION
The adapter baked a per-table decoded `guid` virtual column on `CustomAttribute`, threaded through a bespoke "extras" apparatus: an `extras`/`extras(of:)` source of truth keyed by schema name, a `WinMDRow.guid()`/`extra(_:)` codec, and `+ extras.count`/`rowid + 1 + extras` offset arithmetic woven through `virtuals`, `extent`, `parent`, `ordinal(of:)`, `key(for:)`, and the `WinMDRow` subscript — all to serve a single decoded column the `interfaces` view selects as `iid`.

Now that the SQL engine has a BLOB value type, surface the raw `CustomAttribute.Value` bytes as a real `.blob` column (like any other real cell, keyed off its `#Blob` `ColumnType`) and register a `GUID(blob)` scalar UDF that decodes it to the formatted UUID text, or `NULL` when the blob is not GUID-shaped — preserving the old column's NULL-on-mismatch behaviour. The `interfaces` query computes `GUID(c.Value) AS iid`, and the decode logic moves from `WinMDRow.guid()` into the UDF (via a new value → value `WinMD.iid(decoding:)`, the escapable form of `Tuple.iid(_:)`).

The UDF is a pure value → value function needing no borrowed `Storage`, so it registers cleanly as `Session.routines` and threads through both the interactive `Session.run` path and the render path (merged into the language spec's routines through a new `Routines.merging`). With the codec hoisted, the entire extras apparatus is deleted and the offset arithmetic collapses back to plain `rowid + join keys`. The generated `@com` output is byte-for-byte unchanged.