### PR TITLE
winmd-inspect: rename the `rowid` identity column to `Id`

### DIFF
--- a/Documentation/QueryModel.md
+++ b/Documentation/QueryModel.md
@@ -136,27 +136,27 @@ name through the borrowed catalog:
 The WinMD adapter exposes two **virtual columns** past each relation's real
 fields, at ordinals outside the `SELECT *` range so a `*` never projects them:
 
-- `rowid` — the SQLite-style 1-based row index. A foreign key is a real column
-  holding a target row's `rowid`, so an equi-join over it is an ordinary FK
-  join — the child's foreign-key column against the parent's `rowid`:
-  `SELECT i.Interface FROM InterfaceImpl i JOIN TypeDef t ON i.Class = t.rowid`,
+- `Id` — the 1-based row identity. A foreign key is a real column
+  holding a target row's `Id`, so an equi-join over it is an ordinary FK
+  join — the child's foreign-key column against the parent's `Id`:
+  `SELECT i.Interface FROM InterfaceImpl i JOIN TypeDef t ON i.Class = t.Id`,
   where `InterfaceImpl.Class` is a simple index into `TypeDef`.
-- `parent` — a list-child's owning parent's `rowid`. A list relationship (a
+- `parent` — a list-child's owning parent's `Id`. A list relationship (a
   parent's run of children, e.g. `TypeDef.MethodList → MethodDef`) is not a
   stored key, so the child relates to its owner through the computed `parent`
-  column against the parent's `rowid`:
-  `SELECT m.Name FROM TypeDef t JOIN MethodDef m ON m.parent = t.rowid`.
+  column against the parent's `Id`:
+  `SELECT m.Name FROM TypeDef t JOIN MethodDef m ON m.parent = t.Id`.
 
 A *coded* index column (e.g. `TypeDef.Extends`, a `TypeDefOrRef`) exposes its
 raw encoded value — the packed row-plus-tag token — not a bare row id, so
-relating it to a target table's `rowid` must be spelled out explicitly.
+relating it to a target table's `Id` must be spelled out explicitly.
 
 A real column always takes precedence over a same-named pseudo-column, as in
 SQLite: a table that has its own `Parent` field (`EventMap`, `PropertyMap`,
 `ClassLayout`, …) resolves `Parent` to that real foreign key, so the virtual
 `parent` reaches only the list-child tables that have no real `Parent` field.
 
-Both virtual columns are seekable — `rowid` is dense and monotonic, `parent` is
+Both virtual columns are seekable — `Id` is dense and monotonic, `parent` is
 monotonic over a list-child's runs — so the engine's index-nested-loop join
 seeks them through the same `bound` path it uses for an intrinsic sort key. The
 adapter, not the engine, knows that a WinMD foreign key or list run *is* a join;
@@ -213,7 +213,7 @@ Heap columns read through their tokens: a `#Strings` or `#GUID` column through
 the `Column` value token (`row[.TypeName]`), a `#Blob` column through the
 `BlobColumn` token (`row[token]`, or `row.blob(token)` for the validating
 read). The SQL engine reaches the same foreign-key and list joins through the
-adapter's `rowid`/`parent` virtual columns described above.
+adapter's `Id`/`parent` virtual columns described above.
 
 ## Complexity
 

--- a/Documentation/SynthesisModel.md
+++ b/Documentation/SynthesisModel.md
@@ -20,7 +20,7 @@ it.
 | Layer | Role (ANSI-SPARC) | What it is | Where it lives |
 | --- | --- | --- | --- |
 | Physical / internal | Internal schema | ECMA-335 tables, heaps, coded indices | `Sources/WinMD/` |
-| Conceptual | Conceptual schema | metadata as relations: real columns + `rowid`/`parent` + decoded join keys | `Sources/winmd-inspect/Database+SQL.swift` |
+| Conceptual | Conceptual schema | metadata as relations: real columns + `Id`/`parent` + decoded join keys | `Sources/winmd-inspect/Database+SQL.swift` |
 | External | External schema | COM-interface *views* (`interfaces`/`methods`/`params`/`bases`) | `Sources/winmd-inspect/Resources/Queries/*.sql` |
 | Federation | Component-schema codecs | signature → type spelling; GuidAttribute blob → IID; coded index → join key | `Sources/WinMDSynthesis/`, the decoded columns in `Database+SQL.swift` |
 | Presentation | — | Mustache template rendering rows to source | `Sources/winmd-inspect/Shell.swift` |
@@ -34,7 +34,7 @@ just one `Catalog` it happens to run over.
         ▲
   External schema    interfaces / methods / params / bases   (SQL views)
         ▲
-  Conceptual schema  relations: real cols + rowid/parent + <Col>_<Target> keys
+  Conceptual schema  relations: real cols + Id/parent + <Col>_<Target> keys
         ▲                                   (WinMD → SQL adapter)
         │  ── federation codecs ──  signature→type · blob→IID · coded-index→key
         ▼
@@ -123,17 +123,17 @@ A relation's **real columns** are its ECMA-335 fields (a `#Strings` cell typed
 `.text`, everything else `.integer`). Past them, at ordinals outside the
 `SELECT *` extent so a `*` never projects them, sit the **virtual columns**:
 
-- **`rowid`** — the SQLite-style 1-based row index, exposed by every relation.
-  A simple foreign key is a real column holding a target's `rowid`, so an
+- **`Id`** — the 1-based row identity, exposed by every relation.
+  A simple foreign key is a real column holding a target's `Id`, so an
   equi-join over it is an ordinary FK join.
-- **`parent`** — a list-child's owning parent's `rowid` (e.g.
+- **`parent`** — a list-child's owning parent's `Id` (e.g.
   `MethodDef`'s owning `TypeDef`), computed from the parent's run-length list
   column. A list relationship is not a stored key, so the child relates to its
   owner through this computed column. As in SQLite, a real `Parent` field always
   shadows the virtual one, so `parent` reaches only the genuine list-child
   tables.
 
-Both virtual columns are **seekable** — `rowid` is dense and monotonic, `parent`
+Both virtual columns are **seekable** — `Id` is dense and monotonic, `parent`
 is monotonic over a child's runs — so the engine's index-nested-loop join seeks
 them through the same `bound` path it uses for an intrinsic sort key. The
 adapter, not the engine, knows that a WinMD foreign key or list run *is* a join.
@@ -153,9 +153,9 @@ ordinary readable cells, so that views can navigate over them:
 - **Coded-index join keys.** For every real coded-index column, the adapter
   exposes one decoded column per candidate target table the coded index admits,
   named **`<Column>_<Target>`** (e.g. `CustomAttribute.Parent_TypeDef`). Its
-  value is the target's `rowid` when the cell's tag selects *that* target and is
+  value is the target's `Id` when the cell's tag selects *that* target and is
   non-null, else SQL `NULL`. So an equi-join `JOIN Target ON
-  child.<Col>_<Target> = Target.rowid` navigates the relationship *exactly* —
+  child.<Col>_<Target> = Target.Id` navigates the relationship *exactly* —
   the `NULL` for any other tag means the join admits only the rows whose coded
   index actually points at `Target`. These keys are derived purely from the
   schema's coded-index fields and their `CodedIndex.tables`; no table or column
@@ -253,16 +253,16 @@ keyword spells escaped just as a declaration name does. A language rule is data,
 not a branch in the binary; retargeting to Rust or C is a new template and spec,
 no code change.
 
-1. Run `interfaces` for every interface's `rowid`, namespace, `SANITIZE`d name, and
+1. Run `interfaces` for every interface's `Id`, namespace, `SANITIZE`d name, and
    `iid`, then keep the one whose name matches (or all of them for `*`).
-2. Bind that `rowid` as `:parent` and run `methods` (each `Name` `SANITIZE`d) and
+2. Bind that `Id` as `:parent` and run `methods` (each `Name` `SANITIZE`d) and
    decode each method's return type from its signature with the `Dialect`,
    omitting the clause when it is the spec's no-value `void`; then bind *its*
-   `rowid` as `:parent` and run `params` — the correlated walk down the
+   `Id` as `:parent` and run `params` — the correlated walk down the
    one-to-many relationships, one bound-parameter level at a time. The return
    pseudo-parameter (`Sequence == 0`) is dropped, and each real parameter's type
    is decoded at render time from its signature position.
-3. Bind the interface's `rowid` and run `bases`; a rootless interface defaults to
+3. Bind the interface's `Id` and run `bases`; a rootless interface defaults to
    the spec's COM `root`, except the root interface itself, which inherits
    nothing (so `IUnknown` never becomes its own base).
 4. Render the context through the template, which emits the `@com(interface:)`

--- a/Sources/SQL/AST.swift
+++ b/Sources/SQL/AST.swift
@@ -165,8 +165,8 @@ public struct Relation: Hashable, Sendable {
 ///
 /// The `ON` equality is held as its two column references in source order —
 /// `left = right` — for the consumer to classify. The binding interprets the
-/// pseudo-columns `rowid` (every table's 1-based row index) and `parent` (a
-/// list-child's owning row) within those references.
+/// adapter-computed columns `Id` (every table's 1-based row identity) and
+/// `parent` (a list-child's owning row) within those references.
 public struct Join: Hashable, Sendable {
   /// The relation joined in.
   public let relation: Relation
@@ -189,8 +189,8 @@ public struct Join: Hashable, Sendable {
 ///
 /// A qualifier names a relation by its alias or its table name; an unqualified
 /// reference leaves the relation for the consumer to infer. The name may be a
-/// real column or one of the binding's pseudo-columns (`rowid`, `parent`); the
-/// AST does not distinguish them.
+/// real column or one of the binding's adapter-computed columns (`Id`,
+/// `parent`); the AST does not distinguish them.
 ///
 /// `Column` is `ExpressibleByStringLiteral`, splitting a literal on its first
 /// dot into qualifier and name, so a consumer may write a reference as a plain

--- a/Sources/SQL/Adapter.swift
+++ b/Sources/SQL/Adapter.swift
@@ -126,7 +126,7 @@ extension Catalog where Self: ~Escapable {
 /// A `Table` knows its real column count (`width`, the extent of `SELECT *`),
 /// its `extent` (one past the highest ordinal it can address, real or virtual),
 /// resolves a column name to an ordinal (a real ordinal `< width`, or a virtual
-/// ordinal `>= width` for a computed column such as a `rowid`), and — for a
+/// ordinal `>= width` for a computed column such as an `Id`), and — for a
 /// column whose rows are stored in sorted order — maps a comparison value to a
 /// row boundary so the executor can seek rather than scan. `cursor()` borrows
 /// the table and hands back a cursor tied to that borrow.
@@ -142,14 +142,14 @@ public protocol Table: ~Escapable {
   ///
   /// A relation knows its own column names; the engine reads them to lift a
   /// base table's resolution onto an escapable `Schema` so a join may resolve a
-  /// view against a base table uniformly. The virtual columns (`rowid`,
+  /// view against a base table uniformly. The virtual columns (`Id`,
   /// `parent`) are not in `names`; they resolve through `ordinal(of:)`.
   var names: Array<String> { get }
 
   /// The virtual column names, in ordinal order — virtual `i` of `virtuals`
   /// sits at ordinal `width + i`.
   ///
-  /// A virtual column is computed by the `Row` rather than stored (a `rowid`, a
+  /// A virtual column is computed by the `Row` rather than stored (an `Id`, a
   /// `parent`); naming them lets the engine lift resolution onto an escapable
   /// `Schema`. The default is empty — a relation overrides it only when it
   /// computes a virtual column, and then its `extent` is `width + virtuals.count`.
@@ -158,8 +158,8 @@ public protocol Table: ~Escapable {
   /// One past the highest ordinal this table can address — its real `width`
   /// plus the virtual columns it exposes.
   ///
-  /// A relation with no virtual column has `extent == width`; one exposing a
-  /// `rowid` at `width` has `extent == width + 1`, and so on. A join lays the
+  /// A relation with no virtual column has `extent == width`; one exposing an
+  /// `Id` at `width` has `extent == width + 1`, and so on. A join lays the
   /// inner relation immediately past the outer's `extent` so an outer virtual
   /// column never collides with the inner's space. The default is `width` — a
   /// relation overrides it only when it computes a virtual column.
@@ -169,7 +169,7 @@ public protocol Table: ~Escapable {
   /// such column.
   ///
   /// A real column resolves to an ordinal `< width`; a virtual column — one the
-  /// `Row` computes rather than stores, such as a `rowid` — resolves to an
+  /// `Row` computes rather than stores, such as an `Id` — resolves to an
   /// ordinal `>= width`.
   func ordinal(of name: String) -> Int?
 

--- a/Sources/SQL/Materialised.swift
+++ b/Sources/SQL/Materialised.swift
@@ -23,9 +23,9 @@ internal typealias CTEs = Dictionary<String, Materialised>
 /// the borrowed base catalog, consulting it first when it resolves a name, and
 /// builds the leaf records directly from `rows` rather than opening a cursor.
 ///
-/// It exposes the universal `rowid` virtual column at `width`, so a CTE
+/// It exposes the universal `Id` virtual column at `width`, so a CTE
 /// resolves columns exactly as a base relation does (a real column below
-/// `width`, the `rowid` at `width`).
+/// `width`, the `Id` at `width`).
 internal struct Materialised: Hashable, Sendable {
   /// The relation's column names, in ordinal order.
   internal let columns: Array<String>
@@ -42,18 +42,18 @@ internal struct Materialised: Hashable, Sendable {
   internal var width: Int { columns.count }
 
   /// One past the highest ordinal — the real width plus the lone virtual
-  /// `rowid` column at `width`.
+  /// `Id` column at `width`.
   internal var extent: Int { width + 1 }
 
   /// The resolution schema of this relation: its columns below `width`, a
-  /// virtual `rowid` at `width`.
+  /// virtual `Id` at `width`.
   internal func schema() -> Schema {
-    Schema(width: width, extent: extent, names: columns, virtuals: ["rowid"])
+    Schema(width: width, extent: extent, names: columns, virtuals: ["Id"])
   }
 
   /// The record for the row at `index`, materialising the referenced `ordinals`
   /// into dense slots — a real ordinal (`< width`) reads the stored cell, the
-  /// virtual `rowid` ordinal (`== width`) the 1-based row index.
+  /// virtual `Id` ordinal (`== width`) the 1-based row index.
   internal func record(_ index: Int, _ ordinals: Array<Int>) -> Record {
     let cells = rows[index]
     return Record(ordinals.map {

--- a/Sources/SQL/Operator.swift
+++ b/Sources/SQL/Operator.swift
@@ -654,7 +654,7 @@ private func seek<T: Table & ~Escapable>(_ filter: Filter?,
 /// key is 1-based and reports `nil` for the null reference `0`, so probing with
 /// `0` would misclassify a seekable coded-index column as unseekable and force a
 /// hash build even for a selective join. `1` — the least valid key — answers for
-/// every seekable column (`rowid`, list `parent`, a sorted key, a coded-index
+/// every seekable column (`Id`, list `parent`, a sorted key, a coded-index
 /// key); its value is otherwise irrelevant, since this is only a capability
 /// check (the join loop seeks with the real outer key).
 private func seekable<T: Table & ~Escapable>(_ table: borrowing T,

--- a/Sources/SQL/Resolve.swift
+++ b/Sources/SQL/Resolve.swift
@@ -118,7 +118,7 @@ extension Schema {
 /// combined ordinals `[offset_i, offset_i + extent_i)`, where `offset_i` is the
 /// sum of the `extent`s of the relations before it. Using each relation's
 /// `extent` — its real `width` plus the virtual columns it exposes — rather than
-/// its `width` keeps a relation's virtual columns (a `rowid`, a `parent`) on its
+/// its `width` keeps a relation's virtual columns (an `Id`, a `parent`) on its
 /// own side rather than colliding with the next relation's space. A `Scope`
 /// resolves a possibly qualified `SQL.Column` into that combined space so the
 /// engine's `Filter`, projection, and order all address cells uniformly across

--- a/Sources/SQL/Schema.swift
+++ b/Sources/SQL/Schema.swift
@@ -42,7 +42,7 @@ internal struct Schema {
   /// column resolves against `virtuals` to its ordinal `width + i`. The real
   /// lookup wins, so a relation never hides a real column behind a virtual name.
   /// The match is case-insensitive, as a metadata source's column names are
-  /// (`TypeName`, `rowid`); a schema never carries two names differing only in
+  /// (`TypeName`, `Id`); a schema never carries two names differing only in
   /// case, so the match stays unambiguous.
   internal func ordinal(of name: String) -> Int? {
     let folded = name.lowercased()

--- a/Sources/WinMD/Iteration.swift
+++ b/Sources/WinMD/Iteration.swift
@@ -58,8 +58,8 @@ public struct Tuple: ~Escapable {
   /// The 0-based index of the row within its table.
   ///
   /// ECMA-335 row indices are 1-based; this is the 0-based index the cursor
-  /// addresses the row by. A consumer presenting the SQL `rowid` pseudo-column
-  /// (the SQLite-style 1-based row index) reads `index + 1`.
+  /// addresses the row by. A consumer presenting the SQL `Id` column (the
+  /// 1-based row identity) reads `index + 1`.
   public var index: Int { row }
 
   /// The raw decoded value of column `column`.

--- a/Sources/winmd-inspect/Database+SQL.swift
+++ b/Sources/winmd-inspect/Database+SQL.swift
@@ -18,9 +18,8 @@ internal import WinMD
 ///
 /// Virtual columns sit past a relation's real fields, at ordinals outside the
 /// `SELECT *` range so a `*` never projects them. Every relation exposes the one
-/// universal virtual column, `rowid` (the SQLite-style 1-based row index), at
-/// `width`: `rowid` enables foreign-key joins — an FK is a real column holding a
-/// `rowid`.
+/// universal virtual column, `Id` (the 1-based row identity), at `width`: `Id`
+/// enables foreign-key joins — an FK is a real column holding an `Id`.
 ///
 /// WinMD-specific decodes are *not* virtual columns. A real `#Blob` cell is
 /// surfaced as a `.blob` (its raw heap bytes), and the decode is a scalar UDF
@@ -33,18 +32,18 @@ internal import WinMD
 /// `decode(return:in:)`/`decode(parameter:for:)` methods, which navigate a
 /// method/parameter's signature and apply a target `Dialect`.
 ///
-/// Past `rowid` sit a relation's join keys, at ordinals `width + 1` onward —
+/// Past `Id` sit a relation's join keys, at ordinals `width + 1` onward —
 /// the columns a view equi-joins across. A list-owned table leads the
-/// group with `parent` (the list-child's owning parent's `rowid`), which enables
+/// group with `parent` (the list-child's owning parent's `Id`), which enables
 /// list joins — a list-child relates to its owner through its run rather than a
 /// stored key — and a non-list table simply has no `parent` column. The
 /// coded-index join keys follow: for every real coded-index column a relation
 /// has, one decoded column per candidate target table the coded index admits,
 /// named `<ColumnName>_<TargetSchemaName>` (e.g. a `CustomAttribute.Parent` of
 /// kind `HasCustomAttribute` admitting `TypeDef` yields `Parent_TypeDef`). Its
-/// value is the target's 1-based `rowid` when the cell's coded index tags that
+/// value is the target's 1-based `Id` when the cell's coded index tags that
 /// target (and is non-null), else SQL `NULL`, so a view can equi-join across a
-/// coded index — `JOIN Target ON child.<col>_<Target> = Target.rowid` matches
+/// coded index — `JOIN Target ON child.<col>_<Target> = Target.Id` matches
 /// exactly the rows whose coded index points at `Target`. These are derived
 /// purely from the schema's coded-index fields and their `CodedIndex.tables`,
 /// and — being decoded — are never seekable.
@@ -169,11 +168,11 @@ extension Session {
 /// A `SQL.Table` over one open WinMD table.
 ///
 /// Its real columns are the table's fields; the virtual columns follow, past the
-/// `SELECT *` extent: `rowid` at `width`, then the join keys — `parent` (on a
+/// `SELECT *` extent: `Id` at `width`, then the join keys — `parent` (on a
 /// list-owned table only) leading the coded-index join keys. A real cell is
 /// typed from its field's `ColumnType`: a `#Strings` index is `.text`, a
 /// `#Blob` index is a `.blob`, every other column (a constant, a foreign-key
-/// index, another heap) is `.integer`. A seek is available on `rowid` (a dense
+/// index, another heap) is `.integer`. A seek is available on `Id` (a dense
 /// 1-based index, trivially monotonic), on `parent` over a list-child (whose
 /// owning run is monotonic in row order), and on the table's intrinsic sort key
 /// when the database physically sorts the table.
@@ -191,7 +190,7 @@ internal struct WinMDRelation: SQL.Table, ~Escapable {
   }
 
   /// The number of real columns — the extent of a `SELECT *` projection. The
-  /// `rowid` and `parent` virtual columns sit past it.
+  /// `Id` and `parent` virtual columns sit past it.
   internal var width: Int {
     table.schema.fields.count
   }
@@ -206,34 +205,34 @@ internal struct WinMDRelation: SQL.Table, ~Escapable {
     return names
   }
 
-  /// The virtual column names, in ordinal order — `rowid` at `width`, then its
+  /// The virtual column names, in ordinal order — `Id` at `width`, then its
   /// join keys: `parent` (on a list-owned table only) leading the coded-index
   /// join keys.
   internal var virtuals: Array<String> {
     let parent = WinMDRelation.Link(storage, table) == nil ? [] : ["parent"]
-    return ["rowid"] // the universal identity, at `width`
+    return ["Id"] // the universal identity, at `width`
         + parent // the list-ownership key, present only on a list-owned table
         + keys.map(\.name) // coded-index join keys
   }
 
   /// One past the highest ordinal this relation can address — its real `width`
-  /// plus the universal `rowid` and its join keys (`parent` when list-owned,
+  /// plus the universal `Id` and its join keys (`parent` when list-owned,
   /// then the coded-index join keys).
   internal var extent: Int {
     width // real fields
-        + 1 // `rowid`
+        + 1 // `Id`
         + (WinMDRelation.Link(storage, table) == nil ? 0 : 1) // `parent`
         + keys.count // coded-index join keys
   }
 
-  /// The ordinal of the `rowid` virtual column — the first ordinal past the
+  /// The ordinal of the `Id` virtual column — the first ordinal past the
   /// real fields.
-  private var rowid: Int {
+  private var id: Int {
     width
   }
 
   /// The ordinal of the `parent` virtual column on a list-owned table — the
-  /// first join-key ordinal, immediately past `rowid` — or `nil` when the table
+  /// first join-key ordinal, immediately past `Id` — or `nil` when the table
   /// owns no list (it then has no `parent` column).
   private var parent: Int? {
     WinMDRelation.Link(storage, table) == nil
@@ -247,13 +246,13 @@ internal struct WinMDRelation: SQL.Table, ~Escapable {
                   .caseInsensitiveCompare(name) == .orderedSame {
       return column
     }
-    if name.caseInsensitiveCompare("rowid") == .orderedSame {
-      return rowid
+    if name.caseInsensitiveCompare("Id") == .orderedSame {
+      return id
     }
-    // The join keys follow `rowid`. `parent` (on a list-owned table) leads
+    // The join keys follow `Id`. `parent` (on a list-owned table) leads
     // them; the coded-index join keys follow at `parent + 1` onward (or, on a
     // non-list table, at the first join-key ordinal).
-    let base = rowid + 1
+    let base = id + 1
     if let parent, name.caseInsensitiveCompare("parent") == .orderedSame {
       return parent
     }
@@ -269,17 +268,17 @@ internal struct WinMDRelation: SQL.Table, ~Escapable {
   internal func bound(_ column: Int, _ value: Int, strict: Bool) -> Int? {
     let count = Int(table.rows)
 
-    // `rowid` is a dense 1-based index, so the rows are stored in `rowid` order
+    // `Id` is a dense 1-based index, so the rows are stored in `Id` order
     // by construction; the boundary for a value is the value itself (less one
     // for a non-strict `>= value`), clamped to the row count.
-    if column == rowid {
+    if column == id {
       let index = strict ? value : value - 1
       return min(max(index, 0), count)
     }
 
     // `parent` over a list-child is monotonic in row order — a parent owns a
     // contiguous run of children — so binary-search the rows for the boundary
-    // against the computed parent `rowid`.
+    // against the computed parent `Id`.
     if column == parent, let link = WinMDRelation.Link(storage, table) {
       return owners(link, value, count, strict: strict)
     }
@@ -287,12 +286,12 @@ internal struct WinMDRelation: SQL.Table, ~Escapable {
     // A coded-index join key seeks when its underlying raw coded-index column is
     // the table's intrinsic sort key and the database physically sorts the table
     // (e.g. `CustomAttribute.Parent`, on which the table is sorted): a target
-    // `rowid` `value` encodes to the raw coded cell `(value << bits) | tag`,
+    // `Id` `value` encodes to the raw coded cell `(value << bits) | tag`,
     // whose equal run the raw column's binary search brackets. The join's own
     // equality re-tests the decoded key per row, so the seek need only bracket
     // the run — its precision is an optimisation, not a correctness burden.
     //
-    // A decoded row is 1-based, so only `value >= 1` is a valid target rowid: a
+    // A decoded row is 1-based, so only `value >= 1` is a valid target Id: a
     // non-positive `value` is a null coded-index reference (`WinMDRow.key`
     // decodes any coded index whose row is zero as SQL `NULL`), which no cell can
     // equal — `NULL = 0` is UNKNOWN. Returning `nil` for it defers to a full
@@ -301,7 +300,7 @@ internal struct WinMDRelation: SQL.Table, ~Escapable {
     // would consume without a residual recheck, leaking those rows).
     //
     // The upper bound `value <= Int.max >> key.kind.bits` rejects a decoded
-    // rowid too large to encode without truncation: Swift's `<<` discards the
+    // Id too large to encode without truncation: Swift's `<<` discards the
     // bits shifted past the word, so a larger `value` would alias `encoded` to a
     // real raw coded cell (e.g. with `bits == 5`, `(1 << 59) + 1` encodes to raw
     // `35`, the same cell as `TypeDef` row 1), and `Engine.seek` would consume
@@ -339,12 +338,12 @@ internal struct WinMDRelation: SQL.Table, ~Escapable {
   /// The coded-index join `Key` exposed at ordinal `column`, or `nil` when
   /// `column` is not one of this table's coded-index join keys.
   ///
-  /// The coded-index join keys occupy the ordinals past `rowid` and — on a
+  /// The coded-index join keys occupy the ordinals past `Id` and — on a
   /// list-owned table — the `parent` key, in the order `keys` exposes them;
   /// this maps `column` back through that layout, the inverse of
   /// `ordinal(of:)`'s coded-index-key arm.
   private func key(for column: Int) -> Key? {
-    let base = rowid + 1
+    let base = id + 1
     let lead = parent == nil ? base : base + 1
     let index = column - lead
     let all = keys
@@ -352,7 +351,7 @@ internal struct WinMDRelation: SQL.Table, ~Escapable {
     return all[index]
   }
 
-  /// The partition point of the child rows against a parent `rowid` `value`.
+  /// The partition point of the child rows against a parent `Id` `value`.
   ///
   /// A child row's `parent` is the 1-based row of its owning parent. The owners
   /// are non-decreasing across the child rows (a parent's run precedes the
@@ -392,7 +391,7 @@ extension WinMDRelation {
   /// tables (the tag a cell carries when it points at `target`), and `name` the
   /// `<ColumnName>_<TargetSchemaName>` the join key is exposed under. A cell
   /// whose decoded tag is `tag` and whose row is non-null yields that row's
-  /// 1-based `rowid` in `target`; any other cell yields SQL `NULL`.
+  /// 1-based `Id` in `target`; any other cell yields SQL `NULL`.
   internal struct Key {
     /// The ordinal of the real coded-index column.
     internal let column: Int
@@ -498,12 +497,12 @@ extension WinMDRelation {
 }
 
 extension WinMD.Storage {
-  /// The 1-based `rowid` of the parent that owns the child row at `row`.
+  /// The 1-based `Id` of the parent that owns the child row at `row`.
   ///
   /// A parent at row `p` owns the children `[parent[col] - 1, next[col] - 1)`,
   /// the runs partitioning the child rows in parent order. Binary-search the
   /// parent rows for the one whose run contains `row`: the last parent whose
-  /// 0-based run start is `<= row`. The parent's 1-based `rowid` is `p + 1`.
+  /// 0-based run start is `<= row`. The parent's 1-based `Id` is `p + 1`.
   internal func owner(of row: Int, _ link: WinMDRelation.Link) -> Int {
     let cursor = WinMD.Cursor(copy self, link.parent)
     var lo = 0
@@ -566,12 +565,12 @@ internal struct WinMDCursor: SQL.Cursor, ~Escapable {
 /// reads the WinMD cell — a `#Strings` heap index resolves through the heap as
 /// `.text`, a `#Blob` heap index as an owning `.blob` (the raw heap payload,
 /// for a scalar UDF such as `GUID` to decode), every other column `.integer`;
-/// `rowid` (`count`) is the 1-based row index; and the join keys follow it — on
+/// `Id` (`count`) is the 1-based row index; and the join keys follow it — on
 /// a list-owned table the `parent` ordinal is the owning parent row's 1-based
-/// `rowid` (zero for a row no parent owns) and the coded-index join keys follow
-/// it, while on a non-list table the coded-index join keys follow `rowid`
+/// `Id` (zero for a row no parent owns) and the coded-index join keys follow
+/// it, while on a non-list table the coded-index join keys follow `Id`
 /// directly. A coded-index join-key ordinal decodes a coded-index cell to the
-/// target's 1-based `rowid`, or SQL `NULL` when the cell points elsewhere or is
+/// target's 1-based `Id`, or SQL `NULL` when the cell points elsewhere or is
 /// null.
 internal struct WinMDRow: SQL.Row, ~Escapable {
   /// The WinMD row this view reads.
@@ -594,16 +593,16 @@ internal struct WinMDRow: SQL.Row, ~Escapable {
 
   internal subscript(_ column: Int) -> Value {
     borrowing get {
-      // The real fields are `[0, count)`; `rowid` is `count`, then the join
+      // The real fields are `[0, count)`; `Id` is `count`, then the join
       // keys follow it.
       if column == tuple.count {
         return .integer(tuple.index + 1)
       }
       if column > tuple.count {
-        // Past `rowid`: the join keys. On a list-owned table `parent` leads
-        // them (the owning parent's 1-based `rowid`, zero for a row no parent
+        // Past `Id`: the join keys. On a list-owned table `parent` leads
+        // them (the owning parent's 1-based `Id`, zero for a row no parent
         // owns) and the coded-index join keys follow it; on a non-list table
-        // the coded-index join keys follow `rowid` directly.
+        // the coded-index join keys follow `Id` directly.
         let virtual = column - (tuple.count + 1)
         guard let link else { return self.key(virtual) }
         return virtual == 0
@@ -647,7 +646,7 @@ internal struct WinMDRow: SQL.Row, ~Escapable {
   /// The keys are derived from the tuple's coded-index fields, in the order
   /// `keys` exposes them. The key's column cell is decoded as its coded index;
   /// when the cell's tag selects the key's target table and its row is
-  /// non-null, the value is that 1-based row (the target relation's `rowid`),
+  /// non-null, the value is that 1-based row (the target relation's `Id`),
   /// so a view can equi-join on it. A cell pointing at another target, a null
   /// reference (`row == 0`), or an out-of-range index is SQL `NULL`.
   private func key(_ index: Int) -> Value {
@@ -676,7 +675,7 @@ extension WinMD.Storage {
   }
 
   /// The decoded type spelling of the return of the `MethodDef` at 1-based
-  /// `method` `rowid`, in `dialect`, or `nil` when the row or its signature
+  /// `method` `Id`, in `dialect`, or `nil` when the row or its signature
   /// does not decode.
   ///
   /// This is the signature-navigation the adapter once baked as the
@@ -698,7 +697,7 @@ extension WinMD.Storage {
     return signature.returns.decode(with: resolver, dialect: dialect)
   }
 
-  /// The decoded type spelling of the `Param` at 1-based `parameter` `rowid`, in
+  /// The decoded type spelling of the `Param` at 1-based `parameter` `Id`, in
   /// `dialect`, navigated through its owning method's signature — or `nil` when
   /// it does not decode.
   ///

--- a/Sources/winmd-inspect/Resources/Queries/bases.sql
+++ b/Sources/winmd-inspect/Resources/Queries/bases.sql
@@ -3,7 +3,7 @@ SELECT
   b.TypeName AS base
 FROM
   InterfaceImpl i
-  JOIN TypeRef b ON i.Interface_TypeRef = b.rowid
+  JOIN TypeRef b ON i.Interface_TypeRef = b.Id
 WHERE
   i.Class = :parent
 UNION
@@ -11,6 +11,6 @@ SELECT
   d.TypeName AS base
 FROM
   InterfaceImpl i
-  JOIN TypeDef d ON i.Interface_TypeDef = d.rowid
+  JOIN TypeDef d ON i.Interface_TypeDef = d.Id
 WHERE
   i.Class = :parent

--- a/Sources/winmd-inspect/Resources/Queries/interfaces.sql
+++ b/Sources/winmd-inspect/Resources/Queries/interfaces.sql
@@ -1,44 +1,44 @@
 CREATE VIEW interfaces AS
 SELECT
-  t.rowid,
+  t.Id,
   t.TypeNamespace,
   t.TypeName,
   GUID(c.Value) AS iid
 FROM
   TypeDef t
-  JOIN CustomAttribute c ON c.Parent_TypeDef = t.rowid
-  JOIN MemberRef r ON c.Type_MemberRef = r.rowid
-  JOIN TypeRef g ON r.Class_TypeRef = g.rowid
+  JOIN CustomAttribute c ON c.Parent_TypeDef = t.Id
+  JOIN MemberRef r ON c.Type_MemberRef = r.Id
+  JOIN TypeRef g ON r.Class_TypeRef = g.Id
 WHERE
   g.TypeNamespace = 'Windows.Win32.Foundation.Metadata'
   AND g.TypeName = 'GuidAttribute'
   AND BITAND(t.Flags, 32) = 32
 UNION
 SELECT
-  t.rowid,
+  t.Id,
   t.TypeNamespace,
   t.TypeName,
   GUID(c.Value) AS iid
 FROM
   TypeDef t
-  JOIN CustomAttribute c ON c.Parent_TypeDef = t.rowid
-  JOIN MethodDef m ON c.Type_MethodDef = m.rowid
-  JOIN TypeDef g ON m.parent = g.rowid
+  JOIN CustomAttribute c ON c.Parent_TypeDef = t.Id
+  JOIN MethodDef m ON c.Type_MethodDef = m.Id
+  JOIN TypeDef g ON m.parent = g.Id
 WHERE
   g.TypeNamespace = 'Windows.Win32.Foundation.Metadata'
   AND g.TypeName = 'GuidAttribute'
   AND BITAND(t.Flags, 32) = 32
 UNION
 SELECT
-  t.rowid,
+  t.Id,
   t.TypeNamespace,
   t.TypeName,
   GUID(c.Value) AS iid
 FROM
   TypeDef t
-  JOIN CustomAttribute c ON c.Parent_TypeDef = t.rowid
-  JOIN MemberRef r ON c.Type_MemberRef = r.rowid
-  JOIN TypeDef g ON r.Class_TypeDef = g.rowid
+  JOIN CustomAttribute c ON c.Parent_TypeDef = t.Id
+  JOIN MemberRef r ON c.Type_MemberRef = r.Id
+  JOIN TypeDef g ON r.Class_TypeDef = g.Id
 WHERE
   g.TypeNamespace = 'Windows.Win32.Foundation.Metadata'
   AND g.TypeName = 'GuidAttribute'

--- a/Sources/winmd-inspect/Resources/Queries/methods.sql
+++ b/Sources/winmd-inspect/Resources/Queries/methods.sql
@@ -1,6 +1,6 @@
 CREATE VIEW methods AS
 SELECT
-  rowid,
+  Id,
   Name
 FROM
   MethodDef

--- a/Sources/winmd-inspect/Resources/Queries/params.sql
+++ b/Sources/winmd-inspect/Resources/Queries/params.sql
@@ -1,6 +1,6 @@
 CREATE VIEW params AS
 SELECT
-  rowid,
+  Id,
   Name,
   Sequence
 FROM

--- a/Sources/winmd-inspect/Resources/Render/interfaces.sql
+++ b/Sources/winmd-inspect/Resources/Render/interfaces.sql
@@ -1,5 +1,5 @@
 SELECT
-  rowid,
+  Id,
   TypeNamespace,
   SANITIZE(TypeName) AS TypeName,
   iid

--- a/Sources/winmd-inspect/Resources/Render/methods.sql
+++ b/Sources/winmd-inspect/Resources/Render/methods.sql
@@ -1,5 +1,5 @@
 SELECT
-  rowid,
+  Id,
   SANITIZE(Name) AS Name
 FROM
   methods

--- a/Sources/winmd-inspect/Resources/Render/params.sql
+++ b/Sources/winmd-inspect/Resources/Render/params.sql
@@ -1,5 +1,5 @@
 SELECT
-  rowid,
+  Id,
   SANITIZE(Name) AS Name,
   Sequence
 FROM

--- a/Sources/winmd-inspect/Shell.swift
+++ b/Sources/winmd-inspect/Shell.swift
@@ -396,9 +396,9 @@ internal struct Shell: ~Escapable {
   /// bundled `Resources/Render/*.sql` queries (not Swift literals): the
   /// `interfaces` query selects the one named interface, or every
   /// interface for `*` (its `WHERE TypeName = :name OR '*' = :name`), then
-  /// for each its `methods` bound by the interface's `rowid`, each
-  /// method's `params` bound by the method's `rowid`, and its `bases`
-  /// bound by the interface's `rowid`. The presentation tier is the named
+  /// for each its `methods` bound by the interface's `Id`, each
+  /// method's `params` bound by the method's `Id`, and its `bases`
+  /// bound by the interface's `Id`. The presentation tier is the named
   /// template loaded from `Resources/Templates`. A single interface that
   /// no view names raises `RenderError.interface`; a missing template
   /// resource raises `RenderError.template`.
@@ -445,19 +445,19 @@ internal struct Shell: ~Escapable {
     var sources = Array<String>()
     sources.reserveCapacity(interfaces.count)
     for found in interfaces {
-      let rowid = found[0]
-      // The interface's methods, bound by its rowid; each row is its `rowid`
+      let id = found[0]
+      // The interface's methods, bound by its `Id`; each row is its `Id`
       // then its escaped `Name`. The type spellings are no longer projected —
       // the render decodes them from the signature with the spec's `Dialect`.
       let plan = try Shell.select(Shell.query(named: "methods",
                                               search: search))
       let rows = try Engine.run(plan, session, routines,
-                                bindings: ["parent": rowid])
+                                bindings: ["parent": id])
       var methods = Array<Dictionary<String, Any>>()
       methods.reserveCapacity(rows.count)
       for method in rows {
-        // Each method's parameters, bound by the method's rowid; each row is its
-        // `rowid`, escaped `Name`, and `Sequence`. The return pseudo-parameter
+        // Each method's parameters, bound by the method's `Id`; each row is its
+        // `Id`, escaped `Name`, and `Sequence`. The return pseudo-parameter
         // (`Sequence == 0`) is dropped — only the real parameters spell the
         // requirement's arguments — and the rest decode their type at render
         // time from the parameter's own signature position.
@@ -494,14 +494,14 @@ internal struct Shell: ~Escapable {
         }
         methods.append(entry)
       }
-      // The interface's base, via the `bases` view bound by its rowid. A
+      // The interface's base, via the `bases` view bound by its `Id`. A
       // rootless interface defaults to the spec's COM root, except the root
       // interface itself — which inherits nothing, so it never becomes its own
       // base; an empty `root` applies no default.
       let lineage =
           try Shell.select(Shell.query(named: "bases", search: search))
       let bases = try Engine.run(lineage, session, routines,
-                                 bindings: ["parent": rowid])
+                                 bindings: ["parent": id])
       let base: String? = if let inherited = bases.first {
         inherited[0].text
       } else if language.root.isEmpty || found[2].text == language.root {
@@ -1017,15 +1017,15 @@ extension Session {
   /// declaring type, projecting `CustomAttribute.guid` as the `iid` — a
   /// `methods` view of one interface's methods, a `params` view of one
   /// method's parameters, and a `bases` view of one interface's base type. The
-  /// latter three carry a uniform `:parent` param — the owning row's `rowid` —
+  /// latter three carry a uniform `:parent` param — the owning row's `Id` —
   /// so a render can walk interface → methods → params, binding each level's
-  /// `rowid` to the next's `:parent`, and look up the interface's base by its
-  /// `rowid`.
+  /// `Id` to the next's `:parent`, and look up the interface's base by its
+  /// `Id`.
   ///
   /// The `bases` view navigates the interface's single `InterfaceImpl` row
-  /// (whose simple `Class` index is the interface's 1-based `rowid`) to its
+  /// (whose simple `Class` index is the interface's 1-based `Id`) to its
   /// base type's simple name, projecting `TypeRef.TypeName` as `base`. The
-  /// `Class` column is a *simple* `TypeDef` index — it stores the `rowid`
+  /// `Class` column is a *simple* `TypeDef` index — it stores the `Id`
   /// directly, so the predicate is `i.Class = :parent` (there is no decoded
   /// `Class_TypeDef` join key — `WinMDRelation.keys` derives keys only for
   /// *coded* indices). `Interface` is the coded `TypeDefOrRef`, so its decoded
@@ -1122,7 +1122,7 @@ extension Value {
   }
 
   /// This cell's `integer`, zero for any non-integer cell — the render reads a
-  /// `rowid`/`Sequence` `.integer` column to navigate a signature, so a
+  /// `Id`/`Sequence` `.integer` column to navigate a signature, so a
   /// non-integer cell is a NULL the query guarantees never appears there.
   internal var integer: Int {
     if case let .integer(integer) = self { integer } else { 0 }

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -3032,11 +3032,11 @@ struct EngineWithTests {
     ])
   }
 
-  @Test("a CTE's rowid virtual column resolves")
-  func rowid() throws {
+  @Test("a CTE's Id virtual column resolves")
+  func id() throws {
     let rows = try statement("""
         WITH a (Tag) AS (SELECT Name FROM Parent)
-          SELECT rowid, Tag FROM a WHERE rowid = 2
+          SELECT Id, Tag FROM a WHERE Id = 2
         """, family())
     #expect(rows == [[.integer(2), .text("Bee")]])
   }

--- a/Tests/winmd-inspectTests/AdapterTests.swift
+++ b/Tests/winmd-inspectTests/AdapterTests.swift
@@ -14,8 +14,8 @@ import SQL
 /// `TypeDef` (#2), `MethodDef` (#6), `NestedClass` (#41), and `EventMap` (#18)
 /// — and drive a parsed `SELECT` through `Engine.run` over the `WinMD.Storage`
 /// catalog, asserting the typed `Value` rows the engine yields. They exercise a
-/// single-relation projection / filter / order with the `rowid` virtual column
-/// and a sorted-key seek, a foreign-key join on `rowid`, a list join on the
+/// single-relation projection / filter / order with the `Id` virtual column
+/// and a sorted-key seek, a foreign-key join on `Id`, a list join on the
 /// `parent` virtual column, and a real `Parent` column shadowing that
 /// pseudo-column.
 struct AdapterTests {
@@ -120,7 +120,7 @@ struct AdapterTests {
     // The string columns project as text, the constant as an integer; the
     // WHERE keeps both rows (both are in "NS"), and ORDER BY TypeName sorts
     // Alpha < Beta. `SELECT *` is the two real string heaps plus the constant
-    // and the three index columns — never `rowid` or `parent`.
+    // and the three index columns — never `Id` or `parent`.
     try AdapterTests.with { catalog in
       let rows = try AdapterTests.run(
           "SELECT TypeName, Flags FROM TypeDef "
@@ -132,12 +132,12 @@ struct AdapterTests {
     }
   }
 
-  @Test("excludes rowid and parent from SELECT *")
+  @Test("excludes Id and parent from SELECT *")
   func star() throws {
     // `SELECT *` projects exactly the real fields: a TypeDef has six. Neither
-    // the `rowid` nor the `parent` virtual column appears.
+    // the `Id` nor the `parent` virtual column appears.
     try AdapterTests.with { catalog in
-      let rows = try AdapterTests.run("SELECT * FROM TypeDef ORDER BY rowid",
+      let rows = try AdapterTests.run("SELECT * FROM TypeDef ORDER BY Id",
                                       catalog)
       #expect(rows.count == 2)
       #expect(rows[0].count == 6)
@@ -148,11 +148,11 @@ struct AdapterTests {
     }
   }
 
-  @Test("vends the rowid virtual column 1-based")
-  func rowid() throws {
+  @Test("vends the Id virtual column 1-based")
+  func id() throws {
     try AdapterTests.with { catalog in
       let rows = try AdapterTests.run(
-          "SELECT rowid, TypeName FROM TypeDef ORDER BY rowid", catalog)
+          "SELECT Id, TypeName FROM TypeDef ORDER BY Id", catalog)
       #expect(rows == [
         [.integer(1), .text("Alpha")],
         [.integer(2), .text("Beta")],
@@ -172,15 +172,15 @@ struct AdapterTests {
     }
   }
 
-  @Test("joins through a foreign key on rowid")
+  @Test("joins through a foreign key on Id")
   func foreignKeyJoin() throws {
-    // The FK `NestedClass.NestedClass` holds a TypeDef rowid; the engine joins
+    // The FK `NestedClass.NestedClass` holds a TypeDef Id; the engine joins
     // each NestedClass row to its TypeDef and projects the resolved name.
     try AdapterTests.with { catalog in
       let rows = try AdapterTests.run(
           "SELECT NestedClass.EnclosingClass, TypeDef.TypeName "
           + "FROM NestedClass JOIN TypeDef "
-          + "ON NestedClass.NestedClass = TypeDef.rowid "
+          + "ON NestedClass.NestedClass = TypeDef.Id "
           + "ORDER BY NestedClass.EnclosingClass", catalog)
       #expect(rows == [
         [.integer(1), .text("Beta")],
@@ -193,12 +193,12 @@ struct AdapterTests {
   func listJoin() throws {
     // The `parent` virtual column relates each MethodDef to the TypeDef whose
     // MethodList run owns it: MethodDef[0,1] → TypeDef[0] (Alpha), MethodDef[2]
-    // → TypeDef[1] (Beta). The join seeks TypeDef on its `rowid` per method.
+    // → TypeDef[1] (Beta). The join seeks TypeDef on its `Id` per method.
     try AdapterTests.with { catalog in
       let rows = try AdapterTests.run(
           "SELECT MethodDef.Name, TypeDef.TypeName "
           + "FROM MethodDef JOIN TypeDef "
-          + "ON MethodDef.parent = TypeDef.rowid "
+          + "ON MethodDef.parent = TypeDef.Id "
           + "ORDER BY MethodDef.Name", catalog)
       #expect(rows == [
         [.text("m0"), .text("Alpha")],
@@ -215,20 +215,20 @@ struct AdapterTests {
     // for a table no list owns). EventMap[0].Parent=1, EventMap[1].Parent=2.
     try AdapterTests.with { catalog in
       let rows = try AdapterTests.run(
-          "SELECT Parent FROM EventMap ORDER BY rowid", catalog)
+          "SELECT Parent FROM EventMap ORDER BY Id", catalog)
       #expect(rows == [[.integer(1)], [.integer(2)]])
     }
   }
 
-  @Test("joins through a real Parent foreign key on rowid")
+  @Test("joins through a real Parent foreign key on Id")
   func realParentJoin() throws {
-    // The real `EventMap.Parent` FK holds a TypeDef rowid; the join resolves
+    // The real `EventMap.Parent` FK holds a TypeDef Id; the join resolves
     // each EventMap row to its TypeDef: Parent=1 → Alpha, Parent=2 → Beta.
     try AdapterTests.with { catalog in
       let rows = try AdapterTests.run(
           "SELECT EventMap.Parent, TypeDef.TypeName "
           + "FROM EventMap JOIN TypeDef "
-          + "ON EventMap.Parent = TypeDef.rowid "
+          + "ON EventMap.Parent = TypeDef.Id "
           + "ORDER BY EventMap.Parent", catalog)
       #expect(rows == [
         [.integer(1), .text("Alpha")],

--- a/Tests/winmd-inspectTests/DatabaseSQLTests.swift
+++ b/Tests/winmd-inspectTests/DatabaseSQLTests.swift
@@ -90,7 +90,7 @@ struct DatabaseSQLTests {
   //   Param[1]:    Sequence=1, Name="first"(71) — signature.parameters[0] (i4).
   //   Param[2]:    Sequence=2 — signature.parameters[1] (string).
   //   InterfaceImpl[0]: Class=TypeDef row 1 (the simple `TypeDef` index stores
-  //                the rowid directly, so 1)=IMyInterface;
+  //                the Id directly, so 1)=IMyInterface;
   //                Interface=TypeDefOrRef(TypeRef row 2)=(2<<2)|1=9 — names the
   //                base `IInspectable`, so the `bases` view derives it.
   //   InterfaceImpl[1]: Class=1=IMyInterface; Interface=TypeDefOrRef(TypeDef
@@ -263,27 +263,27 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("the bundled `methods` view yields a method bound by its parent rowid")
+  @Test("the bundled `methods` view yields a method bound by its parent Id")
   func bundledMethods() throws {
-    // `IMyInterface` is `TypeDef` rowid 1, which owns `MethodDef` rowid 1;
-    // binding `:parent` to the interface's rowid yields the method's `rowid` and
+    // `IMyInterface` is `TypeDef` Id 1, which owns `MethodDef` Id 1;
+    // binding `:parent` to the interface's Id yields the method's `Id` and
     // `Name` (the type is no longer a column — the render decodes it).
     try DatabaseSQLTests.with { catalog in
       let rows = try DatabaseSQLTests.run(
-          "SELECT rowid, Name FROM methods", Session.bundled(), catalog,
+          "SELECT Id, Name FROM methods", Session.bundled(), catalog,
           ["parent": .integer(1)])
       #expect(rows == [[.integer(1), .text("MyMethod")]])
     }
   }
 
-  @Test("the bundled `params` view yields params bound by their method rowid")
+  @Test("the bundled `params` view yields params bound by their method Id")
   func bundledParams() throws {
-    // `MethodDef` rowid 1 owns the three `Param` rows; binding `:parent` to it
-    // yields each parameter's `rowid`, `Name`, and `Sequence` (the type is no
+    // `MethodDef` Id 1 owns the three `Param` rows; binding `:parent` to it
+    // yields each parameter's `Id`, `Name`, and `Sequence` (the type is no
     // longer a column — the render navigates from these and decodes it).
     try DatabaseSQLTests.with { catalog in
       let rows = try DatabaseSQLTests.run(
-          "SELECT rowid, Name, Sequence FROM params", Session.bundled(),
+          "SELECT Id, Name, Sequence FROM params", Session.bundled(),
           catalog, ["parent": .integer(1)])
       #expect(rows == [
         [.integer(1), .text(""), .integer(0)],
@@ -327,7 +327,7 @@ struct DatabaseSQLTests {
   @Test("the render decode spells a method's return from its signature")
   func decodesReturn() {
     // The render decodes a return at render time (not through a virtual column):
-    // `MethodDef` rowid 1's signature `void Method(i4, string)` decodes its
+    // `MethodDef` Id 1's signature `void Method(i4, string)` decodes its
     // return to `Void`.
     DatabaseSQLTests.with { catalog in
       #expect(catalog.decode(return: 1, in: .swift) == "Void")
@@ -406,7 +406,7 @@ struct DatabaseSQLTests {
   @Test("excludes the virtual columns from SELECT *")
   func star() throws {
     // `SELECT *` projects exactly the six real `TypeDef` fields — neither
-    // `rowid` nor `parent` appears — for each of the two fixture types.
+    // `Id` nor `parent` appears — for each of the two fixture types.
     try DatabaseSQLTests.with { catalog in
       let rows = try DatabaseSQLTests.run("SELECT * FROM TypeDef", catalog)
       #expect(rows.count == 2)
@@ -425,7 +425,7 @@ struct DatabaseSQLTests {
 
   @Test("the render decode spells each Param, nil for the return parameter")
   func paramType() {
-    // The `Sequence == 0` return pseudo-parameter (`Param` rowid 1) decodes to
+    // The `Sequence == 0` return pseudo-parameter (`Param` Id 1) decodes to
     // `nil`; the two real parameters (rowids 2 and 3) decode to the signature's
     // `i4` (`CInt`) and `string` (`HSTRING`) — the render-time decode replacing
     // the old `ParamType` virtual column.
@@ -439,7 +439,7 @@ struct DatabaseSQLTests {
 
   @Test("the bundled `bases` view yields the interface's derived bases")
   func bundledBases() throws {
-    // `IMyInterface` is `TypeDef` rowid 1; binding `:parent` to its rowid
+    // `IMyInterface` is `TypeDef` Id 1; binding `:parent` to its Id
     // navigates `InterfaceImpl.Class = :parent`, and the view UNIONs both arms
     // of the `Interface` coded index: the cross-file `IInspectable` reached
     // through `Interface_TypeRef` → `TypeRef`, and the same-file `INotGuid`
@@ -454,7 +454,7 @@ struct DatabaseSQLTests {
 
   @Test("the bundled `bases` view is empty for a rootless interface")
   func bundledBasesRoot() throws {
-    // `INotGuid` is `TypeDef` rowid 2 and has no `InterfaceImpl` row, so the
+    // `INotGuid` is `TypeDef` Id 2 and has no `InterfaceImpl` row, so the
     // view yields no base — the render's `IUnknown` default path.
     try DatabaseSQLTests.with { catalog in
       let rows = try DatabaseSQLTests.run(
@@ -499,7 +499,7 @@ struct DatabaseSQLTests {
       var shell = Shell(catalog)
       let query = """
         CREATE VIEW bases AS SELECT b.TypeName AS base FROM InterfaceImpl i
-        JOIN TypeRef b ON i.Interface_TypeRef = b.rowid
+        JOIN TypeRef b ON i.Interface_TypeRef = b.Id
         WHERE i.Class = :parent AND i.Class = 0
         """
       let (name, view) = try DatabaseSQLTests.create(query)
@@ -535,7 +535,7 @@ struct DatabaseSQLTests {
       var shell = Shell(catalog)
       let query = """
         CREATE VIEW bases AS
-        SELECT 'protocol' AS base FROM TypeDef WHERE rowid = :parent
+        SELECT 'protocol' AS base FROM TypeDef WHERE Id = :parent
         """
       let (name, view) = try DatabaseSQLTests.create(query)
       shell.session.register(name, view)
@@ -587,10 +587,10 @@ struct DatabaseSQLTests {
   }
 
 
-  @Test("a coded-index join key decodes to the target's rowid")
+  @Test("a coded-index join key decodes to the target's Id")
   func codedKeyResolves() throws {
     // `CustomAttribute[0].Parent` is `HasCustomAttribute(TypeDef row 1)`, so
-    // the `Parent_TypeDef` key decodes to the owning `TypeDef`'s 1-based rowid.
+    // the `Parent_TypeDef` key decodes to the owning `TypeDef`'s 1-based Id.
     try DatabaseSQLTests.with { catalog in
       let rows = try DatabaseSQLTests.run(
           "SELECT Parent_TypeDef FROM CustomAttribute", catalog)
@@ -633,14 +633,14 @@ struct DatabaseSQLTests {
   @Test("a coded-index join key joins a CustomAttribute to its owning TypeDef")
   func codedKeyJoin() throws {
     // Joining `CustomAttribute` to `TypeDef` on the decoded `Parent_TypeDef`
-    // key against the `TypeDef`'s rowid pairs the `GuidAttribute` row (its
+    // key against the `TypeDef`'s Id pairs the `GuidAttribute` row (its
     // `GUID(Value)` IID) with the `IMyInterface` type it decorates, end to end
     // across the coded index.
     try DatabaseSQLTests.with { catalog in
       let rows = try DatabaseSQLTests.run(
           "SELECT TypeDef.TypeName, GUID(CustomAttribute.Value) "
           + "FROM CustomAttribute "
-          + "JOIN TypeDef ON CustomAttribute.Parent_TypeDef = TypeDef.rowid",
+          + "JOIN TypeDef ON CustomAttribute.Parent_TypeDef = TypeDef.Id",
           catalog)
       #expect(rows == [
         [.text("IMyInterface"),
@@ -895,7 +895,7 @@ struct DatabaseSQLTests {
   func paramTypeGuidClassification() {
     // The signature `void Method(Guid, Guid)` names `System.Guid` parameters;
     // the render decode classifies each by the `Param.Name` hint — `clsid`
-    // (rowid 2) yields `CLSID`, `iid` (rowid 3) yields the default `IID`.
+    // (Id 2) yields `CLSID`, `iid` (Id 3) yields the default `IID`.
     GuidParamFixture.with { catalog in
       #expect(catalog.decode(parameter: 2, for: .swift) == "CLSID")
       #expect(catalog.decode(parameter: 3, for: .swift) == "IID")
@@ -1113,7 +1113,7 @@ private enum SameModuleGuidFixture {
   //                a `MemberRef` into the in-file `TypeDef` (the `Class_TypeDef`
   //                arm).
   //   MethodDef[0]: Name=0, Signature=0, ParamList=1 — the `GuidAttribute`
-  //                `.ctor`, owned by TypeDef[0] (so its `parent` is rowid 1).
+  //                `.ctor`, owned by TypeDef[0] (so its `parent` is Id 1).
   //   MemberRef[0]: Class=MemberRefParent(TypeDef row 1)=(1<<3)|0=8 — the ctor
   //                reference whose declaring class is the in-file `GuidAttribute`
   //                `TypeDef`, so `Class_TypeDef` (not `Class_TypeRef`) decodes.


### PR DESCRIPTION
The adapter exposed every relation's 1-based row identity under the SQLite-style name `rowid`, which is not ISO SQL. Rename it to the standard-looking `Id` so the conceptual schema reads as ordinary SQL: a foreign key is a real column holding a target row's `Id`, and an equi-join spells `ON child.<col> = Target.Id`.

This is a pure lexical rename, not a behavior change. The identity stays a virtual column placed at ordinal `width`, past the real columns, so `SELECT *` never projects it and its output is unchanged. Both producers of the identity are renamed — the `WinMDRelation` adapter (its `virtuals` declaration, `ordinal(of:)` match, `bound` seek, and the private ordinal property) and the `Materialised` CTE relation — so a CTE's `Id` resolves the same way a base table's does. The bundled query and render views join on `Id`, and the prose that called it a "pseudo-column" now describes it as an adapter-computed named column.

The SQL engine is untouched: the identity is not an engine concept, only a name the adapter vends through the generic virtual-column surface, resolved by name in `Schema.ordinal(of:)`. The generic engine test fixtures keep their own arbitrarily-named `rowid` virtual, which is independent of the adapter and collides with an unrelated real `Id` column in those fixtures.