### PR TITLE
SQL: add the || concatenation operator

### DIFF
--- a/Sources/SQL/AST.swift
+++ b/Sources/SQL/AST.swift
@@ -545,11 +545,13 @@ public enum Aggregand: Hashable, Sendable {
   case expression(Expression)
 }
 
-/// A binary arithmetic operator.
+/// A binary operator over two scalar operands.
 ///
-/// The four standard operators over integers; `*` `/` bind tighter than `+`
-/// `-`, and all four are left-associative — the precedence the parser's
-/// climbing grammar encodes and parentheses override.
+/// The four standard arithmetic operators over numbers, and the ISO `||`
+/// string concatenation. `*` `/` bind tighter than `+` `-` `||`, and every
+/// operator is left-associative — the precedence the parser's climbing grammar
+/// encodes and parentheses override. The four arithmetic operators require
+/// numeric operands; `||` requires text operands. All propagate NULL.
 public enum Arithmetic: Hashable, Sendable {
   /// `+`
   case add
@@ -559,6 +561,10 @@ public enum Arithmetic: Hashable, Sendable {
   case multiply
   /// `/` — integer division.
   case divide
+  /// `||` — text concatenation. It joins two text operands into one text value
+  /// and propagates NULL (a NULL operand yields NULL); a non-text operand is a
+  /// `SQLError.operand` type error, as arithmetic faults on a non-numeric one.
+  case concatenate
 }
 
 /// A row filter — a tree of comparisons composed with `AND`, `OR`, and `NOT`.

--- a/Sources/SQL/Filter.swift
+++ b/Sources/SQL/Filter.swift
@@ -581,18 +581,26 @@ extension Row where Self: ~Escapable {
 extension Arithmetic {
   /// Applies the operator to two typed operands, yielding a typed `Value`.
   ///
-  /// The operands must be numeric — integer or double. An `integer ∘ integer`
-  /// stays an integer, with `/` integer division; any double operand makes the
-  /// result a double (a lone integer promoted to `Double`), with `/` real
-  /// division. A NULL on either side propagates — the result is NULL, not a
-  /// fault. A division by zero is `SQLError.divide`, as standard SQL raises
-  /// rather than yielding a value (`inf`/`NaN`), on either an integer or a
-  /// double divisor; a non-numeric (text/boolean/blob) operand is a
+  /// A `||` concatenates two text operands into one text value; the four
+  /// arithmetic operators require numeric operands — integer or double. An
+  /// `integer ∘ integer` stays an integer, with `/` integer division; any
+  /// double operand makes the result a double (a lone integer promoted to
+  /// `Double`), with `/` real division. A NULL on either side propagates — the
+  /// result is NULL, not a fault. A division by zero is `SQLError.divide`, as
+  /// standard SQL raises rather than yielding a value (`inf`/`NaN`), on either
+  /// an integer or a double divisor; an operand of the wrong kind (a
+  /// non-numeric arithmetic operand, or a non-text `||` operand) is a
   /// `SQLError.operand` type error rather than a silent coercion; an integer
   /// result past the `Int` boundary is `SQLError.magnitude`.
   internal func apply(_ lhs: Value, _ rhs: Value) throws(SQLError) -> Value {
     if case .null = lhs { return .null }
     if case .null = rhs { return .null }
+    if case .concatenate = self {
+      guard case let .text(lhs) = lhs, case let .text(rhs) = rhs else {
+        throw .operand("|| operands must be text")
+      }
+      return .text(lhs + rhs)
+    }
     return switch (lhs, rhs) {
     case let (.integer(lhs), .integer(rhs)):
       try apply(lhs, rhs)
@@ -622,6 +630,10 @@ extension Arithmetic {
     case .multiply: lhs.multipliedReportingOverflow(by: rhs)
     case .divide where rhs == 0: throw .divide
     case .divide: lhs.dividedReportingOverflow(by: rhs)
+    // `||` never reaches the numeric path — the public `apply` handles it over
+    // text before dispatching a numeric pair here — so a concatenate over two
+    // integers is an unreachable operand fault.
+    case .concatenate: throw .operand("|| operands must be text")
     }
     guard !outcome.overflow else { throw .magnitude("integer overflow") }
     return .integer(outcome.partialValue)
@@ -644,6 +656,9 @@ extension Arithmetic {
     case .multiply: lhs * rhs
     case .divide where rhs == 0: throw .divide
     case .divide: lhs / rhs
+    // `||` never reaches the numeric path — the public `apply` handles it over
+    // text — so a concatenate over two doubles is an unreachable operand fault.
+    case .concatenate: throw .operand("|| operands must be text")
     }
     guard result.isFinite else {
       throw .magnitude("double result is not finite")

--- a/Sources/SQL/Lexer.swift
+++ b/Sources/SQL/Lexer.swift
@@ -109,6 +109,17 @@ internal struct Lexer: ~Escapable {
     case UInt8(ascii: "="):
       return punctuation(.equal)
 
+    // The `||` concatenation operator: two `|` bytes. A lone `|` begins no
+    // token in this dialect, so a single `|` faults where it sits.
+    case UInt8(ascii: "|"):
+      let start = location
+      advance()
+      guard peek() == UInt8(ascii: "|") else {
+        throw .character("|", at: start)
+      }
+      advance()
+      return Token(kind: .concat, location: start)
+
     case UInt8(ascii: "<"):
       let start = location
       advance()

--- a/Sources/SQL/Parser.swift
+++ b/Sources/SQL/Parser.swift
@@ -39,7 +39,7 @@
 ///                 | [NOT] IN '(' expression (',' expression)* ')'
 ///                 | [NOT] LIKE expression [ESCAPE expression])
 /// expression     := additive
-/// additive       := multiplicative (('+' | '-') multiplicative)*
+/// additive       := multiplicative (('+' | '-' | '||') multiplicative)*
 /// multiplicative := factor (('*' | '/') factor)*
 /// factor         := '(' expression ')' | case | cast | coalesce | nullif
 ///                 | literal | aggregate | call | column
@@ -60,9 +60,10 @@
 /// identifier     := word | '"' … '"'  // a delimited identifier is verbatim
 /// ```
 ///
-/// Arithmetic precedence is `*` `/` > `+` `-`, both levels left-associative; the
-/// cascade of `additive`/`multiplicative` encodes it, and parentheses override
-/// it through `factor`.
+/// Arithmetic precedence is `*` `/` > `+` `-` `||`, both levels
+/// left-associative; the cascade of `additive`/`multiplicative` encodes it (the
+/// `||` string concatenation sharing the additive tier), and parentheses
+/// override it through `factor`.
 ///
 /// A `column` is a single identifier token; a qualifying dot (`t.Name`) is part
 /// of the identifier the lexer scans, so `Column(_:)` splits it into qualifier
@@ -509,7 +510,12 @@ internal struct Parser: ~Escapable {
     try additive()
   }
 
-  /// Parses `multiplicative (('+' | '-') multiplicative)*`, left-associative.
+  /// Parses `multiplicative (('+' | '-' | '||') multiplicative)*`,
+  /// left-associative.
+  ///
+  /// The ISO `||` string concatenation shares this additive precedence tier and
+  /// left-associativity, so `a || b || c` reads left to right and `a + b || c`
+  /// groups `(a + b) || c` — both binding looser than `*`/`/`.
   private mutating func additive() throws(SQLError) -> Expression {
     var lhs = try multiplicative()
     while true {
@@ -517,6 +523,8 @@ internal struct Parser: ~Escapable {
         .add
       } else if try match(.minus) {
         .subtract
+      } else if try match(.concat) {
+        .concatenate
       } else {
         nil
       }

--- a/Sources/SQL/Resolve.swift
+++ b/Sources/SQL/Resolve.swift
@@ -400,6 +400,11 @@ internal struct Scope {
         case let .expression(argument): try derive(argument, routines)
         }
       }
+    case let .binary(.concatenate, lhs, rhs):
+      // `||` yields text; the operands' own types do not shape it, but derive
+      // both for resolution — an unresolved column faults `SQLError.column`
+      // (`Missing || 'x'`) — exactly as the arithmetic `.binary` branch does.
+      try concatenation(lhs, rhs, routines)
     case let .binary(_, lhs, rhs):
       try [derive(lhs, routines), derive(rhs, routines)].contains(.double)
           ? .double : .integer
@@ -448,6 +453,18 @@ internal struct Scope {
     let type = try derive(lhs, routines)
     _ = try derive(rhs, routines)
     return type
+  }
+
+  /// The `.text` type of `lhs || rhs`, deriving both operands for resolution
+  /// first: the result is always text and the operands' own types do not shape
+  /// it, but an unresolved column still faults `SQLError.column`, mirroring the
+  /// arithmetic `.binary` derive branch.
+  private func concatenation(_ lhs: Expression, _ rhs: Expression,
+                             _ routines: Routines)
+      throws(SQLError) -> ValueType {
+    _ = try derive(lhs, routines)
+    _ = try derive(rhs, routines)
+    return .text
   }
 
   /// The target `type` of a `CAST`, deriving `operand` for its ordinal
@@ -822,10 +839,12 @@ internal struct Scope {
     }
   }
 
-  /// The result type of `lhs op rhs` — a double when either operand is a double
-  /// (`Age + 1.5`), else an integer — validating both operands are numeric (a
-  /// text/boolean/blob operand has no arithmetic — `Arithmetic.apply` faults
-  /// `SQLError.operand`); a `/` by a literal zero is rejected up front
+  /// The result type of `lhs op rhs` — a double when either arithmetic operand
+  /// is a double (`Age + 1.5`), an integer for two integer operands, and text
+  /// for `||` — validating each operand's kind as a run would fault: an
+  /// arithmetic operator over a text/boolean/blob operand has no arithmetic and
+  /// `||` over a non-text operand has no concatenation (`Arithmetic.apply`
+  /// faults `SQLError.operand`); a `/` by a literal zero is rejected up front
   /// (`SQLError.divide`); and two literal operands are folded to reject a
   /// deterministic overflow (`SQLError.magnitude`). Typing thus faults as a run
   /// would rather than advertise a header no row can produce.
@@ -835,6 +854,20 @@ internal struct Scope {
       throws(SQLError) -> ValueType {
     let left = try validate(lhs, routines)
     let right = try validate(rhs, routines)
+    if case .concatenate = op {
+      // Both operands are validated above for their OWN errors. `||` yields
+      // text and needs two text operands — UNLESS one folds to a static NULL,
+      // in which case `Arithmetic.apply` returns NULL BEFORE it inspects EITHER
+      // kind, so the whole expression yields NULL and runs whatever the other
+      // operand's type (as the CAST path admits a folded NULL to any target):
+      // `(CASE WHEN 1 = 0 THEN 1 END) || 1` runs. A non-text, non-NULL pairing
+      // faults exactly as the run does.
+      guard left == .text && right == .text
+              || vanishing(lhs, routines) || vanishing(rhs, routines) else {
+        throw .operand("|| operands must be text")
+      }
+      return .text
+    }
     guard left.numeric, right.numeric else {
       throw .operand("operands must be numeric")
     }
@@ -849,6 +882,17 @@ internal struct Scope {
       _ = try op.apply(value(of: lhs), value(of: rhs))
     }
     return left == .double || right == .double ? .double : .integer
+  }
+
+  /// Whether `expression` folds to a static NULL — a row-independent constant
+  /// NULL. A `||` with a vanishing operand yields NULL before its
+  /// `Arithmetic.apply` inspects EITHER operand's kind, so the whole expression
+  /// is valid whatever the other operand's type, mirroring the CAST validation
+  /// path that admits a folded NULL to any target — so a no-match `CASE` typed
+  /// `.integer` that yields NULL lets `(CASE WHEN 1 = 0 THEN 1 END) || 1` run.
+  private func vanishing(_ expression: Expression, _ routines: Routines)
+      -> Bool {
+    if case .null? = constant(expression, routines) { true } else { false }
   }
 
   /// Whether `expression` is a literal zero — the statically-known divisor a

--- a/Sources/SQL/Token.swift
+++ b/Sources/SQL/Token.swift
@@ -88,6 +88,8 @@ extension Token {
     case plus
     case minus
     case slash
+    /// The `||` string-concatenation operator.
+    case concat
     case comma
     case lparen
     case rparen
@@ -164,6 +166,7 @@ extension Token.Kind {
     case .plus: "+"
     case .minus: "-"
     case .slash: "/"
+    case .concat: "||"
     case .comma: ","
     case .lparen: "("
     case .rparen: ")"

--- a/Tests/SQLTests/ConcatTests.swift
+++ b/Tests/SQLTests/ConcatTests.swift
@@ -1,0 +1,156 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQL
+
+import SQLTestSupport
+
+// MARK: - Fixture
+
+/// A relation exercising the `||` concatenation operator: two text columns and
+/// one that is `NULL` in a row, so the NULL-propagation corner is reachable.
+private func things() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["Id": .integer, "A": .text, "B": .text]) {
+      Row(1, "a", "b")
+      Row(2, "c", nil)
+    }
+  }
+}
+
+/// Parses `text` and returns its `Select`, failing on any other shape.
+private func parse(select text: String) throws -> Select {
+  guard case let .select(.select(select)) = try Statement(parsing: text) else {
+    Issue.record("expected a single SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return select
+}
+
+// MARK: - Parsing
+
+struct ConcatParsingTests {
+  @Test func `parses a concatenation`() throws {
+    let select = try parse(select: "SELECT A || B FROM T")
+    let concat = Expression.binary(.concatenate, .column("A"),
+                                   .column("B"))
+    #expect(select.projection
+                == .expressions([Projected(expression: concat)]))
+  }
+
+  @Test func `concatenation is left-associative`() throws {
+    // `a || b || c` reads `(a || b) || c`.
+    let select = try parse(select: "SELECT 'a' || 'b' || 'c'")
+    let inner = Expression.binary(.concatenate, .literal(.string("a")),
+                                  .literal(.string("b")))
+    let outer = Expression.binary(.concatenate, inner,
+                                  .literal(.string("c")))
+    #expect(select.projection
+                == .expressions([Projected(expression: outer)]))
+  }
+}
+
+// MARK: - Evaluation
+
+struct ConcatEvaluationTests {
+  @Test func `concatenates two text values`() throws {
+    try things().expect("SELECT 'a' || 'b'", yields: [["ab"]])
+  }
+
+  @Test func `a NULL right operand propagates NULL`() throws {
+    // Row 2's Last is NULL, so `First || Last` is NULL.
+    try things().expect("SELECT A || B FROM T WHERE Id = 2",
+                        yields: [[nil]])
+  }
+
+  @Test func `a NULL left operand propagates NULL`() throws {
+    // Row 2's Last is NULL on the left this time.
+    try things().expect("SELECT B || A FROM T WHERE Id = 2",
+                        yields: [[nil]])
+  }
+
+  @Test func `concatenates over columns in a projection`() throws {
+    // Row 1 joins "a" and "b"; row 2's Last is NULL, so the result is NULL.
+    try things().expect("SELECT A || B FROM T",
+                        yields: [["ab"], [nil]])
+  }
+
+  @Test func `a non-text operand faults`() throws {
+    // `||` is a character-string operator; a numeric operand is a type error,
+    // as arithmetic faults on a non-numeric one.
+    try things().expect("SELECT 'a' || 1", fails:
+        .operand("|| operands must be text"))
+  }
+
+  @Test func `a statically-NULL operand concatenates as NULL`() throws {
+    // `CASE WHEN 1 = 0 THEN 1 END` yields NULL yet derives `.integer` (the
+    // no-branch schema default). `||` returns NULL for a NULL operand BEFORE
+    // it inspects kinds, so this VALIDATES — the output-schema text guard
+    // admits the folded NULL rather than rejecting the `.integer` type — and
+    // runs, yielding NULL; the caller need not fall back to a CASE desugar.
+    try things().expect("SELECT (CASE WHEN 1 = 0 THEN 1 END) || 'x'",
+                        yields: [[nil]])
+  }
+
+  @Test func `a folded-NULL side admits a non-text other operand`() throws {
+    // `Arithmetic.apply` returns NULL before inspecting EITHER kind, so a
+    // statically-NULL side makes the whole `||` valid regardless of the OTHER
+    // operand's type: `(CASE WHEN 1 = 0 THEN 1 END) || 1` — a folded NULL
+    // beside a bare integer — validates and yields NULL rather than being
+    // rejected for the integer right operand.
+    try things().expect("SELECT (CASE WHEN 1 = 0 THEN 1 END) || 1",
+                        yields: [[nil]])
+  }
+}
+
+// MARK: - Derivation
+
+/// Parses `text` to a `Query`, failing on any other shape.
+private func query(_ text: String) throws -> Query {
+  guard case let .select(query) = try Statement(parsing: text) else {
+    Issue.record("expected a SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return query
+}
+
+/// A `People` catalog with a text `Name` — the base for a derive-level test.
+private func people() -> FixtureCatalog {
+  FixtureCatalog(
+    ["People": FixtureRelation([FixtureField(name: "Name", type: .text)], [])])
+}
+
+/// The type `derive` reports for the sole projected expression of `text`, over
+/// a `People` scope — the schema-only derive surface (`scope(of:)` reads no
+/// cursor and skips `compile`), so `derive` alone resolves the operands.
+private func derived(_ text: String) throws -> ValueType {
+  let select = try parse(select: text)
+  guard case let .expressions(items) = select.projection, items.count == 1
+  else {
+    Issue.record("expected a single projected expression")
+    throw SQLError.incomplete(expected: "one projected expression")
+  }
+  let scope = try people().scope(of: select, Context())
+  return try scope.derive(items[0].expression)
+}
+
+struct ConcatDerivationTests {
+  @Test func `deriving a concatenation resolves both operands`() throws {
+    // `derive` — the schema-only surface a `columns(of:validate:false)` and an
+    // unreachable projection take, which RESOLVES column references — must
+    // derive both `||` operands, so an unresolved `Missing` faults
+    // `SQLError.column` rather than the branch silently advertising a `text`
+    // column, mirroring the arithmetic `.binary` derive branch.
+    #expect(throws: SQLError.column("Missing")) {
+      _ = try derived("SELECT Missing || 'x' FROM People")
+    }
+  }
+
+  @Test func `a resolved concatenation derives text`() throws {
+    // A `||` whose operands both resolve still derives a `.text` column —
+    // resolution succeeds and the result type is text regardless of the
+    // operands' own types.
+    #expect(try derived("SELECT Name || 'x' FROM People") == .text)
+  }
+}


### PR DESCRIPTION
Add the ISO `||` string-concatenation operator: a `.concat` token the lexer scans from two `|` bytes, an `Arithmetic.concatenate` binary operator sharing the additive precedence tier and left-associativity, and evaluation that joins two text operands into one text value, propagates NULL, and faults `SQLError.operand` on a non-text operand — as arithmetic faults on a non-numeric one. The `derive` branch derives both operands for resolution (an unresolved column faults `SQLError.column`) before returning `.text`.