### PR TITLE
SQL: add the IS [NOT] DISTINCT FROM predicate

### DIFF
--- a/Sources/SQL/AST.swift
+++ b/Sources/SQL/AST.swift
@@ -619,6 +619,15 @@ public indirect enum Predicate: Hashable, Sendable {
   /// `LIKE` arms accept, so a caller can bind a range rather than interpolate
   /// it.
   case between(Expression, Operand, Operand, negated: Bool)
+  /// `a IS [NOT] DISTINCT FROM b` — the ISO null-safe comparison of `a` and
+  /// `b`, `negated` marking the `IS NOT DISTINCT FROM` (null-safe equality)
+  /// spelling. It is TWO-VALUED — never UNKNOWN — treating NULL as a comparable
+  /// value: `a IS DISTINCT FROM b` is FALSE iff both are NULL, or both are
+  /// non-NULL and equal, and TRUE otherwise (exactly one NULL, or both non-NULL
+  /// and unequal). `IS NOT DISTINCT FROM` is its negation. A cross-kind pair is
+  /// DISTINCT — the two differ — matching the engine's cross-kind FALSE
+  /// equality. Unlike `=`, a NULL operand never makes the row UNKNOWN.
+  case distinct(Expression, Expression, negated: Bool)
   /// `lhs AND rhs`.
   case and(Predicate, Predicate)
   /// `lhs OR rhs`.

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -687,6 +687,8 @@ extension Predicate {
           || (escape?.aggregated ?? false)
     case let .between(test, lower, upper, _):
       test.aggregated || lower.aggregated || upper.aggregated
+    case let .distinct(lhs, rhs, _):
+      lhs.aggregated || rhs.aggregated
     case let .and(lhs, rhs), let .or(lhs, rhs):
       lhs.aggregated || rhs.aggregated
     case let .not(operand):
@@ -712,6 +714,8 @@ extension Predicate {
       operand.bound || pattern.bound || (escape?.bound ?? false)
     case let .between(test, lower, upper, _):
       test.bound || lower.bound || upper.bound
+    case let .distinct(lhs, rhs, _):
+      lhs.bound || rhs.bound
     case let .and(lhs, rhs), let .or(lhs, rhs):
       lhs.bound || rhs.bound
     case let .not(operand):
@@ -963,6 +967,9 @@ extension Predicate {
       test.collect(into: &expressions)
       lower.collect(into: &expressions)
       upper.collect(into: &expressions)
+    case let .distinct(lhs, rhs, _):
+      lhs.collect(into: &expressions)
+      rhs.collect(into: &expressions)
     case let .and(lhs, rhs), let .or(lhs, rhs):
       lhs.collect(into: &expressions)
       rhs.collect(into: &expressions)

--- a/Sources/SQL/Filter.swift
+++ b/Sources/SQL/Filter.swift
@@ -59,6 +59,15 @@ internal indirect enum Filter: Sendable {
   /// NULL `x`, `a`, or `b` — an unbound or NULL-bound `:parameter` included —
   /// makes a bound UNKNOWN and the row is excluded.
   case between(Term, Operand, Operand, negated: Bool)
+  /// `a IS [NOT] DISTINCT FROM b` — the lowered form of the AST's `distinct`.
+  /// Both operands are plain `Term`s (no `:parameter` form is defined for this
+  /// predicate) and `negated` marks the `IS NOT DISTINCT FROM` (null-safe
+  /// equality) spelling. Evaluating it is TWO-VALUED — never UNKNOWN — treating
+  /// NULL as a comparable value: the two are the SAME iff both are NULL, or
+  /// both non-NULL and equal (a cross-kind pair is DISTINCT, matching
+  /// `matches`'s cross-kind FALSE equality), and `IS DISTINCT FROM` is TRUE
+  /// when they differ, `IS NOT DISTINCT FROM` when they are the same.
+  case distinct(Term, Term, negated: Bool)
   /// `lhs AND rhs`.
   case and(Filter, Filter)
   /// `lhs OR rhs`.
@@ -300,6 +309,9 @@ extension Filter {
     case let .between(test, lower, upper, negated):
       .between(test.remapped(through: slot), lower.remapped(through: slot),
                upper.remapped(through: slot), negated: negated)
+    case let .distinct(lhs, rhs, negated):
+      .distinct(lhs.remapped(through: slot), rhs.remapped(through: slot),
+                negated: negated)
     case let .and(lhs, rhs):
       .and(lhs.remapped(through: slot), rhs.remapped(through: slot))
     case let .or(lhs, rhs):
@@ -388,6 +400,7 @@ extension Filter {
           && (escape.map(\.escape) ?? true)
     case let .between(test, lower, upper, _):
       test.safe && lower.safe && upper.safe
+    case let .distinct(lhs, rhs, _): lhs.safe && rhs.safe
     case let .and(lhs, rhs): lhs.safe && rhs.safe
     case let .or(lhs, rhs): lhs.safe && rhs.safe
     case let .not(operand): operand.safe
@@ -419,7 +432,7 @@ extension Filter {
   private var parameterised: Bool {
     switch self {
     case .bound: true
-    case .compare, .match, .null, .membership: false
+    case .compare, .match, .null, .membership, .distinct: false
     case let .like(_, pattern, escape, _):
       pattern.parameterised || (escape?.parameterised ?? false)
     case let .between(_, lower, upper, _):
@@ -748,6 +761,21 @@ internal func matches(_ lhs: Value, _ op: Comparison, _ rhs: Value) -> Bool? {
   }
 }
 
+/// Whether two typed values DIFFER under ISO `IS DISTINCT FROM` — the null-safe
+/// comparison, treating NULL as a comparable value. Unlike `matches`, it is
+/// TWO-VALUED (never UNKNOWN): two NULLs are the SAME (not DISTINCT), exactly
+/// one NULL is DISTINCT, and two non-NULLs are DISTINCT unless they are equal —
+/// a cross-kind pair being DISTINCT, as `matches` yields FALSE (`== true` is
+/// false) for cross-kind equality. `IS DISTINCT FROM` returns this; `IS NOT
+/// DISTINCT FROM` (null-safe equality) negates it.
+internal func distinct(_ lhs: Value, _ rhs: Value) -> Bool {
+  switch (lhs, rhs) {
+  case (.null, .null): false
+  case (.null, _), (_, .null): true
+  case let (lhs, rhs): matches(lhs, .equal, rhs) != true
+  }
+}
+
 /// Kleene `AND` over two three-valued operands: `false` dominates (a `false`
 /// side makes the whole `false` even against UNKNOWN), both `true` is `true`,
 /// and any other pair is UNKNOWN (`nil`).
@@ -805,6 +833,8 @@ extension Row where Self: ~Escapable {
       try like(operand, pattern, escape, negated, routines, bindings)
     case let .between(test, lower, upper, negated):
       try ranged(test, lower, upper, negated, routines, bindings)
+    case let .distinct(lhs, rhs, negated):
+      try differs(lhs, rhs, negated, routines, bindings)
     case let .and(lhs, rhs):
       // `&&`/`||` take an `@autoclosure` right operand, which would capture the
       // borrowed `~Escapable` row; spell each connective explicitly so a branch
@@ -891,6 +921,23 @@ extension Row where Self: ~Escapable {
     let high = try evaluate(upper, routines, bindings)
     let within = and(above, matches(value, .leq, high))
     return negated ? within.map { !$0 } : within
+  }
+
+  /// Evaluates a lowered `lhs IS [NOT] DISTINCT FROM rhs` against this row.
+  ///
+  /// It is the ISO null-safe comparison — TWO-VALUED, never UNKNOWN — treating
+  /// NULL as a comparable value: `distinct` yields whether the two operand
+  /// values DIFFER (both NULL are the SAME, exactly one NULL DIFFERS, two
+  /// non-NULLs DIFFER unless equal, a cross-kind pair DIFFERS). `IS DISTINCT
+  /// FROM` reads that; `IS NOT DISTINCT FROM` (`negated`, null-safe equality)
+  /// negates it. Unlike a `compare`, a NULL operand never makes the row
+  /// UNKNOWN.
+  private borrowing func differs(_ lhs: Term, _ rhs: Term, _ negated: Bool,
+                                 _ routines: Routines, _ bindings: Bindings)
+      throws(SQLError) -> Bool? {
+    let differ = try distinct(evaluate(lhs, routines, bindings),
+                              evaluate(rhs, routines, bindings))
+    return negated ? !differ : differ
   }
 
   /// Resolves a `LIKE` pattern or escape operand to a value: a term evaluates

--- a/Sources/SQL/Parser.swift
+++ b/Sources/SQL/Parser.swift
@@ -36,6 +36,7 @@
 /// negation       := NOT negation | primary
 /// primary        := '(' predicate ')' | comparison
 /// comparison     := expression (op (expression | param) | IS [NOT] NULL
+///                 | IS [NOT] DISTINCT FROM expression
 ///                 | [NOT] IN '(' expression (',' expression)* ')'
 ///                 | [NOT] LIKE expression [ESCAPE expression]
 ///                 | [NOT] BETWEEN (expression | param) AND
@@ -834,7 +835,9 @@ internal struct Parser: ~Escapable {
   /// `:parameter` right operand binds the comparison to a value resolved at run
   /// time from the engine's bindings — the correlated-subquery primitive. An
   /// `IS NULL` (or `IS NOT NULL`) tail tests the left expression for `NULL`
-  /// rather than comparing it — the way a nullable column is filtered. An `IN`
+  /// rather than comparing it — the way a nullable column is filtered. An `IS
+  /// [NOT] DISTINCT FROM` tail is the ISO null-safe comparison of the two
+  /// expressions, treating NULL as a comparable value. An `IN`
   /// (or `NOT IN`) tail tests the left expression for membership in a
   /// parenthesised value list. A `LIKE` (or `NOT LIKE`) tail tests the left
   /// expression's text against a pattern, with an optional `ESCAPE` character.
@@ -846,6 +849,9 @@ internal struct Parser: ~Escapable {
     let left = try expression()
     if try match(.is) {
       let negated = try match(.not)
+      if try match(.distinct) {
+        return try distinct(left, negated: negated)
+      }
       try expect(.null)
       return .null(left, negated: negated)
     }
@@ -893,6 +899,22 @@ internal struct Parser: ~Escapable {
     }
     try expect(.rparen)
     return .membership(left, values, negated: negated)
+  }
+
+  /// Parses the right operand of `left IS [NOT] DISTINCT FROM right` — the `IS
+  /// [NOT] DISTINCT` is already consumed — into the first-class
+  /// `Predicate.distinct`, `negated` carrying the `IS NOT` (null-safe equality)
+  /// spelling.
+  ///
+  /// It is the ISO null-safe comparison of the two expressions: TWO-VALUED
+  /// (never UNKNOWN), treating NULL as a comparable value, unlike `=`. The
+  /// right operand is an ordinary scalar `expression` — not an `Operand`, as no
+  /// `:parameter` form is defined for this predicate.
+  private mutating func distinct(_ left: Expression, negated: Bool)
+      throws(SQLError) -> Predicate {
+    try expect(.from)
+    let right = try expression()
+    return .distinct(left, right, negated: negated)
   }
 
   /// Parses the bounds tail of `left [NOT] BETWEEN a AND b` — the `BETWEEN` is

--- a/Sources/SQL/Resolve.swift
+++ b/Sources/SQL/Resolve.swift
@@ -61,6 +61,13 @@ private func lower(_ predicate: Predicate,
     // a `.term` or a `:parameter` name resolved from the bindings at eval.
     try .between(term(test), lower(low, term: term), lower(high, term: term),
                  negated: negated)
+  case let .distinct(lhs, rhs, negated):
+    // `a IS [NOT] DISTINCT FROM b` lowers to a first-class `Filter.distinct`
+    // over the two lowered terms — the null-safe comparison the runtime
+    // evaluates TWO-VALUED, treating NULL as a comparable value. No
+    // `:parameter` form is defined, so both sides lower straight through
+    // `term`.
+    try .distinct(term(lhs), term(rhs), negated: negated)
   case let .and(lhs, rhs):
     try .and(lower(lhs, term: term), lower(rhs, term: term))
   case let .or(lhs, rhs):
@@ -1008,6 +1015,16 @@ internal struct Scope {
         return matches(value, .geq, low) == false
       }()
       if !settled { try validate(upper, routines) }
+    case let .distinct(lhs, rhs, _):
+      // `a IS [NOT] DISTINCT FROM b` compares both operands, so validate the
+      // two for real errors (an unknown column, a bad call). BOTH are always
+      // validated — the predicate is TWO-VALUED with no short-circuit: neither
+      // side settles the truth without the other. A cross-kind pair is NOT
+      // rejected: the run's `distinct` treats it as DISTINCT without faulting
+      // (as an `IN` element does), so the schema check accepts what the run
+      // accepts.
+      _ = try validate(lhs, routines)
+      _ = try validate(rhs, routines)
     case let .and(lhs, rhs):
       try check(lhs, routines)
       if constant(lhs, routines) != false { try check(rhs, routines) }
@@ -1283,6 +1300,17 @@ internal struct Scope {
       guard let high = constant(upper, routines) else { return nil }
       let within = and(above, matches(value, .leq, high))
       return negated ? within.map { !$0 } : within
+    case let .distinct(lhs, rhs, negated):
+      // Fold `a IS [NOT] DISTINCT FROM b` as `differs` evaluates it: the
+      // null-safe `distinct` of the two folded values, negated for `IS NOT`.
+      // It is TWO-VALUED, so when BOTH sides fold to ROW-INDEPENDENT constants
+      // the truth is DEFINITE; a row-dependent side leaves it per row (`nil`).
+      guard let lhs = constant(lhs, routines),
+          let rhs = constant(rhs, routines) else {
+        return nil
+      }
+      let differ = distinct(lhs, rhs)
+      return negated ? !differ : differ
     case .bound:
       return nil
     }
@@ -1409,6 +1437,9 @@ internal struct Scope {
       try aggregates(in: test, routines)
       try aggregates(in: lower, routines)
       try aggregates(in: upper, routines)
+    case let .distinct(lhs, rhs, _):
+      try aggregates(in: lhs, routines)
+      try aggregates(in: rhs, routines)
     case let .and(lhs, rhs), let .or(lhs, rhs):
       try aggregates(in: lhs, routines)
       try aggregates(in: rhs, routines)
@@ -1594,6 +1625,13 @@ internal struct Scope {
       if above == false { return negated }
       let within = and(above, matches(value, .leq, try empty(upper, routines)))
       return negated ? within.map { !$0 } : within
+    case let .distinct(lhs, rhs, negated):
+      // Fold `a IS [NOT] DISTINCT FROM b` over the empty group as `differs`
+      // does: the null-safe `distinct` of the two folded values, negated for
+      // `IS NOT`. It is TWO-VALUED — both operands fold to definite values, so
+      // the truth is definite (never UNKNOWN, unlike a `=` over a NULL).
+      let differ = distinct(try empty(lhs, routines), try empty(rhs, routines))
+      return negated ? !differ : differ
     case let .and(lhs, rhs):
       // A `false` left proves the `AND` false without folding the right arm,
       // which a run's short-circuit never evaluates and so must not fault.
@@ -2088,6 +2126,9 @@ extension Filter {
       test.references(into: &ordinals)
       lower.references(into: &ordinals)
       upper.references(into: &ordinals)
+    case let .distinct(lhs, rhs, _):
+      lhs.references(into: &ordinals)
+      rhs.references(into: &ordinals)
     case let .and(lhs, rhs), let .or(lhs, rhs):
       lhs.references(into: &ordinals)
       rhs.references(into: &ordinals)

--- a/Tests/SQLTests/DistinctFromTests.swift
+++ b/Tests/SQLTests/DistinctFromTests.swift
@@ -1,0 +1,213 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQL
+
+import SQLTestSupport
+
+// MARK: - Fixture
+
+/// A relation exercising `IS [NOT] DISTINCT FROM`: two integer columns `K` and
+/// `L`, each `NULL` in some rows, so the null-safe corners (both NULL, exactly
+/// one NULL) are reachable by comparing columns — SQL has no bare `NULL`
+/// literal in expression position, so a NULL operand is spelled as a NULL cell.
+/// Row 5 is both-NULL, rows 3 and 4 are one-NULL, rows 1 and 2 are non-NULL.
+private func things() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["Id": .integer, "K": .integer, "L": .integer]) {
+      Row(1, 5, 5)
+      Row(2, 1, 2)
+      Row(3, 5, nil)
+      Row(4, nil, 7)
+      Row(5, nil, nil)
+    }
+  }
+}
+
+/// Parses `text` and returns its `Select`, failing on any other shape.
+private func parse(select text: String) throws -> Select {
+  guard case let .select(.select(select)) = try Statement(parsing: text) else {
+    Issue.record("expected a single SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return select
+}
+
+// MARK: - Parsing
+
+struct DistinctFromParsingTests {
+  @Test func `IS DISTINCT FROM parses to a first-class node`() throws {
+    // `a IS DISTINCT FROM b` is a first-class `Predicate.distinct` holding both
+    // operands as plain expressions — no `:parameter` form is defined for it.
+    let select =
+        try parse(select: "SELECT * FROM T WHERE K IS DISTINCT FROM 5")
+    #expect(select.predicate
+                == .distinct(.column("K"), .literal(.integer(5)),
+                             negated: false))
+  }
+
+  @Test func `IS NOT DISTINCT FROM parses to a negated first-class node`()
+      throws {
+    // `a IS NOT DISTINCT FROM b` is the same node, `negated` — null-safe
+    // equality.
+    let select =
+        try parse(select: "SELECT * FROM T WHERE K IS NOT DISTINCT FROM 5")
+    #expect(select.predicate
+                == .distinct(.column("K"), .literal(.integer(5)),
+                             negated: true))
+  }
+
+  @Test func `both operands are ordinary expressions`() throws {
+    // Neither side is special — a column against a column parses too.
+    let select =
+        try parse(select: "SELECT * FROM T WHERE K IS DISTINCT FROM Id")
+    #expect(select.predicate
+                == .distinct(.column("K"), .column("Id"), negated: false))
+  }
+}
+
+// MARK: - Evaluation
+
+struct DistinctFromEvaluationTests {
+  @Test func `equal non-null values are NOT DISTINCT`() throws {
+    // Row 1's K is 5 — equal to 5, so `K IS DISTINCT FROM 5` is FALSE and the
+    // row is dropped; the unequal and NULL Ks stay DISTINCT.
+    try things().expect("SELECT Id FROM T WHERE K IS DISTINCT FROM 5",
+                        yields: [[2], [4], [5]])
+  }
+
+  @Test func `equal non-null values match NOT DISTINCT`() throws {
+    // The complement: `K IS NOT DISTINCT FROM 5` keeps only the rows whose K
+    // equals 5 — rows 1 and 3.
+    try things().expect("SELECT Id FROM T WHERE K IS NOT DISTINCT FROM 5",
+                        yields: [[1], [3]])
+  }
+
+  @Test func `exactly one NULL operand is DISTINCT`() throws {
+    // Row 3 (K = 5, L = NULL) and row 4 (K = NULL, L = 7) each pair a NULL with
+    // a non-NULL, so `K IS DISTINCT FROM L` is TRUE for them — a NULL differs
+    // from a non-NULL — where `K = L` would be UNKNOWN and drop them. Row 2
+    // (1 vs 2) also differs; rows 1 (equal) and 5 (both NULL) do not.
+    try things().expect("SELECT Id FROM T WHERE K IS DISTINCT FROM L",
+                        yields: [[2], [3], [4]])
+  }
+
+  @Test func `both NULL operands are NOT DISTINCT`() throws {
+    // Row 5 has both K and L NULL; two NULLs are the SAME, so `K IS NOT DISTINCT
+    // FROM L` keeps it — alongside the equal-valued row 1 — where the null-safe
+    // equality `K = L` (UNKNOWN on any NULL) could never keep the both-NULL row.
+    try things().expect("SELECT Id FROM T WHERE K IS NOT DISTINCT FROM L",
+                        yields: [[1], [5]])
+  }
+
+  @Test func `a non-null against a NULL cell is DISTINCT`() throws {
+    // Row 3's L is NULL against a non-NULL K, so `L IS DISTINCT FROM K` keeps
+    // it; the both-NULL row 5 is NOT DISTINCT and the equal row 1 is not.
+    try things().expect("SELECT Id FROM T WHERE L IS DISTINCT FROM K",
+                        yields: [[2], [3], [4]])
+  }
+
+  @Test func `column against itself is null-safe`() throws {
+    // `K IS NOT DISTINCT FROM K` is TRUE on EVERY row, NULL rows included — a
+    // NULL equals itself under null-safe equality, where `K = K` would be
+    // UNKNOWN (and drop) on the NULL-K rows 4 and 5.
+    try things().expect("SELECT Id FROM T WHERE K IS NOT DISTINCT FROM K",
+                        yields: [[1], [2], [3], [4], [5]])
+  }
+}
+
+// MARK: - Cross-kind
+
+struct DistinctFromCrossKindTests {
+  @Test func `a cross-kind pair is DISTINCT`() throws {
+    // Integer `K` against the text `'5'` is a cross-kind pair — the engine's
+    // `matches` yields FALSE for cross-kind equality, so the two DIFFER — and
+    // `K IS DISTINCT FROM '5'` keeps every non-NULL K (rows 1, 2, 3) and the
+    // NULL Ks too (a NULL differs from a non-NULL text).
+    try things().expect("SELECT Id FROM T WHERE K IS DISTINCT FROM '5'",
+                        yields: [[1], [2], [3], [4], [5]])
+  }
+
+  @Test func `a cross-kind pair is never NOT DISTINCT`() throws {
+    // Its complement keeps nothing: no integer K is null-safe EQUAL to the text
+    // `'5'` (cross-kind is DISTINCT), so `K IS NOT DISTINCT FROM '5'` is FALSE
+    // on every row.
+    try things().empty("SELECT Id FROM T WHERE K IS NOT DISTINCT FROM '5'")
+  }
+}
+
+// MARK: - Two-valued semantics
+
+struct DistinctFromTwoValuedTests {
+  @Test func `IS DISTINCT FROM and IS NOT DISTINCT FROM partition the rows`()
+      throws {
+    // The predicate is TWO-VALUED — never UNKNOWN — so on EVERY row exactly one
+    // of the two spellings holds and neither is UNKNOWN. `K IS NOT DISTINCT FROM
+    // 5` keeps rows 1 and 3 (K = 5); `K IS DISTINCT FROM 5` keeps the OTHER
+    // three — rows 2, 4, 5 — including the NULL-K rows a `=` would leave
+    // UNKNOWN, so together they cover all five rows disjointly.
+    try things().expect("SELECT Id FROM T WHERE K IS NOT DISTINCT FROM 5",
+                        yields: [[1], [3]])
+    try things().expect("SELECT Id FROM T WHERE K IS DISTINCT FROM 5",
+                        yields: [[2], [4], [5]])
+  }
+
+  @Test func `a NULL operand never makes the row UNKNOWN`() throws {
+    // Contrast with `=`: `K = 5` is UNKNOWN on the NULL-K rows and drops them,
+    // so it keeps FEWER rows than `K IS NOT DISTINCT FROM 5`. The null-safe form
+    // keeps rows 1 and 3 (K = 5) and, unlike `=`, is DEFINITELY FALSE (not
+    // UNKNOWN) on the NULL-K rows rather than erroring or admitting them.
+    try things().expect("SELECT Id FROM T WHERE K = 5", yields: [[1], [3]])
+    try things().expect("SELECT Id FROM T WHERE K IS NOT DISTINCT FROM 5",
+                        yields: [[1], [3]])
+  }
+
+  @Test func `NOT of a NULL-operand comparison keeps it while NOT DISTINCT does`()
+      throws {
+    // `NOT (K = 5)` is still UNKNOWN on the NULL-K rows (NOT of UNKNOWN is
+    // UNKNOWN), so it keeps only the definite-unequal row 2 — whereas `K IS
+    // DISTINCT FROM 5` is two-valued and additionally keeps the NULL-K rows 4
+    // and 5.
+    try things().expect("SELECT Id FROM T WHERE NOT (K = 5)", yields: [[2]])
+    try things().expect("SELECT Id FROM T WHERE K IS DISTINCT FROM 5",
+                        yields: [[2], [4], [5]])
+  }
+}
+
+// MARK: - Constant folding
+
+struct DistinctFromFoldingTests {
+  /// The `Id`s of every fixture row — a constant-TRUE `WHERE` keeps them all.
+  private let all = [[1], [2], [3], [4], [5]]
+
+  @Test func `a constant DISTINCT folds true and keeps every row`() throws {
+    // `1 IS DISTINCT FROM 2` folds to a constant TRUE, kept on every row.
+    try things().expect("SELECT Id FROM T WHERE 1 IS DISTINCT FROM 2",
+                        yields: all)
+  }
+
+  @Test func `a constant NOT DISTINCT of equal folds true`() throws {
+    // `1 IS NOT DISTINCT FROM 1` folds TRUE.
+    try things().expect("SELECT Id FROM T WHERE 1 IS NOT DISTINCT FROM 1",
+                        yields: all)
+  }
+
+  @Test func `a constant both-NULL folds NOT DISTINCT`() throws {
+    // `NULLIF(1, 1)` folds to a constant NULL, so both operands fold NULL — the
+    // SAME — and `NULLIF(1, 1) IS DISTINCT FROM NULLIF(1, 1)` folds FALSE
+    // (dropping every row) and its negation TRUE.
+    try things().empty(
+        "SELECT Id FROM T WHERE NULLIF(1, 1) IS DISTINCT FROM NULLIF(1, 1)")
+    try things().expect(
+        "SELECT Id FROM T WHERE NULLIF(1, 1) IS NOT DISTINCT FROM NULLIF(1, 1)",
+        yields: all)
+  }
+
+  @Test func `a constant one-NULL folds DISTINCT`() throws {
+    // Exactly one NULL is DISTINCT, so `1 IS DISTINCT FROM NULLIF(2, 2)` — the
+    // second folding to NULL — folds TRUE.
+    try things().expect(
+        "SELECT Id FROM T WHERE 1 IS DISTINCT FROM NULLIF(2, 2)", yields: all)
+  }
+}


### PR DESCRIPTION
Add the ISO 9075 null-safe comparison `a IS [NOT] DISTINCT FROM b` as a first-class `Predicate.distinct` lowered to `Filter.distinct`, threaded through every predicate/filter walk. It is a TWO-VALUED (never UNKNOWN) comparison that treats NULL as a comparable value: `a IS DISTINCT FROM b` is FALSE iff both operands are NULL, or both are non-NULL and equal, and TRUE otherwise (exactly one NULL, or both non-NULL and unequal). `IS NOT DISTINCT FROM` is its negation — null-safe equality. A cross-kind pair is DISTINCT (the two differ), matching `matches`'s cross-kind FALSE equality, so the null-safe form agrees with the run's ordinary comparison on every non-NULL, like-kind pair.

Both operands are ordinary scalar expressions — no `:parameter` form is defined for this predicate, so both sides lower straight through `term`, the lowered `Filter.distinct` holds two plain `Term`s, and the predicate is never `parameterised`. Unlike a `compare`, a NULL operand never makes the row UNKNOWN: the run's `differs`, the constant-fold, and the empty-group fold each compute the null-safe truth via a shared two-valued `distinct(Value, Value)` helper and negate it, so the truth is definite whenever both sides are decided (constant folding needs both operands row-independent; the empty-group fold always is).

The parser dispatches the tail off the existing `IS [NOT]` arm — a new `DISTINCT FROM` branch beside `NULL` — reusing the existing `DISTINCT` and `FROM` tokens (added for `SELECT DISTINCT` and the `FROM` clause), so no lexer or token change is needed. It runs as a residual filter and does not seek — it is not a range or an equality on a sort key — so the seek path is untouched.