### PR TITLE
winmd-inspect: drop the .tables metacommand

### DIFF
--- a/Documentation/SynthesisModel.md
+++ b/Documentation/SynthesisModel.md
@@ -311,7 +311,7 @@ running each statement through `Shell.execute`. The shell offers:
 - `.schema <query>`, printing a query's result columns and types without running
   it; `.bind <name> <value>`, binding a `:name` parameter; `.template <name>
   '<body>'`, defining an inline Mustache template;
-- `.tables`, `.help`, `.quit`.
+- `.help`, `.quit`.
 
 Meta-commands take a `.` prefix precisely so the SQL `:name` parameter syntax
 stays free for bindings.

--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ piped on stdin). Statements run as they are entered; a `;` is optional. In
 addition to SQL, the shell understands a set of `.`-prefixed metacommands:
 
 ```
-winmd> .tables                    -- list the database's tables
+winmd> SELECT table_name FROM information_schema.tables
+                                  -- list the database's tables
 winmd> .schema SELECT * FROM TypeDef
                                   -- print a query's result columns and types
 winmd> .bind ns 'Windows.Win32.Foundation'

--- a/Sources/winmd-inspect/Shell.swift
+++ b/Sources/winmd-inspect/Shell.swift
@@ -35,18 +35,6 @@ internal protocol Metacommand {
   func execute(against shell: inout Shell) throws
 }
 
-/// `.tables` — list the database's relations.
-internal struct Tables: Metacommand {
-  internal static let spelling = ".tables"
-
-  internal init(_ arguments: Substring) {}
-
-  internal func execute(against shell: inout Shell) throws {
-    let relations = shell.session.storage.tables
-    for index in 0 ..< relations.count { print("  \(relations[index])") }
-  }
-}
-
 /// `.schema <query>` — print a query's result columns (name and type) WITHOUT
 /// running it.
 ///
@@ -335,13 +323,12 @@ internal struct Shell: ~Escapable {
   /// computed so the metatype array (not `Sendable`) is not a shared mutable
   /// global.
   private static var commands: Array<any Metacommand.Type> {
-    [Tables.self, Schema.self, Help.self, Quit.self, Read.self, Render.self,
+    [Schema.self, Help.self, Quit.self, Read.self, Render.self,
      Bind.self, Template.self]
   }
 
   /// The command summary `.help` prints.
   internal static let help = """
-    .tables                 list the database's tables
     .schema <query>         print a query's result columns without running it
     .read <path>            run a file of `;`-separated SQL statements
     .render <iface> <tmpl>  render an interface (or `*`) through a template
@@ -1018,7 +1005,7 @@ internal struct Statements: Sequence {
         }
         // A `.`-meta line yields whole when no statement is pending — a
         // whitespace-only or comment-only line before it is trivia, so drop it
-        // rather than glue the meta line onto it (a `-- note` before `.tables`
+        // rather than glue the meta line onto it (a `-- note` before `.schema`
         // must not turn the meta into SQL). `.template` alone carries a single-
         // quoted (possibly multiline) body: when ITS quote is left open, keep
         // accumulating raw lines until the quote closes, then yield the whole

--- a/Tests/SQLTests/IntrospectionTests.swift
+++ b/Tests/SQLTests/IntrospectionTests.swift
@@ -143,7 +143,8 @@ struct IntrospectionTests {
   @Test func `information_schema.columns lists a view's columns and kinds`() throws {
     // `Adults` is `SELECT Name FROM People` over the `.text` `Name` column, so
     // the overlay lists its one column with the resolved text domain — a
-    // metadata consumer can discover the columns of a view `.tables` reports.
+    // metadata consumer can discover the columns of a view
+    // `information_schema.tables` reports.
     let rows = try run("""
         SELECT column_name, data_type FROM information_schema.columns
          WHERE table_name = 'Adults'

--- a/Tests/winmd-inspectTests/DatabaseSQLTests.swift
+++ b/Tests/winmd-inspectTests/DatabaseSQLTests.swift
@@ -1131,13 +1131,13 @@ struct DatabaseSQLTests {
   }
 
   @Test func `execute routes a .-token to its meta-command`() throws {
-    // The leading-token dispatch matches `.tables` to `Tables`, which lists the
-    // storage's relations; the fixture's catalog vends them, so `execute`
-    // succeeds. A SQL statement takes the parse path instead — exercised by
-    // `scriptSession` — and `.quit` throws the loop's `Stop` sentinel.
+    // The leading-token dispatch matches `.help` to `Help`, which prints the
+    // command summary, so `execute` succeeds. A SQL statement takes the parse
+    // path instead — exercised by `scriptSession` — and `.quit` throws the
+    // loop's `Stop` sentinel.
     try DatabaseSQLTests.with { catalog in
       var shell = Shell(catalog)
-      try shell.execute(".tables")
+      try shell.execute(".help")
       #expect(throws: Shell.Stop.self) { try shell.execute(".quit") }
     }
   }

--- a/Tests/winmd-inspectTests/ShellTests.swift
+++ b/Tests/winmd-inspectTests/ShellTests.swift
@@ -57,7 +57,6 @@ struct ShellTests {
   @Test func `each meta-command answers to its .-prefixed spelling`() {
     // The leading-token dispatch matches a `.`-token against each `Metacommand`
     // type's `spelling`; these are the tokens `execute` routes on.
-    #expect(Tables.spelling == ".tables")
     #expect(Schema.spelling == ".schema")
     #expect(Help.spelling == ".help")
     #expect(Quit.spelling == ".quit")
@@ -170,10 +169,10 @@ struct ShellTests {
       CREATE VIEW a AS SELECT 1;
         SELECT 2 ;
       ;
-      .tables
+      .help
       """
     #expect(Array(Statements(of: script))
-            == ["CREATE VIEW a AS SELECT 1", "SELECT 2", ".tables"])
+            == ["CREATE VIEW a AS SELECT 1", "SELECT 2", ".help"])
     #expect(Array(Statements(of: "")).isEmpty)
     #expect(Array(Statements(of: "   \n  ")).isEmpty)
   }
@@ -261,7 +260,7 @@ struct ShellTests {
     // A comment-only pending is trivia, so a following `.`-meta line is still
     // recognised as a meta-command rather than glued onto the comment and sent
     // through SQL parsing.
-    #expect(Array(Statements(of: "-- note\n.tables")) == [".tables"])
+    #expect(Array(Statements(of: "-- note\n.help")) == [".help"])
     #expect(Array(Statements(of: "/* note */\n.read a.sql")) == [".read a.sql"])
   }
 
@@ -342,8 +341,8 @@ struct ShellTests {
     // a whitespace-only `pending` counts as nothing, so the `.`-line still
     // yields whole and a following statement stays a separate statement —
     // otherwise the meta-command swallows the SQL as its arguments.
-    #expect(Array(Statements(of: "SELECT 1;\n   \n.tables\nSELECT 2;"))
-            == ["SELECT 1", ".tables", "SELECT 2"])
+    #expect(Array(Statements(of: "SELECT 1;\n   \n.help\nSELECT 2;"))
+            == ["SELECT 1", ".help", "SELECT 2"])
   }
 
   @Test func `the reading stream prompts primary then continuation while pending`() {
@@ -368,12 +367,12 @@ struct ShellTests {
     // Each self-terminating statement (its own `;`) leaves nothing pending, so
     // every prompt before a read is the primary — a `.`-meta line likewise. The
     // final read past the last line sees nothing pending too.
-    var script = ["SELECT 1;", ".tables", "SELECT 2;"].makeIterator()
+    var script = ["SELECT 1;", ".help", "SELECT 2;"].makeIterator()
     var pending = Array<Bool>()
     let statements =
         Statements(reading: { script.next() },
                    prompt: { pending.append($0) })
-    #expect(Array(statements) == ["SELECT 1", ".tables", "SELECT 2"])
+    #expect(Array(statements) == ["SELECT 1", ".help", "SELECT 2"])
     #expect(pending.allSatisfy { $0 == false })
   }
 


### PR DESCRIPTION
The `.tables` metacommand listed the storage's relations, but that is exactly what a query over the INFORMATION_SCHEMA overlay already answers:

    SELECT table_name FROM information_schema.tables

The overlay lists base tables AND views, carries the standard catalog columns, and composes with the rest of SQL — so the bespoke metacommand was a redundant, less capable spelling of a portable query. Remove the `Tables` command, its registry entry, and its help line, and point the README example at the equivalent query.

The `Statements` iterator tests that used `.tables` only needed some `.`-meta token to exercise line dispatch; repoint them (and the dispatch test) at `.help`, and refresh the doc/comment references.