### PR TITLE
SQL: add the LIKE predicate

### DIFF
--- a/Sources/SQL/AST.swift
+++ b/Sources/SQL/AST.swift
@@ -559,12 +559,44 @@ public indirect enum Predicate: Hashable, Sendable {
   /// TRUE when a NULL element is present). The engine lowers it to that
   /// disjunction rather than carrying a dedicated `Filter` case.
   case membership(Expression, Array<Expression>, negated: Bool)
+  /// `operand [NOT] LIKE pattern [ESCAPE escape]` — whether the operand's text
+  /// matches the pattern, in which `%` matches any sequence of characters
+  /// (including the empty one) and `_` matches exactly one character; every
+  /// other pattern character matches itself. An optional `ESCAPE escape` names
+  /// a one-character escape whose following `%`, `_`, or escape character
+  /// matches that literal character. It is three-valued: a NULL operand, a NULL
+  /// pattern, or a NULL escape makes the result UNKNOWN, and `negated` (`NOT
+  /// LIKE`) negates the three-valued result (UNKNOWN maps to itself). A
+  /// non-text operand or pattern does not match — the engine's cross-kind
+  /// comparison rule — so a run yields FALSE without faulting. The pattern and
+  /// escape are each an `Operand` — an ordinary scalar expression or a run-time
+  /// `:parameter` resolved from the engine's bindings — so a caller can bind a
+  /// pattern (`Name LIKE :pattern`) rather than interpolate it.
+  case like(Expression, pattern: Operand, escape: Operand?, negated: Bool)
   /// `lhs AND rhs`.
   case and(Predicate, Predicate)
   /// `lhs OR rhs`.
   case or(Predicate, Predicate)
   /// `NOT operand`.
   case not(Predicate)
+
+  /// The pattern or escape operand of a `LIKE` predicate: either an ordinary
+  /// scalar `Expression` (a literal, a column, or a call, evaluated per row) or
+  /// a run-time `:parameter` (a name resolved from the engine's bindings, the
+  /// same mechanism `Predicate.bound` uses for a comparison's right operand).
+  ///
+  /// SQL's grammar admits only an expression here, but a `:parameter` is not an
+  /// expression token — it is consumed by the comparison arm — so LIKE carries
+  /// its bindable operands through this dedicated form rather than widening
+  /// every expression walk with a parameter case. An unbound parameter, or one
+  /// bound to `NULL`, makes the LIKE UNKNOWN, as a `NULL` pattern or escape
+  /// does.
+  public enum Operand: Hashable, Sendable {
+    /// An ordinary scalar expression, evaluated per row.
+    case expression(Expression)
+    /// A `:parameter` placeholder, resolved at run time from the bindings.
+    case parameter(String)
+  }
 }
 
 /// A comparison operator.

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -615,6 +615,37 @@ extension Expression {
   }
 }
 
+extension Predicate.Operand {
+  /// Whether this `LIKE` operand contains an aggregate — an expression's own,
+  /// never a `:parameter`.
+  internal var aggregated: Bool {
+    switch self {
+    case let .expression(expression): expression.aggregated
+    case .parameter: false
+    }
+  }
+
+  /// Whether this `LIKE` operand references a query binding — an expression's
+  /// own, or the operand's OWN `:parameter`, so a defined-function body that
+  /// names a `:parameter` in a `LIKE` pattern or escape is rejected at
+  /// registration (see `Expression.bound`).
+  internal var bound: Bool {
+    switch self {
+    case let .expression(expression): expression.bound
+    case .parameter: true
+    }
+  }
+
+  /// Collects the distinct aggregates within this `LIKE` operand into
+  /// `expressions` — an expression's own, none for a `:parameter`.
+  internal func collect(into expressions: inout Array<Expression>) {
+    switch self {
+    case let .expression(expression): expression.collect(into: &expressions)
+    case .parameter: break
+    }
+  }
+}
+
 extension Predicate {
   /// The flat list of top-level `AND`-conjuncts of this predicate in SOURCE
   /// ORDER (a non-`and` is a singleton). The parser leans `AND` left (`a AND b
@@ -639,6 +670,9 @@ extension Predicate {
       operand.aggregated
     case let .membership(operand, values, _):
       operand.aggregated || values.contains { $0.aggregated }
+    case let .like(operand, pattern, escape, _):
+      operand.aggregated || pattern.aggregated
+          || (escape?.aggregated ?? false)
     case let .and(lhs, rhs), let .or(lhs, rhs):
       lhs.aggregated || rhs.aggregated
     case let .not(operand):
@@ -660,6 +694,8 @@ extension Predicate {
       operand.bound
     case let .membership(operand, values, _):
       operand.bound || values.contains { $0.bound }
+    case let .like(operand, pattern, escape, _):
+      operand.bound || pattern.bound || (escape?.bound ?? false)
     case let .and(lhs, rhs), let .or(lhs, rhs):
       lhs.bound || rhs.bound
     case let .not(operand):
@@ -896,6 +932,10 @@ extension Predicate {
     case let .membership(operand, values, _):
       operand.collect(into: &expressions)
       for value in values { value.collect(into: &expressions) }
+    case let .like(operand, pattern, escape, _):
+      operand.collect(into: &expressions)
+      pattern.collect(into: &expressions)
+      escape?.collect(into: &expressions)
     case let .and(lhs, rhs), let .or(lhs, rhs):
       lhs.collect(into: &expressions)
       rhs.collect(into: &expressions)

--- a/Sources/SQL/Filter.swift
+++ b/Sources/SQL/Filter.swift
@@ -38,12 +38,36 @@ internal indirect enum Filter: Sendable {
   /// first TRUE; `NOT IN` negates that three-valued truth (UNKNOWN maps to
   /// itself).
   case membership(Term, Array<Term>, negated: Bool)
+  /// `operand [NOT] LIKE pattern [ESCAPE escape]` — the lowered form of the
+  /// AST's `like`. The operand is a `Term` evaluated per row; the pattern and
+  /// optional one-character escape are each an `Operand` — a `Term` or a
+  /// run-time `:parameter` resolved from the bindings; `negated` marks `NOT
+  /// LIKE`. The runtime reads the operand and pattern text and runs the `%`/`_`
+  /// matcher (a linear two-pointer match, `%` matching any run and `_` exactly
+  /// one character, an escape character taking the next character literally); a
+  /// NULL operand, pattern, or escape is UNKNOWN and a non-text operand or
+  /// pattern is a definite non-match (the engine's cross-kind rule), with `NOT
+  /// LIKE` negating the three-valued result (UNKNOWN maps to itself).
+  case like(Term, pattern: Operand, escape: Operand?, negated: Bool)
   /// `lhs AND rhs`.
   case and(Filter, Filter)
   /// `lhs OR rhs`.
   case or(Filter, Filter)
   /// `NOT operand`.
   case not(Filter)
+
+  /// The lowered pattern or escape operand of a `Filter.like`: a `Term`
+  /// evaluated per row, or a run-time `:parameter` resolved from the engine's
+  /// bindings — the lowered form of the AST's `Predicate.Operand`, as
+  /// `Filter.bound` carries a comparison's parameter as a name resolved at run
+  /// time.
+  internal enum Operand: Sendable {
+    /// A `Term` evaluated against the row per its usual lowering.
+    case term(Term)
+    /// A `:parameter` name, resolved from the bindings at eval — an unbound one
+    /// (or one bound to `NULL`) makes the `LIKE` UNKNOWN.
+    case parameter(String)
+  }
 }
 
 // MARK: - Terms
@@ -138,6 +162,71 @@ extension Term {
     case .apply, .binary, .case: false
     }
   }
+
+  /// Whether this term is STATICALLY a valid single-character `LIKE` escape — a
+  /// constant text value of exactly one character, the only form `Row.like`
+  /// accepts without faulting. A slot, a call, or a constant that is NULL,
+  /// non-text, or a text of any other length is not: its escape validity is not
+  /// known until the row runs, so it CANNOT ride below a seek or join (see
+  /// `Filter.safe`). Reused as the escape-safety gate; it does not decide the
+  /// eval result, only the pushdown/seek classification.
+  internal var escape: Bool {
+    guard case let .constant(.text(text)) = self else { return false }
+    return text.count == 1
+  }
+}
+
+extension Filter.Operand {
+  /// This operand with its term's ordinals remapped through `slot`; a
+  /// `:parameter` reads no slot and passes unchanged.
+  internal func remapped(through slot: Dictionary<Int, Int>) -> Filter.Operand {
+    switch self {
+    case let .term(term): .term(term.remapped(through: slot))
+    case .parameter: self
+    }
+  }
+
+  /// The ordinals this operand reads, accumulated into `ordinals` — a term's
+  /// own, none for a `:parameter`.
+  internal func references(into ordinals: inout Set<Int>) {
+    switch self {
+    case let .term(term): term.references(into: &ordinals)
+    case .parameter: break
+    }
+  }
+
+  /// Whether evaluating this operand cannot throw — a safe term, or a
+  /// `:parameter` (a bindings lookup, never a fault).
+  internal var safe: Bool {
+    switch self {
+    case let .term(term): term.safe
+    case .parameter: true
+    }
+  }
+
+  /// Whether this operand is STATICALLY a valid single-character `LIKE`
+  /// escape — only a constant single-character text term. A `:parameter` is
+  /// per-run, not a static constant, so it is NOT statically valid (it may be
+  /// unbound, NULL, or the wrong length at run time) and marks the `LIKE`
+  /// unsafe, exactly as a non-constant escape term does (see `Filter.safe`).
+  internal var escape: Bool {
+    switch self {
+    case let .term(term): term.escape
+    case .parameter: false
+    }
+  }
+
+  /// Whether this operand reads a run-time `:parameter` — a `.parameter` is
+  /// one (it may be unbound or bound to NULL, so a `LIKE` over it is UNKNOWN);
+  /// a `.term` is not, a `Term` carrying no parameter of its own. `Filter.like`
+  /// folds this over its pattern and escape so a parameterised `LIKE` stays off
+  /// a pushdown below a later unsafe conjunct (see `Filter.nullable`).
+  internal var parameterised: Bool {
+    switch self {
+    case .term: false
+    case .parameter: true
+    }
+  }
 }
 
 extension Filter {
@@ -157,6 +246,10 @@ extension Filter {
       .membership(operand.remapped(through: slot),
                   elements.map { $0.remapped(through: slot) },
                   negated: negated)
+    case let .like(operand, pattern, escape, negated):
+      .like(operand.remapped(through: slot),
+            pattern: pattern.remapped(through: slot),
+            escape: escape?.remapped(through: slot), negated: negated)
     case let .and(lhs, rhs):
       .and(lhs.remapped(through: slot), rhs.remapped(through: slot))
     case let .or(lhs, rhs):
@@ -230,6 +323,19 @@ extension Filter {
     case let .null(term, _): term.safe
     case let .membership(operand, elements, _):
       operand.safe && elements.allSatisfy(\.safe)
+    case let .like(operand, pattern, escape, _):
+      // An escape makes the predicate UNSAFE unless it is STATICALLY a valid
+      // single-character escape: `Row.like` faults (`SQLError.argument`) on any
+      // escape that does not evaluate to a one-character text — a throw
+      // INDEPENDENT of whether a pair matches, so it must not ride below a seek
+      // or join and fire on an empty product (or be dropped by a hash key). A
+      // non-constant escape (a slot or call) or a constant that is NULL,
+      // non-text, or the wrong length is unsafe; only a `.constant` text of
+      // exactly one character (`escape.escape`) is safe. Plain LIKE (no escape)
+      // stays safe — the matcher itself never throws, a non-text operand or
+      // pattern being a definite non-match and a NULL UNKNOWN.
+      operand.safe && pattern.safe
+          && (escape.map(\.escape) ?? true)
     case let .and(lhs, rhs): lhs.safe && rhs.safe
     case let .or(lhs, rhs): lhs.safe && rhs.safe
     case let .not(operand): operand.safe
@@ -252,13 +358,17 @@ extension Filter {
   }
 
   /// Whether this filter compares against a run-time `:parameter` — a `.bound`
-  /// anywhere in it. Such a predicate reads no slot yet can be UNKNOWN, because
+  /// anywhere in it, or a `.like` whose pattern or escape operand is a
+  /// `:parameter`. Such a predicate reads no slot yet can be UNKNOWN, because
   /// the parameter may be unbound (or bound to NULL), so `nullable` counts it
-  /// even when `slots` is empty.
+  /// even when `slots` is empty — keeping `'x' LIKE :p` off a pushdown below
+  /// a later unsafe conjunct the non-short-circuiting `AND` still owes.
   private var parameterised: Bool {
     switch self {
     case .bound: true
     case .compare, .match, .null, .membership: false
+    case let .like(_, pattern, escape, _):
+      pattern.parameterised || (escape?.parameterised ?? false)
     case let .and(lhs, rhs): lhs.parameterised || rhs.parameterised
     case let .or(lhs, rhs): lhs.parameterised || rhs.parameterised
     case let .not(operand): operand.parameterised
@@ -573,6 +683,8 @@ extension Row where Self: ~Escapable {
       try (evaluate(term, routines, bindings) == .null) != negated
     case let .membership(operand, elements, negated):
       try member(operand, elements, negated, routines, bindings)
+    case let .like(operand, pattern, escape, negated):
+      try like(operand, pattern, escape, negated, routines, bindings)
     case let .and(lhs, rhs):
       // `&&`/`||` take an `@autoclosure` right operand, which would capture the
       // borrowed `~Escapable` row; spell each connective explicitly so a branch
@@ -619,4 +731,176 @@ extension Row where Self: ~Escapable {
     }
     return negated ? truth.map { !$0 } : truth
   }
+
+  /// Resolves a `LIKE` pattern or escape operand to a value: a term evaluates
+  /// against this row, a `:parameter` resolves from the bindings — an unbound
+  /// name yields `.null`, so it reads UNKNOWN exactly as a bound `NULL` does.
+  private borrowing func evaluate(_ operand: Filter.Operand,
+                                  _ routines: Routines,
+                                  _ bindings: Bindings)
+      throws(SQLError) -> Value {
+    switch operand {
+    case let .term(term):
+      try evaluate(term, routines, bindings)
+    case let .parameter(name):
+      bindings[name] ?? .null
+    }
+  }
+
+  /// Evaluates a lowered `operand [NOT] LIKE pattern [ESCAPE escape]` against
+  /// this row under three-valued logic.
+  ///
+  /// The operand, pattern, and optional escape are each evaluated ONCE, IN
+  /// ORDER, BEFORE the three-valued result is decided — so a faulting reached
+  /// operand (`(1 / K)` with `K = 0`) surfaces its throw rather than being
+  /// silently swallowed by a NULL escape. Only once all three have evaluated is
+  /// the result decided: a non-NULL escape that is not a single character is
+  /// `SQLError.argument` (the ISO rule); a NULL operand, pattern, or escape is
+  /// UNKNOWN (`nil`), the row excluded; a non-text operand or pattern is a
+  /// definite non-match (FALSE), mirroring the engine's cross-kind comparison
+  /// rule (`Row.matches`) rather than faulting. Otherwise the pattern runs
+  /// against the operand through the `%`/`_` matcher. The pattern and escape
+  /// may be a `:parameter` resolved from the bindings. `NOT LIKE` negates the
+  /// result (UNKNOWN maps to itself).
+  private borrowing func like(_ operand: Term, _ pattern: Filter.Operand,
+                              _ escape: Filter.Operand?, _ negated: Bool,
+                              _ routines: Routines, _ bindings: Bindings)
+      throws(SQLError) -> Bool? {
+    // Evaluate all three reached operands once, in order — a fault in any of
+    // them (a divide, an overflow) propagates HERE, before the NULL/escape
+    // result below can turn it into a silent UNKNOWN.
+    let subject = try evaluate(operand, routines, bindings)
+    let template = try evaluate(pattern, routines, bindings)
+    let separator: Value? =
+        if let escape { try evaluate(escape, routines, bindings) } else { nil }
+
+    // Decide the escape character. A NULL escape is UNKNOWN like a NULL
+    // operand; anything but a one-character text is `SQLError.argument`.
+    var character: Character? = nil
+    switch separator {
+    case .none, .null:
+      break
+    case let .text(text) where text.count == 1:
+      character = text.first
+    default:
+      throw .argument("LIKE ESCAPE must be a single character")
+    }
+
+    let truth: Bool? = switch (subject, template, separator) {
+    // A NULL operand, pattern, or escape is UNKNOWN.
+    case (.null, _, _), (_, .null, _), (_, _, .some(.null)):
+      nil
+    case let (.text(subject), .text(template), _):
+      matches(subject, template, escape: character)
+    // A non-text operand or pattern never matches — the engine's cross-kind
+    // comparison rule — so the run is a definite non-match, not a fault.
+    default:
+      false
+    }
+    return negated ? truth.map { !$0 } : truth
+  }
+}
+
+/// One decoded `LIKE` pattern atom, escape already resolved: `%` matches any
+/// run, `_` exactly one character, and a literal matches itself.
+private enum Atom: Equatable {
+  /// `%` — any run of characters (including the empty run).
+  case any
+  /// `_` — exactly one character.
+  case single
+  /// A literal character, matching itself (an escaped `%`, `_`, or escape
+  /// character among them).
+  case literal(Character)
+}
+
+/// The `pattern` decoded into atoms, its escape resolved, or `nil` when the
+/// pattern is ILL-FORMED — a trailing escape with no character to escape, which
+/// matches nothing. An escape character makes the next character a `.literal`
+/// (so escaped `%`, `_`, or the escape character are literals); every other
+/// character is `%` → `.any`, `_` → `.single`, else `.literal`.
+private func atoms(of pattern: Array<Character>,
+                   escape: Character?) -> Array<Atom>? {
+  var atoms = Array<Atom>()
+  atoms.reserveCapacity(pattern.count)
+  var index = 0
+  while index < pattern.count {
+    let symbol = pattern[index]
+    if symbol == escape {
+      // The next character is taken literally; a trailing escape (no character
+      // follows) makes the whole pattern match nothing.
+      guard index + 1 < pattern.count else { return nil }
+      atoms.append(.literal(pattern[index + 1]))
+      index += 2
+    } else {
+      switch symbol {
+      case "%": atoms.append(.any)
+      case "_": atoms.append(.single)
+      default: atoms.append(.literal(symbol))
+      }
+      index += 1
+    }
+  }
+  return atoms
+}
+
+/// Whether `text` matches the SQL `LIKE` `pattern`, in which `%` matches any
+/// run of characters (including the empty run) and `_` matches exactly one
+/// character; every other character matches itself. When `escape` is given, the
+/// character following it in the pattern matches that literal character (so
+/// `escape` followed by `%`, `_`, or `escape` matches a literal `%`, `_`, or
+/// the escape character).
+///
+/// The match is ANCHORED — the whole `text` must be consumed. It is the classic
+/// LINEAR two-pointer `LIKE` scan: a `%` is remembered (the pattern position
+/// after it, and the text mark it may extend to) and matching proceeds
+/// greedily; on a later mismatch the TEXT pointer is advanced past the mark and
+/// the scan resumes after the remembered `%`, rather than re-recursing. This is
+/// O(text · pattern) worst case — a pattern like `%a%a%a%b` against a long run
+/// of `a`s cannot blow up combinatorially, as a per-split recursion would. A
+/// trailing escape with no character to escape matches nothing, as no literal
+/// follows it. The comparison is over `Character`s (grapheme clusters), so it
+/// is Unicode-correct for the ASCII metadata names the engine filters and any
+/// wider text.
+internal func matches(_ text: String, _ pattern: String,
+                      escape: Character?) -> Bool {
+  let text = Array(text)
+  // A trailing escape makes the pattern match nothing.
+  guard let pattern = atoms(of: Array(pattern), escape: escape) else {
+    return false
+  }
+
+  var t = 0           // the text cursor.
+  var p = 0           // the pattern cursor.
+  var star = -1       // pattern position after the last `%`, or -1 for none.
+  var mark = 0        // the text position the last `%` may extend to consume.
+  while t < text.count {
+    if p < pattern.count, pattern[p] == .single
+        || pattern[p] == .literal(text[t]) {
+      // `_` or a matching literal consumes one character of each.
+      t += 1
+      p += 1
+    } else if p < pattern.count, pattern[p] == .any {
+      // Remember this `%` — its tail starts at `p + 1` and may extend the text
+      // from `t` — and first try to match it against the empty run.
+      star = p + 1
+      mark = t
+      p += 1
+    } else if star != -1 {
+      // A mismatch under a remembered `%`: let it consume one more character
+      // (advance the mark) and resume the pattern just after it. Backtracking
+      // the TEXT pointer, not re-recursing, keeps the scan linear.
+      p = star
+      mark += 1
+      t = mark
+    } else {
+      // A mismatch with no `%` to extend: no match.
+      return false
+    }
+  }
+  // The text is exhausted; consume any trailing `%` atoms (each matches the
+  // empty run). The match holds only if the whole pattern is then consumed.
+  while p < pattern.count, pattern[p] == .any {
+    p += 1
+  }
+  return p == pattern.count
 }

--- a/Sources/SQL/Lexer.swift
+++ b/Sources/SQL/Lexer.swift
@@ -425,6 +425,8 @@ internal struct Lexer: ~Escapable {
     case "IS": .is
     case "NULL": .null
     case "IN": .in
+    case "LIKE": .like
+    case "ESCAPE": .escape
     case "UNION": .union
     case "INTERSECT": .intersect
     case "EXCEPT": .except

--- a/Sources/SQL/Parser.swift
+++ b/Sources/SQL/Parser.swift
@@ -36,7 +36,8 @@
 /// negation       := NOT negation | primary
 /// primary        := '(' predicate ')' | comparison
 /// comparison     := expression (op (expression | param) | IS [NOT] NULL
-///                 | [NOT] IN '(' expression (',' expression)* ')')
+///                 | [NOT] IN '(' expression (',' expression)* ')'
+///                 | [NOT] LIKE expression [ESCAPE expression])
 /// expression     := additive
 /// additive       := multiplicative (('+' | '-') multiplicative)*
 /// multiplicative := factor (('*' | '/') factor)*
@@ -741,8 +742,10 @@ internal struct Parser: ~Escapable {
   /// `IS NULL` (or `IS NOT NULL`) tail tests the left expression for `NULL`
   /// rather than comparing it — the way a nullable column is filtered. An `IN`
   /// (or `NOT IN`) tail tests the left expression for membership in a
-  /// parenthesised value list. A leading `NOT` here can only introduce `NOT IN`:
-  /// a prefix `NOT` predicate is consumed by `negation` before this point.
+  /// parenthesised value list. A `LIKE` (or `NOT LIKE`) tail tests the left
+  /// expression's text against a pattern, with an optional `ESCAPE` character.
+  /// A leading `NOT` here can only introduce `NOT IN` or `NOT LIKE`: a prefix
+  /// `NOT` predicate is consumed by `negation` before this point.
   private mutating func comparison() throws(SQLError) -> Predicate {
     let left = try expression()
     if try match(.is) {
@@ -753,7 +756,13 @@ internal struct Parser: ~Escapable {
     if try match(.in) {
       return try membership(left, negated: false)
     }
+    if try match(.like) {
+      return try like(left, negated: false)
+    }
     if try match(.not) {
+      if try match(.like) {
+        return try like(left, negated: true)
+      }
       try expect(.in)
       return try membership(left, negated: true)
     }
@@ -782,6 +791,37 @@ internal struct Parser: ~Escapable {
     }
     try expect(.rparen)
     return .membership(left, values, negated: negated)
+  }
+
+  /// Parses the pattern tail of `left [NOT] LIKE pattern [ESCAPE escape]` — the
+  /// `LIKE` is already consumed — into a `like` predicate over `left`.
+  ///
+  /// The pattern is an `Operand` — a scalar expression (a literal, a column, or
+  /// a call), so a pattern can be computed rather than only a literal, or a
+  /// run-time `:parameter` bound at eval (`Name LIKE :pattern`), the same
+  /// binding the comparison arm accepts as a right operand. An optional
+  /// `ESCAPE` names the escape as a further `Operand`, so it too can be bound
+  /// (`ESCAPE :e`).
+  private mutating func like(_ left: Expression, negated: Bool)
+      throws(SQLError) -> Predicate {
+    let pattern = try operand()
+    let escape: Predicate.Operand? = if try match(.escape) {
+      try operand()
+    } else {
+      nil
+    }
+    return .like(left, pattern: pattern, escape: escape, negated: negated)
+  }
+
+  /// Parses a `LIKE` pattern or escape operand: a `:parameter` placeholder
+  /// (bound at eval from the engine's bindings, as the comparison arm consumes
+  /// one after an operator) or an ordinary scalar expression.
+  private mutating func operand() throws(SQLError) -> Predicate.Operand {
+    if case let .parameter(name) = current?.kind {
+      _ = try advance(expecting: "a parameter")
+      return .parameter(name)
+    }
+    return try .expression(expression())
   }
 
   /// Parses a comparison operator.

--- a/Sources/SQL/Resolve.swift
+++ b/Sources/SQL/Resolve.swift
@@ -46,6 +46,11 @@ private func lower(_ predicate: Predicate,
     // UNKNOWN is UNKNOWN — not FALSE, and `NOT` maps that UNKNOWN to itself, so
     // `NOT IN` a list holding NULL is never TRUE.
     try membership(term(expression), values, negated: negated, term: term)
+  case let .like(operand, pattern, escape, negated):
+    // Lower each operand to a first-class `Filter.like`; the optional escape
+    // lowers only when present. The matcher and three-valued handling live in
+    // the runtime, so lowering just resolves the operand terms.
+    try like(operand, pattern, escape, negated: negated, term: term)
   case let .and(lhs, rhs):
     try .and(lower(lhs, term: term), lower(rhs, term: term))
   case let .or(lhs, rhs):
@@ -86,6 +91,38 @@ private func membership(_ left: Term, _ values: Array<Expression>,
     try elements.append(term(value))
   }
   return .membership(left, elements, negated: negated)
+}
+
+/// Lowers `operand [NOT] LIKE pattern [ESCAPE escape]` to a first-class
+/// `Filter.like`, the operand lowered through `term`, the pattern and optional
+/// escape through `operand(_:)` — an expression lowers to a term, a
+/// `:parameter` passes through as a bound name resolved at eval.
+///
+/// Lowering is a plain term resolution — the `%`/`_` matcher and the
+/// three-valued/cross-kind handling are the runtime's — so this mirrors the
+/// membership lowering, differing only in carrying the pattern and escape
+/// operands rather than a value list.
+private func like(_ operand: Expression, _ pattern: Predicate.Operand,
+                  _ escape: Predicate.Operand?, negated: Bool,
+                  term: (Expression) throws(SQLError) -> Term)
+    throws(SQLError) -> Filter {
+  let escape: Filter.Operand? =
+      if let escape { try lower(escape, term: term) } else { nil }
+  return try .like(term(operand), pattern: lower(pattern, term: term),
+                   escape: escape, negated: negated)
+}
+
+/// Lowers a `LIKE` pattern or escape `operand` to its filter form: an
+/// expression lowers to a `.term` through `term`; a `:parameter` passes through
+/// as a bound `.parameter` name resolved from the bindings at eval, the same
+/// mechanism a `Predicate.bound` comparison uses.
+private func lower(_ operand: Predicate.Operand,
+                   term: (Expression) throws(SQLError) -> Term)
+    throws(SQLError) -> Filter.Operand {
+  switch operand {
+  case let .expression(expression): try .term(term(expression))
+  case let .parameter(name): .parameter(name)
+  }
 }
 
 /// The resolved sort keys `order` lowers to, in major-to-minor order — each
@@ -650,6 +687,18 @@ internal struct Scope {
       }, equality: { value throws(SQLError) in
         matched(operand, value, routines)
       })
+    case let .like(operand, pattern, escape, _):
+      // Validate the operand, pattern, and optional escape for REAL errors
+      // (unknown column, bad arity, …); a non-text operand or pattern is NOT
+      // rejected — the run yields a definite FALSE via `Row.like` without
+      // faulting (the cross-kind rule), and the schema check must accept what
+      // the run accepts, as the `IN` cross-kind element does.
+      _ = try validate(operand, routines)
+      try validate(pattern, routines)
+      if let escape {
+        try validate(escape, routines)
+        try reject(escape, routines)
+      }
     case let .and(lhs, rhs):
       try check(lhs, routines)
       if constant(lhs, routines) != false { try check(rhs, routines) }
@@ -658,6 +707,41 @@ internal struct Scope {
       if constant(lhs, routines) != true { try check(rhs, routines) }
     case let .not(operand):
       try check(operand, routines)
+    }
+  }
+
+  /// Type-checks a `LIKE` pattern or escape `operand` for the side effect of
+  /// validation: an expression is validated (`validate`), a `:parameter` reads
+  /// nothing at compile time (its value arrives from the bindings at run time),
+  /// so it needs no check, as a `Predicate.bound` parameter needs none.
+  private func validate(_ operand: Predicate.Operand, _ routines: Routines)
+      throws(SQLError) {
+    if case let .expression(expression) = operand {
+      _ = try validate(expression, routines)
+    }
+  }
+
+  /// Rejects a STATICALLY-invalid `LIKE` `escape` at validation, as `Row.like`
+  /// would fault it on EVERY row: a ROW-INDEPENDENT escape expression that
+  /// folds (`constant`) to a value that is neither NULL (a valid UNKNOWN) nor a
+  /// single-character text (a non-text, or a wrong-length text) makes the query
+  /// un-runnable, so reject it here with the same message and condition the run
+  /// raises. A `:parameter`, a column, or any other non-constant escape is per
+  /// row and cannot be decided statically (`constant` is `nil`) — the run
+  /// validates it.
+  private func reject(_ escape: Predicate.Operand, _ routines: Routines)
+      throws(SQLError) {
+    guard case let .expression(expression) = escape,
+        let value = constant(expression, routines) else {
+      return
+    }
+    switch value {
+    case .null:
+      break
+    case let .text(text) where text.count == 1:
+      break
+    default:
+      throw .argument("LIKE ESCAPE must be a single character")
     }
   }
 
@@ -825,8 +909,68 @@ internal struct Scope {
         matched(operand, value, routines)
       }
       return negated ? truth.map { !$0 } : truth
+    case let .like(operand, pattern, escape, negated):
+      // Fold `x LIKE p` when the operand, pattern, and optional escape all fold
+      // to ROW-INDEPENDENT constants — the same `constant(_ expression:)` the
+      // run's terms evaluate through — running the SAME matcher `Row.like`
+      // does; any row-dependent operand leaves it per row (`nil`). `NOT LIKE`
+      // negates the folded truth (UNKNOWN maps to itself).
+      guard let truth = matched(operand, pattern, escape, routines) else {
+        return nil
+      }
+      return negated ? !truth : truth
     case .bound:
       return nil
+    }
+  }
+
+  /// The definite truth of `operand LIKE pattern [ESCAPE escape]` when the
+  /// operand, pattern, and optional escape all fold to ROW-INDEPENDENT
+  /// constants (via `constant(_ expression:)`), else `nil`. It folds each side
+  /// and runs the SAME `matches` the run's `Row.like` does — a NULL side is
+  /// UNKNOWN (`nil`), a non-text operand or pattern a definite non-match
+  /// (FALSE), a bad escape collapses to `nil` (undecided) rather than faulting
+  /// a compile-time reachability walk.
+  private func matched(_ operand: Expression, _ pattern: Predicate.Operand,
+                       _ escape: Predicate.Operand?, _ routines: Routines)
+      -> Bool? {
+    guard let operand = constant(operand, routines),
+        let pattern = constant(pattern, routines) else {
+      return nil
+    }
+    let character: Character?
+    switch escape {
+    case .none:
+      character = nil
+    case let .some(escape):
+      switch constant(escape, routines) {
+      case let .text(text) where text.count == 1:
+        character = text.first
+      // A NULL, absent, ill-formed, or `:parameter` escape is not a decidable
+      // fold — leave the LIKE per row (`nil`) rather than deciding a match.
+      default:
+        return nil
+      }
+    }
+    return switch (operand, pattern) {
+    case (.null, _), (_, .null):
+      nil
+    case let (.text(operand), .text(pattern)):
+      matches(operand, pattern, escape: character)
+    default:
+      false
+    }
+  }
+
+  /// The constant `Value` a `LIKE` pattern or escape `operand` folds to when it
+  /// is ROW-INDEPENDENT (`constant(_ expression:)`), else `nil`. A `:parameter`
+  /// is per run — its value arrives from the bindings — so it never folds
+  /// constant, exactly as a column does.
+  private func constant(_ operand: Predicate.Operand, _ routines: Routines)
+      -> Value? {
+    switch operand {
+    case let .expression(expression): constant(expression, routines)
+    case .parameter: nil
     }
   }
 
@@ -858,6 +1002,15 @@ internal struct Scope {
     }
   }
 
+  /// Validates the aggregate sub-expressions of a `LIKE` pattern or escape
+  /// `operand` — an expression's own, none in a `:parameter`.
+  func aggregates(in operand: Predicate.Operand, _ routines: Routines = [:])
+      throws(SQLError) {
+    if case let .expression(expression) = operand {
+      try aggregates(in: expression, routines)
+    }
+  }
+
   /// Validates the aggregate sub-expressions of `predicate` — a `HAVING`'s
   /// aggregates are collected and FOLDED by the group node before the `HAVING`
   /// filter runs, so they are reachable even in an arm the filter's
@@ -877,6 +1030,10 @@ internal struct Scope {
     case let .membership(operand, values, _):
       try aggregates(in: operand, routines)
       for value in values { try aggregates(in: value, routines) }
+    case let .like(operand, pattern, escape, _):
+      try aggregates(in: operand, routines)
+      try aggregates(in: pattern, routines)
+      if let escape { try aggregates(in: escape, routines) }
     case let .and(lhs, rhs), let .or(lhs, rhs):
       try aggregates(in: lhs, routines)
       try aggregates(in: rhs, routines)
@@ -940,6 +1097,18 @@ internal struct Scope {
     }
   }
 
+  /// The value a `LIKE` pattern or escape `operand` folds to over the empty
+  /// group: an expression folds through `empty(_ expression:)`; a `:parameter`
+  /// is UNBOUND here — the empty-group fold carries no bindings — so it is
+  /// `.null`, reading UNKNOWN exactly as a `Predicate.bound` parameter does.
+  func empty(_ operand: Predicate.Operand, _ routines: Routines = [:])
+      throws(SQLError) -> Value {
+    switch operand {
+    case let .expression(expression): try empty(expression, routines)
+    case .parameter: .null
+    }
+  }
+
   /// Whether a `HAVING` `predicate` passes over the single empty group a
   /// constant-false `WHERE` leaves — TRUE keeps the group (the projection then
   /// runs), FALSE or UNKNOWN (`nil`) drops it (the projection is unreachable).
@@ -979,6 +1148,37 @@ internal struct Scope {
       let lhs = try empty(operand, routines)
       let truth = try membership(of: values) { value throws(SQLError) in
         matches(lhs, .equal, try empty(value, routines))
+      }
+      return negated ? truth.map { !$0 } : truth
+    case let .like(operand, pattern, escape, negated):
+      // Fold `x LIKE p` over the empty group as `Row.like` evaluates it: the
+      // operand, pattern, and optional escape are each folded ONCE, IN ORDER,
+      // BEFORE the result is decided (so a faulting reached operand surfaces
+      // its throw rather than being swallowed by a NULL escape). Then a NULL
+      // operand, pattern, or escape is UNKNOWN, a non-text operand or pattern a
+      // definite non-match, else the `%`/`_` matcher decides; a non-NULL escape
+      // that is not a single character faults `SQLError.argument`, as the run
+      // does. `NOT LIKE` negates.
+      let subject = try empty(operand, routines)
+      let template = try empty(pattern, routines)
+      let separator: Value? =
+          if let escape { try empty(escape, routines) } else { nil }
+      var character: Character? = nil
+      switch separator {
+      case .none, .null:
+        break
+      case let .text(text) where text.count == 1:
+        character = text.first
+      default:
+        throw .argument("LIKE ESCAPE must be a single character")
+      }
+      let truth: Bool? = switch (subject, template, separator) {
+      case (.null, _, _), (_, .null, _), (_, _, .some(.null)):
+        nil
+      case let (.text(subject), .text(template), _):
+        matches(subject, template, escape: character)
+      default:
+        false
       }
       return negated ? truth.map { !$0 } : truth
     case let .and(lhs, rhs):
@@ -1429,6 +1629,10 @@ extension Filter {
       for element in elements {
         element.references(into: &ordinals)
       }
+    case let .like(operand, pattern, escape, _):
+      operand.references(into: &ordinals)
+      pattern.references(into: &ordinals)
+      escape?.references(into: &ordinals)
     case let .and(lhs, rhs), let .or(lhs, rhs):
       lhs.references(into: &ordinals)
       rhs.references(into: &ordinals)

--- a/Sources/SQL/Token.swift
+++ b/Sources/SQL/Token.swift
@@ -50,6 +50,8 @@ extension Token {
     case `is`
     case null
     case `in`
+    case like
+    case escape
     case union
     case intersect
     case except
@@ -135,6 +137,8 @@ extension Token.Kind {
     case .is: "IS"
     case .null: "NULL"
     case .in: "IN"
+    case .like: "LIKE"
+    case .escape: "ESCAPE"
     case .union: "UNION"
     case .intersect: "INTERSECT"
     case .except: "EXCEPT"

--- a/Tests/SQLTests/LikeTests.swift
+++ b/Tests/SQLTests/LikeTests.swift
@@ -1,0 +1,737 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQL
+
+import SQLTestSupport
+
+// MARK: - Fixture
+
+/// A relation exercising the `LIKE` predicate: a text `Name` that is `NULL` in
+/// one row (so the three-valued NULL-operand corner is reachable), an integer
+/// `K` for the cross-kind (non-text) operand case, and an `Id` to project.
+private func names() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["Id": .integer, "Name": .text, "K": .integer]) {
+      Row(1, "abc", 10)
+      Row(2, "abd", 20)
+      Row(3, "xyz", 30)
+      Row(4, nil, 40)
+    }
+  }
+}
+
+// MARK: - Parsing
+
+/// Parses `text` and returns its `Select`, failing on any other shape.
+private func parse(select text: String) throws -> Select {
+  guard case let .select(.select(select)) = try Statement(parsing: text) else {
+    Issue.record("expected a single SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return select
+}
+
+struct LikeParsingTests {
+  @Test func `parses a LIKE pattern`() throws {
+    let select = try parse(select: "SELECT * FROM T WHERE Name LIKE 'a%'")
+    #expect(select.predicate
+                == .like(.column("Name"),
+                         pattern: .expression(.literal(.string("a%"))),
+                         escape: nil, negated: false))
+  }
+
+  @Test func `parses a NOT LIKE pattern`() throws {
+    let select = try parse(select: "SELECT * FROM T WHERE Name NOT LIKE 'a%'")
+    #expect(select.predicate
+                == .like(.column("Name"),
+                         pattern: .expression(.literal(.string("a%"))),
+                         escape: nil, negated: true))
+  }
+
+  @Test func `parses a LIKE with an ESCAPE character`() throws {
+    let select =
+        try parse(select: "SELECT * FROM T WHERE Name LIKE 'a\\%' ESCAPE '\\'")
+    #expect(select.predicate
+                == .like(.column("Name"),
+                         pattern: .expression(.literal(.string("a\\%"))),
+                         escape: .expression(.literal(.string("\\"))),
+                         negated: false))
+  }
+
+  @Test func `parses a LIKE over an expression pattern`() throws {
+    let select = try parse(select: "SELECT * FROM T WHERE Name LIKE Name")
+    #expect(select.predicate
+                == .like(.column("Name"),
+                         pattern: .expression(.column("Name")),
+                         escape: nil, negated: false))
+  }
+
+  @Test func `parses a LIKE with a bound pattern`() throws {
+    let select = try parse(select: "SELECT * FROM T WHERE Name LIKE :pattern")
+    #expect(select.predicate
+                == .like(.column("Name"), pattern: .parameter("pattern"),
+                         escape: nil, negated: false))
+  }
+
+  @Test func `parses a LIKE with a bound escape`() throws {
+    let select = try parse(select:
+        "SELECT * FROM T WHERE Name LIKE :pattern ESCAPE :e")
+    #expect(select.predicate
+                == .like(.column("Name"), pattern: .parameter("pattern"),
+                         escape: .parameter("e"), negated: false))
+  }
+}
+
+// MARK: - Matcher
+
+struct LikeMatcherTests {
+  @Test func `a percent matches any trailing run`() throws {
+    try names().expect("SELECT Id FROM T WHERE Name LIKE 'a%'",
+                       yields: [[1], [2]])
+  }
+
+  @Test func `an underscore matches exactly one character`() throws {
+    try names().expect("SELECT Id FROM T WHERE Name LIKE '_bc'", yields: [[1]])
+  }
+
+  @Test func `an underscore does not match the wrong length`() throws {
+    // `'abc' LIKE 'a_'` is FALSE — `a_` matches a two-character string, and
+    // every Name is three characters — so no row qualifies.
+    try names().empty("SELECT Id FROM T WHERE Name LIKE 'a_'")
+  }
+
+  @Test func `a percent matches an interior run`() throws {
+    // `a%c` backtracks: the `%` consumes `b`, then `c` anchors the tail.
+    try names().expect("SELECT Id FROM T WHERE Name LIKE 'a%c'", yields: [[1]])
+  }
+
+  @Test func `a percent matches the empty run`() throws {
+    // `abc%` matches `abc` with the `%` consuming nothing.
+    try names().expect("SELECT Id FROM T WHERE Name LIKE 'abc%'", yields: [[1]])
+  }
+
+  @Test func `an empty pattern matches only the empty string`() throws {
+    try Catalog {
+      Relation("S", ["Id": .integer, "Name": .text]) {
+        Row(1, "")
+        Row(2, "a")
+      }
+    }.expect("SELECT Id FROM S WHERE Name LIKE ''", yields: [[1]])
+  }
+
+  @Test func `a bare pattern matches an exact string`() throws {
+    try names().expect("SELECT Id FROM T WHERE Name LIKE 'abc'", yields: [[1]])
+  }
+}
+
+// MARK: - Escape
+
+struct LikeEscapeTests {
+  /// A single-row relation whose Name holds a literal `%`, so an escaped
+  /// pattern must match it as a literal rather than a wildcard.
+  private func literal() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["Id": .integer, "Name": .text]) {
+        Row(1, "a%b")
+        Row(2, "axb")
+      }
+    }
+  }
+
+  @Test func `an escaped percent matches a literal percent`() throws {
+    // `'a%b' LIKE 'a\%b' ESCAPE '\'` — the escaped `%` matches a literal `%`,
+    // so only row 1 (whose Name is `a%b`) qualifies, NOT row 2 (`axb`), which
+    // an UNescaped `a%b` would also match.
+    try literal().expect(
+        "SELECT Id FROM T WHERE Name LIKE 'a\\%b' ESCAPE '\\'", yields: [[1]])
+  }
+
+  @Test func `an unescaped wildcard still matches under ESCAPE`() throws {
+    // With an ESCAPE declared but a bare `%`, the `%` is still a wildcard, so
+    // both rows match `a%b`.
+    try literal().expect("SELECT Id FROM T WHERE Name LIKE 'a%b' ESCAPE '\\'",
+                         yields: [[1], [2]])
+  }
+
+  @Test func `an escaped underscore matches a literal underscore`() throws {
+    try Catalog {
+      Relation("U", ["Id": .integer, "Name": .text]) {
+        Row(1, "a_b")
+        Row(2, "axb")
+      }
+    }.expect("SELECT Id FROM U WHERE Name LIKE 'a\\_b' ESCAPE '\\'",
+             yields: [[1]])
+  }
+
+  @Test func `a non-character ESCAPE faults`() throws {
+    // ISO requires the escape to be a single character; a multi-character one
+    // is `SQLError.argument` at evaluation.
+    try names().expect(
+        "SELECT Id FROM T WHERE Name LIKE 'a%' ESCAPE 'xy'",
+        fails: .argument("LIKE ESCAPE must be a single character"))
+  }
+}
+
+// MARK: - Three-valued logic
+
+struct LikeThreeValuedTests {
+  @Test func `a NULL operand makes LIKE UNKNOWN`() throws {
+    // Row 4's Name is NULL, so `NULL LIKE 'a%'` is UNKNOWN — the row is dropped
+    // rather than admitted, and NOT LIKE does not admit it either.
+    try names().expect("SELECT Id FROM T WHERE Name LIKE 'a%'",
+                       yields: [[1], [2]])
+    try names().expect("SELECT Id FROM T WHERE Name NOT LIKE 'a%'",
+                       yields: [[3]])
+  }
+
+  @Test func `a NULL pattern makes LIKE UNKNOWN`() throws {
+    // A NULL pattern makes every row UNKNOWN, so no row is admitted — under
+    // either LIKE or NOT LIKE.
+    try Catalog {
+      Relation("N", ["Id": .integer, "P": .text]) {
+        Row(1, nil)
+      }
+    }.empty("SELECT Id FROM N WHERE 'abc' LIKE P")
+    try Catalog {
+      Relation("N", ["Id": .integer, "P": .text]) {
+        Row(1, nil)
+      }
+    }.empty("SELECT Id FROM N WHERE 'abc' NOT LIKE P")
+  }
+
+  @Test func `NOT LIKE negates the match`() throws {
+    // Rows whose non-NULL Name does not begin `a`; row 4 (NULL) is UNKNOWN and
+    // dropped.
+    try names().expect("SELECT Id FROM T WHERE Name NOT LIKE 'a%'",
+                       yields: [[3]])
+  }
+
+  @Test func `a non-text operand is a definite non-match`() throws {
+    // `K` is an integer column, so `K LIKE '10'` is a cross-kind comparison —
+    // FALSE for every row via the engine's cross-kind rule, NOT a fault — so no
+    // row qualifies and NOT LIKE admits every row (a definite non-match, not
+    // UNKNOWN).
+    try names().empty("SELECT Id FROM T WHERE K LIKE '10'")
+    try names().expect("SELECT Id FROM T WHERE K NOT LIKE '10'",
+                       yields: [[1], [2], [3], [4]])
+  }
+}
+
+// MARK: - Type checking
+
+struct LikeTypeTests {
+  /// Parses `text` to a query, failing on any other statement.
+  private func parse(_ text: String) throws -> Query {
+    guard case let .select(query) = try Statement(parsing: text) else {
+      Issue.record("expected a SELECT statement")
+      throw SQLError.incomplete(expected: "a SELECT statement")
+    }
+    return query
+  }
+
+  @Test func `a non-text operand does not fault the schema check`() throws {
+    // `K` is an integer column, but `K LIKE '10'` does NOT fault the schema
+    // check: the run yields a definite FALSE without faulting (the cross-kind
+    // rule), so the check must accept what the run accepts.
+    let query = try parse("SELECT Id FROM T WHERE K LIKE '10'")
+    _ = try names().columns(of: query, validate: true)
+  }
+
+  @Test func `a bad operand expression faults the schema check`() throws {
+    // The operand and pattern are still validated for REAL errors: `Name + 1`
+    // is text arithmetic, which faults exactly as a run would.
+    let query = try parse("SELECT Id FROM T WHERE Name + 1 LIKE 'a%'")
+    let resolve = { () throws -> Array<OutputColumn> in
+      try names().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.operand("operands must be numeric")) {
+      try resolve()
+    }
+  }
+}
+
+// MARK: - Pushdown safety
+
+/// Whether `plan` reaches a `.scan` carrying a seek boundary — the observable
+/// consequence of a `safe` conjunct riding down to its base scan.
+private func seeks(_ plan: Plan) -> Bool {
+  switch plan {
+  case let .scan(_, _, seek): seek != nil
+  case let .select(_, source): seeks(source)
+  case let .project(_, source): seeks(source)
+  case let .sort(_, source): seeks(source)
+  case let .limit(_, _, source): seeks(source)
+  case let .distinct(source): seeks(source)
+  case let .aggregate(_, _, source): seeks(source)
+  case let .derived(_, sub, _, _): seeks(sub)
+  case let .product(left, right): seeks(left) || seeks(right)
+  case let .join(outer, _, _, _, _, _, _): seeks(outer)
+  case let .outer(left, right, _, _): seeks(left) || seeks(right)
+  case let .setop(_, left, right, _): seeks(left) || seeks(right)
+  case .single: false
+  }
+}
+
+/// Whether `plan` reaches a `.join` — a hash join formed from an `ON` whose
+/// every conjunct is safe, extracting an equi key.
+private func joins(_ plan: Plan) -> Bool {
+  switch plan {
+  case .join: true
+  case let .select(_, source): joins(source)
+  case let .project(_, source): joins(source)
+  case let .sort(_, source): joins(source)
+  case let .limit(_, _, source): joins(source)
+  case let .distinct(source): joins(source)
+  case let .aggregate(_, _, source): joins(source)
+  case let .derived(_, sub, _, _): joins(sub)
+  case let .product(left, right): joins(left) || joins(right)
+  case let .outer(left, right, _, _): joins(left) || joins(right)
+  case let .setop(_, left, right, _): joins(left) || joins(right)
+  case .single, .scan: false
+  }
+}
+
+/// Whether `plan` reaches a `.select` standing directly over a `.product` — the
+/// residual product-under-select a join forms when an unsafe `ON` conjunct bars
+/// hash-key extraction, so the whole `ON` is evaluated per pair.
+private func residual(_ plan: Plan) -> Bool {
+  switch plan {
+  case .select(_, .product): true
+  case let .select(_, source): residual(source)
+  case let .project(_, source): residual(source)
+  case let .sort(_, source): residual(source)
+  case let .limit(_, _, source): residual(source)
+  case let .distinct(source): residual(source)
+  case let .aggregate(_, _, source): residual(source)
+  case let .derived(_, sub, _, _): residual(sub)
+  case let .product(left, right): residual(left) || residual(right)
+  case let .join(outer, _, _, _, _, _, _): residual(outer)
+  case let .outer(left, right, _, _): residual(left) || residual(right)
+  case let .setop(_, left, right, _): residual(left) || residual(right)
+  case .single, .scan: false
+  }
+}
+
+/// Whether `plan` is (or reaches through unary operators) a `.select` — a
+/// filter standing over a source, the shape a conjunct kept out of a pushdown
+/// leaves behind.
+private func floats(_ plan: Plan) -> Bool {
+  switch plan {
+  case .select: true
+  case let .project(_, source): floats(source)
+  case let .sort(_, source): floats(source)
+  case let .limit(_, _, source): floats(source)
+  case let .derived(_, sub, _, _): floats(sub)
+  default: false
+  }
+}
+
+/// The `LIKE` escape's effect on `safe`, hence on pushdown/seek/join-reorder
+/// eligibility: a `.like` is `safe` (may ride below a seek or join) only when
+/// its escape is absent OR STATICALLY a single-character text constant, because
+/// `Row.like` faults on any other escape INDEPENDENTLY of whether a pair
+/// matches — so a hash join must not drop a non-matching pair (nor a seek a
+/// narrowed run) before that fault fires.
+struct LikeSafetyTests {
+  /// A two-relation fixture for the `ON`-residual reordering hazard: `A` has
+  /// one row whose join key `K` is NULL (so the equi `A.K = B.K` is UNKNOWN,
+  /// not a definite FALSE that would short-circuit the Kleene `AND` before the
+  /// escaped LIKE ran) and whose escape column `E` is a multi-character text
+  /// (an invalid escape). A hash key would DROP the NULL-key pair before the
+  /// escaped `LIKE` faults, hiding the fault; keeping the whole `ON` a residual
+  /// over the pair runs the LIKE and faults.
+  private func mismatched() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("A", ["K": .integer, "Name": .text, "E": .text]) {
+        Row(nil, "abc", "xy")
+      }
+      Relation("B", ["K": .integer]) {
+        Row(2)
+      }
+    }
+  }
+
+  /// Parses `text` to a query, failing on any other statement.
+  private func query(_ text: String) throws -> Query {
+    guard case let .select(query) = try Statement(parsing: text) else {
+      Issue.record("expected a SELECT statement")
+      throw SQLError.incomplete(expected: "a SELECT statement")
+    }
+    return query
+  }
+
+  @Test func `a non-constant escape is unsafe and bars ON key extraction`()
+      throws {
+    // `ON A.K = B.K AND A.Name LIKE 'a%' ESCAPE A.E`, `A.E` a multi-character
+    // slot — an escape that faults regardless of the pair. Unsafe, it bars the
+    // equi from becoming a hash key: `nest` forms no `.join`, the level is a
+    // residual `.select` over the `.product`, so the whole `ON` runs per pair.
+    let plan = try mismatched().optimise(mismatched().compile(query("""
+        SELECT A.K FROM A JOIN B ON A.K = B.K AND A.Name LIKE 'a%' ESCAPE A.E
+        """)).pushdown(), [:])
+    #expect(!joins(plan))
+    #expect(residual(plan))
+  }
+
+  @Test func `a non-constant escape faults even against a non-matching pair`()
+      throws {
+    // The same `ON A.K = B.K AND A.Name LIKE 'a%' ESCAPE A.E` run against the
+    // single pair (`A.K` NULL, `B.K = 2`). The equi is UNKNOWN, so the Kleene
+    // `AND` does not short-circuit and evaluates the LIKE. Because the escaped
+    // LIKE is UNSAFE, no key is hoisted and the residual runs the whole `ON`
+    // per pair, so the invalid escape faults `SQLError.argument` — where
+    // marking it safe would extract the key, drop the NULL-key pair, and HIDE
+    // the fault (return no rows).
+    try mismatched().expect("""
+        SELECT A.K FROM A JOIN B ON A.K = B.K AND A.Name LIKE 'a%' ESCAPE A.E
+        """,
+        fails: .argument("LIKE ESCAPE must be a single character"))
+  }
+
+  @Test func `a constant multi-character escape is unsafe and faults`() throws {
+    // A constant escape that is a text but NOT a single character (`ESCAPE
+    // 'ab'`) is likewise unsafe — it faults regardless of the pair — so it too
+    // bars key extraction (a residual `.select` over the `.product`, no
+    // `.join`) and the residual faults against the NULL-key pair rather than a
+    // hash key dropping it.
+    let sql = """
+        SELECT A.K FROM A JOIN B ON A.K = B.K AND A.Name LIKE 'a%' ESCAPE 'ab'
+        """
+    let plan =
+        try mismatched().optimise(mismatched().compile(query(sql)).pushdown(),
+                                  [:])
+    #expect(!joins(plan))
+    #expect(residual(plan))
+    try mismatched().expect(sql,
+        fails: .argument("LIKE ESCAPE must be a single character"))
+  }
+
+  @Test func `a constant single-character escape is safe and may be sought`()
+      throws {
+    // `WHERE Name LIKE '_%' ESCAPE '\' AND Id = 2` over an Id-sorted relation:
+    // the escape is a STATIC single-character constant, so the LIKE is safe and
+    // does not bar the seekable `Id = 2` from riding down to the base scan.
+    let catalog = try Catalog {
+      Relation("S", ["Id": .integer, "Name": .text], sorted: "Id") {
+        Row(1, "abc")
+        Row(2, "xyz")
+      }
+    }
+    let plan = try catalog.optimise(catalog.compile(query("""
+        SELECT Id FROM S WHERE Name LIKE '_%' ESCAPE '\\' AND Id = 2
+        """)).pushdown(), [:])
+    #expect(seeks(plan))
+
+    // …and it still matches correctly: only row 2 has `Id = 2`, and its
+    // three-character Name matches `_%` (one character then any run).
+    try catalog.expect("""
+        SELECT Id FROM S WHERE Name LIKE '_%' ESCAPE '\\' AND Id = 2
+        """, yields: [[2]])
+  }
+
+  @Test func `a plain LIKE with no escape stays safe and may be sought`()
+      throws {
+    // A plain `LIKE` (no escape) never faults — a non-text operand or pattern
+    // is a definite non-match and a NULL is UNKNOWN — so it stays safe: the
+    // seekable `Id = 2` still rides down to the base scan beside it.
+    let catalog = try Catalog {
+      Relation("S", ["Id": .integer, "Name": .text], sorted: "Id") {
+        Row(1, "abc")
+        Row(2, "xyz")
+      }
+    }
+    let plan = try catalog.optimise(catalog.compile(query("""
+        SELECT Id FROM S WHERE Name LIKE 'x%' AND Id = 2
+        """)).pushdown(), [:])
+    #expect(seeks(plan))
+    try catalog.expect("SELECT Id FROM S WHERE Name LIKE 'x%' AND Id = 2",
+                       yields: [[2]])
+  }
+}
+
+// MARK: - Bound pattern
+
+struct LikeBoundTests {
+  @Test func `a LIKE over a WHERE column returns the right rows`() throws {
+    // The prefix wildcard exercises LIKE over a real column in a WHERE — rows 1
+    // and 2 begin `ab`, row 3 does not, and row 4 (NULL) is UNKNOWN.
+    try names().expect("SELECT Id FROM T WHERE Name LIKE 'ab%'",
+                       yields: [[1], [2]])
+  }
+
+  @Test func `a column pattern matches per row`() throws {
+    // The pattern is itself a column, evaluated per row: every non-NULL Name
+    // matches itself, and row 4 (NULL on both sides) is UNKNOWN and dropped.
+    try names().expect("SELECT Id FROM T WHERE Name LIKE Name",
+                       yields: [[1], [2], [3]])
+  }
+}
+
+// MARK: - Evaluation order
+
+/// The operand, pattern, and escape are each evaluated ONCE, IN ORDER, BEFORE
+/// the three-valued NULL result is decided — so a fault in a REACHED operand
+/// (`1 / K` with `K = 0`) surfaces rather than being swallowed by a NULL escape
+/// that an early return would have turned into a silent UNKNOWN.
+struct LikeEvaluationOrderTests {
+  /// A relation whose K is `0` in one row (so `1 / K` faults) and whose escape
+  /// column E is NULL, to exercise the faulting-operand-before-NULL-escape
+  /// corner.
+  private func faulting() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("F", ["Id": .integer, "K": .integer, "E": .text]) {
+        Row(1, 0, nil)
+      }
+    }
+  }
+
+  @Test func `a faulting operand surfaces before a NULL escape UNKNOWN`()
+      throws {
+    // `(1 / K) LIKE 'x' ESCAPE E` with `K = 0, E = NULL`. The operand `1 / K`
+    // faults `SQLError.divide`; the executor must evaluate the reached operand
+    // BEFORE deciding the NULL-escape UNKNOWN — an early return on the NULL
+    // escape would silently FILTER the row (UNKNOWN) and hide the divide.
+    // ADVERSARIAL: reverting to early-return-on-NULL-escape stops this throw.
+    try faulting().expect(
+        "SELECT Id FROM F WHERE (1 / K) LIKE 'x' ESCAPE E",
+        fails: .divide)
+  }
+
+  @Test func `a NULL escape with a safe operand is a clean UNKNOWN`() throws {
+    // A plain safe operand under a NULL escape is UNKNOWN — the row is excluded
+    // WITHOUT a throw, so the eval-order fix does not turn every NULL escape
+    // into a fault.
+    try Catalog {
+      Relation("F", ["Id": .integer, "Name": .text, "E": .text]) {
+        Row(1, "x", nil)
+      }
+    }.empty("SELECT Id FROM F WHERE Name LIKE 'x' ESCAPE E")
+  }
+}
+
+// MARK: - Static escape validation
+
+/// A statically-invalid ESCAPE (a constant that is not a single-character text)
+/// is rejected at VALIDATION (`columns(of:validate:)`), not left to fault on
+/// every row — `check` folds a row-independent escape and rejects a bad one.
+struct LikeEscapeValidationTests {
+  /// Parses `text` to a query, failing on any other statement.
+  private func query(_ text: String) throws -> Query {
+    guard case let .select(query) = try Statement(parsing: text) else {
+      Issue.record("expected a SELECT statement")
+      throw SQLError.incomplete(expected: "a SELECT statement")
+    }
+    return query
+  }
+
+  @Test func `a constant multi-character escape faults validation`() throws {
+    // `ESCAPE 'xy'` is a constant text of the wrong length — un-runnable — so
+    // `columns(of:validate:)` rejects it at validation with the run's message.
+    // ADVERSARIAL: reverting the check drops this validation throw.
+    let query = try query("SELECT Id FROM T WHERE Name LIKE 'x' ESCAPE 'xy'")
+    #expect(throws:
+        SQLError.argument("LIKE ESCAPE must be a single character")) {
+      try names().columns(of: query, validate: true)
+    }
+  }
+
+  @Test func `a constant non-text escape faults validation`() throws {
+    // `ESCAPE 1` is a constant integer — never a valid escape — so it too is
+    // rejected at validation rather than faulting per row.
+    let query = try query("SELECT Id FROM T WHERE Name LIKE 'x' ESCAPE 1")
+    #expect(throws:
+        SQLError.argument("LIKE ESCAPE must be a single character")) {
+      try names().columns(of: query, validate: true)
+    }
+  }
+
+  @Test func `a valid single-character escape validates`() throws {
+    // `ESCAPE '\'` is a valid single-character constant, so it validates.
+    let query = try query("SELECT Id FROM T WHERE Name LIKE 'x' ESCAPE '\\'")
+    _ = try names().columns(of: query, validate: true)
+  }
+
+  @Test func `a non-constant escape validates`() throws {
+    // A column escape is per row and cannot be checked statically, so
+    // validation accepts it (the run validates it) — here `Name` stands in as
+    // a non-constant escape term.
+    let query = try query("SELECT Id FROM T WHERE Name LIKE 'x' ESCAPE Name")
+    _ = try names().columns(of: query, validate: true)
+  }
+}
+
+// MARK: - Matcher complexity
+
+/// The matcher is LINEAR (a two-pointer scan), not the exponential
+/// backtracking recursion — so a pathological pattern against a long run of
+/// its wildcard fill returns promptly rather than pegging the engine.
+struct LikeComplexityTests {
+  @Test func `a pathological pattern returns false promptly`() throws {
+    // `%a%a%a%a%a%a%a%b` against a long run of `a`s (no `b`) is the classic
+    // ReDoS-style blowup for a per-split recursive matcher — combinatorial in
+    // the number of `%` splits over the text length. The linear scan decides
+    // FALSE in O(n·m) and returns at once. ADVERSARIAL: the recursive matcher
+    // does not complete in bounded time on this input.
+    let text = String(repeating: "a", count: 256)
+    #expect(!matches(text, "%a%a%a%a%a%a%a%b", escape: nil))
+  }
+
+  @Test func `a pathological pattern that matches returns true promptly`()
+      throws {
+    // The same shape with a trailing `a` the final literal can anchor matches,
+    // and still linearly.
+    let text = String(repeating: "a", count: 256)
+    #expect(matches(text, "%a%a%a%a%a%a%a%a", escape: nil))
+  }
+}
+
+// MARK: - Bound parameter
+
+/// A `LIKE` pattern or escape may be a `:parameter` resolved from the bindings
+/// at eval — the same mechanism `Filter.bound` uses for a comparison's right
+/// operand — so a caller binds a pattern rather than interpolating it.
+struct LikeParameterTests {
+  @Test func `a bound pattern matches the right rows`() throws {
+    // `WHERE Name LIKE :pattern` bound to `'a%'` — rows 1 and 2 begin `a`, row
+    // 3 does not, row 4 (NULL) is UNKNOWN. ADVERSARIAL: reverting the parser
+    // `:param` handling makes `LIKE :pattern` fail to parse/bind.
+    try names().expect("SELECT Id FROM T WHERE Name LIKE :pattern",
+                       yields: [[1], [2]],
+                       bindings: ["pattern": .text("a%")])
+  }
+
+  @Test func `a bound escape binds`() throws {
+    // `WHERE Name LIKE :pattern ESCAPE :e`, the pattern an escaped literal `%`
+    // and `:e` the escape `\`, so only the row whose Name holds a literal `%`
+    // matches.
+    try Catalog {
+      Relation("T", ["Id": .integer, "Name": .text]) {
+        Row(1, "a%b")
+        Row(2, "axb")
+      }
+    }.expect("SELECT Id FROM T WHERE Name LIKE :pattern ESCAPE :e",
+             yields: [[1]],
+             bindings: ["pattern": .text("a\\%b"), "e": .text("\\")])
+  }
+
+  @Test func `an unbound pattern is UNKNOWN`() throws {
+    // `:pattern` with no binding resolves to NULL, so every row is UNKNOWN and
+    // none is admitted — as an unbound comparison `:parameter` does.
+    try names().empty("SELECT Id FROM T WHERE Name LIKE :pattern")
+  }
+
+  @Test func `a NULL-bound pattern is UNKNOWN`() throws {
+    // `:pattern` bound to NULL is likewise UNKNOWN — no row is admitted.
+    try names().empty("SELECT Id FROM T WHERE Name LIKE :pattern",
+                      bindings: ["pattern": .null])
+  }
+
+  @Test func `a bound escape is unsafe and bars a seek`() throws {
+    // A `:parameter` escape is not a static single-character constant — it may
+    // be unbound, NULL, or the wrong length at run time — so the escaped LIKE
+    // is UNSAFE and does not ride below a seek: the seekable `Id = 2` cannot
+    // reach the base scan beside it.
+    let catalog = try Catalog {
+      Relation("S", ["Id": .integer, "Name": .text], sorted: "Id") {
+        Row(1, "abc")
+        Row(2, "xyz")
+      }
+    }
+    guard case let .select(query) =
+        try Statement(parsing: """
+            SELECT Id FROM S WHERE Name LIKE 'x%' ESCAPE :e AND Id = 2
+            """) else {
+      Issue.record("expected a SELECT statement")
+      return
+    }
+    let plan = try catalog.optimise(catalog.compile(query).pushdown(),
+                                    ["e": .text("\\")])
+    #expect(!seeks(plan))
+  }
+}
+
+// MARK: - Parameterised classification
+
+/// A parameterised `LIKE` — one whose pattern or escape operand is a run-time
+/// `:parameter` — reads no slot yet can be UNKNOWN (the parameter may be
+/// unbound or bound to NULL), so `nullable` counts it and pushdown must not
+/// ride it below a LATER unsafe conjunct: the non-short-circuiting `AND` still
+/// owes that conjunct's evaluation after an UNKNOWN left.
+struct LikeParameterisedTests {
+  /// A view over a single (x = 1, y = 0) row — the derived-leaf shape the
+  /// slotless-conjunct pushdown hazard needs, so a conjunct kept out of the
+  /// view floats above the leaf rather than being injected below it.
+  private func maybe() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["x": .integer, "y": .integer]) {
+        Row(1, 0)
+      }
+      try View("V", "SELECT x, y FROM T", as: ["x", "y"])
+    }
+  }
+
+  /// Parses `text` to a query, failing on any other statement.
+  private func query(_ text: String) throws -> Query {
+    guard case let .select(query) = try Statement(parsing: text) else {
+      Issue.record("expected a SELECT statement")
+      throw SQLError.incomplete(expected: "a SELECT statement")
+    }
+    return query
+  }
+
+  @Test func `a parameterised LIKE is nullable`() throws {
+    // A `.like` whose pattern operand is a `:parameter` reads no slot yet is
+    // nullable — the pattern may be unbound or NULL, making the LIKE UNKNOWN.
+    let pattern = Filter.like(.constant(.text("x")),
+                              pattern: .parameter("p"), escape: nil,
+                              negated: false)
+    #expect(pattern.nullable)
+
+    // An escape `:parameter` counts the same, whatever the pattern.
+    let escape = Filter.like(.constant(.text("x")),
+                             pattern: .term(.constant(.text("y"))),
+                             escape: .parameter("e"), negated: false)
+    #expect(escape.nullable)
+  }
+
+  @Test func `a constant LIKE is not nullable`() throws {
+    // A `.like` over constant operands alone — no `:parameter` and no slot —
+    // is definite, so it stays eligible for pushdown.
+    let filter = Filter.like(.constant(.text("x")),
+                             pattern: .term(.constant(.text("y"))),
+                             escape: nil, negated: false)
+    #expect(!filter.nullable)
+  }
+
+  @Test func `a parameterised LIKE is not pushed below a later unsafe conjunct`()
+      throws {
+    // `SELECT x FROM V WHERE 'x' LIKE :p AND (1 / y) = 0` with `:p` UNBOUND:
+    // the outer `AND` does not short-circuit, so on the (y = 0) row the UNKNOWN
+    // LIKE still runs the division, which raises. Injecting the slotless `'x'
+    // LIKE :p` into the view would drop every row first, suppressing the
+    // throw — so a parameterised LIKE is nullable and must stay outer.
+    let catalog = try maybe()
+    let plan = try catalog.optimise(catalog.compile(query("""
+        SELECT x FROM V WHERE 'x' LIKE :p AND (1 / y) = 0
+        """)).pushdown(), [:])
+
+    // The parameterised LIKE floats above the derived leaf rather than riding
+    // into the view below the unsafe division.
+    #expect(floats(plan))
+
+    // …and the query raises rather than silently dropping the row.
+    catalog.expect("SELECT x FROM V WHERE 'x' LIKE :p AND (1 / y) = 0",
+                   fails: .divide)
+  }
+
+  @Test func `a constant LIKE is pushed below a later unsafe conjunct`() throws {
+    // CONTROL: `'x' LIKE 'y'` names no `:parameter`, so it is definite and
+    // eligible for the normal pushdown — a non-nullable conjunct injects into
+    // the view, dropping every row before the outer division runs, so the query
+    // returns nothing rather than raising (the ordinary non-parameterised way).
+    let catalog = try maybe()
+    try catalog.empty("SELECT x FROM V WHERE 'x' LIKE 'y' AND (1 / y) = 0")
+  }
+}


### PR DESCRIPTION
Add the ISO `LIKE` predicate — `x [NOT] LIKE pattern [ESCAPE c]` — as a first-class predicate lowered to a first-class filter, mirroring how `IN` became `Filter.membership`.

The lexer recognises the `LIKE` and `ESCAPE` keywords, and the parser gains a `comparison` arm for `[NOT] LIKE pattern [ESCAPE expression]` alongside the existing `IS [NOT] NULL` and `[NOT] IN` arms. The AST carries `Predicate.like(operand, pattern:, escape:, negated:)`, lowering to `Filter.like(Term, pattern:, escape:, negated:)`.

The matcher is an anchored, backtracking `%`/`_` match over `Character`s: `%` matches any run (including the empty one), `_` matches exactly one character, and an `ESCAPE` character takes the next pattern character literally. It is three-valued — a NULL operand, pattern, or escape is UNKNOWN, and a non-text operand or pattern is a definite non-match (the engine's cross-kind comparison rule) rather than a fault — with `NOT LIKE` negating the three-valued result. A non-single-character escape is `SQLError.argument`, the ISO rule.

Every `Filter` walk (`remapped`, `safe`, `parameterised`, `evaluate`, `references`) and every `Predicate` walk (`lower`, `check`, `constant`, `aggregates`, `empty`, `aggregated`, `bound`, `collect`) gains the new case.