### PR TITLE
WinMD: reorganise methods

### DIFF
--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -430,39 +430,43 @@ extension Engine {
     return .project(projection, plan.capped(limit: limit))
   }
 
-  // MARK: - Aggregation
+}
 
-  /// Whether `select` aggregates — it has a `GROUP BY`, a `HAVING`, or an
+// MARK: - Aggregation
+
+extension Select {
+  /// Whether the select aggregates — it has a `GROUP BY`, a `HAVING`, or an
   /// aggregate function anywhere in its projection.
   ///
   /// A query with any of these compiles through the grouped path; one with none
   /// keeps the ordinary `Project(Limit(Sort(Select(_))))` shape unchanged. A
   /// `HAVING` alone (no `GROUP BY`, no aggregate) still aggregates — it filters
   /// the single whole-result group.
-  internal static func aggregates(_ select: Select) -> Bool {
-    if !select.grouping.isEmpty || select.having != nil { return true }
-    switch select.projection {
+  internal var aggregates: Bool {
+    if !grouping.isEmpty || having != nil { return true }
+    switch projection {
     case .all, .columns:
       return false
     case let .expressions(items):
-      return items.contains { aggregated($0.expression) }
+      return items.contains { $0.expression.aggregated }
     }
   }
+}
 
-  /// Whether `expression` contains an aggregate call anywhere within it.
-  private static func aggregated(_ expression: Expression) -> Bool {
-    switch expression {
+extension Expression {
+  /// Whether the expression contains an aggregate call anywhere within it.
+  internal var aggregated: Bool {
+    switch self {
     case .column, .literal:
       false
     case .aggregate:
       true
     case let .call(_, arguments):
-      arguments.contains { aggregated($0) }
+      arguments.contains { $0.aggregated }
     case let .binary(_, lhs, rhs):
-      aggregated(lhs) || aggregated(rhs)
+      lhs.aggregated || rhs.aggregated
     }
   }
-
 }
 
 // MARK: - Aggregation
@@ -1482,7 +1486,7 @@ extension Catalog where Self: ~Escapable {
     // `aggregate` node above the WHERE/join chain and lowers the projection,
     // `HAVING`, and `ORDER BY` against the grouped slot space. A non-aggregate
     // query compiles exactly as before.
-    if Engine.aggregates(select) {
+    if select.aggregates {
       return try group(select, relation, from, ctes, visited)
     }
 

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -407,21 +407,23 @@ extension Engine {
     }
     return slot
   }
+}
 
-  /// Wraps `source` in the `Project(Limit(Sort(Select(_))))` operators, omitting
-  /// each layer when its clause is absent. The `projection`, `filter`, and
-  /// `order` keys are in slot space; an empty `order` omits the sort.
+extension Plan {
+  /// This source plan wrapped in the `Project(Limit(Sort(Select(_))))`
+  /// operators, omitting each layer when its clause is absent. The
+  /// `projection`, `filter`, and `order` keys are in slot space; an empty
+  /// `order` omits the sort.
   ///
   /// The row `limit` sits BELOW the projection — after `WHERE` and `ORDER BY`,
   /// but before the select list is evaluated. A row outside the requested page
   /// is dropped by the limit before its projection runs, so a projection that
   /// could throw (`SELECT 1 / 0 … FETCH FIRST 0 ROWS ONLY`) never evaluates for
   /// a discarded row and the query returns the documented empty page.
-  internal static func shape(
-      _ source: Plan, _ projection: Array<Term>, _ filter: Filter?,
-      _ order: Array<(slot: Int, ascending: Bool)>,
-      _ limit: Limit?) -> Plan {
-    var plan = source
+  internal func shaped(projection: Array<Term>, filter: Filter?,
+                       order: Array<(slot: Int, ascending: Bool)>,
+                       limit: Limit?) -> Plan {
+    var plan = self
     if let filter {
       plan = .select(filter, plan)
     }
@@ -430,7 +432,6 @@ extension Engine {
     }
     return .project(projection, plan.capped(limit: limit))
   }
-
 }
 
 // MARK: - Aggregation
@@ -1506,11 +1507,11 @@ extension Catalog where Self: ~Escapable {
       let ordinals = Engine.referenced(projection, filter, order)
       let slot = Engine.invert(ordinals)
       let scan = from.leaf(ordinals)
-      return Engine.shape(scan,
-                          projection.map { $0.remapped(through: slot) },
-                          filter.map { $0.remapped(through: slot) },
-                          order.map { (slot[$0.column]!, $0.ascending) },
-                          select.limit)
+      return scan.shaped(
+          projection: projection.map { $0.remapped(through: slot) },
+          filter: filter.map { $0.remapped(through: slot) },
+          order: order.map { (slot[$0.column]!, $0.ascending) },
+          limit: select.limit)
     }
 
     // Resolve every joined relation and lay all relations — the FROM relation
@@ -1590,10 +1591,10 @@ extension Catalog where Self: ~Escapable {
               .product(chain, joined[index].leaf(locals[index + 1])))
     }
 
-    return Engine.shape(chain,
-                        projection.map { $0.remapped(through: slot) },
-                        predicate.map { $0.remapped(through: slot) },
-                        order.map { (slot[$0.column]!, $0.ascending) },
-                        select.limit)
+    return chain.shaped(
+        projection: projection.map { $0.remapped(through: slot) },
+        filter: predicate.map { $0.remapped(through: slot) },
+        order: order.map { (slot[$0.column]!, $0.ascending) },
+        limit: select.limit)
   }
 }

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -524,15 +524,15 @@ extension Catalog where Self: ~Escapable {
       try .slot(scope.ordinal(of: column))
     }
     var expressions = Array<Expression>()
-    for expression in Engine.projected(select.projection) {
-      Engine.collect(expression, into: &expressions)
+    for expression in select.projection.projected {
+      expression.collect(into: &expressions)
     }
     if let having = select.having {
-      Engine.collect(having, into: &expressions)
+      having.collect(into: &expressions)
     }
     var aggregations = Array<Aggregation>()
     for expression in expressions {
-      try aggregations.append(Engine.lower(expression, scope))
+      try aggregations.append(expression.aggregation(scope))
     }
 
     // The source materialises exactly the ordinals the WHERE, the keys, and the
@@ -603,69 +603,49 @@ extension Catalog where Self: ~Escapable {
   }
 }
 
-extension Engine {
-  /// The projected expressions of `projection` — an `expressions` list yields
-  /// each item's expression; a `*` or bare-column list yields none (no aggregate
-  /// can hide in them). An aggregate query's projection is always the
-  /// `expressions` case (an aggregate call makes it one).
-  internal static func projected(_ projection: Projection)
-      -> Array<Expression> {
-    switch projection {
+extension Projection {
+  /// The projected expressions — an `expressions` list yields each item's
+  /// expression; a `*` or bare-column list yields none (no aggregate can hide
+  /// in them). An aggregate query's projection is always the `expressions` case
+  /// (an aggregate call makes it one).
+  internal var projected: Array<Expression> {
+    switch self {
     case .all, .columns:
       []
     case let .expressions(items):
       items.map(\.expression)
     }
   }
+}
 
-  /// Collects the distinct aggregate expressions within `expression` into
+extension Expression {
+  /// Collects the distinct aggregate expressions within this expression into
   /// `expressions`, in first-appearance order — the same aggregate written twice
   /// computes once.
-  internal static func collect(_ expression: Expression,
-                               into expressions: inout Array<Expression>) {
-    switch expression {
+  internal func collect(into expressions: inout Array<Expression>) {
+    switch self {
     case .column, .literal:
       break
     case .aggregate:
-      if !expressions.contains(expression) {
-        expressions.append(expression)
+      if !expressions.contains(self) {
+        expressions.append(self)
       }
     case let .call(_, arguments):
-      for argument in arguments { collect(argument, into: &expressions) }
+      for argument in arguments { argument.collect(into: &expressions) }
     case let .binary(_, lhs, rhs):
-      collect(lhs, into: &expressions)
-      collect(rhs, into: &expressions)
+      lhs.collect(into: &expressions)
+      rhs.collect(into: &expressions)
     }
   }
 
-  /// Collects the distinct aggregates within a `predicate` into `expressions`.
-  internal static func collect(_ predicate: Predicate,
-                               into expressions: inout Array<Expression>) {
-    switch predicate {
-    case let .comparison(left, _, right):
-      collect(left, into: &expressions)
-      collect(right, into: &expressions)
-    case let .bound(left, _, _):
-      collect(left, into: &expressions)
-    case let .null(expression, _):
-      collect(expression, into: &expressions)
-    case let .and(lhs, rhs), let .or(lhs, rhs):
-      collect(lhs, into: &expressions)
-      collect(rhs, into: &expressions)
-    case let .not(operand):
-      collect(operand, into: &expressions)
-    }
-  }
-
-  /// Lowers an AST `.aggregate` expression to an `Aggregation`, its argument (if
-  /// any) resolved to a combined base-ordinal term through `scope`.
+  /// Lowers this AST `.aggregate` expression to an `Aggregation`, its argument
+  /// (if any) resolved to a combined base-ordinal term through `scope`.
   ///
   /// `COUNT(*)` has no argument (it counts rows); every other aggregate lowers
-  /// its single operand expression to a term. `expression` is always an
-  /// `.aggregate` — `collect` gathers only those.
-  internal static func lower(_ expression: Expression, _ scope: Scope)
-      throws(SQLError) -> Aggregation {
-    guard case let .aggregate(function, operand) = expression else {
+  /// its single operand expression to a term. `self` is always an `.aggregate`
+  /// — `collect` gathers only those.
+  internal func aggregation(_ scope: Scope) throws(SQLError) -> Aggregation {
+    guard case let .aggregate(function, operand) = self else {
       throw .unsupported("expected an aggregate")
     }
     let argument: Term? = switch operand {
@@ -676,7 +656,26 @@ extension Engine {
     }
     return Aggregation(function: function, argument: argument)
   }
+}
 
+extension Predicate {
+  /// Collects the distinct aggregates within this predicate into `expressions`.
+  internal func collect(into expressions: inout Array<Expression>) {
+    switch self {
+    case let .comparison(left, _, right):
+      left.collect(into: &expressions)
+      right.collect(into: &expressions)
+    case let .bound(left, _, _):
+      left.collect(into: &expressions)
+    case let .null(expression, _):
+      expression.collect(into: &expressions)
+    case let .and(lhs, rhs), let .or(lhs, rhs):
+      lhs.collect(into: &expressions)
+      rhs.collect(into: &expressions)
+    case let .not(operand):
+      operand.collect(into: &expressions)
+    }
+  }
 }
 
 // MARK: - Optimisation

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -18,9 +18,16 @@
 /// chain. Absent layers are omitted. Executing the plan yields the result
 /// records' typed values; formatting them is a client's job.
 public enum Engine {
-  // MARK: - WITH
+  /// The greatest number of fixpoint iterations a recursive CTE may take before
+  /// the engine concludes it does not terminate and throws
+  /// `SQLError.recursion`.
+  internal static let kRecursionCap = 10_000
+}
 
-  /// Whether `cte` actually references itself — the test the fixpoint routing
+// MARK: - WITH
+
+extension CTE {
+  /// Whether the CTE actually references itself — the test the fixpoint routing
   /// turns on, distinct from the syntactic `recursive` flag a `WITH RECURSIVE`
   /// stamps on every member.
   ///
@@ -30,41 +37,40 @@ public enum Engine {
   /// re-evaluate an arm that never reads the CTE, repeating its rows without end
   /// (a `UNION ALL`) or needlessly (a `UNION`). A CTE is recursive in truth when
   /// its recursive arm — the right member of the top-level `UNION`, the one the
-  /// fixpoint compiles with the CTE bound — names `cte.name` in a `FROM`/`JOIN`.
+  /// fixpoint compiles with the CTE bound — names `name` in a `FROM`/`JOIN`.
   /// The anchor is the base case, compiled with the name NOT in scope, so a
   /// `FROM <name>` there reads a base relation of that name, not the CTE.
   /// Scanning the anchor too would misroute `WITH RECURSIVE Parent(Id) AS
   /// (SELECT Id FROM Parent UNION ALL SELECT Id FROM Extra)` — whose anchor
   /// merely reads the same-named base — into the fixpoint.
-  internal static func recursive(_ cte: CTE) -> Bool {
-    guard case let .union(_, arm, _) = cte.query else { return false }
-    return references(arm, cte.name.lowercased())
+  internal var recurses: Bool {
+    guard case let .union(_, arm, _) = query else { return false }
+    return arm.references(name.lowercased())
   }
+}
 
-  /// Whether `query` names the relation `name` (case-folded) in ANY member's
+extension Query {
+  /// Whether the query names the relation `name` (case-folded) in ANY member's
   /// `FROM`/`JOIN` — walking the left-associative `UNION` chain and each arm.
   /// Used to spot a self-reference lurking in a recursive body's anchor;
-  /// `recursive` itself inspects only the recursive arm.
-  internal static func references(_ query: Query, _ name: String) -> Bool {
-    switch query {
+  /// `CTE.recurses` itself inspects only the recursive arm.
+  internal func references(_ name: String) -> Bool {
+    switch self {
     case let .select(select):
-      references(select, name)
+      select.references(name)
     case let .union(left, select, _):
-      references(left, name) || references(select, name)
+      left.references(name) || select.references(name)
     }
   }
+}
 
-  /// Whether `select` names the relation `name` (case-folded) in its `FROM` or
-  /// any `JOIN`.
-  private static func references(_ select: Select, _ name: String) -> Bool {
-    if select.from?.name.lowercased() == name { return true }
-    return select.joins.contains { $0.relation.name.lowercased() == name }
+extension Select {
+  /// Whether the select names the relation `name` (case-folded) in its `FROM`
+  /// or any `JOIN`.
+  internal func references(_ name: String) -> Bool {
+    if from?.name.lowercased() == name { return true }
+    return joins.contains { $0.relation.name.lowercased() == name }
   }
-
-  /// The greatest number of fixpoint iterations a recursive CTE may take before
-  /// the engine concludes it does not terminate and throws
-  /// `SQLError.recursion`.
-  internal static let kRecursionCap = 10_000
 }
 
 // MARK: - Execution
@@ -185,7 +191,7 @@ extension Catalog where Self: ~Escapable {
       // obscurely as an unresolved relation. This covers BOTH routings below (a
       // non-recursive final arm still reaches the run-once branch).
       if cte.recursive, case let .union(anchor, _, _) = cte.query,
-          Engine.references(anchor, cte.name.lowercased()),
+          anchor.references(cte.name.lowercased()),
           case nil = table(named: cte.name),
           case nil = view(named: cte.name) {
         throw .unsupported(
@@ -198,7 +204,7 @@ extension Catalog where Self: ~Escapable {
       // arity of both its arms internally (see `fixpoint`); a non-recursive one
       // checks its body's compiled width here.
       let rows: Array<Array<Value>>
-      if cte.recursive && Engine.recursive(cte) {
+      if cte.recursive && cte.recurses {
         rows = try fixpoint(cte, relations, routines, bindings)
       } else {
         // The width check resolves the body's relations, so it reads the same

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -346,10 +346,10 @@ extension Catalog where Self: ~Escapable {
 
 // MARK: - Compilation
 
-extension Engine {
-  /// Compiles a scalar (FROM-less) `SELECT <expr-list>` into `Project(single)`
-  /// — the projection evaluated against the one empty row the `single` leaf
-  /// yields.
+extension Projection {
+  /// Compiles this scalar (FROM-less) `SELECT <expr-list>` projection into
+  /// `Project(single)` — the projection evaluated against the one empty row the
+  /// `single` leaf yields.
   ///
   /// The projection resolves against an empty schema (no columns), so only
   /// literals, scalar calls, and arithmetic over them lower; a `SELECT *` has no
@@ -357,19 +357,20 @@ extension Engine {
   /// faulting (`SQLError.column` for a column, `SQLError.unsupported` for `*`).
   /// The terms hold no slots, so the `single` row's empty record carries every
   /// value the projection needs.
-  internal static func scalar(_ projection: Projection)
-      throws(SQLError) -> Plan {
-    guard case .all = projection else {
+  internal func scalar() throws(SQLError) -> Plan {
+    guard case .all = self else {
       let schema = Schema(width: 0, extent: 0, names: [], types: [],
                           virtuals: [])
-      let terms = try schema.terms(projection, in: Relation(name: ""))
+      let terms = try schema.terms(self, in: Relation(name: ""))
       return .project(terms, .single)
     }
     // `SELECT *` names every column of the relations in scope; a FROM-less query
     // has none, so there is nothing to expand.
     throw .unsupported("SELECT * requires a FROM clause")
   }
+}
 
+extension Engine {
   /// A relation resolved for compilation: its name-resolution `schema` and a
   /// `leaf` factory that, given the ordinals the query references on its side,
   /// builds the leaf `Plan` — a `scan` for a base table, a `derived` over the
@@ -1467,7 +1468,7 @@ extension Catalog where Self: ~Escapable {
             "a WHERE, GROUP BY, HAVING, ORDER BY, OFFSET/FETCH, or JOIN " +
             "requires a FROM clause")
       }
-      return try Engine.scalar(select.projection)
+      return try select.projection.scalar()
     }
     let from = try resolve(relation, ctes, visited)
 

--- a/Sources/SQL/OutputColumn.swift
+++ b/Sources/SQL/OutputColumn.swift
@@ -198,7 +198,7 @@ extension Catalog where Self: ~Escapable {
       // projection run over the group's results, so EVALUATE them (`empty`) — a
       // divide, overflow, or bad routine call faults as the run would.
       if scope.constant(predicate) == false {
-        if Engine.aggregates(select), select.grouping.isEmpty {
+        if select.aggregates, select.grouping.isEmpty {
           if let having = select.having {
             // HAVING filters the group BEFORE any OFFSET/FETCH limit, so
             // evaluate it UNCONDITIONALLY — a zero `FETCH` or positive `OFFSET`
@@ -235,7 +235,7 @@ extension Catalog where Self: ~Escapable {
     // would yield leaves only its aggregate folds (validated above) reachable.
     // A whole-result aggregate emits exactly ONE row, so a positive OFFSET
     // drops it too — not just a zero FETCH.
-    let sole = Engine.aggregates(select) && select.grouping.isEmpty
+    let sole = select.aggregates && select.grouping.isEmpty
     if !drops(select.limit, single: sole),
         case let .expressions(items) = select.projection {
       for item in items { _ = try scope.type(of: item.expression, routines) }


### PR DESCRIPTION
This pull request refactors and modernizes the SQL engine code by moving several utility functions from global/static scope into more appropriate type extensions and adopting a more object-oriented style. It also improves code readability and maintainability by using instance methods and computed properties instead of static functions, and by grouping related logic with their corresponding types. No changes to the engine's behavior are intended, but the code is now easier to understand and extend.

Key refactorings and improvements:

**Refactoring static functions to instance methods and computed properties:**
- Moved static functions such as `Engine.references`, `Engine.aggregates`, `Engine.projected`, `Engine.collect`, and `Engine.lower` to become instance methods or computed properties on `CTE`, `Query`, `Select`, `Projection`, `Expression`, and `Predicate`, e.g., `select.aggregates`, `projection.projected`, `expression.collect(into:)`, and `expression.aggregation(scope:)`. [[1]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L33-R73) [[2]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060R435-L459) [[3]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L596-R650) [[4]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060R661-R680)

**Improving code clarity and encapsulation:**
- Replaced static utility calls with more natural instance property/method access throughout the codebase, e.g., `cte.recurses` instead of `Engine.recursive(cte)`, `select.projection.scalar()` instead of `Engine.scalar(select.projection)`, and `scan.shaped(...)` instead of `Engine.shape(...)`. [[1]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L201-R207) [[2]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L1461-R1472) [[3]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L1499-R1514) [[4]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L1583-R1598)

**Type-specific logic grouping:**
- Moved logic for identifying recursion, aggregation, and projection into their respective types (`CTE`, `Select`, `Projection`, `Expression`, `Predicate`), increasing cohesion and reducing cross-type dependencies. [[1]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L33-R73) [[2]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060R435-L459) [[3]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L596-R650) [[4]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060R661-R680)

**Minor documentation and naming improvements:**
- Updated comments and documentation to match the new style and clarify function behavior. Also, improved parameter and variable naming for better self-documentation. [[1]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L33-R73) [[2]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L343-R373)

**Consistency across files:**
- Updated references in `Sources/SQL/OutputColumn.swift` to use the new instance property style for aggregation checks, e.g., `select.aggregates` instead of `Engine.aggregates(select)`. [[1]](diffhunk://#diff-0a5052684216bdab157411fa11a75e35fa74c7bfe9bac6299115927523939d64L201-R201) [[2]](diffhunk://#diff-0a5052684216bdab157411fa11a75e35fa74c7bfe9bac6299115927523939d64L238-R238)

These changes collectively make the codebase more idiomatic, maintainable, and easier to extend. [[1]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L33-R73) [[2]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060R435-L459) [[3]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L596-R650) [[4]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060R661-R680) [[5]](diffhunk://#diff-0a5052684216bdab157411fa11a75e35fa74c7bfe9bac6299115927523939d64L201-R201)