### PR TITLE
SQL: evaluate HAVING before the limit in the empty-group type-check

### DIFF
--- a/Sources/SQL/OutputColumn.swift
+++ b/Sources/SQL/OutputColumn.swift
@@ -194,19 +194,21 @@ extension Catalog where Self: ~Escapable {
       // projection run over the group's results, so EVALUATE them (`empty`) — a
       // divide, overflow, or bad routine call faults as the run would.
       if scope.constant(predicate) == false {
-        // The lone empty group is itself unreachable when a limit drops the one
-        // row it would emit — a zero `FETCH` or any positive `OFFSET` — so the
-        // projection never evaluates over it.
-        if Engine.aggregates(select), select.grouping.isEmpty,
-            !dropsSingleRow(select.limit, singleRow: true) {
+        if Engine.aggregates(select), select.grouping.isEmpty {
           if let having = select.having {
-            // Evaluate HAVING over the empty group: it validates its operands
-            // (a divide, overflow, or bad routine call faults) AND yields the
-            // group's fate — a group passes only when HAVING is TRUE, so FALSE
-            // or UNKNOWN drops it and the projection is unreachable.
+            // HAVING filters the group BEFORE any OFFSET/FETCH limit, so
+            // evaluate it UNCONDITIONALLY — a zero `FETCH` or positive `OFFSET`
+            // spares only the projection, never HAVING. It validates its
+            // operands (a divide, overflow, or bad routine call faults) AND
+            // yields the group's fate — a group passes only when HAVING is TRUE,
+            // so FALSE or UNKNOWN drops it and the projection is unreachable.
             if try scope.empty(having, routines) != true { return }
           }
-          if case let .expressions(items) = select.projection {
+          // The lone empty group is itself unreachable when a limit drops the
+          // one row it would emit — a zero `FETCH` or any positive `OFFSET` — so
+          // the projection never evaluates over it.
+          if !drops(select.limit, single: true),
+              case let .expressions(items) = select.projection {
             for item in items { _ = try scope.empty(item.expression, routines) }
           }
         }
@@ -229,21 +231,21 @@ extension Catalog where Self: ~Escapable {
     // would yield leaves only its aggregate folds (validated above) reachable.
     // A whole-result aggregate emits exactly ONE row, so a positive OFFSET
     // drops it too — not just a zero FETCH.
-    let singleRow = Engine.aggregates(select) && select.grouping.isEmpty
-    if !dropsSingleRow(select.limit, singleRow: singleRow),
+    let sole = Engine.aggregates(select) && select.grouping.isEmpty
+    if !drops(select.limit, single: sole),
         case let .expressions(items) = select.projection {
       for item in items { _ = try scope.type(of: item.expression, routines) }
     }
   }
 
-  /// Whether `limit` drops the one row a `singleRow` result would yield, making
-  /// a projection over that row unreachable. A zero `FETCH` (`count == 0`)
-  /// drops every row; a positive `OFFSET` skips the sole row of a single-row
-  /// result (a whole-result aggregate). A `nil` `count` caps nothing, and an
-  /// `offset` of `0` skips nothing.
-  private func dropsSingleRow(_ limit: Limit?, singleRow: Bool) -> Bool {
+  /// Whether `limit` drops the one row a `single`-row result would yield,
+  /// making a projection over that row unreachable. A zero `FETCH`
+  /// (`count == 0`) drops every row; a positive `OFFSET` skips the sole row of
+  /// a single-row result (a whole-result aggregate). A `nil` `count` caps
+  /// nothing, and an `offset` of `0` skips nothing.
+  private func drops(_ limit: Limit?, single: Bool) -> Bool {
     guard let limit else { return false }
-    return limit.count == 0 || (singleRow && limit.offset >= 1)
+    return limit.count == 0 || (single && limit.offset >= 1)
   }
 
   /// The name-resolution schema of `relation`, resolved against this catalog

--- a/Tests/SQLTests/OutputSchemaTests.swift
+++ b/Tests/SQLTests/OutputSchemaTests.swift
@@ -350,4 +350,20 @@ struct OutputSchemaTests {
         "SELECT 1 / 0, COUNT(*) FROM People WHERE 1 = 0 OFFSET 1 ROWS")
     #expect(empty.count == 2)
   }
+
+  @Test("HAVING is evaluated before a zero-FETCH limit, so its faults surface")
+  func havingFaultsUnderZeroLimit() throws {
+    // The compiled plan applies HAVING BEFORE the OFFSET/FETCH limit, so a zero
+    // FETCH spares only the PROJECTION — HAVING still evaluates over the empty
+    // group. A faulting HAVING must therefore surface even under a zero FETCH.
+    #expect(throws: SQLError.self) {
+      try schema("SELECT COUNT(*) FROM People WHERE 1 = 0 "
+          + "HAVING 1 / 0 = 0 FETCH FIRST 0 ROWS ONLY")
+    }
+    // A non-faulting FALSE HAVING drops the empty group cleanly (the limit would
+    // drop it anyway), so the schema resolves.
+    let columns = try schema("SELECT COUNT(*) FROM People WHERE 1 = 0 "
+        + "HAVING COUNT(*) = 1 FETCH FIRST 0 ROWS ONLY")
+    #expect(columns.count == 1)
+  }
 }


### PR DESCRIPTION
The compiled aggregate plan applies HAVING before the OFFSET/FETCH limit, so a zero FETCH or positive OFFSET makes only the projection unreachable — HAVING is still evaluated over the whole-result aggregate's lone empty group. The constant-false-WHERE branch of `typecheck(_ select:)` guarded BOTH the HAVING evaluation and the projection with the limit, so it skipped HAVING entirely when the limit dropped the row. A faulting HAVING under a zero FETCH — `SELECT COUNT(*) FROM People WHERE 1 = 0 HAVING 1 / 0 = 0 FETCH FIRST 0 ROWS ONLY` — was therefore wrongly accepted by `columns(of:)`, though a run throws `SQLError.divide` evaluating HAVING.

Evaluate `scope.empty(having, routines)` unconditionally in the empty- group branch, dropping the group when it is not TRUE, and gate only the projection loop with `dropsSingleRow`. HAVING first (always), then the limit-gated projection — matching the executor's clause order.

Add `havingFaultsUnderZeroLimit`: a faulting HAVING surfaces under a zero FETCH, and a FALSE HAVING drops the group cleanly.