### PR TITLE
winmd-inspect: render generic interfaces as a generic struct wrapper

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -81,6 +81,8 @@ let _ =
                             "winmd-inspect",
                             "SQL",
                             "WinMD",
+                            .product(name: "Mustache",
+                                     package: "swift-mustache"),
                           ],
                           swiftSettings: [
                             .enableExperimentalFeature("Lifetimes"),

--- a/Sources/winmd-inspect/Resources/Render/generics.sql
+++ b/Sources/winmd-inspect/Resources/Render/generics.sql
@@ -1,0 +1,5 @@
+SELECT
+  SANITIZE(Name) AS Name,
+  Number
+FROM
+  generics

--- a/Sources/winmd-inspect/Resources/Render/interfaces.sql
+++ b/Sources/winmd-inspect/Resources/Render/interfaces.sql
@@ -1,7 +1,7 @@
 SELECT
   Id,
   TypeNamespace,
-  SANITIZE(TypeName) AS TypeName,
+  TypeName,
   iid
 FROM
   interfaces

--- a/Sources/winmd-inspect/Resources/Templates/com.mustache
+++ b/Sources/winmd-inspect/Resources/Templates/com.mustache
@@ -1,7 +1,32 @@
 {{! language: swift }}
+{{#generic}}
+// A WinRT parameterised interface has no static IID: its IID is a
+// per-instantiation PIID computed at runtime from the type
+// arguments, so no `@com(interface:)` is emitted on the ABI protocol
+// or the generic wrapper — the runtime projection supplies it.
+internal protocol {{{abi}}}<{{#generics}}{{{name}}}{{^last}}, {{/last}}{{/generics}}>{{#base}}: {{{.}}}{{/base}} {
+{{#generics}}
+    associatedtype {{{name}}}
+{{/generics}}
+{{#methods}}
+    func {{{name}}}({{#params}}_ {{{name}}}: {{{type}}}{{^last}}, {{/last}}{{/params}}){{#returns}} -> {{{.}}}{{/returns}}
+{{/methods}}
+}
+
+public struct {{{name}}}<{{#generics}}{{{name}}}{{^last}}, {{/last}}{{/generics}}> {
+    internal let base: any {{{abi}}}<{{#generics}}{{{name}}}{{^last}}, {{/last}}{{/generics}}>
+{{#methods}}
+    public func {{{name}}}({{#params}}_ {{{local}}}: {{{type}}}{{^last}}, {{/last}}{{/params}}){{#returns}} -> {{{.}}}{{/returns}} {
+        base.{{{name}}}({{#params}}{{{local}}}{{^last}}, {{/last}}{{/params}})
+    }
+{{/methods}}
+}
+{{/generic}}
+{{^generic}}
 @com(interface: "{{{iid}}}")
 public protocol {{{name}}}{{#base}}: {{{.}}}{{/base}} {
 {{#methods}}
     func {{{name}}}({{#params}}_ {{{name}}}: {{{type}}}{{^last}}, {{/last}}{{/params}}){{#returns}} -> {{{.}}}{{/returns}}
 {{/methods}}
 }
+{{/generic}}

--- a/Sources/winmd-inspect/Shell.swift
+++ b/Sources/winmd-inspect/Shell.swift
@@ -504,58 +504,28 @@ internal struct Shell: ~Escapable {
     sources.reserveCapacity(interfaces.count)
     for found in interfaces {
       let id = found[0]
-      // The interface's methods, bound by its `Id`; each row is its `Id`
-      // then its escaped `Name`. The type spellings are no longer projected —
-      // the render decodes them from the signature with the spec's `Dialect`.
-      let plan = try Shell.select(Shell.query(named: "methods",
-                                              search: search))
-      let rows = try session.run(plan, routines,
-                                 bindings: ["parent": id])
-      var methods = Array<Dictionary<String, Any>>()
-      methods.reserveCapacity(rows.count)
-      for method in rows {
-        // Each method's parameters, bound by the method's `Id`; each row is its
-        // `Id`, escaped `Name`, and `Sequence`. The return pseudo-parameter
-        // (`Sequence == 0`) is dropped — only the real parameters spell the
-        // requirement's arguments — and the rest decode their type at render
-        // time from the parameter's own signature position.
-        let selection = try Shell.select(Shell.query(named: "params",
-                                                     search: search))
-        let params = try session.run(selection, routines,
-                                     bindings: ["parent": method[0]])
-        var parameters = Array<Dictionary<String, Any>>()
-        for parameter in params where parameter[2] != .integer(0) {
-          let type = session.storage.decode(parameter: parameter[0].integer,
-                                            for: dialect)
-          parameters.append([
-            "name": parameter[1].text,
-            "type": type ?? "",
-            "last": false,
-          ])
-        }
-        // The trailing parameter's `last` flag drives the template's
-        // `{{^last}}, {{/last}}` comma separation, omitting the final comma.
-        if !parameters.isEmpty {
-          parameters[parameters.count - 1]["last"] = true
-        }
-        var entry: Dictionary<String, Any> = [
-          "name": method[1].text,
-          "params": parameters,
-        ]
-        // The return, decoded at render time; a no-value return (the spec's
-        // `void` spelling, or an undecodable return) leaves `returns` absent, so
-        // the template's `{{#returns}}` clause renders nothing.
-        let returned = session.storage.decode(return: method[0].integer,
-                                              in: dialect)
-        if let returned, let clause = language.returned(returned) {
-          entry["returns"] = clause
-        }
-        methods.append(entry)
-      }
-      // The interface's base, via the `bases` view bound by its `Id`. A
-      // rootless interface defaults to the spec's COM root, except the root
-      // interface itself — which inherits nothing, so it never becomes its own
-      // base; an empty `root` applies no default.
+      // The interface's ordered declared generic-parameter names, through the
+      // `generics` view bound by its `Id` — empty for a non-generic interface.
+      // A generic interface declares at least one; its own name then carries a
+      // CLR arity suffix, stripped below. The names thread into the
+      // method/parameter/return decode so a `VAR` spells its declared name
+      // (`Element`) rather than a positional placeholder (`T0`).
+      let names = try declarations(of: id, routines, search: search)
+      // The names supplied to decode when the interface is generic; `nil`
+      // otherwise, so a non-generic interface decodes exactly as before.
+      let generics: Array<String>? = names.isEmpty ? nil : names
+      // The interface's own methods, decoded with its generic names so a `VAR`
+      // spells its declared name. A generic interface that HAS a base renders
+      // only its own surface here; forwarding a base's inherited methods onto
+      // the wrapper is a follow-up.
+      let methods = try self.methods(of: id, routines, search: search,
+                                     generics: generics, in: dialect,
+                                     language: language)
+      // The interface's named base, via the `bases` view bound by its `Id` (a
+      // `TypeRef`/`TypeDef` simple name). A rootless interface defaults to the
+      // spec's COM root, except the root interface itself — which inherits
+      // nothing, so it never becomes its own base; an empty `root` applies no
+      // default.
       let lineage =
           try Shell.select(Shell.query(named: "bases", search: search))
       let bases = try session.run(lineage, routines,
@@ -567,17 +537,161 @@ internal struct Shell: ~Escapable {
       } else {
         language.root
       }
+      // A generic interface's own `TypeName` carries the CLR arity suffix
+      // (`IVector``1`); strip it — the decode tier strips it only for a
+      // `GENERICINST` use, so the declaration name must be stripped here — so
+      // the emitted name is `IVector`, its `<T>` clause supplied separately.
+      // The keyword escape (`SANITIZE`) is applied HERE, on the STRIPPED name,
+      // not in the `interfaces` query: escaping the suffixed name would spare a
+      // generic whose stripped name is a keyword (`protocol``1` is not the
+      // reserved word `protocol`), leaving `public struct protocol` to be
+      // emitted. Escaping after the strip is why the query projects the raw
+      // `TypeName` — the interface's own name is the one identifier the strip
+      // must precede the escape for, so its escape lives in Swift, not the SQL.
+      let stripped = String(found[2].text.prefix { $0 != "`" })
+      let name = language.escape(stripped)
+      // The ABI-protocol name is the wrapper's own name suffixed with `ABI`,
+      // used for BOTH the ABI protocol's declaration and the wrapper's `base:
+      // any …ABI<…>` existential. The `ABI` suffix must precede the escape (the
+      // same order the base-name spelling uses): a keyword name's `<name>ABI`
+      // is never itself a keyword (no Swift keyword ends in `ABI`), so escaping
+      // the SUFFIXED name is a no-op yielding a plain `protocolABI` — whereas
+      // escaping FIRST then appending `ABI` would splice a backtick pair into
+      // the middle (`` `protocol`ABI ``), which Swift cannot parse.
+      let abi = language.escape(stripped + "ABI")
       var context: Dictionary<String, Any> = [
-        "name": found[2].text,
+        "name": name,
+        "abi": abi,
         "iid": found[3].text,
         "namespace": found[1].text,
         "methods": methods,
       ]
       // An absent `base` skips the template's `{{#base}}` inheritance clause.
       if let base { context["base"] = base }
+      // A generic interface carries its `generic` flag and its ordered clause
+      // `generics` (each with a `last` flag for comma separation); a
+      // non-generic one carries neither, so the template's `{{#generic}}` guard
+      // leaves its output byte-identical to today's.
+      if let generics {
+        context["generic"] = true
+        context["generics"] = generics.enumerated().map { index, name in
+          ["name": name, "last": index == generics.count - 1]
+        }
+      }
       sources.append(mustache.render(context))
     }
     return sources.joined(separator: "\n")
+  }
+
+  /// The template method entries for the interface at `id`, in declaration
+  /// order — each a `name`, a `params` list, and (for a value-returning method)
+  /// a `returns` clause — decoded with the owner's `generics` names threaded so
+  /// a `VAR` spells its declared name.
+  ///
+  /// Each method's parameters, bound by the method's `Id`, drop the return
+  /// pseudo-parameter (`Sequence == 0`); the rest decode their type from their
+  /// own signature position. The return decodes to `returns` unless it is the
+  /// spec's `void` spelling or undecodable, when `{{#returns}}` renders
+  /// nothing.
+  private borrowing func methods(of id: Value, _ routines: Routines,
+                                 search: Array<String>,
+                                 generics: Array<String>?, in dialect: Dialect,
+                                 language: Language) throws
+      -> Array<Dictionary<String, Any>> {
+    let plan = try Shell.select(Shell.query(named: "methods", search: search))
+    let rows = try session.run(plan, routines, bindings: ["parent": id])
+    var methods = Array<Dictionary<String, Any>>()
+    methods.reserveCapacity(rows.count)
+    for method in rows {
+      let selection = try Shell.select(Shell.query(named: "params",
+                                                   search: search))
+      let params = try session.run(selection, routines,
+                                   bindings: ["parent": method[0]])
+      let kept = params.filter { $0[2] != .integer(0) }
+      let types = kept.map {
+        session.storage.decode(parameter: $0[0].integer, generics: generics,
+                               for: dialect) ?? ""
+      }
+      let parameters = Shell.parameters(kept.map(\.[1].text), types: types)
+      var entry: Dictionary<String, Any> = [
+        "name": method[1].text,
+        "params": parameters,
+      ]
+      let returned = session.storage.decode(return: method[0].integer,
+                                            generics: generics, in: dialect)
+      if let returned, let clause = language.returned(returned) {
+        entry["returns"] = clause
+      }
+      methods.append(entry)
+    }
+    return methods
+  }
+
+  /// The template parameter dictionaries for a method's kept parameters — one
+  /// per `(name, type)` pair, in order — with each blank name assigned a
+  /// stable, collision-free `local` and the trailing entry's `last` flag set.
+  ///
+  /// A blank parameter name (`func Foo(_ : T)`) is allowed in a protocol
+  /// requirement's decl, but the wrapper's forwarding method must PASS it by
+  /// name in the call (`base.Foo(arg0)`), so a blank name synthesizes a `local`
+  /// used in BOTH the forwarding method's parameter list (`_ arg0: T`) and the
+  /// call — while `name` stays blank in the requirement. The synthetic name is
+  /// chosen AFTER the method's real names are known: it is the first `arg<N>`
+  /// (from `N == 0`) not already used by a real parameter or an earlier
+  /// synthetic one, so `Foo(_ : T, _ arg0: T)` gives the blank a `local` of
+  /// `arg1` rather than colliding with the real `arg0`. A named parameter's
+  /// `local` is its own name.
+  internal static func parameters(_ names: Array<String>,
+                                  types: Array<String>)
+      -> Array<Dictionary<String, Any>> {
+    // The names in play — the real ones plus each synthetic as it is minted —
+    // so a synthetic never duplicates a real name or a sibling synthetic.
+    var used = Set(names.filter { !$0.isEmpty })
+    var next = 0
+    var parameters = Array<Dictionary<String, Any>>()
+    parameters.reserveCapacity(names.count)
+    for (name, type) in zip(names, types) {
+      let local: String
+      if name.isEmpty {
+        while used.contains("arg\(next)") { next += 1 }
+        local = "arg\(next)"
+        used.insert(local)
+        next += 1
+      } else {
+        local = name
+      }
+      parameters.append([
+        "name": name,
+        "local": local,
+        "type": type,
+        "last": false,
+      ])
+    }
+    // The trailing parameter's `last` flag drives the template's
+    // `{{^last}}, {{/last}}` comma separation, omitting the final comma.
+    if !parameters.isEmpty {
+      parameters[parameters.count - 1]["last"] = true
+    }
+    return parameters
+  }
+
+  /// The ordered declared generic-parameter names of the interface at `id`,
+  /// through the `generics` view bound by its `Id` — an empty list for a
+  /// non-generic interface.
+  ///
+  /// A metadata file with no generic types omits the `GenericParam` table
+  /// entirely (the `#~` valid mask sets a table's bit only when it has rows),
+  /// so the `generics` view over it would resolve no relation; the base table's
+  /// presence is checked first (`opened` is `nil` for an absent table), so a
+  /// file with no generics is simply no generics rather than a faulting query.
+  private borrowing func declarations(of id: Value, _ routines: Routines,
+                                      search: Array<String>) throws
+      -> Array<String> {
+    guard session.storage.opened("GenericParam") != nil else { return [] }
+    let clause =
+        try Shell.select(Shell.query(named: "generics", search: search))
+    let declared = try session.run(clause, routines, bindings: ["parent": id])
+    return declared.map(\.first!.text)
   }
 
   /// The text of the Mustache template named `name` — an inline template
@@ -1156,8 +1270,8 @@ extension Session {
   /// `Queries/*.sql`, then for each name load the first search directory that
   /// has it (else the bundle), parse it as a `CREATE VIEW`, and register it —
   /// so a `-I` directory both shadows an existing view and adds a new one. The
-  /// four COM-interface views are the one bundled set, so adding a query later
-  /// is dropping in another `.sql` beside them (or under a `-I` directory) — no
+  /// COM-interface views are the one bundled set, so adding a query later is
+  /// dropping in another `.sql` beside them (or under a `-I` directory) — no
   /// code change. The views are order-independent (none references another), so
   /// the enumeration order does not matter.
   ///
@@ -1168,11 +1282,11 @@ extension Session {
   /// `MemberRef.Class_TypeRef` → `TypeRef`, filtered to the `GuidAttribute`
   /// declaring type, projecting `CustomAttribute.guid` as the `iid` — a
   /// `methods` view of one interface's methods, a `params` view of one
-  /// method's parameters, and a `bases` view of one interface's base type. The
-  /// latter three carry a uniform `:parent` param — the owning row's `Id` —
-  /// so a render can walk interface → methods → params, binding each level's
-  /// `Id` to the next's `:parent`, and look up the interface's base by its
-  /// `Id`.
+  /// method's parameters, a `bases` view of one interface's named base type,
+  /// and a `generics` view of one interface's declared generic parameters.
+  /// These carry a uniform `:parent` param — the owning row's `Id` — so a
+  /// render can walk interface → methods → params, binding each level's `Id` to
+  /// the next's `:parent`, and look up the interface's base by its `Id`.
   ///
   /// The `bases` view navigates the interface's single `InterfaceImpl` row
   /// (whose simple `Class` index is the interface's 1-based `Id`) to its

--- a/Tests/winmd-inspectTests/DatabaseSQLTests.swift
+++ b/Tests/winmd-inspectTests/DatabaseSQLTests.swift
@@ -5,6 +5,7 @@ import Testing
 
 @testable import winmd_inspect
 
+import Mustache
 import SQL
 @testable import WinMD
 import WinMDSynthesis
@@ -194,6 +195,40 @@ struct DatabaseSQLTests {
                           strings: strings.span.bytes, blob: blob.span.bytes,
                           guid: empty.span.bytes, valid: valid, sorted: 0)
     try body(storage)
+  }
+
+  /// Runs `body` over a `Storage` catalog whose relations carry an (empty)
+  /// `GenericParam` table, so the render's `declarations` guard — which checks
+  /// the table's PRESENCE in storage before running the `generics` view —
+  /// passes and the render takes its generic arm. The rows the arm renders come
+  /// from a `generics` view override the caller registers, so the table need
+  /// hold no rows (an empty range past the last real table); the shared
+  /// fixture omits it (no generics), which the render treats as no generics.
+  private static func withGenerics(
+      _ body: (borrowing Storage) throws -> Void) rethrows {
+    var relations = DatabaseSQLTests.relations
+    relations.append(WinMD.Table(Metadata.Tables.GenericParam.self, rows: 0,
+                                 range: bytes.count ..< bytes.count,
+                                 wide: 0, stride: 8))
+    let valid = DatabaseSQLTests.valid | (1 << 42)
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+
+  /// The bundled template `name`'s body with its leading `{{! language: … }}`
+  /// directive line stripped — the body the render hands to `MustacheTemplate`
+  /// after `language(declaredIn:)` consumes the directive. A test renders it
+  /// directly with a hand-built context to pin the template's output shape.
+  private static func template(named name: String) throws -> String {
+    var body = ""
+    try DatabaseSQLTests.with { catalog in
+      let shell = Shell(catalog)
+      body = try shell.template(named: name, search: [])
+    }
+    guard let newline = body.firstIndex(where: \.isNewline) else { return body }
+    return String(body[body.index(after: newline)...])
   }
 
   /// Plans and runs `query` through the engine over the catalog.
@@ -804,6 +839,294 @@ struct DatabaseSQLTests {
       try shell.execute(".template mine 'interface {{name}}'")
       let rendered = try shell.render("IMyInterface", template: "mine")
       #expect(rendered == "interface IMyInterface")
+    }
+  }
+
+  @Test func `the bundled com template renders a non-generic interface unchanged`() throws {
+    // The fixture's `IMyInterface` (non-generic) renders through the REAL
+    // bundled `com` template: the `{{^generic}}` arm emits today's `@com`
+    // protocol shape unchanged — a static `@com(interface:)` IID, `public
+    // protocol` with its `: IInspectable` base, and one `func` per method —
+    // with no generic-wrapper output. This pins the non-generic output
+    // byte-for-byte so the generic split cannot perturb it.
+    try DatabaseSQLTests.with { catalog in
+      let shell = Shell(catalog)
+      let rendered = try shell.render("IMyInterface", template: "com")
+      #expect(rendered == """
+        @com(interface: "0C733A30-2A1C-11CE-ADE5-00AA0044773D")
+        public protocol IMyInterface: IInspectable {
+            func MyMethod(_ first: CInt, _ : HSTRING)
+        }
+
+        """)
+    }
+  }
+
+  @Test func `the bundled com template renders a generic interface as a wrapper`() throws {
+    // A generic interface renders through the `{{#generic}}` arm of the REAL
+    // bundled `com` template: an internal ABI protocol carrying the ordered
+    // type parameters as its primary associated types (`<Element>` naming an
+    // `associatedtype Element` in the body) — so a requirement mentioning
+    // `Element` resolves — with no static IID (the WinRT PIID is computed at
+    // runtime), plus a public generic `struct` wrapper holding the ABI as a
+    // parameterised existential (`any IVectorABI<Element>`). The context is
+    // built the same way the render loop assembles it for an `IVector`-like
+    // ``1` type (arity suffix stripped, one generic parameter `Element`, one
+    // method whose return decodes to that declared name).
+    let body = try DatabaseSQLTests.template(named: "com")
+    let template = try MustacheTemplate(string: body)
+    let context: [String: Any] = [
+      "name": "IVector",
+      "abi": "IVectorABI",
+      "iid": "00000000-0000-0000-0000-000000000000",
+      "namespace": "Windows.Foundation.Collections",
+      "generic": true,
+      "generics": [["name": "Element", "last": true]],
+      "methods": [
+        [
+          "name": "GetAt",
+          "params": [
+            ["name": "index", "local": "index", "type": "CUnsignedInt",
+             "last": true],
+          ],
+          "returns": "Element",
+        ],
+      ],
+    ]
+    #expect(template.render(context) == """
+      // A WinRT parameterised interface has no static IID: its IID is a
+      // per-instantiation PIID computed at runtime from the type
+      // arguments, so no `@com(interface:)` is emitted on the ABI protocol
+      // or the generic wrapper — the runtime projection supplies it.
+      internal protocol IVectorABI<Element> {
+          associatedtype Element
+          func GetAt(_ index: CUnsignedInt) -> Element
+      }
+
+      public struct IVector<Element> {
+          internal let base: any IVectorABI<Element>
+          public func GetAt(_ index: CUnsignedInt) -> Element {
+              base.GetAt(index)
+          }
+      }
+
+      """)
+  }
+
+  @Test func `a generic interface whose stripped name is a keyword renders escaped`() throws {
+    // A generic type named `protocol``1` strips to the reserved word
+    // `protocol`, which the render escapes to the backticked `` `protocol` ``
+    // for the wrapper `struct` name. The ABI-protocol name is a DIFFERENT
+    // spelling: it suffixes `ABI` onto the stripped name BEFORE escaping, so it
+    // is the plain `protocolABI` (no Swift keyword ends in `ABI`, so the escape
+    // is a no-op). Suffixing `ABI` onto the ALREADY-escaped `` `protocol` ``
+    // would splice a backtick pair into the middle (`` `protocol`ABI ``), which
+    // Swift cannot parse. The wrapper `struct` keeps the escaped bare name
+    // (`` `protocol`<Element> ``); the ABI protocol's declaration and the
+    // wrapper's `base: any …<Element>` existential both spell `protocolABI`.
+    // Overriding `interfaces` to yield a suffixed keyword name over the
+    // fixture's generic-aware storage drives the render's generic arm;
+    // `methods` and `bases` are emptied so the output is the declaration shell
+    // alone.
+    try DatabaseSQLTests.withGenerics { catalog in
+      var shell = Shell(catalog)
+      let interfaces = """
+        CREATE VIEW interfaces AS
+        SELECT Id, TypeNamespace, 'protocol`1' AS TypeName,
+               '00000000-0000-0000-0000-000000000000' AS iid
+        FROM TypeDef WHERE Id = 1
+        """
+      let generics = """
+        CREATE VIEW generics AS
+        SELECT 'Element' AS Name, 0 AS Number FROM TypeDef WHERE Id = :parent
+        """
+      let methods = """
+        CREATE VIEW methods AS
+        SELECT Id, '' AS Name FROM TypeDef WHERE 0 = 1
+        """
+      let bases = """
+        CREATE VIEW bases AS SELECT '' AS base FROM TypeDef WHERE 0 = 1
+        """
+      for query in [interfaces, generics, methods, bases] {
+        let (name, view) = try DatabaseSQLTests.create(query)
+        shell.session.register(name, view)
+      }
+      let rendered = try shell.render("protocol`1", template: "com")
+      #expect(rendered == """
+        // A WinRT parameterised interface has no static IID: its IID is a
+        // per-instantiation PIID computed at runtime from the type
+        // arguments, so no `@com(interface:)` is emitted on the ABI protocol
+        // or the generic wrapper — the runtime projection supplies it.
+        internal protocol protocolABI<Element>: IUnknown {
+            associatedtype Element
+        }
+
+        public struct `protocol`<Element> {
+            internal let base: any protocolABI<Element>
+        }
+
+        """)
+    }
+  }
+
+  @Test func `a generic interface inheriting a non-generic base keeps it plain`() throws {
+    // A generic interface may inherit a NON-generic base — `IInspectable`, a
+    // plain protocol, not a generic one — which arrives through `bases` (a
+    // `TypeRef`/`TypeDef` simple name). Its ABI protocol's inheritance clause
+    // names that base UNCHANGED (`: IInspectable`, no `ABI` suffix and no
+    // arguments): the base is already a protocol and carries no wrapper/ABI
+    // split. The `bases` override supplies the plain name; `methods` are
+    // emptied so the output is the declaration shell.
+    try DatabaseSQLTests.withGenerics { catalog in
+      var shell = Shell(catalog)
+      let interfaces = """
+        CREATE VIEW interfaces AS
+        SELECT Id, TypeNamespace, 'IVector`1' AS TypeName,
+               '00000000-0000-0000-0000-000000000000' AS iid
+        FROM TypeDef WHERE Id = 1
+        """
+      let generics = """
+        CREATE VIEW generics AS
+        SELECT 'Element' AS Name, 0 AS Number FROM TypeDef WHERE Id = :parent
+        """
+      let methods = """
+        CREATE VIEW methods AS
+        SELECT Id, '' AS Name FROM TypeDef WHERE 0 = 1
+        """
+      let bases = """
+        CREATE VIEW bases AS
+        SELECT 'IInspectable' AS base FROM TypeDef WHERE Id = :parent
+        """
+      for query in [interfaces, generics, methods, bases] {
+        let (name, view) = try DatabaseSQLTests.create(query)
+        shell.session.register(name, view)
+      }
+      let rendered = try shell.render("IVector`1", template: "com")
+      #expect(rendered == """
+        // A WinRT parameterised interface has no static IID: its IID is a
+        // per-instantiation PIID computed at runtime from the type
+        // arguments, so no `@com(interface:)` is emitted on the ABI protocol
+        // or the generic wrapper — the runtime projection supplies it.
+        internal protocol IVectorABI<Element>: IInspectable {
+            associatedtype Element
+        }
+
+        public struct IVector<Element> {
+            internal let base: any IVectorABI<Element>
+        }
+
+        """)
+    }
+  }
+
+  @Test func `a generic wrapper forwards a blank parameter under a synthesized name`() throws {
+    // The non-generic renderer allows a blank parameter name (`func Foo(_ :
+    // T)`), and the generic ABI protocol requirement keeps it blank too, but
+    // the wrapper's forwarding method must PASS every argument BY NAME in the
+    // call (`base.Foo(arg0)`) — a blank name there expands to an empty
+    // argument, dropping the argument or mangling the commas. A blank parameter
+    // therefore synthesizes a stable `arg<N>` local, used in BOTH the
+    // forwarding method's parameter list (`_ arg0: T`) and the call. This
+    // context (built as the render loop assembles one) drives the REAL bundled
+    // `com` template: the first parameter is blank (→ `arg0`), the second named
+    // (`value`, kept). The protocol requirement stays blank; only the wrapper's
+    // forwarding surface takes the synthesized names.
+    let body = try DatabaseSQLTests.template(named: "com")
+    let template = try MustacheTemplate(string: body)
+    let context: [String: Any] = [
+      "name": "IPair",
+      "abi": "IPairABI",
+      "iid": "00000000-0000-0000-0000-000000000000",
+      "namespace": "NS",
+      "generic": true,
+      "generics": [["name": "Element", "last": true]],
+      "methods": [
+        [
+          "name": "Set",
+          "params": [
+            ["name": "", "local": "arg0", "type": "Element", "last": false],
+            ["name": "value", "local": "value", "type": "CInt", "last": true],
+          ],
+        ],
+      ],
+    ]
+    #expect(template.render(context) == """
+      // A WinRT parameterised interface has no static IID: its IID is a
+      // per-instantiation PIID computed at runtime from the type
+      // arguments, so no `@com(interface:)` is emitted on the ABI protocol
+      // or the generic wrapper — the runtime projection supplies it.
+      internal protocol IPairABI<Element> {
+          associatedtype Element
+          func Set(_ : Element, _ value: CInt)
+      }
+
+      public struct IPair<Element> {
+          internal let base: any IPairABI<Element>
+          public func Set(_ arg0: Element, _ value: CInt) {
+              base.Set(arg0, value)
+          }
+      }
+
+      """)
+  }
+
+  @Test func `the render synthesizes arg names for blank parameters positionally`() throws {
+    // The render loop itself (not just the template) assigns the `arg<N>`
+    // local: a `Param` whose `Name` is blank gets a positional `arg0`/`arg1`, a
+    // named one keeps its name, so a mix renders `_ arg0: …, _ named: …, _
+    // arg2: …`. A single blank parameter forwards as `base.M(arg0)` — no empty
+    // argument — and a named parameter is untouched. The fixture's storage
+    // decodes the parameter types; `interfaces`/`methods`/`params` are
+    // overridden so the one method takes a blank then a named parameter over
+    // the fixture's `MethodDef` signature. The forwarding call passes both
+    // locals.
+    try DatabaseSQLTests.withGenerics { catalog in
+      var shell = Shell(catalog)
+      let interfaces = """
+        CREATE VIEW interfaces AS
+        SELECT Id, TypeNamespace, 'IThing`1' AS TypeName,
+               '00000000-0000-0000-0000-000000000000' AS iid
+        FROM TypeDef WHERE Id = 1
+        """
+      let generics = """
+        CREATE VIEW generics AS
+        SELECT 'Element' AS Name, 0 AS Number FROM TypeDef WHERE Id = :parent
+        """
+      // The fixture's `MethodDef` Id 1 is `void MyMethod(i4, string)`, its two
+      // real parameters `Param` Id 2 (Sequence 1, `i4` → `CInt`) and Id 3
+      // (Sequence 2, `string` → `HSTRING`). `methods` names the one method;
+      // `params` yields those two rows in order but BLANKS the first's `Name`
+      // (its type still decodes from the real `Param` Id) and names the second
+      // `first`, so the render must synthesize `arg0` for the blank one and
+      // keep `first`. The `Sequence` column is non-zero so neither is filtered
+      // as the return pseudo-parameter.
+      let methods = """
+        CREATE VIEW methods AS
+        SELECT Id, 'MyMethod' AS Name FROM MethodDef WHERE Id = 1
+        """
+      let params = """
+        CREATE VIEW params AS
+        SELECT 2 AS Id, '' AS Name, 1 AS Sequence
+        FROM MethodDef WHERE Id = 1
+        UNION ALL
+        SELECT 3 AS Id, 'first' AS Name, 2 AS Sequence
+        FROM MethodDef WHERE Id = 1
+        """
+      let bases = """
+        CREATE VIEW bases AS SELECT '' AS base FROM TypeDef WHERE 0 = 1
+        """
+      for query in [interfaces, generics, methods, params, bases] {
+        let (name, view) = try DatabaseSQLTests.create(query)
+        shell.session.register(name, view)
+      }
+      let rendered = try shell.render("IThing`1", template: "com")
+      // The wrapper's forwarding method names the blank parameter `arg0` and
+      // keeps `first`; the call passes both. The ABI requirement leaves the
+      // blank parameter blank (`_ : CInt`).
+      #expect(rendered.contains(
+          "public func MyMethod(_ arg0: CInt, _ first: HSTRING) {"))
+      #expect(rendered.contains("base.MyMethod(arg0, first)"))
+      #expect(rendered.contains("func MyMethod(_ : CInt, _ first: HSTRING)"))
     }
   }
 

--- a/Tests/winmd-inspectTests/ShellTests.swift
+++ b/Tests/winmd-inspectTests/ShellTests.swift
@@ -86,6 +86,30 @@ struct ShellTests {
     #expect(Schema("").query.isEmpty)
   }
 
+  @Test func `a blank parameter local avoids colliding with a real name`() {
+    // A generic method with an unnamed parameter followed by a real parameter
+    // named like the synthetic local (`Foo(_ : T, _ arg0: T)`) must not emit
+    // two `arg0` locals — the wrapper's forwarding method would not compile.
+    // The synthetic name is chosen AFTER the real names are known, skipping any
+    // `arg<N>` a real (or earlier synthetic) parameter already uses: the blank
+    // takes `arg1`, the real `arg0` keeps its own name.
+    let collision = Shell.parameters(["", "arg0"], types: ["T", "T"])
+    #expect(collision.map { $0["local"] as? String } == ["arg1", "arg0"])
+    // The blank's `name` stays empty (the protocol requirement spells `_ : T`),
+    // only its `local` is synthesised.
+    #expect(collision.map { $0["name"] as? String } == ["", "arg0"])
+    // Two blanks number sequentially and skip a real `arg1` between them.
+    let mixed = Shell.parameters(["", "arg1", ""], types: ["A", "B", "C"])
+    #expect(mixed.map { $0["local"] as? String } == ["arg0", "arg1", "arg2"])
+    // The last entry carries the `last` flag; the rest do not.
+    #expect(mixed.map { $0["last"] as? Bool } == [false, false, true])
+    // A named-only list keeps each name as its own local, no synthesis.
+    let named = Shell.parameters(["a", "b"], types: ["X", "Y"])
+    #expect(named.map { $0["local"] as? String } == ["a", "b"])
+    // An empty list produces no entries (and sets no `last`).
+    #expect(Shell.parameters([], types: []).isEmpty)
+  }
+
   @Test func `.render parses its interface and template arguments`() {
     // `Render.init` splits the rest of the statement into interface then
     // template; both are required, so anything but two fields leaves them empty


### PR DESCRIPTION
Thread the declared generic parameters into the render and split the template so a WinRT parameterised interface emits as a generic Swift struct wrapper over its OWN surface. This slice owns the whole render integration — the `Resources/Render/generics.sql` query, the context wiring, and the `{{#generic}}` template arm that consumes it — since the `generics` view slice adds only the standalone queryable relation and leaves the default `.render` unchanged.

For each interface the render now queries the `generics` view bound by its `Id` (skipping the query when the file omits the `GenericParam` table — a file with no generics, not an error), and threads the ordered names into the method/parameter/return decode so a `VAR` spells its declared name (`GetAt() -> Element`). It strips the CLR arity suffix from the interface's own name — the decode tier stripped it only for a `GENERICINST` use, so a generic TypeDef's own `` `1 `` name would otherwise poison the declaration — and builds the `generic` flag and the ordered `generics` clause names into the mustache context.

The `com` template gains a `{{#generic}}` arm: an internal ABI protocol carrying the ordered type parameters as its primary associated types (`<Element…>`, each with an `associatedtype` in the body) plus a public generic `struct` wrapper over the ABI as a parameterised existential (`any {{name}}ABI<Element…>`). The type-parameter names must be in scope in BOTH — a requirement like `GetAt() -> Element` lives in the protocol, not the wrapper — so the protocol and the wrapper share one ordered `<T…>` clause threaded from the same `generics` context. It bakes NO static `@com(interface:)` IID on a generic type — a WinRT generic IID is a per-instantiation PIID computed at runtime, a projection concern out of render scope, and an associated-type protocol carries no single IID anyway — with a marker comment noting so. A non-generic interface renders through the `{{^generic}}` arm, byte-identical to before.

Forward each requirement on the public wrapper. The requirements landed only on the internal `{{name}}ABI` protocol, so a client of the wrapper could not call `GetAt`/`SetAt`/etc — the wrapper stored `base` and exposed nothing. The `{{#generic}}` arm now emits a public forwarding method per requirement on the wrapper, calling through `base` (`public func GetAt(_ index: …) -> Element { base.GetAt(index) }`), reusing the same method list the ABI-protocol requirements are generated from, so the wrapper's public surface matches the non-generic arm's. The ABI protocol stays the requirement set and the runtime-PIID marker.

A blank parameter name (`func Foo(_ : T)`) is allowed in a protocol requirement's decl, but the wrapper's forwarding method must PASS the argument BY NAME in the call — a blank name there expands to an empty argument, dropping the argument or mangling the commas (`base.Foo()`). So the render synthesizes a stable `local` for a blank parameter, `arg<N>` by its position among the method's kept parameters, used in BOTH the forwarding method's parameter list (`_ arg0: T`) and the call (`base.Foo(arg0)`), while the protocol requirement leaves the name blank. Each blank's `local` is chosen AFTER the method's real names are known, taking the first `arg<N>` not already used by a real (or earlier synthetic) parameter, in a shared `Shell.parameters` helper, so a real parameter named like a synthetic local never collides.

The generic ABI protocol still names a plain base (the spec's COM root or a named `bases` type) through the shared `{{#base}}` clause. A generic interface that inherits ANOTHER generic interface renders only its own surface here — forwarding a base's inherited methods and spelling a `TypeSpec` generic base in the inheritance clause are a follow-up.

Add render tests: the non-generic output pinned byte-for-byte, a generic interface rendered to the parameterised-ABI-protocol + generic-struct wrapper shape, a keyword-named generic type, a generic interface over a plain non-generic base, and the blank-parameter local synthesis.