### PR TITLE
SQL: clean up free functions

### DIFF
--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -17,12 +17,11 @@
 /// equality a `Select` over its product, with the `WHERE` wrapping the whole
 /// chain. Absent layers are omitted. Executing the plan yields the result
 /// records' typed values; formatting them is a client's job.
-public enum Engine {
-  /// The greatest number of fixpoint iterations a recursive CTE may take before
-  /// the engine concludes it does not terminate and throws
-  /// `SQLError.recursion`.
-  internal static let kRecursionCap = 10_000
-}
+public enum Engine {}
+
+/// The greatest number of fixpoint iterations a recursive CTE may take before
+/// the engine concludes it does not terminate and throws `SQLError.recursion`.
+private let kRecursionCap = 10_000
 
 // MARK: - WITH
 
@@ -408,7 +407,7 @@ extension Catalog where Self: ~Escapable {
     var iterations = 0
     while !working.isEmpty {
       iterations += 1
-      guard iterations <= Engine.kRecursionCap else {
+      guard iterations <= kRecursionCap else {
         throw .recursion(cte.name)
       }
 
@@ -459,72 +458,67 @@ extension Projection {
   }
 }
 
-extension Engine {
-  /// A relation resolved for compilation: its name-resolution `schema` and a
-  /// `leaf` factory that, given the ordinals the query references on its side,
-  /// builds the leaf `Plan` — a `scan` for a base table, a `derived` over the
-  /// view's compiled sub-plan for a view.
-  internal struct Resolved {
-    let schema: Schema
-    let leaf: (Array<Int>) -> Plan
-  }
+/// A relation resolved for compilation: its name-resolution `schema` and a
+/// `leaf` factory that, given the ordinals the query references on its side,
+/// builds the leaf `Plan` — a `scan` for a base table, a `derived` over the
+/// view's compiled sub-plan for a view.
+internal struct Resolved {
+  let schema: Schema
+  let leaf: (Array<Int>) -> Plan
+}
 
-  /// The sorted, deduplicated ordinals a query references: the union of the
-  /// ordinals its `projection` terms read, the columns its `filter` reads, and
-  /// EVERY column its `order` keys read. The projection terms hold ordinals at
-  /// this stage; a scalar call's arguments contribute their read ordinals too.
-  internal static func referenced(
-      _ projection: Array<Term>, _ filter: Filter?,
-      _ order: Array<(column: Int, ascending: Bool)>)
-      -> Array<Int> {
-    var ordinals = Set<Int>()
-    for term in projection {
-      term.references(into: &ordinals)
-    }
-    filter?.references(into: &ordinals)
-    for key in order { ordinals.insert(key.column) }
-    return ordinals.sorted()
+/// The sorted, deduplicated ordinals a query references: the union of the
+/// ordinals its `projection` terms read, the columns its `filter` reads, and
+/// EVERY column its `order` keys read. The projection terms hold ordinals at
+/// this stage; a scalar call's arguments contribute their read ordinals too.
+private func referenced(_ projection: Array<Term>, _ filter: Filter?,
+                        _ order: Array<(column: Int, ascending: Bool)>)
+    -> Array<Int> {
+  var ordinals = Set<Int>()
+  for term in projection {
+    term.references(into: &ordinals)
   }
+  filter?.references(into: &ordinals)
+  for key in order { ordinals.insert(key.column) }
+  return ordinals.sorted()
+}
 
-  /// The inverse map `ordinal → slot` of a referenced-ordinal list: slot `i` is
-  /// `ordinals[i]`, so the map sends `ordinals[i]` back to `i`.
-  internal static func invert(_ ordinals: Array<Int>)
-      -> Dictionary<Int, Int> {
-    var slot = Dictionary<Int, Int>(minimumCapacity: ordinals.count)
-    for index in ordinals.indices {
-      slot[ordinals[index]] = index
-    }
-    return slot
+/// The inverse map `ordinal → slot` of a referenced-ordinal list: slot `i` is
+/// `ordinals[i]`, so the map sends `ordinals[i]` back to `i`.
+private func invert(_ ordinals: Array<Int>) -> Dictionary<Int, Int> {
+  var slot = Dictionary<Int, Int>(minimumCapacity: ordinals.count)
+  for index in ordinals.indices {
+    slot[ordinals[index]] = index
   }
+  return slot
+}
 
-  /// Rejects an `ORDER BY` key naming a column outside the `DISTINCT` output.
-  ///
-  /// `SELECT DISTINCT` sorts the pre-projection rows then dedups the projected
-  /// ones, so ordering on a column the projection drops is ill-defined — after
-  /// dedup one output row stands for many source rows, whose differing sort-key
-  /// values leave no single order. The standard therefore requires every
-  /// `ORDER BY` key under `DISTINCT` to be a column of the select list, as the
-  /// grouped path requires for `GROUP BY`. Each resolved order key's ordinal
-  /// (`order`, paired index-for-index with the AST `keys` for the offending
-  /// name) must equal a projected term that is a bare `.slot` — a plain output
-  /// column; a computed projection is not orderable-on anyway. A key naming no
-  /// output column faults `SQLError.distinct`. Only a `distinct` query is
-  /// checked; a plain `SELECT` may order on any source column.
-  ///
-  /// The check runs in whatever slot space the caller resolved into: the
-  /// non-aggregate paths pass base ordinals, the grouped path passes grouped
-  /// slots. Both are consistent — `order` and `projection` share it — so the
-  /// one comparison serves every compile path.
-  internal static func distinct(
-      _ keys: Array<Order.Key>, _ order: Array<Int>,
-      _ projection: Array<Term>) throws(SQLError) {
-    var output = Set<Int>()
-    for term in projection {
-      if case let .slot(ordinal) = term { output.insert(ordinal) }
-    }
-    for index in order.indices where !output.contains(order[index]) {
-      throw .distinct(keys[index].column.name)
-    }
+/// Rejects an `ORDER BY` key naming a column outside the `DISTINCT` output.
+///
+/// `SELECT DISTINCT` sorts the pre-projection rows then dedups the projected
+/// ones, so ordering on a column the projection drops is ill-defined — after
+/// dedup one output row stands for many source rows, whose differing sort-key
+/// values leave no single order. The standard therefore requires every
+/// `ORDER BY` key under `DISTINCT` to be a column of the select list, as the
+/// grouped path requires for `GROUP BY`. Each resolved order key's ordinal
+/// (`order`, paired index-for-index with the AST `keys` for the offending
+/// name) must equal a projected term that is a bare `.slot` — a plain output
+/// column; a computed projection is not orderable-on anyway. A key naming no
+/// output column faults `SQLError.distinct`. Only a `distinct` query is
+/// checked; a plain `SELECT` may order on any source column.
+///
+/// The check runs in whatever slot space the caller resolved into: the
+/// non-aggregate paths pass base ordinals, the grouped path passes grouped
+/// slots. Both are consistent — `order` and `projection` share it — so the
+/// one comparison serves every compile path.
+private func distinct(_ keys: Array<Order.Key>, _ order: Array<Int>,
+                      _ projection: Array<Term>) throws(SQLError) {
+  var output = Set<Int>()
+  for term in projection {
+    if case let .slot(ordinal) = term { output.insert(ordinal) }
+  }
+  for index in order.indices where !output.contains(order[index]) {
+    throw .distinct(keys[index].column.name)
   }
 }
 
@@ -616,13 +610,13 @@ extension Catalog where Self: ~Escapable {
   /// standard rule that every non-aggregated projection/`ORDER BY` column appear
   /// in the `GROUP BY`.
   internal borrowing func group(_ select: Select, _ relation: Relation,
-                                _ from: Engine.Resolved, _ ctes: CTEs,
+                                _ from: Resolved, _ ctes: CTEs,
                                 _ visited: Set<String>)
       throws(SQLError) -> Plan {
     // Resolve every joined relation and lay the FROM relation and each joined
     // one end to end in one combined ordinal space (as the non-aggregate join
     // path does), so the WHERE, keys, and aggregate arguments resolve uniformly.
-    var joined = Array<Engine.Resolved>()
+    var joined = Array<Resolved>()
     joined.reserveCapacity(select.joins.count)
     for join in select.joins {
       try joined.append(resolve(join.relation, ctes, visited))
@@ -725,10 +719,10 @@ extension Catalog where Self: ~Escapable {
 
     // Under DISTINCT every ORDER BY key must be a select-list column — the
     // dedup runs on the projected rows, so ordering on a dropped column is
-    // ill-defined (see `Engine.distinct`). The order keys and projection are
+    // ill-defined (see `distinct`). The order keys and projection are
     // in grouped-slot space here, aligned with the AST keys index-for-index.
     if select.distinct, let clause = select.order {
-      try Engine.distinct(clause.keys, order.map(\.slot), projection)
+      try distinct(clause.keys, order.map(\.slot), projection)
     }
 
     var plan = node
@@ -960,27 +954,27 @@ extension Catalog where Self: ~Escapable {
   }
 }
 
-extension Engine {
-  /// The seekable `(slot, op, integer)` of `filter`: a `compare` against an
-  /// integer literal, or a `bound` whose parameter resolves to an integer in
-  /// `bindings`. A string operand, an unbound or non-integer parameter, or a
-  /// non-comparison does not qualify, and the relation scans.
-  private static func comparison(_ filter: Filter, _ bindings: Bindings)
-      -> (Int, Comparison, Int)? {
-    switch filter {
-    case let .compare(.slot(slot), op, .constant(.integer(value))):
+/// The seekable `(slot, op, integer)` of `filter`: a `compare` against an
+/// integer literal, or a `bound` whose parameter resolves to an integer in
+/// `bindings`. A string operand, an unbound or non-integer parameter, or a
+/// non-comparison does not qualify, and the relation scans.
+private func comparison(_ filter: Filter, _ bindings: Bindings)
+    -> (Int, Comparison, Int)? {
+  switch filter {
+  case let .compare(.slot(slot), op, .constant(.integer(value))):
+    (slot, op, value)
+  case let .bound(.slot(slot), op, parameter):
+    if case let .integer(value)? = bindings[parameter] {
       (slot, op, value)
-    case let .bound(.slot(slot), op, parameter):
-      if case let .integer(value)? = bindings[parameter] {
-        (slot, op, value)
-      } else {
-        nil
-      }
-    default:
+    } else {
       nil
     }
+  default:
+    nil
   }
+}
 
+extension Engine {
   /// The boundaries `[lower, upper)` to seek for a sort-key comparison, or `nil`
   /// if `filter` does not qualify for the seek path.
   ///
@@ -1080,7 +1074,7 @@ extension Catalog where Self: ~Escapable {
     let conjuncts = filter.conjuncts
     for index in conjuncts.indices {
       guard case let .match(lhs, rhs) = conjuncts[index],
-          let (leftKey, rightKey) = Engine.keys(lhs, rhs, base) else {
+          let (leftKey, rightKey) = keys(lhs, rhs, base) else {
         continue
       }
 
@@ -1110,20 +1104,18 @@ extension Catalog where Self: ~Escapable {
   }
 }
 
-extension Engine {
-  /// The `(outerKey, innerKey)` an equality between slots `lhs` and `rhs`
-  /// relates across the boundary `base`, or `nil` if both fall on one side.
-  ///
-  /// Exactly one slot must be below `base` (the outer key) and the other at or
-  /// above it (the inner key, still in combined space); the order the equality
-  /// was written in does not matter.
-  internal static func keys(_ lhs: Int, _ rhs: Int, _ base: Int)
-      -> (outer: Int, inner: Int)? {
-    switch (lhs < base, rhs < base) {
-    case (true, false): (lhs, rhs)
-    case (false, true): (rhs, lhs)
-    default: nil
-    }
+/// The `(outerKey, innerKey)` an equality between slots `lhs` and `rhs`
+/// relates across the boundary `base`, or `nil` if both fall on one side.
+///
+/// Exactly one slot must be below `base` (the outer key) and the other at or
+/// above it (the inner key, still in combined space); the order the equality
+/// was written in does not matter.
+private func keys(_ lhs: Int, _ rhs: Int, _ base: Int)
+    -> (outer: Int, inner: Int)? {
+  switch (lhs < base, rhs < base) {
+  case (true, false): (lhs, rhs)
+  case (false, true): (rhs, lhs)
+  default: nil
   }
 }
 
@@ -1496,11 +1488,11 @@ extension Catalog where Self: ~Escapable {
   /// the fault and skips it.
   internal borrowing func resolve(_ relation: Relation, _ ctes: CTEs,
                                   _ visited: Set<String> = [])
-      throws(SQLError) -> Engine.Resolved {
+      throws(SQLError) -> Resolved {
     let name = relation.name
     if let cte = ctes[name.lowercased()] {
       let schema = cte.schema()
-      return Engine.Resolved(schema: schema) { ordinals in
+      return Resolved(schema: schema) { ordinals in
         .scan(name: name, ordinals: ordinals, seek: nil)
       }
     }
@@ -1538,7 +1530,7 @@ extension Catalog where Self: ~Escapable {
         throw .columns(expected: projected, got: view.columns.count)
       }
       let schema = view.schema()
-      return Engine.Resolved(schema: schema) { ordinals in
+      return Resolved(schema: schema) { ordinals in
         .derived(name: name, plan: plan, ordinals: ordinals, seek: nil)
       }
     }
@@ -1547,7 +1539,7 @@ extension Catalog where Self: ~Escapable {
       throw .relation(name)
     }
     let schema = table.schema()
-    return Engine.Resolved(schema: schema) { ordinals in
+    return Resolved(schema: schema) { ordinals in
       .scan(name: name, ordinals: ordinals, seek: nil)
     }
   }
@@ -1627,15 +1619,15 @@ extension Catalog where Self: ~Escapable {
 
       // Under DISTINCT every ORDER BY key must be a select-list column — the
       // dedup runs on the projected rows, so ordering on a dropped column is
-      // ill-defined (see `Engine.distinct`). The order keys and projection are
+      // ill-defined (see `distinct`). The order keys and projection are
       // still in base-ordinal space here, aligned with the AST keys by index.
       if select.distinct, let clause = select.order {
-        try Engine.distinct(clause.keys, order.map(\.column), projection)
+        try distinct(clause.keys, order.map(\.column), projection)
       }
 
       // The referenced ordinals, in slot order: slot `i` is `ordinals[i]`.
-      let ordinals = Engine.referenced(projection, filter, order)
-      let slot = Engine.invert(ordinals)
+      let ordinals = referenced(projection, filter, order)
+      let slot = invert(ordinals)
       let scan = from.leaf(ordinals)
       return scan.shaped(
           distinct: select.distinct,
@@ -1648,7 +1640,7 @@ extension Catalog where Self: ~Escapable {
     // Resolve every joined relation and lay all relations — the FROM relation
     // first, then each joined one in source order — end to end in one combined
     // ordinal space.
-    var joined = Array<Engine.Resolved>()
+    var joined = Array<Resolved>()
     joined.reserveCapacity(select.joins.count)
     for join in select.joins {
       try joined.append(resolve(join.relation, ctes, visited))
@@ -1688,10 +1680,10 @@ extension Catalog where Self: ~Escapable {
     let projection = try scope.terms(select.projection)
 
     // Under DISTINCT every ORDER BY key must be a select-list column (see
-    // `Engine.distinct`); order keys and projection are in combined base-ordinal
+    // `distinct`); order keys and projection are in combined base-ordinal
     // space here, aligned with the AST keys index-for-index.
     if select.distinct, let clause = select.order {
-      try Engine.distinct(clause.keys, order.map(\.column), projection)
+      try distinct(clause.keys, order.map(\.column), projection)
     }
 
     // The combined referenced ordinals — projection ∪ every match ∪ WHERE ∪

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -1,23 +1,23 @@
 // Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
-/// The query engine — the compiler, optimiser, and executor for a `SELECT`.
-///
-/// `Engine` runs a `SELECT` entirely against the adapter protocols, with no
-/// knowledge of any data source. It resolves the relation(s) through a borrowed
-/// `Catalog`, *compiles* a logical operator tree, *optimises* it into a physical
-/// one, and *executes* that. Each phase borrows the catalog: `compile`
-/// re-resolves each relation by name to a transient `~Escapable` table to read
-/// its schema (width, ordinals, the set of ordinals the query references) and
-/// emits a name-holding `Plan`; `optimise` re-resolves to read sort-key
-/// seekability and rewrites scans into seeks and the product into an
-/// index-nested-loop join; `execute` re-resolves to open cursors and
-/// materialise. A single relation compiles to `Project(Sort(Select(Scan)))`; a
-/// chain of joins compiles to a left-deep tree of `Product`s, each level's `ON`
-/// equality a `Select` over its product, with the `WHERE` wrapping the whole
-/// chain. Absent layers are omitted. Executing the plan yields the result
-/// records' typed values; formatting them is a client's job.
-public enum Engine {}
+// The query engine — the compiler, optimiser, and executor for a `SELECT`.
+//
+// The engine runs a `SELECT` entirely against the adapter protocols, with no
+// knowledge of any data source. It resolves the relation(s) through a borrowed
+// `Catalog`, *compiles* a logical operator tree, *optimises* it into a physical
+// one, and *executes* that. Each phase borrows the catalog: `compile`
+// re-resolves each relation by name to a transient `~Escapable` table to read
+// its schema (width, ordinals, the set of ordinals the query references) and
+// emits a name-holding `Plan`; `optimise` re-resolves to read sort-key
+// seekability and rewrites scans into seeks and the product into an
+// index-nested-loop join; `execute` re-resolves to open cursors and
+// materialise. A single relation compiles to `Project(Sort(Select(Scan)))`; a
+// chain of joins compiles to a left-deep tree of `Product`s, each level's `ON`
+// equality a `Select` over its product, with the `WHERE` wrapping the whole
+// chain. Absent layers are omitted. Executing the plan yields the result
+// records' typed values; formatting them is a client's job. The compile,
+// optimise, and execute entry points are `Catalog` members.
 
 /// The greatest number of fixpoint iterations a recursive CTE may take before
 /// the engine concludes it does not terminate and throws `SQLError.recursion`.
@@ -926,7 +926,7 @@ extension Catalog where Self: ~Escapable {
     guard let table = table(named: name) else { throw .relation(name) }
     let count = table.cursor().count
 
-    if let range = Engine.boundaries(filter, ordinals, table, count, bindings) {
+    if let range = table.boundaries(filter, ordinals, count, bindings) {
       return .scan(name: name, ordinals: ordinals, seek: range)
     }
 
@@ -939,13 +939,11 @@ extension Catalog where Self: ~Escapable {
     // 0)` the left fold rebuilds so a seekable `id < 0` is the top-level RHS.
     if case let .and(lhs, rhs) = filter {
       if rhs.safe,
-          let range =
-              Engine.boundaries(lhs, ordinals, table, count, bindings) {
+          let range = table.boundaries(lhs, ordinals, count, bindings) {
         return .select(rhs, .scan(name: name, ordinals: ordinals, seek: range))
       }
       if lhs.safe,
-          let range =
-              Engine.boundaries(rhs, ordinals, table, count, bindings) {
+          let range = table.boundaries(rhs, ordinals, count, bindings) {
         return .select(lhs, .scan(name: name, ordinals: ordinals, seek: range))
       }
     }
@@ -974,15 +972,15 @@ private func comparison(_ filter: Filter, _ bindings: Bindings)
   }
 }
 
-extension Engine {
+extension Table where Self: ~Escapable {
   /// The boundaries `[lower, upper)` to seek for a sort-key comparison, or `nil`
   /// if `filter` does not qualify for the seek path.
   ///
   /// It qualifies when `filter` is a sort-key equality or range whose operand
   /// is an integer — a literal, or a bound parameter resolved from `bindings`
-  /// so a correlated child seeks on its parent key — and `table.bound` reports
-  /// the column seekable (a non-`nil` boundary). A range additionally requires
-  /// the column `ordered`: a `bound` boundary partitions a range correctly only
+  /// so a correlated child seeks on its parent key — and `bound` reports the
+  /// column seekable (a non-`nil` boundary). A range additionally requires the
+  /// column `ordered`: a `bound` boundary partitions a range correctly only
   /// when the seeked column is monotonic, so a range on a seekable, unordered
   /// column (a decoded coded-index key) does not qualify and scans, while its
   /// equality still seeks. The comparison's slot maps back to its table ordinal
@@ -992,17 +990,13 @@ extension Engine {
   ///
   /// The hash-join executor reuses this over a pushed inner filter's conjuncts
   /// to seek the inner by a seekable conjunct before bucketing, so a
-  /// seekable/contradictory inner filter reads few or no inner rows — hence it is
-  /// `internal` rather than private to `seek`.
-  internal static func boundaries<T: Table & ~Escapable>(_ filter: Filter,
-                                                         _ ordinals: Array<Int>,
-                                                         _ table: borrowing T,
-                                                         _ count: Int,
-                                                         _ bindings: Bindings)
+  /// seekable/contradictory inner filter reads few or no inner rows.
+  internal borrowing func boundaries(_ filter: Filter, _ ordinals: Array<Int>,
+                                     _ count: Int, _ bindings: Bindings)
       -> Range<Int>? {
     guard let (slot, op, value) = comparison(filter, bindings),
-        let lower = table.bound(ordinals[slot], value, strict: false),
-        let upper = table.bound(ordinals[slot], value, strict: true) else {
+        let lower = bound(ordinals[slot], value, strict: false),
+        let upper = bound(ordinals[slot], value, strict: true) else {
       return nil
     }
 
@@ -1013,7 +1007,7 @@ extension Engine {
     // raw run brackets one tag's value, and the join re-tests the decoded key
     // per row), so equality always seeks; a range on an unordered column
     // returns `nil` and the engine scans and filters.
-    let ordered = table.ordered(ordinals[slot])
+    let ordered = ordered(ordinals[slot])
     return switch op {
     case .equal: lower ..< upper
     case .lt: ordered ? 0 ..< lower : nil

--- a/Sources/SQL/Operator.swift
+++ b/Sources/SQL/Operator.swift
@@ -298,7 +298,7 @@ internal func execute<C: Catalog & ~Escapable>(_ plan: Plan,
   case let .scan(name, ordinals, seek):
     try materialise(name, ordinals, seek, catalog, ctes)
   case let .derived(name, source, ordinals, seek):
-    try derive(name, source, ordinals, seek, catalog, routines, bindings)
+    try catalog.derive(name, source, ordinals, seek, routines, bindings)
   case let .select(filter, .product(outer, inner)):
     // Fuse a residual product with its filter: stream each pair through the
     // predicate rather than materialising the whole cross product first.
@@ -456,37 +456,36 @@ private func materialise<C: Catalog & ~Escapable>(_ name: String,
   return records
 }
 
-/// Executes a view's sub-`plan` against `catalog` and re-lays each resulting
-/// record to the referenced `ordinals` (slots into the view's columns) over the
-/// seek's row range (the whole result when `nil`).
-///
-/// The sub-plan yields full-width view records — its columns at slots
-/// `0 ..< columns.count`; this projects each to the `ordinals` the outer query
-/// reads, in the slot order the outer scan expects (slot `i` is `ordinals[i]`).
-///
-/// The sub-plan runs OUTSIDE the statement's CTE scope — never the caller's
-/// `WITH` — so a caller's `WITH` never reaches into a stored view's body: a
-/// view's own `FROM`/`JOIN` names resolve to base relations (and other views),
-/// never to a statement-local CTE that happens to share a name. Its scope is
-/// instead the `definition_schema.` overlay the view's OWN query names (empty
-/// when it names none), so a view defined over a store relation materialises
-/// exactly as the inline query does — the same overlay the body compiled and
-/// optimised under.
-private func derive<C: Catalog & ~Escapable>(_ name: String, _ plan: Plan,
-                                             _ ordinals: Array<Int>,
-                                             _ seek: Range<Int>?,
-                                             _ catalog: borrowing C,
-                                             _ routines: Routines,
-                                             _ bindings: Bindings)
-    throws(SQLError) -> Array<Record> {
-  let overlay = if let view = catalog.resolve(view: name) {
-    catalog.augment([:], for: view.query, rows: true, routines: routines)
-  } else {
-    CTEs()
+extension Catalog where Self: ~Escapable {
+  /// Executes a view's sub-`plan` against this catalog and re-lays each resulting
+  /// record to the referenced `ordinals` (slots into the view's columns) over the
+  /// seek's row range (the whole result when `nil`).
+  ///
+  /// The sub-plan yields full-width view records — its columns at slots
+  /// `0 ..< columns.count`; this projects each to the `ordinals` the outer query
+  /// reads, in the slot order the outer scan expects (slot `i` is `ordinals[i]`).
+  ///
+  /// The sub-plan runs OUTSIDE the statement's CTE scope — never the caller's
+  /// `WITH` — so a caller's `WITH` never reaches into a stored view's body: a
+  /// view's own `FROM`/`JOIN` names resolve to base relations (and other views),
+  /// never to a statement-local CTE that happens to share a name. Its scope is
+  /// instead the `definition_schema.` overlay the view's OWN query names (empty
+  /// when it names none), so a view defined over a store relation materialises
+  /// exactly as the inline query does — the same overlay the body compiled and
+  /// optimised under.
+  internal borrowing func derive(_ name: String, _ plan: Plan,
+                                 _ ordinals: Array<Int>, _ seek: Range<Int>?,
+                                 _ routines: Routines, _ bindings: Bindings)
+      throws(SQLError) -> Array<Record> {
+    let overlay = if let view = resolve(view: name) {
+      augment([:], for: view.query, rows: true, routines: routines)
+    } else {
+      CTEs()
+    }
+    let rows = try execute(plan, self, overlay, routines, bindings)
+    let range = seek ?? 0 ..< rows.count
+    return range.map { rows[$0].project(ordinals) }
   }
-  let rows = try execute(plan, catalog, overlay, routines, bindings)
-  let range = seek ?? 0 ..< rows.count
-  return range.map { rows[$0].project(ordinals) }
 }
 
 /// The Cartesian product of two materialised relations: every concatenation of

--- a/Sources/SQL/Operator.swift
+++ b/Sources/SQL/Operator.swift
@@ -672,7 +672,7 @@ private func join<C: Catalog & ~Escapable>(_ outer: Array<Record>,
 ///
 /// A pushed inner `filter` (in the inner's standalone slot space) is applied
 /// DURING this scan, before a row is bucketed: the inner is SEEKED by the
-/// filter's seekable conjunct — `Engine.boundaries` over each conjunct, the same
+/// filter's seekable conjunct — `boundaries` over each conjunct, the same
 /// boundary logic the scan seek uses, mapping a slot back to its table column
 /// through `ordinals` — so a seekable/contradictory inner filter reads few or no
 /// inner rows rather than scanning the whole table; when no conjunct is seekable
@@ -753,7 +753,7 @@ private func joined(_ outer: Array<Record>, _ inner: Array<Record>,
 }
 
 /// The inner row range the hash join scans and buckets: the `[lower, upper)`
-/// seeked by `filter`'s first seekable conjunct — `Engine.boundaries` over each,
+/// seeked by `filter`'s first seekable conjunct — `boundaries` over each,
 /// mapping a slot to its table column through `ordinals` — else the whole
 /// `0 ..< count` when no conjunct qualifies (or there is no filter).
 private func seek<T: Table & ~Escapable>(_ filter: Filter?,
@@ -762,8 +762,7 @@ private func seek<T: Table & ~Escapable>(_ filter: Filter?,
                                          _ bindings: Bindings) -> Range<Int> {
   guard let filter else { return 0 ..< count }
   for conjunct in filter.conjuncts {
-    if let range =
-        Engine.boundaries(conjunct, ordinals, inner, count, bindings) {
+    if let range = inner.boundaries(conjunct, ordinals, count, bindings) {
       return range
     }
   }


### PR DESCRIPTION
This pull request refactors the SQL query engine implementation to improve encapsulation, modularity, and clarity. The main changes involve moving several static methods and constants from the `Engine` enum to file-private or extension scope, and shifting responsibilities from the `Engine` type to more appropriate types such as `Catalog` and `Table`. These changes help reduce the visibility of internal logic, make code organization more logical, and clarify ownership of functionality.

**Refactoring for Encapsulation and Modularity:**

* The `Engine` enum is no longer public and is replaced by file-private functions and constants, such as moving `kRecursionCap` to a file-level private constant and making helper functions like `referenced`, `invert`, `distinct`, `comparison`, and `keys` file-private instead of internal static methods. [[1]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L4-R24) [[2]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L476-R474) [[3]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L491-R488) [[4]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L518-R514) [[5]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L963-R959) [[6]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L1113-L1128)

* The `boundaries` logic for determining seekable ranges is moved from a static method on `Engine` to an instance method on `Table` (constrained to `~Escapable`), improving encapsulation and reducing cross-type dependencies. All call sites are updated accordingly. [[1]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L935-R929) [[2]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L948-R946) [[3]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L1001-R999) [[4]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L1022-R1010)

**Simplification and Clarification of Naming:**

* All references to `Engine.Resolved` are replaced with `Resolved`, reflecting the removal of the `Engine` namespace. [[1]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L619-R619) [[2]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L1499-R1489) [[3]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L1541-R1527) [[4]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L1550-R1536) [[5]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L1651-R1637)

* Documentation and inline comments are updated to reference the correct function names and to clarify the logic, especially regarding the `distinct` logic and seekable boundaries. [[1]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L728-R725) [[2]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L1630-R1624) [[3]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060L1691-R1680)

**Operator Execution Improvements:**

* The `derive` logic for executing derived views is moved from a standalone function to an extension method on `Catalog`, clarifying ownership and improving cohesion. [[1]](diffhunk://#diff-90b051b6c59d5ca6612ebe0500cd6ccfecdec8f79c3c79167986ee4298fd0737L301-R301) [[2]](diffhunk://#diff-90b051b6c59d5ca6612ebe0500cd6ccfecdec8f79c3c79167986ee4298fd0737L459-R460)

These changes collectively improve the maintainability and clarity of the SQL engine codebase by reducing unnecessary exposure of internal logic and grouping related functionality together.