### PR TITLE
SQL: add a scalar-call inventory to the query AST

### DIFF
--- a/Sources/SQL/AST.swift
+++ b/Sources/SQL/AST.swift
@@ -459,3 +459,81 @@ public struct Limit: Hashable, Sendable {
     self.offset = offset
   }
 }
+
+// MARK: - Scalar-call inventory
+
+extension Query {
+  /// The names of every scalar-function `call` anywhere in the query — across
+  /// both arms of a `UNION` and every call-bearing clause of each arm.
+  ///
+  /// The introspection builder checks these against the registered routines
+  /// before advertising a view. `compile` resolves a call's ARGUMENTS but
+  /// cannot check the routine EXISTS — it holds no routine set and builds no
+  /// call term, the name binding only at execute — so a call to an unregistered
+  /// function in a `WHERE`/`HAVING` or a later `UNION` arm, invisible to the
+  /// first-arm projection type walk, would otherwise be advertised though a run
+  /// faults `SQLError.function`.
+  internal var calls: Set<String> {
+    switch self {
+    case let .select(select):
+      select.calls
+    case let .union(query, select, _):
+      query.calls.union(select.calls)
+    }
+  }
+}
+
+extension Select {
+  /// The scalar-call names across this arm's call-bearing clauses — the
+  /// projection expressions, the `WHERE`, and the `HAVING`. `GROUP BY`, the
+  /// join equalities, and `ORDER BY` are column references, never calls.
+  internal var calls: Set<String> {
+    var names = Set<String>()
+    if case let .expressions(items) = projection {
+      for item in items { names.formUnion(item.expression.calls) }
+    }
+    if let predicate { names.formUnion(predicate.calls) }
+    if let having { names.formUnion(having.calls) }
+    return names
+  }
+}
+
+extension Predicate {
+  /// The scalar-call names within this predicate tree.
+  internal var calls: Set<String> {
+    switch self {
+    case let .comparison(left, _, right):
+      left.calls.union(right.calls)
+    case let .bound(left, _, _):
+      left.calls
+    case let .null(operand, _):
+      operand.calls
+    case let .and(lhs, rhs), let .or(lhs, rhs):
+      lhs.calls.union(rhs.calls)
+    case let .not(operand):
+      operand.calls
+    }
+  }
+}
+
+extension Expression {
+  /// The scalar-call names within this expression — the call itself and every
+  /// call nested in its arguments, a binary's operands, or an aggregate's
+  /// operand. A bare column or literal names none.
+  internal var calls: Set<String> {
+    switch self {
+    case .column, .literal:
+      []
+    case let .call(name, arguments):
+      arguments.reduce(into: Set([name])) { $0.formUnion($1.calls) }
+    case let .binary(_, lhs, rhs):
+      lhs.calls.union(rhs.calls)
+    case let .aggregate(_, operand):
+      if case let .expression(expression) = operand {
+        expression.calls
+      } else {
+        []
+      }
+    }
+  }
+}

--- a/Tests/SQLTests/ASTTests.swift
+++ b/Tests/SQLTests/ASTTests.swift
@@ -1,0 +1,56 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQL
+
+private func parse(query text: String) throws -> Query {
+  guard case let .select(query) = try Statement(parsing: text) else {
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return query
+}
+
+@Suite struct ScalarCallInventoryTests {
+  @Test("a bare-column query names no calls")
+  func none() throws {
+    #expect(try parse(query: "SELECT a, b FROM t").calls == [])
+  }
+
+  @Test("a projected call is named")
+  func projection() throws {
+    #expect(try parse(query: "SELECT f(a) AS x FROM t").calls == ["f"])
+  }
+
+  @Test("calls nested in arguments and arithmetic are all named")
+  func nested() throws {
+    let calls = try parse(query: "SELECT f(g(a) + h(b)) AS x FROM t").calls
+    #expect(calls == ["f", "g", "h"])
+  }
+
+  @Test("a call in the WHERE is named")
+  func predicate() throws {
+    #expect(try parse(query: "SELECT a FROM t WHERE f(a) = 1").calls == ["f"])
+  }
+
+  @Test("a call in the HAVING is named")
+  func having() throws {
+    let calls = try parse(query: """
+        SELECT a FROM t GROUP BY a HAVING f(a) = 1
+        """).calls
+    #expect(calls == ["f"])
+  }
+
+  @Test("a call in a later UNION arm is named")
+  func laterArm() throws {
+    let calls = try parse(query: """
+        SELECT a FROM t UNION SELECT f(b) FROM u
+        """).calls
+    #expect(calls == ["f"])
+  }
+
+  @Test("a call in an aggregate operand is named")
+  func aggregateOperand() throws {
+    #expect(try parse(query: "SELECT SUM(f(a)) FROM t").calls == ["f"])
+  }
+}


### PR DESCRIPTION
`Query.calls` gathers the names of every scalar-function call anywhere in a query — across both arms of a `UNION` and each arm's call-bearing clauses (the projection expressions, the `WHERE`, and the `HAVING`), recursing through a call's arguments, a binary's operands, and an aggregate's operand. `GROUP BY`, the join equalities, and `ORDER BY` are column references, never calls, and an aggregate is distinct from a scalar `call`.

It lets a schema resolver validate the calls against the registered routines before returning a schema: `compile` resolves a call's arguments but cannot check the routine EXISTS (it holds no routine set; the name binds at execute), so an unknown call in a predicate or a later arm — invisible to a first-arm projection walk — would otherwise slip through. This is the exhaustive membership the resolver checks.