### PR TITLE
SQLEngine: accept quantified ANY/ALL/SOME subqueries

### DIFF
--- a/Sources/SQLEngine/AST.swift
+++ b/Sources/SQLEngine/AST.swift
@@ -862,6 +862,23 @@ public indirect enum Predicate: Hashable, Sendable {
   /// column under Kleene `OR`, the SAME three-valued core the value-list `IN`
   /// uses.
   case within(Expression, Query, negated: Bool)
+  /// `x op {ANY | SOME | ALL} (Q)` — a QUANTIFIED comparison, whether `x op v`
+  /// holds for at least one (`ANY`/`SOME`) or every (`ALL`) value `v` the
+  /// subquery `Q` yields, `op` any of `= <> < <= > >=`. `Q` must project
+  /// exactly ONE column (else `SQLError.arity`). It is three-valued exactly as
+  /// `within` (`IN`) is — reusing the SAME `matches` comparison and Kleene
+  /// combine — folding `x op v` over `Q`'s column under Kleene `OR` for `any`
+  /// (TRUE at the first TRUE, else UNKNOWN if any comparison is UNKNOWN through
+  /// a NULL `x` or element, else FALSE) and under Kleene `AND` for `all` (FALSE
+  /// at the first FALSE, else UNKNOWN if any is UNKNOWN, else TRUE). An EMPTY
+  /// `Q` takes the fold's identity — `any` FALSE (no witness), `all` TRUE
+  /// (vacuous). `= ANY` is `IN` and `<> ALL` is `NOT IN`, but the case is kept
+  /// distinct for the general operator. `SOME` is a synonym for `ANY`,
+  /// normalised to `any` at parse time. In this slice `Q` is UNCORRELATED — it
+  /// names no column of the enclosing query — so the engine materialises it
+  /// ONCE (as `within` does) and folds over that single column; correlation is
+  /// a later slice.
+  case quantified(Expression, Comparison, Quantifier, Query)
   /// `p IS [NOT] <truth value>` — the ISO `<boolean test>`, whether the inner
   /// boolean `Predicate` `p`'s THREE-VALUED result equals the `value`
   /// (`TRUE`/`FALSE`/`UNKNOWN`), or does not when `negated`. Unlike the other
@@ -913,6 +930,22 @@ public enum Truth: Hashable, Sendable {
   case `false`
   /// The truth value `UNKNOWN` — a NULL boolean.
   case unknown
+}
+
+/// The quantifier of a quantified comparison subquery `x op {ANY|ALL} (Q)`.
+///
+/// `ANY` (and its synonym `SOME`, normalised to `any` at parse time) holds when
+/// `x op v` is TRUE for AT LEAST ONE value `v` the subquery yields; `ALL` holds
+/// when it is TRUE for EVERY value. Both are three-valued over NULLs and take
+/// the empty-set identity of their Kleene fold — `ANY` over no rows is FALSE
+/// (OR's identity), `ALL` over no rows is TRUE (AND's identity). `x = ANY (Q)`
+/// is the `IN (Q)` special case and `x <> ALL (Q)` the `NOT IN (Q)` one, but
+/// the general operator makes `< ANY`, `>= ALL`, and the rest first-class.
+public enum Quantifier: Hashable, Sendable {
+  /// `ANY` (or `SOME`) — TRUE for at least one subquery value.
+  case any
+  /// `ALL` — TRUE for every subquery value.
+  case all
 }
 
 /// A comparison operator.

--- a/Sources/SQLEngine/Engine.swift
+++ b/Sources/SQLEngine/Engine.swift
@@ -852,6 +852,10 @@ extension Predicate {
       // Only the OUTER operand can hold an enclosing-group aggregate; the
       // subquery is its own scope.
       operand.aggregated
+    case let .quantified(operand, _, _, _):
+      // As `within`: only the OUTER operand can hold an enclosing-group
+      // aggregate; the subquery is its own scope.
+      operand.aggregated
     case let .like(operand, pattern, escape, _):
       operand.aggregated || pattern.aggregated
           || (escape?.aggregated ?? false)
@@ -888,6 +892,8 @@ extension Predicate {
       // body that nests one still carries a binding to reject at registration.
       query.bound
     case let .within(operand, query, _):
+      operand.bound || query.bound
+    case let .quantified(operand, _, _, query):
       operand.bound || query.bound
     case let .like(operand, pattern, escape, _):
       operand.bound || pattern.bound || (escape?.bound ?? false)
@@ -1081,6 +1087,9 @@ extension Predicate {
     case let .within(operand, query, _):
       operand.collect(subqueries: &queries)
       queries.append(query)
+    case let .quantified(operand, _, _, query):
+      operand.collect(subqueries: &queries)
+      queries.append(query)
     case let .comparison(left, _, right):
       left.collect(subqueries: &queries)
       right.collect(subqueries: &queries)
@@ -1135,6 +1144,12 @@ extension Predicate {
     case let .within(operand, query, _):
       operand.collect(valued: &queries)
       queries.insert(query)
+    case let .quantified(operand, _, _, query):
+      // A quantified comparison reads the subquery's full COLUMN — folding `x
+      // op v` over every value — so it materialises FULL under the `.valued`
+      // role, exactly as `IN (Q)` does, never a cardinality probe.
+      operand.collect(valued: &queries)
+      queries.insert(query)
     case let .comparison(left, _, right):
       left.collect(valued: &queries)
       right.collect(valued: &queries)
@@ -1177,6 +1192,10 @@ extension Predicate {
       break
     case let .within(operand, _, _):
       operand.collect(scalar: &queries)
+    case let .quantified(operand, _, _, _):
+      // As `within`: the quantified subquery is `valued`, not scalar; only the
+      // outer operand's own subqueries are descended.
+      operand.collect(scalar: &queries)
     case let .comparison(left, _, right):
       left.collect(scalar: &queries)
       right.collect(scalar: &queries)
@@ -1218,6 +1237,10 @@ extension Predicate {
     case let .exists(query, _):
       queries.insert(query)
     case let .within(operand, _, _):
+      operand.collect(existential: &queries)
+    case let .quantified(operand, _, _, _):
+      // A quantified subquery is `valued` (its full column is read), not an
+      // existential probe; only the outer operand is descended here.
       operand.collect(existential: &queries)
     case let .comparison(left, _, right):
       left.collect(existential: &queries)
@@ -1731,6 +1754,10 @@ extension Predicate {
       break
     case let .within(operand, _, _):
       // Only the OUTER operand may hold an enclosing-group aggregate.
+      operand.collect(into: &expressions)
+    case let .quantified(operand, _, _, _):
+      // As `within`: only the OUTER operand may hold an enclosing-group
+      // aggregate.
       operand.collect(into: &expressions)
     case let .like(operand, pattern, escape, _):
       operand.collect(into: &expressions)

--- a/Sources/SQLEngine/Filter.swift
+++ b/Sources/SQLEngine/Filter.swift
@@ -92,6 +92,20 @@ internal indirect enum Filter: Equatable, Sendable {
   /// negating the three-valued result (UNKNOWN maps to itself). The operand
   /// `Term` is evaluated once per row.
   case within(Term, Subkey, negated: Bool)
+  /// `x op {ANY | ALL} (Q)` — the lowered form of the AST's `quantified`. The
+  /// operand term `x` is held ONCE, the comparison `op` and the `Quantifier`
+  /// beside it, and the subquery occurrence as its cache `Subkey` (its
+  /// `.valued` role, the FULL column materialised as `within`'s is) — never
+  /// run during `compile`, its single-column arity enforced at COMPILE from the
+  /// compiled width (`SQLError.arity`, no cursor). At RUN `Q` executes ONCE
+  /// against the borrowed catalog (memoised under the `Subkey`, UNCORRELATED)
+  /// and the case folds `x op v` over its lone column with the SAME
+  /// `matches`/Kleene primitives `within` uses: Kleene `OR` for `any` (seeded
+  /// FALSE), Kleene `AND` for `all` (seeded TRUE), so a NULL `x` or element
+  /// makes an otherwise-undecided fold UNKNOWN, and an EMPTY column takes the
+  /// seed — `any` FALSE, `all` TRUE. The operand `Term` is evaluated once per
+  /// row.
+  case quantified(Term, Comparison, Quantifier, Subkey)
   /// `p IS [NOT] <truth value>` — the lowered form of the AST's `truth`. The
   /// inner boolean `Filter` is held once and evaluated to its three-valued
   /// result, which is then MAPPED against `value` (`TRUE`/`FALSE`/`UNKNOWN`) to
@@ -410,6 +424,10 @@ extension Filter {
       // Only the outer operand term reads slots; the subquery is uncorrelated,
       // so remap the operand alone and carry the cache key through.
       .within(operand.remapped(through: slot), key, negated: negated)
+    case let .quantified(operand, op, quantifier, key):
+      // As `within`: only the outer operand reads slots; the uncorrelated
+      // subquery's cache key passes through unchanged.
+      .quantified(operand.remapped(through: slot), op, quantifier, key)
     case let .truth(inner, value, negated):
       .truth(inner.remapped(through: slot), value, negated: negated)
     case let .and(lhs, rhs):
@@ -510,6 +528,10 @@ extension Filter {
       // Only the outer operand term is evaluated; the subquery's memoised
       // values are folded under `matches`, which never throws.
       operand.safe
+    case let .quantified(operand, _, _, _):
+      // As `within`: only the outer operand is evaluated, the memoised values
+      // folded under `matches`, which never throws.
+      operand.safe
     case let .truth(inner, _, _): inner.safe
     case let .and(lhs, rhs): lhs.safe && rhs.safe
     case let .or(lhs, rhs): lhs.safe && rhs.safe
@@ -548,7 +570,11 @@ extension Filter {
   /// test, never UNKNOWN — so it is NOT contingent and stays freely pushable.
   private var contingent: Bool {
     switch self {
-    case .within: true
+    // A quantified comparison is three-valued exactly as `IN (Q)` is — a NULL
+    // in `Q`'s column (or a NULL operand) can make an otherwise-undecided fold
+    // UNKNOWN, slotless yet not definite — so both stay off a pushdown ahead of
+    // a later unsafe conjunct the non-short-circuiting `AND` still owes.
+    case .within, .quantified: true
     case .compare, .bound, .match, .null, .membership, .like, .between,
          .distinct, .exists: false
     case let .truth(inner, _, _): inner.contingent
@@ -571,8 +597,8 @@ extension Filter {
     case .compare, .match, .null, .membership, .distinct: false
     // An UNCORRELATED subquery predicate reads no run-time `:parameter` of the
     // OUTER query — the subquery runs once at run start with the same bindings —
-    // so neither is parameterised for the outer row.
-    case .exists, .within: false
+    // so none is parameterised for the outer row.
+    case .exists, .within, .quantified: false
     case let .like(_, pattern, escape, _):
       pattern.parameterised || (escape?.parameterised ?? false)
     case let .between(_, lower, upper, _):
@@ -1101,6 +1127,12 @@ extension Catalog where Self: ~Escapable {
       // SAME three-valued membership the value-list `IN` uses.
       try member(row, operand, subqueries.values(key), negated, relations,
                  routines, bindings, subqueries)
+    case let .quantified(operand, op, quantifier, key):
+      // Fold `operand op v` over the subquery's memoised single column with the
+      // SAME `matches`/Kleene primitives `within` uses — Kleene `OR` (seeded
+      // FALSE) for `any`, Kleene `AND` (seeded TRUE) for `all`.
+      try quantified(row, operand, op, quantifier, subqueries.values(key),
+                     relations, routines, bindings, subqueries)
     case let .truth(inner, value, negated):
       try tested(evaluate(row, inner, relations, routines, bindings,
                           subqueries), value, negated)
@@ -1191,6 +1223,44 @@ extension Catalog where Self: ~Escapable {
       if truth == true { break }
     }
     return negated ? truth.map { !$0 } : truth
+  }
+
+  /// Evaluates a lowered `operand op {ANY | ALL} (Q)` against `row` over the
+  /// subquery's ALREADY-MATERIALISED single column `values`.
+  ///
+  /// The `operand` is evaluated ONCE per row, then `operand op v` folds over
+  /// the materialised `values` IN ORDER with the SAME `matches`/Kleene
+  /// primitives the value-list and `IN (Q)` `member` folds use — Kleene `OR`
+  /// seeded FALSE for `any` (short-circuiting at the first TRUE), Kleene `AND`
+  /// seeded TRUE for `all` (short-circuiting at the first FALSE). So a NULL
+  /// `operand` or a NULL element makes an otherwise-undecided fold UNKNOWN (not
+  /// FALSE), an EMPTY `values` takes the seed — `any` FALSE (no witness), `all`
+  /// TRUE (vacuous) — and the identity falls out of the fold rather than a
+  /// special case. `= ANY` reduces to the `member` `IN` fold and `<> ALL` to
+  /// its negation, sharing one three-valued core with `within`.
+  private borrowing func quantified(_ row: borrowing some Row & ~Escapable,
+                                    _ operand: Term, _ op: Comparison,
+                                    _ quantifier: Quantifier,
+                                    _ values: Array<Value>,
+                                    _ relations: ScopedRelations,
+                                    _ routines: Routines, _ bindings: Bindings,
+                                    _ subqueries: Subqueries)
+      throws(SQLError) -> Bool? {
+    let value = try evaluate(row, operand, relations, routines, bindings,
+                             subqueries)
+    var truth: Bool? = quantifier == .any ? false : true
+    for element in values {
+      let matched = matches(value, op, element)
+      switch quantifier {
+      case .any:
+        truth = or(truth, matched)
+        if truth == true { return true }
+      case .all:
+        truth = and(truth, matched)
+        if truth == false { return false }
+      }
+    }
+    return truth
   }
 
   /// Evaluates a lowered `test [NOT] BETWEEN lower AND upper` against this row.

--- a/Sources/SQLEngine/Lexer.swift
+++ b/Sources/SQLEngine/Lexer.swift
@@ -439,6 +439,8 @@ internal struct Lexer: ~Escapable {
     case "IN": .in
     case "BETWEEN": .between
     case "EXISTS": .exists
+    case "ANY": .any
+    case "SOME": .some
     case "LIKE": .like
     case "ESCAPE": .escape
     case "PLACING": .placing

--- a/Sources/SQLEngine/Parser.swift
+++ b/Sources/SQLEngine/Parser.swift
@@ -35,12 +35,14 @@
 /// conjunction    := negation (AND negation)*
 /// negation       := NOT negation | [NOT] EXISTS '(' query ')' | primary
 /// primary        := '(' predicate ')' [IS [NOT] truthvalue] | comparison
-/// comparison     := expression (op (expression | param)
+/// comparison     := expression (op (quantifier '(' query ')'
+///                                    | expression | param)
 ///                 | IS [NOT] (NULL | truthvalue | DISTINCT FROM expression)
 ///                 | [NOT] IN '(' (expression (',' expression)* | query) ')'
 ///                 | [NOT] LIKE expression [ESCAPE expression]
 ///                 | [NOT] BETWEEN (expression | param) AND
 ///                                 (expression | param))
+/// quantifier     := ANY | SOME | ALL      // SOME is a synonym for ANY
 /// truthvalue     := TRUE | FALSE | UNKNOWN
 /// expression     := additive
 /// additive       := multiplicative (('+' | '-' | '||') multiplicative)*
@@ -1039,12 +1041,35 @@ internal struct Parser: ~Escapable {
       return try membership(left, negated: true)
     }
     let op = try op()
+    if let quantifier = try quantifier() {
+      // `left op {ANY | SOME | ALL} (query)` — a quantified comparison. The
+      // quantifier follows the operator, so the peek is unambiguous: it is
+      // never a right operand. The subquery is parenthesised as `IN (Q)` is.
+      try expect(.lparen)
+      let query = try query()
+      try expect(.rparen)
+      return .quantified(left, op, quantifier, query)
+    }
     if case let .parameter(name) = current?.kind {
       _ = try advance(expecting: "a parameter")
       return .bound(left: left, op: op, parameter: name)
     }
     let right = try expression()
     return .comparison(left: left, op: op, right: right)
+  }
+
+  /// Consumes an `ANY`, `SOME`, or `ALL` quantifier keyword at the head of a
+  /// quantified comparison's right side — the `ANY`/`ALL` `Quantifier`, `SOME`
+  /// a synonym for `ANY` normalised to `any` here — or `nil` when the next
+  /// token is none of them (an ordinary right operand, which the caller then
+  /// parses). `ALL` is the same keyword a `UNION ALL`/`SELECT ALL` uses,
+  /// disambiguated by grammar position: after a comparison operator it is only
+  /// ever the quantifier.
+  private mutating func quantifier() throws(SQLError) -> Quantifier? {
+    if try match(.any) { return .any }
+    if try match(.some) { return .any }
+    if try match(.all) { return .all }
+    return nil
   }
 
   /// Parses the tail of `left [NOT] IN (…)` — the `IN` is already consumed —

--- a/Sources/SQLEngine/Resolve.swift
+++ b/Sources/SQLEngine/Resolve.swift
@@ -287,6 +287,20 @@ internal struct Subquery {
     return .within(operand, Subkey(scope, query, .valued), negated: negated)
   }
 
+  /// Lowers `operand op {ANY | ALL} (query)` — `operand` already lowered to a
+  /// `Term` — requiring `query` project EXACTLY ONE column (else
+  /// `SQLError.arity`, from the COMPILED width, so a two-column subquery faults
+  /// here WITHOUT running), then carrying the query into the `Filter` under the
+  /// SAME `.valued` role `within` uses — the full column is materialised and
+  /// folded per outer row — to run at execution.
+  internal func quantified(_ operand: Term, _ op: Comparison,
+                           _ quantifier: Quantifier, _ query: Query)
+      throws(SQLError) -> Filter {
+    let width = try width(query)
+    guard width == 1 else { throw .arity(1, width) }
+    return .quantified(operand, op, quantifier, Subkey(scope, query, .valued))
+  }
+
   /// Lowers a scalar subquery `(query)` to a `Term.subquery` reading its
   /// collapsed value from the run-time cache, requiring `query` project EXACTLY
   /// ONE column (else `SQLError.arity`, from the COMPILED width, so a wider
@@ -565,6 +579,13 @@ private func lower(_ predicate: Predicate,
     // lowers to a `Filter.within` folding `x = v` over that column under the
     // value-list `IN`'s three-valued Kleene `OR`.
     try subquery.within(term(expression), query, negated: negated)
+  case let .quantified(expression, op, quantifier, query):
+    // `x op {ANY | ALL} (Q)`. `Q` is UNCORRELATED here, so the materialiser
+    // runs it ONCE, checks it projects exactly ONE column (else
+    // `SQLError.arity`), and lowers to a `Filter.quantified` folding `x op v`
+    // over that column with the SAME `matches`/Kleene primitives `within` uses
+    // — Kleene `OR` for `any`, Kleene `AND` for `all`.
+    try subquery.quantified(term(expression), op, quantifier, query)
   case let .membership(expression, values, negated):
     // `x IN (a, b, …)` is the disjunction `x = a OR x = b OR …` and `NOT IN`
     // its negation, lowered to a first-class `Filter.membership` that evaluates
@@ -1761,6 +1782,14 @@ internal struct Scope {
       try subquery.validate(query)
       let width = try subquery.width(query)
       guard width == 1 else { throw .arity(1, width) }
+    case let .quantified(operand, _, _, query):
+      // As `within`: validate the operand and the inner query, and enforce the
+      // single-column arity the lowering does (`SQLError.arity`), so schema
+      // validation matches execution.
+      _ = try validate(operand, routines, subquery: subquery)
+      try subquery.validate(query)
+      let width = try subquery.width(query)
+      guard width == 1 else { throw .arity(1, width) }
     case .bound:
       // `left op :parameter` with no binding — the schema default `[:]` —
       // yields UNKNOWN without evaluating the left term, so a run just produces
@@ -2168,7 +2197,7 @@ internal struct Scope {
       return nil
     case .bound:
       return nil
-    case .exists, .within:
+    case .exists, .within, .quantified:
       // A subquery predicate is not a ROW-INDEPENDENT constant fold — its truth
       // is decided by the materialised result at lowering time, not by folding
       // operands here — so it never folds statically; treat it as undecided
@@ -2212,7 +2241,7 @@ internal struct Scope {
       settled(operand, routines)
     case .bound:
       false
-    case .exists, .within:
+    case .exists, .within, .quantified:
       // A subquery predicate's truth comes from a materialised result, not from
       // folding constant operands, so it is never settled at compile time.
       false
@@ -2236,7 +2265,10 @@ internal struct Scope {
     // element or operand makes an unmatched test UNKNOWN), so it is not.
     case .exists:
       true
-    case .within:
+    // A quantified comparison is three-valued over NULLs exactly as `IN (Q)` —
+    // a NULL element or operand makes an undecided fold UNKNOWN — so it is not
+    // definite either.
+    case .within, .quantified:
       false
     case let .and(lhs, rhs), let .or(lhs, rhs):
       definite(lhs) && definite(rhs)
@@ -2383,6 +2415,10 @@ internal struct Scope {
     case let .within(operand, _, _):
       // Only the OUTER operand may hold an enclosing-group aggregate; the
       // subquery is its own scope, so it is not walked here.
+      try aggregates(in: operand, routines, subquery: subquery)
+    case let .quantified(operand, _, _, _):
+      // As `within`: only the OUTER operand may hold an enclosing-group
+      // aggregate; the subquery is its own scope.
       try aggregates(in: operand, routines, subquery: subquery)
     case let .like(operand, pattern, escape, _):
       try aggregates(in: operand, routines, subquery: subquery)
@@ -2647,7 +2683,7 @@ internal struct Scope {
       return or(left, try empty(rhs, routines))
     case let .not(operand):
       return try empty(operand, routines).map { !$0 }
-    case .exists, .within:
+    case .exists, .within, .quantified:
       // The whole-result empty-group fold carries no catalog, so it cannot
       // materialise a subquery to decide the predicate — it reads UNKNOWN,
       // dropping the lone empty group, the conservative outcome for the rare
@@ -3226,6 +3262,10 @@ extension Filter {
     case let .within(operand, _, _):
       // Only the outer operand term reads ordinals; the uncorrelated subquery
       // runs against its own relations.
+      operand.references(into: &ordinals)
+    case let .quantified(operand, _, _, _):
+      // As `within`: only the outer operand reads ordinals; the uncorrelated
+      // subquery runs against its own relations.
       operand.references(into: &ordinals)
     case let .like(operand, pattern, escape, _):
       operand.references(into: &ordinals)

--- a/Sources/SQLEngine/Token.swift
+++ b/Sources/SQLEngine/Token.swift
@@ -56,6 +56,10 @@ extension Token {
     case between
     /// The `EXISTS` keyword introducing an `[NOT] EXISTS (subquery)` predicate.
     case exists
+    /// The `ANY` keyword introducing a quantified comparison `x op ANY (Q)`.
+    case any
+    /// The `SOME` keyword — a synonym for `ANY` in a quantified comparison.
+    case some
     case like
     case escape
     /// The `PLACING` keyword separating an `OVERLAY`'s source string from its
@@ -154,6 +158,8 @@ extension Token.Kind {
     case .in: "IN"
     case .between: "BETWEEN"
     case .exists: "EXISTS"
+    case .any: "ANY"
+    case .some: "SOME"
     case .like: "LIKE"
     case .escape: "ESCAPE"
     case .placing: "PLACING"

--- a/Tests/SQLTests/QuantifiedSubqueryTests.swift
+++ b/Tests/SQLTests/QuantifiedSubqueryTests.swift
@@ -1,0 +1,291 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQLEngine
+
+import SQLTestSupport
+
+// MARK: - Fixture
+
+/// Two relations exercising the uncorrelated quantified `op {ANY|SOME|ALL} (Q)`
+/// comparisons: an outer `T` with an integer key `K` that is `NULL` in one row
+/// (so the three-valued corners are reachable), and an inner `S` whose column
+/// `V` holds a `NULL` (so a quantified comparison sees a NULL element) and a
+/// `Flag` used to filter the inner query to empty or to non-empty. `N` holds a
+/// single NULL-bearing column for the NULL-element corners.
+private func fixture() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["Id": .integer, "K": .integer]) {
+      Row(1, 10)
+      Row(2, 20)
+      Row(3, nil)
+      Row(4, 30)
+    }
+    Relation("S", ["V": .integer, "Flag": .integer]) {
+      Row(10, 1)
+      Row(20, 1)
+      Row(99, 0)
+    }
+    // A relation whose single column holds a NULL, for the NULL-element
+    // corners — `V` is `{2, NULL}`.
+    Relation("N", ["V": .integer]) {
+      Row(2)
+      Row(nil)
+    }
+  }
+}
+
+/// Parses `text` and returns its `Select`, failing on any other shape.
+private func parse(select text: String) throws -> Select {
+  guard case let .select(.select(select)) = try Statement(parsing: text) else {
+    Issue.record("expected a single SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return select
+}
+
+/// Parses `text` to a query, failing on any other statement.
+private func parse(query text: String) throws -> Query {
+  guard case let .select(query) = try Statement(parsing: text) else {
+    Issue.record("expected a SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return query
+}
+
+// MARK: - Parsing
+
+struct QuantifiedSubqueryParsingTests {
+  @Test func `parses = ANY over a subquery`() throws {
+    let select =
+        try parse(select: "SELECT Id FROM T WHERE K = ANY (SELECT V FROM S)")
+    let inner = try parse(query: "SELECT V FROM S")
+    #expect(select.predicate
+                == .quantified(.column("K"), .equal, .any, inner))
+  }
+
+  @Test func `parses <> ALL over a subquery`() throws {
+    let select =
+        try parse(select: "SELECT Id FROM T WHERE K <> ALL (SELECT V FROM S)")
+    let inner = try parse(query: "SELECT V FROM S")
+    #expect(select.predicate
+                == .quantified(.column("K"), .unequal, .all, inner))
+  }
+
+  @Test func `parses each comparison operator with a quantifier`() throws {
+    let inner = try parse(query: "SELECT V FROM S")
+    let cases: [(String, Comparison)] = [
+      ("<", .lt), ("<=", .leq), (">", .gt), (">=", .geq),
+    ]
+    for (spelling, op) in cases {
+      let select = try parse(
+          select: "SELECT Id FROM T WHERE K \(spelling) ANY (SELECT V FROM S)")
+      #expect(select.predicate == .quantified(.column("K"), op, .any, inner))
+    }
+  }
+
+  @Test func `SOME parses identically to ANY`() throws {
+    // `SOME` is a synonym for `ANY`, normalised to `.any` at parse time, so the
+    // two spellings produce the SAME AST.
+    let some =
+        try parse(select: "SELECT Id FROM T WHERE K < SOME (SELECT V FROM S)")
+    let any =
+        try parse(select: "SELECT Id FROM T WHERE K < ANY (SELECT V FROM S)")
+    #expect(some.predicate == any.predicate)
+    let inner = try parse(query: "SELECT V FROM S")
+    #expect(some.predicate == .quantified(.column("K"), .lt, .any, inner))
+  }
+
+  @Test func `parses a quantified comparison over a UNION subquery`() throws {
+    // A subquery is a full `query`, so it may itself be a `UNION`.
+    let text = "SELECT Id FROM T WHERE K > ALL "
+        + "(SELECT V FROM S UNION SELECT V FROM N)"
+    let select = try parse(select: text)
+    let inner = try parse(query: "SELECT V FROM S UNION SELECT V FROM N")
+    #expect(select.predicate
+                == .quantified(.column("K"), .gt, .all, inner))
+  }
+}
+
+// MARK: - = ANY / <> ALL equivalence to IN / NOT IN
+
+struct QuantifiedMembershipEquivalenceTests {
+  @Test func `= ANY is IN`() throws {
+    // `x = ANY (Q)` is exactly `x IN (Q)` — the same rows.
+    try fixture().expect(
+        "SELECT Id FROM T WHERE K = ANY (SELECT V FROM S WHERE Flag = 1)",
+        equals: "SELECT Id FROM T WHERE K IN (SELECT V FROM S WHERE Flag = 1)")
+    try fixture().expect(
+        "SELECT Id FROM T WHERE K = ANY (SELECT V FROM S WHERE Flag = 1)",
+        yields: [[1], [2]])
+  }
+
+  @Test func `<> ALL is NOT IN`() throws {
+    // `x <> ALL (Q)` is exactly `x NOT IN (Q)` — the same rows.
+    try fixture().expect(
+        "SELECT Id FROM T WHERE K <> ALL (SELECT V FROM S WHERE Flag = 1)",
+        equals:
+            "SELECT Id FROM T WHERE K NOT IN (SELECT V FROM S WHERE Flag = 1)")
+    // S filtered to Flag = 1 is {10, 20} with no NULL, so `<> ALL` is the plain
+    // complement over non-NULL K: row 4 (30). Row 3 (K NULL) is UNKNOWN.
+    try fixture().expect(
+        "SELECT Id FROM T WHERE K <> ALL (SELECT V FROM S WHERE Flag = 1)",
+        yields: [[4]])
+  }
+}
+
+// MARK: - Ordering-operator quantifier semantics
+
+struct QuantifiedOrderingTests {
+  @Test func `< ANY holds for a value below the maximum`() throws {
+    // S filtered to Flag = 1 is {10, 20}; `K < ANY` is TRUE when K is below
+    // SOME value, i.e. below the maximum 20. K = 10 qualifies (10 < 20); K = 20
+    // and 30 do not; K NULL is UNKNOWN.
+    try fixture().expect(
+        "SELECT Id FROM T WHERE K < ANY (SELECT V FROM S WHERE Flag = 1)",
+        yields: [[1]])
+  }
+
+  @Test func `<= ANY holds for a value at or below the maximum`() throws {
+    // `K <= ANY {10, 20}` is TRUE at or below the maximum 20: K = 10 and 20.
+    try fixture().expect(
+        "SELECT Id FROM T WHERE K <= ANY (SELECT V FROM S WHERE Flag = 1)",
+        yields: [[1], [2]])
+  }
+
+  @Test func `> ALL holds for a value above the maximum`() throws {
+    // `K > ALL {10, 20}` is TRUE only above EVERY value, i.e. above the maximum
+    // 20: K = 30 qualifies; K = 10 and 20 do not; K NULL is UNKNOWN.
+    try fixture().expect(
+        "SELECT Id FROM T WHERE K > ALL (SELECT V FROM S WHERE Flag = 1)",
+        yields: [[4]])
+  }
+
+  @Test func `>= ALL holds for a value at or above the maximum`() throws {
+    // `K >= ALL {10, 20}` is TRUE at or above the maximum 20: K = 20 and 30.
+    try fixture().expect(
+        "SELECT Id FROM T WHERE K >= ALL (SELECT V FROM S WHERE Flag = 1)",
+        yields: [[2], [4]])
+  }
+}
+
+// MARK: - Empty-subquery identities
+
+struct QuantifiedEmptyTests {
+  @Test func `op ANY over an empty subquery is FALSE`() throws {
+    // `x > ANY (empty)` has no witness, so it is FALSE for every row — no row
+    // survives (the Kleene-OR identity FALSE).
+    try fixture().expect(
+        "SELECT Id FROM T WHERE K > ANY (SELECT V FROM S WHERE Flag = 9)",
+        yields: [])
+  }
+
+  @Test func `op ALL over an empty subquery is TRUE`() throws {
+    // `x > ALL (empty)` is vacuously TRUE for every row — every row survives,
+    // including row 3 whose K is NULL, since no comparison is ever made (the
+    // Kleene-AND identity TRUE).
+    try fixture().expect(
+        "SELECT Id FROM T WHERE K > ALL (SELECT V FROM S WHERE Flag = 9)",
+        yields: [[1], [2], [3], [4]])
+  }
+}
+
+// MARK: - The NULL corners
+
+struct QuantifiedNullCornerTests {
+  @Test func `a NULL operand makes a quantified comparison UNKNOWN`() throws {
+    // Row 3's K is NULL, so `NULL < ANY (…)` and `NULL > ALL (…)` are UNKNOWN
+    // (every comparison against NULL is UNKNOWN) — the row is dropped by both.
+    try fixture().empty(
+        "SELECT Id FROM T WHERE K < ANY (SELECT V FROM S WHERE Flag = 1) "
+        + "AND Id = 3")
+    try fixture().empty(
+        "SELECT Id FROM T WHERE K > ALL (SELECT V FROM S WHERE Flag = 1) "
+        + "AND Id = 3")
+  }
+
+  @Test func `ANY over a NULL element still finds a definite witness`() throws {
+    // N.V is {2, NULL}; `10 > ANY (SELECT V FROM N)` finds the definite
+    // `10 > 2` TRUE — a TRUE witness dominates the UNKNOWN from the NULL
+    // element — so the row survives.
+    try fixture().expect(
+        "SELECT Id FROM T WHERE 10 > ANY (SELECT V FROM N) AND Id = 1",
+        yields: [[1]])
+  }
+
+  @Test func `ANY over a NULL element with no witness is UNKNOWN`() throws {
+    // `1 > ANY (SELECT V FROM N)` is `1 > 2 OR 1 > NULL` — FALSE OR UNKNOWN —
+    // which is UNKNOWN, not FALSE: the row is not admitted (the same NULL-OR
+    // corner the value-list `IN` has).
+    try fixture().empty(
+        "SELECT Id FROM T WHERE 1 > ANY (SELECT V FROM N) AND Id = 1")
+  }
+
+  @Test func `ALL over a NULL element with no false is UNKNOWN`() throws {
+    // `10 > ALL (SELECT V FROM N)` is `10 > 2 AND 10 > NULL` — TRUE AND UNKNOWN
+    // — which is UNKNOWN, not TRUE: no definite FALSE settles it, so the NULL
+    // leaves it undecided and the row is dropped (the `NOT IN (…NULL…)` trap
+    // generalised to `> ALL`).
+    try fixture().empty(
+        "SELECT Id FROM T WHERE 10 > ALL (SELECT V FROM N) AND Id = 1")
+  }
+
+  @Test func `ALL over a NULL element with a definite false is FALSE`() throws {
+    // `1 > ALL (SELECT V FROM N)` is `1 > 2 AND 1 > NULL` — a definite FALSE
+    // (`1 > 2`) dominates the UNKNOWN under Kleene AND — so it is FALSE and the
+    // row is dropped, exactly as a run does.
+    try fixture().empty(
+        "SELECT Id FROM T WHERE 1 > ALL (SELECT V FROM N) AND Id = 1")
+  }
+}
+
+// MARK: - Arity
+
+struct QuantifiedArityTests {
+  @Test func `a two-column quantified subquery faults at compile`() throws {
+    // A quantified comparison requires its subquery project exactly ONE column;
+    // a two-column subquery is `SQLError.arity`, checked from the compiled
+    // width, so it faults even though S has rows — reusing IN's arity check.
+    try fixture().expect(
+        "SELECT Id FROM T WHERE K < ANY (SELECT V, Flag FROM S)",
+        fails: .arity(1, 2))
+  }
+
+  @Test func `a two-column quantified subquery faults the schema check too`()
+      throws {
+    // The schema path enforces the SAME single-column arity as the run.
+    let query = try parse(
+        query: "SELECT Id FROM T WHERE K < ANY (SELECT V, Flag FROM S)")
+    let resolve = { () throws -> Array<OutputColumn> in
+      try fixture().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.arity(1, 2)) {
+      try resolve()
+    }
+  }
+}
+
+// MARK: - Type checking
+
+struct QuantifiedTypeTests {
+  @Test func `columns validates a quantified query matching the run`() throws {
+    let query = try parse(
+        query: "SELECT Id FROM T WHERE K < ANY (SELECT V FROM S)")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+  }
+
+  @Test func `a bad inner column faults the schema check`() throws {
+    // The inner query is type-checked too, so an unknown column inside it
+    // faults validation exactly as a run would reject it.
+    let query = try parse(
+        query: "SELECT Id FROM T WHERE K > ALL (SELECT Missing FROM S)")
+    let resolve = { () throws -> Array<OutputColumn> in
+      try fixture().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.column("Missing")) {
+      try resolve()
+    }
+  }
+}


### PR DESCRIPTION
Add the uncorrelated quantified comparison subquery `x op {ANY | SOME | ALL} (Q)`, the last slice of the subquery arc, over any comparison operator `= <> < <= > >=`.

Reuse the merged `IN (Q)` materialise-once machinery: a new `Predicate.quantified` / `Filter.quantified` occurrence is collected as a `.valued` role, so its single column is materialised ONCE per outer-query execution against the borrowed catalog and the fold reads it as escapable data — the operand evaluated once per row, its single-column arity enforced at COMPILE from the compiled width, and typecheck resolving and widthing exactly as run.

The three-valued semantics reuse the SAME `matches`/Kleene `and`/`or` primitives `within` uses, not a hand-rolled NULL rule: `any` folds `x op v` under Kleene `OR` seeded FALSE (TRUE at the first TRUE, else UNKNOWN through a NULL `x` or element, else FALSE) and `all` under Kleene `AND` seeded TRUE (FALSE at the first FALSE, else UNKNOWN, else TRUE). An empty subquery takes the fold's identity — `ANY` FALSE, `ALL` TRUE — so `= ANY` is `IN` and `<> ALL` is `NOT IN`, kept a distinct case for the general operator. `SOME` is a synonym for `ANY`, normalised at parse time.

Correlated quantified comparison is deferred to the correlation branch; a correlated column resolves or faults as it does today.