### PR TITLE
SQL: support a compound ORDER BY with per-key directions

### DIFF
--- a/Sources/SQL/AST.swift
+++ b/Sources/SQL/AST.swift
@@ -9,7 +9,7 @@
 /// SELECT <* | column (, column)*>
 ///   FROM <table> [AS alias]
 ///   (JOIN <table> [AS alias] ON <column> = <column>)*
-///   [WHERE <predicate>] [ORDER BY <column> [ASC|DESC]]
+///   [WHERE <predicate>] [ORDER BY <column> [ASC|DESC] (, …)*]
 ///   [OFFSET <skip> ROWS] [FETCH {FIRST | NEXT} <count> ROWS ONLY]
 /// ```
 ///
@@ -343,18 +343,40 @@ public enum Literal: Hashable, Sendable {
   case integer(Int)
 }
 
-/// An `ORDER BY` clause: a column and its direction.
+/// An `ORDER BY` clause: an ordered list of sort keys, each a column and its
+/// own direction.
+///
+/// The keys are applied major to minor — `ORDER BY a, b DESC, c` sorts by `a`
+/// ascending, breaks ties by `b` descending, then breaks the rest by `c`
+/// ascending — so `keys[0]` is the primary key and each later key orders only
+/// the rows the earlier keys leave equal. A per-key `ASC`/`DESC` governs that
+/// key alone (default `ASC`); `keys` is never empty.
 public struct Order: Hashable, Sendable {
-  /// The column the result is ordered on.
-  public let column: Column
+  /// One sort key: the column to order on and its direction.
+  public struct Key: Hashable, Sendable {
+    /// The column this key orders on.
+    public let column: Column
 
-  /// Whether the order is ascending (`ASC`, the default) rather than
-  /// descending (`DESC`).
-  public let ascending: Bool
+    /// Whether this key is ascending (`ASC`, the default) rather than
+    /// descending (`DESC`).
+    public let ascending: Bool
 
+    public init(column: Column, ascending: Bool = true) {
+      self.column = column
+      self.ascending = ascending
+    }
+  }
+
+  /// The sort keys, in major-to-minor order — `keys[0]` is the primary key.
+  public let keys: Array<Key>
+
+  public init(keys: Array<Key>) {
+    self.keys = keys
+  }
+
+  /// A single-key `ORDER BY` — the common case, ordering on one column.
   public init(column: Column, ascending: Bool = true) {
-    self.column = column
-    self.ascending = ascending
+    self.init(keys: [Key(column: column, ascending: ascending)])
   }
 }
 

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -429,7 +429,7 @@ public enum Engine {
       if let predicate = select.predicate {
         filter = try from.schema.lower(predicate, in: relation)
       }
-      var order: (column: Int, ascending: Bool)? = nil
+      var order = Array<(column: Int, ascending: Bool)>()
       if let clause = select.order {
         order = try from.schema.order(clause, in: relation)
       }
@@ -482,7 +482,7 @@ public enum Engine {
     if let clause = select.predicate {
       predicate = try scope.lower(clause)
     }
-    var order: (column: Int, ascending: Bool)? = nil
+    var order = Array<(column: Int, ascending: Bool)>()
     if let clause = select.order {
       order = try scope.order(clause)
     }
@@ -496,7 +496,7 @@ public enum Engine {
     for term in projection { term.references(into: &references) }
     for match in matches { match.references(into: &references) }
     predicate?.references(into: &references)
-    if let order { references.insert(order.column) }
+    for key in order { references.insert(key.column) }
     let combined = references.sorted()
 
     var slot = Dictionary<Int, Int>(minimumCapacity: combined.count)
@@ -620,17 +620,17 @@ public enum Engine {
 
   /// The sorted, deduplicated ordinals a query references: the union of the
   /// ordinals its `projection` terms read, the columns its `filter` reads, and
-  /// its `order` column. The projection terms hold ordinals at this stage; a
-  /// scalar call's arguments contribute their read ordinals too.
+  /// EVERY column its `order` keys read. The projection terms hold ordinals at
+  /// this stage; a scalar call's arguments contribute their read ordinals too.
   private static func referenced(_ projection: Array<Term>, _ filter: Filter?,
-                                 _ order: (column: Int, ascending: Bool)?)
+                                 _ order: Array<(column: Int, ascending: Bool)>)
       -> Array<Int> {
     var ordinals = Set<Int>()
     for term in projection {
       term.references(into: &ordinals)
     }
     filter?.references(into: &ordinals)
-    if let order { ordinals.insert(order.column) }
+    for key in order { ordinals.insert(key.column) }
     return ordinals.sorted()
   }
 
@@ -646,7 +646,7 @@ public enum Engine {
 
   /// Wraps `source` in the `Project(Limit(Sort(Select(_))))` operators, omitting
   /// each layer when its clause is absent. The `projection`, `filter`, and
-  /// `order` are in slot space.
+  /// `order` keys are in slot space; an empty `order` omits the sort.
   ///
   /// The row `limit` sits BELOW the projection — after `WHERE` and `ORDER BY`,
   /// but before the select list is evaluated. A row outside the requested page
@@ -655,14 +655,14 @@ public enum Engine {
   /// a discarded row and the query returns the documented empty page.
   private static func shape(_ source: Plan, _ projection: Array<Term>,
                             _ filter: Filter?,
-                            _ order: (slot: Int, ascending: Bool)?,
+                            _ order: Array<(slot: Int, ascending: Bool)>,
                             _ limit: Limit?) -> Plan {
     var plan = source
     if let filter {
       plan = .select(filter, plan)
     }
-    if let order {
-      plan = .sort(slot: order.slot, ascending: order.ascending, plan)
+    if !order.isEmpty {
+      plan = .sort(keys: order, plan)
     }
     return .project(projection, plan.capped(limit: limit))
   }
@@ -722,9 +722,8 @@ public enum Engine {
       try .select(filter, optimise(source, catalog, ctes, bindings))
     case let .project(ordinals, source):
       try .project(ordinals, optimise(source, catalog, ctes, bindings))
-    case let .sort(slot, ascending, source):
-      try .sort(slot: slot, ascending: ascending,
-                optimise(source, catalog, ctes, bindings))
+    case let .sort(keys, source):
+      try .sort(keys: keys, optimise(source, catalog, ctes, bindings))
     case let .product(left, right):
       try .product(optimise(left, catalog, ctes, bindings),
                    optimise(right, catalog, ctes, bindings))
@@ -1024,8 +1023,8 @@ extension Plan {
       try source.pushdown().distribute(filter.conjuncts)
     case let .project(terms, source):
       try .project(terms, source.pushdown())
-    case let .sort(slot, ascending, source):
-      try .sort(slot: slot, ascending: ascending, source.pushdown())
+    case let .sort(keys, source):
+      try .sort(keys: keys, source.pushdown())
     case let .product(left, right):
       try .product(left.pushdown(), right.pushdown())
     case let .union(left, right, all):

--- a/Sources/SQL/Operator.swift
+++ b/Sources/SQL/Operator.swift
@@ -121,8 +121,12 @@ internal indirect enum Plan {
   /// call) against the record, in order, to the output row. A bare-column
   /// projection is a list of `.slot` terms, so the simple path is a reorder.
   case project(Array<Term>, Plan)
-  /// τ — orders the records by a typed key on `slot`.
-  case sort(slot: Int, ascending: Bool, Plan)
+  /// τ — orders the records by a list of typed sort keys, major to minor. Each
+  /// key names a `slot` and its direction; `keys[0]` is the primary key and
+  /// each later key orders only the rows the earlier keys leave equal. The sort
+  /// is stable, so rows equal on every key keep their input order. `keys` is
+  /// never empty.
+  case sort(keys: Array<(slot: Int, ascending: Bool)>, Plan)
   /// × — every concatenation of an outer record with an inner one.
   case product(Plan, Plan)
   /// ⋈ — for each outer record, seeks the inner relation `name` on
@@ -238,7 +242,8 @@ extension Plan {
 /// the relation by name, opens its cursor, and materialises its referenced
 /// ordinals over the seek range into dense slots; `select` keeps the admitted
 /// records; `project` rebuilds each from the projected slots; `sort` orders them
-/// by a typed key, stably and in the requested direction; `product` pairs every
+/// by its typed keys major to minor, stably and each in its own direction;
+/// `product` pairs every
 /// outer record with every inner one; `join` re-resolves the inner relation,
 /// seeks it per outer record, and concatenates the matches; `union` runs its
 /// two sides — each with its own union semantics — and concatenates their rows,
@@ -273,16 +278,22 @@ internal func execute<C: Catalog & ~Escapable>(_ plan: Plan,
   case let .project(terms, source):
     try execute(source, catalog, ctes, routines, bindings)
       .map { record throws(SQLError) in try project(terms, record, routines) }
-  case let .sort(slot, ascending, source):
+  case let .sort(keys, source):
     try execute(source, catalog, ctes, routines, bindings)
       .enumerated()
       .sorted { lhs, rhs in
-        let ordered = less(lhs.element[slot], rhs.element[slot])
-        let reverse = less(rhs.element[slot], lhs.element[slot])
-        // A stable sort: keep the source order within an equal-key group by
+        // Compare the keys major to minor: the first key on which the rows
+        // differ decides the order; a key they are equal on falls through to
+        // the next. A key's direction governs that key alone.
+        for key in keys {
+          let ordered = less(lhs.element[key.slot], rhs.element[key.slot])
+          let reverse = less(rhs.element[key.slot], lhs.element[key.slot])
+          if ordered == reverse { continue }
+          return key.ascending ? ordered : reverse
+        }
+        // Equal on every key: keep the source order (a stable sort) by
         // tie-breaking on the original index.
-        if ordered == reverse { return lhs.offset < rhs.offset }
-        return ascending ? ordered : reverse
+        return lhs.offset < rhs.offset
       }
       .map(\.element)
   case let .product(outer, inner):

--- a/Sources/SQL/Parser.swift
+++ b/Sources/SQL/Parser.swift
@@ -29,7 +29,8 @@
 /// additive       := multiplicative (('+' | '-') multiplicative)*
 /// multiplicative := factor (('*' | '/') factor)*
 /// factor         := '(' expression ')' | literal | call | column
-/// order          := ORDER BY column [ASC | DESC]
+/// order          := ORDER BY key (',' key)*
+/// key            := column [ASC | DESC]
 /// limit          := [OFFSET integer ROWS]
 ///                   [FETCH (FIRST | NEXT) [integer] ROWS ONLY]
 /// column         := identifier        // a dotted identifier is qualified
@@ -548,10 +549,22 @@ internal struct Parser: ~Escapable {
 
   // MARK: - Order
 
-  /// Parses `BY identifier [ASC | DESC]` (the `ORDER` keyword is already
-  /// consumed).
+  /// Parses `BY key (',' key)*` — a comma-separated list of sort keys, each a
+  /// column and its own optional `ASC`/`DESC` — into an `Order` (the `ORDER`
+  /// keyword is already consumed). The keys read in source order, major to
+  /// minor.
   private mutating func order() throws(SQLError) -> Order {
     try expect(.by)
+    var keys = [try key()]
+    while try match(.comma) {
+      try keys.append(key())
+    }
+    return Order(keys: keys)
+  }
+
+  /// Parses one sort key — `column [ASC | DESC]`, the direction defaulting to
+  /// ascending.
+  private mutating func key() throws(SQLError) -> Order.Key {
     let column = try column()
 
     var ascending = true
@@ -560,7 +573,7 @@ internal struct Parser: ~Escapable {
     } else {
       _ = try match(.asc)
     }
-    return Order(column: column, ascending: ascending)
+    return Order.Key(column: column, ascending: ascending)
   }
 
   // MARK: - Row limiting

--- a/Sources/SQL/Resolve.swift
+++ b/Sources/SQL/Resolve.swift
@@ -85,10 +85,17 @@ extension Schema {
     }
   }
 
+  /// The resolved sort keys an `ORDER BY` lowers to, in major-to-minor order —
+  /// each key's column an ordinal in this relation, its direction preserved.
   internal func order(_ order: Order, in relation: Relation)
-      throws(SQLError) -> (column: Int, ascending: Bool) {
-    try (column: ordinal(of: order.column, in: relation),
-         ascending: order.ascending)
+      throws(SQLError) -> Array<(column: Int, ascending: Bool)> {
+    var keys = Array<(column: Int, ascending: Bool)>()
+    keys.reserveCapacity(order.keys.count)
+    for key in order.keys {
+      try keys.append((column: ordinal(of: key.column, in: relation),
+                       ascending: key.ascending))
+    }
+    return keys
   }
 
   internal func lower(_ predicate: Predicate, in relation: Relation)
@@ -238,11 +245,18 @@ internal struct Scope {
     }
   }
 
-  /// The `(column, ascending)` pair an `ORDER BY` resolves to, the column a
-  /// combined ordinal.
+  /// The resolved sort keys an `ORDER BY` lowers to, in major-to-minor order —
+  /// each key's column a combined ordinal across the chain, its direction
+  /// preserved.
   internal func order(_ order: Order) throws(SQLError)
-      -> (column: Int, ascending: Bool) {
-    try (column: ordinal(of: order.column), ascending: order.ascending)
+      -> Array<(column: Int, ascending: Bool)> {
+    var keys = Array<(column: Int, ascending: Bool)>()
+    keys.reserveCapacity(order.keys.count)
+    for key in order.keys {
+      try keys.append((column: ordinal(of: key.column),
+                       ascending: key.ascending))
+    }
+    return keys
   }
 
   /// Lowers a join's `ON left = right` to a `match` conjunct, each side

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -250,6 +250,29 @@ private func people() -> Memory {
   return Memory(["People": Relation(fields, records, sorted: 0)])
 }
 
+/// A single-relation catalog for compound ordering: a `Grade` relation whose
+/// `Class`/`Score` columns hold deliberate ties, so a three-key `ORDER BY
+/// Class, Score, Name` needs the third key to settle rows the first two leave
+/// equal. The rows are stored out of every non-`Id` order, so a sort is never a
+/// no-op.
+private func grades() -> Memory {
+  let fields = [
+    Field(name: "Id", kind: .integer),
+    Field(name: "Class", kind: .text),
+    Field(name: "Score", kind: .integer),
+    Field(name: "Name", kind: .text),
+  ]
+  let records = [
+    [.integer(1), .text("B"), .integer(90), .text("Zed")],
+    [.integer(2), .text("A"), .integer(80), .text("Yan")],
+    [.integer(3), .text("A"), .integer(80), .text("Ada")],
+    [.integer(4), .text("B"), .integer(90), .text("Amy")],
+    [.integer(5), .text("A"), .integer(80), .text("Mel")],
+    [.integer(6), .text("A"), .integer(70), .text("Bob")],
+  ] as Array<Array<Value>>
+  return Memory(["Grade": Relation(fields, records, sorted: 0)])
+}
+
 /// A catalog modelling a decoded coded-index key: an `Attribute` relation whose
 /// `Parent` column is seekable but not ordered. It stands in for a
 /// `CustomAttribute` physically sorted on its raw `Parent` coded index with
@@ -518,6 +541,11 @@ private func run(_ text: String) throws -> Array<Array<Value>> {
   try Engine.run(parse(text), people())
 }
 
+/// Runs `text` against the compound-ordering `Grade` catalog.
+private func grades(_ text: String) throws -> Array<Array<Value>> {
+  try Engine.run(parse(text), grades())
+}
+
 /// Runs `text` against the wide catalog.
 private func wide(_ text: String) throws -> Array<Array<Value>> {
   try Engine.run(parse(text), wide())
@@ -645,6 +673,85 @@ struct EngineOrderTests {
     let rows = try run("SELECT Name FROM People ORDER BY Name DESC")
     #expect(rows == [[.text("Eve")], [.text("Dave")], [.text("Carol")],
                      [.text("Bob")], [.text("Alice")]])
+  }
+}
+
+struct EngineCompoundOrderTests {
+  @Test("a single-key ORDER BY still orders as before")
+  func single() throws {
+    // The one-key case is unchanged: ages ascending, ties kept in scan order.
+    let rows = try run("SELECT Id FROM People ORDER BY Age ASC")
+    #expect(rows == [[.integer(2)], [.integer(5)], [.integer(1)],
+                     [.integer(3)], [.integer(4)]])
+  }
+
+  @Test("two keys order by the first, then the second")
+  func twoKeys() throws {
+    // Age ascending, ties by Name ascending: {Bob,Eve} at 25 → Bob, Eve;
+    // {Alice,Carol} at 30 → Alice, Carol; then Dave.
+    let rows = try run("SELECT Name FROM People ORDER BY Age, Name")
+    #expect(rows == [[.text("Bob")], [.text("Eve")], [.text("Alice")],
+                     [.text("Carol")], [.text("Dave")]])
+  }
+
+  @Test("each key carries its own direction")
+  func mixedDirections() throws {
+    // Age descending, ties by Name ascending: Dave(40); Alice, Carol (30);
+    // Bob, Eve (25).
+    let rows =
+        try run("SELECT Name FROM People ORDER BY Age DESC, Name ASC")
+    #expect(rows == [[.text("Dave")], [.text("Alice")], [.text("Carol")],
+                     [.text("Bob")], [.text("Eve")]])
+  }
+
+  @Test("a later key breaks ties the first key leaves")
+  func tieBreak() throws {
+    // Age ascending leaves {Bob,Eve} and {Alice,Carol} tied; a DESC Name key
+    // reorders each pair against the scan order (Eve before Bob, Carol before
+    // Alice) — proof the second key, not the input order, settles the ties.
+    let rows = try run("SELECT Name FROM People ORDER BY Age ASC, Name DESC")
+    #expect(rows == [[.text("Eve")], [.text("Bob")], [.text("Carol")],
+                     [.text("Alice")], [.text("Dave")]])
+  }
+
+  @Test("three keys settle rows the first two leave equal")
+  func threeKeys() throws {
+    // Class ascending, Score ascending, Name ascending. Class A: Bob(70), then
+    // the 80s by Name — Ada, Mel, Yan. Class B: both 90, by Name — Amy, Zed.
+    let rows =
+        try grades("SELECT Id FROM Grade ORDER BY Class, Score, Name")
+    #expect(rows == [[.integer(6)], [.integer(3)], [.integer(5)],
+                     [.integer(2)], [.integer(4)], [.integer(1)]])
+  }
+
+  @Test("a compound ORDER BY is stable across all keys")
+  func stable() throws {
+    // Class and Score alone leave the three Class-A/Score-80 rows tied; with no
+    // further key the sort keeps their scan order — Yan(2), Ada(3), Mel(5).
+    let rows = try grades("SELECT Id FROM Grade ORDER BY Class, Score")
+    #expect(rows == [[.integer(6)], [.integer(2)], [.integer(3)],
+                     [.integer(5)], [.integer(1)], [.integer(4)]])
+  }
+
+  @Test("FETCH takes the top-N of a compound order")
+  func topN() throws {
+    // Age descending, ties by Name ascending, then the first two rows: Dave(40)
+    // and the lower-named of the 30s, Alice.
+    let rows = try run("""
+        SELECT Name FROM People
+          ORDER BY Age DESC, Name ASC FETCH FIRST 2 ROWS ONLY
+        """)
+    #expect(rows == [[.text("Dave")], [.text("Alice")]])
+  }
+
+  @Test("OFFSET then FETCH pages into a compound order")
+  func page() throws {
+    // The full compound order is Dave, Alice, Carol, Bob, Eve; skip 1, take 2.
+    let rows = try run("""
+        SELECT Name FROM People
+          ORDER BY Age DESC, Name ASC OFFSET 1 ROWS FETCH NEXT 2 ROWS ONLY
+        """)
+    #expect(rows == [[.text("Alice")], [.text("Carol")]])
   }
 }
 
@@ -1172,7 +1279,7 @@ private func derived(_ plan: Plan) -> Plan? {
     derived(source)
   case let .project(_, source):
     derived(source)
-  case let .sort(_, _, source):
+  case let .sort(_, source):
     derived(source)
   case let .product(left, right):
     derived(left) ?? derived(right)
@@ -1194,7 +1301,7 @@ private func seeks(_ plan: Plan) -> Bool {
     seeks(source)
   case let .project(_, source):
     seeks(source)
-  case let .sort(_, _, source):
+  case let .sort(_, source):
     seeks(source)
   case let .derived(_, sub, _, _):
     seeks(sub)
@@ -1223,7 +1330,7 @@ private func filters(_ plan: Plan) -> Bool {
     filters(source)
   case let .project(_, source):
     filters(source)
-  case let .sort(_, _, source):
+  case let .sort(_, source):
     filters(source)
   case let .derived(_, sub, _, _):
     filters(sub)
@@ -1253,7 +1360,7 @@ private func pushed(_ plan: Plan) -> Bool {
     pushed(source)
   case let .project(_, source):
     pushed(source)
-  case let .sort(_, _, source):
+  case let .sort(_, source):
     pushed(source)
   case let .derived(_, sub, _, _):
     pushed(sub)
@@ -1274,7 +1381,7 @@ private func floats(_ plan: Plan) -> Bool {
     true
   case let .project(_, source):
     floats(source)
-  case let .sort(_, _, source):
+  case let .sort(_, source):
     floats(source)
   case let .derived(_, sub, _, _):
     floats(sub)
@@ -1295,7 +1402,7 @@ private func joins(_ plan: Plan) -> Bool {
     joins(source)
   case let .project(_, source):
     joins(source)
-  case let .sort(_, _, source):
+  case let .sort(_, source):
     joins(source)
   case let .limit(_, _, source):
     joins(source)
@@ -1321,7 +1428,7 @@ private func residual(_ plan: Plan) -> Bool {
     residual(source)
   case let .project(_, source):
     residual(source)
-  case let .sort(_, _, source):
+  case let .sort(_, source):
     residual(source)
   case let .limit(_, _, source):
     residual(source)
@@ -1429,7 +1536,7 @@ private func injected(_ plan: Plan) -> Bool {
     injected(source)
   case let .project(_, source):
     injected(source)
-  case let .sort(_, _, source):
+  case let .sort(_, source):
     injected(source)
   case let .limit(_, _, source):
     injected(source)

--- a/Tests/SQLTests/ParserTests.swift
+++ b/Tests/SQLTests/ParserTests.swift
@@ -224,6 +224,24 @@ struct OrderTests {
     let select = try parse(select: "SELECT * FROM T ORDER BY TypeName DESC")
     #expect(select.order == Order(column: "TypeName", ascending: false))
   }
+
+  @Test("parses a comma-separated list of sort keys")
+  func multipleKeys() throws {
+    let select =
+        try parse(select: "SELECT * FROM T ORDER BY A, B DESC, C")
+    #expect(select.order == Order(keys: [
+      Order.Key(column: "A", ascending: true),
+      Order.Key(column: "B", ascending: false),
+      Order.Key(column: "C", ascending: true),
+    ]))
+  }
+
+  @Test("a single-key ORDER BY is one key in the list")
+  func singleKey() throws {
+    let select = try parse(select: "SELECT * FROM T ORDER BY TypeName DESC")
+    #expect(select.order?.keys
+              == [Order.Key(column: "TypeName", ascending: false)])
+  }
 }
 
 struct CompositeTests {


### PR DESCRIPTION
Extend `ORDER BY` from a single sort column to a comma-separated list of sort keys, each carrying its own `ASC`/`DESC` — the standard SQL `ORDER BY a DESC, b ASC, c`. The keys apply major to minor: the first is the primary key, and each later key orders only the rows the earlier keys leave equal.

The `Order` AST type now holds an ordered `keys` array of `Order.Key` (column plus direction); a single-key `Order(column:ascending:)` initialiser preserves the common case, so a one-key `ORDER BY` behaves exactly as before. The parser reads `key (',' key)*`, and the EBNF fence gains the `key` production. `Plan.sort` carries an ordered `[(slot, ascending)]` list in place of the lone `(slot, ascending)`; its executor walks the keys major to minor, the first key on which two rows differ deciding the order (that key's direction applied to it alone) and equal-on-all-keys rows falling through to the stable input-order tie-break. `Engine.shape` builds the key list from `Select.order`, `referenced` now materialises EVERY order column's ordinal (not just the first), and the resolvers lower each key to its slot. The `optimise`/`pushdown` recursions and the plan-walker test helpers follow the new `.sort` shape. NULL ordering is unchanged.

Adds engine coverage for two-key, mixed-direction, three-key tie-break, a later key breaking ties the first leaves, an all-keys-stable case, and compound top-N/paging via FETCH/OFFSET, plus a single-key regression; parser coverage for the key list.