### PR TITLE
SQLEngine: accept an ordinal, expression, or alias sort key

### DIFF
--- a/Sources/SQLEngine/AST.swift
+++ b/Sources/SQLEngine/AST.swift
@@ -10,7 +10,8 @@
 ///   FROM <table> [AS alias]
 ///   ([INNER | (LEFT | RIGHT | FULL) [OUTER]] JOIN <table> [AS alias]
 ///     ON <predicate>)*
-///   [WHERE <predicate>] [ORDER BY <column> [ASC|DESC] (, …)*]
+///   [WHERE <predicate>]
+///   [ORDER BY <integer | expression> [ASC|DESC] (, …)*]
 ///   [OFFSET <skip> ROWS] [FETCH {FIRST | NEXT} <count> ROWS ONLY]
 /// ```
 ///
@@ -235,6 +236,96 @@ public struct Select: Hashable, Sendable {
   public var table: String {
     from?.name ?? ""
   }
+
+  /// Every expression the ORDER BY sort EVALUATES over its input rows — the
+  /// direct sort-key expressions AND the projection expressions its OUTPUT
+  /// shorthands reach — the ones a reachable type-check pass must validate as
+  /// it does a projected expression.
+  ///
+  /// The compiled shape is `Project(Limit(Sort(input)))`: the sort is BELOW the
+  /// limit and evaluates each key over the input rows BEFORE the cap pages
+  /// them, so what the sort forces to evaluate is independent of whether the
+  /// projection is reachable. Each ORDER BY key resolves to the expression the
+  /// sort runs, mirroring the resolver's lowering:
+  ///
+  ///   - a direct `.expression(e)` key over the input columns yields `e`;
+  ///   - a bare unqualified column matching a projected explicit-`AS` OUTPUT
+  ///     ALIAS resolves to that projection item's OWN expression (the ISO alias
+  ///     precedence a `ORDER BY x` follows) — the term the sort recomputes
+  ///     below the limit, NOT a fresh input reference;
+  ///   - an `ordinal(n)` resolves to the `n`-th projection item's expression
+  ///     (1-based, in range), the term the sort recomputes below the limit.
+  ///
+  /// A `*` or bare-column projection carries no expression a shorthand could
+  /// reach (each output is a plain column slot compilation already resolves),
+  /// so an ordinal or bare-name key against one contributes nothing to check.
+  ///
+  /// A bare unqualified name binds to a projection OUTPUT name by the SAME rule
+  /// the resolver's `ORDER BY` lowering uses, so the type-check and the run
+  /// agree on which keys are outputs and which are input columns:
+  ///
+  ///   - a NON-grouped query resolves an output name from an EXPLICIT `AS`
+  ///     ALIAS only (`Projected.alias`) — the representation-independent ISO
+  ///     precedence a `ORDER BY x` follows, so a bare projected column (no
+  ///     `AS`) introduces no output and `ORDER BY <bareName>` stays an input
+  ///     reference whether the parser emitted the select list as `columns` or,
+  ///     forced by a sibling `AS`, as `expressions` (mirrors non-grouped
+  ///     `Scope.order`);
+  ///   - a GROUPED query resolves an output name from `Projected.name` (an
+  ///     alias, else a bare column's name) — the SAME output-name set
+  ///     `Grouping.terms`/`Grouping.order` record and bind, so a grouped
+  ///     `ORDER BY <groupcol>` naming an unaliased projected group column
+  ///     resolves to that output here exactly as it does in the run, rather
+  ///     than being (mis)validated as an ambiguous input column.
+  internal var orderKeys: Array<Expression> {
+    // A grouped query's output-name surface includes an unaliased projected
+    // group column (its `Projected.name`), matching the grouped lowering; a
+    // non-grouped query's is an explicit `AS` alias only.
+    orderKeys(named: aggregates ? \.name : \.alias)
+  }
+
+  /// The ORDER BY sort keys resolved to the expression the sort evaluates,
+  /// matching a bare output name against `output` — the projection accessor a
+  /// caller picks to mirror the resolver's lowering (see `orderKeys`).
+  private func orderKeys(named output: KeyPath<Projected, String?>)
+      -> Array<Expression> {
+    guard let order else { return [] }
+    // Only an `expressions` list carries a projection expression an ordinal or
+    // an output-name key could reach; a `*` or bare-column projection names
+    // plain column slots compilation already resolves.
+    let items: Array<Projected>
+    if case let .expressions(projected) = projection {
+      items = projected
+    } else {
+      items = []
+    }
+    var expressions = Array<Expression>()
+    for key in order.keys {
+      switch key.sort {
+      case let .ordinal(position):
+        // An ordinal names the `position`-th projected output (1-based); the
+        // sort recomputes that item's expression below the limit. An
+        // out-of-range ordinal is `compile`'s fault to raise, so skip it here.
+        if position >= 1, position <= items.count {
+          expressions.append(items[position - 1].expression)
+        }
+      case let .expression(expression):
+        // A bare unqualified name binds a matching projection OUTPUT name
+        // before an input column (the ISO precedence), resolving to that
+        // item's expression — the output surface (`output`) mirrors the
+        // resolver's lowering for this query shape.
+        if case let .column(column) = expression, column.qualifier == nil,
+            let item = items.first(where: {
+              $0[keyPath: output]?.lowercased() == column.name.lowercased()
+            }) {
+          expressions.append(item.expression)
+        } else {
+          expressions.append(expression)
+        }
+      }
+    }
+    return expressions
+  }
 }
 
 /// A named relation in a `FROM` or `JOIN`, with an optional alias.
@@ -380,6 +471,31 @@ public enum Projection: Hashable, Sendable {
   ///
   /// A `columns` projection yields each reference's name (the qualifier
   /// dropped); an `expressions` projection yields each item's inferable `name`
+  /// The per-item explicit-`AS` OUTPUT ALIASES of a projection of `count`
+  /// columns, aligned index-for-index with the lowered projection terms — an
+  /// `expressions` item's `alias` (the explicit `AS`, else `nil`); a `*` or a
+  /// bare-column list names none (`nil` throughout).
+  ///
+  /// It is the alias surface an `ORDER BY` output name resolves against, and it
+  /// is REPRESENTATION-INDEPENDENT: only an explicit `AS` introduces an
+  /// output name an `ORDER BY` may bind, so a bare projected column (`SELECT
+  /// a.Name …`) contributes `nil` here whether the parser emitted it as a
+  /// `columns` list or, forced by a sibling `AS`, as an `expressions` list —
+  /// `ORDER BY Name` then resolves identically (an input column) in both. A
+  /// bare `ORDER BY x` prefers a projected item whose explicit alias is `x`
+  /// (the ISO precedence) to an input column of the same name. `count` is the
+  /// lowered projection's width — the `expansion` of a `*`, which this itself
+  /// cannot know — so the returned array always matches the projection terms
+  /// in length.
+  internal func outputs(count: Int) -> Array<String?> {
+    switch self {
+    case .all, .columns:
+      return Array(repeating: nil, count: count)
+    case let .expressions(items):
+      return items.map(\.alias)
+    }
+  }
+
   /// (its alias, else a bare column's name); a non-column expression with no
   /// alias, and a `SELECT *`, have no inferable name and fault with
   /// `SQLError.named`.
@@ -714,8 +830,8 @@ public enum Literal: Hashable, Sendable {
   case blob(Array<UInt8>)
 }
 
-/// An `ORDER BY` clause: an ordered list of sort keys, each a column and its
-/// own direction.
+/// An `ORDER BY` clause: an ordered list of sort keys, each a sort value and
+/// its own direction.
 ///
 /// The keys are applied major to minor — `ORDER BY a, b DESC, c` sorts by `a`
 /// ascending, breaks ties by `b` descending, then breaks the rest by `c`
@@ -723,18 +839,67 @@ public enum Literal: Hashable, Sendable {
 /// the rows the earlier keys leave equal. A per-key `ASC`/`DESC` governs that
 /// key alone (default `ASC`); `keys` is never empty.
 public struct Order: Hashable, Sendable {
-  /// One sort key: the column to order on and its direction.
+  /// One sort key: the value to order on and its direction.
   public struct Key: Hashable, Sendable {
-    /// The column this key orders on.
-    public let column: Column
+    /// An ISO `<sort key>` — the value a key orders on.
+    ///
+    /// The standard makes a sort key an arbitrary value expression over the
+    /// query's columns; SQL practice adds two shorthands that name an OUTPUT
+    /// column of the select list rather than an input value: a 1-based
+    /// `ordinal` and an output `alias`. The three cases:
+    ///
+    /// - `ordinal(n)` — `ORDER BY 1` names the query's first projected output
+    ///   column (1-based). An integer-literal sort key is ALWAYS this ordinal
+    ///   (the ISO rule), never the integer constant `1`; ordering rows by a
+    ///   constant is meaningless, so the standard reads a bare integer here as
+    ///   a select-list position. An out-of-range `n` faults.
+    /// - `expression(e)` — `ORDER BY a + b`, `ORDER BY UPPER(Name)`, or a bare
+    ///   column `ORDER BY Name` (the common case) — any value expression over
+    ///   the INPUT columns, evaluated per row.
+    ///
+    /// An unqualified name is EITHER an output alias (`SELECT x AS y … ORDER BY
+    /// y`) or an input column; it lowers as an `expression(.column(name))` and
+    /// the resolver prefers a matching OUTPUT alias to an input column of the
+    /// same name (the ISO precedence for a bare `ORDER BY` name), falling back
+    /// to the input column when no alias claims it.
+    public enum Sort: Hashable, Sendable {
+      /// `ORDER BY n` — the query's `n`-th projected output column, 1-based.
+      case ordinal(Int)
+      /// `ORDER BY expression` — a value expression over the input columns (a
+      /// bare column, arithmetic, or a call), or a bare name a resolver may
+      /// bind to an output alias first.
+      case expression(Expression)
+    }
+
+    /// The value this key orders on.
+    public let sort: Sort
 
     /// Whether this key is ascending (`ASC`, the default) rather than
     /// descending (`DESC`).
     public let ascending: Bool
 
-    public init(column: Column, ascending: Bool = true) {
-      self.column = column
+    public init(sort: Sort, ascending: Bool = true) {
+      self.sort = sort
       self.ascending = ascending
+    }
+
+    /// A key ordering on a bare (possibly-qualified) column — the common shape,
+    /// lowered to the value expression `expression(.column(column))`. Retained
+    /// so the many single-column constructors keep compiling.
+    public init(column: Column, ascending: Bool = true) {
+      self.init(sort: .expression(.column(column)), ascending: ascending)
+    }
+
+    /// A short spelling of this key for a diagnostic — a bare column's name, an
+    /// ordinal's decimal, else a generic `"an expression"`. It names the
+    /// offending key in a `SELECT DISTINCT` ordering fault
+    /// (`SQLError.distinct`) without reconstructing the whole expression.
+    internal var name: String {
+      switch sort {
+      case let .ordinal(position): "\(position)"
+      case let .expression(.column(column)): column.name
+      case .expression: "an expression"
+      }
     }
   }
 

--- a/Sources/SQLEngine/Aggregate.swift
+++ b/Sources/SQLEngine/Aggregate.swift
@@ -26,7 +26,16 @@
 /// the SOURCE's slot space (the WHERE/join chain below the aggregate), evaluated
 /// against each source record before the fold; the result lands in the grouped
 /// record.
-internal struct Aggregation {
+///
+/// Two aggregations are EQUAL when they fold the same function over the same
+/// resolved argument term — the RESOLVED form column qualification has already
+/// normalized to a slot, so `SUM(Amount)` and `SUM(Sales.Amount)` in a
+/// single-relation scope are one aggregation. Equality (not `Hashable`, since
+/// `Term` is only `Equatable`) is how the grouped path DEDUPS the aggregates
+/// collected from the projection, the `HAVING`, and the `ORDER BY` into one
+/// grouped slot each, so a qualification-equivalent aggregate written in two
+/// clauses computes once and both clauses order/read the same slot.
+internal struct Aggregation: Equatable {
   /// The aggregate function to fold over the group.
   internal let function: Aggregate
 

--- a/Sources/SQLEngine/Engine.swift
+++ b/Sources/SQLEngine/Engine.swift
@@ -468,14 +468,14 @@ internal struct Resolved {
 /// EVERY column its `order` keys read. The projection terms hold ordinals at
 /// this stage; a scalar call's arguments contribute their read ordinals too.
 private func referenced(_ projection: Array<Term>, _ filter: Filter?,
-                        _ order: Array<(column: Int, ascending: Bool)>)
+                        _ order: Array<SortKey>)
     -> Array<Int> {
   var ordinals = Set<Int>()
   for term in projection {
     term.references(into: &ordinals)
   }
   filter?.references(into: &ordinals)
-  for key in order { ordinals.insert(key.column) }
+  for key in order { key.term.references(into: &ordinals) }
   return ordinals.sorted()
 }
 
@@ -489,33 +489,59 @@ private func invert(_ ordinals: Array<Int>) -> Dictionary<Int, Int> {
   return slot
 }
 
-/// Rejects an `ORDER BY` key naming a column outside the `DISTINCT` output.
+/// Rejects an `ORDER BY` key ordering on a value outside the `DISTINCT` output.
 ///
 /// `SELECT DISTINCT` sorts the pre-projection rows then dedups the projected
-/// ones, so ordering on a column the projection drops is ill-defined — after
+/// ones, so ordering on a value the projection drops is ill-defined — after
 /// dedup one output row stands for many source rows, whose differing sort-key
 /// values leave no single order. The standard therefore requires every
-/// `ORDER BY` key under `DISTINCT` to be a column of the select list, as the
-/// grouped path requires for `GROUP BY`. Each resolved order key's ordinal
-/// (`order`, paired index-for-index with the AST `keys` for the offending
-/// name) must equal a projected term that is a bare `.slot` — a plain output
-/// column; a computed projection is not orderable-on anyway. A key naming no
-/// output column faults `SQLError.distinct`. Only a `distinct` query is
-/// checked; a plain `SELECT` may order on any source column.
+/// `ORDER BY` key under `DISTINCT` to be a value of the select list, as the
+/// grouped path requires for `GROUP BY`. An ordinal or an output-alias key
+/// references a select-list output by construction (`SortKey.output`), so it
+/// satisfies the rule whatever its term computes — its value is constant across
+/// a dedup group. An ordinary INPUT expression key satisfies it when either it
+/// reads a projected column — its resolved `Term` is a bare `.slot` (a plain
+/// column read) that a projected bare-slot term also reads — or it REPEATS a
+/// projected select-list expression: its AST `Expression` is structurally equal
+/// to a projected one (`SELECT DISTINCT A + B AS total … ORDER BY A + B`), so
+/// the key orders on a projected distinct value and is well-defined, exactly as
+/// the alias `ORDER BY total` and the ordinal `ORDER BY 1` naming that same
+/// output are. A key ordering on any other value faults `SQLError.distinct`.
 ///
-/// The check runs in whatever slot space the caller resolved into: the
-/// non-aggregate paths pass base ordinals, the grouped path passes grouped
-/// slots. Both are consistent — `order` and `projection` share it — so the
-/// one comparison serves every compile path.
-private func distinct(_ keys: Array<Order.Key>, _ order: Array<Int>,
-                      _ projection: Array<Term>) throws(SQLError) {
-  var output = Set<Int>()
-  for term in projection {
-    if case let .slot(ordinal) = term { output.insert(ordinal) }
+/// The satisfying comparison is over the RESOLVED `Term`s, not the AST: a key
+/// whose lowered `term` equals a projected item's lowered `term` orders on a
+/// projected value. Lowering normalizes column qualification to a slot, so a
+/// key that differs from its projected twin ONLY in qualification — `SELECT
+/// DISTINCT A + 1 AS v … ORDER BY People.A + 1` against a projected `A + 1`,
+/// where the two `.column`s resolve to the same slot — matches, as its
+/// unqualified spelling and its alias/ordinal already do. The one comparison
+/// runs in whatever slot space the caller resolved into (base ordinals on the
+/// non-aggregate paths, grouped slots on the grouped path); `order` and
+/// `projection` share it, so it serves every compile path, and it subsumes the
+/// bare-projected-column case (`ORDER BY <projectedColumn>` lowers to the same
+/// `.slot` the projection reads). `keys` supplies the AST key's spelling for
+/// the fault message; each resolved order key pairs index-for-index with it.
+///
+/// A matching INPUT key is REBOUND to the projected column it matched: this
+/// returns the order keys with each satisfying input key's `column` set to the
+/// index of the projection item whose term it equals, so the DISTINCT
+/// materialisation sorts on that already-materialised projected slot rather
+/// than appending and re-evaluating `term` — a re-evaluation that would
+/// misorder a non-deterministic or stateful key (`ORDER BY tick()` against a
+/// projected `tick()`). An ordinal/alias key already names its column and
+/// passes through.
+private func distinct(_ keys: Array<Order.Key>, _ order: Array<SortKey>,
+                      _ projection: Array<Term>)
+    throws(SQLError) -> Array<SortKey> {
+  var bound = order
+  for index in order.indices where !order[index].output {
+    guard let column = projection.firstIndex(of: order[index].term) else {
+      throw .distinct(keys[index].name)
+    }
+    bound[index] = SortKey(term: order[index].term,
+                           ascending: order[index].ascending, column: column)
   }
-  for index in order.indices where !output.contains(order[index]) {
-    throw .distinct(keys[index].column.name)
-  }
+  return bound
 }
 
 extension Plan {
@@ -523,33 +549,151 @@ extension Plan {
   /// omitting each layer when its clause is absent. The `projection`, `filter`,
   /// and `order` keys are in slot space; an empty `order` omits the sort.
   ///
-  /// Without `distinct` the shape is `Project(Limit(Sort(Select(_))))`: the row
-  /// `limit` sits BELOW the projection — after `WHERE` and `ORDER BY`, but
-  /// before the select list is evaluated. A row outside the requested page is
+  /// Without `distinct` and with no `ORDER BY` key naming a select-list OUTPUT
+  /// (an ordinal or an output alias), the shape is `Project(Limit(Sort(_)))`:
+  /// the row `limit` sits BELOW the projection — after `WHERE` and `ORDER BY`
+  /// but before the select list runs. A row outside the requested page is
   /// dropped by the limit before its projection runs, so a projection that
   /// could throw (`SELECT 1 / 0 … FETCH FIRST 0 ROWS ONLY`) never evaluates for
   /// a discarded row and the query returns the documented empty page.
   ///
+  /// When an `ORDER BY` key names a select-list output over a COMPUTED
+  /// expression (`SELECT next() AS n … ORDER BY n`), reusing the projection
+  /// term as the pre-projection sort key would evaluate that expression twice
+  /// — once to order, once to project — so a non-deterministic or stateful
+  /// routine sorts on one set of values and returns a second, misordering the
+  /// result. `materialised` instead computes the sort-referenced outputs ONCE
+  /// below the sort and orders an output key by that column, then a
+  /// final projection reads those SAME values it sorted on (and computes the
+  /// remaining, unreferenced outputs above the cap). `shaped` takes that shape
+  /// exactly when a key names an output; a pure input-key `ORDER BY` keeps the
+  /// simpler `Project(Sort(_))` (its keys need input columns the materialised
+  /// row has projected away).
+  ///
   /// With `distinct` (`SELECT DISTINCT`) the dedup runs on the projected rows —
   /// after `ORDER BY`, before `OFFSET`/`FETCH` (the ISO order) — so the shape
-  /// is `Limit(Distinct(Project(Sort(Select(_)))))`: the projection loses its
-  /// cap (every candidate row must be projected to dedup it), the `distinct`
-  /// dedups the projected rows, and the `limit` pages the deduplicated result.
+  /// is `Limit(Distinct(Project(Sort(_))))`: the projection loses its cap
+  /// (every candidate row must be projected to dedup it), the `distinct` dedups
+  /// the projected rows, and the `limit` pages the deduplicated result. Its
+  /// `ORDER BY` keys are all output values (the `distinct` rule), so the sort
+  /// runs over the materialised projection here too.
   internal func shaped(distinct: Bool = false, projection: Array<Term>,
-                       filter: Filter?,
-                       order: Array<(slot: Int, ascending: Bool)>,
+                       filter: Filter?, order: Array<SortKey>,
                        limit: Limit?) -> Plan {
     var plan = self
     if let filter {
       plan = .select(filter, plan)
     }
+
+    // An output key names a materialised projection column; sorting on the
+    // recomputed projection term instead would double-evaluate it (WRONG for a
+    // non-deterministic routine). Materialise the sort-referenced outputs once
+    // below the sort, so the order reflects the returned values whenever a key
+    // does — over the FILTERED `plan`, so a HAVING/WHERE above governs.
+    guard !order.contains(where: { $0.output }) else {
+      return plan.materialised(distinct: distinct, projection: projection,
+                               order: order, limit: limit)
+    }
+
     if !order.isEmpty {
-      plan = .sort(keys: order, plan)
+      let keys = order.map { (term: $0.term, ascending: $0.ascending) }
+      plan = .sort(keys: keys, plan)
     }
     guard distinct else {
       return .project(projection, plan.capped(limit: limit))
     }
     return Plan.distinct(.project(projection, plan)).capped(limit: limit)
+  }
+
+  /// This plan (already filtered) shaped so an `ORDER BY` key naming an OUTPUT
+  /// sorts on exactly the value that output returns, computing each such output
+  /// EXACTLY ONCE — the single-evaluation shape `shaped` picks when a key
+  /// references the select list.
+  ///
+  /// Only the sort-REFERENCED outputs are materialised below the sort. A `map`
+  /// projection retains the input columns (slots `0 ..< self.slots`) and
+  /// appends one materialised column per output an ORDER BY key names, then one
+  /// per ordinary INPUT sort key (an `ORDER BY a + b` over non-projected
+  /// columns still needs its input terms). The sort orders by slots into that
+  /// row — an output key by its materialised column, an input key by its
+  /// appended (or existing input) column — so a computed output key is
+  /// evaluated once and its sort value equals the value the row returns.
+  ///
+  /// The final projection produces each output from that row: a sort-referenced
+  /// output READS its materialised slot (never recomputed, preserving the
+  /// single evaluation), and any OTHER output computes its expression from the
+  /// retained input columns. Without `distinct` this final projection sits
+  /// above the cap, so an unreferenced output (`SELECT x, 1 / 0 … ORDER BY x
+  /// FETCH FIRST 0 ROWS`) evaluates only for rows the limit keeps — never for a
+  /// dropped row, restoring the lazy `Project(Limit(_))` page the all-outputs
+  /// shape regressed.
+  ///
+  /// With `distinct` the dedup runs on the WHOLE projected row, so every output
+  /// (not only the sort-referenced ones) is materialised BELOW the distinct —
+  /// the lazy split would dedup on a partial row. The `distinct` then dedups
+  /// the projected rows and `limit` pages the deduplicated result.
+  private func materialised(distinct: Bool, projection: Array<Term>,
+                            order: Array<SortKey>, limit: Limit?) -> Plan {
+    let width = projection.count
+
+    // Under DISTINCT the dedup needs the full projected row, so materialise
+    // every output below the sort (the sort keys are all outputs here) and let
+    // the distinct dedup and the limit page the projected rows.
+    if distinct {
+      var lower = projection
+      var keys = Array<(term: Term, ascending: Bool)>()
+      keys.reserveCapacity(order.count)
+      for key in order {
+        if let column = key.column {
+          keys.append((term: .slot(column), ascending: key.ascending))
+        } else {
+          keys.append((term: .slot(lower.count), ascending: key.ascending))
+          lower.append(key.term)
+        }
+      }
+      let sorted = Plan.sort(keys: keys, .project(lower, self))
+      let outputs = (0 ..< width).map { Term.slot($0) }
+      return Plan.distinct(.project(outputs, sorted)).capped(limit: limit)
+    }
+
+    // Retain the input columns, then append only the outputs an ORDER BY key
+    // names (materialised once) and the input-only sort-key expressions. A
+    // non-sort output stays out of this row — it is computed above the limit.
+    let inputs = slots ?? 0
+    var lower = (0 ..< inputs).map { Term.slot($0) }
+    var materialised = Dictionary<Int, Int>()
+    var keys = Array<(term: Term, ascending: Bool)>()
+    keys.reserveCapacity(order.count)
+    for key in order {
+      if let column = key.column {
+        // Materialise this output once, reusing its slot if an earlier key
+        // named it too, and order by that slot.
+        let slot: Int
+        if let existing = materialised[column] {
+          slot = existing
+        } else {
+          slot = lower.count
+          materialised[column] = slot
+          lower.append(projection[column])
+        }
+        keys.append((term: .slot(slot), ascending: key.ascending))
+      } else {
+        keys.append((term: .slot(lower.count), ascending: key.ascending))
+        lower.append(key.term)
+      }
+    }
+
+    let sorted = Plan.sort(keys: keys, .project(lower, self))
+    // Each output reads its materialised slot when a key named it, else
+    // computes its expression from the retained inputs (above the cap, lazily).
+    let outputs = (0 ..< width).map { column -> Term in
+      if let slot = materialised[column] {
+        .slot(slot)
+      } else {
+        projection[column]
+      }
+    }
+    return .project(outputs, sorted.capped(limit: limit))
   }
 }
 
@@ -776,8 +920,9 @@ extension Catalog where Self: ~Escapable {
     }
 
     // The `GROUP BY` keys and the aggregate arguments lower to combined
-    // base-ordinal terms; the aggregates are collected from the projection and
-    // the `HAVING` (deduplicated so the same aggregate computes once).
+    // base-ordinal terms; the aggregates are collected from the projection, the
+    // `HAVING`, and the `ORDER BY` sort keys (deduplicated so the same
+    // aggregate computes once).
     let keys = try select.grouping.map { column throws(SQLError) -> Term in
       try .slot(scope.ordinal(of: column))
     }
@@ -788,9 +933,30 @@ extension Catalog where Self: ~Escapable {
     if let having = select.having {
       having.collect(into: &expressions)
     }
+    // A grouped `ORDER BY` may sort on an aggregate that is neither projected
+    // nor in the `HAVING` (`GROUP BY Dept ORDER BY COUNT(*) DESC`), so collect
+    // its sort-key expressions too.
+    if let order = select.order {
+      for key in order.keys {
+        if case let .expression(expression) = key.sort {
+          expression.collect(into: &expressions)
+        }
+      }
+    }
+    // Resolve each collected aggregate and dedup by its RESOLVED
+    // `Aggregation` — function plus resolved argument term. `collect` deduped
+    // only exact AST spellings, so a qualification-equivalent pair
+    // (`SUM(Amount)` projected, `SUM(Sales.Amount)` in the `ORDER BY`) survived
+    // as two expressions; both resolve to the same `Aggregation` in a
+    // single-relation scope, so this folds them into ONE grouped slot — the
+    // aggregate computes once and both clauses read/order that slot (which lets
+    // the DISTINCT sort-key check accept it).
     var aggregations = Array<Aggregation>()
     for expression in expressions {
-      try aggregations.append(expression.aggregation(scope, context.routines))
+      let aggregation = try expression.aggregation(scope, context.routines)
+      if !aggregations.contains(aggregation) {
+        aggregations.append(aggregation)
+      }
     }
 
     // The source materialises exactly the ordinals the WHERE, the keys, and the
@@ -843,38 +1009,35 @@ extension Catalog where Self: ~Escapable {
     // Lower the projection, HAVING, and ORDER BY against the grouped slot space,
     // enforcing the projection rule (every non-aggregated column must be a
     // GROUP BY key).
-    var grouping = try Grouping(scope, select.grouping, expressions)
+    var grouping = try Grouping(scope, select.grouping, aggregations)
     let projection = try grouping.terms(select.projection, context.routines)
     let having: Filter? = if let clause = select.having {
       try grouping.lower(clause, context.routines)
     } else {
       nil
     }
-    let order = if let clause = select.order {
-      try grouping.order(clause)
+    var order = if let clause = select.order {
+      try grouping.order(clause, projection, context.routines)
     } else {
-      Array<(slot: Int, ascending: Bool)>()
+      Array<SortKey>()
     }
 
-    // Under DISTINCT every ORDER BY key must be a select-list column — the
-    // dedup runs on the projected rows, so ordering on a dropped column is
+    // Under DISTINCT every ORDER BY key must be a select-list value — the
+    // dedup runs on the projected rows, so ordering on a dropped value is
     // ill-defined (see `distinct`). The order keys and projection are
     // in grouped-slot space here, aligned with the AST keys index-for-index.
+    // A key matching a projected term is rebound to that projected column so
+    // the sort reuses the materialised slot rather than re-evaluating it.
     if select.distinct, let clause = select.order {
-      try distinct(clause.keys, order.map(\.slot), projection)
+      order = try distinct(clause.keys, order, projection)
     }
 
-    var plan = node
-    if let having {
-      plan = .select(having, plan)
-    }
-    if !order.isEmpty {
-      plan = .sort(keys: order, plan)
-    }
-    guard select.distinct else {
-      return .project(projection, plan.capped(limit: select.limit))
-    }
-    return Plan.distinct(.project(projection, plan)).capped(limit: select.limit)
+    // The HAVING filters groups below the sort, the slot the WHERE occupies on
+    // the non-aggregate path, so the shared `shaped` applies it identically —
+    // an ORDER BY key naming a COMPUTED aggregate output (`COUNT(*) * 2 AS n`)
+    // then materialises once and sorts on the returned value.
+    return node.shaped(distinct: select.distinct, projection: projection,
+                       filter: having, order: order, limit: select.limit)
   }
 }
 
@@ -1927,20 +2090,29 @@ extension Catalog where Self: ~Escapable {
         filter = try from.schema.lower(predicate, in: relation,
                                        context.routines)
       }
-      var order = Array<(column: Int, ascending: Bool)>()
-      if let clause = select.order {
-        order = try from.schema.order(clause, in: relation)
-      }
       let projection =
           try from.schema.terms(select.projection, in: relation,
                                 context.routines)
 
-      // Under DISTINCT every ORDER BY key must be a select-list column — the
-      // dedup runs on the projected rows, so ordering on a dropped column is
+      // The ORDER BY lowers its keys against the projection: an ordinal or an
+      // output-alias key resolves to a select-list item's own term, an ordinary
+      // expression key lowers fresh over the source. Its terms and the
+      // projection are still in base-ordinal space here.
+      var order = Array<SortKey>()
+      if let clause = select.order {
+        let names = select.projection.outputs(count: projection.count)
+        order = try from.schema.order(clause, in: relation, projection, names,
+                                      context.routines)
+      }
+
+      // Under DISTINCT every ORDER BY key must be a select-list value — the
+      // dedup runs on the projected rows, so ordering on a dropped value is
       // ill-defined (see `distinct`). The order keys and projection are
-      // still in base-ordinal space here, aligned with the AST keys by index.
+      // aligned with the AST keys by index. A key matching a projected term is
+      // rebound to that projected column so the sort reuses the materialised
+      // slot rather than re-evaluating it.
       if select.distinct, let clause = select.order {
-        try distinct(clause.keys, order.map(\.column), projection)
+        order = try distinct(clause.keys, order, projection)
       }
 
       // The referenced ordinals, in slot order: slot `i` is `ordinals[i]`.
@@ -1951,7 +2123,7 @@ extension Catalog where Self: ~Escapable {
           distinct: select.distinct,
           projection: projection.map { $0.remapped(through: slot) },
           filter: filter.map { $0.remapped(through: slot) },
-          order: order.map { (slot[$0.column]!, $0.ascending) },
+          order: order.map { $0.remapped(through: slot) },
           limit: select.limit)
     }
 
@@ -1993,17 +2165,26 @@ extension Catalog where Self: ~Escapable {
     if let clause = select.predicate {
       predicate = try scope.lower(clause, context.routines)
     }
-    var order = Array<(column: Int, ascending: Bool)>()
-    if let clause = select.order {
-      order = try scope.order(clause)
-    }
     let projection = try scope.terms(select.projection, context.routines)
 
-    // Under DISTINCT every ORDER BY key must be a select-list column (see
+    // The ORDER BY lowers its keys against the projection (as the
+    // single-relation path does): an ordinal or an output-alias key resolves to
+    // a select-list item's own term, an ordinary expression key lowers fresh
+    // over the chain. Its terms and the projection are in combined base-ordinal
+    // space here.
+    var order = Array<SortKey>()
+    if let clause = select.order {
+      let names = select.projection.outputs(count: projection.count)
+      order = try scope.order(clause, projection, names, context.routines)
+    }
+
+    // Under DISTINCT every ORDER BY key must be a select-list value (see
     // `distinct`); order keys and projection are in combined base-ordinal
-    // space here, aligned with the AST keys index-for-index.
+    // space here, aligned with the AST keys index-for-index. A key matching a
+    // projected term is rebound to that projected column so the sort reuses the
+    // materialised slot rather than re-evaluating it.
     if select.distinct, let clause = select.order {
-      try distinct(clause.keys, order.map(\.column), projection)
+      order = try distinct(clause.keys, order, projection)
     }
 
     // The combined referenced ordinals — projection ∪ every match ∪ WHERE ∪
@@ -2014,7 +2195,7 @@ extension Catalog where Self: ~Escapable {
     for term in projection { term.references(into: &references) }
     for match in matches { match.references(into: &references) }
     predicate?.references(into: &references)
-    for key in order { references.insert(key.column) }
+    for key in order { key.term.references(into: &references) }
     let combined = references.sorted()
 
     var slot = Dictionary<Int, Int>(minimumCapacity: combined.count)
@@ -2055,7 +2236,7 @@ extension Catalog where Self: ~Escapable {
         distinct: select.distinct,
         projection: projection.map { $0.remapped(through: slot) },
         filter: predicate.map { $0.remapped(through: slot) },
-        order: order.map { (slot[$0.column]!, $0.ascending) },
+        order: order.map { $0.remapped(through: slot) },
         limit: select.limit)
   }
 }

--- a/Sources/SQLEngine/Filter.swift
+++ b/Sources/SQLEngine/Filter.swift
@@ -15,7 +15,7 @@ public typealias Bindings = Dictionary<String, Value>
 /// off a bare slot before running it. The filter is fully
 /// escapable; the `~Escapable` row it reads materialises only transiently at
 /// evaluation.
-internal indirect enum Filter: Sendable {
+internal indirect enum Filter: Equatable, Sendable {
   /// `left <op> right`, both operands lowered to ordinal-addressed terms (a
   /// slot, a constant, or a scalar-function call).
   case compare(Term, Comparison, Term)
@@ -87,7 +87,7 @@ internal indirect enum Filter: Sendable {
   /// bindings — the lowered form of the AST's `Predicate.Operand`, as
   /// `Filter.bound` carries a comparison's parameter as a name resolved at run
   /// time.
-  internal enum Operand: Sendable {
+  internal enum Operand: Equatable, Sendable {
     /// A `Term` evaluated against the row per its usual lowering.
     case term(Term)
     /// A `:parameter` name, resolved from the bindings at eval — an unbound one
@@ -106,7 +106,7 @@ internal indirect enum Filter: Sendable {
 /// projected expression to a `Term` the executor evaluates per record against
 /// the routines; a bare-column projection lowers to a `.slot`, so the simple
 /// path stays a plain slot read.
-internal indirect enum Term: Sendable {
+internal indirect enum Term: Equatable, Sendable {
   /// The cell at `slot` of the record.
   case slot(Int)
   /// A constant value.
@@ -149,6 +149,43 @@ internal indirect enum Term: Sendable {
 }
 
 extension Term {
+  /// Structural equality over two lowered terms — the RESOLVED form column
+  /// qualification has already normalized to a slot — so a `DISTINCT` ORDER BY
+  /// key can be recognised as one of the projected select-list values it must
+  /// order on (see `distinct`). The compiler cannot synthesise `Equatable` for
+  /// `Term`: the `.case` payload is an `Array<(Filter, Term)>` of tuples, and a
+  /// tuple is not `Equatable`, so the array is not either. Every other case has
+  /// `Equatable` components (the leaf `Value`/`ValueType`/`Arithmetic` are
+  /// `Hashable`, and `Filter`/`Term` conform here), so only the `.case` branch
+  /// needs the element-wise tuple comparison spelled out.
+  internal static func ==(lhs: Term, rhs: Term) -> Bool {
+    switch (lhs, rhs) {
+    case let (.slot(lhs), .slot(rhs)):
+      lhs == rhs
+    case let (.constant(lhs), .constant(rhs)):
+      lhs == rhs
+    case let (.apply(lname, largs), .apply(rname, rargs)):
+      lname == rname && largs == rargs
+    case let (.binary(lop, ll, lr), .binary(rop, rl, rr)):
+      lop == rop && ll == rl && lr == rr
+    case let (.case(lbranches, lelse, ltype),
+              .case(rbranches, relse, rtype)):
+      ltype == rtype && lelse == relse
+          && lbranches.count == rbranches.count
+          && zip(lbranches, rbranches).allSatisfy {
+               $0.0 == $1.0 && $0.1 == $1.1
+             }
+    case let (.cast(lterm, ltype), .cast(rterm, rtype)):
+      lterm == rterm && ltype == rtype
+    case let (.coalesce(lelems, ltype), .coalesce(relems, rtype)):
+      lelems == relems && ltype == rtype
+    case let (.nullif(ll, lr), .nullif(rl, rr)):
+      ll == rl && lr == rr
+    default:
+      false
+    }
+  }
+
   /// The slots this term reads, accumulated into `slots`.
   ///
   /// A `slot` reads itself; a `constant` reads none; an `apply` reads the union

--- a/Sources/SQLEngine/Operator.swift
+++ b/Sources/SQLEngine/Operator.swift
@@ -123,11 +123,13 @@ internal indirect enum Plan {
   /// projection is a list of `.slot` terms, so the simple path is a reorder.
   case project(Array<Term>, Plan)
   /// τ — orders the records by a list of typed sort keys, major to minor. Each
-  /// key names a `slot` and its direction; `keys[0]` is the primary key and
-  /// each later key orders only the rows the earlier keys leave equal. The sort
-  /// is stable, so rows equal on every key keep their input order. `keys` is
-  /// never empty.
-  case sort(keys: Array<(slot: Int, ascending: Bool)>, Plan)
+  /// key is a `Term` evaluated against the record (a slot read for a bare
+  /// column, but any lowered expression — `a + b`, `UPPER(Name)`, or the
+  /// expression the select list's `n`-th item or an aliased item stands for)
+  /// and its direction; `keys[0]` is the primary key and each later key orders
+  /// only the rows the earlier keys leave equal. The sort is stable, so rows
+  /// equal on every key keep their input order. `keys` is never empty.
+  case sort(keys: Array<(term: Term, ascending: Bool)>, Plan)
   /// × — every concatenation of an outer record with an inner one.
   case product(Plan, Plan)
   /// ⋈ — for each outer record, seeks the inner relation `name` on
@@ -337,23 +339,35 @@ extension Catalog where Self: ~Escapable {
           try project(terms, record, routines, bindings)
         }
     case let .sort(keys, source):
-      return try execute(source, context)
-        .enumerated()
+      // Evaluate each key's `Term` against every record UP FRONT — a bare slot
+      // read, but any lowered expression (`a + b`, `UPPER(Name)`, an ordinal's
+      // or alias's select-list item) — so the comparator sorts on precomputed
+      // values. Evaluation may throw (a scalar call, a division), which a
+      // `sorted(by:)` comparator cannot, so it happens here rather than inside
+      // the sort; it also evaluates each key once per row rather than once per
+      // comparison.
+      let rows = try execute(source, context)
+      let sortable = try rows.map { record throws(SQLError) in
+        try keys.map { key throws(SQLError) in
+          try record.evaluate(key.term, routines, bindings)
+        }
+      }
+      return sortable.indices
         .sorted { lhs, rhs in
           // Compare the keys major to minor: the first key on which the rows
           // differ decides the order; a key they are equal on falls through to
           // the next. A key's direction governs that key alone.
-          for key in keys {
-            let ordered = less(lhs.element[key.slot], rhs.element[key.slot])
-            let reverse = less(rhs.element[key.slot], lhs.element[key.slot])
+          for index in keys.indices {
+            let ordered = less(sortable[lhs][index], sortable[rhs][index])
+            let reverse = less(sortable[rhs][index], sortable[lhs][index])
             if ordered == reverse { continue }
-            return key.ascending ? ordered : reverse
+            return keys[index].ascending ? ordered : reverse
           }
           // Equal on every key: keep the source order (a stable sort) by
           // tie-breaking on the original index.
-          return lhs.offset < rhs.offset
+          return lhs < rhs
         }
-        .map(\.element)
+        .map { rows[$0] }
     case let .product(outer, inner):
       return try product(execute(outer, context), execute(inner, context))
     case let .join(outer, name, ordinals, base, column, keys, filter):

--- a/Sources/SQLEngine/OutputColumn.swift
+++ b/Sources/SQLEngine/OutputColumn.swift
@@ -339,6 +339,30 @@ extension Catalog where Self: ~Escapable {
       throws(SQLError) {
     let routines = context.routines
     let scope = try scope(of: select, context, visited: visited)
+    // An `ORDER BY` ordinal names a 1-based SELECT-list position; one outside
+    // `1 ... width` names no output column and faults `SQLError.column` (spelled
+    // as the ordinal), exactly as the compile path's ordinal resolution does —
+    // structural and reachability-independent, so a row-dropping limit never
+    // spares it. `orderKeys` resolves an IN-RANGE ordinal to its projection
+    // expression but silently drops an out-of-range one, so this raises it here.
+    if let clause = select.order {
+      let width = scope.width(of: select.projection)
+      for key in clause.keys {
+        if case let .ordinal(position) = key.sort,
+            position < 1 || position > width {
+          throw .column("\(position)")
+        }
+      }
+    }
+    // A GROUPED `ORDER BY` sorts in the grouped slot space, so each sort key
+    // must name a `GROUP BY` key, an aggregate, or an output — resolve it
+    // through the SAME grouped lowering the run does, faulting `SQLError.grouping`
+    // on a resolvable-but-non-grouped column exactly as the compile path does.
+    // Structural, so it runs regardless of the WHERE/limit reachability the
+    // operand type-check below tracks.
+    if select.aggregates {
+      try order(grouped: select, scope, routines)
+    }
     if let predicate = select.predicate {
       try scope.check(predicate, routines)
       // A false WHERE filters every row, so a GROUP BY forms no group and a
@@ -372,14 +396,33 @@ extension Catalog where Self: ~Escapable {
           if reachable, case let .expressions(items) = select.projection {
             for item in items { _ = try scope.empty(item.expression, routines) }
           }
+          // The lone empty group is sorted BELOW the limit — the shape is
+          // `Project(Limit(Sort(…)))` — so its ORDER BY keys evaluate over
+          // that group's row UNCONDITIONALLY, ahead of a limit that would drop
+          // the projection: an unknown routine or a divide faults here as a run
+          // would. `orderKeys` resolves an ordinal or an output-name key to the
+          // projection expression the sort recomputes below the limit, so a
+          // projection term reached only via the sort is checked even where the
+          // projection block above is skipped.
+          for expression in select.orderKeys {
+            _ = try scope.empty(expression, routines)
+          }
         }
         return
       }
     }
     // Aggregate folds run before HAVING and any limit, so validate every
-    // aggregate operand in the projection and HAVING unconditionally.
+    // aggregate operand in the projection, HAVING, and ORDER BY
+    // unconditionally. A grouped `ORDER BY` may sort on an aggregate that is
+    // neither projected nor in the `HAVING` (`GROUP BY Dept ORDER BY
+    // COUNT(*)`), which `group` collects into the group plan and folds before
+    // `HAVING` — so its operand and arity are checked here, the same as a
+    // projection or `HAVING` aggregate's.
     if case let .expressions(items) = select.projection {
       for item in items { try scope.aggregates(in: item.expression, routines) }
+    }
+    for expression in select.orderKeys {
+      try scope.aggregates(in: expression, routines)
     }
     if let having = select.having {
       try scope.aggregates(in: having, routines)
@@ -403,6 +446,65 @@ extension Catalog where Self: ~Escapable {
     if reachable, case let .expressions(items) = select.projection {
       for item in items { _ = try scope.validate(item.expression, routines) }
     }
+    // The sort sits BELOW the limit — the shape is `Project(Limit(Sort(…)))`
+    // — so it evaluates every ORDER BY key over the input rows BEFORE the cap
+    // pages them, INDEPENDENT of whether the projection is reachable: a limit
+    // that drops every output row still runs the sort. So validate each key
+    // UNCONDITIONALLY — its calls, arithmetic, and column references exactly
+    // as a projected expression's. `orderKeys` resolves an `ordinal(n)` or an
+    // output-name key to the projection expression the sort recomputes below
+    // the limit, so a projection term reached only through the sort is checked
+    // even where the projection block above is skipped under the limit; a
+    // projection term NO sort key reaches stays correctly unchecked (the
+    // projection never runs under a row-dropping limit).
+    for expression in select.orderKeys {
+      _ = try scope.validate(expression, routines)
+    }
+  }
+
+  /// Resolves a GROUPED `select`'s `ORDER BY` through the SAME grouped lowering
+  /// the compile path applies, so the type-check enforces the GROUP BY rules on
+  /// each sort key exactly as a run does — a bare column must be a `GROUP BY`
+  /// key or occur inside an aggregate, else `SQLError.grouping`; an out-of-range
+  /// ordinal `SQLError.column`; a duplicated output name `SQLError.ambiguous`.
+  ///
+  /// It rebuilds the `Grouping` `group` builds — the `GROUP BY` keys and the
+  /// aggregations collected from the projection, `HAVING`, and the `ORDER BY`
+  /// sort keys, deduped by resolved `Aggregation` — then lowers the projection
+  /// and the `ORDER BY` through it, reusing `Grouping.terms`/`Grouping.order` so
+  /// the two paths cannot drift. It resolves only, reading no cursor; a run's
+  /// operand type-check over the (structurally valid) keys stays the caller's.
+  private borrowing func order(grouped select: Select, _ scope: Scope,
+                               _ routines: Routines) throws(SQLError) {
+    guard let clause = select.order else { return }
+    // Collect the distinct aggregates the grouped plan folds — the projection,
+    // the `HAVING`, and the `ORDER BY` sort-key expressions — then dedup by the
+    // RESOLVED `Aggregation`, exactly as `group` does, so a grouped `ORDER BY`
+    // over an aggregate resolves against the same slot the run folds it into.
+    var expressions = Array<Expression>()
+    for expression in select.projection.projected {
+      expression.collect(into: &expressions)
+    }
+    if let having = select.having { having.collect(into: &expressions) }
+    for key in clause.keys {
+      if case let .expression(expression) = key.sort {
+        expression.collect(into: &expressions)
+      }
+    }
+    var aggregations = Array<Aggregation>()
+    for expression in expressions {
+      let aggregation = try expression.aggregation(scope, routines)
+      if !aggregations.contains(aggregation) {
+        aggregations.append(aggregation)
+      }
+    }
+    // Build the grouping and lower the projection through it to record each
+    // output name (an alias, else a group column's own name) — the surface an
+    // `ORDER BY` output name resolves against — then lower the `ORDER BY`, which
+    // faults a non-group column, an out-of-range ordinal, or an ambiguous name.
+    var grouping = try Grouping(scope, select.grouping, aggregations)
+    let projection = try grouping.terms(select.projection, routines)
+    _ = try grouping.order(clause, projection, routines)
   }
 
   /// Whether `limit` drops the one row a `single`-row result would yield,

--- a/Sources/SQLEngine/Parser.swift
+++ b/Sources/SQLEngine/Parser.swift
@@ -60,7 +60,7 @@
 /// aggregate      := COUNT '(' '*' ')'
 ///                 | (COUNT | SUM | MIN | MAX | AVG) '(' expression ')'
 /// order          := ORDER BY key (',' key)*
-/// key            := column [ASC | DESC]
+/// key            := (integer | expression) [ASC | DESC]
 /// limit          := [OFFSET integer ROWS]
 ///                   [FETCH (FIRST | NEXT) [integer] ROWS ONLY]
 /// column         := identifier        // a dotted identifier is qualified
@@ -1111,9 +1111,9 @@ internal struct Parser: ~Escapable {
   // MARK: - Order
 
   /// Parses `BY key (',' key)*` — a comma-separated list of sort keys, each a
-  /// column and its own optional `ASC`/`DESC` — into an `Order` (the `ORDER`
-  /// keyword is already consumed). The keys read in source order, major to
-  /// minor.
+  /// sort value and its own optional `ASC`/`DESC` — into an `Order` (the
+  /// `ORDER` keyword is already consumed). The keys read in source order, major
+  /// to minor.
   private mutating func order() throws(SQLError) -> Order {
     try expect(.by)
     var keys = [try key()]
@@ -1123,10 +1123,27 @@ internal struct Parser: ~Escapable {
     return Order(keys: keys)
   }
 
-  /// Parses one sort key — `column [ASC | DESC]`, the direction defaulting to
-  /// ascending.
+  /// Parses one sort key — `(integer | expression) [ASC | DESC]`, the direction
+  /// defaulting to ascending.
+  ///
+  /// A BARE integer-literal sort key is an ISO output-column ORDINAL (`ORDER BY
+  /// 1` names the first projected column, 1-based), never the integer constant
+  /// — ordering by a constant is meaningless, so the standard reads a lone
+  /// integer here as a select-list position. The key parses as a full value
+  /// `expression` unconditionally and then CLASSIFIES: an expression that is
+  /// exactly a bare integer literal becomes the ordinal, everything else stays
+  /// an `expression`. This keeps `ORDER BY 1 + A` and `ORDER BY 2 * Price` the
+  /// arithmetic expressions they are, and subsumes a bare column (`ORDER BY
+  /// Name`) and an arbitrary computation (`ORDER BY a + b`, `ORDER BY
+  /// UPPER(Name)`).
   private mutating func key() throws(SQLError) -> Order.Key {
-    let column = try column()
+    let sort: Order.Key.Sort
+    switch try expression() {
+    case let .literal(.integer(ordinal)):
+      sort = .ordinal(ordinal)
+    case let value:
+      sort = .expression(value)
+    }
 
     var ascending = true
     if try match(.desc) {
@@ -1134,7 +1151,7 @@ internal struct Parser: ~Escapable {
     } else {
       _ = try match(.asc)
     }
-    return Order.Key(column: column, ascending: ascending)
+    return Order.Key(sort: sort, ascending: ascending)
   }
 
   // MARK: - Row limiting

--- a/Sources/SQLEngine/Resolve.swift
+++ b/Sources/SQLEngine/Resolve.swift
@@ -147,21 +147,119 @@ private func lower(_ operand: Predicate.Operand,
   }
 }
 
+/// One resolved sort key — a lowered `Term`, its direction, and the
+/// SELECT-list output column it names (when it names one).
+///
+/// `term` is the value the sort evaluates per record, `ascending` its own
+/// direction. `column` records the 0-based projection column an ORDINAL or an
+/// output ALIAS names — the two forms that reference the select list by
+/// construction — and is `nil` for an ordinary INPUT expression. `shaped`
+/// materialises each projected output ONCE below the sort and orders an output
+/// key by that materialised column (`slot(column)`), so a computed output is
+/// sorted on exactly the value it returns rather than recomputed by the sort.
+/// A non-deterministic or stateful routine would otherwise sort on one set of
+/// values and return a second, misordering the result. The `SELECT DISTINCT`
+/// ordering check reads `output`, since an output key is well-defined over the
+/// deduplicated rows (its value is constant across a dedup group) whether its
+/// term is a bare column or not.
+internal struct SortKey {
+  /// The value this key orders on.
+  let term: Term
+
+  /// Whether this key is ascending (`ASC`) rather than descending (`DESC`).
+  let ascending: Bool
+
+  /// The 0-based projection column this key names (an ordinal or an output
+  /// alias), or `nil` for an ordinary input expression.
+  let column: Int?
+
+  /// Whether this key references a SELECT-list output (an ordinal or an output
+  /// alias) rather than an ordinary input expression.
+  var output: Bool { column != nil }
+
+  /// This key with its `term` ordinals remapped to slots through `slot`. The
+  /// `column` is a projection-list index, not an ordinal, so it is unchanged.
+  internal func remapped(through slot: Dictionary<Int, Int>) -> SortKey {
+    SortKey(term: term.remapped(through: slot), ascending: ascending,
+            column: column)
+  }
+}
+
 /// The resolved sort keys `order` lowers to, in major-to-minor order — each
-/// key's column resolved to an ordinal through `ordinal` and its direction
-/// preserved.
+/// key's ISO `<sort key>` lowered to a `Term` and its direction preserved.
 ///
 /// A single relation and a join scope share this shape, differing only in how a
-/// key's column resolves to an ordinal (against one schema, or a combined join
-/// space); each caller supplies that resolution as `ordinal`. A grouped scope
-/// orders on projection aliases and grouped slots, so it does not share it.
-private func order(_ order: Order,
-                   ordinal: (Column) throws(SQLError) -> Int)
-    throws(SQLError) -> Array<(column: Int, ascending: Bool)> {
-  var keys = Array<(column: Int, ascending: Bool)>()
+/// key's `expression` lowers to an ordinal-addressed `Term` (against one
+/// schema, or a combined join space); each caller supplies that lowering as
+/// `term`. The grouped scope orders in a different (grouped-slot) space, so it
+/// does not share this.
+///
+/// The three sort-key forms resolve as:
+///
+/// - `ordinal(n)` names the query's `n`-th projected OUTPUT column (1-based).
+///   It resolves to that projection item's already-lowered `Term`
+///   (`projection[n - 1]`) — the SAME expression the select list computes,
+///   re-used over the source rows the sort runs on — so a bare-column ordinal
+///   reads its slot and a computed one (`SELECT a + b … ORDER BY 1`) recomputes
+///   the expression. An `n` outside `1 ... projection.count` faults
+///   `SQLError.column` (spelled as the ordinal), as an unknown column would.
+/// - `expression(.column(name))` with an unqualified `name` is EITHER an output
+///   alias or an input column. A matching output alias wins (the ISO precedence
+///   for a bare `ORDER BY` name), resolving to that projection item's lowered
+///   `Term`; absent an alias, the name lowers as an ordinary input column
+///   through `term`. A qualified column (`t.x`) is always an input reference.
+/// - Any other `expression(e)` lowers directly over the input columns through
+///   `term`.
+///
+/// `names` are the projection's per-item explicit-`AS` output aliases (else
+/// `nil`), aligned index-for-index with `projection`. Only an explicit `AS`
+/// introduces an alias a bare `ORDER BY` name may bind, so the surface is
+/// REPRESENTATION-INDEPENDENT — a bare projected column contributes no output
+/// name and `ORDER BY` resolves it as an input column whether the projection is
+/// a `columns` or an `expressions` list. An alias two items share has no single
+/// term to order on — the two aliases may compute different values, so the
+/// result must not depend on select-list order — and a bare `ORDER BY` name
+/// matching it is `SQLError.ambiguous`, as the grouped `Grouping.order` does.
+private func order(_ order: Order, _ projection: Array<Term>,
+                   _ names: Array<String?>,
+                   term: (Expression) throws(SQLError) -> Term)
+    throws(SQLError) -> Array<SortKey> {
+  // Output aliases two or more projected items share, lowercased. A bare
+  // `ORDER BY` name matching one is ambiguous rather than a silent first-match.
+  var seen = Set<String>()
+  var ambiguous = Set<String>()
+  for name in names.compactMap({ $0?.lowercased() }) {
+    if !seen.insert(name).inserted { ambiguous.insert(name) }
+  }
+  var keys = Array<SortKey>()
   keys.reserveCapacity(order.keys.count)
   for key in order.keys {
-    try keys.append((column: ordinal(key.column), ascending: key.ascending))
+    let resolved: Term
+    let column: Int?
+    switch key.sort {
+    case let .ordinal(position):
+      guard position >= 1, position <= projection.count else {
+        throw .column("\(position)")
+      }
+      resolved = projection[position - 1]
+      column = position - 1
+    case let .expression(expression):
+      if case let .column(name) = expression, name.qualifier == nil,
+          let index = names.firstIndex(where: {
+            $0?.lowercased() == name.name.lowercased()
+          }) {
+        if ambiguous.contains(name.name.lowercased()) {
+          throw .ambiguous(name.name)
+        }
+        resolved = projection[index]
+        column = index
+      } else {
+        resolved = try term(expression)
+        column = nil
+      }
+    }
+    keys.append(SortKey(term: resolved, ascending: key.ascending,
+                        column: column))
   }
   return keys
 }
@@ -229,7 +327,13 @@ extension Schema {
       for argument in arguments {
         try lowered.append(term(argument, in: relation, routines))
       }
-      return .apply(name: name, arguments: lowered)
+      // Case-fold the routine name to the SQL identifier rule the `Routines`
+      // lookup uses (lowercase), so two calls that spell the same routine with
+      // different case — `UPPER(x)` and `upper(x)` — lower to an IDENTICAL
+      // `.apply` term. Term identity then agrees with dispatch (which folds on
+      // lookup), so the DISTINCT ORDER BY guard's projected-term match, the
+      // aggregate dedup, and every other term comparison stay consistent.
+      return .apply(name: name.lowercased(), arguments: lowered)
     case let .binary(op, lhs, rhs):
       return try .binary(op, term(lhs, in: relation, routines),
                          term(rhs, in: relation, routines))
@@ -284,11 +388,20 @@ extension Schema {
   }
 
   /// The resolved sort keys an `ORDER BY` lowers to, in major-to-minor order —
-  /// each key's column an ordinal in this relation, its direction preserved.
-  internal func order(_ order: Order, in relation: Relation)
-      throws(SQLError) -> Array<(column: Int, ascending: Bool)> {
-    try SQLEngine.order(order) { column throws(SQLError) in
-      try ordinal(of: column, in: relation)
+  /// each key's ISO `<sort key>` a `Term` over this relation's ordinals, its
+  /// direction preserved.
+  ///
+  /// `projection` are the query's already-lowered projection terms and `names`
+  /// their output names, so an ordinal or an output-alias key resolves to the
+  /// matching select-list item's `Term` and an ordinary expression key lowers
+  /// fresh over this relation (see the free `order`).
+  internal func order(_ order: Order, in relation: Relation,
+                      _ projection: Array<Term>, _ names: Array<String?>,
+                      _ routines: Routines = [:])
+      throws(SQLError) -> Array<SortKey> {
+    try SQLEngine.order(order, projection, names) {
+      expression throws(SQLError) in
+      try term(expression, in: relation, routines)
     }
   }
 
@@ -355,6 +468,23 @@ internal struct Scope {
   /// `SELECT *`.
   internal var schemas: Array<Schema> {
     members.map(\.schema)
+  }
+
+  /// The number of output columns `projection` yields over this scope — the
+  /// count the lowered `terms(projection)` array carries, and the range a
+  /// 1-based `ORDER BY` ordinal must fall in. A `*` expands to every relation's
+  /// real `width` in chain order (never a virtual column); a bare-column or an
+  /// expression list is its item count. It reads only schemas, matching the
+  /// compile path's `projection.count` without lowering a term.
+  internal func width(of projection: Projection) -> Int {
+    switch projection {
+    case .all:
+      return schemas.reduce(0) { $0 + $1.width }
+    case let .columns(columns):
+      return columns.count
+    case let .expressions(items):
+      return items.count
+    }
   }
 
   /// The value type of the real column at combined `ordinal` — the type the
@@ -1830,7 +1960,10 @@ internal struct Scope {
       for argument in arguments {
         try lowered.append(term(argument, routines))
       }
-      return .apply(name: name, arguments: lowered)
+      // Case-fold the routine name to the identifier rule the lookup uses, so
+      // equivalent-case calls lower to an identical term (see the primary
+      // `term(_:in:_:)`).
+      return .apply(name: name.lowercased(), arguments: lowered)
     case let .binary(op, lhs, rhs):
       return try .binary(op, term(lhs, routines), term(rhs, routines))
     case let .case(whens, otherwise):
@@ -1879,12 +2012,19 @@ internal struct Scope {
   }
 
   /// The resolved sort keys an `ORDER BY` lowers to, in major-to-minor order —
-  /// each key's column a combined ordinal across the chain, its direction
-  /// preserved.
-  internal func order(_ order: Order) throws(SQLError)
-      -> Array<(column: Int, ascending: Bool)> {
-    try SQLEngine.order(order) { column throws(SQLError) in
-      try ordinal(of: column)
+  /// each key's ISO `<sort key>` a `Term` over the chain's combined ordinals,
+  /// its direction preserved.
+  ///
+  /// `projection` are the query's already-lowered projection terms and `names`
+  /// their output names, so an ordinal or an output-alias key resolves to the
+  /// matching select-list item's `Term` and an ordinary expression key lowers
+  /// fresh over the chain (see the free `order`).
+  internal func order(_ order: Order, _ projection: Array<Term>,
+                      _ names: Array<String?>, _ routines: Routines = [:])
+      throws(SQLError) -> Array<SortKey> {
+    try SQLEngine.order(order, projection, names) {
+      expression throws(SQLError) in
+      try term(expression, routines)
     }
   }
 
@@ -1989,14 +2129,26 @@ internal struct Grouping {
   /// key `i` sits at grouped slot `i`.
   private let keys: Dictionary<Int, Int>
 
-  /// The distinct aggregate expressions mapped to their grouped slots — aggregate
-  /// `j` sits at grouped slot `keys.count + j`.
-  private let aggregates: Dictionary<Expression, Int>
+  /// The number of `GROUP BY` keys — aggregate `j` sits at grouped slot
+  /// `offset + j`, following the key slots.
+  private let offset: Int
+
+  /// The query's distinct aggregations, in first-appearance order — aggregate
+  /// `j` sits at grouped slot `offset + j`. Deduped by RESOLVED `Aggregation`
+  /// (function + resolved argument term), so an aggregate expression's grouped
+  /// slot is found by resolving it and matching here — a
+  /// qualification-equivalent aggregate (`SUM(Amount)` vs `SUM(Sales.Amount)`)
+  /// maps to the SAME slot.
+  private let aggregates: Array<Aggregation>
 
   /// Each projected item's output name (an alias, else a bare column's name),
-  /// lowercased, mapped to its grouped term — the surface an `ORDER BY` names a
-  /// projection alias against.
-  private var aliases: Dictionary<String, Term> = [:]
+  /// lowercased, mapped to its grouped term and its 0-based projection column
+  /// — the surface an `ORDER BY` names a projection alias against. The `column`
+  /// is the position the name occupies in the select list, so an `ORDER BY`
+  /// alias sorts on exactly the output that name introduces even when two items
+  /// share one term (two calls to a `deterministic: false` routine) under
+  /// distinct aliases — a term-only lookup would collapse to the first column.
+  private var aliases: Dictionary<String, (term: Term, column: Int)> = [:]
 
   /// Output names two or more projected items share, lowercased. An `ORDER BY`
   /// that names one has no single slot to order on — the same ambiguity the
@@ -2006,26 +2158,31 @@ internal struct Grouping {
 
   /// Builds a grouping over `scope` for the `GROUP BY` `columns` and the
   /// query's distinct `aggregates` (in first-appearance order — aggregate `j` at
-  /// grouped slot `columns.count + j`).
+  /// grouped slot `columns.count + j`). The `aggregates` are already deduped by
+  /// RESOLVED `Aggregation` (see `group`), so a qualification-equivalent pair
+  /// is one entry sharing one slot.
   internal init(_ scope: Scope, _ columns: Array<Column>,
-                _ aggregates: Array<Expression>) throws(SQLError) {
+                _ aggregates: Array<Aggregation>) throws(SQLError) {
     self.scope = scope
     var keys = Dictionary<Int, Int>(minimumCapacity: columns.count)
     for index in columns.indices {
       try keys[scope.ordinal(of: columns[index])] = index
     }
     self.keys = keys
-    var map = Dictionary<Expression, Int>(minimumCapacity: aggregates.count)
-    for index in aggregates.indices {
-      map[aggregates[index]] = columns.count + index
-    }
-    self.aggregates = map
+    self.offset = columns.count
+    self.aggregates = aggregates
   }
 
-  /// The grouped slot an aggregate expression resolves to (an aggregate the
-  /// query collected), or `nil` if it is not one.
-  private func slot(of aggregate: Expression) -> Int? {
-    aggregates[aggregate]
+  /// The grouped slot an aggregate `expression` resolves to (an aggregate the
+  /// query collected), or `nil` if it is not one. The expression is RESOLVED to
+  /// an `Aggregation` — column qualification normalized to a slot — and matched
+  /// against the collected aggregations, so `SUM(Amount)` and
+  /// `SUM(Sales.Amount)` find the same slot in a single-relation scope.
+  private func slot(of expression: Expression, _ routines: Routines = [:])
+      throws(SQLError) -> Int? {
+    guard case .aggregate = expression else { return nil }
+    let aggregation = try expression.aggregation(scope, routines)
+    return aggregates.firstIndex(of: aggregation).map { offset + $0 }
   }
 
   /// Lowers a scalar `expression` to a grouped-space `Term`.
@@ -2036,7 +2193,8 @@ internal struct Grouping {
   /// standard rule.
   private func term(_ expression: Expression,
                     _ routines: Routines = [:]) throws(SQLError) -> Term {
-    if case .aggregate = expression, let slot = slot(of: expression) {
+    if case .aggregate = expression,
+       let slot = try slot(of: expression, routines) {
       return .slot(slot)
     }
     switch expression {
@@ -2052,7 +2210,10 @@ internal struct Grouping {
       for argument in arguments {
         try lowered.append(term(argument, routines))
       }
-      return .apply(name: name, arguments: lowered)
+      // Case-fold the routine name to the identifier rule the lookup uses, so
+      // equivalent-case calls lower to an identical term (see the primary
+      // `term(_:in:_:)`).
+      return .apply(name: name.lowercased(), arguments: lowered)
     case let .binary(op, lhs, rhs):
       return try .binary(op, term(lhs, routines), term(rhs, routines))
     case let .case(whens, otherwise):
@@ -2101,11 +2262,13 @@ internal struct Grouping {
     }
   }
 
-  /// Records a projected item's output `name` → grouped `term`, flagging the
-  /// name ambiguous if another projected item already claimed it.
-  private mutating func record(_ name: String, _ term: Term) {
+  /// Records a projected item's output `name` at projection `column` → its
+  /// grouped `term`, flagging the name ambiguous if another projected item
+  /// already claimed it.
+  private mutating func record(_ name: String, _ column: Int, _ term: Term) {
     let key = name.lowercased()
-    if aliases.updateValue(term, forKey: key) != nil { ambiguous.insert(key) }
+    let entry = (term: term, column: column)
+    if aliases.updateValue(entry, forKey: key) != nil { ambiguous.insert(key) }
   }
 
   /// The grouped-space projected terms, recording each item's output name for an
@@ -2126,22 +2289,22 @@ internal struct Grouping {
     case let .columns(columns):
       var terms = Array<Term>()
       terms.reserveCapacity(columns.count)
-      for column in columns {
-        let term = try term(.column(column), routines)
+      for index in columns.indices {
+        let term = try term(.column(columns[index]), routines)
         terms.append(term)
-        record(column.name, term)
+        record(columns[index].name, index, term)
       }
       return terms
     case let .expressions(items):
       var terms = Array<Term>()
       terms.reserveCapacity(items.count)
-      for item in items {
-        let term = try term(item.expression, routines)
+      for index in items.indices {
+        let term = try term(items[index].expression, routines)
         terms.append(term)
         // Record the output name (`Projected.name` — an alias, else a bare
         // column's name) so an `ORDER BY` may name it (the standard alias
         // ordering on an aggregate); a computed item names nothing.
-        if let name = item.name { record(name, term) }
+        if let name = items[index].name { record(name, index, term) }
       }
       return terms
     }
@@ -2155,45 +2318,69 @@ internal struct Grouping {
     }
   }
 
-  /// The `(slot, ascending)` keys an `ORDER BY` resolves to in grouped
-  /// space, major to minor.
+  /// The resolved sort keys an `ORDER BY` lowers to in grouped space, major to
+  /// minor — each key's ISO `<sort key>` a `Term` over the grouped record's
+  /// slots, its direction preserved.
   ///
-  /// Each order column names a projection output first — an alias, or a bare
-  /// column's name (`terms` recorded these), the standard way to order on an
-  /// aggregate — else a `GROUP BY` key column. A column that is neither is
-  /// `SQLError.grouping`, as a bare non-key column is meaningless over groups.
+  /// Each sort key resolves as, in order:
   ///
-  /// The `sort` operator orders by grouped slots, so an alias resolves only
-  /// when its projected term is a bare `.slot` — a plain group key or a whole
-  /// aggregate (`SUM(x) AS Total`). An alias over a COMPUTED expression
-  /// (`COUNT(*) * 2 AS Doubled`) has no standalone slot to sort on — the
-  /// projection computes it after the sort — so ordering on it is unsupported
-  /// rather than misreported as an unknown column.
-  internal func order(_ order: Order) throws(SQLError)
-      -> Array<(slot: Int, ascending: Bool)> {
-    var resolved = Array<(slot: Int, ascending: Bool)>()
+  /// - `ordinal(n)` — the query's `n`-th projected OUTPUT column (1-based),
+  ///   resolving to that projection item's own grouped-space `Term`
+  ///   (`projection[n - 1]`). An `n` outside `1 ... projection.count` faults
+  ///   `SQLError.column`.
+  /// - `expression(.column(name))` with an unqualified `name` — a projection
+  ///   OUTPUT alias FIRST (the standard alias ordering on an aggregate, `terms`
+  ///   recorded these), then a `GROUP BY` key column, both resolving to their
+  ///   grouped `Term`. A name two projections share is `SQLError.ambiguous`, as
+  ///   the non-grouped `Scope.order` reports for a shared join column.
+  /// - Any other `expression(e)` — an arithmetic over aggregates or keys
+  ///   (`ORDER BY COUNT(*) * 2`, `ORDER BY SUM(x) DESC`) — lowered through
+  ///   `term` into grouped space, so it may name only aggregates and `GROUP BY`
+  ///   keys (a bare non-key column faults `SQLError.grouping`).
+  ///
+  /// Because the `sort` operator now evaluates a `Term` per grouped record
+  /// rather than reading one slot, an alias over a COMPUTED expression
+  /// (`COUNT(*) * 2 AS Doubled`) orders correctly — its recorded grouped term
+  /// recomputes from the group's key and aggregate slots — where the slot-only
+  /// sort once rejected it.
+  ///
+  /// `projection` are the query's already-lowered grouped-space projection
+  /// terms — the ordinal surface the positional keys resolve against; the alias
+  /// and `GROUP BY` surfaces are the `aliases` and `keys` `terms` recorded.
+  internal func order(_ order: Order, _ projection: Array<Term>,
+                      _ routines: Routines = [:])
+      throws(SQLError) -> Array<SortKey> {
+    var resolved = Array<SortKey>()
     resolved.reserveCapacity(order.keys.count)
     for key in order.keys {
-      if key.column.qualifier == nil {
-        let name = key.column.name.lowercased()
-        // A name two projections share has no single slot to order on — reject
-        // it as ambiguous rather than pick the last, matching the non-grouped
-        // `Scope.order` fault for a shared unqualified join column.
-        if ambiguous.contains(name) { throw .ambiguous(key.column.name) }
-        if let term = aliases[name] {
-          guard case let .slot(slot) = term else {
-            throw .unsupported(
-                "ORDER BY on a computed column alias is not supported")
-          }
-          resolved.append((slot, key.ascending))
-          continue
+      switch key.sort {
+      case let .ordinal(position):
+        guard position >= 1, position <= projection.count else {
+          throw .column("\(position)")
         }
+        resolved.append(SortKey(term: projection[position - 1],
+                                ascending: key.ascending,
+                                column: position - 1))
+      case let .expression(expression):
+        if case let .column(reference) = expression,
+            reference.qualifier == nil {
+          let name = reference.name.lowercased()
+          // A name two projections share has no single term to order on —
+          // reject it as ambiguous rather than pick the last, matching the
+          // non-grouped `Scope.order` fault for a shared unqualified column.
+          if ambiguous.contains(name) { throw .ambiguous(reference.name) }
+          if let alias = aliases[name] {
+            // Order on the recorded projection column the alias occupies, not
+            // `firstIndex(of:)` — two items may share a term under distinct
+            // aliases, so a term search would collapse to the first column.
+            resolved.append(SortKey(term: alias.term, ascending: key.ascending,
+                                    column: alias.column))
+            continue
+          }
+        }
+        try resolved.append(SortKey(term: term(expression, routines),
+                                    ascending: key.ascending, column: nil))
       }
-      let ordinal = try scope.ordinal(of: key.column)
-      guard let slot = keys[ordinal] else {
-        throw .grouping(key.column.name)
-      }
-      resolved.append((slot, key.ascending))
     }
     return resolved
   }

--- a/Tests/SQLTests/AggregateTests.swift
+++ b/Tests/SQLTests/AggregateTests.swift
@@ -292,16 +292,16 @@ struct AggregateTests {
         """, yields: [["Games", 90], ["Books", 60], ["Toys", nil]])
   }
 
-  @Test func `ORDER BY on a computed-expression alias is rejected clearly`() throws {
-    // `Doubled` aliases a COMPUTED value (the projection evaluates it after
-    // the sort), so it has no standalone grouped slot to order on — the engine
-    // rejects it as unsupported rather than misreporting an unknown column.
-    #expect(throws: SQLError.self) {
-      try sales().run(Statement(parsing: """
-          SELECT Dept, COUNT(*) * 2 AS Doubled FROM Sales
-            GROUP BY Dept ORDER BY Doubled DESC
-          """))
-    }
+  @Test func `ORDER BY orders on a computed-expression alias`() throws {
+    // `Doubled` aliases a COMPUTED value; the sort now evaluates the alias's
+    // grouped term per row — recomputing `COUNT(*) * 2` from the group's
+    // aggregate slot — rather than reading a standalone slot, so ordering on a
+    // computed alias works. Books 6, Games 6 (a tie, stable by group order),
+    // Toys 2, descending.
+    try sales().expect("""
+        SELECT Dept, COUNT(*) * 2 AS Doubled FROM Sales
+          GROUP BY Dept ORDER BY Doubled DESC
+        """, yields: [["Books", 6], ["Games", 6], ["Toys", 2]])
   }
 
   @Test func `an aggregate query pages with OFFSET/FETCH after ORDER BY`() throws {

--- a/Tests/SQLTests/OrderByExpressionTests.swift
+++ b/Tests/SQLTests/OrderByExpressionTests.swift
@@ -1,0 +1,1186 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+import SQLEngine
+import SQLTestSupport
+
+// MARK: - Fixtures
+
+/// A `People` relation whose columns support every sort-key form: `Name` for a
+/// bare-column and `UPPER(Name)` key, `A`/`B` for an `A + B` arithmetic key,
+/// and deliberate ties so a secondary key is observable.
+private func people() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("People",
+             ["Id": .integer, "Name": .text, "A": .integer, "B": .integer]) {
+      Row(1, "carol", 3, 1)
+      Row(2, "alice", 1, 4)
+      Row(3, "bob", 2, 2)
+      Row(4, "dave", 5, 5)
+    }
+  }
+}
+
+/// A `Sales` relation of `Dept`/`Amount` rows with departments of differing
+/// counts (Books 3, Games 3, Toys 1) so a grouped `ORDER BY COUNT(*)` has a
+/// meaningful order, and distinct sums (Books 60, Games 90, Toys 30) for an
+/// aggregate that is both projected and sorted-on.
+private func sales() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("Sales", ["Dept": .text, "Amount": .integer]) {
+      Row("Books", 10)
+      Row("Books", 20)
+      Row("Books", 30)
+      Row("Games", 40)
+      Row("Games", 50)
+      Row("Games", nil)
+      Row("Toys", 30)
+    }
+  }
+}
+
+/// Two relations that BOTH carry a `Name` column, joined on their `Id`s, so a
+/// bare unqualified `ORDER BY Name` is an ambiguous INPUT reference — the
+/// surface for the representation-independence check.
+private func joined() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("a", ["Id": .integer, "Name": .text]) {
+      Row(1, "carol")
+      Row(2, "alice")
+      Row(3, "bob")
+    }
+    Relation("b", ["Id": .integer, "Name": .text]) {
+      Row(1, "x")
+      Row(2, "y")
+      Row(3, "z")
+    }
+  }
+}
+
+// MARK: - Tests
+
+/// The generalized ISO `<sort key>`: an output ORDINAL, an arbitrary value
+/// EXPRESSION over the input columns, and an output ALIAS — the three forms an
+/// `ORDER BY` key now admits beyond a bare column.
+struct OrderByExpressionTests {
+  @Test func `ORDER BY an ordinal orders on that output column`() throws {
+    // `2` names the second projected column (Name), ascending.
+    try people().expect("SELECT Id, Name FROM People ORDER BY 2",
+                        yields: [[2, "alice"], [3, "bob"], [1, "carol"],
+                                 [4, "dave"]])
+  }
+
+  @Test func `ORDER BY an ordinal DESC reverses that output column`() throws {
+    // `2 DESC` orders on Name descending: dave, carol, bob, alice.
+    try people().expect("SELECT Id, Name FROM People ORDER BY 2 DESC",
+                        yields: [[4, "dave"], [1, "carol"], [3, "bob"],
+                                 [2, "alice"]])
+  }
+
+  @Test func `an ordinal names the output column, not the integer constant`() throws {
+    // A bare integer sort key is the ISO ORDINAL, never the constant `1`;
+    // ordering on `1` therefore orders on the FIRST output column (Id), the
+    // rows already in Id order, rather than treating every row as equal.
+    let catalog = try people()
+    try catalog.expect("SELECT Id, Name FROM People ORDER BY 1",
+                       equals: "SELECT Id, Name FROM People ORDER BY Id")
+  }
+
+  @Test func `an out-of-range ordinal is diagnosed`() throws {
+    // `3` names a third output column the two-column select list has not — an
+    // ordinal outside `1 ... width` faults as an unknown column would.
+    try people().expect("SELECT Id, Name FROM People ORDER BY 3",
+                        fails: SQLError.column("3"))
+  }
+
+  @Test func `ORDER BY an arithmetic expression orders on its value`() throws {
+    // `A + B`: carol 4, alice 5, bob 4, dave 10 — ascending, ties (carol, bob
+    // both 4) kept in scan order (a stable sort).
+    try people().expect("SELECT Name FROM People ORDER BY A + B",
+                        yields: [["carol"], ["bob"], ["alice"], ["dave"]])
+  }
+
+  @Test func `ORDER BY a scalar call orders on the computed value`() throws {
+    // `UPPER(Name)` upper-cases before comparing; the names are already
+    // lower-case and distinct, so the order is the plain alphabetical one.
+    try people().expect("SELECT Id FROM People ORDER BY UPPER(Name)",
+                        yields: [[2], [3], [1], [4]])
+  }
+
+  @Test func `ORDER BY an output alias orders on the aliased value`() throws {
+    // `Total` aliases `A + B`; the ORDER BY names the output alias, ordering on
+    // the same computed value (carol 4, bob 4, alice 5, dave 10).
+    try people().expect("""
+        SELECT Name, A + B AS Total FROM People ORDER BY Total
+        """, yields: [["carol", 4], ["bob", 4], ["alice", 5], ["dave", 10]])
+  }
+
+  @Test func `an output alias wins over an input column of the same name`() throws {
+    // `Name` aliases `UPPER(Name)` here, so the bare `ORDER BY Name` binds the
+    // OUTPUT alias (the ISO precedence) rather than the input `Name` column —
+    // both order the rows the same alphabetically here, but the alias's value
+    // (the upper-cased name) is what the output row carries.
+    try people().expect("""
+        SELECT Id, UPPER(Name) AS Name FROM People ORDER BY Name
+        """, yields: [[2, "ALICE"], [3, "BOB"], [1, "CAROL"], [4, "DAVE"]])
+  }
+
+  @Test func `a mixed multi-key ORDER BY combines an ordinal and an expression`() throws {
+    // Primary `A + B` ascending leaves carol and bob tied at 4; the secondary
+    // ordinal `1` (the Id output column) DESC breaks that tie — carol (Id 1)
+    // before bob (Id 3) — proving the two key forms compose and each carries
+    // its own direction.
+    try people().expect("""
+        SELECT Id FROM People ORDER BY A + B, 1 DESC
+        """, yields: [[3], [1], [2], [4]])
+  }
+
+  @Test func `ORDER BY an input column absent from the select list`() throws {
+    // A plain (non-DISTINCT) query may order on any INPUT column — `A` here —
+    // even one the projection drops; the sort runs on the source rows before
+    // the projection. A ascending: alice 1, bob 2, carol 3, dave 5.
+    try people().expect("SELECT Name FROM People ORDER BY A",
+                        yields: [["alice"], ["bob"], ["carol"], ["dave"]])
+  }
+
+  // MARK: - Output-name binding is representation-independent
+
+  // Only an explicit `AS` alias introduces an ORDER-BY-visible output name. A
+  // bare projected column contributes none, so `ORDER BY <bareName>` resolves
+  // as an INPUT column — identically whether an unrelated select-list item
+  // forced the projection into a `columns` or an `expressions` list.
+
+  @Test func `a bare ORDER BY name over a join is an ambiguous input column`() throws {
+    // Both `a` and `b` carry `Name`, so the bare `ORDER BY Name` is an
+    // ambiguous INPUT reference — no explicit alias claims the name.
+    try joined().expect("""
+        SELECT a.Name, a.Id FROM a JOIN b ON a.Id = b.Id ORDER BY Name
+        """, fails: SQLError.ambiguous("Name"))
+  }
+
+  @Test func `an unrelated AS does not flip a bare ORDER BY name to an output`() throws {
+    // Aliasing ONLY the SECOND item (`a.Id AS id`) forces the projection into
+    // an `expressions` list, but the first item is still a BARE `a.Name` with
+    // no explicit alias — so `ORDER BY Name` remains the same ambiguous INPUT
+    // reference as the `columns`-list form above, not a bind to the first
+    // output. Semantics track the SQL, not the AST representation.
+    try joined().expect("""
+        SELECT a.Name, a.Id AS id FROM a JOIN b ON a.Id = b.Id ORDER BY Name
+        """, fails: SQLError.ambiguous("Name"))
+  }
+
+  @Test func `ORDER BY an explicit alias still binds the projected output`() throws {
+    // An explicit `AS u` DOES introduce an output name, so `ORDER BY u` binds
+    // the projected expression (the upper-cased name), not an input column.
+    try people().expect("""
+        SELECT UPPER(Name) AS u FROM People ORDER BY u
+        """, yields: [["ALICE"], ["BOB"], ["CAROL"], ["DAVE"]])
+  }
+
+  @Test func `a single-table bare ORDER BY name binds the input column`() throws {
+    // One relation, one `Name`: the bare projected column introduces no output
+    // alias, so `ORDER BY Name` binds the unambiguous INPUT column.
+    try people().expect("SELECT Name FROM People ORDER BY Name",
+                        yields: [["alice"], ["bob"], ["carol"], ["dave"]])
+  }
+
+  // MARK: - Duplicate output aliases are ambiguous
+
+  @Test func `ORDER BY a duplicated output alias is ambiguous`() throws {
+    // `A AS k` and `B AS k` both name `k`; the two aliases compute different
+    // values, so a bare `ORDER BY k` has no single term to order on — it is
+    // ambiguous rather than a select-list-order-dependent first-match on `A`.
+    try people().expect("""
+        SELECT A AS k, B AS k FROM People ORDER BY k
+        """, fails: SQLError.ambiguous("k"))
+  }
+
+  @Test func `ORDER BY a non-duplicated output alias still binds`() throws {
+    // Distinct aliases `k`/`j` leave `k` unambiguous, so `ORDER BY k` binds the
+    // `A` output ascending: alice 1, bob 2, carol 3, dave 5.
+    try people().expect("""
+        SELECT A AS k, B AS j FROM People ORDER BY k
+        """, yields: [[1, 4], [2, 2], [3, 1], [5, 5]])
+  }
+
+  @Test func `SELECT DISTINCT admits an ordinal ORDER BY key`() throws {
+    // Under DISTINCT every ORDER BY key must be a select-list value; the
+    // ordinal `1` names the sole output column, so it is admitted. The distinct
+    // A+B totals are 4, 5, 10 (carol and bob share 4), ordered ascending.
+    try people().expect("""
+        SELECT DISTINCT A + B AS Total FROM People ORDER BY 1
+        """, yields: [[4], [5], [10]])
+  }
+
+  @Test func `SELECT DISTINCT rejects an expression ORDER BY key it drops`() throws {
+    // `A` is not a select-list value, so ordering on it under DISTINCT is
+    // ill-defined — one output row stands for many source rows with differing
+    // `A` — and faults.
+    try people().expect("SELECT DISTINCT Name FROM People ORDER BY A",
+                        fails: SQLError.distinct("A"))
+  }
+
+  @Test func `SELECT DISTINCT admits an ORDER BY repeating a projected expression`() throws {
+    // The ORDER BY REPEATS the projected `A + B` expression rather than naming
+    // its alias or ordinal. That sort key IS the projected distinct value, so
+    // ordering on it is well-defined and admitted — the same result as the
+    // alias `ORDER BY Total` and the ordinal `ORDER BY 1` naming that output.
+    // The distinct A+B totals are 4, 5, 10 (carol and bob share 4), ascending.
+    try people().expect("""
+        SELECT DISTINCT A + B AS Total FROM People ORDER BY A + B
+        """, yields: [[4], [5], [10]])
+  }
+
+  @Test func `the alias and ordinal name the same DISTINCT output`() throws {
+    // `ORDER BY Total` (alias) and `ORDER BY 1` (ordinal) produce the SAME order
+    // as the repeated `ORDER BY A + B` above — all three name the one projected
+    // distinct value.
+    try people().expect("""
+        SELECT DISTINCT A + B AS Total FROM People ORDER BY Total
+        """, yields: [[4], [5], [10]])
+    try people().expect("""
+        SELECT DISTINCT A + B AS Total FROM People ORDER BY 1
+        """, yields: [[4], [5], [10]])
+  }
+
+  @Test func `SELECT DISTINCT rejects an expression over a non-projected column`() throws {
+    // Only `A` is projected, so the repeated-expression admission must not
+    // over-accept: `A + B` reads `B`, which the projection drops, so ordering
+    // on it under DISTINCT stays ill-defined and faults.
+    try people().expect("SELECT DISTINCT A FROM People ORDER BY A + B",
+                        fails: SQLError.distinct("an expression"))
+  }
+
+  @Test func `SELECT DISTINCT admits an ORDER BY on a bare projected column`() throws {
+    // A bare projected `A` lowers to a slot the ORDER BY key reads, so the
+    // bare-slot admission (not the expression one) accepts `ORDER BY A`. The
+    // distinct `A` values are 1, 2, 3, 5, ascending.
+    try people().expect("SELECT DISTINCT A FROM People ORDER BY A",
+                        yields: [[1], [2], [3], [5]])
+  }
+
+  @Test func `SELECT DISTINCT admits an ORDER BY differing only in qualification`() throws {
+    // The ORDER BY repeats the projected `A + 1`, but QUALIFIES the column
+    // (`People.A + 1`) where the projection did not (`A + 1`). The two are
+    // different AST expressions, yet both LOWER to the same `Term` — the
+    // column resolves to the same slot — so the sort key IS the projected
+    // distinct value and is admitted, exactly as the unqualified `A + 1`, the
+    // alias `v`, and the ordinal `1` naming that output are. The distinct
+    // A+1 values are 2, 3, 4, 6, ascending.
+    try people().expect("""
+        SELECT DISTINCT A + 1 AS v FROM People ORDER BY People.A + 1
+        """, yields: [[2], [3], [4], [6]])
+  }
+
+  @Test func `the qualified, unqualified, alias, and ordinal DISTINCT keys agree`() throws {
+    // The qualified `People.A + 1` produces the SAME order as the unqualified
+    // `A + 1`, the alias `v`, and the ordinal `1` — all four name the one
+    // projected distinct value (2, 3, 4, 6, ascending).
+    let catalog = try people()
+    try catalog.expect("""
+        SELECT DISTINCT A + 1 AS v FROM People ORDER BY A + 1
+        """, yields: [[2], [3], [4], [6]])
+    try catalog.expect("""
+        SELECT DISTINCT A + 1 AS v FROM People ORDER BY v
+        """, yields: [[2], [3], [4], [6]])
+    try catalog.expect("""
+        SELECT DISTINCT A + 1 AS v FROM People ORDER BY 1
+        """, yields: [[2], [3], [4], [6]])
+  }
+
+  @Test func `SELECT DISTINCT admits a qualified ORDER BY on a bare projected column`() throws {
+    // The projected bare `A` lowers to a slot, and the QUALIFIED `People.A`
+    // key lowers to the SAME slot, so it matches the projected term and is
+    // admitted. The distinct `A` values are 1, 2, 3, 5, ascending.
+    try people().expect("SELECT DISTINCT A FROM People ORDER BY People.A",
+                        yields: [[1], [2], [3], [5]])
+  }
+
+  @Test func `SELECT DISTINCT rejects a qualified key over a non-projected column`() throws {
+    // A resolved-term match must not over-accept: `People.B` lowers to a slot
+    // the projected `A` does not, so ordering on it under DISTINCT stays
+    // ill-defined and faults — the qualification does not make it projected.
+    try people().expect("SELECT DISTINCT A FROM People ORDER BY People.B",
+                        fails: SQLError.distinct("B"))
+  }
+
+  @Test func `SELECT DISTINCT admits a mixed-case ORDER BY repeating a projected call`() throws {
+    // The ORDER BY repeats the projected `UPPER(Name)` call, but spells the
+    // routine in a DIFFERENT case (`upper` vs `UPPER`). A routine resolves by
+    // the case-insensitive SQL identifier rule, so both name the same routine
+    // and the two calls lower to an IDENTICAL term — the sort key IS the
+    // projected distinct value and is admitted, exactly as the same-case
+    // `ORDER BY UPPER(Name)`, the alias `u`, and the ordinal `1` are. The
+    // distinct upper-cased names are ALICE, BOB, CAROL, DAVE, ascending.
+    try people().expect("""
+        SELECT DISTINCT UPPER(Name) AS u FROM People ORDER BY upper(Name)
+        """, yields: [["ALICE"], ["BOB"], ["CAROL"], ["DAVE"]])
+  }
+
+  @Test func `the same-case, mixed-case, alias, and ordinal DISTINCT call keys agree`() throws {
+    // The mixed-case `upper(Name)` produces the SAME order as the same-case
+    // `UPPER(Name)`, the alias `u`, and the ordinal `1` — all four name the one
+    // projected distinct value (ALICE, BOB, CAROL, DAVE, ascending).
+    let catalog = try people()
+    try catalog.expect("""
+        SELECT DISTINCT UPPER(Name) AS u FROM People ORDER BY UPPER(Name)
+        """, yields: [["ALICE"], ["BOB"], ["CAROL"], ["DAVE"]])
+    try catalog.expect("""
+        SELECT DISTINCT UPPER(Name) AS u FROM People ORDER BY u
+        """, yields: [["ALICE"], ["BOB"], ["CAROL"], ["DAVE"]])
+    try catalog.expect("""
+        SELECT DISTINCT UPPER(Name) AS u FROM People ORDER BY 1
+        """, yields: [["ALICE"], ["BOB"], ["CAROL"], ["DAVE"]])
+  }
+
+  @Test func `SELECT DISTINCT admits a mixed-case ORDER BY the other way round`() throws {
+    // The case folding is symmetric: a lower-case `upper(Name)` PROJECTED and
+    // an upper-case `UPPER(Name)` in the ORDER BY lower to the same term too,
+    // so this spelling is admitted as well (ALICE, BOB, CAROL, DAVE).
+    try people().expect("""
+        SELECT DISTINCT upper(Name) AS u FROM People ORDER BY UPPER(Name)
+        """, yields: [["ALICE"], ["BOB"], ["CAROL"], ["DAVE"]])
+  }
+
+  @Test func `SELECT DISTINCT rejects a case-folded key that names a different routine`() throws {
+    // Case folding equates only calls of the SAME routine: `LOWER(Name)` is a
+    // DIFFERENT routine from the projected `UPPER(Name)`, so its term differs
+    // and ordering on it under DISTINCT stays ill-defined and faults.
+    try people().expect("""
+        SELECT DISTINCT UPPER(Name) AS u FROM People ORDER BY LOWER(Name)
+        """, fails: SQLError.distinct("an expression"))
+  }
+
+  @Test func `a non-DISTINCT call resolves and runs regardless of its spelling`() throws {
+    // Name folding is purely about term IDENTITY — dispatch already folds on
+    // lookup, so a plain (non-DISTINCT) query calling `upper` in either case
+    // still resolves the routine and runs. The names are already lower-case and
+    // distinct, so the upper-cased order is the plain alphabetical one.
+    let catalog = try people()
+    try catalog.expect("SELECT Id FROM People ORDER BY upper(Name)",
+                       yields: [[2], [3], [1], [4]])
+    try catalog.expect("SELECT Id FROM People ORDER BY UPPER(Name)",
+                       yields: [[2], [3], [1], [4]])
+  }
+
+  @Test func `a grouped ORDER BY sorts on an aggregate it does not project`() throws {
+    // `COUNT(*)` is neither projected nor in a HAVING, so the group plan must
+    // collect it from the ORDER BY to have a grouped slot to sort on: Toys 1,
+    // then Books and Games tied at 3 (stable, first-appearance order).
+    try sales().expect("""
+        SELECT Dept FROM Sales GROUP BY Dept ORDER BY COUNT(*)
+        """, yields: [["Toys"], ["Books"], ["Games"]])
+  }
+
+  @Test func `a grouped ORDER BY aggregate DESC reverses the group order`() throws {
+    // The reported motivating case — sort groups by their count descending:
+    // Books and Games (3) before Toys (1), the tie kept in first-appearance
+    // order by the stable sort.
+    try sales().expect("""
+        SELECT Dept FROM Sales GROUP BY Dept ORDER BY COUNT(*) DESC
+        """, yields: [["Books"], ["Games"], ["Toys"]])
+  }
+
+  @Test func `a grouped ORDER BY may sort on an unprojected SUM`() throws {
+    // `SUM(Amount)` is only in the ORDER BY (Books 60, Games 90, Toys 30) —
+    // ascending yields Toys, Books, Games.
+    try sales().expect("""
+        SELECT Dept FROM Sales GROUP BY Dept ORDER BY SUM(Amount)
+        """, yields: [["Toys"], ["Books"], ["Games"]])
+  }
+
+  @Test func `an aggregate both projected and sorted-on computes once`() throws {
+    // `COUNT(*)` is projected AND sorted on — `collect` dedups, so it lands in
+    // one grouped slot and the projection and the sort read the same value
+    // (no duplicate-slot regression): counts descending, projected alongside.
+    try sales().expect("""
+        SELECT Dept, COUNT(*) FROM Sales GROUP BY Dept ORDER BY COUNT(*) DESC
+        """, yields: [["Books", 3], ["Games", 3], ["Toys", 1]])
+  }
+
+  // MARK: - Aggregate collection normalizes column qualification
+
+  // Aggregate collection dedups by the RESOLVED aggregation (function plus
+  // resolved argument term), not by AST spelling, so an aggregate written two
+  // ways that differ ONLY in column qualification — `SUM(Amount)` projected,
+  // `SUM(Sales.Amount)` in the ORDER BY — is ONE grouped slot: the aggregate
+  // computes once and both clauses read/order the same value.
+
+  @Test func `SELECT DISTINCT admits an ORDER BY aggregate differing only in qualification`() throws {
+    // The projected `SUM(Amount)` and the ORDER BY `SUM(Sales.Amount)` differ
+    // only in qualification; deduped by resolved form they share ONE grouped
+    // slot, so the sort key IS the projected distinct value and DISTINCT admits
+    // it. Distinct department sums are 60, 90, 30, ordered ascending.
+    try sales().expect("""
+        SELECT DISTINCT SUM(Amount) FROM Sales GROUP BY Dept \
+        ORDER BY SUM(Sales.Amount)
+        """, yields: [[30], [60], [90]])
+  }
+
+  @Test func `a DISTINCT qualified ORDER BY aggregate matches the unqualified form`() throws {
+    // The qualified `SUM(Sales.Amount)` sort key produces the SAME result as the
+    // unqualified `SUM(Amount)` and the ordinal `1` — all three name the one
+    // projected distinct aggregate value.
+    let catalog = try sales()
+    try catalog.expect("""
+        SELECT DISTINCT SUM(Amount) FROM Sales GROUP BY Dept \
+        ORDER BY SUM(Sales.Amount)
+        """, yields: [[30], [60], [90]])
+    try catalog.expect("""
+        SELECT DISTINCT SUM(Amount) FROM Sales GROUP BY Dept \
+        ORDER BY SUM(Amount)
+        """, yields: [[30], [60], [90]])
+    try catalog.expect("""
+        SELECT DISTINCT SUM(Amount) FROM Sales GROUP BY Dept ORDER BY 1
+        """, yields: [[30], [60], [90]])
+  }
+
+  @Test func `a grouped ORDER BY qualified aggregate reuses the projected slot`() throws {
+    // Non-DISTINCT: the projected `SUM(Amount)` (aliased) and the ORDER BY
+    // `SUM(Sales.Amount)` are the SAME resolved aggregation, so SUM computes
+    // ONCE into one grouped slot and the sort orders by it — the qualified and
+    // unqualified sort keys agree (60, 90, 30 by department, descending).
+    let catalog = try sales()
+    try catalog.expect("""
+        SELECT Dept, SUM(Amount) AS s FROM Sales GROUP BY Dept \
+        ORDER BY SUM(Sales.Amount) DESC
+        """, yields: [["Games", 90], ["Books", 60], ["Toys", 30]])
+    try catalog.expect("""
+        SELECT Dept, SUM(Amount) AS s FROM Sales GROUP BY Dept \
+        ORDER BY SUM(Amount) DESC
+        """, yields: [["Games", 90], ["Books", 60], ["Toys", 30]])
+  }
+
+  @Test func `a whole-result qualified ORDER BY aggregate reuses the projected slot`() throws {
+    // The whole-result aggregate form (no GROUP BY): the projected `SUM(Amount)`
+    // and the qualified `SUM(Sales.Amount)` sort key are one aggregation, so the
+    // single group's SUM (180, the sole non-NULL total) computes once and the
+    // sort orders by that shared slot.
+    try sales().expect("""
+        SELECT SUM(Amount) FROM Sales ORDER BY SUM(Sales.Amount)
+        """, yields: [[180]])
+  }
+
+  @Test func `a DISTINCT ORDER BY on a different aggregate still faults`() throws {
+    // Soundness: `SUM(Dept)` in the ORDER BY is a DIFFERENT aggregate from the
+    // projected `COUNT(*)` — a different function over a different operand — so
+    // it is a separate, non-projected grouped slot and ordering on it under
+    // DISTINCT stays ill-defined and faults. (Its own fold over the TEXT `Dept`
+    // never runs; the DISTINCT check rejects it first.)
+    try sales().expect("""
+        SELECT DISTINCT COUNT(*) FROM Sales GROUP BY Dept ORDER BY SUM(Dept)
+        """, fails: SQLError.distinct("an expression"))
+  }
+
+  @Test func `genuinely different aggregates keep separate grouped slots`() throws {
+    // Two different aggregations over the same operand — `SUM(Amount)` and
+    // `MAX(Amount)` — must NOT dedup into one slot: they compute independently.
+    // Books sums 60 / maxes 30, Games 90 / 50, Toys 30 / 30; ordered by SUM.
+    try sales().expect("""
+        SELECT SUM(Amount), MAX(Amount) FROM Sales GROUP BY Dept \
+        ORDER BY SUM(Amount)
+        """, yields: [[30, 30], [60, 30], [90, 50]])
+  }
+
+  // MARK: - Type-checking the sort keys
+
+  /// The result columns `sql` advertises, resolved WITHOUT running it — the
+  /// static shape check `columns(of:)`/`.schema`/`information_schema` drive,
+  /// against the standard prelude so a call like `UPPER` resolves.
+  private func columns(_ catalog: borrowing FixtureCatalog, _ sql: String)
+      throws -> Array<OutputColumn> {
+    guard case let .select(query) = try Statement(parsing: sql) else {
+      throw SQLError.incomplete(expected: "a SELECT statement")
+    }
+    return try catalog.columns(of: query)
+  }
+
+  @Test func `columns(of:) rejects an ORDER BY call to an unknown routine`() throws {
+    // `NOPE` is no registered routine, so the sort would fault at run — the
+    // static shape check must reject it too, not advertise the query as valid.
+    #expect(throws: SQLError.self) {
+      _ = try columns(try people(),
+                      "SELECT Name FROM People ORDER BY NOPE(Name)")
+    }
+  }
+
+  @Test func `columns(of:) rejects a wrong-arity ORDER BY call`() throws {
+    // `UPPER` takes one argument; the two-argument call would fault its arity
+    // at run, so the static shape check rejects it before advertising it.
+    #expect(throws: SQLError.self) {
+      _ = try columns(try people(),
+                      "SELECT Name FROM People ORDER BY UPPER(Name, 2)")
+    }
+  }
+
+  @Test func `columns(of:) accepts a valid ORDER BY call and expression`() throws {
+    // A registered one-argument `UPPER` and an arithmetic key type-check, so
+    // the shape check advertises the query — and it runs.
+    let catalog = try people()
+    let upper =
+        try columns(catalog, "SELECT Name FROM People ORDER BY UPPER(Name)")
+    #expect(upper.count == 1)
+    try catalog.expect("SELECT Id FROM People ORDER BY UPPER(Name)",
+                       yields: [[2], [3], [1], [4]])
+    let sum =
+        try columns(catalog, "SELECT Name FROM People ORDER BY 1 + A")
+    #expect(sum.count == 1)
+  }
+
+  @Test func `columns(of:) rejects a grouped ORDER BY over a bad aggregate operand`() throws {
+    // A grouped `ORDER BY SUM(Bogus)`/`NOPE(Amount)` collects into the group
+    // plan and folds before the sort — an unknown operand column or an unknown
+    // routine would fault at run, so the static shape check rejects both.
+    let catalog = try sales()
+    #expect(throws: SQLError.self) {
+      _ = try columns(catalog, """
+          SELECT Dept FROM Sales GROUP BY Dept ORDER BY SUM(Bogus)
+          """)
+    }
+    #expect(throws: SQLError.self) {
+      _ = try columns(catalog, """
+          SELECT Dept FROM Sales GROUP BY Dept ORDER BY NOPE(Amount)
+          """)
+    }
+  }
+
+  @Test func `columns(of:) accepts a grouped ORDER BY COUNT(*)`() throws {
+    // A valid grouped aggregate sort key type-checks and runs.
+    let catalog = try sales()
+    let advertised = try columns(catalog, """
+        SELECT Dept FROM Sales GROUP BY Dept ORDER BY COUNT(*)
+        """)
+    #expect(advertised.count == 1)
+    try catalog.expect("""
+        SELECT Dept FROM Sales GROUP BY Dept ORDER BY COUNT(*)
+        """, yields: [["Toys"], ["Books"], ["Games"]])
+  }
+
+  @Test func `columns(of:) surfaces a bad ORDER BY call in a view body`() throws {
+    // A view whose body's ORDER BY calls an unknown routine advertises no valid
+    // schema — the shape check reaches into the body's sort keys, so a
+    // `.schema`/`columns(of:)` over the view faults where a run would.
+    let catalog = try Catalog {
+      Relation("People", ["Name": .text]) {
+        Row("carol")
+      }
+      try View("Bad", "SELECT Name FROM People ORDER BY NOPE(Name)",
+               as: ["Name"])
+    }
+    #expect(throws: SQLError.self) {
+      _ = try columns(catalog, "SELECT * FROM Bad")
+    }
+  }
+
+  @Test func `columns(of:) accepts an ORDER BY output alias absent as input`() throws {
+    // `u` names the `UPPER(Name)` output alias, not an input column; the sort
+    // key resolves to the already-validated projection item, so the shape check
+    // must NOT re-validate it as an input column (which would fault, there
+    // being no `u` column) — it advertises the query, and it runs.
+    let catalog = try people()
+    let advertised = try columns(catalog, """
+        SELECT UPPER(Name) AS u FROM People ORDER BY u
+        """)
+    #expect(advertised.count == 1)
+    try catalog.expect("""
+        SELECT UPPER(Name) AS u FROM People ORDER BY u
+        """, yields: [["ALICE"], ["BOB"], ["CAROL"], ["DAVE"]])
+  }
+
+  // MARK: - A grouped ORDER BY output name type-checks like the run
+
+  // The grouped order lowering (`Grouping.terms`/`Grouping.order`) binds a bare
+  // `ORDER BY <name>` to a grouped OUTPUT name — a projected item's
+  // `Projected.name` (an alias, else an unaliased group column's own name) —
+  // before an input column. The schema/type-check path must resolve the SAME
+  // output-name set, so `columns(of:)`/`.schema` accept exactly the grouped
+  // `ORDER BY` queries that compile and run.
+
+  @Test func `columns(of:) accepts a grouped ORDER BY an unaliased group column`() throws {
+    // The reported case: `a.Name` and `COUNT(*)` force an `expressions`
+    // projection, and `a.Name` is a group column with NO explicit alias. The
+    // grouped lowering binds `ORDER BY Name` to that group-column OUTPUT (its
+    // `Projected.name`), so the run ACCEPTS. Before the fix the schema path
+    // treated `Name` as an INPUT column and — both `a` and `b` carrying `Name`
+    // — faulted `SQLError.ambiguous`, rejecting a query that runs. It now binds
+    // the grouped output too, so `columns(of:)` accepts and the query runs.
+    let catalog = try joined()
+    let advertised = try columns(catalog, """
+        SELECT a.Name, COUNT(*) FROM a JOIN b ON a.Id = b.Id \
+        GROUP BY a.Name ORDER BY Name
+        """)
+    #expect(advertised.count == 2)
+    try catalog.expect("""
+        SELECT a.Name, COUNT(*) FROM a JOIN b ON a.Id = b.Id \
+        GROUP BY a.Name ORDER BY Name
+        """, yields: [["alice", 1], ["bob", 1], ["carol", 1]])
+  }
+
+  @Test func `a view over a grouped ORDER BY group-column body validates`() throws {
+    // The same shape as a VIEW body: the schema path reaches into the body's
+    // grouped `ORDER BY Name`, binds it to the group-column output as the run
+    // does, and advertises a valid schema — no spurious ambiguity fault.
+    let catalog = try Catalog {
+      Relation("a", ["Id": .integer, "Name": .text]) {
+        Row(1, "carol")
+        Row(2, "alice")
+      }
+      Relation("b", ["Id": .integer, "Name": .text]) {
+        Row(1, "x")
+        Row(2, "y")
+      }
+      try View("Grouped", """
+          SELECT a.Name, COUNT(*) FROM a JOIN b ON a.Id = b.Id \
+          GROUP BY a.Name ORDER BY Name
+          """, as: ["Name", "n"])
+    }
+    let advertised = try columns(catalog, "SELECT * FROM Grouped")
+    #expect(advertised.count == 2)
+  }
+
+  @Test func `a grouped ORDER BY over an unresolvable name faults in both paths`() throws {
+    // Soundness: `Bogus` is neither a grouped output nor a resolvable input
+    // column, so it faults consistently — the run rejects it, and the schema
+    // path must too (no over-acceptance from the new output-name lookup).
+    let catalog = try joined()
+    #expect(throws: SQLError.self) {
+      _ = try columns(catalog, """
+          SELECT a.Name, COUNT(*) FROM a JOIN b ON a.Id = b.Id \
+          GROUP BY a.Name ORDER BY Bogus
+          """)
+    }
+    catalog.expect("""
+        SELECT a.Name, COUNT(*) FROM a JOIN b ON a.Id = b.Id \
+        GROUP BY a.Name ORDER BY Bogus
+        """, fails: SQLError.column("Bogus"))
+  }
+
+  @Test func `a grouped ORDER BY over an ambiguous non-group input still faults`() throws {
+    // Soundness: `Id` is a group-column-absent INPUT column both `a` and `b`
+    // carry, and no projected output claims the name — so the grouped lowering
+    // resolves it as an ambiguous input and faults, and the schema path agrees.
+    let catalog = try joined()
+    #expect(throws: SQLError.self) {
+      _ = try columns(catalog, """
+          SELECT a.Name, COUNT(*) FROM a JOIN b ON a.Id = b.Id \
+          GROUP BY a.Name ORDER BY Id
+          """)
+    }
+    catalog.expect("""
+        SELECT a.Name, COUNT(*) FROM a JOIN b ON a.Id = b.Id \
+        GROUP BY a.Name ORDER BY Id
+        """, fails: SQLError.ambiguous("Id"))
+  }
+
+  // MARK: - The sort validates below a row-dropping limit
+
+  // The compiled shape is `Project(Limit(Sort(input)))`: the sort evaluates
+  // each ORDER BY key over the input rows BEFORE the cap pages them, so a limit
+  // that drops every output row still runs the sort. The static shape check
+  // must therefore validate the sort keys — and the projection expressions an
+  // ordinal or an output-name key reaches — INDEPENDENT of whether the
+  // projection is reachable under the limit.
+
+  @Test func `a zero-row FETCH does not spare a bad ORDER BY expression`() throws {
+    // The projection (`Name`) is unreachable under a zero FETCH, but the sort
+    // below the limit still evaluates `NOPE(Name)` — an unknown routine — so
+    // the shape check must reject the query rather than advertise it then
+    // fault at run.
+    #expect(throws: SQLError.self) {
+      _ = try columns(try people(), """
+          SELECT Name FROM People ORDER BY NOPE(Name) FETCH FIRST 0 ROWS ONLY
+          """)
+    }
+  }
+
+  @Test func `a zero-row FETCH does not spare an ORDER BY ordinal's projection term`() throws {
+    // The projection block is skipped under a zero FETCH, but `ORDER BY 1`
+    // makes the sort recompute the first projection term — `NOPE(Name)`, an
+    // unknown routine — below the limit, so the shape check must reject it.
+    #expect(throws: SQLError.self) {
+      _ = try columns(try people(), """
+          SELECT NOPE(Name) FROM People ORDER BY 1 FETCH FIRST 0 ROWS ONLY
+          """)
+    }
+  }
+
+  @Test func `a zero-row FETCH does not spare an ORDER BY alias's projection term`() throws {
+    // `n` names the bad `NOPE(Name)` output; the sort recomputes that term
+    // below the zero FETCH, so the shape check must reject it even though the
+    // projection block is skipped.
+    #expect(throws: SQLError.self) {
+      _ = try columns(try people(), """
+          SELECT NOPE(Name) AS n FROM People ORDER BY n FETCH FIRST 0 ROWS ONLY
+          """)
+    }
+  }
+
+  @Test func `an OFFSET past the sole aggregate row does not spare a bad ORDER BY`() throws {
+    // A whole-result aggregate emits ONE row, which a positive OFFSET drops, so
+    // the projection is unreachable — but the sort below the limit still
+    // evaluates `NOPE(Dept)`, so the shape check must reject the query.
+    #expect(throws: SQLError.self) {
+      _ = try columns(try sales(), """
+          SELECT COUNT(*) FROM Sales ORDER BY NOPE(Dept) OFFSET 1 ROWS
+          """)
+    }
+  }
+
+  @Test func `a zero-row FETCH still spares an unreferenced projection expression`() throws {
+    // No ORDER BY, so the sort runs nothing; the projection (`NOPE(Name)`) is
+    // unreachable under a zero FETCH and never evaluated — so the shape check
+    // must NOT reject it. Fixing the sort-key gap introduces no false positive
+    // for a projection term the sort does not reach.
+    let advertised = try columns(try people(), """
+        SELECT NOPE(Name) FROM People FETCH FIRST 0 ROWS ONLY
+        """)
+    #expect(advertised.count == 1)
+  }
+
+  @Test func `a valid ORDER BY under a zero-row FETCH validates and runs empty`() throws {
+    // A valid sort key under a zero FETCH type-checks (the sort runs) and the
+    // query runs to its empty page — no false positive, no fault.
+    let catalog = try people()
+    let advertised = try columns(catalog, """
+        SELECT Name FROM People ORDER BY UPPER(Name) FETCH FIRST 0 ROWS ONLY
+        """)
+    #expect(advertised.count == 1)
+    try catalog.expect("""
+        SELECT Name FROM People ORDER BY UPPER(Name) FETCH FIRST 0 ROWS ONLY
+        """, yields: [])
+  }
+
+  @Test func `columns(of:) surfaces a bad ORDER BY under a limit in a view body`() throws {
+    // A view whose body drops every row with a zero FETCH but sorts on an
+    // unknown routine advertises no valid schema — the shape check reaches
+    // the body's sort keys regardless of the limit, faulting where a run would.
+    let catalog = try Catalog {
+      Relation("People", ["Name": .text]) {
+        Row("carol")
+      }
+      try View("Bad", """
+          SELECT Name FROM People ORDER BY NOPE(Name) FETCH FIRST 0 ROWS ONLY
+          """, as: ["Name"])
+    }
+    #expect(throws: SQLError.self) {
+      _ = try columns(catalog, "SELECT * FROM Bad")
+    }
+  }
+
+  // MARK: - The schema path rejects an out-of-range ORDER BY ordinal
+
+  // An `ORDER BY` ordinal names a 1-based SELECT-list position; one outside
+  // `1 ... width` names no output column and faults `SQLError.column` (spelled
+  // as the ordinal) at run. The static shape check must raise the SAME fault
+  // rather than drop the key and advertise a shape for a query that cannot run.
+
+  @Test func `columns(of:) rejects an out-of-range ORDER BY ordinal`() throws {
+    // `2` is past the one-column select list; the run faults `SQLError.column`,
+    // so the schema path must reject it too — the two paths agree.
+    let catalog = try people()
+    #expect(throws: SQLError.column("2")) {
+      _ = try columns(catalog, "SELECT Name FROM People ORDER BY 2")
+    }
+    catalog.expect("SELECT Name FROM People ORDER BY 2",
+                   fails: SQLError.column("2"))
+  }
+
+  @Test func `columns(of:) accepts an in-range ORDER BY ordinal`() throws {
+    // `1` names the sole output column, in range; the shape check advertises it
+    // and it runs.
+    let catalog = try people()
+    let advertised = try columns(catalog, "SELECT Name FROM People ORDER BY 1")
+    #expect(advertised.count == 1)
+    try catalog.expect("SELECT Name FROM People ORDER BY 1",
+                       yields: [["alice"], ["bob"], ["carol"], ["dave"]])
+  }
+
+  @Test func `columns(of:) rejects a zero or negative ORDER BY ordinal`() throws {
+    // `0` (and a parser-forbidden negative, tested via the AST) is below the
+    // 1-based range, faulting consistently in both paths as the run does.
+    let catalog = try people()
+    #expect(throws: SQLError.column("0")) {
+      _ = try columns(catalog, "SELECT Name FROM People ORDER BY 0")
+    }
+    catalog.expect("SELECT Name FROM People ORDER BY 0",
+                   fails: SQLError.column("0"))
+  }
+
+  @Test func `columns(of:) surfaces an out-of-range ORDER BY ordinal in a view body`() throws {
+    // A view whose body's `ORDER BY 2` names a missing output column advertises
+    // no valid schema — the shape check reaches the body's sort keys, faulting
+    // where a run would.
+    let catalog = try Catalog {
+      Relation("People", ["Name": .text]) {
+        Row("carol")
+      }
+      try View("Bad", "SELECT Name FROM People ORDER BY 2", as: ["Name"])
+    }
+    #expect(throws: SQLError.self) {
+      _ = try columns(catalog, "SELECT * FROM Bad")
+    }
+  }
+
+  // MARK: - The schema path enforces GROUP BY rules on ORDER BY expressions
+
+  // A grouped `ORDER BY` sorts in the grouped slot space, so a sort EXPRESSION
+  // referencing a resolvable-but-non-grouped column faults `SQLError.grouping`
+  // at run (`Grouping.term`). The static shape check validates each grouped
+  // sort key through the SAME grouped lowering, so it rejects exactly the keys
+  // the run does and admits exactly the ones it does.
+
+  @Test func `columns(of:) rejects a grouped ORDER BY over a non-grouped column`() throws {
+    // `b.Id` is a resolvable INPUT column, but neither a `GROUP BY` key nor
+    // inside an aggregate, so `ORDER BY b.Id + 1` faults `SQLError.grouping` at
+    // run — the schema path validates it through the grouped lowering and agrees.
+    let catalog = try joined()
+    #expect(throws: SQLError.grouping("Id")) {
+      _ = try columns(catalog, """
+          SELECT a.Name, COUNT(*) FROM a JOIN b ON a.Id = b.Id \
+          GROUP BY a.Name ORDER BY b.Id + 1
+          """)
+    }
+    catalog.expect("""
+        SELECT a.Name, COUNT(*) FROM a JOIN b ON a.Id = b.Id \
+        GROUP BY a.Name ORDER BY b.Id + 1
+        """, fails: SQLError.grouping("Id"))
+  }
+
+  @Test func `columns(of:) accepts a grouped ORDER BY over a group key or aggregate`() throws {
+    // The valid grouped sort keys still validate and run: a group key
+    // (`a.Name`), a bare aggregate (`COUNT(*)`), and an expression over an
+    // aggregate (`COUNT(*) + 1`) — each admitted by the grouped lowering.
+    let catalog = try joined()
+    for key in ["a.Name", "COUNT(*)", "COUNT(*) + 1"] {
+      let sql = """
+          SELECT a.Name, COUNT(*) FROM a JOIN b ON a.Id = b.Id \
+          GROUP BY a.Name ORDER BY \(key)
+          """
+      let advertised = try columns(catalog, sql)
+      #expect(advertised.count == 2)
+    }
+    try catalog.expect("""
+        SELECT a.Name, COUNT(*) FROM a JOIN b ON a.Id = b.Id \
+        GROUP BY a.Name ORDER BY a.Name
+        """, yields: [["alice", 1], ["bob", 1], ["carol", 1]])
+  }
+
+  @Test func `columns(of:) surfaces a bad grouped ORDER BY expression in a view body`() throws {
+    // A view whose grouped body sorts on a non-grouped column advertises no
+    // valid schema — the shape check reaches the body's grouped sort keys and
+    // faults `SQLError.grouping` where a run would.
+    let catalog = try Catalog {
+      Relation("a", ["Id": .integer, "Name": .text]) {
+        Row(1, "carol")
+      }
+      Relation("b", ["Id": .integer]) {
+        Row(1)
+      }
+      try View("Bad", """
+          SELECT a.Name, COUNT(*) FROM a JOIN b ON a.Id = b.Id \
+          GROUP BY a.Name ORDER BY b.Id + 1
+          """, as: ["Name", "n"])
+    }
+    #expect(throws: SQLError.self) {
+      _ = try columns(catalog, "SELECT * FROM Bad")
+    }
+  }
+}
+
+// MARK: - Single evaluation of a computed output sort key
+
+/// A shared call counter a stateful routine increments — a tiny
+/// `@unchecked Sendable` box over a mutable count, so the non-deterministic
+/// `tick()` routine registered against it both yields successive values and
+/// records how many times the run invoked it. (`NEXT` is a reserved word —
+/// its `FETCH … NEXT` spelling — so the routine is spelled `tick`.) The engine
+/// evaluates a query on one thread, so the box needs no lock.
+private final class Counter: @unchecked Sendable {
+  /// The number of times `next()` has been called.
+  private(set) var count = 0
+
+  /// Increments the count and returns the NEXT value — the sequence `1, 2, 3,
+  /// …` across successive calls, so a row's yielded value doubles as the
+  /// call's order of evaluation.
+  func next() -> Int {
+    count += 1
+    return count
+  }
+}
+
+/// An `ORDER BY` key naming a COMPUTED select-list output must sort on the SAME
+/// value the row returns — the projected expression evaluated ONCE per row.
+/// Reusing the projection term as the pre-projection sort key evaluated it
+/// twice (once to order, once to project), so a non-deterministic routine
+/// sorted on one set of values and returned a second, misordering the result.
+struct OrderBySingleEvaluationTests {
+  /// A four-row table — enough rows that a per-row `tick()` yields four
+  /// distinct values whose order is observable.
+  private func table() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["Id": .integer]) {
+        Row(1)
+        Row(2)
+        Row(3)
+        Row(4)
+      }
+    }
+  }
+
+  @Test func `an ordinal over a stateful output sorts on the returned value`() throws {
+    // `tick()` yields 1, 2, 3, 4 across the four rows — computed ONCE per row
+    // when the output is materialised below the sort. `ORDER BY 1 DESC` then
+    // sorts on those materialised values and returns them in that order:
+    // 4, 3, 2, 1. Double-evaluation would sort on the first set (1…4) yet
+    // return an independently generated SECOND set (5…8), whose values would
+    // NOT be in descending order.
+    let counter = Counter()
+    let routines = try Routines()
+        .registering("tick", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+    try table().expect("SELECT tick() AS n FROM T ORDER BY 1 DESC",
+                       yields: [[4], [3], [2], [1]], routines: routines)
+    // Exactly one call per row: the sort no longer recomputes the output.
+    #expect(counter.count == 4)
+  }
+
+  @Test func `an alias over a stateful output sorts on the returned value`() throws {
+    // The alias form of the same query: `ORDER BY n` names the output, which is
+    // materialised once, so the returned `n`s are in descending order and the
+    // routine is invoked exactly once per row.
+    let counter = Counter()
+    let routines = try Routines()
+        .registering("tick", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+    try table().expect("SELECT tick() AS n FROM T ORDER BY n DESC",
+                       yields: [[4], [3], [2], [1]], routines: routines)
+    #expect(counter.count == 4)
+  }
+
+  @Test func `a deterministic computed output still orders correctly`() throws {
+    // A deterministic computed output (`Id * 10`) orders on exactly the
+    // returned value whether or not it is recomputed — the ordinal and alias
+    // sort on it descending: 40, 30, 20, 10.
+    try table().expect("SELECT Id * 10 AS n FROM T ORDER BY 1 DESC",
+                       yields: [[40], [30], [20], [10]])
+    try table().expect("SELECT Id * 10 AS n FROM T ORDER BY n DESC",
+                       yields: [[40], [30], [20], [10]])
+  }
+
+  @Test func `a stateful output under a secondary input key is computed once`() throws {
+    // A multi-key sort mixing a materialised output ordinal (primary) and an
+    // ordinary INPUT key (`Id`, secondary): the output is still computed once,
+    // so the primary key sorts on the returned values (4, 3, 2, 1) and the
+    // routine is invoked exactly once per row even though an input key rides
+    // alongside it in the materialised sort row.
+    let counter = Counter()
+    let routines = try Routines()
+        .registering("tick", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+    try table().expect("SELECT tick() AS n FROM T ORDER BY 1 DESC, Id ASC",
+                       yields: [[4], [3], [2], [1]], routines: routines)
+    #expect(counter.count == 4)
+  }
+
+  @Test func `a grouped computed output sorts on the returned aggregate`() throws {
+    // The grouped path also materialises a computed output once: order on the
+    // aliased `COUNT(*) * 2` output, an ordinal over it — the sort reads the
+    // materialised aggregate rather than recomputing the projection term.
+    let catalog = try Catalog {
+      Relation("G", ["Dept": .text]) {
+        Row("a")
+        Row("a")
+        Row("a")
+        Row("b")
+        Row("c")
+        Row("c")
+      }
+    }
+    // a 3→6, c 2→4, b 1→2, descending on the doubled count.
+    try catalog.expect("""
+        SELECT Dept, COUNT(*) * 2 AS n FROM G GROUP BY Dept ORDER BY 2 DESC
+        """, yields: [["a", 6], ["c", 4], ["b", 2]])
+    try catalog.expect("""
+        SELECT Dept, COUNT(*) * 2 AS n FROM G GROUP BY Dept ORDER BY n DESC
+        """, yields: [["a", 6], ["c", 4], ["b", 2]])
+  }
+}
+
+/// Only the SORT-referenced outputs are materialised below the sort; every
+/// OTHER output is computed by the final projection ABOVE the cap. The whole
+/// select list materialised below the sort regressed the `Project(Limit(_))`
+/// page — a faulting output an ORDER BY key does NOT name (`1 / 0`) ran for a
+/// row the limit was about to drop, so an empty page faulted instead of empty.
+struct OrderByLazyProjectionTests {
+  @Test func `an unreferenced output does not run for a dropped row`() throws {
+    // `x` is the only sort-referenced output, so `1 / 0` is computed by the
+    // final projection ABOVE the cap — never for a row the empty page drops.
+    // The whole-select-list shape evaluated it below the cap and faulted.
+    try people().empty("""
+        SELECT Id AS x, 1 / 0 FROM People ORDER BY x FETCH FIRST 0 ROWS ONLY
+        """)
+  }
+
+  @Test func `an unreferenced output IS computed for a surviving row`() throws {
+    // A non-empty page: `y` (unreferenced by the sort) computes correctly for
+    // each surviving row, so the lazy split still returns the right values.
+    try people().expect("SELECT Id AS x, Id * 2 AS y FROM People ORDER BY x",
+                        yields: [[1, 2], [2, 4], [3, 6], [4, 8]])
+  }
+
+  @Test func `an unreferenced faulting output STILL faults for a surviving row`() throws {
+    // The laziness is a page skip, not a licence to drop a fault: with rows
+    // surviving the cap the unreferenced `1 / 0` must still evaluate and fault.
+    try people().expect("""
+        SELECT Id AS x, 1 / 0 FROM People ORDER BY x FETCH FIRST 2 ROWS ONLY
+        """, fails: .divide)
+  }
+}
+
+/// A grouped `ORDER BY` alias must sort on the projection column the alias
+/// NAMES — the column's INDEX — not `firstIndex(of:)` of its term. Two
+/// projected items may share one term under distinct aliases (two calls to a
+/// `deterministic: false` routine), so a term search collapses to the first
+/// column and `ORDER BY <second alias>` misorders on the wrong output.
+struct OrderByDuplicateAliasTests {
+  /// A three-row table grouping to three singleton groups, so a per-group
+  /// `tick()` yields a distinct value the alias order is observable over.
+  private func table() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("G", ["Dept": .text]) {
+        Row("a")
+        Row("b")
+        Row("c")
+      }
+    }
+  }
+
+  @Test func `a grouped ORDER BY the second of two shared-term aliases sorts on it`() throws {
+    // Two projections share the term `tick()` under distinct aliases `p`
+    // (column 1) and `q` (column 2). `ORDER BY q DESC` must sort on COLUMN 2:
+    // the sort-referenced `q` is materialised once per group (1, 2, 3 over the
+    // three groups) and ordered DESC, so the returned `q` column descends
+    // 3, 2, 1 — the observable proof the sort ran on `q`, not `p`. The
+    // `firstIndex(of:)` bug resolved `q` to `p`'s column 1 and would sort/
+    // materialise `p` instead, leaving the `q` column NOT descending.
+    let counter = Counter()
+    let routines = try Routines()
+        .registering("tick", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+    try table().expect("""
+        SELECT Dept, tick() AS p, tick() AS q FROM G GROUP BY Dept ORDER BY q DESC
+        """, yields: [["c", 4, 3], ["b", 5, 2], ["a", 6, 1]], routines: routines)
+  }
+
+  @Test func `a grouped ORDER BY the first of two shared-term aliases sorts on it`() throws {
+    // The companion: `ORDER BY p DESC` sorts on COLUMN 1, so the `p` column
+    // descends 3, 2, 1 while `q` is computed above. That the DESCENDING column
+    // moves with the named alias (2 here, 1 above) is what distinguishes the
+    // two — a term search would sort both by column 1, making them identical.
+    let counter = Counter()
+    let routines = try Routines()
+        .registering("tick", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+    try table().expect("""
+        SELECT Dept, tick() AS p, tick() AS q FROM G GROUP BY Dept ORDER BY p DESC
+        """, yields: [["c", 3, 4], ["b", 2, 5], ["a", 1, 6]], routines: routines)
+  }
+
+  @Test func `a non-grouped ORDER BY the second of two shared-term aliases sorts on it`() throws {
+    // The non-grouped path already tracks the matched alias index; confirm it
+    // over the same shared-term shape. `ORDER BY q DESC` sorts on column 1 (the
+    // second output): `q` is materialised once per row (1, 2, 3, 4 in scan
+    // order) and ordered DESC, so the returned `q` column descends 4, 3, 2, 1.
+    let counter = Counter()
+    let routines = try Routines()
+        .registering("tick", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+    try people().expect("""
+        SELECT tick() AS p, tick() AS q FROM People ORDER BY q DESC
+        """, yields: [[5, 4], [6, 3], [7, 2], [8, 1]], routines: routines)
+  }
+}
+
+/// A `SELECT DISTINCT` `ORDER BY` key accepted because its resolved term
+/// REPEATS a projected expression (not an alias or ordinal) must sort on that
+/// ALREADY-MATERIALISED projected slot — the same value the dedup and the
+/// output use — rather than re-evaluating the term. Under DISTINCT the whole
+/// projection materialises once below the sort; leaving the key's `column`
+/// `nil` appended a fresh hidden column and sorted on a SECOND evaluation, so a
+/// stateful key ordered on values the returned column did not carry.
+struct OrderByDistinctExpressionTests {
+  /// A four-row table whose rows are all distinct, so a per-row `tick()` under
+  /// DISTINCT survives the dedup as four rows and its order is observable.
+  private func table() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["Id": .integer]) {
+        Row(1)
+        Row(2)
+        Row(3)
+        Row(4)
+      }
+    }
+  }
+
+  @Test func `a DISTINCT repeated stateful expression sorts on the returned value`() throws {
+    // `tick()` is projected AND repeated in the ORDER BY. It is not an alias or
+    // an ordinal, so it is admitted by the resolved-term match — and must sort
+    // on the projected slot the dedup/output use, materialised ONCE per row (1,
+    // 2, 3, 4). `ORDER BY tick() DESC` then returns them descending: 4, 3, 2,
+    // 1. Re-evaluating the appended term would sort on an independently
+    // generated second set (5…8) while returning the first, misordering the
+    // `n` column and doubling the call count.
+    let counter = Counter()
+    let routines = try Routines()
+        .registering("tick", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+    try table().expect("""
+        SELECT DISTINCT tick() AS n FROM T ORDER BY tick() DESC
+        """, yields: [[4], [3], [2], [1]], routines: routines)
+    // Exactly one call per row: the sort reuses the materialised slot rather
+    // than re-evaluating the appended term (which would count eight).
+    #expect(counter.count == 4)
+  }
+
+  @Test func `the alias and ordinal forms agree with the repeated expression`() throws {
+    // `ORDER BY n` (alias) and `ORDER BY 1` (ordinal) name the SAME projected
+    // slot as the repeated `ORDER BY tick()`, so all three return the stateful
+    // values descending and invoke the routine exactly once per row.
+    for key in ["tick()", "n", "1"] {
+      let counter = Counter()
+      let routines = try Routines()
+          .registering("tick", returns: .integer, deterministic: false) { _ in
+            .integer(counter.next())
+          }
+      try table().expect("""
+          SELECT DISTINCT tick() AS n FROM T ORDER BY \(key) DESC
+          """, yields: [[4], [3], [2], [1]], routines: routines)
+      #expect(counter.count == 4)
+    }
+  }
+
+  @Test func `a DISTINCT repeated deterministic expression still orders correctly`() throws {
+    // A deterministic repeated expression (`Id * 10`) reuses the projected slot
+    // too; the distinct values 10, 20, 30, 40 sort descending regardless of
+    // re-evaluation, so the reuse changes the value, not the order.
+    try table().expect("""
+        SELECT DISTINCT Id * 10 AS n FROM T ORDER BY Id * 10 DESC
+        """, yields: [[40], [30], [20], [10]])
+  }
+
+  @Test func `a DISTINCT key matching no projected expression still faults`() throws {
+    // Soundness: `Id` is not a projected value, so ordering on it under DISTINCT
+    // is ill-defined and faults — the resolved-term reuse admits exactly the
+    // keys the guard already accepted, no more.
+    try table().expect("SELECT DISTINCT Id * 10 FROM T ORDER BY Id",
+                       fails: SQLError.distinct("Id"))
+  }
+}

--- a/Tests/SQLTests/ParserTests.swift
+++ b/Tests/SQLTests/ParserTests.swift
@@ -248,6 +248,76 @@ struct OrderTests {
     #expect(select.order?.keys
               == [Order.Key(column: "TypeName", ascending: false)])
   }
+
+  @Test func `parses an integer sort key as an ordinal`() throws {
+    // A bare integer is the ISO output-column ORDINAL, not the constant.
+    let select = try parse(select: "SELECT A, B FROM T ORDER BY 2 DESC")
+    #expect(select.order
+              == Order(keys: [Order.Key(sort: .ordinal(2), ascending: false)]))
+  }
+
+  @Test func `parses an arithmetic sort key as an expression`() throws {
+    let select = try parse(select: "SELECT * FROM T ORDER BY A + B")
+    let sum = Expression.binary(.add, .column("A"), .column("B"))
+    #expect(select.order
+              == Order(keys: [Order.Key(sort: .expression(sum))]))
+  }
+
+  @Test func `parses a call sort key as an expression`() throws {
+    let select = try parse(select: "SELECT * FROM T ORDER BY UPPER(Name) ASC")
+    let call = Expression.call(name: "UPPER", arguments: [.column("Name")])
+    #expect(select.order
+              == Order(keys: [Order.Key(sort: .expression(call))]))
+  }
+
+  @Test func `a bare column sort key is a column expression`() throws {
+    // The convenience `Key(column:)` and the parsed `.expression(.column)` are
+    // the same key — a bare column stays the common shape.
+    let select = try parse(select: "SELECT * FROM T ORDER BY TypeName")
+    #expect(select.order?.keys == [Order.Key(column: "TypeName")])
+  }
+
+  @Test func `a bare integer sort key is an ordinal`() throws {
+    // Only a LONE integer literal is the output-column ordinal — the key
+    // parses as an expression and classifies to `.ordinal` when it is one.
+    let select = try parse(select: "SELECT A, B FROM T ORDER BY 1")
+    #expect(select.order
+              == Order(keys: [Order.Key(sort: .ordinal(1))]))
+  }
+
+  @Test func `an integer-leading arithmetic sort key is an expression`() throws {
+    // `1 + A` leads with an integer but is NOT a bare integer — it must parse
+    // as the arithmetic expression, not an ordinal `1` with `+ A` left over.
+    let select = try parse(select: "SELECT A FROM T ORDER BY 1 + A")
+    let sum = Expression.binary(.add, .literal(.integer(1)), .column("A"))
+    #expect(select.order
+              == Order(keys: [Order.Key(sort: .expression(sum))]))
+  }
+
+  @Test func `an integer-leading product sort key is an expression`() throws {
+    // `2 * Price` likewise classifies as an expression, DESC still attaching.
+    let select =
+        try parse(select: "SELECT Price FROM T ORDER BY 2 * Price DESC")
+    let product = Expression.binary(.multiply, .literal(.integer(2)),
+                                    .column("Price"))
+    #expect(select.order
+              == Order(keys: [Order.Key(sort: .expression(product),
+                                        ascending: false)]))
+  }
+
+  @Test func `a mixed list keeps an ordinal and an integer-leading expression`()
+      throws {
+    // `1` is the ordinal; `Price * 2 DESC` is an expression — the two forms
+    // compose in one list, each carrying its own direction.
+    let select =
+        try parse(select: "SELECT Price FROM T ORDER BY 1, Price * 2 DESC")
+    let product = Expression.binary(.multiply, .column("Price"),
+                                    .literal(.integer(2)))
+    #expect(select.order == Order(keys: [
+      Order.Key(sort: .ordinal(1)),
+      Order.Key(sort: .expression(product), ascending: false),
+    ]))
+  }
 }
 
 struct CompositeTests {
@@ -579,6 +649,19 @@ struct ExpressionTests {
     #expect(select.projection
                 == .expressions([
                   Projected(expression: .column("Name"), alias: "label")
+                ]))
+  }
+
+  @Test func `an AS on one item flips a bare sibling into an unaliased expression`() throws {
+    // Aliasing only the second item forces the whole list into `expressions`,
+    // but the bare first item carries NO alias (`alias: nil`) — so an
+    // `ORDER BY` output-name binding, which considers only explicit aliases,
+    // treats it exactly as it would in a `columns` list.
+    let select = try parse(select: "SELECT Name, Id AS id FROM T")
+    #expect(select.projection
+                == .expressions([
+                  Projected(expression: .column("Name")),
+                  Projected(expression: .column("Id"), alias: "id"),
                 ]))
   }
 


### PR DESCRIPTION
Generalize the `ORDER BY` sort key from a bare (possibly-qualified) column reference to the ISO `<sort key>` — an arbitrary value expression over the input columns — plus the two SQL conventions that name a SELECT-list OUTPUT column: a 1-based ORDINAL and an output ALIAS.

`Order.Key` now holds an `Order.Key.Sort` that is either `.ordinal(n)` or `.expression(e)`; the `Key(column:)`/`Order(column:)` convenience initializers map a column to `.expression(.column(column))`, so every existing constructor keeps compiling. The parser reads a leading integer literal as the ordinal (the ISO rule — a bare integer sort key is a select-list position, never the integer constant), and anything else as a full `expression`, which subsumes a bare column and an arbitrary computation (`a + b`, `UPPER(Name)`); the EBNF `key := (integer | expression) [ASC | DESC]` and the surrounding doc-comments are updated to match.

Resolution lowers each key to a `Term` rather than a slot: an ordinal or an output alias resolves to the matching projection item's own already-lowered term (re-used over the source rows the sort runs on, so a computed output recomputes), and an ordinary expression lowers fresh over the input columns. An out-of-range ordinal faults `SQLError.column` (spelled as the ordinal), as an unknown column would. The `Plan.sort` node accordingly carries a `Term` per key, which the executor evaluates against each record up front (a `sorted(by:)` comparator cannot throw, and this evaluates each key once per row); the stable multi-key ordering with per-key ASC/DESC and NULL ordering is unchanged, and the referenced-ordinal materialization now unions each key term's read ordinals.

Alias-vs-column precedence: a bare unqualified `ORDER BY` name binds a matching OUTPUT alias before an input column of the same name — the ISO precedence for a bare sort name — falling back to the input column when no alias claims it. A qualified name is always an input reference.

The grouped path gains ordinal and general grouped-expression keys alongside its existing alias and GROUP-BY-key ordering; because the sort now evaluates a term per grouped record, ordering on a COMPUTED alias (`COUNT(*) * 2 AS Doubled`) works where the slot-only sort once rejected it. The DISTINCT ordering guard is adapted to the new key shape: an ordinal or alias references an output by construction (`SortKey.output`) and is always admitted — its value is constant across a dedup group — while an ordinary input expression is admitted only when it reads a select-list output column, preserving the `SQLError.distinct` fault.