### PR TITLE
Testing: adopt raw function names

### DIFF
--- a/Tests/SQLTests/AggregateTests.swift
+++ b/Tests/SQLTests/AggregateTests.swift
@@ -29,29 +29,25 @@ private func sales() throws -> FixtureCatalog {
 // MARK: - Tests
 
 struct AggregateTests {
-  @Test("COUNT(*) over the whole result counts every row")
-  func countStar() throws {
+  @Test func `COUNT(*) over the whole result counts every row`() throws {
     try sales().expect("SELECT COUNT(*) FROM Sales", yields: [[7]])
   }
 
-  @Test("COUNT(*) over an empty result is zero, not no row")
-  func countStarEmpty() throws {
+  @Test func `COUNT(*) over an empty result is zero, not no row`() throws {
     // The degenerate whole-result aggregation yields one group even over no
     // matching rows — COUNT is 0 rather than an empty result.
     try sales().expect("SELECT COUNT(*) FROM Sales WHERE Dept = 'None'",
                        yields: [[0]])
   }
 
-  @Test("COUNT(expr) ignores NULLs where COUNT(*) does not")
-  func countExpr() throws {
+  @Test func `COUNT(expr) ignores NULLs where COUNT(*) does not`() throws {
     // Five of the seven rows have a non-NULL Amount (two are NULL); COUNT(*)
     // counts all seven, COUNT(Amount) only the non-NULL five.
     try sales().expect("SELECT COUNT(Amount), COUNT(*) FROM Sales",
                        yields: [[5, 7]])
   }
 
-  @Test("SUM, MIN, MAX, and AVG skip NULLs over the whole result")
-  func wholeResult() throws {
+  @Test func `SUM, MIN, MAX, and AVG skip NULLs over the whole result`() throws {
     // Amounts 10,20,30,40,50 (the NULLs skipped): SUM 150, MIN 10, MAX 50,
     // AVG 150/5 = 30.0 — real division to an approximate-numeric double.
     try sales().expect("""
@@ -59,8 +55,7 @@ struct AggregateTests {
         """, yields: [[150, 10, 50, 30.0]])
   }
 
-  @Test("AVG is real division yielding an approximate-numeric double")
-  func avgReal() throws {
+  @Test func `AVG is real division yielding an approximate-numeric double`() throws {
     // Books amounts 10,20,30 sum 60 over 3 → 20.0; Games 40,50 sum 90 over 2
     // → 45.0 — real division, not truncating; Toys all-NULL → NULL.
     try sales().expect("""
@@ -68,16 +63,14 @@ struct AggregateTests {
         """, yields: [["Books", 20.0], ["Games", 45.0], ["Toys", nil]])
   }
 
-  @Test("AVG yields a fractional double where integer division truncates")
-  func avgFractional() throws {
+  @Test func `AVG yields a fractional double where integer division truncates`() throws {
     // East Books are 10 and 20: (10 + 20) / 2 = 15.0.
     try sales().expect("""
         SELECT AVG(Amount) FROM Sales WHERE Dept = 'Books' AND Region = 'East'
         """, yields: [[15.0]])
   }
 
-  @Test("an all-NULL group yields NULL for SUM/MIN/MAX/AVG and 0 for COUNT")
-  func allNull() throws {
+  @Test func `an all-NULL group yields NULL for SUM/MIN/MAX/AVG and 0 for COUNT`() throws {
     // Toys has one row whose Amount is NULL: COUNT(*) counts the row (1),
     // COUNT(Amount) skips it (0), and the value aggregates are NULL.
     try sales().expect("""
@@ -87,16 +80,14 @@ struct AggregateTests {
         """, yields: [[1, 0, nil, nil, nil, nil]])
   }
 
-  @Test("GROUP BY one column aggregates each group")
-  func groupByOne() throws {
+  @Test func `GROUP BY one column aggregates each group`() throws {
     try sales().expect("""
         SELECT Dept, COUNT(*), SUM(Amount) FROM Sales
           GROUP BY Dept ORDER BY Dept
         """, yields: [["Books", 3, 60], ["Games", 3, 90], ["Toys", 1, nil]])
   }
 
-  @Test("GROUP BY multiple columns keys on the tuple")
-  func groupByMany() throws {
+  @Test func `GROUP BY multiple columns keys on the tuple`() throws {
     // (Books,East) 10+20, (Books,West) 30, (Games,East) 40, (Games,West)
     // NULL+50, (Toys,East) NULL. Ordered by Dept, ties by first appearance.
     try sales().expect("""
@@ -107,8 +98,7 @@ struct AggregateTests {
                       ["Toys", "East", 1, nil]])
   }
 
-  @Test("a compound ORDER BY sorts grouped output by each key in turn")
-  func orderByCompound() throws {
+  @Test func `a compound ORDER BY sorts grouped output by each key in turn`() throws {
     // Order groups by Dept ascending, breaking ties by Region descending — the
     // second key reverses only the rows the first leaves equal.
     try sales().expect("""
@@ -119,8 +109,7 @@ struct AggregateTests {
                       ["Toys", "East", 1, nil]])
   }
 
-  @Test("mixed integer/double group keys canonicalize into one group")
-  func mixedNumericKeys() throws {
+  @Test func `mixed integer/double group keys canonicalize into one group`() throws {
     // A column carrying both 1 and 1.0 — as a CTE/UNION ALL or any source can —
     // groups them together under the engine's EXACT numeric equality (the same
     // `1` = `1.0` UNION dedup uses), yielding one group of two keyed by the
@@ -135,8 +124,7 @@ struct AggregateTests {
                        yields: [[1, 2]])
   }
 
-  @Test("mixed SUM/AVG widening does not depend on row order")
-  func mixedWideningOrderIndependent() throws {
+  @Test func `mixed SUM/AVG widening does not depend on row order`() throws {
     // Int.max, 1, 0.5 overflows Int if summed as integers first, but the 0.5
     // widens the total to a double — so the result must be the same
     // whether the overflowing integer prefix or the double is seen first, not a
@@ -161,8 +149,7 @@ struct AggregateTests {
     try suffix.expect(query, yields: [[expected, expected / 3]])
   }
 
-  @Test("all-integer SUM tolerates transient overflow if the total fits")
-  func transientIntegerOverflow() throws {
+  @Test func `all-integer SUM tolerates transient overflow if the total fits`() throws {
     // A prefix that overflows Int (Int.max + 1) must not latch a fault when a
     // later value (-1) brings the exact total back into range — the result is
     // the mathematical total, Int.max, whichever order the rows arrive in.
@@ -193,8 +180,7 @@ struct AggregateTests {
                 fails: .magnitude("integer overflow"))
   }
 
-  @Test("AVG divides a wide integer total that SUM could not represent")
-  func avgWideIntegerTotal() throws {
+  @Test func `AVG divides a wide integer total that SUM could not represent`() throws {
     // Two Int.max rows sum to 2 * Int.max, outside Int — SUM would fault, but
     // AVG divides the wide total and returns the finite approximate mean.
     let catalog = try Catalog {
@@ -206,8 +192,7 @@ struct AggregateTests {
     try catalog.expect("SELECT AVG(x) FROM T", yields: [[Double(Int.max)]])
   }
 
-  @Test("MIN/MAX over incomparable kinds is a type error, either order")
-  func minMaxIncomparableKinds() throws {
+  @Test func `MIN/MAX over incomparable kinds is a type error, either order`() throws {
     // A column mixing TEXT and INTEGER (from a CTE/UNION ALL) has no ordering
     // across kinds — MIN/MAX rejects it rather than keeping the first-seen
     // value (which would flip MIN and MAX with row order).
@@ -230,8 +215,7 @@ struct AggregateTests {
     intFirst.expect("SELECT MAX(x) FROM T", fails: fault)
   }
 
-  @Test("MIN/MAX over Int.max and Double(Int.max) is deterministic")
-  func minMaxNumericBoundary() throws {
+  @Test func `MIN/MAX over Int.max and Double(Int.max) is deterministic`() throws {
     // Int.max (2^63 - 1) and Double(Int.max) (2^63) are both numeric and order
     // exactly, so MIN is the integer and MAX the larger double — same result
     // whichever row arrives first, not an order-dependent first-seen keep.
@@ -253,8 +237,7 @@ struct AggregateTests {
                            yields: [[Int.max, Double(Int.max)]])
   }
 
-  @Test("ORDER BY on a duplicated projection output name is ambiguous")
-  func orderByAmbiguousName() throws {
+  @Test func `ORDER BY on a duplicated projection output name is ambiguous`() throws {
     // Two projected columns share the output name `k`, so `ORDER BY k` has no
     // single slot to order on — rejected as ambiguous (as the non-grouped path
     // reports for a shared unqualified join column) rather than silently
@@ -265,8 +248,7 @@ struct AggregateTests {
         """, fails: .ambiguous("k"))
   }
 
-  @Test("MIN and MAX use the engine's typed comparison per group")
-  func minMax() throws {
+  @Test func `MIN and MAX use the engine's typed comparison per group`() throws {
     try sales().expect("""
         SELECT Dept, MIN(Amount), MAX(Amount) FROM Sales
           GROUP BY Dept ORDER BY Dept
@@ -274,8 +256,7 @@ struct AggregateTests {
                       ["Toys", nil, nil]])
   }
 
-  @Test("HAVING filters groups after aggregation")
-  func having() throws {
+  @Test func `HAVING filters groups after aggregation`() throws {
     // Keep only departments whose row count exceeds one — Toys (1 row) drops.
     try sales().expect("""
         SELECT Dept, COUNT(*) FROM Sales
@@ -283,8 +264,7 @@ struct AggregateTests {
         """, yields: [["Books", 3], ["Games", 3]])
   }
 
-  @Test("HAVING may reference an aggregate not in the projection")
-  func havingHidden() throws {
+  @Test func `HAVING may reference an aggregate not in the projection`() throws {
     // The HAVING aggregates SUM(Amount) though the projection does not — the
     // engine still computes it for the group filter.
     // Books SUM 60 drops, Games SUM 90 keeps, Toys SUM NULL drops (UNKNOWN).
@@ -294,8 +274,7 @@ struct AggregateTests {
         """, yields: [["Games"]])
   }
 
-  @Test("HAVING without a GROUP BY filters the single whole-result group")
-  func havingWholeResult() throws {
+  @Test func `HAVING without a GROUP BY filters the single whole-result group`() throws {
     // The whole result is one group; HAVING keeps or drops it. COUNT(*) is 7.
     let catalog = try sales()
     try catalog.expect("SELECT COUNT(*) FROM Sales HAVING COUNT(*) > 5",
@@ -303,8 +282,7 @@ struct AggregateTests {
     try catalog.empty("SELECT COUNT(*) FROM Sales HAVING COUNT(*) > 100")
   }
 
-  @Test("ORDER BY may name an aggregate's projection alias")
-  func orderByAggregate() throws {
+  @Test func `ORDER BY may name an aggregate's projection alias`() throws {
     // Order the departments by their total descending — the ORDER BY names the
     // aggregate's output alias `Total`.
     // Games 90, Books 60, Toys NULL (NULL sorts last descending).
@@ -314,8 +292,7 @@ struct AggregateTests {
         """, yields: [["Games", 90], ["Books", 60], ["Toys", nil]])
   }
 
-  @Test("ORDER BY on a computed-expression alias is rejected clearly")
-  func orderByComputedAlias() throws {
+  @Test func `ORDER BY on a computed-expression alias is rejected clearly`() throws {
     // `Doubled` aliases a COMPUTED value (the projection evaluates it after
     // the sort), so it has no standalone grouped slot to order on — the engine
     // rejects it as unsupported rather than misreporting an unknown column.
@@ -327,8 +304,7 @@ struct AggregateTests {
     }
   }
 
-  @Test("an aggregate query pages with OFFSET/FETCH after ORDER BY")
-  func aggregateFetch() throws {
+  @Test func `an aggregate query pages with OFFSET/FETCH after ORDER BY`() throws {
     // Three groups ordered by Dept; skip one, take one.
     try sales().expect("""
         SELECT Dept, COUNT(*) FROM Sales
@@ -336,8 +312,7 @@ struct AggregateTests {
         """, yields: [["Games", 3]])
   }
 
-  @Test("an aggregate mixes with a scalar arithmetic over the group key")
-  func mixedProjection() throws {
+  @Test func `an aggregate mixes with a scalar arithmetic over the group key`() throws {
     // A grouped query may project the key through arithmetic and a scalar
     // expression alongside the aggregate; COUNT(*) doubled proves it composes.
     try sales().expect("""
@@ -346,8 +321,7 @@ struct AggregateTests {
         """, yields: [["Books", 6], ["Games", 6], ["Toys", 2]])
   }
 
-  @Test("a non-grouped projection column is rejected")
-  func projectionRule() throws {
+  @Test func `a non-grouped projection column is rejected`() throws {
     // `Region` is neither aggregated nor a GROUP BY key, so the query is
     // ill-formed — the standard single-group rule.
     try sales().expect(
@@ -355,36 +329,31 @@ struct AggregateTests {
         fails: .grouping("Region"))
   }
 
-  @Test("a bare column with no GROUP BY and an aggregate is rejected")
-  func bareColumnRule() throws {
+  @Test func `a bare column with no GROUP BY and an aggregate is rejected`() throws {
     // Mixing a bare column with an aggregate and no GROUP BY groups the whole
     // result — the column is then not a key, so it faults.
     try sales().expect("SELECT Dept, COUNT(*) FROM Sales",
                        fails: .grouping("Dept"))
   }
 
-  @Test("the projection-rule fault carries the SS004 SQLSTATE")
-  func projectionRuleState() throws {
+  @Test func `the projection-rule fault carries the SS004 SQLSTATE`() throws {
     #expect(SQLError.grouping("Region").sqlstate == "SS004")
   }
 
-  @Test("SUM over a text column is a type error")
-  func sumText() throws {
+  @Test func `SUM over a text column is a type error`() throws {
     // SUM/AVG require numeric operands; folding a text value faults through the
     // engine's arithmetic rather than coercing.
     try sales().expect("SELECT SUM(Dept) FROM Sales",
                        fails: .operand("operands must be numeric"))
   }
 
-  @Test("AVG over a text column is a type error")
-  func avgText() throws {
+  @Test func `AVG over a text column is a type error`() throws {
     // AVG folds the same numeric total as SUM, so a text operand faults alike.
     try sales().expect("SELECT AVG(Dept) FROM Sales",
                        fails: .operand("operands must be numeric"))
   }
 
-  @Test("only COUNT admits a '*' operand")
-  func starOnlyCount() throws {
+  @Test func `only COUNT admits a '*' operand`() throws {
     // `SUM(*)`/`AVG(*)`/`MIN(*)`/`MAX(*)` are not valid — only `COUNT(*)`
     // counts rows without reading a value.
     let catalog = try sales()
@@ -397,8 +366,7 @@ struct AggregateTests {
     try catalog.expect("SELECT COUNT(*) FROM Sales", yields: [[7]])
   }
 
-  @Test("an aggregate in a WHERE clause is rejected")
-  func aggregateInWhere() throws {
+  @Test func `an aggregate in a WHERE clause is rejected`() throws {
     // An aggregate has no per-row meaning, so it may not appear in a WHERE.
     #expect(throws: SQLError.self) {
       try sales().run(Statement(parsing:
@@ -406,8 +374,7 @@ struct AggregateTests {
     }
   }
 
-  @Test("an aggregate groups a join by a qualified key column")
-  func aggregateOverJoin() throws {
+  @Test func `an aggregate groups a join by a qualified key column`() throws {
     // Aggregation sits above the join chain, so a grouped query over a join
     // folds each aggregate over the joined rows and keys on a qualified column.
     let catalog = try Catalog {
@@ -428,15 +395,13 @@ struct AggregateTests {
         """, yields: [["Books", 30], ["Games", 40]])
   }
 
-  @Test("SUM over an all-integer column stays an exact integer")
-  func sumIntegerExact() throws {
+  @Test func `SUM over an all-integer column stays an exact integer`() throws {
     // Every folded value is an integer, so the total stays an integer — the
     // engine's arithmetic keeps `integer + integer` integral.
     try sales().expect("SELECT SUM(Amount) FROM Sales", yields: [[150]])
   }
 
-  @Test("SUM over a double column yields a double")
-  func sumDouble() throws {
+  @Test func `SUM over a double column yields a double`() throws {
     let catalog = try Catalog {
       Relation("T", ["X": .double]) {
         Row(1.5)
@@ -448,8 +413,7 @@ struct AggregateTests {
     try catalog.expect("SELECT SUM(X) FROM T", yields: [[4.0]])
   }
 
-  @Test("SUM over mixed integer and double columns widens to a double")
-  func sumMixed() throws {
+  @Test func `SUM over mixed integer and double columns widens to a double`() throws {
     let catalog = try Catalog {
       Relation("T", ["X": .integer]) {
         Row(10)
@@ -461,8 +425,7 @@ struct AggregateTests {
     try catalog.expect("SELECT SUM(X) FROM T", yields: [[32.5]])
   }
 
-  @Test("AVG over a double column is a double")
-  func avgDouble() throws {
+  @Test func `AVG over a double column is a double`() throws {
     let catalog = try Catalog {
       Relation("T", ["X": .double]) {
         Row(1.0)

--- a/Tests/SQLTests/DefinitionSchemaTests.swift
+++ b/Tests/SQLTests/DefinitionSchemaTests.swift
@@ -19,8 +19,7 @@ private func parse(_ text: String) throws -> Query {
 // MARK: - Tests
 
 @Suite struct DefinitionSchemaTests {
-  @Test("definition_schema.columns lists a base relation's columns")
-  func columns() throws {
+  @Test func `definition_schema.columns lists a base relation's columns`() throws {
     let catalog = try Catalog {
       Relation("People", ["Name": .text, "Age": .integer])
     }
@@ -30,8 +29,7 @@ private func parse(_ text: String) throws -> Query {
         """, yields: [["Name"], ["Age"]])
   }
 
-  @Test("definition_schema.columns skips a cyclic view and stays usable")
-  func cyclicViewColumns() throws {
+  @Test func `definition_schema.columns skips a cyclic view and stays usable`() throws {
     // `A` reads `B` and `B` reads `A` — a cycle. The store's `columns` builder
     // compiles each view to advertise it, which for a cyclic view would recurse
     // resolve→compile→resolve until the stack overflows (SIGBUS, not an
@@ -56,8 +54,7 @@ private func parse(_ text: String) throws -> Query {
         """)
   }
 
-  @Test("definition_schema.tables lists a cyclic view without crashing")
-  func cyclicViewTables() throws {
+  @Test func `definition_schema.tables lists a cyclic view without crashing`() throws {
     // `definition_schema.tables` enumerates relations and views by NAME without
     // compiling their bodies, so it lists the cyclic view too — the point is it
     // does not hang or crash reaching it. Assert the catalog's own names all

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -296,81 +296,69 @@ private func lineage(_ text: String) throws -> Array<Array<Value>> {
 // MARK: - Single-relation tests
 
 struct EngineProjectionTests {
-  @Test("SELECT * yields every real column and excludes the virtual Id")
-  func star() throws {
+  @Test func `SELECT * yields every real column and excludes the virtual Id`() throws {
     let rows = try run("SELECT * FROM People WHERE Id = 1")
     // Three real columns; `Id` is virtual and never in `*`.
     #expect(rows == [[.integer(1), .text("Alice"), .integer(30)]])
   }
 
-  @Test("SELECT names yields the named columns in order")
-  func named() throws {
+  @Test func `SELECT names yields the named columns in order`() throws {
     try people().expect("SELECT Name, Id FROM People WHERE Id = 2",
                         yields: [["Bob", 2]])
   }
 
-  @Test("a named projection may include the virtual Id column")
-  func virtual() throws {
+  @Test func `a named projection may include the virtual Id column`() throws {
     let rows = try run("SELECT Id, Name FROM People WHERE Name = 'Carol'")
     // Carol is the third row; her 1-based `Id` is 3.
     #expect(rows == [[.integer(3), .text("Carol")]])
   }
 
-  @Test("an unknown column is reported")
-  func unknown() throws {
+  @Test func `an unknown column is reported`() throws {
     #expect(throws: SQLError.column("Missing")) {
       try run("SELECT Missing FROM People")
     }
   }
 
-  @Test("an unknown relation is reported")
-  func relation() throws {
+  @Test func `an unknown relation is reported`() throws {
     try people().expect("SELECT * FROM Absent", fails: .relation("Absent"))
   }
 }
 
 struct EngineFilterTests {
-  @Test("equality on a text column")
-  func text() throws {
+  @Test func `equality on a text column`() throws {
     try people().expect("SELECT Id FROM People WHERE Name = 'Carol'",
                         yields: [[3]])
   }
 
-  @Test("a range on the sorted column")
-  func range() throws {
+  @Test func `a range on the sorted column`() throws {
     try people().expect("SELECT Id FROM People WHERE Id >= 4",
                         yields: [[4], [5]])
   }
 
-  @Test("an AND of a seekable conjunct and a residual")
-  func conjunction() throws {
+  @Test func `an AND of a seekable conjunct and a residual`() throws {
     let rows = try run("SELECT Name FROM People WHERE Id > 1 AND Age = 30")
     #expect(rows == [[.text("Carol")]])
   }
 
-  @Test("an OR scans and admits either side")
-  func disjunction() throws {
+  @Test func `an OR scans and admits either side`() throws {
     let rows =
         try run("SELECT Id FROM People WHERE Id = 1 OR Name = 'Eve'")
     #expect(rows == [[.integer(1)], [.integer(5)]])
   }
 
-  @Test("a NOT scans and negates")
-  func negation() throws {
+  @Test func `a NOT scans and negates`() throws {
     try people().expect("SELECT Id FROM People WHERE NOT Age = 30",
                         yields: [[2], [4], [5]])
   }
 
-  @Test("a filter on the virtual Id column")
-  func virtual() throws {
+  @Test func `a filter on the virtual Id column`() throws {
     try people().expect("SELECT Name FROM People WHERE Id = 4",
                         yields: [["Dave"]])
   }
 }
 
 struct EngineOrderTests {
-  @Test("ORDER BY ascending on an integer column")
-  func ascending() throws {
+  @Test func `ORDER BY ascending on an integer column`() throws {
     let rows = try run("SELECT Id FROM People ORDER BY Age ASC")
     // Ages: Bob 25, Eve 25, Alice 30, Carol 30, Dave 40 — a stable sort keeps
     // the scan order within an equal-key group.
@@ -378,8 +366,7 @@ struct EngineOrderTests {
                      [.integer(3)], [.integer(4)]])
   }
 
-  @Test("ORDER BY descending on a text column")
-  func descending() throws {
+  @Test func `ORDER BY descending on a text column`() throws {
     let rows = try run("SELECT Name FROM People ORDER BY Name DESC")
     #expect(rows == [[.text("Eve")], [.text("Dave")], [.text("Carol")],
                      [.text("Bob")], [.text("Alice")]])
@@ -387,16 +374,14 @@ struct EngineOrderTests {
 }
 
 struct EngineCompoundOrderTests {
-  @Test("a single-key ORDER BY still orders as before")
-  func single() throws {
+  @Test func `a single-key ORDER BY still orders as before`() throws {
     // The one-key case is unchanged: ages ascending, ties kept in scan order.
     let rows = try run("SELECT Id FROM People ORDER BY Age ASC")
     #expect(rows == [[.integer(2)], [.integer(5)], [.integer(1)],
                      [.integer(3)], [.integer(4)]])
   }
 
-  @Test("two keys order by the first, then the second")
-  func twoKeys() throws {
+  @Test func `two keys order by the first, then the second`() throws {
     // Age ascending, ties by Name ascending: {Bob,Eve} at 25 → Bob, Eve;
     // {Alice,Carol} at 30 → Alice, Carol; then Dave.
     let rows = try run("SELECT Name FROM People ORDER BY Age, Name")
@@ -404,8 +389,7 @@ struct EngineCompoundOrderTests {
                      [.text("Carol")], [.text("Dave")]])
   }
 
-  @Test("each key carries its own direction")
-  func mixedDirections() throws {
+  @Test func `each key carries its own direction`() throws {
     // Age descending, ties by Name ascending: Dave(40); Alice, Carol (30);
     // Bob, Eve (25).
     let rows =
@@ -414,8 +398,7 @@ struct EngineCompoundOrderTests {
                      [.text("Bob")], [.text("Eve")]])
   }
 
-  @Test("a later key breaks ties the first key leaves")
-  func tieBreak() throws {
+  @Test func `a later key breaks ties the first key leaves`() throws {
     // Age ascending leaves {Bob,Eve} and {Alice,Carol} tied; a DESC Name key
     // reorders each pair against the scan order (Eve before Bob, Carol before
     // Alice) — proof the second key, not the input order, settles the ties.
@@ -424,8 +407,7 @@ struct EngineCompoundOrderTests {
                      [.text("Alice")], [.text("Dave")]])
   }
 
-  @Test("three keys settle rows the first two leave equal")
-  func threeKeys() throws {
+  @Test func `three keys settle rows the first two leave equal`() throws {
     // Class ascending, Score ascending, Name ascending. Class A: Bob(70), then
     // the 80s by Name — Ada, Mel, Yan. Class B: both 90, by Name — Amy, Zed.
     let rows =
@@ -434,8 +416,7 @@ struct EngineCompoundOrderTests {
                      [.integer(2)], [.integer(4)], [.integer(1)]])
   }
 
-  @Test("a compound ORDER BY is stable across all keys")
-  func stable() throws {
+  @Test func `a compound ORDER BY is stable across all keys`() throws {
     // Class and Score alone leave the three Class-A/Score-80 rows tied; with no
     // further key the sort keeps their scan order — Yan(2), Ada(3), Mel(5).
     let rows = try grades("SELECT Id FROM Grade ORDER BY Class, Score")
@@ -443,8 +424,7 @@ struct EngineCompoundOrderTests {
                      [.integer(5)], [.integer(1)], [.integer(4)]])
   }
 
-  @Test("FETCH takes the top-N of a compound order")
-  func topN() throws {
+  @Test func `FETCH takes the top-N of a compound order`() throws {
     // Age descending, ties by Name ascending, then the first two rows: Dave(40)
     // and the lower-named of the 30s, Alice.
     try people().expect("""
@@ -454,8 +434,7 @@ struct EngineCompoundOrderTests {
         yields: [["Dave"], ["Alice"]])
   }
 
-  @Test("OFFSET then FETCH pages into a compound order")
-  func page() throws {
+  @Test func `OFFSET then FETCH pages into a compound order`() throws {
     // The full compound order is Dave, Alice, Carol, Bob, Eve; skip 1, take 2.
     try people().expect("""
         SELECT Name FROM People
@@ -466,8 +445,7 @@ struct EngineCompoundOrderTests {
 }
 
 struct EngineProjectionPushdownTests {
-  @Test("a query referencing few columns of a wide relation works")
-  func few() throws {
+  @Test func `a query referencing few columns of a wide relation works`() throws {
     // The relation has ten columns; the query reads only C0 (filter, project),
     // C5 (project), and C8 (order). The leaf materialises just those, but the
     // result is exactly as if every column were copied.
@@ -479,8 +457,7 @@ struct EngineProjectionPushdownTests {
 }
 
 struct EngineSeekTests {
-  @Test("the seek path and the scan path return identical results")
-  func equivalence() throws {
+  @Test func `the seek path and the scan path return identical results`() throws {
     // `Id >= 2` seeks the sorted column; the same selection by `Name` (which
     // `bound` reports unseekable) scans. Both must yield the same rows.
     let seek = try run("SELECT Id FROM People WHERE Id >= 2 AND Id <= 4")
@@ -510,8 +487,7 @@ struct EngineSeekTests {
 /// `(Id << Coded.bits) | tag`, decoded to the `TypeDef` `Id` or `NULL`).
 /// The engine-level plan-shape assertion complements the two result assertions.
 struct EngineCodedKeyTests {
-  @Test("a range on an unordered coded key scans and admits only its own rows")
-  func range() throws {
+  @Test func `a range on an unordered coded key scans and admits only its own rows`() throws {
     // `Parent < 5` must return only the TypeDef-tagged rows whose decoded
     // `Id` is `< 5` (td1, td2, td4) — never the other-tag rows (other-a, -b,
     // -c), which decode to NULL. Before the fix the raw boundary
@@ -520,8 +496,7 @@ struct EngineCodedKeyTests {
     #expect(rows == [[.text("td1")], [.text("td2")], [.text("td4")]])
   }
 
-  @Test("a range equals the correct scan-and-filter result")
-  func equivalence() throws {
+  @Test func `a range equals the correct scan-and-filter result`() throws {
     // The seek path (`Parent < 5`) must equal a filter that cannot seek at all
     // (`Name < 'z'` over the same rows, restricted to the tagged ones) — i.e.
     // the range yields exactly the rows a full scan-and-filter would.
@@ -532,8 +507,7 @@ struct EngineCodedKeyTests {
     #expect(seek == scan)
   }
 
-  @Test("an equality on an unordered coded key still seeks its exact run")
-  func equality() throws {
+  @Test func `an equality on an unordered coded key still seeks its exact run`() throws {
     // Equality is always seekable — the exact coded run brackets exactly the
     // rows that decode to the value, and a join rechecks — so `Parent = 4`
     // returns just td4.
@@ -541,8 +515,7 @@ struct EngineCodedKeyTests {
     #expect(rows == [[.text("td4")]])
   }
 
-  @Test("an equality on zero rejects a null coded reference rather than seeking")
-  func null() throws {
+  @Test func `an equality on zero rejects a null coded reference rather than seeking`() throws {
     // A decoded row is 1-based, so `Parent = 0` is `NULL = 0` for every row —
     // UNKNOWN, admitting none. Row 0's stored raw cell is `(0 << 2) | 0 == 0`,
     // which encodes exactly the target the equality would seek; before the fix
@@ -554,8 +527,7 @@ struct EngineCodedKeyTests {
     #expect(rows.isEmpty)
   }
 
-  @Test("an equality too large to encode rejects rather than seeking an alias")
-  func overflow() throws {
+  @Test func `an equality too large to encode rejects rather than seeking an alias`() throws {
     // A decoded Id must be encodable without truncation. `(1 << 62) + 6` is
     // positive but past `Int.max >> Coded.bits`, so `(value << 2) | 0` shifts the
     // high `1` clear out of the word and aliases raw `24` — the same raw cell as
@@ -571,8 +543,7 @@ struct EngineCodedKeyTests {
     #expect(rows.isEmpty)
   }
 
-  @Test("an equality plans a seek, a range plans a scan-and-filter")
-  func plan() throws {
+  @Test func `an equality plans a seek, a range plans a scan-and-filter`() throws {
     // The plan shape proves the gate directly: equality reaches a seeked scan
     // with no residual filter; a range reaches a raw scan under a filter.
     let catalog = attributes()
@@ -590,8 +561,7 @@ struct EngineCodedKeyTests {
     #expect(filters(lessPlan))
   }
 
-  @Test("a sorted key with a leading NULL does not seek it into an equality")
-  func nullableSortedKey() throws {
+  @Test func `a sorted key with a leading NULL does not seek it into an equality`() throws {
     // NULLs sort first, so a direct seek would bracket the NULL row into the
     // `K = 1` range; an equality seek drops the residual, so the sorted-key
     // seek must fall back to a scan and filter the NULL out, not return it.
@@ -604,8 +574,7 @@ struct EngineCodedKeyTests {
     try catalog.expect("SELECT V FROM T WHERE K = 1", yields: [["one"]])
   }
 
-  @Test("a case-varied sorted-column name is still seekable")
-  func foldedSortedKey() throws {
+  @Test func `a case-varied sorted-column name is still seekable`() throws {
     // The fixture folds `sorted: "id"` to the declared `Id`, so an equality on
     // it plans a seek — a case mismatch must not silently build an unsorted
     // relation that drops to a scan the plan-shape tests mean to cover.
@@ -620,8 +589,7 @@ struct EngineCodedKeyTests {
     #expect(seeks(plan))
   }
 
-  @Test("an empty sorted fixture still plans a seek")
-  func emptySortedKey() throws {
+  @Test func `an empty sorted fixture still plans a seek`() throws {
     // A sorted relation with no rows has no leading cell to disqualify the
     // seek; it plans a seek over the empty range, not a scan.
     let catalog = try Catalog {
@@ -634,20 +602,17 @@ struct EngineCodedKeyTests {
 }
 
 struct EngineQualifierTests {
-  @Test("a qualifier matching the alias resolves the column")
-  func alias() throws {
+  @Test func `a qualifier matching the alias resolves the column`() throws {
     try people().expect("SELECT p.Name FROM People AS p WHERE Id = 1",
                         yields: [["Alice"]])
   }
 
-  @Test("a qualifier matching the table name resolves the column")
-  func name() throws {
+  @Test func `a qualifier matching the table name resolves the column`() throws {
     try people().expect("SELECT People.Name FROM People WHERE Id = 1",
                         yields: [["Alice"]])
   }
 
-  @Test("a qualifier naming neither the alias nor the table is reported")
-  func foreign() throws {
+  @Test func `a qualifier naming neither the alias nor the table is reported`() throws {
     // `x` names neither the alias `p` nor the table `People`; a single-relation
     // query rejects it rather than dropping the qualifier and binding `Name`.
     #expect(throws: SQLError.column("Name")) {
@@ -655,8 +620,7 @@ struct EngineQualifierTests {
     }
   }
 
-  @Test("a relation and a view name resolve case-insensitively")
-  func folded() throws {
+  @Test func `a relation and a view name resolve case-insensitively`() throws {
     // The fixture folds a name like the engine and the WinMD catalog do, so a
     // query need not match the declared relation/view casing.
     let catalog = try Catalog {
@@ -669,8 +633,7 @@ struct EngineQualifierTests {
     try catalog.expect("SELECT Name FROM adults", yields: [["Alice"]])
   }
 
-  @Test("a qualifier naming a different table is reported")
-  func mismatch() throws {
+  @Test func `a qualifier naming a different table is reported`() throws {
     // The reviewer's case: `Child.Name` against `FROM Parent` must not resolve
     // to `Parent`'s `Name`; the qualifier names a relation not in scope.
     #expect(throws: SQLError.column("Name")) {
@@ -682,8 +645,7 @@ struct EngineQualifierTests {
 // MARK: - Join tests
 
 struct EngineJoinTests {
-  @Test("a join on a foreign key pairs each child with its parent")
-  func star() throws {
+  @Test func `a join on a foreign key pairs each child with its parent`() throws {
     let rows = try join("""
         SELECT * FROM Parent JOIN Child ON Child.Pid = Parent.Id
         """)
@@ -695,8 +657,7 @@ struct EngineJoinTests {
     ])
   }
 
-  @Test("a qualified projection selects across both relations")
-  func qualified() throws {
+  @Test func `a qualified projection selects across both relations`() throws {
     try family().expect("""
         SELECT Parent.Name, Child.Name FROM Parent
           JOIN Child ON Child.Pid = Parent.Id
@@ -704,8 +665,7 @@ struct EngineJoinTests {
         yields: [["Ada", "Ann"], ["Ada", "Amy"], ["Bee", "Bob"]])
   }
 
-  @Test("a join keys off the inner relation's virtual Id")
-  func virtual() throws {
+  @Test func `a join keys off the inner relation's virtual Id`() throws {
     // `Ordered` has no stored key; its identity is its 1-based `Id`. The
     // child's `Pid` joins to that virtual column.
     let rows = try join("""
@@ -720,8 +680,7 @@ struct EngineJoinTests {
     ])
   }
 
-  @Test("a join keyed off the OUTER relation's virtual Id does not collide")
-  func outerVirtual() throws {
+  @Test func `a join keyed off the OUTER relation's virtual Id does not collide`() throws {
     // The combined ordinal space lays the inner relation past the outer's
     // `extent` — its real width plus the virtual columns it exposes — so an
     // outer virtual column never shares an ordinal with an inner real one. Here
@@ -742,8 +701,7 @@ struct EngineJoinTests {
     ])
   }
 
-  @Test("a WHERE spans both relations")
-  func predicate() throws {
+  @Test func `a WHERE spans both relations`() throws {
     try family().expect("""
         SELECT Child.Name FROM Parent JOIN Child ON Child.Pid = Parent.Id
           WHERE Parent.Name = 'Ada' AND Child.Name = 'Amy'
@@ -751,8 +709,7 @@ struct EngineJoinTests {
         yields: [["Amy"]])
   }
 
-  @Test("ORDER BY orders across the join")
-  func order() throws {
+  @Test func `ORDER BY orders across the join`() throws {
     try family().expect("""
         SELECT Child.Name FROM Parent JOIN Child ON Child.Pid = Parent.Id
           ORDER BY Child.Name ASC
@@ -760,15 +717,13 @@ struct EngineJoinTests {
         yields: [["Amy"], ["Ann"], ["Bob"]])
   }
 
-  @Test("an unqualified name in both relations is ambiguous")
-  func ambiguous() throws {
+  @Test func `an unqualified name in both relations is ambiguous`() throws {
     #expect(throws: SQLError.ambiguous("Name")) {
       try join("SELECT Name FROM Parent JOIN Child ON Child.Pid = Parent.Id")
     }
   }
 
-  @Test("a self-join's shared table name makes a qualified name ambiguous")
-  func selfJoin() throws {
+  @Test func `a self-join's shared table name makes a qualified name ambiguous`() throws {
     #expect(throws: SQLError.ambiguous("Id")) {
       try join("""
           SELECT Parent.Name FROM Parent JOIN Parent ON Parent.Id = Parent.Id
@@ -776,8 +731,7 @@ struct EngineJoinTests {
     }
   }
 
-  @Test("a duplicated alias makes a shared qualified column ambiguous")
-  func duplicate() throws {
+  @Test func `a duplicated alias makes a shared qualified column ambiguous`() throws {
     // `x.Pid` resolves by column (the Child side only); `x.Name` is on both,
     // so the shared alias is ambiguous rather than binding silently to outer.
     #expect(throws: SQLError.ambiguous("Name")) {
@@ -787,8 +741,7 @@ struct EngineJoinTests {
     }
   }
 
-  @Test("a parent with no matching child contributes no rows")
-  func empty() throws {
+  @Test func `a parent with no matching child contributes no rows`() throws {
     let rows = try join("""
         SELECT Parent.Name, Child.Name FROM Parent
           JOIN Child ON Child.Pid = Parent.Id
@@ -797,8 +750,7 @@ struct EngineJoinTests {
     #expect(rows.isEmpty)
   }
 
-  @Test("the seek probe and the scan probe return identical results")
-  func equivalence() throws {
+  @Test func `the seek probe and the scan probe return identical results`() throws {
     // The join seeks `Child.Pid = Parent.Id` when the inner relation is
     // seekable on the key, and scans it otherwise. Both inner orderings — the
     // sorted `Parent` and its unsorted twin used as the inner — must agree.
@@ -822,8 +774,7 @@ struct EngineJoinTests {
 // MARK: - Multi-way join tests
 
 struct EngineMultiJoinTests {
-  @Test("a three-relation chain joins across two foreign keys")
-  func chain() throws {
+  @Test func `a three-relation chain joins across two foreign keys`() throws {
     let rows = try lineage("""
         SELECT House.House, Room.Room, Item.Item FROM House
           JOIN Room ON Room.Hid = House.Id
@@ -838,8 +789,7 @@ struct EngineMultiJoinTests {
     ])
   }
 
-  @Test("a chain seeks each inner relation keyed on its sorted column")
-  func seeked() throws {
+  @Test func `a chain seeks each inner relation keyed on its sorted column`() throws {
     // Walking the chain the other way: `Item` is the outer scan, and both inner
     // relations are seeked on their sorted `Id` — the multi-way nest rewrite
     // turning every `Select`-over-`Product` level into an index-nested loop.
@@ -855,8 +805,7 @@ struct EngineMultiJoinTests {
     ])
   }
 
-  @Test("a WHERE filters across a three-relation chain")
-  func filtered() throws {
+  @Test func `a WHERE filters across a three-relation chain`() throws {
     try lineage().expect("""
         SELECT Item.Item FROM House
           JOIN Room ON Room.Hid = House.Id
@@ -866,8 +815,7 @@ struct EngineMultiJoinTests {
         yields: [["Pot"]])
   }
 
-  @Test("an unqualified name in more than one relation of a chain is ambiguous")
-  func ambiguous() throws {
+  @Test func `an unqualified name in more than one relation of a chain is ambiguous`() throws {
     // `Id` sits in both `House` and `Room`; across the chain it resolves in more
     // than one relation, so an unqualified reference is ambiguous.
     #expect(throws: SQLError.ambiguous("Id")) {
@@ -879,8 +827,7 @@ struct EngineMultiJoinTests {
     }
   }
 
-  @Test("an early ON referencing a not-yet-joined relation is rejected")
-  func premature() throws {
+  @Test func `an early ON referencing a not-yet-joined relation is rejected`() throws {
     // The first join's `ON` qualifies a column with `Item`, a relation joined
     // only LATER. Resolving the match against just the prefix — `House` and
     // `Room` — the qualifier names no relation in scope, so the query is
@@ -895,8 +842,7 @@ struct EngineMultiJoinTests {
     }
   }
 
-  @Test("a valid early ON whose columns are all in its prefix runs")
-  func prefixed() throws {
+  @Test func `a valid early ON whose columns are all in its prefix runs`() throws {
     // Each `ON` references only the prefix it resolves against, so the whole
     // chain compiles and runs — mirroring `chain`, which the prefix-scope fix
     // leaves unchanged.
@@ -912,8 +858,7 @@ struct EngineMultiJoinTests {
     ])
   }
 
-  @Test("an unqualified early-ON column a later relation shares is not ambiguous")
-  func disambiguated() throws {
+  @Test func `an unqualified early-ON column a later relation shares is not ambiguous`() throws {
     // The first join's `ON` reads unqualified `Code`, unique within its prefix
     // `{Author, Book}` even though `Sale` — joined only later — also carries a
     // `Code`. Resolving the match against the prefix binds it; resolving against
@@ -930,8 +875,7 @@ struct EngineMultiJoinTests {
 // MARK: - View tests
 
 struct EngineViewTests {
-  @Test("a view resolves and queries like a table")
-  func table() throws {
+  @Test func `a view resolves and queries like a table`() throws {
     // `SELECT * FROM Adults` runs the view's `SELECT Id, Name FROM Parent
     // WHERE Id >= 2`, exposing the columns as `Key`/`Label`.
     let rows = try view("SELECT * FROM Adults")
@@ -941,25 +885,21 @@ struct EngineViewTests {
     ])
   }
 
-  @Test("a projection over a view selects the view's columns by name")
-  func projection() throws {
+  @Test func `a projection over a view selects the view's columns by name`() throws {
     try views().expect("SELECT Label FROM Adults", yields: [["Bee"], ["Cid"]])
   }
 
-  @Test("a WHERE over a view filters its rows")
-  func filter() throws {
+  @Test func `a WHERE over a view filters its rows`() throws {
     try views().expect("SELECT Label FROM Adults WHERE Key = 3",
                        yields: [["Cid"]])
   }
 
-  @Test("an ORDER BY over a view orders its rows")
-  func order() throws {
+  @Test func `an ORDER BY over a view orders its rows`() throws {
     try views().expect("SELECT Label FROM Adults ORDER BY Label DESC",
                        yields: [["Cid"], ["Bee"]])
   }
 
-  @Test("a view whose definition is a join resolves and queries")
-  func join() throws {
+  @Test func `a view whose definition is a join resolves and queries`() throws {
     // `Pairs` denormalises the `Parent`/`Child` foreign-key join; querying it
     // runs the inner join and exposes its two columns as `Parent`/`Kid`.
     let rows = try view("SELECT * FROM Pairs")
@@ -970,21 +910,18 @@ struct EngineViewTests {
     ])
   }
 
-  @Test("a projection and filter over a join view selects across its columns")
-  func joinProjection() throws {
+  @Test func `a projection and filter over a join view selects across its columns`() throws {
     try views().expect("SELECT Kid FROM Pairs WHERE Parent = 'Ada'",
                        yields: [["Ann"], ["Amy"]])
   }
 
-  @Test("an unknown column of a view is reported")
-  func unknown() throws {
+  @Test func `an unknown column of a view is reported`() throws {
     #expect(throws: SQLError.column("Missing")) {
       try view("SELECT Missing FROM Adults")
     }
   }
 
-  @Test("a SELECT * view over-declaring its columns is rejected at resolution")
-  func wideStar() throws {
+  @Test func `a SELECT * view over-declaring its columns is rejected at resolution`() throws {
     // `Parent` is two columns wide, but the view declares three. A `SELECT *`
     // has no statically known arity, so the parser admits the list; the engine
     // catches the mismatch at resolution rather than indexing past a row.
@@ -996,8 +933,7 @@ struct EngineViewTests {
     }
   }
 
-  @Test("a SELECT * view whose explicit list matches the width resolves")
-  func matchedStar() throws {
+  @Test func `a SELECT * view whose explicit list matches the width resolves`() throws {
     // The same `SELECT *` view declared with the right number of columns
     // resolves and queries — the backstop passes the well-formed view through.
     let star = try View(query: select("SELECT * FROM Parent"),
@@ -1007,8 +943,7 @@ struct EngineViewTests {
     #expect(rows == [[.text("Ada")]])
   }
 
-  @Test("a view's definition is optimised — its seekable predicate seeks")
-  func optimised() throws {
+  @Test func `a view's definition is optimised — its seekable predicate seeks`() throws {
     // `Adults` is `SELECT Id, Name FROM Parent WHERE Id >= 2`, and `Parent` is
     // sorted on `Id`, so the view's sub-plan must seek that run rather than
     // scanning under a `Select`. Compile and optimise an outer query over the
@@ -1333,8 +1268,7 @@ private func injected(_ plan: Plan) -> Bool {
 }
 
 struct EnginePushdownTests {
-  @Test("a single-relation WHERE conjunct rides below the join")
-  func placement() throws {
+  @Test func `a single-relation WHERE conjunct rides below the join`() throws {
     // `WHERE Parent.Name = 'Ada'` references only the outer relation, so it
     // pushes to the Parent leaf inside the join rather than filtering the whole
     // product afterwards — `pushed` sees a filter within the join's outer.
@@ -1348,8 +1282,7 @@ struct EnginePushdownTests {
     #expect(pushed(plan))
   }
 
-  @Test("pushdown down a seekable outer key seeks that leaf inside the join")
-  func seeked() throws {
+  @Test func `pushdown down a seekable outer key seeks that leaf inside the join`() throws {
     // `WHERE Parent.Id = 2` is seekable; pushed to the Parent leaf it becomes a
     // seek inside the join's outer, not a scan-then-filter atop the product.
     let catalog = try family()
@@ -1363,8 +1296,7 @@ struct EnginePushdownTests {
     #expect(pushed(plan))
   }
 
-  @Test("a trailing seekable conjunct survives a rebuilt three-term AND")
-  func seekable() throws {
+  @Test func `a trailing seekable conjunct survives a rebuilt three-term AND`() throws {
     // Pushdown flattens a single-table filter through `conjuncts` and rebuilds
     // it via `conjunction`. A right-leaning rebuild would bury the trailing
     // `Id = 5` under a nested AND, hidden from `seek` (which inspects only a
@@ -1389,8 +1321,7 @@ struct EnginePushdownTests {
     #expect(seeks(plan))
   }
 
-  @Test("a seekable conjunct grouped after an unsafe one does not bypass its throw")
-  func grouped() throws {
+  @Test func `a seekable conjunct grouped after an unsafe one does not bypass its throw`() throws {
     // The left fold rebuilds `(1 / x) = 0 AND (name <> 'z' AND id < 0)` — parsed
     // as `A AND (B AND C)` — into `((A AND B) AND C)`, promoting the seekable
     // `id < 0` to the top-level RHS `seek` inspects. On an id-sorted table whose
@@ -1422,8 +1353,7 @@ struct EnginePushdownTests {
     }
   }
 
-  @Test("pushdown preserves the join's result")
-  func correctness() throws {
+  @Test func `pushdown preserves the join's result`() throws {
     // The pushed plan must return exactly the un-pushed join's rows.
     try family().expect("""
         SELECT Child.Name FROM Parent JOIN Child ON Child.Pid = Parent.Id
@@ -1432,8 +1362,7 @@ struct EnginePushdownTests {
         yields: [["Ann"], ["Amy"]])
   }
 
-  @Test("a non-key predicate on the joined-in relation still uses the join")
-  func inner() throws {
+  @Test func `a non-key predicate on the joined-in relation still uses the join`() throws {
     // `WHERE Parent.Name <> 'zz'` references only the joined-in `Parent`, so
     // pushdown wraps that inner leaf as `Select(_, Scan(Parent))` before the
     // join folds it in. `nest` must look through that pushed filter and still
@@ -1457,8 +1386,7 @@ struct EnginePushdownTests {
         yields: [["Ann", "Ada"], ["Amy", "Ada"], ["Bob", "Bee"]])
   }
 
-  @Test("a spanning WHERE leaves the join path with a residual above it")
-  func spanning() throws {
+  @Test func `a spanning WHERE leaves the join path with a residual above it`() throws {
     // `WHERE Parent.Name <> Child.Name` references BOTH joined relations, so it
     // descends no further than the product and stays as a residual. The ON
     // match must remain adjacent to the product — folded in with the spanning
@@ -1484,8 +1412,7 @@ struct EnginePushdownTests {
         yields: [["Ann", "Ada"], ["Amy", "Ada"], ["Bob", "Bee"]])
   }
 
-  @Test("a WHERE over a join view prunes its rows before the join runs")
-  func view() throws {
+  @Test func `a WHERE over a join view prunes its rows before the join runs`() throws {
     // `Kin` is the Parent/Child join; `WHERE Key = 2` over it must push INTO the
     // view's sub-plan and seek Parent to the single matching row before joining,
     // so only that parent's rows are read — not the whole relation.
@@ -1503,8 +1430,7 @@ struct EnginePushdownTests {
     #expect(pruned.reads == 1)
   }
 
-  @Test("the pushed view result matches the unfiltered view filtered late")
-  func equivalence() throws {
+  @Test func `the pushed view result matches the unfiltered view filtered late`() throws {
     // Running the view then filtering must agree with the pushed plan.
     let (catalog, _) = try counted()
     let all = try catalog.run(parse("SELECT Key, Kid FROM Kin"))
@@ -1514,8 +1440,7 @@ struct EnginePushdownTests {
     #expect(filtered == culled)
   }
 
-  @Test("a slotless predicate stays above the join and skips an empty product")
-  func slotless() throws {
+  @Test func `a slotless predicate stays above the join and skips an empty product`() throws {
     // `WHERE (1 / 0) = 0` reads no slots, so it must stay at the product level
     // and run per pair — not ride down to the left input. `B` is empty, so the
     // join's product is empty and the throwing expression is never evaluated;
@@ -1533,8 +1458,7 @@ struct EnginePushdownTests {
     #expect(rows.isEmpty)
   }
 
-  @Test("a throwing single-side predicate stays above the join, skips an empty product")
-  func hazardous() throws {
+  @Test func `a throwing single-side predicate stays above the join, skips an empty product`() throws {
     // `WHERE (1 / A.x) = 0` reads only `A`'s slot but CAN throw (division), so —
     // like a slotless throwing predicate — it must stay at the product level, not
     // ride down to `A`. `B` is empty, so the product is empty and the division is
@@ -1552,8 +1476,7 @@ struct EnginePushdownTests {
     #expect(rows.isEmpty)
   }
 
-  @Test("an unsafe conjunct bars a later safe one from suppressing its throw")
-  func barrier() throws {
+  @Test func `an unsafe conjunct bars a later safe one from suppressing its throw`() throws {
     // `WHERE (1 / A.x) = 0 AND A.x <> 0`: left-to-right, the division runs first
     // and raises on the matching pair (`A.x = 0` joined to `B.y = 0`). The safe
     // `A.x <> 0` must NOT ride down to `A` — doing so would drop the row before
@@ -1572,8 +1495,7 @@ struct EnginePushdownTests {
     }
   }
 
-  @Test("a lifted inner filter keeps its place before a later unsafe residual")
-  func lifted() throws {
+  @Test func `a lifted inner filter keeps its place before a later unsafe residual`() throws {
     // `WHERE Parent.Name = 'nope' AND (1 / Child.x) = 0`: left-to-right, the
     // false `Parent.Name` check short-circuits before the division on the
     // matching pair (Child.x = 0). `Parent.Name = 'nope'` is a single-side inner
@@ -1597,8 +1519,7 @@ struct EnginePushdownTests {
     #expect(rows.isEmpty)
   }
 
-  @Test("a WHERE over a UNION view pushes into every arm's projection")
-  func union() throws {
+  @Test func `a WHERE over a UNION view pushes into every arm's projection`() throws {
     // `Both` unions `Alpha` and `Beta`, whose shared `Key` output column sits at
     // DIFFERING body slots. `WHERE Key = 2` must rebase PER ARM — the union root
     // fails a single pre-rebased filter — pushing below each arm's projection
@@ -1616,8 +1537,7 @@ struct EnginePushdownTests {
     #expect(rows == [[.text("a2")], [.text("b2")]])
   }
 
-  @Test("a view's throwing projection term is not suppressed by a pushed filter")
-  func throwingView() throws {
+  @Test func `a view's throwing projection term is not suppressed by a pushed filter`() throws {
     // The view projects `1 / z`, which raises on the `z = 0` row. `derive`
     // evaluates every projected column for every view row, so `SELECT id FROM V
     // WHERE id <> 0` raises even though `id <> 0` would exclude that row —
@@ -1635,8 +1555,7 @@ struct EnginePushdownTests {
     }
   }
 
-  @Test("an unsafe outer conjunct bars a later push into a view")
-  func gated() throws {
+  @Test func `an unsafe outer conjunct bars a later push into a view`() throws {
     // `V` is `SELECT x FROM T` with `T.x` sorted and a single `x = 0` row.
     // `SELECT x FROM V WHERE (1 / x) = 0 AND x = 1`: left-to-right, the division
     // runs on the `x = 0` row and raises. The safe seekable `x = 1` must NOT push
@@ -1655,8 +1574,7 @@ struct EnginePushdownTests {
     }
   }
 
-  @Test("a nullable conjunct is not pushed below a later unsafe conjunct")
-  func nullable() throws {
+  @Test func `a nullable conjunct is not pushed below a later unsafe conjunct`() throws {
     // `WHERE A.x = 1 AND (1 / B.y) = 0`: the evaluator's `AND` does not short-
     // circuit, so on the matching pair (A.x NULL, B.y = 0) the UNKNOWN left
     // still runs the right, and the division raises. The safe `A.x = 1`
@@ -1691,8 +1609,7 @@ struct EnginePushdownTests {
     }
   }
 
-  @Test("a nullable conjunct is not pushed into a view below a later unsafe one")
-  func nullableView() throws {
+  @Test func `a nullable conjunct is not pushed into a view below a later unsafe one`() throws {
     // `V` exposes safe columns `x` and `y`. `SELECT x FROM V WHERE x = 1 AND
     // (1 / y) = 0`: the `AND` does not short-circuit, so on the (x NULL, y = 0)
     // row the UNKNOWN left still runs the division, which raises. Pushing the
@@ -1720,8 +1637,7 @@ struct EnginePushdownTests {
     }
   }
 
-  @Test("a slotless bound conjunct is not pushed into a view below a later unsafe one")
-  func boundView() throws {
+  @Test func `a slotless bound conjunct is not pushed into a view below a later unsafe one`() throws {
     // A `.bound` predicate compares against a run-time `:parameter` and reads no
     // slot, yet it is UNKNOWN when the parameter is unbound (or bound to NULL).
     // `SELECT x FROM V WHERE 1 = :missing AND (1 / y) = 0` with `:missing`
@@ -1751,8 +1667,7 @@ struct EnginePushdownTests {
     }
   }
 
-  @Test("a throwing WHERE is not evaluated for a pair an UNKNOWN ON rejects")
-  func gatedMatch() throws {
+  @Test func `a throwing WHERE is not evaluated for a pair an UNKNOWN ON rejects`() throws {
     // `A JOIN V ON A.k = V.k WHERE (1 / A.x) = 0` where `V` is a derived view,
     // so `nest` cannot fold the product into a `Join`. On the `A` row with a
     // NULL `k` and `x = 0`, the ON match is UNKNOWN — the join forms no pair for
@@ -1814,8 +1729,7 @@ private func hashable() -> (catalog: Memory, reads: Counter) {
 }
 
 struct EngineHashJoinTests {
-  @Test("a hash join over an unsorted inner scans it exactly once")
-  func single() throws {
+  @Test func `a hash join over an unsorted inner scans it exactly once`() throws {
     // `Parent` is unsorted, so its `Id` is not seekable and the join hashes it.
     // Four outer children probe the map, but the inner is read only three times
     // — its row count — not twelve (once per outer).
@@ -1832,8 +1746,7 @@ struct EngineHashJoinTests {
     #expect(reads.reads == 3)
   }
 
-  @Test("a coded-index inner key seeks rather than hashing the whole inner")
-  func coded() throws {
+  @Test func `a coded-index inner key seeks rather than hashing the whole inner`() throws {
     // The join strategy is chosen by probing the inner key for seekability. A
     // decoded coded-index column is 1-based and rejects the null reference `0`,
     // so probing with `0` would call it unseekable and hash every inner row;
@@ -1871,8 +1784,7 @@ struct EngineHashJoinTests {
     #expect(reads.reads == 1)
   }
 
-  @Test("an empty outer skips the hash build of an unseekable inner")
-  func empty() throws {
+  @Test func `an empty outer skips the hash build of an unseekable inner`() throws {
     // A contradictory outer WHERE prunes every `Child`, so the outer is empty
     // and no probe can match. The inner `Parent` is unsorted (unseekable), so
     // the join would hash it — but with no probes the build is pointless. The
@@ -1889,8 +1801,7 @@ struct EngineHashJoinTests {
     #expect(reads.reads == 0)
   }
 
-  @Test("an all-NULL-key outer skips the hash build of an unseekable inner")
-  func allNull() throws {
+  @Test func `an all-NULL-key outer skips the hash build of an unseekable inner`() throws {
     // The outer is NON-empty but every `Child.Pid` is NULL (a `WHERE Pid IS
     // NULL` keeps only the null-keyed rows), and a NULL key joins to nothing —
     // so no probe can match. The inner `Parent` is unsorted (unseekable), so the
@@ -1927,8 +1838,7 @@ struct EngineHashJoinTests {
     #expect(reads.reads == 0)
   }
 
-  @Test("the hash probe and the seek probe return identical results")
-  func equivalence() throws {
+  @Test func `the hash probe and the seek probe return identical results`() throws {
     // The sorted `Parent` seeks; its unsorted twin hashes. Both inner orderings
     // must agree — the hash preserves the seek path's outer-major, inner-cursor
     // order.
@@ -1948,8 +1858,7 @@ struct EngineHashJoinTests {
     ])
   }
 
-  @Test("a hash join emits matches outer-major in inner cursor order")
-  func order() throws {
+  @Test func `a hash join emits matches outer-major in inner cursor order`() throws {
     // The unsorted twin forces the hash path. Without an ORDER BY the result
     // must be outer-major (each child in scan order), and a bucket's inner rows
     // in the inner's cursor order — exactly the nested loop's order.
@@ -1964,8 +1873,7 @@ struct EngineHashJoinTests {
     ])
   }
 
-  @Test("a NULL key joins to nothing under the hash path")
-  func null() throws {
+  @Test func `a NULL key joins to nothing under the hash path`() throws {
     // The child with a NULL foreign key is the outer row; a NULL key hashes to
     // nothing, and a NULL inner key is never bucketed. `Parent` here is unsorted
     // so the join hashes.
@@ -2000,8 +1908,7 @@ struct EngineHashJoinTests {
     ])
   }
 
-  @Test("a seekable inner filter seeks the hash inner rather than scanning it")
-  func filtered() throws {
+  @Test func `a seekable inner filter seeks the hash inner rather than scanning it`() throws {
     // `Parent.Code` (the join key) is unseekable, so the join hashes the inner;
     // `Parent.Id` is sorted (seekable and ordered). `Child JOIN Parent ON
     // Parent.Code = Child.Code WHERE Parent.Id < 0` pushes `Parent.Id < 0` onto
@@ -2046,8 +1953,7 @@ struct EngineHashJoinTests {
 // MARK: - Streaming-product tests
 
 struct EngineStreamingProductTests {
-  @Test("a join whose inner is a view leaves a residual product-under-select")
-  func shape() throws {
+  @Test func `a join whose inner is a view leaves a residual product-under-select`() throws {
     // The nest rewrite folds a bare scan into an index-nested join, but the
     // inner here is the `Adults` VIEW (a `derived` leaf), so nest cannot fire
     // and the level stays a `select` over a `product` — the shape the streaming
@@ -2062,8 +1968,7 @@ struct EngineStreamingProductTests {
     #expect(residual(plan))
   }
 
-  @Test("the streamed product filters row by row to the right rows")
-  func correctness() throws {
+  @Test func `the streamed product filters row by row to the right rows`() throws {
     // `Adults` is Parent rows with Id >= 2 (Key 2 → Bee, 3 → Cid); only the
     // child whose Pid equals a Key survives — Bob (Pid 2) against Bee.
     let catalog = try views()
@@ -2074,8 +1979,7 @@ struct EngineStreamingProductTests {
     #expect(rows == [[.text("Bob"), .text("Bee")]])
   }
 
-  @Test("the streamed product equals the eager product filtered")
-  func equivalence() throws {
+  @Test func `the streamed product equals the eager product filtered`() throws {
     // Cross the two inputs by hand — every child paired with every adult in
     // outer-major order — and keep the pairs the ON equality admits. The fused
     // streaming operator must yield exactly this, in this order.
@@ -2097,8 +2001,7 @@ struct EngineStreamingProductTests {
     #expect(streamed == eager)
   }
 
-  @Test("a residual product with UNKNOWN pairs drops them")
-  func unknown() throws {
+  @Test func `a residual product with UNKNOWN pairs drops them`() throws {
     // A NULL-keyed pair evaluates the ON equality to UNKNOWN, which the fused
     // filter drops exactly as `admitted` would — no NULL child reaches a match.
     let child = [
@@ -2166,64 +2069,55 @@ private func functionRun(_ text: String) throws -> Array<Array<Value>> {
 }
 
 struct EngineFunctionTests {
-  @Test("a registered function projects over a column")
-  func projection() throws {
+  @Test func `a registered function projects over a column`() throws {
     let rows = try functionRun("SELECT upper(Name) FROM People WHERE Id = 1")
     #expect(rows == [[.text("ALICE")]])
   }
 
-  @Test("a function projects beside a bare column")
-  func mixed() throws {
+  @Test func `a function projects beside a bare column`() throws {
     let rows =
         try functionRun("SELECT Id, upper(Name) FROM People WHERE Id = 3")
     #expect(rows == [[.integer(3), .text("CAROL")]])
   }
 
-  @Test("a function takes more than one column argument")
-  func multiple() throws {
+  @Test func `a function takes more than one column argument`() throws {
     let rows = try functionRun("SELECT add(Id, Age) FROM People WHERE Id = 2")
     // Bob: Id 2 + Age 25 = 27.
     #expect(rows == [[.integer(27)]])
   }
 
-  @Test("a function takes a literal argument")
-  func literal() throws {
+  @Test func `a function takes a literal argument`() throws {
     let rows = try functionRun("SELECT add(Id, 100) FROM People WHERE Id = 4")
     #expect(rows == [[.integer(104)]])
   }
 
-  @Test("a function call nests another function call")
-  func nested() throws {
+  @Test func `a function call nests another function call`() throws {
     let rows =
         try functionRun("SELECT add(add(Id, 1), Age) FROM People WHERE Id = 5")
     // Eve: (5 + 1) + 25 = 31.
     #expect(rows == [[.integer(31)]])
   }
 
-  @Test("an unregistered function is reported")
-  func unknown() throws {
+  @Test func `an unregistered function is reported`() throws {
     #expect(throws: SQLError.function("missing")) {
       try functionRun("SELECT missing(Name) FROM People")
     }
   }
 
-  @Test("a function rejecting its arguments reports the fault")
-  func invalid() throws {
+  @Test func `a function rejecting its arguments reports the fault`() throws {
     #expect(throws: SQLError.argument("upper expects one text argument")) {
       try functionRun("SELECT upper(Id) FROM People WHERE Id = 1")
     }
   }
 
-  @Test("a function call resolves its name case-insensitively")
-  func folded() throws {
+  @Test func `a function call resolves its name case-insensitively`() throws {
     // `upper` is registered; the natural SQL spelling UPPER resolves to it, as
     // table and column identifiers do.
     let rows = try functionRun("SELECT UPPER(Name) FROM People WHERE Id = 1")
     #expect(rows == [[.text("ALICE")]])
   }
 
-  @Test("the prelude BITAND yields the bitwise AND of two integers")
-  func bitand() throws {
+  @Test func `the prelude BITAND yields the bitwise AND of two integers`() throws {
     // BITAND ships in the prelude (`Routines.standard`): `routines()` never
     // registers it, yet the call resolves through the seeded prelude and folds
     // case-insensitively. 12 & 10 = 8; 6 & 3 = 2.
@@ -2233,8 +2127,7 @@ struct EngineFunctionTests {
             == [[.integer(2)]])
   }
 
-  @Test("BITAND reports a function-argument fault, not a UNION arity error")
-  func bitandFaults() throws {
+  @Test func `BITAND reports a function-argument fault, not a UNION arity error`() throws {
     // The wrong argument count is a function-argument fault (`.argument`), not
     // `.arity` — whose message is the UNION column-count mismatch.
     #expect(throws: SQLError.argument("BITAND takes two arguments")) {
@@ -2245,8 +2138,7 @@ struct EngineFunctionTests {
     }
   }
 
-  @Test("a registered function shadows the prelude BITAND")
-  func bitandShadowed() throws {
+  @Test func `a registered function shadows the prelude BITAND`() throws {
     // The registry is a single flat map with no privileged tier, so a caller's
     // `bitand` registered OVER the prelude one shadows it (house rule: a later
     // binding wins). The user's closure returns -1, not the bitwise AND.
@@ -2259,8 +2151,7 @@ struct EngineFunctionTests {
     #expect(rows == [[.integer(-1)]])
   }
 
-  @Test("routine names colliding only by case merge without trapping")
-  func collision() throws {
+  @Test func `routine names colliding only by case merge without trapping`() throws {
     // "tag" and "TAG" fold to one name; the registry merges them (the later-
     // sorting original spelling wins) instead of trapping on the duplicate.
     let routines: Routines =
@@ -2275,8 +2166,7 @@ struct EngineFunctionTests {
     #expect(rows == [[.text("lower")]])
   }
 
-  @Test("a predicate filters on a scalar function call")
-  func predicate() throws {
+  @Test func `a predicate filters on a scalar function call`() throws {
     // The documented contract: a predicate may call a registered function;
     // `upper(Name) = 'ALICE'` decodes the column before comparing.
     let rows =
@@ -2284,8 +2174,7 @@ struct EngineFunctionTests {
     #expect(rows == [[.integer(1)]])
   }
 
-  @Test("a predicate compares a function result to an integer")
-  func arithmetic() throws {
+  @Test func `a predicate compares a function result to an integer`() throws {
     let rows =
         try functionRun("SELECT Name FROM People WHERE add(Id, 10) = 12")
     #expect(rows == [[.text("Bob")]])
@@ -2310,8 +2199,7 @@ private func defining(_ defs: String...) throws -> Routines {
 }
 
 struct EngineDefinedFunctionTests {
-  @Test("a defined function evaluates its body over the arguments")
-  func projection() throws {
+  @Test func `a defined function evaluates its body over the arguments`() throws {
     let routines =
         try defining("CREATE FUNCTION twice(n INTEGER) RETURNS INTEGER "
                          + "AS n + n")
@@ -2322,8 +2210,7 @@ struct EngineDefinedFunctionTests {
     #expect(rows == [[.integer(60)]])
   }
 
-  @Test("a defined function binds each parameter to its argument by position")
-  func parameters() throws {
+  @Test func `a defined function binds each parameter to its argument by position`() throws {
     let routines =
         try defining("CREATE FUNCTION span(lo INTEGER, hi INTEGER) "
                          + "RETURNS INTEGER AS hi - lo")
@@ -2334,8 +2221,7 @@ struct EngineDefinedFunctionTests {
     #expect(rows == [[.integer(36)]])
   }
 
-  @Test("a defined function projects beside a bare column")
-  func mixed() throws {
+  @Test func `a defined function projects beside a bare column`() throws {
     let routines =
         try defining("CREATE FUNCTION inc(n INTEGER) RETURNS INTEGER AS n + 1")
     let rows =
@@ -2345,8 +2231,7 @@ struct EngineDefinedFunctionTests {
     #expect(rows == [[.integer(2), .integer(26)]])
   }
 
-  @Test("a defined function filters in a predicate")
-  func predicate() throws {
+  @Test func `a defined function filters in a predicate`() throws {
     let routines =
         try defining("CREATE FUNCTION inc(n INTEGER) RETURNS INTEGER AS n + 1")
     let rows =
@@ -2356,8 +2241,7 @@ struct EngineDefinedFunctionTests {
     #expect(rows == [[.text("Alice")], [.text("Carol")]])
   }
 
-  @Test("a parameterless defined function yields its constant body")
-  func nullary() throws {
+  @Test func `a parameterless defined function yields its constant body`() throws {
     let routines =
         try defining("CREATE FUNCTION answer() RETURNS INTEGER AS 40 + 2")
     let rows =
@@ -2366,8 +2250,7 @@ struct EngineDefinedFunctionTests {
     #expect(rows == [[.integer(42)]])
   }
 
-  @Test("a defined function propagates a NULL argument through its body")
-  func nullArgument() throws {
+  @Test func `a defined function propagates a NULL argument through its body`() throws {
     // A NULL bound to a parameter propagates through the body's arithmetic (SQL
     // null propagation), so the result is NULL rather than a fault.
     let routines =
@@ -2382,8 +2265,7 @@ struct EngineDefinedFunctionTests {
     #expect(rows == [[.null]])
   }
 
-  @Test("a call with the wrong argument count faults with the declared arity")
-  func arity() throws {
+  @Test func `a call with the wrong argument count faults with the declared arity`() throws {
     // The declared `parameters` contract is what the static type-check (the
     // `call` contract check, the schema path drives) validates a call against,
     // exactly as it does a native routine's signature — a wrong argument count
@@ -2397,8 +2279,7 @@ struct EngineDefinedFunctionTests {
     }
   }
 
-  @Test("a call with a wrong argument kind faults against the parameter type")
-  func kind() throws {
+  @Test func `a call with a wrong argument kind faults against the parameter type`() throws {
     // A definitively-wrong argument type (text where an integer parameter is
     // declared) is rejected by the same `call` contract check.
     let routines =
@@ -2410,8 +2291,7 @@ struct EngineDefinedFunctionTests {
     }
   }
 
-  @Test("typing reports the declared RETURNS of a defined function")
-  func typing() throws {
+  @Test func `typing reports the declared RETURNS of a defined function`() throws {
     // The result-schema walk types a `f(...)` call by the routine's declared
     // return type without running it, so a defined function's declared RETURNS
     // is what the output column reports.
@@ -2424,8 +2304,7 @@ struct EngineDefinedFunctionTests {
     #expect(columns[0] == OutputColumn(name: "L", type: .text))
   }
 
-  @Test("a defined function body naming an unknown parameter faults at define")
-  func undeclaredParameter() throws {
+  @Test func `a defined function body naming an unknown parameter faults at define`() throws {
     // The body is lowered against its parameters at registration, so a reference
     // to a name the function does not declare faults there — the moment a
     // `CREATE FUNCTION` binds — not at each later call.
@@ -2434,8 +2313,7 @@ struct EngineDefinedFunctionTests {
     }
   }
 
-  @Test("a later defined function shadows an earlier one of the same name")
-  func shadowing() throws {
+  @Test func `a later defined function shadows an earlier one of the same name`() throws {
     // A later registration wins (the house rule the flat registry follows), so
     // the second `inc` — adding 100 — is the one a call resolves.
     let routines = try defining(
@@ -2448,8 +2326,7 @@ struct EngineDefinedFunctionTests {
     #expect(rows == [[.integer(130)]])
   }
 
-  @Test("a body naming its own unregistered name faults as unresolved")
-  func selfReference() throws {
+  @Test func `a body naming its own unregistered name faults as unresolved`() throws {
     // `f() RETURNS INTEGER AS f() + 1` with NO prior `f` early-binds against a
     // map without `f`, so the body's own call is unresolved: registration
     // faults `SQLError.function` — the unregistered-callee case — not a
@@ -2460,8 +2337,7 @@ struct EngineDefinedFunctionTests {
     }
   }
 
-  @Test("a self-referential redefinition captures the prior function")
-  func selfReferenceRedefinition() throws {
+  @Test func `a self-referential redefinition captures the prior function`() throws {
     // `f() AS f() + 1` REPLACING a prior `f` is well-defined under early
     // binding: the new body captures the OLD `f` and computes `f_old() + 1`,
     // terminating. With `f_old()` = 0, `SELECT f()` returns 0 + 1 = 1.
@@ -2474,8 +2350,7 @@ struct EngineDefinedFunctionTests {
     #expect(rows == [[.integer(1)]])
   }
 
-  @Test("a body calling a different existing function still registers")
-  func crossReference() throws {
+  @Test func `a body calling a different existing function still registers`() throws {
     // A body calling a distinct, already-registered routine early-binds it and
     // registers cleanly — the common composition case.
     let routines = try defining(
@@ -2488,8 +2363,7 @@ struct EngineDefinedFunctionTests {
     #expect(rows == [[.integer(32)]])
   }
 
-  @Test("a body calling a prelude routine registers against empty routines")
-  func preludeCall() throws {
+  @Test func `a body calling a prelude routine registers against empty routines`() throws {
     // Registered against EMPTY routines — NOT `defining`, which seeds the
     // prelude — a body calling BITAND still resolves it: registration merges
     // `Routines.standard` under the caller's routines (the run/columns
@@ -2512,8 +2386,7 @@ struct EngineDefinedFunctionTests {
     #expect(odd == [[.integer(1)]])
   }
 
-  @Test("a body calling a still-unknown routine faults at registration")
-  func unknownCall() throws {
+  @Test func `a body calling a still-unknown routine faults at registration`() throws {
     // Merging the prelude into the capture must not mask a genuinely-unknown
     // callee: a body naming `nope`, bound by neither the prelude nor a prior
     // registration, is still unresolved and faults `SQLError.function` at
@@ -2523,8 +2396,7 @@ struct EngineDefinedFunctionTests {
     }
   }
 
-  @Test("a body binds its callee at definition, not at call time")
-  func capturedCallee() throws {
+  @Test func `a body binds its callee at definition, not at call time`() throws {
     // The round-5 root case at the parse level. `g` returns INTEGER 1; `f() AS
     // g()` captures that INTEGER `g`. Redefining `g` to a TEXT body shadows it
     // for QUERIES, but `f` closed over the old `g`, so `SELECT f()` still
@@ -2548,42 +2420,36 @@ struct EngineDefinedFunctionTests {
 // MARK: - NULL tests
 
 struct EngineNullTests {
-  @Test("IS NULL admits only the NULL rows")
-  func isNull() throws {
+  @Test func `IS NULL admits only the NULL rows`() throws {
     try nullable().expect("SELECT Id FROM Maybe WHERE Note IS NULL",
                           yields: [[2], [4]])
   }
 
-  @Test("IS NOT NULL admits only the non-NULL rows")
-  func isNotNull() throws {
+  @Test func `IS NOT NULL admits only the non-NULL rows`() throws {
     let rows = try nullable("SELECT Id FROM Maybe WHERE Note IS NOT NULL")
     #expect(rows == [[.integer(1)], [.integer(3)]])
   }
 
-  @Test("a comparison against a NULL cell is UNKNOWN and rejects")
-  func comparison() throws {
+  @Test func `a comparison against a NULL cell is UNKNOWN and rejects`() throws {
     // For the NULL rows (2, 4) `Note = 'alpha'` is UNKNOWN, not false, so they
     // are not admitted; only the row whose Note equals 'alpha' survives.
     try nullable().expect("SELECT Id FROM Maybe WHERE Note = 'alpha'",
                           yields: [[1]])
   }
 
-  @Test("NOT of a NULL comparison stays UNKNOWN and rejects")
-  func negated() throws {
+  @Test func `NOT of a NULL comparison stays UNKNOWN and rejects`() throws {
     // The NULL rows are UNKNOWN; NOT UNKNOWN is UNKNOWN, so they still reject —
     // only the non-null, non-'alpha' row survives.
     let rows = try nullable("SELECT Id FROM Maybe WHERE NOT Note = 'alpha'")
     #expect(rows == [[.integer(3)]])
   }
 
-  @Test("a NULL cell projects as a NULL value")
-  func projection() throws {
+  @Test func `a NULL cell projects as a NULL value`() throws {
     try nullable().expect("SELECT Note FROM Maybe WHERE Id = 2",
                           yields: [[nil]])
   }
 
-  @Test("ORDER BY ascending sorts NULL keys first, then by value")
-  func orderAscending() throws {
+  @Test func `ORDER BY ascending sorts NULL keys first, then by value`() throws {
     // NULL holds a stable position — first in ascending order — so the non-null
     // notes still sort among themselves ('alpha' before 'gamma') rather than
     // tying with the nulls and leaving the order undefined.
@@ -2591,14 +2457,12 @@ struct EngineNullTests {
                           yields: [[2], [4], [1], [3]])
   }
 
-  @Test("ORDER BY descending sorts NULL keys last")
-  func orderDescending() throws {
+  @Test func `ORDER BY descending sorts NULL keys last`() throws {
     try nullable().expect("SELECT Id FROM Maybe ORDER BY Note DESC",
                           yields: [[3], [1], [2], [4]])
   }
 
-  @Test("a NULL outer join key matches no inner row")
-  func join() throws {
+  @Test func `a NULL outer join key matches no inner row`() throws {
     // The child with a NULL foreign key is the outer row; a NULL key equi-joins
     // to nothing, so it contributes no pair — `Parent` is sorted, so the inner
     // is seeked and the NULL key is skipped before probing.
@@ -2622,8 +2486,7 @@ private func boundRun(_ text: String, _ bindings: Bindings)
 }
 
 struct EngineBoundTests {
-  @Test("a bound parameter filters rows by an outer value")
-  func filter() throws {
+  @Test func `a bound parameter filters rows by an outer value`() throws {
     // The child relation keyed on a bound parent id — the section primitive: a
     // template renders an interface's methods by binding the interface key and
     // running the child query.
@@ -2632,29 +2495,25 @@ struct EngineBoundTests {
     #expect(rows == [[.text("Ann")], [.text("Amy")]])
   }
 
-  @Test("a bound text parameter compares against a text column")
-  func text() throws {
+  @Test func `a bound text parameter compares against a text column`() throws {
     let rows = try boundRun("SELECT Id FROM Parent WHERE Name = :who",
                             ["who": .text("Bee")])
     #expect(rows == [[.integer(2)]])
   }
 
-  @Test("an unbound parameter admits no row")
-  func unbound() throws {
+  @Test func `an unbound parameter admits no row`() throws {
     let rows = try boundRun("SELECT Name FROM Child WHERE Pid = :pid", [:])
     #expect(rows.isEmpty)
   }
 
-  @Test("a bound parameter conjoined with another predicate")
-  func conjunction() throws {
+  @Test func `a bound parameter conjoined with another predicate`() throws {
     let rows = try boundRun("""
         SELECT Name FROM Child WHERE Pid = :pid AND Name = 'Amy'
         """, ["pid": .integer(1)])
     #expect(rows == [[.text("Amy")]])
   }
 
-  @Test("a correlated section runs a child query per outer row")
-  func correlated() throws {
+  @Test func `a correlated section runs a child query per outer row`() throws {
     // The relational shape of a template's nested section: the outer query
     // yields the parents; for each, the child query is re-run with the parent's
     // key bound, producing that parent's children — exactly an interface →
@@ -2683,23 +2542,20 @@ struct EngineBoundTests {
     #expect(sections[2].children.isEmpty)
   }
 
-  @Test("an unbound parameter under NOT still admits no rows")
-  func negated() throws {
+  @Test func `an unbound parameter under NOT still admits no rows`() throws {
     // A missing binding is UNKNOWN, not false; NOT preserves UNKNOWN rather
     // than inverting it into a match, so the predicate admits nothing.
     let rows = try boundRun("SELECT Name FROM Child WHERE NOT Pid = :pid", [:])
     #expect(rows.isEmpty)
   }
 
-  @Test("a bound parameter under NOT inverts the match")
-  func inverted() throws {
+  @Test func `a bound parameter under NOT inverts the match`() throws {
     let rows = try boundRun("SELECT Name FROM Child WHERE NOT Pid = :pid",
                             ["pid": .integer(1)])
     #expect(rows == [[.text("Bob")], [.text("Orphan")]])
   }
 
-  @Test("a bound key plans a seek when its value is known")
-  func seek() throws {
+  @Test func `a bound key plans a seek when its value is known`() throws {
     // Parent is sorted on Id; with `:id` bound the planner resolves it and
     // seeks the run rather than scanning and filtering the whole relation.
     let select = try parse("SELECT Name FROM Parent WHERE Id = :id")
@@ -2710,8 +2566,7 @@ struct EngineBoundTests {
     #expect(!filters(plan))
   }
 
-  @Test("an unbound key cannot seek and scans under the filter")
-  func scan() throws {
+  @Test func `an unbound key cannot seek and scans under the filter`() throws {
     let select = try parse("SELECT Name FROM Parent WHERE Id = :id")
     let catalog = try family()
     let plan = try catalog.optimise(catalog.compile(select), [:])
@@ -2719,8 +2574,7 @@ struct EngineBoundTests {
     #expect(filters(plan))
   }
 
-  @Test("a bound key inside a view seeks when its parameter is supplied")
-  func nested() throws {
+  @Test func `a bound key inside a view seeks when its parameter is supplied`() throws {
     // A parameterized view (`… WHERE Id = :id` over sorted Parent): the bound
     // key seeks inside the view's sub-plan rather than scanning it once :id is
     // supplied, so a reusable view is as fast as the inlined query.
@@ -2762,8 +2616,7 @@ private func tags() -> Memory {
 }
 
 struct EngineUnionTests {
-  @Test("UNION removes whole-row duplicates, keeping the first occurrence")
-  func dedup() throws {
+  @Test func `UNION removes whole-row duplicates, keeping the first occurrence`() throws {
     // People's Age repeats (30 for Alice and Carol, 25 for Bob and Eve); a
     // UNION of the relation with itself collapses every duplicate row.
     let rows = try people().run(parse("""
@@ -2772,8 +2625,7 @@ struct EngineUnionTests {
     #expect(rows == [[.integer(30)], [.integer(25)], [.integer(40)]])
   }
 
-  @Test("UNION ALL keeps every row of every arm in source order")
-  func all() throws {
+  @Test func `UNION ALL keeps every row of every arm in source order`() throws {
     let rows = try people().run(parse("""
         SELECT Age FROM People UNION ALL SELECT Age FROM People
         """))
@@ -2781,8 +2633,7 @@ struct EngineUnionTests {
     #expect(rows == (ages + ages).map { [$0] })
   }
 
-  @Test("a UNION across two relations of matching arity merges and dedups")
-  func merge() throws {
+  @Test func `a UNION across two relations of matching arity merges and dedups`() throws {
     let rows = try tags().run(parse("""
         SELECT Tag FROM Left UNION SELECT Tag FROM Right
         """))
@@ -2790,8 +2641,7 @@ struct EngineUnionTests {
     #expect(rows == [[.text("a")], [.text("shared")], [.text("b")]])
   }
 
-  @Test("a UNION ALL across two relations keeps the shared row twice")
-  func mergeAll() throws {
+  @Test func `a UNION ALL across two relations keeps the shared row twice`() throws {
     let rows = try tags().run(parse("""
         SELECT Tag FROM Left UNION ALL SELECT Tag FROM Right
         """))
@@ -2803,8 +2653,7 @@ struct EngineUnionTests {
     ])
   }
 
-  @Test("an inner UNION dedups before a trailing UNION ALL appends its arm")
-  func nestedAll() throws {
+  @Test func `an inner UNION dedups before a trailing UNION ALL appends its arm`() throws {
     // (Left UNION Right) UNION ALL Extra. The inner UNION dedups `shared`
     // across Left and Right to one row — `a, shared, b` — and the outer UNION
     // ALL then appends Extra's `a` WITHOUT deduplicating, so `a` recurs. A
@@ -2822,8 +2671,7 @@ struct EngineUnionTests {
     ])
   }
 
-  @Test("a UNION of arms projecting differing column counts is rejected")
-  func arity() throws {
+  @Test func `a UNION of arms projecting differing column counts is rejected`() throws {
     #expect(throws: SQLError.arity(1, 2)) {
       try people().run(parse("""
           SELECT Id FROM People UNION SELECT Id, Name FROM People
@@ -2831,8 +2679,7 @@ struct EngineUnionTests {
     }
   }
 
-  @Test("a view defined as a UNION resolves and queries")
-  func view() throws {
+  @Test func `a view defined as a UNION resolves and queries`() throws {
     let both = try View(query: select("""
         SELECT Tag FROM Left UNION SELECT Tag FROM Right
         """), columns: ["Tag"])
@@ -2841,8 +2688,7 @@ struct EngineUnionTests {
     #expect(rows == [[.text("a")], [.text("shared")], [.text("b")]])
   }
 
-  @Test("a bound parameter threads into every arm of a UNION")
-  func bound() throws {
+  @Test func `a bound parameter threads into every arm of a UNION`() throws {
     // Both arms key on the same `:pid`; the binding reaches each alike, so the
     // union is the parent's children drawn from two queries over the relation.
     let rows = try family().run(parse("""
@@ -2861,28 +2707,24 @@ struct EngineUnionTests {
 // MARK: - DISTINCT tests
 
 struct EngineDistinctTests {
-  @Test("DISTINCT removes duplicate rows, keeping the first occurrence")
-  func dedup() throws {
+  @Test func `DISTINCT removes duplicate rows, keeping the first occurrence`() throws {
     // People's Age repeats (30 for Alice and Carol, 25 for Bob and Eve);
     // DISTINCT collapses each duplicate to its first appearance, in row order.
     try people().expect("SELECT DISTINCT Age FROM People",
                         yields: [[30], [25], [40]])
   }
 
-  @Test("a plain SELECT keeps every duplicate row")
-  func all() throws {
+  @Test func `a plain SELECT keeps every duplicate row`() throws {
     try people().expect("SELECT Age FROM People",
                         yields: [[30], [25], [30], [40], [25]])
   }
 
-  @Test("SELECT ALL is the plain, non-deduplicating select")
-  func explicitAll() throws {
+  @Test func `SELECT ALL is the plain, non-deduplicating select`() throws {
     try people().expect("SELECT ALL Age FROM People",
                         yields: [[30], [25], [30], [40], [25]])
   }
 
-  @Test("DISTINCT dedups on the whole projected row, not one column")
-  func multipleColumns() throws {
+  @Test func `DISTINCT dedups on the whole projected row, not one column`() throws {
     // Grade's (Class, Score) pairs repeat — (A, 80) three times, (B, 90)
     // twice — while a single column would over-collapse. DISTINCT keeps one of
     // each distinct pair, first occurrence in row order.
@@ -2890,16 +2732,14 @@ struct EngineDistinctTests {
                         yields: [["B", 90], ["A", 80], ["A", 70]])
   }
 
-  @Test("DISTINCT dedups rows a projection maps together")
-  func projected() throws {
+  @Test func `DISTINCT dedups rows a projection maps together`() throws {
     // Bob (25) and Eve (25), Alice (30) and Carol (30) share an Age; projecting
     // Age alone collapses each pair even though their other columns differ.
     try people().expect("SELECT DISTINCT Age FROM People WHERE Age < 40",
                         yields: [[30], [25]])
   }
 
-  @Test("DISTINCT binds to its own arm within a UNION ALL")
-  func overUnionArm() throws {
+  @Test func `DISTINCT binds to its own arm within a UNION ALL`() throws {
     // DISTINCT is a per-SELECT quantifier: it dedups the LEFT arm alone (its
     // repeated Ages collapse to 30, 25, 40), then the UNION ALL appends the
     // right arm's rows without deduplicating across the arms.
@@ -2909,16 +2749,14 @@ struct EngineDistinctTests {
         """, yields: [[30], [25], [40], [30]])
   }
 
-  @Test("DISTINCT combines with ORDER BY, ordering the deduplicated rows")
-  func ordered() throws {
+  @Test func `DISTINCT combines with ORDER BY, ordering the deduplicated rows`() throws {
     // The distinct Ages, then ascending: dedup keeps 30, 25, 40; ORDER BY sorts
     // them 25, 30, 40.
     try people().expect("SELECT DISTINCT Age FROM People ORDER BY Age",
                         yields: [[25], [30], [40]])
   }
 
-  @Test("DISTINCT dedups before OFFSET/FETCH pages the result")
-  func paged() throws {
+  @Test func `DISTINCT dedups before OFFSET/FETCH pages the result`() throws {
     // Three distinct Ages ordered 25, 30, 40; FETCH FIRST 2 pages the
     // deduplicated, ordered rows — proving the cap sits above the dedup.
     try people().expect("""
@@ -2926,8 +2764,7 @@ struct EngineDistinctTests {
         """, yields: [[25], [30]])
   }
 
-  @Test("DISTINCT over an aggregate dedups the grouped rows")
-  func aggregate() throws {
+  @Test func `DISTINCT over an aggregate dedups the grouped rows`() throws {
     // Grouping People by Age yields one row per distinct Age (25, 30, 40), each
     // with its COUNT; projecting only the COUNT leaves 2, 2, 1 — DISTINCT then
     // collapses the two 2s to one.
@@ -2936,24 +2773,21 @@ struct EngineDistinctTests {
         """, yields: [[2], [1]])
   }
 
-  @Test("a view defined with DISTINCT deduplicates when queried")
-  func view() throws {
+  @Test func `a view defined with DISTINCT deduplicates when queried`() throws {
     let ages = try View(query: select("SELECT DISTINCT Age FROM People"),
                         columns: ["Age"])
     let catalog = Memory(try people().catalog, views: ["Ages": ages])
     try catalog.expect("SELECT Age FROM Ages", yields: [[30], [25], [40]])
   }
 
-  @Test("DISTINCT ordering on a non-projected column faults")
-  func hiddenOrderKey() throws {
+  @Test func `DISTINCT ordering on a non-projected column faults`() throws {
     // Name is not in the DISTINCT output, so after dedup each Age stands for
     // several Names — the order is ill-defined; the standard rejects it.
     try people().expect("SELECT DISTINCT Age FROM People ORDER BY Name",
                         fails: .distinct("Name"))
   }
 
-  @Test("DISTINCT ordering on a projected column pages correctly")
-  func projectedOrderKey() throws {
+  @Test func `DISTINCT ordering on a projected column pages correctly`() throws {
     // Age is a select-list column, so ordering (and paging) on it is well
     // defined: the deduplicated Ages sort 25, 30, 40, and OFFSET 1 drops the
     // first.
@@ -2963,8 +2797,7 @@ struct EngineDistinctTests {
         """, yields: [[30], [40]])
   }
 
-  @Test("DISTINCT over a join rejects a hidden ORDER BY key")
-  func hiddenJoinOrderKey() throws {
+  @Test func `DISTINCT over a join rejects a hidden ORDER BY key`() throws {
     // Child.Name is not projected, so ordering the deduplicated Parent.Name
     // rows on it is ill-defined across the two joined relations.
     try family().expect("""
@@ -2973,13 +2806,11 @@ struct EngineDistinctTests {
         """, fails: .distinct("Name"))
   }
 
-  @Test("SS005 is the DISTINCT ORDER BY SQLSTATE")
-  func sqlstate() {
+  @Test func `SS005 is the DISTINCT ORDER BY SQLSTATE`() {
     #expect(SQLError.distinct("Name").sqlstate == "SS005")
   }
 
-  @Test("grouped DISTINCT rejects ordering on a non-output GROUP BY key")
-  func hiddenGroupedOrderKey() throws {
+  @Test func `grouped DISTINCT rejects ordering on a non-output GROUP BY key`() throws {
     // The output is only COUNT(*); Age is the grouping key but not projected,
     // so ordering (and paging) on it after dedup is ill-defined — the same rule
     // the non-aggregate path enforces, in grouped-slot space.
@@ -2988,8 +2819,7 @@ struct EngineDistinctTests {
         """, fails: .distinct("Age"))
   }
 
-  @Test("grouped DISTINCT orders on a projected aggregate alias")
-  func projectedGroupedOrderKey() throws {
+  @Test func `grouped DISTINCT orders on a projected aggregate alias`() throws {
     // The counts per Age are 2, 2, 1; DISTINCT collapses the two 2s, leaving
     // {1, 2}. Ordering on the projected alias `c` is well defined — ascending
     // yields 1, 2.
@@ -3002,27 +2832,23 @@ struct EngineDistinctTests {
 // MARK: - Arithmetic tests
 
 struct EngineArithmeticTests {
-  @Test("literal arithmetic evaluates over a row")
-  func literal() throws {
+  @Test func `literal arithmetic evaluates over a row`() throws {
     // One row of `People` drives the projection; the value is the same for each,
     // and `Id = 1` selects exactly one.
     try people().expect("SELECT 2 + 3 FROM People WHERE Id = 1", yields: [[5]])
   }
 
-  @Test("multiplication binds tighter than addition")
-  func precedence() throws {
+  @Test func `multiplication binds tighter than addition`() throws {
     try people().expect("SELECT 2 + 3 * 4 FROM People WHERE Id = 1",
                         yields: [[14]])
   }
 
-  @Test("parentheses override precedence")
-  func grouping() throws {
+  @Test func `parentheses override precedence`() throws {
     try people().expect("SELECT (2 + 3) * 4 FROM People WHERE Id = 1",
                         yields: [[20]])
   }
 
-  @Test("subtraction and division are left-associative")
-  func associativity() throws {
+  @Test func `subtraction and division are left-associative`() throws {
     // (20 - 5) - 3 = 12, not 20 - (5 - 3) = 18; (100 / 5) / 2 = 10.
     let difference = try run("SELECT 20 - 5 - 3 FROM People WHERE Id = 1")
     #expect(difference == [[.integer(12)]])
@@ -3030,42 +2856,36 @@ struct EngineArithmeticTests {
     #expect(quotient == [[.integer(10)]])
   }
 
-  @Test("integer division truncates")
-  func integerDivision() throws {
+  @Test func `integer division truncates`() throws {
     try people().expect("SELECT 7 / 2 FROM People WHERE Id = 1", yields: [[3]])
   }
 
-  @Test("arithmetic over a column computes per row")
-  func column() throws {
+  @Test func `arithmetic over a column computes per row`() throws {
     let rows = try run("SELECT Age + 1 FROM People WHERE Id = 2")
     // Bob's Age is 25; 25 + 1 = 26.
     #expect(rows == [[.integer(26)]])
   }
 
-  @Test("arithmetic mixes columns and a function call")
-  func mixed() throws {
+  @Test func `arithmetic mixes columns and a function call`() throws {
     let rows = try functionRun("SELECT add(Id, 1) * 10 FROM People WHERE Id = 3")
     // Carol: (3 + 1) * 10 = 40.
     #expect(rows == [[.integer(40)]])
   }
 
-  @Test("a NULL operand propagates to a NULL result")
-  func nullPropagation() throws {
+  @Test func `a NULL operand propagates to a NULL result`() throws {
     // `Note` is NULL for row 2; `Id + Note` mixes a present integer with a NULL,
     // so the whole expression is NULL rather than a fault.
     try nullable().expect("SELECT Id + Note FROM Maybe WHERE Id = 2",
                           yields: [[nil]])
   }
 
-  @Test("division by zero faults")
-  func divideByZero() throws {
+  @Test func `division by zero faults`() throws {
     #expect(throws: SQLError.divide) {
       try run("SELECT Id / 0 FROM People WHERE Id = 1")
     }
   }
 
-  @Test("arithmetic overflow faults instead of trapping")
-  func overflow() throws {
+  @Test func `arithmetic overflow faults instead of trapping`() throws {
     // `Int.max + 1` and a multiply past the boundary report overflow as a
     // `SQLError` rather than trapping (and aborting) the process.
     #expect(throws: SQLError.magnitude("integer overflow")) {
@@ -3076,8 +2896,7 @@ struct EngineArithmeticTests {
     }
   }
 
-  @Test("a parenthesised expression opens a predicate")
-  func parenthesisedExpression() throws {
+  @Test func `a parenthesised expression opens a predicate`() throws {
     // `(Age + 1)` is the grouped left operand of the comparison, not a predicate
     // group; it matches Dave (40 + 1 = 41). A leading `(` no longer forces a
     // predicate-group parse.
@@ -3088,15 +2907,13 @@ struct EngineArithmeticTests {
     #expect(none.isEmpty)
   }
 
-  @Test("a text operand faults as a type error")
-  func textOperand() throws {
+  @Test func `a text operand faults as a type error`() throws {
     #expect(throws: SQLError.operand("operands must be numeric")) {
       try run("SELECT Name + 1 FROM People WHERE Id = 1")
     }
   }
 
-  @Test("arithmetic in a predicate filters rows")
-  func predicate() throws {
+  @Test func `arithmetic in a predicate filters rows`() throws {
     // `Age + 1 = 26` holds for everyone aged 25 (Bob and Eve); the arithmetic
     // is evaluated per row on the WHERE side too.
     try people().expect("SELECT Name FROM People WHERE Age + 1 = 26",
@@ -3107,68 +2924,57 @@ struct EngineArithmeticTests {
 // MARK: - Scalar (FROM-less) SELECT tests
 
 struct EngineScalarSelectTests {
-  @Test("a FROM-less literal yields exactly one row")
-  func literal() throws {
+  @Test func `a FROM-less literal yields exactly one row`() throws {
     // No relation, so the projection runs against a single empty row; the
     // catalog is never consulted for a table.
     try people().expect("SELECT 42", yields: [[42]])
   }
 
-  @Test("a FROM-less arithmetic computes a scalar")
-  func arithmetic() throws {
+  @Test func `a FROM-less arithmetic computes a scalar`() throws {
     try people().expect("SELECT 1 + 1", yields: [[2]])
   }
 
-  @Test("FROM-less arithmetic honours precedence")
-  func precedence() throws {
+  @Test func `FROM-less arithmetic honours precedence`() throws {
     try people().expect("SELECT 2 + 3 * 4", yields: [[14]])
   }
 
-  @Test("a FROM-less multi-column projection yields one row of each value")
-  func multiColumn() throws {
+  @Test func `a FROM-less multi-column projection yields one row of each value`() throws {
     try people().expect("SELECT 1, 2, 3", yields: [[1, 2, 3]])
   }
 
-  @Test("a FROM-less projection mixes text and integer expressions")
-  func mixed() throws {
+  @Test func `a FROM-less projection mixes text and integer expressions`() throws {
     try people().expect("SELECT 'x', 10 / 2", yields: [["x", 5]])
   }
 
-  @Test("a FROM-less scalar call evaluates against the single row")
-  func call() throws {
+  @Test func `a FROM-less scalar call evaluates against the single row`() throws {
     let rows = try functionRun("SELECT add(40, 2)")
     #expect(rows == [[.integer(42)]])
   }
 
-  @Test("a boolean literal lowers to its truth value")
-  func boolean() throws {
+  @Test func `a boolean literal lowers to its truth value`() throws {
     try people().expect("SELECT TRUE, FALSE", yields: [[true, false]])
   }
 
-  @Test("a hex blob literal lowers to its bytes")
-  func blob() throws {
+  @Test func `a hex blob literal lowers to its bytes`() throws {
     // The `x'53514c'` literal lexes, parses, and lowers to the three-byte
     // blob `SQL`, projected as a `Value.blob`.
     try people().expect("SELECT x'53514c'",
                         yields: [[[0x53, 0x51, 0x4c] as Array<UInt8>]])
   }
 
-  @Test("a boolean operand faults as a non-numeric type error")
-  func booleanArithmetic() throws {
+  @Test func `a boolean operand faults as a non-numeric type error`() throws {
     // Neither boolean nor blob is numeric, so arithmetic over either faults
     // exactly as text does — the type-checker rejects any non-numeric operand.
     try people().expect("SELECT TRUE + 1",
                         fails: .operand("operands must be numeric"))
   }
 
-  @Test("a blob operand faults as a non-numeric type error")
-  func blobArithmetic() throws {
+  @Test func `a blob operand faults as a non-numeric type error`() throws {
     try people().expect("SELECT x'00' + 1",
                         fails: .operand("operands must be numeric"))
   }
 
-  @Test("a NULL-yielding FROM-less expression projects NULL")
-  func null() throws {
+  @Test func `a NULL-yielding FROM-less expression projects NULL`() throws {
     // The bare literal NULL is not in the grammar, but a NULL arises from a
     // function returning it; `nothing` yields NULL for the single row.
     let routines: Routines =
@@ -3177,20 +2983,17 @@ struct EngineScalarSelectTests {
     #expect(rows == [[.null]])
   }
 
-  @Test("a FROM-less SELECT * is rejected — no relation to expand")
-  func star() throws {
+  @Test func `a FROM-less SELECT * is rejected — no relation to expand`() throws {
     #expect(throws: SQLError.unsupported("SELECT * requires a FROM clause")) {
       try run("SELECT *")
     }
   }
 
-  @Test("a FROM-less bare column is rejected — no column to bind")
-  func column() throws {
+  @Test func `a FROM-less bare column is rejected — no column to bind`() throws {
     try people().expect("SELECT Name", fails: .column("Name"))
   }
 
-  @Test("a directly-built FROM-less select with clauses is rejected")
-  func clauses() throws {
+  @Test func `a directly-built FROM-less select with clauses is rejected`() throws {
     // The parser never builds a FROM-less select carrying a WHERE, GROUP BY,
     // HAVING, ORDER BY, OFFSET/FETCH, or JOIN, but a direct `Select(from: nil,
     // …)` can. The engine rejects it rather than silently drop the clause — a
@@ -3248,8 +3051,7 @@ struct EngineScalarSelectTests {
     return select
   }
 
-  @Test("a FROM-less arm of a UNION combines with a FROM arm")
-  func union() throws {
+  @Test func `a FROM-less arm of a UNION combines with a FROM arm`() throws {
     // Both arms project one integer column; the FROM-less arm contributes its
     // single computed row, deduplicating against the People ages.
     let rows = try people().run(parse("""
@@ -3258,8 +3060,7 @@ struct EngineScalarSelectTests {
     #expect(rows == [[.integer(100)], [.integer(30)]])
   }
 
-  @Test("an existing SELECT … FROM … query is unaffected")
-  func regression() throws {
+  @Test func `an existing SELECT … FROM … query is unaffected`() throws {
     // The FROM-optional grammar leaves a normal query parsing and running
     // exactly as before.
     try people().expect("SELECT Name FROM People WHERE Id = 1",
@@ -3277,8 +3078,7 @@ private func statement<C: Catalog & ~Escapable>(_ text: String,
 }
 
 struct EngineWithTests {
-  @Test("a non-recursive CTE materialises as an inline view")
-  func inline() throws {
+  @Test func `a non-recursive CTE materialises as an inline view`() throws {
     // The CTE `adults` is materialised once and the trailing query reads it
     // like a table — the inline-view shape of a non-recursive WITH.
     let rows = try statement("""
@@ -3288,8 +3088,7 @@ struct EngineWithTests {
     #expect(rows == [[.text("Bee")], [.text("Cid")]])
   }
 
-  @Test("a JOIN matches an integer key to an equal double key")
-  func numericJoin() throws {
+  @Test func `a JOIN matches an integer key to an equal double key`() throws {
     // The optimized join paths (hash bucket, seek/final check, CTE nested loop)
     // must use the same mixed-numeric equality a predicate does: `1` and `1.0`
     // are equal, so the row joins rather than being dropped by a raw-`Value`
@@ -3301,8 +3100,7 @@ struct EngineWithTests {
     #expect(rows == [[.integer(1), .double(1.0)]])
   }
 
-  @Test("a JOIN matches a large integer to its rounded double past 2^53")
-  func numericJoinBeyondExactRange() throws {
+  @Test func `a JOIN matches a large integer to its rounded double past 2^53`() throws {
     // Above 2^53 an integer is not exactly representable as `Double`; the
     // predicate treats `9007199254740993` and `9007199254740993.0` as equal by
     // promoting the integer to `Double` (both round to 2^53), so the optimized
@@ -3315,8 +3113,7 @@ struct EngineWithTests {
     #expect(rows == [[.integer(9007199254740993)]])
   }
 
-  @Test("a JOIN keeps distinct large integer keys unequal (exact integers)")
-  func integerJoinStaysExact() throws {
+  @Test func `a JOIN keeps distinct large integer keys unequal (exact integers)`() throws {
     // Two integers that round to the SAME Double past 2^53 are still unequal as
     // integers, so an integer/integer join must NOT pair them — the hash bucket
     // may collide, but the residual `matches` check keeps integer equality
@@ -3329,8 +3126,7 @@ struct EngineWithTests {
     #expect(rows.isEmpty)
   }
 
-  @Test("UNION deduplicates numerically-equal rows across kinds")
-  func unionNumericDedup() throws {
+  @Test func `UNION deduplicates numerically-equal rows across kinds`() throws {
     // `1` and `1.0` are the same numeric value, so UNION keeps one — the first
     // arm's — not both; the dedup uses the numeric equality, not raw `Value`.
     #expect(try statement("SELECT 1 UNION SELECT 1.0", family())
@@ -3340,8 +3136,7 @@ struct EngineWithTests {
             == [[.integer(1)], [.double(1.0)]])
   }
 
-  @Test("UNION dedup keeps distinct integers a rounded double sits between")
-  func unionExactIntegers() throws {
+  @Test func `UNION dedup keeps distinct integers a rounded double sits between`() throws {
     // Dedup is EXACT: `2^53.0` equals the integer `2^53` (folds to it), but NOT
     // the integer `2^53 + 1`. So an earlier approximate row must not absorb
     // both distinct integers — the `2^53 + 1` row survives regardless of order.
@@ -3354,16 +3149,14 @@ struct EngineWithTests {
                      [.integer(9007199254740993)]])
   }
 
-  @Test("ORDER BY orders mixed integer/double keys by magnitude")
-  func orderByMixedNumeric() throws {
+  @Test func `ORDER BY orders mixed integer/double keys by magnitude`() throws {
     let rows = try statement("""
         WITH a (x) AS (SELECT 3 UNION ALL SELECT 1.5) SELECT x FROM a ORDER BY x
         """, family())
     #expect(rows == [[.double(1.5)], [.integer(3)]])
   }
 
-  @Test("ORDER BY over mixed keys past 2^53 stays a total order")
-  func orderByMixedNumericBeyondExactRange() throws {
+  @Test func `ORDER BY over mixed keys past 2^53 stays a total order`() throws {
     // A double ties two distinct integers under promotion; the comparator must
     // stay a strict weak ordering (transitive), keeping the larger integer last
     // rather than misordering it ahead of the smaller via the stable tie-break.
@@ -3377,8 +3170,7 @@ struct EngineWithTests {
     #expect(rows.last == [.integer(9007199254740993)])
   }
 
-  @Test("a CTE infers its columns and filters on them")
-  func inferred() throws {
+  @Test func `a CTE infers its columns and filters on them`() throws {
     let rows = try statement("""
         WITH grown AS (SELECT Id, Name FROM Parent)
           SELECT Name FROM grown WHERE Id = 3
@@ -3386,8 +3178,7 @@ struct EngineWithTests {
     #expect(rows == [[.text("Cid")]])
   }
 
-  @Test("a later CTE reads an earlier one (chained CTEs)")
-  func chained() throws {
+  @Test func `a later CTE reads an earlier one (chained CTEs)`() throws {
     // `b` resolves `a` — the resolver consults the CTEs materialised so far, so
     // a later member sees an earlier one.
     let rows = try statement("""
@@ -3398,8 +3189,7 @@ struct EngineWithTests {
     #expect(rows == [[.text("Cid")]])
   }
 
-  @Test("a CTE shadows a base relation of the same name")
-  func shadow() throws {
+  @Test func `a CTE shadows a base relation of the same name`() throws {
     // `Parent` is a base relation; the CTE of the same name shadows it, so the
     // trailing query reads the CTE's rows, not the base table's.
     let rows = try statement("""
@@ -3409,8 +3199,7 @@ struct EngineWithTests {
     #expect(rows == [[.text("Ada")]])
   }
 
-  @Test("the trailing query joins a CTE against a base relation")
-  func joinBase() throws {
+  @Test func `the trailing query joins a CTE against a base relation`() throws {
     // The CTE `kids` joins to the base `Parent` on the foreign key — proving a
     // materialised relation and a base one combine in one query.
     let rows = try statement("""
@@ -3425,8 +3214,7 @@ struct EngineWithTests {
     ])
   }
 
-  @Test("a CTE's Id virtual column resolves")
-  func id() throws {
+  @Test func `a CTE's Id virtual column resolves`() throws {
     let rows = try statement("""
         WITH a (Tag) AS (SELECT Name FROM Parent)
           SELECT Id, Tag FROM a WHERE Id = 2
@@ -3434,8 +3222,7 @@ struct EngineWithTests {
     #expect(rows == [[.integer(2), .text("Bee")]])
   }
 
-  @Test("a CTE column list of the wrong arity is rejected at parse")
-  func arity() throws {
+  @Test func `a CTE column list of the wrong arity is rejected at parse`() throws {
     #expect(throws: SQLError.columns(expected: 2, got: 1)) {
       try statement("""
           WITH a (x) AS (SELECT Id, Name FROM Parent) SELECT x FROM a
@@ -3443,8 +3230,7 @@ struct EngineWithTests {
     }
   }
 
-  @Test("an unknown column of a CTE is reported")
-  func unknown() throws {
+  @Test func `an unknown column of a CTE is reported`() throws {
     #expect(throws: SQLError.column("Missing")) {
       try statement("""
           WITH a (Id) AS (SELECT Id FROM Parent) SELECT Missing FROM a
@@ -3452,8 +3238,7 @@ struct EngineWithTests {
     }
   }
 
-  @Test("a CTE whose body is a UNION materialises both arms")
-  func union() throws {
+  @Test func `a CTE whose body is a UNION materialises both arms`() throws {
     let rows = try statement("""
         WITH both (Tag) AS (SELECT Tag FROM Left UNION SELECT Tag FROM Right)
           SELECT Tag FROM both
@@ -3461,8 +3246,7 @@ struct EngineWithTests {
     #expect(rows == [[.text("a")], [.text("shared")], [.text("b")]])
   }
 
-  @Test("a CTE column list wider than its SELECT * body is rejected, not trapped")
-  func widthMismatch() throws {
+  @Test func `a CTE column list wider than its SELECT * body is rejected, not trapped`() throws {
     // `Parent` is a two-column relation, but the column list declares three
     // names; the `SELECT *` body's width is known only after it compiles, so
     // the declared arity is checked against the body's compiled width, faulting
@@ -3475,8 +3259,7 @@ struct EngineWithTests {
     }
   }
 
-  @Test("a zero-row SELECT * CTE body of the wrong arity is rejected")
-  func zeroRowWidthMismatch() throws {
+  @Test func `a zero-row SELECT * CTE body of the wrong arity is rejected`() throws {
     // `Parent` is a two-column relation, but the column list declares three
     // names. The body `WHERE Id < 0` yields no rows, so a per-row check would
     // pass it through vacuously and register `a` with a three-column schema
@@ -3494,8 +3277,7 @@ struct EngineWithTests {
     }
   }
 
-  @Test("a WITH list rejects a case-insensitively duplicate query name")
-  func duplicateName() throws {
+  @Test func `a WITH list rejects a case-insensitively duplicate query name`() throws {
     // Two CTEs share a name (`a` and `A`), so the second would silently
     // overwrite the first in the materialised scope — a typo in a multi-CTE
     // query changing the result. The duplicate is rejected before materialising.
@@ -3508,8 +3290,7 @@ struct EngineWithTests {
     }
   }
 
-  @Test("a WHERE pushed onto a joined-in CTE filters its rows before the join")
-  func joinPushedFilter() throws {
+  @Test func `a WHERE pushed onto a joined-in CTE filters its rows before the join`() throws {
     // `kids` is joined to `Parent` on the foreign key, and a single-relation
     // `WHERE kids.Kid = 'Amy'` is pushed onto the CTE inner; only the matching
     // CTE row may join, so a CTE row with any other `Kid` is excluded rather than
@@ -3523,8 +3304,7 @@ struct EngineWithTests {
     #expect(rows == [[.text("Ada"), .text("Amy")]])
   }
 
-  @Test("a statement CTE does not leak into a registered view's body")
-  func viewScoping() throws {
+  @Test func `a statement CTE does not leak into a registered view's body`() throws {
     // `Adults` is a view over the base `Parent`; a statement-local
     // `WITH Parent (Id) AS …` must NOT reach into the view's stored body, so
     // `SELECT Id FROM Adults` still reads the base `Parent`'s ids — a view means
@@ -3541,8 +3321,7 @@ struct EngineWithTests {
     #expect(rows == [[.integer(1)], [.integer(2)], [.integer(3)]])
   }
 
-  @Test("a top-level FROM a CTE still resolves to the CTE, not the base relation")
-  func topLevelCTEShadowsBase() throws {
+  @Test func `a top-level FROM a CTE still resolves to the CTE, not the base relation`() throws {
     // The complement of `viewScoping`: at the STATEMENT level a CTE that names a
     // base relation still shadows it, so a trailing `FROM Parent` reads the CTE
     // — the scoping fix narrows only a view's body, never the statement query.
@@ -3556,8 +3335,7 @@ struct EngineWithTests {
     #expect(rows == [[.integer(99)]])
   }
 
-  @Test("a WITH RECURSIVE arm that never names the CTE runs once, not to a cap")
-  func nonSelfReferentialUnionAll() throws {
+  @Test func `a WITH RECURSIVE arm that never names the CTE runs once, not to a cap`() throws {
     // Every member of a `WITH RECURSIVE` list is syntactically marked recursive,
     // but neither arm of this UNION ALL reads `a`, so it is not recursive in
     // truth: it runs once, yielding exactly its two rows, rather than re-running
@@ -3571,8 +3349,7 @@ struct EngineWithTests {
     #expect(rows == [[.integer(1)], [.integer(2)]])
   }
 
-  @Test("a WITH RECURSIVE whose anchor reads a same-named base is not recursive")
-  func anchorReadsSameNamedBase() throws {
+  @Test func `a WITH RECURSIVE whose anchor reads a same-named base is not recursive`() throws {
     // The CTE `Parent` shares a base relation's name; only the ANCHOR reads that
     // base (the CTE is not in scope there), while the recursive arm reads
     // `Extra` and never names the CTE. Self-reference is detected in the arm
@@ -3633,8 +3410,7 @@ private func counting() -> Routines {
 }
 
 struct EngineRecursiveTests {
-  @Test("a recursive counter enumerates 1..5")
-  func counter() throws {
+  @Test func `a recursive counter enumerates 1..5`() throws {
     // The canonical recursive CTE: seed with 1, then inc(n) while n < 5. The
     // anchor reads the one-row Seed; the recursive arm names the CTE `c`.
     let query = try Statement(parsing: """
@@ -3650,8 +3426,7 @@ struct EngineRecursiveTests {
                      [.integer(4)], [.integer(5)]])
   }
 
-  @Test("a recursive counter runs through Catalog.run(_:statement:)")
-  func statement() throws {
+  @Test func `a recursive counter runs through Catalog.run(_:statement:)`() throws {
     let rows = try seed().run(Statement(parsing: """
         WITH RECURSIVE c (n) AS (
           SELECT 1 AS n FROM Seed
@@ -3663,8 +3438,7 @@ struct EngineRecursiveTests {
     #expect(rows == [[.integer(1)], [.integer(2)], [.integer(3)]])
   }
 
-  @Test("a non-UNION recursive CTE validates its compiled width")
-  func nonUnionWidthMismatch() throws {
+  @Test func `a non-UNION recursive CTE validates its compiled width`() throws {
     // A `WITH RECURSIVE` member whose body is not a UNION runs once, but must
     // still match its declared arity. Here the body resolves `Parent` against
     // the base relation of the same name (two columns) under a three-column
@@ -3679,8 +3453,7 @@ struct EngineRecursiveTests {
     }
   }
 
-  @Test("a recursive CTE with more than one recursive arm is rejected")
-  func multipleRecursiveArms() throws {
+  @Test func `a recursive CTE with more than one recursive arm is rejected`() throws {
     // The body has TWO self-referential arms; the engine models one anchor plus
     // one recursive arm, so the earlier recursive arm would land in the anchor
     // (compiled with the CTE not in scope). Reject it with a clear `unsupported`
@@ -3699,8 +3472,7 @@ struct EngineRecursiveTests {
     }
   }
 
-  @Test("a recursive reference before the final UNION arm is rejected")
-  func recursiveArmBeforeFinal() throws {
+  @Test func `a recursive reference before the final UNION arm is rejected`() throws {
     // The self-reference (`FROM Parent`) is a MIDDLE arm and the final arm is
     // non-recursive, so the recursive-arm check (which inspects the final arm)
     // sees no recursion and the CTE would take the run-once path — compiling the
@@ -3721,8 +3493,7 @@ struct EngineRecursiveTests {
     }
   }
 
-  @Test("a recursive CTE whose anchor reads a same-named base still evaluates")
-  func anchorShadowsBase() throws {
+  @Test func `a recursive CTE whose anchor reads a same-named base still evaluates`() throws {
     // `Parent` intentionally shadows a base relation of the same name: the anchor
     // `SELECT Id FROM Parent` reads the BASE (the CTE is not in scope for the
     // base case), seeding the recursion, while the right arm's `FROM Parent` is
@@ -3744,8 +3515,7 @@ struct EngineRecursiveTests {
                      [.integer(4)], [.integer(5)]])
   }
 
-  @Test("a recursive CTE whose anchor reads a same-named view still evaluates")
-  func anchorShadowsView() throws {
+  @Test func `a recursive CTE whose anchor reads a same-named view still evaluates`() throws {
     // Like `anchorShadowsBase`, but the same-named seed is a registered VIEW,
     // not a base table: the anchor `SELECT id FROM v` resolves to the view (the
     // CTE is not in scope for the base case), and the right arm is the true
@@ -3766,8 +3536,7 @@ struct EngineRecursiveTests {
                      [.integer(4)], [.integer(5)]])
   }
 
-  @Test("UNION dedups rows a UNION ALL recursion would repeat")
-  func dedup() throws {
+  @Test func `UNION dedups rows a UNION ALL recursion would repeat`() throws {
     // The recursive arm re-derives n from 1 without a guard's monotonic bound,
     // but a bare UNION dedups whole rows, so the fixpoint is the distinct set
     // 1..4 reached and nothing new thereafter — it terminates where UNION ALL
@@ -3785,8 +3554,7 @@ struct EngineRecursiveTests {
                      [.integer(4)]])
   }
 
-  @Test("a bare UNION dedups duplicate anchor seed rows")
-  func anchorDedup() throws {
+  @Test func `a bare UNION dedups duplicate anchor seed rows`() throws {
     // The anchor is itself a UNION ALL that yields `1` twice, so the seed
     // carries a duplicate; the recursive arm (`n < 1`) adds nothing new. A bare
     // outer UNION dedups the seed exactly as it dedups an iteration step, so the
@@ -3806,8 +3574,7 @@ struct EngineRecursiveTests {
     #expect(rows == [[.integer(1)]])
   }
 
-  @Test("a transitive-closure self-join reaches every descendant")
-  func closure() throws {
+  @Test func `a transitive-closure self-join reaches every descendant`() throws {
     // The closure of the edge chain 1->2->3->4: seed with the direct edges,
     // then extend each known reach (Src, Dst) by an edge out of Dst. The
     // recursive arm joins the CTE to the base Edge relation.
@@ -3832,8 +3599,7 @@ struct EngineRecursiveTests {
     ])
   }
 
-  @Test("a recursive arm of the wrong width faults, not traps, before rebinding")
-  func widthMismatch() throws {
+  @Test func `a recursive arm of the wrong width faults, not traps, before rebinding`() throws {
     // `Edge` is a two-column relation, but the column list declares three
     // names; the anchor's `SELECT *` compiles to a two-wide plan the fixpoint
     // would bind under the three-column schema, so the recursive arm's read of
@@ -3854,8 +3620,7 @@ struct EngineRecursiveTests {
     }
   }
 
-  @Test("a zero-row SELECT * anchor of the wrong width faults, not passes")
-  func zeroRowWidthMismatch() throws {
+  @Test func `a zero-row SELECT * anchor of the wrong width faults, not passes`() throws {
     // `Edge` is a two-column relation, but the column list declares three
     // names. The anchor `WHERE Src < 0` yields no rows, so a per-row check
     // would seed nothing to validate and bind the CTE under a three-column
@@ -3876,8 +3641,7 @@ struct EngineRecursiveTests {
     }
   }
 
-  @Test("a runaway recursion is capped with SQLError.recursion")
-  func runaway() throws {
+  @Test func `a runaway recursion is capped with SQLError.recursion`() throws {
     // inc(n) with no terminating WHERE produces an unbounded sequence of new
     // rows; UNION ALL keeps every one, so the fixpoint is never reached and the
     // cap fires.

--- a/Tests/SQLTests/ErrorTests.swift
+++ b/Tests/SQLTests/ErrorTests.swift
@@ -9,25 +9,21 @@ private let here = SourceLocation(line: 1, column: 1, offset: 0)
 
 @Suite("SQLSTATE")
 struct SQLStateTests {
-  @Test("an undefined column reports 42703")
-  func column() {
+  @Test func `an undefined column reports 42703`() {
     #expect(SQLError.column("Missing").sqlstate == "42703")
   }
 
-  @Test("an integer overflow reports 22003")
-  func magnitude() {
+  @Test func `an integer overflow reports 22003`() {
     #expect(SQLError.magnitude("integer overflow").sqlstate == "22003")
     // The lexer's out-of-range literal is the same data exception.
     #expect(SQLError.overflow("99", at: here).sqlstate == "22003")
   }
 
-  @Test("a division by zero reports 22012")
-  func divide() {
+  @Test func `a division by zero reports 22012`() {
     #expect(SQLError.divide.sqlstate == "22012")
   }
 
-  @Test("a syntax error reports 42601")
-  func syntax() {
+  @Test func `a syntax error reports 42601`() {
     #expect(SQLError.character("@", at: here).sqlstate == "42601")
     #expect(SQLError.unterminated("string literal", at: here).sqlstate
                 == "42601")
@@ -40,39 +36,32 @@ struct SQLStateTests {
     #expect(SQLError.arity(1, 2).sqlstate == "42601")
   }
 
-  @Test("an undefined relation reports 42P01")
-  func relation() {
+  @Test func `an undefined relation reports 42P01`() {
     #expect(SQLError.relation("Absent").sqlstate == "42P01")
   }
 
-  @Test("an ambiguous column reports 42702")
-  func ambiguous() {
+  @Test func `an ambiguous column reports 42702`() {
     #expect(SQLError.ambiguous("Name").sqlstate == "42702")
   }
 
-  @Test("a duplicate column reports 42701")
-  func duplicate() {
+  @Test func `a duplicate column reports 42701`() {
     #expect(SQLError.duplicate("Name").sqlstate == "42701")
   }
 
-  @Test("an undefined function reports 42883")
-  func function() {
+  @Test func `an undefined function reports 42883`() {
     #expect(SQLError.function("missing").sqlstate == "42883")
   }
 
-  @Test("a rejected function argument reports 22023")
-  func argument() {
+  @Test func `a rejected function argument reports 22023`() {
     #expect(SQLError.argument("bad").sqlstate == "22023")
   }
 
-  @Test("a non-numeric arithmetic operand reports 42804")
-  func operand() {
+  @Test func `a non-numeric arithmetic operand reports 42804`() {
     #expect(
         SQLError.operand("operands must be numeric").sqlstate == "42804")
   }
 
-  @Test("an engine-specific condition reports the SwiftSQL SS class")
-  func unsupported() {
+  @Test func `an engine-specific condition reports the SwiftSQL SS class`() {
     // Engine-specific faults with no standard ISO code squat on the
     // implementation-defined `SS` (SwiftSQL) class rather than borrow a
     // standard one.
@@ -83,16 +72,14 @@ struct SQLStateTests {
     #expect(SQLError.recursion("loop").sqlstate == "SS003")
   }
 
-  @Test(".state round-trips its code and message")
-  func passthrough() {
+  @Test func `.state round-trips its code and message`() {
     let error = SQLError.state("40001", "serialization failure")
     #expect(error.sqlstate == "40001")
     #expect(error.message == "serialization failure")
     #expect(error.description == "serialization failure")
   }
 
-  @Test("message equals description for a semantic case")
-  func message() {
+  @Test func `message equals description for a semantic case`() {
     let error = SQLError.column("Missing")
     #expect(error.message == error.description)
     #expect(error.message == "no such column 'Missing'")

--- a/Tests/SQLTests/FloatTests.swift
+++ b/Tests/SQLTests/FloatTests.swift
@@ -44,15 +44,13 @@ private func arithmetic(_ lhs: Value, _ op: Arithmetic,
 
 @Suite("DOUBLE comparison")
 private struct DoubleComparisonTests {
-  @Test("like doubles compare by magnitude")
-  func equality() {
+  @Test func `like doubles compare by magnitude`() {
     #expect(compare(.double(1.5), .equal, .double(1.5)) == true)
     #expect(compare(.double(1.5), .equal, .double(2.5)) == false)
     #expect(compare(.double(1.5), .unequal, .double(2.5)) == true)
   }
 
-  @Test("doubles order by magnitude")
-  func ordering() {
+  @Test func `doubles order by magnitude`() {
     #expect(compare(.double(1.5), .lt, .double(2.5)) == true)
     #expect(compare(.double(2.5), .lt, .double(1.5)) == false)
     #expect(compare(.double(2.5), .gt, .double(1.5)) == true)
@@ -65,8 +63,7 @@ private struct DoubleComparisonTests {
 
 @Suite("mixed integer/double comparison")
 private struct MixedComparisonTests {
-  @Test("an integer equals a like-valued double — numeric, not cross-type")
-  func numericEquality() {
+  @Test func `an integer equals a like-valued double — numeric, not cross-type`() {
     // Both operands are numeric, so `1 = 1.0` is TRUE, not a cross-kind miss.
     #expect(compare(.integer(1), .equal, .double(1.0)) == true)
     #expect(compare(.double(1.0), .equal, .integer(1)) == true)
@@ -74,8 +71,7 @@ private struct MixedComparisonTests {
     #expect(compare(.integer(1), .unequal, .double(1.5)) == true)
   }
 
-  @Test("an integer orders against a double by magnitude")
-  func numericOrdering() {
+  @Test func `an integer orders against a double by magnitude`() {
     #expect(compare(.integer(1), .lt, .double(1.5)) == true)
     #expect(compare(.double(1.5), .gt, .integer(1)) == true)
     #expect(compare(.integer(2), .lt, .double(1.5)) == false)
@@ -87,8 +83,7 @@ private struct MixedComparisonTests {
 
 @Suite("DOUBLE arithmetic")
 private struct DoubleArithmeticTests {
-  @Test("double arithmetic yields a double")
-  func likeTyped() throws {
+  @Test func `double arithmetic yields a double`() throws {
     #expect(try arithmetic(.double(1.5), .add, .double(2.0)) == .double(3.5))
     #expect(try arithmetic(.double(2.5), .subtract, .double(1.0))
                 == .double(1.5))
@@ -96,14 +91,12 @@ private struct DoubleArithmeticTests {
                 == .double(3.0))
   }
 
-  @Test("double division is real, not truncated")
-  func realDivision() throws {
+  @Test func `double division is real, not truncated`() throws {
     #expect(try arithmetic(.double(5.0), .divide, .double(2.0))
                 == .double(2.5))
   }
 
-  @Test("a mixed integer/double is numeric and yields a double")
-  func mixed() throws {
+  @Test func `a mixed integer/double is numeric and yields a double`() throws {
     // `5 / 2.0` is real division `2.5`, and `2 * 1.5` is `3.0` — the integer
     // promotes to `Double`, so the result is approximate-numeric.
     #expect(try arithmetic(.integer(5), .divide, .double(2.0))
@@ -114,15 +107,13 @@ private struct DoubleArithmeticTests {
                 == .double(2.5))
   }
 
-  @Test("an integer pair still divides as integers")
-  func integerDivisionUnchanged() throws {
+  @Test func `an integer pair still divides as integers`() throws {
     // The mixed-numeric widening does not touch the exact-numeric path: `5 / 2`
     // is still `2`, not `2.5`.
     #expect(try arithmetic(.integer(5), .divide, .integer(2)) == .integer(2))
   }
 
-  @Test("a double divide by zero raises, matching the integer policy")
-  func divideByZero() {
+  @Test func `a double divide by zero raises, matching the integer policy`() {
     #expect(throws: SQLError.divide) {
       try arithmetic(.double(1.0), .divide, .double(0.0))
     }
@@ -131,8 +122,7 @@ private struct DoubleArithmeticTests {
     }
   }
 
-  @Test("a non-finite double result is rejected, never returned")
-  func nonFinite() {
+  @Test func `a non-finite double result is rejected, never returned`() {
     // An overflow to `inf` (a magnitude past `Double`'s range) faults rather
     // than returning `inf`.
     #expect(throws: SQLError.self) {
@@ -145,8 +135,7 @@ private struct DoubleArithmeticTests {
     }
   }
 
-  @Test("a non-finite double literal is rejected at lowering")
-  func nonFiniteLiteral() throws {
+  @Test func `a non-finite double literal is rejected at lowering`() throws {
     // A directly-built `Literal.double(.nan/.infinity)` (the lexer never makes
     // one) is rejected when lowered to a `Value`, so no non-finite double
     // enters a plan; a finite literal lowers unchanged.
@@ -156,8 +145,7 @@ private struct DoubleArithmeticTests {
     #expect(finite == .double(1.5))
   }
 
-  @Test("a routine returning a non-finite double is rejected")
-  func nonFiniteRoutine() {
+  @Test func `a routine returning a non-finite double is rejected`() {
     // A registered routine is a public `Value` producer that bypasses the
     // literal/arithmetic checks; a NaN or inf result is rejected at the call
     // boundary so it never reaches dedup, ordering, or a recursive UNION.
@@ -181,14 +169,12 @@ private struct DoubleArithmeticTests {
 
 @Suite("DOUBLE NULL propagation")
 private struct DoubleNullTests {
-  @Test("a NULL operand is UNKNOWN in a comparison")
-  func comparison() {
+  @Test func `a NULL operand is UNKNOWN in a comparison`() {
     #expect(compare(.double(1.5), .equal, .null) == nil)
     #expect(compare(.double(1.5), .lt, .null) == nil)
   }
 
-  @Test("a NULL operand propagates through arithmetic")
-  func propagation() throws {
+  @Test func `a NULL operand propagates through arithmetic`() throws {
     #expect(try arithmetic(.double(1.5), .add, .null) == .null)
     #expect(try arithmetic(.null, .multiply, .double(1.5)) == .null)
   }
@@ -198,8 +184,7 @@ private struct DoubleNullTests {
 
 @Suite("DOUBLE sort ordering")
 private struct DoubleSortTests {
-  @Test("doubles sort ascending by magnitude, NULL first")
-  func ordering() {
+  @Test func `doubles sort ascending by magnitude, NULL first`() {
     // `less` is the sort primitive: NULL precedes every value, and two doubles
     // order by magnitude.
     #expect(less(.double(1.5), .double(2.5)) == true)
@@ -208,8 +193,7 @@ private struct DoubleSortTests {
     #expect(less(.double(1.5), .null) == false)
   }
 
-  @Test("a mixed integer/double slot sorts by magnitude")
-  func mixed() {
+  @Test func `a mixed integer/double slot sorts by magnitude`() {
     // A slot that happens to mix exact and approximate numerics still orders by
     // magnitude rather than tying at the kind boundary.
     #expect(less(.integer(1), .double(1.5)) == true)
@@ -217,8 +201,7 @@ private struct DoubleSortTests {
     #expect(less(.double(2.5), .integer(2)) == false)
   }
 
-  @Test("a double past Int.max still orders against Int.max, not a false tie")
-  func beyondIntRange() {
+  @Test func `a double past Int.max still orders against Int.max, not a false tie`() {
     // `Double(Int.max)` rounds to 2^63, past `Int` — but `Int.max` (2^63 - 1)
     // is still strictly less, so the pair orders one way, never false both ways
     // (which would leave MIN/MAX and sort order-dependent).
@@ -231,14 +214,12 @@ private struct DoubleSortTests {
 
 @Suite("DOUBLE literal parsing")
 private struct DoubleLiteralTests {
-  @Test("a decimal literal lowers to a double value")
-  func fraction() throws {
+  @Test func `a decimal literal lowers to a double value`() throws {
     let lowered = try value(of: .double(3.14))
     #expect(lowered == .double(3.14))
   }
 
-  @Test("an integer literal stays an integer value")
-  func integer() throws {
+  @Test func `an integer literal stays an integer value`() throws {
     let lowered = try value(of: .integer(3))
     #expect(lowered == .integer(3))
   }

--- a/Tests/SQLTests/FunctionTests.swift
+++ b/Tests/SQLTests/FunctionTests.swift
@@ -7,25 +7,21 @@ import Testing
 import SQLTestSupport
 
 @Suite struct RoutineTests {
-  @Test("a routine's return type defaults to integer")
-  func defaultReturn() {
+  @Test func `a routine's return type defaults to integer`() {
     #expect(Routine(parameters: []) { _ in .integer(0) }.returns == .integer)
   }
 
-  @Test("a routine carries its declared return type")
-  func declaredReturn() {
+  @Test func `a routine carries its declared return type`() {
     #expect(Routine(returns: .text, parameters: []) { _ in .text("x") }
                 .returns == .text)
   }
 
-  @Test("a routine carries its declared parameter contract")
-  func declaredParameters() {
+  @Test func `a routine carries its declared parameter contract`() {
     let routine = Routine(parameters: [.integer, .text]) { _ in .integer(0) }
     #expect(routine.parameters == [.integer, .text])
   }
 
-  @Test("a routine is called to compute a value")
-  func callable() throws {
+  @Test func `a routine is called to compute a value`() throws {
     let double = Routine(parameters: [.integer]) { arguments in
       guard case let .integer(x) = arguments[0] else { return .null }
       return .integer(x * 2)
@@ -33,8 +29,7 @@ import SQLTestSupport
     #expect(try double([.integer(21)]) == .integer(42))
   }
 
-  @Test("a Routine literal registers its declared signature")
-  func routineLiteral() {
+  @Test func `a Routine literal registers its declared signature`() {
     // A client's documented shape: the literal value is a `Routine`, so each
     // registration declares its full signature — its parameters and return
     // type.
@@ -46,8 +41,7 @@ import SQLTestSupport
     #expect(routines["upper"]?.parameters == [.text])
   }
 
-  @Test("registering declares a signature, the return defaulting to integer")
-  func registering() {
+  @Test func `registering declares a signature, the return defaulting to integer`() {
     let routines = Routines()
         .registering("t", returns: .text, parameters: [.text]) {
           _ in .text("x")
@@ -57,16 +51,14 @@ import SQLTestSupport
     #expect(routines["i"]?.returns == .integer)
   }
 
-  @Test("the name subscript resolves case-insensitively")
-  func lookup() {
+  @Test func `the name subscript resolves case-insensitively`() {
     let routines: Routines =
         ["Tag": Routine(returns: .text, parameters: []) { _ in .text("x") }]
     #expect(routines["TAG"] != nil)
     #expect(routines["nope"] == nil)
   }
 
-  @Test("the standard prelude declares BITAND over two integers")
-  func standardBitand() {
+  @Test func `the standard prelude declares BITAND over two integers`() {
     #expect(Routines.standard["bitand"]?.returns == .integer)
     #expect(Routines.standard["bitand"]?.parameters == [.integer, .integer])
   }
@@ -101,8 +93,7 @@ private func id() -> Function {
 }
 
 @Suite struct RoutineContractTests {
-  @Test("a defined call with too few arguments faults at the run path")
-  func arityShort() throws {
+  @Test func `a defined call with too few arguments faults at the run path`() throws {
     // A defined routine reaches the run path without a prior type-check, so its
     // arity is enforced in the call itself: `twice()` reads slot 0 of an empty
     // record, which would trap; the guard turns it into `SQLError.argument`.
@@ -112,8 +103,7 @@ private func id() -> Function {
                          routines: routines)
   }
 
-  @Test("a defined call with too many arguments faults at the run path")
-  func arityLong() throws {
+  @Test func `a defined call with too many arguments faults at the run path`() throws {
     // Extra arguments are not silently ignored: the arity guard rejects a call
     // wider than the declared parameters, the same `SQLError.argument` a native
     // routine's own count check raises.
@@ -123,8 +113,7 @@ private func id() -> Function {
                          routines: routines)
   }
 
-  @Test("registering a body of the wrong type faults against the RETURNS")
-  func returnMismatch() {
+  @Test func `registering a body of the wrong type faults against the RETURNS`() {
     // `f(n INTEGER) RETURNS TEXT AS n + 1` derives an integer body against a
     // declared TEXT result — a contract violation caught at registration, the
     // moment the function binds, with the same `SQLError.argument` case the
@@ -139,8 +128,7 @@ private func id() -> Function {
     }
   }
 
-  @Test("registering a body matching the RETURNS succeeds and runs")
-  func returnMatch() throws {
+  @Test func `registering a body matching the RETURNS succeeds and runs`() throws {
     // A body whose derived type equals the declared result registers cleanly
     // and computes over its argument.
     let routines = try Routines().registering("twice", twice())
@@ -148,8 +136,7 @@ private func id() -> Function {
                          yields: [[14]], routines: routines)
   }
 
-  @Test("a NULL result is allowed against any declared return type")
-  func returnNull() throws {
+  @Test func `a NULL result is allowed against any declared return type`() throws {
     // NULL is not a type — it propagates through any declared result — so a
     // body that yields NULL on a row (a NULL argument through its arithmetic)
     // does not violate the INTEGER contract the derivation checked.
@@ -158,8 +145,7 @@ private func id() -> Function {
                          yields: [[nil]], routines: routines)
   }
 
-  @Test("a duplicate parameter on the public path faults with the later name")
-  func duplicateParameter() {
+  @Test func `a duplicate parameter on the public path faults with the later name`() {
     // The parser rejects a duplicate parameter, but a directly-constructed
     // `Function` bypasses it; the registration path applies the same
     // case-insensitive check so the second (unreachable) slot never registers.
@@ -172,8 +158,7 @@ private func id() -> Function {
     }
   }
 
-  @Test("registering a body calling an unregistered routine faults")
-  func unresolvedCall() {
+  @Test func `registering a body calling an unregistered routine faults`() {
     // A defined body early-binds its calls against the routines captured at
     // definition. `f() RETURNS INTEGER AS g()` with `g` unknown captures a map
     // without `g`, so the returns validation cannot resolve the call: rather
@@ -186,8 +171,7 @@ private func id() -> Function {
     }
   }
 
-  @Test("a body calling an already-registered routine adopts its return type")
-  func resolvedCall() throws {
+  @Test func `a body calling an already-registered routine adopts its return type`() throws {
     // With `g` registered first, `f() RETURNS TEXT AS g()` validates against
     // g's declared TEXT result and registers; the call resolves at run time.
     let g = Function(parameters: [], returns: .text,
@@ -199,8 +183,7 @@ private func id() -> Function {
                          yields: [["x"]], routines: routines)
   }
 
-  @Test("a defined call with a wrong-typed argument faults at the run path")
-  func argumentType() throws {
+  @Test func `a defined call with a wrong-typed argument faults at the run path`() throws {
     // Reached through the RUN path (no prior `columns(validate:)`), the defined
     // dispatch validates each argument's type, not only the arity: `id(Name)`
     // over a TEXT column would otherwise return a `.text` value against the
@@ -212,8 +195,7 @@ private func id() -> Function {
                          routines: routines)
   }
 
-  @Test("a defined call with a NULL argument is allowed and yields NULL")
-  func argumentNull() throws {
+  @Test func `a defined call with a NULL argument is allowed and yields NULL`() throws {
     // NULL is not a type — it propagates through the body — so a NULL argument
     // bound to any declared parameter is admitted (exactly as `BITAND` returns
     // NULL on a NULL argument), and the identity body yields NULL.
@@ -222,8 +204,7 @@ private func id() -> Function {
                          yields: [[nil]], routines: routines)
   }
 
-  @Test("a defined call with a correct-typed argument returns the value")
-  func argumentMatch() throws {
+  @Test func `a defined call with a correct-typed argument returns the value`() throws {
     // A correct-typed argument passes the run-path type check and the identity
     // body returns it — the guard rejects only a definitively-wrong type.
     let routines = try Routines().registering("id", id())
@@ -231,8 +212,7 @@ private func id() -> Function {
                          yields: [[7]], routines: routines)
   }
 
-  @Test("a body naming its own unregistered name faults as unresolved")
-  func selfReference() {
+  @Test func `a body naming its own unregistered name faults as unresolved`() {
     // `f() RETURNS INTEGER AS f() + 1` with NO prior `f` captures a map without
     // `f`, so the body's own call is unresolved: the returns validation faults
     // `SQLError.function`, the unregistered-callee case — not a self-reference
@@ -245,8 +225,7 @@ private func id() -> Function {
     }
   }
 
-  @Test("a body naming its own name over an existing one captures the old one")
-  func selfShadowing() throws {
+  @Test func `a body naming its own name over an existing one captures the old one`() throws {
     // `f() AS f() + 1` REPLACING a prior `f` is well-defined under early
     // binding: the new body captures the OLD `f` (the map before this
     // registration), so it computes `f_old() + 1` and terminates — no
@@ -262,8 +241,7 @@ private func id() -> Function {
                          yields: [[1]], routines: redefined)
   }
 
-  @Test("a body calling a prelude routine registers and runs")
-  func preludeCall() throws {
+  @Test func `a body calling a prelude routine registers and runs`() throws {
     // `lowbit(n INTEGER) AS BITAND(n, 1)` calls the prelude BITAND. The capture
     // seeds `Routines.standard` under `self` — the SAME precedence the public
     // run/columns compose a query's routines with — so the body resolves BITAND
@@ -280,8 +258,7 @@ private func id() -> Function {
                          yields: [[1]], routines: routines)
   }
 
-  @Test("a body calling a still-unknown routine faults at registration")
-  func unknownCall() {
+  @Test func `a body calling a still-unknown routine faults at registration`() {
     // The capture is the prelude overlaid with `self`, NOT every routine: a
     // body naming a routine neither the prelude nor a prior registration binds
     // is still unresolved, faulting `SQLError.function` at registration — the
@@ -293,8 +270,7 @@ private func id() -> Function {
     }
   }
 
-  @Test("a caller function shadows a like-named prelude routine in a body")
-  func preludeShadowed() throws {
+  @Test func `a caller function shadows a like-named prelude routine in a body`() throws {
     // Precedence is standard-under-self: a caller registration of BITAND
     // shadows the prelude one in a later body's capture, so `lowbit(n) AS
     // BITAND(n, 1)` resolves the caller's BITAND (here returning a constant 9),
@@ -313,8 +289,7 @@ private func id() -> Function {
                          yields: [[9]], routines: routines)
   }
 
-  @Test("a defined body binds its callee at definition, not at call time")
-  func capturedCallee() throws {
+  @Test func `a defined body binds its callee at definition, not at call time`() throws {
     // The round-5 root case. `g` returns INTEGER 1; `f() AS g()` captures that
     // INTEGER `g`. Redefining `g` to a TEXT body shadows it for QUERIES, but
     // `f` closed over the old `g`, so `SELECT f()` still returns the INTEGER 1

--- a/Tests/SQLTests/IntrospectionTests.swift
+++ b/Tests/SQLTests/IntrospectionTests.swift
@@ -59,8 +59,7 @@ private func run(_ text: String) throws -> Array<Array<Value>> {
 // MARK: - Tests
 
 struct IntrospectionTests {
-  @Test("information_schema.tables lists base tables and views")
-  func tables() throws {
+  @Test func `information_schema.tables lists base tables and views`() throws {
     let rows = try run("""
         SELECT table_name, table_type FROM information_schema.tables
           ORDER BY table_type, table_name
@@ -77,8 +76,7 @@ struct IntrospectionTests {
     ])
   }
 
-  @Test("information_schema.tables lists an engine-provided view by name")
-  func builtinViewListed() throws {
+  @Test func `information_schema.tables lists an engine-provided view by name`() throws {
     // The built-in views are queryable through `resolve(view:)`, so a consumer
     // discovers them by name — `... WHERE table_name = 'information_schema.
     // columns'` finds the VIEW even though it is engine-provided, not a
@@ -90,8 +88,7 @@ struct IntrospectionTests {
     #expect(rows == [[.text("VIEW")]])
   }
 
-  @Test("information_schema.columns lists an engine-provided view's columns")
-  func builtinViewColumns() throws {
+  @Test func `information_schema.columns lists an engine-provided view's columns`() throws {
     // A built-in view's columns are typed from its body — over the store, all
     // text — exactly as a user view's are.
     let rows = try run("""
@@ -107,8 +104,7 @@ struct IntrospectionTests {
     ])
   }
 
-  @Test("a base relation shadows a same-named built-in information_schema view")
-  func baseShadowsBuiltinView() throws {
+  @Test func `a base relation shadows a same-named built-in information_schema view`() throws {
     // A base relation named for a built-in view shadows it (`resolve(view:)`
     // yields the base), so the built-in is not listed as a VIEW — the base is
     // listed as a BASE TABLE. (The name now resolves to the base, so the store
@@ -123,8 +119,7 @@ struct IntrospectionTests {
     #expect(rows == [[.text("BASE TABLE")]])
   }
 
-  @Test("information_schema.tables carries the standard catalog/schema columns")
-  func tableColumns() throws {
+  @Test func `information_schema.tables carries the standard catalog/schema columns`() throws {
     let rows = try run("""
         SELECT * FROM information_schema.tables WHERE table_name = 'People'
         """)
@@ -132,8 +127,7 @@ struct IntrospectionTests {
     #expect(rows == [[.null, .null, .text("People"), .text("BASE TABLE")]])
   }
 
-  @Test("information_schema.columns names, positions, and types every column")
-  func columns() throws {
+  @Test func `information_schema.columns names, positions, and types every column`() throws {
     let rows = try run("""
         SELECT column_name, ordinal_position, data_type
           FROM information_schema.columns
@@ -146,8 +140,7 @@ struct IntrospectionTests {
     ])
   }
 
-  @Test("information_schema.columns lists a view's columns and kinds")
-  func viewColumns() throws {
+  @Test func `information_schema.columns lists a view's columns and kinds`() throws {
     // `Adults` is `SELECT Name FROM People` over the `.text` `Name` column, so
     // the overlay lists its one column with the resolved text domain — a
     // metadata consumer can discover the columns of a view `.tables` reports.
@@ -159,8 +152,7 @@ struct IntrospectionTests {
     #expect(rows == [[.text("Name"), .text("character varying")]])
   }
 
-  @Test("information_schema.columns types a view defined over the overlay")
-  func viewOverIntrospection() throws {
+  @Test func `information_schema.columns types a view defined over the overlay`() throws {
     // `Meta` reads `information_schema.tables`, whose `table_name` is text, so
     // the builder must seed the view body's OWN introspection overlay for
     // `Meta`'s column to advertise the text domain, not the integer default.
@@ -175,8 +167,7 @@ struct IntrospectionTests {
     #expect(rows == [[.text("character varying")]])
   }
 
-  @Test("information_schema.columns excludes the virtual Id column")
-  func excludesVirtual() throws {
+  @Test func `information_schema.columns excludes the virtual Id column`() throws {
     // `People` exposes a virtual `Id` past its two real columns; the overlay
     // reports only the real ones, so the count is two, not three.
     let rows = try run("""
@@ -186,8 +177,7 @@ struct IntrospectionTests {
     #expect(rows == [[.integer(2)]])
   }
 
-  @Test("information_schema.columns reports YES nullability")
-  func nullability() throws {
+  @Test func `information_schema.columns reports YES nullability`() throws {
     let rows = try run("""
         SELECT is_nullable FROM information_schema.columns
          WHERE table_name = 'Widget'
@@ -195,8 +185,7 @@ struct IntrospectionTests {
     #expect(rows == [[.text("YES")]])
   }
 
-  @Test("a view shadowing a base relation hides the base in the overlay")
-  func shadowed() throws {
+  @Test func `a view shadowing a base relation hides the base in the overlay`() throws {
     // `People` is both a base relation and a view; `resolve` picks the
     // view, so the overlay lists the name once as a VIEW and reports the view's
     // columns — never a base row `SELECT *` can no longer reach.
@@ -217,8 +206,7 @@ struct IntrospectionTests {
     #expect(cols == [[.text("Name")]])
   }
 
-  @Test("a view over information_schema.columns keeps its columns' kinds")
-  func viewOverColumnsKinds() throws {
+  @Test func `a view over information_schema.columns keeps its columns' kinds`() throws {
     // A view reading `information_schema.columns` ITSELF must resolve against a
     // schema-only seed of that relation, so its `column_name` column advertises
     // the text domain rather than falling back to the integer default.
@@ -233,8 +221,7 @@ struct IntrospectionTests {
     #expect(rows == [[.text("character varying")]])
   }
 
-  @Test("information_schema.columns terminates through transitive views")
-  func transitiveViews() throws {
+  @Test func `information_schema.columns terminates through transitive views`() throws {
     // `A` reads `information_schema.columns` and `B` reads `A`; building the
     // columns overlay must not re-enter itself through `B`'s resolution of `A`
     // — it terminates (rather than overflowing), and the schema-only seed rides
@@ -252,8 +239,7 @@ struct IntrospectionTests {
     #expect(rows == [[.text("b"), .text("character varying")]])
   }
 
-  @Test("information_schema.columns hides a view whose WHERE is invalid")
-  func invalidView() throws {
+  @Test func `information_schema.columns hides a view whose WHERE is invalid`() throws {
     // `v`'s projection resolves, but its WHERE names a missing column, so
     // `SELECT * FROM v` throws. The overlay validates the WHOLE body — as the
     // public schema API does — and does not advertise `v` as queryable
@@ -269,8 +255,7 @@ struct IntrospectionTests {
     #expect(rows == [])
   }
 
-  @Test("information_schema.columns hides a view whose UNION arm is invalid")
-  func invalidUnionArm() throws {
+  @Test func `information_schema.columns hides a view whose UNION arm is invalid`() throws {
     // The leading arm resolves, but the second names a missing column, so the
     // whole view cannot run — the overlay must validate EVERY arm, not just the
     // first, and not list `u`.
@@ -287,8 +272,7 @@ struct IntrospectionTests {
     #expect(rows == [])
   }
 
-  @Test("information_schema.columns hides a view whose join ON is invalid")
-  func invalidJoin() throws {
+  @Test func `information_schema.columns hides a view whose join ON is invalid`() throws {
     // The join's ON names a column `People` does not have, so `SELECT * FROM v`
     // fails to compile — the overlay validates each join's ON, not just the
     // projection, and does not list `v`.
@@ -307,8 +291,7 @@ struct IntrospectionTests {
     #expect(rows == [])
   }
 
-  @Test("information_schema.columns hides a view whose GROUP BY is invalid")
-  func invalidGrouping() throws {
+  @Test func `information_schema.columns hides a view whose GROUP BY is invalid`() throws {
     // GROUP BY names a missing column, so `SELECT * FROM v` fails to compile —
     // the overlay validates the grouping, not just the projection.
     let body = try parse("SELECT Name FROM People GROUP BY Missing")
@@ -322,8 +305,7 @@ struct IntrospectionTests {
     #expect(rows == [])
   }
 
-  @Test("information_schema.columns hides a view whose scalar-call arg is bad")
-  func invalidCallArgument() throws {
+  @Test func `information_schema.columns hides a view whose scalar-call arg is bad`() throws {
     // `v`'s projection is a scalar call `BITAND(Missing, 1)` whose ARGUMENT
     // names a column `People` does not have, so `SELECT * FROM v` fails to
     // compile (`Scope.term` resolves `Missing` and throws `SQLError.column`). A
@@ -343,8 +325,7 @@ struct IntrospectionTests {
     #expect(rows == [])
   }
 
-  @Test("information_schema.columns hides a view whose HAVING is invalid")
-  func invalidHaving() throws {
+  @Test func `information_schema.columns hides a view whose HAVING is invalid`() throws {
     // HAVING names a column that is neither a GROUP BY key nor aggregated, so
     // `SELECT * FROM v` fails to compile — the overlay validates the HAVING
     // too.
@@ -361,8 +342,7 @@ struct IntrospectionTests {
     #expect(rows == [])
   }
 
-  @Test("information_schema.columns hides a view over an invalid view")
-  func invalidNestedView() throws {
+  @Test func `information_schema.columns hides a view over an invalid view`() throws {
     // `w`'s WHERE is invalid and `v` reads `w`; `SELECT * FROM v` fails because
     // `w` cannot run, so the overlay validates the nested body and lists
     // neither.
@@ -379,8 +359,7 @@ struct IntrospectionTests {
     #expect(listed == [])
   }
 
-  @Test("information_schema.columns rejects a mismatched nested view")
-  func mismatchedNestedView() throws {
+  @Test func `information_schema.columns rejects a mismatched nested view`() throws {
     // `w` declares one column but its body projects two, so `resolve(w)`
     // faults and `SELECT * FROM v` cannot run; the nested resolution must
     // propagate that mismatch, not mask it with `w`'s declared schema, so `v`
@@ -398,8 +377,7 @@ struct IntrospectionTests {
     #expect(rows == [])
   }
 
-  @Test("information_schema.columns rejects a wrong declared arity over *")
-  func mismatchedStarArity() throws {
+  @Test func `information_schema.columns rejects a wrong declared arity over *`() throws {
     // `v(x)` declares one column but `SELECT *` over two-column `People`
     // projects two, so `resolve` faults `SELECT * FROM v`. The builder
     // compares the compiled body width to the declared count, so `v` is not
@@ -415,8 +393,7 @@ struct IntrospectionTests {
     #expect(rows == [])
   }
 
-  @Test("information_schema.columns hides a cyclic view and stays usable")
-  func cyclicViews() throws {
+  @Test func `information_schema.columns hides a cyclic view and stays usable`() throws {
     // `A` reads `B` and `B` reads `A` — a cycle. `SELECT * FROM A` cannot run:
     // resolution now faults it `.recursion` (see cyclicViewRuns) rather than
     // hanging, so the overlay validates each view via the real `compile`
@@ -441,8 +418,7 @@ struct IntrospectionTests {
     #expect(cyclic == [])
   }
 
-  @Test("a cyclic view faults rather than hanging when run")
-  func cyclicViewRuns() throws {
+  @Test func `a cyclic view faults rather than hanging when run`() throws {
     // `A` over `B` over `A` is a cyclic definition; running it once recursed
     // resolve→compile→resolve until the stack overflowed (an unrecoverable
     // crash, not an `SQLError`). The cycle guard threaded through
@@ -458,8 +434,7 @@ struct IntrospectionTests {
     }
   }
 
-  @Test("a query joins a base relation against information_schema.columns")
-  func joinIntrospection() throws {
+  @Test func `a query joins a base relation against information_schema.columns`() throws {
     // The overlay is an ordinary relation, so it joins and filters like any
     // other — here counting a named table's columns via a WHERE.
     let rows = try run("""
@@ -469,8 +444,7 @@ struct IntrospectionTests {
     #expect(rows == [[.text("character varying")]])
   }
 
-  @Test("an unknown information_schema relation faults as unknown")
-  func unknownReserved() throws {
+  @Test func `an unknown information_schema relation faults as unknown`() throws {
     // A name in the reserved namespace the overlay does not serve is a plain
     // unknown relation.
     #expect(throws: SQLError.self) {
@@ -478,8 +452,7 @@ struct IntrospectionTests {
     }
   }
 
-  @Test("a user CTE shadows the information_schema overlay")
-  func cteShadows() throws {
+  @Test func `a user CTE shadows the information_schema overlay`() throws {
     // The overlay sits after the CTEs: a `WITH` binding the reserved name wins,
     // so the query reads the CTE's rows, not the enumerated metadata.
     let rows = try catalog().run(Statement(parsing: """
@@ -489,8 +462,7 @@ struct IntrospectionTests {
     #expect(rows == [[.integer(1)]])
   }
 
-  @Test("a base relation shadows the built-in information_schema view")
-  func baseShadowsBuiltin() throws {
+  @Test func `a base relation shadows the built-in information_schema view`() throws {
     // A catalog vending its OWN `information_schema.tables` base relation must
     // reach it: a base relation shadows the engine's built-in view (precedence
     // user view > base table > built-in view), so `SELECT *` reads the base
@@ -503,8 +475,7 @@ struct IntrospectionTests {
     #expect(rows == [[.integer(7)]])
   }
 
-  @Test("a CTE may select from the information_schema overlay")
-  func cteReads() throws {
+  @Test func `a CTE may select from the information_schema overlay`() throws {
     let rows = try catalog().run(Statement(parsing: """
         WITH t (n) AS (SELECT table_name FROM information_schema.tables
                         WHERE table_type = 'BASE TABLE')
@@ -513,16 +484,14 @@ struct IntrospectionTests {
     #expect(rows == [[.integer(2)]])
   }
 
-  @Test("columns(of:) resolves an information_schema relation's headers")
-  func schemaHeaders() throws {
+  @Test func `columns(of:) resolves an information_schema relation's headers`() throws {
     let query = try parse("SELECT * FROM information_schema.tables")
     let columns = try catalog().columns(of: query)
     #expect(columns.map(\.name) == ["table_catalog", "table_schema",
                                     "table_name", "table_type"])
   }
 
-  @Test("a fully qualified introspection column resolves like the bare form")
-  func qualifiedColumn() throws {
+  @Test func `a fully qualified introspection column resolves like the bare form`() throws {
     // The relation name itself carries a dot, so a qualified reference has two
     // (`information_schema.tables.table_name`); the last-dot split makes the
     // qualifier the two-part relation name, resolving to the same rows the bare
@@ -540,16 +509,14 @@ struct IntrospectionTests {
     #expect(!qualified.isEmpty)
   }
 
-  @Test("a single-dot qualified column still resolves a base relation")
-  func singleDotQualifier() throws {
+  @Test func `a single-dot qualified column still resolves a base relation`() throws {
     // A table-qualified reference over a base relation keeps its single-dot
     // meaning (qualifier `People`, column `Name`) under last-dot splitting.
     let rows = try run("SELECT People.Name FROM People")
     #expect(rows == [[.text("Ann")]])
   }
 
-  @Test("a view over information_schema.tables yields the inline rows")
-  func viewOverTables() throws {
+  @Test func `a view over information_schema.tables yields the inline rows`() throws {
     // A view whose body selects from a reserved introspection relation must
     // resolve its overlay from ITS OWN query, so selecting from the view yields
     // exactly what the inline query does.
@@ -568,8 +535,7 @@ struct IntrospectionTests {
     #expect(viewed == [[.text("People")], [.text("Widget")]])
   }
 
-  @Test("a view over information_schema.columns yields the inline rows")
-  func viewOverColumns() throws {
+  @Test func `a view over information_schema.columns yields the inline rows`() throws {
     let body = try parse("""
         SELECT column_name, data_type FROM information_schema.columns
           WHERE table_name = 'People'
@@ -590,8 +556,7 @@ struct IntrospectionTests {
     ])
   }
 
-  @Test("information_schema.columns preserves each column's value kind")
-  func materialisedKinds() throws {
+  @Test func `information_schema.columns preserves each column's value kind`() throws {
     // The overlay reports its own columns' kinds — `ordinal_position` is an
     // integer, `table_name`/`data_type` text — not a synthesized all-integer
     // schema.
@@ -606,8 +571,7 @@ struct IntrospectionTests {
     #expect(typed["data_type"] == .text)
   }
 
-  @Test("columns(of:) types a view's columns from its resolved body")
-  func viewKinds() throws {
+  @Test func `columns(of:) types a view's columns from its resolved body`() throws {
     // `Adults` is `SELECT Name FROM People`, over the `.text` `Name` column. A
     // view stores no kinds — its declared schema types every column `.integer`
     // — so resolving the body's kinds is what reports the `.text` here rather
@@ -617,8 +581,7 @@ struct IntrospectionTests {
     #expect(columns == [OutputColumn(name: "Name", type: .text)])
   }
 
-  @Test("a text-returning scalar-call column types character varying")
-  func scalarReturnType() throws {
+  @Test func `a text-returning scalar-call column types character varying`() throws {
     // `v` projects a scalar call `TAG(Name)` whose routine declares a `.text`
     // return type. `information_schema.columns` types the view's column from
     // its body: a `.call` reads the run's routine return-type map, so `iid`
@@ -640,8 +603,7 @@ struct IntrospectionTests {
     #expect(rows == [[.text("iid"), .text("character varying")]])
   }
 
-  @Test("columns(of:) types a scalar call by its routine's return type")
-  func scalarCallColumn() throws {
+  @Test func `columns(of:) types a scalar call by its routine's return type`() throws {
     // The public schema API takes the SAME routines a run would, so a projected
     // `TAG(Name)` reports its declared `.text` return type, not `.integer`.
     let cat = MetaCatalog(["People": MetaRelation([("Name", .text)], [])])
@@ -657,8 +619,7 @@ struct IntrospectionTests {
     #expect(throws: SQLError.self) { let _ = try cat.columns(of: query) }
   }
 
-  @Test("columns(of:) faults on an unknown call in a predicate")
-  func unknownCallPredicateColumns() throws {
+  @Test func `columns(of:) faults on an unknown call in a predicate`() throws {
     // The unknown `NOPE` is in the WHERE, invisible to the first-arm projection
     // walk; the whole-query inventory faults it, exactly as a run would.
     let cat = MetaCatalog(["People": MetaRelation([("Name", .text)], [])])
@@ -666,8 +627,7 @@ struct IntrospectionTests {
     #expect(throws: SQLError.self) { let _ = try cat.columns(of: query) }
   }
 
-  @Test("columns(of:) faults on an unknown call in a later UNION arm")
-  func unknownCallLaterArmColumns() throws {
+  @Test func `columns(of:) faults on an unknown call in a later UNION arm`() throws {
     // The first arm types cleanly; the unknown `NOPE` is in the second arm the
     // first-arm walk never visits.
     let cat = MetaCatalog([
@@ -680,8 +640,7 @@ struct IntrospectionTests {
     #expect(throws: SQLError.self) { let _ = try cat.columns(of: query) }
   }
 
-  @Test("a routine return type crosses a view boundary in schema resolution")
-  func scalarCallThroughView() throws {
+  @Test func `a routine return type crosses a view boundary in schema resolution`() throws {
     // `w` projects `TAG(Name)`; `SELECT * FROM w` must report `t` as the
     // routine's declared `.text`, so schema resolution threads the return map
     // across the view boundary rather than dropping it to `.integer`.
@@ -698,8 +657,7 @@ struct IntrospectionTests {
     #expect(typed == [OutputColumn(name: "t", type: .text)])
   }
 
-  @Test("columns(of:) faults on an unknown call in a view body predicate")
-  func unknownCallViewBodyColumns() throws {
+  @Test func `columns(of:) faults on an unknown call in a view body predicate`() throws {
     // `SELECT * FROM v` names no call, but v's body calls the unregistered
     // `NOPE` in its WHERE — a clause the view-boundary first-arm walk misses.
     // The body's call inventory must fault, as `SELECT * FROM v` would at run.
@@ -712,8 +670,7 @@ struct IntrospectionTests {
     }
   }
 
-  @Test("columns(of:) faults on arithmetic over a non-numeric operand")
-  func nonnumericArithmetic() throws {
+  @Test func `columns(of:) faults on arithmetic over a non-numeric operand`() throws {
     // `Name + 1` has no arithmetic — `Arithmetic.apply` faults on the first
     // non-NULL text row, so the schema faults rather than typing `.integer`.
     let cat = MetaCatalog(["People": MetaRelation([("Name", .text)], [])])
@@ -722,8 +679,7 @@ struct IntrospectionTests {
     }
   }
 
-  @Test("columns(of:) faults on SUM or AVG over a non-numeric operand")
-  func nonnumericAggregate() throws {
+  @Test func `columns(of:) faults on SUM or AVG over a non-numeric operand`() throws {
     // `SUM`/`AVG` fold numerically — `Aggregate.fold` faults on non-numeric —
     // so `SUM(Name)`/`AVG(Name)` fault rather than typing text/double.
     let cat = MetaCatalog(["People": MetaRelation([("Name", .text)], [])])
@@ -735,8 +691,7 @@ struct IntrospectionTests {
     }
   }
 
-  @Test("columns(of:) types numeric aggregates and arithmetic")
-  func numericAggregateTyping() throws {
+  @Test func `columns(of:) types numeric aggregates and arithmetic`() throws {
     let cat = MetaCatalog(["T": MetaRelation(
         [("Name", .text), ("Age", .integer), ("Score", .double)], [])])
     #expect(try cat.columns(of: parse("SELECT SUM(Age) AS x FROM T"))
@@ -755,8 +710,7 @@ struct IntrospectionTests {
                 == [OutputColumn(name: "x", type: .text)])
   }
 
-  @Test("columns(of:) faults on a bad operand in a later UNION arm")
-  func nonnumericLaterArm() throws {
+  @Test func `columns(of:) faults on a bad operand in a later UNION arm`() throws {
     // The first arm types fine; the later arm's `Name + 1` faults, as a run of
     // the union would — the first-arm schema walk never visits it.
     let cat = MetaCatalog(["People":
@@ -768,8 +722,7 @@ struct IntrospectionTests {
     }
   }
 
-  @Test("columns(of:) faults on a bad aggregate operand in a HAVING")
-  func nonnumericHaving() throws {
+  @Test func `columns(of:) faults on a bad aggregate operand in a HAVING`() throws {
     // `SUM(Name)` in the HAVING is not projected, so the projection walk misses
     // it; the whole-query type-check faults it, as a run would.
     let cat = MetaCatalog(["People": MetaRelation([("Name", .text)], [])])
@@ -780,8 +733,7 @@ struct IntrospectionTests {
     }
   }
 
-  @Test("columns(of:) faults on a bad operand in a WHERE")
-  func nonnumericWhere() throws {
+  @Test func `columns(of:) faults on a bad operand in a WHERE`() throws {
     let cat = MetaCatalog(["People":
         MetaRelation([("Name", .text), ("Age", .integer)], [])])
     #expect(throws: SQLError.self) {
@@ -791,8 +743,7 @@ struct IntrospectionTests {
     }
   }
 
-  @Test("columns(of:) types a valid later arm and HAVING")
-  func validLaterArmAndHaving() throws {
+  @Test func `columns(of:) types a valid later arm and HAVING`() throws {
     let cat = MetaCatalog(["People":
         MetaRelation([("Name", .text), ("Age", .integer)], [])])
     #expect(try cat.columns(of: parse("""
@@ -803,8 +754,7 @@ struct IntrospectionTests {
         """)) == [OutputColumn(name: "Name", type: .text)])
   }
 
-  @Test("information_schema.columns hides a view with a bad HAVING operand")
-  func nonnumericHavingView() throws {
+  @Test func `information_schema.columns hides a view with a bad HAVING operand`() throws {
     // The view's HAVING folds `SUM(Name)` over text — a run faults — so the
     // view is not advertised, though its projection types cleanly.
     let body = try parse("""
@@ -820,8 +770,7 @@ struct IntrospectionTests {
     #expect(rows == [])
   }
 
-  @Test("columns(of:) skips an arm a constant-false AND short-circuits")
-  func shortCircuitAnd() throws {
+  @Test func `columns(of:) skips an arm a constant-false AND short-circuits`() throws {
     // `1 = 0` is constantly false, so the executor never evaluates `Name + 1`;
     // the schema resolves rather than faulting on the unreachable arm.
     let cat = MetaCatalog(["People": MetaRelation([("Name", .text)], [])])
@@ -830,16 +779,14 @@ struct IntrospectionTests {
         """)) == [OutputColumn(name: "Name", type: .text)])
   }
 
-  @Test("columns(of:) skips an arm a constant-true OR short-circuits")
-  func shortCircuitOr() throws {
+  @Test func `columns(of:) skips an arm a constant-true OR short-circuits`() throws {
     let cat = MetaCatalog(["People": MetaRelation([("Name", .text)], [])])
     #expect(try cat.columns(of: parse("""
         SELECT Name FROM People WHERE 1 = 1 OR Name + 1 = 2
         """)) == [OutputColumn(name: "Name", type: .text)])
   }
 
-  @Test("columns(of:) still faults on a reachable bad arm")
-  func reachableBadArm() throws {
+  @Test func `columns(of:) still faults on a reachable bad arm`() throws {
     // A constant-TRUE AND does not short-circuit its right arm, and a
     // non-constant guard leaves the arm reachable — both still fault.
     let cat = MetaCatalog(["People":
@@ -856,8 +803,7 @@ struct IntrospectionTests {
     }
   }
 
-  @Test("information_schema.columns lists a view with a short-circuited arm")
-  func shortCircuitView() throws {
+  @Test func `information_schema.columns lists a view with a short-circuited arm`() throws {
     let body = try parse("""
         SELECT Name FROM People WHERE 1 = 0 AND Name + 1 = 2
         """)
@@ -871,8 +817,7 @@ struct IntrospectionTests {
     #expect(rows == [[.text("Name")]])
   }
 
-  @Test("columns(of:) skips an unknown call a false AND short-circuits")
-  func shortCircuitUnknownCall() throws {
+  @Test func `columns(of:) skips an unknown call a false AND short-circuits`() throws {
     // `NOPE` is only in the unreachable arm of `1 = 0 AND …`, so the executor
     // never evaluates it and the query runs — the schema resolves, and call
     // validation rides the same short-circuit-aware walk as operand checking.
@@ -885,8 +830,7 @@ struct IntrospectionTests {
         """)) == [OutputColumn(name: "Name", type: .text)])
   }
 
-  @Test("columns(of:) still faults on a reachable unknown call")
-  func reachableUnknownCall() throws {
+  @Test func `columns(of:) still faults on a reachable unknown call`() throws {
     let cat = MetaCatalog(["People": MetaRelation([("Name", .text)], [])])
     #expect(throws: SQLError.self) {
       let _ = try cat.columns(of: parse("""
@@ -895,8 +839,7 @@ struct IntrospectionTests {
     }
   }
 
-  @Test("information_schema.columns lists a view with an unreachable call")
-  func shortCircuitUnknownCallView() throws {
+  @Test func `information_schema.columns lists a view with an unreachable call`() throws {
     let body = try parse("""
         SELECT Name FROM People WHERE 1 = 0 AND NOPE(Name) = 1
         """)
@@ -910,8 +853,7 @@ struct IntrospectionTests {
     #expect(rows == [[.text("Name")]])
   }
 
-  @Test("columns(of:) derives a schema for a zero-row-limit projection")
-  func zeroRowLimitProjection() throws {
+  @Test func `columns(of:) derives a schema for a zero-row-limit projection`() throws {
     // `FETCH FIRST 0 ROWS ONLY` yields no rows and the limit applies before the
     // projection, so `Name + 1` is never evaluated; the schema DERIVES its
     // nominal type without faulting on the non-numeric operand.
@@ -921,8 +863,7 @@ struct IntrospectionTests {
         """)) == [OutputColumn(name: "x", type: .integer)])
   }
 
-  @Test("columns(of:) still faults on a projection under a non-zero limit")
-  func nonzeroLimitProjection() throws {
+  @Test func `columns(of:) still faults on a projection under a non-zero limit`() throws {
     // A non-zero limit projects rows, so the operand is reachable and faults.
     let cat = MetaCatalog(["People": MetaRelation([("Name", .text)], [])])
     #expect(throws: SQLError.self) {
@@ -932,8 +873,7 @@ struct IntrospectionTests {
     }
   }
 
-  @Test("information_schema.columns lists a zero-row-limit view")
-  func zeroRowLimitView() throws {
+  @Test func `information_schema.columns lists a zero-row-limit view`() throws {
     let body = try parse("""
         SELECT Name + 1 AS x FROM People FETCH FIRST 0 ROWS ONLY
         """)
@@ -947,8 +887,7 @@ struct IntrospectionTests {
     #expect(rows == [[.text("x"), .text("integer")]])
   }
 
-  @Test("columns(of:) validates an aggregate fold under a zero-row limit")
-  func aggregateUnderZeroLimit() throws {
+  @Test func `columns(of:) validates an aggregate fold under a zero-row limit`() throws {
     // A `FETCH FIRST 0 ROWS ONLY` skips a non-aggregate projection, but an
     // aggregate folds every row before the limit, so `SUM(Name)` over text
     // still faults; a numeric fold types cleanly.
@@ -964,8 +903,7 @@ struct IntrospectionTests {
         """)) == [OutputColumn(name: "x", type: .integer)])
   }
 
-  @Test("columns(of:) folds a literal IS NULL test in a short-circuit")
-  func shortCircuitNullTest() throws {
+  @Test func `columns(of:) folds a literal IS NULL test in a short-circuit`() throws {
     // `1 IS NULL` is constantly false and `1 IS NOT NULL` constantly true, so
     // the executor skips the guarded arm; the schema resolves rather than
     // faulting on the unreachable operand or call.
@@ -978,8 +916,7 @@ struct IntrospectionTests {
         """)) == [OutputColumn(name: "Name", type: .text)])
   }
 
-  @Test("columns(of:) skips the work after a constant-false WHERE")
-  func constantFalseWhere() throws {
+  @Test func `columns(of:) skips the work after a constant-false WHERE`() throws {
     // `WHERE 1 = 0` filters every row before projecting, so `Name + 1` is
     // unreachable and the schema resolves.
     let cat = MetaCatalog(["People": MetaRelation([("Name", .text)], [])])
@@ -1000,8 +937,7 @@ struct IntrospectionTests {
     }
   }
 
-  @Test("columns(of:) refines empty-group reachability")
-  func emptyGroupReachability() throws {
+  @Test func `columns(of:) refines empty-group reachability`() throws {
     let cat = MetaCatalog(["People": MetaRelation([("Age", .integer)], [])])
     // A false HAVING drops the empty group before the projection, so its call
     // is unreachable — the query returns an empty result and types cleanly.
@@ -1050,8 +986,7 @@ struct IntrospectionTests {
     }
   }
 
-  @Test("columns(of:) skips an unbound HAVING parameter over the empty group")
-  func emptyGroupUnboundParameter() throws {
+  @Test func `columns(of:) skips an unbound HAVING parameter over the empty group`() throws {
     let cat = MetaCatalog(["People": MetaRelation([("Age", .integer)], [])])
     // With no binding, `... = :p` yields UNKNOWN without evaluating the left,
     // so the divide never runs — the query returns no rows and types cleanly.
@@ -1060,8 +995,7 @@ struct IntrospectionTests {
         """)).count == 1)
   }
 
-  @Test("columns(of:) rejects a non-finite routine result over the empty group")
-  func emptyGroupNonfiniteRoutine() throws {
+  @Test func `columns(of:) rejects a non-finite routine result over the empty group`() throws {
     let cat = MetaCatalog(["People": MetaRelation([("Age", .integer)], [])])
     let routines: Routines =
         ["BAD": Routine(returns: .double, parameters: []) { _ in
@@ -1076,8 +1010,7 @@ struct IntrospectionTests {
     }
   }
 
-  @Test("columns(of:) validates a COUNT expression operand")
-  func countOperand() throws {
+  @Test func `columns(of:) validates a COUNT expression operand`() throws {
     let cat = MetaCatalog(["People":
         MetaRelation([("Name", .text), ("Age", .integer)], [])])
     // COUNT evaluates its operand per row to test non-NULL, so a bad operand
@@ -1092,8 +1025,7 @@ struct IntrospectionTests {
                 == [OutputColumn(name: "c", type: .integer)])
   }
 
-  @Test("columns(of:) skips the projection after a constant-false HAVING")
-  func constantFalseHaving() throws {
+  @Test func `columns(of:) skips the projection after a constant-false HAVING`() throws {
     // `HAVING 1 = 0` filters every group before the projection, so `Name + 1`
     // is unreachable and the schema resolves — but an aggregate fold, which the
     // group node runs before HAVING, is still validated.
@@ -1108,8 +1040,7 @@ struct IntrospectionTests {
     }
   }
 
-  @Test("columns(of:) validates a HAVING aggregate despite a short-circuit")
-  func havingAggregateShortCircuit() throws {
+  @Test func `columns(of:) validates a HAVING aggregate despite a short-circuit`() throws {
     // `HAVING 1 = 0 AND SUM(Name) > 0` short-circuits the comparison, but the
     // group node folds `SUM(Name)` before the HAVING filter, so it faults;
     // a numeric fold in the skipped arm is fine.
@@ -1125,8 +1056,7 @@ struct IntrospectionTests {
         """)) == [OutputColumn(name: "Name", type: .text)])
   }
 
-  @Test("columns(of:) rejects a statically-known division by zero")
-  func divideByZeroLiteral() throws {
+  @Test func `columns(of:) rejects a statically-known division by zero`() throws {
     let cat = MetaCatalog(["People": MetaRelation([("Age", .integer)], [])])
     #expect(throws: SQLError.divide) {
       let _ = try cat.columns(of: parse("SELECT 1 / 0 AS x FROM People"))
@@ -1136,8 +1066,7 @@ struct IntrospectionTests {
                 == [OutputColumn(name: "x", type: .integer)])
   }
 
-  @Test("columns(of:) rejects statically-overflowing literal arithmetic")
-  func overflowLiteral() throws {
+  @Test func `columns(of:) rejects statically-overflowing literal arithmetic`() throws {
     let cat = MetaCatalog(["People": MetaRelation([("Age", .integer)], [])])
     // Both operands literal, so the result overflows on every row (a FROM-less
     // SELECT at once); the schema rejects it rather than advertise a column.
@@ -1154,8 +1083,7 @@ struct IntrospectionTests {
                 == [OutputColumn(name: "x", type: .integer)])
   }
 
-  @Test("columns(of:) accepts a parameterized predicate with no binding")
-  func unboundParameter() throws {
+  @Test func `columns(of:) accepts a parameterized predicate with no binding`() throws {
     // With no binding (the schema default), `Name + 1 = :p` yields UNKNOWN
     // without evaluating the left term, so the query runs (no rows) and the
     // schema resolves rather than faulting on the text arithmetic.
@@ -1165,8 +1093,7 @@ struct IntrospectionTests {
         """)) == [OutputColumn(name: "Name", type: .text)])
   }
 
-  @Test("columns(of:) faults on a bad operand inside a call's arguments")
-  func nonnumericCallArgument() throws {
+  @Test func `columns(of:) faults on a bad operand inside a call's arguments`() throws {
     // `BITAND(Name + 1, 1)` returns integer, but its argument `Name + 1`
     // faults; typing recurses into the arguments, as a run would.
     let cat = MetaCatalog(["People": MetaRelation([("Name", .text)], [])])
@@ -1177,16 +1104,14 @@ struct IntrospectionTests {
     }
   }
 
-  @Test("columns(of:) types a call over valid arguments")
-  func callArgumentTyping() throws {
+  @Test func `columns(of:) types a call over valid arguments`() throws {
     let cat = MetaCatalog(["People": MetaRelation([("Age", .integer)], [])])
     #expect(try cat.columns(of: parse("""
         SELECT BITAND(Age, 1) AS b FROM People
         """)) == [OutputColumn(name: "b", type: .integer)])
   }
 
-  @Test("columns(of:) faults on a call over a wrong-kind argument")
-  func callArgumentKind() throws {
+  @Test func `columns(of:) faults on a call over a wrong-kind argument`() throws {
     // `BITAND` declares an `[.integer, .integer]` contract, so
     // `BITAND(Name, 1)` over the text `Name` faults as a run would (`BITAND`
     // throws `SQLError.argument` on a non-integer non-NULL value); the schema
@@ -1199,8 +1124,7 @@ struct IntrospectionTests {
     }
   }
 
-  @Test("columns(of:) faults on a call over the wrong arity")
-  func callArgumentArity() throws {
+  @Test func `columns(of:) faults on a call over the wrong arity`() throws {
     // `BITAND` takes two arguments, so `BITAND(Age)` faults `SQLError.argument`
     // at run; the static type-check enforces the declared arity, so the schema
     // rejects it rather than typing an integer column.
@@ -1212,8 +1136,7 @@ struct IntrospectionTests {
     }
   }
 
-  @Test("a recursive CTE over the store types a view's standard call")
-  func recursiveStoreRoutineReturns() throws {
+  @Test func `a recursive CTE over the store types a view's standard call`() throws {
     // A view column that is a standard scalar call must appear in
     // definition_schema.columns even when a recursive CTE names the store
     // directly — the cached CTE store entry is seeded with the routine returns,
@@ -1233,8 +1156,7 @@ struct IntrospectionTests {
     #expect(rows == [[.text("b")]])
   }
 
-  @Test("a base relation shadowed by the definition_schema store is hidden")
-  func storeShadowsBase() throws {
+  @Test func `a base relation shadowed by the definition_schema store is hidden`() throws {
     // The store overlay resolves `definition_schema.tables`, so a catalog base
     // relation of that name is unreachable; it must not be advertised as a BASE
     // TABLE, or metadata would disagree with resolution for the reserved name.
@@ -1253,8 +1175,7 @@ struct IntrospectionTests {
     ])
   }
 
-  @Test("information_schema.columns hides a view with an unknown scalar call")
-  func unknownCallView() throws {
+  @Test func `information_schema.columns hides a view with an unknown scalar call`() throws {
     // `v` projects `NOPE(Name)`; `NOPE` is not registered, so `SELECT * FROM v`
     // faults at run. `compile` lowers the call without checking the routine, so
     // the unknown function surfaces at typing — the view is not listed.
@@ -1269,8 +1190,7 @@ struct IntrospectionTests {
     #expect(rows == [])
   }
 
-  @Test("information_schema.columns hides a view whose predicate calls unknown")
-  func unknownCallPredicate() throws {
+  @Test func `information_schema.columns hides a view whose predicate calls unknown`() throws {
     // The unknown `NOPE` is in the WHERE, not the projection, so the first-arm
     // type walk never sees it — only the whole-body call inventory does, and a
     // run of `SELECT * FROM v` would fault `SQLError.function`.
@@ -1285,8 +1205,7 @@ struct IntrospectionTests {
     #expect(rows == [])
   }
 
-  @Test("information_schema.columns hides a view whose later arm calls unknown")
-  func unknownCallLaterArm() throws {
+  @Test func `information_schema.columns hides a view whose later arm calls unknown`() throws {
     // The first arm types cleanly; the unknown `NOPE` is in the second UNION
     // arm, which the first-arm walk never types — the inventory spans arms.
     let body = try parse("""
@@ -1302,8 +1221,7 @@ struct IntrospectionTests {
     #expect(rows == [])
   }
 
-  @Test("information_schema.columns lists a view whose predicate calls known")
-  func knownCallPredicate() throws {
+  @Test func `information_schema.columns lists a view whose predicate calls known`() throws {
     // The gate rejects only an UNKNOWN routine — a registered one in the WHERE
     // (`BITAND`, the standard prelude) leaves the view advertised.
     let body = try parse("SELECT Name FROM People WHERE BITAND(1, 1) = 1")
@@ -1319,8 +1237,7 @@ struct IntrospectionTests {
 
   // MARK: - DEFINITION_SCHEMA store
 
-  @Test("definition_schema.tables is itself queryable as the store")
-  func definitionTables() throws {
+  @Test func `definition_schema.tables is itself queryable as the store`() throws {
     // The store the portable `information_schema.tables` view reads is
     // queryable in its own right — it holds the shape the view merely renames.
     let rows = try run("""
@@ -1336,8 +1253,7 @@ struct IntrospectionTests {
     ])
   }
 
-  @Test("definition_schema.columns is itself queryable as the store")
-  func definitionColumns() throws {
+  @Test func `definition_schema.columns is itself queryable as the store`() throws {
     let rows = try run("""
         SELECT column_name, ordinal_position, data_type
           FROM definition_schema.columns
@@ -1350,8 +1266,7 @@ struct IntrospectionTests {
     ])
   }
 
-  @Test("information_schema.tables yields exactly its definition_schema store")
-  func informationOverDefinition() throws {
+  @Test func `information_schema.tables yields exactly its definition_schema store`() throws {
     // The portable view is a projection over the store, so the two return the
     // same rows — the layering is visible, not conflated.
     let over =
@@ -1362,8 +1277,7 @@ struct IntrospectionTests {
     #expect(!over.isEmpty)
   }
 
-  @Test("an unknown definition_schema relation faults as unknown")
-  func unknownStore() throws {
+  @Test func `an unknown definition_schema relation faults as unknown`() throws {
     // A name in the reserved store namespace the store does not serve is a
     // plain unknown relation, as an unserved information_schema name is.
     #expect(throws: SQLError.self) {
@@ -1371,8 +1285,7 @@ struct IntrospectionTests {
     }
   }
 
-  @Test("a user CTE shadows the definition_schema store")
-  func storeCTEShadows() throws {
+  @Test func `a user CTE shadows the definition_schema store`() throws {
     let rows = try catalog().run(Statement(parsing: """
         WITH "definition_schema.tables" (x) AS (SELECT 1)
           SELECT x FROM "definition_schema.tables"
@@ -1380,8 +1293,7 @@ struct IntrospectionTests {
     #expect(rows == [[.integer(1)]])
   }
 
-  @Test("a view over definition_schema.tables yields the inline rows")
-  func viewOverStoreTables() throws {
+  @Test func `a view over definition_schema.tables yields the inline rows`() throws {
     // A view whose body names the STORE relation directly — not an
     // `information_schema.` view over it — resolves and runs the same as the
     // inline query: the store overlay reaches the view body's compile and
@@ -1402,8 +1314,7 @@ struct IntrospectionTests {
     #expect(viewed == [[.text("People")], [.text("Widget")]])
   }
 
-  @Test("a view over definition_schema.columns yields the inline rows")
-  func viewOverStoreColumns() throws {
+  @Test func `a view over definition_schema.columns yields the inline rows`() throws {
     let body = try parse("""
         SELECT column_name, data_type FROM definition_schema.columns
           WHERE table_name = 'People'

--- a/Tests/SQLTests/LexerTests.swift
+++ b/Tests/SQLTests/LexerTests.swift
@@ -20,83 +20,69 @@ private func lex(_ text: String) throws -> Array<Token.Kind> {
 }
 
 struct LexerTests {
-  @Test("lexes every keyword")
-  func keywords() throws {
+  @Test func `lexes every keyword`() throws {
     #expect(try lex("SELECT FROM WHERE ORDER BY ASC DESC AND OR NOT")
                 == [.select, .from, .where, .order, .by, .asc, .desc,
                     .and, .or, .not])
   }
 
-  @Test("lexes keywords case-insensitively")
-  func keywordsCaseInsensitive() throws {
+  @Test func `lexes keywords case-insensitively`() throws {
     #expect(try lex("select Order by") == [.select, .order, .by])
   }
 
-  @Test("lexes the join keywords")
-  func joinKeywords() throws {
+  @Test func `lexes the join keywords`() throws {
     #expect(try lex("JOIN ON AS") == [.join, .on, .as])
   }
 
-  @Test("lexes the join keywords case-insensitively")
-  func joinKeywordsCaseInsensitive() throws {
+  @Test func `lexes the join keywords case-insensitively`() throws {
     #expect(try lex("join on As") == [.join, .on, .as])
   }
 
-  @Test("lexes the NULL-test keywords")
-  func nullKeywords() throws {
+  @Test func `lexes the NULL-test keywords`() throws {
     #expect(try lex("IS NOT NULL") == [.is, .not, .null])
     #expect(try lex("is null") == [.is, .null])
   }
 
-  @Test("lexes the WITH-clause keywords")
-  func withKeywords() throws {
+  @Test func `lexes the WITH-clause keywords`() throws {
     #expect(try lex("WITH RECURSIVE") == [.with, .recursive])
   }
 
-  @Test("lexes the WITH-clause keywords case-insensitively")
-  func withKeywordsCaseInsensitive() throws {
+  @Test func `lexes the WITH-clause keywords case-insensitively`() throws {
     #expect(try lex("with Recursive") == [.with, .recursive])
   }
 
-  @Test("lexes the row-limiting keywords")
-  func rowLimitKeywords() throws {
+  @Test func `lexes the row-limiting keywords`() throws {
     #expect(try lex("OFFSET FETCH FIRST ROWS ONLY")
                 == [.offset, .fetch, .first, .rows, .only])
     // ROW is a synonym of ROWS, and NEXT of FIRST.
     #expect(try lex("ROW NEXT") == [.rows, .first])
   }
 
-  @Test("lexes the comparison operators")
-  func operators() throws {
+  @Test func `lexes the comparison operators`() throws {
     #expect(try lex("= <> < > <= >=")
                 == [.equal, .unequal, .lt, .gt, .leq, .geq])
   }
 
-  @Test("lexes punctuation tokens")
-  func punctuation() throws {
+  @Test func `lexes punctuation tokens`() throws {
     #expect(try lex("* , ( )")
                 == [.star, .comma, .lparen, .rparen])
   }
 
-  @Test("lexes a dotted identifier as one token")
-  func identifierWithDot() throws {
+  @Test func `lexes a dotted identifier as one token`() throws {
     #expect(try lex("TypeDef.TypeName") == [.identifier("TypeDef.TypeName")])
   }
 
-  @Test("lexes integer literals")
-  func integerLiteral() throws {
+  @Test func `lexes integer literals`() throws {
     #expect(try lex("0 42 1024")
                 == [.integer(0), .integer(42), .integer(1024)])
   }
 
-  @Test("lexes decimal literals with a fraction")
-  func decimalFraction() throws {
+  @Test func `lexes decimal literals with a fraction`() throws {
     #expect(try lex("3.14 1.0 0.5")
                 == [.decimal(3.14), .decimal(1.0), .decimal(0.5)])
   }
 
-  @Test("lexes decimal literals with an exponent")
-  func decimalExponent() throws {
+  @Test func `lexes decimal literals with an exponent`() throws {
     // A bare integer with an exponent is approximate-numeric, as is one with a
     // signed exponent or a fraction and an exponent together.
     #expect(try lex("1e3 2.5e-1 6E2 1.5e+2")
@@ -104,59 +90,50 @@ struct LexerTests {
                     .decimal(6e2), .decimal(1.5e2)])
   }
 
-  @Test("a bare run of digits stays an integer")
-  func integerNotDecimal() throws {
+  @Test func `a bare run of digits stays an integer`() throws {
     // Neither a `.` nor an `e` follows, so each is exact numeric.
     #expect(try lex("7 100") == [.integer(7), .integer(100)])
   }
 
-  @Test("a dot fraction is taken only when a digit follows")
-  func fractionRequiresDigit() throws {
+  @Test func `a dot fraction is taken only when a digit follows`() throws {
     // A `.` begins a fraction only before a digit: `1.5` is one decimal, while
     // `1.5e0` also folds the exponent in.
     #expect(try lex("1.5") == [.decimal(1.5)])
     #expect(try lex("1.5e0") == [.decimal(1.5)])
   }
 
-  @Test("an e with no exponent digit is not an exponent")
-  func bareExponentLetter() throws {
+  @Test func `an e with no exponent digit is not an exponent`() throws {
     // `1e` has no exponent digit, so the number ends at `1` and `e` begins an
     // identifier.
     #expect(try lex("1e") == [.integer(1), .identifier("e")])
   }
 
-  @Test("a decimal literal past Double's range is an overflow")
-  func decimalOverflow() {
+  @Test func `a decimal literal past Double's range is an overflow`() {
     // `Double("1e9999")` is `inf`, not nil — reject it as an overflow, like an
     // out-of-range integer, so no `inf` enters the token stream.
     #expect(throws: SQLError.self) { _ = try lex("1e9999") }
   }
 
-  @Test("a qualified reference is not read as a decimal")
-  func qualifiedReference() throws {
+  @Test func `a qualified reference is not read as a decimal`() throws {
     // A qualified name begins with a letter, so it never enters the numeric
     // scanner — `Field.Flags` is one identifier, dot and all.
     #expect(try lex("Field.Flags") == [.identifier("Field.Flags")])
   }
 
-  @Test("lexes a quoted string literal")
-  func stringLiteral() throws {
+  @Test func `lexes a quoted string literal`() throws {
     #expect(try lex("'Windows.Win32.Foundation'")
                 == [.string("Windows.Win32.Foundation")])
   }
 
-  @Test("unescapes a doubled quote in a string")
-  func escapedQuoteInString() throws {
+  @Test func `unescapes a doubled quote in a string`() throws {
     #expect(try lex("'O''Brien'") == [.string("O'Brien")])
   }
 
-  @Test("lexes an empty string literal")
-  func emptyString() throws {
+  @Test func `lexes an empty string literal`() throws {
     #expect(try lex("''") == [.string("")])
   }
 
-  @Test("lexes a delimited identifier verbatim")
-  func delimitedIdentifier() throws {
+  @Test func `lexes a delimited identifier verbatim`() throws {
     // A double-quoted name is a `quoted` token, case-preserved and never a
     // keyword — distinct from a bare identifier so a dot in it is kept.
     #expect(try lex("\"Offset\"") == [.quoted("Offset")])
@@ -164,25 +141,21 @@ struct LexerTests {
     #expect(try lex("\"a.b\"") == [.quoted("a.b")])
   }
 
-  @Test("unescapes a doubled quote in a delimited identifier")
-  func escapedQuoteInIdentifier() throws {
+  @Test func `unescapes a doubled quote in a delimited identifier`() throws {
     #expect(try lex("\"a\"\"b\"") == [.quoted("a\"b")])
   }
 
-  @Test("lexes tokens with no separating whitespace")
-  func adjacentOperators() throws {
+  @Test func `lexes tokens with no separating whitespace`() throws {
     // No whitespace required between an identifier and an operator.
     #expect(try lex("a<=1")
                 == [.identifier("a"), .leq, .integer(1)])
   }
 
-  @Test("records each token's byte offset")
-  func position() throws {
+  @Test func `records each token's byte offset`() throws {
     #expect(try tokens("SELECT *").map(\.location.offset) == [0, 7])
   }
 
-  @Test("tracks line and column across a newline")
-  func location() throws {
+  @Test func `tracks line and column across a newline`() throws {
     // The lexer tracks 1-based line and column, resetting the column on each
     // newline.
     let locations = try tokens("SELECT *\nFROM T").map(\.location)
@@ -190,8 +163,7 @@ struct LexerTests {
     #expect(locations.map(\.column) == [1, 8, 1, 6])
   }
 
-  @Test("yields one token per next() and nil at end")
-  func streaming() throws {
+  @Test func `yields one token per next() and nil at end`() throws {
     // The lexer yields one token per `next()` call and signals end of input
     // with a trailing `nil`, without ever materialising a token array.
     let text = "SELECT *"
@@ -208,45 +180,37 @@ struct LexerTests {
     #expect(try lexer.next() == nil)
   }
 
-  @Test("rejects an unexpected character")
-  func unexpectedCharacter() {
+  @Test func `rejects an unexpected character`() {
     #expect(throws: SQLError.self) { _ = try lex("SELECT @ FROM T") }
   }
 
-  @Test("rejects an unterminated string")
-  func unterminatedString() {
+  @Test func `rejects an unterminated string`() {
     #expect(throws: SQLError.self) { _ = try lex("'oops") }
   }
 
-  @Test("rejects an unterminated delimited identifier")
-  func unterminatedIdentifier() {
+  @Test func `rejects an unterminated delimited identifier`() {
     #expect(throws: SQLError.self) { _ = try lex("\"oops") }
   }
 
-  @Test("skips a line comment between tokens")
-  func lineComment() throws {
+  @Test func `skips a line comment between tokens`() throws {
     #expect(try lex("SELECT -- pick a star\n*")
                 == [.select, .star])
   }
 
-  @Test("skips a line comment at end of input")
-  func lineCommentAtEnd() throws {
+  @Test func `skips a line comment at end of input`() throws {
     // An unterminated `--` comment at EOF is not a fault.
     #expect(try lex("SELECT * -- trailing") == [.select, .star])
   }
 
-  @Test("skips a block comment spanning a newline")
-  func blockComment() throws {
+  @Test func `skips a block comment spanning a newline`() throws {
     #expect(try lex("SELECT /* a\n block */ *") == [.select, .star])
   }
 
-  @Test("skips a block comment between tokens on one line")
-  func blockCommentInline() throws {
+  @Test func `skips a block comment between tokens on one line`() throws {
     #expect(try lex("SELECT /* star */ *") == [.select, .star])
   }
 
-  @Test("lexes a lone minus and slash as operators")
-  func loneOperators() throws {
+  @Test func `lexes a lone minus and slash as operators`() throws {
     // A single `-` or `/` is still an operator; only `--` and `/*` begin a
     // comment.
     #expect(try lex("a - 1 / 2")
@@ -254,27 +218,23 @@ struct LexerTests {
                     .integer(2)])
   }
 
-  @Test("rejects an unterminated block comment")
-  func unterminatedBlockComment() {
+  @Test func `rejects an unterminated block comment`() {
     #expect(throws: SQLError.self) { _ = try lex("SELECT /* oops") }
   }
 
-  @Test("tracks line and column across a block comment")
-  func commentLocation() throws {
+  @Test func `tracks line and column across a block comment`() throws {
     // Newlines inside a block comment still advance the line counter.
     let locations = try tokens("SELECT /* a\nb */ *").map(\.location)
     #expect(locations.map(\.line) == [1, 2])
     #expect(locations.map(\.column) == [1, 6])
   }
 
-  @Test("scans a bound-parameter placeholder")
-  func parameter() throws {
+  @Test func `scans a bound-parameter placeholder`() throws {
     #expect(try lex("WHERE a = :pid")
                 == [.where, .identifier("a"), .equal, .parameter("pid")])
   }
 
-  @Test("rejects a colon not followed by an identifier")
-  func bareColon() {
+  @Test func `rejects a colon not followed by an identifier`() {
     #expect(throws: SQLError.self) { _ = try lex("SELECT : FROM T") }
   }
 }

--- a/Tests/SQLTests/LimitTests.swift
+++ b/Tests/SQLTests/LimitTests.swift
@@ -49,26 +49,22 @@ private func parse(_ text: String) throws -> Query {
 // MARK: - Tests
 
 struct LimitTests {
-  @Test("FETCH FIRST n ROWS ONLY caps the row count")
-  func caps() throws {
+  @Test func `FETCH FIRST n ROWS ONLY caps the row count`() throws {
     try people().expect("SELECT Id FROM People FETCH FIRST 3 ROWS ONLY",
                         yields: [[1], [2], [3]])
   }
 
-  @Test("FETCH FIRST 0 ROWS ONLY yields no rows")
-  func zero() throws {
+  @Test func `FETCH FIRST 0 ROWS ONLY yields no rows`() throws {
     try people().empty("SELECT Id FROM People FETCH FIRST 0 ROWS ONLY")
   }
 
-  @Test("FETCH with an omitted count takes one row")
-  func defaultsToOne() throws {
+  @Test func `FETCH with an omitted count takes one row`() throws {
     // The ISO `FETCH FIRST ROW ONLY` — no count — takes a single row.
     try people().expect("SELECT Id FROM People FETCH FIRST ROW ONLY",
                         yields: [[1]])
   }
 
-  @Test("ROW and ROWS, FIRST and NEXT, are interchangeable")
-  func synonyms() throws {
+  @Test func `ROW and ROWS, FIRST and NEXT, are interchangeable`() throws {
     // `ROW`/`ROWS` and `FIRST`/`NEXT` are ISO synonyms — the singular and the
     // `NEXT` spelling parse to the same clause as the plural `FIRST` form.
     let catalog = try people()
@@ -78,15 +74,13 @@ struct LimitTests {
                        yields: [[1]])
   }
 
-  @Test("OFFSET n ROWS then FETCH skips then caps")
-  func offset() throws {
+  @Test func `OFFSET n ROWS then FETCH skips then caps`() throws {
     try people().expect(
         "SELECT Id FROM People OFFSET 1 ROWS FETCH NEXT 2 ROWS ONLY",
         yields: [[2], [3]])
   }
 
-  @Test("OFFSET 0 ROWS is the same as no OFFSET")
-  func zeroOffset() throws {
+  @Test func `OFFSET 0 ROWS is the same as no OFFSET`() throws {
     let catalog = try people()
     try catalog.expect(
         "SELECT Id FROM People OFFSET 0 ROWS FETCH NEXT 2 ROWS ONLY",
@@ -96,15 +90,13 @@ struct LimitTests {
         yields: [[1], [2]])
   }
 
-  @Test("OFFSET without a FETCH skips with no cap")
-  func offsetOnly() throws {
+  @Test func `OFFSET without a FETCH skips with no cap`() throws {
     // An `OFFSET` written without a `FETCH` returns every row after the skip.
     try people().expect("SELECT Id FROM People OFFSET 3 ROWS",
                         yields: [[4], [5]])
   }
 
-  @Test("FETCH after ORDER BY takes the top-N in sorted order")
-  func afterOrder() throws {
+  @Test func `FETCH after ORDER BY takes the top-N in sorted order`() throws {
     // Ordered by Age ascending, ties by source order (a stable sort): Bob(25),
     // Eve(25), Alice(30), Carol(30), Dave(40). The FETCH caps the ORDERED
     // result, so it takes the two lowest ages rather than the first two rows.
@@ -113,8 +105,7 @@ struct LimitTests {
         yields: [["Bob"], ["Eve"]])
   }
 
-  @Test("OFFSET then FETCH after ORDER BY skips into the sorted result")
-  func offsetAfterOrder() throws {
+  @Test func `OFFSET then FETCH after ORDER BY skips into the sorted result`() throws {
     // Descending by Id: Eve, Dave, Carol, Bob, Alice — skip 1, take 2.
     try people().expect("""
                  SELECT Name FROM People
@@ -122,30 +113,26 @@ struct LimitTests {
                  """, yields: [["Dave"], ["Carol"]])
   }
 
-  @Test("OFFSET past the end yields no rows")
-  func offsetPastEnd() throws {
+  @Test func `OFFSET past the end yields no rows`() throws {
     let catalog = try people()
     try catalog.empty("SELECT Id FROM People OFFSET 5 ROWS")
     try catalog.empty("SELECT Id FROM People OFFSET 10 ROWS")
   }
 
-  @Test("a FETCH larger than the result yields every row")
-  func largerThanResult() throws {
+  @Test func `a FETCH larger than the result yields every row`() throws {
     let catalog = try people()
     try catalog.expect("SELECT Id FROM People FETCH FIRST 100 ROWS ONLY",
                        equals: "SELECT Id FROM People")
   }
 
-  @Test("FETCH caps rows admitted by a seekable WHERE")
-  func afterWhere() throws {
+  @Test func `FETCH caps rows admitted by a seekable WHERE`() throws {
     // `Id >= 2` seeks to rows 2…5; the FETCH then caps that run to two rows.
     try people().expect(
         "SELECT Id FROM People WHERE Id >= 2 FETCH FIRST 2 ROWS ONLY",
         yields: [[2], [3]])
   }
 
-  @Test("a reserved-word column is reachable via a delimited identifier")
-  func offsetColumn() throws {
+  @Test func `a reserved-word column is reachable via a delimited identifier`() throws {
     // `OFFSET` is a reserved word, so a relation's `Offset` column is reached
     // by the standard delimited identifier `"Offset"`. It selects, orders, and
     // coexists with a genuine OFFSET/FETCH row-limiting clause.
@@ -158,8 +145,7 @@ struct LimitTests {
                 """, yields: [[200]])
   }
 
-  @Test("the row limit applies before a discarded row's projection")
-  func beforeProjection() throws {
+  @Test func `the row limit applies before a discarded row's projection`() throws {
     // The cap sits below the projection, so a select list that would throw —
     // `1 / 0` — never runs for a row outside the page: FETCH 0 and an OFFSET
     // past the end return empty rather than dividing.
@@ -172,8 +158,7 @@ struct LimitTests {
                    fails: .divide)
   }
 
-  @Test("a directly-built negative OFFSET or FETCH is rejected")
-  func rejectsNegative() throws {
+  @Test func `a directly-built negative OFFSET or FETCH is rejected`() throws {
     // The parser cannot spell a negative count, but a direct `Limit` can — the
     // executor's skip and take would trap on it, so the engine rejects it as a
     // query error instead.
@@ -196,8 +181,7 @@ struct LimitTests {
     }
   }
 
-  @Test("a near-maximal FETCH after an OFFSET does not overflow")
-  func saturates() throws {
+  @Test func `a near-maximal FETCH after an OFFSET does not overflow`() throws {
     // A `count` near `Int.max` plus a positive `offset` would overflow an
     // `offset + count` bound; capping by a prefix of the skipped slice returns
     // the remaining rows rather than trapping.

--- a/Tests/SQLTests/OutputSchemaTests.swift
+++ b/Tests/SQLTests/OutputSchemaTests.swift
@@ -136,30 +136,26 @@ private func same(_ lhs: Array<(String, ValueType)>,
 // MARK: - Tests
 
 struct OutputSchemaTests {
-  @Test("SELECT * names and types every real column, never a virtual")
-  func star() throws {
+  @Test func `SELECT * names and types every real column, never a virtual`() throws {
     let columns = try schema("SELECT * FROM People")
     #expect(columns.count == 2)
     #expect(columns[0] == ("Name", .text))
     #expect(columns[1] == ("Age", .integer))
   }
 
-  @Test("a bare-column list carries each column's name and source kind")
-  func bareColumns() throws {
+  @Test func `a bare-column list carries each column's name and source kind`() throws {
     let columns = try schema("SELECT Age, Name FROM People")
     #expect(columns[0] == ("Age", .integer))
     #expect(columns[1] == ("Name", .text))
   }
 
-  @Test("an aliased expression takes its alias, typed by its expression")
-  func alias() throws {
+  @Test func `an aliased expression takes its alias, typed by its expression`() throws {
     let columns = try schema("SELECT Name AS Who, Age AS Years FROM People")
     #expect(columns[0] == ("Who", .text))
     #expect(columns[1] == ("Years", .integer))
   }
 
-  @Test("an unnamed computed expression gets a positional name")
-  func positional() throws {
+  @Test func `an unnamed computed expression gets a positional name`() throws {
     // `Age + 1` has no alias and is not a bare column, so it is `column N`
     // (1-based); an all-integer arithmetic expression is `.integer`.
     let columns = try schema("SELECT Name, Age + 1 FROM People")
@@ -167,8 +163,7 @@ struct OutputSchemaTests {
     #expect(columns[1] == ("column 2", .integer))
   }
 
-  @Test("binary arithmetic with a double operand is a double column")
-  func arithmetic() throws {
+  @Test func `binary arithmetic with a double operand is a double column`() throws {
     // `Age + 1` stays integer (both operands integral); `Age + 1.5` promotes to
     // a double, as the engine's arithmetic does, so the schema types it so.
     let integral = try schema("SELECT Age + 1 FROM People")
@@ -177,16 +172,14 @@ struct OutputSchemaTests {
     #expect(promoted[0].1 == .double)
   }
 
-  @Test("a literal projection carries the literal's kind")
-  func literals() throws {
+  @Test func `a literal projection carries the literal's kind`() throws {
     let columns = try schema("SELECT 'x', 1, 2.5 FROM People")
     #expect(columns[0] == ("column 1", .text))
     #expect(columns[1] == ("column 2", .integer))
     #expect(columns[2] == ("column 3", .double))
   }
 
-  @Test("a join's SELECT * concatenates both relations' columns in order")
-  func joinStar() throws {
+  @Test func `a join's SELECT * concatenates both relations' columns in order`() throws {
     let columns =
         try schema("SELECT * FROM People JOIN Pet ON People.Id = Pet.Id")
     #expect(columns.count == 4)
@@ -194,8 +187,7 @@ struct OutputSchemaTests {
                            ("Species", .text), ("Legs", .integer)]))
   }
 
-  @Test("a qualified column resolves its kind from the naming relation")
-  func qualified() throws {
+  @Test func `a qualified column resolves its kind from the naming relation`() throws {
     let columns = try schema("""
         SELECT People.Name, Pet.Legs
           FROM People JOIN Pet ON People.Id = Pet.Id
@@ -204,8 +196,7 @@ struct OutputSchemaTests {
     #expect(columns[1] == ("Legs", .integer))
   }
 
-  @Test("a UNION names its result off the first arm")
-  func union() throws {
+  @Test func `a UNION names its result off the first arm`() throws {
     // The first arm's projection names the result (the ISO rule), so the
     // schema is the leading SELECT's regardless of the trailing arm.
     let columns =
@@ -214,8 +205,7 @@ struct OutputSchemaTests {
     #expect(columns[0] == ("Name", .text))
   }
 
-  @Test("a view resolves against its registered columns")
-  func view() throws {
+  @Test func `a view resolves against its registered columns`() throws {
     let definition = try View(query: {
       guard case let .select(query) =
           try Statement(parsing: "SELECT Name FROM People") else {
@@ -235,8 +225,7 @@ struct OutputSchemaTests {
     #expect(columns[0] == OutputColumn(name: "Label", type: .text))
   }
 
-  @Test("a data-dependent-empty view derives headers without re-validating")
-  func emptyViewDerives() throws {
+  @Test func `a data-dependent-empty view derives headers without re-validating`() throws {
     // A view whose body is a text-arithmetic projection under a filter that
     // matches no row RUNS to zero rows: the data-dependent WHERE spares the
     // `Name + 1` from ever evaluating. Filling in the empty result's headers
@@ -267,31 +256,27 @@ struct OutputSchemaTests {
     }
   }
 
-  @Test("an unknown relation faults exactly as compilation would")
-  func unknownRelation() throws {
+  @Test func `an unknown relation faults exactly as compilation would`() throws {
     #expect(throws: SQLError.self) {
       let _ = try catalog().columns(of: parse("SELECT * FROM Absent"))
     }
   }
 
-  @Test("an unknown column faults exactly as compilation would")
-  func unknownColumn() throws {
+  @Test func `an unknown column faults exactly as compilation would`() throws {
     #expect(throws: SQLError.self) {
       let _ =
           try catalog().columns(of: parse("SELECT Absent FROM People"))
     }
   }
 
-  @Test("columns(of:) never opens a cursor")
-  func resolveOnly() throws {
+  @Test func `columns(of:) never opens a cursor`() throws {
     // The fixture's cursor traps on any row read, so a passing resolve proves
     // `columns(of:)` reads only schemas.
     let columns = try schema("SELECT Name, Age FROM People WHERE Age > 0")
     #expect(columns.count == 2)
   }
 
-  @Test("a WHERE naming a missing column faults, though the first arm resolves")
-  func invalidPredicate() throws {
+  @Test func `a WHERE naming a missing column faults, though the first arm resolves`() throws {
     // The projection names a real column, so a first-arm-only walk would return
     // a schema; the whole-query validation resolves the WHERE too and faults as
     // a run would.
@@ -302,8 +287,7 @@ struct OutputSchemaTests {
     #expect(throws: SQLError.self) { try resolve() }
   }
 
-  @Test("a UNION whose arms mismatch arity faults, though the first resolves")
-  func invalidUnionArity() throws {
+  @Test func `a UNION whose arms mismatch arity faults, though the first resolves`() throws {
     // The first arm projects one column and the second two — a run would fault
     // with `SQLError.arity`, so the schema resolution must too rather than name
     // the result off the first arm.
@@ -316,8 +300,7 @@ struct OutputSchemaTests {
     #expect(throws: SQLError.self) { try resolve() }
   }
 
-  @Test("a valid multi-column UNION names its result off the first arm")
-  func validUnion() throws {
+  @Test func `a valid multi-column UNION names its result off the first arm`() throws {
     // Both arms project two columns, so the query validates; the result names
     // come from the leading SELECT (the ISO rule).
     let columns = try schema("""
@@ -327,8 +310,7 @@ struct OutputSchemaTests {
     #expect(same(columns, [("Name", .text), ("Age", .integer)]))
   }
 
-  @Test("AVG is typed double and COUNT integer")
-  func aggregateNumeric() throws {
+  @Test func `AVG is typed double and COUNT integer`() throws {
     // The engine always yields a non-NULL AVG as a double and a COUNT as an
     // integer, so the result schema types them so rather than as the scalar
     // default.
@@ -337,8 +319,7 @@ struct OutputSchemaTests {
     #expect(columns[1].1 == .integer)
   }
 
-  @Test("SUM and MIN take the aggregated argument's kind")
-  func aggregateArgument() throws {
+  @Test func `SUM and MIN take the aggregated argument's kind`() throws {
     // SUM/MIN/MAX carry the kind of what they aggregate — an integer column's
     // SUM is an integer, a text column's MIN text.
     let columns =
@@ -348,8 +329,7 @@ struct OutputSchemaTests {
     #expect(columns[2].1 == .text)
   }
 
-  @Test("a zero FETCH over a whole-result aggregate spares its projection")
-  func aggregateZeroFetch() throws {
+  @Test func `a zero FETCH over a whole-result aggregate spares its projection`() throws {
     // A whole-result aggregate (aggregates, no GROUP BY) emits one row, which a
     // FETCH FIRST 0 ROWS ONLY drops — so its projection is unreachable and its
     // literal divide-by-zero never faults. Without the limit the same
@@ -368,8 +348,7 @@ struct OutputSchemaTests {
     #expect(empty.count == 2)
   }
 
-  @Test("a positive OFFSET over a whole-result aggregate spares its projection")
-  func aggregatePositiveOffset() throws {
+  @Test func `a positive OFFSET over a whole-result aggregate spares its projection`() throws {
     // A whole-result aggregate emits exactly ONE row, so an OFFSET of 1 skips
     // it — the projection is unreachable and its divide-by-zero never faults,
     // just as a zero FETCH spares it.
@@ -383,8 +362,7 @@ struct OutputSchemaTests {
     #expect(empty.count == 2)
   }
 
-  @Test("a zero FETCH does not spare a SELECT DISTINCT projection")
-  func distinctZeroFetch() throws {
+  @Test func `a zero FETCH does not spare a SELECT DISTINCT projection`() throws {
     // A DISTINCT plan is `Limit(Distinct(Project(…)))`: the projection
     // evaluates over every candidate row to dedup it BEFORE the cap pages the
     // result, so a zero FETCH does NOT make it unreachable. The schema must
@@ -398,8 +376,7 @@ struct OutputSchemaTests {
     #expect(normal.count == 1)
   }
 
-  @Test("a positive OFFSET does not spare a SELECT DISTINCT projection")
-  func distinctPositiveOffset() throws {
+  @Test func `a positive OFFSET does not spare a SELECT DISTINCT projection`() throws {
     // The OFFSET pages the deduplicated result, so the projection still
     // evaluates over every candidate row and its divide-by-zero faults.
     #expect(throws: SQLError.self) {
@@ -407,8 +384,7 @@ struct OutputSchemaTests {
     }
   }
 
-  @Test("a zero FETCH does not spare a grouped DISTINCT projection")
-  func groupedDistinctZeroFetch() throws {
+  @Test func `a zero FETCH does not spare a grouped DISTINCT projection`() throws {
     // A grouped DISTINCT dedups the projected group rows before the cap, so the
     // projection is reachable and its divide-by-zero faults under a zero FETCH.
     #expect(throws: SQLError.self) {
@@ -417,8 +393,7 @@ struct OutputSchemaTests {
     }
   }
 
-  @Test("a constant-false WHERE still spares a SELECT DISTINCT projection")
-  func distinctFalseWhere() throws {
+  @Test func `a constant-false WHERE still spares a SELECT DISTINCT projection`() throws {
     // A statically-false WHERE yields no rows, so a DISTINCT query has nothing
     // to dedup and the projection is genuinely unreached — the WHERE-based
     // elision stays, unlike the limit-based one.
@@ -426,8 +401,7 @@ struct OutputSchemaTests {
     #expect(columns.count == 1)
   }
 
-  @Test("a zero FETCH does not spare a DISTINCT empty-group projection")
-  func distinctEmptyGroupZeroFetch() throws {
+  @Test func `a zero FETCH does not spare a DISTINCT empty-group projection`() throws {
     // A constant-false WHERE over a whole-result aggregate emits ONE empty
     // group. For a non-distinct query a zero FETCH drops that lone row, so its
     // projection is unreachable and the divide-by-zero is spared. A DISTINCT
@@ -446,8 +420,7 @@ struct OutputSchemaTests {
     #expect(columns.count == 1)
   }
 
-  @Test("HAVING is evaluated before a zero-FETCH limit, so its faults surface")
-  func havingFaultsUnderZeroLimit() throws {
+  @Test func `HAVING is evaluated before a zero-FETCH limit, so its faults surface`() throws {
     // The compiled plan applies HAVING BEFORE the OFFSET/FETCH limit, so a zero
     // FETCH spares only the PROJECTION — HAVING still evaluates over the empty
     // group. A faulting HAVING must therefore surface even under a zero FETCH.
@@ -462,8 +435,7 @@ struct OutputSchemaTests {
     #expect(columns.count == 1)
   }
 
-  @Test("columns(of statement:) derives a WITH against its CTE scope")
-  func statementWith() throws {
+  @Test func `columns(of statement:) derives a WITH against its CTE scope`() throws {
     // The trailing query resolves against the statement's CTEs, schema-only:
     // a CTE `People` SHADOWS the two-column base relation, so a `SELECT *` over
     // it names the CTE's one declared column `x`, not the base's `Name, Age`.
@@ -473,8 +445,7 @@ struct OutputSchemaTests {
     #expect(columns[0].name == "x")
   }
 
-  @Test("columns(of statement:) resolves a WITH's explicit column projection")
-  func statementWithExplicit() throws {
+  @Test func `columns(of statement:) resolves a WITH's explicit column projection`() throws {
     // A bare-column projection reads the CTE's declared columns; a two-column
     // CTE heads its two names, no base relation involved.
     let columns = try catalog().columns(of: Statement(parsing:
@@ -483,8 +454,7 @@ struct OutputSchemaTests {
                  [("a", .integer), ("b", .integer)]))
   }
 
-  @Test("columns(of statement:) leaves a base reachable when no CTE shadows it")
-  func statementWithNoShadow() throws {
+  @Test func `columns(of statement:) leaves a base reachable when no CTE shadows it`() throws {
     // A CTE whose name does not collide leaves the base `People` reachable — the
     // trailing `SELECT *` resolves its two real columns.
     let columns = try catalog().columns(of: Statement(parsing:
@@ -493,8 +463,7 @@ struct OutputSchemaTests {
                  [("Name", .text), ("Age", .integer)]))
   }
 
-  @Test("columns(of statement:) faults on a CREATE VIEW, naming no result")
-  func statementCreate() throws {
+  @Test func `columns(of statement:) faults on a CREATE VIEW, naming no result`() throws {
     let create = try Statement(parsing:
         "CREATE VIEW v AS SELECT Name FROM People")
     #expect(throws: SQLError.self) {
@@ -502,8 +471,7 @@ struct OutputSchemaTests {
     }
   }
 
-  @Test("a WITH whose body arity contradicts its list faults when validating")
-  func statementWithBadArity() throws {
+  @Test func `a WITH whose body arity contradicts its list faults when validating`() throws {
     // The CTE declares ONE column but its body projects TWO — a `SELECT *` over
     // the two-column `People`. The parser cannot catch this (a `SELECT *`'s
     // width is known only at resolution), so a run rejects it with
@@ -518,8 +486,7 @@ struct OutputSchemaTests {
     }
   }
 
-  @Test("a WITH's body is trusted, not compiled, when not validating")
-  func statementWithArityTrusted() throws {
+  @Test func `a WITH's body is trusted, not compiled, when not validating`() throws {
     // `validate: false` is the post-run derive: the run already proved the
     // bodies consistent, so the declared list is TRUSTED without compiling the
     // body. The same arity-mismatched `WITH` that faults when validating
@@ -531,8 +498,7 @@ struct OutputSchemaTests {
     #expect(same(columns.map { ($0.name, $0.type) }, [("a", .integer)]))
   }
 
-  @Test("a well-formed WITH validates and derives its trailing schema")
-  func statementWithValidates() throws {
+  @Test func `a well-formed WITH validates and derives its trailing schema`() throws {
     // A CTE whose declared arity matches its body validates cleanly and derives
     // the trailing query's schema — the body compiled, its width confirmed
     // against the declared list, and its reachable operands type-checked.
@@ -543,8 +509,7 @@ struct OutputSchemaTests {
                  [("a", .integer), ("b", .integer)]))
   }
 
-  @Test("a non-recursive CTE body cannot see its own schema-only self")
-  func statementWithNonRecursiveSelf() throws {
+  @Test func `a non-recursive CTE body cannot see its own schema-only self`() throws {
     // A non-recursive CTE is NOT in scope within its own body — only the PRIOR
     // CTEs and the base catalog are — so a body that names the CTE with no
     // same-named base resolves against nothing and faults `.relation`, exactly
@@ -558,8 +523,7 @@ struct OutputSchemaTests {
     }
   }
 
-  @Test("a same-named-base non-recursive CTE body resolves the base")
-  func statementWithSelfResolvesBase() throws {
+  @Test func `a same-named-base non-recursive CTE body resolves the base`() throws {
     // A non-recursive CTE `People` shadowing the two-column base is NOT in its
     // OWN body's scope, so the body's `SELECT * FROM People` resolves the BASE
     // relation (two columns), matching its declared arity; the trailing query
@@ -573,8 +537,7 @@ struct OutputSchemaTests {
                  [("a", .integer), ("b", .integer)]))
   }
 
-  @Test("a WITH with a duplicate CTE name faults with redefinition")
-  func statementWithDuplicateName() throws {
+  @Test func `a WITH with a duplicate CTE name faults with redefinition`() throws {
     // Two CTEs of the same (case-insensitive) name would silently shadow the
     // earlier binding, so the derive faults `.redefinition` — the same fault
     // `Engine.with` raises before materialising — rather than advertise a schema
@@ -586,8 +549,7 @@ struct OutputSchemaTests {
     }
   }
 
-  @Test("a recursive CTE body sees its own schema-only self and resolves")
-  func statementWithRecursiveSelf() throws {
+  @Test func `a recursive CTE body sees its own schema-only self and resolves`() throws {
     // A genuinely recursive CTE — its FINAL UNION arm names itself — DOES bind
     // its own schema-only self while its body validates, so the recursive
     // reference resolves. The anchor seeds one column, the recursive arm reads
@@ -602,8 +564,7 @@ struct OutputSchemaTests {
     #expect(columns[0].name == "n")
   }
 
-  @Test("a recursive CTE self-referencing its anchor faults as a run does")
-  func statementWithRecursiveAnchorSelf() throws {
+  @Test func `a recursive CTE self-referencing its anchor faults as a run does`() throws {
     // The engine binds a recursive CTE's self ONLY to its FINAL UNION arm: a
     // self-reference in the ANCHOR arm resolves against the base scope, so with
     // no same-named base/view it can only be a misplaced recursive arm — a
@@ -628,8 +589,7 @@ struct OutputSchemaTests {
     }
   }
 
-  @Test("a recursive CTE anchor is operand-checked against the base scope")
-  func statementWithRecursiveAnchorOperand() throws {
+  @Test func `a recursive CTE anchor is operand-checked against the base scope`() throws {
     // A recursive CTE binds its schema-only self (declared columns, typed
     // `.integer`) ONLY inside its final UNION arm; the anchor resolves against
     // the BASE scope — the same scope a run evaluates it in. So the anchor's
@@ -652,8 +612,7 @@ struct OutputSchemaTests {
     }
   }
 
-  @Test("a well-formed recursive CTE with a numeric anchor validates")
-  func statementWithRecursiveAnchorValidates() throws {
+  @Test func `a well-formed recursive CTE with a numeric anchor validates`() throws {
     // The operand check must not reject a runnable recursive CTE: a numeric
     // anchor and a recursive arm free of bad operands validate and derive the
     // trailing schema. This is the counterpart to the text-anchor fault — the

--- a/Tests/SQLTests/ParserTests.swift
+++ b/Tests/SQLTests/ParserTests.swift
@@ -15,8 +15,7 @@ private func parse(select text: String) throws -> Select {
 }
 
 struct ProjectionTests {
-  @Test("parses a SELECT * projection")
-  func star() throws {
+  @Test func `parses a SELECT * projection`() throws {
     let select = try parse(select: "SELECT * FROM TypeDef")
     #expect(select.projection == .all)
     #expect(select.table == "TypeDef")
@@ -24,30 +23,26 @@ struct ProjectionTests {
     #expect(select.order == nil)
   }
 
-  @Test("parses a single-column projection")
-  func singleColumn() throws {
+  @Test func `parses a single-column projection`() throws {
     let select = try parse(select: "SELECT TypeName FROM TypeDef")
     #expect(select.projection == .columns(["TypeName"]))
   }
 
-  @Test("parses a comma-separated column list")
-  func columnList() throws {
+  @Test func `parses a comma-separated column list`() throws {
     let select =
         try parse(select: "SELECT TypeName, TypeNamespace, Flags FROM TypeDef")
     #expect(select.projection
                 == .columns(["TypeName", "TypeNamespace", "Flags"]))
   }
 
-  @Test("parses a dotted column identifier")
-  func dottedColumn() throws {
+  @Test func `parses a dotted column identifier`() throws {
     // Simple column identifiers may carry a qualifying dot; metadata names with
     // dots appear only as string literals.
     let select = try parse(select: "SELECT TypeDef.TypeName FROM TypeDef")
     #expect(select.projection == .columns(["TypeDef.TypeName"]))
   }
 
-  @Test("parses a delimited column identifier as one unqualified name")
-  func delimitedColumn() throws {
+  @Test func `parses a delimited column identifier as one unqualified name`() throws {
     // A delimited identifier is verbatim: a dot in it is part of the name,
     // not a qualifier as in the bare dotted form above.
     let dotted = try parse(select: "SELECT \"a.b\" FROM T")
@@ -59,8 +54,7 @@ struct ProjectionTests {
 }
 
 struct KeywordTests {
-  @Test("parses lowercase keywords")
-  func caseInsensitive() throws {
+  @Test func `parses lowercase keywords`() throws {
     let select =
         try parse(select: "select TypeName from TypeDef where Flags = 1")
     #expect(select.projection == .columns(["TypeName"]))
@@ -69,8 +63,7 @@ struct KeywordTests {
                                             right: .literal(.integer(1))))
   }
 
-  @Test("parses mixed-case keywords")
-  func mixedCase() throws {
+  @Test func `parses mixed-case keywords`() throws {
     let select =
         try parse(select: "SeLeCt * FrOm TypeDef OrDeR By TypeName DeSc")
     #expect(select.order == Order(column: "TypeName", ascending: false))
@@ -78,34 +71,29 @@ struct KeywordTests {
 }
 
 struct SetQuantifierTests {
-  @Test("a plain SELECT is not distinct")
-  func plain() throws {
+  @Test func `a plain SELECT is not distinct`() throws {
     let select = try parse(select: "SELECT TypeName FROM TypeDef")
     #expect(!select.distinct)
   }
 
-  @Test("SELECT DISTINCT sets the distinct flag")
-  func distinct() throws {
+  @Test func `SELECT DISTINCT sets the distinct flag`() throws {
     let select = try parse(select: "SELECT DISTINCT TypeName FROM TypeDef")
     #expect(select.distinct)
     #expect(select.projection == .columns(["TypeName"]))
   }
 
-  @Test("SELECT ALL is the default, not distinct")
-  func explicitAll() throws {
+  @Test func `SELECT ALL is the default, not distinct`() throws {
     let select = try parse(select: "SELECT ALL TypeName FROM TypeDef")
     #expect(!select.distinct)
     #expect(select.projection == .columns(["TypeName"]))
   }
 
-  @Test("DISTINCT is case-insensitive")
-  func caseInsensitive() throws {
+  @Test func `DISTINCT is case-insensitive`() throws {
     let select = try parse(select: "select distinct TypeName from TypeDef")
     #expect(select.distinct)
   }
 
-  @Test("DISTINCT applies to a FROM-less scalar select")
-  func scalar() throws {
+  @Test func `DISTINCT applies to a FROM-less scalar select`() throws {
     let select = try parse(select: "SELECT DISTINCT 1")
     #expect(select.distinct)
     #expect(select.from == nil)
@@ -113,8 +101,7 @@ struct SetQuantifierTests {
 }
 
 struct PredicateTests {
-  @Test("parses each comparison operator")
-  func operators() throws {
+  @Test func `parses each comparison operator`() throws {
     let cases: Array<(String, Comparison)> = [
       ("=", .equal),
       ("<>", .unequal),
@@ -132,8 +119,7 @@ struct PredicateTests {
     }
   }
 
-  @Test("parses a string-literal operand")
-  func stringLiteral() throws {
+  @Test func `parses a string-literal operand`() throws {
     let text =
         "SELECT * FROM TypeDef WHERE TypeNamespace = 'Windows.Win32.Foundation'"
     let select = try parse(select: text)
@@ -143,16 +129,14 @@ struct PredicateTests {
                                right: value))
   }
 
-  @Test("parses a string with an escaped quote")
-  func escapedQuote() throws {
+  @Test func `parses a string with an escaped quote`() throws {
     let select = try parse(select: "SELECT * FROM T WHERE name = 'O''Brien'")
     #expect(select.predicate
                 == .comparison(left: .column("name"), op: .equal,
                                right: .literal(.string("O'Brien"))))
   }
 
-  @Test("parses a function call as a comparison operand")
-  func functionOperand() throws {
+  @Test func `parses a function call as a comparison operand`() throws {
     let select = try parse(select: "SELECT * FROM T WHERE upper(Name) = 'X'")
     let call = Expression.call(name: "upper", arguments: [.column("Name")])
     #expect(select.predicate
@@ -160,8 +144,7 @@ struct PredicateTests {
                                right: .literal(.string("X"))))
   }
 
-  @Test("binds AND tighter than OR")
-  func andBindsTighterThanOr() throws {
+  @Test func `binds AND tighter than OR`() throws {
     // a = 1 OR b = 2 AND c = 3  ==>  a OR (b AND c)
     let select =
         try parse(select: "SELECT * FROM T WHERE a = 1 OR b = 2 AND c = 3")
@@ -174,8 +157,7 @@ struct PredicateTests {
     #expect(select.predicate == .or(a, .and(b, c)))
   }
 
-  @Test("binds NOT tighter than AND")
-  func notBindsTighterThanAnd() throws {
+  @Test func `binds NOT tighter than AND`() throws {
     // NOT a = 1 AND b = 2  ==>  (NOT a) AND b
     let select =
         try parse(select: "SELECT * FROM T WHERE NOT a = 1 AND b = 2")
@@ -186,8 +168,7 @@ struct PredicateTests {
     #expect(select.predicate == .and(.not(a), b))
   }
 
-  @Test("parentheses override operator precedence")
-  func parenthesesOverridePrecedence() throws {
+  @Test func `parentheses override operator precedence`() throws {
     // (a = 1 OR b = 2) AND c = 3
     let select =
         try parse(select: "SELECT * FROM T WHERE (a = 1 OR b = 2) AND c = 3")
@@ -200,34 +181,29 @@ struct PredicateTests {
     #expect(select.predicate == .and(.or(a, b), c))
   }
 
-  @Test("parses IS NULL")
-  func isNull() throws {
+  @Test func `parses IS NULL`() throws {
     let select = try parse(select: "SELECT * FROM T WHERE Note IS NULL")
     #expect(select.predicate == .null(.column("Note"), negated: false))
   }
 
-  @Test("parses IS NOT NULL")
-  func isNotNull() throws {
+  @Test func `parses IS NOT NULL`() throws {
     let select = try parse(select: "SELECT * FROM T WHERE Note IS NOT NULL")
     #expect(select.predicate == .null(.column("Note"), negated: true))
   }
 
-  @Test("parses IS NULL over a function-call operand")
-  func isNullCall() throws {
+  @Test func `parses IS NULL over a function-call operand`() throws {
     let select = try parse(select: "SELECT * FROM T WHERE iid(Id) IS NULL")
     let call = Expression.call(name: "iid", arguments: [.column("Id")])
     #expect(select.predicate == .null(call, negated: false))
   }
 
-  @Test("rejects IS without NULL")
-  func isWithoutNull() {
+  @Test func `rejects IS without NULL`() {
     #expect(throws: SQLError.self) {
       _ = try Statement(parsing: "SELECT * FROM T WHERE Note IS 1")
     }
   }
 
-  @Test("parses OR left-associatively")
-  func leftAssociativeOr() throws {
+  @Test func `parses OR left-associatively`() throws {
     // a = 1 OR b = 2 OR c = 3  ==>  ((a OR b) OR c)
     let select =
         try parse(select: "SELECT * FROM T WHERE a = 1 OR b = 2 OR c = 3")
@@ -242,26 +218,22 @@ struct PredicateTests {
 }
 
 struct OrderTests {
-  @Test("defaults ORDER BY to ascending")
-  func defaultAscending() throws {
+  @Test func `defaults ORDER BY to ascending`() throws {
     let select = try parse(select: "SELECT * FROM T ORDER BY TypeName")
     #expect(select.order == Order(column: "TypeName", ascending: true))
   }
 
-  @Test("parses an explicit ASC order")
-  func explicitAscending() throws {
+  @Test func `parses an explicit ASC order`() throws {
     let select = try parse(select: "SELECT * FROM T ORDER BY TypeName ASC")
     #expect(select.order == Order(column: "TypeName", ascending: true))
   }
 
-  @Test("parses a DESC order")
-  func descending() throws {
+  @Test func `parses a DESC order`() throws {
     let select = try parse(select: "SELECT * FROM T ORDER BY TypeName DESC")
     #expect(select.order == Order(column: "TypeName", ascending: false))
   }
 
-  @Test("parses a comma-separated list of sort keys")
-  func multipleKeys() throws {
+  @Test func `parses a comma-separated list of sort keys`() throws {
     let select =
         try parse(select: "SELECT * FROM T ORDER BY A, B DESC, C")
     #expect(select.order == Order(keys: [
@@ -271,8 +243,7 @@ struct OrderTests {
     ]))
   }
 
-  @Test("a single-key ORDER BY is one key in the list")
-  func singleKey() throws {
+  @Test func `a single-key ORDER BY is one key in the list`() throws {
     let select = try parse(select: "SELECT * FROM T ORDER BY TypeName DESC")
     #expect(select.order?.keys
               == [Order.Key(column: "TypeName", ascending: false)])
@@ -280,8 +251,7 @@ struct OrderTests {
 }
 
 struct CompositeTests {
-  @Test("parses a full SELECT/WHERE/ORDER BY query")
-  func fullQuery() throws {
+  @Test func `parses a full SELECT/WHERE/ORDER BY query`() throws {
     let select =
         try parse(select: """
             SELECT TypeName, TypeNamespace FROM TypeDef
@@ -301,22 +271,19 @@ struct CompositeTests {
 }
 
 struct ColumnTests {
-  @Test("splits a dotted column into qualifier and name")
-  func qualified() {
+  @Test func `splits a dotted column into qualifier and name`() {
     let column = Column("t.Name")
     #expect(column.qualifier == "t")
     #expect(column.name == "Name")
   }
 
-  @Test("leaves an undotted column unqualified")
-  func unqualified() {
+  @Test func `leaves an undotted column unqualified`() {
     let column = Column("Name")
     #expect(column.qualifier == nil)
     #expect(column.name == "Name")
   }
 
-  @Test("splits on the last dot only")
-  func lastDot() {
+  @Test func `splits on the last dot only`() {
     // A two-part relation name may qualify a column — the reserved
     // `information_schema.tables.table_name` — so the split takes the text
     // before the LAST dot as the qualifier and the rest as the name.
@@ -327,35 +294,30 @@ struct ColumnTests {
 }
 
 struct RelationTests {
-  @Test("parses a bare FROM relation with no alias")
-  func bare() throws {
+  @Test func `parses a bare FROM relation with no alias`() throws {
     let select = try parse(select: "SELECT * FROM TypeDef")
     #expect(select.from == Relation(name: "TypeDef"))
     #expect(select.joins.isEmpty)
   }
 
-  @Test("parses an AS alias on the FROM relation")
-  func alias() throws {
+  @Test func `parses an AS alias on the FROM relation`() throws {
     let select = try parse(select: "SELECT * FROM TypeDef AS t")
     #expect(select.from == Relation(name: "TypeDef", alias: "t"))
   }
 
-  @Test("parses an implicit (AS-less) alias")
-  func implicitAlias() throws {
+  @Test func `parses an implicit (AS-less) alias`() throws {
     let select = try parse(select: "SELECT * FROM TypeDef t")
     #expect(select.from == Relation(name: "TypeDef", alias: "t"))
   }
 
-  @Test("does not mistake a following keyword for an alias")
-  func keywordNotAlias() throws {
+  @Test func `does not mistake a following keyword for an alias`() throws {
     let select = try parse(select: "SELECT * FROM TypeDef WHERE Flags = 1")
     #expect(select.from == Relation(name: "TypeDef"))
   }
 }
 
 struct JoinTests {
-  @Test("parses a list-shape join with aliases")
-  func listJoin() throws {
+  @Test func `parses a list-shape join with aliases`() throws {
     let select = try parse(select: """
         SELECT m.Name FROM TypeDef AS t
           JOIN MethodDef AS m ON m.parent = t.Id
@@ -372,8 +334,7 @@ struct JoinTests {
                                             op: .equal, right: value))
   }
 
-  @Test("parses a forward-key join")
-  func forwardJoin() throws {
+  @Test func `parses a forward-key join`() throws {
     let select = try parse(select: """
         SELECT r.TypeName FROM TypeDef AS t
           JOIN TypeRef AS r ON t.Extends = r.Id
@@ -384,8 +345,7 @@ struct JoinTests {
     ])
   }
 
-  @Test("parses a join without aliases")
-  func unaliasedJoin() throws {
+  @Test func `parses a join without aliases`() throws {
     let select = try parse(select: """
         SELECT Name FROM MethodDef
           JOIN Param ON Param.parent = MethodDef.Id
@@ -398,8 +358,7 @@ struct JoinTests {
     ])
   }
 
-  @Test("parses a chain of two joins in source order")
-  func chainedJoins() throws {
+  @Test func `parses a chain of two joins in source order`() throws {
     let select = try parse(select: """
         SELECT Param.Name FROM TypeDef AS t
           JOIN MethodDef AS m ON m.parent = t.Id
@@ -414,15 +373,13 @@ struct JoinTests {
     ])
   }
 
-  @Test("rejects a join missing ON")
-  func missingOn() {
+  @Test func `rejects a join missing ON`() {
     #expect(throws: SQLError.self) {
       _ = try Statement(parsing: "SELECT * FROM A JOIN B b")
     }
   }
 
-  @Test("rejects a join whose ON is not an equality")
-  func nonEqualityOn() {
+  @Test func `rejects a join whose ON is not an equality`() {
     #expect(throws: SQLError.self) {
       _ = try Statement(parsing: "SELECT * FROM A JOIN B ON a.x < b.Id")
     }
@@ -432,8 +389,7 @@ struct JoinTests {
 // MARK: - Literals
 
 struct LiteralTests {
-  @Test("parses TRUE and FALSE as boolean literals")
-  func boolean() throws {
+  @Test func `parses TRUE and FALSE as boolean literals`() throws {
     let yes = try parse(select: "SELECT * FROM T WHERE Sealed = TRUE")
     #expect(yes.predicate
                 == .comparison(left: .column("Sealed"), op: .equal,
@@ -444,62 +400,54 @@ struct LiteralTests {
                                right: .literal(.boolean(false))))
   }
 
-  @Test("recognises the boolean keywords case-insensitively")
-  func booleanCase() throws {
+  @Test func `recognises the boolean keywords case-insensitively`() throws {
     let select = try parse(select: "SELECT * FROM T WHERE a = true")
     #expect(select.predicate
                 == .comparison(left: .column("a"), op: .equal,
                                right: .literal(.boolean(true))))
   }
 
-  @Test("parses an x'…' hex blob literal into its bytes")
-  func blob() throws {
+  @Test func `parses an x'…' hex blob literal into its bytes`() throws {
     let select = try parse(select: "SELECT * FROM T WHERE Sig = x'53514c'")
     #expect(select.predicate
                 == .comparison(left: .column("Sig"), op: .equal,
                                right: .literal(.blob([0x53, 0x51, 0x4c]))))
   }
 
-  @Test("parses an uppercase X'…' prefix and mixed-case hex digits")
-  func blobPrefixAndDigits() throws {
+  @Test func `parses an uppercase X'…' prefix and mixed-case hex digits`() throws {
     let select = try parse(select: "SELECT * FROM T WHERE a = X'aBcDeF'")
     #expect(select.predicate
                 == .comparison(left: .column("a"), op: .equal,
                                right: .literal(.blob([0xab, 0xcd, 0xef]))))
   }
 
-  @Test("parses an empty blob x''")
-  func emptyBlob() throws {
+  @Test func `parses an empty blob x''`() throws {
     let select = try parse(select: "SELECT * FROM T WHERE a = x''")
     #expect(select.predicate
                 == .comparison(left: .column("a"), op: .equal,
                                right: .literal(.blob([]))))
   }
 
-  @Test("a bare x is an ordinary identifier, not a blob prefix")
-  func bareX() throws {
+  @Test func `a bare x is an ordinary identifier, not a blob prefix`() throws {
     // The `x` prefix opens a blob only when a quote follows; alone it is a
     // column name.
     let select = try parse(select: "SELECT x FROM T")
     #expect(select.projection == .columns(["x"]))
   }
 
-  @Test("rejects a blob with an odd hex digit count")
-  func oddBlob() {
+  @Test func `rejects a blob with an odd hex digit count`() {
     #expect(throws: SQLError.self) {
       _ = try Statement(parsing: "SELECT * FROM T WHERE a = x'abc'")
     }
   }
 
-  @Test("rejects a blob with a non-hex digit")
-  func nonHexBlob() {
+  @Test func `rejects a blob with a non-hex digit`() {
     #expect(throws: SQLError.self) {
       _ = try Statement(parsing: "SELECT * FROM T WHERE a = x'gg'")
     }
   }
 
-  @Test("rejects an unterminated blob")
-  func unterminatedBlob() {
+  @Test func `rejects an unterminated blob`() {
     #expect(throws: SQLError.self) {
       _ = try Statement(parsing: "SELECT * FROM T WHERE a = x'abcd")
     }
@@ -507,29 +455,25 @@ struct LiteralTests {
 }
 
 struct ErrorTests {
-  @Test("rejects a query missing FROM")
-  func missingFrom() {
+  @Test func `rejects a query missing FROM`() {
     #expect(throws: SQLError.self) {
       _ = try Statement(parsing: "SELECT TypeName TypeDef")
     }
   }
 
-  @Test("rejects an invalid operator")
-  func badOperator() {
+  @Test func `rejects an invalid operator`() {
     #expect(throws: SQLError.self) {
       _ = try Statement(parsing: "SELECT * FROM T WHERE a ! 1")
     }
   }
 
-  @Test("rejects an unterminated string")
-  func unterminatedString() {
+  @Test func `rejects an unterminated string`() {
     #expect(throws: SQLError.self) {
       _ = try Statement(parsing: "SELECT * FROM T WHERE a = 'unterminated")
     }
   }
 
-  @Test("rejects trailing tokens")
-  func trailingTokens() {
+  @Test func `rejects trailing tokens`() {
     // A bare identifier after the relation is now an implicit alias, so
     // trailing garbage must come after a clause that admits no alias — here a
     // second identifier past the relation's (implicit) alias.
@@ -538,15 +482,13 @@ struct ErrorTests {
     }
   }
 
-  @Test("rejects an empty projection")
-  func emptyProjection() {
+  @Test func `rejects an empty projection`() {
     #expect(throws: SQLError.self) {
       _ = try Statement(parsing: "SELECT FROM T")
     }
   }
 
-  @Test("rejects a FROM keyword with no following relation")
-  func unexpectedEnd() {
+  @Test func `rejects a FROM keyword with no following relation`() {
     // FROM is now optional, so `SELECT *` parses as a FROM-less projection (the
     // engine rejects a `*` with no relation). A bare FROM with no relation,
     // though, ends the input where a relation is required.
@@ -555,8 +497,7 @@ struct ErrorTests {
     }
   }
 
-  @Test("parses a column on either side of a comparison")
-  func columnOperands() throws {
+  @Test func `parses a column on either side of a comparison`() throws {
     // Either operand may be an expression, so a column-vs-column predicate is
     // valid SQL (`a = b`), not an error.
     let select = try parse(select: "SELECT * FROM T WHERE a = b")
@@ -569,14 +510,12 @@ struct ErrorTests {
 // MARK: - Expression projections
 
 struct ExpressionTests {
-  @Test("a bare-column list stays the simpler columns projection")
-  func columns() throws {
+  @Test func `a bare-column list stays the simpler columns projection`() throws {
     let select = try parse(select: "SELECT a, b FROM T")
     #expect(select.projection == .columns(["a", "b"]))
   }
 
-  @Test("a function call yields an expression projection")
-  func call() throws {
+  @Test func `a function call yields an expression projection`() throws {
     let select = try parse(select: "SELECT guid(Name) FROM T")
     #expect(select.projection
                 == .expressions([
@@ -585,8 +524,7 @@ struct ExpressionTests {
                 ]))
   }
 
-  @Test("an aliased column yields an expression projection")
-  func alias() throws {
+  @Test func `an aliased column yields an expression projection`() throws {
     let select = try parse(select: "SELECT Name AS label FROM T")
     #expect(select.projection
                 == .expressions([
@@ -594,8 +532,7 @@ struct ExpressionTests {
                 ]))
   }
 
-  @Test("a call takes literal and nested-call arguments")
-  func arguments() throws {
+  @Test func `a call takes literal and nested-call arguments`() throws {
     let select = try parse(select: "SELECT f(1, g(x), 'lit') FROM T")
     #expect(select.projection
                 == .expressions([
@@ -608,8 +545,7 @@ struct ExpressionTests {
                 ]))
   }
 
-  @Test("a zero-argument call parses")
-  func nullary() throws {
+  @Test func `a zero-argument call parses`() throws {
     let select = try parse(select: "SELECT now() FROM T")
     #expect(select.projection
                 == .expressions([
@@ -633,8 +569,7 @@ struct ArithmeticTests {
     return items[0].expression
   }
 
-  @Test("parses each arithmetic operator")
-  func operators() throws {
+  @Test func `parses each arithmetic operator`() throws {
     let cases: Array<(String, Arithmetic)> = [
       ("+", .add),
       ("-", .subtract),
@@ -648,8 +583,7 @@ struct ArithmeticTests {
     }
   }
 
-  @Test("multiplication binds tighter than addition")
-  func precedence() throws {
+  @Test func `multiplication binds tighter than addition`() throws {
     // 2 + 3 * 4  ==>  2 + (3 * 4)
     let parsed = try expression("SELECT 2 + 3 * 4 FROM T")
     let product = Expression.binary(.multiply, .literal(.integer(3)),
@@ -657,8 +591,7 @@ struct ArithmeticTests {
     #expect(parsed == .binary(.add, .literal(.integer(2)), product))
   }
 
-  @Test("parentheses override precedence")
-  func grouping() throws {
+  @Test func `parentheses override precedence`() throws {
     // (2 + 3) * 4  ==>  (2 + 3) * 4
     let parsed = try expression("SELECT (2 + 3) * 4 FROM T")
     let sum = Expression.binary(.add, .literal(.integer(2)),
@@ -666,8 +599,7 @@ struct ArithmeticTests {
     #expect(parsed == .binary(.multiply, sum, .literal(.integer(4))))
   }
 
-  @Test("addition is left-associative")
-  func leftAssociative() throws {
+  @Test func `addition is left-associative`() throws {
     // 1 - 2 - 3  ==>  (1 - 2) - 3
     let parsed = try expression("SELECT 1 - 2 - 3 FROM T")
     let left = Expression.binary(.subtract, .literal(.integer(1)),
@@ -675,16 +607,14 @@ struct ArithmeticTests {
     #expect(parsed == .binary(.subtract, left, .literal(.integer(3))))
   }
 
-  @Test("arithmetic combines columns and calls")
-  func operands() throws {
+  @Test func `arithmetic combines columns and calls`() throws {
     let parsed = try expression("SELECT add(Id, 1) * 10 FROM T")
     let call = Expression.call(name: "add",
                                arguments: [.column("Id"), .literal(.integer(1))])
     #expect(parsed == .binary(.multiply, call, .literal(.integer(10))))
   }
 
-  @Test("arithmetic parses on either side of a comparison")
-  func predicate() throws {
+  @Test func `arithmetic parses on either side of a comparison`() throws {
     let select = try parse(select: "SELECT * FROM T WHERE Age + 1 = 26")
     let sum = Expression.binary(.add, .column("Age"), .literal(.integer(1)))
     #expect(select.predicate
@@ -696,8 +626,7 @@ struct ArithmeticTests {
 // MARK: - Scalar (FROM-less) SELECT
 
 struct ScalarSelectTests {
-  @Test("parses a FROM-less SELECT with no relation")
-  func bare() throws {
+  @Test func `parses a FROM-less SELECT with no relation`() throws {
     let select = try parse(select: "SELECT 1")
     #expect(select.from == nil)
     #expect(select.joins.isEmpty)
@@ -707,8 +636,7 @@ struct ScalarSelectTests {
                 == .expressions([Projected(expression: .literal(.integer(1)))]))
   }
 
-  @Test("parses a FROM-less arithmetic projection")
-  func arithmetic() throws {
+  @Test func `parses a FROM-less arithmetic projection`() throws {
     let select = try parse(select: "SELECT 1 + 1")
     let sum = Expression.binary(.add, .literal(.integer(1)),
                                 .literal(.integer(1)))
@@ -716,8 +644,7 @@ struct ScalarSelectTests {
     #expect(select.projection == .expressions([Projected(expression: sum)]))
   }
 
-  @Test("parses a FROM-less multi-column projection")
-  func multiColumn() throws {
+  @Test func `parses a FROM-less multi-column projection`() throws {
     let select = try parse(select: "SELECT 1, 2")
     #expect(select.from == nil)
     #expect(select.projection == .expressions([
@@ -726,8 +653,7 @@ struct ScalarSelectTests {
     ]))
   }
 
-  @Test("a FROM-less alias names the projected column")
-  func aliased() throws {
+  @Test func `a FROM-less alias names the projected column`() throws {
     let select = try parse(select: "SELECT 1 + 1 AS two")
     let sum = Expression.binary(.add, .literal(.integer(1)),
                                 .literal(.integer(1)))
@@ -735,8 +661,7 @@ struct ScalarSelectTests {
                 == .expressions([Projected(expression: sum, alias: "two")]))
   }
 
-  @Test("a FROM-less query admits no trailing WHERE")
-  func noWhere() {
+  @Test func `a FROM-less query admits no trailing WHERE`() {
     // With FROM absent there is no relation to filter, so a WHERE that follows
     // is trailing input rather than a clause.
     #expect(throws: SQLError.self) {
@@ -757,8 +682,7 @@ private func parseCreate(_ text: String) throws -> (String, View) {
 }
 
 struct CreateViewTests {
-  @Test("infers a view's columns from a bare-column projection")
-  func inferred() throws {
+  @Test func `infers a view's columns from a bare-column projection`() throws {
     let (name, view) = try parseCreate("CREATE VIEW v AS SELECT a, b FROM t")
     #expect(name == "v")
     #expect(view.columns == ["a", "b"])
@@ -766,22 +690,19 @@ struct CreateViewTests {
                                          from: Relation(name: "t"))))
   }
 
-  @Test("drops a qualifier when inferring a column name")
-  func qualified() throws {
+  @Test func `drops a qualifier when inferring a column name`() throws {
     let (_, view) = try parseCreate("CREATE VIEW v AS SELECT t.a FROM t")
     #expect(view.columns == ["a"])
   }
 
-  @Test("takes an explicit column list over the projection")
-  func explicit() throws {
+  @Test func `takes an explicit column list over the projection`() throws {
     let (name, view) =
         try parseCreate("CREATE VIEW v (x, y) AS SELECT a, b FROM t")
     #expect(name == "v")
     #expect(view.columns == ["x", "y"])
   }
 
-  @Test("rejects an explicit list wider than the projection")
-  func tooWide() {
+  @Test func `rejects an explicit list wider than the projection`() {
     // (a, b) names two columns over a one-value projection — the view would
     // claim a column its rows lack.
     #expect(throws: SQLError.columns(expected: 1, got: 2)) {
@@ -789,8 +710,7 @@ struct CreateViewTests {
     }
   }
 
-  @Test("rejects an explicit list narrower than the projection")
-  func tooNarrow() {
+  @Test func `rejects an explicit list narrower than the projection`() {
     // (a) names one column over a two-value projection — the projected `name`
     // would have no view column.
     #expect(throws: SQLError.columns(expected: 2, got: 1)) {
@@ -798,15 +718,13 @@ struct CreateViewTests {
     }
   }
 
-  @Test("accepts an explicit list matching the projection arity")
-  func matched() throws {
+  @Test func `accepts an explicit list matching the projection arity`() throws {
     let (_, view) =
         try parseCreate("CREATE VIEW v (a, b) AS SELECT id, name FROM t")
     #expect(view.columns == ["a", "b"])
   }
 
-  @Test("defers a SELECT * view's column-count check to the engine")
-  func starExplicit() throws {
+  @Test func `defers a SELECT * view's column-count check to the engine`() throws {
     // A `SELECT *` has no statically known arity, so the parser admits any
     // explicit list; the engine validates it against the relation at
     // resolution.
@@ -815,15 +733,13 @@ struct CreateViewTests {
     #expect(view.columns == ["a", "b"])
   }
 
-  @Test("infers a column name from an expression's alias")
-  func aliased() throws {
+  @Test func `infers a column name from an expression's alias`() throws {
     let (_, view) =
         try parseCreate("CREATE VIEW v AS SELECT guid(Id) AS iid FROM t")
     #expect(view.columns == ["iid"])
   }
 
-  @Test("infers a bare column's name in an expression projection")
-  func mixed() throws {
+  @Test func `infers a bare column's name in an expression projection`() throws {
     // A projection carrying any alias is the richer expressions form; a bare
     // column in it still infers to its own name.
     let (_, view) =
@@ -831,44 +747,38 @@ struct CreateViewTests {
     #expect(view.columns == ["Name", "iid"])
   }
 
-  @Test("parses lowercase CREATE VIEW keywords")
-  func caseInsensitive() throws {
+  @Test func `parses lowercase CREATE VIEW keywords`() throws {
     let (name, view) =
         try parseCreate("create view v as select a from t")
     #expect(name == "v")
     #expect(view.columns == ["a"])
   }
 
-  @Test("rejects a SELECT * view with no explicit columns")
-  func star() {
+  @Test func `rejects a SELECT * view with no explicit columns`() {
     #expect(throws: SQLError.self) {
       _ = try Statement(parsing: "CREATE VIEW v AS SELECT * FROM t")
     }
   }
 
-  @Test("rejects an unaliased expression with no explicit columns")
-  func unnamed() {
+  @Test func `rejects an unaliased expression with no explicit columns`() {
     #expect(throws: SQLError.self) {
       _ = try Statement(parsing: "CREATE VIEW v AS SELECT guid(Id) FROM t")
     }
   }
 
-  @Test("rejects an explicit duplicate column name")
-  func duplicateExplicit() {
+  @Test func `rejects an explicit duplicate column name`() {
     #expect(throws: SQLError.duplicate("x")) {
       _ = try Statement(parsing: "CREATE VIEW v (x, x) AS SELECT a, b FROM t")
     }
   }
 
-  @Test("rejects a case-insensitive explicit duplicate column name")
-  func duplicateExplicitFolded() {
+  @Test func `rejects a case-insensitive explicit duplicate column name`() {
     #expect(throws: SQLError.duplicate("x")) {
       _ = try Statement(parsing: "CREATE VIEW v (X, x) AS SELECT a, b FROM t")
     }
   }
 
-  @Test("rejects an inferred duplicate column name")
-  func duplicateInferred() {
+  @Test func `rejects an inferred duplicate column name`() {
     #expect(throws: SQLError.duplicate("Name")) {
       _ = try Statement(
           parsing: "CREATE VIEW v AS SELECT t.Name, u.Name FROM t "
@@ -876,8 +786,7 @@ struct CreateViewTests {
     }
   }
 
-  @Test("accepts a distinct inferred column list")
-  func distinctInferred() throws {
+  @Test func `accepts a distinct inferred column list`() throws {
     let (_, view) = try parseCreate("CREATE VIEW v AS SELECT a, b FROM t")
     #expect(view.columns == ["a", "b"])
   }
@@ -896,8 +805,7 @@ private func parse(function text: String) throws -> (String, Function) {
 }
 
 struct CreateFunctionTests {
-  @Test("parses a scalar function's name, parameters, return, and body")
-  func full() throws {
+  @Test func `parses a scalar function's name, parameters, return, and body`() throws {
     let (name, function) = try parse(function: """
         CREATE FUNCTION twice(n INTEGER) RETURNS INTEGER AS n + n
         """)
@@ -908,8 +816,7 @@ struct CreateFunctionTests {
     #expect(function.body == .binary(.add, .column("n"), .column("n")))
   }
 
-  @Test("parses several typed parameters in order")
-  func parameters() throws {
+  @Test func `parses several typed parameters in order`() throws {
     let (_, function) = try parse(function: """
         CREATE FUNCTION f(a INTEGER, b TEXT, c BOOLEAN) RETURNS TEXT AS b
         """)
@@ -921,8 +828,7 @@ struct CreateFunctionTests {
     #expect(function.returns == .text)
   }
 
-  @Test("parses a parameterless function over a literal body")
-  func nullary() throws {
+  @Test func `parses a parameterless function over a literal body`() throws {
     let (name, function) = try parse(function: """
         CREATE FUNCTION answer() RETURNS INTEGER AS 42
         """)
@@ -931,8 +837,7 @@ struct CreateFunctionTests {
     #expect(function.body == .literal(.integer(42)))
   }
 
-  @Test("maps the ISO type spellings onto value types")
-  func types() throws {
+  @Test func `maps the ISO type spellings onto value types`() throws {
     let (_, function) = try parse(function: """
         CREATE FUNCTION f(a INT, b REAL, c VARCHAR, d BOOL, e BLOB) \
         RETURNS DOUBLE AS b
@@ -942,8 +847,7 @@ struct CreateFunctionTests {
     #expect(function.returns == .double)
   }
 
-  @Test("parses lowercase CREATE FUNCTION keywords")
-  func caseInsensitive() throws {
+  @Test func `parses lowercase CREATE FUNCTION keywords`() throws {
     let (name, function) = try parse(function: """
         create function f(n integer) returns integer as n
         """)
@@ -951,16 +855,14 @@ struct CreateFunctionTests {
     #expect(function.returns == .integer)
   }
 
-  @Test("rejects a duplicate parameter name")
-  func duplicateParameter() {
+  @Test func `rejects a duplicate parameter name`() {
     #expect(throws: SQLError.duplicate("n")) {
       _ = try Statement(
           parsing: "CREATE FUNCTION f(n INTEGER, n TEXT) RETURNS INTEGER AS n")
     }
   }
 
-  @Test("rejects a case-insensitive duplicate parameter name")
-  func duplicateParameterFolded() {
+  @Test func `rejects a case-insensitive duplicate parameter name`() {
     // The offending (later) spelling is reported, matching the explicit
     // view-column duplicate fault (`CREATE VIEW v (X, x)` reports `x`).
     #expect(throws: SQLError.duplicate("n")) {
@@ -969,16 +871,14 @@ struct CreateFunctionTests {
     }
   }
 
-  @Test("rejects an unknown type spelling")
-  func unknownType() {
+  @Test func `rejects an unknown type spelling`() {
     #expect(throws: SQLError.self) {
       _ = try Statement(
           parsing: "CREATE FUNCTION f(n WIDGET) RETURNS INTEGER AS n")
     }
   }
 
-  @Test("rejects a function with no RETURNS clause")
-  func missingReturns() {
+  @Test func `rejects a function with no RETURNS clause`() {
     #expect(throws: SQLError.self) {
       _ = try Statement(parsing: "CREATE FUNCTION f(n INTEGER) AS n")
     }
@@ -997,24 +897,21 @@ private func parse(query text: String) throws -> Query {
 }
 
 struct UnionTests {
-  @Test("parses UNION into a deduplicating union of two selects")
-  func union() throws {
+  @Test func `parses UNION into a deduplicating union of two selects`() throws {
     let query = try parse(query: "SELECT a FROM t UNION SELECT b FROM u")
     let left = Select(projection: .columns(["a"]), from: Relation(name: "t"))
     let right = Select(projection: .columns(["b"]), from: Relation(name: "u"))
     #expect(query == .union(.select(left), right, all: false))
   }
 
-  @Test("parses UNION ALL into a duplicate-keeping union")
-  func all() throws {
+  @Test func `parses UNION ALL into a duplicate-keeping union`() throws {
     let query = try parse(query: "SELECT a FROM t UNION ALL SELECT b FROM u")
     let left = Select(projection: .columns(["a"]), from: Relation(name: "t"))
     let right = Select(projection: .columns(["b"]), from: Relation(name: "u"))
     #expect(query == .union(.select(left), right, all: true))
   }
 
-  @Test("nests a chain of UNIONs left-associatively in source order")
-  func chain() throws {
+  @Test func `nests a chain of UNIONs left-associatively in source order`() throws {
     let query = try parse(query:
         "SELECT a FROM t UNION SELECT b FROM u UNION ALL SELECT c FROM v")
     let a = Select(projection: .columns(["a"]), from: Relation(name: "t"))
@@ -1023,16 +920,14 @@ struct UnionTests {
     #expect(query == .union(.union(.select(a), b, all: false), c, all: true))
   }
 
-  @Test("recognises lowercase union and all keywords")
-  func caseInsensitive() throws {
+  @Test func `recognises lowercase union and all keywords`() throws {
     let query = try parse(query: "select a from t union all select b from u")
     let left = Select(projection: .columns(["a"]), from: Relation(name: "t"))
     let right = Select(projection: .columns(["b"]), from: Relation(name: "u"))
     #expect(query == .union(.select(left), right, all: true))
   }
 
-  @Test("a CREATE VIEW over a UNION stores the query and the first arm's names")
-  func view() throws {
+  @Test func `a CREATE VIEW over a UNION stores the query and the first arm's names`() throws {
     let (name, view) = try parseCreate(
         "CREATE VIEW v AS SELECT a, b FROM t UNION SELECT c, d FROM u")
     let left = Select(projection: .columns(["a", "b"]),
@@ -1057,8 +952,7 @@ private func parseWith(_ text: String) throws -> (Array<CTE>, Query) {
 }
 
 struct WithTests {
-  @Test("parses a single non-recursive CTE and its trailing query")
-  func single() throws {
+  @Test func `parses a single non-recursive CTE and its trailing query`() throws {
     let (ctes, query) = try parseWith("""
         WITH a AS (SELECT x FROM t) SELECT x FROM a
         """)
@@ -1073,24 +967,21 @@ struct WithTests {
                                     from: Relation(name: "a"))))
   }
 
-  @Test("infers a CTE's columns from its query's projection")
-  func inferred() throws {
+  @Test func `infers a CTE's columns from its query's projection`() throws {
     let (ctes, _) = try parseWith("""
         WITH a AS (SELECT p, q FROM t) SELECT p FROM a
         """)
     #expect(ctes[0].columns == ["p", "q"])
   }
 
-  @Test("an explicit column list names a CTE's columns")
-  func explicit() throws {
+  @Test func `an explicit column list names a CTE's columns`() throws {
     let (ctes, _) = try parseWith("""
         WITH a (k, v) AS (SELECT p, q FROM t) SELECT k FROM a
         """)
     #expect(ctes[0].columns == ["k", "v"])
   }
 
-  @Test("parses several comma-separated CTEs in source order")
-  func chain() throws {
+  @Test func `parses several comma-separated CTEs in source order`() throws {
     let (ctes, query) = try parseWith("""
         WITH a AS (SELECT x FROM t), b AS (SELECT y FROM a) SELECT y FROM b
         """)
@@ -1102,8 +993,7 @@ struct WithTests {
                                     from: Relation(name: "b"))))
   }
 
-  @Test("RECURSIVE marks every CTE of the list recursive")
-  func recursive() throws {
+  @Test func `RECURSIVE marks every CTE of the list recursive`() throws {
     let (ctes, _) = try parseWith("""
         WITH RECURSIVE a (n) AS (SELECT n FROM seed UNION ALL SELECT n FROM a)
           SELECT n FROM a
@@ -1116,8 +1006,7 @@ struct WithTests {
     }
   }
 
-  @Test("a CTE's query may itself be a UNION")
-  func union() throws {
+  @Test func `a CTE's query may itself be a UNION`() throws {
     let (ctes, _) = try parseWith("""
         WITH a AS (SELECT x FROM t UNION SELECT y FROM u) SELECT x FROM a
         """)
@@ -1126,8 +1015,7 @@ struct WithTests {
     #expect(ctes[0].query == .union(.select(left), right, all: false))
   }
 
-  @Test("recognises lowercase with and recursive keywords")
-  func caseInsensitive() throws {
+  @Test func `recognises lowercase with and recursive keywords`() throws {
     let (ctes, query) = try parseWith("""
         with recursive a (n) as (select n from a) select n from a
         """)
@@ -1137,8 +1025,7 @@ struct WithTests {
                                     from: Relation(name: "a"))))
   }
 
-  @Test("an explicit list of the wrong arity is rejected")
-  func arity() throws {
+  @Test func `an explicit list of the wrong arity is rejected`() throws {
     #expect(throws: SQLError.columns(expected: 2, got: 3)) {
       _ = try parseWith("""
           WITH a (x, y, z) AS (SELECT p, q FROM t) SELECT x FROM a
@@ -1146,22 +1033,19 @@ struct WithTests {
     }
   }
 
-  @Test("a CTE naming two columns that collide by case is rejected")
-  func duplicate() throws {
+  @Test func `a CTE naming two columns that collide by case is rejected`() throws {
     #expect(throws: SQLError.duplicate("X")) {
       _ = try parseWith("WITH a (x, X) AS (SELECT p, q FROM t) SELECT x FROM a")
     }
   }
 
-  @Test("a CTE projecting an un-nameable column with no list is rejected")
-  func unnamed() throws {
+  @Test func `a CTE projecting an un-nameable column with no list is rejected`() throws {
     #expect(throws: SQLError.named("SELECT *")) {
       _ = try parseWith("WITH a AS (SELECT * FROM t) SELECT x FROM a")
     }
   }
 
-  @Test("a CTE missing its parenthesised query is rejected")
-  func missingParen() throws {
+  @Test func `a CTE missing its parenthesised query is rejected`() throws {
     #expect(throws: SQLError.self) {
       _ = try parseWith("WITH a AS SELECT x FROM t SELECT x FROM a")
     }

--- a/Tests/SQLTests/ValueTypeTests.swift
+++ b/Tests/SQLTests/ValueTypeTests.swift
@@ -35,23 +35,20 @@ private func compare(_ cell: Value, _ op: Comparison,
 
 @Suite("BOOLEAN value type")
 private struct BooleanTests {
-  @Test("false orders before true")
-  func ordering() {
+  @Test func `false orders before true`() {
     #expect(compare(.boolean(false), .lt, .boolean(true)) == true)
     #expect(compare(.boolean(true), .lt, .boolean(false)) == false)
     #expect(compare(.boolean(false), .lt, .boolean(false)) == false)
     #expect(compare(.boolean(true), .gt, .boolean(false)) == true)
   }
 
-  @Test("like booleans compare equal")
-  func equality() {
+  @Test func `like booleans compare equal`() {
     #expect(compare(.boolean(true), .equal, .boolean(true)) == true)
     #expect(compare(.boolean(true), .equal, .boolean(false)) == false)
     #expect(compare(.boolean(false), .unequal, .boolean(true)) == true)
   }
 
-  @Test("the boundary relations follow the false < true order")
-  func boundaries() {
+  @Test func `the boundary relations follow the false < true order`() {
     #expect(compare(.boolean(false), .leq, .boolean(false)) == true)
     #expect(compare(.boolean(false), .leq, .boolean(true)) == true)
     #expect(compare(.boolean(true), .leq, .boolean(false)) == false)
@@ -64,8 +61,7 @@ private struct BooleanTests {
 
 @Suite("BLOB value type")
 private struct BlobTests {
-  @Test("like blobs compare by byte equality")
-  func equality() {
+  @Test func `like blobs compare by byte equality`() {
     #expect(compare(.blob([0x53, 0x51, 0x4c]), .equal,
                     .blob([0x53, 0x51, 0x4c])) == true)
     #expect(compare(.blob([0x53, 0x51, 0x4c]), .equal,
@@ -74,8 +70,7 @@ private struct BlobTests {
     #expect(compare(.blob([0x00]), .unequal, .blob([])) == true)
   }
 
-  @Test("blobs order lexicographically — memcmp over the bytes")
-  func ordering() {
+  @Test func `blobs order lexicographically — memcmp over the bytes`() {
     // A byte difference decides: `0x01` < `0x02`.
     #expect(compare(.blob([0x01]), .lt, .blob([0x02])) == true)
     #expect(compare(.blob([0x02]), .lt, .blob([0x01])) == false)
@@ -86,8 +81,7 @@ private struct BlobTests {
     #expect(compare(.blob([0x02]), .gt, .blob([0x01, 0xff])) == true)
   }
 
-  @Test("the boundary relations follow the lexicographic order")
-  func boundaries() {
+  @Test func `the boundary relations follow the lexicographic order`() {
     #expect(compare(.blob([0x01]), .leq, .blob([0x01])) == true)
     #expect(compare(.blob([0x01]), .leq, .blob([0x02])) == true)
     #expect(compare(.blob([0x02]), .leq, .blob([0x01])) == false)
@@ -100,8 +94,7 @@ private struct BlobTests {
 
 @Suite("cross-type comparison")
 private struct CrossTypeTests {
-  @Test("unlike types never match — no coercion")
-  func mismatch() {
+  @Test func `unlike types never match — no coercion`() {
     // Every non-null cross-type pair falls to the switch's `default: false`.
     #expect(compare(.boolean(true), .equal, .integer(1)) == false)
     #expect(compare(.integer(1), .equal, .boolean(true)) == false)
@@ -112,8 +105,7 @@ private struct CrossTypeTests {
     #expect(compare(.boolean(true), .lt, .text("z")) == false)
   }
 
-  @Test("a NULL operand is UNKNOWN, not false")
-  func null() {
+  @Test func `a NULL operand is UNKNOWN, not false`() {
     #expect(compare(.boolean(true), .equal, .null) == nil)
     #expect(compare(.blob([0x01]), .lt, .null) == nil)
   }

--- a/Tests/WinMDSynthesisTests/DecodeTests.swift
+++ b/Tests/WinMDSynthesisTests/DecodeTests.swift
@@ -50,8 +50,7 @@ struct DecodeTests {
   // The Swift dialect every case spells against.
   private var dialect: Dialect { .swift }
 
-  @Test("a primitive decodes to its C typealias spelling")
-  func primitives() {
+  @Test func `a primitive decodes to its C typealias spelling`() {
     let cases: Array<(PrimitiveType, String)> = [
       (.void, "Void"),
       (.boolean, "CBool"),
@@ -75,8 +74,7 @@ struct DecodeTests {
     }
   }
 
-  @Test("a pointer wraps its decoded pointee")
-  func pointers() {
+  @Test func `a pointer wraps its decoded pointee`() {
     #expect(SignatureType.pointer(.primitive(.void))
                 .decode(with: resolver, dialect: dialect)
                 == "UnsafeMutableRawPointer")
@@ -93,16 +91,14 @@ struct DecodeTests {
                 == "UnsafeMutablePointer<Unicode.UTF16.CodeUnit>")
   }
 
-  @Test("a generic variable decodes to a T/M-prefixed placeholder")
-  func variables() {
+  @Test func `a generic variable decodes to a T/M-prefixed placeholder`() {
     #expect(SignatureType.variable(scope: .type, 0)
                 .decode(with: resolver, dialect: dialect) == "T0")
     #expect(SignatureType.variable(scope: .method, 2)
                 .decode(with: resolver, dialect: dialect) == "M2")
   }
 
-  @Test("only an IsConst custom modifier marks a pointee const")
-  func modifiers() {
+  @Test func `only an IsConst custom modifier marks a pointee const`() {
     // Two modifier-type references: one resolves to `IsConst`, the other to an
     // unrelated type. Only the former may flip the pointer to immutable.
     let marker = TypeDefOrRef(rawValue: 1)
@@ -129,8 +125,7 @@ struct DecodeTests {
                 == "UnsafeMutablePointer<CInt>")
   }
 
-  @Test("a generic instantiation strips the CLR arity from its base name")
-  func genericInstance() {
+  @Test func `a generic instantiation strips the CLR arity from its base name`() {
     let reference = TypeDefOrRef(rawValue: 1)
     let resolver = Resolver([
       reference.rawValue: Identity(namespace: "Windows.Foundation",
@@ -144,8 +139,7 @@ struct DecodeTests {
                 == "IReference<CInt>")
   }
 
-  @Test("a generic over an unresolved base degrades to the opaque pointer")
-  func unresolvedGenericBase() {
+  @Test func `a generic over an unresolved base degrades to the opaque pointer`() {
     // The base reference resolves to nothing (e.g. a TypeSpec with no
     // identity): the empty resolver leaves it unresolved.
     let base = TypeDefOrRef(rawValue: 1)
@@ -155,8 +149,7 @@ struct DecodeTests {
                 == "UnsafeMutableRawPointer")
   }
 
-  @Test("a named type whose simple name is a keyword is escaped")
-  func keywordNamedType() {
+  @Test func `a named type whose simple name is a keyword is escaped`() {
     // A metadata type whose simple name collides with a target keyword
     // (`protocol`, `repeat`, …) spells escaped, like a declaration name, so a
     // parameter or return of that type still compiles.
@@ -168,8 +161,7 @@ struct DecodeTests {
                 .decode(with: resolver, dialect: dialect) == "`protocol`")
   }
 
-  @Test("a generic base is escaped after its CLR arity is stripped")
-  func keywordGenericBase() {
+  @Test func `a generic base is escaped after its CLR arity is stripped`() {
     // The generic definition's name carries the arity suffix (`protocol``1`),
     // so it matches no keyword until the suffix is stripped; the base must be
     // escaped after the strip, not before, or it spells `protocol<CInt>`.
@@ -183,8 +175,7 @@ struct DecodeTests {
                 == "`protocol`<CInt>")
   }
 
-  @Test("a generic argument keeps the parameter-name class-ID hint")
-  func genericArgumentHint() {
+  @Test func `a generic argument keeps the parameter-name class-ID hint`() {
     let base = TypeDefOrRef(rawValue: 1)
     let guid = TypeDefOrRef(rawValue: 2)
     let resolver = Resolver([
@@ -204,8 +195,7 @@ struct DecodeTests {
                 == "IReference<IID>")
   }
 
-  @Test("a non-void pointer-to-pointer keeps the optional inner slot")
-  func doublePointer() {
+  @Test func `a non-void pointer-to-pointer keeps the optional inner slot`() {
     let marker = TypeDefOrRef(rawValue: 1)
     let foo = TypeDefOrRef(rawValue: 2)
     let resolver = Resolver([
@@ -232,8 +222,7 @@ struct DecodeTests {
                 == "UnsafeMutablePointer<UnsafeMutablePointer<IFoo>?>")
   }
 
-  @Test("a const void-pointer pointee honors const")
-  func constVoidPointer() {
+  @Test func `a const void-pointer pointee honors const`() {
     let marker = TypeDefOrRef(rawValue: 1)
     let resolver = Resolver([
       marker.rawValue: Identity(namespace: "System.Runtime.CompilerServices",
@@ -248,8 +237,7 @@ struct DecodeTests {
                 == "UnsafePointer<UnsafeMutableRawPointer?>")
   }
 
-  @Test("a pointer to a const void pointer keeps the optional raw slot")
-  func constVoidPointerPointee() {
+  @Test func `a pointer to a const void pointer keeps the optional raw slot`() {
     let marker = TypeDefOrRef(rawValue: 1)
     let resolver = Resolver([
       marker.rawValue: Identity(namespace: "System.Runtime.CompilerServices",

--- a/Tests/WinMDSynthesisTests/ResolverTests.swift
+++ b/Tests/WinMDSynthesisTests/ResolverTests.swift
@@ -37,8 +37,7 @@ struct IdentityTests {
     0x00, 0x00, 0xFF, 0x00, 0x01, 0x00,
   ]
 
-  @Test("reads a TypeRef's namespace and name as an Identity")
-  func typeRefIdentity() throws {
+  @Test func `reads a TypeRef's namespace and name as an Identity`() throws {
     let storage = Storage(bytes: IdentityTests.record.span.bytes,
                           relations: IdentityTests.relations.span,
                           strings: IdentityTests.strings.span.bytes,
@@ -50,8 +49,7 @@ struct IdentityTests {
     #expect(identity == Identity(namespace: "System", name: "Guid"))
   }
 
-  @Test("a malformed name offset propagates a WinMDError")
-  func malformedIdentity() {
+  @Test func `a malformed name offset propagates a WinMDError`() {
     let storage = Storage(bytes: IdentityTests.malformed.span.bytes,
                           relations: IdentityTests.relations.span,
                           strings: IdentityTests.strings.span.bytes,

--- a/Tests/WinMDTests/AttributeTests.swift
+++ b/Tests/WinMDTests/AttributeTests.swift
@@ -22,16 +22,14 @@ struct AttributeTests {
     0x00, 0x00,                                      // NumNamed (no named args)
   ]
 
-  @Test("decodes IUnknown's IID")
-  func iunknown() throws {
+  @Test func `decodes IUnknown's IID`() throws {
     let bytes = unknown
     var decoder = AttributeDecoder(bytes.span.bytes)
     let guid = try decoder.guid()
     #expect("\(guid)" == "00000000-0000-0000-C000-000000000046")
   }
 
-  @Test("decodes a fully-populated GUID, fields little-endian")
-  func populated() throws {
+  @Test func `decodes a fully-populated GUID, fields little-endian`() throws {
     // The well-known `ISequentialStream` IID exercises every field: data1/2/3
     // are little-endian, the data4 tail is in order.
     let bytes: Array<UInt8> = [
@@ -47,15 +45,13 @@ struct AttributeTests {
     #expect("\(guid)" == "0C733A30-2A1C-11CE-ADE5-00AA0044773D")
   }
 
-  @Test("renders the canonical uppercase, zero-padded spelling")
-  func description() {
+  @Test func `renders the canonical uppercase, zero-padded spelling`() {
     let guid = UUID(uuid: (0x00, 0x00, 0x00, 0x01, 0x00, 0x02, 0x00, 0x03,
                            0x00, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a))
     #expect("\(guid)" == "00000001-0002-0003-0004-05060708090A")
   }
 
-  @Test("rejects a blob without the 0x0001 prolog")
-  func badProlog() {
+  @Test func `rejects a blob without the 0x0001 prolog`() {
     let bytes: Array<UInt8> = [
       0x00, 0x00,                                      // wrong prolog
       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -67,8 +63,7 @@ struct AttributeTests {
     }
   }
 
-  @Test("rejects a blob too short for the GUID")
-  func truncated() {
+  @Test func `rejects a blob too short for the GUID`() {
     // The prolog and data1, then the blob ends before data2/data3/data4.
     let bytes: Array<UInt8> = [0x01, 0x00, 0x00, 0x00, 0x00, 0x00]
     var decoder = AttributeDecoder(bytes.span.bytes)
@@ -77,8 +72,7 @@ struct AttributeTests {
     }
   }
 
-  @Test("rejects an empty blob")
-  func empty() {
+  @Test func `rejects an empty blob`() {
     let bytes = Array<UInt8>()
     var decoder = AttributeDecoder(bytes.span.bytes)
     #expect(throws: WinMDError.BadImageFormat) {
@@ -86,8 +80,7 @@ struct AttributeTests {
     }
   }
 
-  @Test("rejects a blob missing the NumNamed count")
-  func missingNumNamed() {
+  @Test func `rejects a blob missing the NumNamed count`() {
     // The prolog and a full GUID, but the blob ends before the mandatory
     // 2-byte `NumNamed` count (ECMA-335 §II.23.3).
     let bytes: Array<UInt8> = [
@@ -103,8 +96,7 @@ struct AttributeTests {
     }
   }
 
-  @Test("rejects a blob with a non-zero NumNamed count")
-  func namedArguments() {
+  @Test func `rejects a blob with a non-zero NumNamed count`() {
     // A `[Guid]` has no named arguments, so `NumNamed` must be 0; a non-zero
     // count is malformed for this attribute (ECMA-335 §II.23.3).
     let bytes: Array<UInt8> = [

--- a/Tests/WinMDTests/BlobsHeapTests.swift
+++ b/Tests/WinMDTests/BlobsHeapTests.swift
@@ -12,8 +12,7 @@ struct BlobsHeapTests {
     prefix + Array(repeating: fill, count: count)
   }
 
-  @Test("reads a single-byte compressed length")
-  func singleByteLength() {
+  @Test func `reads a single-byte compressed length`() {
     let bytes = buffer(prefix: [0x03], count: 3)
     let heap = BlobsHeap(bytes.span.bytes)
     #expect(heap[0].count == 3)
@@ -22,8 +21,7 @@ struct BlobsHeapTests {
   // A length of 0x20...0x7F is held in a single byte (high bit clear). The
   // previous `first & 0xE0` discriminator mis-routed these to the 2-byte form
   // (0x40...0x5F) or rejected them outright (0x20...0x3F, 0x60...0x7F).
-  @Test("reads single-byte lengths across the high-bit boundary")
-  func singleByteLengthBoundary() {
+  @Test func `reads single-byte lengths across the high-bit boundary`() {
     for length in [0x20, 0x40, 0x5f, 0x7f] {
       let bytes = buffer(prefix: [UInt8(length)], count: length)
       let heap = BlobsHeap(bytes.span.bytes)
@@ -32,23 +30,20 @@ struct BlobsHeapTests {
   }
 
   // 0x80...0x3FFF is held in two bytes (top two bits "10").
-  @Test("reads a two-byte compressed length")
-  func twoByteLength() {
+  @Test func `reads a two-byte compressed length`() {
     let bytes = buffer(prefix: [0x81, 0x00], count: 0x100)
     let heap = BlobsHeap(bytes.span.bytes)
     #expect(heap[0].count == 0x100)
   }
 
   // 0x4000... is held in four bytes (top three bits "110").
-  @Test("reads a four-byte compressed length")
-  func fourByteLength() {
+  @Test func `reads a four-byte compressed length`() {
     let bytes = buffer(prefix: [0xc0, 0x00, 0x40, 0x00], count: 0x4000)
     let heap = BlobsHeap(bytes.span.bytes)
     #expect(heap[0].count == 0x4000)
   }
 
-  @Test("exposes the blob payload bytes")
-  func contents() {
+  @Test func `exposes the blob payload bytes`() {
     let bytes = buffer(prefix: [0x04], count: 4, fill: 0xcd)
     let heap = BlobsHeap(bytes.span.bytes)
     let blob = heap[0]

--- a/Tests/WinMDTests/CodedIndexTests.swift
+++ b/Tests/WinMDTests/CodedIndexTests.swift
@@ -11,8 +11,7 @@ extension CodedIndex {
 }
 
 struct CodedIndexTests {
-  @Test("each coded index has the expected tag bit width")
-  func widths() {
+  @Test func `each coded index has the expected tag bit width`() {
     #expect(TypeDefOrRef.discriminatorBitWidth == 2)
     #expect(HasConstant.discriminatorBitWidth == 2)
     #expect(HasCustomAttribute.discriminatorBitWidth == 5)
@@ -28,8 +27,7 @@ struct CodedIndexTests {
     #expect(TypeOrMethodDef.discriminatorBitWidth == 1)
   }
 
-  @Test("derives tag width from the table count, not its popcount")
-  func tagBits() {
+  @Test func `derives tag width from the table count, not its popcount`() {
     // `PhysicalSchema.width(of:)` selects the coded-index width from the tag
     // width. It once derived that from the population count of the table count,
     // which is only `ceil(log2(n))` when `n` is a power of two; for the others
@@ -40,104 +38,91 @@ struct CodedIndexTests {
     #expect(HasCustomAttribute.bits == 5)  // 22 tables; popcount(21) is 3
   }
 
-  @Test("splits a TypeDefOrRef into tag and row")
-  func typeDefOrRef() {
+  @Test func `splits a TypeDefOrRef into tag and row`() {
     let index = TypeDefOrRef(rawValue: 909)
     #expect(index.tag == 1)
     #expect(index.row == 227)
     #expect(index.debugDescription == "TypeRef Row 227")
   }
 
-  @Test("splits a HasConstant into tag and row")
-  func hasConstant() {
+  @Test func `splits a HasConstant into tag and row`() {
     let index = HasConstant(rawValue: 909)
     #expect(index.tag == 1)
     #expect(index.row == 227)
     #expect(index.debugDescription == "Param Row 227")
   }
 
-  @Test("splits a HasCustomAttribute into tag and row")
-  func hasCustomAttribute() {
+  @Test func `splits a HasCustomAttribute into tag and row`() {
     let index = HasCustomAttribute(rawValue: 909)
     #expect(index.tag == 13)
     #expect(index.row == 28)
     #expect(index.debugDescription == "TypeSpec Row 28")
   }
 
-  @Test("splits a HasFieldMarshal into tag and row")
-  func hasFieldMarshal() {
+  @Test func `splits a HasFieldMarshal into tag and row`() {
     let index = HasFieldMarshal(rawValue: 909)
     #expect(index.tag == 1)
     #expect(index.row == 454)
     #expect(index.debugDescription == "Param Row 454")
   }
 
-  @Test("splits a HasDeclSecurity into tag and row")
-  func hasDeclSecurity() {
+  @Test func `splits a HasDeclSecurity into tag and row`() {
     let index = HasDeclSecurity(rawValue: 909)
     #expect(index.tag == 1)
     #expect(index.row == 227)
     #expect(index.debugDescription == "MethodDef Row 227")
   }
 
-  @Test("splits a MemberRefParent into tag and row")
-  func memberRefParent() {
+  @Test func `splits a MemberRefParent into tag and row`() {
     let index = MemberRefParent(rawValue: 908)
     #expect(index.tag == 4)
     #expect(index.row == 113)
     #expect(index.debugDescription == "TypeSpec Row 113")
   }
 
-  @Test("splits a HasSemantics into tag and row")
-  func hasSemantics() {
+  @Test func `splits a HasSemantics into tag and row`() {
     let index = HasSemantics(rawValue: 909)
     #expect(index.tag == 1)
     #expect(index.row == 454)
     #expect(index.debugDescription == "PropertyDef Row 454")
   }
 
-  @Test("splits a MethodDefOrRef into tag and row")
-  func methodDefOrRef() {
+  @Test func `splits a MethodDefOrRef into tag and row`() {
     let index = MethodDefOrRef(rawValue: 909)
     #expect(index.tag == 1)
     #expect(index.row == 454)
     #expect(index.debugDescription == "MemberRef Row 454")
   }
 
-  @Test("splits a MemberForwarded into tag and row")
-  func memberForwarded() {
+  @Test func `splits a MemberForwarded into tag and row`() {
     let index = MemberForwarded(rawValue: 909)
     #expect(index.tag == 1)
     #expect(index.row == 454)
     #expect(index.debugDescription == "MethodDef Row 454")
   }
 
-  @Test("splits an Implementation into tag and row")
-  func implementation() {
+  @Test func `splits an Implementation into tag and row`() {
     let index = Implementation(rawValue: 909)
     #expect(index.tag == 1)
     #expect(index.row == 227)
     #expect(index.debugDescription == "AssemblyRef Row 227")
   }
 
-  @Test("splits a CustomAttributeType into tag and row")
-  func customAttributeType() {
+  @Test func `splits a CustomAttributeType into tag and row`() {
     let index = CustomAttributeType(rawValue: 906)
     #expect(index.tag == 2)
     #expect(index.row == 113)
     #expect(index.debugDescription == "MethodDef Row 113")
   }
 
-  @Test("splits a ResolutionScope into tag and row")
-  func resolutionScope() {
+  @Test func `splits a ResolutionScope into tag and row`() {
     let index = ResolutionScope(rawValue: 909)
     #expect(index.tag == 1)
     #expect(index.row == 227)
     #expect(index.debugDescription == "ModuleRef Row 227")
   }
 
-  @Test("splits a TypeOrMethodDef into tag and row")
-  func typeOrMethodDef() {
+  @Test func `splits a TypeOrMethodDef into tag and row`() {
     let index = TypeOrMethodDef(rawValue: 909)
     #expect(index.tag == 1)
     #expect(index.row == 454)

--- a/Tests/WinMDTests/FieldTests.swift
+++ b/Tests/WinMDTests/FieldTests.swift
@@ -56,8 +56,7 @@ struct FieldTests {
     try body(storage)
   }
 
-  @Test("reads typed values through Column tokens")
-  func tokenReads() throws {
+  @Test func `reads typed values through Column tokens`() throws {
     try FieldTests.with { storage in
       let table = FieldTests.relations[0]
       let row = Row<Metadata.Tables.TypeDef>(0, table, storage)
@@ -80,8 +79,7 @@ struct FieldTests {
     }
   }
 
-  @Test("filters and projects typed rows with where and select")
-  func whereSelect() throws {
+  @Test func `filters and projects typed rows with where and select`() throws {
     try FieldTests.with { storage in
       let iterator =
           try storage.rows(of: Metadata.Tables.TypeDef.self)
@@ -95,8 +93,7 @@ struct FieldTests {
     }
   }
 
-  @Test("filters typed rows with a value predicate")
-  func wherePredicate() throws {
+  @Test func `filters typed rows with a value predicate`() throws {
     try FieldTests.with { storage in
       let iterator =
           try storage.rows(of: Metadata.Tables.TypeDef.self)
@@ -110,8 +107,7 @@ struct FieldTests {
     }
   }
 
-  @Test("projects the first row matching a typed predicate")
-  func firstProjection() throws {
+  @Test func `projects the first row matching a typed predicate`() throws {
     try FieldTests.with { storage in
       let iterator =
           try storage.rows(of: Metadata.Tables.TypeDef.self)

--- a/Tests/WinMDTests/GUIDHeapTests.swift
+++ b/Tests/WinMDTests/GUIDHeapTests.swift
@@ -12,8 +12,7 @@ struct GUIDHeapTests {
     0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
   ]
 
-  @Test("reads a GUID by 1-based index and rejects index 0")
-  func subscriptAccess() throws {
+  @Test func `reads a GUID by 1-based index and rejects index 0`() throws {
     let bytes = GUIDHeapTests.heap
     let guids = GUIDHeap(bytes.span.bytes)
     #expect(throws: WinMDError.InvalidIndex) {

--- a/Tests/WinMDTests/NavigationTests.swift
+++ b/Tests/WinMDTests/NavigationTests.swift
@@ -63,8 +63,7 @@ struct NavigationTests {
     try body(storage)
   }
 
-  @Test("resolves a simple-index token to a typed row")
-  func simpleResolution() throws {
+  @Test func `resolves a simple-index token to a typed row`() throws {
     try NavigationTests.with { storage in
       // NestedClass[0].NestedClass is a simple `TypeDef` index; the token
       // resolve lands on the typed `Row<TypeDef>` it names.
@@ -78,8 +77,7 @@ struct NavigationTests {
     }
   }
 
-  @Test("resolves a null simple-index token to nothing")
-  func nullSimpleResolution() throws {
+  @Test func `resolves a null simple-index token to nothing`() throws {
     try NavigationTests.with { storage in
       // The reframed `EnclosingClass` accessor is non-optional; the underlying
       // token resolve is optional and non-nil for a live reference.
@@ -92,8 +90,7 @@ struct NavigationTests {
     }
   }
 
-  @Test("resolves a coded-index token to a type-erased tuple")
-  func codedResolution() throws {
+  @Test func `resolves a coded-index token to a type-erased tuple`() throws {
     try NavigationTests.with { storage in
       // TypeDef[0].Extends is a `TypeDefOrRef` coded index whose tag selects
       // the `TypeRef` table; the token resolve yields the type-erased tuple.
@@ -107,8 +104,7 @@ struct NavigationTests {
     }
   }
 
-  @Test("resolves a null coded-index token to nothing")
-  func nullCodedResolution() throws {
+  @Test func `resolves a null coded-index token to nothing`() throws {
     try NavigationTests.with { storage in
       // TypeDef[1].Extends is the null reference (coded row 0).
       let source = Row<Metadata.Tables.TypeDef>(1,
@@ -120,8 +116,7 @@ struct NavigationTests {
     }
   }
 
-  @Test("narrows a coded resolution to the target with Row(_:)")
-  func typedRoundTrip() throws {
+  @Test func `narrows a coded resolution to the target with Row(_:)`() throws {
     try NavigationTests.with { storage in
       let source = Row<Metadata.Tables.TypeDef>(0,
                                                 NavigationTests.relations[1],
@@ -139,8 +134,7 @@ struct NavigationTests {
     }
   }
 
-  @Test("rejects a Row(_:) narrowing to the wrong table")
-  func typedMismatch() throws {
+  @Test func `rejects a Row(_:) narrowing to the wrong table`() throws {
     try NavigationTests.with { storage in
       let source = Row<Metadata.Tables.TypeDef>(0,
                                                 NavigationTests.relations[1],
@@ -159,8 +153,7 @@ struct NavigationTests {
     }
   }
 
-  @Test("opens a typed list iterator over the run")
-  func listNavigation() throws {
+  @Test func `opens a typed list iterator over the run`() throws {
     try NavigationTests.with { storage in
       // TypeDef[0].FieldList delimits a run ending one before the next row's
       // start, so it yields exactly FieldDef[0] ("string0").
@@ -173,8 +166,7 @@ struct NavigationTests {
     }
   }
 
-  @Test("a typed list run agrees with the reframed accessor")
-  func listAccessorAgrees() throws {
+  @Test func `a typed list run agrees with the reframed accessor`() throws {
     try NavigationTests.with { storage in
       let source = Row<Metadata.Tables.TypeDef>(0,
                                                 NavigationTests.relations[1],
@@ -232,8 +224,7 @@ struct ReverseNavigationTests {
     try body(storage)
   }
 
-  @Test("reverse-navigates a simple-index token to its owners")
-  func simpleReverse() throws {
+  @Test func `reverse-navigates a simple-index token to its owners`() throws {
     // The token names the owning `NestedClass` table and the `NestedClass`
     // ordinal, so the call site needs no schema or ordinal; the rows naming
     // TypeDef[1] are the contiguous run [1, 3).
@@ -248,8 +239,7 @@ struct ReverseNavigationTests {
     }
   }
 
-  @Test("the typed reverse token agrees with the ordinal form")
-  func tokenAgreesWithOrdinal() throws {
+  @Test func `the typed reverse token agrees with the ordinal form`() throws {
     try ReverseNavigationTests.with(0) { storage in
       let target = Row<Metadata.Tables.TypeDef>(1,
                                                 ReverseNavigationTests.relations[0],
@@ -297,8 +287,7 @@ struct ReverseCodedNavigationTests {
 
   private static let valid: UInt64 = (1 << 2) | (1 << 12)
 
-  @Test("reverse-navigates a coded-index token to its owners")
-  func codedReverse() throws {
+  @Test func `reverse-navigates a coded-index token to its owners`() throws {
     // CustomAttribute is left unsorted, so the typed reverse lookup scans; the
     // rows naming TypeDef[0] through `Parent` are 0 and 2.
     let storage =

--- a/Tests/WinMDTests/PhysicalSchemaTests.swift
+++ b/Tests/WinMDTests/PhysicalSchemaTests.swift
@@ -17,8 +17,7 @@ struct PhysicalSchemaTests {
   // the layout the way the database does — through `relations`, which sizes the
   // `Type` column (column 1, a `CustomAttributeType` coded index) via
   // `PhysicalSchema.width(of:)`.
-  @Test("sizes a coded column with reserved tags by its present targets only")
-  func reservedTagsDoNotWiden() throws {
+  @Test func `sizes a coded column with reserved tags by its present targets only`() throws {
     // Header: Reserved(4), Major(1), Minor(1), HeapSizes(1), Reserved(1),
     // Valid(8), Sorted(8), then a 32-bit row count per present table. The three
     // present tables each carry a single row, comfortably below the compressed

--- a/Tests/WinMDTests/QueryTests.swift
+++ b/Tests/WinMDTests/QueryTests.swift
@@ -54,8 +54,7 @@ struct QueryTests {
     body(storage, table)
   }
 
-  @Test("resolves column ordinals by name")
-  func ordinalResolution() {
+  @Test func `resolves column ordinals by name`() {
     QueryTests.with { tuple in
       #expect(tuple.ordinal(for: "Flags") == 0)
       #expect(tuple.ordinal(for: "TypeName") == 1)
@@ -65,16 +64,14 @@ struct QueryTests {
     }
   }
 
-  @Test("reads string cells through the strings heap")
-  func stringResolution() throws {
+  @Test func `reads string cells through the strings heap`() throws {
     QueryTests.with { tuple in
       #expect((try? tuple.string(1)) == "string0")
       #expect((try? tuple.string(2)) == "string1")
     }
   }
 
-  @Test("throws on a malformed strings-heap entry rather than trapping")
-  func malformedStringEntry() {
+  @Test func `throws on a malformed strings-heap entry rather than trapping`() {
     // A record whose TypeName cell points one past the heap end, and whose
     // TypeNamespace cell points at an unterminated run that reaches the heap
     // end without a NUL. Both must throw `.BadImageFormat` through
@@ -110,8 +107,7 @@ struct QueryTests {
     #expect(throws: WinMDError.BadImageFormat) { _ = try tuple.string(2) }
   }
 
-  @Test("rejects a heap read on the wrong column kind")
-  func heapKindMismatch() {
+  @Test func `rejects a heap read on the wrong column kind`() {
     QueryTests.with { tuple in
       // Field 0 (Flags) is a constant, not a string heap index.
       #expect(throws: WinMDError.InvalidColumn) { _ = try tuple.string(0) }
@@ -123,8 +119,7 @@ struct QueryTests {
     }
   }
 
-  @Test("rejects an out-of-bounds column ordinal without trapping")
-  func ordinalBounds() {
+  @Test func `rejects an out-of-bounds column ordinal without trapping`() {
     QueryTests.with { tuple in
       // The throwing accessors index the schema's fields to recover a column's
       // type, so an ordinal outside `0 ..< count` would trap on that lookup
@@ -146,8 +141,7 @@ struct QueryTests {
     }
   }
 
-  @Test("a scan yields nil for an out-of-range offset on both ends")
-  func scanBounds() {
+  @Test func `a scan yields nil for an out-of-range offset on both ends`() {
     // The `Scan.element(_:)` contract is to return `nil` for any offset
     // outside `0 ..< count`. The subscript the conformances delegate to must
     // reject a negative offset as well as one at or past `count`; a negative

--- a/Tests/WinMDTests/ReferencingTests.swift
+++ b/Tests/WinMDTests/ReferencingTests.swift
@@ -68,8 +68,7 @@ struct ReferencingTests {
     return rows
   }
 
-  @Test("finds the referencing run by binary search when sorted")
-  func sortedBinarySearch() throws {
+  @Test func `finds the referencing run by binary search when sorted`() throws {
     // NestedClass is sorted on its key (ordinal 0), so the run referencing
     // TypeDef[1] is found by binary search: rows 1 and 2.
     try ReferencingTests.with(1 << 41) { storage in
@@ -79,8 +78,7 @@ struct ReferencingTests {
     }
   }
 
-  @Test("falls back to a scan when unsorted and agrees")
-  func unsortedScanAgrees() throws {
+  @Test func `falls back to a scan when unsorted and agrees`() throws {
     // With the `Sorted` bit clear the same query falls back to a linear scan
     // and must return the identical matches.
     try ReferencingTests.with(0) { storage in
@@ -90,8 +88,7 @@ struct ReferencingTests {
     }
   }
 
-  @Test("sorted and scan paths agree for every target")
-  func sortedAndScanAgree() throws {
+  @Test func `sorted and scan paths agree for every target`() throws {
     // Every target row resolves to the same set of owners under both paths.
     for row in 0 ..< 4 {
       var sorted = Array<Int>()
@@ -108,8 +105,7 @@ struct ReferencingTests {
     }
   }
 
-  @Test("yields no owners for an unreferenced target")
-  func zeroMatches() throws {
+  @Test func `yields no owners for an unreferenced target`() throws {
     // TypeDef[2] (stored value 3) is named by no NestedClass row.
     try ReferencingTests.with(1 << 41) { storage in
       let target = Tuple(2, ReferencingTests.relations[0], storage)
@@ -123,8 +119,7 @@ struct ReferencingTests {
     }
   }
 
-  @Test("rejects a reverse lookup by an out-of-range column ordinal")
-  func columnOrdinalOutOfRange() throws {
+  @Test func `rejects a reverse lookup by an out-of-range column ordinal`() throws {
     // A negative ordinal or one at/beyond the owner's column count names no
     // field; `referencing` must throw rather than trap on `schema.fields`.
     ReferencingTests.with(0) { storage in
@@ -143,8 +138,7 @@ struct ReferencingTests {
     }
   }
 
-  @Test("rejects a reverse lookup against the wrong table")
-  func simpleIndexTableMismatch() throws {
+  @Test func `rejects a reverse lookup against the wrong table`() throws {
     // `referencing` by a simple `TypeDef` index against a `NestedClass` target
     // is a usage error: the index does not name that table.
     ReferencingTests.with(0) { storage in
@@ -189,8 +183,7 @@ struct ReferencingCodedTests {
 
   private static let valid: UInt64 = (1 << 2) | (1 << 12)
 
-  @Test("scans an unsorted owner by a coded index")
-  func codedReverseScan() throws {
+  @Test func `scans an unsorted owner by a coded index`() throws {
     // CustomAttribute is left unsorted (`Sorted` clear), so the reverse lookup
     // scans; the rows naming TypeDef[0] through `Parent` are 0 and 2.
     let storage = Storage(bytes: ReferencingCodedTests.record.span.bytes,
@@ -219,8 +212,7 @@ struct ReferencingCodedTests {
   // This locks the Option-A behaviour. Were the reserved slots still the old
   // `Module` placeholders, `tag(of: Module)` would find one (tag 0) and the
   // lookup would silently scan instead of throwing.
-  @Test("rejects a reverse lookup whose target is a reserved coded-index table")
-  func reservedCodedIndexTarget() throws {
+  @Test func `rejects a reverse lookup whose target is a reserved coded-index table`() throws {
     // A single Module row (#0): Generation (constant, 2 bytes) + Name (string) +
     // Mvid + EncId + EncBaseId (guid each), all narrow ⇒ stride 10; cells zero.
     // A single CustomAttribute row (#12, stride 6) follows so the owning table is

--- a/Tests/WinMDTests/RequiredReferenceTests.swift
+++ b/Tests/WinMDTests/RequiredReferenceTests.swift
@@ -29,8 +29,7 @@ struct RequiredReferenceTests {
 
   private static let valid: UInt64 = 1 << 9
 
-  @Test("a null required reference throws rather than traps")
-  func nullRequiredReference() throws {
+  @Test func `a null required reference throws rather than traps`() throws {
     let storage = Storage(bytes: RequiredReferenceTests.record.span.bytes,
                           relations: RequiredReferenceTests.relations.span,
                           strings: RequiredReferenceTests.empty.span.bytes,

--- a/Tests/WinMDTests/ResolveTests.swift
+++ b/Tests/WinMDTests/ResolveTests.swift
@@ -58,8 +58,7 @@ struct ResolveTests {
     try body(storage)
   }
 
-  @Test("resolves a coded foreign key to the referenced row")
-  func codedIndexResolution() throws {
+  @Test func `resolves a coded foreign key to the referenced row`() throws {
     try ResolveTests.with { storage in
       // TypeDef[0] extends TypeRef[0] through `Extends` (ordinal 3), a
       // `TypeDefOrRef` coded index whose tag selects the `TypeRef` table.
@@ -75,8 +74,7 @@ struct ResolveTests {
     }
   }
 
-  @Test("resolves a simple index to the referenced row")
-  func simpleIndexResolution() throws {
+  @Test func `resolves a simple index to the referenced row`() throws {
     try ResolveTests.with { storage in
       // NestedClass[0].NestedClass (ordinal 0) is a simple `TypeDef` index;
       // resolving it lands on the six-column TypeDef row it names.
@@ -91,8 +89,7 @@ struct ResolveTests {
     }
   }
 
-  @Test("resolves a null reference to nothing")
-  func nullReference() throws {
+  @Test func `resolves a null reference to nothing`() throws {
     try ResolveTests.with { storage in
       // TypeDef[1].Extends is the null reference (coded row 0), so it resolves
       // to nothing.
@@ -102,8 +99,7 @@ struct ResolveTests {
     }
   }
 
-  @Test("rejects resolving a non-foreign-key column")
-  func columnKindMismatch() throws {
+  @Test func `rejects resolving a non-foreign-key column`() throws {
     ResolveTests.with { storage in
       let source = Tuple(0, ResolveTests.relations[1], storage)
       // Flags (ordinal 0) is a constant and TypeName (ordinal 1) is a string
@@ -123,8 +119,7 @@ struct ResolveTests {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00,
   ]
 
-  @Test("rejects a coded foreign key whose tag is out of range")
-  func codedIndexBadTag() throws {
+  @Test func `rejects a coded foreign key whose tag is out of range`() throws {
     let relations: Array<Table> = [
       Table(Metadata.Tables.TypeDef.self, rows: 1, range: 0 ..< 14,
             wide: 0, stride: 14),
@@ -141,8 +136,7 @@ struct ResolveTests {
     #expect(throws: WinMDError.BadImageFormat) { _ = try source.resolve(3) }
   }
 
-  @Test("rejects a TypeDefOrRef reference whose tag is out of range")
-  func resolveBadTag() throws {
+  @Test func `rejects a TypeDefOrRef reference whose tag is out of range`() throws {
     // A signature can carry a `TypeDefOrRef` directly (not decoded out of a row's
     // coded-index cell), and `Database.resolve(_:)` selects its target table by
     // tag. `TypeDefOrRef` names three tables across two tag bits, so tag 3 is the
@@ -186,8 +180,7 @@ struct ResolveTests {
   private static let methodRow =
       Array<UInt8>(repeating: 0, count: 14)
 
-  @Test("rejects a CustomAttributeType with a reserved tag")
-  func customAttributeReservedTag() throws {
+  @Test func `rejects a CustomAttributeType with a reserved tag`() throws {
     // `Type` = `(1 << CustomAttributeType.bits) | 0`: row 1, tag 0 — reserved.
     let reserved = (1 << CustomAttributeType.bits) | 0
     let record = ResolveTests.attribute(reserved)
@@ -207,8 +200,7 @@ struct ResolveTests {
     #expect(throws: WinMDError.BadImageFormat) { _ = try source.resolve(1) }
   }
 
-  @Test("resolves a CustomAttributeType with a valid tag")
-  func customAttributeValidTag() throws {
+  @Test func `resolves a CustomAttributeType with a valid tag`() throws {
     // `Type` = `(1 << CustomAttributeType.bits) | 2`: row 1, tag 2 — `MethodDef`.
     let valid = (1 << CustomAttributeType.bits) | 2
     let record = ResolveTests.attribute(valid) + ResolveTests.methodRow
@@ -237,8 +229,7 @@ struct ResolveTests {
   // `TypeDef` index) names row 999 — non-null but far past the single TypeDef
   // row. `storage.tuple` returns nil for the out-of-range row; resolution must
   // surface that as a malformed image rather than as "no relationship".
-  @Test("rejects a simple foreign key whose row is out of range")
-  func simpleIndexOutOfRange() throws {
+  @Test func `rejects a simple foreign key whose row is out of range`() throws {
     // TypeDef[0] (the target table) before NestedClass[0] (the source): the
     // relations are ordered by table number. The NestedClass row points its
     // `NestedClass` simple index at row 999, well past the one TypeDef row.
@@ -269,8 +260,7 @@ struct ResolveTests {
     #expect(throws: WinMDError.BadImageFormat) { _ = try source.resolve(0) }
   }
 
-  @Test("rejects a coded foreign key whose row is out of range")
-  func codedIndexOutOfRange() throws {
+  @Test func `rejects a coded foreign key whose row is out of range`() throws {
     // TypeDef[0].Extends (ordinal 3, a `TypeDefOrRef` coded index) names a
     // non-null row through tag 1 (`TypeRef`), but row 999 is far past the single
     // TypeRef row. Encoding: `(999 << 2) | 1`.
@@ -301,8 +291,7 @@ struct ResolveTests {
     #expect(throws: WinMDError.BadImageFormat) { _ = try source.resolve(3) }
   }
 
-  @Test("rejects a TypeDefOrRef reference whose row is out of range")
-  func resolveOutOfRange() throws {
+  @Test func `rejects a TypeDefOrRef reference whose row is out of range`() throws {
     // A `TypeDefOrRef` carried in a signature with tag 1 (`TypeRef`) but row 999:
     // `(999 << 2) | 1`. `Database.resolve(_:)`'s tag guard passes (the tag names
     // a real table) but the row is past the one TypeRef row.
@@ -330,8 +319,7 @@ struct ResolveTests {
     }
   }
 
-  @Test("rejects a simple foreign key whose target table is absent")
-  func simpleIndexAbsentTable() throws {
+  @Test func `rejects a simple foreign key whose target table is absent`() throws {
     // A NestedClass row (#41) whose `NestedClass` (ordinal 0, a simple `TypeDef`
     // index) names a non-null row, but the `TypeDef` table (#2) is absent from
     // the `Valid` mask. A dangling foreign-key target is a malformed image, not a
@@ -357,8 +345,7 @@ struct ResolveTests {
     #expect(throws: WinMDError.BadImageFormat) { _ = try source.resolve(0) }
   }
 
-  @Test("rejects a coded foreign key whose target table is absent")
-  func codedIndexAbsentTable() throws {
+  @Test func `rejects a coded foreign key whose target table is absent`() throws {
     // TypeDef[0].Extends (ordinal 3, a `TypeDefOrRef` coded index) names a
     // non-null row through tag 1 (`TypeRef`), but the `TypeRef` table (#1) is
     // absent from the `Valid` mask. Encoding: `(1 << 2) | 1 = 5`.
@@ -384,8 +371,7 @@ struct ResolveTests {
     #expect(throws: WinMDError.BadImageFormat) { _ = try source.resolve(3) }
   }
 
-  @Test("rejects a TypeDefOrRef reference whose target table is absent")
-  func resolveAbsentTable() throws {
+  @Test func `rejects a TypeDefOrRef reference whose target table is absent`() throws {
     // A `TypeDefOrRef` carried in a signature with tag 1 (`TypeRef`) and row 1:
     // `(1 << 2) | 1`. `Database.resolve(_:)`'s tag guard passes (the tag names a
     // real table), but the `TypeRef` table is absent from the `Valid` mask.

--- a/Tests/WinMDTests/RowLayoutTests.swift
+++ b/Tests/WinMDTests/RowLayoutTests.swift
@@ -16,8 +16,7 @@ struct RowLayoutTests {
   // stride is 14.
   typealias Schema = Metadata.Tables.TypeDef
 
-  @Test("computes narrow column offsets from the schema")
-  func narrowLayout() {
+  @Test func `computes narrow column offsets from the schema`() {
     #expect(Schema.offset(0) == 0)
     #expect(Schema.offset(1) == 4)
     #expect(Schema.offset(2) == 6)
@@ -26,8 +25,7 @@ struct RowLayoutTests {
     #expect(Schema.offset(5) == 12)
   }
 
-  @Test("gives offsets and widths for an all-narrow table")
-  func narrowTable() {
+  @Test func `gives offsets and widths for an all-narrow table`() {
     // No wide indices: offsets are the narrow offsets, every index is 2 bytes,
     // and the stride is the narrow stride.
     let table = Table(Schema.self, rows: 0, range: 0 ..< 0, wide: 0, stride: 14)
@@ -44,8 +42,7 @@ struct RowLayoutTests {
     #expect(table.width(5) == 2)
   }
 
-  @Test("shifts and widens columns past wide indices")
-  func wideTable() {
+  @Test func `shifts and widens columns past wide indices`() {
     // Widen TypeName (column 1) and FieldList (column 4) to 4-byte indices.
     // Each adds two bytes, so the stride grows by four and every column from
     // the first wide index onward shifts by the running popcount.

--- a/Tests/WinMDTests/SignatureTests.swift
+++ b/Tests/WinMDTests/SignatureTests.swift
@@ -31,8 +31,7 @@ private let typeref0: UInt8 = 0x05
 // directly through `SignatureDecoder`; the accessor tests additionally wrap a
 // signature in a one-blob `#Blob` heap and reach it through a `Row`.
 struct SignatureTests {
-  @Test("decodes (i4, string) -> void")
-  func methodPrimitives() throws {
+  @Test func `decodes (i4, string) -> void`() throws {
     let bytes = [DEFAULT, 0x02, VOID, I4, STRING]
     var decoder = SignatureDecoder(bytes.span.bytes)
     let signature = try decoder.method()
@@ -50,8 +49,7 @@ struct SignatureTests {
     }
   }
 
-  @Test("decodes the HASTHIS instance flag")
-  func methodInstance() throws {
+  @Test func `decodes the HASTHIS instance flag`() throws {
     let bytes = [HASTHIS | DEFAULT, 0x00, VOID]
     var decoder = SignatureDecoder(bytes.span.bytes)
     let signature = try decoder.method()
@@ -59,8 +57,7 @@ struct SignatureTests {
     #expect(signature.parameters.isEmpty)
   }
 
-  @Test("decodes a pointer parameter")
-  func pointerParameter() throws {
+  @Test func `decodes a pointer parameter`() throws {
     let bytes = [DEFAULT, 0x01, VOID, PTR, I4]
     var decoder = SignatureDecoder(bytes.span.bytes)
     let signature = try decoder.method()
@@ -70,8 +67,7 @@ struct SignatureTests {
     }
   }
 
-  @Test("decodes a byref parameter")
-  func byrefParameter() throws {
+  @Test func `decodes a byref parameter`() throws {
     let bytes = [DEFAULT, 0x01, VOID, BYREF, U4]
     var decoder = SignatureDecoder(bytes.span.bytes)
     let signature = try decoder.method()
@@ -81,8 +77,7 @@ struct SignatureTests {
     }
   }
 
-  @Test("decodes an SZARRAY return")
-  func arrayReturn() throws {
+  @Test func `decodes an SZARRAY return`() throws {
     let bytes = [DEFAULT, 0x00, SZARRAY, I4]
     var decoder = SignatureDecoder(bytes.span.bytes)
     let signature = try decoder.method()
@@ -92,8 +87,7 @@ struct SignatureTests {
     }
   }
 
-  @Test("decodes a CLASS parameter via a coded index")
-  func namedParameter() throws {
+  @Test func `decodes a CLASS parameter via a coded index`() throws {
     let bytes = [DEFAULT, 0x01, VOID, CLASS, typeref0]
     var decoder = SignatureDecoder(bytes.span.bytes)
     let signature = try decoder.method()
@@ -106,8 +100,7 @@ struct SignatureTests {
     #expect(reference.row == 1)
   }
 
-  @Test("decodes a custom-modified parameter")
-  func modifiedParameter() throws {
+  @Test func `decodes a custom-modified parameter`() throws {
     // `const`-modified value type: CMOD_OPT TypeRef[0], then VALUETYPE TypeRef[0].
     let bytes = [DEFAULT, 0x01, VOID, CMOD_OPT, typeref0, VALUETYPE, typeref0]
     var decoder = SignatureDecoder(bytes.span.bytes)
@@ -123,8 +116,7 @@ struct SignatureTests {
     }
   }
 
-  @Test("decodes a field signature")
-  func field() throws {
+  @Test func `decodes a field signature`() throws {
     let bytes = [FIELD, I4]
     var decoder = SignatureDecoder(bytes.span.bytes)
     let signature = try decoder.field()
@@ -133,15 +125,13 @@ struct SignatureTests {
     }
   }
 
-  @Test("rejects an unknown element type")
-  func malformed() {
+  @Test func `rejects an unknown element type`() {
     let bytes = [DEFAULT, 0x00, 0xff]
     var decoder = SignatureDecoder(bytes.span.bytes)
     #expect(throws: WinMDError.BadImageFormat) { _ = try decoder.method() }
   }
 
-  @Test("rejects an unsupported calling convention")
-  func unsupportedConvention() {
+  @Test func `rejects an unsupported calling convention`() {
     // The prolog's low nibble names the calling convention (ECMA-335 §II.23.2.1);
     // 0x09 and 0x0f are not defined values, so the decoder must reject them rather
     // than silently treating them as the DEFAULT convention.
@@ -154,15 +144,13 @@ struct SignatureTests {
     #expect(throws: WinMDError.BadImageFormat) { _ = try fifteenDecoder.method() }
   }
 
-  @Test("rejects a truncated signature")
-  func truncated() {
+  @Test func `rejects a truncated signature`() {
     let bytes = [DEFAULT, 0x01, VOID]    // missing the parameter
     var decoder = SignatureDecoder(bytes.span.bytes)
     #expect(throws: WinMDError.BadImageFormat) { _ = try decoder.method() }
   }
 
-  @Test("rejects an invalid compressed-integer lead byte")
-  func compressedLeadByte() {
+  @Test func `rejects an invalid compressed-integer lead byte`() {
     // The parameter count is a compressed integer; `0xe0` is `111xxxxx`, not a
     // defined encoding, so decoding must fault rather than read past the blob.
     let bytes = [DEFAULT, 0xe0, VOID]
@@ -170,8 +158,7 @@ struct SignatureTests {
     #expect(throws: WinMDError.BadImageFormat) { _ = try decoder.method() }
   }
 
-  @Test("rejects a compressed integer running off the blob end")
-  func compressedTruncated() {
+  @Test func `rejects a compressed integer running off the blob end`() {
     // `0x80` opens a 2-byte encoding but no second byte follows; `0xc0` opens a
     // 4-byte one with only one byte left. Either must fault, not crash.
     let two = [DEFAULT, 0x80]
@@ -183,8 +170,7 @@ struct SignatureTests {
     #expect(throws: WinMDError.BadImageFormat) { _ = try fourDecoder.method() }
   }
 
-  @Test("decodes a multidimensional ARRAY's negative lower bound")
-  func matrixNegativeBound() throws {
+  @Test func `decodes a multidimensional ARRAY's negative lower bound`() throws {
     // `i4[*]` returning from a method: rank 1, no explicit sizes, one lower
     // bound of -3 (compressed signed `0x7b`, ECMA-335 §II.23.2).
     let bytes = [DEFAULT, 0x00, ARRAY, I4, 0x01, 0x00, 0x01, 0x7b]
@@ -199,8 +185,7 @@ struct SignatureTests {
     #expect(shape.bounds == [-3])
   }
 
-  @Test("decodes a multidimensional ARRAY's 4-byte negative lower bound")
-  func matrixWideNegativeBound() throws {
+  @Test func `decodes a multidimensional ARRAY's 4-byte negative lower bound`() throws {
     // A lower bound whose magnitude exceeds 2^13 needs the 4-byte compressed
     // signed form, which carries 29 payload bits (5 in the lead byte + 24
     // following), so the negative correction subtracts 2^28. The bound -16384
@@ -220,8 +205,7 @@ struct SignatureTests {
     #expect(shape.bounds == [-16384])
   }
 
-  @Test("rejects an ARRAY with more sizes than its rank")
-  func matrixTooManySizes() {
+  @Test func `rejects an ARRAY with more sizes than its rank`() {
     // ECMA-335 §II.23.2.13 constrains `NumSizes` to `<= Rank`. Here rank is 1 but
     // NumSizes is 2 (two sizes, no lower bounds) — the decoder must reject it.
     let bytes = [DEFAULT, 0x00, ARRAY, I4, 0x01, 0x02, 0x01, 0x02, 0x00]
@@ -229,8 +213,7 @@ struct SignatureTests {
     #expect(throws: WinMDError.BadImageFormat) { _ = try decoder.method() }
   }
 
-  @Test("rejects an ARRAY with more lower bounds than its rank")
-  func matrixTooManyBounds() {
+  @Test func `rejects an ARRAY with more lower bounds than its rank`() {
     // Likewise `NumLoBounds` must be `<= Rank`. Rank is 1 but NumLoBounds is 2
     // (no sizes, two bounds) — the decoder must reject it.
     let bytes = [DEFAULT, 0x00, ARRAY, I4, 0x01, 0x00, 0x02, 0x01, 0x02]
@@ -238,8 +221,7 @@ struct SignatureTests {
     #expect(throws: WinMDError.BadImageFormat) { _ = try decoder.method() }
   }
 
-  @Test("decodes a well-formed ARRAY at its rank's limits")
-  func matrixWellFormed() throws {
+  @Test func `decodes a well-formed ARRAY at its rank's limits`() throws {
     // Rank 2 with NumSizes 2 and NumLoBounds 2 — both at the rank limit — decodes
     // to a 2x3 matrix lower-bounded at (0, 1).
     let bytes =
@@ -255,8 +237,7 @@ struct SignatureTests {
     #expect(shape.bounds == [0, 1])
   }
 
-  @Test("rejects a zero-rank ARRAY")
-  func matrixZeroRank() {
+  @Test func `rejects a zero-rank ARRAY`() {
     // ECMA-335 §II.23.2.13 requires `Rank >= 1`. Here rank is 0 (with no sizes
     // and no lower bounds); both `<= Rank` guards pass vacuously, so the rank
     // guard itself must reject it.
@@ -265,8 +246,7 @@ struct SignatureTests {
     #expect(throws: WinMDError.BadImageFormat) { _ = try decoder.method() }
   }
 
-  @Test("rejects EXPLICITTHIS without HASTHIS")
-  func methodExplicitWithoutInstance() {
+  @Test func `rejects EXPLICITTHIS without HASTHIS`() {
     // ECMA-335 §II.23.2.1: EXPLICITTHIS (0x40) is only valid alongside HASTHIS
     // (0x20). A prolog of 0x40 alone — explicit but not instance — is malformed.
     let bytes = [EXPLICITTHIS | DEFAULT, 0x00, VOID]
@@ -274,8 +254,7 @@ struct SignatureTests {
     #expect(throws: WinMDError.BadImageFormat) { _ = try decoder.method() }
   }
 
-  @Test("decodes EXPLICITTHIS alongside HASTHIS")
-  func methodExplicitInstance() throws {
+  @Test func `decodes EXPLICITTHIS alongside HASTHIS`() throws {
     // A prolog of 0x60 sets both HASTHIS and EXPLICITTHIS, which is well-formed.
     let bytes = [EXPLICITTHIS | HASTHIS | DEFAULT, 0x00, VOID]
     var decoder = SignatureDecoder(bytes.span.bytes)
@@ -315,8 +294,7 @@ struct SignatureTests {
 
   private static let empty = Array<UInt8>()
 
-  @Test("decodes a MethodDef signature through the row accessor")
-  func methodAccessor() throws {
+  @Test func `decodes a MethodDef signature through the row accessor`() throws {
     let relations =
         [Table(Metadata.Tables.MethodDef.self, rows: 1, range: 0 ..< 14,
                wide: 0, stride: 14)]
@@ -334,8 +312,7 @@ struct SignatureTests {
     #expect(signature.parameters.isEmpty)
   }
 
-  @Test("decodes a FieldDef signature through the row accessor")
-  func fieldAccessor() throws {
+  @Test func `decodes a FieldDef signature through the row accessor`() throws {
     let relations =
         [Table(Metadata.Tables.FieldDef.self, rows: 1, range: 0 ..< 6,
                wide: 0, stride: 6)]
@@ -362,8 +339,7 @@ struct SignatureTests {
   // high bit is likewise a method-signature flag, invalid on a field.
   private static let fieldHasThisBlob: Array<UInt8> = [0x02, 0x26, I4]
 
-  @Test("rejects a field signature whose prolog carries the GENERIC flag")
-  func fieldGenericProlog() throws {
+  @Test func `rejects a field signature whose prolog carries the GENERIC flag`() throws {
     let relations =
         [Table(Metadata.Tables.FieldDef.self, rows: 1, range: 0 ..< 6,
                wide: 0, stride: 6)]
@@ -377,8 +353,7 @@ struct SignatureTests {
     #expect(throws: WinMDError.BadImageFormat) { _ = try rows[0]!.declaration }
   }
 
-  @Test("rejects a field signature whose prolog carries the HASTHIS flag")
-  func fieldHasThisProlog() throws {
+  @Test func `rejects a field signature whose prolog carries the HASTHIS flag`() throws {
     let relations =
         [Table(Metadata.Tables.FieldDef.self, rows: 1, range: 0 ..< 6,
                wide: 0, stride: 6)]
@@ -402,8 +377,7 @@ struct SignatureTests {
   private static let fieldTrailingBlob: Array<UInt8> =
       [0x03, FIELD, I4, 0xff]
 
-  @Test("rejects a method signature with trailing bytes")
-  func methodTrailingBytes() throws {
+  @Test func `rejects a method signature with trailing bytes`() throws {
     let relations =
         [Table(Metadata.Tables.MethodDef.self, rows: 1, range: 0 ..< 14,
                wide: 0, stride: 14)]
@@ -417,8 +391,7 @@ struct SignatureTests {
     #expect(throws: WinMDError.BadImageFormat) { _ = try rows[0]!.prototype }
   }
 
-  @Test("rejects a field signature with trailing bytes")
-  func fieldTrailingBytes() throws {
+  @Test func `rejects a field signature with trailing bytes`() throws {
     let relations =
         [Table(Metadata.Tables.FieldDef.self, rows: 1, range: 0 ..< 6,
                wide: 0, stride: 6)]
@@ -448,8 +421,7 @@ struct SignatureTests {
   private static let propertyConventionBlob: Array<UInt8> =
       [0x03, 0x08, 0x00, VOID]
 
-  @Test("rejects a method prolog with the reserved high bit set")
-  func reservedProlog() throws {
+  @Test func `rejects a method prolog with the reserved high bit set`() throws {
     let relations =
         [Table(Metadata.Tables.MethodDef.self, rows: 1, range: 0 ..< 14,
                wide: 0, stride: 14)]
@@ -463,8 +435,7 @@ struct SignatureTests {
     #expect(throws: WinMDError.BadImageFormat) { _ = try rows[0]!.prototype }
   }
 
-  @Test("rejects a method prolog naming the FIELD convention")
-  func fieldConvention() throws {
+  @Test func `rejects a method prolog naming the FIELD convention`() throws {
     let relations =
         [Table(Metadata.Tables.MethodDef.self, rows: 1, range: 0 ..< 14,
                wide: 0, stride: 14)]
@@ -478,8 +449,7 @@ struct SignatureTests {
     #expect(throws: WinMDError.BadImageFormat) { _ = try rows[0]!.prototype }
   }
 
-  @Test("rejects a method prolog naming the LOCAL_SIG convention")
-  func localConvention() throws {
+  @Test func `rejects a method prolog naming the LOCAL_SIG convention`() throws {
     let relations =
         [Table(Metadata.Tables.MethodDef.self, rows: 1, range: 0 ..< 14,
                wide: 0, stride: 14)]
@@ -493,8 +463,7 @@ struct SignatureTests {
     #expect(throws: WinMDError.BadImageFormat) { _ = try rows[0]!.prototype }
   }
 
-  @Test("rejects a method prolog naming the PROPERTY convention")
-  func propertyConvention() throws {
+  @Test func `rejects a method prolog naming the PROPERTY convention`() throws {
     let relations =
         [Table(Metadata.Tables.MethodDef.self, rows: 1, range: 0 ..< 14,
                wide: 0, stride: 14)]
@@ -520,8 +489,7 @@ struct SignatureTests {
   // exceeds the heap. Opening it must throw, not read out of bounds.
   private static let longPrefixBlob: Array<UInt8> = [0x7f, DEFAULT]
 
-  @Test("rejects a #Blob signature entry with an invalid length-prefix lead")
-  func methodAccessorBadPrefix() throws {
+  @Test func `rejects a #Blob signature entry with an invalid length-prefix lead`() throws {
     let relations =
         [Table(Metadata.Tables.MethodDef.self, rows: 1, range: 0 ..< 14,
                wide: 0, stride: 14)]
@@ -535,8 +503,7 @@ struct SignatureTests {
     #expect(throws: WinMDError.BadImageFormat) { _ = try rows[0]!.prototype }
   }
 
-  @Test("rejects a #Blob signature entry whose length runs past the heap")
-  func methodAccessorLongPrefix() throws {
+  @Test func `rejects a #Blob signature entry whose length runs past the heap`() throws {
     let relations =
         [Table(Metadata.Tables.MethodDef.self, rows: 1, range: 0 ..< 14,
                wide: 0, stride: 14)]
@@ -550,8 +517,7 @@ struct SignatureTests {
     #expect(throws: WinMDError.BadImageFormat) { _ = try rows[0]!.prototype }
   }
 
-  @Test("rejects a #Blob field entry with an invalid length-prefix lead")
-  func fieldAccessorBadPrefix() throws {
+  @Test func `rejects a #Blob field entry with an invalid length-prefix lead`() throws {
     let relations =
         [Table(Metadata.Tables.FieldDef.self, rows: 1, range: 0 ..< 6,
                wide: 0, stride: 6)]
@@ -565,8 +531,7 @@ struct SignatureTests {
     #expect(throws: WinMDError.BadImageFormat) { _ = try rows[0]!.declaration }
   }
 
-  @Test("rejects a #Blob field entry whose length runs past the heap")
-  func fieldAccessorLongPrefix() throws {
+  @Test func `rejects a #Blob field entry whose length runs past the heap`() throws {
     let relations =
         [Table(Metadata.Tables.FieldDef.self, rows: 1, range: 0 ..< 6,
                wide: 0, stride: 6)]
@@ -580,8 +545,7 @@ struct SignatureTests {
     #expect(throws: WinMDError.BadImageFormat) { _ = try rows[0]!.declaration }
   }
 
-  @Test("a well-formed #Blob signature entry still decodes through the accessor")
-  func methodAccessorWellFormed() throws {
+  @Test func `a well-formed #Blob signature entry still decodes through the accessor`() throws {
     let relations =
         [Table(Metadata.Tables.MethodDef.self, rows: 1, range: 0 ..< 14,
                wide: 0, stride: 14)]
@@ -619,8 +583,7 @@ struct SignatureTests {
   private static let voidPointerBlob: Array<UInt8> =
       [0x05, DEFAULT, 0x01, I4, PTR, VOID]
 
-  @Test("rejects a VOID method parameter")
-  func voidParameter() throws {
+  @Test func `rejects a VOID method parameter`() throws {
     let relations =
         [Table(Metadata.Tables.MethodDef.self, rows: 1, range: 0 ..< 14,
                wide: 0, stride: 14)]
@@ -634,8 +597,7 @@ struct SignatureTests {
     #expect(throws: WinMDError.BadImageFormat) { _ = try rows[0]!.prototype }
   }
 
-  @Test("rejects a VOID field type")
-  func voidField() throws {
+  @Test func `rejects a VOID field type`() throws {
     let relations =
         [Table(Metadata.Tables.FieldDef.self, rows: 1, range: 0 ..< 6,
                wide: 0, stride: 6)]
@@ -649,8 +611,7 @@ struct SignatureTests {
     #expect(throws: WinMDError.BadImageFormat) { _ = try rows[0]!.declaration }
   }
 
-  @Test("decodes a VOID return")
-  func voidReturn() throws {
+  @Test func `decodes a VOID return`() throws {
     let relations =
         [Table(Metadata.Tables.MethodDef.self, rows: 1, range: 0 ..< 14,
                wide: 0, stride: 14)]
@@ -668,8 +629,7 @@ struct SignatureTests {
     #expect(signature.parameters.isEmpty)
   }
 
-  @Test("decodes a VOID pointer parameter")
-  func voidPointer() throws {
+  @Test func `decodes a VOID pointer parameter`() throws {
     let relations =
         [Table(Metadata.Tables.MethodDef.self, rows: 1, range: 0 ..< 14,
                wide: 0, stride: 14)]
@@ -725,28 +685,23 @@ struct SignatureTests {
     #expect(throws: WinMDError.BadImageFormat) { _ = try rows[0]!.prototype }
   }
 
-  @Test("rejects a MethodDef prolog naming the unmanaged C convention")
-  func cConvention() throws {
+  @Test func `rejects a MethodDef prolog naming the unmanaged C convention`() throws {
     try expectPrototypeRejects(SignatureTests.cConventionBlob)
   }
 
-  @Test("rejects a MethodDef prolog naming the unmanaged STDCALL convention")
-  func stdcallConvention() throws {
+  @Test func `rejects a MethodDef prolog naming the unmanaged STDCALL convention`() throws {
     try expectPrototypeRejects(SignatureTests.stdcallConventionBlob)
   }
 
-  @Test("rejects a MethodDef prolog naming the unmanaged THISCALL convention")
-  func thiscallConvention() throws {
+  @Test func `rejects a MethodDef prolog naming the unmanaged THISCALL convention`() throws {
     try expectPrototypeRejects(SignatureTests.thiscallConventionBlob)
   }
 
-  @Test("rejects a MethodDef prolog naming the unmanaged FASTCALL convention")
-  func fastcallConvention() throws {
+  @Test func `rejects a MethodDef prolog naming the unmanaged FASTCALL convention`() throws {
     try expectPrototypeRejects(SignatureTests.fastcallConventionBlob)
   }
 
-  @Test("decodes a DEFAULT-convention MethodDef through prototype")
-  func defaultConvention() throws {
+  @Test func `decodes a DEFAULT-convention MethodDef through prototype`() throws {
     let relations =
         [Table(Metadata.Tables.MethodDef.self, rows: 1, range: 0 ..< 14,
                wide: 0, stride: 14)]
@@ -761,8 +716,7 @@ struct SignatureTests {
     #expect(signature.convention == .default)
   }
 
-  @Test("decodes a VARARG-convention MethodDef through prototype")
-  func varargConvention() throws {
+  @Test func `decodes a VARARG-convention MethodDef through prototype`() throws {
     let relations =
         [Table(Metadata.Tables.MethodDef.self, rows: 1, range: 0 ..< 14,
                wide: 0, stride: 14)]
@@ -779,8 +733,7 @@ struct SignatureTests {
 
   // MARK: - method() itself admits the unmanaged conventions
 
-  @Test("decodes an FNPTR carrying an unmanaged STDCALL convention")
-  func functionPointerUnmanagedConvention() throws {
+  @Test func `decodes an FNPTR carrying an unmanaged STDCALL convention`() throws {
     // FNPTR (0x1b) wraps a nested method signature, and a function pointer
     // (calli) legitimately names an unmanaged convention. The inner method's
     // prolog is 0x03 (THISCALL) over a `() -> void` body. The `prototype`

--- a/Tests/WinMDTests/SortKeyTests.swift
+++ b/Tests/WinMDTests/SortKeyTests.swift
@@ -5,8 +5,7 @@ import Testing
 @testable import WinMD
 
 struct SortKeyTests {
-  @Test("sorted tables name their key column ordinal")
-  func sortedTablesNameTheirKeyColumn() {
+  @Test func `sorted tables name their key column ordinal`() {
     // The key is the ordinal of the column the table is physically ordered by
     // (ECMA-335 §II.22), resolved from each schema's own column order.
     #expect(Metadata.Tables.NestedClass.key == 0)
@@ -15,8 +14,7 @@ struct SortKeyTests {
     #expect(Metadata.Tables.MethodSemantics.key == 2)
   }
 
-  @Test("unsorted tables have no key")
-  func unsortedTablesHaveNoKey() {
+  @Test func `unsorted tables have no key`() {
     // A table the specification does not sort inherits the `nil` default.
     #expect(Metadata.Tables.TypeDef.key == nil)
     #expect(Metadata.Tables.TypeRef.key == nil)

--- a/Tests/WinMDTests/StringsHeapTests.swift
+++ b/Tests/WinMDTests/StringsHeapTests.swift
@@ -30,8 +30,7 @@ struct StringsHeapTests {
     0x53, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x20, 0x31, 0x35, 0x00,
   ]
 
-  @Test("reads null-terminated strings by heap offset")
-  func subscriptAccess() {
+  @Test func `reads null-terminated strings by heap offset`() {
     let bytes = StringsHeapTests.heap
     let heap = StringsHeap(bytes.span.bytes)
 

--- a/Tests/WinMDTests/UserStringsHeapTests.swift
+++ b/Tests/WinMDTests/UserStringsHeapTests.swift
@@ -6,8 +6,7 @@ import Testing
 
 struct UserStringsHeapTests {
   // Offset 0 is always the empty entry: a zero-length blob.
-  @Test("decodes the empty entry at offset 0")
-  func emptyEntry() {
+  @Test func `decodes the empty entry at offset 0`() {
     let bytes: Array<UInt8> = [0x00]
     let heap = UserStringsHeap(bytes.span.bytes)
     #expect(heap[0] == "")
@@ -15,8 +14,7 @@ struct UserStringsHeapTests {
 
   // "Hi" → UTF-16LE `48 00 69 00`, plus a terminal byte `00`, giving a payload
   // of five bytes, prefixed by the single-byte compressed length `0x05`.
-  @Test("decodes a UTF-16 string with a single-byte length")
-  func singleByteLength() {
+  @Test func `decodes a UTF-16 string with a single-byte length`() {
     let bytes: Array<UInt8> = [0x05, 0x48, 0x00, 0x69, 0x00, 0x00]
     let heap = UserStringsHeap(bytes.span.bytes)
     #expect(heap[0] == "Hi")
@@ -24,8 +22,7 @@ struct UserStringsHeapTests {
 
   // The same "Hi" payload, but encoded with a two-byte compressed length
   // (`0x80 0x05`) to exercise the wider length form.
-  @Test("decodes a UTF-16 string with a two-byte length")
-  func twoByteLength() {
+  @Test func `decodes a UTF-16 string with a two-byte length`() {
     let bytes: Array<UInt8> = [0x80, 0x05, 0x48, 0x00, 0x69, 0x00, 0x00]
     let heap = UserStringsHeap(bytes.span.bytes)
     #expect(heap[0] == "Hi")
@@ -33,8 +30,7 @@ struct UserStringsHeapTests {
 
   // A non-zero code unit alongside the terminal flag set, confirming the
   // terminal byte is ignored for the decoded value.
-  @Test("ignores the terminal byte when decoding")
-  func terminalByteIgnored() {
+  @Test func `ignores the terminal byte when decoding`() {
     // "é" (U+00E9) → UTF-16LE `E9 00`, terminal flag `01`, length `0x03`.
     let bytes: Array<UInt8> = [0x03, 0xe9, 0x00, 0x01]
     let heap = UserStringsHeap(bytes.span.bytes)
@@ -44,8 +40,7 @@ struct UserStringsHeapTests {
   // A multi-code-unit string whose code units begin at an odd byte offset (the
   // single-byte length prefix puts `begin` at 1), proving the unaligned read
   // path. "Hello" → UTF-16LE, terminal flag `00`, length `0x0b`.
-  @Test("decodes a multi-code-unit string at an odd offset")
-  func multipleCodeUnits() {
+  @Test func `decodes a multi-code-unit string at an odd offset`() {
     let bytes: Array<UInt8> = [0x0b, 0x48, 0x00, 0x65, 0x00, 0x6c, 0x00,
                                0x6c, 0x00, 0x6f, 0x00, 0x00]
     let heap = UserStringsHeap(bytes.span.bytes)
@@ -55,8 +50,7 @@ struct UserStringsHeapTests {
   // A non-ASCII string requiring a surrogate pair, again starting at an odd
   // `begin`. "😀" (U+1F600) → UTF-16LE surrogates `D83D DE00` i.e. bytes
   // `3D D8 00 DE`, terminal flag `01`, length `0x05`.
-  @Test("decodes a surrogate-pair string at an odd offset")
-  func surrogatePair() {
+  @Test func `decodes a surrogate-pair string at an odd offset`() {
     let bytes: Array<UInt8> = [0x05, 0x3d, 0xd8, 0x00, 0xde, 0x01]
     let heap = UserStringsHeap(bytes.span.bytes)
     #expect(heap[0] == "\u{1f600}")

--- a/Tests/winmd-inspectTests/AdapterTests.swift
+++ b/Tests/winmd-inspectTests/AdapterTests.swift
@@ -115,8 +115,7 @@ struct AdapterTests {
     return try catalog.run(select)
   }
 
-  @Test("projects, filters, and orders a single relation")
-  func singleRelation() throws {
+  @Test func `projects, filters, and orders a single relation`() throws {
     // The string columns project as text, the constant as an integer; the
     // WHERE keeps both rows (both are in "NS"), and ORDER BY TypeName sorts
     // Alpha < Beta. `SELECT *` is the two real string heaps plus the constant
@@ -132,8 +131,7 @@ struct AdapterTests {
     }
   }
 
-  @Test("excludes Id and the owner FK from SELECT *")
-  func star() throws {
+  @Test func `excludes Id and the owner FK from SELECT *`() throws {
     // `SELECT *` projects exactly the real fields: a TypeDef has six. Neither
     // the `Id` nor an owner-foreign-key virtual column appears.
     try AdapterTests.with { catalog in
@@ -148,8 +146,7 @@ struct AdapterTests {
     }
   }
 
-  @Test("vends the Id virtual column 1-based")
-  func id() throws {
+  @Test func `vends the Id virtual column 1-based`() throws {
     try AdapterTests.with { catalog in
       let rows = try AdapterTests.run(
           "SELECT Id, TypeName FROM TypeDef ORDER BY Id", catalog)
@@ -160,8 +157,7 @@ struct AdapterTests {
     }
   }
 
-  @Test("seeks a sorted key rather than scanning")
-  func seek() throws {
+  @Test func `seeks a sorted key rather than scanning`() throws {
     // NestedClass is sorted on its key column, so an equality on it takes the
     // engine's seek path; the one row whose NestedClass index is 2 survives.
     try AdapterTests.with { catalog in
@@ -172,8 +168,7 @@ struct AdapterTests {
     }
   }
 
-  @Test("joins through a foreign key on Id")
-  func foreignKeyJoin() throws {
+  @Test func `joins through a foreign key on Id`() throws {
     // The FK `NestedClass.NestedClass` holds a TypeDef Id; the engine joins
     // each NestedClass row to its TypeDef and projects the resolved name.
     try AdapterTests.with { catalog in
@@ -189,8 +184,7 @@ struct AdapterTests {
     }
   }
 
-  @Test("joins a list child to its owner on the owner FK")
-  func listJoin() throws {
+  @Test func `joins a list child to its owner on the owner FK`() throws {
     // The `TypeDef` owner-FK column relates each MethodDef to the TypeDef whose
     // MethodList run owns it: MethodDef[0,1] → TypeDef[0] (Alpha), MethodDef[2]
     // → TypeDef[1] (Beta). The join seeks TypeDef on its `Id` per method.
@@ -208,8 +202,7 @@ struct AdapterTests {
     }
   }
 
-  @Test("resolves a real Parent foreign-key column")
-  func realParentColumn() throws {
+  @Test func `resolves a real Parent foreign-key column`() throws {
     // EventMap carries a real `Parent` field — a TypeDef index — and owns no
     // list, so it has no owner-FK column: the name resolves to that ordinary
     // foreign key. EventMap[0].Parent=1, EventMap[1].Parent=2.
@@ -220,8 +213,7 @@ struct AdapterTests {
     }
   }
 
-  @Test("joins through a real Parent foreign key on Id")
-  func realParentJoin() throws {
+  @Test func `joins through a real Parent foreign key on Id`() throws {
     // The real `EventMap.Parent` FK holds a TypeDef Id; the join resolves
     // each EventMap row to its TypeDef: Parent=1 → Alpha, Parent=2 → Beta.
     try AdapterTests.with { catalog in

--- a/Tests/winmd-inspectTests/DatabaseSQLTests.swift
+++ b/Tests/winmd-inspectTests/DatabaseSQLTests.swift
@@ -247,8 +247,7 @@ struct DatabaseSQLTests {
                                            bindings: bindings)
   }
 
-  @Test("the bundled `interfaces` view yields the IID-carrying TypeDef")
-  func bundledInterfaces() throws {
+  @Test func `the bundled interfaces view yields the IID-carrying TypeDef`() throws {
     // The `interfaces` view navigates each `TypeDef` to its `GuidAttribute` IID
     // across the coded-index join keys (`TypeDef` ← `CustomAttribute` →
     // `MemberRef` → `TypeRef`), projecting `GUID(c.Value)` as `iid`; the only
@@ -263,8 +262,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("the bundled `methods` view yields a method bound by its parent Id")
-  func bundledMethods() throws {
+  @Test func `the bundled methods view yields a method bound by its parent Id`() throws {
     // `IMyInterface` is `TypeDef` Id 1, which owns `MethodDef` Id 1;
     // binding `:parent` to the interface's Id yields the method's `Id` and
     // `Name` (the type is no longer a column — the render decodes it).
@@ -276,8 +274,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("the bundled `params` view yields params bound by their method Id")
-  func bundledParams() throws {
+  @Test func `the bundled params view yields params bound by their method Id`() throws {
     // `MethodDef` Id 1 owns the three `Param` rows; binding `:parent` to it
     // yields each parameter's `Id`, `Name`, and `Sequence` (the type is no
     // longer a column — the render navigates from these and decodes it).
@@ -293,8 +290,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("a registered view is queryable through the session catalog")
-  func sessionView() throws {
+  @Test func `a registered view is queryable through the session catalog`() throws {
     // `CREATE VIEW guids …` registers a view decoding `CustomAttribute.Value`
     // through the `GUID` UDF; a `SELECT … FROM guids` then resolves it through
     // the session catalog and yields the view's rows. The fixture's single
@@ -311,8 +307,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("a session `CREATE FUNCTION` helper is visible to the render routines")
-  func renderResolvesSessionFunction() throws {
+  @Test func `a session CREATE FUNCTION helper is visible to the render routines`() throws {
     // The bug: the render composed its routine set from the STATIC prelude
     // (`language.routines.merging(Session.routines)`), NOT the session's own
     // routines, so a helper a session `CREATE FUNCTION` defined — reachable
@@ -348,8 +343,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("a view is resolved case-insensitively")
-  func sessionViewCaseInsensitive() throws {
+  @Test func `a view is resolved case-insensitively`() throws {
     // The session catalog folds the view name, so a query may name the view in
     // any case (relation names resolve case-insensitively elsewhere).
     try DatabaseSQLTests.with { catalog in
@@ -361,8 +355,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("a session enumerates its registered views for introspection")
-  func sessionViewsEnumerated() throws {
+  @Test func `a session enumerates its registered views for introspection`() throws {
     // The session implements `Catalog.views()` off its registered set, the
     // surface the `INFORMATION_SCHEMA` overlay lists with a `'VIEW'` table type.
     // A session over one registered view enumerates exactly that view's name.
@@ -374,8 +367,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("a session view is listed in information_schema.tables")
-  func sessionViewIntrospected() throws {
+  @Test func `a session view is listed in information_schema.tables`() throws {
     // The session's registered views appear in the `INFORMATION_SCHEMA` overlay
     // with a `'VIEW'` table type, enumerated beside the storage's base tables —
     // the feature over the real WinMD catalog, not just an in-memory fixture.
@@ -395,8 +387,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("information_schema.columns types the GUID view column as text")
-  func guidColumnTypedText() throws {
+  @Test func `information_schema.columns types the GUID view column as text`() throws {
     // The bundled `interfaces` view projects `GUID(c.Value) AS iid`; `GUID`
     // declares a `.text` return type, so `information_schema.columns` reports
     // `iid`'s `data_type` as `character varying` rather than the integer
@@ -410,8 +401,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("the render decode spells a method's return from its signature")
-  func decodesReturn() {
+  @Test func `the render decode spells a method's return from its signature`() {
     // The render decodes a return at render time (not through a virtual column):
     // `MethodDef` Id 1's signature `void Method(i4, string)` decodes its
     // return to `Void`.
@@ -420,8 +410,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("the `interfaces` view excludes a type with no GuidAttribute")
-  func interfacesViewExcludes() throws {
+  @Test func `the interfaces view excludes a type with no GuidAttribute`() throws {
     // `INotGuid` (TypeDef row 2) carries no `GuidAttribute`, so the view's
     // navigation finds no matching `CustomAttribute` chain for it: it does not
     // appear, leaving only `IMyInterface`.
@@ -432,8 +421,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("the `interfaces` view resolves a same-module MethodDef-ctor IID")
-  func interfacesViewSameModuleMethodDefCtor() throws {
+  @Test func `the interfaces view resolves a same-module MethodDef-ctor IID`() throws {
     // When `GuidAttribute` is defined in the same file, a type's
     // `CustomAttribute.Type` names the attribute's `.ctor` directly as a
     // `MethodDef` (not a cross-module `MemberRef`), so the `MemberRef` chains
@@ -448,8 +436,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("the `interfaces` view resolves a same-module MemberRef-ctor IID")
-  func interfacesViewSameModuleMemberRefCtor() throws {
+  @Test func `the interfaces view resolves a same-module MemberRef-ctor IID`() throws {
     // A same-file constructor can also be encoded as a `MemberRef` whose
     // `Class` points back at the in-file `GuidAttribute` `TypeDef`, so the
     // decoded key is `Class_TypeDef`, not `Class_TypeRef`, and the cross-module
@@ -464,8 +451,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("the `interfaces` view excludes a GuidAttribute-carrying non-interface")
-  func interfacesViewExcludesNonInterface() throws {
+  @Test func `the interfaces view excludes a GuidAttribute-carrying non-interface`() throws {
     // `CThing` is a coclass — a `TypeDef` carrying a `GuidAttribute` yet whose
     // `Flags` clear the `tdInterface` (0x20) bit. Not every GUID-bearing type
     // is a COM interface, so the view's `BITAND(t.Flags, 32) = 32` filter drops
@@ -477,8 +463,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("the GUID UDF decodes a CustomAttribute's Value blob")
-  func guid() throws {
+  @Test func `the GUID UDF decodes a CustomAttribute's Value blob`() throws {
     // The `GUID` UDF decodes the `GuidAttribute`'s `Value` blob (surfaced as a
     // real `.blob` column) to the well-known UUID as text; the fixture's sole
     // `CustomAttribute` is that attribute.
@@ -489,8 +474,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("excludes the virtual columns from SELECT *")
-  func star() throws {
+  @Test func `excludes the virtual columns from SELECT *`() throws {
     // `SELECT *` projects exactly the six real `TypeDef` fields — neither
     // `Id` nor an owner-FK column appears — for each of the two fixture types.
     try DatabaseSQLTests.with { catalog in
@@ -500,8 +484,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("the render decode spells a MethodDef's return")
-  func returnType() {
+  @Test func `the render decode spells a MethodDef's return`() {
     // The signature `void Method(i4, string)` decodes its return to `Void`, the
     // render-time decode replacing the old `ReturnType` virtual column.
     DatabaseSQLTests.with { catalog in
@@ -509,8 +492,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("the render decode spells each Param, nil for the return parameter")
-  func paramType() {
+  @Test func `the render decode spells each Param, nil for the return parameter`() {
     // The `Sequence == 0` return pseudo-parameter (`Param` Id 1) decodes to
     // `nil`; the two real parameters (Ids 2 and 3) decode to the signature's
     // `i4` (`CInt`) and `string` (`HSTRING`) — the render-time decode replacing
@@ -523,8 +505,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("the bundled `bases` view yields the interface's derived bases")
-  func bundledBases() throws {
+  @Test func `the bundled bases view yields the interface's derived bases`() throws {
     // `IMyInterface` is `TypeDef` Id 1; binding `:parent` to its Id
     // navigates `InterfaceImpl.Class = :parent`, and the view UNIONs both arms
     // of the `Interface` coded index: the cross-file `IInspectable` reached
@@ -538,8 +519,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("the bundled `bases` view is empty for a rootless interface")
-  func bundledBasesRoot() throws {
+  @Test func `the bundled bases view is empty for a rootless interface`() throws {
     // `INotGuid` is `TypeDef` Id 2 and has no `InterfaceImpl` row, so the
     // view yields no base — the render's `IUnknown` default path.
     try DatabaseSQLTests.with { catalog in
@@ -550,8 +530,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("renders the fixture interface's `@com` protocol from the views")
-  func render() throws {
+  @Test func `renders the fixture interface's @com protocol from the views`() throws {
     // The render joins the bundled views — `interfaces` → `methods` → `params`
     // → `bases` — and the Mustache template into the `@com` protocol source.
     // The fixture is `IMyInterface` with the well-known IID and the single
@@ -574,8 +553,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("renders the `IUnknown` default for a rootless interface")
-  func renderRoot() throws {
+  @Test func `renders the IUnknown default for a rootless interface`() throws {
     // A `bases`-empty interface (no `InterfaceImpl` row) falls back to the
     // `IUnknown` COM-root convention. The fixture's only IID-carrying type has
     // an `InterfaceImpl`, so this overrides `bases` with a never-matching view
@@ -595,8 +573,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("the root interface renders with no base, not self-inheritance")
-  func renderRootInterface() throws {
+  @Test func `the root interface renders with no base, not self-inheritance`() throws {
     // When the rendered interface is the COM root itself (`IUnknown`), it
     // implements nothing, so `bases` is empty. The root default must not then
     // make it its own base — `public protocol IUnknown: IUnknown` is invalid
@@ -610,8 +587,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("a keyword base interface name is escaped in the inheritance clause")
-  func renderKeywordBase() throws {
+  @Test func `a keyword base interface name is escaped in the inheritance clause`() throws {
     // A base whose `TypeName` is a Swift keyword (`protocol`, `repeat`, …) must
     // be escaped in the `: <base>` clause, exactly as the interface, method, and
     // parameter names are — otherwise `public protocol IMyInterface: protocol`
@@ -630,8 +606,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("an unknown interface name raises a clear render error")
-  func renderUnknown() {
+  @Test func `an unknown interface name raises a clear render error`() {
     DatabaseSQLTests.with { catalog in
       let shell = Shell(catalog)
       #expect(throws: Shell.RenderError.interface("IMissing")) {
@@ -640,8 +615,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("execute routes `.render <iface> <tmpl>` to the render command")
-  func renderCommand() throws {
+  @Test func `execute routes .render <iface> <tmpl> to the render command`() throws {
     // The leading-token dispatch matches `.render` to `Render`, which renders
     // the named interface through the named template (here the fixture's
     // `IMyInterface` through `com`, so `execute` succeeds). Anything but two
@@ -660,8 +634,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("`*` renders every interface in the views")
-  func renderAll() throws {
+  @Test func `* renders every interface in the views`() throws {
     // `*` drops the name filter and loops every interface; this fixture's
     // `interfaces` view holds only `IMyInterface` (the IID-carrying type), so
     // the sweep emits its protocol — exercising the no-filter `*` path.
@@ -673,8 +646,7 @@ struct DatabaseSQLTests {
   }
 
 
-  @Test("a coded-index join key decodes to the target's Id")
-  func codedKeyResolves() throws {
+  @Test func `a coded-index join key decodes to the target's Id`() throws {
     // `CustomAttribute[0].Parent` is `HasCustomAttribute(TypeDef row 1)`, so
     // the `Parent_TypeDef` key decodes to the owning `TypeDef`'s 1-based Id.
     try DatabaseSQLTests.with { catalog in
@@ -684,8 +656,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("a coded-index join key is NULL when it points elsewhere")
-  func codedKeyNull() throws {
+  @Test func `a coded-index join key is NULL when it points elsewhere`() throws {
     // The same `Parent` cell tags `TypeDef` (tag 3), so every other candidate
     // target's join key — here `Parent_MethodDef` (tag 0) — is SQL NULL: a NULL
     // will not equi-join, so only the `TypeDef` key matches.
@@ -704,8 +675,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("a coded-index join key is excluded from SELECT *")
-  func codedKeyStar() throws {
+  @Test func `a coded-index join key is excluded from SELECT *`() throws {
     // `SELECT *` projects exactly the three real `CustomAttribute` fields —
     // neither the virtuals nor the coded-index join keys appear.
     try DatabaseSQLTests.with { catalog in
@@ -716,8 +686,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("a coded-index join key joins a CustomAttribute to its owning TypeDef")
-  func codedKeyJoin() throws {
+  @Test func `a coded-index join key joins a CustomAttribute to its owning TypeDef`() throws {
     // Joining `CustomAttribute` to `TypeDef` on the decoded `Parent_TypeDef`
     // key against the `TypeDef`'s Id pairs the `GuidAttribute` row (its
     // `GUID(Value)` IID) with the `IMyInterface` type it decorates, end to end
@@ -735,8 +704,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("a script's CREATE VIEW is visible to a later statement's SELECT")
-  func scriptSession() throws {
+  @Test func `a script's CREATE VIEW is visible to a later statement's SELECT`() throws {
     // The batch driver seeds the bundled views and threads one shared `Session`
     // across every statement, so a `CREATE VIEW` registered by one statement is
     // visible to a later `SELECT`. `execute` prints rather than returning rows,
@@ -754,8 +722,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("a `.bind` value threads into a later parameterized SELECT")
-  func bindThreadsIntoQuery() throws {
+  @Test func `a .bind value threads into a later parameterized SELECT`() throws {
     // `.bind` stores a `:name` in the shell's `bindings`, which `execute`'s SQL
     // path forwards to `Session.run(_, bindings:)`. Binding `:name` to a
     // `TypeName` the fixture carries, then running `WHERE TypeName = :name`
@@ -783,8 +750,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("a `.bind` value threads into a WITH statement's parameterized body")
-  func bindThreadsIntoWith() throws {
+  @Test func `a .bind value threads into a WITH statement's parameterized body`() throws {
     // A `:name` in a `WITH` body must bind from the shell's `.bind` values the
     // same way a plain `SELECT`'s does — `Session.run` forwards `bindings` to
     // the WITH arm. Binding `:name` to a `TypeName` the fixture carries, then
@@ -812,8 +778,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("a `.template` registers an inline body that shadows a file lookup")
-  func templateRegisters() throws {
+  @Test func `a .template registers an inline body that shadows a file lookup`() throws {
     // `.template` stores its body in the shell's `templates`, and
     // `template(named:)` returns it (unescaped) when present — an inline
     // template shadows the `-I`/bundle resolution. Registering `com` (the one
@@ -829,8 +794,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("a `.render` through an inline template renders the interface")
-  func templateRenders() throws {
+  @Test func `a .render through an inline template renders the interface`() throws {
     // The end-to-end pipeline: define an inline template, then `.render` an
     // interface through it. The fixture's `IMyInterface` renders through a
     // minimal inline template (no language directive — the identity language
@@ -843,8 +807,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("execute routes a `.`-token to its meta-command")
-  func executeMeta() throws {
+  @Test func `execute routes a .-token to its meta-command`() throws {
     // The leading-token dispatch matches `.tables` to `Tables`, which lists the
     // storage's relations; the fixture's catalog vends them, so `execute`
     // succeeds. A SQL statement takes the parse path instead — exercised by
@@ -856,8 +819,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("execute rejects an unknown or empty-argument `.`-command")
-  func executeUnknown() {
+  @Test func `execute rejects an unknown or empty-argument .-command`() {
     // An unrecognised `.`-token is `MetaError.unknown`, and a `.read` with no
     // path executes to the same unknown fault — the empty-argument guard the
     // `Read` command carries.
@@ -872,8 +834,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("`.schema` types a query's result columns without running it")
-  func schemaColumns() throws {
+  @Test func `.schema types a query's result columns without running it`() throws {
     // `.schema` prints the query's result columns — the name and type
     // `session.columns(of:)` resolves WITHOUT opening a cursor, the capability
     // the command formats. `TypeDef.TypeName` is a `#Strings` column, so it
@@ -895,8 +856,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("`.schema` faults on a query that would not run, without running it")
-  func schemaFaults() {
+  @Test func `.schema faults on a query that would not run, without running it`() {
     // `.schema` resolves the query the way a run would, so an unknown relation
     // faults `SQLError.relation` exactly as a run would — the dry-run check —
     // rather than silently printing nothing. An empty query is the unknown-meta
@@ -912,8 +872,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("`.schema` describes a WITH statement, the shape the shell runs")
-  func schemaWith() {
+  @Test func `.schema describes a WITH statement, the shape the shell runs`() {
     // `.schema` routes through the CTE-aware, statement-level derive, so a
     // `WITH` types its trailing query against the CTE scope — the SAME
     // statement the shell runs. The trailing `SELECT n FROM t` resolves `n` off
@@ -929,8 +888,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("`.schema` faults a WITH whose body arity contradicts its list")
-  func schemaWithBadArity() {
+  @Test func `.schema faults a WITH whose body arity contradicts its list`() {
     // The CTE declares ONE column but its body — a `SELECT *` over the
     // six-column `TypeDef` — projects six. The parser cannot catch this (a
     // `SELECT *`'s width is known only at resolution), so a run rejects it with
@@ -945,8 +903,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("an empty SELECT frames its REAL column names, not `column N`")
-  func emptyResultRealHeaders() throws {
+  @Test func `an empty SELECT frames its REAL column names, not column N`() throws {
     // A `SELECT *` yielding no rows still frames its box, and the headers are
     // the RESOLVED result-schema names (`columns(of:)`), not the positional
     // `column N` a syntactic `SELECT *` would fall back to. A false predicate
@@ -962,8 +919,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("a non-empty SELECT frames its rows under the resolved headers")
-  func nonEmptyResultHeaders() throws {
+  @Test func `a non-empty SELECT frames its rows under the resolved headers`() throws {
     // A `SELECT` yielding rows frames them under its resolved headers — the box
     // renderer always heads its grid, so a run with rows keeps the same column
     // names as the empty case. A `CREATE VIEW` is not row output, so `headers`
@@ -978,8 +934,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("a data-dependent empty result headers without re-validating")
-  func emptyResultHeadersDerived() throws {
+  @Test func `a data-dependent empty result headers without re-validating`() throws {
     // A `WHERE` no fixture row satisfies filters the result to empty, so the
     // projection's `TypeName + 1` (text arithmetic) NEVER evaluates — the run
     // SUCCEEDS with zero rows. The header path then DERIVES the `x` header off
@@ -994,8 +949,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("a WITH's SELECT * over a CTE heads the CTE's columns, not the base")
-  func withCTEShadowingHeaders() throws {
+  @Test func `a WITH's SELECT * over a CTE heads the CTE's columns, not the base`() throws {
     // A CTE `TypeDef` SHADOWS the six-column base `TypeDef`: the run resolves
     // the trailing `SELECT * FROM TypeDef` against the CTE (one column `x`), so
     // the header must too — derived with the CTE scope in place, not the base
@@ -1009,8 +963,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("a WITH heads its trailing query's CTE-resolved column names")
-  func withCTEExplicitHeaders() throws {
+  @Test func `a WITH heads its trailing query's CTE-resolved column names`() throws {
     // The trailing query names columns off the CTE it references: an explicit
     // list `(a, b)` heads `a, b` through the CTE, and a bare-column projection
     // reads the CTE's declared column. Both resolve against the CTE scope.
@@ -1025,8 +978,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("a WITH not shadowing a base heads its trailing SELECT * real names")
-  func withCTENotShadowingHeaders() throws {
+  @Test func `a WITH not shadowing a base heads its trailing SELECT * real names`() throws {
     // A CTE whose name does NOT collide with a base relation leaves the base
     // reachable: the trailing `SELECT * FROM TypeDef` resolves the six real
     // base columns, and the unrelated CTE scope does not perturb them.
@@ -1039,8 +991,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("`.schema` still faults a data-dependently ill-typed query")
-  func schemaFaultsIllTyped() {
+  @Test func `.schema still faults a data-dependently ill-typed query`() {
     // The validating default a static shape check keeps: `.schema` reports an
     // ill-typed query even when a data-dependent filter would spare it at run.
     // The SAME `TypeName + 1` the derive-only header renders faults here — the
@@ -1056,8 +1007,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("a `.quit` inside a `.read` file leaves the shell, not just the file")
-  func readPropagatesQuit() throws {
+  @Test func `a .quit inside a .read file leaves the shell, not just the file`() throws {
     // `.read` drives the same statement stream, but a `.quit` in the file must
     // throw `Stop` past the file reader so the whole session ends — the help's
     // promise — not merely the included file. The statement after the `.quit`
@@ -1075,8 +1025,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("a `.read` fault fails an explicit batch fast")
-  func readFailsFastInBatch() throws {
+  @Test func `a .read fault fails an explicit batch fast`() throws {
     // A `strict` shell (an explicit batch) lets an included file's fault
     // propagate, so the run aborts rather than pressing on against a partially
     // applied session. The bad `SELECT` is the file's only statement here; that
@@ -1094,8 +1043,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("a `.read` fault is reported and skipped in shell mode")
-  func readContinuesInShell() throws {
+  @Test func `a .read fault is reported and skipped in shell mode`() throws {
     // A forgiving shell (the interactive/redirected path) reports a statement's
     // fault and reads on, so an included file behaves like its text on stdin: a
     // bad statement does not skip the file's later valid ones. `.read` must not
@@ -1115,8 +1063,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("a script SELECTing a bundled view sees it through the seeded session")
-  func scriptBundledView() throws {
+  @Test func `a script SELECTing a bundled view sees it through the seeded session`() throws {
     // The `script` runner seeds `Session.bundled()`, so a statement may name a
     // bundled view (here `interfaces`) with no explicit `CREATE VIEW` — the gap
     // the old one-shot path (an empty view set) could not span. The session
@@ -1133,8 +1080,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("print-namespaces yields a plain one-per-line list, not a boxed table")
-  func printNamespacesPlainList() throws {
+  @Test func `print-namespaces yields a plain one-per-line list, not a boxed table`() throws {
     // `print-namespaces` DEDUPS through `SELECT DISTINCT … ORDER BY`, but its
     // output is one plain namespace element per row scripts parse a line at a
     // time — NOT the boxed table `Shell.execute` frames a row result as. The
@@ -1150,8 +1096,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("print-namespaces on an empty database yields no lines")
-  func printNamespacesEmpty() throws {
+  @Test func `print-namespaces on an empty database yields no lines`() throws {
     // A database with an empty `TypeDef` table has no namespaces, so the
     // DISTINCT query returns zero rows. `print-namespaces` must then emit
     // NOTHING — an empty element list prints no lines — so a script reading a
@@ -1162,8 +1107,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("print-namespaces yields one blank line for the global namespace")
-  func printNamespacesGlobal() throws {
+  @Test func `print-namespaces yields one blank line for the global namespace`() throws {
     // A database whose lone `TypeDef` lives in the global namespace — a
     // `TypeNamespace` of the empty string — has exactly one namespace: the
     // empty one. `print-namespaces` must yield a single empty-string element,
@@ -1175,8 +1119,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("a coded-index join key admits one key per candidate target table")
-  func codedKeyEnumeration() {
+  @Test func `a coded-index join key admits one key per candidate target table`() {
     // `CustomAttribute.Parent` is `HasCustomAttribute`, which admits 22 target
     // tables, plus `Type` is `CustomAttributeType`, which admits two (its three
     // reserved tags yield no key): the relation exposes 24 join keys in total,
@@ -1193,8 +1136,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("an unowned Param's render decode is nil and does not trap")
-  func paramTypeUnowned() {
+  @Test func `an unowned Param's render decode is nil and does not trap`() {
     // A `Param` no `MethodDef` run owns — the `MethodDef` table is present but
     // has zero rows, so its owner resolves to 0 — decodes to `nil` rather than
     // indexing the negative row `owner - 1` through the parent cursor.
@@ -1203,8 +1145,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("a System.Guid Param decodes to CLSID or IID by its Name")
-  func paramTypeGuidClassification() {
+  @Test func `a System.Guid Param decodes to CLSID or IID by its Name`() {
     // The signature `void Method(Guid, Guid)` names `System.Guid` parameters;
     // the render decode classifies each by the `Param.Name` hint — `clsid`
     // (Id 2) yields `CLSID`, `iid` (Id 3) yields the default `IID`.
@@ -1214,8 +1155,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("a `-I` directory's template shadows the bundled one")
-  func searchTemplateOverride() throws {
+  @Test func `a -I directory's template shadows the bundled one`() throws {
     // A `-I` directory's `Templates/com.mustache` is loaded in place of the
     // bundled template, so the render emits the override's text.
     let root = NSTemporaryDirectory() + "winmd-inspect-\(UUID().uuidString)"
@@ -1232,8 +1172,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("a `-I` directory's view joins the bundled ones in the seed")
-  func searchViewAddition() throws {
+  @Test func `a -I directory's view joins the bundled ones in the seed`() throws {
     // A `-I` directory's `Queries/extra.sql` adds its view to the seed, while
     // the bundled views (here `interfaces`) remain — the union.
     let root = NSTemporaryDirectory() + "winmd-inspect-\(UUID().uuidString)"
@@ -1248,8 +1187,7 @@ struct DatabaseSQLTests {
     #expect(views.keys.contains("interfaces"))
   }
 
-  @Test("a search directory without a match falls back to the bundle")
-  func searchFallsBackToBundle() throws {
+  @Test func `a search directory without a match falls back to the bundle`() throws {
     // A `-I` directory that holds no matching resource leaves the render on the
     // bundled template and views, so the normal `@com` protocol still renders.
     let root = NSTemporaryDirectory() + "winmd-inspect-\(UUID().uuidString)"
@@ -1263,8 +1201,7 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test("with two `-I` directories the last one wins")
-  func searchLastWins() throws {
+  @Test func `with two -I directories the last one wins`() throws {
     // Both directories carry a `Templates/com.mustache`; the render must use the
     // LAST `-I`'s copy, so a later directory overrides an earlier one.
     let first = NSTemporaryDirectory() + "winmd-inspect-\(UUID().uuidString)"

--- a/Tests/winmd-inspectTests/QueryTests.swift
+++ b/Tests/winmd-inspectTests/QueryTests.swift
@@ -32,8 +32,7 @@ struct QueryTests {
     try body(url.path)
   }
 
-  @Test("the database leads the command line; SQL is an optional positional")
-  func databaseLeadsSQL() throws {
+  @Test func `the database leads the command line; SQL is an optional positional`() throws {
     try QueryTests.withDatabase { database in
       // The database leads the command line as the root's positional — the
       // subcommand comes after it — and is propagated into the subcommand's
@@ -63,8 +62,7 @@ struct QueryTests {
     }
   }
 
-  @Test("the leading database is validated to be an existing file")
-  func validatesDatabase() throws {
+  @Test func `the leading database is validated to be an existing file`() throws {
     // The root validates the leading `<database>` before dispatching, so a
     // non-existent path fails the parse whichever subcommand follows.
     #expect(throws: (any Error).self) {

--- a/Tests/winmd-inspectTests/ShellTests.swift
+++ b/Tests/winmd-inspectTests/ShellTests.swift
@@ -31,8 +31,7 @@ struct ShellTests {
     try body(url.path)
   }
 
-  @Test("`query` is the default subcommand; its verb may be omitted")
-  func queryIsDefault() throws {
+  @Test func `query is the default subcommand; its verb may be omitted`() throws {
     try ShellTests.withDatabase { database in
       // With `query` the default subcommand, `<db>` alone parses to a `Query`
       // opening the shell (no script), the same as `<db> query`, and a bare
@@ -55,8 +54,7 @@ struct ShellTests {
     }
   }
 
-  @Test("each meta-command answers to its `.`-prefixed spelling")
-  func spellings() {
+  @Test func `each meta-command answers to its .-prefixed spelling`() {
     // The leading-token dispatch matches a `.`-token against each `Metacommand`
     // type's `spelling`; these are the tokens `execute` routes on.
     #expect(Tables.spelling == ".tables")
@@ -69,8 +67,7 @@ struct ShellTests {
     #expect(Template.spelling == ".template")
   }
 
-  @Test("`.read` parses its trailing path, trimming surrounding whitespace")
-  func read() {
+  @Test func `.read parses its trailing path, trimming surrounding whitespace`() {
     // `Read.init` takes the rest of the statement after the spelling token and
     // trims it to the path; the stream has already split off `.read`.
     #expect(Read(" foo.sql").path == "foo.sql")
@@ -79,8 +76,7 @@ struct ShellTests {
     #expect(Read("").path.isEmpty)
   }
 
-  @Test("`.schema` parses its trailing query, dropping a trailing `;`")
-  func schema() {
+  @Test func `.schema parses its trailing query, dropping a trailing ;`() {
     // `Schema.init` takes the rest of the statement after the spelling token as
     // the query text, trimmed and with a single trailing `;` removed (the same
     // optional terminator a run tolerates).
@@ -90,8 +86,7 @@ struct ShellTests {
     #expect(Schema("").query.isEmpty)
   }
 
-  @Test("`.render` parses its interface and template arguments")
-  func render() {
+  @Test func `.render parses its interface and template arguments`() {
     // `Render.init` splits the rest of the statement into interface then
     // template; both are required, so anything but two fields leaves them empty
     // and `execute` rejects it.
@@ -102,8 +97,7 @@ struct ShellTests {
     #expect(Render("").template.isEmpty)
   }
 
-  @Test("`.bind` parses its name and types its value")
-  func bind() {
+  @Test func `.bind parses its name and types its value`() {
     // `Bind.init` takes the name (the first whitespace token) and the trimmed
     // remainder as the value, typed: an `Int`-parsable value is an `.integer`,
     // else `.text` with a surrounding single-quote pair stripped and a doubled
@@ -125,8 +119,7 @@ struct ShellTests {
     #expect(Bind("  ").name.isEmpty)
   }
 
-  @Test("`.template` parses its name and unquotes the single-quoted body")
-  func template() {
+  @Test func `.template parses its name and unquotes the single-quoted body`() {
     // `Template.init` takes the name (the first whitespace token) then the
     // single-quoted literal that follows, from its first `'` to the matching
     // close, `''` unescaped to one `'`.
@@ -145,8 +138,7 @@ struct ShellTests {
     #expect(Template("t").body.isEmpty)
   }
 
-  @Test("a `;`-separated script streams into trimmed, non-empty statements")
-  func stream() {
+  @Test func `a ;-separated script streams into trimmed, non-empty statements`() {
     // The `Statements` stream is the load-bearing part of a batch run: trailing
     // `;`, whitespace, and blank statements (a `;;`) are dropped, each statement
     // trimmed, and a `.`-meta line yields whole.
@@ -162,8 +154,7 @@ struct ShellTests {
     #expect(Array(Statements(of: "   \n  ")).isEmpty)
   }
 
-  @Test("the statement stream accumulates a SQL statement across lines")
-  func streamMultiline() {
+  @Test func `the statement stream accumulates a SQL statement across lines`() {
     // A SQL statement may span lines, accumulating until a `;` closes it; an
     // unterminated trailing statement still yields at end of input — the
     // closing `;` is optional, so a one-shot query keeps its last statement.
@@ -176,8 +167,7 @@ struct ShellTests {
             == ["SELECT 1,\n       2", "SELECT 3"])
   }
 
-  @Test("a `;` inside a string literal does not terminate the statement")
-  func streamStringLiteral() {
+  @Test func `a ; inside a string literal does not terminate the statement`() {
     // The splitter must not cut a statement at a `;` that lives inside a
     // single-quoted literal — that `;` is data the SQL lexer scans, not a
     // terminator. A doubled `''` is an escaped quote, so it stays in the
@@ -193,8 +183,7 @@ struct ShellTests {
             == ["SELECT 'x;\n y;' AS s"])
   }
 
-  @Test("a `;` inside a comment does not terminate the statement")
-  func streamComment() {
+  @Test func `a ; inside a comment does not terminate the statement`() {
     // Now that the lexer skips comments, the splitter must too: a `;` inside a
     // `--` line comment or a `/* … */` block comment is not a terminator, or a
     // valid script would be cut mid-comment before the lexer could skip it.
@@ -211,8 +200,7 @@ struct ShellTests {
             == ["SELECT 1", "-- trailing\nSELECT 2"])
   }
 
-  @Test("a trivia-only fragment is not yielded as a statement")
-  func streamTriviaOnly() {
+  @Test func `a trivia-only fragment is not yielded as a statement`() {
     // A chunk that is only whitespace and comments carries no statement, so it
     // is dropped rather than handed to the parser as empty input — a trailing
     // or standalone comment, or a comment between terminators.
@@ -223,8 +211,7 @@ struct ShellTests {
             == ["SELECT 1", "SELECT 2"])
   }
 
-  @Test("an unterminated block comment is yielded, not dropped")
-  func streamUnterminatedComment() {
+  @Test func `an unterminated block comment is yielded, not dropped`() {
     // A CLOSED comment is trivia, but an unclosed `/*` is not: the fragment
     // must reach the parser so the lexer's unterminated-block-comment error
     // surfaces on a batch/`.read`/EOF path rather than being silently
@@ -234,8 +221,7 @@ struct ShellTests {
             == ["SELECT 1", "/* missing close"])
   }
 
-  @Test("a `;` or comment inside a delimited identifier is data")
-  func streamDelimitedIdentifier() {
+  @Test func `a ; or comment inside a delimited identifier is data`() {
     // A double-quoted delimited identifier is tracked like a string literal, so
     // `--`, `/* */`, and `;` inside `"…"` are data — not a comment or a
     // terminator — and the real terminator after it is still found.
@@ -247,8 +233,7 @@ struct ShellTests {
             == ["SELECT \"/* x */\" AS c"])
   }
 
-  @Test("a comment before a meta-command does not turn it into SQL")
-  func streamCommentBeforeMeta() {
+  @Test func `a comment before a meta-command does not turn it into SQL`() {
     // A comment-only pending is trivia, so a following `.`-meta line is still
     // recognised as a meta-command rather than glued onto the comment and sent
     // through SQL parsing.
@@ -256,8 +241,7 @@ struct ShellTests {
     #expect(Array(Statements(of: "/* note */\n.read a.sql")) == [".read a.sql"])
   }
 
-  @Test("an open-quote `.`-meta accumulates raw lines into one statement")
-  func streamOpenQuoteMeta() {
+  @Test func `an open-quote .-meta accumulates raw lines into one statement`() {
     // A `.`-meta whose single-quoted string is still open is a multiline meta:
     // the stream accumulates raw lines verbatim (joined with `\n`) until the
     // quote closes, then yields the whole block as ONE statement — the inline
@@ -284,8 +268,7 @@ struct ShellTests {
     #expect(statements[1] == "SELECT 1")
   }
 
-  @Test("an open-quote meta with a trailing-line close still yields one block")
-  func streamOpenQuoteReading() {
+  @Test func `an open-quote meta with a trailing-line close still yields one block`() {
     // Fed line-by-line (the interactive/`reading:` path), the same accumulation
     // holds: the closing `'` arriving on its own trailing line still yields the
     // whole `.template` block as one statement, and the following `SELECT 1`
@@ -298,8 +281,7 @@ struct ShellTests {
     #expect(statements[1] == "SELECT 1")
   }
 
-  @Test("a `.template` name starting with -- still accumulates its body")
-  func streamTemplateDashName() {
+  @Test func `a .template name starting with -- still accumulates its body`() {
     // The `.template` name is the first token; when it starts with `--`, the
     // meta accumulation must NOT treat the rest of the line as a comment (it is
     // meta text, not SQL) — the open single quote still opens a multiline body.
@@ -314,16 +296,14 @@ struct ShellTests {
     #expect(statements[1] == "SELECT 1")
   }
 
-  @Test("an unclosed open-quote meta flushes at end of input")
-  func streamOpenQuoteUnterminated() {
+  @Test func `an unclosed open-quote meta flushes at end of input`() {
     // End of input before the quote closes flushes what was captured — the
     // closing `'` is as optional as a trailing `;`.
     #expect(Array(Statements(of: ".template t 'unterminated\nbody"))
             == [".template t 'unterminated\nbody"])
   }
 
-  @Test("only `.template` accumulates on an open quote; other metas yield whole")
-  func streamOpenQuoteTemplateOnly() {
+  @Test func `only .template accumulates on an open quote; other metas yield whole`() {
     // The open-quote accumulation is `.template`'s alone. An apostrophe in
     // another meta-command's argument — the path in `.read /tmp/O'Brien.sql` —
     // is data, not an unterminated literal: the `.read` yields whole and the
@@ -333,8 +313,7 @@ struct ShellTests {
             == [".read /tmp/O'Brien.sql", "SELECT 1"])
   }
 
-  @Test("a whitespace-only spacer line before a `.`-command is dropped")
-  func streamSpacerBeforeMeta() {
+  @Test func `a whitespace-only spacer line before a .-command is dropped`() {
     // A blank line carrying spaces before a meta-command must not glue onto it:
     // a whitespace-only `pending` counts as nothing, so the `.`-line still
     // yields whole and a following statement stays a separate statement —
@@ -343,8 +322,7 @@ struct ShellTests {
             == ["SELECT 1", ".tables", "SELECT 2"])
   }
 
-  @Test("the reading stream prompts primary then continuation while pending")
-  func promptAccumulates() {
+  @Test func `the reading stream prompts primary then continuation while pending`() {
     // The interactive shell's prompt hook is called before each line read, told
     // whether a statement is pending (mid-accumulation, unterminated). A fresh
     // statement asks for the primary prompt (`false`); an unterminated one asks
@@ -362,8 +340,7 @@ struct ShellTests {
     #expect(pending == [false, true, false])
   }
 
-  @Test("a fresh statement each line prompts primary, never continuation")
-  func promptFresh() {
+  @Test func `a fresh statement each line prompts primary, never continuation`() {
     // Each self-terminating statement (its own `;`) leaves nothing pending, so
     // every prompt before a read is the primary — a `.`-meta line likewise. The
     // final read past the last line sees nothing pending too.
@@ -376,8 +353,7 @@ struct ShellTests {
     #expect(pending.allSatisfy { $0 == false })
   }
 
-  @Test("the batch stream carries no prompt hook and never prompts")
-  func batchIsQuiet() {
+  @Test func `the batch stream carries no prompt hook and never prompts`() {
     // `Statements(of:)` is the argument/`.read` path; it takes no prompt hook,
     // so a batch run never prompts. Draining a multi-statement script drives
     // the same accumulation the interactive stream does, with no prompt to
@@ -386,16 +362,14 @@ struct ShellTests {
             == ["SELECT 1\nFROM Module", "SELECT 2"])
   }
 
-  @Test("the bundled views are the four COM-interface views")
-  func bundled() {
+  @Test func `the bundled views are the four COM-interface views`() {
     // The parse-and-register path a `CREATE VIEW` reuses; the four bundled
     // views register under their case-folded names.
     let views = Session.bundled()
     #expect(Set(views.keys) == ["interfaces", "methods", "params", "bases"])
   }
 
-  @Test("a streamed CREATE VIEW statement parses and registers a view")
-  func register() throws {
+  @Test func `a streamed CREATE VIEW statement parses and registers a view`() throws {
     // A batch run runs each streamed statement through `execute`, whose `CREATE
     // VIEW` branch parses and registers it. A `Database` (a full PE image) is
     // awkward to assemble in memory — the WinMD fixtures all work over
@@ -414,8 +388,7 @@ struct ShellTests {
     #expect(views.keys.contains("v"))
   }
 
-  @Test("a language spec parses its escape, void, root, keyword, and type keys")
-  func languageParses() {
+  @Test func `a language spec parses its escape, void, root, keyword, and type keys`() {
     let swift = Language(parsing: """
       # a comment
       escape-prefix `
@@ -463,8 +436,7 @@ struct ShellTests {
                 .decode(with: resolver, dialect: dialect) == "HRESULT")
   }
 
-  @Test("the box renderer frames a header over a ruled multi-row grid")
-  func boxHeaderAndRows() {
+  @Test func `the box renderer frames a header over a ruled multi-row grid`() {
     // The `.mode box` grid: a `┌─┬─┐` top, the header row, a `├─┼─┤` rule, one
     // line per row, and a `└─┴─┘` bottom, every cell padded one space each side.
     let table = Box.render(["Name", "Id"],
@@ -480,8 +452,7 @@ struct ShellTests {
       """)
   }
 
-  @Test("each column is sized to the widest of its header and its cells")
-  func boxColumnWidth() {
+  @Test func `each column is sized to the widest of its header and its cells`() {
     // Column width is the max of the header and every cell's display width: the
     // first column is sized by its long cell (`elongated`), the second by its
     // header (`X`), which outsizes its one-character cells.
@@ -496,8 +467,7 @@ struct ShellTests {
       """)
   }
 
-  @Test("an empty result renders the header and frame alone")
-  func boxEmptyResult() {
+  @Test func `an empty result renders the header and frame alone`() {
     // With no rows the header row still prints between the top frame and the
     // header rule and bottom frame — sized to the header widths — so the column
     // names remain visible.
@@ -509,8 +479,7 @@ struct ShellTests {
       """)
   }
 
-  @Test("a NULL or empty cell renders as blank padding")
-  func boxNullAndEmptyCell() {
+  @Test func `a NULL or empty cell renders as blank padding`() {
     // A `.null` cell (and an empty `.text`) shows as the empty string — the way
     // the shell's list mode displays a NULL — padded to the column width. A row
     // shorter than the header pads its missing trailing cells empty too.
@@ -527,8 +496,7 @@ struct ShellTests {
       """)
   }
 
-  @Test("a wide (double-width) cell is sized by its display columns")
-  func boxWideCell() {
+  @Test func `a wide (double-width) cell is sized by its display columns`() {
     // A cell's width is measured in display columns, not bytes or scalars: a
     // fullwidth CJK character occupies two columns, so the column sizes to four
     // (two glyphs) rather than mis-sizing on its scalar count, keeping the frame
@@ -543,8 +511,7 @@ struct ShellTests {
       """)
   }
 
-  @Test("the identity spec escapes nothing and applies no conventions")
-  func languageIdentity() {
+  @Test func `the identity spec escapes nothing and applies no conventions`() {
     // A template that declares no language (or names a spec with no resource)
     // gets the identity `Language`: every identifier and return is verbatim, no
     // root default applies, and its `Dialect` falls a primitive back to its

--- a/Tests/winmd-inspectTests/ValueDisplayTests.swift
+++ b/Tests/winmd-inspectTests/ValueDisplayTests.swift
@@ -11,8 +11,7 @@ import SQL
 
 @Suite("BOOLEAN display")
 private struct BooleanDisplayTests {
-  @Test("a boolean renders as TRUE or FALSE")
-  func spelling() {
+  @Test func `a boolean renders as TRUE or FALSE`() {
     #expect(Value.boolean(true).display == "TRUE")
     #expect(Value.boolean(false).display == "FALSE")
   }
@@ -22,14 +21,12 @@ private struct BooleanDisplayTests {
 
 @Suite("DOUBLE display")
 private struct DoubleDisplayTests {
-  @Test("a double renders through its round-tripping description")
-  func description() {
+  @Test func `a double renders through its round-tripping description`() {
     #expect(Value.double(3.14).display == "3.14")
     #expect(Value.double(2.5).display == "2.5")
   }
 
-  @Test("a whole double keeps its .0, marking it approximate-numeric")
-  func whole() {
+  @Test func `a whole double keeps its .0, marking it approximate-numeric`() {
     #expect(Value.double(1.0).display == "1.0")
     #expect(Value.double(1000.0).display == "1000.0")
   }
@@ -39,18 +36,15 @@ private struct DoubleDisplayTests {
 
 @Suite("BLOB display")
 private struct BlobDisplayTests {
-  @Test("a blob renders as a lowercase-hex x'…' literal")
-  func hex() {
+  @Test func `a blob renders as a lowercase-hex x'…' literal`() {
     #expect(Value.blob([0x53, 0x51, 0x4c]).display == "x'53514c'")
   }
 
-  @Test("hex is lowercase and keeps a byte's leading zero")
-  func lowercaseAndPadding() {
+  @Test func `hex is lowercase and keeps a byte's leading zero`() {
     #expect(Value.blob([0x00, 0x0f, 0xab, 0xff]).display == "x'000fabff'")
   }
 
-  @Test("an empty blob renders as x''")
-  func empty() {
+  @Test func `an empty blob renders as x''`() {
     #expect(Value.blob([]).display == "x''")
   }
 }


### PR DESCRIPTION
This pull request refactors the test definitions in `AggregateTests.swift` and `DefinitionSchemaTests.swift` to use backticked function names as test descriptions, rather than string arguments to the `@Test` attribute. This change improves test discoverability and aligns with Swift's recommended style for test naming.

**Test definition refactoring:**

* All test functions in `AggregateTests.swift` now use backticked function names for their descriptions instead of string arguments in the `@Test` attribute. This makes test names more descriptive and directly tied to the test function itself. [[1]](diffhunk://#diff-76b29a890eb1f7f0eb8240649c1eb90f82896c5a1a0ba2143412a4074d133f51L32-R73) [[2]](diffhunk://#diff-76b29a890eb1f7f0eb8240649c1eb90f82896c5a1a0ba2143412a4074d133f51L90-R90) [[3]](diffhunk://#diff-76b29a890eb1f7f0eb8240649c1eb90f82896c5a1a0ba2143412a4074d133f51L110-R101) [[4]](diffhunk://#diff-76b29a890eb1f7f0eb8240649c1eb90f82896c5a1a0ba2143412a4074d133f51L122-R112) [[5]](diffhunk://#diff-76b29a890eb1f7f0eb8240649c1eb90f82896c5a1a0ba2143412a4074d133f51L138-R127) [[6]](diffhunk://#diff-76b29a890eb1f7f0eb8240649c1eb90f82896c5a1a0ba2143412a4074d133f51L164-R152) [[7]](diffhunk://#diff-76b29a890eb1f7f0eb8240649c1eb90f82896c5a1a0ba2143412a4074d133f51L196-R183) [[8]](diffhunk://#diff-76b29a890eb1f7f0eb8240649c1eb90f82896c5a1a0ba2143412a4074d133f51L209-R195) [[9]](diffhunk://#diff-76b29a890eb1f7f0eb8240649c1eb90f82896c5a1a0ba2143412a4074d133f51L233-R218) [[10]](diffhunk://#diff-76b29a890eb1f7f0eb8240649c1eb90f82896c5a1a0ba2143412a4074d133f51L256-R240) [[11]](diffhunk://#diff-76b29a890eb1f7f0eb8240649c1eb90f82896c5a1a0ba2143412a4074d133f51L268-R267) [[12]](diffhunk://#diff-76b29a890eb1f7f0eb8240649c1eb90f82896c5a1a0ba2143412a4074d133f51L297-R285) [[13]](diffhunk://#diff-76b29a890eb1f7f0eb8240649c1eb90f82896c5a1a0ba2143412a4074d133f51L317-R295) [[14]](diffhunk://#diff-76b29a890eb1f7f0eb8240649c1eb90f82896c5a1a0ba2143412a4074d133f51L330-R315) [[15]](diffhunk://#diff-76b29a890eb1f7f0eb8240649c1eb90f82896c5a1a0ba2143412a4074d133f51L349-R356) [[16]](diffhunk://#diff-76b29a890eb1f7f0eb8240649c1eb90f82896c5a1a0ba2143412a4074d133f51L400-R377) [[17]](diffhunk://#diff-76b29a890eb1f7f0eb8240649c1eb90f82896c5a1a0ba2143412a4074d133f51L431-R404) [[18]](diffhunk://#diff-76b29a890eb1f7f0eb8240649c1eb90f82896c5a1a0ba2143412a4074d133f51L451-R416) [[19]](diffhunk://#diff-76b29a890eb1f7f0eb8240649c1eb90f82896c5a1a0ba2143412a4074d133f51L464-R428)

* Similarly, all test functions in `DefinitionSchemaTests.swift` have been updated to use backticked function names for their descriptions. [[1]](diffhunk://#diff-72f18021a3a4aa2d0e12c5a5856db290f60fec4197384b4114ba87595c6560b5L22-R22) [[2]](diffhunk://#diff-72f18021a3a4aa2d0e12c5a5856db290f60fec4197384b4114ba87595c6560b5L33-R32) [[3]](diffhunk://#diff-72f18021a3a4aa2d0e12c5a5856db290f60fec4197384b4114ba87595c6560b5L59-R57)