### PR TITLE
SQL: add the IN value-list predicate

### DIFF
--- a/Sources/SQL/AST.swift
+++ b/Sources/SQL/AST.swift
@@ -495,6 +495,14 @@ public indirect enum Predicate: Hashable, Sendable {
   /// nullable column — an absent decoded attribute — is filtered (`WHERE iid IS
   /// NOT NULL`).
   case null(Expression, negated: Bool)
+  /// `operand IN (v, …)`, or `NOT IN` when `negated` — whether the operand
+  /// equals any value of the non-empty `values` list. It is ISO shorthand for a
+  /// disjunction of equalities under three-valued logic: `x IN (a, b)` is `x = a
+  /// OR x = b`, so a NULL operand or a NULL element makes an otherwise-unmatched
+  /// test UNKNOWN rather than FALSE, and `NOT IN` is the negation of that (never
+  /// TRUE when a NULL element is present). The engine lowers it to that
+  /// disjunction rather than carrying a dedicated `Filter` case.
+  case membership(Expression, Array<Expression>, negated: Bool)
   /// `lhs AND rhs`.
   case and(Predicate, Predicate)
   /// `lhs OR rhs`.

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -628,6 +628,8 @@ extension Predicate {
       left.aggregated
     case let .null(operand, _):
       operand.aggregated
+    case let .membership(operand, values, _):
+      operand.aggregated || values.contains { $0.aggregated }
     case let .and(lhs, rhs), let .or(lhs, rhs):
       lhs.aggregated || rhs.aggregated
     case let .not(operand):
@@ -647,6 +649,8 @@ extension Predicate {
       left.bound || right.bound
     case let .null(operand, _):
       operand.bound
+    case let .membership(operand, values, _):
+      operand.bound || values.contains { $0.bound }
     case let .and(lhs, rhs), let .or(lhs, rhs):
       lhs.bound || rhs.bound
     case let .not(operand):
@@ -873,6 +877,9 @@ extension Predicate {
       left.collect(into: &expressions)
     case let .null(expression, _):
       expression.collect(into: &expressions)
+    case let .membership(operand, values, _):
+      operand.collect(into: &expressions)
+      for value in values { value.collect(into: &expressions) }
     case let .and(lhs, rhs), let .or(lhs, rhs):
       lhs.collect(into: &expressions)
       rhs.collect(into: &expressions)

--- a/Sources/SQL/Filter.swift
+++ b/Sources/SQL/Filter.swift
@@ -29,6 +29,15 @@ internal indirect enum Filter: Sendable {
   /// `term IS NULL`, or `IS NOT NULL` when `negated` — the lowered form of the
   /// AST's `null`, a definite two-valued test (never UNKNOWN).
   case null(Term, negated: Bool)
+  /// `operand [NOT] IN (element, …)` — the lowered form of the AST's
+  /// `membership`. The operand term is held ONCE, the value list lowered to
+  /// element terms, and `negated` marks `NOT IN`. Evaluating it reads the
+  /// operand exactly once per row (an OR-chain of `compare`s would re-evaluate
+  /// a non-idempotent operand, once per element) and folds `operand = element`
+  /// over the elements IN ORDER under Kleene `OR`, short-circuiting at the
+  /// first TRUE; `NOT IN` negates that three-valued truth (UNKNOWN maps to
+  /// itself).
+  case membership(Term, Array<Term>, negated: Bool)
   /// `lhs AND rhs`.
   case and(Filter, Filter)
   /// `lhs OR rhs`.
@@ -144,6 +153,10 @@ extension Filter {
       .match(slot[left]!, slot[right]!)
     case let .null(term, negated):
       .null(term.remapped(through: slot), negated: negated)
+    case let .membership(operand, elements, negated):
+      .membership(operand.remapped(through: slot),
+                  elements.map { $0.remapped(through: slot) },
+                  negated: negated)
     case let .and(lhs, rhs):
       .and(lhs.remapped(through: slot), rhs.remapped(through: slot))
     case let .or(lhs, rhs):
@@ -215,6 +228,8 @@ extension Filter {
     case let .bound(term, _, _): term.safe
     case .match: true
     case let .null(term, _): term.safe
+    case let .membership(operand, elements, _):
+      operand.safe && elements.allSatisfy(\.safe)
     case let .and(lhs, rhs): lhs.safe && rhs.safe
     case let .or(lhs, rhs): lhs.safe && rhs.safe
     case let .not(operand): operand.safe
@@ -243,7 +258,7 @@ extension Filter {
   private var parameterised: Bool {
     switch self {
     case .bound: true
-    case .compare, .match, .null: false
+    case .compare, .match, .null, .membership: false
     case let .and(lhs, rhs): lhs.parameterised || rhs.parameterised
     case let .or(lhs, rhs): lhs.parameterised || rhs.parameterised
     case let .not(operand): operand.parameterised
@@ -556,6 +571,8 @@ extension Row where Self: ~Escapable {
       matches(self[left], .equal, self[right])
     case let .null(term, negated):
       try (evaluate(term, routines, bindings) == .null) != negated
+    case let .membership(operand, elements, negated):
+      try member(operand, elements, negated, routines, bindings)
     case let .and(lhs, rhs):
       // `&&`/`||` take an `@autoclosure` right operand, which would capture the
       // borrowed `~Escapable` row; spell each connective explicitly so a branch
@@ -577,5 +594,29 @@ extension Row where Self: ~Escapable {
     case let .not(operand):
       try evaluate(operand, routines, bindings).map { !$0 }
     }
+  }
+
+  /// Evaluates a lowered `operand [NOT] IN (element, …)` against this row.
+  ///
+  /// The `operand` is evaluated ONCE per row — an OR-chain of `compare`s would
+  /// re-evaluate a non-idempotent operand once per element — then `operand =
+  /// element` folds over the elements IN ORDER under Kleene `OR`, seeded FALSE
+  /// and short-circuiting at the first TRUE (the same left-to-right visit the
+  /// OR-chain made, so a NULL operand or a NULL element keeps the ISO
+  /// three-valued result: an unmatched test yields UNKNOWN, not FALSE). `NOT
+  /// IN` negates that three-valued truth, mapping UNKNOWN to itself via
+  /// `map(!)`.
+  private borrowing func member(_ operand: Term, _ elements: Array<Term>,
+                                _ negated: Bool, _ routines: Routines,
+                                _ bindings: Bindings)
+      throws(SQLError) -> Bool? {
+    let value = try evaluate(operand, routines, bindings)
+    var truth: Bool? = false
+    for element in elements {
+      let element = try evaluate(element, routines, bindings)
+      truth = or(truth, matches(value, .equal, element))
+      if truth == true { break }
+    }
+    return negated ? truth.map { !$0 } : truth
   }
 }

--- a/Sources/SQL/Function.swift
+++ b/Sources/SQL/Function.swift
@@ -29,6 +29,17 @@
 /// defined. A routine that cannot map its arguments throws `SQLError`; one that
 /// does not declare a result type is `.integer`, the engine's exact-numeric
 /// default.
+///
+/// A routine also declares whether it is DETERMINISTIC — ISO SQL's
+/// `DETERMINISTIC` / `NOT DETERMINISTIC` characteristic: a deterministic
+/// routine returns the same value for the same arguments every time and has no
+/// side effect, so the engine may execute it at COMPILE time to fold a
+/// row-independent call (see `Resolve`'s `constant(_:_:)`). A NOT
+/// DETERMINISTIC routine — the default for a host-registered closure, which may
+/// be stateful or observe the clock — is NEVER executed at compile time: it
+/// could return one value while types are being computed and another when the
+/// row is actually reached. The RUN path invokes any routine regardless;
+/// determinism gates only compile-time folding.
 public struct Routine: Sendable {
   /// A routine's implementation — a native Swift closure or a defined SQL
   /// expression body.
@@ -52,14 +63,22 @@ public struct Routine: Sendable {
   /// The declared result type, read to type a call statically.
   public let returns: ValueType
 
+  /// Whether this routine is DETERMINISTIC (ISO SQL) — same arguments yield the
+  /// same value with no side effect. Only a deterministic routine is folded at
+  /// compile time (`Resolve`'s `constant(_:_:)`); a NOT DETERMINISTIC one is
+  /// left for the run to invoke.
+  public let deterministic: Bool
+
   /// The routine's implementation.
   private let body: Body
 
   public init(returns: ValueType = .integer, parameters: Array<ValueType>,
+              deterministic: Bool = false,
               _ compute: @escaping @Sendable (Array<Value>)
                   throws(SQLError) -> Value) {
     self.parameters = parameters
     self.returns = returns
+    self.deterministic = deterministic
     self.body = .native(compute)
   }
 
@@ -92,6 +111,11 @@ public struct Routine: Sendable {
   /// what the returns validation resolves the body's own calls against AND what
   /// the `.defined` case captures, so a nested call evaluates against exactly
   /// the map it was typed against — the two are consistent by construction.
+  ///
+  /// A defined routine is NOT DETERMINISTIC: the DDL (`CREATE FUNCTION`) has no
+  /// `DETERMINISTIC` clause yet, so ISO's default characteristic applies and
+  /// the body is never folded at compile time — the safe choice, since it may
+  /// call a non-deterministic routine.
   internal init(returns: ValueType, parameters: Array<ValueType>,
                 names: Array<String>, body: Expression,
                 _ routines: Routines) throws(SQLError) {
@@ -114,6 +138,7 @@ public struct Routine: Sendable {
     }
     self.parameters = parameters
     self.returns = returns
+    self.deterministic = false
     self.body =
         try .defined(schema.term(body, in: Relation(name: ""), routines),
                      routines)
@@ -224,7 +249,11 @@ public struct Routines: Sendable {
   /// A copy of these routines with a routine computing `compute`, accepting
   /// `parameters` (default none), and returning `returns` (default `.integer`)
   /// bound to `name` (folded to lower case), the binding shadowing any existing
-  /// one.
+  /// one. `deterministic` declares the routine's ISO SQL characteristic and
+  /// defaults to `false` (NOT DETERMINISTIC) — the safe default for a host
+  /// closure, which may be stateful or read the clock: it is not executed at
+  /// compile time. Pass `true` for a pure routine to let a row-independent call
+  /// fold.
   //
   // `SQL.Value` is spelled in full here and in `bitand`: `Routines` conforms to
   // `ExpressibleByDictionaryLiteral`, whose associated `Value` is the literal's
@@ -232,11 +261,13 @@ public struct Routines: Sendable {
   // element, not the engine cell the routine computes.
   public func registering(_ name: String, returns: ValueType = .integer,
                           parameters: Array<ValueType> = [],
+                          deterministic: Bool = false,
                           _ compute: @escaping @Sendable (Array<SQL.Value>)
                               throws(SQLError) -> SQL.Value) -> Routines {
     var functions = self.functions
     functions[name.lowercased()] =
-        Routine(returns: returns, parameters: parameters, compute)
+        Routine(returns: returns, parameters: parameters,
+                deterministic: deterministic, compute)
     return Routines(functions)
   }
 
@@ -311,8 +342,11 @@ public struct Routines: Sendable {
   /// shadow one (see `subscript(_:)`). Its lone member is `BITAND`, the
   /// portable, standards-compliant spelling (Oracle's) of a bitwise AND — an
   /// operation ISO SQL and this grammar otherwise lack; it returns an integer.
+  /// It is DETERMINISTIC — a pure bitwise fold — so a row-independent call may
+  /// fold at compile time.
   public static let standard: Routines =
-      ["bitand": Routine(parameters: [.integer, .integer], bitand)]
+      ["bitand": Routine(parameters: [.integer, .integer],
+                         deterministic: true, bitand)]
 
   /// `BITAND(x, y)` — the bitwise AND of two integers. A NULL argument yields
   /// NULL (SQL null propagation); the wrong argument count or a non-integer

--- a/Sources/SQL/Lexer.swift
+++ b/Sources/SQL/Lexer.swift
@@ -419,6 +419,7 @@ internal struct Lexer: ~Escapable {
     case "AS": .as
     case "IS": .is
     case "NULL": .null
+    case "IN": .in
     case "UNION": .union
     case "ALL": .all
     case "WITH": .with

--- a/Sources/SQL/OutputColumn.swift
+++ b/Sources/SQL/OutputColumn.swift
@@ -347,7 +347,7 @@ extension Catalog where Self: ~Escapable {
       // operand never evaluates (it propagates NULL), but the HAVING and
       // projection run over the group's results, so EVALUATE them (`empty`) — a
       // divide, overflow, or bad routine call faults as the run would.
-      if scope.constant(predicate) == false {
+      if scope.constant(predicate, routines) == false {
         if select.aggregates, select.grouping.isEmpty {
           if let having = select.having {
             // HAVING filters the group BEFORE any OFFSET/FETCH limit, so
@@ -385,7 +385,7 @@ extension Catalog where Self: ~Escapable {
       try scope.check(having, routines)
       // A false HAVING filters every group before the projection, so the
       // projection's non-aggregate work is unreachable.
-      if scope.constant(having) == false { return }
+      if scope.constant(having, routines) == false { return }
     }
     // The projection runs after any limit: a limit that drops every row it
     // would yield leaves only its aggregate folds (validated above) reachable.

--- a/Sources/SQL/Parser.swift
+++ b/Sources/SQL/Parser.swift
@@ -33,7 +33,8 @@
 /// conjunction    := negation (AND negation)*
 /// negation       := NOT negation | primary
 /// primary        := '(' predicate ')' | comparison
-/// comparison     := expression (op (expression | param) | IS [NOT] NULL)
+/// comparison     := expression (op (expression | param) | IS [NOT] NULL
+///                 | [NOT] IN '(' expression (',' expression)* ')')
 /// expression     := additive
 /// additive       := multiplicative (('+' | '-') multiplicative)*
 /// multiplicative := factor (('*' | '/') factor)*
@@ -674,20 +675,31 @@ internal struct Parser: ~Escapable {
     return predicate
   }
 
-  /// Parses `expression (op (expression | :parameter) | IS [NOT] NULL)`.
+  /// Parses `expression (op (expression | :parameter) | IS [NOT] NULL | [NOT]
+  /// IN '(' expression (',' expression)* ')')`.
   ///
   /// Either operand may be a column, a literal, or a scalar-function call, so a
   /// predicate can filter on a decoded value (`WHERE guid(Id) = '…'`). A
   /// `:parameter` right operand binds the comparison to a value resolved at run
   /// time from the engine's bindings — the correlated-subquery primitive. An
   /// `IS NULL` (or `IS NOT NULL`) tail tests the left expression for `NULL`
-  /// rather than comparing it — the way a nullable column is filtered.
+  /// rather than comparing it — the way a nullable column is filtered. An `IN`
+  /// (or `NOT IN`) tail tests the left expression for membership in a
+  /// parenthesised value list. A leading `NOT` here can only introduce `NOT IN`:
+  /// a prefix `NOT` predicate is consumed by `negation` before this point.
   private mutating func comparison() throws(SQLError) -> Predicate {
     let left = try expression()
     if try match(.is) {
       let negated = try match(.not)
       try expect(.null)
       return .null(left, negated: negated)
+    }
+    if try match(.in) {
+      return try membership(left, negated: false)
+    }
+    if try match(.not) {
+      try expect(.in)
+      return try membership(left, negated: true)
     }
     let op = try op()
     if case let .parameter(name) = current?.kind {
@@ -696,6 +708,24 @@ internal struct Parser: ~Escapable {
     }
     let right = try expression()
     return .comparison(left: left, op: op, right: right)
+  }
+
+  /// Parses the value-list tail of `left [NOT] IN (…)` — the `IN` is already
+  /// consumed — into a `membership` predicate over `left`.
+  ///
+  /// The list is parenthesised and non-empty: at least one value expression,
+  /// then any number of comma-separated ones. The subquery form `IN (SELECT …)`
+  /// is not supported, so the parenthesised items are ordinary scalar
+  /// expressions.
+  private mutating func membership(_ left: Expression, negated: Bool)
+      throws(SQLError) -> Predicate {
+    try expect(.lparen)
+    var values = [try expression()]
+    while try match(.comma) {
+      try values.append(expression())
+    }
+    try expect(.rparen)
+    return .membership(left, values, negated: negated)
   }
 
   /// Parses a comparison operator.

--- a/Sources/SQL/Resolve.swift
+++ b/Sources/SQL/Resolve.swift
@@ -36,6 +36,16 @@ private func lower(_ predicate: Predicate,
     try .bound(term(left), op, parameter)
   case let .null(expression, negated):
     try .null(term(expression), negated: negated)
+  case let .membership(expression, values, negated):
+    // `x IN (a, b, …)` is the disjunction `x = a OR x = b OR …` and `NOT IN`
+    // its negation, lowered to a first-class `Filter.membership` that evaluates
+    // the operand ONCE per row (an OR-chain would re-evaluate a side-effecting
+    // operand once per element) and folds the element equalities under Kleene
+    // `OR`. That yields the ISO three-valued result: an unmatched test with a
+    // NULL operand or a NULL element is UNKNOWN — Kleene `OR` of a FALSE and an
+    // UNKNOWN is UNKNOWN — not FALSE, and `NOT` maps that UNKNOWN to itself, so
+    // `NOT IN` a list holding NULL is never TRUE.
+    try membership(term(expression), values, negated: negated, term: term)
   case let .and(lhs, rhs):
     try .and(lower(lhs, term: term), lower(rhs, term: term))
   case let .or(lhs, rhs):
@@ -43,6 +53,39 @@ private func lower(_ predicate: Predicate,
   case let .not(operand):
     try .not(lower(operand, term: term))
   }
+}
+
+/// Lowers `x [NOT] IN (v, …)` — the operand already lowered to `left` — to a
+/// first-class `Filter.membership(left, [v0, v1, …], negated:)`, each value
+/// lowered through `term`.
+///
+/// The operand is held ONCE rather than copied into an OR-chain of `left = vi`
+/// comparisons: that chain re-evaluated `left` per element, so a non-idempotent
+/// operand (a side-effecting scalar call) yielded a different value each
+/// element compared against. The `Filter.membership` runtime evaluates `left`
+/// exactly once per row, then folds `left = vi` over the elements IN ORDER
+/// under Kleene `OR` — the same left-to-right short-circuit and
+/// NULL/three-valued semantics the OR-chain had — and `negated` applies the
+/// `NOT IN` negation.
+///
+/// The value list must be non-empty: the parser rejects `IN ()`, but
+/// `Predicate.membership` is public, so a caller can hand this lowering an
+/// empty list directly, bypassing the grammar. An empty list has no element to
+/// compare against — the membership is undefined — so reject it as an
+/// unsupported shape rather than folding it.
+private func membership(_ left: Term, _ values: Array<Expression>,
+                        negated: Bool,
+                        term: (Expression) throws(SQLError) -> Term)
+    throws(SQLError) -> Filter {
+  guard !values.isEmpty else {
+    throw .unsupported("IN requires a non-empty value list")
+  }
+  var elements = Array<Term>()
+  elements.reserveCapacity(values.count)
+  for value in values {
+    try elements.append(term(value))
+  }
+  return .membership(left, elements, negated: negated)
 }
 
 /// The resolved sort keys `order` lowers to, in major-to-minor order — each
@@ -326,7 +369,7 @@ internal struct Scope {
   internal func derive(_ whens: Array<When>, _ otherwise: Expression?,
                        _ routines: Routines)
       throws(SQLError) -> ValueType {
-    let results = reachable(whens, otherwise)
+    let results = reachable(whens, otherwise, routines)
     guard !results.isEmpty else { return .integer }
     var type = try derive(results[0], routines)
     for result in results.dropFirst() {
@@ -348,11 +391,12 @@ internal struct Scope {
   /// unreachable; an `ELSE` is reachable only when no guard is constant-TRUE. A
   /// guard that is not statically decidable (`constant` is `nil`) leaves its
   /// result reachable.
-  private func reachable(_ whens: Array<When>, _ otherwise: Expression?)
+  private func reachable(_ whens: Array<When>, _ otherwise: Expression?,
+                         _ routines: Routines)
       -> Array<Expression> {
     var results = Array<Expression>()
     for branch in whens {
-      switch constant(branch.when) {
+      switch constant(branch.when, routines) {
       case false: continue
       case true: results.append(branch.then); return results
       case nil: results.append(branch.then)
@@ -424,7 +468,7 @@ internal struct Scope {
       // (skip it), a constant-TRUE one is reachable but makes every LATER branch
       // unreachable — so keep the earlier results and this one, then stop.
       try check(branch.when, routines)
-      switch constant(branch.when) {
+      switch constant(branch.when, routines) {
       case false: continue
       case true: results.append(branch.then); decided = true
       case nil: results.append(branch.then)
@@ -576,44 +620,211 @@ internal struct Scope {
       break
     case let .null(operand, _):
       _ = try validate(operand, routines)
+    case let .membership(operand, values, _):
+      // `x IN (v, …)` lowers to `x = v OR …`, so type it as those comparisons:
+      // validate the operand and each value for real errors (unknown column,
+      // bad arity, …). A cross-kind element (text in an integer list) is NOT
+      // rejected: the lowered `operand = element` comparison yields FALSE at
+      // runtime via `Row.matches` without faulting, so a row still runs (and
+      // may match a like-kind element), and the schema check must accept what
+      // the run accepts — rejecting it here would diverge from the run.
+      //
+      // The OR-chain short-circuits: a DEFINITE constant match (`x = v` folds
+      // TRUE, both row-independent constants) makes the whole `IN` TRUE and
+      // leaves every later element unreachable, so validation stops there —
+      // `1 IN (1 + 0, Name + 1)` type-checks, the run matching `1 = 1 + 0`
+      // before ever reaching `Name + 1`, while `2 IN (1 + 0, Name + 1)` (no
+      // definite match) still validates `Name + 1` and faults.
+      // `matched(operand, value, routines)` is the fold's own primitive.
+      //
+      // An empty list has no OR-chain and cannot be lowered (`lower` would have
+      // no seed), so reject it here too — the parser rejects `IN ()`, but a
+      // caller can build `.membership(_, [], …)` directly, so this validation
+      // faults on that shape rather than typing it as an always-false chain.
+      guard !values.isEmpty else {
+        throw .unsupported("IN requires a non-empty value list")
+      }
+      _ = try validate(operand, routines)
+      _ = try membership(of: values, each: { value throws(SQLError) in
+        _ = try validate(value, routines)
+      }, equality: { value throws(SQLError) in
+        matched(operand, value, routines)
+      })
     case let .and(lhs, rhs):
       try check(lhs, routines)
-      if constant(lhs) != false { try check(rhs, routines) }
+      if constant(lhs, routines) != false { try check(rhs, routines) }
     case let .or(lhs, rhs):
       try check(lhs, routines)
-      if constant(lhs) != true { try check(rhs, routines) }
+      if constant(lhs, routines) != true { try check(rhs, routines) }
     case let .not(operand):
       try check(operand, routines)
     }
   }
 
+  /// The definite truth of the equality `operand = value` when both fold to
+  /// ROW-INDEPENDENT CONSTANTS (via `constant`) — the OR-chain equality an `IN`
+  /// element folds to — else `nil` (a side reading a row is decided per row).
+  /// It folds each side through `constant` — the same `value(of:)`, arithmetic,
+  /// and comparison the run evaluates a `left = element` comparison with — so a
+  /// `true` here is a definite match that short-circuits the chain.
+  private func matched(_ operand: Expression, _ value: Expression,
+                       _ routines: Routines) -> Bool? {
+    guard let lhs = constant(operand, routines),
+        let rhs = constant(value, routines) else {
+      return nil
+    }
+    return matches(lhs, .equal, rhs)
+  }
+
+  /// The constant `Value` `expression` folds to when it is ROW-INDEPENDENT —
+  /// else `nil` (an operand a row, group, or run context decides). A literal
+  /// folds to its value; a binary folds its two operands and applies the SAME
+  /// `Arithmetic.apply(Value, Value)` the run's binary evaluation uses, so the
+  /// fold matches the run exactly (and a would-be fault — a divide, an overflow
+  /// — collapses to `nil` rather than deciding a match). A ROW-INDEPENDENT call
+  /// to a DETERMINISTIC routine (every argument folds constant) folds to its
+  /// routine's value over those folded arguments — the SAME `Routine` the run
+  /// invokes over the same constant arguments, so the fold matches the run; an
+  /// unregistered name, a NOT DETERMINISTIC routine, a non-constant argument,
+  /// or a throwing routine collapses to `nil`. Only a deterministic routine
+  /// folds (ISO): executing a non-deterministic one here could return one value
+  /// while this compile-time walk decides reachability and a DIFFERENT one when
+  /// the run reaches the same call — pruning an element the run keeps. Every
+  /// other expression is not statically foldable: a `column` reads a row and an
+  /// `aggregate` folds a group, so each is `nil`. A ROW-INDEPENDENT `case`
+  /// folds too — walking the `WHEN`s in order over `constant(_ predicate:)`:
+  /// the first constant-TRUE guard yields its folded result, a constant-FALSE
+  /// guard is skipped, and a guard the fold cannot decide (`nil`) means the
+  /// taken branch is per row, so the whole `case` is `nil`; with no
+  /// constant-TRUE guard it folds the `ELSE`, or `.null` when there is none (a
+  /// no-match `CASE` yields NULL). This honours the SAME reachability
+  /// `reachable(_:_:_:)` validates with. Returning `nil` is SOUND — a caller
+  /// that cannot fold an element keeps considering it, never wrongly pruning a
+  /// later one.
+  private func constant(_ expression: Expression, _ routines: Routines)
+      -> Value? {
+    switch expression {
+    case let .literal(literal):
+      return try? SQL.value(of: literal)
+    case let .binary(op, lhs, rhs):
+      guard let lhs = constant(lhs, routines),
+          let rhs = constant(rhs, routines) else {
+        return nil
+      }
+      return try? op.apply(lhs, rhs)
+    case let .call(name, arguments):
+      guard let routine = routines[name], routine.deterministic else {
+        return nil
+      }
+      var values = Array<Value>()
+      values.reserveCapacity(arguments.count)
+      for argument in arguments {
+        guard let value = constant(argument, routines) else { return nil }
+        values.append(value)
+      }
+      guard let result = try? routine(values) else { return nil }
+      // A routine call bypasses `Arithmetic.apply`'s finite check, so a
+      // non-finite double is not a definite value the run would accept — it
+      // faults there — so do not claim a match: fold to `nil` (parity with
+      // `empty(_:_:)`, which rejects the same non-finite result).
+      if case let .double(number) = result, !number.isFinite { return nil }
+      return result
+    case let .case(whens, otherwise):
+      for branch in whens {
+        switch constant(branch.when, routines) {
+        case false: continue
+        case true: return constant(branch.then, routines)
+        case nil: return nil
+        }
+      }
+      guard let otherwise else { return .null }
+      return constant(otherwise, routines)
+    case .column, .aggregate:
+      return nil
+    }
+  }
+
+  /// Folds an `IN` value list as its OR-chain of `operand = element` equalities,
+  /// honouring the executor's SHORT-CIRCUIT: the elements are visited in order,
+  /// each mapped to its three-valued equality truth by `equality`, and the truths
+  /// are OR-folded — but a definite `true` stops the walk, since the OR-chain
+  /// matches there and every LATER element is unreachable (`Row.matches` returns
+  /// on the first true arm). This is the ONE short-circuit the `IN`
+  /// type-check (`check`), constant fold (`constant`), and empty-group evaluator
+  /// (`empty`) all share: each supplies the per-element `equality` its surface
+  /// computes with, and every surface stops at the same element the run does.
+  ///
+  /// `visit` runs on each element BEFORE its truth is taken, so a surface with a
+  /// per-element side effect (validation) applies it to exactly the reachable
+  /// prefix. The fold seeds FALSE (an empty match is FALSE), so the returned
+  /// truth is the disjunction over the visited prefix.
+  private func membership<E: Error>(
+      of elements: Array<Expression>,
+      each visit: (Expression) throws(E) -> Void = { (_: Expression) in },
+      equality: (Expression) throws(E) -> Bool?)
+      throws(E) -> Bool? {
+    var truth: Bool? = false
+    for element in elements {
+      try visit(element)
+      truth = or(truth, try equality(element))
+      // A definite match makes every LATER element unreachable — the OR-chain
+      // short-circuits here, exactly as the run does.
+      if truth == true { break }
+    }
+    return truth
+  }
+
   /// The definite constant truth value of `predicate` when it is statically
-  /// decidable — a comparison of literal operands, composed through
-  /// `AND`/`OR`/`NOT` — else `nil` (a predicate reading a column or a
+  /// decidable — a comparison or `IS [NOT] NULL` whose operands fold to
+  /// ROW-INDEPENDENT `Value`s (via `constant(_ expression:)`: literals,
+  /// arithmetic, deterministic calls, nested `CASE`s), composed through
+  /// `AND`/`OR`/`NOT`/`IN` — else `nil` (a predicate reading a column or a
   /// `:parameter` is decided per row). `check(_:_:)` reads it to skip an arm
   /// the executor's short-circuit proves unreachable, matching `matches` and
   /// `value(of:)`, the primitives the run itself evaluates a comparison with.
-  func constant(_ predicate: Predicate) -> Bool? {
+  /// Folding each operand through `constant(_ expression:)` carries its
+  /// determinism gate: a non-deterministic call operand folds to `nil`, so the
+  /// comparison stays undecided (`nil`) rather than deciding a match the run
+  /// might not make.
+  func constant(_ predicate: Predicate, _ routines: Routines) -> Bool? {
     switch predicate {
     case let .comparison(left, op, right):
-      guard case let .literal(left) = left, case let .literal(right) = right,
-          let lhs = try? value(of: left), let rhs = try? value(of: right) else {
+      guard let lhs = constant(left, routines),
+          let rhs = constant(right, routines) else {
         return nil
       }
       return matches(lhs, op, rhs)
     case let .and(lhs, rhs):
       // `constant` is a pure fold with no side effect, so both arms evaluate.
-      return and(constant(lhs), constant(rhs))
+      return and(constant(lhs, routines), constant(rhs, routines))
     case let .or(lhs, rhs):
-      return or(constant(lhs), constant(rhs))
+      return or(constant(lhs, routines), constant(rhs, routines))
     case let .not(operand):
-      guard let value = constant(operand) else { return nil }
+      guard let value = constant(operand, routines) else { return nil }
       return !value
     case let .null(operand, negated):
-      // A literal is never NULL, so `IS NULL` is definitely false and `IS NOT
-      // NULL` (`negated`) definitely true; a non-literal operand is per row.
-      guard case .literal = operand else { return nil }
-      return negated
+      // A ROW-INDEPENDENT operand that folds to a concrete value is not NULL;
+      // one that folds to `.null` (a NULL literal, or a deterministic routine
+      // returning NULL) is NULL — matching the run. An operand the fold cannot
+      // decide (`nil`) is per row, so the truth is too. This mirrors
+      // `empty(_ predicate:)`'s `.null` arm, which folds via `empty(operand)`.
+      guard let value = constant(operand, routines) else { return nil }
+      let null = if case .null = value { true } else { false }
+      return negated ? !null : null
+    case let .membership(operand, values, negated):
+      // Fold `x IN (…)` exactly as its OR-chain of equalities folds — the same
+      // primitives (`matched`/`constant`, `matches`, `membership`'s
+      // short-circuit) — honouring the OR-chain's short-circuit: once a
+      // ROW-INDEPENDENT element definitely equals the constant operand the fold
+      // is `true`, so a later row-dependent element (which alone would make the
+      // fold per-row `nil`) is unreachable and does not spoil it —
+      // `1 IN (1 + 0, Name + 1)` folds `true`. Absent a decisive match, any
+      // row-dependent element makes it per row (`nil`). `NOT IN` negates the
+      // folded truth (UNKNOWN maps to itself).
+      let truth = membership(of: values) { value in
+        matched(operand, value, routines)
+      }
+      return negated ? truth.map { !$0 } : truth
     case .bound:
       return nil
     }
@@ -663,6 +874,9 @@ internal struct Scope {
       try aggregates(in: left, routines)
     case let .null(operand, _):
       try aggregates(in: operand, routines)
+    case let .membership(operand, values, _):
+      try aggregates(in: operand, routines)
+      for value in values { try aggregates(in: value, routines) }
     case let .and(lhs, rhs), let .or(lhs, rhs):
       try aggregates(in: lhs, routines)
       try aggregates(in: rhs, routines)
@@ -745,6 +959,28 @@ internal struct Scope {
       let value = try empty(operand, routines)
       let null = if case .null = value { true } else { false }
       return negated ? !null : null
+    case let .membership(operand, values, negated):
+      // Fold `x IN (…)` over the empty group as its OR-chain of equalities does
+      // — the folded operand matched against each folded element under
+      // three-valued `OR`, honouring the OR-chain's short-circuit (`membership`):
+      // the run stops at the first TRUE comparison and never evaluates a later
+      // element, so `1 IN (1, 1 / 0)` folds `true` here without folding `1 / 0`
+      // to a `.divide` fault. Negated for `NOT IN`.
+      //
+      // Reject an empty list, as `check` and `lower` do — a whole-result
+      // aggregate `HAVING` over the empty group reaches this fold WITHOUT a
+      // prior `check` (`OutputColumn.typecheck`), so an empty list would
+      // otherwise fold `false` (`true` under `NOT IN`) here while both compile
+      // (`lower`) and schema (`check`) reject it. The parser rejects `IN ()`,
+      // but a caller can build `.membership(_, [], …)` directly.
+      guard !values.isEmpty else {
+        throw .unsupported("IN requires a non-empty value list")
+      }
+      let lhs = try empty(operand, routines)
+      let truth = try membership(of: values) { value throws(SQLError) in
+        matches(lhs, .equal, try empty(value, routines))
+      }
+      return negated ? truth.map { !$0 } : truth
     case let .and(lhs, rhs):
       // A `false` left proves the `AND` false without folding the right arm,
       // which a run's short-circuit never evaluates and so must not fault.
@@ -1129,6 +1365,11 @@ extension Filter {
       ordinals.insert(right)
     case let .null(term, _):
       term.references(into: &ordinals)
+    case let .membership(operand, elements, _):
+      operand.references(into: &ordinals)
+      for element in elements {
+        element.references(into: &ordinals)
+      }
     case let .and(lhs, rhs), let .or(lhs, rhs):
       lhs.references(into: &ordinals)
       rhs.references(into: &ordinals)

--- a/Sources/SQL/Token.swift
+++ b/Sources/SQL/Token.swift
@@ -44,6 +44,7 @@ extension Token {
     case `as`
     case `is`
     case null
+    case `in`
     case union
     case all
     case with
@@ -121,6 +122,7 @@ extension Token.Kind {
     case .as: "AS"
     case .is: "IS"
     case .null: "NULL"
+    case .in: "IN"
     case .union: "UNION"
     case .all: "ALL"
     case .with: "WITH"

--- a/Tests/SQLTests/MembershipTests.swift
+++ b/Tests/SQLTests/MembershipTests.swift
@@ -1,0 +1,513 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQL
+
+import SQLTestSupport
+
+// MARK: - Fixture
+
+/// A relation exercising the `IN` value-list predicate: an integer key `K` that
+/// is `NULL` in some rows, so the three-valued corners (a NULL operand, a NULL
+/// element) are reachable, and a text `Name` for a cross-kind element (which
+/// the run silently non-matches) and for reachable text arithmetic.
+private func members() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["Id": .integer, "K": .integer, "Name": .text]) {
+      Row(1, 10, "a")
+      Row(2, 20, "b")
+      Row(3, nil, "c")
+      Row(4, 30, "d")
+    }
+  }
+}
+
+// MARK: - Parsing
+
+/// Parses `text` and returns its `Select`, failing on any other shape.
+private func parse(select text: String) throws -> Select {
+  guard case let .select(.select(select)) = try Statement(parsing: text) else {
+    Issue.record("expected a single SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return select
+}
+
+struct MembershipParsingTests {
+  @Test func `parses an IN value list`() throws {
+    let select = try parse(select: "SELECT * FROM T WHERE K IN (1, 2, 3)")
+    #expect(select.predicate
+                == .membership(.column("K"),
+                               [.literal(.integer(1)), .literal(.integer(2)),
+                                .literal(.integer(3))], negated: false))
+  }
+
+  @Test func `parses a NOT IN value list`() throws {
+    let select = try parse(select: "SELECT * FROM T WHERE K NOT IN (1, 2)")
+    #expect(select.predicate
+                == .membership(.column("K"),
+                               [.literal(.integer(1)), .literal(.integer(2))],
+                               negated: true))
+  }
+
+  @Test func `parses a single-element IN list`() throws {
+    let select = try parse(select: "SELECT * FROM T WHERE K IN (7)")
+    #expect(select.predicate
+                == .membership(.column("K"), [.literal(.integer(7))],
+                               negated: false))
+  }
+
+  @Test func `parses IN over an expression operand`() throws {
+    let select = try parse(select: "SELECT * FROM T WHERE K + 1 IN (11, 21)")
+    let operand = Expression.binary(.add, .column("K"), .literal(.integer(1)))
+    #expect(select.predicate
+                == .membership(operand,
+                               [.literal(.integer(11)), .literal(.integer(21))],
+                               negated: false))
+  }
+
+  @Test func `rejects an empty IN list`() {
+    #expect(throws: SQLError.self) {
+      _ = try Statement(parsing: "SELECT * FROM T WHERE K IN ()")
+    }
+  }
+}
+
+// MARK: - Evaluation
+
+struct MembershipEvaluationTests {
+  @Test func `IN admits a matching value`() throws {
+    try members().expect("SELECT Id FROM T WHERE K IN (10, 30)",
+                         yields: [[1], [4]])
+  }
+
+  @Test func `IN rejects a non-matching value`() throws {
+    try members().expect("SELECT Id FROM T WHERE K IN (99)", yields: [])
+  }
+
+  @Test func `NOT IN admits the complement`() throws {
+    // Rows with a non-NULL K not in the list; row 3 (K NULL) is UNKNOWN and
+    // dropped.
+    try members().expect("SELECT Id FROM T WHERE K NOT IN (10, 30)",
+                         yields: [[2]])
+  }
+
+  @Test func `a NULL operand makes IN UNKNOWN`() throws {
+    // Row 3's K is NULL, so `NULL IN (10, 20)` is UNKNOWN, not FALSE — the row
+    // is dropped rather than admitted, and would not be admitted by NOT IN
+    // either.
+    try members().expect("SELECT Id FROM T WHERE K IN (10, 20)",
+                         yields: [[1], [2]])
+    try members().expect("SELECT Id FROM T WHERE K NOT IN (10, 20)",
+                         yields: [[4]])
+  }
+
+  @Test func `a NULL element leaves an unmatched IN UNKNOWN`() throws {
+    // Row 3 has K = NULL, so its `K` cell is the NULL element. Over that row,
+    // `20 IN (99, K)` is `20 = 99 OR 20 = NULL` — FALSE OR UNKNOWN — which is
+    // UNKNOWN, not FALSE: the row is not admitted. `NOT IN` negates that
+    // UNKNOWN to UNKNOWN, so it is never TRUE either — the row is dropped both
+    // ways.
+    try members().empty("SELECT Id FROM T WHERE 20 IN (99, K) AND Id = 3")
+    try members().empty("SELECT Id FROM T WHERE 20 NOT IN (99, K) AND Id = 3")
+  }
+
+  @Test func `IN folds like an OR of equalities`() throws {
+    try members().expect("SELECT Id FROM T WHERE K IN (10, 20, 30)",
+                         equals: "SELECT Id FROM T WHERE K = 10 OR K = 20 OR K = 30")
+  }
+}
+
+// MARK: - Type checking
+
+struct MembershipTypeTests {
+  /// Parses `text` to a query, failing on any other statement.
+  private func parse(_ text: String) throws -> Query {
+    guard case let .select(query) = try Statement(parsing: text) else {
+      Issue.record("expected a SELECT statement")
+      throw SQLError.incomplete(expected: "a SELECT statement")
+    }
+    return query
+  }
+
+  @Test func `a cross-kind element does not fault the schema check`() throws {
+    // `K` is an integer column and `'x'` is a text element, but the schema
+    // check does NOT reject it: the lowered `K = 'x'` comparison yields FALSE
+    // at runtime via `Row.matches` without faulting, so the row still runs and
+    // may match the like-kind `10` element. The check must accept what the run
+    // accepts — so `K IN (10, 'x')` types exactly as `K IN (10)`.
+    let mixed = try parse("SELECT Id FROM T WHERE K IN (10, 'x')")
+    let plain = try parse("SELECT Id FROM T WHERE K IN (10)")
+    let columns = try members().columns(of: mixed)
+    #expect(columns == (try members().columns(of: plain)))
+    // The run keeps the `K = 10` row: the text arm silently non-matches.
+    try members().expect("SELECT Id FROM T WHERE K IN (10, 'x')",
+                         yields: [[1]])
+  }
+
+  @Test func `a numeric element of the other numeric kind is admitted`() throws {
+    // An integer operand and a double element are comparable (both numeric), so
+    // the schema check passes and the run matches by magnitude.
+    let query = try parse("SELECT Id FROM T WHERE K IN (10.0, 20.0)")
+    _ = try members().columns(of: query)
+    try members().expect("SELECT Id FROM T WHERE K IN (10.0, 20.0)",
+                         yields: [[1], [2]])
+  }
+
+  @Test func `a definite match short-circuits a later bad element`() throws {
+    // `1 IN (1, Name + 1)` lowers to `1 = 1 OR 1 = Name + 1`; the first
+    // disjunct is a definite constant match, so the OR-chain short-circuits and
+    // `Name + 1` (text arithmetic) is unreachable — the type check does not
+    // validate it, and the query runs (matching every row).
+    let query = try parse("SELECT Id FROM T WHERE 1 IN (1, Name + 1)")
+    _ = try members().columns(of: query, validate: true)
+    try members().expect("SELECT Id FROM T WHERE 1 IN (1, Name + 1)",
+                         yields: [[1], [2], [3], [4]])
+  }
+
+  @Test func `a constant expression element prunes a later unreachable element`() throws {
+    // `1 IN (1 + 0, Name + 1)` lowers to `1 = 1 + 0 OR 1 = Name + 1`; the first
+    // element is a ROW-INDEPENDENT constant expression (not a bare literal)
+    // that folds to `1`, a definite match, so the OR-chain short-circuits and
+    // `Name + 1` (text arithmetic) is unreachable — the type check must fold
+    // the constant element and stop rather than continuing into it, and the
+    // run, matching `1 = 1 + 0` first, keeps every row.
+    let query = try parse("SELECT Id FROM T WHERE 1 IN (1 + 0, Name + 1)")
+    _ = try members().columns(of: query, validate: true)
+    try members().expect("SELECT Id FROM T WHERE 1 IN (1 + 0, Name + 1)",
+                         yields: [[1], [2], [3], [4]])
+  }
+
+  @Test func `a non-matching constant expression element keeps a later element reachable`() throws {
+    // `2 IN (1 + 0, Name + 1)` folds the first element to `1`, which `2` does
+    // NOT match, so `Name + 1` stays reachable — the pruning is PRECISE, not
+    // over-eager — and its text arithmetic must still fault the type check,
+    // matching the run, which would evaluate `2 = Name + 1` and fault.
+    let query = try parse("SELECT Id FROM T WHERE 2 IN (1 + 0, Name + 1)")
+    let resolve = { () throws -> Array<OutputColumn> in
+      try members().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.operand("operands must be numeric")) {
+      try resolve()
+    }
+  }
+
+  @Test func `no definite match leaves a bad element reachable`() throws {
+    // `2 IN (1, Name + 1)` never definitely matches `1`, so `Name + 1` is
+    // reachable and its text arithmetic must still fault the type check.
+    let query = try parse("SELECT Id FROM T WHERE 2 IN (1, Name + 1)")
+    let resolve = { () throws -> Array<OutputColumn> in
+      try members().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.operand("operands must be numeric")) {
+      try resolve()
+    }
+  }
+
+  @Test func `a constant routine call element prunes a later unreachable element`() throws {
+    // `1 IN (BITAND(1, 1), Name + 1)` lowers to `1 = BITAND(1, 1) OR 1 = Name
+    // + 1`; the first element is a ROW-INDEPENDENT scalar CALL — every argument
+    // folds constant — so it folds to the routine's value `1`, a definite
+    // match, and the OR-chain short-circuits before `Name + 1` (text
+    // arithmetic). The type check must fold the call through the SAME routine
+    // the run invokes and stop, and the run, matching `1 = BITAND(1, 1)` first,
+    // keeps every row. (`BITAND` is a standard prelude routine, seeded like the
+    // existing constant-expression tests.)
+    let text = "SELECT Id FROM T WHERE 1 IN (BITAND(1, 1), Name + 1)"
+    let query = try parse(text)
+    _ = try members().columns(of: query, validate: true)
+    try members().expect(text, yields: [[1], [2], [3], [4]])
+  }
+
+  @Test func `a non-deterministic routine call is not folded when pruning`() throws {
+    // `1 IN (probe(), Name + 1)` lowers to `1 = probe() OR 1 = Name + 1`.
+    // `probe` is registered NOT DETERMINISTIC (ISO's default for a host
+    // closure), so the schema check must NOT execute it to fold the first
+    // element — a non-deterministic routine could return one value here and
+    // another when the run reaches the call, wrongly pruning a later element.
+    // With the call unfolded, `Name + 1` stays reachable and its text
+    // arithmetic faults the type check, matching the run's guarantee. (`probe`
+    // returns `1`, which WOULD match `1` and short-circuit had it been folded —
+    // proving the gate keys off the characteristic, not the value.)
+    let routines = Routines()
+        .registering("probe", returns: .integer, deterministic: false) { _ in
+          .integer(1)
+        }
+    let text = "SELECT Id FROM T WHERE 1 IN (probe(), Name + 1)"
+    let query = try parse(text)
+    let resolve = { () throws -> Array<OutputColumn> in
+      try members().columns(of: query, routines: routines, validate: true)
+    }
+    #expect(throws: SQLError.operand("operands must be numeric")) {
+      try resolve()
+    }
+  }
+
+  @Test func `a deterministic routine call is folded when pruning`() throws {
+    // The same query with `probe` declared DETERMINISTIC (ISO
+    // `DETERMINISTIC`): the schema check MAY fold `probe()` to `1`, a definite
+    // match, so the OR-chain short-circuits before `Name + 1` and its text
+    // arithmetic is never reached — `columns(of:)` succeeds. The ONLY change
+    // from the prior test is the `deterministic` flag, so the gate keys off it.
+    let routines = Routines()
+        .registering("probe", returns: .integer, deterministic: true) { _ in
+          .integer(1)
+        }
+    let text = "SELECT Id FROM T WHERE 1 IN (probe(), Name + 1)"
+    let query = try parse(text)
+    _ = try members().columns(of: query, routines: routines, validate: true)
+    try members().expect(text, yields: [[1], [2], [3], [4]],
+                         routines: routines)
+  }
+
+  @Test func `a non-matching constant routine call element keeps a later element reachable`() throws {
+    // `2 IN (BITAND(1, 1), Name + 1)` folds the first element through the
+    // routine to `1`, which `2` does NOT match, so `Name + 1` stays reachable
+    // — the routine fold is PRECISE, not over-eager — and its text arithmetic
+    // must still fault the type check, matching the run.
+    let text = "SELECT Id FROM T WHERE 2 IN (BITAND(1, 1), Name + 1)"
+    let query = try parse(text)
+    let resolve = { () throws -> Array<OutputColumn> in
+      try members().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.operand("operands must be numeric")) {
+      try resolve()
+    }
+  }
+
+  @Test func `a constant CASE element prunes a later unreachable element`() throws {
+    // `1 IN (CASE WHEN 1 = 1 THEN 1 ELSE Name + 1 END, Name + 1)` lowers to `1
+    // = <CASE> OR 1 = Name + 1`; the CASE is ROW-INDEPENDENT — its guard `1 =
+    // 1` folds TRUE, so it folds to its branch result `1` (the row-dependent
+    // ELSE `Name + 1` is unreachable and never folded) — a definite match, so
+    // the OR-chain short-circuits and the trailing `Name + 1` (text arithmetic)
+    // is unreachable. The type check must fold the constant CASE and stop, and
+    // the run, matching `1 = <CASE>` first, keeps every row.
+    let text = "SELECT Id FROM T WHERE 1 IN "
+        + "(CASE WHEN 1 = 1 THEN 1 ELSE Name + 1 END, Name + 1)"
+    let query = try parse(text)
+    _ = try members().columns(of: query, validate: true)
+    try members().expect(text, yields: [[1], [2], [3], [4]])
+  }
+
+  @Test func `a non-matching constant CASE element keeps a later element reachable`() throws {
+    // `2 IN (CASE WHEN 1 = 1 THEN 1 ELSE Name + 1 END, Name + 1)` folds the
+    // CASE to `1`, which `2` does NOT match, so the trailing `Name + 1` stays
+    // reachable — the CASE fold is PRECISE, not over-eager — and its text
+    // arithmetic must still fault the type check, matching the run.
+    let text = "SELECT Id FROM T WHERE 2 IN "
+        + "(CASE WHEN 1 = 1 THEN 1 ELSE Name + 1 END, Name + 1)"
+    let query = try parse(text)
+    let resolve = { () throws -> Array<OutputColumn> in
+      try members().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.operand("operands must be numeric")) {
+      try resolve()
+    }
+  }
+
+  @Test func `a row-dependent CASE guard leaves a later element reachable`() throws {
+    // `1 IN (CASE WHEN Id = 2 THEN 1 ELSE 0 END, Name + 1)` cannot fold the
+    // CASE: its guard `Id = 2` is ROW-DEPENDENT, so `constant` yields `nil` —
+    // the CASE is not a definite match (the run cannot guarantee it equals `1`
+    // on every row) and the trailing `Name + 1` (text arithmetic) stays
+    // reachable, so its text arithmetic must still fault the type check.
+    let text = "SELECT Id FROM T WHERE 1 IN "
+        + "(CASE WHEN Id = 2 THEN 1 ELSE 0 END, Name + 1)"
+    let query = try parse(text)
+    let resolve = { () throws -> Array<OutputColumn> in
+      try members().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.operand("operands must be numeric")) {
+      try resolve()
+    }
+  }
+
+  @Test func `a constant-expression CASE guard prunes a later unreachable element`() throws {
+    // `1 IN (CASE WHEN 1 + 0 = 1 THEN 1 END, Name + 1)` lowers to `1 = <CASE>
+    // OR 1 = Name + 1`; the CASE guard `1 + 0 = 1` is ROW-INDEPENDENT but NOT
+    // bare literals — its left operand is arithmetic. Folding the guard through
+    // `constant(_ expression:)` decides it TRUE, so the CASE folds to `1`, a
+    // definite match, and the OR-chain short-circuits before `Name + 1` (text
+    // arithmetic). The type check must fold the constant guard and stop, and
+    // the run, matching `1 = <CASE>` first, keeps every row.
+    let text = "SELECT Id FROM T WHERE 1 IN "
+        + "(CASE WHEN 1 + 0 = 1 THEN 1 END, Name + 1)"
+    let query = try parse(text)
+    _ = try members().columns(of: query, validate: true)
+    try members().expect(text, yields: [[1], [2], [3], [4]])
+  }
+
+  @Test func `a non-matching constant-expression CASE guard keeps a later element reachable`() throws {
+    // `1 IN (CASE WHEN 1 + 0 = 2 THEN 1 END, Name + 1)`: the guard `1 + 0 = 2`
+    // folds FALSE and the CASE has no ELSE, so it yields NULL — `1 = NULL` is
+    // UNKNOWN, NOT a definite match — so the trailing `Name + 1` (text
+    // arithmetic) stays reachable and must still fault the type check, matching
+    // the run. The pruning is PRECISE: a folded-FALSE guard prunes nothing.
+    let text = "SELECT Id FROM T WHERE 1 IN "
+        + "(CASE WHEN 1 + 0 = 2 THEN 1 END, Name + 1)"
+    let query = try parse(text)
+    let resolve = { () throws -> Array<OutputColumn> in
+      try members().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.operand("operands must be numeric")) {
+      try resolve()
+    }
+  }
+
+  @Test func `a non-deterministic CASE guard leaves a later element reachable`() throws {
+    // `1 IN (CASE WHEN probe() = 1 THEN 1 END, Name + 1)` with `probe`
+    // registered NOT DETERMINISTIC: the guard's `probe()` operand does not fold
+    // through `constant(_ expression:)` (the determinism gate), so the guard is
+    // `nil`, the CASE is `nil`, and the trailing `Name + 1` (text arithmetic)
+    // stays reachable and must still fault the type check. The determinism gate
+    // flows through the comparison fold — a non-deterministic operand keeps the
+    // guard undecided rather than deciding a match the run might not make.
+    let routines = Routines()
+        .registering("probe", returns: .integer, deterministic: false) { _ in
+          .integer(1)
+        }
+    let text = "SELECT Id FROM T WHERE 1 IN "
+        + "(CASE WHEN probe() = 1 THEN 1 END, Name + 1)"
+    let query = try parse(text)
+    let resolve = { () throws -> Array<OutputColumn> in
+      try members().columns(of: query, routines: routines, validate: true)
+    }
+    #expect(throws: SQLError.operand("operands must be numeric")) {
+      try resolve()
+    }
+  }
+
+  @Test func `a constant-expression IS NOT NULL CASE guard prunes a later unreachable element`() throws {
+    // `1 IN (CASE WHEN 1 + 0 IS NOT NULL THEN 1 END, Name + 1)`: the guard `1 +
+    // 0 IS NOT NULL` is ROW-INDEPENDENT but NOT a bare literal. Folding its
+    // operand through `constant(_ expression:)` yields the concrete value `1`,
+    // which is not NULL, so `IS NOT NULL` folds TRUE — the CASE folds to `1`, a
+    // definite match, and the OR-chain short-circuits before `Name + 1` (text
+    // arithmetic). This exercises the generalised `.null` predicate fold.
+    let text = "SELECT Id FROM T WHERE 1 IN "
+        + "(CASE WHEN 1 + 0 IS NOT NULL THEN 1 END, Name + 1)"
+    let query = try parse(text)
+    _ = try members().columns(of: query, validate: true)
+    try members().expect(text, yields: [[1], [2], [3], [4]])
+  }
+
+  @Test func `an empty-group HAVING IN short-circuits a faulting element`()
+      throws {
+    // A whole-result aggregate over an empty source projects one empty group,
+    // whose HAVING `1 IN (1, 1 / 0)` the schema path (`columns(of:)`) folds. The
+    // OR-chain short-circuits on the literal `1 = 1`, so `1 / 0` is unreachable
+    // and must not fault `.divide` — the schema resolves and the query runs.
+    let query = try parse(
+        "SELECT COUNT(*) FROM T WHERE 1 = 0 HAVING 1 IN (1, 1 / 0)")
+    let columns = try members().columns(of: query)
+    #expect(columns.count == 1)
+    try members().expect(
+        "SELECT COUNT(*) FROM T WHERE 1 = 0 HAVING 1 IN (1, 1 / 0)",
+        yields: [[0]])
+  }
+
+  @Test func `an empty-group HAVING empty IN faults the fold`() throws {
+    // The whole-result-aggregate empty-group HAVING fold —
+    // `empty(_:Predicate)`, the surface `OutputColumn.typecheck` drives over
+    // the single empty group a statically-false WHERE leaves — reaches its
+    // `.membership` arm WITHOUT a prior `check`, so it must reject an EMPTY
+    // list itself, as `check` and `lower` do. An empty membership otherwise
+    // folds FALSE (TRUE under `NOT IN`), silently keeping the group past a list
+    // both `check` and `lower` reject. The parser rejects `IN ()`, so build the
+    // empty `NOT IN` as a raw AST and fold it directly on a `Scope` (as
+    // `Scope([]).empty(_:Expression)` is exercised elsewhere), isolating the
+    // fold from the compile-path guard.
+    let having = Predicate.membership(.literal(.integer(1)), [], negated: true)
+    #expect(throws:
+        SQLError.unsupported("IN requires a non-empty value list")) {
+      _ = try Scope([]).empty(having)
+    }
+  }
+
+  /// A `SELECT Id FROM T WHERE <predicate>` built directly, so a
+  /// `Predicate.membership` with an EMPTY value list reaches the engine —
+  /// bypassing the parser, which rejects `IN ()`.
+  private func select(where predicate: Predicate) -> Query {
+    .select(Select(projection: .columns([Column(name: "Id")]),
+                   from: Relation(name: "T"), predicate: predicate))
+  }
+
+  @Test func `an empty IN list faults the schema check, not a crash`() throws {
+    // `Predicate.membership` is public, so a caller can build an EMPTY list
+    // directly, bypassing the parser's `IN ()` rejection. The lowering has no
+    // OR-chain seed for an empty list, so it FAULTS the schema check (an
+    // unsupported shape) rather than trapping on the force-unwrap.
+    let query = select(where: .membership(.column("Id"), [], negated: false))
+    let resolve = { () throws -> Array<OutputColumn> in
+      try members().columns(of: query, validate: true)
+    }
+    #expect(throws:
+        SQLError.unsupported("IN requires a non-empty value list")) {
+      try resolve()
+    }
+  }
+
+  @Test func `an empty IN list faults the run, not a crash`() throws {
+    // The same direct-AST empty list must FAULT the run's compile/lowering (the
+    // OR-chain reduction) rather than crashing on the force-unwrap.
+    let query = select(where: .membership(.column("Id"), [], negated: false))
+    #expect(throws:
+        SQLError.unsupported("IN requires a non-empty value list")) {
+      _ = try members().run(query)
+    }
+  }
+}
+
+// MARK: - Operand evaluated once
+
+/// A shared call counter a stateful routine increments — a tiny
+/// `@unchecked Sendable` box over a mutable count, so the non-deterministic
+/// `stepper()` routine registered against it can both observe successive values
+/// and record how many times the run invoked it. The engine evaluates a row's
+/// filter synchronously on one thread, so the box needs no lock; `@unchecked`
+/// satisfies the `@Sendable` routine closure's capture.
+private final class Counter: @unchecked Sendable {
+  /// The number of times `next()` has been called.
+  private(set) var count = 0
+
+  /// Increments the count and returns the PREVIOUS value — the sequence `0, 1,
+  /// 2, …` across successive calls.
+  func next() -> Int {
+    defer { count += 1 }
+    return count
+  }
+}
+
+struct MembershipOperandTests {
+  /// A single-row table, so a per-row operand is evaluated once for the one row
+  /// under test.
+  private func one() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["Id": .integer]) {
+        Row(1)
+      }
+    }
+  }
+
+  @Test func `the IN operand is evaluated once per row`() throws {
+    // `stepper()` yields 0 on its first call, then 1, 2, …; it is
+    // NON-deterministic so the engine cannot fold it. Over the one row,
+    // `stepper() IN (1, 2)` must evaluate the operand EXACTLY ONCE — yielding
+    // 0 — and 0 ∉ {1, 2}, so the row is EXCLUDED. The old OR-chain lowered this
+    // to `stepper() = 1 OR stepper() = 2`, re-evaluating the operand: the first
+    // call yields 0 (0 ≠ 1) and the SECOND yields 2 (2 = 2), wrongly ADMITTING
+    // the row and calling `stepper()` twice. The first-class membership filter
+    // caches the operand, so the row is dropped and the counter reads exactly
+    // 1.
+    let counter = Counter()
+    let routines = Routines()
+        .registering("stepper", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+    try one().expect("SELECT Id FROM T WHERE stepper() IN (1, 2)", yields: [],
+                     routines: routines)
+    #expect(counter.count == 1)
+  }
+}


### PR DESCRIPTION
Add the ISO `expr IN (v, …)` and `expr NOT IN (v, …)` predicate over a non-empty parenthesised value list (the subquery form is not supported).

The predicate is a new AST node, `Predicate.membership(Expression, Array<Expression>, negated: Bool)`. The parser recognises the `[NOT] IN` tail in `comparison`, alongside `IS [NOT] NULL`; a leading `NOT` there can only introduce `NOT IN`, since a prefix `NOT` predicate is consumed by `negation` first.

The engine lowers `membership` to the disjunction `x = v0 OR x = v1 OR …`, negated for `NOT IN`, over the existing comparison machinery rather than carrying a dedicated `Filter` case. That reuse yields the ISO three-valued semantics for free: an unmatched test with a NULL operand or a NULL element is UNKNOWN (Kleene `OR` of FALSE and UNKNOWN), not FALSE, and `NOT` maps that UNKNOWN to itself, so `NOT IN` a list holding NULL is never TRUE. The output-schema `check` requires each element comparable to the operand — the `matches` rule (like types, or two numerics), a new `ValueType.comparable(with:)` — so a definitively cross-kind element faults rather than silently never matching.

That OR-chain SHORT-CIRCUITS at the first matching element, and every static surface that inspects the list must honour the same reachability the run does. Rather than open-code the fold three times, a single `membership(of:each:equality:)` helper walks the elements in order, OR-folds each element's three-valued equality, and stops at the first definite TRUE — exactly where the run stops. The three surfaces share it: the output-schema `check` (validating each reachable element, and its `each` visitor stops validating once a definite constant match makes the rest unreachable), the constant fold `constant` (a literal operand equal to a literal element folds the whole `IN` TRUE, so a later non-literal element does not spoil it to per-row `nil`), and the whole-result aggregate `empty` (folding over the single empty group without evaluating an element past the first TRUE comparison). So `1 IN (1, Name + 1)` type-checks and runs — the run matches `1 = 1` before ever reaching the text arithmetic `Name + 1` — a guarding `CASE WHEN 1 IN (1, Name + 1)` folds constant-TRUE, and an empty-group `HAVING 1 IN (1, 1 / 0)` resolves without a divide fault, while `2 IN (1, Name + 1)`, with no definite match, still validates `Name + 1` and faults.

The parser rejects `IN ()`, but `Predicate.membership` is public, so a caller can build `.membership(_, [], negated: …)` with an EMPTY value list directly, bypassing the grammar. An empty list has no OR-chain seed — the lowering's `filter!` would trap on the empty reduce — so guard it: both the OR-chain lowering (compile/run) and the output-schema `check` reject an empty list with `SQLError.unsupported`, a fault rather than a crash on the force-unwrap.