### PR TITLE
winmd-inspect: thread generic parameters

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -81,6 +81,8 @@ let _ =
                             "winmd-inspect",
                             "SQL",
                             "WinMD",
+                            .product(name: "Mustache",
+                                     package: "swift-mustache"),
                           ],
                           swiftSettings: [
                             .enableExperimentalFeature("Lifetimes"),

--- a/Sources/WinMD/Signature.swift
+++ b/Sources/WinMD/Signature.swift
@@ -494,6 +494,24 @@ extension Row where Schema == Metadata.Tables.MethodDef {
   }
 }
 
+extension Row where Schema == Metadata.Tables.TypeSpec {
+  /// The decoded type the `TypeSpec` names (ECMA-335 §II.23.2.14).
+  ///
+  /// Distinct from the `Signature` accessor, which vends the raw `#Blob`; this
+  /// decodes that blob into a structured `SignatureType` — a `TypeSpec`
+  /// signature is a single `Type` (typically a `GENERICINST`), so it decodes
+  /// one type and requires the blob be consumed exactly.
+  public var type: SignatureType {
+    get throws(WinMDError) {
+      let entry = try blob(.Signature)
+      var decoder = SignatureDecoder(entry.bytes)
+      let type = try decoder.type()
+      try decoder.end()
+      return type
+    }
+  }
+}
+
 extension Row where Schema == Metadata.Tables.FieldDef {
   /// The decoded field signature (ECMA-335 §II.23.2.4).
   ///

--- a/Sources/WinMDSynthesis/Decode.swift
+++ b/Sources/WinMDSynthesis/Decode.swift
@@ -73,6 +73,16 @@ public struct Dialect: Sendable {
     self.known = known
     self.escape = escape
   }
+
+  /// The generic-parameter declaration clause for the ordered `names`
+  /// (`<Element>`, `<Key, Value>`) — the dialect's generic delimiters wrapped
+  /// around the comma-separated names — or `nil` for a non-generic declaration
+  /// (an empty list), so a caller omits the clause entirely. Variance is
+  /// dropped (the target has no declaration-site variance); names spell plain.
+  public func generics(_ names: Array<String>) -> String? {
+    guard !names.isEmpty else { return nil }
+    return generic.open + names.joined(separator: ", ") + generic.close
+  }
 }
 
 /// The per-dialect decode functions, emitting a target type spelling as text.
@@ -89,33 +99,43 @@ public struct Dialect: Sendable {
 extension SignatureType {
   /// The type spelling of `self` in `dialect`, resolving named types through
   /// `resolver` and disambiguating a `System.Guid` by the `parameter`-name hint.
-  public func decode(parameter: String? = nil, with resolver: Resolver,
+  ///
+  /// A `VAR` generic variable spells its declared parameter's name when the
+  /// owner's ordered `generics` names are supplied (`VAR 0` of `<Element>`
+  /// spells `Element`); absent them (the DB-free path) it degrades to the
+  /// dialect's positional placeholder (`T0`). The names index by the variable's
+  /// operand; an out-of-range operand falls back to the placeholder. An `MVAR`
+  /// (method-level) variable always spells its placeholder — only the
+  /// type-level names are threaded here.
+  public func decode(parameter: String? = nil,
+                     generics: Array<String>? = nil, with resolver: Resolver,
                      dialect: Dialect) -> String {
     switch self {
     case let .primitive(primitive):
       primitive.spelling(dialect)
     case let .pointer(pointee):
-      pointee.spelling(parameter: parameter, const: false, with: resolver,
-                       dialect: dialect)
+      pointee.spelling(parameter: parameter, generics: generics, const: false,
+                       with: resolver, dialect: dialect)
     case let .reference(referent):
-      referent.spelling(parameter: parameter, const: false, with: resolver,
-                        dialect: dialect)
+      referent.spelling(parameter: parameter, generics: generics, const: false,
+                        with: resolver, dialect: dialect)
     case let .array(element):
-      element.spelling(parameter: parameter, const: false, with: resolver,
-                       dialect: dialect)
+      element.spelling(parameter: parameter, generics: generics, const: false,
+                       with: resolver, dialect: dialect)
     case let .matrix(element, _):
-      element.spelling(parameter: parameter, const: false, with: resolver,
-                       dialect: dialect)
+      element.spelling(parameter: parameter, generics: generics, const: false,
+                       with: resolver, dialect: dialect)
     case let .named(kind, reference):
       reference.spelling(kind: kind, parameter: parameter, with: resolver,
                          dialect: dialect)
     case let .variable(scope, index):
-      "\(scope.prefix(dialect))\(index)"
+      scope.spelling(index, generics: generics, dialect: dialect)
     case let .instance(base, arguments):
-      base.specialized(by: arguments, parameter: parameter, with: resolver,
-                       dialect: dialect)
+      base.specialized(by: arguments, parameter: parameter, generics: generics,
+                       with: resolver, dialect: dialect)
     case let .modified(inner, _):
-      inner.decode(parameter: parameter, with: resolver, dialect: dialect)
+      inner.decode(parameter: parameter, generics: generics, with: resolver,
+                   dialect: dialect)
     case .function:
       dialect.opaque
     }
@@ -174,8 +194,8 @@ extension SignatureType {
   /// is `const`), and an `int**`/`IFoo**` a pointer to an optional typed pointer.
   /// Otherwise a non-`void` pointee decodes as `Unsafe{Mutable}Pointer<Pointee>`,
   /// mutable unless a `const` modifier marks the pointee.
-  fileprivate func spelling(parameter: String?, const: Bool,
-                            with resolver: Resolver,
+  fileprivate func spelling(parameter: String?, generics: Array<String>?,
+                            const: Bool, with resolver: Resolver,
                             dialect: Dialect) -> String {
     switch self {
     case .primitive(.void):
@@ -191,15 +211,16 @@ extension SignatureType {
     case .pointer:
       // A non-`void` pointer-to-pointer: the inner pointer slot is itself
       // nullable, so mark the decoded element optional (as the `void**` cases).
-      wrap(decode(parameter: parameter, with: resolver, dialect: dialect)
-               + dialect.optional,
+      wrap(decode(parameter: parameter, generics: generics, with: resolver,
+                  dialect: dialect) + dialect.optional,
            const: const, dialect: dialect)
     case let .modified(inner, modifiers):
-      inner.spelling(parameter: parameter,
+      inner.spelling(parameter: parameter, generics: generics,
                      const: modifiers.constant(with: resolver),
                      with: resolver, dialect: dialect)
     default:
-      wrap(decode(parameter: parameter, with: resolver, dialect: dialect),
+      wrap(decode(parameter: parameter, generics: generics, with: resolver,
+                  dialect: dialect),
            const: const, dialect: dialect)
     }
   }
@@ -284,7 +305,8 @@ extension SignatureType {
   /// hint flows to the arguments as well, so a `System.Guid` argument of a
   /// parameter named `clsid` spells `CLSID` rather than the default `IID`.
   fileprivate func specialized(by arguments: Array<SignatureType>,
-                               parameter: String?, with resolver: Resolver,
+                               parameter: String?, generics: Array<String>?,
+                               with resolver: Resolver,
                                dialect: Dialect) -> String {
     let base = decode(parameter: parameter, with: resolver, dialect: dialect)
     // An unresolved base (e.g. a TypeSpec with no identity) decodes to the
@@ -296,8 +318,8 @@ extension SignatureType {
     // be escaped after the strip, not before, to spell `` `protocol`<…> ``.
     let name = dialect.escape(String(base.prefix { $0 != "`" }))
     let arguments = arguments
-        .map { $0.decode(parameter: parameter, with: resolver,
-                         dialect: dialect) }
+        .map { $0.decode(parameter: parameter, generics: generics,
+                         with: resolver, dialect: dialect) }
         .joined(separator: ", ")
     return "\(name)\(dialect.generic.open)\(arguments)\(dialect.generic.close)"
   }
@@ -311,5 +333,22 @@ extension VariableScope {
     case .type:   dialect.variable.type
     case .method: dialect.variable.method
     }
+  }
+
+  /// The spelling of the generic variable at `index` in this scope: the
+  /// declared parameter's name when this is a type-level `VAR`, the owner's
+  /// ordered `generics` names are supplied, and the operand is in range (`VAR
+  /// 0` of `<Element>` → `Element`); otherwise the positional placeholder
+  /// (`\(prefix)\(index)`). A method-level `MVAR` always spells its
+  /// placeholder — only type-level names are threaded — as does an out-of-range
+  /// operand. The lower bound guards a negative operand: the metadata decoder
+  /// emits none, but the enum case is public, so a malformed programmatic
+  /// `VAR -1` degrades to the placeholder rather than trap on `generics[-1]`.
+  fileprivate func spelling(_ index: Int, generics: Array<String>?,
+                            dialect: Dialect) -> String {
+    if case .type = self, let generics, index >= 0, index < generics.count {
+      return generics[index]
+    }
+    return "\(prefix(dialect))\(index)"
   }
 }

--- a/Sources/WinMDSynthesis/Decode.swift
+++ b/Sources/WinMDSynthesis/Decode.swift
@@ -140,6 +140,85 @@ extension SignatureType {
       dialect.opaque
     }
   }
+
+  /// The ABI-PROTOCOL inheritance spelling of `self`, a generic base of a
+  /// generic ABI protocol's inheritance clause: the base's ABI PROTOCOL name
+  /// `BaseABI` (WITHOUT arguments in the name) plus a `where`-clause pinning
+  /// the base's associated types to the decoded arguments, rather than the
+  /// wrapper `Base<Args…>`.
+  ///
+  /// A generic interface inheriting a generic base has a `TypeSpec`
+  /// (`GENERICINST`) base whose wrapper spelling is `IIterable<Element>` — the
+  /// public wrapper `struct`. An ABI protocol cannot inherit a struct, so its
+  /// inheritance clause names the base's ABI PROTOCOL: `IIterableABI`. The base
+  /// is spelled WITHOUT its arguments in the name — `IIterableABI`, not
+  /// `IIterableABI<Element>` — because a protocol's primary associated types
+  /// are not in scope in its own inheritance clause (`protocol P<T>: Q<T>` does
+  /// not compile in Swift).
+  ///
+  /// The base's arguments are instead carried as SAME-TYPE CONSTRAINTS on the
+  /// deriving ABI protocol, pinning each of the base's associated types to its
+  /// decoded argument: `associates` names the base's ordered generic parameters
+  /// (its associated-type names, e.g. `Element`), which map positionally to
+  /// `arguments`, so `IMap<K,V> : IIterable<IKeyValuePair<K,V>>` yields
+  /// `IMapABI: IIterableABI where Element == IKeyValuePair<K, V>`. Without the
+  /// constraint the inherited associated type is unconstrained — inherited
+  /// methods would have an unknown element type and conformers would not be
+  /// checked against the real WinRT instantiation.
+  ///
+  /// A pass-through argument that is the plain owner parameter of the same name
+  /// (`IVector<Element> : IIterable<Element>`, whose constraint would be the
+  /// redundant `where Element == Element`) is OMITTED — the deriving protocol's
+  /// own primary associated type already refines the inherited one by name — so
+  /// only a constraint whose argument DIFFERS from the base's plain parameter
+  /// is emitted. When every argument is a pass-through the `where` clause is
+  /// absent entirely (a bare `IIterableABI`).
+  ///
+  /// A `GENERICINST` base spells `<simple name>ABI` (the `ABI` suffix on the
+  /// base's stripped, escaped simple name); any other shape — a bare named base
+  /// has no wrapper/ABI split — decodes plain, though the render only reaches
+  /// here for a `TypeSpec` base, which is always a `GENERICINST`.
+  public func abi(generics: Array<String>? = nil,
+                  associates: Array<String> = [], with resolver: Resolver,
+                  dialect: Dialect) -> String {
+    guard case let .instance(base, arguments) = self else {
+      return decode(generics: generics, with: resolver, dialect: dialect)
+    }
+    let spelling = base.decode(with: resolver, dialect: dialect)
+    // An unresolved base (a TypeSpec with no identity) decodes to the opaque
+    // pointer; there is no ABI protocol to inherit, so degrade to it.
+    guard spelling != dialect.opaque else { return spelling }
+    // Strip the CLR arity suffix, append `ABI`, THEN escape. The `ABI` suffix
+    // must precede the escape: a keyword base's `<name>ABI` is never itself a
+    // keyword (no Swift keyword ends in `ABI`), so escaping the SUFFIXED name
+    // is a no-op that yields a plain `protocolABI` — whereas escaping FIRST
+    // would splice a backtick pair into the middle (`` `protocol`ABI ``), two
+    // identifiers Swift cannot parse.
+    let name = dialect.escape(String(spelling.prefix { $0 != "`" }) + "ABI")
+    // Pin each base associated type to its decoded argument, dropping the
+    // redundant pass-through `where X == X`. A missing associate name (the base
+    // param names could not be recovered) or an arg shorter/longer than the
+    // associates list simply contributes no constraint for that position.
+    var constraints = Array<String>()
+    for (associate, argument) in zip(associates, arguments) {
+      let pinned = argument.decode(generics: generics, with: resolver,
+                                   dialect: dialect)
+      // Escape the associate name so the constraint's LHS matches the base ABI
+      // protocol's DECLARED associated-type name, which the render's `SANITIZE`
+      // (the same escape) spells. A keyword-named base parameter (`protocol`)
+      // declares `` `protocol` `` yet `associates` supplies the raw `protocol`,
+      // so the constraint must escape it too or name a nonexistent associate.
+      // The pass-through comparison uses the ESCAPED name as well: a
+      // pass-through argument decodes to the owner's escaped parameter name
+      // (the owner names arrive already escaped through `generics`), so a
+      // keyword pass-through (`` `protocol` == `protocol` ``) is still dropped.
+      let escaped = dialect.escape(associate)
+      guard pinned != escaped else { continue }
+      constraints.append("\(escaped) == \(pinned)")
+    }
+    guard !constraints.isEmpty else { return name }
+    return "\(name) where \(constraints.joined(separator: ", "))"
+  }
 }
 
 // MARK: - Primitives

--- a/Sources/WinMDSynthesis/Resolver.swift
+++ b/Sources/WinMDSynthesis/Resolver.swift
@@ -70,6 +70,17 @@ public struct Resolver: TypeResolver {
     self.init(table)
   }
 
+  /// Builds the `rawValue → Identity` table from one decoded type, resolved
+  /// against a borrowed `Storage` — the `TypeSpec` base of a generic
+  /// interface's inheritance clause is one `Type` (a `GENERICINST`), not a
+  /// whole method signature, so its `TypeDefOrRef` references collect the same.
+  package init(of type: SignatureType,
+               with storage: borrowing Storage) throws(WinMDError) {
+    var table = Dictionary<Int, Identity>()
+    try collect(type, into: &table, with: storage)
+    self.init(table)
+  }
+
   public func resolve(_ reference: TypeDefOrRef, kind: NamedKind) -> Identity? {
     table[reference.rawValue]
   }

--- a/Sources/winmd-inspect/Database+SQL.swift
+++ b/Sources/winmd-inspect/Database+SQL.swift
@@ -787,6 +787,177 @@ extension WinMD.Storage {
                                     dialect: dialect)
   }
 
+  /// The ABI-PROTOCOL inheritance spelling of the `TypeSpec` at 1-based `spec`
+  /// `Id`, in `dialect`, spelled with the owner's ordered `generics` names — or
+  /// `nil` when the row or its signature does not decode.
+  ///
+  /// A generic interface inheriting another generic interface has an
+  /// `InterfaceImpl.Interface` that is a `TypeSpec` — a `GENERICINST` naming
+  /// the specialized base — not a `TypeRef`/`TypeDef`. The `specs` view
+  /// surfaces its `Id`; this opens the `TypeSpec` row, decodes its signature to
+  /// `SignatureType`, builds a `Resolver` over the storage, and spells it with
+  /// the OWNER's generic names threaded, so a `VAR 0` in the base's arguments
+  /// spells the owner's `Element` rather than a placeholder.
+  ///
+  /// The generic arm's inheritance clause is the ABI protocol's, and a protocol
+  /// cannot inherit a wrapper `struct`, so the base names its ABI PROTOCOL:
+  /// `IIterableABI` (the `ABI` suffix on the base's simple name, WITHOUT
+  /// arguments in the name — a protocol's primary associated types are not in
+  /// scope in its own inheritance clause), not the wrapper `IIterable<T>`.
+  /// The base's arguments are carried instead as same-type constraints on the
+  /// deriving ABI protocol (`… where Element == IKeyValuePair<K, V>`), pinning
+  /// the base's associated types to the decoded arguments; the base's ordered
+  /// generic-parameter NAMES (its associated-type names) come from the base's
+  /// own `GenericParam` rows through `associates(ofBase:)`. It spells the base
+  /// through `abi(…)`.
+  internal borrowing func decode(abi spec: Int,
+                                 generics: Array<String>? = nil,
+                                 in dialect: Dialect) -> String? {
+    guard let table = opened("TypeSpec") else { return nil }
+    let cursor = WinMD.Cursor(copy self, table)
+    guard let tuple = cursor[spec - 1],
+        let row = Row<Metadata.Tables.TypeSpec>(tuple),
+        let type = try? row.type,
+        let resolver = try? Resolver(of: type, with: self) else {
+      return nil
+    }
+    // The base's associated-type names — its own declared generic parameters —
+    // map positionally to the `GENERICINST`'s arguments for the same-type
+    // constraints. An empty list (a cross-file base whose `GenericParam` rows
+    // are not in this file, or an unresolvable base) simply emits no
+    // constraints: the bare `IIterableABI` is spelled, as before.
+    let associates = associates(ofBase: type)
+    return type.abi(generics: generics, associates: associates, with: resolver,
+                    dialect: dialect)
+  }
+
+  /// The ordered declared generic-parameter names — the associated-type names —
+  /// of the generic base a `GENERICINST` `type` (`.instance(base, args)`)
+  /// instantiates, read from the base's own `GenericParam` rows; an empty list
+  /// when `type` is not a `GENERICINST`, its base does not resolve to a
+  /// same-file `TypeDef`, or the `GenericParam` table is absent.
+  ///
+  /// The same-type constraints `abi(…)` emits pin the base's associated types
+  /// by NAME (`where Element == …`), and those names are exactly the names the
+  /// base interface's own ABI protocol declares — the base `TypeDef`'s
+  /// `GenericParam` names, in `Number` order. A cross-file base (a `TypeRef`,
+  /// whose `GenericParam` rows live in another module) resolves to no local
+  /// `TypeDef`, so this yields no names and `abi(…)` emits the bare protocol
+  /// (the safe degrade); a same-file base (a `TypeDef`, the shape a
+  /// self-contained fixture and a single-module projection take) yields them.
+  private borrowing func associates(ofBase type: SignatureType)
+      -> Array<String> {
+    // The base must resolve to a same-file `TypeDef` (tag 0 of the
+    // `TypeDefOrRef` coded index) — a cross-file `TypeRef` (tag 1) has no local
+    // `GenericParam` rows — and a `TypeDef` `row` is 1-based, so it is the
+    // base's `Id` directly.
+    guard case let .instance(base, _) = type,
+        case let .named(_, reference) = base,
+        reference.tag == 0, reference.row != 0,
+        let parameters = opened("GenericParam") else {
+      return []
+    }
+    // A `GenericParam.Owner` (ordinal 2) is a `TypeOrMethodDef` coded index; a
+    // `TypeDef` owner has tag 0, so a base `TypeDef` at 1-based `Id` is encoded
+    // `Id << 1`. Collect the matching rows' `Name` (ordinal 3) in `Number`
+    // (ordinal 0) order.
+    let owner = reference.row << 1
+    let cursor = WinMD.Cursor(copy self, parameters)
+    var declared = Array<(number: Int, name: String)>()
+    for index in 0 ..< cursor.count {
+      guard let generic = cursor[index], generic[2] == owner,
+          let name = try? generic.string(3) else { continue }
+      declared.append((generic[0], name))
+    }
+    return declared.sorted { $0.number < $1.number }.map(\.name)
+  }
+
+  /// The 1-based `TypeDef` `Id` of the SAME-FILE base a `TypeSpec`
+  /// (`GENERICINST`) at 1-based `spec` `Id` instantiates — an `IVector`'s
+  /// `IIterable` base — or `nil` when the row does not decode, the base is not
+  /// a same-file `TypeDef` (a cross-file `TypeRef`), or the `TypeSpec` table is
+  /// absent.
+  ///
+  /// The generic-wrapper forwarding walks the base's own methods, which are
+  /// bound by the base's `TypeDef` `Id`; a `GENERICINST` base is a `.named`
+  /// `TypeDefOrRef`, whose tag-0 (`TypeDef`) `row` is that 1-based `Id`
+  /// directly.
+  internal borrowing func base(ofSpec spec: Int) -> Int? {
+    guard let table = opened("TypeSpec") else { return nil }
+    let cursor = WinMD.Cursor(copy self, table)
+    guard let tuple = cursor[spec - 1],
+        let row = Row<Metadata.Tables.TypeSpec>(tuple),
+        let type = try? row.type,
+        case let .instance(base, _) = type,
+        case let .named(_, reference) = base,
+        reference.tag == 0, reference.row != 0 else {
+      return nil
+    }
+    return reference.row
+  }
+
+  /// The base's argument spellings a `TypeSpec` (`GENERICINST`) at 1-based
+  /// `spec` `Id` instantiates, each decoded in the OWNER's `generics` context —
+  /// the SUBSTITUTION that binds the base's `VAR i` to the owner's argument at
+  /// position `i` — or `nil` when the row does not decode.
+  ///
+  /// The generic-wrapper forwarding must decode the base's inherited methods
+  /// with the base's `VAR i` bound to the ARGUMENT the owner instantiates it
+  /// with, not to the owner's own parameter of the same position. For
+  /// `IMap<K,V> : IIterable<IKeyValuePair<K,V>>` the base `TypeSpec`'s sole
+  /// argument is `IKeyValuePair<K,V>` (a `GENERICINST` of two `VAR`s), decoded
+  /// in the owner's `<K, V>` context to `IKeyValuePair<K, V>`; that spelling
+  /// becomes the substitution's element 0, so the base's `First() -> VAR 0`
+  /// forwards as `First() -> IKeyValuePair<K, V>`, not `-> K`. The composition
+  /// is transitive: passing an already-substituted list as `generics` decodes
+  /// the next base level's arguments against it, so a grandbase's `VAR j` reads
+  /// the base's substitution.
+  internal borrowing func substitution(ofSpec spec: Int,
+                                       generics: Array<String>?,
+                                       in dialect: Dialect) -> Array<String>? {
+    guard let table = opened("TypeSpec") else { return nil }
+    let cursor = WinMD.Cursor(copy self, table)
+    guard let tuple = cursor[spec - 1],
+        let row = Row<Metadata.Tables.TypeSpec>(tuple),
+        let type = try? row.type,
+        case let .instance(_, arguments) = type,
+        let resolver = try? Resolver(of: type, with: self) else {
+      return nil
+    }
+    return arguments.map {
+      $0.decode(generics: generics, with: resolver, dialect: dialect)
+    }
+  }
+
+  /// The PUBLIC closed-specialization spelling of the `TypeSpec` at 1-based
+  /// `spec` `Id`, in `dialect` — the wrapper/public spelling `IBase<String>`,
+  /// its closed arguments preserved — or `nil` when the row or its signature
+  /// does not decode.
+  ///
+  /// A NON-generic interface inheriting a CLOSED generic base
+  /// (`IFoo : IBase<String>`) has an `InterfaceImpl.Interface` that is a
+  /// `TypeSpec` — a `GENERICINST` naming the closed base — yet renders the
+  /// public `protocol IFoo: <base>` arm, so its base must be a PUBLIC type its
+  /// public protocol may refine. That is the base's own public closed spelling
+  /// `IBase<String>`, decoded through `decode(…)` — NOT the internal `IBaseABI`
+  /// (a public protocol cannot refine an internal one, and the closed arguments
+  /// would be dropped), which is only the GENERIC-wrapper arm's inheritance
+  /// clause (`decode(abi:)`). No owner `generics` are threaded: a non-generic
+  /// owner declares none, and the base's arguments are already closed (a
+  /// concrete `String`, not an owner `VAR`).
+  internal borrowing func decode(specialization spec: Int,
+                                 in dialect: Dialect) -> String? {
+    guard let table = opened("TypeSpec") else { return nil }
+    let cursor = WinMD.Cursor(copy self, table)
+    guard let tuple = cursor[spec - 1],
+        let row = Row<Metadata.Tables.TypeSpec>(tuple),
+        let type = try? row.type,
+        let resolver = try? Resolver(of: type, with: self) else {
+      return nil
+    }
+    return type.decode(with: resolver, dialect: dialect)
+  }
+
   /// The decoded type spelling of the `Param` at 1-based `parameter` `Id`, in
   /// `dialect`, navigated through its owning method's signature — or `nil` when
   /// it does not decode.

--- a/Sources/winmd-inspect/Database+SQL.swift
+++ b/Sources/winmd-inspect/Database+SQL.swift
@@ -773,6 +773,7 @@ extension WinMD.Storage {
   /// decodes the return. `nil` mirrors the old NULL — an absent row, an
   /// undecodable signature, or an unresolvable one.
   internal borrowing func decode(return method: Int,
+                                 generics: Array<String>? = nil,
                                  in dialect: Dialect) -> String? {
     guard let table = opened("MethodDef") else { return nil }
     let cursor = WinMD.Cursor(copy self, table)
@@ -782,7 +783,8 @@ extension WinMD.Storage {
         let resolver = try? Resolver(of: signature, with: self) else {
       return nil
     }
-    return signature.returns.decode(with: resolver, dialect: dialect)
+    return signature.returns.decode(generics: generics, with: resolver,
+                                    dialect: dialect)
   }
 
   /// The decoded type spelling of the `Param` at 1-based `parameter` `Id`, in
@@ -800,6 +802,7 @@ extension WinMD.Storage {
   /// `System.Guid` `IID`/`CLSID` hint; for any other type the decoder ignores
   /// it, so threading it is always safe.
   internal borrowing func decode(parameter: Int,
+                                 generics: Array<String>? = nil,
                                  for dialect: Dialect) -> String? {
     guard let table = opened("Param") else { return nil }
     let params = WinMD.Cursor(copy self, table)
@@ -825,6 +828,7 @@ extension WinMD.Storage {
     }
     let name = param.ordinal(for: "Name").flatMap { try? param.string($0) }
     return signature.parameters[position - 1]
-        .decode(parameter: name, with: resolver, dialect: dialect)
+        .decode(parameter: name, generics: generics, with: resolver,
+                dialect: dialect)
   }
 }

--- a/Sources/winmd-inspect/Resources/Queries/generics.sql
+++ b/Sources/winmd-inspect/Resources/Queries/generics.sql
@@ -1,0 +1,10 @@
+CREATE VIEW generics AS
+SELECT
+  Name,
+  Number
+FROM
+  GenericParam
+WHERE
+  Owner_TypeDef = :parent
+ORDER BY
+  Number

--- a/Sources/winmd-inspect/Resources/Queries/specs.sql
+++ b/Sources/winmd-inspect/Resources/Queries/specs.sql
@@ -1,0 +1,8 @@
+CREATE VIEW specs AS
+SELECT
+  s.Id AS spec
+FROM
+  InterfaceImpl i
+  JOIN TypeSpec s ON i.Interface_TypeSpec = s.Id
+WHERE
+  i.Class = :parent

--- a/Sources/winmd-inspect/Resources/Render/generics.sql
+++ b/Sources/winmd-inspect/Resources/Render/generics.sql
@@ -1,0 +1,5 @@
+SELECT
+  SANITIZE(Name) AS Name,
+  Number
+FROM
+  generics

--- a/Sources/winmd-inspect/Resources/Render/interfaces.sql
+++ b/Sources/winmd-inspect/Resources/Render/interfaces.sql
@@ -1,7 +1,7 @@
 SELECT
   Id,
   TypeNamespace,
-  SANITIZE(TypeName) AS TypeName,
+  TypeName,
   iid
 FROM
   interfaces

--- a/Sources/winmd-inspect/Resources/Render/specs.sql
+++ b/Sources/winmd-inspect/Resources/Render/specs.sql
@@ -1,0 +1,4 @@
+SELECT
+  spec
+FROM
+  specs

--- a/Sources/winmd-inspect/Resources/Templates/com.mustache
+++ b/Sources/winmd-inspect/Resources/Templates/com.mustache
@@ -1,7 +1,31 @@
 {{! language: swift }}
+{{#generic}}
+// A WinRT parameterised interface: its IID is a per-instantiation PIID computed
+// at runtime from the type arguments, so no static `@com(interface:)` is emitted
+// on the ABI protocol or the generic wrapper — the runtime projection supplies it.
+internal protocol {{{abi}}}<{{#generics}}{{{name}}}{{^last}}, {{/last}}{{/generics}}>{{#base}}: {{{.}}}{{/base}} {
+{{#generics}}
+    associatedtype {{{name}}}
+{{/generics}}
+{{#methods}}
+    func {{{name}}}({{#params}}_ {{{name}}}: {{{type}}}{{^last}}, {{/last}}{{/params}}){{#returns}} -> {{{.}}}{{/returns}}
+{{/methods}}
+}
+
+public struct {{{name}}}<{{#generics}}{{{name}}}{{^last}}, {{/last}}{{/generics}}> {
+    internal let base: any {{{abi}}}<{{#generics}}{{{name}}}{{^last}}, {{/last}}{{/generics}}>
+{{#methods}}
+    public func {{{name}}}({{#params}}_ {{{local}}}: {{{type}}}{{^last}}, {{/last}}{{/params}}){{#returns}} -> {{{.}}}{{/returns}} {
+        base.{{{name}}}({{#params}}{{{local}}}{{^last}}, {{/last}}{{/params}})
+    }
+{{/methods}}
+}
+{{/generic}}
+{{^generic}}
 @com(interface: "{{{iid}}}")
 public protocol {{{name}}}{{#base}}: {{{.}}}{{/base}} {
 {{#methods}}
     func {{{name}}}({{#params}}_ {{{name}}}: {{{type}}}{{^last}}, {{/last}}{{/params}}){{#returns}} -> {{{.}}}{{/returns}}
 {{/methods}}
 }
+{{/generic}}

--- a/Sources/winmd-inspect/Shell.swift
+++ b/Sources/winmd-inspect/Shell.swift
@@ -504,80 +504,342 @@ internal struct Shell: ~Escapable {
     sources.reserveCapacity(interfaces.count)
     for found in interfaces {
       let id = found[0]
-      // The interface's methods, bound by its `Id`; each row is its `Id`
-      // then its escaped `Name`. The type spellings are no longer projected —
-      // the render decodes them from the signature with the spec's `Dialect`.
-      let plan = try Shell.select(Shell.query(named: "methods",
-                                              search: search))
-      let rows = try session.run(plan, routines,
-                                 bindings: ["parent": id])
-      var methods = Array<Dictionary<String, Any>>()
-      methods.reserveCapacity(rows.count)
-      for method in rows {
-        // Each method's parameters, bound by the method's `Id`; each row is its
-        // `Id`, escaped `Name`, and `Sequence`. The return pseudo-parameter
-        // (`Sequence == 0`) is dropped — only the real parameters spell the
-        // requirement's arguments — and the rest decode their type at render
-        // time from the parameter's own signature position.
-        let selection = try Shell.select(Shell.query(named: "params",
-                                                     search: search))
-        let params = try session.run(selection, routines,
-                                     bindings: ["parent": method[0]])
-        var parameters = Array<Dictionary<String, Any>>()
-        for parameter in params where parameter[2] != .integer(0) {
-          let type = session.storage.decode(parameter: parameter[0].integer,
-                                            for: dialect)
-          parameters.append([
-            "name": parameter[1].text,
-            "type": type ?? "",
-            "last": false,
-          ])
-        }
-        // The trailing parameter's `last` flag drives the template's
-        // `{{^last}}, {{/last}}` comma separation, omitting the final comma.
-        if !parameters.isEmpty {
-          parameters[parameters.count - 1]["last"] = true
-        }
-        var entry: Dictionary<String, Any> = [
-          "name": method[1].text,
-          "params": parameters,
-        ]
-        // The return, decoded at render time; a no-value return (the spec's
-        // `void` spelling, or an undecodable return) leaves `returns` absent, so
-        // the template's `{{#returns}}` clause renders nothing.
-        let returned = session.storage.decode(return: method[0].integer,
-                                              in: dialect)
-        if let returned, let clause = language.returned(returned) {
-          entry["returns"] = clause
-        }
-        methods.append(entry)
-      }
-      // The interface's base, via the `bases` view bound by its `Id`. A
-      // rootless interface defaults to the spec's COM root, except the root
-      // interface itself — which inherits nothing, so it never becomes its own
-      // base; an empty `root` applies no default.
+      // The interface's ordered declared generic-parameter names, through the
+      // `generics` view bound by its `Id` — empty for a non-generic interface.
+      // A generic interface declares at least one; its own name then carries a
+      // CLR arity suffix, stripped below. The names thread into the
+      // method/parameter/return decode so a `VAR` spells its declared name
+      // (`Element`) rather than a positional placeholder (`T0`).
+      let names = try declarations(of: id, routines, search: search)
+      // The names supplied to decode when the interface is generic; `nil`
+      // otherwise, so a non-generic interface decodes exactly as before.
+      let generics: Array<String>? = names.isEmpty ? nil : names
+      // The interface's own methods, decoded with its generic names, plus — for
+      // a GENERIC wrapper only — the direct base's inherited methods forwarded
+      // through the wrapper (see `forwarded`).
+      var methods = try self.methods(of: id, routines, search: search,
+                                     generics: generics, in: dialect,
+                                     language: language)
+      methods += try forwarded(of: id, routines, search: search,
+                               generics: generics, in: dialect,
+                               language: language)
+      // The interface's base. A generic base named through a `TypeSpec` (a
+      // `GENERICINST`, e.g. `IIterable<Element>`) is decoded first, through the
+      // `specs` view (its `TypeSpec` `Id`) with the OWNER's `generics` names so
+      // the clause spells the specialized base rather than a bare name; absent
+      // one, the named base comes from the `bases` view (a `TypeRef`/`TypeDef`
+      // simple name). A rootless interface defaults to the spec's COM root,
+      // except the root interface itself — which inherits nothing, so it never
+      // becomes its own base; an empty `root` applies no default.
+      //
+      // A generic base spells its ABI PROTOCOL (`IIterableABI<Element>`), not
+      // its wrapper `struct` — the generic arm's inheritance clause is the ABI
+      // protocol's, and a protocol cannot inherit a struct. A non-generic base
+      // (from `bases`, a plain protocol name) needs no suffix, and neither arm
+      // reaches the wrapper spelling.
+      let specialized = try specialization(of: id, routines, search: search,
+                                           generics: generics, in: dialect)
       let lineage =
           try Shell.select(Shell.query(named: "bases", search: search))
       let bases = try session.run(lineage, routines,
                                   bindings: ["parent": id])
-      let base: String? = if let inherited = bases.first {
+      let base: String? = if let specialized {
+        specialized
+      } else if let inherited = bases.first {
         inherited[0].text
       } else if language.root.isEmpty || found[2].text == language.root {
         nil
       } else {
         language.root
       }
+      // A generic interface's own `TypeName` carries the CLR arity suffix
+      // (`IVector``1`); strip it — the decode tier strips it only for a
+      // `GENERICINST` use, so the declaration name must be stripped here — so
+      // the emitted name is `IVector`, its `<T>` clause supplied separately.
+      // The keyword escape (`SANITIZE`) is applied HERE, on the STRIPPED name,
+      // not in the `interfaces` query: escaping the suffixed name would spare a
+      // generic whose stripped name is a keyword (`protocol``1` is not the
+      // reserved word `protocol`), leaving `public struct protocol` to be
+      // emitted. Escaping after the strip is why the query projects the raw
+      // `TypeName` — the interface's own name is the one identifier the strip
+      // must precede the escape for, so its escape lives in Swift, not the SQL.
+      let stripped = String(found[2].text.prefix { $0 != "`" })
+      let name = language.escape(stripped)
+      // The ABI-protocol name is the wrapper's own name suffixed with `ABI`,
+      // used for BOTH the ABI protocol's declaration and the wrapper's `base:
+      // any …ABI<…>` existential. The `ABI` suffix must precede the escape (the
+      // same order the base-name spelling uses): a keyword name's `<name>ABI` is
+      // never itself a keyword (no Swift keyword ends in `ABI`), so escaping the
+      // SUFFIXED name is a no-op yielding a plain `protocolABI` — whereas
+      // escaping FIRST then appending `ABI` would splice a backtick pair into
+      // the middle (`` `protocol`ABI ``), which Swift cannot parse.
+      let abi = language.escape(stripped + "ABI")
       var context: Dictionary<String, Any> = [
-        "name": found[2].text,
+        "name": name,
+        "abi": abi,
         "iid": found[3].text,
         "namespace": found[1].text,
         "methods": methods,
       ]
       // An absent `base` skips the template's `{{#base}}` inheritance clause.
       if let base { context["base"] = base }
+      // A generic interface carries its `generic` flag and its ordered clause
+      // `generics` (each with a `last` flag for comma separation); a
+      // non-generic one carries neither, so the template's `{{#generic}}` guard
+      // leaves its output byte-identical to today's.
+      if let generics {
+        context["generic"] = true
+        context["generics"] = generics.enumerated().map { index, name in
+          ["name": name, "last": index == generics.count - 1]
+        }
+      }
       sources.append(mustache.render(context))
     }
     return sources.joined(separator: "\n")
+  }
+
+  /// The template method entries for the interface at `id`, in declaration
+  /// order — each a `name`, a `params` list, and (for a value-returning method)
+  /// a `returns` clause — decoded with the owner's `generics` names threaded so
+  /// a `VAR` spells its declared name.
+  ///
+  /// Each method's parameters, bound by the method's `Id`, drop the return
+  /// pseudo-parameter (`Sequence == 0`); the rest decode their type from their
+  /// own signature position. The return decodes to `returns` unless it is the
+  /// spec's `void` spelling or undecodable, when `{{#returns}}` renders
+  /// nothing.
+  private borrowing func methods(of id: Value, _ routines: Routines,
+                                 search: Array<String>,
+                                 generics: Array<String>?, in dialect: Dialect,
+                                 language: Language) throws
+      -> Array<Dictionary<String, Any>> {
+    let plan = try Shell.select(Shell.query(named: "methods", search: search))
+    let rows = try session.run(plan, routines, bindings: ["parent": id])
+    var methods = Array<Dictionary<String, Any>>()
+    methods.reserveCapacity(rows.count)
+    for method in rows {
+      let selection = try Shell.select(Shell.query(named: "params",
+                                                   search: search))
+      let params = try session.run(selection, routines,
+                                   bindings: ["parent": method[0]])
+      let kept = params.filter { $0[2] != .integer(0) }
+      let types = kept.map {
+        session.storage.decode(parameter: $0[0].integer, generics: generics,
+                               for: dialect) ?? ""
+      }
+      let parameters = Shell.parameters(kept.map(\.[1].text), types: types)
+      var entry: Dictionary<String, Any> = [
+        "name": method[1].text,
+        "params": parameters,
+      ]
+      let returned = session.storage.decode(return: method[0].integer,
+                                            generics: generics, in: dialect)
+      if let returned, let clause = language.returned(returned) {
+        entry["returns"] = clause
+      }
+      methods.append(entry)
+    }
+    return methods
+  }
+
+  /// The template method entries the GENERIC wrapper at `id` FORWARDS from its
+  /// inherited base — the direct base's own methods — so the wrapper `struct`
+  /// exposes the base's surface, not only its own.
+  ///
+  /// The non-generic arm inherits its base's requirements transitively (a
+  /// `protocol IFoo: IBase` gets `IBase`'s methods for free), but the generic
+  /// wrapper is a STRUCT whose `base` is an `any …ABI`: the ABI protocol chain
+  /// carries the inherited requirements, yet the wrapper only forwards the
+  /// methods the template is fed, so an inherited method (an `IIterable`'s
+  /// `First` behind an `IVector`) would be missing. This gathers the direct
+  /// base's methods and emits forwarding entries for them, decoded with the
+  /// OWNER's `generics` names — correct for the standard WinRT pass-through
+  /// (`IVector<Element> : IIterable<Element>`), where the base's parameter is
+  /// the owner's parameter of the same name and position, so a base `VAR 0`
+  /// spells the owner's `Element`.
+  ///
+  /// Only a GENERIC owner with a `TypeSpec` (`GENERICINST`) base that resolves
+  /// to a SAME-FILE base `TypeDef` forwards: a non-generic owner (the protocol
+  /// arm already inherits transitively) and a cross-file base (no local rows to
+  /// walk) forward nothing.
+  ///
+  /// The base's methods decode with the base's `VAR i` bound to the ARGUMENT
+  /// the owner instantiates the base with — the SUBSTITUTION `substitution(…)`
+  /// builds by decoding the base `TypeSpec`'s arguments in the owner's
+  /// context — not to the owner's own parameter of that position: `IMap<K,V> :
+  /// IIterable<IKeyValuePair<K,V>>` forwards `First() -> IKeyValuePair<K, V>`,
+  /// not `-> K`. The forward is transitive: it walks the whole base chain, at
+  /// each level composing the substitution (decoding the next base's arguments
+  /// against the current substitution) so a grandbase's `VAR j` resolves
+  /// through the intervening base. A cycle is impossible in well-formed
+  /// metadata (the base chain is a DAG rooted at a non-generic interface), so
+  /// the walk terminates when a level has no `TypeSpec` base.
+  private borrowing func forwarded(of id: Value, _ routines: Routines,
+                                   search: Array<String>,
+                                   generics: Array<String>?,
+                                   in dialect: Dialect,
+                                   language: Language) throws
+      -> Array<Dictionary<String, Any>> {
+    // Only the generic-wrapper arm forwards; the non-generic protocol arm
+    // inherits transitively already.
+    guard generics != nil else { return [] }
+    var forwarded = Array<Dictionary<String, Any>>()
+    // Walk the base chain from the owner, threading the substitution that binds
+    // each level's `VAR i` to the owner's argument at that position. `owner` is
+    // the level whose base is inherited next; `substitution` is that base's
+    // `VAR` bindings in the owner's context (the owner's own `generics` at the
+    // first step, since the owner's `VAR i` IS its own parameter `i`).
+    var owner = id
+    var substitution = generics
+    while let base = try ancestor(of: owner, routines, search: search) {
+      let bindings = session.storage.substitution(ofSpec: base.spec,
+                                                  generics: substitution,
+                                                  in: dialect)
+      forwarded += try methods(of: .integer(base.type), routines,
+                               search: search, generics: bindings,
+                               in: dialect, language: language)
+      // Compose: the next base level's arguments decode against THIS base's
+      // bindings, so its `VAR j` resolves through the base to the owner.
+      owner = .integer(base.type)
+      substitution = bindings
+    }
+    return forwarded
+  }
+
+  /// The SAME-FILE base of the interface at `id` inherited through a `TypeSpec`
+  /// (`GENERICINST`) base — its `TypeSpec` `Id` (`spec`) and the base's own 1-
+  /// based `TypeDef` `Id` (`type`) — or `nil` when it has no such base or the
+  /// base is not a same-file `TypeDef` (a cross-file `TypeRef`, whose rows are
+  /// in another module). It reads the `specs` view for the base `TypeSpec`
+  /// `Id`, then the base's own `TypeDef` `Id` from that spec's decoded
+  /// signature. The
+  /// forwarding walk needs both: the `spec` to build the substitution and the
+  /// `type` to gather the base's methods and to step to the next level.
+  private borrowing func ancestor(of id: Value, _ routines: Routines,
+                                      search: Array<String>) throws
+      -> (spec: Int, type: Int)? {
+    guard session.storage.opened("TypeSpec") != nil else { return nil }
+    let clause = try Shell.select(Shell.query(named: "specs", search: search))
+    let specs = try session.run(clause, routines, bindings: ["parent": id])
+    guard let spec = specs.first,
+        let type = session.storage.base(ofSpec: spec[0].integer) else {
+      return nil
+    }
+    return (spec[0].integer, type)
+  }
+
+  /// The template parameter dictionaries for a method's kept parameters — one
+  /// per `(name, type)` pair, in order — with each blank name assigned a
+  /// stable, collision-free `local` and the trailing entry's `last` flag set.
+  ///
+  /// A blank parameter name (`func Foo(_ : T)`) is allowed in a protocol
+  /// requirement's decl, but the wrapper's forwarding method must PASS it by
+  /// name in the call (`base.Foo(arg0)`), so a blank name synthesizes a `local`
+  /// used in BOTH the forwarding method's parameter list (`_ arg0: T`) and the
+  /// call — while `name` stays blank in the requirement. The synthetic name is
+  /// chosen AFTER the method's real names are known: it is the first `arg<N>`
+  /// (from `N == 0`) not already used by a real parameter or an earlier
+  /// synthetic one, so `Foo(_ : T, _ arg0: T)` gives the blank a `local` of
+  /// `arg1` rather than colliding with the real `arg0`. A named parameter's
+  /// `local` is its own name.
+  internal static func parameters(_ names: Array<String>,
+                                  types: Array<String>)
+      -> Array<Dictionary<String, Any>> {
+    // The names in play — the real ones plus each synthetic as it is minted —
+    // so a synthetic never duplicates a real name or a sibling synthetic.
+    var used = Set(names.filter { !$0.isEmpty })
+    var next = 0
+    var parameters = Array<Dictionary<String, Any>>()
+    parameters.reserveCapacity(names.count)
+    for (name, type) in zip(names, types) {
+      let local: String
+      if name.isEmpty {
+        while used.contains("arg\(next)") { next += 1 }
+        local = "arg\(next)"
+        used.insert(local)
+        next += 1
+      } else {
+        local = name
+      }
+      parameters.append([
+        "name": name,
+        "local": local,
+        "type": type,
+        "last": false,
+      ])
+    }
+    // The trailing parameter's `last` flag drives the template's
+    // `{{^last}}, {{/last}}` comma separation, omitting the final comma.
+    if !parameters.isEmpty {
+      parameters[parameters.count - 1]["last"] = true
+    }
+    return parameters
+  }
+
+  /// The ordered declared generic-parameter names of the interface at `id`,
+  /// through the `generics` view bound by its `Id` — an empty list for a
+  /// non-generic interface.
+  ///
+  /// A metadata file with no generic types omits the `GenericParam` table
+  /// entirely (the `#~` valid mask sets a table's bit only when it has rows),
+  /// so the `generics` view over it would resolve no relation; the base table's
+  /// presence is checked first (`opened` is `nil` for an absent table), so a
+  /// file with no generics is simply no generics rather than a faulting query.
+  private borrowing func declarations(of id: Value, _ routines: Routines,
+                                      search: Array<String>) throws
+      -> Array<String> {
+    guard session.storage.opened("GenericParam") != nil else { return [] }
+    let clause =
+        try Shell.select(Shell.query(named: "generics", search: search))
+    let declared = try session.run(clause, routines, bindings: ["parent": id])
+    return declared.map(\.first!.text)
+  }
+
+  /// The inheritance spelling of the interface at `id`'s closed-generic base —
+  /// whose `InterfaceImpl.Interface` is a `TypeSpec` (a `GENERICINST`, e.g.
+  /// `IIterable<Element>`) — or `nil` when the interface has no such base.
+  ///
+  /// The spelling depends on the OWNER's genericity, not merely on the base
+  /// being a `TypeSpec`:
+  ///
+  /// - A GENERIC owner (`generics != nil`) renders the generic-wrapper arm,
+  ///   whose inheritance clause is the ABI protocol's; a protocol cannot
+  ///   inherit a `struct`, so the base spells its ABI PROTOCOL
+  ///   `IIterableABI` — the `ABI` suffix on the base's simple name (arguments
+  ///   carried as `where`-clause associated-type constraints, not in the name)
+  ///   — through `decode(abi:…)`.
+  ///
+  /// - A NON-generic owner (`generics == nil`) renders the public `protocol …:
+  ///   <base>` arm, so the base must be a PUBLIC type its public protocol may
+  ///   refine — the closed specialization's own PUBLIC spelling `IBase<String>`
+  ///   (a public type, its closed arguments preserved), NOT the internal
+  ///   `IBaseABI` (a public protocol cannot refine an internal one, and the
+  ///   closed arguments would be dropped) — through `decode(specialization:…)`.
+  ///
+  /// The `specs` view surfaces the base's `TypeSpec` `Id` through the
+  /// `Interface_TypeSpec` join key. A metadata file with no generics omits the
+  /// `TypeSpec` table entirely (the `#~` valid mask sets a table's bit only
+  /// when it has rows), so the `specs` view over it resolves no relation; the
+  /// base table's presence is checked first (`opened` is `nil` for an absent
+  /// table), so a file with no `TypeSpec` is simply no generic base rather than
+  /// a faulting query.
+  private borrowing func specialization(of id: Value, _ routines: Routines,
+                                        search: Array<String>,
+                                        generics: Array<String>?,
+                                        in dialect: Dialect) throws -> String? {
+    guard session.storage.opened("TypeSpec") != nil else { return nil }
+    let clause =
+        try Shell.select(Shell.query(named: "specs", search: search))
+    let specs = try session.run(clause, routines, bindings: ["parent": id])
+    guard let spec = specs.first else { return nil }
+    // A generic owner refines the base's ABI protocol; a non-generic owner
+    // refines the base's public closed specialization.
+    guard let generics else {
+      return session.storage.decode(specialization: spec[0].integer,
+                                    in: dialect)
+    }
+    return session.storage.decode(abi: spec[0].integer, generics: generics,
+                                  in: dialect)
   }
 
   /// The text of the Mustache template named `name` — an inline template
@@ -1156,8 +1418,8 @@ extension Session {
   /// `Queries/*.sql`, then for each name load the first search directory that
   /// has it (else the bundle), parse it as a `CREATE VIEW`, and register it —
   /// so a `-I` directory both shadows an existing view and adds a new one. The
-  /// four COM-interface views are the one bundled set, so adding a query later
-  /// is dropping in another `.sql` beside them (or under a `-I` directory) — no
+  /// COM-interface views are the one bundled set, so adding a query later is
+  /// dropping in another `.sql` beside them (or under a `-I` directory) — no
   /// code change. The views are order-independent (none references another), so
   /// the enumeration order does not matter.
   ///
@@ -1168,11 +1430,11 @@ extension Session {
   /// `MemberRef.Class_TypeRef` → `TypeRef`, filtered to the `GuidAttribute`
   /// declaring type, projecting `CustomAttribute.guid` as the `iid` — a
   /// `methods` view of one interface's methods, a `params` view of one
-  /// method's parameters, and a `bases` view of one interface's base type. The
-  /// latter three carry a uniform `:parent` param — the owning row's `Id` —
-  /// so a render can walk interface → methods → params, binding each level's
-  /// `Id` to the next's `:parent`, and look up the interface's base by its
-  /// `Id`.
+  /// method's parameters, a `bases` view of one interface's named base type,
+  /// and a `specs` view of a generic base named through a `TypeSpec`. These
+  /// four carry a uniform `:parent` param — the owning row's `Id` — so a render
+  /// can walk interface → methods → params, binding each level's `Id` to the
+  /// next's `:parent`, and look up the interface's base by its `Id`.
   ///
   /// The `bases` view navigates the interface's single `InterfaceImpl` row
   /// (whose simple `Class` index is the interface's 1-based `Id`) to its
@@ -1185,6 +1447,16 @@ extension Session {
   /// coded index resolve, `UNION`ed: a cross-file base through
   /// `Interface_TypeRef` (a `TypeRef`) and a same-file base through
   /// `Interface_TypeDef` (a `TypeDef` in this module).
+  ///
+  /// A generic base — an `IIterable<Element>`, whose `InterfaceImpl.Interface`
+  /// is a `TypeSpec` (a `GENERICINST`), not a `TypeRef`/`TypeDef` name — has no
+  /// `TypeName` to project, so `bases` cannot spell it; the `specs` view
+  /// instead surfaces its `TypeSpec` `Id` through the `Interface_TypeSpec` join
+  /// key, and the render decodes that signature with the owner's generic names.
+  /// It is a separate view — not a `bases` `UNION` arm — because a metadata
+  /// file with no generics omits the `TypeSpec` table entirely, which a
+  /// `bases`-arm `JOIN TypeSpec` would fail to resolve; the render runs `specs`
+  /// only when the `TypeSpec` table is present.
   ///
   /// A query resource is static, well-formed SQL, so a parse failure is a
   /// programming error rather than user input; it is silently skipped here (the

--- a/Tests/WinMDSynthesisTests/DecodeTests.swift
+++ b/Tests/WinMDSynthesisTests/DecodeTests.swift
@@ -98,6 +98,63 @@ struct DecodeTests {
                 .decode(with: resolver, dialect: dialect) == "M2")
   }
 
+  @Test func `a type variable spells its declared name when names are supplied`() {
+    // With the owner's ordered names threaded, a `VAR` spells the declared
+    // parameter's name (`VAR 0` of `<Element>` → `Element`) rather than the
+    // positional placeholder.
+    #expect(SignatureType.variable(scope: .type, 0)
+                .decode(generics: ["Element"], with: resolver, dialect: dialect)
+                == "Element")
+    #expect(SignatureType.variable(scope: .type, 1)
+                .decode(generics: ["Key", "Value"], with: resolver,
+                        dialect: dialect)
+                == "Value")
+    // An out-of-range operand falls back to the placeholder.
+    #expect(SignatureType.variable(scope: .type, 2)
+                .decode(generics: ["Element"], with: resolver, dialect: dialect)
+                == "T2")
+    // A method variable (`MVAR`) keeps its placeholder — only the type-level
+    // names are threaded, so a method-level operand never indexes them.
+    #expect(SignatureType.variable(scope: .method, 0)
+                .decode(generics: ["Element"], with: resolver, dialect: dialect)
+                == "M0")
+  }
+
+  @Test func `a negative type variable operand falls back to the placeholder`() {
+    // The metadata decoder emits no negative operand, but the enum case and
+    // `decode(generics:)` are public — a malformed programmatic `VAR -1` must
+    // degrade to the positional placeholder rather than trap on `generics[-1]`,
+    // exactly as an out-of-range operand does.
+    #expect(SignatureType.variable(scope: .type, -1)
+                .decode(generics: ["Element"], with: resolver, dialect: dialect)
+                == "T-1")
+  }
+
+  @Test func `a nested type variable spells its declared name`() {
+    // The names thread through the structural cases too: a `VAR` inside a
+    // pointer or a `GENERICINST` argument spells the declared name.
+    #expect(SignatureType.pointer(.variable(scope: .type, 0))
+                .decode(generics: ["Element"], with: resolver, dialect: dialect)
+                == "UnsafeMutablePointer<Element>")
+    let base = TypeDefOrRef(rawValue: 1)
+    let resolver = Resolver([
+      base.rawValue: Identity(namespace: "Windows.Foundation",
+                              name: "IReference`1"),
+    ])
+    #expect(SignatureType.instance(.named(kind: .class, base),
+                                   [.variable(scope: .type, 0)])
+                .decode(generics: ["Element"], with: resolver, dialect: dialect)
+                == "IReference<Element>")
+  }
+
+  @Test func `a generic declaration clause wraps the ordered names`() {
+    // The declaration hook composes the dialect's generic delimiters around the
+    // comma-separated names; an empty list is a non-generic declaration (`nil`).
+    #expect(dialect.generics(["Element"]) == "<Element>")
+    #expect(dialect.generics(["Key", "Value"]) == "<Key, Value>")
+    #expect(dialect.generics([]) == nil)
+  }
+
   @Test func `only an IsConst custom modifier marks a pointee const`() {
     // Two modifier-type references: one resolves to `IsConst`, the other to an
     // unrelated type. Only the former may flip the pointer to immutable.

--- a/Tests/WinMDSynthesisTests/DecodeTests.swift
+++ b/Tests/WinMDSynthesisTests/DecodeTests.swift
@@ -196,6 +196,129 @@ struct DecodeTests {
                 == "IReference<CInt>")
   }
 
+  @Test func `an ABI base suffixes the stripped base name and drops the arguments`() {
+    // A generic ABI protocol's inheritance clause names the base's ABI PROTOCOL,
+    // not its wrapper `struct` — a protocol cannot inherit a struct — so `abi`
+    // spells `BaseABI`: the `ABI` suffix on the stripped, escaped base simple
+    // name, WITHOUT arguments (a protocol's primary associated types are not in
+    // scope in its own inheritance clause, so `BaseABI<Args…>` would not
+    // compile; the deriving protocol's own primary associated type refines the
+    // inherited one instead). The wrapper spelling (`decode`) is `Base<Args…>`
+    // for the same instance.
+    let base = TypeDefOrRef(rawValue: 1)
+    let resolver = Resolver([
+      base.rawValue: Identity(namespace: "Windows.Foundation.Collections",
+                              name: "IIterable`1"),
+    ])
+    let instance = SignatureType.instance(.named(kind: .class, base),
+                                          [.variable(scope: .type, 0)])
+    #expect(instance.abi(generics: ["Element"], with: resolver,
+                         dialect: dialect) == "IIterableABI")
+    // The wrapper spelling of the same instance carries the arguments and no
+    // `ABI` suffix.
+    #expect(instance.decode(generics: ["Element"], with: resolver,
+                            dialect: dialect) == "IIterable<Element>")
+  }
+
+  @Test func `an ABI base pins a differing argument with a constraint`() {
+    // A generic base whose argument is NOT the owner's same-named parameter —
+    // `IMap<K,V> : IIterable<IKeyValuePair<K,V>>`, the base's `Element` bound
+    // to `IKeyValuePair<K, V>` — carries the argument as a same-type constraint
+    // on the deriving ABI protocol (`IIterableABI where Element ==
+    // IKeyValuePair<K, V>`), pinning the inherited associated type; without it
+    // `Element` is unconstrained. `associates` names the base's ordered generic
+    // parameters (its associated-type names), mapped to the arguments.
+    let iiterable = TypeDefOrRef(rawValue: 1)
+    let pair = TypeDefOrRef(rawValue: 2)
+    let resolver = Resolver([
+      iiterable.rawValue: Identity(namespace: "Windows.Foundation.Collections",
+                                   name: "IIterable`1"),
+      pair.rawValue: Identity(namespace: "Windows.Foundation.Collections",
+                              name: "IKeyValuePair`2"),
+    ])
+    // The base argument is `IKeyValuePair<K, V>` (`VAR 0`, `VAR 1`).
+    let argument = SignatureType.instance(.named(kind: .class, pair),
+        [.variable(scope: .type, 0), .variable(scope: .type, 1)])
+    let instance = SignatureType.instance(.named(kind: .class, iiterable),
+                                          [argument])
+    #expect(instance.abi(generics: ["K", "Value"], associates: ["Element"],
+                         with: resolver, dialect: dialect)
+                == "IIterableABI where Element == IKeyValuePair<K, Value>")
+  }
+
+  @Test func `an ABI base omits a redundant pass-through self-constraint`() {
+    // The standard pass-through `IVector<Element> : IIterable<Element>`, whose
+    // base argument IS the owner's same-named parameter, would give the
+    // redundant `where Element == Element`; it is omitted, so the base spells
+    // the bare `IIterableABI` — the deriving protocol's own primary associated
+    // type already refines the inherited one by name.
+    let base = TypeDefOrRef(rawValue: 1)
+    let resolver = Resolver([
+      base.rawValue: Identity(namespace: "Windows.Foundation.Collections",
+                              name: "IIterable`1"),
+    ])
+    let instance = SignatureType.instance(.named(kind: .class, base),
+                                          [.variable(scope: .type, 0)])
+    #expect(instance.abi(generics: ["Element"], associates: ["Element"],
+                         with: resolver, dialect: dialect) == "IIterableABI")
+    // With no `associates` supplied (a cross-file base whose parameter names
+    // are not in this file), the bare protocol is spelled — the safe degrade.
+    #expect(instance.abi(generics: ["Element"], with: resolver,
+                         dialect: dialect) == "IIterableABI")
+  }
+
+  @Test func `an ABI base suffixes ABI before escaping the keyword base name`() {
+    // A keyword-named generic base (`protocol``1`) strips its arity to
+    // `protocol`, then takes the `ABI` suffix BEFORE the keyword escape: the
+    // suffixed `protocolABI` is not a keyword, so the escape is a no-op and it
+    // spells the plain `protocolABI`. Escaping FIRST would splice a backtick
+    // pair into the middle (`` `protocol`ABI ``), two identifiers Swift cannot
+    // parse in an inheritance clause.
+    let base = TypeDefOrRef(rawValue: 1)
+    let resolver = Resolver([
+      base.rawValue: Identity(namespace: "NS", name: "protocol`1"),
+    ])
+    let instance = SignatureType.instance(.named(kind: .class, base),
+                                          [.primitive(.int4)])
+    #expect(instance.abi(with: resolver, dialect: dialect) == "protocolABI")
+  }
+
+  @Test func `an ABI base escapes a keyword associate name in its constraint`() {
+    // A base generic parameter whose name is a keyword (`in`) declares its
+    // associated type escaped (`` `in` ``, through the render's `SANITIZE`), so
+    // the same-type constraint's LHS must escape it too — the constraint pins
+    // the DECLARED associated type by name, and a raw `where in == …` names a
+    // nonexistent associate (and is not even parseable). The associate is
+    // escaped with the dialect (the same escape `SANITIZE` uses), so the
+    // constraint reads `` where `in` == CInt ``.
+    let base = TypeDefOrRef(rawValue: 1)
+    let resolver = Resolver([
+      base.rawValue: Identity(namespace: "NS", name: "IBase`1"),
+    ])
+    let instance = SignatureType.instance(.named(kind: .class, base),
+                                          [.primitive(.int4)])
+    #expect(instance.abi(generics: ["Element"], associates: ["in"],
+                         with: resolver, dialect: dialect)
+                == "IBaseABI where `in` == CInt")
+  }
+
+  @Test func `an ABI base drops a keyword pass-through with the escaped name`() {
+    // A pass-through whose base parameter is a keyword (`in`): the owner's
+    // parameter arrives already escaped through `generics` (`` `in` ``, from
+    // `SANITIZE`), so the argument decodes to `` `in` ``. The pass-through
+    // comparison uses the ESCAPED associate too, so `` `in` == `in` `` is
+    // recognised as redundant and dropped — the bare protocol is spelled, not a
+    // spurious self-constraint.
+    let base = TypeDefOrRef(rawValue: 1)
+    let resolver = Resolver([
+      base.rawValue: Identity(namespace: "NS", name: "IBase`1"),
+    ])
+    let instance = SignatureType.instance(.named(kind: .class, base),
+                                          [.variable(scope: .type, 0)])
+    #expect(instance.abi(generics: ["`in`"], associates: ["in"],
+                         with: resolver, dialect: dialect) == "IBaseABI")
+  }
+
   @Test func `a generic over an unresolved base degrades to the opaque pointer`() {
     // The base reference resolves to nothing (e.g. a TypeSpec with no
     // identity): the empty resolver leaves it unresolved.

--- a/Tests/winmd-inspectTests/DatabaseSQLTests.swift
+++ b/Tests/winmd-inspectTests/DatabaseSQLTests.swift
@@ -5,6 +5,7 @@ import Testing
 
 @testable import winmd_inspect
 
+import Mustache
 import SQL
 @testable import WinMD
 import WinMDSynthesis
@@ -194,6 +195,40 @@ struct DatabaseSQLTests {
                           strings: strings.span.bytes, blob: blob.span.bytes,
                           guid: empty.span.bytes, valid: valid, sorted: 0)
     try body(storage)
+  }
+
+  /// Runs `body` over a `Storage` catalog whose relations carry an (empty)
+  /// `GenericParam` table, so the render's `declarations` guard — which checks
+  /// the table's PRESENCE in storage before running the `generics` view —
+  /// passes and the render takes its generic arm. The rows the arm renders come
+  /// from a `generics` view override the caller registers, so the table need
+  /// hold no rows (an empty range past the last real table); the shared
+  /// fixture omits it (no generics), which the render treats as no generics.
+  private static func withGenerics(
+      _ body: (borrowing Storage) throws -> Void) rethrows {
+    var relations = DatabaseSQLTests.relations
+    relations.append(WinMD.Table(Metadata.Tables.GenericParam.self, rows: 0,
+                                 range: bytes.count ..< bytes.count,
+                                 wide: 0, stride: 8))
+    let valid = DatabaseSQLTests.valid | (1 << 42)
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+
+  /// The bundled template `name`'s body with its leading `{{! language: … }}`
+  /// directive line stripped — the body the render hands to `MustacheTemplate`
+  /// after `language(declaredIn:)` consumes the directive. A test renders it
+  /// directly with a hand-built context to pin the template's output shape.
+  private static func template(named name: String) throws -> String {
+    var body = ""
+    try DatabaseSQLTests.with { catalog in
+      let shell = Shell(catalog)
+      body = try shell.template(named: name, search: [])
+    }
+    guard let newline = body.firstIndex(where: \.isNewline) else { return body }
+    return String(body[body.index(after: newline)...])
   }
 
   /// Plans and runs `query` through the engine over the catalog.
@@ -807,6 +842,422 @@ struct DatabaseSQLTests {
     }
   }
 
+  @Test func `the bundled com template renders a non-generic interface unchanged`() throws {
+    // The fixture's `IMyInterface` (non-generic) renders through the REAL
+    // bundled `com` template: the `{{^generic}}` arm emits today's `@com`
+    // protocol shape unchanged — a static `@com(interface:)` IID, `public
+    // protocol` with its `: IInspectable` base, and one `func` per method — with
+    // no generic-wrapper output. This pins the non-generic output byte-for-byte
+    // so the generic split cannot perturb it.
+    try DatabaseSQLTests.with { catalog in
+      let shell = Shell(catalog)
+      let rendered = try shell.render("IMyInterface", template: "com")
+      #expect(rendered == """
+        @com(interface: "0C733A30-2A1C-11CE-ADE5-00AA0044773D")
+        public protocol IMyInterface: IInspectable {
+            func MyMethod(_ first: CInt, _ : HSTRING)
+        }
+
+        """)
+    }
+  }
+
+  @Test func `the bundled com template renders a generic interface as a wrapper`() throws {
+    // A generic interface renders through the `{{#generic}}` arm of the REAL
+    // bundled `com` template: an internal ABI protocol carrying the ordered
+    // type parameters as its primary associated types (`<Element>` naming an
+    // `associatedtype Element` in the body) — so a requirement mentioning
+    // `Element` resolves — with no static IID (the WinRT PIID is computed at
+    // runtime), plus a public generic `struct` wrapper holding the ABI as a
+    // parameterised existential (`any IVectorABI<Element>`). The context is
+    // built the same way the render loop assembles it for an `IVector`-like
+    // ``1` type (arity suffix stripped, one generic parameter `Element`, one
+    // method whose return decodes to that declared name).
+    let body = try DatabaseSQLTests.template(named: "com")
+    let template = try MustacheTemplate(string: body)
+    let context: [String: Any] = [
+      "name": "IVector",
+      "abi": "IVectorABI",
+      "iid": "00000000-0000-0000-0000-000000000000",
+      "namespace": "Windows.Foundation.Collections",
+      "generic": true,
+      "generics": [["name": "Element", "last": true]],
+      "methods": [
+        [
+          "name": "GetAt",
+          "params": [
+            ["name": "index", "local": "index", "type": "CUnsignedInt",
+             "last": true],
+          ],
+          "returns": "Element",
+        ],
+      ],
+    ]
+    #expect(template.render(context) == """
+      // A WinRT parameterised interface: its IID is a per-instantiation PIID computed
+      // at runtime from the type arguments, so no static `@com(interface:)` is emitted
+      // on the ABI protocol or the generic wrapper — the runtime projection supplies it.
+      internal protocol IVectorABI<Element> {
+          associatedtype Element
+          func GetAt(_ index: CUnsignedInt) -> Element
+      }
+
+      public struct IVector<Element> {
+          internal let base: any IVectorABI<Element>
+          public func GetAt(_ index: CUnsignedInt) -> Element {
+              base.GetAt(index)
+          }
+      }
+
+      """)
+  }
+
+  @Test func `a generic interface whose stripped name is a keyword renders escaped`() throws {
+    // A generic type named `protocol``1` strips to the reserved word
+    // `protocol`, which the render escapes to the backticked `` `protocol` ``
+    // for the wrapper `struct` name. The ABI-protocol name is a DIFFERENT
+    // spelling: it suffixes `ABI` onto the stripped name BEFORE escaping, so it
+    // is the plain `protocolABI` (no Swift keyword ends in `ABI`, so the escape
+    // is a no-op). Suffixing `ABI` onto the ALREADY-escaped `` `protocol` ``
+    // would splice a backtick pair into the middle (`` `protocol`ABI ``), which
+    // Swift cannot parse. The wrapper `struct` keeps the escaped bare name
+    // (`` `protocol`<Element> ``); the ABI protocol's declaration and the
+    // wrapper's `base: any …<Element>` existential both spell `protocolABI`.
+    // Overriding `interfaces` to yield a suffixed keyword name over the
+    // fixture's generic-aware storage drives the render's generic arm;
+    // `methods` and `bases` are emptied so the output is the declaration shell
+    // alone.
+    try DatabaseSQLTests.withGenerics { catalog in
+      var shell = Shell(catalog)
+      let interfaces = """
+        CREATE VIEW interfaces AS
+        SELECT Id, TypeNamespace, 'protocol`1' AS TypeName,
+               '00000000-0000-0000-0000-000000000000' AS iid
+        FROM TypeDef WHERE Id = 1
+        """
+      let generics = """
+        CREATE VIEW generics AS
+        SELECT 'Element' AS Name, 0 AS Number FROM TypeDef WHERE Id = :parent
+        """
+      let methods = """
+        CREATE VIEW methods AS
+        SELECT Id, '' AS Name FROM TypeDef WHERE 0 = 1
+        """
+      let bases = """
+        CREATE VIEW bases AS SELECT '' AS base FROM TypeDef WHERE 0 = 1
+        """
+      for query in [interfaces, generics, methods, bases] {
+        let (name, view) = try DatabaseSQLTests.create(query)
+        shell.session.register(name, view)
+      }
+      let rendered = try shell.render("protocol`1", template: "com")
+      #expect(rendered == """
+        // A WinRT parameterised interface: its IID is a per-instantiation PIID computed
+        // at runtime from the type arguments, so no static `@com(interface:)` is emitted
+        // on the ABI protocol or the generic wrapper — the runtime projection supplies it.
+        internal protocol protocolABI<Element>: IUnknown {
+            associatedtype Element
+        }
+
+        public struct `protocol`<Element> {
+            internal let base: any protocolABI<Element>
+        }
+
+        """)
+    }
+  }
+
+  // A self-contained fixture whose one generic interface `IVector` inherits a
+  // generic base named through a `TypeSpec` — an `IIterable<Element>` — so the
+  // render must decode the `TypeSpec` `GENERICINST` with the owner's generic
+  // names for the inheritance clause (`bases` yields no name; `specs` yields
+  // the `TypeSpec` `Id`). Five narrow tables, in table-number order:
+  //   TypeRef[0]:  ResolutionScope=0, TypeName="IIterable"(1) — the generic
+  //                base the `TypeSpec` instantiates; `class`-tagged, coded as
+  //                TypeDefOrRef(TypeRef row 1)=(1<<2)|1=5 in the signature.
+  //   TypeDef[0]:  Flags=0x21 (interface), TypeName="IVector"(11),
+  //                TypeNamespace="NS"(27), Extends=0, MethodList=1 — the owning
+  //                generic interface; `GenericParam` declares its `Element`.
+  //   InterfaceImpl[0]: Class=1=IVector; Interface=TypeDefOrRef(TypeSpec row
+  //                1)=(1<<2)|2=6 — a generic base named through a `TypeSpec`, so
+  //                both `bases` name arms are NULL and `specs` surfaces its Id.
+  //   TypeSpec[0]: Signature=blob[1] — `GENERICINST CLASS <IIterable> 1 VAR 0`,
+  //                the specialized base `IIterable<Element>`.
+  //   GenericParam[0]: Number=0, Owner=TypeOrMethodDef(TypeDef row 1)=(1<<1)=2,
+  //                Name="Element"(19) — `IVector`'s one declared parameter.
+  private static let genericBytes: Array<UInt8> = [
+    // TypeRef[0]
+    0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+    // TypeDef[0]
+    0x21, 0x00, 0x00, 0x00, 0x0b, 0x00, 0x1b, 0x00,
+    0x00, 0x00, 0x01, 0x00, 0x01, 0x00,
+    // InterfaceImpl[0]
+    0x01, 0x00, 0x06, 0x00,
+    // TypeSpec[0]
+    0x01, 0x00,
+    // GenericParam[0]
+    0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x13, 0x00,
+  ]
+
+  // "\0IIterable\0IVector\0Element\0NS\0": IIterable@1, IVector@11, Element@19,
+  // NS@27.
+  private static let genericStrings: Array<UInt8> = [
+    0x00,
+    0x49, 0x49, 0x74, 0x65, 0x72, 0x61, 0x62, 0x6c, 0x65, 0x00,
+    0x49, 0x56, 0x65, 0x63, 0x74, 0x6f, 0x72, 0x00,
+    0x45, 0x6c, 0x65, 0x6d, 0x65, 0x6e, 0x74, 0x00,
+    0x4e, 0x53, 0x00,
+  ]
+
+  // A `#Blob` heap: offset 0 is the reserved empty blob; offset 1 is the 6-byte
+  // `TypeSpec` signature `IIterable<Element>` — `GENERICINST` (0x15), `CLASS`
+  // (0x12), the `IIterable` TypeDefOrRef coded index (0x05), argument count 1,
+  // `VAR` (0x13) operand 0 — preceded by its length 0x06.
+  private static let genericBlob: Array<UInt8> = [
+    0x00,
+    0x06, 0x15, 0x12, 0x05, 0x01, 0x13, 0x00,
+  ]
+
+  private static let genericRelations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 1, range: 0 ..< 6,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 1, range: 6 ..< 20,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.InterfaceImpl.self, rows: 1, range: 20 ..< 24,
+                wide: 0, stride: 4),
+    WinMD.Table(Metadata.Tables.TypeSpec.self, rows: 1, range: 24 ..< 26,
+                wide: 0, stride: 2),
+    WinMD.Table(Metadata.Tables.GenericParam.self, rows: 1, range: 26 ..< 34,
+                wide: 0, stride: 8),
+  ]
+
+  /// Runs `body` over a `Storage` catalog bound to the generic-base fixture.
+  private static func withGenericBase(
+      _ body: (borrowing Storage) throws -> Void) rethrows {
+    let valid: UInt64 =
+        (1 << 1) | (1 << 2) | (1 << 9) | (1 << 27) | (1 << 42)
+    let storage = Storage(bytes: genericBytes.span.bytes,
+                          relations: genericRelations.span,
+                          strings: genericStrings.span.bytes,
+                          blob: genericBlob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+
+  @Test func `a generic base named through a TypeSpec is decoded specialized`() throws {
+    // A generic interface inheriting another generic interface has an
+    // `InterfaceImpl.Interface` that is a `TypeSpec` (a `GENERICINST`), not a
+    // `TypeRef`/`TypeDef` name — so `bases` (which projects only a `TypeName`)
+    // cannot spell it. The render instead reads the `TypeSpec`'s `Id` through
+    // the REAL bundled `specs` view and decodes its signature with the OWNER's
+    // declared generic names threaded. The generic arm's inheritance clause is
+    // the ABI PROTOCOL's, and a protocol cannot inherit the base's public
+    // wrapper `struct`, so the clause spells the base's ABI PROTOCOL,
+    // `IIterableABI` — the `ABI` suffix on the base's simple name — rather than
+    // the wrapper `IIterable<Element>`, a bare arity-suffixed name, or the root.
+    // The base is spelled WITHOUT arguments: a protocol's primary associated
+    // types are not in scope in its own inheritance clause (`protocol P<T>:
+    // Q<T>` does not compile), so the deriving ABI protocol's own `<Element>`
+    // REFINES the inherited associated type instead — which typechecks for the
+    // WinRT pass-through where the base's argument is the owner's `Element`.
+    // Only `interfaces` is overridden (to name `IVector` without the
+    // `GuidAttribute` chain the fixture omits) and `methods` emptied (the
+    // wrapper's requirements are exercised elsewhere); `generics`, `bases`, and
+    // `specs` are the real bundled views over the storage.
+    try DatabaseSQLTests.withGenericBase { catalog in
+      var shell = Shell(catalog)
+      let interfaces = """
+        CREATE VIEW interfaces AS
+        SELECT Id, TypeNamespace, TypeName,
+               '00000000-0000-0000-0000-000000000000' AS iid
+        FROM TypeDef WHERE Id = 1
+        """
+      let methods = """
+        CREATE VIEW methods AS
+        SELECT Id, '' AS Name FROM TypeDef WHERE 0 = 1
+        """
+      for query in [interfaces, methods] {
+        let (name, view) = try DatabaseSQLTests.create(query)
+        shell.session.register(name, view)
+      }
+      let rendered = try shell.render("IVector", template: "com")
+      #expect(rendered == """
+        // A WinRT parameterised interface: its IID is a per-instantiation PIID computed
+        // at runtime from the type arguments, so no static `@com(interface:)` is emitted
+        // on the ABI protocol or the generic wrapper — the runtime projection supplies it.
+        internal protocol IVectorABI<Element>: IIterableABI {
+            associatedtype Element
+        }
+
+        public struct IVector<Element> {
+            internal let base: any IVectorABI<Element>
+        }
+
+        """)
+    }
+  }
+
+  @Test func `a generic interface inheriting a non-generic base keeps it plain`() throws {
+    // A generic interface may inherit a NON-generic base — `IInspectable`, a
+    // plain protocol, not a generic one — which arrives through `bases` (a
+    // `TypeRef`/`TypeDef` simple name), not `specs`/a `TypeSpec`. Its ABI
+    // protocol's inheritance clause names that base UNCHANGED (`: IInspectable`,
+    // no `ABI` suffix and no arguments): the base is already a protocol and
+    // carries no wrapper/ABI split, so only a GENERIC base (a `TypeSpec`
+    // `GENERICINST`) gets the `ABI`-suffixed spelling. The `withGenerics`
+    // storage carries no `TypeSpec` table, so `specialization` is `nil` and the
+    // `bases` override supplies the plain name; `methods` are emptied so the
+    // output is the declaration shell.
+    try DatabaseSQLTests.withGenerics { catalog in
+      var shell = Shell(catalog)
+      let interfaces = """
+        CREATE VIEW interfaces AS
+        SELECT Id, TypeNamespace, 'IVector`1' AS TypeName,
+               '00000000-0000-0000-0000-000000000000' AS iid
+        FROM TypeDef WHERE Id = 1
+        """
+      let generics = """
+        CREATE VIEW generics AS
+        SELECT 'Element' AS Name, 0 AS Number FROM TypeDef WHERE Id = :parent
+        """
+      let methods = """
+        CREATE VIEW methods AS
+        SELECT Id, '' AS Name FROM TypeDef WHERE 0 = 1
+        """
+      let bases = """
+        CREATE VIEW bases AS
+        SELECT 'IInspectable' AS base FROM TypeDef WHERE Id = :parent
+        """
+      for query in [interfaces, generics, methods, bases] {
+        let (name, view) = try DatabaseSQLTests.create(query)
+        shell.session.register(name, view)
+      }
+      let rendered = try shell.render("IVector`1", template: "com")
+      #expect(rendered == """
+        // A WinRT parameterised interface: its IID is a per-instantiation PIID computed
+        // at runtime from the type arguments, so no static `@com(interface:)` is emitted
+        // on the ABI protocol or the generic wrapper — the runtime projection supplies it.
+        internal protocol IVectorABI<Element>: IInspectable {
+            associatedtype Element
+        }
+
+        public struct IVector<Element> {
+            internal let base: any IVectorABI<Element>
+        }
+
+        """)
+    }
+  }
+
+  @Test func `a generic wrapper forwards a blank parameter under a synthesized name`() throws {
+    // The non-generic renderer allows a blank parameter name (`func Foo(_ :
+    // T)`), and the generic ABI protocol requirement keeps it blank too, but the
+    // wrapper's forwarding method must PASS every argument BY NAME in the call
+    // (`base.Foo(arg0)`) — a blank name there expands to an empty argument,
+    // dropping the argument or mangling the commas. A blank parameter therefore
+    // synthesizes a stable `arg<N>` local, used in BOTH the forwarding method's
+    // parameter list (`_ arg0: T`) and the call. This context (built as the
+    // render loop assembles one) drives the REAL bundled `com` template: the
+    // first parameter is blank (→ `arg0`), the second named (`value`, kept). The
+    // protocol requirement stays blank; only the wrapper's forwarding surface
+    // takes the synthesized names.
+    let body = try DatabaseSQLTests.template(named: "com")
+    let template = try MustacheTemplate(string: body)
+    let context: [String: Any] = [
+      "name": "IPair",
+      "abi": "IPairABI",
+      "iid": "00000000-0000-0000-0000-000000000000",
+      "namespace": "NS",
+      "generic": true,
+      "generics": [["name": "Element", "last": true]],
+      "methods": [
+        [
+          "name": "Set",
+          "params": [
+            ["name": "", "local": "arg0", "type": "Element", "last": false],
+            ["name": "value", "local": "value", "type": "CInt", "last": true],
+          ],
+        ],
+      ],
+    ]
+    #expect(template.render(context) == """
+      // A WinRT parameterised interface: its IID is a per-instantiation PIID computed
+      // at runtime from the type arguments, so no static `@com(interface:)` is emitted
+      // on the ABI protocol or the generic wrapper — the runtime projection supplies it.
+      internal protocol IPairABI<Element> {
+          associatedtype Element
+          func Set(_ : Element, _ value: CInt)
+      }
+
+      public struct IPair<Element> {
+          internal let base: any IPairABI<Element>
+          public func Set(_ arg0: Element, _ value: CInt) {
+              base.Set(arg0, value)
+          }
+      }
+
+      """)
+  }
+
+  @Test func `the render synthesizes arg names for blank parameters positionally`() throws {
+    // The render loop itself (not just the template) assigns the `arg<N>` local:
+    // a `Param` whose `Name` is blank gets a positional `arg0`/`arg1`, a named
+    // one keeps its name, so a mix renders `_ arg0: …, _ named: …, _ arg2: …`.
+    // A single blank parameter forwards as `base.M(arg0)` — no empty argument —
+    // and a named parameter is untouched. The fixture's storage decodes the
+    // parameter types; `interfaces`/`methods`/`params` are overridden so the one
+    // method takes a blank then a named parameter over the fixture's `MethodDef`
+    // signature. The forwarding call passes both locals.
+    try DatabaseSQLTests.withGenerics { catalog in
+      var shell = Shell(catalog)
+      let interfaces = """
+        CREATE VIEW interfaces AS
+        SELECT Id, TypeNamespace, 'IThing`1' AS TypeName,
+               '00000000-0000-0000-0000-000000000000' AS iid
+        FROM TypeDef WHERE Id = 1
+        """
+      let generics = """
+        CREATE VIEW generics AS
+        SELECT 'Element' AS Name, 0 AS Number FROM TypeDef WHERE Id = :parent
+        """
+      // The fixture's `MethodDef` Id 1 is `void MyMethod(i4, string)`, its two
+      // real parameters `Param` Id 2 (Sequence 1, `i4` → `CInt`) and Id 3
+      // (Sequence 2, `string` → `HSTRING`). `methods` names the one method;
+      // `params` yields those two rows in order but BLANKS the first's `Name`
+      // (its type still decodes from the real `Param` Id) and names the second
+      // `first`, so the render must synthesize `arg0` for the blank one and keep
+      // `first`. The `Sequence` column is non-zero so neither is filtered as the
+      // return pseudo-parameter.
+      let methods = """
+        CREATE VIEW methods AS
+        SELECT Id, 'MyMethod' AS Name FROM MethodDef WHERE Id = 1
+        """
+      let params = """
+        CREATE VIEW params AS
+        SELECT 2 AS Id, '' AS Name, 1 AS Sequence
+        FROM MethodDef WHERE Id = 1
+        UNION ALL
+        SELECT 3 AS Id, 'first' AS Name, 2 AS Sequence
+        FROM MethodDef WHERE Id = 1
+        """
+      let bases = """
+        CREATE VIEW bases AS SELECT '' AS base FROM TypeDef WHERE 0 = 1
+        """
+      for query in [interfaces, generics, methods, params, bases] {
+        let (name, view) = try DatabaseSQLTests.create(query)
+        shell.session.register(name, view)
+      }
+      let rendered = try shell.render("IThing`1", template: "com")
+      // The wrapper's forwarding method names the blank parameter `arg0` and
+      // keeps `first`; the call passes both. The ABI requirement leaves the
+      // blank parameter blank (`_ : CInt`).
+      #expect(rendered.contains(
+          "public func MyMethod(_ arg0: CInt, _ first: HSTRING) {"))
+      #expect(rendered.contains("base.MyMethod(arg0, first)"))
+      #expect(rendered.contains("func MyMethod(_ : CInt, _ first: HSTRING)"))
+    }
+  }
+
   @Test func `execute routes a .-token to its meta-command`() throws {
     // The leading-token dispatch matches `.tables` to `Tables`, which lists the
     // storage's relations; the fixture's catalog vends them, so `execute`
@@ -1183,6 +1634,143 @@ struct DatabaseSQLTests {
       let rendered = try shell.render("IMyInterface", template: "com")
       #expect(rendered.contains("LAST"))
       #expect(!rendered.contains("FIRST"))
+    }
+  }
+
+  // A `IMap<K,V> : IIterable<IKeyValuePair<K,V>>` fixture: the base's argument
+  // is NOT a plain owner parameter, so the forwarded base methods must decode
+  // the base's `VAR i` against the SUBSTITUTED argument, not the owner's own
+  // parameter of that position. `IIterable` owns one method, `First() -> VAR 0`
+  // (its element); forwarded into `IMap` the return must spell
+  // `IKeyValuePair<K, V>` (the substituted argument), not `K` (owner `VAR 0`).
+  //
+  // Strings: `\0IMap\0IIterable\0IKeyValuePair\0First\0K\0V\0Element\0NS\0` —
+  // IMap@1, IIterable@6, IKeyValuePair@16, First@30, K@36, V@38, Element@40,
+  // NS@48.
+  private static let mapStrings: Array<UInt8> = [
+    0x00,
+    0x49, 0x4d, 0x61, 0x70, 0x00,
+    0x49, 0x49, 0x74, 0x65, 0x72, 0x61, 0x62, 0x6c, 0x65, 0x00,
+    0x49, 0x4b, 0x65, 0x79, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x50, 0x61, 0x69,
+    0x72, 0x00,
+    0x46, 0x69, 0x72, 0x73, 0x74, 0x00,
+    0x4b, 0x00,
+    0x56, 0x00,
+    0x45, 0x6c, 0x65, 0x6d, 0x65, 0x6e, 0x74, 0x00,
+    0x4e, 0x53, 0x00,
+  ]
+
+  // Blob: offset 0 empty; offset 1 the 4-byte `First` signature — HASTHIS
+  // (0x20), param count 0, return `VAR` (0x13) operand 0 — length 0x04; offset
+  // 6 the 12-byte `TypeSpec` signature `IIterable<IKeyValuePair<K,V>>` —
+  // GENERICINST (0x15) CLASS (0x12) IIterable (TypeDef 2 → coded 0x08) argcount
+  // 1, then the sole argument GENERICINST (0x15) CLASS (0x12) IKeyValuePair
+  // (TypeDef 3 → coded 0x0c) argcount 2, `VAR 0` (0x13 0x00), `VAR 1` (0x13
+  // 0x01) — length 0x0c.
+  private static let mapBlob: Array<UInt8> = [
+    0x00,
+    0x04, 0x20, 0x00, 0x13, 0x00,
+    0x0c, 0x15, 0x12, 0x08, 0x01, 0x15, 0x12, 0x0c, 0x02, 0x13, 0x00,
+    0x13, 0x01,
+  ]
+
+  // Tables: three `TypeDef` (IMap, IIterable, IKeyValuePair); one `MethodDef`
+  // (`First`, owned by IIterable through the `MethodList` ranges 1,1,2); one
+  // `Param` (the return pseudo-parameter, Sequence 0); one `InterfaceImpl`
+  // (Class IMap → Interface the `TypeSpec`); one `TypeSpec`; three
+  // `GenericParam` (IMap's K/V, IIterable's Element).
+  private static let mapBytes: Array<UInt8> = [
+    // TypeDef[0] IMap: Flags 0x21, Name 1, NS 48, Extends 0, Field 1, Method 1
+    0x21, 0x00, 0x00, 0x00, 0x01, 0x00, 0x30, 0x00,
+    0x00, 0x00, 0x01, 0x00, 0x01, 0x00,
+    // TypeDef[1] IIterable: Name 6, NS 48, Field 1, Method 1
+    0x21, 0x00, 0x00, 0x00, 0x06, 0x00, 0x30, 0x00,
+    0x00, 0x00, 0x01, 0x00, 0x01, 0x00,
+    // TypeDef[2] IKeyValuePair: Name 16, NS 48, Field 1, Method 2
+    0x21, 0x00, 0x00, 0x00, 0x10, 0x00, 0x30, 0x00,
+    0x00, 0x00, 0x01, 0x00, 0x02, 0x00,
+    // MethodDef[0] First: RVA 0, ImplFlags 0, Flags 0, Name 30, Sig 1, Param 1
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x1e, 0x00, 0x01, 0x00, 0x01, 0x00,
+    // Param[0] return: Flags 0, Sequence 0, Name 0
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // InterfaceImpl[0]: Class 1 (IMap), Interface TypeSpec 1 (coded 0x06)
+    0x01, 0x00, 0x06, 0x00,
+    // TypeSpec[0]: Signature blob 6
+    0x06, 0x00,
+    // GenericParam[0] IMap.K: Number 0, Flags 0, Owner (TypeDef 1 → 2), Name 36
+    0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x24, 0x00,
+    // GenericParam[1] IMap.V: Number 1, Owner 2, Name 38
+    0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x26, 0x00,
+    // GenericParam[2] IIterable.Element: Number 0, Owner (TypeDef 2 → 4),
+    // Name 40
+    0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x28, 0x00,
+  ]
+
+  private static let mapRelations: Array<WinMD.Table> = [
+    // An empty `TypeRef` table so the bundled `bases` view's `TypeRef` join arm
+    // resolves a relation (the fixture's only base is a same-file `TypeSpec`).
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 0, range: 0 ..< 0,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 3, range: 0 ..< 42,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.MethodDef.self, rows: 1, range: 42 ..< 56,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.Param.self, rows: 1, range: 56 ..< 62,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.InterfaceImpl.self, rows: 1, range: 62 ..< 66,
+                wide: 0, stride: 4),
+    WinMD.Table(Metadata.Tables.TypeSpec.self, rows: 1, range: 66 ..< 68,
+                wide: 0, stride: 2),
+    WinMD.Table(Metadata.Tables.GenericParam.self, rows: 3, range: 68 ..< 92,
+                wide: 0, stride: 8),
+  ]
+
+  /// Runs `body` over a `Storage` catalog bound to the `IMap` fixture.
+  private static func withMap(
+      _ body: (borrowing Storage) throws -> Void) rethrows {
+    let valid: UInt64 =
+        (1 << 1) | (1 << 2) | (1 << 6) | (1 << 8) | (1 << 9) | (1 << 27)
+            | (1 << 42)
+    let storage = Storage(bytes: mapBytes.span.bytes,
+                          relations: mapRelations.span,
+                          strings: mapStrings.span.bytes,
+                          blob: mapBlob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+
+  @Test func `a non-pass-through base forwards its method with the substituted argument`() throws {
+    // `IMap<K,V> : IIterable<IKeyValuePair<K,V>>`: the base `TypeSpec`'s sole
+    // argument is `IKeyValuePair<K,V>`, not a plain owner parameter, so the
+    // forwarded `IIterable.First() -> VAR 0` must decode `VAR 0` as the
+    // SUBSTITUTED argument `IKeyValuePair<K, V>`, not the owner's `VAR 0`
+    // (`K`). Only `interfaces` is overridden (to name `IMap` without the
+    // `GuidAttribute` chain the fixture omits); `generics`, `methods`,
+    // `params`, `specs`, and `bases` are the real bundled views over the
+    // storage, so the substitution and the forwarding walk are exercised end to
+    // end.
+    try DatabaseSQLTests.withMap { catalog in
+      var shell = Shell(catalog)
+      let interfaces = """
+        CREATE VIEW interfaces AS
+        SELECT Id, TypeNamespace, TypeName,
+               '00000000-0000-0000-0000-000000000000' AS iid
+        FROM TypeDef WHERE Id = 1
+        """
+      let (name, view) = try DatabaseSQLTests.create(interfaces)
+      shell.session.register(name, view)
+      let rendered = try shell.render("IMap", template: "com")
+      // The forwarded return spells the substituted argument, not the owner's
+      // `K` and not a placeholder.
+      #expect(rendered.contains(
+          "public func First() -> IKeyValuePair<K, V> {"))
+      #expect(rendered.contains("func First() -> IKeyValuePair<K, V>"))
+      #expect(!rendered.contains("First() -> K"))
+      // The base spells its ABI protocol with the differing argument pinned as
+      // a same-type constraint.
+      #expect(rendered.contains(
+          "IMapABI<K, V>: IIterableABI where Element == IKeyValuePair<K, V>"))
     }
   }
 }

--- a/Tests/winmd-inspectTests/ShellTests.swift
+++ b/Tests/winmd-inspectTests/ShellTests.swift
@@ -362,11 +362,12 @@ struct ShellTests {
             == ["SELECT 1\nFROM Module", "SELECT 2"])
   }
 
-  @Test func `the bundled views are the four COM-interface views`() {
-    // The parse-and-register path a `CREATE VIEW` reuses; the four bundled
+  @Test func `the bundled views are the five COM-interface views`() {
+    // The parse-and-register path a `CREATE VIEW` reuses; the five bundled
     // views register under their case-folded names.
     let views = Session.bundled()
-    #expect(Set(views.keys) == ["interfaces", "methods", "params", "bases"])
+    #expect(Set(views.keys)
+            == ["interfaces", "methods", "params", "bases", "generics"])
   }
 
   @Test func `a streamed CREATE VIEW statement parses and registers a view`() throws {

--- a/Tests/winmd-inspectTests/ShellTests.swift
+++ b/Tests/winmd-inspectTests/ShellTests.swift
@@ -86,6 +86,30 @@ struct ShellTests {
     #expect(Schema("").query.isEmpty)
   }
 
+  @Test func `a blank parameter local avoids colliding with a real name`() {
+    // A generic method with an unnamed parameter followed by a real parameter
+    // named like the synthetic local (`Foo(_ : T, _ arg0: T)`) must not emit
+    // two `arg0` locals — the wrapper's forwarding method would not compile.
+    // The synthetic name is chosen AFTER the real names are known, skipping any
+    // `arg<N>` a real (or earlier synthetic) parameter already uses: the blank
+    // takes `arg1`, the real `arg0` keeps its own name.
+    let collision = Shell.parameters(["", "arg0"], types: ["T", "T"])
+    #expect(collision.map { $0["local"] as? String } == ["arg1", "arg0"])
+    // The blank's `name` stays empty (the protocol requirement spells `_ : T`),
+    // only its `local` is synthesised.
+    #expect(collision.map { $0["name"] as? String } == ["", "arg0"])
+    // Two blanks number sequentially and skip a real `arg1` between them.
+    let mixed = Shell.parameters(["", "arg1", ""], types: ["A", "B", "C"])
+    #expect(mixed.map { $0["local"] as? String } == ["arg0", "arg1", "arg2"])
+    // The last entry carries the `last` flag; the rest do not.
+    #expect(mixed.map { $0["last"] as? Bool } == [false, false, true])
+    // A named-only list keeps each name as its own local, no synthesis.
+    let named = Shell.parameters(["a", "b"], types: ["X", "Y"])
+    #expect(named.map { $0["local"] as? String } == ["a", "b"])
+    // An empty list produces no entries (and sets no `last`).
+    #expect(Shell.parameters([], types: []).isEmpty)
+  }
+
   @Test func `.render parses its interface and template arguments`() {
     // `Render.init` splits the rest of the statement into interface then
     // template; both are required, so anything but two fields leaves them empty
@@ -362,12 +386,13 @@ struct ShellTests {
             == ["SELECT 1\nFROM Module", "SELECT 2"])
   }
 
-  @Test func `the bundled views are the five COM-interface views`() {
-    // The parse-and-register path a `CREATE VIEW` reuses; the five bundled
+  @Test func `the bundled views are the six COM-interface views`() {
+    // The parse-and-register path a `CREATE VIEW` reuses; the six bundled
     // views register under their case-folded names.
     let views = Session.bundled()
     #expect(Set(views.keys)
-            == ["interfaces", "methods", "params", "bases", "generics"])
+            == ["interfaces", "methods", "params", "bases", "generics",
+                "specs"])
   }
 
   @Test func `a streamed CREATE VIEW statement parses and registers a view`() throws {


### PR DESCRIPTION
This pull request adds support for generic interfaces in the WinMD synthesis and inspection pipeline. The main focus is on correctly decoding and rendering generic parameter names for interfaces, ensuring that type variables use their declared names (e.g., `Element`) instead of positional placeholders (e.g., `T0`). The changes also update the code generation templates and database queries to handle generics, and introduce new tests to verify the improved behavior.

**Generic interface decoding and rendering:**

* Added logic to extract and thread ordered generic parameter names from metadata, ensuring that type variables (`VAR`) spell their declared names (e.g., `Element`) instead of positional placeholders (`T0`). This propagates through pointer types, generic instantiations, and other structural cases. [[1]](diffhunk://#diff-aee6cca485fee9a87b0ca5fceac7fed0e75e37985d9296779223130f89b6c4f1R76-R85) [[2]](diffhunk://#diff-aee6cca485fee9a87b0ca5fceac7fed0e75e37985d9296779223130f89b6c4f1R337-R351) [[3]](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425R507-R516) [[4]](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425L529-R539) [[5]](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425L549-R559) [[6]](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425R580-R626)
* Updated the Mustache code generation template to emit generic interface declarations and wrappers, including a generic clause with the correct ordered parameter names.

**Database and query updates:**

* Added new SQL views and queries (`generics.sql`) to extract and order generic parameter names for a given interface from metadata, and integrated them into the code generation flow. [[1]](diffhunk://#diff-f371185095f89d08b7e14b36404562250df90e49fdfc24e44548ba63b96f34faR1-R10) [[2]](diffhunk://#diff-8f11390668c5c61b11acb7fe9fbc8e62251aa165f35b115a9b57cadf4fe5e002R1-R5)

**Decoding improvements:**

* Extended decoding methods to accept and propagate generic parameter names, ensuring all relevant decoding paths (methods, parameters, returns) use the correct names when available. [[1]](diffhunk://#diff-00c23dbc7bd1be8eeecff6ea9793bf2edb96d28a3156717fe70457c790678513R776) [[2]](diffhunk://#diff-00c23dbc7bd1be8eeecff6ea9793bf2edb96d28a3156717fe70457c790678513L785-R787) [[3]](diffhunk://#diff-00c23dbc7bd1be8eeecff6ea9793bf2edb96d28a3156717fe70457c790678513R805) [[4]](diffhunk://#diff-00c23dbc7bd1be8eeecff6ea9793bf2edb96d28a3156717fe70457c790678513L828-R832)

**Testing:**

* Added comprehensive tests to verify that type variables and nested generic structures spell their declared names when generic parameter names are supplied, and that the generic declaration clause is correctly composed.

**Build and dependency updates:**

* Added the `Mustache` package as a dependency in `Package.swift` for template rendering.
* Imported the `Mustache` module in the test suite.