### PR TITLE
SQL: rename the CTEs overlay type to ScopedRelations

### DIFF
--- a/Sources/SQL/Definition.swift
+++ b/Sources/SQL/Definition.swift
@@ -179,8 +179,9 @@ extension Catalog where Self: ~Escapable {
   /// typing path passes `false` for the SCHEMA-ONLY sibling, so resolving a
   /// view body's types never triggers the row build (a view over
   /// `definition_schema.columns` types without the builder re-entering itself).
-  borrowing func augment(_ ctes: CTEs, for query: Query, rows: Bool,
-                         routines: Routines = [:]) -> CTEs {
+  borrowing func augment(_ ctes: ScopedRelations, for query: Query,
+                         rows: Bool, routines: Routines = [:])
+      -> ScopedRelations {
     var names = Set<String>()
     query.collect(into: &names)
     var augmented = ctes
@@ -202,7 +203,7 @@ extension Catalog where Self: ~Escapable {
   /// The name resolves to a user view first, then a built-in `View.standard`
   /// view — so a built-in `information_schema.` view over the store re-resolves
   /// its own `definition_schema.` scan exactly as a user view would.
-  borrowing func overlay(_ name: String) -> CTEs {
+  borrowing func overlay(_ name: String) -> ScopedRelations {
     guard let view = resolve(view: name) else { return [:] }
     return augment([:], for: view.query, rows: true)
   }

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -105,7 +105,7 @@ extension Catalog where Self: ~Escapable {
   /// Runs `query` against this catalog with the common table expressions `ctes`
   /// in scope (empty for a query with no `WITH`), the resolution phases
   /// consulting `ctes` before the base catalog.
-  internal borrowing func run(_ query: Query, _ ctes: CTEs,
+  internal borrowing func run(_ query: Query, _ ctes: ScopedRelations,
                               _ routines: Routines, _ bindings: Bindings)
       throws(SQLError) -> Array<Array<Value>> {
     // Extend the relations with any `definition_schema.` store relation the
@@ -125,10 +125,10 @@ extension Catalog where Self: ~Escapable {
   /// Runs a `Statement` against this catalog, returning its result rows.
   ///
   /// A `select` runs its query directly; a `with` materialises its common table
-  /// expressions, in source order, into the `CTEs` the trailing query resolves
-  /// against (see `with`). A `create` defines a view and a `function` a scalar
-  /// function rather than producing rows, so neither is runnable — both fault
-  /// with `SQLError.statement`.
+  /// expressions, in source order, into the `ScopedRelations` the trailing
+  /// query resolves against (see `with`). A `create` defines a view and a
+  /// `function` a scalar function rather than producing rows, so neither is
+  /// runnable — both fault with `SQLError.statement`.
   public borrowing func run(_ statement: Statement, _ routines: Routines = [:],
                             bindings: Bindings = [:])
       throws(SQLError) -> Array<Array<Value>> {
@@ -150,8 +150,8 @@ extension Catalog where Self: ~Escapable {
   // MARK: - WITH
 
   /// Materialises the common table expressions `ctes`, in source order, into
-  /// the `CTEs` map and runs the trailing `query` against this catalog with that
-  /// map in scope.
+  /// the `ScopedRelations` map and runs the trailing `query` against this
+  /// catalog with that map in scope.
   ///
   /// Each CTE materialises against the base catalog plus every EARLIER CTE,
   /// so a CTE may name one defined before it (chained CTEs); a CTE name shadows
@@ -174,7 +174,7 @@ extension Catalog where Self: ~Escapable {
   internal borrowing func with(_ ctes: Array<CTE>, _ query: Query,
                                _ routines: Routines, _ bindings: Bindings)
       throws(SQLError) -> Array<Array<Value>> {
-    var relations = CTEs()
+    var relations = ScopedRelations()
     for cte in ctes {
       // A query name repeated in the list (case-insensitively) would silently
       // shadow the earlier binding in `relations`, so reject it rather than
@@ -249,7 +249,7 @@ extension Catalog where Self: ~Escapable {
   /// so `SELECT Name + 1 FROM People` in the anchor faults `SQLError.operand`
   /// against the BASE `People` a run reads it against, never wrongly types clean
   /// against the CTE's declared columns.
-  internal borrowing func validate(_ cte: CTE, against ctes: CTEs,
+  internal borrowing func validate(_ cte: CTE, against ctes: ScopedRelations,
                                    routines: Routines = [:],
                                    typecheck: Bool = false)
       throws(SQLError) {
@@ -339,7 +339,7 @@ extension Catalog where Self: ~Escapable {
   /// `SELECT *` arm filtered to zero rows is caught. The anchor compiles with
   /// the CTE name NOT in scope (it does not reference itself); the recursive
   /// arm compiles with the name bound to `cte.columns`, the schema it reads.
-  internal borrowing func fixpoint(_ cte: CTE, _ ctes: CTEs,
+  internal borrowing func fixpoint(_ cte: CTE, _ ctes: ScopedRelations,
                                    _ routines: Routines, _ bindings: Bindings)
       throws(SQLError) -> Array<Array<Value>> {
     // Extend the scope with any `definition_schema.` store relation the CTE's
@@ -610,7 +610,7 @@ extension Catalog where Self: ~Escapable {
   /// standard rule that every non-aggregated projection/`ORDER BY` column appear
   /// in the `GROUP BY`.
   internal borrowing func group(_ select: Select, _ relation: Relation,
-                                _ from: Resolved, _ ctes: CTEs,
+                                _ from: Resolved, _ ctes: ScopedRelations,
                                 _ visited: Set<String>)
       throws(SQLError) -> Plan {
     // Resolve every joined relation and lay the FROM relation and each joined
@@ -841,7 +841,7 @@ extension Catalog where Self: ~Escapable {
 
   /// Rewrites `plan` into a physical one with the in-scope `ctes` (consulted
   /// before the base catalog for seekability) and `bindings`.
-  internal borrowing func optimise(_ plan: Plan, _ ctes: CTEs,
+  internal borrowing func optimise(_ plan: Plan, _ ctes: ScopedRelations,
                                    _ bindings: Bindings)
       throws(SQLError) -> Plan {
     switch plan {
@@ -915,7 +915,7 @@ extension Catalog where Self: ~Escapable {
   /// in slot space, so a comparison's slot maps back to its table ordinal
   /// through the scan's `ordinals` before reading a boundary.
   private borrowing func seek(_ filter: Filter, _ name: String,
-                              _ ordinals: Array<Int>, _ ctes: CTEs,
+                              _ ordinals: Array<Int>, _ ctes: ScopedRelations,
                               _ bindings: Bindings)
       throws(SQLError) -> Plan {
     // A materialised CTE relation stores no sort key, so it is never seekable —
@@ -1048,7 +1048,7 @@ extension Catalog where Self: ~Escapable {
   /// kept the safe inner filter ahead of any unsafe conjunct). When the inner
   /// side is neither shape, the product is preserved.
   private borrowing func nest(_ filter: Filter, _ left: Plan, _ right: Plan,
-                              _ ctes: CTEs, _ bindings: Bindings)
+                              _ ctes: ScopedRelations, _ bindings: Bindings)
       throws(SQLError) -> Plan {
     let inner: (name: String, ordinals: Array<Int>, filter: Filter?)?
     switch right {
@@ -1405,7 +1405,7 @@ extension Catalog where Self: ~Escapable {
   /// chain by the trailing arm's flag. The new arm must project the same column
   /// count as the chain's first `SELECT` — the result columns — else
   /// `SQLError.arity`.
-  internal borrowing func compile(_ query: Query, _ ctes: CTEs = [:],
+  internal borrowing func compile(_ query: Query, _ ctes: ScopedRelations = [:],
                                   _ visited: Set<String> = [])
       throws(SQLError) -> Plan {
     guard case let .union(left, select, all) = query else {
@@ -1423,7 +1423,7 @@ extension Catalog where Self: ~Escapable {
   /// its relations, else the count of its projected items — for the `UNION`
   /// arity check. The relations resolve through this catalog, the `ctes`
   /// consulted first.
-  private borrowing func arity(_ select: Select, _ ctes: CTEs,
+  private borrowing func arity(_ select: Select, _ ctes: ScopedRelations,
                                _ visited: Set<String>)
       throws(SQLError) -> Int {
     switch select.projection {
@@ -1480,7 +1480,7 @@ extension Catalog where Self: ~Escapable {
   /// `definition_schema.` store's `columns` builder, which compiles every view
   /// to advertise it, relies on this: a cyclic view's `try? compile` catches
   /// the fault and skips it.
-  internal borrowing func resolve(_ relation: Relation, _ ctes: CTEs,
+  internal borrowing func resolve(_ relation: Relation, _ ctes: ScopedRelations,
                                   _ visited: Set<String> = [])
       throws(SQLError) -> Resolved {
     let name = relation.name
@@ -1561,7 +1561,8 @@ extension Catalog where Self: ~Escapable {
   /// cells concatenated in order). The tree is logical: every scan is a full
   /// `Scan(_, _, nil)`; the optimiser turns scans into seeks and each product
   /// into a join.
-  internal borrowing func compile(_ select: Select, _ ctes: CTEs = [:],
+  internal borrowing func compile(_ select: Select,
+                                  _ ctes: ScopedRelations = [:],
                                   _ visited: Set<String> = [])
       throws(SQLError) -> Plan {
     guard let relation = select.from else {

--- a/Sources/SQL/Materialised.swift
+++ b/Sources/SQL/Materialised.swift
@@ -5,13 +5,14 @@
 /// relations the engine resolves a `WITH`'s names against.
 ///
 /// It is threaded alongside the borrowed base catalog through every resolution
-/// phase: when the engine resolves a relation name, it consults `CTEs` first (a
-/// CTE name shadows a base table or view of the same name), and a CTE leaf
-/// materialises its records from the `Materialised` rows rather than opening a
-/// base cursor. An empty `CTEs` is the default — a query with no `WITH` resolves
-/// exactly as before. Threading escapable data sidesteps wrapping the borrowed
-/// `~Escapable` base catalog in a unifying overlay type.
-internal typealias CTEs = Dictionary<String, Materialised>
+/// phase: when the engine resolves a relation name, it consults
+/// `ScopedRelations` first (a CTE name shadows a base table or view of the same
+/// name), and a CTE leaf materialises its records from the `Materialised` rows
+/// rather than opening a base cursor. An empty `ScopedRelations` is the default
+/// — a query with no `WITH` resolves exactly as before. Threading escapable
+/// data sidesteps wrapping the borrowed `~Escapable` base catalog in a unifying
+/// overlay type.
+internal typealias ScopedRelations = Dictionary<String, Materialised>
 
 /// An escapable, in-engine relation over `(columns, rows)`.
 ///

--- a/Sources/SQL/Operator.swift
+++ b/Sources/SQL/Operator.swift
@@ -286,7 +286,7 @@ extension Plan {
 /// or stored.
 internal func execute<C: Catalog & ~Escapable>(_ plan: Plan,
                                                _ catalog: borrowing C,
-                                               _ ctes: CTEs,
+                                               _ ctes: ScopedRelations,
                                                _ routines: Routines,
                                                _ bindings: Bindings)
     throws(SQLError) -> Array<Record> {
@@ -377,7 +377,7 @@ private func limited(_ records: Array<Record>, _ count: Int?, _ offset: Int)
 private func union<C: Catalog & ~Escapable>(_ left: Plan, _ right: Plan,
                                             _ all: Bool,
                                             _ catalog: borrowing C,
-                                            _ ctes: CTEs,
+                                            _ ctes: ScopedRelations,
                                             _ routines: Routines,
                                             _ bindings: Bindings)
     throws(SQLError) -> Array<Record> {
@@ -441,7 +441,7 @@ private func materialise<C: Catalog & ~Escapable>(_ name: String,
                                                   _ ordinals: Array<Int>,
                                                   _ seek: Range<Int>?,
                                                   _ catalog: borrowing C,
-                                                  _ ctes: CTEs)
+                                                  _ ctes: ScopedRelations)
     throws(SQLError) -> Array<Record> {
   if let cte = ctes[name.lowercased()] {
     return (seek ?? 0 ..< cte.rows.count).map { cte.record($0, ordinals) }
@@ -480,7 +480,7 @@ extension Catalog where Self: ~Escapable {
     let overlay = if let view = resolve(view: name) {
       augment([:], for: view.query, rows: true, routines: routines)
     } else {
-      CTEs()
+      ScopedRelations()
     }
     let rows = try execute(plan, self, overlay, routines, bindings)
     let range = seek ?? 0 ..< rows.count
@@ -602,7 +602,7 @@ private func join<C: Catalog & ~Escapable>(_ outer: Array<Record>,
                                            _ keys: (left: Int, right: Int),
                                            _ filter: Filter?,
                                            _ catalog: borrowing C,
-                                           _ ctes: CTEs,
+                                           _ ctes: ScopedRelations,
                                            _ routines: Routines,
                                            _ bindings: Bindings)
     throws(SQLError) -> Array<Record> {

--- a/Sources/SQL/OutputColumn.swift
+++ b/Sources/SQL/OutputColumn.swift
@@ -193,7 +193,7 @@ extension Catalog where Self: ~Escapable {
                                  validate: Bool)
       throws(SQLError) -> Array<OutputColumn> {
     let routines = Routines.standard.merging(routines)
-    var overlay = CTEs()
+    var overlay = ScopedRelations()
     for cte in ctes {
       // A name repeated in the list (case-insensitively) would silently shadow
       // the earlier binding in the overlay, so reject it rather than overwrite —
@@ -255,7 +255,7 @@ extension Catalog where Self: ~Escapable {
   /// this arm's relations resolve, gating the view body's reachable-operand
   /// check the same as the outer query's — a `validate: false` derive never
   /// re-type-checks a view body a run already proved runnable.
-  borrowing func columns(of select: Select, _ ctes: CTEs,
+  borrowing func columns(of select: Select, _ ctes: ScopedRelations,
                          visited: Set<String> = [],
                          routines: Routines = [:],
                          validate: Bool = true)
@@ -272,7 +272,7 @@ extension Catalog where Self: ~Escapable {
   /// empty. It reads only schemas, never a cursor. `validate` (default `true`)
   /// rides through to each relation's `schema(of:)`, gating a view body's
   /// reachable-operand check the same as the outer query's.
-  borrowing func scope(of select: Select, _ ctes: CTEs,
+  borrowing func scope(of select: Select, _ ctes: ScopedRelations,
                        visited: Set<String> = [],
                        routines: Routines = [:],
                        validate: Bool = true)
@@ -299,7 +299,7 @@ extension Catalog where Self: ~Escapable {
   /// `Aggregate.fold` faults `SQLError.operand` at run. `compile` cannot catch
   /// this (no evaluating term is built), so a schema path type-checks each arm
   /// before returning metadata. It reads no cursor.
-  borrowing func typecheck(_ query: Query, _ ctes: CTEs,
+  borrowing func typecheck(_ query: Query, _ ctes: ScopedRelations,
                            visited: Set<String> = [],
                            routines: Routines = [:])
       throws(SQLError) {
@@ -338,7 +338,7 @@ extension Catalog where Self: ~Escapable {
   ///     ONLY`, or a positive `OFFSET` over a whole-result aggregate's sole row
   ///     (its output type is still DERIVED for the schema, non-faulting);
   ///     otherwise it validates fully.
-  private borrowing func typecheck(_ select: Select, _ ctes: CTEs,
+  private borrowing func typecheck(_ select: Select, _ ctes: ScopedRelations,
                                    visited: Set<String>,
                                    routines: Routines)
       throws(SQLError) {
@@ -434,7 +434,7 @@ extension Catalog where Self: ~Escapable {
   /// types WITHOUT re-checking its reachable operands, so a view whose body is
   /// data-dependent-empty — a text-arithmetic projection under a filter that
   /// matched no row — does not fault a `SELECT *` over it that already ran.
-  borrowing func schema(of relation: Relation, _ ctes: CTEs,
+  borrowing func schema(of relation: Relation, _ ctes: ScopedRelations,
                         visited: Set<String> = [],
                         routines: Routines = [:],
                         validate: Bool = true)


### PR DESCRIPTION
The `CTEs` typealias undersells its role: it is the resolved-relation overlay the engine consults before the base catalog, carrying not just a statement's user CTEs but also the `definition_schema` store relations and the schema-only shadows a typing path materialises. Rename the type to `ScopedRelations`, which names what it actually is — the relations in scope for a resolution, whatever their origin.

Pure mechanical, behaviour-preserving rename of the type and every type reference to it (parameter/return annotations, constructions, and the doc-comment mentions of the type). Local parameter names (`ctes`, `overlay`) and the "common table expression" prose are unchanged.