### PR TITLE
SQL: add the COALESCE function

### DIFF
--- a/Sources/SQL/AST.swift
+++ b/Sources/SQL/AST.swift
@@ -477,6 +477,17 @@ public indirect enum Expression: Hashable, Sendable {
   /// text-to-number, an out-of-range double-to-integer, a cross-kind pair with
   /// no conversion) faults rather than yielding a wrong value.
   case cast(Expression, ValueType)
+  /// `COALESCE(v1, v2, …)` — the first argument whose value is non-NULL, else
+  /// NULL. The ISO definition is the searched `CASE WHEN v1 IS NOT NULL THEN v1
+  /// … END`, but it is a FIRST-CLASS node rather than that expansion so each
+  /// argument is evaluated EXACTLY ONCE: the desugar re-referenced each `vi` in
+  /// both its `IS NOT NULL` guard and its `THEN`, evaluating a stateful
+  /// argument twice — testing one call's value for NULL and returning a
+  /// different one. The result type is the `ValueType.unified` reduction over
+  /// the arguments (the same unification a `CASE`'s results take), to which the
+  /// selected value is coerced. At least two arguments (the parser enforces
+  /// it).
+  case coalesce(Array<Expression>)
 }
 
 /// One `WHEN predicate THEN result` branch of a `CASE` expression — the guard

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -593,6 +593,8 @@ extension Expression {
           || (otherwise?.aggregated ?? false)
     case let .cast(operand, _):
       operand.aggregated
+    case let .coalesce(arguments):
+      arguments.contains { $0.aggregated }
     }
   }
 
@@ -615,6 +617,8 @@ extension Expression {
           || (otherwise?.bound ?? false)
     case let .cast(operand, _):
       operand.bound
+    case let .coalesce(arguments):
+      arguments.contains { $0.bound }
     }
   }
 }
@@ -900,6 +904,8 @@ extension Expression {
       otherwise?.collect(into: &expressions)
     case let .cast(operand, _):
       operand.collect(into: &expressions)
+    case let .coalesce(arguments):
+      for argument in arguments { argument.collect(into: &expressions) }
     }
   }
 

--- a/Sources/SQL/Filter.swift
+++ b/Sources/SQL/Filter.swift
@@ -105,6 +105,15 @@ internal indirect enum Term: Sendable {
   /// rather than yielding a wrong one. `type` is also the term's static type —
   /// the type the schema advertises for the column.
   case cast(Term, ValueType)
+  /// `COALESCE(v1, v2, …)` — the lowered form of the AST's
+  /// `Expression.coalesce`. Each element term is evaluated IN ORDER exactly
+  /// ONCE, and the first whose value is non-NULL is the result, else NULL. A
+  /// desugar to a `CASE WHEN vi IS NOT NULL THEN vi …` re-evaluated each `vi`,
+  /// so a stateful element yielded a different value to its guard and its
+  /// result; holding the element ONCE (as `membership` holds its operand) fixes
+  /// that. `type` is the unification of the element types, to which the
+  /// selected value is COERCED — the type the schema advertises.
+  case coalesce(Array<Term>, type: ValueType)
 }
 
 extension Term {
@@ -134,6 +143,10 @@ extension Term {
       otherwise?.references(into: &slots)
     case let .cast(operand, _):
       operand.references(into: &slots)
+    case let .coalesce(elements, _):
+      for element in elements {
+        element.references(into: &slots)
+      }
     }
   }
 }
@@ -159,17 +172,20 @@ extension Term {
             }, else: otherwise?.remapped(through: slot), type: type)
     case let .cast(operand, type):
       .cast(operand.remapped(through: slot), type)
+    case let .coalesce(elements, type):
+      .coalesce(elements.map { $0.remapped(through: slot) }, type: type)
     }
   }
 
   /// Whether evaluating this term cannot throw — it is a bare slot read or a
   /// constant. A `binary` arithmetic (`/` raises on a zero divisor), an `apply`
-  /// (a scalar function may raise), or a `cast` (an unconvertible value raises)
-  /// is NOT known safe, whatever its operands.
+  /// (a scalar function may raise), a `cast` (an unconvertible value raises),
+  /// or a `coalesce` (an element may raise) is NOT known safe, whatever its
+  /// operands.
   internal var safe: Bool {
     switch self {
     case .slot, .constant: true
-    case .apply, .binary, .case, .cast: false
+    case .apply, .binary, .case, .cast, .coalesce: false
     }
   }
 
@@ -455,7 +471,31 @@ extension Row where Self: ~Escapable {
       // NULL, an unconvertible value faults (`Value.cast(to:)`), never yielding
       // a wrong value.
       try evaluate(operand, routines, bindings).cast(to: type)
+    case let .coalesce(elements, type):
+      try coalesce(elements, type, routines, bindings)
     }
+  }
+
+  /// Evaluates a lowered `COALESCE(v1, v2, …)` against this row — the
+  /// `elements` visited IN ORDER exactly ONCE, returning the first whose value
+  /// is non-NULL (coerced to the unified `type` the schema advertises), else
+  /// NULL.
+  ///
+  /// Each element is evaluated ONCE: a desugar to `CASE WHEN vi IS NOT NULL
+  /// THEN vi …` evaluated each `vi` twice — its guard and its result — so a
+  /// stateful element tested one value for NULL and returned another.
+  /// `Value.coerced` widens the selected value to `type` (a `.integer` element
+  /// of a `.double` COALESCE), exactly as a `CASE` coerces its taken branch;
+  /// NULL passes unchanged.
+  private borrowing func coalesce(_ elements: Array<Term>, _ type: ValueType,
+                                  _ routines: Routines, _ bindings: Bindings)
+      throws(SQLError) -> Value {
+    for element in elements {
+      let value = try evaluate(element, routines, bindings)
+      if case .null = value { continue }
+      return value.coerced(to: type)
+    }
+    return .null
   }
 
   /// Evaluates a lowered `CASE` — its `branches` and optional `otherwise`

--- a/Sources/SQL/Parser.swift
+++ b/Sources/SQL/Parser.swift
@@ -41,11 +41,12 @@
 /// expression     := additive
 /// additive       := multiplicative (('+' | '-') multiplicative)*
 /// multiplicative := factor (('*' | '/') factor)*
-/// factor         := '(' expression ')' | case | cast
+/// factor         := '(' expression ')' | case | cast | coalesce
 ///                 | literal | aggregate | call | column
 /// case           := CASE [expression] (WHEN (predicate | expression) THEN
 ///                     expression)+ [ELSE expression] END
 /// cast           := CAST '(' expression AS type ')'
+/// coalesce       := COALESCE '(' expression (',' expression)+ ')'
 /// literal        := string | integer | decimal | TRUE | FALSE | blob
 /// blob           := ('x' | 'X') "'" (hex hex)* "'"  // whole bytes
 /// aggregate      := COUNT '(' '*' ')'
@@ -596,6 +597,15 @@ internal struct Parser: ~Escapable {
       return try cast()
     }
 
+    // `COALESCE` is an ISO-defined expansion of a searched `CASE`, recognised
+    // case-insensitively only when written bare (a delimited `"COALESCE"` is a
+    // scalar-call name). Desugar into the first-class `Expression.coalesce`
+    // here — the `(` is consumed — so the conditional's type unification,
+    // coercion, and reachability apply unchanged.
+    if !ident.quoted, ident.text.uppercased() == "COALESCE" {
+      return try coalesce()
+    }
+
     // An aggregate is one of the fixed set of names (recognised
     // case-insensitively, only when written bare — a delimited `"COUNT"` is a
     // scalar name), distinct from a scalar call: it accumulates over a group
@@ -697,6 +707,29 @@ internal struct Parser: ~Escapable {
     let type = try type()
     try expect(.rparen)
     return .cast(operand, type)
+  }
+
+  /// Parses the argument tail of `COALESCE(v1, v2, …)` — the `(` is already
+  /// consumed — into the first-class `Expression.coalesce`.
+  ///
+  /// ISO 9075 defines `COALESCE(v1, v2, …)` as `CASE WHEN v1 IS NOT NULL THEN
+  /// v1 WHEN v2 IS NOT NULL THEN v2 … ELSE NULL END`, but that expansion
+  /// re-references each `vi` in both its guard and its `THEN`, evaluating a
+  /// stateful argument twice — so this builds the first-class node the engine
+  /// evaluates each argument ONCE for, inheriting the same type unification and
+  /// coercion the CASE would. At least two arguments are required — `COALESCE`
+  /// of one value is the value itself and carries no meaning — else
+  /// `SQLError.argument`.
+  private mutating func coalesce() throws(SQLError) -> Expression {
+    var arguments = try [expression()]
+    while try match(.comma) {
+      try arguments.append(expression())
+    }
+    try expect(.rparen)
+    guard arguments.count >= 2 else {
+      throw .argument("COALESCE requires at least two arguments")
+    }
+    return .coalesce(arguments)
   }
 
   // MARK: - Predicate

--- a/Sources/SQL/Resolve.swift
+++ b/Sources/SQL/Resolve.swift
@@ -236,6 +236,19 @@ extension Schema {
       // Lower the operand and attach the target type; the executor converts the
       // evaluated value to it (`Value.cast(to:)`).
       return try .cast(term(operand, in: relation, routines), type)
+    case let .coalesce(arguments):
+      // Lower each argument to a `Term` over this relation and hold them in a
+      // first-class `Term.coalesce` so each is evaluated ONCE. `type` is the
+      // unified argument type the selected value coerces to, derived against a
+      // one-relation scope.
+      var elements = Array<Term>()
+      elements.reserveCapacity(arguments.count)
+      for argument in arguments {
+        try elements.append(term(argument, in: relation, routines))
+      }
+      let scope = Scope([(relation, self)])
+      let type = try scope.derive(expression, routines)
+      return .coalesce(elements, type: type)
     case .aggregate:
       // An aggregate has no per-row meaning — it folds over a group — so it may
       // not appear in a `WHERE`, a join `ON`, or a non-aggregate projection.
@@ -403,6 +416,11 @@ internal struct Scope {
       // its ordinal resolution — an unknown/ambiguous column faults as a
       // projection would.
       try derive(cast: operand, to: type, routines)
+    case let .coalesce(arguments):
+      // The result type is the unification of the arguments (the same
+      // `ValueType.unified` reduction a `CASE`'s results take), the type the
+      // selected value coerces to.
+      try unified(arguments, routines)
     }
   }
 
@@ -413,6 +431,70 @@ internal struct Scope {
                       _ routines: Routines) throws(SQLError) -> ValueType {
     _ = try derive(operand, routines)
     return type
+  }
+
+  /// The unification of the types of `arguments` — the `ValueType.unified`
+  /// reduction a `CASE`'s reachable results and a `COALESCE`'s arguments both
+  /// take. A definitively-irreconcilable pair (a text beside an integer) faults
+  /// `SQLError.operand`; a mixed integer/double pair widens to `double`. The
+  /// list is never empty (the parser requires ≥ 2 COALESCE arguments).
+  ///
+  /// Only a SELECTABLE argument shapes the type. A run skips an argument
+  /// whose value is NULL and moves on, so an argument folding to a constant
+  /// `.null` (`constant(_ expression:)`) can NEVER be the result — its type is
+  /// derived (an unknown column still faults) but is NOT merged, exactly as a
+  /// `CASE` omits an unreachable branch's result type. And an argument that is
+  /// the definite selection (`selects(_:)` — a constant NON-NULL value, or a
+  /// `COUNT` aggregate that is always non-NULL) sets the type and makes every
+  /// LATER argument unreachable — mirroring a `CASE`'s reachable-branch
+  /// unification and the faulting `validate`'s stop.
+  private func unified(_ arguments: Array<Expression>,
+                       _ routines: Routines) throws(SQLError) -> ValueType {
+    var type: ValueType?
+    for argument in arguments {
+      let next = try derive(argument, routines)
+      if case .some(.null) = constant(argument, routines) {
+        // A constant NULL is derived (for its errors) but skipped: it can never
+        // be returned, so its type must not shape the column.
+        continue
+      }
+      guard !selects(argument, routines) else {
+        // A definite selection: merge its type and stop, as every later
+        // argument is unreachable.
+        return try merged(type, next)
+      }
+      type = try merged(type, next)
+    }
+    return type ?? .integer
+  }
+
+  /// Whether `argument` is a COALESCE's definite selection — an argument the
+  /// executor's short-circuit is GUARANTEED to return, making every later
+  /// argument unreachable (neither validated nor unified). That holds when it
+  /// folds to a constant NON-NULL value (`constant(_ expression:)`), or when it
+  /// is a `COUNT` aggregate: `COUNT` alone among the aggregates always yields a
+  /// row count of 0 or more, never NULL, so it always selects — while `SUM` /
+  /// `MIN` / `MAX` / `AVG` are NULL over an empty group and so do NOT stop.
+  private func selects(_ argument: Expression, _ routines: Routines) -> Bool {
+    return switch argument {
+    case .aggregate(.count, _): true
+    default: constant(argument, routines).map { $0 != .null } ?? false
+    }
+  }
+
+  /// The unification of a COALESCE's running result type with the `next`
+  /// selectable argument's type — `next` when there is no running type yet,
+  /// else their `ValueType.unified`, faulting `SQLError.operand` on an
+  /// irreconcilable pair (a text beside an integer). Shared by the `derive`
+  /// (`unified`) and `validate` (`coalesce`) surfaces so both merge only a
+  /// selectable argument's type identically.
+  private func merged(_ running: ValueType?, _ next: ValueType)
+      throws(SQLError) -> ValueType {
+    guard let running else { return next }
+    guard let unified = running.unified(with: next) else {
+      throw .operand("COALESCE arguments have irreconcilable types")
+    }
+    return unified
   }
 
   /// The nominal type of a `CASE` under `derive` — the unification of its
@@ -491,7 +573,50 @@ internal struct Scope {
       try conditional(whens, otherwise, routines)
     case let .cast(operand, type):
       try validate(cast: operand, to: type, routines)
+    case let .coalesce(arguments):
+      try coalesce(arguments, routines)
     }
+  }
+
+  /// The result type of `COALESCE(v1, v2, …)`, validating each REACHABLE
+  /// argument as a run would fault and unifying only the SELECTABLE ones'
+  /// types (`merged`). A definitively-irreconcilable pair (a text argument
+  /// beside an integer) faults `SQLError.operand`, as the column cannot be two
+  /// kinds; a mixed integer/double pair widens to `double`.
+  ///
+  /// The executor returns the first NON-NULL argument and never evaluates a
+  /// later one, so an argument that is the definite selection (`selects(_:)` —
+  /// a constant NON-NULL value, or a `COUNT` aggregate that is always non-NULL)
+  /// makes every LATER argument unreachable — those are NOT validated
+  /// (`COALESCE(1, missing_udf())` and `COALESCE(COUNT(*), missing_udf())` both
+  /// type-check), exactly as a constant-TRUE `CASE` guard makes later branches
+  /// unreachable.
+  ///
+  /// An argument that folds to a constant `.null` is validated (for its own
+  /// errors) but its type is NOT merged: a run skips a NULL and moves on, so
+  /// that argument can never be returned — merging its declared type would
+  /// reject `COALESCE(null_text(), 1)`, a text arm that can only yield the
+  /// integer, exactly as a `CASE` omits a skipped branch's result type. An
+  /// undecidable argument (`nil`) may be selected, so its type is merged and
+  /// the walk continues.
+  private func coalesce(_ arguments: Array<Expression>, _ routines: Routines)
+      throws(SQLError) -> ValueType {
+    var type: ValueType?
+    for argument in arguments {
+      let next = try validate(argument, routines)
+      if case .some(.null) = constant(argument, routines) {
+        // A constant NULL is validated (for its errors) but skipped: it can
+        // never be returned, so its type must not shape the column.
+        continue
+      }
+      guard !selects(argument, routines) else {
+        // A definite selection: merge its type and stop, as every later
+        // argument is unreachable and unvalidated.
+        return try merged(type, next)
+      }
+      type = try merged(type, next)
+    }
+    return type ?? .integer
   }
 
   /// The target `type` of a `CAST`, VALIDATING `operand` for real errors
@@ -895,6 +1020,26 @@ internal struct Scope {
       // binary fold does.
       guard let value = constant(operand, routines) else { return nil }
       return try? value.cast(to: type)
+    case let .coalesce(arguments):
+      // Fold as the run evaluates it — the first argument that folds to a
+      // non-NULL value (COERCED to the unified type, as the executor's
+      // `Term.coalesce` coerces the selected value), else NULL when every
+      // argument folds NULL. An argument the fold cannot decide (`nil`) BEFORE
+      // a decisive non-NULL one means the taken value is per row, so the whole
+      // `COALESCE` is `nil`. Coercing an `.integer` selected from a COALESCE
+      // that unifies to `.double` folds to `.double`, matching the advertised
+      // column type — so a `.double`-typed routine over `COALESCE(1, 2.5)`
+      // folds against the SAME value the run supplies. The unified type is the
+      // one `derive`/`unified` already reduces over the selectable arguments;
+      // an irreconcilable pair (which `derive` would fault on) leaves the value
+      // uncoerced (`try?` → `nil`), a no-op the executor never reaches.
+      let type = try? unified(arguments, routines)
+      for argument in arguments {
+        guard let value = constant(argument, routines) else { return nil }
+        if case .null = value { continue }
+        return type.map { value.coerced(to: $0) } ?? value
+      }
+      return .null
     case .column, .aggregate:
       return nil
     }
@@ -1073,6 +1218,8 @@ internal struct Scope {
       if let otherwise { try aggregates(in: otherwise, routines) }
     case let .cast(operand, _):
       try aggregates(in: operand, routines)
+    case let .coalesce(arguments):
+      for argument in arguments { try aggregates(in: argument, routines) }
     }
   }
 
@@ -1171,6 +1318,18 @@ internal struct Scope {
       // (the common empty-group operand) casts to NULL, an unconvertible value
       // faults as the run would.
       return try empty(operand, routines).cast(to: type)
+    case let .coalesce(arguments):
+      // Evaluate the empty group as a run does — the first argument that folds
+      // to a non-NULL value (coerced to the unified type, as the executor
+      // coerces the selected value), else NULL. A NULL argument propagates
+      // without faulting; a later one is not reached once a non-NULL is taken.
+      let type = try unified(arguments, routines)
+      for argument in arguments {
+        let value = try empty(argument, routines)
+        if case .null = value { continue }
+        return value.coerced(to: type)
+      }
+      return .null
     case .column:
       return .null
     }
@@ -1377,6 +1536,17 @@ internal struct Scope {
       // Lower the operand across the join chain and attach the target type; the
       // executor converts the evaluated value to it (`Value.cast(to:)`).
       return try .cast(term(operand, routines), type)
+    case let .coalesce(arguments):
+      // Lower each argument to a combined-ordinal `Term` and hold them in a
+      // first-class `Term.coalesce` so each is evaluated ONCE; `type` is the
+      // unified argument type the selected value coerces to.
+      var elements = Array<Term>()
+      elements.reserveCapacity(arguments.count)
+      for argument in arguments {
+        try elements.append(term(argument, routines))
+      }
+      let type = try derive(expression, routines)
+      return .coalesce(elements, type: type)
     case .aggregate:
       // An aggregate has no per-row meaning — it folds over a group — so it may
       // not appear in a `WHERE`, a join `ON`, or a non-aggregate projection.
@@ -1585,6 +1755,17 @@ internal struct Grouping {
       // Lower the operand against the grouped slot space and attach the target
       // type; the executor converts the evaluated value to it.
       return try .cast(term(operand, routines), type)
+    case let .coalesce(arguments):
+      // Lower each argument to a grouped-space `Term` and hold them in a
+      // first-class `Term.coalesce` so each is evaluated ONCE; `type` is the
+      // unified argument type (over the grouped scope) the value coerces to.
+      var elements = Array<Term>()
+      elements.reserveCapacity(arguments.count)
+      for argument in arguments {
+        try elements.append(term(argument, routines))
+      }
+      let type = try scope.derive(expression, routines)
+      return .coalesce(elements, type: type)
     case .aggregate:
       // An aggregate reaches here only when it was not collected — an internal
       // inconsistency, since the query gathers every projection/HAVING aggregate.

--- a/Tests/SQLTests/CoalesceTests.swift
+++ b/Tests/SQLTests/CoalesceTests.swift
@@ -1,0 +1,392 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQL
+
+import SQLTestSupport
+
+// MARK: - Fixture
+
+/// A relation exercising `COALESCE`: a nullable integer `K` and a text `Name`,
+/// so a NULL fallthrough and a type unification are reachable.
+private func things() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["Id": .integer, "K": .integer, "Name": .text]) {
+      Row(1, 10, "a")
+      Row(2, nil, "b")
+    }
+  }
+}
+
+/// Parses `text` and returns its `Select`, failing on any other shape.
+private func parse(select text: String) throws -> Select {
+  guard case let .select(.select(select)) = try Statement(parsing: text) else {
+    Issue.record("expected a single SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return select
+}
+
+/// The single output column type of a one-column query's schema.
+private func type(of text: String, _ routines: Routines = [:])
+    throws -> ValueType {
+  guard case let .select(query) = try Statement(parsing: text) else {
+    Issue.record("expected a SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  let columns = try things().columns(of: query, routines: routines)
+  #expect(columns.count == 1)
+  return columns[0].type
+}
+
+// MARK: - COALESCE
+
+struct CoalesceTests {
+  @Test func `COALESCE parses to a first-class node`() throws {
+    // `COALESCE(K, 0)` is a first-class `Expression.coalesce` holding each
+    // argument ONCE — not the re-referencing `CASE` its ISO definition names.
+    let select = try parse(select: "SELECT COALESCE(K, 0) FROM T")
+    let expression = Expression.coalesce([.column("K"),
+                                          .literal(.integer(0))])
+    #expect(select.projection
+                == .expressions([Projected(expression: expression)]))
+  }
+
+  @Test func `takes the first non-NULL argument`() throws {
+    try things().expect("SELECT COALESCE(K, K, 3) FROM T WHERE K IS NULL",
+                        yields: [[3]])
+  }
+
+  @Test func `an earlier non-NULL argument wins`() throws {
+    try things().expect("SELECT COALESCE(K, 99) FROM T WHERE Id = 1",
+                        yields: [[10]])
+  }
+
+  @Test func `all-NULL arguments yield NULL`() throws {
+    try things().expect("SELECT COALESCE(K, K) FROM T WHERE K IS NULL",
+                        yields: [[nil]])
+  }
+
+  @Test func `mixed integer and double arguments widen to double`() throws {
+    // The arguments unify like a CASE's results — the integer widens.
+    #expect(try type(of: "SELECT COALESCE(K, 2.5) AS C FROM T") == .double)
+    try things().expect("SELECT COALESCE(K, 2.5) FROM T",
+                        yields: [[10.0], [2.5]])
+  }
+
+  @Test func `rejects a single argument`() {
+    #expect(throws: SQLError.self) {
+      _ = try Statement(parsing: "SELECT COALESCE(K) FROM T")
+    }
+  }
+
+  @Test func `irreconcilable argument types fault`() throws {
+    // An integer argument beside a text one cannot yield one column type.
+    guard case let .select(query) =
+        try Statement(parsing: "SELECT COALESCE(K, Name) FROM T") else {
+      Issue.record("expected a SELECT statement")
+      return
+    }
+    #expect(throws:
+        SQLError.operand("COALESCE arguments have irreconcilable types")) {
+      _ = try things().columns(of: query)
+    }
+  }
+}
+
+// MARK: - Argument reachability
+
+/// Parses `text` to a `Query`, failing on any other shape.
+private func query(_ text: String) throws -> Query {
+  guard case let .select(query) = try Statement(parsing: text) else {
+    Issue.record("expected a SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return query
+}
+
+struct CoalesceReachabilityTests {
+  @Test func `a constant non-NULL prefix leaves a later argument unreachable`()
+      throws {
+    // The executor returns the constant `1` and never evaluates
+    // `missing_udf()` — an unregistered routine a run would fault `.function`
+    // on — so the typecheck, mirroring that short-circuit, must NOT validate
+    // the unreachable call. `columns(of:)` succeeds and the run yields the `1`.
+    let text = "SELECT COALESCE(1, missing_udf()) FROM T"
+    _ = try things().columns(of: query(text))
+    try things().expect(text, yields: [[1], [1]])
+  }
+
+  @Test func `a constant non-NULL prefix determines the column type`() throws {
+    // The reachable prefix (the constant `1`) shapes the column — an integer —
+    // exactly as a constant-TRUE CASE guard's branch does; the unreachable text
+    // argument does not unify into it.
+    #expect(try type(of: "SELECT COALESCE(1, missing_udf()) AS C FROM T")
+                == .integer)
+  }
+
+  @Test func `a bad operand after a constant prefix is unreachable`() throws {
+    // `Name + 1` over the text `Name` would fault `.operand` if reached, but
+    // the constant `1` selects first, so it is unreachable and not validated.
+    _ = try things().columns(of: query("SELECT COALESCE(1, Name + 1) FROM T"))
+  }
+
+  @Test func `a constant NULL prefix does NOT stop validation`() throws {
+    // COALESCE steps PAST a NULL argument, so a later one is reachable and MUST
+    // be validated. `NULL` is not an expression literal (it is UNKNOWN, spelled
+    // only in `IS NULL`), so a DETERMINISTIC routine folding to `.null` stands
+    // in for the constant-NULL prefix: `missing_udf()` after it still faults
+    // `.function`.
+    let routines = try Routines()
+        .registering("nought", returns: .integer, deterministic: true) { _ in
+          .null
+        }
+    #expect(throws: SQLError.function("missing_udf")) {
+      _ = try things().columns(of:
+          query("SELECT COALESCE(nought(), missing_udf()) FROM T"),
+          routines: routines)
+    }
+  }
+
+  @Test func `a non-constant prefix does NOT stop validation`() throws {
+    // A row-dependent argument (`K`, a nullable integer) is not a definite
+    // selection — the run may fall through it — so a later argument is
+    // reachable and validated: `missing_udf()` after `K` still faults
+    // `.function` (both integer-typed, so the fault is the unknown call, not a
+    // type clash).
+    #expect(throws: SQLError.function("missing_udf")) {
+      _ = try things().columns(of:
+          query("SELECT COALESCE(K, missing_udf()) FROM T"))
+    }
+  }
+
+  @Test func `a constant NULL prefix does NOT shape the type`() throws {
+    // A run skips a NULL argument and moves on, so an argument that folds to a
+    // constant `.null` can never be returned — its DECLARED type must not unify
+    // into the column, exactly as a `CASE` omits a skipped branch's result
+    // type. `null_text()` is a DETERMINISTIC routine declaring `.text` yet
+    // folding to `.null`, so `COALESCE(null_text(), 1)` can only ever yield the
+    // integer `1`: merging the `.text` would clash with the `.integer` and
+    // reject the query, so the constant-NULL arm's type is skipped. It
+    // type-checks, runs to `1`, and the column derives `.integer`.
+    let routines = try Routines()
+        .registering("null_text", returns: .text, deterministic: true) { _ in
+          .null
+        }
+    let text = "SELECT COALESCE(null_text(), 1) FROM T"
+    _ = try things().columns(of: query(text), routines: routines)
+    #expect(try type(of: text, routines) == .integer)
+    try things().expect(text, yields: [[1], [1]], routines: routines)
+  }
+
+  @Test func `a COUNT prefix leaves a later argument unreachable`() throws {
+    // `COUNT(*)` is always non-NULL (a row count of 0 or more), so it is the
+    // definite selection — the executor returns it and never evaluates the
+    // later `missing_udf()`, an unregistered routine a run would fault
+    // `.function` on. The typecheck, mirroring that short-circuit, must NOT
+    // validate the unreachable call. `columns(of:)` succeeds over the
+    // whole-result group and the run yields the count (2).
+    let text = "SELECT COALESCE(COUNT(*), missing_udf()) FROM T"
+    _ = try things().columns(of: query(text))
+    try things().expect(text, yields: [[2]])
+  }
+
+  @Test func `a COUNT prefix determines the column type`() throws {
+    // The reachable prefix (`COUNT(*)`) shapes the column — an integer — and
+    // the unreachable later argument does not unify into it.
+    #expect(try type(of: "SELECT COALESCE(COUNT(*), missing_udf()) AS C FROM T")
+                == .integer)
+  }
+
+  @Test func `a SUM prefix does NOT stop validation`() throws {
+    // Unlike COUNT, SUM is NULL over an empty group, so it is NOT a definite
+    // selection — the run may fall through it — and a later argument stays
+    // reachable and MUST be validated: `missing_udf()` after `SUM(K)` still
+    // faults `.function`.
+    #expect(throws: SQLError.function("missing_udf")) {
+      _ = try things().columns(of:
+          query("SELECT COALESCE(SUM(K), missing_udf()) FROM T"))
+    }
+  }
+
+  @Test func `a SUM prefix falls back to a reachable later argument`() throws {
+    // The CONTROL for the COUNT stop: `COALESCE(SUM(x), 0)` still validates and
+    // derives the later `0` (SUM is nullable, not a stop), unifying to
+    // `.integer`, and runs — SUM over the two-row group is the sum of K.
+    let text = "SELECT COALESCE(SUM(K), 0) FROM T"
+    #expect(try type(of: text) == .integer)
+    try things().expect(text, yields: [[10]])
+  }
+}
+
+// MARK: - Constant folding
+
+/// A deterministic native routine reporting whether its single argument is a
+/// `.double` — 1 when it is, else 0. It DISTINGUISHES `.double(1.0)` from
+/// `.integer(1)`, so the constant fold's coercion of a COALESCE's selected
+/// value is OBSERVABLE through it. Its declared parameter `type` matches the
+/// COALESCE's derived type so the static arity/type check (which demands an
+/// exact match) passes.
+private func doubling(taking type: ValueType) throws -> Routines {
+  try Routines()
+      .registering("is_double", returns: .integer, parameters: [type],
+                   deterministic: true) { arguments in
+        if case .double = arguments[0] { return .integer(1) }
+        return .integer(0)
+      }
+}
+
+/// An `is_double(<coalesce>) = 1` reachability predicate — TRUE only when the
+/// COALESCE's constant fold reports its selected value as a `.double`.
+private func predicate(over coalesce: Expression) -> Predicate {
+  .comparison(left: .call(name: "is_double", arguments: [coalesce]),
+              op: .equal, right: .literal(.integer(1)))
+}
+
+/// The schema validator folds a ROW-INDEPENDENT `COALESCE` (via
+/// `constant(_ expression:)`) to decide a `WHERE` arm's reachability, so its
+/// selected value must carry the SAME type the run's `Term.coalesce` supplies —
+/// the unified type `derive` advertises — or the fold sees a value the run
+/// never produces. The fold coerces the selected value to that unified type,
+/// mirroring the executor (`Value.coerced`) and the sibling empty-group fold.
+///
+/// This engine types a COALESCE by its REACHABLE prefix: a constant non-NULL
+/// argument is the definite selection, so it both sets the unified type and is
+/// the folded value — the coercion is therefore the identity on the constant
+/// path, but it keeps the fold pinned to the advertised type rather than a raw
+/// selected value, matching the run exactly.
+struct CoalesceConstantTests {
+  @Test func `a mixed COALESCE folds to its selected reachable value`() throws {
+    // `COALESCE(1, 2.5)` selects the constant `1` — the definite selection that
+    // makes `2.5` unreachable — so it types as `.integer` and the fold yields
+    // `.integer(1)`, exactly as the run's `Term.coalesce` does over the same
+    // `.integer` lowered type: `is_double` reports FALSE, so the predicate
+    // folds definitely FALSE.
+    let coalesce = Expression.coalesce([.literal(.integer(1)),
+                                        .literal(.double(2.5))])
+    let folded = Scope([]).constant(predicate(over: coalesce),
+                                    try doubling(taking: .integer))
+    #expect(folded == false)
+  }
+
+  @Test func `an all-integer COALESCE is not coerced`() throws {
+    // `COALESCE(1, 2)` unifies to `.integer`, so the selected `1` stays
+    // `.integer(1)`: no spurious coercion to `.double`. `is_double` reports
+    // FALSE, so the predicate folds definitely FALSE.
+    let coalesce = Expression.coalesce([.literal(.integer(1)),
+                                        .literal(.integer(2))])
+    let folded = Scope([]).constant(predicate(over: coalesce),
+                                    try doubling(taking: .integer))
+    #expect(folded == false)
+  }
+
+  @Test func `the constant fold matches the run`() throws {
+    // The fold and the run must yield the SAME value for a ROW-INDEPENDENT
+    // COALESCE. Selecting a `.double` constant yields `.double`; selecting an
+    // integer constant past a NULL-folding double routine yields `.integer`
+    // (the reachable prefix types it), each coerced to the derived type the run
+    // lowers — so `is_double` agrees with the run over the folded value.
+    let nulldouble = try Routines()
+        .registering("null_double", returns: .double, deterministic: true) {
+          _ in .null
+        }
+    // Selects the `.double` constant: fold is `.double(2.5)`.
+    let picksDouble = Expression.coalesce([.literal(.double(2.5)),
+                                           .literal(.integer(1))])
+    #expect(Scope([]).constant(predicate(over: picksDouble),
+                               try doubling(taking: .double)) == true)
+    // NULL double prefix skipped, integer `1` selected: fold is `.integer(1)`.
+    let picksInteger =
+        Expression.coalesce([.call(name: "null_double", arguments: []),
+                             .literal(.integer(1))])
+    #expect(Scope([]).constant(predicate(over: picksInteger),
+                               try doubling(taking: .integer)
+                                   .merging(nulldouble)) == false)
+  }
+}
+
+// MARK: - Typecheck agrees with the run
+
+/// The `WHERE` reachability fold and the run must AGREE on a ROW-INDEPENDENT
+/// `COALESCE`: an arm the run reaches must be type-checked, so the COALESCE's
+/// coerced fold value cannot let validation skip a projection execution runs —
+/// mirroring the CASE-coercion end-to-end shape.
+struct CoalesceTypecheckTests {
+  @Test func `a reachable projection is type-checked`() throws {
+    // `WHERE is_double(COALESCE(2.5, 1)) = 1 AND …` — the COALESCE selects the
+    // `.double` constant, so `is_double` reports 1 and the guard folds TRUE:
+    // the AND's right arm is reachable, so the projection's `Name + 1` (text
+    // arithmetic) is validated and faults, exactly as the run reaches it.
+    let text = """
+        SELECT Name + 1 AS C FROM T
+          WHERE is_double(COALESCE(2.5, 1)) = 1 AND Id = 1
+        """
+    #expect(throws: SQLError.operand("operands must be numeric")) {
+      _ = try things().columns(of: query(text),
+                               routines: doubling(taking: .double))
+    }
+  }
+
+  @Test func `an unreachable projection is skipped`() throws {
+    // The CONTROL: `COALESCE(1, 2)` folds to the integer `1`, so `is_double`
+    // reports 0 and `= 1` folds FALSE — the AND's right arm is unreachable and
+    // its `Name + 1` is NOT validated, so the query type-checks. (The run
+    // likewise never reaches it.)
+    let text = """
+        SELECT Name + 1 AS C FROM T
+          WHERE is_double(COALESCE(1, 2)) = 1 AND Id = 1
+        """
+    let columns = try things().columns(of: query(text),
+                                       routines: doubling(taking: .integer))
+    #expect(columns.count == 1)
+  }
+}
+
+// MARK: - Operand evaluated once
+
+/// A shared call counter a stateful routine increments — a tiny
+/// `@unchecked Sendable` box over a mutable count, so the non-deterministic
+/// `stepper()` routine registered against it both observes successive values
+/// and records how many times the run invoked it. The engine evaluates a row's
+/// projection synchronously on one thread, so the box needs no lock.
+private final class Counter: @unchecked Sendable {
+  /// The number of times `next()` has been called.
+  private(set) var count = 0
+
+  /// Increments the count and returns the PREVIOUS value — the sequence `0, 1,
+  /// 2, …` across successive calls.
+  func next() -> Int {
+    defer { count += 1 }
+    return count
+  }
+}
+
+struct CoalesceOperandTests {
+  /// A single-row table, so a per-row operand runs once for the one row.
+  private func one() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["Id": .integer]) {
+        Row(1)
+      }
+    }
+  }
+
+  @Test func `each COALESCE argument is evaluated once`() throws {
+    // `stepper()` yields 0, then 1, 2, …; it is NON-deterministic so the engine
+    // cannot fold it. `COALESCE(stepper(), 99)` must evaluate `stepper()`
+    // EXACTLY ONCE — yielding 0, a non-NULL value it returns. The old CASE
+    // desugar re-referenced the argument in both its `IS NOT NULL` guard and
+    // its `THEN`, calling `stepper()` twice: the guard saw 0 (non-NULL) and the
+    // THEN returned a DIFFERENT 1. The first-class node holds the argument, so
+    // the counter reads exactly 1 and the value returned is the one tested.
+    let counter = Counter()
+    let routines = try Routines()
+        .registering("stepper", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+    try one().expect("SELECT COALESCE(stepper(), 99) FROM T", yields: [[0]],
+                     routines: routines)
+    #expect(counter.count == 1)
+  }
+}


### PR DESCRIPTION
Add the ISO `COALESCE(v1, v2, …)` — the first argument whose value is non-NULL, else NULL — as a first-class `Expression.coalesce` lowered to `Term.coalesce`, rather than the searched-CASE expansion its definition names. Each argument is evaluated EXACTLY ONCE (the desugar re-referenced each `vi` in both its `IS NOT NULL` guard and its `THEN`), and the selected value is coerced to the `ValueType.unified` reduction over the arguments — the type the schema advertises.

Typing follows the executor's short-circuit: a constant NON-NULL argument (or a COUNT aggregate, which is never NULL) is the definite selection and leaves every later argument unreachable — neither validated nor unified — while a constant NULL argument is validated for its own errors but skipped when shaping the type, so `COALESCE(null_text(), 1)` types as the integer. The constant fold and the empty-group evaluator mirror the run over the same coerced value.