### PR TITLE
Documentation: refresh the synthesis model doc

### DIFF
--- a/Documentation/DatabaseModel.md
+++ b/Documentation/DatabaseModel.md
@@ -108,15 +108,21 @@ materialise a database; each is a view that interprets the raw bytes in place:
 - **`PhysicalSchema`** — an immutable value holding the resolved physical schema
   (all index/column byte widths). Resolved once when the database is opened and
   exposed as `Database.catalog`.
-- **`Table`** — an immutable value describing an *open* table: a schema, a
-  `TupleDescriptor`, the row count, and the table's absolute byte `range`. The
-  present tables are opened once at database open.
-- **`TupleDescriptor`** (`TupleDescriptor.swift`) — a row's physical layout: each
-  column's precomputed byte offset (pre-summed) and width, plus the row
-  `stride`. Computed once per open table.
-- **`Row<Schema>`** — a cursor over a borrowed view: a row index that decodes a
-  cell on demand by arithmetic against the descriptor — `range + row * stride +
-  offset[i]`, a zero-copy unaligned `RawSpan` load. No allocation, no copy.
+- **`Table`** — an immutable value describing an *open* table: a schema, the row
+  count, the table's absolute byte `range`, the record `stride`, and a `wide`
+  width-bitset (bit `i` set iff column `i` is an index the catalog resolved to
+  its wide, 4-byte form). The present tables are opened once at database open.
+  `Table.offset(_:)` recovers a column's byte offset on demand from the schema's
+  compile-time narrow offsets shifted by the `wide` bitset, so no per-table
+  offset array is materialised.
+- **Row layout** (`RowLayout.swift`) — the compile-time narrow column widths and
+  their prefix-sum offsets, a property of a `TableSchema` (`TableSchema.offset(_:)`).
+  A database's wide indices shift these at read time via the `Table`'s bitset;
+  there is no separate per-table descriptor value.
+- **`Row<Schema>`** / **`Tuple`** — a cursor over a borrowed view: a row index
+  that decodes a cell on demand by arithmetic against the schema and the `Table`
+  — `range + row * stride + offset(i)`, a zero-copy unaligned `RawSpan` load. No
+  allocation, no copy.
 - **`TableIterator<Schema>`** — a (table) scan over a table's rows, yielding a
   typed `Row` cursor for each.
 - **`Database`** (`Database.swift`) — the entry point, and itself a `~Escapable`
@@ -141,8 +147,9 @@ materialise a database; each is a view that interprets the raw bytes in place:
 - **Zero allocation on the hot path.** Schema layout is resolved once per table
   at open. Reading a row constructs only a small cursor value and decodes
   exactly the columns that are touched.
-- **Resolve once.** The catalog (index widths) and each table's row descriptor
-  are invariant for the file's lifetime and are computed a single time when the
-  database is opened, not on each access.
-- **O(1) column access.** Column offsets are pre-summed so locating a column is a
-  constant array lookup rather than a walk over preceding columns.
+- **Resolve once.** The catalog (index widths) and each table's `wide` bitset
+  and `stride` are invariant for the file's lifetime and are computed a single
+  time when the database is opened, not on each access.
+- **O(1) column access.** A column's narrow offset is a compile-time prefix sum
+  over its schema, adjusted by the `wide` bitset, so locating a column is
+  constant-time arithmetic rather than a walk over preceding columns.

--- a/Documentation/RelationalModel.md
+++ b/Documentation/RelationalModel.md
@@ -56,7 +56,7 @@ below name the steps of that arithmetic, not components of a running database.
 | Logical schema (the catalog's table/column definitions) | The table definitions in ECMA-335 §II.22 — table number and column descriptors | `TableSchema` (`Table.swift`); the ~40 marker types in `Sources/WinMD/Tables/` |
 | Physical schema / the catalog (system metadata describing the schema) | Resolved index/column byte widths, derived from the `Valid` bitvector, row counts, and `HeapSizes` | `PhysicalSchema` (`PhysicalSchema.swift`), exposed as `Database.catalog` |
 | The catalog resolved once at open | Resolved once when the database is opened | `Database.catalog`, computed in `Database.init` |
-| Row descriptor (precomputes each column's byte offset) | The byte offset and width of each column, pre-summed, plus the row stride | `TupleDescriptor` (`TupleDescriptor.swift`) |
+| Row layout (each column's byte offset and the row stride) | The byte offset and width of each column, plus the row stride | The schema's compile-time narrow offsets (`RowLayout.swift`), shifted by the open `Table`'s `wide` bitset and `stride` |
 | A table / open relation | One table's rows within the file | `Table` (the immutable value in `Table.swift`) |
 | A row / cursor (an offset into the buffer + the shared descriptor) | A row addressed by index into the table's packed rows | `Row<Schema>` (`Iteration.swift`) |
 | A (table) scan | Iterating a table's rows | `TableIterator<Schema>` |
@@ -75,12 +75,14 @@ materialises nothing: a `Database` is a `~Escapable` borrowed view over the
 buffer, not a constructed copy of it. The caller owns and keeps the buffer
 alive; see the zero-copy principle in [DatabaseModel.md](DatabaseModel.md).
 
-**Resolve a row descriptor per table.** With the catalog in hand, each
-present table is *opened* into a `Table` value. At that moment its
-`TupleDescriptor` is computed once: the column widths are resolved against the
-catalog and pre-summed into offsets, so that locating column *i* is a constant
-array lookup rather than a walk over the preceding columns. The value holds the
-schema, the descriptor, the row count, and the table's absolute byte range.
+**Resolve a row layout per table.** With the catalog in hand, each present table
+is *opened* into a `Table` value. At that moment its physical layout is resolved
+once: the catalog decides which index columns are wide, captured as the `Table`'s
+`wide` bitset and record `stride`. A column's offset is the schema's compile-time
+narrow prefix sum (`RowLayout.swift`) shifted by that bitset, so locating column
+*i* is constant-time arithmetic rather than a walk over the preceding columns.
+The `Table` value holds the schema, the `wide` bitset, the `stride`, the row
+count, and the table's absolute byte range.
 
 **Hand out cursors, not copies.** A `Row<Schema>` is a cursor: a row index over
 a borrowed view of the buffer. Constructing one allocates nothing and copies

--- a/Documentation/SynthesisModel.md
+++ b/Documentation/SynthesisModel.md
@@ -69,7 +69,9 @@ algebra — that never imports `WinMD`. It runs entirely against four
   `bound(_:_:strict:)` partition point for a sorted seek; it vends a `Cursor`.
 - **`Cursor`** addresses rows by index.
 - **`Row`** reads a typed cell by ordinal, as a `Value` — `.null`, `.integer`,
-  or `.text`.
+  `.double`, `.text`, `.boolean`, or `.blob`. The `.blob` case is load-bearing
+  for the synthesis path: a `GuidAttribute`'s value arrives as a `#Blob`, and
+  the render's `GUID` UDF (below) turns that blob into an IID string.
 
 `Engine.run(_:_:_:bindings:)` (`Sources/SQL/Engine.swift`) plans and executes a
 `Query` in three phases — **compile → optimise → execute**:
@@ -106,9 +108,13 @@ layer relies on:
   binding a parent row's key into a child query is how the render walks a
   one-to-many relationship one level at a time.
 - **Registered scalar functions** (`Routines`, `Sources/SQL/Function.swift`) —
-  the engine's extension point. The render binds the target-language `SANITIZE`
-  UDF (below) here, so keyword-escaping is a value a query projects rather than
-  logic in the binary.
+  the engine's extension point. Two kinds matter here: the WinMD-domain
+  `GUID(blob)` UDF, which decodes a `GuidAttribute` value blob to the UUID it
+  names (the `interfaces` view spells its `iid` through it), and the
+  target-language `SANITIZE` UDF (below). Both are values a query projects rather
+  than logic in the binary. A registered aggregate (`COUNT`/`SUM`/`MIN`/`MAX`/
+  `AVG`, `Sources/SQL/Aggregate.swift`) exists for interactive use but the
+  synthesis views do not lean on it.
 
 The engine yields typed `Value` rows, never rendered text.
 
@@ -143,16 +149,9 @@ adapter, not the engine, knows that a WinMD foreign key or list run *is* a join.
 
 ### Decoded columns — the federation codecs surfaced as relations
 
-Two further kinds of virtual column expose WinMD's *serialization formats* as
-ordinary readable cells, so that views can navigate over them:
+The adapter exposes one further kind of virtual column so that views can
+navigate over WinMD's *serialization formats*:
 
-- **Per-table decoded extra.** `CustomAttribute.guid` decodes a WinMD-specific
-  column (the UUID a `GuidAttribute` blob names, or `NULL` when the blob is not
-  GUID-shaped), computed in `WinMDRow`, decoded rather than stored, and never
-  seekable. A signature's return/parameter *type* is deliberately **not** a
-  column: the adapter stays type-neutral and the render decodes the spelling from
-  the signature at render time (see Presentation), so no target language leaks
-  into the conceptual schema.
 - **Coded-index join keys.** For every real coded-index column, the adapter
   exposes one decoded column per candidate target table the coded index admits,
   named **`<Column>_<Target>`** (e.g. `CustomAttribute.Parent_TypeDef`). Its
@@ -163,6 +162,15 @@ ordinary readable cells, so that views can navigate over them:
   index actually points at `Target`. These keys are derived purely from the
   schema's coded-index fields and their `CodedIndex.tables`; no table or column
   is special-cased.
+
+A byte-format *decode* that is not itself a relationship is **not** a virtual
+column but a scalar UDF applied in a view. A `GuidAttribute` blob decodes to an
+IID through the `GUID(blob)` function (`Database+SQL.swift`), which the
+`interfaces` view calls on the raw `CustomAttribute.Value` cell — keeping the
+adapter's columns free of any per-attribute decode. Likewise a signature's
+return/parameter *type* is deliberately not a column: the adapter stays
+type-neutral and the render decodes the spelling from the signature at render
+time (see Presentation), so no target language leaks into the conceptual schema.
 
 A `Session` (`Database+SQL.swift`) is the same `Catalog` overlaid with the
 session's registered views, so a `SELECT` may name a view, and a view shadows a
@@ -176,24 +184,32 @@ path, and it is deliberately limited to **byte/format codecs**, not
 relationships:
 
 - **`WinMDSynthesis.Decode`** (`Sources/WinMDSynthesis/Decode.swift`) composes a
-  decoded `SignatureType` into a type spelling: primitives, the pointer/
-  reference/array family, a `System.Guid` to `IID`/`CLSID` by a parameter-name
-  hint, and named types through a well-known table or their resolved simple name.
-  The target spellings themselves are **not** baked in — the composition is
-  parameterized by a `Dialect` the render builds from the language spec
+  decoded `SignatureType` into a type spelling — a pure function of the signature
+  and a `Dialect`. It covers the primitive leaves; the pointer/reference/array
+  family (with `void*` collapsing to a raw pointer and a pointer-to-pointer
+  keeping an optional inner slot); a `System.Guid` classified to `IID`/`CLSID` by
+  a parameter-name hint; a `GENERICINST` as `Base<Args…>` (the CLR arity suffix
+  stripped); a `VAR`/`MVAR` generic variable as a `T`/`M` placeholder; named
+  types resolved through the `Resolver` and then a well-known table or their
+  escaped simple name; and a function pointer degraded to the dialect's opaque
+  pointer. The target spellings themselves are **not** baked in — the composition
+  is parameterized by a `Dialect` the render builds from the language spec
   (`swift.lang`), so the codec is the language-neutral *structure* and the spec
-  supplies the Swift (or Rust, or C) strings. The render, not the adapter,
+  supplies the Swift (or Rust, or C) strings, including the keyword-`escape` that
+  a named type's simple name spells compilably. The render, not the adapter,
   invokes it.
 - **`Resolver`/`Identity`/`TypeResolver`**
   (`Sources/WinMDSynthesis/`) resolve the `TypeDefOrRef` references a signature
   names against a borrowed `Storage` into a `Resolver` — a `rawValue → Identity`
-  table the `Sendable`, database-free decode tier reads. Because a `Database` is
-  `~Escapable` and cannot be captured by a `Sendable` value, resolution is done
-  eagerly while the database is in scope.
-- The **coded-index join keys** and the **GuidAttribute blob decode** in
-  `Database+SQL.swift` are codecs of the same kind: a coded index is a packed
-  tag-plus-row encoding, and a GUID is a blob layout — byte formats, decoded
-  once into a join key or a UUID string.
+  table (namespace + simple name) the `Sendable`, database-free decode tier
+  reads. Because a `Database` is `~Escapable` and cannot be captured by a
+  `Sendable` value, resolution is done eagerly while the database is in scope:
+  every reference a signature carries — directly or nested under a pointer,
+  reference, array, modifier, or instantiation — is collected up front.
+- The **coded-index join keys** in `Database+SQL.swift` and the **`GUID(blob)`
+  UDF** are codecs of the same kind: a coded index is a packed tag-plus-row
+  encoding, and a GUID is a blob layout — byte formats, decoded once into a join
+  key or a UUID string.
 
 These are codecs because they decode a *serialization format*. They are not
 relationships, and so they are not expressed in SQL.
@@ -216,7 +232,8 @@ This is where the logical schema lives. The bundled views — the
   in-file `TypeDef`). All three
   arms filter to the `GuidAttribute` declaring type and to a `tdInterface`
   carrier (`BITAND(Flags, 32) = 32`, so a GUID-bearing coclass is not mistaken
-  for an interface), projecting `CustomAttribute.guid` as the `iid`.
+  for an interface), projecting `GUID(CustomAttribute.Value)` as the `iid` — the
+  UDF decoding the attribute's blob to its UUID.
 - **`methods`** and **`params`** — an interface's methods are the `MethodDef`
   rows it owns; a method's parameters are its `Param` rows. Each is a one-level
   navigation correlated by `:parent` against the owner-FK column (`WHERE


### PR DESCRIPTION
Realign the tracked docs under Documentation/ with the code on main.

SynthesisModel.md carried the largest drift. The IID decode is no longer a per-table `CustomAttribute.guid` virtual column; it is the scalar `GUID(blob)` UDF the `interfaces` view calls on the raw `CustomAttribute.Value` cell, so the decoded-columns and federation sections now describe the UDF rather than a decoded relation. The `Value` enum has grown past `.null`/`.integer`/`.text` to also carry `.double`, `.boolean`, and `.blob` — the last load-bearing for the GUID path — and the engine's scalar-function extension point now covers both the WinMD-domain `GUID` UDF and the language `SANITIZE` UDF. The `Decode` summary is expanded to the shapes it actually composes: the pointer family, `GENERICINST` as `Base<Args>`, `VAR`/`MVAR` variables, function pointers, and the keyword escape.

DatabaseModel.md and RelationalModel.md referenced a `TupleDescriptor` type/file that no longer exists. An open `Table` now captures a `wide` width-bitset and record `stride`; a column's offset is the schema's compile-time narrow prefix sum (RowLayout.swift) shifted by that bitset, with no per-table descriptor value materialised.

QueryModel.md was already current and is unchanged.