### PR TITLE
winmd-inspect: add a generics view over GenericParam

### DIFF
--- a/Sources/winmd-inspect/Resources/Queries/generics.sql
+++ b/Sources/winmd-inspect/Resources/Queries/generics.sql
@@ -1,0 +1,10 @@
+CREATE VIEW generics AS
+SELECT
+  Name,
+  Number
+FROM
+  GenericParam
+WHERE
+  Owner_TypeDef = :parent
+ORDER BY
+  Number

--- a/Tests/winmd-inspectTests/ShellTests.swift
+++ b/Tests/winmd-inspectTests/ShellTests.swift
@@ -362,11 +362,12 @@ struct ShellTests {
             == ["SELECT 1\nFROM Module", "SELECT 2"])
   }
 
-  @Test func `the bundled views are the four COM-interface views`() {
-    // The parse-and-register path a `CREATE VIEW` reuses; the four bundled
+  @Test func `the bundled views are the five COM-interface views`() {
+    // The parse-and-register path a `CREATE VIEW` reuses; the five bundled
     // views register under their case-folded names.
     let views = Session.bundled()
-    #expect(Set(views.keys) == ["interfaces", "methods", "params", "bases"])
+    #expect(Set(views.keys)
+            == ["interfaces", "methods", "params", "bases", "generics"])
   }
 
   @Test func `a streamed CREATE VIEW statement parses and registers a view`() throws {


### PR DESCRIPTION
Add a bundled `generics` query view over `GenericParam`, keyed on the owning `TypeDef` (`Owner_TypeDef`, the decoded coded-index join key) and ordered by `Number`, projecting the parameter `Name`. A sibling render query selects it through the `SANITIZE` UDF, the same shape the `methods`/`params`/`bases` render queries take. The SQL adapter is generic over every WinMD table, so `GenericParam` was already queryable — this is pure SQL, no adapter change.

The bundled-views test now expects the five COM-interface views.