### PR TITLE
WinMDSynthesis: spell a declared generic parameter name

### DIFF
--- a/Sources/WinMDSynthesis/Decode.swift
+++ b/Sources/WinMDSynthesis/Decode.swift
@@ -73,6 +73,22 @@ public struct Dialect: Sendable {
     self.known = known
     self.escape = escape
   }
+
+  /// The generic-parameter declaration clause for the ordered `names`
+  /// (`<Element>`, `<Key, Value>`) — the dialect's generic delimiters wrapped
+  /// around the comma-separated names — or `nil` for a non-generic declaration
+  /// (an empty list), so a caller omits the clause entirely. Variance is
+  /// dropped (the target has no declaration-site variance); names spell plain.
+  ///
+  /// Each name is escaped through the dialect's keyword rule, so a parameter
+  /// whose metadata name is a target keyword (`in`, `class`) declares as
+  /// `` `in` `` — matching the escaped spelling a `VAR` use of the same
+  /// parameter produces, so declaration and use agree.
+  public func generics(_ names: Array<String>) -> String? {
+    guard !names.isEmpty else { return nil }
+    return generic.open + names.map(escape).joined(separator: ", ")
+        + generic.close
+  }
 }
 
 /// The per-dialect decode functions, emitting a target type spelling as text.
@@ -89,33 +105,43 @@ public struct Dialect: Sendable {
 extension SignatureType {
   /// The type spelling of `self` in `dialect`, resolving named types through
   /// `resolver` and disambiguating a `System.Guid` by the `parameter`-name hint.
-  public func decode(parameter: String? = nil, with resolver: Resolver,
+  ///
+  /// A `VAR` generic variable spells its declared parameter's name when the
+  /// owner's ordered `generics` names are supplied (`VAR 0` of `<Element>`
+  /// spells `Element`); absent them (the DB-free path) it degrades to the
+  /// dialect's positional placeholder (`T0`). The names index by the variable's
+  /// operand; an out-of-range operand falls back to the placeholder. An `MVAR`
+  /// (method-level) variable always spells its placeholder — only the
+  /// type-level names are threaded here.
+  public func decode(parameter: String? = nil,
+                     generics: Array<String>? = nil, with resolver: Resolver,
                      dialect: Dialect) -> String {
     switch self {
     case let .primitive(primitive):
       primitive.spelling(dialect)
     case let .pointer(pointee):
-      pointee.spelling(parameter: parameter, const: false, with: resolver,
-                       dialect: dialect)
+      pointee.spelling(parameter: parameter, generics: generics, const: false,
+                       with: resolver, dialect: dialect)
     case let .reference(referent):
-      referent.spelling(parameter: parameter, const: false, with: resolver,
-                        dialect: dialect)
+      referent.spelling(parameter: parameter, generics: generics, const: false,
+                        with: resolver, dialect: dialect)
     case let .array(element):
-      element.spelling(parameter: parameter, const: false, with: resolver,
-                       dialect: dialect)
+      element.spelling(parameter: parameter, generics: generics, const: false,
+                       with: resolver, dialect: dialect)
     case let .matrix(element, _):
-      element.spelling(parameter: parameter, const: false, with: resolver,
-                       dialect: dialect)
+      element.spelling(parameter: parameter, generics: generics, const: false,
+                       with: resolver, dialect: dialect)
     case let .named(kind, reference):
       reference.spelling(kind: kind, parameter: parameter, with: resolver,
                          dialect: dialect)
     case let .variable(scope, index):
-      "\(scope.prefix(dialect))\(index)"
+      scope.spelling(index, generics: generics, dialect: dialect)
     case let .instance(base, arguments):
-      base.specialized(by: arguments, parameter: parameter, with: resolver,
-                       dialect: dialect)
+      base.specialized(by: arguments, parameter: parameter, generics: generics,
+                       with: resolver, dialect: dialect)
     case let .modified(inner, _):
-      inner.decode(parameter: parameter, with: resolver, dialect: dialect)
+      inner.decode(parameter: parameter, generics: generics, with: resolver,
+                   dialect: dialect)
     case .function:
       dialect.opaque
     }
@@ -174,8 +200,8 @@ extension SignatureType {
   /// is `const`), and an `int**`/`IFoo**` a pointer to an optional typed pointer.
   /// Otherwise a non-`void` pointee decodes as `Unsafe{Mutable}Pointer<Pointee>`,
   /// mutable unless a `const` modifier marks the pointee.
-  fileprivate func spelling(parameter: String?, const: Bool,
-                            with resolver: Resolver,
+  fileprivate func spelling(parameter: String?, generics: Array<String>?,
+                            const: Bool, with resolver: Resolver,
                             dialect: Dialect) -> String {
     switch self {
     case .primitive(.void):
@@ -191,15 +217,16 @@ extension SignatureType {
     case .pointer:
       // A non-`void` pointer-to-pointer: the inner pointer slot is itself
       // nullable, so mark the decoded element optional (as the `void**` cases).
-      wrap(decode(parameter: parameter, with: resolver, dialect: dialect)
-               + dialect.optional,
+      wrap(decode(parameter: parameter, generics: generics, with: resolver,
+                  dialect: dialect) + dialect.optional,
            const: const, dialect: dialect)
     case let .modified(inner, modifiers):
-      inner.spelling(parameter: parameter,
+      inner.spelling(parameter: parameter, generics: generics,
                      const: modifiers.constant(with: resolver),
                      with: resolver, dialect: dialect)
     default:
-      wrap(decode(parameter: parameter, with: resolver, dialect: dialect),
+      wrap(decode(parameter: parameter, generics: generics, with: resolver,
+                  dialect: dialect),
            const: const, dialect: dialect)
     }
   }
@@ -284,7 +311,8 @@ extension SignatureType {
   /// hint flows to the arguments as well, so a `System.Guid` argument of a
   /// parameter named `clsid` spells `CLSID` rather than the default `IID`.
   fileprivate func specialized(by arguments: Array<SignatureType>,
-                               parameter: String?, with resolver: Resolver,
+                               parameter: String?, generics: Array<String>?,
+                               with resolver: Resolver,
                                dialect: Dialect) -> String {
     let base = decode(parameter: parameter, with: resolver, dialect: dialect)
     // An unresolved base (e.g. a TypeSpec with no identity) decodes to the
@@ -296,8 +324,8 @@ extension SignatureType {
     // be escaped after the strip, not before, to spell `` `protocol`<…> ``.
     let name = dialect.escape(String(base.prefix { $0 != "`" }))
     let arguments = arguments
-        .map { $0.decode(parameter: parameter, with: resolver,
-                         dialect: dialect) }
+        .map { $0.decode(parameter: parameter, generics: generics,
+                         with: resolver, dialect: dialect) }
         .joined(separator: ", ")
     return "\(name)\(dialect.generic.open)\(arguments)\(dialect.generic.close)"
   }
@@ -311,5 +339,28 @@ extension VariableScope {
     case .type:   dialect.variable.type
     case .method: dialect.variable.method
     }
+  }
+
+  /// The spelling of the generic variable at `index` in this scope: the
+  /// declared parameter's name when this is a type-level `VAR`, the owner's
+  /// ordered `generics` names are supplied, and the operand is in range (`VAR
+  /// 0` of `<Element>` → `Element`); otherwise the positional placeholder
+  /// (`\(prefix)\(index)`). A method-level `MVAR` always spells its
+  /// placeholder — only type-level names are threaded — as does an out-of-range
+  /// operand. The lower bound guards a negative operand: the metadata decoder
+  /// emits none, but the enum case is public, so a malformed programmatic
+  /// `VAR -1` degrades to the placeholder rather than trap on `generics[-1]`.
+  ///
+  /// The declared name is escaped through the dialect's keyword rule, so a
+  /// parameter whose metadata name is a target keyword (`in`, `class`) spells
+  /// its use as `` `in` `` — a raw keyword would be an invalid type reference
+  /// (`UnsafeMutablePointer<in>`) — matching the escaped spelling
+  /// `Dialect.generics(_:)` gives the same parameter's declaration.
+  fileprivate func spelling(_ index: Int, generics: Array<String>?,
+                            dialect: Dialect) -> String {
+    if case .type = self, let generics, index >= 0, index < generics.count {
+      return dialect.escape(generics[index])
+    }
+    return "\(prefix(dialect))\(index)"
   }
 }

--- a/Sources/winmd-inspect/Database+SQL.swift
+++ b/Sources/winmd-inspect/Database+SQL.swift
@@ -773,6 +773,7 @@ extension WinMD.Storage {
   /// decodes the return. `nil` mirrors the old NULL — an absent row, an
   /// undecodable signature, or an unresolvable one.
   internal borrowing func decode(return method: Int,
+                                 generics: Array<String>? = nil,
                                  in dialect: Dialect) -> String? {
     guard let table = opened("MethodDef") else { return nil }
     let cursor = WinMD.Cursor(copy self, table)
@@ -782,7 +783,8 @@ extension WinMD.Storage {
         let resolver = try? Resolver(of: signature, with: self) else {
       return nil
     }
-    return signature.returns.decode(with: resolver, dialect: dialect)
+    return signature.returns.decode(generics: generics, with: resolver,
+                                    dialect: dialect)
   }
 
   /// The decoded type spelling of the `Param` at 1-based `parameter` `Id`, in
@@ -800,6 +802,7 @@ extension WinMD.Storage {
   /// `System.Guid` `IID`/`CLSID` hint; for any other type the decoder ignores
   /// it, so threading it is always safe.
   internal borrowing func decode(parameter: Int,
+                                 generics: Array<String>? = nil,
                                  for dialect: Dialect) -> String? {
     guard let table = opened("Param") else { return nil }
     let params = WinMD.Cursor(copy self, table)
@@ -825,6 +828,7 @@ extension WinMD.Storage {
     }
     let name = param.ordinal(for: "Name").flatMap { try? param.string($0) }
     return signature.parameters[position - 1]
-        .decode(parameter: name, with: resolver, dialect: dialect)
+        .decode(parameter: name, generics: generics, with: resolver,
+                dialect: dialect)
   }
 }

--- a/Tests/WinMDSynthesisTests/DecodeTests.swift
+++ b/Tests/WinMDSynthesisTests/DecodeTests.swift
@@ -98,6 +98,80 @@ struct DecodeTests {
                 .decode(with: resolver, dialect: dialect) == "M2")
   }
 
+  @Test func `a type variable spells its declared name when names are supplied`() {
+    // With the owner's ordered names threaded, a `VAR` spells the declared
+    // parameter's name (`VAR 0` of `<Element>` → `Element`) rather than the
+    // positional placeholder.
+    #expect(SignatureType.variable(scope: .type, 0)
+                .decode(generics: ["Element"], with: resolver, dialect: dialect)
+                == "Element")
+    #expect(SignatureType.variable(scope: .type, 1)
+                .decode(generics: ["Key", "Value"], with: resolver,
+                        dialect: dialect)
+                == "Value")
+    // An out-of-range operand falls back to the placeholder.
+    #expect(SignatureType.variable(scope: .type, 2)
+                .decode(generics: ["Element"], with: resolver, dialect: dialect)
+                == "T2")
+    // A method variable (`MVAR`) keeps its placeholder — only the type-level
+    // names are threaded, so a method-level operand never indexes them.
+    #expect(SignatureType.variable(scope: .method, 0)
+                .decode(generics: ["Element"], with: resolver, dialect: dialect)
+                == "M0")
+  }
+
+  @Test func `a negative type variable operand falls back to the placeholder`() {
+    // The metadata decoder emits no negative operand, but the enum case and
+    // `decode(generics:)` are public — a malformed programmatic `VAR -1` must
+    // degrade to the positional placeholder rather than trap on `generics[-1]`,
+    // exactly as an out-of-range operand does.
+    #expect(SignatureType.variable(scope: .type, -1)
+                .decode(generics: ["Element"], with: resolver, dialect: dialect)
+                == "T-1")
+  }
+
+  @Test func `a nested type variable spells its declared name`() {
+    // The names thread through the structural cases too: a `VAR` inside a
+    // pointer or a `GENERICINST` argument spells the declared name.
+    #expect(SignatureType.pointer(.variable(scope: .type, 0))
+                .decode(generics: ["Element"], with: resolver, dialect: dialect)
+                == "UnsafeMutablePointer<Element>")
+    let base = TypeDefOrRef(rawValue: 1)
+    let resolver = Resolver([
+      base.rawValue: Identity(namespace: "Windows.Foundation",
+                              name: "IReference`1"),
+    ])
+    #expect(SignatureType.instance(.named(kind: .class, base),
+                                   [.variable(scope: .type, 0)])
+                .decode(generics: ["Element"], with: resolver, dialect: dialect)
+                == "IReference<Element>")
+  }
+
+  @Test func `a generic declaration clause wraps the ordered names`() {
+    // The declaration hook composes the dialect's generic delimiters around the
+    // comma-separated names; an empty list is a non-generic declaration (`nil`).
+    #expect(dialect.generics(["Element"]) == "<Element>")
+    #expect(dialect.generics(["Key", "Value"]) == "<Key, Value>")
+    #expect(dialect.generics([]) == nil)
+  }
+
+  @Test func `a keyword-named type variable escapes its use and declaration`() {
+    // A parameter whose metadata name is a Swift keyword (`in`, `class`) must
+    // spell its `VAR` use through the dialect's keyword escape — a raw keyword
+    // is an invalid type reference (`UnsafeMutablePointer<in>`). The escaped
+    // spelling appears bare and inside the structural cases alike.
+    #expect(SignatureType.variable(scope: .type, 0)
+                .decode(generics: ["in"], with: resolver, dialect: dialect)
+                == "`in`")
+    #expect(SignatureType.pointer(.variable(scope: .type, 0))
+                .decode(generics: ["in"], with: resolver, dialect: dialect)
+                == "UnsafeMutablePointer<`in`>")
+    // The declaration clause escapes the same name, so declaration and use
+    // agree — a `` `in` `` use resolves against a `` <`in`> `` declaration.
+    #expect(dialect.generics(["in"]) == "<`in`>")
+    #expect(dialect.generics(["class", "Value"]) == "<`class`, Value>")
+  }
+
   @Test func `only an IsConst custom modifier marks a pointee const`() {
     // Two modifier-type references: one resolves to `IsConst`, the other to an
     // unrelated type. Only the former may flip the pointer to immutable.


### PR DESCRIPTION
The decode tier composed a `GENERICINST` as `Base<Args>` but spelled a `VAR`/`MVAR` as a positional placeholder (`T0`/`M0`), never the declared `GenericParam.Name` — a self-consistent generic declaration and body was not possible.

Thread an optional ordered `generics` name list through the decode: a type-level `VAR` now spells its declared name (`VAR 0` of `<Element>` → `Element`) when the owner's names are supplied and the operand is in range, and degrades to the placeholder otherwise (the DB-free path, an out-of-range operand, and a method-level `MVAR`, whose names are not threaded here). The names flow through the structural cases so a `VAR` inside a pointer or a `GENERICINST` argument spells its name too.

Add a `Dialect.genericDeclaration(_:)` hook that formats the `<T…>` declaration clause from the ordered names — the dialect's generic delimiters around the comma-separated names, `nil` for a non-generic declaration. Variance is dropped: the target has no declaration-site variance, so the names spell plain.

The storage `decode(parameter:)`/`decode(return:)` accessors gain a defaulted `generics:` parameter so a caller with no names decodes exactly as before.

Guard the variable operand's lower bound: the range check tested only `index < generics.count`, so a `VAR -1` with a non-empty names array would subscript `generics[-1]` and trap. The metadata decoder emits no negative operand, but the enum case and `decode(generics:)` are public, so a malformed programmatic signature must degrade to the positional placeholder rather than crash — `index >= 0 && index < generics.count`.