### PR TITLE
SQL: give a routine a declared parameter contract

### DIFF
--- a/Sources/SQL/Function.swift
+++ b/Sources/SQL/Function.swift
@@ -2,29 +2,38 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 /// A registered scalar routine — a per-row computation over evaluated arguments
-/// paired with its declared result type.
+/// paired with its declared signature.
 ///
 /// A routine takes its arguments already evaluated to typed `Value`s (the
 /// engine evaluates each argument expression against the row first) and returns
 /// one `Value`; it is CALLED as a function — `routine(arguments)`. It declares
-/// the result `returns` type, read to TYPE a `f(...)` call WITHOUT running it:
-/// the result-schema walk (`Scope.type(of:)`) and the `INFORMATION_SCHEMA`
-/// `data_type` a view's `GUID(...)` column reports. This is the shape the
-/// per-dialect decode routines (`guid`, `ret_type`, `span_type`, …) take — each
-/// a pure mapping from cell values to a cell value, registered by name and
-/// called from a projection or a predicate. A routine that cannot map its
-/// arguments throws `SQLError`; one that does not declare a result type is
-/// `.integer`, the engine's exact-numeric default.
+/// the type of each positional `parameter` — the count is the arity — and the
+/// result `returns` type, both read to TYPE a `f(...)` call WITHOUT running it:
+/// the result-schema walk (`Scope.type(of:)`) types the call by `returns` and
+/// validates each argument against `parameters`, and the `INFORMATION_SCHEMA`
+/// `data_type` a view's `GUID(...)` column reports from `returns`. This is the
+/// shape the per-dialect decode routines (`guid`, `ret_type`, `span_type`,
+/// …) take — each a pure mapping from cell values to a cell value, registered
+/// by name and called from a projection or a predicate. A routine that cannot
+/// map its arguments throws `SQLError`; one that does not declare a result type
+/// is `.integer`, the engine's exact-numeric default.
 public struct Routine: Sendable {
+  /// The declared type of each positional argument, in order — its count the
+  /// routine's arity. The static type-check validates a call against this: a
+  /// wrong argument count or a definitively-wrong argument type is rejected
+  /// before a schema is published (see `Scope`'s `call`).
+  public let parameters: Array<ValueType>
+
   /// The declared result type, read to type a call statically.
   public let returns: ValueType
 
   /// The per-row computation over evaluated arguments.
   private let compute: @Sendable (Array<Value>) throws(SQLError) -> Value
 
-  public init(returns: ValueType = .integer,
+  public init(returns: ValueType = .integer, parameters: Array<ValueType>,
               _ compute: @escaping @Sendable (Array<Value>)
                   throws(SQLError) -> Value) {
+    self.parameters = parameters
     self.returns = returns
     self.compute = compute
   }
@@ -76,26 +85,22 @@ public struct Routines: Sendable {
     functions[name.lowercased()]
   }
 
-  /// The declared result type of every registered routine, keyed by its
-  /// case-folded name — the map the result-schema walk (`Scope.type(of:)`) and
-  /// the `INFORMATION_SCHEMA` view-column typing read to type a `f(...)` call.
-  public var returns: Dictionary<String, ValueType> {
-    functions.mapValues(\.returns)
-  }
-
-  /// A copy of these routines with a routine computing `compute` and returning
-  /// `returns` (default `.integer`) bound to `name` (folded to lower case), the
-  /// binding shadowing any existing one.
+  /// A copy of these routines with a routine computing `compute`, accepting
+  /// `parameters` (default none), and returning `returns` (default `.integer`)
+  /// bound to `name` (folded to lower case), the binding shadowing any existing
+  /// one.
   //
   // `SQL.Value` is spelled in full here and in `bitand`: `Routines` conforms to
   // `ExpressibleByDictionaryLiteral`, whose associated `Value` is the literal's
-  // element closure type, so an unqualified `Value` inside `Routines` names
-  // that closure, not the engine cell the routine computes.
+  // element `Routine`, so an unqualified `Value` inside `Routines` names that
+  // element, not the engine cell the routine computes.
   public func registering(_ name: String, returns: ValueType = .integer,
+                          parameters: Array<ValueType> = [],
                           _ compute: @escaping @Sendable (Array<SQL.Value>)
                               throws(SQLError) -> SQL.Value) -> Routines {
     var functions = self.functions
-    functions[name.lowercased()] = Routine(returns: returns, compute)
+    functions[name.lowercased()] =
+        Routine(returns: returns, parameters: parameters, compute)
     return Routines(functions)
   }
 
@@ -114,12 +119,15 @@ public struct Routines: Sendable {
   /// shadow one (see `subscript(_:)`). Its lone member is `BITAND`, the
   /// portable, standards-compliant spelling (Oracle's) of a bitwise AND — an
   /// operation ISO SQL and this grammar otherwise lack; it returns an integer.
-  public static let standard: Routines = ["bitand": bitand]
+  public static let standard: Routines =
+      ["bitand": Routine(parameters: [.integer, .integer], bitand)]
 
   /// `BITAND(x, y)` — the bitwise AND of two integers. A NULL argument yields
   /// NULL (SQL null propagation); the wrong argument count or a non-integer
   /// argument is `SQLError.argument` (a function-argument fault — not
-  /// `SQLError.arity`, which is the UNION column-count mismatch).
+  /// `SQLError.arity`, which is the UNION column-count mismatch). Its declared
+  /// `[.integer, .integer]` contract is what the static type-check validates a
+  /// call against, mirroring these run-time faults.
   private static func bitand(_ arguments: Array<SQL.Value>)
       throws(SQLError) -> SQL.Value {
     guard arguments.count == 2 else {
@@ -136,21 +144,12 @@ public struct Routines: Sendable {
 }
 
 extension Routines: ExpressibleByDictionaryLiteral {
-  /// Builds routines from a `name: closure` dictionary literal — the value is a
-  /// BARE closure, so `["upper": { … }]` reads unchanged for a client that
-  /// declares no return type, the routine defaulting to a `.integer` result.
-  /// `registering(_:returns:_:)` declares another return type. An empty literal
-  /// `[:]` is the empty routines; a repeated key keeps the last, and `init(_:)`
-  /// case-folds the names.
-  //
-  // The value is spelled as a closure (not a `Routine`) so the historical
-  // bare-closure registration keeps type-checking; this closure IS the
-  // associated `Value`, so the full `SQL.Value` spelling names the engine cell.
-  public init(dictionaryLiteral elements:
-                  (String, @Sendable (Array<SQL.Value>)
-                      throws(SQLError) -> SQL.Value)...) {
-    self.init(Dictionary(
-        elements.map { ($0.0, Routine(returns: .integer, $0.1)) },
-        uniquingKeysWith: { _, last in last }))
+  /// Builds routines from a `name: Routine` dictionary literal, so every
+  /// registered routine declares its full signature — its `parameters` and
+  /// `returns` — inline: `["bitand": Routine(parameters: [.integer, .integer],
+  /// bitand)]`. An empty literal `[:]` is the empty routines; a repeated key
+  /// keeps the last, and `init(_:)` case-folds the names.
+  public init(dictionaryLiteral elements: (String, Routine)...) {
+    self.init(Dictionary(elements, uniquingKeysWith: { _, last in last }))
   }
 }

--- a/Sources/winmd-inspect/Database+SQL.swift
+++ b/Sources/winmd-inspect/Database+SQL.swift
@@ -170,10 +170,13 @@ extension Session {
   /// session and render paths, which pass these routines EXPLICITLY rather than
   /// relying on the engine's default seeding.
   internal static var routines: Routines {
-    // `GUID` returns the UUID as text, so it is declared `.text` — the result
-    // type the schema walk and the `INFORMATION_SCHEMA` `data_type` a view's
-    // `GUID(...)` column reports read.
-    Routines.standard.registering("guid", returns: .text, Session.guid)
+    // `GUID` returns the UUID as text over one blob argument, so it declares
+    // both its `.text` return type — the result type the schema walk and the
+    // `INFORMATION_SCHEMA` `data_type` a view's `GUID(...)` column reports read
+    // — and its `[.blob]` parameter contract, which the static type-check
+    // validates a `GUID(...)` call against.
+    Routines.standard.registering("guid", returns: .text, parameters: [.blob],
+                                  Session.guid)
   }
 
   /// `GUID(blob)` — the UUID a `GuidAttribute` `CustomAttribute` value blob

--- a/Sources/winmd-inspect/Language.swift
+++ b/Sources/winmd-inspect/Language.swift
@@ -196,8 +196,10 @@ internal struct Language: Sendable {
       }
       return .text(language.escape(identifier))
     }
-    // `SANITIZE` returns text, so it is registered with its return type rather
-    // than through the bare-closure literal (which defaults to `.integer`).
-    return Routines().registering("sanitize", returns: .text, sanitize)
+    // `SANITIZE` returns text over one text argument, so it declares both its
+    // return type and its `[.text]` parameter contract — the signature the
+    // static type-check validates a `SANITIZE(...)` call against.
+    return Routines().registering("sanitize", returns: .text,
+                                  parameters: [.text], sanitize)
   }
 }

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -2128,13 +2128,15 @@ struct EngineStreamingProductTests {
 /// default.
 private func routines() -> Routines {
   Routines.standard
-    .registering("upper") { arguments throws(SQLError) in
+    .registering("upper", returns: .text, parameters: [.text]) {
+      arguments throws(SQLError) in
       guard case let .text(text) = arguments.first else {
         throw .argument("upper expects one text argument")
       }
       return .text(text.uppercased())
     }
-    .registering("add") { arguments throws(SQLError) in
+    .registering("add", parameters: [.integer, .integer]) {
+      arguments throws(SQLError) in
       guard arguments.count == 2,
           case let .integer(lhs) = arguments[0],
           case let .integer(rhs) = arguments[1] else {
@@ -2234,9 +2236,10 @@ struct EngineFunctionTests {
     // The registry is a single flat map with no privileged tier, so a caller's
     // `bitand` registered OVER the prelude one shadows it (house rule: a later
     // binding wins). The user's closure returns -1, not the bitwise AND.
-    let user = Routines.standard.registering("bitand") { _ throws(SQLError) in
-      .integer(-1)
-    }
+    let user = Routines.standard
+        .registering("bitand", parameters: [.integer, .integer]) {
+          _ throws(SQLError) in .integer(-1)
+        }
     let query = try parse("SELECT BITAND(6, 3) FROM People WHERE Id = 1")
     let rows = try people().run(query, user)
     #expect(rows == [[.integer(-1)]])
@@ -2247,8 +2250,12 @@ struct EngineFunctionTests {
     // "tag" and "TAG" fold to one name; the registry merges them (the later-
     // sorting original spelling wins) instead of trapping on the duplicate.
     let routines: Routines =
-        ["tag": { _ in .text("lower") },
-         "TAG": { _ in .text("upper") }]
+        ["tag": Routine(returns: .text, parameters: [.text]) {
+          _ in .text("lower")
+        },
+         "TAG": Routine(returns: .text, parameters: [.text]) {
+          _ in .text("upper")
+        }]
     let query = try parse("SELECT tag(Name) FROM People WHERE Id = 1")
     let rows = try people().run(query, routines)
     #expect(rows == [[.text("lower")]])
@@ -2729,7 +2736,8 @@ struct EngineScalarSelectTests {
   func null() throws {
     // The bare literal NULL is not in the grammar, but a NULL arises from a
     // function returning it; `nothing` yields NULL for the single row.
-    let routines: Routines = ["nothing": { _ in .null }]
+    let routines: Routines =
+        ["nothing": Routine(parameters: []) { _ in .null }]
     let rows = try people().run(parse("SELECT nothing()"), routines)
     #expect(rows == [[.null]])
   }
@@ -3180,7 +3188,8 @@ private func seed() -> Memory {
 /// Routines with an `inc` scalar — `inc(n) = n + 1` — standing in for the `+`
 /// the dialect lacks, so a recursive counter can advance.
 private func counting() -> Routines {
-  Routines().registering("inc") { arguments throws(SQLError) in
+  Routines().registering("inc", parameters: [.integer]) {
+    arguments throws(SQLError) in
     guard case let .integer(n) = arguments.first else {
       throw .argument("inc expects one integer argument")
     }

--- a/Tests/SQLTests/FloatTests.swift
+++ b/Tests/SQLTests/FloatTests.swift
@@ -162,8 +162,12 @@ private struct DoubleArithmeticTests {
     // literal/arithmetic checks; a NaN or inf result is rejected at the call
     // boundary so it never reaches dedup, ordering, or a recursive UNION.
     let routines: Routines =
-        ["nan": { _ in .double(.nan) },
-         "huge": { _ in .double(.infinity) }]
+        ["nan": Routine(returns: .double, parameters: []) {
+          _ in .double(.nan)
+        },
+         "huge": Routine(returns: .double, parameters: []) {
+          _ in .double(.infinity)
+        }]
     #expect(throws: SQLError.self) {
       try evaluate(.apply(name: "nan", arguments: []), Cell(.null), routines)
     }

--- a/Tests/SQLTests/FunctionTests.swift
+++ b/Tests/SQLTests/FunctionTests.swift
@@ -7,48 +7,65 @@ import Testing
 @Suite struct RoutineTests {
   @Test("a routine's return type defaults to integer")
   func defaultReturn() {
-    #expect(Routine { _ in .integer(0) }.returns == .integer)
+    #expect(Routine(parameters: []) { _ in .integer(0) }.returns == .integer)
   }
 
   @Test("a routine carries its declared return type")
   func declaredReturn() {
-    #expect(Routine(returns: .text) { _ in .text("x") }.returns == .text)
+    #expect(Routine(returns: .text, parameters: []) { _ in .text("x") }
+                .returns == .text)
+  }
+
+  @Test("a routine carries its declared parameter contract")
+  func declaredParameters() {
+    let routine = Routine(parameters: [.integer, .text]) { _ in .integer(0) }
+    #expect(routine.parameters == [.integer, .text])
   }
 
   @Test("a routine is called to compute a value")
   func callable() throws {
-    let double = Routine { arguments in
+    let double = Routine(parameters: [.integer]) { arguments in
       guard case let .integer(x) = arguments[0] else { return .null }
       return .integer(x * 2)
     }
     #expect(try double([.integer(21)]) == .integer(42))
   }
 
-  @Test("a bare-closure literal registers an integer-returning routine")
-  func bareClosureLiteral() {
-    // A client's documented shape: a bare closure with no declared return type
-    // registers a routine returning the `.integer` default.
-    let routines: Routines = ["upper": { _ in .text("X") }]
-    #expect(routines["upper"]?.returns == .integer)
+  @Test("a Routine literal registers its declared signature")
+  func routineLiteral() {
+    // A client's documented shape: the literal value is a `Routine`, so each
+    // registration declares its full signature — its parameters and return
+    // type.
+    let routines: Routines =
+        ["upper": Routine(returns: .text, parameters: [.text]) {
+          _ in .text("X")
+        }]
+    #expect(routines["upper"]?.returns == .text)
+    #expect(routines["upper"]?.parameters == [.text])
   }
 
-  @Test("registering declares a return type, defaulting to integer")
+  @Test("registering declares a signature, the return defaulting to integer")
   func registering() {
     let routines = Routines()
-        .registering("t", returns: .text) { _ in .text("x") }
-        .registering("i") { _ in .integer(0) }
-    #expect(routines.returns == ["t": .text, "i": .integer])
+        .registering("t", returns: .text, parameters: [.text]) {
+          _ in .text("x")
+        }
+        .registering("i", parameters: [.integer]) { _ in .integer(0) }
+    #expect(routines["t"]?.returns == .text)
+    #expect(routines["i"]?.returns == .integer)
   }
 
   @Test("the name subscript resolves case-insensitively")
   func lookup() {
-    let routines: Routines = ["Tag": { _ in .text("x") }]
+    let routines: Routines =
+        ["Tag": Routine(returns: .text, parameters: []) { _ in .text("x") }]
     #expect(routines["TAG"] != nil)
     #expect(routines["nope"] == nil)
   }
 
-  @Test("the standard prelude declares BITAND returning an integer")
+  @Test("the standard prelude declares BITAND over two integers")
   func standardBitand() {
-    #expect(Routines.standard.returns == ["bitand": .integer])
+    #expect(Routines.standard["bitand"]?.returns == .integer)
+    #expect(Routines.standard["bitand"]?.parameters == [.integer, .integer])
   }
 }


### PR DESCRIPTION
A `Routine` declared only its result type, enough to type a call but not to validate one: an ill-typed or miscounted call fell through to the routine's own run-time `SQLError.argument`. Carry a `parameters` contract — the declared type of each positional argument, its count the arity — beside `returns`, so a call can be validated statically against the routine's full signature before a schema is published.

`registering` and the `ExpressibleByDictionaryLiteral` conformance now take the signature inline: the literal value is a `Routine` rather than a bare closure, so every registration declares its parameters and return type in one place. `Routines.returns` (the name → return-type map) is dropped — a caller that wants a routine's declared shape reads it off the `Routine`. The prelude `BITAND` declares `[.integer, .integer]`; `GUID`/`SANITIZE` declare their blob and text argument. This is the routine value model only; the type-check that consumes the contract lands separately.