### PR TITLE
winmd-inspect: add `.schema`

### DIFF
--- a/Sources/SQL/Adapter.swift
+++ b/Sources/SQL/Adapter.swift
@@ -53,7 +53,7 @@ public enum ValueType: Hashable, Sendable {
   /// The engine's types map onto the ISO domains: exact numeric to `integer`,
   /// approximate numeric to `double precision`, character to `character
   /// varying`, truth-valued to `boolean`, and binary to `binary varying`.
-  internal var domain: String {
+  public var domain: String {
     switch self {
     case .integer: "integer"
     case .double: "double precision"

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -180,42 +180,20 @@ extension Catalog where Self: ~Escapable {
       guard relations[cte.name.lowercased()] == nil else {
         throw .redefinition(cte.name)
       }
-      // A `WITH RECURSIVE` member's recursive reference must be its FINAL UNION
-      // arm — the engine's model is anchor members then ONE recursive arm. A
-      // reference to the CTE's own name in an EARLIER arm resolves against the
-      // base scope (the CTE is not in scope outside the recursive arm), so a
-      // same-named base or view is a valid seed; but with no such base/view the
-      // reference can only be a misplaced recursive arm — recursion before the
-      // final arm, or a second recursive arm — a shape the engine does not
-      // support. Reject it rather than silently read a same-named base or fail
-      // obscurely as an unresolved relation. This covers BOTH routings below (a
-      // non-recursive final arm still reaches the run-once branch).
-      if cte.recursive, case let .union(anchor, _, _) = cte.query,
-          anchor.references(cte.name.lowercased()),
-          case nil = table(named: cte.name),
-          case nil = view(named: cte.name) {
-        throw .unsupported(
-            "recursive WITH references the CTE outside its final UNION arm")
-      }
+      // Validate the CTE's SHAPE and ARITY against the CTEs done so far — the
+      // compile-time structural check, shared with the dry-run schema path so a
+      // derive rejects exactly the CTEs a run rejects. It faults the recursive
+      // shape and the width mismatch here, BEFORE any rows materialise.
+      try validate(cte, against: relations, routines: routines)
       // A CTE that names itself iterates a fixpoint; every other one — a
       // non-recursive CTE, or one a `WITH RECURSIVE` marks recursive but which
       // does not reference itself — runs its query once. Each resolves against
-      // the base catalog plus the CTEs done so far. A recursive CTE checks the
-      // arity of both its arms internally (see `fixpoint`); a non-recursive one
-      // checks its body's compiled width here.
+      // the base catalog plus the CTEs done so far. The arity of both routings
+      // is already checked by `validate` above.
       let rows: Array<Array<Value>>
       if cte.recursive && cte.recurses {
         rows = try fixpoint(cte, relations, routines, bindings)
       } else {
-        // The width check resolves the body's relations, so it reads the same
-        // `definition_schema.` overlay the body's own run does — a CTE body may
-        // select from a reserved store relation.
-        let scope = augment(relations, for: cte.query, rows: true,
-                            routines: routines)
-        let width = try compile(cte.query, scope).width
-        guard width == cte.columns.count else {
-          throw .columns(expected: cte.columns.count, got: width)
-        }
         rows = try run(cte.query, relations, routines, bindings)
       }
       relations[cte.name.lowercased()] =
@@ -224,6 +202,108 @@ extension Catalog where Self: ~Escapable {
                                     count: cte.columns.count))
     }
     return try run(query, relations, routines, bindings)
+  }
+
+  /// Validates the SHAPE and declared ARITY of a single common table expression
+  /// `cte` against the base catalog plus the CTEs done so far (`ctes`), WITHOUT
+  /// materialising a row — the compile-time structural check `with` runs before
+  /// each CTE materialises, factored out so the dry-run result-schema path
+  /// (`columns(of:with:)`) validates a `WITH` by the SAME code a run does, ending
+  /// the divergence between the two.
+  ///
+  /// It reproduces, without executing, the two structural faults `with` and
+  /// `fixpoint` raise:
+  ///
+  ///   - The RECURSIVE SHAPE. A `WITH RECURSIVE` member's recursive reference
+  ///     must be its FINAL `UNION` arm — the engine's model is anchor members
+  ///     then ONE recursive arm. A reference to the CTE's own name in an EARLIER
+  ///     arm resolves against the base scope (the CTE is not in scope outside
+  ///     the recursive arm), so a same-named base or view is a valid seed; but
+  ///     with no such base/view the reference can only be a misplaced recursive
+  ///     arm — recursion before the final arm, or a second recursive arm — a
+  ///     shape the engine does not support, faulted `SQLError.unsupported`.
+  ///
+  ///   - The DECLARED ARITY. Each CTE body must project exactly the arity its
+  ///     column list declares, or a later reader indexes out of bounds. The
+  ///     body's width is known once it COMPILES — never opening a cursor — so
+  ///     the compiled `Plan.width` is checked against the declared count,
+  ///     faulting `SQLError.columns` on a mismatch. A recursive (self-naming)
+  ///     CTE checks its ANCHOR (self NOT in scope) and its RECURSIVE arm (self
+  ///     bound to the declared columns) separately, exactly as `fixpoint` does;
+  ///     every other CTE checks its whole body with self NOT in scope. This is
+  ///     why the schema path must NOT bind the CTE's self for the whole body: a
+  ///     `WITH RECURSIVE t(n) AS (SELECT n FROM t UNION SELECT n FROM t)` faults
+  ///     the recursive shape here — self is not in scope in the anchor — rather
+  ///     than resolving a self-reference the run would reject.
+  ///
+  /// The reachable-operand type-check the schema path also wants is NOT part of
+  /// the shape/arity check the run relies on — the run DEFERS it to execution.
+  /// It rides in through `typecheck`: the run path passes `false` (it defers),
+  /// the schema path passes `true` (it must fault an ill-typed body statically).
+  /// Folding it here rather than layering it in the schema path keeps ONE per-arm
+  /// scoping for BOTH the structural check and the operand check — a recursive
+  /// CTE's ANCHOR is operand-checked against base + prior CTEs (self NOT in
+  /// scope, the scope the run evaluates the anchor in), NOT the CTE-self overlay,
+  /// so `SELECT Name + 1 FROM People` in the anchor faults `SQLError.operand`
+  /// against the BASE `People` a run reads it against, never wrongly types clean
+  /// against the CTE's declared columns.
+  internal borrowing func validate(_ cte: CTE, against ctes: CTEs,
+                                   routines: Routines = [:],
+                                   typecheck: Bool = false)
+      throws(SQLError) {
+    // Reject a misplaced recursive reference in an EARLIER arm when no
+    // same-named base/view can seed it — the shape `with` rejects before
+    // routing to the fixpoint.
+    if cte.recursive, case let .union(anchor, _, _) = cte.query,
+        anchor.references(cte.name.lowercased()),
+        case nil = table(named: cte.name),
+        case nil = view(named: cte.name) {
+      throw .unsupported(
+          "recursive WITH references the CTE outside its final UNION arm")
+    }
+    // Check the declared arity by compiling the body — never a cursor. A
+    // recursive (self-naming) CTE checks its anchor and recursive arm the way
+    // `fixpoint` does: the anchor with self NOT in scope, the recursive arm
+    // with self bound to the declared columns. Every other CTE checks its whole
+    // body with self NOT in scope. When `typecheck`, the reachable-operand check
+    // runs in the SAME per-arm scope each arity check uses, so the operand check
+    // shares the run's arm scoping and never types an anchor against the
+    // CTE-self overlay.
+    if cte.recursive && cte.recurses, case let .union(anchor, recursive, _) =
+        cte.query {
+      let scope = augment(ctes, for: anchor, rows: false, routines: routines)
+      let width = try compile(anchor, scope).width
+      guard width == cte.columns.count else {
+        throw .columns(expected: cte.columns.count, got: width)
+      }
+      // The anchor is operand-checked with self NOT in scope — the scope the run
+      // evaluates it in — so a text-arithmetic anchor faults against the base
+      // relation, not the CTE's declared (integer) columns.
+      if typecheck { try self.typecheck(anchor, scope, routines: routines) }
+      var probe = augment(ctes, for: .select(recursive), rows: false,
+                          routines: routines)
+      probe[cte.name.lowercased()] =
+          Materialised(columns: cte.columns, rows: [],
+                       types: Array(repeating: .integer,
+                                    count: cte.columns.count))
+      let arm = try compile(.select(recursive), probe).width
+      guard arm == cte.columns.count else {
+        throw .columns(expected: cte.columns.count, got: arm)
+      }
+      // The recursive arm is operand-checked with self bound to the declared
+      // columns — the schema every iteration reads the CTE under.
+      if typecheck {
+        try self.typecheck(.select(recursive), probe, routines: routines)
+      }
+    } else {
+      let scope = augment(ctes, for: cte.query, rows: false, routines: routines)
+      let width = try compile(cte.query, scope).width
+      guard width == cte.columns.count else {
+        throw .columns(expected: cte.columns.count, got: width)
+      }
+      // A non-self-naming body is operand-checked whole with self NOT in scope.
+      if typecheck { try self.typecheck(cte.query, scope, routines: routines) }
+    }
   }
 
   /// Evaluates a recursive `cte` to a fixpoint over this catalog with the

--- a/Sources/SQL/OutputColumn.swift
+++ b/Sources/SQL/OutputColumn.swift
@@ -60,13 +60,25 @@ extension Catalog where Self: ~Escapable {
   /// type rather than the `.integer` default. It defaults to none, matching a
   /// run with no custom routines.
   ///
+  /// `validate` (default `true`) whole-query type-checks before deriving, so a
+  /// static shape check faults an ill-typed query a run would only reach with
+  /// rows — `SELECT Name + 1 …` reports `SQLError.operand`. Pass `false` when a
+  /// run has ALREADY proved the query runnable (an empty result whose headers
+  /// this fills in): the data-dependent filter never reached the projection, so
+  /// re-validating the reachable `Name + 1` would fault a query that SUCCEEDED.
+  /// `compile` still runs either way — it resolves the relations and CTEs the
+  /// derive needs and is non-faulting for a runnable query — only the operand
+  /// type-check is skipped.
+  ///
   /// - Throws: the same resolution faults `run(query)` raises —
   ///   `SQLError.relation` for an unknown relation,
   ///   `SQLError.column`/`SQLError.ambiguous` for a column reference that does
   ///   not resolve to exactly one relation, `SQLError.function` for a call to
   ///   an unregistered scalar function anywhere in the query, `SQLError.arity`
-  ///   for a `UNION` whose arms project differing column counts.
-  public borrowing func columns(of query: Query, routines: Routines = [:])
+  ///   for a `UNION` whose arms project differing column counts; and, when
+  ///   `validate`, `SQLError.operand` for an ill-typed reachable expression.
+  public borrowing func columns(of query: Query, routines: Routines = [:],
+                                validate: Bool = true)
       throws(SQLError) -> Array<OutputColumn> {
     // Extend the scope with any `definition_schema.` store relation the query
     // names, so its result schema resolves the reserved relation the same as a
@@ -83,15 +95,149 @@ extension Catalog where Self: ~Escapable {
     // sees only the first projection; `typecheck` faults an unknown or
     // ill-typed call or a bad operand anywhere a run would evaluate it, and —
     // like the executor — skips an arm a `false AND`/`true OR` short-circuits,
-    // so a query that runs is not rejected for an unreachable call.
+    // so a query that runs is not rejected for an unreachable call. A caller
+    // that already RAN the query (`validate: false`) skips it: a reachable
+    // operand a data-dependent filter never reached would otherwise fault a
+    // query that produced its (empty) result.
     let routines = Routines.standard.merging(routines)
-    try typecheck(query, ctes, routines: routines)
+    if validate { try typecheck(query, ctes, routines: routines) }
     // The result columns are the first arm's projection (the ISO rule a UNION
     // follows), resolved against the validated scope; a scalar call types from
     // its routine's declared return type — the engine prelude merged under
     // `routines`, exactly as a run seeds them, so a standard call (`BITAND`)
-    // types without the caller re-supplying it.
-    return try columns(of: query.first, ctes, routines: routines)
+    // types without the caller re-supplying it. `validate` rides through so a
+    // `SELECT *` over a view derives the body's types WITHOUT re-type-checking
+    // it — the view body's own reachable-operand check is gated the same as the
+    // outer query's, so a `validate: false` derive faults nowhere.
+    return try columns(of: query.first, ctes, routines: routines,
+                       validate: validate)
+  }
+
+  /// The result columns `statement` would yield, named and typed, resolved
+  /// WITHOUT executing it — the statement-level entry that keeps a `WITH`'s CTE
+  /// scope in place.
+  ///
+  /// A `select` derives exactly as `columns(of query:)` does. A `with` derives
+  /// its TRAILING query against the statement's common table expressions, so a
+  /// reference the CTEs bind — a `SELECT *` over a CTE, or a name a CTE shadows
+  /// off a same-named base relation — resolves against the CTE the run did, not
+  /// the base catalog: `WITH t(x) AS (SELECT 1) SELECT * FROM t` reports one
+  /// column `x`, even where a base `t` of a different width exists. The scope is
+  /// SCHEMA-ONLY — each CTE contributes its declared column list (typed
+  /// `.integer`, the default a materialised relation reports) without running
+  /// its body — so the derive never opens a cursor, exactly as `columns(of
+  /// query:)` never does. A `create` names no result, so it faults
+  /// `SQLError.statement` the way running one does.
+  ///
+  /// `routines` and `validate` carry the meaning `columns(of query:)` gives
+  /// them; pass `validate: false` after a run has proved the statement runnable.
+  ///
+  /// - Throws: the resolution faults `columns(of query:)` raises, plus
+  ///   `SQLError.statement` for a `create`.
+  public borrowing func columns(of statement: Statement,
+                                routines: Routines = [:],
+                                validate: Bool = true)
+      throws(SQLError) -> Array<OutputColumn> {
+    switch statement {
+    case let .select(query):
+      return try columns(of: query, routines: routines, validate: validate)
+    case let .with(ctes, query):
+      return try columns(of: query, with: ctes, routines: routines,
+                         validate: validate)
+    case .create:
+      throw .statement("CREATE VIEW names no result columns")
+    }
+  }
+
+  /// The result columns the trailing `query` of a `WITH` would yield, resolved
+  /// against a SCHEMA-ONLY overlay of the `ctes` in scope.
+  ///
+  /// Each CTE binds a `Materialised` of its DECLARED columns with no rows —
+  /// the schema the run's materialised CTE resolves to (columns from the
+  /// declared list, every type `.integer`) — laid into the overlay in source
+  /// order so a later CTE, and the trailing query, resolve a name the same
+  /// precedence a run applies (a CTE shadows a base relation of the same name).
+  /// The `definition_schema.` store augment then extends this overlay for the
+  /// trailing query exactly as `columns(of query:)` does, so a `WITH` whose
+  /// trailing query also names a reserved store relation still resolves it —
+  /// the store yields to a CTE of the same name, the run's order.
+  ///
+  /// A name repeated in the list (case-insensitively) faults
+  /// `SQLError.redefinition`, the same fault `Engine.with` raises before
+  /// materialising, rather than silently shadowing the earlier binding.
+  ///
+  /// When `validate`, each CTE BODY is validated before its schema is trusted by
+  /// the SAME code a run drives — `Engine.validate`, the compile-time structural
+  /// check `Engine.with` runs before materialising: the recursive shape (a
+  /// recursive reference must be the final `UNION` arm; a self-reference in the
+  /// anchor with no same-named base faults `SQLError.unsupported`, the recursive
+  /// shape a run rejects BEFORE materialising) and the declared arity (the
+  /// compiled body width against the column list, `SQLError.columns` on a
+  /// mismatch — the anchor and recursive arm checked separately, self bound only
+  /// in the recursive arm). The schema path also asks that helper to run its
+  /// reachable-operand type-check (`typecheck: true` — the run defers this to
+  /// execution, so it stays OFF the run path): folding it in rather than layering
+  /// it here keeps ONE per-arm scoping for both, so a recursive CTE's ANCHOR is
+  /// operand-checked against the base scope the run evaluates it in, NOT the
+  /// CTE-self overlay. So a dry-run schema is advertised only for a `WITH` that
+  /// could actually run, never for one whose body's shape or width contradicts
+  /// its declared list — nor for one whose reachable operand a run would fault.
+  /// When `validate` is `false` — a
+  /// derive after a successful run — the bodies are TRUSTED, not compiled: the
+  /// run already proved them consistent, and re-checking a data-dependent-empty
+  /// body would fault a statement that succeeded.
+  private borrowing func columns(of query: Query, with ctes: Array<CTE>,
+                                 routines: Routines,
+                                 validate: Bool)
+      throws(SQLError) -> Array<OutputColumn> {
+    let routines = Routines.standard.merging(routines)
+    var overlay = CTEs()
+    for cte in ctes {
+      // A name repeated in the list (case-insensitively) would silently shadow
+      // the earlier binding in the overlay, so reject it rather than overwrite —
+      // the same fault `Engine.with` raises before materialising, so a schema is
+      // advertised only for a `WITH` that could actually run.
+      guard overlay[cte.name.lowercased()] == nil else {
+        throw .redefinition(cte.name)
+      }
+      // The CTE's schema-only self — its declared columns, no rows, every type
+      // `.integer` (the default a materialised relation reports) — bound into
+      // the recursive arm's operand check and, after validation, into the
+      // overlay a later CTE and the trailing query resolve against.
+      let declared =
+          Materialised(columns: cte.columns, rows: [],
+                       types: Array(repeating: .integer,
+                                    count: cte.columns.count))
+      // Validate the body's SHAPE and ARITY against the scope of the PRIOR CTEs
+      // by the SAME code a run uses — `Engine.validate` — so a schema is not
+      // advertised for a `WITH` a run would reject, and this path never again
+      // drifts from the engine's recursive-shape and arity rules. It binds the
+      // CTE's self only inside the recursive arm (never the whole body), so a
+      // recursive reference in the final arm resolves while a self-reference in
+      // the anchor faults the recursive shape exactly as the run does. The
+      // schema path adds ONE thing the run defers to execution: a
+      // reachable-operand type-check over the body — passed IN as `typecheck` so
+      // it runs in the SAME per-arm scope the shared helper computes, checking a
+      // recursive CTE's anchor against the base scope the run evaluates it in
+      // (NOT the CTE-self overlay). A `validate: false` derive skips both — the
+      // run already proved the bodies consistent — so `typecheck: false` there.
+      if validate {
+        // `self.` escapes the shadow the `validate` Bool parameter casts over
+        // the shared `validate(_:against:routines:)` engine helper.
+        try self.validate(cte, against: overlay, routines: routines,
+                          typecheck: true)
+      }
+      // Bind the CTE's schema-only self into the overlay AFTER its body is
+      // validated — the scope a later CTE and the trailing query resolve against
+      // — exactly as `Engine.with` binds the materialised relation after running
+      // its body.
+      overlay[cte.name.lowercased()] = declared
+    }
+    let scope = augment(overlay, for: query, rows: false)
+    _ = try compile(query, scope)
+    if validate { try typecheck(query, scope, routines: routines) }
+    return try columns(of: query.first, scope, routines: routines,
+                       validate: validate)
   }
 
   /// The result columns of a single `select`, resolved against this catalog
@@ -103,12 +249,17 @@ extension Catalog where Self: ~Escapable {
   /// duplicates (and never drifts from) that resolution. It runs only after
   /// compilation has proved the arm resolves. `routines` are the scalar
   /// routines a call types from — its declared return type — rather than the
-  /// `.integer` default.
+  /// `.integer` default. `validate` (default `true`) rides through to any view
+  /// this arm's relations resolve, gating the view body's reachable-operand
+  /// check the same as the outer query's — a `validate: false` derive never
+  /// re-type-checks a view body a run already proved runnable.
   borrowing func columns(of select: Select, _ ctes: CTEs,
                          visited: Set<String> = [],
-                         routines: Routines = [:])
+                         routines: Routines = [:],
+                         validate: Bool = true)
       throws(SQLError) -> Array<OutputColumn> {
-    try scope(of: select, ctes, visited: visited, routines: routines)
+    try scope(of: select, ctes, visited: visited, routines: routines,
+              validate: validate)
         .columns(of: select.projection, routines)
   }
 
@@ -116,18 +267,21 @@ extension Catalog where Self: ~Escapable {
   /// relation resolved to schema and laid end to end in one combined ordinal
   /// space, the same layout compilation resolves a projection against. A
   /// FROM-less `SELECT <expr-list>` projects over no relation, so its scope is
-  /// empty. It reads only schemas, never a cursor.
+  /// empty. It reads only schemas, never a cursor. `validate` (default `true`)
+  /// rides through to each relation's `schema(of:)`, gating a view body's
+  /// reachable-operand check the same as the outer query's.
   borrowing func scope(of select: Select, _ ctes: CTEs,
                        visited: Set<String> = [],
-                       routines: Routines = [:])
+                       routines: Routines = [:],
+                       validate: Bool = true)
       throws(SQLError) -> Scope {
     guard let relation = select.from else { return Scope([]) }
     var relations =
         [(relation, try schema(of: relation, ctes, visited: visited,
-                               routines: routines))]
+                               routines: routines, validate: validate))]
     for join in select.joins {
       let joined = try schema(of: join.relation, ctes, visited: visited,
-                              routines: routines)
+                              routines: routines, validate: validate)
       relations.append((join.relation, joined))
     }
     return Scope(relations)
@@ -272,10 +426,16 @@ extension Catalog where Self: ~Escapable {
   /// being resolved down this chain, breaking a cyclic view (`A` over `B` over
   /// `A`) that would otherwise re-enter here. `routines` ride through so a view
   /// body projecting a scalar call types it from the routine's declared return
-  /// type, not the `.integer` default.
+  /// type, not the `.integer` default. `validate` (default `true`) gates the
+  /// view body's reachable-operand type-check: a `validate: false` derive (an
+  /// empty result whose headers this fills) resolves the body's relations and
+  /// types WITHOUT re-checking its reachable operands, so a view whose body is
+  /// data-dependent-empty — a text-arithmetic projection under a filter that
+  /// matched no row — does not fault a `SELECT *` over it that already ran.
   borrowing func schema(of relation: Relation, _ ctes: CTEs,
                         visited: Set<String> = [],
-                        routines: Routines = [:])
+                        routines: Routines = [:],
+                        validate: Bool = true)
       throws(SQLError) -> Schema {
     let name = relation.name
     if let cte = ctes[name.lowercased()] {
@@ -310,14 +470,21 @@ extension Catalog where Self: ~Escapable {
       // unreachable.
       let overlay = augment([:], for: view.query, rows: false)
       let inner = visited.union([name.lowercased()])
-      try typecheck(view.query, overlay, visited: inner, routines: routines)
+      // Gate the body's reachable-operand check on `validate`: a `validate:
+      // false` derive skips it, so a data-dependent-empty body (a text
+      // arithmetic under an unmatched filter) does not fault a `SELECT *` over
+      // the view that already ran to its (empty) result. `validate` also rides
+      // into the recursive derive so a view over a view stays derive-only.
+      if validate {
+        try typecheck(view.query, overlay, visited: inner, routines: routines)
+      }
       // Type off the body's first arm (the ISO rule for a UNION). Arity — the
       // body's width against the declared columns — is `compile`'s job (the
       // public entry runs it), so on a shortfall fall back to the declared
       // schema rather than re-checking it here.
       let resolved =
           try columns(of: view.query.first, overlay, visited: inner,
-                      routines: routines)
+                      routines: routines, validate: validate)
       guard resolved.count == base.width else { return base }
       return Schema(width: base.width, extent: base.extent, names: base.names,
                     types: resolved.map(\.type), virtuals: base.virtuals)

--- a/Sources/winmd-inspect/Shell.swift
+++ b/Sources/winmd-inspect/Shell.swift
@@ -47,6 +47,49 @@ internal struct Tables: Metacommand {
   }
 }
 
+/// `.schema <query>` — print a query's result columns (name and type) WITHOUT
+/// running it.
+///
+/// A query's result has a name and a type per column, which
+/// `Catalog.columns(of:validate:)` derives by RESOLVING the query the way a run
+/// would — but never opening a cursor, so the shape is inspectable over an
+/// empty or costly source without paying for it. `arguments` is the query text
+/// (a trailing `;` optional); it may be a `SELECT` (or a `UNION`) or a `WITH`,
+/// the runnable shapes `columns(of:)` types — the SAME statements the shell
+/// runs, so a CTE query describes as it executes. A `CREATE VIEW` names no
+/// result columns and faults. `execute` prints one tab-separated
+/// `<name>\t<type>` line per column, the type the ISO `data_type` spelling
+/// `information_schema.columns` reports — a query that does not resolve (an
+/// unknown relation, an unresolved column, a `WITH` whose body arity
+/// contradicts its declared list) faults exactly as a run would, so `.schema`
+/// doubles as a dry-run check.
+internal struct Schema: Metacommand {
+  internal static let spelling = ".schema"
+
+  /// The query text whose result columns to describe — the rest of the
+  /// statement after `.schema`, a trailing `;` optional.
+  internal let query: String
+
+  internal init(_ arguments: Substring) {
+    query = arguments.trimmed.statement.trimmed
+  }
+
+  internal func execute(against shell: inout Shell) throws {
+    guard !query.isEmpty else { throw Shell.MetaError.unknown(Schema.spelling) }
+    // Route through the statement-level, CTE-aware derive with `validate:
+    // true`: it types a `SELECT`/`UNION` AND a `WITH` (the CTE scope kept in
+    // place) and faults a `CREATE VIEW`, so `.schema` describes every runnable
+    // statement the shell runs — the dry run validating the whole statement.
+    let parsed = try Statement(parsing: query)
+    let columns =
+        try shell.session.columns(of: parsed, routines: Session.routines,
+                                  validate: true)
+    for column in columns {
+      print("\(column.name)\t\(column.type.domain)")
+    }
+  }
+}
+
 /// `.help` — print the command summary.
 internal struct Help: Metacommand {
   internal static let spelling = ".help"
@@ -292,13 +335,14 @@ internal struct Shell: ~Escapable {
   /// computed so the metatype array (not `Sendable`) is not a shared mutable
   /// global.
   private static var commands: Array<any Metacommand.Type> {
-    [Tables.self, Help.self, Quit.self, Read.self, Render.self, Bind.self,
-     Template.self]
+    [Tables.self, Schema.self, Help.self, Quit.self, Read.self, Render.self,
+     Bind.self, Template.self]
   }
 
   /// The command summary `.help` prints.
   internal static let help = """
     .tables                 list the database's tables
+    .schema <query>         print a query's result columns without running it
     .read <path>            run a file of `;`-separated SQL statements
     .render <iface> <tmpl>  render an interface (or `*`) through a template
     .bind <name> <value>    bind a `:name` parameter (no value clears it)
@@ -342,9 +386,10 @@ internal struct Shell: ~Escapable {
   /// statement, run through `Session.run` with the shell's `bindings` — a `CREATE
   /// VIEW` registers, a `SELECT` yields rows resolving any `:name` from the
   /// bindings — and its rows print as a `sqlite3`-style `.mode box` table
-  /// (`Box.render`), the column headers taken from the statement's projection.
-  /// The shell does not single out `CREATE VIEW`: it just runs the statement and
-  /// prints what comes back — a `CREATE VIEW` yields no rows, so nothing prints.
+  /// (`Box.render`), the column headers derived from the statement's result
+  /// schema. The shell does not single out `CREATE VIEW`: it just runs the
+  /// statement and prints what comes back — a `CREATE VIEW` yields no rows, so
+  /// nothing prints.
   internal mutating func execute(_ statement: String) throws {
     guard statement.first == "." else {
       let text = statement.statement
@@ -353,7 +398,7 @@ internal struct Shell: ~Escapable {
       // result is empty — the header frame still conveys the zero-row result — so
       // an empty result is NOT treated as no output. A `CREATE VIEW` genuinely
       // produces nothing; `headers` returns nil for it and it is skipped.
-      guard let names = Shell.headers(of: text, rows) else { return }
+      guard let names = headers(of: text, rows) else { return }
       print(Box.render(names, rows))
       return
     }
@@ -582,42 +627,72 @@ internal struct Shell: ~Escapable {
   /// to its result `rows` — or `nil` when `text` is not row output (a `CREATE
   /// VIEW`), so the caller prints nothing.
   ///
-  /// A `SELECT`'s explicit projection names its columns from the statement (an
-  /// aliased or bare column projects its name, the qualifier dropped; a computed
-  /// expression with no alias falls back to a positional `column N`). A `WITH`
-  /// shares this derivation, taking its headers from the TRAILING query's
-  /// projection — `WITH t(n) AS (…) SELECT n FROM t` headers `n`, and a
-  /// zero-row result still frames the real column names with the right width. A
-  /// `SELECT *` (a plain one, or a `WITH`'s trailing `SELECT *` over a CTE)
-  /// carries no names in the statement — its real columns come from the
-  /// engine's resolution (view-shadows-table, joins, unions, CTE-scoped
-  /// schema), which the shell does NOT duplicate here; it frames by the
-  /// produced width (`column N`) pending a resolved-output-schema source
-  /// (INFORMATION_SCHEMA). An unparsable string likewise frames by the produced
-  /// width.
-  internal static func headers(of text: String,
-                               _ rows: Array<Array<Value>>) -> Array<String>? {
+  /// The headers come from the query's RESOLVED result schema
+  /// (`columns(of:validate:)`), the same derivation `information_schema` and
+  /// `.schema` share — so a plain `SELECT` (or a `SELECT *`) over base tables
+  /// headers its REAL column names (view-shadows-table, joins, unions), and a
+  /// zero-row result still frames those names with the right width. The derive
+  /// is `validate: false`: the run above already proved the query runnable, so
+  /// a data-dependent-empty result whose reachable projection a validating
+  /// resolve would fault (`SELECT Name + 1 … WHERE …`) still frames.
+  ///
+  /// A `WITH`'s trailing query resolves against the statement's CTEs — the
+  /// derivation keeps them in scope (`columns(of statement:)` builds a
+  /// schema-only CTE overlay), so a `SELECT *` or any reference to a CTE
+  /// headers what the run produced, not a same-named base relation: `WITH
+  /// TypeDef(x) AS (…) SELECT * FROM TypeDef` headers `x`, the one CTE column,
+  /// even though a six-column base `TypeDef` exists. Only a statement the derive
+  /// still cannot resolve falls back to the trailing query's SYNTACTIC
+  /// projection — an explicit list names its columns, a `SELECT *` carries none
+  /// and frames by the produced width (`column N`). An unparsable string
+  /// likewise frames by the produced width.
+  internal borrowing func headers(of text: String,
+                                  _ rows: Array<Array<Value>>)
+      -> Array<String>? {
     guard let statement = try? Statement(parsing: text) else {
-      return generic(rows)
+      return Shell.generic(rows)
     }
-    let query: SQL.Query
+    if case .create = statement { return nil }
+    // Prefer the resolved result schema (real names for a plain/base/empty
+    // query, and a WITH's CTE-scoped trailing query); fall back to the trailing
+    // query's syntactic projection only when the derive cannot resolve it.
+    if let columns = try? session.columns(of: statement,
+                                          routines: Session.routines,
+                                          validate: false) {
+      return columns.map(\.name)
+    }
+    return Shell.names(of: Shell.trailing(statement).first.projection, rows)
+  }
+
+  /// The row-producing query of `statement` — a `select`'s query, or a `with`'s
+  /// trailing query — the syntactic-projection fallback names its columns off.
+  /// A `create` never reaches here (`headers(of:)` returns `nil` for it first),
+  /// so it maps to its own (nameless) query defensively.
+  private static func trailing(_ statement: Statement) -> SQL.Query {
     switch statement {
-    case .create:
-      return nil
-    case let .select(select):
-      query = select
-    case let .with(_, trailing):
-      query = trailing
+    case let .select(query): query
+    case let .with(_, query): query
+    case let .create(_, view): view.query
     }
-    switch query.first.projection {
+  }
+
+  /// The SYNTACTIC column headers of a `projection` — the fallback for a query
+  /// the resolved schema derive cannot type (a `WITH`'s trailing query over a
+  /// CTE). An explicit projection names its columns from the statement (an
+  /// aliased or bare column projects its name, the qualifier dropped; a
+  /// computed expression with no alias falls back to a positional `column N`);
+  /// a `SELECT *` carries no names, so it frames by the produced width.
+  private static func names(of projection: SQL.Projection,
+                            _ rows: Array<Array<Value>>) -> Array<String> {
+    switch projection {
     case let .columns(list):
-      return list.map(\.name)
+      list.map(\.name)
     case let .expressions(items):
-      return items.enumerated().map { index, item in
+      items.enumerated().map { index, item in
         item.alias ?? column(item.expression) ?? "column \(index + 1)"
       }
     case .all:
-      return generic(rows)
+      generic(rows)
     }
   }
 

--- a/Tests/SQLTests/OutputSchemaTests.swift
+++ b/Tests/SQLTests/OutputSchemaTests.swift
@@ -235,6 +235,38 @@ struct OutputSchemaTests {
     #expect(columns[0] == OutputColumn(name: "Label", type: .text))
   }
 
+  @Test("a data-dependent-empty view derives headers without re-validating")
+  func emptyViewDerives() throws {
+    // A view whose body is a text-arithmetic projection under a filter that
+    // matches no row RUNS to zero rows: the data-dependent WHERE spares the
+    // `Name + 1` from ever evaluating. Filling in the empty result's headers
+    // (`validate: false`) must resolve the view — relations, CTEs, and the
+    // body's own types — WITHOUT re-type-checking the body's reachable
+    // `Name + 1`, which a run never reached; otherwise a query that SUCCEEDED
+    // reports a failure. `validate: true` (the default / `.schema`) still
+    // faults, exactly as running the body over rows would.
+    let definition = try View(query: {
+      guard case let .select(query) = try Statement(parsing:
+          "SELECT Name + 1 AS x FROM People WHERE Name = 'missing'") else {
+        throw SQLError.incomplete(expected: "a SELECT")
+      }
+      return query
+    }(), columns: ["x"])
+    let source = SchemaCatalog([
+      "People": SchemaRelation([("Name", .text), ("Age", .integer)]),
+    ], views: ["Empty": definition])
+    let query = try parse("SELECT * FROM Empty")
+    // `validate: false` derives the header without re-validating the body.
+    let derived = try source.columns(of: query, validate: false)
+    #expect(derived.count == 1)
+    #expect(derived[0].name == "x")
+    // `validate: true` re-type-checks the body's reachable `Name + 1` and
+    // faults with the text-arithmetic operand error, as running the body would.
+    #expect(throws: SQLError.self) {
+      let _ = try source.columns(of: query, validate: true)
+    }
+  }
+
   @Test("an unknown relation faults exactly as compilation would")
   func unknownRelation() throws {
     #expect(throws: SQLError.self) {
@@ -428,5 +460,211 @@ struct OutputSchemaTests {
     let columns = try schema("SELECT COUNT(*) FROM People WHERE 1 = 0 "
         + "HAVING COUNT(*) = 1 FETCH FIRST 0 ROWS ONLY")
     #expect(columns.count == 1)
+  }
+
+  @Test("columns(of statement:) derives a WITH against its CTE scope")
+  func statementWith() throws {
+    // The trailing query resolves against the statement's CTEs, schema-only:
+    // a CTE `People` SHADOWS the two-column base relation, so a `SELECT *` over
+    // it names the CTE's one declared column `x`, not the base's `Name, Age`.
+    let columns = try catalog().columns(of: Statement(parsing:
+        "WITH People(x) AS (SELECT 1) SELECT * FROM People"))
+    #expect(columns.count == 1)
+    #expect(columns[0].name == "x")
+  }
+
+  @Test("columns(of statement:) resolves a WITH's explicit column projection")
+  func statementWithExplicit() throws {
+    // A bare-column projection reads the CTE's declared columns; a two-column
+    // CTE heads its two names, no base relation involved.
+    let columns = try catalog().columns(of: Statement(parsing:
+        "WITH t(a, b) AS (SELECT 1, 2) SELECT a, b FROM t"))
+    #expect(same(columns.map { ($0.name, $0.type) },
+                 [("a", .integer), ("b", .integer)]))
+  }
+
+  @Test("columns(of statement:) leaves a base reachable when no CTE shadows it")
+  func statementWithNoShadow() throws {
+    // A CTE whose name does not collide leaves the base `People` reachable — the
+    // trailing `SELECT *` resolves its two real columns.
+    let columns = try catalog().columns(of: Statement(parsing:
+        "WITH t(x) AS (SELECT 1) SELECT * FROM People"))
+    #expect(same(columns.map { ($0.name, $0.type) },
+                 [("Name", .text), ("Age", .integer)]))
+  }
+
+  @Test("columns(of statement:) faults on a CREATE VIEW, naming no result")
+  func statementCreate() throws {
+    let create = try Statement(parsing:
+        "CREATE VIEW v AS SELECT Name FROM People")
+    #expect(throws: SQLError.self) {
+      let _ = try catalog().columns(of: create)
+    }
+  }
+
+  @Test("a WITH whose body arity contradicts its list faults when validating")
+  func statementWithBadArity() throws {
+    // The CTE declares ONE column but its body projects TWO — a `SELECT *` over
+    // the two-column `People`. The parser cannot catch this (a `SELECT *`'s
+    // width is known only at resolution), so a run rejects it with
+    // `SQLError.columns` when its compiled body width contradicts the declared
+    // list. A `validate: true` derive must not advertise a schema for it, so it
+    // faults the SAME way — declared as `expected`, body width as `got`, as
+    // `Engine.with` does — not report the one trusted declared column.
+    let statement = try Statement(parsing:
+        "WITH t(a) AS (SELECT * FROM People) SELECT * FROM t")
+    #expect(throws: SQLError.columns(expected: 1, got: 2)) {
+      let _ = try catalog().columns(of: statement, validate: true)
+    }
+  }
+
+  @Test("a WITH's body is trusted, not compiled, when not validating")
+  func statementWithArityTrusted() throws {
+    // `validate: false` is the post-run derive: the run already proved the
+    // bodies consistent, so the declared list is TRUSTED without compiling the
+    // body. The same arity-mismatched `WITH` that faults when validating
+    // reports its one declared column here — the empty/data-dependent header
+    // path a successful run fills in.
+    let statement = try Statement(parsing:
+        "WITH t(a) AS (SELECT * FROM People) SELECT * FROM t")
+    let columns = try catalog().columns(of: statement, validate: false)
+    #expect(same(columns.map { ($0.name, $0.type) }, [("a", .integer)]))
+  }
+
+  @Test("a well-formed WITH validates and derives its trailing schema")
+  func statementWithValidates() throws {
+    // A CTE whose declared arity matches its body validates cleanly and derives
+    // the trailing query's schema — the body compiled, its width confirmed
+    // against the declared list, and its reachable operands type-checked.
+    let statement = try Statement(parsing:
+        "WITH t(a, b) AS (SELECT * FROM People) SELECT a, b FROM t")
+    let columns = try catalog().columns(of: statement, validate: true)
+    #expect(same(columns.map { ($0.name, $0.type) },
+                 [("a", .integer), ("b", .integer)]))
+  }
+
+  @Test("a non-recursive CTE body cannot see its own schema-only self")
+  func statementWithNonRecursiveSelf() throws {
+    // A non-recursive CTE is NOT in scope within its own body — only the PRIOR
+    // CTEs and the base catalog are — so a body that names the CTE with no
+    // same-named base resolves against nothing and faults `.relation`, exactly
+    // as `Engine.with` does. Binding the CTE's schema-only self into its own
+    // body's scope would WRONGLY resolve it, advertising a schema for a `WITH`
+    // that cannot run.
+    let statement = try Statement(parsing:
+        "WITH t(x) AS (SELECT * FROM t) SELECT * FROM t")
+    #expect(throws: SQLError.relation("t")) {
+      let _ = try catalog().columns(of: statement, validate: true)
+    }
+  }
+
+  @Test("a same-named-base non-recursive CTE body resolves the base")
+  func statementWithSelfResolvesBase() throws {
+    // A non-recursive CTE `People` shadowing the two-column base is NOT in its
+    // OWN body's scope, so the body's `SELECT * FROM People` resolves the BASE
+    // relation (two columns), matching its declared arity; the trailing query
+    // then reads the CTE's one declared column `x`. Were the CTE's own self
+    // bound in its body, the body would read the CTE (one column) and its arity
+    // would contradict the declared two-column list.
+    let statement = try Statement(parsing:
+        "WITH People(a, b) AS (SELECT * FROM People) SELECT a, b FROM People")
+    let columns = try catalog().columns(of: statement, validate: true)
+    #expect(same(columns.map { ($0.name, $0.type) },
+                 [("a", .integer), ("b", .integer)]))
+  }
+
+  @Test("a WITH with a duplicate CTE name faults with redefinition")
+  func statementWithDuplicateName() throws {
+    // Two CTEs of the same (case-insensitive) name would silently shadow the
+    // earlier binding, so the derive faults `.redefinition` — the same fault
+    // `Engine.with` raises before materialising — rather than advertise a schema
+    // off the shadowing definition.
+    let statement = try Statement(parsing:
+        "WITH t(a) AS (SELECT 1), T(b) AS (SELECT 2) SELECT * FROM t")
+    #expect(throws: SQLError.redefinition("T")) {
+      let _ = try catalog().columns(of: statement, validate: true)
+    }
+  }
+
+  @Test("a recursive CTE body sees its own schema-only self and resolves")
+  func statementWithRecursiveSelf() throws {
+    // A genuinely recursive CTE — its FINAL UNION arm names itself — DOES bind
+    // its own schema-only self while its body validates, so the recursive
+    // reference resolves. The anchor seeds one column, the recursive arm reads
+    // the CTE, and the trailing query names the CTE's declared column `n`.
+    let statement = try Statement(parsing: """
+        WITH RECURSIVE t(n) AS (
+          SELECT 1 UNION SELECT n + 1 FROM t
+        ) SELECT n FROM t
+        """)
+    let columns = try catalog().columns(of: statement, validate: true)
+    #expect(columns.count == 1)
+    #expect(columns[0].name == "n")
+  }
+
+  @Test("a recursive CTE self-referencing its anchor faults as a run does")
+  func statementWithRecursiveAnchorSelf() throws {
+    // The engine binds a recursive CTE's self ONLY to its FINAL UNION arm: a
+    // self-reference in the ANCHOR arm resolves against the base scope, so with
+    // no same-named base/view it can only be a misplaced recursive arm — a
+    // shape the engine rejects `.unsupported`, BEFORE materialising. The derive
+    // now validates the CTE by the SAME `Engine.validate` a run drives, so it
+    // faults IDENTICALLY rather than advertising a schema for a `WITH` a run
+    // would reject.
+    let statement = try Statement(parsing: """
+        WITH RECURSIVE t(n) AS (
+          SELECT n FROM t UNION SELECT n FROM t
+        ) SELECT n FROM t
+        """)
+    let error = SQLError.unsupported(
+        "recursive WITH references the CTE outside its final UNION arm")
+    #expect(throws: error) {
+      let _ = try catalog().columns(of: statement, validate: true)
+    }
+    // The derive faults EXACTLY where a run does — the divergence the schema
+    // path repeatedly drifted into is closed by reusing the engine's own check.
+    #expect(throws: error) {
+      let _ = try catalog().run(statement)
+    }
+  }
+
+  @Test("a recursive CTE anchor is operand-checked against the base scope")
+  func statementWithRecursiveAnchorOperand() throws {
+    // A recursive CTE binds its schema-only self (declared columns, typed
+    // `.integer`) ONLY inside its final UNION arm; the anchor resolves against
+    // the BASE scope — the same scope a run evaluates it in. So the anchor's
+    // reachable operands must be type-checked with self NOT in scope: here the
+    // base `People.Name` is TEXT (the shared fixture), so the anchor `SELECT
+    // Name + 1 FROM People` faults `.operand` exactly as a run's per-row
+    // evaluation would. Were the anchor typed against the CTE-self overlay
+    // (declared `Name` integer) it would type clean and wrongly advertise a
+    // valid schema — the bug this closes. Folding the operand check into the
+    // shared `Engine.validate` keeps the derive on the run's per-arm scope: the
+    // anchor is checked with self NOT in scope, the run's own scope for it, so
+    // the two cannot drift on this axis.
+    let statement = try Statement(parsing: """
+        WITH RECURSIVE People(Name) AS (
+          SELECT Name + 1 FROM People UNION SELECT Name FROM People
+        ) SELECT Name FROM People
+        """)
+    #expect(throws: SQLError.operand("operands must be numeric")) {
+      let _ = try catalog().columns(of: statement, validate: true)
+    }
+  }
+
+  @Test("a well-formed recursive CTE with a numeric anchor validates")
+  func statementWithRecursiveAnchorValidates() throws {
+    // The operand check must not reject a runnable recursive CTE: a numeric
+    // anchor and a recursive arm free of bad operands validate and derive the
+    // trailing schema. This is the counterpart to the text-anchor fault — the
+    // per-arm operand check accepts exactly what a run does.
+    let statement = try Statement(parsing: """
+        WITH RECURSIVE Counter(n) AS (
+          SELECT 1 UNION SELECT n + 1 FROM Counter
+        ) SELECT n FROM Counter
+        """)
+    let columns = try catalog().columns(of: statement, validate: true)
+    #expect(columns.count == 1)
+    #expect(columns[0].name == "n")
   }
 }

--- a/Tests/winmd-inspectTests/DatabaseSQLTests.swift
+++ b/Tests/winmd-inspectTests/DatabaseSQLTests.swift
@@ -835,6 +835,190 @@ struct DatabaseSQLTests {
     }
   }
 
+  @Test("`.schema` types a query's result columns without running it")
+  func schemaColumns() throws {
+    // `.schema` prints the query's result columns — the name and type
+    // `session.columns(of:)` resolves WITHOUT opening a cursor, the capability
+    // the command formats. `TypeDef.TypeName` is a `#Strings` column, so it
+    // types `.text`, and the bundled `interfaces` view's `GUID(c.Value) AS iid`
+    // types `.text` too — the `GUID` UDF's declared `.text` return, not the
+    // integer default a scalar call falls to.
+    try DatabaseSQLTests.with { catalog in
+      let session = Session(catalog, Session.bundled())
+      guard case let .select(query) =
+          try Statement(parsing: "SELECT TypeName, iid FROM interfaces") else {
+        Issue.record("not a SELECT")
+        return
+      }
+      let columns = try session.columns(of: query, routines: Session.routines)
+      #expect(columns == [
+        OutputColumn(name: "TypeName", type: .text),
+        OutputColumn(name: "iid", type: .text),
+      ])
+    }
+  }
+
+  @Test("`.schema` faults on a query that would not run, without running it")
+  func schemaFaults() {
+    // `.schema` resolves the query the way a run would, so an unknown relation
+    // faults `SQLError.relation` exactly as a run would — the dry-run check —
+    // rather than silently printing nothing. An empty query is the unknown-meta
+    // fault its guard raises.
+    DatabaseSQLTests.with { catalog in
+      var shell = Shell(catalog)
+      #expect(throws: SQLError.relation("NoSuchTable")) {
+        try shell.execute(".schema SELECT x FROM NoSuchTable")
+      }
+      #expect(throws: Shell.MetaError.unknown(".schema")) {
+        try shell.execute(".schema")
+      }
+    }
+  }
+
+  @Test("`.schema` describes a WITH statement, the shape the shell runs")
+  func schemaWith() {
+    // `.schema` routes through the CTE-aware, statement-level derive, so a
+    // `WITH` types its trailing query against the CTE scope — the SAME
+    // statement the shell runs. The trailing `SELECT n FROM t` resolves `n` off
+    // the CTE, so `.schema` succeeds rather than rejecting anything but a bare
+    // `SELECT`.
+    DatabaseSQLTests.with { catalog in
+      var shell = Shell(catalog)
+      #expect(throws: Never.self) {
+        try shell.execute(
+            ".schema WITH t(n) AS (SELECT TypeName FROM TypeDef)"
+                + " SELECT n FROM t")
+      }
+    }
+  }
+
+  @Test("`.schema` faults a WITH whose body arity contradicts its list")
+  func schemaWithBadArity() {
+    // The CTE declares ONE column but its body — a `SELECT *` over the
+    // six-column `TypeDef` — projects six. The parser cannot catch this (a
+    // `SELECT *`'s width is known only at resolution), so a run rejects it with
+    // `SQLError.columns`. `.schema` validates the whole statement, so it faults
+    // the SAME way rather than advertising the one trusted declared column.
+    DatabaseSQLTests.with { catalog in
+      var shell = Shell(catalog)
+      #expect(throws: SQLError.columns(expected: 1, got: 6)) {
+        try shell.execute(
+            ".schema WITH t(a) AS (SELECT * FROM TypeDef) SELECT * FROM t")
+      }
+    }
+  }
+
+  @Test("an empty SELECT frames its REAL column names, not `column N`")
+  func emptyResultRealHeaders() throws {
+    // A `SELECT *` yielding no rows still frames its box, and the headers are
+    // the RESOLVED result-schema names (`columns(of:)`), not the positional
+    // `column N` a syntactic `SELECT *` would fall back to. A false predicate
+    // filters every fixture row, so the result is empty yet the six real
+    // `TypeDef` field names frame it. A named projection resolves too.
+    DatabaseSQLTests.with { catalog in
+      let shell = Shell(catalog)
+      #expect(shell.headers(of: "SELECT * FROM TypeDef WHERE 1 = 0", [])
+              == ["Flags", "TypeName", "TypeNamespace", "Extends",
+                  "FieldList", "MethodList"])
+      #expect(shell.headers(of: "SELECT TypeName FROM TypeDef WHERE 1 = 0", [])
+              == ["TypeName"])
+    }
+  }
+
+  @Test("a non-empty SELECT frames its rows under the resolved headers")
+  func nonEmptyResultHeaders() throws {
+    // A `SELECT` yielding rows frames them under its resolved headers — the box
+    // renderer always heads its grid, so a run with rows keeps the same column
+    // names as the empty case. A `CREATE VIEW` is not row output, so `headers`
+    // yields nil (nothing printed).
+    DatabaseSQLTests.with { catalog in
+      let shell = Shell(catalog)
+      #expect(shell.headers(of: "SELECT TypeName FROM TypeDef",
+                            [[.text("IMyInterface")], [.text("INotGuid")]])
+              == ["TypeName"])
+      #expect(shell.headers(of: "CREATE VIEW v AS SELECT TypeName FROM TypeDef",
+                            []) == nil)
+    }
+  }
+
+  @Test("a data-dependent empty result headers without re-validating")
+  func emptyResultHeadersDerived() throws {
+    // A `WHERE` no fixture row satisfies filters the result to empty, so the
+    // projection's `TypeName + 1` (text arithmetic) NEVER evaluates — the run
+    // SUCCEEDS with zero rows. The header path then DERIVES the `x` header off
+    // the query (`validate: false`), never re-type-checking the reachable-but-
+    // unevaluated arithmetic that a validating resolve would fault
+    // `SQLError.operand`. The header survives; no error.
+    DatabaseSQLTests.with { catalog in
+      let shell = Shell(catalog)
+      #expect(shell.headers(of:
+          "SELECT TypeName + 1 AS x FROM TypeDef WHERE TypeName = 'missing'",
+          []) == ["x"])
+    }
+  }
+
+  @Test("a WITH's SELECT * over a CTE heads the CTE's columns, not the base")
+  func withCTEShadowingHeaders() throws {
+    // A CTE `TypeDef` SHADOWS the six-column base `TypeDef`: the run resolves
+    // the trailing `SELECT * FROM TypeDef` against the CTE (one column `x`), so
+    // the header must too — derived with the CTE scope in place, not the base
+    // catalog. The bug this guards headed the six base field names, a
+    // column-count mismatch against the one-column result.
+    DatabaseSQLTests.with { catalog in
+      let shell = Shell(catalog)
+      #expect(shell.headers(of:
+          "WITH TypeDef(x) AS (SELECT 1) SELECT * FROM TypeDef", [[.integer(1)]])
+          == ["x"])
+    }
+  }
+
+  @Test("a WITH heads its trailing query's CTE-resolved column names")
+  func withCTEExplicitHeaders() throws {
+    // The trailing query names columns off the CTE it references: an explicit
+    // list `(a, b)` heads `a, b` through the CTE, and a bare-column projection
+    // reads the CTE's declared column. Both resolve against the CTE scope.
+    DatabaseSQLTests.with { catalog in
+      let shell = Shell(catalog)
+      #expect(shell.headers(of:
+          "WITH t(a, b) AS (SELECT 1, 2) SELECT * FROM t",
+          [[.integer(1), .integer(2)]]) == ["a", "b"])
+      #expect(shell.headers(of:
+          "WITH t(a, b) AS (SELECT 1, 2) SELECT b FROM t",
+          [[.integer(2)]]) == ["b"])
+    }
+  }
+
+  @Test("a WITH not shadowing a base heads its trailing SELECT * real names")
+  func withCTENotShadowingHeaders() throws {
+    // A CTE whose name does NOT collide with a base relation leaves the base
+    // reachable: the trailing `SELECT * FROM TypeDef` resolves the six real
+    // base columns, and the unrelated CTE scope does not perturb them.
+    DatabaseSQLTests.with { catalog in
+      let shell = Shell(catalog)
+      #expect(shell.headers(of:
+          "WITH t(x) AS (SELECT 1) SELECT * FROM TypeDef", [])
+          == ["Flags", "TypeName", "TypeNamespace", "Extends",
+              "FieldList", "MethodList"])
+    }
+  }
+
+  @Test("`.schema` still faults a data-dependently ill-typed query")
+  func schemaFaultsIllTyped() {
+    // The validating default a static shape check keeps: `.schema` reports an
+    // ill-typed query even when a data-dependent filter would spare it at run.
+    // The SAME `TypeName + 1` the derive-only header renders faults here — the
+    // filter is not statically false, so the projection is reachable and its
+    // text arithmetic type-checks to `SQLError.operand`; `.schema` is a dry-run
+    // TYPE check, not a run.
+    DatabaseSQLTests.with { catalog in
+      var shell = Shell(catalog)
+      #expect(throws: SQLError.self) {
+        try shell.execute(
+            ".schema SELECT TypeName + 1 AS x FROM TypeDef WHERE TypeName = ''")
+      }
+    }
+  }
+
   @Test("a `.quit` inside a `.read` file leaves the shell, not just the file")
   func readPropagatesQuit() throws {
     // `.read` drives the same statement stream, but a `.quit` in the file must

--- a/Tests/winmd-inspectTests/ShellTests.swift
+++ b/Tests/winmd-inspectTests/ShellTests.swift
@@ -60,6 +60,7 @@ struct ShellTests {
     // The leading-token dispatch matches a `.`-token against each `Metacommand`
     // type's `spelling`; these are the tokens `execute` routes on.
     #expect(Tables.spelling == ".tables")
+    #expect(Schema.spelling == ".schema")
     #expect(Help.spelling == ".help")
     #expect(Quit.spelling == ".quit")
     #expect(Read.spelling == ".read")
@@ -76,6 +77,17 @@ struct ShellTests {
     #expect(Read("  spaced.sql ").path == "spaced.sql")
     // No argument leaves an empty path — `execute` rejects it as unknown.
     #expect(Read("").path.isEmpty)
+  }
+
+  @Test("`.schema` parses its trailing query, dropping a trailing `;`")
+  func schema() {
+    // `Schema.init` takes the rest of the statement after the spelling token as
+    // the query text, trimmed and with a single trailing `;` removed (the same
+    // optional terminator a run tolerates).
+    #expect(Schema(" SELECT 1").query == "SELECT 1")
+    #expect(Schema("  SELECT 1 ; ").query == "SELECT 1")
+    // No query leaves an empty string — `execute` rejects it as unknown.
+    #expect(Schema("").query.isEmpty)
   }
 
   @Test("`.render` parses its interface and template arguments")
@@ -529,38 +541,6 @@ struct ShellTests {
       │ 中文 │
       └──────┘
       """)
-  }
-
-  @Test("headers frame an empty SELECT by projection and skip CREATE VIEW")
-  func emptyResultHeaders() {
-    // An empty result still frames its columns for an explicit projection — its
-    // names come from the statement regardless of row count. A CREATE VIEW is not
-    // row output and yields nil (nothing printed). A `SELECT *` carries no names
-    // in the statement (its columns come from the engine's resolution, deferred
-    // to a resolved-schema source), so it frames by the produced width.
-    #expect(Shell.headers(of: "SELECT Id, Name FROM T", []) == ["Id", "Name"])
-    #expect(Shell.headers(of: "SELECT Id FROM T", [[.integer(1)]]) == ["Id"])
-    #expect(Shell.headers(of: "CREATE VIEW v AS SELECT 1 AS x", []) == nil)
-    #expect(Shell.headers(of: "SELECT * FROM T", [[.integer(9), .integer(8)]])
-            == ["column 1", "column 2"])
-  }
-
-  @Test("headers derive a WITH from its trailing query's projection")
-  func withResultHeaders() {
-    // A `WITH` frames its box from the TRAILING query's projection, exactly as
-    // a plain `SELECT` does — names come from the statement, not the rows, so
-    // `WITH t(n) AS (…) SELECT n FROM t` headers `n`, not the positional
-    // `column 1` the generic fallback would produce.
-    let query = "WITH t(n) AS (SELECT 1) SELECT n FROM t"
-    #expect(Shell.headers(of: query, [[.integer(1)]]) == ["n"])
-    // A zero-row result still frames the real column name — the header comes
-    // from the projection, so the box is sized to `n` regardless of row count.
-    #expect(Shell.headers(of: query, []) == ["n"])
-    // A trailing `SELECT *` over a CTE carries no names in the statement (they
-    // need CTE-scoped schema resolution, out of scope here), so it frames by
-    // the produced width, the same fallback a plain `SELECT *` takes.
-    #expect(Shell.headers(of: "WITH t(n) AS (SELECT 1) SELECT * FROM t",
-                          [[.integer(1)]]) == ["column 1"])
   }
 
   @Test("the identity spec escapes nothing and applies no conventions")


### PR DESCRIPTION
This pull request adds a new `.schema` metacommand to the SQL shell, allowing users to inspect the result columns (names and types) of a query without actually running it. It also improves the shell's handling of empty SELECT results by ensuring column headers are printed even when no rows are returned. Comprehensive tests are included for these new behaviors.

**New `.schema` metacommand and query inspection:**

* Added `Schema` struct implementing the `.schema <query>` command, which prints a query's result column names and types without executing the query. This provides a dry-run check and helps inspect query shapes efficiently. (`Sources/winmd-inspect/Shell.swift` [Sources/winmd-inspect/Shell.swiftR50-R86](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425R50-R86))
* Registered `.schema` in the shell's command list and help summary, making it available and documented for users. (`Sources/winmd-inspect/Shell.swift` [Sources/winmd-inspect/Shell.swiftL295-R339](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425L295-R339))

**Shell output improvements:**

* Refactored the shell to print column headers for empty SELECT results, preserving the query's shape even when no data is returned. This is handled in a new `lines(of:)` method, which is also testable independently. (`Sources/winmd-inspect/Shell.swift` [[1]](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425R384-R390) [[2]](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425R401-R422)

**API visibility:**

* Made the `domain` property of `ValueType` public to allow type information to be surfaced by `.schema`. (`Sources/SQL/Adapter.swift` [Sources/SQL/Adapter.swiftL56-R56](diffhunk://#diff-5e2790ab4729e595cad0e69349d0ab7aaef73c324a6a97c21588aab1ab1f017cL56-R56))

**Testing:**

* Added tests for `.schema` parsing, error handling, and output, as well as for the new behavior of header emission on empty SELECTs. (`Tests/winmd-inspectTests/DatabaseSQLTests.swift` [[1]](diffhunk://#diff-01940b6db38632bcd9ab8dc1e88be31c8a477c3deafd6b4f5eed1792fbd94784R838-R907) `Tests/winmd-inspectTests/ShellTests.swift` [[2]](diffhunk://#diff-950212843f2a33c4e49c8a7597dbbcc5a9b3e5bd72c3add6d209700590a68544R63) [[3]](diffhunk://#diff-950212843f2a33c4e49c8a7597dbbcc5a9b3e5bd72c3add6d209700590a68544R82-R92)