### PR TITLE
SQL: add the IS TRUE/FALSE/UNKNOWN boolean test

### DIFF
--- a/Sources/SQL/AST.swift
+++ b/Sources/SQL/AST.swift
@@ -628,6 +628,19 @@ public indirect enum Predicate: Hashable, Sendable {
   /// DISTINCT — the two differ — matching the engine's cross-kind FALSE
   /// equality. Unlike `=`, a NULL operand never makes the row UNKNOWN.
   case distinct(Expression, Expression, negated: Bool)
+  /// `p IS [NOT] <truth value>` — the ISO `<boolean test>`, whether the inner
+  /// boolean `Predicate` `p`'s THREE-VALUED result equals the `value`
+  /// (`TRUE`/`FALSE`/`UNKNOWN`), or does not when `negated`. Unlike the other
+  /// predicates the result is DEFINITE two-valued — never itself UNKNOWN — so
+  /// `p IS TRUE` is FALSE (not UNKNOWN) for an UNKNOWN `p`, and `p IS UNKNOWN`
+  /// TESTS for that UNKNOWN. The operand is a `Predicate` rather than an
+  /// `Expression`: a boolean is a predicate to this engine — a bare boolean
+  /// operand `x` bridges as the comparison `x = TRUE`, whose three-valued
+  /// truth IS `x`'s boolean value (`NULL` yielding UNKNOWN) — so a boolean
+  /// column (`flag IS TRUE`) and a parenthesised comparison (`(a > b) IS TRUE`)
+  /// share the one inner-predicate form and reuse the whole comparison
+  /// machinery to evaluate it.
+  case truth(Predicate, value: Truth, negated: Bool)
   /// `lhs AND rhs`.
   case and(Predicate, Predicate)
   /// `lhs OR rhs`.
@@ -652,6 +665,20 @@ public indirect enum Predicate: Hashable, Sendable {
     /// A `:parameter` placeholder, resolved at run time from the bindings.
     case parameter(String)
   }
+}
+
+/// A truth value a `<boolean test>` (`Predicate.truth`) tests against — the
+/// three SQL truth values, `UNKNOWN` being the spelling the test uses for a
+/// NULL boolean (SQL spells UNKNOWN as `NULL` in a value position, but names it
+/// `UNKNOWN` in this test). `p IS TRUE`/`FALSE`/`UNKNOWN` yields a DEFINITE
+/// two-valued result, never itself UNKNOWN.
+public enum Truth: Hashable, Sendable {
+  /// The truth value `TRUE`.
+  case `true`
+  /// The truth value `FALSE`.
+  case `false`
+  /// The truth value `UNKNOWN` — a NULL boolean.
+  case unknown
 }
 
 /// A comparison operator.

--- a/Sources/SQL/Engine.swift
+++ b/Sources/SQL/Engine.swift
@@ -689,6 +689,8 @@ extension Predicate {
       test.aggregated || lower.aggregated || upper.aggregated
     case let .distinct(lhs, rhs, _):
       lhs.aggregated || rhs.aggregated
+    case let .truth(inner, _, _):
+      inner.aggregated
     case let .and(lhs, rhs), let .or(lhs, rhs):
       lhs.aggregated || rhs.aggregated
     case let .not(operand):
@@ -716,6 +718,8 @@ extension Predicate {
       test.bound || lower.bound || upper.bound
     case let .distinct(lhs, rhs, _):
       lhs.bound || rhs.bound
+    case let .truth(inner, _, _):
+      inner.bound
     case let .and(lhs, rhs), let .or(lhs, rhs):
       lhs.bound || rhs.bound
     case let .not(operand):
@@ -970,6 +974,8 @@ extension Predicate {
     case let .distinct(lhs, rhs, _):
       lhs.collect(into: &expressions)
       rhs.collect(into: &expressions)
+    case let .truth(inner, _, _):
+      inner.collect(into: &expressions)
     case let .and(lhs, rhs), let .or(lhs, rhs):
       lhs.collect(into: &expressions)
       rhs.collect(into: &expressions)

--- a/Sources/SQL/Filter.swift
+++ b/Sources/SQL/Filter.swift
@@ -68,6 +68,13 @@ internal indirect enum Filter: Sendable {
   /// `matches`'s cross-kind FALSE equality), and `IS DISTINCT FROM` is TRUE
   /// when they differ, `IS NOT DISTINCT FROM` when they are the same.
   case distinct(Term, Term, negated: Bool)
+  /// `p IS [NOT] <truth value>` — the lowered form of the AST's `truth`. The
+  /// inner boolean `Filter` is held once and evaluated to its three-valued
+  /// result, which is then MAPPED against `value` (`TRUE`/`FALSE`/`UNKNOWN`) to
+  /// a DEFINITE two-valued result — never itself UNKNOWN — and negated for `IS
+  /// NOT`. An UNKNOWN inner is FALSE against `TRUE`/`FALSE` but TRUE against
+  /// `UNKNOWN`, so the test collapses SQL's third value to a two-valued answer.
+  case truth(Filter, Truth, negated: Bool)
   /// `lhs AND rhs`.
   case and(Filter, Filter)
   /// `lhs OR rhs`.
@@ -312,6 +319,8 @@ extension Filter {
     case let .distinct(lhs, rhs, negated):
       .distinct(lhs.remapped(through: slot), rhs.remapped(through: slot),
                 negated: negated)
+    case let .truth(inner, value, negated):
+      .truth(inner.remapped(through: slot), value, negated: negated)
     case let .and(lhs, rhs):
       .and(lhs.remapped(through: slot), rhs.remapped(through: slot))
     case let .or(lhs, rhs):
@@ -401,6 +410,7 @@ extension Filter {
     case let .between(test, lower, upper, _):
       test.safe && lower.safe && upper.safe
     case let .distinct(lhs, rhs, _): lhs.safe && rhs.safe
+    case let .truth(inner, _, _): inner.safe
     case let .and(lhs, rhs): lhs.safe && rhs.safe
     case let .or(lhs, rhs): lhs.safe && rhs.safe
     case let .not(operand): operand.safe
@@ -437,6 +447,7 @@ extension Filter {
       pattern.parameterised || (escape?.parameterised ?? false)
     case let .between(_, lower, upper, _):
       lower.parameterised || upper.parameterised
+    case let .truth(inner, _, _): inner.parameterised
     case let .and(lhs, rhs): lhs.parameterised || rhs.parameterised
     case let .or(lhs, rhs): lhs.parameterised || rhs.parameterised
     case let .not(operand): operand.parameterised
@@ -792,6 +803,23 @@ internal func or(_ lhs: Bool?, _ rhs: Bool?) -> Bool? {
   return lhs == false && rhs == false ? false : nil
 }
 
+/// The ISO `<boolean test>` mapping — a three-valued `operand` tested against a
+/// `Truth` value, negated for `IS NOT`, yielding a DEFINITE two-valued result
+/// that is NEVER itself UNKNOWN. `p IS TRUE` is `operand == true`, `IS FALSE`
+/// is `operand == false`, and `IS UNKNOWN` is `operand == nil` — so an UNKNOWN
+/// operand is FALSE against `TRUE`/`FALSE` and TRUE against `UNKNOWN`. This is
+/// the shared primitive the run (`Filter.truth`) and the folds
+/// (`constant`/`empty`) all map through.
+internal func tested(_ operand: Bool?, _ value: Truth, _ negated: Bool)
+    -> Bool {
+  let matched = switch value {
+  case .true: operand == true
+  case .false: operand == false
+  case .unknown: operand == nil
+  }
+  return negated ? !matched : matched
+}
+
 extension Row where Self: ~Escapable {
   /// Evaluates `filter` against this row under three-valued logic, resolving
   /// scalar calls through `routines` and any bound parameter from `bindings`.
@@ -835,6 +863,8 @@ extension Row where Self: ~Escapable {
       try ranged(test, lower, upper, negated, routines, bindings)
     case let .distinct(lhs, rhs, negated):
       try differs(lhs, rhs, negated, routines, bindings)
+    case let .truth(inner, value, negated):
+      try tested(evaluate(inner, routines, bindings), value, negated)
     case let .and(lhs, rhs):
       // `&&`/`||` take an `@autoclosure` right operand, which would capture the
       // borrowed `~Escapable` row; spell each connective explicitly so a branch

--- a/Sources/SQL/Lexer.swift
+++ b/Sources/SQL/Lexer.swift
@@ -449,6 +449,7 @@ internal struct Lexer: ~Escapable {
     case "RECURSIVE": .recursive
     case "TRUE": .true
     case "FALSE": .false
+    case "UNKNOWN": .unknown
     case "CASE": .case
     case "WHEN": .when
     case "THEN": .then

--- a/Sources/SQL/Parser.swift
+++ b/Sources/SQL/Parser.swift
@@ -34,13 +34,14 @@
 /// disjunction    := conjunction (OR conjunction)*
 /// conjunction    := negation (AND negation)*
 /// negation       := NOT negation | primary
-/// primary        := '(' predicate ')' | comparison
-/// comparison     := expression (op (expression | param) | IS [NOT] NULL
-///                 | IS [NOT] DISTINCT FROM expression
+/// primary        := '(' predicate ')' [IS [NOT] truthvalue] | comparison
+/// comparison     := expression (op (expression | param)
+///                 | IS [NOT] (NULL | truthvalue | DISTINCT FROM expression)
 ///                 | [NOT] IN '(' expression (',' expression)* ')'
 ///                 | [NOT] LIKE expression [ESCAPE expression]
 ///                 | [NOT] BETWEEN (expression | param) AND
 ///                                 (expression | param))
+/// truthvalue     := TRUE | FALSE | UNKNOWN
 /// expression     := additive
 /// additive       := multiplicative (('+' | '-' | '||') multiplicative)*
 /// multiplicative := factor (('*' | '/') factor)*
@@ -888,6 +889,21 @@ internal struct Parser: ~Escapable {
     try expect(.lparen)
     let predicate = try predicate()
     try expect(.rparen)
+    // A parenthesised predicate is itself a `<boolean primary>`, so an `IS
+    // [NOT] TRUE/FALSE/UNKNOWN` tail may test its three-valued result directly
+    // (`(a > b) IS TRUE`) — the inner `Predicate` the test maps against the
+    // truth value. Only a truth-value tail applies here; an `IS NULL` over a
+    // predicate is not a value test.
+    if try match(.is) {
+      let negated = try match(.not)
+      guard let value = try truth() else {
+        let token = try advance(expecting: "TRUE, FALSE, or UNKNOWN")
+        throw .unexpected(token.kind.description,
+                          expected: "TRUE, FALSE, or UNKNOWN",
+                          at: token.location)
+      }
+      return .truth(predicate, value: value, negated: negated)
+    }
     return predicate
   }
 
@@ -901,7 +917,10 @@ internal struct Parser: ~Escapable {
   /// `IS NULL` (or `IS NOT NULL`) tail tests the left expression for `NULL`
   /// rather than comparing it — the way a nullable column is filtered. An `IS
   /// [NOT] DISTINCT FROM` tail is the ISO null-safe comparison of the two
-  /// expressions, treating NULL as a comparable value. An `IN`
+  /// expressions, treating NULL as a comparable value; an `IS [NOT]
+  /// TRUE/FALSE/UNKNOWN` tail is the ISO `<boolean test>`, the boolean operand
+  /// bridging as the comparison `x = TRUE` the test maps to a definite truth.
+  /// An `IN`
   /// (or `NOT IN`) tail tests the left expression for membership in a
   /// parenthesised value list. A `LIKE` (or `NOT LIKE`) tail tests the left
   /// expression's text against a pattern, with an optional `ESCAPE` character.
@@ -915,6 +934,15 @@ internal struct Parser: ~Escapable {
       let negated = try match(.not)
       if try match(.distinct) {
         return try distinct(left, negated: negated)
+      }
+      if let value = try truth() {
+        // `x IS [NOT] TRUE/FALSE/UNKNOWN` — the boolean operand `x` bridges as
+        // the comparison `x = TRUE`, whose three-valued truth IS `x`'s boolean
+        // value (a NULL `x` reading UNKNOWN), the inner `Predicate` the test
+        // maps against `value` to a definite two-valued result.
+        let boolean = Predicate.comparison(left: left, op: .equal,
+                                           right: .literal(.boolean(true)))
+        return .truth(boolean, value: value, negated: negated)
       }
       try expect(.null)
       return .null(left, negated: negated)
@@ -1002,6 +1030,18 @@ internal struct Parser: ~Escapable {
     try expect(.and)
     let upper = try operand()
     return .between(left, lower, upper, negated: negated)
+  }
+
+  /// Consumes a `<truth value>` keyword — `TRUE`, `FALSE`, or `UNKNOWN` — at
+  /// the head of an `IS [NOT]` tail, returning its `Truth`, or `nil` when the
+  /// next token is none of them (an `IS NULL` tail, which the caller then
+  /// handles). The `TRUE`/`FALSE` keywords are the boolean literals; `UNKNOWN`
+  /// is a keyword valid ONLY in this test position.
+  private mutating func truth() throws(SQLError) -> Truth? {
+    if try match(.true) { return .true }
+    if try match(.false) { return .false }
+    if try match(.unknown) { return .unknown }
+    return nil
   }
 
   /// Parses the pattern tail of `left [NOT] LIKE pattern [ESCAPE escape]` — the

--- a/Sources/SQL/Resolve.swift
+++ b/Sources/SQL/Resolve.swift
@@ -68,6 +68,11 @@ private func lower(_ predicate: Predicate,
     // `:parameter` form is defined, so both sides lower straight through
     // `term`.
     try .distinct(term(lhs), term(rhs), negated: negated)
+  case let .truth(inner, value, negated):
+    // `p IS [NOT] <truth value>` lowers to a first-class `Filter.truth` over
+    // the lowered inner boolean filter; the three-valued-to-definite mapping
+    // lives in the runtime (`tested`), so lowering just lowers the operand.
+    try .truth(lower(inner, term: term), value, negated: negated)
   case let .and(lhs, rhs):
     try .and(lower(lhs, term: term), lower(rhs, term: term))
   case let .or(lhs, rhs):
@@ -1032,6 +1037,11 @@ internal struct Scope {
       // accepts.
       _ = try validate(lhs, routines)
       _ = try validate(rhs, routines)
+    case let .truth(inner, _, _):
+      // `p IS [NOT] <truth value>` validates its inner boolean predicate for
+      // real errors; the truth mapping cannot itself fault, so it adds no
+      // further check.
+      try check(inner, routines)
     case let .and(lhs, rhs):
       try check(lhs, routines)
       if constant(lhs, routines) != false { try check(rhs, routines) }
@@ -1318,8 +1328,89 @@ internal struct Scope {
       }
       let differ = distinct(lhs, rhs)
       return negated ? !differ : differ
+    case let .truth(inner, value, negated):
+      // Fold `p IS [NOT] <truth value>` whenever the inner boolean is ROW-
+      // INDEPENDENT. `constant` gives its definite truth; and a `nil` from it
+      // over a `settled` inner (every operand a constant) is a definite UNKNOWN
+      // — NOT a per-row deferral — which `tested` maps to a DEFINITE result
+      // (`p IS UNKNOWN` TRUE, `p IS TRUE` FALSE), so a constant-UNKNOWN test
+      // short-circuits/type-checks as the run does rather than deferring and
+      // validating an unreachable conjunct.
+      let folded = constant(inner, routines)
+      if folded != nil || settled(inner, routines) {
+        return tested(folded, value, negated)
+      }
+      // An `IS [NOT] UNKNOWN` test folds even over a ROW-DEPENDENT inner when
+      // the inner is DEFINITE (two-valued — `IS NULL`, `IS DISTINCT FROM`,
+      // another truth test, and their `AND`/`OR`/`NOT`, never take UNKNOWN):
+      // such an inner is never the third value the test checks for, so
+      // `p IS UNKNOWN` is definitely FALSE and `p IS NOT UNKNOWN` definitely
+      // TRUE regardless of the rows — `(Flag IS NULL) IS UNKNOWN` folds FALSE.
+      // A `TRUE`/`FALSE` test still turns on the inner's per-row value, so it
+      // stays per row.
+      if value == .unknown, definite(inner) { return negated }
+      return nil
     case .bound:
       return nil
+    }
+  }
+
+  /// Whether every operand `predicate` reads folds to a ROW-INDEPENDENT
+  /// constant — so its three-valued truth is fully determined at compile time.
+  /// When it is and `constant(_ predicate:)` is `nil`, that `nil` is a definite
+  /// UNKNOWN (a NULL propagated through constant operands), NOT a per-row
+  /// deferral: the distinction `constant`'s `Bool?` cannot carry, which the
+  /// truth test needs to fold `p IS UNKNOWN`/`p IS TRUE` over a
+  /// constant-UNKNOWN `p`. A row or non-deterministic operand is NOT constant
+  /// (`constant(_ expression:)` is `nil`), so it is not settled; a `:parameter`
+  /// (`.bound`) is per-run, never settled.
+  private func settled(_ predicate: Predicate, _ routines: Routines) -> Bool {
+    switch predicate {
+    case let .comparison(left, _, right):
+      constant(left, routines) != nil && constant(right, routines) != nil
+    case let .null(operand, _):
+      constant(operand, routines) != nil
+    case let .membership(operand, values, _):
+      constant(operand, routines) != nil
+          && values.allSatisfy { constant($0, routines) != nil }
+    case let .like(operand, pattern, escape, _):
+      constant(operand, routines) != nil
+          && constant(pattern, routines) != nil
+          && (escape.map { constant($0, routines) != nil } ?? true)
+    case let .between(test, lower, upper, _):
+      constant(test, routines) != nil && constant(lower, routines) != nil
+          && constant(upper, routines) != nil
+    case let .distinct(lhs, rhs, _):
+      constant(lhs, routines) != nil && constant(rhs, routines) != nil
+    case let .truth(inner, _, _):
+      settled(inner, routines)
+    case let .and(lhs, rhs), let .or(lhs, rhs):
+      settled(lhs, routines) && settled(rhs, routines)
+    case let .not(operand):
+      settled(operand, routines)
+    case .bound:
+      false
+    }
+  }
+
+  /// Whether `predicate` is DEFINITE — two-valued, never evaluating to UNKNOWN,
+  /// even when it reads row data. `IS [NOT] NULL`, `IS [NOT] DISTINCT FROM`,
+  /// and a boolean test all collapse SQL's third value to a definite result by
+  /// construction, and `AND`/`OR`/`NOT` of definite predicates stay definite. A
+  /// comparison, membership, `LIKE`, `BETWEEN`, or bound parameter can be
+  /// UNKNOWN (a NULL operand), so none is definite. This lets an `IS [NOT]
+  /// UNKNOWN` test fold — the third value it checks for can never occur — over
+  /// a row-dependent inner `settled` cannot reach.
+  private func definite(_ predicate: Predicate) -> Bool {
+    switch predicate {
+    case .null, .distinct, .truth:
+      true
+    case let .and(lhs, rhs), let .or(lhs, rhs):
+      definite(lhs) && definite(rhs)
+    case let .not(operand):
+      definite(operand)
+    case .comparison, .membership, .like, .between, .bound:
+      false
     }
   }
 
@@ -1447,6 +1538,8 @@ internal struct Scope {
     case let .distinct(lhs, rhs, _):
       try aggregates(in: lhs, routines)
       try aggregates(in: rhs, routines)
+    case let .truth(inner, _, _):
+      try aggregates(in: inner, routines)
     case let .and(lhs, rhs), let .or(lhs, rhs):
       try aggregates(in: lhs, routines)
       try aggregates(in: rhs, routines)
@@ -1639,6 +1732,13 @@ internal struct Scope {
       // the truth is definite (never UNKNOWN, unlike a `=` over a NULL).
       let differ = distinct(try empty(lhs, routines), try empty(rhs, routines))
       return negated ? !differ : differ
+    case let .truth(inner, value, negated):
+      // Fold `p IS [NOT] <truth value>` over the empty group as `Filter.truth`
+      // evaluates it: `empty` yields the inner's genuine three-valued result
+      // (over zero rows every side is constant, so a `nil` here is a real
+      // UNKNOWN, not a per-row deferral), which `tested` maps to a DEFINITE
+      // result — never itself UNKNOWN.
+      return tested(try empty(inner, routines), value, negated)
     case let .and(lhs, rhs):
       // A `false` left proves the `AND` false without folding the right arm,
       // which a run's short-circuit never evaluates and so must not fault.
@@ -2136,6 +2236,8 @@ extension Filter {
     case let .distinct(lhs, rhs, _):
       lhs.references(into: &ordinals)
       rhs.references(into: &ordinals)
+    case let .truth(inner, _, _):
+      inner.references(into: &ordinals)
     case let .and(lhs, rhs), let .or(lhs, rhs):
       lhs.references(into: &ordinals)
       rhs.references(into: &ordinals)

--- a/Sources/SQL/Token.swift
+++ b/Sources/SQL/Token.swift
@@ -66,6 +66,7 @@ extension Token {
     case recursive
     case `true`
     case `false`
+    case unknown
     case `case`
     case when
     case then
@@ -158,6 +159,7 @@ extension Token.Kind {
     case .recursive: "RECURSIVE"
     case .true: "TRUE"
     case .false: "FALSE"
+    case .unknown: "UNKNOWN"
     case .case: "CASE"
     case .when: "WHEN"
     case .then: "THEN"

--- a/Tests/SQLTests/TruthTestTests.swift
+++ b/Tests/SQLTests/TruthTestTests.swift
@@ -1,0 +1,305 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQL
+
+import SQLTestSupport
+
+// MARK: - Fixture
+
+/// A relation exercising `IS [NOT] TRUE/FALSE/UNKNOWN`: a nullable BOOLEAN
+/// column `Flag` covering all three truth values (TRUE, FALSE, and a NULL row
+/// whose UNKNOWN corner the test collapses to a definite result), beside the
+/// integer columns `A`/`B` a comparison predicate tests and a nullable integer
+/// `N` (NULL in every row) an UNKNOWN comparison reads.
+private func flags() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["Id": .integer, "Flag": .boolean,
+                   "A": .integer, "B": .integer, "N": .integer]) {
+      Row(1, true, 2, 1, nil)
+      Row(2, false, 1, 2, nil)
+      Row(3, nil, 1, 1, nil)
+    }
+  }
+}
+
+/// Parses `text` and returns its `Select`, failing on any other shape.
+private func parse(select text: String) throws -> Select {
+  guard case let .select(.select(select)) = try Statement(parsing: text) else {
+    Issue.record("expected a single SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return select
+}
+
+/// The boolean predicate a bare boolean operand `x` bridges to — the comparison
+/// `x = TRUE`, whose three-valued truth IS `x`'s boolean value — the inner
+/// `Predicate` a column truth test wraps.
+private func boolean(_ column: Column) -> Predicate {
+  .comparison(left: .column(column), op: .equal,
+              right: .literal(.boolean(true)))
+}
+
+// MARK: - Parsing
+
+struct TruthTestParsingTests {
+  @Test func `IS TRUE parses to a truth node over the bridged operand`()
+      throws {
+    // `x IS TRUE` is a `Predicate.truth` whose inner is the bridge comparison
+    // `x = TRUE` — the boolean operand as a predicate.
+    let select = try parse(select: "SELECT * FROM T WHERE Flag IS TRUE")
+    #expect(select.predicate
+                == .truth(boolean("Flag"), value: .true, negated: false))
+  }
+
+  @Test func `IS FALSE parses to a FALSE truth node`() throws {
+    let select = try parse(select: "SELECT * FROM T WHERE Flag IS FALSE")
+    #expect(select.predicate
+                == .truth(boolean("Flag"), value: .false, negated: false))
+  }
+
+  @Test func `IS UNKNOWN parses to an UNKNOWN truth node`() throws {
+    let select = try parse(select: "SELECT * FROM T WHERE Flag IS UNKNOWN")
+    #expect(select.predicate
+                == .truth(boolean("Flag"), value: .unknown, negated: false))
+  }
+
+  @Test func `IS NOT TRUE parses to a negated truth node`() throws {
+    let select = try parse(select: "SELECT * FROM T WHERE Flag IS NOT TRUE")
+    #expect(select.predicate
+                == .truth(boolean("Flag"), value: .true, negated: true))
+  }
+
+  @Test func `IS NOT FALSE parses to a negated FALSE truth node`() throws {
+    let select = try parse(select: "SELECT * FROM T WHERE Flag IS NOT FALSE")
+    #expect(select.predicate
+                == .truth(boolean("Flag"), value: .false, negated: true))
+  }
+
+  @Test func `IS NOT UNKNOWN parses to a negated UNKNOWN truth node`() throws {
+    let select = try parse(select: "SELECT * FROM T WHERE Flag IS NOT UNKNOWN")
+    #expect(select.predicate
+                == .truth(boolean("Flag"), value: .unknown, negated: true))
+  }
+
+  @Test func `IS NULL still parses to a null node, not a truth node`() throws {
+    // The truth-value dispatch is ADDITIVE: an `IS NULL` tail is untouched, so
+    // it lowers to the existing `null` predicate rather than a `truth`.
+    let select = try parse(select: "SELECT * FROM T WHERE Flag IS NULL")
+    #expect(select.predicate == .null(.column("Flag"), negated: false))
+  }
+
+  @Test func `a parenthesised comparison IS TRUE parses to a truth node`()
+      throws {
+    // `(a > b) IS TRUE` tests a parenthesised comparison predicate directly:
+    // the inner `Predicate` is the comparison itself, not the `x = TRUE`
+    // bridge.
+    let select = try parse(select: "SELECT * FROM T WHERE (A > B) IS TRUE")
+    #expect(select.predicate
+                == .truth(.comparison(left: .column("A"), op: .gt,
+                                      right: .column("B")),
+                          value: .true, negated: false))
+  }
+
+  @Test func `a parenthesised comparison IS NOT FALSE parses negated`() throws {
+    let select =
+        try parse(select: "SELECT * FROM T WHERE (A > B) IS NOT FALSE")
+    #expect(select.predicate
+                == .truth(.comparison(left: .column("A"), op: .gt,
+                                      right: .column("B")),
+                          value: .false, negated: true))
+  }
+}
+
+// MARK: - Evaluation over a nullable boolean column
+
+struct TruthColumnEvaluationTests {
+  // Fixture Flags: Id 1 → TRUE, Id 2 → FALSE, Id 3 → NULL (UNKNOWN).
+
+  @Test func `IS TRUE keeps only the TRUE row`() throws {
+    try flags().expect("SELECT Id FROM T WHERE Flag IS TRUE", yields: [[1]])
+  }
+
+  @Test func `IS FALSE keeps only the FALSE row`() throws {
+    try flags().expect("SELECT Id FROM T WHERE Flag IS FALSE", yields: [[2]])
+  }
+
+  @Test func `IS UNKNOWN keeps only the NULL row`() throws {
+    // The UNKNOWN Flag (Id 3) is TESTED for — a definite TRUE — while the
+    // definite TRUE/FALSE rows are FALSE against `IS UNKNOWN`.
+    try flags().expect("SELECT Id FROM T WHERE Flag IS UNKNOWN", yields: [[3]])
+  }
+
+  @Test func `IS NOT TRUE keeps the FALSE and UNKNOWN rows`() throws {
+    // `IS NOT TRUE` is the negation: the FALSE row (Id 2) and the UNKNOWN row
+    // (Id 3) both pass — an UNKNOWN operand is NOT TRUE, so the row is KEPT
+    // (the key divergence from a bare `Flag`, which drops the UNKNOWN row).
+    try flags().expect("SELECT Id FROM T WHERE Flag IS NOT TRUE",
+                       yields: [[2], [3]])
+  }
+
+  @Test func `IS NOT FALSE keeps the TRUE and UNKNOWN rows`() throws {
+    try flags().expect("SELECT Id FROM T WHERE Flag IS NOT FALSE",
+                       yields: [[1], [3]])
+  }
+
+  @Test func `IS NOT UNKNOWN keeps the definite TRUE and FALSE rows`() throws {
+    try flags().expect("SELECT Id FROM T WHERE Flag IS NOT UNKNOWN",
+                       yields: [[1], [2]])
+  }
+
+  @Test func `IS TRUE agrees with the explicit boolean comparison`() throws {
+    // `WHERE Flag IS TRUE` and `WHERE Flag = TRUE` agree — both admit only the
+    // definite TRUE row — because `IS TRUE` is exactly the bridge comparison
+    // the parser builds. `IS NOT TRUE`, though, is NOT `Flag = FALSE`: it also
+    // keeps the UNKNOWN row (see the `IS NOT TRUE` test), the collapse of the
+    // third value the plain comparison cannot express.
+    try flags().expect("SELECT Id FROM T WHERE Flag IS TRUE",
+                       equals: "SELECT Id FROM T WHERE Flag = TRUE")
+  }
+}
+
+// MARK: - Evaluation over a comparison predicate
+
+struct TruthComparisonEvaluationTests {
+  // Fixture A/B: Id 1 → 2 > 1 (TRUE), Id 2 → 1 > 2 (FALSE), Id 3 → 1 > 1
+  // (FALSE). No comparison here is UNKNOWN — both operands are non-null — so
+  // the definite corners are exercised over a real predicate operand.
+
+  @Test func `a comparison IS TRUE keeps the rows the comparison keeps`()
+      throws {
+    // `(A > B) IS TRUE` equals the bare comparison `A > B`: both keep Id 1.
+    try flags().expect("SELECT Id FROM T WHERE (A > B) IS TRUE", yields: [[1]])
+  }
+
+  @Test func `a comparison IS FALSE keeps the rows the comparison rejects`()
+      throws {
+    try flags().expect("SELECT Id FROM T WHERE (A > B) IS FALSE",
+                       yields: [[2], [3]])
+  }
+
+  @Test func `a comparison IS NOT TRUE is the complement of IS TRUE`() throws {
+    try flags().expect("SELECT Id FROM T WHERE (A > B) IS NOT TRUE",
+                       yields: [[2], [3]])
+  }
+
+  @Test func `a comparison IS TRUE equals the bare comparison`() throws {
+    try flags().expect("SELECT Id FROM T WHERE (A > B) IS TRUE",
+                       equals: "SELECT Id FROM T WHERE A > B")
+  }
+
+  @Test func `an UNKNOWN comparison IS UNKNOWN tests for that UNKNOWN`()
+      throws {
+    // `A > N` is UNKNOWN for EVERY row (the NULL `N` is unordered), so `(A > N)
+    // IS UNKNOWN` is a definite TRUE for every row — keeping them all — and
+    // `IS TRUE` drops them all. The truth test collapses the UNKNOWN comparison
+    // to a definite two-valued answer, never itself UNKNOWN.
+    try flags().expect("SELECT Id FROM T WHERE (A > N) IS UNKNOWN",
+                       yields: [[1], [2], [3]])
+  }
+
+  @Test func `an UNKNOWN comparison IS TRUE drops every row`() throws {
+    try flags().empty("SELECT Id FROM T WHERE (A > N) IS TRUE")
+  }
+
+  @Test func `an UNKNOWN comparison IS NOT TRUE keeps every row`() throws {
+    // The negation of a per-row UNKNOWN `IS TRUE` (definite FALSE) is a
+    // definite TRUE — so `IS NOT TRUE` keeps every row, unlike `NOT (A > N)`
+    // which stays UNKNOWN and keeps none.
+    try flags().expect("SELECT Id FROM T WHERE (A > N) IS NOT TRUE",
+                       yields: [[1], [2], [3]])
+  }
+}
+
+// MARK: - Result is never itself UNKNOWN
+
+struct TruthDefiniteTests {
+  @Test func `the test is definite where NOT of the operand is UNKNOWN`()
+      throws {
+    // The whole point: a boolean test yields a DEFINITE two-valued result. Over
+    // the UNKNOWN Flag row (Id 3), `NOT (Flag = TRUE)` is UNKNOWN (dropped),
+    // but `Flag IS NOT TRUE` is a definite TRUE (kept). If the test could be
+    // UNKNOWN the two would agree; they diverge exactly because it cannot.
+    try flags().expect("SELECT Id FROM T WHERE Flag IS NOT TRUE",
+                       yields: [[2], [3]])
+    try flags().expect("SELECT Id FROM T WHERE NOT (Flag = TRUE)",
+                       yields: [[2]])
+  }
+
+  @Test func `IS TRUE and IS NOT TRUE partition every row`() throws {
+    // Because neither is ever UNKNOWN, every row lands in exactly one — their
+    // union is all three rows and their intersection is empty.
+    try flags().expect("SELECT Id FROM T WHERE Flag IS TRUE", yields: [[1]])
+    try flags().expect("SELECT Id FROM T WHERE Flag IS NOT TRUE",
+                       yields: [[2], [3]])
+  }
+}
+
+// MARK: - Constant folding
+
+/// Parses `text` to a `Query`, failing on any other shape.
+private func query(_ text: String) throws -> Query {
+  guard case let .select(query) = try Statement(parsing: text) else {
+    Issue.record("expected a SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return query
+}
+
+struct TruthConstantTests {
+  /// A relation with a text `Name`, so `Name + 1` is a reachable operand fault.
+  private func named() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["Id": .integer, "Name": .text]) {
+        Row(1, "a")
+        Row(2, "b")
+      }
+    }
+  }
+
+  @Test func `a constant-UNKNOWN IS TRUE folds FALSE and short-circuits`()
+      throws {
+    // `CASE WHEN 1 = 0 THEN TRUE END` is a ROW-INDEPENDENT UNKNOWN (no
+    // reachable branch → NULL). `… IS TRUE` folds DEFINITELY FALSE, settling
+    // the `AND` false WITHOUT validating the unreachable `Name + 1 = 0` (a
+    // `.operand` fault over the text `Name`, if reached) — so `columns(of:)`
+    // SUCCEEDS and the run drops every row. Before the fold distinguished a
+    // constant UNKNOWN from a per-row `nil`, the whole `AND` read
+    // row-dependent, the RHS was validated, and it faulted.
+    let text = "SELECT Id FROM T "
+        + "WHERE CASE WHEN 1 = 0 THEN TRUE END IS TRUE AND Name + 1 = 0"
+    _ = try named().columns(of: query(text))
+    try named().empty(text)
+  }
+
+  @Test func `a constant-UNKNOWN IS UNKNOWN folds TRUE`() throws {
+    // The same constant-UNKNOWN operand: `… IS UNKNOWN` is DEFINITELY TRUE, so
+    // the WHERE keeps every row — the fold decides it rather than deferring.
+    try named().expect(
+        "SELECT Id FROM T WHERE CASE WHEN 1 = 0 THEN TRUE END IS UNKNOWN",
+        yields: [[1], [2]])
+  }
+
+  @Test func `a two-valued inner IS UNKNOWN folds FALSE though row-dependent`()
+      throws {
+    // `Name IS NULL` READS a row yet is DEFINITE — an `IS NULL` test is never
+    // itself UNKNOWN — so `… IS UNKNOWN` folds DEFINITELY FALSE regardless of
+    // the rows (not just when the inner is row-INDEPENDENT), settling the `AND`
+    // false WITHOUT validating the unreachable `Name + 1 = 0`. `columns(of:)`
+    // SUCCEEDS and the run drops every row.
+    let text = "SELECT Id FROM T "
+        + "WHERE (Name IS NULL) IS UNKNOWN AND Name + 1 = 0"
+    _ = try named().columns(of: query(text))
+    try named().empty(text)
+  }
+
+  @Test func `a two-valued inner IS NOT UNKNOWN folds TRUE though row-dependent`()
+      throws {
+    // `(Name IS NULL) IS NOT UNKNOWN` is DEFINITELY TRUE — the two-valued inner
+    // never takes the UNKNOWN value — so the WHERE keeps every row.
+    try named().expect(
+        "SELECT Id FROM T WHERE (Name IS NULL) IS NOT UNKNOWN",
+        yields: [[1], [2]])
+  }
+}


### PR DESCRIPTION
Add the ISO 9075 `<boolean test>` — `<boolean primary> IS [NOT] <truth value>` — as a first-class `Predicate.truth(Predicate, value: Truth, negated: Bool)` lowered to `Filter.truth(Filter, Truth, negated: Bool)`. The test evaluates the THREE-VALUED result of a boolean operand and MAPS it against a truth value to a DEFINITE two-valued result that is NEVER itself UNKNOWN: `p IS TRUE` is TRUE exactly when `p` is TRUE (an UNKNOWN or FALSE `p` yielding FALSE, not UNKNOWN), `p IS UNKNOWN` TESTS for that third value, and `IS NOT` negates each — so `p IS NOT TRUE` KEEPS an UNKNOWN row that a bare `p` would drop.

The operand is a `Predicate` rather than an `Expression`: a boolean is a predicate to this engine, so a bare boolean operand `x` bridges as the comparison `x = TRUE` — whose own three-valued truth IS `x`'s boolean value, a NULL `x` reading UNKNOWN — and a parenthesised comparison (`(a > b) IS TRUE`) passes its predicate through directly. Both share the one inner-predicate form and reuse the whole comparison lowering, validation, and evaluation machinery; `Filter.truth` and the `constant`/`empty` folds all map through the shared `tested` primitive, and every walk (remap, safe, parameterised, references, aggregated, bound, collect, aggregates) delegates to the inner filter.

The parser dispatches the truth-value keyword in the `IS [NOT]` tail of `comparison` (coexisting additively with the `IS NULL` arm) and after a parenthesised predicate in `primary`; `UNKNOWN` is a new keyword valid only in this test position, reusing the existing `TRUE`/`FALSE` boolean-literal tokens.