### PR TITLE
SQL: give a registered routine a declared return type

### DIFF
--- a/Sources/SQL/Filter.swift
+++ b/Sources/SQL/Filter.swift
@@ -264,7 +264,7 @@ private func apply<R: Row & ~Escapable>(_ name: String,
                                         _ row: borrowing R,
                                         _ routines: Routines)
     throws(SQLError) -> Value {
-  guard let function = routines.function(named: name) else {
+  guard let routine = routines[name] else {
     throw .function(name)
   }
   var values = Array<Value>()
@@ -272,7 +272,7 @@ private func apply<R: Row & ~Escapable>(_ name: String,
   for argument in arguments {
     try values.append(evaluate(argument, row, routines))
   }
-  let result = try function(values)
+  let result = try routine(values)
   // A registered routine is a public producer of `Value`s that bypasses the
   // literal/arithmetic finite checks; enforce the invariant here so a routine
   // cannot return `inf`/NaN. NaN in particular is unequal to itself and would

--- a/Sources/SQL/Function.swift
+++ b/Sources/SQL/Function.swift
@@ -1,63 +1,101 @@
 // Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
-/// A named scalar function — a per-row computation over typed values.
+/// A registered scalar routine — a per-row computation over evaluated arguments
+/// paired with its declared result type.
 ///
-/// A scalar function takes its arguments already evaluated to typed `Value`s
-/// (the engine evaluates each argument expression against the row first) and
-/// returns one `Value`. This is the signature the per-dialect decode functions
-/// (`guid`, `ret_type`, `span_type`, …) take: each is a pure mapping from cell
-/// values to a cell value, registered by name and called from a projection or a
-/// predicate. A function that cannot map its arguments throws `SQLError`.
-public typealias Scalar =
-    @Sendable (_ arguments: Array<Value>) throws(SQLError) -> Value
+/// A routine takes its arguments already evaluated to typed `Value`s (the
+/// engine evaluates each argument expression against the row first) and returns
+/// one `Value`; it is CALLED as a function — `routine(arguments)`. It declares
+/// the result `returns` type, read to TYPE a `f(...)` call WITHOUT running it:
+/// the result-schema walk (`Scope.type(of:)`) and the `INFORMATION_SCHEMA`
+/// `data_type` a view's `GUID(...)` column reports. This is the shape the
+/// per-dialect decode routines (`guid`, `ret_type`, `span_type`, …) take — each
+/// a pure mapping from cell values to a cell value, registered by name and
+/// called from a projection or a predicate. A routine that cannot map its
+/// arguments throws `SQLError`; one that does not declare a result type is
+/// `.integer`, the engine's exact-numeric default.
+public struct Routine: Sendable {
+  /// The declared result type, read to type a call statically.
+  public let returns: ValueType
 
-/// The catalog of named scalar functions the engine resolves a call against.
+  /// The per-row computation over evaluated arguments.
+  private let compute: @Sendable (Array<Value>) throws(SQLError) -> Value
+
+  public init(returns: ValueType = .integer,
+              _ compute: @escaping @Sendable (Array<Value>)
+                  throws(SQLError) -> Value) {
+    self.returns = returns
+    self.compute = compute
+  }
+
+  /// Computes the cell value for the evaluated `arguments`.
+  public func callAsFunction(_ arguments: Array<Value>)
+      throws(SQLError) -> Value {
+    try compute(arguments)
+  }
+}
+
+/// The catalog of named scalar routines the engine resolves a call against.
 ///
-/// A `SELECT` projection or predicate may call a function by name; the engine
+/// A `SELECT` projection or predicate may call a routine by name; the engine
 /// looks it up here and applies it to its evaluated arguments. `Routines` is
-/// escapable, immutable data — a `[name: Scalar]` map built once and threaded
+/// escapable, immutable data — a `[name: Routine]` map built once and threaded
 /// through compilation and execution beside the catalog. A name the routines do
 /// not know is `SQLError.function` at evaluation. This is the one non-data tier
-/// of synthesis: composing existing functions is free, but a new decode
+/// of synthesis: composing existing routines is free, but a new decode
 /// primitive is a registered closure.
 public struct Routines: Sendable {
-  /// The registered functions, keyed by their case-folded (lower-cased) name.
-  private let functions: Dictionary<String, Scalar>
+  /// The registered routines, keyed by their case-folded (lower-cased) name.
+  private let functions: Dictionary<String, Routine>
 
-  /// Empty routines — every call faults until a function is registered.
+  /// Empty routines — every call faults until a routine is registered.
   public init() {
     self.functions = [:]
   }
 
-  /// Routines over a `name → function` map; each name folds to lower case so a
+  /// Routines over a `name → routine` map; each name folds to lower case so a
   /// call resolves by the SQL identifier rule. Two names differing only by case
   /// merge (the later-sorting original spelling wins) instead of trapping.
-  public init(_ functions: Dictionary<String, Scalar>) {
+  public init(_ functions: Dictionary<String, Routine>) {
     self.functions = functions.sorted { $0.key < $1.key }
-      .reduce(into: Dictionary<String, Scalar>()) {
+      .reduce(into: Dictionary<String, Routine>()) {
         $0[$1.key.lowercased()] = $1.value
       }
   }
 
-  /// The function named `name`, folded to lower case like every other SQL
-  /// identifier, or `nil` if no registered function bears it. There is a single
-  /// flat map with no privileged tier: a prelude function (`Routines.standard`)
+  /// The routine `name` names, folded to lower case like every other SQL
+  /// identifier, or `nil` if no registered routine bears it. There is a single
+  /// flat map with no privileged tier: a prelude routine (`Routines.standard`)
   /// and a caller-registered one resolve through the same lookup, so a later
   /// registration shadows an earlier binding of the same name — the house rule
   /// the resolver already follows (a view shadows a table, a CTE shadows a
   /// view). (A future PATH / search-order mechanism — à la DB2 or PostgreSQL —
   /// would let a qualified call reach a specific one across schemas.)
-  public func function(named name: String) -> Scalar? {
+  public subscript(_ name: String) -> Routine? {
     functions[name.lowercased()]
   }
 
-  /// A copy of these routines with `function` bound to `name` (folded to lower
-  /// case), the binding shadowing any existing one.
-  public func registering(_ name: String, _ function: @escaping Scalar)
-      -> Routines {
+  /// The declared result type of every registered routine, keyed by its
+  /// case-folded name — the map the result-schema walk (`Scope.type(of:)`) and
+  /// the `INFORMATION_SCHEMA` view-column typing read to type a `f(...)` call.
+  public var returns: Dictionary<String, ValueType> {
+    functions.mapValues(\.returns)
+  }
+
+  /// A copy of these routines with a routine computing `compute` and returning
+  /// `returns` (default `.integer`) bound to `name` (folded to lower case), the
+  /// binding shadowing any existing one.
+  //
+  // `SQL.Value` is spelled in full here and in `bitand`: `Routines` conforms to
+  // `ExpressibleByDictionaryLiteral`, whose associated `Value` is the literal's
+  // element closure type, so an unqualified `Value` inside `Routines` names
+  // that closure, not the engine cell the routine computes.
+  public func registering(_ name: String, returns: ValueType = .integer,
+                          _ compute: @escaping @Sendable (Array<SQL.Value>)
+                              throws(SQLError) -> SQL.Value) -> Routines {
     var functions = self.functions
-    functions[name.lowercased()] = function
+    functions[name.lowercased()] = Routine(returns: returns, compute)
     return Routines(functions)
   }
 
@@ -72,17 +110,18 @@ public struct Routines: Sendable {
   /// The standard-library prelude — the routines the engine ships, seeded into
   /// the flat registry at the public entry points so a query reaches them
   /// without a caller registering a closure. They are ordinary entries in the
-  /// same map as any registered function, not a privileged tier, so a caller
-  /// MAY shadow one (see `function(named:)`). Its lone member is `BITAND`, the
+  /// same map as any registered routine, not a privileged tier, so a caller MAY
+  /// shadow one (see `subscript(_:)`). Its lone member is `BITAND`, the
   /// portable, standards-compliant spelling (Oracle's) of a bitwise AND — an
-  /// operation ISO SQL and this grammar otherwise lack.
+  /// operation ISO SQL and this grammar otherwise lack; it returns an integer.
   public static let standard: Routines = ["bitand": bitand]
 
   /// `BITAND(x, y)` — the bitwise AND of two integers. A NULL argument yields
   /// NULL (SQL null propagation); the wrong argument count or a non-integer
   /// argument is `SQLError.argument` (a function-argument fault — not
   /// `SQLError.arity`, which is the UNION column-count mismatch).
-  private static let bitand: Scalar = { arguments in
+  private static func bitand(_ arguments: Array<SQL.Value>)
+      throws(SQLError) -> SQL.Value {
     guard arguments.count == 2 else {
       throw .argument("BITAND takes two arguments")
     }
@@ -97,10 +136,21 @@ public struct Routines: Sendable {
 }
 
 extension Routines: ExpressibleByDictionaryLiteral {
-  /// Builds routines from a `name: function` dictionary literal — an empty
-  /// literal `[:]` is the empty routines, `["upper": …]` registers inline.
-  /// A repeated key keeps the last; `init(_:)` then case-folds the names.
-  public init(dictionaryLiteral elements: (String, Scalar)...) {
-    self.init(Dictionary(elements, uniquingKeysWith: { _, last in last }))
+  /// Builds routines from a `name: closure` dictionary literal — the value is a
+  /// BARE closure, so `["upper": { … }]` reads unchanged for a client that
+  /// declares no return type, the routine defaulting to a `.integer` result.
+  /// `registering(_:returns:_:)` declares another return type. An empty literal
+  /// `[:]` is the empty routines; a repeated key keeps the last, and `init(_:)`
+  /// case-folds the names.
+  //
+  // The value is spelled as a closure (not a `Routine`) so the historical
+  // bare-closure registration keeps type-checking; this closure IS the
+  // associated `Value`, so the full `SQL.Value` spelling names the engine cell.
+  public init(dictionaryLiteral elements:
+                  (String, @Sendable (Array<SQL.Value>)
+                      throws(SQLError) -> SQL.Value)...) {
+    self.init(Dictionary(
+        elements.map { ($0.0, Routine(returns: .integer, $0.1)) },
+        uniquingKeysWith: { _, last in last }))
   }
 }

--- a/Sources/winmd-inspect/Database+SQL.swift
+++ b/Sources/winmd-inspect/Database+SQL.swift
@@ -170,7 +170,10 @@ extension Session {
   /// session and render paths, which pass these routines EXPLICITLY rather than
   /// relying on the engine's default seeding.
   internal static var routines: Routines {
-    Routines.standard.registering("guid", Session.guid)
+    // `GUID` returns the UUID as text, so it is declared `.text` — the result
+    // type the schema walk and the `INFORMATION_SCHEMA` `data_type` a view's
+    // `GUID(...)` column reports read.
+    Routines.standard.registering("guid", returns: .text, Session.guid)
   }
 
   /// `GUID(blob)` — the UUID a `GuidAttribute` `CustomAttribute` value blob
@@ -181,7 +184,8 @@ extension Session {
   /// to a `GuidAttribute`, so a non-GUID blob simply yields `NULL` (preserving
   /// the old `guid` virtual column's NULL-on-mismatch behaviour). A NULL
   /// argument propagates to NULL; a non-blob argument is `SQLError.argument`.
-  private static let guid: Scalar = { arguments in
+  private static func guid(_ arguments: Array<Value>)
+      throws(SQLError) -> Value {
     guard arguments.count == 1 else {
       throw .argument("GUID takes one argument")
     }

--- a/Sources/winmd-inspect/Language.swift
+++ b/Sources/winmd-inspect/Language.swift
@@ -185,7 +185,8 @@ internal struct Language: Sendable {
   /// predicate) should `LIKE` ever be added to the engine.
   internal var routines: Routines {
     let language = self
-    let sanitize: Scalar = { arguments in
+    let sanitize:
+        @Sendable (Array<Value>) throws(SQLError) -> Value = { arguments in
       guard arguments.count == 1 else {
         throw .argument("SANITIZE takes one argument")
       }
@@ -195,6 +196,8 @@ internal struct Language: Sendable {
       }
       return .text(language.escape(identifier))
     }
-    return ["sanitize": sanitize]
+    // `SANITIZE` returns text, so it is registered with its return type rather
+    // than through the bare-closure literal (which defaults to `.integer`).
+    return Routines().registering("sanitize", returns: .text, sanitize)
   }
 }

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -2246,9 +2246,9 @@ struct EngineFunctionTests {
   func collision() throws {
     // "tag" and "TAG" fold to one name; the registry merges them (the later-
     // sorting original spelling wins) instead of trapping on the duplicate.
-    let lower: Scalar = { _ in .text("lower") }
-    let upper: Scalar = { _ in .text("upper") }
-    let routines: Routines = ["tag": lower, "TAG": upper]
+    let routines: Routines =
+        ["tag": { _ in .text("lower") },
+         "TAG": { _ in .text("upper") }]
     let query = try parse("SELECT tag(Name) FROM People WHERE Id = 1")
     let rows = try people().run(query, routines)
     #expect(rows == [[.text("lower")]])

--- a/Tests/SQLTests/FloatTests.swift
+++ b/Tests/SQLTests/FloatTests.swift
@@ -161,8 +161,9 @@ private struct DoubleArithmeticTests {
     // A registered routine is a public `Value` producer that bypasses the
     // literal/arithmetic checks; a NaN or inf result is rejected at the call
     // boundary so it never reaches dedup, ordering, or a recursive UNION.
-    let routines: Routines = ["nan": { _ in .double(.nan) },
-                              "huge": { _ in .double(.infinity) }]
+    let routines: Routines =
+        ["nan": { _ in .double(.nan) },
+         "huge": { _ in .double(.infinity) }]
     #expect(throws: SQLError.self) {
       try evaluate(.apply(name: "nan", arguments: []), Cell(.null), routines)
     }

--- a/Tests/SQLTests/FunctionTests.swift
+++ b/Tests/SQLTests/FunctionTests.swift
@@ -1,0 +1,54 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQL
+
+@Suite struct RoutineTests {
+  @Test("a routine's return type defaults to integer")
+  func defaultReturn() {
+    #expect(Routine { _ in .integer(0) }.returns == .integer)
+  }
+
+  @Test("a routine carries its declared return type")
+  func declaredReturn() {
+    #expect(Routine(returns: .text) { _ in .text("x") }.returns == .text)
+  }
+
+  @Test("a routine is called to compute a value")
+  func callable() throws {
+    let double = Routine { arguments in
+      guard case let .integer(x) = arguments[0] else { return .null }
+      return .integer(x * 2)
+    }
+    #expect(try double([.integer(21)]) == .integer(42))
+  }
+
+  @Test("a bare-closure literal registers an integer-returning routine")
+  func bareClosureLiteral() {
+    // A client's documented shape: a bare closure with no declared return type
+    // registers a routine returning the `.integer` default.
+    let routines: Routines = ["upper": { _ in .text("X") }]
+    #expect(routines["upper"]?.returns == .integer)
+  }
+
+  @Test("registering declares a return type, defaulting to integer")
+  func registering() {
+    let routines = Routines()
+        .registering("t", returns: .text) { _ in .text("x") }
+        .registering("i") { _ in .integer(0) }
+    #expect(routines.returns == ["t": .text, "i": .integer])
+  }
+
+  @Test("the name subscript resolves case-insensitively")
+  func lookup() {
+    let routines: Routines = ["Tag": { _ in .text("x") }]
+    #expect(routines["TAG"] != nil)
+    #expect(routines["nope"] == nil)
+  }
+
+  @Test("the standard prelude declares BITAND returning an integer")
+  func standardBitand() {
+    #expect(Routines.standard.returns == ["bitand": .integer])
+  }
+}


### PR DESCRIPTION
A `Routine` now pairs its per-row `scalar` computation with a declared `returns` type, and `Routines` exposes a `name → ValueType` `returns` map — the shape a schema walk reads to TYPE a `f(...)` call rather than defaulting it.

The dictionary-literal and `registering(_:returns:_:)` forms gain the return type, defaulting to `.integer` so a bare-closure registration is unchanged; the standard `BITAND` declares `.integer`, and winmd-inspect's `GUID`/`SANITIZE` declare `.text`. This reshapes the routine model ahead of the schema typing that consumes it — behaviour is unchanged, since nothing reads `returns` yet.