### PR TITLE
SQL: add LEFT/RIGHT/FULL OUTER joins

### DIFF
--- a/Sources/SQL/AST.swift
+++ b/Sources/SQL/AST.swift
@@ -8,7 +8,8 @@
 /// ```sql
 /// SELECT <* | column (, column)*>
 ///   FROM <table> [AS alias]
-///   (JOIN <table> [AS alias] ON <column> = <column>)*
+///   ([INNER | (LEFT | RIGHT | FULL) [OUTER]] JOIN <table> [AS alias]
+///     ON <predicate>)*
 ///   [WHERE <predicate>] [ORDER BY <column> [ASC|DESC] (, …)*]
 ///   [OFFSET <skip> ROWS] [FETCH {FIRST | NEXT} <count> ROWS ONLY]
 /// ```
@@ -231,8 +232,8 @@ public struct Relation: Hashable, Sendable {
   }
 }
 
-/// A `JOIN` clause: a second relation and the `ON` predicate that relates it to
-/// the rows already in scope.
+/// A `JOIN` clause: a second relation, its join `kind`, and the `ON` predicate
+/// that relates it to the rows already in scope.
 ///
 /// The `ON` predicate is an arbitrary boolean expression over the relation
 /// joined in and the ones already in scope — the same predicate grammar a
@@ -244,22 +245,45 @@ public struct Relation: Hashable, Sendable {
 /// interprets the adapter-computed columns `Id` (every table's 1-based row
 /// identity) and a list-child's owner foreign key within the predicate's column
 /// references.
+///
+/// `kind` is the inner/outer variety: `inner` (the default) keeps only matched
+/// pairs, while a `left`/`right`/`full` OUTER join additionally preserves the
+/// unmatched rows of the left, right, or both sides, NULL-extending the other
+/// side's columns. The `ON` predicate governs MATCHING alone — an unmatched
+/// outer row is still emitted — which is distinct from a post-join `WHERE`.
 public struct Join: Hashable, Sendable {
+  /// The inner/outer variety of a join.
+  public enum Kind: Hashable, Sendable {
+    /// `[INNER] JOIN` — only matched pairs, the default.
+    case inner
+    /// `LEFT [OUTER] JOIN` — every left row, unmatched ones NULL-extended.
+    case left
+    /// `RIGHT [OUTER] JOIN` — every right row, unmatched ones NULL-extended.
+    case right
+    /// `FULL [OUTER] JOIN` — every row of both sides, unmatched NULL-extended.
+    case full
+  }
+
   /// The relation joined in.
   public let relation: Relation
+
+  /// The inner/outer variety of this join.
+  public let kind: Kind
 
   /// The `ON` predicate relating the joined-in relation to those in scope.
   public let on: Predicate
 
-  public init(relation: Relation, on: Predicate) {
+  public init(relation: Relation, kind: Kind = .inner, on: Predicate) {
     self.relation = relation
+    self.kind = kind
     self.on = on
   }
 
   /// A `column = column` equi-join over `relation` — the common shape, as the
   /// two column references its `ON` equates.
-  public init(relation: Relation, left: Column, right: Column) {
-    self.init(relation: relation,
+  public init(relation: Relation, kind: Kind = .inner, left: Column,
+              right: Column) {
+    self.init(relation: relation, kind: kind,
               on: .comparison(left: .column(left), op: .equal,
                               right: .column(right)))
   }

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -763,8 +763,14 @@ extension Catalog where Self: ~Escapable {
 
     let seed = from.leaf(locals[0])
     var chain = select.joins.indices.reduce(seed) { chain, index in
-      .select(matches[index].remapped(through: slot),
-              .product(chain, joined[index].leaf(locals[index + 1])))
+      let leaf = joined[index].leaf(locals[index + 1])
+      let on = matches[index].remapped(through: slot)
+      switch select.joins[index].kind {
+      case .inner:
+        return .select(on, .product(chain, leaf))
+      case .left, .right, .full:
+        return .outer(chain, leaf, on: on, kind: select.joins[index].kind)
+      }
     }
     if let predicate {
       chain = .select(predicate.remapped(through: slot), chain)
@@ -960,6 +966,14 @@ extension Catalog where Self: ~Escapable {
       try .product(optimise(left, context), optimise(right, context))
     case .join:
       plan
+    case let .outer(left, right, on, kind):
+      // Optimise each side (a nested inner join or a seekable scan inside a
+      // side still rewrites), but keep the outer node and its `on` intact — the
+      // `on` governs matching and must not fold into a product or push onto a
+      // leaf, or an unmatched preserved row would be dropped rather than
+      // NULL-extended.
+      try .outer(optimise(left, context), optimise(right, context), on: on,
+                 kind: kind)
     case let .union(left, right, all):
       // Optimise each side with the same bindings so a bound predicate inside an
       // arm seeks; the union itself merely concatenates and deduplicates,
@@ -1232,6 +1246,15 @@ extension Plan {
       try .sort(keys: keys, source.pushdown())
     case let .product(left, right):
       try .product(left.pushdown(), right.pushdown())
+    case let .outer(left, right, on, kind):
+      // Push down WITHIN each side (its own joins/filters rewrite), but the
+      // outer node is a pushdown barrier: a `WHERE` conjunct above it never
+      // rides into a side. Filtering a preserved side's rows before the outer
+      // join is equivalent, but filtering the NULL-extended side's rows before
+      // it would change which rows match, so — preferring correctness — the
+      // whole `WHERE` stays above (`distribute`'s default keeps it a `select`
+      // over this node).
+      try .outer(left.pushdown(), right.pushdown(), on: on, kind: kind)
     case let .union(left, right, all):
       try .union(left.pushdown(), right.pushdown(), all: all)
     case let .distinct(source):
@@ -1864,13 +1887,23 @@ extension Catalog where Self: ~Escapable {
     }
 
     // The left-deep chain: starting from the FROM relation's leaf, each join
-    // folds in the next relation's scan as a `Select` on that join's match over
-    // their product. The optimiser turns each `Select`-over-`Product` level into
-    // an index-nested-loop join.
+    // folds in the next relation's scan. An INNER join is a `Select` on that
+    // join's ON over the product — the optimiser turns each `Select`-over-
+    // `Product` level into an index-nested-loop join. An OUTER join is an
+    // `outer` node holding the ON directly, so the ON governs matching alone
+    // and an unmatched preserved row is NULL-extended rather than dropped; its
+    // ON is NOT distributed into the product (a `WHERE` still filters after
+    // it).
     let seed = from.leaf(locals[0])
     let chain = select.joins.indices.reduce(seed) { chain, index in
-      .select(matches[index].remapped(through: slot),
-              .product(chain, joined[index].leaf(locals[index + 1])))
+      let leaf = joined[index].leaf(locals[index + 1])
+      let on = matches[index].remapped(through: slot)
+      switch select.joins[index].kind {
+      case .inner:
+        return .select(on, .product(chain, leaf))
+      case .left, .right, .full:
+        return .outer(chain, leaf, on: on, kind: select.joins[index].kind)
+      }
     }
 
     return chain.shaped(

--- a/Sources/SQL/Lexer.swift
+++ b/Sources/SQL/Lexer.swift
@@ -415,6 +415,11 @@ internal struct Lexer: ~Escapable {
     case "OR": .or
     case "NOT": .not
     case "JOIN": .join
+    case "INNER": .inner
+    case "LEFT": .left
+    case "RIGHT": .right
+    case "FULL": .full
+    case "OUTER": .outer
     case "ON": .on
     case "AS": .as
     case "IS": .is

--- a/Sources/SQL/Operator.swift
+++ b/Sources/SQL/Operator.swift
@@ -139,6 +139,17 @@ internal indirect enum Plan {
   /// paired.
   case join(Plan, name: String, ordinals: Array<Int>, base: Int,
             column: Int, keys: (left: Int, right: Int), filter: Filter?)
+  /// ⟕/⟖/⟗ — the OUTER join of `left` and `right` on the `on` predicate, in
+  /// combined slot space (the left's slots then the right's). Unlike an inner
+  /// join, the `on` predicate is NOT distributed into the product or pushed
+  /// onto a leaf — it governs MATCHING alone, so an unmatched outer row is
+  /// still emitted with the other side NULL-extended. `kind` selects which
+  /// side's unmatched rows survive: `left` every left row, `right` every right
+  /// row, `full` both — a `.inner` kind never reaches this node (an inner join
+  /// lowers to the `select`/`product`/`join` path). The executor runs it as a
+  /// nested loop that tracks matches, so it composes with an arbitrary
+  /// (non-equi) `on`.
+  case outer(Plan, Plan, on: Filter, kind: Join.Kind)
   /// ∪ — the rows of the `left` sub-plan followed by the `right`'s, in source
   /// order. With `all` the duplicates are kept (`UNION ALL`); without it the
   /// whole-row duplicates of the combined rows are removed, the first occurrence
@@ -236,6 +247,14 @@ extension Plan {
       }
     case let .join(outer, _, ordinals, _, _, _, _):
       outer.slots.map { $0 + ordinals.count }
+    case let .outer(left, right, _, _):
+      // An outer join lays the right's slots after the left's, exactly as a
+      // product does — the NULL-extended side still occupies its slots.
+      if let left = left.slots, let right = right.slots {
+        left + right
+      } else {
+        nil
+      }
     case let .union(left, _, _):
       // Both sides yield rows of the same width — the result columns — so the
       // union's width is its left side's.
@@ -334,6 +353,13 @@ extension Catalog where Self: ~Escapable {
     case let .join(outer, name, ordinals, base, column, keys, filter):
       return try join(execute(outer, context), name, ordinals, base, column,
                       keys, filter, context)
+    case let .outer(left, right, on, kind):
+      // The side widths come from the sub-plans (known for a compiled plan),
+      // so an unmatched row NULL-extends to the right width even when a side
+      // yields no rows to read a width off.
+      return try outer(execute(left, context), left.slots ?? 0,
+                       execute(right, context), right.slots ?? 0, on, kind,
+                       routines, bindings)
     case let .union(left, right, all):
       return try union(left, right, all, context)
     case let .distinct(source):
@@ -521,6 +547,86 @@ private func sift(_ outer: Array<Record>, _ inner: Array<Record>,
       if try record.evaluate(filter, routines, bindings) == true {
         records.append(record)
       }
+    }
+  }
+  return records
+}
+
+/// The OUTER join of `left` and `right` on the `on` predicate — a nested loop
+/// tracking matches so an unmatched preserved row is emitted with the other
+/// side NULL-extended.
+///
+/// `left`/`right` are the two materialised sides and `leftWidth`/`rightWidth`
+/// each side's slot count (needed to NULL-extend even when a side is empty).
+/// Each candidate pair is merged (left slots then right slots) and tested
+/// against `on` under three-valued logic — TRUE matches, UNKNOWN and FALSE do
+/// not, exactly as a `WHERE` admits; `on` governs MATCHING alone, so an
+/// unmatched preserved row is still emitted.
+///
+///   - `left`: every left row, in left-major order — each matched pair, then a
+///     right-NULL row for a left row that matched nothing.
+///   - `right`: the mirror — every right row, in right-major order, its
+///     unmatched ones left-NULL.
+///   - `full`: the left-major pass (matched pairs and right-NULL unmatched-left
+///     rows) followed by a left-NULL row for every right row no left row ever
+///     matched, so both sides' unmatched rows survive.
+///
+/// A `.inner` kind never reaches here — `compile` lowers an inner join through
+/// the product/join path.
+private func outer(_ left: Array<Record>, _ leftWidth: Int,
+                   _ right: Array<Record>, _ rightWidth: Int, _ on: Filter,
+                   _ kind: Join.Kind, _ routines: Routines,
+                   _ bindings: Bindings) throws(SQLError) -> Array<Record> {
+  let leftNulls = Record(Array(repeating: .null, count: leftWidth))
+  let rightNulls = Record(Array(repeating: .null, count: rightWidth))
+
+  // A `right` join preserves the right side, so it drives the loop right-major
+  // and NULL-extends the left. The `on` filter stays in the same combined slot
+  // space (left slots then right slots), so each candidate is still merged
+  // left-first — only the iteration order and the preserved side differ.
+  if kind == .right {
+    var records = Array<Record>()
+    for inner in right {
+      var paired = false
+      for outer in left {
+        let record = outer.merged(with: inner)
+        if try record.evaluate(on, routines, bindings) == true {
+          records.append(record)
+          paired = true
+        }
+      }
+      if !paired { records.append(leftNulls.merged(with: inner)) }
+    }
+    return records
+  }
+
+  var records = Array<Record>()
+  // Track which right rows matched some left row — a `full` join emits the
+  // never-matched ones NULL-extended after the left-major pass.
+  var matched = Array(repeating: false, count: right.count)
+
+  for outer in left {
+    var paired = false
+    for index in right.indices {
+      let record = outer.merged(with: right[index])
+      if try record.evaluate(on, routines, bindings) == true {
+        records.append(record)
+        matched[index] = true
+        paired = true
+      }
+    }
+    // An unmatched left row is preserved (right NULL) for a `left` or `full`
+    // join — the left side is preserved in both.
+    if !paired {
+      records.append(outer.merged(with: rightNulls))
+    }
+  }
+
+  // A `full` join also preserves every right row no left row matched (left
+  // NULL).
+  if kind == .full {
+    for index in right.indices where !matched[index] {
+      records.append(leftNulls.merged(with: right[index]))
     }
   }
   return records

--- a/Sources/SQL/Parser.swift
+++ b/Sources/SQL/Parser.swift
@@ -23,7 +23,8 @@
 ///                   [FROM relation (join)*
 ///                    [where] [group] [having] [order] [limit]]
 /// relation       := identifier [AS identifier]
-/// join           := JOIN relation ON predicate
+/// join           := [INNER | (LEFT | RIGHT | FULL) [OUTER]] JOIN
+///                     relation ON predicate
 /// projection     := '*' | column (',' column)*
 /// where          := WHERE predicate
 /// group          := GROUP BY column (',' column)*
@@ -324,8 +325,8 @@ internal struct Parser: ~Escapable {
     let from = try relation()
 
     var joins = Array<Join>()
-    while try match(.join) {
-      try joins.append(join())
+    while let kind = try joinKind() {
+      try joins.append(join(kind))
     }
     let predicate: Predicate? = if try match(.where) {
       try predicate()
@@ -392,16 +393,45 @@ internal struct Parser: ~Escapable {
     }
   }
 
-  /// Parses the join tail (the `JOIN` keyword is already consumed): a relation,
-  /// `ON`, and an arbitrary boolean predicate — the same grammar a `WHERE`
-  /// admits, so a join relates its sides by an equality, an inequality, an
-  /// expression equality, or any `AND`/`OR`/`NOT` of comparisons. A pure
+  /// Parses an optional join `kind` and its `JOIN` keyword at the current
+  /// position, or `nil` when no join clause begins here.
+  ///
+  /// A bare `JOIN` (or an explicit `INNER JOIN`) is `.inner`; `LEFT`/`RIGHT`/
+  /// `FULL` introduce an outer join, each admitting an optional `OUTER` noise
+  /// word before the mandatory `JOIN`. A leading `INNER`/`LEFT`/`RIGHT`/`FULL`
+  /// commits to a join clause, so a missing `JOIN` after it faults rather than
+  /// silently ending the join chain.
+  private mutating func joinKind() throws(SQLError) -> Join.Kind? {
+    if try match(.join) { return .inner }
+    let kind: Join.Kind
+    if try match(.inner) {
+      kind = .inner
+    } else if try match(.left) {
+      kind = .left
+    } else if try match(.right) {
+      kind = .right
+    } else if try match(.full) {
+      kind = .full
+    } else {
+      return nil
+    }
+    // `OUTER` is an optional noise word on `LEFT`/`RIGHT`/`FULL`; `INNER` never
+    // carries it. Either way `JOIN` must follow.
+    if kind != .inner { _ = try match(.outer) }
+    try expect(.join)
+    return kind
+  }
+
+  /// Parses the join tail (the `kind` and `JOIN` keyword are already consumed):
+  /// a relation, `ON`, and an arbitrary boolean predicate — the same grammar a
+  /// `WHERE` admits, so a join relates its sides by an equality, an inequality,
+  /// an expression equality, or any `AND`/`OR`/`NOT` of comparisons. A pure
   /// `column = column` conjunct hash-joins; the rest is a residual filter.
-  private mutating func join() throws(SQLError) -> Join {
+  private mutating func join(_ kind: Join.Kind) throws(SQLError) -> Join {
     let relation = try relation()
     try expect(.on)
     let on = try predicate()
-    return Join(relation: relation, on: on)
+    return Join(relation: relation, kind: kind, on: on)
   }
 
   // MARK: - Projection

--- a/Sources/SQL/Token.swift
+++ b/Sources/SQL/Token.swift
@@ -40,6 +40,11 @@ extension Token {
     case or
     case not
     case join
+    case inner
+    case left
+    case right
+    case full
+    case outer
     case on
     case `as`
     case `is`
@@ -118,6 +123,11 @@ extension Token.Kind {
     case .or: "OR"
     case .not: "NOT"
     case .join: "JOIN"
+    case .inner: "INNER"
+    case .left: "LEFT"
+    case .right: "RIGHT"
+    case .full: "FULL"
+    case .outer: "OUTER"
     case .on: "ON"
     case .as: "AS"
     case .is: "IS"

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -1192,6 +1192,201 @@ struct EngineNonEquiJoinTests {
   }
 }
 
+// MARK: - Outer join tests
+
+struct EngineOuterJoinTests {
+  @Test func `a LEFT JOIN preserves an unmatched left row, right NULL`() throws {
+    // Every parent survives; Cid, with no child, emits once with the child
+    // columns NULL — the NULL-extension. Matched parents emit each pair.
+    let rows = try join("""
+        SELECT Parent.Name, Child.Name FROM Parent
+          LEFT JOIN Child ON Child.Pid = Parent.Id
+        """)
+    #expect(rows == [
+      [.text("Ada"), .text("Ann")],
+      [.text("Ada"), .text("Amy")],
+      [.text("Bee"), .text("Bob")],
+      [.text("Cid"), .null],
+    ])
+  }
+
+  @Test func `LEFT OUTER JOIN is the same as LEFT JOIN`() throws {
+    // The `OUTER` noise word is optional and changes nothing.
+    let terse = try join("""
+        SELECT Parent.Name, Child.Name FROM Parent
+          LEFT JOIN Child ON Child.Pid = Parent.Id
+        """)
+    let verbose = try join("""
+        SELECT Parent.Name, Child.Name FROM Parent
+          LEFT OUTER JOIN Child ON Child.Pid = Parent.Id
+        """)
+    #expect(terse == verbose)
+  }
+
+  @Test func `a RIGHT JOIN preserves an unmatched right row, left NULL`() throws {
+    // Every child survives, right-major; the Orphan (Pid 9) has no parent and
+    // emits once with the parent columns NULL.
+    let rows = try join("""
+        SELECT Parent.Name, Child.Name FROM Parent
+          RIGHT JOIN Child ON Child.Pid = Parent.Id
+        """)
+    #expect(rows == [
+      [.text("Ada"), .text("Ann")],
+      [.text("Ada"), .text("Amy")],
+      [.text("Bee"), .text("Bob")],
+      [.null, .text("Orphan")],
+    ])
+  }
+
+  @Test func `a FULL JOIN preserves the unmatched rows of both sides`() throws {
+    // The left-major pairs and the childless Cid (right NULL), then the
+    // parentless Orphan (left NULL) — both sides' unmatched rows survive.
+    let rows = try join("""
+        SELECT Parent.Name, Child.Name FROM Parent
+          FULL JOIN Child ON Child.Pid = Parent.Id
+        """)
+    #expect(rows == [
+      [.text("Ada"), .text("Ann")],
+      [.text("Ada"), .text("Amy")],
+      [.text("Bee"), .text("Bob")],
+      [.text("Cid"), .null],
+      [.null, .text("Orphan")],
+    ])
+  }
+
+  @Test func `an ON conjunct keeps an unmatched left row a WHERE would drop`() throws {
+    // ON vs WHERE. Restricting the MATCH with `AND Child.Name = 'Amy'` keeps
+    // every parent — the ON governs matching alone, so a parent that now
+    // matches no child is still emitted NULL-extended. Only Ada matches Amy.
+    let rows = try join("""
+        SELECT Parent.Name, Child.Name FROM Parent
+          LEFT JOIN Child ON Child.Pid = Parent.Id AND Child.Name = 'Amy'
+        """)
+    #expect(rows == [
+      [.text("Ada"), .text("Amy")],
+      [.text("Bee"), .null],
+      [.text("Cid"), .null],
+    ])
+  }
+
+  @Test func `the same predicate in WHERE drops the unmatched rows`() throws {
+    // Moving the predicate to a post-join WHERE filters AFTER the outer join,
+    // so the NULL-extended rows (whose Child.Name is NULL) fail `= 'Amy'` and
+    // drop — turning the LEFT join back to inner-like. This is the ON-vs-WHERE
+    // distinction the outer join preserves.
+    let rows = try join("""
+        SELECT Parent.Name, Child.Name FROM Parent
+          LEFT JOIN Child ON Child.Pid = Parent.Id WHERE Child.Name = 'Amy'
+        """)
+    #expect(rows == [[.text("Ada"), .text("Amy")]])
+  }
+
+  @Test func `a WHERE IS NULL over a LEFT join finds the unmatched rows`() throws {
+    // The anti-join idiom: a LEFT join then `WHERE Child.Name IS NULL` keeps
+    // only the parents with no child — Cid.
+    let rows = try join("""
+        SELECT Parent.Name FROM Parent
+          LEFT JOIN Child ON Child.Pid = Parent.Id WHERE Child.Name IS NULL
+        """)
+    #expect(rows == [[.text("Cid")]])
+  }
+
+  @Test func `a LEFT JOIN with a non-equi ON preserves unmatched rows`() throws {
+    // Outer joins compose with Part 1's non-equi ON: `ON Parent.Id > Child.Pid`
+    // pairs each parent with the children below it, and NULL-extends a parent
+    // that dominates none. Child Pids are 1,1,2,9. Ada(1) > none; Bee(2) >
+    // Pid 1 (Ann, Amy); Cid(3) > Pids 1,1,2 (Ann, Amy, Bob).
+    let rows = try join("""
+        SELECT Parent.Name, Child.Name FROM Parent
+          LEFT JOIN Child ON Parent.Id > Child.Pid
+        """)
+    #expect(rows == [
+      [.text("Ada"), .null],
+      [.text("Bee"), .text("Ann")],
+      [.text("Bee"), .text("Amy")],
+      [.text("Cid"), .text("Ann")],
+      [.text("Cid"), .text("Amy")],
+      [.text("Cid"), .text("Bob")],
+    ])
+  }
+
+  @Test func `a LEFT JOIN plans an outer node, not a distributed product`() throws {
+    // The ON must stay on the outer node — never distributed into a product or
+    // nested into a hash join — or an unmatched row would be dropped. So the
+    // plan reaches an `.outer` node and NOT a `.join`.
+    let catalog = try family()
+    let select = try parse("""
+        SELECT Parent.Name, Child.Name FROM Parent
+          LEFT JOIN Child ON Child.Pid = Parent.Id
+        """)
+    let plan =
+        try catalog.optimise(catalog.compile(select).pushdown(), [:])
+    #expect(outers(plan))
+    #expect(!joins(plan))
+  }
+
+  @Test func `an inner join then a LEFT join preserves the middle unmatched`() throws {
+    // A mixed chain: House JOIN Room (inner) then LEFT JOIN Item. The empty
+    // Attic (no item) survives the LEFT join NULL-extended, while the inner
+    // House-Room pairs are formed first.
+    let rows = try lineage("""
+        SELECT House.House, Room.Room, Item.Item FROM House
+          JOIN Room ON Room.Hid = House.Id
+          LEFT JOIN Item ON Item.Rid = Room.Id
+        """)
+    #expect(rows == [
+      [.text("Burrow"), .text("Kitchen"), .text("Kettle")],
+      [.text("Burrow"), .text("Kitchen"), .text("Pot")],
+      [.text("Burrow"), .text("Attic"), .null],
+      [.text("Manor"), .text("Hall"), .text("Banner")],
+    ])
+  }
+
+  @Test func `an empty right side NULL-extends every left row`() throws {
+    // With no child matching, a LEFT join still emits every parent, right
+    // NULL — the width comes from the plan, not from a right row.
+    let rows = try join("""
+        SELECT Parent.Name, Child.Name FROM Parent
+          LEFT JOIN Child ON Child.Pid = 999
+        """)
+    #expect(rows == [
+      [.text("Ada"), .null],
+      [.text("Bee"), .null],
+      [.text("Cid"), .null],
+    ])
+  }
+}
+
+/// Whether `plan` reaches an `.outer` node — the outer-join operator.
+private func outers(_ plan: Plan) -> Bool {
+  switch plan {
+  case .outer:
+    true
+  case let .select(_, source):
+    outers(source)
+  case let .project(_, source):
+    outers(source)
+  case let .sort(_, source):
+    outers(source)
+  case let .limit(_, _, source):
+    outers(source)
+  case let .distinct(source):
+    outers(source)
+  case let .derived(_, sub, _, _):
+    outers(sub)
+  case let .product(left, right):
+    outers(left) || outers(right)
+  case let .join(source, _, _, _, _, _, _):
+    outers(source)
+  case let .union(left, right, _):
+    outers(left) || outers(right)
+  case let .aggregate(_, _, source):
+    outers(source)
+  case .single, .scan:
+    false
+  }
+}
+
 // MARK: - Multi-way join tests
 
 struct EngineMultiJoinTests {
@@ -1392,6 +1587,8 @@ private func derived(_ plan: Plan) -> Plan? {
     derived(source)
   case let .product(left, right):
     derived(left) ?? derived(right)
+  case let .outer(left, right, _, _):
+    derived(left) ?? derived(right)
   case let .union(left, right, _):
     derived(left) ?? derived(right)
   case let .limit(_, _, source):
@@ -1424,6 +1621,8 @@ private func seeks(_ plan: Plan) -> Bool {
     // A pushed-down key seeks the join's OUTER leaf, so a seek can live inside
     // the join rather than only atop a bare scan.
     seeks(outer)
+  case let .outer(left, right, _, _):
+    seeks(left) || seeks(right)
   case let .union(left, right, _):
     seeks(left) || seeks(right)
   case let .limit(_, _, source):
@@ -1453,6 +1652,8 @@ private func filters(_ plan: Plan) -> Bool {
     filters(sub)
   case let .product(left, right):
     filters(left) || filters(right)
+  case let .outer(left, right, _, _):
+    filters(left) || filters(right)
   case let .union(left, right, _):
     filters(left) || filters(right)
   case let .limit(_, _, source):
@@ -1475,6 +1676,9 @@ private func pushed(_ plan: Plan) -> Bool {
   case let .join(outer, _, _, _, _, _, _):
     seeks(outer) || floats(outer) || pushed(outer)
   case let .product(left, right):
+    seeks(left) || floats(left) || pushed(left) || seeks(right)
+        || floats(right) || pushed(right)
+  case let .outer(left, right, _, _):
     seeks(left) || floats(left) || pushed(left) || seeks(right)
         || floats(right) || pushed(right)
   case let .select(_, source):
@@ -1537,6 +1741,8 @@ private func joins(_ plan: Plan) -> Bool {
     joins(sub)
   case let .product(left, right):
     joins(left) || joins(right)
+  case let .outer(left, right, _, _):
+    joins(left) || joins(right)
   case let .union(left, right, _):
     joins(left) || joins(right)
   case let .aggregate(_, _, source):
@@ -1569,6 +1775,8 @@ private func residual(_ plan: Plan) -> Bool {
     residual(left) || residual(right)
   case let .join(outer, _, _, _, _, _, _):
     residual(outer)
+  case let .outer(left, right, _, _):
+    residual(left) || residual(right)
   case let .union(left, right, _):
     residual(left) || residual(right)
   case let .aggregate(_, _, source):
@@ -1602,6 +1810,8 @@ private func separated(_ plan: Plan) -> Bool {
     separated(left) || separated(right)
   case let .join(outer, _, _, _, _, _, _):
     separated(outer)
+  case let .outer(left, right, _, _):
+    separated(left) || separated(right)
   case let .union(left, right, _):
     separated(left) || separated(right)
   case let .aggregate(_, _, source):
@@ -1636,6 +1846,8 @@ private func stacked(_ plan: Plan) -> Bool {
     stacked(left) || stacked(right)
   case let .join(outer, _, _, _, _, _, _):
     stacked(outer)
+  case let .outer(left, right, _, _):
+    stacked(left) || stacked(right)
   case let .union(left, right, _):
     stacked(left) || stacked(right)
   case let .aggregate(_, _, source):
@@ -1745,6 +1957,8 @@ private func injected(_ plan: Plan) -> Bool {
   case let .derived(_, sub, _, _):
     injected(sub)
   case let .product(left, right):
+    injected(left) || injected(right)
+  case let .outer(left, right, _, _):
     injected(left) || injected(right)
   case let .join(outer, _, _, _, _, _, _):
     injected(outer)
@@ -3090,11 +3304,14 @@ struct EngineBoundTests {
 
 // MARK: - UNION tests
 
-/// A three-relation catalog for `UNION`: `Left` and `Right` each hold a single
+/// A three-relation catalog for `UNION`: `Lhs` and `Rhs` each hold a single
 /// `Tag` text column, sharing the value `shared` so a union across them proves
 /// cross-relation dedup; the values are otherwise distinct. `Extra` repeats the
-/// `a` already in `Left`, so a trailing `UNION ALL Extra` keeps it a second
+/// `a` already in `Lhs`, so a trailing `UNION ALL Extra` keeps it a second
 /// time — proving an inner `UNION`'s dedup survives an outer `UNION ALL`.
+///
+/// The relations are `Lhs`/`Rhs` rather than `Left`/`Right`, now that the
+/// latter are reserved outer-join keywords.
 private func tags() -> Memory {
   let fields = [Field(name: "Tag", type: .text)]
   let left = [
@@ -3109,8 +3326,8 @@ private func tags() -> Memory {
     [.text("a")],
   ] as Array<Array<Value>>
   return Memory([
-    "Left": FixtureRelation(fields, left),
-    "Right": FixtureRelation(fields, right),
+    "Lhs": FixtureRelation(fields, left),
+    "Rhs": FixtureRelation(fields, right),
     "Extra": FixtureRelation(fields, extra),
   ])
 }
@@ -3135,7 +3352,7 @@ struct EngineUnionTests {
 
   @Test func `a UNION across two relations of matching arity merges and dedups`() throws {
     let rows = try tags().run(parse("""
-        SELECT Tag FROM Left UNION SELECT Tag FROM Right
+        SELECT Tag FROM Lhs UNION SELECT Tag FROM Rhs
         """))
     // `shared` appears in both arms but survives once, first occurrence kept.
     #expect(rows == [[.text("a")], [.text("shared")], [.text("b")]])
@@ -3143,7 +3360,7 @@ struct EngineUnionTests {
 
   @Test func `a UNION ALL across two relations keeps the shared row twice`() throws {
     let rows = try tags().run(parse("""
-        SELECT Tag FROM Left UNION ALL SELECT Tag FROM Right
+        SELECT Tag FROM Lhs UNION ALL SELECT Tag FROM Rhs
         """))
     #expect(rows == [
       [.text("a")],
@@ -3154,13 +3371,13 @@ struct EngineUnionTests {
   }
 
   @Test func `an inner UNION dedups before a trailing UNION ALL appends its arm`() throws {
-    // (Left UNION Right) UNION ALL Extra. The inner UNION dedups `shared`
-    // across Left and Right to one row — `a, shared, b` — and the outer UNION
+    // (Lhs UNION Rhs) UNION ALL Extra. The inner UNION dedups `shared`
+    // across Lhs and Rhs to one row — `a, shared, b` — and the outer UNION
     // ALL then appends Extra's `a` WITHOUT deduplicating, so `a` recurs. A
     // chain flattened to the trailing `all` would instead keep both copies of
     // `shared`; honouring each node's own flag keeps exactly one.
     let rows = try tags().run(parse("""
-        SELECT Tag FROM Left UNION SELECT Tag FROM Right
+        SELECT Tag FROM Lhs UNION SELECT Tag FROM Rhs
           UNION ALL SELECT Tag FROM Extra
         """))
     #expect(rows == [
@@ -3181,7 +3398,7 @@ struct EngineUnionTests {
 
   @Test func `a view defined as a UNION resolves and queries`() throws {
     let both = try View(query: select("""
-        SELECT Tag FROM Left UNION SELECT Tag FROM Right
+        SELECT Tag FROM Lhs UNION SELECT Tag FROM Rhs
         """), columns: ["Tag"])
     let catalog = Memory(tags().catalog, views: ["Both": both])
     let rows = try catalog.run(parse("SELECT Tag FROM Both"))
@@ -3740,7 +3957,7 @@ struct EngineWithTests {
 
   @Test func `a CTE whose body is a UNION materialises both arms`() throws {
     let rows = try statement("""
-        WITH both (Tag) AS (SELECT Tag FROM Left UNION SELECT Tag FROM Right)
+        WITH both (Tag) AS (SELECT Tag FROM Lhs UNION SELECT Tag FROM Rhs)
           SELECT Tag FROM both
         """, tags())
     #expect(rows == [[.text("a")], [.text("shared")], [.text("b")]])

--- a/Tests/SQLTests/ParserTests.swift
+++ b/Tests/SQLTests/ParserTests.swift
@@ -402,6 +402,38 @@ struct JoinTests {
                                 right: .column("b.y")))),
     ])
   }
+
+  @Test func `a bare JOIN is an inner join`() throws {
+    let select = try parse(select: "SELECT * FROM A JOIN B ON a.x = b.x")
+    #expect(select.joins.first?.kind == .inner)
+  }
+
+  @Test func `parses each outer join kind, OUTER optional`() throws {
+    let cases: Array<(String, Join.Kind)> = [
+      ("INNER JOIN", .inner),
+      ("LEFT JOIN", .left),
+      ("LEFT OUTER JOIN", .left),
+      ("RIGHT JOIN", .right),
+      ("RIGHT OUTER JOIN", .right),
+      ("FULL JOIN", .full),
+      ("FULL OUTER JOIN", .full),
+    ]
+    for (spelling, kind) in cases {
+      let select = try parse(select: """
+          SELECT * FROM A \(spelling) B ON a.x = b.x
+          """)
+      #expect(select.joins == [
+        Join(relation: Relation(name: "B"), kind: kind,
+             left: Column("a.x"), right: Column("b.x")),
+      ])
+    }
+  }
+
+  @Test func `a join kind without JOIN faults`() {
+    #expect(throws: SQLError.self) {
+      _ = try Statement(parsing: "SELECT * FROM A LEFT B ON a.x = b.x")
+    }
+  }
 }
 
 // MARK: - Literals


### PR DESCRIPTION
Extend the join grammar with `[INNER | (LEFT | RIGHT | FULL) [OUTER]] JOIN`. INNER stays the default and lowers as before; an outer join preserves the unmatched rows of the left, right, or both sides, NULL-extending the other side's columns.

The `Join` AST node gains a `kind`. New reserved keywords LEFT/RIGHT/ FULL/OUTER/INNER are lexed; the parser reads an optional kind before `JOIN` (with `OUTER` an optional noise word) and commits to a join clause once a kind keyword is seen.

A new `Plan.outer(left, right, on:, kind:)` node models the outer join in combined slot space (left slots then right slots). Unlike an inner join, its ON is NOT distributed into the product or pushed onto a leaf — it governs MATCHING alone, so an unmatched preserved row is emitted NULL-extended rather than dropped. The compile left-deep reduce branches on kind: an inner join stays `Select(on, Product)`; an outer join builds the `outer` node with the ON attached. Pushdown treats the outer node as a barrier (a `WHERE` stays above it, preserving the ON-vs-WHERE distinction — a `WHERE` on the null-extended side filters after the join and can turn a LEFT join inner-like); optimise recurses into the sides but keeps the node and ON intact.

The executor runs a nested loop tracking matches, so it composes with an arbitrary (non-equi) ON: LEFT emits every left row (matched pairs, then a right-NULL row for an unmatched left); RIGHT is the right-major mirror; FULL adds a left-NULL row for every never-matched right row. Side widths come from the sub-plans so an empty side still NULL-extends correctly.

Tests cover matched rows, unmatched-left (LEFT), RIGHT, FULL, the ON-vs-WHERE distinction (an ON conjunct keeps a row a WHERE drops), the anti-join `WHERE ... IS NULL` idiom, an outer join with a non-equi ON, a mixed inner-then-outer chain, an empty right side, and the planned `.outer` shape. The UNION fixtures' `Left`/`Right` relations are renamed `Lhs`/`Rhs`, the names now being reserved.