### PR TITLE
SQL: bundle the execution maps into a Context

### DIFF
--- a/Sources/SQL/Context.swift
+++ b/Sources/SQL/Context.swift
@@ -1,0 +1,64 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+/// The escapable execution context threaded beside the borrowed base catalog
+/// through every resolution and execution phase — the three owned maps a run
+/// carries, bundled into one value.
+///
+/// A query runs against a `~Escapable` `Catalog` (borrowed, never copied) plus
+/// this `Context` (fully owned value data):
+///
+///   - `relations` — the in-scope relation overlay: the materialised common
+///     table expressions a `WITH` binds and any `definition_schema.` store
+///     relation the query names, keyed case-folded. The resolver consults it
+///     BEFORE the base catalog, so a name it binds shadows a base table or view.
+///   - `routines` — the scalar functions (UDFs) a call resolves through, keyed
+///     case-folded; the engine prelude (`BITAND`) merged under the caller's.
+///   - `bindings` — the query parameters, each `:name` mapped to its bound
+///     value, read by a `bound` filter and the seek planner.
+///
+/// It is plain escapable data, so it needs none of the lifetime machinery the
+/// borrowed catalog does: extending the `relations` overlay for a CTE's scope,
+/// or rebinding it for a recursive step, is an ordinary value copy — the
+/// `deriving`/`scoping` helpers below. The borrowed catalog stays a SEPARATE
+/// parameter; a `Context` never holds it (a stored `~Escapable` member cannot
+/// yield a `~Escapable` table).
+internal struct Context {
+  /// The in-scope relation overlay — materialised CTEs and store relations,
+  /// consulted before the base catalog.
+  internal let relations: ScopedRelations
+
+  /// The scalar routines (UDFs) a call resolves through.
+  internal let routines: Routines
+
+  /// The query parameter bindings.
+  internal let bindings: Bindings
+
+  /// A context over the three maps — an empty overlay and no bindings by
+  /// default, the shape a bare query with no `WITH` and no parameters runs
+  /// under.
+  internal init(relations: ScopedRelations = [:], routines: Routines = [:],
+                bindings: Bindings = [:]) {
+    self.relations = relations
+    self.routines = routines
+    self.bindings = bindings
+  }
+
+  /// A copy of this context with `relations` REPLACING the overlay, the same
+  /// routines and bindings — the scope a phase reads after `augment` extends
+  /// the overlay with the store relations a query names, or a recursive step
+  /// rebinds a CTE's self.
+  internal func scoping(_ relations: ScopedRelations) -> Context {
+    Context(relations: relations, routines: routines, bindings: bindings)
+  }
+
+  /// A copy of this context whose overlay binds `materialised` to `name` (folded
+  /// to lower case), the binding shadowing any existing one — the recursive
+  /// step's rebinding of a CTE's self to the previous iteration's rows.
+  internal func binding(_ name: String, to materialised: Materialised)
+      -> Context {
+    var relations = relations
+    relations[name.lowercased()] = materialised
+    return scoping(relations)
+  }
+}

--- a/Sources/SQL/Definition.swift
+++ b/Sources/SQL/Definition.swift
@@ -157,55 +157,60 @@ extension Catalog where Self: ~Escapable {
     case .tables:
       tables()
     case .columns:
-      columns(routines)
+      columns(Context(routines: routines))
     }
   }
 
-  /// `ctes` extended with every `definition_schema.` store relation `query`
-  /// names, each built over this catalog as a `Materialised` — the resolution
-  /// surface the engine consults for a reserved store relation.
+  /// `context` with its `relations` overlay extended by every
+  /// `definition_schema.` store relation `query` names, each built over this
+  /// catalog as a `Materialised` — the resolution surface the engine consults
+  /// for a reserved store relation, threaded onward as the working scope.
   ///
   /// The store sits AFTER the common table expressions and BEFORE the base
-  /// catalog: a `definition_schema.` name is added only when `ctes` does not
-  /// already bind it (a user relation may shadow the store), and the extended
-  /// map is consulted first by every resolution phase (compile, optimise,
-  /// execute) — so it shadows a base table or view but yields to a CTE.
-  /// Building runs lazily per named relation: only the reserved relations the
-  /// query actually references are enumerated. A name in the reserved namespace
-  /// but not one the store serves is left unbound, so it faults later as an
-  /// ordinary unknown relation (`SQLError.relation`).
+  /// catalog: a `definition_schema.` name is added only when the overlay does
+  /// not already bind it (a user relation may shadow the store), and the
+  /// extended map is consulted first by every resolution phase (compile,
+  /// optimise, execute) — so it shadows a base table or view but yields to a
+  /// CTE. Building runs lazily per named relation: only the reserved relations
+  /// the query actually references are enumerated. A name in the reserved
+  /// namespace but not one the store serves is left unbound, so it faults later
+  /// as an ordinary unknown relation (`SQLError.relation`).
   ///
   /// `rows` selects the build: a run passes `true` for the enumerated rows; a
   /// typing path passes `false` for the SCHEMA-ONLY sibling, so resolving a
   /// view body's types never triggers the row build (a view over
   /// `definition_schema.columns` types without the builder re-entering itself).
-  borrowing func augment(_ ctes: ScopedRelations, for query: Query,
-                         rows: Bool, routines: Routines = [:])
-      -> ScopedRelations {
+  /// A store relation's row build types a view's scalar-call column through the
+  /// context's `routines`.
+  borrowing func augment(_ context: Context, for query: Query, rows: Bool)
+      -> Context {
     var names = Set<String>()
     query.collect(into: &names)
-    var augmented = ctes
+    var augmented = context.relations
     for name in names where augmented[name.lowercased()] == nil {
       if let relation = Definition(name) {
-        augmented[name.lowercased()] = store(relation, rows: rows, routines)
+        augmented[name.lowercased()] =
+            store(relation, rows: rows, context.routines)
       }
     }
-    return augmented
+    return context.scoping(augmented)
   }
 
-  /// The `definition_schema.` overlay a view's body resolves against — the
-  /// reserved store relations the view `name` names in its OWN query, each
-  /// built over this catalog — or empty when `name` is not a view (or names
-  /// none). It seeds the view sub-plan's execute so a view defined over a store
-  /// relation resolves; it never carries a caller's statement CTEs, so a view
-  /// means what it was registered to mean.
+  /// `context` rescoped to the `definition_schema.` overlay a view's body
+  /// resolves against — the reserved store relations the view `name` names in
+  /// its OWN query, each built over this catalog, the caller's CTEs DROPPED (an
+  /// empty overlay when `name` is not a view or names none). It seeds the view
+  /// sub-plan's execute so a view defined over a store relation resolves; it
+  /// never carries a caller's statement CTEs, so a view means what it was
+  /// registered to mean. The routines and bindings ride through unchanged.
   ///
   /// The name resolves to a user view first, then a built-in `View.standard`
   /// view — so a built-in `information_schema.` view over the store re-resolves
   /// its own `definition_schema.` scan exactly as a user view would.
-  borrowing func overlay(_ name: String) -> ScopedRelations {
-    guard let view = resolve(view: name) else { return [:] }
-    return augment([:], for: view.query, rows: true)
+  borrowing func overlay(_ name: String, _ context: Context) -> Context {
+    let fresh = context.scoping([:])
+    guard let view = resolve(view: name) else { return fresh }
+    return augment(fresh, for: view.query, rows: true)
   }
 
   /// The view named `name`, or `nil`, by the precedence a query name follows.
@@ -286,7 +291,7 @@ extension Catalog where Self: ~Escapable {
   /// types from `routines`, the run's registered routines, so a view's
   /// `GUID(...)` column advertises `character varying`, not the integer
   /// default.
-  private borrowing func columns(_ routines: Routines)
+  private borrowing func columns(_ context: Context)
       -> Materialised {
     var rows = Array<Array<Value>>()
     for name in bases() {
@@ -316,7 +321,7 @@ extension Catalog where Self: ~Escapable {
       // column count: `resolve` rejects a view whose declared arity differs
       // from its body's (`v(x) AS SELECT * FROM People`), so such a view cannot
       // run and is not advertised here.
-      let overlay = augment([:], for: view.query, rows: false)
+      let overlay = augment(context.scoping([:]), for: view.query, rows: false)
       guard let plan = try? compile(view.query, overlay),
           plan.width == view.columns.count else { continue }
       // Type the columns from the body's first arm; type-check every arm's
@@ -325,11 +330,10 @@ extension Catalog where Self: ~Escapable {
       // first-arm resolve would miss it (`compile` cannot check a routine
       // exists), while an arm a short-circuit proves unreachable is skipped. A
       // view a `SELECT *` could not evaluate is not advertised.
-      guard (try? typecheck(view.query, overlay, visited: [name.lowercased()],
-                            routines: routines)) != nil,
+      guard (try? typecheck(view.query, overlay,
+                            visited: [name.lowercased()])) != nil,
           let resolved = try? columns(of: view.query.first, overlay,
-                                      visited: [name.lowercased()],
-                                      routines: routines),
+                                      visited: [name.lowercased()]),
           resolved.count == view.columns.count else { continue }
       for ordinal in view.columns.indices {
         rows.append([.text(name), .text(view.columns[ordinal]),

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -99,16 +99,17 @@ extension Catalog where Self: ~Escapable {
     // always resolves the built-ins (BITAND) even when it supplies unrelated
     // UDFs; an explicitly registered function of the same name still shadows it
     // (the merge keeps the caller's binding on a clash).
-    try run(query, [:], Routines.standard.merging(routines), bindings)
+    try run(query, Context(routines: Routines.standard.merging(routines),
+                           bindings: bindings))
   }
 
-  /// Runs `query` against this catalog with the common table expressions `ctes`
-  /// in scope (empty for a query with no `WITH`), the resolution phases
-  /// consulting `ctes` before the base catalog.
-  internal borrowing func run(_ query: Query, _ ctes: ScopedRelations,
-                              _ routines: Routines, _ bindings: Bindings)
+  /// Runs `query` against this catalog under `context` — the in-scope common
+  /// table expressions (empty for a query with no `WITH`), the routines, and
+  /// the bindings — the resolution phases consulting the overlay before the
+  /// base catalog.
+  internal borrowing func run(_ query: Query, _ context: Context)
       throws(SQLError) -> Array<Array<Value>> {
-    // Extend the relations with any `definition_schema.` store relation the
+    // Extend the overlay with any `definition_schema.` store relation the
     // query names, resolved lazily — the overlay after the
     // CTEs, before the base catalog. Every phase reads the extended map, so a
     // reserved store relation resolves, plans, and materialises exactly as a
@@ -116,10 +117,10 @@ extension Catalog where Self: ~Escapable {
     // the store resolves through the ordinary view machinery. The routines ride
     // in so a store `data_type` row types a view's scalar-call column
     // (`GUID(...)`) by its declared return type.
-    let ctes = augment(ctes, for: query, rows: true, routines: routines)
-    let logical = try compile(query, ctes).pushdown()
-    let plan = try optimise(logical, ctes, bindings)
-    return try execute(plan, self, ctes, routines, bindings).map(\.values)
+    let context = augment(context, for: query, rows: true)
+    let logical = try compile(query, context).pushdown()
+    let plan = try optimise(logical, context)
+    return try execute(plan, self, context).map(\.values)
   }
 
   /// Runs a `Statement` against this catalog, returning its result rows.
@@ -134,12 +135,13 @@ extension Catalog where Self: ~Escapable {
       throws(SQLError) -> Array<Array<Value>> {
     // Seed the standard prelude under the caller's routines (see the query
     // overload) so BITAND resolves regardless of what the caller supplies.
-    let routines = Routines.standard.merging(routines)
+    let context = Context(routines: Routines.standard.merging(routines),
+                          bindings: bindings)
     return switch statement {
     case let .select(query):
-      try run(query, [:], routines, bindings)
+      try run(query, context)
     case let .with(ctes, query):
-      try with(ctes, query, routines, bindings)
+      try with(ctes, query, context)
     case .create:
       throw .statement("CREATE VIEW defines a view rather than producing rows")
     case .function:
@@ -172,7 +174,7 @@ extension Catalog where Self: ~Escapable {
   /// many rows the body yields. A body filtered to zero rows still faults with
   /// `SQLError.columns`, where a per-row check would pass it through vacuously.
   internal borrowing func with(_ ctes: Array<CTE>, _ query: Query,
-                               _ routines: Routines, _ bindings: Bindings)
+                               _ context: Context)
       throws(SQLError) -> Array<Array<Value>> {
     var relations = ScopedRelations()
     for cte in ctes {
@@ -182,11 +184,14 @@ extension Catalog where Self: ~Escapable {
       guard relations[cte.name.lowercased()] == nil else {
         throw .redefinition(cte.name)
       }
+      // The scope for this CTE's body: the base catalog plus every earlier CTE,
+      // over the run's routines and bindings.
+      let scope = context.scoping(relations)
       // Validate the CTE's SHAPE and ARITY against the CTEs done so far — the
       // compile-time structural check, shared with the dry-run schema path so a
       // derive rejects exactly the CTEs a run rejects. It faults the recursive
       // shape and the width mismatch here, BEFORE any rows materialise.
-      try validate(cte, against: relations, routines: routines)
+      try validate(cte, against: scope)
       // A CTE that names itself iterates a fixpoint; every other one — a
       // non-recursive CTE, or one a `WITH RECURSIVE` marks recursive but which
       // does not reference itself — runs its query once. Each resolves against
@@ -194,16 +199,16 @@ extension Catalog where Self: ~Escapable {
       // is already checked by `validate` above.
       let rows: Array<Array<Value>>
       if cte.recursive && cte.recurses {
-        rows = try fixpoint(cte, relations, routines, bindings)
+        rows = try fixpoint(cte, scope)
       } else {
-        rows = try run(cte.query, relations, routines, bindings)
+        rows = try run(cte.query, scope)
       }
       relations[cte.name.lowercased()] =
           Materialised(columns: cte.columns, rows: rows,
                        types: Array(repeating: .integer,
                                     count: cte.columns.count))
     }
-    return try run(query, relations, routines, bindings)
+    return try run(query, context.scoping(relations))
   }
 
   /// Validates the SHAPE and declared ARITY of a single common table expression
@@ -249,8 +254,7 @@ extension Catalog where Self: ~Escapable {
   /// so `SELECT Name + 1 FROM People` in the anchor faults `SQLError.operand`
   /// against the BASE `People` a run reads it against, never wrongly types clean
   /// against the CTE's declared columns.
-  internal borrowing func validate(_ cte: CTE, against ctes: ScopedRelations,
-                                   routines: Routines = [:],
+  internal borrowing func validate(_ cte: CTE, against context: Context,
                                    typecheck: Bool = false)
       throws(SQLError) {
     // Reject a misplaced recursive reference in an EARLIER arm when no
@@ -273,7 +277,7 @@ extension Catalog where Self: ~Escapable {
     // CTE-self overlay.
     if cte.recursive && cte.recurses, case let .union(anchor, recursive, _) =
         cte.query {
-      let scope = augment(ctes, for: anchor, rows: false, routines: routines)
+      let scope = augment(context, for: anchor, rows: false)
       let width = try compile(anchor, scope).width
       guard width == cte.columns.count else {
         throw .columns(expected: cte.columns.count, got: width)
@@ -281,13 +285,12 @@ extension Catalog where Self: ~Escapable {
       // The anchor is operand-checked with self NOT in scope — the scope the run
       // evaluates it in — so a text-arithmetic anchor faults against the base
       // relation, not the CTE's declared (integer) columns.
-      if typecheck { try self.typecheck(anchor, scope, routines: routines) }
-      var probe = augment(ctes, for: .select(recursive), rows: false,
-                          routines: routines)
-      probe[cte.name.lowercased()] =
-          Materialised(columns: cte.columns, rows: [],
-                       types: Array(repeating: .integer,
-                                    count: cte.columns.count))
+      if typecheck { try self.typecheck(anchor, scope) }
+      let empty = Materialised(columns: cte.columns, rows: [],
+                               types: Array(repeating: .integer,
+                                            count: cte.columns.count))
+      let probe = augment(context, for: .select(recursive), rows: false)
+          .binding(cte.name, to: empty)
       let arm = try compile(.select(recursive), probe).width
       guard arm == cte.columns.count else {
         throw .columns(expected: cte.columns.count, got: arm)
@@ -295,16 +298,16 @@ extension Catalog where Self: ~Escapable {
       // The recursive arm is operand-checked with self bound to the declared
       // columns — the schema every iteration reads the CTE under.
       if typecheck {
-        try self.typecheck(.select(recursive), probe, routines: routines)
+        try self.typecheck(.select(recursive), probe)
       }
     } else {
-      let scope = augment(ctes, for: cte.query, rows: false, routines: routines)
+      let scope = augment(context, for: cte.query, rows: false)
       let width = try compile(cte.query, scope).width
       guard width == cte.columns.count else {
         throw .columns(expected: cte.columns.count, got: width)
       }
       // A non-self-naming body is operand-checked whole with self NOT in scope.
-      if typecheck { try self.typecheck(cte.query, scope, routines: routines) }
+      if typecheck { try self.typecheck(cte.query, scope) }
     }
   }
 
@@ -339,28 +342,27 @@ extension Catalog where Self: ~Escapable {
   /// `SELECT *` arm filtered to zero rows is caught. The anchor compiles with
   /// the CTE name NOT in scope (it does not reference itself); the recursive
   /// arm compiles with the name bound to `cte.columns`, the schema it reads.
-  internal borrowing func fixpoint(_ cte: CTE, _ ctes: ScopedRelations,
-                                   _ routines: Routines, _ bindings: Bindings)
+  internal borrowing func fixpoint(_ cte: CTE, _ context: Context)
       throws(SQLError) -> Array<Array<Value>> {
     // Extend the scope with any `definition_schema.` store relation the CTE's
     // body names, so the fixpoint's width-check compiles resolve a reserved
     // relation as the body's own run does. The routines ride in: this store
-    // entry is cached in `ctes` and reused by every anchor/recursive execution
-    // (a later `augment` will not replace a bound name), so a view column using
-    // even a standard routine (`BITAND(...)`) types the same inside the CTE as
-    // the identical SELECT does outside it.
-    let ctes = augment(ctes, for: cte.query, rows: true, routines: routines)
+    // entry is cached in the overlay and reused by every anchor/recursive
+    // execution (a later `augment` will not replace a bound name), so a view
+    // column using even a standard routine (`BITAND(...)`) types the same
+    // inside the CTE as the identical SELECT does outside it.
+    let context = augment(context, for: cte.query, rows: true)
     guard case let .union(anchor, recursive, all) = cte.query else {
       // A non-`UNION` recursive query runs once, but still binds under
       // `cte.columns`, so validate its compiled width here too — the check the
       // anchor and arm get. A body naming a base relation of the CTE's own name
       // (`WITH RECURSIVE Parent(x,y,z) AS (SELECT * FROM Parent)`) would else
       // bind narrow base rows under the wider list and trap on a later read.
-      let width = try compile(cte.query, ctes).width
+      let width = try compile(cte.query, context).width
       guard width == cte.columns.count else {
         throw .columns(expected: cte.columns.count, got: width)
       }
-      return try run(cte.query, ctes, routines, bindings)
+      return try run(cte.query, context)
     }
 
     // A misplaced recursive reference in the anchor (a same-named base/view is
@@ -374,7 +376,7 @@ extension Catalog where Self: ~Escapable {
     // arm reads the absent ordinal, rather than surfacing `SQLError.columns`.
     // The anchor is the base case and does not reference the CTE, so its width
     // resolves with the name not yet in scope.
-    let width = try compile(anchor, ctes).width
+    let width = try compile(anchor, context).width
     guard width == cte.columns.count else {
       throw .columns(expected: cte.columns.count, got: width)
     }
@@ -383,11 +385,10 @@ extension Catalog where Self: ~Escapable {
     // schema every iteration reads it under — so its width resolves too (a
     // `SELECT *` arm spans that schema). Checking it here catches a mismatch
     // even when the arm is filtered to zero rows in every iteration.
-    var probe = ctes
-    probe[cte.name.lowercased()] =
-        Materialised(columns: cte.columns, rows: [],
-                     types: Array(repeating: .integer,
-                                  count: cte.columns.count))
+    let empty = Materialised(columns: cte.columns, rows: [],
+                             types: Array(repeating: .integer,
+                                          count: cte.columns.count))
+    let probe = context.binding(cte.name, to: empty)
     let arm = try compile(.select(recursive), probe).width
     guard arm == cte.columns.count else {
       throw .columns(expected: cte.columns.count, got: arm)
@@ -398,7 +399,7 @@ extension Catalog where Self: ~Escapable {
     // bare `UNION` dedups the seed exactly as it dedups an iteration's rows —
     // duplicate anchor rows collapse to their first occurrence — while `UNION
     // ALL` keeps every anchor row.
-    let anchored = try run(anchor, ctes, routines, bindings)
+    let anchored = try run(anchor, context)
     var seen = Seen()
     var result = all ? anchored
                      : anchored.filter { seen.insert($0) }
@@ -413,13 +414,11 @@ extension Catalog where Self: ~Escapable {
 
       // Bind the CTE name to ONLY the previous step's output and run the
       // recursive arm against the base catalog plus the earlier CTEs.
-      var scope = ctes
-      scope[cte.name.lowercased()] =
-          Materialised(columns: cte.columns, rows: working,
-                       types: Array(repeating: .integer,
-                                    count: cte.columns.count))
-      let produced =
-          try run(.select(recursive), scope, routines, bindings)
+      let step = Materialised(columns: cte.columns, rows: working,
+                              types: Array(repeating: .integer,
+                                           count: cte.columns.count))
+      let produced = try run(.select(recursive), context.binding(cte.name,
+                                                                 to: step))
 
       var next = Array<Array<Value>>()
       for row in produced where all || seen.insert(row) {
@@ -610,7 +609,7 @@ extension Catalog where Self: ~Escapable {
   /// standard rule that every non-aggregated projection/`ORDER BY` column appear
   /// in the `GROUP BY`.
   internal borrowing func group(_ select: Select, _ relation: Relation,
-                                _ from: Resolved, _ ctes: ScopedRelations,
+                                _ from: Resolved, _ context: Context,
                                 _ visited: Set<String>)
       throws(SQLError) -> Plan {
     // Resolve every joined relation and lay the FROM relation and each joined
@@ -619,7 +618,7 @@ extension Catalog where Self: ~Escapable {
     var joined = Array<Resolved>()
     joined.reserveCapacity(select.joins.count)
     for join in select.joins {
-      try joined.append(resolve(join.relation, ctes, visited))
+      try joined.append(resolve(join.relation, context, visited))
     }
     var relations = [(relation, from.schema)]
     for index in select.joins.indices {
@@ -836,13 +835,13 @@ extension Catalog where Self: ~Escapable {
   ///     the product stays (a plain nested loop).
   internal borrowing func optimise(_ plan: Plan, _ bindings: Bindings)
       throws(SQLError) -> Plan {
-    try optimise(plan, [:], bindings)
+    try optimise(plan, Context(bindings: bindings))
   }
 
-  /// Rewrites `plan` into a physical one with the in-scope `ctes` (consulted
-  /// before the base catalog for seekability) and `bindings`.
-  internal borrowing func optimise(_ plan: Plan, _ ctes: ScopedRelations,
-                                   _ bindings: Bindings)
+  /// Rewrites `plan` into a physical one under `context` — the in-scope overlay
+  /// (consulted before the base catalog for seekability) and the bindings a
+  /// bound key seeks like a literal.
+  internal borrowing func optimise(_ plan: Plan, _ context: Context)
       throws(SQLError) -> Plan {
     switch plan {
     case .single:
@@ -857,33 +856,32 @@ extension Catalog where Self: ~Escapable {
       // means what it was registered to mean; its scope is the
       // `definition_schema.` overlay its OWN query names (the same one it
       // compiled under), so a view body's store scan re-resolves.
-      try .derived(name: name, plan: optimise(plan, overlay(name), bindings),
+      try .derived(name: name,
+                   plan: optimise(plan, overlay(name, context)),
                    ordinals: ordinals, seek: seek)
     case let .select(filter, .scan(name, ordinals, nil)):
-      try seek(filter, name, ordinals, ctes, bindings)
+      try seek(filter, name, ordinals, context)
     case let .select(filter, .product(left, right)):
-      try nest(filter, left, right, ctes, bindings)
+      try nest(filter, left, right, context)
     case let .select(filter, source):
-      try .select(filter, optimise(source, ctes, bindings))
+      try .select(filter, optimise(source, context))
     case let .project(ordinals, source):
-      try .project(ordinals, optimise(source, ctes, bindings))
+      try .project(ordinals, optimise(source, context))
     case let .sort(keys, source):
-      try .sort(keys: keys, optimise(source, ctes, bindings))
+      try .sort(keys: keys, optimise(source, context))
     case let .product(left, right):
-      try .product(optimise(left, ctes, bindings),
-                   optimise(right, ctes, bindings))
+      try .product(optimise(left, context), optimise(right, context))
     case .join:
       plan
     case let .union(left, right, all):
       // Optimise each side with the same bindings so a bound predicate inside an
       // arm seeks; the union itself merely concatenates and deduplicates,
       // preserving this node's own `all`.
-      try .union(optimise(left, ctes, bindings),
-                 optimise(right, ctes, bindings), all: all)
+      try .union(optimise(left, context), optimise(right, context), all: all)
     case let .distinct(source):
       // A `distinct` dedups its source without a seek or join of its own;
       // optimise the source below it and rewrap.
-      try .distinct(optimise(source, ctes, bindings))
+      try .distinct(optimise(source, context))
     case let .aggregate(keys, aggregates, source):
       // An aggregate reshapes its source and has no seek or join of its own;
       // optimise its source (the WHERE/join chain below it seeks and nests as
@@ -891,12 +889,11 @@ extension Catalog where Self: ~Escapable {
       // recursion reaches through here, but their grouped-space slots never seek
       // a base relation.
       try .aggregate(keys: keys, aggregates: aggregates,
-                     optimise(source, ctes, bindings))
+                     optimise(source, context))
     case let .limit(count, offset, source):
       // A `limit` is a transparent wrapper — optimise its source and re-cap;
       // the cap itself has no seek or join to rewrite.
-      try .limit(count: count, offset: offset,
-                 optimise(source, ctes, bindings))
+      try .limit(count: count, offset: offset, optimise(source, context))
     }
   }
 
@@ -915,17 +912,17 @@ extension Catalog where Self: ~Escapable {
   /// in slot space, so a comparison's slot maps back to its table ordinal
   /// through the scan's `ordinals` before reading a boundary.
   private borrowing func seek(_ filter: Filter, _ name: String,
-                              _ ordinals: Array<Int>, _ ctes: ScopedRelations,
-                              _ bindings: Bindings)
+                              _ ordinals: Array<Int>, _ context: Context)
       throws(SQLError) -> Plan {
     // A materialised CTE relation stores no sort key, so it is never seekable —
     // leave the scan under the whole filter.
-    guard ctes[name.lowercased()] == nil else {
+    guard context.relations[name.lowercased()] == nil else {
       return .select(filter, .scan(name: name, ordinals: ordinals, seek: nil))
     }
     guard let table = table(named: name) else { throw .relation(name) }
     let count = table.cursor().count
 
+    let bindings = context.bindings
     if let range = table.boundaries(filter, ordinals, count, bindings) {
       return .scan(name: name, ordinals: ordinals, seek: range)
     }
@@ -1048,7 +1045,7 @@ extension Catalog where Self: ~Escapable {
   /// kept the safe inner filter ahead of any unsafe conjunct). When the inner
   /// side is neither shape, the product is preserved.
   private borrowing func nest(_ filter: Filter, _ left: Plan, _ right: Plan,
-                              _ ctes: ScopedRelations, _ bindings: Bindings)
+                              _ context: Context)
       throws(SQLError) -> Plan {
     let inner: (name: String, ordinals: Array<Int>, filter: Filter?)?
     switch right {
@@ -1061,8 +1058,8 @@ extension Catalog where Self: ~Escapable {
     }
 
     guard let inner, let base = left.slots else {
-      return try filter.gated(over: .product(optimise(left, ctes, bindings),
-                                             optimise(right, ctes, bindings)))
+      return try filter.gated(over: .product(optimise(left, context),
+                                             optimise(right, context)))
     }
 
     let conjuncts = filter.conjuncts
@@ -1083,7 +1080,7 @@ extension Catalog where Self: ~Escapable {
       // only when the filter holds), without letting that conjunct throw first
       // (`Parent.Name = 'nope' AND (1 / Child.x) = 0`, the false name excluding
       // the row before the division runs).
-      let join = try Plan.join(optimise(left, ctes, bindings),
+      let join = try Plan.join(optimise(left, context),
                                name: inner.name, ordinals: inner.ordinals,
                                base: base,
                                column: inner.ordinals[rightKey - base],
@@ -1093,8 +1090,8 @@ extension Catalog where Self: ~Escapable {
       return .select(predicate, join)
     }
 
-    return try filter.gated(over: .product(optimise(left, ctes, bindings),
-                                           optimise(right, ctes, bindings)))
+    return try filter.gated(over: .product(optimise(left, context),
+                                           optimise(right, context)))
   }
 }
 
@@ -1405,25 +1402,26 @@ extension Catalog where Self: ~Escapable {
   /// chain by the trailing arm's flag. The new arm must project the same column
   /// count as the chain's first `SELECT` — the result columns — else
   /// `SQLError.arity`.
-  internal borrowing func compile(_ query: Query, _ ctes: ScopedRelations = [:],
+  internal borrowing func compile(_ query: Query,
+                                  _ context: Context = Context(),
                                   _ visited: Set<String> = [])
       throws(SQLError) -> Plan {
     guard case let .union(left, select, all) = query else {
-      return try compile(query.first, ctes, visited)
+      return try compile(query.first, context, visited)
     }
 
-    let width = try arity(query.first, ctes, visited)
-    let count = try arity(select, ctes, visited)
+    let width = try arity(query.first, context, visited)
+    let count = try arity(select, context, visited)
     guard count == width else { throw .arity(width, count) }
-    return try .union(compile(left, ctes, visited),
-                      compile(.select(select), ctes, visited), all: all)
+    return try .union(compile(left, context, visited),
+                      compile(.select(select), context, visited), all: all)
   }
 
   /// The number of result columns `select` projects — the extent of a `*` over
   /// its relations, else the count of its projected items — for the `UNION`
-  /// arity check. The relations resolve through this catalog, the `ctes`
+  /// arity check. The relations resolve through this catalog, the overlay
   /// consulted first.
-  private borrowing func arity(_ select: Select, _ ctes: ScopedRelations,
+  private borrowing func arity(_ select: Select, _ context: Context,
                                _ visited: Set<String>)
       throws(SQLError) -> Int {
     switch select.projection {
@@ -1432,9 +1430,9 @@ extension Catalog where Self: ~Escapable {
       guard let relation = select.from else {
         throw .named("SELECT * with no FROM")
       }
-      var width = try resolve(relation, ctes, visited).schema.width
+      var width = try resolve(relation, context, visited).schema.width
       for join in select.joins {
-        try width += resolve(join.relation, ctes, visited).schema.width
+        try width += resolve(join.relation, context, visited).schema.width
       }
       return width
     case let .columns(columns):
@@ -1480,11 +1478,11 @@ extension Catalog where Self: ~Escapable {
   /// `definition_schema.` store's `columns` builder, which compiles every view
   /// to advertise it, relies on this: a cyclic view's `try? compile` catches
   /// the fault and skips it.
-  internal borrowing func resolve(_ relation: Relation, _ ctes: ScopedRelations,
+  internal borrowing func resolve(_ relation: Relation, _ context: Context,
                                   _ visited: Set<String> = [])
       throws(SQLError) -> Resolved {
     let name = relation.name
-    if let cte = ctes[name.lowercased()] {
+    if let cte = context.relations[name.lowercased()] {
       let schema = cte.schema()
       return Resolved(schema: schema) { ordinals in
         .scan(name: name, ordinals: ordinals, seek: nil)
@@ -1516,7 +1514,8 @@ extension Catalog where Self: ~Escapable {
       // validate a view via `compile`. The rows a view over a reserved
       // relation actually returns are supplied at EXECUTE time, where `derive`
       // rebuilds the overlay with rows and runs the sub-plan.
-      let overlay = augment([:], for: view.query, rows: false)
+      let overlay =
+          augment(context.scoping([:]), for: view.query, rows: false)
       let plan =
           try compile(view.query, overlay, visited.union([name.lowercased()]))
       let projected = plan.width
@@ -1562,7 +1561,7 @@ extension Catalog where Self: ~Escapable {
   /// `Scan(_, _, nil)`; the optimiser turns scans into seeks and each product
   /// into a join.
   internal borrowing func compile(_ select: Select,
-                                  _ ctes: ScopedRelations = [:],
+                                  _ context: Context = Context(),
                                   _ visited: Set<String> = [])
       throws(SQLError) -> Plan {
     guard let relation = select.from else {
@@ -1580,7 +1579,7 @@ extension Catalog where Self: ~Escapable {
       }
       return try select.projection.scalar()
     }
-    let from = try resolve(relation, ctes, visited)
+    let from = try resolve(relation, context, visited)
 
     if let limit = select.limit {
       // The parser yields only non-negative counts (a `-` is its own token), but
@@ -1597,7 +1596,7 @@ extension Catalog where Self: ~Escapable {
     // `HAVING`, and `ORDER BY` against the grouped slot space. A non-aggregate
     // query compiles exactly as before.
     if select.aggregates {
-      return try group(select, relation, from, ctes, visited)
+      return try group(select, relation, from, context, visited)
     }
 
     guard !select.joins.isEmpty else {
@@ -1638,7 +1637,7 @@ extension Catalog where Self: ~Escapable {
     var joined = Array<Resolved>()
     joined.reserveCapacity(select.joins.count)
     for join in select.joins {
-      try joined.append(resolve(join.relation, ctes, visited))
+      try joined.append(resolve(join.relation, context, visited))
     }
 
     var relations = [(relation, from.schema)]

--- a/Sources/SQL/Operator.swift
+++ b/Sources/SQL/Operator.swift
@@ -286,33 +286,33 @@ extension Plan {
 /// or stored.
 internal func execute<C: Catalog & ~Escapable>(_ plan: Plan,
                                                _ catalog: borrowing C,
-                                               _ ctes: ScopedRelations,
-                                               _ routines: Routines,
-                                               _ bindings: Bindings)
+                                               _ context: Context)
     throws(SQLError) -> Array<Record> {
+  let routines = context.routines
+  let bindings = context.bindings
   switch plan {
   case .single:
     // The FROM-less single row: one record with no cells, the source a scalar
     // projection evaluates its constant/call expressions against.
-    [Record([])]
+    return [Record([])]
   case let .scan(name, ordinals, seek):
-    try materialise(name, ordinals, seek, catalog, ctes)
+    return try materialise(name, ordinals, seek, catalog, context.relations)
   case let .derived(name, source, ordinals, seek):
-    try catalog.derive(name, source, ordinals, seek, routines, bindings)
+    return try catalog.derive(name, source, ordinals, seek, context)
   case let .select(filter, .product(outer, inner)):
     // Fuse a residual product with its filter: stream each pair through the
     // predicate rather than materialising the whole cross product first.
-    try sift(execute(outer, catalog, ctes, routines, bindings),
-             execute(inner, catalog, ctes, routines, bindings), filter, routines,
-             bindings)
+    return try sift(execute(outer, catalog, context),
+                    execute(inner, catalog, context), filter, routines,
+                    bindings)
   case let .select(filter, source):
-    try admitted(execute(source, catalog, ctes, routines, bindings), filter,
-                 routines, bindings)
+    return try admitted(execute(source, catalog, context), filter,
+                        routines, bindings)
   case let .project(terms, source):
-    try execute(source, catalog, ctes, routines, bindings)
+    return try execute(source, catalog, context)
       .map { record throws(SQLError) in try project(terms, record, routines) }
   case let .sort(keys, source):
-    try execute(source, catalog, ctes, routines, bindings)
+    return try execute(source, catalog, context)
       .enumerated()
       .sorted { lhs, rhs in
         // Compare the keys major to minor: the first key on which the rows
@@ -330,21 +330,20 @@ internal func execute<C: Catalog & ~Escapable>(_ plan: Plan,
       }
       .map(\.element)
   case let .product(outer, inner):
-    try product(execute(outer, catalog, ctes, routines, bindings),
-                execute(inner, catalog, ctes, routines, bindings))
+    return try product(execute(outer, catalog, context),
+                       execute(inner, catalog, context))
   case let .join(outer, name, ordinals, base, column, keys, filter):
-    try join(execute(outer, catalog, ctes, routines, bindings), name, ordinals,
-             base, column, keys, filter, catalog, ctes, routines, bindings)
+    return try join(execute(outer, catalog, context), name, ordinals,
+                    base, column, keys, filter, catalog, context)
   case let .union(left, right, all):
-    try union(left, right, all, catalog, ctes, routines, bindings)
+    return try union(left, right, all, catalog, context)
   case let .distinct(source):
-    deduplicated(try execute(source, catalog, ctes, routines, bindings))
+    return deduplicated(try execute(source, catalog, context))
   case let .aggregate(keys, aggregates, source):
-    try grouped(execute(source, catalog, ctes, routines, bindings), keys,
-                aggregates, routines)
+    return try grouped(execute(source, catalog, context), keys,
+                       aggregates, routines)
   case let .limit(count, offset, source):
-    limited(try execute(source, catalog, ctes, routines, bindings),
-            count, offset)
+    return limited(try execute(source, catalog, context), count, offset)
   }
 }
 
@@ -377,12 +376,10 @@ private func limited(_ records: Array<Record>, _ count: Int?, _ offset: Int)
 private func union<C: Catalog & ~Escapable>(_ left: Plan, _ right: Plan,
                                             _ all: Bool,
                                             _ catalog: borrowing C,
-                                            _ ctes: ScopedRelations,
-                                            _ routines: Routines,
-                                            _ bindings: Bindings)
+                                            _ context: Context)
     throws(SQLError) -> Array<Record> {
-  let rows = try execute(left, catalog, ctes, routines, bindings)
-      + execute(right, catalog, ctes, routines, bindings)
+  let rows = try execute(left, catalog, context)
+      + execute(right, catalog, context)
   return all ? rows : deduplicated(rows)
 }
 
@@ -475,14 +472,14 @@ extension Catalog where Self: ~Escapable {
   /// optimised under.
   internal borrowing func derive(_ name: String, _ plan: Plan,
                                  _ ordinals: Array<Int>, _ seek: Range<Int>?,
-                                 _ routines: Routines, _ bindings: Bindings)
+                                 _ context: Context)
       throws(SQLError) -> Array<Record> {
     let overlay = if let view = resolve(view: name) {
-      augment([:], for: view.query, rows: true, routines: routines)
+      augment(context.scoping([:]), for: view.query, rows: true)
     } else {
-      ScopedRelations()
+      context.scoping([:])
     }
-    let rows = try execute(plan, self, overlay, routines, bindings)
+    let rows = try execute(plan, self, overlay)
     let range = seek ?? 0 ..< rows.count
     return range.map { rows[$0].project(ordinals) }
   }
@@ -602,17 +599,17 @@ private func join<C: Catalog & ~Escapable>(_ outer: Array<Record>,
                                            _ keys: (left: Int, right: Int),
                                            _ filter: Filter?,
                                            _ catalog: borrowing C,
-                                           _ ctes: ScopedRelations,
-                                           _ routines: Routines,
-                                           _ bindings: Bindings)
+                                           _ context: Context)
     throws(SQLError) -> Array<Record> {
+  let routines = context.routines
+  let bindings = context.bindings
   // A materialised CTE inner has no sort key, so it is scanned in full and the
   // equality on its `keys.right` slot is the join's truth — the same probe a
   // base relation falls back to when its key is unseekable. A pushed inner
   // filter (in the inner's standalone slot space) is applied as each record
   // materialises, before it can pair — mirroring the base seek/hash paths — so a
   // filtered CTE row is never joined.
-  if let cte = ctes[name.lowercased()] {
+  if let cte = context.relations[name.lowercased()] {
     var inner = Array<Record>()
     for index in 0 ..< cte.rows.count {
       let right = cte.record(index, ordinals)

--- a/Sources/SQL/OutputColumn.swift
+++ b/Sources/SQL/OutputColumn.swift
@@ -80,14 +80,18 @@ extension Catalog where Self: ~Escapable {
   public borrowing func columns(of query: Query, routines: Routines = [:],
                                 validate: Bool = true)
       throws(SQLError) -> Array<OutputColumn> {
+    // The engine prelude merged under the caller's routines, exactly as a run
+    // seeds them, so a standard call (`BITAND`) types without the caller
+    // re-supplying it. A typing path has no bindings.
+    let context = Context(routines: Routines.standard.merging(routines))
     // Extend the scope with any `definition_schema.` store relation the query
     // names, so its result schema resolves the reserved relation the same as a
     // run would — SCHEMA-ONLY, so typing never triggers the row build.
-    let ctes = augment([:], for: query, rows: false)
+    let scope = augment(context, for: query, rows: false)
     // Validate the whole query without executing — the same compile the run
     // path drives, resolving every arm and cross-checking a UNION's arity — so
     // a schema is returned only for a query that could actually run.
-    _ = try compile(query, ctes)
+    _ = try compile(query, scope)
     // Type-check every REACHABLE operand and call across all arms — the
     // projection, `WHERE`, and `HAVING` of each. `compile` resolves a call's
     // arguments but cannot check the routine EXISTS or that it is called with
@@ -99,18 +103,14 @@ extension Catalog where Self: ~Escapable {
     // that already RAN the query (`validate: false`) skips it: a reachable
     // operand a data-dependent filter never reached would otherwise fault a
     // query that produced its (empty) result.
-    let routines = Routines.standard.merging(routines)
-    if validate { try typecheck(query, ctes, routines: routines) }
+    if validate { try typecheck(query, scope) }
     // The result columns are the first arm's projection (the ISO rule a UNION
     // follows), resolved against the validated scope; a scalar call types from
-    // its routine's declared return type — the engine prelude merged under
-    // `routines`, exactly as a run seeds them, so a standard call (`BITAND`)
-    // types without the caller re-supplying it. `validate` rides through so a
+    // its routine's declared return type. `validate` rides through so a
     // `SELECT *` over a view derives the body's types WITHOUT re-type-checking
     // it — the view body's own reachable-operand check is gated the same as the
     // outer query's, so a `validate: false` derive faults nowhere.
-    return try columns(of: query.first, ctes, routines: routines,
-                       validate: validate)
+    return try columns(of: query.first, scope, validate: validate)
   }
 
   /// The result columns `statement` would yield, named and typed, resolved
@@ -192,7 +192,7 @@ extension Catalog where Self: ~Escapable {
                                  routines: Routines,
                                  validate: Bool)
       throws(SQLError) -> Array<OutputColumn> {
-    let routines = Routines.standard.merging(routines)
+    let context = Context(routines: Routines.standard.merging(routines))
     var overlay = ScopedRelations()
     for cte in ctes {
       // A name repeated in the list (case-insensitively) would silently shadow
@@ -225,8 +225,8 @@ extension Catalog where Self: ~Escapable {
       // run already proved the bodies consistent — so `typecheck: false` there.
       if validate {
         // `self.` escapes the shadow the `validate` Bool parameter casts over
-        // the shared `validate(_:against:routines:)` engine helper.
-        try self.validate(cte, against: overlay, routines: routines,
+        // the shared `validate(_:against:)` engine helper.
+        try self.validate(cte, against: context.scoping(overlay),
                           typecheck: true)
       }
       // Bind the CTE's schema-only self into the overlay AFTER its body is
@@ -235,11 +235,10 @@ extension Catalog where Self: ~Escapable {
       // its body.
       overlay[cte.name.lowercased()] = declared
     }
-    let scope = augment(overlay, for: query, rows: false)
+    let scope = augment(context.scoping(overlay), for: query, rows: false)
     _ = try compile(query, scope)
-    if validate { try typecheck(query, scope, routines: routines) }
-    return try columns(of: query.first, scope, routines: routines,
-                       validate: validate)
+    if validate { try typecheck(query, scope) }
+    return try columns(of: query.first, scope, validate: validate)
   }
 
   /// The result columns of a single `select`, resolved against this catalog
@@ -255,14 +254,12 @@ extension Catalog where Self: ~Escapable {
   /// this arm's relations resolve, gating the view body's reachable-operand
   /// check the same as the outer query's — a `validate: false` derive never
   /// re-type-checks a view body a run already proved runnable.
-  borrowing func columns(of select: Select, _ ctes: ScopedRelations,
+  borrowing func columns(of select: Select, _ context: Context,
                          visited: Set<String> = [],
-                         routines: Routines = [:],
                          validate: Bool = true)
       throws(SQLError) -> Array<OutputColumn> {
-    try scope(of: select, ctes, visited: visited, routines: routines,
-              validate: validate)
-        .columns(of: select.projection, routines)
+    try scope(of: select, context, visited: visited, validate: validate)
+        .columns(of: select.projection, context.routines)
   }
 
   /// The name-resolution scope of `select` — its FROM relation and each joined
@@ -272,18 +269,17 @@ extension Catalog where Self: ~Escapable {
   /// empty. It reads only schemas, never a cursor. `validate` (default `true`)
   /// rides through to each relation's `schema(of:)`, gating a view body's
   /// reachable-operand check the same as the outer query's.
-  borrowing func scope(of select: Select, _ ctes: ScopedRelations,
+  borrowing func scope(of select: Select, _ context: Context,
                        visited: Set<String> = [],
-                       routines: Routines = [:],
                        validate: Bool = true)
       throws(SQLError) -> Scope {
     guard let relation = select.from else { return Scope([]) }
     var relations =
-        [(relation, try schema(of: relation, ctes, visited: visited,
-                               routines: routines, validate: validate))]
+        [(relation, try schema(of: relation, context, visited: visited,
+                               validate: validate))]
     for join in select.joins {
-      let joined = try schema(of: join.relation, ctes, visited: visited,
-                              routines: routines, validate: validate)
+      let joined = try schema(of: join.relation, context, visited: visited,
+                              validate: validate)
       relations.append((join.relation, joined))
     }
     return Scope(relations)
@@ -299,16 +295,15 @@ extension Catalog where Self: ~Escapable {
   /// `Aggregate.fold` faults `SQLError.operand` at run. `compile` cannot catch
   /// this (no evaluating term is built), so a schema path type-checks each arm
   /// before returning metadata. It reads no cursor.
-  borrowing func typecheck(_ query: Query, _ ctes: ScopedRelations,
-                           visited: Set<String> = [],
-                           routines: Routines = [:])
+  borrowing func typecheck(_ query: Query, _ context: Context,
+                           visited: Set<String> = [])
       throws(SQLError) {
     switch query {
     case let .select(select):
-      try typecheck(select, ctes, visited: visited, routines: routines)
+      try typecheck(select, context, visited: visited)
     case let .union(left, select, _):
-      try typecheck(left, ctes, visited: visited, routines: routines)
-      try typecheck(select, ctes, visited: visited, routines: routines)
+      try typecheck(left, context, visited: visited)
+      try typecheck(select, context, visited: visited)
     }
   }
 
@@ -338,12 +333,11 @@ extension Catalog where Self: ~Escapable {
   ///     ONLY`, or a positive `OFFSET` over a whole-result aggregate's sole row
   ///     (its output type is still DERIVED for the schema, non-faulting);
   ///     otherwise it validates fully.
-  private borrowing func typecheck(_ select: Select, _ ctes: ScopedRelations,
-                                   visited: Set<String>,
-                                   routines: Routines)
+  private borrowing func typecheck(_ select: Select, _ context: Context,
+                                   visited: Set<String>)
       throws(SQLError) {
-    let scope = try scope(of: select, ctes, visited: visited,
-                          routines: routines)
+    let routines = context.routines
+    let scope = try scope(of: select, context, visited: visited)
     if let predicate = select.predicate {
       try scope.check(predicate, routines)
       // A false WHERE filters every row, so a GROUP BY forms no group and a
@@ -434,13 +428,12 @@ extension Catalog where Self: ~Escapable {
   /// types WITHOUT re-checking its reachable operands, so a view whose body is
   /// data-dependent-empty — a text-arithmetic projection under a filter that
   /// matched no row — does not fault a `SELECT *` over it that already ran.
-  borrowing func schema(of relation: Relation, _ ctes: ScopedRelations,
+  borrowing func schema(of relation: Relation, _ context: Context,
                         visited: Set<String> = [],
-                        routines: Routines = [:],
                         validate: Bool = true)
       throws(SQLError) -> Schema {
     let name = relation.name
-    if let cte = ctes[name.lowercased()] {
+    if let cte = context.relations[name.lowercased()] {
       return cte.schema()
     }
     // A reserved store relation types through its SCHEMA-ONLY build (header +
@@ -470,7 +463,7 @@ extension Catalog where Self: ~Escapable {
       // operand a `SELECT * FROM v` run would evaluate — a `WHERE`/`HAVING`, a
       // later `UNION` arm — while skipping an arm a short-circuit proves
       // unreachable.
-      let overlay = augment([:], for: view.query, rows: false)
+      let overlay = augment(context.scoping([:]), for: view.query, rows: false)
       let inner = visited.union([name.lowercased()])
       // Gate the body's reachable-operand check on `validate`: a `validate:
       // false` derive skips it, so a data-dependent-empty body (a text
@@ -478,7 +471,7 @@ extension Catalog where Self: ~Escapable {
       // the view that already ran to its (empty) result. `validate` also rides
       // into the recursive derive so a view over a view stays derive-only.
       if validate {
-        try typecheck(view.query, overlay, visited: inner, routines: routines)
+        try typecheck(view.query, overlay, visited: inner)
       }
       // Type off the body's first arm (the ISO rule for a UNION). Arity — the
       // body's width against the declared columns — is `compile`'s job (the
@@ -486,7 +479,7 @@ extension Catalog where Self: ~Escapable {
       // schema rather than re-checking it here.
       let resolved =
           try columns(of: view.query.first, overlay, visited: inner,
-                      routines: routines, validate: validate)
+                      validate: validate)
       guard resolved.count == base.width else { return base }
       return Schema(width: base.width, extent: base.extent, names: base.names,
                     types: resolved.map(\.type), virtuals: base.virtuals)


### PR DESCRIPTION
The engine threaded three escapable maps — the in-scope relation overlay (the materialised CTEs and definition_schema store relations), the scalar routines, and the query parameter bindings — as separate parameters beside the borrowed base catalog through every resolution and execution phase. Bundle them into one owned `Context` value, so a phase takes `(catalog, context)` rather than `(catalog, ctes/overlay, routines, bindings)`.

The catalog stays a SEPARATE borrowed parameter: a `Context` holding a ~Escapable catalog is toolchain-blocked (a stored ~Escapable member cannot yield a ~Escapable table), so `Context` bundles only the escapable maps. Deriving a scoped copy — extending the overlay for a CTE's scope, or rebinding a CTE's self for a recursive step — is a plain value copy (`scoping`/`binding`), needing none of the lifetime machinery the borrowed catalog does.

The collapse spans the orchestration/resolution layers — run/with/validate/ fixpoint, compile/arity/resolve/group, optimise/seek/nest (Engine), augment/ overlay/store/columns (Definition), execute/union/join/derive (Operator), and columns/scope/typecheck/schema (OutputColumn). The innermost single- field evaluators (project/admitted/sift/hashed, and the Scope/Row type-check and evaluation helpers) keep their `routines`/`bindings` parameters — they carry no catalog and are genuinely clearer on one field. The public `run`/`columns(of:)` entry points are unchanged; each builds the Context that seeds the engine prelude.

Pure refactor — behavior-preserving. CTE scoping extends `context.relations`; recursive with/fixpoint threads a Context whose overlay grew over the same separate borrowed catalog (which now compiles, Context being escapable); the definition_schema overlay rides in `relations` as before.