### PR TITLE
SQLStandard: rename preludeMap to prelude

### DIFF
--- a/Sources/SQLStandard/Prelude.swift
+++ b/Sources/SQLStandard/Prelude.swift
@@ -56,12 +56,12 @@ extension Routines {
   ///   the static contract (the type-check is exact-equality — an integer is
   ///   not a double); an integer-domain overload (`ABS(integer) → integer`, …)
   ///   needs routine overloading, which the single-signature contract lacks.
-  public static let standard: Routines = preludeMap.protecting(preludeMap.names)
+  public static let standard: Routines = prelude.protecting(prelude.names)
 
-  /// The prelude routines as an UNPROTECTED map — `standard` wraps it with
+  /// The prelude routines UNPROTECTED — `standard` wraps this with
   /// `protecting(_:)` so its own names cannot be shadowed. Built through the
   /// dictionary-literal escape hatch, which carries no protected names.
-  private static let preludeMap: Routines = [
+  private static let prelude: Routines = [
     "bitand": Routine(returns: .integer, parameters: [.integer, .integer],
                       deterministic: true, bitand),
     "upper": Routine(returns: .text, parameters: [.text],


### PR DESCRIPTION
The private backing store for the standard prelude was introduced during the SQLStandard split as `preludeMap`. The `Map` suffix echoes the type in the name — a Hungarian-style annotation the coding style avoids. The value is simply the prelude routines (unprotected, before `standard` wraps them with `protecting(_:)`), so `prelude` names what it is without restating that it is a `Routines` dictionary.