### PR TITLE
SQLEngine: rename some types

### DIFF
--- a/Sources/SQLEngine/Context.swift
+++ b/Sources/SQLEngine/Context.swift
@@ -65,7 +65,7 @@ internal struct Context {
   /// A copy of this context whose overlay binds `materialised` to `name` (folded
   /// to lower case), the binding shadowing any existing one — the recursive
   /// step's rebinding of a CTE's self to the previous iteration's rows.
-  internal func binding(_ name: String, to materialised: Materialised)
+  internal func binding(_ name: String, to materialised: RelationInstance)
       -> Context {
     var relations = relations
     relations[name.lowercased()] = materialised

--- a/Sources/SQLEngine/Definition.swift
+++ b/Sources/SQLEngine/Definition.swift
@@ -124,21 +124,22 @@ extension View {
 /// a base table, and the engine answers it by ENUMERATING the catalog rather
 /// than reading a stored relation: `store(_:rows:)` walks the catalog's
 /// `relations()`/`views()` and each relation's schema and builds the named
-/// relation's rows as an escapable `Materialised`. It builds no cached state,
-/// so the engine resolves a `definition_schema.` name lazily, building only the
-/// one a query references. The portable `INFORMATION_SCHEMA` relations are
-/// ordinary VIEWS over these.
+/// relation's rows as an escapable `RelationInstance`. It builds no cached
+/// state, so the engine resolves a `definition_schema.` name lazily, building
+/// only the one a query references. The portable `INFORMATION_SCHEMA`
+/// relations are ordinary VIEWS over these.
 ///
 /// The store is dialect-neutral: it reads only the adapter surface every
 /// `Catalog` shares, so any source gets it for free. It is built in engine core
 /// rather than by an adapter because `Schema` — a relation's `names`/`types` —
 /// is internal to the engine.
 extension Catalog where Self: ~Escapable {
-  /// The `Materialised` for the reserved `definition_schema.` `relation`, built
-  /// over this catalog. When `rows` is `true` the relation is ENUMERATED into
-  /// its rows — `store` walks the catalog's `relations()`/`views()` and each
-  /// relation's schema; when `false` it vends a SCHEMA-ONLY relation (columns +
-  /// types, no rows), exactly what a lazy system table's `schema()` would.
+  /// The `RelationInstance` for the reserved `definition_schema.` `relation`,
+  /// built over this catalog. When `rows` is `true` the relation is ENUMERATED
+  /// into its rows — `store` walks the catalog's `relations()`/`views()` and
+  /// each relation's schema; when `false` it vends a SCHEMA-ONLY relation
+  /// (columns + types, no rows), exactly what a lazy system table's `schema()`
+  /// would.
   ///
   /// The typing paths (the view-body type resolution and the schema path in
   /// `columns(of:)`) resolve a reserved name schema-only, so they read only the
@@ -148,10 +149,10 @@ extension Catalog where Self: ~Escapable {
   /// references.
   borrowing func store(_ relation: Definition, rows: Bool,
                        _ routines: Routines = [:])
-      -> Materialised {
+      -> RelationInstance {
     guard rows else {
-      return Materialised(columns: relation.names, rows: [],
-                          types: relation.types)
+      return RelationInstance(columns: relation.names, rows: [],
+                              types: relation.types)
     }
     return switch relation {
     case .tables:
@@ -163,8 +164,9 @@ extension Catalog where Self: ~Escapable {
 
   /// `context` with its `relations` overlay extended by every
   /// `definition_schema.` store relation `query` names, each built over this
-  /// catalog as a `Materialised` — the resolution surface the engine consults
-  /// for a reserved store relation, threaded onward as the working scope.
+  /// catalog as a `RelationInstance` — the resolution surface the engine
+  /// consults for a reserved store relation, threaded onward as the working
+  /// scope.
   ///
   /// The store sits AFTER the common table expressions and BEFORE the base
   /// catalog: a `definition_schema.` name is added only when the overlay does
@@ -184,16 +186,17 @@ extension Catalog where Self: ~Escapable {
   /// context's `routines`.
   ///
   /// The overlay also binds every DERIVED TABLE THIS query names in its own
-  /// FROM/JOIN — a `FROM (SELECT …) AS t` — under its alias as a `Materialised`
-  /// so the FROM/JOIN resolves it exactly as it resolves a common table
-  /// expression (the `ScopedRelations` path). It binds ONLY this query's own
-  /// aliases, not a nested subquery's: `augment` runs at every query level
-  /// (`run`, `compile`, `typecheck`, and `materialise` each augment the query
-  /// they receive), so a subquery binds its own aliases in its OWN scope. This
-  /// SELECT-scopes derived tables — unlike a statement-scoped, uniquely-named
-  /// CTE — so two sibling subqueries may reuse an alias `t` without colliding,
-  /// and this query's `t` SHADOWS an outer CTE or derived table of the same
-  /// name. A derived table is UNCORRELATED in this cut: its inner query
+  /// FROM/JOIN — a `FROM (SELECT …) AS t` — under its alias as a
+  /// `RelationInstance` so the FROM/JOIN resolves it exactly as it resolves a
+  /// common table expression (the `ScopedRelations` path). It binds ONLY this
+  /// query's own aliases, not a nested subquery's: `augment` runs at every
+  /// query level (`run`, `compile`, `typecheck`, and `materialise` each
+  /// augment the query they receive), so a subquery binds its own aliases in
+  /// its OWN scope. This SELECT-scopes derived tables — unlike a
+  /// statement-scoped, uniquely-named CTE — so two sibling subqueries may reuse
+  /// an alias `t` without colliding, and this query's `t` SHADOWS an outer CTE
+  /// or derived table of the same name. A derived table is UNCORRELATED in this
+  /// cut: its inner query
   /// materialises ONCE, against the overlay WITHOUT its own alias (base catalog
   /// plus the store relations and CTEs in scope, NOT its sibling FROM items),
   /// so a reference to an outer or sibling column resolves as an unknown column
@@ -295,7 +298,7 @@ extension Catalog where Self: ~Escapable {
     // them as one derived layer that SHADOWS an outer CTE or derived alias of
     // the same name in the scope THIS SELECT resolves its OWN references
     // against (projection/WHERE/JOIN-ON/GROUP/HAVING).
-    var layer = Dictionary<String, Materialised>()
+    var layer = Dictionary<String, RelationInstance>()
     for (alias, inner) in derivations {
       layer[alias.lowercased()] =
           try materialise(inner, scope, rows: rows, visited: visited,
@@ -304,13 +307,13 @@ extension Catalog where Self: ~Escapable {
     return context.scoping(augmented.pushing(layer))
   }
 
-  /// A DERIVED TABLE's `query` materialised into a `Materialised` bound under
-  /// its alias: its OUTPUT columns name the relation's columns (the ISO rule —
-  /// a derived table's columns are its inner query's output names), typed from
-  /// the same output-schema walk a scalar subquery's width and a CTE's schema
-  /// use. `rows` selects the build — a run captures the inner query's rows, a
-  /// typing path leaves them empty (schema-only, no cursor) — so the alias
-  /// resolves and types identically on both paths.
+  /// A DERIVED TABLE's `query` materialised into a `RelationInstance` bound
+  /// under its alias: its OUTPUT columns name the relation's columns (the ISO
+  /// rule — a derived table's columns are its inner query's output names),
+  /// typed from the same output-schema walk a scalar subquery's width and a
+  /// CTE's schema use. `rows` selects the build — a run captures the inner
+  /// query's rows, a typing path leaves them empty (schema-only, no cursor) —
+  /// so the alias resolves and types identically on both paths.
   ///
   /// The inner query resolves against `context` (the base catalog plus the
   /// store relations and CTEs in scope), NOT its sibling FROM items, so the
@@ -323,7 +326,7 @@ extension Catalog where Self: ~Escapable {
   private borrowing func materialise(_ query: Query, _ context: Context,
                                      rows: Bool, visited: Set<String> = [],
                                      validate: Bool = true)
-      throws(SQLError) -> Materialised {
+      throws(SQLError) -> RelationInstance {
     // Bind the inner query's OWN derived tables (and store relations) before
     // deriving its schema — a run augments them recursively, so the schema
     // path must too, or a nested derived table's alias resolves as unknown
@@ -417,8 +420,8 @@ extension Catalog where Self: ~Escapable {
       }
       captured = []
     }
-    return Materialised(columns: outputs.map(\.name), rows: captured,
-                        types: outputs.map(\.type), derivation: query)
+    return RelationInstance(columns: outputs.map(\.name), rows: captured,
+                            types: outputs.map(\.type), derivation: query)
   }
 
   /// `context` rescoped to the `definition_schema.` overlay a view's body
@@ -504,7 +507,7 @@ extension Catalog where Self: ~Escapable {
   /// a view (a user view or a built-in `information_schema.` one);
   /// `table_catalog`/`table_schema` are `NULL` (the store models a single
   /// unnamed catalog and schema).
-  private borrowing func tables() -> Materialised {
+  private borrowing func tables() -> RelationInstance {
     var rows = Array<Array<Value>>()
     for name in bases() {
       rows.append([.null, .null, .text(name), .text("BASE TABLE")])
@@ -512,8 +515,8 @@ extension Catalog where Self: ~Escapable {
     for name in listable() {
       rows.append([.null, .null, .text(name), .text("VIEW")])
     }
-    return Materialised(columns: Definition.tables.names, rows: rows,
-                        types: Definition.tables.types)
+    return RelationInstance(columns: Definition.tables.names, rows: rows,
+                            types: Definition.tables.types)
   }
 
   /// `definition_schema.columns` — one row per real column of every base
@@ -530,7 +533,7 @@ extension Catalog where Self: ~Escapable {
   /// `GUID(...)` column advertises `character varying`, not the integer
   /// default.
   private borrowing func columns(_ context: Context)
-      -> Materialised {
+      -> RelationInstance {
     var rows = Array<Array<Value>>()
     for name in bases() {
       guard let table = table(named: name) else { continue }
@@ -581,8 +584,8 @@ extension Catalog where Self: ~Escapable {
                      .text(resolved[ordinal].type.domain), .text("YES")])
       }
     }
-    return Materialised(columns: Definition.columns.names, rows: rows,
-                        types: Definition.columns.types)
+    return RelationInstance(columns: Definition.columns.names, rows: rows,
+                            types: Definition.columns.types)
   }
 }
 

--- a/Sources/SQLEngine/Engine.swift
+++ b/Sources/SQLEngine/Engine.swift
@@ -296,9 +296,9 @@ extension Catalog where Self: ~Escapable {
         rows = try run(cte.query, scope)
       }
       relations[cte.name.lowercased()] =
-          Materialised(columns: cte.columns, rows: rows,
-                       types: Array(repeating: .integer,
-                                    count: cte.columns.count))
+          RelationInstance(columns: cte.columns, rows: rows,
+                           types: Array(repeating: .integer,
+                                        count: cte.columns.count))
     }
     return try run(query, context.scoping(relations))
   }
@@ -387,9 +387,9 @@ extension Catalog where Self: ~Escapable {
       // evaluates it in — so a text-arithmetic anchor faults against the base
       // relation, not the CTE's declared (integer) columns.
       if typecheck { try self.typecheck(anchor, scope) }
-      let empty = Materialised(columns: cte.columns, rows: [],
-                               types: Array(repeating: .integer,
-                                            count: cte.columns.count))
+      let empty = RelationInstance(columns: cte.columns, rows: [],
+                                   types: Array(repeating: .integer,
+                                                count: cte.columns.count))
       // Bind the CTE self BEFORE augmenting the recursive arm, so a derived
       // body in the arm that names the CTE (`FROM (SELECT n FROM a) AS d`)
       // resolves it — `augment` materialises derived bodies eagerly, so the
@@ -440,15 +440,16 @@ extension Catalog where Self: ~Escapable {
   ///
   /// The anchor and the recursive arm are each validated against
   /// `cte.columns.count` by their compiled `Plan.width` BEFORE any rows bind
-  /// under the declared columns: the loop binds `working` as a `Materialised`
-  /// of `cte.columns`, so an arm narrower or wider than the column list — a
-  /// two-column anchor under a three-column list, or a recursive arm of a width
-  /// differing from the anchor's — would trap in `Materialised.record` when the
-  /// next iteration reads it. Checking the compiled width faults with
-  /// `SQLError.columns` regardless of how many rows an arm yields, so even a
-  /// `SELECT *` arm filtered to zero rows is caught. The anchor compiles with
-  /// the CTE name NOT in scope (it does not reference itself); the recursive
-  /// arm compiles with the name bound to `cte.columns`, the schema it reads.
+  /// under the declared columns: the loop binds `working` as a
+  /// `RelationInstance` of `cte.columns`, so an arm narrower or wider than the
+  /// column list — a two-column anchor under a three-column list, or a
+  /// recursive arm of a width differing from the anchor's — would trap in
+  /// `RelationInstance.record` when the next iteration reads it. Checking the
+  /// compiled width faults with `SQLError.columns` regardless of how many rows
+  /// an arm yields, so even a `SELECT *` arm filtered to zero rows is caught.
+  /// The anchor compiles with the CTE name NOT in scope (it does not reference
+  /// itself); the recursive arm compiles with the name bound to `cte.columns`,
+  /// the schema it reads.
   internal borrowing func fixpoint(_ cte: CTE, _ context: Context)
       throws(SQLError) -> Array<Array<Value>> {
     // Extend the scope with any `definition_schema.` store relation the CTE's
@@ -484,7 +485,7 @@ extension Catalog where Self: ~Escapable {
 
     // Validate the anchor's compiled width against the declared columns BEFORE
     // it seeds the working set: the loop binds `working` under `cte.columns` as
-    // a `Materialised`, so an anchor narrower than the column list — a
+    // a `RelationInstance`, so an anchor narrower than the column list — a
     // two-column `Parent` under `t(a, b, c)` — would trap when the recursive
     // arm reads the absent ordinal, rather than surfacing `SQLError.columns`.
     // The anchor is the base case and does not reference the CTE, so its width
@@ -498,9 +499,9 @@ extension Catalog where Self: ~Escapable {
     // schema every iteration reads it under — so its width resolves too (a
     // `SELECT *` arm spans that schema). Checking it here catches a mismatch
     // even when the arm is filtered to zero rows in every iteration.
-    let empty = Materialised(columns: cte.columns, rows: [],
-                             types: Array(repeating: .integer,
-                                          count: cte.columns.count))
+    let empty = RelationInstance(columns: cte.columns, rows: [],
+                                 types: Array(repeating: .integer,
+                                              count: cte.columns.count))
     let probe = context.binding(cte.name, to: empty)
     let arm = try compile(recursive, probe, validate: false).width
     guard arm == cte.columns.count else {
@@ -527,9 +528,9 @@ extension Catalog where Self: ~Escapable {
 
       // Bind the CTE name to ONLY the previous step's output and run the
       // recursive arm against the base catalog plus the earlier CTEs.
-      let step = Materialised(columns: cte.columns, rows: working,
-                              types: Array(repeating: .integer,
-                                           count: cte.columns.count))
+      let step = RelationInstance(columns: cte.columns, rows: working,
+                                  types: Array(repeating: .integer,
+                                               count: cte.columns.count))
       let produced = try run(recursive, context.binding(cte.name, to: step))
 
       var next = Array<Array<Value>>()

--- a/Sources/SQLEngine/Engine.swift
+++ b/Sources/SQLEngine/Engine.swift
@@ -562,8 +562,8 @@ extension Projection {
   /// subqueries the projection nests, so an `EXISTS`/`IN (Q)` inside a scalar
   /// term lowers exactly as it does on the FROM'd path — the FROM-less scalar
   /// select is otherwise the ONE path that would hit the default unsupported
-  /// map and reject a subquery a run materialises. The `Subquery` is threaded,
-  /// not run, here (see `subquery(of:)`).
+  /// map and reject a subquery a run materialises. The `Resolution` is
+  /// threaded, not run, here (see `subquery(of:)`).
   ///
   /// A projection is a BARRED clause position, so a correlated column of THIS
   /// query has no evaluator here. `Schema.terms` bars the seam intrinsically,
@@ -571,7 +571,7 @@ extension Projection {
   /// admitting `plans.rest` — the same cut `columns(of:)` applies on the schema
   /// path, keeping run and derive in lockstep.
   internal func scalar(_ routines: Routines = [:],
-                       subquery: Subquery = .unsupported)
+                       subquery: Resolution = .unsupported)
       throws(SQLError) -> Plan {
     guard case .all = self else {
       let schema = Schema(width: 0, extent: 0, names: [], types: [],
@@ -1866,7 +1866,7 @@ extension Expression {
   /// so it reads the pre-aggregation row the fold gates on. `self` is always an
   /// `.aggregate` — `collect` gathers only those.
   internal func aggregation(_ scope: Scope, _ routines: Routines = [:],
-                            subquery: Subquery = .unsupported)
+                            subquery: Resolution = .unsupported)
       throws(SQLError) -> Aggregation {
     guard case let .aggregate(function, operand, distinct, filter) = self else {
       throw .unsupported("expected an aggregate")
@@ -2795,7 +2795,7 @@ extension Catalog where Self: ~Escapable {
 
   /// The distinct UNCORRELATED subqueries `select` nests, each COMPILED ONCE
   /// against this catalog and `context` for its column count — NEVER run — into
-  /// a `Subquery` map the predicate/projection lowering reads for arity, the
+  /// a `Resolution` map the predicate/projection lowering reads for arity, the
   /// seam that carries each sub-`Query` into its lowered `Filter` as data.
   ///
   /// This is CURSOR-FREE: it drives `compile`, which resolves schemas and reads
@@ -2820,8 +2820,8 @@ extension Catalog where Self: ~Escapable {
   /// query's inner `WHERE` column that binds none of ITS relations resolves
   /// against the enclosing select (and outward), lowering to a synthetic
   /// `Term.parameter` and RECORDING the correlation the lowered node carries.
-  /// The returned `Subquery` also carries `outer` so THIS select's own columns
-  /// correlate outward when it is a subquery.
+  /// The returned `Resolution` also carries `outer` so THIS select's own
+  /// columns correlate outward when it is a subquery.
   ///
   /// `prefixes`, when supplied, gives the PREFIX scope each join `ON` lowers
   /// against — the FROM relation and joins `0…index`, never a relation joined
@@ -2845,7 +2845,7 @@ extension Catalog where Self: ~Escapable {
     // the WHERE is resolved TWICE — each against its own site's scope — so the
     // WHERE occurrence sees the full scope and reports a genuine ambiguity rather
     // than reusing the first `ON` occurrence's narrower prefix correlation.
-    var lowerings = Array<Subquery>()
+    var lowerings = Array<Resolution>()
     lowerings.reserveCapacity(select.joins.count)
     for index in select.joins.indices {
       var queries = Array<Query>()
@@ -2870,7 +2870,7 @@ extension Catalog where Self: ~Escapable {
     return Plans(lowerings, remainder)
   }
 
-  /// Builds ONE lowering `Subquery` over the directly-nested `queries` of a
+  /// Builds ONE lowering `Resolution` over the directly-nested `queries` of a
   /// single SITE, resolving each against `within` — the scope THAT site's
   /// subqueries correlate against (a join `ON`'s prefix, or the full
   /// `enclosing` for the WHERE/HAVING/projection/ORDER). Each distinct `Query`
@@ -2880,7 +2880,7 @@ extension Catalog where Self: ~Escapable {
                                   _ context: Context, _ visited: Set<String>,
                                   _ scope: Subscope, within: Scope?,
                                   outer: Outer?)
-      throws(SQLError) -> Subquery {
+      throws(SQLError) -> Resolution {
     // A nested subquery's FROM resolves against base tables and enclosing CTEs,
     // NOT the enclosing SELECT's derived-table aliases (SELECT-scoped, unseen
     // by a subquery's FROM as a base-table alias would be) — so STRIP them, the
@@ -2973,7 +2973,7 @@ extension Catalog where Self: ~Escapable {
         }
       }
     }
-    return Subquery(scope, widths, types, correlations, outer: outer)
+    return Resolution(scope, widths, types, correlations, outer: outer)
   }
 
   /// The single VALUE a SCALAR subquery `query` collapses to against this

--- a/Sources/SQLEngine/Function.swift
+++ b/Sources/SQLEngine/Function.swift
@@ -195,8 +195,8 @@ public struct Routine: Sendable {
         throw .argument("requires \(expected.domain) arguments")
       }
       // The body's lowered `term` cannot nest a subquery — a `CREATE FUNCTION`
-      // body lowers against `Subquery.unsupported` (no catalog), which rejects
-      // one at registration — so the subquery-free evaluate suffices.
+      // body lowers against `Resolution.unsupported` (no catalog), which
+      // rejects one at registration — so the subquery-free evaluate suffices.
       return try Record(arguments).evaluate(term, routines)
     }
   }
@@ -205,11 +205,11 @@ public struct Routine: Sendable {
 /// An empty `Catalog` vending no relation — the stand-in for the absent catalog
 /// where the evaluator runs a subquery-FREE term.
 ///
-/// A `CREATE FUNCTION` body lowers against `Subquery.unsupported`, so its term
-/// can never nest a scalar subquery and its evaluation never needs a catalog to
-/// materialise one. Passing this empty catalog keeps ONE evaluator: a term that
-/// did reach a `.subquery` would run `cell(of:)` against a catalog resolving no
-/// relation and fault, but a function body never does.
+/// A `CREATE FUNCTION` body lowers against `Resolution.unsupported`, so its
+/// term can never nest a scalar subquery and its evaluation never needs a
+/// catalog to materialise one. Passing this empty catalog keeps ONE evaluator:
+/// a term that did reach a `.subquery` would run `cell(of:)` against a catalog
+/// resolving no relation and fault, but a function body never does.
 internal struct NoCatalog: Catalog {
   internal struct Table: SQLEngine.Table {
     internal struct Cursor: SQLEngine.Cursor {

--- a/Sources/SQLEngine/Operator.swift
+++ b/Sources/SQLEngine/Operator.swift
@@ -728,7 +728,7 @@ private func deduplicated(_ records: Array<Record>) -> Array<Record> {
 ///
 /// A common table expression `name` (in `ctes`, consulted first — a CTE shadows
 /// a base relation) materialises its records directly from the in-engine
-/// `Materialised` rows; else the base relation re-resolves through this
+/// `RelationInstance` rows; else the base relation re-resolves through this
 /// catalog, its cursor opened.
 ///
 /// - Throws: `SQLError.relation` if the name resolves to neither.

--- a/Sources/SQLEngine/OutputColumn.swift
+++ b/Sources/SQLEngine/OutputColumn.swift
@@ -162,7 +162,7 @@ extension Catalog where Self: ~Escapable {
   /// The result columns the trailing `query` of a `WITH` would yield, resolved
   /// against a SCHEMA-ONLY overlay of the `ctes` in scope.
   ///
-  /// Each CTE binds a `Materialised` of its DECLARED columns with no rows —
+  /// Each CTE binds a `RelationInstance` of its DECLARED columns with no rows —
   /// the schema the run's materialised CTE resolves to (columns from the
   /// declared list, every type `.integer`) — laid into the overlay in source
   /// order so a later CTE, and the trailing query, resolve a name the same
@@ -215,9 +215,9 @@ extension Catalog where Self: ~Escapable {
       // the recursive arm's operand check and, after validation, into the
       // overlay a later CTE and the trailing query resolve against.
       let declared =
-          Materialised(columns: cte.columns, rows: [],
-                       types: Array(repeating: .integer,
-                                    count: cte.columns.count))
+          RelationInstance(columns: cte.columns, rows: [],
+                           types: Array(repeating: .integer,
+                                        count: cte.columns.count))
       // Validate the body's SHAPE and ARITY against the scope of the PRIOR CTEs
       // by the SAME code a run uses — `Engine.validate` — so a schema is not
       // advertised for a `WITH` a run would reject, and this path never again

--- a/Sources/SQLEngine/OutputColumn.swift
+++ b/Sources/SQLEngine/OutputColumn.swift
@@ -287,7 +287,7 @@ extension Catalog where Self: ~Escapable {
     let augmented = try augment(context, for: .select(select), rows: false,
                                 visited: visited, validate: validate)
     // A scalar subquery in the projection derives its type from its inner
-    // query's single column, so build the SAME cursor-free `Subquery` map the
+    // query's single column, so build the SAME cursor-free `Resolution` map the
     // compile path's lowering reads — every nested subquery compiled ONCE for
     // its width and single-column type, each discovering its correlation against
     // this select's own scope (`enclosing`) — and pass it to the projection walk
@@ -1005,7 +1005,7 @@ extension Scope {
   /// — `routines` type a scalar call from its declared return type.
   internal func columns(of projection: Projection,
                         _ routines: Routines = [:],
-                        subquery: Subquery = .unsupported)
+                        subquery: Resolution = .unsupported)
       throws(SQLError) -> Array<OutputColumn> {
     return switch projection {
     case .all:
@@ -1044,7 +1044,7 @@ extension Scope {
   /// return type; every other expression `.integer`.
   internal func output(_ item: Projected, at index: Int,
                        _ routines: Routines = [:],
-                       subquery: Subquery = .unsupported)
+                       subquery: Resolution = .unsupported)
       throws(SQLError) -> OutputColumn {
     let name = item.name ?? "column \(index + 1)"
     // DERIVE the nominal output type: the schema reports the type a run would

--- a/Sources/SQLEngine/RelationInstance.swift
+++ b/Sources/SQLEngine/RelationInstance.swift
@@ -8,7 +8,7 @@
 /// It is threaded alongside the borrowed base catalog through every resolution
 /// phase: when the engine resolves a relation name, it consults
 /// `ScopedRelations` first, and a bound leaf materialises its records from the
-/// `Materialised` rows rather than opening a base cursor. An empty
+/// `RelationInstance` rows rather than opening a base cursor. An empty
 /// `ScopedRelations` is the default — a query with no `WITH` and no derived
 /// table resolves exactly as before. Threading escapable data sidesteps
 /// wrapping the borrowed `~Escapable` base catalog in a unifying overlay type.
@@ -30,7 +30,7 @@ internal struct ScopedRelations: Hashable, Sendable,
   /// `definition_schema.` store relation in scope (`derivation == nil`). It is
   /// what a nested subquery's FROM and a revealed body resolve against: a CTE
   /// is statement-scoped, visible under any number of enclosing derived layers.
-  private var base: Dictionary<String, Materialised>
+  private var base: Dictionary<String, RelationInstance>
 
   /// The stack of SELECT-scoped derived layers, outermost first. Each
   /// `augment` for a SELECT with `FROM (SELECT …) AS t` derived tables pushes
@@ -38,7 +38,7 @@ internal struct ScopedRelations: Hashable, Sendable,
   /// innermost (last) layer that binds it, so an inner derived alias shadows an
   /// outer same-named one and both shadow the base. Empty for a query with no
   /// derived table.
-  private var layers: Array<Dictionary<String, Materialised>>
+  private var layers: Array<Dictionary<String, RelationInstance>>
 
   /// An empty overlay — the scope a bare query with no `WITH` and no derived
   /// table runs under.
@@ -47,7 +47,7 @@ internal struct ScopedRelations: Hashable, Sendable,
     self.layers = []
   }
 
-  internal init(dictionaryLiteral elements: (String, Materialised)...) {
+  internal init(dictionaryLiteral elements: (String, RelationInstance)...) {
     self.base = Dictionary(uniqueKeysWithValues: elements)
     self.layers = []
   }
@@ -57,7 +57,7 @@ internal struct ScopedRelations: Hashable, Sendable,
   /// `name` in the INNERMOST layer (the current derived layer, else the base),
   /// shadowing an outer same-named binding without deleting it; setting `nil`
   /// removes it from that layer only.
-  internal subscript(name: String) -> Materialised? {
+  internal subscript(name: String) -> RelationInstance? {
     get {
       for layer in layers.reversed() {
         if let materialised = layer[name] { return materialised }
@@ -81,7 +81,7 @@ internal struct ScopedRelations: Hashable, Sendable,
   /// run→compile→typecheck chain re-augments the same query) is a no-op, so
   /// the stack stays bounded and a self-named alias's body still reads the
   /// base.
-  internal func pushing(_ derivations: Dictionary<String, Materialised>)
+  internal func pushing(_ derivations: Dictionary<String, RelationInstance>)
       -> ScopedRelations {
     guard !derivations.isEmpty else { return self }
     if layers.last == derivations { return self }
@@ -125,18 +125,19 @@ internal struct ScopedRelations: Hashable, Sendable,
 
 /// An escapable, in-engine relation over `(columns, rows)`.
 ///
-/// A `Materialised` is fully owned data — a common table expression's query run
-/// to a fixed set of rows, named by its columns — that the engine resolves a
-/// CTE name to. It is escapable, so it sits beside the `~Escapable` base
-/// catalog without the lifetime machinery a borrowed source needs: the engine
-/// threads a `Dictionary<String, Materialised>` of the in-scope CTEs alongside
-/// the borrowed base catalog, consulting it first when it resolves a name, and
-/// builds the leaf records directly from `rows` rather than opening a cursor.
+/// A `RelationInstance` is fully owned data — a common table expression's
+/// query run to a fixed set of rows, named by its columns — that the engine
+/// resolves a CTE name to. It is escapable, so it sits beside the `~Escapable`
+/// base catalog without the lifetime machinery a borrowed source needs: the
+/// engine threads a `Dictionary<String, RelationInstance>` of the in-scope
+/// CTEs alongside the borrowed base catalog, consulting it first when it
+/// resolves a name, and builds the leaf records directly from `rows` rather
+/// than opening a cursor.
 ///
 /// It exposes the universal `Id` virtual column at `width`, so a CTE
 /// resolves columns exactly as a base relation does (a real column below
 /// `width`, the `Id` at `width`).
-internal struct Materialised: Hashable, Sendable {
+internal struct RelationInstance: Hashable, Sendable {
   /// The relation's column names, in ordinal order.
   internal let columns: Array<String>
 

--- a/Sources/SQLEngine/Resolve.swift
+++ b/Sources/SQLEngine/Resolve.swift
@@ -431,7 +431,7 @@ internal final class SubqueryMemo {
 /// running — every subquery ONCE ahead of lowering. A schema-only surface with
 /// no catalog passes `.unsupported`, whose `width` faults, so a subquery
 /// reaching such a surface is rejected rather than mis-lowered.
-internal struct Subquery {
+internal struct Resolution {
   /// The resolution context every subquery lowered against this surface
   /// materialises under — `.caller` for a top-level compile, `.view(name)` for
   /// a view body's — composed into each lowered `Filter`'s cache key so a
@@ -485,11 +485,11 @@ internal struct Subquery {
     self.admits = admits
   }
 
-  /// A `Subquery` for a lowering surface with no catalog — a schema-only
+  /// A `Resolution` for a lowering surface with no catalog — a schema-only
   /// resolve. It holds no widths, so any subquery lowered against it faults
   /// `SQLError.unsupported` rather than mis-lower.
-  internal static var unsupported: Subquery {
-    Subquery()
+  internal static var unsupported: Resolution {
+    Resolution()
   }
 
   /// This seam with correlation BARRED — the surface a projection / `GROUP BY`
@@ -497,8 +497,8 @@ internal struct Subquery {
   /// cut. It keeps the widths/types/correlations (nested subqueries there still
   /// lower and carry their OWN inner correlation) but rejects a correlated
   /// column of THIS query as unsupported.
-  internal var barred: Subquery {
-    Subquery(scope, widths, types, correlations, outer: outer, admits: false)
+  internal var barred: Resolution {
+    Resolution(scope, widths, types, correlations, outer: outer, admits: false)
   }
 
   /// The synthetic bound-parameter name a CORRELATED reference to `column`
@@ -629,7 +629,7 @@ internal struct Subquery {
   }
 }
 
-/// The PER-SITE lowering seams a select's pre-pass discovers — ONE `Subquery`
+/// The PER-SITE lowering seams a select's pre-pass discovers — ONE `Resolution`
 /// per join `ON` (resolved against that join's PREFIX scope) and one for the
 /// REST (the WHERE, `HAVING`, projection, and `ORDER BY`, resolved against the
 /// full join scope).
@@ -642,19 +642,19 @@ internal struct Subquery {
 internal struct Plans {
   /// The lowering seam of each join `ON`, in join order — `on(i)` reads the
   /// `i`-th, resolved against `prefixes[i]`.
-  private let ons: Array<Subquery>
+  private let ons: Array<Resolution>
 
   /// The lowering seam the WHERE, `HAVING`, projection, and `ORDER BY` share,
   /// resolved against the full join scope.
-  internal let rest: Subquery
+  internal let rest: Resolution
 
-  internal init(_ ons: Array<Subquery>, _ rest: Subquery) {
+  internal init(_ ons: Array<Resolution>, _ rest: Resolution) {
     self.ons = ons
     self.rest = rest
   }
 
   /// The lowering seam of join `index`'s `ON`.
-  internal func on(_ index: Int) -> Subquery {
+  internal func on(_ index: Int) -> Resolution {
     ons[index]
   }
 }
@@ -817,7 +817,7 @@ internal final class ReachedScalars {
   }
 }
 
-/// The validation-side analog of `Subquery` — the seam that lets the dry-run
+/// The validation-side analog of `Resolution` — the seam that lets the dry-run
 /// type-check (`check`) validate the UNCORRELATED inner query an `EXISTS`/`IN
 /// (Q)` nests without itself holding the borrowing catalog.
 ///
@@ -849,7 +849,7 @@ internal struct SubqueryCheck {
 
   /// Each nested `Query` mapped to its single-column output TYPE, derived by
   /// the `typecheck` pre-pass — the type a scalar subquery reports to the
-  /// result schema (`validate`/`derive`), matching the lowering's `Subquery`.
+  /// result schema (`validate`/`derive`), matching the lowering's `Resolution`.
   private let types: Dictionary<Query, ValueType>
 
   /// The scalar inner queries whose OPERAND validation is DEFERRED through the
@@ -865,14 +865,14 @@ internal struct SubqueryCheck {
   private let reached: ReachedScalars
 
   /// The ENCLOSING scope this select's OWN columns correlate against — the
-  /// validation-side analog of `Subquery.outer`, so a correlated column resolves
-  /// against the outer query exactly as the run's lowering does, keeping
-  /// typecheck↔run parity. `nil` for a top-level select.
+  /// validation-side analog of `Resolution.outer`, so a correlated column
+  /// resolves against the outer query exactly as the run's lowering does,
+  /// keeping typecheck↔run parity. `nil` for a top-level select.
   private let outer: Outer?
 
   /// Whether this surface ADMITS a correlated column — the inner `WHERE`/`ON`
   /// (TRUE) versus a projection / `GROUP BY` / `HAVING` (FALSE, diagnosed) — the
-  /// analog of `Subquery.admits`, so validation faults the unsupported
+  /// analog of `Resolution.admits`, so validation faults the unsupported
   /// correlated-projection case exactly where the run does.
   private let admits: Bool
 
@@ -898,7 +898,7 @@ internal struct SubqueryCheck {
 
   /// This checker with correlation BARRED — the surface a projection / `GROUP
   /// BY` / `HAVING` type-checks under, where an outer column is out of the (b)
-  /// cut and is diagnosed rather than resolved. Mirrors `Subquery.barred`.
+  /// cut and is diagnosed rather than resolved. Mirrors `Resolution.barred`.
   internal var barred: SubqueryCheck {
     SubqueryCheck(widths, types, deferred: deferred, reached: reached,
                   outer: outer, admits: false)
@@ -918,7 +918,7 @@ internal struct SubqueryCheck {
   }
 
   /// The outer type `column` correlates to, or `nil` when no enclosing scope
-  /// binds it — the validation-side `Subquery.correlate`: it resolves against
+  /// binds it — the validation-side `Resolution.correlate`: it resolves against
   /// `outer`, faulting `.unsupported` on a BARRED surface (a projection / `GROUP
   /// BY` / `HAVING`) so validation rejects the unsupported correlated-projection
   /// case exactly as the run's lowering does, and returns the outer column's
@@ -1009,7 +1009,7 @@ internal struct SubqueryCheck {
 /// caller supplies that resolution as `term`.
 private func lower(_ predicate: Predicate,
                    term: (Expression) throws(SQLError) -> Term,
-                   subquery: Subquery)
+                   subquery: Resolution)
     throws(SQLError) -> Filter {
   switch predicate {
   case let .comparison(left, op, right):
@@ -1321,7 +1321,7 @@ extension Schema {
   /// engine remaps to slots after gathering the referenced ones.
   internal func terms(_ projection: Projection, in relation: Relation,
                       _ routines: Routines = [:],
-                      subquery: Subquery = .unsupported)
+                      subquery: Resolution = .unsupported)
       throws(SQLError) -> Array<Term> {
     // A projection is a BARRED clause position: a correlated column of THIS
     // query has no evaluator here (only WHERE/ON/HAVING admit one). The cut is
@@ -1360,7 +1360,7 @@ extension Schema {
   /// its lowered arguments.
   internal func term(_ expression: Expression, in relation: Relation,
                      _ routines: Routines = [:],
-                     subquery: Subquery = .unsupported)
+                     subquery: Resolution = .unsupported)
       throws(SQLError) -> Term {
     switch expression {
     case let .column(column):
@@ -1466,7 +1466,7 @@ extension Schema {
   internal func order(_ order: Order, in relation: Relation,
                       _ projection: Array<Term>, _ names: Array<String?>,
                       _ routines: Routines = [:],
-                      subquery: Subquery = .unsupported)
+                      subquery: Resolution = .unsupported)
       throws(SQLError) -> Array<SortKey> {
     // An ORDER BY is BARRED, as the projection is: a correlated column of THIS
     // query is out of the cut here, so the entry bars the seam by construction.
@@ -1479,7 +1479,7 @@ extension Schema {
 
   internal func lower(_ predicate: Predicate, in relation: Relation,
                       _ routines: Routines = [:],
-                      subquery: Subquery = .unsupported)
+                      subquery: Resolution = .unsupported)
       throws(SQLError) -> Filter {
     try SQLEngine.lower(predicate, term: { expression throws(SQLError) in
       try term(expression, in: relation, routines, subquery: subquery)
@@ -1605,7 +1605,7 @@ internal struct Scope {
   /// This is the SCHEMA surface. `validate(_:_:)` is the type-check surface: it
   /// faults exactly as a run would on a bad operand or an unknown/misused call.
   internal func derive(_ expression: Expression, _ routines: Routines = [:],
-                       subquery: Subquery = .unsupported)
+                       subquery: Resolution = .unsupported)
       throws(SQLError) -> ValueType {
     return switch expression {
     case let .column(column):
@@ -1695,7 +1695,7 @@ internal struct Scope {
   /// never runs.
   private func nullif(_ lhs: Expression, _ rhs: Expression,
                       _ routines: Routines,
-                      subquery: Subquery = .unsupported)
+                      subquery: Resolution = .unsupported)
       throws(SQLError) -> ValueType {
     let type = try derive(lhs, routines, subquery: subquery)
     _ = try derive(rhs, routines, subquery: subquery)
@@ -1708,7 +1708,7 @@ internal struct Scope {
   /// arithmetic `.binary` derive branch.
   private func concatenation(_ lhs: Expression, _ rhs: Expression,
                              _ routines: Routines,
-                             subquery: Subquery = .unsupported)
+                             subquery: Resolution = .unsupported)
       throws(SQLError) -> ValueType {
     _ = try derive(lhs, routines, subquery: subquery)
     _ = try derive(rhs, routines, subquery: subquery)
@@ -1720,7 +1720,7 @@ internal struct Scope {
   /// discarding its type, the conversion being nominal.
   private func derive(cast operand: Expression, to type: ValueType,
                       _ routines: Routines,
-                      subquery: Subquery = .unsupported)
+                      subquery: Resolution = .unsupported)
       throws(SQLError) -> ValueType {
     _ = try derive(operand, routines, subquery: subquery)
     return type
@@ -1743,7 +1743,7 @@ internal struct Scope {
   /// unification and the faulting `validate`'s stop.
   private func unified(_ arguments: Array<Expression>,
                        _ routines: Routines,
-                       subquery: Subquery = .unsupported)
+                       subquery: Resolution = .unsupported)
       throws(SQLError) -> ValueType {
     var type: ValueType?
     for argument in arguments {
@@ -1801,7 +1801,7 @@ internal struct Scope {
   /// widens to `double`.
   internal func derive(_ whens: Array<When>, _ otherwise: Expression?,
                        _ routines: Routines,
-                       subquery: Subquery = .unsupported)
+                       subquery: Resolution = .unsupported)
       throws(SQLError) -> ValueType {
     let results = reachable(whens, otherwise, routines)
     guard !results.isEmpty else { return .integer }
@@ -3309,7 +3309,7 @@ internal struct Scope {
   /// list as lowered terms — in source order.
   internal func terms(_ projection: Projection,
                       _ routines: Routines = [:],
-                      subquery: Subquery = .unsupported) throws(SQLError)
+                      subquery: Resolution = .unsupported) throws(SQLError)
       -> Array<Term> {
     // A projection is a BARRED clause position (see `Schema.terms`): the entry
     // bars the seam, so no join-scope projection can admit a correlated column
@@ -3350,7 +3350,7 @@ internal struct Scope {
   /// Lowers a scalar `expression` to a combined-ordinal `Term`.
   internal func term(_ expression: Expression,
                      _ routines: Routines = [:],
-                     subquery: Subquery = .unsupported)
+                     subquery: Resolution = .unsupported)
       throws(SQLError) -> Term {
     switch expression {
     case let .column(column):
@@ -3442,7 +3442,7 @@ internal struct Scope {
   /// fresh over the chain (see the free `order`).
   internal func order(_ order: Order, _ projection: Array<Term>,
                       _ names: Array<String?>, _ routines: Routines = [:],
-                      subquery: Subquery = .unsupported)
+                      subquery: Resolution = .unsupported)
       throws(SQLError) -> Array<SortKey> {
     // An ORDER BY is BARRED, as the projection is (see `Schema.order`).
     let subquery = subquery.barred
@@ -3495,7 +3495,7 @@ internal struct Scope {
   /// byte-for-byte.
   internal func on(_ predicate: Predicate,
                    _ routines: Routines = [:],
-                   subquery: Subquery = .unsupported)
+                   subquery: Resolution = .unsupported)
       throws(SQLError) -> Filter {
     let conjuncts = predicate.conjuncts
     let lowered = try conjuncts.map { conjunct throws(SQLError) in
@@ -3526,7 +3526,7 @@ internal struct Scope {
   /// column reference resolved to a combined ordinal across the chain.
   internal func lower(_ predicate: Predicate,
                       _ routines: Routines = [:],
-                      subquery: Subquery = .unsupported)
+                      subquery: Resolution = .unsupported)
       throws(SQLError) -> Filter {
     try SQLEngine.lower(predicate, term: { expression throws(SQLError) in
       try term(expression, routines, subquery: subquery)
@@ -3609,7 +3609,7 @@ internal struct Grouping {
   /// against the collected aggregations, so `SUM(Amount)` and
   /// `SUM(Sales.Amount)` find the same slot in a single-relation scope.
   private func slot(of expression: Expression, _ routines: Routines = [:],
-                    subquery: Subquery = .unsupported)
+                    subquery: Resolution = .unsupported)
       throws(SQLError) -> Int? {
     guard case .aggregate = expression else { return nil }
     let aggregation = try expression.aggregation(scope, routines,
@@ -3625,7 +3625,7 @@ internal struct Grouping {
   /// standard rule.
   private func term(_ expression: Expression,
                     _ routines: Routines = [:],
-                    subquery: Subquery = .unsupported)
+                    subquery: Resolution = .unsupported)
       throws(SQLError) -> Term {
     if case .aggregate = expression,
        let slot = try slot(of: expression, routines, subquery: subquery) {
@@ -3724,7 +3724,7 @@ internal struct Grouping {
   /// well-defined meaning over groups (which columns?), so it faults.
   internal mutating func terms(_ projection: Projection,
                                _ routines: Routines = [:],
-                               subquery: Subquery = .unsupported)
+                               subquery: Resolution = .unsupported)
       throws(SQLError) -> Array<Term> {
     // A grouped projection is a BARRED clause position (see `Schema.terms`):
     // the entry bars the seam so it cannot admit a correlated column of THIS
@@ -3762,7 +3762,7 @@ internal struct Grouping {
   /// Lowers a `HAVING`/predicate to a grouped-space `Filter`.
   internal func lower(_ predicate: Predicate,
                       _ routines: Routines = [:],
-                      subquery: Subquery = .unsupported)
+                      subquery: Resolution = .unsupported)
       throws(SQLError) -> Filter {
     try SQLEngine.lower(predicate, term: { expression throws(SQLError) in
       try term(expression, routines, subquery: subquery)
@@ -3800,7 +3800,7 @@ internal struct Grouping {
   /// and `GROUP BY` surfaces are the `aliases` and `keys` `terms` recorded.
   internal func order(_ order: Order, _ projection: Array<Term>,
                       _ routines: Routines = [:],
-                      subquery: Subquery = .unsupported)
+                      subquery: Resolution = .unsupported)
       throws(SQLError) -> Array<SortKey> {
     // A grouped ORDER BY is BARRED, as the projection is (see `Schema.order`).
     let subquery = subquery.barred

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -4435,7 +4435,7 @@ struct EngineRecursiveTests {
     // `Edge` is a two-column relation, but the column list declares three
     // names; the anchor's `SELECT *` compiles to a two-wide plan the fixpoint
     // would bind under the three-column schema, so the recursive arm's read of
-    // the absent third ordinal would trap in `Materialised.record`. The
+    // the absent third ordinal would trap in `RelationInstance.record`. The
     // anchor's compiled width is checked against the declared arity BEFORE it
     // seeds the working set, so the fault surfaces as `SQLError.columns` rather
     // than a trap.


### PR DESCRIPTION
This pull request makes a broad and systematic change to the SQL engine codebase, replacing the usage of the `Materialised` type with the more general `RelationInstance` type throughout the engine. This affects function signatures, return types, variable declarations, and documentation comments. Additionally, some terminology is updated for clarity, and the type used for subquery handling is renamed from `Subquery` to `Resolution` to better reflect its purpose.

The most important changes are:

### Type Replacement: `Materialised` → `RelationInstance`

* All references to `Materialised` in return types, variable declarations, and function arguments across `Context.swift`, `Definition.swift`, and `Engine.swift` are replaced with `RelationInstance`. This standardizes the representation of materialized relations in the engine. [[1]](diffhunk://#diff-07728bc1d28c5f221d9dccb6e4abc6771ad0f05c3b6092021046778647c8de8fL68-R68) [[2]](diffhunk://#diff-226bbb012685b516d46f66755374ffc381bc8e2d02b7ab568199461d95cb3fc5L127-R142) [[3]](diffhunk://#diff-226bbb012685b516d46f66755374ffc381bc8e2d02b7ab568199461d95cb3fc5L151-R154) [[4]](diffhunk://#diff-226bbb012685b516d46f66755374ffc381bc8e2d02b7ab568199461d95cb3fc5L166-R169) [[5]](diffhunk://#diff-226bbb012685b516d46f66755374ffc381bc8e2d02b7ab568199461d95cb3fc5L187-R199) [[6]](diffhunk://#diff-226bbb012685b516d46f66755374ffc381bc8e2d02b7ab568199461d95cb3fc5L298-R301) [[7]](diffhunk://#diff-226bbb012685b516d46f66755374ffc381bc8e2d02b7ab568199461d95cb3fc5L307-R316) [[8]](diffhunk://#diff-226bbb012685b516d46f66755374ffc381bc8e2d02b7ab568199461d95cb3fc5L326-R329) [[9]](diffhunk://#diff-226bbb012685b516d46f66755374ffc381bc8e2d02b7ab568199461d95cb3fc5L420-R423) [[10]](diffhunk://#diff-226bbb012685b516d46f66755374ffc381bc8e2d02b7ab568199461d95cb3fc5L507-R518) [[11]](diffhunk://#diff-226bbb012685b516d46f66755374ffc381bc8e2d02b7ab568199461d95cb3fc5L533-R536) [[12]](diffhunk://#diff-226bbb012685b516d46f66755374ffc381bc8e2d02b7ab568199461d95cb3fc5L584-R587) [[13]](diffhunk://#diff-dfda824ffe6d1ab5fe06d21e60b7da95231ef291e4e583ffba2f7b15422ca407L299-R299) [[14]](diffhunk://#diff-dfda824ffe6d1ab5fe06d21e60b7da95231ef291e4e583ffba2f7b15422ca407L390-R390) [[15]](diffhunk://#diff-dfda824ffe6d1ab5fe06d21e60b7da95231ef291e4e583ffba2f7b15422ca407L443-R452) [[16]](diffhunk://#diff-dfda824ffe6d1ab5fe06d21e60b7da95231ef291e4e583ffba2f7b15422ca407L487-R488) [[17]](diffhunk://#diff-dfda824ffe6d1ab5fe06d21e60b7da95231ef291e4e583ffba2f7b15422ca407L501-R502) [[18]](diffhunk://#diff-dfda824ffe6d1ab5fe06d21e60b7da95231ef291e4e583ffba2f7b15422ca407L530-R531)

### Documentation Updates

* All documentation comments are updated to refer to `RelationInstance` instead of `Materialised`, ensuring the documentation matches the new type names and clarifies the engine's internal terminology. [[1]](diffhunk://#diff-226bbb012685b516d46f66755374ffc381bc8e2d02b7ab568199461d95cb3fc5L127-R142) [[2]](diffhunk://#diff-226bbb012685b516d46f66755374ffc381bc8e2d02b7ab568199461d95cb3fc5L166-R169) [[3]](diffhunk://#diff-226bbb012685b516d46f66755374ffc381bc8e2d02b7ab568199461d95cb3fc5L187-R199) [[4]](diffhunk://#diff-226bbb012685b516d46f66755374ffc381bc8e2d02b7ab568199461d95cb3fc5L307-R316) [[5]](diffhunk://#diff-dfda824ffe6d1ab5fe06d21e60b7da95231ef291e4e583ffba2f7b15422ca407L443-R452) [[6]](diffhunk://#diff-dfda824ffe6d1ab5fe06d21e60b7da95231ef291e4e583ffba2f7b15422ca407L487-R488)

### Subquery Handling Type Renaming

* The type used for subquery handling in the projection and aggregation code is renamed from `Subquery` to `Resolution`, and all related function signatures and documentation are updated accordingly, improving code clarity. [[1]](diffhunk://#diff-dfda824ffe6d1ab5fe06d21e60b7da95231ef291e4e583ffba2f7b15422ca407L564-R574) [[2]](diffhunk://#diff-dfda824ffe6d1ab5fe06d21e60b7da95231ef291e4e583ffba2f7b15422ca407L1868-R1869) [[3]](diffhunk://#diff-dfda824ffe6d1ab5fe06d21e60b7da95231ef291e4e583ffba2f7b15422ca407L2797-R2798) [[4]](diffhunk://#diff-dfda824ffe6d1ab5fe06d21e60b7da95231ef291e4e583ffba2f7b15422ca407L2822-R2824) [[5]](diffhunk://#diff-dfda824ffe6d1ab5fe06d21e60b7da95231ef291e4e583ffba2f7b15422ca407L2847-R2848)

These changes collectively improve the consistency, clarity, and maintainability of the SQL engine codebase.