### PR TITLE
SQL: enumerate a catalog's relations and type its columns

### DIFF
--- a/Sources/SQL/Adapter.swift
+++ b/Sources/SQL/Adapter.swift
@@ -18,13 +18,13 @@
 
 // MARK: - Values
 
-/// The kind of value a column holds.
+/// The type of value a column holds.
 ///
 /// A column is integral, approximate-numeric, textual, truth-valued, or binary.
 /// A source uses this to describe its schema and to build the typed `Value`s a
 /// `Row` yields; the engine itself compares and orders on the `Value`, not the
-/// kind.
-public enum ValueKind: Hashable, Sendable {
+/// type.
+public enum ValueType: Hashable, Sendable {
   /// An integral column — exact numeric.
   case integer
   /// An approximate-numeric column — SQL `FLOAT`/`REAL`/`DOUBLE PRECISION`,
@@ -128,11 +128,31 @@ public protocol Catalog: ~Escapable {
   /// default registers no view, so a source without stored queries need not
   /// implement it.
   borrowing func view(named name: String) -> View?
+
+  /// The names of every base relation the catalog holds, in any order.
+  ///
+  /// Where `table(named:)` resolves ONE name, this enumerates them all — the
+  /// surface the engine's `INFORMATION_SCHEMA` overlay walks to build its
+  /// `tables`/`columns` metadata. An `Array<String>` is escapable owned data,
+  /// so the enumeration stays `~Escapable`-safe over a borrowed source. Every
+  /// catalog implements it; a source that cannot enumerate its relations
+  /// returns `[]` (its metadata is then empty rather than wrong).
+  borrowing func relations() -> Array<String>
+
+  /// The names of every view the catalog registers, in any order.
+  ///
+  /// The `INFORMATION_SCHEMA` overlay lists these with a `'VIEW'` table type
+  /// beside the base `relations()`. The default is empty — a source with no
+  /// stored queries need not implement it, matching `view(named:)`.
+  borrowing func views() -> Array<String>
 }
 
 extension Catalog where Self: ~Escapable {
   /// A catalog with no stored queries registers no view.
   public borrowing func view(named name: String) -> View? { nil }
+
+  /// A catalog with no stored queries lists no view.
+  public borrowing func views() -> Array<String> { [] }
 }
 
 // MARK: - Table
@@ -161,6 +181,18 @@ public protocol Table: ~Escapable {
   /// view against a base table uniformly. The virtual columns (`Id`, an owner
   /// foreign key) are not in `names`; they resolve through `ordinal(of:)`.
   var names: Array<String> { get }
+
+  /// The value type of each real column, in ordinal order — type `i` is the
+  /// type of the real column at ordinal `i`, so `types.count == width`.
+  ///
+  /// The engine reads these only to describe a relation's schema — the
+  /// `INFORMATION_SCHEMA` overlay's `data_type` column and
+  /// `Engine.outputSchema` — never to compare or order (that runs on the
+  /// `Value` a `Row` yields). The default is `.integer` for every column, so a
+  /// source that does not type its schema advertises an all-integral relation;
+  /// a source that knows its column types overrides it. The virtual columns
+  /// (`Id`, an owner foreign key) are not typed here — not being ISO columns.
+  var types: Array<ValueType> { get }
 
   /// The virtual column names, in ordinal order — virtual `i` of `virtuals`
   /// sits at ordinal `width + i`.
@@ -221,6 +253,12 @@ public protocol Table: ~Escapable {
 extension Table where Self: ~Escapable {
   /// A relation with no virtual column ends at its real `width`.
   public var extent: Int { width }
+
+  /// A relation that does not type its schema advertises every real column as
+  /// integral, so `types.count` still equals `width`.
+  public var types: Array<ValueType> {
+    Array(repeating: .integer, count: width)
+  }
 
   /// A relation exposes no virtual column by default.
   public var virtuals: Array<String> { [] }

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -554,7 +554,8 @@ public enum Engine {
   private static func scalar(_ projection: Projection)
       throws(SQLError) -> Plan {
     guard case .all = projection else {
-      let schema = Schema(width: 0, extent: 0, names: [], virtuals: [])
+      let schema = Schema(width: 0, extent: 0, names: [], types: [],
+                          virtuals: [])
       let terms = try schema.terms(projection, in: Relation(name: ""))
       return .project(terms, .single)
     }

--- a/Sources/SQL/Materialised.swift
+++ b/Sources/SQL/Materialised.swift
@@ -48,7 +48,8 @@ internal struct Materialised: Hashable, Sendable {
   /// The resolution schema of this relation: its columns below `width`, a
   /// virtual `Id` at `width`.
   internal func schema() -> Schema {
-    Schema(width: width, extent: extent, names: columns, virtuals: ["Id"])
+    Schema(width: width, extent: extent, names: columns,
+           types: Array(repeating: .integer, count: width), virtuals: ["Id"])
   }
 
   /// The record for the row at `index`, materialising the referenced `ordinals`

--- a/Sources/SQL/Schema.swift
+++ b/Sources/SQL/Schema.swift
@@ -24,15 +24,22 @@ internal struct Schema {
   /// The real column names at their ordinals `0 ..< width`.
   internal let names: Array<String>
 
+  /// The value type of each real column at its ordinal `0 ..< width` — type `i`
+  /// types the column named `names[i]`, so `types.count == width`. It describes
+  /// the schema (the `INFORMATION_SCHEMA` overlay's `data_type`,
+  /// `Engine.outputSchema`); the engine never compares or orders on it.
+  internal let types: Array<ValueType>
+
   /// The virtual column names at their ordinals `width ..< extent` — virtual
   /// `i` sits at ordinal `width + i`. A view supplies none.
   internal let virtuals: Array<String>
 
   internal init(width: Int, extent: Int, names: Array<String>,
-                virtuals: Array<String>) {
+                types: Array<ValueType>, virtuals: Array<String>) {
     self.width = width
     self.extent = extent
     self.names = names
+    self.types = types
     self.virtuals = virtuals
   }
 
@@ -61,15 +68,23 @@ extension Table where Self: ~Escapable {
   /// its `virtuals` at and past it, with `width`/`extent` gating a `SELECT *`
   /// and the join split exactly as the table reports them.
   internal borrowing func schema() -> Schema {
-    Schema(width: width, extent: extent, names: names, virtuals: virtuals)
+    Schema(width: width, extent: extent, names: names, types: types,
+           virtuals: virtuals)
   }
 }
 
 extension View {
   /// The resolution schema of this view: its columns in projection order, no
   /// virtual column.
+  ///
+  /// A view's column types are not known without compiling its query, so its
+  /// schema types every column integral — the same default a base table without
+  /// a typed schema advertises. Resolution never reads `types`; only the
+  /// metadata surfaces do, and they see a view's columns through the base
+  /// relations they select from.
   internal func schema() -> Schema {
     Schema(width: columns.count, extent: columns.count, names: columns,
+           types: Array(repeating: .integer, count: columns.count),
            virtuals: [])
   }
 }

--- a/Sources/SQLTestSupport/Builders.swift
+++ b/Sources/SQLTestSupport/Builders.swift
@@ -10,7 +10,7 @@ import SQL
 /// A `Catalog { … }` gathers `Relation`/`View` members; a `Relation` gathers
 /// `Row` members; a `Row` takes bare Swift literals a `ValueConvertible` lifts
 /// into `Value`s, so `Row(1, "Alice", 30)` needs no `.integer(…)`/`.text(…)`
-/// ceremony. The schema is an ordered `KeyValuePairs<String, ValueKind>` so a
+/// ceremony. The schema is an ordered `KeyValuePairs<String, ValueType>` so a
 /// column's position is its declaration order, and `sorted:` marks a column
 /// seekable — driving the fixture store's binary-search `bound`.
 
@@ -106,7 +106,7 @@ public enum Member {
 /// A named base relation: an ordered schema, its rows, and an optional seekable
 /// column.
 ///
-/// The schema is a `KeyValuePairs<String, ValueKind>` so a column's ordinal is
+/// The schema is a `KeyValuePairs<String, ValueType>` so a column's ordinal is
 /// its declaration order; `sorted:` names the column whose rows are stored in
 /// ascending order, which the fixture store's `bound` seeks (and any other
 /// column scans). The body lists the rows as `Row(…)` literals.
@@ -114,10 +114,10 @@ public struct Relation {
   public let member: Member
 
   public init(_ name: String,
-              _ schema: KeyValuePairs<String, ValueKind>,
+              _ schema: KeyValuePairs<String, ValueType>,
               sorted column: String? = nil,
               @RowBuilder rows: () -> Array<Array<Value>> = { [] }) {
-    let fields = schema.map { FixtureField(name: $0.key, kind: $0.value) }
+    let fields = schema.map { FixtureField(name: $0.key, type: $0.value) }
     // Fold the sorted-column name like the engine folds identifiers, so
     // `sorted: "id"` matches a declared `Id`; a name matching no column is a
     // fixture error and traps rather than silently building an unsorted

--- a/Sources/SQLTestSupport/Fixture.swift
+++ b/Sources/SQLTestSupport/Fixture.swift
@@ -17,14 +17,14 @@ import SQL
 /// single copy of the adapter both `EngineTests` and `LimitTests` build
 /// fixtures over.
 
-/// A column's name and value kind.
+/// A column's name and value type.
 public struct FixtureField: Sendable {
   public let name: String
-  public let kind: ValueKind
+  public let type: ValueType
 
-  public init(name: String, kind: ValueKind) {
+  public init(name: String, type: ValueType) {
     self.name = name
-    self.kind = kind
+    self.type = type
   }
 }
 
@@ -101,26 +101,34 @@ public struct FixtureRelation: Sendable {
 /// source would instead annotate them. It is the proof the same protocols admit
 /// both a Span-backed source and an owned one.
 public struct FixtureCatalog: Catalog {
-  public let relations: Dictionary<String, FixtureRelation>
-  public let views: Dictionary<String, SQL.View>
+  public let catalog: Dictionary<String, FixtureRelation>
+  public let registered: Dictionary<String, SQL.View>
 
   public init(_ relations: Dictionary<String, FixtureRelation>,
               views: Dictionary<String, SQL.View> = [:]) {
-    self.relations = relations
-    self.views = views
+    self.catalog = relations
+    self.registered = views
   }
 
   public func table(named name: String) -> FixtureTable? {
     // Fold the lookup like the engine and the WinMD catalog do, so a query's
     // casing need not match the fixture's declared relation name.
     let folded = name.lowercased()
-    return relations.first { $0.key.lowercased() == folded }
+    return catalog.first { $0.key.lowercased() == folded }
         .map { FixtureTable($0.value) }
   }
 
   public func view(named name: String) -> SQL.View? {
     let folded = name.lowercased()
-    return views.first { $0.key.lowercased() == folded }?.value
+    return registered.first { $0.key.lowercased() == folded }?.value
+  }
+
+  public func relations() -> Array<String> {
+    Array(catalog.keys)
+  }
+
+  public func views() -> Array<String> {
+    Array(registered.keys)
   }
 }
 
@@ -138,6 +146,9 @@ public struct FixtureTable: Table {
 
   /// The real column names, in ordinal order.
   public var names: Array<String> { relation.fields.map(\.name) }
+
+  /// The real column types, in ordinal order — the fixtures type their fields.
+  public var types: Array<ValueType> { relation.fields.map(\.type) }
 
   /// The lone virtual `Id` column at ordinal `width`.
   public var virtuals: Array<String> { ["Id"] }

--- a/Sources/WinMD/Storage.swift
+++ b/Sources/WinMD/Storage.swift
@@ -18,7 +18,7 @@ package struct Storage: ~Escapable {
   internal let bytes: RawSpan
 
   /// The open tables of the database, borrowed from `Database.relations`.
-  package let relations: Span<Table>
+  package let tables: Span<Table>
 
   /// The "Strings" (`#Strings`) heap.
   internal let strings: RawSpan
@@ -43,7 +43,7 @@ package struct Storage: ~Escapable {
   package init(bytes: RawSpan, relations: Span<Table>, strings: RawSpan,
                 blob: RawSpan, guid: RawSpan, valid: UInt64, sorted: UInt64) {
     self.bytes = bytes
-    self.relations = relations
+    self.tables = relations
     self.strings = strings
     self.blob = blob
     self.guid = guid
@@ -56,14 +56,14 @@ package struct Storage: ~Escapable {
                                           from begin: Int = 0,
                                           to end: Int? = nil) throws(WinMDError)
       -> TableIterator<Schema> {
-    // `relations` is dense and ordered by table number, so a present table's
+    // `tables` is dense and ordered by table number, so a present table's
     // slot is the number of present tables below it: the population count of
     // the lower bits of `Valid` (the same slot the row counts are read from).
     guard valid & (1 << Schema.number) != 0 else {
       throw .TableNotFound
     }
     let slot = (valid & ((1 << Schema.number) - 1)).nonzeroBitCount
-    return TableIterator<Schema>(self, relations[slot], from: begin, to: end)
+    return TableIterator<Schema>(self, tables[slot], from: begin, to: end)
   }
 
   /// The `Tuple` at the 0-based `row` of the table described by `schema`.
@@ -80,7 +80,7 @@ package struct Storage: ~Escapable {
       throws(WinMDError) -> Tuple? {
     guard valid & (1 << schema.number) != 0 else { return nil }
     let slot = (valid & ((1 << schema.number) - 1)).nonzeroBitCount
-    let table = relations[slot]
+    let table = tables[slot]
     guard row >= 0, row < Int(table.rows) else { return nil }
     return Tuple(row, table, self)
   }
@@ -120,7 +120,7 @@ package struct Storage: ~Escapable {
       throw .TableNotFound
     }
     let slot = (valid & ((1 << schema.number) - 1)).nonzeroBitCount
-    let table = relations[slot]
+    let table = tables[slot]
 
     // The stored cell an owning row holds to name `target`. ECMA-335 rows are
     // 1-based, so `target`'s 0-based row is stored as `target.row + 1`.

--- a/Sources/winmd-inspect/Database+SQL.swift
+++ b/Sources/winmd-inspect/Database+SQL.swift
@@ -61,13 +61,24 @@ extension WinMD.Storage: SQL.Catalog {
   /// `SQLError.relation`.
   @_lifetime(borrow self)
   internal borrowing func table(named name: String) -> WinMDRelation? {
-    for index in 0 ..< relations.count {
-      if relations[index].description.caseInsensitiveCompare(name)
+    for index in 0 ..< tables.count {
+      if tables[index].description.caseInsensitiveCompare(name)
           == .orderedSame {
-        return WinMDRelation(self, relations[index])
+        return WinMDRelation(self, tables[index])
       }
     }
     return nil
+  }
+
+  /// The schema names of every open table — the `INFORMATION_SCHEMA` overlay's
+  /// base-relation enumeration, mapped from the database's open relations.
+  internal borrowing func relations() -> Array<String> {
+    var names = Array<String>()
+    names.reserveCapacity(tables.count)
+    for index in 0 ..< tables.count {
+      names.append("\(tables[index].description)")
+    }
+    return names
   }
 }
 
@@ -91,7 +102,7 @@ internal struct Session: SQL.Catalog, ~Escapable {
   internal let storage: WinMD.Storage
 
   /// The views the session has registered, keyed case-folded.
-  internal var views: Dictionary<String, View>
+  internal var registered: Dictionary<String, View>
 
   /// Opens a session over `storage`, seeding the bundled COM-interface views —
   /// or, where a `-I` `search` directory shadows or adds one, its view.
@@ -99,7 +110,7 @@ internal struct Session: SQL.Catalog, ~Escapable {
   internal init(_ storage: borrowing WinMD.Storage,
                 search: Array<String> = []) {
     self.storage = copy storage
-    self.views = Session.bundled(search: search)
+    self.registered = Session.bundled(search: search)
   }
 
   /// Opens a session over `storage` with an explicit `views` set — the seam a
@@ -109,13 +120,13 @@ internal struct Session: SQL.Catalog, ~Escapable {
   internal init(_ storage: borrowing WinMD.Storage,
                 _ views: Dictionary<String, View>) {
     self.storage = copy storage
-    self.views = views
+    self.registered = views
   }
 
   /// Registers `view` under `name` (case-folded, the way `view(named:)`
   /// resolves it) — the `CREATE VIEW` path.
   internal mutating func register(_ name: String, _ view: View) {
-    views[name.lowercased()] = view
+    registered[name.lowercased()] = view
   }
 
   @_lifetime(borrow self)
@@ -124,7 +135,22 @@ internal struct Session: SQL.Catalog, ~Escapable {
   }
 
   internal borrowing func view(named name: String) -> View? {
-    views[name.lowercased()]
+    registered[name.lowercased()]
+  }
+
+  /// The base relations the session exposes — the storage's open tables, the
+  /// same set `table(named:)` resolves against.
+  internal borrowing func relations() -> Array<String> {
+    storage.relations()
+  }
+
+  /// The names of the views the session registers — the registered and bundled
+  /// set `view(named:)` resolves, so the `INFORMATION_SCHEMA` overlay lists
+  /// them with a `'VIEW'` table type beside the base `relations()`. The stored
+  /// map is keyed case-folded; a view's own declared name is not retained, so
+  /// the folded keys are the names the overlay reports.
+  internal borrowing func views() -> Array<String> {
+    Array(registered.keys)
   }
 }
 
@@ -208,6 +234,27 @@ internal struct WinMDRelation: SQL.Table, ~Escapable {
       names.append("\(table.schema.fields[index].name)")
     }
     return names
+  }
+
+  /// The value type of each real field, in ordinal order — mirroring how a
+  /// `WinMDRow` cell decides its `Value`: a `#Strings` heap index is `.text`, a
+  /// `#Blob` heap index a `.blob`, every other column (a constant, a
+  /// foreign-key index, another heap) an `.integer`. The virtual columns are
+  /// not typed here.
+  internal var types: Array<ValueType> {
+    var types = Array<ValueType>()
+    types.reserveCapacity(table.schema.fields.count)
+    for index in 0 ..< table.schema.fields.count {
+      switch table.schema.fields[index].type {
+      case .index(.heap(.string)):
+        types.append(.text)
+      case .index(.heap(.blob)):
+        types.append(.blob)
+      default:
+        types.append(.integer)
+      }
+    }
+    return types
   }
 
   /// The virtual column names, in ordinal order — `Id` at `width`, then its
@@ -487,11 +534,11 @@ extension WinMDRelation {
       for index in Self.lists.indices
           where Self.lists[index].child
                     .caseInsensitiveCompare(child.description) == .orderedSame {
-        for relation in 0 ..< storage.relations.count
-            where storage.relations[relation].description
+        for relation in 0 ..< storage.tables.count
+            where storage.tables[relation].description
                       .caseInsensitiveCompare(Self.lists[index].parent)
                           == .orderedSame {
-          self.parent = storage.relations[relation]
+          self.parent = storage.tables[relation]
           self.column = Self.lists[index].column
           return
         }
@@ -682,10 +729,10 @@ extension WinMD.Storage {
   /// against the database's relations — the signature decode's table lookup, the
   /// same keying `WinMDRelation.Link` uses to find a list parent.
   internal borrowing func opened(_ schema: String) -> WinMD.Table? {
-    for index in 0 ..< relations.count
-        where relations[index].description
+    for index in 0 ..< tables.count
+        where tables[index].description
                   .caseInsensitiveCompare(schema) == .orderedSame {
-      return relations[index]
+      return tables[index]
     }
     return nil
   }

--- a/Sources/winmd-inspect/Shell.swift
+++ b/Sources/winmd-inspect/Shell.swift
@@ -42,7 +42,7 @@ internal struct Tables: Metacommand {
   internal init(_ arguments: Substring) {}
 
   internal func execute(against shell: inout Shell) throws {
-    let relations = shell.session.storage.relations
+    let relations = shell.session.storage.tables
     for index in 0 ..< relations.count { print("  \(relations[index])") }
   }
 }

--- a/Tests/SQLTests/AggregateTests.swift
+++ b/Tests/SQLTests/AggregateTests.swift
@@ -25,15 +25,19 @@ private struct AggregateRelation: Sendable {
 
 /// A `Catalog` over a dictionary of named relations.
 private struct AggregateMemory: Catalog {
-  let relations: Dictionary<String, AggregateRelation>
+  let catalog: Dictionary<String, AggregateRelation>
 
   init(_ relations: Dictionary<String, AggregateRelation>) {
-    self.relations = relations
+    self.catalog = relations
   }
 
   func table(named name: String) -> AggregateTable? {
-    guard let relation = relations[name] else { return nil }
+    guard let relation = catalog[name] else { return nil }
     return AggregateTable(relation)
+  }
+
+  func relations() -> Array<String> {
+    Array(catalog.keys)
   }
 }
 

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -72,8 +72,8 @@ private func grades() throws -> Memory {
 /// `Relation` (whose only marker is `sorted:`) does not spell.
 private func attributes() -> Memory {
   let fields = [
-    Field(name: "Parent", kind: .integer),
-    Field(name: "Name", kind: .text),
+    Field(name: "Parent", type: .integer),
+    Field(name: "Name", type: .text),
   ]
   // Stored `Parent` = `(Id << 2) | tag` (Coded.bits == 2), ascending.
   // Decoded `Parent`:
@@ -102,7 +102,7 @@ private func attributes() -> Memory {
 /// The ten columns and four rows are generated, so it is built directly as a
 /// `FixtureRelation` rather than a literal-per-row fluent `Relation`.
 private func wide() -> Memory {
-  let fields = (0 ..< 10).map { Field(name: "C\($0)", kind: .integer) }
+  let fields = (0 ..< 10).map { Field(name: "C\($0)", type: .integer) }
   let records = (0 ..< 4).map { row in
     (0 ..< 10).map { Value.integer(row * 10 + $0) }
   }
@@ -161,7 +161,7 @@ private func views() throws -> Memory {
     try View("Picked", "SELECT Id, Name FROM Parent WHERE Id = :id",
              as: ["Key", "Label"])
   }
-  return Memory(try family().relations, views: catalog.views)
+  return Memory(try family().catalog, views: catalog.registered)
 }
 
 /// A catalog with NULL cells: a `Maybe` relation whose `Note` text column is
@@ -990,7 +990,7 @@ struct EngineViewTests {
     // catches the mismatch at resolution rather than indexing past a row.
     let star = try View(query: select("SELECT * FROM Parent"),
                         columns: ["a", "b", "c"])
-    let catalog = Memory(try family().relations, views: ["Star": star])
+    let catalog = Memory(try family().catalog, views: ["Star": star])
     #expect(throws: SQLError.columns(expected: 2, got: 3)) {
       try Engine.run(parse("SELECT a FROM Star"), catalog)
     }
@@ -1002,7 +1002,7 @@ struct EngineViewTests {
     // resolves and queries — the backstop passes the well-formed view through.
     let star = try View(query: select("SELECT * FROM Parent"),
                         columns: ["a", "b"])
-    let catalog = Memory(try family().relations, views: ["Star": star])
+    let catalog = Memory(try family().catalog, views: ["Star": star])
     let rows = try Engine.run(parse("SELECT b FROM Star WHERE a = 1"), catalog)
     #expect(rows == [[.text("Ada")]])
   }
@@ -1221,8 +1221,8 @@ private func residual(_ plan: Plan) -> Bool {
 private func counted() throws -> (catalog: Memory, reads: Counter) {
   let reads = Counter()
   let parent = [
-    Field(name: "Id", kind: .integer),
-    Field(name: "Name", kind: .text),
+    Field(name: "Id", type: .integer),
+    Field(name: "Name", type: .text),
   ]
   let parents = [
     [.integer(1), .text("Ada")],
@@ -1231,8 +1231,8 @@ private func counted() throws -> (catalog: Memory, reads: Counter) {
   ] as Array<Array<Value>>
 
   let child = [
-    Field(name: "Pid", kind: .integer),
-    Field(name: "Kid", kind: .text),
+    Field(name: "Pid", type: .integer),
+    Field(name: "Kid", type: .text),
   ]
   let children = [
     [.integer(1), .text("Ann")],
@@ -1261,8 +1261,8 @@ private func counted() throws -> (catalog: Memory, reads: Counter) {
 /// projection and seeking inside the `Alpha` arm.
 private func spanned() throws -> Memory {
   let alpha = [
-    Field(name: "Key", kind: .integer),
-    Field(name: "Tag", kind: .text),
+    Field(name: "Key", type: .integer),
+    Field(name: "Tag", type: .text),
   ]
   let alphas = [
     [.integer(1), .text("a1")],
@@ -1271,8 +1271,8 @@ private func spanned() throws -> Memory {
   ] as Array<Array<Value>>
 
   let beta = [
-    Field(name: "Tag", kind: .text),
-    Field(name: "Key", kind: .integer),
+    Field(name: "Tag", type: .text),
+    Field(name: "Key", type: .integer),
   ]
   let betas = [
     [.text("b1"), .integer(1)],
@@ -1362,9 +1362,9 @@ struct EnginePushdownTests {
     // survives the three-term AND.
     let catalog = Memory([
       "T": FixtureRelation([
-        Field(name: "Name", kind: .text),
-        Field(name: "Age", kind: .integer),
-        Field(name: "Id", kind: .integer),
+        Field(name: "Name", type: .text),
+        Field(name: "Age", type: .integer),
+        Field(name: "Id", type: .integer),
       ], [
         [.text("a"), .integer(1), .integer(5)],
         [.text("b"), .integer(2), .integer(6)],
@@ -1390,9 +1390,9 @@ struct EnginePushdownTests {
     // residual bars the seek: the plan scans, and it raises.
     let catalog = Memory([
       "T": FixtureRelation([
-        Field(name: "x", kind: .integer),
-        Field(name: "name", kind: .text),
-        Field(name: "id", kind: .integer),
+        Field(name: "x", type: .integer),
+        Field(name: "name", type: .text),
+        Field(name: "id", type: .integer),
       ], [
         [.integer(0), .text("a"), .integer(5)],
       ] as Array<Array<Value>>, sorted: 2),
@@ -1516,9 +1516,9 @@ struct EnginePushdownTests {
     // the query returns no rows. Pushed to the left, it would run once per left
     // row and raise `SQLError.divide`.
     let catalog = Memory([
-      "A": FixtureRelation([Field(name: "x", kind: .integer)],
+      "A": FixtureRelation([Field(name: "x", type: .integer)],
                     [[.integer(1)]] as Array<Array<Value>>),
-      "B": FixtureRelation([Field(name: "y", kind: .integer)],
+      "B": FixtureRelation([Field(name: "y", type: .integer)],
                     [] as Array<Array<Value>>),
     ])
     let rows = try Engine.run(parse("""
@@ -1535,9 +1535,9 @@ struct EnginePushdownTests {
     // never evaluated; the query returns no rows. Pushed to `A` (x = 0) it would
     // divide by zero and raise `SQLError.divide`.
     let catalog = Memory([
-      "A": FixtureRelation([Field(name: "x", kind: .integer)],
+      "A": FixtureRelation([Field(name: "x", type: .integer)],
                     [[.integer(0)]] as Array<Array<Value>>),
-      "B": FixtureRelation([Field(name: "y", kind: .integer)],
+      "B": FixtureRelation([Field(name: "y", type: .integer)],
                     [] as Array<Array<Value>>),
     ])
     let rows = try Engine.run(parse("""
@@ -1554,9 +1554,9 @@ struct EnginePushdownTests {
     // the division runs, silently returning no rows. The earlier unsafe conjunct
     // is an ordering barrier, so the query raises as the un-pushed `AND` would.
     let catalog = Memory([
-      "A": FixtureRelation([Field(name: "x", kind: .integer)],
+      "A": FixtureRelation([Field(name: "x", type: .integer)],
                     [[.integer(0)]] as Array<Array<Value>>),
-      "B": FixtureRelation([Field(name: "y", kind: .integer)],
+      "B": FixtureRelation([Field(name: "y", type: .integer)],
                     [[.integer(0)]] as Array<Array<Value>>),
     ])
     #expect(throws: SQLError.self) {
@@ -1576,11 +1576,11 @@ struct EnginePushdownTests {
     // first and raises. The matching Parent is named 'other', so the row is
     // excluded with no throw.
     let catalog = Memory([
-      "Child": FixtureRelation([Field(name: "Pid", kind: .integer),
-                         Field(name: "x", kind: .integer)],
+      "Child": FixtureRelation([Field(name: "Pid", type: .integer),
+                         Field(name: "x", type: .integer)],
                         [[.integer(1), .integer(0)]] as Array<Array<Value>>),
-      "Parent": FixtureRelation([Field(name: "Id", kind: .integer),
-                          Field(name: "Name", kind: .text)],
+      "Parent": FixtureRelation([Field(name: "Id", type: .integer),
+                          Field(name: "Name", type: .text)],
                          [[.integer(1), .text("other")]]
                              as Array<Array<Value>>),
     ])
@@ -1619,8 +1619,8 @@ struct EnginePushdownTests {
     // pushing `id <> 0` below the view's Project would filter the row first and
     // silently skip the division, so a view whose projection can throw is never
     // pushed into.
-    let t = [Field(name: "id", kind: .integer),
-             Field(name: "z", kind: .integer)]
+    let t = [Field(name: "id", type: .integer),
+             Field(name: "z", type: .integer)]
     let rows = [[.integer(0), .integer(0)]] as Array<Array<Value>>
     let view = try View(query: select("SELECT id, 1 / z FROM T"),
                         columns: ["id", "q"])
@@ -1640,7 +1640,7 @@ struct EnginePushdownTests {
     // outer division ever runs, silently returning no rows. The unsafe outer
     // conjunct is an ordering barrier, so the query raises as the un-pushed `AND`
     // would.
-    let t = [Field(name: "x", kind: .integer)]
+    let t = [Field(name: "x", type: .integer)]
     let rows = [[.integer(0)]] as Array<Array<Value>>
     let view = try View(query: select("SELECT x FROM T"), columns: ["x"])
     let catalog = Memory(["T": FixtureRelation(t, rows, sorted: 0)],
@@ -1662,11 +1662,11 @@ struct EnginePushdownTests {
     // nullable conjunct must NOT ride past a LATER unsafe conjunct, so `A.x = 1`
     // stays a product-level residual and the query raises.
     let catalog = Memory([
-      "A": FixtureRelation([Field(name: "x", kind: .integer),
-                     Field(name: "k", kind: .integer)],
+      "A": FixtureRelation([Field(name: "x", type: .integer),
+                     Field(name: "k", type: .integer)],
                     [[.null, .integer(0)]] as Array<Array<Value>>),
-      "B": FixtureRelation([Field(name: "y", kind: .integer),
-                     Field(name: "k", kind: .integer)],
+      "B": FixtureRelation([Field(name: "y", type: .integer),
+                     Field(name: "k", type: .integer)],
                     [[.integer(0), .integer(0)]] as Array<Array<Value>>),
     ])
     let select = try parse("""
@@ -1697,8 +1697,8 @@ struct EnginePushdownTests {
     // division runs, suppressing the throw. A nullable conjunct must NOT be
     // injected past a LATER unsafe outer conjunct, so `x = 1` stays outer and
     // the query raises.
-    let t = [Field(name: "x", kind: .integer),
-             Field(name: "y", kind: .integer)]
+    let t = [Field(name: "x", type: .integer),
+             Field(name: "y", type: .integer)]
     let rows = [[.null, .integer(0)]] as Array<Array<Value>>
     let view = try View(query: select("SELECT x, y FROM T"),
                         columns: ["x", "y"])
@@ -1728,8 +1728,8 @@ struct EnginePushdownTests {
     // `1 = :missing` into the view would drop every row first, suppressing the
     // throw. A bound conjunct is nullable despite reading no slot, so it stays
     // outer and the query raises.
-    let t = [Field(name: "x", kind: .integer),
-             Field(name: "y", kind: .integer)]
+    let t = [Field(name: "x", type: .integer),
+             Field(name: "y", type: .integer)]
     let rows = [[.integer(1), .integer(0)]] as Array<Array<Value>>
     let view = try View(query: select("SELECT x, y FROM T"),
                         columns: ["x", "y"])
@@ -1760,11 +1760,11 @@ struct EnginePushdownTests {
     // separate inner gate drops that pair before the WHERE runs, so the query
     // does not raise: the matched `x = 1` row fails `(1 / 1) = 0`, leaving no
     // rows.
-    let a = [Field(name: "x", kind: .integer), Field(name: "k", kind: .integer)]
+    let a = [Field(name: "x", type: .integer), Field(name: "k", type: .integer)]
     let catalog = Memory([
       "A": FixtureRelation(a, [[.integer(1), .integer(1)],
                         [.integer(0), .null]] as Array<Array<Value>>),
-      "T": FixtureRelation([Field(name: "k", kind: .integer)],
+      "T": FixtureRelation([Field(name: "k", type: .integer)],
                     [[.integer(1)]] as Array<Array<Value>>),
     ], views: ["V": try View(query: select("SELECT k FROM T"),
                              columns: ["k"])])
@@ -1785,8 +1785,8 @@ struct EnginePushdownTests {
 private func hashable() -> (catalog: Memory, reads: Counter) {
   let reads = Counter()
   let parent = [
-    Field(name: "Id", kind: .integer),
-    Field(name: "Name", kind: .text),
+    Field(name: "Id", type: .integer),
+    Field(name: "Name", type: .text),
   ]
   let parents = [
     [.integer(1), .text("Ada")],
@@ -1795,8 +1795,8 @@ private func hashable() -> (catalog: Memory, reads: Counter) {
   ] as Array<Array<Value>>
 
   let child = [
-    Field(name: "Pid", kind: .integer),
-    Field(name: "Kid", kind: .text),
+    Field(name: "Pid", type: .integer),
+    Field(name: "Kid", type: .text),
   ]
   let children = [
     [.integer(1), .text("Ann")],
@@ -1840,11 +1840,11 @@ struct EngineHashJoinTests {
     // coded run instead. `Attribute.Parent` is such a column (stored raw
     // `(Id << 2) | tag`, decoded to a Id), and one `Type` (Id 6) probes it.
     let reads = Counter()
-    let type = [Field(name: "Id", kind: .integer)]
+    let type = [Field(name: "Id", type: .integer)]
     let types = [[.integer(6)]] as Array<Array<Value>>
     let attribute = [
-      Field(name: "Parent", kind: .integer),
-      Field(name: "Name", kind: .text),
+      Field(name: "Parent", type: .integer),
+      Field(name: "Name", type: .text),
     ]
     let attributes = [
       [.integer(0), .text("null-ref")],
@@ -1898,16 +1898,16 @@ struct EngineHashJoinTests {
     // nested-loop path this replaced read none for an all-null outer too.
     let reads = Counter()
     let parent = [
-      Field(name: "Id", kind: .integer),
-      Field(name: "Name", kind: .text),
+      Field(name: "Id", type: .integer),
+      Field(name: "Name", type: .text),
     ]
     let parents = [
       [.integer(1), .text("Ada")],
       [.integer(2), .text("Bee")],
     ] as Array<Array<Value>>
     let child = [
-      Field(name: "Pid", kind: .integer),
-      Field(name: "Kid", kind: .text),
+      Field(name: "Pid", type: .integer),
+      Field(name: "Kid", type: .text),
     ]
     let children = [
       [.integer(1), .text("Ann")],
@@ -1969,16 +1969,16 @@ struct EngineHashJoinTests {
     // nothing, and a NULL inner key is never bucketed. `Parent` here is unsorted
     // so the join hashes.
     let parent = [
-      Field(name: "Id", kind: .integer),
-      Field(name: "Name", kind: .text),
+      Field(name: "Id", type: .integer),
+      Field(name: "Name", type: .text),
     ]
     let parents = [
       [.integer(1), .text("Ada")],
       [.integer(2), .text("Bee")],
     ] as Array<Array<Value>>
     let child = [
-      Field(name: "Pid", kind: .integer),
-      Field(name: "Name", kind: .text),
+      Field(name: "Pid", type: .integer),
+      Field(name: "Name", type: .text),
     ]
     let children = [
       [.integer(1), .text("Ann")],
@@ -2011,8 +2011,8 @@ struct EngineHashJoinTests {
     // bucketed (three reads) before the filter matched none of it.
     let reads = Counter()
     let parent = [
-      Field(name: "Id", kind: .integer),
-      Field(name: "Code", kind: .integer),
+      Field(name: "Id", type: .integer),
+      Field(name: "Code", type: .integer),
     ]
     let parents = [
       [.integer(1), .integer(10)],
@@ -2020,8 +2020,8 @@ struct EngineHashJoinTests {
       [.integer(3), .integer(30)],
     ] as Array<Array<Value>>
     let child = [
-      Field(name: "Code", kind: .integer),
-      Field(name: "Kid", kind: .text),
+      Field(name: "Code", type: .integer),
+      Field(name: "Kid", type: .text),
     ]
     let children = [
       [.integer(10), .text("Ann")],
@@ -2102,8 +2102,8 @@ struct EngineStreamingProductTests {
     // A NULL-keyed pair evaluates the ON equality to UNKNOWN, which the fused
     // filter drops exactly as `admitted` would — no NULL child reaches a match.
     let child = [
-      Field(name: "Pid", kind: .integer),
-      Field(name: "Name", kind: .text),
+      Field(name: "Pid", type: .integer),
+      Field(name: "Name", type: .text),
     ]
     let children = [
       [.integer(2), .text("Bob")],
@@ -2113,8 +2113,8 @@ struct EngineStreamingProductTests {
         SELECT Id, Name FROM Base WHERE Id >= 2
         """), columns: ["Key", "Label"])
     let base = [
-      Field(name: "Id", kind: .integer),
-      Field(name: "Name", kind: .text),
+      Field(name: "Id", type: .integer),
+      Field(name: "Name", type: .text),
     ]
     let bases = [
       [.integer(2), .text("Bee")],
@@ -2484,7 +2484,7 @@ struct EngineBoundTests {
 /// `a` already in `Left`, so a trailing `UNION ALL Extra` keeps it a second
 /// time — proving an inner `UNION`'s dedup survives an outer `UNION ALL`.
 private func tags() -> Memory {
-  let fields = [Field(name: "Tag", kind: .text)]
+  let fields = [Field(name: "Tag", type: .text)]
   let left = [
     [.text("a")],
     [.text("shared")],
@@ -2578,7 +2578,7 @@ struct EngineUnionTests {
     let both = try View(query: select("""
         SELECT Tag FROM Left UNION SELECT Tag FROM Right
         """), columns: ["Tag"])
-    let catalog = Memory(tags().relations, views: ["Both": both])
+    let catalog = Memory(tags().catalog, views: ["Both": both])
     let rows = try Engine.run(parse("SELECT Tag FROM Both"), catalog)
     #expect(rows == [[.text("a")], [.text("shared")], [.text("b")]])
   }
@@ -3106,7 +3106,7 @@ struct EngineWithTests {
     // bind to the CTE and the query would return `99`.
     let adults =
         try View(query: select("SELECT Id FROM Parent"), columns: ["Id"])
-    let catalog = Memory(try family().relations, views: ["Adults": adults])
+    let catalog = Memory(try family().catalog, views: ["Adults": adults])
     let rows = try statement("""
         WITH Parent (Id) AS (SELECT 99 AS Id FROM Parent WHERE Id = 1)
           SELECT Id FROM Adults
@@ -3121,7 +3121,7 @@ struct EngineWithTests {
     // — the scoping fix narrows only a view's body, never the statement query.
     let adults =
         try View(query: select("SELECT Id FROM Parent"), columns: ["Id"])
-    let catalog = Memory(try family().relations, views: ["Adults": adults])
+    let catalog = Memory(try family().catalog, views: ["Adults": adults])
     let rows = try statement("""
         WITH Parent (Id) AS (SELECT 99 AS Id FROM Parent WHERE Id = 1)
           SELECT Id FROM Parent
@@ -3152,9 +3152,9 @@ struct EngineWithTests {
     // alone, so this is NOT routed through the fixpoint: the two arms materialise
     // once (UNION ALL) instead of the arm re-running to the recursion cap.
     let catalog = Memory([
-      "Parent": FixtureRelation([Field(name: "Id", kind: .integer)],
+      "Parent": FixtureRelation([Field(name: "Id", type: .integer)],
                          [[.integer(1)], [.integer(2)]] as Array<Array<Value>>),
-      "Extra": FixtureRelation([Field(name: "Id", kind: .integer)],
+      "Extra": FixtureRelation([Field(name: "Id", type: .integer)],
                         [[.integer(3)]] as Array<Array<Value>>),
     ])
     let rows = try statement("""
@@ -3173,12 +3173,12 @@ struct EngineWithTests {
 /// `SELECT 1` the dialect lacks expressed as `SELECT 1 FROM Seed`. It also
 /// carries an `Edge(Src, Dst)` relation for a transitive-closure test.
 private func seed() -> Memory {
-  let one = [Field(name: "One", kind: .integer)]
+  let one = [Field(name: "One", type: .integer)]
   let seedRows = [[.integer(1)]] as Array<Array<Value>>
 
   let edge = [
-    Field(name: "Src", kind: .integer),
-    Field(name: "Dst", kind: .integer),
+    Field(name: "Src", type: .integer),
+    Field(name: "Dst", type: .integer),
   ]
   // 1 -> 2 -> 3 -> 4, a simple chain whose closure is every reachable pair.
   let edges = [
@@ -3302,7 +3302,7 @@ struct EngineRecursiveTests {
     // this — the anchor's reference resolves to an existing base relation, so it
     // is a valid seed, not a misplaced recursive arm.
     let catalog = Memory([
-      "Parent": FixtureRelation([Field(name: "Id", kind: .integer)],
+      "Parent": FixtureRelation([Field(name: "Id", type: .integer)],
                          [[.integer(1)]] as Array<Array<Value>>),
     ])
     let rows = try Engine.run(Statement(parsing: """
@@ -3324,7 +3324,7 @@ struct EngineRecursiveTests {
     // self-reference. The guard must accept a view seed as well as a table.
     let view = try View(query: select("SELECT Id FROM Parent"), columns: ["id"])
     let catalog = Memory([
-      "Parent": FixtureRelation([Field(name: "Id", kind: .integer)],
+      "Parent": FixtureRelation([Field(name: "Id", type: .integer)],
                          [[.integer(1)]] as Array<Array<Value>>),
     ], views: ["v": view])
     let rows = try Engine.run(Statement(parsing: """

--- a/Tests/winmd-inspectTests/DatabaseSQLTests.swift
+++ b/Tests/winmd-inspectTests/DatabaseSQLTests.swift
@@ -324,6 +324,19 @@ struct DatabaseSQLTests {
     }
   }
 
+  @Test("a session enumerates its registered views for introspection")
+  func sessionViewsEnumerated() throws {
+    // The session implements `Catalog.views()` off its registered set, the
+    // surface the `INFORMATION_SCHEMA` overlay lists with a `'VIEW'` table type.
+    // A session over one registered view enumerates exactly that view's name.
+    try DatabaseSQLTests.with { catalog in
+      let (name, view) = try DatabaseSQLTests.create(
+          "CREATE VIEW named AS SELECT TypeName FROM TypeDef")
+      let session = Session(catalog, [name: view])
+      #expect(session.views() == ["named"])
+    }
+  }
+
   @Test("the render decode spells a method's return from its signature")
   func decodesReturn() {
     // The render decodes a return at render time (not through a virtual column):
@@ -661,9 +674,9 @@ struct DatabaseSQLTests {
     try DatabaseSQLTests.with { catalog in
       var shell = Shell(catalog)
       try shell.execute("CREATE VIEW names AS SELECT TypeName FROM TypeDef")
-      #expect(shell.session.views.keys.contains("names"))
+      #expect(shell.session.registered.keys.contains("names"))
       let rows = try DatabaseSQLTests.run(
-          "SELECT TypeName FROM names", shell.session.views, catalog)
+          "SELECT TypeName FROM names", shell.session.registered, catalog)
       #expect(rows == [[.text("IMyInterface")], [.text("INotGuid")]])
     }
   }
@@ -841,7 +854,7 @@ struct DatabaseSQLTests {
     DatabaseSQLTests.with { catalog in
       var shell = Shell(catalog)
       #expect(throws: Never.self) { try shell.execute(".read \(path)") }
-      #expect(shell.session.views.keys.contains("ok"))
+      #expect(shell.session.registered.keys.contains("ok"))
     }
   }
 


### PR DESCRIPTION
The engine's adapter surface can resolve a relation by name but not enumerate the set, and it describes a column by name without its value type. An INFORMATION_SCHEMA introspection overlay needs both: it walks every relation a catalog holds and reports each column's data type.

Add two escapable-safe capabilities to the adapter, with defaults that leave existing sources unchanged:

  - `Catalog.relations()` enumerates the base-table names (an owned `Array<String>`, so it stays `~Escapable`-safe over borrowed storage), and `Catalog.views()` the registered view names, defaulting to `[]`.
  - `Table.types` gives each real column's `ValueType`, defaulting to `.integer` over `width`; `Schema` carries the same `types` beside its `names`, threaded through the `Table`/`View`/`Materialised` schema factories. It describes the schema only — the engine never compares or orders on it.

`WinMD.Storage` already has a stored `relations: Span<Table>` property, so its `Catalog.relations()` method would clash with it (a stored property shadows a same-named method); the property is renamed to `tables` to free the method name. The WinMD adapter implements `relations()` from its open tables and derives `types` from the schema fields, mirroring how a `WinMDRow` cell decides its `Value` (a `#Strings` index is `.text`, a `#Blob` index a `.blob`, else `.integer`). The shared `FixtureCatalog` and the `AggregateMemory` test adapter gain `relations()` (and `FixtureTable` derives `types` from its typed fields); their stored relation/view dictionaries are renamed off the new method names to avoid the same-name clash.

`Session` implements `views()` too, off its registered set — the surface the INFORMATION_SCHEMA overlay lists with a `'VIEW'` table type. Its stored view map is renamed from `views` to `registered` so the enumerated `views()` method no longer clashes with the property, and the shell tests that read the map are updated to the new name.