### PR TITLE
SQLEngine: accept EXISTS and IN (subquery) predicates

### DIFF
--- a/Sources/SQLEngine/AST.swift
+++ b/Sources/SQLEngine/AST.swift
@@ -237,6 +237,72 @@ public struct Select: Hashable, Sendable {
     from?.name ?? ""
   }
 
+  /// Whether the EXISTS cardinality `probe` preserves this select's existence —
+  /// so an EXISTS-only occurrence may run the probe rather than a full run.
+  ///
+  /// It holds for a non-set-operation `SELECT` WITHOUT a `HAVING` that is
+  /// EITHER non-`DISTINCT` (its cardinality is the source's, independent of the
+  /// projected values) OR `DISTINCT` WITHOUT an `OFFSET`. `DISTINCT` collapses
+  /// a non-empty source to at least one distinct row, so `SELECT DISTINCT 1
+  /// FROM S` is non-empty iff `S` is — existence is preserved by the constant
+  /// projection. An `OFFSET` breaks that: it skips DISTINCT rows, so emptiness
+  /// depends on the REAL distinct count (`SELECT DISTINCT x FROM S OFFSET 5` is
+  /// empty iff there are `≤ 5` distinct `x`), which the constant projection —
+  /// one distinct row — would wrongly collapse; such a select is not
+  /// probe-eligible.
+  ///
+  /// An aggregate/grouped select without a `HAVING` is probe-eligible: its
+  /// cardinality is a source-only fact the probe preserves WITHOUT the original
+  /// target (see `probe`). A whole-result aggregate (no `GROUP BY`) yields
+  /// EXACTLY ONE row regardless of the source — so EXISTS is true modulo the
+  /// limit — and a grouped one yields ONE ROW PER GROUP, so existence is the
+  /// source's non-emptiness after `WHERE`. A `HAVING` is NOT eligible: group
+  /// survival depends on the aggregate VALUES (which `HAVING` may reference),
+  /// so cardinality is not a source-only fact and the target must run.
+  internal var probable: Bool {
+    guard having == nil else { return false }
+    return !distinct || limit?.offset ?? 0 == 0
+  }
+
+  /// The EXISTS cardinality-probe rewrite of this select — the same
+  /// FROM/`WHERE`/joins, the same `DISTINCT` quantifier, the same `GROUP BY`,
+  /// and the SAME original `OFFSET`/`FETCH`, but its projection replaced with a
+  /// cardinality-preserving target and its `ORDER BY` dropped — so a probe run
+  /// tests whether the row source yields ANY row WITHOUT evaluating the
+  /// original select list or sort keys.
+  ///
+  /// It preserves the row source (FROM, joins, `WHERE`) and the original row
+  /// limit EXACTLY, so its cardinality matches this select's — enough for an
+  /// existence test that honours the original limiting: a `FETCH FIRST 0 ROWS`
+  /// probes zero rows (EXISTS false) and an `OFFSET` past the end probes none
+  /// (false), neither overridden by a synthetic cap. `ORDER BY` is dropped
+  /// because existence is order-independent (the row count after `OFFSET`/
+  /// `FETCH` does not depend on order). A FROM-less `SELECT <exprs>` always
+  /// yields exactly one row and cannot carry a limit, so its probe is just
+  /// `SELECT <constant>` with NO limit — it compiles and yields one row
+  /// (EXISTS true). `DISTINCT` is retained (the caller applies the probe to a
+  /// `DISTINCT` select only when it has no `OFFSET`, so `SELECT DISTINCT 1 FROM
+  /// S` yields exactly one distinct row iff `S` is non-empty).
+  ///
+  /// The probe target is chosen to preserve cardinality without the original:
+  /// a NON-aggregate select projects the constant `1`, one row per source row;
+  /// an aggregate/grouped one projects `COUNT(*)` (with the `GROUP BY` kept), a
+  /// trivial always-computable aggregate whose grouping is the original's — a
+  /// whole-result `COUNT(*)` yields exactly one row (even over an empty source)
+  /// and a grouped one yields one row per group — so the probe's cardinality is
+  /// the original's and the original target (e.g. `SUM(1 / 0)`) never runs. It
+  /// is meaningful only where `probable` holds; the caller applies it only
+  /// there.
+  internal var probe: Select {
+    let target: Expression = aggregates
+        ? .aggregate(.count, of: .star)
+        : .literal(.integer(1))
+    let item = Projected(expression: target)
+    return Select(distinct: distinct, projection: .expressions([item]),
+                  from: from, joins: joins, predicate: predicate,
+                  grouping: grouping, having: nil, order: nil, limit: limit)
+  }
+
   /// Every expression the ORDER BY sort EVALUATES over its input rows — the
   /// direct sort-key expressions AND the projection expressions its OUTPUT
   /// shorthands reach — the ones a reachable type-check pass must validate as
@@ -760,6 +826,28 @@ public indirect enum Predicate: Hashable, Sendable {
   /// DISTINCT — the two differ — matching the engine's cross-kind FALSE
   /// equality. Unlike `=`, a NULL operand never makes the row UNKNOWN.
   case distinct(Expression, Expression, negated: Bool)
+  /// `[NOT] EXISTS (Q)` — whether the subquery `Q` yields at least one row,
+  /// `negated` marking `NOT EXISTS`. It is DEFINITELY two-valued — never
+  /// UNKNOWN — even when `Q` produces NULL-valued rows: the presence of a row
+  /// is TRUE regardless of its values, so `EXISTS` tests cardinality alone. In
+  /// this first slice `Q` is UNCORRELATED — it names no column of the enclosing
+  /// query — so the engine materialises it ONCE (as a common table expression's
+  /// body is materialised) and the whole predicate is the definite non-empty
+  /// test of that result; `negated` flips it. `Predicate` is `indirect`, so it
+  /// nests the whole `Query` without boxing.
+  case exists(Query, negated: Bool)
+  /// `x [NOT] IN (Q)` — whether the operand `x` equals any value the subquery
+  /// `Q` yields, `negated` marking `NOT IN`. `Q` must project exactly ONE
+  /// column (else `SQLError.arity`); the predicate is the three-valued
+  /// membership of `x` in that column, exactly as the value-list `membership`
+  /// is — a NULL `x` or a NULL element makes an otherwise-unmatched test
+  /// UNKNOWN rather than FALSE, and `NOT IN` its negation (never TRUE when a
+  /// NULL element is present), while an EMPTY result is FALSE (TRUE negated).
+  /// In this first slice `Q` is UNCORRELATED (it names no enclosing column), so
+  /// the engine materialises it ONCE and folds `x = v` over the materialised
+  /// column under Kleene `OR`, the SAME three-valued core the value-list `IN`
+  /// uses.
+  case within(Expression, Query, negated: Bool)
   /// `p IS [NOT] <truth value>` — the ISO `<boolean test>`, whether the inner
   /// boolean `Predicate` `p`'s THREE-VALUED result equals the `value`
   /// (`TRUE`/`FALSE`/`UNKNOWN`), or does not when `negated`. Unlike the other

--- a/Sources/SQLEngine/Aggregate.swift
+++ b/Sources/SQLEngine/Aggregate.swift
@@ -301,7 +301,8 @@ private func comparable(_ a: Value, _ b: Value) -> Bool {
 /// today, so it cannot yet reach one.
 internal func grouped(_ records: Array<Record>, _ keys: Array<Term>,
                       _ aggregates: Array<Aggregation>, _ routines: Routines,
-                      _ bindings: Bindings) throws(SQLError) -> Array<Record> {
+                      _ bindings: Bindings, _ subqueries: Subqueries)
+    throws(SQLError) -> Array<Record> {
   var order = Array<Record>()
   var accumulators = Dictionary<Record, Array<Accumulator>>()
 
@@ -309,7 +310,7 @@ internal func grouped(_ records: Array<Record>, _ keys: Array<Term>,
     var cells = Array<Value>()
     cells.reserveCapacity(keys.count)
     for key in keys {
-      try cells.append(record.evaluate(key, routines, bindings))
+      try cells.append(record.evaluate(key, routines, bindings, subqueries))
     }
     let group = Record(cells)
     // Key the group on the EXACT canonical form of its cells so `1` and `1.0`
@@ -329,14 +330,15 @@ internal func grouped(_ records: Array<Record>, _ keys: Array<Term>,
       // applied before the fold — and so before the DISTINCT dedup. A
       // filter-less aggregate folds every row.
       if let filter = aggregates[index].filter {
-        guard try record.evaluate(filter, routines, bindings) == true else {
+        guard try record.evaluate(filter, routines, bindings,
+                                  subqueries) == true else {
           continue
         }
       }
       // `COUNT(*)` has no argument — count the row with a non-NULL sentinel;
       // every other aggregate folds its evaluated argument value.
       let value: Value = if let argument = aggregates[index].argument {
-        try record.evaluate(argument, routines, bindings)
+        try record.evaluate(argument, routines, bindings, subqueries)
       } else {
         .integer(0)
       }

--- a/Sources/SQLEngine/Context.swift
+++ b/Sources/SQLEngine/Context.swift
@@ -34,22 +34,32 @@ internal struct Context {
   /// The query parameter bindings.
   internal let bindings: Bindings
 
+  /// The RUN-time results of the UNCORRELATED subqueries the executing plan
+  /// nests — each `EXISTS`/`IN (Q)` subquery run ONCE and memoised by its
+  /// `Query`, read by the row evaluator. Empty during compilation and every
+  /// schema-only path (which never opens a cursor); the `run` path populates it
+  /// (see `Catalog.subqueries(of:)`) just before executing the plan.
+  internal let subqueries: Subqueries
+
   /// A context over the three maps — an empty overlay and no bindings by
   /// default, the shape a bare query with no `WITH` and no parameters runs
-  /// under.
+  /// under. It carries no subquery results until `run` resolves them.
   internal init(relations: ScopedRelations = [:], routines: Routines = [:],
-                bindings: Bindings = [:]) {
+                bindings: Bindings = [:],
+                subqueries: Subqueries = Subqueries()) {
     self.relations = relations
     self.routines = routines
     self.bindings = bindings
+    self.subqueries = subqueries
   }
 
   /// A copy of this context with `relations` REPLACING the overlay, the same
-  /// routines and bindings — the scope a phase reads after `augment` extends
-  /// the overlay with the store relations a query names, or a recursive step
-  /// rebinds a CTE's self.
+  /// routines, bindings, and subquery results — the scope a phase reads after
+  /// `augment` extends the overlay with the store relations a query names, or a
+  /// recursive step rebinds a CTE's self.
   internal func scoping(_ relations: ScopedRelations) -> Context {
-    Context(relations: relations, routines: routines, bindings: bindings)
+    Context(relations: relations, routines: routines, bindings: bindings,
+            subqueries: subqueries)
   }
 
   /// A copy of this context whose overlay binds `materialised` to `name` (folded
@@ -60,5 +70,14 @@ internal struct Context {
     var relations = relations
     relations[name.lowercased()] = materialised
     return scoping(relations)
+  }
+
+  /// A copy of this context carrying `subqueries` as the executing plan's
+  /// materialised subquery results — the run path's extension just before it
+  /// executes a compiled plan, so the row evaluator reads each subquery result
+  /// off the SAME context that threads everywhere `execute` descends.
+  internal func resolving(_ subqueries: Subqueries) -> Context {
+    Context(relations: relations, routines: routines, bindings: bindings,
+            subqueries: subqueries)
   }
 }

--- a/Sources/SQLEngine/Definition.swift
+++ b/Sources/SQLEngine/Definition.swift
@@ -350,6 +350,11 @@ extension Query {
   /// Collects every relation name this query names in a `FROM`/`JOIN`, across
   /// the set-operation tree and each arm, into `names` — the reserved store
   /// names among them are what `Catalog.augment` builds.
+  ///
+  /// It descends into every nested `EXISTS`/`IN (Q)` subquery (recursing the
+  /// same `subqueries` walk `compile`/`run` use), so a reserved store relation
+  /// mentioned ONLY inside a subquery still reaches `augment` — the overlay is
+  /// materialised before the subquery's width compile and its run resolve it.
   func collect(into names: inout Set<String>) {
     switch self {
     case let .select(select):
@@ -358,6 +363,7 @@ extension Query {
       left.collect(into: &names)
       right.collect(into: &names)
     }
+    for subquery in subqueries { subquery.collect(into: &names) }
   }
 }
 

--- a/Sources/SQLEngine/Engine.swift
+++ b/Sources/SQLEngine/Engine.swift
@@ -119,7 +119,12 @@ extension Catalog where Self: ~Escapable {
     let context = augment(context, for: query, rows: true)
     let logical = try compile(query, context).pushdown()
     let plan = try optimise(logical, context)
-    return try execute(plan, context).map(\.values)
+    // Execute every UNCORRELATED subquery the plan nests ONCE here — where the
+    // borrowing catalog IS in scope — and thread the memoised results into the
+    // context the executor reads (never during `compile`, so a schema-only path
+    // opens no cursor). A query with no `EXISTS`/`IN (Q)` builds an empty one.
+    let subqueries = try subqueries(of: query, context)
+    return try execute(plan, context.resolving(subqueries)).map(\.values)
   }
 
   /// Runs a `Statement` against this catalog, returning its result rows.
@@ -441,11 +446,21 @@ extension Projection {
   /// faulting (`SQLError.column` for a column, `SQLError.unsupported` for `*`).
   /// The terms hold no slots, so the `single` row's empty record carries every
   /// value the projection needs.
-  internal func scalar(_ routines: Routines = [:]) throws(SQLError) -> Plan {
+  ///
+  /// `subquery` carries the compile-time width map of the UNCORRELATED
+  /// subqueries the projection nests, so an `EXISTS`/`IN (Q)` inside a scalar
+  /// term lowers exactly as it does on the FROM'd path — the FROM-less scalar
+  /// select is otherwise the ONE path that would hit the default unsupported
+  /// map and reject a subquery a run materialises. The `Subquery` is threaded,
+  /// not run, here (see `subquery(of:)`).
+  internal func scalar(_ routines: Routines = [:],
+                       subquery: Subquery = .unsupported)
+      throws(SQLError) -> Plan {
     guard case .all = self else {
       let schema = Schema(width: 0, extent: 0, names: [], types: [],
                           virtuals: [])
-      let terms = try schema.terms(self, in: Relation(name: ""), routines)
+      let terms = try schema.terms(self, in: Relation(name: ""), routines,
+                                   subquery: subquery)
       return .project(terms, .single)
     }
     // `SELECT *` names every column of the relations in scope; a FROM-less query
@@ -824,6 +839,15 @@ extension Predicate {
       operand.aggregated
     case let .membership(operand, values, _):
       operand.aggregated || values.contains { $0.aggregated }
+    case .exists:
+      // A subquery is its OWN scope, so an aggregate inside it folds over its
+      // group, not the enclosing one — it never makes the OUTER query an
+      // aggregate one.
+      false
+    case let .within(operand, _, _):
+      // Only the OUTER operand can hold an enclosing-group aggregate; the
+      // subquery is its own scope.
+      operand.aggregated
     case let .like(operand, pattern, escape, _):
       operand.aggregated || pattern.aggregated
           || (escape?.aggregated ?? false)
@@ -854,6 +878,13 @@ extension Predicate {
       operand.bound
     case let .membership(operand, values, _):
       operand.bound || values.contains { $0.bound }
+    case let .exists(query, _):
+      // A `:parameter` inside a subquery binds against the SAME run bindings
+      // (the subquery runs under the enclosing context), so a defined-function
+      // body that nests one still carries a binding to reject at registration.
+      query.bound
+    case let .within(operand, query, _):
+      operand.bound || query.bound
     case let .like(operand, pattern, escape, _):
       operand.bound || pattern.bound || (escape?.bound ?? false)
     case let .between(test, lower, upper, _):
@@ -867,6 +898,302 @@ extension Predicate {
     case let .not(operand):
       operand.bound
     }
+  }
+}
+
+extension Query {
+  /// Whether this query references a query binding — a `.bound` operand — in
+  /// any predicate within it, descending a set operation's arms. A subquery
+  /// nested in a defined-function body is walked through this to reject a
+  /// `:parameter` at registration (see `Expression.bound`).
+  internal var bound: Bool {
+    switch self {
+    case let .select(select): select.bound
+    case let .setop(_, left, right, _): left.bound || right.bound
+    }
+  }
+
+  /// The UNCORRELATED subqueries this query nests DIRECTLY — the union of every
+  /// arm's `Select.subqueries`, descending a set operation's arms but NOT a
+  /// nested subquery's OWN body (each subquery is run as a whole, resolving its
+  /// inner subqueries through its own `run`). The run path materialises these
+  /// once, keyed by occurrence, so a set operation's every arm reads its own
+  /// `EXISTS`/`IN (Q)` result from the SAME cache.
+  internal var subqueries: Array<Query> {
+    switch self {
+    case let .select(select): select.subqueries
+    case let .setop(_, left, right, _): left.subqueries + right.subqueries
+    }
+  }
+
+  /// The subqueries this query nests in an `IN (Q)` position — the ones whose
+  /// single COLUMN of values a run reads, so the materialiser runs each in FULL
+  /// rather than as a cardinality probe. A subquery only ever an `EXISTS`
+  /// operand is absent, so its select list is never evaluated; one used by BOTH
+  /// an `EXISTS` and an `IN` appears here (its values are needed), so its lone
+  /// full materialisation serves both.
+  internal var valued: Set<Query> {
+    switch self {
+    case let .select(select): select.valued
+    case let .setop(_, left, right, _): left.valued.union(right.valued)
+    }
+  }
+}
+
+extension Select {
+  /// Whether this `SELECT` references a query binding — a `.bound` operand — in
+  /// its `WHERE`, any join `ON`, or its `HAVING` (the predicate positions a
+  /// binding may occur in).
+  internal var bound: Bool {
+    if predicate?.bound ?? false { return true }
+    if joins.contains(where: { $0.on.bound }) { return true }
+    return having?.bound ?? false
+  }
+
+  /// The UNCORRELATED subqueries this `SELECT` nests DIRECTLY — those in its
+  /// `WHERE`, each join `ON`, its `HAVING`, its projection, and its `ORDER BY`
+  /// sort-key expressions — in appearance order, for the `compile`/`typecheck`
+  /// pre-pass to materialise ONCE.
+  ///
+  /// It descends this select's own predicates and expressions but NOT into a
+  /// nested subquery's OWN body: each subquery is compiled/run as a whole
+  /// (`compile(query)`/`run(query)`), which recurses into its inner subqueries
+  /// through its own pre-pass, so gathering only the directly-nested ones keeps
+  /// the walk one level and lets each subquery own its inner materialisation.
+  internal var subqueries: Array<Query> {
+    var queries = Array<Query>()
+    predicate?.collect(subqueries: &queries)
+    for join in joins { join.on.collect(subqueries: &queries) }
+    having?.collect(subqueries: &queries)
+    if case let .expressions(items) = projection {
+      for item in items { item.expression.collect(subqueries: &queries) }
+    }
+    for key in order?.keys ?? [] {
+      if case let .expression(expression) = key.sort {
+        expression.collect(subqueries: &queries)
+      }
+    }
+    return queries
+  }
+
+  /// The subqueries this `SELECT` nests in an `IN (Q)` position — the same
+  /// clauses `subqueries` walks, keeping only the `within` operands' queries,
+  /// so a run materialises each in FULL for its values while an `EXISTS`-only
+  /// subquery stays a cardinality probe.
+  internal var valued: Set<Query> {
+    var queries = Set<Query>()
+    predicate?.collect(valued: &queries)
+    for join in joins { join.on.collect(valued: &queries) }
+    having?.collect(valued: &queries)
+    if case let .expressions(items) = projection {
+      for item in items { item.expression.collect(valued: &queries) }
+    }
+    for key in order?.keys ?? [] {
+      if case let .expression(expression) = key.sort {
+        expression.collect(valued: &queries)
+      }
+    }
+    return queries
+  }
+}
+
+extension Predicate {
+  /// Collects the subqueries this predicate nests DIRECTLY into `queries` — the
+  /// whole `Query` of an `exists`/`within`, and any in an operand expression,
+  /// a `CASE` guard, or an `AND`/`OR`/`NOT` — WITHOUT descending a collected
+  /// subquery's own body (`compile`/`run` recurse into it).
+  internal func collect(subqueries queries: inout Array<Query>) {
+    switch self {
+    case let .exists(query, _):
+      queries.append(query)
+    case let .within(operand, query, _):
+      operand.collect(subqueries: &queries)
+      queries.append(query)
+    case let .comparison(left, _, right):
+      left.collect(subqueries: &queries)
+      right.collect(subqueries: &queries)
+    case let .bound(left, _, _):
+      left.collect(subqueries: &queries)
+    case let .null(operand, _):
+      operand.collect(subqueries: &queries)
+    case let .membership(operand, values, _):
+      operand.collect(subqueries: &queries)
+      for value in values { value.collect(subqueries: &queries) }
+    case let .like(operand, pattern, escape, _):
+      operand.collect(subqueries: &queries)
+      pattern.collect(subqueries: &queries)
+      escape?.collect(subqueries: &queries)
+    case let .between(test, lower, upper, _):
+      test.collect(subqueries: &queries)
+      lower.collect(subqueries: &queries)
+      upper.collect(subqueries: &queries)
+    case let .distinct(lhs, rhs, _):
+      lhs.collect(subqueries: &queries)
+      rhs.collect(subqueries: &queries)
+    case let .truth(inner, _, _):
+      inner.collect(subqueries: &queries)
+    case let .and(lhs, rhs), let .or(lhs, rhs):
+      lhs.collect(subqueries: &queries)
+      rhs.collect(subqueries: &queries)
+    case let .not(operand):
+      operand.collect(subqueries: &queries)
+    }
+  }
+
+  /// Whether this predicate nests any `EXISTS`/`IN (Q)` subquery — the schema
+  /// path's reachability check reads this to keep a subquery-bearing `HAVING`
+  /// from being pruned as unreachable, since its truth is decided at RUN by the
+  /// subquery, not statically.
+  internal var subquery: Bool {
+    var queries = Array<Query>()
+    collect(subqueries: &queries)
+    return !queries.isEmpty
+  }
+
+  /// Collects the subqueries this predicate nests in an `IN (Q)` position into
+  /// `queries` — ONLY a `within`'s `Query`, recursing the same structure
+  /// `collect(subqueries:)` does. An `exists`'s `Query` is NOT collected — its
+  /// values are never read — so it materialises as a probe.
+  internal func collect(valued queries: inout Set<Query>) {
+    switch self {
+    case .exists:
+      // An `EXISTS` operand's values are never read — it materialises as a
+      // cardinality probe — so it is NOT a valued occurrence.
+      break
+    case let .within(operand, query, _):
+      operand.collect(valued: &queries)
+      queries.insert(query)
+    case let .comparison(left, _, right):
+      left.collect(valued: &queries)
+      right.collect(valued: &queries)
+    case let .bound(left, _, _):
+      left.collect(valued: &queries)
+    case let .null(operand, _):
+      operand.collect(valued: &queries)
+    case let .membership(operand, values, _):
+      operand.collect(valued: &queries)
+      for value in values { value.collect(valued: &queries) }
+    case let .like(operand, pattern, escape, _):
+      operand.collect(valued: &queries)
+      pattern.collect(valued: &queries)
+      escape?.collect(valued: &queries)
+    case let .between(test, lower, upper, _):
+      test.collect(valued: &queries)
+      lower.collect(valued: &queries)
+      upper.collect(valued: &queries)
+    case let .distinct(lhs, rhs, _):
+      lhs.collect(valued: &queries)
+      rhs.collect(valued: &queries)
+    case let .truth(inner, _, _):
+      inner.collect(valued: &queries)
+    case let .and(lhs, rhs), let .or(lhs, rhs):
+      lhs.collect(valued: &queries)
+      rhs.collect(valued: &queries)
+    case let .not(operand):
+      operand.collect(valued: &queries)
+    }
+  }
+}
+
+extension Predicate.Operand {
+  /// Collects the subqueries in this `LIKE` operand — an expression's own, none
+  /// for a `:parameter`.
+  internal func collect(subqueries queries: inout Array<Query>) {
+    if case let .expression(expression) = self {
+      expression.collect(subqueries: &queries)
+    }
+  }
+
+  /// Collects the `IN (Q)`-position subqueries in this `LIKE` operand — an
+  /// expression's own, none for a `:parameter`.
+  internal func collect(valued queries: inout Set<Query>) {
+    if case let .expression(expression) = self {
+      expression.collect(valued: &queries)
+    }
+  }
+}
+
+extension Expression {
+  /// Collects the subqueries this expression nests DIRECTLY into `queries` —
+  /// reached through a `CASE` guard or an aggregate's argument/FILTER (a scalar
+  /// expression has no other predicate) — recursing its call arguments,
+  /// arithmetic, aggregate operand and FILTER, `CASE`, `CAST`, `COALESCE`, and
+  /// `NULLIF` sub-expressions. A scalar `Expression.subquery` is a LATER slice,
+  /// so none is collected from an expression position yet.
+  internal func collect(subqueries queries: inout Array<Query>) {
+    switch self {
+    case .column, .literal:
+      break
+    case let .aggregate(_, operand, _, filter):
+      if case let .expression(expression) = operand {
+        expression.collect(subqueries: &queries)
+      }
+      filter?.collect(subqueries: &queries)
+    case let .call(_, arguments):
+      for argument in arguments { argument.collect(subqueries: &queries) }
+    case let .binary(_, lhs, rhs):
+      lhs.collect(subqueries: &queries)
+      rhs.collect(subqueries: &queries)
+    case let .case(whens, otherwise):
+      for when in whens {
+        when.when.collect(subqueries: &queries)
+        when.then.collect(subqueries: &queries)
+      }
+      otherwise?.collect(subqueries: &queries)
+    case let .cast(operand, _):
+      operand.collect(subqueries: &queries)
+    case let .coalesce(arguments):
+      for argument in arguments { argument.collect(subqueries: &queries) }
+    case let .nullif(lhs, rhs):
+      lhs.collect(subqueries: &queries)
+      rhs.collect(subqueries: &queries)
+    }
+  }
+
+  /// Collects the `IN (Q)`-position subqueries this expression nests — reached
+  /// through a `CASE` guard or an aggregate's argument/FILTER, mirroring
+  /// `collect(subqueries:)`. An `EXISTS` guard contributes none (it probes).
+  internal func collect(valued queries: inout Set<Query>) {
+    switch self {
+    case .column, .literal:
+      break
+    case let .aggregate(_, operand, _, filter):
+      if case let .expression(expression) = operand {
+        expression.collect(valued: &queries)
+      }
+      filter?.collect(valued: &queries)
+    case let .call(_, arguments):
+      for argument in arguments { argument.collect(valued: &queries) }
+    case let .binary(_, lhs, rhs):
+      lhs.collect(valued: &queries)
+      rhs.collect(valued: &queries)
+    case let .case(whens, otherwise):
+      for when in whens {
+        when.when.collect(valued: &queries)
+        when.then.collect(valued: &queries)
+      }
+      otherwise?.collect(valued: &queries)
+    case let .cast(operand, _):
+      operand.collect(valued: &queries)
+    case let .coalesce(arguments):
+      for argument in arguments { argument.collect(valued: &queries) }
+    case let .nullif(lhs, rhs):
+      lhs.collect(valued: &queries)
+      rhs.collect(valued: &queries)
+    }
+  }
+
+  /// Whether this expression nests any `EXISTS`/`IN (Q)` subquery — reached
+  /// through a `CASE` guard or an aggregate's argument/FILTER. The empty-fold
+  /// reads this to VALIDATE a subquery-guarded projection or sort expression
+  /// (whose selected branch a run decides at RUN by the subquery, not
+  /// statically) rather than prune it, so `columns(of:)` surfaces the same
+  /// fault the run would (`SELECT CASE WHEN EXISTS (Q) THEN 1 / 0 …` raises
+  /// `.divide`). A subquery-free expression keeps the precise empty-fold.
+  internal var subquery: Bool {
+    var queries = Array<Query>()
+    collect(subqueries: &queries)
+    return !queries.isEmpty
   }
 }
 
@@ -887,7 +1214,8 @@ extension Catalog where Self: ~Escapable {
   /// in the `GROUP BY`.
   internal borrowing func group(_ select: Select, _ relation: Relation,
                                 _ from: Resolved, _ context: Context,
-                                _ visited: Set<String>)
+                                _ visited: Set<String>,
+                                _ subscope: Subscope = .caller)
       throws(SQLError) -> Plan {
     // Resolve every joined relation and lay the FROM relation and each joined
     // one end to end in one combined ordinal space (as the non-aggregate join
@@ -907,16 +1235,20 @@ extension Catalog where Self: ~Escapable {
     // resolved against only the prefix already in scope (as the non-aggregate
     // path does). A `column = column` conjunct becomes a `match` hash-join key;
     // the rest is a residual the join runs as a filter.
+    // Materialise every UNCORRELATED subquery ONCE, ahead of lowering, into a
+    // map the join ONs, WHERE, HAVING, projection, and ORDER BY read from.
+    let subquery = try subquery(of: select, context, visited, subscope)
     var matches = Array<Filter>()
     matches.reserveCapacity(select.joins.count)
     for index in select.joins.indices {
       let prefix = Scope(Array(relations[0 ... index + 1]))
       let join = select.joins[index]
-      try matches.append(prefix.on(join.on, context.routines))
+      try matches.append(prefix.on(join.on, context.routines,
+                                   subquery: subquery))
     }
     var predicate: Filter? = nil
     if let clause = select.predicate {
-      predicate = try scope.lower(clause, context.routines)
+      predicate = try scope.lower(clause, context.routines, subquery: subquery)
     }
 
     // The `GROUP BY` keys and the aggregate arguments lower to combined
@@ -953,7 +1285,8 @@ extension Catalog where Self: ~Escapable {
     // the DISTINCT sort-key check accept it).
     var aggregations = Array<Aggregation>()
     for expression in expressions {
-      let aggregation = try expression.aggregation(scope, context.routines)
+      let aggregation = try expression.aggregation(scope, context.routines,
+                                                   subquery: subquery)
       if !aggregations.contains(aggregation) {
         aggregations.append(aggregation)
       }
@@ -1010,14 +1343,16 @@ extension Catalog where Self: ~Escapable {
     // enforcing the projection rule (every non-aggregated column must be a
     // GROUP BY key).
     var grouping = try Grouping(scope, select.grouping, aggregations)
-    let projection = try grouping.terms(select.projection, context.routines)
+    let projection = try grouping.terms(select.projection, context.routines,
+                                        subquery: subquery)
     let having: Filter? = if let clause = select.having {
-      try grouping.lower(clause, context.routines)
+      try grouping.lower(clause, context.routines, subquery: subquery)
     } else {
       nil
     }
     var order = if let clause = select.order {
-      try grouping.order(clause, projection, context.routines)
+      try grouping.order(clause, projection, context.routines,
+                         subquery: subquery)
     } else {
       Array<SortKey>()
     }
@@ -1099,7 +1434,8 @@ extension Expression {
   /// `Filter` — the same combined base-ordinal space the argument resolves in,
   /// so it reads the pre-aggregation row the fold gates on. `self` is always an
   /// `.aggregate` — `collect` gathers only those.
-  internal func aggregation(_ scope: Scope, _ routines: Routines = [:])
+  internal func aggregation(_ scope: Scope, _ routines: Routines = [:],
+                            subquery: Subquery = .unsupported)
       throws(SQLError) -> Aggregation {
     guard case let .aggregate(function, operand, distinct, filter) = self else {
       throw .unsupported("expected an aggregate")
@@ -1108,10 +1444,10 @@ extension Expression {
     case .star:
       nil
     case let .expression(expression):
-      try scope.term(expression, routines)
+      try scope.term(expression, routines, subquery: subquery)
     }
     let gate: Filter? = if let filter {
-      try scope.lower(filter, routines)
+      try scope.lower(filter, routines, subquery: subquery)
     } else {
       nil
     }
@@ -1134,6 +1470,13 @@ extension Predicate {
     case let .membership(operand, values, _):
       operand.collect(into: &expressions)
       for value in values { value.collect(into: &expressions) }
+    case .exists:
+      // A subquery is its own scope — an aggregate inside it folds over its
+      // group, not the enclosing one — so it contributes none here.
+      break
+    case let .within(operand, _, _):
+      // Only the OUTER operand may hold an enclosing-group aggregate.
+      operand.collect(into: &expressions)
     case let .like(operand, pattern, escape, _):
       operand.collect(into: &expressions)
       pattern.collect(into: &expressions)
@@ -1899,17 +2242,137 @@ extension Catalog where Self: ~Escapable {
   /// `SQLError.arity`.
   internal borrowing func compile(_ query: Query,
                                   _ context: Context = Context(),
-                                  _ visited: Set<String> = [])
+                                  _ visited: Set<String> = [],
+                                  _ scope: Subscope = .caller)
       throws(SQLError) -> Plan {
     guard case let .setop(kind, left, right, all) = query else {
-      return try compile(query.first, context, visited)
+      return try compile(query.first, context, visited, scope)
     }
 
     let width = try arity(query.first, context, visited)
     let count = try arity(right.first, context, visited)
     guard count == width else { throw .arity(width, count) }
-    return try .setop(kind, compile(left, context, visited),
-                      compile(right, context, visited), all: all)
+    return try .setop(kind, compile(left, context, visited, scope),
+                      compile(right, context, visited, scope), all: all)
+  }
+
+  /// The distinct UNCORRELATED subqueries `select` nests, each COMPILED ONCE
+  /// against this catalog and `context` for its column count — NEVER run — into
+  /// a `Subquery` map the predicate/projection lowering reads for arity, the
+  /// seam that carries each sub-`Query` into its lowered `Filter` as data.
+  ///
+  /// This is CURSOR-FREE: it drives `compile`, which resolves schemas and reads
+  /// the subquery's `Plan.width` without a cursor, so a schema-only path
+  /// (`columns(of:)`, view resolution) that shares this lowering opens none and
+  /// surfaces no data-dependent error. Every subquery in the `WHERE`, join
+  /// `ON`s, `HAVING`, projection, `ORDER BY` expressions, and aggregate
+  /// arguments and FILTERs is found by a syntactic walk and keyed by its own
+  /// `Query` (which is `Hashable`), so lowering resolves each `EXISTS`/`IN (Q)`
+  /// against the map by identity. A subquery compiles ONCE even if it appears
+  /// twice; it RUNS at execution (see `subqueries(of:)`), UNCORRELATED so once.
+  ///
+  /// `scope` is the resolution context these subqueries lower under — `.caller`
+  /// for a top-level compile, `.view(name)` for a view body's — carried into
+  /// each lowered `Filter`'s cache key so a view-body occurrence and a
+  /// top-level one over the same AST stay distinct entries (see `Subscope`).
+  internal borrowing func subquery(of select: Select, _ context: Context,
+                                   _ visited: Set<String>,
+                                   _ scope: Subscope = .caller)
+      throws(SQLError) -> Subquery {
+    var widths = Dictionary<Query, Int>()
+    for query in select.subqueries where widths[query] == nil {
+      widths[query] = try compile(query, context, visited).width
+    }
+    return Subquery(scope, widths)
+  }
+
+  /// Executes every UNCORRELATED subquery `query` nests ONCE against this
+  /// catalog and `context` — the run-time counterpart of `subquery(of:)` —
+  /// memoising each result under its occurrence `Subkey` (its resolution
+  /// `scope` composed with its `Query`) into a `Subqueries` cache the row
+  /// evaluator reads.
+  ///
+  /// `scope` is the resolution context these subqueries materialise under, so
+  /// the key each writes matches the key its lowered `Filter` reads: `run`
+  /// materialises a top-level query's subqueries under `.caller`; `derive`
+  /// materialises a view body's under `.view(name)`. The two spaces are
+  /// disjoint, so a caller cache and a view-body cache `merged` without either
+  /// overwriting the other (Bug 2).
+  ///
+  /// An `IN (Q)` occurrence (its `Query` in `query.valued`) is materialised in
+  /// FULL — its single column of values IS read. An occurrence ONLY an `EXISTS`
+  /// operand needs no values, so it is materialised as a cardinality PROBE:
+  /// `probe` tests whether the row source yields ANY row WITHOUT evaluating the
+  /// select list or sort keys, so `EXISTS (SELECT 1 / 0 FROM S)` over a
+  /// non-empty `S` is TRUE with no `.divide` (Bug 3), and it honours the
+  /// original `OFFSET`/`FETCH` so a `FETCH FIRST 0 ROWS` or an `OFFSET` past
+  /// the end is EXISTS false. A `Query` used by BOTH is in `valued`, so its
+  /// single full materialisation serves the `EXISTS` occurrence too.
+  ///
+  /// This runs at RUN time, where the borrowing catalog IS in scope, NOT during
+  /// `compile` — so a schema-only path never reaches it and opens no cursor. It
+  /// gathers every arm's directly-nested subquery (a set operation's both arms
+  /// read one cache) and runs each DISTINCT `Query` at most ONCE per
+  /// outer-query execution: its result is the same for every outer row because
+  /// the subquery is UNCORRELATED. Each runs under the SAME `context` —
+  /// a nested subquery resolves ITS own inner subqueries through its own `run`,
+  /// so this walk stays one level.
+  ///
+  /// Per-arm SHORT-CIRCUIT laziness — not running a subquery an `AND`/`OR` never
+  /// reaches — is a follow-up that threads a runner to the evaluation site; this
+  /// materialises every subquery the plan syntactically nests up front.
+  internal borrowing func subqueries(of query: Query, _ context: Context,
+                                     _ scope: Subscope = .caller)
+      throws(SQLError) -> Subqueries {
+    let valued = query.valued
+    var results = Dictionary<Subkey, MaterialisedSubquery>()
+    for nested in query.subqueries {
+      let key = Subkey(scope, nested)
+      guard results[key] == nil else { continue }
+      if valued.contains(nested) {
+        // An `IN (Q)` occurrence: materialise the full result — its single
+        // column of values is folded per outer row.
+        results[key] = MaterialisedSubquery(rows: try run(nested, context))
+      } else {
+        // An `EXISTS`-only occurrence: probe cardinality without evaluating the
+        // select list or sort keys, honouring the original `OFFSET`/`FETCH`.
+        results[key] = MaterialisedSubquery(present: try probe(nested, context))
+      }
+    }
+    return Subqueries(results)
+  }
+
+  /// Whether `query`'s row source yields ANY row — the `EXISTS` cardinality
+  /// probe — WITHOUT evaluating its select list or sort keys.
+  ///
+  /// For a `probable` `SELECT` (see `Select.probable`), it runs a PROBE query
+  /// that keeps the FROM/`WHERE`/joins, the `DISTINCT` quantifier, the `GROUP
+  /// BY`, and the SAME original `OFFSET`/`FETCH` but replaces the projection
+  /// with a cardinality-preserving target and drops the `ORDER BY`, so the
+  /// original select-list expressions never evaluate (no `1 / 0` fault) while
+  /// the original limiting is honoured: a `FETCH FIRST 0 ROWS` probes zero rows
+  /// (EXISTS false) and an `OFFSET` past the end probes none (false). A
+  /// FROM-less `SELECT <exprs>` carries no limit, so its probe is a limit-free
+  /// `SELECT <constant>` that compiles and yields its one row (EXISTS true). A
+  /// `DISTINCT` select without an `OFFSET` is probable too: `SELECT DISTINCT 1
+  /// FROM S` yields exactly one distinct row iff `S` is non-empty, so the
+  /// constant projection preserves existence. An aggregate/grouped select
+  /// WITHOUT a `HAVING` is probable via a `COUNT(*)` target (see
+  /// `Select.probe`): a whole-result aggregate yields exactly one row (EXISTS
+  /// true modulo the limit, even over an empty source) and a grouped one yields
+  /// one row per group, so the probe preserves its cardinality without running
+  /// the original target. A `DISTINCT` select WITH an `OFFSET` (its emptiness
+  /// depends on the real distinct count), a `HAVING` one (group survival
+  /// depends on the aggregate values, not a source-only fact), or a set
+  /// operation is materialised in FULL and tested for emptiness — the rewrite
+  /// would not preserve its cardinality — which for those shapes evaluates the
+  /// select list as a run would anyway.
+  private borrowing func probe(_ query: Query, _ context: Context)
+      throws(SQLError) -> Bool {
+    guard case let .select(select) = query, select.probable else {
+      return try !run(query, context).isEmpty
+    }
+    return try !run(.select(select.probe), context).isEmpty
   }
 
   /// The number of result columns `select` projects — the extent of a `*` over
@@ -2011,8 +2474,12 @@ extension Catalog where Self: ~Escapable {
       // rebuilds the overlay with rows and runs the sub-plan.
       let overlay =
           augment(context.scoping([:]), for: view.query, rows: false)
+      // The body's subqueries resolve under the VIEW's overlay — never the
+      // caller's — so lower them under `.view(name)`, keeping a view-body
+      // occurrence and a top-level one over the same AST distinct entries.
       let plan =
-          try compile(view.query, overlay, visited.union([name.lowercased()]))
+          try compile(view.query, overlay, visited.union([name.lowercased()]),
+                      .view(name.lowercased()))
       let projected = plan.width
       guard view.columns.count == projected else {
         throw .columns(expected: projected, got: view.columns.count)
@@ -2057,7 +2524,8 @@ extension Catalog where Self: ~Escapable {
   /// into a join.
   internal borrowing func compile(_ select: Select,
                                   _ context: Context = Context(),
-                                  _ visited: Set<String> = [])
+                                  _ visited: Set<String> = [],
+                                  _ subscope: Subscope = .caller)
       throws(SQLError) -> Plan {
     guard let relation = select.from else {
       // A FROM-less select projects expressions over a single row; a `WHERE`,
@@ -2072,7 +2540,16 @@ extension Catalog where Self: ~Escapable {
             "a WHERE, GROUP BY, HAVING, ORDER BY, OFFSET/FETCH, or JOIN " +
             "requires a FROM clause")
       }
-      return try select.projection.scalar(context.routines)
+      // A scalar projection may still nest an UNCORRELATED subquery
+      // (`SELECT CASE WHEN EXISTS (Q) …`); compile each ONCE for its width and
+      // thread the map through so the term lowers as it does on the FROM'd path
+      // rather than hit the default unsupported map. The run path builds the
+      // matching run-time cache from `query.subqueries` (which descends the
+      // projection), so the subquery is materialised there — `compile` runs it
+      // never.
+      let subquery = try subquery(of: select, context, visited, subscope)
+      return try select.projection.scalar(context.routines,
+                                          subquery: subquery)
     }
     let from = try resolve(relation, context, visited)
 
@@ -2091,18 +2568,21 @@ extension Catalog where Self: ~Escapable {
     // `HAVING`, and `ORDER BY` against the grouped slot space. A non-aggregate
     // query compiles exactly as before.
     if select.aggregates {
-      return try group(select, relation, from, context, visited)
+      return try group(select, relation, from, context, visited, subscope)
     }
 
     guard !select.joins.isEmpty else {
+      // Materialise every UNCORRELATED subquery ONCE, ahead of lowering, into a
+      // map the WHERE/projection/ORDER BY lowering splices results from.
+      let subquery = try subquery(of: select, context, visited, subscope)
       var filter: Filter? = nil
       if let predicate = select.predicate {
         filter = try from.schema.lower(predicate, in: relation,
-                                       context.routines)
+                                       context.routines, subquery: subquery)
       }
       let projection =
           try from.schema.terms(select.projection, in: relation,
-                                context.routines)
+                                context.routines, subquery: subquery)
 
       // The ORDER BY lowers its keys against the projection: an ordinal or an
       // output-alias key resolves to a select-list item's own term, an ordinary
@@ -2112,7 +2592,7 @@ extension Catalog where Self: ~Escapable {
       if let clause = select.order {
         let names = select.projection.outputs(count: projection.count)
         order = try from.schema.order(clause, in: relation, projection, names,
-                                      context.routines)
+                                      context.routines, subquery: subquery)
       }
 
       // Under DISTINCT every ORDER BY key must be a select-list value — the
@@ -2164,18 +2644,23 @@ extension Catalog where Self: ~Escapable {
     // inequality or expression equality lowers to a residual the join filters.
     // The WHERE and ORDER lower against the whole chain, which legitimately
     // sees every relation.
+    // Materialise every UNCORRELATED subquery ONCE, ahead of lowering, into a
+    // map the join ONs, WHERE, projection, and ORDER BY splice results from.
+    let subquery = try subquery(of: select, context, visited, subscope)
     var matches = Array<Filter>()
     matches.reserveCapacity(select.joins.count)
     for index in select.joins.indices {
       let prefix = Scope(Array(relations[0 ... index + 1]))
       let join = select.joins[index]
-      try matches.append(prefix.on(join.on, context.routines))
+      try matches.append(prefix.on(join.on, context.routines,
+                                   subquery: subquery))
     }
     var predicate: Filter? = nil
     if let clause = select.predicate {
-      predicate = try scope.lower(clause, context.routines)
+      predicate = try scope.lower(clause, context.routines, subquery: subquery)
     }
-    let projection = try scope.terms(select.projection, context.routines)
+    let projection = try scope.terms(select.projection, context.routines,
+                                     subquery: subquery)
 
     // The ORDER BY lowers its keys against the projection (as the
     // single-relation path does): an ordinal or an output-alias key resolves to
@@ -2185,7 +2670,8 @@ extension Catalog where Self: ~Escapable {
     var order = Array<SortKey>()
     if let clause = select.order {
       let names = select.projection.outputs(count: projection.count)
-      order = try scope.order(clause, projection, names, context.routines)
+      order = try scope.order(clause, projection, names, context.routines,
+                              subquery: subquery)
     }
 
     // Under DISTINCT every ORDER BY key must be a select-list value (see

--- a/Sources/SQLEngine/Filter.swift
+++ b/Sources/SQLEngine/Filter.swift
@@ -68,6 +68,30 @@ internal indirect enum Filter: Equatable, Sendable {
   /// `matches`'s cross-kind FALSE equality), and `IS DISTINCT FROM` is TRUE
   /// when they differ, `IS NOT DISTINCT FROM` when they are the same.
   case distinct(Term, Term, negated: Bool)
+  /// `[NOT] EXISTS (Q)` — the lowered form of the AST's `exists`. The subquery
+  /// occurrence is carried as its cache `Subkey` (its resolution scope composed
+  /// with `Q`) — never run during `compile`, so a schema-only path
+  /// (`columns(of:)`, view resolution) opens no cursor. At RUN time it runs
+  /// ONCE against the borrowed catalog (memoised in a `Subqueries` cache under
+  /// the `Subkey`, since it is UNCORRELATED — one result for every outer row,
+  /// under its OWN resolution context) and the case is the DEFINITE two-valued
+  /// non-empty test of that result: TRUE iff `Q` yielded a row, `negated`
+  /// flipping it (never UNKNOWN). It reads no cell of the outer row. An
+  /// EXISTS-only occurrence is materialised as a cardinality PROBE — its select
+  /// list never evaluated. A later correlated slice re-runs `Q` per outer row.
+  case exists(Subkey, negated: Bool)
+  /// `x [NOT] IN (Q)` — the lowered form of the AST's `within`. The subquery
+  /// occurrence is carried as its cache `Subkey` — never run during `compile` —
+  /// and its single-column arity is enforced at COMPILE from its compiled width
+  /// (`SQLError.arity`, no cursor). At RUN time `Q` executes ONCE against the
+  /// borrowed catalog (memoised under the `Subkey` in the `Subqueries` cache,
+  /// UNCORRELATED) and the case folds `operand = v` over its lone column under
+  /// the SAME Kleene `OR` three-valued membership the value-list
+  /// `Filter.membership` uses — a NULL operand or a NULL element making an
+  /// unmatched test UNKNOWN, an EMPTY result FALSE, and `negated` (`NOT IN`)
+  /// negating the three-valued result (UNKNOWN maps to itself). The operand
+  /// `Term` is evaluated once per row.
+  case within(Term, Subkey, negated: Bool)
   /// `p IS [NOT] <truth value>` — the lowered form of the AST's `truth`. The
   /// inner boolean `Filter` is held once and evaluated to its three-valued
   /// result, which is then MAPPED against `value` (`TRUE`/`FALSE`/`UNKNOWN`) to
@@ -356,6 +380,14 @@ extension Filter {
     case let .distinct(lhs, rhs, negated):
       .distinct(lhs.remapped(through: slot), rhs.remapped(through: slot),
                 negated: negated)
+    case let .exists(key, negated):
+      // An UNCORRELATED EXISTS reads no outer slot — its subquery names no
+      // enclosing column — so the remap passes its cache key through unchanged.
+      .exists(key, negated: negated)
+    case let .within(operand, key, negated):
+      // Only the outer operand term reads slots; the subquery is uncorrelated,
+      // so remap the operand alone and carry the cache key through.
+      .within(operand.remapped(through: slot), key, negated: negated)
     case let .truth(inner, value, negated):
       .truth(inner.remapped(through: slot), value, negated: negated)
     case let .and(lhs, rhs):
@@ -447,6 +479,15 @@ extension Filter {
     case let .between(test, lower, upper, _):
       test.safe && lower.safe && upper.safe
     case let .distinct(lhs, rhs, _): lhs.safe && rhs.safe
+    case .exists:
+      // An UNCORRELATED EXISTS reads no outer row — its subquery ran once at run
+      // start into the memo — so evaluating it is a decided lookup that cannot
+      // throw over an empty product.
+      true
+    case let .within(operand, _, _):
+      // Only the outer operand term is evaluated; the subquery's memoised
+      // values are folded under `matches`, which never throws.
+      operand.safe
     case let .truth(inner, _, _): inner.safe
     case let .and(lhs, rhs): lhs.safe && rhs.safe
     case let .or(lhs, rhs): lhs.safe && rhs.safe
@@ -455,18 +496,44 @@ extension Filter {
   }
 
   /// Whether evaluating this filter can be UNKNOWN — it reads at least one slot
-  /// (a NULL cell there makes a comparison against it UNKNOWN) or compares against
-  /// a run-time `:parameter` (which may be unbound or bound to NULL, likewise
-  /// UNKNOWN). Only a filter over constants alone is definite. Selection pushdown
-  /// must not ride a nullable conjunct below a join or into a view when a LATER
-  /// conjunct is unsafe: the evaluator's `AND` does not short-circuit, so the
-  /// un-pushed query evaluates the later conjunct even when this one is UNKNOWN —
-  /// pushing this one down would drop the UNKNOWN row before the later conjunct
-  /// runs, suppressing a throw the left-to-right `AND` owes (`A.x = 1 AND (1 /
-  /// B.y) = 0`, `A.x` NULL and `B.y = 0` on a matching pair; or `1 = :missing AND
-  /// (1 / y) = 0` over a view, `:missing` unbound — slotless yet UNKNOWN).
+  /// (a NULL cell there makes a comparison against it UNKNOWN), compares
+  /// against a run-time `:parameter` (which may be unbound or bound to NULL,
+  /// likewise UNKNOWN), or is an `IN (Q)` subquery test (three-valued: UNKNOWN
+  /// when the materialised subquery holds a NULL, even over a constant
+  /// operand — slotless yet not definite). Only a filter over constants alone
+  /// whose leaves are all definite is TRUE/FALSE for certain. Selection
+  /// pushdown must not ride a nullable conjunct below a join or into a view
+  /// when a LATER conjunct is unsafe: the evaluator's `AND` does not
+  /// short-circuit, so the un-pushed query evaluates the later conjunct even
+  /// when this one is UNKNOWN — pushing this one down drops the UNKNOWN row
+  /// before the later conjunct runs, suppressing a throw the left-to-right
+  /// `AND` owes (`A.x = 1 AND (1 / B.y) = 0`, `A.x` NULL and `B.y = 0` on a
+  /// matching pair; `1 = :missing AND (1 / y) = 0` over a view, `:missing`
+  /// unbound; or `1 IN (SELECT N FROM S) AND (1 / 0) = 0`, `S.N` a non-matching
+  /// NULL making the `IN` UNKNOWN — all slotless yet UNKNOWN).
   internal var nullable: Bool {
-    !slots.isEmpty || parameterised
+    !slots.isEmpty || parameterised || contingent
+  }
+
+  /// Whether this filter can be UNKNOWN INDEPENDENT of any slot or
+  /// `:parameter` — an `IN (Q)` subquery test (`Filter.within`), which is
+  /// three-valued: `x IN (Q)` is UNKNOWN when `Q`'s materialised column holds a
+  /// NULL and no element matches, so a slotless `1 IN (Q)` over a constant
+  /// operand is still not definite. `nullable` counts it even when `slots` is
+  /// empty and nothing is parameterised, keeping an `IN (Q)` conjunct off a
+  /// pushdown ahead of a later unsafe conjunct the non-short-circuiting `AND`
+  /// still owes. An `EXISTS (Q)` is genuinely TWO-valued — a decided non-empty
+  /// test, never UNKNOWN — so it is NOT contingent and stays freely pushable.
+  private var contingent: Bool {
+    switch self {
+    case .within: true
+    case .compare, .bound, .match, .null, .membership, .like, .between,
+         .distinct, .exists: false
+    case let .truth(inner, _, _): inner.contingent
+    case let .and(lhs, rhs): lhs.contingent || rhs.contingent
+    case let .or(lhs, rhs): lhs.contingent || rhs.contingent
+    case let .not(operand): operand.contingent
+    }
   }
 
   /// Whether this filter compares against a run-time `:parameter` — a `.bound`
@@ -480,6 +547,10 @@ extension Filter {
     switch self {
     case .bound: true
     case .compare, .match, .null, .membership, .distinct: false
+    // An UNCORRELATED subquery predicate reads no run-time `:parameter` of the
+    // OUTER query — the subquery runs once at run start with the same bindings —
+    // so neither is parameterised for the outer row.
+    case .exists, .within: false
     case let .like(_, pattern, escape, _):
       pattern.parameterised || (escape?.parameterised ?? false)
     case let .between(_, lower, upper, _):
@@ -535,7 +606,8 @@ extension Row where Self: ~Escapable {
   /// term runs over a materialised projection record or a predicate's borrowed
   /// cursor row.
   internal borrowing func evaluate(_ term: Term, _ routines: Routines,
-                                   _ bindings: Bindings = [:])
+                                   _ bindings: Bindings = [:],
+                                   _ subqueries: Subqueries = Subqueries())
       throws(SQLError) -> Value {
     switch term {
     case let .slot(slot):
@@ -543,28 +615,30 @@ extension Row where Self: ~Escapable {
     case let .constant(value):
       value
     case let .apply(name, arguments):
-      try apply(name, arguments, routines, bindings)
+      try apply(name, arguments, routines, bindings, subqueries)
     case let .binary(op, lhs, rhs):
-      try op.apply(evaluate(lhs, routines, bindings),
-                   evaluate(rhs, routines, bindings))
+      try op.apply(evaluate(lhs, routines, bindings, subqueries),
+                   evaluate(rhs, routines, bindings, subqueries))
     case let .case(branches, otherwise, type):
       // Take the FIRST branch whose guard is three-valued TRUE (UNKNOWN and
       // FALSE skip); with none matching, the `else` term, or `NULL` when there
       // is none. The guard is a `Filter`, so it evaluates over the same row,
-      // routines, and bindings a `WHERE` filter does — a `:parameter` guard
-      // resolves against the bindings, an UNKNOWN one does not select its
-      // branch. The selected value is COERCED to the CASE's unified result
-      // `type` so it matches the column type the schema advertised.
-      try conditional(branches, otherwise, type, routines, bindings)
+      // routines, bindings, and subquery results a `WHERE` filter does — a
+      // `:parameter` guard resolves against the bindings, an UNKNOWN one does
+      // not select its branch. The selected value is COERCED to the CASE's
+      // unified result `type` so it matches the column type the schema
+      // advertised.
+      try conditional(branches, otherwise, type, routines, bindings,
+                      subqueries)
     case let .cast(operand, type):
       // Evaluate the operand and CONVERT it to the target type: NULL casts to
       // NULL, an unconvertible value faults (`Value.cast(to:)`), never yielding
       // a wrong value.
-      try evaluate(operand, routines, bindings).cast(to: type)
+      try evaluate(operand, routines, bindings, subqueries).cast(to: type)
     case let .coalesce(elements, type):
-      try coalesce(elements, type, routines, bindings)
+      try coalesce(elements, type, routines, bindings, subqueries)
     case let .nullif(lhs, rhs):
-      try nullif(lhs, rhs, routines, bindings)
+      try nullif(lhs, rhs, routines, bindings, subqueries)
     }
   }
 
@@ -580,10 +654,11 @@ extension Row where Self: ~Escapable {
   /// of a `.double` COALESCE), exactly as a `CASE` coerces its taken branch;
   /// NULL passes unchanged.
   private borrowing func coalesce(_ elements: Array<Term>, _ type: ValueType,
-                                  _ routines: Routines, _ bindings: Bindings)
+                                  _ routines: Routines, _ bindings: Bindings,
+                                  _ subqueries: Subqueries)
       throws(SQLError) -> Value {
     for element in elements {
-      let value = try evaluate(element, routines, bindings)
+      let value = try evaluate(element, routines, bindings, subqueries)
       if case .null = value { continue }
       return value.coerced(to: type)
     }
@@ -600,10 +675,11 @@ extension Row where Self: ~Escapable {
   /// three-valued: only a definite TRUE equality nulls out, so an UNKNOWN (a
   /// NULL operand) yields `va`.
   private borrowing func nullif(_ lhs: Term, _ rhs: Term,
-                                _ routines: Routines, _ bindings: Bindings)
+                                _ routines: Routines, _ bindings: Bindings,
+                                _ subqueries: Subqueries)
       throws(SQLError) -> Value {
-    let va = try evaluate(lhs, routines, bindings)
-    let vb = try evaluate(rhs, routines, bindings)
+    let va = try evaluate(lhs, routines, bindings, subqueries)
+    let vb = try evaluate(rhs, routines, bindings, subqueries)
     return matches(va, .equal, vb) == true ? .null : va
   }
 
@@ -619,20 +695,24 @@ extension Row where Self: ~Escapable {
   private borrowing func conditional(_ branches: Array<(Filter, Term)>,
                                      _ otherwise: Term?, _ type: ValueType,
                                      _ routines: Routines,
-                                     _ bindings: Bindings)
+                                     _ bindings: Bindings,
+                                     _ subqueries: Subqueries)
       throws(SQLError) -> Value {
     for (gate, result) in branches {
-      if try evaluate(gate, routines, bindings) == true {
-        return try evaluate(result, routines, bindings).coerced(to: type)
+      if try evaluate(gate, routines, bindings, subqueries) == true {
+        return try evaluate(result, routines, bindings, subqueries)
+            .coerced(to: type)
       }
     }
     guard let otherwise else { return .null }
-    return try evaluate(otherwise, routines, bindings).coerced(to: type)
+    return try evaluate(otherwise, routines, bindings, subqueries)
+        .coerced(to: type)
   }
 
   /// Resolves `name` in `routines` and applies it to its evaluated `arguments`.
   private borrowing func apply(_ name: String, _ arguments: Array<Term>,
-                               _ routines: Routines, _ bindings: Bindings)
+                               _ routines: Routines, _ bindings: Bindings,
+                               _ subqueries: Subqueries)
       throws(SQLError) -> Value {
     guard let routine = routines[name] else {
       throw .function(name)
@@ -640,7 +720,7 @@ extension Row where Self: ~Escapable {
     var values = Array<Value>()
     values.reserveCapacity(arguments.count)
     for argument in arguments {
-      try values.append(evaluate(argument, routines, bindings))
+      try values.append(evaluate(argument, routines, bindings, subqueries))
     }
     let result = try routine(values)
     // A registered routine is a public producer of `Value`s that bypasses the
@@ -876,52 +956,68 @@ extension Row where Self: ~Escapable {
   /// row is non-escaping; it threads into the recursion freely and is never
   /// stored.
   internal borrowing func evaluate(_ filter: Filter, _ routines: Routines,
-                                   _ bindings: Bindings)
+                                   _ bindings: Bindings,
+                                   _ subqueries: Subqueries = Subqueries())
       throws(SQLError) -> Bool? {
     switch filter {
     case let .compare(lhs, op, rhs):
-      try matches(evaluate(lhs, routines, bindings), op,
-                  evaluate(rhs, routines, bindings))
+      try matches(evaluate(lhs, routines, bindings, subqueries), op,
+                  evaluate(rhs, routines, bindings, subqueries))
     case let .bound(term, op, parameter):
       if let operand = bindings[parameter] {
-        try matches(evaluate(term, routines, bindings), op, operand)
+        try matches(evaluate(term, routines, bindings, subqueries), op, operand)
       } else {
         nil
       }
     case let .match(left, right):
       matches(self[left], .equal, self[right])
     case let .null(term, negated):
-      try (evaluate(term, routines, bindings) == .null) != negated
+      try (evaluate(term, routines, bindings, subqueries) == .null) != negated
     case let .membership(operand, elements, negated):
-      try member(operand, elements, negated, routines, bindings)
+      try member(operand, elements, negated, routines, bindings, subqueries)
     case let .like(operand, pattern, escape, negated):
-      try like(operand, pattern, escape, negated, routines, bindings)
+      try like(operand, pattern, escape, negated, routines, bindings,
+               subqueries)
     case let .between(test, lower, upper, negated):
-      try ranged(test, lower, upper, negated, routines, bindings)
+      try ranged(test, lower, upper, negated, routines, bindings, subqueries)
     case let .distinct(lhs, rhs, negated):
-      try differs(lhs, rhs, negated, routines, bindings)
+      try differs(lhs, rhs, negated, routines, bindings, subqueries)
+    case let .exists(key, negated):
+      // The subquery ran ONCE at run start (memoised under its `Subkey` in the
+      // cache); this reads the DEFINITE two-valued non-empty test — never
+      // UNKNOWN, and reading no row of the outer relation — `negated` flipping
+      // it. An EXISTS-only occurrence's result is a cardinality probe.
+      try subqueries.present(key) != negated
+    case let .within(operand, key, negated):
+      // Fold `operand = v` over the subquery's memoised single column under the
+      // SAME three-valued membership the value-list `IN` uses.
+      try member(operand, subqueries.values(key), negated, routines,
+                 bindings, subqueries)
     case let .truth(inner, value, negated):
-      try tested(evaluate(inner, routines, bindings), value, negated)
+      try tested(evaluate(inner, routines, bindings, subqueries), value,
+                 negated)
     case let .and(lhs, rhs):
       // `&&`/`||` take an `@autoclosure` right operand, which would capture the
       // borrowed `~Escapable` row; spell each connective explicitly so a branch
       // re-borrows the row rather than capturing it. Kleene `AND`: `false`
       // dominates, an UNKNOWN left yields `false` only against a `false` right.
-      switch try evaluate(lhs, routines, bindings) {
+      switch try evaluate(lhs, routines, bindings, subqueries) {
       case false?: false
-      case true?: try evaluate(rhs, routines, bindings)
-      case nil: try evaluate(rhs, routines, bindings) == false ? false : nil
+      case true?: try evaluate(rhs, routines, bindings, subqueries)
+      case nil:
+        try evaluate(rhs, routines, bindings, subqueries) == false ? false : nil
       }
     case let .or(lhs, rhs):
       // Kleene `OR`: `true` dominates, an UNKNOWN left yields `true` only
       // against a `true` right.
-      switch try evaluate(lhs, routines, bindings) {
+      switch try evaluate(lhs, routines, bindings, subqueries) {
       case true?: true
-      case false?: try evaluate(rhs, routines, bindings)
-      case nil: try evaluate(rhs, routines, bindings) == true ? true : nil
+      case false?: try evaluate(rhs, routines, bindings, subqueries)
+      case nil:
+        try evaluate(rhs, routines, bindings, subqueries) == true ? true : nil
       }
     case let .not(operand):
-      try evaluate(operand, routines, bindings).map { !$0 }
+      try evaluate(operand, routines, bindings, subqueries).map { !$0 }
     }
   }
 
@@ -937,12 +1033,36 @@ extension Row where Self: ~Escapable {
   /// `map(!)`.
   private borrowing func member(_ operand: Term, _ elements: Array<Term>,
                                 _ negated: Bool, _ routines: Routines,
-                                _ bindings: Bindings)
+                                _ bindings: Bindings, _ subqueries: Subqueries)
       throws(SQLError) -> Bool? {
-    let value = try evaluate(operand, routines, bindings)
+    let value = try evaluate(operand, routines, bindings, subqueries)
     var truth: Bool? = false
     for element in elements {
-      let element = try evaluate(element, routines, bindings)
+      let element = try evaluate(element, routines, bindings, subqueries)
+      truth = or(truth, matches(value, .equal, element))
+      if truth == true { break }
+    }
+    return negated ? truth.map { !$0 } : truth
+  }
+
+  /// Evaluates a lowered `operand [NOT] IN (Q)` against this row over the
+  /// subquery's ALREADY-MATERIALISED single column `values`.
+  ///
+  /// It is the value-list `member` fold over constants: the `operand` is
+  /// evaluated ONCE per row, then `operand = v` folds over the materialised
+  /// `values` IN ORDER under Kleene `OR`, seeded FALSE and short-circuiting at
+  /// the first TRUE — so a NULL operand or a NULL element keeps the ISO
+  /// three-valued result (an unmatched test is UNKNOWN, not FALSE), an EMPTY
+  /// `values` folds FALSE (no witness), and `NOT IN` negates that truth,
+  /// mapping UNKNOWN to itself. It reuses the SAME `matches`/`or` primitives
+  /// the value-list `IN` does, so the two forms share one three-valued core.
+  private borrowing func member(_ operand: Term, _ values: Array<Value>,
+                                _ negated: Bool, _ routines: Routines,
+                                _ bindings: Bindings, _ subqueries: Subqueries)
+      throws(SQLError) -> Bool? {
+    let value = try evaluate(operand, routines, bindings, subqueries)
+    var truth: Bool? = false
+    for element in values {
       truth = or(truth, matches(value, .equal, element))
       if truth == true { break }
     }
@@ -979,13 +1099,13 @@ extension Row where Self: ~Escapable {
   private borrowing func ranged(_ test: Term, _ lower: Filter.Operand,
                                 _ upper: Filter.Operand,
                                 _ negated: Bool, _ routines: Routines,
-                                _ bindings: Bindings)
+                                _ bindings: Bindings, _ subqueries: Subqueries)
       throws(SQLError) -> Bool? {
-    let value = try evaluate(test, routines, bindings)
-    let low = try evaluate(lower, routines, bindings)
+    let value = try evaluate(test, routines, bindings, subqueries)
+    let low = try evaluate(lower, routines, bindings, subqueries)
     let above = matches(value, .geq, low)
     guard above != false else { return negated }
-    let high = try evaluate(upper, routines, bindings)
+    let high = try evaluate(upper, routines, bindings, subqueries)
     let within = and(above, matches(value, .leq, high))
     return negated ? within.map { !$0 } : within
   }
@@ -1000,10 +1120,11 @@ extension Row where Self: ~Escapable {
   /// negates it. Unlike a `compare`, a NULL operand never makes the row
   /// UNKNOWN.
   private borrowing func differs(_ lhs: Term, _ rhs: Term, _ negated: Bool,
-                                 _ routines: Routines, _ bindings: Bindings)
+                                 _ routines: Routines, _ bindings: Bindings,
+                                 _ subqueries: Subqueries)
       throws(SQLError) -> Bool? {
-    let differ = try distinct(evaluate(lhs, routines, bindings),
-                              evaluate(rhs, routines, bindings))
+    let differ = try distinct(evaluate(lhs, routines, bindings, subqueries),
+                              evaluate(rhs, routines, bindings, subqueries))
     return negated ? !differ : differ
   }
 
@@ -1012,11 +1133,12 @@ extension Row where Self: ~Escapable {
   /// name yields `.null`, so it reads UNKNOWN exactly as a bound `NULL` does.
   private borrowing func evaluate(_ operand: Filter.Operand,
                                   _ routines: Routines,
-                                  _ bindings: Bindings)
+                                  _ bindings: Bindings,
+                                  _ subqueries: Subqueries)
       throws(SQLError) -> Value {
     switch operand {
     case let .term(term):
-      try evaluate(term, routines, bindings)
+      try evaluate(term, routines, bindings, subqueries)
     case let .parameter(name):
       bindings[name] ?? .null
     }
@@ -1039,15 +1161,20 @@ extension Row where Self: ~Escapable {
   /// result (UNKNOWN maps to itself).
   private borrowing func like(_ operand: Term, _ pattern: Filter.Operand,
                               _ escape: Filter.Operand?, _ negated: Bool,
-                              _ routines: Routines, _ bindings: Bindings)
+                              _ routines: Routines, _ bindings: Bindings,
+                              _ subqueries: Subqueries)
       throws(SQLError) -> Bool? {
     // Evaluate all three reached operands once, in order — a fault in any of
     // them (a divide, an overflow) propagates HERE, before the NULL/escape
     // result below can turn it into a silent UNKNOWN.
-    let subject = try evaluate(operand, routines, bindings)
-    let template = try evaluate(pattern, routines, bindings)
+    let subject = try evaluate(operand, routines, bindings, subqueries)
+    let template = try evaluate(pattern, routines, bindings, subqueries)
     let separator: Value? =
-        if let escape { try evaluate(escape, routines, bindings) } else { nil }
+        if let escape {
+          try evaluate(escape, routines, bindings, subqueries)
+        } else {
+          nil
+        }
 
     // Decide the escape character. A NULL escape is UNKNOWN like a NULL
     // operand; anything but a one-character text is `SQLError.argument`.

--- a/Sources/SQLEngine/Lexer.swift
+++ b/Sources/SQLEngine/Lexer.swift
@@ -438,6 +438,7 @@ internal struct Lexer: ~Escapable {
     case "NULL": .null
     case "IN": .in
     case "BETWEEN": .between
+    case "EXISTS": .exists
     case "LIKE": .like
     case "ESCAPE": .escape
     case "PLACING": .placing

--- a/Sources/SQLEngine/Operator.swift
+++ b/Sources/SQLEngine/Operator.swift
@@ -316,6 +316,9 @@ extension Catalog where Self: ~Escapable {
       throws(SQLError) -> Array<Record> {
     let routines = context.routines
     let bindings = context.bindings
+    // The plan's UNCORRELATED subquery results, run ONCE at run start and read
+    // by the row evaluator wherever an `EXISTS`/`IN (Q)` predicate evaluates.
+    let subqueries = context.subqueries
     switch plan {
     case .single:
       // The FROM-less single row: one record with no cells, the source a scalar
@@ -329,14 +332,14 @@ extension Catalog where Self: ~Escapable {
       // Fuse a residual product with its filter: stream each pair through the
       // predicate rather than materialising the whole cross product first.
       return try sift(execute(outer, context), execute(inner, context),
-                      filter, routines, bindings)
+                      filter, routines, bindings, subqueries)
     case let .select(filter, source):
       return try admitted(execute(source, context), filter, routines,
-                          bindings)
+                          bindings, subqueries)
     case let .project(terms, source):
       return try execute(source, context)
         .map { record throws(SQLError) in
-          try project(terms, record, routines, bindings)
+          try project(terms, record, routines, bindings, subqueries)
         }
     case let .sort(keys, source):
       // Evaluate each key's `Term` against every record UP FRONT — a bare slot
@@ -349,7 +352,7 @@ extension Catalog where Self: ~Escapable {
       let rows = try execute(source, context)
       let sortable = try rows.map { record throws(SQLError) in
         try keys.map { key throws(SQLError) in
-          try record.evaluate(key.term, routines, bindings)
+          try record.evaluate(key.term, routines, bindings, subqueries)
         }
       }
       return sortable.indices
@@ -379,14 +382,14 @@ extension Catalog where Self: ~Escapable {
       // yields no rows to read a width off.
       return try outer(execute(left, context), left.slots ?? 0,
                        execute(right, context), right.slots ?? 0, on, kind,
-                       routines, bindings)
+                       routines, bindings, subqueries)
     case let .setop(kind, left, right, all):
       return try setop(kind, left, right, all, context)
     case let .distinct(source):
       return deduplicated(try execute(source, context))
     case let .aggregate(keys, aggregates, source):
       return try grouped(execute(source, context), keys, aggregates,
-                         routines, bindings)
+                         routines, bindings, subqueries)
     case let .limit(count, offset, source):
       return limited(try execute(source, context), count, offset)
     }
@@ -547,12 +550,13 @@ private func deduplicated(_ records: Array<Record>) -> Array<Record> {
 /// Evaluates each projected `term` against `record` through `routines` to the
 /// output row, in order — slot `i` of the result is `terms[i]`.
 private func project(_ terms: Array<Term>, _ record: Record,
-                     _ routines: Routines, _ bindings: Bindings)
+                     _ routines: Routines, _ bindings: Bindings,
+                     _ subqueries: Subqueries)
     throws(SQLError) -> Record {
   var cells = Array<Value>()
   cells.reserveCapacity(terms.count)
   for term in terms {
-    try cells.append(record.evaluate(term, routines, bindings))
+    try cells.append(record.evaluate(term, routines, bindings, subqueries))
   }
   return Record(cells)
 }
@@ -561,11 +565,12 @@ private func project(_ terms: Array<Term>, _ record: Record,
 /// three-valued logic (UNKNOWN and `false` both reject), resolving scalar calls
 /// through `routines` and parameters from `bindings`.
 private func admitted(_ records: Array<Record>, _ filter: Filter,
-                      _ routines: Routines, _ bindings: Bindings)
+                      _ routines: Routines, _ bindings: Bindings,
+                      _ subqueries: Subqueries)
     throws(SQLError) -> Array<Record> {
   var kept = Array<Record>()
   for record in records {
-    if try record.evaluate(filter, routines, bindings) == true {
+    if try record.evaluate(filter, routines, bindings, subqueries) == true {
       kept.append(record)
     }
   }
@@ -622,10 +627,28 @@ extension Catalog where Self: ~Escapable {
                                  _ ordinals: Array<Int>, _ seek: Range<Int>?,
                                  _ context: Context)
       throws(SQLError) -> Array<Record> {
-    let overlay = if let view = resolve(view: name) {
+    var overlay = if let view = resolve(view: name) {
       augment(context.scoping([:]), for: view.query, rows: true)
     } else {
       context.scoping([:])
+    }
+    // A view body may itself nest `EXISTS`/`IN (Q)` predicates whose subqueries
+    // its own compiled plan carries; resolve them ONCE here — against the view's
+    // overlay, where this catalog is in scope — so the sub-plan's row evaluator
+    // reads each result, just as the top-level `run` resolves a query's own.
+    // Materialise them under `.view(name)` — the SAME scope the body compiled
+    // its lowered `Filter`s under — and MERGE with the caller's cache (keyed
+    // `.caller`). The two id spaces are DISJOINT (see `Subscope`): a view-body
+    // `EXISTS (SELECT V FROM S)` over the view's OWN base `S` and a caller's
+    // pushed `EXISTS (SELECT V FROM S)` over the caller's CTE `S` are the same
+    // AST but SEPARATE occurrences, so each keeps its own result — the pushed
+    // caller conjunct reads its `.caller` entry, the view-body conjunct its
+    // `.view` entry — neither overwriting the other, which a value-keyed merge
+    // would.
+    if let view = resolve(view: name) {
+      let inner = try subqueries(of: view.query, overlay,
+                                 .view(name.lowercased()))
+      overlay = overlay.resolving(context.subqueries.merged(inner))
     }
     let rows = try execute(plan, overlay)
     let range = seek ?? 0 ..< rows.count
@@ -659,13 +682,14 @@ private func product(_ outer: Array<Record>, _ inner: Array<Record>)
 /// `filter` evaluates to `true` under three-valued logic is kept; UNKNOWN and
 /// `false` both drop, exactly as `admitted`.
 private func sift(_ outer: Array<Record>, _ inner: Array<Record>,
-                  _ filter: Filter, _ routines: Routines, _ bindings: Bindings)
+                  _ filter: Filter, _ routines: Routines, _ bindings: Bindings,
+                  _ subqueries: Subqueries)
     throws(SQLError) -> Array<Record> {
   var records = Array<Record>()
   for left in outer {
     for right in inner {
       let record = left.merged(with: right)
-      if try record.evaluate(filter, routines, bindings) == true {
+      if try record.evaluate(filter, routines, bindings, subqueries) == true {
         records.append(record)
       }
     }
@@ -697,7 +721,8 @@ private func sift(_ outer: Array<Record>, _ inner: Array<Record>,
 private func outer(_ left: Array<Record>, _ leftWidth: Int,
                    _ right: Array<Record>, _ rightWidth: Int, _ on: Filter,
                    _ kind: Join.Kind, _ routines: Routines,
-                   _ bindings: Bindings) throws(SQLError) -> Array<Record> {
+                   _ bindings: Bindings, _ subqueries: Subqueries)
+    throws(SQLError) -> Array<Record> {
   let leftNulls = Record(Array(repeating: .null, count: leftWidth))
   let rightNulls = Record(Array(repeating: .null, count: rightWidth))
 
@@ -711,7 +736,7 @@ private func outer(_ left: Array<Record>, _ leftWidth: Int,
       var paired = false
       for outer in left {
         let record = outer.merged(with: inner)
-        if try record.evaluate(on, routines, bindings) == true {
+        if try record.evaluate(on, routines, bindings, subqueries) == true {
           records.append(record)
           paired = true
         }
@@ -730,7 +755,7 @@ private func outer(_ left: Array<Record>, _ leftWidth: Int,
     var paired = false
     for index in right.indices {
       let record = outer.merged(with: right[index])
-      if try record.evaluate(on, routines, bindings) == true {
+      if try record.evaluate(on, routines, bindings, subqueries) == true {
         records.append(record)
         matched[index] = true
         paired = true
@@ -829,6 +854,7 @@ extension Catalog where Self: ~Escapable {
       throws(SQLError) -> Array<Record> {
     let routines = context.routines
     let bindings = context.bindings
+    let subqueries = context.subqueries
     // A materialised CTE inner has no sort key, so it is scanned in full and
     // the equality on its `keys.right` slot is the join's truth — the same
     // probe a base relation falls back to when its key is unseekable. A pushed
@@ -840,7 +866,8 @@ extension Catalog where Self: ~Escapable {
       for index in 0 ..< cte.rows.count {
         let right = cte.record(index, ordinals)
         if let filter,
-            try right.evaluate(filter, routines, bindings) != true { continue }
+            try right.evaluate(filter, routines, bindings,
+                               subqueries) != true { continue }
         inner.append(right)
       }
       return joined(outer, inner, base, keys)
@@ -848,7 +875,7 @@ extension Catalog where Self: ~Escapable {
     guard let inner = table(named: name) else { throw .relation(name) }
     guard inner.seekable(column) else {
       return try inner.hashed(outer, ordinals, base, keys, filter, routines,
-                              bindings)
+                              bindings, subqueries)
     }
 
     let cursor = inner.cursor()
@@ -870,7 +897,8 @@ extension Catalog where Self: ~Escapable {
         // A pushed inner filter is applied as each candidate materialises,
         // before it can pair — an inner row it rejects joins to nothing.
         if let filter,
-            try right.evaluate(filter, routines, bindings) != true { continue }
+            try right.evaluate(filter, routines, bindings,
+                               subqueries) != true { continue }
         // Equal by the SAME rule the predicate uses — integer/integer exact,
         // mixed integer/double promoted — so a seek that scanned wide still
         // pairs exactly.
@@ -914,7 +942,8 @@ extension Table where Self: ~Escapable {
                                     _ ordinals: Array<Int>, _ base: Int,
                                     _ keys: (left: Int, right: Int),
                                     _ filter: Filter?, _ routines: Routines,
-                                    _ bindings: Bindings)
+                                    _ bindings: Bindings,
+                                    _ subqueries: Subqueries)
       throws(SQLError) -> Array<Record> {
     guard outer.contains(where: {
       if case .null = $0[keys.left] { false } else { true }
@@ -933,7 +962,8 @@ extension Table where Self: ~Escapable {
       // Apply the whole pushed filter before bucketing — a filtered inner row
       // is never a join candidate.
       if let filter,
-          try right.evaluate(filter, routines, bindings) != true { continue }
+          try right.evaluate(filter, routines, bindings,
+                             subqueries) != true { continue }
       if case .null = right[slot] { continue }
       buckets[bucket(right[slot]), default: Array<Record>()].append(right)
     }

--- a/Sources/SQLEngine/OutputColumn.swift
+++ b/Sources/SQLEngine/OutputColumn.swift
@@ -334,11 +334,67 @@ extension Catalog where Self: ~Escapable {
   ///     ONLY`, or a positive `OFFSET` over a whole-result aggregate's sole row
   ///     (its output type is still DERIVED for the schema, non-faulting);
   ///     otherwise it validates fully.
+  /// A `SubqueryCheck` for a `select` — every UNCORRELATED subquery it nests
+  /// recursively TYPE-CHECKED against the SAME shape the run evaluates and
+  /// compiled for its arity ONCE, ahead of the `check` walk, into a map `check`
+  /// reads. Validating and compiling each subquery here — where the borrowing
+  /// catalog is in scope — mirrors the run path's lowering (which resolves and
+  /// materialises the inner query), so schema validation matches execution: a
+  /// bad column or routine inside a subquery faults, and a `IN (Q)`'s
+  /// single-column arity is enforced from the compiled width.
+  ///
+  /// An `IN (Q)` occurrence (its `Query` in `select.valued`) has its select
+  /// list READ at run, so its ORIGINAL shape is type-checked — an `IN (SELECT
+  /// 1 / 0 FROM S)` faults `.divide` as the run does. An occurrence ONLY an
+  /// `EXISTS` operand runs through the cardinality PROBE (`Select.probe`:
+  /// constant projection, `DISTINCT` quantifier and original `OFFSET`/`FETCH`
+  /// kept, `ORDER BY` dropped), which never evaluates the original select list
+  /// or sort keys — so its PROBED shape is type-checked, matching the run:
+  /// `EXISTS (SELECT 1 / 0 FROM S)` does NOT fault `.divide` at validate,
+  /// exactly as it does not at run, while a bad inner RELATION or `WHERE`
+  /// (retained by the probe) still faults. A `Query` used by BOTH is in
+  /// `valued`, so its original is checked (the `IN` needs its values). The
+  /// probe applies only to a `probable` `SELECT` — the shape `probe` rewrites
+  /// (a non-set-operation select WITHOUT a `HAVING` that is non-`DISTINCT` or
+  /// `DISTINCT` WITHOUT an `OFFSET`, its target the constant `1` or, for an
+  /// aggregate/grouped one, a cardinality-preserving `COUNT(*)`); any other
+  /// EXISTS-only query (a `HAVING` or set operation) runs in FULL, so its
+  /// original is checked. The arity width is always the ORIGINAL query's
+  /// (cursor-free), as `subquery(of:)` records it on the compile path.
+  private borrowing func subqueryCheck(of select: Select, _ context: Context,
+                                       visited: Set<String>)
+      throws(SQLError) -> SubqueryCheck {
+    let valued = select.valued
+    var widths = Dictionary<Query, Int>()
+    for query in select.subqueries where widths[query] == nil {
+      try typecheck(shape(of: query, valued: valued), context, visited: visited)
+      widths[query] = try compile(query, context, visited).width
+    }
+    return SubqueryCheck(widths)
+  }
+
+  /// The subquery shape a run of `query` type-checks against — the ORIGINAL for
+  /// an `IN (Q)` occurrence (in `valued`, its select list evaluated) or a query
+  /// the probe does not rewrite, else the `Select.probe` the `EXISTS`
+  /// cardinality probe runs (constant projection, `ORDER BY` dropped, original
+  /// `OFFSET`/`FETCH` kept) so validation does not evaluate a select list or
+  /// sort key the run never does.
+  private borrowing func shape(of query: Query, valued: Set<Query>) -> Query {
+    guard !valued.contains(query), case let .select(select) = query,
+        select.probable else {
+      return query
+    }
+    return .select(select.probe)
+  }
+
   private borrowing func typecheck(_ select: Select, _ context: Context,
                                    visited: Set<String>)
       throws(SQLError) {
     let routines = context.routines
     let scope = try scope(of: select, context, visited: visited)
+    // Type-check and compile every UNCORRELATED subquery ONCE, ahead of the
+    // `check` walk, into a map the checks read for validation and arity.
+    let subquery = try subqueryCheck(of: select, context, visited: visited)
     // An `ORDER BY` ordinal names a 1-based SELECT-list position; one outside
     // `1 ... width` names no output column and faults `SQLError.column` (spelled
     // as the ordinal), exactly as the compile path's ordinal resolution does —
@@ -361,10 +417,10 @@ extension Catalog where Self: ~Escapable {
     // Structural, so it runs regardless of the WHERE/limit reachability the
     // operand type-check below tracks.
     if select.aggregates {
-      try order(grouped: select, scope, routines)
+      try order(grouped: select, scope, context, visited)
     }
     if let predicate = select.predicate {
-      try scope.check(predicate, routines)
+      try scope.check(predicate, routines, subquery: subquery)
       // A false WHERE filters every row, so a GROUP BY forms no group and a
       // non-aggregate query yields no row — nothing after is reachable. A
       // whole-result aggregate (an aggregate projection or HAVING, no GROUP BY)
@@ -381,7 +437,18 @@ extension Catalog where Self: ~Escapable {
             // operands (a divide, overflow, or bad routine call faults) AND
             // yields the group's fate — a group passes only when HAVING is TRUE,
             // so FALSE or UNKNOWN drops it and the projection is unreachable.
-            if try scope.empty(having, routines) != true { return }
+            //
+            // A HAVING nesting an `EXISTS`/`IN (Q)` subquery is the exception:
+            // `empty` cannot materialise the subquery (it carries no catalog),
+            // so it folds UNKNOWN — but the subquery is row-independent and may
+            // be TRUE at RUN, keeping the group and RUNNING the projection. So
+            // a subquery-bearing HAVING is NOT-definitely-empty: fall through
+            // and VALIDATE the projection, so `columns(of:)` surfaces the fault
+            // the run would (`SELECT 1 / 0 … HAVING EXISTS (Q)` raises
+            // `.divide`). A subquery-free HAVING keeps the precise pruning.
+            if !having.subquery, try scope.empty(having, routines) != true {
+              return
+            }
           }
           // The lone empty group is itself unreachable when a limit drops the
           // one row it would emit — a zero `FETCH` or any positive `OFFSET`. A
@@ -394,7 +461,9 @@ extension Catalog where Self: ~Escapable {
           var reachable = select.distinct
           if !reachable { reachable = !drops(select.limit, single: true) }
           if reachable, case let .expressions(items) = select.projection {
-            for item in items { _ = try scope.empty(item.expression, routines) }
+            for item in items {
+              try scope.fold(item.expression, routines, subquery: subquery)
+            }
           }
           // The lone empty group is sorted BELOW the limit — the shape is
           // `Project(Limit(Sort(…)))` — so its ORDER BY keys evaluate over
@@ -405,7 +474,7 @@ extension Catalog where Self: ~Escapable {
           // projection term reached only via the sort is checked even where the
           // projection block above is skipped.
           for expression in select.orderKeys {
-            _ = try scope.empty(expression, routines)
+            try scope.fold(expression, routines, subquery: subquery)
           }
         }
         return
@@ -419,14 +488,16 @@ extension Catalog where Self: ~Escapable {
     // `HAVING` — so its operand and arity are checked here, the same as a
     // projection or `HAVING` aggregate's.
     if case let .expressions(items) = select.projection {
-      for item in items { try scope.aggregates(in: item.expression, routines) }
+      for item in items {
+        try scope.aggregates(in: item.expression, routines, subquery: subquery)
+      }
     }
     for expression in select.orderKeys {
-      try scope.aggregates(in: expression, routines)
+      try scope.aggregates(in: expression, routines, subquery: subquery)
     }
     if let having = select.having {
-      try scope.aggregates(in: having, routines)
-      try scope.check(having, routines)
+      try scope.aggregates(in: having, routines, subquery: subquery)
+      try scope.check(having, routines, subquery: subquery)
       // A false HAVING filters every group before the projection, so the
       // projection's non-aggregate work is unreachable.
       if scope.constant(having, routines) == false { return }
@@ -444,7 +515,9 @@ extension Catalog where Self: ~Escapable {
     var reachable = select.distinct
     if !reachable { reachable = !drops(select.limit, single: sole) }
     if reachable, case let .expressions(items) = select.projection {
-      for item in items { _ = try scope.validate(item.expression, routines) }
+      for item in items {
+        _ = try scope.validate(item.expression, routines, subquery: subquery)
+      }
     }
     // The sort sits BELOW the limit — the shape is `Project(Limit(Sort(…)))`
     // — so it evaluates every ORDER BY key over the input rows BEFORE the cap
@@ -458,7 +531,7 @@ extension Catalog where Self: ~Escapable {
     // projection term NO sort key reaches stays correctly unchecked (the
     // projection never runs under a row-dropping limit).
     for expression in select.orderKeys {
-      _ = try scope.validate(expression, routines)
+      _ = try scope.validate(expression, routines, subquery: subquery)
     }
   }
 
@@ -475,8 +548,16 @@ extension Catalog where Self: ~Escapable {
   /// the two paths cannot drift. It resolves only, reading no cursor; a run's
   /// operand type-check over the (structurally valid) keys stays the caller's.
   private borrowing func order(grouped select: Select, _ scope: Scope,
-                               _ routines: Routines) throws(SQLError) {
+                               _ context: Context, _ visited: Set<String>)
+      throws(SQLError) {
     guard let clause = select.order else { return }
+    let routines = context.routines
+    // A grouped aggregate's argument or FILTER may nest an UNCORRELATED
+    // subquery (`ORDER BY SUM(CASE WHEN EXISTS (Q) …)`), which lowering
+    // resolves against the materialised map, so materialise the select's
+    // subqueries ONCE here — the same map the run's `group` builds — for this
+    // structural resolve to lower those aggregates exactly as the run does.
+    let subquery = try subquery(of: select, context, visited)
     // Collect the distinct aggregates the grouped plan folds — the projection,
     // the `HAVING`, and the `ORDER BY` sort-key expressions — then dedup by the
     // RESOLVED `Aggregation`, exactly as `group` does, so a grouped `ORDER BY`
@@ -493,7 +574,8 @@ extension Catalog where Self: ~Escapable {
     }
     var aggregations = Array<Aggregation>()
     for expression in expressions {
-      let aggregation = try expression.aggregation(scope, routines)
+      let aggregation = try expression.aggregation(scope, routines,
+                                                   subquery: subquery)
       if !aggregations.contains(aggregation) {
         aggregations.append(aggregation)
       }
@@ -503,8 +585,9 @@ extension Catalog where Self: ~Escapable {
     // `ORDER BY` output name resolves against — then lower the `ORDER BY`, which
     // faults a non-group column, an out-of-range ordinal, or an ambiguous name.
     var grouping = try Grouping(scope, select.grouping, aggregations)
-    let projection = try grouping.terms(select.projection, routines)
-    _ = try grouping.order(clause, projection, routines)
+    let projection = try grouping.terms(select.projection, routines,
+                                        subquery: subquery)
+    _ = try grouping.order(clause, projection, routines, subquery: subquery)
   }
 
   /// Whether `limit` drops the one row a `single`-row result would yield,

--- a/Sources/SQLEngine/Parser.swift
+++ b/Sources/SQLEngine/Parser.swift
@@ -33,11 +33,11 @@
 /// predicate      := disjunction
 /// disjunction    := conjunction (OR conjunction)*
 /// conjunction    := negation (AND negation)*
-/// negation       := NOT negation | primary
+/// negation       := NOT negation | [NOT] EXISTS '(' query ')' | primary
 /// primary        := '(' predicate ')' [IS [NOT] truthvalue] | comparison
 /// comparison     := expression (op (expression | param)
 ///                 | IS [NOT] (NULL | truthvalue | DISTINCT FROM expression)
-///                 | [NOT] IN '(' expression (',' expression)* ')'
+///                 | [NOT] IN '(' (expression (',' expression)* | query) ')'
 ///                 | [NOT] LIKE expression [ESCAPE expression]
 ///                 | [NOT] BETWEEN (expression | param) AND
 ///                                 (expression | param))
@@ -891,12 +891,37 @@ internal struct Parser: ~Escapable {
     return lhs
   }
 
-  /// Parses `NOT negation` or a primary.
+  /// Parses `NOT negation`, `[NOT] EXISTS (query)`, or a primary.
+  ///
+  /// `EXISTS` is a complete predicate with NO left operand — `EXISTS (Q)` — so
+  /// it is recognised HERE, ahead of the comparison tier a left expression
+  /// begins in. A prefix `NOT` before it sets the `negated` flag directly
+  /// (`NOT EXISTS (Q)`) rather than wrapping it in a `.not`, symmetric with how
+  /// `membership`/`between`/`like` carry their `NOT`; a prefix `NOT` before
+  /// anything else is the ordinary boolean negation.
   private mutating func negation() throws(SQLError) -> Predicate {
     if try match(.not) {
+      if try match(.exists) {
+        return try exists(negated: true)
+      }
       return try .not(negation())
     }
+    if try match(.exists) {
+      return try exists(negated: false)
+    }
     return try primary()
+  }
+
+  /// Parses the `(query)` tail of `[NOT] EXISTS (query)` — the `EXISTS` is
+  /// already consumed — into the first-class `Predicate.exists`, `negated`
+  /// carrying the `NOT EXISTS` spelling. The subquery is a parenthesised
+  /// `query`, so it may itself be a `UNION`; `Predicate` is `indirect`, so it
+  /// nests the whole `Query`.
+  private mutating func exists(negated: Bool) throws(SQLError) -> Predicate {
+    try expect(.lparen)
+    let query = try query()
+    try expect(.rparen)
+    return .exists(query, negated: negated)
   }
 
   /// Parses a parenthesised predicate or a comparison.
@@ -954,7 +979,9 @@ internal struct Parser: ~Escapable {
   /// bridging as the comparison `x = TRUE` the test maps to a definite truth.
   /// An `IN`
   /// (or `NOT IN`) tail tests the left expression for membership in a
-  /// parenthesised value list. A `LIKE` (or `NOT LIKE`) tail tests the left
+  /// parenthesised value list, or — when a `SELECT` follows the `(` — in the
+  /// single column a parenthesised subquery yields. A `LIKE` (or `NOT LIKE`)
+  /// tail tests the left
   /// expression's text against a pattern, with an optional `ESCAPE` character.
   /// A `BETWEEN a AND b` (or `NOT BETWEEN`) tail is the ISO range test,
   /// desugared into a conjunction (or disjunction) of bounds. A leading `NOT`
@@ -1007,16 +1034,24 @@ internal struct Parser: ~Escapable {
     return .comparison(left: left, op: op, right: right)
   }
 
-  /// Parses the value-list tail of `left [NOT] IN (…)` — the `IN` is already
-  /// consumed — into a `membership` predicate over `left`.
+  /// Parses the tail of `left [NOT] IN (…)` — the `IN` is already consumed —
+  /// into a `membership` (value-list) or a `within` (subquery) predicate over
+  /// `left`.
   ///
-  /// The list is parenthesised and non-empty: at least one value expression,
-  /// then any number of comma-separated ones. The subquery form `IN (SELECT …)`
-  /// is not supported, so the parenthesised items are ordinary scalar
-  /// expressions.
+  /// After the opening `(`, ONE token of lookahead disambiguates the two forms:
+  /// a `SELECT` begins a subquery — `left [NOT] IN (query)`, the first-class
+  /// `Predicate.within` (the query may itself be a `UNION`) — and anything
+  /// else begins the value list, a non-empty run of comma-separated
+  /// expressions, the `Predicate.membership`. No rewind is needed: `SELECT`
+  /// never begins an expression, so the peek is unambiguous.
   private mutating func membership(_ left: Expression, negated: Bool)
       throws(SQLError) -> Predicate {
     try expect(.lparen)
+    if current?.kind == .select {
+      let query = try query()
+      try expect(.rparen)
+      return .within(left, query, negated: negated)
+    }
     var values = [try expression()]
     while try match(.comma) {
       try values.append(expression())

--- a/Sources/SQLEngine/Resolve.swift
+++ b/Sources/SQLEngine/Resolve.swift
@@ -18,6 +18,291 @@
 /// resolves is `SQLError.column`; an unqualified name both relations of a join
 /// resolve is `SQLError.ambiguous`.
 
+/// The RESOLUTION CONTEXT a subquery occurrence materialises under — the seam
+/// that keeps two AST-identical subqueries resolving under DIFFERENT overlays
+/// SEPARATE cache entries, so neither overwrites the other.
+///
+/// An uncorrelated subquery's result depends only on the overlay it resolves
+/// against, and in this slice a subquery resolves under exactly one of two
+/// contexts: the top-level CALLER's overlay (its `WITH` CTEs), or a specific
+/// VIEW body's overlay (that view's own base relations, never the caller's
+/// `WITH`). A view `VN` whose body has `EXISTS (SELECT V FROM S)` over an empty
+/// base `S`, run under a caller that binds `WITH S AS (SELECT 1)`, must read
+/// the view's own (empty) `S` — not the caller's CTE — even though both spell
+/// the same AST. Keying the cache by the `Query` VALUE alone collapses the
+/// two; a `Subscope` composed into the key keeps them disjoint. The `caller`
+/// case is distinguished from every `view` case, and two distinct view names
+/// never collide (case-folded), so the caller and view spaces cannot overlap.
+///
+/// It is reproducible at BOTH the compile site (lowering embeds it in the
+/// lowered `Filter`) and the matching materialise site (`run` materialises the
+/// top-level query's subqueries under `.caller`; `derive(name:)` materialises a
+/// view body's under `.view(name)`), so the key a lowered predicate reads is
+/// the key the materialiser wrote.
+internal enum Subscope: Hashable, Sendable {
+  /// The top-level caller's overlay — a subquery textually in the outer query
+  /// (its `WHERE`, projection, …), and an outer conjunct pushed into a view.
+  case caller
+  /// A view body's own overlay, named by the view (case-folded) — a subquery
+  /// textually in that view's registered query.
+  case view(String)
+}
+
+/// The cache identity of one collected subquery OCCURRENCE — its resolution
+/// `context` composed with its `query` AST.
+///
+/// A subquery is keyed neither by its `Query` value alone (which collapses two
+/// AST-identical subqueries under different overlays — see `Subscope`)
+/// nor by a raw counter (which two independent id spaces could not keep
+/// disjoint), but by the PAIR: within one `Subscope`, an identical `Query`
+/// resolves to an identical result, so value-discrimination is correct there;
+/// across scopes the `Subscope` keeps them separate. A caller-space key
+/// (`.caller`) and a view-space key (`.view(name)`) are unequal even for the
+/// same AST, so the two id spaces cannot collide.
+internal struct Subkey: Hashable, Sendable {
+  /// The resolution context this occurrence materialises under.
+  internal let scope: Subscope
+
+  /// The subquery's AST.
+  internal let query: Query
+
+  internal init(_ scope: Subscope, _ query: Query) {
+    self.scope = scope
+    self.query = query
+  }
+}
+
+/// One UNCORRELATED subquery already RUN ONCE at execution — the value a
+/// run-time `Subqueries` cache memoises so the row evaluator reads an
+/// `EXISTS`/`IN (Q)` predicate without re-running the inner query or itself
+/// holding the borrowing catalog.
+///
+/// An `IN (Q)` occurrence needs the subquery's single COLUMN of values, so it
+/// is materialised in FULL (`rows`). An occurrence used only by `EXISTS` needs
+/// nothing but CARDINALITY — whether the row source yields ANY row — so it is
+/// materialised as a `present` PROBE that never evaluates the select list or
+/// sort keys and stops at the first row (`EXISTS (SELECT 1 / 0 FROM S)` over a
+/// non-empty `S` is TRUE with no `.divide`, no full scan). A probe carries no
+/// `rows`, so `values` faults if an `IN` ever reads it — but a query needing
+/// its values is materialised full, so it never does.
+internal struct MaterialisedSubquery {
+  /// The subquery's result rows for an `IN` occurrence materialised in full, or
+  /// `nil` for an `EXISTS`-only occurrence materialised as a cardinality probe.
+  private let rows: Array<Array<Value>>?
+
+  /// Whether the row source yielded a row — the `EXISTS` non-empty test, read
+  /// from the full `rows` or the probe.
+  internal let present: Bool
+
+  /// A full materialisation of `rows` — an `IN` occurrence, whose select list
+  /// IS needed.
+  internal init(rows: Array<Array<Value>>) {
+    self.rows = rows
+    self.present = !rows.isEmpty
+  }
+
+  /// A cardinality probe — an `EXISTS`-only occurrence, carrying only whether
+  /// the row source yielded a row, never the select-list values.
+  internal init(present: Bool) {
+    self.rows = nil
+    self.present = present
+  }
+
+  /// The single column of the result — the `IN (Q)` membership values. Only an
+  /// occurrence materialised in FULL (its select list needed) reads this; a
+  /// probe-only entry carries none, an internal invariant break if reached.
+  internal func values() throws(SQLError) -> Array<Value> {
+    guard let rows else {
+      throw .named("a subquery materialised as a probe has no values")
+    }
+    return rows.map { $0[0] }
+  }
+}
+
+/// The COMPILE-time seam that lowers an `EXISTS`/`IN (Q)` predicate WITHOUT
+/// running its subquery — the fix for the schema-path cursor-contract violation.
+///
+/// Predicate lowering happens over escapable resolution surfaces (`Schema`,
+/// `Scope`, `Grouping`) that carry no catalog, and is shared by SCHEMA-ONLY
+/// paths (`columns(of:)`, view resolution, arity checks) documented NOT to open
+/// a cursor. So lowering carries the sub-`Query` into the `Filter` as DATA
+/// rather than running it: `exists`/`within` build the lowered node holding the
+/// query, which executes ONCE, at RUN time (see `Subqueries`). Only the
+/// single-column arity of an `IN (Q)` is decided here — from the subquery's
+/// COMPILED WIDTH, known without a cursor — so a two-column `IN` subquery faults
+/// `SQLError.arity` at compile as before, never having run.
+///
+/// The `widths` map holds each nested `Query`'s compiled column count, built by
+/// the `compile` path (where the catalog is in scope) by COMPILING — never
+/// running — every subquery ONCE ahead of lowering. A schema-only surface with
+/// no catalog passes `.unsupported`, whose `width` faults, so a subquery
+/// reaching such a surface is rejected rather than mis-lowered.
+internal struct Subquery {
+  /// The resolution context every subquery lowered against this surface
+  /// materialises under — `.caller` for a top-level compile, `.view(name)` for
+  /// a view body's — composed into each lowered `Filter`'s cache key so a
+  /// view-body occurrence and a top-level one over the same AST stay distinct.
+  private let scope: Subscope
+
+  /// Each nested `Query` mapped to its COMPILED column count — cursor-free; an
+  /// `IN (Q)` requires it be 1.
+  private let widths: Dictionary<Query, Int>
+
+  internal init(_ scope: Subscope = .caller,
+                _ widths: Dictionary<Query, Int> = [:]) {
+    self.scope = scope
+    self.widths = widths
+  }
+
+  /// A `Subquery` for a lowering surface with no catalog — a schema-only
+  /// resolve. It holds no widths, so any subquery lowered against it faults
+  /// `SQLError.unsupported` rather than mis-lower.
+  internal static var unsupported: Subquery {
+    Subquery()
+  }
+
+  /// The compiled column count of `query`, or a fault when the surface holds
+  /// none — a subquery reaching a catalog-less lowering surface.
+  private func width(_ query: Query) throws(SQLError) -> Int {
+    guard let width = widths[query] else {
+      throw .unsupported("a subquery is not supported in this position")
+    }
+    return width
+  }
+
+  /// Lowers `[NOT] EXISTS (query)` — the query carried into the `Filter` to run
+  /// at execution, `negated` flipping the non-empty test. `EXISTS` ignores the
+  /// subquery's arity (its column count is irrelevant to a cardinality test),
+  /// but the query must have been compiled in the pre-pass (else a catalog-less
+  /// surface, which faults).
+  internal func exists(_ query: Query, negated: Bool)
+      throws(SQLError) -> Filter {
+    _ = try width(query)
+    return .exists(Subkey(scope, query), negated: negated)
+  }
+
+  /// Lowers `operand [NOT] IN (query)` — `operand` already lowered to a `Term`
+  /// — requiring `query` project EXACTLY ONE column (else `SQLError.arity`,
+  /// checked from the COMPILED width, so a two-column subquery faults here
+  /// without running), then carrying the query into the `Filter` to run at
+  /// execution.
+  internal func within(_ operand: Term, _ query: Query, negated: Bool)
+      throws(SQLError) -> Filter {
+    let width = try width(query)
+    guard width == 1 else { throw .arity(1, width) }
+    return .within(operand, Subkey(scope, query), negated: negated)
+  }
+}
+
+/// The RUN-time cache that executes each UNCORRELATED subquery ONCE and
+/// memoises its result — the seam that gives the row evaluator a subquery result
+/// WITHOUT itself holding the borrowing catalog.
+///
+/// A subquery is UNCORRELATED in this slice — it names no column of the
+/// enclosing query — so its result is the SAME for every outer row and is
+/// computed at most once per outer-query execution. The `run` path, where the
+/// borrowing catalog IS in scope, populates this map BEFORE executing the plan
+/// (see `Catalog.subqueries(of:)`), so the evaluator reads it as plain
+/// escapable data. An `EXISTS` reads whether the result is non-empty; an
+/// `IN (Q)` folds over its single materialised column.
+///
+/// This lands the schema-path cursor fix and the once-per-run memoisation;
+/// per-arm SHORT-CIRCUIT laziness (skipping a subquery an `AND`/`OR` never
+/// reaches) and the per-outer-row re-execution a CORRELATED subquery needs
+/// thread a runner to the evaluation site in a follow-up.
+internal struct Subqueries {
+  private let results: Dictionary<Subkey, MaterialisedSubquery>
+
+  internal init(_ results: Dictionary<Subkey, MaterialisedSubquery> = [:]) {
+    self.results = results
+  }
+
+  /// The materialised result for `key` — every occurrence a runnable plan
+  /// references is populated at run start, so a miss is an internal invariant
+  /// break, reported rather than silently treated as empty.
+  private func result(_ key: Subkey) throws(SQLError) -> MaterialisedSubquery {
+    guard let result = results[key] else {
+      throw .named("a subquery result was not materialised")
+    }
+    return result
+  }
+
+  /// Whether the occurrence `key` yielded a row — the `EXISTS` non-empty test.
+  internal func present(_ key: Subkey) throws(SQLError) -> Bool {
+    try result(key).present
+  }
+
+  /// The single column of the occurrence `key`'s result — the `IN (Q)`
+  /// membership values. The plan compiled the query's width to 1, so the first
+  /// cell of each row is its lone value; an `IN` occurrence is always
+  /// materialised in FULL, so its values are present.
+  internal func values(_ key: Subkey) throws(SQLError) -> Array<Value> {
+    try result(key).values()
+  }
+
+  /// The DISJOINT union of this cache and `other`'s — every entry of both,
+  /// which never collide because their keys carry distinct `Subscope`s: `self`
+  /// holds one resolution context's occurrences (the caller's, keyed
+  /// `.caller`), `other` another's (a view body's, keyed `.view(name)`). A
+  /// subquery AST-identical in both is TWO occurrences under TWO scopes, so it
+  /// occupies TWO keys — neither overwrites the other, and the pushed caller
+  /// filter reads its `.caller` result while the view-body filter reads its
+  /// `.view` one. A collision would be an id-space bug (two contexts sharing a
+  /// scope); it cannot happen, so the merge keeps the existing entry.
+  internal func merged(_ other: Subqueries) -> Subqueries {
+    Subqueries(results.merging(other.results) { existing, _ in existing })
+  }
+}
+
+/// The validation-side analog of `Subquery` — the seam that lets the dry-run
+/// type-check (`check`) validate the UNCORRELATED inner query an `EXISTS`/`IN
+/// (Q)` nests without itself holding the borrowing catalog.
+///
+/// `check` runs over escapable resolution surfaces carrying no catalog, yet a
+/// subquery's inner names and routines must be validated against one for schema
+/// validation to match execution — the recurring lesson that the two must not
+/// diverge. The `typecheck` path, where the borrowing catalog and `Context`
+/// ARE in scope, supplies a `validate` closure that recursively type-checks the
+/// inner query and a `width` closure that compiles it for its column count; a
+/// surface with no catalog passes `.unsupported`, which faults so a subquery
+/// reaching such a surface is rejected rather than passed unvalidated.
+internal struct SubqueryCheck {
+  /// Each nested `Query` mapped to its compiled column count — the map the
+  /// `typecheck` path builds by validating and compiling every subquery ONCE,
+  /// ahead of the `check` walk. A query present here has already been
+  /// type-checked; `check` reads its width to enforce a `IN (Q)`'s single-
+  /// column arity.
+  private let widths: Dictionary<Query, Int>
+
+  internal init(_ widths: Dictionary<Query, Int> = [:]) {
+    self.widths = widths
+  }
+
+  /// A checker for a surface with no catalog — validating a subquery needs one,
+  /// so it holds no widths and faults `SQLError.unsupported` rather than pass a
+  /// subquery unvalidated.
+  internal static var unsupported: SubqueryCheck {
+    SubqueryCheck()
+  }
+
+  /// Asserts the inner `query` was validated in the pre-pass — a query the
+  /// surface's map holds has been type-checked and compiled; one it does not
+  /// reached a catalog-less surface and is rejected.
+  internal func validate(_ query: Query) throws(SQLError) {
+    guard widths[query] != nil else {
+      throw .unsupported("a subquery is not supported in this position")
+    }
+  }
+
+  /// The column count `query` projects — from the pre-pass compile.
+  internal func width(_ query: Query) throws(SQLError) -> Int {
+    guard let width = widths[query] else {
+      throw .unsupported("a subquery is not supported in this position")
+    }
+    return width
+  }
+}
+
 /// Lowers the name-addressed AST `predicate` to the engine's `Filter`, lowering
 /// each leaf's operand expressions through `term` and passing a `bound`
 /// comparison's `:parameter` through unchanged.
@@ -27,7 +312,8 @@
 /// (against one schema, a combined join space, or a grouped slot space); each
 /// caller supplies that resolution as `term`.
 private func lower(_ predicate: Predicate,
-                   term: (Expression) throws(SQLError) -> Term)
+                   term: (Expression) throws(SQLError) -> Term,
+                   subquery: Subquery)
     throws(SQLError) -> Filter {
   switch predicate {
   case let .comparison(left, op, right):
@@ -36,6 +322,19 @@ private func lower(_ predicate: Predicate,
     try .bound(term(left), op, parameter)
   case let .null(expression, negated):
     try .null(term(expression), negated: negated)
+  case let .exists(query, negated):
+    // `[NOT] EXISTS (Q)`. In this first slice `Q` is UNCORRELATED, so the
+    // materialiser runs it ONCE (as a CTE body materialises) and the whole
+    // predicate is the definite non-empty test of that result — never UNKNOWN,
+    // `negated` flipping it. A missing materialiser (a lowering surface with no
+    // catalog in scope) rejects the subquery rather than mis-lower it.
+    try subquery.exists(query, negated: negated)
+  case let .within(expression, query, negated):
+    // `x [NOT] IN (Q)`. `Q` is UNCORRELATED here, so the materialiser runs it
+    // ONCE, checks it projects exactly ONE column (else `SQLError.arity`), and
+    // lowers to a `Filter.within` folding `x = v` over that column under the
+    // value-list `IN`'s three-valued Kleene `OR`.
+    try subquery.within(term(expression), query, negated: negated)
   case let .membership(expression, values, negated):
     // `x IN (a, b, …)` is the disjunction `x = a OR x = b OR …` and `NOT IN`
     // its negation, lowered to a first-class `Filter.membership` that evaluates
@@ -72,13 +371,16 @@ private func lower(_ predicate: Predicate,
     // `p IS [NOT] <truth value>` lowers to a first-class `Filter.truth` over
     // the lowered inner boolean filter; the three-valued-to-definite mapping
     // lives in the runtime (`tested`), so lowering just lowers the operand.
-    try .truth(lower(inner, term: term), value, negated: negated)
+    try .truth(lower(inner, term: term, subquery: subquery), value,
+               negated: negated)
   case let .and(lhs, rhs):
-    try .and(lower(lhs, term: term), lower(rhs, term: term))
+    try .and(lower(lhs, term: term, subquery: subquery),
+             lower(rhs, term: term, subquery: subquery))
   case let .or(lhs, rhs):
-    try .or(lower(lhs, term: term), lower(rhs, term: term))
+    try .or(lower(lhs, term: term, subquery: subquery),
+            lower(rhs, term: term, subquery: subquery))
   case let .not(operand):
-    try .not(lower(operand, term: term))
+    try .not(lower(operand, term: term, subquery: subquery))
   }
 }
 
@@ -288,7 +590,8 @@ extension Schema {
   /// lowers each expression to a term. The terms hold ordinals, which the
   /// engine remaps to slots after gathering the referenced ones.
   internal func terms(_ projection: Projection, in relation: Relation,
-                      _ routines: Routines = [:])
+                      _ routines: Routines = [:],
+                      subquery: Subquery = .unsupported)
       throws(SQLError) -> Array<Term> {
     switch projection {
     case .all:
@@ -304,7 +607,8 @@ extension Schema {
       var terms = Array<Term>()
       terms.reserveCapacity(projected.count)
       for item in projected {
-        try terms.append(term(item.expression, in: relation, routines))
+        try terms.append(term(item.expression, in: relation, routines,
+                              subquery: subquery))
       }
       return terms
     }
@@ -314,7 +618,8 @@ extension Schema {
   /// `.slot(ordinal)`, a literal to a `.constant`, a call to an `.apply` over
   /// its lowered arguments.
   internal func term(_ expression: Expression, in relation: Relation,
-                     _ routines: Routines = [:])
+                     _ routines: Routines = [:],
+                     subquery: Subquery = .unsupported)
       throws(SQLError) -> Term {
     switch expression {
     case let .column(column):
@@ -325,7 +630,8 @@ extension Schema {
       var lowered = Array<Term>()
       lowered.reserveCapacity(arguments.count)
       for argument in arguments {
-        try lowered.append(term(argument, in: relation, routines))
+        try lowered.append(term(argument, in: relation, routines,
+                                subquery: subquery))
       }
       // Case-fold the routine name to the SQL identifier rule the `Routines`
       // lookup uses (lowercase), so two calls that spell the same routine with
@@ -335,19 +641,22 @@ extension Schema {
       // aggregate dedup, and every other term comparison stay consistent.
       return .apply(name: name.lowercased(), arguments: lowered)
     case let .binary(op, lhs, rhs):
-      return try .binary(op, term(lhs, in: relation, routines),
-                         term(rhs, in: relation, routines))
+      return try .binary(op, term(lhs, in: relation, routines,
+                                  subquery: subquery),
+                         term(rhs, in: relation, routines, subquery: subquery))
     case let .case(whens, otherwise):
       // Lower each branch's guard predicate to a `Filter` and its result to a
       // `Term`, and the `ELSE` to a `Term`, over this relation's resolution.
       var branches = Array<(Filter, Term)>()
       branches.reserveCapacity(whens.count)
       for branch in whens {
-        let gate = try lower(branch.when, in: relation, routines)
-        try branches.append((gate, term(branch.then, in: relation, routines)))
+        let gate = try lower(branch.when, in: relation, routines,
+                             subquery: subquery)
+        try branches.append((gate, term(branch.then, in: relation, routines,
+                                        subquery: subquery)))
       }
       let fallback: Term? = if let otherwise {
-        try term(otherwise, in: relation, routines)
+        try term(otherwise, in: relation, routines, subquery: subquery)
       } else {
         nil
       }
@@ -361,7 +670,8 @@ extension Schema {
     case let .cast(operand, type):
       // Lower the operand and attach the target type; the executor converts the
       // evaluated value to it (`Value.cast(to:)`).
-      return try .cast(term(operand, in: relation, routines), type)
+      return try .cast(term(operand, in: relation, routines,
+                            subquery: subquery), type)
     case let .coalesce(arguments):
       // Lower each argument to a `Term` over this relation and hold them in a
       // first-class `Term.coalesce` so each is evaluated ONCE. `type` is the
@@ -370,7 +680,8 @@ extension Schema {
       var elements = Array<Term>()
       elements.reserveCapacity(arguments.count)
       for argument in arguments {
-        try elements.append(term(argument, in: relation, routines))
+        try elements.append(term(argument, in: relation, routines,
+                                 subquery: subquery))
       }
       let scope = Scope([(relation, self)])
       let type = try scope.derive(expression, routines)
@@ -378,8 +689,8 @@ extension Schema {
     case let .nullif(lhs, rhs):
       // Lower both operands to `Term`s over this relation and hold them in a
       // first-class `Term.nullif` so each is evaluated ONCE.
-      return try .nullif(term(lhs, in: relation, routines),
-                         term(rhs, in: relation, routines))
+      return try .nullif(term(lhs, in: relation, routines, subquery: subquery),
+                         term(rhs, in: relation, routines, subquery: subquery))
     case .aggregate:
       // An aggregate has no per-row meaning — it folds over a group — so it may
       // not appear in a `WHERE`, a join `ON`, or a non-aggregate projection.
@@ -397,20 +708,22 @@ extension Schema {
   /// fresh over this relation (see the free `order`).
   internal func order(_ order: Order, in relation: Relation,
                       _ projection: Array<Term>, _ names: Array<String?>,
-                      _ routines: Routines = [:])
+                      _ routines: Routines = [:],
+                      subquery: Subquery = .unsupported)
       throws(SQLError) -> Array<SortKey> {
     try SQLEngine.order(order, projection, names) {
       expression throws(SQLError) in
-      try term(expression, in: relation, routines)
+      try term(expression, in: relation, routines, subquery: subquery)
     }
   }
 
   internal func lower(_ predicate: Predicate, in relation: Relation,
-                      _ routines: Routines = [:])
+                      _ routines: Routines = [:],
+                      subquery: Subquery = .unsupported)
       throws(SQLError) -> Filter {
-    try SQLEngine.lower(predicate) { expression throws(SQLError) in
-      try term(expression, in: relation, routines)
-    }
+    try SQLEngine.lower(predicate, term: { expression throws(SQLError) in
+      try term(expression, in: relation, routines, subquery: subquery)
+    }, subquery: subquery)
   }
 }
 
@@ -751,7 +1064,8 @@ internal struct Scope {
   ///
   /// This is the TYPE-CHECK surface. `derive(_:_:)` is the non-faulting schema
   /// surface, which only DERIVES the nominal output type.
-  internal func validate(_ expression: Expression, _ routines: Routines = [:])
+  internal func validate(_ expression: Expression, _ routines: Routines = [:],
+                         subquery: SubqueryCheck = .unsupported)
       throws(SQLError) -> ValueType {
     switch expression {
     case let .column(column):
@@ -759,19 +1073,20 @@ internal struct Scope {
     case let .literal(literal):
       type(of: literal)
     case let .call(name, arguments):
-      try call(name, over: arguments, routines)
+      try call(name, over: arguments, routines, subquery: subquery)
     case let .aggregate(function, operand, _, filter):
-      try aggregate(function, over: operand, filter: filter, routines)
+      try aggregate(function, over: operand, filter: filter, routines,
+                    subquery: subquery)
     case let .binary(op, lhs, rhs):
-      try arithmetic(op, lhs, rhs, routines)
+      try arithmetic(op, lhs, rhs, routines, subquery: subquery)
     case let .case(whens, otherwise):
-      try conditional(whens, otherwise, routines)
+      try conditional(whens, otherwise, routines, subquery: subquery)
     case let .cast(operand, type):
-      try validate(cast: operand, to: type, routines)
+      try validate(cast: operand, to: type, routines, subquery: subquery)
     case let .coalesce(arguments):
-      try coalesce(arguments, routines)
+      try coalesce(arguments, routines, subquery: subquery)
     case let .nullif(lhs, rhs):
-      try nullif(validate: lhs, rhs, routines)
+      try nullif(validate: lhs, rhs, routines, subquery: subquery)
     }
   }
 
@@ -796,11 +1111,12 @@ internal struct Scope {
   /// integer, exactly as a `CASE` omits a skipped branch's result type. An
   /// undecidable argument (`nil`) may be selected, so its type is merged and
   /// the walk continues.
-  private func coalesce(_ arguments: Array<Expression>, _ routines: Routines)
+  private func coalesce(_ arguments: Array<Expression>, _ routines: Routines,
+                        subquery: SubqueryCheck = .unsupported)
       throws(SQLError) -> ValueType {
     var type: ValueType?
     for argument in arguments {
-      let next = try validate(argument, routines)
+      let next = try validate(argument, routines, subquery: subquery)
       if case .some(.null) = constant(argument, routines) {
         // A constant NULL is validated (for its errors) but skipped: it can
         // never be returned, so its type must not shape the column.
@@ -823,9 +1139,11 @@ internal struct Scope {
   /// its own errors (an unknown column, a bad call) but does not shape the
   /// type.
   private func nullif(validate lhs: Expression, _ rhs: Expression,
-                      _ routines: Routines) throws(SQLError) -> ValueType {
-    let type = try validate(lhs, routines)
-    _ = try validate(rhs, routines)
+                      _ routines: Routines,
+                      subquery: SubqueryCheck = .unsupported)
+      throws(SQLError) -> ValueType {
+    let type = try validate(lhs, routines, subquery: subquery)
+    _ = try validate(rhs, routines, subquery: subquery)
     return type
   }
 
@@ -856,8 +1174,10 @@ internal struct Scope {
   /// NON-constant operand, whose value is unknown at validation, falls to the
   /// structural pair check.
   private func validate(cast operand: Expression, to type: ValueType,
-                        _ routines: Routines) throws(SQLError) -> ValueType {
-    let source = try validate(operand, routines)
+                        _ routines: Routines,
+                        subquery: SubqueryCheck = .unsupported)
+      throws(SQLError) -> ValueType {
+    let source = try validate(operand, routines, subquery: subquery)
     // A constant operand casts to one value only, so its trial cast is the
     // whole decision: it ALLOWS a folded NULL to any target and REJECTS a
     // spelling that always faults (`CAST('abc' AS INTEGER)`). A non-constant
@@ -894,7 +1214,8 @@ internal struct Scope {
   /// 1`) still faults. When no branch is reachable the run yields NULL, typed
   /// `.integer` (the schema default), with no result to validate.
   private func conditional(_ whens: Array<When>, _ otherwise: Expression?,
-                           _ routines: Routines)
+                           _ routines: Routines,
+                           subquery: SubqueryCheck = .unsupported)
       throws(SQLError) -> ValueType {
     var results = Array<Expression>()
     var decided = false
@@ -903,7 +1224,7 @@ internal struct Scope {
       // validate its operands; a constant-FALSE guard's result is unreachable
       // (skip it), a constant-TRUE one is reachable but makes every LATER branch
       // unreachable — so keep the earlier results and this one, then stop.
-      try check(branch.when, routines)
+      try check(branch.when, routines, subquery: subquery)
       switch constant(branch.when, routines) {
       case false: continue
       case true: results.append(branch.then); decided = true
@@ -913,9 +1234,9 @@ internal struct Scope {
     }
     if !decided, let otherwise { results.append(otherwise) }
     guard !results.isEmpty else { return .integer }
-    var type = try validate(results[0], routines)
+    var type = try validate(results[0], routines, subquery: subquery)
     for result in results.dropFirst() {
-      let next = try validate(result, routines)
+      let next = try validate(result, routines, subquery: subquery)
       guard let unified = type.unified(with: next) else {
         throw .operand("CASE results have irreconcilable types")
       }
@@ -941,7 +1262,8 @@ internal struct Scope {
   /// its return type over an un-evaluable argument `compile` resolved but never
   /// type-checked.
   private func call(_ name: String, over arguments: Array<Expression>,
-                    _ routines: Routines)
+                    _ routines: Routines,
+                    subquery: SubqueryCheck = .unsupported)
       throws(SQLError) -> ValueType {
     guard let routine = routines[name] else { throw .function(name) }
     guard (routine.minimum ... routine.parameters.count)
@@ -952,7 +1274,7 @@ internal struct Scope {
       throw .argument("\(name) takes \(arity) arguments")
     }
     for (argument, expected) in zip(arguments, routine.parameters) {
-      let type = try validate(argument, routines)
+      let type = try validate(argument, routines, subquery: subquery)
       guard type == expected else {
         throw .argument("\(name) requires \(expected.domain) arguments")
       }
@@ -970,7 +1292,8 @@ internal struct Scope {
   /// advertising `AVG(Name)` as a double or `SUM(Name)` as text for a query
   /// that cannot fold its rows.
   private func aggregate(_ function: Aggregate, over operand: Aggregand,
-                         filter: Predicate?, _ routines: Routines)
+                         filter: Predicate?, _ routines: Routines,
+                         subquery: SubqueryCheck = .unsupported)
       throws(SQLError) -> ValueType {
     // A `FILTER (WHERE …)` is a per-row gate, so it type-checks as an ordinary
     // predicate — its columns resolve and its comparisons are well-typed — and
@@ -980,7 +1303,7 @@ internal struct Scope {
       guard !filter.aggregated else {
         throw .unsupported("an aggregate is not allowed in a FILTER")
       }
-      try check(filter, routines)
+      try check(filter, routines, subquery: subquery)
       // A FILTER that STATICALLY cannot admit a row makes the operand
       // unreachable: the executor gates on a definite TRUE (a FALSE or UNKNOWN
       // row is skipped, and the argument is evaluated only AFTER the gate), so
@@ -1002,20 +1325,20 @@ internal struct Scope {
       // validate the operand (`COUNT(*)` has none); the result is always an
       // integer count.
       if case let .expression(argument) = operand {
-        _ = try validate(argument, routines)
+        _ = try validate(argument, routines, subquery: subquery)
       }
       return .integer
     case .min, .max:
       switch operand {
       case .star: return .integer
       case let .expression(argument):
-        return try validate(argument, routines)
+        return try validate(argument, routines, subquery: subquery)
       }
     case .sum, .avg:
       let type: ValueType = switch operand {
       case .star: .integer
       case let .expression(argument):
-        try validate(argument, routines)
+        try validate(argument, routines, subquery: subquery)
       }
       if !type.numeric { throw .operand("operands must be numeric") }
       return function == .avg ? .double : type
@@ -1087,10 +1410,11 @@ internal struct Scope {
   /// would rather than advertise a header no row can produce.
   private func arithmetic(_ op: Arithmetic, _ lhs: Expression,
                           _ rhs: Expression,
-                          _ routines: Routines)
+                          _ routines: Routines,
+                          subquery: SubqueryCheck = .unsupported)
       throws(SQLError) -> ValueType {
-    let left = try validate(lhs, routines)
-    let right = try validate(rhs, routines)
+    let left = try validate(lhs, routines, subquery: subquery)
+    let right = try validate(rhs, routines, subquery: subquery)
     if case .concatenate = op {
       // Both operands are validated above for their OWN errors. `||` yields
       // text and needs two text operands — UNLESS one folds to a static NULL,
@@ -1155,19 +1479,33 @@ internal struct Scope {
   /// not type-checked — `WHERE 1 = 0 AND Name + 1 = 2` runs, so its schema
   /// resolves rather than faulting on the unreachable `Name + 1`.
   func check(_ predicate: Predicate,
-             _ routines: Routines = [:])
+             _ routines: Routines = [:],
+             subquery: SubqueryCheck = .unsupported)
       throws(SQLError) {
     switch predicate {
     case let .comparison(left, _, right):
-      _ = try validate(left, routines)
-      _ = try validate(right, routines)
+      _ = try validate(left, routines, subquery: subquery)
+      _ = try validate(right, routines, subquery: subquery)
+    case let .exists(query, _):
+      // Validate the inner UNCORRELATED query as the run's lowering does — it
+      // resolves and type-checks against the enclosing catalog, so a bad column
+      // or routine inside it faults at validation, matching what a run rejects.
+      try subquery.validate(query)
+    case let .within(operand, query, _):
+      // Validate the operand AND the inner query, and enforce the single-column
+      // arity the lowering does (`SQLError.arity`), so schema validation
+      // matches execution — the recurring lesson that the two must not diverge.
+      _ = try validate(operand, routines, subquery: subquery)
+      try subquery.validate(query)
+      let width = try subquery.width(query)
+      guard width == 1 else { throw .arity(1, width) }
     case .bound:
       // `left op :parameter` with no binding — the schema default `[:]` —
       // yields UNKNOWN without evaluating the left term, so a run just produces
       // no rows; schema validation has no bindings, so it does not evaluate it.
       break
     case let .null(operand, _):
-      _ = try validate(operand, routines)
+      _ = try validate(operand, routines, subquery: subquery)
     case let .membership(operand, values, _):
       // `x IN (v, …)` lowers to `x = v OR …`, so type it as those comparisons:
       // validate the operand and each value for real errors (unknown column,
@@ -1192,9 +1530,9 @@ internal struct Scope {
       guard !values.isEmpty else {
         throw .unsupported("IN requires a non-empty value list")
       }
-      _ = try validate(operand, routines)
+      _ = try validate(operand, routines, subquery: subquery)
       _ = try membership(of: values, each: { value throws(SQLError) in
-        _ = try validate(value, routines)
+        _ = try validate(value, routines, subquery: subquery)
       }, equality: { value throws(SQLError) in
         matched(operand, value, routines)
       })
@@ -1204,10 +1542,10 @@ internal struct Scope {
       // rejected — the run yields a definite FALSE via `Row.like` without
       // faulting (the cross-kind rule), and the schema check must accept what
       // the run accepts, as the `IN` cross-kind element does.
-      _ = try validate(operand, routines)
-      try validate(pattern, routines)
+      _ = try validate(operand, routines, subquery: subquery)
+      try validate(pattern, routines, subquery: subquery)
       if let escape {
-        try validate(escape, routines)
+        try validate(escape, routines, subquery: subquery)
         try reject(escape, routines)
       }
     case let .between(test, lower, upper, _):
@@ -1225,8 +1563,8 @@ internal struct Scope {
       // validated — `0 BETWEEN 1 AND (1 / 0)` type-checks, the lower `0 >= 1`
       // FALSE settling the row before the `1 / 0` upper is reached, exactly as
       // an `AND`'s constant-false left leaves its right unchecked.
-      _ = try validate(test, routines)
-      try validate(lower, routines)
+      _ = try validate(test, routines, subquery: subquery)
+      try validate(lower, routines, subquery: subquery)
       let settled = {
         guard let value = constant(test, routines),
             let low = constant(lower, routines) else {
@@ -1234,7 +1572,7 @@ internal struct Scope {
         }
         return matches(value, .geq, low) == false
       }()
-      if !settled { try validate(upper, routines) }
+      if !settled { try validate(upper, routines, subquery: subquery) }
     case let .distinct(lhs, rhs, _):
       // `a IS [NOT] DISTINCT FROM b` compares both operands, so validate the
       // two for real errors (an unknown column, a bad call). BOTH are always
@@ -1243,21 +1581,25 @@ internal struct Scope {
       // rejected: the run's `distinct` treats it as DISTINCT without faulting
       // (as an `IN` element does), so the schema check accepts what the run
       // accepts.
-      _ = try validate(lhs, routines)
-      _ = try validate(rhs, routines)
+      _ = try validate(lhs, routines, subquery: subquery)
+      _ = try validate(rhs, routines, subquery: subquery)
     case let .truth(inner, _, _):
       // `p IS [NOT] <truth value>` validates its inner boolean predicate for
       // real errors; the truth mapping cannot itself fault, so it adds no
       // further check.
-      try check(inner, routines)
+      try check(inner, routines, subquery: subquery)
     case let .and(lhs, rhs):
-      try check(lhs, routines)
-      if constant(lhs, routines) != false { try check(rhs, routines) }
+      try check(lhs, routines, subquery: subquery)
+      if constant(lhs, routines) != false {
+        try check(rhs, routines, subquery: subquery)
+      }
     case let .or(lhs, rhs):
-      try check(lhs, routines)
-      if constant(lhs, routines) != true { try check(rhs, routines) }
+      try check(lhs, routines, subquery: subquery)
+      if constant(lhs, routines) != true {
+        try check(rhs, routines, subquery: subquery)
+      }
     case let .not(operand):
-      try check(operand, routines)
+      try check(operand, routines, subquery: subquery)
     }
   }
 
@@ -1265,10 +1607,11 @@ internal struct Scope {
   /// validation: an expression is validated (`validate`), a `:parameter` reads
   /// nothing at compile time (its value arrives from the bindings at run time),
   /// so it needs no check, as a `Predicate.bound` parameter needs none.
-  private func validate(_ operand: Predicate.Operand, _ routines: Routines)
+  private func validate(_ operand: Predicate.Operand, _ routines: Routines,
+                        subquery: SubqueryCheck = .unsupported)
       throws(SQLError) {
     if case let .expression(expression) = operand {
-      _ = try validate(expression, routines)
+      _ = try validate(expression, routines, subquery: subquery)
     }
   }
 
@@ -1560,6 +1903,12 @@ internal struct Scope {
       return nil
     case .bound:
       return nil
+    case .exists, .within:
+      // A subquery predicate is not a ROW-INDEPENDENT constant fold — its truth
+      // is decided by the materialised result at lowering time, not by folding
+      // operands here — so it never folds statically; treat it as undecided
+      // (per-row) so a reachability walk neither prunes nor faults on it.
+      return nil
     }
   }
 
@@ -1598,6 +1947,10 @@ internal struct Scope {
       settled(operand, routines)
     case .bound:
       false
+    case .exists, .within:
+      // A subquery predicate's truth comes from a materialised result, not from
+      // folding constant operands, so it is never settled at compile time.
+      false
     }
   }
 
@@ -1613,6 +1966,13 @@ internal struct Scope {
     switch predicate {
     case .null, .distinct, .truth:
       true
+    // `EXISTS` is DEFINITELY two-valued — a non-empty test never yields UNKNOWN
+    // — so it is definite, while `IN (Q)` is three-valued over NULLs (a NULL
+    // element or operand makes an unmatched test UNKNOWN), so it is not.
+    case .exists:
+      true
+    case .within:
+      false
     case let .and(lhs, rhs), let .or(lhs, rhs):
       definite(lhs) && definite(rhs)
     case let .not(operand):
@@ -1679,40 +2039,49 @@ internal struct Scope {
   /// a binary's operands and a call's arguments to reach an aggregate, then
   /// validates it (its operand included); a bare column or literal has none.
   func aggregates(in expression: Expression,
-                  _ routines: Routines = [:])
+                  _ routines: Routines = [:],
+                  subquery: SubqueryCheck = .unsupported)
       throws(SQLError) {
     switch expression {
     case .column, .literal:
       break
     case let .aggregate(function, operand, _, filter):
-      _ = try aggregate(function, over: operand, filter: filter, routines)
+      _ = try aggregate(function, over: operand, filter: filter, routines,
+                        subquery: subquery)
     case let .call(_, arguments):
-      for argument in arguments { try aggregates(in: argument, routines) }
+      for argument in arguments {
+        try aggregates(in: argument, routines, subquery: subquery)
+      }
     case let .binary(_, lhs, rhs):
-      try aggregates(in: lhs, routines)
-      try aggregates(in: rhs, routines)
+      try aggregates(in: lhs, routines, subquery: subquery)
+      try aggregates(in: rhs, routines, subquery: subquery)
     case let .case(whens, otherwise):
       for branch in whens {
-        try aggregates(in: branch.when, routines)
-        try aggregates(in: branch.then, routines)
+        try aggregates(in: branch.when, routines, subquery: subquery)
+        try aggregates(in: branch.then, routines, subquery: subquery)
       }
-      if let otherwise { try aggregates(in: otherwise, routines) }
+      if let otherwise {
+        try aggregates(in: otherwise, routines, subquery: subquery)
+      }
     case let .cast(operand, _):
-      try aggregates(in: operand, routines)
+      try aggregates(in: operand, routines, subquery: subquery)
     case let .coalesce(arguments):
-      for argument in arguments { try aggregates(in: argument, routines) }
+      for argument in arguments {
+        try aggregates(in: argument, routines, subquery: subquery)
+      }
     case let .nullif(lhs, rhs):
-      try aggregates(in: lhs, routines)
-      try aggregates(in: rhs, routines)
+      try aggregates(in: lhs, routines, subquery: subquery)
+      try aggregates(in: rhs, routines, subquery: subquery)
     }
   }
 
   /// Validates the aggregate sub-expressions of a `LIKE` pattern or escape
   /// `operand` — an expression's own, none in a `:parameter`.
-  func aggregates(in operand: Predicate.Operand, _ routines: Routines = [:])
+  func aggregates(in operand: Predicate.Operand, _ routines: Routines = [:],
+                  subquery: SubqueryCheck = .unsupported)
       throws(SQLError) {
     if case let .expression(expression) = operand {
-      try aggregates(in: expression, routines)
+      try aggregates(in: expression, routines, subquery: subquery)
     }
   }
 
@@ -1722,37 +2091,82 @@ internal struct Scope {
   /// short-circuit skips. It walks EVERY arm (unlike `check`), reaching an
   /// aggregate through a comparison's operands and `AND`/`OR`/`NOT`.
   func aggregates(in predicate: Predicate,
-                  _ routines: Routines = [:])
+                  _ routines: Routines = [:],
+                  subquery: SubqueryCheck = .unsupported)
       throws(SQLError) {
     switch predicate {
     case let .comparison(left, _, right):
-      try aggregates(in: left, routines)
-      try aggregates(in: right, routines)
+      try aggregates(in: left, routines, subquery: subquery)
+      try aggregates(in: right, routines, subquery: subquery)
     case let .bound(left, _, _):
-      try aggregates(in: left, routines)
+      try aggregates(in: left, routines, subquery: subquery)
     case let .null(operand, _):
-      try aggregates(in: operand, routines)
+      try aggregates(in: operand, routines, subquery: subquery)
     case let .membership(operand, values, _):
-      try aggregates(in: operand, routines)
-      for value in values { try aggregates(in: value, routines) }
+      try aggregates(in: operand, routines, subquery: subquery)
+      for value in values {
+        try aggregates(in: value, routines, subquery: subquery)
+      }
+    case .exists:
+      // A subquery is its OWN scope — any aggregate inside it folds over its
+      // group, not the enclosing one — so an `EXISTS (Q)` contributes no outer
+      // aggregate to collect.
+      break
+    case let .within(operand, _, _):
+      // Only the OUTER operand may hold an enclosing-group aggregate; the
+      // subquery is its own scope, so it is not walked here.
+      try aggregates(in: operand, routines, subquery: subquery)
     case let .like(operand, pattern, escape, _):
-      try aggregates(in: operand, routines)
-      try aggregates(in: pattern, routines)
-      if let escape { try aggregates(in: escape, routines) }
+      try aggregates(in: operand, routines, subquery: subquery)
+      try aggregates(in: pattern, routines, subquery: subquery)
+      if let escape {
+        try aggregates(in: escape, routines, subquery: subquery)
+      }
     case let .between(test, lower, upper, _):
-      try aggregates(in: test, routines)
-      try aggregates(in: lower, routines)
-      try aggregates(in: upper, routines)
+      try aggregates(in: test, routines, subquery: subquery)
+      try aggregates(in: lower, routines, subquery: subquery)
+      try aggregates(in: upper, routines, subquery: subquery)
     case let .distinct(lhs, rhs, _):
-      try aggregates(in: lhs, routines)
-      try aggregates(in: rhs, routines)
+      try aggregates(in: lhs, routines, subquery: subquery)
+      try aggregates(in: rhs, routines, subquery: subquery)
     case let .truth(inner, _, _):
-      try aggregates(in: inner, routines)
+      try aggregates(in: inner, routines, subquery: subquery)
     case let .and(lhs, rhs), let .or(lhs, rhs):
-      try aggregates(in: lhs, routines)
-      try aggregates(in: rhs, routines)
+      try aggregates(in: lhs, routines, subquery: subquery)
+      try aggregates(in: rhs, routines, subquery: subquery)
     case let .not(operand):
-      try aggregates(in: operand, routines)
+      try aggregates(in: operand, routines, subquery: subquery)
+    }
+  }
+
+  /// Validates a whole-result aggregate's PROJECTION or SORT `expression` over
+  /// the single empty group a constant-false `WHERE` leaves — the empty-fold's
+  /// per-expression check, dispatching on whether the expression nests a
+  /// subquery.
+  ///
+  /// A subquery-FREE expression is precisely EMPTY-FOLDED (`empty`): its value
+  /// over the empty group is evaluated exactly as a run does, pruning a
+  /// statically-decided `CASE` branch (a constant-false guard's arm never
+  /// folds, so it cannot fault) — the precise reachability a false-`WHERE`
+  /// whole-result aggregate gives its projection.
+  ///
+  /// An expression that NESTS a subquery cannot be folded: the empty group
+  /// carries no catalog, so a `CASE WHEN EXISTS (Q) …` guard folds UNKNOWN and
+  /// its arms would be pruned — but the subquery is row-independent and may be
+  /// TRUE at RUN, RUNNING the guarded arm. So VALIDATE it as a run would
+  /// (`validate`), which validates BOTH arms of a subquery-guarded `CASE` (a
+  /// `nil`-constant guard leaves both reachable), surfacing the fault the run
+  /// raises — `SELECT CASE WHEN EXISTS (Q) THEN 1 / 0 … WHERE 1 = 0` faults
+  /// `.divide`, matching a run that keeps the empty group and evaluates the
+  /// THEN arm. This mirrors the `having.subquery` carve-out, extended to
+  /// projection and sort expressions.
+  func fold(_ expression: Expression, _ routines: Routines = [:],
+            subquery: SubqueryCheck = .unsupported)
+      throws(SQLError) {
+    if expression.subquery {
+      _ = try validate(expression, routines, subquery: subquery)
+    } else {
+      _ = try empty(expression, routines)
     }
   }
 
@@ -1960,6 +2374,12 @@ internal struct Scope {
       return or(left, try empty(rhs, routines))
     case let .not(operand):
       return try empty(operand, routines).map { !$0 }
+    case .exists, .within:
+      // The whole-result empty-group fold carries no catalog, so it cannot
+      // materialise a subquery to decide the predicate — it reads UNKNOWN,
+      // dropping the lone empty group, the conservative outcome for the rare
+      // `HAVING <subquery predicate>` over a constant-false `WHERE`.
+      return nil
     }
   }
 
@@ -1994,7 +2414,8 @@ internal struct Scope {
   /// bare-column list as `.slot` terms at their combined ordinals, an expression
   /// list as lowered terms — in source order.
   internal func terms(_ projection: Projection,
-                      _ routines: Routines = [:]) throws(SQLError)
+                      _ routines: Routines = [:],
+                      subquery: Subquery = .unsupported) throws(SQLError)
       -> Array<Term> {
     switch projection {
     case .all:
@@ -2018,7 +2439,7 @@ internal struct Scope {
       var terms = Array<Term>()
       terms.reserveCapacity(projected.count)
       for item in projected {
-        try terms.append(term(item.expression, routines))
+        try terms.append(term(item.expression, routines, subquery: subquery))
       }
       return terms
     }
@@ -2026,7 +2447,9 @@ internal struct Scope {
 
   /// Lowers a scalar `expression` to a combined-ordinal `Term`.
   internal func term(_ expression: Expression,
-                     _ routines: Routines = [:]) throws(SQLError) -> Term {
+                     _ routines: Routines = [:],
+                     subquery: Subquery = .unsupported)
+      throws(SQLError) -> Term {
     switch expression {
     case let .column(column):
       return try .slot(ordinal(of: column))
@@ -2036,25 +2459,26 @@ internal struct Scope {
       var lowered = Array<Term>()
       lowered.reserveCapacity(arguments.count)
       for argument in arguments {
-        try lowered.append(term(argument, routines))
+        try lowered.append(term(argument, routines, subquery: subquery))
       }
       // Case-fold the routine name to the identifier rule the lookup uses, so
       // equivalent-case calls lower to an identical term (see the primary
       // `term(_:in:_:)`).
       return .apply(name: name.lowercased(), arguments: lowered)
     case let .binary(op, lhs, rhs):
-      return try .binary(op, term(lhs, routines), term(rhs, routines))
+      return try .binary(op, term(lhs, routines, subquery: subquery),
+                         term(rhs, routines, subquery: subquery))
     case let .case(whens, otherwise):
       // Lower each branch's guard to a combined-ordinal `Filter` and its result
       // to a `Term`, and the `ELSE` to a `Term`, across the join chain.
       var branches = Array<(Filter, Term)>()
       branches.reserveCapacity(whens.count)
       for branch in whens {
-        try branches.append((lower(branch.when, routines),
-                             term(branch.then, routines)))
+        try branches.append((lower(branch.when, routines, subquery: subquery),
+                             term(branch.then, routines, subquery: subquery)))
       }
       let fallback: Term? = if let otherwise {
-        try term(otherwise, routines)
+        try term(otherwise, routines, subquery: subquery)
       } else {
         nil
       }
@@ -2066,7 +2490,7 @@ internal struct Scope {
     case let .cast(operand, type):
       // Lower the operand across the join chain and attach the target type; the
       // executor converts the evaluated value to it (`Value.cast(to:)`).
-      return try .cast(term(operand, routines), type)
+      return try .cast(term(operand, routines, subquery: subquery), type)
     case let .coalesce(arguments):
       // Lower each argument to a combined-ordinal `Term` and hold them in a
       // first-class `Term.coalesce` so each is evaluated ONCE; `type` is the
@@ -2074,14 +2498,15 @@ internal struct Scope {
       var elements = Array<Term>()
       elements.reserveCapacity(arguments.count)
       for argument in arguments {
-        try elements.append(term(argument, routines))
+        try elements.append(term(argument, routines, subquery: subquery))
       }
       let type = try derive(expression, routines)
       return .coalesce(elements, type: type)
     case let .nullif(lhs, rhs):
       // Lower both operands to combined-ordinal `Term`s and hold them in a
       // first-class `Term.nullif` so each is evaluated ONCE.
-      return try .nullif(term(lhs, routines), term(rhs, routines))
+      return try .nullif(term(lhs, routines, subquery: subquery),
+                         term(rhs, routines, subquery: subquery))
     case .aggregate:
       // An aggregate has no per-row meaning — it folds over a group — so it may
       // not appear in a `WHERE`, a join `ON`, or a non-aggregate projection.
@@ -2098,11 +2523,12 @@ internal struct Scope {
   /// matching select-list item's `Term` and an ordinary expression key lowers
   /// fresh over the chain (see the free `order`).
   internal func order(_ order: Order, _ projection: Array<Term>,
-                      _ names: Array<String?>, _ routines: Routines = [:])
+                      _ names: Array<String?>, _ routines: Routines = [:],
+                      subquery: Subquery = .unsupported)
       throws(SQLError) -> Array<SortKey> {
     try SQLEngine.order(order, projection, names) {
       expression throws(SQLError) in
-      try term(expression, routines)
+      try term(expression, routines, subquery: subquery)
     }
   }
 
@@ -2150,10 +2576,12 @@ internal struct Scope {
   /// never raises), so an all-equi or otherwise all-safe `ON` still hash-joins
   /// byte-for-byte.
   internal func on(_ predicate: Predicate,
-                   _ routines: Routines = [:]) throws(SQLError) -> Filter {
+                   _ routines: Routines = [:],
+                   subquery: Subquery = .unsupported)
+      throws(SQLError) -> Filter {
     let conjuncts = predicate.conjuncts
     let lowered = try conjuncts.map { conjunct throws(SQLError) in
-      try lower(conjunct, routines)
+      try lower(conjunct, routines, subquery: subquery)
     }
     // An unsafe conjunct anywhere forbids extracting ANY key: a hoisted key
     // both skips a NULL pair before a LATER unsafe conjunct runs and drops a
@@ -2175,10 +2603,12 @@ internal struct Scope {
   /// Lowers the name-addressed AST `predicate` to the engine's `Filter`, each
   /// column reference resolved to a combined ordinal across the chain.
   internal func lower(_ predicate: Predicate,
-                      _ routines: Routines = [:]) throws(SQLError) -> Filter {
-    try SQLEngine.lower(predicate) { expression throws(SQLError) in
-      try term(expression, routines)
-    }
+                      _ routines: Routines = [:],
+                      subquery: Subquery = .unsupported)
+      throws(SQLError) -> Filter {
+    try SQLEngine.lower(predicate, term: { expression throws(SQLError) in
+      try term(expression, routines, subquery: subquery)
+    }, subquery: subquery)
   }
 }
 
@@ -2256,10 +2686,12 @@ internal struct Grouping {
   /// an `Aggregation` — column qualification normalized to a slot — and matched
   /// against the collected aggregations, so `SUM(Amount)` and
   /// `SUM(Sales.Amount)` find the same slot in a single-relation scope.
-  private func slot(of expression: Expression, _ routines: Routines = [:])
+  private func slot(of expression: Expression, _ routines: Routines = [:],
+                    subquery: Subquery = .unsupported)
       throws(SQLError) -> Int? {
     guard case .aggregate = expression else { return nil }
-    let aggregation = try expression.aggregation(scope, routines)
+    let aggregation = try expression.aggregation(scope, routines,
+                                                 subquery: subquery)
     return aggregates.firstIndex(of: aggregation).map { offset + $0 }
   }
 
@@ -2270,9 +2702,11 @@ internal struct Grouping {
   /// slot only when it is a `GROUP BY` key, else it is `SQLError.grouping` — the
   /// standard rule.
   private func term(_ expression: Expression,
-                    _ routines: Routines = [:]) throws(SQLError) -> Term {
+                    _ routines: Routines = [:],
+                    subquery: Subquery = .unsupported)
+      throws(SQLError) -> Term {
     if case .aggregate = expression,
-       let slot = try slot(of: expression, routines) {
+       let slot = try slot(of: expression, routines, subquery: subquery) {
       return .slot(slot)
     }
     switch expression {
@@ -2286,14 +2720,15 @@ internal struct Grouping {
       var lowered = Array<Term>()
       lowered.reserveCapacity(arguments.count)
       for argument in arguments {
-        try lowered.append(term(argument, routines))
+        try lowered.append(term(argument, routines, subquery: subquery))
       }
       // Case-fold the routine name to the identifier rule the lookup uses, so
       // equivalent-case calls lower to an identical term (see the primary
       // `term(_:in:_:)`).
       return .apply(name: name.lowercased(), arguments: lowered)
     case let .binary(op, lhs, rhs):
-      return try .binary(op, term(lhs, routines), term(rhs, routines))
+      return try .binary(op, term(lhs, routines, subquery: subquery),
+                         term(rhs, routines, subquery: subquery))
     case let .case(whens, otherwise):
       // Lower each branch's guard and result, and the `ELSE`, against the
       // grouped slot space — a bare column in any of them must be a `GROUP BY`
@@ -2301,11 +2736,11 @@ internal struct Grouping {
       var branches = Array<(Filter, Term)>()
       branches.reserveCapacity(whens.count)
       for branch in whens {
-        try branches.append((lower(branch.when, routines),
-                             term(branch.then, routines)))
+        try branches.append((lower(branch.when, routines, subquery: subquery),
+                             term(branch.then, routines, subquery: subquery)))
       }
       let fallback: Term? = if let otherwise {
-        try term(otherwise, routines)
+        try term(otherwise, routines, subquery: subquery)
       } else {
         nil
       }
@@ -2317,7 +2752,7 @@ internal struct Grouping {
     case let .cast(operand, type):
       // Lower the operand against the grouped slot space and attach the target
       // type; the executor converts the evaluated value to it.
-      return try .cast(term(operand, routines), type)
+      return try .cast(term(operand, routines, subquery: subquery), type)
     case let .coalesce(arguments):
       // Lower each argument to a grouped-space `Term` and hold them in a
       // first-class `Term.coalesce` so each is evaluated ONCE; `type` is the
@@ -2325,14 +2760,15 @@ internal struct Grouping {
       var elements = Array<Term>()
       elements.reserveCapacity(arguments.count)
       for argument in arguments {
-        try elements.append(term(argument, routines))
+        try elements.append(term(argument, routines, subquery: subquery))
       }
       let type = try scope.derive(expression, routines)
       return .coalesce(elements, type: type)
     case let .nullif(lhs, rhs):
       // Lower both operands to grouped-space `Term`s and hold them in a
       // first-class `Term.nullif` so each is evaluated ONCE.
-      return try .nullif(term(lhs, routines), term(rhs, routines))
+      return try .nullif(term(lhs, routines, subquery: subquery),
+                         term(rhs, routines, subquery: subquery))
     case .aggregate:
       // An aggregate reaches here only when it was not collected — an internal
       // inconsistency, since the query gathers every projection/HAVING aggregate.
@@ -2359,7 +2795,8 @@ internal struct Grouping {
   /// it — the standard alias ordering on an aggregate. A `SELECT *` has no
   /// well-defined meaning over groups (which columns?), so it faults.
   internal mutating func terms(_ projection: Projection,
-                               _ routines: Routines = [:])
+                               _ routines: Routines = [:],
+                               subquery: Subquery = .unsupported)
       throws(SQLError) -> Array<Term> {
     switch projection {
     case .all:
@@ -2368,7 +2805,8 @@ internal struct Grouping {
       var terms = Array<Term>()
       terms.reserveCapacity(columns.count)
       for index in columns.indices {
-        let term = try term(.column(columns[index]), routines)
+        let term = try term(.column(columns[index]), routines,
+                            subquery: subquery)
         terms.append(term)
         record(columns[index].name, index, term)
       }
@@ -2377,7 +2815,8 @@ internal struct Grouping {
       var terms = Array<Term>()
       terms.reserveCapacity(items.count)
       for index in items.indices {
-        let term = try term(items[index].expression, routines)
+        let term = try term(items[index].expression, routines,
+                            subquery: subquery)
         terms.append(term)
         // Record the output name (`Projected.name` — an alias, else a bare
         // column's name) so an `ORDER BY` may name it (the standard alias
@@ -2390,10 +2829,12 @@ internal struct Grouping {
 
   /// Lowers a `HAVING`/predicate to a grouped-space `Filter`.
   internal func lower(_ predicate: Predicate,
-                      _ routines: Routines = [:]) throws(SQLError) -> Filter {
-    try SQLEngine.lower(predicate) { expression throws(SQLError) in
-      try term(expression, routines)
-    }
+                      _ routines: Routines = [:],
+                      subquery: Subquery = .unsupported)
+      throws(SQLError) -> Filter {
+    try SQLEngine.lower(predicate, term: { expression throws(SQLError) in
+      try term(expression, routines, subquery: subquery)
+    }, subquery: subquery)
   }
 
   /// The resolved sort keys an `ORDER BY` lowers to in grouped space, major to
@@ -2426,7 +2867,8 @@ internal struct Grouping {
   /// terms — the ordinal surface the positional keys resolve against; the alias
   /// and `GROUP BY` surfaces are the `aliases` and `keys` `terms` recorded.
   internal func order(_ order: Order, _ projection: Array<Term>,
-                      _ routines: Routines = [:])
+                      _ routines: Routines = [:],
+                      subquery: Subquery = .unsupported)
       throws(SQLError) -> Array<SortKey> {
     var resolved = Array<SortKey>()
     resolved.reserveCapacity(order.keys.count)
@@ -2456,7 +2898,8 @@ internal struct Grouping {
             continue
           }
         }
-        try resolved.append(SortKey(term: term(expression, routines),
+        try resolved.append(SortKey(term: term(expression, routines,
+                                                subquery: subquery),
                                     ascending: key.ascending, column: nil))
       }
     }
@@ -2490,6 +2933,14 @@ extension Filter {
       for element in elements {
         element.references(into: &ordinals)
       }
+    case .exists:
+      // An UNCORRELATED EXISTS reads no outer ordinal — its subquery names no
+      // enclosing column and runs against its own relations.
+      break
+    case let .within(operand, _, _):
+      // Only the outer operand term reads ordinals; the uncorrelated subquery
+      // runs against its own relations.
+      operand.references(into: &ordinals)
     case let .like(operand, pattern, escape, _):
       operand.references(into: &ordinals)
       pattern.references(into: &ordinals)

--- a/Sources/SQLEngine/Token.swift
+++ b/Sources/SQLEngine/Token.swift
@@ -54,6 +54,8 @@ extension Token {
     case null
     case `in`
     case between
+    /// The `EXISTS` keyword introducing an `[NOT] EXISTS (subquery)` predicate.
+    case exists
     case like
     case escape
     /// The `PLACING` keyword separating an `OVERLAY`'s source string from its
@@ -151,6 +153,7 @@ extension Token.Kind {
     case .null: "NULL"
     case .in: "IN"
     case .between: "BETWEEN"
+    case .exists: "EXISTS"
     case .like: "LIKE"
     case .escape: "ESCAPE"
     case .placing: "PLACING"

--- a/Tests/SQLTests/SubqueryTests.swift
+++ b/Tests/SQLTests/SubqueryTests.swift
@@ -1,0 +1,1655 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQLEngine
+
+import SQLTestSupport
+
+// MARK: - Fixture
+
+/// Two relations exercising the uncorrelated `EXISTS`/`IN (subquery)`
+/// predicates: an outer `T` with an integer key `K` that is `NULL` in one row
+/// (so the three-valued corners are reachable), and an inner `S` whose column
+/// `V` holds a `NULL` (so `IN (SELECT V …)` sees a NULL element) and a `Flag`
+/// used to filter the inner query to empty or to non-empty.
+private func fixture() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["Id": .integer, "K": .integer]) {
+      Row(1, 10)
+      Row(2, 20)
+      Row(3, nil)
+      Row(4, 30)
+    }
+    Relation("S", ["V": .integer, "Flag": .integer]) {
+      Row(10, 1)
+      Row(20, 1)
+      Row(99, 0)
+    }
+    // A relation whose single column holds a NULL, for the `IN (…, NULL)`
+    // corners — `V` is `{2, NULL}` when filtered to its first two rows.
+    Relation("N", ["V": .integer]) {
+      Row(2)
+      Row(nil)
+    }
+  }
+}
+
+/// Parses `text` and returns its `Select`, failing on any other shape.
+private func parse(select text: String) throws -> Select {
+  guard case let .select(.select(select)) = try Statement(parsing: text) else {
+    Issue.record("expected a single SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return select
+}
+
+/// Parses `text` to a query, failing on any other statement.
+private func parse(query text: String) throws -> Query {
+  guard case let .select(query) = try Statement(parsing: text) else {
+    Issue.record("expected a SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return query
+}
+
+/// Parses `text` to a `Statement` — the shape `Catalog.run(_:_:)` takes when a
+/// test asserts on invocation side effects rather than on rows alone.
+private func parse(statement text: String) throws -> Statement {
+  try Statement(parsing: text)
+}
+
+// MARK: - Parsing
+
+struct SubqueryParsingTests {
+  @Test func `parses EXISTS over a subquery`() throws {
+    let select =
+        try parse(select: "SELECT Id FROM T WHERE EXISTS (SELECT V FROM S)")
+    let inner = try parse(query: "SELECT V FROM S")
+    #expect(select.predicate == .exists(inner, negated: false))
+  }
+
+  @Test func `parses NOT EXISTS via the negated flag`() throws {
+    let select =
+        try parse(select: "SELECT Id FROM T WHERE NOT EXISTS (SELECT V FROM S)")
+    let inner = try parse(query: "SELECT V FROM S")
+    // `NOT EXISTS` carries the `negated` flag directly rather than wrapping the
+    // predicate in a `.not`.
+    #expect(select.predicate == .exists(inner, negated: true))
+  }
+
+  @Test func `parses IN over a subquery`() throws {
+    let select =
+        try parse(select: "SELECT Id FROM T WHERE K IN (SELECT V FROM S)")
+    let inner = try parse(query: "SELECT V FROM S")
+    #expect(select.predicate == .within(.column("K"), inner, negated: false))
+  }
+
+  @Test func `parses NOT IN over a subquery`() throws {
+    let select =
+        try parse(select: "SELECT Id FROM T WHERE K NOT IN (SELECT V FROM S)")
+    let inner = try parse(query: "SELECT V FROM S")
+    #expect(select.predicate == .within(.column("K"), inner, negated: true))
+  }
+
+  @Test func `IN over a value list still parses as membership`() throws {
+    // The one-token lookahead only takes the subquery arm on a leading SELECT;
+    // an ordinary value list stays a `membership`, unchanged.
+    let select = try parse(select: "SELECT Id FROM T WHERE K IN (10, 20)")
+    #expect(select.predicate
+                == .membership(.column("K"),
+                               [.literal(.integer(10)), .literal(.integer(20))],
+                               negated: false))
+  }
+
+  @Test func `parses IN over a subquery with a WHERE`() throws {
+    let text = "SELECT Id FROM T WHERE K IN (SELECT V FROM S WHERE Flag = 1)"
+    let select = try parse(select: text)
+    let inner = try parse(query: "SELECT V FROM S WHERE Flag = 1")
+    #expect(select.predicate == .within(.column("K"), inner, negated: false))
+  }
+
+  @Test func `parses EXISTS over a UNION subquery`() throws {
+    // A subquery is a full `query`, so it may itself be a `UNION`; `Predicate`
+    // is `indirect`, so it nests the whole `Query`.
+    let text = "SELECT Id FROM T WHERE EXISTS "
+        + "(SELECT V FROM S UNION SELECT V FROM N)"
+    let select = try parse(select: text)
+    let inner = try parse(query: "SELECT V FROM S UNION SELECT V FROM N")
+    #expect(select.predicate == .exists(inner, negated: false))
+  }
+}
+
+// MARK: - EXISTS execution
+
+struct ExistsEvaluationTests {
+  @Test func `EXISTS keeps every row when the subquery is non-empty`() throws {
+    // The subquery yields rows, so `EXISTS` is TRUE for every outer row — the
+    // whole of T survives.
+    try fixture().expect("SELECT Id FROM T WHERE EXISTS (SELECT V FROM S)",
+                         yields: [[1], [2], [3], [4]])
+  }
+
+  @Test func `EXISTS drops every row when the subquery is empty`() throws {
+    // The subquery filters to zero rows, so `EXISTS` is FALSE for every outer
+    // row — none survive.
+    try fixture().expect(
+        "SELECT Id FROM T WHERE EXISTS (SELECT V FROM S WHERE Flag = 9)",
+        yields: [])
+  }
+
+  @Test func `NOT EXISTS is the negation`() throws {
+    // Over the empty subquery, `NOT EXISTS` is TRUE for every row.
+    try fixture().expect(
+        "SELECT Id FROM T WHERE NOT EXISTS (SELECT V FROM S WHERE Flag = 9)",
+        yields: [[1], [2], [3], [4]])
+    // Over the non-empty subquery, `NOT EXISTS` is FALSE for every row.
+    try fixture().expect(
+        "SELECT Id FROM T WHERE NOT EXISTS (SELECT V FROM S)", yields: [])
+  }
+
+  @Test func `EXISTS is two-valued over a NULL-valued subquery`() throws {
+    // The subquery `N` yields a row whose value is NULL, but `EXISTS` tests
+    // cardinality alone — the presence of ANY row is TRUE, never UNKNOWN — so
+    // every outer row survives, including row 3 whose own K is NULL.
+    try fixture().expect("SELECT Id FROM T WHERE EXISTS (SELECT V FROM N)",
+                         yields: [[1], [2], [3], [4]])
+  }
+}
+
+// MARK: - IN (subquery) execution
+
+struct InQueryEvaluationTests {
+  @Test func `IN over a subquery admits a matching value`() throws {
+    // S.V is {10, 20, 99}; T rows with K in that set are 1 (10) and 2 (20).
+    // Row 4's K (30) is absent, row 3's K is NULL (UNKNOWN, dropped).
+    try fixture().expect(
+        "SELECT Id FROM T WHERE K IN (SELECT V FROM S)", yields: [[1], [2]])
+  }
+
+  @Test func `IN over a filtered subquery`() throws {
+    // Filtered to Flag = 1, S.V is {10, 20}; the run matches the same rows.
+    try fixture().expect(
+        "SELECT Id FROM T WHERE K IN (SELECT V FROM S WHERE Flag = 1)",
+        yields: [[1], [2]])
+  }
+
+  @Test func `NOT IN over a subquery admits the complement`() throws {
+    // S filtered to Flag = 1 yields {10, 20} with no NULL, so `NOT IN` is the
+    // plain complement over non-NULL K: row 4 (30). Row 3 (K NULL) is UNKNOWN.
+    try fixture().expect(
+        "SELECT Id FROM T WHERE K NOT IN (SELECT V FROM S WHERE Flag = 1)",
+        yields: [[4]])
+  }
+
+  @Test func `a NULL operand makes IN over a subquery UNKNOWN`() throws {
+    // Row 3's K is NULL, so `NULL IN (SELECT …)` is UNKNOWN, not FALSE — the
+    // row is dropped by IN and by NOT IN alike.
+    try fixture().empty(
+        "SELECT Id FROM T WHERE K IN (SELECT V FROM S WHERE Flag = 1) "
+        + "AND Id = 3")
+    try fixture().empty(
+        "SELECT Id FROM T WHERE K NOT IN (SELECT V FROM S WHERE Flag = 1) "
+        + "AND Id = 3")
+  }
+
+  @Test func `IN over a subquery folds like the value-list IN`() throws {
+    // The subquery yielding {10, 20} matches exactly the value-list IN of the
+    // same values — the two share one three-valued membership core.
+    try fixture().expect(
+        "SELECT Id FROM T WHERE K IN (SELECT V FROM S WHERE Flag = 1)",
+        equals: "SELECT Id FROM T WHERE K IN (10, 20)")
+  }
+}
+
+// MARK: - The NULL corners
+
+struct InQueryNullCornerTests {
+  @Test func `a value present in a NULL-bearing subquery is TRUE`() throws {
+    // N.V is {2, NULL}; `2 IN (SELECT V FROM N)` finds the definite `2` match,
+    // so it is TRUE regardless of the NULL element — the matching row survives.
+    try fixture().expect(
+        "SELECT Id FROM T WHERE 2 IN (SELECT V FROM N) AND Id = 1",
+        yields: [[1]])
+  }
+
+  @Test func `an absent value in a NULL-bearing subquery is UNKNOWN`() throws {
+    // `1 IN (SELECT V FROM N)` is `1 = 2 OR 1 = NULL` — FALSE OR UNKNOWN —
+    // which is UNKNOWN, not FALSE: the row is not admitted (mirrors the
+    // value-list `1 IN (2, NULL)` corner).
+    try fixture().empty(
+        "SELECT Id FROM T WHERE 1 IN (SELECT V FROM N) AND Id = 1")
+  }
+
+  @Test func `NOT IN a NULL-bearing subquery is UNKNOWN for an absent value`()
+      throws {
+    // `1 NOT IN (SELECT V FROM N)` negates that UNKNOWN to UNKNOWN — never TRUE
+    // when a NULL element is present — so the row is dropped, the classic
+    // `1 NOT IN (2, NULL)` trap.
+    try fixture().empty(
+        "SELECT Id FROM T WHERE 1 NOT IN (SELECT V FROM N) AND Id = 1")
+  }
+
+  @Test func `IN over an empty subquery is FALSE`() throws {
+    // An empty subquery has no witness, so `x IN (empty)` is FALSE — no row
+    // survives.
+    try fixture().expect(
+        "SELECT Id FROM T WHERE K IN (SELECT V FROM S WHERE Flag = 9)",
+        yields: [])
+  }
+
+  @Test func `NOT IN over an empty subquery is TRUE`() throws {
+    // `NOT IN (empty)` is the negation of FALSE — TRUE — so every row survives,
+    // including row 3 whose K is NULL (the NULL trap needs a NULL ELEMENT, and
+    // an empty subquery has none).
+    try fixture().expect(
+        "SELECT Id FROM T WHERE K NOT IN (SELECT V FROM S WHERE Flag = 9)",
+        yields: [[1], [2], [3], [4]])
+  }
+
+  @Test func `IN over a NULL-bearing subquery keeps only the definite match`()
+      throws {
+    // `K IN (SELECT V FROM N)` over N.V = {2, NULL}: no outer K equals 2 (K is
+    // {10, 20, NULL, 30}), so every row is either UNKNOWN (a NULL element makes
+    // an unmatched test UNKNOWN, not FALSE) or, for the NULL-K row, UNKNOWN too
+    // — none survives, the three-valued corner over a NULL element.
+    try fixture().empty("SELECT Id FROM T WHERE K IN (SELECT V FROM N)")
+  }
+}
+
+// MARK: - Arity
+
+struct InQueryArityTests {
+  @Test func `IN over a two-column subquery faults with an arity error`()
+      throws {
+    // `IN (Q)` requires `Q` project exactly ONE column; a two-column subquery
+    // is `SQLError.arity`, checked from the compiled width, so it faults even
+    // though S has rows.
+    try fixture().expect(
+        "SELECT Id FROM T WHERE K IN (SELECT V, Flag FROM S)",
+        fails: .arity(1, 2))
+  }
+
+  @Test func `IN over a two-column subquery faults the schema check too`()
+      throws {
+    // The schema path enforces the SAME single-column arity as the run, so
+    // validation matches execution.
+    let query = try parse(
+        query: "SELECT Id FROM T WHERE K IN (SELECT V, Flag FROM S)")
+    let resolve = { () throws -> Array<OutputColumn> in
+      try fixture().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.arity(1, 2)) {
+      try resolve()
+    }
+  }
+}
+
+// MARK: - Type checking
+
+struct SubqueryTypeTests {
+  @Test func `columns validates a query using EXISTS`() throws {
+    let query =
+        try parse(query: "SELECT Id FROM T WHERE EXISTS (SELECT V FROM S)")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+  }
+
+  @Test func `columns validates a query using IN over a subquery`() throws {
+    let query =
+        try parse(query: "SELECT Id FROM T WHERE K IN (SELECT V FROM S)")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+  }
+
+  @Test func `a bad inner column faults the schema check`() throws {
+    // The inner query is type-checked too, so an unknown column inside it
+    // faults validation exactly as a run would reject it.
+    let query = try parse(
+        query: "SELECT Id FROM T WHERE EXISTS (SELECT Missing FROM S)")
+    let resolve = { () throws -> Array<OutputColumn> in
+      try fixture().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.column("Missing")) {
+      try resolve()
+    }
+  }
+
+  @Test func `a bad routine in the inner query faults the schema check`()
+      throws {
+    // An unregistered routine inside the subquery faults validation as the run
+    // would (`SQLError.function`).
+    let query = try parse(
+        query: "SELECT Id FROM T WHERE K IN (SELECT nope(V) FROM S)")
+    let resolve = { () throws -> Array<OutputColumn> in
+      try fixture().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.function("nope")) {
+      try resolve()
+    }
+  }
+
+  @Test func `a bad relation in the inner query faults the run`() throws {
+    // A subquery over a missing relation faults the run exactly as a top-level
+    // query over it would.
+    try fixture().expect(
+        "SELECT Id FROM T WHERE EXISTS (SELECT V FROM Nope)",
+        fails: .relation("Nope"))
+  }
+
+  @Test func `an EXISTS select-list fault is not validated`() throws {
+    // The run of an EXISTS-only occurrence goes through the cardinality probe,
+    // whose constant projection never evaluates the original `1 / 0` select
+    // list — so validation type-checks the PROBED shape and does NOT surface a
+    // `.divide` the run never raises. Validation matches the run: `columns`
+    // returns clean headers and the query runs, admitting every `T` row.
+    let query =
+        try parse(query: "SELECT Id FROM T WHERE EXISTS (SELECT 1 / 0 FROM S)")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+    try fixture().expect(
+        "SELECT Id FROM T WHERE EXISTS (SELECT 1 / 0 FROM S)",
+        yields: [[1], [2], [3], [4]])
+  }
+
+  @Test func `an IN select-list fault is validated`() throws {
+    // An `IN (Q)` reads the select-list column, so the run evaluates it — and
+    // validation type-checks the ORIGINAL shape, surfacing the `.divide` at
+    // BOTH validate and run, unlike the EXISTS probe.
+    let query =
+        try parse(query: "SELECT Id FROM T WHERE K IN (SELECT 1 / 0 FROM S)")
+    let resolve = { () throws -> Array<OutputColumn> in
+      try fixture().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.divide) {
+      try resolve()
+    }
+    try fixture().expect(
+        "SELECT Id FROM T WHERE K IN (SELECT 1 / 0 FROM S)", fails: .divide)
+  }
+
+  @Test func `an EXISTS bad inner relation is still validated`() throws {
+    // The probe RETAINS the subquery's FROM/`WHERE`, so a genuinely-bad inner
+    // relation still faults validation for an EXISTS-only occurrence — only the
+    // select list and sort keys are spared, not the row source.
+    let query =
+        try parse(query: "SELECT Id FROM T WHERE EXISTS (SELECT 1 FROM Nope)")
+    let resolve = { () throws -> Array<OutputColumn> in
+      try fixture().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.relation("Nope")) {
+      try resolve()
+    }
+  }
+}
+
+// MARK: - ORDER BY expression subqueries
+
+struct OrderBySubqueryTests {
+  @Test func `an EXISTS in an ORDER BY expression is materialised`() throws {
+    // S is non-empty, so the `EXISTS` sort key folds to K for every row — the
+    // subquery in the ORDER BY expression must be materialised (once) exactly
+    // as it is in the projection or WHERE. K ascending sorts NULL (row 3)
+    // first, then 10, 20, 30.
+    try fixture().expect(
+        "SELECT Id FROM T "
+        + "ORDER BY CASE WHEN EXISTS (SELECT V FROM S) THEN K ELSE 0 END, Id",
+        yields: [[3], [1], [2], [4]])
+  }
+
+  @Test func `an ORDER BY EXISTS folds like the equivalent inline key`()
+      throws {
+    // With S non-empty the sort key IS K, so ordering on it equals ordering on
+    // K directly — the subquery lowers to the same result the plain key does.
+    try fixture().expect(
+        "SELECT Id FROM T "
+        + "ORDER BY CASE WHEN EXISTS (SELECT V FROM S) THEN K ELSE 0 END, Id",
+        equals: "SELECT Id FROM T ORDER BY K, Id")
+  }
+
+  @Test func `an IN (subquery) in an ORDER BY expression is materialised`()
+      throws {
+    // The ORDER BY key is 0 for rows whose K is IN S.V ({10, 20, 99}) and 1
+    // otherwise — rows 1 (10) and 2 (20) match, rows 3 (NULL) and 4 (30) do
+    // not — so the matched rows sort first, ties broken by Id.
+    try fixture().expect(
+        "SELECT Id FROM T "
+        + "ORDER BY CASE WHEN K IN (SELECT V FROM S) THEN 0 ELSE 1 END, Id",
+        yields: [[1], [2], [3], [4]])
+  }
+
+  @Test func `columns validates an ORDER BY expression subquery`() throws {
+    // The schema path collects and validates the ORDER BY subquery too, so
+    // `columns(of:)` accepts exactly what the run accepts.
+    let query = try parse(query:
+        "SELECT Id FROM T "
+        + "ORDER BY CASE WHEN EXISTS (SELECT V FROM S) THEN K ELSE 0 END")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+  }
+
+  @Test func `a bad ORDER BY subquery column faults the schema check`()
+      throws {
+    // A bad column inside an ORDER BY subquery faults validation exactly as the
+    // run would — the typecheck collects the same positions the run does.
+    let query = try parse(query:
+        "SELECT Id FROM T "
+        + "ORDER BY CASE WHEN EXISTS (SELECT Missing FROM S) THEN K "
+        + "ELSE 0 END")
+    let resolve = { () throws -> Array<OutputColumn> in
+      try fixture().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.column("Missing")) {
+      try resolve()
+    }
+  }
+}
+
+// MARK: - Aggregate argument and FILTER subqueries
+
+struct AggregateSubqueryTests {
+  @Test func `an EXISTS in an aggregate argument is materialised`() throws {
+    // The subquery in the aggregate ARGUMENT must be materialised like any
+    // other projection subquery. S is non-empty, so the CASE folds to K, and
+    // SUM over T's non-NULL K ({10, 20, 30}) is 60.
+    try fixture().expect(
+        "SELECT SUM(CASE WHEN EXISTS (SELECT V FROM S) THEN K ELSE 0 END) "
+        + "FROM T",
+        yields: [[60]])
+  }
+
+  @Test func `an EXISTS in an aggregate FILTER is materialised`() throws {
+    // The subquery in the aggregate FILTER must be materialised too. The
+    // FILTER admits every row (S non-empty), so SUM(K) folds T's non-NULL K to
+    // 60; over the empty subquery it admits none and folds to NULL.
+    try fixture().expect(
+        "SELECT SUM(K) FILTER (WHERE EXISTS (SELECT V FROM S)) FROM T",
+        yields: [[60]])
+    try fixture().expect(
+        "SELECT SUM(K) FILTER (WHERE EXISTS (SELECT V FROM S WHERE Flag = 9)) "
+        + "FROM T",
+        yields: [[nil]])
+  }
+
+  @Test func `an aggregate FILTER subquery folds like the inline predicate`()
+      throws {
+    // A `FILTER (WHERE EXISTS (non-empty))` admits every row, so it equals no
+    // filter at all — the subquery lowers to the same fold the bare SUM does.
+    try fixture().expect(
+        "SELECT SUM(K) FILTER (WHERE EXISTS (SELECT V FROM S)) FROM T",
+        equals: "SELECT SUM(K) FROM T")
+  }
+
+  @Test func `a grouped aggregate argument subquery is materialised`() throws {
+    // Grouped by K, each group's aggregate argument nests the subquery; S
+    // non-empty makes the CASE 1, so each of the four groups counts 1.
+    try fixture().expect(
+        "SELECT K, "
+        + "SUM(CASE WHEN EXISTS (SELECT V FROM S) THEN 1 ELSE 0 END) "
+        + "FROM T GROUP BY K ORDER BY K",
+        yields: [[nil, 1], [10, 1], [20, 1], [30, 1]])
+  }
+
+  @Test func `a grouped ORDER BY aggregate subquery is materialised`() throws {
+    // The grouped ORDER BY sorts on an aggregate whose argument nests the
+    // subquery — neither projected nor in a HAVING — so the grouped resolve
+    // must materialise it (in both the run and the schema path).
+    try fixture().expect(
+        "SELECT K FROM T GROUP BY K "
+        + "ORDER BY SUM(CASE WHEN EXISTS (SELECT V FROM S) THEN 1 ELSE 0 END), "
+        + "K",
+        yields: [[nil], [10], [20], [30]])
+  }
+
+  @Test func `columns validates an aggregate argument subquery`() throws {
+    let query = try parse(query:
+        "SELECT SUM(CASE WHEN EXISTS (SELECT V FROM S) THEN K ELSE 0 END) "
+        + "FROM T")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+  }
+
+  @Test func `columns validates an aggregate FILTER subquery`() throws {
+    let query = try parse(query:
+        "SELECT SUM(K) FILTER (WHERE EXISTS (SELECT V FROM S)) FROM T")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+  }
+
+  @Test func `columns validates a grouped ORDER BY aggregate subquery`()
+      throws {
+    let query = try parse(query:
+        "SELECT K FROM T GROUP BY K "
+        + "ORDER BY SUM(CASE WHEN EXISTS (SELECT V FROM S) THEN 1 ELSE 0 END), "
+        + "K")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+  }
+
+  @Test func `a bad aggregate FILTER subquery column faults the check`()
+      throws {
+    // A bad column inside an aggregate FILTER subquery faults validation as the
+    // run would — the typecheck descends into the FILTER exactly as the run
+    // materialiser does.
+    let query = try parse(query:
+        "SELECT SUM(K) FILTER (WHERE EXISTS (SELECT Missing FROM S)) FROM T")
+    let resolve = { () throws -> Array<OutputColumn> in
+      try fixture().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.column("Missing")) {
+      try resolve()
+    }
+  }
+}
+
+// MARK: - Deferred execution
+
+/// A shared call counter a stateful routine increments — a tiny
+/// `@unchecked Sendable` box over a mutable count, so a `NOT DETERMINISTIC`
+/// routine records how many times a run invoked it. The engine evaluates a
+/// query on one thread, so the box needs no lock.
+private final class Counter: @unchecked Sendable {
+  private(set) var count = 0
+
+  func next() -> Int {
+    count += 1
+    return count
+  }
+}
+
+/// A subquery executes at RUN time, not during `compile` — so a SCHEMA-ONLY
+/// path (`columns(of:)`) opens NO cursor and runs no inner query, and a run
+/// materialises each UNCORRELATED subquery at most ONCE.
+///
+/// This is the architectural fix: PR-1 materialised subqueries eagerly in
+/// `compile`, so asking for the headers of a query nesting an
+/// `EXISTS`/`IN (subquery)` scanned the inner relation — surfacing data-
+/// dependent errors before the query ever ran. Execution now defers to `run`.
+struct SubqueryDeferralTests {
+  /// A routine registry whose `tick()` counts its invocations, over the
+  /// standard prelude so the ordinary comparisons still resolve.
+  private func routines(_ counter: Counter) throws -> Routines {
+    try Routines()
+        .registering("tick", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+  }
+
+  @Test func `columns does not execute an EXISTS subquery`() throws {
+    // Asking for the result headers must NOT run the inner query: the schema
+    // path shares `compile`'s lowering, which now carries the subquery as data
+    // rather than running it. The counting `tick()` inside the subquery is
+    // never invoked, so the counter stays at 0 — proving compile opens no
+    // cursor on `S`.
+    let counter = Counter()
+    let query = try parse(
+        query: "SELECT Id FROM T WHERE EXISTS (SELECT tick() FROM S)")
+    let columns =
+        try fixture().columns(of: query, routines: routines(counter),
+                              validate: true)
+    #expect(columns.count == 1)
+    #expect(counter.count == 0)
+  }
+
+  @Test func `columns defers a select-list fault an EXISTS probe skips`()
+      throws {
+    // The subquery's select list divides by a NON-constant zero (`Flag - 1`,
+    // which is 0 for S's two `Flag = 1` rows), but it is used ONLY by `EXISTS`,
+    // which needs cardinality — not the projected value. `columns(of:)` returns
+    // the headers WITHOUT triggering the divide (the schema path opens no
+    // cursor), and the RUN materialises the occurrence as a cardinality PROBE
+    // that never evaluates the select list, so it does NOT fault either:
+    // `EXISTS` over non-empty `S` is TRUE, every row of `T` is admitted.
+    let query = try parse(
+        query: "SELECT Id FROM T WHERE EXISTS (SELECT 1 / (Flag - 1) FROM S)")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+    // The run does NOT surface the divide — the EXISTS probe never evaluates
+    // `1 / (Flag - 1)` — so every outer row is admitted (S is non-empty).
+    try fixture().expect(
+        "SELECT Id FROM T WHERE EXISTS (SELECT 1 / (Flag - 1) FROM S)",
+        yields: [[1], [2], [3], [4]])
+  }
+
+  @Test func `columns does not execute an IN subquery`() throws {
+    // The `IN (subquery)` schema path is cursor-free too: its single-column
+    // arity is decided from the compiled width, never by running the inner
+    // query, so `tick()` stays uninvoked.
+    let counter = Counter()
+    let query = try parse(
+        query: "SELECT Id FROM T WHERE K IN (SELECT tick() FROM S)")
+    let columns =
+        try fixture().columns(of: query, routines: routines(counter),
+                              validate: true)
+    #expect(columns.count == 1)
+    #expect(counter.count == 0)
+  }
+
+  @Test func `an EXISTS subquery probes cardinality without its select list`()
+      throws {
+    // The subquery is used ONLY by `EXISTS`, which needs cardinality — not the
+    // projected value — so it materialises as a PROBE that never evaluates the
+    // select list. `tick()` sits in the select list, so the probe never invokes
+    // it: the counter stays 0 (not 3, not 12), and
+    // `EXISTS` over non-empty `S` is still TRUE, admitting every row of `T`.
+    let counter = Counter()
+    let statement =
+        try parse(statement:
+            "SELECT Id FROM T WHERE EXISTS (SELECT tick() FROM S)")
+    let rows = try fixture().run(statement, routines(counter))
+    let expected: Array<Array<Value>> =
+        [[.integer(1)], [.integer(2)], [.integer(3)], [.integer(4)]]
+    #expect(rows == expected)
+    #expect(counter.count == 0)
+  }
+
+  @Test func `an IN subquery runs exactly once per outer-query run`() throws {
+    // Likewise `IN (subquery)`: the single materialised column is computed once
+    // and folded against each outer row, so `tick()` runs once per S row (3),
+    // not once per (outer row × S row).
+    let counter = Counter()
+    let statement =
+        try parse(statement:
+            "SELECT Id FROM T WHERE K IN (SELECT tick() FROM S)")
+    _ = try fixture().run(statement, routines(counter))
+    #expect(counter.count == 3)
+  }
+
+  @Test func `a short-circuited subquery still materialises (follow-up)`()
+      throws {
+    // KNOWN LIMITATION of this slice: subqueries materialise at the START of a
+    // run, so one in an arm an `AND`/`OR` short-circuit would never reach STILL
+    // executes. `1 = 0 AND EXISTS (…)` is statically FALSE, yet the subquery is
+    // materialised up front — here as an EXISTS cardinality PROBE, which never
+    // evaluates the select-list `tick()`, so the counter stays 0. Per-arm
+    // laziness — threading a runner to the evaluation site so an unreached arm
+    // skips its subquery — is a follow-up; the once-per-run materialisation
+    // this slice lands does not depend on it. This test PINS the current
+    // behaviour so the follow-up flips it deliberately.
+    let counter = Counter()
+    let statement =
+        try parse(statement:
+            "SELECT Id FROM T WHERE 1 = 0 AND EXISTS (SELECT tick() FROM S)")
+    let rows = try fixture().run(statement, routines(counter))
+    #expect(rows.isEmpty)
+    #expect(counter.count == 0)
+  }
+}
+
+// MARK: - EXISTS cardinality probe
+
+/// An `EXISTS (Q)` occurrence is materialised as a cardinality PROBE — the row
+/// source is tested for ANY row WITHOUT evaluating the select list or sort
+/// keys, honouring the subquery's original `OFFSET`/`FETCH` — while an `IN (Q)`
+/// occurrence materialises its single column of values. So a fault or a per-row
+/// side effect that lives in an EXISTS subquery's SELECT LIST never fires, but
+/// an `IN`'s column is still read.
+struct ExistsProbeTests {
+  private func fixture() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["Id": .integer, "K": .integer]) {
+        Row(1, 10)
+        Row(2, 20)
+      }
+      Relation("S", ["V": .integer, "Flag": .integer]) {
+        Row(10, 1)
+        Row(20, 1)
+        Row(99, 0)
+      }
+    }
+  }
+
+  @Test func `EXISTS over a dividing select list is safe when non-empty`()
+      throws {
+    // `SELECT 1 / 0 FROM S` divides by a CONSTANT zero — a run of its select
+    // list would fault `.divide`. Used by `EXISTS`, it materialises as a probe
+    // that never evaluates the select list, so `EXISTS` over the non-empty `S`
+    // is TRUE with NO `.divide` — every row of `T` is admitted.
+    try fixture().expect("SELECT Id FROM T WHERE EXISTS (SELECT 1 / 0 FROM S)",
+                         yields: [[1], [2]])
+  }
+
+  @Test func `EXISTS over an empty source is FALSE`() throws {
+    // The probe over an empty row source yields no row, so `EXISTS` is FALSE —
+    // every outer row is dropped. `Flag = 9` matches no `S` row.
+    try fixture().expect(
+        "SELECT Id FROM T WHERE EXISTS (SELECT 1 / 0 FROM S WHERE Flag = 9)",
+        yields: [])
+  }
+
+  @Test func `NOT EXISTS over a dividing select list negates without faulting`()
+      throws {
+    // `NOT EXISTS` over the non-empty `S` is FALSE — still no `.divide`, since
+    // the probe skips the select list — so every outer row is dropped.
+    try fixture().expect(
+        "SELECT Id FROM T WHERE NOT EXISTS (SELECT 1 / 0 FROM S)",
+        yields: [])
+  }
+
+  @Test func `IN still evaluates its subquery column`() throws {
+    // An `IN (Q)` needs the column of VALUES, so its select list IS evaluated —
+    // it is NOT probed. `S.V` is {10, 20, 99}, so the outer rows whose `K` is
+    // in that set survive (both `T` rows).
+    try fixture().expect("SELECT Id FROM T WHERE K IN (SELECT V FROM S)",
+                         yields: [[1], [2]])
+  }
+
+  @Test func `IN over a dividing select list still faults`() throws {
+    // Because `IN` reads the column, a dividing select list DOES fault — the
+    // opposite of the `EXISTS` probe — proving the two occurrences materialise
+    // differently.
+    try fixture().expect("SELECT Id FROM T WHERE K IN (SELECT 1 / 0 FROM S)",
+                         fails: .divide)
+  }
+
+  @Test func `EXISTS over a FROM-less SELECT is TRUE`() throws {
+    // A FROM-less `SELECT 1` yields exactly one row and cannot carry a limit,
+    // so its probe is a limit-free `SELECT <constant>` — it compiles (a
+    // FROM-less select with a limit would be rejected) and yields one row, so
+    // `EXISTS` is TRUE and every outer row is admitted.
+    try fixture().expect("SELECT Id FROM T WHERE EXISTS (SELECT 1)",
+                         yields: [[1], [2]])
+  }
+
+  @Test func `EXISTS honours a FETCH FIRST 0 ROWS limit as FALSE`() throws {
+    // The probe keeps the subquery's ORIGINAL `FETCH FIRST 0 ROWS ONLY`, so the
+    // row source yields zero rows and `EXISTS` is FALSE — a synthetic one-row
+    // cap must NOT override the original limit. Every outer row is dropped, and
+    // the dividing select list still never evaluates (no `.divide`).
+    try fixture().expect(
+        "SELECT Id FROM T "
+        + "WHERE EXISTS (SELECT 1 / 0 FROM S FETCH FIRST 0 ROWS ONLY)",
+        yields: [])
+  }
+
+  @Test func `EXISTS honours an OFFSET past the end as FALSE`() throws {
+    // `S` has three rows; `OFFSET 5 ROWS` skips past every one, so the probe
+    // sees no row and `EXISTS` is FALSE — the preserved OFFSET is not
+    // overridden.
+    try fixture().expect(
+        "SELECT Id FROM T WHERE EXISTS (SELECT V FROM S OFFSET 5 ROWS)",
+        yields: [])
+  }
+
+  @Test func `EXISTS with a positive FETCH over a non-empty source is TRUE`()
+      throws {
+    // A `FETCH FIRST 2 ROWS ONLY` keeps rows, so the non-empty `S` still yields
+    // a row through the probe and `EXISTS` is TRUE — every outer row admitted.
+    try fixture().expect(
+        "SELECT Id FROM T "
+        + "WHERE EXISTS (SELECT V FROM S FETCH FIRST 2 ROWS ONLY)",
+        yields: [[1], [2]])
+  }
+}
+
+// MARK: - DISTINCT EXISTS cardinality probe
+
+/// A `DISTINCT` EXISTS-only subquery is probed too, provided it carries no
+/// `OFFSET`: `DISTINCT` collapses a non-empty source to at least one distinct
+/// row, so `SELECT DISTINCT 1 FROM S` is non-empty iff `S` is — the constant
+/// projection preserves existence WITHOUT evaluating the original select list.
+/// A `DISTINCT` EXISTS WITH an `OFFSET` stays a FULL run: an offset skips
+/// distinct rows, so emptiness depends on the REAL distinct count, which the
+/// constant projection would collapse.
+struct DistinctExistsProbeTests {
+  private func fixture() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["Id": .integer, "K": .integer]) {
+        Row(1, 10)
+        Row(2, 20)
+      }
+      // `V` holds three distinct values, so an `OFFSET` up to two still leaves
+      // a distinct row and past three leaves none.
+      Relation("S", ["V": .integer, "Flag": .integer]) {
+        Row(10, 1)
+        Row(20, 1)
+        Row(99, 0)
+      }
+    }
+  }
+
+  @Test func `DISTINCT EXISTS over a dividing select list is safe`() throws {
+    // A `DISTINCT` EXISTS without an `OFFSET` is probed — `SELECT DISTINCT 1`
+    // yields one distinct row iff `S` is non-empty — so the original `1 / 0`
+    // select list never evaluates and `EXISTS` is TRUE with NO `.divide`.
+    try fixture().expect(
+        "SELECT Id FROM T WHERE EXISTS (SELECT DISTINCT 1 / 0 FROM S)",
+        yields: [[1], [2]])
+  }
+
+  @Test func `DISTINCT EXISTS over an empty source is FALSE`() throws {
+    // The probe over an empty source yields no distinct row, so `EXISTS` is
+    // FALSE — every outer row dropped, the select list still never evaluated.
+    try fixture().expect(
+        "SELECT Id FROM T "
+        + "WHERE EXISTS (SELECT DISTINCT 1 / 0 FROM S WHERE Flag = 9)",
+        yields: [])
+  }
+
+  @Test func `columns validates a DISTINCT EXISTS dividing select list`()
+      throws {
+    // The type-check validates the SAME probed shape the run evaluates, so the
+    // `1 / 0` select list is not checked and validation is clean — matching the
+    // run, which does not fault.
+    let query = try parse(
+        query: "SELECT Id FROM T WHERE EXISTS (SELECT DISTINCT 1 / 0 FROM S)")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+  }
+
+  @Test func `DISTINCT EXISTS honours a FETCH FIRST 0 ROWS limit as FALSE`()
+      throws {
+    // The probe keeps the original `FETCH FIRST 0 ROWS ONLY`, so it pages zero
+    // rows and `EXISTS` is FALSE — every outer row dropped.
+    try fixture().expect(
+        "SELECT Id FROM T "
+        + "WHERE EXISTS (SELECT DISTINCT V FROM S FETCH FIRST 0 ROWS ONLY)",
+        yields: [])
+  }
+
+  @Test func `DISTINCT EXISTS with a positive FETCH is TRUE`() throws {
+    // A `FETCH FIRST 2 ROWS ONLY` keeps the one distinct probe row, so the
+    // non-empty `S` yields it and `EXISTS` is TRUE — every outer row admitted.
+    try fixture().expect(
+        "SELECT Id FROM T "
+        + "WHERE EXISTS (SELECT DISTINCT V FROM S FETCH FIRST 2 ROWS ONLY)",
+        yields: [[1], [2]])
+  }
+
+  @Test func `DISTINCT EXISTS with an OFFSET reflects the real distinct count`()
+      throws {
+    // `S.V` has three distinct values. `OFFSET 5 ROWS` skips past every one, so
+    // the FULL run — the probe is NOT taken for a DISTINCT-with-OFFSET select —
+    // yields no distinct row and `EXISTS` is FALSE.
+    try fixture().expect(
+        "SELECT Id FROM T "
+        + "WHERE EXISTS (SELECT DISTINCT V FROM S OFFSET 5 ROWS)",
+        yields: [])
+    // `OFFSET 1 ROWS` leaves two of the three distinct rows, so `EXISTS` is
+    // TRUE — the real distinct count, not the collapsed single probe row.
+    try fixture().expect(
+        "SELECT Id FROM T "
+        + "WHERE EXISTS (SELECT DISTINCT V FROM S OFFSET 1 ROWS)",
+        yields: [[1], [2]])
+  }
+
+  @Test func `DISTINCT EXISTS with an OFFSET runs the select list`() throws {
+    // A DISTINCT-with-OFFSET select is NOT probe-eligible: its emptiness needs
+    // the real distinct count, so the FULL run evaluates the projection — the
+    // `1 / 0` genuinely faults `.divide`, proving the probe was not taken.
+    try fixture().expect(
+        "SELECT Id FROM T "
+        + "WHERE EXISTS (SELECT DISTINCT 1 / 0 FROM S OFFSET 5 ROWS)",
+        fails: .divide)
+  }
+}
+
+// MARK: - Aggregate EXISTS cardinality probe
+
+/// An aggregate/grouped EXISTS-only subquery WITHOUT a `HAVING` is probed too,
+/// via a cardinality/group-preserving shape whose target is a trivial
+/// `COUNT(*)` (the original target is irrelevant to existence). A WHOLE-RESULT
+/// aggregate (no `GROUP BY`) yields EXACTLY ONE row regardless of the source —
+/// even an empty one — so `EXISTS` is TRUE modulo the limit; a GROUPED one
+/// yields ONE ROW PER GROUP, so existence is the source's non-emptiness after
+/// `WHERE`. The probe keeps FROM/`WHERE`/`GROUP BY` and the original
+/// `OFFSET`/`FETCH` but never evaluates the original target, so `SUM(1 / 0)`
+/// does not fault. A `HAVING` subquery is NOT probed — group survival depends
+/// on the aggregate VALUES, not a source-only fact — so it stays a full run.
+struct AggregateExistsProbeTests {
+  private func fixture() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["Id": .integer, "K": .integer]) {
+        Row(1, 10)
+        Row(2, 20)
+      }
+      // `Flag` doubles as the grouping column `g`: {1, 1, 0} spans two groups.
+      Relation("S", ["V": .integer, "Flag": .integer]) {
+        Row(10, 1)
+        Row(20, 1)
+        Row(99, 0)
+      }
+    }
+  }
+
+  @Test func `whole-result aggregate EXISTS over a dividing target is TRUE`()
+      throws {
+    // A whole-result `SUM(1 / 0)` would fault `.divide` if run. Used by an
+    // EXISTS-only occurrence, it probes via `COUNT(*)`, which yields exactly
+    // one row over the non-empty `S` — so `EXISTS` is TRUE with NO `.divide`
+    // and every outer row is admitted.
+    try fixture().expect(
+        "SELECT Id FROM T WHERE EXISTS (SELECT SUM(1 / 0) FROM S)",
+        yields: [[1], [2]])
+  }
+
+  @Test func `whole-result aggregate EXISTS over an empty source is TRUE`()
+      throws {
+    // A whole-result aggregate yields EXACTLY ONE row even over an empty source
+    // (`SUM` of no rows is NULL, but it is still one row), so its probe —
+    // `COUNT(*)` over the empty `S` — yields one row and `EXISTS` is TRUE. The
+    // dividing target still never evaluates.
+    try fixture().expect(
+        "SELECT Id FROM T "
+        + "WHERE EXISTS (SELECT SUM(1 / 0) FROM S WHERE Flag = 9)",
+        yields: [[1], [2]])
+  }
+
+  @Test func `columns validates a whole-result aggregate EXISTS`() throws {
+    // The type-check validates the SAME probed `COUNT(*)` shape the run uses,
+    // so the `1 / 0` target is not checked — clean, matching the run.
+    let query = try parse(
+        query: "SELECT Id FROM T WHERE EXISTS (SELECT SUM(1 / 0) FROM S)")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+  }
+
+  @Test func `whole-result aggregate EXISTS honours FETCH FIRST 0 as FALSE`()
+      throws {
+    // The probe keeps the original `FETCH FIRST 0 ROWS ONLY`, so it pages away
+    // the one aggregate row and `EXISTS` is FALSE — every outer row dropped.
+    try fixture().expect(
+        "SELECT Id FROM T "
+        + "WHERE EXISTS (SELECT SUM(V) FROM S FETCH FIRST 0 ROWS ONLY)",
+        yields: [])
+  }
+
+  @Test func `grouped aggregate EXISTS over a dividing target is TRUE`()
+      throws {
+    // A grouped `SUM(1 / 0)` probes via `COUNT(*)` keeping the `GROUP BY`,
+    // which yields one row per group — the non-empty `S` has groups, so
+    // `EXISTS` is TRUE with NO `.divide` and every outer row is admitted.
+    try fixture().expect(
+        "SELECT Id FROM T "
+        + "WHERE EXISTS (SELECT SUM(1 / 0) FROM S GROUP BY Flag)",
+        yields: [[1], [2]])
+  }
+
+  @Test func `grouped aggregate EXISTS over an empty source is FALSE`()
+      throws {
+    // A grouped aggregate yields ONE ROW PER GROUP, so an empty source has NO
+    // groups and NO rows — unlike the whole-result case — so the probe yields
+    // nothing and `EXISTS` is FALSE. Every outer row is dropped.
+    try fixture().expect(
+        "SELECT Id FROM T WHERE EXISTS "
+        + "(SELECT SUM(1 / 0) FROM S WHERE Flag = 9 GROUP BY Flag)",
+        yields: [])
+  }
+
+  @Test func `columns validates a grouped aggregate EXISTS`() throws {
+    // The probed grouped `COUNT(*)` shape validates the SAME way the run does,
+    // so the `1 / 0` target is not checked — clean, matching the run.
+    let query = try parse(query:
+        "SELECT Id FROM T WHERE EXISTS "
+        + "(SELECT SUM(1 / 0) FROM S GROUP BY Flag)")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+  }
+
+  @Test func `HAVING aggregate EXISTS is a full run reflecting the filter`()
+      throws {
+    // A `HAVING` is NOT probe-eligible: group survival depends on the aggregate
+    // VALUES. So it runs in FULL and `EXISTS` reflects the real HAVING-filtered
+    // group count. Group `Flag = 1` sums to 30 (> 0) and `Flag = 0` to 99, so
+    // both survive — `EXISTS` is TRUE and every outer row is admitted.
+    try fixture().expect(
+        "SELECT Id FROM T WHERE EXISTS "
+        + "(SELECT SUM(V) FROM S GROUP BY Flag HAVING SUM(V) > 0)",
+        yields: [[1], [2]])
+    // With a HAVING that no group meets, the full run yields no group and
+    // `EXISTS` is FALSE — every outer row dropped.
+    try fixture().expect(
+        "SELECT Id FROM T WHERE EXISTS "
+        + "(SELECT SUM(V) FROM S GROUP BY Flag HAVING SUM(V) > 1000)",
+        yields: [])
+  }
+
+  @Test func `HAVING aggregate EXISTS runs a dividing aggregate`() throws {
+    // Because a `HAVING` subquery is a full run, an aggregate-in-`HAVING`
+    // `1 / 0` is genuinely NEEDED to decide group survival, so it faults
+    // `.divide` — the probe was not taken.
+    try fixture().expect(
+        "SELECT Id FROM T WHERE EXISTS "
+        + "(SELECT SUM(V) FROM S GROUP BY Flag HAVING SUM(1 / 0) > 0)",
+        fails: .divide)
+  }
+
+  @Test func `aggregate EXISTS still faults a bad inner relation`() throws {
+    // The probe RETAINS the subquery's FROM/`WHERE`/`GROUP BY`, so a
+    // genuinely-bad inner relation still faults — only the target is spared.
+    try fixture().expect(
+        "SELECT Id FROM T WHERE EXISTS (SELECT SUM(V) FROM Nope GROUP BY Flag)",
+        fails: .relation("Nope"))
+  }
+
+  @Test func `IN over an aggregate subquery still evaluates its target`()
+      throws {
+    // An aggregate IN subquery is unaffected by the EXISTS probe: `IN` reads
+    // the aggregate VALUE, so the target runs and a dividing one faults.
+    try fixture().expect(
+        "SELECT Id FROM T WHERE K IN (SELECT SUM(1 / 0) FROM S)",
+        fails: .divide)
+  }
+}
+
+// MARK: - Reserved-relation subqueries
+
+/// A reserved `definition_schema.`/`information_schema.` relation named ONLY
+/// inside a nested `EXISTS`/`IN (subquery)` is augmented into the context — the
+/// relation-name collector descends into subqueries, so the store overlay is
+/// materialised before the subquery's WIDTH compile AND its run, exactly as if
+/// the outer query had named it. The outer relation `T` names no reserved
+/// relation, so the coverage comes entirely from the descent.
+struct SubqueryReservedRelationTests {
+  private func fixture() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["Id": .integer]) {
+        Row(1)
+        Row(2)
+      }
+    }
+  }
+
+  @Test func `EXISTS over definition_schema.tables compiles and runs`() throws {
+    // The reserved store relation is named ONLY inside the subquery. Before the
+    // fix its overlay was not materialised (the collector did not descend), so
+    // the WIDTH compile faulted `SQLError.relation`. It now resolves and, since
+    // `definition_schema.tables` lists `T`, `EXISTS` is TRUE for every row.
+    try fixture().expect(
+        "SELECT Id FROM T "
+        + "WHERE EXISTS (SELECT table_name FROM definition_schema.tables)",
+        yields: [[1], [2]])
+  }
+
+  @Test func `IN over information_schema.columns compiles and runs`() throws {
+    // The subquery-only reference is a portable `information_schema.` view over
+    // the store; its body names `definition_schema.columns`, augmented through
+    // the same descent. `information_schema.columns` lists T's `Id` column, so
+    // `'Id' IN (…)` is TRUE and every row survives.
+    try fixture().expect(
+        "SELECT Id FROM T WHERE 'Id' IN "
+        + "(SELECT column_name FROM information_schema.columns)",
+        yields: [[1], [2]])
+  }
+
+  @Test func `columns validates a subquery-only reserved reference`() throws {
+    // The schema path shares the same `augment`, so `columns(of:validate:)`
+    // resolves the subquery-only reserved relation exactly as the run does.
+    let query = try parse(query:
+        "SELECT Id FROM T "
+        + "WHERE EXISTS (SELECT table_name FROM definition_schema.tables)")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+  }
+
+  @Test func `a reserved relation in the OUTER position still works`() throws {
+    // The pre-existing coverage: the reserved relation named in the OUTER FROM
+    // is unaffected by the descent — the collector still gathers it directly.
+    try fixture().expect(
+        "SELECT table_name FROM definition_schema.tables "
+        + "WHERE table_name = 'T'",
+        yields: [["T"]])
+  }
+
+  @Test func `a non-reserved subquery is unaffected by the descent`() throws {
+    // A subquery over an ordinary base relation collects its name too, but it
+    // is not reserved, so `augment` adds nothing and ordinary resolution holds.
+    try Catalog {
+      Relation("T", ["Id": .integer]) {
+        Row(1)
+        Row(2)
+      }
+      Relation("S", ["V": .integer]) {
+        Row(7)
+      }
+    }.expect("SELECT Id FROM T WHERE EXISTS (SELECT V FROM S)",
+             yields: [[1], [2]])
+  }
+}
+
+// MARK: - CASE-guard subquery validation
+
+/// A projection `CASE` whose guard nests an `EXISTS`/`IN (subquery)` is
+/// validated by `columns(of:validate: true)` — the subquery-check threads
+/// through the projection/`ORDER BY`/`HAVING` validation, so a query that runs
+/// is not rejected as unsupported.
+struct SubqueryConditionalValidationTests {
+  @Test func `columns validates a projection CASE EXISTS guard`() throws {
+    // `SELECT CASE WHEN EXISTS (…) THEN Id ELSE 0 END` — the guard's subquery is
+    // validated in the projection-check path, so the query type-checks.
+    let query = try parse(query:
+        "SELECT CASE WHEN EXISTS (SELECT V FROM S) THEN Id ELSE 0 END FROM T")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+  }
+
+  @Test func `columns validates a projection CASE IN guard`() throws {
+    // The `IN (subquery)` guard is validated the same way, its single-column
+    // arity enforced from the compiled width.
+    let query = try parse(query:
+        "SELECT CASE WHEN K IN (SELECT V FROM S) THEN Id ELSE 0 END FROM T")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+  }
+
+  @Test func `a projection CASE EXISTS guard runs correctly`() throws {
+    // S is non-empty, so the guard is TRUE for every row and the CASE yields
+    // Id; the projection-position subquery lowers and runs as a WHERE one.
+    try fixture().expect(
+        "SELECT CASE WHEN EXISTS (SELECT V FROM S) THEN Id ELSE 0 END FROM T",
+        yields: [[1], [2], [3], [4]])
+  }
+
+  @Test func `a bad projection CASE guard subquery column faults the check`()
+      throws {
+    // A bad column inside the projection CASE guard's subquery faults the
+    // validation exactly as a run would — the check descends the guard.
+    let query = try parse(query:
+        "SELECT CASE WHEN EXISTS (SELECT Missing FROM S) THEN Id ELSE 0 END "
+        + "FROM T")
+    let resolve = { () throws -> Array<OutputColumn> in
+      try fixture().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.column("Missing")) {
+      try resolve()
+    }
+  }
+}
+
+// MARK: - View predicate-pushdown subquery inheritance
+
+/// An outer `WHERE EXISTS/IN (Q)` conjunct that pushes INTO a simple view still
+/// resolves against the result the top-level `run` materialised: the view
+/// sub-plan INHERITS (merges) the caller's subquery cache rather than replacing
+/// it with a view-body-only one. Without the merge the pushed conjunct's `Q`,
+/// keyed in the caller's cache, would be missing from the view-only cache and
+/// fault "a subquery result was not materialised".
+struct ViewPushdownSubqueryTests {
+  /// `VW` projects bare columns of `T`, so an outer conjunct over its output
+  /// columns pushes below the projection into the view sub-plan.
+  private func view() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["Id": .integer, "K": .integer]) {
+        Row(1, 10)
+        Row(2, 20)
+        Row(3, nil)
+        Row(4, 30)
+      }
+      Relation("S", ["V": .integer, "Flag": .integer]) {
+        Row(10, 1)
+        Row(20, 1)
+        Row(99, 0)
+      }
+      try View("VW", "SELECT Id, K FROM T", as: ["Id", "K"])
+    }
+  }
+
+  /// A view whose OWN body nests an `EXISTS`, over `T` filtered by that inner
+  /// subquery — its own subquery must still resolve alongside a pushed outer
+  /// one.
+  private func nested() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["Id": .integer, "K": .integer]) {
+        Row(1, 10)
+        Row(2, 20)
+      }
+      Relation("S", ["V": .integer, "Flag": .integer]) {
+        Row(10, 1)
+      }
+      try View("VN", "SELECT Id, K FROM T WHERE EXISTS (SELECT V FROM S)",
+               as: ["Id", "K"])
+    }
+  }
+
+  /// The INVERSE of `nested`: the view `VN`'s body has the SAME
+  /// `EXISTS (SELECT V FROM S)` but over an EMPTY base `S`, so its body filters
+  /// EVERY row out. A caller that binds a NON-empty CTE `S` must NOT leak into
+  /// the view body — the body reads its own (empty) base.
+  private func hollow() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["Id": .integer, "K": .integer]) {
+        Row(1, 10)
+        Row(2, 20)
+      }
+      // An EMPTY base `S`, so the view body's `EXISTS (SELECT V FROM S)` is
+      // FALSE and filters every row.
+      Relation("S", ["V": .integer, "Flag": .integer]) { }
+      try View("VN", "SELECT Id, K FROM T WHERE EXISTS (SELECT V FROM S)",
+               as: ["Id", "K"])
+    }
+  }
+
+  @Test func `an outer EXISTS pushed into a view resolves`() throws {
+    // The outer `WHERE EXISTS (SELECT V FROM S)` conjunct pushes below `VW`'s
+    // projection into its sub-plan; the pushed `Q` resolves against the result
+    // the top-level run materialised (the caller's cache, MERGED into the
+    // view's), not a view-only cache that lacks it. S is non-empty, so the
+    // EXISTS is TRUE and every view row survives.
+    try view().expect("SELECT Id FROM VW WHERE EXISTS (SELECT V FROM S)",
+                      yields: [[1], [2], [3], [4]])
+  }
+
+  @Test func `an outer EXISTS pushed into a view drops rows when empty`()
+      throws {
+    // The pushed EXISTS is FALSE (the inner query filters to zero rows), so no
+    // view row survives — the pushed subquery still resolves, just to empty.
+    try view().expect(
+        "SELECT Id FROM VW WHERE EXISTS (SELECT V FROM S WHERE Flag = 9)",
+        yields: [])
+  }
+
+  @Test func `an outer IN pushed into a view resolves`() throws {
+    // An `IN (Q)` conjunct pushes into the view the same way; S.V is {10, 20,
+    // 99}, so the view rows whose K is in that set survive (Id 1 and 2).
+    try view().expect("SELECT Id FROM VW WHERE K IN (SELECT V FROM S)",
+                      yields: [[1], [2]])
+  }
+
+  @Test func `a view whose body nests a subquery still resolves`() throws {
+    // `VN`'s body itself nests `EXISTS (SELECT V FROM S)`; the merge unions the
+    // view's own materialised subqueries with the caller's, so the body's
+    // subquery resolves too. S is non-empty, so the body keeps every row.
+    try nested().expect("SELECT Id FROM VN", yields: [[1], [2]])
+  }
+
+  @Test func `a view body subquery and a pushed outer one both resolve`()
+      throws {
+    // Both the view body's OWN `EXISTS` and the outer `EXISTS` pushed into it
+    // must resolve — the two caches are layered. S is non-empty, so both are
+    // TRUE and every row survives.
+    try nested().expect("SELECT Id FROM VN WHERE EXISTS (SELECT V FROM S)",
+                        yields: [[1], [2]])
+  }
+
+  @Test func `a pushed outer subquery reads the caller CTE not the view base`()
+      throws {
+    // Bug 1: the view body's `EXISTS (SELECT V FROM S)` reads BASE `S`
+    // (non-empty), and the caller's AST-IDENTICAL outer `EXISTS (SELECT V FROM
+    // S)` — pushed into the view — must read the caller's CTE `S`, an EMPTY
+    // relation shadowing the base. The two subqueries share a `Query` VALUE
+    // but resolve under DIFFERENT overlays: keying the run-time cache by the
+    // `Query` alone (the old merge) collapsed them, so the pushed conjunct read
+    // the view body's base-`S` result and wrongly kept every row. Layering the
+    // caller's cache OVER the view's keeps the contexts distinct: the pushed
+    // EXISTS reads the empty CTE and is FALSE, dropping every row, while the
+    // view body's own EXISTS still reads base `S` and keeps them — so the
+    // result is EMPTY, NOT the base-table interpretation's two rows.
+    let statement = try parse(statement:
+        "WITH S(V) AS (SELECT Id FROM T WHERE 1 = 0) "
+        + "SELECT Id FROM VN WHERE EXISTS (SELECT V FROM S)")
+    let rows = try nested().run(statement, .standard)
+    // The pushed EXISTS resolves against the EMPTY caller CTE — no rows left.
+    #expect(rows.isEmpty)
+    // And this DIFFERS from the base-table interpretation the collapsed cache
+    // gave, proving the caches are kept distinct: reading base `S` (non-empty)
+    // for the pushed EXISTS would have kept both view rows.
+    let base: Array<Array<Value>> = [[.integer(1)], [.integer(2)]]
+    #expect(rows != base)
+  }
+
+  @Test func `a view body subquery reads the view base not the caller CTE`()
+      throws {
+    // Bug 2, the INVERSE direction: the VIEW BODY's `EXISTS (SELECT V FROM S)`
+    // resolves against the view's OWN base `S` (here EMPTY), and the caller's
+    // AST-IDENTICAL `WITH S AS (SELECT 1)` CTE must NOT leak into that body.
+    // Keying the run-time cache by the `Query` VALUE alone let the caller's
+    // (non-empty) CTE result win the merge, so the view body's own EXISTS
+    // wrongly read the CTE and kept every row. Keying by OCCURRENCE — each
+    // subquery's resolution `Subscope` composed with its AST — keeps the
+    // contexts distinct: the body's `.view(vn)` EXISTS reads the empty base
+    // and drops every row, while the caller's `.caller` pushed EXISTS reads the
+    // non-empty CTE and keeps them. The view filters CORRECTLY (its base `S` is
+    // empty), so the result is EMPTY.
+    let statement = try parse(statement:
+        "WITH S(V) AS (SELECT 1) "
+        + "SELECT Id FROM VN WHERE EXISTS (SELECT V FROM S)")
+    let rows = try hollow().run(statement, .standard)
+    // The view body's EXISTS reads its EMPTY base `S`, filtering every row —
+    // NOT the caller's non-empty CTE, which would have kept both rows.
+    #expect(rows.isEmpty)
+    let leaked: Array<Array<Value>> = [[.integer(1)], [.integer(2)]]
+    #expect(rows != leaked)
+  }
+
+  @Test func `both subquery directions stay distinct`() throws {
+    // Prove distinctness BOTH ways against ONE catalog: the view body's EXISTS
+    // over base `S` and the caller's pushed EXISTS over CTE `S` read DIFFERENT
+    // results for the same AST. With base `S` NON-empty (view keeps rows) and
+    // the caller CTE EMPTY (pushed EXISTS drops rows), the result is EMPTY —
+    // only correct if each subquery reads its OWN context. A single collapsed
+    // entry (whichever won) could not give this: the caller-CTE value would
+    // make the view body drop too (still empty, but for the wrong reason), so
+    // this pairs with the base-`S`-empty/CTE-non-empty inverse above — together
+    // they pin BOTH directions.
+    let empty = try parse(statement:
+        "WITH S(V) AS (SELECT Id FROM T WHERE 1 = 0) "
+        + "SELECT Id FROM VN WHERE EXISTS (SELECT V FROM S)")
+    #expect(try nested().run(empty, .standard).isEmpty)
+    // Caller CTE non-empty: the pushed EXISTS is TRUE and the view body's own
+    // EXISTS (base `S` non-empty) is TRUE too, so every row survives — the
+    // caller's CTE result did NOT collapse the view body's base read.
+    let full = try parse(statement:
+        "WITH S(V) AS (SELECT 1) "
+        + "SELECT Id FROM VN WHERE EXISTS (SELECT V FROM S)")
+    let kept: Array<Array<Value>> = [[.integer(1)], [.integer(2)]]
+    #expect(try nested().run(full, .standard) == kept)
+  }
+}
+
+// MARK: - IN (subquery) pushdown nullability
+
+/// An `IN (Q)` predicate is THREE-VALUED — UNKNOWN when its materialised
+/// subquery holds a NULL and nothing matches — so it must be treated NULLABLE
+/// for predicate pushdown even when it is slotless (a constant operand): a
+/// conjunct carrying `IN (Q)` must NOT be pushed AHEAD of a later unsafe
+/// conjunct, or pushdown would drop the UNKNOWN rows before the unsafe one runs
+/// and suppress a throw the non-short-circuiting `AND` owes. An `EXISTS (Q)` is
+/// genuinely TWO-valued (never UNKNOWN), so it stays freely pushable.
+struct InPushdownNullabilityTests {
+  /// A view over bare `T` columns, and an `S` whose single column `N` holds
+  /// only a NULL — so `1 IN (SELECT N FROM S)` is UNKNOWN (no match, a NULL
+  /// element).
+  private func view() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["Id": .integer]) {
+        Row(1)
+        Row(2)
+      }
+      Relation("S", ["N": .integer]) {
+        Row(nil)
+      }
+      try View("VW", "SELECT Id FROM T", as: ["Id"])
+    }
+  }
+
+  @Test func `an IN subquery conjunct is not pushed ahead of an unsafe one`()
+      throws {
+    // Bug 2: `1 IN (SELECT N FROM S)` is UNKNOWN (S.N is a lone NULL, no
+    // match). Under the un-pushed semantics the non-short-circuiting `AND`
+    // still evaluates `(1 / 0) = 0` for every view row, raising `.divide`.
+    // Classifying the slotless `IN (Q)` NON-nullable would let pushdown inject
+    // it into the view ahead of the unsafe division: the UNKNOWN rows would be
+    // dropped inside the view before the outer `(1 / 0) = 0` ran, suppressing
+    // the throw. Treating `.within` as NULLABLE keeps the `IN` conjunct OUTER
+    // (a later conjunct is unsafe), so the division runs and the query THROWS.
+    try view().expect(
+        "SELECT Id FROM VW WHERE 1 IN (SELECT N FROM S) AND (1 / 0) = 0",
+        fails: .divide)
+  }
+
+  @Test func `an EXISTS conjunct still pushes into a view`() throws {
+    // `EXISTS (Q)` is TWO-valued — a decided non-empty test, never UNKNOWN —
+    // so it stays freely pushable. `S` is non-empty, so the pushed `EXISTS` is
+    // TRUE and every view row survives; the pushdown resolves it against the
+    // caller's materialised cache exactly as before.
+    try view().expect("SELECT Id FROM VW WHERE EXISTS (SELECT N FROM S)",
+                      yields: [[1], [2]])
+  }
+}
+
+// MARK: - HAVING subquery reachability
+
+/// A whole-result aggregate under a statically-false `WHERE` emits one empty
+/// group; its `HAVING EXISTS/IN (Q)` is evaluated over that group at RUN and
+/// can be TRUE (the subquery is row-independent), so the projection is
+/// potentially reachable. `columns(of:validate:)` must NOT prune it as
+/// unreachable — it validates the projection so the schema agrees with the run.
+/// A subquery-free HAVING keeps the existing precise pruning.
+struct HavingSubqueryReachabilityTests {
+  @Test func `a HAVING subquery keeps the projection reachable to validate`()
+      throws {
+    // `WHERE 1 = 0` empties the group, but `HAVING EXISTS (SELECT 1)` is TRUE
+    // at run, so the projection RUNS and its `1 / 0` raises `.divide`. The
+    // schema path must not falsely advertise clean headers: with the HAVING
+    // carrying a subquery it is not-definitely-empty, so validation reaches the
+    // projection and surfaces the same `.divide` the run raises.
+    let query = try parse(query:
+        "SELECT 1 / 0 FROM T WHERE 1 = 0 HAVING EXISTS (SELECT V FROM S)")
+    let resolve = { () throws -> Array<OutputColumn> in
+      try fixture().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.divide) {
+      try resolve()
+    }
+  }
+
+  @Test func `the HAVING-subquery projection fault matches the run`() throws {
+    // The run raises `.divide` too — the group passes the true HAVING and the
+    // projection's `1 / 0` evaluates — so schema and run agree.
+    try fixture().expect(
+        "SELECT 1 / 0 FROM T WHERE 1 = 0 HAVING EXISTS (SELECT V FROM S)",
+        fails: .divide)
+  }
+
+  @Test func `a subquery-free HAVING under a false WHERE still prunes`()
+      throws {
+    // No subquery in the HAVING, so the precise empty-group fold applies: the
+    // constant-false `HAVING 1 = 0` drops the lone empty group, leaving the
+    // `1 / 0` projection unreachable — `columns` returns clean headers WITHOUT
+    // faulting, exactly as before this fix.
+    let query = try parse(query:
+        "SELECT 1 / 0 FROM T WHERE 1 = 0 HAVING 1 = 0")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+  }
+
+  @Test func `a subquery-free true HAVING still validates the projection`()
+      throws {
+    // A subquery-free HAVING that folds TRUE over the empty group keeps the
+    // projection reachable exactly as before — so a `1 / 0` still faults
+    // `.divide`, unchanged by the subquery carve-out.
+    let query = try parse(query:
+        "SELECT 1 / 0 FROM T WHERE 1 = 0 HAVING 1 = 1")
+    let resolve = { () throws -> Array<OutputColumn> in
+      try fixture().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.divide) {
+      try resolve()
+    }
+  }
+}
+
+// MARK: - Projection/sort subquery reachability
+
+/// The empty-fold analog of the HAVING carve-out, extended to PROJECTION and
+/// SORT expressions: a whole-result aggregate under a statically-false `WHERE`
+/// emits one empty group, and a projection/sort expression that nests an
+/// `EXISTS`/`IN (Q)` guard is potentially reachable — the subquery is
+/// row-independent and may keep the group at RUN. `columns(of:validate:)` must
+/// VALIDATE its subquery-guarded branches rather than prune them by the empty
+/// fold (which treats the guard as UNKNOWN), so the schema agrees with the run.
+/// A subquery-FREE guarded expression keeps the precise empty-fold pruning.
+struct ProjectionSubqueryReachabilityTests {
+  private func fixture() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["Id": .integer, "K": .integer]) {
+        Row(1, 10)
+        Row(2, 20)
+      }
+      Relation("S", ["V": .integer, "Flag": .integer]) {
+        Row(10, 1)
+      }
+    }
+  }
+
+  @Test func `columns validates a subquery-guarded projection CASE`() throws {
+    // `WHERE 1 = 0` empties the group; the `CASE` guard `EXISTS (SELECT V FROM
+    // S)` folds UNKNOWN in the empty fold, which would prune the THEN arm — but
+    // the subquery is TRUE at RUN, so the THEN arm's `1 / 0` runs. The empty
+    // fold must NOT prune a subquery-guarded branch: validation reaches BOTH
+    // arms and surfaces the `.divide` the run raises.
+    let query = try parse(query:
+        "SELECT CASE WHEN EXISTS (SELECT V FROM S) THEN 1 / 0 "
+        + "ELSE COUNT(*) END FROM T WHERE 1 = 0")
+    #expect(throws: SQLError.divide) {
+      try fixture().columns(of: query, validate: true)
+    }
+  }
+
+  @Test func `the subquery-guarded projection fault matches the run`() throws {
+    // The run raises `.divide` too — `EXISTS` is TRUE over the empty group, so
+    // the THEN arm's `1 / 0` evaluates — so schema and run agree.
+    try fixture().expect(
+        "SELECT CASE WHEN EXISTS (SELECT V FROM S) THEN 1 / 0 "
+        + "ELSE COUNT(*) END FROM T WHERE 1 = 0",
+        fails: .divide)
+  }
+
+  @Test func `a subquery-free guarded projection CASE still prunes`() throws {
+    // No subquery in the guard, so the precise empty-group fold applies: the
+    // constant-false guard `1 = 0` selects the ELSE arm, leaving the `1 / 0`
+    // THEN unreachable — `columns` returns clean headers WITHOUT faulting,
+    // exactly as before this fix.
+    let query = try parse(query:
+        "SELECT CASE WHEN 1 = 0 THEN 1 / 0 ELSE COUNT(*) END "
+        + "FROM T WHERE 1 = 0")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+  }
+
+  @Test func `columns validates a subquery-guarded sort CASE`() throws {
+    // The ORDER BY sits BELOW the limit and evaluates over the empty group's
+    // row unconditionally, so a subquery-guarded sort expression is validated
+    // the same as a projection one: the `EXISTS`-guarded `1 / 0` sort key
+    // surfaces `.divide`, not a pruned clean header.
+    let query = try parse(query:
+        "SELECT COUNT(*) FROM T WHERE 1 = 0 "
+        + "ORDER BY CASE WHEN EXISTS (SELECT V FROM S) THEN 1 / 0 ELSE 1 END")
+    #expect(throws: SQLError.divide) {
+      try fixture().columns(of: query, validate: true)
+    }
+  }
+}
+
+// MARK: - FROM-less scalar subqueries
+
+/// A FROM-less scalar `SELECT <expr-list>` whose projection nests an
+/// UNCORRELATED `EXISTS`/`IN (subquery)` compiles, validates, and runs exactly
+/// as the identical projection does with a FROM clause. The scalar lowering
+/// (`projection.scalar`) is the ONE compile path that otherwise threads the
+/// DEFAULT unsupported subquery map, so a subquery there faulted at compile
+/// before the run-time cache was ever built; the map is now threaded through so
+/// the term lowers, and `run`'s cache (built from `query.subqueries`, which
+/// descends the projection) materialises the subquery the evaluator reads.
+struct FromlessScalarSubqueryTests {
+  @Test func `a scalar EXISTS yields 1 when the subquery is non-empty`()
+      throws {
+    // No outer FROM; the subquery's own `FROM T` is fine. `T` is non-empty, so
+    // `EXISTS` is TRUE and the CASE yields 1.
+    try fixture().expect(
+        "SELECT CASE WHEN EXISTS (SELECT Id FROM T) THEN 1 ELSE 0 END",
+        yields: [[1]])
+  }
+
+  @Test func `a scalar EXISTS yields 0 when the subquery is empty`() throws {
+    // The subquery filters to zero rows, so `EXISTS` is FALSE and the CASE
+    // yields 0 — the scalar projection runs against the single empty row.
+    try fixture().expect(
+        "SELECT CASE WHEN EXISTS (SELECT Id FROM T WHERE Id = 99) "
+        + "THEN 1 ELSE 0 END",
+        yields: [[0]])
+  }
+
+  @Test func `a scalar NOT EXISTS is the negation`() throws {
+    // Over the empty subquery `NOT EXISTS` is TRUE (yields 1); over the
+    // non-empty one it is FALSE (yields 0).
+    try fixture().expect(
+        "SELECT CASE WHEN NOT EXISTS (SELECT Id FROM T WHERE Id = 99) "
+        + "THEN 1 ELSE 0 END",
+        yields: [[1]])
+    try fixture().expect(
+        "SELECT CASE WHEN NOT EXISTS (SELECT Id FROM T) THEN 1 ELSE 0 END",
+        yields: [[0]])
+  }
+
+  @Test func `a scalar IN over a subquery folds the membership test`() throws {
+    // `S.V` is {10, 20, 99}; the scalar `10 IN (…)` is TRUE (yields 1) and
+    // `77 IN (…)` is FALSE (yields 0) — the value-list `IN` core over the
+    // subquery's single materialised column.
+    try fixture().expect(
+        "SELECT CASE WHEN 10 IN (SELECT V FROM S) THEN 1 ELSE 0 END",
+        yields: [[1]])
+    try fixture().expect(
+        "SELECT CASE WHEN 77 IN (SELECT V FROM S) THEN 1 ELSE 0 END",
+        yields: [[0]])
+  }
+
+  @Test func `a scalar IN over a two-column subquery faults with arity`()
+      throws {
+    // The `IN (Q)` single-column arity is decided from the subquery's compiled
+    // WIDTH at compile — cursor-free — so a two-column subquery faults
+    // `SQLError.arity` on the FROM-less path exactly as on the FROM'd one.
+    try fixture().expect(
+        "SELECT CASE WHEN 1 IN (SELECT Id, K FROM T) THEN 1 ELSE 0 END",
+        fails: .arity(1, 2))
+  }
+
+  @Test func `columns validates a scalar EXISTS projection`() throws {
+    // The schema path compiles and type-checks the same FROM-less scalar
+    // projection, so `columns(of:validate:)` accepts exactly what the run does.
+    let query = try parse(query:
+        "SELECT CASE WHEN EXISTS (SELECT Id FROM T) THEN 1 ELSE 0 END")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+  }
+
+  @Test func `a bad inner column in a scalar subquery faults the check`()
+      throws {
+    // A bad column inside the scalar projection's subquery faults the
+    // validation exactly as a run would — the check reaches the subquery.
+    let query = try parse(query:
+        "SELECT CASE WHEN EXISTS (SELECT Missing FROM T) THEN 1 ELSE 0 END")
+    let resolve = { () throws -> Array<OutputColumn> in
+      try fixture().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.column("Missing")) {
+      try resolve()
+    }
+  }
+
+  @Test func `a plain scalar SELECT without a subquery is unaffected`() throws {
+    // A FROM-less scalar select carrying NO subquery lowers exactly as before —
+    // the threaded map is empty and the projection is a plain constant.
+    try fixture().expect("SELECT 1 + 2", yields: [[3]])
+  }
+}
+
+// MARK: - FROM-less scalar reserved-relation subqueries
+
+/// A reserved `definition_schema.` relation named ONLY inside a subquery of a
+/// FROM-less scalar `SELECT` still augments and runs — the relation-name
+/// collector descends the projection's subqueries the same on this path, so the
+/// store overlay is materialised before the subquery's width compile and run.
+struct FromlessScalarReservedRelationTests {
+  private func fixture() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["Id": .integer]) {
+        Row(1)
+        Row(2)
+      }
+    }
+  }
+
+  @Test func `a scalar EXISTS over definition_schema.tables runs`() throws {
+    // The reserved store relation is named ONLY inside the subquery of a
+    // FROM-less scalar select; the descent still augments it, so the width
+    // compile resolves and the run materialises it. It lists `T`, so `EXISTS`
+    // is TRUE and the CASE yields 1.
+    try fixture().expect(
+        "SELECT CASE WHEN EXISTS "
+        + "(SELECT table_name FROM definition_schema.tables) "
+        + "THEN 1 ELSE 0 END",
+        yields: [[1]])
+  }
+
+  @Test func `columns validates a scalar reserved-relation subquery`() throws {
+    // The schema path shares the same augment, so `columns(of:validate:)`
+    // resolves the subquery-only reserved relation exactly as the run does.
+    let query = try parse(query:
+        "SELECT CASE WHEN EXISTS "
+        + "(SELECT table_name FROM definition_schema.tables) "
+        + "THEN 1 ELSE 0 END")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+  }
+}


### PR DESCRIPTION
Add the first slice of the subquery program: uncorrelated EXISTS and IN (SELECT …) predicates, the #1 standard-SQL gap and the LINQ subquery unblocker.

AST. `Predicate` (already `indirect`) gains two cases nesting the existing `Query` node without boxing: `exists(Query, negated:)` for `[NOT] EXISTS (Q)` and `inQuery(Expression, Query, negated:)` for `x [NOT] IN (Q)`. Both stay `Hashable`/`Sendable`, so AST equality — the contract the parser round-trip tests and the LINQ layer rely on — composes for free.

Grammar. `EXISTS` becomes a keyword. It is recognised in `negation` ahead of the comparison tier as a complete predicate with no left operand; `NOT EXISTS` sets the `negated` flag directly rather than wrapping a `.not`. `x [NOT] IN (…)` disambiguates the value list from a subquery by one token of lookahead after `(` — a leading `SELECT` takes the subquery arm — so no rewind is needed and the value-list `IN` is unchanged. The EBNF doc-comment is updated and the old "IN (SELECT …) not supported" note is deleted.

Execution — uncorrelated only. The subquery names no enclosing column in this slice, so `compile`/`typecheck` materialise every nested subquery ONCE ahead of lowering (the CTE-materialise path, `run(subquery, context)`), keyed by its `Query` into a value the escapable lowering surfaces read — the borrowing catalog never enters the lowering data. `EXISTS (Q)` lowers to `Filter.exists`, a DEFINITE two-valued non-empty test (never UNKNOWN, even over NULL-valued rows), `negated` flipping it. `x IN (Q)` lowers to `Filter.inQuery` and folds `x = v` over Q's single materialised column through the SAME `matches`/Kleene-`or` three-valued core the value-list `IN` uses — a NULL operand or element leaves an unmatched test UNKNOWN, an empty result is FALSE, and `NOT IN` negates that (the `1 NOT IN (…, NULL)` trap). `IN (Q)` requires Q project exactly one column, faulting `SQLError.arity` from the compiled width (so a two-column subquery faults even when it yields no row). The inner query is type-checked and compiled on the schema path too, so validation matches the run.

Scalar subqueries, derived tables, correlation, and quantified ANY/ALL/SOME are later stages.