### PR TITLE
winmd-inspect: expose signature decoding as a SQL UDF

### DIFF
--- a/Sources/WinMD/Signature.swift
+++ b/Sources/WinMD/Signature.swift
@@ -474,6 +474,30 @@ internal struct SignatureDecoder: ~Escapable {
   }
 }
 
+// MARK: - Blob decoding
+
+/// The `MethodSignature` a raw method-signature `#Blob` payload decodes to
+/// (ECMA-335 §II.23.2.1).
+///
+/// This is the escapable, bytes → value form of `Row<MethodDef>.prototype`: a
+/// caller that has already copied a `MethodDef.Signature` `#Blob` out of the
+/// borrowed scan (the SQL adapter's `.blob` cell, whose payload is the
+/// length-prefix-stripped signature) decodes it here, without a `Row`. It
+/// mirrors `iid(decoding:)`, the analogous decode over a copied
+/// `CustomAttribute.Value` blob. `bytes` must be the WHOLE signature — the
+/// decode consumes every byte (`end()`) — and, as `prototype` requires, name a
+/// `DEFAULT`/`VARARG` convention; anything else is malformed metadata and
+/// throws.
+public func decode(method bytes: Array<UInt8>) throws(WinMDError)
+    -> MethodSignature {
+  var decoder = SignatureDecoder(bytes.span.bytes)
+  let signature = try decoder.method()
+  guard signature.convention == .default ||
+      signature.convention == .vararg else { throw .BadImageFormat }
+  try decoder.end()
+  return signature
+}
+
 // MARK: - Accessors
 
 extension Row where Schema == Metadata.Tables.MethodDef {

--- a/Sources/winmd-inspect/Database+SQL.swift
+++ b/Sources/winmd-inspect/Database+SQL.swift
@@ -195,8 +195,14 @@ extension Session {
     // — and its `[.blob]` parameter contract, which the static type-check
     // validates a `GUID(...)` call against. `try!`: the name is a compile-time
     // constant and not a protected standard routine, so it never faults.
-    try! Routines.standard.registering("guid", returns: .text,
-                                       parameters: [.blob], Session.guid)
+    //
+    // `SIGNATURE` joins it under the same `[.blob] -> .text` contract, decoding
+    // a `MethodDef.Signature` `#Blob` to its return type's neutral spelling.
+    try! Routines.standard
+        .registering("guid", returns: .text, parameters: [.blob],
+                     Session.guid)
+        .registering("signature", returns: .text, parameters: [.blob],
+                     Session.signature)
   }
 
   /// `GUID(blob)` — the UUID a `GuidAttribute` `CustomAttribute` value blob
@@ -218,6 +224,56 @@ extension Session {
     }
     guard let uuid = try? WinMD.iid(decoding: bytes) else { return .null }
     return .text("\(uuid)")
+  }
+
+  /// `SIGNATURE(blob)` — the return type a `MethodDef.Signature` `#Blob` names,
+  /// as its neutral spelling, or `NULL` when the blob is not a decodable method
+  /// signature.
+  ///
+  /// The value → value companion of the storage's `decode(return:in:)`: where
+  /// that navigates from a method `Id` and spells against a target `Dialect`,
+  /// this decodes a raw signature `#Blob` cell — the payload a `.blob` column
+  /// surfaces — with no database in hand, so a caller queries a return type
+  /// without a render round-trip. It reuses the EXISTING decoder end to end:
+  /// `WinMD.decode(method:)` reads the `MethodSignature`, and the synthesis
+  /// tier's `SignatureType.decode` spells the return. Named types resolve
+  /// through an EMPTY `Resolver` (there is no borrowed storage to navigate from
+  /// a native routine), so a named return degrades to the `neutral` dialect's
+  /// opaque spelling — the DB-free path the decoder already documents — while a
+  /// primitive, pointer, reference, array, or generic variable spells exactly.
+  /// A NULL argument propagates to NULL; a non-blob argument is
+  /// `SQLError.argument`; a malformed or absent signature is NULL, mirroring
+  /// `GUID`'s NULL-on-mismatch.
+  private static func signature(_ arguments: Array<Value>)
+      throws(SQLError) -> Value {
+    guard arguments.count == 1 else {
+      throw .argument("SIGNATURE takes one argument")
+    }
+    if case .null = arguments[0] { return .null }
+    guard case let .blob(bytes) = arguments[0] else {
+      throw .argument("SIGNATURE requires a blob argument")
+    }
+    guard let method = try? WinMD.decode(method: bytes) else { return .null }
+    return .text(method.returns.decode(with: Resolver([:]),
+                                       dialect: Session.neutral))
+  }
+
+  /// The language-neutral `Dialect` `SIGNATURE` spells against — the ECMA-335
+  /// neutral primitive names (an empty `primitives` table falls each key back
+  /// to its own neutral name) with plain pointer, generic, and variable
+  /// spellings, so a DB-free decode yields a readable type without a loaded
+  /// language spec. An unresolvable named type degrades to `opaque`.
+  private static var neutral: Dialect {
+    Dialect(primitives: [:],
+            pointer: (typed: (mutable: "ptr", constant: "ptr"),
+                      untyped: (mutable: "rawptr", constant: "rawptr")),
+            optional: "?",
+            generic: (open: "<", close: ">"),
+            variable: (type: "T", method: "M"),
+            opaque: "object",
+            guid: (iid: "iid", clsid: "clsid"),
+            known: [:],
+            escape: { $0 })
   }
 }
 

--- a/Sources/winmd-inspect/Resources/Queries/signatures.sql
+++ b/Sources/winmd-inspect/Resources/Queries/signatures.sql
@@ -1,0 +1,9 @@
+CREATE VIEW signatures AS
+SELECT
+  Id,
+  Name,
+  SIGNATURE(Signature) AS Type
+FROM
+  MethodDef
+WHERE
+  TypeDef = :parent

--- a/Tests/winmd-inspectTests/DatabaseSQLTests.swift
+++ b/Tests/winmd-inspectTests/DatabaseSQLTests.swift
@@ -509,6 +509,54 @@ struct DatabaseSQLTests {
     }
   }
 
+  @Test func `the SIGNATURE UDF decodes a MethodDef's Signature blob`() throws {
+    // The `SIGNATURE` UDF decodes the `MethodDef.Signature` `#Blob` (surfaced
+    // as a real `.blob` column) to its return type's neutral spelling; the
+    // fixture's sole method's signature is `void Method(i4, string)`, so its
+    // return decodes to `void`. This reuses the SAME decoder the render's
+    // `decode(return:in:)` navigates a method Id through — here driven off the
+    // raw blob cell with no database resolution.
+    try DatabaseSQLTests.with { catalog in
+      let rows = try DatabaseSQLTests.run(
+          "SELECT SIGNATURE(Signature) FROM MethodDef", catalog)
+      #expect(rows == [[.text("void")]])
+    }
+  }
+
+  @Test func `the SIGNATURE UDF is NULL on a malformed blob`() throws {
+    // A blob that is not a decodable method signature yields SQL NULL,
+    // mirroring `GUID`'s NULL-on-mismatch: `x'ff'` (an invalid prolog) does not
+    // decode, so the projection is NULL. It resolves through the session's
+    // routines, the same set the render binds.
+    try DatabaseSQLTests.with { catalog in
+      let rows = try DatabaseSQLTests.run(
+          "SELECT SIGNATURE(x'ff') FROM MethodDef", catalog)
+      #expect(rows == [[.null]])
+    }
+  }
+
+  @Test func `the SIGNATURE UDF propagates a NULL argument`() throws {
+    // A NULL argument propagates to NULL, exactly as `GUID` does — invoked
+    // directly against the session's `signature` routine (the dialect has no
+    // bare `NULL` literal in expression position, so this exercises the
+    // propagation off the routine itself).
+    let routine = Session.routines["signature"]
+    #expect(try routine?([.null]) == .null)
+  }
+
+  @Test func `the bundled signatures view decodes a method's return`() throws {
+    // The bundled `signatures` view projects `SIGNATURE(Signature) AS Type`
+    // over a `TypeDef`'s methods, bound by `:parent` — the render-facing
+    // demonstration of the UDF. `IMyInterface` (Id 1) owns `MyMethod`, whose
+    // signature's return decodes to `void`.
+    try DatabaseSQLTests.with { catalog in
+      let rows = try DatabaseSQLTests.run(
+          "SELECT Name, Type FROM signatures", Session.bundled(), catalog,
+          ["parent": .integer(1)])
+      #expect(rows == [[.text("MyMethod"), .text("void")]])
+    }
+  }
+
   @Test func `excludes the virtual columns from SELECT *`() throws {
     // `SELECT *` projects exactly the six real `TypeDef` fields — neither
     // `Id` nor an owner-FK column appears — for each of the two fixture types.

--- a/Tests/winmd-inspectTests/ShellTests.swift
+++ b/Tests/winmd-inspectTests/ShellTests.swift
@@ -385,12 +385,14 @@ struct ShellTests {
             == ["SELECT 1\nFROM Module", "SELECT 2"])
   }
 
-  @Test func `the bundled views are the five COM-interface views`() {
-    // The parse-and-register path a `CREATE VIEW` reuses; the five bundled
-    // views register under their case-folded names.
+  @Test func `the bundled views are the COM-interface views`() {
+    // The parse-and-register path a `CREATE VIEW` reuses; the bundled views
+    // register under their case-folded names — the five COM-interface views
+    // plus `signatures`, which decodes a method's return through the
+    // `SIGNATURE` UDF.
     let views = Session.bundled()
-    #expect(Set(views.keys)
-            == ["interfaces", "methods", "params", "bases", "generics"])
+    #expect(Set(views.keys) == ["interfaces", "methods", "params", "bases",
+                                "generics", "signatures"])
   }
 
   @Test func `a streamed CREATE VIEW statement parses and registers a view`() throws {


### PR DESCRIPTION
Wire the existing WinMD/Synthesis signature decoder into a domain UDF, `SIGNATURE(blob)`, registered in the winmd session's routines beside `GUID`. It decodes a `MethodDef.Signature` `#Blob` cell — the payload a `.blob` column surfaces — to its return type's neutral spelling as `.text`, NULL on a malformed or absent blob, mirroring `GUID`'s NULL-on-mismatch. It reuses the decoder end to end: a new public `WinMD.decode(method:)`, the bytes -> value companion of `iid(decoding:)`, runs the existing `SignatureDecoder` over the copied blob, and the synthesis tier's `SignatureType.decode` spells the return through an empty `Resolver` and a neutral `Dialect` (named types degrade to opaque on the DB-free path the decoder already documents). The bundled `signatures` query demonstrates it, projecting `SIGNATURE(Signature)` over a type's methods — closing part of the windows-rs render-parity gap.

No engine/parser change: the work is the winmd-inspect adapter plus a read-only-style public decode seam on WinMD.