### PR TITLE
SQL: add the POSITION and OVERLAY string functions

### DIFF
--- a/Sources/SQL/Function.swift
+++ b/Sources/SQL/Function.swift
@@ -60,6 +60,16 @@ public struct Routine: Sendable {
   /// before a schema is published (see `Scope`'s `call`).
   public let parameters: Array<ValueType>
 
+  /// The number of REQUIRED leading arguments; arguments beyond it (up to
+  /// `parameters.count`) are OPTIONAL, so a call's arity may be anywhere in
+  /// `minimum ... parameters.count`. Defaults to `parameters.count` — all
+  /// required, a fixed arity — so every fixed-arity routine is unchanged.
+  /// `OVERLAY` sets it to 3 with an optional fourth `length` the routine
+  /// DEFAULTS from its once-evaluated replacement, so the parser need not
+  /// re-reference the replacement (which would double-evaluate a
+  /// non-deterministic one).
+  public let minimum: Int
+
   /// The declared result type, read to type a call statically.
   public let returns: ValueType
 
@@ -73,10 +83,11 @@ public struct Routine: Sendable {
   private let body: Body
 
   public init(returns: ValueType = .integer, parameters: Array<ValueType>,
-              deterministic: Bool = false,
+              minimum: Int? = nil, deterministic: Bool = false,
               _ compute: @escaping @Sendable (Array<Value>)
                   throws(SQLError) -> Value) {
     self.parameters = parameters
+    self.minimum = minimum ?? parameters.count
     self.returns = returns
     self.deterministic = deterministic
     self.body = .native(compute)
@@ -137,6 +148,7 @@ public struct Routine: Sendable {
                           + "\(returns.domain)")
     }
     self.parameters = parameters
+    self.minimum = parameters.count
     self.returns = returns
     self.deterministic = false
     self.body =
@@ -384,9 +396,16 @@ public struct Routines: Sendable {
   ///
   /// - STRING: `UPPER`/`LOWER` (case fold), `CHAR_LENGTH` (with its ISO synonym
   ///   `CHARACTER_LENGTH`, the same routine under both names), `SUBSTRING` (the
-  ///   two-argument `SUBSTRING(text, start)` form, ISO 1-based indexing), and
+  ///   two-argument `SUBSTRING(text, start)` form, ISO 1-based indexing),
   ///   `TRIM` (the one-argument `TRIM(text)` form, stripping leading and
-  ///   trailing spaces).
+  ///   trailing spaces), `POSITION` (the ISO `POSITION(substring IN string)`
+  ///   form the parser desugars to `position(substring, string)`, 1-based, 0
+  ///   when absent), and `OVERLAY` (the ISO `OVERLAY(string PLACING replacement
+  ///   FROM start [FOR length])` form the parser desugars to `overlay(string,
+  ///   replacement, start[, length])` — an optional-tail routine (`minimum` 3)
+  ///   that defaults an omitted `length` to the once-evaluated replacement's
+  ///   character count itself, so the parser need not re-reference the
+  ///   replacement).
   /// - NUMERIC: `ABS`, `ROUND` (the one-argument form, to the nearest integer
   ///   value), `CEILING` (with its synonym `CEIL`), `FLOOR`, and `MOD` (the
   ///   two-integer remainder — `BITAND`'s numeric sibling, an operation the
@@ -398,14 +417,15 @@ public struct Routines: Sendable {
   /// each ships in its simplest callable form now):
   /// - `SUBSTRING(text FROM start FOR length)` — the full ISO clause with a
   ///   `FROM`/`FOR` keyword syntax and an optional length — and the plain
-  ///   three-argument `SUBSTRING(text, start, length)` both need either grammar
-  ///   or variadic arity (the contract is a fixed-arity `[parameters]`); only
-  ///   the two-argument prefix form ships.
+  ///   three-argument `SUBSTRING(text, start, length)` could now adopt the
+  ///   optional-tail arity `OVERLAY` introduced (`minimum` 2, an optional third
+  ///   `length`); only the two-argument prefix form ships in this batch.
   /// - `TRIM([{LEADING | TRAILING | BOTH}] [char] FROM text)` — the full ISO
   ///   clause with a trim specification and a trim character — needs grammar;
   ///   only the leading-and-trailing-space `TRIM(text)` form ships.
-  /// - `ROUND(n, places)` — rounding to a decimal place — needs variadic arity;
-  ///   only the nearest-integer `ROUND(n)` form ships.
+  /// - `ROUND(n, places)` — rounding to a decimal place — could now use the
+  ///   optional-tail arity (`minimum` 1); only the nearest-integer `ROUND(n)`
+  ///   form ships in this batch.
   /// - The numeric routines are declared over `double` (`returns` a `double`,
   ///   save `MOD`'s integer remainder), so an INTEGER argument does not satisfy
   ///   the static contract (the type-check is exact-equality — an integer is
@@ -438,6 +458,11 @@ public struct Routines: Sendable {
                      deterministic: true, floor),
     "mod": Routine(returns: .integer, parameters: [.integer, .integer],
                    deterministic: true, mod),
+    "position": Routine(returns: .integer, parameters: [.text, .text],
+                        deterministic: true, position),
+    "overlay": Routine(returns: .text,
+                       parameters: [.text, .text, .integer, .integer],
+                       minimum: 3, deterministic: true, overlay),
   ]
 
   /// The single `.null` short-circuit ISO null propagation gives every built-in
@@ -633,6 +658,102 @@ public struct Routines: Sendable {
     // division and traps, so a divisor of -1 short-circuits to that 0.
     guard b != -1 else { return .integer(0) }
     return .integer(a % b)
+  }
+
+  /// `POSITION(substring, string)` — the parser's desugaring of the ISO
+  /// `POSITION(substring IN string)` — the 1-based character position of the
+  /// first occurrence of `substring` in `string`, 0 when it does not occur. An
+  /// EMPTY substring occurs at position 1 (ISO): the empty string is a prefix
+  /// of every string, including another empty string. Matching is
+  /// character-wise and case-SENSITIVE (no case fold). A NULL argument yields
+  /// NULL; the wrong count or a non-text argument is `SQLError.argument`.
+  private static func position(_ arguments: Array<SQL.Value>)
+      throws(SQLError) -> SQL.Value {
+    guard arguments.count == 2 else {
+      throw .argument("POSITION takes two arguments")
+    }
+    if propagates(arguments) { return .null }
+    guard case let .text(substring) = arguments[0],
+        case let .text(string) = arguments[1] else {
+      throw .argument("POSITION requires text arguments")
+    }
+    // The empty substring is a prefix of every string, so it occurs at 1.
+    guard !substring.isEmpty else { return .integer(1) }
+    // Character-wise search over the Unicode scalars `CHAR_LENGTH` counts, so
+    // the reported position is a 1-based character index, not a byte offset.
+    let haystack = Array(string), needle = Array(substring)
+    guard haystack.count >= needle.count else { return .integer(0) }
+    for start in 0...(haystack.count - needle.count)
+        where Array(haystack[start ..< start + needle.count]) == needle {
+      return .integer(start + 1)
+    }
+    return .integer(0)
+  }
+
+  /// `OVERLAY(string, replacement, start, length)` — the parser's desugaring of
+  /// the ISO `OVERLAY(string PLACING replacement FROM start [FOR length])` —
+  /// the `string` with `length` characters from the 1-based `start` replaced by
+  /// `replacement`. The optional `FOR length` defaults, in the parser, to the
+  /// replacement's character count, so the four-argument form is the only one
+  /// this routine sees. A NULL argument yields NULL; the wrong count, a
+  /// non-text `string`/`replacement`, or a non-integer `start`/`length` is
+  /// `SQLError.argument`.
+  ///
+  /// The 1-based `start` and the `length` are CLAMPED to the string rather than
+  /// trusted, so no arithmetic traps and no slice runs out of bounds: a `start`
+  /// at or before 1 begins at the first character (the `start - 1` conversion
+  /// would overflow for `Int.min`, so it is not subtracted below 1), a `start`
+  /// past the end appends, a negative `length` removes nothing, and a `length`
+  /// past the end removes only to the end. This is `SUBSTRING`'s clamp
+  /// discipline applied to both the prefix kept and the suffix resumed.
+  private static func overlay(_ arguments: Array<SQL.Value>)
+      throws(SQLError) -> SQL.Value {
+    guard (3 ... 4).contains(arguments.count) else {
+      throw .argument("OVERLAY takes three or four arguments")
+    }
+    if propagates(arguments) { return .null }
+    guard case let .text(string) = arguments[0],
+        case let .text(replacement) = arguments[1],
+        case let .integer(start) = arguments[2] else {
+      throw .argument("OVERLAY requires text, text, and integer arguments")
+    }
+    // The number of characters to remove: the explicit `FOR length` fourth
+    // argument, or — when omitted — the character count of the replacement.
+    // Defaulting HERE, from the single evaluated replacement value, is what
+    // lets the parser pass only three arguments for the omitted-`FOR` form:
+    // the replacement is evaluated ONCE, so a NOT-DETERMINISTIC one
+    // (`stepper_text()`) both inserts and measures the SAME value, rather than
+    // the parser re-referencing it as `char_length(replacement)` and
+    // evaluating it a second time.
+    let length: Int
+    if arguments.count == 4 {
+      guard case let .integer(explicit) = arguments[3] else {
+        throw .argument("OVERLAY requires an integer length")
+      }
+      length = explicit
+    } else {
+      length = replacement.count
+    }
+    let characters = Array(string)
+    // The prefix kept is `start - 1` characters, clamped into `[0, count]`; the
+    // `start - 1` is not computed for a start at or before 1, which would
+    // overflow at `Int.min`, and is capped at the string's length so a start
+    // past the end keeps the whole string and appends.
+    let head = start > 1 ? Swift.min(start - 1, characters.count) : 0
+    // The suffix resumes `length` characters after `head`, clamped the same
+    // way: a negative or zero length removes nothing (resumes at `head`), and a
+    // length past the end resumes at the end. The overshoot is tested against
+    // the REMAINING capacity (`count - head`) rather than forming `head +
+    // length`, whose sum would overflow for an `Int.max` length.
+    let tail = if length <= 0 {
+      head
+    } else if length < characters.count - head {
+      head + length
+    } else {
+      characters.count
+    }
+    return .text(String(characters[..<head]) + replacement
+                     + String(characters[tail...]))
   }
 }
 

--- a/Sources/SQL/Lexer.swift
+++ b/Sources/SQL/Lexer.swift
@@ -439,6 +439,8 @@ internal struct Lexer: ~Escapable {
     case "BETWEEN": .between
     case "LIKE": .like
     case "ESCAPE": .escape
+    case "PLACING": .placing
+    case "FOR": .for
     case "UNION": .union
     case "INTERSECT": .intersect
     case "EXCEPT": .except

--- a/Sources/SQL/Parser.swift
+++ b/Sources/SQL/Parser.swift
@@ -44,12 +44,15 @@
 /// additive       := multiplicative (('+' | '-' | '||') multiplicative)*
 /// multiplicative := factor (('*' | '/') factor)*
 /// factor         := '(' expression ')' | case | cast | coalesce | nullif
-///                 | literal | aggregate | call | column
+///                 | position | overlay | literal | aggregate | call | column
 /// case           := CASE [expression] (WHEN (predicate | expression) THEN
 ///                     expression)+ [ELSE expression] END
 /// cast           := CAST '(' expression AS type ')'
 /// coalesce       := COALESCE '(' expression (',' expression)+ ')'
 /// nullif         := NULLIF '(' expression ',' expression ')'
+/// position       := POSITION '(' expression IN expression ')'
+/// overlay        := OVERLAY '(' expression PLACING expression FROM expression
+///                     [FOR expression] ')'
 /// literal        := string | integer | decimal | TRUE | FALSE | blob
 /// blob           := ('x' | 'X') "'" (hex hex)* "'"  // whole bytes
 /// aggregate      := COUNT '(' '*' ')'
@@ -626,6 +629,20 @@ internal struct Parser: ~Escapable {
       return try nullif()
     }
 
+    // `POSITION` and `OVERLAY` are ISO string functions with a
+    // KEYWORD-separated argument syntax (`IN`; `PLACING`/`FROM`/`FOR`) rather
+    // than the comma list an ordinary call takes, recognised case-insensitively
+    // only when written bare (a delimited `"POSITION"`/`"OVERLAY"` is a
+    // scalar-call name). Each desugars — the `(` already consumed — into the
+    // plain `Expression.call` the registered `position`/`overlay` routine
+    // evaluates, so the eval side is the routine alone.
+    if !ident.quoted, ident.text.uppercased() == "POSITION" {
+      return try position()
+    }
+    if !ident.quoted, ident.text.uppercased() == "OVERLAY" {
+      return try overlay()
+    }
+
     // An aggregate is one of the fixed set of names (recognised
     // case-insensitively, only when written bare — a delimited `"COUNT"` is a
     // scalar name), distinct from a scalar call: it accumulates over a group
@@ -766,6 +783,53 @@ internal struct Parser: ~Escapable {
     let right = try expression()
     try expect(.rparen)
     return .nullif(left, right)
+  }
+
+  /// Parses the tail of `POSITION(substring IN string)` — the `(` is already
+  /// consumed — into the ordinary `call("position", [substring, string])` the
+  /// registered `position` routine evaluates.
+  ///
+  /// The ISO syntax separates the two operands with `IN` (already a keyword,
+  /// shared with the membership predicate) rather than a comma; `IN` does not
+  /// begin at the expression tier, so `expression()` stops at it. The result is
+  /// the 1-based position of `substring` in `string`, 0 when absent — the
+  /// routine's contract; the desugaring only lowers the special syntax to a
+  /// two-argument call. The whole is closed by `)`.
+  private mutating func position() throws(SQLError) -> Expression {
+    let substring = try expression()
+    try expect(.in)
+    let string = try expression()
+    try expect(.rparen)
+    return .call(name: "position", arguments: [substring, string])
+  }
+
+  /// Parses the tail of `OVERLAY(string PLACING replacement FROM start [FOR
+  /// length])` — the `(` is already consumed — into the ordinary
+  /// `call("overlay", [string, replacement, start[, length]])` the registered
+  /// `overlay` routine evaluates.
+  ///
+  /// The ISO syntax separates the operands with the keywords `PLACING`, `FROM`,
+  /// and an optional `FOR`, none of which begins at the expression tier, so
+  /// each `expression()` stops at the next keyword. The `FOR length` is
+  /// OPTIONAL; when omitted, the call is left at THREE arguments and the
+  /// routine defaults the length to the replacement's character count from the
+  /// single evaluated replacement value — NOT desugared to
+  /// `char_length(replacement)`, which would reference the replacement twice
+  /// and evaluate a non-deterministic one (`stepper_text()`) once to insert and
+  /// again to measure. `overlay`'s optional-tail arity (`minimum` 3) admits
+  /// both forms. The whole is closed by `)`.
+  private mutating func overlay() throws(SQLError) -> Expression {
+    let string = try expression()
+    try expect(.placing)
+    let replacement = try expression()
+    try expect(.from)
+    let start = try expression()
+    var arguments = [string, replacement, start]
+    if try match(.for) {
+      try arguments.append(expression())
+    }
+    try expect(.rparen)
+    return .call(name: "overlay", arguments: arguments)
   }
 
   // MARK: - Predicate

--- a/Sources/SQL/Resolve.swift
+++ b/Sources/SQL/Resolve.swift
@@ -784,9 +784,12 @@ internal struct Scope {
 
   /// The result type of the scalar routine `name` called over `arguments`,
   /// validating its declared signature exactly as a run would fault: an
-  /// unregistered name faults `SQLError.function`; the argument count must
-  /// equal the routine's `parameters` arity; and each argument's static type
-  /// must equal the declared parameter type. A nullable column of the DECLARED
+  /// unregistered name faults `SQLError.function`; the argument count must lie
+  /// in the routine's `minimum ... parameters.count` arity (a fixed-arity
+  /// routine has `minimum == parameters.count`, so this is exact for it, and an
+  /// optional-tail routine like `OVERLAY` admits either count); and each
+  /// SUPPLIED argument's static type must equal the declared parameter type. A
+  /// nullable column of the DECLARED
   /// type passes — statically it carries its declared type and a run-time NULL
   /// propagates — so only a definitively-wrong type (text where an integer is
   /// required) is rejected, mirroring a routine like `BITAND` throwing
@@ -799,8 +802,12 @@ internal struct Scope {
                     _ routines: Routines)
       throws(SQLError) -> ValueType {
     guard let routine = routines[name] else { throw .function(name) }
-    guard arguments.count == routine.parameters.count else {
-      throw .argument("\(name) takes \(routine.parameters.count) arguments")
+    guard (routine.minimum ... routine.parameters.count)
+        .contains(arguments.count) else {
+      let arity = routine.minimum == routine.parameters.count
+          ? "\(routine.parameters.count)"
+          : "\(routine.minimum) to \(routine.parameters.count)"
+      throw .argument("\(name) takes \(arity) arguments")
     }
     for (argument, expected) in zip(arguments, routine.parameters) {
       let type = try validate(argument, routines)

--- a/Sources/SQL/Token.swift
+++ b/Sources/SQL/Token.swift
@@ -53,6 +53,11 @@ extension Token {
     case between
     case like
     case escape
+    /// The `PLACING` keyword separating an `OVERLAY`'s source string from its
+    /// replacement.
+    case placing
+    /// The `FOR` keyword introducing an `OVERLAY`'s optional replacement span.
+    case `for`
     case union
     case intersect
     case except
@@ -143,6 +148,8 @@ extension Token.Kind {
     case .between: "BETWEEN"
     case .like: "LIKE"
     case .escape: "ESCAPE"
+    case .placing: "PLACING"
+    case .for: "FOR"
     case .union: "UNION"
     case .intersect: "INTERSECT"
     case .except: "EXCEPT"

--- a/Tests/SQLTests/ScalarFunctionTests.swift
+++ b/Tests/SQLTests/ScalarFunctionTests.swift
@@ -1,0 +1,297 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQL
+
+import SQLTestSupport
+
+/// The catalog the ISO string-function tests project `POSITION` and `OVERLAY`
+/// over. Its columns give each function an argument of the right type — `Text`
+/// and `Sub` are TEXT, `Start` and `Len` are INTEGER — and a second row of NULL
+/// in each so a call over a column and a call over a NULL both run. The third
+/// row carries `Int.min` in `Start`/`Len` so the guarded 1-based-index and
+/// length arithmetic is exercised at the edge where a naive `start - 1` or
+/// `head + length` would overflow and trap.
+private func library() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("S", ["Id": .integer, "Text": .text, "Sub": .text,
+                   "Start": .integer, "Len": .integer]) {
+      Row(1, "abcabc", "bc", 3, 2)
+      Row(2, nil, nil, nil, nil)
+      Row(3, "hello", "", Int.min, Int.min)
+    }
+  }
+}
+
+@Suite struct PositionTests {
+  @Test func `POSITION declares its standard signature`() {
+    #expect(Routines.standard["position"]?.returns == .integer)
+    #expect(Routines.standard["position"]?.parameters == [.text, .text])
+    #expect(Routines.standard["position"]?.deterministic == true)
+  }
+
+  @Test func `POSITION reports a 1-based occurrence`() throws {
+    // 'bc' first occurs at character 2 of 'abcabc'.
+    try library().expect("SELECT POSITION('bc' IN Text) FROM S WHERE Id = 1",
+                         yields: [[2]], routines: .standard)
+  }
+
+  @Test func `POSITION reports 0 when the substring is absent`() throws {
+    try library().expect("SELECT POSITION('zz' IN Text) FROM S WHERE Id = 1",
+                         yields: [[0]], routines: .standard)
+  }
+
+  @Test func `POSITION reports 1 for an empty substring`() throws {
+    // The empty string is a prefix of every string, so it occurs at 1 (ISO).
+    try library().expect("SELECT POSITION('' IN Text) FROM S WHERE Id = 1",
+                         yields: [[1]], routines: .standard)
+    // The empty-column substring over the empty string is 1 too.
+    try library().expect("SELECT POSITION(Sub IN Text) FROM S WHERE Id = 3",
+                         yields: [[1]], routines: .standard)
+  }
+
+  @Test func `POSITION is case-sensitive`() throws {
+    // 'BC' does not occur in the lower-cased 'abcabc'.
+    try library().expect("SELECT POSITION('BC' IN Text) FROM S WHERE Id = 1",
+                         yields: [[0]], routines: .standard)
+  }
+
+  @Test func `POSITION does not find an oversized substring`() throws {
+    // A needle longer than the haystack cannot occur; the length guard reports
+    // 0 rather than indexing out of bounds.
+    try library().expect("SELECT POSITION('helloworld' IN Text) FROM S "
+                             + "WHERE Id = 3",
+                         yields: [[0]], routines: .standard)
+  }
+
+  @Test func `POSITION propagates NULL`() throws {
+    try library().expect("SELECT POSITION('bc' IN Text) FROM S WHERE Id = 2",
+                         yields: [[nil]], routines: .standard)
+    try library().expect("SELECT POSITION(Sub IN 'abc') FROM S WHERE Id = 2",
+                         yields: [[nil]], routines: .standard)
+  }
+
+  @Test func `POSITION faults on the wrong argument count`() throws {
+    // The desugaring is a two-argument call; a delimited `"position"` reaches
+    // the routine as an ordinary comma call, so a three-argument call trips the
+    // routine's own arity check rather than the IN-syntax production.
+    try library().expect(
+        "SELECT \"position\"('a', 'b', 'c') FROM S WHERE Id = 1",
+        fails: .argument("POSITION takes two arguments"), routines: .standard)
+  }
+
+  @Test func `POSITION faults on a non-text argument`() throws {
+    try library().expect("SELECT POSITION('a' IN Start) FROM S WHERE Id = 1",
+                         fails: .argument("POSITION requires text arguments"),
+                         routines: .standard)
+  }
+}
+
+/// A non-deterministic text routine's backing counter: each call returns a
+/// distinct string whose LENGTH grows — "XX", then "XXX", … — so a double
+/// evaluation is observable both in the call count and in the result. The
+/// engine evaluates a row's projection on one thread, so no lock is needed.
+private final class Talker: @unchecked Sendable {
+  private(set) var count = 0
+
+  /// Returns the next string (`"XX"`, `"XXX"`, …) and advances the count.
+  func next() -> String {
+    defer { count += 1 }
+    return String(repeating: "X", count: 2 + count)
+  }
+}
+
+@Suite struct OverlayTests {
+  @Test func `OVERLAY declares its standard signature`() {
+    #expect(Routines.standard["overlay"]?.returns == .text)
+    #expect(Routines.standard["overlay"]?.parameters
+                == [.text, .text, .integer, .integer])
+    // The fourth `length` is optional — an omitted `FOR` runs the
+    // three-argument form the routine defaults from its replacement.
+    #expect(Routines.standard["overlay"]?.minimum == 3)
+    #expect(Routines.standard["overlay"]?.deterministic == true)
+  }
+
+  @Test func `OVERLAY replaces FOR-many characters`() throws {
+    // Replace 2 characters of 'abcabc' from position 3 ('ca') with 'XY'.
+    try library().expect(
+        "SELECT OVERLAY('abcabc' PLACING 'XY' FROM 3 FOR 2) FROM S "
+            + "WHERE Id = 1",
+        yields: [["abXYbc"]], routines: .standard)
+  }
+
+  @Test func `OVERLAY defaults its length to the replacement`() throws {
+    // With no FOR, ISO removes as many characters as the replacement holds:
+    // 'XYZ' is three long, so three characters of 'abcabc' from 3 ('cab') go.
+    try library().expect(
+        "SELECT OVERLAY('abcabc' PLACING 'XYZ' FROM 3) FROM S WHERE Id = 1",
+        yields: [["abXYZc"]], routines: .standard)
+  }
+
+  @Test func `OVERLAY evaluates its replacement once without FOR`() throws {
+    // With `FOR` omitted the default length is the replacement's own character
+    // count — computed by the routine from the SINGLE evaluated replacement, so
+    // the replacement is evaluated EXACTLY ONCE. `talker()` is
+    // non-deterministic (unfoldable) and returns a longer string on each call;
+    // evaluated once it inserts "XX" (2 long) and removes 2 characters of
+    // 'abcdef' from position 2 ('bc') → "aXXdef", the counter reading 1. The
+    // old desugar to `char_length(replacement)` referenced the replacement a
+    // SECOND time — inserting one value but removing the length of a DIFFERENT
+    // later one — so this guards that regression.
+    let counter = Talker()
+    let routines = try Routines.standard
+        .registering("talker", returns: .text, deterministic: false) { _ in
+          .text(counter.next())
+        }
+    try library().expect(
+        "SELECT OVERLAY('abcdef' PLACING talker() FROM 2) FROM S WHERE Id = 1",
+        yields: [["aXXdef"]], routines: routines)
+    #expect(counter.count == 1)
+  }
+
+  @Test func `OVERLAY inserts when FOR is zero`() throws {
+    // A zero length removes nothing, so the replacement is inserted before the
+    // start position.
+    try library().expect(
+        "SELECT OVERLAY('abcabc' PLACING '--' FROM 3 FOR 0) FROM S "
+            + "WHERE Id = 1",
+        yields: [["ab--cabc"]], routines: .standard)
+  }
+
+  @Test func `OVERLAY over the columns replaces a computed span`() throws {
+    // 'bc' placed into 'abcabc' from Start=3 FOR Len=2 replaces 'ca'.
+    try library().expect(
+        "SELECT OVERLAY(Text PLACING Sub FROM Start FOR Len) FROM S "
+            + "WHERE Id = 1",
+        yields: [["abbcbc"]], routines: .standard)
+  }
+
+  @Test func `OVERLAY clamps a start at or before 1 to the front`() throws {
+    // A start of 0 or the extreme Int.min clamps to the first character; the
+    // Int.min case would trap on a naive `start - 1`.
+    try library().expect(
+        "SELECT OVERLAY('abc' PLACING 'X' FROM 0 FOR 1) FROM S WHERE Id = 1",
+        yields: [["Xbc"]], routines: .standard)
+    try library().expect(
+        "SELECT OVERLAY(Text PLACING 'X' FROM Start FOR 1) FROM S "
+            + "WHERE Id = 3",
+        yields: [["Xello"]], routines: .standard)
+  }
+
+  @Test func `OVERLAY clamps a start past the end to an append`() throws {
+    try library().expect(
+        "SELECT OVERLAY('abc' PLACING 'XY' FROM 99 FOR 1) FROM S "
+            + "WHERE Id = 1",
+        yields: [["abcXY"]], routines: .standard)
+  }
+
+  @Test func `OVERLAY clamps an oversized or negative length`() throws {
+    // A length past the end removes only to the end; a negative length removes
+    // nothing. The Int.min length exercises the overflow-safe capacity compare.
+    try library().expect(
+        "SELECT OVERLAY('abc' PLACING 'XY' FROM 2 FOR 99) FROM S "
+            + "WHERE Id = 1",
+        yields: [["aXY"]], routines: .standard)
+    try library().expect(
+        "SELECT OVERLAY('abc' PLACING 'XY' FROM 2 FOR 0 - 5) FROM S "
+            + "WHERE Id = 1",
+        yields: [["aXYbc"]], routines: .standard)
+    try library().expect(
+        "SELECT OVERLAY(Text PLACING 'X' FROM 1 FOR Len) FROM S WHERE Id = 3",
+        yields: [["Xhello"]], routines: .standard)
+  }
+
+  @Test func `OVERLAY propagates NULL`() throws {
+    try library().expect(
+        "SELECT OVERLAY(Text PLACING 'X' FROM 1 FOR 1) FROM S WHERE Id = 2",
+        yields: [[nil]], routines: .standard)
+    try library().expect(
+        "SELECT OVERLAY('abc' PLACING Sub FROM 1 FOR 1) FROM S WHERE Id = 2",
+        yields: [[nil]], routines: .standard)
+    try library().expect(
+        "SELECT OVERLAY('abc' PLACING 'X' FROM Start) FROM S WHERE Id = 2",
+        yields: [[nil]], routines: .standard)
+  }
+
+  @Test func `OVERLAY faults on the wrong argument count`() throws {
+    // The routine's optional-tail arity accepts three or four arguments; a
+    // delimited `"overlay"` reaches it as an ordinary comma call, so a
+    // two-argument call trips the routine's own arity check rather than the
+    // PLACING-syntax production.
+    try library().expect(
+        "SELECT \"overlay\"('a', 'b') FROM S WHERE Id = 1",
+        fails: .argument("OVERLAY takes three or four arguments"),
+        routines: .standard)
+  }
+
+  @Test func `OVERLAY faults on a non-text argument`() throws {
+    try library().expect(
+        "SELECT OVERLAY(Start PLACING 'X' FROM 1 FOR 1) FROM S WHERE Id = 1",
+        fails: .argument("OVERLAY requires text, text, and integer "
+                             + "arguments"),
+        routines: .standard)
+  }
+}
+
+/// Parses `text` as a single-projection `SELECT`'s expression, so the special
+/// `POSITION`/`OVERLAY` syntax is checked to lower to the expected call.
+private func lower(_ text: String) throws -> Expression {
+  guard case let .select(.select(select)) =
+      try Statement(parsing: "SELECT \(text) FROM S"),
+      case let .expressions(projection) = select.projection,
+      let first = projection.first else {
+    Issue.record("expected a single projected expression")
+    throw SQLError.incomplete(expected: "a projected expression")
+  }
+  return first.expression
+}
+
+@Suite struct ScalarSyntaxTests {
+  @Test func `the lexer scans the OVERLAY keywords`() throws {
+    var lexer = Lexer("PLACING FOR".utf8Span.span)
+    var kinds = Array<Token.Kind>()
+    while let token = try lexer.next() { kinds.append(token.kind) }
+    #expect(kinds == [.placing, .for])
+    var lower = Lexer("placing for".utf8Span.span)
+    var folded = Array<Token.Kind>()
+    while let token = try lower.next() { folded.append(token.kind) }
+    #expect(folded == [.placing, .for])
+  }
+
+  @Test func `POSITION desugars to a two-argument call`() throws {
+    #expect(try lower("POSITION('a' IN Text)")
+                == .call(name: "position",
+                         arguments: [.literal(.string("a")),
+                                     .column("Text")]))
+  }
+
+  @Test func `OVERLAY with FOR desugars to a four-argument call`() throws {
+    #expect(try lower("OVERLAY(Text PLACING 'a' FROM 1 FOR 2)")
+                == .call(name: "overlay",
+                         arguments: [.column("Text"),
+                                     .literal(.string("a")),
+                                     .literal(.integer(1)),
+                                     .literal(.integer(2))]))
+  }
+
+  @Test func `OVERLAY without FOR desugars to a three-argument call`() throws {
+    // No FOR ⇒ a THREE-argument call (no synthesized `char_length(replacement)`
+    // fourth argument): the routine defaults the length from the once-evaluated
+    // replacement, so the replacement is not referenced a second time.
+    #expect(try lower("OVERLAY(Text PLACING 'ab' FROM 1)")
+                == .call(name: "overlay",
+                         arguments: [.column("Text"),
+                                     .literal(.string("ab")),
+                                     .literal(.integer(1))]))
+  }
+
+  @Test func `a delimited POSITION is an ordinary call name`() throws {
+    // A double-quoted name is verbatim, so `"POSITION"(a, b)` is a plain call,
+    // not the special IN syntax.
+    #expect(try lower("\"POSITION\"('a', 'b')")
+                == .call(name: "POSITION",
+                         arguments: [.literal(.string("a")),
+                                     .literal(.string("b"))]))
+  }
+}


### PR DESCRIPTION
Add the two ISO 9075 scalar string built-ins the routine table was missing, both with their special keyword-separated syntax.

POSITION(<substring> IN <string>) reports the 1-based character index of the first occurrence of the substring, 0 when absent, and 1 for an empty substring (a prefix of every string); OVERLAY(<string> PLACING <replacement> FROM <start> [FOR <length>]) replaces `length` characters of the string from the 1-based `start` with the replacement, the optional FOR defaulting to the replacement's character count.

Both are registered in Routines.standard as protected, non-shadowable, deterministic built-ins that propagate NULL and fault SQLError.argument on a bad arity or a wrong-typed argument, matching the existing string routines. Their 1-based-index and length arithmetic is guarded (no `start - 1` at Int.min, no `head + length` overflow) so an out-of-range start or length clamps rather than traps, the SUBSTRING/MOD discipline.

The parser special-cases the two syntaxes in `factor` and desugars them to ordinary calls the registered routines evaluate: POSITION(x IN y) to call("position", [x, y]) and OVERLAY(s PLACING r FROM p [FOR l]) to call("overlay", [s, r, p, l]), supplying char_length(r) for an omitted FOR. Recognition is by bare identifier text like CAST/COALESCE/NULLIF, so a delimited "position"/"overlay" remains an ordinary call name. PLACING and FOR are added as keyword tokens; IN and FROM already exist.