### PR TITLE
SQL: add COALESCE, NULLIF, BETWEEN, and the || concatenation operator

### DIFF
--- a/Sources/SQL/AST.swift
+++ b/Sources/SQL/AST.swift
@@ -468,6 +468,24 @@ public indirect enum Expression: Hashable, Sendable {
   /// engine models one conditional. The result expressions' types must unify to
   /// one result type (see resolution).
   case `case`(Array<When>, else: Expression?)
+  /// `COALESCE(v1, v2, …)` — the first argument whose value is non-NULL, else
+  /// NULL. The ISO definition is the searched `CASE WHEN v1 IS NOT NULL THEN v1
+  /// … END`, but it is a FIRST-CLASS node rather than that expansion so each
+  /// argument is evaluated EXACTLY ONCE: the desugar re-referenced each `vi` in
+  /// both its `IS NOT NULL` guard and its `THEN`, evaluating a stateful
+  /// argument twice — testing one call's value for NULL and returning a
+  /// different one. The result type is the `ValueType.unified` reduction over
+  /// the arguments (the same unification a `CASE`'s results take), to which the
+  /// selected value is coerced. At least two arguments (the parser enforces
+  /// it).
+  case coalesce(Array<Expression>)
+  /// `NULLIF(v1, v2)` — NULL when `v1` equals `v2`, else `v1`. The ISO
+  /// definition is `CASE WHEN v1 = v2 THEN NULL ELSE v1 END`, but it is a
+  /// FIRST-CLASS node rather than that expansion so `v1` is evaluated EXACTLY
+  /// ONCE: the desugar embedded `v1` in both the equality and the `ELSE`,
+  /// evaluating a stateful `v1` twice — comparing one call's value to `v2` and
+  /// returning a different one. The result type is `v1`'s.
+  case nullif(Expression, Expression)
 }
 
 /// One `WHEN predicate THEN result` branch of a `CASE` expression — the guard
@@ -518,11 +536,13 @@ public enum Aggregand: Hashable, Sendable {
   case expression(Expression)
 }
 
-/// A binary arithmetic operator.
+/// A binary operator over two scalar operands.
 ///
-/// The four standard operators over integers; `*` `/` bind tighter than `+`
-/// `-`, and all four are left-associative — the precedence the parser's
-/// climbing grammar encodes and parentheses override.
+/// The four standard arithmetic operators over numbers, and the ISO `||`
+/// string concatenation. `*` `/` bind tighter than `+` `-` `||`, and every
+/// operator is left-associative — the precedence the parser's climbing grammar
+/// encodes and parentheses override. The four arithmetic operators require
+/// numeric operands; `||` requires text operands. All propagate NULL.
 public enum Arithmetic: Hashable, Sendable {
   /// `+`
   case add
@@ -532,6 +552,10 @@ public enum Arithmetic: Hashable, Sendable {
   case multiply
   /// `/` — integer division.
   case divide
+  /// `||` — text concatenation. It joins two text operands into one text value
+  /// and propagates NULL (a NULL operand yields NULL); a non-text operand is a
+  /// `SQLError.operand` type error, as arithmetic faults on a non-numeric one.
+  case concatenate
 }
 
 /// A row filter — a tree of comparisons composed with `AND`, `OR`, and `NOT`.
@@ -559,6 +583,15 @@ public indirect enum Predicate: Hashable, Sendable {
   /// TRUE when a NULL element is present). The engine lowers it to that
   /// disjunction rather than carrying a dedicated `Filter` case.
   case membership(Expression, Array<Expression>, negated: Bool)
+  /// `x [NOT] BETWEEN a AND b` — whether `x` is within the inclusive range
+  /// `[a, b]`, or outside it when `negated`. The ISO definition is `x >= a AND
+  /// x <= b` (and `x < a OR x > b` negated), but it is a FIRST-CLASS node
+  /// rather than that expansion so the test expression `x` is evaluated EXACTLY
+  /// ONCE: the desugar duplicated `x` across both bound comparisons, testing a
+  /// stateful `x`'s lower bound with one call and its upper with another. It
+  /// keeps the ISO three-valued semantics — a NULL `x`, `a`, or `b` makes a
+  /// bound UNKNOWN, excluding the row.
+  case between(Expression, Expression, Expression, negated: Bool)
   /// `lhs AND rhs`.
   case and(Predicate, Predicate)
   /// `lhs OR rhs`.

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -591,6 +591,10 @@ extension Expression {
     case let .case(whens, otherwise):
       whens.contains { $0.when.aggregated || $0.then.aggregated }
           || (otherwise?.aggregated ?? false)
+    case let .coalesce(arguments):
+      arguments.contains { $0.aggregated }
+    case let .nullif(lhs, rhs):
+      lhs.aggregated || rhs.aggregated
     }
   }
 
@@ -611,6 +615,10 @@ extension Expression {
     case let .case(whens, otherwise):
       whens.contains { $0.when.bound || $0.then.bound }
           || (otherwise?.bound ?? false)
+    case let .coalesce(arguments):
+      arguments.contains { $0.bound }
+    case let .nullif(lhs, rhs):
+      lhs.bound || rhs.bound
     }
   }
 }
@@ -639,6 +647,8 @@ extension Predicate {
       operand.aggregated
     case let .membership(operand, values, _):
       operand.aggregated || values.contains { $0.aggregated }
+    case let .between(test, lower, upper, _):
+      test.aggregated || lower.aggregated || upper.aggregated
     case let .and(lhs, rhs), let .or(lhs, rhs):
       lhs.aggregated || rhs.aggregated
     case let .not(operand):
@@ -660,6 +670,8 @@ extension Predicate {
       operand.bound
     case let .membership(operand, values, _):
       operand.bound || values.contains { $0.bound }
+    case let .between(test, lower, upper, _):
+      test.bound || lower.bound || upper.bound
     case let .and(lhs, rhs), let .or(lhs, rhs):
       lhs.bound || rhs.bound
     case let .not(operand):
@@ -858,6 +870,11 @@ extension Expression {
         branch.then.collect(into: &expressions)
       }
       otherwise?.collect(into: &expressions)
+    case let .coalesce(arguments):
+      for argument in arguments { argument.collect(into: &expressions) }
+    case let .nullif(lhs, rhs):
+      lhs.collect(into: &expressions)
+      rhs.collect(into: &expressions)
     }
   }
 
@@ -896,6 +913,10 @@ extension Predicate {
     case let .membership(operand, values, _):
       operand.collect(into: &expressions)
       for value in values { value.collect(into: &expressions) }
+    case let .between(test, lower, upper, _):
+      test.collect(into: &expressions)
+      lower.collect(into: &expressions)
+      upper.collect(into: &expressions)
     case let .and(lhs, rhs), let .or(lhs, rhs):
       lhs.collect(into: &expressions)
       rhs.collect(into: &expressions)
@@ -1070,6 +1091,23 @@ private func comparison(_ filter: Filter, _ bindings: Bindings)
   }
 }
 
+/// The seekable `(slot, lower, upper)` of a non-negated `x BETWEEN lower AND
+/// upper` whose test `x` is a `slot` and whose bounds are integer literals — a
+/// two-sided range the seek reads directly off the sorted key, the same range
+/// `x >= lower AND x <= upper` would seek. A `NOT BETWEEN` (the complement is
+/// two disjoint runs, not one contiguous seek), a non-slot test, or a
+/// non-integer bound does not qualify, and the relation scans under the
+/// residual `between`.
+private func range(_ filter: Filter) -> (Int, Int, Int)? {
+  switch filter {
+  case let .between(.slot(slot), .constant(.integer(lower)),
+                    .constant(.integer(upper)), negated: false):
+    (slot, lower, upper)
+  default:
+    nil
+  }
+}
+
 extension Table where Self: ~Escapable {
   /// The boundaries `[lower, upper)` to seek for a sort-key comparison, or `nil`
   /// if `filter` does not qualify for the seek path.
@@ -1086,12 +1124,41 @@ extension Table where Self: ~Escapable {
   /// `string` operand or an unseekable column never qualifies, and the executor
   /// scans.
   ///
+  /// A first-class `x BETWEEN lower AND upper` (non-negated) whose test `x` is
+  /// the sort-key slot and whose bounds are integer literals seeks a two-sided
+  /// run — the intersection of the `x >= lower` and `x <= upper` partitions,
+  /// exactly the run the desugar would seek — as an ordered-only range. A `NOT
+  /// BETWEEN` (a two-run complement, not one contiguous seek), a non-slot test,
+  /// or a non-integer bound does not qualify; the residual `between` still runs
+  /// over the sought rows either way.
+  ///
   /// The hash-join executor reuses this over a pushed inner filter's conjuncts
   /// to seek the inner by a seekable conjunct before bucketing, so a
   /// seekable/contradictory inner filter reads few or no inner rows.
   internal borrowing func boundaries(_ filter: Filter, _ ordinals: Array<Int>,
                                      _ count: Int, _ bindings: Bindings)
       -> Range<Int>? {
+    // A first-class `x BETWEEN lower AND upper` seeks a two-sided run directly:
+    // the lower boundary is the `x >= lower` partition (inclusive, `strict`
+    // false) and the upper is the `x <= upper` partition (inclusive, `strict`
+    // true), so their intersection `lower ..< upper` is exactly the range the
+    // desugar `x >= lower AND x <= upper` would seek. As a range it seeks ONLY
+    // an ordered key — an unordered seekable column brackets an equality, not
+    // a range — and the residual `between` still runs over the sought rows.
+    if let (slot, low, high) = range(filter) {
+      guard ordered(ordinals[slot]),
+          let lower = bound(ordinals[slot], low, strict: false),
+          let upper = bound(ordinals[slot], high, strict: true) else {
+        return nil
+      }
+      // An inverted `BETWEEN lower AND upper` (lower > upper) is a valid EMPTY
+      // range: the `x >= lower` partition starts after the `x <= upper` one
+      // ends, so `lower > upper` here and `lower ..< upper` would trap Swift's
+      // `Range(lowerBound <= upperBound)` precondition. Seek an empty run.
+      guard lower <= upper else { return lower ..< lower }
+      return lower ..< upper
+    }
+
     guard let (slot, op, value) = comparison(filter, bindings),
         let lower = bound(ordinals[slot], value, strict: false),
         let upper = bound(ordinals[slot], value, strict: true) else {

--- a/Sources/SQL/Filter.swift
+++ b/Sources/SQL/Filter.swift
@@ -38,6 +38,14 @@ internal indirect enum Filter: Sendable {
   /// first TRUE; `NOT IN` negates that three-valued truth (UNKNOWN maps to
   /// itself).
   case membership(Term, Array<Term>, negated: Bool)
+  /// `x [NOT] BETWEEN a AND b` — the lowered form of the AST's `between`. The
+  /// test term `x` is held ONCE, the two bound terms `a` and `b` beside it, and
+  /// `negated` marks `NOT BETWEEN`. Evaluating it reads `x` once per row (an
+  /// `AND`/`OR` of two comparisons would re-evaluate a non-idempotent `x`, once
+  /// per bound) and folds `x >= a` AND `x <= b` (or `x < a` OR `x > b` when
+  /// negated) over the SAME `x` under Kleene logic, so a NULL `x`, `a`, or `b`
+  /// makes a bound UNKNOWN and the row is excluded.
+  case between(Term, Term, Term, negated: Bool)
   /// `lhs AND rhs`.
   case and(Filter, Filter)
   /// `lhs OR rhs`.
@@ -75,6 +83,21 @@ internal indirect enum Term: Sendable {
   /// schema advertises for the column — so the executor COERCES the selected
   /// value to it, widening an `.integer` arm of a `.double` CASE.
   case `case`(Array<(Filter, Term)>, else: Term?, type: ValueType)
+  /// `COALESCE(v1, v2, …)` — the lowered form of the AST's
+  /// `Expression.coalesce`. Each element term is evaluated IN ORDER exactly
+  /// ONCE, and the first whose value is non-NULL is the result, else NULL. A
+  /// desugar to a `CASE WHEN vi IS NOT NULL THEN vi …` re-evaluated each `vi`,
+  /// so a stateful element yielded a different value to its guard and its
+  /// result; holding the element ONCE (as `membership` holds its operand) fixes
+  /// that. `type` is the unification of the element types, to which the
+  /// selected value is COERCED — the type the schema advertises.
+  case coalesce(Array<Term>, type: ValueType)
+  /// `NULLIF(a, b)` — the lowered form of the AST's `Expression.nullif`. Both
+  /// operand terms are evaluated exactly ONCE (`va`, `vb`); the result is NULL
+  /// when `va = vb` is TRUE, else the SAME `va` that was compared. A desugar to
+  /// `CASE WHEN a = b THEN NULL ELSE a END` evaluated `a` twice — comparing one
+  /// value and returning another — which holding `a` ONCE fixes.
+  case nullif(Term, Term)
 }
 
 extension Term {
@@ -102,6 +125,13 @@ extension Term {
         result.references(into: &slots)
       }
       otherwise?.references(into: &slots)
+    case let .coalesce(elements, _):
+      for element in elements {
+        element.references(into: &slots)
+      }
+    case let .nullif(lhs, rhs):
+      lhs.references(into: &slots)
+      rhs.references(into: &slots)
     }
   }
 }
@@ -125,6 +155,10 @@ extension Term {
       .case(branches.map {
               ($0.0.remapped(through: slot), $0.1.remapped(through: slot))
             }, else: otherwise?.remapped(through: slot), type: type)
+    case let .coalesce(elements, type):
+      .coalesce(elements.map { $0.remapped(through: slot) }, type: type)
+    case let .nullif(lhs, rhs):
+      .nullif(lhs.remapped(through: slot), rhs.remapped(through: slot))
     }
   }
 
@@ -135,7 +169,7 @@ extension Term {
   internal var safe: Bool {
     switch self {
     case .slot, .constant: true
-    case .apply, .binary, .case: false
+    case .apply, .binary, .case, .coalesce, .nullif: false
     }
   }
 }
@@ -157,6 +191,9 @@ extension Filter {
       .membership(operand.remapped(through: slot),
                   elements.map { $0.remapped(through: slot) },
                   negated: negated)
+    case let .between(test, lower, upper, negated):
+      .between(test.remapped(through: slot), lower.remapped(through: slot),
+               upper.remapped(through: slot), negated: negated)
     case let .and(lhs, rhs):
       .and(lhs.remapped(through: slot), rhs.remapped(through: slot))
     case let .or(lhs, rhs):
@@ -230,6 +267,8 @@ extension Filter {
     case let .null(term, _): term.safe
     case let .membership(operand, elements, _):
       operand.safe && elements.allSatisfy(\.safe)
+    case let .between(test, lower, upper, _):
+      test.safe && lower.safe && upper.safe
     case let .and(lhs, rhs): lhs.safe && rhs.safe
     case let .or(lhs, rhs): lhs.safe && rhs.safe
     case let .not(operand): operand.safe
@@ -258,7 +297,7 @@ extension Filter {
   private var parameterised: Bool {
     switch self {
     case .bound: true
-    case .compare, .match, .null, .membership: false
+    case .compare, .match, .null, .membership, .between: false
     case let .and(lhs, rhs): lhs.parameterised || rhs.parameterised
     case let .or(lhs, rhs): lhs.parameterised || rhs.parameterised
     case let .not(operand): operand.parameterised
@@ -330,7 +369,50 @@ extension Row where Self: ~Escapable {
       // branch. The selected value is COERCED to the CASE's unified result
       // `type` so it matches the column type the schema advertised.
       try conditional(branches, otherwise, type, routines, bindings)
+    case let .coalesce(elements, type):
+      try coalesce(elements, type, routines, bindings)
+    case let .nullif(lhs, rhs):
+      try nullif(lhs, rhs, routines, bindings)
     }
+  }
+
+  /// Evaluates a lowered `COALESCE(v1, v2, …)` against this row — the
+  /// `elements` visited IN ORDER exactly ONCE, returning the first whose value
+  /// is non-NULL (coerced to the unified `type` the schema advertises), else
+  /// NULL.
+  ///
+  /// Each element is evaluated ONCE: a desugar to `CASE WHEN vi IS NOT NULL
+  /// THEN vi …` evaluated each `vi` twice — its guard and its result — so a
+  /// stateful element tested one value for NULL and returned another.
+  /// `Value.coerced` widens the selected value to `type` (a `.integer` element
+  /// of a `.double` COALESCE), exactly as a `CASE` coerces its taken branch;
+  /// NULL passes unchanged.
+  private borrowing func coalesce(_ elements: Array<Term>, _ type: ValueType,
+                                  _ routines: Routines, _ bindings: Bindings)
+      throws(SQLError) -> Value {
+    for element in elements {
+      let value = try evaluate(element, routines, bindings)
+      if case .null = value { continue }
+      return value.coerced(to: type)
+    }
+    return .null
+  }
+
+  /// Evaluates a lowered `NULLIF(a, b)` against this row — `a` and `b` each
+  /// evaluated ONCE — returning NULL when `a = b` is TRUE, else the SAME `va`
+  /// that was compared.
+  ///
+  /// A desugar to `CASE WHEN a = b THEN NULL ELSE a END` evaluated `a` twice —
+  /// once in the equality and once as the `ELSE` — so a stateful `a` compared
+  /// one value and returned another; holding `va` fixes that. `matches` is
+  /// three-valued: only a definite TRUE equality nulls out, so an UNKNOWN (a
+  /// NULL operand) yields `va`.
+  private borrowing func nullif(_ lhs: Term, _ rhs: Term,
+                                _ routines: Routines, _ bindings: Bindings)
+      throws(SQLError) -> Value {
+    let va = try evaluate(lhs, routines, bindings)
+    let vb = try evaluate(rhs, routines, bindings)
+    return matches(va, .equal, vb) == true ? .null : va
   }
 
   /// Evaluates a lowered `CASE` — its `branches` and optional `otherwise`
@@ -386,18 +468,26 @@ extension Row where Self: ~Escapable {
 extension Arithmetic {
   /// Applies the operator to two typed operands, yielding a typed `Value`.
   ///
-  /// The operands must be numeric — integer or double. An `integer ∘ integer`
-  /// stays an integer, with `/` integer division; any double operand makes the
-  /// result a double (a lone integer promoted to `Double`), with `/` real
-  /// division. A NULL on either side propagates — the result is NULL, not a
-  /// fault. A division by zero is `SQLError.divide`, as standard SQL raises
-  /// rather than yielding a value (`inf`/`NaN`), on either an integer or a
-  /// double divisor; a non-numeric (text/boolean/blob) operand is a
+  /// A `||` concatenates two text operands into one text value; the four
+  /// arithmetic operators require numeric operands — integer or double. An
+  /// `integer ∘ integer` stays an integer, with `/` integer division; any
+  /// double operand makes the result a double (a lone integer promoted to
+  /// `Double`), with `/` real division. A NULL on either side propagates — the
+  /// result is NULL, not a fault. A division by zero is `SQLError.divide`, as
+  /// standard SQL raises rather than yielding a value (`inf`/`NaN`), on either
+  /// an integer or a double divisor; an operand of the wrong kind (a
+  /// non-numeric arithmetic operand, or a non-text `||` operand) is a
   /// `SQLError.operand` type error rather than a silent coercion; an integer
   /// result past the `Int` boundary is `SQLError.magnitude`.
   internal func apply(_ lhs: Value, _ rhs: Value) throws(SQLError) -> Value {
     if case .null = lhs { return .null }
     if case .null = rhs { return .null }
+    if case .concatenate = self {
+      guard case let .text(lhs) = lhs, case let .text(rhs) = rhs else {
+        throw .operand("|| operands must be text")
+      }
+      return .text(lhs + rhs)
+    }
     return switch (lhs, rhs) {
     case let (.integer(lhs), .integer(rhs)):
       try apply(lhs, rhs)
@@ -427,6 +517,10 @@ extension Arithmetic {
     case .multiply: lhs.multipliedReportingOverflow(by: rhs)
     case .divide where rhs == 0: throw .divide
     case .divide: lhs.dividedReportingOverflow(by: rhs)
+    // `||` never reaches the numeric path — the public `apply` handles it over
+    // text before dispatching a numeric pair here — so a concatenate over two
+    // integers is an unreachable operand fault.
+    case .concatenate: throw .operand("|| operands must be text")
     }
     guard !outcome.overflow else { throw .magnitude("integer overflow") }
     return .integer(outcome.partialValue)
@@ -449,6 +543,9 @@ extension Arithmetic {
     case .multiply: lhs * rhs
     case .divide where rhs == 0: throw .divide
     case .divide: lhs / rhs
+    // `||` never reaches the numeric path — the public `apply` handles it over
+    // text — so a concatenate over two doubles is an unreachable operand fault.
+    case .concatenate: throw .operand("|| operands must be text")
     }
     guard result.isFinite else {
       throw .magnitude("double result is not finite")
@@ -573,6 +670,8 @@ extension Row where Self: ~Escapable {
       try (evaluate(term, routines, bindings) == .null) != negated
     case let .membership(operand, elements, negated):
       try member(operand, elements, negated, routines, bindings)
+    case let .between(test, lower, upper, negated):
+      try ranged(test, lower, upper, negated, routines, bindings)
     case let .and(lhs, rhs):
       // `&&`/`||` take an `@autoclosure` right operand, which would capture the
       // borrowed `~Escapable` row; spell each connective explicitly so a branch
@@ -618,5 +717,40 @@ extension Row where Self: ~Escapable {
       if truth == true { break }
     }
     return negated ? truth.map { !$0 } : truth
+  }
+
+  /// Evaluates a lowered `test [NOT] BETWEEN lower AND upper` against this row.
+  ///
+  /// The `test` term is evaluated ONCE per row — an `AND`/`OR` of two
+  /// comparisons would re-evaluate a non-idempotent test once per bound — then
+  /// the two bounds against that SAME value fold under Kleene logic: `test >=
+  /// lower` AND `test <= upper` for BETWEEN, or `test < lower` OR `test >
+  /// upper` for `NOT BETWEEN`. A NULL `test`, `lower`, or `upper` makes a bound
+  /// UNKNOWN (`matches` yields `nil`), so the row is excluded — the ISO
+  /// three-valued range semantics.
+  ///
+  /// The `upper` bound is evaluated ONLY when the lower truth requires it, as
+  /// the documented `AND`/`OR` expansion short-circuits: a definitely-FALSE
+  /// `test >= lower` makes BETWEEN FALSE (Kleene `AND`), and a definitely-TRUE
+  /// `test < lower` makes `NOT BETWEEN` TRUE (Kleene `OR`), each skipping the
+  /// `upper` term — and any error it would raise — exactly as the desugar
+  /// would. Deferring keeps the row rejecting on `0 BETWEEN 1 AND (1 / 0)`
+  /// rather than faulting on an upper the lower already settled.
+  private borrowing func ranged(_ test: Term, _ lower: Term, _ upper: Term,
+                                _ negated: Bool, _ routines: Routines,
+                                _ bindings: Bindings)
+      throws(SQLError) -> Bool? {
+    let value = try evaluate(test, routines, bindings)
+    let low = try evaluate(lower, routines, bindings)
+    if negated {
+      let below = matches(value, .lt, low)
+      guard below != true else { return true }
+      let high = try evaluate(upper, routines, bindings)
+      return or(below, matches(value, .gt, high))
+    }
+    let above = matches(value, .geq, low)
+    guard above != false else { return false }
+    let high = try evaluate(upper, routines, bindings)
+    return and(above, matches(value, .leq, high))
   }
 }

--- a/Sources/SQL/Lexer.swift
+++ b/Sources/SQL/Lexer.swift
@@ -109,6 +109,17 @@ internal struct Lexer: ~Escapable {
     case UInt8(ascii: "="):
       return punctuation(.equal)
 
+    // The `||` concatenation operator: two `|` bytes. A lone `|` begins no
+    // token in this dialect, so a single `|` faults where it sits.
+    case UInt8(ascii: "|"):
+      let start = location
+      advance()
+      guard peek() == UInt8(ascii: "|") else {
+        throw .character("|", at: start)
+      }
+      advance()
+      return Token(kind: .concat, location: start)
+
     case UInt8(ascii: "<"):
       let start = location
       advance()
@@ -425,6 +436,7 @@ internal struct Lexer: ~Escapable {
     case "IS": .is
     case "NULL": .null
     case "IN": .in
+    case "BETWEEN": .between
     case "UNION": .union
     case "INTERSECT": .intersect
     case "EXCEPT": .except

--- a/Sources/SQL/Parser.swift
+++ b/Sources/SQL/Parser.swift
@@ -36,14 +36,17 @@
 /// negation       := NOT negation | primary
 /// primary        := '(' predicate ')' | comparison
 /// comparison     := expression (op (expression | param) | IS [NOT] NULL
-///                 | [NOT] IN '(' expression (',' expression)* ')')
+///                 | [NOT] IN '(' expression (',' expression)* ')'
+///                 | [NOT] BETWEEN expression AND expression)
 /// expression     := additive
-/// additive       := multiplicative (('+' | '-') multiplicative)*
+/// additive       := multiplicative (('+' | '-' | '||') multiplicative)*
 /// multiplicative := factor (('*' | '/') factor)*
-/// factor         := '(' expression ')' | case
+/// factor         := '(' expression ')' | case | coalesce | nullif
 ///                 | literal | aggregate | call | column
 /// case           := CASE [expression] (WHEN (predicate | expression) THEN
 ///                     expression)+ [ELSE expression] END
+/// coalesce       := COALESCE '(' expression (',' expression)+ ')'
+/// nullif         := NULLIF '(' expression ',' expression ')'
 /// literal        := string | integer | decimal | TRUE | FALSE | blob
 /// blob           := ('x' | 'X') "'" (hex hex)* "'"  // whole bytes
 /// aggregate      := COUNT '(' '*' ')'
@@ -56,9 +59,14 @@
 /// identifier     := word | '"' … '"'  // a delimited identifier is verbatim
 /// ```
 ///
-/// Arithmetic precedence is `*` `/` > `+` `-`, both levels left-associative; the
-/// cascade of `additive`/`multiplicative` encodes it, and parentheses override
-/// it through `factor`.
+/// Arithmetic precedence is `*` `/` > `+` `-` `||`, both levels
+/// left-associative; the cascade of `additive`/`multiplicative` encodes it (the
+/// `||` string concatenation sharing the additive tier), and parentheses
+/// override it through `factor`. `COALESCE`/`NULLIF` and `[NOT] BETWEEN` are
+/// the ISO-defined `CASE` expansions and range test, each parsed to a
+/// first-class AST node (`coalesce`/`nullif`/`between`) rather than the
+/// CASE/comparison expansion so its operands are evaluated ONCE, not
+/// re-referenced.
 ///
 /// A `column` is a single identifier token; a qualifying dot (`t.Name`) is part
 /// of the identifier the lexer scans, so `Column(_:)` splits it into qualifier
@@ -505,7 +513,12 @@ internal struct Parser: ~Escapable {
     try additive()
   }
 
-  /// Parses `multiplicative (('+' | '-') multiplicative)*`, left-associative.
+  /// Parses `multiplicative (('+' | '-' | '||') multiplicative)*`,
+  /// left-associative.
+  ///
+  /// The ISO `||` string concatenation shares this additive precedence tier and
+  /// left-associativity, so `a || b || c` reads left to right and `a + b || c`
+  /// groups `(a + b) || c` — both binding looser than `*`/`/`.
   private mutating func additive() throws(SQLError) -> Expression {
     var lhs = try multiplicative()
     while true {
@@ -513,6 +526,8 @@ internal struct Parser: ~Escapable {
         .add
       } else if try match(.minus) {
         .subtract
+      } else if try match(.concat) {
+        .concatenate
       } else {
         nil
       }
@@ -595,6 +610,19 @@ internal struct Parser: ~Escapable {
       return try .aggregate(aggregate, of: aggregand(aggregate))
     }
 
+    // `COALESCE`/`NULLIF` are ISO-defined expansions of a searched `CASE`, each
+    // recognised case-insensitively only when written bare (a delimited
+    // `"COALESCE"` is a scalar-call name). Desugar into the `CASE` AST here —
+    // the `(` is consumed — so the conditional's type unification, coercion,
+    // and reachability apply unchanged.
+    if !ident.quoted {
+      switch ident.text.uppercased() {
+      case "COALESCE": return try coalesce()
+      case "NULLIF": return try nullif()
+      default: break
+      }
+    }
+
     var arguments = Array<Expression>()
     if current?.kind != .rparen {
       try arguments.append(expression())
@@ -673,6 +701,45 @@ internal struct Parser: ~Escapable {
     return .case(whens, else: otherwise)
   }
 
+  /// Parses the argument tail of `COALESCE(v1, v2, …)` — the `(` is already
+  /// consumed — into the first-class `Expression.coalesce`.
+  ///
+  /// ISO 9075 defines `COALESCE(v1, v2, …)` as `CASE WHEN v1 IS NOT NULL THEN
+  /// v1 WHEN v2 IS NOT NULL THEN v2 … ELSE NULL END`, but that expansion
+  /// re-references each `vi` in both its guard and its `THEN`, evaluating a
+  /// stateful argument twice — so this builds the first-class node the engine
+  /// evaluates each argument ONCE for, inheriting the same type unification and
+  /// coercion the CASE would. At least two arguments are required — `COALESCE`
+  /// of one value is the value itself and carries no meaning — else
+  /// `SQLError.argument`.
+  private mutating func coalesce() throws(SQLError) -> Expression {
+    var arguments = try [expression()]
+    while try match(.comma) {
+      try arguments.append(expression())
+    }
+    try expect(.rparen)
+    guard arguments.count >= 2 else {
+      throw .argument("COALESCE requires at least two arguments")
+    }
+    return .coalesce(arguments)
+  }
+
+  /// Parses the argument tail of `NULLIF(v1, v2)` — the `(` is already consumed
+  /// — into the first-class `Expression.nullif`.
+  ///
+  /// ISO 9075 defines `NULLIF(v1, v2)` as `CASE WHEN v1 = v2 THEN NULL ELSE v1
+  /// END`, but that expansion embeds `v1` in both the equality and the `ELSE`,
+  /// evaluating a stateful `v1` twice — so this builds the first-class node the
+  /// engine evaluates `v1` ONCE for. It takes exactly two arguments (else
+  /// `SQLError.argument`).
+  private mutating func nullif() throws(SQLError) -> Expression {
+    let left = try expression()
+    try expect(.comma)
+    let right = try expression()
+    try expect(.rparen)
+    return .nullif(left, right)
+  }
+
   // MARK: - Predicate
 
   /// Parses a predicate at the lowest precedence (`OR`).
@@ -732,7 +799,8 @@ internal struct Parser: ~Escapable {
   }
 
   /// Parses `expression (op (expression | :parameter) | IS [NOT] NULL | [NOT]
-  /// IN '(' expression (',' expression)* ')')`.
+  /// IN '(' expression (',' expression)* ')' | [NOT] BETWEEN expression AND
+  /// expression)`.
   ///
   /// Either operand may be a column, a literal, or a scalar-function call, so a
   /// predicate can filter on a decoded value (`WHERE guid(Id) = '…'`). A
@@ -741,8 +809,10 @@ internal struct Parser: ~Escapable {
   /// `IS NULL` (or `IS NOT NULL`) tail tests the left expression for `NULL`
   /// rather than comparing it — the way a nullable column is filtered. An `IN`
   /// (or `NOT IN`) tail tests the left expression for membership in a
-  /// parenthesised value list. A leading `NOT` here can only introduce `NOT IN`:
-  /// a prefix `NOT` predicate is consumed by `negation` before this point.
+  /// parenthesised value list. A `BETWEEN a AND b` (or `NOT BETWEEN`) tail is
+  /// the ISO range test, desugared into a conjunction (or disjunction) of
+  /// bounds. A leading `NOT` here introduces `NOT IN` or `NOT BETWEEN`: a
+  /// prefix `NOT` predicate is consumed by `negation` before this point.
   private mutating func comparison() throws(SQLError) -> Predicate {
     let left = try expression()
     if try match(.is) {
@@ -753,7 +823,13 @@ internal struct Parser: ~Escapable {
     if try match(.in) {
       return try membership(left, negated: false)
     }
+    if try match(.between) {
+      return try between(left, negated: false)
+    }
     if try match(.not) {
+      if try match(.between) {
+        return try between(left, negated: true)
+      }
       try expect(.in)
       return try membership(left, negated: true)
     }
@@ -782,6 +858,24 @@ internal struct Parser: ~Escapable {
     }
     try expect(.rparen)
     return .membership(left, values, negated: negated)
+  }
+
+  /// Parses the bounds tail of `left [NOT] BETWEEN a AND b` — the `BETWEEN` is
+  /// already consumed — into the first-class `Predicate.between`.
+  ///
+  /// ISO 9075 defines `x BETWEEN a AND b` as `x >= a AND x <= b` (an inclusive
+  /// range) and `x NOT BETWEEN a AND b` as its negation `x < a OR x > b`, but
+  /// that expansion duplicates `x` across both bound comparisons, evaluating a
+  /// stateful `x` twice — so this parses the two bound expressions around the
+  /// `AND` keyword and builds the first-class node the engine evaluates `x`
+  /// ONCE for, keeping the same three-valued NULL semantics (a NULL `x`, `a`,
+  /// or `b` makes a bound UNKNOWN, and the row is excluded).
+  private mutating func between(_ left: Expression, negated: Bool)
+      throws(SQLError) -> Predicate {
+    let lower = try expression()
+    try expect(.and)
+    let upper = try expression()
+    return .between(left, lower, upper, negated: negated)
   }
 
   /// Parses a comparison operator.

--- a/Sources/SQL/Resolve.swift
+++ b/Sources/SQL/Resolve.swift
@@ -46,6 +46,13 @@ private func lower(_ predicate: Predicate,
     // UNKNOWN is UNKNOWN — not FALSE, and `NOT` maps that UNKNOWN to itself, so
     // `NOT IN` a list holding NULL is never TRUE.
     try membership(term(expression), values, negated: negated, term: term)
+  case let .between(test, lower, upper, negated):
+    // `x [NOT] BETWEEN a AND b` lowers to a first-class `Filter.between` that
+    // evaluates the test `x` ONCE per row (an `AND`/`OR` of two comparisons
+    // would re-evaluate a non-idempotent `x`, once per bound) and folds the two
+    // bounds against that same value under Kleene logic — a NULL `x`, `a`, or
+    // `b` making a bound UNKNOWN and excluding the row, the ISO range test.
+    try .between(term(test), term(lower), term(upper), negated: negated)
   case let .and(lhs, rhs):
     try .and(lower(lhs, term: term), lower(rhs, term: term))
   case let .or(lhs, rhs):
@@ -195,6 +202,24 @@ extension Schema {
       let scope = Scope([(relation, self)])
       let type = try scope.derive(whens, otherwise, routines)
       return .case(branches, else: fallback, type: type)
+    case let .coalesce(arguments):
+      // Lower each argument to a `Term` over this relation and hold them in a
+      // first-class `Term.coalesce` so each is evaluated ONCE. `type` is the
+      // unified argument type the selected value coerces to, derived against a
+      // one-relation scope.
+      var elements = Array<Term>()
+      elements.reserveCapacity(arguments.count)
+      for argument in arguments {
+        try elements.append(term(argument, in: relation, routines))
+      }
+      let scope = Scope([(relation, self)])
+      let type = try scope.derive(expression, routines)
+      return .coalesce(elements, type: type)
+    case let .nullif(lhs, rhs):
+      // Lower both operands to `Term`s over this relation and hold them in a
+      // first-class `Term.nullif` so each is evaluated ONCE.
+      return try .nullif(term(lhs, in: relation, routines),
+                         term(rhs, in: relation, routines))
     case .aggregate:
       // An aggregate has no per-row meaning — it folds over a group — so it may
       // not appear in a `WHERE`, a join `ON`, or a non-aggregate projection.
@@ -341,6 +366,11 @@ internal struct Scope {
         case let .expression(argument): try derive(argument, routines)
         }
       }
+    case let .binary(.concatenate, lhs, rhs):
+      // `||` yields text; the operands' own types do not shape it, but derive
+      // both for resolution — an unresolved column faults `SQLError.column`
+      // (`Missing || 'x'`) — exactly as the arithmetic `.binary` branch does.
+      try concatenation(lhs, rhs, routines)
     case let .binary(_, lhs, rhs):
       try [derive(lhs, routines), derive(rhs, routines)].contains(.double)
           ? .double : .integer
@@ -356,7 +386,91 @@ internal struct Scope {
       // reachable `ELSE`) the run yields NULL, for which `.integer` is the
       // schema default.
       try derive(whens, otherwise, routines)
+    case let .coalesce(arguments):
+      // The result type is the unification of the arguments (the same
+      // `ValueType.unified` reduction a `CASE`'s results take), the type the
+      // selected value coerces to.
+      try unified(arguments, routines)
+    case let .nullif(lhs, _):
+      // NULLIF yields either `v1` or NULL, so the column takes `v1`'s type.
+      try derive(lhs, routines)
     }
+  }
+
+  /// The `.text` type of `lhs || rhs`, deriving both operands for resolution
+  /// first: the result is always text and the operands' own types do not shape
+  /// it, but an unresolved column still faults `SQLError.column`, mirroring the
+  /// arithmetic `.binary` derive branch.
+  private func concatenation(_ lhs: Expression, _ rhs: Expression,
+                             _ routines: Routines)
+      throws(SQLError) -> ValueType {
+    _ = try derive(lhs, routines)
+    _ = try derive(rhs, routines)
+    return .text
+  }
+
+  /// The unification of the types of `arguments` — the `ValueType.unified`
+  /// reduction a `CASE`'s reachable results and a `COALESCE`'s arguments both
+  /// take. A definitively-irreconcilable pair (a text beside an integer) faults
+  /// `SQLError.operand`; a mixed integer/double pair widens to `double`. The
+  /// list is never empty (the parser requires ≥ 2 COALESCE arguments).
+  ///
+  /// Only a SELECTABLE argument shapes the type. A run skips an argument
+  /// whose value is NULL and moves on, so an argument folding to a constant
+  /// `.null` (`constant(_ expression:)`) can NEVER be the result — its type is
+  /// derived (an unknown column still faults) but is NOT merged, exactly as a
+  /// `CASE` omits an unreachable branch's result type. And an argument that is
+  /// the definite selection (`selects(_:)` — a constant NON-NULL value, or a
+  /// `COUNT` aggregate that is always non-NULL) sets the type and makes every
+  /// LATER argument unreachable — mirroring a `CASE`'s reachable-branch
+  /// unification and the faulting `validate`'s stop.
+  private func unified(_ arguments: Array<Expression>,
+                       _ routines: Routines) throws(SQLError) -> ValueType {
+    var type: ValueType?
+    for argument in arguments {
+      let next = try derive(argument, routines)
+      if case .some(.null) = constant(argument, routines) {
+        // A constant NULL is derived (for its errors) but skipped: it can never
+        // be returned, so its type must not shape the column.
+        continue
+      }
+      guard !selects(argument, routines) else {
+        // A definite selection: merge its type and stop, as every later
+        // argument is unreachable.
+        return try merged(type, next)
+      }
+      type = try merged(type, next)
+    }
+    return type ?? .integer
+  }
+
+  /// Whether `argument` is a COALESCE's definite selection — an argument the
+  /// executor's short-circuit is GUARANTEED to return, making every later
+  /// argument unreachable (neither validated nor unified). That holds when it
+  /// folds to a constant NON-NULL value (`constant(_ expression:)`), or when it
+  /// is a `COUNT` aggregate: `COUNT` alone among the aggregates always yields a
+  /// row count of 0 or more, never NULL, so it always selects — while `SUM` /
+  /// `MIN` / `MAX` / `AVG` are NULL over an empty group and so do NOT stop.
+  private func selects(_ argument: Expression, _ routines: Routines) -> Bool {
+    return switch argument {
+    case .aggregate(.count, _): true
+    default: constant(argument, routines).map { $0 != .null } ?? false
+    }
+  }
+
+  /// The unification of a COALESCE's running result type with the `next`
+  /// selectable argument's type — `next` when there is no running type yet,
+  /// else their `ValueType.unified`, faulting `SQLError.operand` on an
+  /// irreconcilable pair (a text beside an integer). Shared by the `derive`
+  /// (`unified`) and `validate` (`coalesce`) surfaces so both merge only a
+  /// selectable argument's type identically.
+  private func merged(_ running: ValueType?, _ next: ValueType)
+      throws(SQLError) -> ValueType {
+    guard let running else { return next }
+    guard let unified = running.unified(with: next) else {
+      throw .operand("COALESCE arguments have irreconcilable types")
+    }
+    return unified
   }
 
   /// The nominal type of a `CASE` under `derive` — the unification of its
@@ -433,7 +547,65 @@ internal struct Scope {
       try arithmetic(op, lhs, rhs, routines)
     case let .case(whens, otherwise):
       try conditional(whens, otherwise, routines)
+    case let .coalesce(arguments):
+      try coalesce(arguments, routines)
+    case let .nullif(lhs, rhs):
+      try nullif(lhs, rhs, routines)
     }
+  }
+
+  /// The result type of `COALESCE(v1, v2, …)`, validating each REACHABLE
+  /// argument as a run would fault and unifying only the SELECTABLE ones'
+  /// types (`merged`). A definitively-irreconcilable pair (a text argument
+  /// beside an integer) faults `SQLError.operand`, as the column cannot be two
+  /// kinds; a mixed integer/double pair widens to `double`.
+  ///
+  /// The executor returns the first NON-NULL argument and never evaluates a
+  /// later one, so an argument that is the definite selection (`selects(_:)` —
+  /// a constant NON-NULL value, or a `COUNT` aggregate that is always non-NULL)
+  /// makes every LATER argument unreachable — those are NOT validated
+  /// (`COALESCE(1, missing_udf())` and `COALESCE(COUNT(*), missing_udf())` both
+  /// type-check), exactly as a constant-TRUE `CASE` guard makes later branches
+  /// unreachable.
+  ///
+  /// An argument that folds to a constant `.null` is validated (for its own
+  /// errors) but its type is NOT merged: a run skips a NULL and moves on, so
+  /// that argument can never be returned — merging its declared type would
+  /// reject `COALESCE(null_text(), 1)`, a text arm that can only yield the
+  /// integer, exactly as a `CASE` omits a skipped branch's result type. An
+  /// undecidable argument (`nil`) may be selected, so its type is merged and
+  /// the walk continues.
+  private func coalesce(_ arguments: Array<Expression>, _ routines: Routines)
+      throws(SQLError) -> ValueType {
+    var type: ValueType?
+    for argument in arguments {
+      let next = try validate(argument, routines)
+      if case .some(.null) = constant(argument, routines) {
+        // A constant NULL is validated (for its errors) but skipped: it can
+        // never be returned, so its type must not shape the column.
+        continue
+      }
+      guard !selects(argument, routines) else {
+        // A definite selection: merge its type and stop, as every later
+        // argument is unreachable and unvalidated.
+        return try merged(type, next)
+      }
+      type = try merged(type, next)
+    }
+    return type ?? .integer
+  }
+
+  /// The result type of `NULLIF(v1, v2)`, validating both operands as a run
+  /// would fault. The result is either `v1` or NULL, so the column takes `v1`'s
+  /// type; `v2` need not unify with it (a run compares them under `matches`,
+  /// which yields FALSE across kinds without faulting), so it is validated for
+  /// its own errors (an unknown column, a bad call) but does not shape the
+  /// type.
+  private func nullif(_ lhs: Expression, _ rhs: Expression,
+                      _ routines: Routines) throws(SQLError) -> ValueType {
+    let type = try validate(lhs, routines)
+    _ = try validate(rhs, routines)
+    return type
   }
 
   /// The result type of a `CASE`, validating each REACHABLE branch as a run
@@ -555,10 +727,12 @@ internal struct Scope {
     }
   }
 
-  /// The result type of `lhs op rhs` — a double when either operand is a double
-  /// (`Age + 1.5`), else an integer — validating both operands are numeric (a
-  /// text/boolean/blob operand has no arithmetic — `Arithmetic.apply` faults
-  /// `SQLError.operand`); a `/` by a literal zero is rejected up front
+  /// The result type of `lhs op rhs` — a double when either arithmetic operand
+  /// is a double (`Age + 1.5`), an integer for two integer operands, and text
+  /// for `||` — validating each operand's kind as a run would fault: an
+  /// arithmetic operator over a text/boolean/blob operand has no arithmetic and
+  /// `||` over a non-text operand has no concatenation (`Arithmetic.apply`
+  /// faults `SQLError.operand`); a `/` by a literal zero is rejected up front
   /// (`SQLError.divide`); and two literal operands are folded to reject a
   /// deterministic overflow (`SQLError.magnitude`). Typing thus faults as a run
   /// would rather than advertise a header no row can produce.
@@ -568,6 +742,14 @@ internal struct Scope {
       throws(SQLError) -> ValueType {
     let left = try validate(lhs, routines)
     let right = try validate(rhs, routines)
+    if case .concatenate = op {
+      // `||` joins two text operands into a text result; a non-text operand
+      // faults exactly as `Arithmetic.apply` does at run time.
+      guard left == .text, right == .text else {
+        throw .operand("|| operands must be text")
+      }
+      return .text
+    }
     guard left.numeric, right.numeric else {
       throw .operand("operands must be numeric")
     }
@@ -650,6 +832,31 @@ internal struct Scope {
       }, equality: { value throws(SQLError) in
         matched(operand, value, routines)
       })
+    case let .between(test, lower, upper, negated):
+      // `x [NOT] BETWEEN a AND b` compares `x` against both bounds, so validate
+      // the three operands for real errors (an unknown column, a bad call). A
+      // cross-kind bound is NOT rejected: the run's `matches` yields FALSE
+      // across kinds without faulting (as an `IN` element does), so the schema
+      // check accepts what the run accepts.
+      //
+      // It respects the executor's short-circuit — the same one `ranged`
+      // evaluates with: a DEFINITELY-FALSE lower comparison (`x >= a`) settles
+      // BETWEEN FALSE, and a DEFINITELY-TRUE one (`x < a`) settles a `NOT
+      // BETWEEN` TRUE, each leaving `upper` unreachable, so `upper` is NOT
+      // validated — `0 BETWEEN 1 AND (1 / 0)` type-checks, the lower `0 >= 1`
+      // FALSE settling the row before the `1 / 0` upper is reached, exactly as
+      // an `AND`'s constant-false left leaves its right unchecked.
+      _ = try validate(test, routines)
+      _ = try validate(lower, routines)
+      let settled = {
+        guard let value = constant(test, routines),
+            let low = constant(lower, routines) else {
+          return false
+        }
+        return negated ? matches(value, .lt, low) == true
+                       : matches(value, .geq, low) == false
+      }()
+      if !settled { _ = try validate(upper, routines) }
     case let .and(lhs, rhs):
       try check(lhs, routines)
       if constant(lhs, routines) != false { try check(rhs, routines) }
@@ -739,6 +946,35 @@ internal struct Scope {
       }
       guard let otherwise else { return .null }
       return constant(otherwise, routines)
+    case let .coalesce(arguments):
+      // Fold as the run evaluates it — the first argument that folds to a
+      // non-NULL value (COERCED to the unified type, as the executor's
+      // `Term.coalesce` coerces the selected value), else NULL when every
+      // argument folds NULL. An argument the fold cannot decide (`nil`) BEFORE
+      // a decisive non-NULL one means the taken value is per row, so the whole
+      // `COALESCE` is `nil`. Coercing an `.integer` selected from a COALESCE
+      // that unifies to `.double` folds to `.double`, matching the advertised
+      // column type — so a `.double`-typed routine over `COALESCE(1, 2.5)`
+      // folds against the SAME value the run supplies. The unified type is the
+      // one `derive`/`unified` already reduces over the selectable arguments;
+      // an irreconcilable pair (which `derive` would fault on) leaves the value
+      // uncoerced (`try?` → `nil`), a no-op the executor never reaches.
+      let type = try? unified(arguments, routines)
+      for argument in arguments {
+        guard let value = constant(argument, routines) else { return nil }
+        if case .null = value { continue }
+        return type.map { value.coerced(to: $0) } ?? value
+      }
+      return .null
+    case let .nullif(lhs, rhs):
+      // Fold as the run evaluates it — NULL when `v1 = v2` folds definitely
+      // TRUE, else `v1`; a side the fold cannot decide leaves it per row
+      // (`nil`).
+      guard let va = constant(lhs, routines),
+          let vb = constant(rhs, routines) else {
+        return nil
+      }
+      return matches(va, .equal, vb) == true ? .null : va
     case .column, .aggregate:
       return nil
     }
@@ -825,6 +1061,28 @@ internal struct Scope {
         matched(operand, value, routines)
       }
       return negated ? truth.map { !$0 } : truth
+    case let .between(test, lower, upper, negated):
+      // Fold `x [NOT] BETWEEN a AND b` as `ranged` evaluates it — the folded
+      // `x` against the folded lower first, short-circuiting before the upper:
+      // a definitely-FALSE lower (`x >= a`) settles BETWEEN FALSE and a
+      // definitely-TRUE lower (`x < a`) settles `NOT BETWEEN` TRUE, each
+      // WITHOUT folding the upper — and any fault it carries — so
+      // `0 BETWEEN 1 AND (1 / 0)` folds definitely FALSE rather than `nil`. A
+      // side the fold cannot decide leaves it per row (`nil`).
+      guard let value = constant(test, routines),
+          let low = constant(lower, routines) else {
+        return nil
+      }
+      if negated {
+        let below = matches(value, .lt, low)
+        if below == true { return true }
+        guard let high = constant(upper, routines) else { return nil }
+        return or(below, matches(value, .gt, high))
+      }
+      let above = matches(value, .geq, low)
+      if above == false { return false }
+      guard let high = constant(upper, routines) else { return nil }
+      return and(above, matches(value, .leq, high))
     case .bound:
       return nil
     }
@@ -855,6 +1113,11 @@ internal struct Scope {
         try aggregates(in: branch.then, routines)
       }
       if let otherwise { try aggregates(in: otherwise, routines) }
+    case let .coalesce(arguments):
+      for argument in arguments { try aggregates(in: argument, routines) }
+    case let .nullif(lhs, rhs):
+      try aggregates(in: lhs, routines)
+      try aggregates(in: rhs, routines)
     }
   }
 
@@ -877,6 +1140,10 @@ internal struct Scope {
     case let .membership(operand, values, _):
       try aggregates(in: operand, routines)
       for value in values { try aggregates(in: value, routines) }
+    case let .between(test, lower, upper, _):
+      try aggregates(in: test, routines)
+      try aggregates(in: lower, routines)
+      try aggregates(in: upper, routines)
     case let .and(lhs, rhs), let .or(lhs, rhs):
       try aggregates(in: lhs, routines)
       try aggregates(in: rhs, routines)
@@ -935,6 +1202,24 @@ internal struct Scope {
       }
       guard let otherwise else { return .null }
       return try empty(otherwise, routines).coerced(to: type)
+    case let .coalesce(arguments):
+      // Evaluate the empty group as a run does — the first argument that folds
+      // to a non-NULL value (coerced to the unified type, as the executor
+      // coerces the selected value), else NULL. A NULL argument propagates
+      // without faulting; a later one is not reached once a non-NULL is taken.
+      let type = try unified(arguments, routines)
+      for argument in arguments {
+        let value = try empty(argument, routines)
+        if case .null = value { continue }
+        return value.coerced(to: type)
+      }
+      return .null
+    case let .nullif(lhs, rhs):
+      // Evaluate the empty group as a run does — NULL when `v1 = v2` is TRUE,
+      // else the folded `v1`.
+      let va = try empty(lhs, routines)
+      let vb = try empty(rhs, routines)
+      return matches(va, .equal, vb) == true ? .null : va
     case .column:
       return .null
     }
@@ -981,6 +1266,24 @@ internal struct Scope {
         matches(lhs, .equal, try empty(value, routines))
       }
       return negated ? truth.map { !$0 } : truth
+    case let .between(test, lower, upper, negated):
+      // Fold `x [NOT] BETWEEN a AND b` over the empty group as `ranged` does —
+      // the folded `x` against the folded lower first, short-circuiting before
+      // the upper: a definitely-FALSE lower (`x >= a`) settles BETWEEN FALSE
+      // and a definitely-TRUE lower (`x < a`) settles `NOT BETWEEN` TRUE, each
+      // leaving the upper unfolded — and any fault it would raise unraised —
+      // so `HAVING 0 BETWEEN 1 AND (1 / 0)` drops the group without a `.divide`
+      // fault, exactly as the run does.
+      let value = try empty(test, routines)
+      let low = try empty(lower, routines)
+      if negated {
+        let below = matches(value, .lt, low)
+        if below == true { return true }
+        return or(below, matches(value, .gt, try empty(upper, routines)))
+      }
+      let above = matches(value, .geq, low)
+      if above == false { return false }
+      return and(above, matches(value, .leq, try empty(upper, routines)))
     case let .and(lhs, rhs):
       // A `false` left proves the `AND` false without folding the right arm,
       // which a run's short-circuit never evaluates and so must not fault.
@@ -1094,6 +1397,21 @@ internal struct Scope {
       // branch's value to the type the schema advertises.
       let type = try derive(whens, otherwise, routines)
       return .case(branches, else: fallback, type: type)
+    case let .coalesce(arguments):
+      // Lower each argument to a combined-ordinal `Term` and hold them in a
+      // first-class `Term.coalesce` so each is evaluated ONCE; `type` is the
+      // unified argument type the selected value coerces to.
+      var elements = Array<Term>()
+      elements.reserveCapacity(arguments.count)
+      for argument in arguments {
+        try elements.append(term(argument, routines))
+      }
+      let type = try derive(expression, routines)
+      return .coalesce(elements, type: type)
+    case let .nullif(lhs, rhs):
+      // Lower both operands to combined-ordinal `Term`s and hold them in a
+      // first-class `Term.nullif` so each is evaluated ONCE.
+      return try .nullif(term(lhs, routines), term(rhs, routines))
     case .aggregate:
       // An aggregate has no per-row meaning — it folds over a group — so it may
       // not appear in a `WHERE`, a join `ON`, or a non-aggregate projection.
@@ -1298,6 +1616,21 @@ internal struct Grouping {
       // COERCES the selected branch's value to the advertised column type.
       let type = try scope.derive(whens, otherwise, routines)
       return .case(branches, else: fallback, type: type)
+    case let .coalesce(arguments):
+      // Lower each argument to a grouped-space `Term` and hold them in a
+      // first-class `Term.coalesce` so each is evaluated ONCE; `type` is the
+      // unified argument type (over the grouped scope) the value coerces to.
+      var elements = Array<Term>()
+      elements.reserveCapacity(arguments.count)
+      for argument in arguments {
+        try elements.append(term(argument, routines))
+      }
+      let type = try scope.derive(expression, routines)
+      return .coalesce(elements, type: type)
+    case let .nullif(lhs, rhs):
+      // Lower both operands to grouped-space `Term`s and hold them in a
+      // first-class `Term.nullif` so each is evaluated ONCE.
+      return try .nullif(term(lhs, routines), term(rhs, routines))
     case .aggregate:
       // An aggregate reaches here only when it was not collected — an internal
       // inconsistency, since the query gathers every projection/HAVING aggregate.
@@ -1429,6 +1762,10 @@ extension Filter {
       for element in elements {
         element.references(into: &ordinals)
       }
+    case let .between(test, lower, upper, _):
+      test.references(into: &ordinals)
+      lower.references(into: &ordinals)
+      upper.references(into: &ordinals)
     case let .and(lhs, rhs), let .or(lhs, rhs):
       lhs.references(into: &ordinals)
       rhs.references(into: &ordinals)

--- a/Sources/SQL/Token.swift
+++ b/Sources/SQL/Token.swift
@@ -50,6 +50,7 @@ extension Token {
     case `is`
     case null
     case `in`
+    case between
     case union
     case intersect
     case except
@@ -86,6 +87,8 @@ extension Token {
     case plus
     case minus
     case slash
+    /// The `||` string-concatenation operator.
+    case concat
     case comma
     case lparen
     case rparen
@@ -135,6 +138,7 @@ extension Token.Kind {
     case .is: "IS"
     case .null: "NULL"
     case .in: "IN"
+    case .between: "BETWEEN"
     case .union: "UNION"
     case .intersect: "INTERSECT"
     case .except: "EXCEPT"
@@ -160,6 +164,7 @@ extension Token.Kind {
     case .plus: "+"
     case .minus: "-"
     case .slash: "/"
+    case .concat: "||"
     case .comma: ","
     case .lparen: "("
     case .rparen: ")"

--- a/Tests/SQLTests/BetweenTests.swift
+++ b/Tests/SQLTests/BetweenTests.swift
@@ -1,0 +1,392 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQL
+
+import SQLTestSupport
+
+// MARK: - Fixture
+
+/// A relation exercising `[NOT] BETWEEN`: an integer key `K` that is `NULL` in
+/// one row, so a NULL operand's UNKNOWN corner is reachable.
+private func things() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["Id": .integer, "K": .integer]) {
+      Row(1, 5)
+      Row(2, 1)
+      Row(3, 10)
+      Row(4, nil)
+      Row(5, 15)
+    }
+  }
+}
+
+/// Parses `text` and returns its `Select`, failing on any other shape.
+private func parse(select text: String) throws -> Select {
+  guard case let .select(.select(select)) = try Statement(parsing: text) else {
+    Issue.record("expected a single SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return select
+}
+
+// MARK: - Parsing
+
+struct BetweenParsingTests {
+  @Test func `BETWEEN parses to a first-class node`() throws {
+    // `x BETWEEN a AND b` is a first-class `Predicate.between` holding `x` ONCE
+    // — not the re-referencing `AND` of two comparisons its ISO definition
+    // names.
+    let select = try parse(select: "SELECT * FROM T WHERE K BETWEEN 1 AND 10")
+    #expect(select.predicate
+                == .between(.column("K"), .literal(.integer(1)),
+                            .literal(.integer(10)), negated: false))
+  }
+
+  @Test func `NOT BETWEEN parses to a negated first-class node`() throws {
+    // `x NOT BETWEEN a AND b` is the same node, `negated`.
+    let select =
+        try parse(select: "SELECT * FROM T WHERE K NOT BETWEEN 1 AND 10")
+    #expect(select.predicate
+                == .between(.column("K"), .literal(.integer(1)),
+                            .literal(.integer(10)), negated: true))
+  }
+}
+
+// MARK: - Evaluation
+
+struct BetweenEvaluationTests {
+  /// The `Id`s of every fixture row — a constant-TRUE `WHERE` keeps them all.
+  private let all = [[1], [2], [3], [4], [5]]
+
+  @Test func `a constant BETWEEN is true within the range`() throws {
+    // A constant-true predicate keeps every row.
+    try things().expect("SELECT Id FROM T WHERE 5 BETWEEN 1 AND 10",
+                        yields: all)
+  }
+
+  @Test func `a constant NOT BETWEEN is false within the range`() throws {
+    // A constant-false predicate drops every row.
+    try things().empty("SELECT Id FROM T WHERE 5 NOT BETWEEN 1 AND 10")
+  }
+
+  @Test func `the lower bound is inclusive`() throws {
+    try things().expect("SELECT Id FROM T WHERE 1 BETWEEN 1 AND 10",
+                        yields: all)
+  }
+
+  @Test func `the upper bound is inclusive`() throws {
+    try things().expect("SELECT Id FROM T WHERE 10 BETWEEN 1 AND 10",
+                        yields: all)
+  }
+
+  @Test func `a value outside the range is not between`() throws {
+    try things().empty("SELECT Id FROM T WHERE 15 BETWEEN 1 AND 10")
+  }
+
+  @Test func `BETWEEN over a column keeps only in-range rows`() throws {
+    // K in [1, 10]: rows 1 (5), 2 (1), 3 (10); row 4 (NULL) is UNKNOWN, row 5
+    // (15) is out of range.
+    try things().expect("SELECT Id FROM T WHERE K BETWEEN 1 AND 10",
+                        yields: [[1], [2], [3]])
+  }
+
+  @Test func `NOT BETWEEN over a column keeps only out-of-range rows`() throws {
+    // K outside [2, 8]: row 2 (1) and rows 3/5 (10/15); row 1 (5) is in range,
+    // row 4 (NULL) is UNKNOWN.
+    try things().expect("SELECT Id FROM T WHERE K NOT BETWEEN 2 AND 8",
+                        yields: [[2], [3], [5]])
+  }
+
+  @Test func `a NULL operand is UNKNOWN and excludes the row`() throws {
+    // Row 4's K is NULL, so both bounds are UNKNOWN — the row is excluded, as
+    // the equivalent `K >= 1 AND K <= 10` comparisons would exclude it.
+    try things().expect("SELECT Id FROM T WHERE K BETWEEN 1 AND 10",
+                        equals: "SELECT Id FROM T WHERE K >= 1 AND K <= 10")
+  }
+}
+
+// MARK: - Test expression evaluated once
+
+/// A shared call counter a stateful routine increments — a tiny
+/// `@unchecked Sendable` box over a mutable count, so the non-deterministic
+/// `stepper()` routine registered against it both observes successive values
+/// and records how many times the run invoked it. The engine evaluates a row's
+/// filter synchronously on one thread, so the box needs no lock.
+private final class Counter: @unchecked Sendable {
+  /// The number of times `next()` has been called.
+  private(set) var count = 0
+
+  /// Increments the count and returns the PREVIOUS value — the sequence `0, 1,
+  /// 2, …` across successive calls.
+  func next() -> Int {
+    defer { count += 1 }
+    return count
+  }
+}
+
+struct BetweenOperandTests {
+  /// A single-row table, so a per-row test expression is evaluated once.
+  private func one() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["Id": .integer]) {
+        Row(1)
+      }
+    }
+  }
+
+  @Test func `the BETWEEN test expression is evaluated once`() throws {
+    // `stepper()` yields 0, then 1, …; non-deterministic, so unfoldable.
+    // `stepper() BETWEEN 0 AND 0` must evaluate `stepper()` EXACTLY ONCE —
+    // yielding 0, which IS in [0, 0], so the row is KEPT. The old desugar
+    // duplicated the test across `stepper() >= 0 AND stepper() <= 0`, calling
+    // it twice: the lower bound saw 0 (0 >= 0) and the upper saw a DIFFERENT 1
+    // (1 <= 0 is false), wrongly DROPPING the row and calling it twice. The
+    // first-class node holds the test, so the row is kept and the counter reads
+    // exactly 1.
+    let counter = Counter()
+    let routines = try Routines()
+        .registering("stepper", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+    try one().expect("SELECT Id FROM T WHERE stepper() BETWEEN 0 AND 0",
+                     yields: [[1]], routines: routines)
+    #expect(counter.count == 1)
+  }
+}
+
+// MARK: - Upper bound short-circuit
+
+struct BetweenShortCircuitTests {
+  /// A single-row table — enough to reach the per-row predicate once.
+  private func one() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["Id": .integer]) {
+        Row(1)
+      }
+    }
+  }
+
+  @Test func `a FALSE lower bound skips the upper bound`() throws {
+    // `0 BETWEEN 1 AND (1 / 0)` ≡ `0 >= 1 AND 0 <= (1 / 0)` — the lower
+    // `0 >= 1` is FALSE, so Kleene `AND` is FALSE without the upper `1 / 0`.
+    // The eager form evaluated BOTH bounds and faulted `.divide` on the upper;
+    // deferring it keeps the predicate FALSE, dropping the row with NO throw.
+    try one().empty("SELECT Id FROM T WHERE 0 BETWEEN 1 AND (1 / 0)")
+  }
+
+  @Test func `a TRUE lower bound skips the NOT BETWEEN upper`() throws {
+    // `0 NOT BETWEEN 1 AND (1 / 0)` ≡ `0 < 1 OR 0 > (1 / 0)` — the lower
+    // `0 < 1` is TRUE, so Kleene `OR` is TRUE without the upper `1 / 0`. The
+    // row is kept with NO throw.
+    try one().expect("SELECT Id FROM T WHERE 0 NOT BETWEEN 1 AND (1 / 0)",
+                     yields: [[1]])
+  }
+
+  @Test func `the upper bound is evaluated when the lower does not settle it`()
+      throws {
+    // `5 BETWEEN 1 AND (1 / 0)` — the lower `5 >= 1` is TRUE, so the result
+    // hinges on the upper: the deferred `1 / 0` MUST evaluate and STILL fault,
+    // confirming the upper is not silently dropped when the lower needs it.
+    try one().expect("SELECT Id FROM T WHERE 5 BETWEEN 1 AND (1 / 0)",
+                     fails: .divide)
+  }
+
+  @Test func `a needed upper bound keeps an in-range row`() throws {
+    // `5 BETWEEN 1 AND 10` — the lower `5 >= 1` is TRUE, so the upper `5 <= 10`
+    // is evaluated and TRUE, keeping the row.
+    try one().expect("SELECT Id FROM T WHERE 5 BETWEEN 1 AND 10",
+                     yields: [[1]])
+  }
+}
+
+// MARK: - Typecheck short-circuit
+
+/// Parses `text` to a `Query`, failing on any other shape.
+private func query(_ text: String) throws -> Query {
+  guard case let .select(query) = try Statement(parsing: text) else {
+    Issue.record("expected a SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return query
+}
+
+struct BetweenTypecheckTests {
+  /// A relation with a text `Name`, so `Name + 1` is a reachable operand fault.
+  private func named() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["Id": .integer, "Name": .text]) {
+        Row(1, "a")
+      }
+    }
+  }
+
+  @Test func `a constant FALSE BETWEEN WHERE leaves the projection unreachable`()
+      throws {
+    // `0 BETWEEN 1 AND (1 / 0)` — the constant lower `0 >= 1` folds definitely
+    // FALSE, settling the whole BETWEEN FALSE WITHOUT folding the upper
+    // `1 / 0`. So `constant(_ predicate:)` reports the WHERE always-FALSE, the
+    // projection `Name + 1` (a `.operand` fault over the text `Name`, if
+    // reached) is unreachable, and `columns(of:validate:)` SUCCEEDS. The run
+    // drops every row before the projection, yielding no rows and NO throw.
+    let text = "SELECT Name + 1 FROM T WHERE 0 BETWEEN 1 AND (1 / 0)"
+    _ = try named().columns(of: query(text))
+    try named().empty(text)
+  }
+}
+
+// MARK: - Seek planning
+
+/// A relation sorted on its integer key `Id` (rows 1 … 10), so a BETWEEN over
+/// `Id` can seek a contiguous run rather than scan the whole relation.
+private func sorted() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["Id": .integer], sorted: "Id") {
+      Row(1)
+      Row(2)
+      Row(3)
+      Row(4)
+      Row(5)
+      Row(6)
+      Row(7)
+      Row(8)
+      Row(9)
+      Row(10)
+    }
+  }
+}
+
+/// The seek `Range<Int>` the first `.scan` reachable from `plan` carries, or
+/// `nil` if that scan is unseeked — the run a BETWEEN seek plans over the
+/// sorted key's row positions.
+private func seek(_ plan: Plan) -> Range<Int>? {
+  switch plan {
+  case let .scan(_, _, seek):
+    seek
+  case let .select(_, source):
+    seek(source)
+  case let .project(_, source):
+    seek(source)
+  case let .sort(_, source):
+    seek(source)
+  default:
+    nil
+  }
+}
+
+struct BetweenSeekTests {
+  @Test func `a BETWEEN over the sorted key seeks its two-sided run`() throws {
+    // `Id BETWEEN 3 AND 7` over the `Id`-sorted relation must seek the run
+    // `2 ..< 7` — the positions of Ids 3 … 7 (first `>= 3` at index 2, first
+    // `> 7` at index 7) — exactly the range `Id >= 3 AND Id <= 7` would seek,
+    // not scan all ten rows.
+    let catalog = try sorted()
+    let query = try query("SELECT Id FROM T WHERE Id BETWEEN 3 AND 7")
+    let plan = try catalog.optimise(catalog.compile(query), [:])
+    #expect(seek(plan) == 2 ..< 7)
+    try catalog.expect("SELECT Id FROM T WHERE Id BETWEEN 3 AND 7",
+                       yields: [[3], [4], [5], [6], [7]])
+  }
+
+  @Test func `the seeked BETWEEN matches the equivalent range comparison`()
+      throws {
+    // The desugar `Id >= 3 AND Id <= 7` also seeks over the sorted key and
+    // returns the SAME rows — but seeks only ONE conjunct (`Id >= 3`, the run
+    // `2 ..< 10`) and residuals the other, so the first-class BETWEEN's
+    // two-sided `2 ..< 7` is the TIGHTER run. Parity is the seeked shape and
+    // the rows, and the BETWEEN run sits within the comparison's.
+    let catalog = try sorted()
+    let comparison =
+        try query("SELECT Id FROM T WHERE Id >= 3 AND Id <= 7")
+    let range = try #require(seek(catalog.optimise(catalog.compile(comparison),
+                                                   [:])))
+    #expect(range.lowerBound <= 2 && range.upperBound >= 7)
+    try catalog.expect("SELECT Id FROM T WHERE Id BETWEEN 3 AND 7",
+                       equals: "SELECT Id FROM T WHERE Id >= 3 AND Id <= 7")
+  }
+
+  @Test func `a NOT BETWEEN does not seek — the complement is two runs`()
+      throws {
+    // `Id NOT BETWEEN 3 AND 7` is the complement — two disjoint runs, not one
+    // contiguous seek — so it scans under the residual and returns the
+    // out-of-range rows.
+    let catalog = try sorted()
+    let query = try query("SELECT Id FROM T WHERE Id NOT BETWEEN 3 AND 7")
+    let plan = try catalog.optimise(catalog.compile(query), [:])
+    #expect(seek(plan) == nil)
+    try catalog.expect("SELECT Id FROM T WHERE Id NOT BETWEEN 3 AND 7",
+                       yields: [[1], [2], [8], [9], [10]])
+  }
+
+  @Test func `an expression test does not seek — the operand is not a slot`()
+      throws {
+    // `Id + 1 BETWEEN 4 AND 8` tests an arithmetic term, not a bare key slot,
+    // so it does not qualify for the seek; it scans and filters, admitting the
+    // same rows the seeked `Id BETWEEN 3 AND 7` would.
+    let catalog = try sorted()
+    let query = try query("SELECT Id FROM T WHERE Id + 1 BETWEEN 4 AND 8")
+    let plan = try catalog.optimise(catalog.compile(query), [:])
+    #expect(seek(plan) == nil)
+    try catalog.expect("SELECT Id FROM T WHERE Id + 1 BETWEEN 4 AND 8",
+                       yields: [[3], [4], [5], [6], [7]])
+  }
+
+  @Test func `a bound referencing a column does not seek — it is not constant`()
+      throws {
+    // `Id BETWEEN 3 AND Id` has an upper bound that reads a column, not an
+    // integer literal, so it does not qualify for the seek; it scans and admits
+    // every row whose `Id >= 3` (each row's own `Id` is its upper bound).
+    let catalog = try sorted()
+    let query = try query("SELECT Id FROM T WHERE Id BETWEEN 3 AND Id")
+    let plan = try catalog.optimise(catalog.compile(query), [:])
+    #expect(seek(plan) == nil)
+    try catalog.expect("SELECT Id FROM T WHERE Id BETWEEN 3 AND Id",
+                       yields: [[3], [4], [5], [6], [7], [8], [9], [10]])
+  }
+
+  @Test func `an inverted BETWEEN seeks an empty run without trapping`()
+      throws {
+    // `Id BETWEEN 10 AND 1` is a valid EMPTY range (lower > upper): the
+    // `Id >= 10` partition starts at index 9 and the `Id <= 1` partition ends
+    // at index 1, so the raw `lower ..< upper` (9 ..< 1) would trap Swift's
+    // `Range(lowerBound <= upperBound)` precondition and abort the process. The
+    // guard detects the inversion and seeks the EMPTY run `9 ..< 9` instead, so
+    // the query returns no rows and never traps.
+    let catalog = try sorted()
+    let query = try query("SELECT Id FROM T WHERE Id BETWEEN 10 AND 1")
+    let plan = try catalog.optimise(catalog.compile(query), [:])
+    let range = try #require(seek(plan))
+    #expect(range.isEmpty)
+    try catalog.empty("SELECT Id FROM T WHERE Id BETWEEN 10 AND 1")
+  }
+}
+
+// MARK: - Empty-group short-circuit
+
+struct BetweenEmptyGroupTests {
+  /// A relation to fold a whole-result aggregate over.
+  private func numbers() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["Id": .integer]) {
+        Row(1)
+      }
+    }
+  }
+
+  @Test func `a constant FALSE BETWEEN HAVING type-checks over an empty group`()
+      throws {
+    // A constant-FALSE `WHERE` leaves a whole-result aggregate its single empty
+    // group, over which the `HAVING 0 BETWEEN 1 AND (1 / 0)` folds: the
+    // constant lower `0 >= 1` is FALSE, settling BETWEEN FALSE WITHOUT folding
+    // the upper `1 / 0`. So `empty(_ predicate:)` drops the group WITHOUT a
+    // `.divide` fault, schema/type checking SUCCEEDS, and the run yields no row
+    // with NO throw.
+    let text = """
+        SELECT COUNT(*) FROM T WHERE 1 = 0
+        HAVING 0 BETWEEN 1 AND (1 / 0)
+        """
+    _ = try numbers().columns(of: query(text))
+    try numbers().empty(text)
+  }
+}

--- a/Tests/SQLTests/CoalesceTests.swift
+++ b/Tests/SQLTests/CoalesceTests.swift
@@ -1,0 +1,457 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQL
+
+import SQLTestSupport
+
+// MARK: - Fixture
+
+/// A relation exercising `COALESCE`/`NULLIF`: a nullable integer `K` and a
+/// text `Name`, so a NULL fallthrough and a type unification are reachable.
+private func things() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["Id": .integer, "K": .integer, "Name": .text]) {
+      Row(1, 10, "a")
+      Row(2, nil, "b")
+    }
+  }
+}
+
+/// Parses `text` and returns its `Select`, failing on any other shape.
+private func parse(select text: String) throws -> Select {
+  guard case let .select(.select(select)) = try Statement(parsing: text) else {
+    Issue.record("expected a single SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return select
+}
+
+/// The single output column type of a one-column query's schema.
+private func type(of text: String, _ routines: Routines = [:])
+    throws -> ValueType {
+  guard case let .select(query) = try Statement(parsing: text) else {
+    Issue.record("expected a SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  let columns = try things().columns(of: query, routines: routines)
+  #expect(columns.count == 1)
+  return columns[0].type
+}
+
+// MARK: - COALESCE
+
+struct CoalesceTests {
+  @Test func `COALESCE parses to a first-class node`() throws {
+    // `COALESCE(K, 0)` is a first-class `Expression.coalesce` holding each
+    // argument ONCE — not the re-referencing `CASE` its ISO definition names.
+    let select = try parse(select: "SELECT COALESCE(K, 0) FROM T")
+    let expression = Expression.coalesce([.column("K"),
+                                          .literal(.integer(0))])
+    #expect(select.projection
+                == .expressions([Projected(expression: expression)]))
+  }
+
+  @Test func `takes the first non-NULL argument`() throws {
+    try things().expect("SELECT COALESCE(K, K, 3) FROM T WHERE K IS NULL",
+                        yields: [[3]])
+  }
+
+  @Test func `an earlier non-NULL argument wins`() throws {
+    try things().expect("SELECT COALESCE(K, 99) FROM T WHERE Id = 1",
+                        yields: [[10]])
+  }
+
+  @Test func `all-NULL arguments yield NULL`() throws {
+    try things().expect("SELECT COALESCE(K, K) FROM T WHERE K IS NULL",
+                        yields: [[nil]])
+  }
+
+  @Test func `mixed integer and double arguments widen to double`() throws {
+    // The arguments unify like a CASE's results — the integer widens.
+    #expect(try type(of: "SELECT COALESCE(K, 2.5) AS C FROM T") == .double)
+    try things().expect("SELECT COALESCE(K, 2.5) FROM T",
+                        yields: [[10.0], [2.5]])
+  }
+
+  @Test func `rejects a single argument`() {
+    #expect(throws: SQLError.self) {
+      _ = try Statement(parsing: "SELECT COALESCE(K) FROM T")
+    }
+  }
+
+  @Test func `irreconcilable argument types fault`() throws {
+    // An integer argument beside a text one cannot yield one column type.
+    guard case let .select(query) =
+        try Statement(parsing: "SELECT COALESCE(K, Name) FROM T") else {
+      Issue.record("expected a SELECT statement")
+      return
+    }
+    #expect(throws:
+        SQLError.operand("COALESCE arguments have irreconcilable types")) {
+      _ = try things().columns(of: query)
+    }
+  }
+}
+
+// MARK: - Argument reachability
+
+/// Parses `text` to a `Query`, failing on any other shape.
+private func query(_ text: String) throws -> Query {
+  guard case let .select(query) = try Statement(parsing: text) else {
+    Issue.record("expected a SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return query
+}
+
+struct CoalesceReachabilityTests {
+  @Test func `a constant non-NULL prefix leaves a later argument unreachable`()
+      throws {
+    // The executor returns the constant `1` and never evaluates
+    // `missing_udf()` — an unregistered routine a run would fault `.function`
+    // on — so the typecheck, mirroring that short-circuit, must NOT validate
+    // the unreachable call. `columns(of:)` succeeds and the run yields the `1`.
+    let text = "SELECT COALESCE(1, missing_udf()) FROM T"
+    _ = try things().columns(of: query(text))
+    try things().expect(text, yields: [[1], [1]])
+  }
+
+  @Test func `a constant non-NULL prefix determines the column type`() throws {
+    // The reachable prefix (the constant `1`) shapes the column — an integer —
+    // exactly as a constant-TRUE CASE guard's branch does; the unreachable text
+    // argument does not unify into it.
+    #expect(try type(of: "SELECT COALESCE(1, missing_udf()) AS C FROM T")
+                == .integer)
+  }
+
+  @Test func `a bad operand after a constant prefix is unreachable`() throws {
+    // `Name + 1` over the text `Name` would fault `.operand` if reached, but
+    // the constant `1` selects first, so it is unreachable and not validated.
+    _ = try things().columns(of: query("SELECT COALESCE(1, Name + 1) FROM T"))
+  }
+
+  @Test func `a constant NULL prefix does NOT stop validation`() throws {
+    // COALESCE steps PAST a NULL argument, so a later one is reachable and MUST
+    // be validated. `NULL` is not an expression literal (it is UNKNOWN, spelled
+    // only in `IS NULL`), so a DETERMINISTIC routine folding to `.null` stands
+    // in for the constant-NULL prefix: `missing_udf()` after it still faults
+    // `.function`.
+    let routines = try Routines()
+        .registering("nought", returns: .integer, deterministic: true) { _ in
+          .null
+        }
+    #expect(throws: SQLError.function("missing_udf")) {
+      _ = try things().columns(of:
+          query("SELECT COALESCE(nought(), missing_udf()) FROM T"),
+          routines: routines)
+    }
+  }
+
+  @Test func `a non-constant prefix does NOT stop validation`() throws {
+    // A row-dependent argument (`K`, a nullable integer) is not a definite
+    // selection — the run may fall through it — so a later argument is
+    // reachable and validated: `missing_udf()` after `K` still faults
+    // `.function` (both integer-typed, so the fault is the unknown call, not a
+    // type clash).
+    #expect(throws: SQLError.function("missing_udf")) {
+      _ = try things().columns(of:
+          query("SELECT COALESCE(K, missing_udf()) FROM T"))
+    }
+  }
+
+  @Test func `a constant NULL prefix does NOT shape the type`() throws {
+    // A run skips a NULL argument and moves on, so an argument that folds to a
+    // constant `.null` can never be returned — its DECLARED type must not unify
+    // into the column, exactly as a `CASE` omits a skipped branch's result
+    // type. `null_text()` is a DETERMINISTIC routine declaring `.text` yet
+    // folding to `.null`, so `COALESCE(null_text(), 1)` can only ever yield the
+    // integer `1`: merging the `.text` would clash with the `.integer` and
+    // reject the query, so the constant-NULL arm's type is skipped. It
+    // type-checks, runs to `1`, and the column derives `.integer`.
+    let routines = try Routines()
+        .registering("null_text", returns: .text, deterministic: true) { _ in
+          .null
+        }
+    let text = "SELECT COALESCE(null_text(), 1) FROM T"
+    _ = try things().columns(of: query(text), routines: routines)
+    #expect(try type(of: text, routines) == .integer)
+    try things().expect(text, yields: [[1], [1]], routines: routines)
+  }
+
+  @Test func `a COUNT prefix leaves a later argument unreachable`() throws {
+    // `COUNT(*)` is always non-NULL (a row count of 0 or more), so it is the
+    // definite selection — the executor returns it and never evaluates the
+    // later `missing_udf()`, an unregistered routine a run would fault
+    // `.function` on. The typecheck, mirroring that short-circuit, must NOT
+    // validate the unreachable call. `columns(of:)` succeeds over the
+    // whole-result group and the run yields the count (2).
+    let text = "SELECT COALESCE(COUNT(*), missing_udf()) FROM T"
+    _ = try things().columns(of: query(text))
+    try things().expect(text, yields: [[2]])
+  }
+
+  @Test func `a COUNT prefix determines the column type`() throws {
+    // The reachable prefix (`COUNT(*)`) shapes the column — an integer — and
+    // the unreachable later argument does not unify into it.
+    #expect(try type(of: "SELECT COALESCE(COUNT(*), missing_udf()) AS C FROM T")
+                == .integer)
+  }
+
+  @Test func `a SUM prefix does NOT stop validation`() throws {
+    // Unlike COUNT, SUM is NULL over an empty group, so it is NOT a definite
+    // selection — the run may fall through it — and a later argument stays
+    // reachable and MUST be validated: `missing_udf()` after `SUM(K)` still
+    // faults `.function`.
+    #expect(throws: SQLError.function("missing_udf")) {
+      _ = try things().columns(of:
+          query("SELECT COALESCE(SUM(K), missing_udf()) FROM T"))
+    }
+  }
+
+  @Test func `a SUM prefix falls back to a reachable later argument`() throws {
+    // The CONTROL for the COUNT stop: `COALESCE(SUM(x), 0)` still validates and
+    // derives the later `0` (SUM is nullable, not a stop), unifying to
+    // `.integer`, and runs — SUM over the two-row group is the sum of K.
+    let text = "SELECT COALESCE(SUM(K), 0) FROM T"
+    #expect(try type(of: text) == .integer)
+    try things().expect(text, yields: [[10]])
+  }
+}
+
+// MARK: - Constant folding
+
+/// A deterministic native routine reporting whether its single argument is a
+/// `.double` — 1 when it is, else 0. It DISTINGUISHES `.double(1.0)` from
+/// `.integer(1)`, so the constant fold's coercion of a COALESCE's selected
+/// value is OBSERVABLE through it. Its declared parameter `type` matches the
+/// COALESCE's derived type so the static arity/type check (which demands an
+/// exact match) passes.
+private func doubling(taking type: ValueType) throws -> Routines {
+  try Routines()
+      .registering("is_double", returns: .integer, parameters: [type],
+                   deterministic: true) { arguments in
+        if case .double = arguments[0] { return .integer(1) }
+        return .integer(0)
+      }
+}
+
+/// An `is_double(<coalesce>) = 1` reachability predicate — TRUE only when the
+/// COALESCE's constant fold reports its selected value as a `.double`.
+private func predicate(over coalesce: Expression) -> Predicate {
+  .comparison(left: .call(name: "is_double", arguments: [coalesce]),
+              op: .equal, right: .literal(.integer(1)))
+}
+
+/// The schema validator folds a ROW-INDEPENDENT `COALESCE` (via
+/// `constant(_ expression:)`) to decide a `WHERE` arm's reachability, so its
+/// selected value must carry the SAME type the run's `Term.coalesce` supplies —
+/// the unified type `derive` advertises — or the fold sees a value the run
+/// never produces. The fold coerces the selected value to that unified type,
+/// mirroring the executor (`Value.coerced`) and the sibling empty-group fold.
+///
+/// This engine types a COALESCE by its REACHABLE prefix: a constant non-NULL
+/// argument is the definite selection, so it both sets the unified type and is
+/// the folded value — the coercion is therefore the identity on the constant
+/// path, but it keeps the fold pinned to the advertised type rather than a raw
+/// selected value, matching the run exactly.
+struct CoalesceConstantTests {
+  @Test func `a mixed COALESCE folds to its selected reachable value`() throws {
+    // `COALESCE(1, 2.5)` selects the constant `1` — the definite selection that
+    // makes `2.5` unreachable — so it types as `.integer` and the fold yields
+    // `.integer(1)`, exactly as the run's `Term.coalesce` does over the same
+    // `.integer` lowered type: `is_double` reports FALSE, so the predicate
+    // folds definitely FALSE.
+    let coalesce = Expression.coalesce([.literal(.integer(1)),
+                                        .literal(.double(2.5))])
+    let folded = Scope([]).constant(predicate(over: coalesce),
+                                    try doubling(taking: .integer))
+    #expect(folded == false)
+  }
+
+  @Test func `an all-integer COALESCE is not coerced`() throws {
+    // `COALESCE(1, 2)` unifies to `.integer`, so the selected `1` stays
+    // `.integer(1)`: no spurious coercion to `.double`. `is_double` reports
+    // FALSE, so the predicate folds definitely FALSE.
+    let coalesce = Expression.coalesce([.literal(.integer(1)),
+                                        .literal(.integer(2))])
+    let folded = Scope([]).constant(predicate(over: coalesce),
+                                    try doubling(taking: .integer))
+    #expect(folded == false)
+  }
+
+  @Test func `the constant fold matches the run`() throws {
+    // The fold and the run must yield the SAME value for a ROW-INDEPENDENT
+    // COALESCE. Selecting a `.double` constant yields `.double`; selecting an
+    // integer constant past a NULL-folding double routine yields `.integer`
+    // (the reachable prefix types it), each coerced to the derived type the run
+    // lowers — so `is_double` agrees with the run over the folded value.
+    let nulldouble = try Routines()
+        .registering("null_double", returns: .double, deterministic: true) {
+          _ in .null
+        }
+    // Selects the `.double` constant: fold is `.double(2.5)`.
+    let picksDouble = Expression.coalesce([.literal(.double(2.5)),
+                                           .literal(.integer(1))])
+    #expect(Scope([]).constant(predicate(over: picksDouble),
+                               try doubling(taking: .double)) == true)
+    // NULL double prefix skipped, integer `1` selected: fold is `.integer(1)`.
+    let picksInteger =
+        Expression.coalesce([.call(name: "null_double", arguments: []),
+                             .literal(.integer(1))])
+    #expect(Scope([]).constant(predicate(over: picksInteger),
+                               try doubling(taking: .integer)
+                                   .merging(nulldouble)) == false)
+  }
+}
+
+// MARK: - Typecheck agrees with the run
+
+/// The `WHERE` reachability fold and the run must AGREE on a ROW-INDEPENDENT
+/// `COALESCE`: an arm the run reaches must be type-checked, so the COALESCE's
+/// coerced fold value cannot let validation skip a projection execution runs —
+/// mirroring the CASE-coercion end-to-end shape.
+struct CoalesceTypecheckTests {
+  @Test func `a reachable projection is type-checked`() throws {
+    // `WHERE is_double(COALESCE(2.5, 1)) = 1 AND …` — the COALESCE selects the
+    // `.double` constant, so `is_double` reports 1 and the guard folds TRUE:
+    // the AND's right arm is reachable, so the projection's `Name + 1` (text
+    // arithmetic) is validated and faults, exactly as the run reaches it.
+    let text = """
+        SELECT Name + 1 AS C FROM T
+          WHERE is_double(COALESCE(2.5, 1)) = 1 AND Id = 1
+        """
+    #expect(throws: SQLError.operand("operands must be numeric")) {
+      _ = try things().columns(of: query(text),
+                               routines: doubling(taking: .double))
+    }
+  }
+
+  @Test func `an unreachable projection is skipped`() throws {
+    // The CONTROL: `COALESCE(1, 2)` folds to the integer `1`, so `is_double`
+    // reports 0 and `= 1` folds FALSE — the AND's right arm is unreachable and
+    // its `Name + 1` is NOT validated, so the query type-checks. (The run
+    // likewise never reaches it.)
+    let text = """
+        SELECT Name + 1 AS C FROM T
+          WHERE is_double(COALESCE(1, 2)) = 1 AND Id = 1
+        """
+    let columns = try things().columns(of: query(text),
+                                       routines: doubling(taking: .integer))
+    #expect(columns.count == 1)
+  }
+}
+
+// MARK: - NULLIF
+
+struct NullifTests {
+  @Test func `NULLIF parses to a first-class node`() throws {
+    // `NULLIF(K, 0)` is a first-class `Expression.nullif` holding `K` ONCE —
+    // not the re-referencing `CASE` its ISO definition names.
+    let select = try parse(select: "SELECT NULLIF(K, 0) FROM T")
+    let expression = Expression.nullif(.column("K"), .literal(.integer(0)))
+    #expect(select.projection
+                == .expressions([Projected(expression: expression)]))
+  }
+
+  @Test func `equal arguments yield NULL`() throws {
+    try things().expect("SELECT NULLIF(1, 1)", yields: [[nil]])
+  }
+
+  @Test func `unequal integer arguments yield the first`() throws {
+    try things().expect("SELECT NULLIF(1, 2)", yields: [[1]])
+  }
+
+  @Test func `unequal text arguments yield the first`() throws {
+    try things().expect("SELECT NULLIF('a', 'b')", yields: [["a"]])
+  }
+
+  @Test func `the column type is the first argument's`() throws {
+    // The NULL result imposes no type; the ELSE (the first argument) types it.
+    #expect(try type(of: "SELECT NULLIF(Name, 'x') AS C FROM T") == .text)
+  }
+
+  @Test func `rejects a single argument`() {
+    #expect(throws: SQLError.self) {
+      _ = try Statement(parsing: "SELECT NULLIF(K) FROM T")
+    }
+  }
+}
+
+// MARK: - Operand evaluated once
+
+/// A shared call counter a stateful routine increments — a tiny
+/// `@unchecked Sendable` box over a mutable count, so the non-deterministic
+/// `stepper()` routine registered against it both observes successive values
+/// and records how many times the run invoked it. The engine evaluates a row's
+/// projection synchronously on one thread, so the box needs no lock.
+private final class Counter: @unchecked Sendable {
+  /// The number of times `next()` has been called.
+  private(set) var count = 0
+
+  /// Increments the count and returns the PREVIOUS value — the sequence `0, 1,
+  /// 2, …` across successive calls.
+  func next() -> Int {
+    defer { count += 1 }
+    return count
+  }
+}
+
+struct CoalesceOperandTests {
+  /// A single-row table, so a per-row operand runs once for the one row.
+  private func one() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["Id": .integer]) {
+        Row(1)
+      }
+    }
+  }
+
+  @Test func `each COALESCE argument is evaluated once`() throws {
+    // `stepper()` yields 0, then 1, 2, …; it is NON-deterministic so the engine
+    // cannot fold it. `COALESCE(stepper(), 99)` must evaluate `stepper()`
+    // EXACTLY ONCE — yielding 0, a non-NULL value it returns. The old CASE
+    // desugar re-referenced the argument in both its `IS NOT NULL` guard and
+    // its `THEN`, calling `stepper()` twice: the guard saw 0 (non-NULL) and the
+    // THEN returned a DIFFERENT 1. The first-class node holds the argument, so
+    // the counter reads exactly 1 and the value returned is the one tested.
+    let counter = Counter()
+    let routines = try Routines()
+        .registering("stepper", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+    try one().expect("SELECT COALESCE(stepper(), 99) FROM T", yields: [[0]],
+                     routines: routines)
+    #expect(counter.count == 1)
+  }
+}
+
+struct NullifOperandTests {
+  /// A single-row table, so a per-row operand runs once for the one row.
+  private func one() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["Id": .integer]) {
+        Row(1)
+      }
+    }
+  }
+
+  @Test func `the NULLIF operand is evaluated once`() throws {
+    // `stepper()` yields 0, then 1, …; non-deterministic, so unfoldable.
+    // `NULLIF(stepper(), 99)` must evaluate `stepper()` EXACTLY ONCE — yielding
+    // 0, which ≠ 99, so it returns that SAME 0. The old CASE desugar embedded
+    // the operand in both the `= 99` equality and the `ELSE`, calling
+    // `stepper()` twice: the equality compared 0 and the ELSE returned a
+    // DIFFERENT 1. The first-class node holds the operand, so the counter reads
+    // exactly 1 and the value returned is the one compared.
+    let counter = Counter()
+    let routines = try Routines()
+        .registering("stepper", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+    try one().expect("SELECT NULLIF(stepper(), 99) FROM T", yields: [[0]],
+                     routines: routines)
+    #expect(counter.count == 1)
+  }
+}

--- a/Tests/SQLTests/ConcatTests.swift
+++ b/Tests/SQLTests/ConcatTests.swift
@@ -1,0 +1,136 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQL
+
+import SQLTestSupport
+
+// MARK: - Fixture
+
+/// A relation exercising the `||` concatenation operator: two text columns and
+/// one that is `NULL` in a row, so the NULL-propagation corner is reachable.
+private func things() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["Id": .integer, "A": .text, "B": .text]) {
+      Row(1, "a", "b")
+      Row(2, "c", nil)
+    }
+  }
+}
+
+/// Parses `text` and returns its `Select`, failing on any other shape.
+private func parse(select text: String) throws -> Select {
+  guard case let .select(.select(select)) = try Statement(parsing: text) else {
+    Issue.record("expected a single SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return select
+}
+
+// MARK: - Parsing
+
+struct ConcatParsingTests {
+  @Test func `parses a concatenation`() throws {
+    let select = try parse(select: "SELECT A || B FROM T")
+    let concat = Expression.binary(.concatenate, .column("A"),
+                                   .column("B"))
+    #expect(select.projection
+                == .expressions([Projected(expression: concat)]))
+  }
+
+  @Test func `concatenation is left-associative`() throws {
+    // `a || b || c` reads `(a || b) || c`.
+    let select = try parse(select: "SELECT 'a' || 'b' || 'c'")
+    let inner = Expression.binary(.concatenate, .literal(.string("a")),
+                                  .literal(.string("b")))
+    let outer = Expression.binary(.concatenate, inner,
+                                  .literal(.string("c")))
+    #expect(select.projection
+                == .expressions([Projected(expression: outer)]))
+  }
+}
+
+// MARK: - Evaluation
+
+struct ConcatEvaluationTests {
+  @Test func `concatenates two text values`() throws {
+    try things().expect("SELECT 'a' || 'b'", yields: [["ab"]])
+  }
+
+  @Test func `a NULL right operand propagates NULL`() throws {
+    // Row 2's Last is NULL, so `First || Last` is NULL.
+    try things().expect("SELECT A || B FROM T WHERE Id = 2",
+                        yields: [[nil]])
+  }
+
+  @Test func `a NULL left operand propagates NULL`() throws {
+    // Row 2's Last is NULL on the left this time.
+    try things().expect("SELECT B || A FROM T WHERE Id = 2",
+                        yields: [[nil]])
+  }
+
+  @Test func `concatenates over columns in a projection`() throws {
+    // Row 1 joins "a" and "b"; row 2's Last is NULL, so the result is NULL.
+    try things().expect("SELECT A || B FROM T",
+                        yields: [["ab"], [nil]])
+  }
+
+  @Test func `a non-text operand faults`() throws {
+    // `||` is a character-string operator; a numeric operand is a type error,
+    // as arithmetic faults on a non-numeric one.
+    try things().expect("SELECT 'a' || 1", fails:
+        .operand("|| operands must be text"))
+  }
+}
+
+// MARK: - Derivation
+
+/// Parses `text` to a `Query`, failing on any other shape.
+private func query(_ text: String) throws -> Query {
+  guard case let .select(query) = try Statement(parsing: text) else {
+    Issue.record("expected a SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return query
+}
+
+/// A `People` catalog with a text `Name` — the base for a derive-level test.
+private func people() -> FixtureCatalog {
+  FixtureCatalog(
+    ["People": FixtureRelation([FixtureField(name: "Name", type: .text)], [])])
+}
+
+/// The type `derive` reports for the sole projected expression of `text`, over
+/// a `People` scope — the schema-only derive surface (`scope(of:)` reads no
+/// cursor and skips `compile`), so `derive` alone resolves the operands.
+private func derived(_ text: String) throws -> ValueType {
+  let select = try parse(select: text)
+  guard case let .expressions(items) = select.projection, items.count == 1
+  else {
+    Issue.record("expected a single projected expression")
+    throw SQLError.incomplete(expected: "one projected expression")
+  }
+  let scope = try people().scope(of: select, Context())
+  return try scope.derive(items[0].expression)
+}
+
+struct ConcatDerivationTests {
+  @Test func `deriving a concatenation resolves both operands`() throws {
+    // `derive` — the schema-only surface a `columns(of:validate:false)` and an
+    // unreachable projection take, which RESOLVES column references — must
+    // derive both `||` operands, so an unresolved `Missing` faults
+    // `SQLError.column` rather than the branch silently advertising a `text`
+    // column, mirroring the arithmetic `.binary` derive branch.
+    #expect(throws: SQLError.column("Missing")) {
+      _ = try derived("SELECT Missing || 'x' FROM People")
+    }
+  }
+
+  @Test func `a resolved concatenation derives text`() throws {
+    // A `||` whose operands both resolve still derives a `.text` column —
+    // resolution succeeds and the result type is text regardless of the
+    // operands' own types.
+    #expect(try derived("SELECT Name || 'x' FROM People") == .text)
+  }
+}

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -1636,6 +1636,40 @@ private func seeks(_ plan: Plan) -> Bool {
   }
 }
 
+/// The seek `Range<Int>` the first `.scan` reachable from `plan` carries, or
+/// `nil` if that scan is unseeked (or no scan is reached) — the exact run a
+/// seek test asserts, beyond the boolean `seeks`.
+private func seek(_ plan: Plan) -> Range<Int>? {
+  switch plan {
+  case let .scan(_, _, seek):
+    seek
+  case let .select(_, source):
+    seek(source)
+  case let .project(_, source):
+    seek(source)
+  case let .sort(_, source):
+    seek(source)
+  case let .derived(_, sub, _, _):
+    seek(sub)
+  case let .product(left, right):
+    seek(left) ?? seek(right)
+  case let .join(outer, _, _, _, _, _, _):
+    seek(outer)
+  case let .outer(left, right, _, _):
+    seek(left) ?? seek(right)
+  case let .setop(_, left, right, _):
+    seek(left) ?? seek(right)
+  case let .limit(_, _, source):
+    seek(source)
+  case let .distinct(source):
+    seek(source)
+  case let .aggregate(_, _, source):
+    seek(source)
+  case .single:
+    nil
+  }
+}
+
 /// Whether `plan` wraps a raw (unseeked) `.scan` in a `.select` — the
 /// un-optimised shape the fix eliminates from a view's sub-plan.
 private func filters(_ plan: Plan) -> Bool {


### PR DESCRIPTION
Four ISO DQL query features, the first three implemented as parser-level desugars into existing AST nodes so they inherit the engine's type unification, coercion, reachability, and three-valued NULL semantics unchanged.

COALESCE(v1, v2, …) and NULLIF(v1, v2) are the ISO-defined expansions of a searched CASE — `CASE WHEN vi IS NOT NULL THEN vi … END` and `CASE WHEN v1 = v2 THEN NULL ELSE v1 END` respectively — parsed directly into the Expression.case AST. NULLIF's `THEN NULL` needs a NULL-valued result expression, so a Literal.null case is added (untyped, produced only by this expansion, dropped from CASE branch unification so the ELSE types the column).

x [NOT] BETWEEN a AND b is the ISO range test — `x >= a AND x <= b`, or `x < a OR x > b` when negated — parsed into the existing comparison/AND/OR Predicate structure. A new BETWEEN keyword joins the reused NOT/AND.

|| is the ISO character-string concatenation operator, which is not desugarable: a || token (Lexer/Token), a concatenate case on the binary Arithmetic operator at additive precedence (left-associative), and its evaluation on the existing Term.binary/apply path. It joins two text operands, propagates NULL when either is NULL, and faults SQLError.operand on a non-text operand, matching how arithmetic faults on a non-numeric one.