### PR TITLE
GHA: tweaks to reduce CI overhead

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,6 +9,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   coverage:
     runs-on: windows-latest

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,14 +45,6 @@ jobs:
           restore-keys: |
             llvm-cas-${{ runner.os }}-${{ github.workflow }}-${{ matrix.tag }}-${{ hashFiles('Package.resolved') }}-
             llvm-cas-${{ runner.os }}-${{ github.workflow }}-${{ matrix.tag }}-
-      - name: Build
-        run: >-
-          swift build -v
-          -Xswiftc -explicit-module-build
-          -Xswiftc -cache-compile-job
-          -Xswiftc -cas-path
-          -Xswiftc $env:SWIFT_CAS_PATH
-          -Xswiftc -Rcache-compile-job
       - name: Run tests
         run: >-
           swift test -v --enable-code-coverage

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   windows:
     runs-on: windows-latest


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to improve CI reliability and resource usage. The most important changes include adding concurrency controls to both the coverage and Swift workflows, and removing an unused build step from the coverage workflow.

**Workflow improvements:**

* Added `concurrency` settings to both `.github/workflows/coverage.yml` and `.github/workflows/swift.yml` to ensure that only one workflow run per pull request or branch is active at a time, and any in-progress runs are cancelled if a new run is triggered. [[1]](diffhunk://#diff-a2115d277b5ca5a2f09a999e53440839cf332b94da177f3d1766334555b0f7c6R12-R15) [[2]](diffhunk://#diff-a15ae93f253d520aafce496a0c3580a16547f5bc50ca16d6dcbfdabf547bd8c5R9-R12)

**Build process simplification:**

* Removed the explicit `swift build` step from the coverage workflow, relying on the test step to handle building as needed.