### PR TITLE
SQLEngine: accept correlated subqueries

### DIFF
--- a/Sources/SQLEngine/Definition.swift
+++ b/Sources/SQLEngine/Definition.swift
@@ -412,7 +412,7 @@ extension Catalog where Self: ~Escapable {
       // walk validates the body's nested subqueries exactly as the run path
       // does (`run` compiles from the same base context).
       if validate {
-        _ = try compile(query, context, visited)
+        _ = try compile(query, context, visited, validate: true)
         try typecheck(query, context, visited: visited)
       }
       captured = []
@@ -561,7 +561,7 @@ extension Catalog where Self: ~Escapable {
       // run and is not advertised here.
       guard let overlay = try? augment(context.scoping([:]), for: view.query,
                                        rows: false),
-          let plan = try? compile(view.query, overlay),
+          let plan = try? compile(view.query, overlay, validate: true),
           plan.width == view.columns.count else { continue }
       // Type the columns from the body's first arm; type-check every arm's
       // REACHABLE operands and calls too — an unknown call or a bad operand in
@@ -572,7 +572,8 @@ extension Catalog where Self: ~Escapable {
       guard (try? typecheck(view.query, overlay,
                             visited: [name.lowercased()])) != nil,
           let resolved = try? columns(of: view.query.first, overlay,
-                                      visited: [name.lowercased()]),
+                                      visited: [name.lowercased()],
+                                      validate: true),
           resolved.count == view.columns.count else { continue }
       for ordinal in view.columns.indices {
         rows.append([.text(name), .text(view.columns[ordinal]),

--- a/Sources/SQLEngine/Engine.swift
+++ b/Sources/SQLEngine/Engine.swift
@@ -143,15 +143,27 @@ extension Catalog where Self: ~Escapable {
     // resolves the whole query below.
     if case let .setop(kind, left, right, all) = query {
       // Validate the whole query (per-arm resolution and the cross-arm arity
-      // check) exactly as a single select does, then run each arm on its own.
-      // `validate: false` — the preflight must not eager-type-check a derived
-      // body a data-dependent filter never reaches (execution faults only on a
-      // REACHED operand), matching the non-derived path.
+      // check) exactly as a single select does, then run each arm on its own —
+      // each arm's `run` threads its OWN lazy subquery box. `validate: false` —
+      // the preflight must not eager-type-check a derived body a data-dependent
+      // filter never reaches (execution faults only on a REACHED operand),
+      // matching the non-derived path.
       _ = try compile(query, context, validate: false)
       let combined = try combine(kind, run(left, context).map(Record.init),
                                  run(right, context).map(Record.init), all)
       return combined.map(\.values)
     }
+    // Thread a fresh LAZY subquery cache — a shared box — through BOTH compile
+    // and execute. The executor's row evaluator runs each nested subquery into
+    // it on first reach (where the borrowing catalog IS in scope; a schema-only
+    // path never reaches it, so opens no cursor): an UNCORRELATED occurrence
+    // runs once and memoises, while a CORRELATED one re-executes per outer row
+    // against the correlated bindings, bypassing the memo. Compile stashes each
+    // CORRELATED occurrence's inner PLAN here (compiled once with its enclosing
+    // scope, so its correlated columns are bound `Term.parameter`s), so the
+    // evaluator re-executes THAT plan rather than recompiling the inner query
+    // with no outer scope.
+    let context = context.resolving(Subqueries())
     // Compile from the un-augmented `context` (idempotently augmented inside
     // `compile`, which reveals the base for a nested subquery) — this query's
     // derived aliases are invisible to a subquery's FROM, and a CTE a
@@ -190,18 +202,18 @@ extension Catalog where Self: ~Escapable {
     // and a REACHED operand still faults at execution).
     let augmented = try augment(context, for: query, rows: true,
                                 validate: false)
+    // Record the caller's overlay under `.caller` so a subquery lowered under
+    // it (even one a pushdown moved INTO a view) re-runs against the caller's
+    // relations, not the view's base. REVEAL the base first — this query's
+    // derived-table aliases are SELECT-scoped, invisible to a subquery's FROM,
+    // while the CTEs and `definition_schema.` store relations a `.caller`
+    // subquery's FROM resolves against are kept, so a subquery `FROM d` reads a
+    // CTE `d` a same-named derived alias shadows rather than the derived rows.
+    // The shared box survives from the un-augmented compile into execution.
+    augmented.subqueries.record(overlay: augmented.revealed().relations,
+                                for: .caller)
     let plan = try optimise(logical, augmented)
-    // Execute every UNCORRELATED subquery the plan nests ONCE here — where the
-    // borrowing catalog IS in scope — and thread the memoised results into the
-    // context the executor reads (never during `compile`, so a schema-only path
-    // opens no cursor). A query with no `EXISTS`/`IN (Q)` builds an empty one.
-    // The subqueries materialise against the un-augmented `context` — this
-    // query's own derived aliases are SELECT-scoped, invisible to a subquery's
-    // FROM (`subqueries(of:)` reveals the base, dropping any enclosing derived
-    // alias but keeping CTEs and store relations), so a CTE a same-named
-    // derived alias shadows stays visible to the subquery.
-    let subqueries = try subqueries(of: query, context)
-    return try execute(plan, augmented.resolving(subqueries)).map(\.values)
+    return try execute(plan, augmented).map(\.values)
   }
 
   /// Runs a `Statement` against this catalog, returning its result rows.
@@ -551,6 +563,12 @@ extension Projection {
   /// select is otherwise the ONE path that would hit the default unsupported
   /// map and reject a subquery a run materialises. The `Subquery` is threaded,
   /// not run, here (see `subquery(of:)`).
+  ///
+  /// A projection is a BARRED clause position, so a correlated column of THIS
+  /// query has no evaluator here. `Schema.terms` bars the seam intrinsically,
+  /// so this FROM-less projection CANNOT admit correlation even when handed the
+  /// admitting `plans.rest` — the same cut `columns(of:)` applies on the schema
+  /// path, keeping run and derive in lockstep.
   internal func scalar(_ routines: Routines = [:],
                        subquery: Subquery = .unsupported)
       throws(SQLError) -> Plan {
@@ -1171,6 +1189,19 @@ extension Select {
     }
     return queries
   }
+
+  /// The `Role`s `query` occupies within this `SELECT` — `scalar`, `valued`,
+  /// and/or `existential` — the SHAPES the lowered nodes carry in their
+  /// `Subkey`. The same inner SQL used in more than one position occupies more
+  /// than one role, so a correlated occurrence's pre-compiled plan is recorded
+  /// under each, matching every lowered node that looks it up.
+  internal func roles(of query: Query) -> Array<Role> {
+    var roles = Array<Role>()
+    if scalar.contains(query) { roles.append(.scalar) }
+    if valued.contains(query) { roles.append(.valued) }
+    if existential.contains(query) { roles.append(.existential) }
+    return roles
+  }
 }
 
 extension Predicate {
@@ -1589,7 +1620,8 @@ extension Catalog where Self: ~Escapable {
                                 _ from: Resolved, _ context: Context,
                                 _ visited: Set<String>,
                                 _ subscope: Subscope = .caller,
-                                validate: Bool = true)
+                                _ outer: Outer? = nil,
+                                validate: Bool)
       throws(SQLError) -> Plan {
     // The augmented `context` threads to `subquery(of:)`, which REVEALS the
     // base — this select's and every enclosing select's derived aliases
@@ -1616,21 +1648,34 @@ extension Catalog where Self: ~Escapable {
     // resolved against only the prefix already in scope (as the non-aggregate
     // path does). A `column = column` conjunct becomes a `match` hash-join key;
     // the rest is a residual the join runs as a filter.
-    // Materialise every UNCORRELATED subquery ONCE, ahead of lowering, into a
-    // map the join ONs, WHERE, HAVING, projection, and ORDER BY read from.
-    let subquery = try subquery(of: select, context, visited, subscope,
-                                validate: validate)
+    // Each join's PREFIX scope — the relations available AT that join point,
+    // never one joined LATER — the scope its `ON` lowers against and a subquery
+    // in that `ON` correlates against.
+    let prefixes = select.joins.indices.map { index in
+      Scope(Array(relations[0 ... index + 1]))
+    }
+    // Compile every nested subquery ONCE for arity/type, ahead of lowering, and
+    // discover each one's CORRELATION: a join `ON`'s against its PREFIX scope,
+    // the WHERE against the join `scope`. Only the WHERE and join ONs admit a
+    // correlated column of THIS query; the aggregations, projection, `HAVING`,
+    // and `ORDER BY` lower under a BARRED seam. `validate` gates the eager
+    // type-check of a filtered-out derived body a nested subquery names, off on
+    // the RUN path, on for a schema check.
+    let plans = try subquery(of: select, context, visited, subscope,
+                             enclosing: scope, outer: outer,
+                             prefixes: prefixes)
+    let barred = plans.rest.barred
     var matches = Array<Filter>()
     matches.reserveCapacity(select.joins.count)
     for index in select.joins.indices {
-      let prefix = Scope(Array(relations[0 ... index + 1]))
       let join = select.joins[index]
-      try matches.append(prefix.on(join.on, context.routines,
-                                   subquery: subquery))
+      try matches.append(prefixes[index].on(join.on, context.routines,
+                                            subquery: plans.on(index)))
     }
     var predicate: Filter? = nil
     if let clause = select.predicate {
-      predicate = try scope.lower(clause, context.routines, subquery: subquery)
+      predicate = try scope.lower(clause, context.routines,
+                                  subquery: plans.rest)
     }
 
     // The `GROUP BY` keys and the aggregate arguments lower to combined
@@ -1668,7 +1713,7 @@ extension Catalog where Self: ~Escapable {
     var aggregations = Array<Aggregation>()
     for expression in expressions {
       let aggregation = try expression.aggregation(scope, context.routines,
-                                                   subquery: subquery)
+                                                   subquery: barred)
       if !aggregations.contains(aggregation) {
         aggregations.append(aggregation)
       }
@@ -1726,15 +1771,15 @@ extension Catalog where Self: ~Escapable {
     // GROUP BY key).
     var grouping = try Grouping(scope, select.grouping, aggregations)
     let projection = try grouping.terms(select.projection, context.routines,
-                                        subquery: subquery)
+                                        subquery: barred)
     let having: Filter? = if let clause = select.having {
-      try grouping.lower(clause, context.routines, subquery: subquery)
+      try grouping.lower(clause, context.routines, subquery: barred)
     } else {
       nil
     }
     var order = if let clause = select.order {
       try grouping.order(clause, projection, context.routines,
-                         subquery: subquery)
+                         subquery: barred)
     } else {
       Array<SortKey>()
     }
@@ -2691,7 +2736,8 @@ extension Catalog where Self: ~Escapable {
                                   _ context: Context = Context(),
                                   _ visited: Set<String> = [],
                                   _ scope: Subscope = .caller,
-                                  validate: Bool = true)
+                                  _ outer: Outer? = nil,
+                                  validate: Bool)
       throws(SQLError) -> Plan {
     // Bind the derived tables (and store relations) THIS query names in its own
     // FROM/JOIN before resolving its relations — SELECT-scoped, so a subquery
@@ -2715,7 +2761,7 @@ extension Catalog where Self: ~Escapable {
     let context = try augment(context, for: query, rows: false,
                               visited: visited, validate: validate)
     guard case let .setop(kind, left, right, all) = query else {
-      return try compile(query.first, context, visited, scope,
+      return try compile(query.first, context, visited, scope, outer,
                          validate: validate)
     }
 
@@ -2737,10 +2783,12 @@ extension Catalog where Self: ~Escapable {
     let width = try arity(query.first, head, visited, validate: validate)
     let count = try arity(right.first, tail, visited, validate: validate)
     guard count == width else { throw .arity(width, count) }
+    // Both arms of a set-operation subquery correlate against the SAME
+    // enclosing scope, so each lowers under the shared `outer`.
     return try .setop(kind,
-                      compile(left, context, visited, scope,
+                      compile(left, context, visited, scope, outer,
                               validate: validate),
-                      compile(right, context, visited, scope,
+                      compile(right, context, visited, scope, outer,
                               validate: validate), all: all)
   }
 
@@ -2763,10 +2811,74 @@ extension Catalog where Self: ~Escapable {
   /// for a top-level compile, `.view(name)` for a view body's — carried into
   /// each lowered `Filter`'s cache key so a view-body occurrence and a
   /// top-level one over the same AST stay distinct entries (see `Subscope`).
+  ///
+  /// `enclosing` is the select's OWN resolution scope — the one its nested
+  /// subqueries CORRELATE against: each nested query compiles under a fresh
+  /// `Outer` extending `outer` (this select's own enclosing scope, when it is
+  /// itself a subquery) with `enclosing` as the nearest scope, so a nested
+  /// query's inner `WHERE` column that binds none of ITS relations resolves
+  /// against the enclosing select (and outward), lowering to a synthetic
+  /// `Term.parameter` and RECORDING the correlation the lowered node carries.
+  /// The returned `Subquery` also carries `outer` so THIS select's own columns
+  /// correlate outward when it is a subquery.
+  ///
+  /// `prefixes`, when supplied, gives the PREFIX scope each join `ON` lowers
+  /// against — the FROM relation and joins `0…index`, never a relation joined
+  /// LATER — so a subquery in join `i`'s `ON` correlates against `prefixes[i]`
+  /// (the relations available AT that join point) rather than the full join
+  /// `enclosing`. A correlated reference to a later-joined relation then binds
+  /// against NONE of the prefix's relations and faults `SQLError.column`,
+  /// matching the DIRECT `ON` resolver, which already uses the prefix scope. A
+  /// non-join surface (WHERE/projection/HAVING/ORDER) correlates against
+  /// `enclosing` as before.
   internal borrowing func subquery(of select: Select, _ context: Context,
                                    _ visited: Set<String>,
                                    _ scope: Subscope = .caller,
-                                   validate: Bool = true)
+                                   enclosing: Scope? = nil, outer: Outer? = nil,
+                                   prefixes: Array<Scope> = [])
+      throws(SQLError) -> Plans {
+    // Resolve each SITE'S subqueries against THAT site's own scope, keyed PER
+    // OCCURRENCE: a join `i`'s `ON` against its PREFIX scope `prefixes[i]` (the
+    // relations available AT that join point), the WHERE/HAVING/projection/ORDER
+    // against the full join `enclosing`. The SAME inner SQL in both an `ON` and
+    // the WHERE is resolved TWICE — each against its own site's scope — so the
+    // WHERE occurrence sees the full scope and reports a genuine ambiguity rather
+    // than reusing the first `ON` occurrence's narrower prefix correlation.
+    var lowerings = Array<Subquery>()
+    lowerings.reserveCapacity(select.joins.count)
+    for index in select.joins.indices {
+      var queries = Array<Query>()
+      select.joins[index].on.collect(subqueries: &queries)
+      let within = index < prefixes.count ? prefixes[index] : enclosing
+      try lowerings.append(subquery(queries, select, context, visited, scope,
+                                    within: within, outer: outer))
+    }
+    var rest = Array<Query>()
+    select.predicate?.collect(subqueries: &rest)
+    select.having?.collect(subqueries: &rest)
+    if case let .expressions(items) = select.projection {
+      for item in items { item.expression.collect(subqueries: &rest) }
+    }
+    for key in select.order?.keys ?? [] {
+      if case let .expression(expression) = key.sort {
+        expression.collect(subqueries: &rest)
+      }
+    }
+    let remainder = try subquery(rest, select, context, visited, scope,
+                                 within: enclosing, outer: outer)
+    return Plans(lowerings, remainder)
+  }
+
+  /// Builds ONE lowering `Subquery` over the directly-nested `queries` of a
+  /// single SITE, resolving each against `within` — the scope THAT site's
+  /// subqueries correlate against (a join `ON`'s prefix, or the full
+  /// `enclosing` for the WHERE/HAVING/projection/ORDER). Each distinct `Query`
+  /// is compiled ONCE here; the SAME inner SQL at a DIFFERENT site is resolved
+  /// by that site's own call, against its own scope.
+  private borrowing func subquery(_ queries: Array<Query>, _ select: Select,
+                                  _ context: Context, _ visited: Set<String>,
+                                  _ scope: Subscope, within: Scope?,
+                                  outer: Outer?)
       throws(SQLError) -> Subquery {
     // A nested subquery's FROM resolves against base tables and enclosing CTEs,
     // NOT the enclosing SELECT's derived-table aliases (SELECT-scoped, unseen
@@ -2776,14 +2888,34 @@ extension Catalog where Self: ~Escapable {
     let context = context.revealed()
     var widths = Dictionary<Query, Int>()
     var types = Dictionary<Query, ValueType>()
-    for query in select.subqueries where widths[query] == nil {
-      // `validate` gates the eager type-check of a derived body THIS subquery
-      // nests: a RUN passes `false` so a filtered-out `FROM (SELECT …) AS d` in
-      // an `EXISTS`/`IN (Q)`/scalar subquery is TRUSTED, not rejected, matching
-      // the outer query; a schema check passes `true`. The type derivation
-      // below is already schema-only lenient (`validate: false`).
-      widths[query] =
-          try compile(query, context, visited, validate: validate).width
+    var correlations = Dictionary<Query, Correlation>()
+    for query in queries where widths[query] == nil {
+      // A fresh `Outer` per nested query — its enclosing scope is THIS select
+      // (nearest, `within`), stacked past this select's own enclosing scope
+      // `outer`. A FROM-less select adds no relations, but it is STILL a scope
+      // FRAME: it pushes an EMPTY `Scope` so correlation DEPTH counts this
+      // level. Its own plan runs over a `single` empty record, so a deeper
+      // reference to the true outer must NOT bind as this frame's `.slot` (an
+      // empty record has no such cell) — the empty frame makes that reference
+      // a grandparent one, resolved `.bound` and threaded through `bindings`,
+      // while a genuinely-immediate correlation to a REAL enclosing FROM (a
+      // non-nil `within`) stays `.slot` as before.
+      let nested = (outer ?? Outer()).nested(under: within ?? Scope([]))
+      // A nested subquery's body derivation is SHAPE ONLY, so ALWAYS lenient
+      // (`validate: false`) — this pass exists to record the subquery's width,
+      // arity, and correlation, never to validate its body. Validation of a
+      // subquery's body (and the derived tables nested within it, at any depth)
+      // is the reachability walk's job: `typecheck(_ select:)` re-derives each
+      // REACHED occurrence's body strictly over `subquery.visited`. Compiling a
+      // derived body THIS subquery nests with `validate: true` here would
+      // eager-type-check it BEFORE the walk decides the subquery is reached —
+      // faulting `WHERE 1 = 0 AND 1 IN (SELECT x FROM (SELECT 1 / 0 …) AS d)`,
+      // whose `IN` a run short-circuits away. Structural faults (a bad inner
+      // relation/column, a UNION arity) still surface — they resolve regardless
+      // of `validate`. The type derivation below is already lenient.
+      let plan = try compile(query, context, visited, scope, nested,
+                             validate: false)
+      widths[query] = plan.width
       // A scalar subquery contributes its single-column output type; a wider or
       // an `EXISTS`/`IN (Q)` subquery still records the FIRST column's type
       // (harmless — only a width-1 scalar occurrence reads it, and the lowering
@@ -2791,108 +2923,56 @@ extension Catalog where Self: ~Escapable {
       // the width compile uses, so it matches what the run advertises.
       types[query] =
           try columns(of: query.first, context, visited: visited,
-                      validate: false).first?.type
-    }
-    return Subquery(scope, widths, types)
-  }
-
-  /// Executes every UNCORRELATED subquery `query` nests ONCE against this
-  /// catalog and `context` — the run-time counterpart of `subquery(of:)` —
-  /// memoising each result under its occurrence `Subkey` (its resolution
-  /// `scope` composed with its `Query`) into a `Subqueries` cache the row
-  /// evaluator reads.
-  ///
-  /// `scope` is the resolution context these subqueries materialise under, so
-  /// the key each writes matches the key its lowered `Filter` reads: `run`
-  /// materialises a top-level query's subqueries under `.caller`; `derive`
-  /// materialises a view body's under `.view(name)`. The two spaces are
-  /// disjoint, so a caller cache and a view-body cache `merged` without either
-  /// overwriting the other (Bug 2).
-  ///
-  /// An `IN (Q)` occurrence (its `Query` in `query.valued`) is materialised in
-  /// FULL — its single column of values IS read. An occurrence ONLY an `EXISTS`
-  /// operand needs no values, so it is materialised as a cardinality PROBE:
-  /// `probe` tests whether the row source yields ANY row WITHOUT evaluating the
-  /// select list or sort keys, so `EXISTS (SELECT 1 / 0 FROM S)` over a
-  /// non-empty `S` is TRUE with no `.divide` (Bug 3), and it honours the
-  /// original `OFFSET`/`FETCH` so a `FETCH FIRST 0 ROWS` or an `OFFSET` past
-  /// the end is EXISTS false. A `Query` used by BOTH is in `valued`, so its
-  /// single full materialisation serves the `EXISTS` occurrence too.
-  ///
-  /// A SCALAR occurrence is NOT materialised here: it collapses LAZILY on the
-  /// first evaluation of its `Term.subquery` (see the evaluator's `.subquery`
-  /// case, which runs `cell(of:)` where the catalog is in scope and memoises
-  /// the result), so a scalar subquery in an unreachable `CASE`/`COALESCE` arm
-  /// never runs and its `.cardinality` or inner fault never fires. The returned
-  /// cache carries an empty scalar memo the evaluator fills on first reach.
-  ///
-  /// This runs at RUN time, where the borrowing catalog IS in scope, NOT during
-  /// `compile` — so a schema-only path never reaches it and opens no cursor. It
-  /// gathers every arm's directly-nested subquery (a set operation's both arms
-  /// read one cache) and runs each DISTINCT `IN`/`EXISTS` `Query` at most ONCE
-  /// per outer-query execution: its result is the same for every outer row
-  /// because the subquery is UNCORRELATED. Each runs under the SAME `context` —
-  /// a nested subquery resolves ITS own inner subqueries through its own `run`,
-  /// so this walk stays one level.
-  ///
-  /// Per-arm SHORT-CIRCUIT laziness for the `IN`/`EXISTS` roles — not running a
-  /// subquery an `AND`/`OR` never reaches — is a follow-up that threads a
-  /// runner to the predicate site; those roles still materialise up front here.
-  internal borrowing func subqueries(of query: Query, _ context: Context,
-                                     _ scope: Subscope = .caller)
-      throws(SQLError) -> Subqueries {
-    // A nested subquery's FROM resolves against base tables and enclosing CTEs,
-    // NOT the enclosing SELECT's derived-table aliases — REVEAL the base
-    // (CTEs/store kept, the derived layers dropped) before running/probing each
-    // subquery, mirroring the compile-path reveal in `subquery(of:)`, so a
-    // `FROM d` naming an outer derived alias faults at run exactly as it does
-    // at `columns(of:)`, while a CTE the alias shadowed is exposed beneath.
-    let context = context.revealed()
-    let valued = query.valued
-    let existential = query.existential
-    var results = Dictionary<Subkey, MaterialisedSubquery>()
-    for nested in query.subqueries {
-      // The SAME inner query can occur in more than one ROLE at once — a
-      // scalar subquery, an `IN` value set, and an `EXISTS` probe over
-      // identical SQL — each needing its OWN materialisation SHAPE under its
-      // OWN key, so a scalar read never hits an `IN`/`EXISTS` entry and vice
-      // versa (the role discriminates the key, see `Role`). Materialise one
-      // entry per role the occurrence appears in, each at most once.
-      //
-      // A SCALAR occurrence is NOT materialised here: it collapses LAZILY, on
-      // the FIRST evaluation of its `Term.subquery` (see the evaluator's
-      // `.subquery` case), memoised under its `(scope, query, .scalar)` key,
-      // so an occurrence in an unreachable `CASE`/`COALESCE` arm never runs —
-      // never throws `.cardinality` or an inner fault. The eager roles below
-      // are the `IN`/`EXISTS` operands a `WHERE`/`ON` is not short-circuited
-      // past.
-      if valued.contains(nested) {
-        // An `IN (Q)` occurrence: materialise the full result — its single
-        // column of values is folded per outer row.
-        let key = Subkey(scope, nested, .valued)
-        if results[key] == nil {
-          results[key] = MaterialisedSubquery(rows: try run(nested, context))
-        }
-      }
-      if existential.contains(nested) {
-        // An `EXISTS (Q)` occurrence: probe cardinality without evaluating the
-        // select list or sort keys, honouring the original `OFFSET`/`FETCH`.
-        let key = Subkey(scope, nested, .existential)
-        if results[key] == nil {
-          results[key] = MaterialisedSubquery(present: try probe(nested,
-                                                                 context))
+                      validate: false, outer: nested).first?.type
+      // The correlation the nested compile discovered — the outer columns its
+      // inner `WHERE`/`ON` named — carried into the lowered subquery node so the
+      // per-outer-row re-execution binds them. Empty for an UNCORRELATED one.
+      correlations[query] = nested.correlation
+      // A CORRELATED occurrence's inner PLAN was just compiled with THIS site's
+      // enclosing scope, so its correlated columns are `Term.parameter`s bound
+      // from the outer row. Stash it into the run path's `context.subqueries`
+      // memo (which survives into execution) so the evaluator RE-EXECUTES this
+      // plan per outer row rather than recompiling the inner query fresh —
+      // which, with no outer scope in hand at eval, would fault on the outer
+      // column. Record it under the occurrence's `PlanKey` — its `Subkey` for
+      // each ROLE this query occupies (scalar / `IN` / `EXISTS`) composed with
+      // the correlation's parameter names — the same identity the lowered node
+      // looks up. The names distinguish two occurrences of IDENTICAL inner SQL
+      // under DIFFERENT outer layouts (two set-operation arms whose correlated
+      // column sits at different ordinals), so each arm's node finds ITS OWN
+      // plan rather than the first arm's. The `existential` role records the
+      // PROBED shape
+      // (`probed`: the cardinality-only rewrite when `probable`, else the full
+      // query) so the per-outer-row EXISTS re-execution tests non-emptiness
+      // WITHOUT evaluating the select list — a `1 / 0` projection never runs —
+      // exactly as the UNCORRELATED EXISTS probes. A schema-only path threads a
+      // throwaway memo, harmless there.
+      if !nested.correlation.isEmpty {
+        for role in select.roles(of: query) {
+          // Recompile the EXISTS probe LENIENTLY (`validate: false`), the SAME
+          // way the `plan` above compiled: this builds the run-time plan a
+          // correlated re-execution reuses, so it must not eager-type-check a
+          // filtered-out projection the per-outer-row probe never evaluates.
+          // The reachability walk validates a REACHED occurrence's probe shape
+          // itself (`typecheck(shape(of: reach), …)`), so validation stays the
+          // walk's, never this shape-deriving pass'.
+          let recorded = try role == .existential
+              ? compile(probed(query), context, visited, scope, nested,
+                        validate: false)
+              : plan
+          // Push selection down into the inner plan as the top-level `run` does
+          // (line ~134), so a correlated re-execution enjoys the same seeks and
+          // join placement. The pushdown's nullability analysis treats a
+          // conjunct carrying a correlated `Term.parameter` as nullable, so it
+          // never rides ahead of a LATER unsafe conjunct the inner `AND` still
+          // owes.
+          context.subqueries.record(plan: try recorded.pushdown(),
+                                    for: Subkey(scope, query, role),
+                                    nested.correlation)
         }
       }
     }
-    // Carry the REVEALED base scope the eager occurrences ran against, keyed
-    // under THIS `scope`, so the LAZY scalar path resolves its inner query
-    // against the SAME base — a CTE a same-named derived alias shadows stays
-    // visible to it, exactly as it does to the eager `EXISTS`/`IN (Q)`
-    // occurrences above. Keying per `scope` keeps a view-body cache's relations
-    // distinct from the caller's when the two are `merged` (the evaluator
-    // threads only the executing plan's overlay, which cannot tell them apart),
-    // so a `.view` scalar reads the view's scope.
-    return Subqueries(results, ScalarMemo(), [scope: context.relations])
+    return Subquery(scope, widths, types, correlations, outer: outer)
   }
 
   /// The single VALUE a SCALAR subquery `query` collapses to against this
@@ -2948,12 +3028,24 @@ extension Catalog where Self: ~Escapable {
   /// operation is materialised in FULL and tested for emptiness — the rewrite
   /// would not preserve its cardinality — which for those shapes evaluates the
   /// select list as a run would anyway.
-  private borrowing func probe(_ query: Query, _ context: Context)
+  internal borrowing func probe(_ query: Query, _ context: Context)
       throws(SQLError) -> Bool {
+    return try !run(probed(query), context).isEmpty
+  }
+
+  /// The cardinality-only shape of `query` an `EXISTS` tests for non-emptiness:
+  /// a `probable` `SELECT`'s probe rewrite (`Select.probe` — its select list
+  /// and `ORDER BY` replaced by a cardinality-preserving target, so a `1 / 0`
+  /// projection never evaluates) and the full `query` otherwise (a `HAVING`
+  /// select, a `DISTINCT`-with-`OFFSET` one, or a set operation, whose empty
+  /// test is not a source-only fact the rewrite preserves). The `probe(_:)` run
+  /// and the CORRELATED `existential` plan both compile/execute THIS shape, so
+  /// a correlated EXISTS probes per outer row as an uncorrelated one does.
+  internal borrowing func probed(_ query: Query) -> Query {
     guard case let .select(select) = query, select.probable else {
-      return try !run(query, context).isEmpty
+      return query
     }
-    return try !run(.select(select.probe), context).isEmpty
+    return .select(select.probe)
   }
 
   /// The number of result columns `select` projects — the extent of a `*` over
@@ -2962,7 +3054,7 @@ extension Catalog where Self: ~Escapable {
   /// consulted first.
   private borrowing func arity(_ select: Select, _ context: Context,
                                _ visited: Set<String>,
-                               validate: Bool = true)
+                               validate: Bool)
       throws(SQLError) -> Int {
     switch select.projection {
     case .all:
@@ -3123,7 +3215,8 @@ extension Catalog where Self: ~Escapable {
                                   _ context: Context = Context(),
                                   _ visited: Set<String> = [],
                                   _ subscope: Subscope = .caller,
-                                  validate: Bool = true)
+                                  _ outer: Outer? = nil,
+                                  validate: Bool)
       throws(SQLError) -> Plan {
     // Bind THIS select's own FROM/JOIN derived tables (and store relations)
     // before resolving its relations — SELECT-scoped, so a select reaching
@@ -3167,10 +3260,17 @@ extension Catalog where Self: ~Escapable {
       // matching run-time cache from `query.subqueries` (which descends the
       // projection), so the subquery is materialised there — `compile` runs it
       // never.
-      let subquery = try subquery(of: select, context, visited, subscope,
-                                  validate: validate)
+      // A FROM-less select adds no relations, so its nested subqueries
+      // correlate against this select's own enclosing scope `outer` unchanged;
+      // and its OWN columns (none but a projected outer reference) correlate
+      // outward through `outer` too. The seam is `plans.rest`; `scalar` (via
+      // `Schema.terms`) BARS it — a projection is a barred clause position — so
+      // a correlated column of THIS query is diagnosed, not lowered to a
+      // `Term.parameter`, matching `columns(of:)`'s schema-path rejection.
+      let plans = try subquery(of: select, context, visited, subscope,
+                               outer: outer)
       return try select.projection.scalar(context.routines,
-                                          subquery: subquery)
+                                          subquery: plans.rest)
     }
     let from = try resolve(relation, context, visited, validate: validate)
 
@@ -3190,22 +3290,30 @@ extension Catalog where Self: ~Escapable {
     // query compiles exactly as before.
     if select.aggregates {
       return try group(select, relation, from, context, visited, subscope,
-                       validate: validate)
+                       outer, validate: validate)
     }
 
     guard !select.joins.isEmpty else {
-      // Materialise every UNCORRELATED subquery ONCE, ahead of lowering, into a
-      // map the WHERE/projection/ORDER BY lowering splices results from.
-      let subquery = try subquery(of: select, context, visited, subscope,
-                                  validate: validate)
+      // Compile every nested subquery ONCE for its arity/type, ahead of
+      // lowering, into a map the WHERE/projection/ORDER BY lowering reads — and
+      // discover each one's CORRELATION against this select's single-relation
+      // scope (`enclosing`). This select's OWN columns correlate outward through
+      // `outer`.
+      let enclosing = Scope([(relation, from.schema)])
+      let plans = try subquery(of: select, context, visited, subscope,
+                               enclosing: enclosing, outer: outer)
       var filter: Filter? = nil
       if let predicate = select.predicate {
         filter = try from.schema.lower(predicate, in: relation,
-                                       context.routines, subquery: subquery)
+                                       context.routines, subquery: plans.rest)
       }
+      // The projection and ORDER BY are BARRED clause positions (only the WHERE
+      // admits a correlated column of THIS query); `terms`/`order` bar the seam
+      // intrinsically, so passing `plans.rest` cannot admit one. A nested
+      // subquery there still lowers with its OWN inner correlation.
       let projection =
           try from.schema.terms(select.projection, in: relation,
-                                context.routines, subquery: subquery)
+                                context.routines, subquery: plans.rest)
 
       // The ORDER BY lowers its keys against the projection: an ordinal or an
       // output-alias key resolves to a select-list item's own term, an ordinary
@@ -3215,7 +3323,7 @@ extension Catalog where Self: ~Escapable {
       if let clause = select.order {
         let names = select.projection.outputs(count: projection.count)
         order = try from.schema.order(clause, in: relation, projection, names,
-                                      context.routines, subquery: subquery)
+                                      context.routines, subquery: plans.rest)
       }
 
       // Under DISTINCT every ORDER BY key must be a select-list value — the
@@ -3268,24 +3376,41 @@ extension Catalog where Self: ~Escapable {
     // inequality or expression equality lowers to a residual the join filters.
     // The WHERE and ORDER lower against the whole chain, which legitimately
     // sees every relation.
-    // Materialise every UNCORRELATED subquery ONCE, ahead of lowering, into a
-    // map the join ONs, WHERE, projection, and ORDER BY splice results from.
-    let subquery = try subquery(of: select, context, visited, subscope,
-                                validate: validate)
+    // Each join's PREFIX scope — the FROM relation and joins `0…index`, the
+    // relations available AT that join point, never one joined LATER — the scope
+    // its `ON` lowers against and a subquery in that `ON` correlates against.
+    let prefixes = select.joins.indices.map { index in
+      Scope(Array(relations[0 ... index + 1]))
+    }
+    // Compile every nested subquery ONCE for arity/type, ahead of lowering,
+    // into a map the join ONs, WHERE, projection, and ORDER BY lowering reads —
+    // and discover each one's CORRELATION. A join `ON`'s subquery correlates
+    // against its PREFIX scope; the WHERE/projection/ORDER against the whole
+    // join `scope`. This select's OWN columns correlate outward through `outer`.
+    // `validate` gates a nested filtered-out derived body's eager type-check.
+    let plans = try subquery(of: select, context, visited, subscope,
+                             enclosing: scope, outer: outer,
+                             prefixes: prefixes)
     var matches = Array<Filter>()
     matches.reserveCapacity(select.joins.count)
     for index in select.joins.indices {
-      let prefix = Scope(Array(relations[0 ... index + 1]))
       let join = select.joins[index]
-      try matches.append(prefix.on(join.on, context.routines,
-                                   subquery: subquery))
+      try matches.append(prefixes[index].on(join.on, context.routines,
+                                            subquery: plans.on(index)))
     }
     var predicate: Filter? = nil
     if let clause = select.predicate {
-      predicate = try scope.lower(clause, context.routines, subquery: subquery)
+      predicate = try scope.lower(clause, context.routines,
+                                  subquery: plans.rest)
     }
+    // The projection and ORDER BY are BARRED clause positions: a correlated
+    // column of THIS query is out of the minimal (b) cut there (only its
+    // WHERE/ON admits one), so `terms`/`order` bar the seam intrinsically and
+    // it is diagnosed rather than mis-resolved. A nested subquery in the
+    // projection still lowers — its OWN inner WHERE correlation was discovered
+    // in the pre-pass.
     let projection = try scope.terms(select.projection, context.routines,
-                                     subquery: subquery)
+                                     subquery: plans.rest)
 
     // The ORDER BY lowers its keys against the projection (as the
     // single-relation path does): an ordinal or an output-alias key resolves to
@@ -3296,7 +3421,7 @@ extension Catalog where Self: ~Escapable {
     if let clause = select.order {
       let names = select.projection.outputs(count: projection.count)
       order = try scope.order(clause, projection, names, context.routines,
-                              subquery: subquery)
+                              subquery: plans.rest)
     }
 
     // Under DISTINCT every ORDER BY key must be a select-list value (see

--- a/Sources/SQLEngine/Filter.swift
+++ b/Sources/SQLEngine/Filter.swift
@@ -79,7 +79,7 @@ internal indirect enum Filter: Equatable, Sendable {
   /// flipping it (never UNKNOWN). It reads no cell of the outer row. An
   /// EXISTS-only occurrence is materialised as a cardinality PROBE — its select
   /// list never evaluated. A later correlated slice re-runs `Q` per outer row.
-  case exists(Subkey, negated: Bool)
+  case exists(Subkey, correlation: Correlation, negated: Bool)
   /// `x [NOT] IN (Q)` — the lowered form of the AST's `within`. The subquery
   /// occurrence is carried as its cache `Subkey` — never run during `compile` —
   /// and its single-column arity is enforced at COMPILE from its compiled width
@@ -91,7 +91,7 @@ internal indirect enum Filter: Equatable, Sendable {
   /// unmatched test UNKNOWN, an EMPTY result FALSE, and `negated` (`NOT IN`)
   /// negating the three-valued result (UNKNOWN maps to itself). The operand
   /// `Term` is evaluated once per row.
-  case within(Term, Subkey, negated: Bool)
+  case within(Term, Subkey, correlation: Correlation, negated: Bool)
   /// `x op {ANY | ALL} (Q)` — the lowered form of the AST's `quantified`. The
   /// operand term `x` is held ONCE, the comparison `op` and the `Quantifier`
   /// beside it, and the subquery occurrence as its cache `Subkey` (its
@@ -104,8 +104,11 @@ internal indirect enum Filter: Equatable, Sendable {
   /// FALSE), Kleene `AND` for `all` (seeded TRUE), so a NULL `x` or element
   /// makes an otherwise-undecided fold UNKNOWN, and an EMPTY column takes the
   /// seed — `any` FALSE, `all` TRUE. The operand `Term` is evaluated once per
-  /// row.
-  case quantified(Term, Comparison, Quantifier, Subkey)
+  /// row. A CORRELATED occurrence carries the discovered `correlation` (as
+  /// `within` does) and re-runs its inner plan per outer row; an UNCORRELATED
+  /// one carries an empty correlation and memoises once.
+  case quantified(Term, Comparison, Quantifier, Subkey,
+                  correlation: Correlation)
   /// `p IS [NOT] <truth value>` — the lowered form of the AST's `truth`. The
   /// inner boolean `Filter` is held once and evaluated to its three-valued
   /// result, which is then MAPPED against `value` (`TRUE`/`FALSE`/`UNKNOWN`) to
@@ -147,6 +150,14 @@ internal indirect enum Filter: Equatable, Sendable {
 internal indirect enum Term: Equatable, Sendable {
   /// The cell at `slot` of the record.
   case slot(Int)
+  /// A run-time `:parameter`, resolved from the engine's bindings — the lowered
+  /// form of a CORRELATED subquery's reference to an ENCLOSING query's column.
+  /// An outer column the inner query names binds neither locally nor as an
+  /// ordinary parameter; it lowers to this synthetic name, and the per-outer-row
+  /// re-execution binds it to that row's cell before running the inner plan (see
+  /// `Correlation`). An unbound name (or one bound to NULL) reads `.null`, so a
+  /// comparison against it is UNKNOWN, exactly as a `Filter.bound` operand is.
+  case parameter(String)
   /// A constant value.
   case constant(Value)
   /// A call to the named scalar function over its argument terms, in order.
@@ -196,7 +207,7 @@ internal indirect enum Term: Equatable, Sendable {
   /// value, COERCED to `type` — the inner column's single-column type — as a
   /// `CASE` coerces its selected arm. A later correlated slice re-runs it per
   /// outer row.
-  case subquery(Subkey, type: ValueType)
+  case subquery(Subkey, correlation: Correlation, type: ValueType)
 }
 
 extension Term {
@@ -212,6 +223,8 @@ extension Term {
   internal static func ==(lhs: Term, rhs: Term) -> Bool {
     switch (lhs, rhs) {
     case let (.slot(lhs), .slot(rhs)):
+      lhs == rhs
+    case let (.parameter(lhs), .parameter(rhs)):
       lhs == rhs
     case let (.constant(lhs), .constant(rhs)):
       lhs == rhs
@@ -232,8 +245,8 @@ extension Term {
       lelems == relems && ltype == rtype
     case let (.nullif(ll, lr), .nullif(rl, rr)):
       ll == rl && lr == rr
-    case let (.subquery(lkey, ltype), .subquery(rkey, rtype)):
-      lkey == rkey && ltype == rtype
+    case let (.subquery(lkey, lcorr, ltype), .subquery(rkey, rcorr, rtype)):
+      lkey == rkey && lcorr == rcorr && ltype == rtype
     default:
       false
     }
@@ -248,6 +261,11 @@ extension Term {
     switch self {
     case let .slot(slot):
       slots.insert(slot)
+    case .parameter:
+      // A correlated `:parameter` reads no cell of THIS row — its value comes
+      // from an enclosing row bound into the run's bindings — so it references
+      // no slot of the current record.
+      break
     case .constant:
       break
     case let .apply(_, arguments):
@@ -272,10 +290,14 @@ extension Term {
     case let .nullif(lhs, rhs):
       lhs.references(into: &slots)
       rhs.references(into: &slots)
-    case .subquery:
-      // An UNCORRELATED scalar subquery reads no cell of the outer row — its
-      // value is materialised once from the cache — so it references no slot.
-      break
+    case let .subquery(_, correlation, _):
+      // A CORRELATED scalar subquery reads the enclosing row's cells its inner
+      // `WHERE` names — the correlation's `slot` outer ordinals — so those must
+      // be materialised into the outer record for the per-row re-execution to
+      // bind them. A `bound` source is a threaded binding, not an outer cell, so
+      // it references none. An UNCORRELATED one (empty correlation) references
+      // none — its value is a single cache lookup.
+      slots.formUnion(correlation.slots)
     }
   }
 }
@@ -288,6 +310,10 @@ extension Term {
     switch self {
     case let .slot(ordinal):
       .slot(slot[ordinal]!)
+    case .parameter:
+      // A correlated `:parameter` reads the bindings, not a slot, so the
+      // ordinal-to-slot remap leaves it unchanged.
+      self
     case .constant:
       self
     case let .apply(name, arguments):
@@ -305,9 +331,13 @@ extension Term {
       .coalesce(elements.map { $0.remapped(through: slot) }, type: type)
     case let .nullif(lhs, rhs):
       .nullif(lhs.remapped(through: slot), rhs.remapped(through: slot))
-    case .subquery:
-      // A scalar subquery reads no ordinal (uncorrelated), so it is unchanged.
-      self
+    case let .subquery(key, correlation, type):
+      // A CORRELATED scalar subquery's correlation reads OUTER ordinals; remap
+      // each `slot` to its packed slot so the per-row re-execution reads the
+      // outer record's cell (a `bound` source is unchanged — it reads a threaded
+      // binding). An UNCORRELATED one has an empty map and is unchanged.
+      .subquery(key, correlation: correlation.remapped(through: slot),
+                type: type)
     }
   }
 
@@ -318,8 +348,35 @@ extension Term {
   /// is NOT known safe, whatever its operands.
   internal var safe: Bool {
     switch self {
-    case .slot, .constant: true
+    // A `:parameter` is a bindings lookup, never a fault — safe, as
+    // `Filter.Operand.parameter` is.
+    case .slot, .parameter, .constant: true
     case .apply, .binary, .case, .cast, .coalesce, .nullif, .subquery: false
+    }
+  }
+
+  /// Whether this term reads a run-time `:parameter` anywhere — a CORRELATED
+  /// subquery's synthetic outer binding, which may be unbound or bound to NULL,
+  /// so a comparison over it can be UNKNOWN even when it reads NO slot. Selection
+  /// pushdown reads this (through `Filter.nullable`) so a `.compare`/`.null` over
+  /// a correlated `:parameter` — a slotless `outer_id = 1` — is not moved ahead
+  /// of a later unsafe conjunct the non-short-circuiting `AND` still owes, the
+  /// same treatment a `Filter.bound` parameter already gets.
+  internal var parameterised: Bool {
+    switch self {
+    case .parameter: true
+    case .slot, .constant: false
+    case let .apply(_, arguments): arguments.contains(where: \.parameterised)
+    case let .binary(_, lhs, rhs): lhs.parameterised || rhs.parameterised
+    case let .case(branches, otherwise, _):
+      branches.contains { $0.0.parameterised || $0.1.parameterised }
+          || (otherwise?.parameterised ?? false)
+    case let .cast(operand, _): operand.parameterised
+    case let .coalesce(elements, _): elements.contains(where: \.parameterised)
+    case let .nullif(lhs, rhs): lhs.parameterised || rhs.parameterised
+    // A scalar `.subquery` carries its correlation on the `Filter` side and is
+    // never `safe`, so it stays un-pushed regardless; report false here.
+    case .subquery: false
     }
   }
 
@@ -377,13 +434,14 @@ extension Filter.Operand {
   }
 
   /// Whether this operand reads a run-time `:parameter` — a `.parameter` is
-  /// one (it may be unbound or bound to NULL, so a `LIKE` over it is UNKNOWN);
-  /// a `.term` is not, a `Term` carrying no parameter of its own. `Filter.like`
-  /// folds this over its pattern and escape so a parameterised `LIKE` stays off
-  /// a pushdown below a later unsafe conjunct (see `Filter.nullable`).
+  /// one (it may be unbound or bound to NULL, so a `LIKE` over it is UNKNOWN),
+  /// and a `.term` is one when its `Term` itself carries a correlated
+  /// `Term.parameter`. `Filter.like` folds this over its pattern and escape so a
+  /// parameterised `LIKE` stays off a pushdown below a later unsafe conjunct
+  /// (see `Filter.nullable`).
   internal var parameterised: Bool {
     switch self {
-    case .term: false
+    case let .term(term): term.parameterised
     case .parameter: true
     }
   }
@@ -416,18 +474,26 @@ extension Filter {
     case let .distinct(lhs, rhs, negated):
       .distinct(lhs.remapped(through: slot), rhs.remapped(through: slot),
                 negated: negated)
-    case let .exists(key, negated):
-      // An UNCORRELATED EXISTS reads no outer slot — its subquery names no
-      // enclosing column — so the remap passes its cache key through unchanged.
-      .exists(key, negated: negated)
-    case let .within(operand, key, negated):
-      // Only the outer operand term reads slots; the subquery is uncorrelated,
-      // so remap the operand alone and carry the cache key through.
-      .within(operand.remapped(through: slot), key, negated: negated)
-    case let .quantified(operand, op, quantifier, key):
-      // As `within`: only the outer operand reads slots; the uncorrelated
-      // subquery's cache key passes through unchanged.
-      .quantified(operand.remapped(through: slot), op, quantifier, key)
+    case let .exists(key, correlation, negated):
+      // A CORRELATED EXISTS reads the enclosing row's cells its inner `WHERE`
+      // names; remap each `slot` outer ordinal to its packed slot (a `bound`
+      // source is unchanged). An UNCORRELATED one has an empty map and passes its
+      // cache key through unchanged.
+      .exists(key, correlation: correlation.remapped(through: slot),
+              negated: negated)
+    case let .within(operand, key, correlation, negated):
+      // The outer operand term reads slots; a CORRELATED subquery ALSO reads the
+      // outer cells its inner `WHERE` names, so remap both. An UNCORRELATED one
+      // carries an empty correlation.
+      .within(operand.remapped(through: slot), key,
+              correlation: correlation.remapped(through: slot),
+              negated: negated)
+    case let .quantified(operand, op, quantifier, key, correlation):
+      // As `within`: the outer operand term reads slots; a CORRELATED subquery
+      // ALSO reads the outer cells its inner `WHERE` names, so remap both. An
+      // UNCORRELATED one carries an empty correlation.
+      .quantified(operand.remapped(through: slot), op, quantifier, key,
+                  correlation: correlation.remapped(through: slot))
     case let .truth(inner, value, negated):
       .truth(inner.remapped(through: slot), value, negated: negated)
     case let .and(lhs, rhs):
@@ -519,19 +585,17 @@ extension Filter {
     case let .between(test, lower, upper, _):
       test.safe && lower.safe && upper.safe
     case let .distinct(lhs, rhs, _): lhs.safe && rhs.safe
-    case .exists:
-      // An UNCORRELATED EXISTS reads no outer row — its subquery ran once at run
-      // start into the memo — so evaluating it is a decided lookup that cannot
-      // throw over an empty product.
-      true
-    case let .within(operand, _, _):
-      // Only the outer operand term is evaluated; the subquery's memoised
-      // values are folded under `matches`, which never throws.
-      operand.safe
-    case let .quantified(operand, _, _, _):
-      // As `within`: only the outer operand is evaluated, the memoised values
-      // folded under `matches`, which never throws.
-      operand.safe
+    case .exists, .within, .quantified:
+      // A subquery predicate is NEVER safe to push below a seek or short-
+      // circuiting derived/view filter. Under LAZY materialisation the FIRST
+      // evaluation of even an UNCORRELATED occurrence RUNS the inner query,
+      // which may FAULT (`EXISTS (SELECT 1 FROM S WHERE 1 / z = 0)`); a
+      // CORRELATED one re-runs per outer row. Pushed below a short-circuiting
+      // filter — a view's `WHERE 1 = 0`, a seek — it would be evaluated for a
+      // row the filter drops, raising a throw the unmoved query never reaches,
+      // so it stays at the product level, run only where the outer predicate
+      // reaches it.
+      false
     case let .truth(inner, _, _): inner.safe
     case let .and(lhs, rhs): lhs.safe && rhs.safe
     case let .or(lhs, rhs): lhs.safe && rhs.safe
@@ -585,24 +649,41 @@ extension Filter {
   }
 
   /// Whether this filter compares against a run-time `:parameter` — a `.bound`
-  /// anywhere in it, a `.like` whose pattern or escape operand is a
-  /// `:parameter`, or a `.between` whose lower or upper bound is one. Such a
-  /// predicate reads no slot yet can be UNKNOWN, because the parameter may be
-  /// unbound (or bound to NULL), so `nullable` counts it even when `slots` is
-  /// empty — keeping `'x' LIKE :p` or `1 BETWEEN :lo AND :hi` off a pushdown
-  /// below a later unsafe conjunct the non-short-circuiting `AND` still owes.
-  private var parameterised: Bool {
+  /// anywhere in it, a `.compare`/`.null`/`.membership`/`.distinct` whose TERM
+  /// carries a `Term.parameter` (a CORRELATED subquery's synthetic outer
+  /// binding), a `.like` whose pattern or escape operand is a `:parameter`, or a
+  /// `.between` whose test or bound carries one. Such a predicate reads no slot
+  /// yet can be UNKNOWN, because the parameter may be unbound (or bound to
+  /// NULL), so `nullable` counts it even when `slots` is empty — keeping `'x'
+  /// LIKE :p`, `1 BETWEEN :lo AND :hi`, or a correlated slotless `outer_id = 1`
+  /// off a pushdown below a later unsafe conjunct the non-short-circuiting `AND`
+  /// still owes.
+  ///
+  /// `internal` (not `private`) so `Term.parameterised` can consult a `.case`
+  /// guard `Filter` for a correlated `:parameter`.
+  internal var parameterised: Bool {
     switch self {
     case .bound: true
-    case .compare, .match, .null, .membership, .distinct: false
+    // A term-bearing predicate is parameterised when a TERM carries a correlated
+    // `Term.parameter` — a slotless comparison that can be UNKNOWN, so it must
+    // not ride ahead of a later unsafe conjunct, the same treatment `.bound`
+    // gets.
+    case let .compare(lhs, _, rhs): lhs.parameterised || rhs.parameterised
+    case let .null(term, _): term.parameterised
+    case let .membership(operand, elements, _):
+      operand.parameterised || elements.contains(where: \.parameterised)
+    case let .distinct(lhs, rhs, _): lhs.parameterised || rhs.parameterised
+    case .match: false
     // An UNCORRELATED subquery predicate reads no run-time `:parameter` of the
     // OUTER query — the subquery runs once at run start with the same bindings —
-    // so none is parameterised for the outer row.
+    // so none is parameterised for the outer row. A CORRELATED one is already
+    // NOT `safe` (it re-runs per row), so it never rides a pushdown regardless.
     case .exists, .within, .quantified: false
-    case let .like(_, pattern, escape, _):
-      pattern.parameterised || (escape?.parameterised ?? false)
-    case let .between(_, lower, upper, _):
-      lower.parameterised || upper.parameterised
+    case let .like(operand, pattern, escape, _):
+      operand.parameterised || pattern.parameterised
+          || (escape?.parameterised ?? false)
+    case let .between(test, lower, upper, _):
+      test.parameterised || lower.parameterised || upper.parameterised
     case let .truth(inner, _, _): inner.parameterised
     case let .and(lhs, rhs): lhs.parameterised || rhs.parameterised
     case let .or(lhs, rhs): lhs.parameterised || rhs.parameterised
@@ -676,6 +757,12 @@ extension Catalog where Self: ~Escapable {
     switch term {
     case let .slot(slot):
       row[slot]
+    case let .parameter(name):
+      // A correlated `:parameter` reads its value from the bindings — the
+      // enclosing row's cell, merged in by the per-outer-row re-execution. An
+      // unbound name reads `.null` (a comparison against it is UNKNOWN), exactly
+      // as a `Filter.bound` operand resolves an absent parameter.
+      bindings[name] ?? .null
     case let .constant(value):
       value
     case let .apply(name, arguments):
@@ -709,13 +796,170 @@ extension Catalog where Self: ~Escapable {
                    subqueries)
     case let .nullif(lhs, rhs):
       try nullif(row, lhs, rhs, relations, routines, bindings, subqueries)
-    case let .subquery(key, type):
+    case let .subquery(key, correlation, type):
       // Materialise the scalar subquery LAZILY on this first reach — an
       // occurrence in a skipped `CASE`/`COALESCE` arm is never reached, so it
       // never runs (never throws). COERCE the collapsed value to the inner
-      // column's type, as a `CASE` coerces its selected arm.
-      try scalar(key, type, relations, routines, bindings, subqueries)
+      // column's type, as a `CASE` coerces its selected arm. An UNCORRELATED one
+      // memoises; a CORRELATED one re-runs against this row's correlated
+      // bindings.
+      try scalar(row, key, correlation, type, relations, routines, bindings,
+                 subqueries)
     }
+  }
+
+  /// The `bindings` extended with `correlation`'s outer cells — a `slot` entry
+  /// bound to the cell at that packed ordinal of the IMMEDIATE enclosing `row`,
+  /// a `bound` entry left as the incoming binding the CONTAINING subquery
+  /// already threaded down (a NESTED correlation to a grandparent column) — the
+  /// per-outer-row binding a CORRELATED subquery re-executes under. An
+  /// UNCORRELATED occurrence has an empty correlation, so this returns the
+  /// bindings unchanged.
+  private borrowing func correlated(_ row: borrowing some Row & ~Escapable,
+                                    _ correlation: Correlation,
+                                    _ bindings: Bindings) -> Bindings {
+    guard !correlation.isEmpty else { return bindings }
+    var extended = bindings
+    for (name, source) in correlation {
+      // A `bound` source is already in `bindings` (threaded by the containing
+      // subquery), so it passes through unchanged; only a `slot` reads this
+      // subquery's immediate enclosing row.
+      if case let .slot(slot) = source { extended[name] = row[slot] }
+    }
+    return extended
+  }
+
+  /// The rows a CORRELATED subquery occurrence `key` yields for `row` — the
+  /// SINGLE augment-and-execute path every correlated caller (`present`,
+  /// `values`, `scalar`) routes through, so none can skip the augmentation or
+  /// the per-row overlay. It extends `bindings` with this row's correlated
+  /// values, builds the execution context from the occurrence's scope overlay
+  /// AUGMENTED with the subquery's OWN `WITH`/derived-table rows, looks up the
+  /// PRE-COMPILED plan, and executes it.
+  ///
+  /// The precompiled plan resolves a `WITH` item or a derived table `d` — `FROM
+  /// (SELECT …) AS d` — to a `.scan("d")` the executor binds by NAME from
+  /// `context.relations`, so the rows must be MATERIALISED into the overlay
+  /// first, exactly as the UNCORRELATED `run`/`probe`/`cell` path augments the
+  /// query before running it. Without this the `.scan("d")` faults
+  /// `SQLError.relation("d")` (or mis-binds an outer relation of the same
+  /// name). Augmenting on top of the per-row overlay PRESERVES both the
+  /// correlation bindings and the parent overlay: `augment` only ADDS this
+  /// query's own aliases, and `validate: false` matches the lenient run path (a
+  /// REACHED body operand still faults at execution).
+  ///
+  /// A SET OPERATION binds NO derived alias at the query level — its arms are
+  /// SELECT-scoped, each `FROM (SELECT …) AS d` local to its own arm — so a
+  /// whole-query augment misses them and an arm's `.scan("d")` would fault
+  /// `.relation("d")`. When the plan is a set operation this descends the plan
+  /// and query in lockstep and augments EACH ARM's own aliases before executing
+  /// that arm's sub-plan, exactly as the run and view setop paths do, while the
+  /// correlation bindings and parent overlay ride into every arm through the
+  /// shared `context`.
+  private borrowing func executed(_ row: borrowing some Row & ~Escapable,
+                                  _ key: Subkey, _ correlation: Correlation,
+                                  _ overlay: ScopedRelations,
+                                  _ routines: Routines, _ bindings: Bindings,
+                                  _ subqueries: Subqueries)
+      throws(SQLError) -> Array<Record> {
+    let bindings = correlated(row, correlation, bindings)
+    let context = Context(relations: overlay, routines: routines,
+                          bindings: bindings, subqueries: subqueries)
+    guard let plan = subqueries.plan(key, correlation) else {
+      throw .named("a correlated subquery plan was not compiled")
+    }
+    // A SET-OPERATION plan augments PER ARM (arm-local derived aliases the
+    // query-level augment misses); a single plan augments the whole query once.
+    if case .setop = plan {
+      return try arms(plan, key.query, context)
+    }
+    let augmented =
+        try augment(context, for: key.query, rows: true, validate: false)
+    return try execute(plan, augmented)
+  }
+
+  /// Executes a correlated subquery's SET-OPERATION `plan` arm by arm — the
+  /// plan and its `query` descend in lockstep (compile builds `.setop(kind,
+  /// compile(left), compile(right), all)` from `.setop(kind, left, right,
+  /// all)`), a `.setop` node recursing into both arms and `combine`-ing the
+  /// results and a LEAF arm augmenting THAT arm's own derived aliases into
+  /// `context` (rows, so its `.scan` reads them) before executing its sub-plan.
+  ///
+  /// `context` already carries the per-row correlation bindings and the parent
+  /// overlay, so each arm's augment ADDS only that arm's aliases and every arm
+  /// runs under the same correlated bindings — mirroring the run and view setop
+  /// per-arm augmentation for the correlated shape. Executing the arm sub-plans
+  /// (not re-running the arm queries) preserves any pushed conjunct in the arm
+  /// plan; `validate: false` keeps a data-dependent-empty arm body lenient, as
+  /// the run path is.
+  private borrowing func arms(_ plan: Plan, _ query: Query, _ context: Context)
+      throws(SQLError) -> Array<Record> {
+    if case let .setop(kind, left, right, all) = plan,
+        case let .setop(_, leftQuery, rightQuery, _) = query {
+      return try combine(kind, arms(left, leftQuery, context),
+                         arms(right, rightQuery, context), all)
+    }
+    let augmented =
+        try augment(context, for: query, rows: true, validate: false)
+    return try execute(plan, augmented)
+  }
+
+  /// The `EXISTS` non-empty result of the occurrence `key`, run LAZILY: an
+  /// UNCORRELATED one (empty `correlation`) reads the memo and, on a miss, probes
+  /// once and stores it; a CORRELATED one re-probes per outer row against the
+  /// correlated bindings, never touching the memo.
+  private borrowing func present(_ row: borrowing some Row & ~Escapable,
+                                 _ key: Subkey, _ correlation: Correlation,
+                                 _ relations: ScopedRelations,
+                                 _ routines: Routines, _ bindings: Bindings,
+                                 _ subqueries: Subqueries)
+      throws(SQLError) -> Bool {
+    // Run under the overlay the occurrence's SCOPE was lowered under — the
+    // caller's or the view body's — not the current execution site a pushdown
+    // may have moved this predicate to.
+    let overlay = subqueries.overlay(key.scope) ?? relations
+    // A CORRELATED EXISTS re-executes its PRE-COMPILED PROBE plan (correlated
+    // columns are bound `Term.parameter`s; the plan is the cardinality-only
+    // probed shape, so its select list — a would-fault `1 / 0` — never runs)
+    // against this row's correlated bindings, testing non-empty — bypassing the
+    // memo (the result depends on the row). An UNCORRELATED one memoises and
+    // probes cardinality once, the SAME probed shape.
+    guard correlation.isEmpty else {
+      return try !executed(row, key, correlation, overlay, routines, bindings,
+                           subqueries).isEmpty
+    }
+    let context = Context(relations: overlay, routines: routines,
+                          bindings: bindings, subqueries: subqueries)
+    if let cached = subqueries.present(cached: key) { return cached }
+    let present = try probe(key.query, context)
+    subqueries.store(present: present, for: key)
+    return present
+  }
+
+  /// The `IN (Q)` single column of the occurrence `key`, materialised LAZILY: an
+  /// UNCORRELATED one reads the memo and, on a miss, runs the inner query once
+  /// and stores its lone column; a CORRELATED one re-runs per outer row against
+  /// the correlated bindings, bypassing the memo.
+  private borrowing func values(_ row: borrowing some Row & ~Escapable,
+                                _ key: Subkey, _ correlation: Correlation,
+                                _ relations: ScopedRelations,
+                                _ routines: Routines, _ bindings: Bindings,
+                                _ subqueries: Subqueries)
+      throws(SQLError) -> Array<Value> {
+    let overlay = subqueries.overlay(key.scope) ?? relations
+    // A CORRELATED `IN (Q)` re-executes its PRE-COMPILED inner plan against this
+    // row's correlated bindings for its lone column, bypassing the memo. An
+    // UNCORRELATED one memoises and re-runs its `Query` (recompiling resolves).
+    guard correlation.isEmpty else {
+      return try executed(row, key, correlation, overlay, routines, bindings,
+                          subqueries).map { $0.values[0] }
+    }
+    let context = Context(relations: overlay, routines: routines,
+                          bindings: bindings, subqueries: subqueries)
+    if let cached = subqueries.values(cached: key) { return cached }
+    let values = try run(key.query, context).map { $0[0] }
+    subqueries.store(values: values, for: key)
+    return values
   }
 
   /// The value of a scalar subquery occurrence `key`, materialised LAZILY and
@@ -727,30 +971,30 @@ extension Catalog where Self: ~Escapable {
   /// The subquery is UNCORRELATED, so its value is row-invariant — one run per
   /// REACHED occurrence, none for one only in a skipped arm. The value is
   /// COERCED to the inner column's `type`, as a `CASE` coerces its taken arm.
-  private borrowing func scalar(_ key: Subkey, _ type: ValueType,
+  private borrowing func scalar(_ row: borrowing some Row & ~Escapable,
+                                _ key: Subkey, _ correlation: Correlation,
+                                _ type: ValueType,
                                 _ relations: ScopedRelations,
                                 _ routines: Routines, _ bindings: Bindings,
                                 _ subqueries: Subqueries)
       throws(SQLError) -> Value {
+    let overlay = subqueries.overlay(key.scope) ?? relations
+    // A CORRELATED scalar subquery re-executes its PRE-COMPILED inner plan per
+    // outer row against the correlated bindings, collapsing to its lone cell
+    // (empty → NULL, one row → the cell, more → `.cardinality`), bypassing the
+    // memo (its cell depends on the row). An UNCORRELATED one memoises and
+    // re-runs its `Query`.
+    guard correlation.isEmpty else {
+      let rows = try executed(row, key, correlation, overlay, routines,
+                              bindings, subqueries)
+      guard rows.count <= 1 else { throw .cardinality }
+      return (rows.first?.values.first ?? .null).coerced(to: type)
+    }
+    let context = Context(relations: overlay, routines: routines,
+                          bindings: bindings, subqueries: subqueries)
     if let cached = subqueries.scalar(cached: key) {
       return cached.coerced(to: type)
     }
-    // Resolve the inner query against the cache's BASE scope for THIS
-    // occurrence's OWN `Subscope` — the one the eager `EXISTS`/`IN (Q)`
-    // occurrences of that scope ran against (the revealed base
-    // `subqueries(of:)` kept), which `cell(of:)` reveals for the scalar's FROM.
-    // Picking the scope by `key.scope` keeps a `.view(name)` scalar reading the
-    // VIEW's relations and a `.caller` scalar the caller's after a `merged`
-    // folds the two — the executor threads only the EXECUTING plan's overlay
-    // down the evaluate tree, which cannot tell a view-body scope from the
-    // caller's, so the per-`Subscope` cache scope carries each. An empty cache
-    // scope (a schema path's bare `Subqueries`) falls back to the threaded
-    // overlay, whose derived layer a `cell(of:)` reveal drops to expose a CTE a
-    // same-named derived alias shadows.
-    let owned = subqueries.relations(key.scope)
-    let scope = owned.isEmpty ? relations : owned
-    let context = Context(relations: scope, routines: routines,
-                          bindings: bindings, subqueries: subqueries)
     let value = try cell(of: key.query, context)
     subqueries.store(scalar: value, for: key)
     return value.coerced(to: type)
@@ -1130,22 +1374,34 @@ extension Catalog where Self: ~Escapable {
     case let .distinct(lhs, rhs, negated):
       try differs(row, lhs, rhs, negated, relations, routines, bindings,
                   subqueries)
-    case let .exists(key, negated):
-      // The subquery ran ONCE at run start (memoised under its `Subkey` in the
-      // cache); this reads the DEFINITE two-valued non-empty test — never
-      // UNKNOWN, and reading no row of the outer relation — `negated` flipping
-      // it. An EXISTS-only occurrence's result is a cardinality probe.
-      try subqueries.present(key) != negated
-    case let .within(operand, key, negated):
-      // Fold `operand = v` over the subquery's memoised single column under the
-      // SAME three-valued membership the value-list `IN` uses.
-      try member(row, operand, subqueries.values(key), negated, relations,
-                 routines, bindings, subqueries)
-    case let .quantified(operand, op, quantifier, key):
-      // Fold `operand op v` over the subquery's memoised single column with the
-      // SAME `matches`/Kleene primitives `within` uses — Kleene `OR` (seeded
-      // FALSE) for `any`, Kleene `AND` (seeded TRUE) for `all`.
-      try quantified(row, operand, op, quantifier, subqueries.values(key),
+    case let .exists(key, correlation, negated):
+      // The DEFINITE two-valued `EXISTS` non-empty test — never UNKNOWN,
+      // `negated` flipping it. The subquery runs LAZILY on this first reach (so
+      // an `EXISTS` a short-circuited `AND`/`OR` or an unreached `CASE` arm
+      // guards never runs): an UNCORRELATED one memoises under its `Subkey`; a
+      // CORRELATED one re-runs against this row's correlated bindings, bypassing
+      // the memo.
+      try present(row, key, correlation, relations, routines, bindings,
+                  subqueries) != negated
+    case let .within(operand, key, correlation, negated):
+      // Fold `operand = v` over the subquery's single column under the SAME
+      // three-valued membership the value-list `IN` uses. The column is
+      // materialised LAZILY on this first reach (an UNCORRELATED one memoised, a
+      // CORRELATED one re-run per row against this row's correlated bindings).
+      try member(row, operand,
+                 values(row, key, correlation, relations, routines, bindings,
+                        subqueries),
+                 negated, relations, routines, bindings, subqueries)
+    case let .quantified(operand, op, quantifier, key, correlation):
+      // Fold `operand op v` over the subquery's single column with the SAME
+      // `matches`/Kleene primitives `within` uses — Kleene `OR` (seeded FALSE)
+      // for `any`, Kleene `AND` (seeded TRUE) for `all`. It materialises its
+      // lone column LAZILY through the SAME `values` path `within` drives: an
+      // UNCORRELATED one memoises under its `Subkey`, a CORRELATED one re-runs
+      // its inner plan per outer row against this row's correlated bindings.
+      try quantified(row, operand, op, quantifier,
+                     values(row, key, correlation, relations, routines,
+                            bindings, subqueries),
                      relations, routines, bindings, subqueries)
     case let .truth(inner, value, negated):
       try tested(evaluate(row, inner, relations, routines, bindings,

--- a/Sources/SQLEngine/Operator.swift
+++ b/Sources/SQLEngine/Operator.swift
@@ -786,6 +786,21 @@ extension Catalog where Self: ~Escapable {
       let visited: Set<String> = [name.lowercased()]
       overlay = try augment(context.scoping([:]), for: view.query, rows: true,
                             visited: visited, validate: false)
+      // Record the view body's OWN overlay under `.view(name)` so its LAZY
+      // subqueries re-run against the view's base relations, while a caller
+      // conjunct PUSHED into this body keeps its `.caller` overlay and re-runs
+      // against the caller's — each subquery resolving in its own textual scope
+      // regardless of the execution site a pushdown lands it at. A view body
+      // may nest `EXISTS`/`IN (Q)`/scalar subqueries its own plan carries,
+      // lowered under `.view(name)` — a DISJOINT id space from the `.caller`
+      // one (see `Subscope`) — so a view-body `EXISTS (SELECT V FROM S)` over
+      // the view's OWN base and a caller's pushed one over a same-named CTE are
+      // SEPARATE occurrences. The row evaluator runs each LAZILY into the SAME
+      // shared memo box `context.subqueries` carries (kept in `overlay` via
+      // `scoping`, which preserves the subqueries), so a view-body occurrence
+      // memoises beside the caller's without either overwriting the other.
+      context.subqueries.record(overlay: overlay.revealed().relations,
+                                for: .view(name.lowercased()))
     }
     let rows: Array<Record>
     if let view = resolve(view: name), case .setop = view.query,
@@ -800,32 +815,17 @@ extension Catalog where Self: ~Escapable {
       // plan — the pushed filter lives in each arm's sub-plan — while the
       // per-arm augment binds the arm-local `d` the whole-body overlay missed.
       //
-      // Its subqueries are resolved PER ARM inside `setop`, not here over the
-      // whole-view overlay: an arm's direct `EXISTS`/`IN (Q)` may name that
-      // arm's arm-local derived alias, so materialising it (running it) demands
-      // the arm's own augment in scope — the whole-view overlay binds no arm
-      // alias, so a whole-view materialise would fault `.relation("d")` before
-      // an arm ever ran. Mirrors the per-arm run and `SELECT *` arity paths.
+      // Its subqueries run PER ARM inside `setop`, not here over the whole-view
+      // overlay: an arm's direct `EXISTS`/`IN (Q)` may name that arm's own arm-
+      // local derived alias, so running it demands the arm's own augment in
+      // scope — the whole-view overlay binds no arm alias, so a whole-view
+      // materialise would fault `.relation("d")` before an arm ever ran.
+      // Mirrors the per-arm run and `SELECT *` arity paths.
       rows = try setop(plan, view.query, overlay, name.lowercased())
     } else {
-      // A single-arm view body may itself nest `EXISTS`/`IN (Q)` predicates
-      // whose subqueries its own compiled plan carries; resolve them ONCE here
-      // — against the view's overlay, where this catalog is in scope — so the
-      // sub-plan's row evaluator reads each result, just as the top-level `run`
-      // resolves a query's own. Materialise them under `.view(name)` — the SAME
-      // scope the body compiled its lowered `Filter`s under — and MERGE with
-      // the caller's cache (keyed `.caller`). The two id spaces are DISJOINT
-      // (see `Subscope`): a view-body `EXISTS (SELECT V FROM S)` over the
-      // view's OWN base `S` and a caller's pushed `EXISTS (SELECT V FROM S)`
-      // over the caller's CTE `S` are the same AST but SEPARATE occurrences, so
-      // each keeps its own result — the pushed caller conjunct reads its
-      // `.caller` entry, the view-body conjunct its `.view` entry — neither
-      // overwriting the other, which a value-keyed merge would.
-      if let view = resolve(view: name) {
-        let inner = try subqueries(of: view.query, overlay,
-                                   .view(name.lowercased()))
-        overlay = overlay.resolving(context.subqueries.merged(inner))
-      }
+      // A single-arm view body's subqueries run LAZILY into the shared memo box
+      // the `overlay` carries (recorded above under `.view(name)`), so the
+      // sub-plan's row evaluator reads each result on first reach.
       rows = try execute(plan, overlay)
     }
     let range = seek ?? 0 ..< rows.count
@@ -848,29 +848,17 @@ extension Catalog where Self: ~Escapable {
   /// overlay omitted; and each arm's `d` stays scoped to its arm (two arms may
   /// reuse `d`).
   ///
-  /// A leaf arm's DIRECT `EXISTS`/`IN (Q)` subqueries are materialised here
-  /// too, against the arm-local augmented scope and MERGED into it under
+  /// A leaf arm's DIRECT `EXISTS`/`IN (Q)`/scalar subqueries run LAZILY into
+  /// the shared memo box `overlay.subqueries` carries, lowered under
   /// `.view(name)` — the same scope the arm sub-plan's lowered `Filter`s
-  /// compiled under — so an arm subquery naming that arm's arm-local derived
-  /// alias resolves. The whole-view overlay binds no arm alias, so
-  /// materialising these at the view level would fault `.relation` before an
-  /// arm ran.
-  ///
-  /// Each arm resolves with ITS OWN `inner` cache first — `inner.merged(...)`,
-  /// not the reverse — so the arm keeps `inner`'s FRESH per-arm scalar memo
-  /// rather than the shared caller memo `overlay` carries. Both arms compile
-  /// their scalar subqueries under the SAME `.view(name)` scope, so identical
-  /// scalar text across arms lowers to the SAME `Subkey`; sharing one memo box
-  /// would let the first arm's collapsed value be REUSED by the second — even
-  /// though each arm's scalar reads that arm's OWN arm-local relation and must
-  /// yield its OWN value. A per-arm memo isolates the lazy scalar the way the
-  /// eager per-arm `IN`/`EXISTS` results already are, completing the per-arm
-  /// isolation beyond the eager roles. `merged` keeps `inner`'s scalar box and
-  /// unions the results keeping `inner`'s on a collision; the caller's own
-  /// `.caller` results (a pushed `EXISTS`/`IN (Q)`, which alone are safe enough
-  /// to push into an arm — a scalar-subquery conjunct is UNSAFE and never
-  /// pushes in) ride through under their disjoint scope, so the arm still reads
-  /// a pushed caller `EXISTS`/`IN (Q)` while its own scalar memo stays private.
+  /// compiled under — so an arm subquery resolves against the arm's own
+  /// overlay. The arm's REVEALED overlay is recorded under `.view(name)` before
+  /// executing (last arm's binding wins, but arms share the same base relations
+  /// a subquery's FROM reveals to; the arm-local derived layer is SELECT-scoped
+  /// and invisible to a subquery's FROM, so an arm subquery naming that arm's
+  /// arm-local derived alias faults `.relation` as a single arm's does). A
+  /// caller conjunct PUSHED into an arm keeps its `.caller` overlay and re-runs
+  /// against the caller's relations.
   private borrowing func setop(_ plan: Plan, _ query: Query, _ overlay: Context,
                                _ name: String)
       throws(SQLError) -> Array<Record> {
@@ -879,9 +867,9 @@ extension Catalog where Self: ~Escapable {
       return try combine(kind, setop(left, leftQuery, overlay, name),
                          setop(right, rightQuery, overlay, name), all)
     }
-    var scope = try augment(overlay, for: query, rows: true, validate: false)
-    let inner = try subqueries(of: query, scope, .view(name))
-    scope = scope.resolving(inner.merged(overlay.subqueries))
+    let scope = try augment(overlay, for: query, rows: true, validate: false)
+    scope.subqueries.record(overlay: scope.revealed().relations,
+                            for: .view(name))
     return try execute(plan, scope)
   }
 }

--- a/Sources/SQLEngine/OutputColumn.swift
+++ b/Sources/SQLEngine/OutputColumn.swift
@@ -275,7 +275,7 @@ extension Catalog where Self: ~Escapable {
   /// re-type-checks a view body a run already proved runnable.
   borrowing func columns(of select: Select, _ context: Context,
                          visited: Set<String> = [],
-                         validate: Bool = true)
+                         validate: Bool, outer: Outer? = nil)
       throws(SQLError) -> Array<OutputColumn> {
     // Bind THIS select's own FROM/JOIN derived tables (and store relations)
     // before deriving either the subquery map or the scope — a set-op ARM
@@ -289,16 +289,29 @@ extension Catalog where Self: ~Escapable {
     // A scalar subquery in the projection derives its type from its inner
     // query's single column, so build the SAME cursor-free `Subquery` map the
     // compile path's lowering reads — every nested subquery compiled ONCE for
-    // its width and single-column type — and pass it to the projection walk so
-    // an output type for a `(SELECT …)` matches the type the run advertises.
-    // `subquery(of:)` REVEALS the base — this select's derived aliases are
-    // SELECT-scoped, invisible to a subquery's FROM, while a CTE a same-named
-    // derived alias shadows is resolved beneath the dropped layer.
-    let subquery = try subquery(of: select, augmented, visited,
+    // its width and single-column type, each discovering its correlation against
+    // this select's own scope (`enclosing`) — and pass it to the projection walk
+    // so an output type for a `(SELECT …)` matches the type the run advertises.
+    // The projection walk is BARRED (a correlated column of THIS query in the
+    // projection is diagnosed, as the run's projection lowering bars it).
+    // Resolve over the AUGMENTED context so a subquery naming this select's own
+    // arm-local derived alias binds it, while `subquery(of:)` REVEALS the base
+    // so the subquery's OWN FROM sees no derived alias (a CTE a same-named
+    // derived alias shadows resolved beneath the dropped layer).
+    let scope = try scope(of: select, augmented, visited: visited,
+                          validate: validate)
+    // Pass each join's PREFIX scope so an `ON`'s subquery correlates against its
+    // prefix and the WHERE's against the full scope — the SAME per-occurrence
+    // resolution the run path uses, so a name a WHERE subquery finds ambiguous in
+    // the full scope faults HERE too (typecheck↔run parity), not silently reusing
+    // an `ON` occurrence's narrower prefix.
+    let prefixes = try prefixes(of: select, augmented, visited: visited,
                                 validate: validate)
-    return try scope(of: select, augmented, visited: visited,
-                     validate: validate)
-        .columns(of: select.projection, augmented.routines, subquery: subquery)
+    let plans = try subquery(of: select, augmented, visited, .caller,
+                             enclosing: scope, outer: outer,
+                             prefixes: prefixes)
+    return try scope.columns(of: select.projection, augmented.routines,
+                             subquery: plans.rest.barred)
   }
 
   /// The name-resolution scope of `select` — its FROM relation and each joined
@@ -310,7 +323,7 @@ extension Catalog where Self: ~Escapable {
   /// reachable-operand check the same as the outer query's.
   borrowing func scope(of select: Select, _ context: Context,
                        visited: Set<String> = [],
-                       validate: Bool = true)
+                       validate: Bool)
       throws(SQLError) -> Scope {
     // Bind THIS select's own FROM/JOIN derived tables (and store relations)
     // before resolving its relations — SELECT-scoped, so a subquery select
@@ -334,6 +347,29 @@ extension Catalog where Self: ~Escapable {
     return Scope(relations)
   }
 
+  /// The PREFIX scope of each join of `select` — join `index`'s prefix is the
+  /// FROM relation and joins `0…index`, the relations available AT that join
+  /// point, never one joined LATER. A join `ON`'s subquery correlates against
+  /// its prefix (so a reference to a later-joined relation faults), matching the
+  /// compile path's `subquery(of:)`. Empty for a FROM-less or join-less select.
+  private borrowing func prefixes(of select: Select, _ context: Context,
+                                  visited: Set<String>,
+                                  validate: Bool)
+      throws(SQLError) -> Array<Scope> {
+    guard let relation = select.from, !select.joins.isEmpty else { return [] }
+    var relations =
+        [(relation, try schema(of: relation, context, visited: visited,
+                               validate: validate))]
+    for join in select.joins {
+      let joined = try schema(of: join.relation, context, visited: visited,
+                              validate: validate)
+      relations.append((join.relation, joined))
+    }
+    return select.joins.indices.map { index in
+      Scope(Array(relations[0 ... index + 1]))
+    }
+  }
+
   /// Type-checks every operand in `query` — the projection, `WHERE`, and
   /// `HAVING` of EVERY arm — throwing the run-time fault a bad operand would.
   ///
@@ -346,7 +382,7 @@ extension Catalog where Self: ~Escapable {
   /// this (no evaluating term is built), so a schema path type-checks each arm
   /// before returning metadata. It reads no cursor.
   borrowing func typecheck(_ query: Query, _ context: Context,
-                           visited: Set<String> = [])
+                           visited: Set<String> = [], outer: Outer? = nil)
       throws(SQLError) {
     // Bind the derived tables (and store relations) THIS query names in its own
     // FROM/JOIN before type-checking its arms — SELECT-scoped, so a subquery
@@ -361,10 +397,12 @@ extension Catalog where Self: ~Escapable {
                               visited: visited)
     switch query {
     case let .select(select):
-      try typecheck(select, context, visited: visited)
+      try typecheck(select, context, visited: visited, outer: outer)
     case let .setop(_, left, right, _):
-      try typecheck(left, context, visited: visited)
-      try typecheck(right, context, visited: visited)
+      // Both arms of a set-operation subquery correlate against the same
+      // enclosing scope, so each type-checks under the shared `outer`.
+      try typecheck(left, context, visited: visited, outer: outer)
+      try typecheck(right, context, visited: visited, outer: outer)
     }
   }
 
@@ -422,13 +460,25 @@ extension Catalog where Self: ~Escapable {
   /// original is checked. The arity width is always the ORIGINAL query's
   /// (cursor-free), as `subquery(of:)` records it on the compile path.
   private borrowing func subqueryCheck(of select: Select, _ context: Context,
-                                       visited: Set<String>)
+                                       visited: Set<String>,
+                                       enclosing: Scope? = nil,
+                                       outer: Outer? = nil,
+                                       prefixes: Array<Scope> = [])
       throws(SQLError) -> SubqueryCheck {
-    // An `IN (Q)` (`valued`) occurrence EVALUATES its select list at run, so
-    // its ORIGINAL shape is type-checked EAGERLY here; an `EXISTS` occurrence
-    // runs the cardinality probe, so its PROBED shape is checked. Both roles
-    // always run (a predicate is not short-circuited past), so their operand
-    // validation stays eager, driven by the original-vs-probe `shape`.
+    // Every occurrence's inner-query OPERAND validation DEFERS to the
+    // reachability walk, mirroring the lazy executor: a subquery in an
+    // unreachable `CASE`/`COALESCE` arm or a short-circuited `AND`/`OR` leg is
+    // never materialised, so a THROWING operand (`1 / 0`) the type-check finds
+    // must not fault an arm the run skips. A SCALAR occurrence's operands defer
+    // through the `.subquery` case of the walk (`SubqueryCheck.type` records it
+    // reached), an `IN`/`EXISTS`/quantified one through the `.within`/`.exists`
+    // case (`SubqueryCheck.validate` records it) — each validated in its RUN
+    // shape after the walk: an `IN`'s ORIGINAL (its select list is read), an
+    // EXISTS-only occurrence's cardinality PROBE. A REACHED bad body still
+    // faults (parity both directions). (A bad inner column/relation is a
+    // STRUCTURAL fault the outer `compile` already raised for EVERY subquery
+    // before this runs, so it never reaches here — validation and run agree on
+    // it regardless of the arm.)
     // A nested subquery's FROM resolves against base tables and enclosing CTEs,
     // NOT the enclosing SELECT's derived-table aliases — STRIP them (CTEs/store
     // kept) before type-checking/compiling each subquery, mirroring the compile
@@ -436,93 +486,202 @@ extension Catalog where Self: ~Escapable {
     // derived alias in a subquery's FROM exactly as the run does.
     let context = context.revealed()
     let scalar = select.scalar
-    let valued = select.valued
-    let existential = select.existential
-    // A scalar occurrence's inner-query OPERAND validation DEFERS to the
-    // reachability walk (mirroring the lazy executor — a scalar in an
-    // unreachable `CASE`/`COALESCE` arm never validates) UNLESS the query is
-    // ALSO an `IN` value set: an `IN`'s ORIGINAL shape is validated eagerly (it
-    // runs unconditionally), fully covering the scalar's operands too. A scalar
-    // occurrence's ONLY other eager role, an `EXISTS`, validates just the PROBE
-    // (never the select list), so it does NOT cover the scalar's operands —
-    // such a query stays deferred and its EXISTS probe is ALSO checked eagerly.
-    let deferred = scalar.subtracting(valued)
+    // EVERY scalar occurrence's operand check defers to the walk, keyed here
+    // INDEPENDENTLY of a co-existing `IN`/`EXISTS` twin over identical SQL. A
+    // valued/existential twin's eager arity/type derivation is TOTAL (no
+    // `.divide` on `1 / 0`) and does not reproduce the scalar's operand fault,
+    // and — now that an `IN`/`EXISTS` materialises LAZILY — a twin may itself
+    // sit in an unreachable leg, so it cannot stand in for a REACHABLE scalar's
+    // operand check. Deferring on `scalar` alone (not `scalar - valued`) records
+    // the scalar's own `.scalar` reach in `type` even when a `.valued` reach for
+    // the same query is also present — the two per-occurrence reaches must not
+    // dedup the scalar away.
+    let deferred = scalar
     var widths = Dictionary<Query, Int>()
     var types = Dictionary<Query, ValueType>()
-    for query in select.subqueries where widths[query] == nil {
-      // Eager operand validation runs for every occurrence a run does not
-      // short-circuit past — an `IN` (ORIGINAL shape) or an `EXISTS` (PROBE).
-      // A SCALAR-ONLY occurrence (neither) has its inner-query OPERAND check
-      // DEFERRED: a THROWING operand (`1 / 0`) the type-check detects and the
-      // lazy executor skips must not fault an unreachable arm. (A bad inner
-      // column/relation is a STRUCTURAL fault the outer `compile` already
-      // raised for EVERY subquery before this runs, so it never reaches here —
-      // validation and run agree on it regardless of the arm.)
-      if !deferred.contains(query) || existential.contains(query) {
-        try typecheck(shape(of: query, valued: valued), context,
-                      visited: visited)
-      }
-      // The width and single-column type derive for EVERY subquery — cursor-
-      // free and TOTAL for a clean-resolving inner query (deriving the type of
-      // `1 / 0` yields the integer type WITHOUT dividing), so a reached scalar
-      // shapes the outer `CASE`/projection column type correctly. Only the
-      // deferred OPERAND check that faults `.divide` waits for the reached walk.
-      let width = try compile(query, context, visited).width
-      widths[query] = width
-      types[query] =
-          try columns(of: query.first, context, visited: visited,
-                      validate: false).first?.type
-      // A scalar occurrence's single-column ARITY is enforced EAGERLY,
-      // reachability-independent — a cursor-free width check the run's lowering
-      // also makes — so a two-column scalar subquery in an unreachable arm STILL
-      // faults `SQLError.arity`, kept SEPARATE from the deferred operand check.
-      if scalar.contains(query), width != 1 {
-        throw .arity(1, width)
+    // Derive each SITE'S subqueries' cursor-free width and single-column type
+    // against THAT site's own scope, keyed PER OCCURRENCE — a join `i`'s `ON`
+    // against its PREFIX scope `prefixes[i]` (the relations AT that point, not
+    // one joined LATER), the rest against the full `enclosing` — matching the
+    // run's `subquery(of:)`. The SAME inner SQL in an `ON` and the WHERE
+    // derives TWICE — each against its own site's scope — so a name a WHERE
+    // subquery finds ambiguous in the full scope faults HERE, not the `ON`'s
+    // narrower prefix. The OPERAND validation now DEFERS to the reachability
+    // walk for EVERY site — an `ON` runs the SAME short-circuit walk the
+    // WHERE/HAVING do (`walk` calls `check` per join), so a subquery a
+    // short-circuited `AND`/`OR` leg of the `ON` never reaches is unvalidated,
+    // exactly as the run's join evaluator never materialises it.
+    for index in select.joins.indices {
+      var queries = Array<Query>()
+      select.joins[index].on.collect(subqueries: &queries)
+      let within = index < prefixes.count ? prefixes[index] : enclosing
+      for query in queries {
+        let nested = within.map { (outer ?? Outer()).nested(under: $0) }
+            ?? outer
+        try width(query, scalar, context, visited, nested, &widths, &types)
       }
     }
-    return SubqueryCheck(widths, types, deferred: deferred)
+    // The WHERE, `HAVING`, projection, and `ORDER BY` are walked by the
+    // reachability phase, so their operand check DEFERS; their width and single-
+    // column type still derive here against the full `enclosing` scope.
+    var rest = Array<Query>()
+    select.predicate?.collect(subqueries: &rest)
+    select.having?.collect(subqueries: &rest)
+    if case let .expressions(items) = select.projection {
+      for item in items { item.expression.collect(subqueries: &rest) }
+    }
+    for key in select.order?.keys ?? [] {
+      if case let .expression(expression) = key.sort {
+        expression.collect(subqueries: &rest)
+      }
+    }
+    for query in rest {
+      let nested = enclosing.map { (outer ?? Outer()).nested(under: $0) }
+          ?? outer
+      try width(query, scalar, context, visited, nested, &widths, &types)
+    }
+    // Carry THIS select's own enclosing scope `outer` so its WHERE type-check
+    // (`walk`) resolves a correlated column of THIS query against the outer,
+    // matching the run's lowering; the projection/`HAVING` walk uses `.barred`.
+    return SubqueryCheck(widths, types, deferred: deferred, outer: outer)
   }
 
-  /// The subquery shape a run of `query` type-checks against — the ORIGINAL for
-  /// an `IN (Q)` occurrence (in `valued`, its select list evaluated) or a query
-  /// the probe does not rewrite, else the `Select.probe` the `EXISTS`
-  /// cardinality probe runs (constant projection, `ORDER BY` dropped, original
-  /// `OFFSET`/`FETCH` kept) so validation does not evaluate a select list or
-  /// sort key the run never does.
-  private borrowing func shape(of query: Query, valued: Set<Query>) -> Query {
-    guard !valued.contains(query), case let .select(select) = query,
+  /// Records the cursor-free width and single-column type of `query` into
+  /// `widths`/`types` against the `nested` outer scope, and enforces a scalar
+  /// occurrence's single-column ARITY EAGERLY (reachability-independent, as the
+  /// run's lowering does). Computed ONCE per distinct query at a given site.
+  private borrowing func width(_ query: Query, _ scalar: Set<Query>,
+                               _ context: Context, _ visited: Set<String>,
+                               _ nested: Outer?,
+                               _ widths: inout Dictionary<Query, Int>,
+                               _ types: inout Dictionary<Query, ValueType>)
+      throws(SQLError) {
+    // The width and single-column type derive for EVERY subquery — cursor-free
+    // and TOTAL for a clean-resolving inner query (deriving the type of `1 / 0`
+    // yields the integer type WITHOUT dividing). A distinct query at ONE site is
+    // derived once; the SAME query at ANOTHER site re-derives against ITS scope,
+    // so a WHERE occurrence's ambiguity still faults there. The compile is
+    // SHAPE ONLY, so LENIENT (`validate: false`): this pre-pass runs for EVERY
+    // nested subquery ahead of the reachability walk, so validating a derived
+    // body it nests — `1 IN (SELECT x FROM (SELECT 1 / 0 …) AS d)` — would
+    // fault a subquery a short-circuited `AND`/`OR` leg drops BEFORE the walk
+    // reaches it. Validation of a REACHED subquery's body (and the derived
+    // tables nested within it, at any depth) is the walk's job — `typecheck(_
+    // select:)` re-derives each reached occurrence's body strictly. Structural
+    // faults (a bad inner relation/column, a UNION arity) still surface here —
+    // those resolve regardless of `validate`.
+    let width =
+        try compile(query, context, visited, .caller, nested,
+                    validate: false).width
+    let derived =
+        try columns(of: query.first, context, visited: visited,
+                    validate: false, outer: nested).first?.type
+    if widths[query] == nil {
+      widths[query] = width
+      types[query] = derived
+    }
+    // A scalar occurrence's single-column ARITY is enforced EAGERLY,
+    // reachability-independent — a cursor-free width check the run's lowering
+    // also makes — so a two-column scalar subquery in an unreachable arm STILL
+    // faults `SQLError.arity`, kept SEPARATE from the deferred operand check.
+    if scalar.contains(query), width != 1 {
+      throw .arity(1, width)
+    }
+  }
+
+  /// The subquery shape a run of the reached occurrence `reach` type-checks
+  /// against — chosen from the occurrence's OWN reached ROLE, not the union of
+  /// every role the query occupies in the select. A `scalar` reach (collapses
+  /// the cell) or a `valued` one (`IN (Q)`, its value set read) EVALUATES the
+  /// select list, so its ORIGINAL is type-checked; an `existential` reach
+  /// (`EXISTS`) runs the cardinality PROBE (`Select.probe`: constant
+  /// projection, `ORDER BY` dropped, original `OFFSET`/`FETCH` kept), never its
+  /// select list — so its PROBED shape is checked, matching the run. So the
+  /// SAME inner SQL reached ONLY as an `EXISTS` validates the probe even where
+  /// an unreached arm has it as a scalar. A query the probe does not rewrite (a
+  /// `HAVING` or set operation) runs in FULL, so its original is checked even
+  /// for an `existential` reach.
+  private borrowing func shape(of reach: Reach) -> Query {
+    guard reach.role == .existential, case let .select(select) = reach.query,
         select.probable else {
-      return query
+      return reach.query
     }
     return .select(select.probe)
   }
 
   private borrowing func typecheck(_ select: Select, _ context: Context,
-                                   visited: Set<String>)
+                                   visited: Set<String>, outer: Outer? = nil)
       throws(SQLError) {
-    // Type-check and compile every UNCORRELATED subquery ONCE, ahead of the
-    // reachability walk: the pre-pass validates each `IN`/`EXISTS` inner query
-    // (never short-circuited past) and derives every scalar subquery's
-    // cursor-free arity and type (TOTAL — no `.divide` on `1 / 0`), but DEFERS
-    // a scalar occurrence's inner-query OPERAND validation to the walk, which
-    // records the scalar occurrences it REACHES into the `SubqueryCheck`'s box.
-    // `subqueryCheck` REVEALS the base from the augmented `context`, so a
-    // subquery's FROM sees no derived alias while a shadowed CTE is preserved.
-    let subquery = try subqueryCheck(of: select, context, visited: visited)
+    // This select's OWN resolution scope — the one its nested subqueries
+    // CORRELATE against (`nil` for a FROM-less select, which adds no relations
+    // and correlates through `outer` unchanged). Built from the UNREVEALED
+    // `context` — correlation resolves against the enclosing scope's relations
+    // (its derived aliases among them), unlike an inner subquery's own FROM,
+    // which resolves against the REVEALED base below.
+    let enclosing = select.from == nil
+        ? nil : try scope(of: select, context, visited: visited,
+                          validate: true)
+    // The PREFIX scope of each join, the surface its `ON`'s subquery correlates
+    // against — matching the run's `subquery(of:)`.
+    let prefixes = try prefixes(of: select, context, visited: visited,
+                               validate: true)
+    // Type-check and compile every subquery ONCE, ahead of the reachability
+    // walk: the pre-pass validates each `IN`/`EXISTS` inner query (never
+    // short-circuited past) and derives every scalar subquery's cursor-free
+    // arity and type (TOTAL — no `.divide` on `1 / 0`), but DEFERS a scalar
+    // occurrence's inner-query OPERAND validation to the walk. Each nested
+    // query's CORRELATION resolves against `enclosing` (a join `ON`'s against
+    // its prefix) here, matching the run.
+    let subquery = try subqueryCheck(of: select, context, visited: visited,
+                                     enclosing: enclosing, outer: outer,
+                                     prefixes: prefixes)
     // Walk the query's operands reachability-aware, so an unreachable
-    // `CASE`/`COALESCE` arm's scalar subquery is left unrecorded and unchecked.
-    try walk(select, context, subquery: subquery, visited: visited)
-    // Validate the inner query of each scalar occurrence the walk REACHED,
-    // where the borrowing catalog is in scope — mirroring the lazy executor,
-    // which materialises only a reached scalar subquery. A reached
-    // `(SELECT 1 / 0 …)` faults `.divide` here exactly as the run does; a
-    // skipped one is never reached, so never validated. A subquery's FROM sees
-    // base tables and enclosing CTEs, NOT the enclosing SELECT's derived-table
-    // aliases, so type-check each against the REVEALED base — the derived
-    // layers dropped, the CTEs/store (a shadowed CTE among them) kept.
+    // `CASE`/`COALESCE` arm's subquery is left unrecorded and unchecked.
+    try walk(select, context, subquery: subquery, visited: visited,
+             outer: outer, prefixes: prefixes)
+    // Validate the inner query of each occurrence the walk REACHED — a scalar
+    // or an `IN`/`EXISTS`/quantified one — in the RUN shape of ITS OWN reached
+    // role: an `existential` reach the cardinality PROBE (never its select
+    // list), a `scalar`/`valued` reach the ORIGINAL. The shape is chosen from
+    // the occurrence's role, NOT the union of every role the query occupies in
+    // the select — so the SAME inner SQL reached only as an `EXISTS` validates
+    // the probe even where an UNREACHED arm has it as a scalar. Its correlated
+    // columns resolve against THIS select's scope (nearest), stacked past
+    // `outer` — mirroring the lazy executor. A reached `(SELECT 1 / 0 …)`
+    // faults `.divide` here exactly as the run does, while an unreached one in
+    // a skipped arm does not.
+    //
+    // A subquery's own FROM sees base tables and enclosing CTEs, NOT the
+    // enclosing SELECT's derived-table aliases, so recurse against the REVEALED
+    // base — the derived layers dropped, the CTEs/store (a shadowed CTE among
+    // them) kept — while the correlation `outer` above still carries the
+    // enclosing scope's ordinals.
     let inner = context.revealed()
-    for query in subquery.visited {
-      try typecheck(query, inner, visited: visited)
+    let nested = enclosing.map { (outer ?? Outer()).nested(under: $0) } ?? outer
+    for reach in subquery.visited {
+      try typecheck(shape(of: reach), inner, visited: visited, outer: nested)
+    }
+    // Each join `ON` runs through the SAME reachability/short-circuit walk the
+    // WHERE does, but PREFIX-scoped: an `ON` predicate short-circuits its
+    // `AND`/`OR` at run (`Scope.on` lowers the conjunction the join evaluator
+    // steps), so a subquery a short-circuited leg never reaches is NOT
+    // validated — `ON 1 = 0 AND 1 IN (SELECT 1 / 0 …)` does not fault, exactly
+    // as the join never materialises it — while a REACHED `ON` subquery IS
+    // validated (parity). The `ON`'s LOCAL scope is the join's PREFIX
+    // (`prefixes[index]`, the relations AT that point, never one joined LATER),
+    // so a correlated reference to a later-joined relation faults per that
+    // prefix; its enclosing `outer` stays the select's, so a correlated `ON`
+    // subquery column resolves against THAT prefix stacked past the outer,
+    // matching the run's `subquery(of:)`.
+    for index in select.joins.indices {
+      guard index < prefixes.count else { continue }
+      let prefix = prefixes[index]
+      let scope = (outer ?? Outer()).nested(under: prefix)
+      let on = subquery.scoped(outer)
+      try prefix.check(select.joins[index].on, context.routines, subquery: on)
+      for reach in on.visited {
+        try typecheck(shape(of: reach), inner, visited: visited, outer: scope)
+      }
     }
   }
 
@@ -531,10 +690,18 @@ extension Catalog where Self: ~Escapable {
   /// would evaluate and RECORDING (via `subquery`) each scalar subquery it
   /// reaches, so the caller validates only the reached scalars' inner queries.
   private borrowing func walk(_ select: Select, _ context: Context,
-                              subquery: SubqueryCheck, visited: Set<String>)
+                              subquery: SubqueryCheck, visited: Set<String>,
+                              outer: Outer? = nil,
+                              prefixes: Array<Scope> = [])
       throws(SQLError) {
     let routines = context.routines
-    let scope = try scope(of: select, context, visited: visited)
+    let scope = try scope(of: select, context, visited: visited,
+                          validate: true)
+    // The WHERE admits a correlated column of THIS query (`subquery`); the
+    // projection, `HAVING`, and `ORDER BY` bar it (`barred`), diagnosing the
+    // unsupported correlated-projection/HAVING case exactly as the run's
+    // lowering does.
+    let barred = subquery.barred
     // An `ORDER BY` ordinal names a 1-based SELECT-list position; one outside
     // `1 ... width` names no output column and faults `SQLError.column` (spelled
     // as the ordinal), exactly as the compile path's ordinal resolution does —
@@ -557,7 +724,8 @@ extension Catalog where Self: ~Escapable {
     // Structural, so it runs regardless of the WHERE/limit reachability the
     // operand type-check below tracks.
     if select.aggregates {
-      try order(grouped: select, scope, context, visited)
+      try order(grouped: select, scope, context, visited,
+                outer: outer, prefixes: prefixes)
     }
     if let predicate = select.predicate {
       try scope.check(predicate, routines, subquery: subquery)
@@ -602,7 +770,7 @@ extension Catalog where Self: ~Escapable {
           if !reachable { reachable = !drops(select.limit, single: true) }
           if reachable, case let .expressions(items) = select.projection {
             for item in items {
-              try scope.fold(item.expression, routines, subquery: subquery)
+              try scope.fold(item.expression, routines, subquery: barred)
             }
           }
           // The lone empty group is sorted BELOW the limit — the shape is
@@ -614,7 +782,7 @@ extension Catalog where Self: ~Escapable {
           // projection term reached only via the sort is checked even where the
           // projection block above is skipped.
           for expression in select.orderKeys {
-            try scope.fold(expression, routines, subquery: subquery)
+            try scope.fold(expression, routines, subquery: barred)
           }
         }
         return
@@ -629,15 +797,15 @@ extension Catalog where Self: ~Escapable {
     // projection or `HAVING` aggregate's.
     if case let .expressions(items) = select.projection {
       for item in items {
-        try scope.aggregates(in: item.expression, routines, subquery: subquery)
+        try scope.aggregates(in: item.expression, routines, subquery: barred)
       }
     }
     for expression in select.orderKeys {
-      try scope.aggregates(in: expression, routines, subquery: subquery)
+      try scope.aggregates(in: expression, routines, subquery: barred)
     }
     if let having = select.having {
-      try scope.aggregates(in: having, routines, subquery: subquery)
-      try scope.check(having, routines, subquery: subquery)
+      try scope.aggregates(in: having, routines, subquery: barred)
+      try scope.check(having, routines, subquery: barred)
       // A false HAVING filters every group before the projection, so the
       // projection's non-aggregate work is unreachable.
       if scope.constant(having, routines) == false { return }
@@ -656,7 +824,7 @@ extension Catalog where Self: ~Escapable {
     if !reachable { reachable = !drops(select.limit, single: sole) }
     if reachable, case let .expressions(items) = select.projection {
       for item in items {
-        _ = try scope.validate(item.expression, routines, subquery: subquery)
+        _ = try scope.validate(item.expression, routines, subquery: barred)
       }
     }
     // The sort sits BELOW the limit — the shape is `Project(Limit(Sort(…)))`
@@ -671,7 +839,7 @@ extension Catalog where Self: ~Escapable {
     // projection term NO sort key reaches stays correctly unchecked (the
     // projection never runs under a row-dropping limit).
     for expression in select.orderKeys {
-      _ = try scope.validate(expression, routines, subquery: subquery)
+      _ = try scope.validate(expression, routines, subquery: barred)
     }
   }
 
@@ -688,16 +856,24 @@ extension Catalog where Self: ~Escapable {
   /// the two paths cannot drift. It resolves only, reading no cursor; a run's
   /// operand type-check over the (structurally valid) keys stays the caller's.
   private borrowing func order(grouped select: Select, _ scope: Scope,
-                               _ context: Context, _ visited: Set<String>)
+                               _ context: Context, _ visited: Set<String>,
+                               outer: Outer? = nil,
+                               prefixes: Array<Scope> = [])
       throws(SQLError) {
     guard let clause = select.order else { return }
     let routines = context.routines
-    // A grouped aggregate's argument or FILTER may nest an UNCORRELATED
-    // subquery (`ORDER BY SUM(CASE WHEN EXISTS (Q) …)`), which lowering
-    // resolves against the materialised map, so materialise the select's
-    // subqueries ONCE here — the same map the run's `group` builds — for this
-    // structural resolve to lower those aggregates exactly as the run does.
-    let subquery = try subquery(of: select, context, visited)
+    // A grouped aggregate's argument or FILTER may nest a subquery (`ORDER BY
+    // SUM(CASE WHEN EXISTS (Q) …)`), which lowering resolves against the
+    // materialised map, so build the select's subquery seam ONCE here — the
+    // same one the run's `group` builds — for this structural resolve to lower
+    // those aggregates exactly as the run does. It threads the SAME
+    // `enclosing`/`outer`/`prefixes` the run path passes, so a CORRELATED inner
+    // query (`WHERE S.k = T.k`) resolves its outer column here exactly as at
+    // run, rather than compiling with no enclosing scope and faulting
+    // `SQLError.column`.
+    let subquery = try subquery(of: select, context, visited, .caller,
+                                enclosing: scope, outer: outer,
+                                prefixes: prefixes).rest
     // Collect the distinct aggregates the grouped plan folds — the projection,
     // the `HAVING`, and the `ORDER BY` sort-key expressions — then dedup by the
     // RESOLVED `Aggregation`, exactly as `group` does, so a grouped `ORDER BY`

--- a/Sources/SQLEngine/Resolve.swift
+++ b/Sources/SQLEngine/Resolve.swift
@@ -103,83 +103,313 @@ internal struct Subkey: Hashable, Sendable {
   }
 }
 
-/// One UNCORRELATED subquery already RUN ONCE at execution — the value a
-/// run-time `Subqueries` cache memoises so the row evaluator reads an
-/// `EXISTS`/`IN (Q)` predicate without re-running the inner query or itself
-/// holding the borrowing catalog.
+/// The cache identity of one CORRELATED subquery occurrence's pre-compiled plan
+/// — its occurrence `Subkey` composed with the SET OF SYNTHETIC PARAMETER NAMES
+/// its correlation binds.
 ///
-/// An `IN (Q)` occurrence needs the subquery's single COLUMN of values, so it
-/// is materialised in FULL (`rows`). An occurrence used only by `EXISTS` needs
-/// nothing but CARDINALITY — whether the row source yields ANY row — so it is
-/// materialised as a `present` PROBE that never evaluates the select list or
-/// sort keys and stops at the first row (`EXISTS (SELECT 1 / 0 FROM S)` over a
-/// non-empty `S` is TRUE with no `.divide`, no full scan). A probe carries no
-/// `rows`, so `values` faults if an `IN` ever reads it — but a query needing
-/// its values is materialised full, so it never does.
-///
-/// A SCALAR subquery occurrence is NOT materialised here — it collapses LAZILY,
-/// on the first evaluation of its `Term.subquery`, so a scalar subquery in an
-/// unreachable `CASE`/`COALESCE` arm never runs (see `Subqueries.scalar`). The
-/// eager entries this holds are therefore only the `IN` full result and the
-/// `EXISTS` probe.
-internal struct MaterialisedSubquery {
-  /// The subquery's result rows for an `IN` occurrence materialised in full, or
-  /// `nil` for an `EXISTS`-only probe (which carries no full rows).
-  private let rows: Array<Array<Value>>?
+/// The `Subkey` alone (scope + query + role) does NOT separate two occurrences
+/// of IDENTICAL inner SQL that compile under DIFFERENT outer layouts — the two
+/// arms of a set operation, `SELECT (SELECT m FROM Src WHERE m = k) FROM Outer1
+/// UNION ALL SELECT (SELECT m FROM Src WHERE m = k) FROM Outer2` where
+/// `Outer1.k` sits at ordinal 0 and `Outer2.k` at ordinal 1. Both arms carry
+/// the SAME `Subkey` (same `.caller` scope, same AST, same role), so keying the
+/// plan memo by `Subkey` alone lets the right arm READ the LEFT arm's plan —
+/// which binds `:__correlated_0_0` while the right arm's outer row binds
+/// `:__correlated_0_1`, yielding NULL/wrong results. The correlation's PARAMETER
+/// NAMES (`:__correlated_<depth>_<ordinal>`) encode each occurrence's own outer
+/// layout and are STABLE across the ordinal remap `optimise` applies (it rewrites
+/// the `Source` values, never the keys), so they match at the RECORD site (the
+/// pre-pass compile) and the LOOKUP site (the lowered node) while DIFFERING
+/// between the two arms. Adding them to the key gives each arm its OWN plan yet
+/// preserves legitimate SHARING: an identical occurrence under an identical
+/// outer layout binds the same names and reuses the one plan.
+internal struct PlanKey: Hashable, Sendable {
+  /// The occurrence's `Subkey` — scope, query, and role.
+  private let key: Subkey
 
-  /// Whether the row source yielded a row — the `EXISTS` non-empty test, read
-  /// from the full `rows` or the probe.
-  internal let present: Bool
+  /// The synthetic parameter names this occurrence's correlation binds — its
+  /// outer-layout identity, remap-stable.
+  private let names: Set<String>
 
-  /// A full materialisation of `rows` — an `IN` occurrence, whose select list
-  /// IS needed.
-  internal init(rows: Array<Array<Value>>) {
-    self.rows = rows
-    self.present = !rows.isEmpty
-  }
-
-  /// A cardinality probe — an `EXISTS`-only occurrence, carrying only whether
-  /// the row source yielded a row, never the select-list values.
-  internal init(present: Bool) {
-    self.rows = nil
-    self.present = present
-  }
-
-  /// The single column of the result — the `IN (Q)` membership values. Only an
-  /// occurrence materialised in FULL (its select list needed) reads this; a
-  /// probe-only entry carries none, an internal invariant break if reached.
-  internal func values() throws(SQLError) -> Array<Value> {
-    guard let rows else {
-      throw .named("a subquery materialised as a probe has no values")
-    }
-    return rows.map { $0[0] }
+  internal init(_ key: Subkey, _ correlation: Correlation) {
+    self.key = key
+    self.names = Set(correlation.keys)
   }
 }
 
-/// The mutable memo a `Subqueries` cache shares by REFERENCE for the scalar
-/// subqueries it materialises LAZILY.
+/// Where a correlated synthetic parameter's per-outer-row value comes from — a
+/// cell of the IMMEDIATE enclosing row (`slot`), or an ALREADY-bound parameter
+/// the containing subquery threads through (`bound`).
 ///
-/// A scalar subquery collapses on the FIRST evaluation of its `Term.subquery`,
-/// not eagerly at run start, so an occurrence in an unreachable
-/// `CASE`/`COALESCE` arm never runs (never throws `.cardinality` or an inner
-/// fault). It is UNCORRELATED, so its collapsed value is row-invariant: the
-/// first reached evaluation runs and caches it here, keyed by its `Subkey`, and
-/// every later read of the same key returns the cached value WITHOUT
-/// re-running. The cache is a class so the memo survives `Subqueries` being
-/// copied by value down the evaluate tree — every copy shares the one box.
-internal final class ScalarMemo {
-  private var cells: Dictionary<Subkey, Value> = [:]
+/// A correlation to the subquery's IMMEDIATE enclosing query reads that outer
+/// row directly: `slot` is the outer combined ordinal the re-execution binds
+/// from the current outer row. A correlation to a scope TWO OR MORE levels up
+/// (a NESTED subquery naming a grandparent column) is bound by the CONTAINING
+/// subquery — which the bubble-up marks correlated to that same grandparent, so
+/// it re-executes and binds the parameter — and the inner occurrence only reads
+/// it back through `bindings`, so its source is `bound`: the eval leaves the
+/// threaded binding intact rather than overwriting it from the inner's own row.
+internal enum Source: Hashable, Sendable {
+  /// The value is the current outer row's cell at this combined ordinal.
+  case slot(Int)
+  /// The value is already in `bindings` — threaded down by the containing
+  /// subquery — so the eval passes it through unchanged.
+  case bound
+}
 
-  /// The already-collapsed value for `key`, or `nil` when it has not yet been
-  /// evaluated — the evaluator runs and `store`s it on a miss.
-  internal func value(_ key: Subkey) -> Value? {
-    cells[key]
+/// The CORRELATION of a subquery occurrence — the synthetic bound parameters
+/// its inner query names, each mapped to the `Source` its per-outer-row value
+/// comes from (an immediate-enclosing-row cell, or a threaded binding).
+///
+/// A CORRELATED subquery references a column of an enclosing query
+/// (`SELECT V FROM S WHERE S.k = T.k`, the inner `T.k` outer). This slice ships
+/// the MINIMAL (b) cut: an outer column is allowed ONLY in the inner query's
+/// `WHERE`/`ON` (a comparison operand or a `WHERE`-position term), where it
+/// lowers to a synthetic `Term.parameter(name)` — reusing the run's `bindings`
+/// with NO new evaluator beyond that leaf. This map records, per synthetic
+/// name, the `Source` the per-outer-row re-execution binds it from. An EMPTY map
+/// is an UNCORRELATED occurrence, materialised once and memoised; a NON-empty
+/// one re-runs the inner plan per outer row against a `bindings` extended with
+/// each named cell, bypassing the materialise cache.
+///
+/// An outer column in the inner PROJECTION / `GROUP BY` / `HAVING` is OUT of
+/// this cut — it needs the general (a)-style outer-row evaluator, not a bound
+/// param — so it is DIAGNOSED as unsupported rather than mis-resolved (see
+/// `Outer.parameter`). A column binding neither locally nor in any enclosing
+/// scope stays the ordinary unknown-column fault.
+internal typealias Correlation = Dictionary<String, Source>
+
+extension Dictionary where Key == String, Value == Source {
+  /// This correlation with every `slot` outer ordinal remapped to its packed
+  /// slot through `slot`, so a per-outer-row re-execution reads the outer
+  /// record's cell; a `bound` source is unchanged — it reads a threaded binding,
+  /// not the outer record.
+  internal func remapped(through slot: Dictionary<Int, Int>) -> Correlation {
+    mapValues { source in
+      switch source {
+      case let .slot(ordinal):
+        .slot(slot[ordinal]!)
+      case .bound:
+        .bound
+      }
+    }
   }
 
-  /// Records `value` as the collapsed value of the scalar occurrence `key`, so
-  /// a later read of the same key returns it without re-running the subquery.
-  internal func store(_ value: Value, for key: Subkey) {
-    cells[key] = value
+  /// The outer ordinals this correlation reads from the immediate enclosing row
+  /// — every `slot` source's ordinal, excluding the `bound` (threaded-binding)
+  /// sources — the cells that must be materialised for a per-outer-row
+  /// re-execution.
+  internal var slots: Set<Int> {
+    var slots = Set<Int>()
+    for source in values {
+      if case let .slot(ordinal) = source { slots.insert(ordinal) }
+    }
+    return slots
+  }
+}
+
+/// The ENCLOSING resolution scope a subquery lowers against for its CORRELATED
+/// columns — the scope STACK the minimal (b) correlation cut consults when an
+/// inner column binds against none of the subquery's OWN in-scope relations.
+///
+/// A subquery resolves its columns against its own relations FIRST; a name none
+/// of them binds is a candidate CORRELATED reference to an enclosing query. This
+/// carries the enclosing `Scope`s, innermost last, and — as lowering reaches
+/// each such candidate — resolves it against them (nearest first), MINTS a
+/// synthetic `:parameter` name for the outer combined ordinal, and RECORDS the
+/// (name → ordinal) pair into the shared `correlation` accumulator so the
+/// per-outer-row re-execution can bind that cell. It is a class so the
+/// accumulator survives the seam being copied by value down the lowering, and so
+/// the SAME occurrence lowered on the run and the schema paths accretes into one
+/// map.
+///
+/// A name no enclosing scope binds either stays the ordinary unknown-column
+/// fault (the local surface already raised `SQLError.column`); this only
+/// intercepts a name the OUTER scope binds. Correlation is admitted ONLY where a
+/// synthetic bound param is a valid lowering — a `WHERE`/`ON` term — so a scope
+/// with no admitted position (a projection / `GROUP BY` / `HAVING` surface)
+/// carries no `Outer` and the outer column stays unresolved, DIAGNOSED as
+/// unsupported rather than mis-bound.
+internal final class Outer {
+  /// The enclosing scopes, OUTERMOST first — a column resolves against the
+  /// nearest enclosing (last) that binds it, matching lexical scoping. The LAST
+  /// scope is this subquery's IMMEDIATE parent; any earlier one is a grandparent
+  /// (or further) whose correlation BUBBLES UP to the containing subquery.
+  private let scopes: Array<Scope>
+
+  /// The enclosing subquery's `Outer` — the one holding `scopes` MINUS the last
+  /// — up which a correlation to a non-immediate scope propagates, so the
+  /// CONTAINING subquery is marked correlated to that grandparent column too.
+  /// `nil` at the outermost level (a top-level select's `Outer`).
+  private let parent: Outer?
+
+  /// The correlated references discovered so far — each synthetic `:parameter`
+  /// name mapped to the `Source` its per-outer-row value comes from (this
+  /// subquery's immediate-enclosing-row cell, or a threaded binding).
+  private(set) var correlation: Correlation = [:]
+
+  internal init(_ scopes: Array<Scope> = [], parent: Outer? = nil) {
+    self.scopes = scopes
+    self.parent = parent
+  }
+
+  /// This outer scope extended with `scope` as the NEAREST enclosing one — the
+  /// stack a nested subquery lowers against, seeing its immediate parent last,
+  /// with `self` as the parent so a correlation to a grandparent scope bubbles
+  /// up. The accumulator starts fresh: correlation is recorded PER occurrence,
+  /// not shared across sibling subqueries.
+  internal func nested(under scope: Scope) -> Outer {
+    Outer(scopes + [scope], parent: self)
+  }
+
+  /// The synthetic `:parameter` name a correlated reference to enclosing
+  /// combined `ordinal` at scope `depth` lowers to — deterministic in BOTH, so
+  /// the run and schema lowerings of the SAME occurrence mint identical names
+  /// and the re-execution binds them from the outer row. The `depth` (the
+  /// scope-stack index the reference resolves at) disambiguates two references
+  /// from DIFFERENT enclosing scopes that share an ordinal — a `T.id`
+  /// (grandparent) and a `U.u` (parent) both at combined ordinal 0 — so each
+  /// gets its OWN synthetic param and correlation entry rather than colliding
+  /// on `:__correlated_0`. The depth is a scope-stack index, stable across the
+  /// bubble-up (a parent sees the shared prefix scope at the SAME index), so
+  /// the binding level and the threading levels agree on the name.
+  private func name(for ordinal: Int, at depth: Int) -> String {
+    ":__correlated_\(depth)_\(ordinal)"
+  }
+
+  /// The synthetic bound-parameter name `column` correlates to, or `nil` when no
+  /// enclosing scope binds it (the ordinary unknown-column fault stands).
+  ///
+  /// The enclosing scopes are consulted NEAREST first (the innermost enclosing
+  /// query shadows an outer one, as lexical scoping requires). On a match it
+  /// records the correlation (see `record(_:matching:)`) and returns the name,
+  /// so the caller lowers the column to a `Term.parameter`. A nearer scope that
+  /// binds the name AMBIGUOUSLY (in more than one of its relations) SHADOWS the
+  /// farther ones: `correlated` faults `SQLError.ambiguous`, which propagates
+  /// rather than falling through to rebind the name to a farther relation. Only
+  /// a NOT-FOUND (`nil`) keeps the walk moving outward.
+  internal func parameter(for column: Column) throws(SQLError) -> String? {
+    for depth in scopes.indices.reversed() {
+      guard let ordinal = try scopes[depth].correlated(column) else { continue }
+      let name = name(for: ordinal, at: depth)
+      record(name, ordinal, matching: depth)
+      return name
+    }
+    return nil
+  }
+
+  /// Records the correlation of `name` (the outer combined `ordinal` it reads)
+  /// matched at enclosing-scope `depth`.
+  ///
+  /// A match at the LAST scope (this subquery's immediate parent) reads that
+  /// outer row directly, so the source is the parent-row `slot`. A match at an
+  /// EARLIER scope is a correlation of the CONTAINING subquery too: it is
+  /// recorded `bound` here — the eval threads the value through `bindings`
+  /// rather than reading this subquery's own row — and propagated up to `parent`
+  /// (whose last scope is one level nearer), so the containing occurrence is
+  /// itself marked correlated and re-executes per its enclosing row. Since a
+  /// `Scope` lays relations at cumulative offsets from 0, the `ordinal` is the
+  /// same in every level that shares the matched scope, so the ancestor that
+  /// owns it as its IMMEDIATE parent reads the right cell.
+  private func record(_ name: String, _ ordinal: Int, matching depth: Int) {
+    let immediate = depth == scopes.count - 1
+    correlation[name] = immediate ? .slot(ordinal) : .bound
+    if !immediate { parent?.record(name, ordinal, matching: depth) }
+  }
+
+  /// The value type of the enclosing column `column` names, or `nil` when no
+  /// enclosing scope binds it — the static type a correlated reference
+  /// contributes to the type-check surface (`validate`), so a correlated column
+  /// types as its outer column rather than a placeholder. It records NO
+  /// correlation (a pure type probe); the lowering's `parameter(for:)` records
+  /// the binding. Like `parameter(for:)`, a nearer scope binding the name
+  /// AMBIGUOUSLY SHADOWS the farther ones — `correlated` faults
+  /// `SQLError.ambiguous`, which propagates rather than falling through — so the
+  /// schema-derive and the run's lowering AGREE on the ambiguity.
+  internal func type(for column: Column) throws(SQLError) -> ValueType? {
+    for scope in scopes.reversed() {
+      guard let ordinal = try scope.correlated(column) else { continue }
+      return scope.type(at: ordinal)
+    }
+    return nil
+  }
+}
+
+/// The mutable memo a `Subqueries` cache shares by REFERENCE for the
+/// UNCORRELATED subqueries it materialises LAZILY, keyed by occurrence `Subkey`.
+///
+/// Every subquery ROLE — scalar collapse, `IN` value set, `EXISTS` probe — is
+/// materialised LAZILY, on the FIRST evaluation of its lowered node, so an
+/// occurrence in an unreachable `CASE`/`COALESCE` arm or a short-circuited
+/// `AND`/`OR` never runs (never throws its inner fault) — the folded-in lazy
+/// `IN`/`EXISTS` that the earlier slice left eager. An UNCORRELATED occurrence
+/// is row-invariant, so the first reached evaluation runs it ONCE and caches the
+/// result here; every later read of the same key returns it WITHOUT re-running.
+/// A CORRELATED occurrence is NOT memoised (its result depends on the bound
+/// outer row), so it never reads or writes this — it re-runs per outer row.
+///
+/// It is a class so the memo survives `Subqueries` being copied by value down
+/// the evaluate tree — every copy shares the one box.
+internal final class SubqueryMemo {
+  /// The collapsed scalar value memoised per scalar occurrence.
+  private var scalars: Dictionary<Subkey, Value> = [:]
+  /// The `EXISTS` non-empty result memoised per existential occurrence.
+  private var probes: Dictionary<Subkey, Bool> = [:]
+  /// The `IN (Q)` single-column value set memoised per valued occurrence.
+  private var columns: Dictionary<Subkey, Array<Value>> = [:]
+
+  /// The RESOLUTION OVERLAY each `Subscope`'s subqueries run under — the
+  /// caller's `WITH`/store overlay under `.caller`, a view body's own overlay
+  /// under `.view(name)` — recorded as each scope BEGINS executing, so the lazy
+  /// evaluator runs a subquery against the overlay of the scope it was TEXTUALLY
+  /// lowered under, NOT the (possibly different) overlay of the execution site a
+  /// predicate pushdown moved it to. A caller conjunct pushed INTO a view thus
+  /// still resolves its subquery's `FROM S` against the caller's `S`, not the
+  /// view's base — the correctness the disjoint `Subscope` keying and the
+  /// captured overlay together preserve.
+  private var overlays: Dictionary<Subscope, ScopedRelations> = [:]
+
+  internal func scalar(_ key: Subkey) -> Value? { scalars[key] }
+  internal func store(scalar value: Value, for key: Subkey) {
+    scalars[key] = value
+  }
+
+  internal func present(_ key: Subkey) -> Bool? { probes[key] }
+  internal func store(present value: Bool, for key: Subkey) {
+    probes[key] = value
+  }
+
+  internal func values(_ key: Subkey) -> Array<Value>? { columns[key] }
+  internal func store(values: Array<Value>, for key: Subkey) {
+    columns[key] = values
+  }
+
+  /// The COMPILED inner plan of each CORRELATED occurrence, keyed by its
+  /// occurrence `PlanKey` (its `Subkey` composed with the parameter names its
+  /// correlation binds) — compiled ONCE (with the enclosing scope as its
+  /// `Outer`, so its correlated columns lowered to `Term.parameter`) by the run
+  /// path's compile and stashed here, so the evaluator RE-EXECUTES that plan per
+  /// outer row against the correlated bindings rather than RE-COMPILING the
+  /// inner query fresh (which, with no outer scope in hand at eval, would fault
+  /// on the outer column). Keying by the `PlanKey` keeps two occurrences of the
+  /// SAME inner SQL — under a `.caller` and a `.view(name)` scope, or across two
+  /// set-operation arms whose correlated column has a DIFFERENT outer ordinal —
+  /// DISJOINT, so each executes its OWN plan rather than the first occurrence's,
+  /// while an identical occurrence under an identical outer layout still SHARES.
+  /// An UNCORRELATED occurrence carries none — it re-runs its `Query`
+  /// (recompiling resolves without an outer scope) and memoises.
+  private var plans: Dictionary<PlanKey, Plan> = [:]
+
+  internal func overlay(_ scope: Subscope) -> ScopedRelations? {
+    overlays[scope]
+  }
+  internal func record(overlay: ScopedRelations, for scope: Subscope) {
+    overlays[scope] = overlay
+  }
+
+  internal func plan(_ key: PlanKey) -> Plan? { plans[key] }
+  internal func record(plan: Plan, for key: PlanKey) {
+    if plans[key] == nil { plans[key] = plan }
   }
 }
 
@@ -219,12 +449,40 @@ internal struct Subquery {
   /// occurrence (whose type is irrelevant) may be absent.
   private let types: Dictionary<Query, ValueType>
 
+  /// Each nested `Query` mapped to its CORRELATION — the synthetic bound params
+  /// its inner `WHERE`/`ON` names of an enclosing column, discovered by the
+  /// pre-pass compiling the nested query under this select's scope as its
+  /// `Outer`. An UNCORRELATED nested query maps to the empty correlation (or is
+  /// absent), so its lowered node bypasses nothing; a correlated one carries its
+  /// map into the lowered `Filter`/`Term` so the per-outer-row re-execution
+  /// binds the named cells.
+  private let correlations: Dictionary<Query, Correlation>
+
+  /// The ENCLOSING scope THIS select's OWN columns correlate against — set when
+  /// this select is itself a subquery, so a column its relations do not bind
+  /// resolves against the outer query and lowers to a `Term.parameter`. `nil`
+  /// for a top-level select (no enclosing scope), leaving an unbound column the
+  /// ordinary fault.
+  private let outer: Outer?
+
+  /// Whether this lowering surface ADMITS a correlated column — TRUE for the
+  /// inner `WHERE`/`ON` (a synthetic bound param is a valid lowering there),
+  /// FALSE for the projection / `GROUP BY` / `HAVING` (the minimal (b) cut has
+  /// no evaluator for an outer column there). A barred surface DIAGNOSES a
+  /// correlated column as unsupported rather than mis-resolving it.
+  private let admits: Bool
+
   internal init(_ scope: Subscope = .caller,
                 _ widths: Dictionary<Query, Int> = [:],
-                _ types: Dictionary<Query, ValueType> = [:]) {
+                _ types: Dictionary<Query, ValueType> = [:],
+                _ correlations: Dictionary<Query, Correlation> = [:],
+                outer: Outer? = nil, admits: Bool = true) {
     self.scope = scope
     self.widths = widths
     self.types = types
+    self.correlations = correlations
+    self.outer = outer
+    self.admits = admits
   }
 
   /// A `Subquery` for a lowering surface with no catalog — a schema-only
@@ -232,6 +490,53 @@ internal struct Subquery {
   /// `SQLError.unsupported` rather than mis-lower.
   internal static var unsupported: Subquery {
     Subquery()
+  }
+
+  /// This seam with correlation BARRED — the surface a projection / `GROUP BY`
+  /// / `HAVING` lowers under, where an outer column is out of the minimal (b)
+  /// cut. It keeps the widths/types/correlations (nested subqueries there still
+  /// lower and carry their OWN inner correlation) but rejects a correlated
+  /// column of THIS query as unsupported.
+  internal var barred: Subquery {
+    Subquery(scope, widths, types, correlations, outer: outer, admits: false)
+  }
+
+  /// The synthetic bound-parameter name a CORRELATED reference to `column`
+  /// lowers to, or `nil` when no enclosing scope binds it (the ordinary
+  /// unknown-column fault stands). A `.column` lowering consults this ONLY after
+  /// its own relations fail to bind the name.
+  ///
+  /// On a barred surface (a projection / `GROUP BY` / `HAVING`) an outer column
+  /// IS out of the minimal (b) cut, so a name the enclosing scope binds is
+  /// DIAGNOSED `SQLError.unsupported` rather than mis-resolved — the same fault
+  /// on the run and the schema paths, keeping typecheck↔run parity.
+  internal func correlate(_ column: Column) throws(SQLError) -> String? {
+    guard let name = try outer?.parameter(for: column) else { return nil }
+    guard admits else {
+      throw .unsupported(
+          "a correlated column is only supported in a subquery's WHERE")
+    }
+    return name
+  }
+
+  /// The outer type a correlated reference to `column` contributes to a SCHEMA
+  /// derive, or `nil` when no enclosing scope binds it — the non-recording,
+  /// non-faulting type probe `derive` reads so a correlated column types as its
+  /// outer column rather than faulting `SQLError.column`. A BARRED surface still
+  /// diagnoses it, so this schema surface and the run's lowering AGREE.
+  internal func correlated(_ column: Column) throws(SQLError) -> ValueType? {
+    guard let type = try outer?.type(for: column) else { return nil }
+    guard admits else {
+      throw .unsupported(
+          "a correlated column is only supported in a subquery's WHERE")
+    }
+    return type
+  }
+
+  /// The correlation of the nested `query` — its synthetic outer bindings —
+  /// discovered by the pre-pass, or the empty map for an UNCORRELATED one.
+  private func correlation(of query: Query) -> Correlation {
+    correlations[query] ?? [:]
   }
 
   /// The compiled column count of `query`, or a fault when the surface holds
@@ -272,7 +577,8 @@ internal struct Subquery {
   internal func exists(_ query: Query, negated: Bool)
       throws(SQLError) -> Filter {
     _ = try width(query)
-    return .exists(Subkey(scope, query, .existential), negated: negated)
+    return .exists(Subkey(scope, query, .existential),
+                   correlation: correlation(of: query), negated: negated)
   }
 
   /// Lowers `operand [NOT] IN (query)` — `operand` already lowered to a `Term`
@@ -284,7 +590,8 @@ internal struct Subquery {
       throws(SQLError) -> Filter {
     let width = try width(query)
     guard width == 1 else { throw .arity(1, width) }
-    return .within(operand, Subkey(scope, query, .valued), negated: negated)
+    return .within(operand, Subkey(scope, query, .valued),
+                   correlation: correlation(of: query), negated: negated)
   }
 
   /// Lowers `operand op {ANY | ALL} (query)` — `operand` already lowered to a
@@ -292,13 +599,17 @@ internal struct Subquery {
   /// `SQLError.arity`, from the COMPILED width, so a two-column subquery faults
   /// here WITHOUT running), then carrying the query into the `Filter` under the
   /// SAME `.valued` role `within` uses — the full column is materialised and
-  /// folded per outer row — to run at execution.
+  /// folded per outer row — with the discovered `correlation` threaded exactly
+  /// as `within` threads it, so a CORRELATED quantified re-runs its inner plan
+  /// per outer row (an UNCORRELATED one carries an empty correlation and
+  /// memoises once), to run at execution.
   internal func quantified(_ operand: Term, _ op: Comparison,
                            _ quantifier: Quantifier, _ query: Query)
       throws(SQLError) -> Filter {
     let width = try width(query)
     guard width == 1 else { throw .arity(1, width) }
-    return .quantified(operand, op, quantifier, Subkey(scope, query, .valued))
+    return .quantified(operand, op, quantifier, Subkey(scope, query, .valued),
+                       correlation: correlation(of: query))
   }
 
   /// Lowers a scalar subquery `(query)` to a `Term.subquery` reading its
@@ -312,162 +623,197 @@ internal struct Subquery {
   internal func scalar(_ query: Query) throws(SQLError) -> Term {
     let width = try width(query)
     guard width == 1 else { throw .arity(1, width) }
-    return try .subquery(Subkey(scope, query, .scalar), type: output(query))
+    return try .subquery(Subkey(scope, query, .scalar),
+                         correlation: correlation(of: query),
+                         type: output(query))
   }
 }
 
-/// The RUN-time cache that executes each UNCORRELATED subquery ONCE and
-/// memoises its result — the seam that gives the row evaluator a subquery result
-/// WITHOUT itself holding the borrowing catalog.
+/// The PER-SITE lowering seams a select's pre-pass discovers — ONE `Subquery`
+/// per join `ON` (resolved against that join's PREFIX scope) and one for the
+/// REST (the WHERE, `HAVING`, projection, and `ORDER BY`, resolved against the
+/// full join scope).
 ///
-/// A subquery is UNCORRELATED in this slice — it names no column of the
-/// enclosing query — so its result is the SAME for every outer row and is
-/// computed at most once per outer-query execution. The `run` path, where the
-/// borrowing catalog IS in scope, populates this map BEFORE executing the plan
-/// (see `Catalog.subqueries(of:)`), so the evaluator reads it as plain
-/// escapable data. An `EXISTS` reads whether the result is non-empty; an
-/// `IN (Q)` folds over its single materialised column.
+/// The same inner SQL in both an `ON` and the WHERE is resolved TWICE, each
+/// against its OWN site's scope, so a name the `ON`'s narrow prefix binds
+/// UNAMBIGUOUSLY yet the WHERE's full scope binds in MORE than one relation is a
+/// prefix correlation in the `ON` and a genuine ambiguity in the WHERE — each
+/// per its own site, not the first occurrence's prefix (see `subquery(of:)`).
+internal struct Plans {
+  /// The lowering seam of each join `ON`, in join order — `on(i)` reads the
+  /// `i`-th, resolved against `prefixes[i]`.
+  private let ons: Array<Subquery>
+
+  /// The lowering seam the WHERE, `HAVING`, projection, and `ORDER BY` share,
+  /// resolved against the full join scope.
+  internal let rest: Subquery
+
+  internal init(_ ons: Array<Subquery>, _ rest: Subquery) {
+    self.ons = ons
+    self.rest = rest
+  }
+
+  /// The lowering seam of join `index`'s `ON`.
+  internal func on(_ index: Int) -> Subquery {
+    ons[index]
+  }
+}
+
+/// The RUN-time cache that runs each UNCORRELATED subquery ONCE, LAZILY on the
+/// first reach of its lowered node, and memoises the result — the seam that
+/// gives the row evaluator a subquery result WITHOUT itself holding the
+/// borrowing catalog stored.
 ///
-/// An `IN`/`EXISTS` occurrence is materialised EAGERLY here — its full result
-/// or its probe run at run start, since a `WHERE`/`ON` predicate referencing it
-/// is not short-circuited past. A SCALAR occurrence instead materialises
-/// LAZILY, on the first evaluation of its `Term.subquery` (memoised in
-/// `scalars`), so an occurrence in an unreachable `CASE`/`COALESCE` arm never
-/// runs. Per-arm short-circuit for the `IN`/`EXISTS` roles and the
-/// per-outer-row re-execution a CORRELATED subquery needs thread a runner to
-/// the predicate site in a follow-up.
+/// The evaluator (a `Catalog` method, the catalog IN scope) runs a subquery
+/// itself: it reads this cache first and, on a miss, runs the inner plan and
+/// `store`s the result. An UNCORRELATED occurrence names no enclosing column, so
+/// its result is the SAME for every outer row and is memoised under its
+/// occurrence `Subkey`; a later reach returns it WITHOUT re-running. A CORRELATED
+/// occurrence's result depends on the bound outer row, so it BYPASSES this cache
+/// entirely — the evaluator re-runs its inner plan per outer row against a
+/// `bindings` extended with the correlated cells (this slice does NOT memoise
+/// across distinct binding tuples — a flagged future optimisation). Every role
+/// (scalar / `IN` / `EXISTS`) is lazy, so a subquery an unreachable `CASE` arm
+/// or a short-circuited `AND`/`OR` never reaches never runs.
 internal struct Subqueries {
-  private let results: Dictionary<Subkey, MaterialisedSubquery>
+  /// The shared memo of the UNCORRELATED occurrences materialised LAZILY on
+  /// first reach — a reference so every by-value copy of this cache down the
+  /// evaluate tree shares the one box, keeping each materialise-once.
+  private let memo: SubqueryMemo
 
-  /// The shared memo of the scalar occurrences materialised LAZILY on first
-  /// evaluation — a reference so every by-value copy of this cache down the
-  /// evaluate tree shares the one box, keeping a scalar materialise-once.
-  private let scalars: ScalarMemo
-
-  /// The REVEALED base scope the eager occurrences of this cache ran against,
-  /// keyed PER `Subscope` — the enclosing scope with this SELECT's derived
-  /// aliases revealed away and its CTEs/store relations intact
-  /// (`Context.revealed`), stored under the `Subscope` those occurrences
-  /// materialised in. A LAZY scalar occurrence resolves its inner query against
-  /// the scope of its OWN `Subkey`, not the augmented overlay threaded down the
-  /// evaluate tree: the executor threads only the EXECUTING plan's overlay, so
-  /// after a `merged` folds a view-body cache into the caller's it cannot tell
-  /// a view-body occurrence's scope from the caller's. Keying PER `Subscope`
-  /// keeps a `.view(name)` scalar reading the VIEW's own relations and a
-  /// `.caller` scalar the caller's — one shared scope resolved a view-body
-  /// scalar against the caller's overlay (the round-15 fault). Empty for a
-  /// scope the cache carries no eager occurrence of (a bare `Subqueries()` a
-  /// schema path threads), so the lazy scalar falls back to the threaded
-  /// overlay — whose derived layer a `cell(of:)` reveal drops to expose a CTE a
-  /// same-named derived alias shadows.
-  private let scopes: Dictionary<Subscope, ScopedRelations>
-
-  internal init(_ results: Dictionary<Subkey, MaterialisedSubquery> = [:],
-                _ scalars: ScalarMemo = ScalarMemo(),
-                _ scopes: Dictionary<Subscope, ScopedRelations> = [:]) {
-    self.results = results
-    self.scalars = scalars
-    self.scopes = scopes
+  internal init(_ memo: SubqueryMemo = SubqueryMemo()) {
+    self.memo = memo
   }
 
-  /// The revealed base relations the occurrences of `scope` ran against, or an
-  /// empty map when the cache carries none — the scope a LAZY scalar of that
-  /// `Subscope` resolves its inner query against, falling back to the threaded
-  /// overlay when empty (a schema path's bare cache).
-  internal func relations(_ scope: Subscope) -> ScopedRelations {
-    scopes[scope] ?? [:]
+  /// The memoised `EXISTS` non-empty result for the UNCORRELATED occurrence
+  /// `key`, or `nil` when it has not yet run — the evaluator probes on a miss
+  /// and `store`s it.
+  internal func present(cached key: Subkey) -> Bool? {
+    memo.present(key)
   }
 
-  /// The materialised result for `key` — every occurrence a runnable plan
-  /// references is populated at run start, so a miss is an internal invariant
-  /// break, reported rather than silently treated as empty.
-  private func result(_ key: Subkey) throws(SQLError) -> MaterialisedSubquery {
-    guard let result = results[key] else {
-      throw .named("a subquery result was not materialised")
-    }
-    return result
+  /// Records the `EXISTS` non-empty result of the UNCORRELATED occurrence `key`.
+  internal func store(present value: Bool, for key: Subkey) {
+    memo.store(present: value, for: key)
   }
 
-  /// Whether the occurrence `key` yielded a row — the `EXISTS` non-empty test.
-  internal func present(_ key: Subkey) throws(SQLError) -> Bool {
-    try result(key).present
+  /// The memoised `IN (Q)` single column for the UNCORRELATED occurrence `key`,
+  /// or `nil` when it has not yet run — the evaluator materialises on a miss and
+  /// `store`s it.
+  internal func values(cached key: Subkey) -> Array<Value>? {
+    memo.values(key)
   }
 
-  /// The single column of the occurrence `key`'s result — the `IN (Q)`
-  /// membership values. The plan compiled the query's width to 1, so the first
-  /// cell of each row is its lone value; an `IN` occurrence is always
-  /// materialised in FULL, so its values are present.
-  internal func values(_ key: Subkey) throws(SQLError) -> Array<Value> {
-    try result(key).values()
+  /// Records the `IN (Q)` single-column value set of the UNCORRELATED
+  /// occurrence `key`.
+  internal func store(values: Array<Value>, for key: Subkey) {
+    memo.store(values: values, for: key)
   }
 
-  /// The already-collapsed value memoised for the scalar occurrence `key`, or
-  /// `nil` when it has not yet been evaluated. The evaluator reads this first;
-  /// on a miss it runs the subquery (where the catalog is in scope) and
-  /// `store`s the collapsed value, so a scalar in an unreachable arm never runs
-  /// and a reached one runs at most once.
+  /// The already-collapsed value memoised for the scalar UNCORRELATED
+  /// occurrence `key`, or `nil` when it has not yet been evaluated.
   internal func scalar(cached key: Subkey) -> Value? {
-    scalars.value(key)
+    memo.scalar(key)
   }
 
-  /// Records `value` as the collapsed value of the scalar occurrence `key` —
-  /// the evaluator's memoisation after the first reached evaluation runs the
-  /// subquery, so a later read of the same key returns it without re-running.
+  /// Records `value` as the collapsed value of the scalar UNCORRELATED
+  /// occurrence `key`.
   internal func store(scalar value: Value, for key: Subkey) {
-    scalars.store(value, for: key)
+    memo.store(scalar: value, for: key)
   }
 
-  /// The DISJOINT union of this cache and `other`'s — every entry of both,
-  /// which never collide because their keys carry distinct `Subscope`s: `self`
-  /// holds one resolution context's occurrences (the caller's, keyed
-  /// `.caller`), `other` another's (a view body's, keyed `.view(name)`). A
-  /// subquery AST-identical in both is TWO occurrences under TWO scopes, so it
-  /// occupies TWO keys — neither overwrites the other, and the pushed caller
-  /// filter reads its `.caller` result while the view-body filter reads its
-  /// `.view` one. A collision would be an id-space bug (two contexts sharing a
-  /// scope); it cannot happen, so the merge keeps the existing entry. The
-  /// merged cache keeps `self`'s scalar memo and UNIONS the per-`Subscope`
-  /// base scopes of both — a caller cache and a view-body cache resolve
-  /// DISJOINT scalar keys, so one shared memo serves both spaces, and each
-  /// `Subscope` keeps its OWN base relations (the `.caller` map and the
-  /// `.view(name)` map ride through side by side), so a view-body lazy scalar
-  /// resolves against the VIEW's relations and a caller scalar the caller's —
-  /// keeping only `self`'s left-hand scope would resolve a view-body scalar
-  /// against the caller overlay. Two contexts sharing a `Subscope` would be an
-  /// id-space bug, so a scope collision keeps `self`'s.
+  /// The resolution overlay `scope`'s subqueries run under — the overlay
+  /// recorded as `scope` began executing (see `SubqueryMemo.overlays`), or `nil`
+  /// when none was recorded (a top-level run always records `.caller`).
+  internal func overlay(_ scope: Subscope) -> ScopedRelations? {
+    memo.overlay(scope)
+  }
+
+  /// Records `overlay` as the resolution overlay `scope`'s subqueries run
+  /// under — the caller's before executing the top-level plan, a view body's
+  /// before deriving it — so a subquery lowered under `scope` re-runs against
+  /// ITS overlay even when a pushdown moved its predicate to another site.
+  internal func record(overlay: ScopedRelations, for scope: Subscope) {
+    memo.record(overlay: overlay, for: scope)
+  }
+
+  /// The pre-compiled inner plan of the CORRELATED occurrence `key` under
+  /// `correlation` — compiled once with its enclosing scope so its correlated
+  /// columns are `Term.parameter` — or `nil` for an UNCORRELATED one (which
+  /// recompiles fresh per run). Keyed by the occurrence's `PlanKey` (its `Subkey`
+  /// plus the correlation's parameter names), so two occurrences of the SAME
+  /// inner SQL under DIFFERENT outer layouts — two set-operation arms whose
+  /// correlated column sits at different ordinals — each find their OWN plan.
+  internal func plan(_ key: Subkey, _ correlation: Correlation) -> Plan? {
+    memo.plan(PlanKey(key, correlation))
+  }
+
+  /// Stashes `plan` as the pre-compiled inner plan of the CORRELATED occurrence
+  /// `key` under `correlation`, for the evaluator to re-execute per outer row.
+  internal func record(plan: Plan, for key: Subkey,
+                       _ correlation: Correlation) {
+    memo.record(plan: plan, for: PlanKey(key, correlation))
+  }
+
+  /// This cache — the memo is a shared box the whole run accretes into, so a
+  /// caller cache and a view-body cache share one box, their disjoint `Subscope`
+  /// keys never colliding. The prior eager merge collapses to identity now that
+  /// every occurrence is memoised lazily against this one shared box.
   internal func merged(_ other: Subqueries) -> Subqueries {
-    Subqueries(results.merging(other.results) { existing, _ in existing },
-               scalars,
-               scopes.merging(other.scopes) { existing, _ in existing })
+    self
   }
 }
 
-/// The mutable set of SCALAR-subquery inner queries the type-check walk
-/// REACHED, shared by a `SubqueryCheck` by REFERENCE.
+/// One subquery OCCURRENCE the type-check walk reached — its inner `query`
+/// and the `role` it materialises in AT THAT occurrence.
 ///
-/// A scalar subquery's inner-query OPERAND validation is DEFERRED to the
-/// reachability walk (`Scope.validate`), mirroring the lazy executor: an
-/// occurrence in an unreachable `CASE`/`COALESCE` arm never validates, exactly
-/// as it never runs. The walk cannot itself hold the borrowing catalog a
-/// recursive type-check needs, so as it REACHES each scalar `.subquery` it
-/// records the inner query here; the catalog-bearing `typecheck` phase reads
-/// this set AFTER the walk and type-checks only the reached inner queries. The
-/// box is a class so the reached set survives `SubqueryCheck` being copied by
-/// value down the walk — every copy shares the one box, the same way
-/// `ScalarMemo` shares the run's lazy collapse.
-internal final class ReachedScalars {
-  private var queries: Set<Query> = []
+/// The role is recorded PER OCCURRENCE (not derived from the union of every
+/// role the query occupies in the select) so the deferred type-check picks the
+/// occurrence's OWN run shape: an `existential` reach validates the EXISTS
+/// PROBE (no projection), a `scalar`/`valued` reach the original. So the SAME
+/// inner SQL reached only as an `EXISTS` validates the probe even where an
+/// unreached arm has it as a scalar.
+internal struct Reach: Hashable, Sendable {
+  /// The reached occurrence's inner query.
+  internal let query: Query
 
-  /// Records `query` as a scalar occurrence the walk reached, so the deferred
-  /// type-check phase validates its inner query.
-  internal func reach(_ query: Query) {
-    queries.insert(query)
+  /// The role the occurrence materialises in — the shape its deferred
+  /// type-check validates.
+  internal let role: Role
+
+  internal init(_ query: Query, _ role: Role) {
+    self.query = query
+    self.role = role
+  }
+}
+
+/// The mutable set of subquery OCCURRENCES the type-check walk REACHED, shared
+/// by a `SubqueryCheck` by REFERENCE.
+///
+/// A subquery's inner-query OPERAND validation is DEFERRED to the reachability
+/// walk (`Scope.validate`), mirroring the lazy executor: an occurrence in an
+/// unreachable `CASE`/`COALESCE` arm or a short-circuited `AND`/`OR` leg never
+/// validates, exactly as it never runs. The walk cannot itself hold the
+/// borrowing catalog a recursive type-check needs, so as it REACHES each
+/// occurrence it records the inner query AND its role here; the catalog-bearing
+/// `typecheck` phase reads this set AFTER the walk and type-checks only the
+/// reached occurrences, each in its OWN role's shape. The box is a class so the
+/// reached set survives `SubqueryCheck` being copied by value down the walk —
+/// every copy shares the one box, the same way `ScalarMemo` shares the run's
+/// lazy collapse.
+internal final class ReachedScalars {
+  private var occurrences: Set<Reach> = []
+
+  /// Records `query` as an occurrence the walk reached in `role`, so the
+  /// deferred type-check phase validates its inner query in that role's shape.
+  internal func reach(_ query: Query, as role: Role) {
+    occurrences.insert(Reach(query, role))
   }
 
-  /// The scalar inner queries the walk reached — the ones the deferred phase
-  /// type-checks.
-  internal var reached: Set<Query> {
-    queries
+  /// The subquery occurrences the walk reached — the ones the deferred phase
+  /// type-checks, each in its own role's shape.
+  internal var reached: Set<Reach> {
+    occurrences
   }
 }
 
@@ -506,9 +852,11 @@ internal struct SubqueryCheck {
   /// result schema (`validate`/`derive`), matching the lowering's `Subquery`.
   private let types: Dictionary<Query, ValueType>
 
-  /// The scalar inner queries whose OPERAND validation is DEFERRED to the walk
-  /// — the ones NOT eagerly type-checked in the pre-pass (a scalar-ONLY
-  /// occurrence). The `.subquery` case records a reached one into `reached`.
+  /// The scalar inner queries whose OPERAND validation is DEFERRED through the
+  /// `.subquery` case of the walk — a scalar-ONLY occurrence, recorded reached
+  /// by `type`. An `IN`/`EXISTS`/quantified occurrence defers through
+  /// `validate` instead (its arity/type derivation stays total), so the two
+  /// record paths stay distinct.
   private let deferred: Set<Query>
 
   /// The shared box the walk records each reached scalar occurrence into, read
@@ -516,14 +864,29 @@ internal struct SubqueryCheck {
   /// reached inner queries.
   private let reached: ReachedScalars
 
+  /// The ENCLOSING scope this select's OWN columns correlate against — the
+  /// validation-side analog of `Subquery.outer`, so a correlated column resolves
+  /// against the outer query exactly as the run's lowering does, keeping
+  /// typecheck↔run parity. `nil` for a top-level select.
+  private let outer: Outer?
+
+  /// Whether this surface ADMITS a correlated column — the inner `WHERE`/`ON`
+  /// (TRUE) versus a projection / `GROUP BY` / `HAVING` (FALSE, diagnosed) — the
+  /// analog of `Subquery.admits`, so validation faults the unsupported
+  /// correlated-projection case exactly where the run does.
+  private let admits: Bool
+
   internal init(_ widths: Dictionary<Query, Int> = [:],
                 _ types: Dictionary<Query, ValueType> = [:],
                 deferred: Set<Query> = [],
-                reached: ReachedScalars = ReachedScalars()) {
+                reached: ReachedScalars = ReachedScalars(),
+                outer: Outer? = nil, admits: Bool = true) {
     self.widths = widths
     self.types = types
     self.deferred = deferred
     self.reached = reached
+    self.outer = outer
+    self.admits = admits
   }
 
   /// A checker for a surface with no catalog — validating a subquery needs one,
@@ -533,13 +896,61 @@ internal struct SubqueryCheck {
     SubqueryCheck()
   }
 
-  /// Asserts the inner `query` was validated in the pre-pass — a query the
-  /// surface's map holds has been type-checked and compiled; one it does not
-  /// reached a catalog-less surface and is rejected.
-  internal func validate(_ query: Query) throws(SQLError) {
+  /// This checker with correlation BARRED — the surface a projection / `GROUP
+  /// BY` / `HAVING` type-checks under, where an outer column is out of the (b)
+  /// cut and is diagnosed rather than resolved. Mirrors `Subquery.barred`.
+  internal var barred: SubqueryCheck {
+    SubqueryCheck(widths, types, deferred: deferred, reached: reached,
+                  outer: outer, admits: false)
+  }
+
+  /// This checker over a FRESH `reached` box, carrying `outer` — the surface a
+  /// join `ON` type-checks under. The `ON` shares this select's width/type
+  /// derivation and its enclosing `outer` (a correlated `ON` column resolves
+  /// against the containing query as the WHERE's does), but the caller runs its
+  /// reachability walk against the join's PREFIX scope (its LOCAL relations),
+  /// so a reference to a later-joined relation faults per the prefix. The fresh
+  /// box keeps its reached occurrences separate for the caller to validate
+  /// against that prefix.
+  internal func scoped(_ outer: Outer?) -> SubqueryCheck {
+    SubqueryCheck(widths, types, deferred: deferred,
+                  reached: ReachedScalars(), outer: outer)
+  }
+
+  /// The outer type `column` correlates to, or `nil` when no enclosing scope
+  /// binds it — the validation-side `Subquery.correlate`: it resolves against
+  /// `outer`, faulting `.unsupported` on a BARRED surface (a projection / `GROUP
+  /// BY` / `HAVING`) so validation rejects the unsupported correlated-projection
+  /// case exactly as the run's lowering does, and returns the outer column's
+  /// type so `validate` types the reference as that column. Consulted ONLY after
+  /// the local relations fail to bind the name.
+  internal func correlated(_ column: Column) throws(SQLError) -> ValueType? {
+    guard let type = try outer?.type(for: column) else { return nil }
+    guard admits else {
+      throw .unsupported(
+          "a correlated column is only supported in a subquery's WHERE")
+    }
+    return type
+  }
+
+  /// Asserts the inner `query` was compiled in the pre-pass — a query the
+  /// surface's map holds has had its arity/type derived; one it does not
+  /// reached a catalog-less surface and is rejected — and RECORDS it reached in
+  /// `role`, so the `typecheck` phase validates its OPERANDS after the walk in
+  /// that role's shape. This is the WALK-reach point for an
+  /// `IN`/`EXISTS`/quantified occurrence: `check` calls it only when the
+  /// reachability walk arrives at the `.within`/`.exists`/`.quantified` node,
+  /// so an occurrence in a skipped `CASE`/`COALESCE` arm or a short-circuited
+  /// `AND`/`OR` leg is never recorded — its body is not type-checked, exactly
+  /// as the lazy executor never materialises it. A REACHED one is validated in
+  /// its OWN role's shape (an `EXISTS` reach → the probe), so a reached bad
+  /// body still faults (parity both directions), while an unreached arm's role
+  /// never widens a reached occurrence's shape.
+  internal func validate(_ query: Query, as role: Role) throws(SQLError) {
     guard widths[query] != nil else {
       throw .unsupported("a subquery is not supported in this position")
     }
+    reached.reach(query, as: role)
   }
 
   /// The column count `query` projects — from the pre-pass compile.
@@ -560,13 +971,14 @@ internal struct SubqueryCheck {
   /// pre-pass (`subqueryCheck`), so a two-column subquery in a skipped arm still
   /// faults.
   internal func type(_ query: Query) throws(SQLError) -> ValueType {
-    // A DEFERRED scalar occurrence is REACHED here: record it for the
-    // `typecheck` phase to validate its inner query's OPERANDS, mirroring the
-    // lazy executor materialising only a reached scalar. Its arity and single-
-    // column type were derived eagerly in `subqueryCheck` (cursor-free, total),
-    // so this reads them exactly as an eagerly-checked occurrence does — only
-    // the operand fault (`.divide`) it might raise defers to the reached walk.
-    if deferred.contains(query) { reached.reach(query) }
+    // A DEFERRED scalar occurrence is REACHED here in the `scalar` role: record
+    // it for the `typecheck` phase to validate its inner query's OPERANDS,
+    // mirroring the lazy executor materialising only a reached scalar. Its
+    // arity and single-column type were derived eagerly in `subqueryCheck`
+    // (cursor-free, total), so this reads them exactly as an eagerly-checked
+    // occurrence does — only the operand fault (`.divide`) it might raise
+    // defers to the reached walk.
+    if deferred.contains(query) { reached.reach(query, as: .scalar) }
     let width = try width(query)
     guard width == 1 else { throw .arity(1, width) }
     guard let type = types[query] else {
@@ -575,10 +987,14 @@ internal struct SubqueryCheck {
     return type
   }
 
-  /// The scalar inner queries the walk reached — the ones the `typecheck` phase
-  /// validates after the walk, mirroring the lazy executor's evaluation of only
-  /// a reached scalar subquery.
-  internal var visited: Set<Query> {
+  /// The occurrences the walk reached — the scalar ones recorded by `type` and
+  /// the `IN`/`EXISTS`/quantified ones recorded by `validate` — each paired
+  /// with the ROLE it reached in. The `typecheck` phase validates only these
+  /// after the walk, mirroring the lazy executor's evaluation of only a reached
+  /// subquery, picking each one's RUN shape from ITS OWN reached role (an
+  /// `existential` → the EXISTS probe, a `scalar`/`valued` → the original), not
+  /// from the union of every role the query occupies in the select.
+  internal var visited: Set<Reach> {
     reached.reached
   }
 }
@@ -872,6 +1288,33 @@ extension Schema {
     return ordinal
   }
 
+  /// The ordinal `column` resolves to in `relation`, or `nil` when it is a
+  /// candidate CORRELATED reference to an enclosing scope — this relation does
+  /// not name it — the not-found probe the single-relation `.column` lowering
+  /// consults before correlating outward.
+  ///
+  /// The two not-found situations `ordinal(of:in:)` conflates as `.column` are
+  /// DISTINGUISHED here. A qualifier this relation does NOT answer (its alias,
+  /// else its name), or an unqualified name it does not carry, is a genuine
+  /// not-found → `nil`, so the walk correlates to the outer query. But a
+  /// qualifier this relation DOES answer, naming a column it LACKS, is a hard
+  /// `SQLError.column` that PROPAGATES: the local alias SHADOWS a same-named
+  /// outer relation, so the miss faults against the inner relation rather than
+  /// falling through to bind the outer one. This is the single-relation analog
+  /// of `Scope.find`.
+  internal func find(_ column: Column, in relation: Relation)
+      throws(SQLError) -> Int? {
+    if let qualifier = column.qualifier,
+        (relation.alias ?? relation.name) != qualifier {
+      return nil
+    }
+    guard let ordinal = ordinal(of: column.name) else {
+      guard column.qualifier == nil else { throw .column(column.name) }
+      return nil
+    }
+    return ordinal
+  }
+
   /// The projected terms of `projection`, addressed by ordinal: a `*` or a
   /// bare-column list yields one `.slot(ordinal)` per column; an expression list
   /// lowers each expression to a term. The terms hold ordinals, which the
@@ -880,14 +1323,25 @@ extension Schema {
                       _ routines: Routines = [:],
                       subquery: Subquery = .unsupported)
       throws(SQLError) -> Array<Term> {
+    // A projection is a BARRED clause position: a correlated column of THIS
+    // query has no evaluator here (only WHERE/ON/HAVING admit one). The cut is
+    // intrinsic to the entry, so a caller CANNOT pass an admitting seam into a
+    // projection — the FROM-less scalar path included — keeping the run's
+    // lowering and the schema `columns(of:)` derive in lockstep.
+    let subquery = subquery.barred
     switch projection {
     case .all:
       return (0 ..< width).map { .slot($0) }
     case let .columns(columns):
+      // Lower each bare column through `term`, so a name this relation does not
+      // bind consults the `subquery` surface: a correlated reference on the
+      // BARRED projection surface is diagnosed unsupported (parity with the
+      // schema path) rather than faulting `SQLError.column`.
       var terms = Array<Term>()
       terms.reserveCapacity(columns.count)
       for column in columns {
-        try terms.append(.slot(ordinal(of: column, in: relation)))
+        try terms.append(term(.column(column), in: relation, routines,
+                              subquery: subquery))
       }
       return terms
     case let .expressions(projected):
@@ -910,6 +1364,15 @@ extension Schema {
       throws(SQLError) -> Term {
     switch expression {
     case let .column(column):
+      // Resolve against this relation first; a name it does not bind is a
+      // candidate CORRELATED reference to the enclosing scope, lowered to a
+      // synthetic `Term.parameter` when the outer scope binds it, else the
+      // ordinary unknown-column fault. A QUALIFIED miss on THIS relation (its
+      // alias names it, but the column is absent) is a HARD `.column` `find`
+      // propagates — never a fall-through to correlate a same-qualifier outer
+      // relation, which the local alias SHADOWS.
+      if let ordinal = try find(column, in: relation) { return .slot(ordinal) }
+      if let name = try subquery.correlate(column) { return .parameter(name) }
       return try .slot(ordinal(of: column, in: relation))
     case let .literal(literal):
       return try .constant(value(of: literal))
@@ -1005,7 +1468,10 @@ extension Schema {
                       _ routines: Routines = [:],
                       subquery: Subquery = .unsupported)
       throws(SQLError) -> Array<SortKey> {
-    try SQLEngine.order(order, projection, names) {
+    // An ORDER BY is BARRED, as the projection is: a correlated column of THIS
+    // query is out of the cut here, so the entry bars the seam by construction.
+    let subquery = subquery.barred
+    return try SQLEngine.order(order, projection, names) {
       expression throws(SQLError) in
       try term(expression, in: relation, routines, subquery: subquery)
     }
@@ -1143,7 +1609,17 @@ internal struct Scope {
       throws(SQLError) -> ValueType {
     return switch expression {
     case let .column(column):
-      try type(at: ordinal(of: column))
+      // A column this scope does not bind may be a CORRELATED reference to an
+      // enclosing query (in an inner `WHERE`); type it as the outer column, else
+      // the ordinary column fault. A LOCALLY AMBIGUOUS name is a HARD error
+      // `find` propagates, never a fall-through to outer correlation.
+      if let ordinal = try find(column) {
+        type(at: ordinal)
+      } else if let type = try subquery.correlated(column) {
+        type
+      } else {
+        try type(at: ordinal(of: column))
+      }
     case let .literal(literal):
       type(of: literal)
     case let .call(name, _):
@@ -1381,7 +1857,19 @@ internal struct Scope {
       throws(SQLError) -> ValueType {
     switch expression {
     case let .column(column):
-      try type(at: ordinal(of: column))
+      // A column this scope does not bind may be a CORRELATED reference to an
+      // enclosing query (validated exactly as the run resolves it — a `WHERE`
+      // one types as its outer column, a projection/`HAVING` one faults
+      // unsupported); else the ordinary column fault. A LOCALLY AMBIGUOUS name
+      // is a HARD error `find` propagates, never a fall-through to outer
+      // correlation.
+      if let ordinal = try find(column) {
+        type(at: ordinal)
+      } else if let type = try subquery.correlated(column) {
+        type
+      } else {
+        try type(at: ordinal(of: column))
+      }
     case let .literal(literal):
       type(of: literal)
     case let .call(name, arguments):
@@ -1809,21 +2297,26 @@ internal struct Scope {
       // Validate the inner UNCORRELATED query as the run's lowering does — it
       // resolves and type-checks against the enclosing catalog, so a bad column
       // or routine inside it faults at validation, matching what a run rejects.
-      try subquery.validate(query)
+      // Reached in the `existential` role, so the deferred phase validates its
+      // cardinality PROBE (no select list), never the original projection.
+      try subquery.validate(query, as: .existential)
     case let .within(operand, query, _):
       // Validate the operand AND the inner query, and enforce the single-column
       // arity the lowering does (`SQLError.arity`), so schema validation
       // matches execution — the recurring lesson that the two must not diverge.
+      // Reached in the `valued` role — its value set is read, so the deferred
+      // phase validates the ORIGINAL query.
       _ = try validate(operand, routines, subquery: subquery)
-      try subquery.validate(query)
+      try subquery.validate(query, as: .valued)
       let width = try subquery.width(query)
       guard width == 1 else { throw .arity(1, width) }
     case let .quantified(operand, _, _, query):
       // As `within`: validate the operand and the inner query, and enforce the
       // single-column arity the lowering does (`SQLError.arity`), so schema
-      // validation matches execution.
+      // validation matches execution. Reached `valued` (its values are read),
+      // so the deferred phase validates the ORIGINAL query.
       _ = try validate(operand, routines, subquery: subquery)
-      try subquery.validate(query)
+      try subquery.validate(query, as: .valued)
       let width = try subquery.width(query)
       guard width == 1 else { throw .arity(1, width) }
     case .bound:
@@ -2736,6 +3229,20 @@ internal struct Scope {
     return (member.relation.alias ?? member.relation.name) == qualifier
   }
 
+  /// Whether `column` is a QUALIFIED reference whose qualifier a relation of
+  /// this scope answers — a qualified name a present alias (else a table name)
+  /// names. An UNqualified name is FALSE (it names no one local relation to
+  /// shadow an outer one), as is a qualified name no local relation answers.
+  ///
+  /// A qualified name a local relation answers but none of this scope binds is
+  /// a QUALIFIED MISS on that relation — the local alias SHADOWS a same-named
+  /// enclosing relation, so `find` faults it hard rather than correlating
+  /// outward; an unadmitted qualifier is genuinely not local and correlates.
+  private func shadows(_ column: Column) -> Bool {
+    guard column.qualifier != nil else { return false }
+    return members.contains { admits($0, column) }
+  }
+
   /// The combined ordinal `column` resolves to.
   ///
   /// The name resolves against every admitted relation: present in exactly one
@@ -2754,6 +3261,48 @@ internal struct Scope {
     return resolved
   }
 
+  /// The combined ordinal `column` resolves to as an ENCLOSING reference, or
+  /// `nil` when this scope binds it in NONE of its relations — the probe a
+  /// nested subquery's `Outer` consults for a candidate correlated column. The
+  /// three outcomes are DISTINCT: a name bound by exactly one relation yields
+  /// its ordinal, a name bound by NONE reports `nil` (the `Outer` walk keeps
+  /// looking outward), and a name bound by MORE than one relation of this scope
+  /// is `SQLError.ambiguous` and PROPAGATES — a nearer ambiguous scope SHADOWS
+  /// farther ones rather than falling through to rebind the name to an outer
+  /// column. Only the not-found `SQLError.column` becomes `nil`; every other
+  /// fault (an ambiguity or a qualifier fault) propagates. This is the enclosing
+  /// analog of `find`, which the LOCAL lowering consults for the same reason.
+  internal func correlated(_ column: Column) throws(SQLError) -> Int? {
+    try find(column)
+  }
+
+  /// The combined ordinal `column` resolves to, or `nil` when it is a candidate
+  /// CORRELATED reference to an enclosing scope — the not-found probe a
+  /// `.column` lowering consults before correlating outward. FOUR outcomes stay
+  /// DISTINCT.
+  ///
+  /// A name bound by exactly one relation yields its ordinal (found → bind). A
+  /// name bound by MORE than one relation is `SQLError.ambiguous`, PROPAGATED
+  /// (never `nil`): a local ambiguity is a hard error, not a fall-through, so
+  /// `try?`-swallowing it would silently rebind an ambiguous local name to an
+  /// outer column. The remaining `SQLError.column` — no relation binds the name
+  /// — splits on whether some local relation ADMITTED the qualifier: an
+  /// UNADMITTED qualifier (or an absent unqualified name) is a genuine
+  /// not-found → `nil`, so the walk correlates outward; a qualifier a local
+  /// relation DOES admit, naming a column it LACKS, is a QUALIFIED MISS that
+  /// PROPAGATES as a hard `.column` — the local alias SHADOWS a same-qualifier
+  /// enclosing relation, so it faults against the inner relation rather than
+  /// falling through to bind the outer one.
+  internal func find(_ column: Column) throws(SQLError) -> Int? {
+    do {
+      return try ordinal(of: column)
+    } catch let error {
+      guard case .column = error else { throw error }
+      guard !shadows(column) else { throw error }
+      return nil
+    }
+  }
+
   /// The combined-ordinal projected terms: every real column of every relation
   /// for `*` (in chain order, never a virtual column) as `.slot` terms, a
   /// bare-column list as `.slot` terms at their combined ordinals, an expression
@@ -2762,6 +3311,10 @@ internal struct Scope {
                       _ routines: Routines = [:],
                       subquery: Subquery = .unsupported) throws(SQLError)
       -> Array<Term> {
+    // A projection is a BARRED clause position (see `Schema.terms`): the entry
+    // bars the seam, so no join-scope projection can admit a correlated column
+    // of THIS query.
+    let subquery = subquery.barred
     switch projection {
     case .all:
       // Every real column of every relation, at its combined ordinal — in chain
@@ -2774,10 +3327,14 @@ internal struct Scope {
       }
       return terms
     case let .columns(columns):
+      // Lower each bare column through `term`, so a name none of this scope's
+      // relations bind consults the `subquery` surface: a correlated reference
+      // on the BARRED projection surface is diagnosed unsupported (parity with
+      // the schema path) rather than faulting `SQLError.column`.
       var terms = Array<Term>()
       terms.reserveCapacity(columns.count)
       for column in columns {
-        try terms.append(.slot(ordinal(of: column)))
+        try terms.append(term(.column(column), routines, subquery: subquery))
       }
       return terms
     case let .expressions(projected):
@@ -2797,6 +3354,15 @@ internal struct Scope {
       throws(SQLError) -> Term {
     switch expression {
     case let .column(column):
+      // Resolve the column against this scope's own relations first; a name none
+      // binds is a candidate CORRELATED reference — consult the enclosing scope,
+      // lowering to a synthetic `Term.parameter` bound from the outer row when it
+      // resolves there, else the ordinary unknown-column fault. A LOCALLY
+      // AMBIGUOUS name (bound by more than one relation) is a HARD error `find`
+      // propagates — never a fall-through to outer correlation that would rebind
+      // it to an outer column.
+      if let ordinal = try find(column) { return .slot(ordinal) }
+      if let name = try subquery.correlate(column) { return .parameter(name) }
       return try .slot(ordinal(of: column))
     case let .literal(literal):
       return try .constant(value(of: literal))
@@ -2878,17 +3444,12 @@ internal struct Scope {
                       _ names: Array<String?>, _ routines: Routines = [:],
                       subquery: Subquery = .unsupported)
       throws(SQLError) -> Array<SortKey> {
-    try SQLEngine.order(order, projection, names) {
+    // An ORDER BY is BARRED, as the projection is (see `Schema.order`).
+    let subquery = subquery.barred
+    return try SQLEngine.order(order, projection, names) {
       expression throws(SQLError) in
       try term(expression, routines, subquery: subquery)
     }
-  }
-
-  /// Lowers a join's `ON left = right` to a `match` conjunct, each side
-  /// resolved to a combined ordinal across the chain.
-  internal func match(_ left: Column, _ right: Column) throws(SQLError)
-      -> Filter {
-    try .match(ordinal(of: left), ordinal(of: right))
   }
 
   /// Lowers a join's `ON predicate` to the engine's `Filter` across the chain,
@@ -2897,14 +3458,19 @@ internal struct Scope {
   /// `ON` is safe, and otherwise lowering the entire conjunction as one
   /// residual.
   ///
-  /// A `column = column` conjunct is the hash-join key `nest` folds into a
-  /// physical `Join`, so it lowers to a `match(left, right)` — the same node
-  /// the equi-only `ON` produced — rather than a `compare(.slot, .equal,
-  /// .slot)`, which `nest` would not recognise as a key. Every other leaf (an
-  /// inequality, an expression equality such as `a.x = b.y + 1`, an `IS NULL`,
-  /// a membership, an `OR`/`NOT`) lowers through `lower`, becoming a residual
-  /// the join runs as a filter over the product — nested-loop semantics,
-  /// correct if O(n·m).
+  /// The key is READ OFF the ALREADY-LOWERED conjunct, not by re-resolving the
+  /// AST: a conjunct whose lowered form is a `compare(.slot, .equal, .slot)` —
+  /// both operands columns of the join prefix — IS the hash-join key `nest`
+  /// folds into a physical `Join`, so it is rewritten to the `match(left,
+  /// right)` node `nest` recognises. A conjunct that lowered to a `.parameter`
+  /// operand is a CORRELATED outer reference (`ON V.x = T.id` under an EXISTS,
+  /// lowering to `compare(.slot, .equal, .parameter)`), NOT a column = column
+  /// key, so it stays the residual `ON` filter — re-resolving its AST would
+  /// consult only the prefix and fault `SQLError.column` on the outer column
+  /// that already lowered correctly. Every other leaf (an inequality, an
+  /// expression equality such as `a.x = b.y + 1`, an `IS NULL`, a membership,
+  /// an `OR`/`NOT`) lowers through `lower`, becoming a residual the join runs
+  /// as a filter over the product — nested-loop semantics, correct if O(n·m).
   ///
   /// A `match` key is extracted ONLY WHEN EVERY lowered conjunct is `safe`; if
   /// ANY conjunct is unsafe, the whole `ON` lowers to a single residual and NO
@@ -2940,14 +3506,18 @@ internal struct Scope {
     // non-match before an EARLIER one does — either suppressing the throw the
     // whole-ON residual owes. Lower the entire conjunction as one residual.
     guard lowered.allSatisfy(\.safe) else { return lowered.conjunction! }
-    var filters = Array<Filter>()
-    for (conjunct, residual) in zip(conjuncts, lowered) {
-      if case let .comparison(.column(left),
-                              .equal, .column(right)) = conjunct {
-        try filters.append(match(left, right))
-      } else {
-        filters.append(residual)
+    // Read the equi-join key off the ALREADY-LOWERED term rather than
+    // re-resolving the AST: a key is a `compare(.slot, .equal, .slot)` whose
+    // BOTH operands are columns of the join prefix. A conjunct that lowered to
+    // a `.parameter` operand is a CORRELATED outer reference (`V.x = :outer`),
+    // NOT a column = column key, so it stays the residual `ON` filter — a
+    // re-resolution of its AST would consult only the prefix and fault
+    // `SQLError.column` on the outer column already lowered correctly.
+    let filters = lowered.map { residual -> Filter in
+      if case let .compare(.slot(left), .equal, .slot(right)) = residual {
+        return .match(left, right)
       }
+      return residual
     }
     return filters.conjunction!
   }
@@ -3156,6 +3726,10 @@ internal struct Grouping {
                                _ routines: Routines = [:],
                                subquery: Subquery = .unsupported)
       throws(SQLError) -> Array<Term> {
+    // A grouped projection is a BARRED clause position (see `Schema.terms`):
+    // the entry bars the seam so it cannot admit a correlated column of THIS
+    // query.
+    let subquery = subquery.barred
     switch projection {
     case .all:
       throw .unsupported("SELECT * is not allowed with GROUP BY or aggregates")
@@ -3228,6 +3802,8 @@ internal struct Grouping {
                       _ routines: Routines = [:],
                       subquery: Subquery = .unsupported)
       throws(SQLError) -> Array<SortKey> {
+    // A grouped ORDER BY is BARRED, as the projection is (see `Schema.order`).
+    let subquery = subquery.barred
     var resolved = Array<SortKey>()
     resolved.reserveCapacity(order.keys.count)
     for key in order.keys {
@@ -3291,18 +3867,22 @@ extension Filter {
       for element in elements {
         element.references(into: &ordinals)
       }
-    case .exists:
-      // An UNCORRELATED EXISTS reads no outer ordinal — its subquery names no
-      // enclosing column and runs against its own relations.
-      break
-    case let .within(operand, _, _):
-      // Only the outer operand term reads ordinals; the uncorrelated subquery
-      // runs against its own relations.
+    case let .exists(_, correlation, _):
+      // A CORRELATED EXISTS reads the enclosing row's cells its inner `WHERE`
+      // names — the correlation's `slot` outer ordinals — so those must be
+      // materialised for the per-row re-execution (a `bound` source reads a
+      // threaded binding, not the outer record). An UNCORRELATED one names none.
+      ordinals.formUnion(correlation.slots)
+    case let .within(operand, _, correlation, _):
+      // The outer operand term reads ordinals; a CORRELATED subquery ALSO reads
+      // the outer `slot` cells its inner `WHERE` names.
       operand.references(into: &ordinals)
-    case let .quantified(operand, _, _, _):
-      // As `within`: only the outer operand reads ordinals; the uncorrelated
-      // subquery runs against its own relations.
+      ordinals.formUnion(correlation.slots)
+    case let .quantified(operand, _, _, _, correlation):
+      // As `within`: the outer operand term reads ordinals; a CORRELATED
+      // subquery ALSO reads the outer `slot` cells its inner `WHERE` names.
       operand.references(into: &ordinals)
+      ordinals.formUnion(correlation.slots)
     case let .like(operand, pattern, escape, _):
       operand.references(into: &ordinals)
       pattern.references(into: &ordinals)

--- a/Tests/SQLTests/BetweenTests.swift
+++ b/Tests/SQLTests/BetweenTests.swift
@@ -383,7 +383,7 @@ struct BetweenSeekTests {
     // not scan all ten rows.
     let catalog = try sorted()
     let query = try query("SELECT Id FROM T WHERE Id BETWEEN 3 AND 7")
-    let plan = try catalog.optimise(catalog.compile(query), [:])
+    let plan = try catalog.optimise(catalog.compile(query, validate: true), [:])
     #expect(seek(plan) == 2 ..< 7)
     try catalog.expect("SELECT Id FROM T WHERE Id BETWEEN 3 AND 7",
                        yields: [[3], [4], [5], [6], [7]])
@@ -399,8 +399,8 @@ struct BetweenSeekTests {
     let catalog = try sorted()
     let comparison =
         try query("SELECT Id FROM T WHERE Id >= 3 AND Id <= 7")
-    let range = try #require(seek(catalog.optimise(catalog.compile(comparison),
-                                                   [:])))
+    let compiled = try catalog.compile(comparison, validate: true)
+    let range = try #require(seek(catalog.optimise(compiled, [:])))
     #expect(range.lowerBound <= 2 && range.upperBound >= 7)
     try catalog.expect("SELECT Id FROM T WHERE Id BETWEEN 3 AND 7",
                        equals: "SELECT Id FROM T WHERE Id >= 3 AND Id <= 7")
@@ -413,7 +413,7 @@ struct BetweenSeekTests {
     // out-of-range rows.
     let catalog = try sorted()
     let query = try query("SELECT Id FROM T WHERE Id NOT BETWEEN 3 AND 7")
-    let plan = try catalog.optimise(catalog.compile(query), [:])
+    let plan = try catalog.optimise(catalog.compile(query, validate: true), [:])
     #expect(seek(plan) == nil)
     try catalog.expect("SELECT Id FROM T WHERE Id NOT BETWEEN 3 AND 7",
                        yields: [[1], [2], [8], [9], [10]])
@@ -426,7 +426,7 @@ struct BetweenSeekTests {
     // same rows the seeked `Id BETWEEN 3 AND 7` would.
     let catalog = try sorted()
     let query = try query("SELECT Id FROM T WHERE Id + 1 BETWEEN 4 AND 8")
-    let plan = try catalog.optimise(catalog.compile(query), [:])
+    let plan = try catalog.optimise(catalog.compile(query, validate: true), [:])
     #expect(seek(plan) == nil)
     try catalog.expect("SELECT Id FROM T WHERE Id + 1 BETWEEN 4 AND 8",
                        yields: [[3], [4], [5], [6], [7]])
@@ -439,7 +439,7 @@ struct BetweenSeekTests {
     // every row whose `Id >= 3` (each row's own `Id` is its upper bound).
     let catalog = try sorted()
     let query = try query("SELECT Id FROM T WHERE Id BETWEEN 3 AND Id")
-    let plan = try catalog.optimise(catalog.compile(query), [:])
+    let plan = try catalog.optimise(catalog.compile(query, validate: true), [:])
     #expect(seek(plan) == nil)
     try catalog.expect("SELECT Id FROM T WHERE Id BETWEEN 3 AND Id",
                        yields: [[3], [4], [5], [6], [7], [8], [9], [10]])
@@ -455,7 +455,7 @@ struct BetweenSeekTests {
     // the query returns no rows and never traps.
     let catalog = try sorted()
     let query = try query("SELECT Id FROM T WHERE Id BETWEEN 10 AND 1")
-    let plan = try catalog.optimise(catalog.compile(query), [:])
+    let plan = try catalog.optimise(catalog.compile(query, validate: true), [:])
     let range = try #require(seek(plan))
     #expect(range.isEmpty)
     try catalog.empty("SELECT Id FROM T WHERE Id BETWEEN 10 AND 1")
@@ -471,7 +471,8 @@ struct BetweenSeekTests {
     let catalog = try sorted()
     let query = try query("SELECT Id FROM T WHERE Id BETWEEN :lo AND :hi")
     let bindings: Bindings = ["lo": .integer(3), "hi": .integer(7)]
-    let plan = try catalog.optimise(catalog.compile(query), bindings)
+    let compiled = try catalog.compile(query, validate: true)
+    let plan = try catalog.optimise(compiled, bindings)
     #expect(seek(plan) == 2 ..< 7)
     try catalog.expect("SELECT Id FROM T WHERE Id BETWEEN :lo AND :hi",
                        yields: [[3], [4], [5], [6], [7]], bindings: bindings)
@@ -484,7 +485,7 @@ struct BetweenSeekTests {
     // so none passes. It seeks nothing rather than mis-seeking.
     let catalog = try sorted()
     let query = try query("SELECT Id FROM T WHERE Id BETWEEN :lo AND :hi")
-    let plan = try catalog.optimise(catalog.compile(query),
+    let plan = try catalog.optimise(catalog.compile(query, validate: true),
                                     ["lo": .integer(3)])
     #expect(seek(plan) == nil)
     try catalog.empty("SELECT Id FROM T WHERE Id BETWEEN :lo AND :hi",

--- a/Tests/SQLTests/ConcatTests.swift
+++ b/Tests/SQLTests/ConcatTests.swift
@@ -131,7 +131,7 @@ private func derived(_ text: String) throws -> ValueType {
     Issue.record("expected a single projected expression")
     throw SQLError.incomplete(expected: "one projected expression")
   }
-  let scope = try people().scope(of: select, Context())
+  let scope = try people().scope(of: select, Context(), validate: true)
   return try scope.derive(items[0].expression)
 }
 

--- a/Tests/SQLTests/DerivedTableTests.swift
+++ b/Tests/SQLTests/DerivedTableTests.swift
@@ -1269,6 +1269,86 @@ struct DerivedTableSubqueryBodyValidateThreadingTests {
   }
 }
 
+// MARK: - A short-circuited subquery's nested derived body is not validated
+
+/// The reachability walk is the SOLE validation gate: schema/shape derivation
+/// is ALWAYS lenient (a derived body's columns/types derive WITHOUT evaluating
+/// its projection), and validation applies ONLY to nodes the walk REACHES — so
+/// a derived body nested under a SHORT-CIRCUITED subquery is not validated at
+/// ANY depth. `WHERE 1 = 0 AND 1 IN (SELECT x FROM (SELECT 1 / 0 …) AS d)`
+/// short-circuits the `IN` away, so its nested derived `d` never materialises;
+/// before the fix the schema pre-pass eager-compiled `d` with `validate: true`
+/// and faulted `.divide` for a query the run drops.
+struct DerivedTableSubqueryReachabilityGateTests {
+  @Test func `an unreached subquery's nested derived body is not validated`()
+      throws {
+    // `1 = 0` short-circuits the AND, so the `IN` never materialises — the
+    // nested derived `d`'s ill-typed `1 / 0` projection is unreached. The
+    // STRICT schema path must NOT fault: the walk did not reach the subquery,
+    // so nothing nested under it is validated.
+    let query = try parse(query:
+        "SELECT V FROM S WHERE 1 = 0 AND 1 IN " +
+        "(SELECT x FROM (SELECT 1 / 0 AS x FROM S) AS d)")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.map(\.name) == ["V"])
+  }
+
+  @Test func `an unreached subquery's nested derived body runs empty`() throws {
+    // The run drops every row on the false `WHERE` before the `IN`, so the
+    // nested derived body never evaluates — the query returns empty, not a
+    // `.divide` fault.
+    try fixture().empty(
+        "SELECT V FROM S WHERE 1 = 0 AND 1 IN " +
+        "(SELECT x FROM (SELECT 1 / 0 AS x FROM S) AS d)")
+  }
+
+  @Test func `a reached subquery's nested derived body still faults`() throws {
+    // Parity: `1 = 1` does NOT short-circuit, so the walk REACHES the `IN` and
+    // validates its nested derived body — the ill-typed `1 / 0` faults
+    // `.divide` under the strict schema path, exactly as before the fix.
+    #expect(throws: SQLError.divide) {
+      let query = try parse(query:
+          "SELECT V FROM S WHERE 1 = 1 AND 1 IN " +
+          "(SELECT x FROM (SELECT 1 / 0 AS x FROM S) AS d)")
+      _ = try fixture().columns(of: query, validate: true)
+    }
+  }
+
+  @Test func `a reached subquery's nested derived body faults at run`() throws {
+    // The reached `IN` materialises the nested derived body at run, so the
+    // ill-typed `1 / 0` faults `.divide` — the reached-node strict parity.
+    try fixture().expect(
+        "SELECT V FROM S WHERE 1 = 1 AND 1 IN " +
+        "(SELECT x FROM (SELECT 1 / 0 AS x FROM S) AS d)",
+        fails: .divide)
+  }
+
+  @Test func `a deeper-nested unreached derived body is not validated`()
+      throws {
+    // Depth-independence: the ill-typed derived body is nested a derived table
+    // under a subquery under a derived table. `1 = 0` short-circuits the outer
+    // `IN`, so NOTHING nested under it — at any depth — is validated.
+    let query = try parse(query:
+        "SELECT V FROM S WHERE 1 = 0 AND 1 IN " +
+        "(SELECT y FROM (SELECT x AS y FROM " +
+        "(SELECT 1 / 0 AS x FROM S) AS e) AS d)")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.map(\.name) == ["V"])
+  }
+
+  @Test func `a deeper-nested reached derived body still faults`() throws {
+    // Parity at depth: `1 = 1` reaches the outer `IN`, so its whole nested
+    // stack validates and the innermost `1 / 0` faults `.divide`.
+    #expect(throws: SQLError.divide) {
+      let query = try parse(query:
+          "SELECT V FROM S WHERE 1 = 1 AND 1 IN " +
+          "(SELECT y FROM (SELECT x AS y FROM " +
+          "(SELECT 1 / 0 AS x FROM S) AS e) AS d)")
+      _ = try fixture().columns(of: query, validate: true)
+    }
+  }
+}
+
 // MARK: - A set-operation VIEW body runs each arm with its arm-local aliases
 
 /// A view whose body is a set operation with a DERIVED TABLE in an arm: the
@@ -1963,7 +2043,7 @@ struct DerivedTableDirectCompileTests {
     // is one column wide (`a`) — no `.relation("d")`.
     let select =
         try parse(select: "SELECT a FROM (SELECT V AS a FROM S) AS d")
-    let plan = try fixture().compile(select)
+    let plan = try fixture().compile(select, validate: true)
     #expect(plan.width == 1)
   }
 
@@ -1973,8 +2053,8 @@ struct DerivedTableDirectCompileTests {
     let select =
         try parse(select: "SELECT a FROM (SELECT V AS a FROM S) AS d")
     let catalog = try fixture()
-    let bare = try catalog.compile(select)
-    let wrapped = try catalog.compile(.select(select))
+    let bare = try catalog.compile(select, validate: true)
+    let wrapped = try catalog.compile(.select(select), validate: true)
     #expect(bare.width == wrapped.width)
   }
 
@@ -2006,7 +2086,7 @@ struct DerivedTableDirectCompileTests {
     // is the base.
     let select =
         try parse(select: "SELECT a FROM (SELECT V AS a FROM S) AS S")
-    let plan = try fixture().compile(select)
+    let plan = try fixture().compile(select, validate: true)
     #expect(plan.width == 1)
   }
 }

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -550,13 +550,13 @@ struct EngineCodedKeyTests {
 
     let equal = try parse("SELECT Name FROM Attribute WHERE Parent = 4")
     let equalPlan =
-        try catalog.optimise(catalog.compile(equal), [:])
+        try catalog.optimise(catalog.compile(equal, validate: true), [:])
     #expect(seeks(equalPlan))
     #expect(!filters(equalPlan))
 
     let less = try parse("SELECT Name FROM Attribute WHERE Parent < 5")
     let lessPlan =
-        try catalog.optimise(catalog.compile(less), [:])
+        try catalog.optimise(catalog.compile(less, validate: true), [:])
     #expect(!seeks(lessPlan))
     #expect(filters(lessPlan))
   }
@@ -585,7 +585,7 @@ struct EngineCodedKeyTests {
       }
     }
     let query = try parse("SELECT * FROM T WHERE Id = 1")
-    let plan = try catalog.optimise(catalog.compile(query), [:])
+    let plan = try catalog.optimise(catalog.compile(query, validate: true), [:])
     #expect(seeks(plan))
   }
 
@@ -596,7 +596,7 @@ struct EngineCodedKeyTests {
       Relation("T", ["Id": .integer], sorted: "Id")
     }
     let query = try parse("SELECT * FROM T WHERE Id = 1")
-    let plan = try catalog.optimise(catalog.compile(query), [:])
+    let plan = try catalog.optimise(catalog.compile(query, validate: true), [:])
     #expect(seeks(plan))
   }
 }
@@ -798,8 +798,8 @@ struct EngineNonEquiJoinTests {
         SELECT Parent.Name, Child.Name FROM Parent
           JOIN Child ON Parent.Id < Child.Pid
         """)
-    let plan =
-        try catalog.optimise(catalog.compile(select).pushdown(), [:])
+    let compiled = try catalog.compile(select, validate: true)
+    let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(!joins(plan))
     #expect(residual(plan))
   }
@@ -829,8 +829,8 @@ struct EngineNonEquiJoinTests {
         SELECT Parent.Name, Child.Name FROM Parent
           JOIN Child ON Child.Pid = Parent.Id AND Parent.Name < Child.Name
         """)
-    let plan =
-        try catalog.optimise(catalog.compile(select).pushdown(), [:])
+    let compiled = try catalog.compile(select, validate: true)
+    let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(joins(plan))
   }
 
@@ -853,8 +853,8 @@ struct EngineNonEquiJoinTests {
         SELECT Parent.Name, Child.Name FROM Parent
           JOIN Child ON Child.Pid = Parent.Id + 1
         """)
-    let plan =
-        try catalog.optimise(catalog.compile(select).pushdown(), [:])
+    let compiled = try catalog.compile(select, validate: true)
+    let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(!joins(plan))
     #expect(residual(plan))
   }
@@ -914,8 +914,8 @@ struct EngineNonEquiJoinTests {
     let select = try parse("""
         SELECT A.k FROM A JOIN B ON (1 / A.x) = 0 AND A.k = B.k
         """)
-    let plan =
-        try catalog.optimise(catalog.compile(select).pushdown(), [:])
+    let compiled = try catalog.compile(select, validate: true)
+    let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(!joins(plan))
     #expect(residual(plan))
   }
@@ -933,9 +933,10 @@ struct EngineNonEquiJoinTests {
       "B": FixtureRelation([Field(name: "k", type: .integer)],
                     [[.integer(2)]] as Array<Array<Value>>),
     ])
-    let plan = try catalog.optimise(catalog.compile(parse("""
+    let compiled = try catalog.compile(parse("""
         SELECT A.k FROM A JOIN B ON A.k = B.k AND (1 / A.x) = 0
-        """)).pushdown(), [:])
+        """), validate: true)
+    let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(!joins(plan))
     #expect(residual(plan))
   }
@@ -954,9 +955,10 @@ struct EngineNonEquiJoinTests {
       "B": FixtureRelation([Field(name: "k", type: .integer)],
                     [[.integer(2)]] as Array<Array<Value>>),
     ])
-    let plan = try catalog.optimise(catalog.compile(parse("""
+    let compiled = try catalog.compile(parse("""
         SELECT A.k FROM A JOIN B ON A.k = B.k AND (1 / A.x) = 0
-        """)).pushdown(), [:])
+        """), validate: true)
+    let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(!joins(plan))
     #expect(residual(plan))
     #expect(throws: SQLError.divide) {
@@ -1005,8 +1007,8 @@ struct EngineNonEquiJoinTests {
     // Key pairs (1,1) with 5 < 8 kept; (2,2) with 10 < 3 dropped.
     let rows = try catalog.run(parse(text))
     #expect(rows == [[.integer(1), .integer(8)]])
-    let plan =
-        try catalog.optimise(catalog.compile(parse(text)).pushdown(), [:])
+    let compiled = try catalog.compile(parse(text), validate: true)
+    let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(joins(plan))
   }
 
@@ -1018,8 +1020,8 @@ struct EngineNonEquiJoinTests {
         SELECT Parent.Name, Child.Name FROM Parent
           JOIN Child ON Child.Pid = Parent.Id
         """)
-    let plan =
-        try catalog.optimise(catalog.compile(select).pushdown(), [:])
+    let compiled = try catalog.compile(select, validate: true)
+    let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(joins(plan))
   }
 
@@ -1038,8 +1040,8 @@ struct EngineNonEquiJoinTests {
                            [[.integer(2)]] as Array<Array<Value>>),
     ])
     let text = "SELECT A.k FROM A JOIN B ON A.k < B.k WHERE (1 / A.x) = 0"
-    let plan =
-        try catalog.optimise(catalog.compile(parse(text)).pushdown(), [:])
+    let compiled = try catalog.compile(parse(text), validate: true)
+    let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(separated(plan))
     #expect(residual(plan))
     #expect(try catalog.run(parse(text)).isEmpty)
@@ -1104,8 +1106,8 @@ struct EngineNonEquiJoinTests {
         SELECT A.k1 FROM A
           JOIN B ON A.k1 = B.k1 AND A.k2 = B.k2 WHERE (1 / A.x) = 0
         """
-    let plan =
-        try catalog.optimise(catalog.compile(parse(text)).pushdown(), [:])
+    let compiled = try catalog.compile(parse(text), validate: true)
+    let plan = try catalog.optimise(compiled.pushdown(), [:])
     // The equi key still hash-joins; the leftover match gates above it, and the
     // `WHERE` is a SEPARATE `select` above that gate, not fused with the match.
     #expect(joins(plan))
@@ -1162,8 +1164,8 @@ struct EngineNonEquiJoinTests {
         SELECT A.tag, B.note FROM A
           JOIN B ON A.k1 = B.k1 AND A.k2 = B.k2 WHERE A.tag = 'keep'
         """
-    let plan =
-        try catalog.optimise(catalog.compile(parse(text)).pushdown(), [:])
+    let compiled = try catalog.compile(parse(text), validate: true)
+    let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(joins(plan))
     #expect(try catalog.run(parse(text)) == [[.text("keep"), .text("bee")]])
   }
@@ -1185,8 +1187,8 @@ struct EngineNonEquiJoinTests {
                            [[.integer(1)]] as Array<Array<Value>>),
     ])
     let text = "SELECT A.k FROM A JOIN B ON A.k = B.k WHERE (1 / A.x) = 1"
-    let plan =
-        try catalog.optimise(catalog.compile(parse(text)).pushdown(), [:])
+    let compiled = try catalog.compile(parse(text), validate: true)
+    let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(joins(plan))
     #expect(try catalog.run(parse(text)) == [[.integer(1)]])
   }
@@ -1319,8 +1321,8 @@ struct EngineOuterJoinTests {
         SELECT Parent.Name, Child.Name FROM Parent
           LEFT JOIN Child ON Child.Pid = Parent.Id
         """)
-    let plan =
-        try catalog.optimise(catalog.compile(select).pushdown(), [:])
+    let compiled = try catalog.compile(select, validate: true)
+    let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(outers(plan))
     #expect(!joins(plan))
   }
@@ -1567,7 +1569,8 @@ struct EngineViewTests {
     // `.scan` (a non-nil seek) and carry no `.select` over a raw scan.
     let catalog = try views()
     let select = try parse("SELECT Key, Label FROM Adults")
-    let plan = try catalog.optimise(catalog.compile(select), [:])
+    let compiled = try catalog.compile(select, validate: true)
+    let plan = try catalog.optimise(compiled, [:])
     let sub = try #require(derived(plan))
     #expect(seeks(sub))
     #expect(!filters(sub))
@@ -1979,8 +1982,8 @@ struct EnginePushdownTests {
         SELECT Child.Name FROM Parent JOIN Child ON Child.Pid = Parent.Id
           WHERE Parent.Name = 'Ada'
         """)
-    let plan =
-        try catalog.optimise(catalog.compile(select).pushdown(), [:])
+    let compiled = try catalog.compile(select, validate: true)
+    let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(pushed(plan))
   }
 
@@ -1992,8 +1995,8 @@ struct EnginePushdownTests {
         SELECT Child.Name FROM Parent JOIN Child ON Child.Pid = Parent.Id
           WHERE Parent.Id = 2
         """)
-    let plan =
-        try catalog.optimise(catalog.compile(select).pushdown(), [:])
+    let compiled = try catalog.compile(select, validate: true)
+    let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(seeks(plan))
     #expect(pushed(plan))
   }
@@ -2018,8 +2021,8 @@ struct EnginePushdownTests {
     let select = try parse("""
         SELECT Name FROM T WHERE Name <> 'x' AND Age > 0 AND Id = 5
         """)
-    let plan =
-        try catalog.optimise(catalog.compile(select).pushdown(), [:])
+    let compiled = try catalog.compile(select, validate: true)
+    let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(seeks(plan))
   }
 
@@ -2045,8 +2048,8 @@ struct EnginePushdownTests {
         """)
 
     // The unsafe `(1 / x) = 0` residual bars the `id < 0` seek — the plan scans.
-    let plan =
-        try catalog.optimise(catalog.compile(select).pushdown(), [:])
+    let compiled = try catalog.compile(select, validate: true)
+    let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(!seeks(plan))
 
     // …and the scan raises the division rather than seeking past the empty run.
@@ -2075,8 +2078,8 @@ struct EnginePushdownTests {
         SELECT Child.Name, Parent.Name FROM Child
           JOIN Parent ON Parent.Id = Child.Pid WHERE Parent.Name <> 'zz'
         """)
-    let plan =
-        try catalog.optimise(catalog.compile(select).pushdown(), [:])
+    let compiled = try catalog.compile(select, validate: true)
+    let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(joins(plan))
 
     // …and it returns the correct rows: every child with a matching parent,
@@ -2100,8 +2103,8 @@ struct EnginePushdownTests {
         SELECT Child.Name, Parent.Name FROM Parent
           JOIN Child ON Child.Pid = Parent.Id WHERE Parent.Name <> Child.Name
         """)
-    let plan =
-        try catalog.optimise(catalog.compile(select).pushdown(), [:])
+    let compiled = try catalog.compile(select, validate: true)
+    let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(joins(plan))
     #expect(floats(plan))
 
@@ -2228,8 +2231,8 @@ struct EnginePushdownTests {
     // and seeking the sorted `Alpha` arm.
     let catalog = try spanned()
     let select = try parse("SELECT Tag FROM Both WHERE Key = 2")
-    let plan =
-        try catalog.optimise(catalog.compile(select).pushdown(), [:])
+    let compiled = try catalog.compile(select, validate: true)
+    let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(injected(plan))
     #expect(seeks(plan))
 
@@ -2300,8 +2303,8 @@ struct EnginePushdownTests {
 
     // `A.x = 1` is nullable and precedes the unsafe division, so it is NOT
     // pushed to the `A` leaf — it floats at the product level.
-    let plan =
-        try catalog.optimise(catalog.compile(select).pushdown(), [:])
+    let compiled = try catalog.compile(select, validate: true)
+    let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(!pushed(plan))
     #expect(floats(plan))
 
@@ -2329,8 +2332,8 @@ struct EnginePushdownTests {
 
     // `x = 1` is nullable and precedes the unsafe division, so it is NOT
     // injected into the view — it floats above the derived leaf.
-    let plan =
-        try catalog.optimise(catalog.compile(select).pushdown(), [:])
+    let compiled = try catalog.compile(select, validate: true)
+    let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(floats(plan))
 
     // …and the query raises rather than silently dropping the row.
@@ -2359,8 +2362,8 @@ struct EnginePushdownTests {
     // `1 = :missing` is a slotless bound predicate, hence nullable; it precedes
     // the unsafe division, so it is NOT injected into the view — it floats above
     // the derived leaf.
-    let plan =
-        try catalog.optimise(catalog.compile(select).pushdown(), [:])
+    let compiled = try catalog.compile(select, validate: true)
+    let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(floats(plan))
 
     // …and the query raises rather than silently dropping the row.
@@ -2665,8 +2668,8 @@ struct EngineStreamingProductTests {
         SELECT Child.Name, Adults.Label FROM Child
           JOIN Adults ON Adults.Key = Child.Pid
         """)
-    let plan =
-        try catalog.optimise(catalog.compile(select).pushdown(), [:])
+    let compiled = try catalog.compile(select, validate: true)
+    let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(residual(plan))
   }
 
@@ -3271,7 +3274,7 @@ struct EngineBoundTests {
     // seeks the run rather than scanning and filtering the whole relation.
     let select = try parse("SELECT Name FROM Parent WHERE Id = :id")
     let catalog = try family()
-    let plan = try catalog.optimise(catalog.compile(select),
+    let plan = try catalog.optimise(catalog.compile(select, validate: true),
                                     ["id": .integer(2)])
     #expect(seeks(plan))
     #expect(!filters(plan))
@@ -3280,7 +3283,8 @@ struct EngineBoundTests {
   @Test func `an unbound key cannot seek and scans under the filter`() throws {
     let select = try parse("SELECT Name FROM Parent WHERE Id = :id")
     let catalog = try family()
-    let plan = try catalog.optimise(catalog.compile(select), [:])
+    let compiled = try catalog.compile(select, validate: true)
+    let plan = try catalog.optimise(compiled, [:])
     #expect(!seeks(plan))
     #expect(filters(plan))
   }
@@ -3291,7 +3295,7 @@ struct EngineBoundTests {
     // supplied, so a reusable view is as fast as the inlined query.
     let select = try parse("SELECT Key, Label FROM Picked")
     let catalog = try views()
-    let plan = try catalog.optimise(catalog.compile(select),
+    let plan = try catalog.optimise(catalog.compile(select, validate: true),
                                     ["id": .integer(2)])
     let sub = try #require(derived(plan))
     #expect(seeks(sub))

--- a/Tests/SQLTests/LikeTests.swift
+++ b/Tests/SQLTests/LikeTests.swift
@@ -368,9 +368,10 @@ struct LikeSafetyTests {
     // slot — an escape that faults regardless of the pair. Unsafe, it bars the
     // equi from becoming a hash key: `nest` forms no `.join`, the level is a
     // residual `.select` over the `.product`, so the whole `ON` runs per pair.
-    let plan = try mismatched().optimise(mismatched().compile(query("""
+    let compiled = try mismatched().compile(query("""
         SELECT A.K FROM A JOIN B ON A.K = B.K AND A.Name LIKE 'a%' ESCAPE A.E
-        """)).pushdown(), [:])
+        """), validate: true)
+    let plan = try mismatched().optimise(compiled.pushdown(), [:])
     #expect(!joins(plan))
     #expect(residual(plan))
   }
@@ -399,9 +400,8 @@ struct LikeSafetyTests {
     let sql = """
         SELECT A.K FROM A JOIN B ON A.K = B.K AND A.Name LIKE 'a%' ESCAPE 'ab'
         """
-    let plan =
-        try mismatched().optimise(mismatched().compile(query(sql)).pushdown(),
-                                  [:])
+    let compiled = try mismatched().compile(query(sql), validate: true)
+    let plan = try mismatched().optimise(compiled.pushdown(), [:])
     #expect(!joins(plan))
     #expect(residual(plan))
     try mismatched().expect(sql,
@@ -419,9 +419,10 @@ struct LikeSafetyTests {
         Row(2, "xyz")
       }
     }
-    let plan = try catalog.optimise(catalog.compile(query("""
+    let compiled = try catalog.compile(query("""
         SELECT Id FROM S WHERE Name LIKE '_%' ESCAPE '\\' AND Id = 2
-        """)).pushdown(), [:])
+        """), validate: true)
+    let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(seeks(plan))
 
     // …and it still matches correctly: only row 2 has `Id = 2`, and its
@@ -442,9 +443,10 @@ struct LikeSafetyTests {
         Row(2, "xyz")
       }
     }
-    let plan = try catalog.optimise(catalog.compile(query("""
+    let compiled = try catalog.compile(query("""
         SELECT Id FROM S WHERE Name LIKE 'x%' AND Id = 2
-        """)).pushdown(), [:])
+        """), validate: true)
+    let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(seeks(plan))
     try catalog.expect("SELECT Id FROM S WHERE Name LIKE 'x%' AND Id = 2",
                        yields: [[2]])
@@ -646,7 +648,8 @@ struct LikeParameterTests {
       Issue.record("expected a SELECT statement")
       return
     }
-    let plan = try catalog.optimise(catalog.compile(query).pushdown(),
+    let compiled = try catalog.compile(query, validate: true)
+    let plan = try catalog.optimise(compiled.pushdown(),
                                     ["e": .text("\\")])
     #expect(!seeks(plan))
   }
@@ -713,9 +716,10 @@ struct LikeParameterisedTests {
     // LIKE :p` into the view would drop every row first, suppressing the
     // throw — so a parameterised LIKE is nullable and must stay outer.
     let catalog = try maybe()
-    let plan = try catalog.optimise(catalog.compile(query("""
+    let compiled = try catalog.compile(query("""
         SELECT x FROM V WHERE 'x' LIKE :p AND (1 / y) = 0
-        """)).pushdown(), [:])
+        """), validate: true)
+    let plan = try catalog.optimise(compiled.pushdown(), [:])
 
     // The parameterised LIKE floats above the derived leaf rather than riding
     // into the view below the unsafe division.

--- a/Tests/SQLTests/NullifTests.swift
+++ b/Tests/SQLTests/NullifTests.swift
@@ -103,7 +103,7 @@ private func derived(_ text: String) throws -> ValueType {
     Issue.record("expected a single projected expression")
     throw SQLError.incomplete(expected: "one projected expression")
   }
-  let scope = try people().scope(of: select, Context())
+  let scope = try people().scope(of: select, Context(), validate: true)
   return try scope.derive(items[0].expression)
 }
 

--- a/Tests/SQLTests/QuantifiedSubqueryTests.swift
+++ b/Tests/SQLTests/QuantifiedSubqueryTests.swift
@@ -289,3 +289,85 @@ struct QuantifiedTypeTests {
     }
   }
 }
+
+// MARK: - Correlated quantified execution
+
+/// An outer relation and an inner relation sharing a key `k`, so a quantified
+/// subquery referencing an outer column is CORRELATED: its lone column depends
+/// on the enclosing row, forcing the per-outer-row re-execution the discovered
+/// correlation threads (rather than a once-memoised uncorrelated run).
+private func correlated() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("Toll", ["x": .integer, "k": .integer]) {
+      Row(10, 1)
+      Row(20, 2)
+      Row(99, 3)
+    }
+    Relation("Inn", ["x": .integer, "k": .integer]) {
+      Row(10, 1)
+      Row(20, 2)
+      Row(30, 2)
+    }
+  }
+}
+
+struct CorrelatedQuantifiedTests {
+  @Test func `a correlated = ANY binds the outer key per row`() throws {
+    // `Toll.x = ANY (SELECT i.x FROM Inn i WHERE i.k = Toll.k)` correlates to
+    // `Toll.k`, so the inner column is re-materialised per outer row: row
+    // (10, 1) → {10} (10 = ANY → TRUE), row (20, 2) → {20, 30} (TRUE), row
+    // (99, 3) → {} (FALSE). A `[:]`-correlation eval would re-run the inner
+    // query WITHOUT the outer scope and fail to bind `Toll.k`.
+    let sql = """
+        SELECT x FROM Toll \
+        WHERE x = ANY (SELECT i.x FROM Inn i WHERE i.k = Toll.k) \
+        ORDER BY x
+        """
+    let columns = try correlated().columns(of: parse(query: sql),
+                                           validate: true)
+    #expect(columns.count == 1)
+    try correlated().expect(sql, yields: [[10], [20]])
+  }
+
+  @Test func `a correlated <> ALL keeps the row with no inner match`() throws {
+    // `<> ALL` over the per-row inner column: row (10, 1) → 10 <> ALL {10} is
+    // FALSE, row (20, 2) → 20 <> ALL {20, 30} is FALSE, row (99, 3) → 99 <> ALL
+    // {} is TRUE (an empty ALL is vacuously TRUE). Only row 99 survives.
+    let sql = """
+        SELECT x FROM Toll \
+        WHERE x <> ALL (SELECT i.x FROM Inn i WHERE i.k = Toll.k) \
+        ORDER BY x
+        """
+    let columns = try correlated().columns(of: parse(query: sql),
+                                           validate: true)
+    #expect(columns.count == 1)
+    try correlated().expect(sql, yields: [[99]])
+  }
+
+  @Test func `a correlated > ALL exceeds the per-row inner column`() throws {
+    // `> ALL` over the per-row inner column: row (10, 1) → 10 > ALL {10} FALSE,
+    // row (20, 2) → 20 > ALL {20, 30} FALSE, row (99, 3) → 99 > ALL {} TRUE
+    // (empty ALL). Only row 99 exceeds its (empty) inner column.
+    let sql = """
+        SELECT x FROM Toll \
+        WHERE x > ALL (SELECT i.x FROM Inn i WHERE i.k = Toll.k) \
+        ORDER BY x
+        """
+    try correlated().expect(sql, yields: [[99]])
+  }
+
+  @Test func `an uncorrelated quantified still memoises once`() throws {
+    // With NO outer reference the quantified subquery is uncorrelated — empty
+    // correlation — so it materialises its column ONCE (memoised), folded per
+    // outer row: `Inn.x` ∈ {10, 20, 30}, so `Toll.x = ANY {10, 20, 30}` keeps
+    // rows 10 and 20 (99 is absent).
+    let sql = """
+        SELECT x FROM Toll \
+        WHERE x = ANY (SELECT i.x FROM Inn i) ORDER BY x
+        """
+    let columns = try correlated().columns(of: parse(query: sql),
+                                           validate: true)
+    #expect(columns.count == 1)
+    try correlated().expect(sql, yields: [[10], [20]])
+  }
+}

--- a/Tests/SQLTests/ScalarSubqueryTests.swift
+++ b/Tests/SQLTests/ScalarSubqueryTests.swift
@@ -315,24 +315,75 @@ struct ScalarSubqueryTypeTests {
   }
 }
 
-// MARK: - Uncorrelated boundary
+// MARK: - Correlated resolution
 
 struct ScalarSubqueryCorrelationTests {
-  @Test func `a scalar subquery naming an outer column fails to resolve`()
-      throws {
-    // Correlation is a LATER slice: a scalar subquery referencing an OUTER
-    // column (`T.Id`, not in the inner `S`'s scope) does not resolve — the
-    // inner query faults `SQLError.column` exactly as an unresolved column
-    // does today. This asserts the CURRENT behaviour; it does NOT implement
-    // correlation.
+  @Test func `a scalar subquery naming an outer column resolves`() throws {
+    // A scalar subquery referencing an OUTER column (`T.V`, not in the inner
+    // `S`'s scope) is a CORRELATED reference: it lowers to a synthetic bound
+    // param bound from the outer row and the subquery re-runs per row. `T.V`
+    // matches `S.V` for every row, so the scalar collapses to that value.
     let query = try parse(query:
-        "SELECT (SELECT V FROM S WHERE V = T.Id) FROM T")
-    let resolve = { () throws -> Array<OutputColumn> in
+        "SELECT (SELECT V FROM S WHERE V = T.V) FROM T")
+    // `columns(of:)` VALIDATES the correlated query — resolving the correlated
+    // column against the outer scope exactly as the run does — rather than
+    // faulting `SQLError.column`.
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+    try fixture().expect(
+        "SELECT (SELECT V FROM S WHERE V = T.V) FROM T",
+        yields: [[10], [20], [30]])
+  }
+
+  @Test func `a correlated column in the inner projection is unsupported`()
+      throws {
+    // The minimal (b) cut admits a correlated column ONLY in the inner
+    // subquery's WHERE. One in the inner PROJECTION (`SELECT T.V …`) needs the
+    // general outer-row evaluator, so it is DIAGNOSED unsupported at BOTH
+    // `columns(of:)` and run rather than mis-resolved.
+    let query = try parse(query: "SELECT (SELECT T.V FROM S) FROM T")
+    #expect(throws: SQLError.self) {
       try fixture().columns(of: query, validate: true)
     }
-    #expect(throws: SQLError.column("Id")) {
-      try resolve()
+    try fixture().expect(
+        "SELECT (SELECT T.V FROM S) FROM T",
+        fails: .unsupported(
+            "a correlated column is only supported in a subquery's WHERE"))
+  }
+
+  @Test func `a FROM-less correlated projection subquery is unsupported`()
+      throws {
+    // A FROM-less scalar subquery in the PROJECTION that names an outer column
+    // (`SELECT (SELECT T.Id) FROM T`) is a correlated reference in a barred
+    // clause position. The cut is intrinsic to the projection entry
+    // (`Schema.terms` bars its seam), so this FROM-less projection CANNOT admit
+    // the correlation — run and `columns(of:)` REJECT it with the SAME fault,
+    // never lowering `T.Id` to a run-time `Term.parameter` that would (wrongly)
+    // execute.
+    let query = try parse(query: "SELECT (SELECT T.Id) FROM T")
+    #expect(throws: SQLError.self) {
+      try fixture().columns(of: query, validate: true)
     }
+    try fixture().expect(
+        "SELECT (SELECT T.Id) FROM T",
+        fails: .unsupported(
+            "a correlated column is only supported in a subquery's WHERE"))
+  }
+
+  @Test func `a correlated WHERE subquery still admits and runs`() throws {
+    // The parity case: a correlated column in the inner subquery's WHERE — an
+    // ADMITTING clause position, unchanged by the projection barring — still
+    // lowers `T.V` to a correlated `Term.parameter` and RUNS per outer row.
+    // `(SELECT V FROM S WHERE V = T.V)` collapses to each row's own `V`, so
+    // `= V` keeps every row.
+    let query = try parse(query:
+        "SELECT V FROM T WHERE (SELECT V FROM S WHERE V = T.V) = V")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+    try fixture().expect(
+        "SELECT V FROM T WHERE (SELECT V FROM S WHERE V = T.V) = V " +
+        "ORDER BY V",
+        yields: [[10], [20], [30]])
   }
 }
 
@@ -395,6 +446,52 @@ struct ScalarSubqueryRoleTests {
         SELECT (SELECT W FROM M WHERE W = 1) AS w FROM T \
         WHERE 1 IN (SELECT W FROM M WHERE W = 1) \
         AND EXISTS (SELECT W FROM M WHERE W = 1) ORDER BY w
+        """,
+        yields: [[1], [1], [1]])
+  }
+
+  @Test func `a reachable scalar faults even with an unreachable IN twin`()
+      throws {
+    // Identical inner SQL `(SELECT 1 / 0 FROM S)` occurs BOTH as a REACHABLE
+    // scalar projection AND in an UNREACHABLE `IN` leg (`1 = 1 OR …`, whose OR
+    // short-circuits past the `IN`). Now that an `IN` materialises LAZILY, the
+    // valued twin no longer runs — and its eager arity/type derivation is TOTAL
+    // (no `.divide`) — so it cannot stand in for the scalar's operand check. The
+    // reachable scalar's own operand validation must still fault `.divide`. A
+    // valued twin must NOT suppress the scalar's deferred recording.
+    let query = try parse(query:
+        """
+        SELECT (SELECT 1 / 0 FROM S) FROM T \
+        WHERE 1 = 1 OR 5 IN (SELECT 1 / 0 FROM S)
+        """)
+    #expect(throws: SQLError.divide) {
+      try fixture().columns(of: query, validate: true)
+    }
+    try fixture().expect(
+        """
+        SELECT (SELECT 1 / 0 FROM S) FROM T \
+        WHERE 1 = 1 OR 5 IN (SELECT 1 / 0 FROM S)
+        """,
+        fails: .divide)
+  }
+
+  @Test func `a valid scalar with an unreachable IN twin validates and runs`()
+      throws {
+    // The parity case: the SAME scalar-and-unreachable-IN shape with a VALID
+    // body (`(SELECT W FROM M WHERE W = 1)`) validates AND runs — the scalar
+    // cell (1) per row, the `IN` leg unreached (OR short-circuits). Proof the
+    // fix defers-and-validates the reachable scalar without over-faulting.
+    let query = try parse(query:
+        """
+        SELECT (SELECT W FROM M WHERE W = 1) AS w FROM T \
+        WHERE 1 = 1 OR 5 IN (SELECT W FROM M WHERE W = 1) ORDER BY w
+        """)
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+    try fixture().expect(
+        """
+        SELECT (SELECT W FROM M WHERE W = 1) AS w FROM T \
+        WHERE 1 = 1 OR 5 IN (SELECT W FROM M WHERE W = 1) ORDER BY w
         """,
         yields: [[1], [1], [1]])
   }
@@ -648,5 +745,1053 @@ struct ScalarSubqueryValidationParityTests {
     try fixture().expect(
         "SELECT COALESCE(1, (SELECT 1 / 0 FROM S)) AS c FROM T ORDER BY c",
         yields: [[1], [1], [1]])
+  }
+}
+
+// MARK: - IN/EXISTS validation ↔ run parity
+
+/// An `IN (Q)`/`EXISTS` occurrence is materialised LAZILY at run — one in a
+/// skipped `CASE`/`COALESCE` arm or a short-circuited `AND`/`OR` leg never
+/// runs. Its inner-query OPERAND validation must therefore DEFER to the
+/// reachability walk, exactly as a scalar's does: an occurrence in an
+/// unreachable arm is NOT validated (matching the lazy run), while a REACHED
+/// bad-bodied one still faults at both validate and run (parity both
+/// directions). An `IN` validates its ORIGINAL shape (its value set is read),
+/// an EXISTS-only occurrence the cardinality PROBE (its retained `WHERE` still
+/// faults, its dropped select list does not).
+struct SubqueryValidationParityTests {
+  @Test func `an IN in a skipped CASE arm validates and runs`() throws {
+    // The reviewer's case: the `1 IN (SELECT 1 / 0 …)` sits in the ELSE arm of
+    // a CASE whose `1 = 1` guard is constant TRUE, so the arm is unreachable.
+    // The operand validation defers to the walk, which skips the arm —
+    // `columns(of:)` does NOT fault `.divide` — and the query RUNS, yielding
+    // the reached `0` for every row. Validation and execution AGREE.
+    let sql = """
+        SELECT CASE WHEN 1 = 1 THEN 0 \
+                    ELSE CASE WHEN 1 IN (SELECT 1 / 0 FROM S) THEN 1 END END \
+             AS c FROM T ORDER BY c
+        """
+    let columns = try fixture().columns(of: parse(query: sql), validate: true)
+    #expect(columns.count == 1)
+    try fixture().expect(sql, yields: [[0], [0], [0]])
+  }
+
+  @Test func `an EXISTS in a skipped CASE arm validates and runs`() throws {
+    // The EXISTS mirror: `EXISTS (SELECT V FROM S WHERE 1 / 0 = 1)` — a
+    // THROWING operand the cardinality PROBE RETAINS (it keeps the `WHERE`) —
+    // sits in the skipped ELSE arm. Its operand validation defers, so
+    // `columns(of:)` does NOT fault and the query RUNS the reached `0`.
+    let sql = """
+        SELECT CASE WHEN 1 = 1 THEN 0 \
+                    ELSE CASE WHEN EXISTS (SELECT V FROM S WHERE 1 / 0 = 1) \
+                              THEN 1 END END \
+             AS c FROM T ORDER BY c
+        """
+    let columns = try fixture().columns(of: parse(query: sql), validate: true)
+    #expect(columns.count == 1)
+    try fixture().expect(sql, yields: [[0], [0], [0]])
+  }
+
+  @Test func `a reached bad IN faults both validate and run`() throws {
+    // Parity the other way: with the guard TRUE the arm IS reached, so the walk
+    // records the `IN` and its ORIGINAL shape IS validated — `columns(of:)`
+    // faults `.divide` exactly as the run does.
+    let sql = """
+        SELECT CASE WHEN 1 = 1 \
+                    THEN CASE WHEN 1 IN (SELECT 1 / 0 FROM S) THEN 1 \
+                              ELSE 0 END \
+                    ELSE 0 END FROM T
+        """
+    let resolve = { () throws -> Array<OutputColumn> in
+      try fixture().columns(of: parse(query: sql), validate: true)
+    }
+    #expect(throws: SQLError.divide) {
+      try resolve()
+    }
+    try fixture().expect(sql, fails: .divide)
+  }
+
+  @Test func `a reached bad EXISTS faults both validate and run`() throws {
+    // The EXISTS mirror in the reached direction: the retained `WHERE`'s
+    // `1 / 0` faults `.divide` at BOTH validate and run once the arm reached.
+    let sql = """
+        SELECT CASE WHEN 1 = 1 \
+                    THEN CASE WHEN EXISTS (SELECT V FROM S WHERE 1 / 0 = 1) \
+                              THEN 1 ELSE 0 END \
+                    ELSE 0 END FROM T
+        """
+    let resolve = { () throws -> Array<OutputColumn> in
+      try fixture().columns(of: parse(query: sql), validate: true)
+    }
+    #expect(throws: SQLError.divide) {
+      try resolve()
+    }
+    try fixture().expect(sql, fails: .divide)
+  }
+
+  @Test func `a reached IN in the WHERE still faults`() throws {
+    // The plain WHERE case is not short-circuited past, so a bad-bodied `IN`
+    // there is REACHED and faults `.divide` at both validate and run — the lazy
+    // deferral does not weaken the always-reached position.
+    let sql = "SELECT Id FROM T WHERE 1 IN (SELECT 1 / 0 FROM S)"
+    let resolve = { () throws -> Array<OutputColumn> in
+      try fixture().columns(of: parse(query: sql), validate: true)
+    }
+    #expect(throws: SQLError.divide) {
+      try resolve()
+    }
+    try fixture().expect(sql, fails: .divide)
+  }
+}
+
+// MARK: - Join-ON correlation prefix scope
+
+/// A `JOIN … ON` subquery correlates against the join PREFIX scope — the
+/// relations available AT that join point — not the full join, which includes
+/// relations joined LATER. A correlated reference in an EARLY `ON` to a
+/// LATER-joined relation faults `SQLError.column` exactly as a DIRECT reference
+/// in that `ON` would, rather than mis-binding a slot not present when the
+/// early join's `ON` evaluates.
+private func joins() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("A", ["a": .integer]) {
+      Row(1)
+      Row(2)
+    }
+    Relation("B", ["b": .integer]) {
+      Row(1)
+    }
+    Relation("C", ["Ck": .integer]) {
+      Row(1)
+      Row(2)
+    }
+    Relation("X", ["k": .integer]) {
+      Row(1)
+      Row(2)
+    }
+  }
+}
+
+struct JoinOnCorrelationPrefixTests {
+  @Test func `an early ON correlating to a later join faults at run`() throws {
+    // `A JOIN B ON EXISTS (SELECT 1 FROM X WHERE X.k = C.Ck) JOIN C …` names
+    // `C` in the A×B join's `ON`, but `C` joins LATER, so it is out of that
+    // join's prefix scope. The correlated reference faults `SQLError.column`
+    // (spelled by its bare name, as a direct `C.Ck` there would) rather than
+    // reading a slot not present when the A×B `ON` evaluates.
+    try joins().expect(
+        """
+        SELECT A.a FROM A \
+        JOIN B ON EXISTS (SELECT 1 FROM X WHERE X.k = C.Ck) \
+        JOIN C ON C.Ck = A.a
+        """,
+        fails: .column("Ck"))
+  }
+
+  @Test func `an early ON correlating to a later join faults the check`()
+      throws {
+    // The schema path enforces the SAME prefix scope — `columns(of:)` faults
+    // `SQLError.column` exactly where the run does, keeping typecheck↔run
+    // parity.
+    let query = try parse(query:
+        """
+        SELECT A.a FROM A \
+        JOIN B ON EXISTS (SELECT 1 FROM X WHERE X.k = C.Ck) \
+        JOIN C ON C.Ck = A.a
+        """)
+    let resolve = { () throws -> Array<OutputColumn> in
+      try joins().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.column("Ck")) {
+      try resolve()
+    }
+  }
+
+  @Test func `an ON correlating to a PREFIX relation still works`() throws {
+    // A correlation to a relation IN the prefix (`A`, the FROM relation) is
+    // valid: `ON EXISTS (SELECT 1 FROM X WHERE X.k = A.a)` binds `A.a` from the
+    // A×B row and probes `X`. `X` holds {1, 2}, so the `EXISTS` is true for
+    // every `A` row (a=1, a=2), and the later `C` join matches `C.Ck = A.a`,
+    // yielding both `A` rows.
+    try joins().expect(
+        """
+        SELECT A.a FROM A \
+        JOIN B ON EXISTS (SELECT 1 FROM X WHERE X.k = A.a) \
+        JOIN C ON C.Ck = A.a ORDER BY A.a
+        """,
+        yields: [[1], [2]])
+  }
+}
+
+// MARK: - Reached-role validation shape
+
+/// The deferred type-check picks each reached occurrence's validation SHAPE
+/// from the ROLE it reached in PER OCCURRENCE — an `existential` reach
+/// validates the EXISTS cardinality PROBE (no projection), a `scalar`/`valued`
+/// reach the original — NOT from the union of every role the query occupies in
+/// the select. So the SAME inner SQL reached ONLY as an `EXISTS` validates the
+/// probe even where an UNREACHED `CASE`/`COALESCE` arm has it as a scalar; the
+/// union would mis-mark it "evaluated" and validate the original projection,
+/// faulting `.divide` on a `1 / 0` the run never evaluates.
+struct SubqueryReachedRoleShapeTests {
+  @Test func `an EXISTS reach validates the probe past an unreached scalar`()
+      throws {
+    // `EXISTS (SELECT 1 / 0 FROM S)` is REACHED (the WHERE runs it), so its
+    // cardinality PROBE — a constant projection dropping the `1 / 0` — is
+    // validated: no `.divide`. The IDENTICAL inner `(SELECT 1 / 0 FROM S)` also
+    // occurs as a SCALAR in the ELSE arm of a `1 = 0` CASE, which is UNREACHED,
+    // so its original projection is NOT validated. A global role union would
+    // have marked the query "evaluated" (scalar) and faulted `.divide`.
+    let sql = """
+        SELECT Id FROM T \
+        WHERE EXISTS (SELECT 1 / 0 FROM S) \
+          AND (CASE WHEN 1 = 0 THEN (SELECT 1 / 0 FROM S) ELSE 0 END) = 0 \
+        ORDER BY Id
+        """
+    let columns = try fixture().columns(of: parse(query: sql), validate: true)
+    #expect(columns.count == 1)
+    try fixture().expect(sql, yields: [[1], [2], [3]])
+  }
+
+  @Test func `a reached scalar with a bad projection still faults`() throws {
+    // Parity the other way: with the CASE guard `1 = 1` the scalar arm IS
+    // reached, so the SCALAR role's ORIGINAL projection is validated — its
+    // `1 / 0` faults `.divide` at both validate and run, unchanged by the
+    // EXISTS occurrence sharing the identical inner SQL.
+    let sql = """
+        SELECT Id FROM T \
+        WHERE EXISTS (SELECT 1 / 0 FROM S) \
+          AND (CASE WHEN 1 = 1 THEN (SELECT 1 / 0 FROM S) ELSE 0 END) = 0
+        """
+    let resolve = { () throws -> Array<OutputColumn> in
+      try fixture().columns(of: parse(query: sql), validate: true)
+    }
+    #expect(throws: SQLError.divide) {
+      try resolve()
+    }
+    try fixture().expect(sql, fails: .divide)
+  }
+}
+
+// MARK: - Join-ON short-circuit validation parity
+
+/// A join `ON` predicate short-circuits its `AND`/`OR` at RUN — the join
+/// evaluator steps the lowered conjunction and never materialises a subquery a
+/// FALSE left conjunct settles past. So an `ON` subquery runs through the SAME
+/// reachability/short-circuit walk the WHERE/HAVING do, PREFIX-scoped: one in a
+/// short-circuited leg is NOT eager-validated (matching the lazy run), while a
+/// REACHED `ON` subquery IS validated (parity both directions). The prefix
+/// scope is intact — a correlated `ON` column to a later-joined relation still
+/// faults.
+struct JoinOnShortCircuitValidationTests {
+  @Test func `a short-circuited ON subquery is not validated and runs`()
+      throws {
+    // `ON 1 = 0 AND 1 IN (SELECT 1 / 0 FROM S)` short-circuits on the constant
+    // FALSE left, so the join never materialises the `1 IN (…)` — the walk
+    // skips it, `columns(of:)` does NOT fault `.divide`, and the join RUNS. The
+    // FALSE `ON` matches no A×S pair, so the query yields no rows.
+    let sql = """
+        SELECT A.a FROM A \
+        JOIN B ON 1 = 0 AND 1 IN (SELECT 1 / 0 FROM S)
+        """
+    let columns = try mixed().columns(of: parse(query: sql), validate: true)
+    #expect(columns.count == 1)
+    try mixed().expect(sql, yields: [])
+  }
+
+  @Test func `a reached ON subquery with a bad body still faults`() throws {
+    // Parity: with the left conjunct `1 = 1` the `IN` IS reached, so its
+    // ORIGINAL is validated — its `1 / 0` faults `.divide` at both validate and
+    // run, exactly as an always-reached WHERE occurrence does.
+    let sql = """
+        SELECT A.a FROM A \
+        JOIN B ON 1 = 1 AND 1 IN (SELECT 1 / 0 FROM S)
+        """
+    let resolve = { () throws -> Array<OutputColumn> in
+      try mixed().columns(of: parse(query: sql), validate: true)
+    }
+    #expect(throws: SQLError.divide) {
+      try resolve()
+    }
+    try mixed().expect(sql, fails: .divide)
+  }
+
+  @Test func `a reached EXISTS in the ON validates its probe and runs`()
+      throws {
+    // A REACHED `ON` EXISTS whose retained body is CLEAN validates and runs:
+    // its cardinality probe drops the select list, and `X` holds {1, 2}, so the
+    // EXISTS is TRUE for every A×B pair — the join yields the A rows.
+    let sql = """
+        SELECT A.a FROM A \
+        JOIN B ON 1 = 1 AND EXISTS (SELECT 1 / 0 FROM X) ORDER BY A.a
+        """
+    let columns = try mixed().columns(of: parse(query: sql), validate: true)
+    #expect(columns.count == 1)
+    try mixed().expect(sql, yields: [[1], [2]])
+  }
+
+  @Test func `an early ON correlating to a later join still faults`() throws {
+    // Prefix-scoping is intact under the short-circuit walk: `ON 1 = 1 AND
+    // EXISTS (SELECT 1 FROM X WHERE X.k = C.Ck)` names `C` in the A×B `ON`, but
+    // `C` joins LATER, out of that join's prefix — so the correlated reference
+    // faults `SQLError.column` at both validate and run, per batch-1/4.
+    let sql = """
+        SELECT A.a FROM A \
+        JOIN B ON 1 = 1 AND EXISTS (SELECT 1 FROM X WHERE X.k = C.Ck) \
+        JOIN C ON C.Ck = A.a
+        """
+    let resolve = { () throws -> Array<OutputColumn> in
+      try joins().columns(of: parse(query: sql), validate: true)
+    }
+    #expect(throws: SQLError.column("Ck")) {
+      try resolve()
+    }
+    try joins().expect(sql, fails: .column("Ck"))
+  }
+}
+
+/// A join fixture reused by the `ON` short-circuit tests — `A`×`B` supplies the
+/// join pairs, `S` the throwing inner source, `X` a clean one.
+private func mixed() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("A", ["a": .integer]) {
+      Row(1)
+      Row(2)
+    }
+    Relation("B", ["b": .integer]) {
+      Row(1)
+    }
+    Relation("S", ["V": .integer]) {
+      Row(10)
+    }
+    Relation("X", ["k": .integer]) {
+      Row(1)
+      Row(2)
+    }
+  }
+}
+
+// MARK: - Correlated plan cache occurrence identity
+
+/// The correlated per-outer-row PLAN cache keys on the full occurrence `Subkey`
+/// (scope + query + role), not just the inner `Query`. Two occurrences of the
+/// IDENTICAL inner SQL — one under a `.caller` scope and one under a
+/// `.view(name)` body, whose correlated column resolves to a DIFFERENT ordinal
+/// — each compile and execute their OWN plan; keying by the query alone made a
+/// later occurrence reuse the first's plan (its synthetic-parameter names and
+/// resolved layout), reading the wrong outer cell.
+private func occurrences() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("Src", ["m": .integer]) {
+      Row(10)
+      Row(20)
+      Row(30)
+    }
+    // The caller's outer relation — its correlated column `k` at ordinal 0.
+    Relation("Outer1", ["k": .integer]) {
+      Row(10)
+      Row(20)
+    }
+    // The view's outer relation — a leading `pad` puts its correlated column
+    // `k` at ordinal 1, a DIFFERENT ordinal from `Outer1.k`.
+    Relation("Outer2", ["pad": .integer, "k": .integer]) {
+      Row(0, 20)
+      Row(0, 30)
+    }
+    // A view whose body holds the SAME correlated inner SQL the caller uses,
+    // over `Outer2` (correlated `k` at ordinal 1) — the `.view` occurrence.
+    try View("VW", "SELECT (SELECT m FROM Src WHERE m = k) AS mm FROM Outer2",
+             as: ["mm"])
+  }
+}
+
+struct CorrelatedPlanCacheIdentityTests {
+  @Test func `identical correlated SQL under a caller and a view each hold`()
+      throws {
+    // `(SELECT m FROM Src WHERE m = k)` appears BOTH in the caller (over
+    // `Outer1`, `k` at ordinal 0) and in view `VW`'s body (over `Outer2`, `k`
+    // at ordinal 1) — identical inner SQL, DISTINCT scope AND ordinal. Each
+    // occurrence runs its OWN plan: the caller yields `Outer1.k` ∈ {10, 20}
+    // matched against `Src` → {10, 20}; the view yields `Outer2.k` ∈ {20, 30}
+    // → {20, 30}. A query-only cache key would reuse the first plan (wrong
+    // ordinal/parameter), so the two arms would not both resolve correctly.
+    try occurrences().expect(
+        """
+        SELECT (SELECT m FROM Src WHERE m = k) AS c FROM Outer1 \
+        UNION ALL \
+        SELECT mm FROM VW ORDER BY 1
+        """,
+        yields: [[10], [20], [20], [30]])
+  }
+}
+
+// MARK: - Nested correlation bubble-up
+
+/// A correlation discovered while compiling a subquery NESTED inside another
+/// subquery must BUBBLE UP to mark the CONTAINING subquery correlated. An INNER
+/// `EXISTS` naming a column of a scope TWO levels up (`T.id`, above the middle
+/// `U` query) makes the MIDDLE `EXISTS` correlated to `T` too, so it re-executes
+/// per `T` row and threads the binding down — rather than being treated as
+/// uncorrelated and re-run without the `T` scope.
+private func nested() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["id": .integer]) {
+      Row(1)
+      Row(2)
+      Row(3)
+    }
+    // A single-row source so the MIDDLE `EXISTS` over `U` is non-empty exactly
+    // when its own nested `EXISTS` over `V` is — isolating the bubble-up.
+    Relation("U", ["u": .integer]) {
+      Row(0)
+    }
+    // The innermost source — its `x` matches only `T` rows 2 and 3.
+    Relation("V", ["x": .integer]) {
+      Row(2)
+      Row(3)
+    }
+  }
+}
+
+struct NestedCorrelationBubbleUpTests {
+  @Test func `a two-level nested correlation resolves and runs per T row`()
+      throws {
+    // The INNER `EXISTS (SELECT 1 FROM V WHERE V.x = T.id)` correlates to `T.id`
+    // — two levels up, above the middle `U` query. The correlation bubbles up so
+    // the MIDDLE `EXISTS` is correlated to `T` and re-runs per `T` row. `V.x` ∈
+    // {2, 3}, so only `T` rows 2 and 3 satisfy the inner `EXISTS`; `U` has a
+    // row, so the middle `EXISTS` mirrors the inner. Result: rows 2 and 3.
+    try nested().expect(
+        """
+        SELECT id FROM T \
+        WHERE EXISTS (SELECT 1 FROM U \
+                      WHERE EXISTS (SELECT 1 FROM V WHERE V.x = T.id)) \
+        ORDER BY id
+        """,
+        yields: [[2], [3]])
+  }
+
+  @Test func `a two-level nested correlation validates`() throws {
+    // The schema path resolves the bubbled-up correlation the SAME as the run —
+    // `columns(of:)` validates the two-level correlated query rather than
+    // faulting `SQLError.column` on the enclosing `T.id`.
+    let query = try parse(query:
+        """
+        SELECT id FROM T \
+        WHERE EXISTS (SELECT 1 FROM U \
+                      WHERE EXISTS (SELECT 1 FROM V WHERE V.x = T.id))
+        """)
+    let columns = try nested().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+  }
+}
+
+// MARK: - Correlated scope-depth disambiguation
+
+/// A three-level nest whose INNERMOST subquery correlates to TWO enclosing
+/// scopes at once — its immediate parent `U` and its grandparent `T` — where
+/// the referenced columns share the SAME combined ordinal (both 0, each its
+/// scope's sole column). Keying the synthetic parameter on the ordinal ALONE
+/// collides the two onto one binding, so both terms would read the same cell
+/// and the inner filter returns the wrong rows; keying on scope DEPTH + ordinal
+/// keeps them distinct.
+private func scoped() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["id": .integer]) {
+      Row(1)
+      Row(2)
+      Row(3)
+    }
+    // One row, so the MIDDLE `EXISTS` over `U` is non-empty exactly when its
+    // nested `EXISTS` over `V` is — its sole column `u` is 5, the value `V.y`
+    // must match.
+    Relation("U", ["u": .integer]) {
+      Row(5)
+    }
+    // `V.x` matches `T.id` in {2, 3}, but only `(2, 5)` also has `V.y = U.u`
+    // (5): so only `T` row 2 satisfies BOTH correlated terms. A collided
+    // binding (both terms reading one cell) would drop row 2 too, yielding [].
+    Relation("V", ["x": .integer, "y": .integer]) {
+      Row(2, 5)
+      Row(3, 9)
+    }
+  }
+}
+
+struct CorrelatedScopeDepthTests {
+  @Test func `two same-ordinal correlations from different scopes run right`()
+      throws {
+    // `V.x = T.id` correlates to the GRANDPARENT `T` (ordinal 0), `V.y = U.u`
+    // to the PARENT `U` (also ordinal 0). Depth-keyed synthetic params keep
+    // them distinct, so each term reads its OWN binding: only `T` row 2 matches
+    // (`V.x = 2 = id` AND `V.y = 5 = u`). An ordinal-only key would collide the
+    // two onto `:__correlated_0`, one overwriting the other, yielding [].
+    try scoped().expect(
+        """
+        SELECT id FROM T \
+        WHERE EXISTS (SELECT 1 FROM U \
+                      WHERE EXISTS (SELECT 1 FROM V \
+                                    WHERE V.x = T.id AND V.y = U.u)) \
+        ORDER BY id
+        """,
+        yields: [[2]])
+  }
+
+  @Test func `two same-ordinal correlations from different scopes validate`()
+      throws {
+    // The schema path resolves BOTH correlations the same as the run — no
+    // `SQLError.column` on either enclosing reference.
+    let query = try parse(query:
+        """
+        SELECT id FROM T \
+        WHERE EXISTS (SELECT 1 FROM U \
+                      WHERE EXISTS (SELECT 1 FROM V \
+                                    WHERE V.x = T.id AND V.y = U.u))
+        """)
+    let columns = try scoped().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+  }
+}
+
+// MARK: - Correlated lookup ambiguity shadowing
+
+/// An `Outer` scope resolves a correlated column NEAREST enclosing scope first
+/// (lexical scoping). The three outcomes of a per-scope probe must stay DISTINCT
+/// — found binds, not-found keeps walking outward, and AMBIGUOUS (the name in
+/// more than one relation of a scope) SHADOWS the farther scopes by faulting
+/// `SQLError.ambiguous`, never falling through to rebind the name to a farther
+/// relation. A `try?` that collapsed ambiguous onto not-found silently rebound
+/// a nearer-ambiguous name to an outer column.
+private func relation(_ name: String, _ columns: Array<String>)
+    -> (SQLEngine.Relation, Schema) {
+  (SQLEngine.Relation(name: name),
+   Schema(width: columns.count, extent: columns.count, names: columns,
+          types: columns.map { _ in .integer }, virtuals: []))
+}
+
+struct CorrelatedAmbiguityShadowTests {
+  @Test func `a nearer ambiguous scope shadows a farther one`() throws {
+    // Outer `T(id)`; middle `U(id, u) JOIN V(id, v)` both expose `id`. A bare
+    // `id` correlating outward binds at the NEAREST enclosing scope — the middle
+    // — where it is AMBIGUOUS, so the lookup faults `SQLError.ambiguous` rather
+    // than walking past to rebind it to the farther `T.id`.
+    let outer = Outer([Scope([relation("T", ["id"])])])
+        .nested(under: Scope([relation("U", ["id", "u"]),
+                              relation("V", ["id", "v"])]))
+    #expect(throws: SQLError.ambiguous("id")) {
+      _ = try outer.parameter(for: "id")
+    }
+    // The schema-derive probe shadows identically, so validate and run AGREE.
+    #expect(throws: SQLError.ambiguous("id")) {
+      _ = try outer.type(for: "id")
+    }
+  }
+
+  @Test func `an unambiguous nearer name still correlates`() throws {
+    // `u` is bound by ONLY `U` of the middle scope — unambiguous — so it
+    // correlates to the middle (a non-nil parameter, its outer type). Proof the
+    // shadowing faults ONLY on ambiguity, never a clean nearer match.
+    let outer = Outer([Scope([relation("T", ["id"])])])
+        .nested(under: Scope([relation("U", ["id", "u"]),
+                              relation("V", ["id", "v"])]))
+    #expect(try outer.parameter(for: "u") != nil)
+    #expect(try outer.type(for: "u") == .integer)
+  }
+
+  @Test func `a name absent from the nearer scope resolves outward`() throws {
+    // `key` is absent from the middle `U JOIN V` but present in outer `T` — a
+    // NOT-FOUND at the nearer scope keeps the walk moving outward, so it still
+    // resolves to `T`. Only AMBIGUITY stops the walk; absence does not.
+    let outer = Outer([Scope([relation("T", ["key"])])])
+        .nested(under: Scope([relation("U", ["u"]),
+                              relation("V", ["v"])]))
+    #expect(try outer.parameter(for: "key") != nil)
+    #expect(try outer.type(for: "key") == .integer)
+  }
+}
+
+// MARK: - Correlated EXISTS cardinality probe
+
+/// An outer `T` keyed by `k` and an inner `U` keyed by `k`, so a correlated
+/// EXISTS matches an outer row against the inner source per row — the shape
+/// exercising the per-outer-row cardinality PROBE (the correlated EXISTS must
+/// test non-emptiness WITHOUT evaluating the inner select list, exactly as the
+/// uncorrelated EXISTS probe does).
+private func existence() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["id": .integer, "k": .integer]) {
+      Row(1, 1)
+      Row(2, 2)
+      Row(3, 3)
+    }
+    Relation("U", ["k": .integer]) {
+      Row(1)
+      Row(2)
+    }
+  }
+}
+
+struct CorrelatedExistsProbeTests {
+  @Test func `a correlated EXISTS probes without evaluating a divide`()
+      throws {
+    // `EXISTS (SELECT 1 / 0 FROM U WHERE U.k = T.k)` is correlated to `T.k`, so
+    // it re-runs per outer row — but through the cardinality PROBE, whose
+    // constant projection never evaluates the `1 / 0` select list. `U.k` ∈ {1,
+    // 2} matches `T` rows 1 and 2 (EXISTS TRUE, no `.divide`); row 3 matches
+    // none (FALSE). The FULL plan would have evaluated `1 / 0` and faulted.
+    let sql = """
+        SELECT id FROM T \
+        WHERE EXISTS (SELECT 1 / 0 FROM U WHERE U.k = T.k) ORDER BY id
+        """
+    let columns = try existence().columns(of: parse(query: sql),
+                                                 validate: true)
+    #expect(columns.count == 1)
+    try existence().expect(sql, yields: [[1], [2]])
+  }
+
+  @Test func `a correlated EXISTS with a normal projection still works`()
+      throws {
+    // The same correlation with an ORDINARY select list runs identically — the
+    // probe keeps the FROM/`WHERE`, so the row source and its correlation still
+    // decide existence: rows 1 and 2 match, row 3 does not.
+    let sql = """
+        SELECT id FROM T \
+        WHERE EXISTS (SELECT k FROM U WHERE U.k = T.k) ORDER BY id
+        """
+    try existence().expect(sql, yields: [[1], [2]])
+  }
+}
+
+// MARK: - Local ambiguity is a hard error, not outer correlation
+
+/// A correlated `.column` lowering resolves against its OWN relations FIRST,
+/// falling through to outer correlation only when the name binds NONE of them.
+/// A name bound by MORE than one local relation is LOCALLY AMBIGUOUS — a hard
+/// `SQLError.ambiguous`, NOT a fall-through: swallowing it into outer
+/// correlation would silently rebind an ambiguous inner name to an enclosing
+/// column of the same spelling (the wrong row value). A genuinely-not-found
+/// local name still correlates to the outer.
+private func ambiguity() throws -> FixtureCatalog {
+  try Catalog {
+    // The outer relation exposes `id` AND `label`, either a candidate for an
+    // inner name to (wrongly) correlate to.
+    Relation("T", ["id": .integer, "label": .integer]) {
+      Row(1, 100)
+      Row(2, 200)
+    }
+    // The inner join's two relations BOTH expose `id`, so a bare `id` in the
+    // inner `WHERE` is LOCALLY ambiguous.
+    Relation("U", ["id": .integer, "u": .integer]) {
+      Row(1, 5)
+    }
+    Relation("V", ["id": .integer, "v": .integer]) {
+      Row(1, 5)
+    }
+  }
+}
+
+struct CorrelatedLocalAmbiguityTests {
+  @Test func `a locally ambiguous inner name faults at run`() throws {
+    // `EXISTS (SELECT 1 FROM U JOIN V ON U.u = V.v WHERE id = 1)`: `id` binds
+    // BOTH `U.id` and `V.id`, so it is a LOCAL ambiguity — a hard
+    // `SQLError.ambiguous("id")`, NOT a silent rebind to the outer `T.id`.
+    let sql = """
+        SELECT T.label FROM T \
+        WHERE EXISTS (SELECT 1 FROM U JOIN V ON U.u = V.v WHERE id = 1)
+        """
+    try ambiguity().expect(sql, fails: .ambiguous("id"))
+  }
+
+  @Test func `a locally ambiguous inner name faults the check`() throws {
+    // The schema path faults the SAME `SQLError.ambiguous("id")`, keeping
+    // typecheck↔run parity — not swallowing the ambiguity into a correlation.
+    let sql = """
+        SELECT T.label FROM T \
+        WHERE EXISTS (SELECT 1 FROM U JOIN V ON U.u = V.v WHERE id = 1)
+        """
+    let query = try parse(query: sql)
+    let resolve = { () throws -> Array<OutputColumn> in
+      try ambiguity().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.ambiguous("id")) { try resolve() }
+  }
+
+  @Test func `a not-found inner name still correlates`() throws {
+    // `label` binds NONE of the inner relations (`U`, `V`), so it is a genuine
+    // correlated reference to the outer `T.label` — bound per outer row. `U`
+    // holds a row, so the `EXISTS` is TRUE for the `T` row whose `label` is 100
+    // (row 1) and FALSE for row 2 (`label` 200).
+    let sql = """
+        SELECT T.id FROM T \
+        WHERE EXISTS (SELECT 1 FROM U JOIN V ON U.u = V.v WHERE label = 100) \
+        ORDER BY T.id
+        """
+    try ambiguity().expect(sql, yields: [[1]])
+  }
+}
+
+// MARK: - Correlated parameters are nullable for pushdown
+
+/// A correlated column lowers to a `Term.parameter` whose per-outer-row value
+/// can be NULL, so a SLOTLESS comparison over it (`outer = 1`) can be UNKNOWN.
+/// Selection pushdown must treat such a conjunct as NULLABLE — the same
+/// treatment a `Filter.bound` parameter gets — so it never rides AHEAD of a
+/// LATER unsafe conjunct the non-short-circuiting inner `AND` still owes. Moving
+/// it ahead would drop the UNKNOWN row before the unsafe conjunct (a `1 / 0`)
+/// runs, suppressing a throw the `AND` order owes.
+private func pushdown() throws -> FixtureCatalog {
+  try Catalog {
+    // A single outer row whose correlated key is NULL, so `T.k = 1` is UNKNOWN.
+    Relation("T", ["k": .integer]) {
+      Row(nil)
+    }
+    Relation("P", ["j": .integer]) {
+      Row(1)
+    }
+    // A single `Q` row whose `y` is zero, so `(1 / Q.y) = 0` FAULTS `.divide`
+    // when reached.
+    Relation("Q", ["j": .integer, "y": .integer]) {
+      Row(1, 0)
+    }
+  }
+}
+
+struct CorrelatedPushdownNullableTests {
+  @Test func `a correlated slotless conjunct does not ride ahead of a divide`()
+      throws {
+    // `EXISTS (SELECT 1 FROM P JOIN Q ON P.j = Q.j WHERE T.k = 1 AND
+    // (1 / Q.y) = 0)`: `T.k` is NULL, so `T.k = 1` is UNKNOWN, and the inner
+    // `AND` (which does NOT short-circuit an UNKNOWN left) reaches `(1 / Q.y)
+    // = 0` on the matching P×Q pair — a `.divide`. Treating the correlated
+    // `T.k = 1` as non-nullable would let pushdown descend it below the join,
+    // dropping the pair BEFORE the divide and hiding the fault; treating it
+    // nullable (like a `.bound`) keeps it ahead of the unsafe conjunct, so the
+    // divide runs and faults.
+    let sql = """
+        SELECT k FROM T \
+        WHERE EXISTS (SELECT 1 FROM P JOIN Q ON P.j = Q.j \
+        WHERE T.k = 1 AND (1 / Q.y) = 0)
+        """
+    try pushdown().expect(sql, fails: .divide)
+  }
+}
+
+// MARK: - A qualifier-shadowing local alias is a hard error, not correlation
+
+/// A QUALIFIED correlated reference resolves against its OWN relations first: a
+/// qualifier a LOCAL relation answers (its alias, else its table name) that
+/// names a column the relation LACKS is a hard `SQLError.column` — the local
+/// alias SHADOWS a same-qualifier ENCLOSING relation, so the miss faults
+/// against the inner relation rather than falling through to bind the outer
+/// one. Only a qualifier NO local relation answers (a genuine correlated
+/// reference) walks outward. Two shapes exercise this: a SINGLE-relation inner
+/// subquery whose alias matches an outer alias (Item 1), and a JOINED inner
+/// scope whose local alias matches an outer alias (Item 2).
+private func shadowing() throws -> FixtureCatalog {
+  try Catalog {
+    // The outer relation `T` aliased `x(v)`, a same-qualifier candidate an
+    // inner `x.v` would (wrongly) correlate to.
+    Relation("T", ["v": .integer]) {
+      Row(1)
+    }
+    // The inner source `S` — aliased `x` inside the subquery — carries NO
+    // column `v`, so `x.v` against it is a QUALIFIED MISS on the local alias.
+    Relation("S", ["w": .integer]) {
+      Row(1)
+    }
+    // A second inner relation to join `S` with, for the joined-scope shape.
+    Relation("R", ["w": .integer]) {
+      Row(1)
+    }
+  }
+}
+
+struct CorrelatedQualifierShadowTests {
+  @Test func `a single-relation qualifier shadow faults, not correlates`()
+      throws {
+    // Item 1. Under outer `T AS x(v)`, the subquery `(SELECT 1 FROM S AS x
+    // WHERE x.v = 1)` names `x.v` — the local alias `x` (the inner `S AS x`)
+    // answers the qualifier but LACKS `v`, a hard `.column`. It must NOT fall
+    // through to read the outer `T AS x`'s `v`. Pre-fix the `try?` swallowed
+    // the miss and correlated to the outer `x.v`, silently succeeding.
+    let sql = """
+        SELECT v FROM T AS x \
+        WHERE EXISTS (SELECT 1 FROM S AS x WHERE x.v = 1)
+        """
+    try shadowing().expect(sql, fails: .column("v"))
+  }
+
+  @Test func `a single-relation qualifier shadow faults the check`() throws {
+    // The schema path faults the SAME `SQLError.column("v")`, keeping
+    // typecheck↔run parity — the derive probe shadows the outer alias too.
+    let sql = """
+        SELECT v FROM T AS x \
+        WHERE EXISTS (SELECT 1 FROM S AS x WHERE x.v = 1)
+        """
+    let query = try parse(query: sql)
+    #expect(throws: SQLError.column("v")) {
+      try shadowing().columns(of: query, validate: true)
+    }
+  }
+
+  @Test func `a joined qualifier shadow faults, not correlates`() throws {
+    // Item 2. Under outer `T AS x(v)`, the JOINED inner scope `S AS x JOIN R
+    // ON x.w = R.w` binds a local alias `x` (the inner `S`). An inner `x.v`
+    // names the local `x`, which LACKS `v` — a hard `.column` shadowing the
+    // outer `x`. Pre-fix the blanket `.column`→`nil` in `find` let the lookup
+    // walk outward and rebind `x.v` to the OUTER row.
+    let sql = """
+        SELECT v FROM T AS x \
+        WHERE EXISTS (SELECT 1 FROM S AS x JOIN R ON x.w = R.w \
+        WHERE x.v = 1)
+        """
+    try shadowing().expect(sql, fails: .column("v"))
+  }
+
+  @Test func `a joined qualifier shadow faults the check`() throws {
+    // The schema path faults the SAME `SQLError.column("v")` for the joined
+    // shape — `Scope.find` propagates the qualified miss rather than swallowing
+    // it — so validation and run AGREE.
+    let sql = """
+        SELECT v FROM T AS x \
+        WHERE EXISTS (SELECT 1 FROM S AS x JOIN R ON x.w = R.w \
+        WHERE x.v = 1)
+        """
+    let query = try parse(query: sql)
+    #expect(throws: SQLError.column("v")) {
+      try shadowing().columns(of: query, validate: true)
+    }
+  }
+
+  @Test func `a qualifier no local relation answers still correlates`()
+      throws {
+    // PARITY. A genuinely-correlated qualified reference — the qualifier `T` is
+    // NOT a local alias of the inner `S AS s` — still correlates to the outer
+    // `T` and works: `T.v` binds the outer row (1), so `s.w = T.v` matches the
+    // lone `S` row and the EXISTS is TRUE, projecting the outer `v`.
+    let sql = """
+        SELECT v FROM T \
+        WHERE EXISTS (SELECT 1 FROM S AS s WHERE s.w = T.v) \
+        ORDER BY v
+        """
+    try shadowing().expect(sql, yields: [[1]])
+  }
+}
+
+// MARK: - Per-occurrence prefix/correlation resolution
+
+/// The join-prefix correlation plan is keyed PER OCCURRENCE, not by inner SQL
+/// text. The SAME `EXISTS (SELECT … WHERE X.k = x)` in an early `JOIN … ON`
+/// (whose PREFIX exposes `x` in only ONE relation) and in the `WHERE` (whose
+/// FULL scope exposes `x` in TWO relations) resolves EACH against ITS site's
+/// scope: the `ON` occurrence binds the prefix's lone `x`, while the `WHERE`
+/// occurrence resolves against the full scope and REJECTS the now-ambiguous `x`
+/// — not reusing the first occurrence's narrower prefix binding.
+private func occurrence() throws -> FixtureCatalog {
+  try Catalog {
+    // The FROM relation, the only `x` in the FIRST join's prefix.
+    Relation("A", ["x": .integer]) {
+      Row(1)
+      Row(2)
+    }
+    Relation("B", ["b": .integer]) {
+      Row(1)
+    }
+    // A later-joined relation that ALSO exposes `x`, making a bare `x`
+    // ambiguous in the full `WHERE` scope.
+    Relation("C", ["x": .integer]) {
+      Row(1)
+      Row(2)
+    }
+    Relation("X", ["k": .integer]) {
+      Row(1)
+      Row(2)
+    }
+  }
+}
+
+struct CorrelatedOccurrenceScopeTests {
+  @Test func `an ON occurrence binds its prefix scope`() throws {
+    // In the FIRST join's `ON`, the prefix is `{A, B}` — only `A` exposes `x`,
+    // so `EXISTS (SELECT 1 FROM X WHERE X.k = x)` binds `A.x` unambiguously.
+    // `X` holds {1, 2}, so the `EXISTS` is TRUE for every `A` row.
+    let sql = """
+        SELECT A.x FROM A \
+        JOIN B ON EXISTS (SELECT 1 FROM X WHERE X.k = x) ORDER BY A.x
+        """
+    try occurrence().expect(sql, yields: [[1], [2]])
+  }
+
+  @Test func `a WHERE occurrence resolves against the full scope`() throws {
+    // The IDENTICAL `EXISTS (SELECT 1 FROM X WHERE X.k = x)` also appears in the
+    // `WHERE`, AFTER `C` (which also exposes `x`) has joined. Its correlated `x`
+    // is out of `X`'s own relation and correlates against the FULL `{A, B, C}`
+    // scope, where `x` is bound by BOTH `A` and `C` — an AMBIGUOUS enclosing
+    // reference. The correlation lookup faults `SQLError.ambiguous` per ITS
+    // site (the nearer ambiguous scope shadows any farther one) rather than
+    // reusing the `ON` occurrence's unambiguous prefix `A.x`.
+    let sql = """
+        SELECT A.x FROM A \
+        JOIN B ON EXISTS (SELECT 1 FROM X WHERE X.k = x) \
+        JOIN C ON C.x = A.x \
+        WHERE EXISTS (SELECT 1 FROM X WHERE X.k = x)
+        """
+    try occurrence().expect(sql, fails: .ambiguous("x"))
+  }
+
+  @Test func `a WHERE occurrence faults the check per its site`() throws {
+    // The schema path resolves each occurrence per ITS site too, so the WHERE
+    // occurrence faults `SQLError.ambiguous("x")` at `columns(of:)` exactly as
+    // the run does — typecheck↔run parity, not the first occurrence's prefix.
+    let sql = """
+        SELECT A.x FROM A \
+        JOIN B ON EXISTS (SELECT 1 FROM X WHERE X.k = x) \
+        JOIN C ON C.x = A.x \
+        WHERE EXISTS (SELECT 1 FROM X WHERE X.k = x)
+        """
+    let query = try parse(query: sql)
+    let resolve = { () throws -> Array<OutputColumn> in
+      try occurrence().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.ambiguous("x")) { try resolve() }
+  }
+}
+
+// MARK: - A correlated EXISTS probe honours the outer run's lenience
+
+/// A CORRELATED `EXISTS` recompiles its cardinality PROBE per occurrence, and
+/// that recompile must inherit the enclosing run's `validate` flag rather than
+/// silently defaulting to a strict schema check. An outer `run` (`validate:
+/// false`) proves the query runnable and must NOT eager-type-check a
+/// data-dependent-empty derived body the probe never reaches; a strict
+/// `columns(of:validate:true)` over the SAME query still faults it — parity
+/// in both directions.
+private func lenient() throws -> FixtureCatalog {
+  try Catalog {
+    // The outer relation the EXISTS correlates against.
+    Relation("T", ["id": .integer]) {
+      Row(1)
+    }
+    // The inner source whose derived body projects `Label + 1` — text plus
+    // integer, a `.operand` fault WHEN type-checked — under a `WHERE k = 0`
+    // that matches NO row, so a run empties the body before it ever evaluates
+    // the projection.
+    Relation("S", ["k": .integer, "Label": .text]) {
+      Row(5, "a")
+    }
+  }
+}
+
+struct CorrelatedExistsProbeLenienceTests {
+  @Test func `a run does not fault a probe's filtered-out body`() throws {
+    // `EXISTS (SELECT 1 FROM (SELECT Label + 1 AS x FROM S WHERE k = 0) AS d
+    // WHERE d.x = T.id)`: the derived body's `WHERE k = 0` filters every `S`
+    // row, so `Label + 1` never runs. The correlated EXISTS recompiles its
+    // PROBE per outer row; under the lenient outer run that recompile must
+    // trust the filtered-out projection rather than fault `.operand`. The body
+    // is empty, so the EXISTS is FALSE for the sole `T` row and the run yields
+    // no rows.
+    let sql = """
+        SELECT id FROM T \
+        WHERE EXISTS (SELECT 1 FROM \
+        (SELECT Label + 1 AS x FROM S WHERE k = 0) AS d WHERE d.x = T.id)
+        """
+    try lenient().empty(sql)
+  }
+
+  @Test func `a strict check still faults the probe's body`() throws {
+    // Parity: a strict `columns(of:validate:true)` over the SAME query eager-
+    // type-checks the derived body's reachable projection and faults its ill-
+    // typed `Label + 1`, so the schema path advertises nothing for a query a
+    // run would fault once a row reached the projection.
+    let sql = """
+        SELECT id FROM T \
+        WHERE EXISTS (SELECT 1 FROM \
+        (SELECT Label + 1 AS x FROM S WHERE k = 0) AS d WHERE d.x = T.id)
+        """
+    let query = try parse(query: sql)
+    let resolve = { () throws -> Array<OutputColumn> in
+      try lenient().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.operand("operands must be numeric")) {
+      try resolve()
+    }
+  }
+}
+
+// MARK: - FROM-less scope frame (correlation across an empty frame)
+
+/// A FROM-less SELECT is STILL a scope FRAME. The example
+/// `SELECT id FROM T WHERE (SELECT CASE WHEN EXISTS (SELECT 1 FROM S WHERE
+/// S.x = T.id) THEN 1 END) = 1` nests a FROM-less middle scalar subquery whose
+/// own body holds an `EXISTS` correlating to the OUTER `T` — a scope past the
+/// empty FROM-less frame. The middle plan runs over a single empty record, so
+/// `T.id` must thread through the empty frame as `.bound`, NOT bind from a
+/// `.slot` of that empty record. `S.x` ∈ {2, 3}, so the CASE is 1 exactly for
+/// `T` rows 2 and 3, which the equality `= 1` keeps.
+private func fromless() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["id": .integer]) {
+      Row(1)
+      Row(2)
+      Row(3)
+    }
+    Relation("S", ["x": .integer]) {
+      Row(2)
+      Row(3)
+    }
+  }
+}
+
+struct FromlessScopeFrameTests {
+  @Test func `a correlation across a FROM-less frame runs per outer row`()
+      throws {
+    // The middle `(SELECT CASE WHEN EXISTS (...) THEN 1 END)` is FROM-less, so
+    // its plan runs over a single EMPTY record. The inner `EXISTS`'s `T.id`
+    // names the OUTER `T`, one frame OUT past the empty FROM-less frame — so it
+    // resolves `.bound` and threads through per outer `T` row, rather than
+    // binding a `.slot` of the empty record (which would trap or read wrong).
+    // `S.x` ∈ {2, 3}, so the CASE is 1 for `T` rows 2 and 3.
+    try fromless().expect(
+        """
+        SELECT id FROM T \
+        WHERE (SELECT CASE WHEN EXISTS \
+                          (SELECT 1 FROM S WHERE S.x = T.id) THEN 1 END) = 1 \
+        ORDER BY id
+        """,
+        yields: [[2], [3]])
+  }
+
+  @Test func `a correlation across a FROM-less frame validates`() throws {
+    // The schema path resolves the correlation threaded through the FROM-less
+    // frame the SAME as the run — no `SQLError.column` on the enclosing `T.id`.
+    let query = try parse(query:
+        """
+        SELECT id FROM T \
+        WHERE (SELECT CASE WHEN EXISTS \
+                          (SELECT 1 FROM S WHERE S.x = T.id) THEN 1 END) = 1
+        """)
+    let columns = try fromless().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+  }
+}
+
+// MARK: - Immediate correlation parity (no FROM-less frame)
+
+struct ImmediateCorrelationParityTests {
+  @Test func `a directly correlated EXISTS with a real FROM stays a slot`()
+      throws {
+    // PARITY: the SAME inner `EXISTS (SELECT 1 FROM S WHERE S.x = T.id)` with
+    // NO FROM-less middle correlates to the IMMEDIATE enclosing `T` — one real
+    // frame out — so it resolves `.slot` and reads the outer row directly. The
+    // FROM-less empty-frame rule must not over-thread this immediate case.
+    // `S.x` ∈ {2, 3}, so only `T` rows 2 and 3 satisfy the EXISTS.
+    try fromless().expect(
+        """
+        SELECT id FROM T \
+        WHERE EXISTS (SELECT 1 FROM S WHERE S.x = T.id) \
+        ORDER BY id
+        """,
+        yields: [[2], [3]])
   }
 }

--- a/Tests/SQLTests/SubqueryTests.swift
+++ b/Tests/SQLTests/SubqueryTests.swift
@@ -540,6 +540,37 @@ struct AggregateSubqueryTests {
       try resolve()
     }
   }
+
+  @Test func `columns validates a grouped ORDER BY CORRELATED subquery`()
+      throws {
+    // Batch 7, Item 1: a grouped query whose ORDER BY aggregate argument nests
+    // a CORRELATED subquery (`S.V = T.K`, the inner `T.K` an outer column of the
+    // grouped select). The run path's `group` gives the ORDER BY subquery
+    // lowering the enclosing scope, so it resolves `T.K` and runs; VALIDATION
+    // must thread the SAME enclosing scope, else it compiles the inner query
+    // with NO outer scope and falsely faults `SQLError.column("K")`. It must
+    // succeed exactly as the run does.
+    let query = try parse(query:
+        "SELECT K FROM T GROUP BY K "
+        + "ORDER BY SUM(CASE WHEN EXISTS "
+        + "(SELECT 1 FROM S WHERE S.V = T.K) THEN 1 ELSE 0 END), K")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+  }
+
+  @Test func `a grouped ORDER BY CORRELATED subquery orders the run`() throws {
+    // The correlated `EXISTS (SELECT 1 FROM S WHERE S.V = T.K)` is TRUE for the
+    // groups whose `K` is in `S.V` ({10, 20, 99}) — groups 10 and 20 — and
+    // FALSE for groups NULL and 30, so the ORDER BY key is 0 for {NULL, 30} and
+    // 1 for {10, 20}. Sorting on that key then `K` yields NULL, 30 (key 0) then
+    // 10, 20 (key 1). The run must execute the per-group correlated subquery and
+    // order the groups by it.
+    try fixture().expect(
+        "SELECT K FROM T GROUP BY K "
+        + "ORDER BY SUM(CASE WHEN EXISTS "
+        + "(SELECT 1 FROM S WHERE S.V = T.K) THEN 1 ELSE 0 END), K",
+        yields: [[nil], [30], [10], [20]])
+  }
 }
 
 // MARK: - Deferred execution
@@ -1387,6 +1418,184 @@ struct InPushdownNullabilityTests {
   }
 }
 
+// MARK: - Lazy subquery pushdown safety
+
+/// A LAZY subquery (`EXISTS`/`IN`/quantified) is NEVER pushdown-`safe`: under
+/// lazy materialisation its FIRST evaluation RUNS the inner query, which may
+/// FAULT. A subquery conjunct beside a SEEKABLE conjunct must therefore NOT be
+/// classified safe and left as a residual over a seeked (narrowed) scan: the
+/// non-short-circuiting inner `AND` owes the throw for a row the seek skips, so
+/// riding the subquery below the seek SUPPRESSES that throw.
+///
+/// `T` is SORTED on `Id`, so `Id < 0` is a seekable predicate over an EMPTY
+/// run; `S.z` is zero, so `1 / z` FAULTS `.divide` the moment the subquery is
+/// evaluated. With the subquery the LEFT conjunct (`subquery AND Id < 0`), the
+/// non-short-circuiting `AND` evaluates the subquery FIRST for every scanned
+/// row, so a correct run FAULTS. Pre-fix the subquery reported `safe`, so the
+/// planner seeked on `Id < 0` (an empty run) and left the subquery a residual
+/// over ZERO rows — never evaluating it, wrongly returning zero rows and hiding
+/// the throw. Post-fix the subquery is NOT safe, the seek keeps it above the
+/// scan, and the run FAULTS as the left-to-right `AND` owes.
+struct LazySubqueryPushdownSafetyTests {
+  private func fixture() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["Id": .integer], sorted: "Id") {
+        Row(1)
+        Row(2)
+      }
+      Relation("S", ["z": .integer]) {
+        Row(0)
+      }
+      try View("VW", "SELECT Id FROM T", as: ["Id"])
+    }
+  }
+
+  @Test func `an EXISTS conjunct is not seeked past a skipped row`() throws {
+    // Pre-fix: the uncorrelated `EXISTS` reported `safe`, so it rode below the
+    // `Id < 0` seek as a residual over the empty run and never evaluated —
+    // returning zero rows, SUPPRESSING the `.divide` the leading conjunct owes.
+    // Post-fix it is NOT safe, so the seek keeps it and the run faults.
+    try fixture().expect(
+        """
+        SELECT Id FROM VW \
+        WHERE EXISTS (SELECT 1 FROM S WHERE 1 / z = 0) AND Id < 0
+        """,
+        fails: .divide)
+  }
+
+  @Test func `an IN conjunct is not seeked past a skipped row`() throws {
+    // The `IN (Q)` variant: `Id IN (SELECT 1 / z FROM S)` faults on the first
+    // reach. Pre-fix the `.within` term was `safe` and rode below the empty
+    // `Id < 0` seek, suppressing the throw; post-fix the run faults `.divide`.
+    try fixture().expect(
+        "SELECT Id FROM VW WHERE Id IN (SELECT 1 / z FROM S) AND Id < 0",
+        fails: .divide)
+  }
+
+  @Test func `a quantified conjunct is not seeked past a skipped row`()
+      throws {
+    // The quantified `= ANY (Q)` variant: `Id = ANY (SELECT 1 / z FROM S)`
+    // faults on the first reach. Pre-fix the `.quantified` term was `safe` and
+    // rode below the empty `Id < 0` seek, suppressing the throw; post-fix the
+    // run faults `.divide`.
+    try fixture().expect(
+        "SELECT Id FROM VW WHERE Id = ANY (SELECT 1 / z FROM S) AND Id < 0",
+        fails: .divide)
+  }
+
+  @Test func `an EXISTS still drops rows behind a short-circuiting filter`()
+      throws {
+    // The safety change does NOT over-fault: with the SEEKABLE `Id < 0` the
+    // LEFT conjunct, the non-short-circuiting `AND`'s Kleene evaluation returns
+    // FALSE from the leading `Id < 0` for every row without reaching the
+    // subquery, so the run yields zero rows rather than faulting — the subquery
+    // stays genuinely unreached.
+    try fixture().empty(
+        """
+        SELECT Id FROM VW \
+        WHERE Id < 0 AND EXISTS (SELECT 1 FROM S WHERE 1 / z = 0)
+        """)
+  }
+}
+
+// MARK: - Correlated subquery own derived tables
+
+/// A CORRELATED subquery with its OWN `WITH` item or derived table must AUGMENT
+/// that own relation before executing its precompiled plan per outer row — the
+/// same augmentation the uncorrelated `run`/`probe` paths perform — so the
+/// derived/CTE relation binds during per-outer-row execution rather than
+/// faulting `SQLError.relation` (or resolving to an unintended base relation).
+struct CorrelatedOwnDerivationTests {
+  /// An outer `T(Id)` alone — the correlated subqueries below carry their OWN
+  /// inner derivation.
+  private func fixture() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["Id": .integer]) {
+        Row(1)
+        Row(2)
+        Row(3)
+      }
+    }
+  }
+
+  @Test func `a correlated EXISTS binds its own derived table`() throws {
+    // Pre-fix: the correlated `execute(plan, context)` ran the precompiled plan
+    // under only the parent overlay, so the plan's `.scan("d")` for the derived
+    // table `(SELECT 1 AS k) AS d` faulted `SQLError.relation("d")`. Post-fix
+    // the execute path augments the subquery's own derived rows first, binding
+    // `d`. The self-contained `d.k` is 1, correlated `= T.Id` in the subquery's
+    // WHERE, so the EXISTS is TRUE only for the outer row `Id = 1`.
+    try fixture().expect(
+        """
+        SELECT Id FROM T \
+        WHERE EXISTS (SELECT 1 FROM (SELECT 1 AS k) AS d WHERE d.k = T.Id)
+        """,
+        yields: [[1]])
+  }
+
+  @Test func `a correlated scalar subquery binds its own derived table`()
+      throws {
+    // The scalar variant: `(SELECT d.k FROM (SELECT 1 AS k) AS d WHERE d.k =
+    // T.Id)` derives `d.k` (a self-contained 1) and correlates it `= T.Id` per
+    // outer row, collapsing to 1 for `Id = 1` and NULL (no matching row) for
+    // the rest. Pre-fix it faulted `.relation("d")`; post-fix `d` binds a row.
+    try fixture().expect(
+        """
+        SELECT (SELECT d.k FROM (SELECT 1 AS k) AS d WHERE d.k = T.Id) \
+        FROM T
+        """,
+        yields: [[1], [nil], [nil]])
+  }
+
+  @Test func `a correlated IN binds its own derived table`() throws {
+    // The `IN (Q)` variant: `Id IN (SELECT d.k FROM (SELECT 1 AS k) AS d WHERE
+    // d.k = T.Id)` — the correlated subquery yields its self-contained `d.k`
+    // (1) only when `d.k = T.Id`, so it is TRUE for `Id = 1` alone. Pre-fix the
+    // per-row execute faulted `.relation("d")`; post-fix `d` binds each row.
+    try fixture().expect(
+        """
+        SELECT Id FROM T \
+        WHERE Id IN (SELECT d.k FROM (SELECT 1 AS k) AS d WHERE d.k = T.Id)
+        """,
+        yields: [[1]])
+  }
+
+  @Test func `a correlated EXISTS setop binds each arm's derived table`()
+      throws {
+    // The SET-OPERATION shape: the correlated `EXISTS` subquery is a `UNION
+    // ALL` whose LEFT arm derives its own `d` and correlates it `d.k = T.Id`,
+    // and whose RIGHT arm is a bare `SELECT 2`. Pre-fix the correlated
+    // augment-and-execute augmented at the QUERY level, binding no arm-local
+    // `d`, so the left arm's `.scan("d")` faulted `.relation("d")`; post-fix
+    // it augments EACH ARM, so `d` binds per outer row. The right arm always
+    // yields a row, so the EXISTS is TRUE for every outer row.
+    try fixture().expect(
+        """
+        SELECT Id FROM T WHERE EXISTS ( \
+        SELECT k FROM (SELECT 1 AS k) AS d WHERE d.k = T.Id \
+        UNION ALL SELECT 2)
+        """,
+        yields: [[1], [2], [3]])
+  }
+
+  @Test func `a correlated IN setop keeps only the row its arm derives`()
+      throws {
+    // A DISCRIMINATING setop: `Id IN (SELECT d.k … WHERE d.k = T.Id UNION ALL
+    // SELECT 9)`. The right arm contributes the constant 9 (never an `Id`), so
+    // the membership turns ONLY on the left arm's per-row correlated
+    // derivation — `d.k` (1) is in the column iff `T.Id = 1`. So only the outer
+    // row `Id = 1` is kept, proving each arm augments its OWN `d` under the
+    // per-row correlation rather than merely not faulting.
+    try fixture().expect(
+        """
+        SELECT Id FROM T WHERE Id IN ( \
+        SELECT d.k FROM (SELECT 1 AS k) AS d WHERE d.k = T.Id \
+        UNION ALL SELECT 9)
+        """,
+        yields: [[1]])
+  }
+}
+
 // MARK: - HAVING subquery reachability
 
 /// A whole-result aggregate under a statically-false `WHERE` emits one empty
@@ -1651,5 +1860,118 @@ struct FromlessScalarReservedRelationTests {
         + "THEN 1 ELSE 0 END")
     let columns = try fixture().columns(of: query, validate: true)
     #expect(columns.count == 1)
+  }
+}
+
+// MARK: - Per-occurrence correlated plan cache
+
+/// Two outer relations whose correlated key `k` sits at DIFFERENT ordinals —
+/// `Outer1.k` at ordinal 0, `Outer2.k` at ordinal 1 — and one inner source
+/// `Src`, so the SAME scalar subquery SQL `(SELECT m FROM Src WHERE m = k)` in
+/// each arm of a `UNION ALL` compiles under a DIFFERENT outer layout: the left
+/// arm binds `:__correlated_0_0`, the right `:__correlated_0_1`.
+private func layouts() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("Outer1", ["k": .integer, "a": .integer]) {
+      Row(1, 100)
+      Row(2, 200)
+    }
+    Relation("Outer2", ["b": .integer, "k": .integer]) {
+      Row(300, 3)
+      Row(400, 4)
+    }
+    Relation("Src", ["m": .integer]) {
+      Row(1)
+      Row(2)
+      Row(3)
+      Row(4)
+    }
+  }
+}
+
+/// Batch 7, Item 2: identical CORRELATED inner SQL in two set-operation arms
+/// under DIFFERENT outer layouts must each execute the plan keyed to ITS OWN
+/// correlation. Keying the plan cache by the occurrence `Subkey` alone
+/// (scope + query + role) collapses the two arms — same `.caller` scope, same
+/// AST, same `.scalar` role — so the right arm read the LEFT arm's plan (which
+/// binds `:__correlated_0_0`) while its own row binds `:__correlated_0_1`,
+/// yielding NULL. The `PlanKey` composes the correlation's parameter names into
+/// the cache identity, so each arm finds its own plan.
+struct CorrelatedPlanOccurrenceTests {
+  @Test func `identical correlated SQL in two UNION ALL arms binds each`()
+      throws {
+    // `Outer1.k` at ordinal 0 → `:__correlated_0_0`; `Outer2.k` at ordinal 1 →
+    // `:__correlated_0_1`. The scalar `(SELECT m FROM Src WHERE m = k)` returns
+    // its lone matching `m` per outer row: the left arm over `k` {1, 2} yields
+    // 1, 2; the right arm over `k` {3, 4} yields 3, 4. Pre-fix the right arm
+    // read the left arm's plan and yielded NULL, NULL.
+    try layouts().expect(
+        """
+        SELECT (SELECT m FROM Src WHERE m = k) FROM Outer1 \
+        UNION ALL SELECT (SELECT m FROM Src WHERE m = k) FROM Outer2
+        """,
+        yields: [[1], [2], [3], [4]])
+  }
+}
+
+/// A join `ON` in a correlated subquery whose equality references an ENCLOSING
+/// column: an outer `T`, and a subquery joining `U` and `V` whose `ON`
+/// correlates `V.x` to the outer `T.Id`.
+///
+/// `V.x` matches `T.Id` ∈ {1, 2}; `U` is a single row, so the correlated
+/// `EXISTS (SELECT 1 FROM U JOIN V ON V.x = T.Id)` is TRUE exactly for those
+/// outer rows. The uncorrelated parity `ON V.x = U.y` is a genuine
+/// column = column equi-join key (`U.y` = 2 matches `V.x` = 2), so it is STILL
+/// extracted as the hash-join match key and the join runs.
+private func joined() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["Id": .integer]) {
+      Row(1)
+      Row(2)
+      Row(3)
+      Row(4)
+    }
+    Relation("U", ["y": .integer]) {
+      Row(2)
+    }
+    Relation("V", ["x": .integer]) {
+      Row(1)
+      Row(2)
+    }
+  }
+}
+
+struct CorrelatedJoinOnTests {
+  @Test func `a correlated join ON stays the residual filter`() throws {
+    // `ON V.x = T.Id` lowers to `compare(.slot, .equal, .parameter)` — a
+    // CORRELATED equality against the outer `T.Id`, not a column = column key.
+    // Reading the key off the lowered term leaves it the residual `ON` filter,
+    // evaluated per outer `T` row (`V.x = :outer_Id`). Pre-fix the fast path
+    // re-resolved the ORIGINAL AST via `match(V.x, T.Id)`, which consults ONLY
+    // the join prefix (`U`, `V`) and faulted `SQLError.column("Id")` on the
+    // already-lowered outer column. `V.x` ∈ {1, 2} matches `T.Id` ∈ {1, 2}.
+    try joined().expect(
+        "SELECT Id FROM T WHERE EXISTS (SELECT 1 FROM U JOIN V ON V.x = T.Id)",
+        yields: [[1], [2]])
+  }
+
+  @Test func `columns validates a correlated join ON`() throws {
+    // The schema path must accept exactly what the run does — no prefix-only
+    // re-resolution fault on the correlated outer column.
+    let query = try parse(query:
+        "SELECT Id FROM T WHERE EXISTS (SELECT 1 FROM U JOIN V ON V.x = T.Id)")
+    let columns = try joined().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+  }
+
+  @Test func `an uncorrelated join ON still extracts its equi key`() throws {
+    // PARITY: `ON V.x = U.y` is a genuine column = column equality lowering to
+    // `compare(.slot, .equal, .slot)`, so it is STILL extracted as the
+    // hash-join match key (see `EngineNonEquiJoinTests` for the plan-shape
+    // guard). `U.y` = 2 matches `V.x` = 2, so the join is non-empty and the
+    // UNCORRELATED `EXISTS` is TRUE for EVERY outer `T` row.
+    try joined().expect(
+        "SELECT Id FROM T WHERE EXISTS (SELECT 1 FROM U JOIN V ON V.x = U.y)",
+        yields: [[1], [2], [3], [4]])
   }
 }


### PR DESCRIPTION
Implement a minimal (approach-b) correlation: an inner-WHERE column a subquery does not bind locally is a correlated reference to the enclosing query, lowered to a synthetic bound parameter and re-executed per outer row via the extended `Context.bindings`. A correlated occurrence bypasses the materialise-once cache, since its result depends on the bound outer row.

A correlated column on a BARRED surface — a projection, a `GROUP BY`, or a `HAVING`, all outside the minimal cut — is diagnosed `SQLError.unsupported("a correlated column is only supported in a subquery's WHERE")` at BOTH the validate (schema) and the run (lowering) paths rather than mis-resolved, so type-check and run agree. Lowering a bare-column projection through `term` (not a direct ordinal resolve) threads the barred surface to the run path so that parity holds.

This also folds in lazy `IN`/`EXISTS` evaluation.

Correlated projection/`HAVING` generalisation, `LATERAL`, and decorrelation are non-goals: this is an honest O(outer × inner) first cut.