### PR TITLE
SQLEngine: accept a DISTINCT quantifier and FILTER in aggregates

### DIFF
--- a/Sources/SQLEngine/AST.swift
+++ b/Sources/SQLEngine/AST.swift
@@ -456,7 +456,23 @@ public indirect enum Expression: Hashable, Sendable {
   /// per row), an aggregate accumulates over every row of a group and yields one
   /// value, so the engine recognises the fixed set of aggregate names at parse
   /// time and lowers them through a dedicated mechanism rather than the routines.
-  case aggregate(Aggregate, of: Aggregand)
+  ///
+  /// `distinct` is the ISO `<set quantifier>` written inside the parentheses:
+  /// `DISTINCT` folds each DISTINCT input value once (`COUNT(DISTINCT x)`,
+  /// `SUM(DISTINCT x)`), `ALL` (the default, `distinct` `false`) folds every
+  /// value. It is a no-op for `MIN`/`MAX` — the least/greatest value is the
+  /// same with or without duplicates — but the standard admits it there, so it
+  /// is accepted and ignored. `COUNT(*)` admits no quantifier (the parser
+  /// diagnoses `COUNT(DISTINCT *)`).
+  ///
+  /// `filter`, when present, is the ISO `FILTER (WHERE <search condition>)` —
+  /// the aggregate folds only the rows of the group whose predicate is TRUE (a
+  /// FALSE or UNKNOWN row is skipped), applied as a per-row gate BEFORE the
+  /// value reaches the fold — and before the `DISTINCT` dedup, so the two
+  /// compose as "filter, then dedup". It gates even `COUNT(*)`, which counts
+  /// only the admitted rows.
+  case aggregate(Aggregate, of: Aggregand, distinct: Bool = false,
+                 filter: Predicate? = nil)
   /// A `CASE` conditional expression — the result of its FIRST `when` whose
   /// predicate is TRUE (three-valued: UNKNOWN and FALSE both skip), else the
   /// `else` result, or `NULL` when there is no `ELSE`. The `when`s are held in

--- a/Sources/SQLEngine/Aggregate.swift
+++ b/Sources/SQLEngine/Aggregate.swift
@@ -34,23 +34,43 @@ internal struct Aggregation {
   /// (which counts every row without reading a value).
   internal let argument: Term?
 
-  internal init(function: Aggregate, argument: Term?) {
+  /// Whether the aggregate folds each DISTINCT non-NULL value once (`COUNT`/
+  /// `SUM`/`AVG(DISTINCT x)`) rather than every value — the ISO `DISTINCT` set
+  /// quantifier. It has no effect on `MIN`/`MAX` (the extreme is the same with
+  /// duplicates), which honour it as a no-op.
+  internal let distinct: Bool
+
+  /// The lowered per-row gate of an aggregate's `FILTER (WHERE …)`, or `nil`
+  /// when none is written. A source record folds into the aggregate only when
+  /// this filter evaluates TRUE (a FALSE or UNKNOWN row is skipped), applied
+  /// BEFORE the `distinct` dedup.
+  internal let filter: Filter?
+
+  internal init(function: Aggregate, argument: Term?, distinct: Bool = false,
+                filter: Filter? = nil) {
     self.function = function
     self.argument = argument
+    self.distinct = distinct
+    self.filter = filter
   }
 }
 
 extension Aggregation {
-  /// This aggregation with its argument's slots remapped through `slot`.
+  /// This aggregation with its argument's and filter's slots remapped through
+  /// `slot`.
   internal func remapped(through slot: Dictionary<Int, Int>) -> Aggregation {
     Aggregation(function: function,
-                argument: argument.map { $0.remapped(through: slot) })
+                argument: argument.map { $0.remapped(through: slot) },
+                distinct: distinct,
+                filter: filter.map { $0.remapped(through: slot) })
   }
 
   /// The source slots this aggregation reads, accumulated into `slots` — its
-  /// argument's, or none for `COUNT(*)`.
+  /// argument's and its `FILTER` predicate's, or none for a `COUNT(*)` with no
+  /// filter.
   internal func references(into slots: inout Set<Int>) {
     argument?.references(into: &slots)
+    filter?.references(into: &slots)
   }
 }
 
@@ -70,6 +90,16 @@ extension Aggregation {
 /// empty or all-NULL group yields `COUNT` `0` and the others NULL.
 private struct Accumulator {
   private let function: Aggregate
+  // Whether to fold each DISTINCT non-NULL value once — the ISO `DISTINCT` set
+  // quantifier — tracking the values already folded in `seen`. `MIN`/`MAX`
+  // honour it as a no-op (an extreme is unchanged by duplicates), so the flag
+  // is normalised OFF for them in `init`: the dedup — and the `seen` set it
+  // grows — runs only for `COUNT`/`SUM`/`AVG`, where duplicate multiplicity
+  // matters. This keeps a `MIN`/`MAX(DISTINCT x)` an O(1) STREAMING fold rather
+  // than one whose memory grows with the group's distinct values for no
+  // semantic gain (its result is the same as `MIN`/`MAX(x)` either way).
+  private let distinct: Bool
+  private var seen = Set<Value>()
   private var count = 0
   // SUM/AVG numeric state, kept independent of row order: an exact WIDE integer
   // total (`Int128`, range-checked once at the end) for the all-integer case,
@@ -81,8 +111,12 @@ private struct Accumulator {
   private var widened = false
   private var extreme: Value? = nil
 
-  internal init(_ function: Aggregate) {
+  internal init(_ function: Aggregate, distinct: Bool = false) {
     self.function = function
+    // `DISTINCT` is a no-op for `MIN`/`MAX` (an extreme is unchanged by
+    // duplicates), so normalise it OFF for them: the fold never builds `seen`,
+    // staying O(1) streaming rather than O(distinct-values) memory.
+    self.distinct = distinct && function != .min && function != .max
   }
 
   /// Folds one source `value` into the running aggregate — for `COUNT(*)` the
@@ -98,6 +132,25 @@ private struct Accumulator {
     // Every aggregate but a row-count ignores NULL — a NULL argument does not
     // fold, so an all-NULL group aggregates as an empty one.
     if case .null = value { return }
+    // A double operand widens the SUM/AVG total to an approximate double, and
+    // the widen decision is order-independent: flag it from the CELL'S KIND
+    // before the DISTINCT dedup, so a double anywhere in the group widens even
+    // when it is a duplicate the dedup skips for summation. `1` and `1.0`
+    // canonicalise equal, so a group mixing them dedups to one value whose kind
+    // is whichever appeared first — but the double must still widen the sum
+    // regardless of that order, else an integer-first group faults on an
+    // integer total a double-first group widens to a finite double.
+    if case .double = value, function == .sum || function == .avg {
+      widened = true
+    }
+    // Under `DISTINCT` a value already folded does not fold again — deduped on
+    // its CANONICAL form (the same normalisation a `GROUP BY` key and the
+    // equality UNION use, so `1` and `1.0` count as one distinct value) — so a
+    // repeated value counts, sums, and averages once. `MIN`/`MAX` normalise
+    // `distinct` OFF (an extreme is unchanged by duplicates), so this never
+    // builds `seen` for them. `COUNT(*)`'s row sentinel never reaches here (a
+    // `COUNT(*)` carries no `distinct`), so every counted row still counts.
+    if distinct, !seen.insert(canonical(value)).inserted { return }
     count += 1
     switch function {
     case .count, .min, .max:
@@ -112,19 +165,18 @@ private struct Accumulator {
         }
       }
     case .sum, .avg:
-      // Total every value into a double running sum and flag whether any operand
-      // was a double, while keeping an exact wide (`Int128`) integer total for
-      // the all-integer case. Deferring the widen decision — and range-checking
-      // the wide total only at the end — keeps the result independent of row
-      // order: neither a later double nor a transient prefix overflow that a
-      // later value undoes can change the outcome.
+      // Total every value into a double running sum, while keeping an exact
+      // wide (`Int128`) integer total for the all-integer case; `widened` was
+      // already set above from the cell's kind. Deferring the widen decision —
+      // and range-checking the wide total only at the end — keeps the result
+      // independent of row order: neither a later double nor a transient prefix
+      // overflow that a later value undoes can change the outcome.
       switch value {
       case let .integer(number):
         total += Double(number)
         integer += Int128(number)
       case let .double(number):
         total += number
-        widened = true
       default:
         throw .operand("operands must be numeric")
       }
@@ -257,10 +309,21 @@ internal func grouped(_ records: Array<Record>, _ keys: Array<Term>,
     let identity = Record(cells.map(canonical))
 
     if accumulators[identity] == nil {
-      accumulators[identity] = aggregates.map { Accumulator($0.function) }
+      accumulators[identity] = aggregates.map {
+        Accumulator($0.function, distinct: $0.distinct)
+      }
       order.append(group)
     }
     for index in aggregates.indices {
+      // An aggregate's `FILTER (WHERE …)` gates the row: only a TRUE predicate
+      // admits it (a FALSE or UNKNOWN one, and an unbound `:parameter`, skips),
+      // applied before the fold — and so before the DISTINCT dedup. A
+      // filter-less aggregate folds every row.
+      if let filter = aggregates[index].filter {
+        guard try record.evaluate(filter, routines, bindings) == true else {
+          continue
+        }
+      }
       // `COUNT(*)` has no argument — count the row with a non-NULL sentinel;
       // every other aggregate folds its evaluated argument value.
       let value: Value = if let argument = aggregates[index].argument {
@@ -277,7 +340,9 @@ internal func grouped(_ records: Array<Record>, _ keys: Array<Term>,
   // `0` rather than yielding no row at all. A grouped query over no rows yields
   // no group (standard SQL).
   if keys.isEmpty && order.isEmpty {
-    let empty = aggregates.map { Accumulator($0.function) }
+    let empty = aggregates.map {
+      Accumulator($0.function, distinct: $0.distinct)
+    }
     var cells = Array<Value>()
     cells.reserveCapacity(empty.count)
     for accumulator in empty { try cells.append(accumulator.value) }

--- a/Sources/SQLEngine/Engine.swift
+++ b/Sources/SQLEngine/Engine.swift
@@ -927,14 +927,18 @@ extension Expression {
   }
 
   /// Lowers this AST `.aggregate` expression to an `Aggregation`, its argument
-  /// (if any) resolved to a combined base-ordinal term through `scope`.
+  /// (if any) and its `FILTER` predicate resolved to combined base-ordinal
+  /// forms through `scope`.
   ///
   /// `COUNT(*)` has no argument (it counts rows); every other aggregate lowers
-  /// its single operand expression to a term. `self` is always an `.aggregate`
-  /// — `collect` gathers only those.
+  /// its single operand expression to a term. The `DISTINCT` set quantifier
+  /// carries through as a flag; a `FILTER (WHERE …)` lowers to a source-space
+  /// `Filter` — the same combined base-ordinal space the argument resolves in,
+  /// so it reads the pre-aggregation row the fold gates on. `self` is always an
+  /// `.aggregate` — `collect` gathers only those.
   internal func aggregation(_ scope: Scope, _ routines: Routines = [:])
       throws(SQLError) -> Aggregation {
-    guard case let .aggregate(function, operand) = self else {
+    guard case let .aggregate(function, operand, distinct, filter) = self else {
       throw .unsupported("expected an aggregate")
     }
     let argument: Term? = switch operand {
@@ -943,7 +947,13 @@ extension Expression {
     case let .expression(expression):
       try scope.term(expression, routines)
     }
-    return Aggregation(function: function, argument: argument)
+    let gate: Filter? = if let filter {
+      try scope.lower(filter, routines)
+    } else {
+      nil
+    }
+    return Aggregation(function: function, argument: argument,
+                       distinct: distinct, filter: gate)
   }
 }
 

--- a/Sources/SQLEngine/Lexer.swift
+++ b/Sources/SQLEngine/Lexer.swift
@@ -414,6 +414,7 @@ internal struct Lexer: ~Escapable {
     case "ORDER": .order
     case "GROUP": .group
     case "HAVING": .having
+    case "FILTER": .filter
     case "BY": .by
     case "ASC": .asc
     case "DESC": .desc

--- a/Sources/SQLEngine/Parser.swift
+++ b/Sources/SQLEngine/Parser.swift
@@ -57,8 +57,10 @@
 ///                     [FOR expression] ')'
 /// literal        := string | integer | decimal | TRUE | FALSE | blob
 /// blob           := ('x' | 'X') "'" (hex hex)* "'"  // whole bytes
-/// aggregate      := COUNT '(' '*' ')'
-///                 | (COUNT | SUM | MIN | MAX | AVG) '(' expression ')'
+/// aggregate      := COUNT '(' '*' ')' [filter]
+///                 | (COUNT | SUM | MIN | MAX | AVG)
+///                     '(' [DISTINCT | ALL] expression ')' [filter]
+/// filter         := FILTER '(' WHERE predicate ')'
 /// order          := ORDER BY key (',' key)*
 /// key            := column [ASC | DESC]
 /// limit          := [OFFSET integer ROWS]
@@ -651,7 +653,10 @@ internal struct Parser: ~Escapable {
     // rather than evaluating per row. `COUNT(*)` takes `*` in place of an
     // expression; every aggregate else takes one expression operand.
     if !ident.quoted, let aggregate = aggregate(ident.text) {
-      return try .aggregate(aggregate, of: aggregand(aggregate))
+      let (operand, distinct) = try aggregand(aggregate)
+      let filter = try self.filter()
+      return .aggregate(aggregate, of: operand, distinct: distinct,
+                        filter: filter)
     }
 
     var arguments = Array<Expression>()
@@ -678,23 +683,50 @@ internal struct Parser: ~Escapable {
     }
   }
 
-  /// Parses an aggregate's operand (the `(` is already consumed) and the closing
-  /// `)`: `*` for `COUNT(*)` — admitted only for `COUNT` — else a single
-  /// expression. A non-`COUNT` aggregate over `*` (`SUM(*)`), or an aggregate
-  /// with no operand, faults.
+  /// Parses an aggregate's operand and its optional `<set quantifier>` (the `(`
+  /// is already consumed) and the closing `)`, returning the operand and
+  /// whether `DISTINCT` was written.
+  ///
+  /// `*` is the operand of `COUNT(*)`, admitted only for `COUNT` (a non-`COUNT`
+  /// aggregate over `*` (`SUM(*)`) faults) and takes no quantifier: a
+  /// `COUNT(DISTINCT *)` is diagnosed, as `*` is the whole row rather than a
+  /// value to fold distinctly. Every other aggregate takes one expression
+  /// operand, optionally preceded by `DISTINCT` (fold each distinct value once)
+  /// or `ALL` (the explicit default, fold every value); `distinct` is `true`
+  /// only for a written `DISTINCT`.
   private mutating func aggregand(_ aggregate: Aggregate)
-      throws(SQLError) -> Aggregand {
-    let operand: Aggregand
+      throws(SQLError) -> (operand: Aggregand, distinct: Bool) {
     if try match(.star) {
       guard aggregate == .count else {
         throw .unsupported("only COUNT admits a '*' operand")
       }
-      operand = .star
-    } else {
-      operand = try .expression(expression())
+      try expect(.rparen)
+      return (.star, false)
     }
+    // The optional set quantifier precedes the value expression: `DISTINCT`
+    // folds each distinct value once, `ALL` (the default) folds every value.
+    let distinct = try match(.distinct)
+    if !distinct { _ = try match(.all) }
+    let operand = try Aggregand.expression(expression())
     try expect(.rparen)
-    return operand
+    return (operand, distinct)
+  }
+
+  /// Parses an aggregate's optional `FILTER (WHERE <predicate>)` gate,
+  /// returning the predicate, or `nil` when no `FILTER` follows.
+  ///
+  /// The ISO `<filter clause>` names a search condition an aggregate folds only
+  /// the TRUE rows of (a FALSE or UNKNOWN row skipped), so it parses the same
+  /// predicate grammar a `WHERE` admits, parenthesised after the `WHERE`
+  /// keyword. It applies before the `DISTINCT` dedup (filter, then dedup) and
+  /// gates even `COUNT(*)`.
+  private mutating func filter() throws(SQLError) -> Predicate? {
+    guard try match(.filter) else { return nil }
+    try expect(.lparen)
+    try expect(.where)
+    let predicate = try predicate()
+    try expect(.rparen)
+    return predicate
   }
 
   /// Parses a `CASE` expression (the `CASE` is the next token) into the searched

--- a/Sources/SQLEngine/Resolve.swift
+++ b/Sources/SQLEngine/Resolve.swift
@@ -410,7 +410,7 @@ internal struct Scope {
       type(of: literal)
     case let .call(name, _):
       routines[name]?.returns ?? .integer
-    case let .aggregate(function, operand):
+    case let .aggregate(function, operand, _, _):
       switch function {
       // `COUNT` always counts rows to an integer; `AVG` folds to a double;
       // `SUM`/`MIN`/`MAX` take the operand's own type (an integer for `.star`).
@@ -542,7 +542,7 @@ internal struct Scope {
   /// `MIN` / `MAX` / `AVG` are NULL over an empty group and so do NOT stop.
   private func selects(_ argument: Expression, _ routines: Routines) -> Bool {
     return switch argument {
-    case .aggregate(.count, _): true
+    case .aggregate(.count, _, _, _): true
     default: constant(argument, routines).map { $0 != .null } ?? false
     }
   }
@@ -630,8 +630,8 @@ internal struct Scope {
       type(of: literal)
     case let .call(name, arguments):
       try call(name, over: arguments, routines)
-    case let .aggregate(function, operand):
-      try aggregate(function, over: operand, routines)
+    case let .aggregate(function, operand, _, filter):
+      try aggregate(function, over: operand, filter: filter, routines)
     case let .binary(op, lhs, rhs):
       try arithmetic(op, lhs, rhs, routines)
     case let .case(whens, otherwise):
@@ -840,8 +840,32 @@ internal struct Scope {
   /// advertising `AVG(Name)` as a double or `SUM(Name)` as text for a query
   /// that cannot fold its rows.
   private func aggregate(_ function: Aggregate, over operand: Aggregand,
-                         _ routines: Routines)
+                         filter: Predicate?, _ routines: Routines)
       throws(SQLError) -> ValueType {
+    // A `FILTER (WHERE …)` is a per-row gate, so it type-checks as an ordinary
+    // predicate — its columns resolve and its comparisons are well-typed — and
+    // it may not itself contain an aggregate (ISO forbids an aggregate in a
+    // filter's search condition, as it has no per-row meaning).
+    if let filter {
+      guard !filter.aggregated else {
+        throw .unsupported("an aggregate is not allowed in a FILTER")
+      }
+      try check(filter, routines)
+      // A FILTER that STATICALLY cannot admit a row makes the operand
+      // unreachable: the executor gates on a definite TRUE (a FALSE or UNKNOWN
+      // row is skipped, and the argument is evaluated only AFTER the gate), so
+      // an operand behind a statically non-TRUE filter never folds. `SUM(1 / 0)
+      // FILTER (WHERE 1 = 0)` thus runs to the empty result (NULL) — do NOT
+      // validate the dead operand, or a fault it could never raise (a divide by
+      // zero) would wrongly reject a runnable query. The aggregate is
+      // statically empty, so advertise its declared/derived result type without
+      // the operand's run-time-fault check (`dead(_:_:)` proves the filter
+      // ROW-INDEPENDENTLY never TRUE); a filter that could be TRUE still
+      // validates the operand as a bare aggregate does.
+      if dead(filter, routines) {
+        return try empty(function, over: operand, routines)
+      }
+    }
     switch function {
     case .count:
       // `COUNT(expr)` evaluates `expr` per row to test it is non-NULL, so
@@ -865,6 +889,60 @@ internal struct Scope {
       }
       if !type.numeric { throw .operand("operands must be numeric") }
       return function == .avg ? .double : type
+    }
+  }
+
+  /// The result type of `function` folded over `operand` when a statically
+  /// non-TRUE `FILTER` makes the fold empty — the operand is UNREACHABLE, so it
+  /// is DERIVED for its type (resolving a column) but NOT validated for a
+  /// run-time fault it can never raise (a divide by zero, a non-numeric SUM).
+  /// The empty fold yields `COUNT` `0` and every other aggregate NULL, so the
+  /// type is the set-function's declared/derived one, mirroring `aggregate` but
+  /// non-faulting on the dead operand: `COUNT`/`AVG` fixed, `SUM`/`MIN`/`MAX`
+  /// the operand's own derived type (`.integer` for `.star`).
+  private func empty(_ function: Aggregate, over operand: Aggregand,
+                     _ routines: Routines) throws(SQLError) -> ValueType {
+    switch function {
+    case .count:
+      return .integer
+    case .avg:
+      return .double
+    case .sum, .min, .max:
+      switch operand {
+      case .star: return .integer
+      case let .expression(argument): return try derive(argument, routines)
+      }
+    }
+  }
+
+  /// Whether `filter` is ROW-INDEPENDENTLY never TRUE — so a `FILTER`'s gate
+  /// (which admits a row only on a definite TRUE) can never admit one and the
+  /// aggregate operand behind it is UNREACHABLE. An `AND` is TRUE only when
+  /// EVERY conjunct is TRUE, so a single conjunct that is row-independently
+  /// non-TRUE kills the whole conjunction regardless of the others: flatten the
+  /// top-level `Predicate.and` spine (`a AND (b AND c)` to `a, b, c` — each
+  /// non-AND node one conjunct, not descending into `OR`) and prove it dead
+  /// when ANY conjunct folds definitely FALSE (`constant(_:)` `false`), or is
+  /// `settled` (row-independent) and folds to UNKNOWN (`constant(_:)` `nil`).
+  /// This subsumes the whole-filter case (a settled-non-TRUE filter is a lone
+  /// conjunct). It stays SOUND — only a PROVABLY non-TRUE conjunct kills the
+  /// filter: a row-dependent conjunct (could be TRUE per row) or a settled-TRUE
+  /// one does NOT, so those still validate the operand.
+  private func dead(_ filter: Predicate, _ routines: Routines) -> Bool {
+    var conjuncts: Array<Predicate> = [filter]
+    var index = 0
+    while index < conjuncts.count {
+      if case let .and(lhs, rhs) = conjuncts[index] {
+        conjuncts[index] = lhs
+        conjuncts.append(rhs)
+      } else {
+        index += 1
+      }
+    }
+    return conjuncts.contains { conjunct in
+      let folded = constant(conjunct, routines)
+      return folded == false
+          || (folded == nil && settled(conjunct, routines))
     }
   }
 
@@ -1476,8 +1554,8 @@ internal struct Scope {
     switch expression {
     case .column, .literal:
       break
-    case let .aggregate(function, operand):
-      _ = try aggregate(function, over: operand, routines)
+    case let .aggregate(function, operand, _, filter):
+      _ = try aggregate(function, over: operand, filter: filter, routines)
     case let .call(_, arguments):
       for argument in arguments { try aggregates(in: argument, routines) }
     case let .binary(_, lhs, rhs):
@@ -1565,7 +1643,7 @@ internal struct Scope {
     switch expression {
     case let .literal(literal):
       return try value(of: literal)
-    case let .aggregate(function, _):
+    case let .aggregate(function, _, _, _):
       return function == .count ? .integer(0) : .null
     case let .binary(op, lhs, rhs):
       return try op.apply(empty(lhs, routines), empty(rhs, routines))

--- a/Sources/SQLEngine/Token.swift
+++ b/Sources/SQLEngine/Token.swift
@@ -28,6 +28,9 @@ extension Token {
     case order
     case group
     case having
+    /// The `FILTER` keyword introducing an aggregate's `FILTER (WHERE …)`
+    /// per-row gate.
+    case filter
     case by
     case asc
     case desc
@@ -124,6 +127,7 @@ extension Token.Kind {
     case .order: "ORDER"
     case .group: "GROUP"
     case .having: "HAVING"
+    case .filter: "FILTER"
     case .by: "BY"
     case .asc: "ASC"
     case .desc: "DESC"

--- a/Tests/SQLTests/AggregateDistinctFilterTests.swift
+++ b/Tests/SQLTests/AggregateDistinctFilterTests.swift
@@ -1,0 +1,330 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+import SQLEngine
+import SQLTestSupport
+
+// MARK: - Fixtures
+
+/// An `Orders` relation of `Region`/`Amount` rows with deliberate duplicate
+/// amounts and a NULL. The two regions and the repeated `Amount` values let a
+/// `DISTINCT` set quantifier differ from an `ALL` one, and a `FILTER (WHERE …)`
+/// gate a subset of the rows per group.
+///
+/// East amounts: 10, 10, 20 (one NULL) — three non-NULL rows, two distinct
+/// values (10, 20). West amounts: 20, 20, 30 — three rows, two distinct values
+/// (20, 30). Across both: 10, 10, 20, 20, 20, 30 (and one NULL) — six non-NULL
+/// rows, three distinct values (10, 20, 30).
+private func orders() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("Orders", ["Region": .text, "Amount": .integer]) {
+      Row("East", 10)
+      Row("East", 10)
+      Row("East", 20)
+      Row("East", nil)
+      Row("West", 20)
+      Row("West", 20)
+      Row("West", 30)
+    }
+  }
+}
+
+// MARK: - DISTINCT set quantifier
+
+struct AggregateDistinctTests {
+  @Test func `COUNT(DISTINCT x) counts each value once where COUNT(x) counts every row`() throws {
+    // Six non-NULL amounts (10, 10, 20, 20, 20, 30), three distinct (10, 20,
+    // 30): COUNT(Amount) is 6, COUNT(DISTINCT Amount) is 3.
+    try orders().expect(
+        "SELECT COUNT(Amount), COUNT(DISTINCT Amount) FROM Orders",
+        yields: [[6, 3]])
+  }
+
+  @Test func `SUM(DISTINCT x) totals each distinct value once`() throws {
+    // SUM(Amount) totals every non-NULL row: 10+10+20+20+20+30 = 110.
+    // SUM(DISTINCT Amount) totals the distinct values once: 10+20+30 = 60.
+    try orders().expect(
+        "SELECT SUM(Amount), SUM(DISTINCT Amount) FROM Orders",
+        yields: [[110, 60]])
+  }
+
+  @Test func `AVG(DISTINCT x) averages the distinct values`() throws {
+    // AVG(DISTINCT Amount) is the distinct total 60 over the 3 distinct values
+    // = 20.0 — real division to an approximate-numeric double.
+    try orders().expect("SELECT AVG(DISTINCT Amount) FROM Orders",
+                        yields: [[20.0]])
+  }
+
+  @Test func `DISTINCT is a no-op for MIN and MAX`() throws {
+    // The least/greatest value is unchanged by duplicates, so a MIN/MAX honours
+    // DISTINCT as a no-op — MIN 10, MAX 30 either way. The DISTINCT form
+    // normalises the quantifier OFF, so it never builds the `seen` dedup set
+    // (an O(1) streaming fold, not O(distinct-values) memory), yet must still
+    // agree cell for cell with the plain form.
+    try orders().expect("""
+        SELECT MIN(DISTINCT Amount), MAX(DISTINCT Amount),
+               MIN(Amount), MAX(Amount)
+          FROM Orders
+        """, yields: [[10, 30, 10, 30]])
+  }
+
+  @Test func `MIN and MAX DISTINCT agree with the plain form over duplicates`() throws {
+    // A group whose extreme values (10 and 30) are DUPLICATED many times: the
+    // MIN/MAX(DISTINCT) fold does not dedup (it keeps no `seen` set), so its
+    // memory does not grow with the group, and its result matches the plain
+    // MIN/MAX — the extreme is the same with or without duplicates. Grouped so
+    // the fold runs per group, exercising the streaming path each time.
+    try orders().expect("""
+        SELECT Region, MIN(DISTINCT Amount), MAX(DISTINCT Amount),
+               MIN(Amount), MAX(Amount)
+          FROM Orders
+          GROUP BY Region ORDER BY Region
+        """, yields: [["East", 10, 20, 10, 20], ["West", 20, 30, 20, 30]])
+  }
+
+  @Test func `an explicit ALL quantifier folds every value`() throws {
+    // `ALL` is the explicit default — COUNT(ALL Amount) equals COUNT(Amount).
+    try orders().expect(
+        "SELECT COUNT(ALL Amount), SUM(ALL Amount) FROM Orders",
+        yields: [[6, 110]])
+  }
+
+  @Test func `DISTINCT dedups per group under GROUP BY`() throws {
+    // East distinct amounts are 10, 20 (two); West distinct are 20, 30 (two).
+    // The dedup is per group, so each region counts its own distinct values.
+    try orders().expect("""
+        SELECT Region, COUNT(DISTINCT Amount) FROM Orders
+          GROUP BY Region ORDER BY Region
+        """, yields: [["East", 2], ["West", 2]])
+  }
+
+  @Test func `COUNT(DISTINCT *) is rejected`() throws {
+    // A set quantifier applies to a value, so `*` — the whole row — admits none;
+    // the parser diagnoses `COUNT(DISTINCT *)`.
+    #expect(throws: SQLError.self) {
+      try orders().run(Statement(parsing:
+          "SELECT COUNT(DISTINCT *) FROM Orders"))
+    }
+  }
+}
+
+/// A pair of one-column relations whose values CANONICALISE across the two
+/// kinds: `Ints` holds the exact integers `Int.max` and `1`, `Reals` the double
+/// `1.0` (equal to the integer `1` under `canonical`). Two views `UNION ALL`
+/// them into a single `V` column mixing integer and double cells — `IntFirst`
+/// with the integers before the double, `RealFirst` the reverse — so a
+/// `SUM(DISTINCT …)` over either dedups `1` and `1.0` to one value while the
+/// distinct integer total (`Int.max + 1`) overflows `Int`. An int-first order
+/// must still WIDEN to the finite double a double-first order gives, the
+/// order-independence a skipped double duplicate must not defeat.
+private func mixed() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("Ints", ["N": .integer]) {
+      Row(Int.max)
+      Row(1)
+    }
+    Relation("Reals", ["R": .double]) {
+      Row(1.0)
+    }
+    try View("IntFirst",
+             "SELECT N AS V FROM Ints UNION ALL SELECT R AS V FROM Reals",
+             as: ["V"])
+    try View("RealFirst",
+             "SELECT R AS V FROM Reals UNION ALL SELECT N AS V FROM Ints",
+             as: ["V"])
+  }
+}
+
+// MARK: - DISTINCT numeric widening is order-independent
+
+struct AggregateDistinctWideningTests {
+  // The finite double both orders must yield: the distinct set is `{Int.max,
+  // 1}` (the double `1.0` dedups with the integer `1`), whose integer total
+  // `Int.max + 1` overflows `Int` but widens to this double.
+  private let widened = Double(Int.max) + 1.0
+
+  @Test func `SUM(DISTINCT) widens regardless of row order`() throws {
+    // Int-first: 1 folds (integer), Int.max folds, then 1.0 is a DISTINCT
+    // duplicate skipped for the sum — but it must still set the widen flag,
+    // else the all-integer total Int.max + 1 overflows. Double-first: 1.0 folds
+    // and widens, Int.max folds, then 1 is the skipped duplicate. Both must
+    // yield the SAME finite double.
+    try mixed().expect("SELECT SUM(DISTINCT V) FROM IntFirst",
+                       yields: [[widened]])
+    try mixed().expect("SELECT SUM(DISTINCT V) FROM RealFirst",
+                       yields: [[widened]])
+  }
+
+  @Test func `AVG(DISTINCT) widens regardless of row order`() throws {
+    // AVG divides the widened total by the two distinct values, the same value
+    // for either order — the int-first skipped double must widen it too.
+    let average = widened / 2.0
+    try mixed().expect("SELECT AVG(DISTINCT V) FROM IntFirst",
+                       yields: [[average]])
+    try mixed().expect("SELECT AVG(DISTINCT V) FROM RealFirst",
+                       yields: [[average]])
+  }
+}
+
+// MARK: - FILTER
+
+struct AggregateFilterTests {
+  @Test func `FILTER gates the rows an aggregate folds`() throws {
+    // COUNT(*) counts all seven rows; the filtered COUNT(*) counts only the
+    // four East rows (its WHERE is TRUE for them).
+    try orders().expect("""
+        SELECT COUNT(*), COUNT(*) FILTER (WHERE Region = 'East') FROM Orders
+        """, yields: [[7, 4]])
+  }
+
+  @Test func `FILTER gates a value aggregate before the fold`() throws {
+    // SUM(Amount) over the West rows only: 20+20+30 = 70 (the East rows and the
+    // NULL are gated out).
+    try orders().expect("""
+        SELECT SUM(Amount) FILTER (WHERE Region = 'West') FROM Orders
+        """, yields: [[70]])
+  }
+
+  @Test func `FILTER composes with DISTINCT — filter first, then dedup`() throws {
+    // Gate to the West rows (amounts 20, 20, 30), then dedup: two distinct
+    // values (20, 30), summing to 50.
+    try orders().expect("""
+        SELECT COUNT(DISTINCT Amount) FILTER (WHERE Region = 'West'),
+               SUM(DISTINCT Amount) FILTER (WHERE Region = 'West')
+          FROM Orders
+        """, yields: [[2, 50]])
+  }
+
+  @Test func `FILTER composes with GROUP BY per group`() throws {
+    // Per region, count only the rows whose amount is at least 20. East has one
+    // such row (20); West has all three (20, 20, 30).
+    try orders().expect("""
+        SELECT Region, COUNT(*) FILTER (WHERE Amount >= 20) FROM Orders
+          GROUP BY Region ORDER BY Region
+        """, yields: [["East", 1], ["West", 3]])
+  }
+
+  @Test func `a FILTER whose predicate no row satisfies folds an empty group`() throws {
+    // No row matches, so the filtered COUNT is 0 and the filtered SUM is NULL —
+    // the empty-group result, alongside the unfiltered counts.
+    try orders().expect("""
+        SELECT COUNT(*) FILTER (WHERE Region = 'North'),
+               SUM(Amount) FILTER (WHERE Region = 'North')
+          FROM Orders
+        """, yields: [[0, nil]])
+  }
+
+  @Test func `an aggregate in a FILTER predicate is rejected`() throws {
+    // A FILTER's search condition is a per-row gate, so it may not contain an
+    // aggregate (which has no per-row meaning).
+    #expect(throws: SQLError.self) {
+      try orders().run(Statement(parsing: """
+          SELECT COUNT(*) FILTER (WHERE COUNT(*) > 1) FROM Orders
+          """))
+    }
+  }
+}
+
+// MARK: - a statically-empty FILTER leaves the operand unreachable
+
+struct AggregateFilterUnreachableOperandTests {
+  @Test func `a constant-false FILTER makes the operand unreachable`() throws {
+    // The executor evaluates the FILTER before the argument, so a definitely-
+    // false gate means `1 / 0` never divides: the query validates (no fault on
+    // the dead operand) and RUNS to the empty aggregate result (NULL).
+    let sql = "SELECT SUM(1 / 0) FILTER (WHERE 1 = 0) FROM Orders"
+    _ = try orders().columns(of: Statement(parsing: sql))
+    try orders().expect(sql, yields: [[nil]])
+  }
+
+  @Test func `a bare divide-by-zero operand still faults`() throws {
+    // With no FILTER the operand IS reachable, so a static divide by zero is
+    // rejected exactly as before — the skip is gated on a statically non-TRUE
+    // filter, not a blanket amnesty for the operand.
+    try orders().expect("SELECT SUM(1 / 0) FROM Orders", fails: .divide)
+  }
+
+  @Test func `a constant-true FILTER still validates the operand`() throws {
+    // A definitely-TRUE gate admits every row, so the operand IS reachable and
+    // its static fault stands — a constant-true filter must not skip it.
+    try orders().expect("SELECT SUM(1 / 0) FILTER (WHERE 1 = 1) FROM Orders",
+                        fails: .divide)
+  }
+
+  @Test func `a non-constant FILTER still validates the operand`() throws {
+    // A row-dependent gate cannot prove the operand unreachable, so the operand
+    // is validated as a bare aggregate is — a well-typed operand type-checks.
+    try orders().expect("""
+        SELECT SUM(Amount) FILTER (WHERE Region = 'West') FROM Orders
+        """, yields: [[70]])
+  }
+
+  // A FILTER that folds definitely UNKNOWN — a constant NULL comparison, here
+  // `NULLIF(1, 1) = 1` whose left side folds to NULL — is treated the SAME as a
+  // constant-false one: the executor's gate admits a row only on a definite
+  // TRUE, so an UNKNOWN gate also admits no row and leaves the operand
+  // unreachable. Validation matches that, so `SUM(1 / 0)` behind it validates
+  // and runs to NULL rather than faulting on the dead operand.
+  @Test func `a constant-UNKNOWN FILTER makes the operand unreachable`() throws {
+    let sql = """
+        SELECT SUM(1 / 0) FILTER (WHERE NULLIF(1, 1) = 1) FROM Orders
+        """
+    _ = try orders().columns(of: Statement(parsing: sql))
+    try orders().expect(sql, yields: [[nil]])
+  }
+
+  // A settled-non-TRUE CONJUNCT kills the whole conjunction: an AND is TRUE
+  // only if EVERY conjunct is, so a row-independently non-TRUE conjunct means
+  // no row can pass the gate even when a SIBLING conjunct is per row. Here
+  // `NULLIF(1, 1) = 1` folds definitely UNKNOWN (NULLIF(1,1) is NULL, NULL = 1
+  // is UNKNOWN) while `Amount > 0` is per row — the filter is still dead, so
+  // `SUM(1 / 0)` behind it validates and runs to NULL rather than faulting.
+  @Test func `a settled-UNKNOWN conjunct makes a row-dependent FILTER dead`() throws {
+    let sql = """
+        SELECT SUM(1 / 0)
+                 FILTER (WHERE NULLIF(1, 1) = 1 AND Amount > 0)
+          FROM Orders
+        """
+    _ = try orders().columns(of: Statement(parsing: sql))
+    try orders().expect(sql, yields: [[nil]])
+  }
+
+  // A settled-FALSE conjunct is likewise dead alongside a row-dependent one.
+  @Test func `a settled-FALSE conjunct makes a row-dependent FILTER dead`() throws {
+    let sql = """
+        SELECT SUM(1 / 0) FILTER (WHERE 1 = 0 AND Amount > 0) FROM Orders
+        """
+    _ = try orders().columns(of: Statement(parsing: sql))
+    try orders().expect(sql, yields: [[nil]])
+  }
+
+  // The proof is order-independent — the AND spine is flattened, so a
+  // settled-non-TRUE conjunct SECOND kills the filter as one first does.
+  @Test func `a settled-FALSE conjunct kills the FILTER in either order`() throws {
+    let sql = """
+        SELECT SUM(1 / 0) FILTER (WHERE Amount > 0 AND 1 = 0) FROM Orders
+        """
+    _ = try orders().columns(of: Statement(parsing: sql))
+    try orders().expect(sql, yields: [[nil]])
+  }
+
+  // Soundness: a purely row-dependent conjunction could be TRUE per row, so
+  // the operand IS reachable and its static fault stands — the dead-filter
+  // skip must not fire without a proof of non-TRUE.
+  @Test func `a row-dependent conjunction still validates the operand`() throws {
+    try orders().expect("""
+        SELECT SUM(1 / 0) FILTER (WHERE Amount > 0 AND Region = 'West')
+          FROM Orders
+        """, fails: .divide)
+  }
+
+  // Soundness: a settled-TRUE conjunct does NOT kill the filter — the sibling
+  // `Amount > 0` can still make the conjunction TRUE per row, so the operand is
+  // reachable and its divide by zero is rejected as before.
+  @Test func `a settled-TRUE conjunct does not make the FILTER dead`() throws {
+    try orders().expect("""
+        SELECT SUM(1 / 0) FILTER (WHERE 1 = 1 AND Amount > 0) FROM Orders
+        """, fails: .divide)
+  }
+}


### PR DESCRIPTION
An ISO `<aggregate function>` admits an optional `<set quantifier>` (`[DISTINCT | ALL] <expr>`) and a trailing `FILTER (WHERE <search condition>)`; the dialect previously accepted neither.

`DISTINCT` folds each distinct non-NULL value once, so `COUNT(DISTINCT x)`, `SUM(DISTINCT x)`, and `AVG(DISTINCT x)` differ from their `ALL` forms on duplicated input; the dedup keys on the canonical value form (the normalisation `GROUP BY` and the equality UNION share, so `1` and `1.0` are one distinct value). `ALL` is the explicit default, and the quantifier is a no-op for `MIN`/`MAX` — accepted per the standard, since an extreme is unchanged by duplicates. `COUNT(*)` admits no quantifier; `COUNT(DISTINCT *)` is diagnosed.

`FILTER (WHERE …)` gates the rows an aggregate folds: only a row whose predicate is TRUE reaches the fold (a FALSE or UNKNOWN one is skipped), applied per row before the value feeds the aggregate — and before the `DISTINCT` dedup, so the two compose as "filter, then dedup". It gates even `COUNT(*)`, which then counts only the admitted rows. A filter's search condition is an ordinary per-row predicate and may not itself contain an aggregate.

The `Expression.aggregate` node carries the `distinct` flag and the optional `filter` predicate; the `Aggregation` lowering resolves the filter to a source-space `Filter` beside the argument, and the group accumulator applies the gate and the dedup during the fold. A new `FILTER` keyword token and the grammar's `aggregate`/`filter` productions are added, and the EBNF doc-comment updated to match.