### PR TITLE
winmd-inspect: emit the global namespace as one blank line

### DIFF
--- a/Sources/winmd-inspect/Inspect.swift
+++ b/Sources/winmd-inspect/Inspect.swift
@@ -53,26 +53,32 @@ struct PrintNamespaces: ParsableCommand {
     let data = try Data(contentsOf: options.database.url,
                         options: .alwaysMapped)
     let database = try Database(data.span.bytes)
-    // Zero namespaces must yield zero lines, not one blank line, so scripts
-    // reading a namespace per line never see a spurious empty entry.
-    let out = try PrintNamespaces.namespaces(database.storage)
-    if !out.isEmpty { print(out) }
+    // One line per namespace row: no rows prints nothing, while a lone
+    // empty-string namespace (the global namespace) prints one blank line —
+    // outcomes a joined string cannot tell apart, so scripts read exactly one
+    // line per namespace and none for a namespace-free database.
+    for namespace in try PrintNamespaces.namespaces(database.storage) {
+      print(namespace)
+    }
   }
 
-  /// The database's distinct namespaces as a plain one-per-line list, ascending
-  /// — a `SELECT DISTINCT … ORDER BY` deduplicates and sorts them, the engine's
-  /// own dedup replacing the hand-rolled `Set` + `sorted()`.
+  /// The database's distinct namespaces, ascending, one element per row — a
+  /// `SELECT DISTINCT … ORDER BY` deduplicates and sorts them, the engine's own
+  /// dedup replacing the hand-rolled `Set` + `sorted()`.
   ///
-  /// The result is a plain namespace-per-line list scripts parse, NOT the boxed
-  /// table `Shell.execute` frames a row result as (borders and a `TypeNamespace`
-  /// header): each row's single cell prints on its own line, unframed, so this
-  /// runs the DISTINCT query directly rather than through the shell.
+  /// An element per row, rather than a joined string, keeps the zero-rows case
+  /// (a namespace-free database) distinct from a single empty-string namespace:
+  /// the former yields no lines, the latter one blank line, whereas a
+  /// newline-join collapses both to the empty string. Each element is a plain
+  /// namespace scripts parse a line at a time, NOT the boxed table
+  /// `Shell.execute` frames a row result as (borders and a `TypeNamespace`
+  /// header), so this runs the DISTINCT query directly rather than the shell.
   internal static func namespaces(_ storage: borrowing WinMD.Storage)
-      throws -> String {
+      throws -> Array<String> {
     var session = Session(storage)
     let rows = try session.run(
         "SELECT DISTINCT TypeNamespace FROM TypeDef ORDER BY TypeNamespace")
-    return rows.map { $0[0].display }.joined(separator: "\n")
+    return rows.map { $0[0].display }
   }
 }
 

--- a/Tests/winmd-inspectTests/DatabaseSQLTests.swift
+++ b/Tests/winmd-inspectTests/DatabaseSQLTests.swift
@@ -915,29 +915,42 @@ struct DatabaseSQLTests {
   @Test("print-namespaces yields a plain one-per-line list, not a boxed table")
   func printNamespacesPlainList() throws {
     // `print-namespaces` DEDUPS through `SELECT DISTINCT … ORDER BY`, but its
-    // output is a plain namespace-per-line list scripts parse — NOT the boxed
-    // table `Shell.execute` frames a row result as. The fixture's two TypeDefs
-    // both live in `NS`, so the DISTINCT collapses them to the one line `NS`,
-    // with no `┌─┐`/`│` box borders and no `TypeNamespace` header line.
+    // output is one plain namespace element per row scripts parse a line at a
+    // time — NOT the boxed table `Shell.execute` frames a row result as. The
+    // fixture's two TypeDefs both live in `NS`, so the DISTINCT collapses them
+    // to the single element `NS`, carrying no `┌─┐`/`│` box borders and no
+    // `TypeNamespace` header.
     try DatabaseSQLTests.with { storage in
       let list = try PrintNamespaces.namespaces(storage)
-      #expect(list == "NS")
-      #expect(!list.contains("TypeNamespace"))
-      #expect(!list.contains("┌"))
-      #expect(!list.contains("│"))
+      #expect(list == ["NS"])
+      #expect(!list.contains { $0.contains("TypeNamespace") })
+      #expect(!list.contains { $0.contains("┌") })
+      #expect(!list.contains { $0.contains("│") })
     }
   }
 
-  @Test("print-namespaces on an empty database yields no output line")
+  @Test("print-namespaces on an empty database yields no lines")
   func printNamespacesEmpty() throws {
     // A database with an empty `TypeDef` table has no namespaces, so the
-    // DISTINCT query returns zero rows and the joined list is the empty
-    // string. `print-namespaces` must then emit NOTHING — its `run` guards the
-    // `print` on a non-empty result — so a script reading a namespace per line
-    // never sees a spurious blank entry.
+    // DISTINCT query returns zero rows. `print-namespaces` must then emit
+    // NOTHING — an empty element list prints no lines — so a script reading a
+    // namespace per line never sees a spurious blank entry.
     try NoTypeDefFixture.with { storage in
       let list = try PrintNamespaces.namespaces(storage)
       #expect(list.isEmpty)
+    }
+  }
+
+  @Test("print-namespaces yields one blank line for the global namespace")
+  func printNamespacesGlobal() throws {
+    // A database whose lone `TypeDef` lives in the global namespace — a
+    // `TypeNamespace` of the empty string — has exactly one namespace: the
+    // empty one. `print-namespaces` must yield a single empty-string element,
+    // one blank line, distinct from the zero-rows case that yields no line at
+    // all — a distinction a newline-joined string could not have preserved.
+    try GlobalNamespaceFixture.with { storage in
+      let list = try PrintNamespaces.namespaces(storage)
+      #expect(list == [""])
     }
   }
 
@@ -1075,6 +1088,46 @@ private enum NoTypeDefFixture {
   static func with(_ body: (borrowing Storage) throws -> Void) rethrows {
     let storage = Storage(bytes: empty.span.bytes, relations: relations.span,
                           strings: empty.span.bytes, blob: empty.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+}
+
+/// A fixture whose lone `TypeDef` lives in the global namespace — its
+/// `TypeNamespace` is index 0, the reserved empty string — so
+/// `SELECT DISTINCT TypeNamespace FROM TypeDef` finds a single empty-string
+/// namespace, the one blank-line case that must stay distinct from zero rows.
+private enum GlobalNamespaceFixture {
+  // One narrow (all-index 2-byte) TypeDef packed into a 14-byte row.
+  //
+  //   TypeDef[0]: Flags=0, TypeName="T"(1), TypeNamespace=0 (the empty string),
+  //               Extends=0, FieldList=0, MethodList=0 — a type in the global
+  //               namespace.
+  private static let bytes: Array<UInt8> = [
+    // TypeDef[0]
+    0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  ]
+
+  // "\0T\0": the reserved empty string at offset 0, `T` at offset 1.
+  private static let strings: Array<UInt8> = [
+    0x00,
+    0x54, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 1, range: 0 ..< 14,
+                wide: 0, stride: 14),
+  ]
+
+  private static let valid: UInt64 = (1 << 2)
+
+  /// Runs `body` over a `Storage` catalog bound to the assembled metadata.
+  static func with(_ body: (borrowing Storage) throws -> Void) rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: empty.span.bytes,
                           guid: empty.span.bytes, valid: valid, sorted: 0)
     try body(storage)
   }


### PR DESCRIPTION
`PrintNamespaces` ran the `SELECT DISTINCT TypeNamespace FROM TypeDef ORDER BY TypeNamespace` query, joined the rows into a newline-separated string, and printed it only when non-empty. That guard could not tell a namespace-free database from one whose sole namespace is the global (empty-string) namespace: both produced the empty string, so the single empty namespace was wrongly suppressed alongside the zero-rows case.

Return the namespaces as an element-per-row `Array<String>` and print each on its own line. An empty array prints nothing, as before; a lone empty-string element prints one blank line, restoring the global namespace the old `Set`-based path emitted. The `SELECT DISTINCT … ORDER BY` dedup and the plain one-per-line, unboxed format are unchanged.

Cover the three outcomes: a lone global-namespace `TypeDef` yields one empty-string element, an empty `TypeDef` table yields none, and the multi-type fixture still yields its distinct namespaces.