### PR TITLE
SQL: clean up tests

### DIFF
--- a/Tests/SQLTests/AggregateTests.swift
+++ b/Tests/SQLTests/AggregateTests.swift
@@ -2,98 +2,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 import Testing
-@testable import SQL
-
-// MARK: - In-memory adapter
-
-/// An in-memory relation: a fixed schema plus rows of typed values.
-///
-/// This harness knows nothing of WinMD — it is a self-contained fixture for the
-/// aggregation (`GROUP BY`/`HAVING`/`COUNT`/`SUM`/`MIN`/`MAX`/`AVG`) tests,
-/// deliberately independent of `EngineTests.swift`/`LimitTests.swift` so the
-/// files reconcile cleanly. No column is marked seekable — aggregation reads
-/// every row of a group, so a seek is beside the point here.
-private struct AggregateRelation: Sendable {
-  let names: Array<String>
-  let records: Array<Array<Value>>
-
-  init(_ names: Array<String>, _ records: Array<Array<Value>>) {
-    self.names = names
-    self.records = records
-  }
-}
-
-/// A `Catalog` over a dictionary of named relations.
-private struct AggregateMemory: Catalog {
-  let catalog: Dictionary<String, AggregateRelation>
-
-  init(_ relations: Dictionary<String, AggregateRelation>) {
-    self.catalog = relations
-  }
-
-  func table(named name: String) -> AggregateTable? {
-    guard let relation = catalog[name] else { return nil }
-    return AggregateTable(relation)
-  }
-
-  func relations() -> Array<String> {
-    Array(catalog.keys)
-  }
-}
-
-/// A `Table` over one in-memory relation.
-private struct AggregateTable: Table {
-  let relation: AggregateRelation
-
-  init(_ relation: AggregateRelation) {
-    self.relation = relation
-  }
-
-  var width: Int { relation.names.count }
-
-  var names: Array<String> { relation.names }
-
-  func ordinal(of name: String) -> Int? {
-    relation.names.firstIndex(of: name)
-  }
-
-  func bound(_ column: Int, _ value: Int, strict: Bool) -> Int? { nil }
-
-  func cursor() -> AggregateCursor {
-    AggregateCursor(relation)
-  }
-}
-
-/// An index-addressed cursor over a relation's rows.
-private struct AggregateCursor: Cursor {
-  let relation: AggregateRelation
-
-  init(_ relation: AggregateRelation) {
-    self.relation = relation
-  }
-
-  var count: Int { relation.records.count }
-
-  func row(_ index: Int) -> AggregateRow? {
-    guard index < relation.records.count else { return nil }
-    return AggregateRow(relation, index)
-  }
-}
-
-/// A positional view over one row's cells.
-private struct AggregateRow: Row {
-  let relation: AggregateRelation
-  let index: Int
-
-  init(_ relation: AggregateRelation, _ index: Int) {
-    self.relation = relation
-    self.index = index
-  }
-
-  subscript(_ column: Int) -> Value {
-    borrowing get { relation.records[index][column] }
-  }
-}
+import SQL
+import SQLTestSupport
 
 // MARK: - Fixtures
 
@@ -101,34 +11,19 @@ private struct AggregateRow: Row {
 /// regions, and a NULL `Amount` (a row `COUNT(*)` counts but `COUNT(Amount)`,
 /// `SUM`, `MIN`, `MAX`, `AVG` skip). One department (`Toys`) has ONLY a NULL
 /// amount, exercising the all-NULL group (`SUM`/`AVG` NULL, `COUNT(Amount)` 0).
-private func sales() -> AggregateMemory {
-  let records = [
-    [.text("Books"), .text("East"), .integer(10)],
-    [.text("Books"), .text("East"), .integer(20)],
-    [.text("Books"), .text("West"), .integer(30)],
-    [.text("Games"), .text("East"), .integer(40)],
-    [.text("Games"), .text("West"), .null],
-    [.text("Games"), .text("West"), .integer(50)],
-    [.text("Toys"), .text("East"), .null],
-  ] as Array<Array<Value>>
-  return AggregateMemory(["Sales":
-      AggregateRelation(["Dept", "Region", "Amount"], records)])
-}
-
-// MARK: - Helpers
-
-/// Parses `text` to a query, failing on any other statement.
-private func parse(_ text: String) throws -> Query {
-  guard case let .select(query) = try Statement(parsing: text) else {
-    Issue.record("expected a SELECT statement")
-    throw SQLError.incomplete(expected: "a SELECT statement")
+private func sales() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("Sales",
+             ["Dept": .text, "Region": .text, "Amount": .integer]) {
+      Row("Books", "East", 10)
+      Row("Books", "East", 20)
+      Row("Books", "West", 30)
+      Row("Games", "East", 40)
+      Row("Games", "West", nil)
+      Row("Games", "West", 50)
+      Row("Toys", "East", nil)
+    }
   }
-  return query
-}
-
-/// Runs `text` against the `Sales` catalog, yielding the projected rows.
-private func run(_ text: String) throws -> Array<Array<Value>> {
-  try sales().run(parse(text))
 }
 
 // MARK: - Tests
@@ -136,111 +31,92 @@ private func run(_ text: String) throws -> Array<Array<Value>> {
 struct AggregateTests {
   @Test("COUNT(*) over the whole result counts every row")
   func countStar() throws {
-    #expect(try run("SELECT COUNT(*) FROM Sales") == [[.integer(7)]])
+    try sales().expect("SELECT COUNT(*) FROM Sales", yields: [[7]])
   }
 
   @Test("COUNT(*) over an empty result is zero, not no row")
   func countStarEmpty() throws {
     // The degenerate whole-result aggregation yields one group even over no
     // matching rows — COUNT is 0 rather than an empty result.
-    #expect(try run("SELECT COUNT(*) FROM Sales WHERE Dept = 'None'")
-            == [[.integer(0)]])
+    try sales().expect("SELECT COUNT(*) FROM Sales WHERE Dept = 'None'",
+                       yields: [[0]])
   }
 
   @Test("COUNT(expr) ignores NULLs where COUNT(*) does not")
   func countExpr() throws {
     // Five of the seven rows have a non-NULL Amount (two are NULL); COUNT(*)
     // counts all seven, COUNT(Amount) only the non-NULL five.
-    #expect(try run("SELECT COUNT(Amount), COUNT(*) FROM Sales")
-            == [[.integer(5), .integer(7)]])
+    try sales().expect("SELECT COUNT(Amount), COUNT(*) FROM Sales",
+                       yields: [[5, 7]])
   }
 
   @Test("SUM, MIN, MAX, and AVG skip NULLs over the whole result")
   func wholeResult() throws {
     // Amounts 10,20,30,40,50 (the NULLs skipped): SUM 150, MIN 10, MAX 50,
     // AVG 150/5 = 30.0 — real division to an approximate-numeric double.
-    let rows = try run("""
+    try sales().expect("""
         SELECT SUM(Amount), MIN(Amount), MAX(Amount), AVG(Amount) FROM Sales
-        """)
-    #expect(rows == [[.integer(150), .integer(10), .integer(50),
-                      .double(30.0)]])
+        """, yields: [[150, 10, 50, 30.0]])
   }
 
   @Test("AVG is real division yielding an approximate-numeric double")
   func avgReal() throws {
     // Books amounts 10,20,30 sum 60 over 3 → 20.0; Games 40,50 sum 90 over 2
     // → 45.0 — real division, not truncating; Toys all-NULL → NULL.
-    let rows = try run("""
+    try sales().expect("""
         SELECT Dept, AVG(Amount) FROM Sales GROUP BY Dept ORDER BY Dept
-        """)
-    #expect(rows == [[.text("Books"), .double(20.0)],
-                     [.text("Games"), .double(45.0)],
-                     [.text("Toys"), .null]])
+        """, yields: [["Books", 20.0], ["Games", 45.0], ["Toys", nil]])
   }
 
   @Test("AVG yields a fractional double where integer division truncates")
   func avgFractional() throws {
-    // Books amounts 10,20,30 sum 60 over 3 rows → 20.0; but the East Books
-    // pair 10,20 averages 15.0, and adding a third exercises a non-integral
-    // quotient: 10+20+30 = 60 over the two East rows would be 30/2 = 15.0.
-    let rows = try run("""
-        SELECT AVG(Amount) FROM Sales WHERE Dept = 'Books' AND Region = 'East'
-        """)
     // East Books are 10 and 20: (10 + 20) / 2 = 15.0.
-    #expect(rows == [[.double(15.0)]])
+    try sales().expect("""
+        SELECT AVG(Amount) FROM Sales WHERE Dept = 'Books' AND Region = 'East'
+        """, yields: [[15.0]])
   }
 
   @Test("an all-NULL group yields NULL for SUM/MIN/MAX/AVG and 0 for COUNT")
   func allNull() throws {
     // Toys has one row whose Amount is NULL: COUNT(*) counts the row (1),
     // COUNT(Amount) skips it (0), and the value aggregates are NULL.
-    let rows = try run("""
+    try sales().expect("""
         SELECT COUNT(*), COUNT(Amount), SUM(Amount), MIN(Amount),
                MAX(Amount), AVG(Amount)
           FROM Sales WHERE Dept = 'Toys'
-        """)
-    #expect(rows == [[.integer(1), .integer(0), .null, .null, .null, .null]])
+        """, yields: [[1, 0, nil, nil, nil, nil]])
   }
 
   @Test("GROUP BY one column aggregates each group")
   func groupByOne() throws {
-    let rows = try run("""
+    try sales().expect("""
         SELECT Dept, COUNT(*), SUM(Amount) FROM Sales
           GROUP BY Dept ORDER BY Dept
-        """)
-    #expect(rows == [[.text("Books"), .integer(3), .integer(60)],
-                     [.text("Games"), .integer(3), .integer(90)],
-                     [.text("Toys"), .integer(1), .null]])
+        """, yields: [["Books", 3, 60], ["Games", 3, 90], ["Toys", 1, nil]])
   }
 
   @Test("GROUP BY multiple columns keys on the tuple")
   func groupByMany() throws {
-    let rows = try run("""
-        SELECT Dept, Region, COUNT(*), SUM(Amount) FROM Sales
-          GROUP BY Dept, Region ORDER BY Dept
-        """)
     // (Books,East) 10+20, (Books,West) 30, (Games,East) 40, (Games,West)
     // NULL+50, (Toys,East) NULL. Ordered by Dept, ties by first appearance.
-    #expect(rows == [[.text("Books"), .text("East"), .integer(2), .integer(30)],
-                     [.text("Books"), .text("West"), .integer(1), .integer(30)],
-                     [.text("Games"), .text("East"), .integer(1), .integer(40)],
-                     [.text("Games"), .text("West"), .integer(2), .integer(50)],
-                     [.text("Toys"), .text("East"), .integer(1), .null]])
+    try sales().expect("""
+        SELECT Dept, Region, COUNT(*), SUM(Amount) FROM Sales
+          GROUP BY Dept, Region ORDER BY Dept
+        """, yields: [["Books", "East", 2, 30], ["Books", "West", 1, 30],
+                      ["Games", "East", 1, 40], ["Games", "West", 2, 50],
+                      ["Toys", "East", 1, nil]])
   }
 
   @Test("a compound ORDER BY sorts grouped output by each key in turn")
   func orderByCompound() throws {
     // Order groups by Dept ascending, breaking ties by Region descending — the
     // second key reverses only the rows the first leaves equal.
-    let rows = try run("""
+    try sales().expect("""
         SELECT Dept, Region, COUNT(*), SUM(Amount) FROM Sales
           GROUP BY Dept, Region ORDER BY Dept, Region DESC
-        """)
-    #expect(rows == [[.text("Books"), .text("West"), .integer(1), .integer(30)],
-                     [.text("Books"), .text("East"), .integer(2), .integer(30)],
-                     [.text("Games"), .text("West"), .integer(2), .integer(50)],
-                     [.text("Games"), .text("East"), .integer(1), .integer(40)],
-                     [.text("Toys"), .text("East"), .integer(1), .null]])
+        """, yields: [["Books", "West", 1, 30], ["Books", "East", 2, 30],
+                      ["Games", "West", 2, 50], ["Games", "East", 1, 40],
+                      ["Toys", "East", 1, nil]])
   }
 
   @Test("mixed integer/double group keys canonicalize into one group")
@@ -249,10 +125,14 @@ struct AggregateTests {
     // groups them together under the engine's EXACT numeric equality (the same
     // `1` = `1.0` UNION dedup uses), yielding one group of two keyed by the
     // first-appearance integer, not two one-row groups.
-    let catalog = AggregateMemory(
-        ["T": AggregateRelation(["x"], [[.integer(1)], [.double(1.0)]])])
-    let rows = try catalog.run(parse("SELECT x, COUNT(*) FROM T GROUP BY x"))
-    #expect(rows == [[.integer(1), .integer(2)]])
+    let catalog = try Catalog {
+      Relation("T", ["x": .integer]) {
+        Row(1)
+        Row(1.0)
+      }
+    }
+    try catalog.expect("SELECT x, COUNT(*) FROM T GROUP BY x",
+                       yields: [[1, 2]])
   }
 
   @Test("mixed SUM/AVG widening does not depend on row order")
@@ -261,18 +141,24 @@ struct AggregateTests {
     // widens the total to a double — so the result must be the same
     // whether the overflowing integer prefix or the double is seen first, not a
     // SQLError.magnitude one way and a double the other.
-    let prefix = AggregateMemory(
-        ["T": AggregateRelation(
-            ["x"], [[.integer(.max)], [.integer(1)], [.double(0.5)]])])
-    let suffix = AggregateMemory(
-        ["T": AggregateRelation(
-            ["x"], [[.double(0.5)], [.integer(.max)], [.integer(1)]])])
+    let prefix = try Catalog {
+      Relation("T", ["x": .integer]) {
+        Row(Int.max)
+        Row(1)
+        Row(0.5)
+      }
+    }
+    let suffix = try Catalog {
+      Relation("T", ["x": .integer]) {
+        Row(0.5)
+        Row(Int.max)
+        Row(1)
+      }
+    }
     let expected = Double(Int.max) + 1.0 + 0.5
     let query = "SELECT SUM(x), AVG(x) FROM T"
-    #expect(try prefix.run(parse(query))
-            == [[.double(expected), .double(expected / 3)]])
-    #expect(try suffix.run(parse(query))
-            == [[.double(expected), .double(expected / 3)]])
+    try prefix.expect(query, yields: [[expected, expected / 3]])
+    try suffix.expect(query, yields: [[expected, expected / 3]])
   }
 
   @Test("all-integer SUM tolerates transient overflow if the total fits")
@@ -280,32 +166,44 @@ struct AggregateTests {
     // A prefix that overflows Int (Int.max + 1) must not latch a fault when a
     // later value (-1) brings the exact total back into range — the result is
     // the mathematical total, Int.max, whichever order the rows arrive in.
-    let up = AggregateMemory(
-        ["T": AggregateRelation(
-            ["x"], [[.integer(.max)], [.integer(1)], [.integer(-1)]])])
-    let down = AggregateMemory(
-        ["T": AggregateRelation(
-            ["x"], [[.integer(.max)], [.integer(-1)], [.integer(1)]])])
-    #expect(try up.run(parse("SELECT SUM(x) FROM T"))
-            == [[.integer(.max)]])
-    #expect(try down.run(parse("SELECT SUM(x) FROM T"))
-            == [[.integer(.max)]])
-    // A total that genuinely exceeds Int still faults, in any order.
-    let over = AggregateMemory(
-        ["T": AggregateRelation(["x"], [[.integer(.max)], [.integer(.max)]])])
-    #expect(throws: SQLError.magnitude("integer overflow")) {
-      try over.run(parse("SELECT SUM(x) FROM T"))
+    let up = try Catalog {
+      Relation("T", ["x": .integer]) {
+        Row(Int.max)
+        Row(1)
+        Row(-1)
+      }
     }
+    let down = try Catalog {
+      Relation("T", ["x": .integer]) {
+        Row(Int.max)
+        Row(-1)
+        Row(1)
+      }
+    }
+    try up.expect("SELECT SUM(x) FROM T", yields: [[Int.max]])
+    try down.expect("SELECT SUM(x) FROM T", yields: [[Int.max]])
+    // A total that genuinely exceeds Int still faults, in any order.
+    let over = try Catalog {
+      Relation("T", ["x": .integer]) {
+        Row(Int.max)
+        Row(Int.max)
+      }
+    }
+    over.expect("SELECT SUM(x) FROM T",
+                fails: .magnitude("integer overflow"))
   }
 
   @Test("AVG divides a wide integer total that SUM could not represent")
   func avgWideIntegerTotal() throws {
     // Two Int.max rows sum to 2 * Int.max, outside Int — SUM would fault, but
     // AVG divides the wide total and returns the finite approximate mean.
-    let catalog = AggregateMemory(
-        ["T": AggregateRelation(["x"], [[.integer(.max)], [.integer(.max)]])])
-    #expect(try catalog.run(parse("SELECT AVG(x) FROM T"))
-            == [[.double(Double(Int.max))]])
+    let catalog = try Catalog {
+      Relation("T", ["x": .integer]) {
+        Row(Int.max)
+        Row(Int.max)
+      }
+    }
+    try catalog.expect("SELECT AVG(x) FROM T", yields: [[Double(Int.max)]])
   }
 
   @Test("MIN/MAX over incomparable kinds is a type error, either order")
@@ -314,18 +212,22 @@ struct AggregateTests {
     // across kinds — MIN/MAX rejects it rather than keeping the first-seen
     // value (which would flip MIN and MAX with row order).
     let fault = SQLError.operand("MIN and MAX require a common comparable kind")
-    let textFirst = AggregateMemory(
-        ["T": AggregateRelation(["x"], [[.text("a")], [.integer(1)]])])
-    let intFirst = AggregateMemory(
-        ["T": AggregateRelation(["x"], [[.integer(1)], [.text("a")]])])
-    for catalog in [textFirst, intFirst] {
-      #expect(throws: fault) {
-        try catalog.run(parse("SELECT MIN(x) FROM T"))
-      }
-      #expect(throws: fault) {
-        try catalog.run(parse("SELECT MAX(x) FROM T"))
+    let textFirst = try Catalog {
+      Relation("T", ["x": .text]) {
+        Row("a")
+        Row(1)
       }
     }
+    let intFirst = try Catalog {
+      Relation("T", ["x": .integer]) {
+        Row(1)
+        Row("a")
+      }
+    }
+    textFirst.expect("SELECT MIN(x) FROM T", fails: fault)
+    textFirst.expect("SELECT MAX(x) FROM T", fails: fault)
+    intFirst.expect("SELECT MIN(x) FROM T", fails: fault)
+    intFirst.expect("SELECT MAX(x) FROM T", fails: fault)
   }
 
   @Test("MIN/MAX over Int.max and Double(Int.max) is deterministic")
@@ -333,16 +235,22 @@ struct AggregateTests {
     // Int.max (2^63 - 1) and Double(Int.max) (2^63) are both numeric and order
     // exactly, so MIN is the integer and MAX the larger double — same result
     // whichever row arrives first, not an order-dependent first-seen keep.
-    let intFirst = AggregateMemory(
-        ["T": AggregateRelation(
-            ["x"], [[.integer(.max)], [.double(Double(Int.max))]])])
-    let doubleFirst = AggregateMemory(
-        ["T": AggregateRelation(
-            ["x"], [[.double(Double(Int.max))], [.integer(.max)]])])
-    for catalog in [intFirst, doubleFirst] {
-      #expect(try catalog.run(parse("SELECT MIN(x), MAX(x) FROM T"))
-              == [[.integer(.max), .double(Double(Int.max))]])
+    let intFirst = try Catalog {
+      Relation("T", ["x": .integer]) {
+        Row(Int.max)
+        Row(Double(Int.max))
+      }
     }
+    let doubleFirst = try Catalog {
+      Relation("T", ["x": .integer]) {
+        Row(Double(Int.max))
+        Row(Int.max)
+      }
+    }
+    try intFirst.expect("SELECT MIN(x), MAX(x) FROM T",
+                        yields: [[Int.max, Double(Int.max)]])
+    try doubleFirst.expect("SELECT MIN(x), MAX(x) FROM T",
+                           yields: [[Int.max, Double(Int.max)]])
   }
 
   @Test("ORDER BY on a duplicated projection output name is ambiguous")
@@ -351,68 +259,59 @@ struct AggregateTests {
     // single slot to order on — rejected as ambiguous (as the non-grouped path
     // reports for a shared unqualified join column) rather than silently
     // ordering by whichever projection came last.
-    #expect(throws: SQLError.ambiguous("k")) {
-      try run("""
-          SELECT Dept AS k, Region AS k FROM Sales
-            GROUP BY Dept, Region ORDER BY k
-          """)
-    }
+    try sales().expect("""
+        SELECT Dept AS k, Region AS k FROM Sales
+          GROUP BY Dept, Region ORDER BY k
+        """, fails: .ambiguous("k"))
   }
 
   @Test("MIN and MAX use the engine's typed comparison per group")
   func minMax() throws {
-    let rows = try run("""
+    try sales().expect("""
         SELECT Dept, MIN(Amount), MAX(Amount) FROM Sales
           GROUP BY Dept ORDER BY Dept
-        """)
-    #expect(rows == [[.text("Books"), .integer(10), .integer(30)],
-                     [.text("Games"), .integer(40), .integer(50)],
-                     [.text("Toys"), .null, .null]])
+        """, yields: [["Books", 10, 30], ["Games", 40, 50],
+                      ["Toys", nil, nil]])
   }
 
   @Test("HAVING filters groups after aggregation")
   func having() throws {
     // Keep only departments whose row count exceeds one — Toys (1 row) drops.
-    let rows = try run("""
+    try sales().expect("""
         SELECT Dept, COUNT(*) FROM Sales
           GROUP BY Dept HAVING COUNT(*) > 1 ORDER BY Dept
-        """)
-    #expect(rows == [[.text("Books"), .integer(3)],
-                     [.text("Games"), .integer(3)]])
+        """, yields: [["Books", 3], ["Games", 3]])
   }
 
   @Test("HAVING may reference an aggregate not in the projection")
   func havingHidden() throws {
     // The HAVING aggregates SUM(Amount) though the projection does not — the
     // engine still computes it for the group filter.
-    let rows = try run("""
+    // Books SUM 60 drops, Games SUM 90 keeps, Toys SUM NULL drops (UNKNOWN).
+    try sales().expect("""
         SELECT Dept FROM Sales
           GROUP BY Dept HAVING SUM(Amount) > 70 ORDER BY Dept
-        """)
-    // Books SUM 60 drops, Games SUM 90 keeps, Toys SUM NULL drops (UNKNOWN).
-    #expect(rows == [[.text("Games")]])
+        """, yields: [["Games"]])
   }
 
   @Test("HAVING without a GROUP BY filters the single whole-result group")
   func havingWholeResult() throws {
     // The whole result is one group; HAVING keeps or drops it. COUNT(*) is 7.
-    #expect(try run("SELECT COUNT(*) FROM Sales HAVING COUNT(*) > 5")
-            == [[.integer(7)]])
-    #expect(try run("SELECT COUNT(*) FROM Sales HAVING COUNT(*) > 100") == [])
+    let catalog = try sales()
+    try catalog.expect("SELECT COUNT(*) FROM Sales HAVING COUNT(*) > 5",
+                       yields: [[7]])
+    try catalog.empty("SELECT COUNT(*) FROM Sales HAVING COUNT(*) > 100")
   }
 
   @Test("ORDER BY may name an aggregate's projection alias")
   func orderByAggregate() throws {
     // Order the departments by their total descending — the ORDER BY names the
     // aggregate's output alias `Total`.
-    let rows = try run("""
+    // Games 90, Books 60, Toys NULL (NULL sorts last descending).
+    try sales().expect("""
         SELECT Dept, SUM(Amount) AS Total FROM Sales
           GROUP BY Dept ORDER BY Total DESC
-        """)
-    // Games 90, Books 60, Toys NULL (NULL sorts last descending).
-    #expect(rows == [[.text("Games"), .integer(90)],
-                     [.text("Books"), .integer(60)],
-                     [.text("Toys"), .null]])
+        """, yields: [["Games", 90], ["Books", 60], ["Toys", nil]])
   }
 
   @Test("ORDER BY on a computed-expression alias is rejected clearly")
@@ -421,52 +320,47 @@ struct AggregateTests {
     // the sort), so it has no standalone grouped slot to order on — the engine
     // rejects it as unsupported rather than misreporting an unknown column.
     #expect(throws: SQLError.self) {
-      try run("""
+      try sales().run(Statement(parsing: """
           SELECT Dept, COUNT(*) * 2 AS Doubled FROM Sales
             GROUP BY Dept ORDER BY Doubled DESC
-          """)
+          """))
     }
   }
 
   @Test("an aggregate query pages with OFFSET/FETCH after ORDER BY")
   func aggregateFetch() throws {
     // Three groups ordered by Dept; skip one, take one.
-    let rows = try run("""
+    try sales().expect("""
         SELECT Dept, COUNT(*) FROM Sales
           GROUP BY Dept ORDER BY Dept OFFSET 1 ROWS FETCH NEXT 1 ROWS ONLY
-        """)
-    #expect(rows == [[.text("Games"), .integer(3)]])
+        """, yields: [["Games", 3]])
   }
 
   @Test("an aggregate mixes with a scalar arithmetic over the group key")
   func mixedProjection() throws {
     // A grouped query may project the key through arithmetic and a scalar
     // expression alongside the aggregate; COUNT(*) doubled proves it composes.
-    let rows = try run("""
+    try sales().expect("""
         SELECT Dept, COUNT(*) * 2 FROM Sales
           GROUP BY Dept ORDER BY Dept
-        """)
-    #expect(rows == [[.text("Books"), .integer(6)],
-                     [.text("Games"), .integer(6)],
-                     [.text("Toys"), .integer(2)]])
+        """, yields: [["Books", 6], ["Games", 6], ["Toys", 2]])
   }
 
   @Test("a non-grouped projection column is rejected")
   func projectionRule() throws {
     // `Region` is neither aggregated nor a GROUP BY key, so the query is
     // ill-formed — the standard single-group rule.
-    #expect(throws: SQLError.grouping("Region")) {
-      try run("SELECT Dept, Region, COUNT(*) FROM Sales GROUP BY Dept")
-    }
+    try sales().expect(
+        "SELECT Dept, Region, COUNT(*) FROM Sales GROUP BY Dept",
+        fails: .grouping("Region"))
   }
 
   @Test("a bare column with no GROUP BY and an aggregate is rejected")
   func bareColumnRule() throws {
     // Mixing a bare column with an aggregate and no GROUP BY groups the whole
     // result — the column is then not a key, so it faults.
-    #expect(throws: SQLError.grouping("Dept")) {
-      try run("SELECT Dept, COUNT(*) FROM Sales")
-    }
+    try sales().expect("SELECT Dept, COUNT(*) FROM Sales",
+                       fails: .grouping("Dept"))
   }
 
   @Test("the projection-rule fault carries the SS004 SQLSTATE")
@@ -478,37 +372,37 @@ struct AggregateTests {
   func sumText() throws {
     // SUM/AVG require numeric operands; folding a text value faults through the
     // engine's arithmetic rather than coercing.
-    #expect(throws: SQLError.operand("operands must be numeric")) {
-      try run("SELECT SUM(Dept) FROM Sales")
-    }
+    try sales().expect("SELECT SUM(Dept) FROM Sales",
+                       fails: .operand("operands must be numeric"))
   }
 
   @Test("AVG over a text column is a type error")
   func avgText() throws {
     // AVG folds the same numeric total as SUM, so a text operand faults alike.
-    #expect(throws: SQLError.operand("operands must be numeric")) {
-      try run("SELECT AVG(Dept) FROM Sales")
-    }
+    try sales().expect("SELECT AVG(Dept) FROM Sales",
+                       fails: .operand("operands must be numeric"))
   }
 
   @Test("only COUNT admits a '*' operand")
   func starOnlyCount() throws {
     // `SUM(*)`/`AVG(*)`/`MIN(*)`/`MAX(*)` are not valid — only `COUNT(*)`
     // counts rows without reading a value.
+    let catalog = try sales()
     for function in ["SUM", "AVG", "MIN", "MAX"] {
       #expect(throws: SQLError.self) {
-        try run("SELECT \(function)(*) FROM Sales")
+        try catalog.run(Statement(parsing: "SELECT \(function)(*) FROM Sales"))
       }
     }
     // `COUNT(*)` remains valid — it counts every row.
-    #expect(try run("SELECT COUNT(*) FROM Sales") == [[.integer(7)]])
+    try catalog.expect("SELECT COUNT(*) FROM Sales", yields: [[7]])
   }
 
   @Test("an aggregate in a WHERE clause is rejected")
   func aggregateInWhere() throws {
     // An aggregate has no per-row meaning, so it may not appear in a WHERE.
     #expect(throws: SQLError.self) {
-      try run("SELECT Dept FROM Sales WHERE COUNT(*) > 1 GROUP BY Dept")
+      try sales().run(Statement(parsing:
+          "SELECT Dept FROM Sales WHERE COUNT(*) > 1 GROUP BY Dept"))
     }
   }
 
@@ -516,60 +410,66 @@ struct AggregateTests {
   func aggregateOverJoin() throws {
     // Aggregation sits above the join chain, so a grouped query over a join
     // folds each aggregate over the joined rows and keys on a qualified column.
-    let catalog = AggregateMemory([
-      "Dept": AggregateRelation(["Id", "Name"],
-          [[.integer(1), .text("Books")], [.integer(2), .text("Games")]]),
-      "Item": AggregateRelation(["DeptId", "Price"],
-          [[.integer(1), .integer(10)], [.integer(1), .integer(20)],
-           [.integer(2), .integer(40)]]),
-    ])
-    let rows = try catalog.run(parse("""
+    let catalog = try Catalog {
+      Relation("Dept", ["Id": .integer, "Name": .text]) {
+        Row(1, "Books")
+        Row(2, "Games")
+      }
+      Relation("Item", ["DeptId": .integer, "Price": .integer]) {
+        Row(1, 10)
+        Row(1, 20)
+        Row(2, 40)
+      }
+    }
+    try catalog.expect("""
         SELECT Dept.Name, SUM(Item.Price) FROM Dept
           JOIN Item ON Item.DeptId = Dept.Id
           GROUP BY Dept.Name ORDER BY Dept.Name
-        """))
-    #expect(rows == [[.text("Books"), .integer(30)],
-                     [.text("Games"), .integer(40)]])
+        """, yields: [["Books", 30], ["Games", 40]])
   }
 
   @Test("SUM over an all-integer column stays an exact integer")
   func sumIntegerExact() throws {
     // Every folded value is an integer, so the total stays an integer — the
     // engine's arithmetic keeps `integer + integer` integral.
-    #expect(try run("SELECT SUM(Amount) FROM Sales")
-            == [[.integer(150)]])
+    try sales().expect("SELECT SUM(Amount) FROM Sales", yields: [[150]])
   }
 
   @Test("SUM over a double column yields a double")
   func sumDouble() throws {
-    let catalog = AggregateMemory([
-      "T": AggregateRelation(["X"],
-          [[.double(1.5)], [.double(2.25)], [.double(0.25)]]),
-    ])
+    let catalog = try Catalog {
+      Relation("T", ["X": .double]) {
+        Row(1.5)
+        Row(2.25)
+        Row(0.25)
+      }
+    }
     // 1.5 + 2.25 + 0.25 = 4.0 — the running total widens to a double.
-    let rows = try catalog.run(parse("SELECT SUM(X) FROM T"))
-    #expect(rows == [[.double(4.0)]])
+    try catalog.expect("SELECT SUM(X) FROM T", yields: [[4.0]])
   }
 
   @Test("SUM over mixed integer and double columns widens to a double")
   func sumMixed() throws {
-    let catalog = AggregateMemory([
-      "T": AggregateRelation(["X"],
-          [[.integer(10)], [.double(2.5)], [.integer(20)]]),
-    ])
+    let catalog = try Catalog {
+      Relation("T", ["X": .integer]) {
+        Row(10)
+        Row(2.5)
+        Row(20)
+      }
+    }
     // 10 + 2.5 + 20 = 32.5 — a lone double operand widens the whole total.
-    let rows = try catalog.run(parse("SELECT SUM(X) FROM T"))
-    #expect(rows == [[.double(32.5)]])
+    try catalog.expect("SELECT SUM(X) FROM T", yields: [[32.5]])
   }
 
   @Test("AVG over a double column is a double")
   func avgDouble() throws {
-    let catalog = AggregateMemory([
-      "T": AggregateRelation(["X"],
-          [[.double(1.0)], [.double(2.0)]]),
-    ])
+    let catalog = try Catalog {
+      Relation("T", ["X": .double]) {
+        Row(1.0)
+        Row(2.0)
+      }
+    }
     // (1.0 + 2.0) / 2 = 1.5 — real division over a double total.
-    let rows = try catalog.run(parse("SELECT AVG(X) FROM T"))
-    #expect(rows == [[.double(1.5)]])
+    try catalog.expect("SELECT AVG(X) FROM T", yields: [[1.5]])
   }
 }

--- a/Tests/SQLTests/DefinitionSchemaTests.swift
+++ b/Tests/SQLTests/DefinitionSchemaTests.swift
@@ -2,106 +2,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 import Testing
-@testable import SQL
-
-// MARK: - In-memory adapter
-
-/// A typed in-memory relation — a column name/kind list and rows — for the
-/// DEFINITION_SCHEMA store tests.
-private struct StoreRelation: Sendable {
-  let names: Array<String>
-  let types: Array<ValueType>
-  let records: Array<Array<Value>>
-
-  init(_ columns: Array<(String, ValueType)>,
-       _ records: Array<Array<Value>> = []) {
-    self.names = columns.map(\.0)
-    self.types = columns.map(\.1)
-    self.records = records
-  }
-}
-
-/// A `Catalog` over named typed relations plus registered views, the store
-/// enumerates through `relations()`/`views()`.
-private struct StoreCatalog: Catalog {
-  let catalog: Dictionary<String, StoreRelation>
-  let registered: Dictionary<String, View>
-
-  init(_ catalog: Dictionary<String, StoreRelation>,
-       views: Dictionary<String, View> = [:]) {
-    self.catalog = catalog
-    self.registered = views
-  }
-
-  func table(named name: String) -> StoreTable? {
-    guard let relation = catalog[name] else { return nil }
-    return StoreTable(relation)
-  }
-
-  func view(named name: String) -> View? {
-    registered[name]
-  }
-
-  func relations() -> Array<String> {
-    catalog.keys.sorted()
-  }
-
-  func views() -> Array<String> {
-    registered.keys.sorted()
-  }
-}
-
-/// A `Table` over one typed relation.
-private struct StoreTable: Table {
-  let relation: StoreRelation
-
-  init(_ relation: StoreRelation) {
-    self.relation = relation
-  }
-
-  var width: Int { relation.names.count }
-  var names: Array<String> { relation.names }
-  var types: Array<ValueType> { relation.types }
-
-  func ordinal(of name: String) -> Int? {
-    relation.names.firstIndex(of: name)
-  }
-
-  func bound(_ column: Int, _ value: Int, strict: Bool) -> Int? { nil }
-
-  func cursor() -> StoreCursor {
-    StoreCursor(relation)
-  }
-}
-
-private struct StoreCursor: Cursor {
-  let relation: StoreRelation
-
-  init(_ relation: StoreRelation) {
-    self.relation = relation
-  }
-
-  var count: Int { relation.records.count }
-
-  func row(_ index: Int) -> StoreRow? {
-    guard index < relation.records.count else { return nil }
-    return StoreRow(relation, index)
-  }
-}
-
-private struct StoreRow: Row {
-  let relation: StoreRelation
-  let index: Int
-
-  init(_ relation: StoreRelation, _ index: Int) {
-    self.relation = relation
-    self.index = index
-  }
-
-  subscript(_ column: Int) -> Value {
-    borrowing get { relation.records[index][column] }
-  }
-}
+import SQL
+import SQLTestSupport
 
 // MARK: - Helpers
 
@@ -119,14 +21,13 @@ private func parse(_ text: String) throws -> Query {
 @Suite struct DefinitionSchemaTests {
   @Test("definition_schema.columns lists a base relation's columns")
   func columns() throws {
-    let cat = StoreCatalog([
-      "People": StoreRelation([("Name", .text), ("Age", .integer)]),
-    ])
-    let rows = try cat.run(parse("""
+    let catalog = try Catalog {
+      Relation("People", ["Name": .text, "Age": .integer])
+    }
+    try catalog.expect("""
         SELECT column_name FROM definition_schema.columns
          WHERE table_name = 'People'
-        """))
-    #expect(rows == [[.text("Name")], [.text("Age")]])
+        """, yields: [["Name"], ["Age"]])
   }
 
   @Test("definition_schema.columns skips a cyclic view and stays usable")
@@ -140,20 +41,19 @@ private func parse(_ text: String) throws -> Query {
     // base relation still reports.
     let a = try parse("SELECT * FROM B")
     let b = try parse("SELECT * FROM A")
-    let cat = StoreCatalog(
-        ["People": StoreRelation([("Name", .text)])],
+    let catalog = FixtureCatalog(
+        ["People": FixtureRelation([FixtureField(name: "Name", type: .text)],
+                                   [])],
         views: ["A": View(query: a, columns: ["x"]),
                 "B": View(query: b, columns: ["y"])])
-    let people = try cat.run(parse("""
+    try catalog.expect("""
         SELECT column_name FROM definition_schema.columns
          WHERE table_name = 'People'
-        """))
-    #expect(people == [[.text("Name")]])
-    let cyclic = try cat.run(parse("""
+        """, yields: [["Name"]])
+    try catalog.empty("""
         SELECT column_name FROM definition_schema.columns
          WHERE table_name = 'A' OR table_name = 'B'
-        """))
-    #expect(cyclic == [])
+        """)
   }
 
   @Test("definition_schema.tables lists a cyclic view without crashing")
@@ -165,11 +65,12 @@ private func parse(_ text: String) throws -> Query {
     // does not break this).
     let a = try parse("SELECT * FROM B")
     let b = try parse("SELECT * FROM A")
-    let cat = StoreCatalog(
-        ["People": StoreRelation([("Name", .text)])],
+    let catalog = FixtureCatalog(
+        ["People": FixtureRelation([FixtureField(name: "Name", type: .text)],
+                                   [])],
         views: ["A": View(query: a, columns: ["x"]),
                 "B": View(query: b, columns: ["y"])])
-    let names = try cat.run(parse("""
+    let names = try catalog.run(parse("""
         SELECT table_name FROM definition_schema.tables
         """))
     #expect(names.contains([.text("People")]))

--- a/Tests/SQLTests/IntrospectionTests.swift
+++ b/Tests/SQLTests/IntrospectionTests.swift
@@ -2,124 +2,42 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 import Testing
-@testable import SQL
+import SQL
+
+import SQLTestSupport
 
 // MARK: - In-memory adapter
 
-/// A typed in-memory relation — a column name/kind list and rows — for the
-/// INFORMATION_SCHEMA overlay tests.
-private struct MetaRelation: Sendable {
-  let names: Array<String>
-  let types: Array<ValueType>
-  let records: Array<Array<Value>>
+// The INFORMATION_SCHEMA overlay tests run over the shared SQLTestSupport
+// store, whose `FixtureCatalog`/`FixtureTable` already model named typed
+// relations, registered views, and a virtual `Id` past each relation's real
+// columns — exactly the shape these tests built by hand. `MetaCatalog` aliases
+// the shared catalog so the inline fixtures read as before, and `MetaRelation`
+// lifts the tests' `[(name, kind)]` schema tuples (with optional rows) into a
+// `FixtureRelation`. The store folds `relations()`/`views()` case-insensitively
+// and returns them unordered; every test that observes the enumeration sorts it
+// with an explicit `ORDER BY`, so the order is unobservable here.
+private typealias MetaCatalog = FixtureCatalog
 
-  init(_ columns: Array<(String, ValueType)>,
-       _ records: Array<Array<Value>> = []) {
-    self.names = columns.map(\.0)
-    self.types = columns.map(\.1)
-    self.records = records
-  }
-}
-
-/// A `Catalog` over named typed relations plus registered views, exposing a
-/// virtual `Id` past each relation's real columns (to prove the overlay reports
-/// only the real ones).
-private struct MetaCatalog: Catalog {
-  let catalog: Dictionary<String, MetaRelation>
-  let registered: Dictionary<String, View>
-
-  init(_ catalog: Dictionary<String, MetaRelation>,
-       views: Dictionary<String, View> = [:]) {
-    self.catalog = catalog
-    self.registered = views
-  }
-
-  func table(named name: String) -> MetaTable? {
-    guard let relation = catalog[name] else { return nil }
-    return MetaTable(relation)
-  }
-
-  func view(named name: String) -> View? {
-    registered[name]
-  }
-
-  func relations() -> Array<String> {
-    catalog.keys.sorted()
-  }
-
-  func views() -> Array<String> {
-    registered.keys.sorted()
-  }
-}
-
-/// A `Table` over one typed relation, with a lone virtual `Id` at `width`.
-private struct MetaTable: Table {
-  let relation: MetaRelation
-
-  init(_ relation: MetaRelation) {
-    self.relation = relation
-  }
-
-  var width: Int { relation.names.count }
-  var names: Array<String> { relation.names }
-  var types: Array<ValueType> { relation.types }
-  var virtuals: Array<String> { ["Id"] }
-  var extent: Int { width + 1 }
-
-  func ordinal(of name: String) -> Int? {
-    if name == "Id" { return width }
-    return relation.names.firstIndex(of: name)
-  }
-
-  func bound(_ column: Int, _ value: Int, strict: Bool) -> Int? { nil }
-
-  func cursor() -> MetaCursor {
-    MetaCursor(relation)
-  }
-}
-
-private struct MetaCursor: Cursor {
-  let relation: MetaRelation
-
-  init(_ relation: MetaRelation) {
-    self.relation = relation
-  }
-
-  var count: Int { relation.records.count }
-
-  func row(_ index: Int) -> MetaRow? {
-    guard index < relation.records.count else { return nil }
-    return MetaRow(relation, index)
-  }
-}
-
-private struct MetaRow: Row {
-  let relation: MetaRelation
-  let index: Int
-
-  init(_ relation: MetaRelation, _ index: Int) {
-    self.relation = relation
-    self.index = index
-  }
-
-  subscript(_ column: Int) -> Value {
-    borrowing get {
-      column == relation.names.count ? .integer(index + 1)
-                                     : relation.records[index][column]
-    }
-  }
+/// A `FixtureRelation` from a `[(name, kind)]` schema and optional rows — the
+/// shape the introspection fixtures declare their relations in.
+private func MetaRelation(_ columns: Array<(String, ValueType)>,
+                          _ records: Array<Array<Value>> = [])
+    -> FixtureRelation {
+  FixtureRelation(columns.map { FixtureField(name: $0.0, type: $0.1) }, records)
 }
 
 // MARK: - Fixtures
 
 /// A catalog of two base relations — `People` (a text column, an integer
 /// column) and `Widget` (one text column) — and one registered view `Adults`.
-private func catalog() -> MetaCatalog {
+private func catalog() throws -> MetaCatalog {
   MetaCatalog([
     "People": MetaRelation([("Name", .text), ("Age", .integer)],
                            [[.text("Ann"), .integer(30)]]),
     "Widget": MetaRelation([("Label", .text)], [[.text("cog")]]),
-  ], views: ["Adults": View("SELECT Name FROM People")])
+  ], views: ["Adults": View(query: try parse("SELECT Name FROM People"),
+                            columns: ["Name"])])
 }
 
 // MARK: - Helpers
@@ -637,7 +555,7 @@ struct IntrospectionTests {
     // exactly what the inline query does.
     let body = try parse("""
         SELECT table_name FROM information_schema.tables
-          WHERE table_type = 'BASE TABLE'
+          WHERE table_type = 'BASE TABLE' ORDER BY table_name
         """)
     let source = MetaCatalog([
       "People": MetaRelation([("Name", .text), ("Age", .integer)]),
@@ -1470,7 +1388,7 @@ struct IntrospectionTests {
     // execution (`resolve`/`derive`), not only the top-level query.
     let body = try parse("""
         SELECT table_name FROM definition_schema.tables
-          WHERE table_type = 'BASE TABLE'
+          WHERE table_type = 'BASE TABLE' ORDER BY table_name
         """)
     let source = MetaCatalog([
       "People": MetaRelation([("Name", .text), ("Age", .integer)]),


### PR DESCRIPTION
This pull request refactors the test support code for SQL schema and introspection tests. The main change is to replace custom, inline in-memory catalog and relation implementations in the test files with shared, reusable test fixtures from `SQLTestSupport`. This reduces duplication and makes the tests more maintainable. Additionally, minor updates were made to test queries to ensure deterministic ordering.

**Test infrastructure refactoring:**

* Replaced custom in-memory implementations (`StoreCatalog`, `StoreRelation`, `MetaCatalog`, `MetaRelation`, etc.) in `DefinitionSchemaTests.swift` and `IntrospectionTests.swift` with shared `FixtureCatalog`, `FixtureRelation`, and related helpers from `SQLTestSupport`. This simplifies the test setup and unifies test infrastructure. [[1]](diffhunk://#diff-72f18021a3a4aa2d0e12c5a5856db290f60fec4197384b4114ba87595c6560b5L5-R6) [[2]](diffhunk://#diff-c9c78613ea11cc7a1aabd6b0f7d5ef7cea2c97d814ea0900af137e7a09518cb4L5-R40)

* Updated test fixtures to use the new helpers, e.g., using `Catalog { Relation(...) }` and `FixtureRelation` for defining test relations and views. [[1]](diffhunk://#diff-72f18021a3a4aa2d0e12c5a5856db290f60fec4197384b4114ba87595c6560b5L122-R30) [[2]](diffhunk://#diff-72f18021a3a4aa2d0e12c5a5856db290f60fec4197384b4114ba87595c6560b5L143-R56) [[3]](diffhunk://#diff-72f18021a3a4aa2d0e12c5a5856db290f60fec4197384b4114ba87595c6560b5L168-R73) [[4]](diffhunk://#diff-c9c78613ea11cc7a1aabd6b0f7d5ef7cea2c97d814ea0900af137e7a09518cb4L5-R40)

**Test query improvements:**

* Added explicit `ORDER BY` clauses to queries in `IntrospectionTests.swift` to ensure test results are deterministic and independent of catalog enumeration order. [[1]](diffhunk://#diff-c9c78613ea11cc7a1aabd6b0f7d5ef7cea2c97d814ea0900af137e7a09518cb4L640-R558) [[2]](diffhunk://#diff-c9c78613ea11cc7a1aabd6b0f7d5ef7cea2c97d814ea0900af137e7a09518cb4L1473-R1391)