### PR TITLE
winmd-inspect: rename the rowid pseudo-column to Id

### DIFF
--- a/Tests/SQLTests/ParserTests.swift
+++ b/Tests/SQLTests/ParserTests.swift
@@ -358,13 +358,13 @@ struct JoinTests {
   func listJoin() throws {
     let select = try parse(select: """
         SELECT m.Name FROM TypeDef AS t
-          JOIN MethodDef AS m ON m.parent = t.rowid
+          JOIN MethodDef AS m ON m.parent = t.Id
           WHERE t.TypeName = 'IUnknown'
         """)
     #expect(select.from == Relation(name: "TypeDef", alias: "t"))
     #expect(select.joins == [
       Join(relation: Relation(name: "MethodDef", alias: "m"),
-           left: Column("m.parent"), right: Column("t.rowid")),
+           left: Column("m.parent"), right: Column("t.Id")),
     ])
     #expect(select.projection == .columns([Column("m.Name")]))
     let value = Expression.literal(.string("IUnknown"))
@@ -376,11 +376,11 @@ struct JoinTests {
   func forwardJoin() throws {
     let select = try parse(select: """
         SELECT r.TypeName FROM TypeDef AS t
-          JOIN TypeRef AS r ON t.Extends = r.rowid
+          JOIN TypeRef AS r ON t.Extends = r.Id
         """)
     #expect(select.joins == [
       Join(relation: Relation(name: "TypeRef", alias: "r"),
-           left: Column("t.Extends"), right: Column("r.rowid")),
+           left: Column("t.Extends"), right: Column("r.Id")),
     ])
   }
 
@@ -388,13 +388,13 @@ struct JoinTests {
   func unaliasedJoin() throws {
     let select = try parse(select: """
         SELECT Name FROM MethodDef
-          JOIN Param ON Param.parent = MethodDef.rowid
+          JOIN Param ON Param.parent = MethodDef.Id
         """)
     #expect(select.from == Relation(name: "MethodDef"))
     #expect(select.joins == [
       Join(relation: Relation(name: "Param"),
            left: Column("Param.parent"),
-           right: Column("MethodDef.rowid")),
+           right: Column("MethodDef.Id")),
     ])
   }
 
@@ -402,15 +402,15 @@ struct JoinTests {
   func chainedJoins() throws {
     let select = try parse(select: """
         SELECT Param.Name FROM TypeDef AS t
-          JOIN MethodDef AS m ON m.parent = t.rowid
-          JOIN Param ON Param.parent = m.rowid
+          JOIN MethodDef AS m ON m.parent = t.Id
+          JOIN Param ON Param.parent = m.Id
         """)
     #expect(select.from == Relation(name: "TypeDef", alias: "t"))
     #expect(select.joins == [
       Join(relation: Relation(name: "MethodDef", alias: "m"),
-           left: Column("m.parent"), right: Column("t.rowid")),
+           left: Column("m.parent"), right: Column("t.Id")),
       Join(relation: Relation(name: "Param"),
-           left: Column("Param.parent"), right: Column("m.rowid")),
+           left: Column("Param.parent"), right: Column("m.Id")),
     ])
   }
 
@@ -424,7 +424,7 @@ struct JoinTests {
   @Test("rejects a join whose ON is not an equality")
   func nonEqualityOn() {
     #expect(throws: SQLError.self) {
-      _ = try Statement(parsing: "SELECT * FROM A JOIN B ON a.x < b.rowid")
+      _ = try Statement(parsing: "SELECT * FROM A JOIN B ON a.x < b.Id")
     }
   }
 }

--- a/Tests/winmd-inspectTests/DatabaseSQLTests.swift
+++ b/Tests/winmd-inspectTests/DatabaseSQLTests.swift
@@ -512,7 +512,7 @@ struct DatabaseSQLTests {
   @Test("the render decode spells each Param, nil for the return parameter")
   func paramType() {
     // The `Sequence == 0` return pseudo-parameter (`Param` Id 1) decodes to
-    // `nil`; the two real parameters (rowids 2 and 3) decode to the signature's
+    // `nil`; the two real parameters (Ids 2 and 3) decode to the signature's
     // `i4` (`CInt`) and `string` (`HSTRING`) — the render-time decode replacing
     // the old `ParamType` virtual column.
     DatabaseSQLTests.with { catalog in


### PR DESCRIPTION
`rowid` was a SQLite-ism; ISO SQL has no such non-standard pseudo-column name. The adapter's virtual identity column, its second producer in the CTE materialiser, the .sql query/render resources, and the pseudo-column doc-prose already spell it `Id` — the only stragglers were the parser join tests, which echo the join-key identifiers verbatim, and one prose comment. Align them so the codebase names the row identity `Id` throughout.

The rename is purely lexical: the SQL engine never special-cases the name — it resolves through the generic `virtuals`/`ordinal(of:)` surface by plain lookup — so this is behaviour-preserving. `SELECT *` is unchanged because the identity column stays a virtual past `width`.