### PR TITLE
SQL: storage improvements

### DIFF
--- a/Sources/SQL/Definition.swift
+++ b/Sources/SQL/Definition.swift
@@ -1,0 +1,269 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+/// The reserved namespace a DEFINITION_SCHEMA store relation is named under —
+/// the ISO 9075-11 `DEFINITION_SCHEMA`, the base metadata relations the
+/// portable `INFORMATION_SCHEMA` views read, case-folded for the dotted match.
+private let kDefinitionNamespace = "definition_schema"
+
+/// A base DEFINITION_SCHEMA relation the store serves — the raw metadata the
+/// engine builds by ENUMERATING a catalog. Each carries its column schema as
+/// (name, type) pairs — the ONE source the row build and the schema-only build
+/// (`store(_:rows:)`) share, so name and type cannot drift.
+///
+/// These are the actual store of metadata: the `INFORMATION_SCHEMA` relations
+/// are ordinary VIEWS over them, resolved by the engine's existing view
+/// machinery. The store holds each relation's portable shape, so a view is a
+/// plain column projection — the reshaping the grammar cannot yet express in
+/// SQL (NULL literals, a `CASE` mapping) lives in the builder here, and the
+/// view names and orders the store's columns.
+internal enum Definition {
+  case tables
+  case columns
+
+  /// The store relation `name` denotes, or `nil` if it is not one — the name
+  /// matched case-insensitively against the reserved namespace.
+  internal init?(_ name: String) {
+    switch name.lowercased() {
+    case "\(kDefinitionNamespace).tables":
+      self = .tables
+    case "\(kDefinitionNamespace).columns":
+      self = .columns
+    default:
+      return nil
+    }
+  }
+
+  /// The relation's column names, in order.
+  internal var names: Array<String> { schema.map(\.name) }
+
+  /// The relation's column types, in order.
+  internal var types: Array<ValueType> { schema.map(\.type) }
+
+  /// The relation's column schema — its (name, type) pairs, the ONE source
+  /// `names` and `types` (and the row and schema builders) read, so the two
+  /// cannot drift.
+  private var schema: Array<(name: String, type: ValueType)> {
+    switch self {
+    case .tables:
+      [("table_catalog", .text), ("table_schema", .text),
+       ("table_name", .text), ("table_type", .text)]
+    case .columns:
+      [("table_name", .text), ("column_name", .text),
+       ("ordinal_position", .integer), ("data_type", .text),
+       ("is_nullable", .text)]
+    }
+  }
+}
+
+/// The `DEFINITION_SCHEMA` metadata store — the ISO 9075-11 base relations,
+/// built on demand from any `Catalog` by ENUMERATING it.
+///
+/// A query may name a reserved `definition_schema.` relation
+/// (`definition_schema.tables`, `definition_schema.columns`) wherever it names
+/// a base table, and the engine answers it by ENUMERATING the catalog rather
+/// than reading a stored relation: `store(_:rows:)` walks the catalog's
+/// `relations()`/`views()` and each relation's schema and builds the named
+/// relation's rows as an escapable `Materialised`. It builds no cached state,
+/// so the engine resolves a `definition_schema.` name lazily, building only the
+/// one a query references. The portable `INFORMATION_SCHEMA` relations are
+/// ordinary VIEWS over these.
+///
+/// The store is dialect-neutral: it reads only the adapter surface every
+/// `Catalog` shares, so any source gets it for free. It is built in engine core
+/// rather than by an adapter because `Schema` — a relation's `names`/`types` —
+/// is internal to the engine.
+extension Catalog where Self: ~Escapable {
+  /// The `Materialised` for the reserved `definition_schema.` `relation`, built
+  /// over this catalog. When `rows` is `true` the relation is ENUMERATED into
+  /// its rows — `store` walks the catalog's `relations()`/`views()` and each
+  /// relation's schema; when `false` it vends a SCHEMA-ONLY relation (columns +
+  /// types, no rows), exactly what a lazy system table's `schema()` would.
+  ///
+  /// The typing paths (the view-body type resolution and the schema path in
+  /// `columns(of:)`) resolve a reserved name schema-only, so they read only the
+  /// header and never re-enter the row builder (the row build lists views,
+  /// whose bodies name the relation again). Building either form is lazy, so
+  /// the engine resolves a reserved name building only the one a query
+  /// references.
+  borrowing func store(_ relation: Definition, rows: Bool,
+                       _ routines: Routines = [:])
+      -> Materialised {
+    guard rows else {
+      return Materialised(columns: relation.names, rows: [],
+                          types: relation.types)
+    }
+    return switch relation {
+    case .tables:
+      tables()
+    case .columns:
+      columns(routines)
+    }
+  }
+
+  /// `ctes` extended with every `definition_schema.` store relation `query`
+  /// names, each built over this catalog as a `Materialised` — the resolution
+  /// surface the engine consults for a reserved store relation.
+  ///
+  /// The store sits AFTER the common table expressions and BEFORE the base
+  /// catalog: a `definition_schema.` name is added only when `ctes` does not
+  /// already bind it (a user relation may shadow the store), and the extended
+  /// map is consulted first by every resolution phase (compile, optimise,
+  /// execute) — so it shadows a base table or view but yields to a CTE.
+  /// Building runs lazily per named relation: only the reserved relations the
+  /// query actually references are enumerated. A name in the reserved namespace
+  /// but not one the store serves is left unbound, so it faults later as an
+  /// ordinary unknown relation (`SQLError.relation`).
+  ///
+  /// `rows` selects the build: a run passes `true` for the enumerated rows; a
+  /// typing path passes `false` for the SCHEMA-ONLY sibling, so resolving a
+  /// view body's types never triggers the row build (a view over
+  /// `definition_schema.columns` types without the builder re-entering itself).
+  borrowing func augment(_ ctes: CTEs, for query: Query, rows: Bool,
+                         routines: Routines = [:]) -> CTEs {
+    var names = Set<String>()
+    query.collect(into: &names)
+    var augmented = ctes
+    for name in names where augmented[name.lowercased()] == nil {
+      if let relation = Definition(name) {
+        augmented[name.lowercased()] = store(relation, rows: rows, routines)
+      }
+    }
+    return augmented
+  }
+
+  /// The `definition_schema.` overlay a view's body resolves against — the
+  /// reserved store relations the view `name` names in its OWN query, each
+  /// built over this catalog — or empty when `name` is not a view (or names
+  /// none). It seeds the view sub-plan's execute so a view defined over a store
+  /// relation resolves; it never carries a caller's statement CTEs, so a view
+  /// means what it was registered to mean.
+  borrowing func overlay(_ name: String) -> CTEs {
+    guard let view = view(named: name) else { return [:] }
+    return augment([:], for: view.query, rows: true)
+  }
+
+  /// `definition_schema.tables` — one row per base relation and view, with the
+  /// standard `table_catalog`, `table_schema`, `table_name`, `table_type`
+  /// columns. `table_type` is `'BASE TABLE'` for a base relation, `'VIEW'` for
+  /// a view; `table_catalog`/`table_schema` are `NULL` (the store models a
+  /// single unnamed catalog and schema).
+  private borrowing func tables() -> Materialised {
+    var rows = Array<Array<Value>>()
+    // A view shadows a same-named base relation (a view resolves ahead of a
+    // base), so a shadowed base is unreachable and is not listed — the name
+    // appears once, as the VIEW a query actually resolves.
+    let shadowed = Set(views().map { $0.lowercased() })
+    for name in relations() {
+      // A reserved store name resolves to the store overlay, never a catalog
+      // relation of that name, so such a base is unreachable and is not listed;
+      // nor is a base a view shadows.
+      guard Definition(name) == nil,
+          !shadowed.contains(name.lowercased()) else { continue }
+      rows.append([.null, .null, .text(name), .text("BASE TABLE")])
+    }
+    for name in views() {
+      rows.append([.null, .null, .text(name), .text("VIEW")])
+    }
+    return Materialised(columns: Definition.tables.names, rows: rows,
+                        types: Definition.tables.types)
+  }
+
+  /// `definition_schema.columns` — one row per real column of every base
+  /// relation, with the standard `table_name`, `column_name`,
+  /// `ordinal_position` (1-based), `data_type`, `is_nullable` columns.
+  ///
+  /// Only a relation's REAL columns (`0 ..< width`) are reported — the virtual
+  /// `Id`, owner foreign keys, and coded-index join keys past `width` are not
+  /// ISO columns. `data_type` maps the engine's `ValueType` to its ISO domain;
+  /// `is_nullable` is a first cut of `'YES'` for every column (the engine does
+  /// not yet track per-column nullability). A view's columns are listed too,
+  /// their types resolved from the view's body — a scalar call in that body
+  /// types from `routines`, the run's registered routines, so a view's
+  /// `GUID(...)` column advertises `character varying`, not the integer
+  /// default.
+  private borrowing func columns(_ routines: Routines)
+      -> Materialised {
+    var rows = Array<Array<Value>>()
+    // A view shadows a same-named base relation, so a shadowed base's columns
+    // are unreachable and not listed — only the view's are (below).
+    let shadowed = Set(views().map { $0.lowercased() })
+    for name in relations() {
+      // A reserved store name resolves to the store overlay, not a catalog
+      // relation, so its columns are unreachable and not listed; nor is a base
+      // a view shadows.
+      guard Definition(name) == nil,
+          !shadowed.contains(name.lowercased()) else { continue }
+      guard let table = table(named: name) else { continue }
+      let names = table.names
+      let types = table.types
+      for ordinal in 0 ..< table.width {
+        rows.append([.text(name), .text(names[ordinal]),
+                     .integer(ordinal + 1), .text(types[ordinal].domain),
+                     .text("YES")])
+      }
+    }
+    for name in views() {
+      guard let view = view(named: name) else { continue }
+      // List a view's columns only if its WHOLE body validates — exactly the
+      // resolution a run performs, so a view a `SELECT *` could not run is not
+      // advertised as queryable metadata. Validate via the REAL `compile`
+      // rather than a resolve-only reimplementation of it: a hand-rolled
+      // validator drifts from compile (it missed a scalar call's arguments,
+      // advertising `SELECT BITAND(Missing, 1)` though the run faults on
+      // `Missing`), whereas `compile` resolves every arm's WHERE, joins, GROUP
+      // BY, HAVING, ORDER BY, projection — INCLUDING each scalar call's
+      // arguments — and a UNION's arity. The view body compiles over its OWN
+      // `definition_schema.` overlay, built SCHEMA-ONLY so a view over a store
+      // relation resolves without this row builder re-entering itself.
+      // The body must compile AND its width must equal the view's DECLARED
+      // column count: a view whose declared arity differs from its body's
+      // (`v(x) AS SELECT * FROM People`) cannot run and is not advertised here.
+      let overlay = augment([:], for: view.query, rows: false)
+      guard let plan = try? compile(view.query, overlay),
+          plan.width == view.columns.count else { continue }
+      // Type the columns from the body's first arm; type-check every arm's
+      // REACHABLE operands and calls too — an unknown call or a bad operand in
+      // a `WHERE`/`HAVING` or a later `UNION` arm faults a run, but the
+      // first-arm resolve would miss it (`compile` cannot check a routine
+      // exists), while an arm a short-circuit proves unreachable is skipped. A
+      // view a `SELECT *` could not evaluate is not advertised.
+      guard (try? typecheck(view.query, overlay, visited: [name.lowercased()],
+                            routines: routines)) != nil,
+          let resolved = try? columns(of: view.query.first, overlay,
+                                      visited: [name.lowercased()],
+                                      routines: routines),
+          resolved.count == view.columns.count else { continue }
+      for ordinal in view.columns.indices {
+        rows.append([.text(name), .text(view.columns[ordinal]),
+                     .integer(ordinal + 1),
+                     .text(resolved[ordinal].type.domain), .text("YES")])
+      }
+    }
+    return Materialised(columns: Definition.columns.names, rows: rows,
+                        types: Definition.columns.types)
+  }
+}
+
+extension Query {
+  /// Collects every relation name this query names in a `FROM`/`JOIN`, across
+  /// the `UNION` chain and each arm, into `names` — the reserved store names
+  /// among them are what `Catalog.augment` builds.
+  func collect(into names: inout Set<String>) {
+    switch self {
+    case let .select(select):
+      select.collect(into: &names)
+    case let .union(left, select, _):
+      left.collect(into: &names)
+      select.collect(into: &names)
+    }
+  }
+}
+
+extension Select {
+  /// Collects this select's `FROM` and `JOIN` relation names into `names`.
+  func collect(into names: inout Set<String>) {
+    if let from { names.insert(from.name) }
+    for join in joins { names.insert(join.relation.name) }
+  }
+}

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -103,6 +103,15 @@ extension Catalog where Self: ~Escapable {
   internal borrowing func run(_ query: Query, _ ctes: CTEs,
                               _ routines: Routines, _ bindings: Bindings)
       throws(SQLError) -> Array<Array<Value>> {
+    // Extend the relations with any `definition_schema.` store relation the
+    // query names, resolved lazily — the overlay after the
+    // CTEs, before the base catalog. Every phase reads the extended map, so a
+    // reserved store relation resolves, plans, and materialises exactly as a
+    // common table expression does; a portable `information_schema.` view over
+    // the store resolves through the ordinary view machinery. The routines ride
+    // in so a store `data_type` row types a view's scalar-call column
+    // (`GUID(...)`) by its declared return type.
+    let ctes = augment(ctes, for: query, rows: true, routines: routines)
     let logical = try compile(query, ctes).pushdown()
     let plan = try optimise(logical, ctes, bindings)
     return try execute(plan, self, ctes, routines, bindings).map(\.values)
@@ -192,7 +201,12 @@ extension Catalog where Self: ~Escapable {
       if cte.recursive && Engine.recursive(cte) {
         rows = try fixpoint(cte, relations, routines, bindings)
       } else {
-        let width = try compile(cte.query, relations).width
+        // The width check resolves the body's relations, so it reads the same
+        // `definition_schema.` overlay the body's own run does — a CTE body may
+        // select from a reserved store relation.
+        let scope = augment(relations, for: cte.query, rows: true,
+                            routines: routines)
+        let width = try compile(cte.query, scope).width
         guard width == cte.columns.count else {
           throw .columns(expected: cte.columns.count, got: width)
         }
@@ -238,6 +252,14 @@ extension Catalog where Self: ~Escapable {
   internal borrowing func fixpoint(_ cte: CTE, _ ctes: CTEs,
                                    _ routines: Routines, _ bindings: Bindings)
       throws(SQLError) -> Array<Array<Value>> {
+    // Extend the scope with any `definition_schema.` store relation the CTE's
+    // body names, so the fixpoint's width-check compiles resolve a reserved
+    // relation as the body's own run does. The routines ride in: this store
+    // entry is cached in `ctes` and reused by every anchor/recursive execution
+    // (a later `augment` will not replace a bound name), so a view column using
+    // even a standard routine (`BITAND(...)`) types the same inside the CTE as
+    // the identical SELECT does outside it.
+    let ctes = augment(ctes, for: cte.query, rows: true, routines: routines)
     guard case let .union(anchor, recursive, all) = cte.query else {
       // A non-`UNION` recursive query runs once, but still binds under
       // `cte.columns`, so validate its compiled width here too — the check the
@@ -453,7 +475,8 @@ extension Catalog where Self: ~Escapable {
   /// standard rule that every non-aggregated projection/`ORDER BY` column appear
   /// in the `GROUP BY`.
   internal borrowing func group(_ select: Select, _ relation: Relation,
-                                _ from: Engine.Resolved, _ ctes: CTEs)
+                                _ from: Engine.Resolved, _ ctes: CTEs,
+                                _ visited: Set<String>)
       throws(SQLError) -> Plan {
     // Resolve every joined relation and lay the FROM relation and each joined
     // one end to end in one combined ordinal space (as the non-aggregate join
@@ -461,7 +484,7 @@ extension Catalog where Self: ~Escapable {
     var joined = Array<Engine.Resolved>()
     joined.reserveCapacity(select.joins.count)
     for join in select.joins {
-      try joined.append(resolve(join.relation, ctes))
+      try joined.append(resolve(join.relation, ctes, visited))
     }
     var relations = [(relation, from.schema)]
     for index in select.joins.indices {
@@ -685,10 +708,11 @@ extension Catalog where Self: ~Escapable {
       // Optimise the view's sub-plan with the bindings so a bound predicate
       // inside the view seeks; the derived leaf itself carries no sort key, so
       // the outer query still scans its result as is. The sub-plan resolves
-      // OUTSIDE the statement's CTE scope (an empty CTE map, matching the empty
-      // scope it compiled under) — a view means what it was registered to mean,
-      // never seeing a caller's `WITH`.
-      try .derived(name: name, plan: optimise(plan, [:], bindings),
+      // OUTSIDE the statement's CTE scope — never a caller's `WITH` — so a view
+      // means what it was registered to mean; its scope is the
+      // `definition_schema.` overlay its OWN query names (the same one it
+      // compiled under), so a view body's store scan re-resolves.
+      try .derived(name: name, plan: optimise(plan, overlay(name), bindings),
                    ordinals: ordinals, seek: seek)
     case let .select(filter, .scan(name, ordinals, nil)):
       try seek(filter, name, ordinals, ctes, bindings)
@@ -1262,24 +1286,26 @@ extension Catalog where Self: ~Escapable {
   /// chain by the trailing arm's flag. The new arm must project the same column
   /// count as the chain's first `SELECT` — the result columns — else
   /// `SQLError.arity`.
-  internal borrowing func compile(_ query: Query, _ ctes: CTEs = [:])
+  internal borrowing func compile(_ query: Query, _ ctes: CTEs = [:],
+                                  _ visited: Set<String> = [])
       throws(SQLError) -> Plan {
     guard case let .union(left, select, all) = query else {
-      return try compile(query.first, ctes)
+      return try compile(query.first, ctes, visited)
     }
 
-    let width = try arity(query.first, ctes)
-    let count = try arity(select, ctes)
+    let width = try arity(query.first, ctes, visited)
+    let count = try arity(select, ctes, visited)
     guard count == width else { throw .arity(width, count) }
-    return try .union(compile(left, ctes),
-                      compile(.select(select), ctes), all: all)
+    return try .union(compile(left, ctes, visited),
+                      compile(.select(select), ctes, visited), all: all)
   }
 
   /// The number of result columns `select` projects — the extent of a `*` over
   /// its relations, else the count of its projected items — for the `UNION`
   /// arity check. The relations resolve through this catalog, the `ctes`
   /// consulted first.
-  private borrowing func arity(_ select: Select, _ ctes: CTEs)
+  private borrowing func arity(_ select: Select, _ ctes: CTEs,
+                               _ visited: Set<String>)
       throws(SQLError) -> Int {
     switch select.projection {
     case .all:
@@ -1287,9 +1313,9 @@ extension Catalog where Self: ~Escapable {
       guard let relation = select.from else {
         throw .named("SELECT * with no FROM")
       }
-      var width = try resolve(relation, ctes).schema.width
+      var width = try resolve(relation, ctes, visited).schema.width
       for join in select.joins {
-        try width += resolve(join.relation, ctes).schema.width
+        try width += resolve(join.relation, ctes, visited).schema.width
       }
       return width
     case let .columns(columns):
@@ -1324,7 +1350,17 @@ extension Catalog where Self: ~Escapable {
   /// The parser checks this whenever the projection's arity is statically known;
   /// this is the backstop for a `SELECT *` view, whose width is known only here,
   /// after the sub-plan compiles — a mismatch is `SQLError.columns`.
-  internal borrowing func resolve(_ relation: Relation, _ ctes: CTEs)
+  ///
+  /// `visited` names the views already being resolved down this chain. A view
+  /// whose body reaches back to itself — `A` over `B` over `A`, or a view over
+  /// itself — would recurse resolve→compile→resolve without end (a stack
+  /// overflow, not an `SQLError`); re-encountering a name is a cyclic
+  /// definition, reported as `.recursion` rather than hung. The
+  /// `definition_schema.` store's `columns` builder, which compiles every view
+  /// to advertise it, relies on this: a cyclic view's `try? compile` catches
+  /// the fault and skips it.
+  internal borrowing func resolve(_ relation: Relation, _ ctes: CTEs,
+                                  _ visited: Set<String> = [])
       throws(SQLError) -> Engine.Resolved {
     let name = relation.name
     if let cte = ctes[name.lowercased()] {
@@ -1335,7 +1371,30 @@ extension Catalog where Self: ~Escapable {
     }
 
     if let view = view(named: name) {
-      let plan = try compile(view.query, [:])
+      // A view whose body reaches back to itself — `A` over `B` over `A`, or a
+      // view over itself — would recurse resolve→compile→resolve without end (a
+      // stack overflow, not an `SQLError`). `visited` names the views already
+      // being resolved down this chain; re-encountering one is a cyclic
+      // definition, reported as `.recursion` rather than hung.
+      guard !visited.contains(name.lowercased()) else {
+        throw .recursion(name)
+      }
+      // The view body compiles OUTSIDE the caller's statement CTEs, but it may
+      // still name a reserved `definition_schema.` store relation, so seed its
+      // scope with the overlay built from the view's OWN query — never the
+      // caller's `ctes` — so a view defined over a store relation resolves.
+      //
+      // Compilation resolves only SCHEMAS (names → ordinals/types), never rows,
+      // so the overlay is built SCHEMA-ONLY: a reserved relation types from its
+      // header+types, and the row build is never triggered here. A view over
+      // `definition_schema.columns` would otherwise re-enter that row builder
+      // (which lists views, whose bodies name the relation again) — an
+      // unbounded recursion. The rows a view over a reserved relation actually
+      // returns are supplied at EXECUTE time, where `derive` rebuilds the
+      // overlay with rows and runs the sub-plan.
+      let overlay = augment([:], for: view.query, rows: false)
+      let plan =
+          try compile(view.query, overlay, visited.union([name.lowercased()]))
       let projected = plan.width
       guard view.columns.count == projected else {
         throw .columns(expected: projected, got: view.columns.count)
@@ -1378,7 +1437,8 @@ extension Catalog where Self: ~Escapable {
   /// cells concatenated in order). The tree is logical: every scan is a full
   /// `Scan(_, _, nil)`; the optimiser turns scans into seeks and each product
   /// into a join.
-  internal borrowing func compile(_ select: Select, _ ctes: CTEs = [:])
+  internal borrowing func compile(_ select: Select, _ ctes: CTEs = [:],
+                                  _ visited: Set<String> = [])
       throws(SQLError) -> Plan {
     guard let relation = select.from else {
       // A FROM-less select projects expressions over a single row; a `WHERE`,
@@ -1395,7 +1455,7 @@ extension Catalog where Self: ~Escapable {
       }
       return try Engine.scalar(select.projection)
     }
-    let from = try resolve(relation, ctes)
+    let from = try resolve(relation, ctes, visited)
 
     if let limit = select.limit {
       // The parser yields only non-negative counts (a `-` is its own token), but
@@ -1412,7 +1472,7 @@ extension Catalog where Self: ~Escapable {
     // `HAVING`, and `ORDER BY` against the grouped slot space. A non-aggregate
     // query compiles exactly as before.
     if Engine.aggregates(select) {
-      return try group(select, relation, from, ctes)
+      return try group(select, relation, from, ctes, visited)
     }
 
     guard !select.joins.isEmpty else {
@@ -1444,7 +1504,7 @@ extension Catalog where Self: ~Escapable {
     var joined = Array<Engine.Resolved>()
     joined.reserveCapacity(select.joins.count)
     for join in select.joins {
-      try joined.append(resolve(join.relation, ctes))
+      try joined.append(resolve(join.relation, ctes, visited))
     }
 
     var relations = [(relation, from.schema)]

--- a/Sources/SQL/Materialised.swift
+++ b/Sources/SQL/Materialised.swift
@@ -33,9 +33,20 @@ internal struct Materialised: Hashable, Sendable {
   /// The relation's rows, each a positional array of typed values.
   internal let rows: Array<Array<Value>>
 
-  internal init(columns: Array<String>, rows: Array<Array<Value>>) {
+  /// The value type of each real column, in ordinal order — the types a
+  /// materialised relation reports to the result-schema walk.
+  ///
+  /// A CTE's rows carry no static types, so a call site that has none passes
+  /// `nil` and every column types `.integer` (the historical default); a
+  /// DEFINITION_SCHEMA store relation, whose columns have known ISO domains,
+  /// passes them so `information_schema` columns report their real types.
+  internal let types: Array<ValueType>
+
+  internal init(columns: Array<String>, rows: Array<Array<Value>>,
+                types: Array<ValueType>? = nil) {
     self.columns = columns
     self.rows = rows
+    self.types = types ?? Array(repeating: .integer, count: columns.count)
   }
 
   /// The real column count — the extent of a `SELECT *`.
@@ -49,7 +60,7 @@ internal struct Materialised: Hashable, Sendable {
   /// virtual `Id` at `width`.
   internal func schema() -> Schema {
     Schema(width: width, extent: extent, names: columns,
-           types: Array(repeating: .integer, count: width), virtuals: ["Id"])
+           types: types, virtuals: ["Id"])
   }
 
   /// The record for the row at `index`, materialising the referenced `ordinals`

--- a/Sources/SQL/Operator.swift
+++ b/Sources/SQL/Operator.swift
@@ -282,8 +282,8 @@ internal func execute<C: Catalog & ~Escapable>(_ plan: Plan,
     [Record([])]
   case let .scan(name, ordinals, seek):
     try materialise(name, ordinals, seek, catalog, ctes)
-  case let .derived(_, source, ordinals, seek):
-    try derive(source, ordinals, seek, catalog, routines, bindings)
+  case let .derived(name, source, ordinals, seek):
+    try derive(name, source, ordinals, seek, catalog, routines, bindings)
   case let .select(filter, .product(outer, inner)):
     // Fuse a residual product with its filter: stream each pair through the
     // predicate rather than materialising the whole cross product first.
@@ -439,19 +439,27 @@ private func materialise<C: Catalog & ~Escapable>(_ name: String,
 /// `0 ..< columns.count`; this projects each to the `ordinals` the outer query
 /// reads, in the slot order the outer scan expects (slot `i` is `ordinals[i]`).
 ///
-/// The sub-plan runs OUTSIDE the statement's CTE scope — an empty CTE map, the
-/// same scope it compiled and optimised under — so a caller's `WITH` never
-/// reaches into a stored view's body: a view's own `FROM`/`JOIN` names resolve
-/// to base relations (and other views), never to a statement-local CTE that
-/// happens to share a name.
-private func derive<C: Catalog & ~Escapable>(_ plan: Plan,
+/// The sub-plan runs OUTSIDE the statement's CTE scope — never the caller's
+/// `WITH` — so a caller's `WITH` never reaches into a stored view's body: a
+/// view's own `FROM`/`JOIN` names resolve to base relations (and other views),
+/// never to a statement-local CTE that happens to share a name. Its scope is
+/// instead the `definition_schema.` overlay the view's OWN query names (empty
+/// when it names none), so a view defined over a store relation materialises
+/// exactly as the inline query does — the same overlay the body compiled and
+/// optimised under.
+private func derive<C: Catalog & ~Escapable>(_ name: String, _ plan: Plan,
                                              _ ordinals: Array<Int>,
                                              _ seek: Range<Int>?,
                                              _ catalog: borrowing C,
                                              _ routines: Routines,
                                              _ bindings: Bindings)
     throws(SQLError) -> Array<Record> {
-  let rows = try execute(plan, catalog, [:], routines, bindings)
+  let overlay = if let view = catalog.view(named: name) {
+    catalog.augment([:], for: view.query, rows: true, routines: routines)
+  } else {
+    CTEs()
+  }
+  let rows = try execute(plan, catalog, overlay, routines, bindings)
   let range = seek ?? 0 ..< rows.count
   return range.map { rows[$0].project(ordinals) }
 }

--- a/Sources/SQL/OutputColumn.swift
+++ b/Sources/SQL/OutputColumn.swift
@@ -68,10 +68,14 @@ extension Catalog where Self: ~Escapable {
   ///   for a `UNION` whose arms project differing column counts.
   public borrowing func columns(of query: Query, routines: Routines = [:])
       throws(SQLError) -> Array<OutputColumn> {
+    // Extend the scope with any `definition_schema.` store relation the query
+    // names, so its result schema resolves the reserved relation the same as a
+    // run would — SCHEMA-ONLY, so typing never triggers the row build.
+    let ctes = augment([:], for: query, rows: false)
     // Validate the whole query without executing — the same compile the run
     // path drives, resolving every arm and cross-checking a UNION's arity — so
     // a schema is returned only for a query that could actually run.
-    _ = try compile(query)
+    _ = try compile(query, ctes)
     // Type-check every REACHABLE operand and call across all arms — the
     // projection, `WHERE`, and `HAVING` of each. `compile` resolves a call's
     // arguments but cannot check the routine EXISTS or that it is called with
@@ -81,13 +85,13 @@ extension Catalog where Self: ~Escapable {
     // like the executor — skips an arm a `false AND`/`true OR` short-circuits,
     // so a query that runs is not rejected for an unreachable call.
     let routines = Routines.standard.merging(routines)
-    try typecheck(query, [:], routines: routines)
+    try typecheck(query, ctes, routines: routines)
     // The result columns are the first arm's projection (the ISO rule a UNION
     // follows), resolved against the validated scope; a scalar call types from
     // its routine's declared return type — the engine prelude merged under
     // `routines`, exactly as a run seeds them, so a standard call (`BITAND`)
     // types without the caller re-supplying it.
-    return try columns(of: query.first, [:], routines: routines)
+    return try columns(of: query.first, ctes, routines: routines)
   }
 
   /// The result columns of a single `select`, resolved against this catalog
@@ -247,7 +251,8 @@ extension Catalog where Self: ~Escapable {
   }
 
   /// The name-resolution schema of `relation`, resolved against this catalog
-  /// and the in-scope `ctes` — a CTE first, then a view, then a base table, the
+  /// and the in-scope `ctes` — a CTE first, then a reserved
+  /// `definition_schema.` store relation, then a view, then a base table, the
   /// same precedence `compile` resolves a relation by. It reads only schemas,
   /// never a cursor, so it never executes. `visited` names the views already
   /// being resolved down this chain, breaking a cyclic view (`A` over `B` over
@@ -262,11 +267,20 @@ extension Catalog where Self: ~Escapable {
     if let cte = ctes[name.lowercased()] {
       return cte.schema()
     }
+    // A reserved store relation types through its SCHEMA-ONLY build (header +
+    // types, no rows), so resolving a view over `definition_schema.tables`/
+    // `.columns` reads only the schema and never triggers the row builder.
+    if let relation = Definition(name) {
+      return store(relation, rows: false).schema()
+    }
     if let view = view(named: name) {
       // A view's declared schema types every column `.integer`, since a view
       // stores no types; resolve the view body's own types so a `SELECT *` over
-      // the view reports each column's true type. The names stay the view's
-      // DECLARED ones; only the types come from the resolved body.
+      // the view reports each column's true type. Resolving runs the
+      // RESOLVE-only worker over the view's OWN `definition_schema.` overlay,
+      // built SCHEMA-ONLY so a view over a reserved relation resolves its types
+      // without a row build. The names stay the view's DECLARED ones; only the
+      // types come from the resolved body.
       let base = view.schema()
       // A cyclic view cannot resolve its body's types: resolving it would
       // re-enter this view forever, so break the cycle and fall back to the
@@ -280,14 +294,15 @@ extension Catalog where Self: ~Escapable {
       // operand a `SELECT * FROM v` run would evaluate — a `WHERE`/`HAVING`, a
       // later `UNION` arm — while skipping an arm a short-circuit proves
       // unreachable.
+      let overlay = augment([:], for: view.query, rows: false)
       let inner = visited.union([name.lowercased()])
-      try typecheck(view.query, [:], visited: inner, routines: routines)
+      try typecheck(view.query, overlay, visited: inner, routines: routines)
       // Type off the body's first arm (the ISO rule for a UNION). Arity — the
       // body's width against the declared columns — is `compile`'s job (the
       // public entry runs it), so on a shortfall fall back to the declared
       // schema rather than re-checking it here.
       let resolved =
-          try columns(of: view.query.first, [:], visited: inner,
+          try columns(of: view.query.first, overlay, visited: inner,
                       routines: routines)
       guard resolved.count == base.width else { return base }
       return Schema(width: base.width, extent: base.extent, names: base.names,

--- a/Tests/SQLTests/DefinitionSchemaTests.swift
+++ b/Tests/SQLTests/DefinitionSchemaTests.swift
@@ -1,0 +1,179 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQL
+
+// MARK: - In-memory adapter
+
+/// A typed in-memory relation — a column name/kind list and rows — for the
+/// DEFINITION_SCHEMA store tests.
+private struct StoreRelation: Sendable {
+  let names: Array<String>
+  let types: Array<ValueType>
+  let records: Array<Array<Value>>
+
+  init(_ columns: Array<(String, ValueType)>,
+       _ records: Array<Array<Value>> = []) {
+    self.names = columns.map(\.0)
+    self.types = columns.map(\.1)
+    self.records = records
+  }
+}
+
+/// A `Catalog` over named typed relations plus registered views, the store
+/// enumerates through `relations()`/`views()`.
+private struct StoreCatalog: Catalog {
+  let catalog: Dictionary<String, StoreRelation>
+  let registered: Dictionary<String, View>
+
+  init(_ catalog: Dictionary<String, StoreRelation>,
+       views: Dictionary<String, View> = [:]) {
+    self.catalog = catalog
+    self.registered = views
+  }
+
+  func table(named name: String) -> StoreTable? {
+    guard let relation = catalog[name] else { return nil }
+    return StoreTable(relation)
+  }
+
+  func view(named name: String) -> View? {
+    registered[name]
+  }
+
+  func relations() -> Array<String> {
+    catalog.keys.sorted()
+  }
+
+  func views() -> Array<String> {
+    registered.keys.sorted()
+  }
+}
+
+/// A `Table` over one typed relation.
+private struct StoreTable: Table {
+  let relation: StoreRelation
+
+  init(_ relation: StoreRelation) {
+    self.relation = relation
+  }
+
+  var width: Int { relation.names.count }
+  var names: Array<String> { relation.names }
+  var types: Array<ValueType> { relation.types }
+
+  func ordinal(of name: String) -> Int? {
+    relation.names.firstIndex(of: name)
+  }
+
+  func bound(_ column: Int, _ value: Int, strict: Bool) -> Int? { nil }
+
+  func cursor() -> StoreCursor {
+    StoreCursor(relation)
+  }
+}
+
+private struct StoreCursor: Cursor {
+  let relation: StoreRelation
+
+  init(_ relation: StoreRelation) {
+    self.relation = relation
+  }
+
+  var count: Int { relation.records.count }
+
+  func row(_ index: Int) -> StoreRow? {
+    guard index < relation.records.count else { return nil }
+    return StoreRow(relation, index)
+  }
+}
+
+private struct StoreRow: Row {
+  let relation: StoreRelation
+  let index: Int
+
+  init(_ relation: StoreRelation, _ index: Int) {
+    self.relation = relation
+    self.index = index
+  }
+
+  subscript(_ column: Int) -> Value {
+    borrowing get { relation.records[index][column] }
+  }
+}
+
+// MARK: - Helpers
+
+/// Parses `text` to a query, failing on any other statement.
+private func parse(_ text: String) throws -> Query {
+  guard case let .select(query) = try Statement(parsing: text) else {
+    Issue.record("expected a SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return query
+}
+
+// MARK: - Tests
+
+@Suite struct DefinitionSchemaTests {
+  @Test("definition_schema.columns lists a base relation's columns")
+  func columns() throws {
+    let cat = StoreCatalog([
+      "People": StoreRelation([("Name", .text), ("Age", .integer)]),
+    ])
+    let rows = try cat.run(parse("""
+        SELECT column_name FROM definition_schema.columns
+         WHERE table_name = 'People'
+        """))
+    #expect(rows == [[.text("Name")], [.text("Age")]])
+  }
+
+  @Test("definition_schema.columns skips a cyclic view and stays usable")
+  func cyclicViewColumns() throws {
+    // `A` reads `B` and `B` reads `A` — a cycle. The store's `columns` builder
+    // compiles each view to advertise it, which for a cyclic view would recurse
+    // resolve→compile→resolve until the stack overflows (SIGBUS, not an
+    // `SQLError`). The cycle guard threaded through `compile`/`resolve` faults
+    // `.recursion` instead, which the builder's `try? compile` catches so it
+    // skips the cyclic view. The store must not hang or crash, and an unrelated
+    // base relation still reports.
+    let a = try parse("SELECT * FROM B")
+    let b = try parse("SELECT * FROM A")
+    let cat = StoreCatalog(
+        ["People": StoreRelation([("Name", .text)])],
+        views: ["A": View(query: a, columns: ["x"]),
+                "B": View(query: b, columns: ["y"])])
+    let people = try cat.run(parse("""
+        SELECT column_name FROM definition_schema.columns
+         WHERE table_name = 'People'
+        """))
+    #expect(people == [[.text("Name")]])
+    let cyclic = try cat.run(parse("""
+        SELECT column_name FROM definition_schema.columns
+         WHERE table_name = 'A' OR table_name = 'B'
+        """))
+    #expect(cyclic == [])
+  }
+
+  @Test("definition_schema.tables lists a cyclic view without crashing")
+  func cyclicViewTables() throws {
+    // `definition_schema.tables` enumerates relations and views by NAME without
+    // compiling their bodies, so it lists the cyclic view too — the point is it
+    // does not hang or crash reaching it. Assert the catalog's own names all
+    // appear (a superset check, so a later slice adding engine-provided rows
+    // does not break this).
+    let a = try parse("SELECT * FROM B")
+    let b = try parse("SELECT * FROM A")
+    let cat = StoreCatalog(
+        ["People": StoreRelation([("Name", .text)])],
+        views: ["A": View(query: a, columns: ["x"]),
+                "B": View(query: b, columns: ["y"])])
+    let names = try cat.run(parse("""
+        SELECT table_name FROM definition_schema.tables
+        """))
+    #expect(names.contains([.text("People")]))
+    #expect(names.contains([.text("A")]))
+    #expect(names.contains([.text("B")]))
+  }
+}


### PR DESCRIPTION
This pull request introduces significant enhancements and refactoring to the SQL engine's handling of metadata and query parsing, with a particular focus on supporting ISO-compliant metadata introspection via a reserved `definition_schema` namespace. The changes enable the engine to dynamically overlay and serve metadata tables (`definition_schema.tables` and `definition_schema.columns`) for any catalog, ensure correct parsing of qualified column names, and improve projection name inference. Additionally, some internal call-collection utilities have been removed for simplification.

**Major additions and improvements:**

**1. Metadata Introspection and Reserved Namespace Overlay**
- Introduces a new `Definition` enum and related logic to support ISO 9075-11 `DEFINITION_SCHEMA` relations, allowing the engine to serve `definition_schema.tables` and `definition_schema.columns` dynamically for any catalog. This includes schema-only and row-building modes, and ensures that metadata overlays are resolved lazily and correctly shadowed by user relations or CTEs. (`Sources/SQL/Definition.swift` [[1]](diffhunk://#diff-448b796119dacbb50d996ad49c4ea5701f824a8c827cc8304d16e115e79dcc89R1-R247) `Sources/SQL/Engine.swift` [[2]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060R106-R112) [[3]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L195-R206) [[4]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060R252-R259)

**2. Qualified Column Name Parsing**
- Changes the parsing of `Column` string literals to split on the last dot instead of the first, allowing for proper handling of multi-part relation names (e.g., `definition_schema.tables.table_name` → qualifier `definition_schema.tables`, name `table_name`). (`Sources/SQL/AST.swift` [[1]](diffhunk://#diff-44ae278469f8cb8537a5e8997ce917320e10f66a7fb199bcf35bc353ab154f08L210-R210) [[2]](diffhunk://#diff-44ae278469f8cb8537a5e8997ce917320e10f66a7fb199bcf35bc353ab154f08L225-R238)

**3. Projection and Alias Handling**
- Adds a new method to `Projection` for inferring output column names, following ISO rules for view creation and select projections. Also introduces a `name` property to `Projected` for consistent alias and name resolution. (`Sources/SQL/AST.swift` [[1]](diffhunk://#diff-44ae278469f8cb8537a5e8997ce917320e10f66a7fb199bcf35bc353ab154f08R264-R290) [[2]](diffhunk://#diff-44ae278469f8cb8537a5e8997ce917320e10f66a7fb199bcf35bc353ab154f08R310-R321)

**4. ValueType Enhancements**
- Adds computed properties to `ValueType` for determining if a type is numeric and for retrieving the ISO domain name for each type, supporting accurate metadata reporting. (`Sources/SQL/Adapter.swift` [Sources/SQL/Adapter.swiftR39-R66](diffhunk://#diff-5e2790ab4729e595cad0e69349d0ab7aaef73c324a6a97c21588aab1ab1f017cR39-R66))

**5. Internal Simplification**
- Removes internal extensions and methods for collecting scalar function call names from queries and expressions, as this logic is now handled differently or is no longer needed. (`Sources/SQL/AST.swift` [Sources/SQL/AST.swiftL462-L539](diffhunk://#diff-44ae278469f8cb8537a5e8997ce917320e10f66a7fb199bcf35bc353ab154f08L462-L539))