### PR TITLE
SQL: collapse the two-tier UDF registry into a flat prelude

### DIFF
--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -40,7 +40,11 @@ public enum Engine {
                                                   _ routines: Routines = [:],
                                                   bindings: Bindings = [:])
       throws(SQLError) -> Array<Array<Value>> {
-    try run(query, catalog, [:], routines, bindings)
+    // Seed the standard prelude UNDER the caller's routines so a public call
+    // always resolves the built-ins (BITAND) even when it supplies unrelated
+    // UDFs; an explicitly registered function of the same name still shadows it
+    // (the merge keeps the caller's binding on a clash).
+    try run(query, catalog, [:], Routines.standard.merging(routines), bindings)
   }
 
   /// Runs `query` against `catalog` with the common table expressions `ctes` in
@@ -68,7 +72,10 @@ public enum Engine {
                                                   _ routines: Routines = [:],
                                                   bindings: Bindings = [:])
       throws(SQLError) -> Array<Array<Value>> {
-    switch statement {
+    // Seed the standard prelude under the caller's routines (see the query
+    // overload) so BITAND resolves regardless of what the caller supplies.
+    let routines = Routines.standard.merging(routines)
+    return switch statement {
     case let .select(query):
       try run(query, catalog, [:], routines, bindings)
     case let .with(ctes, query):

--- a/Sources/SQL/Function.swift
+++ b/Sources/SQL/Function.swift
@@ -41,13 +41,15 @@ public struct Routines: Sendable {
   }
 
   /// The function named `name`, folded to lower case like every other SQL
-  /// identifier, or `nil` if neither a built-in nor a registered function bears
-  /// it. An engine built-in resolves AHEAD of a registered function of the same
-  /// name: an unqualified scalar call can never shadow a built-in. (A future
-  /// PATH / search-order mechanism — à la DB2 or PostgreSQL — would let a
-  /// qualified call reach a user's redefinition.)
+  /// identifier, or `nil` if no registered function bears it. There is a single
+  /// flat map with no privileged tier: a prelude function (`Routines.standard`)
+  /// and a caller-registered one resolve through the same lookup, so a later
+  /// registration shadows an earlier binding of the same name — the house rule
+  /// the resolver already follows (a view shadows a table, a CTE shadows a
+  /// view). (A future PATH / search-order mechanism — à la DB2 or PostgreSQL —
+  /// would let a qualified call reach a specific one across schemas.)
   public func function(named name: String) -> Scalar? {
-    Routines.builtins[name.lowercased()] ?? functions[name.lowercased()]
+    functions[name.lowercased()]
   }
 
   /// A copy of these routines with `function` bound to `name` (folded to lower
@@ -67,14 +69,14 @@ public struct Routines: Sendable {
     Routines(functions.merging(other.functions) { _, last in last })
   }
 
-  /// The engine's built-in scalar functions, available to every `Routines` —
-  /// even the empty one — and resolved ahead of a registered function of the
-  /// same name (see `function(named:)`), so an unqualified call always reaches
-  /// the built-in. `BITAND` is the portable, standards-compliant spelling
-  /// (Oracle's) of a bitwise AND, an operation ISO SQL and this grammar
-  /// otherwise lack; it is a built-in so any dialect gets it without registering
-  /// a closure.
-  private static let builtins: Dictionary<String, Scalar> = ["bitand": bitand]
+  /// The standard-library prelude — the routines the engine ships, seeded into
+  /// the flat registry at the public entry points so a query reaches them
+  /// without a caller registering a closure. They are ordinary entries in the
+  /// same map as any registered function, not a privileged tier, so a caller
+  /// MAY shadow one (see `function(named:)`). Its lone member is `BITAND`, the
+  /// portable, standards-compliant spelling (Oracle's) of a bitwise AND — an
+  /// operation ISO SQL and this grammar otherwise lack.
+  public static let standard: Routines = ["bitand": bitand]
 
   /// `BITAND(x, y)` — the bitwise AND of two integers. A NULL argument yields
   /// NULL (SQL null propagation); the wrong argument count or a non-integer

--- a/Sources/winmd-inspect/Database+SQL.swift
+++ b/Sources/winmd-inspect/Database+SQL.swift
@@ -134,13 +134,16 @@ extension Session {
   /// primitives the adapter surfaces over its `.blob` columns rather than
   /// baking as decoded virtual columns.
   ///
-  /// The one entry is `GUID(blob)`, which decodes a `CustomAttribute.Value`
-  /// blob to the UUID it names; the bundled `interfaces` view selects it to
-  /// spell a type's IID. These are escapable, value → value functions — no
-  /// borrowed storage — so they thread through the interactive `Session.run`
-  /// and merge into the render's language routines uniformly.
+  /// The `GUID(blob)` entry decodes a `CustomAttribute.Value` blob to the UUID
+  /// it names; the bundled `interfaces` view selects it to spell a type's IID.
+  /// It is an escapable, value → value function — no borrowed storage — so it
+  /// threads through the interactive `Session.run` and merges into the render's
+  /// language routines uniformly. The engine's standard-library prelude
+  /// (`Routines.standard`, e.g. `BITAND`) is folded in here so it reaches the
+  /// session and render paths, which pass these routines EXPLICITLY rather than
+  /// relying on the engine's default seeding.
   internal static var routines: Routines {
-    ["guid": Session.guid]
+    Routines.standard.registering("guid", Session.guid)
   }
 
   /// `GUID(blob)` — the UUID a `GuidAttribute` `CustomAttribute` value blob

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -2269,8 +2269,11 @@ struct EngineStreamingProductTests {
 /// Routines with two demonstration scalar functions: `upper`, which folds a
 /// text cell to upper case, and `add`, which sums two integer cells. These
 /// stand in for the per-dialect decode functions a synthesis projection calls.
+/// Built from `Routines.standard` so the prelude (e.g. `BITAND`) resolves here
+/// as it does at the engine's public entry points, which seed the prelude by
+/// default.
 private func routines() -> Routines {
-  Routines()
+  Routines.standard
     .registering("upper") { arguments throws(SQLError) in
       guard case let .text(text) = arguments.first else {
         throw .argument("upper expects one text argument")
@@ -2349,10 +2352,11 @@ struct EngineFunctionTests {
     #expect(rows == [[.text("ALICE")]])
   }
 
-  @Test("the built-in BITAND yields the bitwise AND of two integers")
+  @Test("the prelude BITAND yields the bitwise AND of two integers")
   func bitand() throws {
-    // BITAND is an engine built-in: `routines()` never registers it, yet the
-    // call resolves and folds case-insensitively. 12 & 10 = 8; 6 & 3 = 2.
+    // BITAND ships in the prelude (`Routines.standard`): `routines()` never
+    // registers it, yet the call resolves through the seeded prelude and folds
+    // case-insensitively. 12 & 10 = 8; 6 & 3 = 2.
     #expect(try functionRun("SELECT BITAND(12, 10) FROM People WHERE Id = 1")
             == [[.integer(8)]])
     #expect(try functionRun("SELECT bitand(6, 3) FROM People WHERE Id = 1")
@@ -2371,16 +2375,17 @@ struct EngineFunctionTests {
     }
   }
 
-  @Test("a registered function cannot shadow the built-in BITAND")
-  func bitandNotShadowed() throws {
-    // A built-in resolves ahead of a registered function of the same name, so
-    // an unqualified `BITAND` is always the built-in, not the user's closure.
-    let user = Routines().registering("bitand") { _ throws(SQLError) in
+  @Test("a registered function shadows the prelude BITAND")
+  func bitandShadowed() throws {
+    // The registry is a single flat map with no privileged tier, so a caller's
+    // `bitand` registered OVER the prelude one shadows it (house rule: a later
+    // binding wins). The user's closure returns -1, not the bitwise AND.
+    let user = Routines.standard.registering("bitand") { _ throws(SQLError) in
       .integer(-1)
     }
     let query = try parse("SELECT BITAND(6, 3) FROM People WHERE Id = 1")
     let rows = try Engine.run(query, people(), user)
-    #expect(rows == [[.integer(2)]])
+    #expect(rows == [[.integer(-1)]])
   }
 
   @Test("routine names colliding only by case merge without trapping")


### PR DESCRIPTION
`Routines` resolved a call in two tiers: a hardcoded `builtins` map (`["bitand": bitand]`) consulted AHEAD of the caller-registered `functions`, so an unqualified call could never reach a registered function of a built-in's name. That privileged tier is the MySQL-style anti-pattern the UDF audit flagged — built-ins and user functions lived in different namespaces with an implicit, unconfigurable search order.

Dissolve the tiers into one flat map. `function(named:)` is now a single `functions[name.lowercased()]` lookup with no fallback, so a registered function may shadow a shipped one (the house rule the resolver already follows: a view shadows a table, a CTE shadows a view). The built-ins become an ordinary `Routines` value, `Routines.standard` — a standard- library "prelude" — holding `BITAND` as a plain entry, no longer a special case.

The prelude is seeded at the public entry points so BITAND still resolves everywhere it did: both `Engine.run` overloads default their `routines` parameter to `.standard`, and winmd-inspect's `Session` routines fold `.standard` in (its session/render paths pass routines explicitly, bypassing the default), so the composed set is standard ∪ language ∪ winmd. BITAND resolution is unchanged for every existing call site; only the mechanism moved.

The PATH / search-order note in `function(named:)` stays as future work.