### PR TITLE
winmd-inspect: replace the `parent` pseudo-column with owner FK columns

### DIFF
--- a/Documentation/QueryModel.md
+++ b/Documentation/QueryModel.md
@@ -133,32 +133,37 @@ name through the borrowed catalog:
 
 ### Joins over foreign keys and lists
 
-The WinMD adapter exposes two **virtual columns** past each relation's real
-fields, at ordinals outside the `SELECT *` range so a `*` never projects them:
+The WinMD adapter exposes **virtual columns** past each relation's real fields,
+at ordinals outside the `SELECT *` range so a `*` never projects them:
 
-- `Id` — the 1-based row identity. A foreign key is a real column
-  holding a target row's `Id`, so an equi-join over it is an ordinary FK
+- `Id` — the 1-based row identity, on every relation. A foreign key is a real
+  column holding a target row's `Id`, so an equi-join over it is an ordinary FK
   join — the child's foreign-key column against the parent's `Id`:
   `SELECT i.Interface FROM InterfaceImpl i JOIN TypeDef t ON i.Class = t.Id`,
   where `InterfaceImpl.Class` is a simple index into `TypeDef`.
-- `parent` — a list-child's owning parent's `Id`. A list relationship (a
+- an **owner foreign key** — on a list-owned child only, a column named for its
+  owning table whose value is the owning row's `Id`. A list relationship (a
   parent's run of children, e.g. `TypeDef.MethodList → MethodDef`) is not a
-  stored key, so the child relates to its owner through the computed `parent`
-  column against the parent's `Id`:
-  `SELECT m.Name FROM TypeDef t JOIN MethodDef m ON m.parent = t.Id`.
+  stored key, so the child relates to its owner through this named FK column
+  against the owner's `Id` — reading as an ordinary FK join:
+  `SELECT m.Name FROM TypeDef t JOIN MethodDef m ON m.TypeDef = t.Id`. The five
+  are `FieldDef.TypeDef`, `MethodDef.TypeDef`, `Param.MethodDef`,
+  `EventDef.EventMap`, and `PropertyDef.PropertyMap`.
 
 A *coded* index column (e.g. `TypeDef.Extends`, a `TypeDefOrRef`) exposes its
 raw encoded value — the packed row-plus-tag token — not a bare row id, so
 relating it to a target table's `Id` must be spelled out explicitly.
 
-A real column always takes precedence over a same-named pseudo-column, as in
-SQLite: a table that has its own `Parent` field (`EventMap`, `PropertyMap`,
-`ClassLayout`, …) resolves `Parent` to that real foreign key, so the virtual
-`parent` reaches only the list-child tables that have no real `Parent` field.
+An owner FK is named for its owning table, which never collides with a real
+field: no list-child schema carries a field spelled like its owner's table. A
+table with its own `Parent` field (`EventMap`, `PropertyMap`, `ClassLayout`, …)
+is unaffected — `Parent` is that real foreign key, and such a table owns no
+list, so it has no owner-FK column.
 
-Both virtual columns are seekable — `Id` is dense and monotonic, `parent` is
-monotonic over a list-child's runs — so the engine's index-nested-loop join
-seeks them through the same `bound` path it uses for an intrinsic sort key. The
+Both `Id` and an owner FK are seekable — `Id` is dense and monotonic, an owner
+FK is monotonic over a list-child's runs — so the engine's index-nested-loop
+join seeks them through the same `bound` path it uses for an intrinsic sort key.
+The
 adapter, not the engine, knows that a WinMD foreign key or list run *is* a join;
 the engine sees only seekable columns and equi-join predicates.
 
@@ -213,7 +218,7 @@ Heap columns read through their tokens: a `#Strings` or `#GUID` column through
 the `Column` value token (`row[.TypeName]`), a `#Blob` column through the
 `BlobColumn` token (`row[token]`, or `row.blob(token)` for the validating
 read). The SQL engine reaches the same foreign-key and list joins through the
-adapter's `Id`/`parent` virtual columns described above.
+adapter's `Id` and owner-foreign-key virtual columns described above.
 
 ## Complexity
 

--- a/Documentation/SynthesisModel.md
+++ b/Documentation/SynthesisModel.md
@@ -20,7 +20,7 @@ it.
 | Layer | Role (ANSI-SPARC) | What it is | Where it lives |
 | --- | --- | --- | --- |
 | Physical / internal | Internal schema | ECMA-335 tables, heaps, coded indices | `Sources/WinMD/` |
-| Conceptual | Conceptual schema | metadata as relations: real columns + `Id`/`parent` + decoded join keys | `Sources/winmd-inspect/Database+SQL.swift` |
+| Conceptual | Conceptual schema | metadata as relations: real columns + `Id`/owner FK + decoded join keys | `Sources/winmd-inspect/Database+SQL.swift` |
 | External | External schema | COM-interface *views* (`interfaces`/`methods`/`params`/`bases`) | `Sources/winmd-inspect/Resources/Queries/*.sql` |
 | Federation | Component-schema codecs | signature → type spelling; GuidAttribute blob → IID; coded index → join key | `Sources/WinMDSynthesis/`, the decoded columns in `Database+SQL.swift` |
 | Presentation | — | Mustache template rendering rows to source | `Sources/winmd-inspect/Shell.swift` |
@@ -34,7 +34,7 @@ just one `Catalog` it happens to run over.
         ▲
   External schema    interfaces / methods / params / bases   (SQL views)
         ▲
-  Conceptual schema  relations: real cols + Id/parent + <Col>_<Target> keys
+  Conceptual schema  relations: real cols + Id/owner FK + <Col>_<Target> keys
         ▲                                   (WinMD → SQL adapter)
         │  ── federation codecs ──  signature→type · blob→IID · coded-index→key
         ▼
@@ -126,16 +126,19 @@ A relation's **real columns** are its ECMA-335 fields (a `#Strings` cell typed
 - **`Id`** — the 1-based row identity, exposed by every relation.
   A simple foreign key is a real column holding a target's `Id`, so an
   equi-join over it is an ordinary FK join.
-- **`parent`** — a list-child's owning parent's `Id` (e.g.
-  `MethodDef`'s owning `TypeDef`), computed from the parent's run-length list
-  column. A list relationship is not a stored key, so the child relates to its
-  owner through this computed column. As in SQLite, a real `Parent` field always
-  shadows the virtual one, so `parent` reaches only the genuine list-child
-  tables.
+- **an owner foreign key** — on a list-owned child only, a column named for its
+  owning table whose value is the owning row's `Id` (e.g. `MethodDef.TypeDef`),
+  computed from the owner's run-length list column. A list relationship is not a
+  stored key, so the child relates to its owner through this named FK column.
+  The five are `FieldDef.TypeDef`, `MethodDef.TypeDef`, `Param.MethodDef`,
+  `EventDef.EventMap`, and `PropertyDef.PropertyMap`. The name never collides
+  with a real field, and a table with a real `Parent` field owns no list, so it
+  has no owner-FK column.
 
-Both virtual columns are **seekable** — `Id` is dense and monotonic, `parent`
-is monotonic over a child's runs — so the engine's index-nested-loop join seeks
-them through the same `bound` path it uses for an intrinsic sort key. The
+Both `Id` and an owner FK are **seekable** — `Id` is dense and monotonic, an
+owner FK is monotonic over a child's runs — so the engine's index-nested-loop
+join seeks them through the same `bound` path it uses for an intrinsic sort key.
+The
 adapter, not the engine, knows that a WinMD foreign key or list run *is* a join.
 
 ### Decoded columns — the federation codecs surfaced as relations
@@ -207,16 +210,18 @@ This is where the logical schema lives. The bundled views — the
   constructor uses, the three `UNION`ed: a cross-file `Type_MemberRef →
   MemberRef.Class_TypeRef → TypeRef`, and — because the metadata attributes are
   defined in the very file that applies them, so their constructor is local — two
-  same-file arms, `Type_MethodDef → MethodDef.parent → TypeDef` (the constructor
-  named directly as a `MethodDef`) and `Type_MemberRef → MemberRef.Class_TypeDef
-  → TypeDef` (named as a `MemberRef` back into the in-file `TypeDef`). All three
+  same-file arms, `Type_MethodDef → MethodDef.TypeDef → TypeDef` (the
+  constructor named directly as a `MethodDef`) and `Type_MemberRef →
+  MemberRef.Class_TypeDef → TypeDef` (named as a `MemberRef` back into the
+  in-file `TypeDef`). All three
   arms filter to the `GuidAttribute` declaring type and to a `tdInterface`
   carrier (`BITAND(Flags, 32) = 32`, so a GUID-bearing coclass is not mistaken
   for an interface), projecting `CustomAttribute.guid` as the `iid`.
 - **`methods`** and **`params`** — an interface's methods are the `MethodDef`
   rows it owns; a method's parameters are its `Param` rows. Each is a one-level
-  navigation correlated by `:parent` against the `parent` virtual column
-  (`WHERE parent = :parent`), bound per level by the render.
+  navigation correlated by `:parent` against the owner-FK column (`WHERE
+  TypeDef = :parent` for `methods`, `WHERE MethodDef = :parent` for `params`),
+  bound per level by the render.
 - **`bases`** — an interface's base *is its `InterfaceImpl`*. The view navigates
   the interface's `InterfaceImpl` rows (`i.Class = :parent`, a simple `TypeDef`
   index) to each base type's name by whichever coded-index arm the base uses, the

--- a/Sources/SQL/AST.swift
+++ b/Sources/SQL/AST.swift
@@ -165,8 +165,8 @@ public struct Relation: Hashable, Sendable {
 ///
 /// The `ON` equality is held as its two column references in source order —
 /// `left = right` — for the consumer to classify. The binding interprets the
-/// adapter-computed columns `Id` (every table's 1-based row identity) and
-/// `parent` (a list-child's owning row) within those references.
+/// adapter-computed columns `Id` (every table's 1-based row identity) and a
+/// list-child's owner foreign key within those references.
 public struct Join: Hashable, Sendable {
   /// The relation joined in.
   public let relation: Relation
@@ -189,8 +189,8 @@ public struct Join: Hashable, Sendable {
 ///
 /// A qualifier names a relation by its alias or its table name; an unqualified
 /// reference leaves the relation for the consumer to infer. The name may be a
-/// real column or one of the binding's adapter-computed columns (`Id`,
-/// `parent`); the AST does not distinguish them.
+/// real column or one of the binding's adapter-computed columns (`Id`, an owner
+/// foreign key); the AST does not distinguish them.
 ///
 /// `Column` is `ExpressibleByStringLiteral`, splitting a literal on its first
 /// dot into qualifier and name, so a consumer may write a reference as a plain

--- a/Sources/SQL/Adapter.swift
+++ b/Sources/SQL/Adapter.swift
@@ -142,17 +142,18 @@ public protocol Table: ~Escapable {
   ///
   /// A relation knows its own column names; the engine reads them to lift a
   /// base table's resolution onto an escapable `Schema` so a join may resolve a
-  /// view against a base table uniformly. The virtual columns (`Id`,
-  /// `parent`) are not in `names`; they resolve through `ordinal(of:)`.
+  /// view against a base table uniformly. The virtual columns (`Id`, an owner
+  /// foreign key) are not in `names`; they resolve through `ordinal(of:)`.
   var names: Array<String> { get }
 
   /// The virtual column names, in ordinal order — virtual `i` of `virtuals`
   /// sits at ordinal `width + i`.
   ///
-  /// A virtual column is computed by the `Row` rather than stored (an `Id`, a
-  /// `parent`); naming them lets the engine lift resolution onto an escapable
-  /// `Schema`. The default is empty — a relation overrides it only when it
-  /// computes a virtual column, and then its `extent` is `width + virtuals.count`.
+  /// A virtual column is computed by the `Row` rather than stored (an `Id`, an
+  /// owner foreign key); naming them lets the engine lift resolution onto an
+  /// escapable `Schema`. The default is empty — a relation overrides it only
+  /// when it computes a virtual column, and then its `extent` is `width +
+  /// virtuals.count`.
   var virtuals: Array<String> { get }
 
   /// One past the highest ordinal this table can address — its real `width`

--- a/Sources/SQL/Operator.swift
+++ b/Sources/SQL/Operator.swift
@@ -654,9 +654,9 @@ private func seek<T: Table & ~Escapable>(_ filter: Filter?,
 /// key is 1-based and reports `nil` for the null reference `0`, so probing with
 /// `0` would misclassify a seekable coded-index column as unseekable and force a
 /// hash build even for a selective join. `1` — the least valid key — answers for
-/// every seekable column (`Id`, list `parent`, a sorted key, a coded-index
-/// key); its value is otherwise irrelevant, since this is only a capability
-/// check (the join loop seeks with the real outer key).
+/// every seekable column (`Id`, an owner foreign key, a sorted key, a
+/// coded-index key); its value is otherwise irrelevant, since this is only a
+/// capability check (the join loop seeks with the real outer key).
 private func seekable<T: Table & ~Escapable>(_ table: borrowing T,
                                              _ column: Int) -> Bool {
   table.bound(column, 1, strict: false) != nil

--- a/Sources/SQL/Resolve.swift
+++ b/Sources/SQL/Resolve.swift
@@ -118,15 +118,16 @@ extension Schema {
 /// combined ordinals `[offset_i, offset_i + extent_i)`, where `offset_i` is the
 /// sum of the `extent`s of the relations before it. Using each relation's
 /// `extent` — its real `width` plus the virtual columns it exposes — rather than
-/// its `width` keeps a relation's virtual columns (an `Id`, a `parent`) on its
-/// own side rather than colliding with the next relation's space. A `Scope`
-/// resolves a possibly qualified `SQL.Column` into that combined space so the
-/// engine's `Filter`, projection, and order all address cells uniformly across
-/// the chain. A qualifier names a relation by its alias, else its table name; an
-/// unqualified name resolves against every relation and is ambiguous if more
-/// than one resolves it — as is a qualified name two relations share an alias or
-/// table name for (a self-join or a duplicated alias). Resolution reads only
-/// schemas, so the scope is escapable data over the relations' `Schema`s.
+/// its `width` keeps a relation's virtual columns (an `Id`, an owner foreign
+/// key) on its own side rather than colliding with the next relation's space. A
+/// `Scope` resolves a possibly qualified `SQL.Column` into that combined space
+/// so the engine's `Filter`, projection, and order all address cells uniformly
+/// across the chain. A qualifier names a relation by its alias, else its table
+/// name; an unqualified name resolves against every relation and is ambiguous
+/// if more than one resolves it — as is a qualified name two relations share an
+/// alias or table name for (a self-join or a duplicated alias). Resolution
+/// reads only schemas, so the scope is escapable data over the relations'
+/// `Schema`s.
 internal struct Scope {
   /// One relation of the chain: its reference (for qualifier matching), its
   /// name-resolution schema, and its base offset in the combined space.

--- a/Sources/winmd-inspect/Database+SQL.swift
+++ b/Sources/winmd-inspect/Database+SQL.swift
@@ -33,20 +33,22 @@ internal import WinMD
 /// method/parameter's signature and apply a target `Dialect`.
 ///
 /// Past `Id` sit a relation's join keys, at ordinals `width + 1` onward —
-/// the columns a view equi-joins across. A list-owned table leads the
-/// group with `parent` (the list-child's owning parent's `Id`), which enables
-/// list joins — a list-child relates to its owner through its run rather than a
-/// stored key — and a non-list table simply has no `parent` column. The
-/// coded-index join keys follow: for every real coded-index column a relation
-/// has, one decoded column per candidate target table the coded index admits,
-/// named `<ColumnName>_<TargetSchemaName>` (e.g. a `CustomAttribute.Parent` of
-/// kind `HasCustomAttribute` admitting `TypeDef` yields `Parent_TypeDef`). Its
-/// value is the target's 1-based `Id` when the cell's coded index tags that
-/// target (and is non-null), else SQL `NULL`, so a view can equi-join across a
-/// coded index — `JOIN Target ON child.<col>_<Target> = Target.Id` matches
-/// exactly the rows whose coded index points at `Target`. These are derived
-/// purely from the schema's coded-index fields and their `CodedIndex.tables`,
-/// and — being decoded — are never seekable.
+/// the columns a view equi-joins across. A list-owned table leads the group
+/// with its owner foreign key — a column named for the owning table (e.g. a
+/// `MethodDef`'s `TypeDef`), whose value is the owning row's `Id` — which
+/// enables list joins — a list-child relates to its owner through its run
+/// rather than a stored key — and a non-list table simply has no owner column.
+/// The coded-index join keys follow: for every real coded-index column a
+/// relation has, one decoded column per candidate target table the coded index
+/// admits, named `<ColumnName>_<TargetSchemaName>` (e.g. a
+/// `CustomAttribute.Parent` of kind `HasCustomAttribute` admitting `TypeDef`
+/// yields `Parent_TypeDef`). Its value is the target's 1-based `Id` when the
+/// cell's coded index tags that target (and is non-null), else SQL `NULL`, so a
+/// view can equi-join across a coded index — `JOIN Target ON
+/// child.<col>_<Target> = Target.Id` matches exactly the rows whose coded index
+/// points at `Target`. These are derived purely from the schema's coded-index
+/// fields and their `CodedIndex.tables`, and — being decoded — are never
+/// seekable.
 
 // MARK: - Catalog
 
@@ -171,14 +173,14 @@ extension Session {
 /// A `SQL.Table` over one open WinMD table.
 ///
 /// Its real columns are the table's fields; the virtual columns follow, past the
-/// `SELECT *` extent: `Id` at `width`, then the join keys — `parent` (on a
-/// list-owned table only) leading the coded-index join keys. A real cell is
-/// typed from its field's `ColumnType`: a `#Strings` index is `.text`, a
-/// `#Blob` index is a `.blob`, every other column (a constant, a foreign-key
+/// `SELECT *` extent: `Id` at `width`, then the join keys — the owner foreign
+/// key (on a list-owned table only) leading the coded-index join keys. A real
+/// cell is typed from its field's `ColumnType`: a `#Strings` index is `.text`,
+/// a `#Blob` index is a `.blob`, every other column (a constant, a foreign-key
 /// index, another heap) is `.integer`. A seek is available on `Id` (a dense
-/// 1-based index, trivially monotonic), on `parent` over a list-child (whose
-/// owning run is monotonic in row order), and on the table's intrinsic sort key
-/// when the database physically sorts the table.
+/// 1-based index, trivially monotonic), on the owner foreign key over a
+/// list-child (whose owning run is monotonic in row order), and on the table's
+/// intrinsic sort key when the database physically sorts the table.
 internal struct WinMDRelation: SQL.Table, ~Escapable {
   /// The borrowed storage the relation reads from.
   private let storage: WinMD.Storage
@@ -193,7 +195,7 @@ internal struct WinMDRelation: SQL.Table, ~Escapable {
   }
 
   /// The number of real columns — the extent of a `SELECT *` projection. The
-  /// `Id` and `parent` virtual columns sit past it.
+  /// `Id` and owner-foreign-key virtual columns sit past it.
   internal var width: Int {
     table.schema.fields.count
   }
@@ -209,22 +211,22 @@ internal struct WinMDRelation: SQL.Table, ~Escapable {
   }
 
   /// The virtual column names, in ordinal order — `Id` at `width`, then its
-  /// join keys: `parent` (on a list-owned table only) leading the coded-index
-  /// join keys.
+  /// join keys: the owner foreign key (on a list-owned table only) leading the
+  /// coded-index join keys.
   internal var virtuals: Array<String> {
-    let parent = WinMDRelation.Link(storage, table) == nil ? [] : ["parent"]
+    let owner = self.owner.map { [$0] } ?? [] // the list-ownership key
     return ["Id"] // the universal identity, at `width`
-        + parent // the list-ownership key, present only on a list-owned table
+        + owner // present only on a list-owned table
         + keys.map(\.name) // coded-index join keys
   }
 
   /// One past the highest ordinal this relation can address — its real `width`
-  /// plus the universal `Id` and its join keys (`parent` when list-owned,
-  /// then the coded-index join keys).
+  /// plus the universal `Id` and its join keys (the owner foreign key when
+  /// list-owned, then the coded-index join keys).
   internal var extent: Int {
     width // real fields
         + 1 // `Id`
-        + (WinMDRelation.Link(storage, table) == nil ? 0 : 1) // `parent`
+        + (owner == nil ? 0 : 1) // the owner foreign key
         + keys.count // coded-index join keys
   }
 
@@ -234,13 +236,23 @@ internal struct WinMDRelation: SQL.Table, ~Escapable {
     width
   }
 
-  /// The ordinal of the `parent` virtual column on a list-owned table — the
+  /// The name of the owner foreign-key column on a list-owned table — the
+  /// owning table's schema name (e.g. `TypeDef` for a `MethodDef`) — or `nil`
+  /// when the table owns no list (it then has no owner column).
+  ///
+  /// The name comes straight from the list `Link`'s parent table, so it never
+  /// collides with a real field: no list-child schema carries a field spelled
+  /// like its owner's table.
+  private var owner: String? {
+    WinMDRelation.Link(storage, table)
+        .map { "\($0.parent.description)" }
+  }
+
+  /// The ordinal of the owner foreign-key column on a list-owned table — the
   /// first join-key ordinal, immediately past `Id` — or `nil` when the table
-  /// owns no list (it then has no `parent` column).
-  private var parent: Int? {
-    WinMDRelation.Link(storage, table) == nil
-        ? nil
-        : width + 1
+  /// owns no list (it then has no owner column).
+  private var owned: Int? {
+    owner == nil ? nil : width + 1
   }
 
   internal func ordinal(of name: String) -> Int? {
@@ -252,15 +264,16 @@ internal struct WinMDRelation: SQL.Table, ~Escapable {
     if name.caseInsensitiveCompare("Id") == .orderedSame {
       return id
     }
-    // The join keys follow `Id`. `parent` (on a list-owned table) leads
-    // them; the coded-index join keys follow at `parent + 1` onward (or, on a
-    // non-list table, at the first join-key ordinal).
+    // The join keys follow `Id`. The owner foreign key (on a list-owned table)
+    // leads them; the coded-index join keys follow at `owned + 1` onward (or,
+    // on a non-list table, at the first join-key ordinal).
     let base = id + 1
-    if let parent, name.caseInsensitiveCompare("parent") == .orderedSame {
-      return parent
+    if let owner, let owned,
+        name.caseInsensitiveCompare(owner) == .orderedSame {
+      return owned
     }
     let keys = self.keys
-    let lead = parent == nil ? base : base + 1
+    let lead = owned == nil ? base : base + 1
     for index in keys.indices
         where keys[index].name.caseInsensitiveCompare(name) == .orderedSame {
       return lead + index
@@ -279,10 +292,10 @@ internal struct WinMDRelation: SQL.Table, ~Escapable {
       return min(max(index, 0), count)
     }
 
-    // `parent` over a list-child is monotonic in row order — a parent owns a
-    // contiguous run of children — so binary-search the rows for the boundary
-    // against the computed parent `Id`.
-    if column == parent, let link = WinMDRelation.Link(storage, table) {
+    // The owner foreign key over a list-child is monotonic in row order — an
+    // owner owns a contiguous run of children — so binary-search the rows for
+    // the boundary against the computed owner `Id`.
+    if column == owned, let link = WinMDRelation.Link(storage, table) {
       return owners(link, value, count, strict: strict)
     }
 
@@ -342,22 +355,22 @@ internal struct WinMDRelation: SQL.Table, ~Escapable {
   /// `column` is not one of this table's coded-index join keys.
   ///
   /// The coded-index join keys occupy the ordinals past `Id` and — on a
-  /// list-owned table — the `parent` key, in the order `keys` exposes them;
-  /// this maps `column` back through that layout, the inverse of
+  /// list-owned table — the owner foreign key, in the order `keys` exposes
+  /// them; this maps `column` back through that layout, the inverse of
   /// `ordinal(of:)`'s coded-index-key arm.
   private func key(for column: Int) -> Key? {
     let base = id + 1
-    let lead = parent == nil ? base : base + 1
+    let lead = owned == nil ? base : base + 1
     let index = column - lead
     let all = keys
     guard index >= 0, index < all.count else { return nil }
     return all[index]
   }
 
-  /// The partition point of the child rows against a parent `Id` `value`.
+  /// The partition point of the child rows against an owner `Id` `value`.
   ///
-  /// A child row's `parent` is the 1-based row of its owning parent. The owners
-  /// are non-decreasing across the child rows (a parent's run precedes the
+  /// A child row's owner is the 1-based row of its owning parent. The owners
+  /// are non-decreasing across the child rows (an owner's run precedes the
   /// next), so the boundary is found by binary search: with `strict` false the
   /// first child whose owner is `>= value`, with `strict` true the first whose
   /// owner is `> value`.
@@ -530,7 +543,7 @@ extension WinMD.Storage {
 /// A `SQL.Cursor` over the rows of one open WinMD table.
 ///
 /// It wraps WinMD's own `~Escapable` `Cursor` and carries the relation's list
-/// link, so the rows it vends can compute the `parent` virtual column.
+/// link, so the rows it vends can compute the owner foreign-key column.
 internal struct WinMDCursor: SQL.Cursor, ~Escapable {
   /// The borrowed storage the cursor reads from.
   private let storage: WinMD.Storage
@@ -569,9 +582,9 @@ internal struct WinMDCursor: SQL.Cursor, ~Escapable {
 /// `.text`, a `#Blob` heap index as an owning `.blob` (the raw heap payload,
 /// for a scalar UDF such as `GUID` to decode), every other column `.integer`;
 /// `Id` (`count`) is the 1-based row index; and the join keys follow it — on
-/// a list-owned table the `parent` ordinal is the owning parent row's 1-based
-/// `Id` (zero for a row no parent owns) and the coded-index join keys follow
-/// it, while on a non-list table the coded-index join keys follow `Id`
+/// a list-owned table the owner foreign-key ordinal is the owning parent row's
+/// 1-based `Id` (zero for a row no owner claims) and the coded-index join keys
+/// follow it, while on a non-list table the coded-index join keys follow `Id`
 /// directly. A coded-index join-key ordinal decodes a coded-index cell to the
 /// target's 1-based `Id`, or SQL `NULL` when the cell points elsewhere or is
 /// null.
@@ -602,9 +615,9 @@ internal struct WinMDRow: SQL.Row, ~Escapable {
         return .integer(tuple.index + 1)
       }
       if column > tuple.count {
-        // Past `Id`: the join keys. On a list-owned table `parent` leads
-        // them (the owning parent's 1-based `Id`, zero for a row no parent
-        // owns) and the coded-index join keys follow it; on a non-list table
+        // Past `Id`: the join keys. On a list-owned table the owner foreign key
+        // leads them (the owning parent's 1-based `Id`, zero for a row no owner
+        // claims) and the coded-index join keys follow it; on a non-list table
         // the coded-index join keys follow `Id` directly.
         let virtual = column - (tuple.count + 1)
         guard let link else { return self.key(virtual) }

--- a/Sources/winmd-inspect/Resources/Queries/interfaces.sql
+++ b/Sources/winmd-inspect/Resources/Queries/interfaces.sql
@@ -23,7 +23,7 @@ FROM
   TypeDef t
   JOIN CustomAttribute c ON c.Parent_TypeDef = t.Id
   JOIN MethodDef m ON c.Type_MethodDef = m.Id
-  JOIN TypeDef g ON m.parent = g.Id
+  JOIN TypeDef g ON m.TypeDef = g.Id
 WHERE
   g.TypeNamespace = 'Windows.Win32.Foundation.Metadata'
   AND g.TypeName = 'GuidAttribute'

--- a/Sources/winmd-inspect/Resources/Queries/methods.sql
+++ b/Sources/winmd-inspect/Resources/Queries/methods.sql
@@ -5,4 +5,4 @@ SELECT
 FROM
   MethodDef
 WHERE
-  parent = :parent
+  TypeDef = :parent

--- a/Sources/winmd-inspect/Resources/Queries/params.sql
+++ b/Sources/winmd-inspect/Resources/Queries/params.sql
@@ -6,4 +6,4 @@ SELECT
 FROM
   Param
 WHERE
-  parent = :parent
+  MethodDef = :parent

--- a/Tests/winmd-inspectTests/AdapterTests.swift
+++ b/Tests/winmd-inspectTests/AdapterTests.swift
@@ -15,9 +15,9 @@ import SQL
 /// — and drive a parsed `SELECT` through `Engine.run` over the `WinMD.Storage`
 /// catalog, asserting the typed `Value` rows the engine yields. They exercise a
 /// single-relation projection / filter / order with the `Id` virtual column
-/// and a sorted-key seek, a foreign-key join on `Id`, a list join on the
-/// `parent` virtual column, and a real `Parent` column shadowing that
-/// pseudo-column.
+/// and a sorted-key seek, a foreign-key join on `Id`, a list join on the owner
+/// foreign-key column (a `MethodDef`'s `TypeDef`), and a real `Parent` column
+/// that is an ordinary foreign key.
 struct AdapterTests {
   // TypeDef[0..1] (14-byte narrow rows), MethodDef[0..2] (14-byte rows), and
   // NestedClass[0..1] (4-byte rows), packed back to back. ECMA-335 rows are
@@ -37,8 +37,8 @@ struct AdapterTests {
   //   EventMap[0]: Parent=1 EventList=1   (→ TypeDef[0], Alpha)
   //   EventMap[1]: Parent=2 EventList=1   (→ TypeDef[1], Beta)
   //
-  // `EventMap` carries a *real* `Parent` field (a TypeDef index), so its name
-  // must shadow the virtual `parent` pseudo-column.
+  // `EventMap` carries a *real* `Parent` field (a TypeDef index), an ordinary
+  // foreign key; `EventMap` owns no list, so it has no owner-FK column.
   private static let bytes: Array<UInt8> = [
     // TypeDef[0]: Flags, TypeName=1, TypeNamespace=12, Extends, FieldList,
     // MethodList=1.
@@ -120,7 +120,7 @@ struct AdapterTests {
     // The string columns project as text, the constant as an integer; the
     // WHERE keeps both rows (both are in "NS"), and ORDER BY TypeName sorts
     // Alpha < Beta. `SELECT *` is the two real string heaps plus the constant
-    // and the three index columns — never `Id` or `parent`.
+    // and the three index columns — never `Id` or an owner-FK column.
     try AdapterTests.with { catalog in
       let rows = try AdapterTests.run(
           "SELECT TypeName, Flags FROM TypeDef "
@@ -132,10 +132,10 @@ struct AdapterTests {
     }
   }
 
-  @Test("excludes Id and parent from SELECT *")
+  @Test("excludes Id and the owner FK from SELECT *")
   func star() throws {
     // `SELECT *` projects exactly the real fields: a TypeDef has six. Neither
-    // the `Id` nor the `parent` virtual column appears.
+    // the `Id` nor an owner-foreign-key virtual column appears.
     try AdapterTests.with { catalog in
       let rows = try AdapterTests.run("SELECT * FROM TypeDef ORDER BY Id",
                                       catalog)
@@ -189,16 +189,16 @@ struct AdapterTests {
     }
   }
 
-  @Test("joins a list child to its owner on parent")
+  @Test("joins a list child to its owner on the owner FK")
   func listJoin() throws {
-    // The `parent` virtual column relates each MethodDef to the TypeDef whose
+    // The `TypeDef` owner-FK column relates each MethodDef to the TypeDef whose
     // MethodList run owns it: MethodDef[0,1] → TypeDef[0] (Alpha), MethodDef[2]
     // → TypeDef[1] (Beta). The join seeks TypeDef on its `Id` per method.
     try AdapterTests.with { catalog in
       let rows = try AdapterTests.run(
           "SELECT MethodDef.Name, TypeDef.TypeName "
           + "FROM MethodDef JOIN TypeDef "
-          + "ON MethodDef.parent = TypeDef.Id "
+          + "ON MethodDef.TypeDef = TypeDef.Id "
           + "ORDER BY MethodDef.Name", catalog)
       #expect(rows == [
         [.text("m0"), .text("Alpha")],
@@ -208,11 +208,11 @@ struct AdapterTests {
     }
   }
 
-  @Test("resolves a real Parent column over the parent pseudo-column")
-  func realParentShadowsPseudo() throws {
-    // EventMap carries a real `Parent` field — a TypeDef index — so the name
-    // must resolve to that foreign key, not the virtual `parent` (which is 0
-    // for a table no list owns). EventMap[0].Parent=1, EventMap[1].Parent=2.
+  @Test("resolves a real Parent foreign-key column")
+  func realParentColumn() throws {
+    // EventMap carries a real `Parent` field — a TypeDef index — and owns no
+    // list, so it has no owner-FK column: the name resolves to that ordinary
+    // foreign key. EventMap[0].Parent=1, EventMap[1].Parent=2.
     try AdapterTests.with { catalog in
       let rows = try AdapterTests.run(
           "SELECT Parent FROM EventMap ORDER BY Id", catalog)

--- a/Tests/winmd-inspectTests/DatabaseSQLTests.swift
+++ b/Tests/winmd-inspectTests/DatabaseSQLTests.swift
@@ -351,7 +351,7 @@ struct DatabaseSQLTests {
     // When `GuidAttribute` is defined in the same file, a type's
     // `CustomAttribute.Type` names the attribute's `.ctor` directly as a
     // `MethodDef` (not a cross-module `MemberRef`), so the `MemberRef` chains
-    // find nothing: the view's `Type_MethodDef → MethodDef.parent → TypeDef`
+    // find nothing: the view's `Type_MethodDef → MethodDef.TypeDef → TypeDef`
     // arm navigates it instead. `IThing` carries such an attribute, so the view
     // resolves its IID.
     try SameModuleGuidFixture.with { catalog in
@@ -406,7 +406,7 @@ struct DatabaseSQLTests {
   @Test("excludes the virtual columns from SELECT *")
   func star() throws {
     // `SELECT *` projects exactly the six real `TypeDef` fields — neither
-    // `Id` nor `parent` appears — for each of the two fixture types.
+    // `Id` nor an owner-FK column appears — for each of the two fixture types.
     try DatabaseSQLTests.with { catalog in
       let rows = try DatabaseSQLTests.run("SELECT * FROM TypeDef", catalog)
       #expect(rows.count == 2)
@@ -1113,7 +1113,7 @@ private enum SameModuleGuidFixture {
   //                a `MemberRef` into the in-file `TypeDef` (the `Class_TypeDef`
   //                arm).
   //   MethodDef[0]: Name=0, Signature=0, ParamList=1 — the `GuidAttribute`
-  //                `.ctor`, owned by TypeDef[0] (so its `parent` is Id 1).
+  //                `.ctor`, owned by TypeDef[0] (so its `TypeDef` FK is Id 1).
   //   MemberRef[0]: Class=MemberRefParent(TypeDef row 1)=(1<<3)|0=8 — the ctor
   //                reference whose declaring class is the in-file `GuidAttribute`
   //                `TypeDef`, so `Class_TypeDef` (not `Class_TypeRef`) decodes.


### PR DESCRIPTION
The adapter exposed a list-child's owning row under the SQLite-style name `parent`, a virtual pseudo-column present only on the five list-owned child tables, whose value was the owner's 1-based `Id`. This was the last pseudo-column vendor-ism: `parent` reads as a magic name, unlike an ordinary foreign key.

Replace it with a named owner foreign-key column — a column named for the owning table (e.g. a `MethodDef`'s `TypeDef`), still holding the owner's `Id` — so a list join spells the same textbook `ON child.<Owner> = Owner.Id` a real FK join does. The name comes straight from the list `Link`'s parent table, so it never collides with a real field: no list-child schema carries a field spelled like its owner's table. The five are `FieldDef.TypeDef`, `MethodDef.TypeDef`, `Param.MethodDef`, `EventDef.EventMap`, and `PropertyDef.PropertyMap`.

This is a refactor, not a behavior change. The owner FK keeps the exact ordinal layout `parent` had — at `width + 1`, leading the coded-index join keys — and keeps the same binary-search seek: `bound`'s owner arm still partitions the child rows against the owner `Id` through the run-ownership decode, so the engine's index-nested-loop join seeks it as before. The identity and coded-index keys are untouched, so `SELECT *` and every join resolve the same ordinals, and the golden `@com` render is byte-identical.

The bundled query views migrate `parent` to the owner-FK name — `methods` (`WHERE TypeDef = :parent`), `params` (`WHERE MethodDef = :parent`), and the `interfaces` same-file `MethodDef` arm (`ON m.TypeDef = g.Id`). The `:parent` binding name is kept as-is — it is the bound owner-`Id` value the render supplies, independent of the removed column — to minimize render-code churn. `bases.sql`'s `i.Class = :parent` uses the real `Class` column and is untouched.

The SQL engine is untouched: `parent` was never an engine concept, only a name the adapter vended through the generic virtual-column surface. The prose that called it a pseudo-column now describes the owner foreign key.