### PR TITLE
SQL: require Materialised column types

### DIFF
--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -219,7 +219,9 @@ extension Catalog where Self: ~Escapable {
         rows = try run(cte.query, relations, routines, bindings)
       }
       relations[cte.name.lowercased()] =
-          Materialised(columns: cte.columns, rows: rows)
+          Materialised(columns: cte.columns, rows: rows,
+                       types: Array(repeating: .integer,
+                                    count: cte.columns.count))
     }
     return try run(query, relations, routines, bindings)
   }
@@ -301,7 +303,9 @@ extension Catalog where Self: ~Escapable {
     // even when the arm is filtered to zero rows in every iteration.
     var probe = ctes
     probe[cte.name.lowercased()] =
-        Materialised(columns: cte.columns, rows: [])
+        Materialised(columns: cte.columns, rows: [],
+                     types: Array(repeating: .integer,
+                                  count: cte.columns.count))
     let arm = try compile(.select(recursive), probe).width
     guard arm == cte.columns.count else {
       throw .columns(expected: cte.columns.count, got: arm)
@@ -329,7 +333,9 @@ extension Catalog where Self: ~Escapable {
       // recursive arm against the base catalog plus the earlier CTEs.
       var scope = ctes
       scope[cte.name.lowercased()] =
-          Materialised(columns: cte.columns, rows: working)
+          Materialised(columns: cte.columns, rows: working,
+                       types: Array(repeating: .integer,
+                                    count: cte.columns.count))
       let produced =
           try run(.select(recursive), scope, routines, bindings)
 

--- a/Sources/SQL/Materialised.swift
+++ b/Sources/SQL/Materialised.swift
@@ -36,17 +36,17 @@ internal struct Materialised: Hashable, Sendable {
   /// The value type of each real column, in ordinal order — the types a
   /// materialised relation reports to the result-schema walk.
   ///
-  /// A CTE's rows carry no static types, so a call site that has none passes
-  /// `nil` and every column types `.integer` (the historical default); a
+  /// A CTE's rows carry no static types, so its call site types every column
+  /// `.integer` (the same default a view without a typed schema advertises); a
   /// DEFINITION_SCHEMA store relation, whose columns have known ISO domains,
   /// passes them so `information_schema` columns report their real types.
   internal let types: Array<ValueType>
 
   internal init(columns: Array<String>, rows: Array<Array<Value>>,
-                types: Array<ValueType>? = nil) {
+                types: Array<ValueType>) {
     self.columns = columns
     self.rows = rows
-    self.types = types ?? Array(repeating: .integer, count: columns.count)
+    self.types = types
   }
 
   /// The real column count — the extent of a `SELECT *`.


### PR DESCRIPTION
`Materialised.init` took `types` as an optional defaulting to nil, with a nil → all-`.integer` branch that let a CTE call site omit the types its rows carry no static record of. That default was a compat shim from when the CTE builders predated the typed-schema field; it hid the typing decision inside the initializer instead of at the call site that owns it.

Drop the optional and the nil-fill branch: `types` is now required. The CTE materialisation sites — the non-recursive body, the recursive width-probe, and the per-iteration working set — pass an explicit all-`.integer` array of `cte.columns.count`, the same honest default a view without a typed schema advertises, since a CTE's rows carry no static column types. The DEFINITION_SCHEMA store sites already passed their known ISO domains and are unchanged.