### PR TITLE
SQL: add the INTERSECT and EXCEPT set operators

### DIFF
--- a/Sources/SQL/AST.swift
+++ b/Sources/SQL/AST.swift
@@ -116,27 +116,49 @@ public struct CTE: Hashable, Sendable {
   }
 }
 
-/// A query: one `SELECT`, or several combined left-associatively with `UNION`.
+/// One of the ISO set operators combining two query terms.
 ///
-/// A bare `SELECT` is the `select` case; `a UNION b UNION c` nests left —
-/// `union(union(select(a), b, all:), c, all:)` — so the arms read in source
-/// order. `UNION` removes duplicate result rows; `UNION ALL` (`all` true) keeps
-/// them. Every arm must project the same number of columns, and the result
-/// columns are the FIRST arm's projection (the ISO rule).
+/// Each combines the rows of a left and a right term — its arms — into one
+/// result: `union` keeps the rows of either, `intersect` the rows of both, and
+/// `except` the rows of the left not in the right. The `Query.setop` node pairs
+/// a `kind` with an `all` flag governing duplicate handling (see `setop`).
+public enum SetOperation: Hashable, Sendable {
+  /// `UNION` — the rows of either arm.
+  case union
+  /// `INTERSECT` — the rows present in both arms.
+  case intersect
+  /// `EXCEPT` — the rows of the left arm not present in the right.
+  case except
+}
+
+/// A query: one `SELECT`, or several combined with a set operator.
+///
+/// A bare `SELECT` is the `select` case; two query terms combined by a set
+/// operator (`UNION`, `INTERSECT`, `EXCEPT`) form a `setop` node. `INTERSECT`
+/// binds tighter than `UNION`/`EXCEPT` (the ISO precedence), and
+/// same-precedence operators associate left — `a UNION b UNION c` nests left,
+/// `setop(.union, setop(.union, select(a), select(b), all:), select(c), all:)`,
+/// so the arms read in source order, while `a UNION b INTERSECT c` binds as
+/// `a UNION (b INTERSECT c)`. Without `all` a set operation removes duplicate
+/// result rows; with `all` (`ALL`) it keeps them per the operator's
+/// multiplicity rule. Every arm must project the same number of columns, and
+/// the result columns are the FIRST arm's projection (the ISO rule).
 public indirect enum Query: Hashable, Sendable {
   /// A single `SELECT`.
   case select(Select)
-  /// A `UNION` (or `UNION ALL` when `all`) of a query and a further `SELECT`,
-  /// the new arm appended on the right so the chain reads left to right.
-  case union(Query, Select, all: Bool)
+  /// A set operation of `kind` (`UNION`/`INTERSECT`/`EXCEPT`, `ALL` when `all`)
+  /// over a left and a right query term, the right appended so a
+  /// same-precedence chain reads left to right.
+  case setop(SetOperation, Query, Query, all: Bool)
 
   /// The first `SELECT` of the query — the leftmost arm, reached by descending
-  /// the left-associative chain. Its projection names the result columns (the
-  /// ISO rule), so a `CREATE VIEW` infers a union's columns from it.
+  /// the left arm of each set operation. Its projection names the result
+  /// columns (the ISO rule), so a `CREATE VIEW` infers a set operation's
+  /// columns from it.
   public var first: Select {
     switch self {
     case let .select(select): select
-    case let .union(query, _, _): query.first
+    case let .setop(_, left, _, _): left.first
     }
   }
 }

--- a/Sources/SQL/Definition.swift
+++ b/Sources/SQL/Definition.swift
@@ -348,15 +348,15 @@ extension Catalog where Self: ~Escapable {
 
 extension Query {
   /// Collects every relation name this query names in a `FROM`/`JOIN`, across
-  /// the `UNION` chain and each arm, into `names` — the reserved store names
-  /// among them are what `Catalog.augment` builds.
+  /// the set-operation tree and each arm, into `names` — the reserved store
+  /// names among them are what `Catalog.augment` builds.
   func collect(into names: inout Set<String>) {
     switch self {
     case let .select(select):
       select.collect(into: &names)
-    case let .union(left, select, _):
+    case let .setop(_, left, right, _):
       left.collect(into: &names)
-      select.collect(into: &names)
+      right.collect(into: &names)
     }
   }
 }

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -43,22 +43,22 @@ extension CTE {
   /// (SELECT Id FROM Parent UNION ALL SELECT Id FROM Extra)` — whose anchor
   /// merely reads the same-named base — into the fixpoint.
   internal var recurses: Bool {
-    guard case let .union(_, arm, _) = query else { return false }
+    guard case let .setop(.union, _, arm, _) = query else { return false }
     return arm.references(name.lowercased())
   }
 }
 
 extension Query {
   /// Whether the query names the relation `name` (case-folded) in ANY member's
-  /// `FROM`/`JOIN` — walking the left-associative `UNION` chain and each arm.
-  /// Used to spot a self-reference lurking in a recursive body's anchor;
-  /// `CTE.recurses` itself inspects only the recursive arm.
+  /// `FROM`/`JOIN` — walking the set-operation tree and each arm. Used to spot
+  /// a self-reference lurking in a recursive body's anchor; `CTE.recurses`
+  /// itself inspects only the recursive arm.
   internal func references(_ name: String) -> Bool {
     switch self {
     case let .select(select):
       select.references(name)
-    case let .union(left, select, _):
-      left.references(name) || select.references(name)
+    case let .setop(_, left, right, _):
+      left.references(name) || right.references(name)
     }
   }
 }
@@ -260,7 +260,7 @@ extension Catalog where Self: ~Escapable {
     // Reject a misplaced recursive reference in an EARLIER arm when no
     // same-named base/view can seed it — the shape `with` rejects before
     // routing to the fixpoint.
-    if cte.recursive, case let .union(anchor, _, _) = cte.query,
+    if cte.recursive, case let .setop(.union, anchor, _, _) = cte.query,
         anchor.references(cte.name.lowercased()),
         case nil = table(named: cte.name),
         case nil = view(named: cte.name) {
@@ -275,8 +275,8 @@ extension Catalog where Self: ~Escapable {
     // runs in the SAME per-arm scope each arity check uses, so the operand check
     // shares the run's arm scoping and never types an anchor against the
     // CTE-self overlay.
-    if cte.recursive && cte.recurses, case let .union(anchor, recursive, _) =
-        cte.query {
+    if cte.recursive && cte.recurses,
+        case let .setop(.union, anchor, recursive, _) = cte.query {
       let scope = augment(context, for: anchor, rows: false)
       let width = try compile(anchor, scope).width
       guard width == cte.columns.count else {
@@ -289,16 +289,16 @@ extension Catalog where Self: ~Escapable {
       let empty = Materialised(columns: cte.columns, rows: [],
                                types: Array(repeating: .integer,
                                             count: cte.columns.count))
-      let probe = augment(context, for: .select(recursive), rows: false)
+      let probe = augment(context, for: recursive, rows: false)
           .binding(cte.name, to: empty)
-      let arm = try compile(.select(recursive), probe).width
+      let arm = try compile(recursive, probe).width
       guard arm == cte.columns.count else {
         throw .columns(expected: cte.columns.count, got: arm)
       }
       // The recursive arm is operand-checked with self bound to the declared
       // columns — the schema every iteration reads the CTE under.
       if typecheck {
-        try self.typecheck(.select(recursive), probe)
+        try self.typecheck(recursive, probe)
       }
     } else {
       let scope = augment(context, for: cte.query, rows: false)
@@ -314,8 +314,8 @@ extension Catalog where Self: ~Escapable {
   /// Evaluates a recursive `cte` to a fixpoint over this catalog with the
   /// `ctes` in scope, returning every produced row.
   ///
-  /// A recursive CTE's query is a `UNION` of an ANCHOR (its left arm, itself a
-  /// query) and a RECURSIVE arm (its right `SELECT`, which names the CTE). The
+  /// A recursive CTE's query is a `UNION` of an ANCHOR (its left arm) and a
+  /// RECURSIVE arm (its right arm, which names the CTE). The
   /// anchor evaluates once — with the CTE name NOT yet bound — to seed `result`
   /// and the `working` set. Each iteration then binds the CTE name to ONLY the
   /// `working` rows (the SQL semantics — the recursive arm sees just the
@@ -352,7 +352,7 @@ extension Catalog where Self: ~Escapable {
     // column using even a standard routine (`BITAND(...)`) types the same
     // inside the CTE as the identical SELECT does outside it.
     let context = augment(context, for: cte.query, rows: true)
-    guard case let .union(anchor, recursive, all) = cte.query else {
+    guard case let .setop(.union, anchor, recursive, all) = cte.query else {
       // A non-`UNION` recursive query runs once, but still binds under
       // `cte.columns`, so validate its compiled width here too — the check the
       // anchor and arm get. A body naming a base relation of the CTE's own name
@@ -389,7 +389,7 @@ extension Catalog where Self: ~Escapable {
                              types: Array(repeating: .integer,
                                           count: cte.columns.count))
     let probe = context.binding(cte.name, to: empty)
-    let arm = try compile(.select(recursive), probe).width
+    let arm = try compile(recursive, probe).width
     guard arm == cte.columns.count else {
       throw .columns(expected: cte.columns.count, got: arm)
     }
@@ -417,8 +417,7 @@ extension Catalog where Self: ~Escapable {
       let step = Materialised(columns: cte.columns, rows: working,
                               types: Array(repeating: .integer,
                                            count: cte.columns.count))
-      let produced = try run(.select(recursive), context.binding(cte.name,
-                                                                 to: step))
+      let produced = try run(recursive, context.binding(cte.name, to: step))
 
       var next = Array<Array<Value>>()
       for row in produced where all || seen.insert(row) {
@@ -974,11 +973,12 @@ extension Catalog where Self: ~Escapable {
       // NULL-extended.
       try .outer(optimise(left, context), optimise(right, context), on: on,
                  kind: kind)
-    case let .union(left, right, all):
+    case let .setop(kind, left, right, all):
       // Optimise each side with the same bindings so a bound predicate inside an
-      // arm seeks; the union itself merely concatenates and deduplicates,
-      // preserving this node's own `all`.
-      try .union(optimise(left, context), optimise(right, context), all: all)
+      // arm seeks; the set operation itself merely combines its sides,
+      // preserving this node's own `kind` and `all`.
+      try .setop(kind, optimise(left, context), optimise(right, context),
+                 all: all)
     case let .distinct(source):
       // A `distinct` dedups its source without a seek or join of its own;
       // optimise the source below it and rewrap.
@@ -1255,8 +1255,8 @@ extension Plan {
       // whole `WHERE` stays above (`distribute`'s default keeps it a `select`
       // over this node).
       try .outer(left.pushdown(), right.pushdown(), on: on, kind: kind)
-    case let .union(left, right, all):
-      try .union(left.pushdown(), right.pushdown(), all: all)
+    case let .setop(kind, left, right, all):
+      try .setop(kind, left.pushdown(), right.pushdown(), all: all)
     case let .distinct(source):
       // A `distinct` sits above the projection, so no `WHERE` conjunct reaches
       // it to push down; it recurses transparently. A filter must never cross a
@@ -1506,7 +1506,7 @@ extension Plan {
       // would be skipped for the filtered rows, suppressing a raise `derive`
       // owes by evaluating every column of every view row.
       terms.allSatisfy(\.safe) && rebase(conjunct, ordinals) != nil
-    case let .union(left, right, _):
+    case let .setop(_, left, right, _):
       left.pushable(conjunct, ordinals) && right.pushable(conjunct, ordinals)
     default:
       false
@@ -1528,8 +1528,8 @@ extension Plan {
     case let .project(terms, body):
       try .project(terms,
                    body.distribute(conjuncts.map { rebase($0, ordinals)! }))
-    case let .union(left, right, all):
-      try .union(left.inject(conjuncts, ordinals),
+    case let .setop(kind, left, right, all):
+      try .setop(kind, left.inject(conjuncts, ordinals),
                  right.inject(conjuncts, ordinals), all: all)
     default:
       // A view sub-plan is always a `project` (or a `union` of them); anything
@@ -1570,28 +1570,28 @@ extension Plan {
 extension Catalog where Self: ~Escapable {
   /// Compiles `query` over this catalog into a logical operator tree.
   ///
-  /// A single `SELECT` compiles as itself; a `UNION` compiles recursively into a
-  /// BINARY `union` plan that mirrors the left-associative `Query`:
-  /// `compile(.union(left, select, all))` is `.union(compile(left),
-  /// compile(.select(select)), all)`. Each node carries its OWN `all`, so the
-  /// executor honours every `UNION`/`UNION ALL` distinctly — `(A UNION B) UNION
-  /// ALL C` dedups `A ∪ B` before appending `C`, rather than treating the whole
-  /// chain by the trailing arm's flag. The new arm must project the same column
-  /// count as the chain's first `SELECT` — the result columns — else
+  /// A single `SELECT` compiles as itself; a set operation compiles recursively
+  /// into a BINARY `setop` plan that mirrors the `Query`:
+  /// `compile(.setop(kind, left, right, all))` is `.setop(kind, compile(left),
+  /// compile(right), all)`. Each node carries its OWN `kind`/`all`, so the
+  /// executor honours every operator distinctly — `(A UNION B) UNION ALL C`
+  /// dedups `A ∪ B` before appending `C`, rather than treating the whole chain
+  /// by the trailing arm's flag. The right arm must project the same column
+  /// count as the query's first `SELECT` — the result columns — else
   /// `SQLError.arity`.
   internal borrowing func compile(_ query: Query,
                                   _ context: Context = Context(),
                                   _ visited: Set<String> = [])
       throws(SQLError) -> Plan {
-    guard case let .union(left, select, all) = query else {
+    guard case let .setop(kind, left, right, all) = query else {
       return try compile(query.first, context, visited)
     }
 
     let width = try arity(query.first, context, visited)
-    let count = try arity(select, context, visited)
+    let count = try arity(right.first, context, visited)
     guard count == width else { throw .arity(width, count) }
-    return try .union(compile(left, context, visited),
-                      compile(.select(select), context, visited), all: all)
+    return try .setop(kind, compile(left, context, visited),
+                      compile(right, context, visited), all: all)
   }
 
   /// The number of result columns `select` projects — the extent of a `*` over

--- a/Sources/SQL/Lexer.swift
+++ b/Sources/SQL/Lexer.swift
@@ -426,6 +426,8 @@ internal struct Lexer: ~Escapable {
     case "NULL": .null
     case "IN": .in
     case "UNION": .union
+    case "INTERSECT": .intersect
+    case "EXCEPT": .except
     case "ALL": .all
     case "WITH": .with
     case "RECURSIVE": .recursive

--- a/Sources/SQL/Operator.swift
+++ b/Sources/SQL/Operator.swift
@@ -150,15 +150,19 @@ internal indirect enum Plan {
   /// nested loop that tracks matches, so it composes with an arbitrary
   /// (non-equi) `on`.
   case outer(Plan, Plan, on: Filter, kind: Join.Kind)
-  /// ∪ — the rows of the `left` sub-plan followed by the `right`'s, in source
-  /// order. With `all` the duplicates are kept (`UNION ALL`); without it the
-  /// whole-row duplicates of the combined rows are removed, the first occurrence
-  /// preserved (`UNION`). The node is binary and mirrors the left-associative
-  /// `Query` chain, so each `UNION`/`UNION ALL` honours its OWN `all`: a `UNION`
-  /// nested under a `UNION ALL` dedups its own pair before the outer node
-  /// appends the trailing arm. Both sides yield rows of the same width — the
-  /// result columns of the first arm.
-  case union(Plan, Plan, all: Bool)
+  /// A set operation of `kind` (`UNION`/`INTERSECT`/`EXCEPT`) over the `left`
+  /// and `right` sub-plans, both yielding rows of the same width — the result
+  /// columns of the first arm.
+  ///
+  /// Without `all` the result is the distinct rows the operator selects — the
+  /// rows of either (`UNION`), of both (`INTERSECT`), or of the left not in the
+  /// right (`EXCEPT`) — the first occurrence of each kept. With `all` each
+  /// operator keeps multiplicity: `UNION ALL` every row of both sides,
+  /// `INTERSECT ALL` each common row to the lesser count, `EXCEPT ALL` each
+  /// left row beyond the count the right removes. The node is binary and
+  /// mirrors the `Query` set-operation tree, so each node honours its OWN
+  /// `kind`/`all`.
+  case setop(SetOperation, Plan, Plan, all: Bool)
   /// δ — deduplicates its `source`'s rows, keeping the first occurrence of each
   /// distinct whole row and preserving their order (`SELECT DISTINCT`). It sits
   /// above the projection, so it dedups the projected output rows on the SAME
@@ -197,7 +201,7 @@ extension Plan {
     switch self {
     case let .project(terms, _):
       terms.count
-    case let .union(left, _, _):
+    case let .setop(_, left, _, _):
       left.width
     case let .distinct(source):
       // A `distinct` dedups rows without reshaping them, so it is as wide as
@@ -255,9 +259,9 @@ extension Plan {
       } else {
         nil
       }
-    case let .union(left, _, _):
+    case let .setop(_, left, _, _):
       // Both sides yield rows of the same width — the result columns — so the
-      // union's width is its left side's.
+      // set operation's width is its left side's.
       left.slots
     case let .distinct(source):
       // A `distinct` dedups rows without reshaping them, so it spans the same
@@ -296,11 +300,12 @@ extension Plan {
 /// by its typed keys major to minor, stably and each in its own direction;
 /// `product` pairs every
 /// outer record with every inner one; `join` re-resolves the inner relation,
-/// seeks it per outer record, and concatenates the matches; `union` runs its
-/// two sides — each with its own union semantics — and concatenates their rows,
-/// deduplicating the whole row unless `all`; `distinct` deduplicates its
-/// source's whole rows (`SELECT DISTINCT`); `limit` skips the first `offset` of
-/// its source's rows then takes at most `count`.
+/// seeks it per outer record, and concatenates the matches; `setop` runs its
+/// two sides — each with its own set-operation semantics — and combines their
+/// rows by its `kind` (`UNION`/`INTERSECT`/`EXCEPT`), deduplicating unless
+/// `all`; `distinct` deduplicates its source's whole rows (`SELECT DISTINCT`);
+/// `limit` skips the first `offset` of its source's rows then takes at most
+/// `count`.
 /// The catalog is borrowed throughout — a `~Escapable` source is never copied
 /// or stored.
 extension Catalog where Self: ~Escapable {
@@ -360,8 +365,8 @@ extension Catalog where Self: ~Escapable {
       return try outer(execute(left, context), left.slots ?? 0,
                        execute(right, context), right.slots ?? 0, on, kind,
                        routines, bindings)
-    case let .union(left, right, all):
-      return try union(left, right, all, context)
+    case let .setop(kind, left, right, all):
+      return try setop(kind, left, right, all, context)
     case let .distinct(source):
       return deduplicated(try execute(source, context))
     case let .aggregate(keys, aggregates, source):
@@ -390,22 +395,123 @@ private func limited(_ records: Array<Record>, _ count: Int?, _ offset: Int)
   return Array(tail.prefix(count))
 }
 
-/// Concatenates the rows of `left` followed by `right`, deduplicating the whole
-/// combined row — first occurrence kept — unless `all` (`UNION ALL`, every row
-/// kept).
+/// Combines the rows of `left` and `right` by the set operation `kind`,
+/// deduplicating the whole row unless `all`.
 ///
 /// Each side runs through the same `catalog`, `routines`, and `bindings`, so a
-/// bound parameter threads into every arm alike. A side may itself be a `union`,
-/// and it executes with its OWN semantics first — a `UNION` nested under a
-/// `UNION ALL` dedups its pair before the outer node appends `right`. A `Record`
-/// is `Hashable`, so `UNION`'s dedup keys on the materialised row.
+/// bound parameter threads into every arm alike. A side may itself be a
+/// `setop`, and it executes with its OWN semantics first — a nested operation
+/// resolves before the outer node combines its result. A `Record` is `Hashable`
+/// and keys on its `canonical` values (so `1` and `1.0` are one row), the SAME
+/// whole-row equality `UNION`'s dedup uses.
+///
+///   - `.union`: the rows of either side, `left` followed by `right`. Without
+///     `all` the whole-row duplicates are removed (first occurrence kept);
+///     with `all` (`UNION ALL`) every row is kept.
+///   - `.intersect`: the rows present in BOTH sides, in left order. Without
+///     `all` each common row appears once; with `all` (`INTERSECT ALL`) it
+///     appears the LESSER of its two multiplicities.
+///   - `.except`: the rows of `left` NOT balanced by `right`, in left order.
+///     Without `all` each left row absent from `right` appears once; with
+///     `all` (`EXCEPT ALL`) each left row appears its left count less its right
+///     count, floored at zero.
 extension Catalog where Self: ~Escapable {
-  fileprivate borrowing func union(_ left: Plan, _ right: Plan, _ all: Bool,
+  fileprivate borrowing func setop(_ kind: SetOperation, _ left: Plan,
+                                   _ right: Plan, _ all: Bool,
                                    _ context: Context)
       throws(SQLError) -> Array<Record> {
-    let rows = try execute(left, context) + execute(right, context)
-    return all ? rows : deduplicated(rows)
+    let rows = try execute(left, context)
+    switch kind {
+    case .union:
+      let combined = try rows + execute(right, context)
+      return all ? combined : deduplicated(combined)
+    case .intersect:
+      return try intersected(rows, execute(right, context), all)
+    case .except:
+      return try subtracted(rows, execute(right, context), all)
+    }
   }
+}
+
+/// A multiset of records keyed on their `canonical` cell values — the same
+/// exact, transitive whole-row equality `UNION`'s dedup uses (so `1` and `1.0`
+/// are one key), counting each distinct row's occurrences.
+///
+/// It backs the `INTERSECT`/`EXCEPT` multiplicity rules: `right`'s rows are
+/// tallied into one, and a left row is admitted while its remaining count in
+/// the map governs it. `Value` is `Hashable`, so the canonical cell array keys
+/// directly.
+private struct Multiset {
+  private var counts = Dictionary<Array<Value>, Int>()
+
+  /// Tallies each of `records` under its canonical key.
+  internal init(_ records: Array<Record>) {
+    for record in records {
+      counts[record.values.map(canonical), default: 0] += 1
+    }
+  }
+
+  /// Whether the multiset still holds an occurrence of `record`'s row.
+  internal func contains(_ record: Record) -> Bool {
+    (counts[record.values.map(canonical)] ?? 0) > 0
+  }
+
+  /// Removes one occurrence of `record`'s row, reporting whether one was
+  /// present to remove — the `EXCEPT ALL` "cancel a left row against a right"
+  /// step.
+  internal mutating func remove(_ record: Record) -> Bool {
+    let key = record.values.map(canonical)
+    guard let count = counts[key], count > 0 else { return false }
+    counts[key] = count - 1
+    return true
+  }
+}
+
+/// The rows present in both `left` and `right` — `INTERSECT`.
+///
+/// Without `all` each row common to both sides appears once, in left order
+/// (the first occurrence kept); with `all` it appears the LESSER of its left
+/// and right multiplicities. `right` is tallied into a `Multiset`; a left row
+/// is emitted while an occurrence remains to balance it, so the `all` count is
+/// naturally capped at the right side's — and, absent `all`, an emitted row is
+/// recorded in a `Seen` set so later duplicates in `left` are dropped.
+private func intersected(_ left: Array<Record>, _ right: Array<Record>,
+                         _ all: Bool) -> Array<Record> {
+  var remaining = Multiset(right)
+  var rows = Array<Record>()
+  var seen = Seen()
+  for record in left {
+    if all {
+      if remaining.remove(record) { rows.append(record) }
+    } else if remaining.contains(record) && seen.insert(record.values) {
+      rows.append(record)
+    }
+  }
+  return rows
+}
+
+/// The rows of `left` not balanced by `right` — `EXCEPT`.
+///
+/// Without `all` each `left` row with NO match in `right` appears once, in
+/// left order (the first occurrence kept); with `all` each `left` row appears
+/// its left count less its right count, floored at zero. `right` is tallied
+/// into a `Multiset`: for `all` each left row cancels one right occurrence and
+/// is emitted only once the right's copies are exhausted; absent `all` a left
+/// row is emitted when `right` holds none of it, deduplicated through a `Seen`
+/// set.
+private func subtracted(_ left: Array<Record>, _ right: Array<Record>,
+                        _ all: Bool) -> Array<Record> {
+  var remaining = Multiset(right)
+  var rows = Array<Record>()
+  var seen = Seen()
+  for record in left {
+    if all {
+      if !remaining.remove(record) { rows.append(record) }
+    } else if !remaining.contains(record) && seen.insert(record.values) {
+      rows.append(record)
+    }
+  }
+  return rows
 }
 
 /// The rows of `records` with whole-row duplicates removed — the first

--- a/Sources/SQL/OutputColumn.swift
+++ b/Sources/SQL/OutputColumn.swift
@@ -289,8 +289,9 @@ extension Catalog where Self: ~Escapable {
   /// `HAVING` of EVERY arm — throwing the run-time fault a bad operand would.
   ///
   /// The result schema types only the FIRST arm's projection (the ISO rule), so
-  /// a later `UNION` arm's or a `HAVING`'s operand-type error would otherwise
-  /// go unadvertised — `SELECT Age FROM t UNION SELECT Name + 1 FROM t` or `…
+  /// a later set-operation arm's or a `HAVING`'s operand-type error would
+  /// otherwise go unadvertised — `SELECT Age FROM t UNION SELECT Name + 1 FROM
+  /// t` or `…
   /// HAVING SUM(Name) > 0` resolves its names but `Arithmetic.apply`/
   /// `Aggregate.fold` faults `SQLError.operand` at run. `compile` cannot catch
   /// this (no evaluating term is built), so a schema path type-checks each arm
@@ -301,9 +302,9 @@ extension Catalog where Self: ~Escapable {
     switch query {
     case let .select(select):
       try typecheck(select, context, visited: visited)
-    case let .union(left, select, _):
+    case let .setop(_, left, right, _):
       try typecheck(left, context, visited: visited)
-      try typecheck(select, context, visited: visited)
+      try typecheck(right, context, visited: visited)
     }
   }
 

--- a/Sources/SQL/Parser.swift
+++ b/Sources/SQL/Parser.swift
@@ -18,7 +18,8 @@
 /// with           := WITH [RECURSIVE] cte (',' cte)* query
 /// cte            := identifier ['(' identifier (',' identifier)* ')']
 ///                   AS '(' query ')'
-/// query          := select (UNION [ALL] select)*
+/// query          := intersection ((UNION | EXCEPT) [ALL] intersection)*
+/// intersection   := select (INTERSECT [ALL] select)*
 /// select         := SELECT [DISTINCT | ALL] projection
 ///                   [FROM relation (join)*
 ///                    [where] [group] [having] [order] [limit]]
@@ -180,17 +181,41 @@ internal struct Parser: ~Escapable {
     return columns
   }
 
-  /// Parses `select (UNION [ALL] select)*`, left-associative.
+  /// Parses `intersection ((UNION | EXCEPT) [ALL] intersection)*`, the outer
+  /// set-operation tier, left-associative.
   ///
-  /// The leading `SELECT` is the seed `Query`; each `UNION` (optionally `ALL`)
-  /// folds the next `SELECT` onto the right, so `a UNION b UNION c` reads in
-  /// source order. `UNION ALL` keeps duplicate rows; a bare `UNION` removes
-  /// them — the distinction the engine honours.
+  /// The leading `intersection` is the seed `Query`; each `UNION`/`EXCEPT`
+  /// (optionally `ALL`) folds the next `intersection` onto the right, so a
+  /// same-precedence chain (`a UNION b EXCEPT c`) reads left to right.
+  /// `INTERSECT` binds TIGHTER — it lives in the inner `intersection` tier — so
+  /// `a UNION b INTERSECT c` parses as `a UNION (b INTERSECT c)`, the ISO
+  /// precedence. `ALL` keeps duplicate rows per the operator's multiplicity; a
+  /// bare operator removes them — the distinction the engine honours.
   private mutating func query() throws(SQLError) -> Query {
-    var query = try Query.select(select())
-    while try match(.union) {
+    var query = try intersection()
+    while let kind: SetOperation = if try match(.union) { .union }
+                                   else if try match(.except) { .except }
+                                   else { nil } {
       let all = try match(.all)
-      query = try .union(query, select(), all: all)
+      query = try .setop(kind, query, intersection(), all: all)
+    }
+    return query
+  }
+
+  /// Parses `select (INTERSECT [ALL] select)*`, the inner set-operation tier,
+  /// left-associative.
+  ///
+  /// The leading `SELECT` is the seed `Query`; each `INTERSECT` (optionally
+  /// `ALL`) folds the next `SELECT` onto the right. `INTERSECT` binds tighter
+  /// than `UNION`/`EXCEPT`, so this tier is fully consumed before the outer
+  /// `query` tier folds a `UNION`/`EXCEPT` around it. `INTERSECT ALL` keeps
+  /// duplicate rows to the lesser multiplicity; a bare `INTERSECT` removes
+  /// them.
+  private mutating func intersection() throws(SQLError) -> Query {
+    var query = try Query.select(select())
+    while try match(.intersect) {
+      let all = try match(.all)
+      query = try .setop(.intersect, query, .select(select()), all: all)
     }
     return query
   }

--- a/Sources/SQL/SQL.swift
+++ b/Sources/SQL/SQL.swift
@@ -11,7 +11,7 @@ extension Statement {
   /// [WITH [RECURSIVE] cte (, cte)*]
   /// SELECT <* | column (, column)*> FROM <table>
   ///   [WHERE <predicate>] [ORDER BY <column> [ASC|DESC]]
-  ///   (UNION [ALL] SELECT …)*
+  ///   ((UNION | INTERSECT | EXCEPT) [ALL] SELECT …)*
   /// ```
   ///
   /// The resulting AST is generic: it names a relation and its columns as

--- a/Sources/SQL/Token.swift
+++ b/Sources/SQL/Token.swift
@@ -51,6 +51,8 @@ extension Token {
     case null
     case `in`
     case union
+    case intersect
+    case except
     case all
     case with
     case recursive
@@ -134,6 +136,8 @@ extension Token.Kind {
     case .null: "NULL"
     case .in: "IN"
     case .union: "UNION"
+    case .intersect: "INTERSECT"
+    case .except: "EXCEPT"
     case .all: "ALL"
     case .with: "WITH"
     case .recursive: "RECURSIVE"

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -1378,7 +1378,7 @@ private func outers(_ plan: Plan) -> Bool {
     outers(left) || outers(right)
   case let .join(source, _, _, _, _, _, _):
     outers(source)
-  case let .union(left, right, _):
+  case let .setop(_, left, right, _):
     outers(left) || outers(right)
   case let .aggregate(_, _, source):
     outers(source)
@@ -1589,7 +1589,7 @@ private func derived(_ plan: Plan) -> Plan? {
     derived(left) ?? derived(right)
   case let .outer(left, right, _, _):
     derived(left) ?? derived(right)
-  case let .union(left, right, _):
+  case let .setop(_, left, right, _):
     derived(left) ?? derived(right)
   case let .limit(_, _, source):
     derived(source)
@@ -1623,7 +1623,7 @@ private func seeks(_ plan: Plan) -> Bool {
     seeks(outer)
   case let .outer(left, right, _, _):
     seeks(left) || seeks(right)
-  case let .union(left, right, _):
+  case let .setop(_, left, right, _):
     seeks(left) || seeks(right)
   case let .limit(_, _, source):
     seeks(source)
@@ -1654,7 +1654,7 @@ private func filters(_ plan: Plan) -> Bool {
     filters(left) || filters(right)
   case let .outer(left, right, _, _):
     filters(left) || filters(right)
-  case let .union(left, right, _):
+  case let .setop(_, left, right, _):
     filters(left) || filters(right)
   case let .limit(_, _, source):
     filters(source)
@@ -1689,7 +1689,7 @@ private func pushed(_ plan: Plan) -> Bool {
     pushed(source)
   case let .derived(_, sub, _, _):
     pushed(sub)
-  case let .union(left, right, _):
+  case let .setop(_, left, right, _):
     pushed(left) || pushed(right)
   case let .limit(_, _, source):
     pushed(source)
@@ -1743,7 +1743,7 @@ private func joins(_ plan: Plan) -> Bool {
     joins(left) || joins(right)
   case let .outer(left, right, _, _):
     joins(left) || joins(right)
-  case let .union(left, right, _):
+  case let .setop(_, left, right, _):
     joins(left) || joins(right)
   case let .aggregate(_, _, source):
     joins(source)
@@ -1777,7 +1777,7 @@ private func residual(_ plan: Plan) -> Bool {
     residual(outer)
   case let .outer(left, right, _, _):
     residual(left) || residual(right)
-  case let .union(left, right, _):
+  case let .setop(_, left, right, _):
     residual(left) || residual(right)
   case let .aggregate(_, _, source):
     residual(source)
@@ -1812,7 +1812,7 @@ private func separated(_ plan: Plan) -> Bool {
     separated(outer)
   case let .outer(left, right, _, _):
     separated(left) || separated(right)
-  case let .union(left, right, _):
+  case let .setop(_, left, right, _):
     separated(left) || separated(right)
   case let .aggregate(_, _, source):
     separated(source)
@@ -1848,7 +1848,7 @@ private func stacked(_ plan: Plan) -> Bool {
     stacked(outer)
   case let .outer(left, right, _, _):
     stacked(left) || stacked(right)
-  case let .union(left, right, _):
+  case let .setop(_, left, right, _):
     stacked(left) || stacked(right)
   case let .aggregate(_, _, source):
     stacked(source)
@@ -1942,7 +1942,7 @@ private func spanned() throws -> Memory {
 /// arm's body, the per-arm rebase this fix enables.
 private func injected(_ plan: Plan) -> Bool {
   switch plan {
-  case let .union(left, right, _):
+  case let .setop(_, left, right, _):
     (seeks(left) || floats(left)) && (seeks(right) || floats(right))
   case let .select(_, source):
     injected(source)
@@ -3418,6 +3418,120 @@ struct EngineUnionTests {
       [.text("Ann")],
       [.text("Amy")],
     ])
+  }
+}
+
+// MARK: - INTERSECT / EXCEPT tests
+
+/// A two-relation catalog for `INTERSECT`/`EXCEPT` multiplicity: `A` and `B`
+/// each hold a single integer `N`, with duplicates chosen so the operators'
+/// `ALL` counts differ from their distinct forms. `A` holds `1` twice, `2`
+/// thrice, `3` once and `4` once; `B` holds `2` twice, `3` once, `5` once. Thus
+/// `2` and `3` are common (with differing multiplicities), `1`/`4` are A-only,
+/// and `5` is B-only — enough to exercise `min` (INTERSECT ALL) and the floored
+/// difference (EXCEPT ALL).
+private func multiset() -> Memory {
+  let fields = [Field(name: "N", type: .integer)]
+  let a = [1, 1, 2, 2, 2, 3, 4].map { [Value.integer($0)] }
+  let b = [2, 2, 3, 5].map { [Value.integer($0)] }
+  return Memory([
+    "A": FixtureRelation(fields, a),
+    "B": FixtureRelation(fields, b),
+  ])
+}
+
+struct EngineIntersectExceptTests {
+  @Test func `INTERSECT keeps the distinct rows present in both arms`() throws {
+    // `2` and `3` occur in both A and B; the distinct INTERSECT keeps each
+    // once, in A's (left) order, and drops A-only `1`/`4` and B-only `5`.
+    let rows = try multiset().run(parse("""
+        SELECT N FROM A INTERSECT SELECT N FROM B
+        """))
+    #expect(rows == [[.integer(2)], [.integer(3)]])
+  }
+
+  @Test func `INTERSECT ALL keeps each common row to the lesser multiplicity`() throws {
+    // A holds `2` thrice and B twice, so INTERSECT ALL keeps `min(3, 2)` = two;
+    // `3` is once in each, so one — every occurrence in A's order.
+    let rows = try multiset().run(parse("""
+        SELECT N FROM A INTERSECT ALL SELECT N FROM B
+        """))
+    #expect(rows == [[.integer(2)], [.integer(2)], [.integer(3)]])
+  }
+
+  @Test func `EXCEPT keeps the distinct left rows absent from the right`() throws {
+    // A's distinct rows not in B are `1` and `4`; `2`/`3` are removed (present
+    // in B), first occurrence order preserved.
+    let rows = try multiset().run(parse("""
+        SELECT N FROM A EXCEPT SELECT N FROM B
+        """))
+    #expect(rows == [[.integer(1)], [.integer(4)]])
+  }
+
+  @Test func `EXCEPT ALL removes one left row per matching right row`() throws {
+    // A: 1,1,2,2,2,3,4. B removes one `2` per its two copies (leaving one `2`)
+    // and its one `3` (leaving none); `1` (twice) and `4` are untouched — every
+    // survivor in A's order.
+    let rows = try multiset().run(parse("""
+        SELECT N FROM A EXCEPT ALL SELECT N FROM B
+        """))
+    #expect(rows == [
+      [.integer(1)],
+      [.integer(1)],
+      [.integer(2)],
+      [.integer(4)],
+    ])
+  }
+
+  @Test func `INTERSECT binds tighter than UNION`() throws {
+    // `A UNION B INTERSECT C` is `A UNION (B INTERSECT C)` per ISO precedence.
+    // Here the reused `tags()` relations give `B INTERSECT C` = `Rhs INTERSECT
+    // Extra`: Rhs is {shared, b}, Extra is {a}, so the intersection is empty
+    // and the whole result is just Lhs's distinct rows.
+    let rows = try tags().run(parse("""
+        SELECT Tag FROM Lhs
+          UNION SELECT Tag FROM Rhs
+          INTERSECT SELECT Tag FROM Extra
+        """))
+    #expect(rows == [[.text("a")], [.text("shared")]])
+  }
+
+  @Test func `UNION and EXCEPT are same precedence, left-associative`() throws {
+    // `A UNION B EXCEPT C` binds as `(A UNION B) EXCEPT C`. Lhs UNION Rhs is
+    // {a, shared, b}; EXCEPT Extra ({a}) removes `a`, leaving {shared, b}. A
+    // right-associative reading — `A UNION (B EXCEPT C)` — would instead keep
+    // `a` (from Lhs), so the result proves the left grouping.
+    let rows = try tags().run(parse("""
+        SELECT Tag FROM Lhs
+          UNION SELECT Tag FROM Rhs
+          EXCEPT SELECT Tag FROM Extra
+        """))
+    #expect(rows == [[.text("shared")], [.text("b")]])
+  }
+
+  @Test func `INTERSECT of arms projecting differing column counts is rejected`() throws {
+    #expect(throws: SQLError.arity(1, 2)) {
+      try people().run(parse("""
+          SELECT Id FROM People INTERSECT SELECT Id, Name FROM People
+          """))
+    }
+  }
+
+  @Test func `EXCEPT of arms projecting differing column counts is rejected`() throws {
+    #expect(throws: SQLError.arity(2, 1)) {
+      try people().run(parse("""
+          SELECT Id, Name FROM People EXCEPT SELECT Id FROM People
+          """))
+    }
+  }
+
+  @Test func `a view defined as an EXCEPT resolves and queries`() throws {
+    let diff = try View(query: select("""
+        SELECT N FROM A EXCEPT SELECT N FROM B
+        """), columns: ["N"])
+    let catalog = Memory(multiset().catalog, views: ["Diff": diff])
+    let rows = try catalog.run(parse("SELECT N FROM Diff"))
+    #expect(rows == [[.integer(1)], [.integer(4)]])
   }
 }
 

--- a/Tests/SQLTests/ParserTests.swift
+++ b/Tests/SQLTests/ParserTests.swift
@@ -951,14 +951,15 @@ struct UnionTests {
     let query = try parse(query: "SELECT a FROM t UNION SELECT b FROM u")
     let left = Select(projection: .columns(["a"]), from: Relation(name: "t"))
     let right = Select(projection: .columns(["b"]), from: Relation(name: "u"))
-    #expect(query == .union(.select(left), right, all: false))
+    #expect(query == .setop(.union, .select(left), .select(right),
+                            all: false))
   }
 
   @Test func `parses UNION ALL into a duplicate-keeping union`() throws {
     let query = try parse(query: "SELECT a FROM t UNION ALL SELECT b FROM u")
     let left = Select(projection: .columns(["a"]), from: Relation(name: "t"))
     let right = Select(projection: .columns(["b"]), from: Relation(name: "u"))
-    #expect(query == .union(.select(left), right, all: true))
+    #expect(query == .setop(.union, .select(left), .select(right), all: true))
   }
 
   @Test func `nests a chain of UNIONs left-associatively in source order`() throws {
@@ -967,14 +968,16 @@ struct UnionTests {
     let a = Select(projection: .columns(["a"]), from: Relation(name: "t"))
     let b = Select(projection: .columns(["b"]), from: Relation(name: "u"))
     let c = Select(projection: .columns(["c"]), from: Relation(name: "v"))
-    #expect(query == .union(.union(.select(a), b, all: false), c, all: true))
+    #expect(query == .setop(.union,
+                            .setop(.union, .select(a), .select(b), all: false),
+                            .select(c), all: true))
   }
 
   @Test func `recognises lowercase union and all keywords`() throws {
     let query = try parse(query: "select a from t union all select b from u")
     let left = Select(projection: .columns(["a"]), from: Relation(name: "t"))
     let right = Select(projection: .columns(["b"]), from: Relation(name: "u"))
-    #expect(query == .union(.select(left), right, all: true))
+    #expect(query == .setop(.union, .select(left), .select(right), all: true))
   }
 
   @Test func `a CREATE VIEW over a UNION stores the query and the first arm's names`() throws {
@@ -986,7 +989,56 @@ struct UnionTests {
                        from: Relation(name: "u"))
     #expect(name == "v")
     #expect(view.columns == ["a", "b"])
-    #expect(view.query == .union(.select(left), right, all: false))
+    #expect(view.query == .setop(.union, .select(left), .select(right),
+                                 all: false))
+  }
+
+  @Test func `parses INTERSECT into a set operation of two selects`() throws {
+    let query = try parse(query: "SELECT a FROM t INTERSECT SELECT b FROM u")
+    let left = Select(projection: .columns(["a"]), from: Relation(name: "t"))
+    let right = Select(projection: .columns(["b"]), from: Relation(name: "u"))
+    #expect(query == .setop(.intersect, .select(left), .select(right),
+                            all: false))
+  }
+
+  @Test func `parses EXCEPT ALL into a duplicate-keeping set operation`() throws {
+    let query = try parse(query: "SELECT a FROM t EXCEPT ALL SELECT b FROM u")
+    let left = Select(projection: .columns(["a"]), from: Relation(name: "t"))
+    let right = Select(projection: .columns(["b"]), from: Relation(name: "u"))
+    #expect(query == .setop(.except, .select(left), .select(right), all: true))
+  }
+
+  @Test func `INTERSECT binds tighter than UNION, nesting on the right`() throws {
+    // `a UNION b INTERSECT c` is `a UNION (b INTERSECT c)` — ISO precedence.
+    let query = try parse(query:
+        "SELECT a FROM t UNION SELECT b FROM u INTERSECT SELECT c FROM v")
+    let a = Select(projection: .columns(["a"]), from: Relation(name: "t"))
+    let b = Select(projection: .columns(["b"]), from: Relation(name: "u"))
+    let c = Select(projection: .columns(["c"]), from: Relation(name: "v"))
+    #expect(query == .setop(.union, .select(a),
+                            .setop(.intersect, .select(b), .select(c),
+                                   all: false),
+                            all: false))
+  }
+
+  @Test func `UNION and EXCEPT associate left at the same precedence`() throws {
+    // `a UNION b EXCEPT c` is `(a UNION b) EXCEPT c`.
+    let query = try parse(query:
+        "SELECT a FROM t UNION SELECT b FROM u EXCEPT SELECT c FROM v")
+    let a = Select(projection: .columns(["a"]), from: Relation(name: "t"))
+    let b = Select(projection: .columns(["b"]), from: Relation(name: "u"))
+    let c = Select(projection: .columns(["c"]), from: Relation(name: "v"))
+    #expect(query == .setop(.except,
+                            .setop(.union, .select(a), .select(b), all: false),
+                            .select(c), all: false))
+  }
+
+  @Test func `recognises lowercase intersect and except keywords`() throws {
+    let query = try parse(query: "select a from t intersect select b from u")
+    let left = Select(projection: .columns(["a"]), from: Relation(name: "t"))
+    let right = Select(projection: .columns(["b"]), from: Relation(name: "u"))
+    #expect(query == .setop(.intersect, .select(left), .select(right),
+                            all: false))
   }
 }
 
@@ -1050,7 +1102,7 @@ struct WithTests {
         """)
     #expect(ctes[0].recursive == true)
     #expect(ctes[0].columns == ["n"])
-    guard case .union = ctes[0].query else {
+    guard case .setop(.union, _, _, _) = ctes[0].query else {
       Issue.record("expected the recursive CTE's query to be a UNION")
       return
     }
@@ -1062,7 +1114,8 @@ struct WithTests {
         """)
     let left = Select(projection: .columns(["x"]), from: Relation(name: "t"))
     let right = Select(projection: .columns(["y"]), from: Relation(name: "u"))
-    #expect(ctes[0].query == .union(.select(left), right, all: false))
+    #expect(ctes[0].query == .setop(.union, .select(left), .select(right),
+                                    all: false))
   }
 
   @Test func `recognises lowercase with and recursive keywords`() throws {


### PR DESCRIPTION
Extend the SQL dialect with the two remaining ISO set operators alongside UNION. `a INTERSECT b` yields the rows present in both arms, `a EXCEPT b` the rows of the left not in the right; the distinct forms deduplicate and the `ALL` forms keep multiplicity (INTERSECT ALL to the lesser count, EXCEPT ALL the left count less the right, floored at zero).

The grammar honours the ISO precedence through a two-tier set-operation structure: INTERSECT binds tighter than UNION/EXCEPT (an inner `intersection` tier of `select (INTERSECT [ALL] select)*`), while UNION and EXCEPT are same precedence and left-associative (the outer `query` tier), so `a UNION b INTERSECT c` parses as `a UNION (b INTERSECT c)`.

The `Query.union(Query, Select, all:)` AST node generalises to `Query.setop(SetOperation, Query, Query, all:)` — a right arm that is now a query term, so the tiers can nest — and the `Plan.union` node likewise to `Plan.setop`. The executor reuses the whole-row `canonical` equality UNION's dedup keys on: UNION concatenates, INTERSECT/EXCEPT tally the right arm into a canonical-keyed multiset and admit left rows by the remaining count. Recursive CTEs still gate on a top-level `.setop(.union, ...)` (the only set operator ISO admits in a recursive body), the arity check and every AST/Plan walk carry through, and a WHERE conjunct still pushes into a set-operation view's arms (valid for all three operators).