### PR TITLE
Documentation: refresh

### DIFF
--- a/Documentation/QueryModel.md
+++ b/Documentation/QueryModel.md
@@ -81,17 +81,23 @@ protocols (below), which the WinMD database conforms to.
 
 ## Textual SQL (the engine)
 
-The generic `SQL` module lexes and parses the text into a SQL AST — a relation,
-a projection (named columns or `*`), an optional predicate tree of
-`column · comparison · operand` nodes composed with `AND`/`OR`/`NOT`, an
-optional `JOIN … ON`, and an optional `ORDER BY`:
+The generic `SQL` module lexes and parses the text into a SQL AST. The dialect
+is a portable subset of ISO SQL — the authoritative grammar is the doc-comment
+atop `Sources/SQL/Parser.swift`. It covers `SELECT` with a projection (`*`, bare
+columns, or expressions with an `AS` alias, optionally `DISTINCT`), an optional
+predicate tree (`= <> < > <= >=`, `IS [NOT] NULL`, composed with
+`AND`/`OR`/`NOT`), `JOIN … ON`, `GROUP BY`/`HAVING`, `ORDER BY` (multi-key), and
+the ISO `OFFSET`/`FETCH` row-limiting clauses; aggregates
+(`COUNT`/`SUM`/`MIN`/`MAX`/`AVG`); `WITH [RECURSIVE]` CTEs and `UNION [ALL]`; and
+the `CREATE VIEW`/`CREATE FUNCTION` definitional statements. Its values are
+integer, double, text, boolean, and blob:
 
 ```sql
 SELECT TypeName, TypeNamespace FROM TypeDef
  WHERE TypeNamespace = 'Windows.Win32.Foundation'
 ```
 
-`winmd-inspect query` hands the parsed `SELECT` to the database-agnostic
+`winmd-inspect query` hands the parsed statement to the database-agnostic
 `Engine`, which runs entirely against four adapter protocols a data source
 conforms to: a `Catalog` resolves a relation name to a `Table`; a `Table`
 reports its schema (real `width`, a name → ordinal map, and a `bound` for a
@@ -99,7 +105,7 @@ sorted-seek) and vends a `Cursor`; a `Cursor` addresses rows by index; a `Row`
 reads a typed cell by ordinal. Every protocol is `~Escapable`, so a
 borrowed-storage source — a WinMD database over a mapped file — conforms to the
 same surface as an owned one. The engine yields typed `Value`s, never rendered
-text; `winmd-inspect` formats each into a tab-separated line.
+text; `winmd-inspect` formats each result set into a Unicode box-drawing table.
 
 The engine runs the `SELECT` in three phases, each re-resolving relations by
 name through the borrowed catalog:

--- a/Documentation/SynthesisModel.md
+++ b/Documentation/SynthesisModel.md
@@ -284,12 +284,16 @@ Given a SQL string it runs one query; given none it opens a `sqlite3`-style shel
 over the memory-mapped database — a literal `for`-in over a `Statements` stream,
 running each statement through `Shell.execute`. The shell offers:
 
-- bare SQL, run through the same `Engine` and printed tab-separated;
-- `CREATE VIEW …`, registering a session view that subsequent queries may name;
+- bare SQL, run through the same `Engine` and printed as a box-drawing table;
+- `CREATE VIEW …`/`CREATE FUNCTION …`, registering a session view or scalar
+  function that subsequent queries may name;
 - `.read <path>`, running a file of `;`-separated statements (registering views
   and printing selects), so user-authored views compose with the bundled ones;
 - `.render <interface> <template>` (with `*` for the whole database), the
   rendering pipeline above;
+- `.schema <query>`, printing a query's result columns and types without running
+  it; `.bind <name> <value>`, binding a `:name` parameter; `.template <name>
+  '<body>'`, defining an inline Mustache template;
 - `.tables`, `.help`, `.quit`.
 
 Meta-commands take a `.` prefix precisely so the SQL `:name` parameter syntax

--- a/README.md
+++ b/README.md
@@ -21,18 +21,79 @@ ways: a typed Swift combinator surface (`where`/`select` over a borrowed row,
 with `resolve`/`list`/`referencing` foreign-key navigation), and textual SQL run
 through a small, self-contained relational engine.
 
-The SQL engine is a standalone, WinMD-agnostic module: a lexer and parser for a
-minimal `SELECT` dialect, plus an operator algebra (a compiler, an optimiser,
-and an executor) that plans and runs a query against four adapter
-protocols — `Catalog`, `Table`, `Cursor`, and `Row` — knowing nothing of any
-particular data source. `winmd-inspect` adapts the WinMD database to those
-protocols, exposing each table's rows along with two virtual columns — a
-`rowid` (the 1-based row index) and a `parent` (a list-child's owning row) — so
-that foreign-key and parent/child list relationships become ordinary equi-joins
-the engine can plan and seek.
+## Code generation as a database
 
-The `winmd-inspect` command-line tool exposes the reader through its `dump` and
-`query` subcommands, with `query` the default:
+The library goes one step further and treats **code generation as a database
+problem**: the generated source is a *view* over the metadata, and the rules
+that decide what a COM interface *is* are written as SQL rather than as Swift.
+The pipeline is a stack of decoupled layers:
+
+- **WinMD reader** (`Sources/WinMD/`) — reads the ECMA-335 tables stream and
+  heaps in place, as a fixed set of relations. It is SQL-agnostic and never
+  imports the engine.
+- **SQL engine** (`Sources/SQL/`) — a standalone, WinMD-agnostic relational
+  engine: a lexer and parser for a `SELECT` dialect, plus an operator algebra
+  (a compiler, an optimiser, and an executor) that plans and runs a query
+  against four adapter protocols — `Catalog`, `Table`, `Cursor`, and `Row` —
+  knowing nothing of any particular data source.
+- **`winmd-inspect`** (`Sources/winmd-inspect/`) — binds the two. It adapts the
+  WinMD database to the engine's protocols, expresses the COM-interface schema as
+  declarative SQL views (`Sources/winmd-inspect/Resources/Queries/`), and
+  renders a query's rows through [Mustache](https://mustache.github.io)
+  templates (`Sources/winmd-inspect/Resources/Templates/`) to emit source.
+
+The adapter surfaces each table's real columns and adds a universal virtual
+column, `Id` (the 1-based row identity), sitting past the `SELECT *` extent. A
+foreign key is a real column holding a target row's `Id`, so a foreign-key or
+parent/child list relationship becomes an ordinary equi-join the engine can plan
+and seek. A list-owned child additionally carries an **owner foreign key** — a
+column named for its owning table (e.g. a `MethodDef`'s `TypeDef`) — and a coded
+index yields one decoded join key per candidate target
+(`Parent_TypeDef`, `Class_TypeRef`, …). WinMD-specific decodes are exposed as
+scalar functions over the raw cells rather than as columns; for example
+`GUID(blob)` decodes a `GuidAttribute` value blob to the IID it names.
+
+For the full design, see [`SynthesisModel.md`](Documentation/SynthesisModel.md).
+
+## The SQL dialect
+
+The engine implements a portable subset of ISO SQL, WinMD-agnostic and reusable
+on its own. The authoritative grammar lives as the doc-comment atop
+`Sources/SQL/Parser.swift`; in summary it supports:
+
+- **Statements** — `SELECT`; `WITH [RECURSIVE]` common table expressions;
+  `SELECT … UNION [ALL] …`; `CREATE VIEW`; and `CREATE FUNCTION`.
+- **Clauses** — `FROM` (optional: a bare `SELECT 1 + 1` computes a scalar),
+  `JOIN … ON a = b`, `WHERE`, `GROUP BY`, `HAVING`, `ORDER BY` (multi-key, each
+  `ASC`/`DESC`), and the ISO row-limiting `OFFSET n ROWS` /
+  `FETCH { FIRST | NEXT } [n] ROWS ONLY`.
+- **Projection** — `*`, bare columns, or expressions with an optional `AS`
+  alias; `DISTINCT` or `ALL`.
+- **Predicates** — the comparison operators (`=`, `<>`, `<`, `>`, `<=`, `>=`),
+  `IS [NOT] NULL`, and `AND`/`OR`/`NOT`, with parentheses.
+- **Expressions** — arithmetic (`+ - * /`, precedence-aware), literals, column
+  references, aggregates, and scalar-function calls.
+- **Aggregates** — `COUNT(*)`, and `COUNT`/`SUM`/`MIN`/`MAX`/`AVG` over an
+  expression.
+- **Value types** — integer, double, text, boolean (`TRUE`/`FALSE`), and blob
+  (`x'48656c6c6f'`). Text uses single quotes with `''` for an embedded quote.
+- **Identifiers** — bare, or delimited with double quotes (`"Type Name"`) to
+  spell a name verbatim; a dotted bare identifier (`t.Name`) is qualified.
+- **Routines** — `BITAND(x, y)` is the built-in bitwise AND (the engine's only
+  prelude routine). `winmd-inspect` additionally registers the `GUID(blob)`
+  decode. `CREATE FUNCTION f(x INTEGER) RETURNS INTEGER AS <expression>` defines
+  a scalar function over an expression body.
+- **Introspection** — the `information_schema.tables` and
+  `information_schema.columns` views (over a `definition_schema` base) list the
+  database's relations, views, and their columns.
+
+The dialect is a clean subset of the standard; there is no vendor-specific
+`LIMIT`, and comparisons use `<>` for inequality.
+
+## The `winmd-inspect` tool
+
+The `winmd-inspect` command-line tool exposes the reader through two
+subcommands — `query` (the default) and `dump`:
 
 ```
 winmd-inspect <file.winmd> dump
@@ -43,8 +104,44 @@ winmd-inspect <file.winmd> query \
        WHERE TypeNamespace = 'Windows.Win32.Foundation'"
 ```
 
-The `query` subcommand parses the SQL, hands the parsed `SELECT` to the engine,
-and renders each resulting row as a tab-separated line.
+`dump` prints the metadata version and every table's rows. `query` parses the
+SQL, hands the parsed statement to the engine, and renders each resulting row as
+a Unicode box-drawing table:
+
+```
+┌──────────┬──────────────────────────┐
+│ TypeName │ TypeNamespace            │
+├──────────┼──────────────────────────┤
+│ HWND     │ Windows.Win32.Foundation │
+│ …        │ …                        │
+└──────────┴──────────────────────────┘
+```
+
+### The interactive shell
+
+Running `query` with no SQL argument opens an interactive shell (SQL may also be
+piped on stdin). Statements run as they are entered; a `;` is optional. In
+addition to SQL, the shell understands a set of `.`-prefixed metacommands:
+
+```
+winmd> .tables                    -- list the database's tables
+winmd> .schema SELECT * FROM TypeDef
+                                  -- print a query's result columns and types
+winmd> .bind ns 'Windows.Win32.Foundation'
+                                  -- bind a :ns parameter for later queries
+winmd> SELECT TypeName FROM TypeDef WHERE TypeNamespace = :ns;
+winmd> .render IUnknown com       -- render a COM interface through a template
+winmd> .render * com              -- render every interface
+winmd> .template t '{{! language: swift }}…'
+                                  -- define an inline Mustache template
+winmd> .read queries.sql          -- run a file of ;-separated statements
+winmd> .help                      -- list the metacommands
+winmd> .quit
+```
+
+A `-I <directory>` option prepends a search directory for the query, view, and
+template resource files, so a caller can override the bundled ones without
+rebuilding.
 
 ## Build Requirements
 
@@ -63,7 +160,8 @@ swift build
 swift test
 ```
 
-The package vends a `winmd-inspect` executable and a reusable `SQL` library.
+The package vends a `winmd-inspect` executable and two reusable libraries: the
+generic `SQL` engine and the `WinMDSynthesis` code-generation support.
 
 ## Documentation
 
@@ -76,3 +174,7 @@ The on-disk format and the design of the library are described in the
   projection the library is modelled on.
 - [`QueryModel.md`](Documentation/QueryModel.md) — selecting, filtering, and
   navigating the metadata through textual SQL and typed Swift combinators.
+- [`SynthesisModel.md`](Documentation/SynthesisModel.md) — code generation as a
+  database: the schema layers, the declarative views, and the render pipeline.
+</content>
+</invoke>


### PR DESCRIPTION
This pull request significantly refactors and improves documentation and code organization for the `winmd-inspect` tool and its SQL engine, while removing the now-unnecessary `print-namespaces` subcommand. The documentation is expanded to clarify the architecture, SQL dialect, and shell usage, and the codebase is simplified by consolidating functionality and removing redundant tests and fixtures.

**Documentation improvements:**

- Expanded the `README.md` to clearly explain the layered architecture (WinMD reader, SQL engine, and code generation), the SQL dialect, and the interactive shell's capabilities. Added usage examples and described the output format as Unicode box-drawing tables instead of tab-separated lines. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L24-R144) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L65-R164) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R177-R180)
- Updated `Documentation/QueryModel.md` and `Documentation/SynthesisModel.md` to reflect the expanded SQL dialect (including `CREATE FUNCTION`, CTEs, aggregates, etc.) and the new output format. [[1]](diffhunk://#diff-8717a673794bc3a7f27d505a8d046288733ef0ed3ac36d92b228a9d86dba080fL84-R108) [[2]](diffhunk://#diff-2efafce59ebfec5af49cbc1ddd0ddb5ee0d9ce14079a4d9c5f66685d95a19d9eL287-R296)

**Codebase simplification:**

- Removed the `PrintNamespaces` subcommand and its associated code, as its functionality is now covered by a SQL query through the main `query` command, which outputs results as a box-drawing table. [[1]](diffhunk://#diff-0406fad64c2abaf19792d1c62d64bf35d8d50979e07710b921506c14a300653dL42-L84) [[2]](diffhunk://#diff-0406fad64c2abaf19792d1c62d64bf35d8d50979e07710b921506c14a300653dL97)
- Removed the corresponding tests and test fixtures for `print-namespaces` from `DatabaseSQLTests.swift`, as this output format and behavior are no longer relevant. [[1]](diffhunk://#diff-01940b6db38632bcd9ab8dc1e88be31c8a477c3deafd6b4f5eed1792fbd94784L1083-L1121) [[2]](diffhunk://#diff-01940b6db38632bcd9ab8dc1e88be31c8a477c3deafd6b4f5eed1792fbd94784L1233-L1293)

**Minor code cleanup:**

- Removed an unused import of the `SQL` module in `Sources/winmd-inspect/Inspect.swift`.

These changes modernize the documentation, streamline the CLI, and ensure that future maintenance is easier by reducing redundancy and improving clarity.