### PR TITLE
SQL: improve test support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,12 @@ let _ =
                       swiftSettings: [
                         .enableExperimentalFeature("Lifetimes"),
                       ]),
-              .testTarget(name: "SQLTests", dependencies: ["SQL"],
+              .target(name: "SQLTestSupport", dependencies: ["SQL"],
+                      swiftSettings: [
+                        .enableExperimentalFeature("Lifetimes"),
+                      ]),
+              .testTarget(name: "SQLTests",
+                          dependencies: ["SQL", "SQLTestSupport"],
                           swiftSettings: [
                             .enableExperimentalFeature("Lifetimes"),
                           ]),

--- a/Sources/SQLTestSupport/Builders.swift
+++ b/Sources/SQLTestSupport/Builders.swift
@@ -1,0 +1,207 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import SQL
+
+/// Fluent builders over the fixture store, so a test writes a catalog the way
+/// it reads — a nesting of relations, rows, and views — rather than assembling
+/// `FixtureField`/`FixtureRelation`/`FixtureCatalog` values by hand.
+///
+/// A `Catalog { … }` gathers `Relation`/`View` members; a `Relation` gathers
+/// `Row` members; a `Row` takes bare Swift literals a `ValueConvertible` lifts
+/// into `Value`s, so `Row(1, "Alice", 30)` needs no `.integer(…)`/`.text(…)`
+/// ceremony. The schema is an ordered `KeyValuePairs<String, ValueKind>` so a
+/// column's position is its declaration order, and `sorted:` marks a column
+/// seekable — driving the fixture store's binary-search `bound`.
+
+// MARK: - ValueConvertible
+
+/// A Swift value that lifts into a SQL `Value`, so a fixture row is written
+/// with bare literals rather than `.integer(…)`/`.text(…)` cases.
+public protocol ValueConvertible {
+  /// The `Value` this lifts to.
+  var value: Value { get }
+}
+
+extension Value: ValueConvertible {
+  public var value: Value { self }
+}
+
+extension Int: ValueConvertible {
+  public var value: Value { .integer(self) }
+}
+
+extension String: ValueConvertible {
+  public var value: Value { .text(self) }
+}
+
+extension Bool: ValueConvertible {
+  public var value: Value { .boolean(self) }
+}
+
+extension Double: ValueConvertible {
+  public var value: Value { .double(self) }
+}
+
+extension Array: ValueConvertible where Element == UInt8 {
+  public var value: Value { .blob(self) }
+}
+
+/// A `nil` literal projects SQL `NULL`. An `Optional<some ValueConvertible>`
+/// carries a value when present and `NULL` when absent, so `Row(1, nil)` and a
+/// computed optional cell both read as their SQL counterparts.
+extension Optional: ValueConvertible where Wrapped: ValueConvertible {
+  public var value: Value {
+    switch self {
+    case let .some(wrapped): wrapped.value
+    case .none: .null
+    }
+  }
+}
+
+// MARK: - Row builder
+
+/// A builder-gathered row of fixture cells, each a Swift literal the enclosing
+/// `Relation` stores as a `Value`.
+public struct Row {
+  /// The row's cells, in column order.
+  public let cells: Array<Value>
+
+  /// A row of the given cells, each lifted from its Swift literal. A cell is an
+  /// optional `any ValueConvertible` so a bare `nil` literal — which carries no
+  /// type of its own — projects SQL `NULL`, beside the concrete literals.
+  public init(_ cells: (any ValueConvertible)?...) {
+    self.cells = cells.map { $0?.value ?? .null }
+  }
+}
+
+/// Gathers the `Row`s of a `Relation` body into an array of value rows.
+@resultBuilder
+public enum RowBuilder {
+  public static func buildExpression(_ row: Row) -> Array<Value> {
+    row.cells
+  }
+
+  public static func buildBlock(_ rows: Array<Value>...)
+      -> Array<Array<Value>> {
+    rows
+  }
+
+  public static func buildArray(_ rows: Array<Array<Array<Value>>>)
+      -> Array<Array<Value>> {
+    rows.flatMap { $0 }
+  }
+}
+
+// MARK: - Catalog members
+
+/// A catalog member — a base `Relation` or a stored `View` — the
+/// `CatalogBuilder` gathers and `Catalog { … }` assembles into a
+/// `FixtureCatalog`.
+public enum Member {
+  case relation(name: String, FixtureRelation)
+  case view(name: String, SQL.View)
+}
+
+/// A named base relation: an ordered schema, its rows, and an optional seekable
+/// column.
+///
+/// The schema is a `KeyValuePairs<String, ValueKind>` so a column's ordinal is
+/// its declaration order; `sorted:` names the column whose rows are stored in
+/// ascending order, which the fixture store's `bound` seeks (and any other
+/// column scans). The body lists the rows as `Row(…)` literals.
+public struct Relation {
+  public let member: Member
+
+  public init(_ name: String,
+              _ schema: KeyValuePairs<String, ValueKind>,
+              sorted column: String? = nil,
+              @RowBuilder rows: () -> Array<Array<Value>> = { [] }) {
+    let fields = schema.map { FixtureField(name: $0.key, kind: $0.value) }
+    // Fold the sorted-column name like the engine folds identifiers, so
+    // `sorted: "id"` matches a declared `Id`; a name matching no column is a
+    // fixture error and traps rather than silently building an unsorted
+    // relation that would skip the seek path a test means to exercise.
+    let sorted = column.map { name in
+      guard let index = fields.firstIndex(where: {
+        $0.name.lowercased() == name.lowercased()
+      }) else {
+        preconditionFailure("Relation has no column '\(name)' to sort on")
+      }
+      return index
+    }
+    member =
+        .relation(name: name,
+                  FixtureRelation(fields, rows(), sorted: sorted))
+  }
+}
+
+/// A named view: a `SELECT` parsed from its SQL text plus the column names its
+/// rows expose in projection order.
+///
+/// The SQL is parsed through the engine's public `Statement(parsing:)` entry,
+/// so a view built here means exactly what the engine resolves it to; a
+/// non-`SELECT` statement traps as a fixture-construction error.
+public struct View {
+  public let member: Member
+
+  public init(_ name: String, _ sql: String, as columns: Array<String>) throws {
+    let query = try Self.query(sql)
+    member = .view(name: name, SQL.View(query: query, columns: columns))
+  }
+
+  /// Parses `sql` to a `Query`, trapping on any other statement — a fixture's
+  /// view text is a literal the test author controls, so a non-`SELECT` is a
+  /// construction bug rather than a run-time condition to recover from.
+  private static func query(_ sql: String) throws -> Query {
+    guard case let .select(query) = try Statement(parsing: sql) else {
+      throw SQLError.incomplete(expected: "a SELECT statement")
+    }
+    return query
+  }
+}
+
+/// Gathers the `Relation`/`View` members of a `Catalog` body.
+@resultBuilder
+public enum CatalogBuilder {
+  public static func buildExpression(_ relation: Relation) -> Member {
+    relation.member
+  }
+
+  public static func buildExpression(_ view: View) -> Member {
+    view.member
+  }
+
+  public static func buildBlock(_ members: Member...) -> Array<Member> {
+    members
+  }
+
+  public static func buildArray(_ members: Array<Array<Member>>)
+      -> Array<Member> {
+    members.flatMap { $0 }
+  }
+}
+
+// MARK: - Catalog
+
+/// Builds a `FixtureCatalog` from a fluent body of `Relation`/`View` members.
+///
+/// A `try Catalog { Relation(…); View(…) }` reads as the schema it defines,
+/// registering each base relation and each stored view by name — the shared
+/// framework's front door for a test's data source. `try` because a `View`
+/// parses its SQL, which may fault; a `View` naming a column no relation
+/// defines still resolves lazily at query time as a hand-built one does.
+public func Catalog(@CatalogBuilder _ members: () throws -> Array<Member>)
+    throws -> FixtureCatalog {
+  var relations = Dictionary<String, FixtureRelation>()
+  var views = Dictionary<String, SQL.View>()
+  for member in try members() {
+    switch member {
+    case let .relation(name, relation):
+      relations[name] = relation
+    case let .view(name, view):
+      views[name] = view
+    }
+  }
+  return FixtureCatalog(relations, views: views)
+}

--- a/Sources/SQLTestSupport/Collection+Partitioning.swift
+++ b/Sources/SQLTestSupport/Collection+Partitioning.swift
@@ -1,0 +1,27 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+extension Collection {
+  /// The partition point of a collection already partitioned by `predicate` —
+  /// the first index whose element satisfies it, or `endIndex` if none does.
+  ///
+  /// This is the standard `lower_bound` primitive: given a collection whose
+  /// elements are ordered so that every element failing the predicate precedes
+  /// every element satisfying it, a binary search reports the boundary between
+  /// the two runs in `O(log n)` comparisons.
+  func partitioning(by predicate: (Element) -> Bool) -> Index {
+    var lower = startIndex
+    var span = count
+    while span > 0 {
+      let half = span / 2
+      let middle = index(lower, offsetBy: half)
+      if predicate(self[middle]) {
+        span = half
+      } else {
+        lower = index(after: middle)
+        span -= half + 1
+      }
+    }
+    return lower
+  }
+}

--- a/Sources/SQLTestSupport/Expect.swift
+++ b/Sources/SQLTestSupport/Expect.swift
@@ -1,0 +1,84 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import SQL
+import Testing
+
+/// Expectation helpers that run a SQL query against a fixture catalog and check
+/// its rows, forwarding the swift-testing source location so a failure points
+/// at the call site rather than into this file.
+///
+/// `catalog.expect(_:yields:)` runs the query and checks the projected rows
+/// against bare Swift literals a `ValueConvertible` lifts into `Value`s;
+/// `catalog.empty(_:)` checks the query returns nothing; `catalog.expect(_:
+/// fails:)` checks the query raises a given `SQLError`; and
+/// `catalog.expect(_:equals:)` checks two queries return the same rows — the
+/// pervasive "seek result equals scan result" idiom. Each is a `borrowing`
+/// method on the catalog under test, takes a `location` defaulting to the
+/// caller's, and runs through the engine's public `Engine.run`, so the
+/// framework needs no `@testable` import.
+
+/// Parses `sql` to a `Query`, trapping on any other statement.
+private func query(_ sql: String) throws(SQLError) -> Query {
+  guard case let .select(query) = try Statement(parsing: sql) else {
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return query
+}
+
+extension Catalog where Self: ~Escapable {
+  /// Runs `sql` against this catalog through the given routines and bindings.
+  private borrowing func run(_ sql: String, routines: Routines,
+                             bindings: Bindings)
+      throws(SQLError) -> Array<Array<Value>> {
+    try Engine.run(query(sql), self, routines, bindings: bindings)
+  }
+
+  /// Checks `sql` run against this catalog yields exactly `rows`, each row a
+  /// list of Swift literals lifted into `Value`s.
+  public borrowing func expect(_ sql: String,
+      yields rows: Array<Array<(any ValueConvertible)?>>,
+      routines: Routines = [:], bindings: Bindings = [:],
+      location: Testing.SourceLocation = #_sourceLocation) throws {
+    let expected = rows.map { $0.map { $0?.value ?? .null } }
+    let actual = try run(sql, routines: routines, bindings: bindings)
+    #expect(actual == expected, sourceLocation: location)
+  }
+
+  /// Checks `sql` run against this catalog yields no rows.
+  public borrowing func empty(_ sql: String,
+      routines: Routines = [:], bindings: Bindings = [:],
+      location: Testing.SourceLocation = #_sourceLocation) throws {
+    let actual = try run(sql, routines: routines, bindings: bindings)
+    #expect(actual.isEmpty, sourceLocation: location)
+  }
+
+  /// Checks `sql` run against this catalog raises `error`.
+  ///
+  /// The run is eager rather than wrapped in `#expect(throws:)`'s closure — a
+  /// borrowed `~Escapable` catalog cannot be captured by an escaping closure —
+  /// so it catches the outcome and asserts on it, still reporting at the call
+  /// site.
+  public borrowing func expect(_ sql: String, fails error: SQLError,
+      routines: Routines = [:], bindings: Bindings = [:],
+      location: Testing.SourceLocation = #_sourceLocation) {
+    let raised: SQLError?
+    do {
+      _ = try run(sql, routines: routines, bindings: bindings)
+      raised = nil
+    } catch let fault {
+      raised = fault
+    }
+    #expect(raised == error, sourceLocation: location)
+  }
+
+  /// Checks two queries run against this catalog yield the same rows — the
+  /// seek / scan (or hash / seek) equivalence idiom.
+  public borrowing func expect(_ lhs: String, equals rhs: String,
+      routines: Routines = [:], bindings: Bindings = [:],
+      location: Testing.SourceLocation = #_sourceLocation) throws {
+    let left = try run(lhs, routines: routines, bindings: bindings)
+    let right = try run(rhs, routines: routines, bindings: bindings)
+    #expect(left == right, sourceLocation: location)
+  }
+}

--- a/Sources/SQLTestSupport/Fixture.swift
+++ b/Sources/SQLTestSupport/Fixture.swift
@@ -1,0 +1,264 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import SQL
+
+/// An owned, escapable in-memory adapter — the shared fixture store the SQL
+/// engine's tests run their queries against.
+///
+/// The store models a data source entirely in memory: a `FixtureCatalog` over
+/// a dictionary of named `FixtureRelation`s and registered `View`s, vending a
+/// `FixtureTable`/`FixtureCursor`/`FixtureRow` stack the engine walks through
+/// its public adapter protocols. Because the storage is owned rather than
+/// borrowed, every conformer omits `@_lifetime` — the same trick a
+/// `Span`-backed source would replace with lifetime annotations — which is
+/// exactly what a `borrowing Engine.run` admits. It is the proof the engine's
+/// protocols admit an owned source as readily as a mapped-file one, and the
+/// single copy of the adapter both `EngineTests` and `LimitTests` build
+/// fixtures over.
+
+/// A column's name and value kind.
+public struct FixtureField: Sendable {
+  public let name: String
+  public let kind: ValueKind
+
+  public init(name: String, kind: ValueKind) {
+    self.name = name
+    self.kind = kind
+  }
+}
+
+/// The coded-index encoding the in-memory harness models — a raw cell is
+/// `(Id << bits) | tag`, with the tag in the low `bits` (a real coded
+/// index's tag is likewise a small low field, e.g.
+/// `HasCustomAttribute.bits == 5`). Two bits keep the fixtures small while
+/// still being wide enough that a decoded `Id` past `Int.max >> bits` shifts
+/// its high bits out of the word and aliases a real low cell — the truncation
+/// `WinMDRelation.bound`'s upper-bound guard
+/// rejects and this harness mirrors.
+public enum FixtureCoded {
+  public static let bits = 2
+}
+
+/// A mutable tally of the rows a cursor reads, shared by reference so a test
+/// can inspect it after a run. Tests run serially, so the unchecked `Sendable`
+/// is sound.
+public final class FixtureCounter: @unchecked Sendable {
+  public var reads = 0
+
+  public init() {}
+}
+
+/// An in-memory relation: a fixed schema plus rows of typed values.
+///
+/// The `sorted` flag marks a single integral column whose rows are stored in
+/// ascending order; `bound` reports a boundary for that column and `nil` for
+/// any other, so the engine exercises both the seek path and the scan path.
+/// Every relation also exposes a virtual `Id` column — its 1-based row index
+/// — at the ordinal just past its real columns, computed by the `Row` rather
+/// than stored. This type knows nothing of WinMD — it is the proof the engine
+/// is generic.
+public struct FixtureRelation: Sendable {
+  public let fields: Array<FixtureField>
+  public let records: Array<Array<Value>>
+  /// The ordinal of the sorted column, or `nil` if the relation is unsorted.
+  public let sorted: Int?
+  /// A seekable-but-unordered coded column, modelling a decoded coded-index
+  /// key (e.g. `CustomAttribute.Parent_TypeDef`): its stored cell is the raw
+  /// coded value `(Id << bits) | tag`, physically sorted, and `bound`
+  /// brackets it — but the `Row` decodes it (a null reference `Id == 0` or
+  /// any non-`0` tag → `NULL`, else its `Id`), so the decoded column is not
+  /// monotonic in row order. `ordered` reports `false` for it, so the engine
+  /// seeks only an equality and scans a range. The tag occupies
+  /// `FixtureCoded.bits` low bits — wide enough (like a real coded index) that
+  /// a decoded `Id` past
+  /// `Int.max >> FixtureCoded.bits` shifts its high bits entirely out of the
+  /// word and aliases a real low cell, the truncation the seek's upper-bound
+  /// guard rejects.
+  public let coded: Int?
+
+  /// A shared tally the cursor bumps on each row read, or `nil` when a fixture
+  /// does not instrument its reads — the proof selection pushdown and hash join
+  /// materialise fewer rows.
+  public let counter: FixtureCounter?
+
+  public init(_ fields: Array<FixtureField>,
+              _ records: Array<Array<Value>>,
+              sorted: Int? = nil, coded: Int? = nil,
+              counter: FixtureCounter? = nil) {
+    self.fields = fields
+    self.records = records
+    self.sorted = sorted
+    self.coded = coded
+    self.counter = counter
+  }
+}
+
+/// A `Catalog` over a dictionary of named relations.
+///
+/// The adapter is an escapable value, so it conforms to the `~Escapable`
+/// protocols by omitting `@_lifetime` on its own methods — a borrowed-storage
+/// source would instead annotate them. It is the proof the same protocols admit
+/// both a Span-backed source and an owned one.
+public struct FixtureCatalog: Catalog {
+  public let relations: Dictionary<String, FixtureRelation>
+  public let views: Dictionary<String, SQL.View>
+
+  public init(_ relations: Dictionary<String, FixtureRelation>,
+              views: Dictionary<String, SQL.View> = [:]) {
+    self.relations = relations
+    self.views = views
+  }
+
+  public func table(named name: String) -> FixtureTable? {
+    // Fold the lookup like the engine and the WinMD catalog do, so a query's
+    // casing need not match the fixture's declared relation name.
+    let folded = name.lowercased()
+    return relations.first { $0.key.lowercased() == folded }
+        .map { FixtureTable($0.value) }
+  }
+
+  public func view(named name: String) -> SQL.View? {
+    let folded = name.lowercased()
+    return views.first { $0.key.lowercased() == folded }?.value
+  }
+}
+
+/// A `Table` over one in-memory relation, with a virtual `Id` column.
+public struct FixtureTable: Table {
+  public let relation: FixtureRelation
+
+  public init(_ relation: FixtureRelation) {
+    self.relation = relation
+  }
+
+  /// The real columns — `Id` is virtual and excluded from the width, so a
+  /// `SELECT *` never yields it.
+  public var width: Int { relation.fields.count }
+
+  /// The real column names, in ordinal order.
+  public var names: Array<String> { relation.fields.map(\.name) }
+
+  /// The lone virtual `Id` column at ordinal `width`.
+  public var virtuals: Array<String> { ["Id"] }
+
+  /// One past the highest ordinal — the real width plus the lone virtual
+  /// `Id` column at ordinal `width`.
+  public var extent: Int { width + 1 }
+
+  public func ordinal(of name: String) -> Int? {
+    // A real column resolves first; `Id` is the virtual column at the ordinal
+    // just past the real ones, which a real `Id` column of its own shadows.
+    if let real = relation.fields.firstIndex(where: { $0.name == name }) {
+      return real
+    }
+    return name == "Id" ? width : nil
+  }
+
+  public func bound(_ column: Int, _ value: Int, strict: Bool) -> Int? {
+    // The sorted column seeks against `value` directly; the coded column seeks
+    // against the encoded raw cell `(value << FixtureCoded.bits) | 0` — the
+    // tag-0 (TypeDef) encoding of the target `Id` — exactly as
+    // `WinMDRelation` brackets a decoded coded-index key's equal run in the
+    // sorted raw column. A decoded row is 1-based, so the coded column reports
+    // no boundary for a non-positive `value`: it is a null reference
+    // (`Id == 0`) that no cell equals, so the engine scans and filters
+    // rather than seeking the raw run encoding row zero — mirroring
+    // `WinMDRelation.bound`'s `value >= 1` guard. It likewise reports no
+    // boundary for a `value` past `Int.max >> FixtureCoded.bits`, whose shift
+    // would truncate its high bits out of the word and alias a real low cell —
+    // mirroring the adapter's upper-bound guard, so the engine scans and
+    // filters (the huge value matches no decoded cell) instead of seeking the
+    // aliased run. Any other column falls back to a scan.
+    let target: Int? = switch column {
+    case relation.sorted:
+      value
+    case relation.coded
+        where value >= 1 && value <= Int.max >> FixtureCoded.bits:
+      (value << FixtureCoded.bits) | 0
+    default:
+      nil
+    }
+    guard let target else { return nil }
+
+    // NULLs sort FIRST in the engine's ascending order, so a sorted column
+    // whose leading cell is non-integer holds NULL rows a direct seek would
+    // bracket into its range — and the optimiser drops the residual predicate
+    // for an equality seek, returning those NULLs as false matches. Abandon
+    // the seek so the engine scans and filters, preserving the predicate. An
+    // EMPTY relation has no such cell and still seeks (an empty 0 ..< 0 range).
+    if let first = relation.records.first {
+      guard case .integer = first[column] else { return nil }
+    }
+
+    // Partition the (now all-integer) ascending column: the first row whose
+    // cell is `>= target` (non-strict) or `> target` (strict).
+    return relation.records.partitioning { row in
+      guard case let .integer(cell) = row[column] else { return false }
+      return strict ? cell > target : cell >= target
+    }
+  }
+
+  public func ordered(_ column: Int) -> Bool {
+    // The coded column is seekable but not ordered — its stored raw cells are
+    // sorted, but the value the `Row` decodes is not monotonic in row order, so
+    // a range must scan rather than consume a boundary.
+    relation.coded != column
+  }
+
+  public func cursor() -> FixtureCursor {
+    FixtureCursor(relation)
+  }
+}
+
+/// An index-addressed cursor over a relation's rows.
+public struct FixtureCursor: SQL.Cursor {
+  public let relation: FixtureRelation
+
+  public init(_ relation: FixtureRelation) {
+    self.relation = relation
+  }
+
+  public var count: Int { relation.records.count }
+
+  public func row(_ index: Int) -> FixtureRow? {
+    guard index < relation.records.count else { return nil }
+    relation.counter?.reads += 1
+    return FixtureRow(relation, index)
+  }
+}
+
+/// A positional view over one row's cells, real and virtual.
+///
+/// A real ordinal (`< width`) reads the stored cell; the virtual `Id`
+/// ordinal (`== width`) computes the 1-based row index. The view is an
+/// escapable value — no borrowed storage — so it omits `@_lifetime`.
+public struct FixtureRow: SQL.Row {
+  public let relation: FixtureRelation
+  public let index: Int
+
+  public init(_ relation: FixtureRelation, _ index: Int) {
+    self.relation = relation
+    self.index = index
+  }
+
+  public subscript(_ column: Int) -> Value {
+    borrowing get {
+      if column == relation.fields.count { return .integer(index + 1) }
+      // The coded column decodes its raw cell `(Id << FixtureCoded.bits) |
+      // tag` the way a coded-index key does: a tag-`0` (TypeDef) cell whose row
+      // is non-null yields the target `Id`; any other tag (a cell pointing
+      // at a different table) or a null reference (`Id == 0`) yields
+      // `NULL` — the same `row == 0` → `NULL` rule `WinMDRow.key` decodes a
+      // coded index by.
+      if column == relation.coded,
+          case let .integer(raw) = relation.records[index][column] {
+        let mask = (1 << FixtureCoded.bits) - 1
+        return raw & mask == 0 && raw >> FixtureCoded.bits != 0
+                 ? .integer(raw >> FixtureCoded.bits)
+                 : .null
+      }
+      return relation.records[index][column]
+    }
+  }
+}

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -4,250 +4,37 @@
 import Testing
 @testable import SQL
 
+import SQLTestSupport
+
 // MARK: - In-memory adapter
 
-/// A column's name and value kind.
-private struct Field: Sendable {
-  let name: String
-  let kind: ValueKind
-}
-
-/// The coded-index encoding the in-memory harness models — a raw cell is
-/// `(rowid << bits) | tag`, with the tag in the low `bits` (a real coded index's
-/// tag is likewise a small low field, e.g. `HasCustomAttribute.bits == 5`). Two
-/// bits keep the fixtures small while still being wide enough that a decoded
-/// rowid past `Int.max >> bits` shifts its high bits out of the word and aliases
-/// a real low cell — the truncation `WinMDRelation.bound`'s upper-bound guard
-/// rejects and this harness mirrors.
-private enum Coded {
-  static let bits = 2
-}
-
-/// An in-memory relation: a fixed schema plus rows of typed values.
-///
-/// The `sorted` flag marks a single integral column whose rows are stored in
-/// ascending order; `bound` reports a boundary for that column and `nil` for any
-/// other, so the engine exercises both the seek path and the scan path. Every
-/// relation also exposes a virtual `rowid` column — its 1-based row index — at
-/// the ordinal just past its real columns, computed by the `Row` rather than
-/// stored. This type knows nothing of WinMD — it is the proof the engine is
-/// generic.
-private struct Relation: Sendable {
-  let fields: Array<Field>
-  let records: Array<Array<Value>>
-  /// The ordinal of the sorted column, or `nil` if the relation is unsorted.
-  let sorted: Int?
-  /// A seekable-but-unordered coded column, modelling a decoded coded-index key
-  /// (e.g. `CustomAttribute.Parent_TypeDef`): its stored cell is the raw coded
-  /// value `(rowid << bits) | tag`, physically sorted, and `bound` brackets it —
-  /// but the `Row` decodes it (a null reference `rowid == 0` or any non-`0` tag
-  /// → `NULL`, else its `rowid`), so the decoded column is not monotonic in row
-  /// order. `ordered` reports `false` for it, so the engine seeks only an
-  /// equality and scans a range. The tag occupies `Coded.bits` low bits — wide
-  /// enough (like a real coded index) that a decoded rowid past
-  /// `Int.max >> Coded.bits` shifts its high bits entirely out of the word and
-  /// aliases a real low cell, the truncation the seek's upper-bound guard
-  /// rejects.
-  let coded: Int?
-
-  /// A shared tally the cursor bumps on each row read, or `nil` when a fixture
-  /// does not instrument its reads — the proof selection pushdown and hash join
-  /// materialise fewer rows.
-  let counter: Counter?
-
-  init(_ fields: Array<Field>, _ records: Array<Array<Value>>,
-       sorted: Int? = nil, coded: Int? = nil, counter: Counter? = nil) {
-    self.fields = fields
-    self.records = records
-    self.sorted = sorted
-    self.coded = coded
-    self.counter = counter
-  }
-}
-
-/// A mutable tally of the rows a cursor reads, shared by reference so a test can
-/// inspect it after a run. Tests run serially, so the unchecked `Sendable` is
-/// sound.
-private final class Counter: @unchecked Sendable {
-  var reads = 0
-}
-
-/// A `Catalog` over a dictionary of named relations.
-///
-/// The adapter is an escapable value, so it conforms to the `~Escapable`
-/// protocols by omitting `@_lifetime` on its own methods — a borrowed-storage
-/// source would instead annotate them. It is the proof the same protocols admit
-/// both a Span-backed source and an owned one.
-private struct Memory: Catalog {
-  let relations: Dictionary<String, Relation>
-  let views: Dictionary<String, View>
-
-  init(_ relations: Dictionary<String, Relation>,
-       views: Dictionary<String, View> = [:]) {
-    self.relations = relations
-    self.views = views
-  }
-
-  func table(named name: String) -> MemoryTable? {
-    guard let relation = relations[name] else { return nil }
-    return MemoryTable(relation)
-  }
-
-  func view(named name: String) -> View? {
-    views[name]
-  }
-}
-
-/// A `Table` over one in-memory relation, with a virtual `rowid` column.
-private struct MemoryTable: Table {
-  let relation: Relation
-
-  init(_ relation: Relation) {
-    self.relation = relation
-  }
-
-  /// The real columns — `rowid` is virtual and excluded from the width, so a
-  /// `SELECT *` never yields it.
-  var width: Int { relation.fields.count }
-
-  /// The real column names, in ordinal order.
-  var names: Array<String> { relation.fields.map(\.name) }
-
-  /// The lone virtual `rowid` column at ordinal `width`.
-  var virtuals: Array<String> { ["rowid"] }
-
-  /// One past the highest ordinal — the real width plus the lone virtual
-  /// `rowid` column at ordinal `width`.
-  var extent: Int { width + 1 }
-
-  func ordinal(of name: String) -> Int? {
-    // `rowid` is the virtual column at the ordinal just past the real ones.
-    if name == "rowid" { return width }
-    return relation.fields.firstIndex { $0.name == name }
-  }
-
-  func bound(_ column: Int, _ value: Int, strict: Bool) -> Int? {
-    // The sorted column seeks against `value` directly; the coded column seeks
-    // against the encoded raw cell `(value << Coded.bits) | 0` — the tag-0
-    // (TypeDef) encoding of the target `rowid` — exactly as `WinMDRelation`
-    // brackets a decoded coded-index key's equal run in the sorted raw column. A
-    // decoded row is 1-based, so the coded column reports no boundary for a
-    // non-positive `value`: it is a null reference (`rowid == 0`) that no cell
-    // equals, so the engine scans and filters rather than seeking the raw run
-    // encoding row zero — mirroring `WinMDRelation.bound`'s `value >= 1` guard.
-    // It likewise reports no boundary for a `value` past `Int.max >> Coded.bits`,
-    // whose shift would truncate its high bits out of the word and alias a real
-    // low cell — mirroring the adapter's upper-bound guard, so the engine scans
-    // and filters (the huge value matches no decoded cell) instead of seeking the
-    // aliased run. Any other column falls back to a scan.
-    let target: Int
-    switch column {
-    case relation.sorted:
-      target = value
-    case relation.coded where value >= 1 && value <= Int.max >> Coded.bits:
-      target = (value << Coded.bits) | 0
-    default:
-      return nil
-    }
-
-    // Partition the ascending column: the first row whose cell is `>= target`
-    // (non-strict) or `> target` (strict).
-    var lower = 0
-    var upper = relation.records.count
-    while lower < upper {
-      let middle = lower + (upper - lower) / 2
-      guard case let .integer(cell) = relation.records[middle][column] else {
-        return nil
-      }
-      let before = strict ? cell <= target : cell < target
-      if before {
-        lower = middle + 1
-      } else {
-        upper = middle
-      }
-    }
-    return lower
-  }
-
-  func ordered(_ column: Int) -> Bool {
-    // The coded column is seekable but not ordered — its stored raw cells are
-    // sorted, but the value the `Row` decodes is not monotonic in row order, so
-    // a range must scan rather than consume a boundary.
-    relation.coded != column
-  }
-
-  func cursor() -> MemoryCursor {
-    MemoryCursor(relation)
-  }
-}
-
-/// An index-addressed cursor over a relation's rows.
-private struct MemoryCursor: Cursor {
-  let relation: Relation
-
-  init(_ relation: Relation) {
-    self.relation = relation
-  }
-
-  var count: Int { relation.records.count }
-
-  func row(_ index: Int) -> MemoryRow? {
-    guard index < relation.records.count else { return nil }
-    relation.counter?.reads += 1
-    return MemoryRow(relation, index)
-  }
-}
-
-/// A positional view over one row's cells, real and virtual.
-///
-/// A real ordinal (`< width`) reads the stored cell; the virtual `rowid` ordinal
-/// (`== width`) computes the 1-based row index. The view is an escapable value —
-/// the source carries no borrowed storage — so it omits `@_lifetime`.
-private struct MemoryRow: Row {
-  let relation: Relation
-  let index: Int
-
-  init(_ relation: Relation, _ index: Int) {
-    self.relation = relation
-    self.index = index
-  }
-
-  subscript(_ column: Int) -> Value {
-    borrowing get {
-      if column == relation.fields.count { return .integer(index + 1) }
-      // The coded column decodes its raw cell `(rowid << Coded.bits) | tag` the
-      // way a coded-index key does: a tag-`0` (TypeDef) cell whose row is
-      // non-null yields the target `rowid`; any other tag (a cell pointing at a
-      // different table) or a null reference (`rowid == 0`) yields `NULL` — the
-      // same `row == 0` → `NULL` rule `WinMDRow.key` decodes a coded index by.
-      if column == relation.coded,
-          case let .integer(raw) = relation.records[index][column] {
-        let mask = (1 << Coded.bits) - 1
-        return raw & mask == 0 && raw >> Coded.bits != 0
-            ? .integer(raw >> Coded.bits) : .null
-      }
-      return relation.records[index][column]
-    }
-  }
-}
+// The `~Escapable` in-memory adapter and its coded-key/counter machinery now
+// live in the shared `SQLTestSupport` target, built once for every SQL test.
+// The fluent builders (Catalog/Relation/Row/View) author the fixtures below;
+// these aliases keep the store's short names for the inline catalogs the
+// @testable plan-shape and read-counting tests still assemble directly (with a
+// seekable-unordered `coded` column or a shared `counter` the builders do not
+// spell). The store's `Relation` construction is named `FixtureRelation` to
+// leave the plain `Relation` name to the builder.
+private typealias Field = FixtureField
+private typealias Counter = FixtureCounter
+private typealias Coded = FixtureCoded
+private typealias Memory = FixtureCatalog
 
 // MARK: - Fixtures
 
 /// The single-relation catalog: a `People` relation sorted on its `Id` column.
-private func people() -> Memory {
-  let fields = [
-    Field(name: "Id", kind: .integer),
-    Field(name: "Name", kind: .text),
-    Field(name: "Age", kind: .integer),
-  ]
-  let records = [
-    [.integer(1), .text("Alice"), .integer(30)],
-    [.integer(2), .text("Bob"), .integer(25)],
-    [.integer(3), .text("Carol"), .integer(30)],
-    [.integer(4), .text("Dave"), .integer(40)],
-    [.integer(5), .text("Eve"), .integer(25)],
-  ] as Array<Array<Value>>
-  return Memory(["People": Relation(fields, records, sorted: 0)])
+private func people() throws -> Memory {
+  try Catalog {
+    Relation("People", ["Id": .integer, "Name": .text, "Age": .integer],
+             sorted: "Id") {
+      Row(1, "Alice", 30)
+      Row(2, "Bob", 25)
+      Row(3, "Carol", 30)
+      Row(4, "Dave", 40)
+      Row(5, "Eve", 25)
+    }
+  }
 }
 
 /// A single-relation catalog for compound ordering: a `Grade` relation whose
@@ -255,40 +42,40 @@ private func people() -> Memory {
 /// Class, Score, Name` needs the third key to settle rows the first two leave
 /// equal. The rows are stored out of every non-`Id` order, so a sort is never a
 /// no-op.
-private func grades() -> Memory {
-  let fields = [
-    Field(name: "Id", kind: .integer),
-    Field(name: "Class", kind: .text),
-    Field(name: "Score", kind: .integer),
-    Field(name: "Name", kind: .text),
-  ]
-  let records = [
-    [.integer(1), .text("B"), .integer(90), .text("Zed")],
-    [.integer(2), .text("A"), .integer(80), .text("Yan")],
-    [.integer(3), .text("A"), .integer(80), .text("Ada")],
-    [.integer(4), .text("B"), .integer(90), .text("Amy")],
-    [.integer(5), .text("A"), .integer(80), .text("Mel")],
-    [.integer(6), .text("A"), .integer(70), .text("Bob")],
-  ] as Array<Array<Value>>
-  return Memory(["Grade": Relation(fields, records, sorted: 0)])
+private func grades() throws -> Memory {
+  try Catalog {
+    Relation("Grade", ["Id": .integer, "Class": .text, "Score": .integer,
+                       "Name": .text], sorted: "Id") {
+      Row(1, "B", 90, "Zed")
+      Row(2, "A", 80, "Yan")
+      Row(3, "A", 80, "Ada")
+      Row(4, "B", 90, "Amy")
+      Row(5, "A", 80, "Mel")
+      Row(6, "A", 70, "Bob")
+    }
+  }
 }
 
 /// A catalog modelling a decoded coded-index key: an `Attribute` relation whose
 /// `Parent` column is seekable but not ordered. It stands in for a
 /// `CustomAttribute` physically sorted on its raw `Parent` coded index with
 /// mixed tags — each row's stored `Parent` is the raw coded cell
-/// `(rowid << Coded.bits) | tag` (tag `0` a `TypeDef`, tag `1` another table),
+/// `(Id << Coded.bits) | tag` (tag `0` a `TypeDef`, tag `1` another table),
 /// sorted ascending; the `Row` decodes it, so the column reads as the target
-/// `TypeDef` `rowid` (tag `0`) or `NULL` (tag `1`). The raw run brackets one
+/// `TypeDef` `Id` (tag `0`) or `NULL` (tag `1`). The raw run brackets one
 /// tag's equal value, but the tag-1 rows interleaved by row decode to `NULL`, so
 /// a range on the decoded column must not seek the raw boundary — it would
 /// return other-tag rows that decode outside the range.
+///
+/// The `Parent` column is seekable-but-unordered, so it is built directly as a
+/// `FixtureRelation` with `coded: 0` — the seekable-unordered marker the fluent
+/// `Relation` (whose only marker is `sorted:`) does not spell.
 private func attributes() -> Memory {
   let fields = [
     Field(name: "Parent", kind: .integer),
     Field(name: "Name", kind: .text),
   ]
-  // Stored `Parent` = `(rowid << 2) | tag` (Coded.bits == 2), ascending.
+  // Stored `Parent` = `(Id << 2) | tag` (Coded.bits == 2), ascending.
   // Decoded `Parent`:
   //   raw  0 = (0<<2)|0 → NULL (null reference — row 0)
   //   raw  4 = (1<<2)|0 → TypeDef 1     raw  5 = (1<<2)|1 → NULL
@@ -306,61 +93,51 @@ private func attributes() -> Memory {
     [.integer(20), .text("td5")],
     [.integer(24), .text("td6")],
   ] as Array<Array<Value>>
-  return Memory(["Attribute": Relation(fields, records, coded: 0)])
+  return Memory(["Attribute": FixtureRelation(fields, records, coded: 0)])
 }
 
 /// A wide catalog: a `Wide` relation of ten columns, to prove a query that
 /// references only a few of them still works (projection pushdown).
+///
+/// The ten columns and four rows are generated, so it is built directly as a
+/// `FixtureRelation` rather than a literal-per-row fluent `Relation`.
 private func wide() -> Memory {
   let fields = (0 ..< 10).map { Field(name: "C\($0)", kind: .integer) }
   let records = (0 ..< 4).map { row in
     (0 ..< 10).map { Value.integer(row * 10 + $0) }
   }
-  return Memory(["Wide": Relation(fields, records, sorted: 0)])
+  return Memory(["Wide": FixtureRelation(fields, records, sorted: 0)])
 }
 
 /// The join catalog: a `Parent` relation sorted on `Id`, an unsorted twin
 /// `ParentUnsorted` (same rows, no seekable column), and a `Child` relation
 /// whose `Pid` is a foreign key to a parent `Id`. The `Ordered` relation has no
-/// stored key — a join on it keys off its virtual `rowid`.
-private func family() -> Memory {
-  let parent = [
-    Field(name: "Id", kind: .integer),
-    Field(name: "Name", kind: .text),
-  ]
-  let parents = [
-    [.integer(1), .text("Ada")],
-    [.integer(2), .text("Bee")],
-    [.integer(3), .text("Cid")],
-  ] as Array<Array<Value>>
-
-  let child = [
-    Field(name: "Pid", kind: .integer),
-    Field(name: "Name", kind: .text),
-  ]
-  let children = [
-    [.integer(1), .text("Ann")],
-    [.integer(1), .text("Amy")],
-    [.integer(2), .text("Bob")],
-    [.integer(9), .text("Orphan")],
-  ] as Array<Array<Value>>
-
-  // A keyless relation: its identity is its 1-based row position (`rowid`).
-  let ordered = [
-    Field(name: "Label", kind: .text),
-  ]
-  let labels = [
-    [.text("first")],
-    [.text("second")],
-    [.text("third")],
-  ] as Array<Array<Value>>
-
-  return Memory([
-    "Parent": Relation(parent, parents, sorted: 0),
-    "ParentUnsorted": Relation(parent, parents),
-    "Child": Relation(child, children),
-    "Ordered": Relation(ordered, labels),
-  ])
+/// stored key — a join on it keys off its virtual `Id`.
+private func family() throws -> Memory {
+  try Catalog {
+    Relation("Parent", ["Id": .integer, "Name": .text], sorted: "Id") {
+      Row(1, "Ada")
+      Row(2, "Bee")
+      Row(3, "Cid")
+    }
+    Relation("ParentUnsorted", ["Id": .integer, "Name": .text]) {
+      Row(1, "Ada")
+      Row(2, "Bee")
+      Row(3, "Cid")
+    }
+    Relation("Child", ["Pid": .integer, "Name": .text]) {
+      Row(1, "Ann")
+      Row(1, "Amy")
+      Row(2, "Bob")
+      Row(9, "Orphan")
+    }
+    // A keyless relation: its identity is its 1-based row position (`Id`).
+    Relation("Ordered", ["Label": .text]) {
+      Row("first")
+      Row("second")
+      Row("third")
+    }
+  }
 }
 
 /// The view catalog: the `family` relations plus two registered views — `Adults`
@@ -368,113 +145,76 @@ private func family() -> Memory {
 /// the `Parent`/`Child` foreign-key join). A view is queried like a table, and
 /// `Pairs` proves a view whose definition is itself a join.
 private func views() throws -> Memory {
-  // SELECT Id, Name FROM Parent WHERE Id >= 2 — exposed as columns Key, Label.
-  let adults = try View(query: select("""
-      SELECT Id, Name FROM Parent WHERE Id >= 2
-      """), columns: ["Key", "Label"])
-
-  // SELECT Parent.Name, Child.Name FROM Parent JOIN Child ON … — a view over a
-  // join, its two projected columns exposed as Parent and Kid.
-  let pairs = try View(query: select("""
-      SELECT Parent.Name, Child.Name FROM Parent
-        JOIN Child ON Child.Pid = Parent.Id
-      """), columns: ["Parent", "Kid"])
-
-  // SELECT Id, Name FROM Parent WHERE Id = :id — a parameterized view whose
-  // bound key seeks inside its sub-plan when :id is supplied.
-  let picked = try View(query: select("""
-      SELECT Id, Name FROM Parent WHERE Id = :id
-      """), columns: ["Key", "Label"])
-
-  let catalog = family()
-  return Memory(catalog.relations,
-                views: ["Adults": adults, "Pairs": pairs, "Picked": picked])
+  // Registered over the `family` relations, so the view bodies resolve their
+  // `Parent`/`Child` against the same base tables the other join tests use.
+  let catalog = try Catalog {
+    // SELECT Id, Name FROM Parent WHERE Id >= 2 — columns exposed as Key/Label.
+    try View("Adults", "SELECT Id, Name FROM Parent WHERE Id >= 2",
+             as: ["Key", "Label"])
+    // A view over a join, its two projected columns exposed as Parent and Kid.
+    try View("Pairs", """
+        SELECT Parent.Name, Child.Name FROM Parent
+          JOIN Child ON Child.Pid = Parent.Id
+        """, as: ["Parent", "Kid"])
+    // A parameterized view whose bound key seeks inside its sub-plan when :id
+    // is supplied.
+    try View("Picked", "SELECT Id, Name FROM Parent WHERE Id = :id",
+             as: ["Key", "Label"])
+  }
+  return Memory(try family().relations, views: catalog.views)
 }
 
 /// A catalog with NULL cells: a `Maybe` relation whose `Note` text column is
 /// `NULL` in some rows, to exercise three-valued comparison and `IS [NOT] NULL`.
-private func nullable() -> Memory {
-  let fields = [
-    Field(name: "Id", kind: .integer),
-    Field(name: "Note", kind: .text),
-  ]
-  let records = [
-    [.integer(1), .text("alpha")],
-    [.integer(2), .null],
-    [.integer(3), .text("gamma")],
-    [.integer(4), .null],
-  ] as Array<Array<Value>>
-  return Memory(["Maybe": Relation(fields, records)])
+private func nullable() throws -> Memory {
+  try Catalog {
+    Relation("Maybe", ["Id": .integer, "Note": .text]) {
+      Row(1, "alpha")
+      Row(2, nil)
+      Row(3, "gamma")
+      Row(4, nil)
+    }
+  }
 }
 
 /// The null-key join catalog: a `Parent` sorted on `Id` and a `Child` one of
 /// whose foreign keys is `NULL`, to prove a `NULL` join key matches nothing.
-private func nullableKeys() -> Memory {
-  let parent = [
-    Field(name: "Id", kind: .integer),
-    Field(name: "Name", kind: .text),
-  ]
-  let parents = [
-    [.integer(1), .text("Ada")],
-    [.integer(2), .text("Bee")],
-  ] as Array<Array<Value>>
-
-  let child = [
-    Field(name: "Pid", kind: .integer),
-    Field(name: "Name", kind: .text),
-  ]
-  let children = [
-    [.integer(1), .text("Ann")],
-    [.null, .text("Nobody")],
-    [.integer(2), .text("Bob")],
-  ] as Array<Array<Value>>
-
-  return Memory([
-    "Parent": Relation(parent, parents, sorted: 0),
-    "Child": Relation(child, children),
-  ])
+private func nullableKeys() throws -> Memory {
+  try Catalog {
+    Relation("Parent", ["Id": .integer, "Name": .text], sorted: "Id") {
+      Row(1, "Ada")
+      Row(2, "Bee")
+    }
+    Relation("Child", ["Pid": .integer, "Name": .text]) {
+      Row(1, "Ann")
+      Row(nil, "Nobody")
+      Row(2, "Bob")
+    }
+  }
 }
 
 /// A three-level catalog for multi-way joins: `House` → `Room` → `Item`, each
 /// child carrying a foreign key to its parent's `Id`. `House` and `Room` are
 /// sorted on `Id`, so a join keyed on `Id` seeks; `Item` is unsorted and scans.
-private func lineage() -> Memory {
-  let house = [
-    Field(name: "Id", kind: .integer),
-    Field(name: "House", kind: .text),
-  ]
-  let houses = [
-    [.integer(1), .text("Burrow")],
-    [.integer(2), .text("Manor")],
-  ] as Array<Array<Value>>
-
-  let room = [
-    Field(name: "Id", kind: .integer),
-    Field(name: "Hid", kind: .integer),
-    Field(name: "Room", kind: .text),
-  ]
-  let rooms = [
-    [.integer(1), .integer(1), .text("Kitchen")],
-    [.integer(2), .integer(1), .text("Attic")],
-    [.integer(3), .integer(2), .text("Hall")],
-  ] as Array<Array<Value>>
-
-  let item = [
-    Field(name: "Rid", kind: .integer),
-    Field(name: "Item", kind: .text),
-  ]
-  let items = [
-    [.integer(1), .text("Kettle")],
-    [.integer(1), .text("Pot")],
-    [.integer(3), .text("Banner")],
-    [.integer(9), .text("Lost")],
-  ] as Array<Array<Value>>
-
-  return Memory([
-    "House": Relation(house, houses, sorted: 0),
-    "Room": Relation(room, rooms, sorted: 0),
-    "Item": Relation(item, items),
-  ])
+private func lineage() throws -> Memory {
+  try Catalog {
+    Relation("House", ["Id": .integer, "House": .text], sorted: "Id") {
+      Row(1, "Burrow")
+      Row(2, "Manor")
+    }
+    Relation("Room", ["Id": .integer, "Hid": .integer, "Room": .text],
+             sorted: "Id") {
+      Row(1, 1, "Kitchen")
+      Row(2, 1, "Attic")
+      Row(3, 2, "Hall")
+    }
+    Relation("Item", ["Rid": .integer, "Item": .text]) {
+      Row(1, "Kettle")
+      Row(1, "Pot")
+      Row(3, "Banner")
+      Row(9, "Lost")
+    }
+  }
 }
 
 /// A chain whose first join's `ON` uses an unqualified column that is unique in
@@ -487,39 +227,21 @@ private func lineage() -> Memory {
 /// Resolving the match against the prefix binds `Code` unambiguously; resolving
 /// it against the whole chain would (wrongly) see `Code` in two relations and
 /// report `SQLError.ambiguous`.
-private func shared() -> Memory {
-  let author = [
-    Field(name: "Aid", kind: .integer),
-    Field(name: "Code", kind: .integer),
-  ]
-  let authors = [
-    [.integer(1), .integer(10)],
-    [.integer(2), .integer(20)],
-  ] as Array<Array<Value>>
-
-  let book = [
-    Field(name: "Bid", kind: .integer),
-    Field(name: "Aid", kind: .integer),
-  ]
-  let books = [
-    [.integer(100), .integer(10)],
-    [.integer(101), .integer(20)],
-  ] as Array<Array<Value>>
-
-  let sale = [
-    Field(name: "Sid", kind: .integer),
-    Field(name: "Code", kind: .integer),
-  ]
-  let sales = [
-    [.integer(100), .integer(900)],
-    [.integer(101), .integer(901)],
-  ] as Array<Array<Value>>
-
-  return Memory([
-    "Author": Relation(author, authors, sorted: 0),
-    "Book": Relation(book, books, sorted: 1),
-    "Sale": Relation(sale, sales),
-  ])
+private func shared() throws -> Memory {
+  try Catalog {
+    Relation("Author", ["Aid": .integer, "Code": .integer], sorted: "Aid") {
+      Row(1, 10)
+      Row(2, 20)
+    }
+    Relation("Book", ["Bid": .integer, "Aid": .integer], sorted: "Aid") {
+      Row(100, 10)
+      Row(101, 20)
+    }
+    Relation("Sale", ["Sid": .integer, "Code": .integer]) {
+      Row(100, 900)
+      Row(101, 901)
+    }
+  }
 }
 
 /// Parses `text` to a query, failing on any other statement.
@@ -544,11 +266,6 @@ private func run(_ text: String) throws -> Array<Array<Value>> {
 /// Runs `text` against the compound-ordering `Grade` catalog.
 private func grades(_ text: String) throws -> Array<Array<Value>> {
   try Engine.run(parse(text), grades())
-}
-
-/// Runs `text` against the wide catalog.
-private func wide(_ text: String) throws -> Array<Array<Value>> {
-  try Engine.run(parse(text), wide())
 }
 
 /// Runs `text` against the coded-key `Attribute` catalog.
@@ -576,31 +293,26 @@ private func lineage(_ text: String) throws -> Array<Array<Value>> {
   try Engine.run(parse(text), lineage())
 }
 
-/// Runs `text` against the `shared`-column chain catalog.
-private func shared(_ text: String) throws -> Array<Array<Value>> {
-  try Engine.run(parse(text), shared())
-}
-
 // MARK: - Single-relation tests
 
 struct EngineProjectionTests {
-  @Test("SELECT * yields every real column and excludes the virtual rowid")
+  @Test("SELECT * yields every real column and excludes the virtual Id")
   func star() throws {
     let rows = try run("SELECT * FROM People WHERE Id = 1")
-    // Three real columns; `rowid` is virtual and never in `*`.
+    // Three real columns; `Id` is virtual and never in `*`.
     #expect(rows == [[.integer(1), .text("Alice"), .integer(30)]])
   }
 
   @Test("SELECT names yields the named columns in order")
   func named() throws {
-    let rows = try run("SELECT Name, Id FROM People WHERE Id = 2")
-    #expect(rows == [[.text("Bob"), .integer(2)]])
+    try people().expect("SELECT Name, Id FROM People WHERE Id = 2",
+                        yields: [["Bob", 2]])
   }
 
-  @Test("a named projection may include the virtual rowid column")
+  @Test("a named projection may include the virtual Id column")
   func virtual() throws {
-    let rows = try run("SELECT rowid, Name FROM People WHERE Name = 'Carol'")
-    // Carol is the third row; her 1-based `rowid` is 3.
+    let rows = try run("SELECT Id, Name FROM People WHERE Name = 'Carol'")
+    // Carol is the third row; her 1-based `Id` is 3.
     #expect(rows == [[.integer(3), .text("Carol")]])
   }
 
@@ -613,23 +325,21 @@ struct EngineProjectionTests {
 
   @Test("an unknown relation is reported")
   func relation() throws {
-    #expect(throws: SQLError.relation("Absent")) {
-      try run("SELECT * FROM Absent")
-    }
+    try people().expect("SELECT * FROM Absent", fails: .relation("Absent"))
   }
 }
 
 struct EngineFilterTests {
   @Test("equality on a text column")
   func text() throws {
-    let rows = try run("SELECT Id FROM People WHERE Name = 'Carol'")
-    #expect(rows == [[.integer(3)]])
+    try people().expect("SELECT Id FROM People WHERE Name = 'Carol'",
+                        yields: [[3]])
   }
 
   @Test("a range on the sorted column")
   func range() throws {
-    let rows = try run("SELECT Id FROM People WHERE Id >= 4")
-    #expect(rows == [[.integer(4)], [.integer(5)]])
+    try people().expect("SELECT Id FROM People WHERE Id >= 4",
+                        yields: [[4], [5]])
   }
 
   @Test("an AND of a seekable conjunct and a residual")
@@ -647,14 +357,14 @@ struct EngineFilterTests {
 
   @Test("a NOT scans and negates")
   func negation() throws {
-    let rows = try run("SELECT Id FROM People WHERE NOT Age = 30")
-    #expect(rows == [[.integer(2)], [.integer(4)], [.integer(5)]])
+    try people().expect("SELECT Id FROM People WHERE NOT Age = 30",
+                        yields: [[2], [4], [5]])
   }
 
-  @Test("a filter on the virtual rowid column")
+  @Test("a filter on the virtual Id column")
   func virtual() throws {
-    let rows = try run("SELECT Name FROM People WHERE rowid = 4")
-    #expect(rows == [[.text("Dave")]])
+    try people().expect("SELECT Name FROM People WHERE Id = 4",
+                        yields: [["Dave"]])
   }
 }
 
@@ -737,21 +447,21 @@ struct EngineCompoundOrderTests {
   func topN() throws {
     // Age descending, ties by Name ascending, then the first two rows: Dave(40)
     // and the lower-named of the 30s, Alice.
-    let rows = try run("""
+    try people().expect("""
         SELECT Name FROM People
           ORDER BY Age DESC, Name ASC FETCH FIRST 2 ROWS ONLY
-        """)
-    #expect(rows == [[.text("Dave")], [.text("Alice")]])
+        """,
+        yields: [["Dave"], ["Alice"]])
   }
 
   @Test("OFFSET then FETCH pages into a compound order")
   func page() throws {
     // The full compound order is Dave, Alice, Carol, Bob, Eve; skip 1, take 2.
-    let rows = try run("""
+    try people().expect("""
         SELECT Name FROM People
           ORDER BY Age DESC, Name ASC OFFSET 1 ROWS FETCH NEXT 2 ROWS ONLY
-        """)
-    #expect(rows == [[.text("Alice")], [.text("Carol")]])
+        """,
+        yields: [["Alice"], ["Carol"]])
   }
 }
 
@@ -761,14 +471,10 @@ struct EngineProjectionPushdownTests {
     // The relation has ten columns; the query reads only C0 (filter, project),
     // C5 (project), and C8 (order). The leaf materialises just those, but the
     // result is exactly as if every column were copied.
-    let rows = try wide("""
+    try wide().expect("""
         SELECT C5, C0 FROM Wide WHERE C0 >= 10 ORDER BY C8 DESC
-        """)
-    #expect(rows == [
-      [.integer(35), .integer(30)],
-      [.integer(25), .integer(20)],
-      [.integer(15), .integer(10)],
-    ])
+        """,
+        yields: [[35, 30], [25, 20], [15, 10]])
   }
 }
 
@@ -801,13 +507,13 @@ struct EngineSeekTests {
 /// `CustomAttribute` in the byte-buffer harness is impractical, and the leak is
 /// purely a property of `boundaries`/`bound` over an unordered seekable column,
 /// which the memory table models faithfully (stored raw
-/// `(rowid << Coded.bits) | tag`, decoded to the `TypeDef` `rowid` or `NULL`).
+/// `(Id << Coded.bits) | tag`, decoded to the `TypeDef` `Id` or `NULL`).
 /// The engine-level plan-shape assertion complements the two result assertions.
 struct EngineCodedKeyTests {
   @Test("a range on an unordered coded key scans and admits only its own rows")
   func range() throws {
     // `Parent < 5` must return only the TypeDef-tagged rows whose decoded
-    // `rowid` is `< 5` (td1, td2, td4) — never the other-tag rows (other-a, -b,
+    // `Id` is `< 5` (td1, td2, td4) — never the other-tag rows (other-a, -b,
     // -c), which decode to NULL. Before the fix the raw boundary
     // `0 ..< bound(5)` seeked the low raw run, sweeping in the interleaved NULLs.
     let rows = try attributes("SELECT Name FROM Attribute WHERE Parent < 5")
@@ -842,7 +548,7 @@ struct EngineCodedKeyTests {
     // which encodes exactly the target the equality would seek; before the fix
     // `bound(0, …)` bracketed that raw run and `Engine.seek` consumed it with no
     // residual recheck, leaking the null-reference row. The fix returns `nil`
-    // for a non-positive decoded rowid, so the query scans and filters, and the
+    // for a non-positive decoded Id, so the query scans and filters, and the
     // decoded `NULL` correctly fails `= 0`.
     let rows = try attributes("SELECT Name FROM Attribute WHERE Parent = 0")
     #expect(rows.isEmpty)
@@ -850,14 +556,14 @@ struct EngineCodedKeyTests {
 
   @Test("an equality too large to encode rejects rather than seeking an alias")
   func overflow() throws {
-    // A decoded rowid must be encodable without truncation. `(1 << 62) + 6` is
+    // A decoded Id must be encodable without truncation. `(1 << 62) + 6` is
     // positive but past `Int.max >> Coded.bits`, so `(value << 2) | 0` shifts the
     // high `1` clear out of the word and aliases raw `24` — the same raw cell as
     // `td6` (`(6 << 2) | 0`). Before the upper-bound guard, `bound` bracketed
     // that aliased run and `Engine.seek` consumed the standalone equality with no
     // residual recheck, returning td6 for a value no decoded key equals. The
     // guard returns `nil` for the unencodable value, so the query scans and
-    // filters — every decoded key is a small rowid or NULL, none equals the huge
+    // filters — every decoded key is a small Id or NULL, none equals the huge
     // value — and admits nothing.
     let alias = (1 << 62) + 6
     let rows =
@@ -883,19 +589,61 @@ struct EngineCodedKeyTests {
     #expect(!seeks(lessPlan))
     #expect(filters(lessPlan))
   }
+
+  @Test("a sorted key with a leading NULL does not seek it into an equality")
+  func nullableSortedKey() throws {
+    // NULLs sort first, so a direct seek would bracket the NULL row into the
+    // `K = 1` range; an equality seek drops the residual, so the sorted-key
+    // seek must fall back to a scan and filter the NULL out, not return it.
+    let catalog = try Catalog {
+      Relation("T", ["K": .integer, "V": .text], sorted: "K") {
+        Row(nil, "null")
+        Row(1, "one")
+      }
+    }
+    try catalog.expect("SELECT V FROM T WHERE K = 1", yields: [["one"]])
+  }
+
+  @Test("a case-varied sorted-column name is still seekable")
+  func foldedSortedKey() throws {
+    // The fixture folds `sorted: "id"` to the declared `Id`, so an equality on
+    // it plans a seek — a case mismatch must not silently build an unsorted
+    // relation that drops to a scan the plan-shape tests mean to cover.
+    let catalog = try Catalog {
+      Relation("T", ["Id": .integer], sorted: "id") {
+        Row(1)
+        Row(2)
+      }
+    }
+    let query = try parse("SELECT * FROM T WHERE Id = 1")
+    let plan = try Engine.optimise(Engine.compile(query, catalog), catalog, [:])
+    #expect(seeks(plan))
+  }
+
+  @Test("an empty sorted fixture still plans a seek")
+  func emptySortedKey() throws {
+    // A sorted relation with no rows has no leading cell to disqualify the
+    // seek; it plans a seek over the empty range, not a scan.
+    let catalog = try Catalog {
+      Relation("T", ["Id": .integer], sorted: "Id")
+    }
+    let query = try parse("SELECT * FROM T WHERE Id = 1")
+    let plan = try Engine.optimise(Engine.compile(query, catalog), catalog, [:])
+    #expect(seeks(plan))
+  }
 }
 
 struct EngineQualifierTests {
   @Test("a qualifier matching the alias resolves the column")
   func alias() throws {
-    let rows = try run("SELECT p.Name FROM People AS p WHERE Id = 1")
-    #expect(rows == [[.text("Alice")]])
+    try people().expect("SELECT p.Name FROM People AS p WHERE Id = 1",
+                        yields: [["Alice"]])
   }
 
   @Test("a qualifier matching the table name resolves the column")
   func name() throws {
-    let rows = try run("SELECT People.Name FROM People WHERE Id = 1")
-    #expect(rows == [[.text("Alice")]])
+    try people().expect("SELECT People.Name FROM People WHERE Id = 1",
+                        yields: [["Alice"]])
   }
 
   @Test("a qualifier naming neither the alias nor the table is reported")
@@ -905,6 +653,20 @@ struct EngineQualifierTests {
     #expect(throws: SQLError.column("Name")) {
       try run("SELECT x.Name FROM People AS p")
     }
+  }
+
+  @Test("a relation and a view name resolve case-insensitively")
+  func folded() throws {
+    // The fixture folds a name like the engine and the WinMD catalog do, so a
+    // query need not match the declared relation/view casing.
+    let catalog = try Catalog {
+      Relation("People", ["Id": .integer, "Name": .text]) {
+        Row(1, "Alice")
+      }
+      try View("Adults", "SELECT Name FROM People", as: ["Name"])
+    }
+    try catalog.expect("SELECT Name FROM people", yields: [["Alice"]])
+    try catalog.expect("SELECT Name FROM adults", yields: [["Alice"]])
   }
 
   @Test("a qualifier naming a different table is reported")
@@ -935,24 +697,20 @@ struct EngineJoinTests {
 
   @Test("a qualified projection selects across both relations")
   func qualified() throws {
-    let rows = try join("""
+    try family().expect("""
         SELECT Parent.Name, Child.Name FROM Parent
           JOIN Child ON Child.Pid = Parent.Id
-        """)
-    #expect(rows == [
-      [.text("Ada"), .text("Ann")],
-      [.text("Ada"), .text("Amy")],
-      [.text("Bee"), .text("Bob")],
-    ])
+        """,
+        yields: [["Ada", "Ann"], ["Ada", "Amy"], ["Bee", "Bob"]])
   }
 
-  @Test("a join keys off the inner relation's virtual rowid")
+  @Test("a join keys off the inner relation's virtual Id")
   func virtual() throws {
-    // `Ordered` has no stored key; its identity is its 1-based `rowid`. The
+    // `Ordered` has no stored key; its identity is its 1-based `Id`. The
     // child's `Pid` joins to that virtual column.
     let rows = try join("""
         SELECT Ordered.Label, Child.Name FROM Child
-          JOIN Ordered ON Ordered.rowid = Child.Pid
+          JOIN Ordered ON Ordered.Id = Child.Pid
         """)
     // Pid 1 → "first" (Ann, Amy), Pid 2 → "second" (Bob); Pid 9 has no row.
     #expect(rows == [
@@ -962,21 +720,21 @@ struct EngineJoinTests {
     ])
   }
 
-  @Test("a join keyed off the OUTER relation's virtual rowid does not collide")
+  @Test("a join keyed off the OUTER relation's virtual Id does not collide")
   func outerVirtual() throws {
     // The combined ordinal space lays the inner relation past the outer's
     // `extent` — its real width plus the virtual columns it exposes — so an
     // outer virtual column never shares an ordinal with an inner real one. Here
-    // `Ordered` is the OUTER relation, and the join keys off its virtual `rowid`
+    // `Ordered` is the OUTER relation, and the join keys off its virtual `Id`
     // at ordinal `width`; the inner `Child.Pid` is a real column at ordinal 0.
     // Were the inner laid at the outer's `width` (or at a base collapsed to 0
     // by a `1 << 32` reserve on a 32-bit host), `Child.Pid` would land on the
-    // outer `rowid`'s ordinal and the join's cells would corrupt one another.
+    // outer `Id`'s ordinal and the join's cells would corrupt one another.
     let rows = try join("""
-        SELECT Ordered.rowid, Child.Name FROM Ordered
-          JOIN Child ON Child.Pid = Ordered.rowid
+        SELECT Ordered.Id, Child.Name FROM Ordered
+          JOIN Child ON Child.Pid = Ordered.Id
         """)
-    // rowid 1 → Ann, Amy; rowid 2 → Bob; rowid 3 has no child; Pid 9 no parent.
+    // Id 1 → Ann, Amy; Id 2 → Bob; Id 3 has no child; Pid 9 no parent.
     #expect(rows == [
       [.integer(1), .text("Ann")],
       [.integer(1), .text("Amy")],
@@ -986,20 +744,20 @@ struct EngineJoinTests {
 
   @Test("a WHERE spans both relations")
   func predicate() throws {
-    let rows = try join("""
+    try family().expect("""
         SELECT Child.Name FROM Parent JOIN Child ON Child.Pid = Parent.Id
           WHERE Parent.Name = 'Ada' AND Child.Name = 'Amy'
-        """)
-    #expect(rows == [[.text("Amy")]])
+        """,
+        yields: [["Amy"]])
   }
 
   @Test("ORDER BY orders across the join")
   func order() throws {
-    let rows = try join("""
+    try family().expect("""
         SELECT Child.Name FROM Parent JOIN Child ON Child.Pid = Parent.Id
           ORDER BY Child.Name ASC
-        """)
-    #expect(rows == [[.text("Amy")], [.text("Ann")], [.text("Bob")]])
+        """,
+        yields: [["Amy"], ["Ann"], ["Bob"]])
   }
 
   @Test("an unqualified name in both relations is ambiguous")
@@ -1020,11 +778,11 @@ struct EngineJoinTests {
 
   @Test("a duplicated alias makes a shared qualified column ambiguous")
   func duplicate() throws {
-    // `x.Id`/`x.Pid` resolve by column (one side each); `x.Name` is on both,
+    // `x.Pid` resolves by column (the Child side only); `x.Name` is on both,
     // so the shared alias is ambiguous rather than binding silently to outer.
     #expect(throws: SQLError.ambiguous("Name")) {
       try join("""
-          SELECT x.Name FROM Parent AS x JOIN Child AS x ON x.Id = x.Pid
+          SELECT x.Name FROM Parent AS x JOIN Child AS x ON x.Pid = x.Pid
           """)
     }
   }
@@ -1099,13 +857,13 @@ struct EngineMultiJoinTests {
 
   @Test("a WHERE filters across a three-relation chain")
   func filtered() throws {
-    let rows = try lineage("""
+    try lineage().expect("""
         SELECT Item.Item FROM House
           JOIN Room ON Room.Hid = House.Id
           JOIN Item ON Item.Rid = Room.Id
           WHERE House.House = 'Burrow' AND Item.Item = 'Pot'
-        """)
-    #expect(rows == [[.text("Pot")]])
+        """,
+        yields: [["Pot"]])
   }
 
   @Test("an unqualified name in more than one relation of a chain is ambiguous")
@@ -1160,15 +918,12 @@ struct EngineMultiJoinTests {
     // `{Author, Book}` even though `Sale` — joined only later — also carries a
     // `Code`. Resolving the match against the prefix binds it; resolving against
     // the whole chain would see two `Code`s and report `SQLError.ambiguous`.
-    let rows = try shared("""
+    try shared().expect("""
         SELECT Author.Aid, Book.Bid, Sale.Code FROM Author
           JOIN Book ON Code = Book.Aid
           JOIN Sale ON Sale.Sid = Book.Bid
-        """)
-    #expect(rows == [
-      [.integer(1), .integer(100), .integer(900)],
-      [.integer(2), .integer(101), .integer(901)],
-    ])
+        """,
+        yields: [[1, 100, 900], [2, 101, 901]])
   }
 }
 
@@ -1188,20 +943,19 @@ struct EngineViewTests {
 
   @Test("a projection over a view selects the view's columns by name")
   func projection() throws {
-    let rows = try view("SELECT Label FROM Adults")
-    #expect(rows == [[.text("Bee")], [.text("Cid")]])
+    try views().expect("SELECT Label FROM Adults", yields: [["Bee"], ["Cid"]])
   }
 
   @Test("a WHERE over a view filters its rows")
   func filter() throws {
-    let rows = try view("SELECT Label FROM Adults WHERE Key = 3")
-    #expect(rows == [[.text("Cid")]])
+    try views().expect("SELECT Label FROM Adults WHERE Key = 3",
+                       yields: [["Cid"]])
   }
 
   @Test("an ORDER BY over a view orders its rows")
   func order() throws {
-    let rows = try view("SELECT Label FROM Adults ORDER BY Label DESC")
-    #expect(rows == [[.text("Cid")], [.text("Bee")]])
+    try views().expect("SELECT Label FROM Adults ORDER BY Label DESC",
+                       yields: [["Cid"], ["Bee"]])
   }
 
   @Test("a view whose definition is a join resolves and queries")
@@ -1218,8 +972,8 @@ struct EngineViewTests {
 
   @Test("a projection and filter over a join view selects across its columns")
   func joinProjection() throws {
-    let rows = try view("SELECT Kid FROM Pairs WHERE Parent = 'Ada'")
-    #expect(rows == [[.text("Ann")], [.text("Amy")]])
+    try views().expect("SELECT Kid FROM Pairs WHERE Parent = 'Ada'",
+                       yields: [["Ann"], ["Amy"]])
   }
 
   @Test("an unknown column of a view is reported")
@@ -1236,7 +990,7 @@ struct EngineViewTests {
     // catches the mismatch at resolution rather than indexing past a row.
     let star = try View(query: select("SELECT * FROM Parent"),
                         columns: ["a", "b", "c"])
-    let catalog = Memory(family().relations, views: ["Star": star])
+    let catalog = Memory(try family().relations, views: ["Star": star])
     #expect(throws: SQLError.columns(expected: 2, got: 3)) {
       try Engine.run(parse("SELECT a FROM Star"), catalog)
     }
@@ -1248,7 +1002,7 @@ struct EngineViewTests {
     // resolves and queries — the backstop passes the well-formed view through.
     let star = try View(query: select("SELECT * FROM Parent"),
                         columns: ["a", "b"])
-    let catalog = Memory(family().relations, views: ["Star": star])
+    let catalog = Memory(try family().relations, views: ["Star": star])
     let rows = try Engine.run(parse("SELECT b FROM Star WHERE a = 1"), catalog)
     #expect(rows == [[.text("Ada")]])
   }
@@ -1493,8 +1247,8 @@ private func counted() throws -> (catalog: Memory, reads: Counter) {
       """), columns: ["Key", "Name", "Kid"])
   let catalog =
       Memory([
-        "Parent": Relation(parent, parents, sorted: 0, counter: reads),
-        "Child": Relation(child, children),
+        "Parent": FixtureRelation(parent, parents, sorted: 0, counter: reads),
+        "Child": FixtureRelation(child, children),
       ], views: ["Kin": kin])
   return (catalog, reads)
 }
@@ -1532,8 +1286,8 @@ private func spanned() throws -> Memory {
       SELECT Key, Tag FROM Alpha UNION ALL SELECT Key, Tag FROM Beta
       """), columns: ["Key", "Tag"])
   return Memory([
-    "Alpha": Relation(alpha, alphas, sorted: 0),
-    "Beta": Relation(beta, betas),
+    "Alpha": FixtureRelation(alpha, alphas, sorted: 0),
+    "Beta": FixtureRelation(beta, betas),
   ], views: ["Both": both])
 }
 
@@ -1571,7 +1325,7 @@ struct EnginePushdownTests {
     // `WHERE Parent.Name = 'Ada'` references only the outer relation, so it
     // pushes to the Parent leaf inside the join rather than filtering the whole
     // product afterwards — `pushed` sees a filter within the join's outer.
-    let catalog = family()
+    let catalog = try family()
     let select = try parse("""
         SELECT Child.Name FROM Parent JOIN Child ON Child.Pid = Parent.Id
           WHERE Parent.Name = 'Ada'
@@ -1586,7 +1340,7 @@ struct EnginePushdownTests {
   func seeked() throws {
     // `WHERE Parent.Id = 2` is seekable; pushed to the Parent leaf it becomes a
     // seek inside the join's outer, not a scan-then-filter atop the product.
-    let catalog = family()
+    let catalog = try family()
     let select = try parse("""
         SELECT Child.Name FROM Parent JOIN Child ON Child.Pid = Parent.Id
           WHERE Parent.Id = 2
@@ -1607,7 +1361,7 @@ struct EnginePushdownTests {
     // the immediate RHS, as the parser produced it, so the sort-key seek
     // survives the three-term AND.
     let catalog = Memory([
-      "T": Relation([
+      "T": FixtureRelation([
         Field(name: "Name", kind: .text),
         Field(name: "Age", kind: .integer),
         Field(name: "Id", kind: .integer),
@@ -1635,7 +1389,7 @@ struct EnginePushdownTests {
     // seeks a conjunct only when the residual is safe, so the unsafe division
     // residual bars the seek: the plan scans, and it raises.
     let catalog = Memory([
-      "T": Relation([
+      "T": FixtureRelation([
         Field(name: "x", kind: .integer),
         Field(name: "name", kind: .text),
         Field(name: "id", kind: .integer),
@@ -1662,11 +1416,11 @@ struct EnginePushdownTests {
   @Test("pushdown preserves the join's result")
   func correctness() throws {
     // The pushed plan must return exactly the un-pushed join's rows.
-    let rows = try join("""
+    try family().expect("""
         SELECT Child.Name FROM Parent JOIN Child ON Child.Pid = Parent.Id
           WHERE Parent.Name = 'Ada'
-        """)
-    #expect(rows == [[.text("Ann")], [.text("Amy")]])
+        """,
+        yields: [["Ann"], ["Amy"]])
   }
 
   @Test("a non-key predicate on the joined-in relation still uses the join")
@@ -1676,7 +1430,7 @@ struct EnginePushdownTests {
     // join folds it in. `nest` must look through that pushed filter and still
     // form a `Join` — not fall back to a residual product filtered by the ON
     // predicate (O(left × filtered-right)).
-    let catalog = family()
+    let catalog = try family()
     let select = try parse("""
         SELECT Child.Name, Parent.Name FROM Child
           JOIN Parent ON Parent.Id = Child.Pid WHERE Parent.Name <> 'zz'
@@ -1688,15 +1442,11 @@ struct EnginePushdownTests {
 
     // …and it returns the correct rows: every child with a matching parent,
     // the joined-in predicate keeping all of them (no parent is named 'zz').
-    let rows = try join("""
+    try family().expect("""
         SELECT Child.Name, Parent.Name FROM Child
           JOIN Parent ON Parent.Id = Child.Pid WHERE Parent.Name <> 'zz'
-        """)
-    #expect(rows == [
-      [.text("Ann"), .text("Ada")],
-      [.text("Amy"), .text("Ada")],
-      [.text("Bob"), .text("Bee")],
-    ])
+        """,
+        yields: [["Ann", "Ada"], ["Amy", "Ada"], ["Bob", "Bee"]])
   }
 
   @Test("a spanning WHERE leaves the join path with a residual above it")
@@ -1707,7 +1457,7 @@ struct EnginePushdownTests {
     // conjunct — so `nest` still finds it and forms a `Join`, keeping the
     // spanning predicate as a `Select` ABOVE the join rather than degrading to a
     // filtered Cartesian `product`.
-    let catalog = family()
+    let catalog = try family()
     let select = try parse("""
         SELECT Child.Name, Parent.Name FROM Parent
           JOIN Child ON Child.Pid = Parent.Id WHERE Parent.Name <> Child.Name
@@ -1720,15 +1470,11 @@ struct EnginePushdownTests {
 
     // …and it returns the join's rows filtered by the spanning predicate: every
     // matched pair survives, none sharing a name across the two relations.
-    let rows = try join("""
+    try family().expect("""
         SELECT Child.Name, Parent.Name FROM Parent
           JOIN Child ON Child.Pid = Parent.Id WHERE Parent.Name <> Child.Name
-        """)
-    #expect(rows == [
-      [.text("Ann"), .text("Ada")],
-      [.text("Amy"), .text("Ada")],
-      [.text("Bob"), .text("Bee")],
-    ])
+        """,
+        yields: [["Ann", "Ada"], ["Amy", "Ada"], ["Bob", "Bee"]])
   }
 
   @Test("a WHERE over a join view prunes its rows before the join runs")
@@ -1770,9 +1516,9 @@ struct EnginePushdownTests {
     // the query returns no rows. Pushed to the left, it would run once per left
     // row and raise `SQLError.divide`.
     let catalog = Memory([
-      "A": Relation([Field(name: "x", kind: .integer)],
+      "A": FixtureRelation([Field(name: "x", kind: .integer)],
                     [[.integer(1)]] as Array<Array<Value>>),
-      "B": Relation([Field(name: "y", kind: .integer)],
+      "B": FixtureRelation([Field(name: "y", kind: .integer)],
                     [] as Array<Array<Value>>),
     ])
     let rows = try Engine.run(parse("""
@@ -1789,9 +1535,9 @@ struct EnginePushdownTests {
     // never evaluated; the query returns no rows. Pushed to `A` (x = 0) it would
     // divide by zero and raise `SQLError.divide`.
     let catalog = Memory([
-      "A": Relation([Field(name: "x", kind: .integer)],
+      "A": FixtureRelation([Field(name: "x", kind: .integer)],
                     [[.integer(0)]] as Array<Array<Value>>),
-      "B": Relation([Field(name: "y", kind: .integer)],
+      "B": FixtureRelation([Field(name: "y", kind: .integer)],
                     [] as Array<Array<Value>>),
     ])
     let rows = try Engine.run(parse("""
@@ -1808,9 +1554,9 @@ struct EnginePushdownTests {
     // the division runs, silently returning no rows. The earlier unsafe conjunct
     // is an ordering barrier, so the query raises as the un-pushed `AND` would.
     let catalog = Memory([
-      "A": Relation([Field(name: "x", kind: .integer)],
+      "A": FixtureRelation([Field(name: "x", kind: .integer)],
                     [[.integer(0)]] as Array<Array<Value>>),
-      "B": Relation([Field(name: "y", kind: .integer)],
+      "B": FixtureRelation([Field(name: "y", kind: .integer)],
                     [[.integer(0)]] as Array<Array<Value>>),
     ])
     #expect(throws: SQLError.self) {
@@ -1830,10 +1576,10 @@ struct EnginePushdownTests {
     // first and raises. The matching Parent is named 'other', so the row is
     // excluded with no throw.
     let catalog = Memory([
-      "Child": Relation([Field(name: "Pid", kind: .integer),
+      "Child": FixtureRelation([Field(name: "Pid", kind: .integer),
                          Field(name: "x", kind: .integer)],
                         [[.integer(1), .integer(0)]] as Array<Array<Value>>),
-      "Parent": Relation([Field(name: "Id", kind: .integer),
+      "Parent": FixtureRelation([Field(name: "Id", kind: .integer),
                           Field(name: "Name", kind: .text)],
                          [[.integer(1), .text("other")]]
                              as Array<Array<Value>>),
@@ -1878,7 +1624,7 @@ struct EnginePushdownTests {
     let rows = [[.integer(0), .integer(0)]] as Array<Array<Value>>
     let view = try View(query: select("SELECT id, 1 / z FROM T"),
                         columns: ["id", "q"])
-    let catalog = Memory(["T": Relation(t, rows)], views: ["V": view])
+    let catalog = Memory(["T": FixtureRelation(t, rows)], views: ["V": view])
     #expect(throws: SQLError.self) {
       _ = try Engine.run(parse("SELECT id FROM V WHERE id <> 0"), catalog)
     }
@@ -1897,7 +1643,7 @@ struct EnginePushdownTests {
     let t = [Field(name: "x", kind: .integer)]
     let rows = [[.integer(0)]] as Array<Array<Value>>
     let view = try View(query: select("SELECT x FROM T"), columns: ["x"])
-    let catalog = Memory(["T": Relation(t, rows, sorted: 0)],
+    let catalog = Memory(["T": FixtureRelation(t, rows, sorted: 0)],
                          views: ["V": view])
     #expect(throws: SQLError.self) {
       _ = try Engine.run(parse("SELECT x FROM V WHERE (1 / x) = 0 AND x = 1"),
@@ -1916,10 +1662,10 @@ struct EnginePushdownTests {
     // nullable conjunct must NOT ride past a LATER unsafe conjunct, so `A.x = 1`
     // stays a product-level residual and the query raises.
     let catalog = Memory([
-      "A": Relation([Field(name: "x", kind: .integer),
+      "A": FixtureRelation([Field(name: "x", kind: .integer),
                      Field(name: "k", kind: .integer)],
                     [[.null, .integer(0)]] as Array<Array<Value>>),
-      "B": Relation([Field(name: "y", kind: .integer),
+      "B": FixtureRelation([Field(name: "y", kind: .integer),
                      Field(name: "k", kind: .integer)],
                     [[.integer(0), .integer(0)]] as Array<Array<Value>>),
     ])
@@ -1956,7 +1702,7 @@ struct EnginePushdownTests {
     let rows = [[.null, .integer(0)]] as Array<Array<Value>>
     let view = try View(query: select("SELECT x, y FROM T"),
                         columns: ["x", "y"])
-    let catalog = Memory(["T": Relation(t, rows)], views: ["V": view])
+    let catalog = Memory(["T": FixtureRelation(t, rows)], views: ["V": view])
     let select = try parse("SELECT x FROM V WHERE x = 1 AND (1 / y) = 0")
 
     // `x = 1` is nullable and precedes the unsafe division, so it is NOT
@@ -1987,7 +1733,7 @@ struct EnginePushdownTests {
     let rows = [[.integer(1), .integer(0)]] as Array<Array<Value>>
     let view = try View(query: select("SELECT x, y FROM T"),
                         columns: ["x", "y"])
-    let catalog = Memory(["T": Relation(t, rows)], views: ["V": view])
+    let catalog = Memory(["T": FixtureRelation(t, rows)], views: ["V": view])
     let select = try parse("SELECT x FROM V WHERE 1 = :missing AND (1 / y) = 0")
 
     // `1 = :missing` is a slotless bound predicate, hence nullable; it precedes
@@ -2016,9 +1762,9 @@ struct EnginePushdownTests {
     // rows.
     let a = [Field(name: "x", kind: .integer), Field(name: "k", kind: .integer)]
     let catalog = Memory([
-      "A": Relation(a, [[.integer(1), .integer(1)],
+      "A": FixtureRelation(a, [[.integer(1), .integer(1)],
                         [.integer(0), .null]] as Array<Array<Value>>),
-      "T": Relation([Field(name: "k", kind: .integer)],
+      "T": FixtureRelation([Field(name: "k", kind: .integer)],
                     [[.integer(1)]] as Array<Array<Value>>),
     ], views: ["V": try View(query: select("SELECT k FROM T"),
                              columns: ["k"])])
@@ -2060,8 +1806,8 @@ private func hashable() -> (catalog: Memory, reads: Counter) {
   ] as Array<Array<Value>>
 
   let catalog = Memory([
-    "Parent": Relation(parent, parents, counter: reads),
-    "Child": Relation(child, children),
+    "Parent": FixtureRelation(parent, parents, counter: reads),
+    "Child": FixtureRelation(child, children),
   ])
   return (catalog, reads)
 }
@@ -2092,7 +1838,7 @@ struct EngineHashJoinTests {
     // so probing with `0` would call it unseekable and hash every inner row;
     // probing with a valid `1` finds it seekable, so a selective join seeks the
     // coded run instead. `Attribute.Parent` is such a column (stored raw
-    // `(rowid << 2) | tag`, decoded to a rowid), and one `Type` (Id 6) probes it.
+    // `(Id << 2) | tag`, decoded to a Id), and one `Type` (Id 6) probes it.
     let reads = Counter()
     let type = [Field(name: "Id", kind: .integer)]
     let types = [[.integer(6)]] as Array<Array<Value>>
@@ -2109,8 +1855,9 @@ struct EngineHashJoinTests {
       [.integer(24), .text("td6")],
     ] as Array<Array<Value>>
     let catalog = Memory([
-      "Type": Relation(type, types),
-      "Attribute": Relation(attribute, attributes, coded: 0, counter: reads),
+      "Type": FixtureRelation(type, types),
+      "Attribute": FixtureRelation(attribute, attributes, coded: 0,
+                                   counter: reads),
     ])
     let rows = try Engine.run(parse("""
         SELECT Attribute.Name FROM Type
@@ -2168,8 +1915,8 @@ struct EngineHashJoinTests {
       [.null, .text("Nobody")],
     ] as Array<Array<Value>>
     let catalog = Memory([
-      "Parent": Relation(parent, parents, counter: reads),
-      "Child": Relation(child, children),
+      "Parent": FixtureRelation(parent, parents, counter: reads),
+      "Child": FixtureRelation(child, children),
     ])
     let rows = try Engine.run(parse("""
         SELECT Child.Kid, Parent.Name FROM Child
@@ -2239,8 +1986,8 @@ struct EngineHashJoinTests {
       [.integer(2), .text("Bob")],
     ] as Array<Array<Value>>
     let catalog = Memory([
-      "Parent": Relation(parent, parents),
-      "Child": Relation(child, children),
+      "Parent": FixtureRelation(parent, parents),
+      "Child": FixtureRelation(child, children),
     ])
     let rows = try Engine.run(parse("""
         SELECT Child.Name, Parent.Name FROM Child
@@ -2283,8 +2030,8 @@ struct EngineHashJoinTests {
     // `Parent` is sorted on `Id` (column 0), so `Id` seeks but the join key
     // `Code` (column 1) does not — forcing the hash path.
     let catalog = Memory([
-      "Parent": Relation(parent, parents, sorted: 0, counter: reads),
-      "Child": Relation(child, children),
+      "Parent": FixtureRelation(parent, parents, sorted: 0, counter: reads),
+      "Child": FixtureRelation(child, children),
     ])
     let rows = try Engine.run(parse("""
         SELECT Child.Kid, Parent.Id FROM Child
@@ -2374,8 +2121,8 @@ struct EngineStreamingProductTests {
       [.integer(3), .text("Cid")],
     ] as Array<Array<Value>>
     let catalog = Memory([
-      "Child": Relation(child, children),
-      "Base": Relation(base, bases, sorted: 0),
+      "Child": FixtureRelation(child, children),
+      "Base": FixtureRelation(base, bases, sorted: 0),
     ], views: ["Adults": adults])
     let rows = try Engine.run(parse("""
         SELECT Child.Name, Adults.Label FROM Child
@@ -2543,8 +2290,8 @@ struct EngineFunctionTests {
 struct EngineNullTests {
   @Test("IS NULL admits only the NULL rows")
   func isNull() throws {
-    let rows = try nullable("SELECT Id FROM Maybe WHERE Note IS NULL")
-    #expect(rows == [[.integer(2)], [.integer(4)]])
+    try nullable().expect("SELECT Id FROM Maybe WHERE Note IS NULL",
+                          yields: [[2], [4]])
   }
 
   @Test("IS NOT NULL admits only the non-NULL rows")
@@ -2557,8 +2304,8 @@ struct EngineNullTests {
   func comparison() throws {
     // For the NULL rows (2, 4) `Note = 'alpha'` is UNKNOWN, not false, so they
     // are not admitted; only the row whose Note equals 'alpha' survives.
-    let rows = try nullable("SELECT Id FROM Maybe WHERE Note = 'alpha'")
-    #expect(rows == [[.integer(1)]])
+    try nullable().expect("SELECT Id FROM Maybe WHERE Note = 'alpha'",
+                          yields: [[1]])
   }
 
   @Test("NOT of a NULL comparison stays UNKNOWN and rejects")
@@ -2571,8 +2318,8 @@ struct EngineNullTests {
 
   @Test("a NULL cell projects as a NULL value")
   func projection() throws {
-    let rows = try nullable("SELECT Note FROM Maybe WHERE Id = 2")
-    #expect(rows == [[.null]])
+    try nullable().expect("SELECT Note FROM Maybe WHERE Id = 2",
+                          yields: [[nil]])
   }
 
   @Test("ORDER BY ascending sorts NULL keys first, then by value")
@@ -2580,14 +2327,14 @@ struct EngineNullTests {
     // NULL holds a stable position — first in ascending order — so the non-null
     // notes still sort among themselves ('alpha' before 'gamma') rather than
     // tying with the nulls and leaving the order undefined.
-    let rows = try nullable("SELECT Id FROM Maybe ORDER BY Note ASC")
-    #expect(rows == [[.integer(2)], [.integer(4)], [.integer(1)], [.integer(3)]])
+    try nullable().expect("SELECT Id FROM Maybe ORDER BY Note ASC",
+                          yields: [[2], [4], [1], [3]])
   }
 
   @Test("ORDER BY descending sorts NULL keys last")
   func orderDescending() throws {
-    let rows = try nullable("SELECT Id FROM Maybe ORDER BY Note DESC")
-    #expect(rows == [[.integer(3)], [.integer(1)], [.integer(2)], [.integer(4)]])
+    try nullable().expect("SELECT Id FROM Maybe ORDER BY Note DESC",
+                          yields: [[3], [1], [2], [4]])
   }
 
   @Test("a NULL outer join key matches no inner row")
@@ -2652,7 +2399,7 @@ struct EngineBoundTests {
     // yields the parents; for each, the child query is re-run with the parent's
     // key bound, producing that parent's children — exactly an interface →
     // methods expansion.
-    let catalog = family()
+    let catalog = try family()
     let parents = try Engine.run(parse("SELECT Id, Name FROM Parent"), catalog)
     let query = try parse("SELECT Name FROM Child WHERE Pid = :pid")
 
@@ -2697,7 +2444,7 @@ struct EngineBoundTests {
     // Parent is sorted on Id; with `:id` bound the planner resolves it and
     // seeks the run rather than scanning and filtering the whole relation.
     let select = try parse("SELECT Name FROM Parent WHERE Id = :id")
-    let catalog = family()
+    let catalog = try family()
     let plan = try Engine.optimise(Engine.compile(select, catalog), catalog,
                                    ["id": .integer(2)])
     #expect(seeks(plan))
@@ -2707,7 +2454,7 @@ struct EngineBoundTests {
   @Test("an unbound key cannot seek and scans under the filter")
   func scan() throws {
     let select = try parse("SELECT Name FROM Parent WHERE Id = :id")
-    let catalog = family()
+    let catalog = try family()
     let plan = try Engine.optimise(Engine.compile(select, catalog), catalog,
                                    [:])
     #expect(!seeks(plan))
@@ -2750,9 +2497,9 @@ private func tags() -> Memory {
     [.text("a")],
   ] as Array<Array<Value>>
   return Memory([
-    "Left": Relation(fields, left),
-    "Right": Relation(fields, right),
-    "Extra": Relation(fields, extra),
+    "Left": FixtureRelation(fields, left),
+    "Right": FixtureRelation(fields, right),
+    "Extra": FixtureRelation(fields, extra),
   ])
 }
 
@@ -2860,20 +2607,19 @@ struct EngineArithmeticTests {
   func literal() throws {
     // One row of `People` drives the projection; the value is the same for each,
     // and `Id = 1` selects exactly one.
-    let rows = try run("SELECT 2 + 3 FROM People WHERE Id = 1")
-    #expect(rows == [[.integer(5)]])
+    try people().expect("SELECT 2 + 3 FROM People WHERE Id = 1", yields: [[5]])
   }
 
   @Test("multiplication binds tighter than addition")
   func precedence() throws {
-    let rows = try run("SELECT 2 + 3 * 4 FROM People WHERE Id = 1")
-    #expect(rows == [[.integer(14)]])
+    try people().expect("SELECT 2 + 3 * 4 FROM People WHERE Id = 1",
+                        yields: [[14]])
   }
 
   @Test("parentheses override precedence")
   func grouping() throws {
-    let rows = try run("SELECT (2 + 3) * 4 FROM People WHERE Id = 1")
-    #expect(rows == [[.integer(20)]])
+    try people().expect("SELECT (2 + 3) * 4 FROM People WHERE Id = 1",
+                        yields: [[20]])
   }
 
   @Test("subtraction and division are left-associative")
@@ -2887,8 +2633,7 @@ struct EngineArithmeticTests {
 
   @Test("integer division truncates")
   func integerDivision() throws {
-    let rows = try run("SELECT 7 / 2 FROM People WHERE Id = 1")
-    #expect(rows == [[.integer(3)]])
+    try people().expect("SELECT 7 / 2 FROM People WHERE Id = 1", yields: [[3]])
   }
 
   @Test("arithmetic over a column computes per row")
@@ -2909,8 +2654,8 @@ struct EngineArithmeticTests {
   func nullPropagation() throws {
     // `Note` is NULL for row 2; `Id + Note` mixes a present integer with a NULL,
     // so the whole expression is NULL rather than a fault.
-    let rows = try nullable("SELECT Id + Note FROM Maybe WHERE Id = 2")
-    #expect(rows == [[.null]])
+    try nullable().expect("SELECT Id + Note FROM Maybe WHERE Id = 2",
+                          yields: [[nil]])
   }
 
   @Test("division by zero faults")
@@ -2955,8 +2700,8 @@ struct EngineArithmeticTests {
   func predicate() throws {
     // `Age + 1 = 26` holds for everyone aged 25 (Bob and Eve); the arithmetic
     // is evaluated per row on the WHERE side too.
-    let rows = try run("SELECT Name FROM People WHERE Age + 1 = 26")
-    #expect(rows == [[.text("Bob")], [.text("Eve")]])
+    try people().expect("SELECT Name FROM People WHERE Age + 1 = 26",
+                        yields: [["Bob"], ["Eve"]])
   }
 }
 
@@ -2967,32 +2712,27 @@ struct EngineScalarSelectTests {
   func literal() throws {
     // No relation, so the projection runs against a single empty row; the
     // catalog is never consulted for a table.
-    let rows = try run("SELECT 42")
-    #expect(rows == [[.integer(42)]])
+    try people().expect("SELECT 42", yields: [[42]])
   }
 
   @Test("a FROM-less arithmetic computes a scalar")
   func arithmetic() throws {
-    let rows = try run("SELECT 1 + 1")
-    #expect(rows == [[.integer(2)]])
+    try people().expect("SELECT 1 + 1", yields: [[2]])
   }
 
   @Test("FROM-less arithmetic honours precedence")
   func precedence() throws {
-    let rows = try run("SELECT 2 + 3 * 4")
-    #expect(rows == [[.integer(14)]])
+    try people().expect("SELECT 2 + 3 * 4", yields: [[14]])
   }
 
   @Test("a FROM-less multi-column projection yields one row of each value")
   func multiColumn() throws {
-    let rows = try run("SELECT 1, 2, 3")
-    #expect(rows == [[.integer(1), .integer(2), .integer(3)]])
+    try people().expect("SELECT 1, 2, 3", yields: [[1, 2, 3]])
   }
 
   @Test("a FROM-less projection mixes text and integer expressions")
   func mixed() throws {
-    let rows = try run("SELECT 'x', 10 / 2")
-    #expect(rows == [[.text("x"), .integer(5)]])
+    try people().expect("SELECT 'x', 10 / 2", yields: [["x", 5]])
   }
 
   @Test("a FROM-less scalar call evaluates against the single row")
@@ -3019,9 +2759,7 @@ struct EngineScalarSelectTests {
 
   @Test("a FROM-less bare column is rejected — no column to bind")
   func column() throws {
-    #expect(throws: SQLError.column("Name")) {
-      try run("SELECT Name")
-    }
+    try people().expect("SELECT Name", fails: .column("Name"))
   }
 
   @Test("a directly-built FROM-less select with clauses is rejected")
@@ -3097,8 +2835,8 @@ struct EngineScalarSelectTests {
   func regression() throws {
     // The FROM-optional grammar leaves a normal query parsing and running
     // exactly as before.
-    let rows = try run("SELECT Name FROM People WHERE Id = 1")
-    #expect(rows == [[.text("Alice")]])
+    try people().expect("SELECT Name FROM People WHERE Id = 1",
+                        yields: [["Alice"]])
   }
 }
 
@@ -3368,7 +3106,7 @@ struct EngineWithTests {
     // bind to the CTE and the query would return `99`.
     let adults =
         try View(query: select("SELECT Id FROM Parent"), columns: ["Id"])
-    let catalog = Memory(family().relations, views: ["Adults": adults])
+    let catalog = Memory(try family().relations, views: ["Adults": adults])
     let rows = try statement("""
         WITH Parent (Id) AS (SELECT 99 AS Id FROM Parent WHERE Id = 1)
           SELECT Id FROM Adults
@@ -3383,7 +3121,7 @@ struct EngineWithTests {
     // — the scoping fix narrows only a view's body, never the statement query.
     let adults =
         try View(query: select("SELECT Id FROM Parent"), columns: ["Id"])
-    let catalog = Memory(family().relations, views: ["Adults": adults])
+    let catalog = Memory(try family().relations, views: ["Adults": adults])
     let rows = try statement("""
         WITH Parent (Id) AS (SELECT 99 AS Id FROM Parent WHERE Id = 1)
           SELECT Id FROM Parent
@@ -3414,9 +3152,9 @@ struct EngineWithTests {
     // alone, so this is NOT routed through the fixpoint: the two arms materialise
     // once (UNION ALL) instead of the arm re-running to the recursion cap.
     let catalog = Memory([
-      "Parent": Relation([Field(name: "Id", kind: .integer)],
+      "Parent": FixtureRelation([Field(name: "Id", kind: .integer)],
                          [[.integer(1)], [.integer(2)]] as Array<Array<Value>>),
-      "Extra": Relation([Field(name: "Id", kind: .integer)],
+      "Extra": FixtureRelation([Field(name: "Id", kind: .integer)],
                         [[.integer(3)]] as Array<Array<Value>>),
     ])
     let rows = try statement("""
@@ -3450,8 +3188,8 @@ private func seed() -> Memory {
   ] as Array<Array<Value>>
 
   return Memory([
-    "Seed": Relation(one, seedRows),
-    "Edge": Relation(edge, edges),
+    "Seed": FixtureRelation(one, seedRows),
+    "Edge": FixtureRelation(edge, edges),
   ])
 }
 
@@ -3564,7 +3302,7 @@ struct EngineRecursiveTests {
     // this — the anchor's reference resolves to an existing base relation, so it
     // is a valid seed, not a misplaced recursive arm.
     let catalog = Memory([
-      "Parent": Relation([Field(name: "Id", kind: .integer)],
+      "Parent": FixtureRelation([Field(name: "Id", kind: .integer)],
                          [[.integer(1)]] as Array<Array<Value>>),
     ])
     let rows = try Engine.run(Statement(parsing: """
@@ -3586,7 +3324,7 @@ struct EngineRecursiveTests {
     // self-reference. The guard must accept a view seed as well as a table.
     let view = try View(query: select("SELECT Id FROM Parent"), columns: ["id"])
     let catalog = Memory([
-      "Parent": Relation([Field(name: "Id", kind: .integer)],
+      "Parent": FixtureRelation([Field(name: "Id", kind: .integer)],
                          [[.integer(1)]] as Array<Array<Value>>),
     ], views: ["v": view])
     let rows = try Engine.run(Statement(parsing: """

--- a/Tests/SQLTests/LimitTests.swift
+++ b/Tests/SQLTests/LimitTests.swift
@@ -2,143 +2,37 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 import Testing
-@testable import SQL
-
-// MARK: - In-memory adapter
-
-/// An in-memory relation: a fixed schema plus rows of typed values.
-///
-/// The `sorted` flag marks a single integral column whose rows are stored in
-/// ascending order; `bound` reports a boundary for that column and `nil` for
-/// any other, so a `FETCH` after a seekable `WHERE` still exercises the cap.
-/// This harness knows nothing of WinMD — it is a self-contained fixture for the
-/// row-limiting (`OFFSET`/`FETCH`) tests, deliberately independent of
-/// `EngineTests.swift` so the two files reconcile cleanly.
-private struct LimitRelation: Sendable {
-  let names: Array<String>
-  let records: Array<Array<Value>>
-  /// The ordinal of the sorted column, or `nil` if the relation is unsorted.
-  let sorted: Int?
-
-  init(_ names: Array<String>, _ records: Array<Array<Value>>,
-       sorted: Int? = nil) {
-    self.names = names
-    self.records = records
-    self.sorted = sorted
-  }
-}
-
-/// A `Catalog` over a dictionary of named relations.
-private struct LimitMemory: Catalog {
-  let relations: Dictionary<String, LimitRelation>
-
-  init(_ relations: Dictionary<String, LimitRelation>) {
-    self.relations = relations
-  }
-
-  func table(named name: String) -> LimitTable? {
-    guard let relation = relations[name] else { return nil }
-    return LimitTable(relation)
-  }
-}
-
-/// A `Table` over one in-memory relation.
-private struct LimitTable: Table {
-  let relation: LimitRelation
-
-  init(_ relation: LimitRelation) {
-    self.relation = relation
-  }
-
-  var width: Int { relation.names.count }
-
-  var names: Array<String> { relation.names }
-
-  func ordinal(of name: String) -> Int? {
-    relation.names.firstIndex(of: name)
-  }
-
-  func bound(_ column: Int, _ value: Int, strict: Bool) -> Int? {
-    guard column == relation.sorted else { return nil }
-    var lower = 0
-    var upper = relation.records.count
-    while lower < upper {
-      let middle = lower + (upper - lower) / 2
-      guard case let .integer(cell) = relation.records[middle][column] else {
-        return nil
-      }
-      let before = strict ? cell <= value : cell < value
-      if before {
-        lower = middle + 1
-      } else {
-        upper = middle
-      }
-    }
-    return lower
-  }
-
-  func cursor() -> LimitCursor {
-    LimitCursor(relation)
-  }
-}
-
-/// An index-addressed cursor over a relation's rows.
-private struct LimitCursor: Cursor {
-  let relation: LimitRelation
-
-  init(_ relation: LimitRelation) {
-    self.relation = relation
-  }
-
-  var count: Int { relation.records.count }
-
-  func row(_ index: Int) -> LimitRow? {
-    guard index < relation.records.count else { return nil }
-    return LimitRow(relation, index)
-  }
-}
-
-/// A positional view over one row's cells.
-private struct LimitRow: Row {
-  let relation: LimitRelation
-  let index: Int
-
-  init(_ relation: LimitRelation, _ index: Int) {
-    self.relation = relation
-    self.index = index
-  }
-
-  subscript(_ column: Int) -> Value {
-    borrowing get { relation.records[index][column] }
-  }
-}
+import SQL
+import SQLTestSupport
 
 // MARK: - Fixtures
 
 /// A `People` relation of five rows, sorted ascending on its `Id` column.
-private func people() -> LimitMemory {
-  let records = [
-    [.integer(1), .text("Alice"), .integer(30)],
-    [.integer(2), .text("Bob"), .integer(25)],
-    [.integer(3), .text("Carol"), .integer(30)],
-    [.integer(4), .text("Dave"), .integer(40)],
-    [.integer(5), .text("Eve"), .integer(25)],
-  ] as Array<Array<Value>>
-  return LimitMemory(["People": LimitRelation(["Id", "Name", "Age"], records,
-                                              sorted: 0)])
+private func people() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("People", ["Id": .integer, "Name": .text, "Age": .integer],
+             sorted: "Id") {
+      Row(1, "Alice", 30)
+      Row(2, "Bob", 25)
+      Row(3, "Carol", 30)
+      Row(4, "Dave", 40)
+      Row(5, "Eve", 25)
+    }
+  }
 }
 
 /// A `Block` relation whose columns include `Offset` — a real WinMD column name
 /// (`ManifestResource` and `FieldLayout` both declare one) — to prove the
 /// reserved word `OFFSET` is still reachable as a column via a delimited
 /// identifier (`"Offset"`).
-private func blocks() -> LimitMemory {
-  let records = [
-    [.integer(1), .integer(100)],
-    [.integer(2), .integer(200)],
-    [.integer(3), .integer(300)],
-  ] as Array<Array<Value>>
-  return LimitMemory(["Block": LimitRelation(["Id", "Offset"], records)])
+private func blocks() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("Block", ["Id": .integer, "Offset": .integer]) {
+      Row(1, 100)
+      Row(2, 200)
+      Row(3, 300)
+    }
+  }
 }
 
 // MARK: - Helpers
@@ -152,62 +46,61 @@ private func parse(_ text: String) throws -> Query {
   return query
 }
 
-/// Runs `text` against the `People` catalog, yielding the projected rows.
-private func run(_ text: String) throws -> Array<Array<Value>> {
-  try Engine.run(parse(text), people())
-}
-
 // MARK: - Tests
 
 struct LimitTests {
   @Test("FETCH FIRST n ROWS ONLY caps the row count")
   func caps() throws {
-    let rows = try run("SELECT Id FROM People FETCH FIRST 3 ROWS ONLY")
-    #expect(rows == [[.integer(1)], [.integer(2)], [.integer(3)]])
+    try people().expect("SELECT Id FROM People FETCH FIRST 3 ROWS ONLY",
+                        yields: [[1], [2], [3]])
   }
 
   @Test("FETCH FIRST 0 ROWS ONLY yields no rows")
   func zero() throws {
-    #expect(try run("SELECT Id FROM People FETCH FIRST 0 ROWS ONLY") == [])
+    try people().empty("SELECT Id FROM People FETCH FIRST 0 ROWS ONLY")
   }
 
   @Test("FETCH with an omitted count takes one row")
   func defaultsToOne() throws {
     // The ISO `FETCH FIRST ROW ONLY` — no count — takes a single row.
-    #expect(try run("SELECT Id FROM People FETCH FIRST ROW ONLY")
-            == [[.integer(1)]])
+    try people().expect("SELECT Id FROM People FETCH FIRST ROW ONLY",
+                        yields: [[1]])
   }
 
   @Test("ROW and ROWS, FIRST and NEXT, are interchangeable")
   func synonyms() throws {
     // `ROW`/`ROWS` and `FIRST`/`NEXT` are ISO synonyms — the singular and the
     // `NEXT` spelling parse to the same clause as the plural `FIRST` form.
-    let canonical = try run("SELECT Id FROM People FETCH FIRST 1 ROWS ONLY")
-    #expect(try run("SELECT Id FROM People FETCH NEXT 1 ROW ONLY") == canonical)
-    #expect(canonical == [[.integer(1)]])
+    let catalog = try people()
+    try catalog.expect("SELECT Id FROM People FETCH NEXT 1 ROW ONLY",
+                       equals: "SELECT Id FROM People FETCH FIRST 1 ROWS ONLY")
+    try catalog.expect("SELECT Id FROM People FETCH FIRST 1 ROWS ONLY",
+                       yields: [[1]])
   }
 
   @Test("OFFSET n ROWS then FETCH skips then caps")
   func offset() throws {
-    let rows =
-        try run("SELECT Id FROM People OFFSET 1 ROWS FETCH NEXT 2 ROWS ONLY")
-    #expect(rows == [[.integer(2)], [.integer(3)]])
+    try people().expect(
+        "SELECT Id FROM People OFFSET 1 ROWS FETCH NEXT 2 ROWS ONLY",
+        yields: [[2], [3]])
   }
 
   @Test("OFFSET 0 ROWS is the same as no OFFSET")
   func zeroOffset() throws {
-    let rows =
-        try run("SELECT Id FROM People OFFSET 0 ROWS FETCH NEXT 2 ROWS ONLY")
-    let bare = try run("SELECT Id FROM People FETCH FIRST 2 ROWS ONLY")
-    #expect(rows == bare)
-    #expect(rows == [[.integer(1)], [.integer(2)]])
+    let catalog = try people()
+    try catalog.expect(
+        "SELECT Id FROM People OFFSET 0 ROWS FETCH NEXT 2 ROWS ONLY",
+        equals: "SELECT Id FROM People FETCH FIRST 2 ROWS ONLY")
+    try catalog.expect(
+        "SELECT Id FROM People OFFSET 0 ROWS FETCH NEXT 2 ROWS ONLY",
+        yields: [[1], [2]])
   }
 
   @Test("OFFSET without a FETCH skips with no cap")
   func offsetOnly() throws {
     // An `OFFSET` written without a `FETCH` returns every row after the skip.
-    let rows = try run("SELECT Id FROM People OFFSET 3 ROWS")
-    #expect(rows == [[.integer(4)], [.integer(5)]])
+    try people().expect("SELECT Id FROM People OFFSET 3 ROWS",
+                        yields: [[4], [5]])
   }
 
   @Test("FETCH after ORDER BY takes the top-N in sorted order")
@@ -215,39 +108,40 @@ struct LimitTests {
     // Ordered by Age ascending, ties by source order (a stable sort): Bob(25),
     // Eve(25), Alice(30), Carol(30), Dave(40). The FETCH caps the ORDERED
     // result, so it takes the two lowest ages rather than the first two rows.
-    let rows =
-        try run("SELECT Name FROM People ORDER BY Age FETCH FIRST 2 ROWS ONLY")
-    #expect(rows == [[.text("Bob")], [.text("Eve")]])
+    try people().expect(
+        "SELECT Name FROM People ORDER BY Age FETCH FIRST 2 ROWS ONLY",
+        yields: [["Bob"], ["Eve"]])
   }
 
   @Test("OFFSET then FETCH after ORDER BY skips into the sorted result")
   func offsetAfterOrder() throws {
     // Descending by Id: Eve, Dave, Carol, Bob, Alice — skip 1, take 2.
-    let rows = try run("""
-        SELECT Name FROM People
-          ORDER BY Id DESC OFFSET 1 ROWS FETCH NEXT 2 ROWS ONLY
-        """)
-    #expect(rows == [[.text("Dave")], [.text("Carol")]])
+    try people().expect("""
+                 SELECT Name FROM People
+                   ORDER BY Id DESC OFFSET 1 ROWS FETCH NEXT 2 ROWS ONLY
+                 """, yields: [["Dave"], ["Carol"]])
   }
 
   @Test("OFFSET past the end yields no rows")
   func offsetPastEnd() throws {
-    #expect(try run("SELECT Id FROM People OFFSET 5 ROWS") == [])
-    #expect(try run("SELECT Id FROM People OFFSET 10 ROWS") == [])
+    let catalog = try people()
+    try catalog.empty("SELECT Id FROM People OFFSET 5 ROWS")
+    try catalog.empty("SELECT Id FROM People OFFSET 10 ROWS")
   }
 
   @Test("a FETCH larger than the result yields every row")
   func largerThanResult() throws {
-    let all = try run("SELECT Id FROM People")
-    #expect(try run("SELECT Id FROM People FETCH FIRST 100 ROWS ONLY") == all)
+    let catalog = try people()
+    try catalog.expect("SELECT Id FROM People FETCH FIRST 100 ROWS ONLY",
+                       equals: "SELECT Id FROM People")
   }
 
   @Test("FETCH caps rows admitted by a seekable WHERE")
   func afterWhere() throws {
     // `Id >= 2` seeks to rows 2…5; the FETCH then caps that run to two rows.
-    let rows =
-        try run("SELECT Id FROM People WHERE Id >= 2 FETCH FIRST 2 ROWS ONLY")
-    #expect(rows == [[.integer(2)], [.integer(3)]])
+    try people().expect(
+        "SELECT Id FROM People WHERE Id >= 2 FETCH FIRST 2 ROWS ONLY",
+        yields: [[2], [3]])
   }
 
   @Test("a reserved-word column is reachable via a delimited identifier")
@@ -255,13 +149,13 @@ struct LimitTests {
     // `OFFSET` is a reserved word, so a relation's `Offset` column is reached
     // by the standard delimited identifier `"Offset"`. It selects, orders, and
     // coexists with a genuine OFFSET/FETCH row-limiting clause.
-    let catalog = blocks()
-    #expect(try Engine.run(parse("SELECT \"Offset\" FROM Block"), catalog)
-            == [[.integer(100)], [.integer(200)], [.integer(300)]])
-    #expect(try Engine.run(parse("""
-        SELECT "Offset" FROM Block
-          ORDER BY "Offset" DESC OFFSET 1 ROWS FETCH NEXT 1 ROWS ONLY
-        """), catalog) == [[.integer(200)]])
+    let catalog = try blocks()
+    try catalog.expect("SELECT \"Offset\" FROM Block",
+                       yields: [[100], [200], [300]])
+    try catalog.expect("""
+                SELECT "Offset" FROM Block
+                  ORDER BY "Offset" DESC OFFSET 1 ROWS FETCH NEXT 1 ROWS ONLY
+                """, yields: [[200]])
   }
 
   @Test("the row limit applies before a discarded row's projection")
@@ -269,13 +163,13 @@ struct LimitTests {
     // The cap sits below the projection, so a select list that would throw —
     // `1 / 0` — never runs for a row outside the page: FETCH 0 and an OFFSET
     // past the end return empty rather than dividing.
-    #expect(try run("SELECT 1 / 0 FROM People FETCH FIRST 0 ROWS ONLY") == [])
-    #expect(try run("SELECT 1 / 0 FROM People OFFSET 10 ROWS") == [])
+    let catalog = try people()
+    try catalog.empty("SELECT 1 / 0 FROM People FETCH FIRST 0 ROWS ONLY")
+    try catalog.empty("SELECT 1 / 0 FROM People OFFSET 10 ROWS")
     // A page that DOES admit a row still evaluates the projection (and throws),
     // confirming the guard is the empty page, not a skipped projection.
-    #expect(throws: SQLError.self) {
-      try run("SELECT 1 / 0 FROM People FETCH FIRST 1 ROW ONLY")
-    }
+    catalog.expect("SELECT 1 / 0 FROM People FETCH FIRST 1 ROW ONLY",
+                   fails: .divide)
   }
 
   @Test("a directly-built negative OFFSET or FETCH is rejected")
@@ -289,12 +183,17 @@ struct LimitTests {
     }
     let fault =
         SQLError.unsupported("OFFSET and FETCH row counts must be non-negative")
+    let catalog = try people()
     let negativeOffset = Select(projection: base.projection, from: base.from,
                                 limit: Limit(count: 1, offset: -1))
-    #expect(throws: fault) { try Engine.run(.select(negativeOffset), people()) }
+    #expect(throws: fault) {
+      try Engine.run(.select(negativeOffset), catalog)
+    }
     let negativeCount = Select(projection: base.projection, from: base.from,
                                limit: Limit(count: -1))
-    #expect(throws: fault) { try Engine.run(.select(negativeCount), people()) }
+    #expect(throws: fault) {
+      try Engine.run(.select(negativeCount), catalog)
+    }
   }
 
   @Test("a near-maximal FETCH after an OFFSET does not overflow")
@@ -302,11 +201,9 @@ struct LimitTests {
     // A `count` near `Int.max` plus a positive `offset` would overflow an
     // `offset + count` bound; capping by a prefix of the skipped slice returns
     // the remaining rows rather than trapping.
-    let rows = try run("""
-        SELECT Id FROM People
-          OFFSET 1 ROWS FETCH NEXT 9223372036854775807 ROWS ONLY
-        """)
-    #expect(rows == [[.integer(2)], [.integer(3)],
-                     [.integer(4)], [.integer(5)]])
+    try people().expect("""
+                 SELECT Id FROM People
+                   OFFSET 1 ROWS FETCH NEXT 9223372036854775807 ROWS ONLY
+                 """, yields: [[2], [3], [4], [5]])
   }
 }


### PR DESCRIPTION
This pull request introduces a new test support module, `SQLTestSupport`, which provides a fluent API for building SQL test fixtures, expectation helpers for testing SQL queries, and an in-memory SQL adapter for use in tests. The changes improve test ergonomics and code reuse by centralizing test utilities and making fixture construction expressive and concise.

**Test Support Module Introduction**

* Added a new target, `SQLTestSupport`, to the package manifest. This module is now a dependency of `SQLTests`, and both use the same experimental Swift feature flags. (`Package.swift`)

**Fixture Builders and Fluent APIs**

* Introduced `Builders.swift`, which provides fluent builders for constructing SQL test fixtures, including protocols and result builders for rows, relations, and catalogs. This allows tests to define schemas and data in a readable, nested style using Swift literals.

**Test Expectations**

* Added `Expect.swift`, which defines expectation helpers for asserting SQL query results in tests. These helpers check query output, empty results, expected failures, and equivalence of query results, all while forwarding source locations for clear test failure reporting.

**In-Memory SQL Adapter**

* Implemented `Fixture.swift`, which provides an in-memory SQL adapter conforming to the engine's public protocols. This adapter supports owned, escapable storage and models SQL tables, views, and cursors, enabling expressive and efficient test harnesses.