### PR TITLE
SQL: add an approximate-numeric DOUBLE value type

### DIFF
--- a/Sources/SQL/AST.swift
+++ b/Sources/SQL/AST.swift
@@ -339,8 +339,11 @@ public enum Comparison: Hashable, Sendable {
 public enum Literal: Hashable, Sendable {
   /// A single-quoted string literal, with its escapes resolved.
   case string(String)
-  /// An integer literal.
+  /// An integer literal — a bare run of digits, exact numeric.
   case integer(Int)
+  /// An approximate-numeric literal — a decimal with a `.` fraction and/or an
+  /// exponent (`3.14`, `1.0`, `1e3`, `2.5e-1`), a binary64 `Double`.
+  case double(Double)
 }
 
 /// An `ORDER BY` clause: a column and its direction.

--- a/Sources/SQL/Adapter.swift
+++ b/Sources/SQL/Adapter.swift
@@ -20,12 +20,16 @@
 
 /// The kind of value a column holds.
 ///
-/// A column is integral, textual, truth-valued, or binary. A source uses this
-/// to describe its schema and to build the typed `Value`s a `Row` yields; the
-/// engine itself compares and orders on the `Value`, not the kind.
+/// A column is integral, approximate-numeric, textual, truth-valued, or binary.
+/// A source uses this to describe its schema and to build the typed `Value`s a
+/// `Row` yields; the engine itself compares and orders on the `Value`, not the
+/// kind.
 public enum ValueKind: Hashable, Sendable {
-  /// An integral column.
+  /// An integral column — exact numeric.
   case integer
+  /// An approximate-numeric column — SQL `FLOAT`/`REAL`/`DOUBLE PRECISION`,
+  /// carried as a binary64 `Double`.
+  case double
   /// A textual column.
   case text
   /// A truth-valued column — `TRUE` or `FALSE`; its UNKNOWN is `NULL`.
@@ -45,8 +49,20 @@ public enum ValueKind: Hashable, Sendable {
 public enum Value: Hashable, Sendable {
   /// SQL `NULL` — the absence of a value.
   case null
-  /// An integral value.
+  /// An integral value — exact numeric.
   case integer(Int)
+  /// An approximate-numeric value — SQL `FLOAT`/`REAL`/`DOUBLE PRECISION`,
+  /// carried as a binary64 `Double`. A double compares and does arithmetic with
+  /// another double, and — both being numeric — with an `integer` too, the
+  /// integer promoted to `Double`; a mixed integer/double arithmetic yields a
+  /// double, and `/` is real division (no truncation).
+  ///
+  /// INVARIANT: a `double` must be FINITE — never `inf` or NaN. NaN is unequal
+  /// to itself, so it would break UNION/CTE duplicate elimination and ordering;
+  /// the engine's producers enforce this (a literal or arithmetic result past
+  /// range faults, a routine's non-finite result is rejected), so a `Catalog`,
+  /// `Row`, and `Scalar` must likewise vend only finite doubles.
+  case double(Double)
   /// A textual value.
   case text(String)
   /// A truth value — `TRUE` or `FALSE`. Its UNKNOWN is the existing `null`; a

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -292,9 +292,9 @@ public enum Engine {
     // duplicate anchor rows collapse to their first occurrence — while `UNION
     // ALL` keeps every anchor row.
     let anchored = try run(anchor, catalog, ctes, routines, bindings)
-    var seen = Set<Array<Value>>()
+    var seen = Seen()
     var result = all ? anchored
-                     : anchored.filter { seen.insert($0).inserted }
+                     : anchored.filter { seen.insert($0) }
     var working = result
 
     var iterations = 0
@@ -311,7 +311,7 @@ public enum Engine {
           try run(.select(recursive), catalog, scope, routines, bindings)
 
       var next = Array<Array<Value>>()
-      for row in produced where all || seen.insert(row).inserted {
+      for row in produced where all || seen.insert(row) {
         next.append(row)
       }
       result += next

--- a/Sources/SQL/Error.swift
+++ b/Sources/SQL/Error.swift
@@ -65,9 +65,10 @@ public enum SQLError: Error, Hashable, Sendable {
   /// A scalar function rejects its arguments (the wrong count, or a value it
   /// cannot map); the string describes the fault.
   case argument(String)
-  /// A binary arithmetic expression applies to a non-integer (text) operand —
-  /// the operands must be integers, not a silent coercion; the string describes
-  /// the fault. A NULL operand is not a fault: it propagates to a NULL result.
+  /// A binary arithmetic expression applies to a non-numeric (text, boolean, or
+  /// blob) operand — the operands must be numeric (integer or double), not a
+  /// silent coercion; the string describes the fault. A NULL operand is not a
+  /// fault: it propagates to a NULL result.
   case operand(String)
   /// A binary arithmetic expression divides by zero — standard SQL raises rather
   /// than yielding a value.
@@ -190,7 +191,7 @@ extension SQLError {
   ///   value out of range (the out-of-range integer literal and the arithmetic
   ///   overflow), `22012` division by zero, and `22023` invalid parameter value
   ///   (a scalar function's rejected argument).
-  /// - `42804` (datatype mismatch) is the non-integer arithmetic operand — a
+  /// - `42804` (datatype mismatch) is the non-numeric arithmetic operand — a
   ///   type error at evaluation rather than a value-range fault.
   /// - Class `SS` — the implementation-defined class this engine squats on
   ///   (SwiftSQL) for a condition with no standard ISO code — `SS001`, a query

--- a/Sources/SQL/Filter.swift
+++ b/Sources/SQL/Filter.swift
@@ -225,10 +225,15 @@ extension Array where Element == Filter {
 }
 
 /// The literal `literal` as a typed `Value`.
-internal func value(of literal: Literal) -> Value {
-  switch literal {
+internal func value(of literal: Literal) throws(SQLError) -> Value {
+  return switch literal {
   case let .integer(integer): .integer(integer)
   case let .string(string): .text(string)
+  case let .double(double) where double.isFinite: .double(double)
+  // A directly-built `Literal.double` bypasses the lexer's finite check; reject
+  // NaN/inf at lowering so no non-finite double reaches a plan (it would break
+  // dedup and ordering — see the `Value.double` invariant).
+  case .double: throw .magnitude("double literal is not finite")
   }
 }
 
@@ -267,7 +272,16 @@ private func apply<R: Row & ~Escapable>(_ name: String,
   for argument in arguments {
     try values.append(evaluate(argument, row, routines))
   }
-  return try function(values)
+  let result = try function(values)
+  // A registered routine is a public producer of `Value`s that bypasses the
+  // literal/arithmetic finite checks; enforce the invariant here so a routine
+  // cannot return `inf`/NaN. NaN in particular is unequal to itself and would
+  // break UNION/CTE dedup and ORDER BY (and stall a recursive UNION at the
+  // cap).
+  if case let .double(number) = result, !number.isFinite {
+    throw .magnitude("function '\(name)' produced a non-finite double")
+  }
+  return result
 }
 
 // MARK: - Evaluation
@@ -275,18 +289,37 @@ private func apply<R: Row & ~Escapable>(_ name: String,
 extension Arithmetic {
   /// Applies the operator to two typed operands, yielding a typed `Value`.
   ///
-  /// Both operands must be integers: `integer ∘ integer` is an integer, with `/`
-  /// integer division. A NULL on either side propagates — the result is NULL,
-  /// not a fault. A division by zero is `SQLError.divide`, as standard SQL
-  /// raises rather than yielding a value; a non-integer (text) operand is a
+  /// The operands must be numeric — integer or double. An `integer ∘ integer`
+  /// stays an integer, with `/` integer division; any double operand makes the
+  /// result a double (a lone integer promoted to `Double`), with `/` real
+  /// division. A NULL on either side propagates — the result is NULL, not a
+  /// fault. A division by zero is `SQLError.divide`, as standard SQL raises
+  /// rather than yielding a value (`inf`/`NaN`), on either an integer or a
+  /// double divisor; a non-numeric (text/boolean/blob) operand is a
   /// `SQLError.operand` type error rather than a silent coercion; an integer
   /// result past the `Int` boundary is `SQLError.magnitude`.
   internal func apply(_ lhs: Value, _ rhs: Value) throws(SQLError) -> Value {
     if case .null = lhs { return .null }
     if case .null = rhs { return .null }
-    guard case let .integer(lhs) = lhs, case let .integer(rhs) = rhs else {
-      throw .operand("operands must be integers")
+    return switch (lhs, rhs) {
+    case let (.integer(lhs), .integer(rhs)):
+      try apply(lhs, rhs)
+    // Any double operand widens the pair to double arithmetic — both operands
+    // being numeric — with a lone integer promoted to `Double`.
+    case let (.double(lhs), .double(rhs)):
+      try apply(lhs, rhs)
+    case let (.integer(lhs), .double(rhs)):
+      try apply(Double(lhs), rhs)
+    case let (.double(lhs), .integer(rhs)):
+      try apply(lhs, Double(rhs))
+    default:
+      throw .operand("operands must be numeric")
     }
+  }
+
+  /// Applies the operator to two integers: `integer ∘ integer` is an integer,
+  /// with `/` integer division.
+  private func apply(_ lhs: Int, _ rhs: Int) throws(SQLError) -> Value {
     // Report overflow rather than trap: operands are parsed literals or column
     // values that can reach the `Int` boundary (`Int.max + 1`, `Int.min / -1`),
     // and Swift's `+`/`-`/`*`/`/` would trap — aborting the process — instead of
@@ -300,6 +333,30 @@ extension Arithmetic {
     }
     guard !outcome.overflow else { throw .magnitude("integer overflow") }
     return .integer(outcome.partialValue)
+  }
+
+  /// Applies the operator to two doubles: `double ∘ double` is a double, with
+  /// `/` real division (no truncation).
+  ///
+  /// A non-finite result is rejected rather than returned: division by zero is
+  /// `SQLError.divide` (matching the integer policy), and an overflow to `inf`
+  /// or a NaN from an indeterminate form (`inf - inf`) is `SQLError.magnitude`.
+  /// A NaN must never reach a result — it is unequal to itself, so it would
+  /// break duplicate elimination (a UNION would keep both copies) and ordering
+  /// (a non-transitive sort key), and a recursive UNION echoing it would
+  /// iterate to the recursion cap.
+  private func apply(_ lhs: Double, _ rhs: Double) throws(SQLError) -> Value {
+    let result: Double = switch self {
+    case .add: lhs + rhs
+    case .subtract: lhs - rhs
+    case .multiply: lhs * rhs
+    case .divide where rhs == 0: throw .divide
+    case .divide: lhs / rhs
+    }
+    guard result.isFinite else {
+      throw .magnitude("double result is not finite")
+    }
+    return .double(result)
   }
 }
 
@@ -339,13 +396,21 @@ extension Comparison {
 ///
 /// A `NULL` on either side is UNKNOWN (`nil`): `NULL` is unordered and unequal
 /// to everything, itself included, so no comparison against it is ever true or
-/// false. A like-typed non-null pair compares — two integers, two strings, two
-/// booleans (`false < true`), or two blobs (byte equality, lexicographic
-/// order); a cross-typed pair (an integer against a string) never matches.
-private func matches(_ lhs: Value, _ op: Comparison, _ rhs: Value) -> Bool? {
+/// false. A like-typed non-null pair compares — two integers, two doubles, two
+/// strings, two booleans (`false < true`), or two blobs (byte equality,
+/// lexicographic order). An integer against a double is numeric too — both
+/// sides are numbers — so the integer promotes to `Double` and they compare by
+/// magnitude (`1 = 1.0` is true); only a cross-*kind* pair (a number against a
+/// string) never matches.
+internal func matches(_ lhs: Value, _ op: Comparison, _ rhs: Value) -> Bool? {
   switch (lhs, rhs) {
   case (.null, _), (_, .null): nil
   case let (.integer(lhs), .integer(rhs)): op.apply(lhs, rhs)
+  case let (.double(lhs), .double(rhs)): op.apply(lhs, rhs)
+  // A mixed integer/double pair is numeric, not cross-type: promote the integer
+  // to `Double` and compare by magnitude, so `1 = 1.0` and `1 < 1.5`.
+  case let (.integer(lhs), .double(rhs)): op.apply(Double(lhs), rhs)
+  case let (.double(lhs), .integer(rhs)): op.apply(lhs, Double(rhs))
   case let (.text(lhs), .text(rhs)): op.apply(lhs, rhs)
   // `Bool` is not `Comparable`, so compare on its truth ordinal — `false` is
   // `0`, `true` is `1` — which orders `false < true` and equates like values.

--- a/Sources/SQL/Lexer.swift
+++ b/Sources/SQL/Lexer.swift
@@ -144,7 +144,7 @@ internal struct Lexer: ~Escapable {
       return try parameter()
 
     case let b where digit(b):
-      return try integer()
+      return try number()
 
     case let b where initial(b):
       return identifier()
@@ -260,14 +260,59 @@ internal struct Lexer: ~Escapable {
                  location: start)
   }
 
-  /// Scans an integer literal at the current position.
-  private mutating func integer() throws(SQLError) -> Token {
+  /// Scans a numeric literal at the current position — an integer or a decimal.
+  ///
+  /// A bare run of digits is an `integer`. A `.` fraction and/or an `e`/`E`
+  /// exponent makes it a `decimal` (an approximate-numeric `Double`): `3.14`,
+  /// `1.0`, `1e3`, `2.5e-1`. The `.` and exponent are each consumed only when a
+  /// digit follows — a `.` with no fraction digit (`1.`) leaves the `.` for the
+  /// caller and scans the leading integer, and an `e` with no exponent digit is
+  /// not an exponent — so a qualified reference is never misread as a float (an
+  /// identifier's leading `.` never reaches here: it begins with a letter, not
+  /// a digit). An integer past the `Int` boundary faults; a decimal does not
+  /// (an out-of-range magnitude is IEEE `inf`).
+  private mutating func number() throws(SQLError) -> Token {
     let start = location
     while let byte = peek(), digit(byte) {
       advance()
     }
 
+    var decimal = false
+    // A `.` is a fraction only when a digit follows; otherwise it is not part
+    // of the number (a lone `1.` scans as the integer `1`).
+    if peek() == UInt8(ascii: "."), let next = peek(1), digit(next) {
+      decimal = true
+      advance()
+      while let byte = peek(), digit(byte) {
+        advance()
+      }
+    }
+
+    // An `e`/`E` exponent takes an optional sign then at least one digit; short
+    // of that it is not an exponent and the number ends before the `e`.
+    if peek() == UInt8(ascii: "e") || peek() == UInt8(ascii: "E") {
+      let sign = peek(1) == UInt8(ascii: "+") || peek(1) == UInt8(ascii: "-")
+      if let next = peek(sign ? 2 : 1), digit(next) {
+        decimal = true
+        advance()
+        if sign { advance() }
+        while let byte = peek(), digit(byte) {
+          advance()
+        }
+      }
+    }
+
     let text = String(bytes, start.offset ..< position)
+    if decimal {
+      // `Double` never returns nil for lexer-shaped digits, but it yields `inf`
+      // for a magnitude past its range (`1e9999`); reject that as an overflow —
+      // like an out-of-range integer literal — so no `inf` (and thus no `inf -
+      // inf` NaN) enters the engine.
+      guard let value = Double(text), value.isFinite else {
+        throw .overflow(text, at: start)
+      }
+      return Token(kind: .decimal(value), location: start)
+    }
     guard let value = Int(text) else {
       throw .overflow(text, at: start)
     }

--- a/Sources/SQL/Operator.swift
+++ b/Sources/SQL/Operator.swift
@@ -337,8 +337,8 @@ private func union<C: Catalog & ~Escapable>(_ left: Plan, _ right: Plan,
   guard !all else { return rows }
 
   var records = Array<Record>()
-  var seen = Set<Record>()
-  for record in rows where seen.insert(record).inserted {
+  var seen = Seen()
+  for record in rows where seen.insert(record.values) {
     records.append(record)
   }
   return records
@@ -483,6 +483,52 @@ private func sift(_ outer: Array<Record>, _ inner: Array<Record>,
 /// to nothing, and every path preserves outer-major order, the inner matches in
 /// cursor order within each outer.
 ///
+/// The HASH-JOIN bucket a key falls in — a grouping key, NOT the equality. A
+/// numeric value buckets by its `Double` magnitude (an `.integer` promoted), so
+/// every value equal to it under `Filter.matches` shares a bucket: `1` and
+/// `1.0`, and an integer and the double it rounds to past 2^53. A non-numeric
+/// value (text, boolean, blob, null) buckets as itself. The bucket may over-
+/// group — two distinct large integers can share a `Double` bucket — so hash
+/// probing pairs it with a RESIDUAL `matches(_,.equal,_)` check, the same exact
+/// equality the predicate uses (integer/integer exact, mixed promoted). The
+/// seek and CTE nested-loop paths compare with `matches` directly.
+private func bucket(_ value: Value) -> Value {
+  if case let .integer(number) = value { return .double(Double(number)) }
+  return value
+}
+
+/// A value folded to its EXACT canonical form for duplicate elimination: a
+/// whole `double` exactly equal to an `Int` (`Int(exactly:)`) becomes that
+/// `.integer`, so `1.0` and `1` are the same value; every other value (a
+/// fractional double, text, boolean, blob, null) is itself. Unlike the join's
+/// promoted `bucket`, this is EXACT and transitive, so two integers stay
+/// distinct even when they round to the same double — an earlier approximate
+/// row cannot absorb two unequal exact integers.
+private func canonical(_ value: Value) -> Value {
+  if case let .double(number) = value, let integer = Int(exactly: number) {
+    return .integer(integer)
+  }
+  return value
+}
+
+/// Tracks the rows already emitted for UNION / recursive-CTE duplicate
+/// elimination under the engine's EXACT numeric equality. A plain
+/// `Set<Array<Value>>` over raw cells keeps `1` and `1.0` (and would keep both)
+/// apart; keying each row by its cells' `canonical` form — exact and transitive
+/// — dedups `1`/`1.0` while keeping distinct integers separate even when they
+/// round to the same double, and (unlike a promoted key) makes the result
+/// independent of arm order. Two NULLs stay not distinct (`.null` is its own
+/// canonical). No residual check needed: exact equality is an equivalence.
+internal struct Seen {
+  private var keys = Set<Array<Value>>()
+
+  /// Records `row` and reports whether it was NEW (not a duplicate of one
+  /// already seen) — the `Set.insert(_:).inserted` shape the dedup sites use.
+  internal mutating func insert(_ row: Array<Value>) -> Bool {
+    keys.insert(row.map(canonical)).inserted
+  }
+}
+
 /// - Throws: `SQLError.relation` if the inner name resolves to neither.
 private func join<C: Catalog & ~Escapable>(_ outer: Array<Record>,
                                            _ name: String,
@@ -525,6 +571,10 @@ private func join<C: Catalog & ~Escapable>(_ outer: Array<Record>,
     // A NULL key equi-joins to nothing — NULL is unequal to every value,
     // itself included — so it contributes no pair and need not probe.
     if case .null = value { continue }
+    // Seek by the RAW value — the sorted key is a single-kind (integer) column,
+    // and a promoted double would defeat the seek; the numeric equality below
+    // still admits a mixed-kind match (a whole double past the range is caught
+    // by the residual check even if the seek scanned wide).
     let range = probe(inner, column, value, cursor.count)
     for index in range {
       guard let row = cursor.row(index) else { continue }
@@ -533,7 +583,10 @@ private func join<C: Catalog & ~Escapable>(_ outer: Array<Record>,
       // it can pair — an inner row it rejects joins to nothing.
       if let filter,
           try evaluate(filter, right, routines, bindings) != true { continue }
-      if right[slot] == value {
+      // Equal by the SAME rule the predicate uses — integer/integer exact,
+      // mixed integer/double promoted — so a seek that scanned wide still pairs
+      // exactly.
+      if matches(value, .equal, right[slot]) == true {
         records.append(left.merged(with: right))
       }
     }
@@ -593,16 +646,19 @@ private func hashed<T: Table & ~Escapable>(_ outer: Array<Record>,
     // never a join candidate.
     if let filter,
         try evaluate(filter, right, routines, bindings) != true { continue }
-    let key = right[slot]
-    if case .null = key { continue }
-    buckets[key, default: Array<Record>()].append(right)
+    if case .null = right[slot] { continue }
+    buckets[bucket(right[slot]), default: Array<Record>()].append(right)
   }
 
   var records = Array<Record>()
   for left in outer {
     let value = left[keys.left]
     if case .null = value { continue }
-    for right in buckets[value] ?? [] {
+    // Probe the bucket, then confirm each candidate with the exact `matches`
+    // equality — the bucket over-groups (two distinct large integers can share
+    // a `Double` bucket), so the residual check keeps integer/integer exact.
+    for right in buckets[bucket(value)] ?? []
+        where matches(value, .equal, right[slot]) == true {
       records.append(left.merged(with: right))
     }
   }
@@ -621,7 +677,9 @@ private func joined(_ outer: Array<Record>, _ inner: Array<Record>,
   for left in outer {
     let value = left[keys.left]
     if case .null = value { continue }
-    for right in inner where right[slot] == value {
+    // The same exact/promoted equality the predicate and the other join paths
+    // use — integer/integer exact, mixed integer/double promoted.
+    for right in inner where matches(value, .equal, right[slot]) == true {
       records.append(left.merged(with: right))
     }
   }
@@ -690,9 +748,37 @@ internal func less(_ lhs: Value, _ rhs: Value) -> Bool {
   case (.null, _): true
   case (_, .null): false
   case let (.integer(lhs), .integer(rhs)): lhs < rhs
+  case let (.double(lhs), .double(rhs)): lhs < rhs
+  // A mixed integer/double key is numeric and ordered by magnitude — but
+  // EXACTLY, not via a lossy `Double(integer)`. Past 2^53 a promotion ties a
+  // double with two distinct integers that themselves order exactly, which
+  // would make this comparator non-transitive (not a strict weak ordering);
+  // the exact form breaks the tie by the integer the double denotes.
+  case let (.integer(lhs), .double(rhs)): less(integer: lhs, double: rhs)
+  case let (.double(lhs), .integer(rhs)): less(double: lhs, integer: rhs)
   case let (.text(lhs), .text(rhs)): lhs < rhs
   case let (.boolean(lhs), .boolean(rhs)): !lhs && rhs
   case let (.blob(lhs), .blob(rhs)): lhs.lexicographicallyPrecedes(rhs)
   default: false
   }
+}
+
+/// Whether integer `lhs` is strictly less than double `rhs`, compared EXACTLY.
+/// `Double(lhs) < rhs` decides it unless the two tie under promotion — then
+/// `rhs` is integral and denotes an exact integer (`Int(exactly:)`) the
+/// integers compare against, so a value past 2^53 orders by its true magnitude.
+private func less(integer lhs: Int, double rhs: Double) -> Bool {
+  let promoted = Double(lhs)
+  guard promoted == rhs else { return promoted < rhs }
+  guard let exact = Int(exactly: rhs) else { return false }
+  return lhs < exact
+}
+
+/// Whether double `lhs` is strictly less than integer `rhs`, compared EXACTLY —
+/// the mirror of `less(integer:double:)`.
+private func less(double lhs: Double, integer rhs: Int) -> Bool {
+  let promoted = Double(rhs)
+  guard lhs == promoted else { return lhs < promoted }
+  guard let exact = Int(exactly: lhs) else { return false }
+  return exact < rhs
 }

--- a/Sources/SQL/Parser.swift
+++ b/Sources/SQL/Parser.swift
@@ -393,9 +393,9 @@ internal struct Parser: ~Escapable {
     return lhs
   }
 
-  /// Parses an arithmetic factor: a parenthesised expression, a string/integer
-  /// literal, a function call (`name(args)`), or a bare (possibly-qualified)
-  /// column.
+  /// Parses an arithmetic factor: a parenthesised expression, a string,
+  /// integer, or decimal literal, a function call (`name(args)`), or a bare
+  /// (possibly-qualified) column.
   ///
   /// Parentheses override the precedence the cascade encodes. A function call is
   /// an identifier immediately followed by `(`; an identifier not so followed is
@@ -414,6 +414,10 @@ internal struct Parser: ~Escapable {
     if case let .integer(value) = current?.kind {
       _ = try advance(expecting: "a literal")
       return .literal(.integer(value))
+    }
+    if case let .decimal(value) = current?.kind {
+      _ = try advance(expecting: "a literal")
+      return .literal(.double(value))
     }
 
     let ident = try name()
@@ -534,12 +538,13 @@ internal struct Parser: ~Escapable {
     }
   }
 
-  /// Parses a string or integer literal.
+  /// Parses a string, integer, or decimal literal.
   private mutating func literal() throws(SQLError) -> Literal {
     let token = try advance(expecting: "a literal")
     return switch token.kind {
     case let .string(value): .string(value)
     case let .integer(value): .integer(value)
+    case let .decimal(value): .double(value)
     default:
       throw .unexpected(token.kind.description,
                         expected: "a literal", at: token.location)

--- a/Sources/SQL/Resolve.swift
+++ b/Sources/SQL/Resolve.swift
@@ -72,7 +72,7 @@ extension Schema {
     case let .column(column):
       return try .slot(ordinal(of: column, in: relation))
     case let .literal(literal):
-      return .constant(value(of: literal))
+      return try .constant(value(of: literal))
     case let .call(name, arguments):
       var lowered = Array<Term>()
       lowered.reserveCapacity(arguments.count)
@@ -225,7 +225,7 @@ internal struct Scope {
     case let .column(column):
       return try .slot(ordinal(of: column))
     case let .literal(literal):
-      return .constant(value(of: literal))
+      return try .constant(value(of: literal))
     case let .call(name, arguments):
       var lowered = Array<Term>()
       lowered.reserveCapacity(arguments.count)

--- a/Sources/SQL/Token.swift
+++ b/Sources/SQL/Token.swift
@@ -50,7 +50,11 @@ extension Token {
     /// a bare `identifier` a dot in it is part of the name, not a qualifier.
     case quoted(String)
     case string(String)
+    /// A bare integer literal — a run of digits with no fraction or exponent.
     case integer(Int)
+    /// An approximate-numeric literal — a decimal with a `.` fraction and/or an
+    /// exponent (`3.14`, `1.0`, `1e3`, `2.5e-1`), scanned into a `Double`.
+    case decimal(Double)
     /// A bound parameter placeholder `:name`, holding the parameter's name.
     case parameter(String)
 
@@ -105,6 +109,7 @@ extension Token.Kind {
     case let .quoted(name): "\"\(name)\""
     case let .string(value): "'\(value)'"
     case let .integer(value): "\(value)"
+    case let .decimal(value): "\(value)"
     case let .parameter(name): ":\(name)"
     case .star: "*"
     case .plus: "+"

--- a/Sources/winmd-inspect/Shell.swift
+++ b/Sources/winmd-inspect/Shell.swift
@@ -1093,6 +1093,11 @@ extension Value {
     switch self {
     case .null:                 ""
     case let .integer(integer): "\(integer)"
+    // A double renders through Swift's default `Double` description — the
+    // shortest decimal that round-trips to the same binary64 — so it is
+    // lossless and keeps a `.0` on a whole value (`1.0`, not `1`), marking the
+    // cell approximate-numeric rather than an integer.
+    case let .double(double):   "\(double)"
     case let .text(text):       text
     case let .boolean(boolean): boolean ? "TRUE" : "FALSE"
     // A blob renders as a lowercase-hex `x'…'` literal — lowercase `x` and

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -2825,7 +2825,7 @@ struct EngineArithmeticTests {
 
   @Test("a text operand faults as a type error")
   func textOperand() throws {
-    #expect(throws: SQLError.operand("operands must be integers")) {
+    #expect(throws: SQLError.operand("operands must be numeric")) {
       try run("SELECT Name + 1 FROM People WHERE Id = 1")
     }
   }
@@ -2987,6 +2987,95 @@ struct EngineWithTests {
           SELECT Label FROM adults
         """, family())
     #expect(rows == [[.text("Bee")], [.text("Cid")]])
+  }
+
+  @Test("a JOIN matches an integer key to an equal double key")
+  func numericJoin() throws {
+    // The optimized join paths (hash bucket, seek/final check, CTE nested loop)
+    // must use the same mixed-numeric equality a predicate does: `1` and `1.0`
+    // are equal, so the row joins rather than being dropped by a raw-`Value`
+    // key comparison.
+    let rows = try statement("""
+        WITH a (x) AS (SELECT 1), b (x) AS (SELECT 1.0)
+          SELECT * FROM a JOIN b ON a.x = b.x
+        """, family())
+    #expect(rows == [[.integer(1), .double(1.0)]])
+  }
+
+  @Test("a JOIN matches a large integer to its rounded double past 2^53")
+  func numericJoinBeyondExactRange() throws {
+    // Above 2^53 an integer is not exactly representable as `Double`; the
+    // predicate treats `9007199254740993` and `9007199254740993.0` as equal by
+    // promoting the integer to `Double` (both round to 2^53), so the optimized
+    // join must too — a fold-double-to-Int key would drop the row.
+    let rows = try statement("""
+        WITH a (x) AS (SELECT 9007199254740993),
+             b (x) AS (SELECT 9007199254740993.0)
+          SELECT a.x FROM a JOIN b ON a.x = b.x
+        """, family())
+    #expect(rows == [[.integer(9007199254740993)]])
+  }
+
+  @Test("a JOIN keeps distinct large integer keys unequal (exact integers)")
+  func integerJoinStaysExact() throws {
+    // Two integers that round to the SAME Double past 2^53 are still unequal as
+    // integers, so an integer/integer join must NOT pair them — the hash bucket
+    // may collide, but the residual `matches` check keeps integer equality
+    // exact.
+    let rows = try statement("""
+        WITH a (x) AS (SELECT 9007199254740992),
+             b (x) AS (SELECT 9007199254740993)
+          SELECT a.x FROM a JOIN b ON a.x = b.x
+        """, family())
+    #expect(rows.isEmpty)
+  }
+
+  @Test("UNION deduplicates numerically-equal rows across kinds")
+  func unionNumericDedup() throws {
+    // `1` and `1.0` are the same numeric value, so UNION keeps one — the first
+    // arm's — not both; the dedup uses the numeric equality, not raw `Value`.
+    #expect(try statement("SELECT 1 UNION SELECT 1.0", family())
+            == [[.integer(1)]])
+    // UNION ALL keeps every row.
+    #expect(try statement("SELECT 1 UNION ALL SELECT 1.0", family())
+            == [[.integer(1)], [.double(1.0)]])
+  }
+
+  @Test("UNION dedup keeps distinct integers a rounded double sits between")
+  func unionExactIntegers() throws {
+    // Dedup is EXACT: `2^53.0` equals the integer `2^53` (folds to it), but NOT
+    // the integer `2^53 + 1`. So an earlier approximate row must not absorb
+    // both distinct integers — the `2^53 + 1` row survives regardless of order.
+    let rows = try statement("""
+        SELECT 9007199254740992.0
+          UNION SELECT 9007199254740992
+          UNION SELECT 9007199254740993
+        """, family())
+    #expect(rows == [[.double(9007199254740992.0)],
+                     [.integer(9007199254740993)]])
+  }
+
+  @Test("ORDER BY orders mixed integer/double keys by magnitude")
+  func orderByMixedNumeric() throws {
+    let rows = try statement("""
+        WITH a (x) AS (SELECT 3 UNION ALL SELECT 1.5) SELECT x FROM a ORDER BY x
+        """, family())
+    #expect(rows == [[.double(1.5)], [.integer(3)]])
+  }
+
+  @Test("ORDER BY over mixed keys past 2^53 stays a total order")
+  func orderByMixedNumericBeyondExactRange() throws {
+    // A double ties two distinct integers under promotion; the comparator must
+    // stay a strict weak ordering (transitive), keeping the larger integer last
+    // rather than misordering it ahead of the smaller via the stable tie-break.
+    let rows = try statement("""
+        WITH a (x) AS (SELECT 9007199254740993
+                       UNION ALL SELECT 9007199254740993.0
+                       UNION ALL SELECT 9007199254740992)
+          SELECT x FROM a ORDER BY x
+        """, family())
+    #expect(rows.count == 3)
+    #expect(rows.last == [.integer(9007199254740993)])
   }
 
   @Test("a CTE infers its columns and filters on them")

--- a/Tests/SQLTests/ErrorTests.swift
+++ b/Tests/SQLTests/ErrorTests.swift
@@ -65,10 +65,10 @@ struct SQLStateTests {
     #expect(SQLError.argument("bad").sqlstate == "22023")
   }
 
-  @Test("a non-integer arithmetic operand reports 42804")
+  @Test("a non-numeric arithmetic operand reports 42804")
   func operand() {
     #expect(
-        SQLError.operand("operands must be integers").sqlstate == "42804")
+        SQLError.operand("operands must be numeric").sqlstate == "42804")
   }
 
   @Test("an engine-specific condition reports the SwiftSQL SS class")

--- a/Tests/SQLTests/FloatTests.swift
+++ b/Tests/SQLTests/FloatTests.swift
@@ -1,0 +1,231 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQL
+
+// MARK: - Harness
+
+/// A one-cell row that yields a fixed `Value` at slot `0` — the minimal `Row`
+/// that drives the comparison and arithmetic choke points (`matches` and
+/// `Arithmetic.apply`, reached through `evaluate`) over a `double` cell without
+/// a whole relation.
+///
+/// The source carries no borrowed storage, so it omits `@_lifetime`.
+private struct Cell: Row {
+  let value: Value
+
+  init(_ value: Value) {
+    self.value = value
+  }
+
+  subscript(_ column: Int) -> Value {
+    borrowing get { value }
+  }
+}
+
+/// Evaluates `cell op constant` through the engine's three-valued comparison —
+/// `true`, `false`, or `nil` (UNKNOWN) — the path a real `WHERE` takes.
+private func compare(_ cell: Value, _ op: Comparison,
+                     _ constant: Value) -> Bool? {
+  try! evaluate(.compare(.slot(0), op, .constant(constant)),
+                Cell(cell), Routines(), [:])
+}
+
+/// Evaluates `lhs op rhs` through the engine's arithmetic — a typed `Value`, or
+/// a thrown `SQLError` (a divide by zero, a non-numeric operand).
+private func arithmetic(_ lhs: Value, _ op: Arithmetic,
+                        _ rhs: Value) throws(SQLError) -> Value {
+  try evaluate(.binary(op, .constant(lhs), .constant(rhs)),
+               Cell(.null), Routines())
+}
+
+// MARK: - Comparison
+
+@Suite("DOUBLE comparison")
+private struct DoubleComparisonTests {
+  @Test("like doubles compare by magnitude")
+  func equality() {
+    #expect(compare(.double(1.5), .equal, .double(1.5)) == true)
+    #expect(compare(.double(1.5), .equal, .double(2.5)) == false)
+    #expect(compare(.double(1.5), .unequal, .double(2.5)) == true)
+  }
+
+  @Test("doubles order by magnitude")
+  func ordering() {
+    #expect(compare(.double(1.5), .lt, .double(2.5)) == true)
+    #expect(compare(.double(2.5), .lt, .double(1.5)) == false)
+    #expect(compare(.double(2.5), .gt, .double(1.5)) == true)
+    #expect(compare(.double(1.5), .leq, .double(1.5)) == true)
+    #expect(compare(.double(2.5), .geq, .double(2.5)) == true)
+  }
+}
+
+// MARK: - Mixed integer/double
+
+@Suite("mixed integer/double comparison")
+private struct MixedComparisonTests {
+  @Test("an integer equals a like-valued double — numeric, not cross-type")
+  func numericEquality() {
+    // Both operands are numeric, so `1 = 1.0` is TRUE, not a cross-kind miss.
+    #expect(compare(.integer(1), .equal, .double(1.0)) == true)
+    #expect(compare(.double(1.0), .equal, .integer(1)) == true)
+    #expect(compare(.integer(2), .equal, .double(2.5)) == false)
+    #expect(compare(.integer(1), .unequal, .double(1.5)) == true)
+  }
+
+  @Test("an integer orders against a double by magnitude")
+  func numericOrdering() {
+    #expect(compare(.integer(1), .lt, .double(1.5)) == true)
+    #expect(compare(.double(1.5), .gt, .integer(1)) == true)
+    #expect(compare(.integer(2), .lt, .double(1.5)) == false)
+    #expect(compare(.double(0.5), .lt, .integer(1)) == true)
+  }
+}
+
+// MARK: - Arithmetic
+
+@Suite("DOUBLE arithmetic")
+private struct DoubleArithmeticTests {
+  @Test("double arithmetic yields a double")
+  func likeTyped() throws {
+    #expect(try arithmetic(.double(1.5), .add, .double(2.0)) == .double(3.5))
+    #expect(try arithmetic(.double(2.5), .subtract, .double(1.0))
+                == .double(1.5))
+    #expect(try arithmetic(.double(1.5), .multiply, .double(2.0))
+                == .double(3.0))
+  }
+
+  @Test("double division is real, not truncated")
+  func realDivision() throws {
+    #expect(try arithmetic(.double(5.0), .divide, .double(2.0))
+                == .double(2.5))
+  }
+
+  @Test("a mixed integer/double is numeric and yields a double")
+  func mixed() throws {
+    // `5 / 2.0` is real division `2.5`, and `2 * 1.5` is `3.0` — the integer
+    // promotes to `Double`, so the result is approximate-numeric.
+    #expect(try arithmetic(.integer(5), .divide, .double(2.0))
+                == .double(2.5))
+    #expect(try arithmetic(.integer(2), .multiply, .double(1.5))
+                == .double(3.0))
+    #expect(try arithmetic(.double(1.5), .add, .integer(1))
+                == .double(2.5))
+  }
+
+  @Test("an integer pair still divides as integers")
+  func integerDivisionUnchanged() throws {
+    // The mixed-numeric widening does not touch the exact-numeric path: `5 / 2`
+    // is still `2`, not `2.5`.
+    #expect(try arithmetic(.integer(5), .divide, .integer(2)) == .integer(2))
+  }
+
+  @Test("a double divide by zero raises, matching the integer policy")
+  func divideByZero() {
+    #expect(throws: SQLError.divide) {
+      try arithmetic(.double(1.0), .divide, .double(0.0))
+    }
+    #expect(throws: SQLError.divide) {
+      try arithmetic(.double(1.0), .divide, .integer(0))
+    }
+  }
+
+  @Test("a non-finite double result is rejected, never returned")
+  func nonFinite() {
+    // An overflow to `inf` (a magnitude past `Double`'s range) faults rather
+    // than returning `inf`.
+    #expect(throws: SQLError.self) {
+      try arithmetic(.double(1e308), .multiply, .double(1e308))
+    }
+    // A NaN from an indeterminate form (`inf - inf`) faults — never returned,
+    // since NaN is unequal to itself and would break dedup and ordering.
+    #expect(throws: SQLError.self) {
+      try arithmetic(.double(.infinity), .subtract, .double(.infinity))
+    }
+  }
+
+  @Test("a non-finite double literal is rejected at lowering")
+  func nonFiniteLiteral() throws {
+    // A directly-built `Literal.double(.nan/.infinity)` (the lexer never makes
+    // one) is rejected when lowered to a `Value`, so no non-finite double
+    // enters a plan; a finite literal lowers unchanged.
+    #expect(throws: SQLError.self) { _ = try value(of: .double(.nan)) }
+    #expect(throws: SQLError.self) { _ = try value(of: .double(.infinity)) }
+    let finite = try value(of: .double(1.5))
+    #expect(finite == .double(1.5))
+  }
+
+  @Test("a routine returning a non-finite double is rejected")
+  func nonFiniteRoutine() {
+    // A registered routine is a public `Value` producer that bypasses the
+    // literal/arithmetic checks; a NaN or inf result is rejected at the call
+    // boundary so it never reaches dedup, ordering, or a recursive UNION.
+    let routines: Routines = ["nan": { _ in .double(.nan) },
+                              "huge": { _ in .double(.infinity) }]
+    #expect(throws: SQLError.self) {
+      try evaluate(.apply(name: "nan", arguments: []), Cell(.null), routines)
+    }
+    #expect(throws: SQLError.self) {
+      try evaluate(.apply(name: "huge", arguments: []), Cell(.null), routines)
+    }
+  }
+}
+
+// MARK: - NULL
+
+@Suite("DOUBLE NULL propagation")
+private struct DoubleNullTests {
+  @Test("a NULL operand is UNKNOWN in a comparison")
+  func comparison() {
+    #expect(compare(.double(1.5), .equal, .null) == nil)
+    #expect(compare(.double(1.5), .lt, .null) == nil)
+  }
+
+  @Test("a NULL operand propagates through arithmetic")
+  func propagation() throws {
+    #expect(try arithmetic(.double(1.5), .add, .null) == .null)
+    #expect(try arithmetic(.null, .multiply, .double(1.5)) == .null)
+  }
+}
+
+// MARK: - Sort
+
+@Suite("DOUBLE sort ordering")
+private struct DoubleSortTests {
+  @Test("doubles sort ascending by magnitude, NULL first")
+  func ordering() {
+    // `less` is the sort primitive: NULL precedes every value, and two doubles
+    // order by magnitude.
+    #expect(less(.double(1.5), .double(2.5)) == true)
+    #expect(less(.double(2.5), .double(1.5)) == false)
+    #expect(less(.null, .double(1.5)) == true)
+    #expect(less(.double(1.5), .null) == false)
+  }
+
+  @Test("a mixed integer/double slot sorts by magnitude")
+  func mixed() {
+    // A slot that happens to mix exact and approximate numerics still orders by
+    // magnitude rather than tying at the kind boundary.
+    #expect(less(.integer(1), .double(1.5)) == true)
+    #expect(less(.double(1.5), .integer(2)) == true)
+    #expect(less(.double(2.5), .integer(2)) == false)
+  }
+}
+
+// MARK: - Literal
+
+@Suite("DOUBLE literal parsing")
+private struct DoubleLiteralTests {
+  @Test("a decimal literal lowers to a double value")
+  func fraction() throws {
+    let lowered = try value(of: .double(3.14))
+    #expect(lowered == .double(3.14))
+  }
+
+  @Test("an integer literal stays an integer value")
+  func integer() throws {
+    let lowered = try value(of: .integer(3))
+    #expect(lowered == .integer(3))
+  }
+}

--- a/Tests/SQLTests/LexerTests.swift
+++ b/Tests/SQLTests/LexerTests.swift
@@ -89,6 +89,56 @@ struct LexerTests {
                 == [.integer(0), .integer(42), .integer(1024)])
   }
 
+  @Test("lexes decimal literals with a fraction")
+  func decimalFraction() throws {
+    #expect(try lex("3.14 1.0 0.5")
+                == [.decimal(3.14), .decimal(1.0), .decimal(0.5)])
+  }
+
+  @Test("lexes decimal literals with an exponent")
+  func decimalExponent() throws {
+    // A bare integer with an exponent is approximate-numeric, as is one with a
+    // signed exponent or a fraction and an exponent together.
+    #expect(try lex("1e3 2.5e-1 6E2 1.5e+2")
+                == [.decimal(1e3), .decimal(2.5e-1),
+                    .decimal(6e2), .decimal(1.5e2)])
+  }
+
+  @Test("a bare run of digits stays an integer")
+  func integerNotDecimal() throws {
+    // Neither a `.` nor an `e` follows, so each is exact numeric.
+    #expect(try lex("7 100") == [.integer(7), .integer(100)])
+  }
+
+  @Test("a dot fraction is taken only when a digit follows")
+  func fractionRequiresDigit() throws {
+    // A `.` begins a fraction only before a digit: `1.5` is one decimal, while
+    // `1.5e0` also folds the exponent in.
+    #expect(try lex("1.5") == [.decimal(1.5)])
+    #expect(try lex("1.5e0") == [.decimal(1.5)])
+  }
+
+  @Test("an e with no exponent digit is not an exponent")
+  func bareExponentLetter() throws {
+    // `1e` has no exponent digit, so the number ends at `1` and `e` begins an
+    // identifier.
+    #expect(try lex("1e") == [.integer(1), .identifier("e")])
+  }
+
+  @Test("a decimal literal past Double's range is an overflow")
+  func decimalOverflow() {
+    // `Double("1e9999")` is `inf`, not nil — reject it as an overflow, like an
+    // out-of-range integer, so no `inf` enters the token stream.
+    #expect(throws: SQLError.self) { _ = try lex("1e9999") }
+  }
+
+  @Test("a qualified reference is not read as a decimal")
+  func qualifiedReference() throws {
+    // A qualified name begins with a letter, so it never enters the numeric
+    // scanner — `Field.Flags` is one identifier, dot and all.
+    #expect(try lex("Field.Flags") == [.identifier("Field.Flags")])
+  }
+
   @Test("lexes a quoted string literal")
   func stringLiteral() throws {
     #expect(try lex("'Windows.Win32.Foundation'")

--- a/Tests/winmd-inspectTests/ValueDisplayTests.swift
+++ b/Tests/winmd-inspectTests/ValueDisplayTests.swift
@@ -18,6 +18,23 @@ private struct BooleanDisplayTests {
   }
 }
 
+// MARK: - Double
+
+@Suite("DOUBLE display")
+private struct DoubleDisplayTests {
+  @Test("a double renders through its round-tripping description")
+  func description() {
+    #expect(Value.double(3.14).display == "3.14")
+    #expect(Value.double(2.5).display == "2.5")
+  }
+
+  @Test("a whole double keeps its .0, marking it approximate-numeric")
+  func whole() {
+    #expect(Value.double(1.0).display == "1.0")
+    #expect(Value.double(1000.0).display == "1000.0")
+  }
+}
+
 // MARK: - Blob
 
 @Suite("BLOB display")


### PR DESCRIPTION
Extend the engine's `Value`/`ValueKind` with a `double` — the standard-SQL `FLOAT`/`REAL`/`DOUBLE PRECISION`, a binary64 `Double` — the exact-numeric `integer`'s approximate-numeric companion. `Double` is `Hashable`, `Sendable`, and `Comparable`, so a double rides the generic `Comparison.apply` and the value keeps its conformances.

Unlike the boolean/blob additions, a double is not walled off from the other numeric kind: an `integer` and a `double` are both numbers, so a mixed pair is numeric rather than cross-type. `matches` promotes the integer to `Double` and compares by magnitude — `1 = 1.0` is TRUE, `1 < 1.5` is TRUE — reaching the switch's `default: false` only for a number against a non-number. The sort helper `less` promotes the same way so a slot mixing the two orders by magnitude rather than tying at the kind boundary.

`Arithmetic.apply` splits into an integer overload (unchanged: exact, with `/` integer division and `Int`-boundary overflow reporting) and a double overload (real division, no truncation, no boundary — an out-of-range magnitude is IEEE `inf`). Any double operand widens the pair to double arithmetic with a lone integer promoted, so `2 * 1.5` is `3.0` and `5 / 2.0` is `2.5`, while `5 / 2` stays the integer `2`. Division by zero still raises `SQLError.divide` on either kind of divisor rather than yielding `inf`/`NaN`, matching the integer policy; a non-numeric operand is now `operands must be numeric`, broadening the former integers-only message (its `42804` SQLSTATE is unchanged). NULL propagates as before.

The lexer's numeric scanner (`integer()` renamed `number()`) now recognises a decimal literal: a `.` fraction and/or an `e`/`E` exponent (`3.14`, `1.0`, `1e3`, `2.5e-1`) scans into a new `.decimal(Double)` token, a bare run of digits stays `.integer`. The `.` and the exponent are each taken only before a digit, so a lone `1.` scans the integer `1`, an `e` with no exponent digit ends the number, and a qualified reference — always letter-led, so never entering the numeric scanner — is never misread as a float. The parser lowers a `.decimal` token to `Expression.literal(.double(...))`.

The shell renders a double through Swift's default `Double` description — the shortest decimal that round-trips to the same binary64 — so it is lossless and keeps a `.0` on a whole value (`1.0`, not `1`), marking the cell approximate-numeric.

AVG and the other aggregates are untouched; a double result there is a follow-on.