### PR TITLE
Decant: add the streaming serialization core

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,7 @@ let _ =
               .library(name: "SQLEngine", targets: ["SQLEngine"]),
               .library(name: "SQLStandard", targets: ["SQLStandard"]),
               .library(name: "WinMDSynthesis", targets: ["WinMDSynthesis"]),
+              .library(name: "Decant", targets: ["Decant"]),
             ],
             dependencies: [
               .package(url: "https://github.com/apple/swift-argument-parser",
@@ -22,6 +23,15 @@ let _ =
             ],
             targets: [
               .target(name: "CPE", dependencies: []),
+
+              .target(name: "Decant", dependencies: [],
+                      swiftSettings: [
+                        .enableExperimentalFeature("Lifetimes"),
+                      ]),
+              .testTarget(name: "DecantTests", dependencies: ["Decant"],
+                          swiftSettings: [
+                            .enableExperimentalFeature("Lifetimes"),
+                          ]),
 
               // SQLEngine
               .target(name: "SQLEngine", dependencies: [],

--- a/Sources/Decant/Core+Deserialization.swift
+++ b/Sources/Decant/Core+Deserialization.swift
@@ -1,0 +1,94 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+/// The standard-library `Deserializable` conformances — the leaf deserializers a
+/// macro-derived or hand-written struct's fields recurse into.
+///
+/// Each is `@inlinable`: a struct's generated `decode` bottoms out in, say,
+/// `UInt16.deserialize`, and only inlining that leaf across the module boundary
+/// keeps the whole aggregate specialized. A non-`@inlinable` leaf here would
+/// silently regress every field that touches it to witness-table dispatch.
+
+// MARK: - Bool
+
+extension Bool: Deserializable {
+  @inlinable
+  public static func deserialize<D>(from deserializer: inout D)
+      throws(D.Failure) -> Bool
+      where D: Deserializer & ~Copyable & ~Escapable {
+    try deserializer.bool()
+  }
+}
+
+// MARK: - Fixed-width integers
+
+extension FixedWidthInteger where Self: Deserializable {
+  @inlinable
+  public static func deserialize<D>(from deserializer: inout D)
+      throws(D.Failure) -> Self
+      where D: Deserializer & ~Copyable & ~Escapable {
+    try deserializer.integer(Self.self)
+  }
+}
+
+extension Int: Deserializable {}
+extension Int8: Deserializable {}
+extension Int16: Deserializable {}
+extension Int32: Deserializable {}
+extension Int64: Deserializable {}
+extension UInt: Deserializable {}
+extension UInt8: Deserializable {}
+extension UInt16: Deserializable {}
+extension UInt32: Deserializable {}
+extension UInt64: Deserializable {}
+
+// MARK: - Floating point
+
+extension Double: Deserializable {
+  @inlinable
+  public static func deserialize<D>(from deserializer: inout D)
+      throws(D.Failure) -> Double
+      where D: Deserializer & ~Copyable & ~Escapable {
+    try deserializer.double()
+  }
+}
+
+// MARK: - String
+
+extension String: Deserializable {
+  @inlinable
+  public static func deserialize<D>(from deserializer: inout D)
+      throws(D.Failure) -> String
+      where D: Deserializer & ~Copyable & ~Escapable {
+    try deserializer.string()
+  }
+}
+
+// MARK: - Optional
+
+extension Optional: Deserializable where Wrapped: Deserializable {
+  @inlinable
+  public static func deserialize<D>(from deserializer: inout D)
+      throws(D.Failure) -> Wrapped?
+      where D: Deserializer & ~Copyable & ~Escapable {
+    guard try deserializer.some() else { return nil }
+    return try deserializer.decode(Wrapped.self)
+  }
+}
+
+// MARK: - Array
+
+extension Array: Deserializable where Element: Deserializable {
+  @inlinable
+  public static func deserialize<D>(from deserializer: inout D)
+      throws(D.Failure) -> Array<Element>
+      where D: Deserializer & ~Copyable & ~Escapable {
+    let count = try deserializer.count()
+    var elements = Array<Element>()
+    elements.reserveCapacity(count)
+    for _ in 0 ..< count {
+      try elements.append(deserializer.decode(Element.self))
+    }
+    return elements
+  }
+}

--- a/Sources/Decant/Core+Serialization.swift
+++ b/Sources/Decant/Core+Serialization.swift
@@ -1,0 +1,107 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+/// The standard-library `Serializable` conformances — the leaf serializers a
+/// macro-derived or hand-written struct's fields recurse into.
+///
+/// Each is `@inlinable`: a struct's generated `field` bottoms out in, say,
+/// `UInt16.serialize`, and only inlining that leaf across the module boundary
+/// keeps the whole aggregate specialized. A non-`@inlinable` leaf here would
+/// silently regress every field that touches it to witness-table dispatch.
+
+// MARK: - Bool
+
+extension Bool: Serializable {
+  @inlinable
+  public func serialize<S>(into serializer: consuming S)
+      throws(S.Failure) -> S
+      where S: Serializer & ~Copyable & ~Escapable {
+    var serializer = serializer
+    try serializer.serialize(self)
+    return serializer
+  }
+}
+
+// MARK: - Fixed-width integers
+
+extension FixedWidthInteger where Self: Serializable {
+  @inlinable
+  public func serialize<S>(into serializer: consuming S)
+      throws(S.Failure) -> S
+      where S: Serializer & ~Copyable & ~Escapable {
+    var serializer = serializer
+    try serializer.serialize(self)
+    return serializer
+  }
+}
+
+extension Int: Serializable {}
+extension Int8: Serializable {}
+extension Int16: Serializable {}
+extension Int32: Serializable {}
+extension Int64: Serializable {}
+extension UInt: Serializable {}
+extension UInt8: Serializable {}
+extension UInt16: Serializable {}
+extension UInt32: Serializable {}
+extension UInt64: Serializable {}
+
+// MARK: - Floating point
+
+extension Double: Serializable {
+  @inlinable
+  public func serialize<S>(into serializer: consuming S)
+      throws(S.Failure) -> S
+      where S: Serializer & ~Copyable & ~Escapable {
+    var serializer = serializer
+    try serializer.serialize(self)
+    return serializer
+  }
+}
+
+// MARK: - String
+
+extension String: Serializable {
+  @inlinable
+  public func serialize<S>(into serializer: consuming S)
+      throws(S.Failure) -> S
+      where S: Serializer & ~Copyable & ~Escapable {
+    var serializer = serializer
+    try serializer.serialize(self)
+    return serializer
+  }
+}
+
+// MARK: - Optional
+
+extension Optional: Serializable where Wrapped: Serializable {
+  @inlinable
+  public func serialize<S>(into serializer: consuming S)
+      throws(S.Failure) -> S
+      where S: Serializer & ~Copyable & ~Escapable {
+    var serializer = serializer
+    switch self {
+    case .none:
+      try serializer.null()
+      return serializer
+    case let .some(wrapped):
+      try serializer.some()
+      return try wrapped.serialize(into: serializer)
+    }
+  }
+}
+
+// MARK: - Array
+
+extension Array: Serializable where Element: Serializable {
+  @inlinable
+  public func serialize<S>(into serializer: consuming S)
+      throws(S.Failure) -> S
+      where S: Serializer & ~Copyable & ~Escapable {
+    var sequence = serializer.sequence(count: count)
+    for element in self {
+      try sequence.element(element)
+    }
+    return try sequence.end()
+  }
+}

--- a/Sources/Decant/Deserializer.swift
+++ b/Sources/Decant/Deserializer.swift
@@ -1,0 +1,96 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+/// Reads the primitive shapes of a value — booleans, integers, strings,
+/// sequences, structures — back from a byte format.
+///
+/// A deserializer is the read counterpart of `Serializer`: the TYPE names the
+/// shape to expect and the deserializer reads exactly that at the cursor. That
+/// type-driven order is what lets a non-self-describing format be read at all —
+/// a layout that carries no tags relies entirely on the type to dictate every
+/// read — and a self-describing format simply ignores the structure it does not
+/// need.
+///
+/// A deserializer owns the read cursor: it holds a borrowed view of the input
+/// and a mutating position, reads a value, and advances. Because it borrows the
+/// input it is `~Escapable`; because it is threaded through a recursive read
+/// without copies it is `~Copyable` and passed `inout`. It copies OUT owned
+/// values (an `Int`, a decoded struct) as it walks and never vends a borrowed
+/// view that outlives a step.
+///
+/// Every method is `@inlinable` so a caller in another module specializes the
+/// whole read tree to straight-line code.
+public protocol Deserializer: ~Copyable, ~Escapable {
+  /// The error this deserializer raises, carried concretely by typed throws.
+  associatedtype Failure: Error
+
+  /// Reads a fixed-width integer of the requested width — the caller names the
+  /// width the type dictates.
+  @inlinable
+  mutating func integer<T: FixedWidthInteger>(_: T.Type) throws(Failure) -> T
+
+  /// Reads a boolean.
+  @inlinable
+  mutating func bool() throws(Failure) -> Bool
+
+  /// Reads a double-precision floating-point value.
+  @inlinable
+  mutating func double() throws(Failure) -> Double
+
+  /// Reads a string.
+  @inlinable
+  mutating func string() throws(Failure) -> String
+
+  /// Reads a run of raw bytes as an owned array.
+  @inlinable
+  mutating func bytes() throws(Failure) -> Array<UInt8>
+
+  /// Reads whether the next value is present: true if a value follows, false
+  /// for the absent case.
+  @inlinable
+  mutating func some() throws(Failure) -> Bool
+
+  /// Reads a sequence's element count, so the caller can pull exactly that many
+  /// elements with `decode`.
+  @inlinable
+  mutating func count() throws(Failure) -> Int
+
+  /// Begins reading a structure named `name` with `count` fields. The caller
+  /// then reads each field in declaration order with `decode`. The name and
+  /// count are the type's hint, not read from the input.
+  @inlinable
+  mutating func structure(_ name: StaticString, fields count: Int)
+      throws(Failure)
+
+  /// Ends reading a structure begun with `structure(_:fields:)`.
+  @inlinable
+  mutating func end() throws(Failure)
+}
+
+extension Deserializer where Self: ~Copyable & ~Escapable {
+  /// Reads one value of a `Deserializable` type, recursing into its
+  /// conformance — the generic entry point every compound read pulls through.
+  /// `@inlinable` so it specializes across the module boundary.
+  @inlinable
+  public mutating func decode<T: Deserializable>(_: T.Type = T.self)
+      throws(Failure) -> T {
+    try T.deserialize(from: &self)
+  }
+}
+
+/// A type that can read itself back from a `Deserializer`, written once against
+/// the abstract shape vocabulary regardless of the byte format.
+///
+/// A conformance calls exactly the methods that describe its shape and returns
+/// an owned value copied out of the borrow. The `@Deserializable` macro
+/// generates one for a struct (one field read per stored property in
+/// declaration order, matching the write side).
+public protocol Deserializable {
+  /// Reads `Self` from the deserializer. Generic over the format so no
+  /// existential appears — which is also forced, since a `~Escapable`
+  /// deserializer has none.
+  @inlinable
+  static func deserialize<D>(from deserializer: inout D)
+      throws(D.Failure) -> Self
+      where D: Deserializer & ~Copyable & ~Escapable
+}

--- a/Sources/Decant/Error.swift
+++ b/Sources/Decant/Error.swift
@@ -1,0 +1,52 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+/// The error a `Decant` read or write raises — one concrete type carried by
+/// typed throws through the whole generic driver stack.
+///
+/// Because every method is `throws(DecantError)`, the error stays concrete
+/// across the generic calls and is never boxed as an `any Error`. A concrete
+/// format layered on the core may raise its own error type instead when its
+/// vocabulary differs (a text grammar's syntax faults, say); this type covers
+/// the shape-level faults the core itself detects.
+public enum DecantError: Error, Sendable {
+  /// A fault the caller describes directly, for a condition no other case
+  /// models. The string is the message.
+  case custom(String)
+  /// A value of the wrong kind was read: the format found `found` where the
+  /// type asked for `expected`.
+  case mismatch(expected: StaticString, found: StaticString)
+  /// A compound value of the wrong length was read — `count` elements where the
+  /// type expected the shape `expected` describes.
+  case length(Int, expected: StaticString)
+  /// A structure carries a field the type does not know — the string names it.
+  case unknown(String)
+  /// A structure omits a field the type requires — the string names it.
+  case missing(StaticString)
+  /// The input ended while a value was still required — a truncated buffer, or
+  /// a prefix that promised more bytes than the input holds.
+  case truncated
+  /// A sink could not accept more bytes — a fixed-capacity buffer overflowed.
+  case overflow
+}
+
+extension DecantError: CustomStringConvertible {
+  public var description: String {
+    switch self {
+    case let .custom(message):
+      message
+    case let .mismatch(expected, found):
+      "expected \(expected) but found \(found)"
+    case let .length(count, expected):
+      "invalid length \(count), expected \(expected)"
+    case let .unknown(name):
+      "unknown field '\(name)'"
+    case let .missing(name):
+      "missing field '\(name)'"
+    case .truncated:
+      "input ended before the value was complete"
+    case .overflow:
+      "the sink cannot accept more bytes"
+    }
+  }
+}

--- a/Sources/Decant/Serializer.swift
+++ b/Sources/Decant/Serializer.swift
@@ -1,0 +1,149 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+/// Writes the primitive shapes of a value — booleans, integers, strings,
+/// sequences, structures — to a byte format.
+///
+/// A serializer is one half of a two-part decoupling: a `Serializable` type
+/// describes its own shape by calling these methods, and a `Serializer`
+/// interprets that shape as bytes; neither knows the other, so the compiler
+/// pairs any type with any format with no glue between them.
+///
+/// The methods write straight to the underlying byte sink — no intermediate
+/// value tree is ever built — so a value's structure IS the traversal: a single
+/// streaming pass with no per-node allocation. A compound value is written in
+/// three phases through a sub-serializer: open it, write each child, then close
+/// it.
+///
+/// Every method is `@inlinable` so a caller in another module specializes the
+/// whole write tree to straight-line code; without it the write funnels through
+/// witness-table dispatch and runs measurably slower.
+public protocol Serializer: ~Copyable, ~Escapable {
+  /// The error this serializer raises, carried concretely by typed throws.
+  associatedtype Failure: Error
+
+  /// The sub-serializer that writes a sequence element by element.
+  associatedtype Sequences: SequenceSerializer & ~Copyable & ~Escapable
+      where Sequences.Failure == Failure, Sequences.Parent == Self
+
+  /// The sub-serializer that writes a structure field by field.
+  associatedtype Structures: StructureSerializer & ~Copyable & ~Escapable
+      where Structures.Failure == Failure, Structures.Parent == Self
+
+  /// Writes a boolean.
+  @inlinable
+  mutating func serialize(_ value: Bool) throws(Failure)
+
+  /// Writes a fixed-width integer of any width.
+  @inlinable
+  mutating func serialize<T: FixedWidthInteger>(_ value: T) throws(Failure)
+
+  /// Writes a double-precision floating-point value.
+  @inlinable
+  mutating func serialize(_ value: Double) throws(Failure)
+
+  /// Writes a string.
+  @inlinable
+  mutating func serialize(_ value: String) throws(Failure)
+
+  /// Writes a run of raw bytes.
+  @inlinable
+  mutating func serialize(bytes: some Sequence<UInt8>) throws(Failure)
+
+  /// Writes the absence of a value.
+  @inlinable
+  mutating func null() throws(Failure)
+
+  /// Writes the marker that a wrapped value is present, so the read side can
+  /// tell a present value from an absent one before the value itself.
+  @inlinable
+  mutating func some() throws(Failure)
+
+  /// Opens a sequence of `count` elements (nil if the length is not known),
+  /// consuming the serializer and returning the sub-serializer the caller
+  /// drives once per element; the sub-serializer's `end` hands the serializer
+  /// back.
+  ///
+  /// Non-throwing so the consume is total: were it to throw, the consumed
+  /// serializer could not be restored to the caller's slot. Any framing bytes a
+  /// fixed-capacity sink might reject are deferred to the first `element` or to
+  /// `end`, which do throw.
+  @inlinable
+  @_lifetime(copy self)
+  consuming func sequence(count: Int?) -> Sequences
+
+  /// Opens a structure named `name` with `count` fields, consuming the
+  /// serializer and returning the sub-serializer the caller drives once per
+  /// field; the sub-serializer's `end` hands the serializer back. Non-throwing
+  /// for the same reason as `sequence`.
+  @inlinable
+  @_lifetime(copy self)
+  consuming func structure(_ name: StaticString, fields count: Int)
+      -> Structures
+}
+
+/// The sub-serializer that writes a sequence: `element` once per child, then
+/// `end`.
+///
+/// Each `element` writes straight to the sink, so a sequence streams with no
+/// buffering. `end` is `consuming`, closing the sequence exactly once.
+public protocol SequenceSerializer: ~Copyable, ~Escapable {
+  /// The error this serializer raises, matching its parent serializer.
+  associatedtype Failure: Error
+
+  /// The serializer this sub-serializer returns to the caller when the
+  /// sequence ends.
+  associatedtype Parent: Serializer & ~Copyable & ~Escapable
+      where Parent.Failure == Failure
+
+  /// Writes one element, recursing into its `Serializable` conformance.
+  @inlinable
+  mutating func element<T: Serializable>(_ value: borrowing T) throws(Failure)
+
+  /// Closes the sequence and returns the parent serializer so the caller can
+  /// keep writing — the `~Copyable` hand-back in place of an `inout` slot.
+  @inlinable
+  @_lifetime(copy self)
+  consuming func end() throws(Failure) -> Parent
+}
+
+/// The sub-serializer that writes a structure: `field` once per stored property
+/// in declaration order, then `end`.
+public protocol StructureSerializer: ~Copyable, ~Escapable {
+  /// The error this serializer raises, matching its parent serializer.
+  associatedtype Failure: Error
+
+  /// The serializer this sub-serializer returns to the caller when the
+  /// structure ends.
+  associatedtype Parent: Serializer & ~Copyable & ~Escapable
+      where Parent.Failure == Failure
+
+  /// Writes one named field, recursing into its `Serializable` conformance.
+  @inlinable
+  mutating func field<T: Serializable>(_ name: StaticString,
+                                       _ value: borrowing T) throws(Failure)
+
+  /// Closes the structure and returns the parent serializer so the caller can
+  /// keep writing — the `~Copyable` hand-back in place of an `inout` slot.
+  @inlinable
+  @_lifetime(copy self)
+  consuming func end() throws(Failure) -> Parent
+}
+
+/// A type that can describe its own shape to a `Serializer`, written once
+/// against the abstract shape vocabulary regardless of the byte format.
+///
+/// A conformance calls exactly the methods that describe its shape and knows
+/// nothing of any concrete format; the `@Serializable` macro generates one for
+/// a struct (a `field` per stored property in declaration order).
+public protocol Serializable {
+  /// Drives `serializer` to write `self`, consuming it and returning it so the
+  /// caller can keep writing. Generic over the format so no existential appears
+  /// on the write path; the serializer is `~Copyable` because it owns the byte
+  /// sink, and it is threaded by consume/return rather than `inout` so a throw
+  /// on a compound path never leaves a half-consumed slot.
+  @inlinable
+  func serialize<S>(into serializer: consuming S)
+      throws(S.Failure) -> S
+      where S: Serializer & ~Copyable & ~Escapable
+}

--- a/Sources/Decant/Sink.swift
+++ b/Sources/Decant/Sink.swift
@@ -1,0 +1,77 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+/// The byte destination a `Serializer` writes into.
+///
+/// A serializer is generic over its sink so one write of a value can drive
+/// bytes into a caller-provided fixed buffer or into a growable buffer with no
+/// change to the value or the format — a self-describing format cannot know its
+/// output length in advance, so the destination must be pluggable.
+///
+/// A `Sink` is `~Escapable` and `~Copyable`: a fixed-capacity conformer is
+/// backed by a view over uninitialized capacity, which is itself
+/// `~Escapable`/`~Copyable`, so the sink holding one must be too. It is
+/// threaded `inout` through the recursive write.
+///
+/// Every method is `@inlinable` so a caller in another module specializes the
+/// append across the format boundary; without it the append regresses to a
+/// witness-table call.
+public protocol Sink: ~Copyable, ~Escapable {
+  /// Appends a contiguous run of bytes to the output. Throws `.overflow` if a
+  /// fixed-capacity conformer cannot accept them.
+  @inlinable
+  mutating func append(_ bytes: some Sequence<UInt8>) throws(DecantError)
+
+  /// Appends one byte to the output. Throws `.overflow` if a fixed-capacity
+  /// conformer is full.
+  @inlinable
+  mutating func append(_ byte: UInt8) throws(DecantError)
+}
+
+extension Sink where Self: ~Copyable & ~Escapable {
+  /// Appends a single byte through the sequence overload by default; a
+  /// conformer with a cheaper single-byte path overrides this.
+  @inlinable
+  public mutating func append(_ byte: UInt8) throws(DecantError) {
+    try append(CollectionOfOne(byte))
+  }
+}
+
+/// A growable `Sink` backed by a reallocating `Array<UInt8>` — the destination
+/// a caller reaches for when the finished bytes must outlive the write.
+///
+/// It is `Escapable`/`Copyable` (an owned array outlives any borrow), so a
+/// caller keeps its `bytes` after the write; a fixed-capacity conformer over a
+/// caller-supplied buffer is the alternative when the output length is bounded.
+public struct ArraySink: Sink {
+  /// The accumulated output bytes; `@usableFromInline` so the `@inlinable`
+  /// append methods may mutate it across the module boundary.
+  @usableFromInline
+  internal var storage: Array<UInt8>
+
+  /// The accumulated output bytes.
+  @inlinable
+  public var bytes: Array<UInt8> {
+    storage
+  }
+
+  /// Creates an empty sink, optionally reserving capacity.
+  @inlinable
+  public init(capacity: Int = 0) {
+    storage = Array<UInt8>()
+    if capacity > 0 {
+      storage.reserveCapacity(capacity)
+    }
+  }
+
+  @inlinable
+  public mutating func append(_ bytes: some Sequence<UInt8>)
+      throws(DecantError) {
+    storage.append(contentsOf: bytes)
+  }
+
+  @inlinable
+  public mutating func append(_ byte: UInt8) throws(DecantError) {
+    storage.append(byte)
+  }
+}

--- a/Tests/DecantTests/SmokeTests.swift
+++ b/Tests/DecantTests/SmokeTests.swift
@@ -1,0 +1,407 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import Decant
+
+// MARK: - A minimal test-only format
+//
+// A concrete format is NOT part of the shipped `Decant` library — the concrete
+// formats live in their own modules. This tiny format exists only so the test
+// target can drive a value through the driver surface end to end and confirm it
+// round-trips. It is a fixed-width layout: a bool and a byte are one byte each,
+// an integer is its little-endian eight-byte value, a string and a byte run are
+// a length prefix (eight bytes) then their bytes, an optional is a presence
+// byte then the value, and a compound is its children back to back.
+
+private struct TestSerializer<Output: Sink>: Serializer, ~Copyable {
+  typealias Failure = DecantError
+
+  var sink: Output
+
+  init(_ sink: consuming Output) {
+    self.sink = sink
+  }
+
+  consuming func finish() -> Output {
+    sink
+  }
+
+  mutating func length(_ value: Int) throws(DecantError) {
+    try sink.append(withUnsafeBytes(of: UInt64(value).littleEndian) {
+      Array($0)
+    })
+  }
+
+  mutating func serialize(_ value: Bool) throws(DecantError) {
+    try sink.append(value ? 1 : 0)
+  }
+
+  mutating func serialize<T: FixedWidthInteger>(_ value: T)
+      throws(DecantError) {
+    let word = Int64(truncatingIfNeeded: value).littleEndian
+    try sink.append(withUnsafeBytes(of: word) { Array($0) })
+  }
+
+  mutating func serialize(_ value: Double) throws(DecantError) {
+    try sink.append(withUnsafeBytes(of: value.bitPattern.littleEndian) {
+      Array($0)
+    })
+  }
+
+  mutating func serialize(_ value: String) throws(DecantError) {
+    let bytes = Array(value.utf8)
+    try length(bytes.count)
+    try sink.append(bytes)
+  }
+
+  mutating func serialize(bytes: some Sequence<UInt8>) throws(DecantError) {
+    let buffer = Array(bytes)
+    try length(buffer.count)
+    try sink.append(buffer)
+  }
+
+  mutating func null() throws(DecantError) {
+    try sink.append(0)
+  }
+
+  mutating func some() throws(DecantError) {
+    try sink.append(1)
+  }
+
+  consuming func sequence(count: Int?) -> TestSequenceSerializer<Output> {
+    TestSequenceSerializer(self, count: count ?? 0)
+  }
+
+  consuming func structure(_ name: StaticString, fields count: Int)
+      -> TestStructureSerializer<Output> {
+    TestStructureSerializer(self)
+  }
+}
+
+private struct TestSequenceSerializer<Output: Sink>: SequenceSerializer,
+    ~Copyable {
+  typealias Failure = DecantError
+  typealias Parent = TestSerializer<Output>
+
+  var serializer: TestSerializer<Output>?
+  var pending: Int?
+
+  init(_ serializer: consuming TestSerializer<Output>, count: Int) {
+    self.serializer = consume serializer
+    pending = count
+  }
+
+  mutating func element<T: Serializable>(_ value: borrowing T)
+      throws(DecantError) {
+    var inner = serializer.take()!
+    if let pending {
+      try inner.length(pending)
+      self.pending = nil
+    }
+    inner = try value.serialize(into: inner)
+    serializer = consume inner
+  }
+
+  consuming func end() throws(DecantError) -> TestSerializer<Output> {
+    var inner = serializer.take()!
+    if let pending {
+      try inner.length(pending)
+    }
+    return inner
+  }
+}
+
+private struct TestStructureSerializer<Output: Sink>: StructureSerializer,
+    ~Copyable {
+  typealias Failure = DecantError
+  typealias Parent = TestSerializer<Output>
+
+  var serializer: TestSerializer<Output>?
+
+  init(_ serializer: consuming TestSerializer<Output>) {
+    self.serializer = consume serializer
+  }
+
+  mutating func field<T: Serializable>(_ name: StaticString,
+      _ value: borrowing T) throws(DecantError) {
+    var inner = serializer.take()!
+    inner = try value.serialize(into: inner)
+    serializer = consume inner
+  }
+
+  consuming func end() throws(DecantError) -> TestSerializer<Output> {
+    var this = self
+    return this.serializer.take()!
+  }
+}
+
+private struct TestDeserializer: Deserializer {
+  typealias Failure = DecantError
+
+  let storage: Array<UInt8>
+  var position: Int
+
+  init(_ bytes: Array<UInt8>) {
+    storage = bytes
+    position = 0
+  }
+
+  mutating func take(_ n: Int) throws(DecantError) -> ArraySlice<UInt8> {
+    guard position + n <= storage.count else { throw .truncated }
+    defer { position += n }
+    return storage[position ..< position + n]
+  }
+
+  mutating func word() throws(DecantError) -> UInt64 {
+    var value: UInt64 = 0
+    for (index, byte) in try take(8).enumerated() {
+      value |= UInt64(byte) << (8 * index)
+    }
+    return value
+  }
+
+  mutating func integer<T: FixedWidthInteger>(_: T.Type)
+      throws(DecantError) -> T {
+    T(truncatingIfNeeded: Int64(bitPattern: try word()))
+  }
+
+  mutating func bool() throws(DecantError) -> Bool {
+    try take(1).first! != 0
+  }
+
+  mutating func double() throws(DecantError) -> Double {
+    Double(bitPattern: try word())
+  }
+
+  mutating func string() throws(DecantError) -> String {
+    String(decoding: try bytes(), as: UTF8.self)
+  }
+
+  mutating func bytes() throws(DecantError) -> Array<UInt8> {
+    let count = Int(try word())
+    return Array(try take(count))
+  }
+
+  mutating func some() throws(DecantError) -> Bool {
+    try take(1).first! != 0
+  }
+
+  mutating func count() throws(DecantError) -> Int {
+    Int(try word())
+  }
+
+  mutating func structure(_ name: StaticString, fields count: Int)
+      throws(DecantError) {}
+
+  mutating func end() throws(DecantError) {}
+}
+
+private func roundtrip<T: Serializable & Deserializable>(_ value: T)
+    throws(DecantError) -> T {
+  var serializer = TestSerializer(ArraySink())
+  serializer = try value.serialize(into: serializer)
+  var deserializer = TestDeserializer(serializer.finish().bytes)
+  return try deserializer.decode(T.self)
+}
+
+// MARK: - Fixtures
+
+/// A HAND-WRITTEN conformance over the driver surface — confirms the protocols
+/// are usable directly, without any derive. The derive sugar layers on this
+/// core in its own module, so nothing here reaches for a macro.
+private struct Version: Equatable {
+  var major: UInt16
+  var minor: UInt16
+}
+
+extension Version: Serializable {
+  func serialize<S>(into serializer: consuming S)
+      throws(S.Failure) -> S
+      where S: Serializer & ~Copyable & ~Escapable {
+    var structure =
+        (consume serializer).structure("Version", fields: 2)
+    try structure.field("major", major)
+    try structure.field("minor", minor)
+    return try structure.end()
+  }
+}
+
+extension Version: Deserializable {
+  static func deserialize<D>(from deserializer: inout D)
+      throws(D.Failure) -> Version
+      where D: Deserializer & ~Copyable & ~Escapable {
+    try deserializer.structure("Version", fields: 2)
+    let major = try deserializer.integer(UInt16.self)
+    let minor = try deserializer.integer(UInt16.self)
+    try deserializer.end()
+    return Version(major: major, minor: minor)
+  }
+}
+
+// MARK: - A borrowed fixed-capacity serializer
+//
+// The advertised borrowed-buffer output path: a `Sink` over a caller-supplied
+// `MutableSpan` that owns no storage of its own, so it is genuinely
+// `~Escapable`. A serializer holding one is itself `~Escapable` — which is
+// exactly the conformance the serializer surface's `~Escapable` opt-out
+// restores. Before it, `BorrowSerializer: Serializer` was rejected because a
+// `Serializer` still carried the default `Escapable` requirement.
+
+private struct BufferSink: Sink, ~Copyable, ~Escapable {
+  var buffer: MutableSpan<UInt8>
+  var count: Int
+
+  @_lifetime(copy buffer)
+  init(_ buffer: consuming MutableSpan<UInt8>) {
+    self.buffer = buffer
+    count = 0
+  }
+
+  mutating func append(_ bytes: some Sequence<UInt8>) throws(DecantError) {
+    for byte in bytes { try append(byte) }
+  }
+
+  mutating func append(_ byte: UInt8) throws(DecantError) {
+    guard count < buffer.count else { throw .overflow }
+    buffer[count] = byte
+    count += 1
+  }
+}
+
+private struct BorrowSerializer: Serializer, ~Copyable, ~Escapable {
+  typealias Failure = DecantError
+
+  var sink: BufferSink
+
+  @_lifetime(copy sink)
+  init(_ sink: consuming BufferSink) {
+    self.sink = sink
+  }
+
+  mutating func serialize(_ value: Bool) throws(DecantError) {
+    try sink.append(value ? 1 : 0)
+  }
+
+  mutating func serialize<T: FixedWidthInteger>(_ value: T)
+      throws(DecantError) {
+    try sink.append(UInt8(truncatingIfNeeded: value))
+  }
+
+  mutating func serialize(_ value: Double) throws(DecantError) {
+    try sink.append(UInt8(truncatingIfNeeded: value.bitPattern))
+  }
+
+  mutating func serialize(_ value: String) throws(DecantError) {
+    try sink.append(value.utf8)
+  }
+
+  mutating func serialize(bytes: some Sequence<UInt8>) throws(DecantError) {
+    for byte in bytes { try sink.append(byte) }
+  }
+
+  mutating func null() throws(DecantError) {
+    try sink.append(0)
+  }
+
+  mutating func some() throws(DecantError) {
+    try sink.append(1)
+  }
+
+  @_lifetime(copy self)
+  consuming func sequence(count: Int?) -> BorrowSubSerializer {
+    BorrowSubSerializer(self)
+  }
+
+  @_lifetime(copy self)
+  consuming func structure(_ name: StaticString, fields count: Int)
+      -> BorrowSubSerializer {
+    BorrowSubSerializer(self)
+  }
+}
+
+private struct BorrowSubSerializer: SequenceSerializer, StructureSerializer,
+    ~Copyable, ~Escapable {
+  typealias Failure = DecantError
+  typealias Parent = BorrowSerializer
+
+  var serializer: BorrowSerializer?
+
+  @_lifetime(copy serializer)
+  init(_ serializer: consuming BorrowSerializer) {
+    self.serializer = consume serializer
+  }
+
+  mutating func element<T: Serializable>(_ value: borrowing T)
+      throws(DecantError) {
+    serializer = try value.serialize(into: serializer.take()!)
+  }
+
+  mutating func field<T: Serializable>(_ name: StaticString,
+                                       _ value: borrowing T)
+      throws(DecantError) {
+    serializer = try value.serialize(into: serializer.take()!)
+  }
+
+  @_lifetime(copy self)
+  consuming func end() throws(DecantError) -> BorrowSerializer {
+    var this = self
+    return this.serializer.take()!
+  }
+}
+
+/// A compile-time proof that a `~Escapable` serializer — one whose sink borrows
+/// a fixed buffer — satisfies `Serializer & ~Copyable & ~Escapable` and so may
+/// drive a `Serializable`. That it type-checks is the guarantee the PR
+/// restores; the round-trip below then exercises it at run time.
+private func serialize<S>(_ value: borrowing Version,
+                          into serializer: consuming S)
+    throws(S.Failure) -> S
+    where S: Serializer & ~Copyable & ~Escapable {
+  try value.serialize(into: serializer)
+}
+
+// MARK: - Tests
+
+struct SmokeTests {
+  @Test func `a hand-written conformance round-trips`() throws {
+    let version = Version(major: 6, minor: 4)
+    #expect(try roundtrip(version) == version)
+  }
+
+  @Test func `a truncated buffer throws rather than crashing`() throws {
+    var serializer = TestSerializer(ArraySink())
+    serializer = try Version(major: 1, minor: 2).serialize(into: serializer)
+    var deserializer =
+        TestDeserializer(Array(serializer.finish().bytes.dropLast(3)))
+    #expect(throws: DecantError.self) {
+      _ = try deserializer.decode(Version.self)
+    }
+  }
+
+  @Test func `a borrowed fixed-buffer serializer conforms and writes`()
+      throws {
+    var storage = Array<UInt8>(repeating: 0, count: 8)
+    try storage.withUnsafeMutableBufferPointer { raw throws(DecantError) in
+      let span = MutableSpan<UInt8>(_unsafeElements: raw)
+      let serializer = BorrowSerializer(BufferSink(span))
+      _ = try serialize(Version(major: 1, minor: 2), into: serializer)
+    }
+    // A structure of two `UInt16` fields writes one byte each in this compact
+    // format: the low byte of `major` then of `minor`.
+    #expect(storage[0] == 1)
+    #expect(storage[1] == 2)
+  }
+}
+
+// MARK: - Sink
+
+struct SinkTests {
+  @Test func `the growable ArraySink accumulates appended bytes`() throws {
+    var sink = ArraySink()
+    try sink.append(0x01)
+    try sink.append([0x02, 0x03] as Array<UInt8>)
+    try sink.append(CollectionOfOne(0x04))
+    #expect(sink.bytes == [0x01, 0x02, 0x03, 0x04])
+  }
+}


### PR DESCRIPTION
Introduce Decant, a streaming serialization core that pairs any type with any byte format through the compiler rather than through an existential. A value drives a borrowed serializer over a Sink, and a type reconstructs itself from a borrowed deserializer, so neither side materializes an intermediate representation.

The core is deliberately macro-free and dependency-free: it is protocol infrastructure only. The Serializer/Deserializer surfaces, the Sink abstraction with its growable ArraySink, DecantError, and the stdlib conformances are all that ship here. The opt-in derive sugar and the concrete byte formats each layer on this core in their own modules.

The test target proves the protocols directly with a hand-written conformance driven end to end through a minimal test-only fixed-width format, alongside the Sink accumulation test. No derive is reached for at this layer.