### PR TITLE
DecantMacros: add the derive layer on the Decant core

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,7 @@
 // swift-tools-version: 6.4
 
 import PackageDescription
+import CompilerPluginSupport
 
 let _ =
     Package(name: "SwiftWinMD",
@@ -13,12 +14,15 @@ let _ =
               .library(name: "SQLStandard", targets: ["SQLStandard"]),
               .library(name: "WinMDSynthesis", targets: ["WinMDSynthesis"]),
               .library(name: "Decant", targets: ["Decant"]),
+              .library(name: "DecantMacros", targets: ["DecantMacros"]),
             ],
             dependencies: [
               .package(url: "https://github.com/apple/swift-argument-parser",
                        from: "1.5.0"),
               .package(url: "https://github.com/hummingbird-project/swift-mustache",
                        from: "2.0.0"),
+              .package(url: "https://github.com/swiftlang/swift-syntax.git",
+                       branch: "main"),
             ],
             targets: [
               .target(name: "CPE", dependencies: []),
@@ -28,6 +32,41 @@ let _ =
                         .enableExperimentalFeature("Lifetimes"),
                       ]),
               .testTarget(name: "DecantTests", dependencies: ["Decant"],
+                          swiftSettings: [
+                            .enableExperimentalFeature("Lifetimes"),
+                          ]),
+
+              .macro(name: "DecantMacrosPlugin",
+                     dependencies: [
+                       .product(name: "SwiftSyntax",
+                                package: "swift-syntax"),
+                       .product(name: "SwiftSyntaxBuilder",
+                                package: "swift-syntax"),
+                       .product(name: "SwiftSyntaxMacros",
+                                package: "swift-syntax"),
+                       .product(name: "SwiftDiagnostics",
+                                package: "swift-syntax"),
+                       .product(name: "SwiftCompilerPlugin",
+                                package: "swift-syntax"),
+                     ]),
+              .target(name: "DecantMacros",
+                      dependencies: ["Decant", "DecantMacrosPlugin"],
+                      swiftSettings: [
+                        .enableExperimentalFeature("Lifetimes"),
+                      ]),
+              .testTarget(name: "DecantMacrosTests",
+                          dependencies: [
+                            "DecantMacrosPlugin",
+                            .product(name: "SwiftSyntaxMacroExpansion",
+                                     package: "swift-syntax"),
+                            .product(name: "SwiftSyntaxMacrosGenericTestSupport",
+                                     package: "swift-syntax"),
+                          ],
+                          swiftSettings: [
+                            .enableExperimentalFeature("Lifetimes"),
+                          ]),
+              .testTarget(name: "DecantMacrosClientTests",
+                          dependencies: ["DecantMacros"],
                           swiftSettings: [
                             .enableExperimentalFeature("Lifetimes"),
                           ]),

--- a/Sources/DecantMacros/Macros.swift
+++ b/Sources/DecantMacros/Macros.swift
@@ -1,0 +1,37 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+@_exported import Decant
+
+/// Derives a `Serializable` conformance for a struct, writing one field per
+/// stored property in declaration order.
+///
+/// The DECLARATION lives here in `DecantMacros`, the opt-in derive layer; the
+/// IMPLEMENTATION lives in the `DecantMacrosPlugin` compiler plugin so
+/// swift-syntax is a compile-time-only dependency that never links into a
+/// client. The `Decant` core carries no macro at all.
+@attached(extension, conformances: Serializable, names: named(serialize(into:)))
+public macro Serializable() =
+    #externalMacro(module: "DecantMacrosPlugin", type: "SerializableMacro")
+
+/// Derives a `Deserializable` conformance for a struct, reading each stored
+/// property in declaration order — the inverse of `@Serializable`, matching its
+/// field order.
+@attached(extension, conformances: Deserializable,
+          names: named(deserialize(from:)))
+public macro Deserializable() =
+    #externalMacro(module: "DecantMacrosPlugin", type: "DeserializableMacro")
+
+/// Marks a stored property to be written and read under a different name than
+/// its Swift spelling. The plain-fields derive does not yet honor it; the
+/// spelling is declared so it is stable ahead of that support.
+@attached(peer)
+public macro DecantName(_ name: StaticString) =
+    #externalMacro(module: "DecantMacrosPlugin", type: "DecantNameMacro")
+
+/// Marks a stored property the derive should skip. The plain-fields derive does
+/// not yet honor it; the spelling is declared so it is stable ahead of that
+/// support.
+@attached(peer)
+public macro DecantSkip() =
+    #externalMacro(module: "DecantMacrosPlugin", type: "DecantSkipMacro")

--- a/Sources/DecantMacrosPlugin/Macros.swift
+++ b/Sources/DecantMacrosPlugin/Macros.swift
@@ -1,0 +1,2869 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+@_spi(RawSyntax) import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+import SwiftDiagnostics
+
+/// The diagnostics the derive macros raise when applied to an unsupported
+/// declaration.
+///
+/// The macros are syntactic: they see spellings, not resolved types, so they
+/// refuse anything but a struct up front and leave the type-checker to verify
+/// each field's `Serializable`/`Deserializable` conformance.
+internal enum DecantDiagnostic: String, DiagnosticMessage {
+  case nonstruct
+  case lazy
+  case constant
+  case wrapper
+  case deprecated
+  case initializer
+  case conditional
+  case isolation
+  case inferred
+
+  internal var message: String {
+    switch self {
+    case .nonstruct:
+      "@Serializable / @Deserializable can only be applied to a struct"
+    case .lazy:
+      "@Serializable / @Deserializable cannot derive a `lazy` property: a "
+        + "lazy var has a mutating getter and is not a memberwise-init "
+        + "parameter"
+    case .constant:
+      "@Serializable / @Deserializable cannot derive an initialized `let` "
+        + "(not a memberwise-init parameter); make it a `var` or remove the "
+        + "initializer"
+    case .wrapper:
+      "@Serializable / @Deserializable cannot derive a property-wrapper-backed "
+        + "property; its memberwise-init parameter is the wrapper storage, not "
+        + "the wrapped value"
+    case .deprecated:
+      "@Serializable cannot derive a deprecated stored property: the generated "
+        + "serialize reads `self.<field>`, which warns on every access to a "
+        + "deprecated member and so breaks a warning-free build; exclude the "
+        + "field or drop its @available(*, deprecated). @Deserializable alone "
+        + "is fine — it passes the field as a memberwise-init argument"
+    case .initializer:
+      "@Deserializable requires the synthesized memberwise initializer, which "
+        + "is suppressed by a custom initializer; declare a matching "
+        + "init(<field>: …) or remove the custom initializer"
+    case .conditional:
+      "@Serializable / @Deserializable cannot derive this many independent "
+        + "`#if` blocks over stored properties: the per-branch initializer "
+        + "calls are the cartesian product of the blocks' clauses, which here "
+        + "exceeds the emission cap; reduce the conditional stored properties"
+    case .isolation:
+      "@Serializable / @Deserializable cannot derive a global-actor-isolated "
+        + "type whose stored property may be non-Sendable: the witnesses are "
+        + "nonisolated (the requirements are), so the generated `self.<field>` "
+        + "read and memberwise-init call are rejected unless every field is "
+        + "Sendable, which the syntactic macro cannot confirm; make the field "
+        + "type Sendable, drop the global actor, or write the conformance by "
+        + "hand"
+    case .inferred:
+      "@Serializable / @Deserializable cannot derive a stored property whose "
+        + "type is inferred from an initializer that mentions a generic "
+        + "parameter: the conditional conformance is constrained on each "
+        + "field's WRITTEN type, and this field has none to constrain, so the "
+        + "generated body would fail to type-check; add an explicit type "
+        + "annotation naming the generic parameter"
+    }
+  }
+
+  internal var diagnosticID: MessageID {
+    MessageID(domain: "DecantMacros", id: rawValue)
+  }
+
+  internal var severity: DiagnosticSeverity {
+    .error
+  }
+}
+
+/// The stored properties, in declaration order, a derive emits reads and writes
+/// for.
+///
+/// A stored property is a `var`/`let` binding whose accessor block, if any,
+/// holds only `willSet`/`didSet` observers; a computed property (a getter, or
+/// an accessor list with `get`/`set`/`_read`/`_modify`/`unsafeAddress`/
+/// `unsafeMutableAddress`) is skipped. Several bindings on one `let a, b: Int`
+/// line expand to one entry each, as does a tuple binding — `var (x, y):
+/// (Int, Int)`, whose components Swift stores separately.
+internal enum DecantModel {
+  /// Which side of the round-trip a collection serves. Serialize reads
+  /// `self.<name>` (nonmutating) and so accepts any stored property, including
+  /// an initialized `let`; deserialize passes each field to the synthesized
+  /// memberwise init, which omits an initialized `let`, so that shape is
+  /// rejected only here.
+  internal enum Direction {
+    case serialize
+    case deserialize
+  }
+
+  /// One stored property's name and, when it is written, its declared type.
+  ///
+  /// The name is all a derive's emission needs: the write reads `self.<name>`
+  /// and the read passes its `decode` to the memberwise-init argument labelled
+  /// `<name>`, whose parameter supplies the type. The macro is syntactic and
+  /// never resolves the property's type.
+  ///
+  /// `type` is the trimmed spelling of the field's written type annotation, or
+  /// `nil` when none is written (an inferred `var count = 0`) or the binding is
+  /// a tuple whose per-element types the syntactic macro does not split out. It
+  /// exists only so `matches` can prove a user init's parameter types equal the
+  /// fields': a `nil` type is unprovable and forces a non-match (the safe
+  /// `.initializer` diagnostic).
+  ///
+  /// `coercion` is the spelling the read's `decode() as <coercion>` cast
+  /// annotates with — normally `type`, but an implicitly-unwrapped optional
+  /// `T!` is normalized to the optional `T?`: `as T!` is not a legal coercion
+  /// target, yet the memberwise-init parameter (still `T!`) accepts a `T?`
+  /// value, and `Optional` is `Deserializable`. An opaque `some P` field
+  /// carries NO coercion at all — `as some P` is not a legal coercion target —
+  /// so the read stays a bare `decode()` the memberwise-init parameter's opaque
+  /// type drives, matching the type-less fallback. Matching (`passes`) keeps
+  /// the verbatim `type` so an init parameter spelled `T!` still equals the
+  /// field.
+  internal struct Field {
+    internal let name: String
+    internal let type: String?
+    internal let coercion: String?
+  }
+
+  /// A run of stored properties sharing a compilation condition, in declaration
+  /// order.
+  ///
+  /// A member under no `#if` is an `unconditional` run; a member under an
+  /// `#if`/`#elseif`/`#else` is one `conditional` block whose clauses the
+  /// derive mirrors verbatim into the generated code — the plugin cannot
+  /// evaluate a condition (it arrives unresolved), so it re-emits the guard and
+  /// lets the compiler activate the matching branch. A clause's body recurses
+  /// through `Segment` again, so a nested `#if` is supported.
+  internal enum Segment {
+    case unconditional(Array<Field>)
+    case conditional(Array<Clause>)
+  }
+
+  /// One clause of an `#if`/`#elseif`/`#else` block: the pound keyword
+  /// spelling, the condition copied verbatim (`nil` for the conditionless
+  /// `#else`), and the stored properties the clause guards, as their own
+  /// segment list so a nested `#if` recurses.
+  internal struct Clause {
+    internal let pound: String
+    internal let condition: String?
+    internal let segments: Array<Segment>
+  }
+
+  /// The stored properties of a struct, split into `segments` that mirror its
+  /// `#if` structure. The serialize/deserialize emission walks the segments
+  /// directly.
+  internal struct Model {
+    internal let segments: Array<Segment>
+  }
+
+  /// Extracts the stored properties of `declaration`, mirroring its `#if`
+  /// structure in the returned segments, or raises `.nonstruct` if it is not a
+  /// struct (and the other field diagnostics as they arise).
+  internal static func model(of declaration: some DeclGroupSyntax,
+                             for direction: Direction,
+                             in context: some MacroExpansionContext,
+                             at node: AttributeSyntax) -> Model? {
+    guard declaration.is(StructDeclSyntax.self) else {
+      context.diagnose(Diagnostic(node: node,
+                                  message: DecantDiagnostic.nonstruct))
+      return nil
+    }
+
+    // The generated conformance extension copies the type's own `@available`
+    // AND the enclosing type chain's (see `available`), so a serialize read of
+    // `self.<field>` runs inside a context carrying that whole gate. When the
+    // gate DEPRECATES a field's platform — the enclosing type is deprecated —
+    // the read sits in a deprecated context where Swift suppresses the
+    // deprecation warning, so the field's deprecation is COVERED and the
+    // serialize guard must not fire; a NON-deprecated context still warns and
+    // the guard fires. This mirrors the deprecated-INIT coverage: the same
+    // `Availability` model, weighed the same way.
+    let deprecation = availability(available(declaration)
+        + available(enclosing: context.lexicalContext))
+    guard let segments = collect(declaration.memberBlock.members,
+                                 for: direction, under: deprecation,
+                                 in: context, at: node) else {
+      return nil
+    }
+    // A global-actor-isolated type isolates its stored properties, but the
+    // emitted witnesses are `nonisolated` (the requirements are), and Swift
+    // lets a nonisolated body read an isolated stored property — and call the
+    // memberwise init — only when its value is `Sendable`. Sendability is a
+    // semantic conformance the syntactic macro cannot see, so it approximates:
+    // a field whose written type is not a recognizably-`Sendable` standard
+    // spelling (`safe`) may be non-Sendable, which would make the generated
+    // `self.<name>` read (serialize) and `Self(<name>: …)` call (deserialize)
+    // fail to compile from the nonisolated witness. Diagnose that up front — a
+    // clear guide beats a silent actor-isolation error — rather than derive
+    // code the compiler rejects. An all-`safe` isolated type (the common
+    // `@MainActor` case) derives unchanged. A field of no written type is left
+    // to the compiler, as its spelling gives nothing to judge.
+    if isolated(declaration), risky(segments) {
+      context.diagnose(Diagnostic(node: node,
+                                  message: DecantDiagnostic.isolation))
+      return nil
+    }
+    // The single generic environment the derive reasons over: the type's own
+    // clause plus every parameter an enclosing type OR extension contributes
+    // (see `environment`). The inferred-field guard, the init-candidate check,
+    // and the conformance's `where` clause all consume it, so the guard sees
+    // exactly the parameters the constraint builder does.
+    let scope = environment(of: declaration, enclosing: context.lexicalContext)
+    // The conditional conformance a generic type derives is constrained on each
+    // serialized field's WRITTEN type (see `constrained`). A field that infers
+    // its type from an initializer mentioning a generic parameter — `struct
+    // Box<T: Defaulted> { var value = T.defaultValue }`, or an enclosing
+    // parameter `struct Outer<T: Defaulted> { @Serializable struct Inner { var
+    // value = T.defaultValue } }` — has no written type to constrain, yet the
+    // generated body reads and reconstructs a `T` needing `T: Serializable`/
+    // `Deserializable`, so an unconstrained conformance would fail to
+    // type-check downstream. Deriving the constraint from the initializer
+    // expression is unreliable (the syntactic macro cannot resolve
+    // `T.defaultValue`'s type), so diagnose the field up front — a clear guide
+    // to annotate beats a cryptic conformance failure — rather than emit code
+    // the compiler rejects. The scan consults `scope`, the SAME environment the
+    // constraint builder uses, so an enclosing parameter an unannotated field
+    // initialises from is caught too.
+    if inferred(declaration, mentioning: Set(scope)) {
+      context.diagnose(Diagnostic(node: node,
+                                  message: DecantDiagnostic.inferred))
+      return nil
+    }
+    // Serialize reads `self.<field>` under each `#if` guard and calls no
+    // initializer, so its emission is linear in the fields and needs neither
+    // the branch cap nor the init-resolution analysis below. Return before
+    // both, so a serialize-only struct derives however many `#if` blocks it
+    // carries.
+    guard direction == .deserialize else {
+      return Model(segments: segments)
+    }
+    // A cartesian product of the conditional blocks' clauses drives the
+    // per-branch deserialize initializer calls, so a runaway product would emit
+    // enormous code. Cap it with the `.conditional` diagnostic rather than do
+    // so. The cap is deserialize-only: only the deserialize side multiplies its
+    // `Self(…)` leaves. A field-less `#if` is already dropped from the
+    // segments, so it neither counts here nor multiplies the branches.
+    guard branches(segments) <= cap else {
+      context.diagnose(Diagnostic(node: node,
+                                  message: DecantDiagnostic.conditional))
+      return nil
+    }
+    // Declaring any initializer in the primary struct declaration suppresses
+    // the synthesized memberwise initializer, which deserialize calls as
+    // `Self(<field>: …)`. (An init in an extension does not suppress it, and
+    // the macro sees only the primary declaration's members anyway.) The check
+    // is per emitted build: `resolutions` enumerates each build's ACTIVE fields
+    // paired with its ACTIVE inits — inits gated by the same `#if` clauses as
+    // fields, so a conditional init counts only in the builds it compiles in.
+    // A build is fine when no init is active (the memberwise init is
+    // synthesized) or when an active init covers the build's fields; otherwise
+    // the suppressed memberwise init has no callable `Self(…)` replacement, so
+    // diagnose. A single flattened list would wrongly demand a conditional init
+    // cover builds it is not compiled in. Serialize reads `self.<field>` and
+    // never calls an init, so this is deserialize-only.
+    //
+    // The enumeration is its own cartesian, over the `#if` blocks that carry a
+    // field OR an init (`resolutions` prunes the rest, as many field/init-less
+    // helper-only blocks would otherwise blow the product up though they vary
+    // no build). It is not the emission branch count `branches(_ segments:)`
+    // caps — an init-only `#if` is dropped from the segments yet still branches
+    // the resolution — so cap it separately, with the same `.conditional`
+    // diagnostic, before enumerating.
+    guard branches(declaration.memberBlock.members) <= cap else {
+      context.diagnose(Diagnostic(node: node,
+                                  message: DecantDiagnostic.conditional))
+      return nil
+    }
+    // The generated extension carries the type's own `@available` AND the
+    // enclosing type chain's (the emission copies both onto it), so a user init
+    // gated the SAME as the type — or as an enclosing type — is callable
+    // wherever the conformance exists. The resolution analysis weighs an init's
+    // version gate against this full set: a gate the extension already carries
+    // is covered and callable, a NARROWER one is not.
+    let gate = available(declaration)
+        + available(enclosing: context.lexicalContext)
+    let resolutions = self.resolutions(declaration.memberBlock.members)
+    guard resolutions.allSatisfy({ resolvable($0, under: gate) }) else {
+      context.diagnose(Diagnostic(node: node,
+                                  message: DecantDiagnostic.initializer))
+      return nil
+    }
+    // The emission reads each typed field with an EXPLICIT type
+    // (`decode() as <type>`), so the field's declared type — not the generic
+    // `decode()` — drives overload resolution; a type-less field stays a bare
+    // `decode()`. Swift RANKS the overloads it keeps: the EXACT
+    // memberwise-equivalent init — parameters corresponding one-to-one to the
+    // fields, with no extra parameter, even a defaulted one — outranks an init
+    // that relies on a defaulted extra parameter, so a unique exact candidate
+    // resolves the call unambiguously. A build is ambiguous only when NO unique
+    // best candidate exists: two or more inits stay viable against the typed
+    // call and none is a unique exact match — either the annotation cannot
+    // break the tie because a field carries no type to annotate with, or two
+    // inits share the covered fields' types and differ only by extra defaulted
+    // parameters (`init(x: Int, y: Int = 0)` and `init(x: Int, z: Int = 0)`
+    // both take `Self(x: … as Int)`, neither exact). A set with one best-ranked
+    // exact candidate — say `init(x: Int)` beside `init(x: Int, y: Int = 0)` —
+    // resolves to it and derives.
+    for resolution in resolutions where ambiguous(resolution, under: gate) {
+      context.diagnose(Diagnostic(node: node,
+                                  message: DecantDiagnostic.initializer))
+      return nil
+    }
+    return Model(segments: segments)
+  }
+
+  /// Collects `members`, in declaration order, into segments that mirror their
+  /// `#if` structure: a stored `var`/`let` extends the current unconditional
+  /// run, and an `IfConfigDeclSyntax` becomes one conditional block whose
+  /// clauses recurse through `collect` again. Returns `nil` once a field
+  /// diagnostic has fired.
+  private static func collect(_ members: MemberBlockItemListSyntax,
+                              for direction: Direction,
+                              under gate: Availability,
+                              in context: some MacroExpansionContext,
+                              at node: AttributeSyntax) -> Array<Segment>? {
+    var segments = Array<Segment>()
+    var run = Array<Field>()
+    func flush() {
+      guard !run.isEmpty else { return }
+      segments.append(.unconditional(run))
+      run.removeAll()
+    }
+    for member in members {
+      if let conditional = member.decl.as(IfConfigDeclSyntax.self) {
+        flush()
+        guard let clauses = clauses(of: conditional, for: direction,
+                                    under: gate, in: context, at: node) else {
+          return nil
+        }
+        // An `#if` guarding only non-field members (helper methods,
+        // typealiases, computed properties, or a nested field-less `#if`)
+        // contributes no stored field, so the serialized field set is the same
+        // in every clause. Dropping it keeps the emission unconditional and,
+        // crucially, keeps such a block out of the deserialize branch product —
+        // otherwise many field-less blocks would multiply the per-branch
+        // `Self(…)` calls (and hit the `.conditional` cap) though the field set
+        // never varies. The init-suppression analysis still sees any init the
+        // block guards, since it walks the primary declaration's members
+        // directly rather than these segments.
+        guard clauses.contains(where: { carries($0.segments) }) else {
+          continue
+        }
+        segments.append(.conditional(clauses))
+        continue
+      }
+      guard let binding = member.decl.as(VariableDeclSyntax.self) else {
+        continue
+      }
+      guard append(binding, for: direction, under: gate, to: &run,
+                   in: context, at: node) else {
+        return nil
+      }
+    }
+    flush()
+    return segments
+  }
+
+  /// The clauses of `conditional`, each carrying its verbatim condition and its
+  /// recursively collected segments. A clause whose body is not member
+  /// declarations (an `#if` around statements or attributes) contributes no
+  /// segments. Returns `nil` once a field diagnostic has fired.
+  private static func clauses(of conditional: IfConfigDeclSyntax,
+                              for direction: Direction,
+                              under gate: Availability,
+                              in context: some MacroExpansionContext,
+                              at node: AttributeSyntax) -> Array<Clause>? {
+    var clauses = Array<Clause>()
+    for clause in conditional.clauses {
+      guard case let .decls(members)? = clause.elements else {
+        clauses.append(Clause(pound: clause.poundKeyword.text,
+                              condition: clause.condition?.trimmedDescription,
+                              segments: []))
+        continue
+      }
+      guard let segments = collect(members, for: direction, under: gate,
+                                   in: context, at: node) else {
+        return nil
+      }
+      clauses.append(Clause(pound: clause.poundKeyword.text,
+                            condition: clause.condition?.trimmedDescription,
+                            segments: segments))
+    }
+    return clauses
+  }
+
+  /// Whether `segments` carry a stored field at any depth — an unconditional
+  /// run holding one, or a conditional clause that recursively does. A field-
+  /// less `#if` (guarding only methods, typealiases, or computed properties)
+  /// answers `false`, so `collect` drops it rather than record a conditional
+  /// segment whose clauses vary no field.
+  private static func carries(_ segments: Array<Segment>) -> Bool {
+    segments.contains { segment in
+      switch segment {
+      case let .unconditional(run):
+        return !run.isEmpty
+      case let .conditional(clauses):
+        return clauses.contains { carries($0.segments) }
+      }
+    }
+  }
+
+  /// Appends the stored properties `binding` declares to `run`, or diagnoses
+  /// and returns `false` for a shape the derive rejects (a `lazy`,
+  /// wrapper-backed, or — on the deserialize side — an initialized `let`).
+  private static func append(_ binding: VariableDeclSyntax,
+                             for direction: Direction,
+                             under gate: Availability,
+                             to run: inout Array<Field>,
+                             in context: some MacroExpansionContext,
+                             at node: AttributeSyntax) -> Bool {
+    guard !typed(binding.modifiers) else { return true }
+    // A `lazy var` has a mutating getter, so serialize's nonmutating
+    // `self.<name>` read cannot type-check, and it is not a memberwise-init
+    // parameter for deserialize to pass. Reject rather than miscompile.
+    guard !lazy(binding.modifiers) else {
+      context.diagnose(Diagnostic(node: node,
+                                  message: DecantDiagnostic.lazy))
+      return false
+    }
+    let constant = binding.bindingSpecifier.tokenKind == .keyword(.let)
+    for (pattern, type) in bindings(of: binding) {
+      // A computed property has no storage: serialize does not read it and it
+      // is not a memberwise-init parameter, so it contributes no field and its
+      // attributes are irrelevant. Skip it BEFORE the wrapper check, so an
+      // attribute the derive does not recognize on a computed property (say a
+      // `@MainActor var y: Int { 0 }`) is not misread as a property wrapper.
+      guard !computed(pattern.accessorBlock) else { continue }
+      // A property wrapper's synthesized memberwise parameter is typed for the
+      // wrapper storage, which need not match the wrapped value serialize
+      // writes. The syntactic macro cannot resolve the two, so it rejects a
+      // wrapper-backed stored property on both sides rather than emit a shape
+      // that deserializes differently than it serialized.
+      guard !wrapped(binding.attributes) else {
+        context.diagnose(Diagnostic(node: node,
+                                    message: DecantDiagnostic.wrapper))
+        return false
+      }
+      // A deprecated stored field warns on every access, and serialize reads
+      // `self.<field>` — UNLESS the read sits in a deprecated context, where
+      // Swift suppresses the warning. The generated extension copies the type's
+      // and enclosing chain's `@available` (`gate`), so when that gate covers
+      // the field's deprecation ON ITS PLATFORM the extension IS a deprecated
+      // context and the read is warning-free; only an UNCOVERED deprecation
+      // (the extension is not deprecated on the field's platform) breaks a
+      // warning-free build. Reject only such an uncovered field, and only on
+      // serialize — deserialize passes the field as a memberwise-init argument
+      // (`Self(<label>: …)`), which is not an access and never warns (mirroring
+      // the deprecated-init coverage on deserialize). An `unavailable`/
+      // `obsoleted:` field is worse than deprecated — reading it is an ERROR a
+      // deprecated context does NOT suppress — so it is rejected outright
+      // (`disqualified`), never excused by the gate.
+      let field = availability(binding.attributes)
+      guard !(direction == .serialize
+                && (field.disqualified
+                      || !covers(deprecation: gate, field))) else {
+        context.diagnose(Diagnostic(node: node,
+                                    message: DecantDiagnostic.deprecated))
+        return false
+      }
+      // Swift omits an initialized `let` from the synthesized memberwise init,
+      // so deserialize would pass an argument no parameter accepts. An
+      // uninitialized `let` and any `var` remain memberwise parameters. The
+      // nonmutating serialize read of `self.<name>` is fine either way, so this
+      // rejection is deserialize-only.
+      guard !(direction == .deserialize
+                && constant && pattern.initializer != nil) else {
+        context.diagnose(Diagnostic(node: node,
+                                    message: DecantDiagnostic.constant))
+        return false
+      }
+      append(pattern.pattern, typed: type, to: &run)
+    }
+    return true
+  }
+
+  /// The number of distinct deserialize branches `segments` describes: the
+  /// product over each conditional block of the sum of its clauses' branch
+  /// counts, plus one for the synthesized `#else` a block without a source
+  /// `#else` gains (the case no clause is active). An unconditional segment is
+  /// one branch; a block multiplies. This is the count `builds` emits, so the
+  /// cap it guards is exact.
+  ///
+  /// The product SATURATES at `cap + 1`: many independent conditional blocks
+  /// would overflow `Int` before the `<= cap` comparison and trap the plugin
+  /// instead of raising `.conditional`, so once the running product passes the
+  /// cap the fold stops and returns `cap + 1`. A saturated value stays `> cap`,
+  /// so the diagnostic still fires for the oversized shape; a within-cap
+  /// product is exact and unaffected. `branches` never exceeds `cap + 1`, so
+  /// each clause's term is bounded and the clause sum cannot overflow.
+  private static func branches(_ segments: Array<Segment>) -> Int {
+    var product = 1
+    for segment in segments {
+      guard case let .conditional(clauses) = segment else { continue }
+      var sum = clauses.reduce(0) { $0 + branches($1.segments) }
+      if clauses.last?.condition != nil { sum += 1 }
+      let (scaled, overflow) = product.multipliedReportingOverflow(by: sum)
+      guard !overflow, scaled <= cap else { return cap + 1 }
+      product = scaled
+    }
+    return product
+  }
+
+  /// The emission cap on the deserialize branch count. Past it the per-branch
+  /// `Self(…)` calls — the cartesian product of the `#if` blocks' clauses —
+  /// would emit enormous code, so `branches` saturates here and `model` raises
+  /// `.conditional`.
+  private static let cap = 256
+
+  /// One emitted build: the fields active in it, in declaration order, paired
+  /// with the initializers active in it. The derive emits a `Self(<fields>)`
+  /// for the build, and its active inits are the ones in scope that suppress
+  /// the synthesized memberwise init in that build.
+  private struct Resolution {
+    internal let fields: Array<Field>
+    internal let inits: Array<InitializerDeclSyntax>
+  }
+
+  /// Every emitted build's active fields and active initializers — the
+  /// cartesian of the `#if` blocks' clause selections, each selection carrying
+  /// the fields AND the inits its clauses compile. Fields and inits share the
+  /// same `#if` structure, so one walk yields both: a field or init a clause
+  /// guards appears only in the builds that keep that clause. A block without a
+  /// source `#else` contributes an implicit "no clause active" build that omits
+  /// the block's fields and inits, matching the synthesized `#else` leaf the
+  /// emission produces. A clause whose body is not member declarations (a `#if`
+  /// around statements) contributes nothing.
+  ///
+  /// An `#if` block carrying NEITHER a field NOR an init at any depth
+  /// (`pertinent` answers `false`: a block of helper methods, computed
+  /// properties, or typealiases) varies no build — the same fields and inits
+  /// are active whichever clause the compiler picks — so it is skipped rather
+  /// than branched over. Many such blocks would otherwise multiply the
+  /// cartesian pointlessly (and blow the resolution up) though the analysis'
+  /// answer never changes.
+  ///
+  /// `model` caps `branches(_ members:)` before this runs, so the enumeration
+  /// is bounded. The field walk needs no diagnostics: `collect` has already
+  /// validated the shapes and fired any field diagnostic.
+  private static func resolutions(_ members: MemberBlockItemListSyntax)
+      -> Array<Resolution> {
+    var properties = Array<Field>()
+    var initializers = Array<InitializerDeclSyntax>()
+    var index = members.startIndex
+    while index != members.endIndex {
+      let decl = members[index].decl
+      if let binding = decl.as(VariableDeclSyntax.self) {
+        properties.append(contentsOf: fields(of: binding))
+      } else if let initializer = decl.as(InitializerDeclSyntax.self) {
+        initializers.append(initializer)
+      } else if let block = decl.as(IfConfigDeclSyntax.self),
+                pertinent(block) {
+        break
+      }
+      index = members.index(after: index)
+    }
+    guard index != members.endIndex,
+          let block = members[index].decl.as(IfConfigDeclSyntax.self) else {
+      return [Resolution(fields: properties, inits: initializers)]
+    }
+    let after = members.index(after: index)
+    let rest = MemberBlockItemListSyntax(members[after...])
+    // Splice each clause's members ahead of `rest` and recurse, so the
+    // remaining top-level members join every clause selection.
+    func joined(_ clause: MemberBlockItemListSyntax?) -> Array<Resolution> {
+      let head = clause.map { Array($0) } ?? []
+      let spliced = MemberBlockItemListSyntax(head + Array(rest))
+      return resolutions(spliced).map { resolution in
+        Resolution(fields: properties + resolution.fields,
+                   inits: initializers + resolution.inits)
+      }
+    }
+    var builds = Array<Resolution>()
+    for clause in block.clauses {
+      guard case let .decls(members)? = clause.elements else {
+        builds += joined(nil)
+        continue
+      }
+      builds += joined(members)
+    }
+    // A block without a source `#else` still has the "no clause active" build,
+    // which omits the block's members.
+    if block.clauses.last?.condition != nil {
+      builds += joined(nil)
+    }
+    return builds
+  }
+
+  /// Whether `block` carries a stored field or an initializer in any clause, at
+  /// any depth — the predicate that decides a block matters to the resolution
+  /// enumeration. A block of only helper methods, computed properties, or
+  /// typealiases (or a nested block of the same) varies neither the active
+  /// fields nor the active inits, so `resolutions` skips it. A block carrying
+  /// an init but no field is still pertinent: the init suppresses the
+  /// memberwise init in the builds that compile it, which the analysis must
+  /// weigh even though `collect` drops the field-less block from the emitted
+  /// segments.
+  private static func pertinent(_ block: IfConfigDeclSyntax) -> Bool {
+    block.clauses.contains { clause in
+      guard case let .decls(members)? = clause.elements else { return false }
+      return members.contains { member in
+        let decl = member.decl
+        if let binding = decl.as(VariableDeclSyntax.self) {
+          return !fields(of: binding).isEmpty
+        }
+        if decl.is(InitializerDeclSyntax.self) { return true }
+        if let nested = decl.as(IfConfigDeclSyntax.self) {
+          return pertinent(nested)
+        }
+        return false
+      }
+    }
+  }
+
+  /// The number of distinct builds the resolution enumeration visits — the
+  /// product over each PERTINENT `#if` block of the sum of its clauses' build
+  /// counts, plus one for the synthesized "no clause active" build a block
+  /// without a source `#else` gains. A non-pertinent block `resolutions` skips
+  /// contributes no factor, matching the enumeration.
+  ///
+  /// This is the resolution cartesian, not the emission branch count
+  /// `branches(_ segments:)` caps: an init-only `#if` is dropped from the
+  /// segments (so that overload sees one branch) yet still branches the
+  /// resolution here. Like it, the product SATURATES at `cap + 1`, so many
+  /// blocks cannot overflow `Int` before `model`'s `<= cap` guard raises
+  /// `.conditional`.
+  private static func branches(_ members: MemberBlockItemListSyntax) -> Int {
+    var product = 1
+    for member in members {
+      guard let block = member.decl.as(IfConfigDeclSyntax.self),
+            pertinent(block) else { continue }
+      var sum = block.clauses.reduce(0) { partial, clause in
+        guard case let .decls(members)? = clause.elements else {
+          return partial
+        }
+        return partial + branches(members)
+      }
+      if block.clauses.last?.condition != nil { sum += 1 }
+      let (scaled, overflow) = product.multipliedReportingOverflow(by: sum)
+      guard !overflow, scaled <= cap else { return cap + 1 }
+      product = scaled
+    }
+    return product
+  }
+
+  /// The stored fields `binding` declares, in declaration order — the same
+  /// fields `collect` gathers, without the diagnostics it has already fired.
+  /// Skips a type-level member, a computed property, and (mirroring the
+  /// deserialize side that owns the resolution analysis) an initialized `let`,
+  /// none of which is a memberwise parameter.
+  private static func fields(of binding: VariableDeclSyntax) -> Array<Field> {
+    guard !typed(binding.modifiers) else { return [] }
+    let constant = binding.bindingSpecifier.tokenKind == .keyword(.let)
+    var fields = Array<Field>()
+    for (pattern, type) in bindings(of: binding) {
+      guard !computed(pattern.accessorBlock) else { continue }
+      guard !(constant && pattern.initializer != nil) else { continue }
+      append(pattern.pattern, typed: type, to: &fields)
+    }
+    return fields
+  }
+
+  /// Whether `resolution` needs no `.initializer` diagnostic: either no init is
+  /// active in the build (the memberwise init is synthesized) or an active init
+  /// is a callable replacement covering the build's active fields by label AND
+  /// type. An active init present but none covering leaves the suppressed
+  /// memberwise init with no callable `Self(…)` target, so the build is
+  /// unresolvable and the caller diagnoses.
+  private static func resolvable(_ resolution: Resolution,
+                                 under gate: Array<String>) -> Bool {
+    resolution.inits.isEmpty
+        || resolution.inits.contains { covers($0, resolution.fields,
+                                              under: gate) }
+  }
+
+  /// Whether `resolution`'s active inits leave the emitted `Self(<labels>: …)`
+  /// call with no unique best-ranked candidate, so the caller diagnoses.
+  ///
+  /// An init stays viable against the typed call — each typed field read
+  /// `decode() as <type>` — only if its matched parameter matches the field by
+  /// label AND type; a type-less field stays a bare `decode()`, so it is kept
+  /// live by LABEL alone (the annotation cannot break a tie resting on it).
+  /// Fewer than two viable inits is unambiguous. When two or more stay viable,
+  /// Swift ranks an EXACT candidate — parameters corresponding one-to-one to
+  /// the fields, no extra parameter — above one that needs a defaulted extra
+  /// parameter, so a UNIQUE exact candidate resolves the call and is not a tie.
+  /// The set is ambiguous only when no unique best candidate exists: either no
+  /// exact candidate (two overloads each needing a different default) or two or
+  /// more equally exact candidates (a type-less field they share by label).
+  private static func ambiguous(_ resolution: Resolution,
+                                under gate: Array<String>) -> Bool {
+    let live = resolution.inits.filter { callable($0, under: gate)
+        && inferable($0, resolution.fields)
+        && consistent($0, resolution.fields)
+        && viable(parameters(of: $0), resolution.fields,
+                  generics: generics(of: $0)) }
+    guard live.count >= 2 else { return false }
+    let exact = live.filter {
+      exact(parameters(of: $0), resolution.fields, generics: generics(of: $0))
+    }
+    return exact.count != 1
+  }
+
+  /// Whether the typed `Self(<fields>: …)` call resolves `parameters` EXACTLY:
+  /// viable, and every parameter is matched to a field with no extra parameter
+  /// left over (`parameters.count == fields.count`). An exact match is the
+  /// memberwise-equivalent init Swift ranks above an overload that relies on a
+  /// defaulted extra parameter.
+  private static func exact(_ parameters: Array<FunctionParameterSyntax>,
+                            _ fields: Array<Field>,
+                            generics: Set<String>) -> Bool {
+    parameters.count == fields.count
+        && viable(parameters, fields, generics: generics)
+  }
+
+  /// Whether the typed `Self(<fields>: …)` call keeps `parameters` viable: the
+  /// `covers` subsequence-with-defaults rule, matching each parameter to its
+  /// field by label — and by TYPE when the field carries one (the annotation
+  /// fixes it), by label alone when it does not. A parameter whose type IS one
+  /// of the init's own `generics` matches by label: the passed field fixes the
+  /// generic, so the spelling need not equal the field's.
+  private static func viable(_ parameters: Array<FunctionParameterSyntax>,
+                             _ fields: Array<Field>,
+                             generics: Set<String>) -> Bool {
+    var field = 0
+    for parameter in parameters {
+      let matched = field < fields.count
+          && matches(parameter, fields[field], generics: generics)
+      if matched {
+        field += 1
+      } else if parameter.defaultValue == nil {
+        return false
+      }
+    }
+    return field == fields.count
+  }
+
+  /// Whether `parameter` matches `field` for the viable/exact overload check: a
+  /// type-less field matches by LABEL alone (the bare `decode()` cannot fix the
+  /// type), a typed field matches by label AND type (`passes`) OR by label when
+  /// the parameter's type is one of the init's `generics` (the field's decoded
+  /// value fixes the generic).
+  private static func matches(_ parameter: FunctionParameterSyntax,
+                              _ field: Field,
+                              generics: Set<String>) -> Bool {
+    if field.type == nil { return labelled(parameter, field) }
+    return passes(parameter, field)
+        || generic(parameter, field, generics: generics)
+  }
+
+  /// The generic parameter names `initializer` declares — its own `<…>` clause,
+  /// the set `inferable` and the overload matching consult so a parameter typed
+  /// as one of them is matched by label and bound by the passed field.
+  private static func generics(of initializer: InitializerDeclSyntax)
+      -> Set<String> {
+    Set(initializer.genericParameterClause?.parameters
+        .map { $0.name.text } ?? [])
+  }
+
+  /// Whether `parameter`'s type is exactly one of the init's `generics` and its
+  /// label is `field.name` — a generic parameter the passed field binds, so the
+  /// derive's `Self(<field>: decode() as <fieldtype>)` supplies the type. The
+  /// parameter must carry no specifier the memberwise init lacks (`passes`
+  /// enforces the same for a concrete parameter).
+  private static func generic(_ parameter: FunctionParameterSyntax,
+                              _ field: Field, generics: Set<String>) -> Bool {
+    guard labelled(parameter, field), !specified(parameter.type),
+          let identifier = parameter.type.as(IdentifierTypeSyntax.self),
+          identifier.genericArgumentClause == nil else {
+      return false
+    }
+    return generics.contains(identifier.name.text)
+  }
+
+  /// Whether `initializer` covers the build's `fields` by label AND type and is
+  /// plainly callable, so the derive's `Self(<fields>)` resolves against it —
+  /// the label-and-type-parity check plus the callability guard.
+  ///
+  /// Label parity alone does not suffice: `struct S { var x: Int;
+  /// init(x: String) }` suppresses the memberwise init and matches on the `x`
+  /// label, yet the derive's `try Self(x: deserializer.decode())` infers
+  /// `decode` as `String` while serialize writes `self.x` as `Int` — a shape a
+  /// non-self-converting format round-trips wrong. So each parameter's trimmed
+  /// type spelling must equal the corresponding field's. A field with no
+  /// captured type (`Field.type == nil`: an inferred `var count = 0`, or a
+  /// tuple element) makes equivalence unprovable, so it is a non-match.
+  ///
+  /// A field a `#if` guards is absent from the builds that omit its clause, so
+  /// the `Self(<active fields>)` for such a build passes a SUBSET of the init's
+  /// parameters. `covers` (below) enforces that every skipped parameter carries
+  /// a default, and a mutually-exclusive field is active once per build, so
+  /// `#if A var x #else var x #endif; init(x:)` covers each build's single `x`
+  /// while `var base; #if A var x #endif; init(base:x:)` needs `x` defaulted.
+  private static func covers(_ initializer: InitializerDeclSyntax,
+                             _ fields: Array<Field>,
+                             under gate: Array<String>) -> Bool {
+    callable(initializer, under: gate)
+        && inferable(initializer, fields)
+        && consistent(initializer, fields)
+        && covers(parameters(of: initializer), fields,
+                  generics: generics(of: initializer))
+  }
+
+  /// Whether every generic parameter `initializer` declares is INFERABLE from
+  /// the fields the derive's `Self(<fields>: …)` actually passes — the types of
+  /// the parameters matched to a field, not the skipped defaulted ones.
+  ///
+  /// A generic parameter reachable only through a SKIPPED defaulted parameter
+  /// cannot be inferred at the call: `init<U>(x: Int, y: U? = nil)` covers a
+  /// lone `x` field by defaulting `y`, but the emitted `Self(x: … as Int)`
+  /// passes no argument mentioning `U`, so `U` is unbound and the call fails to
+  /// type-check. Rejecting such a candidate leaves the suppressed memberwise
+  /// init with no callable replacement, so the normal `.initializer` diagnostic
+  /// fires rather than uncompilable code. A non-generic init is inferable;
+  /// an init whose every generic parameter appears in a PASSED parameter's type
+  /// (`init<U>(x: U)` matched to `x`) is inferable and stays a candidate.
+  private static func inferable(_ initializer: InitializerDeclSyntax,
+                                _ fields: Array<Field>) -> Bool {
+    let generics = generics(of: initializer)
+    guard !generics.isEmpty else { return true }
+    var mentioned = Set<String>()
+    var field = 0
+    for parameter in parameters(of: initializer) {
+      guard field < fields.count,
+            matches(parameter, fields[field], generics: generics) else {
+        continue
+      }
+      mentioned.formUnion(references(parameter.type))
+      field += 1
+    }
+    return generics.isSubset(of: mentioned)
+  }
+
+  /// Whether the field types the derive's `Self(<fields>: …)` passes bind each
+  /// of `initializer`'s generic parameters CONSISTENTLY — no generic bound to
+  /// two different field types across the parameters it types.
+  ///
+  /// `init<U>(x: U, y: U)` matched to `var x: Int; var y: String` accepts each
+  /// parameter by label alone (a generic-typed parameter matches by label, the
+  /// passed field fixing the type), so the label-and-subsequence checks read it
+  /// as covering — but the emitted `Self(x: … as Int, y: … as String)` infers
+  /// `U` as both `Int` and `String`, a conflict Swift rejects. Recording the
+  /// field type each generic-typed parameter binds and rejecting a second,
+  /// DIFFERENT binding for the same generic keeps such an init from being a
+  /// candidate, so the normal `.initializer` diagnostic fires rather than a
+  /// `Self(…)` that will not compile. A generic bound to ONE type throughout
+  /// (`var x: Int; var y: Int; init<U>(x: U, y: U)`) is consistent and covers.
+  /// A field of no captured type cannot conflict-check (its bound type is
+  /// unknown), so it records nothing and leaves the generic free.
+  private static func consistent(_ initializer: InitializerDeclSyntax,
+                                 _ fields: Array<Field>) -> Bool {
+    let generics = generics(of: initializer)
+    guard !generics.isEmpty else { return true }
+    var bindings = Dictionary<String, String>()
+    var field = 0
+    for parameter in parameters(of: initializer) {
+      guard field < fields.count,
+            matches(parameter, fields[field], generics: generics) else {
+        continue
+      }
+      defer { field += 1 }
+      guard generic(parameter, fields[field], generics: generics),
+            let identifier = parameter.type.as(IdentifierTypeSyntax.self),
+            let bound = fields[field].type else {
+        continue
+      }
+      let name = identifier.name.text
+      if let existing = bindings[name], existing != bound { return false }
+      bindings[name] = bound
+    }
+    return true
+  }
+
+  /// Whether `initializer` is plainly callable as the derive's synchronous
+  /// `Self(…)` in a `throws(D.Failure)` context — non-failable, non-throwing,
+  /// non-async, non-isolated, and callable-and-warning-free under `@available`.
+  ///
+  /// A failable `init?` yields `Self?`, not the `Self` the derive binds; a
+  /// `throws` (or `throws(SomeError)`) init raises an error the typed-throws
+  /// context cannot absorb, though a `throws(Never)` init is nonthrowing and
+  /// stays callable (`nonthrowing`); an `async` init cannot be awaited from the
+  /// synchronous call. A custom
+  /// (non-built-in) attribute — a global actor such as `@MainActor` — imposes
+  /// actor isolation the nonisolated `deserialize` witness cannot honor. A
+  /// non-isolation built-in attribute (`@inlinable`, `@objc`, …) is harmless.
+  /// `@available` is callable only when it leaves the init callable and
+  /// warning-free: an `unavailable`/`obsoleted:` argument makes it uncallable
+  /// and a `deprecated` argument warns at the `Self(…)` call (which the
+  /// warning-free build rejects), so either disqualifies it — UNLESS the
+  /// deprecation is covered by `gate`, the type's own `@available` the
+  /// extension copies. A deprecated init gated the SAME as a deprecated type is
+  /// called from a deprecated extension, where the call raises no warning, so
+  /// it stays callable; a deprecation the extension does not carry still warns
+  /// and disqualifies. A version restriction — a platform `introduced:` or
+  /// short-form version such as `@available(macOS 99, *)`, or `@available(swift
+  /// 99)` — disqualifies the init only when it is NOT covered by `gate`: one
+  /// gated the SAME as the type is emitted under that gate and IS callable,
+  /// while a NARROWER one gates the init to a version the witness is not
+  /// emitted under, so `Self(…)` would call an unavailable init. See
+  /// `isolating`, `unavailable`, `restricted`.
+  private static func callable(_ initializer: InitializerDeclSyntax,
+                               under gate: Array<String>) -> Bool {
+    guard initializer.optionalMark == nil else { return false }
+    guard !isolating(initializer.attributes) else { return false }
+    guard !unavailable(initializer.attributes, under: gate) else {
+      return false
+    }
+    guard !restricted(initializer.attributes, under: gate) else {
+      return false
+    }
+    let effects = initializer.signature.effectSpecifiers
+    return nonthrowing(effects?.throwsClause)
+        && effects?.asyncSpecifier == nil
+  }
+
+  /// Whether `clause` leaves the init NONTHROWING at the call site — no clause
+  /// at all, or a TYPED `throws(Never)`, which Swift treats as nonthrowing (the
+  /// derive's `Self(…)` needs no `try`, and where a field's `decode()` already
+  /// forces `try`, the extra nonthrowing init raises nothing). A plain `throws`
+  /// or a `throws(SomeError)` over a real error type raises an error the
+  /// derive's `throws(D.Failure)` context cannot absorb, so it stays throwing.
+  private static func nonthrowing(_ clause: ThrowsClauseSyntax?) -> Bool {
+    guard let clause else { return true }
+    guard let type = clause.type?.as(IdentifierTypeSyntax.self) else {
+      return false
+    }
+    return type.genericArgumentClause == nil && type.name.text == "Never"
+  }
+
+  /// The `initializer`'s parameters as an array.
+  private static func parameters(of initializer: InitializerDeclSyntax)
+      -> Array<FunctionParameterSyntax> {
+    Array(initializer.signature.parameterClause.parameters)
+  }
+
+  /// Whether the derive's `Self(<fields>)` call — passing `fields`, in order,
+  /// by their memberwise labels — resolves against `parameters`, the init's
+  /// parameter list.
+  ///
+  /// Swift matches call arguments to parameters in declaration order and lets a
+  /// defaulted parameter be skipped, so the branch's `fields` must be a
+  /// SUBSEQUENCE of `parameters` (matched by label AND type), and every skipped
+  /// parameter must carry a default. A parameter matched to a field must also
+  /// be a spelling the memberwise init could have — no wildcard label
+  /// (positional, matching no named field), no `inout`/ownership/`isolated`
+  /// specifier (a by-value rvalue cannot satisfy it), and a field of no
+  /// captured type is unprovable — any of which makes it a non-match.
+  private static func covers(_ parameters: Array<FunctionParameterSyntax>,
+                             _ fields: Array<Field>,
+                             generics: Set<String>) -> Bool {
+    var field = 0
+    for parameter in parameters {
+      // The covers path demands type parity for safety: a field with no
+      // captured type is unprovable and never matches (unlike the viable path,
+      // which keeps a type-less field live by label). A parameter typed as one
+      // of the init's own `generics` still matches by label — the passed typed
+      // field binds the generic — so an `init<U>(x: U)` covers a typed `x`.
+      let matched = field < fields.count
+          && fields[field].type != nil
+          && (passes(parameter, fields[field])
+                || generic(parameter, fields[field], generics: generics))
+      if matched {
+        field += 1
+      } else if parameter.defaultValue == nil {
+        // A parameter this branch does not pass — because its field is inactive
+        // — must default, or the shorter `Self(…)` call cannot resolve.
+        return false
+      }
+    }
+    // Every active field must have found a parameter, in order.
+    return field == fields.count
+  }
+
+  /// Whether `parameter` is the one the derive's `Self(…)` passes `field` to:
+  /// its external label is `field.name`, its type equals the field's, and it
+  /// carries no specifier the memberwise init lacks.
+  private static func passes(_ parameter: FunctionParameterSyntax,
+                             _ field: Field) -> Bool {
+    guard labelled(parameter, field) else { return false }
+    // A parameter specifier — `inout`, `borrowing`, `consuming`, or any other
+    // the parser attaches to the type — is one the memberwise init never
+    // carries, and the derive's `Self(<field>: deserializer.decode())` passes a
+    // by-value rvalue an `inout` (or ownership-annotated) parameter will not
+    // accept. Its type parses as an `AttributedTypeSyntax` whose specifiers
+    // (`inout Int` → a `SimpleTypeSpecifier`) are non-empty, so reject any such
+    // parameter rather than accept an init the emitted call cannot compile
+    // against.
+    guard !specified(parameter.type) else { return false }
+    guard let type = field.type else { return false }
+    return parameter.type.trimmedDescription == type
+  }
+
+  /// Whether `parameter`'s external label is `field.name` — the label-only half
+  /// of `passes`, so `Self(<field>: …)` names this parameter regardless of the
+  /// TYPES the generic `decode()` cannot fix yet. `viable` uses it to keep a
+  /// type-less field's init live; `passes` adds the specifier and type check.
+  private static func labelled(_ parameter: FunctionParameterSyntax,
+                               _ field: Field) -> Bool {
+    // A `_` first name is the WILDCARD: the parameter has NO external label and
+    // is passed positionally, unlike a field named `_`, whose memberwise label
+    // is the escaped `` `_` ``. `Identifier` would canonicalize both to the
+    // string `"_"` and conflate them, so `init(_ x: Int)` would falsely match
+    // `var _: Int` — yet the derive emits `` Self(`_`: …) ``, a real label that
+    // does not resolve to the positional init. A positional parameter matches
+    // no named field, so treat the wildcard as unmatchable.
+    guard parameter.firstName.tokenKind != .wildcard else { return false }
+    let label = Identifier(parameter.firstName)?.name
+        ?? parameter.firstName.text
+    return label == field.name
+  }
+
+  /// Whether `type` carries a parameter specifier the synthesized memberwise
+  /// initializer would never spell — `inout` or an ownership modifier
+  /// (`borrowing`/`consuming`), and any other specifier the parser attaches. A
+  /// specified parameter type parses as an `AttributedTypeSyntax` whose
+  /// `specifiers` list holds the modifier, so a non-empty list is the signal;
+  /// the derive's by-value `Self(<field>: …)` call cannot satisfy such a
+  /// parameter, so a carrying init must not match.
+  private static func specified(_ type: TypeSyntax) -> Bool {
+    guard let attributed = type.as(AttributedTypeSyntax.self) else {
+      return false
+    }
+    return !attributed.specifiers.isEmpty
+  }
+
+  /// Whether `attributes` carry an attribute that could impose actor isolation
+  /// on the initializer — any custom attribute, since a global actor
+  /// (`@MainActor`, or a custom `@SomeGlobalActor`) is a custom attribute. An
+  /// isolated init cannot be called from the derive's synchronous, nonisolated
+  /// `deserialize` witness, so the init is not a memberwise-equivalent
+  /// replacement. A Swift built-in declaration attribute (`builtins`, e.g.
+  /// `@inlinable` / `@available`) does not affect the synchronous nonisolated
+  /// call and passes here; the trailing name is matched so a qualified spelling
+  /// is covered too, like `wrapped`. `@available` is a built-in, so its
+  /// isolation is a non-issue — but its ARGUMENTS may still make the init
+  /// uncallable or warning-carrying, which `unavailable` checks separately.
+  private static func isolating(_ attributes: AttributeListSyntax) -> Bool {
+    attributes.contains { attribute in
+      guard case let .attribute(attribute) = attribute,
+            let name = trailing(attribute.attributeName) else {
+        return false
+      }
+      return !builtins.contains(name)
+    }
+  }
+
+  /// Whether `attributes` carry an `@available` that stops the derive's
+  /// `Self(<field>: …)` call from a clean compile — an `unavailable`/
+  /// `obsoleted:` argument, which makes the init uncallable, or a `deprecated`
+  /// argument the enclosing extension does NOT itself carry ON THE SAME
+  /// PLATFORM, whose call then warns and so breaks the warning-free build. A
+  /// plain platform availability (`@available(macOS 10.0, *)`, only `introduced`
+  /// / `*` / version restrictions) is harmless and reports `false`.
+  ///
+  /// The check is SEMANTIC and PER PLATFORM, not by exact gate text. The init's
+  /// attributes and `gate` — the type's copied `@available` spellings the
+  /// extension repeats — each parse into an ``Availability`` model keyed by
+  /// platform (`macOS`, `iOS`, …, `swift`, and the `*` fallback). An
+  /// `unavailable`/`obsoleted:` on ANY platform disqualifies unconditionally:
+  /// the deprecated extension does not make an unavailable init callable, so
+  /// those stay rejected by their mere presence. A `deprecation` is EXCUSED only
+  /// where covered: for EACH platform the init is deprecated on, the type must
+  /// ALSO be deprecated on that same platform (at the same or an earlier
+  /// version), so the `Self(…)` call sits inside a matching deprecated context
+  /// where Swift suppresses the warning. A type deprecated only on `macOS` does
+  /// NOT cover an init deprecated on `iOS`, since an `iOS` build's extension is
+  /// not `iOS`-deprecated and the call there would warn.
+  ///
+  /// `unavailable` and a bare `deprecated` are unlabeled identifier tokens in
+  /// the argument list; `obsoleted:` and `deprecated:` (with a version) are
+  /// labeled arguments. Both spellings are modelled. Only `@available` carries
+  /// availability arguments, so a non-`@available` attribute contributes nothing
+  /// and its isolation, if any, is left to `isolating`.
+  private static func unavailable(_ attributes: AttributeListSyntax,
+                                  under gate: Array<String>) -> Bool {
+    let initializer = availability(attributes)
+    guard !initializer.disqualified else { return true }
+    return !covers(deprecation: availability(gate), initializer)
+  }
+
+  /// Whether `type` — the extension's own parsed availability — covers every
+  /// platform-scoped deprecation `initializer` carries, so the derive's
+  /// `Self(…)` call raises no deprecation warning. A deprecated init is
+  /// warning-free ONLY inside an extension that is deprecated on the SAME
+  /// platform: Swift suppresses the warning in a deprecated context, and the
+  /// extension inherits the type's per-platform deprecation. So for each
+  /// platform the init is deprecated on, the type must be deprecated on that
+  /// platform too, at the same or an earlier version (an earlier type
+  /// deprecation still spans the init's). An init deprecation the type does not
+  /// match on its platform would warn on a build of that platform, so it is not
+  /// covered. The `*` fallback deprecates every platform, so a `*`-deprecated
+  /// type covers any init deprecation and a `*`-deprecated init needs the type
+  /// deprecated on `*` too.
+  private static func covers(deprecation type: Availability,
+                             _ initializer: Availability) -> Bool {
+    initializer.deprecations.allSatisfy { platform, version in
+      guard let cover = type.deprecation(on: platform) else { return false }
+      return precedes(cover, version)
+    }
+  }
+
+  /// Whether `attributes` gate the init to a VERSION or PLATFORM the generated
+  /// witness is not itself emitted under — an availability the extension's own
+  /// gate does NOT cover, so the init is a NARROWER replacement `Self(…)` could
+  /// call where it does not exist.
+  ///
+  /// The check is SEMANTIC and PER PLATFORM. The init's attributes and `gate` —
+  /// the type's copied `@available` spellings the extension repeats — parse into
+  /// an ``Availability`` model, and the init COVERS the extension iff, on every
+  /// platform the extension is available, the init is available there too at the
+  /// same or an EARLIER introduced version. A same-or-BROADER init gate is fine:
+  /// an `@available(macOS 10.0, iOS 13.0, *)` type with an `@available(macOS
+  /// 10.0, *)` init is covered, since the init's `*` fallback makes it available
+  /// wherever the extension is (its `iOS` context included). A NARROWER gate —
+  /// `@available(macOS 99, *)` under a `macOS 10.0` type, or a
+  /// version-restricted init under an ungated type — leaves `Self(…)`
+  /// uncallable below the init's floor yet callable at the witness's, a mismatch
+  /// the macro cannot guarantee away, so `callable` rejects it and the
+  /// `.initializer` diagnostic (or memberwise fallback) applies. `unavailable`/
+  /// `obsoleted:`/`deprecated` are NOT restrictions here — they are left to
+  /// `unavailable` — so a purely deprecating gate never trips this.
+  private static func restricted(_ attributes: AttributeListSyntax,
+                                 under gate: Array<String>) -> Bool {
+    !covers(introduction: availability(gate), availability(attributes))
+  }
+
+  /// Whether `initializer` is introduced no later than `type` on every platform
+  /// EITHER model restricts, so the derive's `Self(…)` reaches it wherever the
+  /// extension exists.
+  ///
+  /// The extension inherits `type`'s per-platform floor; an `@available` names
+  /// only the platforms it RESTRICTS and leaves every other platform available
+  /// with no floor (`introduction(on:)` reports that unrestricted floor). So the
+  /// init covers the extension iff, on each platform either names, the init's
+  /// floor is at or below the type's. A same-or-BROADER init is fine — an
+  /// `@available(macOS 10.0, iOS 13.0, *)` type with an `@available(macOS 10.0,
+  /// *)` init covers `iOS` through the init's unrestricted fallback. A platform
+  /// the INIT restricts but the type does not (a narrower `swift` version, say)
+  /// has a type floor of nothing and an init floor above it, so it is not
+  /// covered; likewise a later init floor on a shared platform, or any init
+  /// restriction under an ungated type.
+  private static func covers(introduction type: Availability,
+                             _ initializer: Availability) -> Bool {
+    let platforms = Set(type.introductions.keys)
+        .union(initializer.introductions.keys)
+    return platforms.allSatisfy { platform in
+      precedes(initializer.introduction(on: platform),
+               type.introduction(on: platform))
+    }
+  }
+
+  /// A semantic per-platform reading of a declaration's `@available` gate — the
+  /// single model the coverage predicates compare, replacing the earlier
+  /// exact-attribute-text and single-boolean checks so a NARROWER platform or
+  /// version cannot slip through a shallow match.
+  ///
+  /// Each platform Swift restricts — `macOS`, `iOS`, …, the pseudo-platform
+  /// `swift`, and the `*` wildcard fallback — maps to the state the gate assigns
+  /// it: its introduced-version floor, its deprecation (present, with an
+  /// optional version), and whether an `unavailable`/`obsoleted:` disqualifies
+  /// it outright. A platform NO `@available` names is unrestricted — available
+  /// from version zero, not deprecated — which the accessors report by falling
+  /// back to the `*` wildcard and then to that unrestricted default. A version
+  /// is a `[Int]` component list ordered by `precedes`; a missing version reads
+  /// as the zero floor, since an unversioned `deprecated`/`introduced` spans
+  /// every version.
+  private struct Availability {
+    /// One platform's gate state — its introduced floor, its deprecation, and
+    /// whether a hard `unavailable`/`obsoleted:` disqualifies it.
+    fileprivate struct State {
+      fileprivate var introduced: Array<Int>?
+      fileprivate var deprecated: Array<Int>??
+      fileprivate var disqualified: Bool = false
+    }
+
+    /// The per-platform states, keyed by platform name (`*` for the wildcard).
+    fileprivate var states: Dictionary<String, State> = [:]
+
+    /// Whether ANY platform carries a hard `unavailable`/`obsoleted:`, which
+    /// disqualifies the init unconditionally — the deprecated extension never
+    /// makes an unavailable init callable.
+    fileprivate var disqualified: Bool {
+      states.values.contains { $0.disqualified }
+    }
+
+    /// The introduced floor of every platform this gate RESTRICTS with one,
+    /// keyed by platform — the platforms `covers(introduction:)` weighs. The
+    /// `*` wildcard carries no floor, so it never appears here.
+    fileprivate var introductions: Dictionary<String, Array<Int>> {
+      states.compactMapValues(\.introduced)
+    }
+
+    /// The deprecation of every platform this gate deprecates, keyed by platform
+    /// (a missing version reads as the zero floor) — the entries
+    /// `covers(deprecation:)` must each find matched on the type.
+    fileprivate var deprecations: Dictionary<String, Array<Int>> {
+      states.compactMapValues { $0.deprecated.map { $0 ?? [] } }
+    }
+
+    /// The introduced floor `platform` reaches under this gate: its own when
+    /// named, else the `*` wildcard's, else the unrestricted zero floor — an
+    /// unnamed platform is available from the start.
+    fileprivate func introduction(on platform: String) -> Array<Int> {
+      states[platform]?.introduced
+          ?? states["*"]?.introduced
+          ?? []
+    }
+
+    /// The deprecation `platform` carries under this gate — its own when
+    /// deprecated, else the `*` wildcard's when it deprecates every platform,
+    /// else `nil` (not deprecated there). A missing version reads as the zero
+    /// floor, so an unversioned deprecation spans every version.
+    fileprivate func deprecation(on platform: String) -> Array<Int>? {
+      if let own = states[platform]?.deprecated { return own ?? [] }
+      if let wildcard = states["*"]?.deprecated { return wildcard ?? [] }
+      return nil
+    }
+  }
+
+  /// The ``Availability`` model of an attribute list — the init side of both
+  /// coverage predicates. Only `@available` attributes contribute; each folds
+  /// its per-platform arguments into the shared model.
+  private static func availability(_ attributes: AttributeListSyntax)
+      -> Availability {
+    var model = Availability()
+    for case let .attribute(attribute) in attributes
+        where trailing(attribute.attributeName) == "available" {
+      if case let .availability(arguments)? = attribute.arguments {
+        absorb(arguments, into: &model)
+      }
+    }
+    return model
+  }
+
+  /// The ``Availability`` model of the type's copied `@available` spellings —
+  /// the gate side of both coverage predicates. Each `gate` entry is a verbatim
+  /// `@available(...)` spelling `available` produced, so it re-parses into an
+  /// `AttributeSyntax` and folds into the shared model.
+  private static func availability(_ gate: Array<String>) -> Availability {
+    var model = Availability()
+    for spelling in gate {
+      let attribute: AttributeSyntax = "\(raw: spelling)"
+      if case let .availability(arguments)? = attribute.arguments {
+        absorb(arguments, into: &model)
+      }
+    }
+    return model
+  }
+
+  /// Folds one `@available` argument list into `model`, in either spelling.
+  ///
+  /// A SHORT form (`@available(macOS 10.0, iOS 13.0, *)`) lists a version
+  /// restriction per platform — each an introduced floor — trailed by a bare
+  /// `*` wildcard token; it carries no deprecation or unavailability. A LONG
+  /// form (`@available(macOS, deprecated: 10.0)`, `@available(*, unavailable)`)
+  /// LEADS with a single platform token — a name or `*` — that every following
+  /// keyword argument (`introduced:`/`deprecated:`/`obsoleted:`, or a bare
+  /// `deprecated`/`unavailable`) scopes to. Both a leading long-form `*` and a
+  /// trailing short-form `*` land in the same branch: the long form scopes its
+  /// following keywords to that `*`, while the short form's trailing `*` scopes
+  /// nothing, so tracking it is harmless. `message:`/`renamed:` carry no
+  /// availability and are ignored.
+  private static func absorb(_ arguments: AvailabilityArgumentListSyntax,
+                             into model: inout Availability) {
+    var platform: String? = nil
+    for argument in arguments {
+      switch argument.argument {
+      case let .availabilityVersionRestriction(restriction):
+        let floor = version(restriction.version)
+        model.states[restriction.platform.text, default: .init()]
+            .introduced = floor
+      case let .token(token):
+        if token.text == "deprecated" {
+          scope(platform) { $0.deprecated = .some(nil) }
+        } else if token.text == "unavailable" {
+          scope(platform) { $0.disqualified = true }
+        } else {
+          platform = token.text
+        }
+      case let .availabilityLabeledArgument(labeled):
+        absorb(labeled, on: platform, into: &model)
+      }
+    }
+
+    /// Applies `mutate` to the current long-form `platform`'s state, defaulting
+    /// a first mention. A bare `deprecated`/`unavailable` before any platform
+    /// token cannot occur in a well-formed gate, so an absent platform is a
+    /// no-op.
+    func scope(_ platform: String?,
+               _ mutate: (inout Availability.State) -> Void) {
+      guard let platform else { return }
+      mutate(&model.states[platform, default: .init()])
+    }
+  }
+
+  /// Folds one long-form labeled argument (`introduced:`/`deprecated:`/
+  /// `obsoleted:`, with a version) onto `platform`'s state. `obsoleted:`
+  /// disqualifies like `unavailable`; `message:`/`renamed:` are ignored.
+  private static func absorb(_ labeled: AvailabilityLabeledArgumentSyntax,
+                             on platform: String?,
+                             into model: inout Availability) {
+    guard let platform else { return }
+    let floor: Array<Int>?
+    if case let .version(tuple) = labeled.value { floor = version(tuple) }
+    else { floor = nil }
+    switch labeled.label.tokenKind {
+    case .keyword(.introduced):
+      model.states[platform, default: .init()].introduced = floor ?? []
+    case .keyword(.deprecated):
+      model.states[platform, default: .init()].deprecated = .some(floor)
+    case .keyword(.obsoleted):
+      model.states[platform, default: .init()].disqualified = true
+    default:
+      break
+    }
+  }
+
+  /// A version tuple as its ordered `[Int]` components — `10.0` as `[10, 0]` —
+  /// the shape `precedes` compares. A missing tuple is the empty (zero) floor.
+  private static func version(_ tuple: VersionTupleSyntax?) -> Array<Int> {
+    guard let tuple else { return [] }
+    let major = Int(tuple.major.text) ?? 0
+    let rest = tuple.components.compactMap { Int($0.number.text) }
+    return [major] + rest
+  }
+
+  /// Whether `first` is at or before `second` as a version — component-wise,
+  /// shorter padded with zeros, so `[10]` precedes `[10, 0]` and `[10, 0]`
+  /// precedes `[10, 1]`. The empty floor precedes every version.
+  private static func precedes(_ first: Array<Int>,
+                               _ second: Array<Int>) -> Bool {
+    let width = max(first.count, second.count)
+    for index in 0 ..< width {
+      let a = index < first.count ? first[index] : 0
+      let b = index < second.count ? second[index] : 0
+      if a != b { return a < b }
+    }
+    return true
+  }
+
+  /// The `@available` attributes on `declaration`, in source order, each as its
+  /// verbatim spelling — the attributes a conformance extension must repeat.
+  ///
+  /// When the annotated type is itself availability-limited — `@available(*,
+  /// deprecated)`, `@available(*, unavailable)`, or a platform gate such as
+  /// `@available(macOS, unavailable)` — a BARE `extension <Type>: …` references
+  /// the limited type and so WARNS (deprecated) or ERRORS (unavailable). The
+  /// generated extension must carry the same `@available` to stay callable and
+  /// warning-free, so the emission copies each attribute this returns onto the
+  /// `extension`. Only `@available` propagates: a property wrapper or other
+  /// attribute is irrelevant to the extension. The attribute name is matched on
+  /// its trailing component, like the other helpers, so a qualified spelling is
+  /// covered too. A type with no `@available` yields an empty array and the
+  /// emitted extension is unchanged.
+  internal static func available(_ declaration: some DeclGroupSyntax)
+      -> Array<String> {
+    available(declaration.attributes)
+  }
+
+  /// The `@available` spellings on an attribute list — the shared filter both
+  /// the direct-declaration and enclosing-context availability draw on.
+  private static func available(_ attributes: AttributeListSyntax)
+      -> Array<String> {
+    attributes.compactMap { attribute in
+      guard case let .attribute(attribute) = attribute,
+            trailing(attribute.attributeName) == "available" else {
+        return nil
+      }
+      return attribute.trimmedDescription
+    }
+  }
+
+  /// The `@available` spellings the ENCLOSING type context contributes, from
+  /// innermost enclosing type outward, so the generated extension carries the
+  /// availability of every type its qualified name references.
+  ///
+  /// A derived type nested in an availability-limited type — `@available(*,
+  /// unavailable) struct Outer { @Serializable struct Inner { … } }` — expands
+  /// to `extension Outer.Inner: …`, referencing the limited `Outer`; a bare
+  /// extension then ERRORS (`unavailable`) or WARNS (`deprecated`) as it
+  /// would for a limited annotated type. The direct declaration's own
+  /// `@available` is not enough, since the LIMITATION is on the enclosing type,
+  /// so the extension inherits the enclosing chain's gates too. The compiler
+  /// detaches the annotated declaration (its `.parent` is nil in the plugin),
+  /// but `MacroExpansionContext.lexicalContext` still yields the enclosing
+  /// declaration groups, so their `@available` is readable here.
+  ///
+  /// Each enclosing entry that is a type declaration contributes its verbatim
+  /// `@available` spellings; a non-type entry (a function or accessor the type
+  /// nests in) carries no relevant availability and adds none. A type nested at
+  /// top level has an empty enclosing context and inherits nothing.
+  internal static func available(enclosing context: Array<Syntax>)
+      -> Array<String> {
+    context.flatMap { entry -> Array<String> in
+      guard let group = group(entry) else { return [] }
+      return available(group.attributes)
+    }
+  }
+
+  /// The generic parameter names in scope at the derived type: its OWN clause
+  /// first, then every parameter each ENCLOSING lexical entry contributes,
+  /// innermost outward, deduplicated in that order.
+  ///
+  /// This is the SINGLE generic environment the derive computes: `constrained`
+  /// (the conformance's `where` clause), `inferred` (the unannotated-field
+  /// guard), and `inferable` (the init-candidate check) all consume it, so no
+  /// caller recomputes a partial view. An in-scope parameter a field mentions
+  /// gets a `where … : Serializable`/`Deserializable`, an unannotated field
+  /// whose initializer mentions one is diagnosed `.inferred`, and an init whose
+  /// own generic parameter is not one of these must be inferable from the
+  /// passed fields to be a callable replacement.
+  ///
+  /// The own clause and the enclosing chain both feed it, and — beyond an
+  /// enclosing generic TYPE, whose clause `parameters(enclosing:)` reads — an
+  /// enclosing EXTENSION contributes the generic environment of the type it
+  /// extends. A non-generic type in no generic context yields an empty array.
+  internal static func environment(of declaration: some DeclGroupSyntax,
+                                   enclosing context: Array<Syntax>)
+      -> Array<String> {
+    var scope = Array<String>()
+    func add(_ names: some Sequence<String>) {
+      for name in names where !scope.contains(name) { scope.append(name) }
+    }
+    if let structure = declaration.as(StructDeclSyntax.self) {
+      add(structure.genericParameterClause?.parameters
+          .map { $0.name.text } ?? [])
+    }
+    add(parameters(enclosing: context))
+    return scope
+  }
+
+  /// The generic parameter names every ENCLOSING lexical entry contributes,
+  /// innermost outward — the parameters in scope at the derived type beyond its
+  /// own.
+  ///
+  /// A type nested in a generic outer — `struct Outer<T> { @Serializable struct
+  /// Inner { var value: T } }` — stores the enclosing `T`, which the derive
+  /// must recognise as a generic parameter to constrain the conformance on. An
+  /// enclosing EXTENSION extends a generic type too — `extension Outer where T:
+  /// … { @Serializable struct Inner { var value: T } }` — so `T` is likewise in
+  /// scope; the extension contributes the generic arguments spelled on its
+  /// extended type (`extension Outer<T>`) AND the parameters its `where` clause
+  /// names, the only spellings from which the detached plugin can recover the
+  /// extended type's parameters (a bare `extension Outer` carries neither, so
+  /// it contributes none). As with `available(enclosing:)`, the detached
+  /// declaration cannot reach these, but `lexicalContext` yields the enclosing
+  /// groups. A non-generic or non-type/-extension entry contributes none.
+  internal static func parameters(enclosing context: Array<Syntax>)
+      -> Array<String> {
+    context.flatMap { entry -> Array<String> in
+      if let extended = entry.as(ExtensionDeclSyntax.self) {
+        return extending(extended)
+      }
+      return generics(entry)?.parameters.map { $0.name.text } ?? []
+    }
+  }
+
+  /// The generic parameter names an enclosing `extension` contributes: the
+  /// identifiers its extended type's generic argument clause spells
+  /// (`extension Outer<T>` → `T`) together with the SUBJECT of each `where`
+  /// requirement (`extension Outer where T: P` → `T`), deduplicated. A bare
+  /// `extension Outer` carries neither, so the detached plugin cannot recover
+  /// the extended type's parameters and the extension contributes none.
+  ///
+  /// Only a requirement's LEFT side (its subject) is a parameter reference; the
+  /// right side is the constraint (`P` in `T: P`), never a parameter to
+  /// constrain, so it is not collected.
+  private static func extending(_ extension: ExtensionDeclSyntax)
+      -> Array<String> {
+    var names = Set<String>()
+    if let identifier =
+        `extension`.extendedType.as(IdentifierTypeSyntax.self),
+       let arguments = identifier.genericArgumentClause {
+      collect(arguments, into: &names)
+    }
+    for requirement in `extension`.genericWhereClause?.requirements ?? [] {
+      switch requirement.requirement {
+      case let .conformanceRequirement(conformance):
+        names.formUnion(references(conformance.leftType))
+      case let .sameTypeRequirement(sameType):
+        collect(sameType.leftType, into: &names)
+      default:
+        break
+      }
+    }
+    return Array(names)
+  }
+
+  /// The `DeclGroupSyntax` an enclosing lexical entry names, or `nil` when the
+  /// entry is not a type declaration (a function/accessor the type nests in).
+  /// The concrete type declarations are matched individually: `DeclGroupSyntax`
+  /// is the shared shape whose `attributes` the availability walk reads.
+  private static func group(_ entry: Syntax) -> (any DeclGroupSyntax)? {
+    if let structure = entry.as(StructDeclSyntax.self) { return structure }
+    if let enumeration = entry.as(EnumDeclSyntax.self) { return enumeration }
+    if let classes = entry.as(ClassDeclSyntax.self) { return classes }
+    if let actor = entry.as(ActorDeclSyntax.self) { return actor }
+    if let extended = entry.as(ExtensionDeclSyntax.self) { return extended }
+    return nil
+  }
+
+  /// The generic parameter clause an enclosing lexical entry declares, or `nil`
+  /// when the entry is not a generic type declaration. An extension carries no
+  /// generic parameter clause of its own (its parameters come from the extended
+  /// type), so it contributes none.
+  private static func generics(_ entry: Syntax)
+      -> GenericParameterClauseSyntax? {
+    if let structure = entry.as(StructDeclSyntax.self) {
+      return structure.genericParameterClause
+    }
+    if let enumeration = entry.as(EnumDeclSyntax.self) {
+      return enumeration.genericParameterClause
+    }
+    if let classes = entry.as(ClassDeclSyntax.self) {
+      return classes.genericParameterClause
+    }
+    return nil
+  }
+
+  /// The generic PARAMETERS a conditional conformance must constrain — those a
+  /// serialized field type mentions, deduplicated in first-mention order.
+  ///
+  /// `serializer.field(…, self.<field>)` requires the field's value type to
+  /// conform to `Serializable`, and `deserializer.decode()` requires
+  /// `Deserializable`, so `struct Box<T> { var value: T }` type-checks only when
+  /// `T` does. An UNCONDITIONAL `extension Box: Decant.Serializable` therefore
+  /// fails; the correct derive is CONDITIONAL — `extension Box: … where …`.
+  ///
+  /// The requirement is expressed on the generic PARAMETERS the field type
+  /// mentions, not on the field's WRITTEN type: Swift's grammar rejects a
+  /// conformance requirement whose left side is an APPLIED concrete type
+  /// (`where Array<T>: …`, `where Wrapper<T>: …`) — the left side must be a
+  /// generic parameter or a dependent-member type — so an applied-type clause
+  /// fails to type-check before the generated body ever runs. Constraining the
+  /// mentioned parameters is always LEGAL (the left side is a generic
+  /// parameter) and, for a container whose conditional conformance is element-
+  /// driven (`Array<T>`, `Optional<T>`, `Set<T>`, `Dictionary<K, V>`), it is
+  /// the exact lowering: `Array<T>: Serializable` holds precisely when
+  /// `T: Serializable`, so `where T: Serializable` is neither weaker nor
+  /// stronger. For a general applied type (`Wrapper<T>`), the parameter
+  /// constraint is the tightest requirement Swift's grammar can express: the
+  /// exotic "conforms for EVERY `T`" wrapper cannot be captured as an extension
+  /// where-clause at all, so the mentioned parameter is the correct fallback.
+  ///
+  /// Only a parameter a field type mentions is constrained: a concrete
+  /// `var x: Int` mentions none (and `Int: Serializable` would be redundant),
+  /// and a phantom parameter no field mentions gets none. A non-generic type
+  /// nested in no generic context yields an empty array and the extension stays
+  /// unconditional.
+  ///
+  /// The in-scope generic parameters are the type's OWN clause AND every
+  /// parameter an ENCLOSING type declares (`enclosing`): a type nested in a
+  /// generic outer — `struct Outer<T> { @Serializable struct Inner { var value:
+  /// T } }` — has no own clause, yet `Inner`'s field stores the OUTER `T`, so
+  /// an UNCONDITIONAL `extension Outer.Inner: Serializable` type-checks for
+  /// every `T` while its body's `field(…, self.value)` needs `T: Serializable`
+  /// and fails to compile. Constraining the mentioned enclosing parameter —
+  /// `extension Outer.Inner: … where T: Serializable` — is the correct
+  /// conditional conformance. A parameter is a LEGAL requirement left side
+  /// however it is scoped, so an enclosing parameter constrains just as an own
+  /// one does.
+  ///
+  /// The direction selects the serialized fields — the deserialize side drops
+  /// an initialized `let`, as `model` does — so the constraint set matches the
+  /// fields the emission actually reads or writes. A parameter is emitted in
+  /// the order the type DECLARES it (own parameters first, then the enclosing
+  /// chain outward), so `Pair<A, B>` constrains `A` before `B` however the
+  /// fields mention them.
+  internal static func constrained(_ declaration: some DeclGroupSyntax,
+                                   for direction: Direction,
+                                   scope: Array<String>) -> Array<String> {
+    guard let structure = declaration.as(StructDeclSyntax.self) else {
+      return []
+    }
+    let environment = Set(scope)
+    // A field written through a SAME-SCOPE typealias hides the generic it
+    // resolves to: `struct S<T> { typealias Value = T; var value: Value }`
+    // records only `Value`, which is no in-scope parameter, so the naive walk
+    // emits NO `where T: …` and the generated unconditional extension then
+    // serializes an unconstrained `T` that fails to type-check. Expanding the
+    // field type through the type's own typealiases before the walk — `Value`
+    // to `T`, `[Value]` to `[T]` — surfaces the hidden parameter (or dependent
+    // member), so the correct conditional constraint is emitted.
+    let aliases = self.aliases(structure.memberBlock.members)
+    var mentioned = Set<String>()
+    var dependents = Array<String>()
+    for written in types(of: structure.memberBlock.members, for: direction) {
+      let type = expand(written, through: aliases)
+      // A field typed as — or WRAPPING — a dependent member of an in-scope
+      // parameter needs that member ITSELF to conform. A bare `T.Element` in
+      // `struct Box<T: Sequence> { var value: T.Element }` passes a `T.Element`
+      // to `field(…)` and decodes a `T.Element`; a wrapped `[T.Element]` (or
+      // `T.Element?`, `Wrapper<T.Element>`) serializes an `Array<T.Element>`
+      // whose conformance likewise rests on `T.Element`. Constraining the base
+      // `T` supplies neither, and would wrongly forbid a sequence whose ELEMENT
+      // alone is serializable. A dependent member is a LEGAL where-clause left
+      // side (unlike an applied `Wrapper<T>`), so emit the full `T.Element` as
+      // the requirement — descending the wrapper to reach it — rather than
+      // reduce it to `T`. A type surfacing no dependent member lowers to the
+      // parameters it mentions (a bare `T`, a container's element parameter, or
+      // a general applied type's mentioned parameters), the tightest legal
+      // requirement Swift's grammar expresses for it.
+      let members = self.dependents(of: type, in: environment)
+      guard members.isEmpty else {
+        for member in members where !dependents.contains(member) {
+          dependents.append(member)
+        }
+        continue
+      }
+      mentioned.formUnion(references(type))
+    }
+    return scope.filter { mentioned.contains($0) } + dependents
+  }
+
+  /// The SAME-SCOPE typealiases `members` declare, mapping each alias name to
+  /// its aliased type — the `typealias Value = T` declarations in the type's
+  /// own member block, which `expand` substitutes to surface a generic
+  /// parameter a field hides behind an alias.
+  ///
+  /// Only a plain (non-generic) alias contributes: a `typealias Boxed<U> =
+  /// Wrapper<U>` binds its own parameter and does not stand for an outer
+  /// parameter, so substituting a field's `Boxed<T>` for it would misread its
+  /// argument. A `#if`-guarded alias is not descended — an alias resolving
+  /// differently per branch is out of scope, so it is left to the compiler.
+  private static func aliases(_ members: MemberBlockItemListSyntax)
+      -> Dictionary<String, TypeSyntax> {
+    var aliases = Dictionary<String, TypeSyntax>()
+    for member in members {
+      guard let alias = member.decl.as(TypeAliasDeclSyntax.self),
+            alias.genericParameterClause == nil else {
+        continue
+      }
+      aliases[alias.name.text] = alias.initializer.value
+    }
+    return aliases
+  }
+
+  /// `type` with each same-scope alias identifier substituted for its aliased
+  /// type, recursively so a chained `typealias A = B; typealias B = T` resolves
+  /// to `T` — the field type the constraint walk actually reasons over.
+  ///
+  /// A bare `IdentifierTypeSyntax` naming an alias becomes the aliased type
+  /// (itself re-expanded); a wrapper (`[Value]`, `Value?`, `Wrapper<Value>`)
+  /// has its element/argument spellings expanded and is rebuilt from them, so a
+  /// hidden parameter is surfaced however deep it sits. A generic-argument-
+  /// bearing identifier whose base name is an alias is NOT substituted (a plain
+  /// alias takes no arguments), so only its arguments expand. The rebuild goes
+  /// through the trimmed spelling and one re-parse, the same shape `sendable`
+  /// and the `Availability` gate parse; a spelling that fails to re-parse falls
+  /// back to `type` unchanged. `depth` bounds a pathological alias cycle.
+  private static func expand(_ type: TypeSyntax,
+                             through aliases: Dictionary<String, TypeSyntax>,
+                             depth: Int = 16) -> TypeSyntax {
+    guard depth > 0, !aliases.isEmpty else { return type }
+    if let identifier = type.as(IdentifierTypeSyntax.self),
+       identifier.genericArgumentClause == nil,
+       let aliased = aliases[identifier.name.text] {
+      return expand(aliased, through: aliases, depth: depth - 1)
+    }
+    let elements = wrapped(type)
+    guard !elements.isEmpty else { return type }
+    let expanded = elements.map {
+      expand($0, through: aliases, depth: depth - 1).trimmedDescription
+    }
+    return rebuild(type, from: expanded) ?? type
+  }
+
+  /// `type` re-spelled with its wrapped/element types replaced by `elements`,
+  /// re-parsed — an array/optional/IUO/dictionary sugar or an applied
+  /// `Wrapper<…>` rebuilt around the (already alias-expanded) inner spellings.
+  /// A shape `wrapped` does not describe, or a re-spelling that fails to parse,
+  /// yields `nil` so `expand` keeps the original type.
+  private static func rebuild(_ type: TypeSyntax, from elements: Array<String>)
+      -> TypeSyntax? {
+    let spelling: String
+    if type.is(ArrayTypeSyntax.self), elements.count == 1 {
+      spelling = "[\(elements[0])]"
+    } else if type.is(OptionalTypeSyntax.self), elements.count == 1 {
+      spelling = "\(elements[0])?"
+    } else if type.is(ImplicitlyUnwrappedOptionalTypeSyntax.self),
+              elements.count == 1 {
+      spelling = "\(elements[0])!"
+    } else if type.is(DictionaryTypeSyntax.self), elements.count == 2 {
+      spelling = "[\(elements[0]): \(elements[1])]"
+    } else if let identifier = type.as(IdentifierTypeSyntax.self),
+              identifier.genericArgumentClause != nil {
+      spelling = "\(identifier.name.text)<\(elements.joined(separator: ", "))>"
+    } else {
+      return nil
+    }
+    let rebuilt = TypeSyntax("\(raw: spelling)")
+    return rebuilt.hasError ? nil : rebuilt
+  }
+
+  /// The dependent-member requirements a field `type` contributes — the full
+  /// spellings (`T.Element`, `T.A.B`) it needs conforming, whether `type` IS
+  /// such a member or WRAPS one.
+  ///
+  /// A `MemberTypeSyntax` whose BASE is (recursively) an in-scope generic
+  /// parameter is a dependent member itself and yields its own spelling. A
+  /// wrapper — the array `[X]`, optional `X?`, implicitly-unwrapped `X!`,
+  /// dictionary `[K: V]`, or a general applied `Wrapper<…>` sugar/spelling —
+  /// descends into each wrapped/element type and yields the members THOSE hold,
+  /// so `[T.Element]` surfaces `T.Element` just as the bare member does: the
+  /// serialized `Array<T.Element>` conforms exactly when `T.Element` does. A
+  /// member based on a concrete qualified symbol (`Namespace.T`, whose base is
+  /// no parameter), and any type wrapping none, yields nothing, so it falls
+  /// through to the mentioned-parameter lowering.
+  private static func dependents(of type: TypeSyntax,
+                                 in scope: Set<String>) -> Array<String> {
+    if let member = type.as(MemberTypeSyntax.self),
+       member.genericArgumentClause == nil,
+       rooted(member.baseType, in: scope) {
+      return [member.trimmedDescription]
+    }
+    return wrapped(type).flatMap { dependents(of: $0, in: scope) }
+  }
+
+  /// The element/wrapped types a container `type` holds — an array's element,
+  /// an optional's or implicitly-unwrapped optional's wrapped type, a
+  /// dictionary's key and value, or every generic argument of an applied
+  /// `Wrapper<…>` — the types `dependents(of:in:)` descends to reach a nested
+  /// dependent member. A non-container type wraps nothing and yields the empty
+  /// array.
+  private static func wrapped(_ type: TypeSyntax) -> Array<TypeSyntax> {
+    if let array = type.as(ArrayTypeSyntax.self) {
+      return [array.element]
+    }
+    if let optional = type.as(OptionalTypeSyntax.self) {
+      return [optional.wrappedType]
+    }
+    if let iuo = type.as(ImplicitlyUnwrappedOptionalTypeSyntax.self) {
+      return [iuo.wrappedType]
+    }
+    if let dictionary = type.as(DictionaryTypeSyntax.self) {
+      return [dictionary.key, dictionary.value]
+    }
+    if let identifier = type.as(IdentifierTypeSyntax.self),
+       let arguments = identifier.genericArgumentClause {
+      return arguments.arguments.compactMap { argument in
+        guard case let .type(type) = argument.argument else { return nil }
+        return type
+      }
+    }
+    return []
+  }
+
+  /// Whether `type` roots a dependent-member spelling at an in-scope generic
+  /// parameter — a bare `IdentifierTypeSyntax` named one of `scope`, or a
+  /// `MemberTypeSyntax` (`T.A` in `T.A.B`) whose own base recursively does. A
+  /// generic-argument-bearing base (`Wrapper<T>.Element`) is an applied type,
+  /// not a parameter root, so it does not root a dependent member.
+  private static func rooted(_ type: TypeSyntax,
+                             in scope: Set<String>) -> Bool {
+    if let identifier = type.as(IdentifierTypeSyntax.self) {
+      return identifier.genericArgumentClause == nil
+          && scope.contains(identifier.name.text)
+    }
+    if let member = type.as(MemberTypeSyntax.self) {
+      return member.genericArgumentClause == nil
+          && rooted(member.baseType, in: scope)
+    }
+    return false
+  }
+
+  /// Whether `declaration` is a struct with a serialized stored property that
+  /// infers its type from an initializer mentioning an in-scope generic
+  /// parameter (`parameters`) — the shape `model` rejects with `.inferred`.
+  ///
+  /// The conditional conformance constrains each field's WRITTEN type
+  /// (`constrained`), so a field with no annotation contributes no constraint
+  /// even when its inferred type needs one. `var value = T.defaultValue`
+  /// reconstructs a `T` the generated body requires be `Serializable`/
+  /// `Deserializable`, but the derive cannot name the constraint, so the body
+  /// would not type-check. Only a field whose INITIALIZER references a generic
+  /// parameter is caught: an inferred `var count = 0` is concrete and fine, and
+  /// an annotated `var value: T` carries its own constraint. A struct in no
+  /// generic context has no parameters to mention, so it never triggers.
+  ///
+  /// `parameters` is the UNIFIED environment (`environment`), so a parameter an
+  /// ENCLOSING type or extension declares — `struct Outer<T: Defaulted> {
+  /// @Serializable struct Inner { var value = T.defaultValue } }` — is caught
+  /// just as an own parameter is: the constraint builder would see no written
+  /// type to constrain the enclosing `T` on either, so the guard must consult
+  /// the same environment it does.
+  ///
+  /// The scan descends through `#if` (like `types(of:)` and `collect`), so a
+  /// generic-dependent inferred field guarded by a conditional — `#if DEBUG var
+  /// value = T.defaultValue #endif` — is caught too: `collect` still emits the
+  /// field but `constrained` sees no written type to constrain, leaving the
+  /// active branch's conformance unconditional and its `T` reconstruction
+  /// unchecked. A top-level scan alone would miss it.
+  private static func inferred(_ declaration: some DeclGroupSyntax,
+                               mentioning parameters: Set<String>) -> Bool {
+    guard let structure = declaration.as(StructDeclSyntax.self),
+          !parameters.isEmpty else {
+      return false
+    }
+    return inferred(structure.memberBlock.members, mentioning: parameters)
+  }
+
+  /// Whether `members` hold — at top level or descending through `#if` — an
+  /// unannotated stored field whose initializer mentions a parameter in
+  /// `parameters`. The `#if` walk mirrors `types(of:)`, so a conditionally-
+  /// compiled inferred field is scanned like a top-level one.
+  private static func inferred(_ members: MemberBlockItemListSyntax,
+                               mentioning parameters: Set<String>) -> Bool {
+    members.contains { member in
+      if let block = member.decl.as(IfConfigDeclSyntax.self) {
+        return block.clauses.contains { clause in
+          guard case let .decls(members)? = clause.elements else {
+            return false
+          }
+          return inferred(members, mentioning: parameters)
+        }
+      }
+      guard let binding = member.decl.as(VariableDeclSyntax.self),
+            !typed(binding.modifiers) else {
+        return false
+      }
+      return binding.bindings.contains { pattern in
+        guard !computed(pattern.accessorBlock),
+              pattern.typeAnnotation == nil,
+              let value = pattern.initializer?.value else {
+          return false
+        }
+        return !mentions(value).isDisjoint(with: parameters)
+      }
+    }
+  }
+
+  /// The identifier names the expression `value` references STRUCTURALLY — the
+  /// expression-tree analogue of `references`, sharing its `collect` walk so an
+  /// unannotated field's initializer is tested for a generic-parameter mention
+  /// the SAME way a field type is.
+  ///
+  /// The walk skips the trailing member of a qualified member access, so a
+  /// concrete `Namespace.T()` in a `struct Holder<T>` does NOT surface `T`: the
+  /// base (`Namespace`) is descended but the `.T` declName is a member of a
+  /// concrete symbol, not a reference to the parameter. A flat token scan would
+  /// collect the `.T` token and wrongly raise `.inferred` on a field whose
+  /// inferred type is concrete.
+  private static func mentions(_ value: ExprSyntax) -> Set<String> {
+    var names = Set<String>()
+    collect(value, into: &names)
+    return names
+  }
+
+  /// The written types of the stored fields `members` serialize, in declaration
+  /// order and descending through `#if`, mirroring `fields`' skip rules — a
+  /// type-level member, a computed property, and (on deserialize) an initialized
+  /// `let` contribute none. A field with no written annotation (`var count = 0`)
+  /// or a tuple binding carries no single type and is skipped: it cannot
+  /// reference a generic parameter this analysis could name.
+  private static func types(_ binding: VariableDeclSyntax,
+                            for direction: Direction) -> Array<TypeSyntax> {
+    guard !typed(binding.modifiers) else { return [] }
+    let constant = binding.bindingSpecifier.tokenKind == .keyword(.let)
+    var types = Array<TypeSyntax>()
+    for (pattern, type) in bindings(of: binding) {
+      guard !computed(pattern.accessorBlock) else { continue }
+      guard !(direction == .deserialize
+                && constant && pattern.initializer != nil) else { continue }
+      if let type { types.append(type) }
+    }
+    return types
+  }
+
+  /// The written types of every serialized stored field `members` hold, walking
+  /// their `#if` structure so a conditionally-compiled field's type is included
+  /// too — a generic a `#if var value: T` guards must still be constrained.
+  private static func types(of members: MemberBlockItemListSyntax,
+                            for direction: Direction) -> Array<TypeSyntax> {
+    var types = Array<TypeSyntax>()
+    for member in members {
+      if let block = member.decl.as(IfConfigDeclSyntax.self) {
+        for clause in block.clauses {
+          guard case let .decls(members)? = clause.elements else { continue }
+          types += self.types(of: members, for: direction)
+        }
+      } else if let binding = member.decl.as(VariableDeclSyntax.self) {
+        types += self.types(binding, for: direction)
+      }
+    }
+    return types
+  }
+
+  /// The identifier names `type` references STRUCTURALLY — every
+  /// `IdentifierTypeSyntax` name in the type tree, but NOT the trailing member
+  /// component of a qualified `MemberTypeSyntax`, whose base alone names a
+  /// type. A bare `T` yields `T`, a nested `Array<T>` yields `Array` and `T`,
+  /// and a `Dictionary<K, V>` yields `Dictionary`, `K`, and `V` — the caller
+  /// intersects these with the in-scope generic parameters, so the container
+  /// names (`Array`, `Dictionary`) fall away.
+  ///
+  /// The walk is STRUCTURAL, not a flat token scan, so a qualified concrete
+  /// type whose member name happens to equal a generic parameter —
+  /// `Namespace.T` in a `struct Holder<T>` — does NOT surface that `T`: the
+  /// base component (`Namespace`) is descended, but the `.T` member is part of
+  /// a fully qualified concrete type, not a reference to the parameter, so it
+  /// is not collected. A flat token scan would collect the `.T` token and
+  /// wrongly constrain on `Holder`'s `T`. When a generic parameter is
+  /// itself the BASE — `T.Element`, a dependent-member spelling — the base `T`
+  /// IS descended and collected, so a genuine associated-type dependence is
+  /// kept; only the trailing member component is skipped.
+  private static func references(_ type: TypeSyntax) -> Set<String> {
+    var names = Set<String>()
+    collect(type, into: &names)
+    return names
+  }
+
+  /// Descends `syntax` collecting the base/standalone identifier names into
+  /// `names`, skipping the trailing member component of every qualified
+  /// reference — a type's `MemberTypeSyntax` (`references`) OR an expression's
+  /// `MemberAccessExprSyntax` (`mentions`), so ONE structural walk serves both
+  /// the field-type and the inferred-initializer paths.
+  ///
+  /// A generic argument clause is a child of its `IdentifierTypeSyntax`, so
+  /// recursing over children walks `Array<T>`'s `T`; a member type descends
+  /// its base but not its `.name`, and a member access descends its base but
+  /// not its `.declName`. A standalone `IdentifierTypeSyntax` (a type `T`) or
+  /// `DeclReferenceExprSyntax` (an expression `T`) contributes its name.
+  private static func collect(_ syntax: some SyntaxProtocol,
+                              into names: inout Set<String>) {
+    if let member = syntax.as(MemberTypeSyntax.self) {
+      collect(member.baseType, into: &names)
+      if let arguments = member.genericArgumentClause {
+        collect(arguments, into: &names)
+      }
+      return
+    }
+    if let access = syntax.as(MemberAccessExprSyntax.self) {
+      if let base = access.base { collect(base, into: &names) }
+      return
+    }
+    if let identifier = syntax.as(IdentifierTypeSyntax.self) {
+      names.insert(identifier.name.text)
+    }
+    if let reference = syntax.as(DeclReferenceExprSyntax.self) {
+      names.insert(reference.baseName.text)
+    }
+    for child in syntax.children(viewMode: .sourceAccurate) {
+      collect(child, into: &names)
+    }
+  }
+
+  /// Whether the annotated `declaration` carries actor isolation the emitted
+  /// witnesses must shed — a global-actor attribute (`@MainActor` or a custom
+  /// `@SomeGlobalActor`), which is a custom (non-built-in) attribute like a
+  /// property wrapper.
+  ///
+  /// A global-actor-isolated type isolates its members, so a plain emitted
+  /// `serialize`/`deserialize` INHERITS that isolation and cannot satisfy the
+  /// NONISOLATED `Serializable`/`Deserializable` requirement — a Swift 6
+  /// conformance-isolation error. The emission marks the witnesses
+  /// `nonisolated` when this answers `true`, restoring them to the
+  /// requirement's isolation. A value type's `Sendable` stored properties stay
+  /// reachable from the nonisolated body — serialize reads `self.<field>` and
+  /// deserialize calls the memberwise init — so the bodies compile.
+  ///
+  /// The derive's OWN attributes (`@Serializable`/`@Deserializable` and the
+  /// peer markers `@DecantName`/`@DecantSkip`) sit in the same attribute list
+  /// and are custom attributes too, so they are excluded here — otherwise a
+  /// derive on every type would read as isolated. A built-in (`@available`,
+  /// `@frozen`) imposes no isolation and passes through, matching `wrapped`. An
+  /// explicit `nonisolated` modifier already leaves the type unisolated and
+  /// carries no attribute, so it needs no prefix.
+  internal static func isolated(_ declaration: some DeclGroupSyntax) -> Bool {
+    declaration.attributes.contains { attribute in
+      guard case let .attribute(attribute) = attribute,
+            let name = trailing(attribute.attributeName) else {
+        return false
+      }
+      switch name {
+      case "Serializable", "Deserializable", "DecantName", "DecantSkip":
+        return false
+      case let name where builtins.contains(name):
+        return false
+      default:
+        return true
+      }
+    }
+  }
+
+  /// Whether any field in `segments` carries a written type that is not a
+  /// recognizably-`Sendable` standard type, so a nonisolated witness of a
+  /// global-actor-isolated type could not safely reach it. Recurses through the
+  /// `#if` clauses like `carries`. A field of no written type is judged safe:
+  /// its spelling gives nothing to reject, so it is left to the compiler.
+  private static func risky(_ segments: Array<Segment>) -> Bool {
+    segments.contains { segment in
+      switch segment {
+      case let .unconditional(run):
+        return run.contains { field in field.type.map { !safe($0) } ?? false }
+      case let .conditional(clauses):
+        return clauses.contains { risky($0.segments) }
+      }
+    }
+  }
+
+  /// Whether the written type spelling `type` names a standard type known to be
+  /// `Sendable` by value, so an isolated stored property of it stays reachable
+  /// from a nonisolated witness. An optional (`T?`) or array (`[T]`) of a safe
+  /// element is safe; a `Sendable` composition (`P & Sendable`) is safe; every
+  /// other spelling — a bare user nominal the macro cannot resolve — is treated
+  /// as possibly non-Sendable. Deliberately conservative on the SAFE side: it
+  /// names only the standard value types, so a false "risky" (a user `Sendable`
+  /// type) diagnoses rather than a false "safe" miscompiling.
+  ///
+  /// The GENERIC standard spellings `Optional<T>` and `Array<T>` are the
+  /// desugared forms of `T?` and `[T]` — Sendable under the same condition on
+  /// the element — so each is normalized to its sugar and the same check runs,
+  /// rather than falling through to the bare-name set and diagnosing a
+  /// valid model. Only the sugars the allowlist recognizes are desugared here:
+  /// dictionary sugar (`[K: V]`) is deliberately excluded above, so
+  /// `Dictionary<K, V>` is not desugared either, keeping the two spellings in
+  /// step.
+  private static func safe(_ type: String) -> Bool {
+    if type.hasSuffix("?"), !type.hasPrefix("(") {
+      return safe(String(type.dropLast()))
+    }
+    if type.hasPrefix("["), type.hasSuffix("]"), !type.contains(":") {
+      return safe(String(type.dropFirst().dropLast()))
+    }
+    if let element = element(of: "Optional", in: type) {
+      return safe(element)
+    }
+    if let element = element(of: "Array", in: type) {
+      return safe(element)
+    }
+    if sendable(type) { return true }
+    return sendables.contains(type)
+  }
+
+  /// Whether the type spelling `type` names `Sendable` as a real identifier —
+  /// the bare protocol (`Sendable`), an existential over it (`any Sendable`),
+  /// or a composition one of whose members is exactly `Sendable`
+  /// (`T & Sendable`, `Sendable & P`). A composition carrying `Sendable`
+  /// existentially is Sendable, so it is safe to reach from a nonisolated
+  /// witness.
+  ///
+  /// The spelling is parsed and its structure inspected rather than
+  /// substring-matched: a bare `type.contains("Sendable")` treats a
+  /// `NonSendable`, a `MySendableThing`, or an `Array<NonSendable>` as safe, so
+  /// the nonisolated witness would then touch actor-isolated non-Sendable state
+  /// the compiler rejects. Matching the identifier `Sendable` as a component —
+  /// `IdentifierTypeSyntax` named `Sendable`, itself or under an `any`, or a
+  /// member of a `&` composition — accepts only the genuinely-Sendable
+  /// spellings and diagnoses the rest.
+  private static func sendable(_ type: String) -> Bool {
+    sendable(TypeSyntax("\(raw: type)"))
+  }
+
+  /// Whether the parsed `type` is `Sendable`, `any Sendable`, or a composition
+  /// with a `Sendable` member — the syntax-tree half of the string overload.
+  private static func sendable(_ type: TypeSyntax) -> Bool {
+    if let identifier = type.as(IdentifierTypeSyntax.self) {
+      return identifier.name.text == "Sendable"
+    }
+    if let some = type.as(SomeOrAnyTypeSyntax.self) {
+      return sendable(some.constraint)
+    }
+    if let composition = type.as(CompositionTypeSyntax.self) {
+      return composition.elements.contains { sendable($0.type) }
+    }
+    return false
+  }
+
+  /// The single generic argument of `type` when it is the standard spelling
+  /// `wrapper<Element>` — `element(of: "Optional", in: "Optional<Int>")` yields
+  /// `"Int"` — or `nil` when `type` is not that wrapper applied to exactly one
+  /// argument. The match is on the trimmed spelling, so a nested `Optional<
+  /// Array<Int>>` yields `"Array<Int>"` for the caller to recurse on. A
+  /// comma-bearing argument list (a two-parameter generic) is not a single
+  /// element and yields `nil`.
+  private static func element(of wrapper: String, in type: String) -> String? {
+    let prefix = "\(wrapper)<"
+    guard type.hasPrefix(prefix), type.hasSuffix(">") else { return nil }
+    let inner = type.dropFirst(prefix.count).dropLast()
+    guard !inner.contains(",") else { return nil }
+    return String(inner)
+  }
+
+  /// The standard-library value types known `Sendable` by their bare spelling.
+  /// A field of one of these stays readable from a nonisolated witness of an
+  /// isolated type; anything outside this set the macro cannot vouch for.
+  private static let sendables: Set<String> = [
+    "Int", "Int8", "Int16", "Int32", "Int64",
+    "UInt", "UInt8", "UInt16", "UInt32", "UInt64",
+    "Float", "Double", "Float16", "Bool", "Character", "String",
+    "Substring", "Unicode.Scalar", "StaticString",
+  ]
+
+  /// Whether `modifiers` mark the declaration `lazy`. A `lazy var` has a
+  /// mutating getter and is absent from the synthesized memberwise
+  /// initializer, so it is neither serializable nor a memberwise parameter.
+  private static func lazy(_ modifiers: DeclModifierListSyntax) -> Bool {
+    modifiers.contains { $0.name.tokenKind == .keyword(.lazy) }
+  }
+
+  /// The Swift built-in declaration attributes that can appear on a stored
+  /// property and are NOT property wrappers, so `wrapped` passes a property
+  /// carrying one through rather than rejecting it. A property wrapper is a
+  /// user-defined custom type; these are the known compiler-defined spellings.
+  /// Matched on the trailing name component, like the marker allowlist, so a
+  /// qualified spelling (were one to occur) is covered too.
+  private static let builtins: Set<String> = [
+    "available", "objc", "nonobjc", "inline", "inlinable", "usableFromInline",
+    "discardableResult", "dynamicMemberLookup", "dynamicCallable", "IBOutlet",
+    "IBInspectable", "IBAction", "NSManaged", "NSCopying", "GKInspectable",
+    "preconcurrency", "Sendable", "unchecked", "frozen",
+    "warn_unqualified_access",
+  ]
+
+  /// Whether `attributes` mark the declaration property-wrapper-backed: a
+  /// custom attribute — an `AttributeSyntax` naming a type, whether
+  /// unqualified (`@W`, an `IdentifierTypeSyntax`) or qualified (`@MyModule.W`,
+  /// a `MemberTypeSyntax`) — that is neither one of the derive's own peer
+  /// markers `@DecantName` / `@DecantSkip` nor a Swift built-in declaration
+  /// attribute (`builtins`, e.g. `@available`), all of which pass through. A
+  /// qualified wrapper's `attributeName` is a member type, so matching only the
+  /// plain identifier would let it bypass the guard. The allowlist matches the
+  /// trailing name component, so a marker passes however it is spelled. A
+  /// wrapper's memberwise parameter is the wrapper storage, not the wrapped
+  /// value, so the syntactic derive cannot keep the two sides consistent.
+  private static func wrapped(_ attributes: AttributeListSyntax) -> Bool {
+    attributes.contains { attribute in
+      guard case let .attribute(attribute) = attribute,
+            let name = trailing(attribute.attributeName) else {
+        return false
+      }
+      switch name {
+      case "DecantName", "DecantSkip":
+        return false
+      case let name where builtins.contains(name):
+        return false
+      default:
+        return true
+      }
+    }
+  }
+
+  /// The trailing name component of an attribute's `attributeName`, or `nil`
+  /// when it is neither a plain identifier (`W`, an `IdentifierTypeSyntax`) nor
+  /// a qualified member type (`MyModule.W`, a `MemberTypeSyntax`, whose
+  /// trailing component is what an unqualified marker would match). A
+  /// non-nominal attribute name has no simple component and is not a candidate.
+  private static func trailing(_ type: TypeSyntax) -> String? {
+    if let identifier = type.as(IdentifierTypeSyntax.self) {
+      return identifier.name.text
+    }
+    if let member = type.as(MemberTypeSyntax.self) {
+      return member.name.text
+    }
+    return nil
+  }
+
+  /// Whether `modifiers` mark the declaration a type-level (`static`/`class`)
+  /// member rather than an instance stored property. A type property is neither
+  /// serialized state nor a memberwise-init parameter, so it contributes no
+  /// field.
+  private static func typed(_ modifiers: DeclModifierListSyntax) -> Bool {
+    modifiers.contains {
+      switch $0.name.tokenKind {
+      case .keyword(.static), .keyword(.class):
+        return true
+      default:
+        return false
+      }
+    }
+  }
+
+  /// The bindings `binding` declares, each paired with the written type that
+  /// applies to it — the SINGLE place the multi-binding type-propagation rule
+  /// lives, so every field-collection walk resolves a binding's type the same
+  /// way.
+  ///
+  /// SwiftSyntax annotates only the TRAILING binding of a `var x, y: Int` line
+  /// (`y: Int`), leaving the earlier `x` with no `typeAnnotation` though Swift
+  /// gives it the shared `Int`. A binding with its own annotation keeps it; an
+  /// annotation-less binding takes the type of the NEXT annotated binding, as
+  /// a run of comma-separated names shares the following declaration's type
+  /// (`var a: String, b, c: Int` — `b` and `c` are `Int`). A binding that
+  /// carries an INITIALIZER instead infers its type from that value, not the
+  /// trailing annotation (`var x = 1, y: Int` — `x` is not `Int`), so it takes
+  /// no propagated type. A tuple binding (`var (x, y): (Int, String)`) carries
+  /// its own annotation on the one binding, so nothing propagates across it.
+  private static func bindings(of binding: VariableDeclSyntax)
+      -> Array<(binding: PatternBindingSyntax, type: TypeSyntax?)> {
+    let patterns = Array(binding.bindings)
+    return patterns.indices.map { index in
+      let pattern = patterns[index]
+      if let type = pattern.typeAnnotation?.type {
+        return (pattern, type)
+      }
+      guard pattern.initializer == nil else { return (pattern, nil) }
+      // An annotation-less, initializer-less binding shares the type of the
+      // next binding that carries one.
+      let shared = patterns[index...]
+          .lazy.compactMap { $0.typeAnnotation?.type }.first
+      return (pattern, shared)
+    }
+  }
+
+  /// Appends the stored properties `pattern` binds to `fields`, in declaration
+  /// order, carrying `type` (the binding's written type annotation, or `nil`)
+  /// on each identifier field.
+  ///
+  /// An identifier binds one property named for it, typed `type`. A tuple
+  /// binding — a `var (x, y): (Int, Int)` line, for which Swift synthesizes
+  /// `x` and `y` as separate stored properties — destructures into one property
+  /// per element, named for its element pattern; the whole tuple type SPLITS
+  /// per element, so `x` records `Int` and `y` records `Int`, each with its own
+  /// coerced `decode() as Int`. Per-leaf coercion matters when an extension
+  /// adds a same-labelled overload (`init(x: String, y: String)`): the
+  /// memberwise init then shares the label, and the `as Int` casts pick the
+  /// `Int` init, disambiguating the otherwise-ambiguous `Self(x:y:)` call. A
+  /// tuple whose element arity does NOT match its annotation (a spelling the
+  /// macro cannot split leaf-for-leaf) drops to a `nil` type per element, the
+  /// safe fallback that forces a non-match. A `_` element binds nothing, so it
+  /// contributes no property. Nesting recurses, splitting the nested tuple type
+  /// alongside.
+  ///
+  /// A name is stored in its canonical (backtick-stripped) spelling: a
+  /// `` var `self` `` binding's token text carries the backticks, but the
+  /// serialization-name key, the memberwise argument label, and the serialize
+  /// member access each re-derive a source-safe spelling from the bare word.
+  /// `Identifier` performs that canonicalization.
+  private static func append(_ pattern: PatternSyntax,
+                             typed type: TypeSyntax?,
+                             to fields: inout Array<Field>) {
+    if let identifier = pattern.as(IdentifierPatternSyntax.self) {
+      let name = Identifier(identifier.identifier)?.name
+          ?? identifier.identifier.text
+      fields.append(Field(name: name, type: type?.trimmedDescription,
+                          coercion: type.flatMap(coercion)))
+    } else if let tuple = pattern.as(TuplePatternSyntax.self) {
+      let elements = split(type, count: tuple.elements.count)
+      for (element, type) in zip(tuple.elements, elements) {
+        append(element.pattern, typed: type, to: &fields)
+      }
+    }
+  }
+
+  /// The per-element written types a tuple `pattern` of `count` elements
+  /// destructures `type` into, or `count` `nil`s when `type` cannot be split
+  /// leaf-for-leaf.
+  ///
+  /// `var (x, y): (Int, Int)` splits `(Int, Int)` into `[Int, Int]`, one type
+  /// per element, so each field records its own type and decodes with a coerced
+  /// `decode() as Int`. A `type` that is not a `TupleTypeSyntax` (an inferred
+  /// tuple binding with no annotation, `var (x, y) = (1, 2)`) or whose element
+  /// arity does not match the pattern's yields `nil`s: the macro cannot map
+  /// element to type, so the safe type-less fallback keeps each field a
+  /// non-match. A labelled tuple type element keeps its type — the label is
+  /// dropped, as the field name comes from the element PATTERN, not the type.
+  private static func split(_ type: TypeSyntax?, count: Int)
+      -> Array<TypeSyntax?> {
+    guard let tuple = type?.as(TupleTypeSyntax.self),
+          tuple.elements.count == count else {
+      return Array(repeating: nil, count: count)
+    }
+    return tuple.elements.map { $0.type }
+  }
+
+  /// The `decode() as <spelling>` cast target for a field of written `type`,
+  /// or `nil` when the type admits no legal coercion and the read must stay a
+  /// bare `decode()`.
+  ///
+  /// Normally the trimmed `type` spelling. An implicitly-unwrapped optional
+  /// `T!` is an `ImplicitlyUnwrappedOptionalType` node whose `!` is only sugar
+  /// on the annotation — Swift rejects it as a coercion target (`as T!` is not
+  /// legal) — so it is normalized to the optional `T?` spelling, which IS a
+  /// legal coercion and which the field's `T!` memberwise-init parameter
+  /// accepts (`Optional` conforms to `Deserializable`). Only the outermost IUO
+  /// sugar is rewritten; a nested `T` is left verbatim.
+  ///
+  /// An opaque `some P` field is a `SomeOrAnyType` node whose specifier is
+  /// `some`: Swift permits `some` only in a declaration position, never as a
+  /// cast target (`decode() as some P` is rejected), so it yields `nil` and the
+  /// read stays a bare `decode()` the opaque memberwise-init parameter drives —
+  /// exactly the type-less fallback. An `any P` existential, by contrast, IS a
+  /// legal coercion target, so it keeps its spelling.
+  private static func coercion(of type: TypeSyntax) -> String? {
+    if let some = type.as(SomeOrAnyTypeSyntax.self),
+       some.someOrAnySpecifier.tokenKind == .keyword(.some) {
+      return nil
+    }
+    guard let iuo =
+        type.as(ImplicitlyUnwrappedOptionalTypeSyntax.self) else {
+      return type.trimmedDescription
+    }
+    return "\(iuo.wrappedType.trimmedDescription)?"
+  }
+
+  /// Whether `block` makes its binding a computed property, rather than a
+  /// stored property (whose accessor block, if present, holds only
+  /// `willSet`/`didSet` observers).
+  ///
+  /// A bare getter (`{ … }`) is computed; an accessor list is computed when
+  /// it names any accessor that supplies or intercepts storage, leaving pure
+  /// observers as the only stored case.
+  private static func computed(_ block: AccessorBlockSyntax?) -> Bool {
+    guard let block else { return false }
+    switch block.accessors {
+    case .getter:
+      return true
+    case let .accessors(accessors):
+      return accessors.contains { computing($0.accessorSpecifier.tokenKind) }
+    }
+  }
+
+  /// Whether `kind` names an accessor that supplies or intercepts storage, as
+  /// opposed to a `willSet`/`didSet` observer.
+  private static func computing(_ kind: TokenKind) -> Bool {
+    switch kind {
+    case .keyword(.get), .keyword(.set), .keyword(._read),
+         .keyword(._modify), .keyword(.unsafeAddress),
+         .keyword(.unsafeMutableAddress):
+      return true
+    default:
+      return false
+    }
+  }
+}
+
+/// Expands `@Serializable` to a `Serializable` conformance whose `serialize`
+/// writes each stored property in declaration order.
+public struct SerializableMacro: ExtensionMacro {
+  public static func expansion(of node: AttributeSyntax,
+                               attachedTo declaration: some DeclGroupSyntax,
+                               providingExtensionsOf type: some TypeSyntaxProtocol,
+                               conformingTo protocols: Array<TypeSyntax>,
+                               in context: some MacroExpansionContext)
+      throws -> Array<ExtensionDeclSyntax> {
+    guard let model =
+        DecantModel.model(of: declaration, for: .serialize,
+                          in: context, at: node) else {
+      return []
+    }
+
+    let name = trimmed(type)
+    // The serializer generic parameter takes a hygienic name: a readable `S`
+    // shadows any same-named generic parameter of the type or an enclosing
+    // context (an error under Swift 6), and the detached declaration cannot
+    // reveal which names those are.
+    let serializer = parameter(named: "Serializer", in: context)
+    // The sub-serializer local is hygienic so a field named `structure` (or
+    // `serializer`) reads through `self`, never this introduced name.
+    let structure = context.makeUniqueName("structure").text
+    // The field count is a plain literal when no `#if` guards a field; a
+    // conditional field makes it a hygienic local a mirrored `#if` accumulates,
+    // since the plugin cannot resolve which branch the compiler activates.
+    let field = { (field: DecantModel.Field) in
+      "    try \(structure).field(\(key(field.name)), "
+        + "self.\(member(field.name)))"
+    }
+    let count = context.makeUniqueName("fields").text
+    let fields = preamble(model.segments, into: count)
+    let lines = writes(model.segments, with: field)
+    // The sub-serializer local is mutated by each `field(…)` write, so it is a
+    // `var` — unless the struct has no stored property at all, when no write
+    // mutates it and a `var` would warn "never mutated"; a fieldless struct
+    // binds it `let`. (A struct whose only fields are conditional still emits a
+    // guarded write, so it stays `var`.)
+    let binding = empty(model.segments) ? "let" : "var"
+    // An availability-limited type — `@available(*, deprecated)`,
+    // `@available(*, unavailable)`, or a platform gate — makes a bare
+    // `extension <Type>` warn or error, so its `@available` leads the
+    // extension. A type nested in a limited ENCLOSING type has the same problem
+    // through its qualified name (`extension Outer.Inner` references a limited
+    // `Outer`), so the enclosing chain's `@available` leads the extension too.
+    let available = attributed(DecantModel.available(declaration)
+        + DecantModel.available(enclosing: context.lexicalContext))
+    // A global-actor-isolated type (`@MainActor`) isolates its members, so a
+    // plain `serialize` would inherit that isolation and could not satisfy the
+    // nonisolated `Serializable` requirement (a Swift 6 conformance-isolation
+    // error). Marking the witness `nonisolated` restores the requirement's
+    // isolation; a non-isolated type emits it unchanged.
+    let nonisolated = DecantModel.isolated(declaration) ? "nonisolated " : ""
+    // A generic type whose serialized field's type mentions a generic parameter
+    // type-checks only when that parameter is `Serializable`
+    // (`serializer.field(…)` requires it), so the conformance is CONDITIONAL: a
+    // `where T: Decant.Serializable` per referenced parameter — including a
+    // parameter an ENCLOSING generic type declares that a field stores. A
+    // non-generic type in no generic context constrains nothing and the
+    // conformance stays unconditional.
+    let scope = DecantModel.environment(of: declaration,
+                                        enclosing: context.lexicalContext)
+    let clause =
+        constrained(DecantModel.constrained(declaration, for: .serialize,
+                                             scope: scope),
+                    to: "Decant.Serializable")
+
+    let body = """
+    \(available)extension \(name): Decant.Serializable\(clause) {
+      \(nonisolated)public func serialize<\(serializer)>(into serializer: \
+    consuming \(serializer))
+          throws(\(serializer).Failure) -> \(serializer)
+          where \(serializer): Decant.Serializer & ~Copyable & ~Escapable {
+    \(fields)    \(binding) \(structure) = (consume serializer).structure(\
+    \(key(canonical(type))), fields: \(counted(model.segments, as: count)))
+    \(lines)
+        return try \(structure).end()
+      }
+    }
+    """
+
+    return try [ExtensionDeclSyntax("\(raw: body)")]
+  }
+}
+
+/// Expands `@Deserializable` to a `Deserializable` conformance whose
+/// `deserialize` reads each stored property in declaration order — the inverse
+/// field order of `@Serializable`.
+public struct DeserializableMacro: ExtensionMacro {
+  public static func expansion(of node: AttributeSyntax,
+                               attachedTo declaration: some DeclGroupSyntax,
+                               providingExtensionsOf type: some TypeSyntaxProtocol,
+                               conformingTo protocols: Array<TypeSyntax>,
+                               in context: some MacroExpansionContext)
+      throws -> Array<ExtensionDeclSyntax> {
+    guard let model =
+        DecantModel.model(of: declaration, for: .deserialize,
+                          in: context, at: node) else {
+      return []
+    }
+
+    let name = trimmed(type)
+    // The deserializer generic parameter takes a hygienic name: a readable `D`
+    // shadows any same-named generic parameter of the type or an enclosing
+    // context (an error under Swift 6), and the detached declaration cannot
+    // reveal which names those are.
+    let deserializer = parameter(named: "Deserializer", in: context)
+    // Each field is read directly in its memberwise-init argument position, so
+    // the init parameter supplies `decode`'s contextual result type — the read
+    // of a field whose type is inferred from its initializer (`var count = 0`,
+    // no written annotation) type-checks with no annotation to lend it. Swift
+    // evaluates call arguments left-to-right in source order, so the reads run
+    // in declaration order; each `decode` mutation of `deserializer` completes
+    // before the next argument, so exclusive access holds. No decoded
+    // temporary is introduced, which is also why a field named `deserializer`
+    // cannot shadow the `inout` parameter `end` reads through.
+    //
+    // Each field of a known declared type is read with an EXPLICIT type
+    // (`decode() as <type>`), so the field type — not the otherwise-
+    // unconstrained generic `decode()` — drives overload resolution to the
+    // matching init. Annotating unconditionally (not only when `model`
+    // detected a primary-declaration ambiguity) disambiguates the call against
+    // an init declared in an EXTENSION too: such an init does NOT suppress the
+    // synthesized memberwise init, so both participate in overload resolution,
+    // which the macro never sees — yet the annotation resolves the call
+    // regardless, and is harmless when only one init is viable. A field of no
+    // captured type (an inferred `var count = 0`, or a tuple element) cannot be
+    // annotated, so it keeps the bare `decode()`, whose contextual result type
+    // the sole memberwise-init parameter still supplies. An IUO field annotates
+    // with the normalized optional spelling (`coercion`), since `as T!` is not
+    // a legal coercion target.
+    let argument = { (field: DecantModel.Field) in
+      guard let coercion = field.coercion else {
+        return "\(label(field.name)): deserializer.decode()"
+      }
+      return "\(label(field.name)): deserializer.decode() as \(coercion)"
+    }
+    // The reconstructed value binds to a hygienic local so `end` runs after all
+    // reads and before the return, without a field named `value` colliding.
+    let value = context.makeUniqueName("value").text
+    let count = context.makeUniqueName("fields").text
+    let fields = preamble(model.segments, into: count)
+    // A `#if` cannot appear inside an initializer's argument list, so a
+    // conditional field forces a per-branch `Self(…)` call — the cartesian
+    // product of the blocks' clauses, each listing its active fields inline,
+    // all wrapped in the mirrored guards. `structure`/`end` frame the whole
+    // tree once, outside the branches; only one branch compiles, so the shared
+    // `value` local is declared and returned within each.
+    let tree = builds(model.segments, with: argument, binding: value)
+    // An availability-limited type — `@available(*, deprecated)`,
+    // `@available(*, unavailable)`, or a platform gate — makes a bare
+    // `extension <Type>` warn or error, so its `@available` leads the
+    // extension. A type nested in a limited ENCLOSING type has the same problem
+    // through its qualified name (`extension Outer.Inner` references a limited
+    // `Outer`), so the enclosing chain's `@available` leads the extension too.
+    let available = attributed(DecantModel.available(declaration)
+        + DecantModel.available(enclosing: context.lexicalContext))
+    // A global-actor-isolated type (`@MainActor`) isolates its members, so a
+    // plain `deserialize` would inherit that isolation and could not satisfy
+    // the nonisolated `Deserializable` requirement (a Swift 6 conformance-
+    // isolation error). Marking the witness `nonisolated` restores the
+    // requirement's isolation; a non-isolated type emits it unchanged.
+    let nonisolated = DecantModel.isolated(declaration) ? "nonisolated " : ""
+    // A generic type whose serialized field's type mentions a generic parameter
+    // type-checks only when that parameter is `Deserializable`
+    // (`deserializer.decode()` requires it), so the conformance is CONDITIONAL:
+    // a `where T: Decant.Deserializable` per referenced parameter — including a
+    // parameter an ENCLOSING generic type declares that a field stores. A
+    // non-generic type in no generic context constrains nothing and the
+    // conformance stays unconditional.
+    let scope = DecantModel.environment(of: declaration,
+                                        enclosing: context.lexicalContext)
+    let clause =
+        constrained(DecantModel.constrained(declaration, for: .deserialize,
+                                             scope: scope),
+                    to: "Decant.Deserializable")
+
+    let body = """
+    \(available)extension \(name): Decant.Deserializable\(clause) {
+      \(nonisolated)public static func deserialize<\(deserializer)>(from \
+    deserializer: inout \(deserializer))
+          throws(\(deserializer).Failure) -> Self
+          where \(deserializer): Decant.Deserializer & ~Copyable \
+    & ~Escapable {
+    \(fields)    try deserializer.structure(\(key(canonical(type))), \
+    fields: \(counted(model.segments, as: count)))
+    \(tree)
+      }
+    }
+    """
+
+    return try [ExtensionDeclSyntax("\(raw: body)")]
+  }
+}
+
+/// The `@DecantName` marker — a peer macro that expands to nothing; declared so
+/// the spelling is stable ahead of derive support for it.
+public struct DecantNameMacro: PeerMacro {
+  public static func expansion(of node: AttributeSyntax,
+                               providingPeersOf decl: some DeclSyntaxProtocol,
+                               in context: some MacroExpansionContext)
+      throws -> Array<DeclSyntax> {
+    []
+  }
+}
+
+/// The `@DecantSkip` marker — a peer macro that expands to nothing, as above.
+public struct DecantSkipMacro: PeerMacro {
+  public static func expansion(of node: AttributeSyntax,
+                               providingPeersOf decl: some DeclSyntaxProtocol,
+                               in context: some MacroExpansionContext)
+      throws -> Array<DeclSyntax> {
+    []
+  }
+}
+
+/// Whether any segment, at any depth, guards a field with `#if`. When none
+/// does, the derive emits exactly the unconditional shape it always has: a
+/// literal field count and a flat write/read list.
+private func conditional(_ segments: Array<DecantModel.Segment>) -> Bool {
+  segments.contains {
+    if case .conditional = $0 { return true }
+    return false
+  }
+}
+
+/// Whether `segments` carry no stored field at any depth — a struct with no
+/// serialized property. The serialize sub-serializer local is then never
+/// mutated by a `field(…)` write, so it binds `let` rather than a `var` that
+/// would warn.
+private func empty(_ segments: Array<DecantModel.Segment>) -> Bool {
+  segments.allSatisfy { segment in
+    switch segment {
+    case let .unconditional(run):
+      return run.isEmpty
+    case let .conditional(clauses):
+      return clauses.allSatisfy { empty($0.segments) }
+    }
+  }
+}
+
+/// The number of fields in this level's unconditional runs, not descending into
+/// a `#if` — the constant part of the field count at the level a count
+/// accumulator is initialized or incremented.
+private func direct(_ segments: Array<DecantModel.Segment>) -> Int {
+  segments.reduce(0) {
+    guard case let .unconditional(run) = $1 else { return $0 }
+    return $0 + run.count
+  }
+}
+
+/// The `fields:` argument for `structure(…)`: a literal count when no `#if`
+/// guards a field, otherwise the accumulator local `name` a mirrored `#if`
+/// tallies (see `preamble`).
+private func counted(_ segments: Array<DecantModel.Segment>,
+                     as name: String) -> String {
+  conditional(segments) ? name : "\(direct(segments))"
+}
+
+/// The lines, if any, that declare and accumulate the field-count local `name`
+/// ahead of `structure(…)`. Empty when no field is conditional; otherwise a
+/// `var name = <unconditional count>` seed followed by a `#if` tree mirroring
+/// the fields' guards, each active clause adding its own fields — the plugin
+/// cannot resolve which clause the compiler picks, so it re-emits the guard.
+private func preamble(_ segments: Array<DecantModel.Segment>,
+                      into name: String) -> String {
+  guard conditional(segments) else { return "" }
+  return "    var \(name) = \(direct(segments))\n"
+    + accumulate(segments, into: name)
+}
+
+/// The `#if` tree that increments the count local `name` by each active
+/// clause's fields, recursing into a nested `#if`. Only conditional segments
+/// contribute; an unconditional run is already in the seed or a `+=` above.
+private func accumulate(_ segments: Array<DecantModel.Segment>,
+                        into name: String) -> String {
+  var lines = ""
+  for segment in segments {
+    guard case let .conditional(clauses) = segment else { continue }
+    for clause in clauses {
+      lines += "    \(directive(clause))\n"
+      let count = direct(clause.segments)
+      if count > 0 { lines += "    \(name) += \(count)\n" }
+      lines += accumulate(clause.segments, into: name)
+    }
+    lines += "    #endif\n"
+  }
+  return lines
+}
+
+/// The serialize `field(…)` writes in declaration order, mirroring each `#if`
+/// so a conditional field is written only under the same guard. `write` renders
+/// one field's line.
+private func writes(_ segments: Array<DecantModel.Segment>,
+                    with write: (DecantModel.Field) -> String) -> String {
+  var lines = Array<String>()
+  for segment in segments {
+    switch segment {
+    case let .unconditional(run):
+      lines.append(contentsOf: run.map(write))
+    case let .conditional(clauses):
+      for clause in clauses {
+        lines.append("    \(directive(clause))")
+        let body = writes(clause.segments, with: write)
+        if !body.isEmpty { lines.append(body) }
+      }
+      lines.append("    #endif")
+    }
+  }
+  return lines.joined(separator: "\n")
+}
+
+/// The per-branch deserialize body: a `#if` tree whose every leaf is a complete
+/// `try Self(…)` over that branch's active fields, in declaration order,
+/// followed by the framing `end` and the return. Each `#if` block multiplies
+/// the leaves — the cartesian product of the blocks' clauses — since an
+/// initializer's argument list cannot itself hold a `#if`. `argument` renders
+/// one field's `label: deserializer.decode()`; `value` is the shared result
+/// local (only one branch compiles, so it is declared and returned per leaf).
+///
+/// A block without an `#else` still needs a leaf for the case no clause is
+/// active — its conditional fields are simply absent — so an implicit `#else`
+/// is synthesized, unlike serialize where an inactive clause correctly adds and
+/// writes nothing.
+private func builds(_ segments: Array<DecantModel.Segment>,
+                    with argument: (DecantModel.Field) -> String,
+                    binding value: String) -> String {
+  func render(_ segments: Array<DecantModel.Segment>,
+              _ prefix: Array<String>) -> String {
+    var arguments = prefix
+    var index = 0
+    while index < segments.count,
+          case let .unconditional(run) = segments[index] {
+      arguments.append(contentsOf: run.map(argument))
+      index += 1
+    }
+    guard index < segments.count,
+          case let .conditional(clauses) = segments[index] else {
+      // A leaf with no active field decodes nothing, so its `Self()` calls the
+      // synthesized no-argument memberwise init — which is nonthrowing (a
+      // throwing or failable custom replacement is rejected by `matches`). A
+      // `try` on it would warn "no calls to throwing functions occur", failing
+      // the warning-free build, so drop the `try` for the fieldless call. A
+      // leaf with a field keeps the `try`: each `decode()` can throw. This
+      // covers a fully-empty struct and an empty synthesized `#else` branch.
+      let call = arguments.joined(separator: ", ")
+      let build = arguments.isEmpty ? "Self()" : "try Self(\(call))"
+      return "    let \(value) = \(build)\n"
+        + "    try deserializer.end()\n    return \(value)"
+    }
+    let rest = Array(segments[(index + 1)...])
+    var lines = ""
+    for clause in clauses {
+      lines += "    \(directive(clause))\n"
+      lines += render(clause.segments + rest, arguments) + "\n"
+    }
+    // No source `#else` means the block's fields are absent when no clause is
+    // active, so synthesize an `#else` leaf carrying only the surrounding
+    // fields — the emitted `Self(…)` must be complete in every branch.
+    if clauses.last?.condition != nil {
+      lines += "    #else\n\(render(rest, arguments))\n"
+    }
+    return lines + "    #endif"
+  }
+  return render(segments, [])
+}
+
+/// The pound-directive line for `clause` — `#if COND` / `#elseif COND` /
+/// `#else` — with the condition tokens copied verbatim so the generated guard
+/// evaluates identically to the source's.
+private func directive(_ clause: DecantModel.Clause) -> String {
+  guard let condition = clause.condition else { return clause.pound }
+  return "\(clause.pound) \(condition)"
+}
+
+/// The leading-attribute prefix for a generated `extension`, from `attributes`
+/// (the annotated type's verbatim `@available` spellings): each attribute on
+/// its own line ahead of the `extension`, so the emission reads
+/// `@available(...) \n extension <Type>: …`. An empty list yields the empty
+/// string, so a type with no `@available` emits its extension unchanged.
+internal func attributed(_ attributes: Array<String>) -> String {
+  attributes.map { "\($0)\n" }.joined()
+}
+
+/// The `where` clause constraining each generic parameter in `parameters` to
+/// `protocol` — ` where T: Decant.Serializable, U: Decant.Serializable` — for
+/// the generated extension's conditional conformance, or the empty string when
+/// `parameters` is empty (a non-generic type, or one whose parameters no
+/// serialized field mentions, stays an unconditional conformance).
+///
+/// The requirement is on the generic PARAMETERS, never on a field's applied
+/// written type: Swift rejects a conformance requirement whose left side is an
+/// applied concrete type (`where Array<T>: …`), so the caller lowers each field
+/// type to the parameters it mentions (see `DecantModel.constrained`). The
+/// extension header carries this beside the method's own `where` on its
+/// serializer/deserializer parameter; the two clauses are independent. A
+/// serialized field's own value type must conform, so the caller passes
+/// `Decant.Serializable` for the serialize side and `Decant.Deserializable` for
+/// the deserialize side.
+internal func constrained(_ parameters: Array<String>,
+                          to protocol: String) -> String {
+  guard !parameters.isEmpty else { return "" }
+  let clauses = parameters.map { "\($0): \(`protocol`)" }
+  return " where \(clauses.joined(separator: ", "))"
+}
+
+/// A hygienic name for the `serialize`/`deserialize` generic parameter, built
+/// from `role` (`Serializer`/`Deserializer`).
+///
+/// The method's generic parameter is nested in the type, so a same-named type
+/// generic parameter shadows it, which Swift 6 rejects. That collision arises
+/// with the type's OWN parameter — `@Serializable struct Box<S>` — and, just as
+/// fatally, with an ENCLOSING context's — `struct Outer<S> { @Serializable
+/// struct Inner { … } }`, where the emitted `serialize<S>` shadows `Outer`'s
+/// `S` even though `Inner` is not itself generic. The compiler hands the macro
+/// the attached declaration DETACHED from its surrounding tree (its `.parent`
+/// is `nil` in the plugin process), so the enclosing parameters cannot be read
+/// to reserve them. A readable `S`/`D` is therefore unsafe in general, and the
+/// derive always takes a hygienic name: `makeUniqueName` yields a
+/// `__macro_local_…` token guaranteed distinct from any source name, in or
+/// around the type, so the parameter never shadows.
+internal func parameter(named role: String,
+                        in context: some MacroExpansionContext) -> String {
+  context.makeUniqueName(role).text
+}
+
+/// The type name for a `providingExtensionsOf` argument, stripped of
+/// whitespace, so it reads cleanly in the generated `extension` header.
+///
+/// The result is used in an IDENTIFIER position, so it keeps the source
+/// spelling: a raw type name (SE-0451: `` `Quote"Type` ``) keeps its backticks,
+/// which are exactly what makes `` extension `Quote"Type` `` parse. The
+/// deserialize constructor is spelled `Self`, not this name, so a model named
+/// after the generic `Deserializer` parameter (`struct D`) is unshadowed. The
+/// serialized structure-name string is the canonical (backtick-stripped)
+/// spelling instead — see `canonical`.
+internal func trimmed(_ type: some TypeSyntaxProtocol) -> String {
+  type.trimmedDescription
+}
+
+/// The canonical (backtick-stripped) spelling of `type`'s name, for the
+/// serialized structure-name key.
+///
+/// The structure name stays the real type name so round-trip names are stable;
+/// only its emitted spelling differs by position. `trimmed` keeps the source
+/// spelling for identifier positions, but the string key must carry the bare
+/// name — a raw type name's `` `Quote"Type` `` would otherwise serialize the
+/// backticks. `Identifier` strips them; a non-nominal or malformed type has no
+/// simple name, so the trimmed spelling is the fallback. `key` then emits this
+/// as a valid string literal (a `"` forces `#"…"#` delimiters).
+internal func canonical(_ type: some TypeSyntaxProtocol) -> String {
+  guard let identifier = type.as(IdentifierTypeSyntax.self),
+        let name = Identifier(identifier.name)?.name else {
+    return trimmed(type)
+  }
+  return name
+}
+
+/// Whether `name` is a plain Swift identifier — one that needs no backticks to
+/// be written as itself — as opposed to a keyword or a raw identifier (SE-0451:
+/// `` `foo bar` ``, `` `quote"x` ``, which carry spaces, punctuation, or other
+/// characters a plain identifier cannot). A plain identifier is a nonempty run
+/// of an identifier-start scalar (`_` or an XID-start) followed by
+/// identifier-continue scalars (`_` or XID-continue); the XID properties track
+/// Swift's identifier grammar. A keyword satisfies this shape but is separately
+/// a keyword, so callers that must distinguish the two also test `keyword`.
+private func plain(_ name: String) -> Bool {
+  var scalars = name.unicodeScalars.makeIterator()
+  guard let first = scalars.next(),
+        first == "_" || first.properties.isXIDStart else {
+    return false
+  }
+  while let scalar = scalars.next() {
+    guard scalar == "_" || scalar.properties.isXIDContinue else {
+      return false
+    }
+  }
+  return true
+}
+
+/// Whether `name` is a Swift keyword. All keywords are `Keyword` cases, so this
+/// covers every reserved word, not just `self`/`init`.
+private func keyword(_ name: String) -> Bool {
+  var name = name
+  return name.withSyntaxText { Keyword($0) != nil }
+}
+
+/// `name` as a source-safe member access after a `.` in `self.<name>`.
+///
+/// A field name is collected in its canonical spelling (`append` strips the
+/// backticks off a declared `` var `self` `` or `` var `foo bar` `` through
+/// `Identifier`), so serialize must re-escape any name that is not a plain
+/// identifier before it emits the member access, or the read miscompiles:
+/// `self.self` reads the whole instance, `self.init` is an error, and
+/// `self.foo bar` does not parse. A keyword and a raw identifier both need the
+/// backticks; the wildcard `_` is a plain, non-keyword identifier yet a bare
+/// `self._` does not parse, so it needs the backticks too. Only a plain
+/// identifier that is neither a keyword nor `_` is written bare.
+internal func member(_ name: String) -> String {
+  plain(name) && !keyword(name) && name != "_" ? name : "`\(name)`"
+}
+
+/// `name` as a source-safe argument label in `S(<name>: …)`.
+///
+/// The label rule differs from `member`: an argument label accepts a keyword
+/// unescaped — escaping one instead WARNS — so a keyword is written bare, but
+/// a raw identifier (`` `foo bar` ``) is NOT a valid bare label (`foo bar:` is
+/// a syntax error) and must keep its backticks. The wildcard `_` is a plain,
+/// non-keyword identifier yet a bare `_:` label is an OMITTED (positional)
+/// label, not the real `_` label the memberwise init expects, so `_` must be
+/// backticked (`` `_`: `` warns for neither a keyword nor a raw identifier). So
+/// a name is escaped when it is neither a plain identifier nor a keyword, or
+/// when it is `_`.
+internal func label(_ name: String) -> String {
+  (plain(name) || keyword(name)) && name != "_" ? name : "`\(name)`"
+}
+
+/// `name` as a Swift string literal for the serialization-name key in
+/// `field("<name>", …)`.
+///
+/// The serialized name stays the real property name, so round-trip keys are
+/// stable; only its SOURCE spelling must be a valid literal. A raw identifier
+/// carries characters — a `"` or `\` — that break a bare `"\(name)"`
+/// interpolation, so the literal is built through `StringLiteralExprSyntax`,
+/// which escapes the contents (or wraps them in `#"…"#`) correctly.
+internal func key(_ name: String) -> String {
+  StringLiteralExprSyntax(content: name).description
+}

--- a/Sources/DecantMacrosPlugin/Plugin.swift
+++ b/Sources/DecantMacrosPlugin/Plugin.swift
@@ -1,0 +1,19 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import SwiftCompilerPlugin
+import SwiftSyntaxMacros
+
+/// The compiler-plugin entry point — the host process the toolchain launches to
+/// expand the `DecantMacros` derive declarations. swift-syntax is depended on
+/// ONLY by this `.macro` target, so it is compile-time-only and never links
+/// into a client.
+@main
+internal struct DecantMacrosPlugin: CompilerPlugin {
+  internal let providingMacros: Array<any Macro.Type> = [
+    SerializableMacro.self,
+    DeserializableMacro.self,
+    DecantNameMacro.self,
+    DecantSkipMacro.self,
+  ]
+}

--- a/Tests/DecantMacrosClientTests/ReExportTests.swift
+++ b/Tests/DecantMacrosClientTests/ReExportTests.swift
@@ -1,0 +1,1767 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+// Imports ONLY DecantMacros — never Decant directly — so this target fails
+// to build if the derive layer stops re-exporting the `Decant` core. A macro
+// expansion references `Decant.Serializable`/`Decant.Serializer` (and the
+// deserialize equivalents) in this scope; without the re-export their members
+// are not visible here and the conformance does not compile.
+import DecantMacros
+import Testing
+
+@Serializable
+@Deserializable
+struct Probe {
+  let x: Int
+  let y: Int
+}
+
+// An implicitly-unwrapped optional field `Int!`. The read cannot annotate as
+// `decode() as Int!` — the `!` sugar is not a legal coercion target — so the
+// derive normalizes the cast to `decode() as Int?`, which the memberwise-init
+// parameter (still `Int!`) accepts (`Optional` is `Deserializable`). That this
+// COMPILES and round-trips WARNING-FREE — the swiftc-level guard the expansion
+// golden cannot give — proves the normalization.
+@Serializable
+@Deserializable
+struct IUOProbe: Equatable {
+  var x: Int!
+}
+
+// A field declared with a keyword name — `` var `self` `` / `` var `init` ``
+// — is stored under the BARE word (`self`/`init`). The derive must re-escape
+// it in the serialize `self.`self`` member-access position: without the
+// escape, `self.self` serializes the whole instance and `self.init` fails to
+// compile. The deserialize argument label stays the bare `self:` / `init:`
+// (an argument label accepts a keyword unescaped), and the serialization-name
+// STRING keys stay the bare words (data, not identifiers). That this derives
+// AND round-trips WARNING-FREE is the guard.
+@Serializable
+@Deserializable
+struct KeywordProbe: Equatable {
+  var `self`: Int
+  var `init`: Int
+  var x: Int
+}
+
+// A field declared with a RAW identifier name (SE-0451) — `` var `foo bar` ``
+// carries a space and `` var `quote"x` `` a quote, neither a plain identifier
+// nor a keyword. The derive must spell each source-safely in three contexts:
+// the serialize member access (`self.`foo bar``, backtick-escaped), the
+// serialization-name STRING key (a valid literal — the quote forces `#"…"#`
+// delimiters), and the deserialize init LABEL (`` `foo bar`: ``, backticked,
+// since a bare `foo bar:` is a syntax error). Without any one of these the
+// bare interpolation fails to compile. That it derives AND round-trips
+// WARNING-FREE is the guard.
+@Serializable
+@Deserializable
+struct RawNameProbe: Equatable {
+  var `foo bar`: Int
+  var `quote"x`: Int
+}
+
+// A field named exactly the wildcard `_` — canonicalized to the bare word
+// `_`. It is a plain, non-keyword identifier, yet BOTH derive contexts need
+// backticks the other escaping rules miss: the serialize member access
+// `` self.`_` `` (a bare `self._` does not parse) and the deserialize init
+// LABEL `` `_`: `` (a bare `_:` is an OMITTED positional label, not the real
+// `_` label the memberwise init `UnderscoreProbe(_:x:)` expects, so it
+// mis-binds). The serialization-name STRING key stays the bare `"_"` (data,
+// not an identifier). That this derives AND round-trips WARNING-FREE — with the
+// escaped `` `_`: `` label carrying the value to the right parameter — is the
+// guard; a bare `_:` would compile to a positional argument and round-trip
+// wrong.
+@Serializable
+@Deserializable
+struct UnderscoreProbe: Equatable {
+  var `_`: Int
+  var x: Int
+}
+
+// A struct whose TYPE NAME is a RAW identifier (SE-0451) carrying a quote —
+// `` `Quote"Type` ``. The derive must spell it source-safely by position: the
+// `` extension `Quote"Type` `` header keeps the backticks (an identifier
+// position), while the serialized structure-name `structure(…)` argument is
+// the CANONICAL bare name emitted as a valid string LITERAL — the quote forces
+// `#"…"#` delimiters, so a bare `structure("Quote"Type", …)` interpolation
+// would not compile. The deserialize constructor is `Self`, so the type name
+// never appears in call position. That this derives AND round-trips
+// WARNING-FREE is the guard.
+@Serializable
+@Deserializable
+struct `Quote"Type`: Equatable {
+  var x: Int
+}
+
+// A struct whose TYPE NAME is exactly `D` — the same letter the deserialize
+// derive gives its generic `Deserializer` parameter (`deserialize<D>`). Were
+// the constructor spelled by name (`try D(x: …)`), that `D` would resolve to
+// the generic parameter (the `Deserializer` type) rather than the enclosing
+// model, so a valid model named `D` would not derive. The derive spells the
+// constructor `Self`, which is the conforming model unambiguously and is not
+// shadowed by the generic parameter. That this derives AND round-trips
+// WARNING-FREE is the guard.
+@Serializable
+@Deserializable
+struct D: Equatable {
+  var x: Int
+}
+
+// A generic struct whose type parameter is named exactly `S` — the letter the
+// serialize derive gives its own `Serializer` generic parameter. The method's
+// `<S>` is nested in the type, so a same-named type parameter shadows it, which
+// Swift 6 rejects; the derive detects the collision and gives the serialize
+// parameter a hygienic name instead. The fields do not even depend on `S`, so
+// the model is otherwise valid. That this derives AND round-trips WARNING-FREE
+// is the guard; the shadowing spelling would not compile.
+@Serializable
+@Deserializable
+struct SerializerCollisionProbe<S>: Equatable {
+  var x: Int
+}
+
+// The deserialize twin — a type parameter named `D`, the letter the
+// deserialize derive gives its `Deserializer` generic parameter, which the
+// method's `<D>` would otherwise shadow. Same guard.
+@Serializable
+@Deserializable
+struct DeserializerCollisionProbe<D>: Equatable {
+  var x: Int
+}
+
+// A NON-generic type nested in a generic context. The derive is applied to
+// `Inner`, whose emitted `serialize<S>`/`deserialize<D>` would — with a
+// readable spelling — shadow the enclosing `NestingProbe`'s `S`/`D`, a Swift 6
+// error, even though `Inner` does not itself use them. The compiler hands the
+// macro the declaration DETACHED from its enclosing tree, so those names are
+// invisible and cannot be reserved; the derive always takes a hygienic generic
+// parameter name, which shadows nothing in or around the type. That `Inner`
+// derives AND round-trips WARNING-FREE is the guard.
+struct NestingProbe<S, D> {
+  @Serializable
+  @Deserializable
+  struct Inner: Equatable {
+    var x: Int
+  }
+
+  // Doubly nested, under a second generic level, to confirm the hygienic name
+  // clears every enclosing scope, not just the innermost.
+  struct Middle<T> {
+    @Serializable
+    @Deserializable
+    struct Leaf: Equatable {
+      var y: Int
+    }
+  }
+}
+
+// A generic type whose stored field's type USES the generic parameter, so the
+// derive must emit a CONDITIONAL conformance — `extension Box: … where T: …`.
+// An unconditional conformance would not type-check: `serializer.field` needs
+// `T: Serializable` and `deserializer.decode()` needs `T: Deserializable`.
+// `Box<Int>` supplies a conforming `T`, so the conditional conformance holds
+// and the value round-trips; that it derives AND round-trips is the guard.
+@Serializable
+@Deserializable
+public struct GenericFieldProbe<T>: Equatable where T: Equatable {
+  public var value: T
+}
+
+// Two generic parameters, each read by a field, so BOTH are constrained. A
+// `Pair<Int, Int>` conforms on both parameters and round-trips.
+@Serializable
+@Deserializable
+public struct GenericPairProbe<A, B>: Equatable
+    where A: Equatable, B: Equatable {
+  public var a: A
+  public var b: B
+}
+
+// A wrapper that conforms to `Serializable`/`Deserializable` for EVERY `T`,
+// serializing only its own `Int` and ignoring the phantom `T`. It stands in
+// for a real container that conforms independent of its element.
+public struct Wrapper<T>: Serializable, Deserializable, Equatable {
+  public var payload: Int
+
+  public init(payload: Int) {
+    self.payload = payload
+  }
+
+  public func serialize<S>(into serializer: consuming S)
+      throws(S.Failure) -> S
+      where S: Serializer & ~Copyable & ~Escapable {
+    var structure = (consume serializer).structure("Wrapper", fields: 1)
+    try structure.field("payload", payload)
+    return try structure.end()
+  }
+
+  public static func deserialize<D>(from deserializer: inout D)
+      throws(D.Failure) -> Self
+      where D: Deserializer & ~Copyable & ~Escapable {
+    try deserializer.structure("Wrapper", fields: 1)
+    let value = try Self(payload: deserializer.decode())
+    try deserializer.end()
+    return value
+  }
+}
+
+// A model whose field wraps `T` in a general (non-container) type. The derive
+// cannot legally constrain the WRITTEN type — `where Wrapper<T>: Serializable`
+// has an applied-type left side Swift's grammar REJECTS — so it falls back to
+// the parameter the type mentions: `where T: Serializable`. That the emitted
+// extension COMPILES (not merely expands to text) with the parameter constraint
+// and `HolderProbe<Int>` round-trips is the guard: a naive `where Wrapper<T>:
+// …` clause fails to type-check before the body runs, which an expansion-only
+// golden would not catch.
+@Serializable
+@Deserializable
+public struct HolderProbe<T>: Equatable {
+  public var value: Wrapper<T>
+}
+
+// A container field whose element is the generic parameter — the derive lowers
+// `Array<T>` to `where T: Serializable`, the exact condition under which the
+// array conforms. That `Bag<Int>` COMPILES and round-trips proves the lowered
+// element-parameter clause is legal and sufficient (an applied `where Array<T>:
+// …` would fail to type-check). Nesting is covered too: `Array<Optional<T>>`
+// mentions only `T`, so it lowers to the same `where T: Serializable`.
+@Serializable
+@Deserializable
+public struct BagProbe<T> {
+  public var items: Array<T>
+  public var maybe: Array<Optional<T>>
+}
+
+extension BagProbe: Equatable where T: Equatable {}
+
+// A stored property carrying a built-in declaration attribute — `@available`,
+// which is NOT a property wrapper. The derive must collect and round-trip it
+// rather than reject it as wrapper-backed; that it derives is the guard. The
+// availability is a plain platform introduction (not `deprecated`) so the
+// serialize read of `self.x` stays warning-free — the expansion test carries
+// the `deprecated` spelling, where no member access type-checks.
+@Serializable
+@Deserializable
+struct BuiltinAttributeProbe: Equatable {
+  @available(macOS 10.0, *) var x: Int
+  var y: Int
+}
+
+// A struct whose only initializer is the memberwise-EQUIVALENT one the user
+// wrote by hand: its argument labels match the fields in order, so the
+// derive's `MatchingInitProbe(value:)` call resolves and no `.initializer`
+// diagnostic fires. That it derives and round-trips is the guard that the
+// match escape hatch is not a false negative.
+@Serializable
+@Deserializable
+struct MatchingInitProbe: Equatable {
+  var value: Int
+  init(value: Int) {
+    self.value = value
+  }
+}
+
+// A matching init inside an `#if true` — no `#else`. The per-branch scan finds
+// the one active clause carries a match, so no `.initializer` diagnostic fires
+// and the derive proceeds; the memberwise-equivalent init the clause supplies
+// is what `Self(value:tag:)` resolves against in this build. The `#if true tag`
+// field is a conditional field, absent from the branch that omits the clause,
+// so its `tag` parameter carries a DEFAULT — the omitting build's
+// `Self(value:)` resolves through it. That it derives AND round-trips is the
+// guard that a matching conditional init is not a false positive of the
+// mutually-exclusive analysis, and that a defaulted conditional-field
+// parameter satisfies the per-branch match.
+@Serializable
+@Deserializable
+struct ConditionalMatchingInitProbe: Equatable {
+  var value: Int
+  #if true
+  var tag: Int
+  init(value: Int, tag: Int = 0) {
+    self.value = value
+    self.tag = tag
+  }
+  #endif
+}
+
+// A tuple stored binding destructures into its components, so the generated
+// conformance writes and reads each and the synthesized memberwise init —
+// flattened to `TupleProbe(a:x:y:b:)` — reconstructs them. That this compiles
+// is the guarantee: a syntactic derive that skipped the tuple would emit too
+// few fields and a mismatched initializer.
+@Serializable
+@Deserializable
+struct TupleProbe {
+  var a: Int
+  var (x, y): (Int, Int)
+  var b: Int
+}
+
+// A nested tuple binding flattens the same way — `NestedProbe(x:y:z:)`.
+@Serializable
+@Deserializable
+struct NestedProbe {
+  var (x, (y, z)): (Int, (Int, Int))
+}
+
+// Stored properties named exactly for the macro's own introduced locals — the
+// serialize sub-serializer (`structure`), the consumed `serializer`, and the
+// `inout deserializer` parameter. Without hygiene the generated `field(…)`
+// operand or the decoded `let` would resolve to those introduced names, so this
+// FAILS to compile: `field("structure", structure)` would pass the
+// sub-serializer (not `Serializable`) and `let deserializer = …` would shadow
+// the parameter the structure-close reads. With `makeUniqueName` locals and
+// `self.`-qualified reads it derives, compiles, and does not miscompile.
+@Serializable
+@Deserializable
+struct HygieneProbe {
+  var structure: Int
+  var serializer: Int
+  var deserializer: Int
+}
+
+// A type-level member — `static let`/`static var`, and the `class` spelling on
+// the reference-count-free struct is still type level — is NOT an instance
+// stored property and NOT a memberwise-init parameter. The derive must skip it:
+// were `version`/`shared` collected, serialize would emit `self.version` and
+// deserialize would pass an argument the memberwise init `StaticProbe(x:y:)`
+// has no parameter for, so this FAILS to compile. That it derives is the guard.
+@Serializable
+@Deserializable
+struct StaticProbe {
+  static let version = 1
+  nonisolated(unsafe) static var shared = 0
+  let x: Int
+  var y: Int
+}
+
+// A field whose type is inferred from its initializer (`count`, no written
+// annotation). The read is emitted in the memberwise-init argument position, so
+// the init parameter supplies `decode`'s result type; without that context the
+// generic `decode()` has nothing to infer against and this FAILS to type-check.
+@Serializable
+@Deserializable
+struct InferredProbe {
+  var count = 0
+  let name: String
+}
+
+// An untyped tuple leaf — `(x, y)` inferred `(1, 2)` — flattens to the same
+// init-argument reads, so each leaf's type comes from its `InferredTupleProbe`
+// parameter. It compiles for the same reason `InferredProbe` does.
+@Serializable
+@Deserializable
+struct InferredTupleProbe {
+  var (x, y) = (1, 2)
+}
+
+// The shapes the diagnostics for `lazy` and initialized `let` must NOT
+// over-reject: an uninitialized `let` is a REQUIRED memberwise parameter, an
+// initialized `var` is a DEFAULTED one, and an observed stored `var` stays a
+// parameter too. All three remain instance stored properties in the
+// synthesized memberwise init, so the derive collects each and this compiles;
+// were the rejection too broad, `MemberwiseProbe(x:y:z:)` would lose a
+// parameter and the generated init call would fail to type-check.
+@Serializable
+@Deserializable
+struct MemberwiseProbe {
+  let x: Int
+  var y = 0
+  var z = 0 {
+    didSet {}
+  }
+}
+
+// An initialized `let` is a valid stored property on the serialize side: the
+// generated `serialize` reads `self.version` (nonmutating), and Swift omits it
+// only from the memberwise init — which serialize never calls. So a
+// `@Serializable`-only struct carrying one derives and writes it; were the
+// initialized-`let` rejection still shared with deserialize, this would refuse
+// to compile. (`@Deserializable` on the same shape stays diagnosed — proven in
+// the expansion tests — so no silent round-trip mismatch escapes.)
+@Serializable
+struct VersionedProbe {
+  let version = 1
+  let payload: Int
+}
+
+// Stored properties guarded by `#if` — a validated bug the derive once dropped
+// silently, since an `IfConfigDeclSyntax` member is neither a `var` nor a `let`
+// binding. The plugin cannot evaluate a compilation condition (it arrives
+// unresolved), so the derive MIRRORS the guards into the generated code and
+// lets the compiler activate the matching clause. The test build's config is
+// fixed, so `#if true` (active) and `#if false` (inactive) exercise BOTH a live
+// and a dead branch deterministically: the type — and the derived code — carry
+// `t` (under `#if true`) but not `skip` (under `#if false`), so a correct
+// round-trip writes and reads exactly `a`, `t`, `b`. Were the guards dropped,
+// serialize would write too few fields and deserialize would call a `Self(…)`
+// missing `t`; were the inactive field NOT guarded, `self.skip` would not even
+// compile. That this derives, compiles, and round-trips is the guard.
+@Serializable
+@Deserializable
+struct ConditionalProbe: Equatable {
+  var a: Int
+  #if true
+  var t: Int
+  #endif
+  #if false
+  var skip: Int
+  #endif
+  var b: Int
+}
+
+// An `#if true`/`#else`: the `#if` clause is active, so `live` is the compiled
+// field and `dead` is absent. The derive emits a `Self(…)` per branch — the
+// active one carries `live` — so it round-trips `a`, `live`, `b`.
+@Serializable
+@Deserializable
+struct IfElseActiveProbe: Equatable {
+  var a: Int
+  #if true
+  var live: Int
+  #else
+  var dead: Int
+  #endif
+  var b: Int
+}
+
+// An `#if false`/`#else`: the ELSE clause is active, so `chosen` is the
+// compiled field and the `#if` clause's `other` is absent. The per-branch
+// `Self(…)` for the else clause carries `chosen`, so it round-trips `a`,
+// `chosen`, `b` — proving the derive follows the guard the compiler activates
+// rather than the first-written clause.
+@Serializable
+@Deserializable
+struct IfElseInactiveProbe: Equatable {
+  var a: Int
+  #if false
+  var other: Int
+  #else
+  var chosen: Int
+  #endif
+  var b: Int
+}
+
+// A matching init whose CONDITIONAL field lives under `#if false`, so the
+// build that omits the clause is the one that compiles: `omitted` is absent and
+// the derive emits `Self(kept:)`. The init's `omitted` parameter carries a
+// DEFAULT, so that shorter call resolves — the guard that a defaulted
+// conditional-field parameter lets an omitting branch reuse the custom init
+// rather than diagnose. It round-trips exactly `kept`.
+@Serializable
+@Deserializable
+struct DefaultedConditionalInitProbe: Equatable {
+  var kept: Int
+  #if false
+  var omitted: Int
+  #endif
+  init(kept: Int, omitted: Int = 0) {
+    self.kept = kept
+    #if false
+    self.omitted = omitted
+    #endif
+  }
+}
+
+// Mutually-exclusive `#if` clauses declaring the SAME field `x`, plus the exact
+// replacement `init(x:)`. Every build compiles ONE `x`, so the derive emits
+// `Self(x:)` in each branch and the custom init resolves in every build. A
+// flattened field list would hold two `x`s and reject the one-parameter init;
+// the per-branch match sees one active `x` per branch, so it derives and
+// round-trips `x` rather than diagnosing `.initializer`.
+@Serializable
+@Deserializable
+struct ExclusiveSameFieldProbe: Equatable {
+  #if true
+  var x: Int
+  #else
+  var x: Int
+  #endif
+  init(x: Int) {
+    self.x = x
+  }
+}
+
+// A matching init carrying NO availability (nor any other disqualifying
+// attribute): it stays a memberwise-equivalent replacement, so the derive
+// reuses it (no `.initializer` diagnostic) and the value round-trips. A
+// version-restricted `@available` (a platform `introduced:`/short-form
+// version, or `swift <version>`) would instead be a non-match — it gates the
+// init to a version the witness is not emitted under — proven in the expansion
+// tests, alongside `unavailable`/`obsoleted`/`deprecated`.
+@Serializable
+@Deserializable
+struct MatchingInitAvailabilityProbe: Equatable {
+  var x: Int
+  init(x: Int) {
+    self.x = x
+  }
+}
+
+// A conditional field `x` and a custom init in the SAME `#if` as the field.
+// In the build where the clause is active, `init(base:x:)` is compiled and
+// covers `Self(base:x:)`; in the build that omits it, neither `x` nor the init
+// is compiled, so the synthesized memberwise `init(base:)` applies. The
+// per-build analysis matches the init only against its active build, so it does
+// not demand `x` carry a default — a validated bug the global scan diagnosed.
+// The test build's `#if true` is active, so it round-trips `base` and `x`.
+@Serializable
+@Deserializable
+struct ConditionalInitProbe: Equatable {
+  var base: Int
+  #if true
+  var x: Int
+  init(base: Int, x: Int) {
+    self.base = base
+    self.x = x
+  }
+  #endif
+}
+
+// Two same-labelled initializer overloads active together — `init(x: Int)` and
+// `init(x: String)`. The bare `Self(x: deserializer.decode())` would leave the
+// generic `decode()` no result type and the `init(x:)` set ambiguous; the
+// derive disambiguates by reading the field with its declared type
+// (`decode() as Int`), so overload resolution picks `init(x: Int)`. That this
+// derives AND round-trips WARNING-FREE — through the `Int` init, not the
+// `String` one — is the guard.
+@Serializable
+@Deserializable
+struct OverloadedInitProbe: Equatable {
+  var x: Int
+  init(x: Int) {
+    self.x = x
+  }
+  init(x: String) {
+    self.x = Int(x) ?? 0
+  }
+}
+
+// A same-labelled init overload declared in an EXTENSION — `init(x: String)`
+// — which the macro CANNOT see (it reads only the primary declaration) and
+// which does NOT suppress the synthesized `init(x: Int)`. Both join overload
+// resolution at the derive's call site, so a bare `Self(x: deserializer
+// .decode())` would leave `decode()` untyped and the `init(x:)` set an
+// ambiguity — a hard `swiftc` error in this client target the macro test
+// cannot catch. The derive annotating the read `decode() as Int`
+// unconditionally picks the `Int` init regardless. That this compiles AND
+// round-trips WARNING-FREE is the guard.
+@Serializable
+@Deserializable
+struct ExtensionOverloadProbe: Equatable {
+  var x: Int
+}
+
+extension ExtensionOverloadProbe {
+  init(x: String) {
+    self.x = Int(x) ?? 0
+  }
+}
+
+// A tuple stored binding whose written annotation SPLITS per leaf, beside a
+// same-labelled init overload in an EXTENSION. Without the split, `x` and `y`
+// would record no type and decode as bare `deserializer.decode()`; with the
+// `init(x: String, y: String)` overload also live (an extension init does not
+// suppress the memberwise `init(x: Int, y: Int)`), the bare `Self(x:y:)` call
+// would be AMBIGUOUS — a hard `swiftc` error the macro golden cannot catch. The
+// per-leaf split records `x: Int`/`y: Int` and emits `decode() as Int` casts,
+// which pick the `Int` init and resolve the call. That this compiles AND
+// round-trips WARNING-FREE is the guard.
+@Serializable
+@Deserializable
+struct TupleOverloadProbe: Equatable {
+  var (x, y): (Int, Int)
+}
+
+extension TupleOverloadProbe {
+  init(x: String, y: String) {
+    self.x = Int(x) ?? 0
+    self.y = Int(y) ?? 0
+  }
+}
+
+// A derived type NESTED in an EXTENSION of a generic type, whose OUTER
+// parameter a field stores. The `extension Probe where T: Equatable` carries
+// `T` in scope, so `Inner`'s `var value: T` mentions the enclosing `T` — but a
+// naive derive that reads generic parameters only from enclosing TYPE
+// declarations would treat the extension as contributing NONE, emit an
+// UNCONDITIONAL `extension Probe.Inner: Serializable`, and fail to compile
+// (the body needs `T: Serializable`/`Deserializable`). The unified generic
+// environment reads the extension's `where`-clause subject `T`, so the derive
+// emits the CONDITIONAL `extension …Inner: … where T: …`. That an
+// `EnclosingExtensionProbe<Int>.Inner` round-trips is the guard; before the
+// fix the unconditional conformance did not compile.
+public struct EnclosingExtensionProbe<T> {}
+
+extension EnclosingExtensionProbe where T: Equatable {
+  @Serializable
+  @Deserializable
+  public struct Inner: Equatable {
+    public var value: T
+
+    public init(value: T) {
+      self.value = value
+    }
+  }
+}
+
+// A struct with NO stored properties. Its deserialize branch decodes nothing,
+// so it must call the synthesized no-argument memberwise init WITHOUT `try` —
+// that init is nonthrowing, and a `try Self()` would warn "no calls to
+// throwing functions occur", failing the warning-free build. That this derives
+// AND round-trips WARNING-FREE is the guard.
+@Serializable
+@Deserializable
+struct EmptyProbe: Equatable {}
+
+// A conditional-ONLY field set: `payload` lives under `#if false`, so the
+// build that compiles is the synthesized `#else` with no active field. That
+// empty branch must also emit `Self()` without `try` — the same warning-free
+// guard as `EmptyProbe`, but for a synthesized empty branch rather than a
+// fieldless struct. The `#if false` clause is dead, so it round-trips nothing.
+@Serializable
+@Deserializable
+struct EmptyBranchProbe: Equatable {
+  #if false
+  var payload: Int
+  #endif
+}
+
+// Many `#if` blocks guarding ONLY methods and computed properties — no stored
+// field, no initializer — beside two real fields. The blocks are dropped from
+// the emitted segments AND pruned from the init-resolution enumeration, so the
+// derive stays a single build rather than expanding a 2^12 cartesian over the
+// helper blocks (which would hang or hit the `.conditional` cap). That this
+// derives quickly and round-trips `first`/`second` is the guard.
+@Serializable
+@Deserializable
+struct HelperOnlyConditionalProbe: Equatable {
+  var first: Int
+  var second: Int
+  #if true
+  func h0() {}
+  #endif
+  #if true
+  func h1() {}
+  #endif
+  #if true
+  func h2() {}
+  #endif
+  #if true
+  func h3() {}
+  #endif
+  #if true
+  func h4() {}
+  #endif
+  #if true
+  func h5() {}
+  #endif
+  #if true
+  var c6: Int { 0 }
+  #endif
+  #if true
+  var c7: Int { 0 }
+  #endif
+  #if true
+  var c8: Int { 0 }
+  #endif
+  #if true
+  var c9: Int { 0 }
+  #endif
+  #if true
+  var c10: Int { 0 }
+  #endif
+  #if true
+  var c11: Int { 0 }
+  #endif
+
+  static func == (lhs: HelperOnlyConditionalProbe,
+                  rhs: HelperOnlyConditionalProbe) -> Bool {
+    lhs.first == rhs.first && lhs.second == rhs.second
+  }
+}
+
+// Nine INDEPENDENT `#if` stored fields — a deserialize branch product of
+// 2^9 = 512, past the 256 cap — under `@Serializable` ALONE. Serialize emits a
+// LINEAR field-count accumulator and `#if`-guarded writes, not the cartesian
+// `Self(…)` the cap guards, so the cap must NOT block it: the branch product
+// is a deserialize-only limit. That this SERIALIZE-only struct derives (the
+// same shape `@Deserializable` diagnoses `.conditional`, proven in the
+// expansion tests) is the guard. All clauses are `#if true`, so it writes all
+// nine fields.
+@Serializable
+struct ManyConditionalSerializeProbe {
+  #if true
+  var f1: Int
+  #endif
+  #if true
+  var f2: Int
+  #endif
+  #if true
+  var f3: Int
+  #endif
+  #if true
+  var f4: Int
+  #endif
+  #if true
+  var f5: Int
+  #endif
+  #if true
+  var f6: Int
+  #endif
+  #if true
+  var f7: Int
+  #endif
+  #if true
+  var f8: Int
+  #endif
+  #if true
+  var f9: Int
+  #endif
+}
+
+// A `@available(*, deprecated)` TYPE. A bare `extension DeprecatedProbe: …`
+// references the deprecated type and WARNS ("'DeprecatedProbe' is deprecated"),
+// which the warning-free build rejects; the derive must copy the type's
+// `@available` onto BOTH conformance extensions so they compile warning-free.
+// That this whole target still builds warning-free — with the derived
+// extensions guarded by the same availability — is the guard.
+@available(*, deprecated)
+@Serializable
+@Deserializable
+struct DeprecatedProbe: Equatable {
+  var x: Int
+}
+
+// A struct with a `@available(*, deprecated)` STORED FIELD, derived
+// `@Deserializable` ONLY. Deserialize passes the field as a memberwise-init
+// argument (`Self(x: …)`), which is not an access and so does not warn — the
+// `@Serializable` side, which would read `self.x`, is the one the derive
+// rejects. That this target builds warning-free WITH the deserialize
+// conformance derived over a deprecated field is the guard; it is not
+// `@Serializable`, so `roundtrip` cannot serialize it and the test decodes it
+// directly.
+@Deserializable
+struct DeprecatedFieldProbe: Equatable {
+  @available(*, deprecated) var x: Int
+}
+
+// A `@available(*, deprecated)` TYPE with a matching `@available(*,
+// deprecated)` custom init. The custom init suppresses the synthesized
+// memberwise init, so `@Deserializable` must call THIS init as `Self(x: …)`.
+// Its deprecation is covered by the type's — the derived extension is emitted
+// `@available(*, deprecated)` too, so the call sits inside a deprecated context
+// and raises no deprecation warning. That this target builds warning-free with
+// the deserialize conformance derived over the deprecated init is the guard.
+// (`x` is not itself deprecated, so the `@Serializable` read of `self.x` stays
+// warning-free and the value round-trips.)
+@available(*, deprecated)
+@Serializable
+@Deserializable
+struct DeprecatedInitProbe: Equatable {
+  var x: Int
+
+  @available(*, deprecated)
+  init(x: Int) {
+    self.x = x
+  }
+}
+
+// A `@available(*, deprecated, message: "type")` TYPE with a `@available(*,
+// deprecated, message: "init")` custom init — the two deprecations spell
+// DIFFERENT messages. The custom init suppresses the synthesized memberwise
+// init, so `@Deserializable` must call THIS init as `Self(x: …)`. The derived
+// extension is emitted `@available(*, deprecated, message: "type")`, and Swift
+// suppresses the `Self(x: …)` deprecation warning inside a deprecated context
+// REGARDLESS of the message, so the call is warning-free even though the two
+// messages differ. Coverage is by deprecation KIND, not exact gate text; this
+// target building warning-free is the guard. Before the fix the exact-text
+// gate comparison left the init UNCOVERED, so `@Deserializable` fired
+// `.initializer` and no conformance was emitted — the round-trip below then
+// failed to compile.
+@available(*, deprecated, message: "type")
+@Serializable
+@Deserializable
+struct DeprecatedMessageProbe: Equatable {
+  var x: Int
+
+  @available(*, deprecated, message: "init")
+  init(x: Int) {
+    self.x = x
+  }
+}
+
+// An `@available(*, unavailable)` TYPE. A bare extension over it is a hard
+// ERROR, not merely a warning — so before the fix this shape did not compile at
+// all. The copied `@available(*, unavailable)` on each extension makes the
+// conformance track the type's unavailability, so the target builds. It is
+// never instantiated (an unavailable type cannot be), so no round-trip runs; it
+// exists purely as a compile guard.
+@available(*, unavailable)
+@Serializable
+@Deserializable
+struct UnavailableProbe: Equatable {
+  var x: Int
+}
+
+// A platform-gated TYPE — `@available(macOS 10.0, *)`. The derive copies the
+// gate verbatim onto each extension so the conformance is available exactly
+// where the type is; the deployment target satisfies the gate, so it derives
+// and round-trips.
+@available(macOS 10.0, *)
+@Serializable
+@Deserializable
+struct PlatformProbe: Equatable {
+  var x: Int
+}
+
+// A platform-gated TYPE — `@available(macOS 10.0, iOS 13.0, *)` — with a custom
+// init gated SAME-or-BROADER: `@available(macOS 10.0, *)`. The init names macOS
+// at the type's floor and leaves iOS to its `*` fallback, so it is available
+// everywhere the extension is (its macOS 10.0 floor and its iOS 13.0 floor
+// included). The derive weighs coverage SEMANTICALLY per platform, not by exact
+// gate text, so the broader init is a safe replacement: `@Deserializable` calls
+// it as `Self(x: …)` and the target builds warning-free. Before the fix the
+// exact-text gate comparison rejected the differing init spelling, fired
+// `.initializer`, and emitted no conformance, so the round-trip did not compile.
+@available(macOS 10.0, iOS 13.0, *)
+@Serializable
+@Deserializable
+struct BroaderInitProbe: Equatable {
+  var x: Int
+
+  @available(macOS 10.0, *)
+  init(x: Int) {
+    self.x = x
+  }
+}
+
+// A PLATFORM-scoped deprecation matched on both sides — the type and the custom
+// init are both `@available(macOS, deprecated: 10.0)`. The custom init
+// suppresses the synthesized memberwise init, so `@Deserializable` must call it
+// as `Self(x: …)`. The derived extension inherits the type's macOS deprecation,
+// so the call sits inside a macOS-deprecated context where Swift suppresses the
+// init's deprecation warning — the deprecation is covered ON ITS PLATFORM. That
+// this target builds warning-free is the guard: a build for macOS derives the
+// conformance over the platform-deprecated init with no warning. (`x` is not
+// deprecated, so the `@Serializable` read of `self.x` stays warning-free and the
+// value round-trips.)
+@available(macOS, deprecated: 10.0)
+@Serializable
+@Deserializable
+struct PlatformDeprecatedInitProbe: Equatable {
+  var x: Int
+
+  @available(macOS, deprecated: 10.0)
+  init(x: Int) {
+    self.x = x
+  }
+}
+
+// A derived type NESTED in a `@available(*, deprecated)` ENCLOSING type, whose
+// custom init is `@available(*, deprecated)` to MATCH. The init suppresses the
+// synthesized memberwise init, so `@Deserializable` must call THIS init as
+// `Self(x: …)` — and a deprecated init is callable warning-free only from a
+// deprecated context. The init-resolution analysis weighs the init's gate
+// against the availability the generated extension carries: with the direct
+// declaration alone, `Inner` has NO `@available`, so the deprecated init is
+// UNCOVERED, `@Deserializable` fires `.initializer`, and no conformance is
+// emitted — the round-trip below then fails to compile. Reading the ENCLOSING
+// chain's `@available` (from the lexical context) into the gate covers the init
+// — the enclosing deprecation is copied onto the extension, so the call sits in
+// a deprecated context — and the conformance derives. That the derive covers a
+// deprecated init under a deprecated ENCLOSING type and `Inner` round-trips
+// warning-free is the guard; before reading the enclosing gate the derive
+// diagnosed the init and emitted no `Deserializable`, so this did not compile.
+@available(*, deprecated)
+enum EnclosingDeprecatedProbe {
+  @Serializable
+  @Deserializable
+  struct Inner: Equatable {
+    var x: Int
+
+    @available(*, deprecated)
+    init(x: Int) {
+      self.x = x
+    }
+  }
+}
+
+// A derived type NESTED in a generic ENCLOSING type whose OUTER parameter a
+// field stores. `Inner` has no generic clause of its own, so a naive
+// `extension EnclosingGenericProbe.Inner: Serializable` is UNCONDITIONAL and
+// type-checks for every `T` — but the body's `field(…, self.value)` needs
+// `T: Serializable` and `decode() as T` needs `T: Deserializable`, so the
+// unconditional conformance FAILS to compile. The derive reads the enclosing
+// `T` from the lexical context and, seeing a field mention it, emits the
+// CONDITIONAL `extension EnclosingGenericProbe.Inner: … where T: …`. That the
+// conformance derives over the ENCLOSING parameter and `Inner<Int>` round-trips
+// is the guard; before the fix the unconditional conformance did not compile.
+public struct EnclosingGenericProbe<T> {
+  @Serializable
+  @Deserializable
+  public struct Inner: Equatable where T: Equatable {
+    public var value: T
+
+    public init(value: T) {
+      self.value = value
+    }
+  }
+}
+
+// A concrete field whose written type is QUALIFIED and whose trailing member
+// component happens to equal the enclosing generic parameter — `Namespace.T` in
+// a `Holder<T>`. The field does NOT depend on `Holder`'s `T`: `Namespace.T` is
+// a fully-qualified concrete type. A flat token scan would see the `.T` token
+// and wrongly emit `extension Holder: … where T: …`, so `Holder<NonSerial>`
+// would LOSE the conformance it should keep. The structural walk descends the
+// base (`Namespace`) but not the trailing `.T`, so no parameter is mentioned
+// and the conformance stays UNCONDITIONAL. That `Holder<NonSerial>` — whose
+// `NonSerial` is neither `Serializable` nor `Deserializable` — still conforms
+// and round-trips is the guard: an unconditional conformance holds for a
+// non-conforming `T`, which a `where T: …` clause would have forbidden.
+enum QualifiedNamespace {
+  struct T: Serializable, Deserializable, Equatable {
+    var payload: Int
+
+    init(payload: Int) {
+      self.payload = payload
+    }
+
+    func serialize<S>(into serializer: consuming S)
+        throws(S.Failure) -> S
+        where S: Serializer & ~Copyable & ~Escapable {
+      var structure = (consume serializer).structure("T", fields: 1)
+      try structure.field("payload", self.payload)
+      return try structure.end()
+    }
+
+    static func deserialize<D>(from deserializer: inout D)
+        throws(D.Failure) -> Self
+        where D: Deserializer & ~Copyable & ~Escapable {
+      try deserializer.structure("T", fields: 1)
+      let value = try Self(payload: deserializer.decode())
+      try deserializer.end()
+      return value
+    }
+  }
+}
+
+// A non-`Serializable`, non-`Deserializable` element to instantiate the
+// qualified-member holder with, proving the derived conformance is
+// unconditional (a `where T: …` clause would reject this `T`).
+struct NonSerial: Equatable {}
+
+@Serializable
+@Deserializable
+struct QualifiedMemberProbe<T>: Equatable where T: Equatable {
+  var value: QualifiedNamespace.T
+}
+
+// A field typed as a DEPENDENT MEMBER of a generic parameter — `T.Element` in
+// `struct Box<T: Sequence>`. The body passes a `T.Element` to `field(…)` and
+// decodes a `T.Element`, so `T.Element` ITSELF must conform; constraining the
+// base `T` does not supply that and wrongly forbids a `Box<T>` whose ELEMENT
+// alone is serializable. A dependent member is a LEGAL where-clause left side,
+// so the derive emits `where T.Element: …` directly. That `Box<Array<Int>>`
+// (whose `Element` is `Int`) COMPILES and round-trips is the real-compile
+// guard: before the fix the base-`T` reduction (`where T: …`, requiring the
+// non-conforming `Array<Int>` sequence itself to conform) rejected it.
+@Serializable
+@Deserializable
+public struct DependentMemberProbe<T: Sequence>: Equatable
+    where T.Element: Equatable {
+  public var value: T.Element
+}
+
+// A field typed as a WRAPPED dependent member — `Array<T.Element>` in `struct
+// Box<T: Sequence>`. The body serializes an `Array<T.Element>` and decodes one,
+// whose conformance rests on `T.Element`, not the base `T`; constraining `T`
+// wrongly forbids a `Box<T>` whose ELEMENT alone is serializable. The derive
+// descends the array wrapper to the dependent member and emits `where
+// T.Element: …` directly. That `Box<Array<Int>>` (whose `Element` is `Int`)
+// COMPILES and round-trips is the real-compile guard: before the fix the
+// wrapper reduced to the base `T` (`where T: …`, requiring the non-conforming
+// `Array<Int>` sequence itself to conform) and rejected it.
+@Serializable
+@Deserializable
+public struct WrappedDependentMemberProbe<T: Sequence>: Equatable
+    where T.Element: Equatable {
+  public var values: Array<T.Element>
+}
+
+// A struct with a `var x, y: Int` MULTI-BINDING line — SwiftSyntax annotates
+// only the trailing `y` — and an EXTENSION adding a same-label overload
+// `init(x: String, y: Int)`. The derive must propagate the shared `Int` to the
+// earlier `x`, so the read is `decode() as Int` and the `Self(x:y:)` call
+// resolves to the synthesized `init(x: Int, y: Int)` unambiguously. That this
+// target builds with NO ambiguity is the guard: before the fix `x` carried no
+// type, its read stayed a bare `decode()`, and `Self(x:y:)` was ambiguous
+// between the `Int` and `String` inits.
+@Serializable
+@Deserializable
+struct SharedBindingOverloadProbe: Equatable {
+  var x, y: Int
+}
+
+extension SharedBindingOverloadProbe {
+  init(x: String, y: Int) {
+    self.x = Int(x) ?? 0
+    self.y = y
+  }
+}
+
+// A struct with a `var x, y: Int` MULTI-BINDING line and a MATCHING primary
+// custom `init(x: Int, y: Int)`. The custom init suppresses the synthesized
+// memberwise init, so `@Deserializable` must recognise it as a covering
+// replacement — which needs the earlier `x`'s propagated `Int` type to prove
+// parity. That this DERIVES (no `.initializer` diagnostic) and round-trips is
+// the guard: before the fix `x` had no type, so the matching init was falsely
+// rejected.
+@Serializable
+@Deserializable
+struct SharedBindingInitProbe: Equatable {
+  var x, y: Int
+
+  init(x: Int, y: Int) {
+    self.x = x
+    self.y = y
+  }
+}
+
+// A struct whose custom init reuses ONE generic parameter across fields of the
+// SAME type — `var x: Int; var y: Int; init<U>(x: U, y: U)`. Both fields bind
+// `U` to `Int`, a consistent binding, so the init covers and `Self(x: … as Int,
+// y: … as Int)` type-checks. That this DERIVES and round-trips is the guard —
+// the twin of the reject case (a `U` bound to two DIFFERENT types), which is
+// diagnosed rather than emitted as an uncompilable call.
+@Serializable
+@Deserializable
+struct RepeatedGenericInitProbe: Equatable {
+  var x: Int
+  var y: Int
+
+  init<U>(x: U, y: U) {
+    self.x = (x as? Int) ?? 0
+    self.y = (y as? Int) ?? 0
+  }
+}
+
+// A concrete namespace whose member type is NAMED for a generic parameter, to
+// prove item 2's structural walk of an inferred initializer. `Namespace.T()`
+// is a concrete symbol; its `.T` member is NOT a reference to `Holder`'s `T`.
+enum InferredNamespace {
+  struct T: Serializable, Deserializable, Equatable {
+    var payload: Int
+
+    init(payload: Int = 0) {
+      self.payload = payload
+    }
+
+    func serialize<S>(into serializer: consuming S)
+        throws(S.Failure) -> S
+        where S: Serializer & ~Copyable & ~Escapable {
+      var structure = (consume serializer).structure("T", fields: 1)
+      try structure.field("payload", self.payload)
+      return try structure.end()
+    }
+
+    static func deserialize<D>(from deserializer: inout D)
+        throws(D.Failure) -> Self
+        where D: Deserializer & ~Copyable & ~Escapable {
+      try deserializer.structure("T", fields: 1)
+      let value = try Self(payload: deserializer.decode())
+      try deserializer.end()
+      return value
+    }
+  }
+}
+
+// An INFERRED field initialised from a concrete qualified symbol whose member
+// name equals the generic parameter — `var value = InferredNamespace.T()` in a
+// `Holder<T>`. The field's inferred type is the CONCRETE `InferredNamespace.T`
+// and needs no generic constraint. The inferred-initializer scan walks the
+// expression STRUCTURALLY (like `references` walks a type), skipping the `.T`
+// member of `InferredNamespace`, so it is NOT counted as a mention of the
+// generic `T`. That this DERIVES with no `.inferred` diagnostic and round-trips
+// is the guard: before the fix a flat token scan saw the `.T` token, read it as
+// a mention of `T`, and wrongly raised `.inferred`.
+@Serializable
+@Deserializable
+struct InferredQualifiedProbe<T>: Equatable {
+  var value = InferredNamespace.T()
+}
+
+// A custom replacement initializer declared `throws(Never)`, which Swift treats
+// as NONTHROWING — callable as the derive's `Self(…)` with no `try` the
+// typed-throws context cannot absorb. The init-candidate check must accept it
+// (item 3); before the fix the mere presence of a throws clause forced the
+// `.initializer` diagnostic. That this DERIVES and round-trips is the guard.
+@Serializable
+@Deserializable
+public struct NonthrowingInitProbe: Equatable {
+  public var x: Int
+
+  public init(x: Int) throws(Never) {
+    self.x = x
+  }
+}
+
+// A `@MainActor`-isolated TYPE. A global-actor-isolated type isolates its
+// members, so a plainly-emitted `serialize`/`deserialize` would inherit that
+// isolation and could NOT satisfy the NONISOLATED `Serializable`/
+// `Deserializable` requirement — a Swift 6 conformance-isolation error that,
+// before the fix, made this shape fail to compile. The derive detects the
+// isolation and emits each witness `nonisolated`, restoring it to the
+// requirement's isolation; the value type's `Sendable` stored property stays
+// reachable from the nonisolated body. That this whole target builds
+// WARNING-FREE — the swiftc-level guard the expansion golden cannot give —
+// and round-trips is the guard.
+@MainActor
+@Serializable
+@Deserializable
+struct IsolatedProbe: Equatable {
+  var x: Int
+}
+
+// A `@MainActor`-isolated TYPE whose fields spell the standard Sendable
+// wrappers GENERICALLY — `Optional<Int>` / `Array<Int>` rather than the sugar
+// `Int?` / `[Int]`. Each is Sendable under the same condition as its sugar, so
+// the derive must recognize the generic spelling safe and emit `nonisolated`
+// witnesses — before the fix these fell through the sugar-only allowlist and
+// were diagnosed. That this target builds WARNING-FREE and round-trips is the
+// guard.
+@MainActor
+@Serializable
+@Deserializable
+struct IsolatedGenericProbe: Equatable {
+  var maybe: Optional<Int>
+  var many: Array<Int>
+}
+
+// A `@available(*, deprecated)` TYPE with a `@available(*, deprecated)` STORED
+// FIELD, derived on BOTH sides. Serialize reads `self.x`, which normally warns
+// on a deprecated field and breaks a warning-free build — but the derived
+// extension copies the type's `@available(*, deprecated)`, so the read sits in
+// a DEPRECATED context where Swift suppresses the warning. The field's
+// deprecation is thus COVERED by the enclosing type's, so the serialize side
+// must derive (not diagnose `.deprecated`). That this target builds
+// WARNING-FREE — the serialize `self.x` read inside the deprecated extension —
+// and round-trips is the guard. Before the fix the serialize guard rejected the
+// deprecated field unconditionally, so no `@Serializable` conformance was
+// emitted and this round-trip did not compile.
+@available(*, deprecated)
+@Serializable
+@Deserializable
+struct DeprecatedFieldCoveredProbe: Equatable {
+  @available(*, deprecated) var x: Int
+}
+
+// A generic struct whose field is written through a SAME-SCOPE typealias that
+// hides the parameter — `typealias Value = T; var value: Value`. The written
+// field type is only `Value`, no in-scope parameter, so a naive constraint walk
+// emits NO `where T: …` and the unconditional `extension Aliased: Serializable`
+// serializes an unconstrained `T` that fails to type-check. The derive must
+// EXPAND `Value` to `T` before the walk and emit the CONDITIONAL `where T: …`.
+// That `AliasedFieldProbe<Int>` COMPILES and round-trips is the real-compile
+// guard: before the fix the hidden `T` went unconstrained and the invalid
+// unconditional conformance did not compile.
+@Serializable
+@Deserializable
+public struct AliasedFieldProbe<T>: Equatable where T: Equatable {
+  public typealias Value = T
+  public var value: Value
+}
+
+// A generic struct whose field is written through a SAME-SCOPE typealias to a
+// WRAPPED dependent member — `typealias Values = Array<T.Element>; var values:
+// Values`. Expanding the alias must compose with the wrapped-dependent walk:
+// `Values` becomes `Array<T.Element>`, which descends to the dependent member
+// `T.Element`, so the derive emits `where T.Element: …`. That
+// `AliasedDependentProbe<Array<Int>>` (whose `Element` is the conforming `Int`)
+// COMPILES and round-trips — though the SEQUENCE `Array<Int>` need not itself
+// conform — is the guard.
+@Serializable
+@Deserializable
+public struct AliasedDependentProbe<T: Sequence>: Equatable
+    where T.Element: Equatable {
+  public typealias Values = Array<T.Element>
+  public var values: Values
+}
+
+// A tiny concrete format, in the CLIENT scope so it drives a macro-derived
+// value through the re-exported `Serializer`/`Deserializer` surface end to
+// end. It is fixed-width: an integer is its little-endian eight bytes and a
+// structure is its children back to back — enough to prove the derived
+// conformances round-trip. (The `Decant` test target has its own richer
+// version; this one exists so the client target, which never imports `Decant`
+// directly, still runs a round-trip.)
+private struct ClientSerializer: Serializer, ~Copyable {
+  typealias Failure = DecantError
+
+  var sink: ArraySink
+
+  init(_ sink: consuming ArraySink) {
+    self.sink = sink
+  }
+
+  consuming func finish() -> ArraySink {
+    sink
+  }
+
+  mutating func serialize(_ value: Bool) throws(DecantError) {
+    try sink.append(value ? 1 : 0)
+  }
+
+  mutating func serialize<T: FixedWidthInteger>(_ value: T)
+      throws(DecantError) {
+    let word = Int64(truncatingIfNeeded: value).littleEndian
+    try sink.append(withUnsafeBytes(of: word) { Array($0) })
+  }
+
+  mutating func serialize(_ value: Double) throws(DecantError) {
+    try sink.append(withUnsafeBytes(of: value.bitPattern.littleEndian) {
+      Array($0)
+    })
+  }
+
+  mutating func serialize(_ value: String) throws(DecantError) {
+    try sink.append(Array(value.utf8))
+  }
+
+  mutating func serialize(bytes: some Sequence<UInt8>) throws(DecantError) {
+    try sink.append(Array(bytes))
+  }
+
+  mutating func null() throws(DecantError) {
+    try sink.append(0)
+  }
+
+  mutating func some() throws(DecantError) {
+    try sink.append(1)
+  }
+
+  consuming func sequence(count: Int?) -> ClientSubSerializer {
+    // Write the element count as one little-endian word so the deserializer's
+    // `count()` reads it back; a known count is always supplied here (the
+    // derive never streams), so the `nil` case writes zero.
+    var this = self
+    try? this.serialize(Int64(count ?? 0))
+    return ClientSubSerializer(this)
+  }
+
+  consuming func structure(_ name: StaticString, fields count: Int)
+      -> ClientSubSerializer {
+    ClientSubSerializer(self)
+  }
+}
+
+private struct ClientSubSerializer: SequenceSerializer, StructureSerializer,
+    ~Copyable {
+  typealias Failure = DecantError
+  typealias Parent = ClientSerializer
+
+  var serializer: ClientSerializer?
+
+  init(_ serializer: consuming ClientSerializer) {
+    self.serializer = consume serializer
+  }
+
+  mutating func element<T: Serializable>(_ value: borrowing T)
+      throws(DecantError) {
+    serializer = try value.serialize(into: serializer.take()!)
+  }
+
+  mutating func field<T: Serializable>(_ name: StaticString,
+                                       _ value: borrowing T)
+      throws(DecantError) {
+    serializer = try value.serialize(into: serializer.take()!)
+  }
+
+  consuming func end() throws(DecantError) -> ClientSerializer {
+    var this = self
+    return this.serializer.take()!
+  }
+}
+
+private struct ClientDeserializer: Deserializer {
+  typealias Failure = DecantError
+
+  let storage: Array<UInt8>
+  var position: Int
+
+  init(_ bytes: Array<UInt8>) {
+    storage = bytes
+    position = 0
+  }
+
+  mutating func word() throws(DecantError) -> UInt64 {
+    guard position + 8 <= storage.count else { throw .truncated }
+    defer { position += 8 }
+    var value: UInt64 = 0
+    for index in 0 ..< 8 {
+      value |= UInt64(storage[position + index]) << (8 * index)
+    }
+    return value
+  }
+
+  mutating func byte() throws(DecantError) -> UInt8 {
+    guard position < storage.count else { throw .truncated }
+    defer { position += 1 }
+    return storage[position]
+  }
+
+  mutating func integer<T: FixedWidthInteger>(_: T.Type)
+      throws(DecantError) -> T {
+    T(truncatingIfNeeded: Int64(bitPattern: try word()))
+  }
+
+  mutating func bool() throws(DecantError) -> Bool {
+    try byte() != 0
+  }
+
+  mutating func double() throws(DecantError) -> Double {
+    Double(bitPattern: try word())
+  }
+
+  mutating func string() throws(DecantError) -> String {
+    ""
+  }
+
+  mutating func bytes() throws(DecantError) -> Array<UInt8> {
+    []
+  }
+
+  mutating func some() throws(DecantError) -> Bool {
+    try byte() != 0
+  }
+
+  mutating func count() throws(DecantError) -> Int {
+    Int(try word())
+  }
+
+  mutating func structure(_ name: StaticString, fields count: Int)
+      throws(DecantError) {}
+
+  mutating func end() throws(DecantError) {}
+}
+
+private func roundtrip<T: Serializable & Deserializable>(_ value: T)
+    throws(DecantError) -> T {
+  var serializer = ClientSerializer(ArraySink())
+  serializer = try value.serialize(into: serializer)
+  var deserializer = ClientDeserializer(serializer.finish().bytes)
+  return try deserializer.decode(T.self)
+}
+
+struct ClientRoundTripTests {
+  @Test func `a keyword-named field round-trips through the derive`() throws {
+    let probe = KeywordProbe(self: 1, init: 2, x: 3)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func `a raw-named field round-trips through the derive`() throws {
+    let probe = RawNameProbe(`foo bar`: 4, `quote"x`: 5)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func `an implicitly-unwrapped optional field round-trips`() throws {
+    let probe = IUOProbe(x: 6)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func `an underscore-named field round-trips through the derive`()
+      throws {
+    let probe = UnderscoreProbe(`_`: 1, x: 2)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func `a raw-named type round-trips through the derive`() throws {
+    let probe = `Quote"Type`(x: 8)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func `a type named for the generic parameter round-trips`() throws {
+    let probe = D(x: 9)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func `a built-in-attributed field round-trips through the derive`()
+      throws {
+    let probe = BuiltinAttributeProbe(x: 6, y: 7)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func `a matching user init round-trips through the derive`() throws {
+    let probe = MatchingInitProbe(value: 7)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func `a lone matching conditional init round-trips through the derive`()
+      throws {
+    let probe = ConditionalMatchingInitProbe(value: 8, tag: 9)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func `a type parameter named S round-trips through the derive`()
+      throws {
+    let probe = SerializerCollisionProbe<Never>(x: 10)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func `a type parameter named D round-trips through the derive`()
+      throws {
+    let probe = DeserializerCollisionProbe<Never>(x: 11)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func `a generic type's conditional conformance round-trips`() throws {
+    let probe = GenericFieldProbe<Int>(value: 10)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func `a two-parameter generic type round-trips through the derive`()
+      throws {
+    let probe = GenericPairProbe<Int, Int>(a: 11, b: 12)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func `a wrapper field's parameter-constrained conformance compiles`()
+      throws {
+    // `HolderProbe<Int>` conforms via the LEGAL `where T: Serializable` the
+    // derive lowered `Wrapper<T>` to — an applied `where Wrapper<T>: …` would
+    // not type-check. That this COMPILES (the client target builds) and
+    // round-trips is the real-compile guard the expansion golden cannot give.
+    let probe = HolderProbe<Int>(value: Wrapper(payload: 99))
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func `a container field's lowered element constraint round-trips`()
+      throws {
+    // `BagProbe<Int>` conforms via `where T: Serializable`, the element
+    // parameter its `Array<T>` (and nested `Array<Optional<T>>`) fields lower
+    // to. That it COMPILES and round-trips proves the lowered element clause is
+    // legal and sufficient.
+    let probe = BagProbe<Int>(items: [1, 2, 3], maybe: [4, nil, 6])
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func `a type nested in a generic context round-trips`() throws {
+    let probe = NestingProbe<Never, Never>.Inner(x: 12)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func `a doubly-nested type round-trips through the derive`() throws {
+    let probe = NestingProbe<Never, Never>.Middle<Never>.Leaf(y: 13)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func `a conditional field round-trips through the derive`() throws {
+    // `t` is under `#if true` (present); `skip` under `#if false` (absent), so
+    // the memberwise init is `ConditionalProbe(a:t:b:)`.
+    let probe = ConditionalProbe(a: 14, t: 15, b: 16)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func `an if-else active clause round-trips through the derive`()
+      throws {
+    let probe = IfElseActiveProbe(a: 17, live: 18, b: 19)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func `an if-else inactive clause round-trips through the derive`()
+      throws {
+    let probe = IfElseInactiveProbe(a: 20, chosen: 21, b: 22)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func `a defaulted conditional init round-trips through the derive`()
+      throws {
+    let probe = DefaultedConditionalInitProbe(kept: 23)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func `a no-availability init round-trips through the derive`() throws {
+    let probe = MatchingInitAvailabilityProbe(x: 24)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func
+      `a mutually-exclusive same #if field round-trips through the derive`()
+      throws {
+    let probe = ExclusiveSameFieldProbe(x: 25)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func
+      `a same-#if conditional-field init round-trips through the derive`()
+      throws {
+    let probe = ConditionalInitProbe(base: 26, x: 27)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func `an overloaded same-label init round-trips through the derive`()
+      throws {
+    let probe = OverloadedInitProbe(x: 28)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func `an extension init overload round-trips through the derive`()
+      throws {
+    let probe = ExtensionOverloadProbe(x: 29)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func `a tuple field disambiguates an extension overload`() throws {
+    let probe = TupleOverloadProbe(x: 30, y: 31)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func
+      `a type in a generic extension stores the enclosing parameter`() throws {
+    let probe = EnclosingExtensionProbe<Int>.Inner(value: 32)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func `an empty struct round-trips through the derive`() throws {
+    let probe = EmptyProbe()
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func `an empty conditional branch round-trips through the derive`()
+      throws {
+    let probe = EmptyBranchProbe()
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func `helper-only #if blocks round-trip through the derive`() throws {
+    let probe = HelperOnlyConditionalProbe(first: 29, second: 30)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func `a serialize-only over-cap struct serializes through the derive`()
+      throws {
+    let probe = ManyConditionalSerializeProbe(f1: 1, f2: 2, f3: 3, f4: 4,
+                                              f5: 5, f6: 6, f7: 7, f8: 8, f9: 9)
+    let serializer = try probe.serialize(into: ClientSerializer(ArraySink()))
+    #expect(serializer.finish().bytes.count == 9 * 8)
+  }
+
+  // The test is itself `@available(*, deprecated)` so its use of the deprecated
+  // type is warning-free; the guard is that the derived conformances exist and
+  // round-trip on a deprecated type.
+  @available(*, deprecated)
+  @Test func `a deprecated type round-trips through the derive`() throws {
+    let probe = DeprecatedProbe(x: 31)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @available(macOS 10.0, *)
+  @Test func `a platform-gated type round-trips through the derive`() throws {
+    let probe = PlatformProbe(x: 32)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  // The type is `@available(macOS 10.0, iOS 13.0, *)`, so the test carries the
+  // same gate to use it warning-free; the guard is that the derive covers the
+  // SAME-or-BROADER `@available(macOS 10.0, *)` init semantically per platform —
+  // its `*` fallback spans the type's iOS floor — and round-trips. Before the
+  // fix the exact-text gate comparison rejected the init, so this did not
+  // compile.
+  @available(macOS 10.0, iOS 13.0, *)
+  @Test func `a broader-gated init round-trips through the derive`() throws {
+    let probe = BroaderInitProbe(x: 33)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  // The test carries `@available(macOS, deprecated: 10.0)` so its use of the
+  // platform-deprecated type and init is warning-free on macOS; the guard is
+  // that the derived deserialize covers the init's deprecation ON ITS PLATFORM —
+  // the type is deprecated on macOS too, so the `Self(x: …)` call sits in a
+  // macOS-deprecated context — and round-trips warning-free.
+  @available(macOS, deprecated: 10.0)
+  @Test func
+      `a platform-deprecated init round-trips through the derive`() throws {
+    let probe = PlatformDeprecatedInitProbe(x: 40)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  // The nonisolated witnesses let a `@MainActor`-isolated type conform and
+  // round-trip. The test is itself `@MainActor` to build and compare the
+  // isolated value; the derived `serialize`/`deserialize` are nonisolated, so
+  // `roundtrip` calls them freely off the actor.
+  @MainActor
+  @Test func `a global-actor type round-trips through the derive`() throws {
+    let probe = IsolatedProbe(x: 34)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @MainActor
+  @Test func
+      `a global-actor type with generic wrappers round-trips`() throws {
+    let probe = IsolatedGenericProbe(maybe: 35, many: [36, 37])
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  // The test is itself `@available(*, deprecated)` so its use of the deprecated
+  // type and init is warning-free; the guard is that the derived deserialize —
+  // calling the deprecated `Self(x: …)` from the deprecated extension — exists
+  // and round-trips.
+  @available(*, deprecated)
+  @Test func `a deprecated-init type round-trips through the derive`() throws {
+    let probe = DeprecatedInitProbe(x: 38)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  // The test is itself `@available(*, deprecated)` so its use of the deprecated
+  // type and init is warning-free; the guard is that the derived deserialize
+  // covers the init by deprecation KIND — the init's `message: "init"` differs
+  // from the type's `message: "type"` — and round-trips. Before the fix the
+  // exact-text gate comparison rejected the init, so this did not compile.
+  @available(*, deprecated)
+  @Test func `a deprecated-init type with a differing message round-trips`()
+      throws {
+    let probe = DeprecatedMessageProbe(x: 41)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  // The test is itself `@available(*, deprecated)` so its use of the type
+  // nested in a deprecated enclosing type is warning-free; the guard is that
+  // the derived conformances INHERIT the enclosing `@available(*, deprecated)`
+  // (so the target builds warning-free) and round-trip.
+  @available(*, deprecated)
+  @Test func `a type in a deprecated enclosing type round-trips`() throws {
+    let probe = EnclosingDeprecatedProbe.Inner(x: 39)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func `a type storing an enclosing generic parameter round-trips`()
+      throws {
+    let probe = EnclosingGenericProbe<Int>.Inner(value: 40)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func `a qualified-member field keeps an unconditional conformance`()
+      throws {
+    // `QualifiedMemberProbe<NonSerial>` conforms though `NonSerial` is neither
+    // `Serializable` nor `Deserializable`: the field is the concrete
+    // `QualifiedNamespace.T`, so the conformance is unconditional and the `T`
+    // parameter is unconstrained. A `where T: …` clause would reject this.
+    let value = QualifiedNamespace.T(payload: 41)
+    let probe = QualifiedMemberProbe<NonSerial>(value: value)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func `a dependent-member field constrains the member directly`()
+      throws {
+    // `DependentMemberProbe<Array<Int>>` conforms via `where T.Element: …`,
+    // the dependent member the `T.Element` field lowers to. Its `Element` is
+    // the conforming `Int`, so it round-trips even though the SEQUENCE
+    // `Array<Int>` need not itself conform. A base-`T` reduction would have
+    // demanded that and rejected this.
+    let probe = DependentMemberProbe<Array<Int>>(value: 42)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func `an inferred qualified-symbol field derives unconstrained`()
+      throws {
+    // `InferredQualifiedProbe<NonSerial>` derives though its inferred field is
+    // initialised from `InferredNamespace.T()`, whose `.T` member equals the
+    // generic parameter: the structural walk of the initializer skips the
+    // qualified member, so no `.inferred` diagnostic fires. A flat token scan
+    // would have counted the `.T` and rejected it.
+    let probe = InferredQualifiedProbe<NonSerial>()
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func `a throws(Never) replacement init round-trips`() throws {
+    // `NonthrowingInitProbe`'s custom `init(x:) throws(Never)` is nonthrowing,
+    // so the derive's `Self(x: …)` type-checks and no `.initializer` diagnostic
+    // fires. A genuine `throws` init would still be diagnosed.
+    let probe = NonthrowingInitProbe(x: 43)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func
+      `a deprecated stored field deserializes through the derive`() throws {
+    // A `@Deserializable`-only struct over a deprecated stored field derives
+    // (the serialize side would read `self.x` and warn, but deserialize passes
+    // `x` as a memberwise-init argument, which does not). It is not
+    // `@Serializable`, so it is decoded directly rather than round-tripped: one
+    // little-endian word decodes to `x`. The `Equatable` compare and the
+    // `x:`-labeled init argument are not member accesses, so the test is
+    // warning-free too.
+    var deserializer =
+        ClientDeserializer([33, 0, 0, 0, 0, 0, 0, 0])
+    let probe = try deserializer.decode(DeprecatedFieldProbe.self)
+    #expect(probe == DeprecatedFieldProbe(x: 33))
+  }
+
+  @Test func `a wrapped dependent-member field constrains the member directly`()
+      throws {
+    // `WrappedDependentMemberProbe<Array<Int>>` conforms via `where
+    // T.Element: …`, the dependent member its `Array<T.Element>` field descends
+    // to. Its `Element` is the conforming `Int`, so it round-trips even though
+    // the SEQUENCE `Array<Int>` need not itself conform. A base-`T` reduction
+    // would have demanded that and rejected this.
+    let probe = WrappedDependentMemberProbe<Array<Int>>(values: [44, 45])
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func `a shared-binding overload resolves unambiguously`() throws {
+    // `SharedBindingOverloadProbe`'s `var x, y: Int` line gives `x` its shared
+    // `Int` type, so `Self(x:y:)` resolves to the `Int` init over the
+    // extension's `String` overload. Before the fix the untyped `x` left the
+    // call ambiguous and this did not compile.
+    let probe = SharedBindingOverloadProbe(x: 46, y: 47)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func `a shared-binding matching init round-trips`() throws {
+    // `SharedBindingInitProbe`'s matching `init(x: Int, y: Int)` covers the
+    // `var x, y: Int` line only once `x` carries the propagated `Int`. Before
+    // the fix the untyped `x` broke parity and the init was falsely rejected.
+    let probe = SharedBindingInitProbe(x: 48, y: 49)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func `a repeated generic init with one field type round-trips`()
+      throws {
+    // `RepeatedGenericInitProbe`'s `init<U>(x: U, y: U)` binds `U` to `Int` for
+    // both fields — a consistent binding — so it covers and round-trips. The
+    // reject twin (a `U` bound to two different types) is diagnosed instead.
+    let probe = RepeatedGenericInitProbe(x: 50, y: 51)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  // The test is itself `@available(*, deprecated)` so its use of the deprecated
+  // type is warning-free; the guard is that BOTH derives exist over a
+  // deprecated field under a deprecated type — serialize's `self.x` read is
+  // covered by the extension's copied `@available(*, deprecated)` — and
+  // round-trip.
+  @available(*, deprecated)
+  @Test func `a deprecated field under a deprecated type round-trips`() throws {
+    let probe = DeprecatedFieldCoveredProbe(x: 52)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func `a same-scope alias field constrains the hidden parameter`()
+      throws {
+    // `AliasedFieldProbe<Int>` conforms via `where T: …`, the parameter its
+    // `typealias Value = T` field hides. That it COMPILES and round-trips is
+    // the real-compile guard: before the alias expansion the hidden `T` went
+    // unconstrained and the unconditional conformance did not type-check.
+    let probe = AliasedFieldProbe<Int>(value: 53)
+    #expect(try roundtrip(probe) == probe)
+  }
+
+  @Test func `a same-scope alias to a wrapped dependent member constrains it`()
+      throws {
+    // `AliasedDependentProbe<Array<Int>>` conforms via `where T.Element: …`:
+    // the alias `Values = Array<T.Element>` expands and the array wrapper
+    // descends to the dependent member. Its `Element` is the conforming `Int`,
+    // so it round-trips though the SEQUENCE `Array<Int>` need not conform.
+    let probe = AliasedDependentProbe<Array<Int>>(values: [54, 55])
+    #expect(try roundtrip(probe) == probe)
+  }
+}

--- a/Tests/DecantMacrosTests/MacroExpansionTests.swift
+++ b/Tests/DecantMacrosTests/MacroExpansionTests.swift
@@ -1,0 +1,4861 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+import SwiftSyntaxMacros
+import SwiftSyntaxMacroExpansion
+import SwiftSyntaxMacrosGenericTestSupport
+@testable import DecantMacrosPlugin
+
+/// The macro specifications the expansion assertions run against — the derive
+/// macros mapped to the conformances they add.
+private let macros: Dictionary<String, MacroSpec> = [
+  "Serializable": MacroSpec(type: SerializableMacro.self,
+                            conformances: ["Serializable"]),
+  "Deserializable": MacroSpec(type: DeserializableMacro.self,
+                              conformances: ["Deserializable"]),
+]
+
+/// Asserts that `source` expands to `expanded`, routing any failure to
+/// swift-testing so it reads as a `@Test` failure rather than an XCTest one.
+private func expand(_ source: String, to expanded: String,
+                    _ location: SourceLocation = #_sourceLocation) {
+  assertMacroExpansion(source, expandedSource: expanded, macroSpecs: macros,
+                       failureHandler: { failure in
+                         Issue.record("\(failure.message)")
+                       })
+}
+
+struct MacroExpansionTests {
+  @Test func `Serializable writes each stored property in declaration order`() {
+    expand("""
+      @Serializable
+      struct Point {
+        var x: Int32
+        var y: Int32
+        var label: String
+      }
+      """,
+      to: """
+      struct Point {
+        var x: Int32
+        var y: Int32
+        var label: String
+      }
+
+      extension Point: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("Point", fields: 3)
+          try __macro_local_9structurefMu_.field("x", self.x)
+          try __macro_local_9structurefMu_.field("y", self.y)
+          try __macro_local_9structurefMu_.field("label", self.label)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func `Deserializable reads each property into its init argument`() {
+    expand("""
+      @Deserializable
+      struct Point {
+        var x: Int32
+        var y: Int32
+        var label: String
+      }
+      """,
+      to: """
+      struct Point {
+        var x: Int32
+        var y: Int32
+        var label: String
+      }
+
+      extension Point: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("Point", fields: 3)
+          let __macro_local_5valuefMu_ = try Self(x: deserializer.decode() as Int32, y: deserializer.decode() as Int32, label: deserializer.decode() as String)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func `a global-actor type derives nonisolated serialize`() {
+    // A `@MainActor` (or any global-actor-isolated) type isolates its members,
+    // so a plain `serialize` would inherit that isolation and could not satisfy
+    // the NONISOLATED `Serializable` requirement — a Swift 6 conformance-
+    // isolation error. The witness is emitted `nonisolated` so it satisfies the
+    // requirement; a value type's `Sendable` `self.<field>` reads stay
+    // reachable from the nonisolated body.
+    expand("""
+      @MainActor
+      @Serializable
+      struct S {
+        var x: Int
+      }
+      """,
+      to: """
+      @MainActor
+      struct S {
+        var x: Int
+      }
+
+      extension S: Decant.Serializable {
+        nonisolated public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("S", fields: 1)
+          try __macro_local_9structurefMu_.field("x", self.x)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func `a global-actor type derives nonisolated deserialize`() {
+    // The deserialize twin: a `@MainActor` type's `deserialize` is emitted
+    // `nonisolated` so it satisfies the nonisolated `Deserializable`
+    // requirement. The memberwise-init call runs from the nonisolated body.
+    expand("""
+      @MainActor
+      @Deserializable
+      struct S {
+        var x: Int
+      }
+      """,
+      to: """
+      @MainActor
+      struct S {
+        var x: Int
+      }
+
+      extension S: Decant.Deserializable {
+        nonisolated public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("S", fields: 1)
+          let __macro_local_5valuefMu_ = try Self(x: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func
+      `a global-actor type with a possibly non-Sendable field is diagnosed`() {
+    // The nonisolated witness of a global-actor-isolated type can read an
+    // isolated stored property (and call the memberwise init) only when the
+    // value is `Sendable`. A field whose written type is not a recognizably
+    // `Sendable` standard type may be non-Sendable — the syntactic macro cannot
+    // confirm the conformance — so the derive would emit `self.<field>` and
+    // `Self(<field>: …)` the compiler rejects from the nonisolated body.
+    // Diagnose up front rather than emit that. (An all-`Sendable` isolated type
+    // still derives — the goldens above.)
+    assertMacroExpansion("""
+      @MainActor
+      @Serializable
+      @Deserializable
+      struct S {
+        var c: C
+      }
+      """,
+      expandedSource: """
+      @MainActor
+      struct S {
+        var c: C
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.isolation.message,
+                       line: 2, column: 1),
+        DiagnosticSpec(message: DecantDiagnostic.isolation.message,
+                       line: 3, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func
+      `a non-isolated type with a non-Sendable field is not diagnosed`() {
+    // The isolation check is gated on the global actor: an UNISOLATED type's
+    // witness is not nonisolated, so its `self.<field>` read needs no
+    // Sendability, and a non-Sendable field derives unhindered.
+    expand("""
+      @Serializable
+      struct S {
+        var c: C
+      }
+      """,
+      to: """
+      struct S {
+        var c: C
+      }
+
+      extension S: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("S", fields: 1)
+          try __macro_local_9structurefMu_.field("c", self.c)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func `a non-isolated type derives an unmarked serialize`() {
+    // The negative half: a type carrying NO global-actor attribute is not
+    // isolated, so its witness is emitted WITHOUT `nonisolated`. The `@frozen`
+    // built-in attribute imposes no isolation and does not trip the check.
+    expand("""
+      @frozen
+      @Serializable
+      struct S {
+        var x: Int
+      }
+      """,
+      to: """
+      @frozen
+      struct S {
+        var x: Int
+      }
+
+      extension S: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("S", fields: 1)
+          try __macro_local_9structurefMu_.field("x", self.x)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func
+      `a global-actor field whose name merely contains Sendable is diagnosed`() {
+    // The Sendability check matches `Sendable` as a real identifier, not a
+    // SUBSTRING: a field typed `NonSendable` (a normal non-Sendable class)
+    // spells the letters `Sendable` but is not the `Sendable` protocol, so it
+    // may be actor-isolated non-Sendable state the nonisolated witness cannot
+    // reach. Diagnose it rather than let a `.contains("Sendable")` wave it
+    // through into code the compiler rejects.
+    assertMacroExpansion("""
+      @MainActor
+      @Serializable
+      @Deserializable
+      struct S {
+        var value: NonSendable
+      }
+      """,
+      expandedSource: """
+      @MainActor
+      struct S {
+        var value: NonSendable
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.isolation.message,
+                       line: 2, column: 1),
+        DiagnosticSpec(message: DecantDiagnostic.isolation.message,
+                       line: 3, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func
+      `a global-actor field of an array of a Sendable-substring type is diagnosed`()
+  {
+    // The substring trap also hid inside a container: `Array<NonSendable>`
+    // desugars to its element `NonSendable`, which is NOT the `Sendable`
+    // protocol, so the array is not vouched Sendable and the field is
+    // diagnosed. Only a genuine `Sendable` element (or standard value type)
+    // would make the array safe.
+    assertMacroExpansion("""
+      @MainActor
+      @Serializable
+      struct S {
+        var values: Array<NonSendable>
+      }
+      """,
+      expandedSource: """
+      @MainActor
+      struct S {
+        var values: Array<NonSendable>
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.isolation.message,
+                       line: 2, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func `a global-actor field of any Sendable derives nonisolated`() {
+    // An existential over the real `Sendable` protocol (`any Sendable`) IS
+    // Sendable, so an isolated stored property of it stays reachable from the
+    // nonisolated witness and the derive proceeds. The identifier check accepts
+    // it where the substring check happened to too — but here it is accepted
+    // for the RIGHT reason (a real `Sendable` token, not the substring).
+    expand("""
+      @MainActor
+      @Serializable
+      struct S {
+        var value: any Sendable
+      }
+      """,
+      to: """
+      @MainActor
+      struct S {
+        var value: any Sendable
+      }
+
+      extension S: Decant.Serializable {
+        nonisolated public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("S", fields: 1)
+          try __macro_local_9structurefMu_.field("value", self.value)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func `a global-actor field of a Sendable composition derives`() {
+    // A composition one of whose members is the real `Sendable` protocol
+    // (`P & Sendable`) is Sendable, so the field is safe and the derive
+    // proceeds — the composition-member half of the identifier check.
+    expand("""
+      @MainActor
+      @Serializable
+      struct S {
+        var value: any P & Sendable
+      }
+      """,
+      to: """
+      @MainActor
+      struct S {
+        var value: any P & Sendable
+      }
+
+      extension S: Decant.Serializable {
+        nonisolated public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("S", fields: 1)
+          try __macro_local_9structurefMu_.field("value", self.value)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func `an implicitly-unwrapped optional field casts to the optional`() {
+    // A field of implicitly-unwrapped optional type `Int!` cannot annotate its
+    // read as `decode() as Int!` — the `!` sugar is not a legal coercion
+    // target — so the cast is normalized to the optional `Int?`, which IS
+    // legal and which the memberwise-init parameter (still `Int!`) accepts.
+    expand("""
+      @Deserializable
+      struct S {
+        var x: Int!
+      }
+      """,
+      to: """
+      struct S {
+        var x: Int!
+      }
+
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("S", fields: 1)
+          let __macro_local_5valuefMu_ = try Self(x: deserializer.decode() as Int?)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func
+      `a nested implicitly-unwrapped optional field casts to the optional`() {
+    // The normalization rewrites only the outermost IUO sugar: `[Int]!` casts
+    // as `[Int]?`, the wrapped `[Int]` left verbatim.
+    expand("""
+      @Deserializable
+      struct S {
+        var y: [Int]!
+      }
+      """,
+      to: """
+      struct S {
+        var y: [Int]!
+      }
+
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("S", fields: 1)
+          let __macro_local_5valuefMu_ = try Self(y: deserializer.decode() as [Int]?)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func `an opaque field reads without an as coercion`() {
+    // An opaque `some P` field cannot annotate its read as
+    // `decode() as some …` — `some` is legal only in a declaration position,
+    // never as a cast target — so the read stays a bare `decode()`, whose
+    // contextual result type the opaque memberwise-init parameter drives. A
+    // concrete field keeps its `as` annotation (the sibling goldens); only the
+    // opaque one sheds it, exactly as a type-less field does.
+    expand("""
+      @Deserializable
+      struct S {
+        var x: some P & Decant.Deserializable = X()
+      }
+      """,
+      to: """
+      struct S {
+        var x: some P & Decant.Deserializable = X()
+      }
+
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("S", fields: 1)
+          let __macro_local_5valuefMu_ = try Self(x: deserializer.decode())
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func `an existential field keeps its as coercion`() {
+    // Only opaque `some` sheds the cast: an `any P` existential IS a legal
+    // coercion target, so it keeps the `decode() as any P` annotation like any
+    // concrete type.
+    expand("""
+      @Deserializable
+      struct S {
+        var x: any Decant.Deserializable
+      }
+      """,
+      to: """
+      struct S {
+        var x: any Decant.Deserializable
+      }
+
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("S", fields: 1)
+          let __macro_local_5valuefMu_ = try Self(x: deserializer.decode() as any Decant.Deserializable)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func `the derive skips a computed property`() {
+    expand("""
+      @Serializable
+      struct Box {
+        var value: Int
+        var doubled: Int { value * 2 }
+      }
+      """,
+      to: """
+      struct Box {
+        var value: Int
+        var doubled: Int { value * 2 }
+      }
+
+      extension Box: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("Box", fields: 1)
+          try __macro_local_9structurefMu_.field("value", self.value)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func `the derive ignores an attribute on a computed property`() {
+    // A computed property has no storage, so it is neither serialized nor a
+    // memberwise-init parameter and its attributes are irrelevant. The
+    // computed skip must run BEFORE the property-wrapper check, so an
+    // attribute the derive does not recognize (`@MainActor`) on the computed
+    // `y` is not misread as a wrapper and does not reject the whole derive;
+    // only the stored `x` is serialized.
+    expand("""
+      @Serializable
+      struct S {
+        var x: Int
+        @MainActor var y: Int { 0 }
+      }
+      """,
+      to: """
+      struct S {
+        var x: Int
+        @MainActor var y: Int { 0 }
+      }
+
+      extension S: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("S", fields: 1)
+          try __macro_local_9structurefMu_.field("x", self.x)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func
+      `the wrapper check still rejects a stored field beside a computed one`() {
+    // The reorder skips the computed `y` (its `@MainActor` ignored), but the
+    // property-wrapper check must still fire for the STORED wrapped `x`: a
+    // wrapper-backed stored property is rejected as before.
+    assertMacroExpansion("""
+      @Serializable
+      struct S {
+        @W(raw: 0) var x: Int
+        @MainActor var y: Int { 0 }
+      }
+      """,
+      expandedSource: """
+      struct S {
+        @W(raw: 0) var x: Int
+        @MainActor var y: Int { 0 }
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.wrapper.message,
+                       line: 1, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func `Serializable on a deprecated stored field is diagnosed`() {
+    // A deprecated stored field warns on every access, and serialize reads
+    // `self.<field>`; no structuring lets a non-deprecated witness touch it
+    // warning-free, so the field is diagnosed rather than emitted (mirroring
+    // the rejection of a deprecated init).
+    assertMacroExpansion("""
+      @Serializable
+      struct S {
+        @available(*, deprecated) var x: Int
+      }
+      """,
+      expandedSource: """
+      struct S {
+        @available(*, deprecated) var x: Int
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.deprecated.message,
+                       line: 1, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func `both derives on a deprecated stored field diagnose serialize`() {
+    // The serialize side of a combined `@Serializable @Deserializable` still
+    // reads `self.<field>`, so the deprecated-field rejection fires from the
+    // serialize expansion (which emits nothing) even when deserialize is
+    // derived alongside. Deserialize passes the field as a memberwise-init
+    // argument, not an access, so it derives warning-free next to the
+    // diagnostic.
+    assertMacroExpansion("""
+      @Serializable
+      @Deserializable
+      struct S {
+        @available(*, deprecated) var x: Int
+      }
+      """,
+      expandedSource: """
+      struct S {
+        @available(*, deprecated) var x: Int
+      }
+
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("S", fields: 1)
+          let __macro_local_5valuefMu_ = try Self(x: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.deprecated.message,
+                       line: 1, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func `Deserializable alone on a deprecated stored field derives`() {
+    // Deserialize passes the deprecated field as a memberwise-init argument
+    // (`Self(x: …)`), which is not an access and so does not warn — the derive
+    // is warning-free, so a `@Deserializable`-only shape is allowed rather than
+    // diagnosed (unlike the serialize side, which reads `self.<field>`).
+    expand("""
+      @Deserializable
+      struct S {
+        @available(*, deprecated) var x: Int
+      }
+      """,
+      to: """
+      struct S {
+        @available(*, deprecated) var x: Int
+      }
+
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("S", fields: 1)
+          let __macro_local_5valuefMu_ = try Self(x: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func `Serializable keeps an observed stored property in order`() {
+    expand("""
+      @Serializable
+      struct Counter {
+        var a: Int
+        var n: Int = 0 {
+          didSet {}
+        }
+        var b: Int
+      }
+      """,
+      to: """
+      struct Counter {
+        var a: Int
+        var n: Int = 0 {
+          didSet {}
+        }
+        var b: Int
+      }
+
+      extension Counter: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("Counter", fields: 3)
+          try __macro_local_9structurefMu_.field("a", self.a)
+          try __macro_local_9structurefMu_.field("n", self.n)
+          try __macro_local_9structurefMu_.field("b", self.b)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func `Deserializable keeps an observed stored property in order`() {
+    expand("""
+      @Deserializable
+      struct Counter {
+        var a: Int
+        var n: Int = 0 {
+          didSet {}
+        }
+        var b: Int
+      }
+      """,
+      to: """
+      struct Counter {
+        var a: Int
+        var n: Int = 0 {
+          didSet {}
+        }
+        var b: Int
+      }
+
+      extension Counter: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("Counter", fields: 3)
+          let __macro_local_5valuefMu_ = try Self(a: deserializer.decode() as Int, n: deserializer.decode() as Int, b: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func `Serializable destructures a tuple binding in order`() {
+    expand("""
+      @Serializable
+      struct Line {
+        var a: Int
+        var (x, y): (Int, Int)
+        var b: Int
+      }
+      """,
+      to: """
+      struct Line {
+        var a: Int
+        var (x, y): (Int, Int)
+        var b: Int
+      }
+
+      extension Line: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("Line", fields: 4)
+          try __macro_local_9structurefMu_.field("a", self.a)
+          try __macro_local_9structurefMu_.field("x", self.x)
+          try __macro_local_9structurefMu_.field("y", self.y)
+          try __macro_local_9structurefMu_.field("b", self.b)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func `Deserializable destructures a tuple binding in order`() {
+    expand("""
+      @Deserializable
+      struct Line {
+        var a: Int
+        var (x, y): (Int, Int)
+        var b: Int
+      }
+      """,
+      to: """
+      struct Line {
+        var a: Int
+        var (x, y): (Int, Int)
+        var b: Int
+      }
+
+      extension Line: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("Line", fields: 4)
+          let __macro_local_5valuefMu_ = try Self(a: deserializer.decode() as Int, x: deserializer.decode() as Int, y: deserializer.decode() as Int, b: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func `the derive names a tuple component for its pattern`() {
+    expand("""
+      @Serializable
+      struct Pair {
+        var (x, y): (p: Int, q: Int)
+      }
+      """,
+      to: """
+      struct Pair {
+        var (x, y): (p: Int, q: Int)
+      }
+
+      extension Pair: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("Pair", fields: 2)
+          try __macro_local_9structurefMu_.field("x", self.x)
+          try __macro_local_9structurefMu_.field("y", self.y)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func `the derive recurses through a nested tuple binding`() {
+    expand("""
+      @Deserializable
+      struct Nested {
+        var (x, (y, z)): (Int, (Int, Int))
+      }
+      """,
+      to: """
+      struct Nested {
+        var (x, (y, z)): (Int, (Int, Int))
+      }
+
+      extension Nested: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("Nested", fields: 3)
+          let __macro_local_5valuefMu_ = try Self(x: deserializer.decode() as Int, y: deserializer.decode() as Int, z: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func `the derive drops a wildcard tuple element`() {
+    expand("""
+      @Serializable
+      struct Half {
+        var (x, _): (Int, Int)
+      }
+      """,
+      to: """
+      struct Half {
+        var (x, _): (Int, Int)
+      }
+
+      extension Half: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("Half", fields: 1)
+          try __macro_local_9structurefMu_.field("x", self.x)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func `applying the derive to an enum is diagnosed`() {
+    assertMacroExpansion("""
+      @Serializable
+      enum Color {
+        case red
+        case green
+      }
+      """,
+      expandedSource: """
+      enum Color {
+        case red
+        case green
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.nonstruct.message,
+                       line: 1, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func `applying the derive to a lazy property is diagnosed`() {
+    assertMacroExpansion("""
+      @Serializable
+      struct S {
+        lazy var cache = 0
+      }
+      """,
+      expandedSource: """
+      struct S {
+        lazy var cache = 0
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.lazy.message,
+                       line: 1, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func `applying the derive to an initialized let is diagnosed`() {
+    assertMacroExpansion("""
+      @Deserializable
+      struct S {
+        let version = 1
+      }
+      """,
+      expandedSource: """
+      struct S {
+        let version = 1
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.constant.message,
+                       line: 1, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func `Serializable writes an initialized let it reads through self`() {
+    expand("""
+      @Serializable
+      struct S {
+        let version = 1
+        let x: Int
+      }
+      """,
+      to: """
+      struct S {
+        let version = 1
+        let x: Int
+      }
+
+      extension S: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("S", fields: 2)
+          try __macro_local_9structurefMu_.field("version", self.version)
+          try __macro_local_9structurefMu_.field("x", self.x)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func `applying the derive to a wrapper-backed property is diagnosed`() {
+    assertMacroExpansion("""
+      @Serializable
+      struct S {
+        @W(raw: 0) var x: Int
+      }
+      """,
+      expandedSource: """
+      struct S {
+        @W(raw: 0) var x: Int
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.wrapper.message,
+                       line: 1, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func `applying the derive to a qualified-wrapper property is diagnosed`()
+  {
+    assertMacroExpansion("""
+      @Serializable
+      struct S {
+        @MyModule.W(raw: 0) var x: Int
+      }
+      """,
+      expandedSource: """
+      struct S {
+        @MyModule.W(raw: 0) var x: Int
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.wrapper.message,
+                       line: 1, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func `the derive keeps a property carrying a built-in attribute`() {
+    // A built-in declaration attribute — a plain `@available` platform gate —
+    // is not a property wrapper, so the field is collected and serialized
+    // rather than rejected. (A *deprecated* `@available` is a separate case:
+    // its `self.<field>` read would warn, so it is diagnosed instead.)
+    expand("""
+      @Serializable
+      struct S {
+        @available(macOS 10.0, *) var x: Int
+        var y: Int
+      }
+      """,
+      to: """
+      struct S {
+        @available(macOS 10.0, *) var x: Int
+        var y: Int
+      }
+
+      extension S: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("S", fields: 2)
+          try __macro_local_9structurefMu_.field("x", self.x)
+          try __macro_local_9structurefMu_.field("y", self.y)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func `the derive keeps a property carrying @DecantName or @DecantSkip`()
+  {
+    expand("""
+      @Serializable
+      struct S {
+        @DecantName var x: Int
+        @DecantSkip var y: Int
+      }
+      """,
+      to: """
+      struct S {
+        @DecantName var x: Int
+        @DecantSkip var y: Int
+      }
+
+      extension S: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("S", fields: 2)
+          try __macro_local_9structurefMu_.field("x", self.x)
+          try __macro_local_9structurefMu_.field("y", self.y)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func `the derive keeps an uninitialized let and initialized var`() {
+    expand("""
+      @Deserializable
+      struct S {
+        let x: Int
+        var y = 0
+      }
+      """,
+      to: """
+      struct S {
+        let x: Int
+        var y = 0
+      }
+
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("S", fields: 2)
+          let __macro_local_5valuefMu_ = try Self(x: deserializer.decode() as Int, y: deserializer.decode())
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func `Serializable reads a field named for a local through self`() {
+    expand("""
+      @Serializable
+      struct S {
+        var structure: Int
+        var serializer: Int
+      }
+      """,
+      to: """
+      struct S {
+        var structure: Int
+        var serializer: Int
+      }
+
+      extension S: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("S", fields: 2)
+          try __macro_local_9structurefMu_.field("structure", self.structure)
+          try __macro_local_9structurefMu_.field("serializer", self.serializer)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func `Deserializable reads a param-named field in argument position`()
+  {
+    expand("""
+      @Deserializable
+      struct S {
+        var deserializer: Int
+        var value: Int
+      }
+      """,
+      to: """
+      struct S {
+        var deserializer: Int
+        var value: Int
+      }
+
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("S", fields: 2)
+          let __macro_local_5valuefMu_ = try Self(deserializer: deserializer.decode() as Int, value: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func `the derive skips a type-level stored property`() {
+    expand("""
+      @Deserializable
+      struct S {
+        static let version = 1
+        static var shared = 0
+        let x: Int
+        var y: Int
+      }
+      """,
+      to: """
+      struct S {
+        static let version = 1
+        static var shared = 0
+        let x: Int
+        var y: Int
+      }
+
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("S", fields: 2)
+          let __macro_local_5valuefMu_ = try Self(x: deserializer.decode() as Int, y: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func `the derive reads an inferred-type field without annotating it`() {
+    expand("""
+      @Deserializable
+      struct S {
+        var count = 0
+        let name: String
+      }
+      """,
+      to: """
+      struct S {
+        var count = 0
+        let name: String
+      }
+
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("S", fields: 2)
+          let __macro_local_5valuefMu_ = try Self(count: deserializer.decode(), name: deserializer.decode() as String)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func `Serializable escapes a keyword field name in the member access`()
+  {
+    expand("""
+      @Serializable
+      struct S {
+        var `self`: Int
+        var `init`: Int
+        var x: Int
+      }
+      """,
+      to: """
+      struct S {
+        var `self`: Int
+        var `init`: Int
+        var x: Int
+      }
+
+      extension S: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("S", fields: 3)
+          try __macro_local_9structurefMu_.field("self", self.`self`)
+          try __macro_local_9structurefMu_.field("init", self.`init`)
+          try __macro_local_9structurefMu_.field("x", self.x)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func `Serializable escapes a raw field name in each emission context`()
+  {
+    // A raw identifier (SE-0451) carries characters no bare interpolation
+    // survives: the member access must backtick it and the string key must be
+    // a valid literal — a `"` forces `#"…"#` delimiters.
+    expand("""
+      @Serializable
+      struct S {
+        var `foo bar`: Int
+        var `quote"x`: Int
+      }
+      """,
+      to: """
+      struct S {
+        var `foo bar`: Int
+        var `quote"x`: Int
+      }
+
+      extension S: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("S", fields: 2)
+          try __macro_local_9structurefMu_.field("foo bar", self.`foo bar`)
+          try __macro_local_9structurefMu_.field(#"quote"x"#, self.`quote"x`)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func `Deserializable escapes a raw field name in the init label`() {
+    // A raw identifier is NOT a valid bare argument label (`foo bar:` is a
+    // syntax error), so the label must keep its backticks — unlike a keyword,
+    // which stays bare.
+    expand("""
+      @Deserializable
+      struct S {
+        var `foo bar`: Int
+        var `quote"x`: Int
+      }
+      """,
+      to: """
+      struct S {
+        var `foo bar`: Int
+        var `quote"x`: Int
+      }
+
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("S", fields: 2)
+          let __macro_local_5valuefMu_ = try Self(`foo bar`: deserializer.decode() as Int, `quote"x`: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func `Deserializable keeps a keyword field name bare in the init label`()
+  {
+    // An argument label accepts a keyword unescaped — escaping one instead
+    // warns — so the bare `self:` / `init:` labels are correct, and only the
+    // serialize member access above is escaped.
+    expand("""
+      @Deserializable
+      struct S {
+        var `self`: Int
+        var `init`: Int
+        var x: Int
+      }
+      """,
+      to: """
+      struct S {
+        var `self`: Int
+        var `init`: Int
+        var x: Int
+      }
+
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("S", fields: 3)
+          let __macro_local_5valuefMu_ = try Self(self: deserializer.decode() as Int, init: deserializer.decode() as Int, x: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func `Serializable escapes an underscore field name in the member access`()
+  {
+    // The wildcard `_` is a plain, non-keyword identifier, so the keyword and
+    // raw-identifier rules leave it bare — but a bare `self._` does not parse,
+    // so the member access must backtick it. The serialization-name STRING key
+    // stays the bare `"_"` (data, not an identifier).
+    expand("""
+      @Serializable
+      struct S {
+        var `_`: Int
+        var x: Int
+      }
+      """,
+      to: """
+      struct S {
+        var `_`: Int
+        var x: Int
+      }
+
+      extension S: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("S", fields: 2)
+          try __macro_local_9structurefMu_.field("_", self.`_`)
+          try __macro_local_9structurefMu_.field("x", self.x)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func `Deserializable escapes an underscore field name in the init label`()
+  {
+    // A bare `_:` argument label is an OMITTED (positional) label, not the real
+    // `_` label the memberwise init requires, so the label must be backticked
+    // (`` `_`: ``) — unlike an ordinary keyword, which stays bare. Escaping `_`
+    // as a label warns for neither a keyword nor a raw identifier.
+    expand("""
+      @Deserializable
+      struct S {
+        var `_`: Int
+        var x: Int
+      }
+      """,
+      to: """
+      struct S {
+        var `_`: Int
+        var x: Int
+      }
+
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("S", fields: 2)
+          let __macro_local_5valuefMu_ = try Self(`_`: deserializer.decode() as Int, x: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func `Serializable spells a raw type name safely in each context`() {
+    // A raw type name (SE-0451) carrying a quote must be spelled by position:
+    // the `extension` header keeps the backticks (identifier position) while
+    // the serialized structure name is the CANONICAL bare name as a valid
+    // string literal — the quote forces `#"…"#` delimiters.
+    expand(#"""
+      @Serializable
+      struct `Quote"Type` {
+        var x: Int
+      }
+      """#,
+      to: #"""
+      struct `Quote"Type` {
+        var x: Int
+      }
+
+      extension `Quote"Type`: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure(#"Quote"Type"#, fields: 1)
+          try __macro_local_9structurefMu_.field("x", self.x)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """#)
+  }
+
+  @Test func `Deserializable spells a raw type name safely in each context`() {
+    // The `extension` header keeps the backticks (an identifier position); the
+    // `structure(…)` argument is the canonical bare name as a valid `#"…"#`
+    // literal. The constructor is `Self`, so the raw type name never appears in
+    // call position.
+    expand(#"""
+      @Deserializable
+      struct `Quote"Type` {
+        var x: Int
+      }
+      """#,
+      to: #"""
+      struct `Quote"Type` {
+        var x: Int
+      }
+
+      extension `Quote"Type`: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure(#"Quote"Type"#, fields: 1)
+          let __macro_local_5valuefMu_ = try Self(x: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """#)
+  }
+
+  @Test func `deserialize constructs Self, not the model type name`() {
+    // The deserialize signature names its generic `Deserializer` parameter `D`.
+    // A model named `D` collides with it, so a by-name constructor (`try D(…)`)
+    // would resolve to the generic parameter, not the model. The derive spells
+    // the constructor `Self`, which is the conforming type unambiguously, so a
+    // `struct D` derives — the `try Self(x: …)` line below is the guard.
+    expand("""
+      @Deserializable
+      struct D {
+        var x: Int
+      }
+      """,
+      to: """
+      struct D {
+        var x: Int
+      }
+
+      extension D: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("D", fields: 1)
+          let __macro_local_5valuefMu_ = try Self(x: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func `deserialize is diagnosed when a custom init suppresses the init`()
+  {
+    assertMacroExpansion("""
+      @Deserializable
+      struct S {
+        var x: Int
+        init() {
+          x = 0
+        }
+      }
+      """,
+      expandedSource: """
+      struct S {
+        var x: Int
+        init() {
+          x = 0
+        }
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.initializer.message,
+                       line: 1, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func `a matching user init suppresses no diagnostic and derives`() {
+    expand("""
+      @Deserializable
+      struct S {
+        var x: Int
+        init(x: Int) {
+          self.x = x
+        }
+      }
+      """,
+      to: """
+      struct S {
+        var x: Int
+        init(x: Int) {
+          self.x = x
+        }
+      }
+
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("S", fields: 1)
+          let __macro_local_5valuefMu_ = try Self(x: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func `deserialize is diagnosed when an init matches by label only`() {
+    // The label matches, but `init(x: String)` reconstructs an `Int` field
+    // from a `String` decode: a shape a non-self-converting format round-trips
+    // wrong, so the type mismatch must still diagnose.
+    assertMacroExpansion("""
+      @Deserializable
+      struct S {
+        var x: Int
+        init(x: String) {
+          self.x = Int(x) ?? 0
+        }
+      }
+      """,
+      expandedSource: """
+      struct S {
+        var x: Int
+        init(x: String) {
+          self.x = Int(x) ?? 0
+        }
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.initializer.message,
+                       line: 1, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func `deserialize is diagnosed when a matching field has no type`() {
+    // `count`'s type is inferred from its initializer, so the macro cannot
+    // prove `init(count: Int)`'s parameter type equals it; equivalence is
+    // unprovable, so the init does not match and the diagnostic fires.
+    assertMacroExpansion("""
+      @Deserializable
+      struct S {
+        var count = 0
+        init(count: Int) {
+          self.count = count
+        }
+      }
+      """,
+      expandedSource: """
+      struct S {
+        var count = 0
+        init(count: Int) {
+          self.count = count
+        }
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.initializer.message,
+                       line: 1, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func
+      `deserialize is diagnosed when a repeated generic binds two types`() {
+    // The init reuses one generic `U` for `x` and `y`, whose fields are `Int`
+    // and `String`. A per-label match would read the init as covering, but the
+    // emitted `Self(x: … as Int, y: … as String)` would infer `U` as both — a
+    // conflict Swift rejects. The candidate is rejected as inconsistent, so the
+    // intended `.initializer` diagnostic fires rather than uncompilable code.
+    assertMacroExpansion("""
+      @Deserializable
+      struct S {
+        var x: Int
+        var y: String
+        init<U>(x: U, y: U) {
+          self.x = x as! Int
+          self.y = y as! String
+        }
+      }
+      """,
+      expandedSource: """
+      struct S {
+        var x: Int
+        var y: String
+        init<U>(x: U, y: U) {
+          self.x = x as! Int
+          self.y = y as! String
+        }
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.initializer.message,
+                       line: 1, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func `deserialize is diagnosed when only a failable init matches`() {
+    assertMacroExpansion("""
+      @Deserializable
+      struct S {
+        var x: Int
+        init?(x: Int) {
+          self.x = x
+        }
+      }
+      """,
+      expandedSource: """
+      struct S {
+        var x: Int
+        init?(x: Int) {
+          self.x = x
+        }
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.initializer.message,
+                       line: 1, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func `deserialize is diagnosed when only a throwing init matches`() {
+    assertMacroExpansion("""
+      @Deserializable
+      struct S {
+        var x: Int
+        init(x: Int) throws {
+          self.x = x
+        }
+      }
+      """,
+      expandedSource: """
+      struct S {
+        var x: Int
+        init(x: Int) throws {
+          self.x = x
+        }
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.initializer.message,
+                       line: 1, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func `a throws(Never) replacement init derives without diagnosis`() {
+    // Swift treats `throws(Never)` as NONTHROWING, so the custom
+    // `init(x:) throws(Never)` is callable as the derive's `Self(x: …)` with no
+    // error the typed-throws context must absorb. The init-candidate check
+    // accepts it — a genuine `throws` (above) is still diagnosed — and the
+    // derive emits the memberwise-equivalent call unchanged.
+    expand("""
+      @Deserializable
+      struct S {
+        var x: Int
+        init(x: Int) throws(Never) {
+          self.x = x
+        }
+      }
+      """,
+      to: """
+      struct S {
+        var x: Int
+        init(x: Int) throws(Never) {
+          self.x = x
+        }
+      }
+
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("S", fields: 1)
+          let __macro_local_5valuefMu_ = try Self(x: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func `deserialize is diagnosed when only an async init matches`() {
+    assertMacroExpansion("""
+      @Deserializable
+      struct S {
+        var x: Int
+        init(x: Int) async {
+          self.x = x
+        }
+      }
+      """,
+      expandedSource: """
+      struct S {
+        var x: Int
+        init(x: Int) async {
+          self.x = x
+        }
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.initializer.message,
+                       line: 1, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func `deserialize is diagnosed for a MainActor-isolated init`() {
+    // `@MainActor init(x: Int)` matches the `x` label and the `Int` spelling,
+    // but the derive's synchronous, nonisolated `deserialize` witness cannot
+    // call an actor-isolated init — `Self(x: deserializer.decode())` would be
+    // an isolation violation. The custom (non-built-in) attribute signals the
+    // init is not a nonisolated replacement, so it is a non-match and the
+    // `.initializer` diagnostic fires rather than an ill-typed expansion.
+    assertMacroExpansion("""
+      @Deserializable
+      struct S {
+        var x: Int
+        @MainActor init(x: Int) {
+          self.x = x
+        }
+      }
+      """,
+      expandedSource: """
+      struct S {
+        var x: Int
+        @MainActor init(x: Int) {
+          self.x = x
+        }
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.initializer.message,
+                       line: 1, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func `deserialize is diagnosed for a custom global-actor init`() {
+    // A custom global actor is a custom attribute like `@MainActor`, imposing
+    // isolation the nonisolated witness cannot honor, so `@MyActor init(x:)` is
+    // a non-match and the `.initializer` diagnostic fires.
+    assertMacroExpansion("""
+      @Deserializable
+      struct S {
+        var x: Int
+        @MyActor init(x: Int) {
+          self.x = x
+        }
+      }
+      """,
+      expandedSource: """
+      struct S {
+        var x: Int
+        @MyActor init(x: Int) {
+          self.x = x
+        }
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.initializer.message,
+                       line: 1, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func `deserialize is diagnosed for an isolated-parameter init`() {
+    // An `isolated` parameter parses as a specified type, so it is rejected
+    // like `inout`/`borrowing`: the derive's by-value call cannot supply it,
+    // and the `.initializer` diagnostic fires.
+    assertMacroExpansion("""
+      @Deserializable
+      struct S {
+        var x: MyActor
+        init(x: isolated MyActor) {
+          self.x = x
+        }
+      }
+      """,
+      expandedSource: """
+      struct S {
+        var x: MyActor
+        init(x: isolated MyActor) {
+          self.x = x
+        }
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.initializer.message,
+                       line: 1, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func `an inlinable user init matches and derives`() {
+    // A built-in declaration attribute — `@inlinable` — does not impose actor
+    // isolation on the synchronous nonisolated call, so an `@inlinable` init
+    // remains a valid memberwise-equivalent replacement: it matches, no
+    // diagnostic fires, and the derive proceeds.
+    expand("""
+      @Deserializable
+      struct S {
+        var x: Int
+        @inlinable init(x: Int) {
+          self.x = x
+        }
+      }
+      """,
+      to: """
+      struct S {
+        var x: Int
+        @inlinable init(x: Int) {
+          self.x = x
+        }
+      }
+
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("S", fields: 1)
+          let __macro_local_5valuefMu_ = try Self(x: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func `Serializable with a custom init is not diagnosed`() {
+    expand("""
+      @Serializable
+      struct S {
+        var x: Int
+        init() {
+          x = 0
+        }
+      }
+      """,
+      to: """
+      struct S {
+        var x: Int
+        init() {
+          x = 0
+        }
+      }
+
+      extension S: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("S", fields: 1)
+          try __macro_local_9structurefMu_.field("x", self.x)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func `the derive skips a static property on the serialize side`() {
+    expand("""
+      @Serializable
+      struct S {
+        static let version = 1
+        let x: Int
+        var y: Int
+      }
+      """,
+      to: """
+      struct S {
+        static let version = 1
+        let x: Int
+        var y: Int
+      }
+
+      extension S: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("S", fields: 2)
+          try __macro_local_9structurefMu_.field("x", self.x)
+          try __macro_local_9structurefMu_.field("y", self.y)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func `the derive gives its generic parameter a hygienic name`() {
+    // The serialize/deserialize generic parameter is always hygienic, even for
+    // a type whose parameter (`T`) does not collide with `S`/`D`: the compiler
+    // hands the macro the declaration detached from its enclosing tree, so a
+    // readable `S`/`D` could still shadow an enclosing context's parameter the
+    // macro cannot see. A `__macro_local_…` name never shadows.
+    expand("""
+      @Serializable
+      @Deserializable
+      struct Pair<T> {
+        var x: Int
+        var y: Int
+      }
+      """,
+      to: """
+      struct Pair<T> {
+        var x: Int
+        var y: Int
+      }
+
+      extension Pair: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("Pair", fields: 2)
+          try __macro_local_9structurefMu_.field("x", self.x)
+          try __macro_local_9structurefMu_.field("y", self.y)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+
+      extension Pair: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("Pair", fields: 2)
+          let __macro_local_5valuefMu_ = try Self(x: deserializer.decode() as Int, y: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func `a type parameter named S does not shadow the serializer`() {
+    // The type's own `S` would collide with a readable serialize `<S>`; the
+    // hygienic name sidesteps it, as it does for any parameter name.
+    expand("""
+      @Serializable
+      struct Box<S> {
+        var x: Int
+      }
+      """,
+      to: """
+      struct Box<S> {
+        var x: Int
+      }
+
+      extension Box: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("Box", fields: 1)
+          try __macro_local_9structurefMu_.field("x", self.x)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func `a type parameter named D does not shadow the deserializer`() {
+    // The deserialize twin — the type's own `D` would collide with a readable
+    // `<D>`; the hygienic name sidesteps it.
+    expand("""
+      @Deserializable
+      struct Box<D> {
+        var x: Int
+      }
+      """,
+      to: """
+      struct Box<D> {
+        var x: Int
+      }
+
+      extension Box: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("Box", fields: 1)
+          let __macro_local_5valuefMu_ = try Self(x: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func `a type nested in a generic context does not shadow`() {
+    // The derive is applied to `Inner`, which is not itself generic, but is
+    // nested in `Outer<S>`. A readable serialize `<S>` would shadow `Outer`'s
+    // `S` (an error under Swift 6). The hygienic parameter name avoids it even
+    // though the detached declaration cannot reveal the enclosing `S`.
+    expand("""
+      struct Outer<S> {
+        @Serializable
+        struct Inner {
+          var x: Int
+        }
+      }
+      """,
+      to: """
+      struct Outer<S> {
+        struct Inner {
+          var x: Int
+        }
+      }
+
+      extension Outer.Inner: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("Outer.Inner", fields: 1)
+          try __macro_local_9structurefMu_.field("x", self.x)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func `deserialize is diagnosed for an omitted-label positional init`() {
+    // The field is named `_`, and the only init takes a POSITIONAL parameter
+    // (`init(_ x: Int)`, an omitted external label), which is NOT the escaped
+    // `` `_` `` label the derive emits as `` Self(`_`: …) ``. The omitted `_`
+    // must not be conflated with a field named `_`, so the init does not match
+    // and the `.initializer` diagnostic fires — rather than emitting a call the
+    // positional init does not accept.
+    assertMacroExpansion("""
+      @Deserializable
+      struct S {
+        var `_`: Int
+        init(_ x: Int) {
+          self.`_` = x
+        }
+      }
+      """,
+      expandedSource: """
+      struct S {
+        var `_`: Int
+        init(_ x: Int) {
+          self.`_` = x
+        }
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.initializer.message,
+                       line: 1, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func `deserialize is diagnosed for a non-matching conditional init`() {
+    // An init inside an active `#if` still suppresses the synthesized
+    // memberwise init in that build, but the scan once saw only top-level
+    // inits, so the active branch derived an uncompilable `Self(x: …)`. The
+    // scan now recurses through the `#if` clause; the plugin cannot resolve the
+    // condition (`#if true` keeps the branch deterministically active), so a
+    // non-matching conditional init diagnoses conservatively.
+    assertMacroExpansion("""
+      @Deserializable
+      struct S {
+        var x: Int
+        #if true
+        init() {
+          self.x = 0
+        }
+        #endif
+      }
+      """,
+      expandedSource: """
+      struct S {
+        var x: Int
+        #if true
+        init() {
+          self.x = 0
+        }
+        #endif
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.initializer.message,
+                       line: 1, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func `a matching conditional init suppresses no diagnostic and derives`()
+  {
+    // A conditional init that matches the fields is safe in either build:
+    // active it replaces the memberwise init, inactive the memberwise init is
+    // synthesized, so it never diagnoses and the derive proceeds. The `#if`
+    // guards no stored field, so it is dropped from the emission entirely — the
+    // serialized field set never varies — and the count and `Self(…)` are the
+    // plain unconditional shape.
+    expand("""
+      @Deserializable
+      struct S {
+        var x: Int
+        #if true
+        init(x: Int) {
+          self.x = x
+        }
+        #endif
+      }
+      """,
+      to: """
+      struct S {
+        var x: Int
+        #if true
+        init(x: Int) {
+          self.x = x
+        }
+        #endif
+      }
+
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("S", fields: 1)
+          let __macro_local_5valuefMu_ = try Self(x: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func `deserialize is diagnosed for a nested conditional init`() {
+    // The recursion descends through a nested `#if`, so a non-matching init two
+    // `#if` levels deep is still found and diagnosed.
+    assertMacroExpansion("""
+      @Deserializable
+      struct S {
+        var x: Int
+        #if true
+        #if true
+        init() {
+          self.x = 0
+        }
+        #endif
+        #endif
+      }
+      """,
+      expandedSource: """
+      struct S {
+        var x: Int
+        #if true
+        #if true
+        init() {
+          self.x = 0
+        }
+        #endif
+        #endif
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.initializer.message,
+                       line: 1, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func
+      `deserialize is diagnosed when a matching clause has a non-matching sibling`()
+  {
+    // The `#if true` clause holds a matching init, but the mutually-exclusive
+    // `#else` clause holds a non-matching one — and in the build where the
+    // `#else` is active, its `init()` still suppresses the memberwise init with
+    // no callable `Self(x: …)` target. A per-branch scan finds the `#else`
+    // clause unsafe (no match in reach), so it diagnoses even though the `#if`
+    // build alone would compile; a global "some clause matches" scan misses it.
+    assertMacroExpansion("""
+      @Deserializable
+      struct S {
+        var x: Int
+        #if true
+        init(x: Int) {
+          self.x = x
+        }
+        #else
+        init() {
+          self.x = 0
+        }
+        #endif
+      }
+      """,
+      expandedSource: """
+      struct S {
+        var x: Int
+        #if true
+        init(x: Int) {
+          self.x = x
+        }
+        #else
+        init() {
+          self.x = 0
+        }
+        #endif
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.initializer.message,
+                       line: 1, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func
+      `deserialize is diagnosed when the non-matching sibling is the #if clause`()
+  {
+    // The reverse arrangement: the `#else` clause matches while the `#if false`
+    // clause does not. The plugin cannot resolve the condition, so it holds
+    // each clause to its own active init set; the `#if` clause's `init()`
+    // suppresses with no match in reach, so the derive still diagnoses.
+    assertMacroExpansion("""
+      @Deserializable
+      struct S {
+        var x: Int
+        #if false
+        init() {
+          self.x = 0
+        }
+        #else
+        init(x: Int) {
+          self.x = x
+        }
+        #endif
+      }
+      """,
+      expandedSource: """
+      struct S {
+        var x: Int
+        #if false
+        init() {
+          self.x = 0
+        }
+        #else
+        init(x: Int) {
+          self.x = x
+        }
+        #endif
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.initializer.message,
+                       line: 1, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func
+      `deserialize is diagnosed for two non-matching #elseif clauses`() {
+    // Neither mutually-exclusive clause carries a matching init, so every
+    // active build suppresses with no callable target; both scopes are unsafe.
+    assertMacroExpansion("""
+      @Deserializable
+      struct S {
+        var x: Int
+        #if false
+        init() {
+          self.x = 0
+        }
+        #elseif true
+        init(y: Int) {
+          self.x = y
+        }
+        #endif
+      }
+      """,
+      expandedSource: """
+      struct S {
+        var x: Int
+        #if false
+        init() {
+          self.x = 0
+        }
+        #elseif true
+        init(y: Int) {
+          self.x = y
+        }
+        #endif
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.initializer.message,
+                       line: 1, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func
+      `a top-level match saves a non-matching conditional sibling init`() {
+    // A top-level matching init is active in every build, so it replaces the
+    // memberwise init the conditional `init()` also suppresses — every build
+    // has a callable `Self(x: …)` target. The per-build analysis pairs the
+    // active fields with the active inits: the `#if true` build sees both
+    // inits, the `#else` build only the top-level one, and each covers the
+    // single `x`, so no diagnostic fires. The `#if` guards no stored field, so
+    // it is dropped from the emission and the plain shape derives.
+    expand("""
+      @Deserializable
+      struct S {
+        var x: Int
+        init(x: Int) {
+          self.x = x
+        }
+        #if true
+        init() {
+          self.init(x: 0)
+        }
+        #endif
+      }
+      """,
+      to: """
+      struct S {
+        var x: Int
+        init(x: Int) {
+          self.x = x
+        }
+        #if true
+        init() {
+          self.init(x: 0)
+        }
+        #endif
+      }
+
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("S", fields: 1)
+          let __macro_local_5valuefMu_ = try Self(x: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func `deserialize is diagnosed for an inout-parameter init`() {
+    // `init(x: inout Int)` matches the `x` label and the bare `Int` spelling,
+    // but the derive's by-value `Self(x: deserializer.decode())` cannot bind
+    // the `inout` parameter's lvalue, so the specified parameter is a non-match
+    // and the `.initializer` diagnostic fires.
+    assertMacroExpansion("""
+      @Deserializable
+      struct S {
+        var x: Int
+        init(x: inout Int) {
+          self.x = x
+        }
+      }
+      """,
+      expandedSource: """
+      struct S {
+        var x: Int
+        init(x: inout Int) {
+          self.x = x
+        }
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.initializer.message,
+                       line: 1, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func `deserialize is diagnosed for a borrowing-parameter init`() {
+    // An ownership specifier the memberwise init never carries is rejected the
+    // same way as `inout`: the derive's by-value call cannot satisfy it.
+    assertMacroExpansion("""
+      @Deserializable
+      struct S {
+        var x: Int
+        init(x: borrowing Int) {
+          self.x = x
+        }
+      }
+      """,
+      expandedSource: """
+      struct S {
+        var x: Int
+        init(x: borrowing Int) {
+          self.x = x
+        }
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.initializer.message,
+                       line: 1, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func `Serializable mirrors a conditional field's #if guard`() {
+    // A stored property under `#if` cannot be counted or written
+    // unconditionally — the plugin never resolves the condition — so the derive
+    // mirrors the guard: a count accumulator tallies the field only in its
+    // clause, and the write is emitted under the same `#if`.
+    expand("""
+      @Serializable
+      struct S {
+        var a: Int
+        #if os(Windows)
+        var trace: Int
+        #endif
+        var b: Int
+      }
+      """,
+      to: """
+      struct S {
+        var a: Int
+        #if os(Windows)
+        var trace: Int
+        #endif
+        var b: Int
+      }
+
+      extension S: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_6fieldsfMu_ = 2
+          #if os(Windows)
+          __macro_local_6fieldsfMu_ += 1
+          #endif
+          var __macro_local_9structurefMu_ = (consume serializer).structure("S", fields: __macro_local_6fieldsfMu_)
+          try __macro_local_9structurefMu_.field("a", self.a)
+          #if os(Windows)
+          try __macro_local_9structurefMu_.field("trace", self.trace)
+          #endif
+          try __macro_local_9structurefMu_.field("b", self.b)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func `Deserializable emits a per-branch Self for a conditional field`()
+  {
+    // An initializer's argument list cannot hold a `#if`, so the derive emits a
+    // complete `Self(…)` per branch under the mirrored guard. A `#if` with no
+    // `#else` still needs a leaf for the inactive case — its field absent — so
+    // an `#else` is synthesized. The count accumulator frames the whole tree.
+    expand("""
+      @Deserializable
+      struct S {
+        var a: Int
+        #if os(Windows)
+        var trace: Int
+        #endif
+        var b: Int
+      }
+      """,
+      to: """
+      struct S {
+        var a: Int
+        #if os(Windows)
+        var trace: Int
+        #endif
+        var b: Int
+      }
+
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          var __macro_local_6fieldsfMu_ = 2
+          #if os(Windows)
+          __macro_local_6fieldsfMu_ += 1
+          #endif
+          try deserializer.structure("S", fields: __macro_local_6fieldsfMu_)
+          #if os(Windows)
+          let __macro_local_5valuefMu_ = try Self(a: deserializer.decode() as Int, trace: deserializer.decode() as Int, b: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+          #else
+          let __macro_local_5valuefMu_ = try Self(a: deserializer.decode() as Int, b: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+          #endif
+        }
+      }
+      """)
+  }
+
+  @Test func `Deserializable mirrors an #if/#elseif/#else chain`() {
+    // Each clause of the chain is a distinct branch, so the derive emits a
+    // `Self(…)` per clause carrying that clause's active field. The source
+    // `#else` is the exhaustive fallback, so no `#else` is synthesized.
+    expand("""
+      @Deserializable
+      struct S {
+        var a: Int
+        #if DEBUG
+        var d: Int
+        #elseif TEST
+        var t: Int
+        #else
+        var r: Int
+        #endif
+      }
+      """,
+      to: """
+      struct S {
+        var a: Int
+        #if DEBUG
+        var d: Int
+        #elseif TEST
+        var t: Int
+        #else
+        var r: Int
+        #endif
+      }
+
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          var __macro_local_6fieldsfMu_ = 1
+          #if DEBUG
+          __macro_local_6fieldsfMu_ += 1
+          #elseif TEST
+          __macro_local_6fieldsfMu_ += 1
+          #else
+          __macro_local_6fieldsfMu_ += 1
+          #endif
+          try deserializer.structure("S", fields: __macro_local_6fieldsfMu_)
+          #if DEBUG
+          let __macro_local_5valuefMu_ = try Self(a: deserializer.decode() as Int, d: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+          #elseif TEST
+          let __macro_local_5valuefMu_ = try Self(a: deserializer.decode() as Int, t: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+          #else
+          let __macro_local_5valuefMu_ = try Self(a: deserializer.decode() as Int, r: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+          #endif
+        }
+      }
+      """)
+  }
+
+  @Test func `Serializable recurses through a nested #if`() {
+    // A `#if` inside a clause recurses: the count accumulates the outer then
+    // the inner field under nested guards, each write emitted under both.
+    expand("""
+      @Serializable
+      struct S {
+        #if A
+        var x: Int
+        #if B
+        var y: Int
+        #endif
+        #endif
+      }
+      """,
+      to: """
+      struct S {
+        #if A
+        var x: Int
+        #if B
+        var y: Int
+        #endif
+        #endif
+      }
+
+      extension S: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_6fieldsfMu_ = 0
+          #if A
+          __macro_local_6fieldsfMu_ += 1
+          #if B
+          __macro_local_6fieldsfMu_ += 1
+          #endif
+          #endif
+          var __macro_local_9structurefMu_ = (consume serializer).structure("S", fields: __macro_local_6fieldsfMu_)
+          #if A
+          try __macro_local_9structurefMu_.field("x", self.x)
+          #if B
+          try __macro_local_9structurefMu_.field("y", self.y)
+          #endif
+          #endif
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func `too many independent #if blocks is diagnosed`() {
+    // The per-branch deserialize calls are the cartesian product of the blocks'
+    // clauses, so nine two-clause `#if`s would emit 2^9 = 512 `Self(…)` calls,
+    // past the 256 cap. The `.conditional` diagnostic fires instead.
+    assertMacroExpansion("""
+      @Deserializable
+      struct S {
+        #if A
+        var a: Int
+        #endif
+        #if B
+        var b: Int
+        #endif
+        #if C
+        var c: Int
+        #endif
+        #if D
+        var d: Int
+        #endif
+        #if E
+        var e: Int
+        #endif
+        #if F
+        var f: Int
+        #endif
+        #if G
+        var g: Int
+        #endif
+        #if H
+        var h: Int
+        #endif
+        #if I
+        var i: Int
+        #endif
+      }
+      """,
+      expandedSource: """
+      struct S {
+        #if A
+        var a: Int
+        #endif
+        #if B
+        var b: Int
+        #endif
+        #if C
+        var c: Int
+        #endif
+        #if D
+        var d: Int
+        #endif
+        #if E
+        var e: Int
+        #endif
+        #if F
+        var f: Int
+        #endif
+        #if G
+        var g: Int
+        #endif
+        #if H
+        var h: Int
+        #endif
+        #if I
+        var i: Int
+        #endif
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.conditional.message,
+                       line: 1, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func
+      `deserialize is diagnosed for a conditional-field init without a default`()
+  {
+    // `x` is a `#if`-guarded conditional field, so the branch that omits the
+    // clause emits `Self(base:)` — but the top-level `init(base:x:)` suppresses
+    // the memberwise init in every build and gives `x` no default, so that
+    // shorter call cannot resolve. The init is a non-match and the
+    // `.initializer` diagnostic fires.
+    assertMacroExpansion("""
+      @Deserializable
+      struct S {
+        var base: Int
+        #if true
+        var x: Int
+        #endif
+        init(base: Int, x: Int) {
+          self.base = base
+        }
+      }
+      """,
+      expandedSource: """
+      struct S {
+        var base: Int
+        #if true
+        var x: Int
+        #endif
+        init(base: Int, x: Int) {
+          self.base = base
+        }
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.initializer.message,
+                       line: 1, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func
+      `a conditional-field init with a default derives`() {
+    // The same shape, but `x`'s parameter now carries a default, so the branch
+    // that omits the `#if` clause resolves `Self(base:)` through it and the
+    // branch that keeps it passes `x`. The init matches in every build, no
+    // diagnostic fires, and the per-branch `Self(…)` shape derives.
+    expand("""
+      @Deserializable
+      struct S {
+        var base: Int
+        #if true
+        var x: Int
+        #endif
+        init(base: Int, x: Int = 0) {
+          self.base = base
+        }
+      }
+      """,
+      to: """
+      struct S {
+        var base: Int
+        #if true
+        var x: Int
+        #endif
+        init(base: Int, x: Int = 0) {
+          self.base = base
+        }
+      }
+
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          var __macro_local_6fieldsfMu_ = 1
+          #if true
+          __macro_local_6fieldsfMu_ += 1
+          #endif
+          try deserializer.structure("S", fields: __macro_local_6fieldsfMu_)
+          #if true
+          let __macro_local_5valuefMu_ = try Self(base: deserializer.decode() as Int, x: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+          #else
+          let __macro_local_5valuefMu_ = try Self(base: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+          #endif
+        }
+      }
+      """)
+  }
+
+  @Test func `deserialize is diagnosed for an unavailable init`() {
+    // `@available(*, unavailable)` makes the init uncallable, so the derive's
+    // `Self(x: …)` would resolve to an unavailable initializer — a hard error.
+    // The init is a non-match, so the safe `.initializer` diagnostic fires
+    // instead. `@available` is a built-in, so only its arguments — not the
+    // attribute itself — flag it.
+    assertMacroExpansion("""
+      @Deserializable
+      struct S {
+        var x: Int
+        @available(*, unavailable) init(x: Int) {
+          self.x = x
+        }
+      }
+      """,
+      expandedSource: """
+      struct S {
+        var x: Int
+        @available(*, unavailable) init(x: Int) {
+          self.x = x
+        }
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.initializer.message,
+                       line: 1, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func `deserialize is diagnosed for an obsoleted init`() {
+    // An `obsoleted:` argument likewise makes the init uncallable past the
+    // version, so it is a non-match and the `.initializer` diagnostic fires.
+    assertMacroExpansion("""
+      @Deserializable
+      struct S {
+        var x: Int
+        @available(macOS, obsoleted: 1.0) init(x: Int) {
+          self.x = x
+        }
+      }
+      """,
+      expandedSource: """
+      struct S {
+        var x: Int
+        @available(macOS, obsoleted: 1.0) init(x: Int) {
+          self.x = x
+        }
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.initializer.message,
+                       line: 1, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func `deserialize is diagnosed for a deprecated init`() {
+    // Calling a `deprecated` init WARNS at the emitted `Self(x: …)`, which the
+    // warning-free build rejects, so a `deprecated` `@available` is a non-match
+    // too and the `.initializer` diagnostic fires rather than a warning.
+    assertMacroExpansion("""
+      @Deserializable
+      struct S {
+        var x: Int
+        @available(*, deprecated) init(x: Int) {
+          self.x = x
+        }
+      }
+      """,
+      expandedSource: """
+      struct S {
+        var x: Int
+        @available(*, deprecated) init(x: Int) {
+          self.x = x
+        }
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.initializer.message,
+                       line: 1, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func `deserialize is diagnosed for a version-restricted init`() {
+    // A short-form platform version restriction (`@available(macOS 10.0, *)`)
+    // gates the init to a deployment target the generated witness is NOT
+    // emitted under, so `Self(x: …)` compiles above the version and errors
+    // below it — the macro cannot guarantee the witness is gated the same. The
+    // init is therefore not a safe unconditional replacement; it is a non-match
+    // and the `.initializer` diagnostic fires.
+    assertMacroExpansion("""
+      @Deserializable
+      struct S {
+        var x: Int
+        @available(macOS 10.0, *) init(x: Int) {
+          self.x = x
+        }
+      }
+      """,
+      expandedSource: """
+      struct S {
+        var x: Int
+        @available(macOS 10.0, *) init(x: Int) {
+          self.x = x
+        }
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.initializer.message,
+                       line: 1, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func `deserialize is diagnosed for a swift-version-restricted init`() {
+    // The language-version spelling (`@available(swift 99)`) gates the init to
+    // a Swift version the witness is not emitted under, exactly like a platform
+    // version restriction, so it is a non-match and the `.initializer`
+    // diagnostic fires rather than an uncallable `Self(x: …)`.
+    assertMacroExpansion("""
+      @Deserializable
+      struct S {
+        var x: Int
+        @available(swift 99) init(x: Int) {
+          self.x = x
+        }
+      }
+      """,
+      expandedSource: """
+      struct S {
+        var x: Int
+        @available(swift 99) init(x: Int) {
+          self.x = x
+        }
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.initializer.message,
+                       line: 1, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func `deserialize is diagnosed for an introduced-restricted init`() {
+    // The long-form version restriction (`@available(macOS, introduced: 99)`)
+    // gates the init like the short form, so it too is a non-match and the
+    // `.initializer` diagnostic fires.
+    assertMacroExpansion("""
+      @Deserializable
+      struct S {
+        var x: Int
+        @available(macOS, introduced: 99) init(x: Int) {
+          self.x = x
+        }
+      }
+      """,
+      expandedSource: """
+      struct S {
+        var x: Int
+        @available(macOS, introduced: 99) init(x: Int) {
+          self.x = x
+        }
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.initializer.message,
+                       line: 1, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func
+      `an init gated the same as the type is covered and derives`() {
+    // The type is `@available(macOS 10.0, *)`, so the generated extension
+    // carries that same gate and the witness's `Self(x: …)` runs only where the
+    // conformance exists — exactly where the equally-gated `init(x: Int)` is
+    // callable. The init's gate is covered by the type's, so it is a safe
+    // replacement: no `.initializer` diagnostic, and the extension leads with
+    // the copied `@available(macOS 10.0, *)`.
+    expand("""
+      @available(macOS 10.0, *)
+      @Deserializable
+      struct S {
+        var x: Int
+        @available(macOS 10.0, *) init(x: Int) {
+          self.x = x
+        }
+      }
+      """,
+      to: """
+      @available(macOS 10.0, *)
+      struct S {
+        var x: Int
+        @available(macOS 10.0, *) init(x: Int) {
+          self.x = x
+        }
+      }
+
+      @available(macOS 10.0, *)
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("S", fields: 1)
+          let __macro_local_5valuefMu_ = try Self(x: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func
+      `a deprecated init covered by a deprecated type derives`() {
+    // The type is `@available(*, deprecated)`, so the generated extension is
+    // emitted deprecated too; a `Self(x: …)` inside a deprecated extension
+    // raises no deprecation warning, so the equally-deprecated `init(x: Int)`
+    // is a warning-free replacement. Its deprecation is covered by the type's,
+    // so no `.initializer` diagnostic fires and the extension leads with the
+    // copied `@available(*, deprecated)`.
+    expand("""
+      @available(*, deprecated)
+      @Deserializable
+      struct S {
+        var x: Int
+        @available(*, deprecated) init(x: Int) {
+          self.x = x
+        }
+      }
+      """,
+      to: """
+      @available(*, deprecated)
+      struct S {
+        var x: Int
+        @available(*, deprecated) init(x: Int) {
+          self.x = x
+        }
+      }
+
+      @available(*, deprecated)
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("S", fields: 1)
+          let __macro_local_5valuefMu_ = try Self(x: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func
+      `a deprecated init derives when the type's deprecation differs`() {
+    // The type is `@available(*, deprecated, message: "type")` and the init is
+    // `@available(*, deprecated, message: "init")` — the two deprecations spell
+    // DIFFERENT messages. The generated extension is still emitted deprecated,
+    // and Swift suppresses the `Self(x: …)` deprecation warning inside a
+    // deprecated context REGARDLESS of the message, so the init stays a
+    // warning-free replacement. Coverage is by availability KIND — a deprecated
+    // gate covers a deprecated init — not by exact gate text, so no
+    // `.initializer` diagnostic fires and the extension leads with the copied
+    // `@available(*, deprecated, message: "type")`.
+    expand("""
+      @available(*, deprecated, message: "type")
+      @Deserializable
+      struct S {
+        var x: Int
+        @available(*, deprecated, message: "init") init(x: Int) {
+          self.x = x
+        }
+      }
+      """,
+      to: """
+      @available(*, deprecated, message: "type")
+      struct S {
+        var x: Int
+        @available(*, deprecated, message: "init") init(x: Int) {
+          self.x = x
+        }
+      }
+
+      @available(*, deprecated, message: "type")
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("S", fields: 1)
+          let __macro_local_5valuefMu_ = try Self(x: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func
+      `a deprecated init on a non-deprecated type is still diagnosed`() {
+    // The type carries no deprecation, so the extension is not deprecated and
+    // the `Self(x: …)` call to a `deprecated` init WARNS — the deprecation is
+    // NOT covered by the (empty) type gate, so the `.initializer` diagnostic
+    // still fires.
+    assertMacroExpansion("""
+      @Deserializable
+      struct S {
+        var x: Int
+        @available(*, deprecated) init(x: Int) {
+          self.x = x
+        }
+      }
+      """,
+      expandedSource: """
+      struct S {
+        var x: Int
+        @available(*, deprecated) init(x: Int) {
+          self.x = x
+        }
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.initializer.message,
+                       line: 1, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func
+      `an init gated narrower than the type is diagnosed`() {
+    // The type is `@available(macOS 10.0, *)` but the init is
+    // `@available(macOS 99, *)` — a NARROWER gate the extension does NOT carry.
+    // Below macOS 99 the witness compiles yet `Self(x: …)` calls an unavailable
+    // init, so the gate is not covered and the init is not a safe replacement:
+    // the `.initializer` diagnostic fires.
+    assertMacroExpansion("""
+      @available(macOS 10.0, *)
+      @Deserializable
+      struct S {
+        var x: Int
+        @available(macOS 99, *) init(x: Int) {
+          self.x = x
+        }
+      }
+      """,
+      expandedSource: """
+      @available(macOS 10.0, *)
+      struct S {
+        var x: Int
+        @available(macOS 99, *) init(x: Int) {
+          self.x = x
+        }
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.initializer.message,
+                       line: 2, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func
+      `an init gated broader than the type is covered and derives`() {
+    // The type is `@available(macOS 10.0, iOS 13.0, *)`, so the extension
+    // carries that gate; the init is `@available(macOS 10.0, *)` — a SAME-or-
+    // BROADER gate. Per platform: on macOS the init's 10.0 floor matches the
+    // type's, and on iOS the init's `*` fallback (no floor) is broader than the
+    // type's 13.0, so the init is available everywhere the extension is. The
+    // coverage is SEMANTIC and per platform, not by exact gate text, so the
+    // broader init is a safe replacement and the derive proceeds, leading with
+    // the copied `@available(macOS 10.0, iOS 13.0, *)`.
+    expand("""
+      @available(macOS 10.0, iOS 13.0, *)
+      @Deserializable
+      struct S {
+        var x: Int
+        @available(macOS 10.0, *) init(x: Int) {
+          self.x = x
+        }
+      }
+      """,
+      to: """
+      @available(macOS 10.0, iOS 13.0, *)
+      struct S {
+        var x: Int
+        @available(macOS 10.0, *) init(x: Int) {
+          self.x = x
+        }
+      }
+
+      @available(macOS 10.0, iOS 13.0, *)
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("S", fields: 1)
+          let __macro_local_5valuefMu_ = try Self(x: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func
+      `a platform-matched deprecated init is covered and derives`() {
+    // The type and the init are BOTH `@available(macOS, deprecated: 10.0)` — a
+    // platform-scoped deprecation on the SAME platform. The extension inherits
+    // the type's macOS deprecation, so the `Self(x: …)` call sits inside a
+    // macOS-deprecated context where Swift suppresses the init's deprecation
+    // warning. The deprecation is covered on its platform, so the derive
+    // proceeds warning-free, leading with the copied
+    // `@available(macOS, deprecated: 10.0)`.
+    expand("""
+      @available(macOS, deprecated: 10.0)
+      @Deserializable
+      struct S {
+        var x: Int
+        @available(macOS, deprecated: 10.0) init(x: Int) {
+          self.x = x
+        }
+      }
+      """,
+      to: """
+      @available(macOS, deprecated: 10.0)
+      struct S {
+        var x: Int
+        @available(macOS, deprecated: 10.0) init(x: Int) {
+          self.x = x
+        }
+      }
+
+      @available(macOS, deprecated: 10.0)
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("S", fields: 1)
+          let __macro_local_5valuefMu_ = try Self(x: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func
+      `a platform-mismatched deprecated init is diagnosed`() {
+    // The type is `@available(iOS, deprecated: 13.0)` but the init is
+    // `@available(macOS, deprecated: 10.0)` — deprecations on DIFFERENT
+    // platforms. On a macOS build the extension is NOT macOS-deprecated, so the
+    // `Self(x: …)` call to the macOS-deprecated init WARNS there — the
+    // deprecation is not covered on its platform. The `.initializer` diagnostic
+    // fires rather than the macro emitting warning-tripping code. (A single
+    // global boolean — "the type is deprecated somewhere" — would wrongly accept
+    // it and leave the macOS warning; the per-platform model rejects it.)
+    assertMacroExpansion("""
+      @available(iOS, deprecated: 13.0)
+      @Deserializable
+      struct S {
+        var x: Int
+        @available(macOS, deprecated: 10.0) init(x: Int) {
+          self.x = x
+        }
+      }
+      """,
+      expandedSource: """
+      @available(iOS, deprecated: 13.0)
+      struct S {
+        var x: Int
+        @available(macOS, deprecated: 10.0) init(x: Int) {
+          self.x = x
+        }
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.initializer.message,
+                       line: 2, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func `a user init with no availability matches and derives`() {
+    // The control for the version-restricted rejections: an init carrying no
+    // `@available` (nor any other disqualifying attribute) is a plain
+    // memberwise-equivalent replacement, so it matches, no diagnostic fires,
+    // and the derive proceeds.
+    expand("""
+      @Deserializable
+      struct S {
+        var x: Int
+        init(x: Int) {
+          self.x = x
+        }
+      }
+      """,
+      to: """
+      struct S {
+        var x: Int
+        init(x: Int) {
+          self.x = x
+        }
+      }
+
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("S", fields: 1)
+          let __macro_local_5valuefMu_ = try Self(x: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func
+      `a replacement init for mutually-exclusive same #if fields derives`() {
+    // Mutually-exclusive `#if` clauses declare the SAME field `x`, so EVERY
+    // build's emitted call is `Self(x:)` — one active `x`, never both copies.
+    // `init(x: Int)` is the exact replacement in every branch. A flattened
+    // field list holds two `x`s and fails the count check, but the per-branch
+    // match sees one active `x` per branch and derives; no `.initializer`.
+    expand("""
+      @Deserializable
+      struct S {
+        #if true
+        var x: Int
+        #else
+        var x: Int
+        #endif
+        init(x: Int) {
+          self.x = x
+        }
+      }
+      """,
+      to: """
+      struct S {
+        #if true
+        var x: Int
+        #else
+        var x: Int
+        #endif
+        init(x: Int) {
+          self.x = x
+        }
+      }
+
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          var __macro_local_6fieldsfMu_ = 0
+          #if true
+          __macro_local_6fieldsfMu_ += 1
+          #else
+          __macro_local_6fieldsfMu_ += 1
+          #endif
+          try deserializer.structure("S", fields: __macro_local_6fieldsfMu_)
+          #if true
+          let __macro_local_5valuefMu_ = try Self(x: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+          #else
+          let __macro_local_5valuefMu_ = try Self(x: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+          #endif
+        }
+      }
+      """)
+  }
+
+  @Test func `a field-less #if guarding only members contributes no branch`() {
+    // An `#if` around a helper method, a typealias, or a computed property
+    // guards no STORED field, so the serialized field set is identical in every
+    // clause. The derive drops such a block entirely rather than mirror it: the
+    // emission stays the plain shape over the two real fields, and the block
+    // adds no deserialize branch to multiply.
+    expand("""
+      @Deserializable
+      struct S {
+        var a: Int
+        #if os(Windows)
+        func helper() {}
+        #endif
+        #if DEBUG
+        typealias Alias = Int
+        #else
+        var computed: Int { 0 }
+        #endif
+        var b: Int
+      }
+      """,
+      to: """
+      struct S {
+        var a: Int
+        #if os(Windows)
+        func helper() {}
+        #endif
+        #if DEBUG
+        typealias Alias = Int
+        #else
+        var computed: Int { 0 }
+        #endif
+        var b: Int
+      }
+
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("S", fields: 2)
+          let __macro_local_5valuefMu_ = try Self(a: deserializer.decode() as Int, b: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func
+      `many field-less #if blocks that would exceed the cap still derive`() {
+    // Nine two-clause field-less `#if` blocks would be 2^9 = 512 branches —
+    // past the 256 cap — WERE they counted. Each guards only a method, so none
+    // is a stored field and all are dropped; the branch product stays 1 and the
+    // derive proceeds over the single real field rather than diagnosing
+    // `.conditional`.
+    let blocks = (0 ..< 9).map { index in
+      "  #if C\(index)\n  func f\(index)() {}\n  #else\n"
+        + "  func g\(index)() {}\n  #endif"
+    }.joined(separator: "\n")
+    expand("@Deserializable\nstruct S {\n  var x: Int\n\(blocks)\n}",
+      to: """
+      struct S {
+        var x: Int
+      \(blocks)
+      }
+
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("S", fields: 1)
+          let __macro_local_5valuefMu_ = try Self(x: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func
+      `a conditional init covering only its active branch derives`() {
+    // `init(base:x:)` lives inside the SAME `#if` as its conditional field `x`,
+    // so it is compiled only in the build where `x` is too. The per-build
+    // analysis pairs them: the active build has fields `[base, x]` and the init
+    // covering them, the inactive build has only `base` and NO active init, so
+    // the synthesized `init(base:)` applies. Neither build is unsafe, so no
+    // `.initializer` diagnostic fires though `x` has no default — the earlier
+    // global scan wrongly demanded the conditional init cover the build it is
+    // not compiled in.
+    expand("""
+      @Deserializable
+      struct S {
+        var base: Int
+        #if true
+        var x: Int
+        init(base: Int, x: Int) {
+          self.base = base
+          self.x = x
+        }
+        #endif
+      }
+      """,
+      to: """
+      struct S {
+        var base: Int
+        #if true
+        var x: Int
+        init(base: Int, x: Int) {
+          self.base = base
+          self.x = x
+        }
+        #endif
+      }
+
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          var __macro_local_6fieldsfMu_ = 1
+          #if true
+          __macro_local_6fieldsfMu_ += 1
+          #endif
+          try deserializer.structure("S", fields: __macro_local_6fieldsfMu_)
+          #if true
+          let __macro_local_5valuefMu_ = try Self(base: deserializer.decode() as Int, x: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+          #else
+          let __macro_local_5valuefMu_ = try Self(base: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+          #endif
+        }
+      }
+      """)
+  }
+
+  @Test func
+      `ambiguous same-label inits decode with an explicit field type`() {
+    // Both `init(x: Int)` and `init(x: String)` are active, so the bare
+    // `Self(x: deserializer.decode())` leaves the generic `decode()` no result
+    // type and the `init(x:)` overload set is ambiguous. The derive reads the
+    // field with its declared type — `decode() as Int` — so overload resolution
+    // picks `init(x: Int)`; no diagnostic fires.
+    expand("""
+      @Deserializable
+      struct S {
+        var x: Int
+        init(x: Int) {
+          self.x = x
+        }
+        init(x: String) {
+          self.x = Int(x) ?? 0
+        }
+      }
+      """,
+      to: """
+      struct S {
+        var x: Int
+        init(x: Int) {
+          self.x = x
+        }
+        init(x: String) {
+          self.x = Int(x) ?? 0
+        }
+      }
+
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("S", fields: 1)
+          let __macro_local_5valuefMu_ = try Self(x: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func `a single matching init still annotates the decode by type`() {
+    // The derive annotates each typed field's read `decode() as <type>` even
+    // when one `init(x: Int)` makes the call unambiguous: the annotation is
+    // harmless here, and it is what disambiguates an init declared in an
+    // extension — invisible to the macro yet live in overload resolution.
+    expand("""
+      @Deserializable
+      struct S {
+        var x: Int
+        init(x: Int) {
+          self.x = x
+        }
+      }
+      """,
+      to: """
+      struct S {
+        var x: Int
+        init(x: Int) {
+          self.x = x
+        }
+      }
+
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("S", fields: 1)
+          let __macro_local_5valuefMu_ = try Self(x: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func
+      `an ambiguous overload set on an inferred-type field is diagnosed`() {
+    // The field `x` has no written type (inferred from its initializer), so the
+    // ambiguous `init(x:)` overload set cannot be broken by an explicit
+    // annotation — there is no type to spell. The ambiguity is unresolvable
+    // syntactically, so the `.initializer` diagnostic fires.
+    assertMacroExpansion("""
+      @Deserializable
+      struct S {
+        var x = 0
+        init(x: Int) {
+          self.x = x
+        }
+        init(x: String) {
+          self.x = Int(x) ?? 0
+        }
+      }
+      """,
+      expandedSource: """
+      struct S {
+        var x = 0
+        init(x: Int) {
+          self.x = x
+        }
+        init(x: String) {
+          self.x = Int(x) ?? 0
+        }
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.initializer.message,
+                       line: 1, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func
+      `a plain field's decode is annotated so an extension init cannot tie`() {
+    // The macro sees only the primary declaration — an `init(x:)` in an
+    // EXTENSION is invisible to it, does NOT suppress the synthesized
+    // memberwise init, yet still joins overload resolution at the call site. A
+    // bare `Self(x: decode())` would leave `decode()` untyped against both the
+    // synthesized `init(x: Int)` and an extension `init(x: String)` and fail
+    // to compile. Annotating the read `decode() as Int` unconditionally — the
+    // plain no-extension struct emits the same — resolves the call regardless.
+    expand("""
+      @Deserializable
+      struct S {
+        var x: Int
+      }
+      """,
+      to: """
+      struct S {
+        var x: Int
+      }
+
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("S", fields: 1)
+          let __macro_local_5valuefMu_ = try Self(x: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func
+      `an overload set ambiguous after typing is diagnosed, not emitted`() {
+    // Two primary inits cover the single `x: Int` field by the SAME parameter
+    // type, differing only by an extra DEFAULTED parameter, so the typed call
+    // `Self(x: decode() as Int)` keeps BOTH viable — the annotation cannot
+    // break the tie. Rather than emit an ambiguous call, the `.initializer`
+    // diagnostic fires; a set left one viable init after typing derives.
+    assertMacroExpansion("""
+      @Deserializable
+      struct S {
+        var x: Int
+        init(x: Int, y: Int = 0) {
+          self.x = x
+        }
+        init(x: Int, z: Int = 0) {
+          self.x = x
+        }
+      }
+      """,
+      expandedSource: """
+      struct S {
+        var x: Int
+        init(x: Int, y: Int = 0) {
+          self.x = x
+        }
+        init(x: Int, z: Int = 0) {
+          self.x = x
+        }
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.initializer.message,
+                       line: 1, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func
+      `an overload set left with one viable init after typing derives`() {
+    // Two primary inits share the `x` LABEL but differ in `x`'s TYPE, so the
+    // typed call `Self(x: decode() as Int)` leaves exactly the `init(x: Int)`
+    // viable — the `init(x: String)` is dropped by the annotation. One viable
+    // init is unambiguous, so the derive emits the annotated call, no error.
+    expand("""
+      @Deserializable
+      struct S {
+        var x: Int
+        init(x: Int) {
+          self.x = x
+        }
+        init(x: String) {
+          self.x = Int(x) ?? 0
+        }
+      }
+      """,
+      to: """
+      struct S {
+        var x: Int
+        init(x: Int) {
+          self.x = x
+        }
+        init(x: String) {
+          self.x = Int(x) ?? 0
+        }
+      }
+
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("S", fields: 1)
+          let __macro_local_5valuefMu_ = try Self(x: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func
+      `an exact init ranks above a defaulted-extra overload and derives`() {
+    // Two primary inits stay viable against `Self(x: decode() as Int)`, but
+    // `init(x: Int)` corresponds one-to-one to the single field while
+    // `init(x: Int, y: Int = 0)` relies on a defaulted EXTRA parameter. Swift
+    // ranks the exact memberwise-equivalent init above the defaulted overload,
+    // so the call resolves to it unambiguously — a UNIQUE best candidate is not
+    // a tie, so the derive emits the call, no `.initializer` diagnostic.
+    expand("""
+      @Deserializable
+      struct S {
+        var x: Int
+        init(x: Int) {
+          self.x = x
+        }
+        init(x: Int, y: Int = 0) {
+          self.x = x
+        }
+      }
+      """,
+      to: """
+      struct S {
+        var x: Int
+        init(x: Int) {
+          self.x = x
+        }
+        init(x: Int, y: Int = 0) {
+          self.x = x
+        }
+      }
+
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("S", fields: 1)
+          let __macro_local_5valuefMu_ = try Self(x: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func
+      `the synthesized memberwise init ranks above an extension overload`() {
+    // The struct declares no init, so the memberwise `init(x: Int)` is
+    // synthesized and invisible in source; an `init(x: Int, y: Int = 0)` in an
+    // EXTENSION also joins overload resolution at the call site. The exact
+    // synthesized init ranks above the defaulted-extra extension overload, so
+    // `Self(x: decode() as Int)` resolves to it and the emitted code compiles.
+    // The macro sees no primary init, so it derives with no diagnostic.
+    expand("""
+      @Deserializable
+      struct S {
+        var x: Int
+      }
+      extension S {
+        init(x: Int, y: Int = 0) {
+          self.x = x
+        }
+      }
+      """,
+      to: """
+      struct S {
+        var x: Int
+      }
+      extension S {
+        init(x: Int, y: Int = 0) {
+          self.x = x
+        }
+      }
+
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("S", fields: 1)
+          let __macro_local_5valuefMu_ = try Self(x: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func `an overflowing #if block product is diagnosed, not trapped`() {
+    // Enough independent two-clause `#if` blocks (each an implicit `#else`
+    // doubles the branch count) that the cartesian product overflows `Int`
+    // before the `<= 256` comparison. The count SATURATES instead of trapping
+    // the plugin, so the `.conditional` diagnostic fires for the oversized
+    // shape. Sixty-four blocks alone would be 2^64, past `Int.max`.
+    let blocks = (0 ..< 64).map { index in
+      "  #if C\(index)\n  var f\(index): Int\n  #endif"
+    }.joined(separator: "\n")
+    let structure = "struct S {\n\(blocks)\n}"
+    assertMacroExpansion("@Deserializable\n\(structure)",
+      expandedSource: structure,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.conditional.message,
+                       line: 1, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func `helper-only #if blocks resolve as a single build`() {
+    // Twelve `#if` blocks guarding only a method — no stored field, no
+    // initializer — beside two real fields. The blocks are dropped from the
+    // emitted segments AND pruned from the init-resolution enumeration, so the
+    // derive stays ONE build rather than expanding a 2^12 cartesian (which
+    // would hit the `.conditional` cap or hang). It derives the plain
+    // unconditional shape over `first`/`second`, no diagnostic.
+    let blocks = (0 ..< 12).map { index in
+      "  #if true\n  func helper\(index)() {}\n  #endif"
+    }.joined(separator: "\n")
+    let source = """
+      @Deserializable
+      struct S {
+        var first: Int
+        var second: Int
+      \(blocks)
+      }
+      """
+    expand(source, to: """
+      struct S {
+        var first: Int
+        var second: Int
+      \(blocks)
+      }
+
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("S", fields: 2)
+          let __macro_local_5valuefMu_ = try Self(first: deserializer.decode() as Int, second: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func `an empty struct deserializes with a try-free Self()`() {
+    // A struct with no stored property decodes nothing, so its `Self()` calls
+    // the nonthrowing no-argument memberwise init. Emitting `try Self()` would
+    // warn "no calls to throwing functions occur" and fail the warning-free
+    // build, so the `try` is dropped for the fieldless call.
+    expand("""
+      @Deserializable
+      struct Empty {}
+      """,
+      to: """
+      struct Empty {}
+
+      extension Empty: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("Empty", fields: 0)
+          let __macro_local_5valuefMu_ = Self()
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func `an empty synthesized #else branch is a try-free Self()`() {
+    // A conditional-only field set: `payload` lives under `#if false`, so the
+    // synthesized `#else` branch — the case no clause is active — decodes no
+    // field. That empty leaf emits `Self()` without `try`, warning-free, while
+    // the `#if` branch with the field keeps the hoisted `try Self(…)`.
+    expand("""
+      @Deserializable
+      struct S {
+        #if false
+        var payload: Int
+        #endif
+      }
+      """,
+      to: """
+      struct S {
+        #if false
+        var payload: Int
+        #endif
+      }
+
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          var __macro_local_6fieldsfMu_ = 0
+          #if false
+          __macro_local_6fieldsfMu_ += 1
+          #endif
+          try deserializer.structure("S", fields: __macro_local_6fieldsfMu_)
+          #if false
+          let __macro_local_5valuefMu_ = try Self(payload: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+          #else
+          let __macro_local_5valuefMu_ = Self()
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+          #endif
+        }
+      }
+      """)
+  }
+
+  @Test func `a serialize-only over-cap struct derives without the cap`() {
+    // Nine independent `#if` stored fields — a deserialize branch product of
+    // 2^9 = 512, past the 256 cap. Serialize emits only a LINEAR count
+    // accumulator and `#if`-guarded writes, not the cartesian `Self(…)` the cap
+    // guards, so `@Serializable` derives regardless of the product. (The SAME
+    // shape under `@Deserializable` diagnoses `.conditional`, above.)
+    let fields = (1 ... 9).map { "  #if true\n  var f\($0): Int\n  #endif" }
+        .joined(separator: "\n")
+    let counts = (1 ... 9).map { _ in
+      "    #if true\n    __macro_local_6fieldsfMu_ += 1\n    #endif"
+    }.joined(separator: "\n")
+    let writes = (1 ... 9).map { index in
+      "    #if true\n    try __macro_local_9structurefMu_.field("
+        + "\"f\(index)\", self.f\(index))\n    #endif"
+    }.joined(separator: "\n")
+    expand("@Serializable\nstruct S {\n\(fields)\n}", to: """
+      struct S {
+      \(fields)
+      }
+
+      extension S: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_6fieldsfMu_ = 0
+      \(counts)
+          var __macro_local_9structurefMu_ = (consume serializer).structure("S", fields: __macro_local_6fieldsfMu_)
+      \(writes)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func
+      `a deprecated type's serialize extension carries its @available`() {
+    // The annotated type is `@available(*, deprecated)`, so a BARE
+    // `extension S` would reference the deprecated type and warn, failing the
+    // warning-free build. The derive copies the attribute onto the extension,
+    // spelled AHEAD of `extension`, so the conformance stays warning-free.
+    expand("""
+      @available(*, deprecated)
+      @Serializable
+      struct S {
+        var x: Int
+      }
+      """,
+      to: """
+      @available(*, deprecated)
+      struct S {
+        var x: Int
+      }
+
+      @available(*, deprecated)
+      extension S: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("S", fields: 1)
+          try __macro_local_9structurefMu_.field("x", self.x)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func
+      `a deprecated type's deserialize extension carries its @available`() {
+    // The deserialize twin: the `@available(*, deprecated)` leads the
+    // `extension`, so the conformance references the deprecated type
+    // warning-free.
+    expand("""
+      @available(*, deprecated)
+      @Deserializable
+      struct S {
+        var x: Int
+      }
+      """,
+      to: """
+      @available(*, deprecated)
+      struct S {
+        var x: Int
+      }
+
+      @available(*, deprecated)
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("S", fields: 1)
+          let __macro_local_5valuefMu_ = try Self(x: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func
+      `an unavailable type's extension carries its @available`() {
+    // An `@available(*, unavailable)` type makes a bare `extension S` a hard
+    // ERROR, not just a warning. Copying the attribute onto the extension is
+    // what lets an unavailable type derive at all.
+    expand("""
+      @available(*, unavailable)
+      @Serializable
+      struct S {
+        var x: Int
+      }
+      """,
+      to: """
+      @available(*, unavailable)
+      struct S {
+        var x: Int
+      }
+
+      @available(*, unavailable)
+      extension S: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("S", fields: 1)
+          try __macro_local_9structurefMu_.field("x", self.x)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func `a platform @available is copied onto the extension verbatim`() {
+    // A plain platform gate copies through unchanged — the same arguments, in
+    // the same order — so the extension is available exactly where the type is.
+    expand("""
+      @available(macOS 10.0, *)
+      @Serializable
+      struct S {
+        var x: Int
+      }
+      """,
+      to: """
+      @available(macOS 10.0, *)
+      struct S {
+        var x: Int
+      }
+
+      @available(macOS 10.0, *)
+      extension S: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("S", fields: 1)
+          try __macro_local_9structurefMu_.field("x", self.x)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func `several @available attributes all copy onto the extension`() {
+    // A type may carry one `@available` per platform; the derive copies EVERY
+    // one, in source order, each on its own line ahead of `extension`.
+    expand("""
+      @available(macOS 10.0, *)
+      @available(iOS 13.0, *)
+      @Serializable
+      struct S {
+        var x: Int
+      }
+      """,
+      to: """
+      @available(macOS 10.0, *)
+      @available(iOS 13.0, *)
+      struct S {
+        var x: Int
+      }
+
+      @available(macOS 10.0, *)
+      @available(iOS 13.0, *)
+      extension S: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("S", fields: 1)
+          try __macro_local_9structurefMu_.field("x", self.x)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func
+      `a non-@available type attribute is not copied onto the extension`() {
+    // Only `@available` propagates: a `@dynamicMemberLookup` (or any other
+    // non-availability attribute) on the type is irrelevant to the conformance
+    // extension and must NOT be copied — the bare extension stays unchanged.
+    expand("""
+      @dynamicMemberLookup
+      @Serializable
+      struct S {
+        var x: Int
+        subscript(dynamicMember member: String) -> Int { 0 }
+      }
+      """,
+      to: """
+      @dynamicMemberLookup
+      struct S {
+        var x: Int
+        subscript(dynamicMember member: String) -> Int { 0 }
+      }
+
+      extension S: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("S", fields: 1)
+          try __macro_local_9structurefMu_.field("x", self.x)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func `a generic type derives a conditional conformance`() {
+    // `serializer.field(…, self.value)` needs `T: Serializable` and
+    // `deserializer.decode()` needs `T: Deserializable`, so an UNCONDITIONAL
+    // conformance would not type-check. The derive constrains the generic
+    // parameter a serialized field references: a `where` clause per side.
+    expand("""
+      @Serializable @Deserializable
+      struct Box<T> {
+        var value: T
+      }
+      """,
+      to: """
+      struct Box<T> {
+        var value: T
+      }
+
+      extension Box: Decant.Serializable where T: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("Box", fields: 1)
+          try __macro_local_9structurefMu_.field("value", self.value)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+
+      extension Box: Decant.Deserializable where T: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("Box", fields: 1)
+          let __macro_local_5valuefMu_ = try Self(value: deserializer.decode() as T)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func `each generic parameter in a field type is constrained`() {
+    // Two parameters, each read by a field, are each constrained.
+    expand("""
+      @Serializable
+      struct Pair<A, B> {
+        var a: A
+        var b: B
+      }
+      """,
+      to: """
+      struct Pair<A, B> {
+        var a: A
+        var b: B
+      }
+
+      extension Pair: Decant.Serializable where A: Decant.Serializable, B: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("Pair", fields: 2)
+          try __macro_local_9structurefMu_.field("a", self.a)
+          try __macro_local_9structurefMu_.field("b", self.b)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func `a container field lowers to its element parameter`() {
+    // The derive lowers the FIELD's container type `Array<T>` to the generic
+    // PARAMETER it drives — `where T: Serializable`, which is exactly when
+    // `Array<T>: Serializable` holds. An applied-type left side
+    // (`where Array<T>: …`) is ILLEGAL Swift — the left side must be a generic
+    // parameter or dependent-member type — so the parameter lowering is both
+    // legal and precise.
+    expand("""
+      @Serializable
+      struct Wrap<T> {
+        var items: Array<T>
+      }
+      """,
+      to: """
+      struct Wrap<T> {
+        var items: Array<T>
+      }
+
+      extension Wrap: Decant.Serializable where T: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("Wrap", fields: 1)
+          try __macro_local_9structurefMu_.field("items", self.items)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func `a phantom generic parameter is not constrained`() {
+    // No serialized field's type references `T`, so it gets no constraint and
+    // the conformance stays unconditional.
+    expand("""
+      @Serializable
+      struct Phantom<T> {
+        var x: Int
+      }
+      """,
+      to: """
+      struct Phantom<T> {
+        var x: Int
+      }
+
+      extension Phantom: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("Phantom", fields: 1)
+          try __macro_local_9structurefMu_.field("x", self.x)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func `a wrapper field constrains its mentioned parameter`() {
+    // A field whose type wraps `T` in a general (non-container) type cannot
+    // legally constrain the WRITTEN type — `where Wrapper<T>: Serializable` has
+    // an applied-type left side Swift's grammar REJECTS — so the derive falls
+    // back to the parameter the type mentions: `where T: Serializable`. The
+    // exotic "conforms for EVERY T" wrapper is inexpressible as a where-clause,
+    // so the mentioned-parameter constraint is the correct legal fallback.
+    expand("""
+      @Serializable @Deserializable
+      struct Holder<T> {
+        var value: Wrapper<T>
+      }
+      """,
+      to: """
+      struct Holder<T> {
+        var value: Wrapper<T>
+      }
+
+      extension Holder: Decant.Serializable where T: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("Holder", fields: 1)
+          try __macro_local_9structurefMu_.field("value", self.value)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+
+      extension Holder: Decant.Deserializable where T: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("Holder", fields: 1)
+          let __macro_local_5valuefMu_ = try Self(value: deserializer.decode() as Wrapper<T>)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func `a dependent-member field constrains the member directly`() {
+    // A `T.Element` field needs `T.Element` ITSELF to conform — the body
+    // passes a `T.Element` to `field(…)` and decodes one — so the derive
+    // constrains the dependent member DIRECTLY, `where T.Element: …`, NOT the
+    // base `T`. A dependent member is a LEGAL where-clause left side (unlike an
+    // applied `Wrapper<T>`), and constraining the base `T` would neither supply
+    // the member's conformance nor permit a container whose element alone
+    // conforms.
+    expand("""
+      @Serializable @Deserializable
+      struct Box<T> {
+        var value: T.Element
+      }
+      """,
+      to: """
+      struct Box<T> {
+        var value: T.Element
+      }
+
+      extension Box: Decant.Serializable where T.Element: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("Box", fields: 1)
+          try __macro_local_9structurefMu_.field("value", self.value)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+
+      extension Box: Decant.Deserializable where T.Element: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("Box", fields: 1)
+          let __macro_local_5valuefMu_ = try Self(value: deserializer.decode() as T.Element)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """)
+  }
+
+  @Test func `a dictionary field lowers to both element parameters`() {
+    // A `Dictionary<K, V>` field lowers to BOTH element parameters —
+    // `where K: Serializable, V: Serializable`, in the type's declared
+    // parameter order — the exact condition under which the dictionary
+    // conforms. An applied-type left side is illegal, so both parameters are
+    // constrained instead.
+    expand("""
+      @Serializable
+      struct Map<K, V> {
+        var pairs: Dictionary<K, V>
+      }
+      """,
+      to: """
+      struct Map<K, V> {
+        var pairs: Dictionary<K, V>
+      }
+
+      extension Map: Decant.Serializable where K: Decant.Serializable, V: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("Map", fields: 1)
+          try __macro_local_9structurefMu_.field("pairs", self.pairs)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func `a nested container field lowers to the innermost parameter`() {
+    // Nesting recurses: `Array<Optional<T>>` mentions only `T`, so the derive
+    // lowers to `where T: Serializable` — no applied-type left side at any
+    // depth.
+    expand("""
+      @Serializable
+      struct Nest<T> {
+        var items: Array<Optional<T>>
+      }
+      """,
+      to: """
+      struct Nest<T> {
+        var items: Array<Optional<T>>
+      }
+
+      extension Nest: Decant.Serializable where T: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("Nest", fields: 1)
+          try __macro_local_9structurefMu_.field("items", self.items)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func `a generic type composes @available with the where clause`() {
+    // An availability-limited generic type gets BOTH the copied `@available`
+    // attribute and the conditional-conformance `where` clause.
+    expand("""
+      @available(macOS 10.0, *)
+      @Serializable
+      struct Box<T> {
+        var value: T
+      }
+      """,
+      to: """
+      @available(macOS 10.0, *)
+      struct Box<T> {
+        var value: T
+      }
+
+      @available(macOS 10.0, *)
+      extension Box: Decant.Serializable where T: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("Box", fields: 1)
+          try __macro_local_9structurefMu_.field("value", self.value)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func
+      `an inferred generic-dependent field is diagnosed`() {
+    // A stored property that infers its type from an initializer mentioning a
+    // generic parameter (`var value = T.defaultValue`) has no WRITTEN type for
+    // the conditional conformance to constrain, yet the generated body needs
+    // `T: Serializable`/`Deserializable`. Deriving the constraint from the
+    // initializer expression is unreliable (the syntactic macro cannot resolve
+    // `T.defaultValue`'s type), so the derive diagnoses the shape — a clear
+    // guide to annotate — rather than emit an unconstrained conformance the
+    // compiler later rejects. An explicit annotation (`var value: T = …`)
+    // carries its own constraint and derives.
+    assertMacroExpansion("""
+      @Serializable
+      @Deserializable
+      struct Box<T: Defaulted> {
+        var value = T.defaultValue
+      }
+      """,
+      expandedSource: """
+      struct Box<T: Defaulted> {
+        var value = T.defaultValue
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.inferred.message,
+                       line: 1, column: 1),
+        DiagnosticSpec(message: DecantDiagnostic.inferred.message,
+                       line: 2, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func `an inferred concrete field in a generic type derives`() {
+    // The `.inferred` guard fires only when the initializer mentions a generic
+    // parameter. A concrete inferred field (`var count = 0`) in a generic type
+    // is fully typed and derives an unconditional conformance.
+    expand("""
+      @Serializable
+      struct Counter<T> {
+        var count = 0
+      }
+      """,
+      to: """
+      struct Counter<T> {
+        var count = 0
+      }
+
+      extension Counter: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("Counter", fields: 1)
+          try __macro_local_9structurefMu_.field("count", self.count)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func
+      `an inferred qualified-symbol field in a generic type derives`() {
+    // The inferred-initializer scan walks the expression STRUCTURALLY, so a
+    // field initialised from a concrete qualified symbol whose member name
+    // equals the generic parameter (`var value = Namespace.T()`) does NOT
+    // surface `T`: the `.T` member of `Namespace` is a concrete symbol, not a
+    // reference to the parameter. No `.inferred` diagnostic fires and the
+    // conformance is unconditional. A flat token scan would count the `.T`
+    // token and wrongly diagnose.
+    expand("""
+      @Serializable
+      struct Holder<T> {
+        var value = Namespace.T()
+      }
+      """,
+      to: """
+      struct Holder<T> {
+        var value = Namespace.T()
+      }
+
+      extension Holder: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("Holder", fields: 1)
+          try __macro_local_9structurefMu_.field("value", self.value)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func
+      `an inferred generic-dependent field under #if is diagnosed`() {
+    // The `.inferred` guard descends through `#if`, like the field walk: a
+    // generic-dependent inferred field guarded by a conditional
+    // (`#if DEBUG var value = T.defaultValue #endif`) has no written type to
+    // constrain, so the active branch's conformance would be unconditional and
+    // its `T` reconstruction unchecked. A top-level-only scan would miss it, so
+    // the recursion catches it — diagnosed `.inferred`, exactly as the
+    // top-level shape is.
+    assertMacroExpansion("""
+      @Serializable
+      @Deserializable
+      struct Box<T: Defaulted> {
+        #if DEBUG
+        var value = T.defaultValue
+        #endif
+      }
+      """,
+      expandedSource: """
+      struct Box<T: Defaulted> {
+        #if DEBUG
+        var value = T.defaultValue
+        #endif
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.inferred.message,
+                       line: 1, column: 1),
+        DiagnosticSpec(message: DecantDiagnostic.inferred.message,
+                       line: 2, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func `an inferred concrete field under #if in a generic type derives`() {
+    // The recursion fires only for a generic-parameter mention: a CONCRETE
+    // inferred field inside `#if` (`#if DEBUG var n = 0 #endif`) is fully typed
+    // and derives its (guarded) conformance, just like a top-level concrete
+    // inferred field.
+    expand("""
+      @Serializable
+      struct Counter<T> {
+        #if DEBUG
+        var n = 0
+        #endif
+      }
+      """,
+      to: """
+      struct Counter<T> {
+        #if DEBUG
+        var n = 0
+        #endif
+      }
+
+      extension Counter: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_6fieldsfMu_ = 0
+          #if DEBUG
+          __macro_local_6fieldsfMu_ += 1
+          #endif
+          var __macro_local_9structurefMu_ = (consume serializer).structure("Counter", fields: __macro_local_6fieldsfMu_)
+          #if DEBUG
+          try __macro_local_9structurefMu_.field("n", self.n)
+          #endif
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func `a generic Optional field under actor isolation derives`() {
+    // `Optional<Int>` is Sendable exactly as the sugar `Int?` is, so a
+    // `@MainActor`-isolated model spelling the generic form must be recognized
+    // safe and derive a nonisolated witness — not fall through to `.isolation`.
+    expand("""
+      @MainActor
+      @Serializable
+      struct S {
+        var x: Optional<Int>
+      }
+      """,
+      to: """
+      @MainActor
+      struct S {
+        var x: Optional<Int>
+      }
+
+      extension S: Decant.Serializable {
+        nonisolated public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("S", fields: 1)
+          try __macro_local_9structurefMu_.field("x", self.x)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func `a generic Array field under actor isolation derives`() {
+    // `Array<Int>` is Sendable exactly as the sugar `[Int]` is, so the generic
+    // spelling must be recognized safe under a global actor too.
+    expand("""
+      @MainActor
+      @Serializable
+      struct S {
+        var xs: Array<Int>
+      }
+      """,
+      to: """
+      @MainActor
+      struct S {
+        var xs: Array<Int>
+      }
+
+      extension S: Decant.Serializable {
+        nonisolated public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("S", fields: 1)
+          try __macro_local_9structurefMu_.field("xs", self.xs)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func
+      `deserialize is diagnosed for an uninferable generic init`() {
+    // A custom init whose generic parameter is reachable ONLY through a SKIPPED
+    // defaulted parameter — `init<U>(x: Int, y: U? = nil)` — suppresses the
+    // memberwise init, but the emitted `Self(x: … as Int)` passes nothing that
+    // fixes `U`, so `U` is unbound and the call would not type-check. The
+    // candidate is rejected (its generic parameter is not inferable from the
+    // passed fields), so the `.initializer` diagnostic fires rather than an
+    // uncompilable expansion.
+    assertMacroExpansion("""
+      @Deserializable
+      struct S {
+        var x: Int
+        init<U>(x: Int, y: U? = nil) {
+          self.x = x
+        }
+      }
+      """,
+      expandedSource: """
+      struct S {
+        var x: Int
+        init<U>(x: Int, y: U? = nil) {
+          self.x = x
+        }
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: DecantDiagnostic.initializer.message,
+                       line: 1, column: 1),
+      ],
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func `deserialize derives for an inferable generic init`() {
+    // The parity: a custom init whose generic parameter IS inferable from a
+    // PASSED field is a callable replacement and the derive uses it. Here `y`'s
+    // generic `U` is fixed by the passed `y` argument (`U == Int`), so `U` is
+    // bound at the call and the init covers — unlike the uninferable case where
+    // the generic reaches only a skipped defaulted parameter. No `.initializer`
+    // diagnostic; each read is annotated from its field's written type.
+    assertMacroExpansion("""
+      @Deserializable
+      struct S {
+        var x: Int
+        var y: Int
+        init<U>(x: Int, y: U) where U == Int {
+          self.x = x
+          self.y = y
+        }
+      }
+      """,
+      expandedSource: """
+      struct S {
+        var x: Int
+        var y: Int
+        init<U>(x: Int, y: U) where U == Int {
+          self.x = x
+          self.y = y
+        }
+      }
+
+      extension S: Decant.Deserializable {
+        public static func deserialize<__macro_local_12DeserializerfMu_>(from deserializer: inout __macro_local_12DeserializerfMu_)
+            throws(__macro_local_12DeserializerfMu_.Failure) -> Self
+            where __macro_local_12DeserializerfMu_: Decant.Deserializer & ~Copyable & ~Escapable {
+          try deserializer.structure("S", fields: 2)
+          let __macro_local_5valuefMu_ = try Self(x: deserializer.decode() as Int, y: deserializer.decode() as Int)
+          try deserializer.end()
+          return __macro_local_5valuefMu_
+        }
+      }
+      """,
+      macroSpecs: macros,
+      failureHandler: { failure in Issue.record("\(failure.message)") })
+  }
+
+  @Test func
+      `Serializable on a deprecated field under a deprecated type derives`() {
+    // The field is `@available(*, deprecated)`, but so is the TYPE, so the
+    // generated extension copies `@available(*, deprecated)` and the serialize
+    // `self.x` read sits inside a deprecated context where Swift suppresses the
+    // deprecation warning. The field's deprecation is COVERED by the type's, so
+    // the serialize side derives (no `.deprecated` diagnostic) rather than
+    // rejecting — mirroring the deprecated-init coverage by KIND. The
+    // NON-deprecated-type shape (a plain `@Serializable struct` with a
+    // deprecated field) still diagnoses, above.
+    expand("""
+      @available(*, deprecated)
+      @Serializable
+      struct S {
+        @available(*, deprecated) var x: Int
+      }
+      """,
+      to: """
+      @available(*, deprecated)
+      struct S {
+        @available(*, deprecated) var x: Int
+      }
+
+      @available(*, deprecated)
+      extension S: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("S", fields: 1)
+          try __macro_local_9structurefMu_.field("x", self.x)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func `a same-scope alias field constrains the hidden parameter`() {
+    // The field is written through a same-scope `typealias Value = T`, so the
+    // written type is only `Value` — no in-scope parameter — and a naive walk
+    // would emit an UNCONDITIONAL conformance that serializes an unconstrained
+    // `T`. The derive EXPANDS the alias to `T` before the constraint walk and
+    // emits the CONDITIONAL `where T: Decant.Serializable`, just as a bare
+    // `var value: T` field would.
+    expand("""
+      @Serializable
+      struct Box<T> {
+        typealias Value = T
+        var value: Value
+      }
+      """,
+      to: """
+      struct Box<T> {
+        typealias Value = T
+        var value: Value
+      }
+
+      extension Box: Decant.Serializable where T: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("Box", fields: 1)
+          try __macro_local_9structurefMu_.field("value", self.value)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+
+  @Test func
+      `a same-scope alias to a wrapped dependent member constrains it`() {
+    // The alias `Values = Array<T.Element>` hides a WRAPPED dependent member.
+    // Expansion composes with the wrapped-dependent walk: `Values` expands to
+    // `Array<T.Element>`, whose array wrapper descends to the dependent member
+    // `T.Element`, so the derive emits `where T.Element: Decant.Serializable` —
+    // not the base `T`, which would wrongly demand the whole sequence conform.
+    expand("""
+      @Serializable
+      struct Box<T: Sequence> {
+        typealias Values = Array<T.Element>
+        var values: Values
+      }
+      """,
+      to: """
+      struct Box<T: Sequence> {
+        typealias Values = Array<T.Element>
+        var values: Values
+      }
+
+      extension Box: Decant.Serializable where T.Element: Decant.Serializable {
+        public func serialize<__macro_local_10SerializerfMu_>(into serializer: consuming __macro_local_10SerializerfMu_)
+            throws(__macro_local_10SerializerfMu_.Failure) -> __macro_local_10SerializerfMu_
+            where __macro_local_10SerializerfMu_: Decant.Serializer & ~Copyable & ~Escapable {
+          var __macro_local_9structurefMu_ = (consume serializer).structure("Box", fields: 1)
+          try __macro_local_9structurefMu_.field("values", self.values)
+          return try __macro_local_9structurefMu_.end()
+        }
+      }
+      """)
+  }
+}


### PR DESCRIPTION
Add the opt-in derive sugar as its own bring-up step layered on the Decant core. @Serializable and @Deserializable derive the two conformances field by field in declaration order, and @DecantName and @DecantSkip reserve the per-property spellings ahead of their support.

The macro DECLARATIONS live in DecantMacros and expand through the DecantMacrosPlugin compiler plugin. That split confines swift-syntax to a compile-time dependency of the plugin so it never links into a client: DecantMacros itself depends only on Decant and the plugin, and the core carries no macro at all. A client that prefers to write a conformance by hand — as the core test target does — never pulls this layer in.

The emitted serialize conformance constrains its serializer to Serializer & ~Copyable & ~Escapable, mirroring the core surface and the emitted deserialize side, so a struct derived here accepts a non-escapable borrowed-buffer serializer.

The test target verifies the derive by expansion: it asserts the exact generated code for the plain-fields struct, the inverse read, a skipped computed property, and the struct-only diagnostic. Those assertions need only the plugin and the swift-syntax macro test support, not a runtime format, so this step proves the codegen without a round-trip.