### PR TITLE
SQLEngine: accept a scalar subquery expression

### DIFF
--- a/Sources/SQLEngine/AST.swift
+++ b/Sources/SQLEngine/AST.swift
@@ -693,6 +693,20 @@ public indirect enum Expression: Hashable, Sendable {
   /// evaluating a stateful `v1` twice — comparing one call's value to `v2` and
   /// returning a different one. The result type is `v1`'s.
   case nullif(Expression, Expression)
+  /// A scalar subquery `(SELECT …)` — a nested `Query` in expression position,
+  /// yielding ONE value: its lone cell when it returns exactly one row, NULL
+  /// when it returns none, and `SQLError.cardinality` when it returns more. The
+  /// inner query must project EXACTLY ONE column (checked at compile, cursor-
+  /// free, from its compiled width); the value's type is that column's. `Query`
+  /// is `indirect`, so nesting it here composes the synthesized `Hashable`.
+  ///
+  /// In this slice the subquery is UNCORRELATED — it names no column of the
+  /// enclosing query — so it runs ONCE per outer-query execution (memoised in
+  /// the same `Subqueries` cache an `EXISTS`/`IN (Q)` predicate uses) and its
+  /// value is the same for every outer row. A reference to an outer column
+  /// resolves (or faults) as any other column would; correlation is a later
+  /// slice.
+  case subquery(Query)
 }
 
 /// One `WHEN predicate THEN result` branch of a `CASE` expression — the guard

--- a/Sources/SQLEngine/Aggregate.swift
+++ b/Sources/SQLEngine/Aggregate.swift
@@ -299,10 +299,12 @@ private func comparable(_ a: Value, _ b: Value) -> Bool {
 /// UNBOUND. The key evaluation threads them for the same reason and to keep the
 /// two evaluate sites consistent, though a `GROUP BY` key is a bare column
 /// today, so it cannot yet reach one.
-internal func grouped(_ records: Array<Record>, _ keys: Array<Term>,
-                      _ aggregates: Array<Aggregation>, _ routines: Routines,
-                      _ bindings: Bindings, _ subqueries: Subqueries)
-    throws(SQLError) -> Array<Record> {
+internal func grouped<C>(_ records: Array<Record>, _ keys: Array<Term>,
+                         _ aggregates: Array<Aggregation>,
+                         _ catalog: borrowing C, _ relations: ScopedRelations,
+                         _ routines: Routines, _ bindings: Bindings,
+                         _ subqueries: Subqueries)
+    throws(SQLError) -> Array<Record> where C: Catalog & ~Escapable {
   var order = Array<Record>()
   var accumulators = Dictionary<Record, Array<Accumulator>>()
 
@@ -310,7 +312,8 @@ internal func grouped(_ records: Array<Record>, _ keys: Array<Term>,
     var cells = Array<Value>()
     cells.reserveCapacity(keys.count)
     for key in keys {
-      try cells.append(record.evaluate(key, routines, bindings, subqueries))
+      try cells.append(record.evaluate(key, catalog, relations, routines,
+                                       bindings, subqueries))
     }
     let group = Record(cells)
     // Key the group on the EXACT canonical form of its cells so `1` and `1.0`
@@ -325,20 +328,21 @@ internal func grouped(_ records: Array<Record>, _ keys: Array<Term>,
       order.append(group)
     }
     for index in aggregates.indices {
-      // An aggregate's `FILTER (WHERE …)` gates the row: only a TRUE predicate
-      // admits it (a FALSE or UNKNOWN one, and an unbound `:parameter`, skips),
-      // applied before the fold — and so before the DISTINCT dedup. A
-      // filter-less aggregate folds every row.
+      // An aggregate's `FILTER (WHERE …)` gates the row: only a TRUE
+      // predicate admits it (a FALSE or UNKNOWN one, and an unbound
+      // `:parameter`, skips), applied before the fold — and so before the
+      // DISTINCT dedup. A filter-less aggregate folds every row.
       if let filter = aggregates[index].filter {
-        guard try record.evaluate(filter, routines, bindings,
-                                  subqueries) == true else {
+        guard try record.evaluate(filter, catalog, relations, routines,
+                                  bindings, subqueries) == true else {
           continue
         }
       }
       // `COUNT(*)` has no argument — count the row with a non-NULL sentinel;
       // every other aggregate folds its evaluated argument value.
       let value: Value = if let argument = aggregates[index].argument {
-        try record.evaluate(argument, routines, bindings, subqueries)
+        try record.evaluate(argument, catalog, relations, routines, bindings,
+                            subqueries)
       } else {
         .integer(0)
       }
@@ -346,10 +350,10 @@ internal func grouped(_ records: Array<Record>, _ keys: Array<Term>,
     }
   }
 
-  // A whole-result aggregation with no matching row still yields one group — the
-  // empty group — so the degenerate `SELECT COUNT(*) FROM T` over no rows counts
-  // `0` rather than yielding no row at all. A grouped query over no rows yields
-  // no group (standard SQL).
+  // A whole-result aggregation with no matching row still yields one group —
+  // the empty group — so the degenerate `SELECT COUNT(*) FROM T` over no rows
+  // counts `0` rather than yielding no row at all. A grouped query over no
+  // rows yields no group (standard SQL).
   if keys.isEmpty && order.isEmpty {
     let empty = aggregates.map {
       Accumulator($0.function, distinct: $0.distinct)

--- a/Sources/SQLEngine/Engine.swift
+++ b/Sources/SQLEngine/Engine.swift
@@ -737,7 +737,9 @@ extension Expression {
   /// Whether the expression contains an aggregate call anywhere within it.
   internal var aggregated: Bool {
     switch self {
-    case .column, .literal:
+    case .column, .literal, .subquery:
+      // An aggregate INSIDE a scalar subquery belongs to that subquery, not the
+      // enclosing query, so a `subquery` is not an aggregated expression here.
       false
     case .aggregate:
       true
@@ -765,7 +767,9 @@ extension Expression {
   /// registration rather than silently evaluating that reference as UNBOUND.
   internal var bound: Bool {
     switch self {
-    case .column, .literal, .aggregate:
+    case .column, .literal, .aggregate, .subquery:
+      // An UNCORRELATED scalar subquery references no query binding of the
+      // enclosing query (correlation is a later slice), so it is not bound.
       false
     case let .call(_, arguments):
       arguments.contains { $0.bound }
@@ -938,6 +942,32 @@ extension Query {
     case let .setop(_, left, right, _): left.valued.union(right.valued)
     }
   }
+
+  /// The subqueries this query nests in a SCALAR-subquery position — the ones a
+  /// run collapses to a single VALUE (empty → NULL, one row → the cell, more →
+  /// `SQLError.cardinality`), distinct from a `valued` (`IN`) or `EXISTS`-probe
+  /// occurrence. The materialiser reads this to decide a scalar occurrence's
+  /// materialisation.
+  internal var scalar: Set<Query> {
+    switch self {
+    case let .select(select): select.scalar
+    case let .setop(_, left, right, _): left.scalar.union(right.scalar)
+    }
+  }
+
+  /// The subqueries this query nests in an `EXISTS (Q)` position — the ones a
+  /// run materialises as a cardinality PROBE. The SAME query may ALSO occur as
+  /// a `valued` (`IN`) or `scalar` occurrence over identical SQL; each role is
+  /// a DISTINCT cache entry (see `Role`), so the materialiser produces an
+  /// existential probe entry whenever a query occurs here — never reusing a
+  /// `valued`/`scalar` entry for an `EXISTS` read.
+  internal var existential: Set<Query> {
+    switch self {
+    case let .select(select): select.existential
+    case let .setop(_, left, right, _):
+      left.existential.union(right.existential)
+    }
+  }
 }
 
 extension Select {
@@ -991,6 +1021,48 @@ extension Select {
     for key in order?.keys ?? [] {
       if case let .expression(expression) = key.sort {
         expression.collect(valued: &queries)
+      }
+    }
+    return queries
+  }
+
+  /// The subqueries this `SELECT` nests in a SCALAR-subquery position — the
+  /// same clauses `subqueries` walks, keeping only the `Expression.subquery`
+  /// queries, so a run materialises each as its collapsed single VALUE (empty →
+  /// NULL, one row → the cell, more → `SQLError.cardinality`), distinct from a
+  /// `valued` (`IN`, full column) or `EXISTS`-probe occurrence.
+  internal var scalar: Set<Query> {
+    var queries = Set<Query>()
+    predicate?.collect(scalar: &queries)
+    for join in joins { join.on.collect(scalar: &queries) }
+    having?.collect(scalar: &queries)
+    if case let .expressions(items) = projection {
+      for item in items { item.expression.collect(scalar: &queries) }
+    }
+    for key in order?.keys ?? [] {
+      if case let .expression(expression) = key.sort {
+        expression.collect(scalar: &queries)
+      }
+    }
+    return queries
+  }
+
+  /// The subqueries this `SELECT` nests in an `EXISTS (Q)` position — the
+  /// same clauses `subqueries` walks, keeping only the `exists` operands'
+  /// queries, so a run materialises each as a cardinality PROBE under its own
+  /// `existential` key, distinct from any `valued`/`scalar` occurrence over the
+  /// same SQL.
+  internal var existential: Set<Query> {
+    var queries = Set<Query>()
+    predicate?.collect(existential: &queries)
+    for join in joins { join.on.collect(existential: &queries) }
+    having?.collect(existential: &queries)
+    if case let .expressions(items) = projection {
+      for item in items { item.expression.collect(existential: &queries) }
+    }
+    for key in order?.keys ?? [] {
+      if case let .expression(expression) = key.sort {
+        expression.collect(existential: &queries)
       }
     }
     return queries
@@ -1093,6 +1165,90 @@ extension Predicate {
       operand.collect(valued: &queries)
     }
   }
+
+  /// Collects the SCALAR-subquery-position queries this predicate nests into
+  /// `queries` — an operand expression's own `subquery`, a `CASE` guard's, and
+  /// those under `AND`/`OR`/`NOT`, mirroring `collect(subqueries:)`. An
+  /// `EXISTS`/`IN (Q)`'s own `Query` is NOT a scalar occurrence — it is
+  /// probed/valued — so it is not collected here.
+  internal func collect(scalar queries: inout Set<Query>) {
+    switch self {
+    case .exists:
+      break
+    case let .within(operand, _, _):
+      operand.collect(scalar: &queries)
+    case let .comparison(left, _, right):
+      left.collect(scalar: &queries)
+      right.collect(scalar: &queries)
+    case let .bound(left, _, _):
+      left.collect(scalar: &queries)
+    case let .null(operand, _):
+      operand.collect(scalar: &queries)
+    case let .membership(operand, values, _):
+      operand.collect(scalar: &queries)
+      for value in values { value.collect(scalar: &queries) }
+    case let .like(operand, pattern, escape, _):
+      operand.collect(scalar: &queries)
+      pattern.collect(scalar: &queries)
+      escape?.collect(scalar: &queries)
+    case let .between(test, lower, upper, _):
+      test.collect(scalar: &queries)
+      lower.collect(scalar: &queries)
+      upper.collect(scalar: &queries)
+    case let .distinct(lhs, rhs, _):
+      lhs.collect(scalar: &queries)
+      rhs.collect(scalar: &queries)
+    case let .truth(inner, _, _):
+      inner.collect(scalar: &queries)
+    case let .and(lhs, rhs), let .or(lhs, rhs):
+      lhs.collect(scalar: &queries)
+      rhs.collect(scalar: &queries)
+    case let .not(operand):
+      operand.collect(scalar: &queries)
+    }
+  }
+
+  /// Collects the `EXISTS (Q)`-position subqueries this predicate nests into
+  /// `queries` — ONLY an `exists`'s `Query`, recursing the same structure
+  /// `collect(subqueries:)` does. An `IN (Q)`'s `Query` is NOT collected
+  /// here — its values are read, so it is a `valued` occurrence, not an
+  /// existential one — but its operand's own subqueries are still descended.
+  internal func collect(existential queries: inout Set<Query>) {
+    switch self {
+    case let .exists(query, _):
+      queries.insert(query)
+    case let .within(operand, _, _):
+      operand.collect(existential: &queries)
+    case let .comparison(left, _, right):
+      left.collect(existential: &queries)
+      right.collect(existential: &queries)
+    case let .bound(left, _, _):
+      left.collect(existential: &queries)
+    case let .null(operand, _):
+      operand.collect(existential: &queries)
+    case let .membership(operand, values, _):
+      operand.collect(existential: &queries)
+      for value in values { value.collect(existential: &queries) }
+    case let .like(operand, pattern, escape, _):
+      operand.collect(existential: &queries)
+      pattern.collect(existential: &queries)
+      escape?.collect(existential: &queries)
+    case let .between(test, lower, upper, _):
+      test.collect(existential: &queries)
+      lower.collect(existential: &queries)
+      upper.collect(existential: &queries)
+    case let .distinct(lhs, rhs, _):
+      lhs.collect(existential: &queries)
+      rhs.collect(existential: &queries)
+    case let .truth(inner, _, _):
+      inner.collect(existential: &queries)
+    case let .and(lhs, rhs), let .or(lhs, rhs):
+      lhs.collect(existential: &queries)
+      rhs.collect(existential: &queries)
+    case let .not(operand):
+      operand.collect(existential: &queries)
+    }
+  }
 }
 
 extension Predicate.Operand {
@@ -1111,19 +1267,39 @@ extension Predicate.Operand {
       expression.collect(valued: &queries)
     }
   }
+
+  /// Collects the scalar-subquery-position queries in this `LIKE` operand — an
+  /// expression's own, none for a `:parameter`.
+  internal func collect(scalar queries: inout Set<Query>) {
+    if case let .expression(expression) = self {
+      expression.collect(scalar: &queries)
+    }
+  }
+
+  /// Collects the `EXISTS (Q)`-position subqueries in this `LIKE` operand —
+  /// an expression's own, none for a `:parameter`.
+  internal func collect(existential queries: inout Set<Query>) {
+    if case let .expression(expression) = self {
+      expression.collect(existential: &queries)
+    }
+  }
 }
 
 extension Expression {
   /// Collects the subqueries this expression nests DIRECTLY into `queries` —
-  /// reached through a `CASE` guard or an aggregate's argument/FILTER (a scalar
-  /// expression has no other predicate) — recursing its call arguments,
-  /// arithmetic, aggregate operand and FILTER, `CASE`, `CAST`, `COALESCE`, and
-  /// `NULLIF` sub-expressions. A scalar `Expression.subquery` is a LATER slice,
-  /// so none is collected from an expression position yet.
+  /// its own scalar `subquery`, and those reached through a `CASE` guard or an
+  /// aggregate's argument/FILTER — recursing its call arguments, arithmetic,
+  /// aggregate operand and FILTER, `CASE`, `CAST`, `COALESCE`, and `NULLIF`
+  /// sub-expressions WITHOUT descending a collected subquery's own body
+  /// (`compile`/`run` recurse into it). A scalar `Expression.subquery` is
+  /// collected so the pre-pass compiles it (for its width and type) and the run
+  /// materialises its single value.
   internal func collect(subqueries queries: inout Array<Query>) {
     switch self {
     case .column, .literal:
       break
+    case let .subquery(query):
+      queries.append(query)
     case let .aggregate(_, operand, _, filter):
       if case let .expression(expression) = operand {
         expression.collect(subqueries: &queries)
@@ -1152,10 +1328,13 @@ extension Expression {
 
   /// Collects the `IN (Q)`-position subqueries this expression nests — reached
   /// through a `CASE` guard or an aggregate's argument/FILTER, mirroring
-  /// `collect(subqueries:)`. An `EXISTS` guard contributes none (it probes).
+  /// `collect(subqueries:)`. An `EXISTS` guard contributes none (it probes),
+  /// and a SCALAR `subquery` contributes none here — its single value is read
+  /// (`scalar`), not its column (`values`), so it is a `scalar` occurrence, not
+  /// a `valued` one.
   internal func collect(valued queries: inout Set<Query>) {
     switch self {
-    case .column, .literal:
+    case .column, .literal, .subquery:
       break
     case let .aggregate(_, operand, _, filter):
       if case let .expression(expression) = operand {
@@ -1183,13 +1362,86 @@ extension Expression {
     }
   }
 
-  /// Whether this expression nests any `EXISTS`/`IN (Q)` subquery — reached
-  /// through a `CASE` guard or an aggregate's argument/FILTER. The empty-fold
-  /// reads this to VALIDATE a subquery-guarded projection or sort expression
-  /// (whose selected branch a run decides at RUN by the subquery, not
-  /// statically) rather than prune it, so `columns(of:)` surfaces the same
-  /// fault the run would (`SELECT CASE WHEN EXISTS (Q) THEN 1 / 0 …` raises
-  /// `.divide`). A subquery-free expression keeps the precise empty-fold.
+  /// Collects the SCALAR-subquery-position queries this expression nests — its
+  /// own `subquery`, and those reached through a `CASE` guard or an aggregate's
+  /// argument/FILTER, mirroring `collect(subqueries:)`. A scalar occurrence is
+  /// materialised as its collapsed single VALUE (empty → NULL, one row → the
+  /// cell, more → `SQLError.cardinality`), distinct from a `valued` (`IN`) or
+  /// `EXISTS`-probe occurrence.
+  internal func collect(scalar queries: inout Set<Query>) {
+    switch self {
+    case .column, .literal:
+      break
+    case let .subquery(query):
+      queries.insert(query)
+    case let .aggregate(_, operand, _, filter):
+      if case let .expression(expression) = operand {
+        expression.collect(scalar: &queries)
+      }
+      filter?.collect(scalar: &queries)
+    case let .call(_, arguments):
+      for argument in arguments { argument.collect(scalar: &queries) }
+    case let .binary(_, lhs, rhs):
+      lhs.collect(scalar: &queries)
+      rhs.collect(scalar: &queries)
+    case let .case(whens, otherwise):
+      for when in whens {
+        when.when.collect(scalar: &queries)
+        when.then.collect(scalar: &queries)
+      }
+      otherwise?.collect(scalar: &queries)
+    case let .cast(operand, _):
+      operand.collect(scalar: &queries)
+    case let .coalesce(arguments):
+      for argument in arguments { argument.collect(scalar: &queries) }
+    case let .nullif(lhs, rhs):
+      lhs.collect(scalar: &queries)
+      rhs.collect(scalar: &queries)
+    }
+  }
+
+  /// Collects the `EXISTS (Q)`-position subqueries this expression nests —
+  /// reached through a `CASE` guard or an aggregate's FILTER, mirroring
+  /// `collect(subqueries:)`. A scalar `subquery` contributes none here — its
+  /// value is read, so it is a `scalar` occurrence, not an existential one.
+  internal func collect(existential queries: inout Set<Query>) {
+    switch self {
+    case .column, .literal, .subquery:
+      break
+    case let .aggregate(_, operand, _, filter):
+      if case let .expression(expression) = operand {
+        expression.collect(existential: &queries)
+      }
+      filter?.collect(existential: &queries)
+    case let .call(_, arguments):
+      for argument in arguments { argument.collect(existential: &queries) }
+    case let .binary(_, lhs, rhs):
+      lhs.collect(existential: &queries)
+      rhs.collect(existential: &queries)
+    case let .case(whens, otherwise):
+      for when in whens {
+        when.when.collect(existential: &queries)
+        when.then.collect(existential: &queries)
+      }
+      otherwise?.collect(existential: &queries)
+    case let .cast(operand, _):
+      operand.collect(existential: &queries)
+    case let .coalesce(arguments):
+      for argument in arguments { argument.collect(existential: &queries) }
+    case let .nullif(lhs, rhs):
+      lhs.collect(existential: &queries)
+      rhs.collect(existential: &queries)
+    }
+  }
+
+  /// Whether this expression nests any `EXISTS`/`IN (Q)`/scalar subquery —
+  /// reached through a `CASE` guard or an aggregate's argument/FILTER, or its
+  /// own scalar `subquery`. The empty-fold reads this to VALIDATE a
+  /// subquery-guarded projection or sort expression (whose selected branch a
+  /// run decides at RUN by the subquery, not statically) rather than prune it,
+  /// so `columns(of:)` surfaces the same fault the run would (`SELECT CASE WHEN
+  /// EXISTS (Q) THEN 1 / 0 …` raises `.divide`). A subquery-free expression
+  /// keeps the precise empty-fold.
   internal var subquery: Bool {
     var queries = Array<Query>()
     collect(subqueries: &queries)
@@ -1397,7 +1649,10 @@ extension Expression {
   /// computes once.
   internal func collect(into expressions: inout Array<Expression>) {
     switch self {
-    case .column, .literal:
+    case .column, .literal, .subquery:
+      // An aggregate inside a scalar `subquery` belongs to THAT subquery's own
+      // grouping, not the enclosing query's, so it is not collected here — the
+      // subquery is compiled and run as a whole plan.
       break
     case .aggregate:
       if !expressions.contains(self) {
@@ -2280,10 +2535,19 @@ extension Catalog where Self: ~Escapable {
                                    _ scope: Subscope = .caller)
       throws(SQLError) -> Subquery {
     var widths = Dictionary<Query, Int>()
+    var types = Dictionary<Query, ValueType>()
     for query in select.subqueries where widths[query] == nil {
       widths[query] = try compile(query, context, visited).width
+      // A scalar subquery contributes its single-column output type; a wider or
+      // an `EXISTS`/`IN (Q)` subquery still records the FIRST column's type
+      // (harmless — only a width-1 scalar occurrence reads it, and the lowering
+      // rejects a wider one). It derives cursor-free against the SAME context
+      // the width compile uses, so it matches what the run advertises.
+      types[query] =
+          try columns(of: query.first, context, visited: visited,
+                      validate: false).first?.type
     }
-    return Subquery(scope, widths)
+    return Subquery(scope, widths, types)
   }
 
   /// Executes every UNCORRELATED subquery `query` nests ONCE against this
@@ -2309,37 +2573,86 @@ extension Catalog where Self: ~Escapable {
   /// the end is EXISTS false. A `Query` used by BOTH is in `valued`, so its
   /// single full materialisation serves the `EXISTS` occurrence too.
   ///
+  /// A SCALAR occurrence is NOT materialised here: it collapses LAZILY on the
+  /// first evaluation of its `Term.subquery` (see the evaluator's `.subquery`
+  /// case, which runs `cell(of:)` where the catalog is in scope and memoises
+  /// the result), so a scalar subquery in an unreachable `CASE`/`COALESCE` arm
+  /// never runs and its `.cardinality` or inner fault never fires. The returned
+  /// cache carries an empty scalar memo the evaluator fills on first reach.
+  ///
   /// This runs at RUN time, where the borrowing catalog IS in scope, NOT during
   /// `compile` — so a schema-only path never reaches it and opens no cursor. It
   /// gathers every arm's directly-nested subquery (a set operation's both arms
-  /// read one cache) and runs each DISTINCT `Query` at most ONCE per
-  /// outer-query execution: its result is the same for every outer row because
-  /// the subquery is UNCORRELATED. Each runs under the SAME `context` —
+  /// read one cache) and runs each DISTINCT `IN`/`EXISTS` `Query` at most ONCE
+  /// per outer-query execution: its result is the same for every outer row
+  /// because the subquery is UNCORRELATED. Each runs under the SAME `context` —
   /// a nested subquery resolves ITS own inner subqueries through its own `run`,
   /// so this walk stays one level.
   ///
-  /// Per-arm SHORT-CIRCUIT laziness — not running a subquery an `AND`/`OR` never
-  /// reaches — is a follow-up that threads a runner to the evaluation site; this
-  /// materialises every subquery the plan syntactically nests up front.
+  /// Per-arm SHORT-CIRCUIT laziness for the `IN`/`EXISTS` roles — not running a
+  /// subquery an `AND`/`OR` never reaches — is a follow-up that threads a
+  /// runner to the predicate site; those roles still materialise up front here.
   internal borrowing func subqueries(of query: Query, _ context: Context,
                                      _ scope: Subscope = .caller)
       throws(SQLError) -> Subqueries {
     let valued = query.valued
+    let existential = query.existential
     var results = Dictionary<Subkey, MaterialisedSubquery>()
     for nested in query.subqueries {
-      let key = Subkey(scope, nested)
-      guard results[key] == nil else { continue }
+      // The SAME inner query can occur in more than one ROLE at once — a
+      // scalar subquery, an `IN` value set, and an `EXISTS` probe over
+      // identical SQL — each needing its OWN materialisation SHAPE under its
+      // OWN key, so a scalar read never hits an `IN`/`EXISTS` entry and vice
+      // versa (the role discriminates the key, see `Role`). Materialise one
+      // entry per role the occurrence appears in, each at most once.
+      //
+      // A SCALAR occurrence is NOT materialised here: it collapses LAZILY, on
+      // the FIRST evaluation of its `Term.subquery` (see the evaluator's
+      // `.subquery` case), memoised under its `(scope, query, .scalar)` key,
+      // so an occurrence in an unreachable `CASE`/`COALESCE` arm never runs —
+      // never throws `.cardinality` or an inner fault. The eager roles below
+      // are the `IN`/`EXISTS` operands a `WHERE`/`ON` is not short-circuited
+      // past.
       if valued.contains(nested) {
         // An `IN (Q)` occurrence: materialise the full result — its single
         // column of values is folded per outer row.
-        results[key] = MaterialisedSubquery(rows: try run(nested, context))
-      } else {
-        // An `EXISTS`-only occurrence: probe cardinality without evaluating the
+        let key = Subkey(scope, nested, .valued)
+        if results[key] == nil {
+          results[key] = MaterialisedSubquery(rows: try run(nested, context))
+        }
+      }
+      if existential.contains(nested) {
+        // An `EXISTS (Q)` occurrence: probe cardinality without evaluating the
         // select list or sort keys, honouring the original `OFFSET`/`FETCH`.
-        results[key] = MaterialisedSubquery(present: try probe(nested, context))
+        let key = Subkey(scope, nested, .existential)
+        if results[key] == nil {
+          results[key] = MaterialisedSubquery(present: try probe(nested,
+                                                                 context))
+        }
       }
     }
     return Subqueries(results)
+  }
+
+  /// The single VALUE a SCALAR subquery `query` collapses to against this
+  /// catalog and `context`: NULL when it yields no row, its lone cell when it
+  /// yields exactly one, and `SQLError.cardinality` when it yields more than
+  /// one (the ISO `<scalar subquery>` cardinality rule).
+  ///
+  /// The compile pre-pass checked `query`'s width to exactly 1
+  /// (`SQLError.arity`, cursor-free), so each result row has exactly one cell
+  /// and the collapse reads the first. A wider subquery never reaches here — it
+  /// faulted at compile.
+  ///
+  /// The evaluator calls this LAZILY, on the first reach of a scalar
+  /// `Term.subquery`, so an occurrence in an unreachable `CASE`/`COALESCE` arm
+  /// never runs it — preserving short-circuit semantics — and memoises the
+  /// result for the reached occurrence's later reads.
+  internal borrowing func cell(of query: Query, _ context: Context)
+      throws(SQLError) -> Value {
+    let rows = try run(query, context)
+    guard rows.count <= 1 else { throw .cardinality }
+    return rows.first?.first ?? .null
   }
 
   /// Whether `query`'s row source yields ANY row — the `EXISTS` cardinality

--- a/Sources/SQLEngine/Error.swift
+++ b/Sources/SQLEngine/Error.swift
@@ -125,6 +125,12 @@ public enum SQLError: Error, Hashable, Sendable {
   /// ill-defined; the standard requires every `ORDER BY` key under `DISTINCT`
   /// to be an output column. The string is the offending column's name.
   case distinct(String)
+  /// A scalar subquery `(SELECT …)` used where at most one row is admitted
+  /// yielded MORE THAN ONE row — the ISO `<scalar subquery>` requires a
+  /// cardinality of at most one, an empty result standing for NULL and a single
+  /// row for its lone cell. A wider result cannot collapse to one value, so a
+  /// run raises rather than picking one arbitrarily.
+  case cardinality
 }
 
 extension SQLError: CustomStringConvertible {
@@ -183,6 +189,8 @@ extension SQLError: CustomStringConvertible {
           + "or be used in an aggregate function"
     case let .distinct(name):
       "ORDER BY column '\(name)' must appear in the SELECT DISTINCT list"
+    case .cardinality:
+      "a scalar subquery yielded more than one row"
     }
   }
 }
@@ -218,9 +226,11 @@ extension SQLError {
   ///   (a `CREATE VIEW`, or a malformed `WITH` member), `SS003`, a recursive
   ///   CTE that did not reach a fixpoint within the iteration cap, `SS004`, an
   ///   aggregate query naming a non-aggregated column absent from the `GROUP
-  ///   BY`, and `SS005`, a `SELECT DISTINCT` ordering on a column absent from
-  ///   its select list. ISO leaves classes whose first character is `5`–`9` or
-  ///   `I`–`Z` implementation-defined, so `SS` is a safe squat.
+  ///   BY`, `SS005`, a `SELECT DISTINCT` ordering on a column absent from its
+  ///   select list, and `SS006`, a scalar subquery yielding more than one row
+  ///   (ISO's `21000` cardinality violation, kept in the engine's own class for
+  ///   uniformity with its siblings). ISO leaves classes whose first character
+  ///   is `5`–`9` or `I`–`Z` implementation-defined, so `SS` is a safe squat.
   public var sqlstate: String {
     switch self {
     case let .state(code, _):
@@ -263,6 +273,8 @@ extension SQLError {
       "SS004"
     case .distinct:
       "SS005"
+    case .cardinality:
+      "SS006"
     }
   }
 

--- a/Sources/SQLEngine/Filter.swift
+++ b/Sources/SQLEngine/Filter.swift
@@ -170,6 +170,19 @@ internal indirect enum Term: Equatable, Sendable {
   /// `CASE WHEN a = b THEN NULL ELSE a END` evaluated `a` twice — comparing one
   /// value and returning another — which holding `a` ONCE fixes.
   case nullif(Term, Term)
+  /// A scalar subquery `(SELECT …)` — the lowered form of the AST's
+  /// `Expression.subquery`. The subquery occurrence is carried as its cache
+  /// `Subkey` (its resolution scope composed with the inner `Query`) — never
+  /// run during `compile`, so a schema-only path opens no cursor — and its
+  /// single-column arity is enforced at COMPILE from its compiled width
+  /// (`SQLError.arity`, no cursor). At RUN it runs ONCE against the borrowed
+  /// catalog (memoised under the `Subkey` in the `Subqueries` cache,
+  /// UNCORRELATED), collapsing to its lone cell (empty → NULL, one row → the
+  /// cell, more → `SQLError.cardinality`), and the case reads that collapsed
+  /// value, COERCED to `type` — the inner column's single-column type — as a
+  /// `CASE` coerces its selected arm. A later correlated slice re-runs it per
+  /// outer row.
+  case subquery(Subkey, type: ValueType)
 }
 
 extension Term {
@@ -205,6 +218,8 @@ extension Term {
       lelems == relems && ltype == rtype
     case let (.nullif(ll, lr), .nullif(rl, rr)):
       ll == rl && lr == rr
+    case let (.subquery(lkey, ltype), .subquery(rkey, rtype)):
+      lkey == rkey && ltype == rtype
     default:
       false
     }
@@ -243,6 +258,10 @@ extension Term {
     case let .nullif(lhs, rhs):
       lhs.references(into: &slots)
       rhs.references(into: &slots)
+    case .subquery:
+      // An UNCORRELATED scalar subquery reads no cell of the outer row — its
+      // value is materialised once from the cache — so it references no slot.
+      break
     }
   }
 }
@@ -272,6 +291,9 @@ extension Term {
       .coalesce(elements.map { $0.remapped(through: slot) }, type: type)
     case let .nullif(lhs, rhs):
       .nullif(lhs.remapped(through: slot), rhs.remapped(through: slot))
+    case .subquery:
+      // A scalar subquery reads no ordinal (uncorrelated), so it is unchanged.
+      self
     }
   }
 
@@ -283,7 +305,7 @@ extension Term {
   internal var safe: Bool {
     switch self {
     case .slot, .constant: true
-    case .apply, .binary, .case, .cast, .coalesce, .nullif: false
+    case .apply, .binary, .case, .cast, .coalesce, .nullif, .subquery: false
     }
   }
 
@@ -597,28 +619,45 @@ internal func value(of literal: Literal) throws(SQLError) -> Value {
 }
 
 extension Row where Self: ~Escapable {
+  /// Evaluates a SUBQUERY-FREE `term` against this row through `routines` — the
+  /// entry point for a `CREATE FUNCTION` body (which cannot nest a subquery,
+  /// see `NoCatalog`) and the unit choke points. It runs against `NoCatalog`,
+  /// so a term that reached a scalar `.subquery` would fault; a subquery-free
+  /// one never does.
+  internal borrowing func evaluate(_ term: Term, _ routines: Routines,
+                                   _ bindings: Bindings = [:])
+      throws(SQLError) -> Value {
+    try evaluate(term, NoCatalog(), [:], routines, bindings)
+  }
+
   /// Evaluates `term` against this row through `routines`, yielding a typed
   /// value.
   ///
   /// A `slot` reads the row's cell; a `constant` is itself; an `apply` looks
   /// the function up in the routines (`SQLError.function` on a miss), evaluates
-  /// its arguments, and applies it. The `borrowing` row is non-escaping — a
-  /// term runs over a materialised projection record or a predicate's borrowed
-  /// cursor row.
-  internal borrowing func evaluate(_ term: Term, _ routines: Routines,
-                                   _ bindings: Bindings = [:],
-                                   _ subqueries: Subqueries = Subqueries())
-      throws(SQLError) -> Value {
+  /// its arguments, and applies it; a scalar `.subquery` materialises against
+  /// `catalog` LAZILY on first reach (memoised, so an unreachable arm never
+  /// runs it). The `borrowing` row is non-escaping — a term runs over a
+  /// materialised projection record or a predicate's borrowed cursor row.
+  internal borrowing func evaluate<C>(_ term: Term, _ catalog: borrowing C,
+                                      _ relations: ScopedRelations,
+                                      _ routines: Routines,
+                                      _ bindings: Bindings = [:],
+                                      _ subqueries: Subqueries = Subqueries())
+      throws(SQLError) -> Value where C: Catalog & ~Escapable {
     switch term {
     case let .slot(slot):
       self[slot]
     case let .constant(value):
       value
     case let .apply(name, arguments):
-      try apply(name, arguments, routines, bindings, subqueries)
+      try apply(name, arguments, catalog, relations, routines, bindings,
+                subqueries)
     case let .binary(op, lhs, rhs):
-      try op.apply(evaluate(lhs, routines, bindings, subqueries),
-                   evaluate(rhs, routines, bindings, subqueries))
+      try op.apply(evaluate(lhs, catalog, relations, routines, bindings,
+                            subqueries),
+                   evaluate(rhs, catalog, relations, routines, bindings,
+                            subqueries))
     case let .case(branches, otherwise, type):
       // Take the FIRST branch whose guard is three-valued TRUE (UNKNOWN and
       // FALSE skip); with none matching, the `else` term, or `NULL` when there
@@ -627,19 +666,53 @@ extension Row where Self: ~Escapable {
       // `:parameter` guard resolves against the bindings, an UNKNOWN one does
       // not select its branch. The selected value is COERCED to the CASE's
       // unified result `type` so it matches the column type the schema
-      // advertised.
-      try conditional(branches, otherwise, type, routines, bindings,
-                      subqueries)
+      // advertised. A scalar subquery in an UNREACHED arm is never evaluated,
+      // so it never runs (never throws) — the lazy `.subquery` case honours it.
+      try conditional(branches, otherwise, type, catalog, relations, routines,
+                      bindings, subqueries)
     case let .cast(operand, type):
       // Evaluate the operand and CONVERT it to the target type: NULL casts to
       // NULL, an unconvertible value faults (`Value.cast(to:)`), never yielding
       // a wrong value.
-      try evaluate(operand, routines, bindings, subqueries).cast(to: type)
+      try evaluate(operand, catalog, relations, routines, bindings, subqueries)
+          .cast(to: type)
     case let .coalesce(elements, type):
-      try coalesce(elements, type, routines, bindings, subqueries)
+      try coalesce(elements, type, catalog, relations, routines, bindings,
+                   subqueries)
     case let .nullif(lhs, rhs):
-      try nullif(lhs, rhs, routines, bindings, subqueries)
+      try nullif(lhs, rhs, catalog, relations, routines, bindings, subqueries)
+    case let .subquery(key, type):
+      // Materialise the scalar subquery LAZILY on this first reach — an
+      // occurrence in a skipped `CASE`/`COALESCE` arm is never reached, so it
+      // never runs (never throws). COERCE the collapsed value to the inner
+      // column's type, as a `CASE` coerces its selected arm.
+      try scalar(key, type, catalog, relations, routines, bindings, subqueries)
     }
+  }
+
+  /// The value of a scalar subquery occurrence `key`, materialised LAZILY and
+  /// MEMOISED: on the first reach it runs the inner query ONCE (where `catalog`
+  /// is in scope) — empty → NULL, one row → its cell, more → `.cardinality`,
+  /// plus any inner fault — collapsing to one value and caching it under `key`;
+  /// a later reach returns the cached value WITHOUT re-running.
+  ///
+  /// The subquery is UNCORRELATED, so its value is row-invariant — one run per
+  /// REACHED occurrence, none for one only in a skipped arm. The value is
+  /// COERCED to the inner column's `type`, as a `CASE` coerces its taken arm.
+  private borrowing func scalar<C>(_ key: Subkey, _ type: ValueType,
+                                   _ catalog: borrowing C,
+                                   _ relations: ScopedRelations,
+                                   _ routines: Routines, _ bindings: Bindings,
+                                   _ subqueries: Subqueries)
+      throws(SQLError) -> Value where C: Catalog & ~Escapable {
+    if let cached = subqueries.scalar(cached: key) {
+      return cached.coerced(to: type)
+    }
+    let context = Context(relations: relations, routines: routines,
+                          bindings: bindings, subqueries: subqueries)
+    let value = try catalog.cell(of: key.query, context)
+    subqueries.store(scalar: value, for: key)
+    return value.coerced(to: type)
   }
 
   /// Evaluates a lowered `COALESCE(v1, v2, …)` against this row — the
@@ -653,12 +726,16 @@ extension Row where Self: ~Escapable {
   /// `Value.coerced` widens the selected value to `type` (a `.integer` element
   /// of a `.double` COALESCE), exactly as a `CASE` coerces its taken branch;
   /// NULL passes unchanged.
-  private borrowing func coalesce(_ elements: Array<Term>, _ type: ValueType,
-                                  _ routines: Routines, _ bindings: Bindings,
-                                  _ subqueries: Subqueries)
-      throws(SQLError) -> Value {
+  private borrowing func coalesce<C>(_ elements: Array<Term>,
+                                     _ type: ValueType, _ catalog: borrowing C,
+                                     _ relations: ScopedRelations,
+                                     _ routines: Routines,
+                                     _ bindings: Bindings,
+                                     _ subqueries: Subqueries)
+      throws(SQLError) -> Value where C: Catalog & ~Escapable {
     for element in elements {
-      let value = try evaluate(element, routines, bindings, subqueries)
+      let value = try evaluate(element, catalog, relations, routines, bindings,
+                               subqueries)
       if case .null = value { continue }
       return value.coerced(to: type)
     }
@@ -674,12 +751,16 @@ extension Row where Self: ~Escapable {
   /// one value and returned another; holding `va` fixes that. `matches` is
   /// three-valued: only a definite TRUE equality nulls out, so an UNKNOWN (a
   /// NULL operand) yields `va`.
-  private borrowing func nullif(_ lhs: Term, _ rhs: Term,
-                                _ routines: Routines, _ bindings: Bindings,
-                                _ subqueries: Subqueries)
-      throws(SQLError) -> Value {
-    let va = try evaluate(lhs, routines, bindings, subqueries)
-    let vb = try evaluate(rhs, routines, bindings, subqueries)
+  private borrowing func nullif<C>(_ lhs: Term, _ rhs: Term,
+                                   _ catalog: borrowing C,
+                                   _ relations: ScopedRelations,
+                                   _ routines: Routines, _ bindings: Bindings,
+                                   _ subqueries: Subqueries)
+      throws(SQLError) -> Value where C: Catalog & ~Escapable {
+    let va = try evaluate(lhs, catalog, relations, routines, bindings,
+                          subqueries)
+    let vb = try evaluate(rhs, catalog, relations, routines, bindings,
+                          subqueries)
     return matches(va, .equal, vb) == true ? .null : va
   }
 
@@ -692,35 +773,41 @@ extension Row where Self: ~Escapable {
   /// arm of a CASE that unifies to `.double` must widen to match.
   /// `Value.coerced` performs that one widening; NULL and an already-matching
   /// value pass unchanged, so an all-same CASE (no widening) is untouched.
-  private borrowing func conditional(_ branches: Array<(Filter, Term)>,
-                                     _ otherwise: Term?, _ type: ValueType,
-                                     _ routines: Routines,
-                                     _ bindings: Bindings,
-                                     _ subqueries: Subqueries)
-      throws(SQLError) -> Value {
+  private borrowing func conditional<C>(_ branches: Array<(Filter, Term)>,
+                                        _ otherwise: Term?, _ type: ValueType,
+                                        _ catalog: borrowing C,
+                                        _ relations: ScopedRelations,
+                                        _ routines: Routines,
+                                        _ bindings: Bindings,
+                                        _ subqueries: Subqueries)
+      throws(SQLError) -> Value where C: Catalog & ~Escapable {
     for (gate, result) in branches {
-      if try evaluate(gate, routines, bindings, subqueries) == true {
-        return try evaluate(result, routines, bindings, subqueries)
-            .coerced(to: type)
+      if try evaluate(gate, catalog, relations, routines, bindings,
+                      subqueries) == true {
+        return try evaluate(result, catalog, relations, routines, bindings,
+                            subqueries).coerced(to: type)
       }
     }
     guard let otherwise else { return .null }
-    return try evaluate(otherwise, routines, bindings, subqueries)
-        .coerced(to: type)
+    return try evaluate(otherwise, catalog, relations, routines, bindings,
+                        subqueries).coerced(to: type)
   }
 
   /// Resolves `name` in `routines` and applies it to its evaluated `arguments`.
-  private borrowing func apply(_ name: String, _ arguments: Array<Term>,
-                               _ routines: Routines, _ bindings: Bindings,
-                               _ subqueries: Subqueries)
-      throws(SQLError) -> Value {
+  private borrowing func apply<C>(_ name: String, _ arguments: Array<Term>,
+                                  _ catalog: borrowing C,
+                                  _ relations: ScopedRelations,
+                                  _ routines: Routines, _ bindings: Bindings,
+                                  _ subqueries: Subqueries)
+      throws(SQLError) -> Value where C: Catalog & ~Escapable {
     guard let routine = routines[name] else {
       throw .function(name)
     }
     var values = Array<Value>()
     values.reserveCapacity(arguments.count)
     for argument in arguments {
-      try values.append(evaluate(argument, routines, bindings, subqueries))
+      try values.append(evaluate(argument, catalog, relations, routines,
+                                 bindings, subqueries))
     }
     let result = try routine(values)
     // A registered routine is a public producer of `Value`s that bypasses the
@@ -938,6 +1025,17 @@ internal func tested(_ operand: Bool?, _ value: Truth, _ negated: Bool)
 }
 
 extension Row where Self: ~Escapable {
+  /// Evaluates a SUBQUERY-FREE `filter` against this row under three-valued
+  /// logic through `routines` and `bindings` — the choke point a unit test
+  /// drives directly. It runs against `NoCatalog`, so a filter that reached an
+  /// `EXISTS`/`IN (Q)`/scalar subquery would fault; a subquery-free one never
+  /// does.
+  internal borrowing func evaluate(_ filter: Filter, _ routines: Routines,
+                                   _ bindings: Bindings)
+      throws(SQLError) -> Bool? {
+    try evaluate(filter, NoCatalog(), [:], routines, bindings)
+  }
+
   /// Evaluates `filter` against this row under three-valued logic, resolving
   /// scalar calls through `routines` and any bound parameter from `bindings`.
   ///
@@ -955,33 +1053,42 @@ extension Row where Self: ~Escapable {
   /// (its `== true` gate), so UNKNOWN and `false` both reject. The `borrowing`
   /// row is non-escaping; it threads into the recursion freely and is never
   /// stored.
-  internal borrowing func evaluate(_ filter: Filter, _ routines: Routines,
-                                   _ bindings: Bindings,
-                                   _ subqueries: Subqueries = Subqueries())
-      throws(SQLError) -> Bool? {
+  internal borrowing func evaluate<C>(_ filter: Filter, _ catalog: borrowing C,
+                                      _ relations: ScopedRelations,
+                                      _ routines: Routines,
+                                      _ bindings: Bindings,
+                                      _ subqueries: Subqueries = Subqueries())
+      throws(SQLError) -> Bool? where C: Catalog & ~Escapable {
     switch filter {
     case let .compare(lhs, op, rhs):
-      try matches(evaluate(lhs, routines, bindings, subqueries), op,
-                  evaluate(rhs, routines, bindings, subqueries))
+      try matches(evaluate(lhs, catalog, relations, routines, bindings,
+                           subqueries), op,
+                  evaluate(rhs, catalog, relations, routines, bindings,
+                           subqueries))
     case let .bound(term, op, parameter):
       if let operand = bindings[parameter] {
-        try matches(evaluate(term, routines, bindings, subqueries), op, operand)
+        try matches(evaluate(term, catalog, relations, routines, bindings,
+                             subqueries), op, operand)
       } else {
         nil
       }
     case let .match(left, right):
       matches(self[left], .equal, self[right])
     case let .null(term, negated):
-      try (evaluate(term, routines, bindings, subqueries) == .null) != negated
+      try (evaluate(term, catalog, relations, routines, bindings,
+                    subqueries) == .null) != negated
     case let .membership(operand, elements, negated):
-      try member(operand, elements, negated, routines, bindings, subqueries)
+      try member(operand, elements, negated, catalog, relations, routines,
+                 bindings, subqueries)
     case let .like(operand, pattern, escape, negated):
-      try like(operand, pattern, escape, negated, routines, bindings,
-               subqueries)
+      try like(operand, pattern, escape, negated, catalog, relations, routines,
+               bindings, subqueries)
     case let .between(test, lower, upper, negated):
-      try ranged(test, lower, upper, negated, routines, bindings, subqueries)
+      try ranged(test, lower, upper, negated, catalog, relations, routines,
+                 bindings, subqueries)
     case let .distinct(lhs, rhs, negated):
-      try differs(lhs, rhs, negated, routines, bindings, subqueries)
+      try differs(lhs, rhs, negated, catalog, relations, routines, bindings,
+                  subqueries)
     case let .exists(key, negated):
       // The subquery ran ONCE at run start (memoised under its `Subkey` in the
       // cache); this reads the DEFINITE two-valued non-empty test — never
@@ -991,33 +1098,40 @@ extension Row where Self: ~Escapable {
     case let .within(operand, key, negated):
       // Fold `operand = v` over the subquery's memoised single column under the
       // SAME three-valued membership the value-list `IN` uses.
-      try member(operand, subqueries.values(key), negated, routines,
-                 bindings, subqueries)
+      try member(operand, subqueries.values(key), negated, catalog, relations,
+                 routines, bindings, subqueries)
     case let .truth(inner, value, negated):
-      try tested(evaluate(inner, routines, bindings, subqueries), value,
-                 negated)
+      try tested(evaluate(inner, catalog, relations, routines, bindings,
+                          subqueries), value, negated)
     case let .and(lhs, rhs):
       // `&&`/`||` take an `@autoclosure` right operand, which would capture the
       // borrowed `~Escapable` row; spell each connective explicitly so a branch
       // re-borrows the row rather than capturing it. Kleene `AND`: `false`
       // dominates, an UNKNOWN left yields `false` only against a `false` right.
-      switch try evaluate(lhs, routines, bindings, subqueries) {
+      switch try evaluate(lhs, catalog, relations, routines, bindings,
+                          subqueries) {
       case false?: false
-      case true?: try evaluate(rhs, routines, bindings, subqueries)
+      case true?:
+        try evaluate(rhs, catalog, relations, routines, bindings, subqueries)
       case nil:
-        try evaluate(rhs, routines, bindings, subqueries) == false ? false : nil
+        try evaluate(rhs, catalog, relations, routines, bindings,
+                     subqueries) == false ? false : nil
       }
     case let .or(lhs, rhs):
       // Kleene `OR`: `true` dominates, an UNKNOWN left yields `true` only
       // against a `true` right.
-      switch try evaluate(lhs, routines, bindings, subqueries) {
+      switch try evaluate(lhs, catalog, relations, routines, bindings,
+                          subqueries) {
       case true?: true
-      case false?: try evaluate(rhs, routines, bindings, subqueries)
+      case false?:
+        try evaluate(rhs, catalog, relations, routines, bindings, subqueries)
       case nil:
-        try evaluate(rhs, routines, bindings, subqueries) == true ? true : nil
+        try evaluate(rhs, catalog, relations, routines, bindings,
+                     subqueries) == true ? true : nil
       }
     case let .not(operand):
-      try evaluate(operand, routines, bindings, subqueries).map { !$0 }
+      try evaluate(operand, catalog, relations, routines, bindings,
+                   subqueries).map { !$0 }
     }
   }
 
@@ -1031,14 +1145,18 @@ extension Row where Self: ~Escapable {
   /// three-valued result: an unmatched test yields UNKNOWN, not FALSE). `NOT
   /// IN` negates that three-valued truth, mapping UNKNOWN to itself via
   /// `map(!)`.
-  private borrowing func member(_ operand: Term, _ elements: Array<Term>,
-                                _ negated: Bool, _ routines: Routines,
-                                _ bindings: Bindings, _ subqueries: Subqueries)
-      throws(SQLError) -> Bool? {
-    let value = try evaluate(operand, routines, bindings, subqueries)
+  private borrowing func member<C>(_ operand: Term, _ elements: Array<Term>,
+                                   _ negated: Bool, _ catalog: borrowing C,
+                                   _ relations: ScopedRelations,
+                                   _ routines: Routines, _ bindings: Bindings,
+                                   _ subqueries: Subqueries)
+      throws(SQLError) -> Bool? where C: Catalog & ~Escapable {
+    let value = try evaluate(operand, catalog, relations, routines, bindings,
+                             subqueries)
     var truth: Bool? = false
     for element in elements {
-      let element = try evaluate(element, routines, bindings, subqueries)
+      let element = try evaluate(element, catalog, relations, routines,
+                                 bindings, subqueries)
       truth = or(truth, matches(value, .equal, element))
       if truth == true { break }
     }
@@ -1056,11 +1174,14 @@ extension Row where Self: ~Escapable {
   /// `values` folds FALSE (no witness), and `NOT IN` negates that truth,
   /// mapping UNKNOWN to itself. It reuses the SAME `matches`/`or` primitives
   /// the value-list `IN` does, so the two forms share one three-valued core.
-  private borrowing func member(_ operand: Term, _ values: Array<Value>,
-                                _ negated: Bool, _ routines: Routines,
-                                _ bindings: Bindings, _ subqueries: Subqueries)
-      throws(SQLError) -> Bool? {
-    let value = try evaluate(operand, routines, bindings, subqueries)
+  private borrowing func member<C>(_ operand: Term, _ values: Array<Value>,
+                                   _ negated: Bool, _ catalog: borrowing C,
+                                   _ relations: ScopedRelations,
+                                   _ routines: Routines, _ bindings: Bindings,
+                                   _ subqueries: Subqueries)
+      throws(SQLError) -> Bool? where C: Catalog & ~Escapable {
+    let value = try evaluate(operand, catalog, relations, routines, bindings,
+                             subqueries)
     var truth: Bool? = false
     for element in values {
       truth = or(truth, matches(value, .equal, element))
@@ -1096,16 +1217,21 @@ extension Row where Self: ~Escapable {
   /// run-time `:parameter` resolved from the bindings (an unbound or NULL-bound
   /// one reading UNKNOWN, excluding the row) — the same binding a comparison's
   /// right operand accepts.
-  private borrowing func ranged(_ test: Term, _ lower: Filter.Operand,
-                                _ upper: Filter.Operand,
-                                _ negated: Bool, _ routines: Routines,
-                                _ bindings: Bindings, _ subqueries: Subqueries)
-      throws(SQLError) -> Bool? {
-    let value = try evaluate(test, routines, bindings, subqueries)
-    let low = try evaluate(lower, routines, bindings, subqueries)
+  private borrowing func ranged<C>(_ test: Term, _ lower: Filter.Operand,
+                                   _ upper: Filter.Operand, _ negated: Bool,
+                                   _ catalog: borrowing C,
+                                   _ relations: ScopedRelations,
+                                   _ routines: Routines, _ bindings: Bindings,
+                                   _ subqueries: Subqueries)
+      throws(SQLError) -> Bool? where C: Catalog & ~Escapable {
+    let value = try evaluate(test, catalog, relations, routines, bindings,
+                             subqueries)
+    let low = try evaluate(lower, catalog, relations, routines, bindings,
+                           subqueries)
     let above = matches(value, .geq, low)
     guard above != false else { return negated }
-    let high = try evaluate(upper, routines, bindings, subqueries)
+    let high = try evaluate(upper, catalog, relations, routines, bindings,
+                            subqueries)
     let within = and(above, matches(value, .leq, high))
     return negated ? within.map { !$0 } : within
   }
@@ -1119,26 +1245,34 @@ extension Row where Self: ~Escapable {
   /// FROM` reads that; `IS NOT DISTINCT FROM` (`negated`, null-safe equality)
   /// negates it. Unlike a `compare`, a NULL operand never makes the row
   /// UNKNOWN.
-  private borrowing func differs(_ lhs: Term, _ rhs: Term, _ negated: Bool,
-                                 _ routines: Routines, _ bindings: Bindings,
-                                 _ subqueries: Subqueries)
-      throws(SQLError) -> Bool? {
-    let differ = try distinct(evaluate(lhs, routines, bindings, subqueries),
-                              evaluate(rhs, routines, bindings, subqueries))
+  private borrowing func differs<C>(_ lhs: Term, _ rhs: Term, _ negated: Bool,
+                                    _ catalog: borrowing C,
+                                    _ relations: ScopedRelations,
+                                    _ routines: Routines,
+                                    _ bindings: Bindings,
+                                    _ subqueries: Subqueries)
+      throws(SQLError) -> Bool? where C: Catalog & ~Escapable {
+    let differ =
+        try distinct(evaluate(lhs, catalog, relations, routines, bindings,
+                              subqueries),
+                     evaluate(rhs, catalog, relations, routines, bindings,
+                              subqueries))
     return negated ? !differ : differ
   }
 
   /// Resolves a `LIKE` pattern or escape operand to a value: a term evaluates
   /// against this row, a `:parameter` resolves from the bindings — an unbound
   /// name yields `.null`, so it reads UNKNOWN exactly as a bound `NULL` does.
-  private borrowing func evaluate(_ operand: Filter.Operand,
-                                  _ routines: Routines,
-                                  _ bindings: Bindings,
-                                  _ subqueries: Subqueries)
-      throws(SQLError) -> Value {
+  private borrowing func evaluate<C>(_ operand: Filter.Operand,
+                                     _ catalog: borrowing C,
+                                     _ relations: ScopedRelations,
+                                     _ routines: Routines,
+                                     _ bindings: Bindings,
+                                     _ subqueries: Subqueries)
+      throws(SQLError) -> Value where C: Catalog & ~Escapable {
     switch operand {
     case let .term(term):
-      try evaluate(term, routines, bindings, subqueries)
+      try evaluate(term, catalog, relations, routines, bindings, subqueries)
     case let .parameter(name):
       bindings[name] ?? .null
     }
@@ -1159,19 +1293,24 @@ extension Row where Self: ~Escapable {
   /// against the operand through the `%`/`_` matcher. The pattern and escape
   /// may be a `:parameter` resolved from the bindings. `NOT LIKE` negates the
   /// result (UNKNOWN maps to itself).
-  private borrowing func like(_ operand: Term, _ pattern: Filter.Operand,
-                              _ escape: Filter.Operand?, _ negated: Bool,
-                              _ routines: Routines, _ bindings: Bindings,
-                              _ subqueries: Subqueries)
-      throws(SQLError) -> Bool? {
+  private borrowing func like<C>(_ operand: Term, _ pattern: Filter.Operand,
+                                 _ escape: Filter.Operand?, _ negated: Bool,
+                                 _ catalog: borrowing C,
+                                 _ relations: ScopedRelations,
+                                 _ routines: Routines, _ bindings: Bindings,
+                                 _ subqueries: Subqueries)
+      throws(SQLError) -> Bool? where C: Catalog & ~Escapable {
     // Evaluate all three reached operands once, in order — a fault in any of
     // them (a divide, an overflow) propagates HERE, before the NULL/escape
     // result below can turn it into a silent UNKNOWN.
-    let subject = try evaluate(operand, routines, bindings, subqueries)
-    let template = try evaluate(pattern, routines, bindings, subqueries)
+    let subject = try evaluate(operand, catalog, relations, routines, bindings,
+                               subqueries)
+    let template = try evaluate(pattern, catalog, relations, routines,
+                                bindings, subqueries)
     let separator: Value? =
         if let escape {
-          try evaluate(escape, routines, bindings, subqueries)
+          try evaluate(escape, catalog, relations, routines, bindings,
+                       subqueries)
         } else {
           nil
         }

--- a/Sources/SQLEngine/Function.swift
+++ b/Sources/SQLEngine/Function.swift
@@ -194,9 +194,45 @@ public struct Routine: Sendable {
           where !argument.matches(expected) {
         throw .argument("requires \(expected.domain) arguments")
       }
+      // The body's lowered `term` cannot nest a subquery — a `CREATE FUNCTION`
+      // body lowers against `Subquery.unsupported` (no catalog), which rejects
+      // one at registration — so the subquery-free evaluate suffices.
       return try Record(arguments).evaluate(term, routines)
     }
   }
+}
+
+/// An empty `Catalog` vending no relation — the stand-in for the absent catalog
+/// where the evaluator runs a subquery-FREE term.
+///
+/// A `CREATE FUNCTION` body lowers against `Subquery.unsupported`, so its term
+/// can never nest a scalar subquery and its evaluation never needs a catalog to
+/// materialise one. Passing this empty catalog keeps ONE evaluator: a term that
+/// did reach a `.subquery` would run `cell(of:)` against a catalog resolving no
+/// relation and fault, but a function body never does.
+internal struct NoCatalog: Catalog {
+  internal struct Table: SQLEngine.Table {
+    internal struct Cursor: SQLEngine.Cursor {
+      internal struct Row: SQLEngine.Row {
+        internal subscript(_ column: Int) -> Value { .null }
+      }
+
+      internal var count: Int { 0 }
+      internal func row(_ index: Int) -> Row? { nil }
+    }
+
+    internal var width: Int { 0 }
+    internal var names: Array<String> { [] }
+    internal func ordinal(of name: String) -> Int? { nil }
+    internal func bound(_ column: Int, _ value: Int, strict: Bool) -> Int? {
+      nil
+    }
+
+    internal func cursor() -> Cursor { Cursor() }
+  }
+
+  internal func table(named name: String) -> Table? { nil }
+  internal func relations() -> Array<String> { [] }
 }
 
 extension Value {

--- a/Sources/SQLEngine/Operator.swift
+++ b/Sources/SQLEngine/Operator.swift
@@ -332,15 +332,23 @@ extension Catalog where Self: ~Escapable {
       // Fuse a residual product with its filter: stream each pair through the
       // predicate rather than materialising the whole cross product first.
       return try sift(execute(outer, context), execute(inner, context),
-                      filter, routines, bindings, subqueries)
+                      filter, self, context.relations, routines, bindings,
+                      subqueries)
     case let .select(filter, source):
-      return try admitted(execute(source, context), filter, routines,
-                          bindings, subqueries)
+      return try admitted(execute(source, context), filter, self,
+                          context.relations, routines, bindings, subqueries)
     case let .project(terms, source):
-      return try execute(source, context)
-        .map { record throws(SQLError) in
-          try project(terms, record, routines, bindings, subqueries)
-        }
+      // An explicit loop, not a `.map` closure: the borrowed `~Escapable` self
+      // a projected scalar subquery materialises against cannot be captured by
+      // a closure, so each record projects in a direct re-borrow.
+      let source = try execute(source, context)
+      var projected = Array<Record>()
+      projected.reserveCapacity(source.count)
+      for record in source {
+        try projected.append(project(terms, record, self, context.relations,
+                                     routines, bindings, subqueries))
+      }
+      return projected
     case let .sort(keys, source):
       // Evaluate each key's `Term` against every record UP FRONT — a bare slot
       // read, but any lowered expression (`a + b`, `UPPER(Name)`, an ordinal's
@@ -348,12 +356,19 @@ extension Catalog where Self: ~Escapable {
       // values. Evaluation may throw (a scalar call, a division), which a
       // `sorted(by:)` comparator cannot, so it happens here rather than inside
       // the sort; it also evaluates each key once per row rather than once per
-      // comparison.
+      // comparison. An explicit loop keeps the borrowed `self` a scalar sort
+      // key materialises against out of a closure capture.
       let rows = try execute(source, context)
-      let sortable = try rows.map { record throws(SQLError) in
-        try keys.map { key throws(SQLError) in
-          try record.evaluate(key.term, routines, bindings, subqueries)
+      var sortable = Array<Array<Value>>()
+      sortable.reserveCapacity(rows.count)
+      for record in rows {
+        var cells = Array<Value>()
+        cells.reserveCapacity(keys.count)
+        for key in keys {
+          try cells.append(record.evaluate(key.term, self, context.relations,
+                                           routines, bindings, subqueries))
         }
+        sortable.append(cells)
       }
       return sortable.indices
         .sorted { lhs, rhs in
@@ -382,14 +397,14 @@ extension Catalog where Self: ~Escapable {
       // yields no rows to read a width off.
       return try outer(execute(left, context), left.slots ?? 0,
                        execute(right, context), right.slots ?? 0, on, kind,
-                       routines, bindings, subqueries)
+                       self, context.relations, routines, bindings, subqueries)
     case let .setop(kind, left, right, all):
       return try setop(kind, left, right, all, context)
     case let .distinct(source):
       return deduplicated(try execute(source, context))
     case let .aggregate(keys, aggregates, source):
-      return try grouped(execute(source, context), keys, aggregates,
-                         routines, bindings, subqueries)
+      return try grouped(execute(source, context), keys, aggregates, self,
+                         context.relations, routines, bindings, subqueries)
     case let .limit(count, offset, source):
       return limited(try execute(source, context), count, offset)
     }
@@ -548,29 +563,36 @@ private func deduplicated(_ records: Array<Record>) -> Array<Record> {
 }
 
 /// Evaluates each projected `term` against `record` through `routines` to the
-/// output row, in order — slot `i` of the result is `terms[i]`.
-private func project(_ terms: Array<Term>, _ record: Record,
-                     _ routines: Routines, _ bindings: Bindings,
-                     _ subqueries: Subqueries)
-    throws(SQLError) -> Record {
+/// output row, in order — slot `i` of the result is `terms[i]`. The `catalog`
+/// and `relations` thread through so a projected scalar subquery materialises
+/// lazily on first reach (see the evaluator's `.subquery` case).
+private func project<C>(_ terms: Array<Term>, _ record: Record,
+                        _ catalog: borrowing C, _ relations: ScopedRelations,
+                        _ routines: Routines, _ bindings: Bindings,
+                        _ subqueries: Subqueries)
+    throws(SQLError) -> Record where C: Catalog & ~Escapable {
   var cells = Array<Value>()
   cells.reserveCapacity(terms.count)
   for term in terms {
-    try cells.append(record.evaluate(term, routines, bindings, subqueries))
+    try cells.append(record.evaluate(term, catalog, relations, routines,
+                                     bindings, subqueries))
   }
   return Record(cells)
 }
 
 /// Keeps the `records` the `filter` admits — those it evaluates to `true` under
 /// three-valued logic (UNKNOWN and `false` both reject), resolving scalar calls
-/// through `routines` and parameters from `bindings`.
-private func admitted(_ records: Array<Record>, _ filter: Filter,
-                      _ routines: Routines, _ bindings: Bindings,
-                      _ subqueries: Subqueries)
-    throws(SQLError) -> Array<Record> {
+/// through `routines` and parameters from `bindings`. The `catalog` and
+/// `relations` thread through for a scalar subquery in `filter`.
+private func admitted<C>(_ records: Array<Record>, _ filter: Filter,
+                         _ catalog: borrowing C, _ relations: ScopedRelations,
+                         _ routines: Routines, _ bindings: Bindings,
+                         _ subqueries: Subqueries)
+    throws(SQLError) -> Array<Record> where C: Catalog & ~Escapable {
   var kept = Array<Record>()
   for record in records {
-    if try record.evaluate(filter, routines, bindings, subqueries) == true {
+    if try record.evaluate(filter, catalog, relations, routines, bindings,
+                           subqueries) == true {
       kept.append(record)
     }
   }
@@ -681,15 +703,17 @@ private func product(_ outer: Array<Record>, _ inner: Array<Record>)
 /// product: outer-major, each admitted inner in its own order. A pair the
 /// `filter` evaluates to `true` under three-valued logic is kept; UNKNOWN and
 /// `false` both drop, exactly as `admitted`.
-private func sift(_ outer: Array<Record>, _ inner: Array<Record>,
-                  _ filter: Filter, _ routines: Routines, _ bindings: Bindings,
-                  _ subqueries: Subqueries)
-    throws(SQLError) -> Array<Record> {
+private func sift<C>(_ outer: Array<Record>, _ inner: Array<Record>,
+                     _ filter: Filter, _ catalog: borrowing C,
+                     _ relations: ScopedRelations, _ routines: Routines,
+                     _ bindings: Bindings, _ subqueries: Subqueries)
+    throws(SQLError) -> Array<Record> where C: Catalog & ~Escapable {
   var records = Array<Record>()
   for left in outer {
     for right in inner {
       let record = left.merged(with: right)
-      if try record.evaluate(filter, routines, bindings, subqueries) == true {
+      if try record.evaluate(filter, catalog, relations, routines, bindings,
+                             subqueries) == true {
         records.append(record)
       }
     }
@@ -718,11 +742,12 @@ private func sift(_ outer: Array<Record>, _ inner: Array<Record>,
 ///
 /// A `.inner` kind never reaches here — `compile` lowers an inner join through
 /// the product/join path.
-private func outer(_ left: Array<Record>, _ leftWidth: Int,
-                   _ right: Array<Record>, _ rightWidth: Int, _ on: Filter,
-                   _ kind: Join.Kind, _ routines: Routines,
-                   _ bindings: Bindings, _ subqueries: Subqueries)
-    throws(SQLError) -> Array<Record> {
+private func outer<C>(_ left: Array<Record>, _ leftWidth: Int,
+                      _ right: Array<Record>, _ rightWidth: Int, _ on: Filter,
+                      _ kind: Join.Kind, _ catalog: borrowing C,
+                      _ relations: ScopedRelations, _ routines: Routines,
+                      _ bindings: Bindings, _ subqueries: Subqueries)
+    throws(SQLError) -> Array<Record> where C: Catalog & ~Escapable {
   let leftNulls = Record(Array(repeating: .null, count: leftWidth))
   let rightNulls = Record(Array(repeating: .null, count: rightWidth))
 
@@ -736,7 +761,8 @@ private func outer(_ left: Array<Record>, _ leftWidth: Int,
       var paired = false
       for outer in left {
         let record = outer.merged(with: inner)
-        if try record.evaluate(on, routines, bindings, subqueries) == true {
+        if try record.evaluate(on, catalog, relations, routines, bindings,
+                               subqueries) == true {
           records.append(record)
           paired = true
         }
@@ -755,7 +781,8 @@ private func outer(_ left: Array<Record>, _ leftWidth: Int,
     var paired = false
     for index in right.indices {
       let record = outer.merged(with: right[index])
-      if try record.evaluate(on, routines, bindings, subqueries) == true {
+      if try record.evaluate(on, catalog, relations, routines, bindings,
+                             subqueries) == true {
         records.append(record)
         matched[index] = true
         paired = true
@@ -866,16 +893,17 @@ extension Catalog where Self: ~Escapable {
       for index in 0 ..< cte.rows.count {
         let right = cte.record(index, ordinals)
         if let filter,
-            try right.evaluate(filter, routines, bindings,
-                               subqueries) != true { continue }
+            try right.evaluate(filter, self, context.relations, routines,
+                               bindings, subqueries) != true { continue }
         inner.append(right)
       }
       return joined(outer, inner, base, keys)
     }
     guard let inner = table(named: name) else { throw .relation(name) }
     guard inner.seekable(column) else {
-      return try inner.hashed(outer, ordinals, base, keys, filter, routines,
-                              bindings, subqueries)
+      return try inner.hashed(outer, ordinals, base, keys, filter, self,
+                              context.relations, routines, bindings,
+                              subqueries)
     }
 
     let cursor = inner.cursor()
@@ -897,8 +925,8 @@ extension Catalog where Self: ~Escapable {
         // A pushed inner filter is applied as each candidate materialises,
         // before it can pair — an inner row it rejects joins to nothing.
         if let filter,
-            try right.evaluate(filter, routines, bindings,
-                               subqueries) != true { continue }
+            try right.evaluate(filter, self, context.relations, routines,
+                               bindings, subqueries) != true { continue }
         // Equal by the SAME rule the predicate uses — integer/integer exact,
         // mixed integer/double promoted — so a seek that scanned wide still
         // pairs exactly.
@@ -938,13 +966,16 @@ extension Catalog where Self: ~Escapable {
 /// WHERE (`… WHERE key IS NULL`, or one pruning every row) must not force a full
 /// scan of a large unseekable inner.
 extension Table where Self: ~Escapable {
-  fileprivate borrowing func hashed(_ outer: Array<Record>,
-                                    _ ordinals: Array<Int>, _ base: Int,
-                                    _ keys: (left: Int, right: Int),
-                                    _ filter: Filter?, _ routines: Routines,
-                                    _ bindings: Bindings,
-                                    _ subqueries: Subqueries)
-      throws(SQLError) -> Array<Record> {
+  fileprivate borrowing func hashed<C>(_ outer: Array<Record>,
+                                       _ ordinals: Array<Int>, _ base: Int,
+                                       _ keys: (left: Int, right: Int),
+                                       _ filter: Filter?,
+                                       _ catalog: borrowing C,
+                                       _ relations: ScopedRelations,
+                                       _ routines: Routines,
+                                       _ bindings: Bindings,
+                                       _ subqueries: Subqueries)
+      throws(SQLError) -> Array<Record> where C: Catalog & ~Escapable {
     guard outer.contains(where: {
       if case .null = $0[keys.left] { false } else { true }
     }) else { return [] }
@@ -962,7 +993,7 @@ extension Table where Self: ~Escapable {
       // Apply the whole pushed filter before bucketing — a filtered inner row
       // is never a join candidate.
       if let filter,
-          try right.evaluate(filter, routines, bindings,
+          try right.evaluate(filter, catalog, relations, routines, bindings,
                              subqueries) != true { continue }
       if case .null = right[slot] { continue }
       buckets[bucket(right[slot]), default: Array<Record>()].append(right)

--- a/Sources/SQLEngine/OutputColumn.swift
+++ b/Sources/SQLEngine/OutputColumn.swift
@@ -258,8 +258,14 @@ extension Catalog where Self: ~Escapable {
                          visited: Set<String> = [],
                          validate: Bool = true)
       throws(SQLError) -> Array<OutputColumn> {
-    try scope(of: select, context, visited: visited, validate: validate)
-        .columns(of: select.projection, context.routines)
+    // A scalar subquery in the projection derives its type from its inner
+    // query's single column, so build the SAME cursor-free `Subquery` map the
+    // compile path's lowering reads — every nested subquery compiled ONCE for
+    // its width and single-column type — and pass it to the projection walk so
+    // an output type for a `(SELECT …)` matches the type the run advertises.
+    let subquery = try subquery(of: select, context, visited)
+    return try scope(of: select, context, visited: visited, validate: validate)
+        .columns(of: select.projection, context.routines, subquery: subquery)
   }
 
   /// The name-resolution scope of `select` — its FROM relation and each joined
@@ -364,13 +370,57 @@ extension Catalog where Self: ~Escapable {
   private borrowing func subqueryCheck(of select: Select, _ context: Context,
                                        visited: Set<String>)
       throws(SQLError) -> SubqueryCheck {
+    // An `IN (Q)` (`valued`) occurrence EVALUATES its select list at run, so
+    // its ORIGINAL shape is type-checked EAGERLY here; an `EXISTS` occurrence
+    // runs the cardinality probe, so its PROBED shape is checked. Both roles
+    // always run (a predicate is not short-circuited past), so their operand
+    // validation stays eager, driven by the original-vs-probe `shape`.
+    let scalar = select.scalar
     let valued = select.valued
+    let existential = select.existential
+    // A scalar occurrence's inner-query OPERAND validation DEFERS to the
+    // reachability walk (mirroring the lazy executor — a scalar in an
+    // unreachable `CASE`/`COALESCE` arm never validates) UNLESS the query is
+    // ALSO an `IN` value set: an `IN`'s ORIGINAL shape is validated eagerly (it
+    // runs unconditionally), fully covering the scalar's operands too. A scalar
+    // occurrence's ONLY other eager role, an `EXISTS`, validates just the PROBE
+    // (never the select list), so it does NOT cover the scalar's operands —
+    // such a query stays deferred and its EXISTS probe is ALSO checked eagerly.
+    let deferred = scalar.subtracting(valued)
     var widths = Dictionary<Query, Int>()
+    var types = Dictionary<Query, ValueType>()
     for query in select.subqueries where widths[query] == nil {
-      try typecheck(shape(of: query, valued: valued), context, visited: visited)
-      widths[query] = try compile(query, context, visited).width
+      // Eager operand validation runs for every occurrence a run does not
+      // short-circuit past — an `IN` (ORIGINAL shape) or an `EXISTS` (PROBE).
+      // A SCALAR-ONLY occurrence (neither) has its inner-query OPERAND check
+      // DEFERRED: a THROWING operand (`1 / 0`) the type-check detects and the
+      // lazy executor skips must not fault an unreachable arm. (A bad inner
+      // column/relation is a STRUCTURAL fault the outer `compile` already
+      // raised for EVERY subquery before this runs, so it never reaches here —
+      // validation and run agree on it regardless of the arm.)
+      if !deferred.contains(query) || existential.contains(query) {
+        try typecheck(shape(of: query, valued: valued), context,
+                      visited: visited)
+      }
+      // The width and single-column type derive for EVERY subquery — cursor-
+      // free and TOTAL for a clean-resolving inner query (deriving the type of
+      // `1 / 0` yields the integer type WITHOUT dividing), so a reached scalar
+      // shapes the outer `CASE`/projection column type correctly. Only the
+      // deferred OPERAND check that faults `.divide` waits for the reached walk.
+      let width = try compile(query, context, visited).width
+      widths[query] = width
+      types[query] =
+          try columns(of: query.first, context, visited: visited,
+                      validate: false).first?.type
+      // A scalar occurrence's single-column ARITY is enforced EAGERLY,
+      // reachability-independent — a cursor-free width check the run's lowering
+      // also makes — so a two-column scalar subquery in an unreachable arm STILL
+      // faults `SQLError.arity`, kept SEPARATE from the deferred operand check.
+      if scalar.contains(query), width != 1 {
+        throw .arity(1, width)
+      }
     }
-    return SubqueryCheck(widths)
+    return SubqueryCheck(widths, types, deferred: deferred)
   }
 
   /// The subquery shape a run of `query` type-checks against — the ORIGINAL for
@@ -390,11 +440,35 @@ extension Catalog where Self: ~Escapable {
   private borrowing func typecheck(_ select: Select, _ context: Context,
                                    visited: Set<String>)
       throws(SQLError) {
+    // Type-check and compile every UNCORRELATED subquery ONCE, ahead of the
+    // reachability walk: the pre-pass validates each `IN`/`EXISTS` inner query
+    // (never short-circuited past) and derives every scalar subquery's
+    // cursor-free arity and type (TOTAL — no `.divide` on `1 / 0`), but DEFERS
+    // a scalar occurrence's inner-query OPERAND validation to the walk, which
+    // records the scalar occurrences it REACHES into the `SubqueryCheck`'s box.
+    let subquery = try subqueryCheck(of: select, context, visited: visited)
+    // Walk the query's operands reachability-aware, so an unreachable
+    // `CASE`/`COALESCE` arm's scalar subquery is left unrecorded and unchecked.
+    try walk(select, context, subquery: subquery, visited: visited)
+    // Validate the inner query of each scalar occurrence the walk REACHED,
+    // where the borrowing catalog is in scope — mirroring the lazy executor,
+    // which materialises only a reached scalar subquery. A reached
+    // `(SELECT 1 / 0 …)` faults `.divide` here exactly as the run does; a
+    // skipped one is never reached, so never validated.
+    for query in subquery.visited {
+      try typecheck(query, context, visited: visited)
+    }
+  }
+
+  /// Walks the operands of `select` reachability-aware — the SAME order and
+  /// short-circuit rules the executor applies — validating each operand a run
+  /// would evaluate and RECORDING (via `subquery`) each scalar subquery it
+  /// reaches, so the caller validates only the reached scalars' inner queries.
+  private borrowing func walk(_ select: Select, _ context: Context,
+                              subquery: SubqueryCheck, visited: Set<String>)
+      throws(SQLError) {
     let routines = context.routines
     let scope = try scope(of: select, context, visited: visited)
-    // Type-check and compile every UNCORRELATED subquery ONCE, ahead of the
-    // `check` walk, into a map the checks read for validation and arity.
-    let subquery = try subqueryCheck(of: select, context, visited: visited)
     // An `ORDER BY` ordinal names a 1-based SELECT-list position; one outside
     // `1 ... width` names no output column and faults `SQLError.column` (spelled
     // as the ordinal), exactly as the compile path's ordinal resolution does —
@@ -681,7 +755,8 @@ extension Scope {
   /// The output columns a `projection` yields over this scope, named and typed
   /// — `routines` type a scalar call from its declared return type.
   internal func columns(of projection: Projection,
-                        _ routines: Routines = [:])
+                        _ routines: Routines = [:],
+                        subquery: Subquery = .unsupported)
       throws(SQLError) -> Array<OutputColumn> {
     return switch projection {
     case .all:
@@ -690,7 +765,7 @@ extension Scope {
       try references.map { column throws(SQLError) in try output(of: column) }
     case let .expressions(items):
       try items.indices.map { index throws(SQLError) in
-        try output(items[index], at: index, routines)
+        try output(items[index], at: index, routines, subquery: subquery)
       }
     }
   }
@@ -719,14 +794,17 @@ extension Scope {
   /// source type and a literal its own; a scalar call its routine's declared
   /// return type; every other expression `.integer`.
   internal func output(_ item: Projected, at index: Int,
-                       _ routines: Routines = [:])
+                       _ routines: Routines = [:],
+                       subquery: Subquery = .unsupported)
       throws(SQLError) -> OutputColumn {
     let name = item.name ?? "column \(index + 1)"
     // DERIVE the nominal output type: the schema reports the type a run would
     // produce and never faults on an operand. Run-time operand and call
     // validation is `typecheck`'s job, reachability-aware, so a schema resolves
-    // even for an expression a zero-row limit makes unreachable.
+    // even for an expression a zero-row limit makes unreachable. A scalar
+    // subquery derives its single-column type from the `subquery` map.
     return try OutputColumn(name: name,
-                            type: derive(item.expression, routines))
+                            type: derive(item.expression, routines,
+                                         subquery: subquery))
   }
 }

--- a/Sources/SQLEngine/Parser.swift
+++ b/Sources/SQLEngine/Parser.swift
@@ -45,8 +45,10 @@
 /// expression     := additive
 /// additive       := multiplicative (('+' | '-' | '||') multiplicative)*
 /// multiplicative := factor (('*' | '/') factor)*
-/// factor         := '(' expression ')' | case | cast | coalesce | nullif
-///                 | position | overlay | literal | aggregate | call | column
+/// factor         := subquery | '(' expression ')' | case | cast | coalesce
+///                 | nullif | position | overlay | literal | aggregate | call
+///                 | column
+/// subquery       := '(' query ')'  // scalar: yields <= 1 row x 1 col at run
 /// case           := CASE [expression] (WHEN (predicate | expression) THEN
 ///                     expression)+ [ELSE expression] END
 /// cast           := CAST '(' expression AS type ')'
@@ -571,6 +573,17 @@ internal struct Parser: ~Escapable {
   /// empty.
   private mutating func factor() throws(SQLError) -> Expression {
     if try match(.lparen) {
+      // ONE token of lookahead after `(` disambiguates a SCALAR SUBQUERY from a
+      // parenthesised expression: a `SELECT` begins a subquery — `(query)`, the
+      // first-class `Expression.subquery` (the query may itself be a `UNION`) —
+      // and anything else begins a parenthesised expression. No rewind is
+      // needed: `SELECT` never begins an expression, so the peek is
+      // unambiguous, exactly as the `IN (…)` and `EXISTS (…)` lookaheads are.
+      if current?.kind == .select {
+        let query = try query()
+        try expect(.rparen)
+        return .subquery(query)
+      }
       let expression = try expression()
       try expect(.rparen)
       return expression

--- a/Sources/SQLEngine/Resolve.swift
+++ b/Sources/SQLEngine/Resolve.swift
@@ -48,17 +48,44 @@ internal enum Subscope: Hashable, Sendable {
   case view(String)
 }
 
+/// The ROLE a subquery occurrence materialises in — its SHAPE in the cache.
+///
+/// The SAME inner SQL can occur in three roles at once, each needing a
+/// DIFFERENT materialisation, so the role discriminates the cache entry: a
+/// `scalar` occurrence (`Expression.subquery`) collapses to one cell
+/// (`cell(of:)`), a `valued` occurrence (`IN (SELECT …)`, `Predicate.within`)
+/// keeps the materialised rows for its value set, and an `existential`
+/// occurrence (`EXISTS (SELECT …)`) is a cardinality PROBE that never runs
+/// the select list. Keying the cache without the role collapses the three onto
+/// one entry, so an `IN` reading a scalar entry faults (no rows) and an
+/// `EXISTS` reading a scalar entry mis-reads `present` — the role keeps them
+/// disjoint.
+internal enum Role: Hashable, Sendable {
+  /// A scalar-subquery occurrence — collapsed to a single cell.
+  case scalar
+  /// An `IN (SELECT …)` occurrence — materialised in full for its value
+  /// set.
+  case valued
+  /// An `EXISTS (SELECT …)` occurrence — a cardinality probe.
+  case existential
+}
+
 /// The cache identity of one collected subquery OCCURRENCE — its resolution
-/// `context` composed with its `query` AST.
+/// `context` composed with its `query` AST and its `role`.
 ///
 /// A subquery is keyed neither by its `Query` value alone (which collapses two
 /// AST-identical subqueries under different overlays — see `Subscope`)
 /// nor by a raw counter (which two independent id spaces could not keep
-/// disjoint), but by the PAIR: within one `Subscope`, an identical `Query`
+/// disjoint), but by the TRIPLE: within one `Subscope`, an identical `Query`
 /// resolves to an identical result, so value-discrimination is correct there;
 /// across scopes the `Subscope` keeps them separate. A caller-space key
 /// (`.caller`) and a view-space key (`.view(name)`) are unequal even for the
 /// same AST, so the two id spaces cannot collide.
+///
+/// The `role` keeps the three materialisation SHAPES of one `(scope, query)`
+/// disjoint (see `Role`): a `scalar` read can never hit a `valued` or an
+/// `existential` entry and vice versa, so identical inner SQL used in more than
+/// one role no longer cross-reads the wrong entry.
 internal struct Subkey: Hashable, Sendable {
   /// The resolution context this occurrence materialises under.
   internal let scope: Subscope
@@ -66,9 +93,13 @@ internal struct Subkey: Hashable, Sendable {
   /// The subquery's AST.
   internal let query: Query
 
-  internal init(_ scope: Subscope, _ query: Query) {
+  /// The role this occurrence materialises in — its cache SHAPE.
+  internal let role: Role
+
+  internal init(_ scope: Subscope, _ query: Query, _ role: Role) {
     self.scope = scope
     self.query = query
+    self.role = role
   }
 }
 
@@ -85,9 +116,15 @@ internal struct Subkey: Hashable, Sendable {
 /// non-empty `S` is TRUE with no `.divide`, no full scan). A probe carries no
 /// `rows`, so `values` faults if an `IN` ever reads it — but a query needing
 /// its values is materialised full, so it never does.
+///
+/// A SCALAR subquery occurrence is NOT materialised here — it collapses LAZILY,
+/// on the first evaluation of its `Term.subquery`, so a scalar subquery in an
+/// unreachable `CASE`/`COALESCE` arm never runs (see `Subqueries.scalar`). The
+/// eager entries this holds are therefore only the `IN` full result and the
+/// `EXISTS` probe.
 internal struct MaterialisedSubquery {
   /// The subquery's result rows for an `IN` occurrence materialised in full, or
-  /// `nil` for an `EXISTS`-only occurrence materialised as a cardinality probe.
+  /// `nil` for an `EXISTS`-only probe (which carries no full rows).
   private let rows: Array<Array<Value>>?
 
   /// Whether the row source yielded a row — the `EXISTS` non-empty test, read
@@ -119,6 +156,33 @@ internal struct MaterialisedSubquery {
   }
 }
 
+/// The mutable memo a `Subqueries` cache shares by REFERENCE for the scalar
+/// subqueries it materialises LAZILY.
+///
+/// A scalar subquery collapses on the FIRST evaluation of its `Term.subquery`,
+/// not eagerly at run start, so an occurrence in an unreachable
+/// `CASE`/`COALESCE` arm never runs (never throws `.cardinality` or an inner
+/// fault). It is UNCORRELATED, so its collapsed value is row-invariant: the
+/// first reached evaluation runs and caches it here, keyed by its `Subkey`, and
+/// every later read of the same key returns the cached value WITHOUT
+/// re-running. The cache is a class so the memo survives `Subqueries` being
+/// copied by value down the evaluate tree — every copy shares the one box.
+internal final class ScalarMemo {
+  private var cells: Dictionary<Subkey, Value> = [:]
+
+  /// The already-collapsed value for `key`, or `nil` when it has not yet been
+  /// evaluated — the evaluator runs and `store`s it on a miss.
+  internal func value(_ key: Subkey) -> Value? {
+    cells[key]
+  }
+
+  /// Records `value` as the collapsed value of the scalar occurrence `key`, so
+  /// a later read of the same key returns it without re-running the subquery.
+  internal func store(_ value: Value, for key: Subkey) {
+    cells[key] = value
+  }
+}
+
 /// The COMPILE-time seam that lowers an `EXISTS`/`IN (Q)` predicate WITHOUT
 /// running its subquery — the fix for the schema-path cursor-contract violation.
 ///
@@ -145,13 +209,22 @@ internal struct Subquery {
   private let scope: Subscope
 
   /// Each nested `Query` mapped to its COMPILED column count — cursor-free; an
-  /// `IN (Q)` requires it be 1.
+  /// `IN (Q)` and a scalar subquery each require it be 1.
   private let widths: Dictionary<Query, Int>
 
+  /// Each nested `Query` mapped to its single-column output TYPE, derived
+  /// cursor-free in the compile pre-pass — the static type a scalar subquery
+  /// contributes (the executor coerces its collapsed value to it, as a `CASE`
+  /// coerces its arms). Only a width-1 query has one, so an `EXISTS`/`IN (Q)`
+  /// occurrence (whose type is irrelevant) may be absent.
+  private let types: Dictionary<Query, ValueType>
+
   internal init(_ scope: Subscope = .caller,
-                _ widths: Dictionary<Query, Int> = [:]) {
+                _ widths: Dictionary<Query, Int> = [:],
+                _ types: Dictionary<Query, ValueType> = [:]) {
     self.scope = scope
     self.widths = widths
+    self.types = types
   }
 
   /// A `Subquery` for a lowering surface with no catalog — a schema-only
@@ -170,6 +243,27 @@ internal struct Subquery {
     return width
   }
 
+  /// The single-column output type `query` contributes as a scalar subquery.
+  /// The compile pre-pass records it beside the width for every subquery, so a
+  /// scalar occurrence reads it; a surface with no catalog holds none and
+  /// faults, rejecting the subquery rather than mis-typing it.
+  private func output(_ query: Query) throws(SQLError) -> ValueType {
+    guard let type = types[query] else {
+      throw .unsupported("a subquery is not supported in this position")
+    }
+    return type
+  }
+
+  /// The static single-column type a scalar subquery `query` contributes to a
+  /// SCHEMA derive — its single-column arity enforced first (else
+  /// `SQLError.arity`, matching the lowering), so this schema surface and the
+  /// run's lowering AGREE on both the arity fault and the type.
+  internal func scalar(type query: Query) throws(SQLError) -> ValueType {
+    let width = try width(query)
+    guard width == 1 else { throw .arity(1, width) }
+    return try output(query)
+  }
+
   /// Lowers `[NOT] EXISTS (query)` — the query carried into the `Filter` to run
   /// at execution, `negated` flipping the non-empty test. `EXISTS` ignores the
   /// subquery's arity (its column count is irrelevant to a cardinality test),
@@ -178,7 +272,7 @@ internal struct Subquery {
   internal func exists(_ query: Query, negated: Bool)
       throws(SQLError) -> Filter {
     _ = try width(query)
-    return .exists(Subkey(scope, query), negated: negated)
+    return .exists(Subkey(scope, query, .existential), negated: negated)
   }
 
   /// Lowers `operand [NOT] IN (query)` — `operand` already lowered to a `Term`
@@ -190,7 +284,21 @@ internal struct Subquery {
       throws(SQLError) -> Filter {
     let width = try width(query)
     guard width == 1 else { throw .arity(1, width) }
-    return .within(operand, Subkey(scope, query), negated: negated)
+    return .within(operand, Subkey(scope, query, .valued), negated: negated)
+  }
+
+  /// Lowers a scalar subquery `(query)` to a `Term.subquery` reading its
+  /// collapsed value from the run-time cache, requiring `query` project EXACTLY
+  /// ONE column (else `SQLError.arity`, from the COMPILED width, so a wider
+  /// subquery faults here WITHOUT running). The term carries the subquery's
+  /// occurrence `Subkey` — its resolution scope composed with `query` — and its
+  /// single-column TYPE, to which the executor coerces the collapsed value (the
+  /// empty → NULL and >1-row → cardinality cases are decided at RUN, in the
+  /// materialiser).
+  internal func scalar(_ query: Query) throws(SQLError) -> Term {
+    let width = try width(query)
+    guard width == 1 else { throw .arity(1, width) }
+    return try .subquery(Subkey(scope, query, .scalar), type: output(query))
   }
 }
 
@@ -206,15 +314,26 @@ internal struct Subquery {
 /// escapable data. An `EXISTS` reads whether the result is non-empty; an
 /// `IN (Q)` folds over its single materialised column.
 ///
-/// This lands the schema-path cursor fix and the once-per-run memoisation;
-/// per-arm SHORT-CIRCUIT laziness (skipping a subquery an `AND`/`OR` never
-/// reaches) and the per-outer-row re-execution a CORRELATED subquery needs
-/// thread a runner to the evaluation site in a follow-up.
+/// An `IN`/`EXISTS` occurrence is materialised EAGERLY here — its full result
+/// or its probe run at run start, since a `WHERE`/`ON` predicate referencing it
+/// is not short-circuited past. A SCALAR occurrence instead materialises
+/// LAZILY, on the first evaluation of its `Term.subquery` (memoised in
+/// `scalars`), so an occurrence in an unreachable `CASE`/`COALESCE` arm never
+/// runs. Per-arm short-circuit for the `IN`/`EXISTS` roles and the
+/// per-outer-row re-execution a CORRELATED subquery needs thread a runner to
+/// the predicate site in a follow-up.
 internal struct Subqueries {
   private let results: Dictionary<Subkey, MaterialisedSubquery>
 
-  internal init(_ results: Dictionary<Subkey, MaterialisedSubquery> = [:]) {
+  /// The shared memo of the scalar occurrences materialised LAZILY on first
+  /// evaluation — a reference so every by-value copy of this cache down the
+  /// evaluate tree shares the one box, keeping a scalar materialise-once.
+  private let scalars: ScalarMemo
+
+  internal init(_ results: Dictionary<Subkey, MaterialisedSubquery> = [:],
+                _ scalars: ScalarMemo = ScalarMemo()) {
     self.results = results
+    self.scalars = scalars
   }
 
   /// The materialised result for `key` — every occurrence a runnable plan
@@ -240,6 +359,22 @@ internal struct Subqueries {
     try result(key).values()
   }
 
+  /// The already-collapsed value memoised for the scalar occurrence `key`, or
+  /// `nil` when it has not yet been evaluated. The evaluator reads this first;
+  /// on a miss it runs the subquery (where the catalog is in scope) and
+  /// `store`s the collapsed value, so a scalar in an unreachable arm never runs
+  /// and a reached one runs at most once.
+  internal func scalar(cached key: Subkey) -> Value? {
+    scalars.value(key)
+  }
+
+  /// Records `value` as the collapsed value of the scalar occurrence `key` —
+  /// the evaluator's memoisation after the first reached evaluation runs the
+  /// subquery, so a later read of the same key returns it without re-running.
+  internal func store(scalar value: Value, for key: Subkey) {
+    scalars.store(value, for: key)
+  }
+
   /// The DISJOINT union of this cache and `other`'s — every entry of both,
   /// which never collide because their keys carry distinct `Subscope`s: `self`
   /// holds one resolution context's occurrences (the caller's, keyed
@@ -248,9 +383,41 @@ internal struct Subqueries {
   /// occupies TWO keys — neither overwrites the other, and the pushed caller
   /// filter reads its `.caller` result while the view-body filter reads its
   /// `.view` one. A collision would be an id-space bug (two contexts sharing a
-  /// scope); it cannot happen, so the merge keeps the existing entry.
+  /// scope); it cannot happen, so the merge keeps the existing entry. The
+  /// merged cache keeps `self`'s scalar memo — a caller cache and a view-body
+  /// cache resolve DISJOINT scalar keys, so one shared memo serves both spaces.
   internal func merged(_ other: Subqueries) -> Subqueries {
-    Subqueries(results.merging(other.results) { existing, _ in existing })
+    Subqueries(results.merging(other.results) { existing, _ in existing },
+               scalars)
+  }
+}
+
+/// The mutable set of SCALAR-subquery inner queries the type-check walk
+/// REACHED, shared by a `SubqueryCheck` by REFERENCE.
+///
+/// A scalar subquery's inner-query OPERAND validation is DEFERRED to the
+/// reachability walk (`Scope.validate`), mirroring the lazy executor: an
+/// occurrence in an unreachable `CASE`/`COALESCE` arm never validates, exactly
+/// as it never runs. The walk cannot itself hold the borrowing catalog a
+/// recursive type-check needs, so as it REACHES each scalar `.subquery` it
+/// records the inner query here; the catalog-bearing `typecheck` phase reads
+/// this set AFTER the walk and type-checks only the reached inner queries. The
+/// box is a class so the reached set survives `SubqueryCheck` being copied by
+/// value down the walk — every copy shares the one box, the same way
+/// `ScalarMemo` shares the run's lazy collapse.
+internal final class ReachedScalars {
+  private var queries: Set<Query> = []
+
+  /// Records `query` as a scalar occurrence the walk reached, so the deferred
+  /// type-check phase validates its inner query.
+  internal func reach(_ query: Query) {
+    queries.insert(query)
+  }
+
+  /// The scalar inner queries the walk reached — the ones the deferred phase
+  /// type-checks.
+  internal var reached: Set<Query> {
+    queries
   }
 }
 
@@ -262,20 +429,51 @@ internal struct Subqueries {
 /// subquery's inner names and routines must be validated against one for schema
 /// validation to match execution — the recurring lesson that the two must not
 /// diverge. The `typecheck` path, where the borrowing catalog and `Context`
-/// ARE in scope, supplies a `validate` closure that recursively type-checks the
-/// inner query and a `width` closure that compiles it for its column count; a
-/// surface with no catalog passes `.unsupported`, which faults so a subquery
-/// reaching such a surface is rejected rather than passed unvalidated.
+/// ARE in scope, builds this from the maps it fills by validating and compiling
+/// every subquery ahead of the `check` walk; a surface with no catalog passes
+/// `.unsupported`, which faults so a subquery reaching such a surface is
+/// rejected rather than passed unvalidated.
+///
+/// An `EXISTS`/`IN (Q)` inner query is type-checked EAGERLY in that pre-pass
+/// (its predicate is not short-circuited past, so it always runs), as is every
+/// scalar subquery's cursor-free ARITY and TYPE derivation (TOTAL — a CASE's
+/// static column type unifies all arms regardless of runtime reachability, and
+/// deriving the type of `1 / 0` yields the integer type WITHOUT dividing). A
+/// scalar subquery's inner-query OPERAND validation is instead DEFERRED: the
+/// `.subquery` case of the reachability walk records the reached query into the
+/// shared `reached` box, and the `typecheck` phase validates only those after
+/// the walk — so an unreachable arm's scalar subquery is not validated, exactly
+/// as the executor does not evaluate it.
 internal struct SubqueryCheck {
   /// Each nested `Query` mapped to its compiled column count — the map the
-  /// `typecheck` path builds by validating and compiling every subquery ONCE,
-  /// ahead of the `check` walk. A query present here has already been
-  /// type-checked; `check` reads its width to enforce a `IN (Q)`'s single-
-  /// column arity.
+  /// `typecheck` path builds by compiling every subquery ONCE, ahead of the
+  /// `check` walk. `check` reads its width to enforce a `IN (Q)`'s or a scalar
+  /// subquery's single-column arity.
   private let widths: Dictionary<Query, Int>
 
-  internal init(_ widths: Dictionary<Query, Int> = [:]) {
+  /// Each nested `Query` mapped to its single-column output TYPE, derived by
+  /// the `typecheck` pre-pass — the type a scalar subquery reports to the
+  /// result schema (`validate`/`derive`), matching the lowering's `Subquery`.
+  private let types: Dictionary<Query, ValueType>
+
+  /// The scalar inner queries whose OPERAND validation is DEFERRED to the walk
+  /// — the ones NOT eagerly type-checked in the pre-pass (a scalar-ONLY
+  /// occurrence). The `.subquery` case records a reached one into `reached`.
+  private let deferred: Set<Query>
+
+  /// The shared box the walk records each reached scalar occurrence into, read
+  /// by the catalog-bearing `typecheck` phase after the walk to validate the
+  /// reached inner queries.
+  private let reached: ReachedScalars
+
+  internal init(_ widths: Dictionary<Query, Int> = [:],
+                _ types: Dictionary<Query, ValueType> = [:],
+                deferred: Set<Query> = [],
+                reached: ReachedScalars = ReachedScalars()) {
     self.widths = widths
+    self.types = types
+    self.deferred = deferred
+    self.reached = reached
   }
 
   /// A checker for a surface with no catalog — validating a subquery needs one,
@@ -300,6 +498,38 @@ internal struct SubqueryCheck {
       throw .unsupported("a subquery is not supported in this position")
     }
     return width
+  }
+
+  /// The single-column output type `query` contributes as a scalar subquery —
+  /// from the pre-pass derive — validating its single-column arity first (else
+  /// `SQLError.arity`, matching the run's lowering). This is the WALK-reached
+  /// path, so a scalar occurrence whose operand validation was deferred is
+  /// recorded REACHED here, for the `typecheck` phase to validate its inner
+  /// query. The cursor-free arity/type derivation stays SEPARATE and total: the
+  /// arity of an unreachable scalar was already enforced eagerly in the
+  /// pre-pass (`subqueryCheck`), so a two-column subquery in a skipped arm still
+  /// faults.
+  internal func type(_ query: Query) throws(SQLError) -> ValueType {
+    // A DEFERRED scalar occurrence is REACHED here: record it for the
+    // `typecheck` phase to validate its inner query's OPERANDS, mirroring the
+    // lazy executor materialising only a reached scalar. Its arity and single-
+    // column type were derived eagerly in `subqueryCheck` (cursor-free, total),
+    // so this reads them exactly as an eagerly-checked occurrence does — only
+    // the operand fault (`.divide`) it might raise defers to the reached walk.
+    if deferred.contains(query) { reached.reach(query) }
+    let width = try width(query)
+    guard width == 1 else { throw .arity(1, width) }
+    guard let type = types[query] else {
+      throw .unsupported("a subquery is not supported in this position")
+    }
+    return type
+  }
+
+  /// The scalar inner queries the walk reached — the ones the `typecheck` phase
+  /// validates after the walk, mirroring the lazy executor's evaluation of only
+  /// a reached scalar subquery.
+  internal var visited: Set<Query> {
+    reached.reached
   }
 }
 
@@ -665,7 +895,8 @@ extension Schema {
       // branch's value to the type the schema advertises. Derive it against a
       // one-relation scope, this Schema's own resolution surface.
       let scope = Scope([(relation, self)])
-      let type = try scope.derive(whens, otherwise, routines)
+      let type = try scope.derive(whens, otherwise, routines,
+                                  subquery: subquery)
       return .case(branches, else: fallback, type: type)
     case let .cast(operand, type):
       // Lower the operand and attach the target type; the executor converts the
@@ -684,13 +915,19 @@ extension Schema {
                                  subquery: subquery))
       }
       let scope = Scope([(relation, self)])
-      let type = try scope.derive(expression, routines)
+      let type = try scope.derive(expression, routines, subquery: subquery)
       return .coalesce(elements, type: type)
     case let .nullif(lhs, rhs):
       // Lower both operands to `Term`s over this relation and hold them in a
       // first-class `Term.nullif` so each is evaluated ONCE.
       return try .nullif(term(lhs, in: relation, routines, subquery: subquery),
                          term(rhs, in: relation, routines, subquery: subquery))
+    case let .subquery(query):
+      // A scalar subquery lowers to a `Term.subquery` reading its collapsed
+      // value from the run-time cache, carrying its occurrence `Subkey` and
+      // single-column type, the single-column arity enforced from the compiled
+      // width (no cursor). The query is UNCORRELATED — it reads no cell here.
+      return try subquery.scalar(query)
     case .aggregate:
       // An aggregate has no per-row meaning — it folds over a group — so it may
       // not appear in a `WHERE`, a join `ON`, or a non-aggregate projection.
@@ -844,7 +1081,8 @@ internal struct Scope {
   ///
   /// This is the SCHEMA surface. `validate(_:_:)` is the type-check surface: it
   /// faults exactly as a run would on a bad operand or an unknown/misused call.
-  internal func derive(_ expression: Expression, _ routines: Routines = [:])
+  internal func derive(_ expression: Expression, _ routines: Routines = [:],
+                       subquery: Subquery = .unsupported)
       throws(SQLError) -> ValueType {
     return switch expression {
     case let .column(column):
@@ -862,16 +1100,18 @@ internal struct Scope {
       case .sum, .min, .max:
         switch operand {
         case .star: .integer
-        case let .expression(argument): try derive(argument, routines)
+        case let .expression(argument):
+          try derive(argument, routines, subquery: subquery)
         }
       }
     case let .binary(.concatenate, lhs, rhs):
       // `||` yields text; the operands' own types do not shape it, but derive
       // both for resolution — an unresolved column faults `SQLError.column`
       // (`Missing || 'x'`) — exactly as the arithmetic `.binary` branch does.
-      try concatenation(lhs, rhs, routines)
+      try concatenation(lhs, rhs, routines, subquery: subquery)
     case let .binary(_, lhs, rhs):
-      try [derive(lhs, routines), derive(rhs, routines)].contains(.double)
+      try [derive(lhs, routines, subquery: subquery),
+           derive(rhs, routines, subquery: subquery)].contains(.double)
           ? .double : .integer
     case let .case(whens, otherwise):
       // The result type is the unification of every REACHABLE branch result (and
@@ -884,25 +1124,32 @@ internal struct Scope {
       // one `WHEN`; when none is reachable (every guard constant-false, no
       // reachable `ELSE`) the run yields NULL, for which `.integer` is the
       // schema default.
-      try derive(whens, otherwise, routines)
+      try derive(whens, otherwise, routines, subquery: subquery)
     case let .cast(operand, type):
       // A cast's static type is the target type; the conversion is nominal, so
       // the operand's own type does not shape it. Derive the operand anyway for
       // its ordinal resolution — an unknown/ambiguous column faults as a
       // projection would.
-      try derive(cast: operand, to: type, routines)
+      try derive(cast: operand, to: type, routines, subquery: subquery)
     case let .coalesce(arguments):
       // The result type is the unification of the arguments (the same
       // `ValueType.unified` reduction a `CASE`'s results take), the type the
       // selected value coerces to.
-      try unified(arguments, routines)
+      try unified(arguments, routines, subquery: subquery)
     case let .nullif(lhs, rhs):
       // NULLIF yields either `v1` or NULL, so the column takes `v1`'s type —
       // but derive BOTH operands for resolution, returning the LHS type: an
       // unresolved column faults `SQLError.column` (`NULLIF(1, Missing)`) on
       // this derive-only surface too, mirroring the `||`/arithmetic derive
       // branch rather than leaving the RHS unresolved.
-      try nullif(lhs, rhs, routines)
+      try nullif(lhs, rhs, routines, subquery: subquery)
+    case let .subquery(query):
+      // A scalar subquery's static type is its single-column output type — the
+      // compile pre-pass recorded it beside the width for every subquery, so
+      // `derive` reads it (enforcing the single-column arity). A surface with
+      // no catalog holds none and faults, rejecting the subquery rather than
+      // mis-typing it, so this derive and the run's lowering AGREE.
+      try subquery.scalar(type: query)
     }
   }
 
@@ -914,9 +1161,11 @@ internal struct Scope {
   /// (`columns(of:validate:false)`, an unreachable projection) where `validate`
   /// never runs.
   private func nullif(_ lhs: Expression, _ rhs: Expression,
-                      _ routines: Routines) throws(SQLError) -> ValueType {
-    let type = try derive(lhs, routines)
-    _ = try derive(rhs, routines)
+                      _ routines: Routines,
+                      subquery: Subquery = .unsupported)
+      throws(SQLError) -> ValueType {
+    let type = try derive(lhs, routines, subquery: subquery)
+    _ = try derive(rhs, routines, subquery: subquery)
     return type
   }
 
@@ -925,10 +1174,11 @@ internal struct Scope {
   /// it, but an unresolved column still faults `SQLError.column`, mirroring the
   /// arithmetic `.binary` derive branch.
   private func concatenation(_ lhs: Expression, _ rhs: Expression,
-                             _ routines: Routines)
+                             _ routines: Routines,
+                             subquery: Subquery = .unsupported)
       throws(SQLError) -> ValueType {
-    _ = try derive(lhs, routines)
-    _ = try derive(rhs, routines)
+    _ = try derive(lhs, routines, subquery: subquery)
+    _ = try derive(rhs, routines, subquery: subquery)
     return .text
   }
 
@@ -936,8 +1186,10 @@ internal struct Scope {
   /// resolution — a schema-surface non-faulting derive of the operand — and
   /// discarding its type, the conversion being nominal.
   private func derive(cast operand: Expression, to type: ValueType,
-                      _ routines: Routines) throws(SQLError) -> ValueType {
-    _ = try derive(operand, routines)
+                      _ routines: Routines,
+                      subquery: Subquery = .unsupported)
+      throws(SQLError) -> ValueType {
+    _ = try derive(operand, routines, subquery: subquery)
     return type
   }
 
@@ -957,10 +1209,12 @@ internal struct Scope {
   /// LATER argument unreachable — mirroring a `CASE`'s reachable-branch
   /// unification and the faulting `validate`'s stop.
   private func unified(_ arguments: Array<Expression>,
-                       _ routines: Routines) throws(SQLError) -> ValueType {
+                       _ routines: Routines,
+                       subquery: Subquery = .unsupported)
+      throws(SQLError) -> ValueType {
     var type: ValueType?
     for argument in arguments {
-      let next = try derive(argument, routines)
+      let next = try derive(argument, routines, subquery: subquery)
       if case .some(.null) = constant(argument, routines) {
         // A constant NULL is derived (for its errors) but skipped: it can never
         // be returned, so its type must not shape the column.
@@ -1013,13 +1267,14 @@ internal struct Scope {
   /// faulting `validate` (`conditional`) — a mixed integer/double `CASE` still
   /// widens to `double`.
   internal func derive(_ whens: Array<When>, _ otherwise: Expression?,
-                       _ routines: Routines)
+                       _ routines: Routines,
+                       subquery: Subquery = .unsupported)
       throws(SQLError) -> ValueType {
     let results = reachable(whens, otherwise, routines)
     guard !results.isEmpty else { return .integer }
-    var type = try derive(results[0], routines)
+    var type = try derive(results[0], routines, subquery: subquery)
     for result in results.dropFirst() {
-      let next = try derive(result, routines)
+      let next = try derive(result, routines, subquery: subquery)
       guard let unified = type.unified(with: next) else {
         throw .operand("CASE results have irreconcilable types")
       }
@@ -1087,6 +1342,13 @@ internal struct Scope {
       try coalesce(arguments, routines, subquery: subquery)
     case let .nullif(lhs, rhs):
       try nullif(validate: lhs, rhs, routines, subquery: subquery)
+    case let .subquery(query):
+      // A scalar subquery's static type is its single-column output type — the
+      // pre-pass validated and compiled its inner query and derived the type,
+      // enforcing the single-column arity (else `SQLError.arity`), so this
+      // reads that type exactly as the run's lowering does. A surface with no
+      // catalog holds none and faults, rejecting the subquery unvalidated.
+      try subquery.type(query)
     }
   }
 
@@ -1754,7 +2016,10 @@ internal struct Scope {
         return nil
       }
       return matches(va, .equal, vb) == true ? .null : va
-    case .column, .aggregate:
+    case .column, .aggregate, .subquery:
+      // A `subquery` is row-independent but is materialised at RUN (this
+      // compile-time fold has no cache), so it is not statically foldable —
+      // `nil`, like a `column` or `aggregate`.
       return nil
     }
   }
@@ -2043,7 +2308,10 @@ internal struct Scope {
                   subquery: SubqueryCheck = .unsupported)
       throws(SQLError) {
     switch expression {
-    case .column, .literal:
+    case .column, .literal, .subquery:
+      // A scalar `subquery` nests no OUTER aggregate — its inner aggregates are
+      // validated within the subquery's own type-check — so it contributes none
+      // here, like a bare `column`.
       break
     case let .aggregate(function, operand, _, filter):
       _ = try aggregate(function, over: operand, filter: filter, routines,
@@ -2243,7 +2511,12 @@ internal struct Scope {
       let va = try empty(lhs, routines)
       let vb = try empty(rhs, routines)
       return matches(va, .equal, vb) == true ? .null : va
-    case .column:
+    case .column, .subquery:
+      // A bare column cannot appear over an empty group (a grouping error
+      // `compile` rejected). A scalar `subquery` is materialised at RUN (this
+      // fold carries no cache), and its value is uncorrelated — group-
+      // independent — so this pre-run fold treats it as the undecided `.null`,
+      // never faulting on a subquery the run would materialise cleanly.
       return .null
     }
   }
@@ -2485,7 +2758,7 @@ internal struct Scope {
       // Attach the unified result type — the same `ValueType.unified` reduction
       // `derive`/`validate` compute — so the executor COERCES the selected
       // branch's value to the type the schema advertises.
-      let type = try derive(whens, otherwise, routines)
+      let type = try derive(whens, otherwise, routines, subquery: subquery)
       return .case(branches, else: fallback, type: type)
     case let .cast(operand, type):
       // Lower the operand across the join chain and attach the target type; the
@@ -2500,13 +2773,20 @@ internal struct Scope {
       for argument in arguments {
         try elements.append(term(argument, routines, subquery: subquery))
       }
-      let type = try derive(expression, routines)
+      let type = try derive(expression, routines, subquery: subquery)
       return .coalesce(elements, type: type)
     case let .nullif(lhs, rhs):
       // Lower both operands to combined-ordinal `Term`s and hold them in a
       // first-class `Term.nullif` so each is evaluated ONCE.
       return try .nullif(term(lhs, routines, subquery: subquery),
                          term(rhs, routines, subquery: subquery))
+    case let .subquery(query):
+      // A scalar subquery lowers to a `Term.subquery` reading its collapsed
+      // value from the run-time cache, carrying its occurrence `Subkey` and
+      // single-column type; the single-column arity is enforced from the
+      // compiled width here (no cursor). The query is UNCORRELATED, so it reads
+      // no cell of this row.
+      return try subquery.scalar(query)
     case .aggregate:
       // An aggregate has no per-row meaning — it folds over a group — so it may
       // not appear in a `WHERE`, a join `ON`, or a non-aggregate projection.
@@ -2747,7 +3027,8 @@ internal struct Grouping {
       // Attach the unified result type — the same `ValueType.unified` reduction
       // `derive`/`validate` compute — over the grouped scope, so the executor
       // COERCES the selected branch's value to the advertised column type.
-      let type = try scope.derive(whens, otherwise, routines)
+      let type = try scope.derive(whens, otherwise, routines,
+                                  subquery: subquery)
       return .case(branches, else: fallback, type: type)
     case let .cast(operand, type):
       // Lower the operand against the grouped slot space and attach the target
@@ -2762,13 +3043,18 @@ internal struct Grouping {
       for argument in arguments {
         try elements.append(term(argument, routines, subquery: subquery))
       }
-      let type = try scope.derive(expression, routines)
+      let type = try scope.derive(expression, routines, subquery: subquery)
       return .coalesce(elements, type: type)
     case let .nullif(lhs, rhs):
       // Lower both operands to grouped-space `Term`s and hold them in a
       // first-class `Term.nullif` so each is evaluated ONCE.
       return try .nullif(term(lhs, routines, subquery: subquery),
                          term(rhs, routines, subquery: subquery))
+    case let .subquery(query):
+      // A scalar subquery is UNCORRELATED — row-independent, so it needs no
+      // `GROUP BY` key — and lowers to a `Term.subquery` reading its collapsed
+      // value from the cache, carrying its `Subkey` and single-column type.
+      return try subquery.scalar(query)
     case .aggregate:
       // An aggregate reaches here only when it was not collected — an internal
       // inconsistency, since the query gathers every projection/HAVING aggregate.

--- a/Tests/SQLTests/ScalarSubqueryTests.swift
+++ b/Tests/SQLTests/ScalarSubqueryTests.swift
@@ -1,0 +1,652 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQLEngine
+
+import SQLTestSupport
+
+// MARK: - Fixture
+
+/// Two relations exercising the uncorrelated SCALAR subquery: an outer `T`
+/// whose integer key `V` ranges over a known set, and an inner source `S`
+/// whose `V` a scalar subquery reduces with `MIN`/`MAX`, plus an EMPTY-able
+/// `E` (filtered to no rows) for the empty → NULL corner and a MULTI-row `M`
+/// (two rows) for the >1-row cardinality fault.
+private func fixture() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["Id": .integer, "V": .integer]) {
+      Row(1, 10)
+      Row(2, 20)
+      Row(3, 30)
+    }
+    Relation("S", ["V": .integer]) {
+      Row(10)
+      Row(20)
+      Row(30)
+    }
+    // A source with two rows and a text column, for the >1-row fault and the
+    // type-of-the-inner-column check.
+    Relation("M", ["W": .integer, "Name": .text]) {
+      Row(1, "a")
+      Row(2, "b")
+    }
+    // A source that filters to no rows via `Flag`, for the empty → NULL corner.
+    Relation("E", ["V": .integer, "Flag": .integer]) {
+      Row(99, 0)
+    }
+  }
+}
+
+/// Parses `text` and returns its `Select`, failing on any other shape.
+private func parse(select text: String) throws -> Select {
+  guard case let .select(.select(select)) = try Statement(parsing: text) else {
+    Issue.record("expected a single SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return select
+}
+
+/// Parses `text` to a query, failing on any other statement.
+private func parse(query text: String) throws -> Query {
+  guard case let .select(query) = try Statement(parsing: text) else {
+    Issue.record("expected a SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return query
+}
+
+// MARK: - Parsing
+
+struct ScalarSubqueryParsingTests {
+  @Test func `parses a scalar subquery in the projection`() throws {
+    let select =
+        try parse(select: "SELECT (SELECT MAX(V) FROM S) AS m FROM T")
+    let inner = try parse(query: "SELECT MAX(V) FROM S")
+    guard case let .expressions(items) = select.projection else {
+      Issue.record("expected an expressions projection")
+      return
+    }
+    #expect(items.count == 1)
+    #expect(items[0].expression == .subquery(inner))
+    #expect(items[0].alias == "m")
+  }
+
+  @Test func `parses a scalar subquery as a comparison operand`() throws {
+    let select = try parse(
+        select: "SELECT Id FROM T WHERE V = (SELECT MIN(V) FROM S)")
+    let inner = try parse(query: "SELECT MIN(V) FROM S")
+    #expect(select.predicate
+                == .comparison(left: .column("V"), op: .equal,
+                               right: .subquery(inner)))
+  }
+
+  @Test func `a parenthesised arithmetic stays arithmetic`() throws {
+    // The one-token lookahead only takes the subquery arm on a leading SELECT;
+    // `(1 + 2)` is an ordinary parenthesised expression, not a subquery.
+    let select = try parse(select: "SELECT (1 + 2) AS n FROM T")
+    guard case let .expressions(items) = select.projection else {
+      Issue.record("expected an expressions projection")
+      return
+    }
+    #expect(items[0].expression
+                == .binary(.add, .literal(.integer(1)),
+                           .literal(.integer(2))))
+  }
+
+  @Test func `disambiguates a subquery from a group by the SELECT peek`()
+      throws {
+    // `(SELECT …)` is a subquery; `(1 + V)` is a parenthesised expression —
+    // the same leading `(`, resolved by the one token after it.
+    let subquery = try parse(select: "SELECT (SELECT MAX(V) FROM S) FROM T")
+    let group = try parse(select: "SELECT (1 + V) AS n FROM T")
+    guard case let .expressions(subItems) = subquery.projection,
+        case let .expressions(groupItems) = group.projection else {
+      Issue.record("expected expressions projections")
+      return
+    }
+    if case .subquery = subItems[0].expression {} else {
+      Issue.record("expected a scalar subquery")
+    }
+    #expect(groupItems[0].expression
+                == .binary(.add, .literal(.integer(1)), .column("V")))
+  }
+
+  @Test func `a scalar subquery round-trips by AST equality`() throws {
+    // Two parses of the same scalar-subquery query yield equal ASTs — the
+    // nested `Query` composes the synthesized `Hashable`/`Equatable`.
+    let text = "SELECT (SELECT MAX(V) FROM S) AS m FROM T"
+    #expect(try parse(query: text) == parse(query: text))
+  }
+
+  @Test func `a scalar subquery over a UNION parses`() throws {
+    // A scalar subquery is a full `query`, so it may itself be a `UNION`.
+    let text =
+        "SELECT (SELECT V FROM S UNION SELECT W FROM M) FROM T"
+    let select = try parse(select: text)
+    let inner = try parse(query: "SELECT V FROM S UNION SELECT W FROM M")
+    guard case let .expressions(items) = select.projection else {
+      Issue.record("expected an expressions projection")
+      return
+    }
+    #expect(items[0].expression == .subquery(inner))
+  }
+}
+
+// MARK: - Projection execution
+
+struct ScalarSubqueryProjectionTests {
+  @Test func `a scalar subquery in the projection is the same per row`()
+      throws {
+    // `(SELECT MAX(V) FROM S)` is 30 for EVERY outer row — uncorrelated, run
+    // once — so each `T` row projects (Id, 30).
+    try fixture().expect(
+        "SELECT Id, (SELECT MAX(V) FROM S) AS m FROM T ORDER BY Id",
+        yields: [[1, 30], [2, 30], [3, 30]])
+  }
+
+  @Test func `a scalar subquery folds like its literal value`() throws {
+    // The scalar collapses to a constant 30, so projecting it equals
+    // projecting the literal 30 for every row.
+    try fixture().expect(
+        "SELECT Id, (SELECT MAX(V) FROM S) FROM T",
+        equals: "SELECT Id, 30 FROM T")
+  }
+
+  @Test func `a scalar subquery types from its inner column`() throws {
+    // The scalar's TYPE is the inner projection's single-column type: `MAX(V)`
+    // over an integer column is integer, and a text inner column makes the
+    // scalar text.
+    let integer = try parse(query: "SELECT (SELECT MAX(V) FROM S) AS m FROM T")
+    let integerColumns = try fixture().columns(of: integer, validate: true)
+    #expect(integerColumns.count == 1)
+    #expect(integerColumns[0].type == .integer)
+
+    let text = try parse(query:
+        "SELECT (SELECT MAX(Name) FROM M) AS n FROM T")
+    let textColumns = try fixture().columns(of: text, validate: true)
+    #expect(textColumns[0].type == .text)
+  }
+}
+
+// MARK: - Comparison execution
+
+struct ScalarSubqueryComparisonTests {
+  @Test func `a scalar subquery as a comparison operand filters`() throws {
+    // `WHERE V = (SELECT MIN(V) FROM S)` keeps the row whose V is the minimum
+    // (10) — row 1.
+    try fixture().expect(
+        "SELECT Id FROM T WHERE V = (SELECT MIN(V) FROM S)", yields: [[1]])
+  }
+
+  @Test func `a scalar subquery comparison folds like its value`() throws {
+    // The scalar collapses to 10, so the comparison equals `V = 10`.
+    try fixture().expect(
+        "SELECT Id FROM T WHERE V = (SELECT MIN(V) FROM S)",
+        equals: "SELECT Id FROM T WHERE V = 10")
+  }
+
+  @Test func `a scalar subquery works in arithmetic`() throws {
+    // The scalar is an ordinary expression, so it composes in arithmetic:
+    // `V - (SELECT MIN(V) FROM S)` is `V - 10`.
+    try fixture().expect(
+        "SELECT V - (SELECT MIN(V) FROM S) AS d FROM T ORDER BY d",
+        yields: [[0], [10], [20]])
+  }
+}
+
+// MARK: - Empty and NULL
+
+struct ScalarSubqueryEmptyTests {
+  @Test func `an empty scalar subquery yields NULL`() throws {
+    // A scalar subquery over an empty source is NULL (not an error, not zero) —
+    // `E` filtered to `Flag = 1` has no row.
+    try fixture().expect(
+        "SELECT Id, (SELECT V FROM E WHERE Flag = 1) AS m FROM T ORDER BY Id",
+        yields: [[1, nil], [2, nil], [3, nil]])
+  }
+
+  @Test func `an empty scalar subquery NULL propagates in arithmetic`()
+      throws {
+    // The empty scalar is NULL, and NULL propagates through `+` — every row's
+    // computed column is NULL.
+    try fixture().expect(
+        "SELECT V + (SELECT V FROM E WHERE Flag = 1) AS s FROM T",
+        yields: [[nil], [nil], [nil]])
+  }
+
+  @Test func `an empty scalar subquery in a comparison admits no row`()
+      throws {
+    // `V = NULL` is UNKNOWN for every row, so the filter admits none.
+    try fixture().empty(
+        "SELECT Id FROM T WHERE V = (SELECT V FROM E WHERE Flag = 1)")
+  }
+}
+
+// MARK: - Cardinality
+
+struct ScalarSubqueryCardinalityTests {
+  @Test func `a scalar subquery over more than one row faults`() throws {
+    // `M` has two rows, so `(SELECT W FROM M)` yields two — a scalar subquery
+    // admits at most one, so the run raises `SQLError.cardinality`.
+    try fixture().expect(
+        "SELECT (SELECT W FROM M) FROM T", fails: .cardinality)
+  }
+
+  @Test func `exactly one row collapses to its cell`() throws {
+    // Filtered to one row, the same source yields a single value — no fault,
+    // the lone cell (1) for every outer row.
+    try fixture().expect(
+        "SELECT Id, (SELECT W FROM M WHERE W = 1) AS w FROM T ORDER BY Id",
+        yields: [[1, 1], [2, 1], [3, 1]])
+  }
+
+  @Test func `the cardinality error carries the SS SQLSTATE`() throws {
+    // The cardinality violation is an engine-specific `SS`-class condition.
+    #expect(SQLError.cardinality.sqlstate == "SS006")
+  }
+}
+
+// MARK: - Width
+
+struct ScalarSubqueryWidthTests {
+  @Test func `a two-column scalar subquery faults at compile`() throws {
+    // A scalar subquery must project EXACTLY ONE column; a two-column inner
+    // query is `SQLError.arity`, checked cursor-free from the compiled width,
+    // so it faults even though `M` has rows.
+    try fixture().expect(
+        "SELECT (SELECT W, Name FROM M) FROM T", fails: .arity(1, 2))
+  }
+
+  @Test func `a two-column scalar subquery faults the schema check`() throws {
+    // The schema path enforces the SAME single-column arity as the run —
+    // `columns(of:)` faults exactly where a run would.
+    let query = try parse(query: "SELECT (SELECT W, Name FROM M) FROM T")
+    let resolve = { () throws -> Array<OutputColumn> in
+      try fixture().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.arity(1, 2)) {
+      try resolve()
+    }
+  }
+}
+
+// MARK: - Type checking
+
+struct ScalarSubqueryTypeTests {
+  @Test func `columns validates a scalar-subquery query`() throws {
+    let query = try parse(query: "SELECT (SELECT MAX(V) FROM S) FROM T")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+  }
+
+  @Test func `a bad inner column faults the schema check`() throws {
+    // The inner query is type-checked, so an unknown column inside it faults
+    // validation exactly as a run would reject it.
+    let query = try parse(query: "SELECT (SELECT Missing FROM S) FROM T")
+    let resolve = { () throws -> Array<OutputColumn> in
+      try fixture().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.column("Missing")) {
+      try resolve()
+    }
+  }
+
+  @Test func `a bad inner relation faults the run`() throws {
+    // A scalar subquery over a missing relation faults the run as a top-level
+    // query over it would.
+    try fixture().expect(
+        "SELECT (SELECT V FROM Nope) FROM T", fails: .relation("Nope"))
+  }
+
+  @Test func `a scalar subquery select-list fault is validated`() throws {
+    // A scalar subquery EVALUATES its select list (it collapses the cell), so
+    // its ORIGINAL shape is type-checked — a `(SELECT 1 / 0 …)` faults
+    // `.divide` at BOTH validate and run, unlike the EXISTS probe.
+    let query = try parse(query: "SELECT (SELECT 1 / 0 FROM S) FROM T")
+    let resolve = { () throws -> Array<OutputColumn> in
+      try fixture().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.divide) {
+      try resolve()
+    }
+    try fixture().expect(
+        "SELECT (SELECT 1 / 0 FROM S) FROM T", fails: .divide)
+  }
+}
+
+// MARK: - Uncorrelated boundary
+
+struct ScalarSubqueryCorrelationTests {
+  @Test func `a scalar subquery naming an outer column fails to resolve`()
+      throws {
+    // Correlation is a LATER slice: a scalar subquery referencing an OUTER
+    // column (`T.Id`, not in the inner `S`'s scope) does not resolve — the
+    // inner query faults `SQLError.column` exactly as an unresolved column
+    // does today. This asserts the CURRENT behaviour; it does NOT implement
+    // correlation.
+    let query = try parse(query:
+        "SELECT (SELECT V FROM S WHERE V = T.Id) FROM T")
+    let resolve = { () throws -> Array<OutputColumn> in
+      try fixture().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.column("Id")) {
+      try resolve()
+    }
+  }
+}
+
+// MARK: - Cross-role cache identity
+
+/// Identical inner SQL used in more than one ROLE at once — scalar, `IN`, and
+/// `EXISTS` — must materialise under DISTINCT cache entries, so a scalar read
+/// never hits an `IN`/`EXISTS` entry and vice versa. The run-time cache keys on
+/// `(scope, query, role)`; keying without the role collapsed the three onto one
+/// entry, so an `IN` reading a scalar entry faulted (no rows) and an `EXISTS`
+/// reading a scalar entry mis-read `present`.
+struct ScalarSubqueryRoleTests {
+  @Test func `the same SQL as a scalar and an IN filter each read their own`()
+      throws {
+    // The reviewer's case: `(SELECT W FROM M WHERE W = 1)` occurs BOTH as a
+    // scalar projection AND as an `IN` value set — identical inner SQL. The
+    // scalar yields its cell (1) for every row, and the `IN` filters `1 IN
+    // {1}` to keep every row, each from its OWN entry — no cross-read.
+    try fixture().expect(
+        """
+        SELECT (SELECT W FROM M WHERE W = 1) AS w FROM T \
+        WHERE 1 IN (SELECT W FROM M WHERE W = 1) ORDER BY w
+        """,
+        yields: [[1], [1], [1]])
+  }
+
+  @Test func `the same SQL as a scalar and an EXISTS both see the row`()
+      throws {
+    // `(SELECT W FROM M WHERE W = 1)` occurs as a scalar AND an `EXISTS`. The
+    // EXISTS sees `present == true` (the subquery has a row) from its OWN
+    // existential entry, NOT the scalar entry, so every row is kept and the
+    // scalar projects its cell (1).
+    try fixture().expect(
+        """
+        SELECT (SELECT W FROM M WHERE W = 1) AS w FROM T \
+        WHERE EXISTS (SELECT W FROM M WHERE W = 1) ORDER BY w
+        """,
+        yields: [[1], [1], [1]])
+  }
+
+  @Test func `an EXISTS over identical scalar SQL with no row keeps nothing`()
+      throws {
+    // The scalar occurrence over an empty filter is NULL, and the EXISTS over
+    // the IDENTICAL empty SQL is FALSE (no row) — read from its own
+    // existential entry, not the scalar's `present`. So the filter admits none.
+    try fixture().empty(
+        """
+        SELECT (SELECT W FROM M WHERE W = 99) AS w FROM T \
+        WHERE EXISTS (SELECT W FROM M WHERE W = 99)
+        """)
+  }
+
+  @Test func `the same SQL as a scalar and an IN and an EXISTS all coexist`()
+      throws {
+    // All three roles over identical SQL at once: the scalar cell (1), the `IN`
+    // membership (`1 IN {1}` true), and the `EXISTS` probe (has a row) each
+    // read their OWN entry, so every row is kept and projects the cell.
+    try fixture().expect(
+        """
+        SELECT (SELECT W FROM M WHERE W = 1) AS w FROM T \
+        WHERE 1 IN (SELECT W FROM M WHERE W = 1) \
+        AND EXISTS (SELECT W FROM M WHERE W = 1) ORDER BY w
+        """,
+        yields: [[1], [1], [1]])
+  }
+
+  @Test func `a multi-row subquery faults as a scalar but succeeds as an IN`()
+      throws {
+    // `(SELECT W FROM M)` yields TWO rows. As a scalar occurrence it faults
+    // `SQLError.cardinality`; the identical SQL as an `IN` value set is valid.
+    // The scalar entry faults the run — role-correct semantics on shared SQL.
+    try fixture().expect(
+        """
+        SELECT (SELECT W FROM M) AS w FROM T \
+        WHERE 1 IN (SELECT W FROM M)
+        """,
+        fails: .cardinality)
+  }
+
+  @Test func `a multi-row subquery as an IN alone keeps its matching rows`()
+      throws {
+    // The SAME multi-row `(SELECT W FROM M)` used ONLY as an `IN` (no scalar
+    // occurrence) succeeds: `M` holds {1, 2}, so `1 IN (SELECT W FROM M)` is
+    // true and every `T` row is kept — proof the `IN` role materialises full.
+    try fixture().expect(
+        "SELECT Id FROM T WHERE 1 IN (SELECT W FROM M) ORDER BY Id",
+        yields: [[1], [2], [3]])
+  }
+}
+
+// MARK: - Lazy short-circuit materialisation
+
+/// A scalar subquery materialises LAZILY, on the first evaluation of its
+/// `Term.subquery` — NOT eagerly before the plan runs — so an occurrence in an
+/// unreachable `CASE`/`COALESCE` arm never executes, honouring the engine's
+/// short-circuit and reachability semantics. A reached occurrence still runs
+/// (and enforces cardinality / surfaces an inner fault), memoised so a value
+/// over a single row is the SAME across every outer row.
+struct ScalarSubqueryLazyTests {
+  @Test func `a multi-row scalar in a skipped CASE arm never runs`() throws {
+    // The reviewer's exact case: the `THEN` arm holds a multi-row scalar
+    // subquery, but its guard `1 = 0` is FALSE, so the arm is never selected —
+    // the scalar never runs, so no `.cardinality` fault. Every row yields the
+    // `ELSE` 0.
+    try fixture().expect(
+        """
+        SELECT CASE WHEN 1 = 0 THEN (SELECT W FROM M) ELSE 0 END AS c \
+        FROM T ORDER BY c
+        """,
+        yields: [[0], [0], [0]])
+  }
+
+  @Test func `a multi-row scalar in a reached CASE arm still faults`() throws {
+    // The mirror: with the guard `1 = 1` TRUE, the arm IS selected, so the
+    // multi-row scalar DOES run and faults `.cardinality` — the reachable arm
+    // enforces the ISO cardinality rule.
+    try fixture().expect(
+        "SELECT CASE WHEN 1 = 1 THEN (SELECT W FROM M) ELSE 0 END FROM T",
+        fails: .cardinality)
+  }
+
+  @Test func `a multi-row scalar in a skipped COALESCE arm never runs`()
+      throws {
+    // `COALESCE` short-circuits at the first non-NULL argument: the first arm
+    // `V` is never NULL, so the second arm's multi-row scalar subquery is never
+    // reached — no `.cardinality` fault, every row yields its `V`.
+    try fixture().expect(
+        """
+        SELECT COALESCE(V, (SELECT W FROM M)) AS c FROM T ORDER BY c
+        """,
+        yields: [[10], [20], [30]])
+  }
+
+  @Test func `a multi-row scalar in a reached COALESCE arm faults`() throws {
+    // When the first `COALESCE` argument IS NULL, the second arm is reached, so
+    // its multi-row scalar subquery runs and faults `.cardinality`. `E`
+    // filtered to no rows is a NULL first argument for every outer row.
+    try fixture().expect(
+        """
+        SELECT COALESCE((SELECT V FROM E WHERE Flag = 1), \
+        (SELECT W FROM M)) FROM T
+        """,
+        fails: .cardinality)
+  }
+
+  @Test func `a divide-by-zero scalar in a skipped CASE arm never runs`()
+      throws {
+    // A throwing inner query (`1 / 0`) in an unreachable arm never evaluates,
+    // so its `.divide` never fires — the same short-circuit the multi-row case
+    // shows, over an arithmetic fault.
+    try fixture().expect(
+        """
+        SELECT CASE WHEN 1 = 0 THEN (SELECT 1 / 0 FROM S) ELSE 0 END AS c \
+        FROM T ORDER BY c
+        """,
+        yields: [[0], [0], [0]])
+  }
+
+  @Test func `a divide-by-zero scalar in a reached CASE arm faults`() throws {
+    // The reachable arm runs the throwing inner query, so `.divide` fires — the
+    // lazy path preserves the fault a reached scalar must surface.
+    try fixture().expect(
+        "SELECT CASE WHEN 1 = 1 THEN (SELECT 1 / 0 FROM S) ELSE 0 END FROM T",
+        fails: .divide)
+  }
+
+  @Test func `a reached single-row scalar yields its value across all rows`()
+      throws {
+    // Materialise-once: a reached scalar over a SINGLE row collapses to its
+    // cell (1) and is memoised, so it reads the SAME value for every outer row
+    // — the guard `1 = 1` reaches it, and all three `T` rows project 1.
+    try fixture().expect(
+        """
+        SELECT CASE WHEN 1 = 1 THEN (SELECT W FROM M WHERE W = 1) \
+        ELSE 0 END AS w FROM T ORDER BY w
+        """,
+        yields: [[1], [1], [1]])
+  }
+
+  @Test func `a skipped scalar arm folds like its reachable literal`() throws {
+    // The skipped-arm query yields exactly what the same CASE with the scalar
+    // replaced by a never-run placeholder would — every row is the `ELSE` 0 —
+    // so the lazy skip changes nothing but WHETHER the scalar executes.
+    try fixture().expect(
+        """
+        SELECT CASE WHEN 1 = 0 THEN (SELECT W FROM M) ELSE 0 END FROM T
+        """,
+        equals: "SELECT 0 FROM T")
+  }
+}
+
+// MARK: - Validation ↔ run parity
+
+/// Validation (`columns(of:)`) must AGREE with execution on which scalar
+/// subqueries it faults on: a scalar occurrence's inner-query OPERAND
+/// validation is DEFERRED to the reachability walk, mirroring the lazy executor
+/// — so an occurrence in an unreachable `CASE`/`COALESCE` arm is NOT validated
+/// (it never runs), while a REACHED bad scalar still faults at validation (it
+/// would fault at run). The cursor-free ARITY/TYPE derivation stays EAGER and
+/// SEPARATE: a two-column scalar in a skipped arm still faults `.arity`.
+struct ScalarSubqueryValidationParityTests {
+  @Test func `a divide scalar in a skipped CASE arm validates and runs`()
+      throws {
+    // The reviewer's case: `columns(of:)` for a skipped THEN arm's throwing
+    // scalar SUCCEEDS (no `.divide`) — the operand validation defers to the
+    // reachability walk, which skips the unreachable arm — AND the query RUNS
+    // successfully, so validation and execution AGREE.
+    let query = try parse(query:
+        "SELECT CASE WHEN 1 = 0 THEN (SELECT 1 / 0 FROM S) ELSE 0 END FROM T")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+    #expect(columns.first?.type == .integer)
+    try fixture().expect(
+        """
+        SELECT CASE WHEN 1 = 0 THEN (SELECT 1 / 0 FROM S) ELSE 0 END AS c \
+        FROM T ORDER BY c
+        """,
+        yields: [[0], [0], [0]])
+  }
+
+  @Test func `a divide scalar in a reached CASE arm faults validation`()
+      throws {
+    // The mirror: with the guard `1 = 1` TRUE, the arm IS reached, so the walk
+    // records the scalar and its inner query IS validated — `columns(of:)`
+    // faults `.divide` exactly as the run does. Parity in the other direction:
+    // validation still rejects what the executor faults on.
+    let query = try parse(query:
+        "SELECT CASE WHEN 1 = 1 THEN (SELECT 1 / 0 FROM S) ELSE 0 END FROM T")
+    let resolve = { () throws -> Array<OutputColumn> in
+      try fixture().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.divide) {
+      try resolve()
+    }
+    try fixture().expect(
+        "SELECT CASE WHEN 1 = 1 THEN (SELECT 1 / 0 FROM S) ELSE 0 END FROM T",
+        fails: .divide)
+  }
+
+  @Test func `a two-column scalar in a skipped arm still faults arity`()
+      throws {
+    // ARITY stays EAGER and reachability-INDEPENDENT — the cursor-free width
+    // check is SEPARATE from the deferred operand validation — so a two-column
+    // scalar subquery in an UNREACHABLE arm STILL faults `SQLError.arity`, even
+    // though its inner-query operand validation would defer.
+    let query = try parse(query:
+        """
+        SELECT CASE WHEN 1 = 0 THEN (SELECT W, Name FROM M) ELSE 0 END \
+        FROM T
+        """)
+    let resolve = { () throws -> Array<OutputColumn> in
+      try fixture().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.arity(1, 2)) {
+      try resolve()
+    }
+  }
+
+  @Test func `a bad inner column in a skipped arm faults both alike`() throws {
+    // A bad inner COLUMN is a STRUCTURAL resolution fault the COMPILE path
+    // raises for EVERY subquery — reachability-independent, unlike the operand
+    // `.divide` above — so it fires at BOTH validate and run REGARDLESS of the
+    // arm's reachability. The run itself faults `.column` (compile resolves the
+    // scalar's inner columns to build the plan), so `columns(of:)` faulting
+    // `.column` PRESERVES parity — validation rejects exactly what the executor
+    // rejects. Only the OPERAND fault (`1 / 0`) the typecheck detects and the
+    // lazy executor skips needed deferring; a bad column never did.
+    let query = try parse(query:
+        """
+        SELECT CASE WHEN 1 = 0 THEN (SELECT Missing FROM S) ELSE 0 END \
+        FROM T
+        """)
+    let resolve = { () throws -> Array<OutputColumn> in
+      try fixture().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.column("Missing")) {
+      try resolve()
+    }
+    try fixture().expect(
+        "SELECT CASE WHEN 1 = 0 THEN (SELECT Missing FROM S) ELSE 0 END FROM T",
+        fails: .column("Missing"))
+  }
+
+  @Test func `a bad inner column in a reached arm faults validation`() throws {
+    // A reached scalar with a bad inner column faults `SQLError.column` at
+    // validation exactly as the run rejects it — parity in the reached
+    // direction, the same structural fault the skipped case shows.
+    let query = try parse(query:
+        """
+        SELECT CASE WHEN 1 = 1 THEN (SELECT Missing FROM S) ELSE 0 END \
+        FROM T
+        """)
+    let resolve = { () throws -> Array<OutputColumn> in
+      try fixture().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.column("Missing")) {
+      try resolve()
+    }
+  }
+
+  @Test func `a divide scalar in a skipped COALESCE arm validates`() throws {
+    // `COALESCE` short-circuits at the first non-NULL argument. A CONSTANT
+    // non-NULL first argument makes the second arm STATICALLY unreachable — the
+    // reachability the validation walk honours — so the throwing scalar's
+    // operand validation defers and is never reached: `columns(of:)` SUCCEEDS
+    // and the query RUNS. (A non-constant first argument like a column is NOT
+    // statically known non-NULL, so validation would treat the second arm as
+    // reachable — the walk mirrors only the STATIC short-circuit.)
+    let query = try parse(query:
+        "SELECT COALESCE(1, (SELECT 1 / 0 FROM S)) FROM T")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+    try fixture().expect(
+        "SELECT COALESCE(1, (SELECT 1 / 0 FROM S)) AS c FROM T ORDER BY c",
+        yields: [[1], [1], [1]])
+  }
+}


### PR DESCRIPTION
Add the ISO `<scalar subquery>` in expression position — a nested `Query` that yields ONE value — building on the uncorrelated EXISTS/IN (subquery) predicates.

A new `Expression.subquery(Query)` case parses from `(query)` in `<factor>`, disambiguated from a parenthesised expression by one token of lookahead: a `(` followed by `SELECT` opens a subquery, anything else a grouped expression (no rewind — `SELECT` never begins an expression). The parser's EBNF fence gains a `subquery` production. The scalar composes anywhere an expression may appear — a projection, a comparison operand, arithmetic, a `CASE`, an `ORDER BY` expression, an aggregate argument.

The inner query must project EXACTLY ONE column, checked at compile from its compiled width (`SQLError.arity`, cursor-free), so a two-column scalar subquery faults without running. The scalar's static type for the result schema is the inner projection's single-column type, recorded in the same cursor-free pre-pass that records the width, so the schema derive and the run's lowering agree.

Execution is uncorrelated and materialise-once, reusing the EXISTS/IN cache: a scalar occurrence runs its inner query ONCE per outer-query execution and COLLAPSES the result — empty to NULL, exactly one row to its lone cell, more than one row to a new `SS`-class `SQLError.cardinality` (SS006, the ISO cardinality violation). `Expression.subquery` lowers to a `Term.subquery` carrying the occurrence's cache key and single-column type, reading the collapsed value from the cache and coercing it as a `CASE` coerces its arm. Collection, the reserved-relation augment, and the type-check parity mirror the predicate slice: a scalar occurrence is collected in every expression position, its inner query validated and its width enforced identically at `columns(of:)` and at run, and its select-list fault surfaced at both (unlike an EXISTS probe).

The scalar is uncorrelated in this slice — a reference to an outer column resolves or faults as any unresolved column does today. Correlation, derived tables, and the quantified `ANY`/`ALL`/`SOME` comparisons are later stages.