### PR TITLE
SQL: add standard aggregates with GROUP BY and HAVING

### DIFF
--- a/Sources/SQL/AST.swift
+++ b/Sources/SQL/AST.swift
@@ -116,6 +116,18 @@ public struct Select: Hashable, Sendable {
   /// The row filter, if any.
   public let predicate: Predicate?
 
+  /// The `GROUP BY` columns, in source order — empty for a query with no
+  /// explicit grouping. A query that aggregates without a `GROUP BY` (`SELECT
+  /// COUNT(*) FROM T`) leaves this empty and aggregates the whole result as a
+  /// single group.
+  public let grouping: Array<Column>
+
+  /// The `HAVING` filter over the grouped rows, if any — a predicate the engine
+  /// applies AFTER aggregation, so it may reference the aggregates and the
+  /// grouping columns. A `HAVING` without a `GROUP BY` filters the single
+  /// whole-result group.
+  public let having: Predicate?
+
   /// The ordering applied to the result, if any.
   public let order: Order?
 
@@ -124,11 +136,14 @@ public struct Select: Hashable, Sendable {
 
   public init(projection: Projection, from: Relation?,
               joins: Array<Join> = [], predicate: Predicate? = nil,
+              grouping: Array<Column> = [], having: Predicate? = nil,
               order: Order? = nil, limit: Limit? = nil) {
     self.projection = projection
     self.from = from
     self.joins = joins
     self.predicate = predicate
+    self.grouping = grouping
+    self.having = having
     self.order = order
     self.limit = limit
   }
@@ -276,6 +291,43 @@ public indirect enum Expression: Hashable, Sendable {
   /// `lhs <op> rhs` — a binary arithmetic expression over two sub-expressions,
   /// the engine evaluating it per row to a typed `Value`.
   case binary(Arithmetic, Expression, Expression)
+  /// An aggregate function over a group of rows — `COUNT(*)`, `COUNT(x)`,
+  /// `SUM(x)`, `MIN(x)`, `MAX(x)`, `AVG(x)`. Unlike a scalar `call` (evaluated
+  /// per row), an aggregate accumulates over every row of a group and yields one
+  /// value, so the engine recognises the fixed set of aggregate names at parse
+  /// time and lowers them through a dedicated mechanism rather than the routines.
+  case aggregate(Aggregate, of: Aggregand)
+}
+
+/// A standard SQL aggregate function.
+///
+/// The engine recognises this fixed set by name (case-insensitively) at parse
+/// time, distinct from a scalar-function `call`. `COUNT` counts rows (or
+/// non-NULL values); `SUM`/`AVG` total and average the non-NULL integers;
+/// `MIN`/`MAX` take the least/greatest non-NULL value by the engine's typed
+/// comparison.
+public enum Aggregate: Hashable, Sendable {
+  /// `COUNT` — the number of rows (`*`) or of non-NULL values.
+  case count
+  /// `SUM` — the total of the non-NULL integer values.
+  case sum
+  /// `MIN` — the least non-NULL value.
+  case min
+  /// `MAX` — the greatest non-NULL value.
+  case max
+  /// `AVG` — the average of the non-NULL integer values.
+  case avg
+}
+
+/// An aggregate's operand: `*` (rows), valid only for `COUNT`, or a scalar
+/// expression evaluated per row and aggregated over the group.
+public enum Aggregand: Hashable, Sendable {
+  /// `*` — the whole row, the operand of `COUNT(*)`. It counts every row of the
+  /// group, NULLs included, so it is admitted only for `COUNT`.
+  case star
+  /// An expression evaluated per row; the aggregate folds its non-NULL values
+  /// over the group.
+  case expression(Expression)
 }
 
 /// A binary arithmetic operator.

--- a/Sources/SQL/Aggregate.swift
+++ b/Sources/SQL/Aggregate.swift
@@ -1,0 +1,289 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+/// Aggregation — grouping a relation and folding aggregate functions over each
+/// group.
+///
+/// An aggregate query groups its filtered rows by the `GROUP BY` columns (or
+/// treats the whole result as one group when there is none) and folds a
+/// `COUNT`/`SUM`/`MIN`/`MAX`/`AVG` accumulator over every row of a group. Unlike
+/// a scalar function — evaluated per row through the `Routines` — an aggregate
+/// accumulates over a group, so it is a separate mechanism the engine
+/// recognises by name at parse time and lowers to an `Aggregation` here, never
+/// routed through `Function.swift`.
+///
+/// The `Aggregate` node yields one grouped `Record` per group whose slots are
+/// the group-key values (slots `0 ..< keys.count`, in key order) followed by the
+/// aggregate results (slot `keys.count + j` is aggregate `j`), the slot space
+/// the projection, the `HAVING`, and the `ORDER BY` are lowered against.
+
+/// A lowered aggregate — the ordinal-addressed form of an AST `Expression`'s
+/// `.aggregate`, ready for the executor to fold over a group.
+///
+/// The `function` is the standard aggregate; `argument` is the term evaluated
+/// per source record whose non-NULL values the aggregate folds, or `nil` for
+/// `COUNT(*)`, which counts rows without reading any value. The argument is in
+/// the SOURCE's slot space (the WHERE/join chain below the aggregate), evaluated
+/// against each source record before the fold; the result lands in the grouped
+/// record.
+internal struct Aggregation {
+  /// The aggregate function to fold over the group.
+  internal let function: Aggregate
+
+  /// The term evaluated per source record and folded, or `nil` for `COUNT(*)`
+  /// (which counts every row without reading a value).
+  internal let argument: Term?
+
+  internal init(function: Aggregate, argument: Term?) {
+    self.function = function
+    self.argument = argument
+  }
+}
+
+extension Aggregation {
+  /// This aggregation with its argument's slots remapped through `slot`.
+  internal func remapped(through slot: Dictionary<Int, Int>) -> Aggregation {
+    Aggregation(function: function,
+                argument: argument.map { $0.remapped(through: slot) })
+  }
+
+  /// The source slots this aggregation reads, accumulated into `slots` — its
+  /// argument's, or none for `COUNT(*)`.
+  internal func references(into slots: inout Set<Int>) {
+    argument?.references(into: &slots)
+  }
+}
+
+// MARK: - Accumulation
+
+/// A running aggregate over the rows of a group — the fold's state.
+///
+/// One accumulator per aggregate per group folds each source record's argument
+/// value in, then `value` reads off the result. `COUNT` counts rows (or non-NULL
+/// values); `SUM`/`AVG` total the non-NULL numeric values — an all-integer
+/// total stays an exact integer, any double operand widens the total to an
+/// approximate double, and the widen/overflow choice is deferred to the end so
+/// the result does not depend on row order — `AVG` then dividing by the non-NULL
+/// count as real division to an approximate-numeric double; `MIN`/`MAX` keep
+/// the least/greatest non-NULL value by the engine's typed `less`. Every
+/// aggregate but `COUNT` IGNORES NULLs — a NULL argument does not fold — and an
+/// empty or all-NULL group yields `COUNT` `0` and the others NULL.
+private struct Accumulator {
+  private let function: Aggregate
+  private var count = 0
+  // SUM/AVG numeric state, kept independent of row order: an exact WIDE integer
+  // total (`Int128`, range-checked once at the end) for the all-integer case,
+  // and a parallel double total used once any operand is a double. A wide total
+  // means a transient prefix overflow cannot latch a fault a later value undoes,
+  // and the widen decision is deferred so a double anywhere widens the group.
+  private var integer: Int128 = 0
+  private var total = 0.0
+  private var widened = false
+  private var extreme: Value? = nil
+
+  init(_ function: Aggregate) {
+    self.function = function
+  }
+
+  /// Folds one source `value` into the running aggregate — for `COUNT(*)` the
+  /// value is a sentinel `.integer` (a row is always counted); every other
+  /// aggregate ignores a NULL.
+  ///
+  /// - Throws: `SQLError.operand` if `SUM`/`AVG` meets a non-numeric value, or
+  ///   if `MIN`/`MAX` meets a value whose kind has no ordering against the one
+  ///   already seen (a TEXT after an INTEGER). An integer overflow or a
+  ///   non-finite double total is not raised here — the widen/overflow decision
+  ///   is deferred to `value` so it is order-independent.
+  mutating func fold(_ value: Value) throws(SQLError) {
+    // Every aggregate but a row-count ignores NULL — a NULL argument does not
+    // fold, so an all-NULL group aggregates as an empty one.
+    if case .null = value { return }
+    count += 1
+    switch function {
+    case .count, .min, .max:
+      if function != .count {
+        // Keep the least (`MIN`) or greatest (`MAX`) value by the engine's typed
+        // comparison; the first non-NULL value seeds it, and a later value of an
+        // unorderable kind is a type error, not an order-dependent keep.
+        extreme = if let current = extreme {
+          try keep(value, over: current)
+        } else {
+          value
+        }
+      }
+    case .sum, .avg:
+      // Total every value into a double running sum and flag whether any operand
+      // was a double, while keeping an exact wide (`Int128`) integer total for
+      // the all-integer case. Deferring the widen decision — and range-checking
+      // the wide total only at the end — keeps the result independent of row
+      // order: neither a later double nor a transient prefix overflow that a
+      // later value undoes can change the outcome.
+      switch value {
+      case let .integer(number):
+        total += Double(number)
+        integer += Int128(number)
+      case let .double(number):
+        total += number
+        widened = true
+      default:
+        throw .operand("operands must be numeric")
+      }
+    }
+  }
+
+  /// The value MIN/MAX keeps between a `candidate` and the running `extreme` —
+  /// the lesser for `MIN`, the greater for `MAX`, by the engine's typed `less`.
+  ///
+  /// - Throws: `SQLError.operand` if the two kinds have no ordering (a TEXT and
+  ///   an INTEGER, say). `less` orders neither way for such a pair, so keeping
+  ///   the first-seen value would make MIN/MAX depend on row order; a type error
+  ///   is deterministic instead.
+  private func keep(_ candidate: Value, over extreme: Value)
+      throws(SQLError) -> Value {
+    guard comparable(candidate, extreme) else {
+      throw .operand("MIN and MAX require a common comparable kind")
+    }
+    return (function == .min ? less(candidate, extreme)
+                             : less(extreme, candidate)) ? candidate : extreme
+  }
+
+  /// The aggregate's result once every row is folded.
+  ///
+  /// `COUNT` is the row/value count (`0` for an empty group); `SUM` the numeric
+  /// total — an exact integer when every value folded was an integer, a double
+  /// once any widened it (`NULL` when no value folded, an empty or all-NULL
+  /// group); `AVG` the real quotient of the total over the non-NULL count as an
+  /// approximate-numeric double (`NULL` when none); `MIN`/`MAX` the extreme
+  /// value (`NULL` when none).
+  ///
+  /// - Throws: `SQLError.magnitude` if an all-integer `SUM` total does not fit
+  ///   `Int` — the exact wide total is range-checked once, so only a truly
+  ///   out-of-range total faults, never a transient prefix overflow a later
+  ///   value undoes — or a `SUM`/`AVG` double result is not finite. `AVG`
+  ///   divides the wide total, so an integer sum outside `Int` still averages.
+  var value: Value {
+    get throws(SQLError) {
+      switch function {
+      case .count:
+        return .integer(count)
+      case .sum:
+        guard count != 0 else { return .null }
+        if widened {
+          guard total.isFinite else {
+            throw .magnitude("double result is not finite")
+          }
+          return .double(total)
+        }
+        guard let sum = Int(exactly: integer) else {
+          throw .magnitude("integer overflow")
+        }
+        return .integer(sum)
+      case .avg:
+        // AVG is real division of the numeric total over the non-NULL count,
+        // yielding an approximate-numeric double — not truncating like the
+        // engine's integer `/`. An empty or all-NULL group has no value, so AVG
+        // is NULL. It divides the WIDE total (the exact Int128, or the double
+        // total when a double widened it), so an all-integer sum outside Int
+        // still averages rather than faulting like SUM's Int-bounded result.
+        guard count != 0 else { return .null }
+        let sum: Double = widened ? total : Double(integer)
+        let average = sum / Double(count)
+        guard average.isFinite else {
+          throw .magnitude("double result is not finite")
+        }
+        return .double(average)
+      case .min, .max:
+        return extreme ?? .null
+      }
+    }
+  }
+}
+
+/// Whether MIN/MAX can order two non-NULL values: the same kind, or both
+/// numeric (integer/double, which `less` orders by magnitude). A cross-kind
+/// non-numeric pair — TEXT vs INTEGER, BLOB vs BOOLEAN — has no ordering, so a
+/// MIN/MAX over a column mixing them is a type error rather than a first-seen,
+/// order-dependent result.
+private func comparable(_ a: Value, _ b: Value) -> Bool {
+  switch (a, b) {
+  case (.integer, .integer), (.double, .double),
+       (.integer, .double), (.double, .integer),
+       (.text, .text), (.boolean, .boolean), (.blob, .blob):
+    true
+  default:
+    false
+  }
+}
+
+// MARK: - Execution
+
+/// Groups `records` by the `keys` terms and folds each `aggregates` accumulator
+/// over every record of a group, yielding one grouped record per group.
+///
+/// A grouped record's slots are the key values (slots `0 ..< keys.count`, in key
+/// order) followed by the aggregate results (slot `keys.count + j` is
+/// `aggregates[j]`). Groups are keyed on the EXACT canonical form of the
+/// evaluated key values (`canonical` — so `1` and `1.0` fall in one group, the
+/// equality UNION and predicates use), and each group emits its FIRST-appearance
+/// original key values, in first-appearance order, so a later `ORDER BY`
+/// re-sorts deterministically. With no `keys` the whole input
+/// is ONE group — the degenerate whole-result aggregation (`SELECT COUNT(*) FROM
+/// T`) — which yields a single grouped record even over an empty input (`COUNT`
+/// `0`, the others NULL), the standard SQL rule.
+internal func grouped(_ records: Array<Record>, _ keys: Array<Term>,
+                      _ aggregates: Array<Aggregation>, _ routines: Routines)
+    throws(SQLError) -> Array<Record> {
+  var order = Array<Record>()
+  var accumulators = Dictionary<Record, Array<Accumulator>>()
+
+  for record in records {
+    var cells = Array<Value>()
+    cells.reserveCapacity(keys.count)
+    for key in keys {
+      try cells.append(evaluate(key, record, routines))
+    }
+    let group = Record(cells)
+    // Key the group on the EXACT canonical form of its cells so `1` and `1.0`
+    // fall in one group (the equality UNION and predicates use), while the
+    // emitted group keeps the first-appearance ORIGINAL values.
+    let identity = Record(cells.map(canonical))
+
+    if accumulators[identity] == nil {
+      accumulators[identity] = aggregates.map { Accumulator($0.function) }
+      order.append(group)
+    }
+    for index in aggregates.indices {
+      // `COUNT(*)` has no argument — count the row with a non-NULL sentinel;
+      // every other aggregate folds its evaluated argument value.
+      let value: Value = if let argument = aggregates[index].argument {
+        try evaluate(argument, record, routines)
+      } else {
+        .integer(0)
+      }
+      try accumulators[identity]![index].fold(value)
+    }
+  }
+
+  // A whole-result aggregation with no matching row still yields one group — the
+  // empty group — so the degenerate `SELECT COUNT(*) FROM T` over no rows counts
+  // `0` rather than yielding no row at all. A grouped query over no rows yields
+  // no group (standard SQL).
+  if keys.isEmpty && order.isEmpty {
+    let empty = aggregates.map { Accumulator($0.function) }
+    var cells = Array<Value>()
+    cells.reserveCapacity(empty.count)
+    for accumulator in empty { try cells.append(accumulator.value) }
+    return [Record(cells)]
+  }
+
+  var groups = Array<Record>()
+  groups.reserveCapacity(order.count)
+  for group in order {
+    var cells = group.values
+    for accumulator in accumulators[Record(cells.map(canonical))]! {
+      try cells.append(accumulator.value)
+    }
+    groups.append(Record(cells))
+  }
+  return groups
+}

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -403,13 +403,16 @@ public enum Engine {
       throws(SQLError) -> Plan {
     guard let relation = select.from else {
       // A FROM-less select projects expressions over a single row; a `WHERE`,
-      // `ORDER BY`, `OFFSET`/`FETCH`, or `JOIN` has no relation to apply to. The
-      // parser never produces that shape, but a direct `Select(from: nil, …)`
-      // can, so reject it rather than silently ignore the clause.
+      // `GROUP BY`, `HAVING`, `ORDER BY`, `OFFSET`/`FETCH`, or `JOIN` has no
+      // relation to apply to. The parser never produces that shape, but a direct
+      // `Select(from: nil, …)` can, so reject it rather than silently ignore the
+      // clause — a scalar projection would drop a `GROUP BY`/`HAVING` otherwise.
       guard select.joins.isEmpty, select.predicate == nil,
+          select.grouping.isEmpty, select.having == nil,
           select.order == nil, select.limit == nil else {
         throw .unsupported(
-            "a WHERE, ORDER BY, OFFSET/FETCH, or JOIN requires a FROM clause")
+            "a WHERE, GROUP BY, HAVING, ORDER BY, OFFSET/FETCH, or JOIN " +
+            "requires a FROM clause")
       }
       return try scalar(select.projection)
     }
@@ -422,6 +425,15 @@ public enum Engine {
       guard limit.offset >= 0, (limit.count ?? 0) >= 0 else {
         throw .unsupported("OFFSET and FETCH row counts must be non-negative")
       }
+    }
+
+    // An aggregate query — one with a `GROUP BY`, a `HAVING`, or an aggregate in
+    // its projection — compiles through the grouped path, which places an
+    // `aggregate` node above the WHERE/join chain and lowers the projection,
+    // `HAVING`, and `ORDER BY` against the grouped slot space. A non-aggregate
+    // query compiles exactly as before.
+    if aggregates(select) {
+      return try group(select, relation, from, catalog, ctes)
     }
 
     guard !select.joins.isEmpty else {
@@ -667,6 +679,243 @@ public enum Engine {
     return .project(projection, plan.capped(limit: limit))
   }
 
+  // MARK: - Aggregation
+
+  /// Whether `select` aggregates — it has a `GROUP BY`, a `HAVING`, or an
+  /// aggregate function anywhere in its projection.
+  ///
+  /// A query with any of these compiles through the grouped path; one with none
+  /// keeps the ordinary `Project(Limit(Sort(Select(_))))` shape unchanged. A
+  /// `HAVING` alone (no `GROUP BY`, no aggregate) still aggregates — it filters
+  /// the single whole-result group.
+  private static func aggregates(_ select: Select) -> Bool {
+    if !select.grouping.isEmpty || select.having != nil { return true }
+    switch select.projection {
+    case .all, .columns:
+      return false
+    case let .expressions(items):
+      return items.contains { aggregated($0.expression) }
+    }
+  }
+
+  /// Whether `expression` contains an aggregate call anywhere within it.
+  private static func aggregated(_ expression: Expression) -> Bool {
+    switch expression {
+    case .column, .literal:
+      false
+    case .aggregate:
+      true
+    case let .call(_, arguments):
+      arguments.contains { aggregated($0) }
+    case let .binary(_, lhs, rhs):
+      aggregated(lhs) || aggregated(rhs)
+    }
+  }
+
+  /// Compiles an aggregate `select` into `Project(Limit(Sort(Having(Aggregate(
+  /// source)))))`, the `source` the WHERE/join chain and the aggregate node
+  /// grouping it.
+  ///
+  /// The source (a scan, or a left-deep join chain) materialises exactly the
+  /// ordinals the WHERE, the `GROUP BY` keys, and the aggregate arguments read.
+  /// The `aggregate` node groups it by the keys and folds each aggregate over a
+  /// group, yielding grouped records whose slots are the key values then the
+  /// aggregate results. The projection, `HAVING`, and `ORDER BY` lower against
+  /// that grouped slot space through a `Grouping`, which also enforces the
+  /// standard rule that every non-aggregated projection/`ORDER BY` column appear
+  /// in the `GROUP BY`.
+  private static func group<C: Catalog & ~Escapable>(_ select: Select,
+                                                     _ relation: Relation,
+                                                     _ from: Resolved,
+                                                     _ catalog: borrowing C,
+                                                     _ ctes: CTEs)
+      throws(SQLError) -> Plan {
+    // Resolve every joined relation and lay the FROM relation and each joined
+    // one end to end in one combined ordinal space (as the non-aggregate join
+    // path does), so the WHERE, keys, and aggregate arguments resolve uniformly.
+    var joined = Array<Resolved>()
+    joined.reserveCapacity(select.joins.count)
+    for join in select.joins {
+      try joined.append(resolve(join.relation, catalog, ctes))
+    }
+    var relations = [(relation, from.schema)]
+    for index in select.joins.indices {
+      relations.append((select.joins[index].relation, joined[index].schema))
+    }
+    let scope = Scope(relations)
+
+    // Each join's ON equality lowers to a `match` at its own chain level,
+    // resolved against only the prefix already in scope (as the non-aggregate
+    // path does).
+    var matches = Array<Filter>()
+    matches.reserveCapacity(select.joins.count)
+    for index in select.joins.indices {
+      let prefix = Scope(Array(relations[0 ... index + 1]))
+      let join = select.joins[index]
+      try matches.append(prefix.match(join.left, join.right))
+    }
+    var predicate: Filter? = nil
+    if let clause = select.predicate {
+      predicate = try scope.lower(clause)
+    }
+
+    // The `GROUP BY` keys and the aggregate arguments lower to combined
+    // base-ordinal terms; the aggregates are collected from the projection and
+    // the `HAVING` (deduplicated so the same aggregate computes once).
+    let keys = try select.grouping.map { column throws(SQLError) -> Term in
+      try .slot(scope.ordinal(of: column))
+    }
+    var expressions = Array<Expression>()
+    for expression in projected(select.projection) {
+      collect(expression, into: &expressions)
+    }
+    if let having = select.having {
+      collect(having, into: &expressions)
+    }
+    var aggregations = Array<Aggregation>()
+    for expression in expressions {
+      try aggregations.append(lower(expression, scope))
+    }
+
+    // The source materialises exactly the ordinals the WHERE, the keys, and the
+    // aggregate arguments read — never the projection/HAVING/ORDER, which read
+    // the GROUPED record. Pack them per relation in chain order, building the
+    // combined-ordinal → slot map and each relation's leaf ordinals.
+    var references = Set<Int>()
+    for match in matches { match.references(into: &references) }
+    predicate?.references(into: &references)
+    for key in keys { key.references(into: &references) }
+    for aggregation in aggregations { aggregation.references(into: &references) }
+    let combined = references.sorted()
+
+    var slot = Dictionary<Int, Int>(minimumCapacity: combined.count)
+    var locals = Array<Array<Int>>()
+    var packed = 0
+    for (offset, extent) in scope.layout {
+      let local = combined.compactMap {
+        offset <= $0 && $0 < offset + extent ? $0 - offset : nil
+      }
+      for index in local.indices {
+        slot[offset + local[index]] = packed + index
+      }
+      locals.append(local)
+      packed += local.count
+    }
+
+    let seed = from.leaf(locals[0])
+    var chain = select.joins.indices.reduce(seed) { chain, index in
+      .select(matches[index].remapped(through: slot),
+              .product(chain, joined[index].leaf(locals[index + 1])))
+    }
+    if let predicate {
+      chain = .select(predicate.remapped(through: slot), chain)
+    }
+
+    // The aggregate node groups the source by the remapped keys and folds each
+    // aggregate; its output is the grouped slot space the rest lowers against.
+    let node = Plan.aggregate(keys: keys.map { $0.remapped(through: slot) },
+                              aggregates: aggregations.map {
+                                $0.remapped(through: slot)
+                              }, chain)
+
+    // Lower the projection, HAVING, and ORDER BY against the grouped slot space,
+    // enforcing the projection rule (every non-aggregated column must be a
+    // GROUP BY key).
+    var grouping = try Grouping(scope, select.grouping, expressions)
+    let projection = try grouping.terms(select.projection)
+    let having: Filter? = if let clause = select.having {
+      try grouping.lower(clause)
+    } else {
+      nil
+    }
+    let order = if let clause = select.order {
+      try grouping.order(clause)
+    } else {
+      Array<(slot: Int, ascending: Bool)>()
+    }
+
+    var plan = node
+    if let having {
+      plan = .select(having, plan)
+    }
+    if !order.isEmpty {
+      plan = .sort(keys: order, plan)
+    }
+    return .project(projection, plan.capped(limit: select.limit))
+  }
+
+  /// The projected expressions of `projection` — an `expressions` list yields
+  /// each item's expression; a `*` or bare-column list yields none (no aggregate
+  /// can hide in them). An aggregate query's projection is always the
+  /// `expressions` case (an aggregate call makes it one).
+  private static func projected(_ projection: Projection) -> Array<Expression> {
+    switch projection {
+    case .all, .columns:
+      []
+    case let .expressions(items):
+      items.map(\.expression)
+    }
+  }
+
+  /// Collects the distinct aggregate expressions within `expression` into
+  /// `expressions`, in first-appearance order — the same aggregate written twice
+  /// computes once.
+  private static func collect(_ expression: Expression,
+                              into expressions: inout Array<Expression>) {
+    switch expression {
+    case .column, .literal:
+      break
+    case .aggregate:
+      if !expressions.contains(expression) {
+        expressions.append(expression)
+      }
+    case let .call(_, arguments):
+      for argument in arguments { collect(argument, into: &expressions) }
+    case let .binary(_, lhs, rhs):
+      collect(lhs, into: &expressions)
+      collect(rhs, into: &expressions)
+    }
+  }
+
+  /// Collects the distinct aggregates within a `predicate` into `expressions`.
+  private static func collect(_ predicate: Predicate,
+                              into expressions: inout Array<Expression>) {
+    switch predicate {
+    case let .comparison(left, _, right):
+      collect(left, into: &expressions)
+      collect(right, into: &expressions)
+    case let .bound(left, _, _):
+      collect(left, into: &expressions)
+    case let .null(expression, _):
+      collect(expression, into: &expressions)
+    case let .and(lhs, rhs), let .or(lhs, rhs):
+      collect(lhs, into: &expressions)
+      collect(rhs, into: &expressions)
+    case let .not(operand):
+      collect(operand, into: &expressions)
+    }
+  }
+
+  /// Lowers an AST `.aggregate` expression to an `Aggregation`, its argument (if
+  /// any) resolved to a combined base-ordinal term through `scope`.
+  ///
+  /// `COUNT(*)` has no argument (it counts rows); every other aggregate lowers
+  /// its single operand expression to a term. `expression` is always an
+  /// `.aggregate` — `collect` gathers only those.
+  private static func lower(_ expression: Expression, _ scope: Scope)
+      throws(SQLError) -> Aggregation {
+    guard case let .aggregate(function, operand) = expression else {
+      throw .unsupported("expected an aggregate")
+    }
+    let argument: Term? = switch operand {
+    case .star:
+      nil
+    case let .expression(expression):
+      try scope.term(expression)
+    }
+    return Aggregation(function: function, argument: argument)
+  }
+
   // MARK: - Optimisation
 
   /// Rewrites the logical `plan` into a physical one, re-resolving relations by
@@ -735,6 +984,14 @@ public enum Engine {
       // preserving this node's own `all`.
       try .union(optimise(left, catalog, ctes, bindings),
                  optimise(right, catalog, ctes, bindings), all: all)
+    case let .aggregate(keys, aggregates, source):
+      // An aggregate reshapes its source and has no seek or join of its own;
+      // optimise its source (the WHERE/join chain below it seeks and nests as
+      // usual) and rewrap. The `HAVING`/projection sit above it as `select`s the
+      // recursion reaches through here, but their grouped-space slots never seek
+      // a base relation.
+      try .aggregate(keys: keys, aggregates: aggregates,
+                     optimise(source, catalog, ctes, bindings))
     case let .limit(count, offset, source):
       // A `limit` is a transparent wrapper — optimise its source and re-cap;
       // the cap itself has no seek or join to rewrite.
@@ -1029,6 +1286,13 @@ extension Plan {
       try .product(left.pushdown(), right.pushdown())
     case let .union(left, right, all):
       try .union(left.pushdown(), right.pushdown(), all: all)
+    case let .aggregate(keys, aggregates, source):
+      // An aggregate reshapes rows into a fresh grouped slot space, so it is a
+      // pushdown barrier: a `HAVING`/projection filter above it is in grouped
+      // space and stays there (`distribute`'s default keeps it as a `select`
+      // over the aggregate), while the WHERE below it — already placed under the
+      // aggregate at compile — pushes down within the source as usual.
+      try .aggregate(keys: keys, aggregates: aggregates, source.pushdown())
     case let .limit(count, offset, source):
       // A `limit` is the outermost operator, so no `WHERE` conjunct ever reaches
       // it to push down; it recurses transparently, its source pushed as usual.

--- a/Sources/SQL/Error.swift
+++ b/Sources/SQL/Error.swift
@@ -112,6 +112,11 @@ public enum SQLError: Error, Hashable, Sendable {
   /// iteration cap (`kRecursionCap`) — it produces rows without end. The string
   /// is the offending CTE's name.
   case recursion(String)
+  /// An aggregate query names a column in its projection, `HAVING`, or `ORDER
+  /// BY` that is neither aggregated nor a `GROUP BY` key — the standard rule
+  /// requires every non-aggregated column to appear in the `GROUP BY`. The
+  /// string is the offending column's name.
+  case grouping(String)
 }
 
 extension SQLError: CustomStringConvertible {
@@ -165,6 +170,9 @@ extension SQLError: CustomStringConvertible {
       "statement is not runnable as a query: \(detail)"
     case let .recursion(name):
       "recursive CTE '\(name)' did not terminate"
+    case let .grouping(name):
+      "column '\(name)' must appear in the GROUP BY clause "
+          + "or be used in an aggregate function"
     }
   }
 }
@@ -197,9 +205,10 @@ extension SQLError {
   ///   (SwiftSQL) for a condition with no standard ISO code — `SS001`, a query
   ///   shape the engine does not support (a FROM-less `SELECT *`, or a clause
   ///   with no `FROM`), `SS002`, a statement that is not runnable as a query
-  ///   (a `CREATE VIEW`, or a malformed `WITH` member), and `SS003`, a recursive
-  ///   CTE that did not reach a fixpoint within the iteration cap. ISO leaves
-  ///   classes whose first character is `5`–`9` or `I`–`Z`
+  ///   (a `CREATE VIEW`, or a malformed `WITH` member), `SS003`, a recursive
+  ///   CTE that did not reach a fixpoint within the iteration cap, and `SS004`,
+  ///   an aggregate query naming a non-aggregated column absent from the `GROUP
+  ///   BY`. ISO leaves classes whose first character is `5`–`9` or `I`–`Z`
   ///   implementation-defined, so `SS` is a safe squat.
   public var sqlstate: String {
     switch self {
@@ -239,6 +248,8 @@ extension SQLError {
       "SS002"
     case .recursion:
       "SS003"
+    case .grouping:
+      "SS004"
     }
   }
 

--- a/Sources/SQL/Lexer.swift
+++ b/Sources/SQL/Lexer.swift
@@ -338,6 +338,8 @@ internal struct Lexer: ~Escapable {
     case "FROM": .from
     case "WHERE": .where
     case "ORDER": .order
+    case "GROUP": .group
+    case "HAVING": .having
     case "BY": .by
     case "ASC": .asc
     case "DESC": .desc

--- a/Sources/SQL/Operator.swift
+++ b/Sources/SQL/Operator.swift
@@ -148,6 +148,17 @@ internal indirect enum Plan {
   /// appends the trailing arm. Both sides yield rows of the same width — the
   /// result columns of the first arm.
   case union(Plan, Plan, all: Bool)
+  /// Γ — groups its `source`'s records by the `keys` terms and folds each
+  /// `aggregates` accumulator over every record of a group, yielding one grouped
+  /// record per group. The grouped record's slots are the `keys` values (slots
+  /// `0 ..< keys.count`, in key order) followed by the aggregate results (slot
+  /// `keys.count + j` is `aggregates[j]`), the slot space the projection, the
+  /// `HAVING`, and the `ORDER BY` are lowered against. With no `keys` the whole
+  /// source is one group — the degenerate `SELECT COUNT(*) FROM T` — yielding a
+  /// single grouped record even over an empty source (`COUNT` `0`, the others
+  /// NULL). It sits above the WHERE/join chain and below the projection, so it
+  /// aggregates the filtered rows and the projection reads its output.
+  case aggregate(keys: Array<Term>, aggregates: Array<Aggregation>, Plan)
   /// A row cap on its `source`'s output: skips the first `offset` records then
   /// takes at most `count` of the rest, in the source's order. It sits over the
   /// sort/select but BELOW the projection, so it caps the ordered rows before
@@ -175,6 +186,9 @@ extension Plan {
       // A `limit` caps rows without reshaping them, so it is as wide as its
       // source.
       source.width
+    case let .aggregate(keys, aggregates, _):
+      // A grouped record is the key values followed by the aggregate results.
+      keys.count + aggregates.count
     default:
       // `compile` always tops an arm with a `project`; nothing else reaches a
       // view's sub-plan root. Measuring nil would mask a width mismatch, so a
@@ -220,6 +234,10 @@ extension Plan {
       // A `limit` caps rows without reshaping them, so it spans the same slots
       // as its source.
       source.slots
+    case let .aggregate(keys, aggregates, _):
+      // A grouped record reshapes its source into the key values followed by the
+      // aggregate results — a fresh slot space of that width.
+      keys.count + aggregates.count
     default:
       nil
     }
@@ -304,6 +322,9 @@ internal func execute<C: Catalog & ~Escapable>(_ plan: Plan,
              base, column, keys, filter, catalog, ctes, routines, bindings)
   case let .union(left, right, all):
     try union(left, right, all, catalog, ctes, routines, bindings)
+  case let .aggregate(keys, aggregates, source):
+    try grouped(execute(source, catalog, ctes, routines, bindings), keys,
+                aggregates, routines)
   case let .limit(count, offset, source):
     limited(try execute(source, catalog, ctes, routines, bindings),
             count, offset)
@@ -514,8 +535,9 @@ private func bucket(_ value: Value) -> Value {
 /// fractional double, text, boolean, blob, null) is itself. Unlike the join's
 /// promoted `bucket`, this is EXACT and transitive, so two integers stay
 /// distinct even when they round to the same double — an earlier approximate
-/// row cannot absorb two unequal exact integers.
-private func canonical(_ value: Value) -> Value {
+/// row cannot absorb two unequal exact integers. Grouping reuses it to key its
+/// groups so `1` and `1.0` fall in one group, matching UNION's dedup.
+internal func canonical(_ value: Value) -> Value {
   if case let .double(number) = value, let integer = Int(exactly: number) {
     return .integer(integer)
   }
@@ -776,20 +798,25 @@ internal func less(_ lhs: Value, _ rhs: Value) -> Bool {
 
 /// Whether integer `lhs` is strictly less than double `rhs`, compared EXACTLY.
 /// `Double(lhs) < rhs` decides it unless the two tie under promotion — then
-/// `rhs` is integral and denotes an exact integer (`Int(exactly:)`) the
-/// integers compare against, so a value past 2^53 orders by its true magnitude.
+/// `rhs` is a whole double equal to `Double(lhs)`. If it denotes an exact `Int`
+/// the integers compare directly, so a value past 2^53 orders by its true
+/// magnitude; if it does not (`Double(Int.max)` rounds to 2^63, past `Int`),
+/// `rhs` lies outside `Int` — positive here, so `lhs < rhs` — never a false tie
+/// leaving the pair unordered.
 private func less(integer lhs: Int, double rhs: Double) -> Bool {
   let promoted = Double(lhs)
   guard promoted == rhs else { return promoted < rhs }
-  guard let exact = Int(exactly: rhs) else { return false }
+  guard let exact = Int(exactly: rhs) else { return rhs > 0 }
   return lhs < exact
 }
 
 /// Whether double `lhs` is strictly less than integer `rhs`, compared EXACTLY —
-/// the mirror of `less(integer:double:)`.
+/// the mirror of `less(integer:double:)`. An out-of-`Int` tie means `lhs` lies
+/// outside `Int`, so its sign decides: a positive `lhs` (past `Int.max`) is not
+/// less than any `Int`.
 private func less(double lhs: Double, integer rhs: Int) -> Bool {
   let promoted = Double(rhs)
   guard lhs == promoted else { return lhs < promoted }
-  guard let exact = Int(exactly: lhs) else { return false }
+  guard let exact = Int(exactly: lhs) else { return lhs < 0 }
   return exact < rhs
 }

--- a/Sources/SQL/Parser.swift
+++ b/Sources/SQL/Parser.swift
@@ -14,11 +14,14 @@
 ///                   AS '(' query ')'
 /// query          := select (UNION [ALL] select)*
 /// select         := SELECT projection
-///                   [FROM relation (join)* [where] [order] [limit]]
+///                   [FROM relation (join)*
+///                    [where] [group] [having] [order] [limit]]
 /// relation       := identifier [AS identifier]
 /// join           := JOIN relation ON column '=' column
 /// projection     := '*' | column (',' column)*
 /// where          := WHERE predicate
+/// group          := GROUP BY column (',' column)*
+/// having         := HAVING predicate
 /// predicate      := disjunction
 /// disjunction    := conjunction (OR conjunction)*
 /// conjunction    := negation (AND negation)*
@@ -28,7 +31,9 @@
 /// expression     := additive
 /// additive       := multiplicative (('+' | '-') multiplicative)*
 /// multiplicative := factor (('*' | '/') factor)*
-/// factor         := '(' expression ')' | literal | call | column
+/// factor         := '(' expression ')' | literal | aggregate | call | column
+/// aggregate      := COUNT '(' '*' ')'
+///                 | (COUNT | SUM | MIN | MAX | AVG) '(' expression ')'
 /// order          := ORDER BY key (',' key)*
 /// key            := column [ASC | DESC]
 /// limit          := [OFFSET integer ROWS]
@@ -261,6 +266,12 @@ internal struct Parser: ~Escapable {
     } else {
       nil
     }
+    let grouping = try match(.group) ? try grouping() : []
+    let having: Predicate? = if try match(.having) {
+      try self.predicate()
+    } else {
+      nil
+    }
     let order: Order? = if try match(.order) {
       try order()
     } else {
@@ -269,7 +280,20 @@ internal struct Parser: ~Escapable {
     let limit = try rowLimit()
 
     return Select(projection: projection, from: from, joins: joins,
-                  predicate: predicate, order: order, limit: limit)
+                  predicate: predicate, grouping: grouping, having: having,
+                  order: order, limit: limit)
+  }
+
+  /// Parses `BY column (, column)*` (the `GROUP` keyword is already consumed) —
+  /// the `GROUP BY` grouping columns, in source order.
+  private mutating func grouping() throws(SQLError) -> Array<Column> {
+    try expect(.by)
+    var columns = Array<Column>()
+    try columns.append(column())
+    while try match(.comma) {
+      try columns.append(column())
+    }
+    return columns
   }
 
   // MARK: - Relation
@@ -429,6 +453,15 @@ internal struct Parser: ~Escapable {
                                   : Column(ident.text))
     }
 
+    // An aggregate is one of the fixed set of names (recognised
+    // case-insensitively, only when written bare — a delimited `"COUNT"` is a
+    // scalar name), distinct from a scalar call: it accumulates over a group
+    // rather than evaluating per row. `COUNT(*)` takes `*` in place of an
+    // expression; every aggregate else takes one expression operand.
+    if !ident.quoted, let aggregate = aggregate(ident.text) {
+      return try .aggregate(aggregate, of: aggregand(aggregate))
+    }
+
     var arguments = Array<Expression>()
     if current?.kind != .rparen {
       try arguments.append(expression())
@@ -438,6 +471,38 @@ internal struct Parser: ~Escapable {
     }
     try expect(.rparen)
     return .call(name: ident.text, arguments: arguments)
+  }
+
+  /// The `Aggregate` the bare name `text` spells (case-insensitively), or `nil`
+  /// when it is not an aggregate — a scalar-function name.
+  private func aggregate(_ text: String) -> Aggregate? {
+    switch text.uppercased() {
+    case "COUNT": .count
+    case "SUM": .sum
+    case "MIN": .min
+    case "MAX": .max
+    case "AVG": .avg
+    default: nil
+    }
+  }
+
+  /// Parses an aggregate's operand (the `(` is already consumed) and the closing
+  /// `)`: `*` for `COUNT(*)` — admitted only for `COUNT` — else a single
+  /// expression. A non-`COUNT` aggregate over `*` (`SUM(*)`), or an aggregate
+  /// with no operand, faults.
+  private mutating func aggregand(_ aggregate: Aggregate)
+      throws(SQLError) -> Aggregand {
+    let operand: Aggregand
+    if try match(.star) {
+      guard aggregate == .count else {
+        throw .unsupported("only COUNT admits a '*' operand")
+      }
+      operand = .star
+    } else {
+      operand = try .expression(expression())
+    }
+    try expect(.rparen)
+    return operand
   }
 
   // MARK: - Predicate

--- a/Sources/SQL/Resolve.swift
+++ b/Sources/SQL/Resolve.swift
@@ -82,6 +82,10 @@ extension Schema {
       return .apply(name: name, arguments: lowered)
     case let .binary(op, lhs, rhs):
       return try .binary(op, term(lhs, in: relation), term(rhs, in: relation))
+    case .aggregate:
+      // An aggregate has no per-row meaning — it folds over a group — so it may
+      // not appear in a `WHERE`, a join `ON`, or a non-aggregate projection.
+      throw .unsupported("an aggregate is not allowed here")
     }
   }
 
@@ -242,6 +246,10 @@ internal struct Scope {
       return .apply(name: name, arguments: lowered)
     case let .binary(op, lhs, rhs):
       return try .binary(op, term(lhs), term(rhs))
+    case .aggregate:
+      // An aggregate has no per-row meaning — it folds over a group — so it may
+      // not appear in a `WHERE`, a join `ON`, or a non-aggregate projection.
+      throw .unsupported("an aggregate is not allowed here")
     }
   }
 
@@ -283,6 +291,213 @@ internal struct Scope {
     case let .not(operand):
       try .not(lower(operand))
     }
+  }
+}
+
+// MARK: - Grouped scope
+
+/// The grouped slot space of an aggregate query — the lowering surface for the
+/// projection, `HAVING`, and `ORDER BY` that read a grouped record.
+///
+/// An `aggregate` node yields grouped records whose slots are the `GROUP BY` key
+/// values (slots `0 ..< keys.count`, in key order) followed by the aggregate
+/// results (slot `keys.count + j` is aggregate `j`). A `Grouping` lowers a
+/// name-addressed AST expression into that space: an aggregate call maps to its
+/// result slot; a bare column maps to its key slot ONLY when it is a `GROUP BY`
+/// key — the standard rule that a non-aggregated column must appear in the
+/// `GROUP BY` (else `SQLError.grouping`). It also records each projected item's
+/// output name so an `ORDER BY` may name a projection alias, the standard way to
+/// order on an aggregate (`ORDER BY <count-alias>`).
+///
+/// The keys and aggregates resolve against the underlying `Scope`, so the same
+/// combined-ordinal resolution the source uses decides which projection columns
+/// are keys.
+internal struct Grouping {
+  private let scope: Scope
+
+  /// Each `GROUP BY` key's combined base ordinal mapped to its grouped slot —
+  /// key `i` sits at grouped slot `i`.
+  private let keys: Dictionary<Int, Int>
+
+  /// The distinct aggregate expressions mapped to their grouped slots — aggregate
+  /// `j` sits at grouped slot `keys.count + j`.
+  private let aggregates: Dictionary<Expression, Int>
+
+  /// Each projected item's output name (an alias, else a bare column's name),
+  /// lowercased, mapped to its grouped term — the surface an `ORDER BY` names a
+  /// projection alias against.
+  private var aliases: Dictionary<String, Term> = [:]
+
+  /// Output names two or more projected items share, lowercased. An `ORDER BY`
+  /// that names one has no single slot to order on — the same ambiguity the
+  /// non-grouped `Scope.order` reports for a shared unqualified join column
+  /// (`SQLError.ambiguous`) rather than silently picking the last projection.
+  private var ambiguous: Set<String> = []
+
+  /// Builds a grouping over `scope` for the `GROUP BY` `columns` and the
+  /// query's distinct `aggregates` (in first-appearance order — aggregate `j` at
+  /// grouped slot `columns.count + j`).
+  internal init(_ scope: Scope, _ columns: Array<Column>,
+                _ aggregates: Array<Expression>) throws(SQLError) {
+    self.scope = scope
+    var keys = Dictionary<Int, Int>(minimumCapacity: columns.count)
+    for index in columns.indices {
+      try keys[scope.ordinal(of: columns[index])] = index
+    }
+    self.keys = keys
+    var map = Dictionary<Expression, Int>(minimumCapacity: aggregates.count)
+    for index in aggregates.indices {
+      map[aggregates[index]] = columns.count + index
+    }
+    self.aggregates = map
+  }
+
+  /// The grouped slot an aggregate expression resolves to (an aggregate the
+  /// query collected), or `nil` if it is not one.
+  private func slot(of aggregate: Expression) -> Int? {
+    aggregates[aggregate]
+  }
+
+  /// Lowers a scalar `expression` to a grouped-space `Term`.
+  ///
+  /// An aggregate call maps to its result slot; a literal to a constant; a
+  /// `call`/`binary` recurses over its operands; a bare column maps to its key
+  /// slot only when it is a `GROUP BY` key, else it is `SQLError.grouping` — the
+  /// standard rule.
+  private func term(_ expression: Expression) throws(SQLError) -> Term {
+    if case .aggregate = expression, let slot = slot(of: expression) {
+      return .slot(slot)
+    }
+    switch expression {
+    case let .column(column):
+      let ordinal = try scope.ordinal(of: column)
+      guard let slot = keys[ordinal] else { throw .grouping(column.name) }
+      return .slot(slot)
+    case let .literal(literal):
+      return try .constant(value(of: literal))
+    case let .call(name, arguments):
+      var lowered = Array<Term>()
+      lowered.reserveCapacity(arguments.count)
+      for argument in arguments {
+        try lowered.append(term(argument))
+      }
+      return .apply(name: name, arguments: lowered)
+    case let .binary(op, lhs, rhs):
+      return try .binary(op, term(lhs), term(rhs))
+    case .aggregate:
+      // An aggregate reaches here only when it was not collected — an internal
+      // inconsistency, since the query gathers every projection/HAVING aggregate.
+      throw .unsupported("uncollected aggregate")
+    }
+  }
+
+  /// Records a projected item's output `name` → grouped `term`, flagging the
+  /// name ambiguous if another projected item already claimed it.
+  private mutating func record(_ name: String, _ term: Term) {
+    let key = name.lowercased()
+    if aliases.updateValue(term, forKey: key) != nil { ambiguous.insert(key) }
+  }
+
+  /// The grouped-space projected terms, recording each item's output name for an
+  /// `ORDER BY` to name.
+  ///
+  /// A `columns` projection (`SELECT Dept … GROUP BY Dept`) lowers each column
+  /// as a grouped term — a `GROUP BY` key, else `SQLError.grouping`. An
+  /// `expressions` projection lowers each item's expression and records its
+  /// output name (an alias, else a bare column's name) so an `ORDER BY` may name
+  /// it — the standard alias ordering on an aggregate. A `SELECT *` has no
+  /// well-defined meaning over groups (which columns?), so it faults.
+  internal mutating func terms(_ projection: Projection)
+      throws(SQLError) -> Array<Term> {
+    switch projection {
+    case .all:
+      throw .unsupported("SELECT * is not allowed with GROUP BY or aggregates")
+    case let .columns(columns):
+      var terms = Array<Term>()
+      terms.reserveCapacity(columns.count)
+      for column in columns {
+        let term = try term(.column(column))
+        terms.append(term)
+        record(column.name, term)
+      }
+      return terms
+    case let .expressions(items):
+      var terms = Array<Term>()
+      terms.reserveCapacity(items.count)
+      for item in items {
+        let term = try term(item.expression)
+        terms.append(term)
+        // Record the output name — an alias, else a bare column's name — so an
+        // `ORDER BY` may name it (the standard alias ordering on an aggregate).
+        if let alias = item.alias {
+          record(alias, term)
+        } else if case let .column(column) = item.expression {
+          record(column.name, term)
+        }
+      }
+      return terms
+    }
+  }
+
+  /// Lowers a `HAVING`/predicate to a grouped-space `Filter`.
+  internal func lower(_ predicate: Predicate) throws(SQLError) -> Filter {
+    switch predicate {
+    case let .comparison(left, op, right):
+      try .compare(term(left), op, term(right))
+    case let .bound(left, op, parameter):
+      try .bound(term(left), op, parameter)
+    case let .null(expression, negated):
+      try .null(term(expression), negated: negated)
+    case let .and(lhs, rhs):
+      try .and(lower(lhs), lower(rhs))
+    case let .or(lhs, rhs):
+      try .or(lower(lhs), lower(rhs))
+    case let .not(operand):
+      try .not(lower(operand))
+    }
+  }
+
+  /// The `(slot, ascending)` keys an `ORDER BY` resolves to in grouped
+  /// space, major to minor.
+  ///
+  /// Each order column names a projection output first — an alias, or a bare
+  /// column's name (`terms` recorded these), the standard way to order on an
+  /// aggregate — else a `GROUP BY` key column. A column that is neither is
+  /// `SQLError.grouping`, as a bare non-key column is meaningless over groups.
+  ///
+  /// The `sort` operator orders by grouped slots, so an alias resolves only
+  /// when its projected term is a bare `.slot` — a plain group key or a whole
+  /// aggregate (`SUM(x) AS Total`). An alias over a COMPUTED expression
+  /// (`COUNT(*) * 2 AS Doubled`) has no standalone slot to sort on — the
+  /// projection computes it after the sort — so ordering on it is unsupported
+  /// rather than misreported as an unknown column.
+  internal func order(_ order: Order) throws(SQLError)
+      -> Array<(slot: Int, ascending: Bool)> {
+    var resolved = Array<(slot: Int, ascending: Bool)>()
+    resolved.reserveCapacity(order.keys.count)
+    for key in order.keys {
+      if key.column.qualifier == nil {
+        let name = key.column.name.lowercased()
+        // A name two projections share has no single slot to order on — reject
+        // it as ambiguous rather than pick the last, matching the non-grouped
+        // `Scope.order` fault for a shared unqualified join column.
+        if ambiguous.contains(name) { throw .ambiguous(key.column.name) }
+        if let term = aliases[name] {
+          guard case let .slot(slot) = term else {
+            throw .unsupported(
+                "ORDER BY on a computed column alias is not supported")
+          }
+          resolved.append((slot, key.ascending))
+          continue
+        }
+      }
+      let ordinal = try scope.ordinal(of: key.column)
+      guard let slot = keys[ordinal] else {
+        throw .grouping(key.column.name)
+      }
+      resolved.append((slot, key.ascending))
+    }
+    return resolved
   }
 }
 

--- a/Sources/SQL/Token.swift
+++ b/Sources/SQL/Token.swift
@@ -23,6 +23,8 @@ extension Token {
     case from
     case `where`
     case order
+    case group
+    case having
     case by
     case asc
     case desc
@@ -85,6 +87,8 @@ extension Token.Kind {
     case .from: "FROM"
     case .where: "WHERE"
     case .order: "ORDER"
+    case .group: "GROUP"
+    case .having: "HAVING"
     case .by: "BY"
     case .asc: "ASC"
     case .desc: "DESC"

--- a/Tests/SQLTests/AggregateTests.swift
+++ b/Tests/SQLTests/AggregateTests.swift
@@ -1,0 +1,572 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQL
+
+// MARK: - In-memory adapter
+
+/// An in-memory relation: a fixed schema plus rows of typed values.
+///
+/// This harness knows nothing of WinMD — it is a self-contained fixture for the
+/// aggregation (`GROUP BY`/`HAVING`/`COUNT`/`SUM`/`MIN`/`MAX`/`AVG`) tests,
+/// deliberately independent of `EngineTests.swift`/`LimitTests.swift` so the
+/// files reconcile cleanly. No column is marked seekable — aggregation reads
+/// every row of a group, so a seek is beside the point here.
+private struct AggregateRelation: Sendable {
+  let names: Array<String>
+  let records: Array<Array<Value>>
+
+  init(_ names: Array<String>, _ records: Array<Array<Value>>) {
+    self.names = names
+    self.records = records
+  }
+}
+
+/// A `Catalog` over a dictionary of named relations.
+private struct AggregateMemory: Catalog {
+  let relations: Dictionary<String, AggregateRelation>
+
+  init(_ relations: Dictionary<String, AggregateRelation>) {
+    self.relations = relations
+  }
+
+  func table(named name: String) -> AggregateTable? {
+    guard let relation = relations[name] else { return nil }
+    return AggregateTable(relation)
+  }
+}
+
+/// A `Table` over one in-memory relation.
+private struct AggregateTable: Table {
+  let relation: AggregateRelation
+
+  init(_ relation: AggregateRelation) {
+    self.relation = relation
+  }
+
+  var width: Int { relation.names.count }
+
+  var names: Array<String> { relation.names }
+
+  func ordinal(of name: String) -> Int? {
+    relation.names.firstIndex(of: name)
+  }
+
+  func bound(_ column: Int, _ value: Int, strict: Bool) -> Int? { nil }
+
+  func cursor() -> AggregateCursor {
+    AggregateCursor(relation)
+  }
+}
+
+/// An index-addressed cursor over a relation's rows.
+private struct AggregateCursor: Cursor {
+  let relation: AggregateRelation
+
+  init(_ relation: AggregateRelation) {
+    self.relation = relation
+  }
+
+  var count: Int { relation.records.count }
+
+  func row(_ index: Int) -> AggregateRow? {
+    guard index < relation.records.count else { return nil }
+    return AggregateRow(relation, index)
+  }
+}
+
+/// A positional view over one row's cells.
+private struct AggregateRow: Row {
+  let relation: AggregateRelation
+  let index: Int
+
+  init(_ relation: AggregateRelation, _ index: Int) {
+    self.relation = relation
+    self.index = index
+  }
+
+  subscript(_ column: Int) -> Value {
+    borrowing get { relation.records[index][column] }
+  }
+}
+
+// MARK: - Fixtures
+
+/// A `Sales` relation of `Dept`/`Region`/`Amount` rows — three departments, two
+/// regions, and a NULL `Amount` (a row `COUNT(*)` counts but `COUNT(Amount)`,
+/// `SUM`, `MIN`, `MAX`, `AVG` skip). One department (`Toys`) has ONLY a NULL
+/// amount, exercising the all-NULL group (`SUM`/`AVG` NULL, `COUNT(Amount)` 0).
+private func sales() -> AggregateMemory {
+  let records = [
+    [.text("Books"), .text("East"), .integer(10)],
+    [.text("Books"), .text("East"), .integer(20)],
+    [.text("Books"), .text("West"), .integer(30)],
+    [.text("Games"), .text("East"), .integer(40)],
+    [.text("Games"), .text("West"), .null],
+    [.text("Games"), .text("West"), .integer(50)],
+    [.text("Toys"), .text("East"), .null],
+  ] as Array<Array<Value>>
+  return AggregateMemory(["Sales":
+      AggregateRelation(["Dept", "Region", "Amount"], records)])
+}
+
+// MARK: - Helpers
+
+/// Parses `text` to a query, failing on any other statement.
+private func parse(_ text: String) throws -> Query {
+  guard case let .select(query) = try Statement(parsing: text) else {
+    Issue.record("expected a SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return query
+}
+
+/// Runs `text` against the `Sales` catalog, yielding the projected rows.
+private func run(_ text: String) throws -> Array<Array<Value>> {
+  try Engine.run(parse(text), sales())
+}
+
+// MARK: - Tests
+
+struct AggregateTests {
+  @Test("COUNT(*) over the whole result counts every row")
+  func countStar() throws {
+    #expect(try run("SELECT COUNT(*) FROM Sales") == [[.integer(7)]])
+  }
+
+  @Test("COUNT(*) over an empty result is zero, not no row")
+  func countStarEmpty() throws {
+    // The degenerate whole-result aggregation yields one group even over no
+    // matching rows — COUNT is 0 rather than an empty result.
+    #expect(try run("SELECT COUNT(*) FROM Sales WHERE Dept = 'None'")
+            == [[.integer(0)]])
+  }
+
+  @Test("COUNT(expr) ignores NULLs where COUNT(*) does not")
+  func countExpr() throws {
+    // Five of the seven rows have a non-NULL Amount (two are NULL); COUNT(*)
+    // counts all seven, COUNT(Amount) only the non-NULL five.
+    #expect(try run("SELECT COUNT(Amount), COUNT(*) FROM Sales")
+            == [[.integer(5), .integer(7)]])
+  }
+
+  @Test("SUM, MIN, MAX, and AVG skip NULLs over the whole result")
+  func wholeResult() throws {
+    // Amounts 10,20,30,40,50 (the NULLs skipped): SUM 150, MIN 10, MAX 50,
+    // AVG 150/5 = 30.0 — real division to an approximate-numeric double.
+    let rows = try run("""
+        SELECT SUM(Amount), MIN(Amount), MAX(Amount), AVG(Amount) FROM Sales
+        """)
+    #expect(rows == [[.integer(150), .integer(10), .integer(50),
+                      .double(30.0)]])
+  }
+
+  @Test("AVG is real division yielding an approximate-numeric double")
+  func avgReal() throws {
+    // Books amounts 10,20,30 sum 60 over 3 → 20.0; Games 40,50 sum 90 over 2
+    // → 45.0 — real division, not truncating; Toys all-NULL → NULL.
+    let rows = try run("""
+        SELECT Dept, AVG(Amount) FROM Sales GROUP BY Dept ORDER BY Dept
+        """)
+    #expect(rows == [[.text("Books"), .double(20.0)],
+                     [.text("Games"), .double(45.0)],
+                     [.text("Toys"), .null]])
+  }
+
+  @Test("AVG yields a fractional double where integer division truncates")
+  func avgFractional() throws {
+    // Books amounts 10,20,30 sum 60 over 3 rows → 20.0; but the East Books
+    // pair 10,20 averages 15.0, and adding a third exercises a non-integral
+    // quotient: 10+20+30 = 60 over the two East rows would be 30/2 = 15.0.
+    let rows = try run("""
+        SELECT AVG(Amount) FROM Sales WHERE Dept = 'Books' AND Region = 'East'
+        """)
+    // East Books are 10 and 20: (10 + 20) / 2 = 15.0.
+    #expect(rows == [[.double(15.0)]])
+  }
+
+  @Test("an all-NULL group yields NULL for SUM/MIN/MAX/AVG and 0 for COUNT")
+  func allNull() throws {
+    // Toys has one row whose Amount is NULL: COUNT(*) counts the row (1),
+    // COUNT(Amount) skips it (0), and the value aggregates are NULL.
+    let rows = try run("""
+        SELECT COUNT(*), COUNT(Amount), SUM(Amount), MIN(Amount),
+               MAX(Amount), AVG(Amount)
+          FROM Sales WHERE Dept = 'Toys'
+        """)
+    #expect(rows == [[.integer(1), .integer(0), .null, .null, .null, .null]])
+  }
+
+  @Test("GROUP BY one column aggregates each group")
+  func groupByOne() throws {
+    let rows = try run("""
+        SELECT Dept, COUNT(*), SUM(Amount) FROM Sales
+          GROUP BY Dept ORDER BY Dept
+        """)
+    #expect(rows == [[.text("Books"), .integer(3), .integer(60)],
+                     [.text("Games"), .integer(3), .integer(90)],
+                     [.text("Toys"), .integer(1), .null]])
+  }
+
+  @Test("GROUP BY multiple columns keys on the tuple")
+  func groupByMany() throws {
+    let rows = try run("""
+        SELECT Dept, Region, COUNT(*), SUM(Amount) FROM Sales
+          GROUP BY Dept, Region ORDER BY Dept
+        """)
+    // (Books,East) 10+20, (Books,West) 30, (Games,East) 40, (Games,West)
+    // NULL+50, (Toys,East) NULL. Ordered by Dept, ties by first appearance.
+    #expect(rows == [[.text("Books"), .text("East"), .integer(2), .integer(30)],
+                     [.text("Books"), .text("West"), .integer(1), .integer(30)],
+                     [.text("Games"), .text("East"), .integer(1), .integer(40)],
+                     [.text("Games"), .text("West"), .integer(2), .integer(50)],
+                     [.text("Toys"), .text("East"), .integer(1), .null]])
+  }
+
+  @Test("a compound ORDER BY sorts grouped output by each key in turn")
+  func orderByCompound() throws {
+    // Order groups by Dept ascending, breaking ties by Region descending — the
+    // second key reverses only the rows the first leaves equal.
+    let rows = try run("""
+        SELECT Dept, Region, COUNT(*), SUM(Amount) FROM Sales
+          GROUP BY Dept, Region ORDER BY Dept, Region DESC
+        """)
+    #expect(rows == [[.text("Books"), .text("West"), .integer(1), .integer(30)],
+                     [.text("Books"), .text("East"), .integer(2), .integer(30)],
+                     [.text("Games"), .text("West"), .integer(2), .integer(50)],
+                     [.text("Games"), .text("East"), .integer(1), .integer(40)],
+                     [.text("Toys"), .text("East"), .integer(1), .null]])
+  }
+
+  @Test("mixed integer/double group keys canonicalize into one group")
+  func mixedNumericKeys() throws {
+    // A column carrying both 1 and 1.0 — as a CTE/UNION ALL or any source can —
+    // groups them together under the engine's EXACT numeric equality (the same
+    // `1` = `1.0` UNION dedup uses), yielding one group of two keyed by the
+    // first-appearance integer, not two one-row groups.
+    let catalog = AggregateMemory(
+        ["T": AggregateRelation(["x"], [[.integer(1)], [.double(1.0)]])])
+    let rows = try Engine.run(
+        parse("SELECT x, COUNT(*) FROM T GROUP BY x"), catalog)
+    #expect(rows == [[.integer(1), .integer(2)]])
+  }
+
+  @Test("mixed SUM/AVG widening does not depend on row order")
+  func mixedWideningOrderIndependent() throws {
+    // Int.max, 1, 0.5 overflows Int if summed as integers first, but the 0.5
+    // widens the total to a double — so the result must be the same
+    // whether the overflowing integer prefix or the double is seen first, not a
+    // SQLError.magnitude one way and a double the other.
+    let prefix = AggregateMemory(
+        ["T": AggregateRelation(
+            ["x"], [[.integer(.max)], [.integer(1)], [.double(0.5)]])])
+    let suffix = AggregateMemory(
+        ["T": AggregateRelation(
+            ["x"], [[.double(0.5)], [.integer(.max)], [.integer(1)]])])
+    let expected = Double(Int.max) + 1.0 + 0.5
+    let query = "SELECT SUM(x), AVG(x) FROM T"
+    #expect(try Engine.run(parse(query), prefix)
+            == [[.double(expected), .double(expected / 3)]])
+    #expect(try Engine.run(parse(query), suffix)
+            == [[.double(expected), .double(expected / 3)]])
+  }
+
+  @Test("all-integer SUM tolerates transient overflow if the total fits")
+  func transientIntegerOverflow() throws {
+    // A prefix that overflows Int (Int.max + 1) must not latch a fault when a
+    // later value (-1) brings the exact total back into range — the result is
+    // the mathematical total, Int.max, whichever order the rows arrive in.
+    let up = AggregateMemory(
+        ["T": AggregateRelation(
+            ["x"], [[.integer(.max)], [.integer(1)], [.integer(-1)]])])
+    let down = AggregateMemory(
+        ["T": AggregateRelation(
+            ["x"], [[.integer(.max)], [.integer(-1)], [.integer(1)]])])
+    #expect(try Engine.run(parse("SELECT SUM(x) FROM T"), up)
+            == [[.integer(.max)]])
+    #expect(try Engine.run(parse("SELECT SUM(x) FROM T"), down)
+            == [[.integer(.max)]])
+    // A total that genuinely exceeds Int still faults, in any order.
+    let over = AggregateMemory(
+        ["T": AggregateRelation(["x"], [[.integer(.max)], [.integer(.max)]])])
+    #expect(throws: SQLError.magnitude("integer overflow")) {
+      try Engine.run(parse("SELECT SUM(x) FROM T"), over)
+    }
+  }
+
+  @Test("AVG divides a wide integer total that SUM could not represent")
+  func avgWideIntegerTotal() throws {
+    // Two Int.max rows sum to 2 * Int.max, outside Int — SUM would fault, but
+    // AVG divides the wide total and returns the finite approximate mean.
+    let catalog = AggregateMemory(
+        ["T": AggregateRelation(["x"], [[.integer(.max)], [.integer(.max)]])])
+    #expect(try Engine.run(parse("SELECT AVG(x) FROM T"), catalog)
+            == [[.double(Double(Int.max))]])
+  }
+
+  @Test("MIN/MAX over incomparable kinds is a type error, either order")
+  func minMaxIncomparableKinds() throws {
+    // A column mixing TEXT and INTEGER (from a CTE/UNION ALL) has no ordering
+    // across kinds — MIN/MAX rejects it rather than keeping the first-seen
+    // value (which would flip MIN and MAX with row order).
+    let fault = SQLError.operand("MIN and MAX require a common comparable kind")
+    let textFirst = AggregateMemory(
+        ["T": AggregateRelation(["x"], [[.text("a")], [.integer(1)]])])
+    let intFirst = AggregateMemory(
+        ["T": AggregateRelation(["x"], [[.integer(1)], [.text("a")]])])
+    for catalog in [textFirst, intFirst] {
+      #expect(throws: fault) {
+        try Engine.run(parse("SELECT MIN(x) FROM T"), catalog)
+      }
+      #expect(throws: fault) {
+        try Engine.run(parse("SELECT MAX(x) FROM T"), catalog)
+      }
+    }
+  }
+
+  @Test("MIN/MAX over Int.max and Double(Int.max) is deterministic")
+  func minMaxNumericBoundary() throws {
+    // Int.max (2^63 - 1) and Double(Int.max) (2^63) are both numeric and order
+    // exactly, so MIN is the integer and MAX the larger double — same result
+    // whichever row arrives first, not an order-dependent first-seen keep.
+    let intFirst = AggregateMemory(
+        ["T": AggregateRelation(
+            ["x"], [[.integer(.max)], [.double(Double(Int.max))]])])
+    let doubleFirst = AggregateMemory(
+        ["T": AggregateRelation(
+            ["x"], [[.double(Double(Int.max))], [.integer(.max)]])])
+    for catalog in [intFirst, doubleFirst] {
+      #expect(try Engine.run(parse("SELECT MIN(x), MAX(x) FROM T"), catalog)
+              == [[.integer(.max), .double(Double(Int.max))]])
+    }
+  }
+
+  @Test("ORDER BY on a duplicated projection output name is ambiguous")
+  func orderByAmbiguousName() throws {
+    // Two projected columns share the output name `k`, so `ORDER BY k` has no
+    // single slot to order on — rejected as ambiguous (as the non-grouped path
+    // reports for a shared unqualified join column) rather than silently
+    // ordering by whichever projection came last.
+    #expect(throws: SQLError.ambiguous("k")) {
+      try run("""
+          SELECT Dept AS k, Region AS k FROM Sales
+            GROUP BY Dept, Region ORDER BY k
+          """)
+    }
+  }
+
+  @Test("MIN and MAX use the engine's typed comparison per group")
+  func minMax() throws {
+    let rows = try run("""
+        SELECT Dept, MIN(Amount), MAX(Amount) FROM Sales
+          GROUP BY Dept ORDER BY Dept
+        """)
+    #expect(rows == [[.text("Books"), .integer(10), .integer(30)],
+                     [.text("Games"), .integer(40), .integer(50)],
+                     [.text("Toys"), .null, .null]])
+  }
+
+  @Test("HAVING filters groups after aggregation")
+  func having() throws {
+    // Keep only departments whose row count exceeds one — Toys (1 row) drops.
+    let rows = try run("""
+        SELECT Dept, COUNT(*) FROM Sales
+          GROUP BY Dept HAVING COUNT(*) > 1 ORDER BY Dept
+        """)
+    #expect(rows == [[.text("Books"), .integer(3)],
+                     [.text("Games"), .integer(3)]])
+  }
+
+  @Test("HAVING may reference an aggregate not in the projection")
+  func havingHidden() throws {
+    // The HAVING aggregates SUM(Amount) though the projection does not — the
+    // engine still computes it for the group filter.
+    let rows = try run("""
+        SELECT Dept FROM Sales
+          GROUP BY Dept HAVING SUM(Amount) > 70 ORDER BY Dept
+        """)
+    // Books SUM 60 drops, Games SUM 90 keeps, Toys SUM NULL drops (UNKNOWN).
+    #expect(rows == [[.text("Games")]])
+  }
+
+  @Test("HAVING without a GROUP BY filters the single whole-result group")
+  func havingWholeResult() throws {
+    // The whole result is one group; HAVING keeps or drops it. COUNT(*) is 7.
+    #expect(try run("SELECT COUNT(*) FROM Sales HAVING COUNT(*) > 5")
+            == [[.integer(7)]])
+    #expect(try run("SELECT COUNT(*) FROM Sales HAVING COUNT(*) > 100") == [])
+  }
+
+  @Test("ORDER BY may name an aggregate's projection alias")
+  func orderByAggregate() throws {
+    // Order the departments by their total descending — the ORDER BY names the
+    // aggregate's output alias `Total`.
+    let rows = try run("""
+        SELECT Dept, SUM(Amount) AS Total FROM Sales
+          GROUP BY Dept ORDER BY Total DESC
+        """)
+    // Games 90, Books 60, Toys NULL (NULL sorts last descending).
+    #expect(rows == [[.text("Games"), .integer(90)],
+                     [.text("Books"), .integer(60)],
+                     [.text("Toys"), .null]])
+  }
+
+  @Test("ORDER BY on a computed-expression alias is rejected clearly")
+  func orderByComputedAlias() throws {
+    // `Doubled` aliases a COMPUTED value (the projection evaluates it after
+    // the sort), so it has no standalone grouped slot to order on — the engine
+    // rejects it as unsupported rather than misreporting an unknown column.
+    #expect(throws: SQLError.self) {
+      try run("""
+          SELECT Dept, COUNT(*) * 2 AS Doubled FROM Sales
+            GROUP BY Dept ORDER BY Doubled DESC
+          """)
+    }
+  }
+
+  @Test("an aggregate query pages with OFFSET/FETCH after ORDER BY")
+  func aggregateFetch() throws {
+    // Three groups ordered by Dept; skip one, take one.
+    let rows = try run("""
+        SELECT Dept, COUNT(*) FROM Sales
+          GROUP BY Dept ORDER BY Dept OFFSET 1 ROWS FETCH NEXT 1 ROWS ONLY
+        """)
+    #expect(rows == [[.text("Games"), .integer(3)]])
+  }
+
+  @Test("an aggregate mixes with a scalar arithmetic over the group key")
+  func mixedProjection() throws {
+    // A grouped query may project the key through arithmetic and a scalar
+    // expression alongside the aggregate; COUNT(*) doubled proves it composes.
+    let rows = try run("""
+        SELECT Dept, COUNT(*) * 2 FROM Sales
+          GROUP BY Dept ORDER BY Dept
+        """)
+    #expect(rows == [[.text("Books"), .integer(6)],
+                     [.text("Games"), .integer(6)],
+                     [.text("Toys"), .integer(2)]])
+  }
+
+  @Test("a non-grouped projection column is rejected")
+  func projectionRule() throws {
+    // `Region` is neither aggregated nor a GROUP BY key, so the query is
+    // ill-formed — the standard single-group rule.
+    #expect(throws: SQLError.grouping("Region")) {
+      try run("SELECT Dept, Region, COUNT(*) FROM Sales GROUP BY Dept")
+    }
+  }
+
+  @Test("a bare column with no GROUP BY and an aggregate is rejected")
+  func bareColumnRule() throws {
+    // Mixing a bare column with an aggregate and no GROUP BY groups the whole
+    // result — the column is then not a key, so it faults.
+    #expect(throws: SQLError.grouping("Dept")) {
+      try run("SELECT Dept, COUNT(*) FROM Sales")
+    }
+  }
+
+  @Test("the projection-rule fault carries the SS004 SQLSTATE")
+  func projectionRuleState() throws {
+    #expect(SQLError.grouping("Region").sqlstate == "SS004")
+  }
+
+  @Test("SUM over a text column is a type error")
+  func sumText() throws {
+    // SUM/AVG require numeric operands; folding a text value faults through the
+    // engine's arithmetic rather than coercing.
+    #expect(throws: SQLError.operand("operands must be numeric")) {
+      try run("SELECT SUM(Dept) FROM Sales")
+    }
+  }
+
+  @Test("AVG over a text column is a type error")
+  func avgText() throws {
+    // AVG folds the same numeric total as SUM, so a text operand faults alike.
+    #expect(throws: SQLError.operand("operands must be numeric")) {
+      try run("SELECT AVG(Dept) FROM Sales")
+    }
+  }
+
+  @Test("only COUNT admits a '*' operand")
+  func starOnlyCount() throws {
+    // `SUM(*)`/`AVG(*)`/`MIN(*)`/`MAX(*)` are not valid — only `COUNT(*)`
+    // counts rows without reading a value.
+    for function in ["SUM", "AVG", "MIN", "MAX"] {
+      #expect(throws: SQLError.self) {
+        try run("SELECT \(function)(*) FROM Sales")
+      }
+    }
+    // `COUNT(*)` remains valid — it counts every row.
+    #expect(try run("SELECT COUNT(*) FROM Sales") == [[.integer(7)]])
+  }
+
+  @Test("an aggregate in a WHERE clause is rejected")
+  func aggregateInWhere() throws {
+    // An aggregate has no per-row meaning, so it may not appear in a WHERE.
+    #expect(throws: SQLError.self) {
+      try run("SELECT Dept FROM Sales WHERE COUNT(*) > 1 GROUP BY Dept")
+    }
+  }
+
+  @Test("an aggregate groups a join by a qualified key column")
+  func aggregateOverJoin() throws {
+    // Aggregation sits above the join chain, so a grouped query over a join
+    // folds each aggregate over the joined rows and keys on a qualified column.
+    let catalog = AggregateMemory([
+      "Dept": AggregateRelation(["Id", "Name"],
+          [[.integer(1), .text("Books")], [.integer(2), .text("Games")]]),
+      "Item": AggregateRelation(["DeptId", "Price"],
+          [[.integer(1), .integer(10)], [.integer(1), .integer(20)],
+           [.integer(2), .integer(40)]]),
+    ])
+    let rows = try Engine.run(parse("""
+        SELECT Dept.Name, SUM(Item.Price) FROM Dept
+          JOIN Item ON Item.DeptId = Dept.Id
+          GROUP BY Dept.Name ORDER BY Dept.Name
+        """), catalog)
+    #expect(rows == [[.text("Books"), .integer(30)],
+                     [.text("Games"), .integer(40)]])
+  }
+
+  @Test("SUM over an all-integer column stays an exact integer")
+  func sumIntegerExact() throws {
+    // Every folded value is an integer, so the total stays an integer — the
+    // engine's arithmetic keeps `integer + integer` integral.
+    #expect(try run("SELECT SUM(Amount) FROM Sales")
+            == [[.integer(150)]])
+  }
+
+  @Test("SUM over a double column yields a double")
+  func sumDouble() throws {
+    let catalog = AggregateMemory([
+      "T": AggregateRelation(["X"],
+          [[.double(1.5)], [.double(2.25)], [.double(0.25)]]),
+    ])
+    // 1.5 + 2.25 + 0.25 = 4.0 — the running total widens to a double.
+    let rows = try Engine.run(parse("SELECT SUM(X) FROM T"), catalog)
+    #expect(rows == [[.double(4.0)]])
+  }
+
+  @Test("SUM over mixed integer and double columns widens to a double")
+  func sumMixed() throws {
+    let catalog = AggregateMemory([
+      "T": AggregateRelation(["X"],
+          [[.integer(10)], [.double(2.5)], [.integer(20)]]),
+    ])
+    // 10 + 2.5 + 20 = 32.5 — a lone double operand widens the whole total.
+    let rows = try Engine.run(parse("SELECT SUM(X) FROM T"), catalog)
+    #expect(rows == [[.double(32.5)]])
+  }
+
+  @Test("AVG over a double column is a double")
+  func avgDouble() throws {
+    let catalog = AggregateMemory([
+      "T": AggregateRelation(["X"],
+          [[.double(1.0)], [.double(2.0)]]),
+    ])
+    // (1.0 + 2.0) / 2 = 1.5 — real division over a double total.
+    let rows = try Engine.run(parse("SELECT AVG(X) FROM T"), catalog)
+    #expect(rows == [[.double(1.5)]])
+  }
+}

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -1287,6 +1287,8 @@ private func derived(_ plan: Plan) -> Plan? {
     derived(left) ?? derived(right)
   case let .limit(_, _, source):
     derived(source)
+  case let .aggregate(_, _, source):
+    derived(source)
   case .single, .scan, .join:
     nil
   }
@@ -1315,6 +1317,8 @@ private func seeks(_ plan: Plan) -> Bool {
     seeks(left) || seeks(right)
   case let .limit(_, _, source):
     seeks(source)
+  case let .aggregate(_, _, source):
+    seeks(source)
   case .single:
     false
   }
@@ -1339,6 +1343,8 @@ private func filters(_ plan: Plan) -> Bool {
   case let .union(left, right, _):
     filters(left) || filters(right)
   case let .limit(_, _, source):
+    filters(source)
+  case let .aggregate(_, _, source):
     filters(source)
   case .single, .scan, .join:
     false
@@ -1367,6 +1373,8 @@ private func pushed(_ plan: Plan) -> Bool {
   case let .union(left, right, _):
     pushed(left) || pushed(right)
   case let .limit(_, _, source):
+    pushed(source)
+  case let .aggregate(_, _, source):
     pushed(source)
   case .single, .scan:
     false
@@ -1412,6 +1420,8 @@ private func joins(_ plan: Plan) -> Bool {
     joins(left) || joins(right)
   case let .union(left, right, _):
     joins(left) || joins(right)
+  case let .aggregate(_, _, source):
+    joins(source)
   case .single, .scan:
     false
   }
@@ -1440,6 +1450,8 @@ private func residual(_ plan: Plan) -> Bool {
     residual(outer)
   case let .union(left, right, _):
     residual(left) || residual(right)
+  case let .aggregate(_, _, source):
+    residual(source)
   case .single, .scan:
     false
   }
@@ -1546,6 +1558,8 @@ private func injected(_ plan: Plan) -> Bool {
     injected(left) || injected(right)
   case let .join(outer, _, _, _, _, _, _):
     injected(outer)
+  case let .aggregate(_, _, source):
+    injected(source)
   case .single, .scan:
     false
   }
@@ -3012,20 +3026,33 @@ struct EngineScalarSelectTests {
 
   @Test("a directly-built FROM-less select with clauses is rejected")
   func clauses() throws {
-    // The parser never builds a FROM-less select carrying a WHERE, ORDER BY,
-    // OFFSET/FETCH, or JOIN, but `Select.init` is public, so a direct
-    // `Select(from: nil, …)` can. The engine must reject it rather than
-    // silently drop the clause — a false predicate would otherwise still
-    // return the scalar row.
+    // The parser never builds a FROM-less select carrying a WHERE, GROUP BY,
+    // HAVING, ORDER BY, OFFSET/FETCH, or JOIN, but a direct `Select(from: nil,
+    // …)` can. The engine rejects it rather than silently drop the clause — a
+    // false predicate or HAVING would otherwise still return the scalar row.
     let fault =
         SQLError.unsupported(
-            "a WHERE, ORDER BY, OFFSET/FETCH, or JOIN requires a FROM clause")
+            "a WHERE, GROUP BY, HAVING, ORDER BY, OFFSET/FETCH, or JOIN " +
+            "requires a FROM clause")
     let filtered = try EngineScalarSelectTests.select(
         "SELECT 1 FROM People WHERE Id = 99")
     #expect(throws: fault) {
       try Engine.run(.select(Select(projection: filtered.projection,
                                     from: nil,
                                     predicate: filtered.predicate)), people())
+    }
+    let grouped = try EngineScalarSelectTests.select(
+        "SELECT Id FROM People GROUP BY Id")
+    #expect(throws: fault) {
+      try Engine.run(.select(Select(projection: grouped.projection, from: nil,
+                                    grouping: grouped.grouping)), people())
+    }
+    let filteredGroup = try EngineScalarSelectTests.select(
+        "SELECT Id FROM People GROUP BY Id HAVING COUNT(*) > 0")
+    #expect(throws: fault) {
+      try Engine.run(.select(Select(projection: filteredGroup.projection,
+                                    from: nil,
+                                    having: filteredGroup.having)), people())
     }
     let ordered =
         try EngineScalarSelectTests.select("SELECT Id FROM People ORDER BY Id")

--- a/Tests/SQLTests/FloatTests.swift
+++ b/Tests/SQLTests/FloatTests.swift
@@ -211,6 +211,15 @@ private struct DoubleSortTests {
     #expect(less(.double(1.5), .integer(2)) == true)
     #expect(less(.double(2.5), .integer(2)) == false)
   }
+
+  @Test("a double past Int.max still orders against Int.max, not a false tie")
+  func beyondIntRange() {
+    // `Double(Int.max)` rounds to 2^63, past `Int` — but `Int.max` (2^63 - 1)
+    // is still strictly less, so the pair orders one way, never false both ways
+    // (which would leave MIN/MAX and sort order-dependent).
+    #expect(less(.integer(.max), .double(Double(Int.max))) == true)
+    #expect(less(.double(Double(Int.max)), .integer(.max)) == false)
+  }
 }
 
 // MARK: - Literal


### PR DESCRIPTION
Implement the standard SQL aggregate functions — COUNT(*), COUNT(expr), SUM, MIN, MAX, and AVG — with GROUP BY and HAVING, closing the largest remaining standard-SQL gap for counts and rollups over metadata.

Aggregates are a separate mechanism from the scalar Routines: the fixed set of aggregate names is recognised at parse time (Expression.aggregate over an Aggregand of `*` or an expression), distinct from a scalar call, so an aggregate never routes through Function.swift. The engine places a new Plan.aggregate node above the WHERE/join chain and below the projection — the standard evaluation order FROM/WHERE -> GROUP BY + aggregate -> HAVING -> SELECT -> ORDER BY -> OFFSET/FETCH. The node groups its source records by the GROUP BY keys (or the whole result as one group when there is none) and folds each aggregate over a group, yielding grouped records whose slots are the key values then the aggregate results. The projection, HAVING, and ORDER BY lower against that grouped slot space through a Grouping, which enforces the standard rule that every non-aggregated projection/ORDER BY column appear in the GROUP BY (else SQLError.grouping, SQLSTATE SS004).

Standard NULL semantics: COUNT(*) counts rows; COUNT(expr)/SUM/AVG/MIN/ MAX skip NULLs; an empty or all-NULL group yields COUNT 0 and the others NULL. AVG is truncating integer division, matching the engine's `/`, and MIN/MAX use the engine's typed comparison. The aggregate node is a pushdown/optimise barrier: a WHERE below it still seeks and nests, while HAVING and the projection stay above it in grouped space.

A non-aggregate query is unchanged — the aggregate node appears only when the query has a GROUP BY, a HAVING, or an aggregate in its projection.

Judgement calls: AVG is integer division (matching Arithmetic.apply); ORDER BY may name a bare-slot projection alias (SUM(x) AS Total) but an alias over a computed expression has no standalone sort slot and is rejected as unsupported rather than misreported as an unknown column.