### PR TITLE
winmd-inspect: drop the redundant print-namespaces subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,13 @@ protocols, exposing each table's rows along with two virtual columns — a
 that foreign-key and parent/child list relationships become ordinary equi-joins
 the engine can plan and seek.
 
-The `winmd-inspect` command-line tool exposes the reader through its `dump`,
-`print-namespaces`, and `query` subcommands:
+The `winmd-inspect` command-line tool exposes the reader through its `dump` and
+`query` subcommands, with `query` the default:
 
 ```
 winmd-inspect <file.winmd> dump
-winmd-inspect <file.winmd> print-namespaces
+winmd-inspect <file.winmd> \
+    "SELECT DISTINCT TypeNamespace FROM TypeDef ORDER BY TypeNamespace"
 winmd-inspect <file.winmd> query \
     "SELECT TypeName, TypeNamespace FROM TypeDef \
        WHERE TypeNamespace = 'Windows.Win32.Foundation'"

--- a/Sources/winmd-inspect/Inspect.swift
+++ b/Sources/winmd-inspect/Inspect.swift
@@ -4,7 +4,6 @@
 internal import struct Foundation.Data
 
 internal import ArgumentParser
-internal import SQL
 internal import WinMD
 
 struct Dump: ParsableCommand {
@@ -39,49 +38,6 @@ struct Dump: ParsableCommand {
   }
 }
 
-struct PrintNamespaces: ParsableCommand {
-  static var configuration: CommandConfiguration {
-    CommandConfiguration(abstract: "Print namespaces referenced in the database.")
-  }
-
-  @OptionGroup
-  var options: InspectOptions
-
-  func run() throws {
-    // The caller owns the mapping; it must outlive the database, which is a
-    // borrowed view over it.
-    let data = try Data(contentsOf: options.database.url,
-                        options: .alwaysMapped)
-    let database = try Database(data.span.bytes)
-    // One line per namespace row: no rows prints nothing, while a lone
-    // empty-string namespace (the global namespace) prints one blank line —
-    // outcomes a joined string cannot tell apart, so scripts read exactly one
-    // line per namespace and none for a namespace-free database.
-    for namespace in try PrintNamespaces.namespaces(database.storage) {
-      print(namespace)
-    }
-  }
-
-  /// The database's distinct namespaces, ascending, one element per row — a
-  /// `SELECT DISTINCT … ORDER BY` deduplicates and sorts them, the engine's own
-  /// dedup replacing the hand-rolled `Set` + `sorted()`.
-  ///
-  /// An element per row, rather than a joined string, keeps the zero-rows case
-  /// (a namespace-free database) distinct from a single empty-string namespace:
-  /// the former yields no lines, the latter one blank line, whereas a
-  /// newline-join collapses both to the empty string. Each element is a plain
-  /// namespace scripts parse a line at a time, NOT the boxed table
-  /// `Shell.execute` frames a row result as (borders and a `TypeNamespace`
-  /// header), so this runs the DISTINCT query directly rather than the shell.
-  internal static func namespaces(_ storage: borrowing WinMD.Storage)
-      throws -> Array<String> {
-    var session = Session(storage)
-    let rows = try session.run(
-        "SELECT DISTINCT TypeNamespace FROM TypeDef ORDER BY TypeNamespace")
-    return rows.map { $0[0].display }
-  }
-}
-
 struct InspectOptions: ParsableArguments {
   // "C:\\Windows\\System32\\WinMetadata\\Windows.Foundation.winmd"
   @Argument
@@ -94,7 +50,6 @@ struct Inspect: ParsableCommand {
     CommandConfiguration(abstract: "Windows Metadata File Inspection Utility",
                          subcommands: [
                            Dump.self,
-                           PrintNamespaces.self,
                            Query.self,
                          ],
                          defaultSubcommand: Query.self)

--- a/Tests/winmd-inspectTests/DatabaseSQLTests.swift
+++ b/Tests/winmd-inspectTests/DatabaseSQLTests.swift
@@ -1080,45 +1080,6 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test func `print-namespaces yields a plain one-per-line list, not a boxed table`() throws {
-    // `print-namespaces` DEDUPS through `SELECT DISTINCT … ORDER BY`, but its
-    // output is one plain namespace element per row scripts parse a line at a
-    // time — NOT the boxed table `Shell.execute` frames a row result as. The
-    // fixture's two TypeDefs both live in `NS`, so the DISTINCT collapses them
-    // to the single element `NS`, carrying no `┌─┐`/`│` box borders and no
-    // `TypeNamespace` header.
-    try DatabaseSQLTests.with { storage in
-      let list = try PrintNamespaces.namespaces(storage)
-      #expect(list == ["NS"])
-      #expect(!list.contains { $0.contains("TypeNamespace") })
-      #expect(!list.contains { $0.contains("┌") })
-      #expect(!list.contains { $0.contains("│") })
-    }
-  }
-
-  @Test func `print-namespaces on an empty database yields no lines`() throws {
-    // A database with an empty `TypeDef` table has no namespaces, so the
-    // DISTINCT query returns zero rows. `print-namespaces` must then emit
-    // NOTHING — an empty element list prints no lines — so a script reading a
-    // namespace per line never sees a spurious blank entry.
-    try NoTypeDefFixture.with { storage in
-      let list = try PrintNamespaces.namespaces(storage)
-      #expect(list.isEmpty)
-    }
-  }
-
-  @Test func `print-namespaces yields one blank line for the global namespace`() throws {
-    // A database whose lone `TypeDef` lives in the global namespace — a
-    // `TypeNamespace` of the empty string — has exactly one namespace: the
-    // empty one. `print-namespaces` must yield a single empty-string element,
-    // one blank line, distinct from the zero-rows case that yields no line at
-    // all — a distinction a newline-joined string could not have preserved.
-    try GlobalNamespaceFixture.with { storage in
-      let list = try PrintNamespaces.namespaces(storage)
-      #expect(list == [""])
-    }
-  }
-
   @Test func `a coded-index join key admits one key per candidate target table`() {
     // `CustomAttribute.Parent` is `HasCustomAttribute`, which admits 22 target
     // tables, plus `Type` is `CustomAttributeType`, which admits two (its three
@@ -1230,67 +1191,6 @@ struct DatabaseSQLTests {
 /// table is present (so the list link resolves to it) but has zero rows, so the
 /// owner of the lone `Param` resolves to 0. `decode(parameter:for:)` must then
 /// yield `nil` rather than index a negative `MethodDef` row.
-/// A fixture whose `TypeDef` table is present but empty: it contributes zero
-/// rows, so `SELECT DISTINCT TypeNamespace FROM TypeDef` finds no namespaces.
-private enum NoTypeDefFixture {
-  private static let empty = Array<UInt8>()
-
-  private static let relations: Array<WinMD.Table> = [
-    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 0, range: 0 ..< 0,
-                wide: 0, stride: 14),
-  ]
-
-  private static let valid: UInt64 = (1 << 2)
-
-  /// Runs `body` over a `Storage` catalog bound to the empty metadata.
-  static func with(_ body: (borrowing Storage) throws -> Void) rethrows {
-    let storage = Storage(bytes: empty.span.bytes, relations: relations.span,
-                          strings: empty.span.bytes, blob: empty.span.bytes,
-                          guid: empty.span.bytes, valid: valid, sorted: 0)
-    try body(storage)
-  }
-}
-
-/// A fixture whose lone `TypeDef` lives in the global namespace — its
-/// `TypeNamespace` is index 0, the reserved empty string — so
-/// `SELECT DISTINCT TypeNamespace FROM TypeDef` finds a single empty-string
-/// namespace, the one blank-line case that must stay distinct from zero rows.
-private enum GlobalNamespaceFixture {
-  // One narrow (all-index 2-byte) TypeDef packed into a 14-byte row.
-  //
-  //   TypeDef[0]: Flags=0, TypeName="T"(1), TypeNamespace=0 (the empty string),
-  //               Extends=0, FieldList=0, MethodList=0 — a type in the global
-  //               namespace.
-  private static let bytes: Array<UInt8> = [
-    // TypeDef[0]
-    0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-  ]
-
-  // "\0T\0": the reserved empty string at offset 0, `T` at offset 1.
-  private static let strings: Array<UInt8> = [
-    0x00,
-    0x54, 0x00,
-  ]
-
-  private static let empty = Array<UInt8>()
-
-  private static let relations: Array<WinMD.Table> = [
-    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 1, range: 0 ..< 14,
-                wide: 0, stride: 14),
-  ]
-
-  private static let valid: UInt64 = (1 << 2)
-
-  /// Runs `body` over a `Storage` catalog bound to the assembled metadata.
-  static func with(_ body: (borrowing Storage) throws -> Void) rethrows {
-    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
-                          strings: strings.span.bytes, blob: empty.span.bytes,
-                          guid: empty.span.bytes, valid: valid, sorted: 0)
-    try body(storage)
-  }
-}
-
 private enum UnownedParamFixture {
   // Two narrow tables packed back to back. `MethodDef` contributes no records
   // (zero rows); `Param` contributes one.


### PR DESCRIPTION
`print-namespaces` printed the distinct type namespaces, one per line, by running `SELECT DISTINCT TypeNamespace FROM TypeDef ORDER BY TypeNamespace`. Now that `query` is the default subcommand and the engine supports `DISTINCT` and `ORDER BY`, that canned query is spelled directly:

    winmd-inspect <file.winmd> \
        "SELECT DISTINCT TypeNamespace FROM TypeDef ORDER BY TypeNamespace"

Remove the `PrintNamespaces` command, its sole-use `namespaces(_:)` helper and query text, its entry in the root `subcommands` array, and the now-unused `SQL` import. Drop the three tests that exercised it along with the two fixtures (`NoTypeDefFixture`, `GlobalNamespaceFixture`) used only by them, and refresh the README to the default-query form.