### PR TITLE
SQL: add the CAST expression

### DIFF
--- a/Sources/SQL/AST.swift
+++ b/Sources/SQL/AST.swift
@@ -468,6 +468,15 @@ public indirect enum Expression: Hashable, Sendable {
   /// engine models one conditional. The result expressions' types must unify to
   /// one result type (see resolution).
   case `case`(Array<When>, else: Expression?)
+  /// A `CAST(operand AS type)` — the ISO explicit conversion of the `operand`
+  /// expression to the target `ValueType`. Unlike the widening `CASE` unifies
+  /// its arms with, a cast is a NOMINAL conversion whose static type is the
+  /// target, so the engine advertises `type` for the column and CONVERTS the
+  /// evaluated value to it per row (see `Value.cast(to:)`). A `NULL` operand
+  /// casts to `NULL` for any target; an unconvertible value (an unparseable
+  /// text-to-number, an out-of-range double-to-integer, a cross-kind pair with
+  /// no conversion) faults rather than yielding a wrong value.
+  case cast(Expression, ValueType)
 }
 
 /// One `WHEN predicate THEN result` branch of a `CASE` expression — the guard

--- a/Sources/SQL/Adapter.swift
+++ b/Sources/SQL/Adapter.swift
@@ -60,6 +60,37 @@ public enum ValueType: Hashable, Sendable {
     return nil
   }
 
+  /// Whether a value of this type can convert to `target` under `CAST` for AT
+  /// LEAST ONE value — the STRUCTURAL half of `Value.cast(to:)`, the one shared
+  /// truth both the runtime cast and the schema type-check consult so they
+  /// cannot drift.
+  ///
+  /// A pair is castable when `Value.cast(to:)` has a conversion arm for it; an
+  /// UNSUPPORTED pair — the one that falls to `Value.cast`'s `42846` arm for
+  /// EVERY value of this kind — is not. A like-kind cast is the identity; a
+  /// numeric pair converts (`integer` ↔ `double`); `text` bridges every kind
+  /// (each type spells to and parses from text) and `blob` bridges `text`
+  /// alone. The remaining cross-kind pairs — a boolean against a number or a
+  /// blob, a number against a blob — have no ISO conversion.
+  ///
+  /// A castable pair may still fault at RUN time on a particular value — a
+  /// `text` that is not a number, a `double` past `Int` range, a `blob` that is
+  /// not UTF-8 — so a reachable good value runs; only a NEVER-castable pair is
+  /// an unconditional fault the schema rejects early.
+  internal func castable(to target: ValueType) -> Bool {
+    switch (self, target) {
+    case (.integer, .integer), (.double, .double), (.text, .text),
+         (.boolean, .boolean), (.blob, .blob):
+      true
+    case (.integer, .double), (.double, .integer):
+      true
+    case (.text, _), (_, .text):
+      true
+    default:
+      false
+    }
+  }
+
   /// The ISO `data_type` spelling of this value type.
   ///
   /// The engine's types map onto the ISO domains: exact numeric to `integer`,
@@ -127,6 +158,207 @@ extension Value {
       return .double(Double(number))
     }
     return self
+  }
+
+  /// This value CONVERTED to `type` — the ISO `CAST(… AS type)` explicit
+  /// conversion, wider than the numeric-widening `coerced(to:)`.
+  ///
+  /// `NULL` converts to `NULL` for every target. A value already of `type`
+  /// passes through. The remaining conversions form the supported matrix:
+  ///
+  /// - `integer` ↔ `double`: an integer widens to a double exactly; a double
+  ///   TRUNCATES toward zero to an integer (`1.9` → `1`, `-1.9` → `-1`), the
+  ///   ISO exact-numeric-from-approximate rule, faulting when the truncated
+  ///   magnitude exceeds `Int` (`22003`).
+  /// - number → `text`: its canonical spelling (`42`, `1.5`).
+  /// - `text` → `integer`/`double`: the parsed number, its surrounding
+  ///   whitespace trimmed; an unparseable spelling faults `22018` (invalid
+  ///   character value for cast). A `double` that parses to a non-finite
+  ///   magnitude (`1e999`) is out of range (`22003`).
+  /// - `boolean` → `text`: `true`/`false`; `text` → `boolean`: the ISO
+  ///   truth-value spellings `true`/`false`/`t`/`f`/`yes`/`no`/`on`/`off`/`1`/
+  ///   `0` (case-insensitively, trimmed), else `22018`.
+  /// - `text` ↔ `blob`: the text's UTF-8 octets, and a blob decoded as UTF-8
+  ///   text (invalid UTF-8 faults `22018`).
+  ///
+  /// Every other cross-kind pair — a number against a boolean or a blob, a
+  /// boolean against a blob — has no ISO conversion and faults `SQLError.state`
+  /// `42846` (cannot coerce). These are exactly the pairs
+  /// `ValueType.castable(to:)` rejects: its conversion arms below cover the
+  /// castable pairs, and this `default` arm faults for the rest, so the
+  /// structural predicate the schema type-check consults cannot drift from the
+  /// runtime cast.
+  internal func cast(to type: ValueType) throws(SQLError) -> Value {
+    switch (self, type) {
+    case (.null, _):
+      return .null
+
+    // A value already of the target type is unchanged.
+    case (.integer, .integer), (.double, .double), (.text, .text),
+         (.boolean, .boolean), (.blob, .blob):
+      return self
+
+    // integer ↔ double: exact widening, truncating narrowing.
+    case let (.integer(number), .double):
+      return .double(Double(number))
+    case let (.double(number), .integer):
+      let truncated = number.rounded(.towardZero)
+      guard truncated >= Double(Int.min), truncated < -Double(Int.min) else {
+        throw .magnitude("double '\(number)' out of Int range for cast")
+      }
+      return .integer(Int(truncated))
+
+    // number → text: canonical spelling.
+    case let (.integer(number), .text):
+      return .text("\(number)")
+    case let (.double(number), .text):
+      return .text("\(number)")
+
+    // text → number: parse the trimmed spelling.
+    case let (.text(text), .integer):
+      // gate the trimmed spelling against the SQL INTEGER format FIRST (mirror
+      // the text → double `decimal` split): a malformed spelling ('12abc',
+      // '1.5') is an invalid character (`22018`), while a format-valid spelling
+      // `Int(_:)` still cannot represent ('9223372036854775808') is a numeric
+      // value out of range (`22003`), the same fault an integer-literal
+      // overflow and the double → integer range check use.
+      let spelling = text.trimmed
+      guard spelling.integer else {
+        throw .state("22018", "cannot cast '\(text)' to integer")
+      }
+      guard let number = Int(spelling) else {
+        throw .magnitude("integer '\(text)' out of range for cast")
+      }
+      return .integer(number)
+    case let (.text(text), .double):
+      // `Double(_:)` accepts Swift spellings the SQL numeric grammar does not —
+      // a hex float `0x1p2`, `inf`/`infinity`/`nan`, an underscore group — so
+      // gate the trimmed spelling against the SQL DECIMAL format FIRST: only a
+      // format-valid spelling reaches `Double(_:)`, and the `isFinite` guard
+      // then catches a valid-format magnitude past range (`1e999` → `22003`).
+      let spelling = text.trimmed
+      guard spelling.decimal, let number = Double(spelling) else {
+        throw .state("22018", "cannot cast '\(text)' to double")
+      }
+      guard number.isFinite else {
+        throw .magnitude("double '\(text)' out of range for cast")
+      }
+      return .double(number)
+
+    // boolean ↔ text.
+    case let (.boolean(truth), .text):
+      return .text(truth ? "true" : "false")
+    case let (.text(text), .boolean):
+      return switch text.trimmed.lowercased() {
+      case "true", "t", "yes", "on", "1": .boolean(true)
+      case "false", "f", "no", "off", "0": .boolean(false)
+      default: throw .state("22018", "cannot cast '\(text)' to boolean")
+      }
+
+    // text ↔ blob: the UTF-8 octets, and their decode.
+    case let (.text(text), .blob):
+      return .blob(Array(text.utf8))
+    case let (.blob(bytes), .text):
+      var decoder = UTF8()
+      var iterator = bytes.makeIterator()
+      var text = ""
+      loop: while true {
+        switch decoder.decode(&iterator) {
+        case let .scalarValue(scalar): text.unicodeScalars.append(scalar)
+        case .emptyInput: break loop
+        case .error: throw .state("22018", "cannot cast blob to text")
+        }
+      }
+      return .text(text)
+
+    default:
+      throw .state("42846",
+                   "cannot cast \(self.type.domain) to \(type.domain)")
+    }
+  }
+
+  /// The `ValueType` of this value's kind — a `null` has no kind of its own, so
+  /// it reports `.integer`, the schema default; it is used only to describe an
+  /// unconvertible cast, and a `null` never reaches that arm (it casts to
+  /// `null` for every target).
+  private var type: ValueType {
+    switch self {
+    case .null, .integer: .integer
+    case .double: .double
+    case .text: .text
+    case .boolean: .boolean
+    case .blob: .blob
+    }
+  }
+}
+
+extension String {
+  /// This string with leading and trailing ASCII whitespace removed — the
+  /// surrounding space an ISO `CAST` of a character string to a number ignores.
+  fileprivate var trimmed: String {
+    let space: Set<Character> = [" ", "\t", "\n", "\r"]
+    return String(drop { space.contains($0) }.reversed()
+                      .drop { space.contains($0) }.reversed())
+  }
+
+  /// Whether this string is a SQL DECIMAL numeric spelling — an optional
+  /// leading sign, a digit run, an optional `.` fraction, and an optional
+  /// `e`/`E` exponent (its own optional sign then a digit run) — the same
+  /// grammar the lexer scans a numeric literal by. It admits NO Swift extension
+  /// `Double(_:)` accepts: no hexadecimal (`0x`, a `p` exponent), no
+  /// `inf`/`infinity`/`nan`, no underscore digit groups. A CAST of a character
+  /// string to a number validates its spelling against this before parsing, so
+  /// a format the engine would not lex is an invalid character (`22018`), never
+  /// a Swift value.
+  fileprivate var decimal: Bool {
+    var characters = Substring(self)
+    func digits() -> Bool {
+      let count = characters.count
+      characters = characters.drop { $0.isASCIIDigit }
+      return characters.count < count
+    }
+    if characters.first == "+" || characters.first == "-" {
+      characters = characters.dropFirst()
+    }
+    guard digits() else { return false }
+    if characters.first == "." {
+      characters = characters.dropFirst()
+      guard digits() else { return false }
+    }
+    if characters.first == "e" || characters.first == "E" {
+      characters = characters.dropFirst()
+      if characters.first == "+" || characters.first == "-" {
+        characters = characters.dropFirst()
+      }
+      guard digits() else { return false }
+    }
+    return characters.isEmpty
+  }
+
+  /// Whether this string is a SQL INTEGER numeric spelling — an optional
+  /// leading sign then a digit run, with NO fraction, exponent, hexadecimal,
+  /// underscore group, or `inf`/`nan`. A CAST of a character string to an
+  /// integer validates its spelling against this before parsing, so a malformed
+  /// spelling is an invalid character (`22018`) while a format-valid spelling
+  /// `Int(_:)` cannot represent is a numeric value out of range (`22003`), not
+  /// a Swift `nil` conflated with the malformed case.
+  fileprivate var integer: Bool {
+    var characters = Substring(self)
+    if characters.first == "+" || characters.first == "-" {
+      characters = characters.dropFirst()
+    }
+    let count = characters.count
+    characters = characters.drop { $0.isASCIIDigit }
+    return characters.count < count && characters.isEmpty
+  }
+}
+
+extension Character {
+  /// Whether this character is an ASCII decimal digit, `0`–`9` — the digit the
+  /// SQL numeric grammar admits, excluding the Unicode digits the broader
+  /// `Character.isNumber` would.
+  fileprivate var isASCIIDigit: Bool {
+    return isASCII && isNumber
   }
 }
 

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -591,6 +591,8 @@ extension Expression {
     case let .case(whens, otherwise):
       whens.contains { $0.when.aggregated || $0.then.aggregated }
           || (otherwise?.aggregated ?? false)
+    case let .cast(operand, _):
+      operand.aggregated
     }
   }
 
@@ -611,6 +613,8 @@ extension Expression {
     case let .case(whens, otherwise):
       whens.contains { $0.when.bound || $0.then.bound }
           || (otherwise?.bound ?? false)
+    case let .cast(operand, _):
+      operand.bound
     }
   }
 }
@@ -858,6 +862,8 @@ extension Expression {
         branch.then.collect(into: &expressions)
       }
       otherwise?.collect(into: &expressions)
+    case let .cast(operand, _):
+      operand.collect(into: &expressions)
     }
   }
 

--- a/Sources/SQL/Filter.swift
+++ b/Sources/SQL/Filter.swift
@@ -75,6 +75,12 @@ internal indirect enum Term: Sendable {
   /// schema advertises for the column — so the executor COERCES the selected
   /// value to it, widening an `.integer` arm of a `.double` CASE.
   case `case`(Array<(Filter, Term)>, else: Term?, type: ValueType)
+  /// A `CAST(operand AS type)` — the lowered form of the AST's
+  /// `Expression.cast`. The executor evaluates the operand `Term` and CONVERTS
+  /// the value to `type` (`Value.cast(to:)`), so an unconvertible value faults
+  /// rather than yielding a wrong one. `type` is also the term's static type —
+  /// the type the schema advertises for the column.
+  case cast(Term, ValueType)
 }
 
 extension Term {
@@ -102,6 +108,8 @@ extension Term {
         result.references(into: &slots)
       }
       otherwise?.references(into: &slots)
+    case let .cast(operand, _):
+      operand.references(into: &slots)
     }
   }
 }
@@ -125,17 +133,19 @@ extension Term {
       .case(branches.map {
               ($0.0.remapped(through: slot), $0.1.remapped(through: slot))
             }, else: otherwise?.remapped(through: slot), type: type)
+    case let .cast(operand, type):
+      .cast(operand.remapped(through: slot), type)
     }
   }
 
   /// Whether evaluating this term cannot throw — it is a bare slot read or a
-  /// constant. A `binary` arithmetic (`/` raises on a zero divisor) or an
-  /// `apply` (a scalar function may raise) is NOT known safe, whatever its
-  /// operands.
+  /// constant. A `binary` arithmetic (`/` raises on a zero divisor), an `apply`
+  /// (a scalar function may raise), or a `cast` (an unconvertible value raises)
+  /// is NOT known safe, whatever its operands.
   internal var safe: Bool {
     switch self {
     case .slot, .constant: true
-    case .apply, .binary, .case: false
+    case .apply, .binary, .case, .cast: false
     }
   }
 }
@@ -330,6 +340,11 @@ extension Row where Self: ~Escapable {
       // branch. The selected value is COERCED to the CASE's unified result
       // `type` so it matches the column type the schema advertised.
       try conditional(branches, otherwise, type, routines, bindings)
+    case let .cast(operand, type):
+      // Evaluate the operand and CONVERT it to the target type: NULL casts to
+      // NULL, an unconvertible value faults (`Value.cast(to:)`), never yielding
+      // a wrong value.
+      try evaluate(operand, routines, bindings).cast(to: type)
     }
   }
 

--- a/Sources/SQL/Parser.swift
+++ b/Sources/SQL/Parser.swift
@@ -40,10 +40,11 @@
 /// expression     := additive
 /// additive       := multiplicative (('+' | '-') multiplicative)*
 /// multiplicative := factor (('*' | '/') factor)*
-/// factor         := '(' expression ')' | case
+/// factor         := '(' expression ')' | case | cast
 ///                 | literal | aggregate | call | column
 /// case           := CASE [expression] (WHEN (predicate | expression) THEN
 ///                     expression)+ [ELSE expression] END
+/// cast           := CAST '(' expression AS type ')'
 /// literal        := string | integer | decimal | TRUE | FALSE | blob
 /// blob           := ('x' | 'X') "'" (hex hex)* "'"  // whole bytes
 /// aggregate      := COUNT '(' '*' ')'
@@ -586,6 +587,14 @@ internal struct Parser: ~Escapable {
                                   : Column(ident.text))
     }
 
+    // `CAST` is the ISO explicit-conversion operator, recognised bare (a
+    // delimited `"CAST"` is an ordinary scalar-call name) like an aggregate.
+    // Its tail is `expression AS type )`, not the comma-separated argument list
+    // a call takes, so it dispatches to its own production.
+    if !ident.quoted, ident.text.uppercased() == "CAST" {
+      return try cast()
+    }
+
     // An aggregate is one of the fixed set of names (recognised
     // case-insensitively, only when written bare — a delimited `"COUNT"` is a
     // scalar name), distinct from a scalar call: it accumulates over a group
@@ -671,6 +680,22 @@ internal struct Parser: ~Escapable {
     }
     try expect(.end)
     return .case(whens, else: otherwise)
+  }
+
+  /// Parses the `CAST` tail — `expression AS type )` (the `CAST (` is already
+  /// consumed) — into `Expression.cast`.
+  ///
+  /// The operand is a full scalar expression; `AS` (already a keyword, shared
+  /// with aliasing) separates it from the target `type`, which reuses the same
+  /// `type()` domain spellings a `CREATE FUNCTION` parameter or a column type
+  /// names (`INTEGER`, `TEXT`, `DOUBLE`, `BOOLEAN`, `BLOB`, …). The whole is
+  /// closed by `)`.
+  private mutating func cast() throws(SQLError) -> Expression {
+    let operand = try expression()
+    try expect(.as)
+    let type = try type()
+    try expect(.rparen)
+    return .cast(operand, type)
   }
 
   // MARK: - Predicate

--- a/Sources/SQL/Resolve.swift
+++ b/Sources/SQL/Resolve.swift
@@ -195,6 +195,10 @@ extension Schema {
       let scope = Scope([(relation, self)])
       let type = try scope.derive(whens, otherwise, routines)
       return .case(branches, else: fallback, type: type)
+    case let .cast(operand, type):
+      // Lower the operand and attach the target type; the executor converts the
+      // evaluated value to it (`Value.cast(to:)`).
+      return try .cast(term(operand, in: relation, routines), type)
     case .aggregate:
       // An aggregate has no per-row meaning — it folds over a group — so it may
       // not appear in a `WHERE`, a join `ON`, or a non-aggregate projection.
@@ -356,7 +360,22 @@ internal struct Scope {
       // reachable `ELSE`) the run yields NULL, for which `.integer` is the
       // schema default.
       try derive(whens, otherwise, routines)
+    case let .cast(operand, type):
+      // A cast's static type is the target type; the conversion is nominal, so
+      // the operand's own type does not shape it. Derive the operand anyway for
+      // its ordinal resolution — an unknown/ambiguous column faults as a
+      // projection would.
+      try derive(cast: operand, to: type, routines)
     }
+  }
+
+  /// The target `type` of a `CAST`, deriving `operand` for its ordinal
+  /// resolution — a schema-surface non-faulting derive of the operand — and
+  /// discarding its type, the conversion being nominal.
+  private func derive(cast operand: Expression, to type: ValueType,
+                      _ routines: Routines) throws(SQLError) -> ValueType {
+    _ = try derive(operand, routines)
+    return type
   }
 
   /// The nominal type of a `CASE` under `derive` — the unification of its
@@ -433,7 +452,52 @@ internal struct Scope {
       try arithmetic(op, lhs, rhs, routines)
     case let .case(whens, otherwise):
       try conditional(whens, otherwise, routines)
+    case let .cast(operand, type):
+      try validate(cast: operand, to: type, routines)
     }
+  }
+
+  /// The target `type` of a `CAST`, VALIDATING `operand` for real errors
+  /// (unknown column, bad call arity, …) as a run would fault, and REJECTING a
+  /// cast the runtime could never perform before advertising the target type.
+  ///
+  /// A cast whose (operand type → target type) PAIR is structurally
+  /// unsupported — a boolean to a number, a number to a blob — faults `42846`
+  /// for EVERY value of the operand's kind, so `SELECT CAST(TRUE AS INTEGER)`
+  /// would otherwise advertise an integer column though executing it
+  /// unconditionally throws. `ValueType.castable(to:)` — the same structural
+  /// truth the runtime cast consults — rejects that pair here, at validation.
+  ///
+  /// A castable-but-VALUE-dependent pair still passes: a `text` to a number, or
+  /// a `blob` to `text`, is a supported pair whose fault (`22018`/`22003`)
+  /// depends on the value, so a reachable good value runs — `CAST('1' AS
+  /// INTEGER)` type-checks. The exception is a CONSTANT operand that folds and
+  /// ALWAYS fails: `CAST('abc' AS INTEGER)` is unparseable for the one value it
+  /// can have, so a trial cast of the folded constant rejects it too.
+  ///
+  /// The constant fold runs FIRST, before the structural pair rejection: a
+  /// constant operand casts to ONE value, so its trial cast decides the cast
+  /// outright — it ALLOWS a statically-NULL operand (`CAST(CASE WHEN 1 = 0
+  /// THEN 1 END AS BLOB)` folds to `.null`, which casts to ANY target) even
+  /// where the operand's DERIVED type would make the pair structurally
+  /// unsupported, and it still REJECTS a constant that always fails. Only a
+  /// NON-constant operand, whose value is unknown at validation, falls to the
+  /// structural pair check.
+  private func validate(cast operand: Expression, to type: ValueType,
+                        _ routines: Routines) throws(SQLError) -> ValueType {
+    let source = try validate(operand, routines)
+    // A constant operand casts to one value only, so its trial cast is the
+    // whole decision: it ALLOWS a folded NULL to any target and REJECTS a
+    // spelling that always faults (`CAST('abc' AS INTEGER)`). A non-constant
+    // operand folds to `nil`, so the structural pair check rejects a kind that
+    // could never cast (`CAST(<boolean column> AS INTEGER)` → `42846`).
+    if let value = constant(operand, routines) {
+      _ = try value.cast(to: type)
+    } else if !source.castable(to: type) {
+      throw .state("42846",
+                   "cannot cast \(source.domain) to \(type.domain)")
+    }
+    return type
   }
 
   /// The result type of a `CASE`, validating each REACHABLE branch as a run
@@ -739,6 +803,14 @@ internal struct Scope {
       }
       guard let otherwise else { return .null }
       return constant(otherwise, routines)
+    case let .cast(operand, type):
+      // A ROW-INDEPENDENT operand folds to its converted value — the SAME
+      // `Value.cast(to:)` the run applies, so the fold matches. A would-be
+      // fault (an unconvertible value) collapses to `nil`, so the cast stays
+      // undecided rather than deciding a match, just as a would-be-faulting
+      // binary fold does.
+      guard let value = constant(operand, routines) else { return nil }
+      return try? value.cast(to: type)
     case .column, .aggregate:
       return nil
     }
@@ -855,6 +927,8 @@ internal struct Scope {
         try aggregates(in: branch.then, routines)
       }
       if let otherwise { try aggregates(in: otherwise, routines) }
+    case let .cast(operand, _):
+      try aggregates(in: operand, routines)
     }
   }
 
@@ -935,6 +1009,11 @@ internal struct Scope {
       }
       guard let otherwise else { return .null }
       return try empty(otherwise, routines).coerced(to: type)
+    case let .cast(operand, type):
+      // Convert the operand's empty-group value exactly as a run does — a NULL
+      // (the common empty-group operand) casts to NULL, an unconvertible value
+      // faults as the run would.
+      return try empty(operand, routines).cast(to: type)
     case .column:
       return .null
     }
@@ -1094,6 +1173,10 @@ internal struct Scope {
       // branch's value to the type the schema advertises.
       let type = try derive(whens, otherwise, routines)
       return .case(branches, else: fallback, type: type)
+    case let .cast(operand, type):
+      // Lower the operand across the join chain and attach the target type; the
+      // executor converts the evaluated value to it (`Value.cast(to:)`).
+      return try .cast(term(operand, routines), type)
     case .aggregate:
       // An aggregate has no per-row meaning — it folds over a group — so it may
       // not appear in a `WHERE`, a join `ON`, or a non-aggregate projection.
@@ -1298,6 +1381,10 @@ internal struct Grouping {
       // COERCES the selected branch's value to the advertised column type.
       let type = try scope.derive(whens, otherwise, routines)
       return .case(branches, else: fallback, type: type)
+    case let .cast(operand, type):
+      // Lower the operand against the grouped slot space and attach the target
+      // type; the executor converts the evaluated value to it.
+      return try .cast(term(operand, routines), type)
     case .aggregate:
       // An aggregate reaches here only when it was not collected — an internal
       // inconsistency, since the query gathers every projection/HAVING aggregate.

--- a/Tests/SQLTests/CastTests.swift
+++ b/Tests/SQLTests/CastTests.swift
@@ -1,0 +1,334 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQL
+
+import SQLTestSupport
+
+// MARK: - Fixture
+
+/// A relation exercising `CAST`: an integer `Id`, an approximate `D`, a textual
+/// `T` (both numeric and non-numeric spellings) with a `T` row that is `NULL`
+/// so a cast of a NULL operand is covered, and a boolean `B` so a NON-constant
+/// operand of a structurally-unsupported pair (a boolean column to an integer)
+/// is covered.
+private func things() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("C",
+             ["Id": .integer, "D": .double, "T": .text, "B": .boolean]) {
+      Row(1, 1.9, "42", true)
+      Row(2, 2.5, "x", false)
+      Row(3, 3.0, nil, true)
+    }
+  }
+}
+
+// MARK: - Parsing
+
+/// Parses `text` and returns its `Select`, failing on any other shape.
+private func parse(select text: String) throws -> Select {
+  guard case let .select(.select(select)) = try Statement(parsing: text) else {
+    Issue.record("expected a single SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return select
+}
+
+struct CastParsingTests {
+  @Test func `parses a CAST to a typed conversion`() throws {
+    let select = try parse(select: "SELECT CAST(Id AS DOUBLE) FROM C")
+    let expression = Expression.cast(.column("Id"), .double)
+    #expect(select.projection
+                == .expressions([Projected(expression: expression)]))
+  }
+
+  @Test func `a delimited CAST is an ordinary function name`() throws {
+    // `"CAST"(x)` is a scalar call, not the conversion operator — only the bare
+    // keyword spelling is a cast.
+    let select = try parse(select: #"SELECT "CAST"(Id) FROM C"#)
+    let expression = Expression.call(name: "CAST", arguments: [.column("Id")])
+    #expect(select.projection
+                == .expressions([Projected(expression: expression)]))
+  }
+
+  @Test func `rejects a CAST missing AS`() {
+    #expect(throws: SQLError.self) {
+      _ = try Statement(parsing: "SELECT CAST(Id DOUBLE) FROM C")
+    }
+  }
+
+  @Test func `rejects a CAST to an unknown type`() {
+    #expect(throws: SQLError.self) {
+      _ = try Statement(parsing: "SELECT CAST(Id AS WIDGET) FROM C")
+    }
+  }
+}
+
+// MARK: - Numeric conversions
+
+struct CastNumericTests {
+  @Test func `integer widens to double exactly`() throws {
+    try things().expect("SELECT CAST(Id AS DOUBLE) FROM C WHERE Id = 1",
+                        yields: [[1.0]])
+  }
+
+  @Test func `double truncates toward zero to integer`() throws {
+    // `1.9` → `1`, `2.5` → `2`, `3.0` → `3` — ISO truncation, not rounding.
+    try things().expect("SELECT CAST(D AS INTEGER) FROM C",
+                        yields: [[1], [2], [3]])
+  }
+
+  @Test func `a number casts to its canonical text`() throws {
+    try things().expect("SELECT CAST(42 AS TEXT)", yields: [["42"]])
+  }
+
+  @Test func `text parses to an integer`() throws {
+    try things().expect("SELECT CAST('42' AS INTEGER)", yields: [[42]])
+  }
+
+  @Test func `text parses to a double`() throws {
+    try things().expect("SELECT CAST('2.5' AS DOUBLE)", yields: [[2.5]])
+    try things().expect("SELECT CAST('1.5' AS DOUBLE)", yields: [[1.5]])
+  }
+
+  @Test func `text of overflowing magnitude to double faults`() throws {
+    // `'1e999'` PARSES to a finite-syntax spelling but its magnitude is out of
+    // range — `Double('1e999')` is `inf` — so the cast raises the numeric
+    // value out-of-range fault (`22003`), matching the numeric-literal path,
+    // NOT the invalid-character fault (`22018`) reserved for an unparseable
+    // spelling.
+    try things().expect(
+        "SELECT CAST('1e999' AS DOUBLE)",
+        fails: .magnitude("double '1e999' out of range for cast"))
+  }
+
+  @Test func `unparseable text to double faults`() throws {
+    // `'abc'` is no number at all, so its cast raises the ISO
+    // invalid-character-for-cast fault (`22018`), distinct from the
+    // out-of-range fault above.
+    try things().expect("SELECT CAST('abc' AS DOUBLE)",
+                        fails: .state("22018", "cannot cast 'abc' to double"))
+  }
+
+  @Test func `unparseable text to integer faults`() throws {
+    // Row 2's `T` is `'x'`, which is no integer, so the cast raises the ISO
+    // invalid-character-for-cast fault (`22018`) rather than yielding a value.
+    try things().expect("SELECT CAST(T AS INTEGER) FROM C WHERE Id = 2",
+                        fails: .state("22018", "cannot cast 'x' to integer"))
+  }
+}
+
+// MARK: - NULL, boolean, and blob
+
+struct CastValueTests {
+  @Test func `NULL casts to NULL for any target`() throws {
+    // Row 3's `T` is NULL; casting it to INTEGER stays NULL, never a fault.
+    try things().expect("SELECT CAST(T AS INTEGER) FROM C WHERE Id = 3",
+                        yields: [[nil]])
+  }
+
+  @Test func `a boolean casts to text`() throws {
+    try things().expect("SELECT CAST(TRUE AS TEXT)", yields: [["true"]])
+  }
+
+  @Test func `text casts to a boolean`() throws {
+    try things().expect("SELECT CAST('no' AS BOOLEAN)", yields: [[false]])
+  }
+
+  @Test func `text casts to a blob as its UTF-8 octets`() throws {
+    try things().expect("SELECT CAST('AB' AS BLOB)",
+                        yields: [[[UInt8(0x41), UInt8(0x42)]]])
+  }
+
+  @Test func `a blob casts back to text`() throws {
+    try things().expect("SELECT CAST(x'4142' AS TEXT)", yields: [["AB"]])
+  }
+
+  @Test func `an unsupported cross-kind cast faults`() throws {
+    // A boolean has no conversion to an integer — a cross-kind pair with no ISO
+    // conversion faults `42846` (cannot coerce).
+    try things().expect(
+        "SELECT CAST(TRUE AS INTEGER)",
+        fails: .state("42846", "cannot cast boolean to integer"))
+  }
+}
+
+// MARK: - Schema and column
+
+struct CastSchemaTests {
+  private func parse(_ text: String) throws -> Query {
+    guard case let .select(query) = try Statement(parsing: text) else {
+      Issue.record("expected a SELECT statement")
+      throw SQLError.incomplete(expected: "a SELECT statement")
+    }
+    return query
+  }
+
+  /// The single output column type of a one-column query's schema.
+  private func type(of text: String) throws -> ValueType {
+    let columns = try things().columns(of: parse(text))
+    #expect(columns.count == 1)
+    return columns[0].type
+  }
+
+  @Test func `the schema reports the target type`() throws {
+    // The cast's static type is the target, whatever the operand's own type.
+    #expect(try type(of: "SELECT CAST(Id AS DOUBLE) AS V FROM C") == .double)
+    #expect(try type(of: "SELECT CAST(D AS INTEGER) AS V FROM C") == .integer)
+    #expect(try type(of: "SELECT CAST(Id AS TEXT) AS V FROM C") == .text)
+  }
+
+  @Test func `casting over a column converts each row`() throws {
+    // `CAST(Id AS TEXT)` spells each integer identity canonically.
+    try things().expect("SELECT CAST(Id AS TEXT) FROM C",
+                        yields: [["1"], ["2"], ["3"]])
+  }
+
+  @Test func `a cast in a WHERE filters rows`() throws {
+    // Keep the rows whose truncated `D` is `2` — only row 2 (`2.5` → `2`).
+    try things().expect("SELECT Id FROM C WHERE CAST(D AS INTEGER) = 2",
+                        yields: [[2]])
+  }
+
+  @Test func `a structurally impossible cast is rejected at validation`()
+      throws {
+    // `CAST(TRUE AS INTEGER)` is a reachable projection whose (boolean →
+    // integer) pair `Value.cast(to:)` faults `42846` for EVERY value, so the
+    // schema type-check rejects it rather than advertising an integer column.
+    #expect(throws: SQLError.state("42846",
+                                   "cannot cast boolean to integer")) {
+      _ = try things().columns(of: parse("SELECT CAST(TRUE AS INTEGER)"))
+    }
+  }
+
+  @Test func `a value-dependent cast passes validation`() throws {
+    // A castable-but-value-dependent pair — `integer` → `double` always
+    // convertible, `text` → `integer` convertible for a good spelling —
+    // type-checks and reports the target type; only a bad VALUE faults at run.
+    #expect(try type(of: "SELECT CAST(1 AS DOUBLE)") == .double)
+    #expect(try type(of: "SELECT CAST('1' AS INTEGER)") == .integer)
+  }
+
+  @Test func `a constant cast that always fails is rejected at validation`()
+      throws {
+    // `CAST('abc' AS INTEGER)` has a castable pair but a CONSTANT operand that
+    // converts to no value, so a trial cast of the folded constant rejects it
+    // at validation, not only at run.
+    #expect(throws: SQLError.state("22018",
+                                   "cannot cast 'abc' to integer")) {
+      _ = try things().columns(of: parse("SELECT CAST('abc' AS INTEGER)"))
+    }
+  }
+
+  @Test func `a statically-NULL operand validates for any target`() throws {
+    // `CASE WHEN 1 = 0 THEN 1 END` folds to NULL, but its DERIVED type is the
+    // default `.integer`, whose (integer → blob) pair is structurally
+    // unsupported. The constant fold runs FIRST, so the folded NULL trial-casts
+    // to `.blob` — a NULL casts to ANY target — and validation SUCCEEDS with a
+    // blob column rather than rejecting `42846` a query the run would perform.
+    let sql = "SELECT CAST(CASE WHEN 1 = 0 THEN 1 END AS BLOB)"
+    let columns = try things().columns(of: parse(sql), validate: true)
+    #expect(columns.count == 1)
+    #expect(columns[0].type == .blob)
+    try things().expect(sql, yields: [[nil]])
+  }
+
+  @Test func `a constant unsupported cast is rejected by the trial`() throws {
+    // `CAST(TRUE AS INTEGER)` has a CONSTANT non-NULL operand, so the trial
+    // cast of the folded `true` — no boolean-to-integer conversion — rejects it
+    // `42846`, the same fault the structural check would raise.
+    #expect(throws: SQLError.state("42846",
+                                   "cannot cast boolean to integer")) {
+      _ = try things().columns(of: parse("SELECT CAST(TRUE AS INTEGER)"),
+                               validate: true)
+    }
+  }
+
+  @Test func `a non-constant unsupported cast is rejected structurally`()
+      throws {
+    // `CAST(B AS INTEGER)` reads a boolean COLUMN, so it folds to no constant;
+    // the structural pair check rejects the (boolean → integer) kind `42846`
+    // without a value to trial.
+    #expect(throws: SQLError.state("42846",
+                                   "cannot cast boolean to integer")) {
+      _ = try things().columns(of: parse("SELECT CAST(B AS INTEGER) FROM C"),
+                               validate: true)
+    }
+  }
+
+  @Test func `a value-dependent cast still validates`() throws {
+    // `CAST('1' AS INTEGER)` is a castable pair whose fault depends on the
+    // value, so it type-checks as an integer column even after the reorder —
+    // the trial cast of the constant `'1'` succeeds.
+    #expect(try type(of: "SELECT CAST('1' AS INTEGER)") == .integer)
+  }
+}
+
+// MARK: - SQL numeric format
+
+struct CastNumericFormatTests {
+  @Test func `a Swift hex float is not a SQL number`() throws {
+    // `Double('0x1p2')` is `4.0`, a Swift spelling the SQL grammar rejects, so
+    // the cast faults invalid character (`22018`), never yielding `4.0`.
+    try things().expect(
+        "SELECT CAST('0x1p2' AS DOUBLE)",
+        fails: .state("22018", "cannot cast '0x1p2' to double"))
+  }
+
+  @Test func `the infinity spelling is not a SQL number`() throws {
+    // `Double('inf')` PARSES to a non-finite magnitude, but `inf` is no SQL
+    // numeric spelling, so it is an invalid character (`22018`) — NOT the
+    // out-of-range fault (`22003`) a valid-format overflow raises.
+    try things().expect("SELECT CAST('inf' AS DOUBLE)",
+                        fails: .state("22018", "cannot cast 'inf' to double"))
+  }
+
+  @Test func `the NaN spelling is not a SQL number`() throws {
+    try things().expect("SELECT CAST('nan' AS DOUBLE)",
+                        fails: .state("22018", "cannot cast 'nan' to double"))
+  }
+
+  @Test func `a format-valid overflow is still out of range`() throws {
+    // `'1e999'` is a valid SQL decimal spelling whose magnitude is past range,
+    // so it passes the format gate and faults out-of-range (`22003`),
+    // unchanged.
+    try things().expect(
+        "SELECT CAST('1e999' AS DOUBLE)",
+        fails: .magnitude("double '1e999' out of range for cast"))
+  }
+
+  @Test func `valid SQL decimal spellings parse`() throws {
+    try things().expect("SELECT CAST('1.5' AS DOUBLE)", yields: [[1.5]])
+    try things().expect("SELECT CAST('-3' AS DOUBLE)", yields: [[-3.0]])
+    try things().expect("SELECT CAST('2e3' AS DOUBLE)", yields: [[2000.0]])
+  }
+
+  @Test func `a format-valid integer overflow is out of range`() throws {
+    // `'9223372036854775808'` is a VALID integer spelling — `Int.max` plus one
+    // — so it passes the format gate and `Int(_:)` returns `nil` only for
+    // RANGE, faulting out-of-range (`22003`), NOT the invalid-character fault
+    // (`22018`) an unspellable text raises.
+    try things().expect(
+        "SELECT CAST('9223372036854775808' AS INTEGER)",
+        fails: .magnitude(
+            "integer '9223372036854775808' out of range for cast"))
+  }
+
+  @Test func `a malformed integer spelling faults invalid character`() throws {
+    // `'12abc'` and `'1.5'` are no SQL integer spelling — trailing letters, a
+    // fraction — so each is an invalid character (`22018`), the format gate
+    // rejecting them before `Int(_:)` conflates them with a range overflow.
+    try things().expect(
+        "SELECT CAST('12abc' AS INTEGER)",
+        fails: .state("22018", "cannot cast '12abc' to integer"))
+    try things().expect(
+        "SELECT CAST('1.5' AS INTEGER)",
+        fails: .state("22018", "cannot cast '1.5' to integer"))
+  }
+
+  @Test func `valid SQL integer spellings parse`() throws {
+    try things().expect("SELECT CAST('42' AS INTEGER)", yields: [[42]])
+    try things().expect("SELECT CAST('-7' AS INTEGER)", yields: [[-7]])
+  }
+}


### PR DESCRIPTION
Add the ISO `CAST(expr AS type)` explicit-conversion expression to the SQL engine as a first-class scalar expression.

The AST gains `Expression.cast(Expression, ValueType)`, lowered to `Term.cast(Term, ValueType)`; the static type of a cast is its target type, which the schema advertises, and the executor CONVERTS the evaluated value to that type per row through the new `Value.cast(to:)`. That conversion widens the existing numeric-only `Value.coerced(to:)` into a full matrix: NULL casts to NULL for any target; integer widens to double exactly and double truncates toward zero to integer (range-checked); a number spells to its canonical text and text parses back to a number (an unparseable spelling faulting `22018`); boolean converts to/from its text spellings; and text converts to/from a blob as its UTF-8 octets. A cross-kind pair with no ISO conversion faults `42846`.

The parser recognises the bare `CAST` keyword in `factor` (like an aggregate name; `AS` is already a keyword) and parses `CAST ( expression AS type )`, reusing the existing type-name domain spellings; the EBNF comment gains the `cast` production. The new `Expression`/`Term` case is handled in every walk — `references`/`remapped`/`safe`/`evaluate` (Filter), `term`/`derive`/`validate`/ `constant`/`empty`/`aggregates` (Resolve, across the single-relation, join, and grouped scopes), and `aggregated`/`bound`/`collect` (Engine).