### PR TITLE
WinMD: decode property signatures

### DIFF
--- a/Sources/WinMD/Signature.swift
+++ b/Sources/WinMD/Signature.swift
@@ -185,6 +185,25 @@ public struct FieldSignature: Sendable {
   }
 }
 
+/// A decoded property signature (ECMA-335 §II.23.2.5).
+public struct PropertySignature: Sendable {
+  /// Whether the property has an implicit `this` parameter (`HASTHIS`).
+  public let `instance`: Bool
+
+  /// The property's type.
+  public let type: SignatureType
+
+  /// The index parameter types, in order; empty for a non-indexer property.
+  public let parameters: Array<SignatureType>
+
+  public init(instance: Bool, type: SignatureType,
+              parameters: Array<SignatureType>) {
+    self.instance = `instance`
+    self.type = type
+    self.parameters = parameters
+  }
+}
+
 // MARK: - Decoding
 
 /// A cursor decoding a `#Blob` signature byte stream (ECMA-335 §II.23.2).
@@ -429,6 +448,30 @@ internal struct SignatureDecoder: ~Escapable {
     guard prolog == 0x06 else { throw .BadImageFormat }
     return FieldSignature(type: try type())
   }
+
+  /// Decodes a property signature (ECMA-335 §II.23.2.5): a `PROPERTY` prolog
+  /// byte (`0x08`, optionally OR'd with `HASTHIS` `0x20`), a parameter count,
+  /// the property's `Type`, then that many index-parameter `Type`s.
+  ///
+  /// The count precedes the property type and names the index parameters an
+  /// indexer property carries; a plain property has a count of zero and no
+  /// index parameters.
+  internal mutating func property() throws(WinMDError) -> PropertySignature {
+    let prolog = try byte()
+    guard prolog & ~0x20 == 0x08 else { throw .BadImageFormat }
+    let `instance` = prolog & 0x20 != 0    // HASTHIS
+
+    let count = try compressed()
+    let type = try type()
+
+    var parameters = Array<SignatureType>()
+    for _ in 0 ..< count {
+      try parameters.append(self.type())
+    }
+
+    return PropertySignature(instance: `instance`, type: type,
+                             parameters: parameters)
+  }
 }
 
 // MARK: - Accessors
@@ -461,6 +504,22 @@ extension Row where Schema == Metadata.Tables.FieldDef {
       let entry = try blob(.Signature)
       var decoder = SignatureDecoder(entry.bytes)
       let signature = try decoder.field()
+      try decoder.end()
+      return signature
+    }
+  }
+}
+
+extension Row where Schema == Metadata.Tables.PropertyDef {
+  /// The decoded property signature (ECMA-335 §II.23.2.5).
+  ///
+  /// Distinct from the `Type` accessor, which vends the raw `#Blob`; this
+  /// decodes that blob into a structured `PropertySignature`.
+  public var declaration: PropertySignature {
+    get throws(WinMDError) {
+      let entry = try blob(.Type)
+      var decoder = SignatureDecoder(entry.bytes)
+      let signature = try decoder.property()
       try decoder.end()
       return signature
     }

--- a/Tests/WinMDTests/SignatureTests.swift
+++ b/Tests/WinMDTests/SignatureTests.swift
@@ -10,6 +10,7 @@ private let DEFAULT: UInt8 = 0x00
 private let HASTHIS: UInt8 = 0x20
 private let EXPLICITTHIS: UInt8 = 0x40
 private let FIELD: UInt8 = 0x06
+private let PROPERTY: UInt8 = 0x08
 private let VOID: UInt8 = 0x01
 private let I4: UInt8 = 0x08
 private let U4: UInt8 = 0x09
@@ -123,6 +124,51 @@ struct SignatureTests {
     guard case .primitive(.int4) = signature.type else {
       Issue.record("field not i4"); return
     }
+  }
+
+  @Test func `decodes a property signature`() throws {
+    // PROPERTY, no index parameters, an I4 property type.
+    let bytes = [PROPERTY, 0x00, I4]
+    var decoder = SignatureDecoder(bytes.span.bytes)
+    let signature = try decoder.property()
+    #expect(!signature.instance)
+    guard case .primitive(.int4) = signature.type else {
+      Issue.record("property not i4"); return
+    }
+    #expect(signature.parameters.isEmpty)
+  }
+
+  @Test func `decodes the property HASTHIS instance flag`() throws {
+    let bytes = [PROPERTY | HASTHIS, 0x00, STRING]
+    var decoder = SignatureDecoder(bytes.span.bytes)
+    let signature = try decoder.property()
+    #expect(signature.instance)
+    guard case .primitive(.string) = signature.type else {
+      Issue.record("property not string"); return
+    }
+  }
+
+  @Test func `decodes an indexer property's index parameters`() throws {
+    // PROPERTY, two index parameters (I4, STRING), a U4 property type.
+    let bytes = [PROPERTY, 0x02, U4, I4, STRING]
+    var decoder = SignatureDecoder(bytes.span.bytes)
+    let signature = try decoder.property()
+    guard case .primitive(.uint4) = signature.type else {
+      Issue.record("property not u4"); return
+    }
+    #expect(signature.parameters.count == 2)
+    guard case .primitive(.int4) = signature.parameters[0],
+        case .primitive(.string) = signature.parameters[1] else {
+      Issue.record("index parameters not (i4, string)"); return
+    }
+  }
+
+  @Test func `rejects a property signature with a non-PROPERTY prolog`() {
+    // A FIELD (0x06) prolog names a field, not a property; `property()` must
+    // reject it (ECMA-335 §II.23.2.5).
+    let bytes = [FIELD, 0x00, I4]
+    var decoder = SignatureDecoder(bytes.span.bytes)
+    #expect(throws: WinMDError.BadImageFormat) { _ = try decoder.property() }
   }
 
   @Test func `rejects an unknown element type`() {
@@ -327,6 +373,80 @@ struct SignatureTests {
     guard case .primitive(.int4) = signature.type else {
       Issue.record("field not i4"); return
     }
+  }
+
+  // A `PropertyDef` row whose `Type` cell (ordinal 2) is the heap offset 0.
+  // The narrow stride is Flags (2) + Name (2) + Type (2) = 6.
+  private static let propertyRecord: Array<UInt8> = [
+    0x00, 0x00,                // Flags
+    0x00, 0x00,                // Name
+    0x00, 0x00,                // Type (heap offset 0)
+  ]
+
+  // A blob heap holding `PROPERTY, 0, I4` — a plain `I4` property — length-
+  // prefixed.
+  private static let propertyBlob: Array<UInt8> = [0x03, PROPERTY, 0x00, I4]
+
+  // A blob heap holding `PROPERTY, 1, STRING, I4` — a `String this[i4]`
+  // indexer — length-prefixed.
+  private static let indexerBlob: Array<UInt8> =
+      [0x04, PROPERTY, 0x01, STRING, I4]
+
+  // A blob heap holding a `FIELD, I4` field signature under a `PropertyDef`
+  // row: the FIELD prolog is not a property, so `declaration` must reject it.
+  private static let propertyFieldBlob: Array<UInt8> = [0x02, FIELD, I4]
+
+  @Test func `decodes a PropertyDef signature through the row accessor`() throws {
+    let relations =
+        [Table(Metadata.Tables.PropertyDef.self, rows: 1, range: 0 ..< 6,
+               wide: 0, stride: 6)]
+    let storage = Storage(bytes: SignatureTests.propertyRecord.span.bytes,
+                          relations: relations.span,
+                          strings: SignatureTests.empty.span.bytes,
+                          blob: SignatureTests.propertyBlob.span.bytes,
+                          guid: SignatureTests.empty.span.bytes,
+                          valid: 1 << 23, sorted: 0)
+    let rows = try storage.rows(of: Metadata.Tables.PropertyDef.self)
+    let signature = try rows[0]!.declaration
+    guard case .primitive(.int4) = signature.type else {
+      Issue.record("property not i4"); return
+    }
+    #expect(signature.parameters.isEmpty)
+  }
+
+  @Test func `decodes a PropertyDef indexer through the row accessor`() throws {
+    let relations =
+        [Table(Metadata.Tables.PropertyDef.self, rows: 1, range: 0 ..< 6,
+               wide: 0, stride: 6)]
+    let storage = Storage(bytes: SignatureTests.propertyRecord.span.bytes,
+                          relations: relations.span,
+                          strings: SignatureTests.empty.span.bytes,
+                          blob: SignatureTests.indexerBlob.span.bytes,
+                          guid: SignatureTests.empty.span.bytes,
+                          valid: 1 << 23, sorted: 0)
+    let rows = try storage.rows(of: Metadata.Tables.PropertyDef.self)
+    let signature = try rows[0]!.declaration
+    guard case .primitive(.string) = signature.type else {
+      Issue.record("property not string"); return
+    }
+    #expect(signature.parameters.count == 1)
+    guard case .primitive(.int4) = signature.parameters[0] else {
+      Issue.record("index parameter not i4"); return
+    }
+  }
+
+  @Test func `rejects a PropertyDef signature with a non-PROPERTY prolog`() throws {
+    let relations =
+        [Table(Metadata.Tables.PropertyDef.self, rows: 1, range: 0 ..< 6,
+               wide: 0, stride: 6)]
+    let storage = Storage(bytes: SignatureTests.propertyRecord.span.bytes,
+                          relations: relations.span,
+                          strings: SignatureTests.empty.span.bytes,
+                          blob: SignatureTests.propertyFieldBlob.span.bytes,
+                          guid: SignatureTests.empty.span.bytes,
+                          valid: 1 << 23, sorted: 0)
+    let rows = try storage.rows(of: Metadata.Tables.PropertyDef.self)
+    #expect(throws: WinMDError.BadImageFormat) { _ = try rows[0]!.declaration }
   }
 
   // A field signature whose prolog is `FIELD | GENERIC` (`0x16`): the `GENERIC`


### PR DESCRIPTION
Add PropertySig decoding (ECMA-335 §II.23.2.5), the one signature form the reader did not yet decode. A `PropertySignature` carries the `HASTHIS` instance flag, the property `type`, and the index `parameters` an indexer property declares; a `property()` entry on `SignatureDecoder` validates the leading `PROPERTY` (0x08, optionally OR'd with `HASTHIS` 0x20) prolog, reads the parameter count, the property type, then that many index- parameter types, reusing the shared `Type` decoder.

`PropertyDef.declaration` mirrors `FieldDef.declaration`, decoding the row's `Type` `#Blob` entry through the validating `blob(_:)` path.