### PR TITLE
SQL: add the CASE expression

### DIFF
--- a/Sources/SQL/AST.swift
+++ b/Sources/SQL/AST.swift
@@ -401,6 +401,34 @@ public indirect enum Expression: Hashable, Sendable {
   /// value, so the engine recognises the fixed set of aggregate names at parse
   /// time and lowers them through a dedicated mechanism rather than the routines.
   case aggregate(Aggregate, of: Aggregand)
+  /// A `CASE` conditional expression — the result of its FIRST `when` whose
+  /// predicate is TRUE (three-valued: UNKNOWN and FALSE both skip), else the
+  /// `else` result, or `NULL` when there is no `ELSE`. The `when`s are held in
+  /// source order.
+  ///
+  /// Both ISO forms reduce to this searched shape: a SEARCHED `CASE WHEN cond
+  /// THEN r … END` carries its predicates directly, and a SIMPLE `CASE op WHEN v
+  /// THEN r … END` is normalised at parse time to `WHEN op = v THEN r …`, so the
+  /// engine models one conditional. The result expressions' types must unify to
+  /// one result type (see resolution).
+  case `case`(Array<When>, else: Expression?)
+}
+
+/// One `WHEN predicate THEN result` branch of a `CASE` expression — the guard
+/// and the value it yields when the guard is the first TRUE one.
+public struct When: Hashable, Sendable {
+  /// The guard predicate — TRUE selects this branch (UNKNOWN and FALSE skip it).
+  /// A simple `CASE`'s `WHEN value` is normalised to the equality `operand =
+  /// value` here.
+  public let when: Predicate
+
+  /// The result expression this branch yields when its guard is the first TRUE.
+  public let then: Expression
+
+  public init(when: Predicate, then: Expression) {
+    self.when = when
+    self.then = then
+  }
 }
 
 /// A standard SQL aggregate function.

--- a/Sources/SQL/Adapter.swift
+++ b/Sources/SQL/Adapter.swift
@@ -48,6 +48,18 @@ public enum ValueType: Hashable, Sendable {
     }
   }
 
+  /// The single type a value of this type and one of `other` UNIFY to, or `nil`
+  /// when they are irreconcilable — the rule a `CASE` reconciles its result
+  /// types by. Like types unify to themselves; a mixed integer/double pair
+  /// widens to `double` (both numeric, the integer promoted, as arithmetic and
+  /// comparison do); any other cross-kind pair — text against a number, boolean
+  /// against blob — has no common type and does not unify.
+  internal func unified(with other: ValueType) -> ValueType? {
+    if self == other { return self }
+    if numeric && other.numeric { return .double }
+    return nil
+  }
+
   /// The ISO `data_type` spelling of this value type.
   ///
   /// The engine's types map onto the ISO domains: exact numeric to `integer`,
@@ -98,6 +110,24 @@ public enum Value: Hashable, Sendable {
   /// equality (`=`/`<>`) and lexicographic order (`<`/`>`/`<=`/`>=`), both free
   /// from `Array<UInt8>: Comparable`.
   case blob(Array<UInt8>)
+}
+
+extension Value {
+  /// This value coerced to `type` — the widening a `CASE` (or a defined
+  /// function body) applies so a selected branch's raw value matches the
+  /// unified result type the schema advertises.
+  ///
+  /// `ValueType.unified` performs one widening only — a mixed integer/double
+  /// pair to `.double` — so this promotes an `.integer` to `.double` when
+  /// `type` is `.double` and leaves every other value unchanged: NULL stays
+  /// NULL, a value already of the unified type passes through, and a
+  /// non-widening unified type (every arm the same) needs no coercion.
+  internal func coerced(to type: ValueType) -> Value {
+    if case .double = type, case let .integer(number) = self {
+      return .double(Double(number))
+    }
+    return self
+  }
 }
 
 // MARK: - View

--- a/Sources/SQL/Aggregate.swift
+++ b/Sources/SQL/Aggregate.swift
@@ -230,9 +230,14 @@ private func comparable(_ a: Value, _ b: Value) -> Bool {
 /// is ONE group — the degenerate whole-result aggregation (`SELECT COUNT(*) FROM
 /// T`) — which yields a single grouped record even over an empty input (`COUNT`
 /// `0`, the others NULL), the standard SQL rule.
+///
+/// The `bindings` thread through to every key and argument evaluation, so a
+/// `:parameter` inside a group key or an aggregate argument — the guard of a
+/// `SUM(CASE WHEN Id = :target THEN K ELSE 0 END)`, say — resolves against
+/// the same execution bindings the projection and `WHERE` evaluate with.
 internal func grouped(_ records: Array<Record>, _ keys: Array<Term>,
-                      _ aggregates: Array<Aggregation>, _ routines: Routines)
-    throws(SQLError) -> Array<Record> {
+                      _ aggregates: Array<Aggregation>, _ routines: Routines,
+                      _ bindings: Bindings) throws(SQLError) -> Array<Record> {
   var order = Array<Record>()
   var accumulators = Dictionary<Record, Array<Accumulator>>()
 
@@ -240,7 +245,7 @@ internal func grouped(_ records: Array<Record>, _ keys: Array<Term>,
     var cells = Array<Value>()
     cells.reserveCapacity(keys.count)
     for key in keys {
-      try cells.append(evaluate(key, record, routines))
+      try cells.append(evaluate(key, record, routines, bindings))
     }
     let group = Record(cells)
     // Key the group on the EXACT canonical form of its cells so `1` and `1.0`
@@ -256,7 +261,7 @@ internal func grouped(_ records: Array<Record>, _ keys: Array<Term>,
       // `COUNT(*)` has no argument — count the row with a non-NULL sentinel;
       // every other aggregate folds its evaluated argument value.
       let value: Value = if let argument = aggregates[index].argument {
-        try evaluate(argument, record, routines)
+        try evaluate(argument, record, routines, bindings)
       } else {
         .integer(0)
       }

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -444,11 +444,11 @@ extension Projection {
   /// faulting (`SQLError.column` for a column, `SQLError.unsupported` for `*`).
   /// The terms hold no slots, so the `single` row's empty record carries every
   /// value the projection needs.
-  internal func scalar() throws(SQLError) -> Plan {
+  internal func scalar(_ routines: Routines = [:]) throws(SQLError) -> Plan {
     guard case .all = self else {
       let schema = Schema(width: 0, extent: 0, names: [], types: [],
                           virtuals: [])
-      let terms = try schema.terms(self, in: Relation(name: ""))
+      let terms = try schema.terms(self, in: Relation(name: ""), routines)
       return .project(terms, .single)
     }
     // `SELECT *` names every column of the relations in scope; a FROM-less query
@@ -589,6 +589,68 @@ extension Expression {
       arguments.contains { $0.aggregated }
     case let .binary(_, lhs, rhs):
       lhs.aggregated || rhs.aggregated
+    case let .case(whens, otherwise):
+      whens.contains { $0.when.aggregated || $0.then.aggregated }
+          || (otherwise?.aggregated ?? false)
+    }
+  }
+
+  /// Whether the expression references a query binding — a `.bound` predicate —
+  /// anywhere within it, reached only through a `CASE` guard (a scalar
+  /// expression has no other predicate). A defined-function body is validated
+  /// over its parameter schema and evaluated with only its argument record — no
+  /// query bindings reach it — so a body naming a `:parameter` is rejected at
+  /// registration rather than silently evaluating that reference as UNBOUND.
+  internal var bound: Bool {
+    switch self {
+    case .column, .literal, .aggregate:
+      false
+    case let .call(_, arguments):
+      arguments.contains { $0.bound }
+    case let .binary(_, lhs, rhs):
+      lhs.bound || rhs.bound
+    case let .case(whens, otherwise):
+      whens.contains { $0.when.bound || $0.then.bound }
+          || (otherwise?.bound ?? false)
+    }
+  }
+}
+
+extension Predicate {
+  /// Whether the predicate contains an aggregate call anywhere within it — used
+  /// to spot an aggregate hiding in a `CASE` guard (`CASE WHEN COUNT(*) > 1
+  /// …`), which makes the enclosing query an aggregate one.
+  internal var aggregated: Bool {
+    switch self {
+    case let .comparison(left, _, right):
+      left.aggregated || right.aggregated
+    case let .bound(left, _, _):
+      left.aggregated
+    case let .null(operand, _):
+      operand.aggregated
+    case let .and(lhs, rhs), let .or(lhs, rhs):
+      lhs.aggregated || rhs.aggregated
+    case let .not(operand):
+      operand.aggregated
+    }
+  }
+
+  /// Whether the predicate references a query binding — a `.bound` operand — in
+  /// any position within it. A defined-function body's `CASE` guards are walked
+  /// through this to reject a `:parameter` at registration (see
+  /// `Expression.bound`).
+  internal var bound: Bool {
+    switch self {
+    case .bound:
+      true
+    case let .comparison(left, _, right):
+      left.bound || right.bound
+    case let .null(operand, _):
+      operand.bound
+    case let .and(lhs, rhs), let .or(lhs, rhs):
+      lhs.bound || rhs.bound
+    case let .not(operand):
+      operand.bound
     }
   }
 }
@@ -638,7 +700,7 @@ extension Catalog where Self: ~Escapable {
     }
     var predicate: Filter? = nil
     if let clause = select.predicate {
-      predicate = try scope.lower(clause)
+      predicate = try scope.lower(clause, context.routines)
     }
 
     // The `GROUP BY` keys and the aggregate arguments lower to combined
@@ -656,7 +718,7 @@ extension Catalog where Self: ~Escapable {
     }
     var aggregations = Array<Aggregation>()
     for expression in expressions {
-      try aggregations.append(expression.aggregation(scope))
+      try aggregations.append(expression.aggregation(scope, context.routines))
     }
 
     // The source materialises exactly the ordinals the WHERE, the keys, and the
@@ -704,9 +766,9 @@ extension Catalog where Self: ~Escapable {
     // enforcing the projection rule (every non-aggregated column must be a
     // GROUP BY key).
     var grouping = try Grouping(scope, select.grouping, expressions)
-    let projection = try grouping.terms(select.projection)
+    let projection = try grouping.terms(select.projection, context.routines)
     let having: Filter? = if let clause = select.having {
-      try grouping.lower(clause)
+      try grouping.lower(clause, context.routines)
     } else {
       nil
     }
@@ -770,6 +832,12 @@ extension Expression {
     case let .binary(_, lhs, rhs):
       lhs.collect(into: &expressions)
       rhs.collect(into: &expressions)
+    case let .case(whens, otherwise):
+      for branch in whens {
+        branch.when.collect(into: &expressions)
+        branch.then.collect(into: &expressions)
+      }
+      otherwise?.collect(into: &expressions)
     }
   }
 
@@ -779,7 +847,8 @@ extension Expression {
   /// `COUNT(*)` has no argument (it counts rows); every other aggregate lowers
   /// its single operand expression to a term. `self` is always an `.aggregate`
   /// — `collect` gathers only those.
-  internal func aggregation(_ scope: Scope) throws(SQLError) -> Aggregation {
+  internal func aggregation(_ scope: Scope, _ routines: Routines = [:])
+      throws(SQLError) -> Aggregation {
     guard case let .aggregate(function, operand) = self else {
       throw .unsupported("expected an aggregate")
     }
@@ -787,7 +856,7 @@ extension Expression {
     case .star:
       nil
     case let .expression(expression):
-      try scope.term(expression)
+      try scope.term(expression, routines)
     }
     return Aggregation(function: function, argument: argument)
   }
@@ -1577,7 +1646,7 @@ extension Catalog where Self: ~Escapable {
             "a WHERE, GROUP BY, HAVING, ORDER BY, OFFSET/FETCH, or JOIN " +
             "requires a FROM clause")
       }
-      return try select.projection.scalar()
+      return try select.projection.scalar(context.routines)
     }
     let from = try resolve(relation, context, visited)
 
@@ -1602,14 +1671,16 @@ extension Catalog where Self: ~Escapable {
     guard !select.joins.isEmpty else {
       var filter: Filter? = nil
       if let predicate = select.predicate {
-        filter = try from.schema.lower(predicate, in: relation)
+        filter = try from.schema.lower(predicate, in: relation,
+                                       context.routines)
       }
       var order = Array<(column: Int, ascending: Bool)>()
       if let clause = select.order {
         order = try from.schema.order(clause, in: relation)
       }
       let projection =
-          try from.schema.terms(select.projection, in: relation)
+          try from.schema.terms(select.projection, in: relation,
+                                context.routines)
 
       // Under DISTINCT every ORDER BY key must be a select-list column — the
       // dedup runs on the projected rows, so ordering on a dropped column is
@@ -1665,13 +1736,13 @@ extension Catalog where Self: ~Escapable {
     }
     var predicate: Filter? = nil
     if let clause = select.predicate {
-      predicate = try scope.lower(clause)
+      predicate = try scope.lower(clause, context.routines)
     }
     var order = Array<(column: Int, ascending: Bool)>()
     if let clause = select.order {
       order = try scope.order(clause)
     }
-    let projection = try scope.terms(select.projection)
+    let projection = try scope.terms(select.projection, context.routines)
 
     // Under DISTINCT every ORDER BY key must be a select-list column (see
     // `distinct`); order keys and projection are in combined base-ordinal

--- a/Sources/SQL/Filter.swift
+++ b/Sources/SQL/Filter.swift
@@ -15,7 +15,7 @@ public typealias Bindings = Dictionary<String, Value>
 /// off a bare slot before running it. The filter is fully
 /// escapable; the `~Escapable` row it reads materialises only transiently at
 /// evaluation.
-internal indirect enum Filter {
+internal indirect enum Filter: Sendable {
   /// `left <op> right`, both operands lowered to ordinal-addressed terms (a
   /// slot, a constant, or a scalar-function call).
   case compare(Term, Comparison, Term)
@@ -57,6 +57,15 @@ internal indirect enum Term: Sendable {
   /// `lhs <op> rhs` — a binary arithmetic over two operand terms, the lowered
   /// form of the AST's `Expression.binary`.
   case binary(Arithmetic, Term, Term)
+  /// A `CASE` conditional — the lowered form of the AST's `Expression.case`. Each
+  /// branch is a guard `Filter` and the result `Term` it yields; the executor
+  /// evaluates the guards in order and takes the first whose three-valued value
+  /// is TRUE (UNKNOWN and FALSE skip), else the `else` term, or `NULL` when there
+  /// is none. `type` is the unification of the branch result types (the same
+  /// `ValueType.unified` reduction `derive`/`validate` compute) — the type the
+  /// schema advertises for the column — so the executor COERCES the selected
+  /// value to it, widening an `.integer` arm of a `.double` CASE.
+  case `case`(Array<(Filter, Term)>, else: Term?, type: ValueType)
 }
 
 extension Term {
@@ -78,6 +87,12 @@ extension Term {
     case let .binary(_, lhs, rhs):
       lhs.references(into: &slots)
       rhs.references(into: &slots)
+    case let .case(branches, otherwise, _):
+      for (gate, result) in branches {
+        gate.references(into: &slots)
+        result.references(into: &slots)
+      }
+      otherwise?.references(into: &slots)
     }
   }
 }
@@ -97,6 +112,10 @@ extension Term {
              arguments: arguments.map { $0.remapped(through: slot) })
     case let .binary(op, lhs, rhs):
       .binary(op, lhs.remapped(through: slot), rhs.remapped(through: slot))
+    case let .case(branches, otherwise, type):
+      .case(branches.map {
+              ($0.0.remapped(through: slot), $0.1.remapped(through: slot))
+            }, else: otherwise?.remapped(through: slot), type: type)
     }
   }
 
@@ -107,7 +126,7 @@ extension Term {
   internal var safe: Bool {
     switch self {
     case .slot, .constant: true
-    case .apply, .binary: false
+    case .apply, .binary, .case: false
     }
   }
 }
@@ -272,7 +291,8 @@ internal func value(of literal: Literal) throws(SQLError) -> Value {
 /// arguments, and applies it. The `borrowing` row is non-escaping — a term runs
 /// over a materialised projection record or a predicate's borrowed cursor row.
 internal func evaluate<R: Row & ~Escapable>(_ term: Term, _ row: borrowing R,
-                                            _ routines: Routines)
+                                            _ routines: Routines,
+                                            _ bindings: Bindings = [:])
     throws(SQLError) -> Value {
   switch term {
   case let .slot(slot):
@@ -280,17 +300,52 @@ internal func evaluate<R: Row & ~Escapable>(_ term: Term, _ row: borrowing R,
   case let .constant(value):
     value
   case let .apply(name, arguments):
-    try apply(name, arguments, row, routines)
+    try apply(name, arguments, row, routines, bindings)
   case let .binary(op, lhs, rhs):
-    try op.apply(evaluate(lhs, row, routines), evaluate(rhs, row, routines))
+    try op.apply(evaluate(lhs, row, routines, bindings),
+                 evaluate(rhs, row, routines, bindings))
+  case let .case(branches, otherwise, type):
+    // Take the FIRST branch whose guard is three-valued TRUE (UNKNOWN and FALSE
+    // skip); with none matching, the `else` term, or `NULL` when there is none.
+    // The guard is a `Filter`, so it evaluates over the same row, routines, and
+    // bindings a `WHERE` filter does — a `:parameter` guard resolves against the
+    // bindings, an UNKNOWN one does not select its branch. The selected value is
+    // COERCED to the CASE's unified result `type` so it matches the column type
+    // the schema advertised.
+    try `case`(branches, otherwise, type, row, routines, bindings)
   }
+}
+
+/// Evaluates a lowered `CASE` — its `branches` and optional `otherwise`
+/// term — against `row`, taking the first guard that is TRUE and coercing the
+/// selected value to the CASE's unified result `type`.
+///
+/// The schema advertises the column as `type` — the unification of the branch
+/// result types — yet a branch yields its own raw `Value`, so a `.integer` arm
+/// of a CASE that unifies to `.double` must widen to match. `Value.coerced`
+/// performs that one widening; NULL and an already-matching value pass
+/// unchanged, so an all-same CASE (no widening) is untouched.
+private func `case`<R: Row & ~Escapable>(_ branches: Array<(Filter, Term)>,
+                                         _ otherwise: Term?, _ type: ValueType,
+                                         _ row: borrowing R,
+                                         _ routines: Routines,
+                                         _ bindings: Bindings)
+    throws(SQLError) -> Value {
+  for (gate, result) in branches {
+    if try evaluate(gate, row, routines, bindings) == true {
+      return try evaluate(result, row, routines, bindings).coerced(to: type)
+    }
+  }
+  guard let otherwise else { return .null }
+  return try evaluate(otherwise, row, routines, bindings).coerced(to: type)
 }
 
 /// Resolves `name` in `routines` and applies it to its evaluated `arguments`.
 private func apply<R: Row & ~Escapable>(_ name: String,
                                         _ arguments: Array<Term>,
                                         _ row: borrowing R,
-                                        _ routines: Routines)
+                                        _ routines: Routines,
+                                        _ bindings: Bindings)
     throws(SQLError) -> Value {
   guard let routine = routines[name] else {
     throw .function(name)
@@ -298,7 +353,7 @@ private func apply<R: Row & ~Escapable>(_ name: String,
   var values = Array<Value>()
   values.reserveCapacity(arguments.count)
   for argument in arguments {
-    try values.append(evaluate(argument, row, routines))
+    try values.append(evaluate(argument, row, routines, bindings))
   }
   let result = try routine(values)
   // A registered routine is a public producer of `Value`s that bypasses the
@@ -490,17 +545,18 @@ internal func evaluate<R: Row & ~Escapable>(_ filter: Filter,
     throws(SQLError) -> Bool? {
   switch filter {
   case let .compare(lhs, op, rhs):
-    try matches(evaluate(lhs, row, routines), op, evaluate(rhs, row, routines))
+    try matches(evaluate(lhs, row, routines, bindings), op,
+                evaluate(rhs, row, routines, bindings))
   case let .bound(term, op, parameter):
     if let operand = bindings[parameter] {
-      try matches(evaluate(term, row, routines), op, operand)
+      try matches(evaluate(term, row, routines, bindings), op, operand)
     } else {
       nil
     }
   case let .match(left, right):
     matches(row[left], .equal, row[right])
   case let .null(term, negated):
-    try (evaluate(term, row, routines) == .null) != negated
+    try (evaluate(term, row, routines, bindings) == .null) != negated
   case let .and(lhs, rhs):
     // `&&`/`||` take an `@autoclosure` right operand, which would capture the
     // borrowed `~Escapable` row; spell each connective explicitly so a branch

--- a/Sources/SQL/Function.swift
+++ b/Sources/SQL/Function.swift
@@ -95,6 +95,15 @@ public struct Routine: Sendable {
   internal init(returns: ValueType, parameters: Array<ValueType>,
                 names: Array<String>, body: Expression,
                 _ routines: Routines) throws(SQLError) {
+    // A body's inputs are its declared parameters, not query bindings: it is
+    // validated over the parameter schema and later evaluated against ONLY the
+    // argument record, so a `:parameter` reference (reachable through a `CASE`
+    // guard) would always be UNBOUND at call time — the caller's `bindings`
+    // never reach a routine body — and silently pick the wrong branch. Reject
+    // a `.bound` anywhere in the body at registration rather than lowering it.
+    guard !body.bound else {
+      throw .argument("the body cannot reference a query parameter")
+    }
     let schema = Schema(width: names.count, extent: names.count,
                         names: names, types: parameters, virtuals: [])
     let scope = Scope([(Relation(name: ""), schema)])
@@ -106,7 +115,8 @@ public struct Routine: Sendable {
     self.parameters = parameters
     self.returns = returns
     self.body =
-        try .defined(schema.term(body, in: Relation(name: "")), routines)
+        try .defined(schema.term(body, in: Relation(name: ""), routines),
+                     routines)
   }
 
   /// Computes the cell value for the evaluated `arguments`, resolving a defined

--- a/Sources/SQL/Lexer.swift
+++ b/Sources/SQL/Lexer.swift
@@ -425,6 +425,11 @@ internal struct Lexer: ~Escapable {
     case "RECURSIVE": .recursive
     case "TRUE": .true
     case "FALSE": .false
+    case "CASE": .case
+    case "WHEN": .when
+    case "THEN": .then
+    case "ELSE": .else
+    case "END": .end
     default: .identifier(text)
     }
     return Token(kind: kind, location: start)

--- a/Sources/SQL/Operator.swift
+++ b/Sources/SQL/Operator.swift
@@ -310,7 +310,9 @@ internal func execute<C: Catalog & ~Escapable>(_ plan: Plan,
                         routines, bindings)
   case let .project(terms, source):
     return try execute(source, catalog, context)
-      .map { record throws(SQLError) in try project(terms, record, routines) }
+      .map { record throws(SQLError) in
+        try project(terms, record, routines, bindings)
+      }
   case let .sort(keys, source):
     return try execute(source, catalog, context)
       .enumerated()
@@ -341,7 +343,7 @@ internal func execute<C: Catalog & ~Escapable>(_ plan: Plan,
     return deduplicated(try execute(source, catalog, context))
   case let .aggregate(keys, aggregates, source):
     return try grouped(execute(source, catalog, context), keys,
-                       aggregates, routines)
+                       aggregates, routines, bindings)
   case let .limit(count, offset, source):
     return limited(try execute(source, catalog, context), count, offset)
   }
@@ -401,11 +403,12 @@ private func deduplicated(_ records: Array<Record>) -> Array<Record> {
 /// Evaluates each projected `term` against `record` through `routines` to the
 /// output row, in order — slot `i` of the result is `terms[i]`.
 private func project(_ terms: Array<Term>, _ record: Record,
-                     _ routines: Routines) throws(SQLError) -> Record {
+                     _ routines: Routines, _ bindings: Bindings)
+    throws(SQLError) -> Record {
   var cells = Array<Value>()
   cells.reserveCapacity(terms.count)
   for term in terms {
-    try cells.append(evaluate(term, record, routines))
+    try cells.append(evaluate(term, record, routines, bindings))
   }
   return Record(cells)
 }

--- a/Sources/SQL/Parser.swift
+++ b/Sources/SQL/Parser.swift
@@ -37,7 +37,10 @@
 /// expression     := additive
 /// additive       := multiplicative (('+' | '-') multiplicative)*
 /// multiplicative := factor (('*' | '/') factor)*
-/// factor         := '(' expression ')' | literal | aggregate | call | column
+/// factor         := '(' expression ')' | case
+///                 | literal | aggregate | call | column
+/// case           := CASE [expression] (WHEN (predicate | expression) THEN
+///                     expression)+ [ELSE expression] END
 /// literal        := string | integer | decimal | TRUE | FALSE | blob
 /// blob           := ('x' | 'X') "'" (hex hex)* "'"  // whole bytes
 /// aggregate      := COUNT '(' '*' ')'
@@ -494,6 +497,9 @@ internal struct Parser: ~Escapable {
       try expect(.rparen)
       return expression
     }
+    if current?.kind == .case {
+      return try conditional()
+    }
     if case let .string(value) = current?.kind {
       _ = try advance(expecting: "a literal")
       return .literal(.string(value))
@@ -573,6 +579,41 @@ internal struct Parser: ~Escapable {
     }
     try expect(.rparen)
     return operand
+  }
+
+  /// Parses a `CASE` expression (the `CASE` is the next token) into the searched
+  /// `Expression.case`, admitting both ISO forms.
+  ///
+  /// A `WHEN` directly after `CASE` is the SEARCHED form — each `WHEN` a full
+  /// predicate. An expression after `CASE` is the SIMPLE form's operand — each
+  /// `WHEN value` is normalised to the equality `operand = value`, so both forms
+  /// share one searched AST. At least one `WHEN` is required; an optional `ELSE`
+  /// gives the no-branch result (absent, the result is `NULL`); the whole is
+  /// closed by `END`.
+  private mutating func conditional() throws(SQLError) -> Expression {
+    try expect(.case)
+    let operand: Expression? = current?.kind == .when ? nil
+                                                       : try expression()
+
+    var whens = Array<When>()
+    repeat {
+      try expect(.when)
+      let when: Predicate = if let operand {
+        try .comparison(left: operand, op: .equal, right: expression())
+      } else {
+        try predicate()
+      }
+      try expect(.then)
+      try whens.append(When(when: when, then: expression()))
+    } while current?.kind == .when
+
+    let otherwise: Expression? = if try match(.else) {
+      try expression()
+    } else {
+      nil
+    }
+    try expect(.end)
+    return .case(whens, else: otherwise)
   }
 
   // MARK: - Predicate

--- a/Sources/SQL/Resolve.swift
+++ b/Sources/SQL/Resolve.swift
@@ -87,7 +87,8 @@ extension Schema {
   /// bare-column list yields one `.slot(ordinal)` per column; an expression list
   /// lowers each expression to a term. The terms hold ordinals, which the
   /// engine remaps to slots after gathering the referenced ones.
-  internal func terms(_ projection: Projection, in relation: Relation)
+  internal func terms(_ projection: Projection, in relation: Relation,
+                      _ routines: Routines = [:])
       throws(SQLError) -> Array<Term> {
     switch projection {
     case .all:
@@ -103,7 +104,7 @@ extension Schema {
       var terms = Array<Term>()
       terms.reserveCapacity(projected.count)
       for item in projected {
-        try terms.append(term(item.expression, in: relation))
+        try terms.append(term(item.expression, in: relation, routines))
       }
       return terms
     }
@@ -112,7 +113,8 @@ extension Schema {
   /// Lowers a scalar `expression` to an ordinal-addressed `Term`: a column to a
   /// `.slot(ordinal)`, a literal to a `.constant`, a call to an `.apply` over
   /// its lowered arguments.
-  internal func term(_ expression: Expression, in relation: Relation)
+  internal func term(_ expression: Expression, in relation: Relation,
+                     _ routines: Routines = [:])
       throws(SQLError) -> Term {
     switch expression {
     case let .column(column):
@@ -123,11 +125,33 @@ extension Schema {
       var lowered = Array<Term>()
       lowered.reserveCapacity(arguments.count)
       for argument in arguments {
-        try lowered.append(term(argument, in: relation))
+        try lowered.append(term(argument, in: relation, routines))
       }
       return .apply(name: name, arguments: lowered)
     case let .binary(op, lhs, rhs):
-      return try .binary(op, term(lhs, in: relation), term(rhs, in: relation))
+      return try .binary(op, term(lhs, in: relation, routines),
+                         term(rhs, in: relation, routines))
+    case let .case(whens, otherwise):
+      // Lower each branch's guard predicate to a `Filter` and its result to a
+      // `Term`, and the `ELSE` to a `Term`, over this relation's resolution.
+      var branches = Array<(Filter, Term)>()
+      branches.reserveCapacity(whens.count)
+      for branch in whens {
+        let gate = try lower(branch.when, in: relation, routines)
+        try branches.append((gate, term(branch.then, in: relation, routines)))
+      }
+      let fallback: Term? = if let otherwise {
+        try term(otherwise, in: relation, routines)
+      } else {
+        nil
+      }
+      // Attach the unified result type — the same `ValueType.unified` reduction
+      // `derive`/`validate` compute — so the executor COERCES the selected
+      // branch's value to the type the schema advertises. Derive it against a
+      // one-relation scope, this Schema's own resolution surface.
+      let scope = Scope([(relation, self)])
+      let type = try scope.derive(whens, otherwise, routines)
+      return .case(branches, else: fallback, type: type)
     case .aggregate:
       // An aggregate has no per-row meaning — it folds over a group — so it may
       // not appear in a `WHERE`, a join `ON`, or a non-aggregate projection.
@@ -144,10 +168,11 @@ extension Schema {
     }
   }
 
-  internal func lower(_ predicate: Predicate, in relation: Relation)
+  internal func lower(_ predicate: Predicate, in relation: Relation,
+                      _ routines: Routines = [:])
       throws(SQLError) -> Filter {
     try SQL.lower(predicate) { expression throws(SQLError) in
-      try term(expression, in: relation)
+      try term(expression, in: relation, routines)
     }
   }
 }
@@ -276,7 +301,65 @@ internal struct Scope {
     case let .binary(_, lhs, rhs):
       try [derive(lhs, routines), derive(rhs, routines)].contains(.double)
           ? .double : .integer
+    case let .case(whens, otherwise):
+      // The result type is the unification of every REACHABLE branch result (and
+      // the `ELSE`) — the executor's short-circuit means an unreachable branch
+      // (a constant-false guard, or any branch after a constant-true one) never
+      // yields a value, so it cannot shape the column's type. The reachable
+      // result types must UNIFY; a definitively-irreconcilable clash (text
+      // beside an integer) faults `SQLError.operand` here too, so this lowering
+      // surface and the faulting `validate` AGREE. A `CASE` always has at least
+      // one `WHEN`; when none is reachable (every guard constant-false, no
+      // reachable `ELSE`) the run yields NULL, for which `.integer` is the
+      // schema default.
+      try derive(whens, otherwise, routines)
     }
+  }
+
+  /// The nominal type of a `CASE` under `derive` — the unification of its
+  /// REACHABLE result types, and `.integer` when no branch is reachable (the
+  /// run yields NULL). The reachable result types must UNIFY (`unified`):
+  /// a definitively-irreconcilable pair (a text result beside an integer one)
+  /// faults `SQLError.operand`, so this lowering surface AGREES with the
+  /// faulting `validate` (`conditional`) — a mixed integer/double `CASE` still
+  /// widens to `double`.
+  internal func derive(_ whens: Array<When>, _ otherwise: Expression?,
+                       _ routines: Routines)
+      throws(SQLError) -> ValueType {
+    let results = reachable(whens, otherwise)
+    guard !results.isEmpty else { return .integer }
+    var type = try derive(results[0], routines)
+    for result in results.dropFirst() {
+      let next = try derive(result, routines)
+      guard let unified = type.unified(with: next) else {
+        throw .operand("CASE results have irreconcilable types")
+      }
+      type = unified
+    }
+    return type
+  }
+
+  /// The result expressions of a `CASE` the executor's short-circuit can REACH,
+  /// in branch order: a `WHEN` whose guard is statically constant-FALSE has an
+  /// unreachable result and is dropped; a `WHEN` whose guard is statically
+  /// constant-TRUE is itself reachable and keeps every EARLIER reachable branch
+  /// (a row an earlier row-dependent guard matches takes that branch, never
+  /// reaching this one), but makes every STRICTLY-LATER `WHEN` and the `ELSE`
+  /// unreachable; an `ELSE` is reachable only when no guard is constant-TRUE. A
+  /// guard that is not statically decidable (`constant` is `nil`) leaves its
+  /// result reachable.
+  private func reachable(_ whens: Array<When>, _ otherwise: Expression?)
+      -> Array<Expression> {
+    var results = Array<Expression>()
+    for branch in whens {
+      switch constant(branch.when) {
+      case false: continue
+      case true: results.append(branch.then); return results
+      case nil: results.append(branch.then)
+      }
+    }
+    if let otherwise { results.append(otherwise) }
+    return results
   }
 
   /// The value type a scalar `expression` yields, VALIDATING each operand and
@@ -304,7 +387,61 @@ internal struct Scope {
       try aggregate(function, over: operand, routines)
     case let .binary(op, lhs, rhs):
       try arithmetic(op, lhs, rhs, routines)
+    case let .case(whens, otherwise):
+      try conditional(whens, otherwise, routines)
     }
+  }
+
+  /// The result type of a `CASE`, validating each REACHABLE branch as a run
+  /// would fault and honouring the executor's short-circuit: each evaluated
+  /// `WHEN` guard is a boolean predicate whose operands are validated (`check`);
+  /// only a REACHABLE result expression is validated; and the reachable result
+  /// types must UNIFY to one type (`ValueType.unified`) — a
+  /// definitively-irreconcilable pair (a text result beside an integer one)
+  /// faults `SQLError.operand`, as a query cannot yield a column of two kinds. A
+  /// mixed integer/double `CASE` widens to `double`.
+  ///
+  /// The executor takes the first TRUE guard's result and never evaluates a
+  /// later branch, so a `WHEN` whose guard is statically constant-FALSE has an
+  /// unreachable result — its operands are NOT validated (`CASE WHEN 1 = 0 THEN
+  /// Name + 1 ELSE 0 END` type-checks). A constant-TRUE guard is itself
+  /// reachable and KEEPS every earlier reachable branch — a row an earlier
+  /// row-dependent guard matches takes that branch, never reaching the
+  /// constant-TRUE one — so those earlier results are still validated (`CASE WHEN
+  /// Id = 1 THEN Name + 1 WHEN 1 = 1 THEN 0 END` faults on the reachable `Id = 1`
+  /// branch's `Name + 1`); it makes only every STRICTLY-LATER guard, result, and
+  /// the `ELSE` unreachable. A REACHABLE bad operand (`WHEN Id = 1 THEN Name +
+  /// 1`) still faults. When no branch is reachable the run yields NULL, typed
+  /// `.integer` (the schema default), with no result to validate.
+  private func conditional(_ whens: Array<When>, _ otherwise: Expression?,
+                           _ routines: Routines)
+      throws(SQLError) -> ValueType {
+    var results = Array<Expression>()
+    var decided = false
+    for branch in whens {
+      // The guard up to (and including) the decisive one is evaluated, so
+      // validate its operands; a constant-FALSE guard's result is unreachable
+      // (skip it), a constant-TRUE one is reachable but makes every LATER branch
+      // unreachable — so keep the earlier results and this one, then stop.
+      try check(branch.when, routines)
+      switch constant(branch.when) {
+      case false: continue
+      case true: results.append(branch.then); decided = true
+      case nil: results.append(branch.then)
+      }
+      if decided { break }
+    }
+    if !decided, let otherwise { results.append(otherwise) }
+    guard !results.isEmpty else { return .integer }
+    var type = try validate(results[0], routines)
+    for result in results.dropFirst() {
+      let next = try validate(result, routines)
+      guard let unified = type.unified(with: next) else {
+        throw .operand("CASE results have irreconcilable types")
+      }
+      type = unified
+    }
+    return type
   }
 
   /// The result type of the scalar routine `name` called over `arguments`,
@@ -501,6 +638,12 @@ internal struct Scope {
     case let .binary(_, lhs, rhs):
       try aggregates(in: lhs, routines)
       try aggregates(in: rhs, routines)
+    case let .case(whens, otherwise):
+      for branch in whens {
+        try aggregates(in: branch.when, routines)
+        try aggregates(in: branch.then, routines)
+      }
+      if let otherwise { try aggregates(in: otherwise, routines) }
     }
   }
 
@@ -563,6 +706,21 @@ internal struct Scope {
         throw .magnitude("function '\(name)' produced a non-finite double")
       }
       return result
+    case let .case(whens, otherwise):
+      // Evaluate the `CASE` over the empty group exactly as a run does: the
+      // first branch whose guard folds TRUE (`empty(predicate)`) yields its
+      // result, else the `ELSE`, else `NULL`. A skipped branch's result never
+      // folds, so it cannot fault. The selected value is COERCED to the CASE's
+      // unified result type (`derive`), just as the executor's
+      // `Row.conditional` widens it — an `.integer` arm of a CASE that unifies
+      // to `.double` folds to `.double`, so the empty group matches the
+      // advertised column type. NULL (a no-match, no-ELSE fold) passes through.
+      let type = try derive(whens, otherwise, routines)
+      for branch in whens where try empty(branch.when, routines) == true {
+        return try empty(branch.then, routines).coerced(to: type)
+      }
+      guard let otherwise else { return .null }
+      return try empty(otherwise, routines).coerced(to: type)
     case .column:
       return .null
     }
@@ -633,7 +791,8 @@ internal struct Scope {
   /// for `*` (in chain order, never a virtual column) as `.slot` terms, a
   /// bare-column list as `.slot` terms at their combined ordinals, an expression
   /// list as lowered terms — in source order.
-  internal func terms(_ projection: Projection) throws(SQLError)
+  internal func terms(_ projection: Projection,
+                      _ routines: Routines = [:]) throws(SQLError)
       -> Array<Term> {
     switch projection {
     case .all:
@@ -657,14 +816,15 @@ internal struct Scope {
       var terms = Array<Term>()
       terms.reserveCapacity(projected.count)
       for item in projected {
-        try terms.append(term(item.expression))
+        try terms.append(term(item.expression, routines))
       }
       return terms
     }
   }
 
   /// Lowers a scalar `expression` to a combined-ordinal `Term`.
-  internal func term(_ expression: Expression) throws(SQLError) -> Term {
+  internal func term(_ expression: Expression,
+                     _ routines: Routines = [:]) throws(SQLError) -> Term {
     switch expression {
     case let .column(column):
       return try .slot(ordinal(of: column))
@@ -674,11 +834,30 @@ internal struct Scope {
       var lowered = Array<Term>()
       lowered.reserveCapacity(arguments.count)
       for argument in arguments {
-        try lowered.append(term(argument))
+        try lowered.append(term(argument, routines))
       }
       return .apply(name: name, arguments: lowered)
     case let .binary(op, lhs, rhs):
-      return try .binary(op, term(lhs), term(rhs))
+      return try .binary(op, term(lhs, routines), term(rhs, routines))
+    case let .case(whens, otherwise):
+      // Lower each branch's guard to a combined-ordinal `Filter` and its result
+      // to a `Term`, and the `ELSE` to a `Term`, across the join chain.
+      var branches = Array<(Filter, Term)>()
+      branches.reserveCapacity(whens.count)
+      for branch in whens {
+        try branches.append((lower(branch.when, routines),
+                             term(branch.then, routines)))
+      }
+      let fallback: Term? = if let otherwise {
+        try term(otherwise, routines)
+      } else {
+        nil
+      }
+      // Attach the unified result type — the same `ValueType.unified` reduction
+      // `derive`/`validate` compute — so the executor COERCES the selected
+      // branch's value to the type the schema advertises.
+      let type = try derive(whens, otherwise, routines)
+      return .case(branches, else: fallback, type: type)
     case .aggregate:
       // An aggregate has no per-row meaning — it folds over a group — so it may
       // not appear in a `WHERE`, a join `ON`, or a non-aggregate projection.
@@ -705,9 +884,10 @@ internal struct Scope {
 
   /// Lowers the name-addressed AST `predicate` to the engine's `Filter`, each
   /// column reference resolved to a combined ordinal across the chain.
-  internal func lower(_ predicate: Predicate) throws(SQLError) -> Filter {
+  internal func lower(_ predicate: Predicate,
+                      _ routines: Routines = [:]) throws(SQLError) -> Filter {
     try SQL.lower(predicate) { expression throws(SQLError) in
-      try term(expression)
+      try term(expression, routines)
     }
   }
 }
@@ -782,7 +962,8 @@ internal struct Grouping {
   /// `call`/`binary` recurses over its operands; a bare column maps to its key
   /// slot only when it is a `GROUP BY` key, else it is `SQLError.grouping` — the
   /// standard rule.
-  private func term(_ expression: Expression) throws(SQLError) -> Term {
+  private func term(_ expression: Expression,
+                    _ routines: Routines = [:]) throws(SQLError) -> Term {
     if case .aggregate = expression, let slot = slot(of: expression) {
       return .slot(slot)
     }
@@ -797,11 +978,31 @@ internal struct Grouping {
       var lowered = Array<Term>()
       lowered.reserveCapacity(arguments.count)
       for argument in arguments {
-        try lowered.append(term(argument))
+        try lowered.append(term(argument, routines))
       }
       return .apply(name: name, arguments: lowered)
     case let .binary(op, lhs, rhs):
-      return try .binary(op, term(lhs), term(rhs))
+      return try .binary(op, term(lhs, routines), term(rhs, routines))
+    case let .case(whens, otherwise):
+      // Lower each branch's guard and result, and the `ELSE`, against the
+      // grouped slot space — a bare column in any of them must be a `GROUP BY`
+      // key, an aggregate its result slot, as elsewhere in a grouped expression.
+      var branches = Array<(Filter, Term)>()
+      branches.reserveCapacity(whens.count)
+      for branch in whens {
+        try branches.append((lower(branch.when, routines),
+                             term(branch.then, routines)))
+      }
+      let fallback: Term? = if let otherwise {
+        try term(otherwise, routines)
+      } else {
+        nil
+      }
+      // Attach the unified result type — the same `ValueType.unified` reduction
+      // `derive`/`validate` compute — over the grouped scope, so the executor
+      // COERCES the selected branch's value to the advertised column type.
+      let type = try scope.derive(whens, otherwise, routines)
+      return .case(branches, else: fallback, type: type)
     case .aggregate:
       // An aggregate reaches here only when it was not collected — an internal
       // inconsistency, since the query gathers every projection/HAVING aggregate.
@@ -825,7 +1026,8 @@ internal struct Grouping {
   /// output name (an alias, else a bare column's name) so an `ORDER BY` may name
   /// it — the standard alias ordering on an aggregate. A `SELECT *` has no
   /// well-defined meaning over groups (which columns?), so it faults.
-  internal mutating func terms(_ projection: Projection)
+  internal mutating func terms(_ projection: Projection,
+                               _ routines: Routines = [:])
       throws(SQLError) -> Array<Term> {
     switch projection {
     case .all:
@@ -834,7 +1036,7 @@ internal struct Grouping {
       var terms = Array<Term>()
       terms.reserveCapacity(columns.count)
       for column in columns {
-        let term = try term(.column(column))
+        let term = try term(.column(column), routines)
         terms.append(term)
         record(column.name, term)
       }
@@ -843,7 +1045,7 @@ internal struct Grouping {
       var terms = Array<Term>()
       terms.reserveCapacity(items.count)
       for item in items {
-        let term = try term(item.expression)
+        let term = try term(item.expression, routines)
         terms.append(term)
         // Record the output name (`Projected.name` — an alias, else a bare
         // column's name) so an `ORDER BY` may name it (the standard alias
@@ -855,9 +1057,10 @@ internal struct Grouping {
   }
 
   /// Lowers a `HAVING`/predicate to a grouped-space `Filter`.
-  internal func lower(_ predicate: Predicate) throws(SQLError) -> Filter {
+  internal func lower(_ predicate: Predicate,
+                      _ routines: Routines = [:]) throws(SQLError) -> Filter {
     try SQL.lower(predicate) { expression throws(SQLError) in
-      try term(expression)
+      try term(expression, routines)
     }
   }
 

--- a/Sources/SQL/Token.swift
+++ b/Sources/SQL/Token.swift
@@ -50,6 +50,11 @@ extension Token {
     case recursive
     case `true`
     case `false`
+    case `case`
+    case when
+    case then
+    case `else`
+    case end
 
     // Operands.
     case identifier(String)
@@ -122,6 +127,11 @@ extension Token.Kind {
     case .recursive: "RECURSIVE"
     case .true: "TRUE"
     case .false: "FALSE"
+    case .case: "CASE"
+    case .when: "WHEN"
+    case .then: "THEN"
+    case .else: "ELSE"
+    case .end: "END"
     case let .identifier(name): name
     case let .quoted(name): "\"\(name)\""
     case let .string(value): "'\(value)'"

--- a/Tests/SQLTests/AggregateTests.swift
+++ b/Tests/SQLTests/AggregateTests.swift
@@ -425,6 +425,20 @@ struct AggregateTests {
     try catalog.expect("SELECT SUM(X) FROM T", yields: [[32.5]])
   }
 
+  @Test func `an aggregate argument's CASE guard reads the query bindings`() throws {
+    // `SUM(CASE WHEN Region = :target THEN Amount ELSE 0 END)` folds a CASE
+    // whose guard names a `:parameter`; the execution bindings must reach the
+    // aggregate ARGUMENT the same as a projection or WHERE, or `:target` is
+    // unbound, the guard is UNKNOWN for every row, the ELSE 0 always wins, and
+    // the SUM collapses to 0. Bound to `East`, only the East amounts fold —
+    // 10 + 20 + 40 (Toys/East is NULL, skipped) = 70 — neither 0 (the unbound
+    // result) nor 150 (the all-rows SUM(Amount)).
+    try sales().expect("""
+        SELECT SUM(CASE WHEN Region = :target THEN Amount ELSE 0 END)
+          FROM Sales
+        """, yields: [[70]], bindings: ["target": .text("East")])
+  }
+
   @Test func `AVG over a double column is a double`() throws {
     let catalog = try Catalog {
       Relation("T", ["X": .double]) {

--- a/Tests/SQLTests/CaseTests.swift
+++ b/Tests/SQLTests/CaseTests.swift
@@ -1,0 +1,378 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQL
+
+import SQLTestSupport
+
+// MARK: - Fixture
+
+/// A relation exercising the `CASE` expression: an integer `K` that is `NULL`
+/// in one row (so a searched guard and a simple operand meet a NULL), and a
+/// text `Name` to unify or clash result types against.
+private func things() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["Id": .integer, "K": .integer, "Name": .text]) {
+      Row(1, 10, "a")
+      Row(2, 20, "b")
+      Row(3, nil, "c")
+    }
+  }
+}
+
+// MARK: - Parsing
+
+/// Parses `text` and returns its `Select`, failing on any other shape.
+private func parse(select text: String) throws -> Select {
+  guard case let .select(.select(select)) = try Statement(parsing: text) else {
+    Issue.record("expected a single SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return select
+}
+
+struct CaseParsingTests {
+  @Test func `parses a searched CASE`() throws {
+    let select = try parse(select: """
+        SELECT CASE WHEN K = 10 THEN 1 ELSE 0 END FROM T
+        """)
+    let branch = When(when: .comparison(left: .column("K"), op: .equal,
+                                        right: .literal(.integer(10))),
+                      then: .literal(.integer(1)))
+    let expression = Expression.case([branch], else: .literal(.integer(0)))
+    #expect(select.projection == .expressions([Projected(expression: expression)]))
+  }
+
+  @Test func `normalises a simple CASE to a searched one`() throws {
+    // `CASE K WHEN 10 THEN 1 …` becomes `CASE WHEN K = 10 THEN 1 …`.
+    let select = try parse(select: """
+        SELECT CASE K WHEN 10 THEN 1 WHEN 20 THEN 2 END FROM T
+        """)
+    let first = When(when: .comparison(left: .column("K"), op: .equal,
+                                       right: .literal(.integer(10))),
+                     then: .literal(.integer(1)))
+    let second = When(when: .comparison(left: .column("K"), op: .equal,
+                                        right: .literal(.integer(20))),
+                      then: .literal(.integer(2)))
+    let expression = Expression.case([first, second], else: nil)
+    #expect(select.projection == .expressions([Projected(expression: expression)]))
+  }
+
+  @Test func `a CASE with no ELSE has a nil else`() throws {
+    let select = try parse(select: "SELECT CASE WHEN K = 10 THEN 1 END FROM T")
+    guard case let .expressions(items) = select.projection,
+        case let .case(_, otherwise) = items[0].expression else {
+      Issue.record("expected a CASE projection")
+      return
+    }
+    #expect(otherwise == nil)
+  }
+
+  @Test func `rejects a CASE with no WHEN`() {
+    #expect(throws: SQLError.self) {
+      _ = try Statement(parsing: "SELECT CASE ELSE 0 END FROM T")
+    }
+  }
+
+  @Test func `rejects an unterminated CASE`() {
+    #expect(throws: SQLError.self) {
+      _ = try Statement(parsing: "SELECT CASE WHEN K = 1 THEN 2 FROM T")
+    }
+  }
+}
+
+// MARK: - Evaluation
+
+struct CaseEvaluationTests {
+  @Test func `takes the first matching branch`() throws {
+    // K = 10 (row 1) → 1; K = 20 (row 2) → 2; row 3 (K NULL) → the ELSE, 0.
+    try things().expect("""
+        SELECT CASE WHEN K = 10 THEN 1 WHEN K = 20 THEN 2 ELSE 0 END FROM T
+        """, yields: [[1], [2], [0]])
+  }
+
+  @Test func `an earlier branch wins over a later one`() throws {
+    // Both guards hold for K = 10, but the first wins.
+    try things().expect("""
+        SELECT CASE WHEN K = 10 THEN 100 WHEN K >= 10 THEN 200 ELSE 0 END
+          FROM T WHERE Id = 1
+        """, yields: [[100]])
+  }
+
+  @Test func `no matching branch and no ELSE yields NULL`() throws {
+    // No K equals 99, and there is no ELSE, so every row yields NULL.
+    try things().expect("SELECT CASE WHEN K = 99 THEN 1 END FROM T",
+                        yields: [[nil], [nil], [nil]])
+  }
+
+  @Test func `an UNKNOWN guard skips its branch`() throws {
+    // Row 3's K is NULL, so `K = 10` is UNKNOWN — the branch is skipped, not
+    // taken — and the ELSE yields 9. Rows 1 and 2 take a matching branch.
+    try things().expect("""
+        SELECT CASE WHEN K = 10 THEN 1 WHEN K = 20 THEN 2 ELSE 9 END FROM T
+        """, yields: [[1], [2], [9]])
+  }
+
+  @Test func `a simple CASE with a NULL operand takes the ELSE`() throws {
+    // Row 3's K is NULL, so `K = 10`/`K = 20` are both UNKNOWN (a NULL operand
+    // matches no WHEN value); the ELSE yields 0. Rows 1 and 2 match.
+    try things().expect("""
+        SELECT CASE K WHEN 10 THEN 1 WHEN 20 THEN 2 ELSE 0 END FROM T
+        """, yields: [[1], [2], [0]])
+  }
+
+  @Test func `a CASE in a WHERE filters rows`() throws {
+    // Keep rows whose CASE yields a truthy 1: K = 10 or K = 20.
+    try things().expect("""
+        SELECT Id FROM T
+          WHERE CASE WHEN K = 10 THEN 1 WHEN K = 20 THEN 1 ELSE 0 END = 1
+        """, yields: [[1], [2]])
+  }
+
+  @Test func `a mixed CASE coerces the integer branch to double`() throws {
+    // The results unify to `.double`, so the schema advertises the column as
+    // double; the executor must COERCE the selected branch's value to match.
+    // Row 1 takes the integer THEN `1`, which widens to `.double(1.0)` rather
+    // than staying `.integer(1)`; rows 2 and 3 take the double ELSE `2.5`.
+    try things().expect(
+        "SELECT CASE WHEN Id = 1 THEN 1 ELSE 2.5 END AS C FROM T",
+        yields: [[1.0], [2.5], [2.5]])
+  }
+
+  @Test func `an all-integer CASE is not coerced`() throws {
+    // The results unify to `.integer` — no widening — so each branch value is
+    // yielded unchanged as an integer, never a spurious double.
+    try things().expect(
+        "SELECT CASE WHEN Id = 1 THEN 1 ELSE 2 END AS C FROM T",
+        yields: [[1], [2], [2]])
+  }
+
+  @Test func `a no-match mixed CASE with no ELSE stays NULL`() throws {
+    // A mixed integer/double CASE unifies to `.double`, but no K matches and
+    // there is no ELSE, so every row yields NULL — coercion to `.double` leaves
+    // NULL as NULL, never a double.
+    try things().expect("""
+        SELECT CASE WHEN K = 98 THEN 1 WHEN K = 99 THEN 2.5 END AS C FROM T
+        """, yields: [[nil], [nil], [nil]])
+  }
+}
+
+// MARK: - Type unification
+
+struct CaseTypeTests {
+  private func parse(_ text: String) throws -> Query {
+    guard case let .select(query) = try Statement(parsing: text) else {
+      Issue.record("expected a SELECT statement")
+      throw SQLError.incomplete(expected: "a SELECT statement")
+    }
+    return query
+  }
+
+  /// The single output column type of a one-column query's schema.
+  private func type(of text: String) throws -> ValueType {
+    let columns = try things().columns(of: parse(text))
+    #expect(columns.count == 1)
+    return columns[0].type
+  }
+
+  @Test func `like result types unify to that type`() throws {
+    #expect(try type(of: "SELECT CASE WHEN K = 1 THEN K ELSE 0 END AS C FROM T")
+                == .integer)
+  }
+
+  @Test func `mixed integer and double results widen to double`() throws {
+    #expect(try type(of:
+        "SELECT CASE WHEN K = 1 THEN 1 ELSE 2.5 END AS C FROM T") == .double)
+  }
+
+  @Test func `irreconcilable result types fault`() throws {
+    // An integer result beside a text result cannot yield one column type.
+    let query = try parse(
+        "SELECT CASE WHEN K = 1 THEN 1 ELSE Name END AS C FROM T")
+    let resolve = { () throws -> Array<OutputColumn> in
+      try things().columns(of: query)
+    }
+    #expect(throws:
+        SQLError.operand("CASE results have irreconcilable types")) {
+      try resolve()
+    }
+  }
+
+  @Test func `running an irreconcilable CASE faults like the type check`()
+      throws {
+    // A row-dependent guard (`Id = 2`, matched by a fixture row) keeps both the
+    // text `Name` branch and the integer `0` ELSE reachable — a constant guard
+    // would drop an arm and mask the clash. Lowering unifies the reachable
+    // result types just as the type check does, so the RUN faults with the same
+    // error rather than leaking a text value at a column typed by the first
+    // branch; `columns(of:)` faults identically, so the two paths AGREE.
+    let text =
+        "SELECT CASE WHEN Id = 2 THEN Name ELSE 0 END FROM T"
+    try things().expect(text,
+        fails: .operand("CASE results have irreconcilable types"))
+    let resolve = { () throws -> Array<OutputColumn> in
+      try things().columns(of: parse(text))
+    }
+    #expect(throws:
+        SQLError.operand("CASE results have irreconcilable types")) {
+      try resolve()
+    }
+  }
+}
+
+// MARK: - Branch reachability
+
+/// The type check honours the executor's short-circuit: a `WHEN` whose guard is
+/// statically constant-FALSE has an unreachable result the run never evaluates,
+/// so its operands are not validated; once an earlier guard is constant-TRUE
+/// every later branch and the `ELSE` are unreachable too.
+struct CaseReachabilityTests {
+  private func parse(_ text: String) throws -> Query {
+    guard case let .select(query) = try Statement(parsing: text) else {
+      Issue.record("expected a SELECT statement")
+      throw SQLError.incomplete(expected: "a SELECT statement")
+    }
+    return query
+  }
+
+  @Test func `a constant-false guard's bad result is unreachable`() throws {
+    // `1 = 0` is statically false, so `Name + 1` (text arithmetic) is never
+    // evaluated — the type check validates the reachable `ELSE 0` only and the
+    // column types as its integer.
+    let query = try parse(
+        "SELECT CASE WHEN 1 = 0 THEN Name + 1 ELSE 0 END AS C FROM T")
+    let columns = try things().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+    #expect(columns[0].type == .integer)
+  }
+
+  @Test func `a constant-false-guarded bad branch runs`() throws {
+    // The same query runs: the false guard skips `Name + 1`, so every row takes
+    // the ELSE 0.
+    try things().expect(
+        "SELECT CASE WHEN 1 = 0 THEN Name + 1 ELSE 0 END FROM T",
+        yields: [[0], [0], [0]])
+  }
+
+  @Test func `a reachable bad result still faults`() throws {
+    // `Id = 1` is per-row, not statically false, so `Name + 1` IS reachable and
+    // the text arithmetic must still fault.
+    let query = try parse(
+        "SELECT CASE WHEN Id = 1 THEN Name + 1 ELSE 0 END AS C FROM T")
+    let resolve = { () throws -> Array<OutputColumn> in
+      try things().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.operand("operands must be numeric")) {
+      try resolve()
+    }
+  }
+
+  @Test func `a constant-true guard makes a later bad branch unreachable`()
+      throws {
+    // `1 = 1` is statically true, so the first branch always wins and the later
+    // `WHEN 1 = 1 THEN Name + 1` is unreachable — its operands are not
+    // validated, so the type check passes and the column types as the first
+    // result's integer.
+    let query = try parse("""
+        SELECT CASE WHEN 1 = 1 THEN 0 WHEN 1 = 1 THEN Name + 1 END AS C FROM T
+        """)
+    let columns = try things().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+    #expect(columns[0].type == .integer)
+  }
+
+  @Test func `an earlier branch before a constant-true guard stays reachable`()
+      throws {
+    // `WHEN 1 = 1` is constant-TRUE, but it comes AFTER the row-dependent `WHEN
+    // Id = 1`, which a row with `Id = 1` still matches — so that earlier branch
+    // is REACHABLE and its `Name + 1` (text arithmetic) must still fault. The
+    // constant-TRUE guard drops only the STRICTLY-LATER branches and the ELSE,
+    // not the branches before it.
+    let query = try parse("""
+        SELECT CASE WHEN Id = 1 THEN Name + 1 WHEN 1 = 1 THEN 0 END AS C FROM T
+        """)
+    let resolve = { () throws -> Array<OutputColumn> in
+      try things().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.operand("operands must be numeric")) {
+      try resolve()
+    }
+  }
+
+  @Test func `an earlier branch clashing a constant-true guard's type reports`()
+      throws {
+    // The earlier reachable `THEN Name` (text) and the constant-TRUE guard's
+    // `THEN 0` (integer) both shape the column, so their irreconcilable types
+    // must be reported rather than the constant-TRUE branch's alone winning.
+    let query = try parse("""
+        SELECT CASE WHEN Id = 1 THEN Name WHEN 1 = 1 THEN 0 END AS C FROM T
+        """)
+    let resolve = { () throws -> Array<OutputColumn> in
+      try things().columns(of: query, validate: true)
+    }
+    #expect(throws:
+        SQLError.operand("CASE results have irreconcilable types")) {
+      try resolve()
+    }
+  }
+}
+
+// MARK: - Empty-group folding
+
+/// The schema validator folds the projection over the single empty group a
+/// constant-false `WHERE` leaves (`Scope.empty`), exactly as a run does — so a
+/// CASE there must COERCE its selected value to the unified result type, just
+/// as the executor's `Row.conditional` does, or the folded value clashes the
+/// advertised column type and a routine argument the run accepts is rejected.
+struct CaseEmptyGroupTests {
+  private func parse(_ text: String) throws -> Query {
+    guard case let .select(query) = try Statement(parsing: text) else {
+      Issue.record("expected a SELECT statement")
+      throw SQLError.incomplete(expected: "a SELECT statement")
+    }
+    return query
+  }
+
+  /// `CASE WHEN COUNT(*) = 0 THEN COUNT(*) ELSE 2.5 END` — a mixed CASE whose
+  /// guard is NOT statically decidable (a `COUNT(*)` operand), so BOTH arms are
+  /// reachable and the result unifies to `.double`. Over the empty group
+  /// `COUNT(*)` is `0`, so the guard folds TRUE and the integer `COUNT(*)` arm
+  /// is selected — folding to `0`, which must WIDEN to the unified `.double`.
+  private func mixed() -> Expression {
+    let guard0 = Predicate.comparison(left: .aggregate(.count, of: .star),
+                                      op: .equal,
+                                      right: .literal(.integer(0)))
+    let branch = When(when: guard0,
+                      then: .aggregate(.count, of: .star))
+    return .case([branch], else: .literal(.double(2.5)))
+  }
+
+  @Test func `the empty-group fold coerces the selected value`() throws {
+    // The whole-result group over no rows folds `COUNT(*)` to `0`; the CASE
+    // unifies to `.double`, so the fold yields `.double(0.0)`, not
+    // `.integer(0)` — matching the run, whose executor coerces the same value.
+    #expect(try Scope([]).empty(mixed()) == .double(0.0))
+  }
+
+  @Test func `a DOUBLE routine accepts the coerced empty-group CASE`()
+      throws {
+    // `f(x DOUBLE) RETURNS DOUBLE AS x` over the mixed CASE: the constant-false
+    // WHERE leaves one empty group, so `columns(of:)` folds the projection and
+    // dispatches the routine over the folded argument. The coerced
+    // `.double(0.0)` satisfies the DOUBLE parameter — schema validation
+    // SUCCEEDS, as the run does; a raw `.integer(0)` would fault
+    // `SQLError.argument`.
+    let f = Function(parameters: [Function.Parameter(name: "x", type: .double)],
+                     returns: .double, body: .column("x"))
+    let routines = try Routines().registering("f", f)
+    let query = try parse("""
+        SELECT f(CASE WHEN COUNT(*) = 0 THEN COUNT(*) ELSE 2.5 END) AS C
+          FROM T WHERE 1 = 0
+        """)
+    let columns = try things().columns(of: query, routines: routines,
+                                       validate: true)
+    #expect(columns.count == 1)
+    #expect(columns[0].type == .double)
+  }
+}

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -2313,6 +2313,18 @@ struct EngineDefinedFunctionTests {
     }
   }
 
+  @Test func `a defined function body referencing a query parameter faults at define`() throws {
+    // A body's inputs are its declared parameters, not query bindings: a routine
+    // body is evaluated with only its argument record, so a `:parameter` (here
+    // reached through a CASE guard) would always be UNBOUND and silently pick
+    // the ELSE branch. Registration rejects the `.bound`.
+    #expect(throws:
+        SQLError.argument("the body cannot reference a query parameter")) {
+      _ = try defining("CREATE FUNCTION f() RETURNS INTEGER AS "
+                           + "CASE WHEN 1 = :p THEN 1 ELSE 0 END")
+    }
+  }
+
   @Test func `a later defined function shadows an earlier one of the same name`() throws {
     // A later registration wins (the house rule the flat registry follows), so
     // the second `inc` — adding 100 — is the one a call resolves.

--- a/Tests/SQLTests/FunctionTests.swift
+++ b/Tests/SQLTests/FunctionTests.swift
@@ -308,4 +308,60 @@ private func id() -> Function {
     try numbers().expect("SELECT g() FROM N WHERE Id = 1",
                          yields: [["x"]], routines: routines)
   }
+
+  @Test func `a body referencing a query parameter faults at registration`() {
+    // A body's inputs are its declared parameters, not query bindings. `f() AS
+    // CASE WHEN 1 = :p THEN 1 ELSE 0 END` reaches a `:parameter` through a CASE
+    // guard, but a routine body is evaluated with only its argument record — the
+    // caller's bindings never reach it — so `:p` would always be UNBOUND and
+    // silently pick the ELSE branch. The registration rejects the `.bound`.
+    let body =
+        Expression.case([When(when: .bound(left: .literal(.integer(1)),
+                                           op: .equal, parameter: "p"),
+                              then: .literal(.integer(1)))],
+                        else: .literal(.integer(0)))
+    let function = Function(parameters: [], returns: .integer, body: body)
+    #expect(throws:
+        SQLError.argument("the body cannot reference a query parameter")) {
+      _ = try Routines().registering("f", function)
+    }
+  }
+
+  @Test func `a body with a bound-free CASE registers cleanly`() throws {
+    // The rejection is of a `.bound` specifically, not of a CASE in a body: a
+    // guard over the parameter (`CASE WHEN n = 7 THEN 1 ELSE 0 END`) registers
+    // and computes — here yielding 1 for the matching argument (N.V is 7).
+    let body =
+        Expression.case([When(when: .comparison(left: .column("n"),
+                                                op: .equal,
+                                                right: .literal(.integer(7))),
+                              then: .literal(.integer(1)))],
+                        else: .literal(.integer(0)))
+    let function =
+        Function(parameters: [Function.Parameter(name: "n", type: .integer)],
+                 returns: .integer, body: body)
+    let routines = try Routines().registering("seven", function)
+    try numbers().expect("SELECT seven(V) FROM N WHERE Id = 1",
+                         yields: [[1]], routines: routines)
+  }
+
+  @Test func `a RETURNS DOUBLE body of a mixed CASE returns a double`() throws {
+    // `f(n INTEGER) RETURNS DOUBLE AS CASE WHEN n = 7 THEN 1 ELSE 2.5 END`: the
+    // body's results unify to `.double`, so it TYPES as double and the RETURNS
+    // check passes. Called with N.V = 7 it takes the integer THEN `1`, which
+    // the CASE coercion widens to `.double(1.0)` — the value now matches the
+    // declared double return, not a bare `.integer(1)`.
+    let body =
+        Expression.case([When(when: .comparison(left: .column("n"),
+                                                op: .equal,
+                                                right: .literal(.integer(7))),
+                              then: .literal(.integer(1)))],
+                        else: .literal(.double(2.5)))
+    let function =
+        Function(parameters: [Function.Parameter(name: "n", type: .integer)],
+                 returns: .double, body: body)
+    let routines = try Routines().registering("choose", function)
+    try numbers().expect("SELECT choose(V) FROM N WHERE Id = 1",
+                         yields: [[1.0]], routines: routines)
+  }
 }


### PR DESCRIPTION
Add the ISO `CASE` value expression in both forms — searched `CASE WHEN cond THEN r … [ELSE r] END` and simple `CASE op WHEN v THEN r … [ELSE r] END` — usable anywhere a scalar expression is (projection, WHERE, …).

The AST models one conditional, `Expression.case(Array<When>, else: Expression?)`, each `When` a guard `Predicate` and a result `Expression`. The parser normalises a simple `CASE op WHEN v` to the searched `WHEN op = v` at parse time, so the engine carries a single shape. A branch is taken on the FIRST guard that is three-valued TRUE (UNKNOWN and FALSE skip); with none matching the `ELSE` result, or NULL when there is no `ELSE` — so a simple `CASE` over a NULL operand matches no branch and falls to the `ELSE`.

The engine lowers it to a new `Term.case([(Filter, Term)], else: Term?, type:)` — the one lowered case a conditional needs — evaluated by taking the first guard `Filter` that is TRUE. Guard evaluation threads the query bindings through `Term` evaluation (a new defaulted parameter), so a `:parameter` guard resolves like a `WHERE` one; `Filter` gains the `Sendable` conformance `Term` requires. Resolution reconciles the result types by a new `ValueType.unified(with:)` — like types unify, a mixed integer/double pair widens to `double`, and an irreconcilable pair (text beside integer) faults `SQLError.operand` — with the non-faulting schema `derive` falling back to the first result's type.

The lowered term carries that unified `type` — computed at every lowering surface by the SAME `deriveCase` reduction (`ValueType.unified` over the reachable branch results) the schema `derive` uses, so the lowering and the type-check agree — and the evaluator COERCES the selected branch's value to it. Without this the schema would advertise a `DOUBLE` column for `CASE WHEN Id = 1 THEN 1 ELSE 2.5 END` while a branch-1 row yielded a raw `.integer(1)`, the value contradicting the advertised type; the same mismatch let a defined function `RETURNS DOUBLE` with such a CASE body return an integer. `Value.coerced(to:)` performs the one widening `ValueType.unified` can produce — an `.integer` to `.double` when the unified type is `.double` — leaving NULL and an already-matching value unchanged, so an all-same CASE (no widening) is untouched. Threading the run's `routines` into lowering lets `deriveCase` type a scalar-call arm (a UDF `RETURNS DOUBLE`) exactly as the output schema does.

Both type-check surfaces honour the executor's short-circuit, so they validate and type only REACHABLE branches. A `WHEN` whose guard is statically constant-FALSE (folded by the existing `constant`) has a result the run never evaluates, so its operands are not validated. A constant-TRUE guard is itself reachable and KEEPS every EARLIER reachable branch — a row an earlier row-dependent guard matches takes that branch, never reaching the constant-TRUE one — so those earlier results are still validated and typed; it drops only the STRICTLY-LATER `WHEN`s and the `ELSE`. `CASE WHEN 1 = 0 THEN Name + 1 ELSE 0 END` thus type-checks and runs — the false guard spares the text arithmetic `Name + 1` — while a reachable bad operand (`WHEN Id = 1 THEN Name + 1`, or the same before a later constant-TRUE guard) still faults. Result-type unification (both the faulting `validate` and the schema `derive`) runs over that full reachable set, so an earlier reachable result's type still shapes and can clash the column rather than a later constant-TRUE branch's winning alone. A `CASE` whose guard is an `IN` inherits the IN OR-chain's short-circuit through `constant`, so `CASE WHEN 1 IN (1, Name + 1) THEN 0 ELSE Name + 1 END` sees a constant-TRUE guard and spares the ELSE.

A `CASE` guard is the one place a `Predicate` — and thus a `.bound` `:parameter` — can hide inside a scalar `Expression`, which surfaces a defined-function body hazard: a body is validated over its positional parameter schema and later evaluated against ONLY the argument record, so a query binding never reaches it. `CREATE FUNCTION f() RETURNS INTEGER AS CASE WHEN 1 = :p THEN 1 ELSE 0 END` was accepted and lowered with a `.bound(:p)` guard that is always UNBOUND at call time, silently taking the ELSE branch. Reject it at registration: a new `Expression.bound` / `Predicate.bound` walk (mirroring `aggregated`) reports a `.bound` in any position of the body, and `Routine`'s defined initializer faults `SQLError.argument` — a body's inputs are its declared parameters, not query bindings — rather than lowering a reference that can never resolve.

Reject an irreconcilable CASE when LOWERING, not only when validating. The schema `validate` (`conditional`) already faulted `SQLError.operand` on a reachable pair of result types that does not unify, but `run` lowers through the CASE type helper, which merely defaulted to the first result's type — so `SELECT CASE WHEN Id = 2 THEN Name ELSE 0 END FROM T` compiled and leaked a text value at runtime under an integer column. That helper now faults on the same non-unifying reachable pair with the same error, so lowering and the type check AGREE: a mixed integer/double CASE still widens to `double`, only a definitively-irreconcilable pair faults.

The CASE type helper is an OVERLOAD of `derive` — `derive(_ whens:_ otherwise:_ routines:)` beside the scalar `derive(_ expression:_ routines:)` — rather than the compound `deriveCase`, which the coding style reserves for type names.