### PR TITLE
SQL: support `DISTINCT`

### DIFF
--- a/Sources/SQL/AST.swift
+++ b/Sources/SQL/AST.swift
@@ -101,6 +101,11 @@ public indirect enum Query: Hashable, Sendable {
 /// expand — nor a bare-column reference; only literals, calls, and arithmetic
 /// over them resolve against the empty row.
 public struct Select: Hashable, Sendable {
+  /// Whether `SELECT DISTINCT` was written — the result rows are deduplicated,
+  /// the first occurrence of each distinct row kept. `false` for the default
+  /// `SELECT` (equivalently the explicit `SELECT ALL`), which keeps every row.
+  public let distinct: Bool
+
   /// The columns the query yields.
   public let projection: Projection
 
@@ -134,10 +139,12 @@ public struct Select: Hashable, Sendable {
   /// The row limit applied to the (ordered) result, if any.
   public let limit: Limit?
 
-  public init(projection: Projection, from: Relation?,
-              joins: Array<Join> = [], predicate: Predicate? = nil,
-              grouping: Array<Column> = [], having: Predicate? = nil,
-              order: Order? = nil, limit: Limit? = nil) {
+  public init(distinct: Bool = false, projection: Projection,
+              from: Relation?, joins: Array<Join> = [],
+              predicate: Predicate? = nil, grouping: Array<Column> = [],
+              having: Predicate? = nil, order: Order? = nil,
+              limit: Limit? = nil) {
+    self.distinct = distinct
     self.projection = projection
     self.from = from
     self.joins = joins

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -413,20 +413,57 @@ extension Engine {
     }
     return slot
   }
+
+  /// Rejects an `ORDER BY` key naming a column outside the `DISTINCT` output.
+  ///
+  /// `SELECT DISTINCT` sorts the pre-projection rows then dedups the projected
+  /// ones, so ordering on a column the projection drops is ill-defined — after
+  /// dedup one output row stands for many source rows, whose differing sort-key
+  /// values leave no single order. The standard therefore requires every
+  /// `ORDER BY` key under `DISTINCT` to be a column of the select list, as the
+  /// grouped path requires for `GROUP BY`. Each resolved order key's ordinal
+  /// (`order`, paired index-for-index with the AST `keys` for the offending
+  /// name) must equal a projected term that is a bare `.slot` — a plain output
+  /// column; a computed projection is not orderable-on anyway. A key naming no
+  /// output column faults `SQLError.distinct`. Only a `distinct` query is
+  /// checked; a plain `SELECT` may order on any source column.
+  ///
+  /// The check runs in whatever slot space the caller resolved into: the
+  /// non-aggregate paths pass base ordinals, the grouped path passes grouped
+  /// slots. Both are consistent — `order` and `projection` share it — so the
+  /// one comparison serves every compile path.
+  internal static func distinct(
+      _ keys: Array<Order.Key>, _ order: Array<Int>,
+      _ projection: Array<Term>) throws(SQLError) {
+    var output = Set<Int>()
+    for term in projection {
+      if case let .slot(ordinal) = term { output.insert(ordinal) }
+    }
+    for index in order.indices where !output.contains(order[index]) {
+      throw .distinct(keys[index].column.name)
+    }
+  }
 }
 
 extension Plan {
-  /// This source plan wrapped in the `Project(Limit(Sort(Select(_))))`
-  /// operators, omitting each layer when its clause is absent. The
-  /// `projection`, `filter`, and `order` keys are in slot space; an empty
-  /// `order` omits the sort.
+  /// This source plan wrapped in the projection/limit/sort/select operators,
+  /// omitting each layer when its clause is absent. The `projection`, `filter`,
+  /// and `order` keys are in slot space; an empty `order` omits the sort.
   ///
-  /// The row `limit` sits BELOW the projection — after `WHERE` and `ORDER BY`,
-  /// but before the select list is evaluated. A row outside the requested page
-  /// is dropped by the limit before its projection runs, so a projection that
+  /// Without `distinct` the shape is `Project(Limit(Sort(Select(_))))`: the row
+  /// `limit` sits BELOW the projection — after `WHERE` and `ORDER BY`, but
+  /// before the select list is evaluated. A row outside the requested page is
+  /// dropped by the limit before its projection runs, so a projection that
   /// could throw (`SELECT 1 / 0 … FETCH FIRST 0 ROWS ONLY`) never evaluates for
   /// a discarded row and the query returns the documented empty page.
-  internal func shaped(projection: Array<Term>, filter: Filter?,
+  ///
+  /// With `distinct` (`SELECT DISTINCT`) the dedup runs on the projected rows —
+  /// after `ORDER BY`, before `OFFSET`/`FETCH` (the ISO order) — so the shape
+  /// is `Limit(Distinct(Project(Sort(Select(_)))))`: the projection loses its
+  /// cap (every candidate row must be projected to dedup it), the `distinct`
+  /// dedups the projected rows, and the `limit` pages the deduplicated result.
+  internal func shaped(distinct: Bool = false, projection: Array<Term>,
+                       filter: Filter?,
                        order: Array<(slot: Int, ascending: Bool)>,
                        limit: Limit?) -> Plan {
     var plan = self
@@ -436,7 +473,10 @@ extension Plan {
     if !order.isEmpty {
       plan = .sort(keys: order, plan)
     }
-    return .project(projection, plan.capped(limit: limit))
+    guard distinct else {
+      return .project(projection, plan.capped(limit: limit))
+    }
+    return Plan.distinct(.project(projection, plan)).capped(limit: limit)
   }
 }
 
@@ -600,6 +640,14 @@ extension Catalog where Self: ~Escapable {
       Array<(slot: Int, ascending: Bool)>()
     }
 
+    // Under DISTINCT every ORDER BY key must be a select-list column — the
+    // dedup runs on the projected rows, so ordering on a dropped column is
+    // ill-defined (see `Engine.distinct`). The order keys and projection are
+    // in grouped-slot space here, aligned with the AST keys index-for-index.
+    if select.distinct, let clause = select.order {
+      try Engine.distinct(clause.keys, order.map(\.slot), projection)
+    }
+
     var plan = node
     if let having {
       plan = .select(having, plan)
@@ -607,7 +655,10 @@ extension Catalog where Self: ~Escapable {
     if !order.isEmpty {
       plan = .sort(keys: order, plan)
     }
-    return .project(projection, plan.capped(limit: select.limit))
+    guard select.distinct else {
+      return .project(projection, plan.capped(limit: select.limit))
+    }
+    return Plan.distinct(.project(projection, plan)).capped(limit: select.limit)
   }
 }
 
@@ -752,6 +803,10 @@ extension Catalog where Self: ~Escapable {
       // preserving this node's own `all`.
       try .union(optimise(left, ctes, bindings),
                  optimise(right, ctes, bindings), all: all)
+    case let .distinct(source):
+      // A `distinct` dedups its source without a seek or join of its own;
+      // optimise the source below it and rewrap.
+      try .distinct(optimise(source, ctes, bindings))
     case let .aggregate(keys, aggregates, source):
       // An aggregate reshapes its source and has no seek or join of its own;
       // optimise its source (the WHERE/join chain below it seeks and nests as
@@ -1054,6 +1109,12 @@ extension Plan {
       try .product(left.pushdown(), right.pushdown())
     case let .union(left, right, all):
       try .union(left.pushdown(), right.pushdown(), all: all)
+    case let .distinct(source):
+      // A `distinct` sits above the projection, so no `WHERE` conjunct reaches
+      // it to push down; it recurses transparently. A filter must never cross a
+      // dedup — filtering before or after it yields different rows — and none
+      // can, since it sits above the projection like the cap.
+      try .distinct(source.pushdown())
     case let .aggregate(keys, aggregates, source):
       // An aggregate reshapes rows into a fresh grouped slot space, so it is a
       // pushdown barrier: a `HAVING`/projection filter above it is in grouped
@@ -1509,11 +1570,20 @@ extension Catalog where Self: ~Escapable {
       let projection =
           try from.schema.terms(select.projection, in: relation)
 
+      // Under DISTINCT every ORDER BY key must be a select-list column — the
+      // dedup runs on the projected rows, so ordering on a dropped column is
+      // ill-defined (see `Engine.distinct`). The order keys and projection are
+      // still in base-ordinal space here, aligned with the AST keys by index.
+      if select.distinct, let clause = select.order {
+        try Engine.distinct(clause.keys, order.map(\.column), projection)
+      }
+
       // The referenced ordinals, in slot order: slot `i` is `ordinals[i]`.
       let ordinals = Engine.referenced(projection, filter, order)
       let slot = Engine.invert(ordinals)
       let scan = from.leaf(ordinals)
       return scan.shaped(
+          distinct: select.distinct,
           projection: projection.map { $0.remapped(through: slot) },
           filter: filter.map { $0.remapped(through: slot) },
           order: order.map { (slot[$0.column]!, $0.ascending) },
@@ -1562,6 +1632,13 @@ extension Catalog where Self: ~Escapable {
     }
     let projection = try scope.terms(select.projection)
 
+    // Under DISTINCT every ORDER BY key must be a select-list column (see
+    // `Engine.distinct`); order keys and projection are in combined base-ordinal
+    // space here, aligned with the AST keys index-for-index.
+    if select.distinct, let clause = select.order {
+      try Engine.distinct(clause.keys, order.map(\.column), projection)
+    }
+
     // The combined referenced ordinals — projection ∪ every match ∪ WHERE ∪
     // order — packed per relation in chain order: relation i's referenced
     // ordinals take a contiguous slot run after every earlier relation's,
@@ -1598,6 +1675,7 @@ extension Catalog where Self: ~Escapable {
     }
 
     return chain.shaped(
+        distinct: select.distinct,
         projection: projection.map { $0.remapped(through: slot) },
         filter: predicate.map { $0.remapped(through: slot) },
         order: order.map { (slot[$0.column]!, $0.ascending) },

--- a/Sources/SQL/Error.swift
+++ b/Sources/SQL/Error.swift
@@ -120,6 +120,11 @@ public enum SQLError: Error, Hashable, Sendable {
   /// requires every non-aggregated column to appear in the `GROUP BY`. The
   /// string is the offending column's name.
   case grouping(String)
+  /// A `SELECT DISTINCT` orders on a column absent from its select list — the
+  /// dedup runs on the projected rows, so ordering on a dropped column is
+  /// ill-defined; the standard requires every `ORDER BY` key under `DISTINCT`
+  /// to be an output column. The string is the offending column's name.
+  case distinct(String)
 }
 
 extension SQLError: CustomStringConvertible {
@@ -176,6 +181,8 @@ extension SQLError: CustomStringConvertible {
     case let .grouping(name):
       "column '\(name)' must appear in the GROUP BY clause "
           + "or be used in an aggregate function"
+    case let .distinct(name):
+      "ORDER BY column '\(name)' must appear in the SELECT DISTINCT list"
     }
   }
 }
@@ -209,10 +216,11 @@ extension SQLError {
   ///   shape the engine does not support (a FROM-less `SELECT *`, or a clause
   ///   with no `FROM`), `SS002`, a statement that is not runnable as a query
   ///   (a `CREATE VIEW`, or a malformed `WITH` member), `SS003`, a recursive
-  ///   CTE that did not reach a fixpoint within the iteration cap, and `SS004`,
-  ///   an aggregate query naming a non-aggregated column absent from the `GROUP
-  ///   BY`. ISO leaves classes whose first character is `5`–`9` or `I`–`Z`
-  ///   implementation-defined, so `SS` is a safe squat.
+  ///   CTE that did not reach a fixpoint within the iteration cap, `SS004`, an
+  ///   aggregate query naming a non-aggregated column absent from the `GROUP
+  ///   BY`, and `SS005`, a `SELECT DISTINCT` ordering on a column absent from
+  ///   its select list. ISO leaves classes whose first character is `5`–`9` or
+  ///   `I`–`Z` implementation-defined, so `SS` is a safe squat.
   public var sqlstate: String {
     switch self {
     case let .state(code, _):
@@ -253,6 +261,8 @@ extension SQLError {
       "SS003"
     case .grouping:
       "SS004"
+    case .distinct:
+      "SS005"
     }
   }
 

--- a/Sources/SQL/Lexer.swift
+++ b/Sources/SQL/Lexer.swift
@@ -395,6 +395,7 @@ internal struct Lexer: ~Escapable {
     case "CREATE": .create
     case "VIEW": .view
     case "SELECT": .select
+    case "DISTINCT": .distinct
     case "FROM": .from
     case "WHERE": .where
     case "ORDER": .order

--- a/Sources/SQL/Operator.swift
+++ b/Sources/SQL/Operator.swift
@@ -148,6 +148,12 @@ internal indirect enum Plan {
   /// appends the trailing arm. Both sides yield rows of the same width — the
   /// result columns of the first arm.
   case union(Plan, Plan, all: Bool)
+  /// δ — deduplicates its `source`'s rows, keeping the first occurrence of each
+  /// distinct whole row and preserving their order (`SELECT DISTINCT`). It sits
+  /// above the projection, so it dedups the projected output rows on the SAME
+  /// whole-row key `UNION` uses (`Value` is `Hashable`). The plain `SELECT`
+  /// (equivalently `SELECT ALL`) omits it.
+  case distinct(Plan)
   /// Γ — groups its `source`'s records by the `keys` terms and folds each
   /// `aggregates` accumulator over every record of a group, yielding one grouped
   /// record per group. The grouped record's slots are the `keys` values (slots
@@ -182,6 +188,10 @@ extension Plan {
       terms.count
     case let .union(left, _, _):
       left.width
+    case let .distinct(source):
+      // A `distinct` dedups rows without reshaping them, so it is as wide as
+      // its source.
+      source.width
     case let .limit(_, _, source):
       // A `limit` caps rows without reshaping them, so it is as wide as its
       // source.
@@ -230,6 +240,10 @@ extension Plan {
       // Both sides yield rows of the same width — the result columns — so the
       // union's width is its left side's.
       left.slots
+    case let .distinct(source):
+      // A `distinct` dedups rows without reshaping them, so it spans the same
+      // slots as its source.
+      source.slots
     case let .limit(_, _, source):
       // A `limit` caps rows without reshaping them, so it spans the same slots
       // as its source.
@@ -265,7 +279,8 @@ extension Plan {
 /// outer record with every inner one; `join` re-resolves the inner relation,
 /// seeks it per outer record, and concatenates the matches; `union` runs its
 /// two sides — each with its own union semantics — and concatenates their rows,
-/// deduplicating the whole row unless `all`; `limit` skips the first `offset` of
+/// deduplicating the whole row unless `all`; `distinct` deduplicates its
+/// source's whole rows (`SELECT DISTINCT`); `limit` skips the first `offset` of
 /// its source's rows then takes at most `count`.
 /// The catalog is borrowed throughout — a `~Escapable` source is never copied
 /// or stored.
@@ -322,6 +337,8 @@ internal func execute<C: Catalog & ~Escapable>(_ plan: Plan,
              base, column, keys, filter, catalog, ctes, routines, bindings)
   case let .union(left, right, all):
     try union(left, right, all, catalog, ctes, routines, bindings)
+  case let .distinct(source):
+    deduplicated(try execute(source, catalog, ctes, routines, bindings))
   case let .aggregate(keys, aggregates, source):
     try grouped(execute(source, catalog, ctes, routines, bindings), keys,
                 aggregates, routines)
@@ -366,14 +383,22 @@ private func union<C: Catalog & ~Escapable>(_ left: Plan, _ right: Plan,
     throws(SQLError) -> Array<Record> {
   let rows = try execute(left, catalog, ctes, routines, bindings)
       + execute(right, catalog, ctes, routines, bindings)
-  guard !all else { return rows }
+  return all ? rows : deduplicated(rows)
+}
 
-  var records = Array<Record>()
+/// The rows of `records` with whole-row duplicates removed — the first
+/// occurrence of each distinct row kept and their order preserved.
+///
+/// A `Record` is `Hashable`, so the dedup keys on the materialised row's values
+/// through the `Seen` set — the SAME whole-row equality `UNION` uses. It backs
+/// both a bare `UNION` and `SELECT DISTINCT`.
+private func deduplicated(_ records: Array<Record>) -> Array<Record> {
+  var rows = Array<Record>()
   var seen = Seen()
-  for record in rows where seen.insert(record.values) {
-    records.append(record)
+  for record in records where seen.insert(record.values) {
+    rows.append(record)
   }
-  return records
+  return rows
 }
 
 /// Evaluates each projected `term` against `record` through `routines` to the

--- a/Sources/SQL/OutputColumn.swift
+++ b/Sources/SQL/OutputColumn.swift
@@ -209,10 +209,16 @@ extension Catalog where Self: ~Escapable {
             if try scope.empty(having, routines) != true { return }
           }
           // The lone empty group is itself unreachable when a limit drops the
-          // one row it would emit — a zero `FETCH` or any positive `OFFSET` — so
-          // the projection never evaluates over it.
-          if !drops(select.limit, single: true),
-              case let .expressions(items) = select.projection {
+          // one row it would emit — a zero `FETCH` or any positive `OFFSET`. A
+          // DISTINCT select is the exception: its plan is
+          // `Limit(Distinct(Project(…)))`, so the projection evaluates over the
+          // empty group's row (dedup needs it) BEFORE the cap pages the
+          // deduplicated result — a zero FETCH or skipping OFFSET does not
+          // spare it, mirroring the main projection path below. (`||` with a
+          // `borrowing self` autoclosure needs the two-statement form.)
+          var reachable = select.distinct
+          if !reachable { reachable = !drops(select.limit, single: true) }
+          if reachable, case let .expressions(items) = select.projection {
             for item in items { _ = try scope.empty(item.expression, routines) }
           }
         }
@@ -234,10 +240,16 @@ extension Catalog where Self: ~Escapable {
     // The projection runs after any limit: a limit that drops every row it
     // would yield leaves only its aggregate folds (validated above) reachable.
     // A whole-result aggregate emits exactly ONE row, so a positive OFFSET
-    // drops it too — not just a zero FETCH.
+    // drops it too — not just a zero FETCH. A DISTINCT select is the exception:
+    // its plan is `Limit(Distinct(Project(…)))`, so the projection evaluates
+    // over EVERY candidate row (dedup needs them) BEFORE the cap pages the
+    // deduplicated result — a zero FETCH or skipping OFFSET does not spare it.
+    // A false WHERE still yields no rows to dedup (handled above), so only the
+    // limit-based elision is bypassed for DISTINCT.
     let sole = select.aggregates && select.grouping.isEmpty
-    if !drops(select.limit, single: sole),
-        case let .expressions(items) = select.projection {
+    var reachable = select.distinct
+    if !reachable { reachable = !drops(select.limit, single: sole) }
+    if reachable, case let .expressions(items) = select.projection {
       for item in items { _ = try scope.type(of: item.expression, routines) }
     }
   }

--- a/Sources/SQL/Parser.swift
+++ b/Sources/SQL/Parser.swift
@@ -13,7 +13,7 @@
 /// cte            := identifier ['(' identifier (',' identifier)* ')']
 ///                   AS '(' query ')'
 /// query          := select (UNION [ALL] select)*
-/// select         := SELECT projection
+/// select         := SELECT [DISTINCT | ALL] projection
 ///                   [FROM relation (join)*
 ///                    [where] [group] [having] [order] [limit]]
 /// relation       := identifier [AS identifier]
@@ -225,9 +225,13 @@ internal struct Parser: ~Escapable {
   /// admits no relation, joins, `WHERE`, `ORDER BY`, or `LIMIT` to follow.
   private mutating func select() throws(SQLError) -> Select {
     try expect(.select)
+    // An optional set quantifier: `DISTINCT` deduplicates the result rows;
+    // `ALL` (the default when neither is written) keeps every row.
+    let distinct = try match(.distinct)
+    if !distinct { _ = try match(.all) }
     let projection = try projection()
     guard try match(.from) else {
-      return Select(projection: projection, from: nil)
+      return Select(distinct: distinct, projection: projection, from: nil)
     }
     let from = try relation()
 
@@ -253,9 +257,9 @@ internal struct Parser: ~Escapable {
     }
     let limit = try rowLimit()
 
-    return Select(projection: projection, from: from, joins: joins,
-                  predicate: predicate, grouping: grouping, having: having,
-                  order: order, limit: limit)
+    return Select(distinct: distinct, projection: projection, from: from,
+                  joins: joins, predicate: predicate, grouping: grouping,
+                  having: having, order: order, limit: limit)
   }
 
   /// Parses `BY column (, column)*` (the `GROUP` keyword is already consumed) —

--- a/Sources/SQL/Token.swift
+++ b/Sources/SQL/Token.swift
@@ -20,6 +20,7 @@ extension Token {
     case create
     case view
     case select
+    case distinct
     case from
     case `where`
     case order
@@ -89,6 +90,7 @@ extension Token.Kind {
     case .create: "CREATE"
     case .view: "VIEW"
     case .select: "SELECT"
+    case .distinct: "DISTINCT"
     case .from: "FROM"
     case .where: "WHERE"
     case .order: "ORDER"

--- a/Sources/winmd-inspect/Inspect.swift
+++ b/Sources/winmd-inspect/Inspect.swift
@@ -4,6 +4,7 @@
 internal import struct Foundation.Data
 
 internal import ArgumentParser
+internal import SQL
 internal import WinMD
 
 struct Dump: ParsableCommand {
@@ -47,20 +48,31 @@ struct PrintNamespaces: ParsableCommand {
   var options: InspectOptions
 
   func run() throws {
+    // The caller owns the mapping; it must outlive the database, which is a
+    // borrowed view over it.
     let data = try Data(contentsOf: options.database.url,
                         options: .alwaysMapped)
     let database = try Database(data.span.bytes)
+    // Zero namespaces must yield zero lines, not one blank line, so scripts
+    // reading a namespace per line never see a spurious empty entry.
+    let out = try PrintNamespaces.namespaces(database.storage)
+    if !out.isEmpty { print(out) }
+  }
 
-    var namespaces = Set<String>()
-    let rows = try database.rows(of: Metadata.Tables.TypeDef.self)
-    for i in 0 ..< rows.count {
-      let row = rows[i]!
-      namespaces.insert(row.TypeNamespace)
-    }
-
-    for namespace in namespaces.sorted() {
-      print(namespace)
-    }
+  /// The database's distinct namespaces as a plain one-per-line list, ascending
+  /// — a `SELECT DISTINCT … ORDER BY` deduplicates and sorts them, the engine's
+  /// own dedup replacing the hand-rolled `Set` + `sorted()`.
+  ///
+  /// The result is a plain namespace-per-line list scripts parse, NOT the boxed
+  /// table `Shell.execute` frames a row result as (borders and a `TypeNamespace`
+  /// header): each row's single cell prints on its own line, unframed, so this
+  /// runs the DISTINCT query directly rather than through the shell.
+  internal static func namespaces(_ storage: borrowing WinMD.Storage)
+      throws -> String {
+    var session = Session(storage)
+    let rows = try session.run(
+        "SELECT DISTINCT TypeNamespace FROM TypeDef ORDER BY TypeNamespace")
+    return rows.map { $0[0].display }.joined(separator: "\n")
   }
 }
 

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -1040,6 +1040,8 @@ private func derived(_ plan: Plan) -> Plan? {
     derived(left) ?? derived(right)
   case let .limit(_, _, source):
     derived(source)
+  case let .distinct(source):
+    derived(source)
   case let .aggregate(_, _, source):
     derived(source)
   case .single, .scan, .join:
@@ -1070,6 +1072,8 @@ private func seeks(_ plan: Plan) -> Bool {
     seeks(left) || seeks(right)
   case let .limit(_, _, source):
     seeks(source)
+  case let .distinct(source):
+    seeks(source)
   case let .aggregate(_, _, source):
     seeks(source)
   case .single:
@@ -1096,6 +1100,8 @@ private func filters(_ plan: Plan) -> Bool {
   case let .union(left, right, _):
     filters(left) || filters(right)
   case let .limit(_, _, source):
+    filters(source)
+  case let .distinct(source):
     filters(source)
   case let .aggregate(_, _, source):
     filters(source)
@@ -1126,6 +1132,8 @@ private func pushed(_ plan: Plan) -> Bool {
   case let .union(left, right, _):
     pushed(left) || pushed(right)
   case let .limit(_, _, source):
+    pushed(source)
+  case let .distinct(source):
     pushed(source)
   case let .aggregate(_, _, source):
     pushed(source)
@@ -1167,6 +1175,8 @@ private func joins(_ plan: Plan) -> Bool {
     joins(source)
   case let .limit(_, _, source):
     joins(source)
+  case let .distinct(source):
+    joins(source)
   case let .derived(_, sub, _, _):
     joins(sub)
   case let .product(left, right):
@@ -1194,6 +1204,8 @@ private func residual(_ plan: Plan) -> Bool {
   case let .sort(_, source):
     residual(source)
   case let .limit(_, _, source):
+    residual(source)
+  case let .distinct(source):
     residual(source)
   case let .derived(_, sub, _, _):
     residual(sub)
@@ -1304,6 +1316,8 @@ private func injected(_ plan: Plan) -> Bool {
   case let .sort(_, source):
     injected(source)
   case let .limit(_, _, source):
+    injected(source)
+  case let .distinct(source):
     injected(source)
   case let .derived(_, sub, _, _):
     injected(sub)
@@ -2588,6 +2602,147 @@ struct EngineUnionTests {
       [.text("Ann")],
       [.text("Amy")],
     ])
+  }
+}
+
+// MARK: - DISTINCT tests
+
+struct EngineDistinctTests {
+  @Test("DISTINCT removes duplicate rows, keeping the first occurrence")
+  func dedup() throws {
+    // People's Age repeats (30 for Alice and Carol, 25 for Bob and Eve);
+    // DISTINCT collapses each duplicate to its first appearance, in row order.
+    try people().expect("SELECT DISTINCT Age FROM People",
+                        yields: [[30], [25], [40]])
+  }
+
+  @Test("a plain SELECT keeps every duplicate row")
+  func all() throws {
+    try people().expect("SELECT Age FROM People",
+                        yields: [[30], [25], [30], [40], [25]])
+  }
+
+  @Test("SELECT ALL is the plain, non-deduplicating select")
+  func explicitAll() throws {
+    try people().expect("SELECT ALL Age FROM People",
+                        yields: [[30], [25], [30], [40], [25]])
+  }
+
+  @Test("DISTINCT dedups on the whole projected row, not one column")
+  func multipleColumns() throws {
+    // Grade's (Class, Score) pairs repeat — (A, 80) three times, (B, 90)
+    // twice — while a single column would over-collapse. DISTINCT keeps one of
+    // each distinct pair, first occurrence in row order.
+    try grades().expect("SELECT DISTINCT Class, Score FROM Grade",
+                        yields: [["B", 90], ["A", 80], ["A", 70]])
+  }
+
+  @Test("DISTINCT dedups rows a projection maps together")
+  func projected() throws {
+    // Bob (25) and Eve (25), Alice (30) and Carol (30) share an Age; projecting
+    // Age alone collapses each pair even though their other columns differ.
+    try people().expect("SELECT DISTINCT Age FROM People WHERE Age < 40",
+                        yields: [[30], [25]])
+  }
+
+  @Test("DISTINCT binds to its own arm within a UNION ALL")
+  func overUnionArm() throws {
+    // DISTINCT is a per-SELECT quantifier: it dedups the LEFT arm alone (its
+    // repeated Ages collapse to 30, 25, 40), then the UNION ALL appends the
+    // right arm's rows without deduplicating across the arms.
+    try people().expect("""
+        SELECT DISTINCT Age FROM People
+          UNION ALL SELECT Age FROM People WHERE Id = 1
+        """, yields: [[30], [25], [40], [30]])
+  }
+
+  @Test("DISTINCT combines with ORDER BY, ordering the deduplicated rows")
+  func ordered() throws {
+    // The distinct Ages, then ascending: dedup keeps 30, 25, 40; ORDER BY sorts
+    // them 25, 30, 40.
+    try people().expect("SELECT DISTINCT Age FROM People ORDER BY Age",
+                        yields: [[25], [30], [40]])
+  }
+
+  @Test("DISTINCT dedups before OFFSET/FETCH pages the result")
+  func paged() throws {
+    // Three distinct Ages ordered 25, 30, 40; FETCH FIRST 2 pages the
+    // deduplicated, ordered rows — proving the cap sits above the dedup.
+    try people().expect("""
+        SELECT DISTINCT Age FROM People ORDER BY Age FETCH FIRST 2 ROWS ONLY
+        """, yields: [[25], [30]])
+  }
+
+  @Test("DISTINCT over an aggregate dedups the grouped rows")
+  func aggregate() throws {
+    // Grouping People by Age yields one row per distinct Age (25, 30, 40), each
+    // with its COUNT; projecting only the COUNT leaves 2, 2, 1 — DISTINCT then
+    // collapses the two 2s to one.
+    try people().expect("""
+        SELECT DISTINCT COUNT(*) FROM People GROUP BY Age
+        """, yields: [[2], [1]])
+  }
+
+  @Test("a view defined with DISTINCT deduplicates when queried")
+  func view() throws {
+    let ages = try View(query: select("SELECT DISTINCT Age FROM People"),
+                        columns: ["Age"])
+    let catalog = Memory(try people().catalog, views: ["Ages": ages])
+    try catalog.expect("SELECT Age FROM Ages", yields: [[30], [25], [40]])
+  }
+
+  @Test("DISTINCT ordering on a non-projected column faults")
+  func hiddenOrderKey() throws {
+    // Name is not in the DISTINCT output, so after dedup each Age stands for
+    // several Names — the order is ill-defined; the standard rejects it.
+    try people().expect("SELECT DISTINCT Age FROM People ORDER BY Name",
+                        fails: .distinct("Name"))
+  }
+
+  @Test("DISTINCT ordering on a projected column pages correctly")
+  func projectedOrderKey() throws {
+    // Age is a select-list column, so ordering (and paging) on it is well
+    // defined: the deduplicated Ages sort 25, 30, 40, and OFFSET 1 drops the
+    // first.
+    try people().expect("""
+        SELECT DISTINCT Age FROM People ORDER BY Age
+          OFFSET 1 ROWS FETCH FIRST 2 ROWS ONLY
+        """, yields: [[30], [40]])
+  }
+
+  @Test("DISTINCT over a join rejects a hidden ORDER BY key")
+  func hiddenJoinOrderKey() throws {
+    // Child.Name is not projected, so ordering the deduplicated Parent.Name
+    // rows on it is ill-defined across the two joined relations.
+    try family().expect("""
+        SELECT DISTINCT Parent.Name FROM Parent
+          JOIN Child ON Child.Pid = Parent.Id ORDER BY Child.Name
+        """, fails: .distinct("Name"))
+  }
+
+  @Test("SS005 is the DISTINCT ORDER BY SQLSTATE")
+  func sqlstate() {
+    #expect(SQLError.distinct("Name").sqlstate == "SS005")
+  }
+
+  @Test("grouped DISTINCT rejects ordering on a non-output GROUP BY key")
+  func hiddenGroupedOrderKey() throws {
+    // The output is only COUNT(*); Age is the grouping key but not projected,
+    // so ordering (and paging) on it after dedup is ill-defined — the same rule
+    // the non-aggregate path enforces, in grouped-slot space.
+    try people().expect("""
+        SELECT DISTINCT COUNT(*) FROM People GROUP BY Age ORDER BY Age
+        """, fails: .distinct("Age"))
+  }
+
+  @Test("grouped DISTINCT orders on a projected aggregate alias")
+  func projectedGroupedOrderKey() throws {
+    // The counts per Age are 2, 2, 1; DISTINCT collapses the two 2s, leaving
+    // {1, 2}. Ordering on the projected alias `c` is well defined — ascending
+    // yields 1, 2.
+    try people().expect("""
+        SELECT DISTINCT COUNT(*) AS c FROM People GROUP BY Age ORDER BY c
+        """, yields: [[1], [2]])
   }
 }
 

--- a/Tests/SQLTests/OutputSchemaTests.swift
+++ b/Tests/SQLTests/OutputSchemaTests.swift
@@ -351,6 +351,69 @@ struct OutputSchemaTests {
     #expect(empty.count == 2)
   }
 
+  @Test("a zero FETCH does not spare a SELECT DISTINCT projection")
+  func distinctZeroFetch() throws {
+    // A DISTINCT plan is `Limit(Distinct(Project(…)))`: the projection
+    // evaluates over every candidate row to dedup it BEFORE the cap pages the
+    // result, so a zero FETCH does NOT make it unreachable. The schema must
+    // fault its divide-by-zero exactly as a run would — unlike the non-distinct
+    // form, whose `Project(Limit(…))` shape the zero FETCH still spares.
+    #expect(throws: SQLError.self) {
+      try schema("SELECT DISTINCT 1 / 0 FROM People FETCH FIRST 0 ROWS ONLY")
+    }
+    let normal = try schema(
+        "SELECT 1 / 0 FROM People FETCH FIRST 0 ROWS ONLY")
+    #expect(normal.count == 1)
+  }
+
+  @Test("a positive OFFSET does not spare a SELECT DISTINCT projection")
+  func distinctPositiveOffset() throws {
+    // The OFFSET pages the deduplicated result, so the projection still
+    // evaluates over every candidate row and its divide-by-zero faults.
+    #expect(throws: SQLError.self) {
+      try schema("SELECT DISTINCT 1 / 0 FROM People OFFSET 1 ROWS")
+    }
+  }
+
+  @Test("a zero FETCH does not spare a grouped DISTINCT projection")
+  func groupedDistinctZeroFetch() throws {
+    // A grouped DISTINCT dedups the projected group rows before the cap, so the
+    // projection is reachable and its divide-by-zero faults under a zero FETCH.
+    #expect(throws: SQLError.self) {
+      try schema("SELECT DISTINCT 1 / 0 FROM People GROUP BY Name "
+          + "FETCH FIRST 0 ROWS ONLY")
+    }
+  }
+
+  @Test("a constant-false WHERE still spares a SELECT DISTINCT projection")
+  func distinctFalseWhere() throws {
+    // A statically-false WHERE yields no rows, so a DISTINCT query has nothing
+    // to dedup and the projection is genuinely unreached — the WHERE-based
+    // elision stays, unlike the limit-based one.
+    let columns = try schema("SELECT DISTINCT 1 / 0 FROM People WHERE 1 = 0")
+    #expect(columns.count == 1)
+  }
+
+  @Test("a zero FETCH does not spare a DISTINCT empty-group projection")
+  func distinctEmptyGroupZeroFetch() throws {
+    // A constant-false WHERE over a whole-result aggregate emits ONE empty
+    // group. For a non-distinct query a zero FETCH drops that lone row, so its
+    // projection is unreachable and the divide-by-zero is spared. A DISTINCT
+    // query is the exception: its `Limit(Distinct(Project(…)))` plan evaluates
+    // the projection over the empty group's row (to dedup) BEFORE the cap, so
+    // the divide-by-zero faults exactly as a run does — the empty-group gate
+    // must bypass the limit elision under DISTINCT just as the main path does.
+    #expect(throws: SQLError.self) {
+      try schema("SELECT DISTINCT COUNT(*) / 0 FROM People WHERE 1 = 0 "
+          + "FETCH FIRST 0 ROWS ONLY")
+    }
+    // The non-distinct equivalent's zero FETCH drops the lone empty-group row,
+    // so its projection is unreachable and the schema resolves cleanly.
+    let columns = try schema(
+        "SELECT COUNT(*) / 0 FROM People WHERE 1 = 0 FETCH FIRST 0 ROWS ONLY")
+    #expect(columns.count == 1)
+  }
+
   @Test("HAVING is evaluated before a zero-FETCH limit, so its faults surface")
   func havingFaultsUnderZeroLimit() throws {
     // The compiled plan applies HAVING BEFORE the OFFSET/FETCH limit, so a zero

--- a/Tests/SQLTests/ParserTests.swift
+++ b/Tests/SQLTests/ParserTests.swift
@@ -77,6 +77,41 @@ struct KeywordTests {
   }
 }
 
+struct SetQuantifierTests {
+  @Test("a plain SELECT is not distinct")
+  func plain() throws {
+    let select = try parse(select: "SELECT TypeName FROM TypeDef")
+    #expect(!select.distinct)
+  }
+
+  @Test("SELECT DISTINCT sets the distinct flag")
+  func distinct() throws {
+    let select = try parse(select: "SELECT DISTINCT TypeName FROM TypeDef")
+    #expect(select.distinct)
+    #expect(select.projection == .columns(["TypeName"]))
+  }
+
+  @Test("SELECT ALL is the default, not distinct")
+  func explicitAll() throws {
+    let select = try parse(select: "SELECT ALL TypeName FROM TypeDef")
+    #expect(!select.distinct)
+    #expect(select.projection == .columns(["TypeName"]))
+  }
+
+  @Test("DISTINCT is case-insensitive")
+  func caseInsensitive() throws {
+    let select = try parse(select: "select distinct TypeName from TypeDef")
+    #expect(select.distinct)
+  }
+
+  @Test("DISTINCT applies to a FROM-less scalar select")
+  func scalar() throws {
+    let select = try parse(select: "SELECT DISTINCT 1")
+    #expect(select.distinct)
+    #expect(select.from == nil)
+  }
+}
+
 struct PredicateTests {
   @Test("parses each comparison operator")
   func operators() throws {

--- a/Tests/winmd-inspectTests/DatabaseSQLTests.swift
+++ b/Tests/winmd-inspectTests/DatabaseSQLTests.swift
@@ -912,6 +912,35 @@ struct DatabaseSQLTests {
     }
   }
 
+  @Test("print-namespaces yields a plain one-per-line list, not a boxed table")
+  func printNamespacesPlainList() throws {
+    // `print-namespaces` DEDUPS through `SELECT DISTINCT … ORDER BY`, but its
+    // output is a plain namespace-per-line list scripts parse — NOT the boxed
+    // table `Shell.execute` frames a row result as. The fixture's two TypeDefs
+    // both live in `NS`, so the DISTINCT collapses them to the one line `NS`,
+    // with no `┌─┐`/`│` box borders and no `TypeNamespace` header line.
+    try DatabaseSQLTests.with { storage in
+      let list = try PrintNamespaces.namespaces(storage)
+      #expect(list == "NS")
+      #expect(!list.contains("TypeNamespace"))
+      #expect(!list.contains("┌"))
+      #expect(!list.contains("│"))
+    }
+  }
+
+  @Test("print-namespaces on an empty database yields no output line")
+  func printNamespacesEmpty() throws {
+    // A database with an empty `TypeDef` table has no namespaces, so the
+    // DISTINCT query returns zero rows and the joined list is the empty
+    // string. `print-namespaces` must then emit NOTHING — its `run` guards the
+    // `print` on a non-empty result — so a script reading a namespace per line
+    // never sees a spurious blank entry.
+    try NoTypeDefFixture.with { storage in
+      let list = try PrintNamespaces.namespaces(storage)
+      #expect(list.isEmpty)
+    }
+  }
+
   @Test("a coded-index join key admits one key per candidate target table")
   func codedKeyEnumeration() {
     // `CustomAttribute.Parent` is `HasCustomAttribute`, which admits 22 target
@@ -1030,6 +1059,27 @@ struct DatabaseSQLTests {
 /// table is present (so the list link resolves to it) but has zero rows, so the
 /// owner of the lone `Param` resolves to 0. `decode(parameter:for:)` must then
 /// yield `nil` rather than index a negative `MethodDef` row.
+/// A fixture whose `TypeDef` table is present but empty: it contributes zero
+/// rows, so `SELECT DISTINCT TypeNamespace FROM TypeDef` finds no namespaces.
+private enum NoTypeDefFixture {
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 0, range: 0 ..< 0,
+                wide: 0, stride: 14),
+  ]
+
+  private static let valid: UInt64 = (1 << 2)
+
+  /// Runs `body` over a `Storage` catalog bound to the empty metadata.
+  static func with(_ body: (borrowing Storage) throws -> Void) rethrows {
+    let storage = Storage(bytes: empty.span.bytes, relations: relations.span,
+                          strings: empty.span.bytes, blob: empty.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+}
+
 private enum UnownedParamFixture {
   // Two narrow tables packed back to back. `MethodDef` contributes no records
   // (zero rows); `Param` contributes one.


### PR DESCRIPTION
This pull request adds support for the `SELECT DISTINCT` SQL clause to the query engine, allowing queries to deduplicate result rows as specified by the SQL standard. The implementation introduces a new `distinct` flag in the `Select` AST, updates the execution plan to support a new `distinct` operator, and ensures deduplication occurs at the correct stage of query processing. Additionally, the parser, lexer, and tests are updated to handle and validate the new functionality.

**Support for `SELECT DISTINCT`:**

- Added a `distinct` Boolean property to the `Select` AST node, updated its initializer, and modified the parser to recognize and set this flag when `DISTINCT` is present in a query. [[1]](diffhunk://#diff-44ae278469f8cb8537a5e8997ce917320e10f66a7fb199bcf35bc353ab154f08R104-R108) [[2]](diffhunk://#diff-44ae278469f8cb8537a5e8997ce917320e10f66a7fb199bcf35bc353ab154f08L137-R147) [[3]](diffhunk://#diff-6c11b53db7442865204eb0deb0f35640964bb2e9f54779311e62ae0b206f19d2R226-R232) [[4]](diffhunk://#diff-6c11b53db7442865204eb0deb0f35640964bb2e9f54779311e62ae0b206f19d2L254-R260) [[5]](diffhunk://#diff-6c11b53db7442865204eb0deb0f35640964bb2e9f54779311e62ae0b206f19d2L16-R16)
- Updated the lexer and token definitions to include the `DISTINCT` keyword. [[1]](diffhunk://#diff-3a41d2f1d12fb42c8cf94decbe20e627053820a0d629708ea2b1ec942a3c087fR338) [[2]](diffhunk://#diff-6bee202b401e2acfe37621d278f23fdbf5efbea53383a92e7057b79b73efcfedR23) [[3]](diffhunk://#diff-6bee202b401e2acfe37621d278f23fdbf5efbea53383a92e7057b79b73efcfedR88)

**Query Planning and Execution:**

- Introduced a new `.distinct` case to the `Plan` enum, with associated logic to deduplicate rows after projection and before pagination, matching SQL's semantics. [[1]](diffhunk://#diff-90b051b6c59d5ca6612ebe0500cd6ccfecdec8f79c3c79167986ee4298fd0737R151-R156) [[2]](diffhunk://#diff-90b051b6c59d5ca6612ebe0500cd6ccfecdec8f79c3c79167986ee4298fd0737R191-R194) [[3]](diffhunk://#diff-90b051b6c59d5ca6612ebe0500cd6ccfecdec8f79c3c79167986ee4298fd0737R243-R246) [[4]](diffhunk://#diff-90b051b6c59d5ca6612ebe0500cd6ccfecdec8f79c3c79167986ee4298fd0737L268-R283) [[5]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L413-R430) [[6]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060R440-R444) [[7]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060R614-R618) [[8]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060R762-R765) [[9]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060R1068-R1073)
- Updated the query shaping and planning logic to insert the `distinct` operator when required, ensuring deduplication is performed at the correct stage. [[1]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060R1534) [[2]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060R1619)

**Execution and Deduplication:**

- Implemented the `deduplicated` function to remove duplicate rows, ensuring only the first occurrence of each distinct row is kept, and applied it in both `SELECT DISTINCT` and `UNION` (without `ALL`). [[1]](diffhunk://#diff-90b051b6c59d5ca6612ebe0500cd6ccfecdec8f79c3c79167986ee4298fd0737R340-R341) [[2]](diffhunk://#diff-90b051b6c59d5ca6612ebe0500cd6ccfecdec8f79c3c79167986ee4298fd0737L369-R401)

**Testing and Examples:**

- Updated the test suite to support plans containing the new `.distinct` operator by extending all relevant plan traversal functions. [[1]](diffhunk://#diff-e8174e88eb2a0c88c2b70fa00f7eb5e2a81461462b190ccadef1bfc5ad2a18b2R1043-R1044) [[2]](diffhunk://#diff-e8174e88eb2a0c88c2b70fa00f7eb5e2a81461462b190ccadef1bfc5ad2a18b2R1075-R1076) [[3]](diffhunk://#diff-e8174e88eb2a0c88c2b70fa00f7eb5e2a81461462b190ccadef1bfc5ad2a18b2R1104-R1105) [[4]](diffhunk://#diff-e8174e88eb2a0c88c2b70fa00f7eb5e2a81461462b190ccadef1bfc5ad2a18b2R1136-R1137) [[5]](diffhunk://#diff-e8174e88eb2a0c88c2b70fa00f7eb5e2a81461462b190ccadef1bfc5ad2a18b2R1178-R1179) [[6]](diffhunk://#diff-e8174e88eb2a0c88c2b70fa00f7eb5e2a81461462b190ccadef1bfc5ad2a18b2R1208-R1209) [[7]](diffhunk://#diff-e8174e88eb2a0c88c2b70fa00f7eb5e2a81461462b190ccadef1bfc5ad2a18b2R1320-R1321)
- Updated the `winmd-inspect` tool to use `SELECT DISTINCT` for deduplicating namespaces, removing the previous manual deduplication logic.

These changes collectively add robust support for `SELECT DISTINCT`, aligning the engine's behavior with SQL standards and simplifying client code that previously had to deduplicate results manually.