### PR TITLE
SQLStandard: extract the SQLStandard prelude, make the engine pure

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,9 @@ let _ =
             ],
             products: [
               .executable(name: "winmd-inspect", targets: ["winmd-inspect"]),
+              .library(name: "SQL", targets: ["SQL"]),
               .library(name: "SQLEngine", targets: ["SQLEngine"]),
+              .library(name: "SQLStandard", targets: ["SQLStandard"]),
               .library(name: "WinMDSynthesis", targets: ["WinMDSynthesis"]),
             ],
             dependencies: [
@@ -26,12 +28,29 @@ let _ =
                       swiftSettings: [
                         .enableExperimentalFeature("Lifetimes"),
                       ]),
-              .target(name: "SQLTestSupport", dependencies: ["SQLEngine"],
+              .target(name: "SQLStandard", dependencies: ["SQLEngine"],
+                      swiftSettings: [
+                        .enableExperimentalFeature("Lifetimes"),
+                      ]),
+              .target(name: "SQL",
+                      dependencies: ["SQLEngine", "SQLStandard"],
+                      swiftSettings: [
+                        .enableExperimentalFeature("Lifetimes"),
+                      ]),
+              .target(name: "SQLTestSupport",
+                      dependencies: ["SQLEngine", "SQLStandard"],
                       swiftSettings: [
                         .enableExperimentalFeature("Lifetimes"),
                       ]),
               .testTarget(name: "SQLTests",
-                          dependencies: ["SQLEngine", "SQLTestSupport"],
+                          dependencies: ["SQLEngine", "SQLStandard",
+                                         "SQLTestSupport"],
+                          swiftSettings: [
+                            .enableExperimentalFeature("Lifetimes"),
+                          ]),
+              .testTarget(name: "SQLStandardTests",
+                          dependencies: ["SQLEngine", "SQLStandard",
+                                         "SQLTestSupport"],
                           swiftSettings: [
                             .enableExperimentalFeature("Lifetimes"),
                           ]),
@@ -61,6 +80,7 @@ let _ =
               .executableTarget(name: "winmd-inspect",
                                 dependencies: [
                                   "SQLEngine",
+                                  "SQLStandard",
                                   "WinMD",
                                   "WinMDSynthesis",
                                   .product(name: "ArgumentParser",
@@ -80,6 +100,7 @@ let _ =
                           dependencies: [
                             "winmd-inspect",
                             "SQLEngine",
+                            "SQLStandard",
                             "WinMD",
                             .product(name: "Mustache",
                                      package: "swift-mustache"),

--- a/Sources/SQL/SQL.swift
+++ b/Sources/SQL/SQL.swift
@@ -1,0 +1,11 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+// The umbrella module: one `import SQL` brings the pure engine (`SQLEngine`)
+// and the ISO standard-library prelude with its import-activated defaulting
+// (`SQLStandard`). This is the conformance-by-default surface — a consumer that
+// wants the built-ins available without threading `Routines.standard` imports
+// `SQL`; a consumer that wants the pure engine alone imports `SQLEngine`.
+
+@_exported import SQLEngine
+@_exported import SQLStandard

--- a/Sources/SQLEngine/Engine.swift
+++ b/Sources/SQLEngine/Engine.swift
@@ -92,15 +92,14 @@ extension Catalog where Self: ~Escapable {
   ///   `SQLError.column` if a referenced column is absent, `SQLError.ambiguous`
   ///   if an unqualified name is resolved by more than one relation of a chain,
   ///   `SQLError.arity` if a `UNION`'s arms project differing column counts.
-  public borrowing func run(_ query: Query, _ routines: Routines = [:],
+  public borrowing func run(_ query: Query, _ routines: Routines,
                             bindings: Bindings = [:])
       throws(SQLError) -> Array<Array<Value>> {
-    // Seed the standard prelude UNDER the caller's routines so a public call
-    // always resolves the built-ins (BITAND) even when it supplies unrelated
-    // UDFs; an explicitly registered function of the same name still shadows it
-    // (the merge keeps the caller's binding on a clash).
-    try run(query, Context(routines: Routines.standard.merging(routines),
-                           bindings: bindings))
+    // The engine is PURE: it resolves calls against exactly the `routines`
+    // given, seeding no prelude of its own. `import SQLStandard` adds a
+    // prelude-defaulting overload (`run(_:bindings:)` — see `SQLStandard`),
+    // so a call under that module reaches the built-ins without naming them.
+    try run(query, Context(routines: routines, bindings: bindings))
   }
 
   /// Runs `query` against this catalog under `context` — the in-scope common
@@ -130,13 +129,12 @@ extension Catalog where Self: ~Escapable {
   /// query resolves against (see `with`). A `create` defines a view and a
   /// `function` a scalar function rather than producing rows, so neither is
   /// runnable — both fault with `SQLError.statement`.
-  public borrowing func run(_ statement: Statement, _ routines: Routines = [:],
+  public borrowing func run(_ statement: Statement, _ routines: Routines,
                             bindings: Bindings = [:])
       throws(SQLError) -> Array<Array<Value>> {
-    // Seed the standard prelude under the caller's routines (see the query
-    // overload) so BITAND resolves regardless of what the caller supplies.
-    let context = Context(routines: Routines.standard.merging(routines),
-                          bindings: bindings)
+    // Pure engine: it uses exactly `routines` (see the query overload);
+    // `import SQLStandard` re-defaults the prelude via an overload.
+    let context = Context(routines: routines, bindings: bindings)
     return switch statement {
     case let .select(query):
       try run(query, context)

--- a/Sources/SQLEngine/Function.swift
+++ b/Sources/SQLEngine/Function.swift
@@ -231,19 +231,59 @@ public struct Routines: Sendable {
   /// The registered routines, keyed by their case-folded (lower-cased) name.
   private let functions: Dictionary<String, Routine>
 
+  /// The case-folded names that `registering(_:…)` refuses to bind — the
+  /// PROTECTED routines a standard-library prelude marks so a caller extending
+  /// it cannot shadow an ISO built-in and silently change what a query naming
+  /// it computes. The set travels WITH the value: the empty routines and a
+  /// dictionary literal carry none (the escape hatch a prelude is BUILT
+  /// through), and `merging(_:)` unions both sides' sets, so protection is a
+  /// property of the routines rather than a module-wide constant. The engine
+  /// itself ships no built-in, so a `Routines` it builds is unprotected; the
+  /// `SQLStandard` prelude marks its own names (see `protecting(_:)`).
+  private let protected: Set<String>
+
   /// Empty routines — every call faults until a routine is registered.
   public init() {
     self.functions = [:]
+    self.protected = []
   }
 
   /// Routines over a `name → routine` map; each name folds to lower case so a
   /// call resolves by the SQL identifier rule. Two names differing only by case
-  /// merge (the later-sorting original spelling wins) instead of trapping.
+  /// merge (the later-sorting original spelling wins) instead of trapping. The
+  /// map carries no protected names — it is the lower-level escape hatch a
+  /// prelude is built through (see `protecting(_:)`).
   public init(_ functions: Dictionary<String, Routine>) {
     self.functions = functions.sorted { $0.key < $1.key }
       .reduce(into: Dictionary<String, Routine>()) {
         $0[$1.key.lowercased()] = $1.value
       }
+    self.protected = []
+  }
+
+  /// A private designated initializer carrying an explicit protected-name set,
+  /// so `protecting(_:)` and `merging(_:)` can preserve or union it while the
+  /// public inits default it empty.
+  private init(_ functions: Dictionary<String, Routine>,
+               protected: Set<String>) {
+    self.functions = functions
+    self.protected = protected
+  }
+
+  /// These routines with `names` (case-folded) marked PROTECTED — the seam a
+  /// standard-library prelude uses to declare its built-ins non-shadowable: a
+  /// later `registering(_:…)` of a protected name faults SQLSTATE `42723`
+  /// rather than shadow it. The engine ships no prelude, so it never calls
+  /// this; `SQLStandard` marks the standard routines' own names.
+  public func protecting(_ names: Set<String>) -> Routines {
+    Routines(functions,
+             protected: protected.union(names.map { $0.lowercased() }))
+  }
+
+  /// The case-folded names of the registered routines — the set a prelude
+  /// passes to `protecting(_:)` to mark its own built-ins non-shadowable.
+  public var names: Set<String> {
+    Set(functions.keys)
   }
 
   /// The routine `name` names, folded to lower case like every other SQL
@@ -260,24 +300,14 @@ public struct Routines: Sendable {
     functions[name.lowercased()]
   }
 
-  /// The names of the standard-library routines, case-folded — the built-ins
-  /// `Routines.standard` seeds. These are PROTECTED: `registering(_:…)` rejects
-  /// a binding of any of them, so a caller extending the prelude cannot shadow
-  /// an ISO built-in and silently change what a query naming it computes.
-  /// Constructing a `Routines` DIRECTLY through `init(_:)` or the dictionary
-  /// literal is a lower-level escape hatch that still admits a standard name —
-  /// it is how `standard` itself is built — but the public composition API
-  /// (`registering`) does not.
-  private static let protected = Set(standard.functions.keys)
-
-  /// Faults if `name` (case-folded) is a protected standard routine — the check
-  /// both `registering` overloads apply before binding, so neither the closure
-  /// nor the `CREATE FUNCTION` path shadows a built-in. It carries SQLSTATE
-  /// `42723` (duplicate function, the PostgreSQL subclass on the `42` class)
-  /// via the `.state` passthrough — no semantic case models a reserved-name
-  /// fault, and `.function`'s message ("no such function") would misdescribe
-  /// the condition.
-  private static func reserved(_ name: String) throws(SQLError) {
+  /// Faults if `name` (case-folded) is a protected routine of THESE routines —
+  /// the check both `registering` overloads apply before binding, so neither
+  /// the closure nor the `CREATE FUNCTION` path shadows a name a prelude marked
+  /// (see `protecting(_:)`). It carries SQLSTATE `42723` (duplicate function,
+  /// the PostgreSQL subclass on the `42` class) via the `.state` passthrough —
+  /// no semantic case models a reserved-name fault, and `.function`'s message
+  /// ("no such function") would misdescribe the condition.
+  private func reserved(_ name: String) throws(SQLError) {
     guard !protected.contains(name.lowercased()) else {
       throw .state("42723", "'\(name)' is a standard routine and "
                        + "cannot be redefined")
@@ -305,12 +335,12 @@ public struct Routines: Sendable {
                               @escaping @Sendable (Array<SQLEngine.Value>)
                                   throws(SQLError) -> SQLEngine.Value)
       throws(SQLError) -> Routines {
-    try Routines.reserved(name)
+    try reserved(name)
     var functions = self.functions
     functions[name.lowercased()] =
         Routine(returns: returns, parameters: parameters,
                 deterministic: deterministic, compute)
-    return Routines(functions)
+    return Routines(functions, protected: protected)
   }
 
   /// A copy of these routines with the DEFINED `function` bound to `name`
@@ -336,28 +366,30 @@ public struct Routines: Sendable {
   /// registers, so neither path admits a duplicate.
   ///
   /// The body EARLY-BINDS the routines its own calls name: it captures the
-  /// standard prelude OVERLAID with these routines — `Routines.standard`
-  /// merged under the map before this registration, the SAME precedence the
-  /// public `run`/`columns` compose a query's routines with (the prelude is
-  /// the base, a caller registration shadows a like-named prelude routine) —
-  /// and resolves its nested calls through that captured environment at run
-  /// time, the ISO subject-routine rule (a body's routine references are fixed
-  /// when it is defined). Bringing the prelude into the capture is what lets a
-  /// body call a built-in: `lowbit(n) AS BITAND(n, 1)` resolves `BITAND` here
-  /// exactly as an ordinary `SELECT` would, rather than faulting at
-  /// registration for a routine the query path can see. A body naming its OWN
-  /// registration `name` is well-defined, not recursion: `f() AS f() + 1`
-  /// REPLACING a prior `f` captures the OLD `f`, so it computes `f_old() + 1`
-  /// and terminates. With NO prior `f` and no prelude `f`, the captured map
-  /// lacks `f`, so the body's call is unresolved and the returns validation
-  /// above faults `SQLError.function` — the unregistered-callee case, not a
-  /// self-reference one. Query-level resolution is UNCHANGED: a top-level
-  /// `SELECT f()` still resolves `f` to the LATEST binding (a later
-  /// registration shadows an earlier one); capture governs only a body's
-  /// INTERNAL calls, not which `f` a query reaches.
-  public func registering(_ name: String, _ function: Function)
+  /// `ambient` routines OVERLAID with these routines — `ambient` merged under
+  /// the map before this registration (the prelude is the base, a caller
+  /// registration shadows a like-named prelude routine) — and resolves its
+  /// nested calls through that captured environment at run time, the ISO
+  /// subject-routine rule (a body's routine references are fixed when it is
+  /// defined). `ambient` is the environment a prelude layer supplies so a body
+  /// may call a built-in: `SQLStandard` passes `Routines.standard`, so
+  /// `lowbit(n) AS BITAND(n, 1)` resolves `BITAND` here exactly as an ordinary
+  /// `SELECT` would, rather than faulting at registration for a routine the
+  /// query path can see. The pure engine supplies no ambient of its own —
+  /// `import SQLStandard` re-defaults it (see the two-argument overload there).
+  /// A body naming its OWN registration `name` is well-defined, not recursion:
+  /// `f() AS f() + 1` REPLACING a prior `f` captures the OLD `f`, so it
+  /// computes `f_old() + 1` and terminates. With NO prior `f` and no ambient
+  /// `f`, the captured map lacks `f`, so the body's call is unresolved and the
+  /// returns validation above faults `SQLError.function` — the
+  /// unregistered-callee case, not a self-reference one. Query-level resolution
+  /// is UNCHANGED: a top-level `SELECT f()` still resolves `f` to the LATEST
+  /// binding (a later registration shadows an earlier one); capture governs
+  /// only a body's INTERNAL calls, not which `f` a query reaches.
+  public func registering(_ name: String, _ function: Function,
+                          capturing ambient: Routines)
       throws(SQLError) -> Routines {
-    try Routines.reserved(name)
+    try reserved(name)
     var seen = Set<String>()
     for parameter in function.parameters
         where !seen.insert(parameter.name.lowercased()).inserted {
@@ -368,393 +400,19 @@ public struct Routines: Sendable {
         try Routine(returns: function.returns,
                     parameters: function.parameters.map(\.type),
                     names: function.parameters.map(\.name),
-                    body: function.body, Routines.standard.merging(self))
-    return Routines(functions)
+                    body: function.body, ambient.merging(self))
+    return Routines(functions, protected: protected)
   }
 
   /// These routines overlaid with `other`'s — a caller composing two routine
   /// sources (e.g. a target-language spec's UDFs and a data source's domain
   /// UDFs). A name `other` also binds shadows this one's; names are already
-  /// case-folded on both sides.
+  /// case-folded on both sides. Both sides' protected names are unioned, so
+  /// merging a prelude in keeps its built-ins non-shadowable (see
+  /// `protecting(_:)`).
   public func merging(_ other: Routines) -> Routines {
-    Routines(functions.merging(other.functions) { _, last in last })
-  }
-
-  /// The standard-library prelude — the routines the engine ships, seeded into
-  /// the flat registry at the public entry points (`Routines.standard` merged
-  /// under a caller's routines) so a query reaches them without a caller
-  /// registering a closure. They are PROTECTED: a caller cannot shadow one
-  /// through `registering(_:…)` (see `protected`/`reserved(_:)`), so a query
-  /// naming a built-in always reaches the shipped one. Every member is a pure,
-  /// side-effect-free mapping and so DETERMINISTIC — a row-independent call
-  /// folds at compile time — and returns NULL on any NULL argument (SQL null
-  /// propagation), faulting `SQLError.argument` on the wrong argument count or
-  /// a value it cannot map, mirroring its declared `[parameters]`/`returns`
-  /// contract the static type-check validates a call against.
-  ///
-  /// The set covers the ISO scalar built-ins the grammar can already CALL
-  /// (`f(…)`), in two families:
-  ///
-  /// - STRING: `UPPER`/`LOWER` (case fold), `CHAR_LENGTH` (with its ISO synonym
-  ///   `CHARACTER_LENGTH`, the same routine under both names), `SUBSTRING` (the
-  ///   two-argument `SUBSTRING(text, start)` form, ISO 1-based indexing),
-  ///   `TRIM` (the one-argument `TRIM(text)` form, stripping leading and
-  ///   trailing spaces), `POSITION` (the ISO `POSITION(substring IN string)`
-  ///   form the parser desugars to `position(substring, string)`, 1-based, 0
-  ///   when absent), and `OVERLAY` (the ISO `OVERLAY(string PLACING replacement
-  ///   FROM start [FOR length])` form the parser desugars to `overlay(string,
-  ///   replacement, start[, length])` — an optional-tail routine (`minimum` 3)
-  ///   that defaults an omitted `length` to the once-evaluated replacement's
-  ///   character count itself, so the parser need not re-reference the
-  ///   replacement).
-  /// - NUMERIC: `ABS`, `ROUND` (the one-argument form, to the nearest integer
-  ///   value), `CEILING` (with its synonym `CEIL`), `FLOOR`, and `MOD` (the
-  ///   two-integer remainder — `BITAND`'s numeric sibling, an operation the
-  ///   grammar's `%` otherwise lacks a call spelling for). `BITAND` — the
-  ///   portable, standards-compliant spelling (Oracle's) of a bitwise AND, an
-  ///   operation ISO SQL and this grammar otherwise lack — is kept.
-  ///
-  /// FOLLOW-UPS (each needs grammar or overloading this batch does not add, so
-  /// each ships in its simplest callable form now):
-  /// - `SUBSTRING(text FROM start FOR length)` — the full ISO clause with a
-  ///   `FROM`/`FOR` keyword syntax and an optional length — and the plain
-  ///   three-argument `SUBSTRING(text, start, length)` could now adopt the
-  ///   optional-tail arity `OVERLAY` introduced (`minimum` 2, an optional third
-  ///   `length`); only the two-argument prefix form ships in this batch.
-  /// - `TRIM([{LEADING | TRAILING | BOTH}] [char] FROM text)` — the full ISO
-  ///   clause with a trim specification and a trim character — needs grammar;
-  ///   only the leading-and-trailing-space `TRIM(text)` form ships.
-  /// - `ROUND(n, places)` — rounding to a decimal place — could now use the
-  ///   optional-tail arity (`minimum` 1); only the nearest-integer `ROUND(n)`
-  ///   form ships in this batch.
-  /// - The numeric routines are declared over `double` (`returns` a `double`,
-  ///   save `MOD`'s integer remainder), so an INTEGER argument does not satisfy
-  ///   the static contract (the type-check is exact-equality — an integer is
-  ///   not a double); an integer-domain overload (`ABS(integer) → integer`, …)
-  ///   needs routine overloading, which the single-signature contract lacks.
-  public static let standard: Routines = [
-    "bitand": Routine(returns: .integer, parameters: [.integer, .integer],
-                      deterministic: true, bitand),
-    "upper": Routine(returns: .text, parameters: [.text],
-                     deterministic: true, upper),
-    "lower": Routine(returns: .text, parameters: [.text],
-                     deterministic: true, lower),
-    "char_length": Routine(returns: .integer, parameters: [.text],
-                           deterministic: true, length),
-    "character_length": Routine(returns: .integer, parameters: [.text],
-                                deterministic: true, length),
-    "substring": Routine(returns: .text, parameters: [.text, .integer],
-                         deterministic: true, substring),
-    "trim": Routine(returns: .text, parameters: [.text],
-                    deterministic: true, trim),
-    "abs": Routine(returns: .double, parameters: [.double],
-                   deterministic: true, abs),
-    "round": Routine(returns: .double, parameters: [.double],
-                     deterministic: true, round),
-    "ceiling": Routine(returns: .double, parameters: [.double],
-                       deterministic: true, ceiling),
-    "ceil": Routine(returns: .double, parameters: [.double],
-                    deterministic: true, ceiling),
-    "floor": Routine(returns: .double, parameters: [.double],
-                     deterministic: true, floor),
-    "mod": Routine(returns: .integer, parameters: [.integer, .integer],
-                   deterministic: true, mod),
-    "position": Routine(returns: .integer, parameters: [.text, .text],
-                        deterministic: true, position),
-    "overlay": Routine(returns: .text,
-                       parameters: [.text, .text, .integer, .integer],
-                       minimum: 3, deterministic: true, overlay),
-  ]
-
-  /// The single `.null` short-circuit ISO null propagation gives every built-in
-  /// — a NULL argument yields NULL — factored out so each routine reads as its
-  /// mapping alone. Returns `true` when any argument is NULL, so the caller
-  /// returns `.null` before matching a concrete kind.
-  private static func propagates(_ arguments: Array<SQLEngine.Value>) -> Bool {
-    arguments.contains(.null)
-  }
-
-  /// `BITAND(x, y)` — the bitwise AND of two integers. A NULL argument yields
-  /// NULL (SQL null propagation); the wrong argument count or a non-integer
-  /// argument is `SQLError.argument` (a function-argument fault — not
-  /// `SQLError.arity`, which is the UNION column-count mismatch). Its declared
-  /// `[.integer, .integer]` contract is what the static type-check validates a
-  /// call against, mirroring these run-time faults.
-  private static func bitand(_ arguments: Array<SQLEngine.Value>)
-      throws(SQLError) -> SQLEngine.Value {
-    guard arguments.count == 2 else {
-      throw .argument("BITAND takes two arguments")
-    }
-    if propagates(arguments) { return .null }
-    guard case let .integer(x) = arguments[0],
-        case let .integer(y) = arguments[1] else {
-      throw .argument("BITAND requires integer arguments")
-    }
-    return .integer(x & y)
-  }
-
-  /// `UPPER(text)` — the string upper-cased. A NULL argument yields NULL; the
-  /// wrong count or a non-text argument is `SQLError.argument`.
-  private static func upper(_ arguments: Array<SQLEngine.Value>)
-      throws(SQLError) -> SQLEngine.Value {
-    guard arguments.count == 1 else {
-      throw .argument("UPPER takes one argument")
-    }
-    if propagates(arguments) { return .null }
-    guard case let .text(string) = arguments[0] else {
-      throw .argument("UPPER requires a text argument")
-    }
-    return .text(string.uppercased())
-  }
-
-  /// `LOWER(text)` — the string lower-cased. A NULL argument yields NULL; the
-  /// wrong count or a non-text argument is `SQLError.argument`.
-  private static func lower(_ arguments: Array<SQLEngine.Value>)
-      throws(SQLError) -> SQLEngine.Value {
-    guard arguments.count == 1 else {
-      throw .argument("LOWER takes one argument")
-    }
-    if propagates(arguments) { return .null }
-    guard case let .text(string) = arguments[0] else {
-      throw .argument("LOWER requires a text argument")
-    }
-    return .text(string.lowercased())
-  }
-
-  /// `CHAR_LENGTH(text)` / `CHARACTER_LENGTH(text)` — the number of characters
-  /// in the string (its Unicode character count, not its UTF-8 byte length). A
-  /// NULL argument yields NULL; the wrong count or a non-text argument is
-  /// `SQLError.argument`.
-  private static func length(_ arguments: Array<SQLEngine.Value>)
-      throws(SQLError) -> SQLEngine.Value {
-    guard arguments.count == 1 else {
-      throw .argument("CHAR_LENGTH takes one argument")
-    }
-    if propagates(arguments) { return .null }
-    guard case let .text(string) = arguments[0] else {
-      throw .argument("CHAR_LENGTH requires a text argument")
-    }
-    return .integer(string.count)
-  }
-
-  /// `SUBSTRING(text, start)` — the substring of `text` from the 1-based
-  /// `start` character to the end, the ISO indexing where the first character
-  /// is position 1. A `start` at or before 1 begins at the first character; a
-  /// `start` past the end yields the empty string. A NULL argument yields NULL;
-  /// the wrong count, a non-text first argument, or a non-integer second is
-  /// `SQLError.argument`.
-  private static func substring(_ arguments: Array<SQLEngine.Value>)
-      throws(SQLError) -> SQLEngine.Value {
-    guard arguments.count == 2 else {
-      throw .argument("SUBSTRING takes two arguments")
-    }
-    if propagates(arguments) { return .null }
-    guard case let .text(string) = arguments[0],
-        case let .integer(start) = arguments[1] else {
-      throw .argument("SUBSTRING requires a text and an integer argument")
-    }
-    // ISO positions are 1-based; a start at or before 1 clamps to the first
-    // character, and one past the end clamps to the end (the empty tail). The
-    // `start - 1` conversion overflows for `Int.min`, so a start at or before
-    // 1 takes the whole string directly rather than subtracting.
-    let drop = start > 1 ? start - 1 : 0
-    return .text(String(string.dropFirst(drop)))
-  }
-
-  /// `TRIM(text)` — the string with leading and trailing SPACE characters
-  /// removed (the one-argument ISO form, whose implicit trim character is a
-  /// space and whose implicit specification is BOTH). A NULL argument yields
-  /// NULL; the wrong count or a non-text argument is `SQLError.argument`.
-  private static func trim(_ arguments: Array<SQLEngine.Value>)
-      throws(SQLError) -> SQLEngine.Value {
-    guard arguments.count == 1 else {
-      throw .argument("TRIM takes one argument")
-    }
-    if propagates(arguments) { return .null }
-    guard case let .text(string) = arguments[0] else {
-      throw .argument("TRIM requires a text argument")
-    }
-    return .text(String(string.drop(while: { $0 == " " })
-                            .reversed().drop(while: { $0 == " " })
-                            .reversed()))
-  }
-
-  /// `ABS(n)` — the absolute value of a real number. A NULL argument yields
-  /// NULL; the wrong count or a non-double argument is `SQLError.argument`.
-  private static func abs(_ arguments: Array<SQLEngine.Value>)
-      throws(SQLError) -> SQLEngine.Value {
-    guard arguments.count == 1 else {
-      throw .argument("ABS takes one argument")
-    }
-    if propagates(arguments) { return .null }
-    guard case let .double(value) = arguments[0] else {
-      throw .argument("ABS requires a double argument")
-    }
-    return .double(Swift.abs(value))
-  }
-
-  /// `ROUND(n)` — the real number rounded to the nearest integer value (ties
-  /// away from zero, the ISO default), carried as a double. A NULL argument
-  /// yields NULL; the wrong count or a non-double argument is
-  /// `SQLError.argument`.
-  private static func round(_ arguments: Array<SQLEngine.Value>)
-      throws(SQLError) -> SQLEngine.Value {
-    guard arguments.count == 1 else {
-      throw .argument("ROUND takes one argument")
-    }
-    if propagates(arguments) { return .null }
-    guard case let .double(value) = arguments[0] else {
-      throw .argument("ROUND requires a double argument")
-    }
-    return .double(value.rounded())
-  }
-
-  /// `CEILING(n)` / `CEIL(n)` — the least integer value not less than `n`,
-  /// carried as a double. A NULL argument yields NULL; the wrong count or a
-  /// non-double argument is `SQLError.argument`.
-  private static func ceiling(_ arguments: Array<SQLEngine.Value>)
-      throws(SQLError) -> SQLEngine.Value {
-    guard arguments.count == 1 else {
-      throw .argument("CEILING takes one argument")
-    }
-    if propagates(arguments) { return .null }
-    guard case let .double(value) = arguments[0] else {
-      throw .argument("CEILING requires a double argument")
-    }
-    return .double(value.rounded(.up))
-  }
-
-  /// `FLOOR(n)` — the greatest integer value not greater than `n`, carried as a
-  /// double. A NULL argument yields NULL; the wrong count or a non-double
-  /// argument is `SQLError.argument`.
-  private static func floor(_ arguments: Array<SQLEngine.Value>)
-      throws(SQLError) -> SQLEngine.Value {
-    guard arguments.count == 1 else {
-      throw .argument("FLOOR takes one argument")
-    }
-    if propagates(arguments) { return .null }
-    guard case let .double(value) = arguments[0] else {
-      throw .argument("FLOOR requires a double argument")
-    }
-    return .double(value.rounded(.down))
-  }
-
-  /// `MOD(a, b)` — the remainder of `a` divided by `b`, both integers (the ISO
-  /// `MOD` function, distinct from the grammar's `%` operator). A zero divisor
-  /// is `SQLError.divide`, as integer arithmetic's `%` by zero is. A NULL
-  /// argument yields NULL; the wrong count or a non-integer argument is
-  /// `SQLError.argument`.
-  private static func mod(_ arguments: Array<SQLEngine.Value>)
-      throws(SQLError) -> SQLEngine.Value {
-    guard arguments.count == 2 else {
-      throw .argument("MOD takes two arguments")
-    }
-    if propagates(arguments) { return .null }
-    guard case let .integer(a) = arguments[0],
-        case let .integer(b) = arguments[1] else {
-      throw .argument("MOD requires integer arguments")
-    }
-    guard b != 0 else { throw .divide }
-    // `a % -1` is mathematically 0, but `Int.min % -1` overflows the implied
-    // division and traps, so a divisor of -1 short-circuits to that 0.
-    guard b != -1 else { return .integer(0) }
-    return .integer(a % b)
-  }
-
-  /// `POSITION(substring, string)` — the parser's desugaring of the ISO
-  /// `POSITION(substring IN string)` — the 1-based character position of the
-  /// first occurrence of `substring` in `string`, 0 when it does not occur. An
-  /// EMPTY substring occurs at position 1 (ISO): the empty string is a prefix
-  /// of every string, including another empty string. Matching is
-  /// character-wise and case-SENSITIVE (no case fold). A NULL argument yields
-  /// NULL; the wrong count or a non-text argument is `SQLError.argument`.
-  private static func position(_ arguments: Array<SQLEngine.Value>)
-      throws(SQLError) -> SQLEngine.Value {
-    guard arguments.count == 2 else {
-      throw .argument("POSITION takes two arguments")
-    }
-    if propagates(arguments) { return .null }
-    guard case let .text(substring) = arguments[0],
-        case let .text(string) = arguments[1] else {
-      throw .argument("POSITION requires text arguments")
-    }
-    // The empty substring is a prefix of every string, so it occurs at 1.
-    guard !substring.isEmpty else { return .integer(1) }
-    // Character-wise search over the Unicode scalars `CHAR_LENGTH` counts, so
-    // the reported position is a 1-based character index, not a byte offset.
-    let haystack = Array(string), needle = Array(substring)
-    guard haystack.count >= needle.count else { return .integer(0) }
-    for start in 0...(haystack.count - needle.count)
-        where Array(haystack[start ..< start + needle.count]) == needle {
-      return .integer(start + 1)
-    }
-    return .integer(0)
-  }
-
-  /// `OVERLAY(string, replacement, start, length)` — the parser's desugaring of
-  /// the ISO `OVERLAY(string PLACING replacement FROM start [FOR length])` —
-  /// the `string` with `length` characters from the 1-based `start` replaced by
-  /// `replacement`. The optional `FOR length` defaults, in the parser, to the
-  /// replacement's character count, so the four-argument form is the only one
-  /// this routine sees. A NULL argument yields NULL; the wrong count, a
-  /// non-text `string`/`replacement`, or a non-integer `start`/`length` is
-  /// `SQLError.argument`.
-  ///
-  /// The 1-based `start` and the `length` are CLAMPED to the string rather than
-  /// trusted, so no arithmetic traps and no slice runs out of bounds: a `start`
-  /// at or before 1 begins at the first character (the `start - 1` conversion
-  /// would overflow for `Int.min`, so it is not subtracted below 1), a `start`
-  /// past the end appends, a negative `length` removes nothing, and a `length`
-  /// past the end removes only to the end. This is `SUBSTRING`'s clamp
-  /// discipline applied to both the prefix kept and the suffix resumed.
-  private static func overlay(_ arguments: Array<SQLEngine.Value>)
-      throws(SQLError) -> SQLEngine.Value {
-    guard (3 ... 4).contains(arguments.count) else {
-      throw .argument("OVERLAY takes three or four arguments")
-    }
-    if propagates(arguments) { return .null }
-    guard case let .text(string) = arguments[0],
-        case let .text(replacement) = arguments[1],
-        case let .integer(start) = arguments[2] else {
-      throw .argument("OVERLAY requires text, text, and integer arguments")
-    }
-    // The number of characters to remove: the explicit `FOR length` fourth
-    // argument, or — when omitted — the character count of the replacement.
-    // Defaulting HERE, from the single evaluated replacement value, is what
-    // lets the parser pass only three arguments for the omitted-`FOR` form:
-    // the replacement is evaluated ONCE, so a NOT-DETERMINISTIC one
-    // (`stepper_text()`) both inserts and measures the SAME value, rather than
-    // the parser re-referencing it as `char_length(replacement)` and
-    // evaluating it a second time.
-    let length: Int
-    if arguments.count == 4 {
-      guard case let .integer(explicit) = arguments[3] else {
-        throw .argument("OVERLAY requires an integer length")
-      }
-      length = explicit
-    } else {
-      length = replacement.count
-    }
-    let characters = Array(string)
-    // The prefix kept is `start - 1` characters, clamped into `[0, count]`; the
-    // `start - 1` is not computed for a start at or before 1, which would
-    // overflow at `Int.min`, and is capped at the string's length so a start
-    // past the end keeps the whole string and appends.
-    let head = start > 1 ? Swift.min(start - 1, characters.count) : 0
-    // The suffix resumes `length` characters after `head`, clamped the same
-    // way: a negative or zero length removes nothing (resumes at `head`), and a
-    // length past the end resumes at the end. The overshoot is tested against
-    // the REMAINING capacity (`count - head`) rather than forming `head +
-    // length`, whose sum would overflow for an `Int.max` length.
-    let tail = if length <= 0 {
-      head
-    } else if length < characters.count - head {
-      head + length
-    } else {
-      characters.count
-    }
-    return .text(String(characters[..<head]) + replacement
-                     + String(characters[tail...]))
+    Routines(functions.merging(other.functions) { _, last in last },
+             protected: protected.union(other.protected))
   }
 }
 

--- a/Sources/SQLEngine/OutputColumn.swift
+++ b/Sources/SQLEngine/OutputColumn.swift
@@ -77,13 +77,13 @@ extension Catalog where Self: ~Escapable {
   ///   an unregistered scalar function anywhere in the query, `SQLError.arity`
   ///   for a `UNION` whose arms project differing column counts; and, when
   ///   `validate`, `SQLError.operand` for an ill-typed reachable expression.
-  public borrowing func columns(of query: Query, routines: Routines = [:],
+  public borrowing func columns(of query: Query, routines: Routines,
                                 validate: Bool = true)
       throws(SQLError) -> Array<OutputColumn> {
-    // The engine prelude merged under the caller's routines, exactly as a run
-    // seeds them, so a standard call (`BITAND`) types without the caller
-    // re-supplying it. A typing path has no bindings.
-    let context = Context(routines: Routines.standard.merging(routines))
+    // Pure engine: it types calls against exactly the `routines` given, seeding
+    // no prelude. `import SQLStandard` adds a prelude-defaulting overload
+    // (`columns(of:validate:)`). A typing path has no bindings.
+    let context = Context(routines: routines)
     // Extend the scope with any `definition_schema.` store relation the query
     // names, so its result schema resolves the reserved relation the same as a
     // run would — SCHEMA-ONLY, so typing never triggers the row build.
@@ -135,7 +135,7 @@ extension Catalog where Self: ~Escapable {
   /// - Throws: the resolution faults `columns(of query:)` raises, plus
   ///   `SQLError.statement` for a `create` or a `function`.
   public borrowing func columns(of statement: Statement,
-                                routines: Routines = [:],
+                                routines: Routines,
                                 validate: Bool = true)
       throws(SQLError) -> Array<OutputColumn> {
     switch statement {
@@ -192,7 +192,7 @@ extension Catalog where Self: ~Escapable {
                                  routines: Routines,
                                  validate: Bool)
       throws(SQLError) -> Array<OutputColumn> {
-    let context = Context(routines: Routines.standard.merging(routines))
+    let context = Context(routines: routines)
     var overlay = ScopedRelations()
     for cte in ctes {
       // A name repeated in the list (case-insensitively) would silently shadow

--- a/Sources/SQLStandard/Overlay.swift
+++ b/Sources/SQLStandard/Overlay.swift
@@ -1,0 +1,59 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+public import SQLEngine
+
+// The prelude-defaulting overlay: `import SQLStandard` re-defaults the standard
+// prelude on the engine's pure entry points. The engine takes routines
+// explicitly and seeds no built-ins; these overloads supply `Routines.standard`
+// so a call that names no routines resolves the ISO built-ins. `import
+// SQLEngine` alone sees only the pure entry points (routines passed
+// explicitly, no prelude); adding this module — or the umbrella `SQL` —
+// restores the conformance-by-default a single import gives.
+
+extension Catalog where Self: ~Escapable {
+  /// Runs `query` against this catalog with the standard prelude in scope,
+  /// resolving a built-in (`UPPER`, `BITAND`, …) without the caller naming it.
+  /// The pure engine `run(_:_:bindings:)` takes routines explicitly; this
+  /// overload defaults them to `Routines.standard`.
+  public borrowing func run(_ query: Query, bindings: Bindings = [:])
+      throws(SQLError) -> Array<Array<Value>> {
+    try run(query, .standard, bindings: bindings)
+  }
+
+  /// Runs `statement` against this catalog with the standard prelude in scope —
+  /// the prelude-defaulting counterpart of the pure engine overload.
+  public borrowing func run(_ statement: Statement, bindings: Bindings = [:])
+      throws(SQLError) -> Array<Array<Value>> {
+    try run(statement, .standard, bindings: bindings)
+  }
+
+  /// The result columns `query` would yield, typed with the standard prelude in
+  /// scope so a projected built-in reports its declared type. The pure engine
+  /// `columns(of:routines:validate:)` requires routines; this defaults them.
+  public borrowing func columns(of query: Query, validate: Bool = true)
+      throws(SQLError) -> Array<OutputColumn> {
+    try columns(of: query, routines: .standard, validate: validate)
+  }
+
+  /// The result columns `statement` would yield, typed with the standard
+  /// prelude in scope — the prelude-defaulting counterpart of the pure
+  /// overload.
+  public borrowing func columns(of statement: Statement, validate: Bool = true)
+      throws(SQLError) -> Array<OutputColumn> {
+    try columns(of: statement, routines: .standard, validate: validate)
+  }
+}
+
+extension Routines {
+  /// A copy of these routines with the DEFINED `function` bound to `name`, its
+  /// body EARLY-BINDING against the standard prelude overlaid with these
+  /// routines — the prelude-defaulting counterpart of the engine's
+  /// `registering(_:_:capturing:)`, so `lowbit(n) AS BITAND(n, 1)` resolves the
+  /// built-in at registration exactly as a query would. Registering a protected
+  /// standard name still faults SQLSTATE `42723`.
+  public func registering(_ name: String, _ function: Function)
+      throws(SQLError) -> Routines {
+    try registering(name, function, capturing: .standard)
+  }
+}

--- a/Sources/SQLStandard/Prelude.swift
+++ b/Sources/SQLStandard/Prelude.swift
@@ -1,0 +1,388 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+public import SQLEngine
+
+extension Routines {
+  /// The standard-library prelude — the ISO scalar built-ins the `SQLStandard`
+  /// layer installs so a query reaches them without a caller registering a
+  /// closure (the prelude-defaulting `run`/`columns` overloads seed it). They
+  /// are PROTECTED: a caller cannot shadow one through `registering(_:…)` (the
+  /// prelude marks its names via `protecting(_:)`), so a query naming a
+  /// built-in always reaches the shipped one. Every member is a pure,
+  /// side-effect-free mapping and so DETERMINISTIC — a row-independent call
+  /// folds at compile time — and returns NULL on any NULL argument (SQL null
+  /// propagation), faulting `SQLError.argument` on the wrong argument count or
+  /// a value it cannot map, mirroring its declared `[parameters]`/`returns`
+  /// contract the static type-check validates a call against.
+  ///
+  /// The set covers the ISO scalar built-ins the grammar can already CALL
+  /// (`f(…)`), in two families:
+  ///
+  /// - STRING: `UPPER`/`LOWER` (case fold), `CHAR_LENGTH` (with its ISO synonym
+  ///   `CHARACTER_LENGTH`, the same routine under both names), `SUBSTRING` (the
+  ///   two-argument `SUBSTRING(text, start)` form, ISO 1-based indexing),
+  ///   `TRIM` (the one-argument `TRIM(text)` form, stripping leading and
+  ///   trailing spaces), `POSITION` (the ISO `POSITION(substring IN string)`
+  ///   form the parser desugars to `position(substring, string)`, 1-based, 0
+  ///   when absent), and `OVERLAY` (the ISO `OVERLAY(string PLACING replacement
+  ///   FROM start [FOR length])` form the parser desugars to `overlay(string,
+  ///   replacement, start[, length])` — an optional-tail routine (`minimum` 3)
+  ///   that defaults an omitted `length` to the once-evaluated replacement's
+  ///   character count itself, so the parser need not re-reference the
+  ///   replacement).
+  /// - NUMERIC: `ABS`, `ROUND` (the one-argument form, to the nearest integer
+  ///   value), `CEILING` (with its synonym `CEIL`), `FLOOR`, and `MOD` (the
+  ///   two-integer remainder — `BITAND`'s numeric sibling, an operation the
+  ///   grammar's `%` otherwise lacks a call spelling for). `BITAND` — the
+  ///   portable, standards-compliant spelling (Oracle's) of a bitwise AND, an
+  ///   operation ISO SQL and this grammar otherwise lack — is kept.
+  ///
+  /// FOLLOW-UPS (each needs grammar or overloading this batch does not add, so
+  /// each ships in its simplest callable form now):
+  /// - `SUBSTRING(text FROM start FOR length)` — the full ISO clause with a
+  ///   `FROM`/`FOR` keyword syntax and an optional length — and the plain
+  ///   three-argument `SUBSTRING(text, start, length)` could now adopt the
+  ///   optional-tail arity `OVERLAY` introduced (`minimum` 2, an optional third
+  ///   `length`); only the two-argument prefix form ships in this batch.
+  /// - `TRIM([{LEADING | TRAILING | BOTH}] [char] FROM text)` — the full ISO
+  ///   clause with a trim specification and a trim character — needs grammar;
+  ///   only the leading-and-trailing-space `TRIM(text)` form ships.
+  /// - `ROUND(n, places)` — rounding to a decimal place — could now use the
+  ///   optional-tail arity (`minimum` 1); only the nearest-integer `ROUND(n)`
+  ///   form ships in this batch.
+  /// - The numeric routines are declared over `double` (`returns` a `double`,
+  ///   save `MOD`'s integer remainder), so an INTEGER argument does not satisfy
+  ///   the static contract (the type-check is exact-equality — an integer is
+  ///   not a double); an integer-domain overload (`ABS(integer) → integer`, …)
+  ///   needs routine overloading, which the single-signature contract lacks.
+  public static let standard: Routines = preludeMap.protecting(preludeMap.names)
+
+  /// The prelude routines as an UNPROTECTED map — `standard` wraps it with
+  /// `protecting(_:)` so its own names cannot be shadowed. Built through the
+  /// dictionary-literal escape hatch, which carries no protected names.
+  private static let preludeMap: Routines = [
+    "bitand": Routine(returns: .integer, parameters: [.integer, .integer],
+                      deterministic: true, bitand),
+    "upper": Routine(returns: .text, parameters: [.text],
+                     deterministic: true, upper),
+    "lower": Routine(returns: .text, parameters: [.text],
+                     deterministic: true, lower),
+    "char_length": Routine(returns: .integer, parameters: [.text],
+                           deterministic: true, length),
+    "character_length": Routine(returns: .integer, parameters: [.text],
+                                deterministic: true, length),
+    "substring": Routine(returns: .text, parameters: [.text, .integer],
+                         deterministic: true, substring),
+    "trim": Routine(returns: .text, parameters: [.text],
+                    deterministic: true, trim),
+    "abs": Routine(returns: .double, parameters: [.double],
+                   deterministic: true, abs),
+    "round": Routine(returns: .double, parameters: [.double],
+                     deterministic: true, round),
+    "ceiling": Routine(returns: .double, parameters: [.double],
+                       deterministic: true, ceiling),
+    "ceil": Routine(returns: .double, parameters: [.double],
+                    deterministic: true, ceiling),
+    "floor": Routine(returns: .double, parameters: [.double],
+                     deterministic: true, floor),
+    "mod": Routine(returns: .integer, parameters: [.integer, .integer],
+                   deterministic: true, mod),
+    "position": Routine(returns: .integer, parameters: [.text, .text],
+                        deterministic: true, position),
+    "overlay": Routine(returns: .text,
+                       parameters: [.text, .text, .integer, .integer],
+                       minimum: 3, deterministic: true, overlay),
+  ]
+
+  /// The single `.null` short-circuit ISO null propagation gives every built-in
+  /// — a NULL argument yields NULL — factored out so each routine reads as its
+  /// mapping alone. Returns `true` when any argument is NULL, so the caller
+  /// returns `.null` before matching a concrete kind.
+  private static func propagates(_ arguments: Array<SQLEngine.Value>) -> Bool {
+    arguments.contains(.null)
+  }
+
+  /// `BITAND(x, y)` — the bitwise AND of two integers. A NULL argument yields
+  /// NULL (SQL null propagation); the wrong argument count or a non-integer
+  /// argument is `SQLError.argument` (a function-argument fault — not
+  /// `SQLError.arity`, which is the UNION column-count mismatch). Its declared
+  /// `[.integer, .integer]` contract is what the static type-check validates a
+  /// call against, mirroring these run-time faults.
+  private static func bitand(_ arguments: Array<SQLEngine.Value>)
+      throws(SQLError) -> SQLEngine.Value {
+    guard arguments.count == 2 else {
+      throw .argument("BITAND takes two arguments")
+    }
+    if propagates(arguments) { return .null }
+    guard case let .integer(x) = arguments[0],
+        case let .integer(y) = arguments[1] else {
+      throw .argument("BITAND requires integer arguments")
+    }
+    return .integer(x & y)
+  }
+
+  /// `UPPER(text)` — the string upper-cased. A NULL argument yields NULL; the
+  /// wrong count or a non-text argument is `SQLError.argument`.
+  private static func upper(_ arguments: Array<SQLEngine.Value>)
+      throws(SQLError) -> SQLEngine.Value {
+    guard arguments.count == 1 else {
+      throw .argument("UPPER takes one argument")
+    }
+    if propagates(arguments) { return .null }
+    guard case let .text(string) = arguments[0] else {
+      throw .argument("UPPER requires a text argument")
+    }
+    return .text(string.uppercased())
+  }
+
+  /// `LOWER(text)` — the string lower-cased. A NULL argument yields NULL; the
+  /// wrong count or a non-text argument is `SQLError.argument`.
+  private static func lower(_ arguments: Array<SQLEngine.Value>)
+      throws(SQLError) -> SQLEngine.Value {
+    guard arguments.count == 1 else {
+      throw .argument("LOWER takes one argument")
+    }
+    if propagates(arguments) { return .null }
+    guard case let .text(string) = arguments[0] else {
+      throw .argument("LOWER requires a text argument")
+    }
+    return .text(string.lowercased())
+  }
+
+  /// `CHAR_LENGTH(text)` / `CHARACTER_LENGTH(text)` — the number of characters
+  /// in the string (its Unicode character count, not its UTF-8 byte length). A
+  /// NULL argument yields NULL; the wrong count or a non-text argument is
+  /// `SQLError.argument`.
+  private static func length(_ arguments: Array<SQLEngine.Value>)
+      throws(SQLError) -> SQLEngine.Value {
+    guard arguments.count == 1 else {
+      throw .argument("CHAR_LENGTH takes one argument")
+    }
+    if propagates(arguments) { return .null }
+    guard case let .text(string) = arguments[0] else {
+      throw .argument("CHAR_LENGTH requires a text argument")
+    }
+    return .integer(string.count)
+  }
+
+  /// `SUBSTRING(text, start)` — the substring of `text` from the 1-based
+  /// `start` character to the end, the ISO indexing where the first character
+  /// is position 1. A `start` at or before 1 begins at the first character; a
+  /// `start` past the end yields the empty string. A NULL argument yields NULL;
+  /// the wrong count, a non-text first argument, or a non-integer second is
+  /// `SQLError.argument`.
+  private static func substring(_ arguments: Array<SQLEngine.Value>)
+      throws(SQLError) -> SQLEngine.Value {
+    guard arguments.count == 2 else {
+      throw .argument("SUBSTRING takes two arguments")
+    }
+    if propagates(arguments) { return .null }
+    guard case let .text(string) = arguments[0],
+        case let .integer(start) = arguments[1] else {
+      throw .argument("SUBSTRING requires a text and an integer argument")
+    }
+    // ISO positions are 1-based; a start at or before 1 clamps to the first
+    // character, and one past the end clamps to the end (the empty tail). The
+    // `start - 1` conversion overflows for `Int.min`, so a start at or before
+    // 1 takes the whole string directly rather than subtracting.
+    let drop = start > 1 ? start - 1 : 0
+    return .text(String(string.dropFirst(drop)))
+  }
+
+  /// `TRIM(text)` — the string with leading and trailing SPACE characters
+  /// removed (the one-argument ISO form, whose implicit trim character is a
+  /// space and whose implicit specification is BOTH). A NULL argument yields
+  /// NULL; the wrong count or a non-text argument is `SQLError.argument`.
+  private static func trim(_ arguments: Array<SQLEngine.Value>)
+      throws(SQLError) -> SQLEngine.Value {
+    guard arguments.count == 1 else {
+      throw .argument("TRIM takes one argument")
+    }
+    if propagates(arguments) { return .null }
+    guard case let .text(string) = arguments[0] else {
+      throw .argument("TRIM requires a text argument")
+    }
+    return .text(String(string.drop(while: { $0 == " " })
+                            .reversed().drop(while: { $0 == " " })
+                            .reversed()))
+  }
+
+  /// `ABS(n)` — the absolute value of a real number. A NULL argument yields
+  /// NULL; the wrong count or a non-double argument is `SQLError.argument`.
+  private static func abs(_ arguments: Array<SQLEngine.Value>)
+      throws(SQLError) -> SQLEngine.Value {
+    guard arguments.count == 1 else {
+      throw .argument("ABS takes one argument")
+    }
+    if propagates(arguments) { return .null }
+    guard case let .double(value) = arguments[0] else {
+      throw .argument("ABS requires a double argument")
+    }
+    return .double(Swift.abs(value))
+  }
+
+  /// `ROUND(n)` — the real number rounded to the nearest integer value (ties
+  /// away from zero, the ISO default), carried as a double. A NULL argument
+  /// yields NULL; the wrong count or a non-double argument is
+  /// `SQLError.argument`.
+  private static func round(_ arguments: Array<SQLEngine.Value>)
+      throws(SQLError) -> SQLEngine.Value {
+    guard arguments.count == 1 else {
+      throw .argument("ROUND takes one argument")
+    }
+    if propagates(arguments) { return .null }
+    guard case let .double(value) = arguments[0] else {
+      throw .argument("ROUND requires a double argument")
+    }
+    return .double(value.rounded())
+  }
+
+  /// `CEILING(n)` / `CEIL(n)` — the least integer value not less than `n`,
+  /// carried as a double. A NULL argument yields NULL; the wrong count or a
+  /// non-double argument is `SQLError.argument`.
+  private static func ceiling(_ arguments: Array<SQLEngine.Value>)
+      throws(SQLError) -> SQLEngine.Value {
+    guard arguments.count == 1 else {
+      throw .argument("CEILING takes one argument")
+    }
+    if propagates(arguments) { return .null }
+    guard case let .double(value) = arguments[0] else {
+      throw .argument("CEILING requires a double argument")
+    }
+    return .double(value.rounded(.up))
+  }
+
+  /// `FLOOR(n)` — the greatest integer value not greater than `n`, carried as a
+  /// double. A NULL argument yields NULL; the wrong count or a non-double
+  /// argument is `SQLError.argument`.
+  private static func floor(_ arguments: Array<SQLEngine.Value>)
+      throws(SQLError) -> SQLEngine.Value {
+    guard arguments.count == 1 else {
+      throw .argument("FLOOR takes one argument")
+    }
+    if propagates(arguments) { return .null }
+    guard case let .double(value) = arguments[0] else {
+      throw .argument("FLOOR requires a double argument")
+    }
+    return .double(value.rounded(.down))
+  }
+
+  /// `MOD(a, b)` — the remainder of `a` divided by `b`, both integers (the ISO
+  /// `MOD` function, distinct from the grammar's `%` operator). A zero divisor
+  /// is `SQLError.divide`, as integer arithmetic's `%` by zero is. A NULL
+  /// argument yields NULL; the wrong count or a non-integer argument is
+  /// `SQLError.argument`.
+  private static func mod(_ arguments: Array<SQLEngine.Value>)
+      throws(SQLError) -> SQLEngine.Value {
+    guard arguments.count == 2 else {
+      throw .argument("MOD takes two arguments")
+    }
+    if propagates(arguments) { return .null }
+    guard case let .integer(a) = arguments[0],
+        case let .integer(b) = arguments[1] else {
+      throw .argument("MOD requires integer arguments")
+    }
+    guard b != 0 else { throw .divide }
+    // `a % -1` is mathematically 0, but `Int.min % -1` overflows the implied
+    // division and traps, so a divisor of -1 short-circuits to that 0.
+    guard b != -1 else { return .integer(0) }
+    return .integer(a % b)
+  }
+
+  /// `POSITION(substring, string)` — the parser's desugaring of the ISO
+  /// `POSITION(substring IN string)` — the 1-based character position of the
+  /// first occurrence of `substring` in `string`, 0 when it does not occur. An
+  /// EMPTY substring occurs at position 1 (ISO): the empty string is a prefix
+  /// of every string, including another empty string. Matching is
+  /// character-wise and case-SENSITIVE (no case fold). A NULL argument yields
+  /// NULL; the wrong count or a non-text argument is `SQLError.argument`.
+  private static func position(_ arguments: Array<SQLEngine.Value>)
+      throws(SQLError) -> SQLEngine.Value {
+    guard arguments.count == 2 else {
+      throw .argument("POSITION takes two arguments")
+    }
+    if propagates(arguments) { return .null }
+    guard case let .text(substring) = arguments[0],
+        case let .text(string) = arguments[1] else {
+      throw .argument("POSITION requires text arguments")
+    }
+    // The empty substring is a prefix of every string, so it occurs at 1.
+    guard !substring.isEmpty else { return .integer(1) }
+    // Character-wise search over the Unicode scalars `CHAR_LENGTH` counts, so
+    // the reported position is a 1-based character index, not a byte offset.
+    let haystack = Array(string), needle = Array(substring)
+    guard haystack.count >= needle.count else { return .integer(0) }
+    for start in 0...(haystack.count - needle.count)
+        where Array(haystack[start ..< start + needle.count]) == needle {
+      return .integer(start + 1)
+    }
+    return .integer(0)
+  }
+
+  /// `OVERLAY(string, replacement, start, length)` — the parser's desugaring of
+  /// the ISO `OVERLAY(string PLACING replacement FROM start [FOR length])` —
+  /// the `string` with `length` characters from the 1-based `start` replaced by
+  /// `replacement`. The optional `FOR length` defaults, in the parser, to the
+  /// replacement's character count, so the four-argument form is the only one
+  /// this routine sees. A NULL argument yields NULL; the wrong count, a
+  /// non-text `string`/`replacement`, or a non-integer `start`/`length` is
+  /// `SQLError.argument`.
+  ///
+  /// The 1-based `start` and the `length` are CLAMPED to the string rather than
+  /// trusted, so no arithmetic traps and no slice runs out of bounds: a `start`
+  /// at or before 1 begins at the first character (the `start - 1` conversion
+  /// would overflow for `Int.min`, so it is not subtracted below 1), a `start`
+  /// past the end appends, a negative `length` removes nothing, and a `length`
+  /// past the end removes only to the end. This is `SUBSTRING`'s clamp
+  /// discipline applied to both the prefix kept and the suffix resumed.
+  private static func overlay(_ arguments: Array<SQLEngine.Value>)
+      throws(SQLError) -> SQLEngine.Value {
+    guard (3 ... 4).contains(arguments.count) else {
+      throw .argument("OVERLAY takes three or four arguments")
+    }
+    if propagates(arguments) { return .null }
+    guard case let .text(string) = arguments[0],
+        case let .text(replacement) = arguments[1],
+        case let .integer(start) = arguments[2] else {
+      throw .argument("OVERLAY requires text, text, and integer arguments")
+    }
+    // The number of characters to remove: the explicit `FOR length` fourth
+    // argument, or — when omitted — the character count of the replacement.
+    // Defaulting HERE, from the single evaluated replacement value, is what
+    // lets the parser pass only three arguments for the omitted-`FOR` form:
+    // the replacement is evaluated ONCE, so a NOT-DETERMINISTIC one
+    // (`stepper_text()`) both inserts and measures the SAME value, rather than
+    // the parser re-referencing it as `char_length(replacement)` and
+    // evaluating it a second time.
+    let length: Int
+    if arguments.count == 4 {
+      guard case let .integer(explicit) = arguments[3] else {
+        throw .argument("OVERLAY requires an integer length")
+      }
+      length = explicit
+    } else {
+      length = replacement.count
+    }
+    let characters = Array(string)
+    // The prefix kept is `start - 1` characters, clamped into `[0, count]`; the
+    // `start - 1` is not computed for a start at or before 1, which would
+    // overflow at `Int.min`, and is capped at the string's length so a start
+    // past the end keeps the whole string and appends.
+    let head = start > 1 ? Swift.min(start - 1, characters.count) : 0
+    // The suffix resumes `length` characters after `head`, clamped the same
+    // way: a negative or zero length removes nothing (resumes at `head`), and a
+    // length past the end resumes at the end. The overshoot is tested against
+    // the REMAINING capacity (`count - head`) rather than forming `head +
+    // length`, whose sum would overflow for an `Int.max` length.
+    let tail = if length <= 0 {
+      head
+    } else if length < characters.count - head {
+      head + length
+    } else {
+      characters.count
+    }
+    return .text(String(characters[..<head]) + replacement
+                     + String(characters[tail...]))
+  }
+}

--- a/Sources/SQLTestSupport/Expect.swift
+++ b/Sources/SQLTestSupport/Expect.swift
@@ -2,6 +2,10 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 import SQLEngine
+// Re-export SQLStandard so a test importing `SQLTestSupport` sees the
+// prelude-defaulting `run`/`columns` overloads and `Routines.standard`; the
+// fixtures default to the standard prelude, matching a run under `import SQL`.
+@_exported import SQLStandard
 import Testing
 
 /// Expectation helpers that run a SQL query against a fixture catalog and check
@@ -38,7 +42,7 @@ extension Catalog where Self: ~Escapable {
   /// list of Swift literals lifted into `Value`s.
   public borrowing func expect(_ sql: String,
       yields rows: Array<Array<(any ValueConvertible)?>>,
-      routines: Routines = [:], bindings: Bindings = [:],
+      routines: Routines = .standard, bindings: Bindings = [:],
       location: Testing.SourceLocation = #_sourceLocation) throws {
     let expected = rows.map { $0.map { $0?.value ?? .null } }
     let actual = try run(sql, routines: routines, bindings: bindings)
@@ -47,7 +51,7 @@ extension Catalog where Self: ~Escapable {
 
   /// Checks `sql` run against this catalog yields no rows.
   public borrowing func empty(_ sql: String,
-      routines: Routines = [:], bindings: Bindings = [:],
+      routines: Routines = .standard, bindings: Bindings = [:],
       location: Testing.SourceLocation = #_sourceLocation) throws {
     let actual = try run(sql, routines: routines, bindings: bindings)
     #expect(actual.isEmpty, sourceLocation: location)
@@ -60,7 +64,7 @@ extension Catalog where Self: ~Escapable {
   /// so it catches the outcome and asserts on it, still reporting at the call
   /// site.
   public borrowing func expect(_ sql: String, fails error: SQLError,
-      routines: Routines = [:], bindings: Bindings = [:],
+      routines: Routines = .standard, bindings: Bindings = [:],
       location: Testing.SourceLocation = #_sourceLocation) {
     let raised: SQLError?
     do {
@@ -75,7 +79,7 @@ extension Catalog where Self: ~Escapable {
   /// Checks two queries run against this catalog yield the same rows — the
   /// seek / scan (or hash / seek) equivalence idiom.
   public borrowing func expect(_ lhs: String, equals rhs: String,
-      routines: Routines = [:], bindings: Bindings = [:],
+      routines: Routines = .standard, bindings: Bindings = [:],
       location: Testing.SourceLocation = #_sourceLocation) throws {
     let left = try run(lhs, routines: routines, bindings: bindings)
     let right = try run(rhs, routines: routines, bindings: bindings)

--- a/Sources/winmd-inspect/Database+SQL.swift
+++ b/Sources/winmd-inspect/Database+SQL.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 internal import SQLEngine
+internal import SQLStandard
 internal import WinMDSynthesis
 internal import WinMD
 

--- a/Tests/SQLStandardTests/OverlayTests.swift
+++ b/Tests/SQLStandardTests/OverlayTests.swift
@@ -1,0 +1,73 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import SQLEngine
+import SQLStandard
+import SQLTestSupport
+import Testing
+
+/// A small catalog the overlay tests project the built-ins over.
+private func library() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("L", ["Id": .integer, "Text": .text, "Num": .integer]) {
+      Row(1, "aBc", 30)
+    }
+  }
+}
+
+/// The `SQLStandard` overlay: `import SQLStandard` re-defaults the prelude on
+/// the pure engine's entry points, and the relocated protected-name and
+/// defined-body-capture seams behave exactly as before the split.
+@Suite struct OverlayTests {
+  @Test func `run defaults the prelude so a built-in resolves without routines`()
+      throws {
+    // The prelude-defaulting `run(_:bindings:)` overload seeds
+    // `Routines.standard`, so UPPER resolves though no routines are passed.
+    let rows = try library()
+        .run(Statement(parsing: "SELECT UPPER(Text) FROM L WHERE Id = 1"))
+    #expect(rows == [[.text("ABC")]])
+  }
+
+  @Test func `columns defaults the prelude and types a built-in call`() throws {
+    let query = try Statement(parsing: "SELECT UPPER(Text) FROM L")
+    guard case let .select(select) = query else {
+      throw SQLError.incomplete(expected: "a SELECT")
+    }
+    let columns = try library().columns(of: select)
+    #expect(columns.map(\.type) == [.text])
+  }
+
+  @Test func `registering over a protected standard name is rejected`() throws {
+    // BITAND is protected in `Routines.standard`; a `registering` of it faults
+    // SQLSTATE 42723 through the relocated protected-name seam.
+    #expect(throws: SQLError.state("42723",
+        "'bitand' is a standard routine and cannot be redefined")) {
+      try Routines.standard
+          .registering("bitand", parameters: [.integer, .integer]) {
+            _ in .null
+          }
+    }
+  }
+
+  @Test func `a defined body binds a prelude built-in via the capture seam`()
+      throws {
+    // Registered against EMPTY routines, a defined body calling BITAND still
+    // resolves it: the two-argument `registering(_:_:)` overload captures
+    // `Routines.standard` (the relocated early-binding capture).
+    guard case let .function(name, function) =
+        try Statement(parsing: "CREATE FUNCTION lowbit(n INTEGER) "
+                          + "RETURNS INTEGER AS BITAND(n, 1)")
+    else { throw SQLError.incomplete(expected: "a CREATE FUNCTION") }
+    let routines = try Routines().registering(name, function)
+    let rows = try library()
+        .run(Statement(parsing: "SELECT lowbit(Num) FROM L WHERE Id = 1"),
+             routines)
+    // Num is 30 (even); BITAND(30, 1) = 0.
+    #expect(rows == [[.integer(0)]])
+  }
+
+  @Test func `the standard prelude declares BITAND over two integers`() {
+    #expect(Routines.standard["bitand"]?.returns == .integer)
+    #expect(Routines.standard["bitand"]?.parameters == [.integer, .integer])
+  }
+}

--- a/Tests/SQLTests/FunctionTests.swift
+++ b/Tests/SQLTests/FunctionTests.swift
@@ -248,34 +248,37 @@ private func library() throws -> FixtureCatalog {
   // MARK: - Protection (non-shadowable)
 
   @Test func `registering over a standard routine is rejected`() {
-    // A standard built-in is protected: `registering` refuses to bind its name
-    // (SQLSTATE 42723) rather than shadow it.
+    // A standard built-in is protected: registering its name over the prelude
+    // faults (SQLSTATE 42723) rather than shadow it. Protection travels with
+    // the routines (`Routines.standard` marks its own names), so the guard
+    // fires on the prelude, not on a fresh `Routines`.
     #expect(throws: SQLError.state("42723",
         "'upper' is a standard routine and cannot be redefined")) {
-      try Routines().registering("upper", returns: .text,
-                                 parameters: [.text]) { _ in .text("x") }
+      try Routines.standard.registering("upper", returns: .text,
+                                        parameters: [.text]) { _ in .text("x") }
     }
   }
 
   @Test func `registering a defined function over a standard name is rejected`() {
     // The `CREATE FUNCTION` path is protected too: a defined routine cannot
-    // take a built-in's name.
+    // take a built-in's name of the prelude.
     let function = Function(parameters: [], returns: .integer,
                             body: .literal(.integer(0)))
     #expect(throws: SQLError.state("42723",
         "'floor' is a standard routine and cannot be redefined")) {
-      try Routines().registering("floor", function)
+      try Routines.standard.registering("floor", function)
     }
   }
 
   @Test func `protection resolves the name case-insensitively`() {
     // The guard case-folds the name like every identifier, so a differently-
-    // cased spelling of a built-in is rejected too.
+    // cased spelling of a prelude built-in is rejected too.
     #expect(throws: SQLError.state("42723",
         "'BitAnd' is a standard routine and cannot be redefined")) {
-      try Routines().registering("BitAnd", parameters: [.integer, .integer]) {
-        _ in .integer(0)
-      }
+      try Routines.standard
+          .registering("BitAnd", parameters: [.integer, .integer]) {
+            _ in .integer(0)
+          }
     }
   }
 

--- a/Tests/SQLTests/OutputSchemaTests.swift
+++ b/Tests/SQLTests/OutputSchemaTests.swift
@@ -3,6 +3,7 @@
 
 import Testing
 @testable import SQLEngine
+import SQLStandard
 
 // MARK: - In-memory adapter
 


### PR DESCRIPTION
Split the ISO standard-library prelude out of the engine into a new
`SQLStandard` layer, leaving `SQLEngine` a pure engine that ships no
built-in scalar routine and seeds none. The `Routine`/`Routines` machinery,
the protected-name rule, and the dictionary-literal conformance stay in the
engine; the 14-entry `standard` prelude, its impl closures, and the shared
null-propagation helper move to `SQLStandard`.

The engine's public entry points no longer merge `Routines.standard`: `run`
and `columns` take the routines they are given (routines now required, no
implicit prelude). `SQLStandard` adds import-activated overloads —
`run(_:bindings:)`, `columns(of:validate:)` — that default the prelude, so a
call under `import SQLStandard` (or the umbrella `SQL`) resolves the built-ins
without naming them while `import SQLEngine` alone stays pure.

Two purity seams relocate to the standard layer:

  - Protected names travel WITH the value. `Routines` gains a `protected` name
    set (empty for the plain inits and the dictionary literal — the escape
    hatch a prelude is built through) that `merging(_:)` unions and
    `registering(_:…)` checks, and a `protecting(_:)` seam a prelude uses to
    mark its own names. `Routines.standard` marks its 14 names, so shadowing a
    built-in still faults SQLSTATE 42723 — now a property of the prelude rather
    than a module-wide constant, keeping the engine free of any reserved name.

  - The defined-body early-binding capture is parameterised. The engine's
    `registering(_:_:capturing:)` captures the ambient routines a caller
    supplies; `SQLStandard` adds the two-argument `registering(_:_:)` that
    passes `Routines.standard`, so a `CREATE FUNCTION` body may call a built-in
    exactly as a query would.

The umbrella `SQL` target `@_exported import`s both, restoring the
conformance-by-default a single import gave. `winmd-inspect` and the test
support import `SQLStandard`; `GUID`/`SANITIZE` stay adapter-domain UDFs in
`winmd-inspect`. The protection tests that registered a built-in over EMPTY
routines now register over `Routines.standard`, matching the relocated seam,
and a new `SQLStandardTests` suite exercises the prelude defaulting, the
protected-name guard, and the defined-body capture.