### PR TITLE
SQL: `IN`, `CASE` support

### DIFF
--- a/Sources/SQL/AST.swift
+++ b/Sources/SQL/AST.swift
@@ -467,6 +467,14 @@ public indirect enum Predicate: Hashable, Sendable {
   /// nullable column — an absent decoded attribute — is filtered (`WHERE iid IS
   /// NOT NULL`).
   case null(Expression, negated: Bool)
+  /// `operand IN (v, …)`, or `NOT IN` when `negated` — whether the operand
+  /// equals any value of the non-empty `values` list. It is ISO shorthand for a
+  /// disjunction of equalities under three-valued logic: `x IN (a, b)` is `x = a
+  /// OR x = b`, so a NULL operand or a NULL element makes an otherwise-unmatched
+  /// test UNKNOWN rather than FALSE, and `NOT IN` is the negation of that (never
+  /// TRUE when a NULL element is present). The engine lowers it to that
+  /// disjunction rather than carrying a dedicated `Filter` case.
+  case membership(Expression, Array<Expression>, negated: Bool)
   /// `lhs AND rhs`.
   case and(Predicate, Predicate)
   /// `lhs OR rhs`.

--- a/Sources/SQL/AST.swift
+++ b/Sources/SQL/AST.swift
@@ -401,6 +401,34 @@ public indirect enum Expression: Hashable, Sendable {
   /// value, so the engine recognises the fixed set of aggregate names at parse
   /// time and lowers them through a dedicated mechanism rather than the routines.
   case aggregate(Aggregate, of: Aggregand)
+  /// A `CASE` conditional expression — the result of its FIRST `when` whose
+  /// predicate is TRUE (three-valued: UNKNOWN and FALSE both skip), else the
+  /// `else` result, or `NULL` when there is no `ELSE`. The `when`s are held in
+  /// source order.
+  ///
+  /// Both ISO forms reduce to this searched shape: a SEARCHED `CASE WHEN cond
+  /// THEN r … END` carries its predicates directly, and a SIMPLE `CASE op WHEN v
+  /// THEN r … END` is normalised at parse time to `WHEN op = v THEN r …`, so the
+  /// engine models one conditional. The result expressions' types must unify to
+  /// one result type (see resolution).
+  case `case`(Array<When>, else: Expression?)
+}
+
+/// One `WHEN predicate THEN result` branch of a `CASE` expression — the guard
+/// and the value it yields when the guard is the first TRUE one.
+public struct When: Hashable, Sendable {
+  /// The guard predicate — TRUE selects this branch (UNKNOWN and FALSE skip it).
+  /// A simple `CASE`'s `WHEN value` is normalised to the equality `operand =
+  /// value` here.
+  public let when: Predicate
+
+  /// The result expression this branch yields when its guard is the first TRUE.
+  public let then: Expression
+
+  public init(when: Predicate, then: Expression) {
+    self.when = when
+    self.then = then
+  }
 }
 
 /// A standard SQL aggregate function.

--- a/Sources/SQL/Adapter.swift
+++ b/Sources/SQL/Adapter.swift
@@ -58,6 +58,18 @@ public enum ValueType: Hashable, Sendable {
     self == other || (numeric && other.numeric)
   }
 
+  /// The single type a value of this type and one of `other` UNIFY to, or `nil`
+  /// when they are irreconcilable — the rule a `CASE` reconciles its result
+  /// types by. Like types unify to themselves; a mixed integer/double pair
+  /// widens to `double` (both numeric, the integer promoted, as arithmetic and
+  /// comparison do); any other cross-kind pair — text against a number, boolean
+  /// against blob — has no common type and does not unify.
+  internal func unified(with other: ValueType) -> ValueType? {
+    if self == other { return self }
+    if numeric && other.numeric { return .double }
+    return nil
+  }
+
   /// The ISO `data_type` spelling of this value type.
   ///
   /// The engine's types map onto the ISO domains: exact numeric to `integer`,
@@ -108,6 +120,24 @@ public enum Value: Hashable, Sendable {
   /// equality (`=`/`<>`) and lexicographic order (`<`/`>`/`<=`/`>=`), both free
   /// from `Array<UInt8>: Comparable`.
   case blob(Array<UInt8>)
+}
+
+extension Value {
+  /// This value coerced to `type` — the widening a `CASE` (or a defined
+  /// function body) applies so a selected branch's raw value matches the
+  /// unified result type the schema advertises.
+  ///
+  /// `ValueType.unified` performs one widening only — a mixed integer/double
+  /// pair to `.double` — so this promotes an `.integer` to `.double` when
+  /// `type` is `.double` and leaves every other value unchanged: NULL stays
+  /// NULL, a value already of the unified type passes through, and a
+  /// non-widening unified type (every arm the same) needs no coercion.
+  internal func coerced(to type: ValueType) -> Value {
+    if case .double = type, case let .integer(number) = self {
+      return .double(Double(number))
+    }
+    return self
+  }
 }
 
 // MARK: - View

--- a/Sources/SQL/Adapter.swift
+++ b/Sources/SQL/Adapter.swift
@@ -48,6 +48,16 @@ public enum ValueType: Hashable, Sendable {
     }
   }
 
+  /// Whether a value of this type may be compared for equality against one of
+  /// `other` — the same rule `matches` applies: like types compare, and an
+  /// integer and a double are comparable (both numeric, the integer promoted).
+  /// A cross-kind pair — a number against text, boolean, or blob — never
+  /// matches, so it is not comparable. The `IN` value list and a simple `CASE`
+  /// require each element comparable to the tested value by this rule.
+  internal func comparable(with other: ValueType) -> Bool {
+    self == other || (numeric && other.numeric)
+  }
+
   /// The ISO `data_type` spelling of this value type.
   ///
   /// The engine's types map onto the ISO domains: exact numeric to `integer`,

--- a/Sources/SQL/Aggregate.swift
+++ b/Sources/SQL/Aggregate.swift
@@ -230,9 +230,17 @@ private func comparable(_ a: Value, _ b: Value) -> Bool {
 /// is ONE group — the degenerate whole-result aggregation (`SELECT COUNT(*) FROM
 /// T`) — which yields a single grouped record even over an empty input (`COUNT`
 /// `0`, the others NULL), the standard SQL rule.
+///
+/// The `bindings` thread through both the key and the argument evaluation — the
+/// same bindings the projection and the `WHERE` filter resolve against — so a
+/// `:parameter` reached from inside an aggregate's argument (a
+/// `COUNT(CASE WHEN K = :k …)`) binds to its query value rather than reading as
+/// UNBOUND. The key evaluation threads them for the same reason and to keep the
+/// two evaluate sites consistent, though a `GROUP BY` key is a bare column
+/// today, so it cannot yet reach one.
 internal func grouped(_ records: Array<Record>, _ keys: Array<Term>,
-                      _ aggregates: Array<Aggregation>, _ routines: Routines)
-    throws(SQLError) -> Array<Record> {
+                      _ aggregates: Array<Aggregation>, _ routines: Routines,
+                      _ bindings: Bindings) throws(SQLError) -> Array<Record> {
   var order = Array<Record>()
   var accumulators = Dictionary<Record, Array<Accumulator>>()
 
@@ -240,7 +248,7 @@ internal func grouped(_ records: Array<Record>, _ keys: Array<Term>,
     var cells = Array<Value>()
     cells.reserveCapacity(keys.count)
     for key in keys {
-      try cells.append(evaluate(key, record, routines))
+      try cells.append(record.evaluate(key, routines, bindings))
     }
     let group = Record(cells)
     // Key the group on the EXACT canonical form of its cells so `1` and `1.0`
@@ -256,7 +264,7 @@ internal func grouped(_ records: Array<Record>, _ keys: Array<Term>,
       // `COUNT(*)` has no argument — count the row with a non-NULL sentinel;
       // every other aggregate folds its evaluated argument value.
       let value: Value = if let argument = aggregates[index].argument {
-        try evaluate(argument, record, routines)
+        try record.evaluate(argument, routines, bindings)
       } else {
         .integer(0)
       }

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -444,11 +444,11 @@ extension Projection {
   /// faulting (`SQLError.column` for a column, `SQLError.unsupported` for `*`).
   /// The terms hold no slots, so the `single` row's empty record carries every
   /// value the projection needs.
-  internal func scalar() throws(SQLError) -> Plan {
+  internal func scalar(_ routines: Routines = [:]) throws(SQLError) -> Plan {
     guard case .all = self else {
       let schema = Schema(width: 0, extent: 0, names: [], types: [],
                           virtuals: [])
-      let terms = try schema.terms(self, in: Relation(name: ""))
+      let terms = try schema.terms(self, in: Relation(name: ""), routines)
       return .project(terms, .single)
     }
     // `SELECT *` names every column of the relations in scope; a FROM-less query
@@ -589,6 +589,72 @@ extension Expression {
       arguments.contains { $0.aggregated }
     case let .binary(_, lhs, rhs):
       lhs.aggregated || rhs.aggregated
+    case let .case(whens, otherwise):
+      whens.contains { $0.when.aggregated || $0.then.aggregated }
+          || (otherwise?.aggregated ?? false)
+    }
+  }
+
+  /// Whether the expression references a query binding — a `.bound` predicate —
+  /// anywhere within it, reached only through a `CASE` guard (a scalar
+  /// expression has no other predicate). A defined-function body is validated
+  /// over its parameter schema and evaluated with only its argument record — no
+  /// query bindings reach it — so a body naming a `:parameter` is rejected at
+  /// registration rather than silently evaluating that reference as UNBOUND.
+  internal var bound: Bool {
+    switch self {
+    case .column, .literal, .aggregate:
+      false
+    case let .call(_, arguments):
+      arguments.contains { $0.bound }
+    case let .binary(_, lhs, rhs):
+      lhs.bound || rhs.bound
+    case let .case(whens, otherwise):
+      whens.contains { $0.when.bound || $0.then.bound }
+          || (otherwise?.bound ?? false)
+    }
+  }
+}
+
+extension Predicate {
+  /// Whether the predicate contains an aggregate call anywhere within it — used
+  /// to spot an aggregate hiding in a `CASE` guard (`CASE WHEN COUNT(*) > 1
+  /// …`), which makes the enclosing query an aggregate one.
+  internal var aggregated: Bool {
+    switch self {
+    case let .comparison(left, _, right):
+      left.aggregated || right.aggregated
+    case let .bound(left, _, _):
+      left.aggregated
+    case let .null(operand, _):
+      operand.aggregated
+    case let .membership(operand, values, _):
+      operand.aggregated || values.contains { $0.aggregated }
+    case let .and(lhs, rhs), let .or(lhs, rhs):
+      lhs.aggregated || rhs.aggregated
+    case let .not(operand):
+      operand.aggregated
+    }
+  }
+
+  /// Whether the predicate references a query binding — a `.bound` operand — in
+  /// any position within it. A defined-function body's `CASE` guards are walked
+  /// through this to reject a `:parameter` at registration (see
+  /// `Expression.bound`).
+  internal var bound: Bool {
+    switch self {
+    case .bound:
+      true
+    case let .comparison(left, _, right):
+      left.bound || right.bound
+    case let .null(operand, _):
+      operand.bound
+    case let .membership(operand, values, _):
+      operand.bound || values.contains { $0.bound }
+    case let .and(lhs, rhs), let .or(lhs, rhs):
+      lhs.bound || rhs.bound
+    case let .not(operand):
+      operand.bound
     }
   }
 }
@@ -638,7 +704,7 @@ extension Catalog where Self: ~Escapable {
     }
     var predicate: Filter? = nil
     if let clause = select.predicate {
-      predicate = try scope.lower(clause)
+      predicate = try scope.lower(clause, context.routines)
     }
 
     // The `GROUP BY` keys and the aggregate arguments lower to combined
@@ -656,7 +722,7 @@ extension Catalog where Self: ~Escapable {
     }
     var aggregations = Array<Aggregation>()
     for expression in expressions {
-      try aggregations.append(expression.aggregation(scope))
+      try aggregations.append(expression.aggregation(scope, context.routines))
     }
 
     // The source materialises exactly the ordinals the WHERE, the keys, and the
@@ -704,9 +770,9 @@ extension Catalog where Self: ~Escapable {
     // enforcing the projection rule (every non-aggregated column must be a
     // GROUP BY key).
     var grouping = try Grouping(scope, select.grouping, expressions)
-    let projection = try grouping.terms(select.projection)
+    let projection = try grouping.terms(select.projection, context.routines)
     let having: Filter? = if let clause = select.having {
-      try grouping.lower(clause)
+      try grouping.lower(clause, context.routines)
     } else {
       nil
     }
@@ -770,6 +836,12 @@ extension Expression {
     case let .binary(_, lhs, rhs):
       lhs.collect(into: &expressions)
       rhs.collect(into: &expressions)
+    case let .case(whens, otherwise):
+      for branch in whens {
+        branch.when.collect(into: &expressions)
+        branch.then.collect(into: &expressions)
+      }
+      otherwise?.collect(into: &expressions)
     }
   }
 
@@ -779,7 +851,8 @@ extension Expression {
   /// `COUNT(*)` has no argument (it counts rows); every other aggregate lowers
   /// its single operand expression to a term. `self` is always an `.aggregate`
   /// — `collect` gathers only those.
-  internal func aggregation(_ scope: Scope) throws(SQLError) -> Aggregation {
+  internal func aggregation(_ scope: Scope, _ routines: Routines = [:])
+      throws(SQLError) -> Aggregation {
     guard case let .aggregate(function, operand) = self else {
       throw .unsupported("expected an aggregate")
     }
@@ -787,7 +860,7 @@ extension Expression {
     case .star:
       nil
     case let .expression(expression):
-      try scope.term(expression)
+      try scope.term(expression, routines)
     }
     return Aggregation(function: function, argument: argument)
   }
@@ -1580,7 +1653,7 @@ extension Catalog where Self: ~Escapable {
             "a WHERE, GROUP BY, HAVING, ORDER BY, OFFSET/FETCH, or JOIN " +
             "requires a FROM clause")
       }
-      return try select.projection.scalar()
+      return try select.projection.scalar(context.routines)
     }
     let from = try resolve(relation, context, visited)
 
@@ -1605,14 +1678,16 @@ extension Catalog where Self: ~Escapable {
     guard !select.joins.isEmpty else {
       var filter: Filter? = nil
       if let predicate = select.predicate {
-        filter = try from.schema.lower(predicate, in: relation)
+        filter = try from.schema.lower(predicate, in: relation,
+                                       context.routines)
       }
       var order = Array<(column: Int, ascending: Bool)>()
       if let clause = select.order {
         order = try from.schema.order(clause, in: relation)
       }
       let projection =
-          try from.schema.terms(select.projection, in: relation)
+          try from.schema.terms(select.projection, in: relation,
+                                context.routines)
 
       // Under DISTINCT every ORDER BY key must be a select-list column — the
       // dedup runs on the projected rows, so ordering on a dropped column is
@@ -1668,13 +1743,13 @@ extension Catalog where Self: ~Escapable {
     }
     var predicate: Filter? = nil
     if let clause = select.predicate {
-      predicate = try scope.lower(clause)
+      predicate = try scope.lower(clause, context.routines)
     }
     var order = Array<(column: Int, ascending: Bool)>()
     if let clause = select.order {
       order = try scope.order(clause)
     }
-    let projection = try scope.terms(select.projection)
+    let projection = try scope.terms(select.projection, context.routines)
 
     // Under DISTINCT every ORDER BY key must be a select-list column (see
     // `distinct`); order keys and projection are in combined base-ordinal

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -804,6 +804,9 @@ extension Predicate {
       left.collect(into: &expressions)
     case let .null(expression, _):
       expression.collect(into: &expressions)
+    case let .membership(operand, values, _):
+      operand.collect(into: &expressions)
+      for value in values { value.collect(into: &expressions) }
     case let .and(lhs, rhs), let .or(lhs, rhs):
       lhs.collect(into: &expressions)
       rhs.collect(into: &expressions)

--- a/Sources/SQL/Filter.swift
+++ b/Sources/SQL/Filter.swift
@@ -15,7 +15,7 @@ public typealias Bindings = Dictionary<String, Value>
 /// off a bare slot before running it. The filter is fully
 /// escapable; the `~Escapable` row it reads materialises only transiently at
 /// evaluation.
-internal indirect enum Filter {
+internal indirect enum Filter: Sendable {
   /// `left <op> right`, both operands lowered to ordinal-addressed terms (a
   /// slot, a constant, or a scalar-function call).
   case compare(Term, Comparison, Term)
@@ -57,6 +57,15 @@ internal indirect enum Term: Sendable {
   /// `lhs <op> rhs` — a binary arithmetic over two operand terms, the lowered
   /// form of the AST's `Expression.binary`.
   case binary(Arithmetic, Term, Term)
+  /// A `CASE` conditional — the lowered form of the AST's `Expression.case`. Each
+  /// branch is a guard `Filter` and the result `Term` it yields; the executor
+  /// evaluates the guards in order and takes the first whose three-valued value
+  /// is TRUE (UNKNOWN and FALSE skip), else the `else` term, or `NULL` when there
+  /// is none. `type` is the unification of the branch result types (the same
+  /// `ValueType.unified` reduction `derive`/`validate` compute) — the type the
+  /// schema advertises for the column — so the executor COERCES the selected
+  /// value to it, widening an `.integer` arm of a `.double` CASE.
+  case `case`(Array<(Filter, Term)>, else: Term?, type: ValueType)
 }
 
 extension Term {
@@ -78,6 +87,12 @@ extension Term {
     case let .binary(_, lhs, rhs):
       lhs.references(into: &slots)
       rhs.references(into: &slots)
+    case let .case(branches, otherwise, _):
+      for (gate, result) in branches {
+        gate.references(into: &slots)
+        result.references(into: &slots)
+      }
+      otherwise?.references(into: &slots)
     }
   }
 }
@@ -97,6 +112,10 @@ extension Term {
              arguments: arguments.map { $0.remapped(through: slot) })
     case let .binary(op, lhs, rhs):
       .binary(op, lhs.remapped(through: slot), rhs.remapped(through: slot))
+    case let .case(branches, otherwise, type):
+      .case(branches.map {
+              ($0.0.remapped(through: slot), $0.1.remapped(through: slot))
+            }, else: otherwise?.remapped(through: slot), type: type)
     }
   }
 
@@ -107,7 +126,7 @@ extension Term {
   internal var safe: Bool {
     switch self {
     case .slot, .constant: true
-    case .apply, .binary: false
+    case .apply, .binary, .case: false
     }
   }
 }
@@ -272,7 +291,8 @@ internal func value(of literal: Literal) throws(SQLError) -> Value {
 /// arguments, and applies it. The `borrowing` row is non-escaping — a term runs
 /// over a materialised projection record or a predicate's borrowed cursor row.
 internal func evaluate<R: Row & ~Escapable>(_ term: Term, _ row: borrowing R,
-                                            _ routines: Routines)
+                                            _ routines: Routines,
+                                            _ bindings: Bindings = [:])
     throws(SQLError) -> Value {
   switch term {
   case let .slot(slot):
@@ -280,17 +300,52 @@ internal func evaluate<R: Row & ~Escapable>(_ term: Term, _ row: borrowing R,
   case let .constant(value):
     value
   case let .apply(name, arguments):
-    try apply(name, arguments, row, routines)
+    try apply(name, arguments, row, routines, bindings)
   case let .binary(op, lhs, rhs):
-    try op.apply(evaluate(lhs, row, routines), evaluate(rhs, row, routines))
+    try op.apply(evaluate(lhs, row, routines, bindings),
+                 evaluate(rhs, row, routines, bindings))
+  case let .case(branches, otherwise, type):
+    // Take the FIRST branch whose guard is three-valued TRUE (UNKNOWN and FALSE
+    // skip); with none matching, the `else` term, or `NULL` when there is none.
+    // The guard is a `Filter`, so it evaluates over the same row, routines, and
+    // bindings a `WHERE` filter does — a `:parameter` guard resolves against the
+    // bindings, an UNKNOWN one does not select its branch. The selected value is
+    // COERCED to the CASE's unified result `type` so it matches the column type
+    // the schema advertised.
+    try `case`(branches, otherwise, type, row, routines, bindings)
   }
+}
+
+/// Evaluates a lowered `CASE` — its `branches` and optional `otherwise`
+/// term — against `row`, taking the first guard that is TRUE and coercing the
+/// selected value to the CASE's unified result `type`.
+///
+/// The schema advertises the column as `type` — the unification of the branch
+/// result types — yet a branch yields its own raw `Value`, so a `.integer` arm
+/// of a CASE that unifies to `.double` must widen to match. `Value.coerced`
+/// performs that one widening; NULL and an already-matching value pass
+/// unchanged, so an all-same CASE (no widening) is untouched.
+private func `case`<R: Row & ~Escapable>(_ branches: Array<(Filter, Term)>,
+                                         _ otherwise: Term?, _ type: ValueType,
+                                         _ row: borrowing R,
+                                         _ routines: Routines,
+                                         _ bindings: Bindings)
+    throws(SQLError) -> Value {
+  for (gate, result) in branches {
+    if try evaluate(gate, row, routines, bindings) == true {
+      return try evaluate(result, row, routines, bindings).coerced(to: type)
+    }
+  }
+  guard let otherwise else { return .null }
+  return try evaluate(otherwise, row, routines, bindings).coerced(to: type)
 }
 
 /// Resolves `name` in `routines` and applies it to its evaluated `arguments`.
 private func apply<R: Row & ~Escapable>(_ name: String,
                                         _ arguments: Array<Term>,
                                         _ row: borrowing R,
-                                        _ routines: Routines)
+                                        _ routines: Routines,
+                                        _ bindings: Bindings)
     throws(SQLError) -> Value {
   guard let routine = routines[name] else {
     throw .function(name)
@@ -298,7 +353,7 @@ private func apply<R: Row & ~Escapable>(_ name: String,
   var values = Array<Value>()
   values.reserveCapacity(arguments.count)
   for argument in arguments {
-    try values.append(evaluate(argument, row, routines))
+    try values.append(evaluate(argument, row, routines, bindings))
   }
   let result = try routine(values)
   // A registered routine is a public producer of `Value`s that bypasses the
@@ -490,17 +545,18 @@ internal func evaluate<R: Row & ~Escapable>(_ filter: Filter,
     throws(SQLError) -> Bool? {
   switch filter {
   case let .compare(lhs, op, rhs):
-    try matches(evaluate(lhs, row, routines), op, evaluate(rhs, row, routines))
+    try matches(evaluate(lhs, row, routines, bindings), op,
+                evaluate(rhs, row, routines, bindings))
   case let .bound(term, op, parameter):
     if let operand = bindings[parameter] {
-      try matches(evaluate(term, row, routines), op, operand)
+      try matches(evaluate(term, row, routines, bindings), op, operand)
     } else {
       nil
     }
   case let .match(left, right):
     matches(row[left], .equal, row[right])
   case let .null(term, negated):
-    try (evaluate(term, row, routines) == .null) != negated
+    try (evaluate(term, row, routines, bindings) == .null) != negated
   case let .and(lhs, rhs):
     // `&&`/`||` take an `@autoclosure` right operand, which would capture the
     // borrowed `~Escapable` row; spell each connective explicitly so a branch

--- a/Sources/SQL/Filter.swift
+++ b/Sources/SQL/Filter.swift
@@ -284,87 +284,86 @@ internal func value(of literal: Literal) throws(SQLError) -> Value {
   }
 }
 
-/// Evaluates `term` against `row` through `routines`, yielding a typed value.
-///
-/// A `slot` reads the row's cell; a `constant` is itself; an `apply` looks the
-/// function up in the routines (`SQLError.function` on a miss), evaluates its
-/// arguments, and applies it. The `borrowing` row is non-escaping — a term runs
-/// over a materialised projection record or a predicate's borrowed cursor row.
-internal func evaluate<R: Row & ~Escapable>(_ term: Term, _ row: borrowing R,
-                                            _ routines: Routines,
-                                            _ bindings: Bindings = [:])
-    throws(SQLError) -> Value {
-  switch term {
-  case let .slot(slot):
-    row[slot]
-  case let .constant(value):
-    value
-  case let .apply(name, arguments):
-    try apply(name, arguments, row, routines, bindings)
-  case let .binary(op, lhs, rhs):
-    try op.apply(evaluate(lhs, row, routines, bindings),
-                 evaluate(rhs, row, routines, bindings))
-  case let .case(branches, otherwise, type):
-    // Take the FIRST branch whose guard is three-valued TRUE (UNKNOWN and FALSE
-    // skip); with none matching, the `else` term, or `NULL` when there is none.
-    // The guard is a `Filter`, so it evaluates over the same row, routines, and
-    // bindings a `WHERE` filter does — a `:parameter` guard resolves against the
-    // bindings, an UNKNOWN one does not select its branch. The selected value is
-    // COERCED to the CASE's unified result `type` so it matches the column type
-    // the schema advertised.
-    try `case`(branches, otherwise, type, row, routines, bindings)
-  }
-}
-
-/// Evaluates a lowered `CASE` — its `branches` and optional `otherwise`
-/// term — against `row`, taking the first guard that is TRUE and coercing the
-/// selected value to the CASE's unified result `type`.
-///
-/// The schema advertises the column as `type` — the unification of the branch
-/// result types — yet a branch yields its own raw `Value`, so a `.integer` arm
-/// of a CASE that unifies to `.double` must widen to match. `Value.coerced`
-/// performs that one widening; NULL and an already-matching value pass
-/// unchanged, so an all-same CASE (no widening) is untouched.
-private func `case`<R: Row & ~Escapable>(_ branches: Array<(Filter, Term)>,
-                                         _ otherwise: Term?, _ type: ValueType,
-                                         _ row: borrowing R,
-                                         _ routines: Routines,
-                                         _ bindings: Bindings)
-    throws(SQLError) -> Value {
-  for (gate, result) in branches {
-    if try evaluate(gate, row, routines, bindings) == true {
-      return try evaluate(result, row, routines, bindings).coerced(to: type)
+extension Row where Self: ~Escapable {
+  /// Evaluates `term` against this row through `routines`, yielding a typed
+  /// value.
+  ///
+  /// A `slot` reads the row's cell; a `constant` is itself; an `apply` looks
+  /// the function up in the routines (`SQLError.function` on a miss), evaluates
+  /// its arguments, and applies it. The `borrowing` row is non-escaping — a
+  /// term runs over a materialised projection record or a predicate's borrowed
+  /// cursor row.
+  internal borrowing func evaluate(_ term: Term, _ routines: Routines,
+                                   _ bindings: Bindings = [:])
+      throws(SQLError) -> Value {
+    switch term {
+    case let .slot(slot):
+      self[slot]
+    case let .constant(value):
+      value
+    case let .apply(name, arguments):
+      try apply(name, arguments, routines, bindings)
+    case let .binary(op, lhs, rhs):
+      try op.apply(evaluate(lhs, routines, bindings),
+                   evaluate(rhs, routines, bindings))
+    case let .case(branches, otherwise, type):
+      // Take the FIRST branch whose guard is three-valued TRUE (UNKNOWN and
+      // FALSE skip); with none matching, the `else` term, or `NULL` when there
+      // is none. The guard is a `Filter`, so it evaluates over the same row,
+      // routines, and bindings a `WHERE` filter does — a `:parameter` guard
+      // resolves against the bindings, an UNKNOWN one does not select its
+      // branch. The selected value is COERCED to the CASE's unified result
+      // `type` so it matches the column type the schema advertised.
+      try conditional(branches, otherwise, type, routines, bindings)
     }
   }
-  guard let otherwise else { return .null }
-  return try evaluate(otherwise, row, routines, bindings).coerced(to: type)
-}
 
-/// Resolves `name` in `routines` and applies it to its evaluated `arguments`.
-private func apply<R: Row & ~Escapable>(_ name: String,
-                                        _ arguments: Array<Term>,
-                                        _ row: borrowing R,
-                                        _ routines: Routines,
-                                        _ bindings: Bindings)
-    throws(SQLError) -> Value {
-  guard let routine = routines[name] else {
-    throw .function(name)
+  /// Evaluates a lowered `CASE` — its `branches` and optional `otherwise`
+  /// term — against this row, taking the first guard that is TRUE and coercing
+  /// the selected value to the CASE's unified result `type`.
+  ///
+  /// The schema advertises the column as `type` — the unification of the branch
+  /// result types — yet a branch yields its own raw `Value`, so a `.integer`
+  /// arm of a CASE that unifies to `.double` must widen to match.
+  /// `Value.coerced` performs that one widening; NULL and an already-matching
+  /// value pass unchanged, so an all-same CASE (no widening) is untouched.
+  private borrowing func conditional(_ branches: Array<(Filter, Term)>,
+                                     _ otherwise: Term?, _ type: ValueType,
+                                     _ routines: Routines,
+                                     _ bindings: Bindings)
+      throws(SQLError) -> Value {
+    for (gate, result) in branches {
+      if try evaluate(gate, routines, bindings) == true {
+        return try evaluate(result, routines, bindings).coerced(to: type)
+      }
+    }
+    guard let otherwise else { return .null }
+    return try evaluate(otherwise, routines, bindings).coerced(to: type)
   }
-  var values = Array<Value>()
-  values.reserveCapacity(arguments.count)
-  for argument in arguments {
-    try values.append(evaluate(argument, row, routines, bindings))
+
+  /// Resolves `name` in `routines` and applies it to its evaluated `arguments`.
+  private borrowing func apply(_ name: String, _ arguments: Array<Term>,
+                               _ routines: Routines, _ bindings: Bindings)
+      throws(SQLError) -> Value {
+    guard let routine = routines[name] else {
+      throw .function(name)
+    }
+    var values = Array<Value>()
+    values.reserveCapacity(arguments.count)
+    for argument in arguments {
+      try values.append(evaluate(argument, routines, bindings))
+    }
+    let result = try routine(values)
+    // A registered routine is a public producer of `Value`s that bypasses the
+    // literal/arithmetic finite checks; enforce the invariant here so a routine
+    // cannot return `inf`/NaN. NaN in particular is unequal to itself and would
+    // break UNION/CTE dedup and ORDER BY (and stall a recursive UNION at the
+    // cap).
+    if case let .double(number) = result, !number.isFinite {
+      throw .magnitude("function '\(name)' produced a non-finite double")
+    }
+    return result
   }
-  let result = try routine(values)
-  // A registered routine is a public producer of `Value`s that bypasses the
-  // literal/arithmetic finite checks; enforce the invariant here so a routine
-  // cannot return `inf`/NaN. NaN in particular is unequal to itself and would
-  // break UNION/CTE dedup and ORDER BY (and stall a recursive UNION at the
-  // cap).
-  if case let .double(number) = result, !number.isFinite {
-    throw .magnitude("function '\(name)' produced a non-finite double")
-  }
-  return result
 }
 
 // MARK: - Evaluation
@@ -522,60 +521,61 @@ internal func or(_ lhs: Bool?, _ rhs: Bool?) -> Bool? {
   return lhs == false && rhs == false ? false : nil
 }
 
-/// Evaluates `filter` against `row` under three-valued logic, resolving scalar
-/// calls through `routines` and any bound parameter from `bindings`.
-///
-/// The result is `true`, `false`, or `nil` — SQL's UNKNOWN. A `compare`
-/// evaluates both operand terms and matches them — a `NULL` operand making the
-/// comparison UNKNOWN; a `bound` matches the left term against the parameter's
-/// bound value, but an unbound or absent parameter is UNKNOWN (`nil`), not
-/// `false` — a missing binding cannot be inverted into a match by `NOT`. A
-/// `match` tests both cells equal under the same three-valued rule, so a `NULL`
-/// join key matches nothing; a `null` is a definite test of whether its term
-/// is `NULL` (`true`/`false`, never UNKNOWN), negated for `IS NOT NULL`. `AND`
-/// and `OR` follow Kleene logic (`false` dominates `AND`, `true` dominates `OR`,
-/// UNKNOWN otherwise) and `NOT` maps UNKNOWN to itself. The executor admits a
-/// row only when the whole predicate is `true` (its `== true` gate), so UNKNOWN
-/// and `false` both reject. The `borrowing` row is non-escaping; it threads
-/// into the recursion freely and is never stored.
-internal func evaluate<R: Row & ~Escapable>(_ filter: Filter,
-                                            _ row: borrowing R,
-                                            _ routines: Routines,
-                                            _ bindings: Bindings)
-    throws(SQLError) -> Bool? {
-  switch filter {
-  case let .compare(lhs, op, rhs):
-    try matches(evaluate(lhs, row, routines, bindings), op,
-                evaluate(rhs, row, routines, bindings))
-  case let .bound(term, op, parameter):
-    if let operand = bindings[parameter] {
-      try matches(evaluate(term, row, routines, bindings), op, operand)
-    } else {
-      nil
+extension Row where Self: ~Escapable {
+  /// Evaluates `filter` against this row under three-valued logic, resolving
+  /// scalar calls through `routines` and any bound parameter from `bindings`.
+  ///
+  /// The result is `true`, `false`, or `nil` — SQL's UNKNOWN. A `compare`
+  /// evaluates both operand terms and matches them — a `NULL` operand making
+  /// the comparison UNKNOWN; a `bound` matches the left term against the
+  /// parameter's bound value, but an unbound or absent parameter is UNKNOWN
+  /// (`nil`), not `false` — a missing binding cannot be inverted into a match
+  /// by `NOT`. A `match` tests both cells equal under the same three-valued
+  /// rule, so a `NULL` join key matches nothing; a `null` is a definite test of
+  /// whether its term is `NULL` (`true`/`false`, never UNKNOWN), negated for
+  /// `IS NOT NULL`. `AND` and `OR` follow Kleene logic (`false` dominates
+  /// `AND`, `true` dominates `OR`, UNKNOWN otherwise) and `NOT` maps UNKNOWN to
+  /// itself. The executor admits a row only when the whole predicate is `true`
+  /// (its `== true` gate), so UNKNOWN and `false` both reject. The `borrowing`
+  /// row is non-escaping; it threads into the recursion freely and is never
+  /// stored.
+  internal borrowing func evaluate(_ filter: Filter, _ routines: Routines,
+                                   _ bindings: Bindings)
+      throws(SQLError) -> Bool? {
+    switch filter {
+    case let .compare(lhs, op, rhs):
+      try matches(evaluate(lhs, routines, bindings), op,
+                  evaluate(rhs, routines, bindings))
+    case let .bound(term, op, parameter):
+      if let operand = bindings[parameter] {
+        try matches(evaluate(term, routines, bindings), op, operand)
+      } else {
+        nil
+      }
+    case let .match(left, right):
+      matches(self[left], .equal, self[right])
+    case let .null(term, negated):
+      try (evaluate(term, routines, bindings) == .null) != negated
+    case let .and(lhs, rhs):
+      // `&&`/`||` take an `@autoclosure` right operand, which would capture the
+      // borrowed `~Escapable` row; spell each connective explicitly so a branch
+      // re-borrows the row rather than capturing it. Kleene `AND`: `false`
+      // dominates, an UNKNOWN left yields `false` only against a `false` right.
+      switch try evaluate(lhs, routines, bindings) {
+      case false?: false
+      case true?: try evaluate(rhs, routines, bindings)
+      case nil: try evaluate(rhs, routines, bindings) == false ? false : nil
+      }
+    case let .or(lhs, rhs):
+      // Kleene `OR`: `true` dominates, an UNKNOWN left yields `true` only
+      // against a `true` right.
+      switch try evaluate(lhs, routines, bindings) {
+      case true?: true
+      case false?: try evaluate(rhs, routines, bindings)
+      case nil: try evaluate(rhs, routines, bindings) == true ? true : nil
+      }
+    case let .not(operand):
+      try evaluate(operand, routines, bindings).map { !$0 }
     }
-  case let .match(left, right):
-    matches(row[left], .equal, row[right])
-  case let .null(term, negated):
-    try (evaluate(term, row, routines, bindings) == .null) != negated
-  case let .and(lhs, rhs):
-    // `&&`/`||` take an `@autoclosure` right operand, which would capture the
-    // borrowed `~Escapable` row; spell each connective explicitly so a branch
-    // re-borrows the row rather than capturing it. Kleene `AND`: `false`
-    // dominates, an UNKNOWN left yields `false` only against a `false` right.
-    switch try evaluate(lhs, row, routines, bindings) {
-    case false?: false
-    case true?: try evaluate(rhs, row, routines, bindings)
-    case nil: try evaluate(rhs, row, routines, bindings) == false ? false : nil
-    }
-  case let .or(lhs, rhs):
-    // Kleene `OR`: `true` dominates, an UNKNOWN left yields `true` only against
-    // a `true` right.
-    switch try evaluate(lhs, row, routines, bindings) {
-    case true?: true
-    case false?: try evaluate(rhs, row, routines, bindings)
-    case nil: try evaluate(rhs, row, routines, bindings) == true ? true : nil
-    }
-  case let .not(operand):
-    try evaluate(operand, row, routines, bindings).map { !$0 }
   }
 }

--- a/Sources/SQL/Function.swift
+++ b/Sources/SQL/Function.swift
@@ -157,7 +157,7 @@ public struct Routine: Sendable {
           where !argument.matches(expected) {
         throw .argument("requires \(expected.domain) arguments")
       }
-      return try evaluate(term, Record(arguments), routines)
+      return try Record(arguments).evaluate(term, routines)
     }
   }
 }

--- a/Sources/SQL/Function.swift
+++ b/Sources/SQL/Function.swift
@@ -95,6 +95,15 @@ public struct Routine: Sendable {
   internal init(returns: ValueType, parameters: Array<ValueType>,
                 names: Array<String>, body: Expression,
                 _ routines: Routines) throws(SQLError) {
+    // A body's inputs are its declared parameters, not query bindings: it is
+    // validated over the parameter schema and later evaluated against ONLY the
+    // argument record, so a `:parameter` reference (reachable through a `CASE`
+    // guard) would always be UNBOUND at call time — the caller's `bindings`
+    // never reach a routine body — and silently pick the wrong branch. Reject
+    // a `.bound` anywhere in the body at registration rather than lowering it.
+    guard !body.bound else {
+      throw .argument("the body cannot reference a query parameter")
+    }
     let schema = Schema(width: names.count, extent: names.count,
                         names: names, types: parameters, virtuals: [])
     let scope = Scope([(Relation(name: ""), schema)])
@@ -106,7 +115,8 @@ public struct Routine: Sendable {
     self.parameters = parameters
     self.returns = returns
     self.body =
-        try .defined(schema.term(body, in: Relation(name: "")), routines)
+        try .defined(schema.term(body, in: Relation(name: ""), routines),
+                     routines)
   }
 
   /// Computes the cell value for the evaluated `arguments`, resolving a defined

--- a/Sources/SQL/Lexer.swift
+++ b/Sources/SQL/Lexer.swift
@@ -426,6 +426,11 @@ internal struct Lexer: ~Escapable {
     case "RECURSIVE": .recursive
     case "TRUE": .true
     case "FALSE": .false
+    case "CASE": .case
+    case "WHEN": .when
+    case "THEN": .then
+    case "ELSE": .else
+    case "END": .end
     default: .identifier(text)
     }
     return Token(kind: kind, location: start)

--- a/Sources/SQL/Lexer.swift
+++ b/Sources/SQL/Lexer.swift
@@ -419,6 +419,7 @@ internal struct Lexer: ~Escapable {
     case "AS": .as
     case "IS": .is
     case "NULL": .null
+    case "IN": .in
     case "UNION": .union
     case "ALL": .all
     case "WITH": .with

--- a/Sources/SQL/Operator.swift
+++ b/Sources/SQL/Operator.swift
@@ -343,7 +343,7 @@ internal func execute<C: Catalog & ~Escapable>(_ plan: Plan,
     return deduplicated(try execute(source, catalog, context))
   case let .aggregate(keys, aggregates, source):
     return try grouped(execute(source, catalog, context), keys,
-                       aggregates, routines)
+                       aggregates, routines, bindings)
   case let .limit(count, offset, source):
     return limited(try execute(source, catalog, context), count, offset)
   }
@@ -408,7 +408,7 @@ private func project(_ terms: Array<Term>, _ record: Record,
   var cells = Array<Value>()
   cells.reserveCapacity(terms.count)
   for term in terms {
-    try cells.append(evaluate(term, record, routines, bindings))
+    try cells.append(record.evaluate(term, routines, bindings))
   }
   return Record(cells)
 }
@@ -421,7 +421,7 @@ private func admitted(_ records: Array<Record>, _ filter: Filter,
     throws(SQLError) -> Array<Record> {
   var kept = Array<Record>()
   for record in records {
-    if try evaluate(filter, record, routines, bindings) == true {
+    if try record.evaluate(filter, routines, bindings) == true {
       kept.append(record)
     }
   }
@@ -520,7 +520,7 @@ private func sift(_ outer: Array<Record>, _ inner: Array<Record>,
   for left in outer {
     for right in inner {
       let record = left.merged(with: right)
-      if try evaluate(filter, record, routines, bindings) == true {
+      if try record.evaluate(filter, routines, bindings) == true {
         records.append(record)
       }
     }
@@ -617,7 +617,7 @@ private func join<C: Catalog & ~Escapable>(_ outer: Array<Record>,
     for index in 0 ..< cte.rows.count {
       let right = cte.record(index, ordinals)
       if let filter,
-          try evaluate(filter, right, routines, bindings) != true { continue }
+          try right.evaluate(filter, routines, bindings) != true { continue }
       inner.append(right)
     }
     return joined(outer, inner, base, keys)
@@ -647,7 +647,7 @@ private func join<C: Catalog & ~Escapable>(_ outer: Array<Record>,
       // A pushed inner filter is applied as each candidate materialises, before
       // it can pair — an inner row it rejects joins to nothing.
       if let filter,
-          try evaluate(filter, right, routines, bindings) != true { continue }
+          try right.evaluate(filter, routines, bindings) != true { continue }
       // Equal by the SAME rule the predicate uses — integer/integer exact,
       // mixed integer/double promoted — so a seek that scanned wide still pairs
       // exactly.
@@ -710,7 +710,7 @@ private func hashed<T: Table & ~Escapable>(_ outer: Array<Record>,
     // Apply the whole pushed filter before bucketing — a filtered inner row is
     // never a join candidate.
     if let filter,
-        try evaluate(filter, right, routines, bindings) != true { continue }
+        try right.evaluate(filter, routines, bindings) != true { continue }
     if case .null = right[slot] { continue }
     buckets[bucket(right[slot]), default: Array<Record>()].append(right)
   }

--- a/Sources/SQL/Operator.swift
+++ b/Sources/SQL/Operator.swift
@@ -310,7 +310,9 @@ internal func execute<C: Catalog & ~Escapable>(_ plan: Plan,
                         routines, bindings)
   case let .project(terms, source):
     return try execute(source, catalog, context)
-      .map { record throws(SQLError) in try project(terms, record, routines) }
+      .map { record throws(SQLError) in
+        try project(terms, record, routines, bindings)
+      }
   case let .sort(keys, source):
     return try execute(source, catalog, context)
       .enumerated()
@@ -401,11 +403,12 @@ private func deduplicated(_ records: Array<Record>) -> Array<Record> {
 /// Evaluates each projected `term` against `record` through `routines` to the
 /// output row, in order — slot `i` of the result is `terms[i]`.
 private func project(_ terms: Array<Term>, _ record: Record,
-                     _ routines: Routines) throws(SQLError) -> Record {
+                     _ routines: Routines, _ bindings: Bindings)
+    throws(SQLError) -> Record {
   var cells = Array<Value>()
   cells.reserveCapacity(terms.count)
   for term in terms {
-    try cells.append(evaluate(term, record, routines))
+    try cells.append(evaluate(term, record, routines, bindings))
   }
   return Record(cells)
 }

--- a/Sources/SQL/Parser.swift
+++ b/Sources/SQL/Parser.swift
@@ -38,7 +38,10 @@
 /// expression     := additive
 /// additive       := multiplicative (('+' | '-') multiplicative)*
 /// multiplicative := factor (('*' | '/') factor)*
-/// factor         := '(' expression ')' | literal | aggregate | call | column
+/// factor         := '(' expression ')' | case
+///                 | literal | aggregate | call | column
+/// case           := CASE [expression] (WHEN (predicate | expression) THEN
+///                     expression)+ [ELSE expression] END
 /// literal        := string | integer | decimal | TRUE | FALSE | blob
 /// blob           := ('x' | 'X') "'" (hex hex)* "'"  // whole bytes
 /// aggregate      := COUNT '(' '*' ')'
@@ -495,6 +498,9 @@ internal struct Parser: ~Escapable {
       try expect(.rparen)
       return expression
     }
+    if current?.kind == .case {
+      return try conditional()
+    }
     if case let .string(value) = current?.kind {
       _ = try advance(expecting: "a literal")
       return .literal(.string(value))
@@ -574,6 +580,41 @@ internal struct Parser: ~Escapable {
     }
     try expect(.rparen)
     return operand
+  }
+
+  /// Parses a `CASE` expression (the `CASE` is the next token) into the searched
+  /// `Expression.case`, admitting both ISO forms.
+  ///
+  /// A `WHEN` directly after `CASE` is the SEARCHED form — each `WHEN` a full
+  /// predicate. An expression after `CASE` is the SIMPLE form's operand — each
+  /// `WHEN value` is normalised to the equality `operand = value`, so both forms
+  /// share one searched AST. At least one `WHEN` is required; an optional `ELSE`
+  /// gives the no-branch result (absent, the result is `NULL`); the whole is
+  /// closed by `END`.
+  private mutating func conditional() throws(SQLError) -> Expression {
+    try expect(.case)
+    let operand: Expression? = current?.kind == .when ? nil
+                                                       : try expression()
+
+    var whens = Array<When>()
+    repeat {
+      try expect(.when)
+      let when: Predicate = if let operand {
+        try .comparison(left: operand, op: .equal, right: expression())
+      } else {
+        try predicate()
+      }
+      try expect(.then)
+      try whens.append(When(when: when, then: expression()))
+    } while current?.kind == .when
+
+    let otherwise: Expression? = if try match(.else) {
+      try expression()
+    } else {
+      nil
+    }
+    try expect(.end)
+    return .case(whens, else: otherwise)
   }
 
   // MARK: - Predicate

--- a/Sources/SQL/Parser.swift
+++ b/Sources/SQL/Parser.swift
@@ -33,7 +33,8 @@
 /// conjunction    := negation (AND negation)*
 /// negation       := NOT negation | primary
 /// primary        := '(' predicate ')' | comparison
-/// comparison     := expression (op (expression | param) | IS [NOT] NULL)
+/// comparison     := expression (op (expression | param) | IS [NOT] NULL
+///                 | [NOT] IN '(' expression (',' expression)* ')')
 /// expression     := additive
 /// additive       := multiplicative (('+' | '-') multiplicative)*
 /// multiplicative := factor (('*' | '/') factor)*
@@ -633,20 +634,31 @@ internal struct Parser: ~Escapable {
     return predicate
   }
 
-  /// Parses `expression (op (expression | :parameter) | IS [NOT] NULL)`.
+  /// Parses `expression (op (expression | :parameter) | IS [NOT] NULL | [NOT]
+  /// IN '(' expression (',' expression)* ')')`.
   ///
   /// Either operand may be a column, a literal, or a scalar-function call, so a
   /// predicate can filter on a decoded value (`WHERE guid(Id) = '…'`). A
   /// `:parameter` right operand binds the comparison to a value resolved at run
   /// time from the engine's bindings — the correlated-subquery primitive. An
   /// `IS NULL` (or `IS NOT NULL`) tail tests the left expression for `NULL`
-  /// rather than comparing it — the way a nullable column is filtered.
+  /// rather than comparing it — the way a nullable column is filtered. An `IN`
+  /// (or `NOT IN`) tail tests the left expression for membership in a
+  /// parenthesised value list. A leading `NOT` here can only introduce `NOT IN`:
+  /// a prefix `NOT` predicate is consumed by `negation` before this point.
   private mutating func comparison() throws(SQLError) -> Predicate {
     let left = try expression()
     if try match(.is) {
       let negated = try match(.not)
       try expect(.null)
       return .null(left, negated: negated)
+    }
+    if try match(.in) {
+      return try membership(left, negated: false)
+    }
+    if try match(.not) {
+      try expect(.in)
+      return try membership(left, negated: true)
     }
     let op = try op()
     if case let .parameter(name) = current?.kind {
@@ -655,6 +667,24 @@ internal struct Parser: ~Escapable {
     }
     let right = try expression()
     return .comparison(left: left, op: op, right: right)
+  }
+
+  /// Parses the value-list tail of `left [NOT] IN (…)` — the `IN` is already
+  /// consumed — into a `membership` predicate over `left`.
+  ///
+  /// The list is parenthesised and non-empty: at least one value expression,
+  /// then any number of comma-separated ones. The subquery form `IN (SELECT …)`
+  /// is not supported, so the parenthesised items are ordinary scalar
+  /// expressions.
+  private mutating func membership(_ left: Expression, negated: Bool)
+      throws(SQLError) -> Predicate {
+    try expect(.lparen)
+    var values = [try expression()]
+    while try match(.comma) {
+      try values.append(expression())
+    }
+    try expect(.rparen)
+    return .membership(left, values, negated: negated)
   }
 
   /// Parses a comparison operator.

--- a/Sources/SQL/Resolve.swift
+++ b/Sources/SQL/Resolve.swift
@@ -36,6 +36,14 @@ private func lower(_ predicate: Predicate,
     try .bound(term(left), op, parameter)
   case let .null(expression, negated):
     try .null(term(expression), negated: negated)
+  case let .membership(expression, values, negated):
+    // `x IN (a, b, …)` is the disjunction `x = a OR x = b OR …` and `NOT IN`
+    // its negation, so lowering to that OR-chain (over the shared comparison
+    // machinery) yields the ISO three-valued result: an unmatched test with a
+    // NULL operand or a NULL element is UNKNOWN — Kleene `OR` of a FALSE and an
+    // UNKNOWN is UNKNOWN — not FALSE, and `NOT` maps that UNKNOWN to itself, so
+    // `NOT IN` a list holding NULL is never TRUE.
+    try membership(term(expression), values, negated: negated, term: term)
   case let .and(lhs, rhs):
     try .and(lower(lhs, term: term), lower(rhs, term: term))
   case let .or(lhs, rhs):
@@ -43,6 +51,33 @@ private func lower(_ predicate: Predicate,
   case let .not(operand):
     try .not(lower(operand, term: term))
   }
+}
+
+/// Lowers `x [NOT] IN (v, …)` — the operand already lowered to `left` — to the
+/// disjunction `left = v0 OR left = v1 OR …`, negated for `NOT IN`, each value
+/// lowered through `term`.
+///
+/// The value list must be non-empty: the parser rejects `IN ()`, but
+/// `Predicate.membership` is public, so a caller can hand this lowering an
+/// empty list directly, bypassing the grammar. An empty list has no OR-chain
+/// seed — the disjunction is undefined — so reject it as an unsupported shape
+/// rather than folding it. The left-leaning fold matches the parser's own `OR`
+/// association; the three-valued `OR` of the comparisons gives the ISO
+/// membership semantics, and the outer `NOT` the `NOT IN` negation.
+private func membership(_ left: Term, _ values: Array<Expression>,
+                        negated: Bool,
+                        term: (Expression) throws(SQLError) -> Term)
+    throws(SQLError) -> Filter {
+  guard !values.isEmpty else {
+    throw .unsupported("IN requires a non-empty value list")
+  }
+  var filter: Filter? = nil
+  for value in values {
+    let equality = try Filter.compare(left, .equal, term(value))
+    filter = if let filter { .or(filter, equality) } else { equality }
+  }
+  let disjunction = filter!
+  return negated ? .not(disjunction) : disjunction
 }
 
 /// The resolved sort keys `order` lowers to, in major-to-minor order — each
@@ -439,6 +474,35 @@ internal struct Scope {
       break
     case let .null(operand, _):
       _ = try validate(operand, routines)
+    case let .membership(operand, values, _):
+      // `x IN (v, …)` lowers to `x = v OR …`, so type it as those comparisons:
+      // validate the operand and each value, and require each value COMPARABLE
+      // to the operand — a definitively cross-kind element (text in an integer
+      // list) can never match, so reject it up front as a run's comparison
+      // would silently never match. The comparability rule is `matches`'s: like
+      // types, or two numerics.
+      //
+      // The OR-chain short-circuits: a DEFINITE constant match (`x = v` folds
+      // TRUE, both literals) makes the whole `IN` TRUE and leaves every later
+      // element unreachable, so validation stops there — `1 IN (1, Name + 1)`
+      // type-checks, the run matching `1 = 1` before ever reaching `Name + 1`,
+      // while `2 IN (1, Name + 1)` (no definite match) still validates `Name + 1`
+      // and faults. `matched(operand, value)` is the fold's own primitive.
+      //
+      // An empty list has no OR-chain and cannot be lowered (`lower` would have
+      // no seed), so reject it here too — the parser rejects `IN ()`, but a
+      // caller can build `.membership(_, [], …)` directly, so this validation
+      // faults on that shape rather than typing it as an always-false chain.
+      guard !values.isEmpty else {
+        throw .unsupported("IN requires a non-empty value list")
+      }
+      let type = try validate(operand, routines)
+      _ = try membership(of: values, each: { value throws(SQLError) in
+        let element = try validate(value, routines)
+        guard type.comparable(with: element) else {
+          throw .operand("IN list element is not comparable to the operand")
+        }
+      }, equality: { value throws(SQLError) in matched(operand, value) })
     case let .and(lhs, rhs):
       try check(lhs, routines)
       if constant(lhs) != false { try check(rhs, routines) }
@@ -448,6 +512,51 @@ internal struct Scope {
     case let .not(operand):
       try check(operand, routines)
     }
+  }
+
+  /// The definite truth of the equality `operand = value` when BOTH are literals
+  /// — the OR-chain equality an `IN` element folds to — else `nil` (a non-literal
+  /// side is decided per row). It folds through `value(of:)` and `matches`, the
+  /// same primitives the run compares with, so a `true` here is a definite match
+  /// that short-circuits the chain.
+  private func matched(_ operand: Expression, _ value: Expression) -> Bool? {
+    guard case let .literal(operand) = operand,
+        case let .literal(value) = value,
+        let lhs = try? SQL.value(of: operand),
+        let rhs = try? SQL.value(of: value) else {
+      return nil
+    }
+    return matches(lhs, .equal, rhs)
+  }
+
+  /// Folds an `IN` value list as its OR-chain of `operand = element` equalities,
+  /// honouring the executor's SHORT-CIRCUIT: the elements are visited in order,
+  /// each mapped to its three-valued equality truth by `equality`, and the truths
+  /// are OR-folded — but a definite `true` stops the walk, since the OR-chain
+  /// matches there and every LATER element is unreachable (`Row.matches` returns
+  /// on the first true arm). This is the ONE short-circuit the `IN`
+  /// type-check (`check`), constant fold (`constant`), and empty-group evaluator
+  /// (`empty`) all share: each supplies the per-element `equality` its surface
+  /// computes with, and every surface stops at the same element the run does.
+  ///
+  /// `visit` runs on each element BEFORE its truth is taken, so a surface with a
+  /// per-element side effect (validation) applies it to exactly the reachable
+  /// prefix. The fold seeds FALSE (an empty match is FALSE), so the returned
+  /// truth is the disjunction over the visited prefix.
+  private func membership<E: Error>(
+      of elements: Array<Expression>,
+      each visit: (Expression) throws(E) -> Void = { (_: Expression) in },
+      equality: (Expression) throws(E) -> Bool?)
+      throws(E) -> Bool? {
+    var truth: Bool? = false
+    for element in elements {
+      try visit(element)
+      truth = or(truth, try equality(element))
+      // A definite match makes every LATER element unreachable — the OR-chain
+      // short-circuits here, exactly as the run does.
+      if truth == true { break }
+    }
+    return truth
   }
 
   /// The definite constant truth value of `predicate` when it is statically
@@ -477,6 +586,17 @@ internal struct Scope {
       // NULL` (`negated`) definitely true; a non-literal operand is per row.
       guard case .literal = operand else { return nil }
       return negated
+    case let .membership(operand, values, negated):
+      // Fold `x IN (…)` exactly as its OR-chain of equalities folds — the same
+      // primitives (`value(of:)`, `matches`, `membership`'s short-circuit) —
+      // honouring the OR-chain's short-circuit: once a LITERAL element definitely
+      // equals the literal operand the fold is `true`, so a later non-literal
+      // element (which alone would make the fold per-row `nil`) is unreachable
+      // and does not spoil it — `1 IN (1, Name + 1)` folds `true`. Absent a
+      // decisive match, any non-literal element makes it per row (`nil`). `NOT
+      // IN` negates the folded truth (UNKNOWN maps to itself).
+      let truth = membership(of: values) { value in matched(operand, value) }
+      return negated ? truth.map { !$0 } : truth
     case .bound:
       return nil
     }
@@ -520,6 +640,9 @@ internal struct Scope {
       try aggregates(in: left, routines)
     case let .null(operand, _):
       try aggregates(in: operand, routines)
+    case let .membership(operand, values, _):
+      try aggregates(in: operand, routines)
+      for value in values { try aggregates(in: value, routines) }
     case let .and(lhs, rhs), let .or(lhs, rhs):
       try aggregates(in: lhs, routines)
       try aggregates(in: rhs, routines)
@@ -587,6 +710,18 @@ internal struct Scope {
       let value = try empty(operand, routines)
       let null = if case .null = value { true } else { false }
       return negated ? !null : null
+    case let .membership(operand, values, negated):
+      // Fold `x IN (…)` over the empty group as its OR-chain of equalities does
+      // — the folded operand matched against each folded element under
+      // three-valued `OR`, honouring the OR-chain's short-circuit (`membership`):
+      // the run stops at the first TRUE comparison and never evaluates a later
+      // element, so `1 IN (1, 1 / 0)` folds `true` here without folding `1 / 0`
+      // to a `.divide` fault. Negated for `NOT IN`.
+      let lhs = try empty(operand, routines)
+      let truth = try membership(of: values) { value throws(SQLError) in
+        matches(lhs, .equal, try empty(value, routines))
+      }
+      return negated ? truth.map { !$0 } : truth
     case let .and(lhs, rhs):
       // A `false` left proves the `AND` false without folding the right arm,
       // which a run's short-circuit never evaluates and so must not fault.

--- a/Sources/SQL/Resolve.swift
+++ b/Sources/SQL/Resolve.swift
@@ -122,7 +122,8 @@ extension Schema {
   /// bare-column list yields one `.slot(ordinal)` per column; an expression list
   /// lowers each expression to a term. The terms hold ordinals, which the
   /// engine remaps to slots after gathering the referenced ones.
-  internal func terms(_ projection: Projection, in relation: Relation)
+  internal func terms(_ projection: Projection, in relation: Relation,
+                      _ routines: Routines = [:])
       throws(SQLError) -> Array<Term> {
     switch projection {
     case .all:
@@ -138,7 +139,7 @@ extension Schema {
       var terms = Array<Term>()
       terms.reserveCapacity(projected.count)
       for item in projected {
-        try terms.append(term(item.expression, in: relation))
+        try terms.append(term(item.expression, in: relation, routines))
       }
       return terms
     }
@@ -147,7 +148,8 @@ extension Schema {
   /// Lowers a scalar `expression` to an ordinal-addressed `Term`: a column to a
   /// `.slot(ordinal)`, a literal to a `.constant`, a call to an `.apply` over
   /// its lowered arguments.
-  internal func term(_ expression: Expression, in relation: Relation)
+  internal func term(_ expression: Expression, in relation: Relation,
+                     _ routines: Routines = [:])
       throws(SQLError) -> Term {
     switch expression {
     case let .column(column):
@@ -158,11 +160,33 @@ extension Schema {
       var lowered = Array<Term>()
       lowered.reserveCapacity(arguments.count)
       for argument in arguments {
-        try lowered.append(term(argument, in: relation))
+        try lowered.append(term(argument, in: relation, routines))
       }
       return .apply(name: name, arguments: lowered)
     case let .binary(op, lhs, rhs):
-      return try .binary(op, term(lhs, in: relation), term(rhs, in: relation))
+      return try .binary(op, term(lhs, in: relation, routines),
+                         term(rhs, in: relation, routines))
+    case let .case(whens, otherwise):
+      // Lower each branch's guard predicate to a `Filter` and its result to a
+      // `Term`, and the `ELSE` to a `Term`, over this relation's resolution.
+      var branches = Array<(Filter, Term)>()
+      branches.reserveCapacity(whens.count)
+      for branch in whens {
+        let gate = try lower(branch.when, in: relation, routines)
+        try branches.append((gate, term(branch.then, in: relation, routines)))
+      }
+      let fallback: Term? = if let otherwise {
+        try term(otherwise, in: relation, routines)
+      } else {
+        nil
+      }
+      // Attach the unified result type — the same `ValueType.unified` reduction
+      // `derive`/`validate` compute — so the executor COERCES the selected
+      // branch's value to the type the schema advertises. Derive it against a
+      // one-relation scope, this Schema's own resolution surface.
+      let scope = Scope([(relation, self)])
+      let type = try scope.deriveCase(whens, otherwise, routines)
+      return .case(branches, else: fallback, type: type)
     case .aggregate:
       // An aggregate has no per-row meaning — it folds over a group — so it may
       // not appear in a `WHERE`, a join `ON`, or a non-aggregate projection.
@@ -179,10 +203,11 @@ extension Schema {
     }
   }
 
-  internal func lower(_ predicate: Predicate, in relation: Relation)
+  internal func lower(_ predicate: Predicate, in relation: Relation,
+                      _ routines: Routines = [:])
       throws(SQLError) -> Filter {
     try SQL.lower(predicate) { expression throws(SQLError) in
-      try term(expression, in: relation)
+      try term(expression, in: relation, routines)
     }
   }
 }
@@ -311,7 +336,56 @@ internal struct Scope {
     case let .binary(_, lhs, rhs):
       try [derive(lhs, routines), derive(rhs, routines)].contains(.double)
           ? .double : .integer
+    case let .case(whens, otherwise):
+      // The result type is the unification of every REACHABLE branch result (and
+      // the `ELSE`) — the executor's short-circuit means an unreachable branch
+      // (a constant-false guard, or any branch after a constant-true one) never
+      // yields a value, so it cannot shape the column's type. This is the
+      // non-faulting surface, so an irreconcilable clash falls back to the first
+      // reachable result's type rather than faulting — `validate` reports the
+      // clash. A `CASE` always has at least one `WHEN`; when none is reachable
+      // (every guard constant-false, no reachable `ELSE`) the run yields NULL,
+      // for which `.integer` is the schema default.
+      try deriveCase(whens, otherwise, routines)
     }
+  }
+
+  /// The nominal type of a `CASE` under `derive` — the unification of its
+  /// REACHABLE result types, defaulting to the first when they do not unify, and
+  /// `.integer` when no branch is reachable (the run yields NULL).
+  internal func deriveCase(_ whens: Array<When>, _ otherwise: Expression?,
+                           _ routines: Routines)
+      throws(SQLError) -> ValueType {
+    let results = reachable(whens, otherwise)
+    guard !results.isEmpty else { return .integer }
+    var type = try derive(results[0], routines)
+    for result in results.dropFirst() {
+      type = try type.unified(with: derive(result, routines)) ?? type
+    }
+    return type
+  }
+
+  /// The result expressions of a `CASE` the executor's short-circuit can REACH,
+  /// in branch order: a `WHEN` whose guard is statically constant-FALSE has an
+  /// unreachable result and is dropped; a `WHEN` whose guard is statically
+  /// constant-TRUE is itself reachable and keeps every EARLIER reachable branch
+  /// (a row an earlier row-dependent guard matches takes that branch, never
+  /// reaching this one), but makes every STRICTLY-LATER `WHEN` and the `ELSE`
+  /// unreachable; an `ELSE` is reachable only when no guard is constant-TRUE. A
+  /// guard that is not statically decidable (`constant` is `nil`) leaves its
+  /// result reachable.
+  private func reachable(_ whens: Array<When>, _ otherwise: Expression?)
+      -> Array<Expression> {
+    var results = Array<Expression>()
+    for branch in whens {
+      switch constant(branch.when) {
+      case false: continue
+      case true: results.append(branch.then); return results
+      case nil: results.append(branch.then)
+      }
+    }
+    if let otherwise { results.append(otherwise) }
+    return results
   }
 
   /// The value type a scalar `expression` yields, VALIDATING each operand and
@@ -339,7 +413,61 @@ internal struct Scope {
       try aggregate(function, over: operand, routines)
     case let .binary(op, lhs, rhs):
       try arithmetic(op, lhs, rhs, routines)
+    case let .case(whens, otherwise):
+      try conditional(whens, otherwise, routines)
     }
+  }
+
+  /// The result type of a `CASE`, validating each REACHABLE branch as a run
+  /// would fault and honouring the executor's short-circuit: each evaluated
+  /// `WHEN` guard is a boolean predicate whose operands are validated (`check`);
+  /// only a REACHABLE result expression is validated; and the reachable result
+  /// types must UNIFY to one type (`ValueType.unified`) — a
+  /// definitively-irreconcilable pair (a text result beside an integer one)
+  /// faults `SQLError.operand`, as a query cannot yield a column of two kinds. A
+  /// mixed integer/double `CASE` widens to `double`.
+  ///
+  /// The executor takes the first TRUE guard's result and never evaluates a
+  /// later branch, so a `WHEN` whose guard is statically constant-FALSE has an
+  /// unreachable result — its operands are NOT validated (`CASE WHEN 1 = 0 THEN
+  /// Name + 1 ELSE 0 END` type-checks). A constant-TRUE guard is itself
+  /// reachable and KEEPS every earlier reachable branch — a row an earlier
+  /// row-dependent guard matches takes that branch, never reaching the
+  /// constant-TRUE one — so those earlier results are still validated (`CASE WHEN
+  /// Id = 1 THEN Name + 1 WHEN 1 = 1 THEN 0 END` faults on the reachable `Id = 1`
+  /// branch's `Name + 1`); it makes only every STRICTLY-LATER guard, result, and
+  /// the `ELSE` unreachable. A REACHABLE bad operand (`WHEN Id = 1 THEN Name +
+  /// 1`) still faults. When no branch is reachable the run yields NULL, typed
+  /// `.integer` (the schema default), with no result to validate.
+  private func conditional(_ whens: Array<When>, _ otherwise: Expression?,
+                           _ routines: Routines)
+      throws(SQLError) -> ValueType {
+    var results = Array<Expression>()
+    var decided = false
+    for branch in whens {
+      // The guard up to (and including) the decisive one is evaluated, so
+      // validate its operands; a constant-FALSE guard's result is unreachable
+      // (skip it), a constant-TRUE one is reachable but makes every LATER branch
+      // unreachable — so keep the earlier results and this one, then stop.
+      try check(branch.when, routines)
+      switch constant(branch.when) {
+      case false: continue
+      case true: results.append(branch.then); decided = true
+      case nil: results.append(branch.then)
+      }
+      if decided { break }
+    }
+    if !decided, let otherwise { results.append(otherwise) }
+    guard !results.isEmpty else { return .integer }
+    var type = try validate(results[0], routines)
+    for result in results.dropFirst() {
+      let next = try validate(result, routines)
+      guard let unified = type.unified(with: next) else {
+        throw .operand("CASE results have irreconcilable types")
+      }
+      type = unified
+    }
+    return type
   }
 
   /// The result type of the scalar routine `name` called over `arguments`,
@@ -621,6 +749,12 @@ internal struct Scope {
     case let .binary(_, lhs, rhs):
       try aggregates(in: lhs, routines)
       try aggregates(in: rhs, routines)
+    case let .case(whens, otherwise):
+      for branch in whens {
+        try aggregates(in: branch.when, routines)
+        try aggregates(in: branch.then, routines)
+      }
+      if let otherwise { try aggregates(in: otherwise, routines) }
     }
   }
 
@@ -686,6 +820,21 @@ internal struct Scope {
         throw .magnitude("function '\(name)' produced a non-finite double")
       }
       return result
+    case let .case(whens, otherwise):
+      // Evaluate the `CASE` over the empty group exactly as a run does: the
+      // first branch whose guard folds TRUE (`empty(predicate)`) yields its
+      // result, else the `ELSE`, else `NULL`. A skipped branch's result never
+      // folds, so it cannot fault. The selected value is COERCED to the CASE's
+      // unified result type (`deriveCase`), just as the executor's
+      // `Row.conditional` widens it — an `.integer` arm of a CASE that unifies
+      // to `.double` folds to `.double`, so the empty group matches the
+      // advertised column type. NULL (a no-match, no-ELSE fold) passes through.
+      let type = try deriveCase(whens, otherwise, routines)
+      for branch in whens where try empty(branch.when, routines) == true {
+        return try empty(branch.then, routines).coerced(to: type)
+      }
+      guard let otherwise else { return .null }
+      return try empty(otherwise, routines).coerced(to: type)
     case .column:
       return .null
     }
@@ -768,7 +917,8 @@ internal struct Scope {
   /// for `*` (in chain order, never a virtual column) as `.slot` terms, a
   /// bare-column list as `.slot` terms at their combined ordinals, an expression
   /// list as lowered terms — in source order.
-  internal func terms(_ projection: Projection) throws(SQLError)
+  internal func terms(_ projection: Projection,
+                      _ routines: Routines = [:]) throws(SQLError)
       -> Array<Term> {
     switch projection {
     case .all:
@@ -792,14 +942,15 @@ internal struct Scope {
       var terms = Array<Term>()
       terms.reserveCapacity(projected.count)
       for item in projected {
-        try terms.append(term(item.expression))
+        try terms.append(term(item.expression, routines))
       }
       return terms
     }
   }
 
   /// Lowers a scalar `expression` to a combined-ordinal `Term`.
-  internal func term(_ expression: Expression) throws(SQLError) -> Term {
+  internal func term(_ expression: Expression,
+                     _ routines: Routines = [:]) throws(SQLError) -> Term {
     switch expression {
     case let .column(column):
       return try .slot(ordinal(of: column))
@@ -809,11 +960,30 @@ internal struct Scope {
       var lowered = Array<Term>()
       lowered.reserveCapacity(arguments.count)
       for argument in arguments {
-        try lowered.append(term(argument))
+        try lowered.append(term(argument, routines))
       }
       return .apply(name: name, arguments: lowered)
     case let .binary(op, lhs, rhs):
-      return try .binary(op, term(lhs), term(rhs))
+      return try .binary(op, term(lhs, routines), term(rhs, routines))
+    case let .case(whens, otherwise):
+      // Lower each branch's guard to a combined-ordinal `Filter` and its result
+      // to a `Term`, and the `ELSE` to a `Term`, across the join chain.
+      var branches = Array<(Filter, Term)>()
+      branches.reserveCapacity(whens.count)
+      for branch in whens {
+        try branches.append((lower(branch.when, routines),
+                             term(branch.then, routines)))
+      }
+      let fallback: Term? = if let otherwise {
+        try term(otherwise, routines)
+      } else {
+        nil
+      }
+      // Attach the unified result type — the same `ValueType.unified` reduction
+      // `derive`/`validate` compute — so the executor COERCES the selected
+      // branch's value to the type the schema advertises.
+      let type = try deriveCase(whens, otherwise, routines)
+      return .case(branches, else: fallback, type: type)
     case .aggregate:
       // An aggregate has no per-row meaning — it folds over a group — so it may
       // not appear in a `WHERE`, a join `ON`, or a non-aggregate projection.
@@ -840,9 +1010,10 @@ internal struct Scope {
 
   /// Lowers the name-addressed AST `predicate` to the engine's `Filter`, each
   /// column reference resolved to a combined ordinal across the chain.
-  internal func lower(_ predicate: Predicate) throws(SQLError) -> Filter {
+  internal func lower(_ predicate: Predicate,
+                      _ routines: Routines = [:]) throws(SQLError) -> Filter {
     try SQL.lower(predicate) { expression throws(SQLError) in
-      try term(expression)
+      try term(expression, routines)
     }
   }
 }
@@ -917,7 +1088,8 @@ internal struct Grouping {
   /// `call`/`binary` recurses over its operands; a bare column maps to its key
   /// slot only when it is a `GROUP BY` key, else it is `SQLError.grouping` — the
   /// standard rule.
-  private func term(_ expression: Expression) throws(SQLError) -> Term {
+  private func term(_ expression: Expression,
+                    _ routines: Routines = [:]) throws(SQLError) -> Term {
     if case .aggregate = expression, let slot = slot(of: expression) {
       return .slot(slot)
     }
@@ -932,11 +1104,31 @@ internal struct Grouping {
       var lowered = Array<Term>()
       lowered.reserveCapacity(arguments.count)
       for argument in arguments {
-        try lowered.append(term(argument))
+        try lowered.append(term(argument, routines))
       }
       return .apply(name: name, arguments: lowered)
     case let .binary(op, lhs, rhs):
-      return try .binary(op, term(lhs), term(rhs))
+      return try .binary(op, term(lhs, routines), term(rhs, routines))
+    case let .case(whens, otherwise):
+      // Lower each branch's guard and result, and the `ELSE`, against the
+      // grouped slot space — a bare column in any of them must be a `GROUP BY`
+      // key, an aggregate its result slot, as elsewhere in a grouped expression.
+      var branches = Array<(Filter, Term)>()
+      branches.reserveCapacity(whens.count)
+      for branch in whens {
+        try branches.append((lower(branch.when, routines),
+                             term(branch.then, routines)))
+      }
+      let fallback: Term? = if let otherwise {
+        try term(otherwise, routines)
+      } else {
+        nil
+      }
+      // Attach the unified result type — the same `ValueType.unified` reduction
+      // `derive`/`validate` compute — over the grouped scope, so the executor
+      // COERCES the selected branch's value to the advertised column type.
+      let type = try scope.deriveCase(whens, otherwise, routines)
+      return .case(branches, else: fallback, type: type)
     case .aggregate:
       // An aggregate reaches here only when it was not collected — an internal
       // inconsistency, since the query gathers every projection/HAVING aggregate.
@@ -960,7 +1152,8 @@ internal struct Grouping {
   /// output name (an alias, else a bare column's name) so an `ORDER BY` may name
   /// it — the standard alias ordering on an aggregate. A `SELECT *` has no
   /// well-defined meaning over groups (which columns?), so it faults.
-  internal mutating func terms(_ projection: Projection)
+  internal mutating func terms(_ projection: Projection,
+                               _ routines: Routines = [:])
       throws(SQLError) -> Array<Term> {
     switch projection {
     case .all:
@@ -969,7 +1162,7 @@ internal struct Grouping {
       var terms = Array<Term>()
       terms.reserveCapacity(columns.count)
       for column in columns {
-        let term = try term(.column(column))
+        let term = try term(.column(column), routines)
         terms.append(term)
         record(column.name, term)
       }
@@ -978,7 +1171,7 @@ internal struct Grouping {
       var terms = Array<Term>()
       terms.reserveCapacity(items.count)
       for item in items {
-        let term = try term(item.expression)
+        let term = try term(item.expression, routines)
         terms.append(term)
         // Record the output name (`Projected.name` — an alias, else a bare
         // column's name) so an `ORDER BY` may name it (the standard alias
@@ -990,9 +1183,10 @@ internal struct Grouping {
   }
 
   /// Lowers a `HAVING`/predicate to a grouped-space `Filter`.
-  internal func lower(_ predicate: Predicate) throws(SQLError) -> Filter {
+  internal func lower(_ predicate: Predicate,
+                      _ routines: Routines = [:]) throws(SQLError) -> Filter {
     try SQL.lower(predicate) { expression throws(SQLError) in
-      try term(expression)
+      try term(expression, routines)
     }
   }
 

--- a/Sources/SQL/Token.swift
+++ b/Sources/SQL/Token.swift
@@ -51,6 +51,11 @@ extension Token {
     case recursive
     case `true`
     case `false`
+    case `case`
+    case when
+    case then
+    case `else`
+    case end
 
     // Operands.
     case identifier(String)
@@ -124,6 +129,11 @@ extension Token.Kind {
     case .recursive: "RECURSIVE"
     case .true: "TRUE"
     case .false: "FALSE"
+    case .case: "CASE"
+    case .when: "WHEN"
+    case .then: "THEN"
+    case .else: "ELSE"
+    case .end: "END"
     case let .identifier(name): name
     case let .quoted(name): "\"\(name)\""
     case let .string(value): "'\(value)'"

--- a/Sources/SQL/Token.swift
+++ b/Sources/SQL/Token.swift
@@ -44,6 +44,7 @@ extension Token {
     case `as`
     case `is`
     case null
+    case `in`
     case union
     case all
     case with
@@ -116,6 +117,7 @@ extension Token.Kind {
     case .as: "AS"
     case .is: "IS"
     case .null: "NULL"
+    case .in: "IN"
     case .union: "UNION"
     case .all: "ALL"
     case .with: "WITH"

--- a/Tests/SQLTests/AggregateTests.swift
+++ b/Tests/SQLTests/AggregateTests.swift
@@ -435,4 +435,25 @@ struct AggregateTests {
     // (1.0 + 2.0) / 2 = 1.5 — real division over a double total.
     try catalog.expect("SELECT AVG(X) FROM T", yields: [[1.5]])
   }
+
+  @Test func `an aggregate argument resolves a bound parameter`() throws {
+    // A `:parameter` reached from inside an aggregate's argument binds to its
+    // query value the same way the projection and the WHERE do — the CASE guard
+    // sees `:k` as 10, so exactly the one Amount = 10 row folds a 1 into the
+    // COUNT rather than reading `:k` as UNBOUND and counting 0.
+    try sales().expect("""
+        SELECT COUNT(CASE WHEN Amount = :k THEN 1 END) FROM Sales
+        """, yields: [[1]], bindings: ["k": .integer(10)])
+  }
+
+  @Test func `a SUM argument resolves a bound parameter`() throws {
+    // The bound parameter reaches a SUM's argument, not just a COUNT's —
+    // proving the fix is the general per-record argument evaluation, one
+    // aggregate fold path for every function. With :k = 20 the CASE keeps each
+    // Amount that equals 20 and folds 0 otherwise, so SUM is the single 20 —
+    // read as UNBOUND the guard never matches and SUM is 0.
+    try sales().expect("""
+        SELECT SUM(CASE WHEN Amount = :k THEN Amount ELSE 0 END) FROM Sales
+        """, yields: [[20]], bindings: ["k": .integer(20)])
+  }
 }

--- a/Tests/SQLTests/CaseTests.swift
+++ b/Tests/SQLTests/CaseTests.swift
@@ -1,0 +1,373 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQL
+
+import SQLTestSupport
+
+// MARK: - Fixture
+
+/// A relation exercising the `CASE` expression: an integer `K` that is `NULL`
+/// in one row (so a searched guard and a simple operand meet a NULL), and a
+/// text `Name` to unify or clash result types against.
+private func things() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["Id": .integer, "K": .integer, "Name": .text]) {
+      Row(1, 10, "a")
+      Row(2, 20, "b")
+      Row(3, nil, "c")
+    }
+  }
+}
+
+// MARK: - Parsing
+
+/// Parses `text` and returns its `Select`, failing on any other shape.
+private func parse(select text: String) throws -> Select {
+  guard case let .select(.select(select)) = try Statement(parsing: text) else {
+    Issue.record("expected a single SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return select
+}
+
+struct CaseParsingTests {
+  @Test func `parses a searched CASE`() throws {
+    let select = try parse(select: """
+        SELECT CASE WHEN K = 10 THEN 1 ELSE 0 END FROM T
+        """)
+    let branch = When(when: .comparison(left: .column("K"), op: .equal,
+                                        right: .literal(.integer(10))),
+                      then: .literal(.integer(1)))
+    let expression = Expression.case([branch], else: .literal(.integer(0)))
+    #expect(select.projection == .expressions([Projected(expression: expression)]))
+  }
+
+  @Test func `normalises a simple CASE to a searched one`() throws {
+    // `CASE K WHEN 10 THEN 1 …` becomes `CASE WHEN K = 10 THEN 1 …`.
+    let select = try parse(select: """
+        SELECT CASE K WHEN 10 THEN 1 WHEN 20 THEN 2 END FROM T
+        """)
+    let first = When(when: .comparison(left: .column("K"), op: .equal,
+                                       right: .literal(.integer(10))),
+                     then: .literal(.integer(1)))
+    let second = When(when: .comparison(left: .column("K"), op: .equal,
+                                        right: .literal(.integer(20))),
+                      then: .literal(.integer(2)))
+    let expression = Expression.case([first, second], else: nil)
+    #expect(select.projection == .expressions([Projected(expression: expression)]))
+  }
+
+  @Test func `a CASE with no ELSE has a nil else`() throws {
+    let select = try parse(select: "SELECT CASE WHEN K = 10 THEN 1 END FROM T")
+    guard case let .expressions(items) = select.projection,
+        case let .case(_, otherwise) = items[0].expression else {
+      Issue.record("expected a CASE projection")
+      return
+    }
+    #expect(otherwise == nil)
+  }
+
+  @Test func `rejects a CASE with no WHEN`() {
+    #expect(throws: SQLError.self) {
+      _ = try Statement(parsing: "SELECT CASE ELSE 0 END FROM T")
+    }
+  }
+
+  @Test func `rejects an unterminated CASE`() {
+    #expect(throws: SQLError.self) {
+      _ = try Statement(parsing: "SELECT CASE WHEN K = 1 THEN 2 FROM T")
+    }
+  }
+}
+
+// MARK: - Evaluation
+
+struct CaseEvaluationTests {
+  @Test func `takes the first matching branch`() throws {
+    // K = 10 (row 1) → 1; K = 20 (row 2) → 2; row 3 (K NULL) → the ELSE, 0.
+    try things().expect("""
+        SELECT CASE WHEN K = 10 THEN 1 WHEN K = 20 THEN 2 ELSE 0 END FROM T
+        """, yields: [[1], [2], [0]])
+  }
+
+  @Test func `an earlier branch wins over a later one`() throws {
+    // Both guards hold for K = 10, but the first wins.
+    try things().expect("""
+        SELECT CASE WHEN K = 10 THEN 100 WHEN K >= 10 THEN 200 ELSE 0 END
+          FROM T WHERE Id = 1
+        """, yields: [[100]])
+  }
+
+  @Test func `no matching branch and no ELSE yields NULL`() throws {
+    // No K equals 99, and there is no ELSE, so every row yields NULL.
+    try things().expect("SELECT CASE WHEN K = 99 THEN 1 END FROM T",
+                        yields: [[nil], [nil], [nil]])
+  }
+
+  @Test func `an UNKNOWN guard skips its branch`() throws {
+    // Row 3's K is NULL, so `K = 10` is UNKNOWN — the branch is skipped, not
+    // taken — and the ELSE yields 9. Rows 1 and 2 take a matching branch.
+    try things().expect("""
+        SELECT CASE WHEN K = 10 THEN 1 WHEN K = 20 THEN 2 ELSE 9 END FROM T
+        """, yields: [[1], [2], [9]])
+  }
+
+  @Test func `a simple CASE with a NULL operand takes the ELSE`() throws {
+    // Row 3's K is NULL, so `K = 10`/`K = 20` are both UNKNOWN (a NULL operand
+    // matches no WHEN value); the ELSE yields 0. Rows 1 and 2 match.
+    try things().expect("""
+        SELECT CASE K WHEN 10 THEN 1 WHEN 20 THEN 2 ELSE 0 END FROM T
+        """, yields: [[1], [2], [0]])
+  }
+
+  @Test func `a CASE in a WHERE filters rows`() throws {
+    // Keep rows whose CASE yields a truthy 1: K = 10 or K = 20.
+    try things().expect("""
+        SELECT Id FROM T
+          WHERE CASE WHEN K = 10 THEN 1 WHEN K = 20 THEN 1 ELSE 0 END = 1
+        """, yields: [[1], [2]])
+  }
+
+  @Test func `a mixed CASE coerces the integer branch to double`() throws {
+    // The results unify to `.double`, so the schema advertises the column as
+    // double; the executor must COERCE the selected branch's value to match.
+    // Row 1 takes the integer THEN `1`, which widens to `.double(1.0)` rather
+    // than staying `.integer(1)`; rows 2 and 3 take the double ELSE `2.5`.
+    try things().expect(
+        "SELECT CASE WHEN Id = 1 THEN 1 ELSE 2.5 END AS C FROM T",
+        yields: [[1.0], [2.5], [2.5]])
+  }
+
+  @Test func `an all-integer CASE is not coerced`() throws {
+    // The results unify to `.integer` — no widening — so each branch value is
+    // yielded unchanged as an integer, never a spurious double.
+    try things().expect(
+        "SELECT CASE WHEN Id = 1 THEN 1 ELSE 2 END AS C FROM T",
+        yields: [[1], [2], [2]])
+  }
+
+  @Test func `a no-match mixed CASE with no ELSE stays NULL`() throws {
+    // A mixed integer/double CASE unifies to `.double`, but no K matches and
+    // there is no ELSE, so every row yields NULL — coercion to `.double` leaves
+    // NULL as NULL, never a double.
+    try things().expect("""
+        SELECT CASE WHEN K = 98 THEN 1 WHEN K = 99 THEN 2.5 END AS C FROM T
+        """, yields: [[nil], [nil], [nil]])
+  }
+}
+
+// MARK: - Type unification
+
+struct CaseTypeTests {
+  private func parse(_ text: String) throws -> Query {
+    guard case let .select(query) = try Statement(parsing: text) else {
+      Issue.record("expected a SELECT statement")
+      throw SQLError.incomplete(expected: "a SELECT statement")
+    }
+    return query
+  }
+
+  /// The single output column type of a one-column query's schema.
+  private func type(of text: String) throws -> ValueType {
+    let columns = try things().columns(of: parse(text))
+    #expect(columns.count == 1)
+    return columns[0].type
+  }
+
+  @Test func `like result types unify to that type`() throws {
+    #expect(try type(of: "SELECT CASE WHEN K = 1 THEN K ELSE 0 END AS C FROM T")
+                == .integer)
+  }
+
+  @Test func `mixed integer and double results widen to double`() throws {
+    #expect(try type(of:
+        "SELECT CASE WHEN K = 1 THEN 1 ELSE 2.5 END AS C FROM T") == .double)
+  }
+
+  @Test func `irreconcilable result types fault`() throws {
+    // An integer result beside a text result cannot yield one column type.
+    let query = try parse(
+        "SELECT CASE WHEN K = 1 THEN 1 ELSE Name END AS C FROM T")
+    let resolve = { () throws -> Array<OutputColumn> in
+      try things().columns(of: query)
+    }
+    #expect(throws:
+        SQLError.operand("CASE results have irreconcilable types")) {
+      try resolve()
+    }
+  }
+}
+
+// MARK: - Branch reachability
+
+/// The type check honours the executor's short-circuit: a `WHEN` whose guard is
+/// statically constant-FALSE has an unreachable result the run never evaluates,
+/// so its operands are not validated; once an earlier guard is constant-TRUE
+/// every later branch and the `ELSE` are unreachable too.
+struct CaseReachabilityTests {
+  private func parse(_ text: String) throws -> Query {
+    guard case let .select(query) = try Statement(parsing: text) else {
+      Issue.record("expected a SELECT statement")
+      throw SQLError.incomplete(expected: "a SELECT statement")
+    }
+    return query
+  }
+
+  @Test func `a constant-false guard's bad result is unreachable`() throws {
+    // `1 = 0` is statically false, so `Name + 1` (text arithmetic) is never
+    // evaluated — the type check validates the reachable `ELSE 0` only and the
+    // column types as its integer.
+    let query = try parse(
+        "SELECT CASE WHEN 1 = 0 THEN Name + 1 ELSE 0 END AS C FROM T")
+    let columns = try things().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+    #expect(columns[0].type == .integer)
+  }
+
+  @Test func `a constant-false-guarded bad branch runs`() throws {
+    // The same query runs: the false guard skips `Name + 1`, so every row takes
+    // the ELSE 0.
+    try things().expect(
+        "SELECT CASE WHEN 1 = 0 THEN Name + 1 ELSE 0 END FROM T",
+        yields: [[0], [0], [0]])
+  }
+
+  @Test func `a reachable bad result still faults`() throws {
+    // `Id = 1` is per-row, not statically false, so `Name + 1` IS reachable and
+    // the text arithmetic must still fault.
+    let query = try parse(
+        "SELECT CASE WHEN Id = 1 THEN Name + 1 ELSE 0 END AS C FROM T")
+    let resolve = { () throws -> Array<OutputColumn> in
+      try things().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.operand("operands must be numeric")) {
+      try resolve()
+    }
+  }
+
+  @Test func `a constant-true guard makes a later bad branch unreachable`()
+      throws {
+    // `1 = 1` is statically true, so the first branch always wins and the later
+    // `WHEN 1 = 1 THEN Name + 1` is unreachable — its operands are not
+    // validated, so the type check passes and the column types as the first
+    // result's integer.
+    let query = try parse("""
+        SELECT CASE WHEN 1 = 1 THEN 0 WHEN 1 = 1 THEN Name + 1 END AS C FROM T
+        """)
+    let columns = try things().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+    #expect(columns[0].type == .integer)
+  }
+
+  @Test func `an earlier branch before a constant-true guard stays reachable`()
+      throws {
+    // `WHEN 1 = 1` is constant-TRUE, but it comes AFTER the row-dependent `WHEN
+    // Id = 1`, which a row with `Id = 1` still matches — so that earlier branch
+    // is REACHABLE and its `Name + 1` (text arithmetic) must still fault. The
+    // constant-TRUE guard drops only the STRICTLY-LATER branches and the ELSE,
+    // not the branches before it.
+    let query = try parse("""
+        SELECT CASE WHEN Id = 1 THEN Name + 1 WHEN 1 = 1 THEN 0 END AS C FROM T
+        """)
+    let resolve = { () throws -> Array<OutputColumn> in
+      try things().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.operand("operands must be numeric")) {
+      try resolve()
+    }
+  }
+
+  @Test func `an earlier branch clashing a constant-true guard's type reports`()
+      throws {
+    // The earlier reachable `THEN Name` (text) and the constant-TRUE guard's
+    // `THEN 0` (integer) both shape the column, so their irreconcilable types
+    // must be reported rather than the constant-TRUE branch's alone winning.
+    let query = try parse("""
+        SELECT CASE WHEN Id = 1 THEN Name WHEN 1 = 1 THEN 0 END AS C FROM T
+        """)
+    let resolve = { () throws -> Array<OutputColumn> in
+      try things().columns(of: query, validate: true)
+    }
+    #expect(throws:
+        SQLError.operand("CASE results have irreconcilable types")) {
+      try resolve()
+    }
+  }
+
+  @Test func `a decisive IN guard folds a CASE constant-true`() throws {
+    // `1 IN (1, Name + 1)` folds constant-TRUE — the IN OR-chain short-circuits
+    // on the literal `1 = 1` before the row-dependent `Name + 1`. So the guard
+    // is constant-TRUE and the `ELSE Name + 1` is unreachable: the type check
+    // must NOT validate it, and the query runs (every row takes the THEN).
+    let query = try parse("""
+        SELECT CASE WHEN 1 IN (1, Name + 1) THEN 0 ELSE Name + 1 END AS C FROM T
+        """)
+    let columns = try things().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+    #expect(columns[0].type == .integer)
+    try things().expect("""
+        SELECT CASE WHEN 1 IN (1, Name + 1) THEN 0 ELSE Name + 1 END FROM T
+        """, yields: [[0], [0], [0]])
+  }
+}
+
+// MARK: - Empty-group folding
+
+/// The schema validator folds the projection over the single empty group a
+/// constant-false `WHERE` leaves (`Scope.empty`), exactly as a run does — so a
+/// CASE there must COERCE its selected value to the unified result type, just
+/// as the executor's `Row.conditional` does, or the folded value clashes the
+/// advertised column type and a routine argument the run accepts is rejected.
+struct CaseEmptyGroupTests {
+  private func parse(_ text: String) throws -> Query {
+    guard case let .select(query) = try Statement(parsing: text) else {
+      Issue.record("expected a SELECT statement")
+      throw SQLError.incomplete(expected: "a SELECT statement")
+    }
+    return query
+  }
+
+  /// `CASE WHEN COUNT(*) = 0 THEN COUNT(*) ELSE 2.5 END` — a mixed CASE whose
+  /// guard is NOT statically decidable (a `COUNT(*)` operand), so BOTH arms are
+  /// reachable and the result unifies to `.double`. Over the empty group
+  /// `COUNT(*)` is `0`, so the guard folds TRUE and the integer `COUNT(*)` arm
+  /// is selected — folding to `0`, which must WIDEN to the unified `.double`.
+  private func mixed() -> Expression {
+    let guard0 = Predicate.comparison(left: .aggregate(.count, of: .star),
+                                      op: .equal,
+                                      right: .literal(.integer(0)))
+    let branch = When(when: guard0,
+                      then: .aggregate(.count, of: .star))
+    return .case([branch], else: .literal(.double(2.5)))
+  }
+
+  @Test func `the empty-group fold coerces the selected value`() throws {
+    // The whole-result group over no rows folds `COUNT(*)` to `0`; the CASE
+    // unifies to `.double`, so the fold yields `.double(0.0)`, not
+    // `.integer(0)` — matching the run, whose executor coerces the same value.
+    #expect(try Scope([]).empty(mixed()) == .double(0.0))
+  }
+
+  @Test func `a DOUBLE routine accepts the coerced empty-group CASE`()
+      throws {
+    // `f(x DOUBLE) RETURNS DOUBLE AS x` over the mixed CASE: the constant-false
+    // WHERE leaves one empty group, so `columns(of:)` folds the projection and
+    // dispatches the routine over the folded argument. The coerced
+    // `.double(0.0)` satisfies the DOUBLE parameter — schema validation
+    // SUCCEEDS, as the run does; a raw `.integer(0)` would fault
+    // `SQLError.argument`.
+    let f = Function(parameters: [Function.Parameter(name: "x", type: .double)],
+                     returns: .double, body: .column("x"))
+    let routines = try Routines().registering("f", f)
+    let query = try parse("""
+        SELECT f(CASE WHEN COUNT(*) = 0 THEN COUNT(*) ELSE 2.5 END) AS C
+          FROM T WHERE 1 = 0
+        """)
+    let columns = try things().columns(of: query, routines: routines,
+                                       validate: true)
+    #expect(columns.count == 1)
+    #expect(columns[0].type == .double)
+  }
+}

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -2313,6 +2313,18 @@ struct EngineDefinedFunctionTests {
     }
   }
 
+  @Test func `a defined function body referencing a query parameter faults at define`() throws {
+    // A body's inputs are its declared parameters, not query bindings: a routine
+    // body is evaluated with only its argument record, so a `:parameter` (here
+    // reached through a CASE guard) would always be UNBOUND and silently pick
+    // the ELSE branch. Registration rejects the `.bound`.
+    #expect(throws:
+        SQLError.argument("the body cannot reference a query parameter")) {
+      _ = try defining("CREATE FUNCTION f() RETURNS INTEGER AS "
+                           + "CASE WHEN 1 = :p THEN 1 ELSE 0 END")
+    }
+  }
+
   @Test func `a later defined function shadows an earlier one of the same name`() throws {
     // A later registration wins (the house rule the flat registry follows), so
     // the second `inc` — adding 100 — is the one a call resolves.

--- a/Tests/SQLTests/FloatTests.swift
+++ b/Tests/SQLTests/FloatTests.swift
@@ -28,16 +28,16 @@ private struct Cell: Row {
 /// `true`, `false`, or `nil` (UNKNOWN) — the path a real `WHERE` takes.
 private func compare(_ cell: Value, _ op: Comparison,
                      _ constant: Value) -> Bool? {
-  try! evaluate(.compare(.slot(0), op, .constant(constant)),
-                Cell(cell), Routines(), [:])
+  try! Cell(cell).evaluate(.compare(.slot(0), op, .constant(constant)),
+                           Routines(), [:])
 }
 
 /// Evaluates `lhs op rhs` through the engine's arithmetic — a typed `Value`, or
 /// a thrown `SQLError` (a divide by zero, a non-numeric operand).
 private func arithmetic(_ lhs: Value, _ op: Arithmetic,
                         _ rhs: Value) throws(SQLError) -> Value {
-  try evaluate(.binary(op, .constant(lhs), .constant(rhs)),
-               Cell(.null), Routines())
+  try Cell(.null).evaluate(.binary(op, .constant(lhs), .constant(rhs)),
+                           Routines())
 }
 
 // MARK: - Comparison
@@ -157,10 +157,10 @@ private struct DoubleArithmeticTests {
           _ in .double(.infinity)
         }]
     #expect(throws: SQLError.self) {
-      try evaluate(.apply(name: "nan", arguments: []), Cell(.null), routines)
+      try Cell(.null).evaluate(.apply(name: "nan", arguments: []), routines)
     }
     #expect(throws: SQLError.self) {
-      try evaluate(.apply(name: "huge", arguments: []), Cell(.null), routines)
+      try Cell(.null).evaluate(.apply(name: "huge", arguments: []), routines)
     }
   }
 }

--- a/Tests/SQLTests/FunctionTests.swift
+++ b/Tests/SQLTests/FunctionTests.swift
@@ -308,4 +308,60 @@ private func id() -> Function {
     try numbers().expect("SELECT g() FROM N WHERE Id = 1",
                          yields: [["x"]], routines: routines)
   }
+
+  @Test func `a body referencing a query parameter faults at registration`() {
+    // A body's inputs are its declared parameters, not query bindings. `f() AS
+    // CASE WHEN 1 = :p THEN 1 ELSE 0 END` reaches a `:parameter` through a CASE
+    // guard, but a routine body is evaluated with only its argument record — the
+    // caller's bindings never reach it — so `:p` would always be UNBOUND and
+    // silently pick the ELSE branch. The registration rejects the `.bound`.
+    let body =
+        Expression.case([When(when: .bound(left: .literal(.integer(1)),
+                                           op: .equal, parameter: "p"),
+                              then: .literal(.integer(1)))],
+                        else: .literal(.integer(0)))
+    let function = Function(parameters: [], returns: .integer, body: body)
+    #expect(throws:
+        SQLError.argument("the body cannot reference a query parameter")) {
+      _ = try Routines().registering("f", function)
+    }
+  }
+
+  @Test func `a body with a bound-free CASE registers cleanly`() throws {
+    // The rejection is of a `.bound` specifically, not of a CASE in a body: a
+    // guard over the parameter (`CASE WHEN n = 7 THEN 1 ELSE 0 END`) registers
+    // and computes — here yielding 1 for the matching argument (N.V is 7).
+    let body =
+        Expression.case([When(when: .comparison(left: .column("n"),
+                                                op: .equal,
+                                                right: .literal(.integer(7))),
+                              then: .literal(.integer(1)))],
+                        else: .literal(.integer(0)))
+    let function =
+        Function(parameters: [Function.Parameter(name: "n", type: .integer)],
+                 returns: .integer, body: body)
+    let routines = try Routines().registering("seven", function)
+    try numbers().expect("SELECT seven(V) FROM N WHERE Id = 1",
+                         yields: [[1]], routines: routines)
+  }
+
+  @Test func `a RETURNS DOUBLE body of a mixed CASE returns a double`() throws {
+    // `f(n INTEGER) RETURNS DOUBLE AS CASE WHEN n = 7 THEN 1 ELSE 2.5 END`: the
+    // body's results unify to `.double`, so it TYPES as double and the RETURNS
+    // check passes. Called with N.V = 7 it takes the integer THEN `1`, which
+    // the CASE coercion widens to `.double(1.0)` — the value now matches the
+    // declared double return, not a bare `.integer(1)`.
+    let body =
+        Expression.case([When(when: .comparison(left: .column("n"),
+                                                op: .equal,
+                                                right: .literal(.integer(7))),
+                              then: .literal(.integer(1)))],
+                        else: .literal(.double(2.5)))
+    let function =
+        Function(parameters: [Function.Parameter(name: "n", type: .integer)],
+                 returns: .double, body: body)
+    let routines = try Routines().registering("choose", function)
+    try numbers().expect("SELECT choose(V) FROM N WHERE Id = 1",
+                         yields: [[1.0]], routines: routines)
+  }
 }

--- a/Tests/SQLTests/MembershipTests.swift
+++ b/Tests/SQLTests/MembershipTests.swift
@@ -1,0 +1,228 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQL
+
+import SQLTestSupport
+
+// MARK: - Fixture
+
+/// A relation exercising the `IN` value-list predicate: an integer key `K` that
+/// is `NULL` in some rows, so the three-valued corners (a NULL operand, a NULL
+/// element) are reachable, and a text `Name` to fault an incompatible element
+/// type against.
+private func members() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["Id": .integer, "K": .integer, "Name": .text]) {
+      Row(1, 10, "a")
+      Row(2, 20, "b")
+      Row(3, nil, "c")
+      Row(4, 30, "d")
+    }
+  }
+}
+
+// MARK: - Parsing
+
+/// Parses `text` and returns its `Select`, failing on any other shape.
+private func parse(select text: String) throws -> Select {
+  guard case let .select(.select(select)) = try Statement(parsing: text) else {
+    Issue.record("expected a single SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return select
+}
+
+struct MembershipParsingTests {
+  @Test func `parses an IN value list`() throws {
+    let select = try parse(select: "SELECT * FROM T WHERE K IN (1, 2, 3)")
+    #expect(select.predicate
+                == .membership(.column("K"),
+                               [.literal(.integer(1)), .literal(.integer(2)),
+                                .literal(.integer(3))], negated: false))
+  }
+
+  @Test func `parses a NOT IN value list`() throws {
+    let select = try parse(select: "SELECT * FROM T WHERE K NOT IN (1, 2)")
+    #expect(select.predicate
+                == .membership(.column("K"),
+                               [.literal(.integer(1)), .literal(.integer(2))],
+                               negated: true))
+  }
+
+  @Test func `parses a single-element IN list`() throws {
+    let select = try parse(select: "SELECT * FROM T WHERE K IN (7)")
+    #expect(select.predicate
+                == .membership(.column("K"), [.literal(.integer(7))],
+                               negated: false))
+  }
+
+  @Test func `parses IN over an expression operand`() throws {
+    let select = try parse(select: "SELECT * FROM T WHERE K + 1 IN (11, 21)")
+    let operand = Expression.binary(.add, .column("K"), .literal(.integer(1)))
+    #expect(select.predicate
+                == .membership(operand,
+                               [.literal(.integer(11)), .literal(.integer(21))],
+                               negated: false))
+  }
+
+  @Test func `rejects an empty IN list`() {
+    #expect(throws: SQLError.self) {
+      _ = try Statement(parsing: "SELECT * FROM T WHERE K IN ()")
+    }
+  }
+}
+
+// MARK: - Evaluation
+
+struct MembershipEvaluationTests {
+  @Test func `IN admits a matching value`() throws {
+    try members().expect("SELECT Id FROM T WHERE K IN (10, 30)",
+                         yields: [[1], [4]])
+  }
+
+  @Test func `IN rejects a non-matching value`() throws {
+    try members().expect("SELECT Id FROM T WHERE K IN (99)", yields: [])
+  }
+
+  @Test func `NOT IN admits the complement`() throws {
+    // Rows with a non-NULL K not in the list; row 3 (K NULL) is UNKNOWN and
+    // dropped.
+    try members().expect("SELECT Id FROM T WHERE K NOT IN (10, 30)",
+                         yields: [[2]])
+  }
+
+  @Test func `a NULL operand makes IN UNKNOWN`() throws {
+    // Row 3's K is NULL, so `NULL IN (10, 20)` is UNKNOWN, not FALSE — the row
+    // is dropped rather than admitted, and would not be admitted by NOT IN
+    // either.
+    try members().expect("SELECT Id FROM T WHERE K IN (10, 20)",
+                         yields: [[1], [2]])
+    try members().expect("SELECT Id FROM T WHERE K NOT IN (10, 20)",
+                         yields: [[4]])
+  }
+
+  @Test func `a NULL element leaves an unmatched IN UNKNOWN`() throws {
+    // Row 3 has K = NULL, so its `K` cell is the NULL element. Over that row,
+    // `20 IN (99, K)` is `20 = 99 OR 20 = NULL` — FALSE OR UNKNOWN — which is
+    // UNKNOWN, not FALSE: the row is not admitted. `NOT IN` negates that
+    // UNKNOWN to UNKNOWN, so it is never TRUE either — the row is dropped both
+    // ways.
+    try members().empty("SELECT Id FROM T WHERE 20 IN (99, K) AND Id = 3")
+    try members().empty("SELECT Id FROM T WHERE 20 NOT IN (99, K) AND Id = 3")
+  }
+
+  @Test func `IN folds like an OR of equalities`() throws {
+    try members().expect("SELECT Id FROM T WHERE K IN (10, 20, 30)",
+                         equals: "SELECT Id FROM T WHERE K = 10 OR K = 20 OR K = 30")
+  }
+}
+
+// MARK: - Type checking
+
+struct MembershipTypeTests {
+  /// Parses `text` to a query, failing on any other statement.
+  private func parse(_ text: String) throws -> Query {
+    guard case let .select(query) = try Statement(parsing: text) else {
+      Issue.record("expected a SELECT statement")
+      throw SQLError.incomplete(expected: "a SELECT statement")
+    }
+    return query
+  }
+
+  @Test func `an incompatible element type faults the schema check`() throws {
+    // `K` is an integer column; a text element can never match, so the WHERE
+    // type check (the output-schema path) rejects it up front rather than
+    // silently never matching. It faults where a comparison to a text literal
+    // would be classified as ill-typed.
+    let query = try parse("SELECT Id FROM T WHERE K IN (10, 'x')")
+    let resolve = { () throws -> Array<OutputColumn> in
+      try members().columns(of: query)
+    }
+    #expect(throws:
+        SQLError.operand("IN list element is not comparable to the operand")) {
+      try resolve()
+    }
+  }
+
+  @Test func `a numeric element of the other numeric kind is admitted`() throws {
+    // An integer operand and a double element are comparable (both numeric), so
+    // the schema check passes and the run matches by magnitude.
+    let query = try parse("SELECT Id FROM T WHERE K IN (10.0, 20.0)")
+    _ = try members().columns(of: query)
+    try members().expect("SELECT Id FROM T WHERE K IN (10.0, 20.0)",
+                         yields: [[1], [2]])
+  }
+
+  @Test func `a definite match short-circuits a later bad element`() throws {
+    // `1 IN (1, Name + 1)` lowers to `1 = 1 OR 1 = Name + 1`; the first
+    // disjunct is a definite constant match, so the OR-chain short-circuits and
+    // `Name + 1` (text arithmetic) is unreachable — the type check does not
+    // validate it, and the query runs (matching every row).
+    let query = try parse("SELECT Id FROM T WHERE 1 IN (1, Name + 1)")
+    _ = try members().columns(of: query, validate: true)
+    try members().expect("SELECT Id FROM T WHERE 1 IN (1, Name + 1)",
+                         yields: [[1], [2], [3], [4]])
+  }
+
+  @Test func `no definite match leaves a bad element reachable`() throws {
+    // `2 IN (1, Name + 1)` never definitely matches `1`, so `Name + 1` is
+    // reachable and its text arithmetic must still fault the type check.
+    let query = try parse("SELECT Id FROM T WHERE 2 IN (1, Name + 1)")
+    let resolve = { () throws -> Array<OutputColumn> in
+      try members().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.operand("operands must be numeric")) {
+      try resolve()
+    }
+  }
+
+  @Test func `an empty-group HAVING IN short-circuits a faulting element`()
+      throws {
+    // A whole-result aggregate over an empty source projects one empty group,
+    // whose HAVING `1 IN (1, 1 / 0)` the schema path (`columns(of:)`) folds. The
+    // OR-chain short-circuits on the literal `1 = 1`, so `1 / 0` is unreachable
+    // and must not fault `.divide` — the schema resolves and the query runs.
+    let query = try parse(
+        "SELECT COUNT(*) FROM T WHERE 1 = 0 HAVING 1 IN (1, 1 / 0)")
+    let columns = try members().columns(of: query)
+    #expect(columns.count == 1)
+    try members().expect(
+        "SELECT COUNT(*) FROM T WHERE 1 = 0 HAVING 1 IN (1, 1 / 0)",
+        yields: [[0]])
+  }
+
+  /// A `SELECT Id FROM T WHERE <predicate>` built directly, so a
+  /// `Predicate.membership` with an EMPTY value list reaches the engine —
+  /// bypassing the parser, which rejects `IN ()`.
+  private func select(where predicate: Predicate) -> Query {
+    .select(Select(projection: .columns([Column(name: "Id")]),
+                   from: Relation(name: "T"), predicate: predicate))
+  }
+
+  @Test func `an empty IN list faults the schema check, not a crash`() throws {
+    // `Predicate.membership` is public, so a caller can build an EMPTY list
+    // directly, bypassing the parser's `IN ()` rejection. The lowering has no
+    // OR-chain seed for an empty list, so it FAULTS the schema check (an
+    // unsupported shape) rather than trapping on the force-unwrap.
+    let query = select(where: .membership(.column("Id"), [], negated: false))
+    let resolve = { () throws -> Array<OutputColumn> in
+      try members().columns(of: query, validate: true)
+    }
+    #expect(throws:
+        SQLError.unsupported("IN requires a non-empty value list")) {
+      try resolve()
+    }
+  }
+
+  @Test func `an empty IN list faults the run, not a crash`() throws {
+    // The same direct-AST empty list must FAULT the run's compile/lowering (the
+    // OR-chain reduction) rather than crashing on the force-unwrap.
+    let query = select(where: .membership(.column("Id"), [], negated: false))
+    #expect(throws:
+        SQLError.unsupported("IN requires a non-empty value list")) {
+      _ = try members().run(query)
+    }
+  }
+}

--- a/Tests/SQLTests/ValueTypeTests.swift
+++ b/Tests/SQLTests/ValueTypeTests.swift
@@ -27,8 +27,8 @@ private struct Cell: Row {
 /// `true`, `false`, or `nil` (UNKNOWN) — the path a real `WHERE` takes.
 private func compare(_ cell: Value, _ op: Comparison,
                      _ constant: Value) -> Bool? {
-  try! evaluate(.compare(.slot(0), op, .constant(constant)),
-                Cell(cell), Routines(), [:])
+  try! Cell(cell).evaluate(.compare(.slot(0), op, .constant(constant)),
+                           Routines(), [:])
 }
 
 // MARK: - Boolean


### PR DESCRIPTION
This pull request introduces support for SQL `CASE` expressions and `IN` membership predicates, along with several related enhancements and internal refactorings. The main changes involve extending the SQL AST, filter, and engine layers to represent, lower, and evaluate these constructs. The changes also improve type handling for comparisons and unify result types, and refactor evaluation logic for better composability.

### New SQL Features

* Added support for `CASE` conditional expressions to the AST (`Expression.case`), including a new `When` struct to represent `WHEN ... THEN ...` branches. The engine and filter layers are extended to lower and evaluate these expressions, ensuring correct short-circuiting and result type unification. [[1]](diffhunk://#diff-44ae278469f8cb8537a5e8997ce917320e10f66a7fb199bcf35bc353ab154f08R404-R431) [[2]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060R592-R616) [[3]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060R798-R803) [[4]](diffhunk://#diff-66f69cc14663ff59f1854b7179f51accad89aa0a7e6731e6880d344908ac4facR60-R65) [[5]](diffhunk://#diff-66f69cc14663ff59f1854b7179f51accad89aa0a7e6731e6880d344908ac4facR87-R92) [[6]](diffhunk://#diff-66f69cc14663ff59f1854b7179f51accad89aa0a7e6731e6880d344908ac4facR112-R115) [[7]](diffhunk://#diff-66f69cc14663ff59f1854b7179f51accad89aa0a7e6731e6880d344908ac4facL110-R126) [[8]](diffhunk://#diff-66f69cc14663ff59f1854b7179f51accad89aa0a7e6731e6880d344908ac4facL268-R343)
* Added support for `IN` membership predicates to the AST (`Predicate.membership`). This is modeled as a disjunction of equalities, with correct handling for NULLs and negation, and is lowered and evaluated in the filter and engine layers. [[1]](diffhunk://#diff-44ae278469f8cb8537a5e8997ce917320e10f66a7fb199bcf35bc353ab154f08R498-R505) [[2]](diffhunk://#diff-17b25ce60c991c310ee255f6a741f950ad95c4914ac769a53001f1bcec229060R838-R840)

### Type System Enhancements

* Introduced `ValueType.comparable(with:)` and `ValueType.unified(with:)` to determine if values can be compared or unified, supporting correct type checking for `CASE` and `IN` constructs.

### Evaluation and Refactoring

* Refactored evaluation logic: `evaluate` functions for terms and filters are now methods on `Row`, improving composability and consistency. This also includes improved handling of routines and bindings, and ensures correct evaluation of new constructs. [[1]](diffhunk://#diff-b0e440c2f8026eff524509824378dd26b9ce74962ac418a30a4dfa463d3c9987L243-R243) [[2]](diffhunk://#diff-b0e440c2f8026eff524509824378dd26b9ce74962ac418a30a4dfa463d3c9987L259-R259) [[3]](diffhunk://#diff-66f69cc14663ff59f1854b7179f51accad89aa0a7e6731e6880d344908ac4facL268-R343) [[4]](diffhunk://#diff-66f69cc14663ff59f1854b7179f51accad89aa0a7e6731e6880d344908ac4facL470-R568) [[5]](diffhunk://#diff-c2a824b19cb7761a8c6ab76d4d4cb9cc4ffd627966f6138baa92cd2219777331L150-R150) [[6]](diffhunk://#diff-90b051b6c59d5ca6612ebe0500cd6ccfecdec8f79c3c79167986ee4298fd0737L313-R315)
* Added `Sendable` conformance to several core types (`Filter`, `Term`, etc.) for improved concurrency safety. [[1]](diffhunk://#diff-66f69cc14663ff59f1854b7179f51accad89aa0a7e6731e6880d344908ac4facL18-R18) [[2]](diffhunk://#diff-66f69cc14663ff59f1854b7179f51accad89aa0a7e6731e6880d344908ac4facR60-R65)

### SQL Lexer Updates

* Updated the SQL lexer to recognize new keywords: `IN`, `CASE`, `WHEN`, `THEN`, `ELSE`, and `END`, enabling correct parsing of the new constructs.

These changes collectively add important SQL language features and improve the internal structure and type safety of the codebase.