### PR TITLE
SQL: BLOB+BOOL Support

### DIFF
--- a/Sources/SQL/AST.swift
+++ b/Sources/SQL/AST.swift
@@ -444,6 +444,12 @@ public enum Literal: Hashable, Sendable {
   /// An approximate-numeric literal — a decimal with a `.` fraction and/or an
   /// exponent (`3.14`, `1.0`, `1e3`, `2.5e-1`), a binary64 `Double`.
   case double(Double)
+  /// A truth-valued literal — the keyword `TRUE` or `FALSE`. SQL's third truth
+  /// value UNKNOWN is spelled `NULL`, not a literal here.
+  case boolean(Bool)
+  /// A binary-string literal — a hex `x'…'` run of byte pairs, its bytes taken
+  /// verbatim.
+  case blob(Array<UInt8>)
 }
 
 /// An `ORDER BY` clause: an ordered list of sort keys, each a column and its

--- a/Sources/SQL/Filter.swift
+++ b/Sources/SQL/Filter.swift
@@ -229,6 +229,8 @@ internal func value(of literal: Literal) throws(SQLError) -> Value {
   return switch literal {
   case let .integer(integer): .integer(integer)
   case let .string(string): .text(string)
+  case let .boolean(boolean): .boolean(boolean)
+  case let .blob(bytes): .blob(bytes)
   case let .double(double) where double.isFinite: .double(double)
   // A directly-built `Literal.double` bypasses the lexer's finite check; reject
   // NaN/inf at lowering so no non-finite double reaches a plan (it would break

--- a/Sources/SQL/Lexer.swift
+++ b/Sources/SQL/Lexer.swift
@@ -143,6 +143,13 @@ internal struct Lexer: ~Escapable {
     case UInt8(ascii: ":"):
       return try parameter()
 
+    // An `x'…'`/`X'…'` binary-string literal. The `x` prefix is also an
+    // identifier lead byte, so scan a blob only when a quote follows;
+    // otherwise fall through to `identifier()` as an ordinary name.
+    case UInt8(ascii: "x"), UInt8(ascii: "X"):
+      return if peek(1) == UInt8(ascii: "'") { try blob() }
+          else { identifier() }
+
     case let b where digit(b):
       return try number()
 
@@ -260,6 +267,59 @@ internal struct Lexer: ~Escapable {
                  location: start)
   }
 
+  /// Scans a binary-string literal `x'…'`/`X'…'` at the current position.
+  ///
+  /// The `x` prefix and its opening quote are consumed; the body is a run of
+  /// hex digit pairs — each pair one byte, high nibble first — closed by a
+  /// quote. The count of digits must be even (a whole number of bytes); an
+  /// empty body `x''` is the empty blob. A non-hex digit faults where it sits,
+  /// an odd digit count faults at the close, and an unclosed body is
+  /// unterminated.
+  private mutating func blob() throws(SQLError) -> Token {
+    let start = location
+    advance()
+    advance()
+
+    var bytes = Array<UInt8>()
+    var high: UInt8? = nil
+    while let byte = peek() {
+      if byte == UInt8(ascii: "'") {
+        guard high == nil else {
+          throw .character("'", at: location)
+        }
+        advance()
+        return Token(kind: .blob(bytes), location: start)
+      }
+      guard let nibble = nibble(byte) else {
+        throw .character(Character(UnicodeScalar(byte)), at: location)
+      }
+      if let leading = high {
+        bytes.append(leading << 4 | nibble)
+        high = nil
+      } else {
+        high = nibble
+      }
+      advance()
+    }
+
+    throw .unterminated("binary literal", at: start)
+  }
+
+  /// The value of the ASCII hex digit `byte` (`0`–`9`, `a`–`f`, `A`–`F`), or
+  /// `nil` when it is not a hex digit.
+  private func nibble(_ byte: UInt8) -> UInt8? {
+    switch byte {
+    case UInt8(ascii: "0") ... UInt8(ascii: "9"):
+      byte - UInt8(ascii: "0")
+    case UInt8(ascii: "a") ... UInt8(ascii: "f"):
+      byte - UInt8(ascii: "a") + 10
+    case UInt8(ascii: "A") ... UInt8(ascii: "F"):
+      byte - UInt8(ascii: "A") + 10
+    default:
+      nil
+    }
+  }
+
   /// Scans a numeric literal at the current position — an integer or a decimal.
   ///
   /// A bare run of digits is an `integer`. A `.` fraction and/or an `e`/`E`
@@ -360,6 +420,8 @@ internal struct Lexer: ~Escapable {
     case "ALL": .all
     case "WITH": .with
     case "RECURSIVE": .recursive
+    case "TRUE": .true
+    case "FALSE": .false
     default: .identifier(text)
     }
     return Token(kind: kind, location: start)

--- a/Sources/SQL/Parser.swift
+++ b/Sources/SQL/Parser.swift
@@ -32,6 +32,8 @@
 /// additive       := multiplicative (('+' | '-') multiplicative)*
 /// multiplicative := factor (('*' | '/') factor)*
 /// factor         := '(' expression ')' | literal | aggregate | call | column
+/// literal        := string | integer | decimal | TRUE | FALSE | blob
+/// blob           := ('x' | 'X') "'" (hex hex)* "'"  // whole bytes
 /// aggregate      := COUNT '(' '*' ')'
 ///                 | (COUNT | SUM | MIN | MAX | AVG) '(' expression ')'
 /// order          := ORDER BY key (',' key)*
@@ -416,6 +418,14 @@ internal struct Parser: ~Escapable {
       _ = try advance(expecting: "a literal")
       return .literal(.double(value))
     }
+    if case let .blob(bytes) = current?.kind {
+      _ = try advance(expecting: "a literal")
+      return .literal(.blob(bytes))
+    }
+    if current?.kind == .true || current?.kind == .false {
+      let token = try advance(expecting: "a literal")
+      return .literal(.boolean(token.kind == .true))
+    }
 
     let ident = try name()
     guard try match(.lparen) else {
@@ -576,13 +586,16 @@ internal struct Parser: ~Escapable {
     }
   }
 
-  /// Parses a string, integer, or decimal literal.
+  /// Parses a string, integer, decimal, boolean, or binary literal.
   private mutating func literal() throws(SQLError) -> Literal {
     let token = try advance(expecting: "a literal")
     return switch token.kind {
     case let .string(value): .string(value)
     case let .integer(value): .integer(value)
     case let .decimal(value): .double(value)
+    case let .blob(bytes): .blob(bytes)
+    case .true: .boolean(true)
+    case .false: .boolean(false)
     default:
       throw .unexpected(token.kind.description,
                         expected: "a literal", at: token.location)

--- a/Sources/SQL/Resolve.swift
+++ b/Sources/SQL/Resolve.swift
@@ -253,6 +253,8 @@ internal struct Scope {
       case .string: .text
       case .integer: .integer
       case .double: .double
+      case .boolean: .boolean
+      case .blob: .blob
       }
     case let .call(name, arguments):
       try call(name, over: arguments, routines, validate: validate)

--- a/Sources/SQL/Token.swift
+++ b/Sources/SQL/Token.swift
@@ -45,6 +45,8 @@ extension Token {
     case all
     case with
     case recursive
+    case `true`
+    case `false`
 
     // Operands.
     case identifier(String)
@@ -57,6 +59,9 @@ extension Token {
     /// An approximate-numeric literal — a decimal with a `.` fraction and/or an
     /// exponent (`3.14`, `1.0`, `1e3`, `2.5e-1`), scanned into a `Double`.
     case decimal(Double)
+    /// A binary-string literal — an `x'…'` run of hex byte pairs, its bytes
+    /// scanned out. `x''` is the empty blob.
+    case blob(Array<UInt8>)
     /// A bound parameter placeholder `:name`, holding the parameter's name.
     case parameter(String)
 
@@ -109,11 +114,15 @@ extension Token.Kind {
     case .all: "ALL"
     case .with: "WITH"
     case .recursive: "RECURSIVE"
+    case .true: "TRUE"
+    case .false: "FALSE"
     case let .identifier(name): name
     case let .quoted(name): "\"\(name)\""
     case let .string(value): "'\(value)'"
     case let .integer(value): "\(value)"
     case let .decimal(value): "\(value)"
+    case let .blob(bytes):
+      "x'" + bytes.reduce(into: "") { $0 += Self.hex($1) } + "'"
     case let .parameter(name): ":\(name)"
     case .star: "*"
     case .plus: "+"
@@ -129,5 +138,12 @@ extension Token.Kind {
     case .leq: "<="
     case .geq: ">="
     }
+  }
+
+  /// `byte` as two lowercase-hex nibbles, high nibble first — a byte's fixed
+  /// two-digit spelling, keeping its leading zero.
+  private static func hex(_ byte: UInt8) -> String {
+    let digits = Array("0123456789abcdef")
+    return String([digits[Int(byte >> 4)], digits[Int(byte & 0x0f)]])
   }
 }

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -2732,6 +2732,33 @@ struct EngineScalarSelectTests {
     #expect(rows == [[.integer(42)]])
   }
 
+  @Test("a boolean literal lowers to its truth value")
+  func boolean() throws {
+    try people().expect("SELECT TRUE, FALSE", yields: [[true, false]])
+  }
+
+  @Test("a hex blob literal lowers to its bytes")
+  func blob() throws {
+    // The `x'53514c'` literal lexes, parses, and lowers to the three-byte
+    // blob `SQL`, projected as a `Value.blob`.
+    try people().expect("SELECT x'53514c'",
+                        yields: [[[0x53, 0x51, 0x4c] as Array<UInt8>]])
+  }
+
+  @Test("a boolean operand faults as a non-numeric type error")
+  func booleanArithmetic() throws {
+    // Neither boolean nor blob is numeric, so arithmetic over either faults
+    // exactly as text does — the type-checker rejects any non-numeric operand.
+    try people().expect("SELECT TRUE + 1",
+                        fails: .operand("operands must be numeric"))
+  }
+
+  @Test("a blob operand faults as a non-numeric type error")
+  func blobArithmetic() throws {
+    try people().expect("SELECT x'00' + 1",
+                        fails: .operand("operands must be numeric"))
+  }
+
   @Test("a NULL-yielding FROM-less expression projects NULL")
   func null() throws {
     // The bare literal NULL is not in the grammar, but a NULL arises from a

--- a/Tests/SQLTests/ParserTests.swift
+++ b/Tests/SQLTests/ParserTests.swift
@@ -394,6 +394,83 @@ struct JoinTests {
   }
 }
 
+// MARK: - Literals
+
+struct LiteralTests {
+  @Test("parses TRUE and FALSE as boolean literals")
+  func boolean() throws {
+    let yes = try parse(select: "SELECT * FROM T WHERE Sealed = TRUE")
+    #expect(yes.predicate
+                == .comparison(left: .column("Sealed"), op: .equal,
+                               right: .literal(.boolean(true))))
+    let no = try parse(select: "SELECT * FROM T WHERE Sealed = FALSE")
+    #expect(no.predicate
+                == .comparison(left: .column("Sealed"), op: .equal,
+                               right: .literal(.boolean(false))))
+  }
+
+  @Test("recognises the boolean keywords case-insensitively")
+  func booleanCase() throws {
+    let select = try parse(select: "SELECT * FROM T WHERE a = true")
+    #expect(select.predicate
+                == .comparison(left: .column("a"), op: .equal,
+                               right: .literal(.boolean(true))))
+  }
+
+  @Test("parses an x'…' hex blob literal into its bytes")
+  func blob() throws {
+    let select = try parse(select: "SELECT * FROM T WHERE Sig = x'53514c'")
+    #expect(select.predicate
+                == .comparison(left: .column("Sig"), op: .equal,
+                               right: .literal(.blob([0x53, 0x51, 0x4c]))))
+  }
+
+  @Test("parses an uppercase X'…' prefix and mixed-case hex digits")
+  func blobPrefixAndDigits() throws {
+    let select = try parse(select: "SELECT * FROM T WHERE a = X'aBcDeF'")
+    #expect(select.predicate
+                == .comparison(left: .column("a"), op: .equal,
+                               right: .literal(.blob([0xab, 0xcd, 0xef]))))
+  }
+
+  @Test("parses an empty blob x''")
+  func emptyBlob() throws {
+    let select = try parse(select: "SELECT * FROM T WHERE a = x''")
+    #expect(select.predicate
+                == .comparison(left: .column("a"), op: .equal,
+                               right: .literal(.blob([]))))
+  }
+
+  @Test("a bare x is an ordinary identifier, not a blob prefix")
+  func bareX() throws {
+    // The `x` prefix opens a blob only when a quote follows; alone it is a
+    // column name.
+    let select = try parse(select: "SELECT x FROM T")
+    #expect(select.projection == .columns(["x"]))
+  }
+
+  @Test("rejects a blob with an odd hex digit count")
+  func oddBlob() {
+    #expect(throws: SQLError.self) {
+      _ = try Statement(parsing: "SELECT * FROM T WHERE a = x'abc'")
+    }
+  }
+
+  @Test("rejects a blob with a non-hex digit")
+  func nonHexBlob() {
+    #expect(throws: SQLError.self) {
+      _ = try Statement(parsing: "SELECT * FROM T WHERE a = x'gg'")
+    }
+  }
+
+  @Test("rejects an unterminated blob")
+  func unterminatedBlob() {
+    #expect(throws: SQLError.self) {
+      _ = try Statement(parsing: "SELECT * FROM T WHERE a = x'abcd")
+    }
+  }
+}
+
 struct ErrorTests {
   @Test("rejects a query missing FROM")
   func missingFrom() {


### PR DESCRIPTION
This pull request extends SQL literal support in the parser and engine by adding boolean (`TRUE`, `FALSE`) and binary blob (`x'…'`) literals. It updates the lexer, parser, AST, and value lowering to recognize and handle these new literal types, and adds comprehensive tests for both valid and invalid cases.

**Literal support enhancements:**

* Added support for boolean literals (`TRUE`, `FALSE`) throughout the lexer, parser, AST (`Literal.boolean`), and value lowering, including case-insensitive recognition and SQL spelling. [[1]](diffhunk://#diff-44ae278469f8cb8537a5e8997ce917320e10f66a7fb199bcf35bc353ab154f08R447-R452) [[2]](diffhunk://#diff-6c11b53db7442865204eb0deb0f35640964bb2e9f54779311e62ae0b206f19d2R421-R428) [[3]](diffhunk://#diff-6c11b53db7442865204eb0deb0f35640964bb2e9f54779311e62ae0b206f19d2L579-R598) [[4]](diffhunk://#diff-06b3d42404e969aa3130f5ee2ea5119b8d2d9c7fdb970a2b4abb78148636e451R256-R257) [[5]](diffhunk://#diff-6bee202b401e2acfe37621d278f23fdbf5efbea53383a92e7057b79b73efcfedR48-R49) [[6]](diffhunk://#diff-6bee202b401e2acfe37621d278f23fdbf5efbea53383a92e7057b79b73efcfedR117-R125) [[7]](diffhunk://#diff-3a41d2f1d12fb42c8cf94decbe20e627053820a0d629708ea2b1ec942a3c087fR423-R424) [[8]](diffhunk://#diff-66f69cc14663ff59f1854b7179f51accad89aa0a7e6731e6880d344908ac4facR232-R233)
* Added support for binary blob literals (`x'…'` or `X'…'`) including lexing, parsing, AST representation (`Literal.blob`), value lowering, and SQL spelling as hex. Handles empty blobs and validates hex digit pairs. [[1]](diffhunk://#diff-44ae278469f8cb8537a5e8997ce917320e10f66a7fb199bcf35bc353ab154f08R447-R452) [[2]](diffhunk://#diff-6c11b53db7442865204eb0deb0f35640964bb2e9f54779311e62ae0b206f19d2R421-R428) [[3]](diffhunk://#diff-6c11b53db7442865204eb0deb0f35640964bb2e9f54779311e62ae0b206f19d2L579-R598) [[4]](diffhunk://#diff-06b3d42404e969aa3130f5ee2ea5119b8d2d9c7fdb970a2b4abb78148636e451R256-R257) [[5]](diffhunk://#diff-6bee202b401e2acfe37621d278f23fdbf5efbea53383a92e7057b79b73efcfedR62-R64) [[6]](diffhunk://#diff-6bee202b401e2acfe37621d278f23fdbf5efbea53383a92e7057b79b73efcfedR117-R125) [[7]](diffhunk://#diff-6bee202b401e2acfe37621d278f23fdbf5efbea53383a92e7057b79b73efcfedR142-R148) [[8]](diffhunk://#diff-3a41d2f1d12fb42c8cf94decbe20e627053820a0d629708ea2b1ec942a3c087fR146-R152) [[9]](diffhunk://#diff-3a41d2f1d12fb42c8cf94decbe20e627053820a0d629708ea2b1ec942a3c087fR270-R322) [[10]](diffhunk://#diff-66f69cc14663ff59f1854b7179f51accad89aa0a7e6731e6880d344908ac4facR232-R233)

**Lexer and parser updates:**

* Updated the grammar and parser logic to recognize boolean and blob literals as valid expressions, and to distinguish a bare `x` as an identifier unless immediately followed by a quote. [[1]](diffhunk://#diff-6c11b53db7442865204eb0deb0f35640964bb2e9f54779311e62ae0b206f19d2R35-R36) [[2]](diffhunk://#diff-6c11b53db7442865204eb0deb0f35640964bb2e9f54779311e62ae0b206f19d2R421-R428) [[3]](diffhunk://#diff-6c11b53db7442865204eb0deb0f35640964bb2e9f54779311e62ae0b206f19d2L579-R598) [[4]](diffhunk://#diff-3a41d2f1d12fb42c8cf94decbe20e627053820a0d629708ea2b1ec942a3c087fR146-R152)

**Testing improvements:**

* Added thorough tests for boolean and blob literal parsing, lowering, and error handling (odd digit count, non-hex digit, unterminated blob), as well as for case-insensitive keywords and correct rejection in arithmetic contexts. [[1]](diffhunk://#diff-e8174e88eb2a0c88c2b70fa00f7eb5e2a81461462b190ccadef1bfc5ad2a18b2R2735-R2761) [[2]](diffhunk://#diff-fd576ece59b68395579c921741bd2154ece42673cbdbfbb7822d91ae9992b325R397-R473)

These changes ensure the SQL engine now fully supports boolean and hex blob literals with robust parsing, lowering, and error reporting.