### PR TITLE
SQL: generalize join ON to an arbitrary predicate

### DIFF
--- a/Sources/SQL/AST.swift
+++ b/Sources/SQL/AST.swift
@@ -231,27 +231,37 @@ public struct Relation: Hashable, Sendable {
   }
 }
 
-/// A `JOIN` clause: a second relation and the equality that relates it to the
-/// rows already in scope.
+/// A `JOIN` clause: a second relation and the `ON` predicate that relates it to
+/// the rows already in scope.
 ///
-/// The `ON` equality is held as its two column references in source order —
-/// `left = right` — for the consumer to classify. The binding interprets the
-/// adapter-computed columns `Id` (every table's 1-based row identity) and a
-/// list-child's owner foreign key within those references.
+/// The `ON` predicate is an arbitrary boolean expression over the relation
+/// joined in and the ones already in scope — the same predicate grammar a
+/// `WHERE` admits — so a join may relate its sides by an equality (`a.x =
+/// b.y`), an inequality (`a.x < b.y`), an expression equality (`a.x = b.y +
+/// 1`), or any `AND`/`OR`/`NOT` of comparisons. A pure `column = column`
+/// equality conjunct still lowers to a hash-join key; the rest becomes a
+/// residual filter over the join (nested-loop semantics). The consumer
+/// interprets the adapter-computed columns `Id` (every table's 1-based row
+/// identity) and a list-child's owner foreign key within the predicate's column
+/// references.
 public struct Join: Hashable, Sendable {
   /// The relation joined in.
   public let relation: Relation
 
-  /// The left side of the `ON` equality.
-  public let left: Column
+  /// The `ON` predicate relating the joined-in relation to those in scope.
+  public let on: Predicate
 
-  /// The right side of the `ON` equality.
-  public let right: Column
-
-  public init(relation: Relation, left: Column, right: Column) {
+  public init(relation: Relation, on: Predicate) {
     self.relation = relation
-    self.left = left
-    self.right = right
+    self.on = on
+  }
+
+  /// A `column = column` equi-join over `relation` — the common shape, as the
+  /// two column references its `ON` equates.
+  public init(relation: Relation, left: Column, right: Column) {
+    self.init(relation: relation,
+              on: .comparison(left: .column(left), op: .equal,
+                              right: .column(right)))
   }
 }
 

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -617,6 +617,16 @@ extension Expression {
 }
 
 extension Predicate {
+  /// The flat list of top-level `AND`-conjuncts of this predicate in SOURCE
+  /// ORDER (a non-`and` is a singleton). The parser leans `AND` left (`a AND b
+  /// AND c` is `.and(.and(a, b), c)`), so a left-first flatten yields the
+  /// conjuncts as written — the order `Scope.on` walks to bound its safe
+  /// key-extraction prefix.
+  internal var conjuncts: Array<Predicate> {
+    guard case let .and(lhs, rhs) = self else { return [self] }
+    return lhs.conjuncts + rhs.conjuncts
+  }
+
   /// Whether the predicate contains an aggregate call anywhere within it — used
   /// to spot an aggregate hiding in a `CASE` guard (`CASE WHEN COUNT(*) > 1
   /// …`), which makes the enclosing query an aggregate one.
@@ -692,15 +702,16 @@ extension Catalog where Self: ~Escapable {
     }
     let scope = Scope(relations)
 
-    // Each join's ON equality lowers to a `match` at its own chain level,
+    // Each join's ON predicate lowers to a `Filter` at its own chain level,
     // resolved against only the prefix already in scope (as the non-aggregate
-    // path does).
+    // path does). A `column = column` conjunct becomes a `match` hash-join key;
+    // the rest is a residual the join runs as a filter.
     var matches = Array<Filter>()
     matches.reserveCapacity(select.joins.count)
     for index in select.joins.indices {
       let prefix = Scope(Array(relations[0 ... index + 1]))
       let join = select.joins[index]
-      try matches.append(prefix.match(join.left, join.right))
+      try matches.append(prefix.on(join.on, context.routines))
     }
     var predicate: Filter? = nil
     if let clause = select.predicate {
@@ -1253,12 +1264,25 @@ extension Plan {
   /// belongs to the left child and rides down; one entirely at or above it
   /// belongs to the right child, rebased into that child's own slot space; one
   /// straddling the boundary — or reading no slots, or able to throw when
-  /// evaluated (a division or scalar call) — stays here. A
-  /// `select` (a join's `ON` match, whose
-  /// two sides straddle every boundary) is transparent — the conjuncts descend
-  /// through it into the product beneath. At a `derived` leaf the conjuncts push
-  /// into the view; at a base `scan` they land directly above it. Any conjunct
-  /// that cannot descend is re-conjoined as a `select` at this level.
+  /// evaluated (a division or scalar call) — stays here. A `select` is a join's
+  /// `ON` gate, whose two sides straddle every boundary, and is a BARRIER for
+  /// an UNSAFE `WHERE` conjunct: `nest` folds only ONE `match` into the hash
+  /// `Join`'s key, leaving every other `ON` conjunct (a match beyond that key,
+  /// or a non-equi residual) as the gate's residual under the join, and the
+  /// gate drops a pair its leftover conjuncts evaluate UNKNOWN or `false`
+  /// BEFORE the `WHERE` runs. So fusing a throwing `WHERE` conjunct into the
+  /// gate — the `AND` not short-circuiting, still evaluating it for a pair the
+  /// gate already dropped — would raise an error the separate gate suppresses,
+  /// whether the leftover is a non-equi residual (`A JOIN B ON A.k < B.k WHERE
+  /// (1 / A.x) = 0`, `A.k` NULL) or a second equi key (`… ON A.k1 = B.k1 AND
+  /// A.k2 = B.k2 WHERE (1 / A.x) = 0`, `A.k2` NULL). Every UNSAFE `WHERE`
+  /// conjunct stays a separate `select` above the gate, preserving the
+  /// `ON`-drops-before-`WHERE` ordering; a SAFE `WHERE` conjunct (which never
+  /// raises) still descends below the gate — as the product loop's ordering
+  /// allows — so a safe single-relation conjunct reaches its base scan. The
+  /// match keys fold down so `nest` can join under the gate. At a `derived`
+  /// leaf the conjuncts push into the view; at a base `scan` they land right
+  /// above it. A conjunct that cannot descend is re-conjoined here.
   private func distribute(_ conjuncts: Array<Filter>)
       throws(SQLError) -> Plan {
     switch self {
@@ -1307,15 +1331,69 @@ extension Plan {
           Plan.product(try left.distribute(down),
                        try right.distribute(over.map { $0.shifted(by: base) }))
       return product.residual(here)
-    case let .select(match, source):
-      // A join's `ON` match straddles both sides, so it never captures a
-      // single-relation conjunct. Fold it in with the descending conjuncts so
-      // the product carries one `Select([match, spanning…], Product)`: `nest`
-      // finds the match to form the `Join` and keeps any spanning residual above
-      // it. Wrapping it outside instead — `Select(match, source.distribute(…))`
-      // — would leave `Select(match, Select(spanning, Product))`, whose match is
-      // no longer adjacent to the product, so `nest` could not fold it.
-      return try source.distribute(match.conjuncts + conjuncts)
+    case let .select(gate, source):
+      // A join's `ON` gate straddles both sides, so it never captures a
+      // single-relation conjunct. Its equi `column = column` conjuncts are the
+      // `match` keys `nest` folds into a hash `Join`; any other conjunct is a
+      // residual (non-equi) `ON` predicate the join runs over its product.
+      var matches = Array<Filter>()
+      var residual = Array<Filter>()
+      for conjunct in gate.conjuncts {
+        if case .match = conjunct {
+          matches.append(conjunct)
+        } else {
+          residual.append(conjunct)
+        }
+      }
+      // The `ON` gate is ALWAYS a DISTRIBUTION BARRIER for an UNSAFE outer
+      // `WHERE` conjunct, whether the gate is mixed (a non-equi residual) or
+      // PURE-equi (only matches). `nest` folds only ONE `match` into the hash
+      // `Join`'s key and leaves every other `ON` conjunct — a match beyond that
+      // key, plus any non-equi residual — as the gate's own residual `select`
+      // under the join, which drops a pair it evaluates UNKNOWN or `false`
+      // BEFORE the `WHERE` runs. Because the evaluator's `AND` does not
+      // short-circuit, FUSING a throwing `WHERE` conjunct into that gate
+      // residual would evaluate it for a pair the gate has already dropped.
+      // This bites a pure-equi `ON` too: `A JOIN B ON A.k1 = B.k1 AND A.k2 =
+      // B.k2 WHERE (1 / A.x) = 0`, `A.k1` matching, `A.k2` NULL, `A.x` = 0 —
+      // `nest` keys on `A.k1 = B.k1`, so the surviving pair reaches the
+      // leftover `A.k2 = B.k2` (UNKNOWN), which should drop it; a fused `A.k2 =
+      // B.k2 AND (1 / A.x) = 0` would instead divide by zero. So every UNSAFE
+      // `WHERE` conjunct stays a SEPARATE `select` ABOVE the gate — never fused
+      // with a leftover `ON` conjunct — keeping the `ON`-drops-before-`WHERE`
+      // order.
+      //
+      // A SAFE `WHERE` conjunct, by contrast, never raises, so pushing it below
+      // the gate can only drop rows, not suppress a throw; it still descends
+      // (`matches + residual + safe`) so a safe single-relation conjunct
+      // reaches its base scan as before. `distribute`'s product loop keeps it
+      // AFTER the `ON` residual, and its own barrier bars it from riding past
+      // an unsafe `ON` conjunct — a safe `WHERE` pushed to a base scan below
+      // the product does not co-locate with, nor reorder around, the gate's
+      // leftover conjuncts. A safe conjunct stays above when the loop would
+      // keep it at the product level anyway — mirroring that loop's ordering
+      // rules so descending it never suppresses a throw the `WHERE`'s
+      // non-short-circuiting `AND` owes: after ANY earlier unsafe conjunct
+      // (a `barrier`), or when it is NULLABLE and a LATER conjunct is unsafe
+      // (a `hazard`). The match keys still fold down beside the residual so
+      // `nest` can form the join under the gate; a single-equality pure-equi
+      // `ON` folds its one key and carries no leftover conjunct, so a safe
+      // `WHERE` descends and an unsafe one sits directly above the join.
+      var safe = Array<Filter>()
+      var above = Array<Filter>()
+      var barrier = false
+      for (index, conjunct) in conjuncts.enumerated() {
+        let hazard =
+            conjunct.nullable && conjuncts[(index + 1)...].contains { !$0.safe }
+        if conjunct.safe && !barrier && !hazard {
+          safe.append(conjunct)
+        } else {
+          above.append(conjunct)
+        }
+        if !conjunct.safe { barrier = true }
+      }
+      let gated = try source.distribute(matches + residual + safe)
+      return gated.residual(above)
     case .derived:
       return try into(conjuncts)
     default:
@@ -1724,14 +1802,16 @@ extension Catalog where Self: ~Escapable {
     }
     let scope = Scope(relations)
 
-    // Each join's ON equality lowers to a `match` at its own chain level,
+    // Each join's ON predicate lowers to a `Filter` at its own chain level,
     // resolved against only the prefix already in scope plus the relation that
     // join introduces — the FROM relation and joins `0…index` — never a
     // relation joined later. Since `Scope` lays relations at cumulative offsets
     // from 0, a prefix scope yields the same global combined ordinals as the
-    // full-chain scope, so the match ordinals remap through `slot` as before;
+    // full-chain scope, so the ON ordinals remap through `slot` as before;
     // resolving against the prefix rejects a reference to a not-yet-joined
     // relation (`SQLError.column`) and judges ambiguity only within the prefix.
+    // A `column = column` conjunct lowers to a `match` hash-join key; any
+    // inequality or expression equality lowers to a residual the join filters.
     // The WHERE and ORDER lower against the whole chain, which legitimately
     // sees every relation.
     var matches = Array<Filter>()
@@ -1739,7 +1819,7 @@ extension Catalog where Self: ~Escapable {
     for index in select.joins.indices {
       let prefix = Scope(Array(relations[0 ... index + 1]))
       let join = select.joins[index]
-      try matches.append(prefix.match(join.left, join.right))
+      try matches.append(prefix.on(join.on, context.routines))
     }
     var predicate: Filter? = nil
     if let clause = select.predicate {

--- a/Sources/SQL/Parser.swift
+++ b/Sources/SQL/Parser.swift
@@ -23,7 +23,7 @@
 ///                   [FROM relation (join)*
 ///                    [where] [group] [having] [order] [limit]]
 /// relation       := identifier [AS identifier]
-/// join           := JOIN relation ON column '=' column
+/// join           := JOIN relation ON predicate
 /// projection     := '*' | column (',' column)*
 /// where          := WHERE predicate
 /// group          := GROUP BY column (',' column)*
@@ -393,14 +393,15 @@ internal struct Parser: ~Escapable {
   }
 
   /// Parses the join tail (the `JOIN` keyword is already consumed): a relation,
-  /// `ON`, and a single `column = column` equality.
+  /// `ON`, and an arbitrary boolean predicate — the same grammar a `WHERE`
+  /// admits, so a join relates its sides by an equality, an inequality, an
+  /// expression equality, or any `AND`/`OR`/`NOT` of comparisons. A pure
+  /// `column = column` conjunct hash-joins; the rest is a residual filter.
   private mutating func join() throws(SQLError) -> Join {
     let relation = try relation()
     try expect(.on)
-    let left = try column()
-    try expect(.equal)
-    let right = try column()
-    return Join(relation: relation, left: left, right: right)
+    let on = try predicate()
+    return Join(relation: relation, on: on)
   }
 
   // MARK: - Projection

--- a/Sources/SQL/Resolve.swift
+++ b/Sources/SQL/Resolve.swift
@@ -1118,6 +1118,65 @@ internal struct Scope {
     try .match(ordinal(of: left), ordinal(of: right))
   }
 
+  /// Lowers a join's `ON predicate` to the engine's `Filter` across the chain,
+  /// emitting a `match` for each pure `column = column` equality — the
+  /// hash-join key `nest` folds into a physical `Join` — ONLY WHEN the WHOLE
+  /// `ON` is safe, and otherwise lowering the entire conjunction as one
+  /// residual.
+  ///
+  /// A `column = column` conjunct is the hash-join key `nest` folds into a
+  /// physical `Join`, so it lowers to a `match(left, right)` — the same node
+  /// the equi-only `ON` produced — rather than a `compare(.slot, .equal,
+  /// .slot)`, which `nest` would not recognise as a key. Every other leaf (an
+  /// inequality, an expression equality such as `a.x = b.y + 1`, an `IS NULL`,
+  /// a membership, an `OR`/`NOT`) lowers through `lower`, becoming a residual
+  /// the join runs as a filter over the product — nested-loop semantics,
+  /// correct if O(n·m).
+  ///
+  /// A `match` key is extracted ONLY WHEN EVERY lowered conjunct is `safe`; if
+  /// ANY conjunct is unsafe, the whole `ON` lowers to a single residual and NO
+  /// key is hoisted. The hash join evaluates its key equality BEFORE any
+  /// residual conjunct AND skips a NULL key (an equi `match` drops a pair whose
+  /// key cell is NULL), so an extracted key changes the `ON`'s left-to-right
+  /// Kleene error behaviour on two hazards, both suppressing a throw the
+  /// residual `select` over the product would raise (the order the WHERE
+  /// pushdown barriers preserve):
+  ///   - an UNSAFE conjunct BEFORE the key (`ON (1 / A.x) = 0 AND A.k = B.k`):
+  ///     hoisting the key would let its non-match drop a pair before the
+  ///     unsafe conjunct runs (`A.x = 0` ⇒ `SQLError.divide`);
+  ///   - a NULLABLE key BEFORE an UNSAFE conjunct (`ON A.k = B.k AND (1 / A.x)
+  ///     = 0`, `A.k` NULL, `A.x = 0`): the equality is UNKNOWN, so the Kleene
+  ///     `AND` must still evaluate the unsafe RHS and raise — but the hash join
+  ///     skips the NULL key and drops the pair before the RHS runs.
+  /// The engine has no NOT NULL schema (a column surfaces as a `Value` that may
+  /// be `.null`), so it cannot prove a key operand non-nullable; EVERY equi key
+  /// is treated as nullable, collapsing both hazards to the single whole-`ON`
+  /// rule. An equi `column = column` is always `safe` (comparing two cells
+  /// never raises), so an all-equi or otherwise all-safe `ON` still hash-joins
+  /// byte-for-byte.
+  internal func on(_ predicate: Predicate,
+                   _ routines: Routines = [:]) throws(SQLError) -> Filter {
+    let conjuncts = predicate.conjuncts
+    let lowered = try conjuncts.map { conjunct throws(SQLError) in
+      try lower(conjunct, routines)
+    }
+    // An unsafe conjunct anywhere forbids extracting ANY key: a hoisted key
+    // both skips a NULL pair before a LATER unsafe conjunct runs and drops a
+    // non-match before an EARLIER one does — either suppressing the throw the
+    // whole-ON residual owes. Lower the entire conjunction as one residual.
+    guard lowered.allSatisfy(\.safe) else { return lowered.conjunction! }
+    var filters = Array<Filter>()
+    for (conjunct, residual) in zip(conjuncts, lowered) {
+      if case let .comparison(.column(left),
+                              .equal, .column(right)) = conjunct {
+        try filters.append(match(left, right))
+      } else {
+        filters.append(residual)
+      }
+    }
+    return filters.conjunction!
+  }
+
   /// Lowers the name-addressed AST `predicate` to the engine's `Filter`, each
   /// column reference resolved to a combined ordinal across the chain.
   internal func lower(_ predicate: Predicate,

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -771,6 +771,427 @@ struct EngineJoinTests {
   }
 }
 
+// MARK: - Non-equi join tests
+
+struct EngineNonEquiJoinTests {
+  @Test func `an inequality ON pairs every row the predicate admits`() throws {
+    // `ON Parent.Id < Child.Pid` is a pure inequality — no equi conjunct —
+    // so it is a nested loop: for each parent, every child whose Pid exceeds
+    // its Id, in outer-major order.
+    let rows = try join("""
+        SELECT Parent.Name, Child.Name FROM Parent
+          JOIN Child ON Parent.Id < Child.Pid
+        """)
+    #expect(rows == [
+      [.text("Ada"), .text("Bob")],
+      [.text("Ada"), .text("Orphan")],
+      [.text("Bee"), .text("Orphan")],
+      [.text("Cid"), .text("Orphan")],
+    ])
+  }
+
+  @Test func `a pure inequality ON plans a residual product, not a hash join`() throws {
+    // No `column = column` conjunct, so `nest` cannot form a `.join`; the level
+    // stays a `.select` over a `.product` — the nested-loop shape.
+    let catalog = try family()
+    let select = try parse("""
+        SELECT Parent.Name, Child.Name FROM Parent
+          JOIN Child ON Parent.Id < Child.Pid
+        """)
+    let plan =
+        try catalog.optimise(catalog.compile(select).pushdown(), [:])
+    #expect(!joins(plan))
+    #expect(residual(plan))
+  }
+
+  @Test func `a mixed ON hashes the equi conjunct and filters the residual`() throws {
+    // `ON Child.Pid = Parent.Id AND Child.Name < 'B'`: the equality hash-joins
+    // each child to its parent; the residual inequality beside the key then
+    // keeps only pairs whose child name sorts before 'B' — dropping Bob, the
+    // sole B-name.
+    let rows = try join("""
+        SELECT Parent.Name, Child.Name FROM Parent
+          JOIN Child ON Child.Pid = Parent.Id AND Child.Name < 'B'
+        """)
+    // Equi pairs (Ada,Ann),(Ada,Amy),(Bee,Bob); the residual drops (Bee,Bob).
+    #expect(rows == [
+      [.text("Ada"), .text("Ann")],
+      [.text("Ada"), .text("Amy")],
+    ])
+  }
+
+  @Test func `a mixed ON still plans a hash join for its equi conjunct`() throws {
+    // The `column = column` conjunct becomes a `.join`; the inequality
+    // survives as a residual `.select` over it — the equi fast-path still
+    // triggers.
+    let catalog = try family()
+    let select = try parse("""
+        SELECT Parent.Name, Child.Name FROM Parent
+          JOIN Child ON Child.Pid = Parent.Id AND Parent.Name < Child.Name
+        """)
+    let plan =
+        try catalog.optimise(catalog.compile(select).pushdown(), [:])
+    #expect(joins(plan))
+  }
+
+  @Test func `an expression equality ON is a residual, not a hash key`() throws {
+    // `ON Child.Pid = Parent.Id + 1` equates a column with an EXPRESSION, so
+    // it is not a bare `column = column` key: it lowers to a residual over the
+    // product (nested loop), not a hash join.
+    let rows = try join("""
+        SELECT Parent.Name, Child.Name FROM Parent
+          JOIN Child ON Child.Pid = Parent.Id + 1
+        """)
+    // Parent 1 (Ada) → Pid 2: Bob. Parent 2 (Bee) → Pid 3: none.
+    // Parent 3 (Cid) → Pid 4: none.
+    #expect(rows == [[.text("Ada"), .text("Bob")]])
+  }
+
+  @Test func `an expression equality ON plans a residual product`() throws {
+    let catalog = try family()
+    let select = try parse("""
+        SELECT Parent.Name, Child.Name FROM Parent
+          JOIN Child ON Child.Pid = Parent.Id + 1
+        """)
+    let plan =
+        try catalog.optimise(catalog.compile(select).pushdown(), [:])
+    #expect(!joins(plan))
+    #expect(residual(plan))
+  }
+
+  @Test func `a non-equi ON equals the eager product filtered`() throws {
+    // The nested-loop join over an inequality must yield exactly the eager
+    // cross product filtered by the same predicate, in outer-major order.
+    let catalog = try family()
+    let parents = try catalog.run(parse("SELECT Name, Id FROM Parent"))
+    let children = try catalog.run(parse("SELECT Name, Pid FROM Child"))
+    var expected = Array<Array<Value>>()
+    for parent in parents {
+      for child in children where less(parent[1], child[1]) {
+        expected.append([parent[0], child[0]])
+      }
+    }
+    let rows = try catalog.run(parse("""
+        SELECT Parent.Name, Child.Name FROM Parent
+          JOIN Child ON Parent.Id < Child.Pid
+        """))
+    #expect(rows == expected)
+  }
+
+  @Test func `an unsafe ON conjunct before an equi key is preserved`() throws {
+    // `ON (1 / A.x) = 0 AND A.k = B.k` over a product pair where `A.x = 0` and
+    // `A.k <> B.k`. The hash join evaluates its key equality BEFORE any
+    // residual, so hoisting `A.k = B.k` to a key would drop the non-matching
+    // pair and skip the division the earlier unsafe conjunct owes. The unsafe
+    // leading conjunct bars extraction, so the WHOLE ON stays a residual over
+    // the product and the division raises `SQLError.divide` rather than the
+    // query returning no rows.
+    let catalog = Memory([
+      "A": FixtureRelation([Field(name: "x", type: .integer),
+                     Field(name: "k", type: .integer)],
+                    [[.integer(0), .integer(1)]] as Array<Array<Value>>),
+      "B": FixtureRelation([Field(name: "k", type: .integer)],
+                    [[.integer(2)]] as Array<Array<Value>>),
+    ])
+    #expect(throws: SQLError.divide) {
+      _ = try catalog.run(parse("""
+          SELECT A.k FROM A JOIN B ON (1 / A.x) = 0 AND A.k = B.k
+          """))
+    }
+  }
+
+  @Test func `an unsafe-prefixed ON extracts no equi key, planning a residual`() throws {
+    // The same `ON (1 / A.x) = 0 AND A.k = B.k`: the unsafe leading conjunct
+    // bars the equi from becoming a `match`, so `nest` forms no `.join` — the
+    // level is a residual `.select` over a `.product`, the whole ON per pair.
+    let catalog = Memory([
+      "A": FixtureRelation([Field(name: "x", type: .integer),
+                     Field(name: "k", type: .integer)],
+                    [[.integer(0), .integer(1)]] as Array<Array<Value>>),
+      "B": FixtureRelation([Field(name: "k", type: .integer)],
+                    [[.integer(2)]] as Array<Array<Value>>),
+    ])
+    let select = try parse("""
+        SELECT A.k FROM A JOIN B ON (1 / A.x) = 0 AND A.k = B.k
+        """)
+    let plan =
+        try catalog.optimise(catalog.compile(select).pushdown(), [:])
+    #expect(!joins(plan))
+    #expect(residual(plan))
+  }
+
+  @Test func `an equi key before an unsafe residual extracts no key, planning a residual`() throws {
+    // `ON A.k = B.k AND (1 / A.x) = 0` (equi FIRST) has an unsafe conjunct, so
+    // NO key is extracted and the WHOLE ON lowers to a residual over the
+    // product. A hash key would skip a NULL-key pair before the unsafe RHS ran,
+    // suppressing the divide the left-to-right Kleene AND owes — so the equi
+    // must NOT hoist while an unsafe conjunct FOLLOWS it.
+    let catalog = Memory([
+      "A": FixtureRelation([Field(name: "x", type: .integer),
+                     Field(name: "k", type: .integer)],
+                    [[.integer(0), .integer(1)]] as Array<Array<Value>>),
+      "B": FixtureRelation([Field(name: "k", type: .integer)],
+                    [[.integer(2)]] as Array<Array<Value>>),
+    ])
+    let plan = try catalog.optimise(catalog.compile(parse("""
+        SELECT A.k FROM A JOIN B ON A.k = B.k AND (1 / A.x) = 0
+        """)).pushdown(), [:])
+    #expect(!joins(plan))
+    #expect(residual(plan))
+  }
+
+  @Test func `a nullable ON key before an unsafe residual raises`() throws {
+    // `ON A.k = B.k AND (1 / A.x) = 0` with `A.k` NULL and `A.x = 0`. The
+    // equality is UNKNOWN (a NULL operand), so the Kleene AND must still
+    // evaluate the unsafe RHS `(1 / A.x) = 0` and raise `SQLError.divide`.
+    // Extracting `A.k = B.k` to a hash key would skip the NULL key and DROP the
+    // pair before the RHS ran, returning no rows — so no key is hoisted and the
+    // WHOLE ON stays a residual over the product that raises.
+    let catalog = Memory([
+      "A": FixtureRelation([Field(name: "x", type: .integer),
+                     Field(name: "k", type: .integer)],
+                    [[.integer(0), .null]] as Array<Array<Value>>),
+      "B": FixtureRelation([Field(name: "k", type: .integer)],
+                    [[.integer(2)]] as Array<Array<Value>>),
+    ])
+    let plan = try catalog.optimise(catalog.compile(parse("""
+        SELECT A.k FROM A JOIN B ON A.k = B.k AND (1 / A.x) = 0
+        """)).pushdown(), [:])
+    #expect(!joins(plan))
+    #expect(residual(plan))
+    #expect(throws: SQLError.divide) {
+      _ = try catalog.run(parse("""
+          SELECT A.k FROM A JOIN B ON A.k = B.k AND (1 / A.x) = 0
+          """))
+    }
+  }
+
+  @Test func `a definite-false ON key before an unsafe residual short-circuits without raising`() throws {
+    // `ON A.k = B.k AND (1 / A.x) = 0` with `A.k = 5`, `B.k = 3` (non-NULL,
+    // definitely UNEQUAL) and `A.x = 0`. The equality is definite FALSE, so the
+    // Kleene AND short-circuits (`false` dominates) and never evaluates the
+    // unsafe RHS — no rows, no raise. Both the product+select and the residual
+    // agree, distinguishing a definite-FALSE key from the UNKNOWN NULL one.
+    let catalog = Memory([
+      "A": FixtureRelation([Field(name: "x", type: .integer),
+                     Field(name: "k", type: .integer)],
+                    [[.integer(0), .integer(5)]] as Array<Array<Value>>),
+      "B": FixtureRelation([Field(name: "k", type: .integer)],
+                    [[.integer(3)]] as Array<Array<Value>>),
+    ])
+    let rows = try catalog.run(parse("""
+        SELECT A.k FROM A JOIN B ON A.k = B.k AND (1 / A.x) = 0
+        """))
+    #expect(rows.isEmpty)
+  }
+
+  @Test func `a safe non-equi before an equi still extracts the equi key`() throws {
+    // SAFE-prefix — `ON A.p < B.q AND A.k = B.k`. The leading `<` is safe
+    // (comparing two cells never raises), so it does not bar extraction: the
+    // equi `A.k = B.k` still becomes a hash key beside the residual inequality.
+    let catalog = Memory([
+      "A": FixtureRelation([Field(name: "k", type: .integer),
+                     Field(name: "p", type: .integer)],
+                    [[.integer(1), .integer(5)],
+                     [.integer(2), .integer(10)]] as Array<Array<Value>>),
+      "B": FixtureRelation([Field(name: "k", type: .integer),
+                     Field(name: "q", type: .integer)],
+                    [[.integer(1), .integer(8)],
+                     [.integer(2), .integer(3)]] as Array<Array<Value>>),
+    ])
+    let text = """
+        SELECT A.k, B.q FROM A JOIN B ON A.p < B.q AND A.k = B.k
+        """
+    // Key pairs (1,1) with 5 < 8 kept; (2,2) with 10 < 3 dropped.
+    let rows = try catalog.run(parse(text))
+    #expect(rows == [[.integer(1), .integer(8)]])
+    let plan =
+        try catalog.optimise(catalog.compile(parse(text)).pushdown(), [:])
+    #expect(joins(plan))
+  }
+
+  @Test func `a pure equi ON still plans a hash join`() throws {
+    // The equi fast-path is unchanged: an all-`column = column` ON extracts
+    // its key and folds into a `.join`.
+    let catalog = try family()
+    let select = try parse("""
+        SELECT Parent.Name, Child.Name FROM Parent
+          JOIN Child ON Child.Pid = Parent.Id
+        """)
+    let plan =
+        try catalog.optimise(catalog.compile(select).pushdown(), [:])
+    #expect(joins(plan))
+  }
+
+  @Test func `a nullable ON gate drops a pair before an unsafe WHERE`() throws {
+    // `A JOIN B ON A.k < B.k WHERE (1 / A.x) = 0`, `A.k` NULL and `A.x` = 0.
+    // The residual `ON` gate `A.k < B.k` is UNKNOWN (a NULL operand), so the
+    // pair is DROPPED at the gate and the `WHERE` never runs on it — no rows,
+    // no raise. The gate is a distribution BARRIER: the `WHERE` stays a
+    // SEPARATE `select` above the residual `ON` gate rather than fused into one
+    // throwing `A.k < B.k AND (1 / A.x) = 0` over the product.
+    let catalog = Memory([
+      "A": FixtureRelation([Field(name: "x", type: .integer),
+                            Field(name: "k", type: .integer)],
+                           [[.integer(0), .null]] as Array<Array<Value>>),
+      "B": FixtureRelation([Field(name: "k", type: .integer)],
+                           [[.integer(2)]] as Array<Array<Value>>),
+    ])
+    let text = "SELECT A.k FROM A JOIN B ON A.k < B.k WHERE (1 / A.x) = 0"
+    let plan =
+        try catalog.optimise(catalog.compile(parse(text)).pushdown(), [:])
+    #expect(separated(plan))
+    #expect(residual(plan))
+    #expect(try catalog.run(parse(text)).isEmpty)
+  }
+
+  @Test func `a surviving ON pair still runs the unsafe WHERE`() throws {
+    // CONTROL — the same `A JOIN B ON A.k < B.k WHERE (1 / A.x) = 0`, but now
+    // `A.k` = 1 and `B.k` = 2, so the `ON` gate is TRUE and the pair PASSES it.
+    // The `WHERE` then runs on the surviving pair and `(1 / A.x) = 0` with
+    // `A.x` = 0 raises `SQLError.divide` — the `WHERE` still applies after the
+    // gate.
+    let catalog = Memory([
+      "A": FixtureRelation([Field(name: "x", type: .integer),
+                            Field(name: "k", type: .integer)],
+                           [[.integer(0), .integer(1)]] as Array<Array<Value>>),
+      "B": FixtureRelation([Field(name: "k", type: .integer)],
+                           [[.integer(2)]] as Array<Array<Value>>),
+    ])
+    #expect(throws: SQLError.divide) {
+      _ = try catalog.run(parse("""
+          SELECT A.k FROM A JOIN B ON A.k < B.k WHERE (1 / A.x) = 0
+          """))
+    }
+  }
+
+  @Test func `a safe WHERE over a non-equi ON join returns correct rows`()
+      throws {
+    // A SAFE `WHERE` over a non-equi `ON` join yields the same rows the eager
+    // product filtered by both `ON` and `WHERE` would — whether or not the safe
+    // `WHERE` fuses with the gate. `ON Parent.Id < Child.Pid WHERE Child.Name
+    // <> 'Orphan'` pairs each parent with a later-keyed child, then drops the
+    // Orphan child.
+    let rows = try join("""
+        SELECT Parent.Name, Child.Name FROM Parent
+          JOIN Child ON Parent.Id < Child.Pid WHERE Child.Name <> 'Orphan'
+        """)
+    #expect(rows == [[.text("Ada"), .text("Bob")]])
+  }
+
+  @Test func `a leftover ON match gates a pair before an unsafe WHERE`() throws {
+    // `A JOIN B ON A.k1 = B.k1 AND A.k2 = B.k2 WHERE (1 / A.x) = 0`, with
+    // `A.k1` matching, `A.k2` NULL, and `A.x` = 0. `nest` folds ONE equi key
+    // (`A.k1 = B.k1`) into the hash `.join`, leaving `A.k2 = B.k2` as the
+    // gate's own residual under the join. The surviving `k1` pair reaches that
+    // leftover match, which is UNKNOWN (a NULL `A.k2`), so the pair is DROPPED
+    // at the gate BEFORE the `WHERE` runs — no rows, no raise. The `ON` gate is
+    // a BARRIER even though it is PURE-equi: the `WHERE` stays a SEPARATE
+    // `select` above the leftover-match gate rather than fused into a throwing
+    // `A.k2 = B.k2 AND (1 / A.x) = 0` that would divide by zero on the pair.
+    let catalog = Memory([
+      "A": FixtureRelation([Field(name: "x", type: .integer),
+                            Field(name: "k1", type: .integer),
+                            Field(name: "k2", type: .integer)],
+                           [[.integer(0), .integer(1), .null]]
+                             as Array<Array<Value>>),
+      "B": FixtureRelation([Field(name: "k1", type: .integer),
+                            Field(name: "k2", type: .integer)],
+                           [[.integer(1), .integer(5)]]
+                             as Array<Array<Value>>),
+    ])
+    let text = """
+        SELECT A.k1 FROM A
+          JOIN B ON A.k1 = B.k1 AND A.k2 = B.k2 WHERE (1 / A.x) = 0
+        """
+    let plan =
+        try catalog.optimise(catalog.compile(parse(text)).pushdown(), [:])
+    // The equi key still hash-joins; the leftover match gates above it, and the
+    // `WHERE` is a SEPARATE `select` above that gate, not fused with the match.
+    #expect(joins(plan))
+    #expect(stacked(plan))
+    #expect(try catalog.run(parse(text)).isEmpty)
+  }
+
+  @Test func `both ON matches passing lets the unsafe WHERE raise`() throws {
+    // CONTROL — the same two-key `ON` and unsafe `WHERE`, but now BOTH keys
+    // match (`A.k2` = 5 = `B.k2`), so the pair passes the whole `ON` gate. The
+    // `WHERE` then runs on the surviving pair and `(1 / A.x) = 0` with `A.x`
+    // = 0 raises `SQLError.divide` — the `WHERE` still applies after the gate.
+    let catalog = Memory([
+      "A": FixtureRelation([Field(name: "x", type: .integer),
+                            Field(name: "k1", type: .integer),
+                            Field(name: "k2", type: .integer)],
+                           [[.integer(0), .integer(1), .integer(5)]]
+                             as Array<Array<Value>>),
+      "B": FixtureRelation([Field(name: "k1", type: .integer),
+                            Field(name: "k2", type: .integer)],
+                           [[.integer(1), .integer(5)]]
+                             as Array<Array<Value>>),
+    ])
+    #expect(throws: SQLError.divide) {
+      _ = try catalog.run(parse("""
+          SELECT A.k1 FROM A
+            JOIN B ON A.k1 = B.k1 AND A.k2 = B.k2 WHERE (1 / A.x) = 0
+          """))
+    }
+  }
+
+  @Test func `a two-equality pure-equi ON with a safe WHERE joins correctly`()
+      throws {
+    // The equi fast-path is intact under the always-barrier rule: a two-key
+    // pure-equi `ON` still hash-joins (one key folded, the other gating over
+    // the join) and a SAFE `WHERE` above returns the expected rows. `A.k1` and
+    // `A.k2` pick out exactly the `B` row whose BOTH keys match; the `WHERE`
+    // then keeps only the tagged pair.
+    let catalog = Memory([
+      "A": FixtureRelation([Field(name: "k1", type: .integer),
+                            Field(name: "k2", type: .integer),
+                            Field(name: "tag", type: .text)],
+                           [[.integer(1), .integer(5), .text("keep")],
+                            [.integer(1), .integer(9), .text("drop")]]
+                             as Array<Array<Value>>),
+      "B": FixtureRelation([Field(name: "k1", type: .integer),
+                            Field(name: "k2", type: .integer),
+                            Field(name: "note", type: .text)],
+                           [[.integer(1), .integer(5), .text("bee")],
+                            [.integer(1), .integer(9), .text("cee")]]
+                             as Array<Array<Value>>),
+    ])
+    let text = """
+        SELECT A.tag, B.note FROM A
+          JOIN B ON A.k1 = B.k1 AND A.k2 = B.k2 WHERE A.tag = 'keep'
+        """
+    let plan =
+        try catalog.optimise(catalog.compile(parse(text)).pushdown(), [:])
+    #expect(joins(plan))
+    #expect(try catalog.run(parse(text)) == [[.text("keep"), .text("bee")]])
+  }
+
+  @Test func `a single-equality ON still plans a hash join and behaves`() throws {
+    // A single-equality pure-equi `ON A.k = B.k` folds its ONE key into the
+    // hash `.join` and carries no leftover conjunct, so the `WHERE` sits
+    // above the join. A matching pair runs the `WHERE`; a NULL key drops the
+    // pair at the join, so the `WHERE` never runs on it. `A` holds a matching
+    // row (`k` = 1, `x` = 1) and a NULL-key row (`k` NULL, `x` = 0): the match
+    // returns the pair `WHERE A.x = 1` admits, and the NULL-key row is dropped
+    // before the unsafe `(1 / A.x)` would ever divide.
+    let catalog = Memory([
+      "A": FixtureRelation([Field(name: "x", type: .integer),
+                            Field(name: "k", type: .integer)],
+                           [[.integer(1), .integer(1)],
+                            [.integer(0), .null]] as Array<Array<Value>>),
+      "B": FixtureRelation([Field(name: "k", type: .integer)],
+                           [[.integer(1)]] as Array<Array<Value>>),
+    ])
+    let text = "SELECT A.k FROM A JOIN B ON A.k = B.k WHERE (1 / A.x) = 1"
+    let plan =
+        try catalog.optimise(catalog.compile(parse(text)).pushdown(), [:])
+    #expect(joins(plan))
+    #expect(try catalog.run(parse(text)) == [[.integer(1)]])
+  }
+}
+
 // MARK: - Multi-way join tests
 
 struct EngineMultiJoinTests {
@@ -1152,6 +1573,73 @@ private func residual(_ plan: Plan) -> Bool {
     residual(left) || residual(right)
   case let .aggregate(_, _, source):
     residual(source)
+  case .single, .scan:
+    false
+  }
+}
+
+/// Whether `plan` reaches a `.select` standing directly over ANOTHER `.select`
+/// over a `.product` — the WHERE-above-a-separate-ON-gate shape the barrier
+/// preserves (the outer `select` the `WHERE`, the inner the residual `ON`
+/// gate), as opposed to one fused `.select(ON AND WHERE, product)`.
+private func separated(_ plan: Plan) -> Bool {
+  switch plan {
+  case .select(_, .select(_, .product)):
+    true
+  case let .select(_, source):
+    separated(source)
+  case let .project(_, source):
+    separated(source)
+  case let .sort(_, source):
+    separated(source)
+  case let .limit(_, _, source):
+    separated(source)
+  case let .distinct(source):
+    separated(source)
+  case let .derived(_, sub, _, _):
+    separated(sub)
+  case let .product(left, right):
+    separated(left) || separated(right)
+  case let .join(outer, _, _, _, _, _, _):
+    separated(outer)
+  case let .union(left, right, _):
+    separated(left) || separated(right)
+  case let .aggregate(_, _, source):
+    separated(source)
+  case .single, .scan:
+    false
+  }
+}
+
+/// Whether `plan` reaches a `.select` standing over ANOTHER `.select` over a
+/// `.join` — the WHERE-above-a-leftover-ON-gate shape the always-barrier rule
+/// preserves for a pure-equi `ON` whose extra equi key `nest` leaves gating
+/// over the hash join (the outer `select` the `WHERE`, the inner the leftover
+/// match), as opposed to one fused `.select(match AND WHERE, join)`.
+private func stacked(_ plan: Plan) -> Bool {
+  switch plan {
+  case .select(_, .select(_, .join)):
+    true
+  case let .select(_, source):
+    stacked(source)
+  case let .project(_, source):
+    stacked(source)
+  case let .sort(_, source):
+    stacked(source)
+  case let .limit(_, _, source):
+    stacked(source)
+  case let .distinct(source):
+    stacked(source)
+  case let .derived(_, sub, _, _):
+    stacked(sub)
+  case let .product(left, right):
+    stacked(left) || stacked(right)
+  case let .join(outer, _, _, _, _, _, _):
+    stacked(outer)
+  case let .union(left, right, _):
+    stacked(left) || stacked(right)
+  case let .aggregate(_, _, source):
+    stacked(source)
   case .single, .scan:
     false
   }

--- a/Tests/SQLTests/ParserTests.swift
+++ b/Tests/SQLTests/ParserTests.swift
@@ -379,10 +379,28 @@ struct JoinTests {
     }
   }
 
-  @Test func `rejects a join whose ON is not an equality`() {
-    #expect(throws: SQLError.self) {
-      _ = try Statement(parsing: "SELECT * FROM A JOIN B ON a.x < b.Id")
-    }
+  @Test func `parses a non-equi ON as an arbitrary predicate`() throws {
+    let select = try parse(select: """
+        SELECT * FROM A JOIN B ON a.x < b.Id
+        """)
+    #expect(select.joins == [
+      Join(relation: Relation(name: "B"),
+           on: .comparison(left: .column("a.x"), op: .lt,
+                           right: .column("b.Id"))),
+    ])
+  }
+
+  @Test func `parses a mixed equi-and-residual ON`() throws {
+    let select = try parse(select: """
+        SELECT * FROM A JOIN B ON a.k = b.k AND a.x < b.y
+        """)
+    #expect(select.joins == [
+      Join(relation: Relation(name: "B"),
+           on: .and(.comparison(left: .column("a.k"), op: .equal,
+                                right: .column("b.k")),
+                    .comparison(left: .column("a.x"), op: .lt,
+                                right: .column("b.y")))),
+    ])
   }
 }
 


### PR DESCRIPTION
The join grammar admitted only a single `column = column` equality after `ON`. Generalize it to the full `WHERE` predicate grammar so a join may relate its sides by an inequality (`a.x < b.y`), an expression equality (`a.x = b.y + 1`), or any `AND`/`OR`/`NOT` of comparisons — the ISO rule of arbitrary join predicates.

The `Join` AST node now holds an `on: Predicate` rather than a `left`/ `right` column pair (a convenience initializer still spells the common `column = column` shape). The parser parses a full predicate after `ON`.

Lowering splits the predicate: a pure `column = column` conjunct lowers to a `match` node — the hash-join key the physical `nest` rewrite folds into a `Join` — exactly as the equi-only `ON` did, so the equi fast-path is unchanged. Every other leaf (an inequality, an expression equality, an `IS NULL`, a membership) and any `OR`/`NOT` lowers through the shared `lower`, becoming a residual `select` over the product: the streaming nested-loop path already present for a view inner. A mixed `ON a.x = b.y AND a.z < b.w` hash-joins the equality and filters the inequality as a residual over the join.

No new operator or executor path is needed — the existing `distribute`/ `nest`/`gated` machinery and the fused product-under-select executor carry the residual. Tests cover a pure inequality, a mixed equi-plus- residual, and an expression equality, each asserting both the result rows and the planned shape (hash `.join` vs residual `.product`).