### PR TITLE
WinMD: correct the stale guid virtual-column doc reference

### DIFF
--- a/Sources/WinMD/Attribute.swift
+++ b/Sources/WinMD/Attribute.swift
@@ -92,9 +92,10 @@ extension Tuple {
   ///
   /// A `Row`/`Tuple` is a borrowed view that cannot escape the scan, so the
   /// blob's bytes are copied out and run through `AttributeDecoder` after. This
-  /// is the codec the SQL adapter's `guid` virtual column on `CustomAttribute`
-  /// reads (mapping a failure to SQL `NULL`); `Row<TypeDef>.iid` performs the
-  /// equivalent decode inline as it navigates to the attribute. A malformed
+  /// is the codec the SQL adapter's `guid` scalar function over a
+  /// `CustomAttribute` `#Blob` reads (mapping a failure to SQL `NULL`);
+  /// `Row<TypeDef>.iid` performs the equivalent decode inline as it
+  /// navigates to the attribute. A malformed
   /// `Value` blob throws.
   public func iid(_ column: Int) throws(WinMDError) -> UUID {
     let blob = try blob(column)


### PR DESCRIPTION
`Tuple.iid(_:)`'s doc-comment described `guid` in the present tense as the SQL adapter's virtual column on `CustomAttribute`. That is stale: `guid` is now a registered scalar UDF (`Routines.standard.registering ("guid", …, Session.guid)`), and the adapter documents these WinMD decodes as scalar functions rather than virtual columns. Describe it as the `guid` scalar function over a `CustomAttribute` `#Blob`, keeping the NULL-on-failure note. Doc-only; no behaviour change.