### PR TITLE
SQL: add the scalar-function standard library (strings, numerics)

### DIFF
--- a/Sources/SQL/Function.swift
+++ b/Sources/SQL/Function.swift
@@ -236,24 +236,51 @@ public struct Routines: Sendable {
 
   /// The routine `name` names, folded to lower case like every other SQL
   /// identifier, or `nil` if no registered routine bears it. There is a single
-  /// flat map with no privileged tier: a prelude routine (`Routines.standard`)
-  /// and a caller-registered one resolve through the same lookup, so a later
-  /// registration shadows an earlier binding of the same name — the house rule
-  /// the resolver already follows (a view shadows a table, a CTE shadows a
-  /// view). (A future PATH / search-order mechanism — à la DB2 or PostgreSQL —
-  /// would let a qualified call reach a specific one across schemas.)
+  /// flat map with no privileged tier at LOOKUP: a prelude routine
+  /// (`Routines.standard`) and a caller-registered one resolve through the same
+  /// lookup, so a name resolves to whatever the map binds. (A future PATH /
+  /// search-order mechanism — à la DB2 or PostgreSQL — would let a qualified
+  /// call reach a specific one across schemas.) A caller does not REACH this
+  /// map past a standard name, though: `registering(_:…)` refuses to bind one
+  /// (see `protected`), so the shadowing a lower-level `init` still permits
+  /// never arises through the public extension surface.
   public subscript(_ name: String) -> Routine? {
     functions[name.lowercased()]
+  }
+
+  /// The names of the standard-library routines, case-folded — the built-ins
+  /// `Routines.standard` seeds. These are PROTECTED: `registering(_:…)` rejects
+  /// a binding of any of them, so a caller extending the prelude cannot shadow
+  /// an ISO built-in and silently change what a query naming it computes.
+  /// Constructing a `Routines` DIRECTLY through `init(_:)` or the dictionary
+  /// literal is a lower-level escape hatch that still admits a standard name —
+  /// it is how `standard` itself is built — but the public composition API
+  /// (`registering`) does not.
+  private static let protected = Set(standard.functions.keys)
+
+  /// Faults if `name` (case-folded) is a protected standard routine — the check
+  /// both `registering` overloads apply before binding, so neither the closure
+  /// nor the `CREATE FUNCTION` path shadows a built-in. It carries SQLSTATE
+  /// `42723` (duplicate function, the PostgreSQL subclass on the `42` class)
+  /// via the `.state` passthrough — no semantic case models a reserved-name
+  /// fault, and `.function`'s message ("no such function") would misdescribe
+  /// the condition.
+  private static func reserved(_ name: String) throws(SQLError) {
+    guard !protected.contains(name.lowercased()) else {
+      throw .state("42723", "'\(name)' is a standard routine and "
+                       + "cannot be redefined")
+    }
   }
 
   /// A copy of these routines with a routine computing `compute`, accepting
   /// `parameters` (default none), and returning `returns` (default `.integer`)
   /// bound to `name` (folded to lower case), the binding shadowing any existing
-  /// one. `deterministic` declares the routine's ISO SQL characteristic and
-  /// defaults to `false` (NOT DETERMINISTIC) — the safe default for a host
-  /// closure, which may be stateful or read the clock: it is not executed at
-  /// compile time. Pass `true` for a pure routine to let a row-independent call
-  /// fold.
+  /// one — UNLESS `name` is a protected standard routine (`reserved(_:)`),
+  /// which faults rather than shadow an ISO built-in. `deterministic` declares
+  /// the routine's ISO SQL characteristic and defaults to `false` (NOT
+  /// DETERMINISTIC) — the safe default for a host closure, which may be
+  /// stateful or read the clock: it is not executed at compile time. Pass
+  /// `true` for a pure routine to let a row-independent call fold.
   //
   // `SQL.Value` is spelled in full here and in `bitand`: `Routines` conforms to
   // `ExpressibleByDictionaryLiteral`, whose associated `Value` is the literal's
@@ -263,7 +290,9 @@ public struct Routines: Sendable {
                           parameters: Array<ValueType> = [],
                           deterministic: Bool = false,
                           _ compute: @escaping @Sendable (Array<SQL.Value>)
-                              throws(SQLError) -> SQL.Value) -> Routines {
+                              throws(SQLError) -> SQL.Value)
+      throws(SQLError) -> Routines {
+    try Routines.reserved(name)
     var functions = self.functions
     functions[name.lowercased()] =
         Routine(returns: returns, parameters: parameters,
@@ -272,9 +301,11 @@ public struct Routines: Sendable {
   }
 
   /// A copy of these routines with the DEFINED `function` bound to `name`
-  /// (folded to lower case), the binding shadowing any existing one — the
-  /// registration a consumer performs for a parsed `CREATE FUNCTION`, mirroring
-  /// a catalog registering a `CREATE VIEW`'s `View`.
+  /// (folded to lower case), the binding shadowing any existing one — UNLESS
+  /// `name` is a protected standard routine (`reserved(_:)`), which faults
+  /// rather than shadow an ISO built-in — the registration a consumer performs
+  /// for a parsed `CREATE FUNCTION`, mirroring a catalog registering a `CREATE
+  /// VIEW`'s `View`.
   ///
   /// The function's body is lowered to a term over its parameters HERE, so a
   /// body naming a parameter the function does not declare faults
@@ -313,6 +344,7 @@ public struct Routines: Sendable {
   /// INTERNAL calls, not which `f` a query reaches.
   public func registering(_ name: String, _ function: Function)
       throws(SQLError) -> Routines {
+    try Routines.reserved(name)
     var seen = Set<String>()
     for parameter in function.parameters
         where !seen.insert(parameter.name.lowercased()).inserted {
@@ -336,17 +368,85 @@ public struct Routines: Sendable {
   }
 
   /// The standard-library prelude — the routines the engine ships, seeded into
-  /// the flat registry at the public entry points so a query reaches them
-  /// without a caller registering a closure. They are ordinary entries in the
-  /// same map as any registered routine, not a privileged tier, so a caller MAY
-  /// shadow one (see `subscript(_:)`). Its lone member is `BITAND`, the
-  /// portable, standards-compliant spelling (Oracle's) of a bitwise AND — an
-  /// operation ISO SQL and this grammar otherwise lack; it returns an integer.
-  /// It is DETERMINISTIC — a pure bitwise fold — so a row-independent call may
-  /// fold at compile time.
-  public static let standard: Routines =
-      ["bitand": Routine(parameters: [.integer, .integer],
-                         deterministic: true, bitand)]
+  /// the flat registry at the public entry points (`Routines.standard` merged
+  /// under a caller's routines) so a query reaches them without a caller
+  /// registering a closure. They are PROTECTED: a caller cannot shadow one
+  /// through `registering(_:…)` (see `protected`/`reserved(_:)`), so a query
+  /// naming a built-in always reaches the shipped one. Every member is a pure,
+  /// side-effect-free mapping and so DETERMINISTIC — a row-independent call
+  /// folds at compile time — and returns NULL on any NULL argument (SQL null
+  /// propagation), faulting `SQLError.argument` on the wrong argument count or
+  /// a value it cannot map, mirroring its declared `[parameters]`/`returns`
+  /// contract the static type-check validates a call against.
+  ///
+  /// The set covers the ISO scalar built-ins the grammar can already CALL
+  /// (`f(…)`), in two families:
+  ///
+  /// - STRING: `UPPER`/`LOWER` (case fold), `CHAR_LENGTH` (with its ISO synonym
+  ///   `CHARACTER_LENGTH`, the same routine under both names), `SUBSTRING` (the
+  ///   two-argument `SUBSTRING(text, start)` form, ISO 1-based indexing), and
+  ///   `TRIM` (the one-argument `TRIM(text)` form, stripping leading and
+  ///   trailing spaces).
+  /// - NUMERIC: `ABS`, `ROUND` (the one-argument form, to the nearest integer
+  ///   value), `CEILING` (with its synonym `CEIL`), `FLOOR`, and `MOD` (the
+  ///   two-integer remainder — `BITAND`'s numeric sibling, an operation the
+  ///   grammar's `%` otherwise lacks a call spelling for). `BITAND` — the
+  ///   portable, standards-compliant spelling (Oracle's) of a bitwise AND, an
+  ///   operation ISO SQL and this grammar otherwise lack — is kept.
+  ///
+  /// FOLLOW-UPS (each needs grammar or overloading this batch does not add, so
+  /// each ships in its simplest callable form now):
+  /// - `SUBSTRING(text FROM start FOR length)` — the full ISO clause with a
+  ///   `FROM`/`FOR` keyword syntax and an optional length — and the plain
+  ///   three-argument `SUBSTRING(text, start, length)` both need either grammar
+  ///   or variadic arity (the contract is a fixed-arity `[parameters]`); only
+  ///   the two-argument prefix form ships.
+  /// - `TRIM([{LEADING | TRAILING | BOTH}] [char] FROM text)` — the full ISO
+  ///   clause with a trim specification and a trim character — needs grammar;
+  ///   only the leading-and-trailing-space `TRIM(text)` form ships.
+  /// - `ROUND(n, places)` — rounding to a decimal place — needs variadic arity;
+  ///   only the nearest-integer `ROUND(n)` form ships.
+  /// - The numeric routines are declared over `double` (`returns` a `double`,
+  ///   save `MOD`'s integer remainder), so an INTEGER argument does not satisfy
+  ///   the static contract (the type-check is exact-equality — an integer is
+  ///   not a double); an integer-domain overload (`ABS(integer) → integer`, …)
+  ///   needs routine overloading, which the single-signature contract lacks.
+  public static let standard: Routines = [
+    "bitand": Routine(returns: .integer, parameters: [.integer, .integer],
+                      deterministic: true, bitand),
+    "upper": Routine(returns: .text, parameters: [.text],
+                     deterministic: true, upper),
+    "lower": Routine(returns: .text, parameters: [.text],
+                     deterministic: true, lower),
+    "char_length": Routine(returns: .integer, parameters: [.text],
+                           deterministic: true, length),
+    "character_length": Routine(returns: .integer, parameters: [.text],
+                                deterministic: true, length),
+    "substring": Routine(returns: .text, parameters: [.text, .integer],
+                         deterministic: true, substring),
+    "trim": Routine(returns: .text, parameters: [.text],
+                    deterministic: true, trim),
+    "abs": Routine(returns: .double, parameters: [.double],
+                   deterministic: true, abs),
+    "round": Routine(returns: .double, parameters: [.double],
+                     deterministic: true, round),
+    "ceiling": Routine(returns: .double, parameters: [.double],
+                       deterministic: true, ceiling),
+    "ceil": Routine(returns: .double, parameters: [.double],
+                    deterministic: true, ceiling),
+    "floor": Routine(returns: .double, parameters: [.double],
+                     deterministic: true, floor),
+    "mod": Routine(returns: .integer, parameters: [.integer, .integer],
+                   deterministic: true, mod),
+  ]
+
+  /// The single `.null` short-circuit ISO null propagation gives every built-in
+  /// — a NULL argument yields NULL — factored out so each routine reads as its
+  /// mapping alone. Returns `true` when any argument is NULL, so the caller
+  /// returns `.null` before matching a concrete kind.
+  private static func propagates(_ arguments: Array<SQL.Value>) -> Bool {
+    arguments.contains(.null)
+  }
 
   /// `BITAND(x, y)` — the bitwise AND of two integers. A NULL argument yields
   /// NULL (SQL null propagation); the wrong argument count or a non-integer
@@ -359,13 +459,180 @@ public struct Routines: Sendable {
     guard arguments.count == 2 else {
       throw .argument("BITAND takes two arguments")
     }
-    if case .null = arguments[0] { return .null }
-    if case .null = arguments[1] { return .null }
+    if propagates(arguments) { return .null }
     guard case let .integer(x) = arguments[0],
         case let .integer(y) = arguments[1] else {
       throw .argument("BITAND requires integer arguments")
     }
     return .integer(x & y)
+  }
+
+  /// `UPPER(text)` — the string upper-cased. A NULL argument yields NULL; the
+  /// wrong count or a non-text argument is `SQLError.argument`.
+  private static func upper(_ arguments: Array<SQL.Value>)
+      throws(SQLError) -> SQL.Value {
+    guard arguments.count == 1 else {
+      throw .argument("UPPER takes one argument")
+    }
+    if propagates(arguments) { return .null }
+    guard case let .text(string) = arguments[0] else {
+      throw .argument("UPPER requires a text argument")
+    }
+    return .text(string.uppercased())
+  }
+
+  /// `LOWER(text)` — the string lower-cased. A NULL argument yields NULL; the
+  /// wrong count or a non-text argument is `SQLError.argument`.
+  private static func lower(_ arguments: Array<SQL.Value>)
+      throws(SQLError) -> SQL.Value {
+    guard arguments.count == 1 else {
+      throw .argument("LOWER takes one argument")
+    }
+    if propagates(arguments) { return .null }
+    guard case let .text(string) = arguments[0] else {
+      throw .argument("LOWER requires a text argument")
+    }
+    return .text(string.lowercased())
+  }
+
+  /// `CHAR_LENGTH(text)` / `CHARACTER_LENGTH(text)` — the number of characters
+  /// in the string (its Unicode character count, not its UTF-8 byte length). A
+  /// NULL argument yields NULL; the wrong count or a non-text argument is
+  /// `SQLError.argument`.
+  private static func length(_ arguments: Array<SQL.Value>)
+      throws(SQLError) -> SQL.Value {
+    guard arguments.count == 1 else {
+      throw .argument("CHAR_LENGTH takes one argument")
+    }
+    if propagates(arguments) { return .null }
+    guard case let .text(string) = arguments[0] else {
+      throw .argument("CHAR_LENGTH requires a text argument")
+    }
+    return .integer(string.count)
+  }
+
+  /// `SUBSTRING(text, start)` — the substring of `text` from the 1-based
+  /// `start` character to the end, the ISO indexing where the first character
+  /// is position 1. A `start` at or before 1 begins at the first character; a
+  /// `start` past the end yields the empty string. A NULL argument yields NULL;
+  /// the wrong count, a non-text first argument, or a non-integer second is
+  /// `SQLError.argument`.
+  private static func substring(_ arguments: Array<SQL.Value>)
+      throws(SQLError) -> SQL.Value {
+    guard arguments.count == 2 else {
+      throw .argument("SUBSTRING takes two arguments")
+    }
+    if propagates(arguments) { return .null }
+    guard case let .text(string) = arguments[0],
+        case let .integer(start) = arguments[1] else {
+      throw .argument("SUBSTRING requires a text and an integer argument")
+    }
+    // ISO positions are 1-based; a start at or before 1 clamps to the first
+    // character, and one past the end clamps to the end (the empty tail). The
+    // `start - 1` conversion overflows for `Int.min`, so a start at or before
+    // 1 takes the whole string directly rather than subtracting.
+    let drop = start > 1 ? start - 1 : 0
+    return .text(String(string.dropFirst(drop)))
+  }
+
+  /// `TRIM(text)` — the string with leading and trailing SPACE characters
+  /// removed (the one-argument ISO form, whose implicit trim character is a
+  /// space and whose implicit specification is BOTH). A NULL argument yields
+  /// NULL; the wrong count or a non-text argument is `SQLError.argument`.
+  private static func trim(_ arguments: Array<SQL.Value>)
+      throws(SQLError) -> SQL.Value {
+    guard arguments.count == 1 else {
+      throw .argument("TRIM takes one argument")
+    }
+    if propagates(arguments) { return .null }
+    guard case let .text(string) = arguments[0] else {
+      throw .argument("TRIM requires a text argument")
+    }
+    return .text(String(string.drop(while: { $0 == " " })
+                            .reversed().drop(while: { $0 == " " })
+                            .reversed()))
+  }
+
+  /// `ABS(n)` — the absolute value of a real number. A NULL argument yields
+  /// NULL; the wrong count or a non-double argument is `SQLError.argument`.
+  private static func abs(_ arguments: Array<SQL.Value>)
+      throws(SQLError) -> SQL.Value {
+    guard arguments.count == 1 else {
+      throw .argument("ABS takes one argument")
+    }
+    if propagates(arguments) { return .null }
+    guard case let .double(value) = arguments[0] else {
+      throw .argument("ABS requires a double argument")
+    }
+    return .double(Swift.abs(value))
+  }
+
+  /// `ROUND(n)` — the real number rounded to the nearest integer value (ties
+  /// away from zero, the ISO default), carried as a double. A NULL argument
+  /// yields NULL; the wrong count or a non-double argument is
+  /// `SQLError.argument`.
+  private static func round(_ arguments: Array<SQL.Value>)
+      throws(SQLError) -> SQL.Value {
+    guard arguments.count == 1 else {
+      throw .argument("ROUND takes one argument")
+    }
+    if propagates(arguments) { return .null }
+    guard case let .double(value) = arguments[0] else {
+      throw .argument("ROUND requires a double argument")
+    }
+    return .double(value.rounded())
+  }
+
+  /// `CEILING(n)` / `CEIL(n)` — the least integer value not less than `n`,
+  /// carried as a double. A NULL argument yields NULL; the wrong count or a
+  /// non-double argument is `SQLError.argument`.
+  private static func ceiling(_ arguments: Array<SQL.Value>)
+      throws(SQLError) -> SQL.Value {
+    guard arguments.count == 1 else {
+      throw .argument("CEILING takes one argument")
+    }
+    if propagates(arguments) { return .null }
+    guard case let .double(value) = arguments[0] else {
+      throw .argument("CEILING requires a double argument")
+    }
+    return .double(value.rounded(.up))
+  }
+
+  /// `FLOOR(n)` — the greatest integer value not greater than `n`, carried as a
+  /// double. A NULL argument yields NULL; the wrong count or a non-double
+  /// argument is `SQLError.argument`.
+  private static func floor(_ arguments: Array<SQL.Value>)
+      throws(SQLError) -> SQL.Value {
+    guard arguments.count == 1 else {
+      throw .argument("FLOOR takes one argument")
+    }
+    if propagates(arguments) { return .null }
+    guard case let .double(value) = arguments[0] else {
+      throw .argument("FLOOR requires a double argument")
+    }
+    return .double(value.rounded(.down))
+  }
+
+  /// `MOD(a, b)` — the remainder of `a` divided by `b`, both integers (the ISO
+  /// `MOD` function, distinct from the grammar's `%` operator). A zero divisor
+  /// is `SQLError.divide`, as integer arithmetic's `%` by zero is. A NULL
+  /// argument yields NULL; the wrong count or a non-integer argument is
+  /// `SQLError.argument`.
+  private static func mod(_ arguments: Array<SQL.Value>)
+      throws(SQLError) -> SQL.Value {
+    guard arguments.count == 2 else {
+      throw .argument("MOD takes two arguments")
+    }
+    if propagates(arguments) { return .null }
+    guard case let .integer(a) = arguments[0],
+        case let .integer(b) = arguments[1] else {
+      throw .argument("MOD requires integer arguments")
+    }
+    guard b != 0 else { throw .divide }
+    // `a % -1` is mathematically 0, but `Int.min % -1` overflows the implied
+    // division and traps, so a divisor of -1 short-circuits to that 0.
+    guard b != -1 else { return .integer(0) }
+    return .integer(a % b)
   }
 }
 

--- a/Sources/winmd-inspect/Database+SQL.swift
+++ b/Sources/winmd-inspect/Database+SQL.swift
@@ -192,9 +192,10 @@ extension Session {
     // both its `.text` return type — the result type the schema walk and the
     // `INFORMATION_SCHEMA` `data_type` a view's `GUID(...)` column reports read
     // — and its `[.blob]` parameter contract, which the static type-check
-    // validates a `GUID(...)` call against.
-    Routines.standard.registering("guid", returns: .text, parameters: [.blob],
-                                  Session.guid)
+    // validates a `GUID(...)` call against. `try!`: the name is a compile-time
+    // constant and not a protected standard routine, so it never faults.
+    try! Routines.standard.registering("guid", returns: .text,
+                                       parameters: [.blob], Session.guid)
   }
 
   /// `GUID(blob)` — the UUID a `GuidAttribute` `CustomAttribute` value blob

--- a/Sources/winmd-inspect/Language.swift
+++ b/Sources/winmd-inspect/Language.swift
@@ -198,8 +198,10 @@ internal struct Language: Sendable {
     }
     // `SANITIZE` returns text over one text argument, so it declares both its
     // return type and its `[.text]` parameter contract — the signature the
-    // static type-check validates a `SANITIZE(...)` call against.
-    return Routines().registering("sanitize", returns: .text,
-                                  parameters: [.text], sanitize)
+    // static type-check validates a `SANITIZE(...)` call against. `try!`: the
+    // name is a compile-time constant and not a protected standard routine, so
+    // `registering` never faults it.
+    return try! Routines().registering("sanitize", returns: .text,
+                                       parameters: [.text], sanitize)
   }
 }

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -2739,21 +2739,14 @@ struct EngineStreamingProductTests {
 
 // MARK: - Scalar-function tests
 
-/// Routines with two demonstration scalar functions: `upper`, which folds a
-/// text cell to upper case, and `add`, which sums two integer cells. These
-/// stand in for the per-dialect decode functions a synthesis projection calls.
-/// Built from `Routines.standard` so the prelude (e.g. `BITAND`) resolves here
-/// as it does at the engine's public entry points, which seed the prelude by
-/// default.
+/// Routines with a demonstration scalar function `add`, which sums two integer
+/// cells — standing in for the per-dialect decode functions a synthesis
+/// projection calls. Built from `Routines.standard` so the prelude (`UPPER`,
+/// `BITAND`, …) resolves here as it does at the engine's public entry points,
+/// which seed the prelude by default; the string built-in `UPPER` folds a text
+/// cell to upper case, so no demo `upper` is registered (it is protected).
 private func routines() -> Routines {
-  Routines.standard
-    .registering("upper", returns: .text, parameters: [.text]) {
-      arguments throws(SQLError) in
-      guard case let .text(text) = arguments.first else {
-        throw .argument("upper expects one text argument")
-      }
-      return .text(text.uppercased())
-    }
+  try! Routines.standard
     .registering("add", parameters: [.integer, .integer]) {
       arguments throws(SQLError) in
       guard arguments.count == 2,
@@ -2807,14 +2800,17 @@ struct EngineFunctionTests {
   }
 
   @Test func `a function rejecting its arguments reports the fault`() throws {
-    #expect(throws: SQLError.argument("upper expects one text argument")) {
+    // The run path does not statically type-check a call — it invokes the
+    // routine, whose own kind check faults an INTEGER passed to the text
+    // built-in UPPER.
+    #expect(throws: SQLError.argument("UPPER requires a text argument")) {
       try functionRun("SELECT upper(Id) FROM People WHERE Id = 1")
     }
   }
 
   @Test func `a function call resolves its name case-insensitively`() throws {
-    // `upper` is registered; the natural SQL spelling UPPER resolves to it, as
-    // table and column identifiers do.
+    // The built-in `UPPER` resolves through the seeded prelude; the natural SQL
+    // spelling UPPER resolves to it, as table and column identifiers do.
     let rows = try functionRun("SELECT UPPER(Name) FROM People WHERE Id = 1")
     #expect(rows == [[.text("ALICE")]])
   }
@@ -2840,17 +2836,18 @@ struct EngineFunctionTests {
     }
   }
 
-  @Test func `a registered function shadows the prelude BITAND`() throws {
-    // The registry is a single flat map with no privileged tier, so a caller's
-    // `bitand` registered OVER the prelude one shadows it (house rule: a later
-    // binding wins). The user's closure returns -1, not the bitwise AND.
-    let user = Routines.standard
-        .registering("bitand", parameters: [.integer, .integer]) {
-          _ throws(SQLError) in .integer(-1)
-        }
-    let query = try parse("SELECT BITAND(6, 3) FROM People WHERE Id = 1")
-    let rows = try people().run(query, user)
-    #expect(rows == [[.integer(-1)]])
+  @Test func `registering over a protected prelude routine is rejected`() throws {
+    // BITAND is a protected standard built-in, so a caller cannot shadow it
+    // through `registering`: the binding faults (SQLSTATE 42723) rather than
+    // silently changing what a query naming BITAND computes. The prelude one
+    // therefore always wins at the query's call site.
+    #expect(throws: SQLError.state("42723",
+        "'bitand' is a standard routine and cannot be redefined")) {
+      try Routines.standard
+          .registering("bitand", parameters: [.integer, .integer]) {
+            _ throws(SQLError) in .integer(-1)
+          }
+    }
   }
 
   @Test func `routine names colliding only by case merge without trapping`() throws {
@@ -4117,7 +4114,7 @@ private func seed() -> Memory {
 /// Routines with an `inc` scalar — `inc(n) = n + 1` — standing in for the `+`
 /// the dialect lacks, so a recursive counter can advance.
 private func counting() -> Routines {
-  Routines().registering("inc", parameters: [.integer]) {
+  try! Routines().registering("inc", parameters: [.integer]) {
     arguments throws(SQLError) in
     guard case let .integer(n) = arguments.first else {
       throw .argument("inc expects one integer argument")

--- a/Tests/SQLTests/FunctionTests.swift
+++ b/Tests/SQLTests/FunctionTests.swift
@@ -41,8 +41,8 @@ import SQLTestSupport
     #expect(routines["upper"]?.parameters == [.text])
   }
 
-  @Test func `registering declares a signature, the return defaulting to integer`() {
-    let routines = Routines()
+  @Test func `registering declares a signature, the return defaulting to integer`() throws {
+    let routines = try Routines()
         .registering("t", returns: .text, parameters: [.text]) {
           _ in .text("x")
         }
@@ -61,6 +61,230 @@ import SQLTestSupport
   @Test func `the standard prelude declares BITAND over two integers`() {
     #expect(Routines.standard["bitand"]?.returns == .integer)
     #expect(Routines.standard["bitand"]?.parameters == [.integer, .integer])
+  }
+}
+
+/// A small catalog the standard-library tests project the built-ins over. Its
+/// columns give each built-in an argument of the RIGHT type (`Text`, `Num`,
+/// `Real`) and, in a second row, a NULL of each, so a call over a column and a
+/// call over a NULL both run. `Pad` is a text column with leading and trailing
+/// spaces for `TRIM`. A third row carries `Int.min` in `Num` so the integer
+/// routines are exercised at the edge where a naive `start - 1` or `a % -1`
+/// would overflow and trap.
+private func library() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("L", ["Id": .integer, "Text": .text, "Pad": .text,
+                   "Num": .integer, "Real": .double]) {
+      Row(1, "aBc", "  hi  ", -7, -2.5)
+      Row(2, nil, nil, nil, nil)
+      Row(3, "hello", "", Int.min, 0.0)
+    }
+  }
+}
+
+@Suite struct StandardLibraryTests {
+  // MARK: - Declared signatures
+
+  @Test func `each standard routine declares its signature`() {
+    let standard = Routines.standard
+    #expect(standard["upper"]?.returns == .text)
+    #expect(standard["upper"]?.parameters == [.text])
+    #expect(standard["lower"]?.returns == .text)
+    #expect(standard["char_length"]?.returns == .integer)
+    #expect(standard["char_length"]?.parameters == [.text])
+    #expect(standard["character_length"]?.returns == .integer)
+    #expect(standard["substring"]?.parameters == [.text, .integer])
+    #expect(standard["substring"]?.returns == .text)
+    #expect(standard["trim"]?.returns == .text)
+    #expect(standard["abs"]?.parameters == [.double])
+    #expect(standard["abs"]?.returns == .double)
+    #expect(standard["round"]?.returns == .double)
+    #expect(standard["ceiling"]?.returns == .double)
+    #expect(standard["ceil"]?.returns == .double)
+    #expect(standard["floor"]?.returns == .double)
+    #expect(standard["mod"]?.parameters == [.integer, .integer])
+    #expect(standard["mod"]?.returns == .integer)
+  }
+
+  @Test func `every standard routine is deterministic`() {
+    for name in ["bitand", "upper", "lower", "char_length",
+                 "character_length", "substring", "trim", "abs", "round",
+                 "ceiling", "ceil", "floor", "mod"] {
+      #expect(Routines.standard[name]?.deterministic == true)
+    }
+  }
+
+  @Test func `columns(of:) reports a built-in call by its declared type`() throws {
+    // The schema walk types a call by its routine's `returns`, so a projected
+    // built-in reports the declared header — text for UPPER, integer for
+    // CHAR_LENGTH, double for ROUND — when the standard prelude is in scope.
+    let query = try Statement(parsing:
+        "SELECT UPPER(Text), CHAR_LENGTH(Text), ROUND(Real) FROM L")
+    let typed = try library().columns(of: query, routines: .standard)
+    #expect(typed.map(\.type) == [.text, .integer, .double])
+  }
+
+  // MARK: - String routines
+
+  @Test func `UPPER and LOWER fold a text column`() throws {
+    try library().expect("SELECT UPPER(Text), LOWER(Text) FROM L WHERE Id = 1",
+                         yields: [["ABC", "abc"]], routines: .standard)
+  }
+
+  @Test func `UPPER folds a text literal`() throws {
+    try library().expect("SELECT UPPER('aBc') FROM L WHERE Id = 1",
+                         yields: [["ABC"]], routines: .standard)
+  }
+
+  @Test func `CHAR_LENGTH and its synonym count characters`() throws {
+    try library().expect(
+        "SELECT CHAR_LENGTH(Text), CHARACTER_LENGTH(Text) FROM L WHERE Id = 1",
+        yields: [[3, 3]], routines: .standard)
+  }
+
+  @Test func `SUBSTRING takes an ISO 1-based start`() throws {
+    // Position 2 of 'aBc' is 'Bc'; a start at or before 1 is the whole string.
+    try library().expect("SELECT SUBSTRING(Text, 2) FROM L WHERE Id = 1",
+                         yields: [["Bc"]], routines: .standard)
+    try library().expect("SELECT SUBSTRING(Text, 1) FROM L WHERE Id = 1",
+                         yields: [["aBc"]], routines: .standard)
+  }
+
+  @Test func `SUBSTRING clamps a start at or before 1 to the whole string`()
+      throws {
+    // A start of 0, a negative start, and the extreme `Int.min` all clamp to
+    // the first character; the `Int.min` case would trap on a naive
+    // `start - 1`, so it exercises the guarded conversion over an integer
+    // column.
+    try library().expect("SELECT SUBSTRING(Text, 0) FROM L WHERE Id = 3",
+                         yields: [["hello"]], routines: .standard)
+    try library().expect("SELECT SUBSTRING(Text, Num) FROM L WHERE Id = 1",
+                         yields: [["aBc"]], routines: .standard)
+    try library().expect("SELECT SUBSTRING(Text, Num) FROM L WHERE Id = 3",
+                         yields: [["hello"]], routines: .standard)
+    try library().expect("SELECT SUBSTRING(Text, 2) FROM L WHERE Id = 3",
+                         yields: [["ello"]], routines: .standard)
+  }
+
+  @Test func `TRIM strips leading and trailing spaces`() throws {
+    try library().expect("SELECT TRIM(Pad) FROM L WHERE Id = 1",
+                         yields: [["hi"]], routines: .standard)
+  }
+
+  // MARK: - Numeric routines
+
+  @Test func `ABS takes the magnitude of a real number`() throws {
+    try library().expect("SELECT ABS(Real) FROM L WHERE Id = 1",
+                         yields: [[2.5]], routines: .standard)
+  }
+
+  @Test func `ROUND CEILING CEIL and FLOOR shape a real number`() throws {
+    try library().expect(
+        "SELECT ROUND(2.5), CEILING(2.1), CEIL(2.1), FLOOR(2.9) FROM L "
+            + "WHERE Id = 1",
+        yields: [[3.0, 3.0, 3.0, 2.0]], routines: .standard)
+  }
+
+  @Test func `MOD takes the integer remainder`() throws {
+    try library().expect("SELECT MOD(7, 3), MOD(Num, 3) FROM L WHERE Id = 1",
+                         yields: [[1, -1]], routines: .standard)
+  }
+
+  @Test func `MOD by zero faults like integer division`() throws {
+    try library().expect("SELECT MOD(7, 0) FROM L WHERE Id = 1",
+                         fails: .divide, routines: .standard)
+  }
+
+  @Test func `MOD of Int.min by -1 and by 1 is zero without trapping`()
+      throws {
+    // `Int.min % -1` overflows the implied division and traps, so a divisor
+    // of -1 short-circuits to the mathematical remainder, 0; `Int.min % 1` is
+    // 0 too. The divisor is spelt `0 - 1` since the grammar has no negative
+    // literal.
+    try library().expect("SELECT MOD(Num, 0 - 1) FROM L WHERE Id = 3",
+                         yields: [[0]], routines: .standard)
+    try library().expect("SELECT MOD(Num, 1) FROM L WHERE Id = 3",
+                         yields: [[0]], routines: .standard)
+  }
+
+  // MARK: - NULL propagation
+
+  @Test func `a built-in returns NULL on a NULL argument`() throws {
+    // Every built-in propagates NULL, the way BITAND does — the Id = 2 row
+    // holds a NULL in each column.
+    try library().expect(
+        "SELECT UPPER(Text), CHAR_LENGTH(Text), SUBSTRING(Text, 1), "
+            + "TRIM(Pad), ABS(Real), ROUND(Real), FLOOR(Real), MOD(Num, 3) "
+            + "FROM L WHERE Id = 2",
+        yields: [[nil, nil, nil, nil, nil, nil, nil, nil]],
+        routines: .standard)
+  }
+
+  // MARK: - Bad arity and kind
+
+  @Test func `a built-in faults on the wrong argument count`() throws {
+    // The run path invokes the routine without a prior static type-check, so
+    // each built-in's own arity check reports the count fault.
+    try library().expect("SELECT UPPER(Text, Text) FROM L WHERE Id = 1",
+                         fails: .argument("UPPER takes one argument"),
+                         routines: .standard)
+    try library().expect("SELECT MOD(1) FROM L WHERE Id = 1",
+                         fails: .argument("MOD takes two arguments"),
+                         routines: .standard)
+  }
+
+  @Test func `a built-in faults on a wrong-typed argument`() throws {
+    // Likewise the run invokes the routine, whose own kind check faults a
+    // numeric column passed to UPPER's text argument and a text column passed
+    // to MOD's integer arguments.
+    try library().expect("SELECT UPPER(Num) FROM L WHERE Id = 1",
+                         fails: .argument("UPPER requires a text argument"),
+                         routines: .standard)
+    try library().expect("SELECT MOD(Text, 1) FROM L WHERE Id = 1",
+                         fails: .argument("MOD requires integer arguments"),
+                         routines: .standard)
+  }
+
+  // MARK: - Protection (non-shadowable)
+
+  @Test func `registering over a standard routine is rejected`() {
+    // A standard built-in is protected: `registering` refuses to bind its name
+    // (SQLSTATE 42723) rather than shadow it.
+    #expect(throws: SQLError.state("42723",
+        "'upper' is a standard routine and cannot be redefined")) {
+      try Routines().registering("upper", returns: .text,
+                                 parameters: [.text]) { _ in .text("x") }
+    }
+  }
+
+  @Test func `registering a defined function over a standard name is rejected`() {
+    // The `CREATE FUNCTION` path is protected too: a defined routine cannot
+    // take a built-in's name.
+    let function = Function(parameters: [], returns: .integer,
+                            body: .literal(.integer(0)))
+    #expect(throws: SQLError.state("42723",
+        "'floor' is a standard routine and cannot be redefined")) {
+      try Routines().registering("floor", function)
+    }
+  }
+
+  @Test func `protection resolves the name case-insensitively`() {
+    // The guard case-folds the name like every identifier, so a differently-
+    // cased spelling of a built-in is rejected too.
+    #expect(throws: SQLError.state("42723",
+        "'BitAnd' is a standard routine and cannot be redefined")) {
+      try Routines().registering("BitAnd", parameters: [.integer, .integer]) {
+        _ in .integer(0)
+      }
+    }
+  }
+
+  @Test func `registering a non-standard name still succeeds`() throws {
+    // Protection covers only the standard set — a fresh name binds as before.
+    let routines = try Routines().registering("mine", parameters: [.integer]) {
+      _ in .integer(1)
+    }
+    #expect(routines["mine"] != nil)
   }
 }
 

--- a/Tests/SQLTests/IntrospectionTests.swift
+++ b/Tests/SQLTests/IntrospectionTests.swift
@@ -593,9 +593,8 @@ struct IntrospectionTests {
         ["People": MetaRelation([("Name", .text)], [])],
         views: ["v": View(query: body, columns: ["iid"])])
     let routines =
-        Routines().registering("tag", returns: .text, parameters: [.text]) {
-          _ in .text("x")
-        }
+        try Routines().registering("tag", returns: .text,
+                                   parameters: [.text]) { _ in .text("x") }
     let rows = try cat.run(parse("""
         SELECT column_name, data_type FROM information_schema.columns
          WHERE table_name = 'v'
@@ -609,9 +608,8 @@ struct IntrospectionTests {
     let cat = MetaCatalog(["People": MetaRelation([("Name", .text)], [])])
     let query = try parse("SELECT TAG(Name) AS t FROM People")
     let routines =
-        Routines().registering("tag", returns: .text, parameters: [.text]) {
-          _ in .text("x")
-        }
+        try Routines().registering("tag", returns: .text,
+                                   parameters: [.text]) { _ in .text("x") }
     #expect(try cat.columns(of: query, routines: routines)
                 == [OutputColumn(name: "t", type: .text)])
     // Without the routines, `TAG` is an unknown function that a run could not
@@ -649,9 +647,8 @@ struct IntrospectionTests {
         ["People": MetaRelation([("Name", .text)], [])],
         views: ["w": View(query: body, columns: ["t"])])
     let routines =
-        Routines().registering("tag", returns: .text, parameters: [.text]) {
-          _ in .text("x")
-        }
+        try Routines().registering("tag", returns: .text,
+                                   parameters: [.text]) { _ in .text("x") }
     let typed =
         try cat.columns(of: parse("SELECT * FROM w"), routines: routines)
     #expect(typed == [OutputColumn(name: "t", type: .text)])

--- a/Tests/SQLTests/MembershipTests.swift
+++ b/Tests/SQLTests/MembershipTests.swift
@@ -230,7 +230,7 @@ struct MembershipTypeTests {
     // arithmetic faults the type check, matching the run's guarantee. (`probe`
     // returns `1`, which WOULD match `1` and short-circuit had it been folded —
     // proving the gate keys off the characteristic, not the value.)
-    let routines = Routines()
+    let routines = try Routines()
         .registering("probe", returns: .integer, deterministic: false) { _ in
           .integer(1)
         }
@@ -250,7 +250,7 @@ struct MembershipTypeTests {
     // match, so the OR-chain short-circuits before `Name + 1` and its text
     // arithmetic is never reached — `columns(of:)` succeeds. The ONLY change
     // from the prior test is the `deterministic` flag, so the gate keys off it.
-    let routines = Routines()
+    let routines = try Routines()
         .registering("probe", returns: .integer, deterministic: true) { _ in
           .integer(1)
         }
@@ -364,7 +364,7 @@ struct MembershipTypeTests {
     // stays reachable and must still fault the type check. The determinism gate
     // flows through the comparison fold — a non-deterministic operand keeps the
     // guard undecided rather than deciding a match the run might not make.
-    let routines = Routines()
+    let routines = try Routines()
         .registering("probe", returns: .integer, deterministic: false) { _ in
           .integer(1)
         }
@@ -502,7 +502,7 @@ struct MembershipOperandTests {
     // caches the operand, so the row is dropped and the counter reads exactly
     // 1.
     let counter = Counter()
-    let routines = Routines()
+    let routines = try Routines()
         .registering("stepper", returns: .integer, deterministic: false) { _ in
           .integer(counter.next())
         }

--- a/Tests/winmd-inspectTests/DatabaseSQLTests.swift
+++ b/Tests/winmd-inspectTests/DatabaseSQLTests.swift
@@ -358,8 +358,8 @@ struct DatabaseSQLTests {
       var session = Session(catalog, Session.bundled())
       _ = try session.run("CREATE FUNCTION twice(n INTEGER) RETURNS INTEGER "
                           + "AS n + n")
-      let language = Routines().registering("sanitize", returns: .text,
-                                            parameters: [.text]) { $0[0] }
+      let language = try Routines().registering("sanitize", returns: .text,
+                                                parameters: [.text]) { $0[0] }
       // The OLD render composition — the static prelude, WITHOUT the
       // session's routines — cannot resolve the session helper.
       let stale = language.merging(Session.routines)


### PR DESCRIPTION
Extend `Routines.standard` from its lone `BITAND` to a first batch of ISO scalar built-ins the grammar can already call as `f(...)`:

  - STRING: UPPER, LOWER, CHAR_LENGTH (with its ISO synonym CHARACTER_LENGTH), SUBSTRING(text, start) (ISO 1-based), TRIM(text) (leading/trailing spaces).
  - NUMERIC: ABS, ROUND, CEILING (with its synonym CEIL), FLOOR, MOD.

Each declares its `[parameters]`/`returns` contract (so the static type-check types and validates a call), returns NULL on any NULL argument, and faults `SQLError.argument` on the wrong arity or kind, mirroring BITAND. All are DETERMINISTIC, so a row-independent call folds at compile time.

Make the standard set NON-SHADOWABLE. `Routines.standard` was documented as an ordinary map tier a caller could shadow; ISO built-ins should be reserved. Both `registering` overloads now reject a standard name via a `reserved(_:)` guard (SQLSTATE 42723), so a caller extending the prelude cannot silently change what a query naming a built-in computes. This makes the closure `registering` throwing; in-tree callers are migrated (the demo `upper`/`bitand` test routines, now redundant against the real built-ins, are dropped or repurposed into protection tests; non-protected registrations gain `try`/`try!`).

Constructing a `Routines` directly through `init(_:)` or the dictionary literal remains a lower-level escape hatch that still admits a standard name — it is how `standard` itself is built — but the public composition API does not.

Deferred (each ships now in its simplest callable form): the full `SUBSTRING(text FROM start FOR length)` and 3-argument forms and `TRIM([spec] [char] FROM text)` need grammar; `ROUND(n, places)` needs variadic arity; an integer-domain numeric overload (`ABS(integer) -> integer`) needs routine overloading the single-signature contract does not model, so the numeric routines are declared over `double`.