### PR TITLE
SQLEngine: accept a derived table in FROM

### DIFF
--- a/Sources/SQLEngine/AST.swift
+++ b/Sources/SQLEngine/AST.swift
@@ -394,20 +394,55 @@ public struct Select: Hashable, Sendable {
   }
 }
 
-/// A named relation in a `FROM` or `JOIN`, with an optional alias.
+/// A relation in a `FROM` or `JOIN`: a base relation named by an identifier, or
+/// a DERIVED TABLE — a parenthesised subquery `(SELECT …)` — each with an
+/// alias.
 ///
-/// `name` is the relation's spelling; `alias`, when present, is the short name
-/// a qualified column reference may use in its place (`FROM TypeDef AS t`).
+/// A `named` relation's `name` is its spelling; its `alias`, when present, is
+/// the short name a qualified column reference may use in its place (`FROM
+/// TypeDef AS t`). A `derived` relation wraps a `Query`, materialised once
+/// and resolved under a MANDATORY alias — ISO requires a derived table be named
+/// (`FROM (SELECT …) AS t`) — so `alias` is always present and `name` is that
+/// alias, the key the resolution scope binds its materialised rows under.
 public struct Relation: Hashable, Sendable {
-  /// The relation's name.
-  public let name: String
+  /// Where a relation's rows come from: a named base relation/view/CTE, or a
+  /// derived table's inner query.
+  public enum Source: Hashable, Sendable {
+    /// A relation named by an identifier — a base table, a view, or a CTE.
+    case named(String)
+    /// A derived table — the inner `Query` a `FROM (SELECT …) AS t` runs.
+    case derived(Query)
+  }
 
-  /// The alias bound to the relation, if any.
+  /// The relation's source — a named relation or a derived table's query.
+  public let source: Source
+
+  /// The alias bound to the relation. Optional for a `named` relation, always
+  /// present for a `derived` one (ISO requires a derived table be aliased).
   public let alias: String?
 
+  /// A named base relation, view, or CTE with an optional alias.
   public init(name: String, alias: String? = nil) {
-    self.name = name
+    self.source = .named(name)
     self.alias = alias
+  }
+
+  /// A derived table over `query`, resolved under the mandatory `alias`.
+  public init(derived query: Query, as alias: String) {
+    self.source = .derived(query)
+    self.alias = alias
+  }
+
+  /// The name the resolution scope keys this relation under: the identifier for
+  /// a `named` relation, the alias for a `derived` one (a derived table's rows
+  /// are bound under its alias, the only name a column may qualify it by).
+  public var name: String {
+    switch source {
+    case let .named(name):
+      name
+    case .derived:
+      alias ?? ""
+    }
   }
 }
 

--- a/Sources/SQLEngine/Context.swift
+++ b/Sources/SQLEngine/Context.swift
@@ -80,4 +80,25 @@ internal struct Context {
     Context(relations: relations, routines: routines, bindings: bindings,
             subqueries: subqueries)
   }
+
+  /// A copy of this context with every enclosing SELECT's derived-table aliases
+  /// REVEALED away — the overlay's derived layers dropped, its common table
+  /// expressions and `definition_schema.` store relations (the base layer)
+  /// KEPT — the scope a NESTED subquery's FROM resolves against.
+  ///
+  /// A derived-table alias is SELECT-scoped: it names a relation only in its
+  /// OWN SELECT's FROM/JOIN and expressions, invisible to a nested subquery's
+  /// FROM exactly as a base-table alias in the enclosing FROM is (a subquery
+  /// does not see the enclosing query's FROM relations; only base tables and
+  /// enclosing CTEs are in its relation scope). A CTE, by contrast, is
+  /// statement-scoped — visible inside a nested subquery's FROM — so it stays.
+  /// The seam that compiles/materialises a nested subquery (`subquery(of:)`,
+  /// `subqueries(of:)`, `cell(of:)`, and the type-check counterparts) reveals
+  /// the base so a subquery's `FROM d` cannot scan an outer derived alias `d`,
+  /// while a same-named CTE `d` the derived alias SHADOWED is resolved again
+  /// — the layered overlay never deleted it. The subquery re-augments its OWN
+  /// derived tables into a fresh layer.
+  internal func revealed() -> Context {
+    scoping(relations.revealed())
+  }
 }

--- a/Sources/SQLEngine/Definition.swift
+++ b/Sources/SQLEngine/Definition.swift
@@ -182,8 +182,28 @@ extension Catalog where Self: ~Escapable {
   /// `definition_schema.columns` types without the builder re-entering itself).
   /// A store relation's row build types a view's scalar-call column through the
   /// context's `routines`.
-  borrowing func augment(_ context: Context, for query: Query, rows: Bool)
-      -> Context {
+  ///
+  /// The overlay also binds every DERIVED TABLE THIS query names in its own
+  /// FROM/JOIN — a `FROM (SELECT …) AS t` — under its alias as a `Materialised`
+  /// so the FROM/JOIN resolves it exactly as it resolves a common table
+  /// expression (the `ScopedRelations` path). It binds ONLY this query's own
+  /// aliases, not a nested subquery's: `augment` runs at every query level
+  /// (`run`, `compile`, `typecheck`, and `materialise` each augment the query
+  /// they receive), so a subquery binds its own aliases in its OWN scope. This
+  /// SELECT-scopes derived tables — unlike a statement-scoped, uniquely-named
+  /// CTE — so two sibling subqueries may reuse an alias `t` without colliding,
+  /// and this query's `t` SHADOWS an outer CTE or derived table of the same
+  /// name. A derived table is UNCORRELATED in this cut: its inner query
+  /// materialises ONCE, against the overlay WITHOUT its own alias (base catalog
+  /// plus the store relations and CTEs in scope, NOT its sibling FROM items),
+  /// so a reference to an outer or sibling column resolves as an unknown column
+  /// — LATERAL is a later feature. `rows` selects the build the same as for the
+  /// store: a run materialises the inner query's rows, a typing path resolves
+  /// its OUTPUT columns to a schema-only relation (no cursor) and validates the
+  /// inner body, so a derived table's alias types exactly as a run's would.
+  borrowing func augment(_ context: Context, for query: Query, rows: Bool,
+                         visited: Set<String> = [], validate: Bool = true)
+      throws(SQLError) -> Context {
     var names = Set<String>()
     query.collect(into: &names)
     var augmented = context.relations
@@ -193,24 +213,242 @@ extension Catalog where Self: ~Escapable {
             store(relation, rows: rows, context.routines)
       }
     }
-    return context.scoping(augmented)
+    var derivations = Array<(String, Query)>()
+    query.collect(derived: &derivations)
+    guard !derivations.isEmpty else { return context.scoping(augmented) }
+    // A derived table's alias sharing a RANGE NAME with another FROM/JOIN item
+    // in THIS SELECT's own scope collides: the alias-keyed overlay holds one
+    // binding under that name, so binding the derived rows would SHADOW the
+    // sibling — `FROM T JOIN (…) AS T` resolves the base `T` scan to the
+    // derived rows, and `FROM (…) AS d JOIN (…) AS d` resolves both to the
+    // later's. A duplicate RELATION alias (`FROM T AS d JOIN S AS d`) instead
+    // leaves BOTH in scope, so a shared column is `SQLError.ambiguous` — reject
+    // the same way here rather than silently shadow, faulting the ALIAS
+    // ambiguous at BOTH the schema-only path and a run, BEFORE binding the
+    // derived rows below (so the sibling is never shadowed). The collision is a
+    // range name TWO of THIS query's own FROM/JOIN items spell where one is a
+    // derived alias; a named-vs-named duplicate (no derived alias) stays the
+    // lazy per-reference ambiguity. This query's own ranges are its OWN scope:
+    // `collect(ranges:)`, `collect(sources:)`, and `collect(derived:)` all
+    // stop at a `SELECT`, so a nested subquery's, a sibling subquery's, or a
+    // set-operation arm's same-named alias (a DIFFERENT SELECT's ranges) is
+    // unaffected, and a derived alias equal to an ENCLOSING query's relation is
+    // not a same-scope collision (it shadows per normal scoping).
+    //
+    // The collision is counted against BOTH the EXPOSED range name and each
+    // named relation's SOURCE name. A qualified reference names an item by its
+    // range name (`alias ?? name`), but `resolve` LOOKS THE NAMED RELATION UP
+    // BY ITS SOURCE NAME in the overlay — so a derived alias `T` shadowing an
+    // aliased base `T AS x` (exposed range `x`, source `T`) would bind the
+    // derived rows under `T`, and the base scan for `T AS x` — keyed on `T` —
+    // would resolve to the DERIVED rows rather than the base table/CTE.
+    // Counting the source names too faults that alias BEFORE binding the
+    // derived rows, so `FROM T AS x JOIN (…) AS T` is rejected exactly as
+    // `FROM T JOIN (…) AS T` is.
+    var ranges = Array<String>()
+    query.collect(ranges: &ranges)
+    var identifiers = Array<String>()
+    query.collect(sources: &identifiers)
+    var counts = Dictionary<String, Int>()
+    for range in ranges { counts[range.lowercased(), default: 0] += 1 }
+    let sources = Set(identifiers.map { $0.lowercased() })
+    for (alias, _) in derivations {
+      let name = alias.lowercased()
+      // >1 range: the derived alias equals another FROM/JOIN item's exposed
+      // range name (a sibling derived alias, or an unaliased named relation).
+      // A source-name match: the derived alias equals a named relation's
+      // SOURCE name (an aliased base `T AS x` whose exposed range is `x`) —
+      // `resolve` keys that relation on `T`, so the derived `T` would capture
+      // its scan.
+      if counts[name, default: 0] > 1 || sources.contains(name) {
+        throw .ambiguous(alias)
+      }
+    }
+    // The scope every derived body resolves against: the enclosing scope with
+    // ALL derived layers REVEALED away, leaving the base (every CTE and store
+    // relation). Revealing rather than a name blanket lets a self-named
+    // `(SELECT … FROM T) AS T` read the BASE `T` while a `WITH t … FROM (SELECT
+    // … FROM t) AS t` still reads the CTE `t`: the alias being DEFINED is in
+    // its derived layer this augment is BUILDING (not yet pushed), so it is out
+    // of scope in its own body, but a same-named CTE in the base is not.
+    // Revealing keeps a derived table UNCORRELATED/no-LATERAL — a sibling
+    // `FROM` item lives in the layer being built, invisible to the revealed
+    // base scope, so `FROM (…) AS a JOIN (SELECT v FROM a) AS b` faults `a`.
+    let scope = context.scoping(augmented.revealed())
+    // The idempotent re-augment keys on the derivation IDENTITY, not the name.
+    // The run→compile→typecheck chain each augments the query it receives, so
+    // the innermost derived layer may ALREADY bind THIS select's aliases to
+    // THIS select's derivations — the same query, materialised against the
+    // same revealed base scope. Skip re-materialising then (leave the layer as
+    // is), so `augment` stays idempotent without re-resolving — and, on a run,
+    // a stateful body is not re-executed. A binding whose derivation DIFFERS
+    // (an ENCLOSING query's same-named derived table) is not this select's, so
+    // a fresh layer is materialised and pushed, SHADOWING the outer one — a
+    // nested subquery's `FROM t` reads ITS `t`. A self-named alias resolves the
+    // base: the layer being pushed is not yet in scope when a body resolves.
+    if derivations.allSatisfy({ augmented.derivation(of: $0.0.lowercased())
+                                == $0.1 }) {
+      return context.scoping(augmented)
+    }
+    // Materialise each alias's body against the revealed base scope (a
+    // same-named CTE visible, the derived aliases being defined not), then push
+    // them as one derived layer that SHADOWS an outer CTE or derived alias of
+    // the same name in the scope THIS SELECT resolves its OWN references
+    // against (projection/WHERE/JOIN-ON/GROUP/HAVING).
+    var layer = Dictionary<String, Materialised>()
+    for (alias, inner) in derivations {
+      layer[alias.lowercased()] =
+          try materialise(inner, scope, rows: rows, visited: visited,
+                          validate: validate)
+    }
+    return context.scoping(augmented.pushing(layer))
+  }
+
+  /// A DERIVED TABLE's `query` materialised into a `Materialised` bound under
+  /// its alias: its OUTPUT columns name the relation's columns (the ISO rule —
+  /// a derived table's columns are its inner query's output names), typed from
+  /// the same output-schema walk a scalar subquery's width and a CTE's schema
+  /// use. `rows` selects the build — a run captures the inner query's rows, a
+  /// typing path leaves them empty (schema-only, no cursor) — so the alias
+  /// resolves and types identically on both paths.
+  ///
+  /// The inner query resolves against `context` (the base catalog plus the
+  /// store relations and CTEs in scope), NOT its sibling FROM items, so the
+  /// derived table is UNCORRELATED: a reference to an outer or sibling column
+  /// faults as an unknown column (LATERAL is a later feature). Its OWN derived
+  /// tables (a `FROM (SELECT … FROM (…) AS x) AS y`) are augmented into `scope`
+  /// FIRST — the schema derivation resolves `x` exactly as a run would — so the
+  /// schema and run paths bind the same nested aliases before either reads the
+  /// inner query.
+  private borrowing func materialise(_ query: Query, _ context: Context,
+                                     rows: Bool, visited: Set<String> = [],
+                                     validate: Bool = true)
+      throws(SQLError) -> Materialised {
+    // Bind the inner query's OWN derived tables (and store relations) before
+    // deriving its schema — a run augments them recursively, so the schema
+    // path must too, or a nested derived table's alias resolves as unknown
+    // here while the run resolves it (schema/run parity). `visited` threads the
+    // cyclic-view guard through: a derived body naming a view under resolution
+    // re-enters `columns`/`compile` with that view already visited, so the
+    // resolver faults `.recursion` rather than recursing to a stack overflow.
+    //
+    // This augment is SCHEMA-ONLY (`rows: false`), even on a run (`rows`
+    // `true`): it exists only to derive the inner query's OUTPUT schema
+    // (`columns(of:)` below), which reads name/schema bindings — NOT rows. The
+    // single row materialisation is `run(query, context)`'s job below, and it
+    // re-augments the body itself. Materialising here as well (`rows: true`)
+    // would EXECUTE a nested derived body once for the schema and AGAIN in that
+    // run, so a stateful routine in a `FROM (SELECT tick() …)` nested a level
+    // down would fire twice for one query.
+    let scope = try augment(context, for: query, rows: false, visited: visited,
+                            validate: validate)
+    // The derived table's columns are its inner query's OUTPUT columns (the ISO
+    // rule) — the FIRST arm's projection, the same arm the result-schema walk
+    // and a CTE's declared list resolve against — typed against the augmented
+    // `scope` so a derived table over a CTE, a store relation, or a nested
+    // derived table resolves. `columns(of:)` REVEALS the base for the body's
+    // NESTED subqueries: `scope`'s derived layer shadows a CTE this body's own
+    // FROM alias names, and revealing drops that layer, so a nested
+    // `EXISTS (… FROM t)` reads the enclosing CTE `t` beneath — the layered
+    // overlay never overwrote it, keeping schema/run parity without a
+    // pre-augment context. The caller's `validate` threads through, so a RUN's
+    // output discovery (`validate: false`) stays LENIENT — a nested derived
+    // body's scalar a filter drops (`(SELECT Label + 1 …) … WHERE k = 0`) is
+    // NOT eager-type-checked before execution, exactly as the non-derived path
+    // never evaluates an unreached operand — while the strict schema path
+    // (`validate: true`) still faults it.
+    let outputs = try columns(of: query.first, scope, visited: visited,
+                              validate: validate)
+    // A derived table's columns are its inner query's OUTPUT names, so two
+    // same-named ones (`SELECT Id AS x, V AS x`) leave the shadowed one
+    // unreachable through the alias — exactly the case the Parser rejects for a
+    // view's or a CTE's inferred column list. Fault it the SAME way here
+    // (`SQLError.duplicate`, the "duplicate view column" fault), so it faults
+    // at BOTH the schema-only path and a run rather than silently exposing the
+    // first `x`. A plain top-level `SELECT Id AS x, V AS x` stays legal — the
+    // duplicate matters only where the relation is named and its columns are
+    // addressed by that name (a view, a CTE, a derived table).
+    var seen = Set<String>()
+    for output in outputs
+        where !seen.insert(output.name.lowercased()).inserted {
+      throw .duplicate(output.name)
+    }
+    let captured: Array<Array<Value>>
+    if rows {
+      // Resolve the inner body's relations against `visited` BEFORE running it,
+      // so a body naming a view under resolution through this derived table
+      // (`FROM (SELECT * FROM <self>) AS d`) faults `.recursion` rather than
+      // recursing to a stack overflow. `run` re-compiles the body WITHOUT the
+      // cyclic-view guard, so on the EXECUTE path (`derive` seeds `visited`
+      // with the view under resolution) this guarded resolve fires — the
+      // strict output discovery above no longer carries it once `validate` is
+      // `false`. `validate: false` keeps it structural: the recursion guard
+      // fires in `resolve` regardless, while a data-dependent operand a filter
+      // drops is NOT eager-type-checked.
+      _ = try compile(query, context, visited, validate: false)
+      // A run captures the inner query's rows once (uncorrelated).
+      captured = try run(query, context)
+    } else {
+      // The schema-only path reads no cursor. When `validate`, it still
+      // VALIDATES the whole inner body exactly as a run does — `compile`
+      // resolves every arm's WHERE, joins, and projection and cross-checks a
+      // UNION's arity; `typecheck` faults an ill-typed or unknown reachable
+      // operand/call — so an invalid inner body (a bad column in a WHERE, or a
+      // later arm) faults at the schema-only path exactly as at run, keeping
+      // schema/run parity. The first-arm projection alone (`outputs` above)
+      // would miss a fault outside it, advertising a schema for a derived table
+      // that cannot run. When `validate` is `false` — a derive after a
+      // successful run — the body is TRUSTED, not compiled/type-checked: the
+      // outer run already proved it runnable, and re-checking a reachable
+      // operand a data-dependent filter never reached would fault a query that
+      // SUCCEEDED (`SELECT Name + 1 … WHERE Id = -1`), unlike the non-derived
+      // path whose empty run never evaluates it.
+      //
+      // Compile/type-check from the revealed base `context` (idempotently
+      // re-augmented inside each, which pushes the body's own derived layer):
+      // `compile` reveals that scope for the body's nested subqueries, so a
+      // subquery reading a CTE a body's FROM alias shadows resolves it beneath
+      // the dropped layer — the layered overlay never overwrote it. The schema
+      // walk validates the body's nested subqueries exactly as the run path
+      // does (`run` compiles from the same base context).
+      if validate {
+        _ = try compile(query, context, visited)
+        try typecheck(query, context, visited: visited)
+      }
+      captured = []
+    }
+    return Materialised(columns: outputs.map(\.name), rows: captured,
+                        types: outputs.map(\.type), derivation: query)
   }
 
   /// `context` rescoped to the `definition_schema.` overlay a view's body
   /// resolves against — the reserved store relations the view `name` names in
   /// its OWN query, each built over this catalog, the caller's CTEs DROPPED (an
   /// empty overlay when `name` is not a view or names none). It seeds the view
-  /// sub-plan's execute so a view defined over a store relation resolves; it
+  /// sub-plan's OPTIMISE so a view defined over a store relation resolves; it
   /// never carries a caller's statement CTEs, so a view means what it was
   /// registered to mean. The routines and bindings ride through unchanged.
   ///
   /// The name resolves to a user view first, then a built-in `View.standard`
   /// view — so a built-in `information_schema.` view over the store re-resolves
   /// its own `definition_schema.` scan exactly as a user view would.
-  borrowing func overlay(_ name: String, _ context: Context) -> Context {
+  ///
+  /// The augment is SCHEMA-ONLY (`rows: false`): the optimiser needs only
+  /// name/schema bindings — it treats a store or derived alias as an unseekable
+  /// materialised relation — NOT rows. Materialising here (`rows: true`) would
+  /// EXECUTE the view's derived-table bodies during optimisation, so a stateful
+  /// or non-deterministic routine in a `FROM (SELECT tick() …)` would run once
+  /// at optimise and AGAIN at `derive`, double-consuming it. The single
+  /// execution happens at `derive`/run.
+  borrowing func overlay(_ name: String, _ context: Context)
+      throws(SQLError) -> Context {
     let fresh = context.scoping([:])
     guard let view = resolve(view: name) else { return fresh }
-    return augment(fresh, for: view.query, rows: true)
+    // `validate: false` — this overlay is the OPTIMISER's schema-only view-body
+    // scope on the RUN path (`resolve`/`compile` already validated the body
+    // under the caller's `validate`), so a data-dependent-empty derived body
+    // the view nests must not be re-type-checked and fault a run.
+    return try augment(fresh, for: view.query, rows: false, validate: false)
   }
 
   /// The view named `name`, or `nil`, by the precedence a query name follows.
@@ -321,8 +559,9 @@ extension Catalog where Self: ~Escapable {
       // column count: `resolve` rejects a view whose declared arity differs
       // from its body's (`v(x) AS SELECT * FROM People`), so such a view cannot
       // run and is not advertised here.
-      let overlay = augment(context.scoping([:]), for: view.query, rows: false)
-      guard let plan = try? compile(view.query, overlay),
+      guard let overlay = try? augment(context.scoping([:]), for: view.query,
+                                       rows: false),
+          let plan = try? compile(view.query, overlay),
           plan.width == view.columns.count else { continue }
       // Type the columns from the body's first arm; type-check every arm's
       // REACHABLE operands and calls too — an unknown call or a bad operand in
@@ -347,14 +586,16 @@ extension Catalog where Self: ~Escapable {
 }
 
 extension Query {
-  /// Collects every relation name this query names in a `FROM`/`JOIN`, across
+  /// Collects every relation name THIS query names in a `FROM`/`JOIN`, across
   /// the set-operation tree and each arm, into `names` — the reserved store
   /// names among them are what `Catalog.augment` builds.
   ///
-  /// It descends into every nested `EXISTS`/`IN (Q)` subquery (recursing the
-  /// same `subqueries` walk `compile`/`run` use), so a reserved store relation
-  /// mentioned ONLY inside a subquery still reaches `augment` — the overlay is
-  /// materialised before the subquery's width compile and its run resolve it.
+  /// It does NOT descend a nested `EXISTS`/`IN (Q)`/scalar subquery: each
+  /// subquery is compiled, type-checked, and run as a whole (`compile`/
+  /// `typecheck`/`run` each `augment` the query they receive), so a subquery
+  /// binds its OWN store relations in its OWN scope. Descending here would
+  /// instead lift a subquery's names into this query's statement-global
+  /// overlay, where a sibling subquery could not rebind a same-named entry.
   func collect(into names: inout Set<String>) {
     switch self {
     case let .select(select):
@@ -363,7 +604,63 @@ extension Query {
       left.collect(into: &names)
       right.collect(into: &names)
     }
-    for subquery in subqueries { subquery.collect(into: &names) }
+  }
+
+  /// Collects the DERIVED TABLES a single `SELECT` arm names in its own
+  /// `FROM`/`JOIN` — each alias paired with its inner `Query` — into
+  /// `derivations`. `Catalog.augment` materialises each once and binds it under
+  /// its alias in the scope of the arm that owns it, so the resolution scope
+  /// reads a derived table exactly as it reads a common table expression (see
+  /// `ScopedRelations`).
+  ///
+  /// It stops at a `SELECT`: a `setop` collects NOTHING here, so its two arms'
+  /// derived aliases never merge into one map. Each arm is augmented on its own
+  /// as `compile`/`typecheck`/`scope` descend it (each `augment`s the arm it
+  /// receives), so a derived alias binds only in the arm that names it — a
+  /// left arm's `FROM T` resolves the base relation (or a same-named CTE),
+  /// never a `derived T` a right arm named. Hoisting both arms into one
+  /// query-level map instead bound a right arm's `T` query-wide, mis-resolving
+  /// the left arm.
+  ///
+  /// It likewise does NOT descend a nested `EXISTS`/`IN (Q)`/scalar subquery,
+  /// or a derived table's OWN inner query: derived aliases are scoped to the
+  /// SELECT that owns their FROM/JOIN — not a statement-scoped, uniquely-named
+  /// CTE — so each subquery and each inner query `augment`s its own derived
+  /// tables in its own scope (see `Catalog.augment`/`materialise`). Descending
+  /// would bind those aliases into one map, where two siblings sharing an alias
+  /// `t` collide and an inner `t` cannot shadow an outer.
+  func collect(derived derivations: inout Array<(String, Query)>) {
+    if case let .select(select) = self {
+      select.collect(derived: &derivations)
+    }
+  }
+
+  /// Collects the RANGE NAMES a single `SELECT` arm binds in its own `FROM`/
+  /// `JOIN` — the alias a qualified reference names each item by (its explicit
+  /// alias, else a named relation's spelling), duplicates KEPT — into `ranges`.
+  /// `Catalog.augment` counts these to fault a derived alias that shadows a
+  /// same-scope sibling. It stops at a `SELECT` as `collect(derived:)` does: a
+  /// `setop` collects nothing, so each arm's ranges stay in its own scope, and
+  /// a nested subquery is not descended.
+  func collect(ranges: inout Array<String>) {
+    if case let .select(select) = self {
+      select.collect(ranges: &ranges)
+    }
+  }
+
+  /// Collects the SOURCE NAMES a single `SELECT` arm's `FROM`/`JOIN` NAMED
+  /// relations carry — the identifier `resolve` keys each named relation on in
+  /// the overlay (`relation.name` for a `.named` source, IGNORING its alias),
+  /// not the range name a qualified reference uses — into `sources`.
+  /// `Catalog.augment` checks these too so a derived alias `T` shadowing an
+  /// aliased base `T AS x` (exposed range `x`, source `T`) collides — `resolve`
+  /// would otherwise bind the base scan, keyed on `T`, to the derived rows. It
+  /// stops at a `SELECT` as `collect(ranges:)` does: a `setop` collects
+  /// nothing, and a nested subquery is not descended.
+  func collect(sources: inout Array<String>) {
+    if case let .select(select) = self {
+      select.collect(sources: &sources)
+    }
   }
 }
 
@@ -372,5 +669,43 @@ extension Select {
   func collect(into names: inout Set<String>) {
     if let from { names.insert(from.name) }
     for join in joins { names.insert(join.relation.name) }
+  }
+
+  /// Collects the range name of this select's `FROM` and each `JOIN` item — the
+  /// alias a qualified reference names it by (`relation.alias`, else the named
+  /// relation's spelling), matching `Scope.admits` — into `ranges`, duplicates
+  /// KEPT so a collision counts.
+  func collect(ranges: inout Array<String>) {
+    if let from { ranges.append(from.alias ?? from.name) }
+    for join in joins {
+      ranges.append(join.relation.alias ?? join.relation.name)
+    }
+  }
+
+  /// Collects the SOURCE NAME of this select's `FROM` and each `JOIN` NAMED
+  /// relation — the `relation.name` (`.named`'s identifier, its alias ignored)
+  /// that `resolve` keys the relation on — into `sources`, a derived table's
+  /// source contributing NONE (its rows key on its alias, already a range).
+  func collect(sources: inout Array<String>) {
+    if let from, case .named = from.source { sources.append(from.name) }
+    for join in joins {
+      if case .named = join.relation.source {
+        sources.append(join.relation.name)
+      }
+    }
+  }
+
+  /// Collects this select's `FROM` and `JOIN` derived tables — each alias with
+  /// its inner query — into `derivations`.
+  func collect(derived derivations: inout Array<(String, Query)>) {
+    if case let .derived(query) = from?.source, let alias = from?.alias {
+      derivations.append((alias, query))
+    }
+    for join in joins {
+      if case let .derived(query) = join.relation.source,
+          let alias = join.relation.alias {
+        derivations.append((alias, query))
+      }
+    }
   }
 }

--- a/Sources/SQLEngine/Engine.swift
+++ b/Sources/SQLEngine/Engine.swift
@@ -66,9 +66,32 @@ extension Query {
 extension Select {
   /// Whether the select names the relation `name` (case-folded) in its `FROM`
   /// or any `JOIN`.
+  ///
+  /// A relation contributes a reference by its SOURCE, not its binding name: a
+  /// `.named` relation names `name` when its identifier matches; a `.derived`
+  /// one names NOTHING through its alias — a `FROM (SELECT …) AS a` does not
+  /// reference a relation `a` — but its inner query is recursed into for the
+  /// REAL `.named` references its body holds. So a recursive-CTE fixpoint
+  /// detector sees a self-reference nested inside a derived body (`FROM (SELECT
+  /// n FROM a) AS d` names `a`) yet is NOT fooled by a shadowing derived alias
+  /// (`FROM (SELECT … ) AS a` does not name the CTE `a`).
   internal func references(_ name: String) -> Bool {
-    if from?.name.lowercased() == name { return true }
-    return joins.contains { $0.relation.name.lowercased() == name }
+    from?.references(name) ?? false
+        || joins.contains { $0.relation.references(name) }
+  }
+}
+
+extension Relation {
+  /// Whether this relation references the relation `name` (case-folded): a
+  /// `.named` relation by its identifier, a `.derived` one by RECURSING into
+  /// its inner query — the derived alias itself is not a reference.
+  internal func references(_ name: String) -> Bool {
+    switch source {
+    case let .named(identifier):
+      identifier.lowercased() == name
+    case let .derived(query):
+      query.references(name)
+    }
   }
 }
 
@@ -108,23 +131,77 @@ extension Catalog where Self: ~Escapable {
   /// base catalog.
   internal borrowing func run(_ query: Query, _ context: Context)
       throws(SQLError) -> Array<Array<Value>> {
-    // Extend the overlay with any `definition_schema.` store relation the
-    // query names, resolved lazily — the overlay after the
-    // CTEs, before the base catalog. Every phase reads the extended map, so a
-    // reserved store relation resolves, plans, and materialises exactly as a
-    // common table expression does; a portable `information_schema.` view over
-    // the store resolves through the ordinary view machinery. The routines ride
-    // in so a store `data_type` row types a view's scalar-call column
-    // (`GUID(...)`) by its declared return type.
-    let context = augment(context, for: query, rows: true)
-    let logical = try compile(query, context).pushdown()
-    let plan = try optimise(logical, context)
+    // A set operation runs each ARM against its OWN scope and combines the
+    // results, rather than materialising both arms' derived tables into one
+    // shared overlay the executor scans by name. Both arms bind their aliases
+    // in ONE map, so a right arm's `derived T` would shadow a left arm's base
+    // (or CTE) `T` at the leaf scan — the executor keys a `.scan` by name and
+    // cannot tell the two `T`s apart. Running per arm scopes each arm's derived
+    // tables to that arm: the left arm's `FROM T` scans the base relation and
+    // the right arm's its own derived one, then `combine` merges them under the
+    // operator's duplicate rule. The arity across arms is checked as `compile`
+    // resolves the whole query below.
+    if case let .setop(kind, left, right, all) = query {
+      // Validate the whole query (per-arm resolution and the cross-arm arity
+      // check) exactly as a single select does, then run each arm on its own.
+      // `validate: false` — the preflight must not eager-type-check a derived
+      // body a data-dependent filter never reaches (execution faults only on a
+      // REACHED operand), matching the non-derived path.
+      _ = try compile(query, context, validate: false)
+      let combined = try combine(kind, run(left, context).map(Record.init),
+                                 run(right, context).map(Record.init), all)
+      return combined.map(\.values)
+    }
+    // Compile from the un-augmented `context` (idempotently augmented inside
+    // `compile`, which reveals the base for a nested subquery) — this query's
+    // derived aliases are invisible to a subquery's FROM, and a CTE a
+    // same-named derived alias shadows stays visible beneath the revealed base.
+    // Compile VALIDATES the whole query (schema-only, `rows: false`) BEFORE any
+    // row materialises below, so an invalid query — an unknown column resolving
+    // over a `FROM (SELECT tick() …) AS d` — faults WITHOUT ever executing the
+    // derived body's stateful routine. A materialise ahead of this compile
+    // would run the body for a query that cannot run.
+    //
+    // `validate: false` gates the derived-body type-check OFF: the preflight
+    // proves the OUTER query runnable and resolves its relations, but a data-
+    // dependent body expression a filter drops (`FROM (SELECT Label + 1 AS x
+    // FROM K WHERE k = 0) AS d`) must NOT be rejected here — execution faults
+    // ONLY on an expression a surviving row reaches, exactly as the non-derived
+    // `SELECT Label + 1 FROM K WHERE k = 0` runs to zero rows. The eager body
+    // type-check stays for the EXPLICIT schema path (`columns` `validate:
+    // true`).
+    let logical = try compile(query, context, validate: false).pushdown()
+    // Now that `compile` proved the query runnable, extend the overlay with any
+    // `definition_schema.` store relation the query names (resolved lazily —
+    // the overlay after the CTEs, before the base catalog) AND MATERIALISE this
+    // query's derived tables (`rows: true`, executing each body ONCE). Every
+    // phase reads the extended map, so a reserved store relation resolves,
+    // plans, and materialises exactly as a common table expression does; a
+    // portable `information_schema.` view over the store resolves through the
+    // ordinary view machinery. The routines ride in so a store `data_type` row
+    // types a view's scalar-call column (`GUID(...)`) by its declared return
+    // type.
+    //
+    // `validate: false` — this run materialise executes each body's rows, but a
+    // NESTED derived body's schema is still derived schema-only inside
+    // `materialise` (to name the inner alias's columns); `validate: true` there
+    // would eager-type-check a doubly-nested filtered-out body on the RUN path.
+    // The run stays lenient at every depth (the outer query already compiled,
+    // and a REACHED operand still faults at execution).
+    let augmented = try augment(context, for: query, rows: true,
+                                validate: false)
+    let plan = try optimise(logical, augmented)
     // Execute every UNCORRELATED subquery the plan nests ONCE here — where the
     // borrowing catalog IS in scope — and thread the memoised results into the
     // context the executor reads (never during `compile`, so a schema-only path
     // opens no cursor). A query with no `EXISTS`/`IN (Q)` builds an empty one.
+    // The subqueries materialise against the un-augmented `context` — this
+    // query's own derived aliases are SELECT-scoped, invisible to a subquery's
+    // FROM (`subqueries(of:)` reveals the base, dropping any enclosing derived
+    // alias but keeping CTEs and store relations), so a CTE a same-named
+    // derived alias shadows stays visible to the subquery.
     let subqueries = try subqueries(of: query, context)
-    return try execute(plan, context.resolving(subqueries)).map(\.values)
+    return try execute(plan, augmented.resolving(subqueries)).map(\.values)
   }
 
   /// Runs a `Statement` against this catalog, returning its result rows.
@@ -257,6 +334,14 @@ extension Catalog where Self: ~Escapable {
   /// so `SELECT Name + 1 FROM People` in the anchor faults `SQLError.operand`
   /// against the BASE `People` a run reads it against, never wrongly types clean
   /// against the CTE's declared columns.
+  ///
+  /// `typecheck` ALSO gates the eager type-check of a DERIVED body the CTE
+  /// body nests: the arity `augment`/`compile` below thread `validate:
+  /// typecheck` so a run (`typecheck: false`) derives a `FROM (SELECT …) AS d`
+  /// LENIENTLY — a data-dependent body expression a filter drops (`FROM (SELECT
+  /// Label + 1 AS x FROM K WHERE k = 0) AS d`) is TRUSTED, not rejected, as
+  /// the non-`WITH` and `WITH`-trailing paths already do — while the schema
+  /// path (`typecheck: true`) keeps the strict body type-check.
   internal borrowing func validate(_ cte: CTE, against context: Context,
                                    typecheck: Bool = false)
       throws(SQLError) {
@@ -280,8 +365,9 @@ extension Catalog where Self: ~Escapable {
     // CTE-self overlay.
     if cte.recursive && cte.recurses,
         case let .setop(.union, anchor, recursive, _) = cte.query {
-      let scope = augment(context, for: anchor, rows: false)
-      let width = try compile(anchor, scope).width
+      let scope = try augment(context, for: anchor, rows: false,
+                              validate: typecheck)
+      let width = try compile(anchor, scope, validate: typecheck).width
       guard width == cte.columns.count else {
         throw .columns(expected: cte.columns.count, got: width)
       }
@@ -292,9 +378,14 @@ extension Catalog where Self: ~Escapable {
       let empty = Materialised(columns: cte.columns, rows: [],
                                types: Array(repeating: .integer,
                                             count: cte.columns.count))
-      let probe = augment(context, for: recursive, rows: false)
-          .binding(cte.name, to: empty)
-      let arm = try compile(recursive, probe).width
+      // Bind the CTE self BEFORE augmenting the recursive arm, so a derived
+      // body in the arm that names the CTE (`FROM (SELECT n FROM a) AS d`)
+      // resolves it — `augment` materialises derived bodies eagerly, so the
+      // self must be in scope by then, not bound only afterwards.
+      let probe = try augment(context.binding(cte.name, to: empty),
+                              for: recursive, rows: false,
+                              validate: typecheck)
+      let arm = try compile(recursive, probe, validate: typecheck).width
       guard arm == cte.columns.count else {
         throw .columns(expected: cte.columns.count, got: arm)
       }
@@ -304,8 +395,9 @@ extension Catalog where Self: ~Escapable {
         try self.typecheck(recursive, probe)
       }
     } else {
-      let scope = augment(context, for: cte.query, rows: false)
-      let width = try compile(cte.query, scope).width
+      let scope = try augment(context, for: cte.query, rows: false,
+                              validate: typecheck)
+      let width = try compile(cte.query, scope, validate: typecheck).width
       guard width == cte.columns.count else {
         throw .columns(expected: cte.columns.count, got: width)
       }
@@ -354,14 +446,20 @@ extension Catalog where Self: ~Escapable {
     // execution (a later `augment` will not replace a bound name), so a view
     // column using even a standard routine (`BITAND(...)`) types the same
     // inside the CTE as the identical SELECT does outside it.
-    let context = augment(context, for: cte.query, rows: true)
+    // `validate: false` on every arity `compile` below — `fixpoint` is a pure
+    // RUN path (only `with` routes a self-naming CTE here), so a derived body
+    // the CTE's arm nests must be TRUSTED, not eager-type-checked: a data-
+    // dependent body expression a filter drops must not fault a CTE that runs
+    // empty, matching the non-recursive and non-`WITH` paths.
+    let context = try augment(context, for: cte.query, rows: true,
+                              validate: false)
     guard case let .setop(.union, anchor, recursive, all) = cte.query else {
       // A non-`UNION` recursive query runs once, but still binds under
       // `cte.columns`, so validate its compiled width here too — the check the
       // anchor and arm get. A body naming a base relation of the CTE's own name
       // (`WITH RECURSIVE Parent(x,y,z) AS (SELECT * FROM Parent)`) would else
       // bind narrow base rows under the wider list and trap on a later read.
-      let width = try compile(cte.query, context).width
+      let width = try compile(cte.query, context, validate: false).width
       guard width == cte.columns.count else {
         throw .columns(expected: cte.columns.count, got: width)
       }
@@ -379,7 +477,7 @@ extension Catalog where Self: ~Escapable {
     // arm reads the absent ordinal, rather than surfacing `SQLError.columns`.
     // The anchor is the base case and does not reference the CTE, so its width
     // resolves with the name not yet in scope.
-    let width = try compile(anchor, context).width
+    let width = try compile(anchor, context, validate: false).width
     guard width == cte.columns.count else {
       throw .columns(expected: cte.columns.count, got: width)
     }
@@ -392,7 +490,7 @@ extension Catalog where Self: ~Escapable {
                              types: Array(repeating: .integer,
                                           count: cte.columns.count))
     let probe = context.binding(cte.name, to: empty)
-    let arm = try compile(recursive, probe).width
+    let arm = try compile(recursive, probe, validate: false).width
     guard arm == cte.columns.count else {
       throw .columns(expected: cte.columns.count, got: arm)
     }
@@ -1490,15 +1588,23 @@ extension Catalog where Self: ~Escapable {
   internal borrowing func group(_ select: Select, _ relation: Relation,
                                 _ from: Resolved, _ context: Context,
                                 _ visited: Set<String>,
-                                _ subscope: Subscope = .caller)
+                                _ subscope: Subscope = .caller,
+                                validate: Bool = true)
       throws(SQLError) -> Plan {
+    // The augmented `context` threads to `subquery(of:)`, which REVEALS the
+    // base — this select's and every enclosing select's derived aliases
+    // dropped, the CTEs and store relations kept — before lowering a nested
+    // subquery, so its FROM sees no derived alias while a CTE a same-named
+    // derived alias shadows stays visible (a grouped `ORDER BY SUM((SELECT x
+    // FROM d))` reads the CTE `d` beneath the derived `d`).
     // Resolve every joined relation and lay the FROM relation and each joined
     // one end to end in one combined ordinal space (as the non-aggregate join
     // path does), so the WHERE, keys, and aggregate arguments resolve uniformly.
     var joined = Array<Resolved>()
     joined.reserveCapacity(select.joins.count)
     for join in select.joins {
-      try joined.append(resolve(join.relation, context, visited))
+      try joined.append(resolve(join.relation, context, visited,
+                                validate: validate))
     }
     var relations = [(relation, from.schema)]
     for index in select.joins.indices {
@@ -1512,7 +1618,8 @@ extension Catalog where Self: ~Escapable {
     // the rest is a residual the join runs as a filter.
     // Materialise every UNCORRELATED subquery ONCE, ahead of lowering, into a
     // map the join ONs, WHERE, HAVING, projection, and ORDER BY read from.
-    let subquery = try subquery(of: select, context, visited, subscope)
+    let subquery = try subquery(of: select, context, visited, subscope,
+                                validate: validate)
     var matches = Array<Filter>()
     matches.reserveCapacity(select.joins.count)
     for index in select.joins.indices {
@@ -1824,8 +1931,14 @@ extension Catalog where Self: ~Escapable {
       // means what it was registered to mean; its scope is the
       // `definition_schema.` overlay its OWN query names (the same one it
       // compiled under), so a view body's store scan re-resolves.
+      //
+      // A SET-OPERATION view body's arm scans an arm-local derived alias the
+      // whole-view overlay does not bind (arms are SELECT-scoped), so `seek`
+      // would fault `.relation` resolving it. Optimise each arm under THAT
+      // arm's own augmented overlay — the same per-arm scope `derive`/`setop`
+      // execute it under — so the arm's `d` resolves for the seek rewrite.
       try .derived(name: name,
-                   plan: optimise(plan, overlay(name, context)),
+                   plan: optimise(view: name, plan, context),
                    ordinals: ordinals, seek: seek)
     case let .select(filter, .scan(name, ordinals, nil)):
       try seek(filter, name, ordinals, context)
@@ -1872,6 +1985,58 @@ extension Catalog where Self: ~Escapable {
       // the cap itself has no seek or join to rewrite.
       try .limit(count: count, offset: offset, optimise(source, context))
     }
+  }
+
+  /// Optimises a VIEW body's sub-`plan` for the view named `name`, resolving
+  /// its scans under the view's OWN overlay rather than a caller's scope.
+  ///
+  /// A SINGLE-arm body optimises under the whole-view overlay
+  /// (`overlay(name:)`) — the same scope it compiled under. A SET-OPERATION
+  /// body optimises each ARM under THAT arm's own augmented overlay: an arm
+  /// scans its arm-local derived alias, which the whole-view overlay does not
+  /// bind (arms are SELECT-scoped), so `seek` would fault `.relation` resolving
+  /// it. The `plan` tree mirrors the `query` tree, so this descends the two in
+  /// lockstep — a `.setop` node recurses into both arms, a LEAF arm augments
+  /// the arm's aliases SCHEMA-ONLY (`rows: false`, so `seek` treats them as
+  /// unseekable materialised relations by name/schema WITHOUT executing a
+  /// derived body) and optimises the arm sub-plan under that arm-local scope —
+  /// matching the per-arm scope `derive`/`setop` execute it under.
+  private borrowing func optimise(view name: String, _ plan: Plan,
+                                  _ context: Context)
+      throws(SQLError) -> Plan {
+    let overlay = try overlay(name, context)
+    guard let view = resolve(view: name), case .setop = view.query,
+        case .setop = plan else {
+      return try optimise(plan, overlay)
+    }
+    return try optimise(plan, view.query, overlay)
+  }
+
+  /// Optimises a view body's SET-OPERATION `plan` arm by arm, each arm sub-plan
+  /// under `overlay` AUGMENTED with THAT arm's own derived aliases, descending
+  /// the `plan` and `query` trees in lockstep (they mirror each other).
+  private borrowing func optimise(_ plan: Plan, _ query: Query,
+                                  _ overlay: Context)
+      throws(SQLError) -> Plan {
+    if case let .setop(kind, left, right, all) = plan,
+        case let .setop(_, leftQuery, rightQuery, _) = query {
+      return try .setop(kind, optimise(left, leftQuery, overlay),
+                        optimise(right, rightQuery, overlay), all: all)
+    }
+    // Schema-only (`rows: false`): the optimiser needs the arm's derived alias
+    // bound by name/schema so `seek` treats it as an unseekable materialised
+    // relation — NOT its rows. Materialising here would EXECUTE the arm's
+    // derived body during optimisation (a stateful routine would run once here
+    // and again at `derive`), so bind schema-only and let the single execution
+    // happen at run.
+    //
+    // `validate: false` — this is the RUN path's optimiser, matching the
+    // `overlay(name:)` above: `resolve`/`compile` already validated the view
+    // body under the caller's `validate`, so an arm's data-dependent-empty
+    // derived body must not be re-type-checked here and fault a run that its
+    // filtered-out rows never reach.
+    return try optimise(plan, augment(overlay, for: query, rows: false,
+                                      validate: false))
   }
 
   // MARK: - Physical seek
@@ -2525,17 +2690,58 @@ extension Catalog where Self: ~Escapable {
   internal borrowing func compile(_ query: Query,
                                   _ context: Context = Context(),
                                   _ visited: Set<String> = [],
-                                  _ scope: Subscope = .caller)
+                                  _ scope: Subscope = .caller,
+                                  validate: Bool = true)
       throws(SQLError) -> Plan {
+    // Bind the derived tables (and store relations) THIS query names in its own
+    // FROM/JOIN before resolving its relations — SELECT-scoped, so a subquery
+    // compiled through here binds its OWN aliases (an outer statement-global
+    // pre-collection would leave a sibling subquery's same-named `t` bound to
+    // the wrong one). Schema-only (`rows: false`): compilation reads schemas,
+    // never a cursor. Idempotent when the caller already augmented (`run`).
+    // `visited` carries the cyclic-view guard through, so a derived table in a
+    // view body under resolution that names the view faults `.recursion`.
+    // A nested subquery's FROM sees base tables and enclosing CTEs, NOT this
+    // query's derived aliases — so the augmented `context` threads onward and
+    // `subquery(of:)` REVEALS the base before lowering a subquery (this query's
+    // and every enclosing query's derived aliases dropped, the CTEs and store
+    // relations kept, a CTE a same-named derived alias here shadows still
+    // visible). The layered overlay never overwrote the CTE, so no pre-augment
+    // context is threaded. `validate` gates a derived body's eager type-check:
+    // a RUN preflight passes `false` so a data-dependent body expression an
+    // execution never evaluates is not rejected here (the outer query still
+    // faults, and a REACHED body operand still faults at run), matching the
+    // non-derived path; a schema check passes `true`.
+    let context = try augment(context, for: query, rows: false,
+                              visited: visited, validate: validate)
     guard case let .setop(kind, left, right, all) = query else {
-      return try compile(query.first, context, visited, scope)
+      return try compile(query.first, context, visited, scope,
+                         validate: validate)
     }
 
-    let width = try arity(query.first, context, visited)
-    let count = try arity(right.first, context, visited)
+    // A set operation collects NO derived aliases at the query level — arms are
+    // SCOPED, so `collect(derived:)` stops at a `SELECT` — leaving the augment
+    // above with no arm-local bindings. But the `SELECT *` arity check resolves
+    // each arm's `*` BEFORE the recursive per-arm compile augments that arm, so
+    // augment each arm's OWN derived aliases into a PER-ARM scope first, as the
+    // per-arm `compile`/`run` scope them: `SELECT * FROM (SELECT V FROM S) AS
+    // d` resolves `d`'s width. It is per arm so the left arm's `d` never
+    // leaks to the right (the arm-scoping fix); the width each check computes
+    // matches what the arm actually produces at run.
+    let head = try augment(context, for: .select(query.first),
+                           rows: false, visited: visited,
+                           validate: validate)
+    let tail = try augment(context, for: .select(right.first),
+                           rows: false, visited: visited,
+                           validate: validate)
+    let width = try arity(query.first, head, visited, validate: validate)
+    let count = try arity(right.first, tail, visited, validate: validate)
     guard count == width else { throw .arity(width, count) }
-    return try .setop(kind, compile(left, context, visited, scope),
-                      compile(right, context, visited, scope), all: all)
+    return try .setop(kind,
+                      compile(left, context, visited, scope,
+                              validate: validate),
+                      compile(right, context, visited, scope,
+                              validate: validate), all: all)
   }
 
   /// The distinct UNCORRELATED subqueries `select` nests, each COMPILED ONCE
@@ -2559,12 +2765,25 @@ extension Catalog where Self: ~Escapable {
   /// top-level one over the same AST stay distinct entries (see `Subscope`).
   internal borrowing func subquery(of select: Select, _ context: Context,
                                    _ visited: Set<String>,
-                                   _ scope: Subscope = .caller)
+                                   _ scope: Subscope = .caller,
+                                   validate: Bool = true)
       throws(SQLError) -> Subquery {
+    // A nested subquery's FROM resolves against base tables and enclosing CTEs,
+    // NOT the enclosing SELECT's derived-table aliases (SELECT-scoped, unseen
+    // by a subquery's FROM as a base-table alias would be) — so STRIP them, the
+    // CTEs/store relations kept, before compiling each subquery. Applied for
+    // scalar, `IN`, and `EXISTS` alike (`select.subqueries` covers all three).
+    let context = context.revealed()
     var widths = Dictionary<Query, Int>()
     var types = Dictionary<Query, ValueType>()
     for query in select.subqueries where widths[query] == nil {
-      widths[query] = try compile(query, context, visited).width
+      // `validate` gates the eager type-check of a derived body THIS subquery
+      // nests: a RUN passes `false` so a filtered-out `FROM (SELECT …) AS d` in
+      // an `EXISTS`/`IN (Q)`/scalar subquery is TRUSTED, not rejected, matching
+      // the outer query; a schema check passes `true`. The type derivation
+      // below is already schema-only lenient (`validate: false`).
+      widths[query] =
+          try compile(query, context, visited, validate: validate).width
       // A scalar subquery contributes its single-column output type; a wider or
       // an `EXISTS`/`IN (Q)` subquery still records the FIRST column's type
       // (harmless — only a width-1 scalar occurrence reads it, and the lowering
@@ -2622,6 +2841,13 @@ extension Catalog where Self: ~Escapable {
   internal borrowing func subqueries(of query: Query, _ context: Context,
                                      _ scope: Subscope = .caller)
       throws(SQLError) -> Subqueries {
+    // A nested subquery's FROM resolves against base tables and enclosing CTEs,
+    // NOT the enclosing SELECT's derived-table aliases — REVEAL the base
+    // (CTEs/store kept, the derived layers dropped) before running/probing each
+    // subquery, mirroring the compile-path reveal in `subquery(of:)`, so a
+    // `FROM d` naming an outer derived alias faults at run exactly as it does
+    // at `columns(of:)`, while a CTE the alias shadowed is exposed beneath.
+    let context = context.revealed()
     let valued = query.valued
     let existential = query.existential
     var results = Dictionary<Subkey, MaterialisedSubquery>()
@@ -2658,7 +2884,15 @@ extension Catalog where Self: ~Escapable {
         }
       }
     }
-    return Subqueries(results)
+    // Carry the REVEALED base scope the eager occurrences ran against, keyed
+    // under THIS `scope`, so the LAZY scalar path resolves its inner query
+    // against the SAME base — a CTE a same-named derived alias shadows stays
+    // visible to it, exactly as it does to the eager `EXISTS`/`IN (Q)`
+    // occurrences above. Keying per `scope` keeps a view-body cache's relations
+    // distinct from the caller's when the two are `merged` (the evaluator
+    // threads only the executing plan's overlay, which cannot tell them apart),
+    // so a `.view` scalar reads the view's scope.
+    return Subqueries(results, ScalarMemo(), [scope: context.relations])
   }
 
   /// The single VALUE a SCALAR subquery `query` collapses to against this
@@ -2677,6 +2911,13 @@ extension Catalog where Self: ~Escapable {
   /// result for the reached occurrence's later reads.
   internal borrowing func cell(of query: Query, _ context: Context)
       throws(SQLError) -> Value {
+    // A scalar subquery is a nested subquery: its FROM resolves against base
+    // tables and enclosing CTEs, NOT the enclosing SELECT's derived-table
+    // aliases (the evaluator threads the owning plan's overlay, which binds
+    // them for the owning scan). STRIP them (CTEs/store kept), matching the
+    // eager `IN`/`EXISTS` strip in `subqueries(of:)`, so a scalar subquery's
+    // `FROM d` cannot scan an outer derived alias `d`.
+    let context = context.revealed()
     let rows = try run(query, context)
     guard rows.count <= 1 else { throw .cardinality }
     return rows.first?.first ?? .null
@@ -2720,7 +2961,8 @@ extension Catalog where Self: ~Escapable {
   /// arity check. The relations resolve through this catalog, the overlay
   /// consulted first.
   private borrowing func arity(_ select: Select, _ context: Context,
-                               _ visited: Set<String>)
+                               _ visited: Set<String>,
+                               validate: Bool = true)
       throws(SQLError) -> Int {
     switch select.projection {
     case .all:
@@ -2728,9 +2970,12 @@ extension Catalog where Self: ~Escapable {
       guard let relation = select.from else {
         throw .named("SELECT * with no FROM")
       }
-      var width = try resolve(relation, context, visited).schema.width
+      var width =
+          try resolve(relation, context, visited, validate: validate)
+              .schema.width
       for join in select.joins {
-        try width += resolve(join.relation, context, visited).schema.width
+        try width += resolve(join.relation, context, visited,
+                             validate: validate).schema.width
       }
       return width
     case let .columns(columns):
@@ -2777,7 +3022,8 @@ extension Catalog where Self: ~Escapable {
   /// to advertise it, relies on this: a cyclic view's `try? compile` catches
   /// the fault and skips it.
   internal borrowing func resolve(_ relation: Relation, _ context: Context,
-                                  _ visited: Set<String> = [])
+                                  _ visited: Set<String> = [],
+                                  validate: Bool = true)
       throws(SQLError) -> Resolved {
     let name = relation.name
     if let cte = context.relations[name.lowercased()] {
@@ -2812,14 +3058,25 @@ extension Catalog where Self: ~Escapable {
       // validate a view via `compile`. The rows a view over a reserved
       // relation actually returns are supplied at EXECUTE time, where `derive`
       // rebuilds the overlay with rows and runs the sub-plan.
+      // This view name enters `visited` BEFORE its body's derived tables
+      // materialise, so a body naming this view through a derived table
+      // (`FROM (SELECT * FROM <self>) AS d`) re-enters `augment`/`materialise`
+      // with the view already visited and faults `.recursion` here rather than
+      // recursing to a stack overflow.
+      let inner = visited.union([name.lowercased()])
+      // `validate` threads into the view body's schema-only augment + compile
+      // so a RUN (`validate: false`) resolving `FROM <view>` does NOT eager-
+      // type-check a data-dependent-empty derived body the view nests — as the
+      // lenient run of the same query inline; a schema check keeps it strict.
       let overlay =
-          augment(context.scoping([:]), for: view.query, rows: false)
+          try augment(context.scoping([:]), for: view.query, rows: false,
+                      visited: inner, validate: validate)
       // The body's subqueries resolve under the VIEW's overlay — never the
       // caller's — so lower them under `.view(name)`, keeping a view-body
       // occurrence and a top-level one over the same AST distinct entries.
       let plan =
-          try compile(view.query, overlay, visited.union([name.lowercased()]),
-                      .view(name.lowercased()))
+          try compile(view.query, overlay, inner, .view(name.lowercased()),
+                      validate: validate)
       let projected = plan.width
       guard view.columns.count == projected else {
         throw .columns(expected: projected, got: view.columns.count)
@@ -2865,8 +3122,31 @@ extension Catalog where Self: ~Escapable {
   internal borrowing func compile(_ select: Select,
                                   _ context: Context = Context(),
                                   _ visited: Set<String> = [],
-                                  _ subscope: Subscope = .caller)
+                                  _ subscope: Subscope = .caller,
+                                  validate: Bool = true)
       throws(SQLError) -> Plan {
+    // Bind THIS select's own FROM/JOIN derived tables (and store relations)
+    // before resolving its relations — SELECT-scoped, so a select reaching
+    // this entry DIRECTLY (a bare `compile(select)`, not through the `Query`
+    // wrapper) resolves its OWN derived aliases rather than faulting
+    // `.relation`, the same as its schema siblings `columns(of select:)`/
+    // `scope(of select:)`. Schema-only (`rows: false`): compilation reads
+    // schemas, never a cursor. Idempotent when the caller already augmented
+    // (the `Query` wrapper augments this select before its `compile(query.
+    // first, …)`), so the wrapped path does not re-derive — a binding whose
+    // derivation matches is kept, so a self-named `(SELECT … FROM T) AS T`
+    // still reads the base and a shadowed CTE keeps its binding. `visited`
+    // carries the cyclic-view guard, `validate` gates a derived body's eager
+    // type-check the same as the wrapper's.
+    //
+    // The augmented `context` threads onward to `subquery(of:)`/`group`, which
+    // REVEAL the base before lowering a nested subquery — this select's (and
+    // every enclosing select's) derived aliases dropped, the CTEs and store
+    // relations kept — so a subquery's FROM sees no derived alias while a CTE
+    // a same-named derived alias here shadows stays visible. The layered
+    // overlay never overwrote the CTE, so no separate pre-augment context runs.
+    let context = try augment(context, for: .select(select), rows: false,
+                              visited: visited, validate: validate)
     guard let relation = select.from else {
       // A FROM-less select projects expressions over a single row; a `WHERE`,
       // `GROUP BY`, `HAVING`, `ORDER BY`, `OFFSET`/`FETCH`, or `JOIN` has no
@@ -2887,11 +3167,12 @@ extension Catalog where Self: ~Escapable {
       // matching run-time cache from `query.subqueries` (which descends the
       // projection), so the subquery is materialised there — `compile` runs it
       // never.
-      let subquery = try subquery(of: select, context, visited, subscope)
+      let subquery = try subquery(of: select, context, visited, subscope,
+                                  validate: validate)
       return try select.projection.scalar(context.routines,
                                           subquery: subquery)
     }
-    let from = try resolve(relation, context, visited)
+    let from = try resolve(relation, context, visited, validate: validate)
 
     if let limit = select.limit {
       // The parser yields only non-negative counts (a `-` is its own token), but
@@ -2908,13 +3189,15 @@ extension Catalog where Self: ~Escapable {
     // `HAVING`, and `ORDER BY` against the grouped slot space. A non-aggregate
     // query compiles exactly as before.
     if select.aggregates {
-      return try group(select, relation, from, context, visited, subscope)
+      return try group(select, relation, from, context, visited, subscope,
+                       validate: validate)
     }
 
     guard !select.joins.isEmpty else {
       // Materialise every UNCORRELATED subquery ONCE, ahead of lowering, into a
       // map the WHERE/projection/ORDER BY lowering splices results from.
-      let subquery = try subquery(of: select, context, visited, subscope)
+      let subquery = try subquery(of: select, context, visited, subscope,
+                                  validate: validate)
       var filter: Filter? = nil
       if let predicate = select.predicate {
         filter = try from.schema.lower(predicate, in: relation,
@@ -2963,7 +3246,8 @@ extension Catalog where Self: ~Escapable {
     var joined = Array<Resolved>()
     joined.reserveCapacity(select.joins.count)
     for join in select.joins {
-      try joined.append(resolve(join.relation, context, visited))
+      try joined.append(resolve(join.relation, context, visited,
+                                validate: validate))
     }
 
     var relations = [(relation, from.schema)]
@@ -2986,7 +3270,8 @@ extension Catalog where Self: ~Escapable {
     // sees every relation.
     // Materialise every UNCORRELATED subquery ONCE, ahead of lowering, into a
     // map the join ONs, WHERE, projection, and ORDER BY splice results from.
-    let subquery = try subquery(of: select, context, visited, subscope)
+    let subquery = try subquery(of: select, context, visited, subscope,
+                                validate: validate)
     var matches = Array<Filter>()
     matches.reserveCapacity(select.joins.count)
     for index in select.joins.indices {

--- a/Sources/SQLEngine/Filter.swift
+++ b/Sources/SQLEngine/Filter.swift
@@ -735,7 +735,21 @@ extension Catalog where Self: ~Escapable {
     if let cached = subqueries.scalar(cached: key) {
       return cached.coerced(to: type)
     }
-    let context = Context(relations: relations, routines: routines,
+    // Resolve the inner query against the cache's BASE scope for THIS
+    // occurrence's OWN `Subscope` — the one the eager `EXISTS`/`IN (Q)`
+    // occurrences of that scope ran against (the revealed base
+    // `subqueries(of:)` kept), which `cell(of:)` reveals for the scalar's FROM.
+    // Picking the scope by `key.scope` keeps a `.view(name)` scalar reading the
+    // VIEW's relations and a `.caller` scalar the caller's after a `merged`
+    // folds the two — the executor threads only the EXECUTING plan's overlay
+    // down the evaluate tree, which cannot tell a view-body scope from the
+    // caller's, so the per-`Subscope` cache scope carries each. An empty cache
+    // scope (a schema path's bare `Subqueries`) falls back to the threaded
+    // overlay, whose derived layer a `cell(of:)` reveal drops to expose a CTE a
+    // same-named derived alias shadows.
+    let owned = subqueries.relations(key.scope)
+    let scope = owned.isEmpty ? relations : owned
+    let context = Context(relations: scope, routines: routines,
                           bindings: bindings, subqueries: subqueries)
     let value = try cell(of: key.query, context)
     subqueries.store(scalar: value, for: key)

--- a/Sources/SQLEngine/Materialised.swift
+++ b/Sources/SQLEngine/Materialised.swift
@@ -1,18 +1,127 @@
 // Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
-/// The common table expressions in scope, keyed case-folded — the materialised
-/// relations the engine resolves a `WITH`'s names against.
+/// The relations in scope, keyed case-folded — the materialised relations the
+/// engine resolves a query's `FROM`/`JOIN` names against, consulted before the
+/// base catalog (a bound name shadows a base table or view of the same name).
 ///
 /// It is threaded alongside the borrowed base catalog through every resolution
 /// phase: when the engine resolves a relation name, it consults
-/// `ScopedRelations` first (a CTE name shadows a base table or view of the same
-/// name), and a CTE leaf materialises its records from the `Materialised` rows
-/// rather than opening a base cursor. An empty `ScopedRelations` is the default
-/// — a query with no `WITH` resolves exactly as before. Threading escapable
-/// data sidesteps wrapping the borrowed `~Escapable` base catalog in a unifying
-/// overlay type.
-internal typealias ScopedRelations = Dictionary<String, Materialised>
+/// `ScopedRelations` first, and a bound leaf materialises its records from the
+/// `Materialised` rows rather than opening a base cursor. An empty
+/// `ScopedRelations` is the default — a query with no `WITH` and no derived
+/// table resolves exactly as before. Threading escapable data sidesteps
+/// wrapping the borrowed `~Escapable` base catalog in a unifying overlay type.
+///
+/// It is a NON-DESTRUCTIVE LAYERED scope, not a flat map. The overlay is a
+/// stack of layers: a `base` layer holds the statement-scoped bindings — every
+/// common table expression a `WITH` materialises and every store relation a
+/// query names — and each `augment` for a SELECT PUSHES a derived layer holding
+/// that SELECT's own `FROM (SELECT …) AS t` derived aliases. A name resolves
+/// against the INNERMOST layer that binds it, so a derived alias `t` SHADOWS a
+/// same-named CTE `t` in the base layer WITHOUT deleting it — `reveal` drops
+/// the derived layers and the CTE beneath is resolved again. This makes the
+/// CTE-overwrite class impossible: a nested subquery's FROM, a lazy scalar, and
+/// a set-op arm each resolve against the REVEALED base rather than a
+/// separately-threaded pre-augment context.
+internal struct ScopedRelations: Hashable, Sendable,
+                                 ExpressibleByDictionaryLiteral {
+  /// The statement-scoped bindings — every common table expression and
+  /// `definition_schema.` store relation in scope (`derivation == nil`). It is
+  /// what a nested subquery's FROM and a revealed body resolve against: a CTE
+  /// is statement-scoped, visible under any number of enclosing derived layers.
+  private var base: Dictionary<String, Materialised>
+
+  /// The stack of SELECT-scoped derived layers, outermost first. Each
+  /// `augment` for a SELECT with `FROM (SELECT …) AS t` derived tables pushes
+  /// one layer binding that SELECT's own aliases; a name resolves against the
+  /// innermost (last) layer that binds it, so an inner derived alias shadows an
+  /// outer same-named one and both shadow the base. Empty for a query with no
+  /// derived table.
+  private var layers: Array<Dictionary<String, Materialised>>
+
+  /// An empty overlay — the scope a bare query with no `WITH` and no derived
+  /// table runs under.
+  internal init() {
+    self.base = [:]
+    self.layers = []
+  }
+
+  internal init(dictionaryLiteral elements: (String, Materialised)...) {
+    self.base = Dictionary(uniqueKeysWithValues: elements)
+    self.layers = []
+  }
+
+  /// The binding `name` resolves to — the innermost derived layer that holds
+  /// it, else the base layer — or `nil` when no layer binds it. Setting binds
+  /// `name` in the INNERMOST layer (the current derived layer, else the base),
+  /// shadowing an outer same-named binding without deleting it; setting `nil`
+  /// removes it from that layer only.
+  internal subscript(name: String) -> Materialised? {
+    get {
+      for layer in layers.reversed() {
+        if let materialised = layer[name] { return materialised }
+      }
+      return base[name]
+    }
+    set {
+      if layers.isEmpty {
+        base[name] = newValue
+      } else {
+        layers[layers.count - 1][name] = newValue
+      }
+    }
+  }
+
+  /// This overlay with `derivations` PUSHED as a new derived layer — the scope
+  /// a SELECT resolves its own FROM/JOIN and expressions against, each derived
+  /// alias shadowing an outer same-named CTE or derived alias without deleting
+  /// it. It is idempotent on the layer's IDENTITY: pushing a layer whose
+  /// aliases and derivation queries EQUAL the innermost derived layer's (the
+  /// run→compile→typecheck chain re-augments the same query) is a no-op, so
+  /// the stack stays bounded and a self-named alias's body still reads the
+  /// base.
+  internal func pushing(_ derivations: Dictionary<String, Materialised>)
+      -> ScopedRelations {
+    guard !derivations.isEmpty else { return self }
+    if layers.last == derivations { return self }
+    var copy = self
+    copy.layers.append(derivations)
+    return copy
+  }
+
+  /// This overlay with every derived layer DROPPED, leaving the base layer —
+  /// the scope a NESTED subquery's FROM resolves against. A derived alias is
+  /// SELECT-scoped: it names a relation only in its OWN SELECT's FROM/JOIN and
+  /// expressions, invisible to a nested subquery's FROM exactly as a base-table
+  /// alias in the enclosing FROM is. A CTE, by contrast, is statement-scoped
+  /// — visible inside a nested subquery's FROM — so the base layer stays,
+  /// REVEALING any CTE a dropped derived alias shadowed.
+  internal func revealed() -> ScopedRelations {
+    var copy = self
+    copy.layers = []
+    return copy
+  }
+
+  /// The derivation query bound for `name` in the innermost derived layer that
+  /// holds it, else `nil` — the identity `augment` keys its per-alias
+  /// idempotence on (a binding whose `derivation` EQUALS the inner query is
+  /// this SELECT's own prior pass, left rather than re-derived).
+  internal func derivation(of name: String) -> Query? {
+    for layer in layers.reversed() {
+      if let materialised = layer[name] { return materialised.derivation }
+    }
+    return nil
+  }
+
+  /// Whether NO layer binds any name — an untouched overlay. The lazy-scalar
+  /// path reads it to tell a cache carrying this occurrence's pre-augment scope
+  /// from a bare one (a schema path's `Subqueries`), falling back to the
+  /// threaded overlay for the latter.
+  internal var isEmpty: Bool {
+    base.isEmpty && layers.allSatisfy(\.isEmpty)
+  }
+}
 
 /// An escapable, in-engine relation over `(columns, rows)`.
 ///
@@ -43,11 +152,35 @@ internal struct Materialised: Hashable, Sendable {
   /// passes them so `information_schema` columns report their real types.
   internal let types: Array<ValueType>
 
+  /// The inner `Query` this binding is the materialised body of, when it is a
+  /// DERIVED TABLE's — `nil` for a common table expression's or a store
+  /// relation's binding. It is the derivation's IDENTITY, not merely a flag:
+  /// `augment` keys idempotence on it, so it can tell THIS query's own prior
+  /// materialisation of an alias (the run→compile double augment, or a
+  /// self-named `(SELECT … FROM T) AS T`) apart from an ENCLOSING query's
+  /// same-named derived binding.
+  ///
+  /// `augment` reads it two ways. Dropping the enclosing scope's derived
+  /// bindings (any non-`nil` `derivation`) before resolving a body is what lets
+  /// a self-named `(SELECT … FROM T) AS T` read the base `T` while KEEPING a
+  /// same-named CTE in scope (so `WITH t … FROM (SELECT … FROM t) AS t`
+  /// resolves the CTE). And a binding whose `derivation` EQUALS the inner query
+  /// being materialised is this query's own prior pass, left as materialised
+  /// rather than re-derived (idempotent); a binding whose `derivation` differs
+  /// — or is `nil` — is an enclosing query's, and this query's alias
+  /// re-materialises over it, SHADOWING it.
+  internal let derivation: Query?
+
+  /// Whether this binding is a DERIVED TABLE's materialised body — as opposed
+  /// to a common table expression's or a store relation's.
+  internal var derived: Bool { derivation != nil }
+
   internal init(columns: Array<String>, rows: Array<Array<Value>>,
-                types: Array<ValueType>) {
+                types: Array<ValueType>, derivation: Query? = nil) {
     self.columns = columns
     self.rows = rows
     self.types = types
+    self.derivation = derivation
   }
 
   /// The real column count — the extent of a `SELECT *`.

--- a/Sources/SQLEngine/Operator.swift
+++ b/Sources/SQLEngine/Operator.swift
@@ -606,16 +606,24 @@ extension Catalog where Self: ~Escapable {
                                    _ right: Plan, _ all: Bool,
                                    _ context: Context)
       throws(SQLError) -> Array<Record> {
-    let rows = try execute(left, context)
-    switch kind {
-    case .union:
-      let combined = try rows + execute(right, context)
-      return all ? combined : deduplicated(combined)
-    case .intersect:
-      return try intersected(rows, execute(right, context), all)
-    case .except:
-      return try subtracted(rows, execute(right, context), all)
-    }
+    try combine(kind, execute(left, context), execute(right, context), all)
+  }
+}
+
+/// Combines two set-operation arms' records under `kind` and `all` — `union`
+/// keeps the rows of either, `intersect` those of both, `except` the left's not
+/// balanced by the right — the executor's `setop` node and the per-arm run path
+/// share this ONE combiner so the two agree on duplicate handling.
+internal func combine(_ kind: SetOperation, _ left: Array<Record>,
+                      _ right: Array<Record>, _ all: Bool) -> Array<Record> {
+  switch kind {
+  case .union:
+    let combined = left + right
+    return all ? combined : deduplicated(combined)
+  case .intersect:
+    return intersected(left, right, all)
+  case .except:
+    return subtracted(left, right, all)
   }
 }
 
@@ -765,32 +773,116 @@ extension Catalog where Self: ~Escapable {
                                  _ ordinals: Array<Int>, _ seek: Range<Int>?,
                                  _ context: Context)
       throws(SQLError) -> Array<Record> {
-    var overlay = if let view = resolve(view: name) {
-      augment(context.scoping([:]), for: view.query, rows: true)
-    } else {
-      context.scoping([:])
-    }
-    // A view body may itself nest `EXISTS`/`IN (Q)` predicates whose subqueries
-    // its own compiled plan carries; resolve them ONCE here — against the view's
-    // overlay, where this catalog is in scope — so the sub-plan's row evaluator
-    // reads each result, just as the top-level `run` resolves a query's own.
-    // Materialise them under `.view(name)` — the SAME scope the body compiled
-    // its lowered `Filter`s under — and MERGE with the caller's cache (keyed
-    // `.caller`). The two id spaces are DISJOINT (see `Subscope`): a view-body
-    // `EXISTS (SELECT V FROM S)` over the view's OWN base `S` and a caller's
-    // pushed `EXISTS (SELECT V FROM S)` over the caller's CTE `S` are the same
-    // AST but SEPARATE occurrences, so each keeps its own result — the pushed
-    // caller conjunct reads its `.caller` entry, the view-body conjunct its
-    // `.view` entry — neither overwriting the other, which a value-keyed merge
-    // would.
+    var overlay = context.scoping([:])
     if let view = resolve(view: name) {
-      let inner = try subqueries(of: view.query, overlay,
-                                 .view(name.lowercased()))
-      overlay = overlay.resolving(context.subqueries.merged(inner))
+      // EXECUTION-path materialise (`rows: true`): a nested derived body's
+      // schema is derived schema-only inside `materialise`, so `validate:
+      // false` keeps that lenient — a data-dependent-empty derived body in a
+      // view body must not fault at run, matching the top-level run path.
+      // Seed the cyclic-view guard with THIS view's own name, as
+      // `resolve(view:)` does, so a body materialising this view through a
+      // derived table (`FROM (SELECT * FROM <self>) AS d`) faults `.recursion`
+      // in `materialise` rather than re-running the body without end.
+      let visited: Set<String> = [name.lowercased()]
+      overlay = try augment(context.scoping([:]), for: view.query, rows: true,
+                            visited: visited, validate: false)
     }
-    let rows = try execute(plan, overlay)
+    let rows: Array<Record>
+    if let view = resolve(view: name), case .setop = view.query,
+        case .setop = plan {
+      // A SET-OPERATION view body executes each ARM's sub-plan under an overlay
+      // AUGMENTED with THAT arm's own derived aliases. A `setop` collects NO
+      // derived aliases at the query level (arms are SELECT-scoped), so the
+      // overlay built above binds none; a `CREATE VIEW v AS SELECT * FROM
+      // (SELECT Id FROM T) AS d UNION ALL …` would else execute an arm `.scan`
+      // over an unbound `d`. Executing the arm SUB-PLANS (not re-running the
+      // arm queries) preserves any conjunct the caller PUSHED into the view's
+      // plan — the pushed filter lives in each arm's sub-plan — while the
+      // per-arm augment binds the arm-local `d` the whole-body overlay missed.
+      //
+      // Its subqueries are resolved PER ARM inside `setop`, not here over the
+      // whole-view overlay: an arm's direct `EXISTS`/`IN (Q)` may name that
+      // arm's arm-local derived alias, so materialising it (running it) demands
+      // the arm's own augment in scope — the whole-view overlay binds no arm
+      // alias, so a whole-view materialise would fault `.relation("d")` before
+      // an arm ever ran. Mirrors the per-arm run and `SELECT *` arity paths.
+      rows = try setop(plan, view.query, overlay, name.lowercased())
+    } else {
+      // A single-arm view body may itself nest `EXISTS`/`IN (Q)` predicates
+      // whose subqueries its own compiled plan carries; resolve them ONCE here
+      // — against the view's overlay, where this catalog is in scope — so the
+      // sub-plan's row evaluator reads each result, just as the top-level `run`
+      // resolves a query's own. Materialise them under `.view(name)` — the SAME
+      // scope the body compiled its lowered `Filter`s under — and MERGE with
+      // the caller's cache (keyed `.caller`). The two id spaces are DISJOINT
+      // (see `Subscope`): a view-body `EXISTS (SELECT V FROM S)` over the
+      // view's OWN base `S` and a caller's pushed `EXISTS (SELECT V FROM S)`
+      // over the caller's CTE `S` are the same AST but SEPARATE occurrences, so
+      // each keeps its own result — the pushed caller conjunct reads its
+      // `.caller` entry, the view-body conjunct its `.view` entry — neither
+      // overwriting the other, which a value-keyed merge would.
+      if let view = resolve(view: name) {
+        let inner = try subqueries(of: view.query, overlay,
+                                   .view(name.lowercased()))
+        overlay = overlay.resolving(context.subqueries.merged(inner))
+      }
+      rows = try execute(plan, overlay)
+    }
     let range = seek ?? 0 ..< rows.count
     return range.map { rows[$0].project(ordinals) }
+  }
+
+  /// Executes a view body's SET-OPERATION `plan` arm by arm, each arm sub-plan
+  /// under `overlay` AUGMENTED with THAT arm's own derived aliases, combining
+  /// the arms under each node's operator.
+  ///
+  /// The `plan` tree mirrors the `query` tree (compile builds `.setop(kind,
+  /// compile(left), compile(right), all)` from `.setop(kind, left, right,
+  /// all)`), so this descends the two in lockstep: a `.setop` node recurses
+  /// into both arms and `combine`s the results, and a LEAF arm — a `.select`
+  /// query, its sub-plan any non-`setop` node — augments the arm's derived
+  /// aliases into `overlay` (rows, so its `.scan` reads them) and executes the
+  /// sub-plan under that arm-local scope. Executing the sub-plan (not
+  /// re-running the arm query) keeps any conjunct the caller pushed into the
+  /// plan; the per-arm augment binds the arm-local derived alias the whole-body
+  /// overlay omitted; and each arm's `d` stays scoped to its arm (two arms may
+  /// reuse `d`).
+  ///
+  /// A leaf arm's DIRECT `EXISTS`/`IN (Q)` subqueries are materialised here
+  /// too, against the arm-local augmented scope and MERGED into it under
+  /// `.view(name)` — the same scope the arm sub-plan's lowered `Filter`s
+  /// compiled under — so an arm subquery naming that arm's arm-local derived
+  /// alias resolves. The whole-view overlay binds no arm alias, so
+  /// materialising these at the view level would fault `.relation` before an
+  /// arm ran.
+  ///
+  /// Each arm resolves with ITS OWN `inner` cache first — `inner.merged(...)`,
+  /// not the reverse — so the arm keeps `inner`'s FRESH per-arm scalar memo
+  /// rather than the shared caller memo `overlay` carries. Both arms compile
+  /// their scalar subqueries under the SAME `.view(name)` scope, so identical
+  /// scalar text across arms lowers to the SAME `Subkey`; sharing one memo box
+  /// would let the first arm's collapsed value be REUSED by the second — even
+  /// though each arm's scalar reads that arm's OWN arm-local relation and must
+  /// yield its OWN value. A per-arm memo isolates the lazy scalar the way the
+  /// eager per-arm `IN`/`EXISTS` results already are, completing the per-arm
+  /// isolation beyond the eager roles. `merged` keeps `inner`'s scalar box and
+  /// unions the results keeping `inner`'s on a collision; the caller's own
+  /// `.caller` results (a pushed `EXISTS`/`IN (Q)`, which alone are safe enough
+  /// to push into an arm — a scalar-subquery conjunct is UNSAFE and never
+  /// pushes in) ride through under their disjoint scope, so the arm still reads
+  /// a pushed caller `EXISTS`/`IN (Q)` while its own scalar memo stays private.
+  private borrowing func setop(_ plan: Plan, _ query: Query, _ overlay: Context,
+                               _ name: String)
+      throws(SQLError) -> Array<Record> {
+    if case let .setop(kind, left, right, all) = plan,
+        case let .setop(_, leftQuery, rightQuery, _) = query {
+      return try combine(kind, setop(left, leftQuery, overlay, name),
+                         setop(right, rightQuery, overlay, name), all)
+    }
+    var scope = try augment(overlay, for: query, rows: true, validate: false)
+    let inner = try subqueries(of: query, scope, .view(name))
+    scope = scope.resolving(inner.merged(overlay.subqueries))
+    return try execute(plan, scope)
   }
 }
 

--- a/Sources/SQLEngine/OutputColumn.swift
+++ b/Sources/SQLEngine/OutputColumn.swift
@@ -86,12 +86,20 @@ extension Catalog where Self: ~Escapable {
     let context = Context(routines: routines)
     // Extend the scope with any `definition_schema.` store relation the query
     // names, so its result schema resolves the reserved relation the same as a
-    // run would — SCHEMA-ONLY, so typing never triggers the row build.
-    let scope = augment(context, for: query, rows: false)
+    // run would — SCHEMA-ONLY, so typing never triggers the row build. A
+    // derived body is validated only when `validate`: a `validate: false`
+    // derive after a run trusts the body rather than re-checking a reachable
+    // operand a data-dependent filter never reached (matching the non-derived
+    // path, whose empty run never evaluates it).
+    let scope = try augment(context, for: query, rows: false,
+                            validate: validate)
     // Validate the whole query without executing — the same compile the run
     // path drives, resolving every arm and cross-checking a UNION's arity — so
-    // a schema is returned only for a query that could actually run.
-    _ = try compile(query, scope)
+    // a schema is returned only for a query that could actually run. `validate`
+    // threads through: a `validate: false` derive after a run must NOT eager-
+    // type-check a derived body in a subquery a data-dependent filter dropped,
+    // matching the run's lenient compile.
+    _ = try compile(query, scope, validate: validate)
     // Type-check every REACHABLE operand and call across all arms — the
     // projection, `WHERE`, and `HAVING` of each. `compile` resolves a call's
     // arguments but cannot check the routine EXISTS or that it is called with
@@ -235,10 +243,21 @@ extension Catalog where Self: ~Escapable {
       // its body.
       overlay[cte.name.lowercased()] = declared
     }
-    let scope = augment(context.scoping(overlay), for: query, rows: false)
-    _ = try compile(query, scope)
-    if validate { try typecheck(query, scope) }
-    return try columns(of: query.first, scope, validate: validate)
+    // Compile/type-check/derive from the base `context.scoping(overlay)`
+    // (idempotently augmented within each, which pushes the trailing query's
+    // derived layer and reveals the base for a nested subquery), so a nested
+    // subquery's FROM sees the CTE overlay and base tables but NOT this query's
+    // derived aliases, and a CTE a same-named derived alias shadows stays
+    // visible beneath the revealed base. Thread `validate` into `compile` as
+    // the non-`WITH` path does: a `validate: false` derive after a successful
+    // run must NOT eager-type-check a derived body in the trailing query — a
+    // data-dependent body expression a filter drops (`FROM (SELECT Label + 1 AS
+    // x FROM K WHERE k = 0) AS d`) is TRUSTED, not rejected, matching the run.
+    // `validate: true` keeps the strict schema check.
+    let base = context.scoping(overlay)
+    _ = try compile(query, base, validate: validate)
+    if validate { try typecheck(query, base) }
+    return try columns(of: query.first, base, validate: validate)
   }
 
   /// The result columns of a single `select`, resolved against this catalog
@@ -258,14 +277,28 @@ extension Catalog where Self: ~Escapable {
                          visited: Set<String> = [],
                          validate: Bool = true)
       throws(SQLError) -> Array<OutputColumn> {
+    // Bind THIS select's own FROM/JOIN derived tables (and store relations)
+    // before deriving either the subquery map or the scope — a set-op ARM
+    // reaches here directly (`columns(of query.first, …)`), and the top-level
+    // augment collected NO arm-local aliases (arms are SELECT-scoped), so a
+    // subquery naming the arm's own derived alias (`WHERE Id IN (SELECT Id FROM
+    // d)`) would else compile against a scope missing `d`. Schema-only, no
+    // cursor; `validate` gates a derived body's own operand check.
+    let augmented = try augment(context, for: .select(select), rows: false,
+                                visited: visited, validate: validate)
     // A scalar subquery in the projection derives its type from its inner
     // query's single column, so build the SAME cursor-free `Subquery` map the
     // compile path's lowering reads — every nested subquery compiled ONCE for
     // its width and single-column type — and pass it to the projection walk so
     // an output type for a `(SELECT …)` matches the type the run advertises.
-    let subquery = try subquery(of: select, context, visited)
-    return try scope(of: select, context, visited: visited, validate: validate)
-        .columns(of: select.projection, context.routines, subquery: subquery)
+    // `subquery(of:)` REVEALS the base — this select's derived aliases are
+    // SELECT-scoped, invisible to a subquery's FROM, while a CTE a same-named
+    // derived alias shadows is resolved beneath the dropped layer.
+    let subquery = try subquery(of: select, augmented, visited,
+                                validate: validate)
+    return try scope(of: select, augmented, visited: visited,
+                     validate: validate)
+        .columns(of: select.projection, augmented.routines, subquery: subquery)
   }
 
   /// The name-resolution scope of `select` — its FROM relation and each joined
@@ -279,6 +312,16 @@ extension Catalog where Self: ~Escapable {
                        visited: Set<String> = [],
                        validate: Bool = true)
       throws(SQLError) -> Scope {
+    // Bind THIS select's own FROM/JOIN derived tables (and store relations)
+    // before resolving its relations — SELECT-scoped, so a subquery select
+    // whose schema is derived directly here (a scalar subquery's output type)
+    // resolves its OWN aliases. Schema-only: `scope` reads no cursor. `visited`
+    // carries the cyclic-view guard into a derived body's materialise, and
+    // `validate` gates that body's own reachable-operand check the same as the
+    // outer query's — a `validate: false` derive trusts a run-proven body.
+    let context =
+        try augment(context, for: .select(select), rows: false,
+                    visited: visited, validate: validate)
     guard let relation = select.from else { return Scope([]) }
     var relations =
         [(relation, try schema(of: relation, context, visited: visited,
@@ -305,6 +348,17 @@ extension Catalog where Self: ~Escapable {
   borrowing func typecheck(_ query: Query, _ context: Context,
                            visited: Set<String> = [])
       throws(SQLError) {
+    // Bind the derived tables (and store relations) THIS query names in its own
+    // FROM/JOIN before type-checking its arms — SELECT-scoped, so a subquery
+    // type-checked through here (e.g. from `subqueryCheck`) resolves its OWN
+    // aliases. Schema-only (`rows: false`): the type-check reads no cursor.
+    // `visited` carries the cyclic-view guard into a derived body's derive.
+    // A nested subquery's FROM sees base tables and enclosing CTEs, NOT this
+    // query's derived aliases — its type-check lowers against the base
+    // `subqueryCheck` REVEALS from the augmented `context` (enclosing derived
+    // aliases dropped, CTEs and store kept, a shadowed CTE preserved).
+    let context = try augment(context, for: query, rows: false,
+                              visited: visited)
     switch query {
     case let .select(select):
       try typecheck(select, context, visited: visited)
@@ -375,6 +429,12 @@ extension Catalog where Self: ~Escapable {
     // runs the cardinality probe, so its PROBED shape is checked. Both roles
     // always run (a predicate is not short-circuited past), so their operand
     // validation stays eager, driven by the original-vs-probe `shape`.
+    // A nested subquery's FROM resolves against base tables and enclosing CTEs,
+    // NOT the enclosing SELECT's derived-table aliases — STRIP them (CTEs/store
+    // kept) before type-checking/compiling each subquery, mirroring the compile
+    // path's strip in `subquery(of:)`, so the schema path faults an outer
+    // derived alias in a subquery's FROM exactly as the run does.
+    let context = context.revealed()
     let scalar = select.scalar
     let valued = select.valued
     let existential = select.existential
@@ -446,6 +506,8 @@ extension Catalog where Self: ~Escapable {
     // cursor-free arity and type (TOTAL — no `.divide` on `1 / 0`), but DEFERS
     // a scalar occurrence's inner-query OPERAND validation to the walk, which
     // records the scalar occurrences it REACHES into the `SubqueryCheck`'s box.
+    // `subqueryCheck` REVEALS the base from the augmented `context`, so a
+    // subquery's FROM sees no derived alias while a shadowed CTE is preserved.
     let subquery = try subqueryCheck(of: select, context, visited: visited)
     // Walk the query's operands reachability-aware, so an unreachable
     // `CASE`/`COALESCE` arm's scalar subquery is left unrecorded and unchecked.
@@ -454,9 +516,13 @@ extension Catalog where Self: ~Escapable {
     // where the borrowing catalog is in scope — mirroring the lazy executor,
     // which materialises only a reached scalar subquery. A reached
     // `(SELECT 1 / 0 …)` faults `.divide` here exactly as the run does; a
-    // skipped one is never reached, so never validated.
+    // skipped one is never reached, so never validated. A subquery's FROM sees
+    // base tables and enclosing CTEs, NOT the enclosing SELECT's derived-table
+    // aliases, so type-check each against the REVEALED base — the derived
+    // layers dropped, the CTEs/store (a shadowed CTE among them) kept.
+    let inner = context.revealed()
     for query in subquery.visited {
-      try typecheck(query, context, visited: visited)
+      try typecheck(query, inner, visited: visited)
     }
   }
 
@@ -723,8 +789,15 @@ extension Catalog where Self: ~Escapable {
       // operand a `SELECT * FROM v` run would evaluate — a `WHERE`/`HAVING`, a
       // later `UNION` arm — while skipping an arm a short-circuit proves
       // unreachable.
-      let overlay = augment(context.scoping([:]), for: view.query, rows: false)
+      // The view name enters `visited` BEFORE its body's derived tables
+      // materialise, so a derived table naming this view (`FROM (SELECT * FROM
+      // <self>) AS d`) re-enters with the view already visited and faults
+      // `.recursion` rather than recursing to a stack overflow — the guard
+      // rides through `augment`/`materialise` into the derived body.
       let inner = visited.union([name.lowercased()])
+      let overlay =
+          try augment(context.scoping([:]), for: view.query, rows: false,
+                      visited: inner, validate: validate)
       // Gate the body's reachable-operand check on `validate`: a `validate:
       // false` derive skips it, so a data-dependent-empty body (a text
       // arithmetic under an unmatched filter) does not fault a `SELECT *` over

--- a/Sources/SQLEngine/Parser.swift
+++ b/Sources/SQLEngine/Parser.swift
@@ -23,7 +23,8 @@
 /// select         := SELECT [DISTINCT | ALL] projection
 ///                   [FROM relation (join)*
 ///                    [where] [group] [having] [order] [limit]]
-/// relation       := identifier [AS identifier]
+/// relation       := (identifier | derived) [AS identifier]
+/// derived        := '(' query ')' AS identifier  // a derived table (aliased)
 /// join           := [INNER | (LEFT | RIGHT | FULL) [OUTER]] JOIN
 ///                     relation ON predicate
 /// projection     := '*' | column (',' column)*
@@ -408,13 +409,47 @@ internal struct Parser: ~Escapable {
 
   // MARK: - Relation
 
-  /// Parses a relation name and an optional alias.
+  /// Parses a relation — a named base relation/view/CTE, or a DERIVED TABLE (a
+  /// parenthesised subquery) — with its alias.
   ///
-  /// The alias may be introduced by `AS` (`TypeDef AS t`) or written directly
-  /// after the name (`TypeDef t`); the latter is admitted only when the next
-  /// token is a bare identifier, so a following keyword (`JOIN`, `WHERE`, …) or
-  /// the end of input is not mistaken for an alias.
+  /// A leading `(` is disambiguated by ONE token of lookahead: a `SELECT` after
+  /// it begins a derived table `(SELECT …) AS t` (the query may itself be a
+  /// `UNION`), so it parses `query`; anything else is a parenthesised relation
+  /// `(a JOIN b)`, which this dialect does not yet accept in a relation
+  /// position. The peek is unambiguous — `SELECT` never begins a relation
+  /// name — exactly as the scalar-subquery and `IN (…)` lookaheads are, so
+  /// no rewind is needed.
+  ///
+  /// Derived table's alias is REQUIRED (ISO): `FROM (SELECT …)` with no `AS t`
+  /// faults. A named relation's alias is optional and may be introduced by `AS`
+  /// (`TypeDef AS t`) or written directly after the name (`TypeDef t`); the
+  /// latter is admitted only when the next token is a bare identifier, so a
+  /// following keyword (`JOIN`, `WHERE`, …) or the end of input is not mistaken
+  /// for an alias.
   private mutating func relation() throws(SQLError) -> Relation {
+    if try match(.lparen) {
+      guard let token = current else {
+        throw .incomplete(expected: "a derived table '(SELECT …)'")
+      }
+      guard token.kind == .select else {
+        throw .unexpected(token.kind.description,
+                          expected: "a derived table '(SELECT …)'",
+                          at: token.location)
+      }
+      let query = try query()
+      try expect(.rparen)
+      // ISO requires a derived table be named, so the alias is MANDATORY — an
+      // `AS`-less spelling faults rather than binding an unnamed relation.
+      guard try match(.as) || isName(current?.kind) else {
+        guard let token = current else {
+          throw .incomplete(expected: "'AS' and an alias for the derived table")
+        }
+        throw .unexpected(token.kind.description,
+                          expected: "'AS' and an alias for the derived table",
+                          at: token.location)
+      }
+      return try Relation(derived: query, as: identifier())
+    }
     let name = try identifier()
     let alias: String? = if try match(.as) {
       try identifier()

--- a/Sources/SQLEngine/Resolve.swift
+++ b/Sources/SQLEngine/Resolve.swift
@@ -344,10 +344,38 @@ internal struct Subqueries {
   /// evaluate tree shares the one box, keeping a scalar materialise-once.
   private let scalars: ScalarMemo
 
+  /// The REVEALED base scope the eager occurrences of this cache ran against,
+  /// keyed PER `Subscope` — the enclosing scope with this SELECT's derived
+  /// aliases revealed away and its CTEs/store relations intact
+  /// (`Context.revealed`), stored under the `Subscope` those occurrences
+  /// materialised in. A LAZY scalar occurrence resolves its inner query against
+  /// the scope of its OWN `Subkey`, not the augmented overlay threaded down the
+  /// evaluate tree: the executor threads only the EXECUTING plan's overlay, so
+  /// after a `merged` folds a view-body cache into the caller's it cannot tell
+  /// a view-body occurrence's scope from the caller's. Keying PER `Subscope`
+  /// keeps a `.view(name)` scalar reading the VIEW's own relations and a
+  /// `.caller` scalar the caller's — one shared scope resolved a view-body
+  /// scalar against the caller's overlay (the round-15 fault). Empty for a
+  /// scope the cache carries no eager occurrence of (a bare `Subqueries()` a
+  /// schema path threads), so the lazy scalar falls back to the threaded
+  /// overlay — whose derived layer a `cell(of:)` reveal drops to expose a CTE a
+  /// same-named derived alias shadows.
+  private let scopes: Dictionary<Subscope, ScopedRelations>
+
   internal init(_ results: Dictionary<Subkey, MaterialisedSubquery> = [:],
-                _ scalars: ScalarMemo = ScalarMemo()) {
+                _ scalars: ScalarMemo = ScalarMemo(),
+                _ scopes: Dictionary<Subscope, ScopedRelations> = [:]) {
     self.results = results
     self.scalars = scalars
+    self.scopes = scopes
+  }
+
+  /// The revealed base relations the occurrences of `scope` ran against, or an
+  /// empty map when the cache carries none — the scope a LAZY scalar of that
+  /// `Subscope` resolves its inner query against, falling back to the threaded
+  /// overlay when empty (a schema path's bare cache).
+  internal func relations(_ scope: Subscope) -> ScopedRelations {
+    scopes[scope] ?? [:]
   }
 
   /// The materialised result for `key` — every occurrence a runnable plan
@@ -398,11 +426,19 @@ internal struct Subqueries {
   /// filter reads its `.caller` result while the view-body filter reads its
   /// `.view` one. A collision would be an id-space bug (two contexts sharing a
   /// scope); it cannot happen, so the merge keeps the existing entry. The
-  /// merged cache keeps `self`'s scalar memo — a caller cache and a view-body
-  /// cache resolve DISJOINT scalar keys, so one shared memo serves both spaces.
+  /// merged cache keeps `self`'s scalar memo and UNIONS the per-`Subscope`
+  /// base scopes of both — a caller cache and a view-body cache resolve
+  /// DISJOINT scalar keys, so one shared memo serves both spaces, and each
+  /// `Subscope` keeps its OWN base relations (the `.caller` map and the
+  /// `.view(name)` map ride through side by side), so a view-body lazy scalar
+  /// resolves against the VIEW's relations and a caller scalar the caller's —
+  /// keeping only `self`'s left-hand scope would resolve a view-body scalar
+  /// against the caller overlay. Two contexts sharing a `Subscope` would be an
+  /// id-space bug, so a scope collision keeps `self`'s.
   internal func merged(_ other: Subqueries) -> Subqueries {
     Subqueries(results.merging(other.results) { existing, _ in existing },
-               scalars)
+               scalars,
+               scopes.merging(other.scopes) { existing, _ in existing })
   }
 }
 

--- a/Tests/SQLTests/DerivedTableTests.swift
+++ b/Tests/SQLTests/DerivedTableTests.swift
@@ -1,0 +1,2118 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQLEngine
+
+import SQLTestSupport
+
+// MARK: - Fixture
+
+/// Two relations exercising the uncorrelated DERIVED TABLE: an outer keyed `T`
+/// and a source `S` whose `V` a derived table projects/aggregates, plus a `K`
+/// keyed on `T` for the JOIN case.
+private func fixture() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["Id": .integer, "V": .integer]) {
+      Row(1, 10)
+      Row(2, 20)
+      Row(3, 30)
+    }
+    Relation("S", ["V": .integer]) {
+      Row(10)
+      Row(20)
+      Row(30)
+    }
+    // A relation joined to a derived table over `T` on a shared key.
+    Relation("K", ["k": .integer, "Label": .text]) {
+      Row(1, "a")
+      Row(2, "b")
+    }
+  }
+}
+
+/// Parses `text` and returns its `Select`, failing on any other shape.
+private func parse(select text: String) throws -> Select {
+  guard case let .select(.select(select)) = try Statement(parsing: text) else {
+    Issue.record("expected a single SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return select
+}
+
+/// Parses `text` to a query, failing on any other statement.
+private func parse(query text: String) throws -> Query {
+  guard case let .select(query) = try Statement(parsing: text) else {
+    Issue.record("expected a SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return query
+}
+
+// MARK: - Parsing
+
+struct DerivedTableParsingTests {
+  @Test func `parses a derived table in FROM with an alias`() throws {
+    let select = try parse(select: "SELECT t.a FROM (SELECT V AS a FROM S) AS t")
+    let inner = try parse(query: "SELECT V AS a FROM S")
+    #expect(select.from == Relation(derived: inner, as: "t"))
+  }
+
+  @Test func `parses a derived table alias without AS`() throws {
+    // The `AS` is optional the same as a named relation's, so a bare alias
+    // after the closing paren names the derived table.
+    let select = try parse(select: "SELECT t.a FROM (SELECT V AS a FROM S) t")
+    let inner = try parse(query: "SELECT V AS a FROM S")
+    #expect(select.from == Relation(derived: inner, as: "t"))
+  }
+
+  @Test func `parses a derived table in a JOIN`() throws {
+    let select = try parse(select:
+        "SELECT T.Id FROM T JOIN (SELECT Id AS k FROM T) AS d ON T.Id = d.k")
+    let inner = try parse(query: "SELECT Id AS k FROM T")
+    #expect(select.from == Relation(name: "T"))
+    #expect(select.joins.count == 1)
+    #expect(select.joins[0].relation == Relation(derived: inner, as: "d"))
+  }
+
+  @Test func `parses a derived table over a UNION`() throws {
+    // A derived table is a full `query`, so it may itself be a `UNION`.
+    let select = try parse(select:
+        "SELECT t.V FROM (SELECT V FROM S UNION SELECT V FROM T) AS t")
+    let inner = try parse(query: "SELECT V FROM S UNION SELECT V FROM T")
+    #expect(select.from == Relation(derived: inner, as: "t"))
+  }
+
+  @Test func `a parenthesised relation without SELECT is not a derived table`()
+      throws {
+    // The one-token lookahead only takes the derived-table arm on a leading
+    // `SELECT`; anything else in a relation position faults (no parenthesised
+    // relation `(a JOIN b)` in this dialect yet).
+    #expect(throws: SQLError.self) {
+      _ = try parse(select: "SELECT a FROM (T)")
+    }
+  }
+
+  @Test func `a derived table round-trips by AST equality`() throws {
+    // Two parses of the same derived-table query yield equal ASTs — the nested
+    // `Query` in `Relation.Source.derived` composes the synthesized
+    // `Hashable`/`Equatable`.
+    let text = "SELECT t.a FROM (SELECT V AS a FROM S) AS t"
+    #expect(try parse(query: text) == parse(query: text))
+  }
+}
+
+// MARK: - Mandatory alias
+
+struct DerivedTableAliasTests {
+  @Test func `a derived table with no alias faults`() throws {
+    // ISO requires a derived table be named — `FROM (SELECT …)` with no alias
+    // faults at parse.
+    #expect(throws: SQLError.self) {
+      _ = try parse(select: "SELECT a FROM (SELECT V AS a FROM S)")
+    }
+  }
+
+  @Test func `a derived table with a trailing keyword and no alias faults`()
+      throws {
+    // A following clause keyword (`WHERE`) is not an alias, so the missing
+    // alias still faults rather than binding the keyword.
+    #expect(throws: SQLError.self) {
+      _ = try parse(select:
+          "SELECT a FROM (SELECT V AS a FROM S) WHERE a > 0")
+    }
+  }
+}
+
+// MARK: - Execution
+
+struct DerivedTableExecutionTests {
+  @Test func `a derived table projects its inner column via the alias`()
+      throws {
+    // `FROM (SELECT V AS a FROM S) AS t` exposes one column `a` under `t`;
+    // `t.a` reads it — the inner `V` renamed by the inner projection.
+    try fixture().expect(
+        "SELECT t.a FROM (SELECT V AS a FROM S) AS t ORDER BY t.a",
+        yields: [[10], [20], [30]])
+  }
+
+  @Test func `a derived table resolves an unqualified inner column`() throws {
+    // The derived column resolves both qualified (`t.a`) and unqualified (`a`),
+    // exactly as a base-table alias's columns do.
+    try fixture().expect(
+        "SELECT a FROM (SELECT V AS a FROM S) AS t ORDER BY a",
+        yields: [[10], [20], [30]])
+  }
+
+  @Test func `a derived table equals its inner query renamed`() throws {
+    // The derived table's rows ARE the inner query's rows, so selecting through
+    // the alias equals selecting the inner query directly.
+    try fixture().expect(
+        "SELECT a FROM (SELECT V AS a FROM S) AS t ORDER BY a",
+        equals: "SELECT V AS a FROM S ORDER BY a")
+  }
+
+  @Test func `a derived table filters on the alias`() throws {
+    // A `WHERE` over the derived column filters the materialised rows.
+    try fixture().expect(
+        "SELECT a FROM (SELECT V AS a FROM S) AS t WHERE a > 10 ORDER BY a",
+        yields: [[20], [30]])
+  }
+
+  @Test func `a derived table joins on its alias`() throws {
+    // `FROM T JOIN (SELECT Id AS k FROM T) AS d ON T.Id = d.k` — uncorrelated
+    // derived table joined on a shared key; each `T` row matches its own `d`
+    // row (Id 1, 2, 3), so the join yields three pairs.
+    try fixture().expect(
+        "SELECT T.Id, d.k FROM T " +
+        "JOIN (SELECT Id AS k FROM T) AS d ON T.Id = d.k ORDER BY T.Id",
+        yields: [[1, 1], [2, 2], [3, 3]])
+  }
+
+  @Test func `a derived table joins a base relation on the alias key`() throws {
+    // Join `K` to a derived table over `T`: only the `T` rows whose `Id`
+    // matches a `K.k` (1 and 2) pair, so the result is the two labelled rows.
+    try fixture().expect(
+        "SELECT d.Id, K.Label FROM K " +
+        "JOIN (SELECT Id, V FROM T) AS d ON K.k = d.Id ORDER BY d.Id",
+        yields: [[1, "a"], [2, "b"]])
+  }
+
+  @Test func `a derived table over an aggregate projects the aggregate`()
+      throws {
+    // `FROM (SELECT MAX(V) AS m FROM S) AS t` — a derived table over a
+    // whole-result aggregate has one row, one column `m`, the maximum 30.
+    try fixture().expect(
+        "SELECT m FROM (SELECT MAX(V) AS m FROM S) AS t", yields: [[30]])
+  }
+
+  @Test func `a derived table over a GROUP BY projects each group`() throws {
+    // `FROM (SELECT V AS g, COUNT(*) AS n FROM S GROUP BY V) AS t` — one row
+    // per distinct `V`, each with count 1.
+    try fixture().expect(
+        "SELECT g, n FROM " +
+        "(SELECT V AS g, COUNT(*) AS n FROM S GROUP BY V) AS t ORDER BY g",
+        yields: [[10, 1], [20, 1], [30, 1]])
+  }
+
+  @Test func `a derived table over a UNION runs`() throws {
+    // The inner query may be a `UNION`; its distinct rows are the derived
+    // table's rows.
+    try fixture().expect(
+        "SELECT v FROM " +
+        "(SELECT V AS v FROM S UNION SELECT V AS v FROM T) AS t ORDER BY v",
+        yields: [[10], [20], [30]])
+  }
+}
+
+// MARK: - Schema
+
+struct DerivedTableSchemaTests {
+  @Test func `columns reports the derived table's columns`() throws {
+    // `columns(of:)` reports the derived table's projected columns — the inner
+    // query's output name and type under the alias — matching the run.
+    let query =
+        try parse(query: "SELECT t.a FROM (SELECT V AS a FROM S) AS t")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+    #expect(columns[0].name == "a")
+    #expect(columns[0].type == .integer)
+  }
+
+  @Test func `columns reports a starred derived table's columns`() throws {
+    // A `SELECT *` over a derived table spans its inner query's output columns.
+    let query =
+        try parse(query: "SELECT * FROM (SELECT Id, V FROM T) AS t")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.map(\.name) == ["Id", "V"])
+  }
+
+  @Test func `a derived table over a bad inner column faults`() throws {
+    // The inner query is validated exactly as a run validates it: an unknown
+    // inner column faults, so the schema is not advertised for a query that
+    // cannot run.
+    #expect(throws: SQLError.self) {
+      let query =
+          try parse(query: "SELECT t.a FROM (SELECT Missing AS a FROM S) AS t")
+      _ = try fixture().columns(of: query, validate: true)
+    }
+  }
+
+  @Test func `a bad inner column faults the run too`() throws {
+    // Typecheck ↔ run parity: the same bad inner column faults the run.
+    try fixture().expect(
+        "SELECT t.a FROM (SELECT Missing AS a FROM S) AS t",
+        fails: .column("Missing"))
+  }
+}
+
+// MARK: - Duplicate derived output columns
+
+/// A derived table's columns are its inner query's OUTPUT names (the ISO rule),
+/// so two same-named ones leave the shadowed column unreachable through the
+/// alias — the same case the Parser rejects for a view's or a CTE's inferred
+/// column list. A derived table faults it the SAME way (`SQLError.duplicate`),
+/// at BOTH `columns(of:)` and a run.
+struct DerivedTableDuplicateColumnTests {
+  @Test func `a duplicate derived output column faults the run`() throws {
+    // `(SELECT Id AS x, V AS x FROM T) AS d` exposes `x` twice; `d.x` would
+    // silently read the first. Reject it as a duplicate, exactly as a CTE over
+    // the same body faults `SQLError.duplicate`.
+    try fixture().expect(
+        "SELECT d.x FROM (SELECT Id AS x, V AS x FROM T) AS d",
+        fails: .duplicate("x"))
+  }
+
+  @Test func `a duplicate derived output column faults the schema path`()
+      throws {
+    // Schema ↔ run parity: the same duplicate faults `columns(of:)`, so the
+    // schema is not advertised for a query the run rejects — the `SQLError`
+    // case a view/CTE raises.
+    #expect(throws: SQLError.duplicate("x")) {
+      let query = try parse(query:
+          "SELECT d.x FROM (SELECT Id AS x, V AS x FROM T) AS d")
+      _ = try fixture().columns(of: query, validate: true)
+    }
+  }
+
+  @Test func `distinct derived output columns resolve`() throws {
+    // Control: two DIFFERENTLY named output columns resolve fine — the check
+    // fires only on a genuine same-name collision.
+    try fixture().expect(
+        "SELECT d.x, d.y FROM (SELECT Id AS x, V AS y FROM T) AS d " +
+        "ORDER BY d.x",
+        yields: [[1, 10], [2, 20], [3, 30]])
+  }
+}
+
+// MARK: - Duplicate same-scope derived aliases
+
+/// Two derived tables sharing an alias in ONE SELECT's own FROM/JOIN collide:
+/// the alias-keyed overlay would rebind the earlier under the later, so both
+/// FROM items resolve to the later's rows. This matches the existing duplicate
+/// RELATION alias behavior (`FROM T AS d JOIN S AS d`, which makes a shared
+/// column `SQLError.ambiguous`) rather than silently rebinding — the collision
+/// is caught when augmenting THIS SELECT's own derived tables, so a nested or
+/// sibling subquery's same-named alias (a DIFFERENT SELECT) is unaffected.
+struct DerivedTableDuplicateAliasTests {
+  @Test func `duplicate derived aliases fault ambiguous at the run`() throws {
+    // `(SELECT Id AS a FROM T) AS d JOIN (SELECT V AS b FROM S) AS d` — a
+    // single SELECT with two derived tables aliased `d`. Faults the ALIAS
+    // ambiguous rather than letting the later derived `d(b)` rebind over the
+    // earlier `d(a)`.
+    try fixture().expect(
+        "SELECT d.b FROM (SELECT Id AS a FROM T) AS d " +
+        "JOIN (SELECT V AS b FROM S) AS d ON 1 = 1",
+        fails: .ambiguous("d"))
+  }
+
+  @Test func `duplicate derived aliases fault ambiguous at the schema path`()
+      throws {
+    // Schema ↔ run parity: the same collision faults `columns(of:)`.
+    #expect(throws: SQLError.ambiguous("d")) {
+      let query = try parse(query:
+          "SELECT d.b FROM (SELECT Id AS a FROM T) AS d " +
+          "JOIN (SELECT V AS b FROM S) AS d ON 1 = 1")
+      _ = try fixture().columns(of: query, validate: true)
+    }
+  }
+
+  @Test func `a duplicate base-table alias's shared column stays ambiguous`()
+      throws {
+    // The behavior the derived case matches: two base relations sharing the
+    // alias `d` leave BOTH in scope, so a shared column is `SQLError.ambiguous`
+    // — the same ambiguity family the derived collision now raises.
+    try fixture().expect(
+        "SELECT d.Id FROM T AS d JOIN S AS d ON 1 = 1",
+        fails: .ambiguous("Id"))
+  }
+
+  @Test func `distinct derived aliases in one SELECT both resolve`() throws {
+    // Control: two derived tables with DIFFERENT aliases in one SELECT's
+    // FROM/JOIN each resolve to their OWN columns — no collision.
+    try fixture().expect(
+        "SELECT c.a, d.b FROM (SELECT Id AS a FROM T) AS c " +
+        "JOIN (SELECT V AS b FROM S) AS d ON c.a = 1 ORDER BY d.b",
+        yields: [[1, 10], [1, 20], [1, 30]])
+  }
+}
+
+// MARK: - A derived alias colliding with a same-scope base relation
+
+/// A derived table's alias sharing a RANGE NAME with a BASE/named relation in
+/// the SAME SELECT's FROM/JOIN is a duplicate range name: the alias-keyed
+/// overlay binds the derived rows under that name, which would SHADOW the base
+/// scan — `FROM T JOIN (SELECT V AS a FROM S) AS T` would resolve the base `T`
+/// to the derived rows. This is the same ambiguity family a duplicate RELATION
+/// alias (`FROM T AS d JOIN S AS d`) raises, and it faults at BOTH `columns(of:
+/// )` and a run, BEFORE binding the derived rows, so the base is never
+/// shadowed.
+struct DerivedTableBaseAliasCollisionTests {
+  @Test func `a derived alias colliding with a base relation faults the run`()
+      throws {
+    // The reviewer's case: a derived table aliased `T` in a JOIN collides with
+    // the base `FROM T` of the same SELECT. Faults the ALIAS ambiguous rather
+    // than binding the derived `T(a)` over the base `T` scan.
+    try fixture().expect(
+        "SELECT a FROM T JOIN (SELECT V AS a FROM S) AS T ON 1 = 1",
+        fails: .ambiguous("T"))
+  }
+
+  @Test func `a derived alias colliding with a base faults the schema path`()
+      throws {
+    // Schema ↔ run parity: the same collision faults `columns(of:)`, so the
+    // schema is not advertised for a query the run rejects.
+    #expect(throws: SQLError.ambiguous("T")) {
+      let query = try parse(query:
+          "SELECT a FROM T JOIN (SELECT V AS a FROM S) AS T ON 1 = 1")
+      _ = try fixture().columns(of: query, validate: true)
+    }
+  }
+
+  @Test func `a base relation colliding with a leading derived alias faults`()
+      throws {
+    // Reverse order — the derived table is the `FROM` item and the base `T` is
+    // the JOIN — collides just the same, so a range name's collision does not
+    // depend on which side spells the derived alias.
+    try fixture().expect(
+        "SELECT a FROM (SELECT V AS a FROM S) AS T JOIN T ON 1 = 1",
+        fails: .ambiguous("T"))
+  }
+
+  @Test func `a base and leading derived collision faults the schema path`()
+      throws {
+    // Schema ↔ run parity for the reverse order.
+    #expect(throws: SQLError.ambiguous("T")) {
+      let query = try parse(query:
+          "SELECT a FROM (SELECT V AS a FROM S) AS T JOIN T ON 1 = 1")
+      _ = try fixture().columns(of: query, validate: true)
+    }
+  }
+
+  @Test func `a derived alias colliding with a named alias faults`() throws {
+    // The collision is on the RANGE NAME a qualified reference uses, so a base
+    // relation renamed `d` (`FROM S AS d`) collides with a derived table
+    // aliased `d` too — not the base's spelling `S`.
+    try fixture().expect(
+        "SELECT a FROM S AS d JOIN (SELECT V AS a FROM S) AS d ON 1 = 1",
+        fails: .ambiguous("d"))
+  }
+
+  @Test func `a derived alias not colliding with any base resolves`() throws {
+    // Control: a derived alias `d` that no FROM/JOIN range name shares resolves
+    // — both its OWN column (`d.a`) and the sibling base relation's (`T.V`).
+    try fixture().expect(
+        "SELECT d.a, T.V FROM T JOIN (SELECT V AS a FROM S) AS d " +
+        "ON d.a = T.V ORDER BY T.V",
+        yields: [[10, 10], [20, 20], [30, 30]])
+  }
+
+  @Test func `a derived alias equal to an outer relation is not a collision`()
+      throws {
+    // Scoping, not a same-scope collision: an EXISTS subquery's derived table
+    // aliased `T` sits in its OWN SELECT, whose only FROM range is that derived
+    // `T` — the enclosing `FROM T` is a DIFFERENT SELECT's range. The inner `T`
+    // shadows the outer per normal scoping, so `t.a` reads the derived rows and
+    // no duplicate-range fault fires.
+    try fixture().expect(
+        "SELECT Id FROM T " +
+        "WHERE EXISTS (SELECT 1 FROM (SELECT V AS a FROM S) AS T " +
+                      "WHERE T.a = 10) ORDER BY Id",
+        yields: [[1], [2], [3]])
+  }
+
+  @Test func `a derived alias colliding with an aliased base's source faults`()
+      throws {
+    // The base `T` is ALIASED `x`, so its EXPOSED range name is `x`, not `T` —
+    // yet `resolve` looks the named relation up by its SOURCE name `T` in the
+    // overlay. A derived table aliased `T` would bind under `T` and capture the
+    // `T AS x` scan (which keys on `T`), so `x.V` fails or both sides scan the
+    // derived rows. Fault the ALIAS ambiguous on the source-name collision,
+    // BEFORE binding the derived rows.
+    try fixture().expect(
+        "SELECT x.V FROM T AS x JOIN (SELECT V AS a FROM S) AS T ON 1 = 1",
+        fails: .ambiguous("T"))
+  }
+
+  @Test func `an aliased base's source collision faults the schema path`()
+      throws {
+    // Schema ↔ run parity: the source-name collision faults `columns(of:)` too.
+    #expect(throws: SQLError.ambiguous("T")) {
+      let query = try parse(query:
+          "SELECT x.V FROM T AS x JOIN (SELECT V AS a FROM S) AS T ON 1 = 1")
+      _ = try fixture().columns(of: query, validate: true)
+    }
+  }
+
+  @Test func `a leading derived alias colliding with an aliased base source`()
+      throws {
+    // Reverse order — the derived `T` is the `FROM` item, the aliased base `T
+    // AS x` the JOIN — collides on the source `T` just the same.
+    try fixture().expect(
+        "SELECT x.V FROM (SELECT V AS a FROM S) AS T JOIN T AS x ON 1 = 1",
+        fails: .ambiguous("T"))
+  }
+
+  @Test func `the reverse aliased-base source collision faults the schema`()
+      throws {
+    // Schema ↔ run parity for the reverse order.
+    #expect(throws: SQLError.ambiguous("T")) {
+      let query = try parse(query:
+          "SELECT x.V FROM (SELECT V AS a FROM S) AS T JOIN T AS x ON 1 = 1")
+      _ = try fixture().columns(of: query, validate: true)
+    }
+  }
+
+  @Test func `a derived alias not sharing an aliased base's source resolves`()
+      throws {
+    // Control: the base `T AS x`'s source `T` and its range `x` neither equal
+    // the derived alias `d`, so `x.V` and `d`'s column both resolve — no
+    // source-name collision fires for a derived alias no relation sources.
+    try fixture().expect(
+        "SELECT x.V, d.a FROM T AS x JOIN (SELECT V AS a FROM S) AS d " +
+        "ON d.a = x.V ORDER BY x.V",
+        yields: [[10, 10], [20, 20], [30, 30]])
+  }
+}
+
+// MARK: - SELECT-scoped aliases
+
+struct DerivedTableScopingTests {
+  @Test func `sibling EXISTS subqueries reuse an alias without colliding`()
+      throws {
+    // Two INDEPENDENT derived tables share the alias `t` in two separate
+    // `EXISTS` subqueries, each with DIFFERENT columns (`a` from `S`, `b` from
+    // `K`). A statement-global overlay bound only the FIRST `t`, so the second
+    // `EXISTS`'s `t.b` would mis-resolve to the first `t` (no `b`) and fault.
+    // SELECT-scoped, each `t` resolves to its OWN derived table: both
+    // subqueries are TRUE (S has V=10, K has k=1), so every `T` row is kept.
+    try fixture().expect(
+        "SELECT Id FROM T " +
+        "WHERE EXISTS (SELECT 1 FROM (SELECT V AS a FROM S) AS t " +
+                      "WHERE t.a = 10) " +
+        "AND EXISTS (SELECT 1 FROM (SELECT k AS b FROM K) AS t " +
+                    "WHERE t.b = 1) ORDER BY Id",
+        yields: [[1], [2], [3]])
+  }
+
+  @Test func `sibling derived tables reuse an alias reading their own rows`()
+      throws {
+    // Each sibling `t` reads its OWN rows: the first `EXISTS` filters `t.a` to
+    // a value only `S` has (30) and the second `t.b` to one only `K` has (2),
+    // so both hold and the outer query keeps its row — proof each `t` bound its
+    // own materialised relation, not a shared one.
+    try fixture().expect(
+        "SELECT Id FROM T WHERE Id = 1 " +
+        "AND EXISTS (SELECT 1 FROM (SELECT V AS a FROM S) AS t " +
+                    "WHERE t.a = 30) " +
+        "AND EXISTS (SELECT 1 FROM (SELECT k AS b FROM K) AS t " +
+                    "WHERE t.b = 2)",
+        yields: [[1]])
+  }
+
+  @Test func `an inner derived table shadows an outer CTE of the same name`()
+      throws {
+    // A CTE `t` is in scope statement-wide, but a derived table aliased `t` in
+    // an inner `FROM` SHADOWS it within that SELECT: the derived `t(a)` reads
+    // `S`'s `V` renamed, not the CTE's single row `99`. So `SELECT a` yields
+    // the three `S` values, never the CTE's `99` (no column `a`). A `WITH` is
+    // a statement, so run it through the statement entry rather than the
+    // query-only `expect`.
+    let statement = try Statement(parsing:
+        "WITH t(x) AS (SELECT 99) " +
+        "SELECT a FROM (SELECT V AS a FROM S) AS t ORDER BY a")
+    let rows = try fixture().run(statement, .standard)
+    #expect(rows == [[.integer(10)], [.integer(20)], [.integer(30)]])
+  }
+}
+
+// MARK: - A nested subquery's own derived alias shadows an enclosing one
+
+/// A nested subquery's OWN derived alias must SHADOW an enclosing same-named
+/// derived table, resolving its OWN body's columns rather than the outer one's.
+/// Idempotence keys on the derivation's IDENTITY, not its name: an enclosing
+/// query's derived `t` in scope is re-materialised over by the subquery's own
+/// `t` (a DIFFERENT inner query), while a re-augment of THIS query's SAME
+/// derivation is left in place — and a same-named CTE stays visible.
+struct DerivedTableNestedShadowTests {
+  @Test func `a nested EXISTS subquery derived alias shadows an outer one`()
+      throws {
+    // The outer `FROM (SELECT Id AS x FROM T) AS t` binds a derived `t` with
+    // column `x`; the `EXISTS` subquery's OWN `FROM (SELECT V AS a FROM S) AS
+    // t` binds a derived `t` with column `a`. The subquery's `WHERE t.a = 10`
+    // must resolve the INNER `t` (column `a`, a value only `S`'s 10 has), never
+    // the outer `t` (column `x`). Keying idempotence on the name skipped the
+    // inner materialise, so `t.a` mis-resolved to the outer `t`; keying on the
+    // derivation's identity re-materialises the inner `t`, so the subquery is
+    // TRUE and every outer row is kept.
+    try fixture().expect(
+        "SELECT x FROM (SELECT Id AS x FROM T) AS t " +
+        "WHERE EXISTS (SELECT 1 FROM (SELECT V AS a FROM S) AS t " +
+                      "WHERE t.a = 10) ORDER BY x",
+        yields: [[1], [2], [3]])
+  }
+
+  @Test func `the nested-shadow query advertises the outer schema`() throws {
+    // Schema ↔ run parity: `columns(of:)` resolves the inner `t.a` too (never
+    // faulting on the outer `t`'s missing `a`), and the RESULT columns are the
+    // OUTER query's projection `x` — the enclosing derived `t`'s column.
+    let query = try parse(query:
+        "SELECT x FROM (SELECT Id AS x FROM T) AS t " +
+        "WHERE EXISTS (SELECT 1 FROM (SELECT V AS a FROM S) AS t " +
+                      "WHERE t.a = 10)")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.map(\.name) == ["x"])
+  }
+
+  @Test func `a nested EXISTS shadow reads the inner rows`() throws {
+    // The inner `t` reads ITS own rows, not the outer's: `WHERE t.a = 30`
+    // filters to a value only `S` has (30), so the subquery holds; had it
+    // resolved the outer `t` (column `x` = the `Id`s 1, 2, 3), `t.a` would
+    // fault. One outer row is kept.
+    try fixture().expect(
+        "SELECT x FROM (SELECT Id AS x FROM T) AS t WHERE x = 1 " +
+        "AND EXISTS (SELECT 1 FROM (SELECT V AS a FROM S) AS t " +
+                    "WHERE t.a = 30)",
+        yields: [[1]])
+  }
+
+  @Test func `a nested scalar subquery derived alias shadows an outer one`()
+      throws {
+    // A SCALAR-subquery variant: the outer `FROM (SELECT Id AS x FROM T) AS t`
+    // binds derived `t(x)`; the projection's scalar `(SELECT MIN(t.a) FROM
+    // (SELECT V AS a FROM S) AS t)` binds its OWN derived `t(a)`. The scalar's
+    // `t.a` must resolve the INNER `t` (column `a`), yielding `S`'s minimum 10
+    // for every outer row — proof the inner alias shadowed the outer.
+    try fixture().expect(
+        "SELECT x, (SELECT MIN(t.a) FROM (SELECT V AS a FROM S) AS t) " +
+        "FROM (SELECT Id AS x FROM T) AS t ORDER BY x",
+        yields: [[1, 10], [2, 10], [3, 10]])
+  }
+}
+
+// MARK: - Nested derived tables
+
+struct DerivedTableNestingTests {
+  @Test func `a derived table nested in a derived table resolves and runs`()
+      throws {
+    // `FROM (SELECT * FROM (SELECT V FROM S) AS x) AS y` — deriving `y`'s
+    // schema must FIRST bind its OWN inner derived table `x`, as the run does,
+    // or `x` resolves as unknown. Both the schema and the run resolve the
+    // projected column `V` and read `S`'s rows through the two levels.
+    let query =
+        try parse(query: "SELECT * FROM (SELECT * FROM (SELECT V FROM S) " +
+                         "AS x) AS y")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.map(\.name) == ["V"])
+    try fixture().expect(
+        "SELECT V FROM (SELECT * FROM (SELECT V FROM S) AS x) AS y " +
+        "ORDER BY V",
+        yields: [[10], [20], [30]])
+  }
+
+  @Test func `a nested derived table filters through both levels`() throws {
+    // The nested derived table's rows flow up unchanged: a `WHERE` on the
+    // outer derived column filters the same rows the inner projected.
+    try fixture().expect(
+        "SELECT V FROM (SELECT V FROM (SELECT V FROM S) AS x) AS y " +
+        "WHERE V > 10 ORDER BY V",
+        yields: [[20], [30]])
+  }
+}
+
+// MARK: - Schema/run validation parity
+
+struct DerivedTableSchemaParityTests {
+  @Test func `a bad inner predicate faults the schema-only path`() throws {
+    // The inner body's `WHERE Missing = 1` names an unknown column. The
+    // schema-only path (`validate: true`) compiles and type-checks the WHOLE
+    // inner body — not just the first-arm projection — so it FAULTS the unknown
+    // column exactly as the run does, keeping schema/run parity.
+    #expect(throws: SQLError.self) {
+      let query = try parse(query:
+          "SELECT t.a FROM (SELECT V AS a FROM S WHERE Missing = 1) AS t")
+      _ = try fixture().columns(of: query, validate: true)
+    }
+  }
+
+  @Test func `a bad inner predicate faults the run too`() throws {
+    // Typecheck ↔ run parity: the same bad inner predicate column faults the
+    // run.
+    try fixture().expect(
+        "SELECT t.a FROM (SELECT V AS a FROM S WHERE Missing = 1) AS t",
+        fails: .column("Missing"))
+  }
+
+  @Test func `a bad inner column outside the first arm faults the schema path`()
+      throws {
+    // The inner body's bad column is in a later `UNION` arm, which the
+    // first-arm projection derive never sees; the whole-body compile the
+    // schema-only path now runs catches it, matching the run.
+    #expect(throws: SQLError.self) {
+      let query = try parse(query:
+          "SELECT t.a FROM (SELECT V AS a FROM S " +
+          "UNION SELECT Missing AS a FROM S) AS t")
+      _ = try fixture().columns(of: query, validate: true)
+    }
+  }
+
+  @Test func `a valid inner body still advertises its schema`() throws {
+    // A derived table whose inner body has a WELL-FORMED predicate still
+    // reports its schema on the schema-only path — the whole-body validation
+    // accepts exactly what runs, so a valid body is not rejected.
+    let query = try parse(query:
+        "SELECT t.a FROM (SELECT V AS a FROM S WHERE V > 10) AS t")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+    #expect(columns[0].name == "a")
+    #expect(columns[0].type == .integer)
+  }
+
+  @Test func `validate false skips a derived body's operand check`() throws {
+    // A derived body whose projection `Label + 1` faults ONLY when type-checked
+    // (text plus integer), guarded by `WHERE k = 0` so the run empties before
+    // it evaluates. With `validate: false` — a derive after a successful run —
+    // the body is TRUSTED, so headers return WITHOUT the operand fault, exactly
+    // as the NON-derived path does (its empty run never evaluates the
+    // projection). An earlier round validated the body unconditionally, so this
+    // faulted `.operand` before returning headers.
+    let query = try parse(query:
+        "SELECT * FROM (SELECT Label + 1 AS x FROM K WHERE k = 0) AS d")
+    let columns = try fixture().columns(of: query, validate: false)
+    #expect(columns.map(\.name) == ["x"])
+  }
+
+  @Test func `validate true still faults a bad derived body`() throws {
+    // Parity with a run: with `validate: true` the SAME body still faults its
+    // ill-typed projection, so the schema path advertises no schema for a
+    // derived table a run would fault once it reached the projection.
+    #expect(throws: SQLError.self) {
+      let query = try parse(query:
+          "SELECT * FROM (SELECT Label + 1 AS x FROM K WHERE k = 0) AS d")
+      _ = try fixture().columns(of: query, validate: true)
+    }
+  }
+}
+
+// MARK: - A run must not eager-type-check a derived body
+
+/// A RUN preflight (`compile`) must NOT eager-type-check a derived body: an
+/// expression a data-dependent filter never reaches is lenient at run — the
+/// executor faults only on an expression a SURVIVING row evaluates, exactly as
+/// the NON-derived query does. The eager body type-check stays for the EXPLICIT
+/// schema path (`columns(of:validate:true)`), which stays strict.
+struct DerivedTableRunLenienceTests {
+  @Test func `a filtered-out ill-typed body runs to zero rows`() throws {
+    // `FROM (SELECT Label + 1 AS x FROM K WHERE k = 0) AS d` — the body's text
+    // arithmetic `Label + 1` faults ONLY when evaluated, but `WHERE k = 0` (no
+    // `K` row has `k = 0`) empties the derived table before the projection
+    // runs. The run preflight compiles the OUTER query WITHOUT eager-type-
+    // checking the derived body, so the run returns ZERO rows rather than
+    // faulting `.operand` — an earlier round rejected it before materialising.
+    try fixture().empty(
+        "SELECT * FROM (SELECT Label + 1 AS x FROM K WHERE k = 0) AS d")
+  }
+
+  @Test func `the derived form matches the non-derived form`() throws {
+    // Parity with the non-derived query: `SELECT Label + 1 FROM K WHERE k = 0`
+    // also runs to zero rows (the filter drops every row before the
+    // projection). The derived-table wrapper must behave identically — empty.
+    try fixture().empty("SELECT Label + 1 FROM K WHERE k = 0")
+  }
+
+  @Test func `columns validate true still faults the filtered-out body`()
+      throws {
+    // The EXPLICIT schema path stays STRICT: `columns(of:validate:true)` on the
+    // SAME body still faults `.operand`, so a caller asking to validate the
+    // schema gets the ill-typed projection rejected even though a run empties.
+    #expect(throws: SQLError.operand("operands must be numeric")) {
+      let query = try parse(query:
+          "SELECT * FROM (SELECT Label + 1 AS x FROM K WHERE k = 0) AS d")
+      _ = try fixture().columns(of: query, validate: true)
+    }
+  }
+
+  @Test func `a reached ill-typed body still faults at run`() throws {
+    // Lenient is NOT never: a body whose `WHERE` KEEPS a row (`k = 1` matches
+    // `K`'s first row) reaches the ill-typed `Label + 1` at run, so the
+    // executor faults `.operand` — only an UNEVALUATED expression is spared.
+    try fixture().expect(
+        "SELECT * FROM (SELECT Label + 1 AS x FROM K WHERE k = 1) AS d",
+        fails: .operand("operands must be numeric"))
+  }
+}
+
+// MARK: - A WITH trailing query threads validate to a derived body
+
+/// The `WITH` schema path (`columns(of statement:)`) must thread `validate` to
+/// its trailing query's derived tables exactly as the non-`WITH` path does: a
+/// `validate: false` derive after a successful run TRUSTS a derived body a
+/// filter empties rather than re-type-checking it, while `validate: true` stays
+/// strict.
+struct DerivedTableWithValidateThreadingTests {
+  @Test func `validate false trusts a filtered-out body in the trailing query`()
+      throws {
+    // The trailing query wraps the SAME filtered-out ill-typed body under a
+    // `WITH`. A run empties (the body never evaluates `Label + 1`); a
+    // `validate: false` derive after that run must return the headers WITHOUT
+    // the `.operand` fault, matching the non-`WITH` path. The `WITH` path
+    // re-augmented the trailing query's derived table with the DEFAULT
+    // `validate: true` before this fix, so it still faulted `.operand`.
+    let statement = try Statement(parsing:
+        "WITH c(x) AS (SELECT 1) " +
+        "SELECT * FROM (SELECT Label + 1 AS x FROM K WHERE k = 0) AS d")
+    let rows = try fixture().run(statement, .standard)
+    #expect(rows.isEmpty)
+    let columns = try fixture().columns(of: statement, validate: false)
+    #expect(columns.map(\.name) == ["x"])
+  }
+
+  @Test func `validate true still faults the trailing query's body`() throws {
+    // The EXPLICIT schema path stays STRICT under `WITH` too: `validate: true`
+    // on the same trailing-query body still faults its ill-typed projection.
+    #expect(throws: SQLError.operand("operands must be numeric")) {
+      let statement = try Statement(parsing:
+          "WITH c(x) AS (SELECT 1) " +
+          "SELECT * FROM (SELECT Label + 1 AS x FROM K WHERE k = 0) AS d")
+      _ = try fixture().columns(of: statement, validate: true)
+    }
+  }
+}
+
+// MARK: - Uncorrelated boundary
+
+struct DerivedTableCorrelationTests {
+  @Test func `a derived table referencing an outer column faults`() throws {
+    // PR-3 is UNCORRELATED: the inner query resolves against the base catalog,
+    // NOT its sibling/outer FROM items, so a reference to the outer `T.Id`
+    // resolves as an unknown column (no LATERAL yet).
+    try fixture().expect(
+        "SELECT T.Id FROM T " +
+        "JOIN (SELECT V AS v FROM S WHERE V = T.Id) AS d ON T.Id = d.v",
+        fails: .column("Id"))
+  }
+
+  @Test func `a derived table referencing a sibling column faults`() throws {
+    // A reference to a sibling derived table's column is likewise unknown —
+    // the inner query sees neither its outer nor its sibling FROM items.
+    try fixture().expect(
+        "SELECT a.v FROM (SELECT V AS v FROM S) AS a " +
+        "JOIN (SELECT a.v AS w FROM S) AS b ON a.v = b.w",
+        fails: .column("v"))
+  }
+}
+
+// MARK: - Set-operation arm scoping
+
+/// A derived table's alias is scoped to the ARM that names it: a `setop` never
+/// hoists both arms' derived aliases into one shared map, so a left arm's
+/// `FROM T` resolves the base relation (or a same-named CTE), never a
+/// `derived T` the right arm named.
+struct DerivedTableSetOperationScopingTests {
+  @Test func `a set-op arm derived alias does not bind the other arm`()
+      throws {
+    // The RIGHT arm names a derived table aliased `T`; the LEFT arm's `FROM T`
+    // must resolve the BASE `T` (columns `Id`, `V`), NOT the right arm's
+    // `derived T` (whose only column is `a`). Hoisting both arms into one map
+    // bound the right `T` query-wide, so `SELECT Id FROM T` faulted on the
+    // unknown `Id`. Per-arm scoping keeps the base `T`, so the left arm scans
+    // its rows and `UNION ALL` appends the right arm's.
+    // `UNION ALL` keeps arm order, so no trailing sort is needed (and a bare
+    // union's `ORDER BY` would bind to the right arm's select, not the union).
+    try fixture().expect(
+        "SELECT Id FROM T " +
+        "UNION ALL SELECT a FROM (SELECT V AS a FROM S) AS T",
+        yields: [[1], [2], [3], [10], [20], [30]])
+  }
+
+  @Test func `a set-op arm resolves a CTE the other arm shadows`() throws {
+    // A statement CTE `T(Id)` is in scope for both arms; the RIGHT arm shadows
+    // it within its own scope with a `derived T`. The LEFT arm's `FROM T` must
+    // resolve the CTE (rows 100, 200), never the right arm's derived `T`. A
+    // shared arm map bound the right `T` query-wide, hiding the CTE from the
+    // left arm.
+    let statement = try Statement(parsing:
+        "WITH T(Id) AS (SELECT 100 UNION ALL SELECT 200) " +
+        "SELECT Id FROM T " +
+        "UNION ALL SELECT a FROM (SELECT V AS a FROM S) AS T")
+    let rows = try fixture().run(statement, .standard)
+    #expect(rows == [[.integer(100)], [.integer(200)],
+                     [.integer(10)], [.integer(20)], [.integer(30)]])
+  }
+
+  @Test func `a set-op arm derived alias is invisible at the schema path too`()
+      throws {
+    // Schema ↔ run parity: `columns(of:)` derives the first (left) arm's
+    // projection against the BASE `T`, so the result column is `Id`, not the
+    // right arm's `a`.
+    let query = try parse(query:
+        "SELECT Id FROM T " +
+        "UNION ALL SELECT a FROM (SELECT V AS a FROM S) AS T")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.map(\.name) == ["Id"])
+  }
+}
+
+// MARK: - No LATERAL: sibling FROM items are invisible
+
+/// A derived table is UNCORRELATED/no-LATERAL: its inner query resolves against
+/// the enclosing OUTER scope only, so a sibling `FROM`/`JOIN` item is invisible
+/// inside it.
+struct DerivedTableSiblingVisibilityTests {
+  @Test func `a derived table cannot read an earlier sibling as a relation`()
+      throws {
+    // `FROM (…) AS a JOIN (SELECT v FROM a) AS b` — `b`'s inner query names the
+    // SIBLING `a` as a relation. Threading the accumulating sibling map let
+    // `b` read `a` as a CTE; the outer-scope-only rule now faults on the
+    // unknown relation `a` (no LATERAL).
+    try fixture().expect(
+        "SELECT b.v FROM (SELECT V AS v FROM S) AS a " +
+        "JOIN (SELECT v FROM a) AS b ON a.v = b.v",
+        fails: .relation("a"))
+  }
+
+  @Test func `a sibling-reading derived table faults the schema path too`()
+      throws {
+    // Schema ↔ run parity: the same sibling reference faults `columns(of:)`,
+    // so the schema is not advertised for a query the run rejects.
+    #expect(throws: SQLError.self) {
+      let query = try parse(query:
+          "SELECT b.v FROM (SELECT V AS v FROM S) AS a " +
+          "JOIN (SELECT v FROM a) AS b ON a.v = b.v")
+      _ = try fixture().columns(of: query, validate: true)
+    }
+  }
+
+  @Test func `independent sibling derived tables both resolve`() throws {
+    // Control: two sibling derived tables that do NOT reference each other
+    // still resolve and run — each materialises against the shared outer scope
+    // (the base catalog), so both read `S` and join on their own columns.
+    try fixture().expect(
+        "SELECT a.v FROM (SELECT V AS v FROM S) AS a " +
+        "JOIN (SELECT V AS w FROM S) AS b ON a.v = b.w ORDER BY a.v",
+        yields: [[10], [20], [30]])
+  }
+}
+
+// MARK: - Self-named derived alias resolves the base relation in its body
+
+/// A derived alias may share the name of the BASE relation its own body
+/// references — `(SELECT … FROM T) AS T`. Its body's `FROM T` must resolve the
+/// BASE `T`, never the derived alias itself, on BOTH the schema-only and the
+/// run paths: `augment` materialises the body against the alias-free outer
+/// scope, so the run→compile double augmentation is IDEMPOTENT (the second
+/// pass, whose context already binds the derived `T`, still reads the base).
+struct DerivedTableSelfNamedAliasTests {
+  @Test func `a derived alias resolves the base relation its body names`()
+      throws {
+    // `(SELECT Id AS a FROM T) AS T` — the inner `FROM T` reads the BASE `T`
+    // (columns `Id`, `V`), projecting `Id AS a`, and the derived alias is also
+    // `T`. Before the idempotent fix the schema-only augment re-materialised
+    // the body against the already-bound one-column derived `T`, faulting
+    // `.column("Id")`; now the body resolves the base `T` on both paths.
+    try fixture().expect(
+        "SELECT a FROM (SELECT Id AS a FROM T) AS T ORDER BY a",
+        yields: [[1], [2], [3]])
+  }
+
+  @Test func `a self-named derived alias advertises its schema`() throws {
+    // Schema ↔ run parity: `columns(of:)` derives the body against the base
+    // `T`, so the result column is the inner projection `a`, not a fault.
+    let query =
+        try parse(query: "SELECT a FROM (SELECT Id AS a FROM T) AS T")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+    #expect(columns[0].name == "a")
+    #expect(columns[0].type == .integer)
+  }
+
+  @Test func `a self-named derived alias under a JOIN reads the base`() throws {
+    // A variant where the inner body references the base relation by the SAME
+    // name as the alias, joined to another relation: `(SELECT Id AS k FROM T)
+    // AS T` joined to `K` on the key. The inner `FROM T` still resolves the
+    // base `T`, so the join pairs `K.k` with the base rows (1, 2).
+    try fixture().expect(
+        "SELECT T.k, K.Label FROM (SELECT Id AS k FROM T) AS T " +
+        "JOIN K ON K.k = T.k ORDER BY T.k",
+        yields: [[1, "a"], [2, "b"]])
+  }
+}
+
+// MARK: - Set-op SELECT * arity resolves an arm's own derived aliases
+
+/// A set operation's `SELECT *` arm resolves its OWN derived aliases for the
+/// cross-arm arity check. The top-level augment collects NO arm-local
+/// derivations (arms are scoped), so the star-arity check augments each arm's
+/// own aliases into a PER-ARM scope first — per arm, so a left arm's alias
+/// never leaks to the right — matching what each arm produces at run.
+struct DerivedTableSetOperationStarTests {
+  @Test func `a set-op SELECT * arm resolves its own derived table`() throws {
+    // `SELECT * FROM (SELECT V FROM S) AS d UNION ALL SELECT V FROM S` — the
+    // left `SELECT *` spans the arm-local derived `d` (one column `V`). Before
+    // the fix the star-arity check ran with no arm-local binding and faulted on
+    // the unknown relation `d`; now it augments `d` per arm, so both arms are
+    // one column wide and the union appends `S`'s rows to themselves.
+    // `UNION ALL` keeps arm order (a bare union's `ORDER BY` binds the last
+    // arm's select, not the union), so no trailing sort is used.
+    try fixture().expect(
+        "SELECT * FROM (SELECT V FROM S) AS d UNION ALL SELECT V FROM S",
+        yields: [[10], [20], [30], [10], [20], [30]])
+  }
+
+  @Test func `a set-op SELECT * arm advertises its arity at the schema path`()
+      throws {
+    // Schema ↔ run parity: `columns(of:)` compiles the whole set operation, so
+    // the star arm's width (derived `d`'s one column) matches the other arm's,
+    // and the result column is the first arm's `V`.
+    let query = try parse(query:
+        "SELECT * FROM (SELECT V FROM S) AS d UNION ALL SELECT V FROM S")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.map(\.name) == ["V"])
+  }
+
+  @Test func `a set-op SELECT * in the right arm resolves its own derived`()
+      throws {
+    // A variant with the derived table in the RIGHT arm's `SELECT *`: the left
+    // arm is a plain `SELECT V FROM S`, the right `SELECT * FROM (SELECT V FROM
+    // S) AS d`. The right arm's `d` must resolve for its star arity (one
+    // column), so the arities match and the union runs.
+    try fixture().expect(
+        "SELECT V FROM S UNION ALL SELECT * FROM (SELECT V FROM S) AS d",
+        yields: [[10], [20], [30], [10], [20], [30]])
+  }
+
+  @Test func `a set-op arm star derived alias does not leak to the other arm`()
+      throws {
+    // No leak: the left arm's derived `d` is scoped to that arm, so the right
+    // arm's own `SELECT * FROM (…) AS d` resolves ITS own `d` — both arms name
+    // `d` for their own derived table without colliding. A one-column output
+    // each, so the union runs. (`UNION ALL` keeps arm order; the right arm
+    // reads `T`'s `V` values 10, 20, 30.)
+    try fixture().expect(
+        "SELECT * FROM (SELECT V FROM S) AS d " +
+        "UNION ALL SELECT * FROM (SELECT V FROM T) AS d",
+        yields: [[10], [20], [30], [10], [20], [30]])
+  }
+}
+
+// MARK: - Cyclic-view guard through derived-table materialisation
+
+/// A catalog with a CYCLIC view — `Loop`'s body reaches back to itself through
+/// a derived table — and a NON-cyclic view `Src` over the base `S`. Resolving
+/// `Loop` must fault `.recursion`, not recurse to a stack overflow; `Src`
+/// resolves as any other view.
+private func views() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("S", ["V": .integer]) {
+      Row(10)
+      Row(20)
+      Row(30)
+    }
+    // A view whose body names itself through a derived table.
+    try View("Loop", "SELECT * FROM (SELECT * FROM Loop) AS d", as: ["V"])
+    // A well-formed view a derived table can resolve.
+    try View("Src", "SELECT V FROM S", as: ["V"])
+  }
+}
+
+// MARK: - A derived alias preserves a same-named CTE (and base tables)
+
+/// Stripping a derived alias from the scope its body resolves against must drop
+/// ONLY the derived binding, KEEPING a same-named CTE (or base table): the
+/// alias being defined is out of scope in its own body, but an enclosing CTE of
+/// that name is visible. A blanket name-drop removed the CTE too, so a
+/// CTE-shadowing derived body faulted.
+struct DerivedTableCTEShadowTests {
+  @Test func `a derived body resolves an enclosing CTE of its own alias name`()
+      throws {
+    // `WITH t(x) AS (SELECT 1) SELECT * FROM (SELECT x FROM t) AS t` — the
+    // inner `FROM t` is inside the derived table ALSO aliased `t`; the alias
+    // being defined is out of scope in its own body, so `t` resolves the CTE
+    // (projecting its `x` = 1), not the derived table itself. A name-blanket
+    // drop removed the CTE, faulting `.relation("t")` (or resolving a base).
+    let statement = try Statement(parsing:
+        "WITH t(x) AS (SELECT 1) SELECT * FROM (SELECT x FROM t) AS t")
+    let rows = try fixture().run(statement, .standard)
+    #expect(rows == [[.integer(1)]])
+  }
+
+  @Test func `the CTE-shadowing derived body advertises its schema`() throws {
+    // Schema ↔ run parity: `columns(of:)` derives the body against the CTE `t`
+    // too, so the result column is the CTE's `x`, resolved rather than faulted.
+    let statement = try Statement(parsing:
+        "WITH t(x) AS (SELECT 1) SELECT * FROM (SELECT x FROM t) AS t")
+    let columns = try fixture().columns(of: statement, validate: true)
+    #expect(columns.map(\.name) == ["x"])
+  }
+
+  @Test func `a self-named derived body over a base table reads the base`()
+      throws {
+    // Control (no CTE): the SAME shape over the BASE relation `T` resolves the
+    // base — the body's `FROM T` reads columns `Id`, `V`, projecting `Id`, and
+    // the derived alias is also `T`. Dropping only the derived binding leaves
+    // the base reachable (a base table is not in the overlay), so this is the
+    // round-2/3 behaviour intact.
+    try fixture().expect(
+        "SELECT Id FROM (SELECT Id FROM T) AS T ORDER BY Id",
+        yields: [[1], [2], [3]])
+  }
+
+  @Test func `a sibling derived alias stays invisible to a CTE-shadowing body`()
+      throws {
+    // A sibling derived alias remains invisible (round-2), yet a same-named CTE
+    // is visible: a CTE `a(v)` (one row 7) is in scope, a sibling `FROM (…) AS
+    // a` binds a derived `a` (three rows), and `b`'s body `FROM a` must read
+    // the CTE `a`, NOT the sibling derived `a`. So `b` yields the CTE's single
+    // 7 and the cross join to the three-row sibling `a` gives 7 three times;
+    // had `b` read the sibling derived `a` it would be three rows, product 9.
+    let statement = try Statement(parsing:
+        "WITH a(v) AS (SELECT 7) " +
+        "SELECT b.v FROM (SELECT V AS v FROM S) AS a " +
+        "JOIN (SELECT v FROM a) AS b ON b.v = b.v ORDER BY b.v")
+    let rows = try fixture().run(statement, .standard)
+    #expect(rows == [[.integer(7)], [.integer(7)], [.integer(7)]])
+  }
+}
+
+// MARK: - A CTE shadowed by a derived alias stays visible to a lazy scalar
+
+/// A LAZY scalar subquery resolves against the PRE-AUGMENT scope, exactly as
+/// the eager `EXISTS`/`IN (Q)` subqueries do. For `WITH d(x) AS (…) SELECT
+/// (SELECT x FROM d) FROM (SELECT y FROM T) AS d`, the derived `d` OVERWRITES
+/// the CTE `d` in the executor's augmented overlay before the lazy scalar runs;
+/// resolving the scalar against that overlay (subscoped) could not restore the
+/// hidden CTE, faulting `.relation("d")`. Threading the pre-augment scope — the
+/// one the eager paths ran against, CTEs intact — lets the scalar read the CTE.
+struct DerivedTableCTEShadowScalarTests {
+  @Test func `a lazy scalar reads a CTE a derived alias shadows`() throws {
+    // The scalar `(SELECT x FROM d)` reads the CTE `d` (one row, x = 1), NOT
+    // the shadowing derived `d`; the outer FROM's derived `d` yields three rows
+    // (T's Ids), so each output row is the CTE's 1.
+    let statement = try Statement(parsing:
+        "WITH d(x) AS (SELECT 1) " +
+        "SELECT (SELECT x FROM d) FROM (SELECT Id AS y FROM T) AS d")
+    let rows = try fixture().run(statement, .standard)
+    #expect(rows == [[.integer(1)], [.integer(1)], [.integer(1)]])
+  }
+
+  @Test func `the CTE-shadowing lazy scalar advertises its schema`() throws {
+    // Schema ↔ run parity: `columns(of:)` derives the scalar against the CTE
+    // `d` too, so the projection resolves rather than faulting `.relation`.
+    let statement = try Statement(parsing:
+        "WITH d(x) AS (SELECT 1) " +
+        "SELECT (SELECT x FROM d) FROM (SELECT Id AS y FROM T) AS d")
+    let columns = try fixture().columns(of: statement, validate: true)
+    #expect(columns.count == 1)
+  }
+
+  @Test func `an eager EXISTS reads a CTE a derived alias shadows`() throws {
+    // Parity check: the eager `EXISTS` path already reads the CTE `d` (round
+    // 8/9). `EXISTS (SELECT 1 FROM d)` over the CTE `d` (non-empty) is TRUE for
+    // every outer row, so all three derived `d` rows survive — the behaviour
+    // the lazy scalar now matches.
+    let statement = try Statement(parsing:
+        "WITH d(x) AS (SELECT 1) " +
+        "SELECT y FROM (SELECT Id AS y FROM T) AS d " +
+        "WHERE EXISTS (SELECT 1 FROM d) ORDER BY y")
+    let rows = try fixture().run(statement, .standard)
+    #expect(rows == [[.integer(1)], [.integer(2)], [.integer(3)]])
+  }
+
+  @Test func `an eager IN reads a CTE a derived alias shadows`() throws {
+    // Parity check for the `IN (Q)` eager role: `Id IN (SELECT x FROM d)` folds
+    // over the CTE `d`'s single value 1, so only the derived row with Id = 1
+    // survives — the CTE, not the shadowing derived `d`, feeds the membership.
+    let statement = try Statement(parsing:
+        "WITH d(x) AS (SELECT 1) " +
+        "SELECT y FROM (SELECT Id AS y FROM T) AS d " +
+        "WHERE y IN (SELECT x FROM d) ORDER BY y")
+    let rows = try fixture().run(statement, .standard)
+    #expect(rows == [[.integer(1)]])
+  }
+
+  @Test func `a lazy scalar over the shadowing derived alias itself works`()
+      throws {
+    // Control: a scalar subquery that DOES name the shadowing derived `d`
+    // resolves it where intended. Here the scalar `(SELECT MAX(y) FROM e)`
+    // reads a DIFFERENT derived alias `e`, and the outer derived `d` (aliased
+    // to avoid the source `T` collision) drives the rows; the scalar collapses
+    // to MAX = 3, so each of the three rows carries 3.
+    let statement = try Statement(parsing:
+        "WITH c(x) AS (SELECT 1) " +
+        "SELECT (SELECT MAX(y) FROM (SELECT Id AS y FROM T) AS e) " +
+        "FROM (SELECT Id FROM T) AS d")
+    let rows = try fixture().run(statement, .standard)
+    #expect(rows == [[.integer(3)], [.integer(3)], [.integer(3)]])
+  }
+}
+
+// MARK: - A CTE body threads validate to its own derived tables (round 14)
+
+/// A CTE (`WITH`) body's OWN derived tables must be validated with the same
+/// leniency the run uses: `with` validates a CTE with `typecheck: false` (defer
+/// operand checks to execution), so the CTE-body's schema-only `augment`/
+/// `compile` must derive a nested derived table with `validate: false` too — a
+/// data-dependent-empty body a filter drops must not fault a CTE that runs
+/// empty, exactly as the equivalent non-derived CTE runs. The strict schema
+/// path (`typecheck: true`) keeps the eager body type-check.
+struct DerivedTableCTEBodyValidateThreadingTests {
+  @Test func `a filtered-out body in a CTE runs to zero rows`() throws {
+    // The reviewer's case: the CTE `c(x)`'s body wraps the SAME filtered-out
+    // ill-typed derived table (`Label + 1` under `WHERE k = 0`, which drops
+    // every `K` row). A run must empty rather than fault `.operand` — the CTE
+    // validation threaded `typecheck: false`, so the CTE-body's derived table
+    // derives with `validate: false`. Before the fix the CTE-body augment/
+    // compile defaulted to `validate: true` and faulted during validation.
+    let statement = try Statement(parsing:
+        "WITH c(x) AS (SELECT x FROM " +
+        "(SELECT Label + 1 AS x FROM K WHERE k = 0) AS d) SELECT * FROM c")
+    let rows = try fixture().run(statement, .standard)
+    #expect(rows.isEmpty)
+  }
+
+  @Test func `the CTE form matches the non-derived CTE`() throws {
+    // Parity: the equivalent CTE whose body is NON-derived
+    // (`SELECT Label + 1 AS x FROM K WHERE k = 0`) also runs to zero rows — the
+    // filter drops every row before the projection. The derived-table wrapper
+    // inside the CTE body must behave identically.
+    let derived = try Statement(parsing:
+        "WITH c(x) AS (SELECT x FROM " +
+        "(SELECT Label + 1 AS x FROM K WHERE k = 0) AS d) SELECT * FROM c")
+    let plain = try Statement(parsing:
+        "WITH c(x) AS (SELECT Label + 1 AS x FROM K WHERE k = 0) " +
+        "SELECT * FROM c")
+    let lhs = try fixture().run(derived, .standard)
+    let rhs = try fixture().run(plain, .standard)
+    #expect(lhs.isEmpty)
+    #expect(lhs == rhs)
+  }
+
+  @Test func `columns validate false returns the CTE headers`() throws {
+    // A `validate: false` derive after the run TRUSTS the CTE-body's derived
+    // table rather than eager-type-checking it, so it returns the trailing
+    // query's headers WITHOUT the `.operand` fault.
+    let statement = try Statement(parsing:
+        "WITH c(x) AS (SELECT x FROM " +
+        "(SELECT Label + 1 AS x FROM K WHERE k = 0) AS d) SELECT * FROM c")
+    let columns = try fixture().columns(of: statement, validate: false)
+    #expect(columns.map(\.name) == ["x"])
+  }
+
+  @Test func `columns validate true still faults the CTE body`() throws {
+    // The EXPLICIT schema path stays STRICT: `validate: true` threads
+    // `typecheck: true` into the CTE validation, so the CTE-body's derived
+    // table is eager-type-checked and its ill-typed `Label + 1` still faults
+    // `.operand`.
+    #expect(throws: SQLError.operand("operands must be numeric")) {
+      let statement = try Statement(parsing:
+          "WITH c(x) AS (SELECT x FROM " +
+          "(SELECT Label + 1 AS x FROM K WHERE k = 0) AS d) SELECT * FROM c")
+      _ = try fixture().columns(of: statement, validate: true)
+    }
+  }
+
+  @Test func `a reached ill-typed body in a CTE still faults at run`() throws {
+    // Lenient is NOT never: a CTE-body derived table whose `WHERE` KEEPS a row
+    // (`k = 1` matches `K`'s first row) reaches the ill-typed `Label + 1` at
+    // run, so the executor faults `.operand` — only an UNEVALUATED body is
+    // spared.
+    let statement = try Statement(parsing:
+        "WITH c(x) AS (SELECT x FROM " +
+        "(SELECT Label + 1 AS x FROM K WHERE k = 1) AS d) SELECT * FROM c")
+    #expect(throws: SQLError.operand("operands must be numeric")) {
+      _ = try fixture().run(statement, .standard)
+    }
+  }
+}
+
+// MARK: - A subquery body threads validate to its own derived tables (sweep)
+
+/// The unifying sweep found `subquery(of:)` compiled an `EXISTS`/`IN (Q)`/
+/// scalar subquery's body with the DEFAULT `validate: true`, so a filtered-out
+/// derived table NESTED in a subquery body leaked the eager type-check onto the
+/// RUN path. `compile(select)`/`group`/`subquery(of:)` now thread `validate`,
+/// so a run derives a subquery-body derived table LENIENTLY while a schema
+/// check keeps it strict.
+struct DerivedTableSubqueryBodyValidateThreadingTests {
+  @Test func `a filtered-out body in an EXISTS subquery runs`() throws {
+    // The `EXISTS` subquery's body nests the SAME filtered-out ill-typed
+    // derived table. The subquery has no surviving row, so the `EXISTS` is
+    // FALSE and the outer query keeps no row — but it must not FAULT `.operand`
+    // during the run preflight. Before the sweep `subquery(of:)` eager-type-
+    // checked the derived body and faulted.
+    try fixture().empty(
+        "SELECT Id FROM T WHERE EXISTS " +
+        "(SELECT 1 FROM (SELECT Label + 1 AS x FROM K WHERE k = 0) AS d)")
+  }
+
+  @Test func `columns validate true still faults the subquery body`() throws {
+    // The EXPLICIT schema path stays STRICT: `validate: true` eager-type-checks
+    // the subquery-body's derived table, so the ill-typed `Label + 1` faults
+    // `.operand`.
+    #expect(throws: SQLError.operand("operands must be numeric")) {
+      let query = try parse(query:
+          "SELECT Id FROM T WHERE EXISTS " +
+          "(SELECT 1 FROM (SELECT Label + 1 AS x FROM K WHERE k = 0) AS d)")
+      _ = try fixture().columns(of: query, validate: true)
+    }
+  }
+
+  @Test func `a reached ill-typed body in a subquery still faults at run`()
+      throws {
+    // Lenient is NOT never: a subquery-body derived table whose `WHERE` keeps a
+    // row reaches the ill-typed `Label + 1` at run, so the executor faults
+    // `.operand`.
+    try fixture().expect(
+        "SELECT Id FROM T WHERE EXISTS " +
+        "(SELECT 1 FROM (SELECT Label + 1 AS x FROM K WHERE k = 1) AS d)",
+        fails: .operand("operands must be numeric"))
+  }
+}
+
+// MARK: - A set-operation VIEW body runs each arm with its arm-local aliases
+
+/// A view whose body is a set operation with a DERIVED TABLE in an arm: the
+/// `derive` path must run each arm with its arm-local derived aliases (as the
+/// top-level `run` does), not execute the precompiled whole-`setop` plan under
+/// an overlay that binds none.
+private func setopViews() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["Id": .integer, "V": .integer]) {
+      Row(1, 10)
+      Row(2, 20)
+    }
+    // A derived table in the LEFT arm.
+    try View("VL", "SELECT * FROM (SELECT Id FROM T) AS d " +
+                   "UNION ALL SELECT Id FROM T", as: ["Id"])
+    // A derived table in the RIGHT arm.
+    try View("VR", "SELECT Id FROM T " +
+                   "UNION ALL SELECT * FROM (SELECT Id FROM T) AS d",
+             as: ["Id"])
+    // A LEFT arm whose IN subquery names the arm's ENCLOSING derived `d`. The
+    // arm's `FROM (…) AS d` is a SELECT-scoped derived alias, INVISIBLE to the
+    // arm's own nested `IN` subquery's FROM — so `(SELECT Id FROM d)` faults
+    // `.relation("d")` exactly as it would for a base-table alias.
+    try View("VI", "SELECT Id FROM (SELECT Id FROM T) AS d " +
+                   "WHERE Id IN (SELECT Id FROM d) " +
+                   "UNION ALL SELECT Id FROM T", as: ["Id"])
+    // A RIGHT arm whose IN subquery names its ENCLOSING derived `d` — the same
+    // SELECT-scoped-alias fault as `VI`, in the right arm.
+    try View("VJ", "SELECT Id FROM T " +
+                   "UNION ALL SELECT Id FROM (SELECT Id FROM T) AS d " +
+                   "WHERE Id IN (SELECT Id FROM d)", as: ["Id"])
+  }
+}
+
+struct DerivedTableSetOperationViewTests {
+  @Test func `selecting a set-op view with a left-arm derived table runs`()
+      throws {
+    // The view body's LEFT arm scans the arm-local derived `d`; executing the
+    // precompiled `setop` plan under an arm-less overlay faulted resolving the
+    // `d` scan. Per-arm run binds `d`, so the view returns the union rows.
+    try setopViews().expect("SELECT Id FROM VL ORDER BY Id",
+                            yields: [[1], [1], [2], [2]])
+  }
+
+  @Test func `selecting a set-op view with a right-arm derived table runs`()
+      throws {
+    // The variant with the derived table in the RIGHT arm resolves the same
+    // way — each arm runs with its own derived aliases.
+    try setopViews().expect("SELECT Id FROM VR ORDER BY Id",
+                            yields: [[1], [1], [2], [2]])
+  }
+
+  @Test func `a set-op view with a derived-table arm advertises its schema`()
+      throws {
+    // Schema ↔ run parity: the view's `columns(of:)`/schema resolves the arms'
+    // derived aliases too (compile augments each arm per arm for the star-arity
+    // check), so the view advertises its one column `Id`.
+    let query = try parse(query: "SELECT Id FROM VL")
+    let columns = try setopViews().columns(of: query, validate: true)
+    #expect(columns.map(\.name) == ["Id"])
+  }
+
+  @Test func `a set-op left arm IN subquery cannot see its enclosing derived`()
+      throws {
+    // The LEFT arm's `IN (SELECT Id FROM d)` names the arm's ENCLOSING derived
+    // `d`. A derived-table alias is SELECT-scoped, so it is INVISIBLE to a
+    // nested subquery's FROM (as a base-table alias would be) — the subquery
+    // faults `.relation("d")`, at a run.
+    try setopViews().expect("SELECT Id FROM VI ORDER BY Id",
+                            fails: .relation("d"))
+  }
+
+  @Test func `a set-op right arm IN subquery cannot see its enclosing derived`()
+      throws {
+    // The RIGHT-arm variant faults the same way — the arm's enclosing derived
+    // `d` is invisible to its nested `IN` subquery's FROM.
+    try setopViews().expect("SELECT Id FROM VJ ORDER BY Id",
+                            fails: .relation("d"))
+  }
+
+  @Test func `a set-op arm IN subquery over enclosing derived faults schema`()
+      throws {
+    // Schema ↔ run parity: `columns(of:)` faults `.relation("d")` on the arm's
+    // nested `IN` subquery naming the enclosing derived alias exactly as a run
+    // does.
+    let query = try parse(query: "SELECT Id FROM VI")
+    #expect(throws: SQLError.relation("d")) {
+      _ = try setopViews().columns(of: query, validate: true)
+    }
+  }
+}
+
+// MARK: - A set-op arm's scalar subquery cannot see its enclosing derived
+
+/// A set-op view whose arms carry a scalar subquery `(SELECT MAX(a) FROM d)`
+/// naming the arm's ENCLOSING derived alias `d`. A derived-table alias is
+/// SELECT-scoped, INVISIBLE to a nested scalar subquery's FROM (as a base-table
+/// alias would be), so the scalar faults `.relation("d")` — the same
+/// outer-derived-alias-in-subquery fault the `IN`/`EXISTS` variants raise. A
+/// scalar over a SHARED base relation stays legal.
+private func setopScalarViews() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("S", ["V": .integer]) {
+      Row(10)
+      Row(20)
+      Row(30)
+    }
+    Relation("U", ["V": .integer]) {
+      Row(40)
+      Row(50)
+    }
+    // A scalar subquery `(SELECT MAX(a) FROM d)` naming the arm's ENCLOSING
+    // derived `d`: the alias is SELECT-scoped, so the scalar's FROM cannot see
+    // it and faults `.relation("d")` at both arms.
+    try View("VMax",
+             "SELECT (SELECT MAX(a) FROM d) AS m " +
+             "FROM (SELECT V AS a FROM S WHERE V < 30) AS d " +
+             "UNION ALL " +
+             "SELECT (SELECT MAX(a) FROM d) AS m " +
+             "FROM (SELECT V AS a FROM S WHERE V > 10) AS d",
+             as: ["m"])
+    // A single arm whose scalar subquery names the enclosing derived `d` in
+    // both its projection and its WHERE — the same fault, in a single SELECT.
+    try View("VTwice",
+             "SELECT (SELECT MAX(a) FROM d) AS m " +
+             "FROM (SELECT V AS a FROM S) AS d " +
+             "WHERE (SELECT MAX(a) FROM d) = 30",
+             as: ["m"])
+    // Two arms with IDENTICAL scalar text reading a SHARED base relation `U`
+    // (no derived alias): legal and the same value in both arms — both yield
+    // MAX(U) = 50.
+    try View("VShared",
+             "SELECT (SELECT MAX(V) FROM U) AS m FROM S WHERE V = 10 " +
+             "UNION ALL " +
+             "SELECT (SELECT MAX(V) FROM U) AS m FROM S WHERE V = 20",
+             as: ["m"])
+  }
+}
+
+struct DerivedTableSetOperationScalarTests {
+  @Test func `a set-op arm scalar subquery cannot see its enclosing derived`()
+      throws {
+    // A scalar subquery `(SELECT MAX(a) FROM d)` in each arm names the arm's
+    // ENCLOSING derived `d`. The derived alias is SELECT-scoped, invisible to
+    // the scalar subquery's FROM, so it faults `.relation("d")` at a run — the
+    // scalar variant of the outer-derived-alias-in-subquery fault.
+    try setopScalarViews().expect("SELECT m FROM VMax",
+                                  fails: .relation("d"))
+  }
+
+  @Test func `a set-op arm scalar over an enclosing derived faults schema`()
+      throws {
+    // Schema ↔ run parity: `columns(of:)` faults `.relation("d")` on the arm's
+    // scalar subquery naming the enclosing derived alias exactly as a run does.
+    let query = try parse(query: "SELECT m FROM VMax")
+    #expect(throws: SQLError.relation("d")) {
+      _ = try setopScalarViews().columns(of: query, validate: true)
+    }
+  }
+
+  @Test func `a single-arm scalar cannot see its enclosing derived`() throws {
+    // The scalar subquery `(SELECT MAX(a) FROM d)`, reached in both the
+    // projection and the WHERE of a single arm, names the enclosing derived
+    // `d` — invisible to its FROM, so it faults `.relation("d")`.
+    try setopScalarViews().expect("SELECT m FROM VTwice",
+                                  fails: .relation("d"))
+  }
+
+  @Test func `two arms sharing a non-arm-local scalar both yield it`() throws {
+    // Control: two arms with IDENTICAL scalar text over a SHARED relation `U`
+    // (no arm-local `d`) each correctly yield MAX(U) = 50 — arm isolation does
+    // not perturb a scalar that reads no arm-local relation.
+    try setopScalarViews().expect("SELECT m FROM VShared",
+                                  yields: [[50], [50]])
+  }
+}
+
+// MARK: - A set-op view's optimiser augment threads validate leniently
+
+/// Selecting from a SET-OPERATION view runs the run-path optimiser, which
+/// re-augments each leaf arm to bind its arm-local derived aliases. That
+/// per-arm augment defaulted to `validate: true`, so an arm's data-dependent-
+/// empty derived body (`Label + 1 AS x` under `WHERE k = 0`, no surviving row)
+/// was TYPE-CHECKED during optimisation and faulted `.operand` — even though
+/// `overlay(name:)` above and the run's materialise paths are lenient. The
+/// per-arm optimiser augment now threads `validate: false` (the optimiser needs
+/// schema/name bindings only), so a set-op view arm runs exactly as its
+/// single-arm and non-derived equivalents do.
+private func setopValidateViews() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("S", ["V": .integer]) {
+      Row(10)
+      Row(20)
+    }
+    Relation("K", ["k": .integer, "Label": .text]) {
+      Row(1, "a")
+      Row(2, "b")
+    }
+    // A LEFT arm whose derived table has a filtered-out ill-typed body
+    // (`Label + 1` under `WHERE k = 0`, dropping every `K` row); the RIGHT arm
+    // is plain. The whole run yields only the right arm's rows.
+    try View("VF", "SELECT x FROM " +
+                   "(SELECT Label + 1 AS x FROM K WHERE k = 0) AS d " +
+                   "UNION ALL SELECT V FROM S", as: ["x"])
+    // The same filtered-out ill-typed derived table in a SINGLE-arm view — no
+    // set operation, so the optimiser takes the whole-view overlay path.
+    try View("VS", "SELECT x FROM " +
+                   "(SELECT Label + 1 AS x FROM K WHERE k = 0) AS d",
+             as: ["x"])
+    // A REACHED ill-typed arm body (`k = 2` keeps a `K` row) still faults at
+    // run — leniency spares only an UNEVALUATED expression.
+    try View("VB", "SELECT x FROM " +
+                   "(SELECT Label + 1 AS x FROM K WHERE k = 2) AS d " +
+                   "UNION ALL SELECT V FROM S", as: ["x"])
+  }
+}
+
+struct DerivedTableSetOperationValidateTests {
+  @Test func `a set-op arm's filtered-out derived body runs lenient`() throws {
+    // The reviewer's case: the left arm's derived body is ill-typed but
+    // filtered out. The optimiser's per-arm augment threaded `validate: true`
+    // and faulted `.operand` before `derive` executed the view; threading
+    // `validate: false` runs it, yielding only the right arm's `S` rows.
+    try setopValidateViews().expect("SELECT * FROM VF ORDER BY x",
+                                    yields: [[10], [20]])
+  }
+
+  @Test func `the set-op arm matches the single-arm view`() throws {
+    // Parity: the SINGLE-arm view over the SAME filtered-out derived body runs
+    // to zero rows — the optimiser's whole-view overlay was already lenient
+    // (`overlay(name:)` passes `validate: false`), and the set-op arm now
+    // matches it, both running WITHOUT the `.operand` fault.
+    try setopValidateViews().empty("SELECT * FROM VS")
+  }
+
+  @Test func `a reached ill-typed arm body still faults at run`() throws {
+    // Leniency is NOT never: the arm's `WHERE k = 2` KEEPS a `K` row, so the
+    // run reaches the ill-typed `Label + 1` and the executor faults `.operand`.
+    try setopValidateViews().expect("SELECT * FROM VB",
+                                    fails: .operand("operands must be numeric"))
+  }
+}
+
+// MARK: - A derived alias is not a recursive relation reference
+
+/// The `WITH RECURSIVE` fixpoint detector inspects a relation's SOURCE, not its
+/// binding name: a derived table's alias is not a recursive reference, while a
+/// genuine self-reference nested inside a derived body IS.
+struct DerivedTableRecursionReferenceTests {
+  @Test func `a shadowing derived alias is not a recursive reference`() throws {
+    // `WITH RECURSIVE a(n) AS (SELECT 1 UNION ALL SELECT n FROM (SELECT 2 AS n)
+    // AS a) SELECT n FROM a` — the second arm's `FROM (…) AS a` merely NAMES a
+    // derived table `a`; it does not reference the CTE `a`, so the CTE is NOT
+    // recursive and the arm runs ONCE (never to the recursion cap). The
+    // `UNION ALL` keeps both arms: the anchor 1, then the derived table's 2.
+    let statement = try Statement(parsing:
+        "WITH RECURSIVE a(n) AS " +
+        "(SELECT 1 UNION ALL SELECT n FROM (SELECT 2 AS n) AS a) " +
+        "SELECT n FROM a ORDER BY n")
+    let rows = try fixture().run(statement, .standard)
+    #expect(rows == [[.integer(1)], [.integer(2)]])
+  }
+
+  @Test func `a self-reference nested in a derived body is detected`() throws {
+    // `WITH RECURSIVE a(n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM (SELECT n
+    // FROM a) AS d WHERE n < 3) …` — the second arm's derived body `FROM a`
+    // genuinely references the CTE `a`, so the CTE IS recursive and routes
+    // through the fixpoint. Detecting the nested reference is what makes the
+    // recursion fire: the frontier climbs 1 → 2 → 3 and stops (`n < 3` empties
+    // it), yielding 1, 2, 3. Were the nested `a` NOT seen, the arm would run
+    // ONCE against an unbound `a` and fault.
+    let statement = try Statement(parsing:
+        "WITH RECURSIVE a(n) AS " +
+        "(SELECT 1 UNION ALL " +
+        "SELECT n + 1 FROM (SELECT n FROM a) AS d WHERE n < 3) " +
+        "SELECT n FROM a ORDER BY n")
+    let rows = try fixture().run(statement, .standard)
+    #expect(rows == [[.integer(1)], [.integer(2)], [.integer(3)]])
+  }
+}
+
+struct DerivedTableCyclicViewTests {
+  @Test func `a derived table over a cyclic view faults recursion at run`()
+      throws {
+    // The view body's derived table names the view under resolution. The
+    // `visited` guard, threaded through `augment`/`materialise` into the
+    // schema-derivation compile, catches the re-entry and faults `.recursion`
+    // rather than recursing to a stack overflow.
+    try views().expect("SELECT * FROM Loop", fails: .recursion("Loop"))
+  }
+
+  @Test func `a derived table over a cyclic view faults recursion at columns`()
+      throws {
+    // Schema ↔ run parity: `columns(of:)` compiles the same cyclic body, so it
+    // raises the same `.recursion` — never a hang — as the run.
+    let query = try parse(query: "SELECT * FROM Loop")
+    let raised: SQLError?
+    do {
+      _ = try views().columns(of: query, validate: true)
+      raised = nil
+    } catch let fault as SQLError {
+      raised = fault
+    }
+    #expect(raised == .recursion("Loop"))
+  }
+
+  @Test func `a derived table over a non-cyclic view resolves`() throws {
+    // Control: a derived table over a well-formed view still resolves and runs
+    // — the guard fires only on a genuine cycle.
+    try views().expect(
+        "SELECT V FROM (SELECT * FROM Src) AS d ORDER BY V",
+        yields: [[10], [20], [30]])
+  }
+
+  @Test func `a non-cyclic view derived table advertises its schema`() throws {
+    // Schema ↔ run parity for the control: `columns(of:)` derives the column
+    // through the view and the derived table without faulting.
+    let query = try parse(query: "SELECT V FROM (SELECT * FROM Src) AS d")
+    let columns = try views().columns(of: query, validate: true)
+    #expect(columns.map(\.name) == ["V"])
+  }
+}
+
+// MARK: - An enclosing derived alias is invisible to a nested subquery's FROM
+
+/// A derived-table alias in the outer SELECT's FROM is SELECT-scoped: it names
+/// a relation only in the OWNING SELECT's own FROM/JOIN and expressions, NOT
+/// inside a nested `EXISTS`/`IN`/scalar subquery's FROM — a subquery does not
+/// see the enclosing query's FROM relations, exactly as a base-table alias in
+/// the enclosing FROM is invisible. So `FROM d` inside the subquery faults
+/// `.relation("d")` (the enclosing derived `d` is stripped), while a same-named
+/// CTE stays visible, the subquery's OWN derived table still resolves, and a
+/// correlated COLUMN reference still works (that is orthogonal to FROM scope).
+struct DerivedTableSubqueryScopeTests {
+  @Test func `an EXISTS subquery FROM cannot see the enclosing derived alias`()
+      throws {
+    // The reviewer's case: `EXISTS (SELECT 1 FROM d)` names the enclosing
+    // derived `d`. The alias is SELECT-scoped, invisible to the subquery's
+    // FROM, so it faults `.relation("d")` at a run.
+    try fixture().expect(
+        "SELECT x FROM (SELECT 1 AS x) AS d WHERE EXISTS (SELECT 1 FROM d)",
+        fails: .relation("d"))
+  }
+
+  @Test func `an EXISTS subquery FROM cannot see the derived alias at columns`()
+      throws {
+    // Schema ↔ run parity: `columns(of:)` faults `.relation("d")` on the same
+    // subquery FROM naming the enclosing derived alias.
+    let query = try parse(query:
+        "SELECT x FROM (SELECT 1 AS x) AS d WHERE EXISTS (SELECT 1 FROM d)")
+    #expect(throws: SQLError.relation("d")) {
+      _ = try fixture().columns(of: query, validate: true)
+    }
+  }
+
+  @Test func `an enclosing base-table alias is invisible to the subquery too`()
+      throws {
+    // The SAME fault a base-table alias `d` in the enclosing FROM raises: a
+    // nested subquery's `FROM d` sees neither an enclosing base-table alias nor
+    // an enclosing derived alias — both are SELECT-scoped range variables.
+    try fixture().expect(
+        "SELECT Id FROM T AS d WHERE EXISTS (SELECT 1 FROM d)",
+        fails: .relation("d"))
+  }
+
+  @Test func `an IN subquery FROM cannot see the enclosing derived alias`()
+      throws {
+    // The `IN` variant: `Id IN (SELECT Id FROM d)` names the enclosing derived
+    // `d`, invisible to the subquery's FROM — the same `.relation("d")` fault.
+    try fixture().expect(
+        "SELECT x FROM (SELECT 1 AS x, 1 AS Id) AS d " +
+        "WHERE Id IN (SELECT Id FROM d)",
+        fails: .relation("d"))
+  }
+
+  @Test func `a scalar subquery FROM cannot see the enclosing derived alias`()
+      throws {
+    // The scalar variant: `(SELECT MAX(x) FROM d)` names the enclosing derived
+    // `d` — invisible to its FROM, so it faults `.relation("d")`.
+    try fixture().expect(
+        "SELECT x FROM (SELECT 1 AS x) AS d " +
+        "WHERE (SELECT MAX(x) FROM d) = 1",
+        fails: .relation("d"))
+  }
+
+  @Test func `a same-named CTE stays visible inside the subquery`() throws {
+    // A CTE `d` is statement-scoped, so it IS visible inside a nested
+    // subquery's FROM — the enclosing derived `d` is stripped, not the CTE. The
+    // `EXISTS (SELECT 1 FROM d)` resolves the CTE `d` (one row), so the
+    // subquery is TRUE and the outer derived row is kept.
+    let statement = try Statement(parsing:
+        "WITH d(x) AS (SELECT 1) " +
+        "SELECT y FROM (SELECT 2 AS y) AS d WHERE EXISTS (SELECT 1 FROM d)")
+    let rows = try fixture().run(statement, .standard)
+    #expect(rows == [[.integer(2)]])
+  }
+
+  @Test func `a same-named CTE resolves inside the subquery at columns`()
+      throws {
+    // Schema ↔ run parity: `columns(of:)` resolves the CTE `d` inside the
+    // subquery FROM too (never faulting on the stripped enclosing derived `d`),
+    // advertising the outer projection `y`.
+    let statement = try Statement(parsing:
+        "WITH d(x) AS (SELECT 1) " +
+        "SELECT y FROM (SELECT 2 AS y) AS d WHERE EXISTS (SELECT 1 FROM d)")
+    let columns = try fixture().columns(of: statement, validate: true)
+    #expect(columns.map(\.name) == ["y"])
+  }
+
+  @Test func `a subquery's own derived table still resolves`() throws {
+    // The subquery augments its OWN derived table `e` — the strip drops only
+    // the ENCLOSING derived aliases, so `EXISTS (SELECT 1 FROM (SELECT 2 AS z)
+    // AS e)` resolves `e` and the subquery is TRUE, keeping the outer row.
+    try fixture().expect(
+        "SELECT x FROM (SELECT 1 AS x) AS d " +
+        "WHERE EXISTS (SELECT 1 FROM (SELECT 2 AS z) AS e)",
+        yields: [[1]])
+  }
+
+  @Test func `an uncorrelated EXISTS over a base table still runs`() throws {
+    // Orthogonal to the derived-alias strip: a nested subquery over a BASE
+    // relation (`EXISTS (SELECT 1 FROM S)`) resolves and runs exactly as
+    // before — stripping the ENCLOSING derived aliases keeps base tables (and
+    // CTEs) in the subquery's FROM scope. `S` is non-empty, so every outer
+    // derived row is kept.
+    try fixture().expect(
+        "SELECT x FROM (SELECT Id AS x FROM T) AS d " +
+        "WHERE EXISTS (SELECT 1 FROM S) ORDER BY x",
+        yields: [[1], [2], [3]])
+  }
+}
+
+// MARK: - A CTE a derived BODY's own FROM shadows stays visible to its subquery
+
+/// The schema-path analog of the round-8 CTE-not-hidden test: a derived
+/// table's BODY whose own FROM alias shadows an enclosing CTE, with a NESTED
+/// subquery in that body naming the CTE. The body's schema is derived through
+/// `materialise`, which augments the body's own FROM alias OVER the CTE in its
+/// overlay — so subscoping that overlay for the nested subquery would leave the
+/// CTE unbound. The schema walk must resolve the body's nested subqueries
+/// against the PRE-augment context (CTE intact), matching the run path, so
+/// `columns(of:)` and a run both read the CTE inside the nested subquery.
+struct DerivedTableBodyCTEShadowSubqueryTests {
+  @Test func `a body FROM alias shadows a CTE its nested subquery still reads`()
+      throws {
+    // `WITH t(x) AS (SELECT 1) SELECT * FROM (SELECT y FROM (SELECT 2 AS y)
+    // AS t WHERE EXISTS (SELECT x FROM t)) AS d` — the outer derived body's own
+    // `FROM (SELECT 2 AS y) AS t` SHADOWS the CTE `t`, and the body's nested
+    // `EXISTS (SELECT x FROM t)` names `t` — which resolves the CTE
+    // (statement-scoped, visible in a subquery), reading its `x` = 1. The CTE
+    // has one row, so the EXISTS is TRUE and the body yields `y` = 2. Before
+    // the fix the schema walk's overlay OVERWROTE the CTE with the body's
+    // derived `t`, so subscoping dropped it and `SELECT x FROM t` faulted.
+    let statement = try Statement(parsing:
+        "WITH t(x) AS (SELECT 1) " +
+        "SELECT * FROM (SELECT y FROM (SELECT 2 AS y) AS t " +
+                       "WHERE EXISTS (SELECT x FROM t)) AS d")
+    let rows = try fixture().run(statement, .standard)
+    #expect(rows == [[.integer(2)]])
+  }
+
+  @Test func `the CTE-in-nested-subquery body advertises its schema`() throws {
+    // Schema ↔ run parity: `columns(of:)` derives the body against the CTE `t`
+    // inside the nested subquery too — resolving `SELECT x FROM t` rather than
+    // faulting on the body's derived `t` (no column `x`) — advertising the
+    // outer projection `y`.
+    let statement = try Statement(parsing:
+        "WITH t(x) AS (SELECT 1) " +
+        "SELECT * FROM (SELECT y FROM (SELECT 2 AS y) AS t " +
+                       "WHERE EXISTS (SELECT x FROM t)) AS d")
+    let columns = try fixture().columns(of: statement, validate: true)
+    #expect(columns.map(\.name) == ["y"])
+  }
+}
+
+// MARK: - The optimiser does not execute a view's derived-table body
+
+/// A shared call counter a stateful routine increments — a tiny
+/// `@unchecked Sendable` box over a mutable count, so the non-deterministic
+/// `tick()` routine registered against it records how many times a run invoked
+/// it. The engine evaluates a projection synchronously on one thread, so the
+/// box needs no lock.
+private final class Counter: @unchecked Sendable {
+  /// The number of times `next()` has been called.
+  private(set) var count = 0
+
+  /// Increments the count and returns the current value.
+  func next() -> Int {
+    count += 1
+    return count
+  }
+}
+
+/// The optimiser augments a view body SCHEMA-ONLY (`rows: false`), so it never
+/// executes a derived table's body during optimisation. A stateful routine in a
+/// view's `FROM (SELECT tick() …)` runs at `derive`/run alone — exactly ONCE
+/// for `SELECT * FROM v`, not doubled by an optimise-time materialisation.
+struct DerivedTableViewOptimiseTests {
+  @Test func `a view's stateful derived-body routine runs exactly once`()
+      throws {
+    // `CREATE VIEW v AS SELECT x FROM (SELECT tick() AS x FROM T) AS d` — the
+    // derived body calls the non-deterministic COUNTING routine `tick()` once
+    // per `T` row. `T` has one row, so a single execution of the view invokes
+    // `tick()` EXACTLY once. When the optimiser materialised the derived body
+    // (`rows: true`) it ran the body during optimisation AND again at `derive`,
+    // so the counter read TWICE; `rows: false` binds the alias schema-only, so
+    // the single execution at run is the only invocation.
+    let counter = Counter()
+    let routines = try Routines()
+        .registering("tick", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+    let catalog = try Catalog {
+      Relation("T", ["Id": .integer]) {
+        Row(1)
+      }
+      try View("v", "SELECT x FROM (SELECT tick() AS x FROM T) AS d",
+               as: ["x"])
+    }
+    let rows = try catalog.run(Statement(parsing: "SELECT * FROM v"),
+                               routines)
+    #expect(rows == [[.integer(1)]])
+    #expect(counter.count == 1)
+  }
+}
+
+// MARK: - A derived body executes exactly once, and only after validation
+
+/// A derived table's body is materialised (executed) ONLY after `compile`
+/// validates the whole query, and each level of a nested derived table runs its
+/// body EXACTLY once. A stateful `tick()` in the body records the invocations:
+/// an invalid query executes it 0×, a valid single-level derived table 1×, and
+/// a nested derived table 1× — never doubled by an output-schema-discovery
+/// materialisation ahead of the single run.
+struct DerivedTableExecutionOnceTests {
+  /// A single-row `T`, a counting `tick()`, and the catalog registering it — so
+  /// one execution of a body naming `tick()` once per row invokes it once.
+  private func harness() throws -> (Counter, Routines, FixtureCatalog) {
+    let counter = Counter()
+    let routines = try Routines()
+        .registering("tick", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+    let catalog = try Catalog {
+      Relation("T", ["Id": .integer]) {
+        Row(1)
+      }
+    }
+    return (counter, routines, catalog)
+  }
+
+  @Test func `an invalid query never executes the derived body`() throws {
+    // `SELECT missing FROM (SELECT tick() AS x FROM T) AS d` FAILS during
+    // column resolution — `missing` is unknown — so it must NEVER execute the
+    // derived body's stateful `tick()`. `run` compiles/VALIDATES the whole
+    // query (schema-only) BEFORE materialising any derived rows, so the fault
+    // is raised with the body executed ZERO times. Materialising ahead of the
+    // compile would have run `tick()` for a query that cannot run.
+    let (counter, routines, catalog) = try harness()
+    let query =
+        try parse(query: "SELECT missing FROM (SELECT tick() AS x FROM T) AS d")
+    #expect(throws: SQLError.column("missing")) {
+      _ = try catalog.run(query, routines)
+    }
+    #expect(counter.count == 0)
+  }
+
+  @Test func `columns of an invalid query never executes the derived body`()
+      throws {
+    // Schema ↔ run parity: `columns(of:)` faults the same unknown column and,
+    // being schema-only throughout, likewise executes the body zero times.
+    let (counter, routines, catalog) = try harness()
+    let query =
+        try parse(query: "SELECT missing FROM (SELECT tick() AS x FROM T) AS d")
+    #expect(throws: SQLError.column("missing")) {
+      _ = try catalog.columns(of: query, routines: routines)
+    }
+    #expect(counter.count == 0)
+  }
+
+  @Test func `a nested derived body executes exactly once`() throws {
+    // `SELECT x FROM (SELECT x FROM (SELECT tick() AS x FROM T) AS n) AS d` — a
+    // derived table whose own body nests a derived table. The output-schema
+    // discovery augment used to materialise (`rows: true`) the nested body once
+    // to derive `d`'s schema, then the single run materialised it AGAIN, so
+    // `tick()` fired TWICE and the query returned the SECOND value. Discovery
+    // is now schema-only (`rows: false`), so the nested body runs EXACTLY once
+    // and the query returns the first (only) value.
+    let (counter, routines, catalog) = try harness()
+    let query = try parse(query:
+        "SELECT x FROM (SELECT x FROM (SELECT tick() AS x FROM T) AS n) AS d")
+    let rows = try catalog.run(query, routines)
+    #expect(rows == [[.integer(1)]])
+    #expect(counter.count == 1)
+  }
+
+  @Test func `a single-level derived body executes exactly once`() throws {
+    // Control: a valid single-level derived table runs its body exactly once.
+    let (counter, routines, catalog) = try harness()
+    let query =
+        try parse(query: "SELECT x FROM (SELECT tick() AS x FROM T) AS d")
+    let rows = try catalog.run(query, routines)
+    #expect(rows == [[.integer(1)]])
+    #expect(counter.count == 1)
+  }
+}
+
+// MARK: - A view-body lazy scalar reads the view's scope, not the caller's
+
+/// A base relation `T` and a view `Count` whose body has a lazy SCALAR subquery
+/// `(SELECT COUNT(*) FROM T)` over that BASE `T`. The base has three rows, so
+/// the view's scalar collapses to three regardless of the caller.
+private func scopedScalarView() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["V": .integer]) {
+      Row(10)
+      Row(20)
+      Row(30)
+    }
+    // A one-row anchor a caller-scope scalar projects over (a FROM-less
+    // `WITH … SELECT <scalar>` is not a query shape the grammar accepts).
+    Relation("One", ["V": .integer]) {
+      Row(1)
+    }
+    // The scalar `(SELECT COUNT(*) FROM T)` is a LAZY scalar occurrence keyed
+    // under `.view("count")`; it must resolve against the BASE `T` (count 3),
+    // never a caller CTE `T`.
+    try View("Count", "SELECT (SELECT COUNT(*) FROM T) AS n", as: ["n"])
+  }
+}
+
+/// The run-time subquery cache tracks the pre-augment relation scope PER
+/// `Subscope`, so a view-body LAZY scalar resolves under the VIEW overlay, not
+/// the caller's. A single left-hand scope let a caller CTE `T` mask the view's
+/// own base `T`: `WITH T AS (…) SELECT * FROM Count` resolved the view scalar's
+/// `(SELECT COUNT(*) FROM T)` against the caller CTE `T` (five rows) instead of
+/// the base `T` (three) the view compiled against — the round-15 fault.
+struct DerivedTableViewScalarScopeTests {
+  @Test func `a view scalar reads the view's T not the caller CTE`() throws {
+    // `WITH T AS (five distinct rows) SELECT * FROM Count` — the caller binds a
+    // CTE `T` of five rows, shadowing the base `T` in the CALLER's scope. The
+    // view `Count`'s body scalar `(SELECT COUNT(*) FROM T)` was compiled over
+    // the base `T` (three rows), so it must collapse to 3, NOT the caller CTE's
+    // 5. The lazy scalar now resolves under its own `.view("count")` scope (the
+    // view's base `T`), not the merged caller scope.
+    let statement = try Statement(parsing:
+        "WITH T(V) AS (SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 " +
+        "UNION ALL SELECT 4 UNION ALL SELECT 5) SELECT * FROM Count")
+    let rows = try scopedScalarView().run(statement, .standard)
+    #expect(rows == [[.integer(3)]])
+  }
+
+  @Test func `the caller-CTE view scalar advertises the view's schema`()
+      throws {
+    // Schema ↔ run parity: `columns(of:)` derives the view scalar under the
+    // same `.view` scope, advertising the view's projection `n` rather than
+    // faulting or shifting to the caller CTE.
+    let statement = try Statement(parsing:
+        "WITH T(V) AS (SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 " +
+        "UNION ALL SELECT 4 UNION ALL SELECT 5) SELECT * FROM Count")
+    let columns = try scopedScalarView().columns(of: statement, validate: true)
+    #expect(columns.map(\.name) == ["n"])
+  }
+
+  @Test func `a caller-scope scalar still reads the caller CTE`() throws {
+    // No regression on the `.caller` scope: a TOP-LEVEL scalar
+    // `(SELECT COUNT(*) FROM T)` — textually in the caller, keyed `.caller` —
+    // reads the caller CTE `T` (five rows), the scope its own occurrence ran
+    // against. The per-`Subscope` map keeps the caller scalar on the caller
+    // scope and the view scalar on the view scope at once.
+    let statement = try Statement(parsing:
+        "WITH T(V) AS (SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 " +
+        "UNION ALL SELECT 4 UNION ALL SELECT 5) " +
+        "SELECT (SELECT COUNT(*) FROM T) AS n FROM One")
+    let rows = try scopedScalarView().run(statement, .standard)
+    #expect(rows == [[.integer(5)]])
+  }
+}
+
+// MARK: - The direct-select compile entry binds derived aliases
+
+/// The `compile(_ select:)` entry — reached DIRECTLY by a caller that already
+/// holds a `Select` (not wrapped in a `Query`) — must bind THIS select's own
+/// FROM derived aliases before resolving its relations, the same as the `Query`
+/// wrapper (`compile(.select(select))`) and `run` do. Compiling the reviewer's
+/// `SELECT a FROM (SELECT V AS a FROM S) AS d` through the bare-select entry
+/// must resolve `d` and project `a` rather than fault `.relation("d")` or bind
+/// against an unrelated `d`, matching the query path (schema/run parity).
+struct DerivedTableDirectCompileTests {
+  @Test func `the direct-select entry resolves a derived alias`() throws {
+    // The bare `compile(select)` binds `d` before resolving FROM, so the plan
+    // is one column wide (`a`) — no `.relation("d")`.
+    let select =
+        try parse(select: "SELECT a FROM (SELECT V AS a FROM S) AS d")
+    let plan = try fixture().compile(select)
+    #expect(plan.width == 1)
+  }
+
+  @Test func `the direct-select and query entries agree on width`() throws {
+    // Parity: the bare-select entry and the `Query` wrapper resolve the same
+    // derived alias to the same plan width — the fix does not fault one path.
+    let select =
+        try parse(select: "SELECT a FROM (SELECT V AS a FROM S) AS d")
+    let catalog = try fixture()
+    let bare = try catalog.compile(select)
+    let wrapped = try catalog.compile(.select(select))
+    #expect(bare.width == wrapped.width)
+  }
+
+  @Test func `the direct-select schema entry resolves a derived alias`()
+      throws {
+    // `columns(of select:)` — the schema counterpart of the bare-select entry —
+    // advertises the derived alias's projected column `a`, matching the run.
+    let select =
+        try parse(select: "SELECT a FROM (SELECT V AS a FROM S) AS d")
+    let columns = try fixture().columns(of: select, Context(),
+                                        validate: true)
+    #expect(columns.map(\.name) == ["a"])
+  }
+
+  @Test func `the run yields the derived alias's rows`() throws {
+    // Run parity: the SAME SQL succeeds through `run`, projecting `a` (the `S`
+    // values) — the direct-select entry now matches it.
+    try fixture().expect(
+        "SELECT a FROM (SELECT V AS a FROM S) AS d ORDER BY a",
+        yields: [[10], [20], [30]])
+  }
+
+  @Test func `a self-named direct-select derived alias reads the base`()
+      throws {
+    // No double-augment regression: a derived alias equal to a base relation
+    // (`(SELECT V AS a FROM S) AS S`) still reads the BASE `S` in its body —
+    // the wrapper's augment and this entry's augment key on the derivation
+    // identity, so the wrapped path does not re-derive and the body's own `S`
+    // is the base.
+    let select =
+        try parse(select: "SELECT a FROM (SELECT V AS a FROM S) AS S")
+    let plan = try fixture().compile(select)
+    #expect(plan.width == 1)
+  }
+}
+
+// MARK: - A grouped ORDER BY aggregate subquery reads the shadowed CTE
+
+/// The last CTE-overwrite-class path: a GROUPED `ORDER BY` sorting on an
+/// aggregate over a SCALAR subquery that names a CTE a same-named derived alias
+/// shadows. The aggregate's argument subquery is lowered through the grouped
+/// path, so its scope must reveal the base — the derived alias `d` shadows
+/// the CTE `d` non-destructively, and the subquery's `FROM d` resolves the CTE
+/// beneath. The layered overlay makes this structural: no per-path pre-augment
+/// threading, the reveal exposes the CTE the derived layer shadowed.
+struct DerivedTableGroupedOrderScalarShadowTests {
+  @Test func `a grouped ORDER BY aggregate subquery reads the shadowed CTE`()
+      throws {
+    // `WITH d(x) AS (SELECT 1) SELECT y FROM (SELECT 2 AS y) AS d GROUP BY y
+    // ORDER BY SUM((SELECT x FROM d))` — the scalar `(SELECT x FROM d)` in
+    // the ORDER BY aggregate names the CTE `d` (x = 1), NOT the shadowing
+    // `d` (whose column is `y`). One group (y = 2), so `SUM` folds the single
+    // scalar value 1; the row is the group's `y` = 2. Had the scalar read the
+    // derived `d`, `x` would not resolve and it would fault.
+    let statement = try Statement(parsing:
+        "WITH d(x) AS (SELECT 1) SELECT y FROM (SELECT 2 AS y) AS d " +
+        "GROUP BY y ORDER BY SUM((SELECT x FROM d))")
+    let rows = try fixture().run(statement, .standard)
+    #expect(rows == [[.integer(2)]])
+  }
+
+  @Test func `the grouped ORDER BY subquery advertises the outer schema`()
+      throws {
+    // Schema ↔ run parity: `columns(of:, validate: true)` resolves the ORDER
+    // BY aggregate's scalar subquery against the revealed base too, reading the
+    // CTE `d` rather than faulting on the shadowing derived `d`, and advertises
+    // the outer projection `y`.
+    let statement = try Statement(parsing:
+        "WITH d(x) AS (SELECT 1) SELECT y FROM (SELECT 2 AS y) AS d " +
+        "GROUP BY y ORDER BY SUM((SELECT x FROM d))")
+    let columns = try fixture().columns(of: statement, validate: true)
+    #expect(columns.map(\.name) == ["y"])
+  }
+}
+
+// MARK: - A derived-table run stays lenient in output discovery
+
+/// The caller's `validate` flag threads through the derived-table OUTPUT
+/// DISCOVERY (the schema walk that names a derived table's columns before a
+/// run), so a derived-table RUN stays LENIENT like the surrounding non-derived
+/// path: a scalar subquery a data-dependent filter drops from the result is
+/// NOT strictly validated before execution. A `WHERE k = 0` over `K` (keyed
+/// 1, 2) filters EVERY row out, so the inner `Label + 1` — a text-plus-integer
+/// operand that would fault if evaluated — never runs, exactly as the
+/// non-derived form runs to zero rows without touching it. The strict
+/// `columns(of:, validate: true)` preflight still faults, so the fix narrows
+/// to the lenient run path without disabling validation.
+struct DerivedTableLenientOutputTests {
+  @Test func `a derived run over a filtered-out inner scalar returns nothing`()
+      throws {
+    // The inner scalar `(SELECT x FROM (SELECT Label + 1 AS x FROM K WHERE
+    // k = 0) AS n)` sits over a doubly-nested derived table whose `WHERE k = 0`
+    // drops every row, so `Label + 1` never evaluates and the outer derived
+    // table `d` yields zero rows. The output discovery for the run must thread
+    // `validate: false` into the nested derived body, or it eager-type-checks
+    // `Label + 1` and faults BEFORE execution.
+    try fixture().empty(
+        "SELECT * FROM (SELECT (SELECT x " +
+        "                      FROM (SELECT Label + 1 AS x FROM K " +
+        "                            WHERE k = 0) AS n) AS s " +
+        "               FROM K WHERE k = 0) AS d")
+  }
+
+  @Test func `a derived run equals its non-derived form`() throws {
+    // Run ↔ non-derived parity: wrapping the SELECT in a derived table changes
+    // nothing — both return zero rows without faulting on `Label + 1`.
+    try fixture().expect(
+        "SELECT * FROM (SELECT (SELECT x " +
+        "                      FROM (SELECT Label + 1 AS x FROM K " +
+        "                            WHERE k = 0) AS n) AS s " +
+        "               FROM K WHERE k = 0) AS d",
+        equals:
+        "SELECT (SELECT x " +
+        "        FROM (SELECT Label + 1 AS x FROM K WHERE k = 0) AS n) AS s " +
+        "FROM K WHERE k = 0")
+  }
+
+  @Test func `a simple derived run over a filtered scalar returns nothing`()
+      throws {
+    // The isolating case: a derived table wrapping a scalar over a
+    // filtered-empty relation. `WHERE k = 0` drops every row, so `Label + 1`
+    // never evaluates and the derived table `d` yields nothing.
+    try fixture().empty(
+        "SELECT * FROM (SELECT (SELECT Label + 1 FROM K WHERE k = 0) AS s " +
+        "               FROM K WHERE k = 0) AS d")
+  }
+
+  @Test func `the strict preflight still faults on the inner scalar`() throws {
+    // Parity: `columns(of:, validate: true)` — the EXPLICIT schema path — still
+    // eager-type-checks the inner body and faults on `Label + 1`, proving the
+    // fix narrows to the lenient run path and does not disable validation.
+    #expect(throws: SQLError.self) {
+      let query = try parse(query:
+          "SELECT * FROM (SELECT (SELECT x " +
+          "                      FROM (SELECT Label + 1 AS x FROM K " +
+          "                            WHERE k = 0) AS n) AS s " +
+          "               FROM K WHERE k = 0) AS d")
+      _ = try fixture().columns(of: query, validate: true)
+    }
+  }
+}


### PR DESCRIPTION
Accept an uncorrelated derived table in a relation position: `FROM (SELECT …) AS t` (and as a JOIN operand). A new `Relation.Source.derived(Query)` wraps the inner query; a leading `(` is disambiguated from a parenthesised relation by one token of `SELECT` lookahead.

The alias is mandatory, as ISO requires a derived table be named, and becomes the relation's name — the key the resolution scope binds its materialised rows under. Resolution reuses the CTE path: the inner query is materialised once into a `Materialised` bound in the `ScopedRelations` overlay, so the FROM/JOIN and its columns resolve exactly as a common table expression does, and validation derives the same output schema it runs.

The derived table is uncorrelated in this cut — its inner query is materialised against the surrounding overlay, not its sibling FROM items — so a reference to an outer or sibling column resolves as an unknown column. LATERAL and correlated derived tables are a later stage.