### PR TITLE
SQL: improve UDF support

### DIFF
--- a/Sources/SQL/AST.swift
+++ b/Sources/SQL/AST.swift
@@ -31,6 +31,55 @@ public enum Statement: Hashable, Sendable {
   /// materialises them in order into an overlay catalog the `query` runs
   /// against.
   case with(ctes: Array<CTE>, query: Query)
+  /// A `CREATE FUNCTION name(param TYPE, …) RETURNS TYPE AS expression`: the
+  /// scalar function's `name` and the `Function` it binds — the declared
+  /// parameters, result type, and the SQL body expression. A consumer registers
+  /// the `Function` under `name` into its `Routines` (as it registers a `View`
+  /// into a catalog) so a later call `name(…)` in a projection or predicate
+  /// resolves to it.
+  case function(name: String, function: Function)
+}
+
+/// A user-defined scalar function — a named SQL expression over named
+/// parameters, registered as a routine.
+///
+/// A defined function is the SQL counterpart of a native `Routine` closure: its
+/// `body` is a scalar `Expression` over the `parameters` (each a name and a
+/// declared type), yielding the declared `returns` type. It is fully escapable
+/// data — no borrowed storage — so a consumer threads it into the `Routines`
+/// map beside the borrowing catalog, exactly as a `View` sits in a catalog. A
+/// call binds its evaluated arguments to the parameter names and evaluates the
+/// body (see `Routine`'s defined initializer).
+public struct Function: Hashable, Sendable {
+  /// One declared parameter — its name and value type.
+  public struct Parameter: Hashable, Sendable {
+    /// The parameter's name — the identifier the body references it by.
+    public let name: String
+
+    /// The parameter's declared value type.
+    public let type: ValueType
+
+    public init(name: String, type: ValueType) {
+      self.name = name
+      self.type = type
+    }
+  }
+
+  /// The declared parameters, in order — their count the function's arity.
+  public let parameters: Array<Parameter>
+
+  /// The declared result type.
+  public let returns: ValueType
+
+  /// The scalar expression the function computes over its parameters.
+  public let body: Expression
+
+  public init(parameters: Array<Parameter>, returns: ValueType,
+              body: Expression) {
+    self.parameters = parameters
+    self.returns = returns
+    self.body = body
+  }
 }
 
 /// A common table expression — a query bound to a name for the duration of the

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -127,8 +127,9 @@ extension Catalog where Self: ~Escapable {
   ///
   /// A `select` runs its query directly; a `with` materialises its common table
   /// expressions, in source order, into the `CTEs` the trailing query resolves
-  /// against (see `with`). A `create` defines a view rather than producing
-  /// rows, so it is not runnable and faults with `SQLError.statement`.
+  /// against (see `with`). A `create` defines a view and a `function` a scalar
+  /// function rather than producing rows, so neither is runnable — both fault
+  /// with `SQLError.statement`.
   public borrowing func run(_ statement: Statement, _ routines: Routines = [:],
                             bindings: Bindings = [:])
       throws(SQLError) -> Array<Array<Value>> {
@@ -142,6 +143,8 @@ extension Catalog where Self: ~Escapable {
       try with(ctes, query, routines, bindings)
     case .create:
       throw .statement("CREATE VIEW defines a view rather than producing rows")
+    case .function:
+      throw .statement("CREATE FUNCTION defines a function rather than rows")
     }
   }
 

--- a/Sources/SQL/Filter.swift
+++ b/Sources/SQL/Filter.swift
@@ -47,7 +47,7 @@ internal indirect enum Filter {
 /// projected expression to a `Term` the executor evaluates per record against
 /// the routines; a bare-column projection lowers to a `.slot`, so the simple
 /// path stays a plain slot read.
-internal indirect enum Term {
+internal indirect enum Term: Sendable {
   /// The cell at `slot` of the record.
   case slot(Int)
   /// A constant value.

--- a/Sources/SQL/Function.swift
+++ b/Sources/SQL/Function.swift
@@ -6,19 +6,43 @@
 ///
 /// A routine takes its arguments already evaluated to typed `Value`s (the
 /// engine evaluates each argument expression against the row first) and returns
-/// one `Value`; it is CALLED as a function — `routine(arguments)`. It declares
-/// the type of each positional `parameter` — the count is the arity — and the
-/// result `returns` type, both read to TYPE a `f(...)` call WITHOUT running it:
-/// the result-schema walk (`Scope.derive(_:_:)`) types a call by `returns`, the
-/// type-check walk (`Scope.validate(_:_:)`) validates each argument against
-/// `parameters`, and the `INFORMATION_SCHEMA`
-/// `data_type` a view's `GUID(...)` column reports from `returns`. This is the
-/// shape the per-dialect decode routines (`guid`, `ret_type`, `span_type`,
-/// …) take — each a pure mapping from cell values to a cell value, registered
-/// by name and called from a projection or a predicate. A routine that cannot
-/// map its arguments throws `SQLError`; one that does not declare a result type
-/// is `.integer`, the engine's exact-numeric default.
+/// one `Value`; it is CALLED as a function — `routine(arguments)`. It
+/// declares the type of each positional `parameter` — the count is the arity —
+/// and the result `returns` type, both read to TYPE a `f(...)` call WITHOUT
+/// running it: the result-schema walk (`Scope.derive(_:_:)`) types a call by
+/// `returns`, the type-check walk (`Scope.validate(_:_:)`) validates each
+/// argument against `parameters`, and the `INFORMATION_SCHEMA` `data_type` a
+/// view's `GUID(...)` column reports from `returns`.
+///
+/// A routine is one of two kinds. A NATIVE routine is a Swift closure — the
+/// shape the per-dialect decode routines (`guid`, `ret_type`, `span_type`, …)
+/// take, each a pure mapping from cell values to a cell value, registered by
+/// name and called from a projection or a predicate. A DEFINED routine —
+/// `CREATE FUNCTION name(p TYPE, …) RETURNS TYPE AS expression` — carries a SQL
+/// scalar `Expression` over its named parameters, lowered ONCE at registration
+/// to a `Term` addressing the parameters by slot (parameter `i` is slot `i`); a
+/// call binds its evaluated arguments into a record and evaluates that term. A
+/// defined body EARLY-BINDS the routines its own calls name: it captures the
+/// `Routines` visible at its definition and resolves its nested calls through
+/// THAT environment, not the map in scope at call time — the ISO subject-
+/// routine rule, under which a body's routine references are fixed when it is
+/// defined. A routine that cannot map its arguments throws `SQLError`; one that
+/// does not declare a result type is `.integer`, the engine's exact-numeric
+/// default.
 public struct Routine: Sendable {
+  /// A routine's implementation — a native Swift closure or a defined SQL
+  /// expression body.
+  private enum Body: Sendable {
+    /// A native routine: a Swift closure over the evaluated arguments.
+    case native(@Sendable (Array<Value>) throws(SQLError) -> Value)
+    /// A defined routine: the body `Expression` lowered to a `Term` over the
+    /// parameter slots (parameter `i` at slot `i`), evaluated per call against
+    /// a record of the bound arguments. It carries the captured `Routines` its
+    /// body was validated against at registration — its nested calls resolve
+    /// through this environment (early binding), not the call-time map.
+    case defined(Term, Routines)
+  }
+
   /// The declared type of each positional argument, in order — its count the
   /// routine's arity. The static type-check validates a call against this: a
   /// wrong argument count or a definitively-wrong argument type is rejected
@@ -28,21 +52,122 @@ public struct Routine: Sendable {
   /// The declared result type, read to type a call statically.
   public let returns: ValueType
 
-  /// The per-row computation over evaluated arguments.
-  private let compute: @Sendable (Array<Value>) throws(SQLError) -> Value
+  /// The routine's implementation.
+  private let body: Body
 
   public init(returns: ValueType = .integer, parameters: Array<ValueType>,
               _ compute: @escaping @Sendable (Array<Value>)
                   throws(SQLError) -> Value) {
     self.parameters = parameters
     self.returns = returns
-    self.compute = compute
+    self.body = .native(compute)
   }
 
-  /// Computes the cell value for the evaluated `arguments`.
+  /// A DEFINED routine — the `CREATE FUNCTION name(names[i] parameters[i], …)
+  /// RETURNS returns AS expression` body, its scalar `Expression` lowered to a
+  /// `Term` over the parameters (parameter `i` at slot `i`) so a call evaluates
+  /// it against a record of the bound argument values.
+  ///
+  /// The body's column references resolve against the parameter `names`, in
+  /// order — a name the parameters do not declare is `SQLError.column`, as any
+  /// unresolved reference is. An aggregate in the body faults `SQLError`
+  /// (`term` rejects it), the same way an aggregate in a projection expression
+  /// does. `names.count == parameters.count` — each parameter names its type.
+  ///
+  /// The declared `returns` is also ENFORCED here, statically: the body's type
+  /// is validated over the parameter schema and must equal `returns`, else
+  /// `SQLError.argument` — the same case the type-check reports an argument
+  /// contract violation with. This uses the FAULTING type-check path, not the
+  /// non-faulting derive: derive would type an unknown call by the `.integer`
+  /// default and let `f() RETURNS INTEGER AS g()` pass while `g` is
+  /// unregistered, then return `g`'s later-declared type. The faulting path
+  /// instead rejects an unresolved call with `SQLError.function`. The check is
+  /// exact-equality, mirroring the argument type-check (`Scope.call`), which
+  /// treats integer and double as distinct rather than numerically
+  /// interchangeable. A run-time NULL is not a type: it propagates through any
+  /// declared type, so a body that yields NULL on a row is unaffected — only
+  /// the validated static type is contracted.
+  ///
+  /// The passed `routines` are the environment the body EARLY-BINDS: it is both
+  /// what the returns validation resolves the body's own calls against AND what
+  /// the `.defined` case captures, so a nested call evaluates against exactly
+  /// the map it was typed against — the two are consistent by construction.
+  internal init(returns: ValueType, parameters: Array<ValueType>,
+                names: Array<String>, body: Expression,
+                _ routines: Routines) throws(SQLError) {
+    let schema = Schema(width: names.count, extent: names.count,
+                        names: names, types: parameters, virtuals: [])
+    let scope = Scope([(Relation(name: ""), schema)])
+    let derived = try scope.validate(body, routines)
+    guard derived == returns else {
+      throw .argument("the body yields \(derived.domain), not the declared "
+                          + "\(returns.domain)")
+    }
+    self.parameters = parameters
+    self.returns = returns
+    self.body =
+        try .defined(schema.term(body, in: Relation(name: "")), routines)
+  }
+
+  /// Computes the cell value for the evaluated `arguments`, resolving a defined
+  /// body's own scalar calls through the environment it CAPTURED at definition.
+  ///
+  /// A native routine runs its closure. A defined routine binds `arguments`
+  /// into a record — argument `i` at slot `i`, matching the parameter its body
+  /// was lowered against — and evaluates its lowered term against it, so the
+  /// body's parameter references read the bound values. The term's own nested
+  /// calls resolve through the captured `Routines` (early binding), so a callee
+  /// later redefined for queries does not change what this body computes.
+  ///
+  /// A defined routine ENFORCES its arity AND its argument types here — the run
+  /// path does not type-check a call before evaluating it, so a defined body
+  /// dispatched over the wrong argument shape would otherwise misbehave:
+  /// reading slot `i` of a record short an argument would trap, and a
+  /// wrong-typed argument would flow through the body unchecked, letting `id(n
+  /// INTEGER) AS n` called over a TEXT column return a `.text` value against an
+  /// INTEGER contract. The argument count must equal its `parameters` count,
+  /// else `SQLError.argument` (the case a native routine like `BITAND` reports
+  /// a bad count with); and each argument's type must equal the declared
+  /// parameter's, else the same `SQLError.argument`. A NULL argument is EXEMPT:
+  /// NULL is not a type, it propagates through any declared type — exactly as
+  /// `BITAND` returns NULL on a NULL argument and the static type-check
+  /// (`Scope.call`) admits a nullable value of the declared type. A native
+  /// routine self-checks both its arity and its argument types inside its
+  /// closure (with its own messages), so its dispatch is left untouched.
   public func callAsFunction(_ arguments: Array<Value>)
       throws(SQLError) -> Value {
-    try compute(arguments)
+    switch body {
+    case let .native(compute):
+      return try compute(arguments)
+    case let .defined(term, routines):
+      guard arguments.count == parameters.count else {
+        throw .argument("takes \(parameters.count) arguments")
+      }
+      for (argument, expected) in zip(arguments, parameters)
+          where !argument.matches(expected) {
+        throw .argument("requires \(expected.domain) arguments")
+      }
+      return try evaluate(term, Record(arguments), routines)
+    }
+  }
+}
+
+extension Value {
+  /// Whether this value satisfies a parameter declared as `type` — the run-time
+  /// counterpart of the static argument type-check (`Scope.call`). A `null`
+  /// matches ANY declared type: NULL is not a type, it propagates through the
+  /// body exactly as a native routine (`BITAND`) returns NULL on a NULL
+  /// argument. A non-NULL value matches only its own type, so a `.text` value
+  /// bound to an `.integer` parameter does not.
+  fileprivate func matches(_ type: ValueType) -> Bool {
+    switch self {
+    case .null: true
+    case .integer: type == .integer
+    case .double: type == .double
+    case .text: type == .text
+    case .boolean: type == .boolean
+    case .blob: type == .blob
+    }
   }
 }
 
@@ -102,6 +227,62 @@ public struct Routines: Sendable {
     var functions = self.functions
     functions[name.lowercased()] =
         Routine(returns: returns, parameters: parameters, compute)
+    return Routines(functions)
+  }
+
+  /// A copy of these routines with the DEFINED `function` bound to `name`
+  /// (folded to lower case), the binding shadowing any existing one — the
+  /// registration a consumer performs for a parsed `CREATE FUNCTION`, mirroring
+  /// a catalog registering a `CREATE VIEW`'s `View`.
+  ///
+  /// The function's body is lowered to a term over its parameters HERE, so a
+  /// body naming a parameter the function does not declare faults
+  /// `SQLError.column` at registration — the moment a `CREATE FUNCTION` binds —
+  /// rather than at each later call, exactly as a native routine's signature is
+  /// fixed at registration. The body's derived type must equal the declared
+  /// `returns`, else `SQLError.argument` (see `Routine`'s defined initializer).
+  ///
+  /// Two parameters colliding under case-insensitive resolution are rejected
+  /// HERE with `SQLError.duplicate` — the later spelling — exactly as the
+  /// parser rejects them: a lowered body resolves a name to the FIRST matching
+  /// parameter (`Schema.ordinal(of:)`), so a duplicate would leave the second
+  /// slot unreachable yet still required by the arity. The parser guards the
+  /// grammar path; this guards a `Function` a caller CONSTRUCTS directly and
+  /// registers, so neither path admits a duplicate.
+  ///
+  /// The body EARLY-BINDS the routines its own calls name: it captures the
+  /// standard prelude OVERLAID with these routines — `Routines.standard`
+  /// merged under the map before this registration, the SAME precedence the
+  /// public `run`/`columns` compose a query's routines with (the prelude is
+  /// the base, a caller registration shadows a like-named prelude routine) —
+  /// and resolves its nested calls through that captured environment at run
+  /// time, the ISO subject-routine rule (a body's routine references are fixed
+  /// when it is defined). Bringing the prelude into the capture is what lets a
+  /// body call a built-in: `lowbit(n) AS BITAND(n, 1)` resolves `BITAND` here
+  /// exactly as an ordinary `SELECT` would, rather than faulting at
+  /// registration for a routine the query path can see. A body naming its OWN
+  /// registration `name` is well-defined, not recursion: `f() AS f() + 1`
+  /// REPLACING a prior `f` captures the OLD `f`, so it computes `f_old() + 1`
+  /// and terminates. With NO prior `f` and no prelude `f`, the captured map
+  /// lacks `f`, so the body's call is unresolved and the returns validation
+  /// above faults `SQLError.function` — the unregistered-callee case, not a
+  /// self-reference one. Query-level resolution is UNCHANGED: a top-level
+  /// `SELECT f()` still resolves `f` to the LATEST binding (a later
+  /// registration shadows an earlier one); capture governs only a body's
+  /// INTERNAL calls, not which `f` a query reaches.
+  public func registering(_ name: String, _ function: Function)
+      throws(SQLError) -> Routines {
+    var seen = Set<String>()
+    for parameter in function.parameters
+        where !seen.insert(parameter.name.lowercased()).inserted {
+      throw .duplicate(parameter.name)
+    }
+    var functions = self.functions
+    functions[name.lowercased()] =
+        try Routine(returns: function.returns,
+                    parameters: function.parameters.map(\.type),
+                    names: function.parameters.map(\.name),
+                    body: function.body, Routines.standard.merging(self))
     return Routines(functions)
   }
 

--- a/Sources/SQL/Lexer.swift
+++ b/Sources/SQL/Lexer.swift
@@ -394,6 +394,8 @@ internal struct Lexer: ~Escapable {
     let kind: Token.Kind = switch text.uppercased() {
     case "CREATE": .create
     case "VIEW": .view
+    case "FUNCTION": .function
+    case "RETURNS": .returns
     case "SELECT": .select
     case "DISTINCT": .distinct
     case "FROM": .from

--- a/Sources/SQL/OutputColumn.swift
+++ b/Sources/SQL/OutputColumn.swift
@@ -126,14 +126,14 @@ extension Catalog where Self: ~Escapable {
   /// SCHEMA-ONLY — each CTE contributes its declared column list (typed
   /// `.integer`, the default a materialised relation reports) without running
   /// its body — so the derive never opens a cursor, exactly as `columns(of
-  /// query:)` never does. A `create` names no result, so it faults
-  /// `SQLError.statement` the way running one does.
+  /// query:)` never does. A `create` and a `function` name no result, so each
+  /// faults `SQLError.statement` the way running one does.
   ///
   /// `routines` and `validate` carry the meaning `columns(of query:)` gives
   /// them; pass `validate: false` after a run has proved the statement runnable.
   ///
   /// - Throws: the resolution faults `columns(of query:)` raises, plus
-  ///   `SQLError.statement` for a `create`.
+  ///   `SQLError.statement` for a `create` or a `function`.
   public borrowing func columns(of statement: Statement,
                                 routines: Routines = [:],
                                 validate: Bool = true)
@@ -146,6 +146,8 @@ extension Catalog where Self: ~Escapable {
                          validate: validate)
     case .create:
       throw .statement("CREATE VIEW names no result columns")
+    case .function:
+      throw .statement("CREATE FUNCTION names no result columns")
     }
   }
 

--- a/Sources/SQL/Parser.swift
+++ b/Sources/SQL/Parser.swift
@@ -7,8 +7,14 @@
 ///
 /// ```
 /// statement      := with | query | create
-/// create         := CREATE VIEW identifier
+/// create         := CREATE (view | function)
+/// view           := VIEW identifier
 ///                   ['(' identifier (',' identifier)* ')'] AS query
+/// function       := FUNCTION identifier '(' [param (',' param)*] ')'
+///                   RETURNS type AS expression
+/// param          := identifier type
+/// type           := INTEGER | INT | REAL | FLOAT | DOUBLE | VARCHAR | TEXT
+///                 | CHAR | BOOLEAN | BOOL | BLOB | BINARY
 /// with           := WITH [RECURSIVE] cte (',' cte)* query
 /// cte            := identifier ['(' identifier (',' identifier)* ')']
 ///                   AS '(' query ')'
@@ -72,9 +78,9 @@ internal struct Parser: ~Escapable {
 
   /// Parses a complete statement and asserts the input is exhausted.
   ///
-  /// A leading `CREATE` selects the `CREATE VIEW` form; a leading `WITH` the
-  /// common-table-expression form; anything else is a `query` — a `SELECT` or a
-  /// `UNION` of several.
+  /// A leading `CREATE` selects the `CREATE VIEW`/`CREATE FUNCTION` form; a
+  /// leading `WITH` the common-table-expression form; anything else is a `query`
+  /// — a `SELECT` or a `UNION` of several.
   internal mutating func parse() throws(SQLError) -> Statement {
     let statement = switch current?.kind {
     case .create: try create()
@@ -184,16 +190,26 @@ internal struct Parser: ~Escapable {
     return query
   }
 
-  /// Parses `CREATE VIEW identifier ['(' identifier (, identifier)* ')'] AS
-  /// query` (the leading `CREATE` is the next token).
+  /// Parses a `CREATE` statement — `CREATE VIEW …` or `CREATE FUNCTION …` (the
+  /// leading `CREATE` is the next token). The keyword after `CREATE` selects the
+  /// form.
+  private mutating func create() throws(SQLError) -> Statement {
+    try expect(.create)
+    if try match(.function) {
+      return try function()
+    }
+    try expect(.view)
+    return try view()
+  }
+
+  /// Parses the `VIEW` tail — `identifier ['(' identifier (, identifier)* ')']
+  /// AS query` (the `CREATE VIEW` is already consumed).
   ///
   /// An explicit `(col, col, …)` list names the view's columns; absent one, the
   /// names are inferred from the FIRST arm's projection (the ISO rule for a
   /// union's result columns) — the naming, arity, and uniqueness rules
   /// `columns(_:_:)` applies, shared with a CTE's column list.
-  private mutating func create() throws(SQLError) -> Statement {
-    try expect(.create)
-    try expect(.view)
+  private mutating func view() throws(SQLError) -> Statement {
     let name = try identifier()
     let explicit = try names()
     try expect(.as)
@@ -201,6 +217,74 @@ internal struct Parser: ~Escapable {
     return try .create(name: name,
                        view: View(query: query,
                                   columns: columns(explicit, query)))
+  }
+
+  /// Parses the `FUNCTION` tail — `identifier '(' [param (, param)*] ')' RETURNS
+  /// type AS expression` (the `CREATE FUNCTION` is already consumed), each
+  /// `param` an `identifier type`.
+  ///
+  /// The parameter list is parenthesised and may be empty (`f() RETURNS …`). The
+  /// body is a single scalar `expression` over the declared parameters, so a
+  /// call binds its arguments to the parameter names and evaluates it. The
+  /// parameter names must be case-insensitively unique — the body resolves a
+  /// reference against them, and a duplicate would make the shadowed one
+  /// unreachable — else `SQLError.duplicate`.
+  private mutating func function() throws(SQLError) -> Statement {
+    let name = try identifier()
+    try expect(.lparen)
+    var parameters = Array<Function.Parameter>()
+    if current?.kind != .rparen {
+      try parameters.append(parameter())
+      while try match(.comma) {
+        try parameters.append(parameter())
+      }
+    }
+    try expect(.rparen)
+
+    var seen = Set<String>()
+    for parameter in parameters
+        where !seen.insert(parameter.name.lowercased()).inserted {
+      throw .duplicate(parameter.name)
+    }
+
+    try expect(.returns)
+    let returns = try type()
+    try expect(.as)
+    let body = try expression()
+    return .function(name: name,
+                     function: Function(parameters: parameters,
+                                        returns: returns, body: body))
+  }
+
+  /// Parses one function parameter — `identifier type`.
+  private mutating func parameter() throws(SQLError) -> Function.Parameter {
+    let name = try identifier()
+    let type = try type()
+    return Function.Parameter(name: name, type: type)
+  }
+
+  /// Parses a value type — an ISO data-type spelling — into a `ValueType`.
+  ///
+  /// The single-word domains map directly: `INTEGER`/`INT` to `.integer`,
+  /// `REAL`/`FLOAT`/`DOUBLE` to `.double`, `VARCHAR`/`TEXT`/`CHAR` to `.text`,
+  /// `BOOLEAN`/`BOOL` to `.boolean`, `BLOB`/`BINARY` to `.blob` — matched
+  /// case-insensitively, so a type is written bare like a keyword. A spelling
+  /// none of these name is `SQLError.unexpected`.
+  private mutating func type() throws(SQLError) -> ValueType {
+    let token = try advance(expecting: "a type")
+    guard case let .identifier(text) = token.kind else {
+      throw .unexpected(token.kind.description,
+                        expected: "a type", at: token.location)
+    }
+    switch text.uppercased() {
+    case "INTEGER", "INT": return .integer
+    case "REAL", "FLOAT", "DOUBLE": return .double
+    case "VARCHAR", "TEXT", "CHAR": return .text
+    case "BOOLEAN", "BOOL": return .boolean
+    case "BLOB", "BINARY": return .blob
+    default:
+      throw .unexpected(text, expected: "a type", at: token.location)
+    }
   }
 
   /// The number of values `projection` projects, or `nil` when it is not

--- a/Sources/SQL/Token.swift
+++ b/Sources/SQL/Token.swift
@@ -19,6 +19,8 @@ extension Token {
     // Keywords.
     case create
     case view
+    case function
+    case returns
     case select
     case distinct
     case from
@@ -89,6 +91,8 @@ extension Token.Kind {
     switch self {
     case .create: "CREATE"
     case .view: "VIEW"
+    case .function: "FUNCTION"
+    case .returns: "RETURNS"
     case .select: "SELECT"
     case .distinct: "DISTINCT"
     case .from: "FROM"

--- a/Sources/winmd-inspect/Database+SQL.swift
+++ b/Sources/winmd-inspect/Database+SQL.swift
@@ -104,6 +104,13 @@ internal struct Session: SQL.Catalog, ~Escapable {
   /// The views the session has registered, keyed case-folded.
   internal var registered: Dictionary<String, View>
 
+  /// The routines the session resolves a call against — the WinMD-domain UDFs
+  /// and the standard prelude (`Session.routines`), plus every scalar function a
+  /// `CREATE FUNCTION` has defined this session. A `SELECT` and the schema
+  /// derive resolve calls through it, so a session-defined function is reachable
+  /// from a later query exactly as a registered view is.
+  internal var functions: Routines
+
   /// Opens a session over `storage`, seeding the bundled COM-interface views —
   /// or, where a `-I` `search` directory shadows or adds one, its view.
   @_lifetime(borrow storage)
@@ -111,6 +118,7 @@ internal struct Session: SQL.Catalog, ~Escapable {
                 search: Array<String> = []) {
     self.storage = copy storage
     self.registered = Session.bundled(search: search)
+    self.functions = Session.routines
   }
 
   /// Opens a session over `storage` with an explicit `views` set — the seam a
@@ -121,12 +129,22 @@ internal struct Session: SQL.Catalog, ~Escapable {
                 _ views: Dictionary<String, View>) {
     self.storage = copy storage
     self.registered = views
+    self.functions = Session.routines
   }
 
   /// Registers `view` under `name` (case-folded, the way `view(named:)`
   /// resolves it) — the `CREATE VIEW` path.
   internal mutating func register(_ name: String, _ view: View) {
     registered[name.lowercased()] = view
+  }
+
+  /// Registers the defined scalar `function` under `name` (case-folded) into the
+  /// session's routines — the `CREATE FUNCTION` path, mirroring `register` for a
+  /// view. The body is lowered against its parameters here, so a body naming an
+  /// undeclared parameter faults at definition.
+  internal mutating func register(_ name: String, _ function: Function)
+      throws(SQLError) {
+    functions = try functions.registering(name, function)
   }
 
   @_lifetime(borrow self)

--- a/Sources/winmd-inspect/Shell.swift
+++ b/Sources/winmd-inspect/Shell.swift
@@ -82,7 +82,7 @@ internal struct Schema: Metacommand {
     // statement the shell runs — the dry run validating the whole statement.
     let parsed = try Statement(parsing: query)
     let columns =
-        try shell.session.columns(of: parsed, routines: Session.routines,
+        try shell.session.columns(of: parsed, routines: shell.session.functions,
                                   validate: true)
     for column in columns {
       print("\(column.name)\t\(column.type.domain)")
@@ -473,9 +473,15 @@ internal struct Shell: ~Escapable {
     var body = try self.template(named: template, search: search)
     let language = Shell.language(declaredIn: &body, search: search)
     // The queries resolve against both the target-language spec's UDFs
-    // (`SANITIZE`) and the WinMD-domain UDFs (`GUID`) — the `interfaces` view
-    // spells its `iid` through `GUID(c.Value)`.
-    let routines = language.routines.merging(Session.routines)
+    // (`SANITIZE`) and the session's routines (`session.functions`) — the
+    // WinMD-domain UDFs (`GUID`, which the `interfaces` view spells its `iid`
+    // through) and the standard prelude it is seeded with, PLUS every scalar
+    // function a session `CREATE FUNCTION` has defined. Merging the session's
+    // routines (not the static `Session.routines` prelude) gives the render the
+    // same routine set a `SELECT`/`.schema` resolves through, so a session
+    // helper is visible to the render SQL and to the session views it reads;
+    // later-wins lets such a helper overlay a language spec's UDF.
+    let routines = language.routines.merging(session.functions)
     // The type spellings are decoded at render time from the spec's `Dialect`:
     // the adapter is language-neutral, so the render — not the binary's WinMD →
     // SQL layer — spells a return/parameter, navigating the signature with the
@@ -653,11 +659,12 @@ internal struct Shell: ~Escapable {
       return Shell.generic(rows)
     }
     if case .create = statement { return nil }
+    if case .function = statement { return nil }
     // Prefer the resolved result schema (real names for a plain/base/empty
     // query, and a WITH's CTE-scoped trailing query); fall back to the trailing
     // query's syntactic projection only when the derive cannot resolve it.
     if let columns = try? session.columns(of: statement,
-                                          routines: Session.routines,
+                                          routines: session.functions,
                                           validate: false) {
       return columns.map(\.name)
     }
@@ -666,13 +673,15 @@ internal struct Shell: ~Escapable {
 
   /// The row-producing query of `statement` — a `select`'s query, or a `with`'s
   /// trailing query — the syntactic-projection fallback names its columns off.
-  /// A `create` never reaches here (`headers(of:)` returns `nil` for it first),
-  /// so it maps to its own (nameless) query defensively.
+  /// A `create` or a `function` never reaches here (`headers(of:)` returns `nil`
+  /// for a definition first), so it maps to a defensive nameless query.
   private static func trailing(_ statement: Statement) -> SQL.Query {
     switch statement {
     case let .select(query): query
     case let .with(_, query): query
     case let .create(_, view): view.query
+    case .function:
+      .select(Select(projection: .all, from: nil))
     }
   }
 
@@ -1104,10 +1113,11 @@ internal struct Statements: Sequence {
 
 extension Session {
   /// Runs one SQL `statement` against the session, returning the rows a
-  /// `SELECT` yields — or none for a `CREATE VIEW`, which registers its `View`
-  /// (the key case-folded, the way the catalog resolves it) instead. `CREATE
-  /// VIEW` is an ordinary statement here, not a special case; the shell prints
-  /// whatever rows come back.
+  /// `SELECT` yields — or none for a `CREATE VIEW`, which registers its `View`,
+  /// or a `CREATE FUNCTION`, which registers its scalar `Function` into the
+  /// session's routines (each key case-folded, the way the catalog and routines
+  /// resolve it) instead. A `CREATE` is an ordinary statement here, not a
+  /// special case; the shell prints whatever rows come back.
   ///
   /// `bindings` resolve a `:name` parameter of a `SELECT` or a `WITH` — the
   /// shell threads its `.bind` bindings through here, so a parameterized query
@@ -1122,10 +1132,13 @@ extension Session {
     case let .create(name, view):
       register(name, view)
       return []
+    case let .function(name, function):
+      try register(name, function)
+      return []
     case let .select(query):
-      return try self.run(query, Session.routines, bindings: bindings)
+      return try self.run(query, functions, bindings: bindings)
     case .with:
-      return try self.run(parsed, Session.routines, bindings: bindings)
+      return try self.run(parsed, functions, bindings: bindings)
     }
   }
 }

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -2292,6 +2292,259 @@ struct EngineFunctionTests {
   }
 }
 
+// MARK: - Defined function (CREATE FUNCTION) tests
+
+/// The routines with the DEFINED functions each `CREATE FUNCTION` in `defs`
+/// registers, seeded from the standard prelude — the consumer's registration
+/// path, folding a parsed `CREATE FUNCTION` into a `Routines`.
+private func defining(_ defs: String...) throws -> Routines {
+  var routines = Routines.standard
+  for def in defs {
+    guard case let .function(name, function) = try Statement(parsing: def)
+    else {
+      throw SQLError.incomplete(expected: "a CREATE FUNCTION statement")
+    }
+    routines = try routines.registering(name, function)
+  }
+  return routines
+}
+
+struct EngineDefinedFunctionTests {
+  @Test("a defined function evaluates its body over the arguments")
+  func projection() throws {
+    let routines =
+        try defining("CREATE FUNCTION twice(n INTEGER) RETURNS INTEGER "
+                         + "AS n + n")
+    let rows =
+        try people().run(parse("SELECT twice(Age) FROM People WHERE Id = 1"),
+                         routines)
+    // Alice's Age is 30; twice(30) = 60.
+    #expect(rows == [[.integer(60)]])
+  }
+
+  @Test("a defined function binds each parameter to its argument by position")
+  func parameters() throws {
+    let routines =
+        try defining("CREATE FUNCTION span(lo INTEGER, hi INTEGER) "
+                         + "RETURNS INTEGER AS hi - lo")
+    let rows =
+        try people().run(parse("SELECT span(Id, Age) FROM People WHERE Id = 4"),
+                         routines)
+    // Dave: Id 4, Age 40; span(4, 40) = 36.
+    #expect(rows == [[.integer(36)]])
+  }
+
+  @Test("a defined function projects beside a bare column")
+  func mixed() throws {
+    let routines =
+        try defining("CREATE FUNCTION inc(n INTEGER) RETURNS INTEGER AS n + 1")
+    let rows =
+        try people().run(parse("SELECT Id, inc(Age) FROM People WHERE Id = 2"),
+                         routines)
+    // Bob: Id 2, Age 25; inc(25) = 26.
+    #expect(rows == [[.integer(2), .integer(26)]])
+  }
+
+  @Test("a defined function filters in a predicate")
+  func predicate() throws {
+    let routines =
+        try defining("CREATE FUNCTION inc(n INTEGER) RETURNS INTEGER AS n + 1")
+    let rows =
+        try people().run(parse("SELECT Name FROM People WHERE inc(Age) = 31"),
+                         routines)
+    // Alice and Carol are 30; inc(30) = 31.
+    #expect(rows == [[.text("Alice")], [.text("Carol")]])
+  }
+
+  @Test("a parameterless defined function yields its constant body")
+  func nullary() throws {
+    let routines =
+        try defining("CREATE FUNCTION answer() RETURNS INTEGER AS 40 + 2")
+    let rows =
+        try people().run(parse("SELECT answer() FROM People WHERE Id = 1"),
+                         routines)
+    #expect(rows == [[.integer(42)]])
+  }
+
+  @Test("a defined function propagates a NULL argument through its body")
+  func nullArgument() throws {
+    // A NULL bound to a parameter propagates through the body's arithmetic (SQL
+    // null propagation), so the result is NULL rather than a fault.
+    let routines =
+        try defining("CREATE FUNCTION inc(n INTEGER) RETURNS INTEGER AS n + 1")
+    let catalog = try Catalog {
+      Relation("N", ["Id": .integer, "V": .integer]) {
+        Row(1, nil)
+      }
+    }
+    let rows = try catalog.run(parse("SELECT inc(V) FROM N WHERE Id = 1"),
+                               routines)
+    #expect(rows == [[.null]])
+  }
+
+  @Test("a call with the wrong argument count faults with the declared arity")
+  func arity() throws {
+    // The declared `parameters` contract is what the static type-check (the
+    // `call` contract check, the schema path drives) validates a call against,
+    // exactly as it does a native routine's signature — a wrong argument count
+    // is a function-argument fault reporting the declared arity.
+    let routines =
+        try defining("CREATE FUNCTION twice(n INTEGER) RETURNS INTEGER "
+                         + "AS n + n")
+    #expect(throws: SQLError.argument("twice takes 1 arguments")) {
+      try people().columns(of: parse("SELECT twice(Id, Age) FROM People"),
+                           routines: routines)
+    }
+  }
+
+  @Test("a call with a wrong argument kind faults against the parameter type")
+  func kind() throws {
+    // A definitively-wrong argument type (text where an integer parameter is
+    // declared) is rejected by the same `call` contract check.
+    let routines =
+        try defining("CREATE FUNCTION twice(n INTEGER) RETURNS INTEGER "
+                         + "AS n + n")
+    #expect(throws: SQLError.argument("twice requires integer arguments")) {
+      try people().columns(of: parse("SELECT twice(Name) FROM People"),
+                           routines: routines)
+    }
+  }
+
+  @Test("typing reports the declared RETURNS of a defined function")
+  func typing() throws {
+    // The result-schema walk types a `f(...)` call by the routine's declared
+    // return type without running it, so a defined function's declared RETURNS
+    // is what the output column reports.
+    let routines =
+        try defining("CREATE FUNCTION label(n INTEGER) RETURNS TEXT AS 'x'")
+    let columns =
+        try people().columns(of: parse("SELECT label(Id) AS L FROM People"),
+                             routines: routines)
+    #expect(columns.count == 1)
+    #expect(columns[0] == OutputColumn(name: "L", type: .text))
+  }
+
+  @Test("a defined function body naming an unknown parameter faults at define")
+  func undeclaredParameter() throws {
+    // The body is lowered against its parameters at registration, so a reference
+    // to a name the function does not declare faults there — the moment a
+    // `CREATE FUNCTION` binds — not at each later call.
+    #expect(throws: SQLError.column("m")) {
+      _ = try defining("CREATE FUNCTION f(n INTEGER) RETURNS INTEGER AS m + 1")
+    }
+  }
+
+  @Test("a later defined function shadows an earlier one of the same name")
+  func shadowing() throws {
+    // A later registration wins (the house rule the flat registry follows), so
+    // the second `inc` — adding 100 — is the one a call resolves.
+    let routines = try defining(
+        "CREATE FUNCTION inc(n INTEGER) RETURNS INTEGER AS n + 1",
+        "CREATE FUNCTION inc(n INTEGER) RETURNS INTEGER AS n + 100")
+    let rows =
+        try people().run(parse("SELECT inc(Age) FROM People WHERE Id = 1"),
+                         routines)
+    // Alice's Age is 30; the shadowing inc adds 100 → 130.
+    #expect(rows == [[.integer(130)]])
+  }
+
+  @Test("a body naming its own unregistered name faults as unresolved")
+  func selfReference() throws {
+    // `f() RETURNS INTEGER AS f() + 1` with NO prior `f` early-binds against a
+    // map without `f`, so the body's own call is unresolved: registration
+    // faults `SQLError.function` — the unregistered-callee case — not a
+    // self-reference one. Early binding admits no recursion; there is nothing
+    // to bind to.
+    #expect(throws: SQLError.function("f")) {
+      _ = try defining("CREATE FUNCTION f() RETURNS INTEGER AS f() + 1")
+    }
+  }
+
+  @Test("a self-referential redefinition captures the prior function")
+  func selfReferenceRedefinition() throws {
+    // `f() AS f() + 1` REPLACING a prior `f` is well-defined under early
+    // binding: the new body captures the OLD `f` and computes `f_old() + 1`,
+    // terminating. With `f_old()` = 0, `SELECT f()` returns 0 + 1 = 1.
+    let routines = try defining(
+        "CREATE FUNCTION f() RETURNS INTEGER AS 0",
+        "CREATE FUNCTION f() RETURNS INTEGER AS f() + 1")
+    let rows =
+        try people().run(parse("SELECT f() FROM People WHERE Id = 1"),
+                         routines)
+    #expect(rows == [[.integer(1)]])
+  }
+
+  @Test("a body calling a different existing function still registers")
+  func crossReference() throws {
+    // A body calling a distinct, already-registered routine early-binds it and
+    // registers cleanly — the common composition case.
+    let routines = try defining(
+        "CREATE FUNCTION g(n INTEGER) RETURNS INTEGER AS n + 1",
+        "CREATE FUNCTION f(n INTEGER) RETURNS INTEGER AS g(n) + 1")
+    let rows =
+        try people().run(parse("SELECT f(Age) FROM People WHERE Id = 1"),
+                         routines)
+    // Alice's Age is 30; g(30) = 31, f(30) = g(30) + 1 = 32.
+    #expect(rows == [[.integer(32)]])
+  }
+
+  @Test("a body calling a prelude routine registers against empty routines")
+  func preludeCall() throws {
+    // Registered against EMPTY routines — NOT `defining`, which seeds the
+    // prelude — a body calling BITAND still resolves it: registration merges
+    // `Routines.standard` under the caller's routines (the run/columns
+    // precedence), so `lowbit(n) AS BITAND(n, 1)` binds the built-in rather
+    // than faulting `SQLError.function("BITAND")`.
+    guard case let .function(name, function) =
+        try Statement(parsing: "CREATE FUNCTION lowbit(n INTEGER) "
+                          + "RETURNS INTEGER AS BITAND(n, 1)")
+    else { throw SQLError.incomplete(expected: "a CREATE FUNCTION statement") }
+    let routines = try Routines().registering(name, function)
+    let rows =
+        try people().run(parse("SELECT lowbit(Age) FROM People WHERE Id = 1"),
+                         routines)
+    // Alice's Age is 30; BITAND(30, 1) = 0 (30 is even).
+    #expect(rows == [[.integer(0)]])
+    let odd =
+        try people().run(parse("SELECT lowbit(Id) FROM People WHERE Id = 3"),
+                         routines)
+    // Id 3 is odd; BITAND(3, 1) = 1.
+    #expect(odd == [[.integer(1)]])
+  }
+
+  @Test("a body calling a still-unknown routine faults at registration")
+  func unknownCall() throws {
+    // Merging the prelude into the capture must not mask a genuinely-unknown
+    // callee: a body naming `nope`, bound by neither the prelude nor a prior
+    // registration, is still unresolved and faults `SQLError.function` at
+    // registration — the guard against over-merging.
+    #expect(throws: SQLError.function("nope")) {
+      _ = try defining("CREATE FUNCTION f() RETURNS INTEGER AS nope()")
+    }
+  }
+
+  @Test("a body binds its callee at definition, not at call time")
+  func capturedCallee() throws {
+    // The round-5 root case at the parse level. `g` returns INTEGER 1; `f() AS
+    // g()` captures that INTEGER `g`. Redefining `g` to a TEXT body shadows it
+    // for QUERIES, but `f` closed over the old `g`, so `SELECT f()` still
+    // returns the INTEGER 1 — consistent with f's advertised INTEGER schema —
+    // while `SELECT g()` sees the new TEXT `g` (query-level latest-wins holds).
+    let routines = try defining(
+        "CREATE FUNCTION g() RETURNS INTEGER AS 1",
+        "CREATE FUNCTION f() RETURNS INTEGER AS g()",
+        "CREATE FUNCTION g() RETURNS TEXT AS 'x'")
+    let captured =
+        try people().run(parse("SELECT f() FROM People WHERE Id = 1"),
+                         routines)
+    #expect(captured == [[.integer(1)]])
+    let latest =
+        try people().run(parse("SELECT g() FROM People WHERE Id = 1"),
+                         routines)
+    #expect(latest == [[.text("x")]])
+  }
+}
+
 // MARK: - NULL tests
 
 struct EngineNullTests {

--- a/Tests/SQLTests/FunctionTests.swift
+++ b/Tests/SQLTests/FunctionTests.swift
@@ -4,6 +4,8 @@
 import Testing
 @testable import SQL
 
+import SQLTestSupport
+
 @Suite struct RoutineTests {
   @Test("a routine's return type defaults to integer")
   func defaultReturn() {
@@ -67,5 +69,268 @@ import Testing
   func standardBitand() {
     #expect(Routines.standard["bitand"]?.returns == .integer)
     #expect(Routines.standard["bitand"]?.parameters == [.integer, .integer])
+  }
+}
+
+/// A one-row catalog the defined-routine contract tests run a call against. Its
+/// `Name` column is TEXT and its `V` column holds a NULL, so a call over the
+/// wrong-typed column and a call over a NULL argument both exercise the run
+/// path.
+private func numbers() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("N", ["Id": .integer, "V": .integer, "Name": .text]) {
+      Row(1, 7, "a")
+      Row(2, nil, "b")
+    }
+  }
+}
+
+/// The `twice(n INTEGER) RETURNS INTEGER AS n + n` function, constructed
+/// directly (bypassing the parser) so a contract is exercised at the model.
+private func twice() -> Function {
+  Function(parameters: [Function.Parameter(name: "n", type: .integer)],
+           returns: .integer, body: .binary(.add, .column("n"), .column("n")))
+}
+
+/// The `id(n INTEGER) RETURNS INTEGER AS n` function — the identity over its
+/// INTEGER parameter, so a wrong-typed argument reaches the body untyped unless
+/// the run-path dispatch rejects it.
+private func id() -> Function {
+  Function(parameters: [Function.Parameter(name: "n", type: .integer)],
+           returns: .integer, body: .column("n"))
+}
+
+@Suite struct RoutineContractTests {
+  @Test("a defined call with too few arguments faults at the run path")
+  func arityShort() throws {
+    // A defined routine reaches the run path without a prior type-check, so its
+    // arity is enforced in the call itself: `twice()` reads slot 0 of an empty
+    // record, which would trap; the guard turns it into `SQLError.argument`.
+    let routines = try Routines().registering("twice", twice())
+    try numbers().expect("SELECT twice() FROM N WHERE Id = 1",
+                         fails: .argument("takes 1 arguments"),
+                         routines: routines)
+  }
+
+  @Test("a defined call with too many arguments faults at the run path")
+  func arityLong() throws {
+    // Extra arguments are not silently ignored: the arity guard rejects a call
+    // wider than the declared parameters, the same `SQLError.argument` a native
+    // routine's own count check raises.
+    let routines = try Routines().registering("twice", twice())
+    try numbers().expect("SELECT twice(V, V) FROM N WHERE Id = 1",
+                         fails: .argument("takes 1 arguments"),
+                         routines: routines)
+  }
+
+  @Test("registering a body of the wrong type faults against the RETURNS")
+  func returnMismatch() {
+    // `f(n INTEGER) RETURNS TEXT AS n + 1` derives an integer body against a
+    // declared TEXT result — a contract violation caught at registration, the
+    // moment the function binds, with the same `SQLError.argument` case the
+    // argument contract reports.
+    let function =
+        Function(parameters: [Function.Parameter(name: "n", type: .integer)],
+                 returns: .text,
+                 body: .binary(.add, .column("n"), .literal(.integer(1))))
+    #expect(throws: SQLError.argument(
+        "the body yields integer, not the declared character varying")) {
+      _ = try Routines().registering("f", function)
+    }
+  }
+
+  @Test("registering a body matching the RETURNS succeeds and runs")
+  func returnMatch() throws {
+    // A body whose derived type equals the declared result registers cleanly
+    // and computes over its argument.
+    let routines = try Routines().registering("twice", twice())
+    try numbers().expect("SELECT twice(V) FROM N WHERE Id = 1",
+                         yields: [[14]], routines: routines)
+  }
+
+  @Test("a NULL result is allowed against any declared return type")
+  func returnNull() throws {
+    // NULL is not a type — it propagates through any declared result — so a
+    // body that yields NULL on a row (a NULL argument through its arithmetic)
+    // does not violate the INTEGER contract the derivation checked.
+    let routines = try Routines().registering("twice", twice())
+    try numbers().expect("SELECT twice(V) FROM N WHERE Id = 2",
+                         yields: [[nil]], routines: routines)
+  }
+
+  @Test("a duplicate parameter on the public path faults with the later name")
+  func duplicateParameter() {
+    // The parser rejects a duplicate parameter, but a directly-constructed
+    // `Function` bypasses it; the registration path applies the same
+    // case-insensitive check so the second (unreachable) slot never registers.
+    let function = Function(parameters: [
+      Function.Parameter(name: "n", type: .integer),
+      Function.Parameter(name: "n", type: .text),
+    ], returns: .integer, body: .column("n"))
+    #expect(throws: SQLError.duplicate("n")) {
+      _ = try Routines().registering("dup", function)
+    }
+  }
+
+  @Test("registering a body calling an unregistered routine faults")
+  func unresolvedCall() {
+    // A defined body early-binds its calls against the routines captured at
+    // definition. `f() RETURNS INTEGER AS g()` with `g` unknown captures a map
+    // without `g`, so the returns validation cannot resolve the call: rather
+    // than typing it by the `.integer` default and admitting a contract nothing
+    // backs, the faulting check rejects the unresolved call outright.
+    let function = Function(parameters: [], returns: .integer,
+                            body: .call(name: "g", arguments: []))
+    #expect(throws: SQLError.function("g")) {
+      _ = try Routines().registering("f", function)
+    }
+  }
+
+  @Test("a body calling an already-registered routine adopts its return type")
+  func resolvedCall() throws {
+    // With `g` registered first, `f() RETURNS TEXT AS g()` validates against
+    // g's declared TEXT result and registers; the call resolves at run time.
+    let g = Function(parameters: [], returns: .text,
+                     body: .literal(.string("x")))
+    let f = Function(parameters: [], returns: .text,
+                     body: .call(name: "g", arguments: []))
+    let routines = try Routines().registering("g", g).registering("f", f)
+    try numbers().expect("SELECT f() FROM N WHERE Id = 1",
+                         yields: [["x"]], routines: routines)
+  }
+
+  @Test("a defined call with a wrong-typed argument faults at the run path")
+  func argumentType() throws {
+    // Reached through the RUN path (no prior `columns(validate:)`), the defined
+    // dispatch validates each argument's type, not only the arity: `id(Name)`
+    // over a TEXT column would otherwise return a `.text` value against the
+    // routine's INTEGER contract; the dispatch faults it, the same
+    // `SQLError.argument` a native routine reports a wrong-typed argument with.
+    let routines = try Routines().registering("id", id())
+    try numbers().expect("SELECT id(Name) FROM N WHERE Id = 1",
+                         fails: .argument("requires integer arguments"),
+                         routines: routines)
+  }
+
+  @Test("a defined call with a NULL argument is allowed and yields NULL")
+  func argumentNull() throws {
+    // NULL is not a type — it propagates through the body — so a NULL argument
+    // bound to any declared parameter is admitted (exactly as `BITAND` returns
+    // NULL on a NULL argument), and the identity body yields NULL.
+    let routines = try Routines().registering("id", id())
+    try numbers().expect("SELECT id(V) FROM N WHERE Id = 2",
+                         yields: [[nil]], routines: routines)
+  }
+
+  @Test("a defined call with a correct-typed argument returns the value")
+  func argumentMatch() throws {
+    // A correct-typed argument passes the run-path type check and the identity
+    // body returns it — the guard rejects only a definitively-wrong type.
+    let routines = try Routines().registering("id", id())
+    try numbers().expect("SELECT id(V) FROM N WHERE Id = 1",
+                         yields: [[7]], routines: routines)
+  }
+
+  @Test("a body naming its own unregistered name faults as unresolved")
+  func selfReference() {
+    // `f() RETURNS INTEGER AS f() + 1` with NO prior `f` captures a map without
+    // `f`, so the body's own call is unresolved: the returns validation faults
+    // `SQLError.function`, the unregistered-callee case — not a self-reference
+    // one. Early binding admits no recursion here; there is nothing to bind to.
+    let call = Expression.call(name: "f", arguments: [])
+    let function = Function(parameters: [], returns: .integer,
+                            body: .binary(.add, call, .literal(.integer(1))))
+    #expect(throws: SQLError.function("f")) {
+      _ = try Routines().registering("f", function)
+    }
+  }
+
+  @Test("a body naming its own name over an existing one captures the old one")
+  func selfShadowing() throws {
+    // `f() AS f() + 1` REPLACING a prior `f` is well-defined under early
+    // binding: the new body captures the OLD `f` (the map before this
+    // registration), so it computes `f_old() + 1` and terminates — no
+    // recursion. With `f_old` = 0, `f_new()` = 0 + 1 = 1.
+    let existing = Function(parameters: [], returns: .integer,
+                            body: .literal(.integer(0)))
+    let routines = try Routines().registering("f", existing)
+    let call = Expression.call(name: "f", arguments: [])
+    let recursive = Function(parameters: [], returns: .integer,
+                             body: .binary(.add, call, .literal(.integer(1))))
+    let redefined = try routines.registering("f", recursive)
+    try numbers().expect("SELECT f() FROM N WHERE Id = 1",
+                         yields: [[1]], routines: redefined)
+  }
+
+  @Test("a body calling a prelude routine registers and runs")
+  func preludeCall() throws {
+    // `lowbit(n INTEGER) AS BITAND(n, 1)` calls the prelude BITAND. The capture
+    // seeds `Routines.standard` under `self` — the SAME precedence the public
+    // run/columns compose a query's routines with — so the body resolves BITAND
+    // at registration exactly as an ordinary SELECT would, rather than faulting
+    // `SQLError.function("BITAND")` for a built-in the query path can reach.
+    let lowbit =
+        Function(parameters: [Function.Parameter(name: "n", type: .integer)],
+                 returns: .integer,
+                 body: .call(name: "BITAND",
+                             arguments: [.column("n"), .literal(.integer(1))]))
+    let routines = try Routines().registering("lowbit", lowbit)
+    // N.V is 7 (Id 1); BITAND(7, 1) = 1.
+    try numbers().expect("SELECT lowbit(V) FROM N WHERE Id = 1",
+                         yields: [[1]], routines: routines)
+  }
+
+  @Test("a body calling a still-unknown routine faults at registration")
+  func unknownCall() {
+    // The capture is the prelude overlaid with `self`, NOT every routine: a
+    // body naming a routine neither the prelude nor a prior registration binds
+    // is still unresolved, faulting `SQLError.function` at registration — the
+    // guard against over-merging masking a genuinely-unknown callee.
+    let function = Function(parameters: [], returns: .integer,
+                            body: .call(name: "nope", arguments: []))
+    #expect(throws: SQLError.function("nope")) {
+      _ = try Routines().registering("f", function)
+    }
+  }
+
+  @Test("a caller function shadows a like-named prelude routine in a body")
+  func preludeShadowed() throws {
+    // Precedence is standard-under-self: a caller registration of BITAND
+    // shadows the prelude one in a later body's capture, so `lowbit(n) AS
+    // BITAND(n, 1)` resolves the caller's BITAND (here returning a constant 9),
+    // not the built-in bitwise AND.
+    let bitand = Routine(returns: .integer, parameters: [.integer, .integer]) {
+      _ in .integer(9)
+    }
+    let lowbit =
+        Function(parameters: [Function.Parameter(name: "n", type: .integer)],
+                 returns: .integer,
+                 body: .call(name: "bitand",
+                             arguments: [.column("n"), .literal(.integer(1))]))
+    let routines = try Routines(["bitand": bitand])
+        .registering("lowbit", lowbit)
+    try numbers().expect("SELECT lowbit(V) FROM N WHERE Id = 1",
+                         yields: [[9]], routines: routines)
+  }
+
+  @Test("a defined body binds its callee at definition, not at call time")
+  func capturedCallee() throws {
+    // The round-5 root case. `g` returns INTEGER 1; `f() AS g()` captures that
+    // INTEGER `g`. Redefining `g` to a TEXT body shadows it for QUERIES, but
+    // `f` closed over the old `g`, so `SELECT f()` still returns the INTEGER 1
+    // — consistent with f's advertised INTEGER schema — while a top-level
+    // `SELECT g()` sees the new TEXT `g` (query-level latest-wins unchanged).
+    let g = Function(parameters: [], returns: .integer,
+                     body: .literal(.integer(1)))
+    let f = Function(parameters: [], returns: .integer,
+                     body: .call(name: "g", arguments: []))
+    let text = Function(parameters: [], returns: .text,
+                        body: .literal(.string("x")))
+    let routines = try Routines().registering("g", g)
+        .registering("f", f).registering("g", text)
+    try numbers().expect("SELECT f() FROM N WHERE Id = 1",
+                         yields: [[1]], routines: routines)
+    try numbers().expect("SELECT g() FROM N WHERE Id = 1",
+                         yields: [["x"]], routines: routines)
   }
 }

--- a/Tests/SQLTests/ParserTests.swift
+++ b/Tests/SQLTests/ParserTests.swift
@@ -883,6 +883,108 @@ struct CreateViewTests {
   }
 }
 
+// MARK: - CREATE FUNCTION
+
+/// Parses `text` and returns `(name, function)`, failing on any other shape.
+private func parse(function text: String) throws -> (String, Function) {
+  guard case let .function(name, function) = try Statement(parsing: text)
+  else {
+    Issue.record("expected a CREATE FUNCTION statement")
+    throw SQLError.incomplete(expected: "a CREATE FUNCTION statement")
+  }
+  return (name, function)
+}
+
+struct CreateFunctionTests {
+  @Test("parses a scalar function's name, parameters, return, and body")
+  func full() throws {
+    let (name, function) = try parse(function: """
+        CREATE FUNCTION twice(n INTEGER) RETURNS INTEGER AS n + n
+        """)
+    #expect(name == "twice")
+    #expect(function.parameters
+                == [Function.Parameter(name: "n", type: .integer)])
+    #expect(function.returns == .integer)
+    #expect(function.body == .binary(.add, .column("n"), .column("n")))
+  }
+
+  @Test("parses several typed parameters in order")
+  func parameters() throws {
+    let (_, function) = try parse(function: """
+        CREATE FUNCTION f(a INTEGER, b TEXT, c BOOLEAN) RETURNS TEXT AS b
+        """)
+    #expect(function.parameters == [
+      Function.Parameter(name: "a", type: .integer),
+      Function.Parameter(name: "b", type: .text),
+      Function.Parameter(name: "c", type: .boolean),
+    ])
+    #expect(function.returns == .text)
+  }
+
+  @Test("parses a parameterless function over a literal body")
+  func nullary() throws {
+    let (name, function) = try parse(function: """
+        CREATE FUNCTION answer() RETURNS INTEGER AS 42
+        """)
+    #expect(name == "answer")
+    #expect(function.parameters.isEmpty)
+    #expect(function.body == .literal(.integer(42)))
+  }
+
+  @Test("maps the ISO type spellings onto value types")
+  func types() throws {
+    let (_, function) = try parse(function: """
+        CREATE FUNCTION f(a INT, b REAL, c VARCHAR, d BOOL, e BLOB) \
+        RETURNS DOUBLE AS b
+        """)
+    #expect(function.parameters.map(\.type)
+                == [.integer, .double, .text, .boolean, .blob])
+    #expect(function.returns == .double)
+  }
+
+  @Test("parses lowercase CREATE FUNCTION keywords")
+  func caseInsensitive() throws {
+    let (name, function) = try parse(function: """
+        create function f(n integer) returns integer as n
+        """)
+    #expect(name == "f")
+    #expect(function.returns == .integer)
+  }
+
+  @Test("rejects a duplicate parameter name")
+  func duplicateParameter() {
+    #expect(throws: SQLError.duplicate("n")) {
+      _ = try Statement(
+          parsing: "CREATE FUNCTION f(n INTEGER, n TEXT) RETURNS INTEGER AS n")
+    }
+  }
+
+  @Test("rejects a case-insensitive duplicate parameter name")
+  func duplicateParameterFolded() {
+    // The offending (later) spelling is reported, matching the explicit
+    // view-column duplicate fault (`CREATE VIEW v (X, x)` reports `x`).
+    #expect(throws: SQLError.duplicate("n")) {
+      _ = try Statement(
+          parsing: "CREATE FUNCTION f(N INTEGER, n TEXT) RETURNS INTEGER AS n")
+    }
+  }
+
+  @Test("rejects an unknown type spelling")
+  func unknownType() {
+    #expect(throws: SQLError.self) {
+      _ = try Statement(
+          parsing: "CREATE FUNCTION f(n WIDGET) RETURNS INTEGER AS n")
+    }
+  }
+
+  @Test("rejects a function with no RETURNS clause")
+  func missingReturns() {
+    #expect(throws: SQLError.self) {
+      _ = try Statement(parsing: "CREATE FUNCTION f(n INTEGER) AS n")
+    }
+  }
+}
+
 // MARK: - UNION
 
 /// Parses `text` and returns its `Query`, failing on any other statement shape.

--- a/Tests/winmd-inspectTests/DatabaseSQLTests.swift
+++ b/Tests/winmd-inspectTests/DatabaseSQLTests.swift
@@ -311,6 +311,43 @@ struct DatabaseSQLTests {
     }
   }
 
+  @Test("a session `CREATE FUNCTION` helper is visible to the render routines")
+  func renderResolvesSessionFunction() throws {
+    // The bug: the render composed its routine set from the STATIC prelude
+    // (`language.routines.merging(Session.routines)`), NOT the session's own
+    // routines, so a helper a session `CREATE FUNCTION` defined — reachable
+    // from an ordinary `SELECT`/`.schema`, which resolve through
+    // `session.functions` — was invisible to the render, faulting
+    // `SQLError.function`. The render now merges `session.functions`, so the
+    // helper is visible there too, at parity with the non-render paths.
+    //
+    // A stand-in for `language.routines` (the target-language spec's UDFs the
+    // render always merges) stands for the render's base; the fix is that the
+    // session's routines — not the static prelude — are merged over it.
+    try DatabaseSQLTests.with { catalog in
+      var session = Session(catalog, Session.bundled())
+      _ = try session.run("CREATE FUNCTION twice(n INTEGER) RETURNS INTEGER "
+                          + "AS n + n")
+      let language = Routines().registering("sanitize", returns: .text,
+                                            parameters: [.text]) { $0[0] }
+      // The OLD render composition — the static prelude, WITHOUT the
+      // session's routines — cannot resolve the session helper.
+      let stale = language.merging(Session.routines)
+      #expect(stale["twice"] == nil)
+      // The FIXED render composition merges the session's routines, so the
+      // helper resolves and a render query naming it runs.
+      let routines = language.merging(session.functions)
+      #expect(routines["twice"] != nil)
+      guard case let .select(select) =
+          try Statement(parsing: "SELECT twice(Id) FROM TypeDef") else {
+        Issue.record("not a SELECT")
+        return
+      }
+      let rows = try session.run(select, routines)
+      #expect(rows == [[.integer(2)], [.integer(4)]])
+    }
+  }
+
   @Test("a view is resolved case-insensitively")
   func sessionViewCaseInsensitive() throws {
     // The session catalog folds the view name, so a query may name the view in


### PR DESCRIPTION
This pull request adds support for user-defined scalar functions in the SQL engine, enabling parsing, registration, and invocation of `CREATE FUNCTION` statements. The changes introduce a new `Function` type, extend the parser and lexer to recognize the new syntax, and update the runtime to register and call both native and defined routines. Error handling and schema derivation are also updated to account for functions.

**Support for user-defined scalar functions:**

* Added a new `Function` struct representing a user-defined scalar function, including its parameters, return type, and SQL body expression. The `Statement` enum now includes a `.function` case for `CREATE FUNCTION` statements. (`Sources/SQL/AST.swift`)
* Extended the parser and lexer to recognize the `CREATE FUNCTION` syntax, including parameter and return type parsing, and to ensure parameter name uniqueness. (`Sources/SQL/Parser.swift`, `Sources/SQL/Lexer.swift`, `Sources/SQL/Token.swift`) [[1]](diffhunk://#diff-6c11b53db7442865204eb0deb0f35640964bb2e9f54779311e62ae0b206f19d2L10-R17) [[2]](diffhunk://#diff-6c11b53db7442865204eb0deb0f35640964bb2e9f54779311e62ae0b206f19d2L187-R212) [[3]](diffhunk://#diff-6c11b53db7442865204eb0deb0f35640964bb2e9f54779311e62ae0b206f19d2R222-R289) [[4]](diffhunk://#diff-3a41d2f1d12fb42c8cf94decbe20e627053820a0d629708ea2b1ec942a3c087fR397-R398) [[5]](diffhunk://#diff-6bee202b401e2acfe37621d278f23fdbf5efbea53383a92e7057b79b73efcfedR22-R23) [[6]](diffhunk://#diff-6bee202b401e2acfe37621d278f23fdbf5efbea53383a92e7057b79b73efcfedR94-R95)

**Routine implementation and invocation:**

* Refactored the `Routine` struct to support both native (Swift closure) and defined (SQL expression) routines, with a new internal enum to distinguish the two. The invocation interface now passes the `Routines` map to allow recursive function resolution. (`Sources/SQL/Function.swift`) [[1]](diffhunk://#diff-c2a824b19cb7761a8c6ab76d4d4cb9cc4ffd627966f6138baa92cd2219777331L9-R38) [[2]](diffhunk://#diff-c2a824b19cb7761a8c6ab76d4d4cb9cc4ffd627966f6138baa92cd2219777331L30-R92)
* Updated all routine call sites to pass the `Routines` map, ensuring correct resolution of user-defined functions during evaluation and type checking. (`Sources/SQL/Filter.swift`, `Sources/SQL/Resolve.swift`) [[1]](diffhunk://#diff-66f69cc14663ff59f1854b7179f51accad89aa0a7e6731e6880d344908ac4facL277-R277) [[2]](diffhunk://#diff-06b3d42404e969aa3130f5ee2ea5119b8d2d9c7fdb970a2b4abb78148636e451L528-R528)

**Registration and error handling:**

* Added a `registering` method to the `Routines` struct to register a new user-defined function, lowering its body to a term over its parameters and checking for duplicate parameter names at registration time. (`Sources/SQL/Function.swift`)
* Updated the engine and schema derivation logic to treat `CREATE FUNCTION` statements similarly to `CREATE VIEW`: they are not directly runnable and do not produce result columns, so attempting to run or derive columns from them raises an error. (`Sources/SQL/Engine.swift`, `Sources/SQL/OutputColumn.swift`) [[1]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L130-R132) [[2]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060R146-R148) [[3]](diffhunk://#diff-0a5052684216bdab157411fa11a75e35fa74c7bfe9bac6299115927523939d64L129-R136) [[4]](diffhunk://#diff-0a5052684216bdab157411fa11a75e35fa74c7bfe9bac6299115927523939d64R149-R150)

**Other improvements:**

* Marked `Term` as `Sendable` to support concurrency. (`Sources/SQL/Filter.swift`)

These changes collectively enable full support for user-defined scalar functions in SQL, from parsing through execution.