### PR TITLE
SQL: add the BETWEEN predicate

### DIFF
--- a/Sources/SQL/AST.swift
+++ b/Sources/SQL/AST.swift
@@ -606,6 +606,19 @@ public indirect enum Predicate: Hashable, Sendable {
   /// `:parameter` resolved from the engine's bindings — so a caller can bind a
   /// pattern (`Name LIKE :pattern`) rather than interpolate it.
   case like(Expression, pattern: Operand, escape: Operand?, negated: Bool)
+  /// `x [NOT] BETWEEN a AND b` — whether `x` is within the inclusive range
+  /// `[a, b]`, or outside it when `negated`. The ISO definition is `x >= a AND
+  /// x <= b` (and `x < a OR x > b` negated), but it is a FIRST-CLASS node
+  /// rather than that expansion so the test expression `x` is evaluated EXACTLY
+  /// ONCE: the desugar duplicated `x` across both bound comparisons, testing a
+  /// stateful `x`'s lower bound with one call and its upper with another. It
+  /// keeps the ISO three-valued semantics — a NULL `x`, `a`, or `b` makes a
+  /// bound UNKNOWN, excluding the row. Each bound `a` and `b` is an `Operand` —
+  /// an ordinary scalar expression or a run-time `:parameter` resolved from the
+  /// bindings (`x BETWEEN :lo AND :hi`) — the same binding the comparison and
+  /// `LIKE` arms accept, so a caller can bind a range rather than interpolate
+  /// it.
+  case between(Expression, Operand, Operand, negated: Bool)
   /// `lhs AND rhs`.
   case and(Predicate, Predicate)
   /// `lhs OR rhs`.

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -685,6 +685,8 @@ extension Predicate {
     case let .like(operand, pattern, escape, _):
       operand.aggregated || pattern.aggregated
           || (escape?.aggregated ?? false)
+    case let .between(test, lower, upper, _):
+      test.aggregated || lower.aggregated || upper.aggregated
     case let .and(lhs, rhs), let .or(lhs, rhs):
       lhs.aggregated || rhs.aggregated
     case let .not(operand):
@@ -708,6 +710,8 @@ extension Predicate {
       operand.bound || values.contains { $0.bound }
     case let .like(operand, pattern, escape, _):
       operand.bound || pattern.bound || (escape?.bound ?? false)
+    case let .between(test, lower, upper, _):
+      test.bound || lower.bound || upper.bound
     case let .and(lhs, rhs), let .or(lhs, rhs):
       lhs.bound || rhs.bound
     case let .not(operand):
@@ -955,6 +959,10 @@ extension Predicate {
       operand.collect(into: &expressions)
       pattern.collect(into: &expressions)
       escape?.collect(into: &expressions)
+    case let .between(test, lower, upper, _):
+      test.collect(into: &expressions)
+      lower.collect(into: &expressions)
+      upper.collect(into: &expressions)
     case let .and(lhs, rhs), let .or(lhs, rhs):
       lhs.collect(into: &expressions)
       rhs.collect(into: &expressions)
@@ -1129,6 +1137,42 @@ private func comparison(_ filter: Filter, _ bindings: Bindings)
   }
 }
 
+/// The seekable `(slot, lower, upper)` of a non-negated `x BETWEEN lower AND
+/// upper` whose test `x` is a `slot` and whose bounds EACH resolve to an
+/// integer — a `.term` integer literal, or a `:parameter` bound to an integer
+/// in `bindings`, the same resolution `comparison` applies to a `.bound` — a
+/// two-sided run the seek reads directly off the sorted key, exactly the range
+/// `x >= lower AND x <= upper` would seek, so a fully-bound parameterised range
+/// seeks rather than regressing to a scan. A `NOT BETWEEN` (the complement is
+/// two disjoint runs, not one contiguous seek), a non-slot test, or a bound
+/// that does not resolve to an integer (a non-constant term, a string, or an
+/// unbound or non-integer parameter) does not qualify, and the relation scans
+/// under the residual `between`.
+private func range(_ filter: Filter, _ bindings: Bindings) -> (Int, Int, Int)? {
+  guard case let .between(.slot(slot), lower, upper, negated: false) = filter,
+      let low = integer(lower, bindings),
+      let high = integer(upper, bindings) else {
+    return nil
+  }
+  return (slot, low, high)
+}
+
+/// The integer a BETWEEN bound seeks on: a `.term` integer literal, or a
+/// `:parameter` bound to an integer in `bindings` — the same resolution
+/// `comparison` gives a `.bound`'s parameter. Any other operand — a
+/// non-constant term, a non-integer constant, or an unbound or non-integer
+/// parameter — does not seek (`nil`), and the residual `between` runs instead.
+private func integer(_ operand: Filter.Operand, _ bindings: Bindings) -> Int? {
+  switch operand {
+  case let .term(.constant(.integer(value))):
+    value
+  case let .parameter(name):
+    if case let .integer(value)? = bindings[name] { value } else { nil }
+  case .term:
+    nil
+  }
+}
+
 extension Table where Self: ~Escapable {
   /// The boundaries `[lower, upper)` to seek for a sort-key comparison, or `nil`
   /// if `filter` does not qualify for the seek path.
@@ -1145,12 +1189,43 @@ extension Table where Self: ~Escapable {
   /// `string` operand or an unseekable column never qualifies, and the executor
   /// scans.
   ///
+  /// A first-class `x BETWEEN lower AND upper` (non-negated) whose test `x` is
+  /// the sort-key slot and whose bounds each resolve to an integer — a literal,
+  /// or a `:parameter` bound in `bindings` (so `x BETWEEN :lo AND :hi` seeks
+  /// rather than scans) — seeks a two-sided run: the intersection of the
+  /// `x >= lower` and `x <= upper` partitions, exactly the run the desugar
+  /// would seek, as an ordered-only range. A `NOT BETWEEN` (a two-run
+  /// complement, not one contiguous seek), a non-slot test, or a bound that
+  /// does not resolve to an integer does not qualify; the residual `between`
+  /// still runs over the sought rows either way.
+  ///
   /// The hash-join executor reuses this over a pushed inner filter's conjuncts
   /// to seek the inner by a seekable conjunct before bucketing, so a
   /// seekable/contradictory inner filter reads few or no inner rows.
   internal borrowing func boundaries(_ filter: Filter, _ ordinals: Array<Int>,
                                      _ count: Int, _ bindings: Bindings)
       -> Range<Int>? {
+    // A first-class `x BETWEEN lower AND upper` seeks a two-sided run directly:
+    // the lower boundary is the `x >= lower` partition (inclusive, `strict`
+    // false) and the upper is the `x <= upper` partition (inclusive, `strict`
+    // true), so their intersection `lower ..< upper` is exactly the range the
+    // desugar `x >= lower AND x <= upper` would seek. As a range it seeks ONLY
+    // an ordered key — an unordered seekable column brackets an equality, not
+    // a range — and the residual `between` still runs over the sought rows.
+    if let (slot, low, high) = range(filter, bindings) {
+      guard ordered(ordinals[slot]),
+          let lower = bound(ordinals[slot], low, strict: false),
+          let upper = bound(ordinals[slot], high, strict: true) else {
+        return nil
+      }
+      // An inverted `BETWEEN lower AND upper` (lower > upper) is a valid EMPTY
+      // range: the `x >= lower` partition starts after the `x <= upper` one
+      // ends, so `lower > upper` here and `lower ..< upper` would trap Swift's
+      // `Range(lowerBound <= upperBound)` precondition. Seek an empty run.
+      guard lower <= upper else { return lower ..< lower }
+      return lower ..< upper
+    }
+
     guard let (slot, op, value) = comparison(filter, bindings),
         let lower = bound(ordinals[slot], value, strict: false),
         let upper = bound(ordinals[slot], value, strict: true) else {

--- a/Sources/SQL/Filter.swift
+++ b/Sources/SQL/Filter.swift
@@ -49,6 +49,16 @@ internal indirect enum Filter: Sendable {
   /// pattern is a definite non-match (the engine's cross-kind rule), with `NOT
   /// LIKE` negating the three-valued result (UNKNOWN maps to itself).
   case like(Term, pattern: Operand, escape: Operand?, negated: Bool)
+  /// `x [NOT] BETWEEN a AND b` — the lowered form of the AST's `between`. The
+  /// test term `x` is held ONCE, the two bounds `a` and `b` beside it — each an
+  /// `Operand`, a `Term` evaluated per row or a run-time `:parameter` resolved
+  /// from the bindings — and `negated` marks `NOT BETWEEN`. Evaluating it reads
+  /// `x` once per row (an `AND`/`OR` of two comparisons would re-evaluate a
+  /// non-idempotent `x`, once per bound) and folds `x >= a` AND `x <= b` (or `x
+  /// < a` OR `x > b` when negated) over the SAME `x` under Kleene logic, so a
+  /// NULL `x`, `a`, or `b` — an unbound or NULL-bound `:parameter` included —
+  /// makes a bound UNKNOWN and the row is excluded.
+  case between(Term, Operand, Operand, negated: Bool)
   /// `lhs AND rhs`.
   case and(Filter, Filter)
   /// `lhs OR rhs`.
@@ -287,6 +297,9 @@ extension Filter {
       .like(operand.remapped(through: slot),
             pattern: pattern.remapped(through: slot),
             escape: escape?.remapped(through: slot), negated: negated)
+    case let .between(test, lower, upper, negated):
+      .between(test.remapped(through: slot), lower.remapped(through: slot),
+               upper.remapped(through: slot), negated: negated)
     case let .and(lhs, rhs):
       .and(lhs.remapped(through: slot), rhs.remapped(through: slot))
     case let .or(lhs, rhs):
@@ -373,6 +386,8 @@ extension Filter {
       // pattern being a definite non-match and a NULL UNKNOWN.
       operand.safe && pattern.safe
           && (escape.map(\.escape) ?? true)
+    case let .between(test, lower, upper, _):
+      test.safe && lower.safe && upper.safe
     case let .and(lhs, rhs): lhs.safe && rhs.safe
     case let .or(lhs, rhs): lhs.safe && rhs.safe
     case let .not(operand): operand.safe
@@ -395,17 +410,20 @@ extension Filter {
   }
 
   /// Whether this filter compares against a run-time `:parameter` — a `.bound`
-  /// anywhere in it, or a `.like` whose pattern or escape operand is a
-  /// `:parameter`. Such a predicate reads no slot yet can be UNKNOWN, because
-  /// the parameter may be unbound (or bound to NULL), so `nullable` counts it
-  /// even when `slots` is empty — keeping `'x' LIKE :p` off a pushdown below
-  /// a later unsafe conjunct the non-short-circuiting `AND` still owes.
+  /// anywhere in it, a `.like` whose pattern or escape operand is a
+  /// `:parameter`, or a `.between` whose lower or upper bound is one. Such a
+  /// predicate reads no slot yet can be UNKNOWN, because the parameter may be
+  /// unbound (or bound to NULL), so `nullable` counts it even when `slots` is
+  /// empty — keeping `'x' LIKE :p` or `1 BETWEEN :lo AND :hi` off a pushdown
+  /// below a later unsafe conjunct the non-short-circuiting `AND` still owes.
   private var parameterised: Bool {
     switch self {
     case .bound: true
     case .compare, .match, .null, .membership: false
     case let .like(_, pattern, escape, _):
       pattern.parameterised || (escape?.parameterised ?? false)
+    case let .between(_, lower, upper, _):
+      lower.parameterised || upper.parameterised
     case let .and(lhs, rhs): lhs.parameterised || rhs.parameterised
     case let .or(lhs, rhs): lhs.parameterised || rhs.parameterised
     case let .not(operand): operand.parameterised
@@ -785,6 +803,8 @@ extension Row where Self: ~Escapable {
       try member(operand, elements, negated, routines, bindings)
     case let .like(operand, pattern, escape, negated):
       try like(operand, pattern, escape, negated, routines, bindings)
+    case let .between(test, lower, upper, negated):
+      try ranged(test, lower, upper, negated, routines, bindings)
     case let .and(lhs, rhs):
       // `&&`/`||` take an `@autoclosure` right operand, which would capture the
       // borrowed `~Escapable` row; spell each connective explicitly so a branch
@@ -830,6 +850,47 @@ extension Row where Self: ~Escapable {
       if truth == true { break }
     }
     return negated ? truth.map { !$0 } : truth
+  }
+
+  /// Evaluates a lowered `test [NOT] BETWEEN lower AND upper` against this row.
+  ///
+  /// The `test` term is evaluated ONCE per row — an `AND`/`OR` of two
+  /// comparisons would re-evaluate a non-idempotent test once per bound — then
+  /// the two bounds fold against that SAME value under Kleene logic as `test >=
+  /// lower AND test <= upper`. `NOT BETWEEN` is the NEGATION of that same
+  /// truth, NOT the `test < lower OR test > upper` expansion: with a cross-kind
+  /// bound `matches` yields FALSE for EVERY ordering operator (so `test <
+  /// lower` is not the complement of `test >= lower`), and the expansion would
+  /// diverge from `NOT (test BETWEEN lower AND upper)` — e.g. `K NOT BETWEEN
+  /// 'a' AND 10` must KEEP the row (the cross-kind `K >= 'a'` is FALSE, so
+  /// BETWEEN is FALSE and its negation TRUE), which the expansion's two FALSE
+  /// ordering checks would wrongly reject. A NULL `test`, `lower`, or `upper`
+  /// makes a bound UNKNOWN (`matches` yields `nil`), so the row is excluded —
+  /// the ISO three-valued range semantics.
+  ///
+  /// The `upper` bound is evaluated ONLY when the lower does not already settle
+  /// the truth: a definitely-FALSE `test >= lower` makes BETWEEN FALSE (and NOT
+  /// BETWEEN TRUE) under Kleene `AND` without reaching the `upper` term — or
+  /// any error it would raise — so `0 BETWEEN 1 AND (1 / 0)` rejects the row
+  /// rather than dividing by zero, as the desugar's constant-false left would
+  /// leave its right unevaluated.
+  ///
+  /// Each bound is an `Operand` — a `Term` evaluated against the row or a
+  /// run-time `:parameter` resolved from the bindings (an unbound or NULL-bound
+  /// one reading UNKNOWN, excluding the row) — the same binding a comparison's
+  /// right operand accepts.
+  private borrowing func ranged(_ test: Term, _ lower: Filter.Operand,
+                                _ upper: Filter.Operand,
+                                _ negated: Bool, _ routines: Routines,
+                                _ bindings: Bindings)
+      throws(SQLError) -> Bool? {
+    let value = try evaluate(test, routines, bindings)
+    let low = try evaluate(lower, routines, bindings)
+    let above = matches(value, .geq, low)
+    guard above != false else { return negated }
+    let high = try evaluate(upper, routines, bindings)
+    let within = and(above, matches(value, .leq, high))
+    return negated ? within.map { !$0 } : within
   }
 
   /// Resolves a `LIKE` pattern or escape operand to a value: a term evaluates

--- a/Sources/SQL/Lexer.swift
+++ b/Sources/SQL/Lexer.swift
@@ -436,6 +436,7 @@ internal struct Lexer: ~Escapable {
     case "IS": .is
     case "NULL": .null
     case "IN": .in
+    case "BETWEEN": .between
     case "LIKE": .like
     case "ESCAPE": .escape
     case "UNION": .union

--- a/Sources/SQL/Parser.swift
+++ b/Sources/SQL/Parser.swift
@@ -37,7 +37,9 @@
 /// primary        := '(' predicate ')' | comparison
 /// comparison     := expression (op (expression | param) | IS [NOT] NULL
 ///                 | [NOT] IN '(' expression (',' expression)* ')'
-///                 | [NOT] LIKE expression [ESCAPE expression])
+///                 | [NOT] LIKE expression [ESCAPE expression]
+///                 | [NOT] BETWEEN (expression | param) AND
+///                                 (expression | param))
 /// expression     := additive
 /// additive       := multiplicative (('+' | '-' | '||') multiplicative)*
 /// multiplicative := factor (('*' | '/') factor)*
@@ -836,8 +838,10 @@ internal struct Parser: ~Escapable {
   /// (or `NOT IN`) tail tests the left expression for membership in a
   /// parenthesised value list. A `LIKE` (or `NOT LIKE`) tail tests the left
   /// expression's text against a pattern, with an optional `ESCAPE` character.
-  /// A leading `NOT` here can only introduce `NOT IN` or `NOT LIKE`: a prefix
-  /// `NOT` predicate is consumed by `negation` before this point.
+  /// A `BETWEEN a AND b` (or `NOT BETWEEN`) tail is the ISO range test,
+  /// desugared into a conjunction (or disjunction) of bounds. A leading `NOT`
+  /// here introduces `NOT IN`, `NOT LIKE`, or `NOT BETWEEN`: a prefix `NOT`
+  /// predicate is consumed by `negation` before this point.
   private mutating func comparison() throws(SQLError) -> Predicate {
     let left = try expression()
     if try match(.is) {
@@ -851,9 +855,15 @@ internal struct Parser: ~Escapable {
     if try match(.like) {
       return try like(left, negated: false)
     }
+    if try match(.between) {
+      return try between(left, negated: false)
+    }
     if try match(.not) {
       if try match(.like) {
         return try like(left, negated: true)
+      }
+      if try match(.between) {
+        return try between(left, negated: true)
       }
       try expect(.in)
       return try membership(left, negated: true)
@@ -883,6 +893,29 @@ internal struct Parser: ~Escapable {
     }
     try expect(.rparen)
     return .membership(left, values, negated: negated)
+  }
+
+  /// Parses the bounds tail of `left [NOT] BETWEEN a AND b` — the `BETWEEN` is
+  /// already consumed — into the first-class `Predicate.between`.
+  ///
+  /// ISO 9075 defines `x BETWEEN a AND b` as `x >= a AND x <= b` (an inclusive
+  /// range) and `x NOT BETWEEN a AND b` as its negation `x < a OR x > b`, but
+  /// that expansion duplicates `x` across both bound comparisons, evaluating a
+  /// stateful `x` twice — so this parses the two bounds around the `AND`
+  /// keyword and builds the first-class node the engine evaluates `x` ONCE for,
+  /// keeping the same three-valued NULL semantics (a NULL `x`, `a`, or `b`
+  /// makes a bound UNKNOWN, and the row is excluded).
+  ///
+  /// Each bound is an `Operand` — a scalar expression, or a run-time
+  /// `:parameter` bound at eval (`Id BETWEEN :lo AND :hi`), the same binding
+  /// the comparison and `LIKE` arms accept — so a caller can bind a range
+  /// rather than fall back to the duplicated `Id >= :lo AND Id <= :hi` desugar.
+  private mutating func between(_ left: Expression, negated: Bool)
+      throws(SQLError) -> Predicate {
+    let lower = try operand()
+    try expect(.and)
+    let upper = try operand()
+    return .between(left, lower, upper, negated: negated)
   }
 
   /// Parses the pattern tail of `left [NOT] LIKE pattern [ESCAPE escape]` — the

--- a/Sources/SQL/Resolve.swift
+++ b/Sources/SQL/Resolve.swift
@@ -51,6 +51,16 @@ private func lower(_ predicate: Predicate,
     // lowers only when present. The matcher and three-valued handling live in
     // the runtime, so lowering just resolves the operand terms.
     try like(operand, pattern, escape, negated: negated, term: term)
+  case let .between(test, low, high, negated):
+    // `x [NOT] BETWEEN a AND b` lowers to a first-class `Filter.between` that
+    // evaluates the test `x` ONCE per row (an `AND`/`OR` of two comparisons
+    // would re-evaluate a non-idempotent `x`, once per bound) and folds the two
+    // bounds against that same value under Kleene logic — a NULL `x`, `a`, or
+    // `b` making a bound UNKNOWN and excluding the row, the ISO range test.
+    // Each bound lowers through the same `Operand` form a `LIKE` pattern does,
+    // a `.term` or a `:parameter` name resolved from the bindings at eval.
+    try .between(term(test), lower(low, term: term), lower(high, term: term),
+                 negated: negated)
   case let .and(lhs, rhs):
     try .and(lower(lhs, term: term), lower(rhs, term: term))
   case let .or(lhs, rhs):
@@ -973,6 +983,31 @@ internal struct Scope {
         try validate(escape, routines)
         try reject(escape, routines)
       }
+    case let .between(test, lower, upper, _):
+      // `x [NOT] BETWEEN a AND b` compares `x` against both bounds, so validate
+      // the three operands for real errors (an unknown column, a bad call). A
+      // cross-kind bound is NOT rejected: the run's `matches` yields FALSE
+      // across kinds without faulting (as an `IN` element does), so the schema
+      // check accepts what the run accepts.
+      //
+      // It respects the executor's short-circuit — the same one `ranged`
+      // evaluates with: a DEFINITELY-FALSE lower comparison (`x >= a`) settles
+      // the whole truth (BETWEEN FALSE, NOT BETWEEN TRUE — the latter is the
+      // negation of that truth, not the divergent `x < a OR x > b` expansion),
+      // leaving `upper` unreachable for BOTH spellings, so `upper` is NOT
+      // validated — `0 BETWEEN 1 AND (1 / 0)` type-checks, the lower `0 >= 1`
+      // FALSE settling the row before the `1 / 0` upper is reached, exactly as
+      // an `AND`'s constant-false left leaves its right unchecked.
+      _ = try validate(test, routines)
+      try validate(lower, routines)
+      let settled = {
+        guard let value = constant(test, routines),
+            let low = constant(lower, routines) else {
+          return false
+        }
+        return matches(value, .geq, low) == false
+      }()
+      if !settled { try validate(upper, routines) }
     case let .and(lhs, rhs):
       try check(lhs, routines)
       if constant(lhs, routines) != false { try check(rhs, routines) }
@@ -1230,6 +1265,24 @@ internal struct Scope {
         return nil
       }
       return negated ? !truth : truth
+    case let .between(test, lower, upper, negated):
+      // Fold `x [NOT] BETWEEN a AND b` as `ranged` evaluates it: BETWEEN is the
+      // Kleene `x >= a AND x <= b`, and NOT BETWEEN its NEGATION (not the
+      // `x < a OR x > b` expansion, which diverges on a cross-kind bound — see
+      // `ranged`). The folded `x >= a` short-circuits before the upper: a
+      // definitely-FALSE one settles BETWEEN FALSE (and NOT BETWEEN TRUE)
+      // without folding the upper — or any fault it carries — so
+      // `0 BETWEEN 1 AND (1 / 0)` folds definitely FALSE rather than `nil`. A
+      // side the fold cannot decide leaves it per row (`nil`).
+      guard let value = constant(test, routines),
+          let low = constant(lower, routines) else {
+        return nil
+      }
+      let above = matches(value, .geq, low)
+      if above == false { return negated }
+      guard let high = constant(upper, routines) else { return nil }
+      let within = and(above, matches(value, .leq, high))
+      return negated ? within.map { !$0 } : within
     case .bound:
       return nil
     }
@@ -1352,6 +1405,10 @@ internal struct Scope {
       try aggregates(in: operand, routines)
       try aggregates(in: pattern, routines)
       if let escape { try aggregates(in: escape, routines) }
+    case let .between(test, lower, upper, _):
+      try aggregates(in: test, routines)
+      try aggregates(in: lower, routines)
+      try aggregates(in: upper, routines)
     case let .and(lhs, rhs), let .or(lhs, rhs):
       try aggregates(in: lhs, routines)
       try aggregates(in: rhs, routines)
@@ -1522,6 +1579,21 @@ internal struct Scope {
         false
       }
       return negated ? truth.map { !$0 } : truth
+    case let .between(test, lower, upper, negated):
+      // Fold `x [NOT] BETWEEN a AND b` over the empty group as `ranged` does:
+      // BETWEEN is `x >= a AND x <= b`, and NOT BETWEEN its NEGATION (not the
+      // `x < a OR x > b` expansion, which diverges on a cross-kind bound — see
+      // `ranged`). The folded `x >= a` short-circuits before the upper: a
+      // definitely-FALSE one settles BETWEEN FALSE (and NOT BETWEEN TRUE)
+      // leaving the upper unfolded — and any fault it would raise unraised — so
+      // `HAVING 0 BETWEEN 1 AND (1 / 0)` drops the group without a `.divide`
+      // fault, exactly as the run does.
+      let value = try empty(test, routines)
+      let low = try empty(lower, routines)
+      let above = matches(value, .geq, low)
+      if above == false { return negated }
+      let within = and(above, matches(value, .leq, try empty(upper, routines)))
+      return negated ? within.map { !$0 } : within
     case let .and(lhs, rhs):
       // A `false` left proves the `AND` false without folding the right arm,
       // which a run's short-circuit never evaluates and so must not fault.
@@ -2012,6 +2084,10 @@ extension Filter {
       operand.references(into: &ordinals)
       pattern.references(into: &ordinals)
       escape?.references(into: &ordinals)
+    case let .between(test, lower, upper, _):
+      test.references(into: &ordinals)
+      lower.references(into: &ordinals)
+      upper.references(into: &ordinals)
     case let .and(lhs, rhs), let .or(lhs, rhs):
       lhs.references(into: &ordinals)
       rhs.references(into: &ordinals)

--- a/Sources/SQL/Token.swift
+++ b/Sources/SQL/Token.swift
@@ -50,6 +50,7 @@ extension Token {
     case `is`
     case null
     case `in`
+    case between
     case like
     case escape
     case union
@@ -139,6 +140,7 @@ extension Token.Kind {
     case .is: "IS"
     case .null: "NULL"
     case .in: "IN"
+    case .between: "BETWEEN"
     case .like: "LIKE"
     case .escape: "ESCAPE"
     case .union: "UNION"

--- a/Tests/SQLTests/BetweenTests.swift
+++ b/Tests/SQLTests/BetweenTests.swift
@@ -1,0 +1,522 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQL
+
+import SQLTestSupport
+
+// MARK: - Fixture
+
+/// A relation exercising `[NOT] BETWEEN`: an integer key `K` that is `NULL` in
+/// one row, so a NULL operand's UNKNOWN corner is reachable.
+private func things() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["Id": .integer, "K": .integer]) {
+      Row(1, 5)
+      Row(2, 1)
+      Row(3, 10)
+      Row(4, nil)
+      Row(5, 15)
+    }
+  }
+}
+
+/// Parses `text` and returns its `Select`, failing on any other shape.
+private func parse(select text: String) throws -> Select {
+  guard case let .select(.select(select)) = try Statement(parsing: text) else {
+    Issue.record("expected a single SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return select
+}
+
+// MARK: - Parsing
+
+struct BetweenParsingTests {
+  @Test func `BETWEEN parses to a first-class node`() throws {
+    // `x BETWEEN a AND b` is a first-class `Predicate.between` holding `x` ONCE
+    // — not the re-referencing `AND` of two comparisons its ISO definition
+    // names.
+    let select = try parse(select: "SELECT * FROM T WHERE K BETWEEN 1 AND 10")
+    #expect(select.predicate
+                == .between(.column("K"), .expression(.literal(.integer(1))),
+                            .expression(.literal(.integer(10))),
+                            negated: false))
+  }
+
+  @Test func `NOT BETWEEN parses to a negated first-class node`() throws {
+    // `x NOT BETWEEN a AND b` is the same node, `negated`.
+    let select =
+        try parse(select: "SELECT * FROM T WHERE K NOT BETWEEN 1 AND 10")
+    #expect(select.predicate
+                == .between(.column("K"), .expression(.literal(.integer(1))),
+                            .expression(.literal(.integer(10))),
+                            negated: true))
+  }
+}
+
+// MARK: - Evaluation
+
+struct BetweenEvaluationTests {
+  /// The `Id`s of every fixture row — a constant-TRUE `WHERE` keeps them all.
+  private let all = [[1], [2], [3], [4], [5]]
+
+  @Test func `a constant BETWEEN is true within the range`() throws {
+    // A constant-true predicate keeps every row.
+    try things().expect("SELECT Id FROM T WHERE 5 BETWEEN 1 AND 10",
+                        yields: all)
+  }
+
+  @Test func `a constant NOT BETWEEN is false within the range`() throws {
+    // A constant-false predicate drops every row.
+    try things().empty("SELECT Id FROM T WHERE 5 NOT BETWEEN 1 AND 10")
+  }
+
+  @Test func `the lower bound is inclusive`() throws {
+    try things().expect("SELECT Id FROM T WHERE 1 BETWEEN 1 AND 10",
+                        yields: all)
+  }
+
+  @Test func `the upper bound is inclusive`() throws {
+    try things().expect("SELECT Id FROM T WHERE 10 BETWEEN 1 AND 10",
+                        yields: all)
+  }
+
+  @Test func `a value outside the range is not between`() throws {
+    try things().empty("SELECT Id FROM T WHERE 15 BETWEEN 1 AND 10")
+  }
+
+  @Test func `BETWEEN over a column keeps only in-range rows`() throws {
+    // K in [1, 10]: rows 1 (5), 2 (1), 3 (10); row 4 (NULL) is UNKNOWN, row 5
+    // (15) is out of range.
+    try things().expect("SELECT Id FROM T WHERE K BETWEEN 1 AND 10",
+                        yields: [[1], [2], [3]])
+  }
+
+  @Test func `NOT BETWEEN over a column keeps only out-of-range rows`() throws {
+    // K outside [2, 8]: row 2 (1) and rows 3/5 (10/15); row 1 (5) is in range,
+    // row 4 (NULL) is UNKNOWN.
+    try things().expect("SELECT Id FROM T WHERE K NOT BETWEEN 2 AND 8",
+                        yields: [[2], [3], [5]])
+  }
+
+  @Test func `a NULL operand is UNKNOWN and excludes the row`() throws {
+    // Row 4's K is NULL, so both bounds are UNKNOWN — the row is excluded, as
+    // the equivalent `K >= 1 AND K <= 10` comparisons would exclude it.
+    try things().expect("SELECT Id FROM T WHERE K BETWEEN 1 AND 10",
+                        equals: "SELECT Id FROM T WHERE K >= 1 AND K <= 10")
+  }
+}
+
+// MARK: - Cross-kind negation
+
+struct BetweenCrossKindTests {
+  @Test func `NOT BETWEEN is the negation of BETWEEN across kinds`() throws {
+    // The parser and validator accept a cross-kind bound, so both spellings
+    // are reachable and must agree. With integer `K` and the text lower bound
+    // `'a'`, `matches` yields FALSE for every ordering operator, so `K >= 'a'`
+    // is FALSE — making BETWEEN FALSE and NOT BETWEEN TRUE. `K NOT BETWEEN 'a'
+    // AND 10` must therefore equal `NOT (K BETWEEN 'a' AND 10)`, NOT the
+    // `K < 'a' OR K > 10` expansion whose two FALSE ordering checks would
+    // wrongly REJECT the row.
+    try things().expect(
+        "SELECT Id FROM T WHERE K NOT BETWEEN 'a' AND 10",
+        equals: "SELECT Id FROM T WHERE NOT (K BETWEEN 'a' AND 10)")
+  }
+
+  @Test func `a cross-kind NOT BETWEEN keeps every non-NULL row`() throws {
+    // BETWEEN is FALSE for every non-NULL `K` (the cross-kind `K >= 'a'` is
+    // FALSE), so its negation keeps rows 1, 2, 3, 5; row 4's NULL `K` is
+    // UNKNOWN and stays excluded, as NOT of UNKNOWN is UNKNOWN.
+    try things().expect("SELECT Id FROM T WHERE K NOT BETWEEN 'a' AND 10",
+                        yields: [[1], [2], [3], [5]])
+  }
+
+  @Test func `a cross-kind upper bound negates equivalently`() throws {
+    // The divergence is not lower-bound-specific: with the text upper bound
+    // `'z'`, `K <= 'z'` is FALSE, so BETWEEN is FALSE and the two spellings
+    // still agree.
+    try things().expect(
+        "SELECT Id FROM T WHERE K NOT BETWEEN 1 AND 'z'",
+        equals: "SELECT Id FROM T WHERE NOT (K BETWEEN 1 AND 'z')")
+  }
+}
+
+// MARK: - Parameter bounds
+
+struct BetweenParameterTests {
+  @Test func `a parameterised bound parses to an Operand parameter`() throws {
+    // `Id BETWEEN :lo AND :hi` carries each bound as an `Operand.parameter` —
+    // the same run-time binding a comparison or `LIKE` accepts — so a caller
+    // need not fall back to the duplicated `Id >= :lo AND Id <= :hi` desugar.
+    let select =
+        try parse(select: "SELECT * FROM T WHERE Id BETWEEN :lo AND :hi")
+    #expect(select.predicate
+                == .between(.column("Id"), .parameter("lo"),
+                            .parameter("hi"), negated: false))
+  }
+
+  @Test func `parameterised bounds bind at run time`() throws {
+    // `K BETWEEN :lo AND :hi` with lo = 1, hi = 10 keeps the in-range rows,
+    // exactly as the literal `K BETWEEN 1 AND 10` does.
+    try things().expect("SELECT Id FROM T WHERE K BETWEEN :lo AND :hi",
+                        yields: [[1], [2], [3]],
+                        bindings: ["lo": .integer(1), "hi": .integer(10)])
+  }
+
+  @Test func `a parameterised range matches the bound-comparison desugar`()
+      throws {
+    // The whole point of the feature: a bound range runs directly rather than
+    // through the duplicated `K >= :lo AND K <= :hi` the first-class node
+    // replaces — the same rows, the same bindings.
+    try things().expect(
+        "SELECT Id FROM T WHERE K BETWEEN :lo AND :hi",
+        equals: "SELECT Id FROM T WHERE K >= :lo AND K <= :hi",
+        bindings: ["lo": .integer(2), "hi": .integer(10)])
+  }
+
+  @Test func `a literal lower and a parameter upper mix`() throws {
+    // The bounds are independent operands, so one may be a literal and the
+    // other a parameter. K in [2, 10]: rows 1 (5) and 3 (10).
+    try things().expect("SELECT Id FROM T WHERE K BETWEEN 2 AND :hi",
+                        yields: [[1], [3]], bindings: ["hi": .integer(10)])
+  }
+
+  @Test func `an unbound parameter bound is UNKNOWN and excludes every row`()
+      throws {
+    // An unbound `:lo` reads NULL, so `K >= :lo` is UNKNOWN for every row and
+    // none passes — exactly as an unbound comparison parameter does.
+    try things().empty("SELECT Id FROM T WHERE K BETWEEN :lo AND 10")
+  }
+
+  @Test func `a NULL-bound parameter is UNKNOWN and excludes every row`()
+      throws {
+    // A `:lo` bound to NULL reads UNKNOWN just as an unbound one does.
+    try things().empty("SELECT Id FROM T WHERE K BETWEEN :lo AND 10",
+                       bindings: ["lo": .null])
+  }
+
+  @Test func `NOT BETWEEN binds its parameter bounds at run time`() throws {
+    // The negated range takes bound bounds too: `K NOT BETWEEN :lo AND :hi`
+    // with lo = 2, hi = 8 matches the literal `K NOT BETWEEN 2 AND 8`.
+    try things().expect(
+        "SELECT Id FROM T WHERE K NOT BETWEEN :lo AND :hi",
+        equals: "SELECT Id FROM T WHERE K NOT BETWEEN 2 AND 8",
+        bindings: ["lo": .integer(2), "hi": .integer(8)])
+  }
+}
+
+// MARK: - Test expression evaluated once
+
+/// A shared call counter a stateful routine increments — a tiny
+/// `@unchecked Sendable` box over a mutable count, so the non-deterministic
+/// `stepper()` routine registered against it both observes successive values
+/// and records how many times the run invoked it. The engine evaluates a row's
+/// filter synchronously on one thread, so the box needs no lock.
+private final class Counter: @unchecked Sendable {
+  /// The number of times `next()` has been called.
+  private(set) var count = 0
+
+  /// Increments the count and returns the PREVIOUS value — the sequence `0, 1,
+  /// 2, …` across successive calls.
+  func next() -> Int {
+    defer { count += 1 }
+    return count
+  }
+}
+
+struct BetweenOperandTests {
+  /// A single-row table, so a per-row test expression is evaluated once.
+  private func one() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["Id": .integer]) {
+        Row(1)
+      }
+    }
+  }
+
+  @Test func `the BETWEEN test expression is evaluated once`() throws {
+    // `stepper()` yields 0, then 1, …; non-deterministic, so unfoldable.
+    // `stepper() BETWEEN 0 AND 0` must evaluate `stepper()` EXACTLY ONCE —
+    // yielding 0, which IS in [0, 0], so the row is KEPT. The old desugar
+    // duplicated the test across `stepper() >= 0 AND stepper() <= 0`, calling
+    // it twice: the lower bound saw 0 (0 >= 0) and the upper saw a DIFFERENT 1
+    // (1 <= 0 is false), wrongly DROPPING the row and calling it twice. The
+    // first-class node holds the test, so the row is kept and the counter reads
+    // exactly 1.
+    let counter = Counter()
+    let routines = try Routines()
+        .registering("stepper", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+    try one().expect("SELECT Id FROM T WHERE stepper() BETWEEN 0 AND 0",
+                     yields: [[1]], routines: routines)
+    #expect(counter.count == 1)
+  }
+}
+
+// MARK: - Upper bound short-circuit
+
+struct BetweenShortCircuitTests {
+  /// A single-row table — enough to reach the per-row predicate once.
+  private func one() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["Id": .integer]) {
+        Row(1)
+      }
+    }
+  }
+
+  @Test func `a FALSE lower bound skips the upper bound`() throws {
+    // `0 BETWEEN 1 AND (1 / 0)` ≡ `0 >= 1 AND 0 <= (1 / 0)` — the lower
+    // `0 >= 1` is FALSE, so Kleene `AND` is FALSE without the upper `1 / 0`.
+    // The eager form evaluated BOTH bounds and faulted `.divide` on the upper;
+    // deferring it keeps the predicate FALSE, dropping the row with NO throw.
+    try one().empty("SELECT Id FROM T WHERE 0 BETWEEN 1 AND (1 / 0)")
+  }
+
+  @Test func `a TRUE lower bound skips the NOT BETWEEN upper`() throws {
+    // `0 NOT BETWEEN 1 AND (1 / 0)` ≡ `0 < 1 OR 0 > (1 / 0)` — the lower
+    // `0 < 1` is TRUE, so Kleene `OR` is TRUE without the upper `1 / 0`. The
+    // row is kept with NO throw.
+    try one().expect("SELECT Id FROM T WHERE 0 NOT BETWEEN 1 AND (1 / 0)",
+                     yields: [[1]])
+  }
+
+  @Test func `the upper bound is evaluated when the lower does not settle it`()
+      throws {
+    // `5 BETWEEN 1 AND (1 / 0)` — the lower `5 >= 1` is TRUE, so the result
+    // hinges on the upper: the deferred `1 / 0` MUST evaluate and STILL fault,
+    // confirming the upper is not silently dropped when the lower needs it.
+    try one().expect("SELECT Id FROM T WHERE 5 BETWEEN 1 AND (1 / 0)",
+                     fails: .divide)
+  }
+
+  @Test func `a needed upper bound keeps an in-range row`() throws {
+    // `5 BETWEEN 1 AND 10` — the lower `5 >= 1` is TRUE, so the upper `5 <= 10`
+    // is evaluated and TRUE, keeping the row.
+    try one().expect("SELECT Id FROM T WHERE 5 BETWEEN 1 AND 10",
+                     yields: [[1]])
+  }
+}
+
+// MARK: - Typecheck short-circuit
+
+/// Parses `text` to a `Query`, failing on any other shape.
+private func query(_ text: String) throws -> Query {
+  guard case let .select(query) = try Statement(parsing: text) else {
+    Issue.record("expected a SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return query
+}
+
+struct BetweenTypecheckTests {
+  /// A relation with a text `Name`, so `Name + 1` is a reachable operand fault.
+  private func named() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["Id": .integer, "Name": .text]) {
+        Row(1, "a")
+      }
+    }
+  }
+
+  @Test func `a constant FALSE BETWEEN WHERE leaves the projection unreachable`()
+      throws {
+    // `0 BETWEEN 1 AND (1 / 0)` — the constant lower `0 >= 1` folds definitely
+    // FALSE, settling the whole BETWEEN FALSE WITHOUT folding the upper
+    // `1 / 0`. So `constant(_ predicate:)` reports the WHERE always-FALSE, the
+    // projection `Name + 1` (a `.operand` fault over the text `Name`, if
+    // reached) is unreachable, and `columns(of:validate:)` SUCCEEDS. The run
+    // drops every row before the projection, yielding no rows and NO throw.
+    let text = "SELECT Name + 1 FROM T WHERE 0 BETWEEN 1 AND (1 / 0)"
+    _ = try named().columns(of: query(text))
+    try named().empty(text)
+  }
+}
+
+// MARK: - Seek planning
+
+/// A relation sorted on its integer key `Id` (rows 1 … 10), so a BETWEEN over
+/// `Id` can seek a contiguous run rather than scan the whole relation.
+private func sorted() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["Id": .integer], sorted: "Id") {
+      Row(1)
+      Row(2)
+      Row(3)
+      Row(4)
+      Row(5)
+      Row(6)
+      Row(7)
+      Row(8)
+      Row(9)
+      Row(10)
+    }
+  }
+}
+
+/// The seek `Range<Int>` the first `.scan` reachable from `plan` carries, or
+/// `nil` if that scan is unseeked — the run a BETWEEN seek plans over the
+/// sorted key's row positions.
+private func seek(_ plan: Plan) -> Range<Int>? {
+  switch plan {
+  case let .scan(_, _, seek):
+    seek
+  case let .select(_, source):
+    seek(source)
+  case let .project(_, source):
+    seek(source)
+  case let .sort(_, source):
+    seek(source)
+  default:
+    nil
+  }
+}
+
+struct BetweenSeekTests {
+  @Test func `a BETWEEN over the sorted key seeks its two-sided run`() throws {
+    // `Id BETWEEN 3 AND 7` over the `Id`-sorted relation must seek the run
+    // `2 ..< 7` — the positions of Ids 3 … 7 (first `>= 3` at index 2, first
+    // `> 7` at index 7) — exactly the range `Id >= 3 AND Id <= 7` would seek,
+    // not scan all ten rows.
+    let catalog = try sorted()
+    let query = try query("SELECT Id FROM T WHERE Id BETWEEN 3 AND 7")
+    let plan = try catalog.optimise(catalog.compile(query), [:])
+    #expect(seek(plan) == 2 ..< 7)
+    try catalog.expect("SELECT Id FROM T WHERE Id BETWEEN 3 AND 7",
+                       yields: [[3], [4], [5], [6], [7]])
+  }
+
+  @Test func `the seeked BETWEEN matches the equivalent range comparison`()
+      throws {
+    // The desugar `Id >= 3 AND Id <= 7` also seeks over the sorted key and
+    // returns the SAME rows — but seeks only ONE conjunct (`Id >= 3`, the run
+    // `2 ..< 10`) and residuals the other, so the first-class BETWEEN's
+    // two-sided `2 ..< 7` is the TIGHTER run. Parity is the seeked shape and
+    // the rows, and the BETWEEN run sits within the comparison's.
+    let catalog = try sorted()
+    let comparison =
+        try query("SELECT Id FROM T WHERE Id >= 3 AND Id <= 7")
+    let range = try #require(seek(catalog.optimise(catalog.compile(comparison),
+                                                   [:])))
+    #expect(range.lowerBound <= 2 && range.upperBound >= 7)
+    try catalog.expect("SELECT Id FROM T WHERE Id BETWEEN 3 AND 7",
+                       equals: "SELECT Id FROM T WHERE Id >= 3 AND Id <= 7")
+  }
+
+  @Test func `a NOT BETWEEN does not seek — the complement is two runs`()
+      throws {
+    // `Id NOT BETWEEN 3 AND 7` is the complement — two disjoint runs, not one
+    // contiguous seek — so it scans under the residual and returns the
+    // out-of-range rows.
+    let catalog = try sorted()
+    let query = try query("SELECT Id FROM T WHERE Id NOT BETWEEN 3 AND 7")
+    let plan = try catalog.optimise(catalog.compile(query), [:])
+    #expect(seek(plan) == nil)
+    try catalog.expect("SELECT Id FROM T WHERE Id NOT BETWEEN 3 AND 7",
+                       yields: [[1], [2], [8], [9], [10]])
+  }
+
+  @Test func `an expression test does not seek — the operand is not a slot`()
+      throws {
+    // `Id + 1 BETWEEN 4 AND 8` tests an arithmetic term, not a bare key slot,
+    // so it does not qualify for the seek; it scans and filters, admitting the
+    // same rows the seeked `Id BETWEEN 3 AND 7` would.
+    let catalog = try sorted()
+    let query = try query("SELECT Id FROM T WHERE Id + 1 BETWEEN 4 AND 8")
+    let plan = try catalog.optimise(catalog.compile(query), [:])
+    #expect(seek(plan) == nil)
+    try catalog.expect("SELECT Id FROM T WHERE Id + 1 BETWEEN 4 AND 8",
+                       yields: [[3], [4], [5], [6], [7]])
+  }
+
+  @Test func `a bound referencing a column does not seek — it is not constant`()
+      throws {
+    // `Id BETWEEN 3 AND Id` has an upper bound that reads a column, not an
+    // integer literal, so it does not qualify for the seek; it scans and admits
+    // every row whose `Id >= 3` (each row's own `Id` is its upper bound).
+    let catalog = try sorted()
+    let query = try query("SELECT Id FROM T WHERE Id BETWEEN 3 AND Id")
+    let plan = try catalog.optimise(catalog.compile(query), [:])
+    #expect(seek(plan) == nil)
+    try catalog.expect("SELECT Id FROM T WHERE Id BETWEEN 3 AND Id",
+                       yields: [[3], [4], [5], [6], [7], [8], [9], [10]])
+  }
+
+  @Test func `an inverted BETWEEN seeks an empty run without trapping`()
+      throws {
+    // `Id BETWEEN 10 AND 1` is a valid EMPTY range (lower > upper): the
+    // `Id >= 10` partition starts at index 9 and the `Id <= 1` partition ends
+    // at index 1, so the raw `lower ..< upper` (9 ..< 1) would trap Swift's
+    // `Range(lowerBound <= upperBound)` precondition and abort the process. The
+    // guard detects the inversion and seeks the EMPTY run `9 ..< 9` instead, so
+    // the query returns no rows and never traps.
+    let catalog = try sorted()
+    let query = try query("SELECT Id FROM T WHERE Id BETWEEN 10 AND 1")
+    let plan = try catalog.optimise(catalog.compile(query), [:])
+    let range = try #require(seek(plan))
+    #expect(range.isEmpty)
+    try catalog.empty("SELECT Id FROM T WHERE Id BETWEEN 10 AND 1")
+  }
+
+  @Test func `a parameterised BETWEEN seeks its two-sided run once bound`()
+      throws {
+    // `Id BETWEEN :lo AND :hi` with lo = 3, hi = 7 resolves both bounds from
+    // the bindings and seeks the SAME `2 ..< 7` run the literal `Id BETWEEN 3
+    // AND 7` does — not a whole-table scan — so the parameterised range this
+    // feature replaces does not regress against the `Id >= :lo AND Id <= :hi`
+    // desugar's seek.
+    let catalog = try sorted()
+    let query = try query("SELECT Id FROM T WHERE Id BETWEEN :lo AND :hi")
+    let bindings: Bindings = ["lo": .integer(3), "hi": .integer(7)]
+    let plan = try catalog.optimise(catalog.compile(query), bindings)
+    #expect(seek(plan) == 2 ..< 7)
+    try catalog.expect("SELECT Id FROM T WHERE Id BETWEEN :lo AND :hi",
+                       yields: [[3], [4], [5], [6], [7]], bindings: bindings)
+  }
+
+  @Test func `an unbound parameter bound does not seek and scans`() throws {
+    // With no binding for `:hi`, the upper bound resolves to no integer, so the
+    // range does not qualify and the relation scans under the residual
+    // `between` — which reads the unbound `:hi` as NULL, UNKNOWN for every row,
+    // so none passes. It seeks nothing rather than mis-seeking.
+    let catalog = try sorted()
+    let query = try query("SELECT Id FROM T WHERE Id BETWEEN :lo AND :hi")
+    let plan = try catalog.optimise(catalog.compile(query),
+                                    ["lo": .integer(3)])
+    #expect(seek(plan) == nil)
+    try catalog.empty("SELECT Id FROM T WHERE Id BETWEEN :lo AND :hi",
+                      bindings: ["lo": .integer(3)])
+  }
+}
+
+// MARK: - Empty-group short-circuit
+
+struct BetweenEmptyGroupTests {
+  /// A relation to fold a whole-result aggregate over.
+  private func numbers() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["Id": .integer]) {
+        Row(1)
+      }
+    }
+  }
+
+  @Test func `a constant FALSE BETWEEN HAVING type-checks over an empty group`()
+      throws {
+    // A constant-FALSE `WHERE` leaves a whole-result aggregate its single empty
+    // group, over which the `HAVING 0 BETWEEN 1 AND (1 / 0)` folds: the
+    // constant lower `0 >= 1` is FALSE, settling BETWEEN FALSE WITHOUT folding
+    // the upper `1 / 0`. So `empty(_ predicate:)` drops the group WITHOUT a
+    // `.divide` fault, schema/type checking SUCCEEDS, and the run yields no row
+    // with NO throw.
+    let text = """
+        SELECT COUNT(*) FROM T WHERE 1 = 0
+        HAVING 0 BETWEEN 1 AND (1 / 0)
+        """
+    _ = try numbers().columns(of: query(text))
+    try numbers().empty(text)
+  }
+}


### PR DESCRIPTION
Add the ISO `x [NOT] BETWEEN a AND b` range test as a first-class `Predicate.between` lowered to `Filter.between`, rather than the desugar `x >= a AND x <= b` (or `x < a OR x > b` negated) that duplicates the test expression across both bound comparisons. The test operand is evaluated ONCE per row and the two bounds fold against that same value under Kleene logic — a NULL test or bound makes a bound UNKNOWN and excludes the row.

The upper bound is evaluated lazily: a definitely-FALSE lower comparison settles BETWEEN FALSE (and a definitely-TRUE one settles NOT BETWEEN TRUE) without reaching the upper — across the eval, constant-fold, and empty-group surfaces — so `0 BETWEEN 1 AND (1 / 0)` rejects the row rather than faulting. A non-negated `x BETWEEN lower AND upper` over an ordered sort-key slot with integer bounds seeks a two-sided run directly off the sorted key, with an inverted range (`lower > upper`) seeking an empty run rather than trapping.