### PR TITLE
SQL: simplify walking

### DIFF
--- a/Sources/SQL/Filter.swift
+++ b/Sources/SQL/Filter.swift
@@ -423,6 +423,22 @@ internal func matches(_ lhs: Value, _ op: Comparison, _ rhs: Value) -> Bool? {
   }
 }
 
+/// Kleene `AND` over two three-valued operands: `false` dominates (a `false`
+/// side makes the whole `false` even against UNKNOWN), both `true` is `true`,
+/// and any other pair is UNKNOWN (`nil`).
+internal func and(_ lhs: Bool?, _ rhs: Bool?) -> Bool? {
+  if lhs == false || rhs == false { return false }
+  return lhs == true && rhs == true ? true : nil
+}
+
+/// Kleene `OR` over two three-valued operands: `true` dominates (a `true` side
+/// makes the whole `true` even against UNKNOWN), both `false` is `false`, and
+/// any other pair is UNKNOWN (`nil`).
+internal func or(_ lhs: Bool?, _ rhs: Bool?) -> Bool? {
+  if lhs == true || rhs == true { return true }
+  return lhs == false && rhs == false ? false : nil
+}
+
 /// Evaluates `filter` against `row` under three-valued logic, resolving scalar
 /// calls through `routines` and any bound parameter from `bindings`.
 ///

--- a/Sources/SQL/Resolve.swift
+++ b/Sources/SQL/Resolve.swift
@@ -18,6 +18,33 @@
 /// resolves is `SQLError.column`; an unqualified name both relations of a join
 /// resolve is `SQLError.ambiguous`.
 
+/// Lowers the name-addressed AST `predicate` to the engine's `Filter`, lowering
+/// each leaf's operand expressions through `term` and passing a `bound`
+/// comparison's `:parameter` through unchanged.
+///
+/// Every predicate lowering — a single relation, a join scope, a grouped scope —
+/// shares this shape, differing only in how a leaf term resolves its columns
+/// (against one schema, a combined join space, or a grouped slot space); each
+/// caller supplies that resolution as `term`.
+private func lower(_ predicate: Predicate,
+                   term: (Expression) throws(SQLError) -> Term)
+    throws(SQLError) -> Filter {
+  switch predicate {
+  case let .comparison(left, op, right):
+    try .compare(term(left), op, term(right))
+  case let .bound(left, op, parameter):
+    try .bound(term(left), op, parameter)
+  case let .null(expression, negated):
+    try .null(term(expression), negated: negated)
+  case let .and(lhs, rhs):
+    try .and(lower(lhs, term: term), lower(rhs, term: term))
+  case let .or(lhs, rhs):
+    try .or(lower(lhs, term: term), lower(rhs, term: term))
+  case let .not(operand):
+    try .not(lower(operand, term: term))
+  }
+}
+
 extension Schema {
   /// The ordinal of the column `column` names, validating its qualifier against
   /// `relation`.
@@ -104,19 +131,8 @@ extension Schema {
 
   internal func lower(_ predicate: Predicate, in relation: Relation)
       throws(SQLError) -> Filter {
-    switch predicate {
-    case let .comparison(left, op, right):
-      try .compare(term(left, in: relation), op, term(right, in: relation))
-    case let .bound(left, op, parameter):
-      try .bound(term(left, in: relation), op, parameter)
-    case let .null(expression, negated):
-      try .null(term(expression, in: relation), negated: negated)
-    case let .and(lhs, rhs):
-      try .and(lower(lhs, in: relation), lower(rhs, in: relation))
-    case let .or(lhs, rhs):
-      try .or(lower(lhs, in: relation), lower(rhs, in: relation))
-    case let .not(operand):
-      try .not(lower(operand, in: relation))
+    try SQL.lower(predicate) { expression throws(SQLError) in
+      try term(expression, in: relation)
     }
   }
 }
@@ -648,19 +664,8 @@ internal struct Scope {
   /// Lowers the name-addressed AST `predicate` to the engine's `Filter`, each
   /// column reference resolved to a combined ordinal across the chain.
   internal func lower(_ predicate: Predicate) throws(SQLError) -> Filter {
-    switch predicate {
-    case let .comparison(left, op, right):
-      try .compare(term(left), op, term(right))
-    case let .bound(left, op, parameter):
-      try .bound(term(left), op, parameter)
-    case let .null(expression, negated):
-      try .null(term(expression), negated: negated)
-    case let .and(lhs, rhs):
-      try .and(lower(lhs), lower(rhs))
-    case let .or(lhs, rhs):
-      try .or(lower(lhs), lower(rhs))
-    case let .not(operand):
-      try .not(lower(operand))
+    try SQL.lower(predicate) { expression throws(SQLError) in
+      try term(expression)
     }
   }
 }
@@ -809,19 +814,8 @@ internal struct Grouping {
 
   /// Lowers a `HAVING`/predicate to a grouped-space `Filter`.
   internal func lower(_ predicate: Predicate) throws(SQLError) -> Filter {
-    switch predicate {
-    case let .comparison(left, op, right):
-      try .compare(term(left), op, term(right))
-    case let .bound(left, op, parameter):
-      try .bound(term(left), op, parameter)
-    case let .null(expression, negated):
-      try .null(term(expression), negated: negated)
-    case let .and(lhs, rhs):
-      try .and(lower(lhs), lower(rhs))
-    case let .or(lhs, rhs):
-      try .or(lower(lhs), lower(rhs))
-    case let .not(operand):
-      try .not(lower(operand))
+    try SQL.lower(predicate) { expression throws(SQLError) in
+      try term(expression)
     }
   }
 

--- a/Sources/SQL/Resolve.swift
+++ b/Sources/SQL/Resolve.swift
@@ -432,11 +432,10 @@ internal struct Scope {
       }
       return matches(lhs, op, rhs)
     case let .and(lhs, rhs):
-      if constant(lhs) == false || constant(rhs) == false { return false }
-      return constant(lhs) == true && constant(rhs) == true ? true : nil
+      // `constant` is a pure fold with no side effect, so both arms evaluate.
+      return and(constant(lhs), constant(rhs))
     case let .or(lhs, rhs):
-      if constant(lhs) == true || constant(rhs) == true { return true }
-      return constant(lhs) == false && constant(rhs) == false ? false : nil
+      return or(constant(lhs), constant(rhs))
     case let .not(operand):
       guard let value = constant(operand) else { return nil }
       return !value
@@ -556,17 +555,16 @@ internal struct Scope {
       let null = if case .null = value { true } else { false }
       return negated ? !null : null
     case let .and(lhs, rhs):
+      // A `false` left proves the `AND` false without folding the right arm,
+      // which a run's short-circuit never evaluates and so must not fault.
       let left = try empty(lhs, routines)
       if left == false { return false }
-      let right = try empty(rhs, routines)
-      if right == false { return false }
-      return left == true && right == true ? true : nil
+      return and(left, try empty(rhs, routines))
     case let .or(lhs, rhs):
+      // A `true` left proves the `OR` true without folding the right arm.
       let left = try empty(lhs, routines)
       if left == true { return true }
-      let right = try empty(rhs, routines)
-      if right == true { return true }
-      return left == false && right == false ? false : nil
+      return or(left, try empty(rhs, routines))
     case let .not(operand):
       return try empty(operand, routines).map { !$0 }
     }

--- a/Sources/SQL/Resolve.swift
+++ b/Sources/SQL/Resolve.swift
@@ -45,6 +45,25 @@ private func lower(_ predicate: Predicate,
   }
 }
 
+/// The resolved sort keys `order` lowers to, in major-to-minor order — each
+/// key's column resolved to an ordinal through `ordinal` and its direction
+/// preserved.
+///
+/// A single relation and a join scope share this shape, differing only in how a
+/// key's column resolves to an ordinal (against one schema, or a combined join
+/// space); each caller supplies that resolution as `ordinal`. A grouped scope
+/// orders on projection aliases and grouped slots, so it does not share it.
+private func order(_ order: Order,
+                   ordinal: (Column) throws(SQLError) -> Int)
+    throws(SQLError) -> Array<(column: Int, ascending: Bool)> {
+  var keys = Array<(column: Int, ascending: Bool)>()
+  keys.reserveCapacity(order.keys.count)
+  for key in order.keys {
+    try keys.append((column: ordinal(key.column), ascending: key.ascending))
+  }
+  return keys
+}
+
 extension Schema {
   /// The ordinal of the column `column` names, validating its qualifier against
   /// `relation`.
@@ -120,13 +139,9 @@ extension Schema {
   /// each key's column an ordinal in this relation, its direction preserved.
   internal func order(_ order: Order, in relation: Relation)
       throws(SQLError) -> Array<(column: Int, ascending: Bool)> {
-    var keys = Array<(column: Int, ascending: Bool)>()
-    keys.reserveCapacity(order.keys.count)
-    for key in order.keys {
-      try keys.append((column: ordinal(of: key.column, in: relation),
-                       ascending: key.ascending))
+    try SQL.order(order) { column throws(SQLError) in
+      try ordinal(of: column, in: relation)
     }
-    return keys
   }
 
   internal func lower(_ predicate: Predicate, in relation: Relation)
@@ -645,13 +660,9 @@ internal struct Scope {
   /// preserved.
   internal func order(_ order: Order) throws(SQLError)
       -> Array<(column: Int, ascending: Bool)> {
-    var keys = Array<(column: Int, ascending: Bool)>()
-    keys.reserveCapacity(order.keys.count)
-    for key in order.keys {
-      try keys.append((column: ordinal(of: key.column),
-                       ascending: key.ascending))
+    try SQL.order(order) { column throws(SQLError) in
+      try ordinal(of: column)
     }
-    return keys
   }
 
   /// Lowers a join's `ON left = right` to a `match` conjunct, each side


### PR DESCRIPTION
This pull request refactors parts of the SQL query resolution and evaluation logic to improve code reuse, maintainability, and correctness in handling three-valued logic (true/false/unknown). The main changes include extracting common logic for lowering predicates and orderings, and centralizing the implementation of three-valued `AND`/`OR` logic.

**Core logic refactoring and code deduplication:**

- Extracted the logic for lowering predicates (`Predicate` to `Filter`) and orderings (`Order`) into shared private functions (`lower` and `order`) in `Sources/SQL/Resolve.swift`, allowing all relevant consumers (such as `Schema`, `Scope`, and `Grouping`) to use a single implementation. This removes duplicated code and ensures consistent behavior. [[1]](diffhunk://#diff-06b3d42404e969aa3130f5ee2ea5119b8d2d9c7fdb970a2b4abb78148636e451R21-R66) [[2]](diffhunk://#diff-06b3d42404e969aa3130f5ee2ea5119b8d2d9c7fdb970a2b4abb78148636e451L96-R150) [[3]](diffhunk://#diff-06b3d42404e969aa3130f5ee2ea5119b8d2d9c7fdb970a2b4abb78148636e451L632-L638) [[4]](diffhunk://#diff-06b3d42404e969aa3130f5ee2ea5119b8d2d9c7fdb970a2b4abb78148636e451L651-R677) [[5]](diffhunk://#diff-06b3d42404e969aa3130f5ee2ea5119b8d2d9c7fdb970a2b4abb78148636e451L812-R827)

**Three-valued logic improvements:**

- Introduced dedicated `and` and `or` functions in `Sources/SQL/Filter.swift` to correctly implement SQL's three-valued logic (Kleene logic) for `AND` and `OR` operations, ensuring that `false` and `true` dominate as appropriate and that unknown (`nil`) is handled correctly.
- Updated constant folding and runtime evaluation of `AND`/`OR` in `Scope` to use the new `and` and `or` helpers, ensuring correctness and short-circuiting behavior. [[1]](diffhunk://#diff-06b3d42404e969aa3130f5ee2ea5119b8d2d9c7fdb970a2b4abb78148636e451L404-R438) [[2]](diffhunk://#diff-06b3d42404e969aa3130f5ee2ea5119b8d2d9c7fdb970a2b4abb78148636e451R558-R567)

These changes make the codebase more robust, easier to maintain, and less error-prone, especially in handling SQL's nuanced logical semantics.