### PR TITLE
WinMD: decode CustomAttrib blobs per ECMA-335 §II.23.3

### DIFF
--- a/Sources/WinMD/Attribute.swift
+++ b/Sources/WinMD/Attribute.swift
@@ -4,25 +4,100 @@
 import struct Foundation.UUID
 import typealias Foundation.uuid_t
 
+// MARK: - Value model
+
+/// A decoded custom-attribute argument value (ECMA-335 §II.23.3).
+///
+/// A `CustomAttrib` blob carries the constructor's fixed arguments and any
+/// named field/property arguments as serialised leaves. This is the decoded
+/// leaf: the scalar element types the grammar spells (`bool`, `char`, the
+/// integers, `r4`/`r8`, a `SerString`), a `System.Type` name kept distinct from
+/// a plain string, and an enumeration carrying its type name and underlying
+/// integer.
+///
+/// The per-width integer cases windows-rs keeps (`I1`, `U2`, …) collapse to a
+/// single `integer(Int64)` because this only reads metadata; a `u8` that must
+/// stay unsigned takes the distinct `unsigned` case so the model is lossless.
+/// `enumeration` carries its underlying integer as a nested `AttributeValue` so
+/// it inherits that same signedness — a `u8`-backed enum stays `unsigned`, a
+/// signed enum stays `integer` — rather than folding through a lossy `Int64`.
+/// `array` reserves the `SZARRAY` shape whose producer is deferred; `null` is a
+/// null `SerString` or null array.
+public indirect enum AttributeValue: Sendable, Hashable {
+  case boolean(Bool)
+  case integer(Int64)
+  case unsigned(UInt64)
+  case real(Double)
+  case string(String)
+  case type(String)
+  case enumeration(name: String, value: AttributeValue)
+  case array(Array<AttributeValue>)
+  case null
+}
+
+/// Which member a `NamedArg` assigns (ECMA-335 §II.23.3): the `FIELD`
+/// (`0x53`) or `PROPERTY` (`0x54`) byte that leads a `NamedArg`. It is the
+/// only disambiguator when an attribute class declares both a field and a
+/// property of the same name, so `named()` carries it beside the name and
+/// value.
+internal enum Member: Sendable, Hashable {
+  case field
+  case property
+}
+
+/// How a `CustomAttrib` blob names the enum type whose underlying integer a
+/// value carries (ECMA-335 §II.23.3).
+///
+/// A `FixedArg`'s enum comes from the constructor signature as a `TypeDefOrRef`
+/// coded index (`reference`); a `NamedArg`'s enum is spelled inline as a
+/// `SerString` type name after the `0x55` `ENUM` tag (`named`). Neither form
+/// encodes the underlying `CorElementType` — a decoder must resolve it from
+/// metadata — so this is the key an `underlying` resolver is handed.
+internal enum EnumType: Sendable {
+  case reference(TypeDefOrRef)
+  case named(String)
+}
+
 // MARK: - Decoding
 
 /// A cursor decoding a custom-attribute `Value` blob (ECMA-335 §II.23.3).
 ///
 /// A custom-attribute value opens with a `0x0001` prolog, then the
-/// constructor's fixed arguments serialised in declaration order, then any
-/// named arguments. This cursor reads the leaves the `[Guid(...)]` constructor
-/// needs — the fixed-size integers spelling a GUID — mirroring
-/// `SignatureDecoder`'s shape: it borrows the blob's bytes and advances a
-/// position, and is `~Escapable` because it holds a `RawSpan`. Only the GUID
-/// path is decoded today; the general §II.23.3 grammar can extend this later.
+/// constructor's fixed arguments serialised in declaration order, then a
+/// `NumNamed` count and that many named field/property arguments. This cursor
+/// mirrors `SignatureDecoder`'s shape — it borrows the blob's bytes, advances a
+/// position, and is `~Escapable` because it holds a `RawSpan` — and vends the
+/// §II.23.3 grammar's leaves:
+///
+/// - `string()` reads a `PackedLen`-prefixed UTF-8 string, with the `0xFF`
+///   null and `0x00` empty markers.
+/// - `fixed(_:)` decodes one `FixedArg` *given* its type from the constructor
+///   signature — a `FixedArg` carries no leading type tag.
+/// - `named()` reads a self-describing `NamedArg`: the `FIELD`/`PROPERTY` byte,
+///   the field-or-property type, the name, then the value.
+///
+/// The `guid()` fast path stays: a `GuidAttribute`'s fixed-arg shape
+/// (`u32, u16, u16, u8×8`) is a compile-time constant needing no signature.
 internal struct AttributeDecoder: ~Escapable {
   private let bytes: RawSpan
   private var position: Int
 
+  /// Resolves an enum type to the `CorElementType` of its underlying integer.
+  ///
+  /// A `CustomAttrib` blob names an enum but never its underlying element type
+  /// (ECMA-335 §II.23.3), so a value carried as an enum must be read at the
+  /// width and signedness of that underlying integer — resolved from metadata,
+  /// not assumed to be `I4`. This closure performs that lookup; `nil` means the
+  /// enum type could not be resolved, which the caller treats as malformed.
+  private let underlying: (EnumType) -> CorElementType?
+
   @_lifetime(copy bytes)
-  internal init(_ bytes: RawSpan) {
+  internal init(_ bytes: RawSpan,
+                underlying: @escaping (EnumType) -> CorElementType? =
+                    { _ in nil }) {
     self.bytes = bytes
     self.position = 0
+    self.underlying = underlying
   }
 
   /// Reads a little-endian fixed-width value and advances past it.
@@ -35,9 +110,211 @@ internal struct AttributeDecoder: ~Escapable {
     return value
   }
 
+  /// Reads the next raw byte and advances past it.
+  private mutating func byte() throws(WinMDError) -> UInt8 {
+    try read(as: UInt8.self)
+  }
+
   /// Reads the fixed `0x0001` prolog and advances past it.
-  private mutating func prolog() throws(WinMDError) {
+  internal mutating func prolog() throws(WinMDError) {
     guard try read(as: UInt16.self) == 0x0001 else { throw .BadImageFormat }
+  }
+
+  /// Reads a `PackedLen` (compressed unsigned integer) and advances past it
+  /// (ECMA-335 §II.23.2).
+  ///
+  /// The lead byte selects the encoding: `0x00..0x7f` is 1 byte, `0x80..0xbf`
+  /// 2 bytes, `0xc0..0xdf` 4 bytes; `0xe0` and above is not a defined encoding.
+  /// A well-formed encoding must fit within the blob. This mirrors
+  /// `SignatureDecoder.width`/`compressed`, guarding the shared
+  /// `RawSpan.compressed` against a malformed lead byte or an over-read.
+  private mutating func length() throws(WinMDError) -> Int {
+    guard position < bytes.byteCount else { throw .BadImageFormat }
+    let lead = bytes.read(at: position, as: UInt8.self)
+    let width = switch lead {
+    case 0x00 ... 0x7f: 1
+    case 0x80 ... 0xbf: 2
+    case 0xc0 ... 0xdf: 4
+    default:            throw .BadImageFormat
+    }
+    guard position + width <= bytes.byteCount else { throw .BadImageFormat }
+    let (begin, value) = bytes.compressed(at: position)
+    position = begin
+    return value
+  }
+
+  /// Reads a `SerString` and advances past it (ECMA-335 §II.23.3).
+  ///
+  /// A `SerString` is a single `0xFF` byte for a null string, or a `PackedLen`
+  /// byte count followed by that many UTF-8 bytes (a count of zero is the empty
+  /// string). Returns `nil` for the `0xFF` null marker.
+  ///
+  /// The bytes are decoded with a *validating* UTF-8 pass: an invalid byte
+  /// sequence is malformed metadata and throws, rather than silently
+  /// substituting U+FFFD replacement characters and accepting a corrupted
+  /// name or value.
+  internal mutating func string() throws(WinMDError) -> String? {
+    guard position < bytes.byteCount else { throw .BadImageFormat }
+    guard bytes.read(at: position, as: UInt8.self) != 0xff else {
+      position = position + 1
+      return nil
+    }
+    let count = try length()
+    guard position + count <= bytes.byteCount else { throw .BadImageFormat }
+    let span = bytes.extracting(position ..< position + count)
+    guard let value = String(validating: span, as: UTF8.self) else {
+      throw .BadImageFormat
+    }
+    position = position + count
+    return value
+  }
+
+  /// Decodes one `FixedArg` given its type from the constructor signature
+  /// (ECMA-335 §II.23.3).
+  ///
+  /// A `FixedArg` carries no leading type tag, so the type drives the read: a
+  /// primitive maps to the matching fixed-width read, `STRING` to a
+  /// `SerString`, a named reference type to a `System.Type` name (a
+  /// `SerString`), and a named value type (an enum) to its underlying integer
+  /// — read at the width and signedness the enum's underlying `CorElementType`
+  /// resolves to, not a hardcoded `I4`. `SZARRAY` is deferred and throws.
+  internal mutating func fixed(_ type: SignatureType)
+      throws(WinMDError) -> AttributeValue {
+    switch type {
+    case .primitive(.boolean):
+      switch try read(as: UInt8.self) {
+      case 0: return .boolean(false)
+      case 1: return .boolean(true)
+      default: throw .BadImageFormat
+      }
+    case .primitive(.char):
+      return .integer(Int64(try read(as: UInt16.self)))
+    case .primitive(.int1):
+      return .integer(Int64(try read(as: Int8.self)))
+    case .primitive(.uint1):
+      return .integer(Int64(try read(as: UInt8.self)))
+    case .primitive(.int2):
+      return .integer(Int64(try read(as: Int16.self)))
+    case .primitive(.uint2):
+      return .integer(Int64(try read(as: UInt16.self)))
+    case .primitive(.int4):
+      return .integer(Int64(try read(as: Int32.self)))
+    case .primitive(.uint4):
+      return .integer(Int64(try read(as: UInt32.self)))
+    case .primitive(.int8):
+      return .integer(try read(as: Int64.self))
+    case .primitive(.uint8):
+      return .unsigned(try read(as: UInt64.self))
+    case .primitive(.float):
+      return .real(Double(try read(as: Float32.self)))
+    case .primitive(.double):
+      return .real(try read(as: Float64.self))
+    case .primitive(.string):
+      guard let value = try string() else { return .null }
+      return .string(value)
+    case .named(kind: .class, _):
+      guard let value = try string() else { return .null }
+      return .type(value)
+    case let .named(kind: .value, reference):
+      return try integer(of: .reference(reference))
+    default:
+      throw .BadImageFormat
+    }
+  }
+
+  /// Reads an enum value at its underlying integer width and signedness
+  /// (ECMA-335 §II.23.3).
+  ///
+  /// The blob names the enum type but not its underlying `CorElementType`, so
+  /// `underlying` resolves it from metadata: a `U4`-backed (flags) enum reads
+  /// four *unsigned* bytes — a value at or above `0x80000000` stays positive
+  /// rather than decoding negative under an `I4` read — and a narrower or wider
+  /// enum consumes exactly its own width. An enum type that cannot be resolved,
+  /// or one whose underlying type is not an integer, is malformed.
+  private mutating func integer(of enumeration: EnumType)
+      throws(WinMDError) -> AttributeValue {
+    guard let element = underlying(enumeration),
+        let primitive = integral(element) else { throw .BadImageFormat }
+    return try fixed(.primitive(primitive))
+  }
+
+  /// The `PrimitiveType` an integer `CorElementType` names, or `nil` for a
+  /// non-integer element type. An enum's underlying type must be one of the
+  /// integral primitives (`bool`/`char`/`i1`..`u8`); anything else is invalid.
+  private func integral(_ element: CorElementType) -> PrimitiveType? {
+    switch element {
+    case .etBoolean: .boolean
+    case .etChar:    .char
+    case .etInt1:    .int1
+    case .etUInt1:   .uint1
+    case .etInt2:    .int2
+    case .etUInt2:   .uint2
+    case .etInt4:    .int4
+    case .etUInt4:   .uint4
+    case .etInt8:    .int8
+    case .etUInt8:   .uint8
+    default:         nil
+    }
+  }
+
+  /// Decodes one `NamedArg` and advances past it (ECMA-335 §II.23.3).
+  ///
+  /// A `NamedArg` is a `FIELD` (`0x53`) or `PROPERTY` (`0x54`) byte, a
+  /// self-describing `FieldOrPropType` byte, the `SerString` name, then the
+  /// value. The type is read before the name but drives the value read after
+  /// it: a bare element-type byte selects a primitive or string; `0x50` a
+  /// `System.Type` name (a `SerString`); `0x55` an enum, spelled as a
+  /// `SerString` type name then its underlying integer. `0x51` (boxed) and
+  /// `0x1d` (`SZARRAY`) are deferred and throw.
+  ///
+  /// The `FIELD`/`PROPERTY` byte is returned as the `Member` kind: it is the
+  /// only disambiguator when a class declares both a field and a property of
+  /// the same name, so a caller must know which member to assign.
+  internal mutating func named() throws(WinMDError)
+      -> (member: Member, name: String, value: AttributeValue) {
+    let lead = try byte()
+    let member: Member = switch lead {
+    case 0x53: .field
+    case 0x54: .property
+    default:   throw .BadImageFormat
+    }
+
+    let element = CorElementType(rawValue: try byte())
+    let primitive: PrimitiveType? = switch element {
+    case .etBoolean: .boolean
+    case .etChar:    .char
+    case .etInt1:    .int1
+    case .etUInt1:   .uint1
+    case .etInt2:    .int2
+    case .etUInt2:   .uint2
+    case .etInt4:    .int4
+    case .etUInt4:   .uint4
+    case .etInt8:    .int8
+    case .etUInt8:   .uint8
+    case .etFloat:   .float
+    case .etDouble:  .double
+    case .etString:  .string
+    default:         nil
+    }
+
+    if let primitive {
+      guard let name = try string() else { throw .BadImageFormat }
+      return (member, name, try fixed(.primitive(primitive)))
+    }
+
+    switch element.rawValue {
+    case 0x50:       // TYPE (System.Type)
+      guard let name = try string() else { throw .BadImageFormat }
+      guard let value = try string() else { return (member, name, .null) }
+      return (member, name, .type(value))
+    case 0x55:       // ENUM
+      guard let type = try string() else { throw .BadImageFormat }
+      guard let name = try string() else { throw .BadImageFormat }
+      let value = try integer(of: .named(type))
+      return (member, name, .enumeration(name: type, value: value))
+    default:
+      throw .BadImageFormat
+    }
   }
 
   /// Decodes a `GuidAttribute` value: the prolog, then the GUID as the

--- a/Sources/WinMD/Extensions/String+Extensions.swift
+++ b/Sources/WinMD/Extensions/String+Extensions.swift
@@ -7,4 +7,17 @@ extension String {
       where Encoding.CodeUnit == UInt8 {
     self = span.withUnsafeBytes { String(decoding: $0, as: encoding) }
   }
+
+  /// Decodes a borrowed byte span as a string in the given encoding, failing
+  /// on any invalid code-unit sequence rather than substituting the U+FFFD
+  /// replacement character.
+  init?<Encoding: Unicode.Encoding>(validating span: RawSpan,
+                                    as encoding: Encoding.Type)
+      where Encoding.CodeUnit == UInt8 {
+    let value = span.withUnsafeBytes {
+      String(validating: $0, as: encoding)
+    }
+    guard let value else { return nil }
+    self = value
+  }
 }

--- a/Tests/WinMDTests/AttributeTests.swift
+++ b/Tests/WinMDTests/AttributeTests.swift
@@ -112,4 +112,376 @@ struct AttributeTests {
       _ = try decoder.guid()
     }
   }
+
+  // A `FixedArg` carries no leading type tag (ECMA-335 §II.23.3), so each is
+  // decoded by handing `fixed(_:)` the type the constructor signature would
+  // supply. The fixtures are the raw serialised leaf bytes.
+  @Test func `decodes a boolean FixedArg`() throws {
+    var atrue = AttributeDecoder(([0x01] as Array<UInt8>).span.bytes)
+    #expect(try atrue.fixed(.primitive(.boolean)) == .boolean(true))
+    var afalse = AttributeDecoder(([0x00] as Array<UInt8>).span.bytes)
+    #expect(try afalse.fixed(.primitive(.boolean)) == .boolean(false))
+  }
+
+  @Test func `rejects a boolean FixedArg byte outside 0 and 1`() {
+    // ECMA-335 §II.23.3 encodes a bool as a single byte that must be 0 or 1;
+    // any other value is malformed.
+    var decoder = AttributeDecoder(([0x02] as Array<UInt8>).span.bytes)
+    #expect(throws: WinMDError.BadImageFormat) {
+      _ = try decoder.fixed(.primitive(.boolean))
+    }
+  }
+
+  @Test func `rejects a named boolean whose byte is outside 0 and 1`() {
+    // The named path routes a bool value through `fixed`, so the same guard
+    // must fault a malformed byte. FIELD (0x53), BOOLEAN (0x02), name "B".
+    let bytes: Array<UInt8> = [
+      0x53,                                            // FIELD
+      0x02,                                            // BOOLEAN type
+      0x01, 0x42,                                      // name "B"
+      0x02,                                            // value 2 (malformed)
+    ]
+    var decoder = AttributeDecoder(bytes.span.bytes)
+    #expect(throws: WinMDError.BadImageFormat) {
+      _ = try decoder.named()
+    }
+  }
+
+  @Test func `decodes a char FixedArg`() throws {
+    let bytes: Array<UInt8> = [0x41, 0x00]              // U+0041 'A', LE u16
+    var decoder = AttributeDecoder(bytes.span.bytes)
+    #expect(try decoder.fixed(.primitive(.char)) == .integer(0x41))
+  }
+
+  @Test func `decodes the signed integer FixedArgs`() throws {
+    let i1: Array<UInt8> = [0xff]                       // -1
+    let i2: Array<UInt8> = [0x00, 0x80]                 // -32768
+    let i4: Array<UInt8> = [0xff, 0xff, 0xff, 0xff]     // -1
+    let i8: Array<UInt8> = [0xfe, 0xff, 0xff, 0xff,     // -2
+                            0xff, 0xff, 0xff, 0xff]
+    var d1 = AttributeDecoder(i1.span.bytes)
+    #expect(try d1.fixed(.primitive(.int1)) == .integer(-1))
+    var d2 = AttributeDecoder(i2.span.bytes)
+    #expect(try d2.fixed(.primitive(.int2)) == .integer(-32768))
+    var d4 = AttributeDecoder(i4.span.bytes)
+    #expect(try d4.fixed(.primitive(.int4)) == .integer(-1))
+    var d8 = AttributeDecoder(i8.span.bytes)
+    #expect(try d8.fixed(.primitive(.int8)) == .integer(-2))
+  }
+
+  @Test func `decodes the unsigned integer FixedArgs`() throws {
+    let u1: Array<UInt8> = [0xff]                       // 255
+    let u2: Array<UInt8> = [0xff, 0xff]                 // 65535
+    let u4: Array<UInt8> = [0xff, 0xff, 0xff, 0xff]     // 4294967295
+    let u8: Array<UInt8> = [0xff, 0xff, 0xff, 0xff,     // UInt64.max
+                            0xff, 0xff, 0xff, 0xff]
+    var d1 = AttributeDecoder(u1.span.bytes)
+    #expect(try d1.fixed(.primitive(.uint1)) == .integer(255))
+    var d2 = AttributeDecoder(u2.span.bytes)
+    #expect(try d2.fixed(.primitive(.uint2)) == .integer(65535))
+    var d4 = AttributeDecoder(u4.span.bytes)
+    #expect(try d4.fixed(.primitive(.uint4)) == .integer(4294967295))
+    var d8 = AttributeDecoder(u8.span.bytes)
+    #expect(try d8.fixed(.primitive(.uint8)) == .unsigned(.max))
+  }
+
+  @Test func `decodes the floating-point FixedArgs`() throws {
+    let r4: Array<UInt8> = [0x00, 0x00, 0x80, 0x3f]     // 1.0 (r4)
+    let r8: Array<UInt8> = [0x00, 0x00, 0x00, 0x00,     // 2.0 (r8)
+                            0x00, 0x00, 0x00, 0x40]
+    var d4 = AttributeDecoder(r4.span.bytes)
+    #expect(try d4.fixed(.primitive(.float)) == .real(1.0))
+    var d8 = AttributeDecoder(r8.span.bytes)
+    #expect(try d8.fixed(.primitive(.double)) == .real(2.0))
+  }
+
+  @Test func `decodes a string FixedArg`() throws {
+    let bytes: Array<UInt8> = [0x03, 0x66, 0x6f, 0x6f]  // len 3, "foo"
+    var decoder = AttributeDecoder(bytes.span.bytes)
+    #expect(try decoder.fixed(.primitive(.string)) == .string("foo"))
+  }
+
+  @Test func `decodes a System.Type FixedArg as a type name`() throws {
+    // A named reference type in the constructor signature (System.Type) is
+    // serialised as a `SerString` naming the type.
+    let name = "System.Int32"
+    let bytes = [UInt8(name.utf8.count)] + Array(name.utf8)
+    var decoder = AttributeDecoder(bytes.span.bytes)
+    let reference = TypeDefOrRef(rawValue: 0)
+    #expect(try decoder.fixed(.named(kind: .class, reference))
+              == .type(name))
+  }
+
+  @Test func `decodes an i4-backed enum FixedArg`() throws {
+    // A named value type (an enum) is serialised as its underlying integer,
+    // read at the width the resolved underlying `CorElementType` names — here
+    // a signed i4.
+    let bytes: Array<UInt8> = [0xff, 0xff, 0xff, 0xff]  // -1 as i4
+    var decoder = AttributeDecoder(bytes.span.bytes) { _ in .etInt4 }
+    let reference = TypeDefOrRef(rawValue: 0)
+    #expect(try decoder.fixed(.named(kind: .value, reference))
+              == .integer(-1))
+  }
+
+  @Test func `decodes a u4-backed enum FixedArg unsigned`() throws {
+    // A flags enum is commonly backed by u4; a value at or above 0x80000000
+    // must stay positive, not decode negative under an i4 read.
+    let bytes: Array<UInt8> = [0x00, 0x00, 0x00, 0x80]  // 0x80000000
+    var decoder = AttributeDecoder(bytes.span.bytes) { _ in .etUInt4 }
+    let reference = TypeDefOrRef(rawValue: 0)
+    #expect(try decoder.fixed(.named(kind: .value, reference))
+              == .integer(0x8000_0000))
+  }
+
+  @Test func `decodes a narrower u1-backed enum FixedArg`() throws {
+    // A byte-backed enum consumes exactly one byte, not four.
+    let bytes: Array<UInt8> = [0xff, 0xaa, 0xaa, 0xaa]  // only the first byte
+    var decoder = AttributeDecoder(bytes.span.bytes) { _ in .etUInt1 }
+    let reference = TypeDefOrRef(rawValue: 0)
+    #expect(try decoder.fixed(.named(kind: .value, reference))
+              == .integer(255))
+  }
+
+  @Test func `rejects an enum FixedArg whose type cannot resolve`() {
+    // With no resolvable underlying type the read cannot proceed; guessing i4
+    // would silently mis-decode, so this is malformed.
+    let bytes: Array<UInt8> = [0x02, 0x00, 0x00, 0x00]
+    var decoder = AttributeDecoder(bytes.span.bytes)
+    let reference = TypeDefOrRef(rawValue: 0)
+    #expect(throws: WinMDError.BadImageFormat) {
+      _ = try decoder.fixed(.named(kind: .value, reference))
+    }
+  }
+
+  @Test func `defers a SZARRAY FixedArg`() {
+    let bytes: Array<UInt8> = [0x00, 0x00, 0x00, 0x00]
+    var decoder = AttributeDecoder(bytes.span.bytes)
+    #expect(throws: WinMDError.BadImageFormat) {
+      _ = try decoder.fixed(.array(.primitive(.int4)))
+    }
+  }
+
+  @Test func `reads a SerString`() throws {
+    let bytes: Array<UInt8> = [0x03, 0x62, 0x61, 0x72]  // len 3, "bar"
+    var decoder = AttributeDecoder(bytes.span.bytes)
+    #expect(try decoder.string() == "bar")
+  }
+
+  @Test func `reads a null SerString as nil`() throws {
+    let bytes: Array<UInt8> = [0xff]                    // null marker
+    var decoder = AttributeDecoder(bytes.span.bytes)
+    #expect(try decoder.string() == nil)
+  }
+
+  @Test func `reads an empty SerString`() throws {
+    let bytes: Array<UInt8> = [0x00]                    // len 0
+    var decoder = AttributeDecoder(bytes.span.bytes)
+    #expect(try decoder.string() == "")
+  }
+
+  @Test func `reads a multi-byte UTF-8 SerString`() throws {
+    // "é€" — a two-byte and a three-byte sequence — decodes exactly, with no
+    // replacement characters.
+    let text = "é€"
+    let bytes = [UInt8(text.utf8.count)] + Array(text.utf8)
+    var decoder = AttributeDecoder(bytes.span.bytes)
+    #expect(try decoder.string() == text)
+  }
+
+  @Test func `rejects a SerString with invalid UTF-8`() {
+    // A lone 0x80 continuation byte is invalid UTF-8; a validating decode
+    // rejects it rather than substituting a U+FFFD replacement character.
+    let bytes: Array<UInt8> = [0x02, 0x80, 0x41]        // len 2, bad bytes
+    var decoder = AttributeDecoder(bytes.span.bytes)
+    #expect(throws: WinMDError.BadImageFormat) {
+      _ = try decoder.string()
+    }
+  }
+
+  @Test func `decodes a named field argument`() throws {
+    // FIELD (0x53), STRING (0x0e), name "Doc", value "hi".
+    let bytes: Array<UInt8> = [
+      0x53,                                            // FIELD
+      0x0e,                                            // STRING type
+      0x03, 0x44, 0x6f, 0x63,                          // name "Doc"
+      0x02, 0x68, 0x69,                                // value "hi"
+    ]
+    var decoder = AttributeDecoder(bytes.span.bytes)
+    let (member, name, value) = try decoder.named()
+    #expect(member == .field)
+    #expect(name == "Doc")
+    #expect(value == .string("hi"))
+  }
+
+  @Test func `decodes a named property argument`() throws {
+    // PROPERTY (0x54), I4 (0x08), name "Count", value 7.
+    let bytes: Array<UInt8> = [
+      0x54,                                            // PROPERTY
+      0x08,                                            // I4 type
+      0x05, 0x43, 0x6f, 0x75, 0x6e, 0x74,              // name "Count"
+      0x07, 0x00, 0x00, 0x00,                          // value 7
+    ]
+    var decoder = AttributeDecoder(bytes.span.bytes)
+    let (member, name, value) = try decoder.named()
+    #expect(member == .property)
+    #expect(name == "Count")
+    #expect(value == .integer(7))
+  }
+
+  @Test func `decodes a named enum argument carrying its type name`() throws {
+    // FIELD (0x53), ENUM (0x55), enum type "E", name "Kind", value 3.
+    let bytes: Array<UInt8> = [
+      0x53,                                            // FIELD
+      0x55,                                            // ENUM type
+      0x01, 0x45,                                      // enum type "E"
+      0x04, 0x4b, 0x69, 0x6e, 0x64,                    // name "Kind"
+      0x03, 0x00, 0x00, 0x00,                          // value 3 (i4)
+    ]
+    var decoder = AttributeDecoder(bytes.span.bytes) { _ in .etInt4 }
+    let (member, name, value) = try decoder.named()
+    #expect(member == .field)
+    #expect(name == "Kind")
+    // A signed underlying enum carries its value as a nested `.integer`.
+    #expect(value == .enumeration(name: "E", value: .integer(3)))
+  }
+
+  @Test func `decodes a named u4-backed flags enum unsigned`() throws {
+    // A u4-backed flags enum value at or above 0x80000000 must stay positive
+    // and consume four bytes, not decode negative under an i4 read. A `u4`
+    // still widens into a signed `.integer` (its bit-31 value fits `Int64`).
+    let bytes: Array<UInt8> = [
+      0x53,                                            // FIELD
+      0x55,                                            // ENUM type
+      0x01, 0x46,                                      // enum type "F"
+      0x04, 0x4b, 0x69, 0x6e, 0x64,                    // name "Kind"
+      0x00, 0x00, 0x00, 0x80,                          // value 0x80000000
+    ]
+    var decoder = AttributeDecoder(bytes.span.bytes) { _ in .etUInt4 }
+    let (member, name, value) = try decoder.named()
+    #expect(member == .field)
+    #expect(name == "Kind")
+    #expect(value == .enumeration(name: "F", value: .integer(0x8000_0000)))
+  }
+
+  @Test func `decodes a named u8-backed enum bit 63 set unsigned`() throws {
+    // The reviewer's case: a `u8`-backed enum value with bit 63 set must stay
+    // unsigned. It resolves through `integer(of:)` to a `.unsigned` leaf, which
+    // the named path now preserves inside `.enumeration` rather than funneling
+    // through `Int64` (which would surface -9223372036854775808).
+    let bytes: Array<UInt8> = [
+      0x53,                                            // FIELD
+      0x55,                                            // ENUM type
+      0x01, 0x47,                                      // enum type "G"
+      0x04, 0x4b, 0x69, 0x6e, 0x64,                    // name "Kind"
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80,  // 0x8000000000000000
+    ]
+    var decoder = AttributeDecoder(bytes.span.bytes) { _ in .etUInt8 }
+    let (member, name, value) = try decoder.named()
+    #expect(member == .field)
+    #expect(name == "Kind")
+    #expect(value == .enumeration(name: "G",
+                                  value: .unsigned(0x8000_0000_0000_0000)))
+  }
+
+  @Test func `matches the fixed-arg u8 enum representation`() throws {
+    // The fixed-arg path (already correct) and the named path now agree: both
+    // carry a `u8`-backed enum's value as a `.unsigned` leaf.
+    let bytes: Array<UInt8> = [
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80,  // 0x8000000000000000
+    ]
+    var decoder = AttributeDecoder(bytes.span.bytes) { _ in .etUInt8 }
+    let reference = TypeDefOrRef(rawValue: 0)
+    let fixed = try decoder.fixed(.named(kind: .value, reference))
+    #expect(fixed == .unsigned(0x8000_0000_0000_0000))
+
+    let named: Array<UInt8> = [
+      0x53,                                            // FIELD
+      0x55,                                            // ENUM type
+      0x01, 0x47,                                      // enum type "G"
+      0x04, 0x4b, 0x69, 0x6e, 0x64,                    // name "Kind"
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80,  // 0x8000000000000000
+    ]
+    var other = AttributeDecoder(named.span.bytes) { _ in .etUInt8 }
+    let (_, _, value) = try other.named()
+    #expect(value == .enumeration(name: "G", value: fixed))
+  }
+
+  @Test func `rejects a named enum whose type cannot resolve`() {
+    let bytes: Array<UInt8> = [
+      0x53,                                            // FIELD
+      0x55,                                            // ENUM type
+      0x01, 0x45,                                      // enum type "E"
+      0x04, 0x4b, 0x69, 0x6e, 0x64,                    // name "Kind"
+      0x03, 0x00, 0x00, 0x00,                          // value 3
+    ]
+    var decoder = AttributeDecoder(bytes.span.bytes)
+    #expect(throws: WinMDError.BadImageFormat) {
+      _ = try decoder.named()
+    }
+  }
+
+  @Test func `decodes a named System.Type argument`() throws {
+    // PROPERTY (0x54), TYPE (0x50), name "T", value "System.Object".
+    let type = "System.Object"
+    let bytes: Array<UInt8> = [
+      0x54,                                            // PROPERTY
+      0x50,                                            // TYPE
+      0x01, 0x54,                                      // name "T"
+    ] + [UInt8(type.utf8.count)] + Array(type.utf8)
+    var decoder = AttributeDecoder(bytes.span.bytes)
+    let (member, name, value) = try decoder.named()
+    #expect(member == .property)
+    #expect(name == "T")
+    #expect(value == .type(type))
+  }
+
+  @Test func `distinguishes a same-named field and property`() throws {
+    // A field "X" and a property "X" differ only by the leading FIELD/
+    // PROPERTY byte; both carry I4 (0x08) value 1.
+    let field: Array<UInt8> = [
+      0x53,                                            // FIELD
+      0x08,                                            // I4 type
+      0x01, 0x58,                                      // name "X"
+      0x01, 0x00, 0x00, 0x00,                          // value 1
+    ]
+    let property: Array<UInt8> = [
+      0x54,                                            // PROPERTY
+      0x08,                                            // I4 type
+      0x01, 0x58,                                      // name "X"
+      0x01, 0x00, 0x00, 0x00,                          // value 1
+    ]
+    var afield = AttributeDecoder(field.span.bytes)
+    var aproperty = AttributeDecoder(property.span.bytes)
+    let (fmember, fname, fvalue) = try afield.named()
+    let (pmember, pname, pvalue) = try aproperty.named()
+    #expect(fmember == .field)
+    #expect(pmember == .property)
+    #expect(fname == pname)
+    #expect(fvalue == pvalue)
+    #expect(fmember != pmember)
+  }
+
+  @Test func `rejects a named argument with a bad field-or-prop byte`() {
+    let bytes: Array<UInt8> = [0x00, 0x0e, 0x00]        // not FIELD/PROPERTY
+    var decoder = AttributeDecoder(bytes.span.bytes)
+    #expect(throws: WinMDError.BadImageFormat) {
+      _ = try decoder.named()
+    }
+  }
+
+  @Test func `rejects a SerString claiming more bytes than remain`() {
+    let bytes: Array<UInt8> = [0x08, 0x61, 0x62]        // len 8, only 2 bytes
+    var decoder = AttributeDecoder(bytes.span.bytes)
+    #expect(throws: WinMDError.BadImageFormat) {
+      _ = try decoder.string()
+    }
+  }
+
+  @Test func `rejects a FixedArg past the end of the blob`() {
+    let bytes: Array<UInt8> = [0x00]                    // one byte, need four
+    var decoder = AttributeDecoder(bytes.span.bytes)
+    #expect(throws: WinMDError.BadImageFormat) {
+      _ = try decoder.fixed(.primitive(.int4))
+    }
+  }
 }


### PR DESCRIPTION
Generalize the existing GUID-only AttributeDecoder into a full ECMA-335 §II.23.3 CustomAttrib grammar decoder, and add the AttributeValue model the decoded leaves inhabit.

The decoder gains serString() — a PackedLen-prefixed UTF-8 SerString with the 0xFF null and 0x00 empty markers; fixed(_:) — one FixedArg decoded given its constructor-signature type, since a FixedArg carries no leading type tag; and named() — a self-describing NamedArg (the FIELD/PROPERTY byte, the field-or-property type, the name, then the value). The 0x0001 prolog is validated and every read is length-guarded, rejecting malformed input with WinMDError rather than trapping or over-reading, matching the SignatureDecoder hardening. The GUID fast path is unchanged.

AttributeValue collapses the per-width windows-rs cases into a single integer/real, keeps type distinct from string and enumeration carrying its type name, and reserves array for the deferred SZARRAY producer. The handle-first element types are bool/char/i1..u8/r4/r8/string, System.Type names, and enums (as their underlying i4); SZARRAY and boxed are deferred.

The adapter/SQL exposure is a later stage; this is decoder + model only.