### PR TITLE
SQL: add the NULLIF function

### DIFF
--- a/Sources/SQL/AST.swift
+++ b/Sources/SQL/AST.swift
@@ -488,6 +488,13 @@ public indirect enum Expression: Hashable, Sendable {
   /// selected value is coerced. At least two arguments (the parser enforces
   /// it).
   case coalesce(Array<Expression>)
+  /// `NULLIF(v1, v2)` — NULL when `v1` equals `v2`, else `v1`. The ISO
+  /// definition is `CASE WHEN v1 = v2 THEN NULL ELSE v1 END`, but it is a
+  /// FIRST-CLASS node rather than that expansion so `v1` is evaluated EXACTLY
+  /// ONCE: the desugar embedded `v1` in both the equality and the `ELSE`,
+  /// evaluating a stateful `v1` twice — comparing one call's value to `v2` and
+  /// returning a different one. The result type is `v1`'s.
+  case nullif(Expression, Expression)
 }
 
 /// One `WHEN predicate THEN result` branch of a `CASE` expression — the guard

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -595,6 +595,8 @@ extension Expression {
       operand.aggregated
     case let .coalesce(arguments):
       arguments.contains { $0.aggregated }
+    case let .nullif(lhs, rhs):
+      lhs.aggregated || rhs.aggregated
     }
   }
 
@@ -619,6 +621,8 @@ extension Expression {
       operand.bound
     case let .coalesce(arguments):
       arguments.contains { $0.bound }
+    case let .nullif(lhs, rhs):
+      lhs.bound || rhs.bound
     }
   }
 }
@@ -906,6 +910,9 @@ extension Expression {
       operand.collect(into: &expressions)
     case let .coalesce(arguments):
       for argument in arguments { argument.collect(into: &expressions) }
+    case let .nullif(lhs, rhs):
+      lhs.collect(into: &expressions)
+      rhs.collect(into: &expressions)
     }
   }
 

--- a/Sources/SQL/Filter.swift
+++ b/Sources/SQL/Filter.swift
@@ -114,6 +114,12 @@ internal indirect enum Term: Sendable {
   /// that. `type` is the unification of the element types, to which the
   /// selected value is COERCED — the type the schema advertises.
   case coalesce(Array<Term>, type: ValueType)
+  /// `NULLIF(a, b)` — the lowered form of the AST's `Expression.nullif`. Both
+  /// operand terms are evaluated exactly ONCE (`va`, `vb`); the result is NULL
+  /// when `va = vb` is TRUE, else the SAME `va` that was compared. A desugar to
+  /// `CASE WHEN a = b THEN NULL ELSE a END` evaluated `a` twice — comparing one
+  /// value and returning another — which holding `a` ONCE fixes.
+  case nullif(Term, Term)
 }
 
 extension Term {
@@ -147,6 +153,9 @@ extension Term {
       for element in elements {
         element.references(into: &slots)
       }
+    case let .nullif(lhs, rhs):
+      lhs.references(into: &slots)
+      rhs.references(into: &slots)
     }
   }
 }
@@ -174,18 +183,20 @@ extension Term {
       .cast(operand.remapped(through: slot), type)
     case let .coalesce(elements, type):
       .coalesce(elements.map { $0.remapped(through: slot) }, type: type)
+    case let .nullif(lhs, rhs):
+      .nullif(lhs.remapped(through: slot), rhs.remapped(through: slot))
     }
   }
 
   /// Whether evaluating this term cannot throw — it is a bare slot read or a
   /// constant. A `binary` arithmetic (`/` raises on a zero divisor), an `apply`
   /// (a scalar function may raise), a `cast` (an unconvertible value raises),
-  /// or a `coalesce` (an element may raise) is NOT known safe, whatever its
-  /// operands.
+  /// a `coalesce` (an element may raise), or a `nullif` (an operand may raise)
+  /// is NOT known safe, whatever its operands.
   internal var safe: Bool {
     switch self {
     case .slot, .constant: true
-    case .apply, .binary, .case, .cast, .coalesce: false
+    case .apply, .binary, .case, .cast, .coalesce, .nullif: false
     }
   }
 
@@ -473,6 +484,8 @@ extension Row where Self: ~Escapable {
       try evaluate(operand, routines, bindings).cast(to: type)
     case let .coalesce(elements, type):
       try coalesce(elements, type, routines, bindings)
+    case let .nullif(lhs, rhs):
+      try nullif(lhs, rhs, routines, bindings)
     }
   }
 
@@ -496,6 +509,23 @@ extension Row where Self: ~Escapable {
       return value.coerced(to: type)
     }
     return .null
+  }
+
+  /// Evaluates a lowered `NULLIF(a, b)` against this row — `a` and `b` each
+  /// evaluated ONCE — returning NULL when `a = b` is TRUE, else the SAME `va`
+  /// that was compared.
+  ///
+  /// A desugar to `CASE WHEN a = b THEN NULL ELSE a END` evaluated `a` twice —
+  /// once in the equality and once as the `ELSE` — so a stateful `a` compared
+  /// one value and returned another; holding `va` fixes that. `matches` is
+  /// three-valued: only a definite TRUE equality nulls out, so an UNKNOWN (a
+  /// NULL operand) yields `va`.
+  private borrowing func nullif(_ lhs: Term, _ rhs: Term,
+                                _ routines: Routines, _ bindings: Bindings)
+      throws(SQLError) -> Value {
+    let va = try evaluate(lhs, routines, bindings)
+    let vb = try evaluate(rhs, routines, bindings)
+    return matches(va, .equal, vb) == true ? .null : va
   }
 
   /// Evaluates a lowered `CASE` — its `branches` and optional `otherwise`

--- a/Sources/SQL/Parser.swift
+++ b/Sources/SQL/Parser.swift
@@ -41,12 +41,13 @@
 /// expression     := additive
 /// additive       := multiplicative (('+' | '-') multiplicative)*
 /// multiplicative := factor (('*' | '/') factor)*
-/// factor         := '(' expression ')' | case | cast | coalesce
+/// factor         := '(' expression ')' | case | cast | coalesce | nullif
 ///                 | literal | aggregate | call | column
 /// case           := CASE [expression] (WHEN (predicate | expression) THEN
 ///                     expression)+ [ELSE expression] END
 /// cast           := CAST '(' expression AS type ')'
 /// coalesce       := COALESCE '(' expression (',' expression)+ ')'
+/// nullif         := NULLIF '(' expression ',' expression ')'
 /// literal        := string | integer | decimal | TRUE | FALSE | blob
 /// blob           := ('x' | 'X') "'" (hex hex)* "'"  // whole bytes
 /// aggregate      := COUNT '(' '*' ')'
@@ -606,6 +607,15 @@ internal struct Parser: ~Escapable {
       return try coalesce()
     }
 
+    // `NULLIF` is an ISO-defined expansion of a searched `CASE`, recognised
+    // case-insensitively only when written bare (a delimited `"NULLIF"` is a
+    // scalar-call name). Desugar into the first-class `Expression.nullif` here
+    // — the `(` is consumed — so the conditional's type derivation and
+    // coercion apply unchanged.
+    if !ident.quoted, ident.text.uppercased() == "NULLIF" {
+      return try nullif()
+    }
+
     // An aggregate is one of the fixed set of names (recognised
     // case-insensitively, only when written bare — a delimited `"COUNT"` is a
     // scalar name), distinct from a scalar call: it accumulates over a group
@@ -730,6 +740,22 @@ internal struct Parser: ~Escapable {
       throw .argument("COALESCE requires at least two arguments")
     }
     return .coalesce(arguments)
+  }
+
+  /// Parses the argument tail of `NULLIF(v1, v2)` — the `(` is already consumed
+  /// — into the first-class `Expression.nullif`.
+  ///
+  /// ISO 9075 defines `NULLIF(v1, v2)` as `CASE WHEN v1 = v2 THEN NULL ELSE v1
+  /// END`, but that expansion embeds `v1` in both the equality and the `ELSE`,
+  /// evaluating a stateful `v1` twice — so this builds the first-class node the
+  /// engine evaluates `v1` ONCE for. It takes exactly two arguments (else
+  /// `SQLError.argument`).
+  private mutating func nullif() throws(SQLError) -> Expression {
+    let left = try expression()
+    try expect(.comma)
+    let right = try expression()
+    try expect(.rparen)
+    return .nullif(left, right)
   }
 
   // MARK: - Predicate

--- a/Sources/SQL/Resolve.swift
+++ b/Sources/SQL/Resolve.swift
@@ -249,6 +249,11 @@ extension Schema {
       let scope = Scope([(relation, self)])
       let type = try scope.derive(expression, routines)
       return .coalesce(elements, type: type)
+    case let .nullif(lhs, rhs):
+      // Lower both operands to `Term`s over this relation and hold them in a
+      // first-class `Term.nullif` so each is evaluated ONCE.
+      return try .nullif(term(lhs, in: relation, routines),
+                         term(rhs, in: relation, routines))
     case .aggregate:
       // An aggregate has no per-row meaning — it folds over a group — so it may
       // not appear in a `WHERE`, a join `ON`, or a non-aggregate projection.
@@ -421,7 +426,28 @@ internal struct Scope {
       // `ValueType.unified` reduction a `CASE`'s results take), the type the
       // selected value coerces to.
       try unified(arguments, routines)
+    case let .nullif(lhs, rhs):
+      // NULLIF yields either `v1` or NULL, so the column takes `v1`'s type —
+      // but derive BOTH operands for resolution, returning the LHS type: an
+      // unresolved column faults `SQLError.column` (`NULLIF(1, Missing)`) on
+      // this derive-only surface too, mirroring the `||`/arithmetic derive
+      // branch rather than leaving the RHS unresolved.
+      try nullif(lhs, rhs, routines)
     }
+  }
+
+  /// The result type of `NULLIF(v1, v2)` under `derive` — `v1`'s type, deriving
+  /// BOTH operands for resolution first: NULLIF yields either `v1` or NULL, so
+  /// its own RHS type does not shape the column, but an unresolved column still
+  /// faults `SQLError.column`, mirroring the `||`/arithmetic derive branch. So
+  /// `NULLIF(1, Missing)` faults `.column` on the derive-only paths
+  /// (`columns(of:validate:false)`, an unreachable projection) where `validate`
+  /// never runs.
+  private func nullif(_ lhs: Expression, _ rhs: Expression,
+                      _ routines: Routines) throws(SQLError) -> ValueType {
+    let type = try derive(lhs, routines)
+    _ = try derive(rhs, routines)
+    return type
   }
 
   /// The target `type` of a `CAST`, deriving `operand` for its ordinal
@@ -575,6 +601,8 @@ internal struct Scope {
       try validate(cast: operand, to: type, routines)
     case let .coalesce(arguments):
       try coalesce(arguments, routines)
+    case let .nullif(lhs, rhs):
+      try nullif(validate: lhs, rhs, routines)
     }
   }
 
@@ -617,6 +645,19 @@ internal struct Scope {
       type = try merged(type, next)
     }
     return type ?? .integer
+  }
+
+  /// The result type of `NULLIF(v1, v2)`, validating both operands as a run
+  /// would fault. The result is either `v1` or NULL, so the column takes `v1`'s
+  /// type; `v2` need not unify with it (a run compares them under `matches`,
+  /// which yields FALSE across kinds without faulting), so it is validated for
+  /// its own errors (an unknown column, a bad call) but does not shape the
+  /// type.
+  private func nullif(validate lhs: Expression, _ rhs: Expression,
+                      _ routines: Routines) throws(SQLError) -> ValueType {
+    let type = try validate(lhs, routines)
+    _ = try validate(rhs, routines)
+    return type
   }
 
   /// The target `type` of a `CAST`, VALIDATING `operand` for real errors
@@ -1040,6 +1081,15 @@ internal struct Scope {
         return type.map { value.coerced(to: $0) } ?? value
       }
       return .null
+    case let .nullif(lhs, rhs):
+      // Fold as the run evaluates it — NULL when `v1 = v2` folds definitely
+      // TRUE, else `v1`; a side the fold cannot decide leaves it per row
+      // (`nil`).
+      guard let va = constant(lhs, routines),
+          let vb = constant(rhs, routines) else {
+        return nil
+      }
+      return matches(va, .equal, vb) == true ? .null : va
     case .column, .aggregate:
       return nil
     }
@@ -1220,6 +1270,9 @@ internal struct Scope {
       try aggregates(in: operand, routines)
     case let .coalesce(arguments):
       for argument in arguments { try aggregates(in: argument, routines) }
+    case let .nullif(lhs, rhs):
+      try aggregates(in: lhs, routines)
+      try aggregates(in: rhs, routines)
     }
   }
 
@@ -1330,6 +1383,12 @@ internal struct Scope {
         return value.coerced(to: type)
       }
       return .null
+    case let .nullif(lhs, rhs):
+      // Evaluate the empty group as a run does — NULL when `v1 = v2` is TRUE,
+      // else the folded `v1`.
+      let va = try empty(lhs, routines)
+      let vb = try empty(rhs, routines)
+      return matches(va, .equal, vb) == true ? .null : va
     case .column:
       return .null
     }
@@ -1547,6 +1606,10 @@ internal struct Scope {
       }
       let type = try derive(expression, routines)
       return .coalesce(elements, type: type)
+    case let .nullif(lhs, rhs):
+      // Lower both operands to combined-ordinal `Term`s and hold them in a
+      // first-class `Term.nullif` so each is evaluated ONCE.
+      return try .nullif(term(lhs, routines), term(rhs, routines))
     case .aggregate:
       // An aggregate has no per-row meaning — it folds over a group — so it may
       // not appear in a `WHERE`, a join `ON`, or a non-aggregate projection.
@@ -1766,6 +1829,10 @@ internal struct Grouping {
       }
       let type = try scope.derive(expression, routines)
       return .coalesce(elements, type: type)
+    case let .nullif(lhs, rhs):
+      // Lower both operands to grouped-space `Term`s and hold them in a
+      // first-class `Term.nullif` so each is evaluated ONCE.
+      return try .nullif(term(lhs, routines), term(rhs, routines))
     case .aggregate:
       // An aggregate reaches here only when it was not collected — an internal
       // inconsistency, since the query gathers every projection/HAVING aggregate.

--- a/Tests/SQLTests/NullifTests.swift
+++ b/Tests/SQLTests/NullifTests.swift
@@ -1,0 +1,179 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQL
+
+import SQLTestSupport
+
+// MARK: - Fixture
+
+/// A relation exercising `NULLIF`: a nullable integer `K` and a text `Name`, so
+/// a NULL result and a first-argument type are both reachable.
+private func things() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["Id": .integer, "K": .integer, "Name": .text]) {
+      Row(1, 10, "a")
+      Row(2, nil, "b")
+    }
+  }
+}
+
+/// Parses `text` and returns its `Select`, failing on any other shape.
+private func parse(select text: String) throws -> Select {
+  guard case let .select(.select(select)) = try Statement(parsing: text) else {
+    Issue.record("expected a single SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return select
+}
+
+/// Parses `text` to a `Query`, failing on any other shape.
+private func query(_ text: String) throws -> Query {
+  guard case let .select(query) = try Statement(parsing: text) else {
+    Issue.record("expected a SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return query
+}
+
+/// The single output column type of a one-column query's schema.
+private func type(of text: String, _ routines: Routines = [:])
+    throws -> ValueType {
+  guard case let .select(query) = try Statement(parsing: text) else {
+    Issue.record("expected a SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  let columns = try things().columns(of: query, routines: routines)
+  #expect(columns.count == 1)
+  return columns[0].type
+}
+
+// MARK: - NULLIF
+
+struct NullifTests {
+  @Test func `NULLIF parses to a first-class node`() throws {
+    // `NULLIF(K, 0)` is a first-class `Expression.nullif` holding `K` ONCE —
+    // not the re-referencing `CASE` its ISO definition names.
+    let select = try parse(select: "SELECT NULLIF(K, 0) FROM T")
+    let expression = Expression.nullif(.column("K"), .literal(.integer(0)))
+    #expect(select.projection
+                == .expressions([Projected(expression: expression)]))
+  }
+
+  @Test func `equal arguments yield NULL`() throws {
+    try things().expect("SELECT NULLIF(1, 1)", yields: [[nil]])
+  }
+
+  @Test func `unequal integer arguments yield the first`() throws {
+    try things().expect("SELECT NULLIF(1, 2)", yields: [[1]])
+  }
+
+  @Test func `unequal text arguments yield the first`() throws {
+    try things().expect("SELECT NULLIF('a', 'b')", yields: [["a"]])
+  }
+
+  @Test func `the column type is the first argument's`() throws {
+    // The NULL result imposes no type; the ELSE (the first argument) types it.
+    #expect(try type(of: "SELECT NULLIF(Name, 'x') AS C FROM T") == .text)
+  }
+
+  @Test func `rejects a single argument`() {
+    #expect(throws: SQLError.self) {
+      _ = try Statement(parsing: "SELECT NULLIF(K) FROM T")
+    }
+  }
+}
+
+// MARK: - Derivation resolves both operands
+
+/// A `People` catalog with a text `Name` — the base for a derive-level test.
+private func people() -> FixtureCatalog {
+  FixtureCatalog(
+    ["People": FixtureRelation([FixtureField(name: "Name", type: .text)], [])])
+}
+
+/// The type `derive` reports for the sole projected expression of `text`, over
+/// a `People` scope — the schema-only derive surface (`scope(of:)` reads no
+/// cursor and skips `compile`), so `derive` alone resolves the operands.
+private func derived(_ text: String) throws -> ValueType {
+  let select = try parse(select: text)
+  guard case let .expressions(items) = select.projection, items.count == 1
+  else {
+    Issue.record("expected a single projected expression")
+    throw SQLError.incomplete(expected: "one projected expression")
+  }
+  let scope = try people().scope(of: select, Context())
+  return try scope.derive(items[0].expression)
+}
+
+/// The `derive` surface RESOLVES column references without `compile`'s
+/// lowering, so `derive` alone must resolve BOTH NULLIF operands: the LHS
+/// shapes the result type and the RHS resolves for its errors, exactly as the
+/// `||`/arithmetic derive branch derives both sides.
+struct NullifDerivationTests {
+  @Test func `deriving NULLIF resolves the second operand`() throws {
+    // `derive` — the schema-only surface a `columns(of:validate:false)` and an
+    // unreachable projection take, which RESOLVES column references — must
+    // derive both `NULLIF` operands, so an unresolved RHS `Missing` faults
+    // `SQLError.column` rather than the branch silently returning the LHS type,
+    // mirroring the arithmetic `.binary` derive branch.
+    #expect(throws: SQLError.column("Missing")) {
+      _ = try derived("SELECT NULLIF(1, Missing) FROM People")
+    }
+  }
+
+  @Test func `a resolved NULLIF derives the first operand's type`() throws {
+    // A `NULLIF` whose operands both resolve derives the LHS type — the text
+    // `Name`, not the integer RHS — the result being either `v1` or NULL.
+    #expect(try derived("SELECT NULLIF(Name, 0) FROM People") == .text)
+  }
+}
+
+// MARK: - Operand evaluated once
+
+/// A shared call counter a stateful routine increments — a tiny
+/// `@unchecked Sendable` box over a mutable count, so the non-deterministic
+/// `stepper()` routine registered against it both observes successive values
+/// and records how many times the run invoked it. The engine evaluates a row's
+/// projection synchronously on one thread, so the box needs no lock.
+private final class Counter: @unchecked Sendable {
+  /// The number of times `next()` has been called.
+  private(set) var count = 0
+
+  /// Increments the count and returns the PREVIOUS value — the sequence `0, 1,
+  /// 2, …` across successive calls.
+  func next() -> Int {
+    defer { count += 1 }
+    return count
+  }
+}
+
+struct NullifOperandTests {
+  /// A single-row table, so a per-row operand runs once for the one row.
+  private func one() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["Id": .integer]) {
+        Row(1)
+      }
+    }
+  }
+
+  @Test func `the NULLIF operand is evaluated once`() throws {
+    // `stepper()` yields 0, then 1, …; non-deterministic, so unfoldable.
+    // `NULLIF(stepper(), 99)` must evaluate `stepper()` EXACTLY ONCE — yielding
+    // 0, which ≠ 99, so it returns that SAME 0. The old CASE desugar embedded
+    // the operand in both the `= 99` equality and the `ELSE`, calling
+    // `stepper()` twice: the equality compared 0 and the ELSE returned a
+    // DIFFERENT 1. The first-class node holds the operand, so the counter reads
+    // exactly 1 and the value returned is the one compared.
+    let counter = Counter()
+    let routines = try Routines()
+        .registering("stepper", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+    try one().expect("SELECT NULLIF(stepper(), 99) FROM T", yields: [[0]],
+                     routines: routines)
+    #expect(counter.count == 1)
+  }
+}


### PR DESCRIPTION
Add the ISO `NULLIF(v1, v2)` — NULL when `v1` equals `v2`, else `v1` — as a first-class `Expression.nullif` lowered to `Term.nullif`, rather than the `CASE WHEN v1 = v2 THEN NULL ELSE v1 END` expansion its definition names. Both operands are evaluated EXACTLY ONCE (the desugar embedded `v1` in both the equality and the `ELSE`), the result is NULL only on a definite TRUE equality (an UNKNOWN cross-NULL comparison yields `v1`), and the column takes `v1`'s type.

The `derive` branch derives BOTH operands — the LHS for the result type and the RHS for resolution — before returning the LHS type, mirroring the `||`/arithmetic derive branch, so `NULLIF(1, Missing)` faults `SQLError.column` on the derive-only surface (`columns(of:validate:false)`, an unreachable projection) where the faulting `validate` never runs.