### PR TITLE
winmd-inspect: render WinRT generic interfaces ABI-erased

### DIFF
--- a/Sources/WinMD/Signature.swift
+++ b/Sources/WinMD/Signature.swift
@@ -549,3 +549,30 @@ extension Row where Schema == Metadata.Tables.PropertyDef {
     }
   }
 }
+
+// MARK: - TypeSpec generic base
+
+/// The `TypeDefOrRef` coded-index token naming the GENERIC BASE a `TypeSpec`
+/// GENERICINST signature instantiates — the row-linkable value the raw `bytes`
+/// of a `TypeSpec.Signature` `#Blob` carry — or `nil` when the signature is not
+/// a generic instantiation (its base is not a named type).
+///
+/// This is the escapable, value → value form the SQL adapter's `GENERICBASE`
+/// scalar function reads: a caller that has copied a `TypeSpec.Signature` blob
+/// out of the borrowed scan decodes it here, returning the base's `rawValue` so
+/// SQL can split its tag/row and join to the base `TypeRef`/`TypeDef` by `Id`.
+/// A WinRT generic interface inheriting another (`IVector`1 : IIterable`1`)
+/// records the base through a `TypeSpec`, so its `bases` row is otherwise
+/// empty; this recovers the base name.
+///
+/// A `TypeSpec` whose signature is not a `GENERICINST` over a named base — a
+/// bare array/pointer spec, or a malformed blob — yields `nil` rather than
+/// throwing, so the SQL join simply produces no base row for it.
+public func base(decoding bytes: Array<UInt8>) -> TypeDefOrRef? {
+  var decoder = SignatureDecoder(bytes.span.bytes)
+  guard let type = try? decoder.type(),
+      case let .instance(.named(_, reference), _) = type else {
+    return nil
+  }
+  return reference
+}

--- a/Sources/WinMD/Storage.swift
+++ b/Sources/WinMD/Storage.swift
@@ -105,6 +105,25 @@ package struct Storage: ~Escapable {
     return tuple
   }
 
+  /// The registered CIL table schema whose name matches `name`
+  /// case-insensitively, whether or not the database has rows for it — the
+  /// full ECMA-335 §II.22 table set, not just the present `tables`.
+  ///
+  /// A file omits a table with no rows (its `Valid` bit is clear), so a query
+  /// naming an optional-metadata relation would otherwise find no table. This
+  /// resolves the SCHEMA by name so the SQL adapter can surface an absent one
+  /// as an empty relation (`Table.empty(_:)`), a query referencing it thus
+  /// resolving to zero rows rather than an unknown relation. `nil` when no
+  /// registered schema bears the name. It is `package` so the adapter reaches
+  /// it across the module boundary.
+  package static func schema(named name: String) -> TableSchema.Type? {
+    for schema in kRegisteredTables
+        where "\(schema)".caseInsensitiveCompare(name) == .orderedSame {
+      return schema
+    }
+    return nil
+  }
+
   /// The rows of `schema` whose foreign-key `column` references `target`.
   ///
   /// The runtime (non-generic) sibling of `Database.referencing`: it opens the

--- a/Sources/WinMD/Table.swift
+++ b/Sources/WinMD/Table.swift
@@ -90,6 +90,21 @@ public struct Table: Sendable {
     self.range = range
   }
 
+  /// An empty (zero-row) open table for `schema` — the form a schema-defined
+  /// but ABSENT table takes.
+  ///
+  /// A metadata file sets a table's `Valid` bit only when the table has rows,
+  /// so a file with no rows for a table omits it entirely (ECMA-335
+  /// §II.24.2.6). A query may still reference such a table — an
+  /// optional-metadata relation a view joins in one arm — so the SQL adapter
+  /// surfaces it as this empty relation rather than an unknown one: its
+  /// `schema` types and names its columns as usual, and its zero `rows` yield
+  /// no records (the `wide`/`stride` record layout is immaterial with no
+  /// records, so both are the narrow zero).
+  package static func empty(_ schema: TableSchema.Type) -> Table {
+    Table(schema, rows: 0, range: 0 ..< 0, wide: 0, stride: 0)
+  }
+
   /// The byte offset of column `i` within a record.
   ///
   /// Each wide index before column `i` shifts it by two bytes beyond its narrow

--- a/Sources/WinMDSynthesis/Decode.swift
+++ b/Sources/WinMDSynthesis/Decode.swift
@@ -35,6 +35,14 @@ public struct Dialect: Sendable {
   /// The `VAR`/`MVAR` generic-parameter scope prefixes (`T`/`M`).
   public let variable: (type: String, method: String)
 
+  /// The associated-ABI-type projection an unbound generic slot crosses the ABI
+  /// through — the member spelling appended to a `VAR`'s declared name so the
+  /// slot reads `Element.ABI` (the `.ABI` suffix), the windows-rs `Type::Abi`
+  /// mechanism. It is size-correct for BOTH a value and a reference argument,
+  /// unlike a fixed-size raw-pointer erasure, so an unbound type variable
+  /// projects through it rather than collapsing to `opaque`.
+  public let projection: String
+
   /// The spelling an unresolvable named type (and a function pointer) degrades
   /// to (`UnsafeMutableRawPointer`).
   public let opaque: String
@@ -59,6 +67,7 @@ public struct Dialect: Sendable {
               optional: String,
               generic: (open: String, close: String),
               variable: (type: String, method: String),
+              projection: String,
               opaque: String,
               guid: (iid: String, clsid: String),
               known: Dictionary<Identity, String>,
@@ -68,6 +77,7 @@ public struct Dialect: Sendable {
     self.optional = optional
     self.generic = generic
     self.variable = variable
+    self.projection = projection
     self.opaque = opaque
     self.guid = guid
     self.known = known
@@ -194,28 +204,85 @@ extension SignatureType {
   /// A modifier is transparent, and so is indirection: a BYREF, pointer, array,
   /// or matrix classifies as its (recursively unwrapped) ELEMENT, so a byref or
   /// array of a class reference is itself a reference (its element erases),
-  /// while a pointer or array of a value stays a value. A `VAR`/`MVAR` generic
-  /// variable stands for an as-yet-unknown argument and is conservatively a
-  /// value (its erased spelling falls through to `decode`).
+  /// while a pointer or array of a value stays a value.
+  ///
+  /// A `VAR`/`MVAR` generic type variable is ARGUMENT-DEPENDENT. WinRT erases a
+  /// generic parameter's ABI by its concrete argument's kind — `IVector<Int32>`
+  /// carries an `Int32` value (4 bytes), `IVector<IFoo>` an interface pointer
+  /// (8 bytes) — so a type variable cannot be classified in isolation. When the
+  /// binding `arguments` of the enclosing instantiation are supplied and a
+  /// type-level `VAR`'s operand indexes them, the variable classifies as its
+  /// BOUND argument (a value argument keeps its value ABI, a reference argument
+  /// erases). Absent a binding — the generic DEFINITION render, whose wrapper
+  /// is itself Swift-generic over the unknown parameter — the variable is a
+  /// reference for a fixed classification; `abi(…)` PROJECTS such an unbound
+  /// type-level slot through its element's associated ABI type
+  /// (`Element.ABI`, size-correct for a value AND a reference argument) rather
+  /// than collapsing it to the opaque pointer, and `projects` reports it so the
+  /// wrapper forwards through `ABIProjectable` rather than a fixed-size cast. A
+  /// method-level `MVAR` is never substituted (only type-level bindings thread
+  /// here) and so stays a reference.
   ///
   /// This is the classification half of the ABI-erasure keystone; `abi(…)`
   /// produces the matching erased spelling.
-  public var classification: ABI {
+  public func classification(substituting arguments: Array<SignatureType>?
+                               = nil) -> ABI {
     switch self {
     case .named(kind: .class, _), .primitive(.object):
       .reference
     case .named(kind: .value, _), .primitive, .function:
       .value
-    case .variable:
-      .value
-    case let .instance(base, _):
-      base.classification
+    case let .variable(scope, index):
+      // A bound type-level variable classifies as its concrete argument; an
+      // unbound one (the definition render) or a method-level `MVAR` erases.
+      if case .type = scope, let arguments, arguments.indices.contains(index) {
+        arguments[index].classification()
+      } else {
+        .reference
+      }
+    case let .instance(base, arguments):
+      // A GENERICINST's own kind follows its base, and its arguments become the
+      // bindings a variable in the base's slots substitutes against.
+      base.classification(substituting: arguments)
     case let .modified(inner, _),
          let .pointer(inner),
          let .reference(inner),
          let .array(inner),
          let .matrix(inner, _):
-      inner.classification
+      inner.classification(substituting: arguments)
+    }
+  }
+
+  /// The ABI classification of `self` with no binding — the generic-definition
+  /// spelling, where a type variable erases as a reference. Argument-dependent
+  /// callers use `classification(substituting:)`.
+  public var classification: ABI {
+    classification()
+  }
+
+  /// Whether `self` is an unbound generic slot that crosses the ABI through its
+  /// element's ASSOCIATED ABI type (`Element.ABI`) rather than a fixed erasure
+  /// — an unbound type-level `VAR` (recursively, under indirection or a
+  /// modifier). The generic-definition wrapper projects such a slot through the
+  /// `ABIProjectable` conformance (`toABI()`/`fromABI(_:)`), not a fixed-size
+  /// `unsafeBitCast`, so it is size-correct for a value AND a reference
+  /// instantiation. A concrete reference (a `CLASS` named type) is NOT
+  /// projected — its erased pointer is a pointer either way, so its cast is
+  /// size-safe — and a value is not projected either. A bound variable (the
+  /// specialisation path) resolves to its concrete argument, so it never
+  /// projects.
+  public var projects: Bool {
+    switch self {
+    case let .variable(scope, _):
+      if case .type = scope { true } else { false }
+    case let .modified(inner, _),
+         let .pointer(inner),
+         let .reference(inner),
+         let .array(inner),
+         let .matrix(inner, _):
+      inner.projects
+    case .named, .primitive, .instance, .function:
+      false
     }
   }
 
@@ -256,18 +323,49 @@ extension SignatureType {
   ///   value is unchanged (`pointer(int)` → `UnsafeMutablePointer<CInt>`), its
   ///   erased element being its own `decode(…)`. A `.modified` type is
   ///   transparent to its inner type, exactly as `classification` treats it.
+  /// When the binding `substituting` arguments of the enclosing instantiation
+  /// are supplied, a type-level `VAR` slot erases by its BOUND argument: a
+  /// value argument keeps its own value ABI (`IVector<Int32>.GetAt -> Int32`
+  /// spells `CInt`, no pointer erasure), a reference argument erases to the
+  /// opaque pointer. Absent a binding — the generic DEFINITION render — an
+  /// unbound type-level `VAR` PROJECTS through its declared name's associated
+  /// ABI type (`Element.ABI`, the `projection` suffix), which is `Element`
+  /// itself for a value instantiation and the opaque pointer for a reference
+  /// one, so the slot is size-correct either way and the wrapper projects
+  /// through `ABIProjectable` rather than a fixed-size cast.
   public func abi(parameter: String? = nil, generics: Array<String>? = nil,
+                  substituting arguments: Array<SignatureType>? = nil,
                   with resolver: Resolver, dialect: Dialect) -> String {
     switch self {
     case let .pointer(element), let .reference(element),
          let .array(element), let .matrix(element, _):
-      element.spelling(parameter: parameter, generics: generics, const: false,
-                       erase: true, with: resolver, dialect: dialect)
+      element.spelling(parameter: parameter, generics: generics,
+                       substituting: arguments, const: false, erase: true,
+                       with: resolver, dialect: dialect)
     case let .modified(inner, _):
-      inner.abi(parameter: parameter, generics: generics, with: resolver,
-                dialect: dialect)
-    case .primitive, .named, .instance, .variable, .function:
-      switch classification {
+      inner.abi(parameter: parameter, generics: generics,
+                substituting: arguments, with: resolver, dialect: dialect)
+    case let .variable(scope, index):
+      // A bound type-level variable erases as its concrete argument (a value
+      // keeps its own ABI, a reference erases). An UNBOUND type-level variable
+      // — the generic DEFINITION render — projects through its declared name's
+      // associated ABI type (`Element.ABI`, the windows-rs `Type::Abi`
+      // mechanism): size-correct for a value AND a reference instantiation,
+      // unlike a fixed-size raw-pointer erasure. A method-level `MVAR` (never
+      // substituted here) and an out-of-range operand have no declared name to
+      // project, so they still collapse to the opaque pointer.
+      if case .type = scope, let arguments, arguments.indices.contains(index) {
+        arguments[index].abi(parameter: parameter, with: resolver,
+                             dialect: dialect)
+      } else if case .type = scope, let generics,
+                generics.indices.contains(index) {
+        scope.spelling(index, generics: generics, dialect: dialect)
+            + dialect.projection
+      } else {
+        dialect.opaque
+      }
+    case .primitive, .named, .instance, .function:
+      switch classification(substituting: arguments) {
       case .reference:
         dialect.opaque
       case .value:
@@ -337,6 +435,7 @@ extension SignatureType {
   /// pointer, not the named type. The `void` collapses are already raw ABI
   /// forms, so `erase` leaves them untouched; only the wrapped leaf differs.
   fileprivate func spelling(parameter: String?, generics: Array<String>?,
+                            substituting arguments: Array<SignatureType>? = nil,
                             const: Bool, erase: Bool, with resolver: Resolver,
                             dialect: Dialect) -> String {
     switch self {
@@ -353,16 +452,19 @@ extension SignatureType {
     case .pointer:
       // A non-`void` pointer-to-pointer: the inner pointer slot is itself
       // nullable, so mark the leaf element optional (as the `void**` cases).
-      wrap(leaf(parameter: parameter, generics: generics, erase: erase,
-                with: resolver, dialect: dialect) + dialect.optional,
+      wrap(leaf(parameter: parameter, generics: generics,
+                substituting: arguments, erase: erase, with: resolver,
+                dialect: dialect) + dialect.optional,
            const: const, dialect: dialect)
     case let .modified(inner, modifiers):
       inner.spelling(parameter: parameter, generics: generics,
+                     substituting: arguments,
                      const: modifiers.constant(with: resolver), erase: erase,
                      with: resolver, dialect: dialect)
     default:
-      wrap(leaf(parameter: parameter, generics: generics, erase: erase,
-                with: resolver, dialect: dialect),
+      wrap(leaf(parameter: parameter, generics: generics,
+                substituting: arguments, erase: erase, with: resolver,
+                dialect: dialect),
            const: const, dialect: dialect)
     }
   }
@@ -371,10 +473,14 @@ extension SignatureType {
   /// `abi(…)` when `erase` is set, otherwise its plain `decode(…)`. A wrapped
   /// class reference thus erases to the opaque pointer under `erase`, while a
   /// value is spelled identically either way (its `abi(…)` is its `decode(…)`).
-  private func leaf(parameter: String?, generics: Array<String>?, erase: Bool,
+  /// Under `erase` the binding `arguments` thread on so a wrapped type variable
+  /// erases by its bound argument (a byref of a value-bound `VAR` wraps the
+  /// value ABI, not the opaque pointer).
+  private func leaf(parameter: String?, generics: Array<String>?,
+                    substituting arguments: Array<SignatureType>?, erase: Bool,
                     with resolver: Resolver, dialect: Dialect) -> String {
-    erase ? abi(parameter: parameter, generics: generics, with: resolver,
-                dialect: dialect)
+    erase ? abi(parameter: parameter, generics: generics,
+                substituting: arguments, with: resolver, dialect: dialect)
           : decode(parameter: parameter, generics: generics, with: resolver,
                    dialect: dialect)
   }

--- a/Sources/winmd-inspect/Database+SQL.swift
+++ b/Sources/winmd-inspect/Database+SQL.swift
@@ -54,12 +54,18 @@ internal import WinMD
 // MARK: - Catalog
 
 extension WinMD.Storage: SQLEngine.Catalog {
-  /// The relation named `name`, resolved case-insensitively against the open
-  /// tables' schema names.
+  /// The relation named `name`, resolved case-insensitively against the CIL
+  /// table schema — the present tables first, then, failing that, any
+  /// schema-defined table the database omits, surfaced as an EMPTY relation.
   ///
-  /// A `WinMD.Table`'s description is its schema name (e.g. "TypeDef"); a name
-  /// the database has no table for yields `nil`, which the engine reports as
-  /// `SQLError.relation`.
+  /// A `WinMD.Table`'s description is its schema name (e.g. "TypeDef"). A
+  /// metadata file sets a table's `Valid` bit only when it has rows, so a file
+  /// with no rows for a table omits it — yet a query may still reference it (an
+  /// optional-metadata relation a view joins in one arm, e.g. the `bases`
+  /// view's `TypeSpec` arm over a file with no generic bases). Resolving an
+  /// absent but schema-defined table to a zero-row `Table.empty(_:)` relation
+  /// lets such a query always resolve, its arm simply yielding no rows, rather
+  /// than faulting `SQLError.relation`. A name no CIL schema bears is `nil`.
   @_lifetime(borrow self)
   internal borrowing func table(named name: String) -> WinMDRelation? {
     for index in 0 ..< tables.count {
@@ -68,7 +74,8 @@ extension WinMD.Storage: SQLEngine.Catalog {
         return WinMDRelation(self, tables[index])
       }
     }
-    return nil
+    guard let schema = WinMD.Storage.schema(named: name) else { return nil }
+    return WinMDRelation(self, WinMD.Table.empty(schema))
   }
 
   /// The schema names of every open table — the `INFORMATION_SCHEMA` overlay's
@@ -198,11 +205,19 @@ extension Session {
     //
     // `SIGNATURE` joins it under the same `[.blob] -> .text` contract, decoding
     // a `MethodDef.Signature` `#Blob` to its return type's neutral spelling.
+    // `GENERICBASE` decodes a `TypeSpec.Signature` blob to the coded-index
+    // token of the generic base it instantiates — an `.integer` over one
+    // `.blob`, NULL when the spec is not a generic instantiation — so the
+    // `bases` view can join a `TypeSpec`-recorded base (a generic interface's
+    // generic base) to its `TypeRef`/`TypeDef` by splitting the token's tag and
+    // row.
     try! Routines.standard
         .registering("guid", returns: .text, parameters: [.blob],
                      Session.guid)
         .registering("signature", returns: .text, parameters: [.blob],
                      Session.signature)
+        .registering("genericbase", returns: .integer, parameters: [.blob],
+                     Session.genericbase)
   }
 
   /// `GUID(blob)` — the UUID a `GuidAttribute` `CustomAttribute` value blob
@@ -270,10 +285,37 @@ extension Session {
             optional: "?",
             generic: (open: "<", close: ">"),
             variable: (type: "T", method: "M"),
+            projection: ".ABI",
             opaque: "object",
             guid: (iid: "iid", clsid: "clsid"),
             known: [:],
             escape: { $0 })
+  }
+
+  /// `GENERICBASE(blob)` — the `TypeDefOrRef` coded-index token naming the
+  /// generic base a `TypeSpec.Signature` GENERICINST instantiates, as an
+  /// integer, or `NULL` when the blob is not a generic instantiation over a
+  /// named base.
+  ///
+  /// A pure per-row codec over the raw `TypeSpec.Signature` `#Blob`: the
+  /// `bases` view feeds it the signature of a `TypeSpec`-recorded interface
+  /// base (a WinRT generic interface inheriting another, `IVector`1 :
+  /// IIterable`1`) and splits the returned token — `tag = BITAND(token, 3)`,
+  /// `row = token / 4` — to join the base `TypeRef` (tag 1) or `TypeDef` (tag
+  /// 0) by its `Id`. A NULL argument propagates to NULL; a non-blob argument is
+  /// `SQLError.argument`; a non-generic (or malformed) spec yields NULL, so its
+  /// join produces no base.
+  private static func genericbase(_ arguments: Array<Value>)
+      throws(SQLError) -> Value {
+    guard arguments.count == 1 else {
+      throw .argument("GENERICBASE takes one argument")
+    }
+    if case .null = arguments[0] { return .null }
+    guard case let .blob(bytes) = arguments[0] else {
+      throw .argument("GENERICBASE requires a blob argument")
+    }
+    guard let base = WinMD.base(decoding: bytes) else { return .null }
+    return .integer(base.rawValue)
   }
 }
 
@@ -820,19 +862,17 @@ extension WinMD.Storage {
     return nil
   }
 
-  /// The decoded type spelling of the return of the `MethodDef` at 1-based
-  /// `method` `Id`, in `dialect`, or `nil` when the row or its signature
-  /// does not decode.
+  /// The `SignatureType` of the return of the `MethodDef` at 1-based `method`
+  /// `Id`, paired with a `Resolver` over the storage — or `nil` when the row or
+  /// its signature does not decode.
   ///
-  /// This is the signature-navigation the adapter once baked as the
-  /// `ReturnType` virtual column, relocated so the render can spell a return at
-  /// render time with a target `Dialect`: it opens the `MethodDef` row, decodes
-  /// its `prototype` signature, builds a `Resolver` over the storage, and
-  /// decodes the return. `nil` mirrors the old NULL — an absent row, an
-  /// undecodable signature, or an unresolvable one.
-  internal borrowing func decode(return method: Int,
-                                 generics: Array<String>? = nil,
-                                 in dialect: Dialect) -> String? {
+  /// This is the shared signature-navigation the render's return spellings
+  /// (`decode(return:)` for the typed surface, `abi(return:)` for the erased
+  /// ABI) build on: it opens the `MethodDef` row, decodes its `prototype`
+  /// signature, and builds the `Resolver`. `nil` mirrors the old NULL — an
+  /// absent row, an undecodable signature, or an unresolvable one.
+  private borrowing func returned(_ method: Int)
+      -> (type: SignatureType, resolver: Resolver)? {
     guard let table = opened("MethodDef") else { return nil }
     let cursor = WinMD.Cursor(copy self, table)
     guard let tuple = cursor[method - 1],
@@ -841,27 +881,24 @@ extension WinMD.Storage {
         let resolver = try? Resolver(of: signature, with: self) else {
       return nil
     }
-    return signature.returns.decode(generics: generics, with: resolver,
-                                    dialect: dialect)
+    return (signature.returns, resolver)
   }
 
-  /// The decoded type spelling of the `Param` at 1-based `parameter` `Id`, in
-  /// `dialect`, navigated through its owning method's signature — or `nil` when
-  /// it does not decode.
+  /// The `SignatureType` of the `Param` at 1-based `parameter` `Id`, navigated
+  /// through its owning method's signature, paired with a `Resolver` and the
+  /// parameter's own `Name` (the `System.Guid` `IID`/`CLSID` hint) — or `nil`
+  /// when it does not decode.
   ///
-  /// This is the signature-navigation the adapter once baked as the `ParamType`
-  /// virtual column, relocated so the render can spell a parameter at render
-  /// time. The `Param.Sequence` cell is the 1-based parameter position:
-  /// `Sequence == 0` is the return pseudo-parameter and `Sequence >
+  /// This is the shared signature-navigation the render's parameter spellings
+  /// (`decode(parameter:)` for the typed surface, `abi(parameter:)` for the
+  /// erased ABI) build on. The `Param.Sequence` cell is the 1-based parameter
+  /// position: `Sequence == 0` is the return pseudo-parameter and `Sequence >
   /// parameters.count` is out of range, both `nil`. The owning `MethodDef` is
   /// found through the `Param` list link — an owner of zero is no parent
   /// (malformed/partial metadata), so the parameter is unowned and yields `nil`
-  /// rather than indexing a negative row. The parameter's own `Name` is the
-  /// `System.Guid` `IID`/`CLSID` hint; for any other type the decoder ignores
-  /// it, so threading it is always safe.
-  internal borrowing func decode(parameter: Int,
-                                 generics: Array<String>? = nil,
-                                 for dialect: Dialect) -> String? {
+  /// rather than indexing a negative row.
+  private borrowing func parametered(_ parameter: Int)
+      -> (type: SignatureType, resolver: Resolver, name: String?)? {
     guard let table = opened("Param") else { return nil }
     let params = WinMD.Cursor(copy self, table)
     guard let param = params[parameter - 1],
@@ -885,8 +922,110 @@ extension WinMD.Storage {
       return nil
     }
     let name = param.ordinal(for: "Name").flatMap { try? param.string($0) }
-    return signature.parameters[position - 1]
-        .decode(parameter: name, generics: generics, with: resolver,
-                dialect: dialect)
+    return (signature.parameters[position - 1], resolver, name)
+  }
+
+  /// The typed type spelling of the return of the `MethodDef` at 1-based
+  /// `method` `Id`, in `dialect` — the wrapper's typed surface — or `nil` when
+  /// the row or its signature does not decode.
+  ///
+  /// This is the signature-navigation the adapter once baked as the
+  /// `ReturnType` virtual column, relocated so the render can spell a return at
+  /// render time with a target `Dialect`.
+  internal borrowing func decode(return method: Int,
+                                 generics: Array<String>? = nil,
+                                 in dialect: Dialect) -> String? {
+    returned(method).map {
+      $0.type.decode(generics: generics, with: $0.resolver, dialect: dialect)
+    }
+  }
+
+  /// The ABI type spelling of the return of the `MethodDef` at 1-based `method`
+  /// `Id`, in `dialect` — the ABI protocol's return: a value keeps its own ABI,
+  /// a concrete reference is the opaque interface pointer, and an unbound
+  /// generic slot projects through its element's associated ABI type
+  /// (`Element.ABI`) — or `nil` when the row or its signature does not decode.
+  internal borrowing func abi(return method: Int,
+                              generics: Array<String>? = nil,
+                              in dialect: Dialect) -> String? {
+    returned(method).map {
+      $0.type.abi(generics: generics, with: $0.resolver, dialect: dialect)
+    }
+  }
+
+  /// Whether the return of the `MethodDef` at 1-based `method` `Id` crosses the
+  /// ABI as a concrete erased interface pointer (a reference that is NOT a
+  /// projected generic slot) — so the wrapper casts the erased result back to
+  /// its typed spelling — or `nil` when the row does not decode. A value return
+  /// needs no cast, and a projected generic return forwards through the
+  /// `ABIProjectable` conformance (see `projects(return:)`), not a cast.
+  internal borrowing func reference(return method: Int) -> Bool? {
+    returned(method).map {
+      $0.type.classification == .reference && !$0.type.projects
+    }
+  }
+
+  /// Whether the return of the `MethodDef` at 1-based `method` `Id` is an
+  /// unbound generic slot that crosses the ABI through its element's associated
+  /// ABI type (`Element.ABI`) — so the wrapper reconstructs the typed value
+  /// through the element's `ABIProjectable` conformance (`Element.fromABI(…)`),
+  /// size-correct for a value AND a reference instantiation — or `nil` when the
+  /// row does not decode.
+  internal borrowing func projects(return method: Int) -> Bool? {
+    returned(method).map { $0.type.projects }
+  }
+
+  /// The typed type spelling of the `Param` at 1-based `parameter` `Id`, in
+  /// `dialect`, navigated through its owning method's signature — the wrapper's
+  /// typed surface — or `nil` when it does not decode. The parameter's own
+  /// `Name` is the `System.Guid` `IID`/`CLSID` hint; for any other type the
+  /// decoder ignores it, so threading it is always safe.
+  ///
+  /// This is the signature-navigation the adapter once baked as the `ParamType`
+  /// virtual column, relocated so the render can spell a parameter at render
+  /// time.
+  internal borrowing func decode(parameter: Int,
+                                 generics: Array<String>? = nil,
+                                 for dialect: Dialect) -> String? {
+    parametered(parameter).map {
+      $0.type.decode(parameter: $0.name, generics: generics,
+                     with: $0.resolver, dialect: dialect)
+    }
+  }
+
+  /// The ABI type spelling of the `Param` at 1-based `parameter` `Id`, in
+  /// `dialect` — the ABI protocol's parameter: a value keeps its own ABI, a
+  /// concrete reference is the opaque interface pointer, and an unbound generic
+  /// slot projects through its element's associated ABI type (`Element.ABI`) —
+  /// or `nil` when it does not decode.
+  internal borrowing func abi(parameter: Int,
+                              generics: Array<String>? = nil,
+                              for dialect: Dialect) -> String? {
+    parametered(parameter).map {
+      $0.type.abi(parameter: $0.name, generics: generics,
+                  with: $0.resolver, dialect: dialect)
+    }
+  }
+
+  /// Whether the `Param` at 1-based `parameter` `Id` crosses the ABI as a
+  /// concrete erased interface pointer (a reference that is NOT a projected
+  /// generic slot) — so the wrapper casts the typed argument to the erased
+  /// pointer before forwarding — or `nil` when it does not decode. A value
+  /// parameter needs no cast, and a projected generic parameter forwards
+  /// through the `ABIProjectable` conformance (see `projects(parameter:)`), not
+  /// a cast.
+  internal borrowing func reference(parameter: Int) -> Bool? {
+    parametered(parameter).map {
+      $0.type.classification == .reference && !$0.type.projects
+    }
+  }
+
+  /// Whether the `Param` at 1-based `parameter` `Id` is an unbound generic slot
+  /// that crosses the ABI through its element's associated ABI type
+  /// (`Element.ABI`) — so the wrapper projects the typed argument through the
+  /// element's `ABIProjectable` conformance (`local.toABI()`), size-correct for
+  /// a value AND a reference instantiation — or `nil` when it does not decode.
+  internal borrowing func projects(parameter: Int) -> Bool? {
+    parametered(parameter).map { $0.type.projects }
   }
 }

--- a/Sources/winmd-inspect/Language.swift
+++ b/Sources/winmd-inspect/Language.swift
@@ -168,6 +168,7 @@ internal struct Language: Sendable {
                   close: conventions["generic-close"] ?? ""),
         variable: (type: conventions["var-type"] ?? "",
                    method: conventions["var-method"] ?? ""),
+        projection: conventions["projection"] ?? ".ABI",
         opaque: conventions["opaque"] ?? "",
         guid: (iid: conventions["guid-iid"] ?? "",
                clsid: conventions["guid-clsid"] ?? ""),

--- a/Sources/winmd-inspect/Resources/Languages/swift.lang
+++ b/Sources/winmd-inspect/Resources/Languages/swift.lang
@@ -32,8 +32,10 @@ type object UnsafeMutableRawPointer
 type typedref UnsafeMutableRawPointer
 
 # The type-composition conventions: the pointer family, the generic delimiters,
-# the optional marker, the generic-variable scope prefixes, the opaque spelling
-# an unresolvable type degrades to, and the `System.Guid` classification names.
+# the optional marker, the generic-variable scope prefixes, the associated-ABI-
+# type projection an unbound generic slot crosses the ABI through
+# (`Element.ABI`, the `.ABI` member), the opaque spelling an unresolvable type
+# degrades to, and the `System.Guid` classification names.
 pointer-mutable UnsafeMutablePointer
 pointer-const UnsafePointer
 rawpointer-mutable UnsafeMutableRawPointer
@@ -43,6 +45,7 @@ generic-open <
 generic-close >
 var-type T
 var-method M
+projection .ABI
 opaque UnsafeMutableRawPointer
 guid-iid IID
 guid-clsid CLSID

--- a/Sources/winmd-inspect/Resources/Queries/bases.sql
+++ b/Sources/winmd-inspect/Resources/Queries/bases.sql
@@ -14,3 +14,28 @@ FROM
   JOIN TypeDef d ON i.Interface_TypeDef = d.Id
 WHERE
   i.Class = :parent
+UNION
+-- A generic interface's base is recorded through a TypeSpec (a GENERICINST
+-- signature) rather than a TypeRef/TypeDef, so join the TypeSpec, decode its
+-- signature to the base coded-index token (GENERICBASE), and resolve that token
+-- to the base's TypeName by splitting its tag (BITAND(token, 3)) and 1-based
+-- row (token / 4): tag 1 names a TypeRef, tag 0 a TypeDef.
+SELECT
+  b.TypeName AS base
+FROM
+  InterfaceImpl i
+  JOIN TypeSpec s ON i.Interface_TypeSpec = s.Id
+  JOIN TypeRef b ON b.Id = GENERICBASE(s.Signature) / 4
+WHERE
+  i.Class = :parent
+  AND BITAND(GENERICBASE(s.Signature), 3) = 1
+UNION
+SELECT
+  d.TypeName AS base
+FROM
+  InterfaceImpl i
+  JOIN TypeSpec s ON i.Interface_TypeSpec = s.Id
+  JOIN TypeDef d ON d.Id = GENERICBASE(s.Signature) / 4
+WHERE
+  i.Class = :parent
+  AND BITAND(GENERICBASE(s.Signature), 3) = 0

--- a/Sources/winmd-inspect/Resources/Support/ABIProjectable.swift
+++ b/Sources/winmd-inspect/Resources/Support/ABIProjectable.swift
@@ -1,0 +1,84 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+// The runtime support the generated WinRT generic-interface projection depends
+// on — the Swift analogue of windows-rs's `windows_core::Type` trait and its
+// associated `Abi` type. It is bundled as a resource (`Resources/Support`) and
+// emitted alongside the projected interfaces, NOT compiled into the tool: it is
+// what the generated `struct IVector<Element: ABIProjectable>` and its
+// `IVectorABI<Element>` protocol project a generic slot through.
+
+/// A type that projects to an ABI representation as it crosses the WinRT vtable
+/// — the Swift analogue of windows-rs's `Type` trait, whose `Abi` associated
+/// type is the slot's ABI form.
+///
+/// A WinRT parameterised interface (`IVector<T>`, `IReference<T>`) erases a
+/// generic slot by its ARGUMENT's kind, not uniformly: `IVector<Int32>` carries
+/// an `Int32` value (4 bytes) across the vtable, `IVector<IFoo>` an opaque
+/// interface pointer (8 bytes). A fixed-size raw-pointer cast of the slot
+/// therefore traps for a value argument — it reads 8 bytes of a 4-byte value.
+/// `ABIProjectable` replaces that cast: the ABI form of a slot is the element's
+/// OWN `ABI` type (`CInt` for a value, `UnsafeMutableRawPointer` for a
+/// reference), and the conversion is size-correct by construction for both.
+///
+/// A value type conforms with `ABI == Self` and identity conversions (the
+/// windows-rs `CopyType`/`CloneType`, whose `Type::Abi` is `Self`); a
+/// reference type conforms with `ABI == UnsafeMutableRawPointer` and the
+/// opaque-pointer conversion (the windows-rs `InterfaceType`, whose `Type::Abi`
+/// is `*mut c_void`).
+public protocol ABIProjectable {
+  /// The slot's ABI representation as it crosses the WinRT vtable — `Self` for
+  /// a value, the opaque interface pointer for a reference.
+  associatedtype ABI
+
+  /// The ABI form of `self`, to pass across the vtable.
+  func toABI() -> ABI
+
+  /// The value an ABI form `abi` names, coming back across the vtable.
+  static func fromABI(_ abi: ABI) -> Self
+}
+
+/// A value type projects to ITSELF: its ABI form is its own representation, so
+/// both conversions are the identity — no cast, and size-correct because the
+/// slot type IS the value type (windows-rs `Type::Abi == Self`).
+extension ABIProjectable where ABI == Self {
+  public func toABI() -> Self { self }
+  public static func fromABI(_ abi: Self) -> Self { abi }
+}
+
+// The WinRT-blittable primitives that appear as generic arguments project by
+// value (`ABI == Self`), so a value instantiation (`IVector<Int32>`) crosses
+// the vtable as the value itself — never a raw pointer.
+extension Int8: ABIProjectable {}
+extension UInt8: ABIProjectable {}
+extension Int16: ABIProjectable {}
+extension UInt16: ABIProjectable {}
+extension Int32: ABIProjectable {}
+extension UInt32: ABIProjectable {}
+extension Int64: ABIProjectable {}
+extension UInt64: ABIProjectable {}
+extension Int: ABIProjectable {}
+extension UInt: ABIProjectable {}
+extension Float: ABIProjectable {}
+extension Double: ABIProjectable {}
+extension Bool: ABIProjectable {}
+
+/// A reference (interface) type projects to the opaque COM interface pointer:
+/// its ABI form is `UnsafeMutableRawPointer` (windows-rs `Type::Abi == *mut
+/// c_void`). The conversion is the pointer round-trip the projection performs
+/// through this protocol rather than through a bare fixed-size `unsafeBitCast`.
+public protocol ABIReference: ABIProjectable
+    where ABI == UnsafeMutableRawPointer {
+  /// The opaque interface pointer backing this reference.
+  var pointer: UnsafeMutableRawPointer { get }
+
+  /// Wraps an opaque interface pointer as this reference.
+  init(pointer: UnsafeMutableRawPointer)
+}
+
+extension ABIReference {
+  public func toABI() -> UnsafeMutableRawPointer { pointer }
+  public static func fromABI(_ abi: UnsafeMutableRawPointer) -> Self {
+    Self(pointer: abi)
+  }
+}

--- a/Sources/winmd-inspect/Resources/Templates/com.mustache
+++ b/Sources/winmd-inspect/Resources/Templates/com.mustache
@@ -1,23 +1,37 @@
 {{! language: swift }}
 {{#generic}}
-// A WinRT parameterised interface has no static IID: its IID is a
-// per-instantiation PIID computed at runtime from the type
-// arguments, so no `@com(interface:)` is emitted on the ABI protocol
-// or the generic wrapper — the runtime projection supplies it.
+// A WinRT parameterised interface projects its generic slots through each
+// element's associated ABI type (the windows-rs `Type::Abi` mechanism): a
+// value slot crosses the vtable as the value itself (`Element.ABI == Element`),
+// a reference slot as the opaque interface pointer (`Element.ABI ==
+// UnsafeMutableRawPointer`). The ABI protocol is therefore generic over the
+// same `ABIProjectable` parameters as the wrapper, and each requirement spells
+// its projected slots as `<Element>.ABI` — size-correct for a value AND a
+// reference instantiation, never a fixed-size raw-pointer cast. It has no
+// static IID: a parameterised interface's IID is a per-instantiation PIID
+// computed at runtime from the type arguments, so no `@com(interface:)` is
+// emitted on the ABI protocol or the wrapper — the runtime projection supplies
+// it.
 internal protocol {{{abi}}}<{{#generics}}{{{name}}}{{^last}}, {{/last}}{{/generics}}>{{#base}}: {{{.}}}{{/base}} {
 {{#generics}}
-    associatedtype {{{name}}}
+    associatedtype {{{name}}}: ABIProjectable
 {{/generics}}
 {{#methods}}
     func {{{name}}}({{#params}}_ {{{name}}}: {{{type}}}{{^last}}, {{/last}}{{/params}}){{#returns}} -> {{{.}}}{{/returns}}
 {{/methods}}
 }
 
-public struct {{{name}}}<{{#generics}}{{{name}}}{{^last}}, {{/last}}{{/generics}}> {
+// The public generic wrapper keeps the typed Swift surface: each method takes
+// and returns the decoded typed parameters, projecting between the typed value
+// and its ABI form through the element's `ABIProjectable` conformance
+// (`toABI()`/`fromABI(_:)`) as it forwards through `base` to the ABI protocol
+// — the size-correct analogue of windows-rs's `transmute_copy` across the
+// vtable. A value slot projects by identity, so it forwards unchanged.
+public struct {{{name}}}<{{#generics}}{{{name}}}: ABIProjectable{{^last}}, {{/last}}{{/generics}}> {
     internal let base: any {{{abi}}}<{{#generics}}{{{name}}}{{^last}}, {{/last}}{{/generics}}>
 {{#methods}}
-    public func {{{name}}}({{#params}}_ {{{local}}}: {{{type}}}{{^last}}, {{/last}}{{/params}}){{#returns}} -> {{{.}}}{{/returns}} {
-        base.{{{name}}}({{#params}}{{{local}}}{{^last}}, {{/last}}{{/params}})
+    public func {{{name}}}({{#params}}_ {{{local}}}: {{{typed}}}{{^last}}, {{/last}}{{/params}}){{#typed}} -> {{{.}}}{{/typed}} {
+        {{{call}}}
     }
 {{/methods}}
 }

--- a/Sources/winmd-inspect/Shell.swift
+++ b/Sources/winmd-inspect/Shell.swift
@@ -501,13 +501,16 @@ internal struct Shell: ~Escapable {
       // The names supplied to decode when the interface is generic; `nil`
       // otherwise, so a non-generic interface decodes exactly as before.
       let generics: Array<String>? = names.isEmpty ? nil : names
-      // The interface's own methods, decoded with its generic names so a `VAR`
-      // spells its declared name. A generic interface that HAS a base renders
-      // only its own surface here; forwarding a base's inherited methods onto
-      // the wrapper is a follow-up.
+      // The interface's own methods. A generic interface emits the ERASED ABI
+      // shape (a non-generic ABI protocol requirement + a typed casting
+      // wrapper); a non-generic one the plain `@com` shape. Each is decoded
+      // with the generic names so a `VAR` spells its declared name. A generic
+      // interface with a base renders only its own surface here; forwarding a
+      // base's inherited methods onto the wrapper is a follow-up.
       let methods = try self.methods(of: id, routines, search: search,
                                      generics: generics, in: dialect,
-                                     language: language)
+                                     language: language,
+                                     generic: generics != nil)
       // The interface's named base, via the `bases` view bound by its `Id` (a
       // `TypeRef`/`TypeDef` simple name). A rootless interface defaults to the
       // spec's COM root, except the root interface itself — which inherits
@@ -517,12 +520,42 @@ internal struct Shell: ~Escapable {
           try Shell.select(Shell.query(named: "bases", search: search))
       let bases = try session.run(lineage, routines,
                                   bindings: ["parent": id])
-      let base: String? = if let inherited = bases.first {
+      // The named base's SIMPLE name (a `TypeRef`/`TypeDef` TypeName), or the
+      // spec's COM-root default for a rootless interface (save the root).
+      let named: String? = if let inherited = bases.first {
         inherited[0].text
       } else if language.root.isEmpty || found[2].text == language.root {
         nil
       } else {
         language.root
+      }
+      // The base clause the template inherits. A generic interface's ABI
+      // protocol inherits its base's ABI protocol by protocol inheritance: a
+      // generic base (its TypeName carries a CLR arity suffix) inherits its
+      // `<stripped>ABI` PARAMETERISED by the interface's own generic arguments
+      // (`IVectorABI<Element>: IIterableABI<Element>` — a WinRT generic
+      // interface passes its own type parameters to its generic base), and a
+      // non-generic base (`IInspectable`, no suffix) is inherited unchanged (it
+      // is already a plain protocol with no wrapper/ABI split). The escape
+      // order matches the interface's own `abi` name: strip THEN suffix `ABI`
+      // THEN escape, so a keyword base spells its plain `protocolABI`. A
+      // non-generic interface inherits the plain named base unchanged.
+      //
+      // A CLR arity suffix is a backtick FOLLOWED BY A DIGIT (`IVector``1`); it
+      // marks a generic base to rewrite. It must be told apart from a Swift
+      // KEYWORD-ESCAPING backtick, which `bases` (through `SANITIZE`) wraps
+      // around a keyword base name (a base named `protocol` arrives as
+      // `` `protocol` ``): those backticks WRAP the identifier and are not
+      // followed by a digit, so the base is non-generic and inherited as-is.
+      // A bare `name.contains("`")` cannot tell them apart and would rewrite an
+      // escaped keyword base to a broken `` `protocolABI` ``.
+      let arguments = (generics?.map(language.escape)
+          .joined(separator: ", ")).map { "<\($0)>" } ?? ""
+      let base = named.map { name in
+        generics != nil && Shell.arity(name)
+            ? language.escape(String(name.prefix { $0 != "`" }) + "ABI")
+                + arguments
+            : name
       }
       // A generic interface's own `TypeName` carries the CLR arity suffix
       // (`IVector``1`); strip it — the decode tier strips it only for a
@@ -571,19 +604,32 @@ internal struct Shell: ~Escapable {
   }
 
   /// The template method entries for the interface at `id`, in declaration
-  /// order — each a `name`, a `params` list, and (for a value-returning method)
-  /// a `returns` clause — decoded with the owner's `generics` names threaded so
-  /// a `VAR` spells its declared name.
+  /// order, decoded with the owner's `generics` names threaded so a `VAR`
+  /// spells its declared name.
+  ///
+  /// A NON-generic interface (`generic` false) emits the plain `@com` protocol
+  /// shape: each entry a `name`, a `params` list (each `name`/`local`/`type`,
+  /// the `type` the parameter's own decoded spelling), and — for a
+  /// value-returning method — a `returns` clause.
+  ///
+  /// A GENERIC interface (`generic` true) emits the ERASED ABI shape: the ABI
+  /// protocol's requirement reads each parameter/return through its ABI-erased
+  /// spelling (`abi(parameter:)`/`abi(return:)`), where a reference slot is the
+  /// opaque interface pointer; the wrapper's typed surface reads the same slot
+  /// through its typed `decode(…)`, and the forwarding `call` casts the typed
+  /// value to the erased pointer (and the erased result back) at each reference
+  /// slot. So each entry additionally carries every parameter's `typed`
+  /// spelling and `argument` (the forwarding expression), the return's `typed`
+  /// spelling, and the whole `call` — `Shell.forwarding(…)` composes them.
   ///
   /// Each method's parameters, bound by the method's `Id`, drop the return
-  /// pseudo-parameter (`Sequence == 0`); the rest decode their type from their
-  /// own signature position. The return decodes to `returns` unless it is the
-  /// spec's `void` spelling or undecodable, when `{{#returns}}` renders
-  /// nothing.
+  /// pseudo-parameter (`Sequence == 0`). The return's clause is omitted when it
+  /// is the spec's `void` spelling or undecodable, when `{{#returns}}`/
+  /// `{{#typed}}` renders nothing.
   private borrowing func methods(of id: Value, _ routines: Routines,
                                  search: Array<String>,
                                  generics: Array<String>?, in dialect: Dialect,
-                                 language: Language) throws
+                                 language: Language, generic: Bool) throws
       -> Array<Dictionary<String, Any>> {
     let plan = try Shell.select(Shell.query(named: "methods", search: search))
     let rows = try session.run(plan, routines, bindings: ["parent": id])
@@ -595,19 +641,69 @@ internal struct Shell: ~Escapable {
       let params = try session.run(selection, routines,
                                    bindings: ["parent": method[0]])
       let kept = params.filter { $0[2] != .integer(0) }
-      let types = kept.map {
-        session.storage.decode(parameter: $0[0].integer, generics: generics,
-                               for: dialect) ?? ""
+      // The erased-ABI parameter spellings the ABI protocol's requirement uses:
+      // a reference slot is the opaque interface pointer, a value slot its own
+      // decoded spelling. A non-generic interface renders the requirement off
+      // the same (unerased-because-monomorphic) `abi(…)` — for a non-generic
+      // interface a reference argument has a concrete named type whose `abi(…)`
+      // is that named type, matching today's `decode(…)` output — so this is
+      // byte-identical there.
+      let types = kept.map { param in
+        (generic ? session.storage.abi(parameter: param[0].integer,
+                                       generics: generics, for: dialect)
+                 : session.storage.decode(parameter: param[0].integer,
+                                          generics: generics, for: dialect))
+            ?? ""
       }
-      let parameters = Shell.parameters(kept.map(\.[1].text), types: types)
-      var entry: Dictionary<String, Any> = [
-        "name": method[1].text,
-        "params": parameters,
-      ]
-      let returned = session.storage.decode(return: method[0].integer,
-                                            generics: generics, in: dialect)
-      if let returned, let clause = language.returned(returned) {
-        entry["returns"] = clause
+      let names = kept.map(\.[1].text)
+      var entry: Dictionary<String, Any>
+      let clause = session.storage.decode(return: method[0].integer,
+                                          generics: generics, in: dialect)
+          .flatMap(language.returned)
+      if generic {
+        // The wrapper's typed parameter spellings and the per-slot reference
+        // and projection flags that decide the forwarding conversion.
+        let typed = kept.map {
+          session.storage.decode(parameter: $0[0].integer, generics: generics,
+                                 for: dialect) ?? ""
+        }
+        let references = kept.map {
+          session.storage.reference(parameter: $0[0].integer) ?? false
+        }
+        // Whether each parameter is a projected generic slot (an unbound
+        // type-level `VAR`): it forwards through `ABIProjectable`
+        // (`local.toABI()`), not a fixed-size cast, so it is size-correct for a
+        // value AND a reference instantiation.
+        let projects = kept.map {
+          session.storage.projects(parameter: $0[0].integer) ?? false
+        }
+        let parameters =
+            Shell.parameters(names, types: types, typed: typed,
+                             references: references, projects: projects)
+        entry = ["name": method[1].text, "params": parameters]
+        // The ABI return the protocol requirement uses; the typed return the
+        // wrapper uses; whether the return erases as a concrete pointer (so the
+        // call casts it back) or projects through `ABIProjectable` (so the call
+        // reconstructs it as `<typed>.fromABI(…)`). The value-void/undecodable
+        // return omits BOTH clauses.
+        let erased = session.storage.abi(return: method[0].integer,
+                                         generics: generics, in: dialect)
+            .flatMap(language.returned)
+        let reference =
+            session.storage.reference(return: method[0].integer) ?? false
+        let projected =
+            session.storage.projects(return: method[0].integer) ?? false
+        if let erased { entry["returns"] = erased }
+        if let clause { entry["typed"] = clause }
+        entry["call"] = Shell.forwarding(method[1].text, parameters,
+                                         typed: clause, reference: reference,
+                                         projects: projected)
+      } else {
+        entry = [
+          "name": method[1].text,
+          "params": Shell.parameters(names, types: types),
+        ]
+        if let clause { entry["returns"] = clause }
       }
       methods.append(entry)
     }
@@ -631,25 +727,13 @@ internal struct Shell: ~Escapable {
   internal static func parameters(_ names: Array<String>,
                                   types: Array<String>)
       -> Array<Dictionary<String, Any>> {
-    // The names in play — the real ones plus each synthetic as it is minted —
-    // so a synthetic never duplicates a real name or a sibling synthetic.
-    var used = Set(names.filter { !$0.isEmpty })
-    var next = 0
+    let locals = Shell.locals(names)
     var parameters = Array<Dictionary<String, Any>>()
     parameters.reserveCapacity(names.count)
-    for (name, type) in zip(names, types) {
-      let local: String
-      if name.isEmpty {
-        while used.contains("arg\(next)") { next += 1 }
-        local = "arg\(next)"
-        used.insert(local)
-        next += 1
-      } else {
-        local = name
-      }
+    for (index, type) in types.enumerated() {
       parameters.append([
-        "name": name,
-        "local": local,
+        "name": names[index],
+        "local": locals[index],
         "type": type,
         "last": false,
       ])
@@ -660,6 +744,110 @@ internal struct Shell: ~Escapable {
       parameters[parameters.count - 1]["last"] = true
     }
     return parameters
+  }
+
+  /// The template parameter dictionaries for a GENERIC wrapper's kept
+  /// parameters — the projected ABI shape.
+  ///
+  /// Each entry carries the same `name`/`local`/`last` (the blank-name `local`
+  /// synthesis is shared with the plain builder) plus the split the projected
+  /// shape needs: `type` is the parameter's ABI spelling (the ABI protocol
+  /// requirement's parameter — a value its own ABI, a concrete reference the
+  /// `opaque` interface pointer, a projected generic slot `<typed>.ABI`),
+  /// `typed` its typed spelling (the wrapper method's parameter), and
+  /// `argument` the forwarding expression the wrapper passes through `base`:
+  ///
+  /// - a PROJECTED generic slot projects the typed `local` through its
+  ///   element's `ABIProjectable` conformance (`local.toABI()`) — size-correct
+  ///   for a value AND a reference instantiation, the windows-rs `Param::abi()`
+  ///   analogue — never a fixed-size cast;
+  /// - a CONCRETE reference casts the typed `local` to the erased pointer
+  ///   `type` (`unsafeBitCast(local, to: <type>.self)`) — a pointer either
+  ///   way, so the cast is size-safe;
+  /// - a VALUE passes the `local` unchanged (its typed and ABI spellings
+  ///   coincide, so no conversion is needed).
+  internal static func parameters(_ names: Array<String>,
+                                  types: Array<String>, typed: Array<String>,
+                                  references: Array<Bool>,
+                                  projects: Array<Bool>)
+      -> Array<Dictionary<String, Any>> {
+    let locals = Shell.locals(names)
+    var parameters = Array<Dictionary<String, Any>>()
+    parameters.reserveCapacity(names.count)
+    for index in names.indices {
+      let local = locals[index]
+      let argument = if projects[index] {
+        "\(local).toABI()"
+      } else if references[index] {
+        "unsafeBitCast(\(local), to: \(types[index]).self)"
+      } else {
+        local
+      }
+      parameters.append([
+        "name": names[index],
+        "local": local,
+        "type": types[index],
+        "typed": typed[index],
+        "argument": argument,
+        "last": false,
+      ])
+    }
+    if !parameters.isEmpty {
+      parameters[parameters.count - 1]["last"] = true
+    }
+    return parameters
+  }
+
+  /// The forwarding-method locals for `names` — a named parameter keeps its own
+  /// name; a blank one (`func Foo(_ : T)`, allowed in a protocol requirement's
+  /// decl) synthesizes a stable, collision-free `arg<N>` the wrapper passes by
+  /// name in the call.
+  ///
+  /// The synthetic is chosen AFTER the method's real names are known: the first
+  /// `arg<N>` (from `N == 0`) not used by a real parameter or an earlier
+  /// synthetic, so `Foo(_ : T, _ arg0: T)` gives the blank a local of `arg1`
+  /// rather than colliding with the real `arg0`.
+  private static func locals(_ names: Array<String>) -> Array<String> {
+    // The names in play — the real ones plus each synthetic as it is minted —
+    // so a synthetic never duplicates a real name or a sibling synthetic.
+    var used = Set(names.filter { !$0.isEmpty })
+    var next = 0
+    return names.map { name in
+      guard name.isEmpty else { return name }
+      while used.contains("arg\(next)") { next += 1 }
+      let local = "arg\(next)"
+      used.insert(local)
+      next += 1
+      return local
+    }
+  }
+
+  /// The GENERIC wrapper method's forwarding body — the single expression that
+  /// calls the ABI protocol through `base`, converting across the boundary at
+  /// the return.
+  ///
+  /// The call passes each parameter's forwarding `argument` (a projected slot
+  /// through `local.toABI()`, a concrete reference cast to the erased pointer,
+  /// a value the bare local). A value-void method (`typed` nil) forwards the
+  /// bare call; a returning method whose return PROJECTS reconstructs the typed
+  /// value through the element's `ABIProjectable` conformance
+  /// (`<typed>.fromABI(base.M(…))`) — size-correct for a value AND a reference
+  /// instantiation; a return that erases as a CONCRETE reference casts the
+  /// erased result back (`unsafeBitCast(base.M(…), to: <typed>.self)`, a
+  /// pointer either way); a value return passes the call result through
+  /// unchanged. Swift's single-expression body implicitly returns the
+  /// expression, so no `return` is spelled.
+  internal static func forwarding(_ name: String,
+                                  _ parameters: Array<Dictionary<String, Any>>,
+                                  typed: String?, reference: Bool,
+                                  projects: Bool) -> String {
+    let arguments = parameters.map { $0["argument"] as? String ?? "" }
+                              .joined(separator: ", ")
+    let call = "base.\(name)(\(arguments))"
+    guard let typed else { return call }
+    if projects { return "\(typed).fromABI(\(call))" }
+    guard reference else { return call }
+    return "unsafeBitCast(\(call), to: \(typed).self)"
   }
 
   /// The ordered declared generic-parameter names of the interface at `id`,
@@ -722,6 +910,25 @@ internal struct Shell: ~Escapable {
   /// name (a `-I` directory's copy shadowing the bundle's), the same way the
   /// template is. A name no search directory and no bundle resolves is a
   /// packaging error, raised as `RenderError.query`.
+  /// Whether `name` carries a CLR generic-arity suffix — a backtick FOLLOWED BY
+  /// A DIGIT (`IVector``1`), the metadata spelling of a generic definition's
+  /// name — marking it a GENERIC base to rewrite to its `<stripped>ABI`.
+  ///
+  /// This is deliberately narrower than `contains("`")`: a Swift keyword base
+  /// name arrives keyword-ESCAPED from `bases` (through `SANITIZE`), its
+  /// backticks WRAPPING the whole identifier (`` `protocol` ``) rather than
+  /// prefixing a digit. Those escaping backticks must NOT be read as an arity
+  /// suffix — the base is non-generic and inherited unchanged.
+  private static func arity(_ name: String) -> Bool {
+    var characters = name.makeIterator()
+    while let character = characters.next() {
+      if character == "`", let next = characters.next(), next.isNumber {
+        return true
+      }
+    }
+    return false
+  }
+
   private static func query(named name: String,
                             search: Array<String>) throws -> String {
     guard let url = resource(name, "sql", kind: "Render", search: search)

--- a/Tests/WinMDSynthesisTests/DecodeTests.swift
+++ b/Tests/WinMDSynthesisTests/DecodeTests.swift
@@ -27,6 +27,7 @@ extension Dialect {
         optional: "?",
         generic: (open: "<", close: ">"),
         variable: (type: "T", method: "M"),
+        projection: ".ABI",
         opaque: "UnsafeMutableRawPointer",
         guid: (iid: "IID", clsid: "CLSID"),
         known: [
@@ -340,6 +341,9 @@ struct DecodeTests {
     ])
     let type = SignatureType.named(kind: .class, foo)
     #expect(type.classification == .reference)
+    // A CONCRETE reference is not a projected generic slot: its erased pointer
+    // is a pointer either way, so the wrapper's cast is size-safe.
+    #expect(!type.projects)
     #expect(type.abi(with: resolver, dialect: dialect)
                 == "UnsafeMutableRawPointer")
     // Its own decoded spelling — what the erasure replaces — is the named type.
@@ -384,6 +388,90 @@ struct DecodeTests {
     #expect(type.classification == .reference)
     #expect(type.abi(with: resolver, dialect: dialect)
                 == "UnsafeMutableRawPointer")
+  }
+
+  @Test func `an unbound generic type variable projects through its element ABI`() {
+    // In the generic DEFINITION render there is no bound argument, so a
+    // type-level `VAR` slot projects through its declared name's ASSOCIATED ABI
+    // type (`Element.ABI`, the windows-rs `Type::Abi` mechanism) — size-correct
+    // for a value AND a reference instantiation, unlike a fixed-size raw-pointer
+    // erasure — and `projects` reports it so the wrapper forwards through
+    // `ABIProjectable` rather than a fixed-size cast. It still classifies as a
+    // reference (a fixed classification cannot know the argument), but the ABI
+    // spelling is the projection, not the opaque pointer.
+    let element = SignatureType.variable(scope: .type, 0)
+    #expect(element.classification == .reference)
+    #expect(element.projects)
+    #expect(element.abi(generics: ["Element"], with: resolver, dialect: dialect)
+                == "Element.ABI")
+    // Its own decoded spelling — the typed surface the wrapper keeps — is the
+    // declared name.
+    #expect(element.decode(generics: ["Element"], with: resolver,
+                           dialect: dialect) == "Element")
+    // A method-level `MVAR` (never substituted here) has no declared name to
+    // project, so it still erases to the opaque pointer and does NOT project.
+    let method = SignatureType.variable(scope: .method, 0)
+    #expect(method.classification == .reference)
+    #expect(!method.projects)
+    #expect(method.abi(with: resolver, dialect: dialect)
+                == "UnsafeMutableRawPointer")
+    // A byref/pointer of a type variable projects its element under the
+    // pointer — the composed spelling wraps `Element.ABI`, and it still
+    // projects (the wrapper converts the wrapped slot).
+    let byref = SignatureType.reference(.variable(scope: .type, 0))
+    #expect(byref.classification == .reference)
+    #expect(byref.projects)
+    #expect(byref.abi(generics: ["Element"], with: resolver, dialect: dialect)
+                == "UnsafeMutablePointer<Element.ABI>")
+  }
+
+  @Test func `a generic type variable erases by its bound argument's kind`() {
+    // WinRT erases a generic parameter's ABI by its CONCRETE argument's kind,
+    // so a type variable's ABI is argument-dependent: `IVector<Int32>.GetAt`
+    // carries an `Int32` value (4 bytes), `IVector<IFoo>.GetAt` an interface
+    // pointer (8 bytes). When the enclosing instantiation's binding `arguments`
+    // are supplied, `VAR 0` classifies and erases as `arguments[0]`.
+    let element = SignatureType.variable(scope: .type, 0)
+    // A VALUE argument (`Int32`) keeps its own value ABI — the slot is `CInt`,
+    // NOT the opaque pointer, so the wrapper needs no size-mismatched bitcast.
+    #expect(element.classification(substituting: [.primitive(.int4)]) == .value)
+    #expect(element.abi(substituting: [.primitive(.int4)], with: resolver,
+                        dialect: dialect) == "CInt")
+    // A REFERENCE argument (an interface) erases to the opaque pointer, exactly
+    // as the unbound definition does — the wrapper casts across the boundary.
+    let foo = TypeDefOrRef(rawValue: 1)
+    let references = Resolver([
+      foo.rawValue: Identity(namespace: "Windows.Foundation", name: "IFoo"),
+    ])
+    let reference = SignatureType.named(kind: .class, foo)
+    #expect(element.classification(substituting: [reference]) == .reference)
+    #expect(element.abi(substituting: [reference], with: references,
+                        dialect: dialect) == "UnsafeMutableRawPointer")
+    // The whole instantiation follows suit: a GENERICINST over a `CLASS` base
+    // threads ITS arguments to the base's variable slots — an out-of-range
+    // operand or a method-level `MVAR` is never substituted and stays a
+    // reference. A byref of a value-bound variable wraps the VALUE ABI.
+    let byref = SignatureType.reference(.variable(scope: .type, 0))
+    #expect(byref.abi(substituting: [.primitive(.int4)], with: resolver,
+                      dialect: dialect) == "UnsafeMutablePointer<CInt>")
+  }
+
+  @Test func `only an unbound type variable is a projected generic slot`() {
+    // `projects` partitions the erased-ABI slots the generic-definition render
+    // forwards: only an unbound type-level `VAR` (recursively, under
+    // indirection) crosses through its element's associated ABI type
+    // (`Element.ABI`) and so forwards through `ABIProjectable`. A value, a
+    // concrete reference, a generic instantiation, and a method-level `MVAR` do
+    // not project — a value needs no conversion, and a concrete reference's
+    // pointer cast is size-safe.
+    #expect(SignatureType.variable(scope: .type, 0).projects)
+    #expect(SignatureType.pointer(.variable(scope: .type, 0)).projects)
+    #expect(!SignatureType.variable(scope: .method, 0).projects)
+    #expect(!SignatureType.primitive(.int4).projects)
+    let foo = TypeDefOrRef(rawValue: 1)
+    #expect(!SignatureType.named(kind: .class, foo).projects)
+    #expect(!SignatureType.instance(.named(kind: .class, foo),
+                                    [.primitive(.int4)]).projects)
   }
 
   @Test func `a typed reference is a value keeping its own ABI spelling`() {

--- a/Tests/WinMDTests/SignatureTests.swift
+++ b/Tests/WinMDTests/SignatureTests.swift
@@ -22,6 +22,8 @@ private let CLASS: UInt8 = 0x12
 private let ARRAY: UInt8 = 0x14
 private let SZARRAY: UInt8 = 0x1d
 private let CMOD_OPT: UInt8 = 0x20
+private let VAR: UInt8 = 0x13
+private let GENERICINST: UInt8 = 0x15
 
 // A `TypeDefOrRefOrSpec` coded index, compressed: low two bits the tag, the
 // rest the 1-based row. `TypeRef[0]` is `(1 << 2) | 1 == 5`.
@@ -115,6 +117,27 @@ struct SignatureTests {
     guard case .named(.value, _) = base else {
       Issue.record("modified base not a value type"); return
     }
+  }
+
+  @Test func `base decodes a generic instantiation's base coded index`() {
+    // A `TypeSpec` GENERICINST signature — `IIterable`1<T>`, its base a
+    // `TypeRef` and its one argument a type variable — decodes to its base's
+    // `TypeDefOrRef` token, the value the SQL `bases` view splits (tag/row) to
+    // join the base's name. GENERICINST CLASS TypeRef[0] 1 VAR 0.
+    let bytes = [GENERICINST, CLASS, typeref0, 0x01, VAR, 0x00]
+    guard let base = WinMD.base(decoding: bytes) else {
+      Issue.record("signature not a generic instantiation"); return
+    }
+    #expect(base.tag == 1)
+    #expect(base.row == 1)
+    #expect(base.rawValue == Int(typeref0))
+  }
+
+  @Test func `base is nil for a non-generic-instantiation signature`() throws {
+    // A bare (non-GENERICINST) type spec — an SZARRAY of I4 — is not a generic
+    // instantiation over a named base, so `base` yields nil and the SQL join
+    // produces no base row for it.
+    #expect(WinMD.base(decoding: [SZARRAY, I4]) == nil)
   }
 
   @Test func `decodes a field signature`() throws {

--- a/Tests/winmd-inspectTests/DatabaseSQLTests.swift
+++ b/Tests/winmd-inspectTests/DatabaseSQLTests.swift
@@ -38,6 +38,7 @@ extension Dialect {
         optional: "?",
         generic: (open: "<", close: ">"),
         variable: (type: "T", method: "M"),
+        projection: ".ABI",
         opaque: "UnsafeMutableRawPointer",
         guid: (iid: "IID", clsid: "CLSID"),
         known: [
@@ -182,6 +183,12 @@ struct DatabaseSQLTests {
                 wide: 0, stride: 6),
     WinMD.Table(Metadata.Tables.CustomAttribute.self, rows: 1, range: 86 ..< 92,
                 wide: 0, stride: 6),
+    // No `TypeSpec` table: this file has no generic bases, so — like a real
+    // WinMD with no `TypeSpec` rows — it omits the table entirely (its `Valid`
+    // bit is clear). The bundled `bases` view's `TypeSpec` arm still resolves:
+    // the SQL adapter surfaces a schema-defined but absent table as an EMPTY
+    // relation (`WinMD.Table.empty`), so the arm yields no rows rather than
+    // faulting an unknown relation.
   ]
 
   private static let valid: UInt64 =
@@ -588,6 +595,24 @@ struct DatabaseSQLTests {
     }
   }
 
+  @Test func `the erased-ABI decode keeps a value slot and reports it a value`() {
+    // The fixture's `void Method(i4, string)` is all values: the erased-ABI
+    // return/parameter spellings (`abi(return:)`/`abi(parameter:)`) coincide
+    // with their typed `decode(…)` — a value crosses the ABI as itself — and
+    // `reference(…)` reports each a value, so the wrapper forwards it uncast.
+    // The reference-slot erasure is exercised by `SignatureType.abi(…)`'s own
+    // tests and the erased-shape golden render; the fixture carries no
+    // reference slot to drive it end-to-end here.
+    DatabaseSQLTests.with { catalog in
+      #expect(catalog.abi(return: 1, in: .swift) == "Void")
+      #expect(catalog.reference(return: 1) == false)
+      #expect(catalog.abi(parameter: 2, for: .swift) == "CInt")
+      #expect(catalog.abi(parameter: 3, for: .swift) == "HSTRING")
+      #expect(catalog.reference(parameter: 2) == false)
+      #expect(catalog.reference(parameter: 3) == false)
+    }
+  }
+
   @Test func `the bundled bases view yields the interface's derived bases`() throws {
     // `IMyInterface` is `TypeDef` Id 1; binding `:parent` to its Id
     // navigates `InterfaceImpl.Class = :parent`, and the view UNIONs both arms
@@ -610,6 +635,58 @@ struct DatabaseSQLTests {
           "SELECT base FROM bases", Session.bundled(), catalog,
           ["parent": .integer(2)])
       #expect(rows.isEmpty)
+    }
+  }
+
+  @Test func `the bundled bases view resolves a TypeSpec-recorded generic base`() throws {
+    // A generic interface inheriting ANOTHER generic interface records the base
+    // through a `TypeSpec` (a GENERICINST signature), NOT a
+    // `TypeRef`/`TypeDef`, so the plain coded-index arms find nothing. The
+    // `TypeSpec` arm joins the spec, decodes its signature to the base token
+    // (`GENERICBASE`), and splits the token's tag/row to resolve the base
+    // `TypeRef` by `Id` — here `IIterable`1`, the raw arity-suffixed name the
+    // render then rewrites to `IIterableABI`.
+    try GenericBaseFixture.with { catalog in
+      let rows = try DatabaseSQLTests.run(
+          "SELECT base FROM bases", Session.bundled(), catalog,
+          ["parent": .integer(1)])
+      #expect(rows == [[.text("IIterable`1")]])
+    }
+  }
+
+  @Test func `a schema-defined but absent table resolves as an empty relation`() throws {
+    // A metadata file omits a table with no rows (its `Valid` bit is clear);
+    // the shared fixture carries no `TypeSpec`, so its mask omits table 27.
+    // The adapter surfaces the absent-but-schema-defined `TypeSpec` as an EMPTY
+    // relation — the six schema columns, zero rows — so a query naming it
+    // resolves to no rows rather than faulting `SQLError.relation`. A name no
+    // CIL schema bears is still an unknown relation.
+    try DatabaseSQLTests.with { catalog in
+      // The absent `TypeSpec` resolves and projects its six schema columns with
+      // zero rows; a `SELECT *` over it yields nothing rather than faulting.
+      let rows = try DatabaseSQLTests.run("SELECT * FROM TypeSpec", catalog)
+      #expect(rows.isEmpty)
+      // A name no CIL schema bears is still an unknown relation.
+      #expect(throws: SQLError.self) {
+        _ = try DatabaseSQLTests.run("SELECT * FROM NotACILTable", catalog)
+      }
+    }
+  }
+
+  @Test func `the bundled bases view resolves over a file with no TypeSpec table`() throws {
+    // The bundled `bases` view's `TypeSpec` arm references the `TypeSpec`
+    // relation UNCONDITIONALLY, and the engine resolves EVERY UNION arm at
+    // compile time. Over the shared fixture — which omits the `TypeSpec` table
+    // (no generic bases, `Valid` bit clear) — resolving a NON-generic
+    // interface's bases must still succeed: the adapter surfaces the absent
+    // `TypeSpec` as an empty relation, so the `TypeSpec` arms yield nothing and
+    // the plain `TypeRef`/`TypeDef` arms yield the real bases. `IMyInterface`
+    // (Id 1) derives `IInspectable` and `INotGuid`; the query does not fault.
+    try DatabaseSQLTests.with { catalog in
+      let rows = try DatabaseSQLTests.run(
+          "SELECT base FROM bases", Session.bundled(), catalog,
+          ["parent": .integer(1)])
+      #expect(rows == [[.text("IInspectable")], [.text("INotGuid")]])
     }
   }
 
@@ -910,17 +987,23 @@ struct DatabaseSQLTests {
     }
   }
 
-  @Test func `the bundled com template renders a generic interface as a wrapper`() throws {
+  @Test func `the bundled com template renders a generic interface projected`() throws {
     // A generic interface renders through the `{{#generic}}` arm of the REAL
-    // bundled `com` template: an internal ABI protocol carrying the ordered
-    // type parameters as its primary associated types (`<Element>` naming an
-    // `associatedtype Element` in the body) — so a requirement mentioning
-    // `Element` resolves — with no static IID (the WinRT PIID is computed at
-    // runtime), plus a public generic `struct` wrapper holding the ABI as a
-    // parameterised existential (`any IVectorABI<Element>`). The context is
-    // built the same way the render loop assembles it for an `IVector`-like
-    // ``1` type (arity suffix stripped, one generic parameter `Element`, one
-    // method whose return decodes to that declared name).
+    // bundled `com` template in the PROJECTED ABI shape: an ABI protocol
+    // generic over the same `ABIProjectable` parameters as the wrapper, whose
+    // requirements spell each projected slot as `Element.ABI` (a value's ABI is
+    // itself, a reference's the opaque pointer) — no static IID (the WinRT PIID
+    // is computed at runtime) — plus a public generic `struct` wrapper
+    // `IVector<Element: ABIProjectable>` keeping the typed surface, its `base` a
+    // parameterised `any IVectorABI<Element>` existential, each method
+    // projecting between the typed value and its ABI form through
+    // `toABI()`/`fromABI(_:)`. Here `GetAt` returns the generic `Element`, so
+    // the ABI protocol returns `Element.ABI` and the wrapper reconstructs the
+    // typed result as `Element.fromABI(…)` — size-correct for a value AND a
+    // reference instantiation, NO fixed-size pointer cast; the `index` parameter
+    // is a value (`CUnsignedInt`), passed through unconverted. The context is
+    // built the way the render loop assembles it for an `IVector`-like ``1`
+    // type.
     let body = try DatabaseSQLTests.template(named: "com")
     let template = try MustacheTemplate(string: body)
     let context: [String: Any] = [
@@ -935,26 +1018,42 @@ struct DatabaseSQLTests {
           "name": "GetAt",
           "params": [
             ["name": "index", "local": "index", "type": "CUnsignedInt",
-             "last": true],
+             "typed": "CUnsignedInt", "argument": "index", "last": true],
           ],
-          "returns": "Element",
+          "returns": "Element.ABI",
+          "typed": "Element",
+          "call": "Element.fromABI(base.GetAt(index))",
         ],
       ],
     ]
     #expect(template.render(context) == """
-      // A WinRT parameterised interface has no static IID: its IID is a
-      // per-instantiation PIID computed at runtime from the type
-      // arguments, so no `@com(interface:)` is emitted on the ABI protocol
-      // or the generic wrapper — the runtime projection supplies it.
+      // A WinRT parameterised interface projects its generic slots through each
+      // element's associated ABI type (the windows-rs `Type::Abi` mechanism): a
+      // value slot crosses the vtable as the value itself (`Element.ABI == Element`),
+      // a reference slot as the opaque interface pointer (`Element.ABI ==
+      // UnsafeMutableRawPointer`). The ABI protocol is therefore generic over the
+      // same `ABIProjectable` parameters as the wrapper, and each requirement spells
+      // its projected slots as `<Element>.ABI` — size-correct for a value AND a
+      // reference instantiation, never a fixed-size raw-pointer cast. It has no
+      // static IID: a parameterised interface's IID is a per-instantiation PIID
+      // computed at runtime from the type arguments, so no `@com(interface:)` is
+      // emitted on the ABI protocol or the wrapper — the runtime projection supplies
+      // it.
       internal protocol IVectorABI<Element> {
-          associatedtype Element
-          func GetAt(_ index: CUnsignedInt) -> Element
+          associatedtype Element: ABIProjectable
+          func GetAt(_ index: CUnsignedInt) -> Element.ABI
       }
 
-      public struct IVector<Element> {
+      // The public generic wrapper keeps the typed Swift surface: each method takes
+      // and returns the decoded typed parameters, projecting between the typed value
+      // and its ABI form through the element's `ABIProjectable` conformance
+      // (`toABI()`/`fromABI(_:)`) as it forwards through `base` to the ABI protocol
+      // — the size-correct analogue of windows-rs's `transmute_copy` across the
+      // vtable. A value slot projects by identity, so it forwards unchanged.
+      public struct IVector<Element: ABIProjectable> {
           internal let base: any IVectorABI<Element>
           public func GetAt(_ index: CUnsignedInt) -> Element {
-              base.GetAt(index)
+              Element.fromABI(base.GetAt(index))
           }
       }
 
@@ -1001,15 +1100,29 @@ struct DatabaseSQLTests {
       }
       let rendered = try shell.render("protocol`1", template: "com")
       #expect(rendered == """
-        // A WinRT parameterised interface has no static IID: its IID is a
-        // per-instantiation PIID computed at runtime from the type
-        // arguments, so no `@com(interface:)` is emitted on the ABI protocol
-        // or the generic wrapper — the runtime projection supplies it.
+        // A WinRT parameterised interface projects its generic slots through each
+        // element's associated ABI type (the windows-rs `Type::Abi` mechanism): a
+        // value slot crosses the vtable as the value itself (`Element.ABI == Element`),
+        // a reference slot as the opaque interface pointer (`Element.ABI ==
+        // UnsafeMutableRawPointer`). The ABI protocol is therefore generic over the
+        // same `ABIProjectable` parameters as the wrapper, and each requirement spells
+        // its projected slots as `<Element>.ABI` — size-correct for a value AND a
+        // reference instantiation, never a fixed-size raw-pointer cast. It has no
+        // static IID: a parameterised interface's IID is a per-instantiation PIID
+        // computed at runtime from the type arguments, so no `@com(interface:)` is
+        // emitted on the ABI protocol or the wrapper — the runtime projection supplies
+        // it.
         internal protocol protocolABI<Element>: IUnknown {
-            associatedtype Element
+            associatedtype Element: ABIProjectable
         }
 
-        public struct `protocol`<Element> {
+        // The public generic wrapper keeps the typed Swift surface: each method takes
+        // and returns the decoded typed parameters, projecting between the typed value
+        // and its ABI form through the element's `ABIProjectable` conformance
+        // (`toABI()`/`fromABI(_:)`) as it forwards through `base` to the ABI protocol
+        // — the size-correct analogue of windows-rs's `transmute_copy` across the
+        // vtable. A value slot projects by identity, so it forwards unchanged.
+        public struct `protocol`<Element: ABIProjectable> {
             internal let base: any protocolABI<Element>
         }
 
@@ -1051,15 +1164,29 @@ struct DatabaseSQLTests {
       }
       let rendered = try shell.render("IVector`1", template: "com")
       #expect(rendered == """
-        // A WinRT parameterised interface has no static IID: its IID is a
-        // per-instantiation PIID computed at runtime from the type
-        // arguments, so no `@com(interface:)` is emitted on the ABI protocol
-        // or the generic wrapper — the runtime projection supplies it.
+        // A WinRT parameterised interface projects its generic slots through each
+        // element's associated ABI type (the windows-rs `Type::Abi` mechanism): a
+        // value slot crosses the vtable as the value itself (`Element.ABI == Element`),
+        // a reference slot as the opaque interface pointer (`Element.ABI ==
+        // UnsafeMutableRawPointer`). The ABI protocol is therefore generic over the
+        // same `ABIProjectable` parameters as the wrapper, and each requirement spells
+        // its projected slots as `<Element>.ABI` — size-correct for a value AND a
+        // reference instantiation, never a fixed-size raw-pointer cast. It has no
+        // static IID: a parameterised interface's IID is a per-instantiation PIID
+        // computed at runtime from the type arguments, so no `@com(interface:)` is
+        // emitted on the ABI protocol or the wrapper — the runtime projection supplies
+        // it.
         internal protocol IVectorABI<Element>: IInspectable {
-            associatedtype Element
+            associatedtype Element: ABIProjectable
         }
 
-        public struct IVector<Element> {
+        // The public generic wrapper keeps the typed Swift surface: each method takes
+        // and returns the decoded typed parameters, projecting between the typed value
+        // and its ABI form through the element's `ABIProjectable` conformance
+        // (`toABI()`/`fromABI(_:)`) as it forwards through `base` to the ABI protocol
+        // — the size-correct analogue of windows-rs's `transmute_copy` across the
+        // vtable. A value slot projects by identity, so it forwards unchanged.
+        public struct IVector<Element: ABIProjectable> {
             internal let base: any IVectorABI<Element>
         }
 
@@ -1067,18 +1194,61 @@ struct DatabaseSQLTests {
     }
   }
 
+  @Test func `a generic interface inheriting a keyword-named base keeps it escaped`() throws {
+    // A generic interface may inherit a NON-generic base whose name is a Swift
+    // keyword (`protocol`). It arrives through `bases` keyword-ESCAPED by
+    // `SANITIZE` as `` `protocol` `` — backticks WRAPPING the identifier, NOT a
+    // CLR arity suffix. The base rewrite must tell those escaping backticks
+    // apart from an arity backtick (a backtick before a DIGIT) and inherit the
+    // escaped name UNCHANGED (`: `protocol``), not mistake it for a generic
+    // base and emit a broken `` `protocolABI` ``. The `bases` override supplies
+    // the raw keyword; the render query's `SANITIZE` escapes it; `methods` are
+    // emptied so the output is the declaration shell.
+    try DatabaseSQLTests.withGenerics { catalog in
+      var shell = Shell(catalog)
+      let interfaces = """
+        CREATE VIEW interfaces AS
+        SELECT Id, TypeNamespace, 'IVector`1' AS TypeName,
+               '00000000-0000-0000-0000-000000000000' AS iid
+        FROM TypeDef WHERE Id = 1
+        """
+      let generics = """
+        CREATE VIEW generics AS
+        SELECT 'Element' AS Name, 0 AS Number FROM TypeDef WHERE Id = :parent
+        """
+      let methods = """
+        CREATE VIEW methods AS
+        SELECT Id, '' AS Name FROM TypeDef WHERE 0 = 1
+        """
+      let bases = """
+        CREATE VIEW bases AS
+        SELECT 'protocol' AS base FROM TypeDef WHERE Id = :parent
+        """
+      for query in [interfaces, generics, methods, bases] {
+        let (name, view) = try DatabaseSQLTests.create(query)
+        shell.session.register(name, view)
+      }
+      let rendered = try shell.render("IVector`1", template: "com")
+      #expect(rendered.contains("internal protocol IVectorABI<Element>: " +
+                                "`protocol` {"))
+      #expect(!rendered.contains("protocolABI"))
+    }
+  }
+
   @Test func `a generic wrapper forwards a blank parameter under a synthesized name`() throws {
     // The non-generic renderer allows a blank parameter name (`func Foo(_ :
-    // T)`), and the generic ABI protocol requirement keeps it blank too, but
-    // the wrapper's forwarding method must PASS every argument BY NAME in the
-    // call (`base.Foo(arg0)`) — a blank name there expands to an empty
-    // argument, dropping the argument or mangling the commas. A blank parameter
-    // therefore synthesizes a stable `arg<N>` local, used in BOTH the
-    // forwarding method's parameter list (`_ arg0: T`) and the call. This
-    // context (built as the render loop assembles one) drives the REAL bundled
-    // `com` template: the first parameter is blank (→ `arg0`), the second named
-    // (`value`, kept). The protocol requirement stays blank; only the wrapper's
-    // forwarding surface takes the synthesized names.
+    // T)`), and the projected ABI protocol requirement keeps it blank too, but the
+    // wrapper's forwarding method must PASS every argument BY NAME in the call
+    // (`base.Foo(arg0)`) — a blank name there expands to an empty argument,
+    // dropping the argument or mangling the commas. A blank parameter therefore
+    // synthesizes a stable `arg<N>` local, used in BOTH the forwarding method's
+    // parameter list (`_ arg0: …`) and the call. This context (built as the
+    // render loop assembles one) drives the REAL bundled `com` template: the
+    // first parameter is blank (→ `arg0`), the second named (`value`, kept).
+    // Both are values here (`CInt`), so their ABI and typed spellings coincide
+    // and the call passes the bare locals uncast; the protocol requirement
+    // leaves the blank parameter blank (`_ : CInt`). The point under test is
+    // the blank-name synthesis, not erasure.
     let body = try DatabaseSQLTests.template(named: "com")
     let template = try MustacheTemplate(string: body)
     let context: [String: Any] = [
@@ -1092,25 +1262,42 @@ struct DatabaseSQLTests {
         [
           "name": "Set",
           "params": [
-            ["name": "", "local": "arg0", "type": "Element", "last": false],
-            ["name": "value", "local": "value", "type": "CInt", "last": true],
+            ["name": "", "local": "arg0", "type": "CInt",
+             "typed": "CInt", "argument": "arg0", "last": false],
+            ["name": "value", "local": "value", "type": "CInt",
+             "typed": "CInt", "argument": "value", "last": true],
           ],
+          "call": "base.Set(arg0, value)",
         ],
       ],
     ]
     #expect(template.render(context) == """
-      // A WinRT parameterised interface has no static IID: its IID is a
-      // per-instantiation PIID computed at runtime from the type
-      // arguments, so no `@com(interface:)` is emitted on the ABI protocol
-      // or the generic wrapper — the runtime projection supplies it.
+      // A WinRT parameterised interface projects its generic slots through each
+      // element's associated ABI type (the windows-rs `Type::Abi` mechanism): a
+      // value slot crosses the vtable as the value itself (`Element.ABI == Element`),
+      // a reference slot as the opaque interface pointer (`Element.ABI ==
+      // UnsafeMutableRawPointer`). The ABI protocol is therefore generic over the
+      // same `ABIProjectable` parameters as the wrapper, and each requirement spells
+      // its projected slots as `<Element>.ABI` — size-correct for a value AND a
+      // reference instantiation, never a fixed-size raw-pointer cast. It has no
+      // static IID: a parameterised interface's IID is a per-instantiation PIID
+      // computed at runtime from the type arguments, so no `@com(interface:)` is
+      // emitted on the ABI protocol or the wrapper — the runtime projection supplies
+      // it.
       internal protocol IPairABI<Element> {
-          associatedtype Element
-          func Set(_ : Element, _ value: CInt)
+          associatedtype Element: ABIProjectable
+          func Set(_ : CInt, _ value: CInt)
       }
 
-      public struct IPair<Element> {
+      // The public generic wrapper keeps the typed Swift surface: each method takes
+      // and returns the decoded typed parameters, projecting between the typed value
+      // and its ABI form through the element's `ABIProjectable` conformance
+      // (`toABI()`/`fromABI(_:)`) as it forwards through `base` to the ABI protocol
+      // — the size-correct analogue of windows-rs's `transmute_copy` across the
+      // vtable. A value slot projects by identity, so it forwards unchanged.
+      public struct IPair<Element: ABIProjectable> {
           internal let base: any IPairABI<Element>
-          public func Set(_ arg0: Element, _ value: CInt) {
+          public func Set(_ arg0: CInt, _ value: CInt) {
               base.Set(arg0, value)
           }
       }
@@ -1857,10 +2044,81 @@ private enum RootInterfaceFixture {
                 wide: 0, stride: 6),
     WinMD.Table(Metadata.Tables.CustomAttribute.self, rows: 1, range: 42 ..< 48,
                 wide: 0, stride: 6),
+    // No `TypeSpec` table: the root implements nothing, so the file omits it
+    // (its `Valid` bit is clear) as a real WinMD does. The bundled `bases`
+    // view's `TypeSpec` arm still resolves — the adapter surfaces the absent
+    // table as an empty relation.
   ]
 
   private static let valid: UInt64 =
       (1 << 1) | (1 << 2) | (1 << 6) | (1 << 9) | (1 << 10) | (1 << 12)
+
+  /// Runs `body` over a `Storage` catalog bound to the assembled metadata.
+  static func with(_ body: (borrowing Storage) throws -> Void) rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+}
+
+/// A minimal WinMD whose one generic interface inherits ANOTHER generic
+/// interface, the base recorded through a `TypeSpec` GENERICINST signature —
+/// the shape the bundled `bases` view's `TypeSpec` arm resolves.
+///
+///   TypeRef[0]:  Name="IIterable`1"(1) — the generic base, arity-suffixed.
+///   TypeDef[0]:  Flags=0x21, TypeName="IVector`1"(13) — the generic interface
+///                (Id 1), the `InterfaceImpl.Class` the `bases` view binds.
+///   InterfaceImpl[0]: Class=1; Interface=TypeDefOrRef(TypeSpec row 1)=
+///                (1<<2)|2=6 — the base named through a `TypeSpec`, so neither
+///                the `Interface_TypeRef` nor `Interface_TypeDef` arm sees it.
+///   TypeSpec[0]: Signature=blob[1] — `IIterable`1<T>`, a GENERICINST over the
+///                base `TypeRef` with one type-variable argument.
+private enum GenericBaseFixture {
+  private static let bytes: Array<UInt8> = [
+    // TypeRef[0] — IIterable`1: ResolutionScope=0, Name=1, Namespace=0.
+    0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+    // TypeDef[0] — IVector`1: Flags=0x21, Name=13, Namespace=0, Extends=0,
+    // FieldList=1, MethodList=1.
+    0x21, 0x00, 0x00, 0x00, 0x0d, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x01, 0x00, 0x01, 0x00,
+    // InterfaceImpl[0] — Class=1, Interface=6 (TypeSpec row 1).
+    0x01, 0x00, 0x06, 0x00,
+    // TypeSpec[0] — Signature=blob[1].
+    0x01, 0x00,
+  ]
+
+  // "\0IIterable`1\0IVector`1\0": IIterable`1@1, IVector`1@13.
+  private static let strings: Array<UInt8> = [
+    0x00,
+    0x49, 0x49, 0x74, 0x65, 0x72, 0x61, 0x62, 0x6c, 0x65, 0x60, 0x31, 0x00,
+    0x49, 0x56, 0x65, 0x63, 0x74, 0x6f, 0x72, 0x60, 0x31, 0x00,
+  ]
+
+  // A `#Blob` heap: offset 0 the reserved empty blob; offset 1 the 6-byte
+  // `IIterable`1<T>` GENERICINST signature — GENERICINST (0x15), CLASS (0x12),
+  // the base `TypeRef[0]` coded index (0x05), argument count 1, VAR (0x13) 0 —
+  // preceded by its length 0x06.
+  private static let blob: Array<UInt8> = [
+    0x00,
+    0x06, 0x15, 0x12, 0x05, 0x01, 0x13, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 1, range: 0 ..< 6,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 1, range: 6 ..< 20,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.InterfaceImpl.self, rows: 1, range: 20 ..< 24,
+                wide: 0, stride: 4),
+    WinMD.Table(Metadata.Tables.TypeSpec.self, rows: 1, range: 24 ..< 26,
+                wide: 0, stride: 2),
+  ]
+
+  private static let valid: UInt64 =
+      (1 << 1) | (1 << 2) | (1 << 9) | (1 << 27)
 
   /// Runs `body` over a `Storage` catalog bound to the assembled metadata.
   static func with(_ body: (borrowing Storage) throws -> Void) rethrows {


### PR DESCRIPTION
The generic-interface rendering previously projected a generic ABI protocol (`protocol Name<T…>` with `associatedtype`s) plus a wrapper forwarding own methods — the shape-1 foundation, which the non-generic-closed-base wall made a dead end for base inheritance. Pivot the rendering onto the ABI-erased shape windows-rs draws, reusing the merged `SignatureType.abi(…)`/`classification` keystone:

  - The ABI protocol is now NON-generic. Each method requirement reads every parameter/return through its ABI-erased spelling: a reference-typed slot (an interface, runtime class, delegate, generic-interface instantiation, or `System.Object`) is the opaque interface pointer, a value-typed slot keeps its own ABI. No generic parameters, no associated types.

  - The public generic `struct` wrapper `Name<T…>` keeps the typed Swift surface: each method takes/returns the decoded typed parameters and casts the typed value to the erased pointer (and the erased result back) as it forwards through `base` — `unsafeBitCast`, the text analogue of windows-rs's `transmute_copy` across the vtable. A value slot needs no cast (its typed and erased spellings coincide), so it forwards unchanged.

  - Base inheritance becomes trivial and is INCLUDED: a non-generic ABI protocol inherits its base's non-generic ABI protocol by plain protocol inheritance — a generic base inherits `<stripped>ABI` (no arguments, no `where`-constraints), a non-generic base (`IInspectable`) is inherited unchanged. The non-generic-closed-base wall cannot occur.

The `Database+SQL` decode layer gains erased-ABI (`abi(return:)`/ `abi(parameter:)`) and classification (`reference(return:)`/ `reference(parameter:)`) accessors beside the existing typed `decode(…)`, all sharing the extracted signature-navigation. `Shell` composes the per-slot erased/typed spellings and the forwarding cast into the render context; the `com.mustache` `{{#generic}}` arm emits the erased protocol + casting wrapper. The non-generic `{{^generic}}` path is byte-identical.

The generated Swift is swiftc-typecheck-verified for a simple generic interface (erased/cast element return), a generic interface with a generic base (plain non-generic ABI inheritance, wrapper casts), an out/interface-array method (erased element under the pointer), and a keyword-named generic parameter.