### PR TITLE
WinMD: give the validating String initializer explicit access control

### DIFF
--- a/Sources/WinMD/Extensions/String+Extensions.swift
+++ b/Sources/WinMD/Extensions/String+Extensions.swift
@@ -11,8 +11,8 @@ extension String {
   /// Decodes a borrowed byte span as a string in the given encoding, failing
   /// on any invalid code-unit sequence rather than substituting the U+FFFD
   /// replacement character.
-  init?<Encoding: Unicode.Encoding>(validating span: RawSpan,
-                                    as encoding: Encoding.Type)
+  internal init?<Encoding: Unicode.Encoding>(validating span: RawSpan,
+                                             as encoding: Encoding.Type)
       where Encoding.CodeUnit == UInt8 {
     let value = span.withUnsafeBytes {
       String(validating: $0, as: encoding)


### PR DESCRIPTION
The failable `String(validating:as:)` RawSpan initializer added for the custom-attribute decoder was declared without an access-control modifier, relying on the implicit-internal default. Spell the `internal` modifier explicitly, consistent with the project convention that every declaration states its access level.