### PR TITLE
SQLEngine: bundle the context across calls

### DIFF
--- a/Sources/SQLEngine/Aggregate.swift
+++ b/Sources/SQLEngine/Aggregate.swift
@@ -303,9 +303,7 @@ extension Catalog where Self: ~Escapable {
   internal borrowing func grouped(_ records: Array<Record>,
                                   _ keys: Array<Term>,
                                   _ aggregates: Array<Aggregation>,
-                                  _ relations: ScopedRelations,
-                                  _ routines: Routines, _ bindings: Bindings,
-                                  _ subqueries: Subqueries)
+                                  _ context: Context)
       throws(SQLError) -> Array<Record> {
     var order = Array<Record>()
     var accumulators = Dictionary<Record, Array<Accumulator>>()
@@ -314,8 +312,7 @@ extension Catalog where Self: ~Escapable {
       var cells = Array<Value>()
       cells.reserveCapacity(keys.count)
       for key in keys {
-        try cells.append(evaluate(record, key, relations, routines, bindings,
-                                  subqueries))
+        try cells.append(evaluate(record, key, context))
       }
       let group = Record(cells)
       // Key the group on the EXACT canonical form of its cells so `1` and `1.0`
@@ -335,16 +332,14 @@ extension Catalog where Self: ~Escapable {
         // `:parameter`, skips), applied before the fold — and so before the
         // DISTINCT dedup. A filter-less aggregate folds every row.
         if let filter = aggregates[index].filter {
-          guard try evaluate(record, filter, relations, routines, bindings,
-                             subqueries) == true else {
+          guard try evaluate(record, filter, context) == true else {
             continue
           }
         }
         // `COUNT(*)` has no argument — count the row with a non-NULL sentinel;
         // every other aggregate folds its evaluated argument value.
         let value: Value = if let argument = aggregates[index].argument {
-          try evaluate(record, argument, relations, routines, bindings,
-                       subqueries)
+          try evaluate(record, argument, context)
         } else {
           .integer(0)
         }

--- a/Sources/SQLEngine/Context.swift
+++ b/Sources/SQLEngine/Context.swift
@@ -41,16 +41,48 @@ internal struct Context {
   /// (see `Catalog.subqueries(of:)`) just before executing the plan.
   internal let subqueries: Subqueries
 
-  /// A context over the three maps — an empty overlay and no bindings by
-  /// default, the shape a bare query with no `WITH` and no parameters runs
-  /// under. It carries no subquery results until `run` resolves them.
+  /// The cyclic-view guard — the view names currently under resolution, so a
+  /// view body that materialises itself (directly or through a derived table)
+  /// faults `SQLError.recursion` rather than resolving without end.
+  internal let visited: Set<String>
+
+  /// Whether a derived table's body is EAGER type-checked at resolution. A RUN
+  /// preflight, or a schema-only path after a run has proved the statement
+  /// runnable, passes `false` so a data-dependent-empty body expression an
+  /// execution never evaluates is not rejected; a strict schema check keeps it
+  /// `true`.
+  internal let validate: Bool
+
+  /// The resolution overlay a nested subquery lowers its cache key under —
+  /// `.caller` for a top-level compile, `.view(name)` for a view body's — so a
+  /// view-body occurrence and a top-level one over the same AST stay distinct
+  /// cache entries (see `Subscope`).
+  internal let subscope: Subscope
+
+  /// The enclosing correlation stack a nested subquery correlates against — the
+  /// `Outer` scopes an inner `WHERE` column that binds none of ITS relations
+  /// resolves outward through, lowering to a synthetic `Term.parameter` and
+  /// recording the correlation. `nil` at the top level (no enclosing query).
+  internal let outer: Outer?
+
+  /// A context over the maps and resolution scope — an empty overlay, no
+  /// bindings, an empty visited guard, eager validation, the caller scope, and
+  /// no enclosing correlation by default: the shape a bare top-level query with
+  /// no `WITH` and no parameters resolves and runs under. It carries no
+  /// subquery results until `run` resolves them.
   internal init(relations: ScopedRelations = [:], routines: Routines = [:],
                 bindings: Bindings = [:],
-                subqueries: Subqueries = Subqueries()) {
+                subqueries: Subqueries = Subqueries(),
+                visited: Set<String> = [], validate: Bool = true,
+                subscope: Subscope = .caller, outer: Outer? = nil) {
     self.relations = relations
     self.routines = routines
     self.bindings = bindings
     self.subqueries = subqueries
+    self.visited = visited
+    self.validate = validate
+    self.subscope = subscope
+    self.outer = outer
   }
 
   /// A copy of this context with `relations` REPLACING the overlay, the same
@@ -59,7 +91,23 @@ internal struct Context {
   /// recursive step rebinds a CTE's self.
   internal func scoping(_ relations: ScopedRelations) -> Context {
     Context(relations: relations, routines: routines, bindings: bindings,
-            subqueries: subqueries)
+            subqueries: subqueries, visited: visited, validate: validate,
+            subscope: subscope, outer: outer)
+  }
+
+  /// A copy of this context ENTERING a fresh body scope over `relations` — the
+  /// SINGLE derivation every view/derived-table/CTE body-entry seam routes
+  /// through, `scoping(relations)` with the enclosing correlation stack CLEARED
+  /// (`uncorrelated()`). A body scope — a view definition, a non-LATERAL derived
+  /// table, or a CTE — is resolved INDEPENDENTLY of its call site, so it must
+  /// NOT correlate against an enclosing query's row: an unbound column in the
+  /// body must fault rather than bind outward to the caller. Folding the reset
+  /// INTO body-entry makes the clear intrinsic — a future body seam that routes
+  /// through `body(_:)` cannot forget to append `uncorrelated()`. A site that
+  /// also guards the cyclic-view chain or gates the eager type-check chains
+  /// `visiting(_:)`/`validating(_:)` AFTER `body(_:)`.
+  internal func body(_ relations: ScopedRelations) -> Context {
+    scoping(relations).uncorrelated()
   }
 
   /// A copy of this context whose overlay binds `materialised` to `name` (folded
@@ -78,7 +126,8 @@ internal struct Context {
   /// row's cells before re-executing its inner plan.
   internal func binding(_ bindings: Bindings) -> Context {
     Context(relations: relations, routines: routines, bindings: bindings,
-            subqueries: subqueries)
+            subqueries: subqueries, visited: visited, validate: validate,
+            subscope: subscope, outer: outer)
   }
 
   /// A copy of this context carrying `subqueries` as the executing plan's
@@ -87,7 +136,8 @@ internal struct Context {
   /// off the SAME context that threads everywhere `execute` descends.
   internal func resolving(_ subqueries: Subqueries) -> Context {
     Context(relations: relations, routines: routines, bindings: bindings,
-            subqueries: subqueries)
+            subqueries: subqueries, visited: visited, validate: validate,
+            subscope: subscope, outer: outer)
   }
 
   /// A copy of this context with every enclosing SELECT's derived-table aliases
@@ -109,5 +159,67 @@ internal struct Context {
   /// derived tables into a fresh layer.
   internal func revealed() -> Context {
     scoping(relations.revealed())
+  }
+
+  /// A copy of this context with `name` (folded to lower case) ADDED to the
+  /// cyclic-view guard — the scope a view body resolves under, so a nested
+  /// reference back to the view faults `SQLError.recursion` rather than
+  /// resolving without end.
+  internal func visiting(_ name: String) -> Context {
+    var visited = visited
+    visited.insert(name.lowercased())
+    return Context(relations: relations, routines: routines,
+                   bindings: bindings, subqueries: subqueries,
+                   visited: visited, validate: validate, subscope: subscope,
+                   outer: outer)
+  }
+
+  /// A copy of this context with the eager-typecheck gate set to `flag` — a RUN
+  /// preflight or a post-run schema-only path passes `false` to keep a
+  /// data-dependent body lenient.
+  internal func validating(_ flag: Bool) -> Context {
+    Context(relations: relations, routines: routines, bindings: bindings,
+            subqueries: subqueries, visited: visited, validate: flag,
+            subscope: subscope, outer: outer)
+  }
+
+  /// A copy of this context resolving its nested subqueries under `subscope` —
+  /// `.view(name)` for a view body, `.caller` for a top-level compile — so an
+  /// occurrence's cache key carries the scope it lowered under.
+  internal func scoped(as subscope: Subscope) -> Context {
+    Context(relations: relations, routines: routines, bindings: bindings,
+            subqueries: subqueries, visited: visited, validate: validate,
+            subscope: subscope, outer: outer)
+  }
+
+  /// A copy of this context whose enclosing correlation stack is EXTENDED with
+  /// `scope` as the nearest enclosing one (`Outer.nested(under:)`, starting a
+  /// fresh stack at the top level) — the scope a nested subquery correlates
+  /// against, so an inner column binding none of its own relations resolves
+  /// outward and records the correlation.
+  internal func nesting(under scope: Scope) -> Context {
+    with(outer: (outer ?? Outer()).nested(under: scope))
+  }
+
+  /// A copy of this context carrying `outer` as its enclosing correlation stack
+  /// — the direct set a caller uses when it already holds the `Outer` a nested
+  /// subquery lowers against.
+  internal func with(outer: Outer?) -> Context {
+    Context(relations: relations, routines: routines, bindings: bindings,
+            subqueries: subqueries, visited: visited, validate: validate,
+            subscope: subscope, outer: outer)
+  }
+
+  /// A copy of this context with the enclosing correlation stack CLEARED — the
+  /// scope a body that must NOT correlate against the caller's row resolves
+  /// under: a view body and a non-LATERAL derived table body. Neither may see
+  /// an enclosing query's columns (a view is defined independently of its call
+  /// site; a derived table is uncorrelated), so an unbound column in either
+  /// must fault rather than bind outward to the caller. Every OTHER field —
+  /// the relation overlay, routines, bindings, subquery results, the visited
+  /// guard, the validate gate, and the subscope — is preserved; only `outer`
+  /// resets to `nil`, restoring the top-level default.
+  internal func uncorrelated() -> Context {
+    with(outer: nil)
   }
 }

--- a/Sources/SQLEngine/Context.swift
+++ b/Sources/SQLEngine/Context.swift
@@ -72,6 +72,15 @@ internal struct Context {
     return scoping(relations)
   }
 
+  /// A copy of this context with `bindings` REPLACING the parameter bindings,
+  /// the same overlay, routines, and subquery results — a correlated subquery's
+  /// per-outer-row rebinding, which extends the bindings with the enclosing
+  /// row's cells before re-executing its inner plan.
+  internal func binding(_ bindings: Bindings) -> Context {
+    Context(relations: relations, routines: routines, bindings: bindings,
+            subqueries: subqueries)
+  }
+
   /// A copy of this context carrying `subqueries` as the executing plan's
   /// materialised subquery results — the run path's extension just before it
   /// executes a compiled plan, so the row evaluator reads each subquery result

--- a/Sources/SQLEngine/Definition.swift
+++ b/Sources/SQLEngine/Definition.swift
@@ -204,8 +204,7 @@ extension Catalog where Self: ~Escapable {
   /// store: a run materialises the inner query's rows, a typing path resolves
   /// its OUTPUT columns to a schema-only relation (no cursor) and validates the
   /// inner body, so a derived table's alias types exactly as a run's would.
-  borrowing func augment(_ context: Context, for query: Query, rows: Bool,
-                         visited: Set<String> = [], validate: Bool = true)
+  borrowing func augment(_ context: Context, for query: Query, rows: Bool)
       throws(SQLError) -> Context {
     var names = Set<String>()
     query.collect(into: &names)
@@ -277,7 +276,13 @@ extension Catalog where Self: ~Escapable {
     // Revealing keeps a derived table UNCORRELATED/no-LATERAL — a sibling
     // `FROM` item lives in the layer being built, invisible to the revealed
     // base scope, so `FROM (…) AS a JOIN (SELECT v FROM a) AS b` faults `a`.
-    let scope = context.scoping(augmented.revealed())
+    // `uncorrelated()` likewise CLEARS the enclosing correlation stack: a
+    // non-LATERAL derived body must NOT see an ENCLOSING query's row either, so
+    // `… IN (SELECT x FROM (SELECT 1 AS x FROM S WHERE S.k = T.k) AS d)` faults
+    // on `T.k` — and CONSISTENTLY at both the strict schema pass and the
+    // run, rather than the strict pass binding it while the lenient run records
+    // no correlation and then faults at execution (a schema/run MISMATCH).
+    let scope = context.body(augmented.revealed())
     // The idempotent re-augment keys on the derivation IDENTITY, not the name.
     // The run→compile→typecheck chain each augments the query it receives, so
     // the innermost derived layer may ALREADY bind THIS select's aliases to
@@ -301,8 +306,7 @@ extension Catalog where Self: ~Escapable {
     var layer = Dictionary<String, RelationInstance>()
     for (alias, inner) in derivations {
       layer[alias.lowercased()] =
-          try materialise(inner, scope, rows: rows, visited: visited,
-                          validate: validate)
+          try materialise(inner, scope, rows: rows)
     }
     return context.scoping(augmented.pushing(layer))
   }
@@ -324,8 +328,7 @@ extension Catalog where Self: ~Escapable {
   /// schema and run paths bind the same nested aliases before either reads the
   /// inner query.
   private borrowing func materialise(_ query: Query, _ context: Context,
-                                     rows: Bool, visited: Set<String> = [],
-                                     validate: Bool = true)
+                                     rows: Bool)
       throws(SQLError) -> RelationInstance {
     // Bind the inner query's OWN derived tables (and store relations) before
     // deriving its schema — a run augments them recursively, so the schema
@@ -343,8 +346,7 @@ extension Catalog where Self: ~Escapable {
     // would EXECUTE a nested derived body once for the schema and AGAIN in that
     // run, so a stateful routine in a `FROM (SELECT tick() …)` nested a level
     // down would fire twice for one query.
-    let scope = try augment(context, for: query, rows: false, visited: visited,
-                            validate: validate)
+    let scope = try augment(context, for: query, rows: false)
     // The derived table's columns are its inner query's OUTPUT columns (the ISO
     // rule) — the FIRST arm's projection, the same arm the result-schema walk
     // and a CTE's declared list resolve against — typed against the augmented
@@ -360,8 +362,7 @@ extension Catalog where Self: ~Escapable {
     // NOT eager-type-checked before execution, exactly as the non-derived path
     // never evaluates an unreached operand — while the strict schema path
     // (`validate: true`) still faults it.
-    let outputs = try columns(of: query.first, scope, visited: visited,
-                              validate: validate)
+    let outputs = try columns(of: query.first, scope)
     // A derived table's columns are its inner query's OUTPUT names, so two
     // same-named ones (`SELECT Id AS x, V AS x`) leave the shadowed one
     // unreachable through the alias — exactly the case the Parser rejects for a
@@ -388,7 +389,7 @@ extension Catalog where Self: ~Escapable {
       // `false`. `validate: false` keeps it structural: the recursion guard
       // fires in `resolve` regardless, while a data-dependent operand a filter
       // drops is NOT eager-type-checked.
-      _ = try compile(query, context, visited, validate: false)
+      _ = try compile(query, context.validating(false))
       // A run captures the inner query's rows once (uncorrelated).
       captured = try run(query, context)
     } else {
@@ -414,9 +415,9 @@ extension Catalog where Self: ~Escapable {
       // the dropped layer — the layered overlay never overwrote it. The schema
       // walk validates the body's nested subqueries exactly as the run path
       // does (`run` compiles from the same base context).
-      if validate {
-        _ = try compile(query, context, visited, validate: true)
-        try typecheck(query, context, visited: visited)
+      if context.validate {
+        _ = try compile(query, context.validating(true))
+        try typecheck(query, context)
       }
       captured = []
     }
@@ -445,13 +446,17 @@ extension Catalog where Self: ~Escapable {
   /// execution happens at `derive`/run.
   borrowing func overlay(_ name: String, _ context: Context)
       throws(SQLError) -> Context {
-    let fresh = context.scoping([:])
+    // `uncorrelated()` CLEARS the caller's correlation stack: a view body is
+    // resolved independently of its call site, so it must NOT correlate against
+    // an enclosing row when the view is optimised from inside a correlated
+    // subquery.
+    let fresh = context.body([:])
     guard let view = resolve(view: name) else { return fresh }
     // `validate: false` — this overlay is the OPTIMISER's schema-only view-body
     // scope on the RUN path (`resolve`/`compile` already validated the body
     // under the caller's `validate`), so a data-dependent-empty derived body
     // the view nests must not be re-type-checked and fault a run.
-    return try augment(fresh, for: view.query, rows: false, validate: false)
+    return try augment(fresh.validating(false), for: view.query, rows: false)
   }
 
   /// The view named `name`, or `nil`, by the precedence a query name follows.
@@ -561,22 +566,25 @@ extension Catalog where Self: ~Escapable {
       // The body must compile AND its width must equal the view's DECLARED
       // column count: `resolve` rejects a view whose declared arity differs
       // from its body's (`v(x) AS SELECT * FROM People`), so such a view cannot
-      // run and is not advertised here.
-      guard let overlay = try? augment(context.scoping([:]), for: view.query,
-                                       rows: false),
-          let plan = try? compile(view.query, overlay, validate: true),
+      // run and is not advertised here. `uncorrelated()` CLEARS the correlation
+      // stack: a view body is defined independently of any call site, so the
+      // schema-only listing must resolve it exactly as the compile path does —
+      // never binding an unbound view-definition column to an enclosing row.
+      let fresh = context.body([:]).validating(true)
+      guard let overlay = try? augment(fresh, for: view.query, rows: false),
+          let plan = try? compile(view.query, overlay),
           plan.width == view.columns.count else { continue }
+      // The type-check and derive resolve the body under the cyclic-view guard
+      // seeded with THIS view's name.
+      let inner = overlay.visiting(name)
       // Type the columns from the body's first arm; type-check every arm's
       // REACHABLE operands and calls too — an unknown call or a bad operand in
       // a `WHERE`/`HAVING` or a later `UNION` arm faults a run, but the
       // first-arm resolve would miss it (`compile` cannot check a routine
       // exists), while an arm a short-circuit proves unreachable is skipped. A
       // view a `SELECT *` could not evaluate is not advertised.
-      guard (try? typecheck(view.query, overlay,
-                            visited: [name.lowercased()])) != nil,
-          let resolved = try? columns(of: view.query.first, overlay,
-                                      visited: [name.lowercased()],
-                                      validate: true),
+      guard (try? typecheck(view.query, inner)) != nil,
+          let resolved = try? columns(of: view.query.first, inner),
           resolved.count == view.columns.count else { continue }
       for ordinal in view.columns.indices {
         rows.append([.text(name), .text(view.columns[ordinal]),

--- a/Sources/SQLEngine/Engine.swift
+++ b/Sources/SQLEngine/Engine.swift
@@ -148,7 +148,7 @@ extension Catalog where Self: ~Escapable {
       // the preflight must not eager-type-check a derived body a data-dependent
       // filter never reaches (execution faults only on a REACHED operand),
       // matching the non-derived path.
-      _ = try compile(query, context, validate: false)
+      _ = try compile(query, context.validating(false))
       let combined = try combine(kind, run(left, context).map(Record.init),
                                  run(right, context).map(Record.init), all)
       return combined.map(\.values)
@@ -182,7 +182,7 @@ extension Catalog where Self: ~Escapable {
     // `SELECT Label + 1 FROM K WHERE k = 0` runs to zero rows. The eager body
     // type-check stays for the EXPLICIT schema path (`columns` `validate:
     // true`).
-    let logical = try compile(query, context, validate: false).pushdown()
+    let logical = try compile(query, context.validating(false)).pushdown()
     // Now that `compile` proved the query runnable, extend the overlay with any
     // `definition_schema.` store relation the query names (resolved lazily —
     // the overlay after the CTEs, before the base catalog) AND MATERIALISE this
@@ -200,8 +200,8 @@ extension Catalog where Self: ~Escapable {
     // would eager-type-check a doubly-nested filtered-out body on the RUN path.
     // The run stays lenient at every depth (the outer query already compiled,
     // and a REACHED operand still faults at execution).
-    let augmented = try augment(context, for: query, rows: true,
-                                validate: false)
+    let augmented = try augment(context.validating(false), for: query,
+                                rows: true)
     // Record the caller's overlay under `.caller` so a subquery lowered under
     // it (even one a pushdown moved INTO a view) re-runs against the caller's
     // relations, not the view's base. REVEAL the base first — this query's
@@ -277,8 +277,12 @@ extension Catalog where Self: ~Escapable {
         throw .redefinition(cte.name)
       }
       // The scope for this CTE's body: the base catalog plus every earlier CTE,
-      // over the run's routines and bindings.
-      let scope = context.scoping(relations)
+      // over the run's routines and bindings. `body(_:)` enters this fresh
+      // statement-scoped body with the correlation stack CLEARED — a CTE is
+      // resolved independently of any call site (a `WITH` is statement-level, so
+      // the stack is already empty here; routing through `body(_:)` keeps the
+      // clear intrinsic to entering a body scope rather than incidental).
+      let scope = context.body(relations)
       // Validate the CTE's SHAPE and ARITY against the CTEs done so far — the
       // compile-time structural check, shared with the dry-run schema path so a
       // derive rejects exactly the CTEs a run rejects. It faults the recursive
@@ -300,7 +304,7 @@ extension Catalog where Self: ~Escapable {
                            types: Array(repeating: .integer,
                                         count: cte.columns.count))
     }
-    return try run(query, context.scoping(relations))
+    return try run(query, context.body(relations))
   }
 
   /// Validates the SHAPE and declared ARITY of a single common table expression
@@ -377,9 +381,9 @@ extension Catalog where Self: ~Escapable {
     // CTE-self overlay.
     if cte.recursive && cte.recurses,
         case let .setop(.union, anchor, recursive, _) = cte.query {
-      let scope = try augment(context, for: anchor, rows: false,
-                              validate: typecheck)
-      let width = try compile(anchor, scope, validate: typecheck).width
+      let scope = try augment(context.validating(typecheck), for: anchor,
+                              rows: false)
+      let width = try compile(anchor, scope).width
       guard width == cte.columns.count else {
         throw .columns(expected: cte.columns.count, got: width)
       }
@@ -394,10 +398,9 @@ extension Catalog where Self: ~Escapable {
       // body in the arm that names the CTE (`FROM (SELECT n FROM a) AS d`)
       // resolves it — `augment` materialises derived bodies eagerly, so the
       // self must be in scope by then, not bound only afterwards.
-      let probe = try augment(context.binding(cte.name, to: empty),
-                              for: recursive, rows: false,
-                              validate: typecheck)
-      let arm = try compile(recursive, probe, validate: typecheck).width
+      let bound = context.binding(cte.name, to: empty).validating(typecheck)
+      let probe = try augment(bound, for: recursive, rows: false)
+      let arm = try compile(recursive, probe).width
       guard arm == cte.columns.count else {
         throw .columns(expected: cte.columns.count, got: arm)
       }
@@ -407,9 +410,9 @@ extension Catalog where Self: ~Escapable {
         try self.typecheck(recursive, probe)
       }
     } else {
-      let scope = try augment(context, for: cte.query, rows: false,
-                              validate: typecheck)
-      let width = try compile(cte.query, scope, validate: typecheck).width
+      let scope = try augment(context.validating(typecheck), for: cte.query,
+                              rows: false)
+      let width = try compile(cte.query, scope).width
       guard width == cte.columns.count else {
         throw .columns(expected: cte.columns.count, got: width)
       }
@@ -464,15 +467,15 @@ extension Catalog where Self: ~Escapable {
     // the CTE's arm nests must be TRUSTED, not eager-type-checked: a data-
     // dependent body expression a filter drops must not fault a CTE that runs
     // empty, matching the non-recursive and non-`WITH` paths.
-    let context = try augment(context, for: cte.query, rows: true,
-                              validate: false)
+    let context = try augment(context.validating(false), for: cte.query,
+                              rows: true)
     guard case let .setop(.union, anchor, recursive, all) = cte.query else {
       // A non-`UNION` recursive query runs once, but still binds under
       // `cte.columns`, so validate its compiled width here too — the check the
       // anchor and arm get. A body naming a base relation of the CTE's own name
       // (`WITH RECURSIVE Parent(x,y,z) AS (SELECT * FROM Parent)`) would else
       // bind narrow base rows under the wider list and trap on a later read.
-      let width = try compile(cte.query, context, validate: false).width
+      let width = try compile(cte.query, context).width
       guard width == cte.columns.count else {
         throw .columns(expected: cte.columns.count, got: width)
       }
@@ -490,7 +493,7 @@ extension Catalog where Self: ~Escapable {
     // arm reads the absent ordinal, rather than surfacing `SQLError.columns`.
     // The anchor is the base case and does not reference the CTE, so its width
     // resolves with the name not yet in scope.
-    let width = try compile(anchor, context, validate: false).width
+    let width = try compile(anchor, context).width
     guard width == cte.columns.count else {
       throw .columns(expected: cte.columns.count, got: width)
     }
@@ -503,7 +506,7 @@ extension Catalog where Self: ~Escapable {
                                  types: Array(repeating: .integer,
                                               count: cte.columns.count))
     let probe = context.binding(cte.name, to: empty)
-    let arm = try compile(recursive, probe, validate: false).width
+    let arm = try compile(recursive, probe).width
     guard arm == cte.columns.count else {
       throw .columns(expected: cte.columns.count, got: arm)
     }
@@ -1618,11 +1621,7 @@ extension Catalog where Self: ~Escapable {
   /// standard rule that every non-aggregated projection/`ORDER BY` column appear
   /// in the `GROUP BY`.
   internal borrowing func group(_ select: Select, _ relation: Relation,
-                                _ from: Resolved, _ context: Context,
-                                _ visited: Set<String>,
-                                _ subscope: Subscope = .caller,
-                                _ outer: Outer? = nil,
-                                validate: Bool)
+                                _ from: Resolved, _ context: Context)
       throws(SQLError) -> Plan {
     // The augmented `context` threads to `subquery(of:)`, which REVEALS the
     // base — this select's and every enclosing select's derived aliases
@@ -1636,8 +1635,7 @@ extension Catalog where Self: ~Escapable {
     var joined = Array<Resolved>()
     joined.reserveCapacity(select.joins.count)
     for join in select.joins {
-      try joined.append(resolve(join.relation, context, visited,
-                                validate: validate))
+      try joined.append(resolve(join.relation, context))
     }
     var relations = [(relation, from.schema)]
     for index in select.joins.indices {
@@ -1662,8 +1660,7 @@ extension Catalog where Self: ~Escapable {
     // and `ORDER BY` lower under a BARRED seam. `validate` gates the eager
     // type-check of a filtered-out derived body a nested subquery names, off on
     // the RUN path, on for a schema check.
-    let plans = try subquery(of: select, context, visited, subscope,
-                             enclosing: scope, outer: outer,
+    let plans = try subquery(of: select, context, enclosing: scope,
                              prefixes: prefixes)
     let barred = plans.rest.barred
     var matches = Array<Filter>()
@@ -2081,8 +2078,8 @@ extension Catalog where Self: ~Escapable {
     // body under the caller's `validate`, so an arm's data-dependent-empty
     // derived body must not be re-type-checked here and fault a run that its
     // filtered-out rows never reach.
-    return try optimise(plan, augment(overlay, for: query, rows: false,
-                                      validate: false))
+    return try optimise(plan, augment(overlay.validating(false), for: query,
+                                      rows: false))
   }
 
   // MARK: - Physical seek
@@ -2733,12 +2730,9 @@ extension Catalog where Self: ~Escapable {
   /// by the trailing arm's flag. The right arm must project the same column
   /// count as the query's first `SELECT` — the result columns — else
   /// `SQLError.arity`.
+  ///
   internal borrowing func compile(_ query: Query,
-                                  _ context: Context = Context(),
-                                  _ visited: Set<String> = [],
-                                  _ scope: Subscope = .caller,
-                                  _ outer: Outer? = nil,
-                                  validate: Bool)
+                                  _ context: Context = Context())
       throws(SQLError) -> Plan {
     // Bind the derived tables (and store relations) THIS query names in its own
     // FROM/JOIN before resolving its relations — SELECT-scoped, so a subquery
@@ -2759,11 +2753,9 @@ extension Catalog where Self: ~Escapable {
     // execution never evaluates is not rejected here (the outer query still
     // faults, and a REACHED body operand still faults at run), matching the
     // non-derived path; a schema check passes `true`.
-    let context = try augment(context, for: query, rows: false,
-                              visited: visited, validate: validate)
+    let context = try augment(context, for: query, rows: false)
     guard case let .setop(kind, left, right, all) = query else {
-      return try compile(query.first, context, visited, scope, outer,
-                         validate: validate)
+      return try compile(query.first, context)
     }
 
     // A set operation collects NO derived aliases at the query level — arms are
@@ -2775,22 +2767,15 @@ extension Catalog where Self: ~Escapable {
     // d` resolves `d`'s width. It is per arm so the left arm's `d` never
     // leaks to the right (the arm-scoping fix); the width each check computes
     // matches what the arm actually produces at run.
-    let head = try augment(context, for: .select(query.first),
-                           rows: false, visited: visited,
-                           validate: validate)
-    let tail = try augment(context, for: .select(right.first),
-                           rows: false, visited: visited,
-                           validate: validate)
-    let width = try arity(query.first, head, visited, validate: validate)
-    let count = try arity(right.first, tail, visited, validate: validate)
+    let head = try augment(context, for: .select(query.first), rows: false)
+    let tail = try augment(context, for: .select(right.first), rows: false)
+    let width = try arity(query.first, head)
+    let count = try arity(right.first, tail)
     guard count == width else { throw .arity(width, count) }
     // Both arms of a set-operation subquery correlate against the SAME
-    // enclosing scope, so each lowers under the shared `outer`.
-    return try .setop(kind,
-                      compile(left, context, visited, scope, outer,
-                              validate: validate),
-                      compile(right, context, visited, scope, outer,
-                              validate: validate), all: all)
+    // enclosing scope, so each lowers under the shared `context.outer`.
+    return try .setop(kind, compile(left, context), compile(right, context),
+                      all: all)
   }
 
   /// The distinct UNCORRELATED subqueries `select` nests, each COMPILED ONCE
@@ -2808,20 +2793,21 @@ extension Catalog where Self: ~Escapable {
   /// against the map by identity. A subquery compiles ONCE even if it appears
   /// twice; it RUNS at execution (see `subqueries(of:)`), UNCORRELATED so once.
   ///
-  /// `scope` is the resolution context these subqueries lower under — `.caller`
-  /// for a top-level compile, `.view(name)` for a view body's — carried into
-  /// each lowered `Filter`'s cache key so a view-body occurrence and a
-  /// top-level one over the same AST stay distinct entries (see `Subscope`).
+  /// `context.subscope` is the resolution context these subqueries lower under
+  /// — `.caller` for a top-level compile, `.view(name)` for a view body's —
+  /// carried into each lowered `Filter`'s cache key so a view-body occurrence
+  /// and a top-level one over the same AST stay distinct entries (see
+  /// `Subscope`).
   ///
   /// `enclosing` is the select's OWN resolution scope — the one its nested
   /// subqueries CORRELATE against: each nested query compiles under a fresh
-  /// `Outer` extending `outer` (this select's own enclosing scope, when it is
-  /// itself a subquery) with `enclosing` as the nearest scope, so a nested
-  /// query's inner `WHERE` column that binds none of ITS relations resolves
+  /// `Outer` extending `context.outer` (this select's own enclosing scope, when
+  /// it is itself a subquery) with `enclosing` the nearest scope, so a nested
+  /// query's inner `WHERE` column binding none of ITS relations resolves
   /// against the enclosing select (and outward), lowering to a synthetic
   /// `Term.parameter` and RECORDING the correlation the lowered node carries.
-  /// The returned `Resolution` also carries `outer` so THIS select's own
-  /// columns correlate outward when it is a subquery.
+  /// The returned `Resolution` also carries `context.outer` so THIS select's
+  /// own columns correlate outward when it is a subquery.
   ///
   /// `prefixes`, when supplied, gives the PREFIX scope each join `ON` lowers
   /// against — the FROM relation and joins `0…index`, never a relation joined
@@ -2833,9 +2819,7 @@ extension Catalog where Self: ~Escapable {
   /// non-join surface (WHERE/projection/HAVING/ORDER) correlates against
   /// `enclosing` as before.
   internal borrowing func subquery(of select: Select, _ context: Context,
-                                   _ visited: Set<String>,
-                                   _ scope: Subscope = .caller,
-                                   enclosing: Scope? = nil, outer: Outer? = nil,
+                                   enclosing: Scope? = nil,
                                    prefixes: Array<Scope> = [])
       throws(SQLError) -> Plans {
     // Resolve each SITE'S subqueries against THAT site's own scope, keyed PER
@@ -2851,8 +2835,7 @@ extension Catalog where Self: ~Escapable {
       var queries = Array<Query>()
       select.joins[index].on.collect(subqueries: &queries)
       let within = index < prefixes.count ? prefixes[index] : enclosing
-      try lowerings.append(subquery(queries, select, context, visited, scope,
-                                    within: within, outer: outer))
+      try lowerings.append(subquery(queries, select, context, within: within))
     }
     var rest = Array<Query>()
     select.predicate?.collect(subqueries: &rest)
@@ -2865,8 +2848,7 @@ extension Catalog where Self: ~Escapable {
         expression.collect(subqueries: &rest)
       }
     }
-    let remainder = try subquery(rest, select, context, visited, scope,
-                                 within: enclosing, outer: outer)
+    let remainder = try subquery(rest, select, context, within: enclosing)
     return Plans(lowerings, remainder)
   }
 
@@ -2877,9 +2859,7 @@ extension Catalog where Self: ~Escapable {
   /// is compiled ONCE here; the SAME inner SQL at a DIFFERENT site is resolved
   /// by that site's own call, against its own scope.
   private borrowing func subquery(_ queries: Array<Query>, _ select: Select,
-                                  _ context: Context, _ visited: Set<String>,
-                                  _ scope: Subscope, within: Scope?,
-                                  outer: Outer?)
+                                  _ context: Context, within: Scope?)
       throws(SQLError) -> Resolution {
     // A nested subquery's FROM resolves against base tables and enclosing CTEs,
     // NOT the enclosing SELECT's derived-table aliases (SELECT-scoped, unseen
@@ -2887,6 +2867,7 @@ extension Catalog where Self: ~Escapable {
     // CTEs/store relations kept, before compiling each subquery. Applied for
     // scalar, `IN`, and `EXISTS` alike (`select.subqueries` covers all three).
     let context = context.revealed()
+    let scope = context.subscope
     var widths = Dictionary<Query, Int>()
     var types = Dictionary<Query, ValueType>()
     var correlations = Dictionary<Query, Correlation>()
@@ -2901,7 +2882,11 @@ extension Catalog where Self: ~Escapable {
       // a grandparent one, resolved `.bound` and threaded through `bindings`,
       // while a genuinely-immediate correlation to a REAL enclosing FROM (a
       // non-nil `within`) stays `.slot` as before.
-      let nested = (outer ?? Outer()).nested(under: within ?? Scope([]))
+      let nested = (context.outer ?? Outer()).nested(under: within ?? Scope([]))
+      // The context each nested compile/derive threads: the revealed base with
+      // this frame's `nested` as the enclosing correlation stack and the
+      // shape-only lenience below.
+      let inner = context.with(outer: nested).validating(false)
       // A nested subquery's body derivation is SHAPE ONLY, so ALWAYS lenient
       // (`validate: false`) — this pass exists to record the subquery's width,
       // arity, and correlation, never to validate its body. Validation of a
@@ -2914,8 +2899,7 @@ extension Catalog where Self: ~Escapable {
       // whose `IN` a run short-circuits away. Structural faults (a bad inner
       // relation/column, a UNION arity) still surface — they resolve regardless
       // of `validate`. The type derivation below is already lenient.
-      let plan = try compile(query, context, visited, scope, nested,
-                             validate: false)
+      let plan = try compile(query, inner)
       widths[query] = plan.width
       // A scalar subquery contributes its single-column output type; a wider or
       // an `EXISTS`/`IN (Q)` subquery still records the FIRST column's type
@@ -2923,8 +2907,7 @@ extension Catalog where Self: ~Escapable {
       // rejects a wider one). It derives cursor-free against the SAME context
       // the width compile uses, so it matches what the run advertises.
       types[query] =
-          try columns(of: query.first, context, visited: visited,
-                      validate: false, outer: nested).first?.type
+          try columns(of: query.first, inner).first?.type
       // The correlation the nested compile discovered — the outer columns its
       // inner `WHERE`/`ON` named — carried into the lowered subquery node so the
       // per-outer-row re-execution binds them. Empty for an UNCORRELATED one.
@@ -2958,8 +2941,7 @@ extension Catalog where Self: ~Escapable {
           // itself (`typecheck(shape(of: reach), …)`), so validation stays the
           // walk's, never this shape-deriving pass'.
           let recorded = try role == .existential
-              ? compile(probed(query), context, visited, scope, nested,
-                        validate: false)
+              ? compile(probed(query), inner)
               : plan
           // Push selection down into the inner plan as the top-level `run` does
           // (line ~134), so a correlated re-execution enjoys the same seeks and
@@ -2973,7 +2955,8 @@ extension Catalog where Self: ~Escapable {
         }
       }
     }
-    return Resolution(scope, widths, types, correlations, outer: outer)
+    return Resolution(scope, widths, types, correlations,
+                      outer: context.outer)
   }
 
   /// The single VALUE a SCALAR subquery `query` collapses to against this
@@ -3053,9 +3036,7 @@ extension Catalog where Self: ~Escapable {
   /// its relations, else the count of its projected items — for the `UNION`
   /// arity check. The relations resolve through this catalog, the overlay
   /// consulted first.
-  private borrowing func arity(_ select: Select, _ context: Context,
-                               _ visited: Set<String>,
-                               validate: Bool)
+  private borrowing func arity(_ select: Select, _ context: Context)
       throws(SQLError) -> Int {
     switch select.projection {
     case .all:
@@ -3063,12 +3044,9 @@ extension Catalog where Self: ~Escapable {
       guard let relation = select.from else {
         throw .named("SELECT * with no FROM")
       }
-      var width =
-          try resolve(relation, context, visited, validate: validate)
-              .schema.width
+      var width = try resolve(relation, context).schema.width
       for join in select.joins {
-        try width += resolve(join.relation, context, visited,
-                             validate: validate).schema.width
+        try width += resolve(join.relation, context).schema.width
       }
       return width
     case let .columns(columns):
@@ -3114,9 +3092,7 @@ extension Catalog where Self: ~Escapable {
   /// `definition_schema.` store's `columns` builder, which compiles every view
   /// to advertise it, relies on this: a cyclic view's `try? compile` catches
   /// the fault and skips it.
-  internal borrowing func resolve(_ relation: Relation, _ context: Context,
-                                  _ visited: Set<String> = [],
-                                  validate: Bool = true)
+  internal borrowing func resolve(_ relation: Relation, _ context: Context)
       throws(SQLError) -> Resolved {
     let name = relation.name
     if let cte = context.relations[name.lowercased()] {
@@ -3132,7 +3108,7 @@ extension Catalog where Self: ~Escapable {
       // stack overflow, not an `SQLError`). `visited` names the views already
       // being resolved down this chain; re-encountering one is a cyclic
       // definition, reported as `.recursion` rather than hung.
-      guard !visited.contains(name.lowercased()) else {
+      guard !context.visited.contains(name.lowercased()) else {
         throw .recursion(name)
       }
       // The view body compiles OUTSIDE the caller's statement CTEs, but it may
@@ -3156,20 +3132,24 @@ extension Catalog where Self: ~Escapable {
       // (`FROM (SELECT * FROM <self>) AS d`) re-enters `augment`/`materialise`
       // with the view already visited and faults `.recursion` here rather than
       // recursing to a stack overflow.
-      let inner = visited.union([name.lowercased()])
-      // `validate` threads into the view body's schema-only augment + compile
-      // so a RUN (`validate: false`) resolving `FROM <view>` does NOT eager-
-      // type-check a data-dependent-empty derived body the view nests — as the
-      // lenient run of the same query inline; a schema check keeps it strict.
+      // `context.validate` threads into the view body's schema-only augment +
+      // compile so a RUN (`validate: false`) resolving `FROM <view>` does NOT
+      // eager-type-check a data-dependent-empty derived body the view nests —
+      // as the lenient inline run does; a schema check keeps it strict.
+      // `uncorrelated()` CLEARS the caller's correlation stack: a view is
+      // defined independently of its call site, so its body must NOT correlate
+      // against an enclosing row when the view is queried from inside a
+      // correlated subquery. Without it an unbound column in the view
+      // DEFINITION would bind to the caller's row rather than fault.
       let overlay =
-          try augment(context.scoping([:]), for: view.query, rows: false,
-                      visited: inner, validate: validate)
+          try augment(context.body([:]).visiting(name),
+                      for: view.query, rows: false)
       // The body's subqueries resolve under the VIEW's overlay — never the
       // caller's — so lower them under `.view(name)`, keeping a view-body
       // occurrence and a top-level one over the same AST distinct entries.
       let plan =
-          try compile(view.query, overlay, inner, .view(name.lowercased()),
-                      validate: validate)
+          try compile(view.query,
+                      overlay.scoped(as: .view(name.lowercased())))
       let projected = plan.width
       guard view.columns.count == projected else {
         throw .columns(expected: projected, got: view.columns.count)
@@ -3212,12 +3192,9 @@ extension Catalog where Self: ~Escapable {
   /// cells concatenated in order). The tree is logical: every scan is a full
   /// `Scan(_, _, nil)`; the optimiser turns scans into seeks and each product
   /// into a join.
+  ///
   internal borrowing func compile(_ select: Select,
-                                  _ context: Context = Context(),
-                                  _ visited: Set<String> = [],
-                                  _ subscope: Subscope = .caller,
-                                  _ outer: Outer? = nil,
-                                  validate: Bool)
+                                  _ context: Context = Context())
       throws(SQLError) -> Plan {
     // Bind THIS select's own FROM/JOIN derived tables (and store relations)
     // before resolving its relations — SELECT-scoped, so a select reaching
@@ -3239,8 +3216,7 @@ extension Catalog where Self: ~Escapable {
     // relations kept — so a subquery's FROM sees no derived alias while a CTE
     // a same-named derived alias here shadows stays visible. The layered
     // overlay never overwrote the CTE, so no separate pre-augment context runs.
-    let context = try augment(context, for: .select(select), rows: false,
-                              visited: visited, validate: validate)
+    let context = try augment(context, for: .select(select), rows: false)
     guard let relation = select.from else {
       // A FROM-less select projects expressions over a single row; a `WHERE`,
       // `GROUP BY`, `HAVING`, `ORDER BY`, `OFFSET`/`FETCH`, or `JOIN` has no
@@ -3268,12 +3244,11 @@ extension Catalog where Self: ~Escapable {
       // `Schema.terms`) BARS it — a projection is a barred clause position — so
       // a correlated column of THIS query is diagnosed, not lowered to a
       // `Term.parameter`, matching `columns(of:)`'s schema-path rejection.
-      let plans = try subquery(of: select, context, visited, subscope,
-                               outer: outer)
+      let plans = try subquery(of: select, context)
       return try select.projection.scalar(context.routines,
                                           subquery: plans.rest)
     }
-    let from = try resolve(relation, context, visited, validate: validate)
+    let from = try resolve(relation, context)
 
     if let limit = select.limit {
       // The parser yields only non-negative counts (a `-` is its own token), but
@@ -3290,8 +3265,7 @@ extension Catalog where Self: ~Escapable {
     // `HAVING`, and `ORDER BY` against the grouped slot space. A non-aggregate
     // query compiles exactly as before.
     if select.aggregates {
-      return try group(select, relation, from, context, visited, subscope,
-                       outer, validate: validate)
+      return try group(select, relation, from, context)
     }
 
     guard !select.joins.isEmpty else {
@@ -3301,8 +3275,7 @@ extension Catalog where Self: ~Escapable {
       // scope (`enclosing`). This select's OWN columns correlate outward through
       // `outer`.
       let enclosing = Scope([(relation, from.schema)])
-      let plans = try subquery(of: select, context, visited, subscope,
-                               enclosing: enclosing, outer: outer)
+      let plans = try subquery(of: select, context, enclosing: enclosing)
       var filter: Filter? = nil
       if let predicate = select.predicate {
         filter = try from.schema.lower(predicate, in: relation,
@@ -3355,8 +3328,7 @@ extension Catalog where Self: ~Escapable {
     var joined = Array<Resolved>()
     joined.reserveCapacity(select.joins.count)
     for join in select.joins {
-      try joined.append(resolve(join.relation, context, visited,
-                                validate: validate))
+      try joined.append(resolve(join.relation, context))
     }
 
     var relations = [(relation, from.schema)]
@@ -3389,8 +3361,7 @@ extension Catalog where Self: ~Escapable {
     // against its PREFIX scope; the WHERE/projection/ORDER against the whole
     // join `scope`. This select's OWN columns correlate outward through `outer`.
     // `validate` gates a nested filtered-out derived body's eager type-check.
-    let plans = try subquery(of: select, context, visited, subscope,
-                             enclosing: scope, outer: outer,
+    let plans = try subquery(of: select, context, enclosing: scope,
                              prefixes: prefixes)
     var matches = Array<Filter>()
     matches.reserveCapacity(select.joins.count)

--- a/Sources/SQLEngine/Filter.swift
+++ b/Sources/SQLEngine/Filter.swift
@@ -734,7 +734,8 @@ extension Row where Self: ~Escapable {
   internal borrowing func evaluate(_ term: Term, _ routines: Routines,
                                    _ bindings: Bindings = [:])
       throws(SQLError) -> Value {
-    try NoCatalog().evaluate(self, term, [:], routines, bindings)
+    try NoCatalog().evaluate(self, term,
+                             Context(routines: routines, bindings: bindings))
   }
 }
 
@@ -748,11 +749,7 @@ extension Catalog where Self: ~Escapable {
   /// runs it). The `borrowing` row is non-escaping — a term runs over a
   /// materialised projection record or a predicate's borrowed cursor row.
   internal borrowing func evaluate(_ row: borrowing some Row & ~Escapable,
-                                   _ term: Term,
-                                   _ relations: ScopedRelations,
-                                   _ routines: Routines,
-                                   _ bindings: Bindings = [:],
-                                   _ subqueries: Subqueries = Subqueries())
+                                   _ term: Term, _ context: Context)
       throws(SQLError) -> Value {
     switch term {
     case let .slot(slot):
@@ -762,17 +759,13 @@ extension Catalog where Self: ~Escapable {
       // enclosing row's cell, merged in by the per-outer-row re-execution. An
       // unbound name reads `.null` (a comparison against it is UNKNOWN), exactly
       // as a `Filter.bound` operand resolves an absent parameter.
-      bindings[name] ?? .null
+      context.bindings[name] ?? .null
     case let .constant(value):
       value
     case let .apply(name, arguments):
-      try apply(row, name, arguments, relations, routines, bindings,
-                subqueries)
+      try apply(row, name, arguments, context)
     case let .binary(op, lhs, rhs):
-      try op.apply(evaluate(row, lhs, relations, routines, bindings,
-                            subqueries),
-                   evaluate(row, rhs, relations, routines, bindings,
-                            subqueries))
+      try op.apply(evaluate(row, lhs, context), evaluate(row, rhs, context))
     case let .case(branches, otherwise, type):
       // Take the FIRST branch whose guard is three-valued TRUE (UNKNOWN and
       // FALSE skip); with none matching, the `else` term, or `NULL` when there
@@ -783,19 +776,16 @@ extension Catalog where Self: ~Escapable {
       // unified result `type` so it matches the column type the schema
       // advertised. A scalar subquery in an UNREACHED arm is never evaluated,
       // so it never runs (never throws) — the lazy `.subquery` case honours it.
-      try conditional(row, branches, otherwise, type, relations, routines,
-                      bindings, subqueries)
+      try conditional(row, branches, otherwise, type, context)
     case let .cast(operand, type):
       // Evaluate the operand and CONVERT it to the target type: NULL casts to
       // NULL, an unconvertible value faults (`Value.cast(to:)`), never yielding
       // a wrong value.
-      try evaluate(row, operand, relations, routines, bindings, subqueries)
-          .cast(to: type)
+      try evaluate(row, operand, context).cast(to: type)
     case let .coalesce(elements, type):
-      try coalesce(row, elements, type, relations, routines, bindings,
-                   subqueries)
+      try coalesce(row, elements, type, context)
     case let .nullif(lhs, rhs):
-      try nullif(row, lhs, rhs, relations, routines, bindings, subqueries)
+      try nullif(row, lhs, rhs, context)
     case let .subquery(key, correlation, type):
       // Materialise the scalar subquery LAZILY on this first reach — an
       // occurrence in a skipped `CASE`/`COALESCE` arm is never reached, so it
@@ -803,8 +793,7 @@ extension Catalog where Self: ~Escapable {
       // column's type, as a `CASE` coerces its selected arm. An UNCORRELATED one
       // memoises; a CORRELATED one re-runs against this row's correlated
       // bindings.
-      try scalar(row, key, correlation, type, relations, routines, bindings,
-                 subqueries)
+      try scalar(row, key, correlation, type, context)
     }
   }
 
@@ -858,14 +847,11 @@ extension Catalog where Self: ~Escapable {
   /// shared `context`.
   private borrowing func executed(_ row: borrowing some Row & ~Escapable,
                                   _ key: Subkey, _ correlation: Correlation,
-                                  _ overlay: ScopedRelations,
-                                  _ routines: Routines, _ bindings: Bindings,
-                                  _ subqueries: Subqueries)
+                                  _ context: Context)
       throws(SQLError) -> Array<Record> {
-    let bindings = correlated(row, correlation, bindings)
-    let context = Context(relations: overlay, routines: routines,
-                          bindings: bindings, subqueries: subqueries)
-    guard let plan = subqueries.plan(key, correlation) else {
+    let bindings = correlated(row, correlation, context.bindings)
+    let context = context.binding(bindings)
+    guard let plan = context.subqueries.plan(key, correlation) else {
       throw .named("a correlated subquery plan was not compiled")
     }
     // A SET-OPERATION plan augments PER ARM (arm-local derived aliases the
@@ -910,14 +896,14 @@ extension Catalog where Self: ~Escapable {
   /// correlated bindings, never touching the memo.
   private borrowing func present(_ row: borrowing some Row & ~Escapable,
                                  _ key: Subkey, _ correlation: Correlation,
-                                 _ relations: ScopedRelations,
-                                 _ routines: Routines, _ bindings: Bindings,
-                                 _ subqueries: Subqueries)
+                                 _ context: Context)
       throws(SQLError) -> Bool {
     // Run under the overlay the occurrence's SCOPE was lowered under — the
     // caller's or the view body's — not the current execution site a pushdown
     // may have moved this predicate to.
-    let overlay = subqueries.overlay(key.scope) ?? relations
+    let context =
+        context.scoping(context.subqueries.overlay(key.scope)
+                        ?? context.relations)
     // A CORRELATED EXISTS re-executes its PRE-COMPILED PROBE plan (correlated
     // columns are bound `Term.parameter`s; the plan is the cardinality-only
     // probed shape, so its select list — a would-fault `1 / 0` — never runs)
@@ -925,14 +911,11 @@ extension Catalog where Self: ~Escapable {
     // memo (the result depends on the row). An UNCORRELATED one memoises and
     // probes cardinality once, the SAME probed shape.
     guard correlation.isEmpty else {
-      return try !executed(row, key, correlation, overlay, routines, bindings,
-                           subqueries).isEmpty
+      return try !executed(row, key, correlation, context).isEmpty
     }
-    let context = Context(relations: overlay, routines: routines,
-                          bindings: bindings, subqueries: subqueries)
-    if let cached = subqueries.present(cached: key) { return cached }
+    if let cached = context.subqueries.present(cached: key) { return cached }
     let present = try probe(key.query, context)
-    subqueries.store(present: present, for: key)
+    context.subqueries.store(present: present, for: key)
     return present
   }
 
@@ -942,23 +925,20 @@ extension Catalog where Self: ~Escapable {
   /// the correlated bindings, bypassing the memo.
   private borrowing func values(_ row: borrowing some Row & ~Escapable,
                                 _ key: Subkey, _ correlation: Correlation,
-                                _ relations: ScopedRelations,
-                                _ routines: Routines, _ bindings: Bindings,
-                                _ subqueries: Subqueries)
+                                _ context: Context)
       throws(SQLError) -> Array<Value> {
-    let overlay = subqueries.overlay(key.scope) ?? relations
+    let context =
+        context.scoping(context.subqueries.overlay(key.scope)
+                        ?? context.relations)
     // A CORRELATED `IN (Q)` re-executes its PRE-COMPILED inner plan against this
     // row's correlated bindings for its lone column, bypassing the memo. An
     // UNCORRELATED one memoises and re-runs its `Query` (recompiling resolves).
     guard correlation.isEmpty else {
-      return try executed(row, key, correlation, overlay, routines, bindings,
-                          subqueries).map { $0.values[0] }
+      return try executed(row, key, correlation, context).map { $0.values[0] }
     }
-    let context = Context(relations: overlay, routines: routines,
-                          bindings: bindings, subqueries: subqueries)
-    if let cached = subqueries.values(cached: key) { return cached }
+    if let cached = context.subqueries.values(cached: key) { return cached }
     let values = try run(key.query, context).map { $0[0] }
-    subqueries.store(values: values, for: key)
+    context.subqueries.store(values: values, for: key)
     return values
   }
 
@@ -973,30 +953,26 @@ extension Catalog where Self: ~Escapable {
   /// COERCED to the inner column's `type`, as a `CASE` coerces its taken arm.
   private borrowing func scalar(_ row: borrowing some Row & ~Escapable,
                                 _ key: Subkey, _ correlation: Correlation,
-                                _ type: ValueType,
-                                _ relations: ScopedRelations,
-                                _ routines: Routines, _ bindings: Bindings,
-                                _ subqueries: Subqueries)
+                                _ type: ValueType, _ context: Context)
       throws(SQLError) -> Value {
-    let overlay = subqueries.overlay(key.scope) ?? relations
+    let context =
+        context.scoping(context.subqueries.overlay(key.scope)
+                        ?? context.relations)
     // A CORRELATED scalar subquery re-executes its PRE-COMPILED inner plan per
     // outer row against the correlated bindings, collapsing to its lone cell
     // (empty → NULL, one row → the cell, more → `.cardinality`), bypassing the
     // memo (its cell depends on the row). An UNCORRELATED one memoises and
     // re-runs its `Query`.
     guard correlation.isEmpty else {
-      let rows = try executed(row, key, correlation, overlay, routines,
-                              bindings, subqueries)
+      let rows = try executed(row, key, correlation, context)
       guard rows.count <= 1 else { throw .cardinality }
       return (rows.first?.values.first ?? .null).coerced(to: type)
     }
-    let context = Context(relations: overlay, routines: routines,
-                          bindings: bindings, subqueries: subqueries)
-    if let cached = subqueries.scalar(cached: key) {
+    if let cached = context.subqueries.scalar(cached: key) {
       return cached.coerced(to: type)
     }
     let value = try cell(of: key.query, context)
-    subqueries.store(scalar: value, for: key)
+    context.subqueries.store(scalar: value, for: key)
     return value.coerced(to: type)
   }
 
@@ -1012,13 +988,10 @@ extension Catalog where Self: ~Escapable {
   /// NULL passes unchanged.
   private borrowing func coalesce(_ row: borrowing some Row & ~Escapable,
                                   _ elements: Array<Term>, _ type: ValueType,
-                                  _ relations: ScopedRelations,
-                                  _ routines: Routines, _ bindings: Bindings,
-                                  _ subqueries: Subqueries)
+                                  _ context: Context)
       throws(SQLError) -> Value {
     for element in elements {
-      let value = try evaluate(row, element, relations, routines, bindings,
-                               subqueries)
+      let value = try evaluate(row, element, context)
       if case .null = value { continue }
       return value.coerced(to: type)
     }
@@ -1035,13 +1008,10 @@ extension Catalog where Self: ~Escapable {
   /// three-valued: only a definite TRUE equality nulls out, so an UNKNOWN (a
   /// NULL operand) yields `va`.
   private borrowing func nullif(_ row: borrowing some Row & ~Escapable,
-                                _ lhs: Term, _ rhs: Term,
-                                _ relations: ScopedRelations,
-                                _ routines: Routines, _ bindings: Bindings,
-                                _ subqueries: Subqueries)
+                                _ lhs: Term, _ rhs: Term, _ context: Context)
       throws(SQLError) -> Value {
-    let va = try evaluate(row, lhs, relations, routines, bindings, subqueries)
-    let vb = try evaluate(row, rhs, relations, routines, bindings, subqueries)
+    let va = try evaluate(row, lhs, context)
+    let vb = try evaluate(row, rhs, context)
     return matches(va, .equal, vb) == true ? .null : va
   }
 
@@ -1057,39 +1027,30 @@ extension Catalog where Self: ~Escapable {
   private borrowing func conditional(_ row: borrowing some Row & ~Escapable,
                                      _ branches: Array<(Filter, Term)>,
                                      _ otherwise: Term?, _ type: ValueType,
-                                     _ relations: ScopedRelations,
-                                     _ routines: Routines,
-                                     _ bindings: Bindings,
-                                     _ subqueries: Subqueries)
+                                     _ context: Context)
       throws(SQLError) -> Value {
     for (gate, result) in branches {
-      if try evaluate(row, gate, relations, routines, bindings,
-                      subqueries) == true {
-        return try evaluate(row, result, relations, routines, bindings,
-                            subqueries).coerced(to: type)
+      if try evaluate(row, gate, context) == true {
+        return try evaluate(row, result, context).coerced(to: type)
       }
     }
     guard let otherwise else { return .null }
-    return try evaluate(row, otherwise, relations, routines, bindings,
-                        subqueries).coerced(to: type)
+    return try evaluate(row, otherwise, context).coerced(to: type)
   }
 
   /// Resolves `name` in `routines` and applies it to its `arguments` evaluated
   /// against `row`.
   private borrowing func apply(_ row: borrowing some Row & ~Escapable,
                                _ name: String, _ arguments: Array<Term>,
-                               _ relations: ScopedRelations,
-                               _ routines: Routines, _ bindings: Bindings,
-                               _ subqueries: Subqueries)
+                               _ context: Context)
       throws(SQLError) -> Value {
-    guard let routine = routines[name] else {
+    guard let routine = context.routines[name] else {
       throw .function(name)
     }
     var values = Array<Value>()
     values.reserveCapacity(arguments.count)
     for argument in arguments {
-      try values.append(evaluate(row, argument, relations, routines, bindings,
-                                 subqueries))
+      try values.append(evaluate(row, argument, context))
     }
     let result = try routine(values)
     // A registered routine is a public producer of `Value`s that bypasses the
@@ -1315,7 +1276,8 @@ extension Row where Self: ~Escapable {
   internal borrowing func evaluate(_ filter: Filter, _ routines: Routines,
                                    _ bindings: Bindings)
       throws(SQLError) -> Bool? {
-    try NoCatalog().evaluate(self, filter, [:], routines, bindings)
+    try NoCatalog().evaluate(self, filter,
+                             Context(routines: routines, bindings: bindings))
   }
 }
 
@@ -1338,42 +1300,29 @@ extension Catalog where Self: ~Escapable {
   /// row is non-escaping; it threads into the recursion freely and is never
   /// stored.
   internal borrowing func evaluate(_ row: borrowing some Row & ~Escapable,
-                                   _ filter: Filter,
-                                   _ relations: ScopedRelations,
-                                   _ routines: Routines,
-                                   _ bindings: Bindings,
-                                   _ subqueries: Subqueries = Subqueries())
+                                   _ filter: Filter, _ context: Context)
       throws(SQLError) -> Bool? {
     switch filter {
     case let .compare(lhs, op, rhs):
-      try matches(evaluate(row, lhs, relations, routines, bindings,
-                           subqueries), op,
-                  evaluate(row, rhs, relations, routines, bindings,
-                           subqueries))
+      try matches(evaluate(row, lhs, context), op, evaluate(row, rhs, context))
     case let .bound(term, op, parameter):
-      if let operand = bindings[parameter] {
-        try matches(evaluate(row, term, relations, routines, bindings,
-                             subqueries), op, operand)
+      if let operand = context.bindings[parameter] {
+        try matches(evaluate(row, term, context), op, operand)
       } else {
         nil
       }
     case let .match(left, right):
       matches(row[left], .equal, row[right])
     case let .null(term, negated):
-      try (evaluate(row, term, relations, routines, bindings,
-                    subqueries) == .null) != negated
+      try (evaluate(row, term, context) == .null) != negated
     case let .membership(operand, elements, negated):
-      try member(row, operand, elements, negated, relations, routines,
-                 bindings, subqueries)
+      try member(row, operand, elements, negated, context)
     case let .like(operand, pattern, escape, negated):
-      try like(row, operand, pattern, escape, negated, relations, routines,
-               bindings, subqueries)
+      try like(row, operand, pattern, escape, negated, context)
     case let .between(test, lower, upper, negated):
-      try ranged(row, test, lower, upper, negated, relations, routines,
-                 bindings, subqueries)
+      try ranged(row, test, lower, upper, negated, context)
     case let .distinct(lhs, rhs, negated):
-      try differs(row, lhs, rhs, negated, relations, routines, bindings,
-                  subqueries)
+      try differs(row, lhs, rhs, negated, context)
     case let .exists(key, correlation, negated):
       // The DEFINITE two-valued `EXISTS` non-empty test — never UNKNOWN,
       // `negated` flipping it. The subquery runs LAZILY on this first reach (so
@@ -1381,17 +1330,14 @@ extension Catalog where Self: ~Escapable {
       // guards never runs): an UNCORRELATED one memoises under its `Subkey`; a
       // CORRELATED one re-runs against this row's correlated bindings, bypassing
       // the memo.
-      try present(row, key, correlation, relations, routines, bindings,
-                  subqueries) != negated
+      try present(row, key, correlation, context) != negated
     case let .within(operand, key, correlation, negated):
       // Fold `operand = v` over the subquery's single column under the SAME
       // three-valued membership the value-list `IN` uses. The column is
       // materialised LAZILY on this first reach (an UNCORRELATED one memoised, a
       // CORRELATED one re-run per row against this row's correlated bindings).
-      try member(row, operand,
-                 values(row, key, correlation, relations, routines, bindings,
-                        subqueries),
-                 negated, relations, routines, bindings, subqueries)
+      try member(row, operand, values(row, key, correlation, context),
+                 negated, context)
     case let .quantified(operand, op, quantifier, key, correlation):
       // Fold `operand op v` over the subquery's single column with the SAME
       // `matches`/Kleene primitives `within` uses — Kleene `OR` (seeded FALSE)
@@ -1400,41 +1346,33 @@ extension Catalog where Self: ~Escapable {
       // UNCORRELATED one memoises under its `Subkey`, a CORRELATED one re-runs
       // its inner plan per outer row against this row's correlated bindings.
       try quantified(row, operand, op, quantifier,
-                     values(row, key, correlation, relations, routines,
-                            bindings, subqueries),
-                     relations, routines, bindings, subqueries)
+                     values(row, key, correlation, context), context)
     case let .truth(inner, value, negated):
-      try tested(evaluate(row, inner, relations, routines, bindings,
-                          subqueries), value, negated)
+      try tested(evaluate(row, inner, context), value, negated)
     case let .and(lhs, rhs):
       // `&&`/`||` take an `@autoclosure` right operand, which would capture the
       // borrowed `~Escapable` row; spell each connective explicitly so a branch
       // re-borrows the row rather than capturing it. Kleene `AND`: `false`
       // dominates, an UNKNOWN left yields `false` only against a `false` right.
-      switch try evaluate(row, lhs, relations, routines, bindings,
-                          subqueries) {
+      switch try evaluate(row, lhs, context) {
       case false?: false
       case true?:
-        try evaluate(row, rhs, relations, routines, bindings, subqueries)
+        try evaluate(row, rhs, context)
       case nil:
-        try evaluate(row, rhs, relations, routines, bindings,
-                     subqueries) == false ? false : nil
+        try evaluate(row, rhs, context) == false ? false : nil
       }
     case let .or(lhs, rhs):
       // Kleene `OR`: `true` dominates, an UNKNOWN left yields `true` only
       // against a `true` right.
-      switch try evaluate(row, lhs, relations, routines, bindings,
-                          subqueries) {
+      switch try evaluate(row, lhs, context) {
       case true?: true
       case false?:
-        try evaluate(row, rhs, relations, routines, bindings, subqueries)
+        try evaluate(row, rhs, context)
       case nil:
-        try evaluate(row, rhs, relations, routines, bindings,
-                     subqueries) == true ? true : nil
+        try evaluate(row, rhs, context) == true ? true : nil
       }
     case let .not(operand):
-      try evaluate(row, operand, relations, routines, bindings,
-                   subqueries).map { !$0 }
+      try evaluate(row, operand, context).map { !$0 }
     }
   }
 
@@ -1450,17 +1388,12 @@ extension Catalog where Self: ~Escapable {
   /// `map(!)`.
   private borrowing func member(_ row: borrowing some Row & ~Escapable,
                                 _ operand: Term, _ elements: Array<Term>,
-                                _ negated: Bool,
-                                _ relations: ScopedRelations,
-                                _ routines: Routines, _ bindings: Bindings,
-                                _ subqueries: Subqueries)
+                                _ negated: Bool, _ context: Context)
       throws(SQLError) -> Bool? {
-    let value = try evaluate(row, operand, relations, routines, bindings,
-                             subqueries)
+    let value = try evaluate(row, operand, context)
     var truth: Bool? = false
     for element in elements {
-      let element = try evaluate(row, element, relations, routines, bindings,
-                                 subqueries)
+      let element = try evaluate(row, element, context)
       truth = or(truth, matches(value, .equal, element))
       if truth == true { break }
     }
@@ -1480,13 +1413,9 @@ extension Catalog where Self: ~Escapable {
   /// the value-list `IN` does, so the two forms share one three-valued core.
   private borrowing func member(_ row: borrowing some Row & ~Escapable,
                                 _ operand: Term, _ values: Array<Value>,
-                                _ negated: Bool,
-                                _ relations: ScopedRelations,
-                                _ routines: Routines, _ bindings: Bindings,
-                                _ subqueries: Subqueries)
+                                _ negated: Bool, _ context: Context)
       throws(SQLError) -> Bool? {
-    let value = try evaluate(row, operand, relations, routines, bindings,
-                             subqueries)
+    let value = try evaluate(row, operand, context)
     var truth: Bool? = false
     for element in values {
       truth = or(truth, matches(value, .equal, element))
@@ -1511,13 +1440,9 @@ extension Catalog where Self: ~Escapable {
   private borrowing func quantified(_ row: borrowing some Row & ~Escapable,
                                     _ operand: Term, _ op: Comparison,
                                     _ quantifier: Quantifier,
-                                    _ values: Array<Value>,
-                                    _ relations: ScopedRelations,
-                                    _ routines: Routines, _ bindings: Bindings,
-                                    _ subqueries: Subqueries)
+                                    _ values: Array<Value>, _ context: Context)
       throws(SQLError) -> Bool? {
-    let value = try evaluate(row, operand, relations, routines, bindings,
-                             subqueries)
+    let value = try evaluate(row, operand, context)
     var truth: Bool? = quantifier == .any ? false : true
     for element in values {
       let matched = matches(value, op, element)
@@ -1563,18 +1488,13 @@ extension Catalog where Self: ~Escapable {
   private borrowing func ranged(_ row: borrowing some Row & ~Escapable,
                                 _ test: Term, _ lower: Filter.Operand,
                                 _ upper: Filter.Operand, _ negated: Bool,
-                                _ relations: ScopedRelations,
-                                _ routines: Routines, _ bindings: Bindings,
-                                _ subqueries: Subqueries)
+                                _ context: Context)
       throws(SQLError) -> Bool? {
-    let value = try evaluate(row, test, relations, routines, bindings,
-                             subqueries)
-    let low = try evaluate(row, lower, relations, routines, bindings,
-                           subqueries)
+    let value = try evaluate(row, test, context)
+    let low = try evaluate(row, lower, context)
     let above = matches(value, .geq, low)
     guard above != false else { return negated }
-    let high = try evaluate(row, upper, relations, routines, bindings,
-                            subqueries)
+    let high = try evaluate(row, upper, context)
     let within = and(above, matches(value, .leq, high))
     return negated ? within.map { !$0 } : within
   }
@@ -1590,15 +1510,10 @@ extension Catalog where Self: ~Escapable {
   /// UNKNOWN.
   private borrowing func differs(_ row: borrowing some Row & ~Escapable,
                                  _ lhs: Term, _ rhs: Term, _ negated: Bool,
-                                 _ relations: ScopedRelations,
-                                 _ routines: Routines, _ bindings: Bindings,
-                                 _ subqueries: Subqueries)
+                                 _ context: Context)
       throws(SQLError) -> Bool? {
-    let differ =
-        try distinct(evaluate(row, lhs, relations, routines, bindings,
-                              subqueries),
-                     evaluate(row, rhs, relations, routines, bindings,
-                              subqueries))
+    let differ = try distinct(evaluate(row, lhs, context),
+                              evaluate(row, rhs, context))
     return negated ? !differ : differ
   }
 
@@ -1606,16 +1521,13 @@ extension Catalog where Self: ~Escapable {
   /// against `row`, a `:parameter` resolves from the bindings — an unbound name
   /// yields `.null`, so it reads UNKNOWN exactly as a bound `NULL` does.
   private borrowing func evaluate(_ row: borrowing some Row & ~Escapable,
-                                  _ operand: Filter.Operand,
-                                  _ relations: ScopedRelations,
-                                  _ routines: Routines, _ bindings: Bindings,
-                                  _ subqueries: Subqueries)
+                                  _ operand: Filter.Operand, _ context: Context)
       throws(SQLError) -> Value {
     switch operand {
     case let .term(term):
-      try evaluate(row, term, relations, routines, bindings, subqueries)
+      try evaluate(row, term, context)
     case let .parameter(name):
-      bindings[name] ?? .null
+      context.bindings[name] ?? .null
     }
   }
 
@@ -1637,20 +1549,16 @@ extension Catalog where Self: ~Escapable {
   private borrowing func like(_ row: borrowing some Row & ~Escapable,
                               _ operand: Term, _ pattern: Filter.Operand,
                               _ escape: Filter.Operand?, _ negated: Bool,
-                              _ relations: ScopedRelations,
-                              _ routines: Routines, _ bindings: Bindings,
-                              _ subqueries: Subqueries)
+                              _ context: Context)
       throws(SQLError) -> Bool? {
     // Evaluate all three reached operands once, in order — a fault in any of
     // them (a divide, an overflow) propagates HERE, before the NULL/escape
     // result below can turn it into a silent UNKNOWN.
-    let subject = try evaluate(row, operand, relations, routines, bindings,
-                               subqueries)
-    let template = try evaluate(row, pattern, relations, routines, bindings,
-                                subqueries)
+    let subject = try evaluate(row, operand, context)
+    let template = try evaluate(row, pattern, context)
     let separator: Value? =
         if let escape {
-          try evaluate(row, escape, relations, routines, bindings, subqueries)
+          try evaluate(row, escape, context)
         } else {
           nil
         }

--- a/Sources/SQLEngine/Filter.swift
+++ b/Sources/SQLEngine/Filter.swift
@@ -860,7 +860,7 @@ extension Catalog where Self: ~Escapable {
       return try arms(plan, key.query, context)
     }
     let augmented =
-        try augment(context, for: key.query, rows: true, validate: false)
+        try augment(context.validating(false), for: key.query, rows: true)
     return try execute(plan, augmented)
   }
 
@@ -886,7 +886,7 @@ extension Catalog where Self: ~Escapable {
                          arms(right, rightQuery, context), all)
     }
     let augmented =
-        try augment(context, for: query, rows: true, validate: false)
+        try augment(context.validating(false), for: query, rows: true)
     return try execute(plan, augmented)
   }
 

--- a/Sources/SQLEngine/Operator.swift
+++ b/Sources/SQLEngine/Operator.swift
@@ -750,7 +750,7 @@ extension Catalog where Self: ~Escapable {
                                  _ ordinals: Array<Int>, _ seek: Range<Int>?,
                                  _ context: Context)
       throws(SQLError) -> Array<Record> {
-    var overlay = context.scoping([:])
+    var overlay = context.body([:])
     if let view = resolve(view: name) {
       // EXECUTION-path materialise (`rows: true`): a nested derived body's
       // schema is derived schema-only inside `materialise`, so `validate:
@@ -759,10 +759,12 @@ extension Catalog where Self: ~Escapable {
       // Seed the cyclic-view guard with THIS view's own name, as
       // `resolve(view:)` does, so a body materialising this view through a
       // derived table (`FROM (SELECT * FROM <self>) AS d`) faults `.recursion`
-      // in `materialise` rather than re-running the body without end.
-      let visited: Set<String> = [name.lowercased()]
-      overlay = try augment(context.scoping([:]), for: view.query, rows: true,
-                            visited: visited, validate: false)
+      // in `materialise` rather than re-running the body without end. `body([:])`
+      // enters the view-body scope with the caller's correlation stack CLEARED,
+      // so a nested derived body's schema (derived while `augment`/`materialise`
+      // resolves it) cannot bind an unbound column outward to an enclosing row.
+      let fresh = context.body([:]).visiting(name).validating(false)
+      overlay = try augment(fresh, for: view.query, rows: true)
       // Record the view body's OWN overlay under `.view(name)` so its LAZY
       // subqueries re-run against the view's base relations, while a caller
       // conjunct PUSHED into this body keeps its `.caller` overlay and re-runs
@@ -844,7 +846,7 @@ extension Catalog where Self: ~Escapable {
       return try combine(kind, setop(left, leftQuery, overlay, name),
                          setop(right, rightQuery, overlay, name), all)
     }
-    let scope = try augment(overlay, for: query, rows: true, validate: false)
+    let scope = try augment(overlay.validating(false), for: query, rows: true)
     scope.subqueries.record(overlay: scope.revealed().relations,
                             for: .view(name))
     return try execute(plan, scope)

--- a/Sources/SQLEngine/Operator.swift
+++ b/Sources/SQLEngine/Operator.swift
@@ -314,11 +314,6 @@ extension Plan {
 extension Catalog where Self: ~Escapable {
   internal borrowing func execute(_ plan: Plan, _ context: Context)
       throws(SQLError) -> Array<Record> {
-    let routines = context.routines
-    let bindings = context.bindings
-    // The plan's UNCORRELATED subquery results, run ONCE at run start and read
-    // by the row evaluator wherever an `EXISTS`/`IN (Q)` predicate evaluates.
-    let subqueries = context.subqueries
     switch plan {
     case .single:
       // The FROM-less single row: one record with no cells, the source a scalar
@@ -332,11 +327,9 @@ extension Catalog where Self: ~Escapable {
       // Fuse a residual product with its filter: stream each pair through the
       // predicate rather than materialising the whole cross product first.
       return try sift(execute(outer, context), execute(inner, context),
-                      filter, context.relations, routines, bindings,
-                      subqueries)
+                      filter, context)
     case let .select(filter, source):
-      return try admitted(execute(source, context), filter, context.relations,
-                          routines, bindings, subqueries)
+      return try admitted(execute(source, context), filter, context)
     case let .project(terms, source):
       // An explicit loop, not a `.map` closure: the borrowed `~Escapable` self
       // a projected scalar subquery materialises against cannot be captured by
@@ -345,8 +338,7 @@ extension Catalog where Self: ~Escapable {
       var projected = Array<Record>()
       projected.reserveCapacity(source.count)
       for record in source {
-        try projected.append(project(terms, record, context.relations,
-                                     routines, bindings, subqueries))
+        try projected.append(project(terms, record, context))
       }
       return projected
     case let .sort(keys, source):
@@ -365,8 +357,7 @@ extension Catalog where Self: ~Escapable {
         var cells = Array<Value>()
         cells.reserveCapacity(keys.count)
         for key in keys {
-          try cells.append(evaluate(record, key.term, context.relations,
-                                    routines, bindings, subqueries))
+          try cells.append(evaluate(record, key.term, context))
         }
         sortable.append(cells)
       }
@@ -397,14 +388,13 @@ extension Catalog where Self: ~Escapable {
       // yields no rows to read a width off.
       return try outer(execute(left, context), left.slots ?? 0,
                        execute(right, context), right.slots ?? 0, on, kind,
-                       context.relations, routines, bindings, subqueries)
+                       context)
     case let .setop(kind, left, right, all):
       return try setop(kind, left, right, all, context)
     case let .distinct(source):
       return deduplicated(try execute(source, context))
     case let .aggregate(keys, aggregates, source):
-      return try grouped(execute(source, context), keys, aggregates,
-                         context.relations, routines, bindings, subqueries)
+      return try grouped(execute(source, context), keys, aggregates, context)
     case let .limit(count, offset, source):
       return limited(try execute(source, context), count, offset)
     }
@@ -415,15 +405,12 @@ extension Catalog where Self: ~Escapable {
   /// and `relations` thread through so a projected scalar subquery materialises
   /// lazily on first reach (see the evaluator's `.subquery` case).
   private borrowing func project(_ terms: Array<Term>, _ record: Record,
-                                 _ relations: ScopedRelations,
-                                 _ routines: Routines, _ bindings: Bindings,
-                                 _ subqueries: Subqueries)
+                                 _ context: Context)
       throws(SQLError) -> Record {
     var cells = Array<Value>()
     cells.reserveCapacity(terms.count)
     for term in terms {
-      try cells.append(evaluate(record, term, relations, routines, bindings,
-                                subqueries))
+      try cells.append(evaluate(record, term, context))
     }
     return Record(cells)
   }
@@ -433,14 +420,11 @@ extension Catalog where Self: ~Escapable {
   /// scalar calls through `routines` and parameters from `bindings`. This
   /// catalog and `relations` thread through for a scalar subquery in `filter`.
   private borrowing func admitted(_ records: Array<Record>, _ filter: Filter,
-                                  _ relations: ScopedRelations,
-                                  _ routines: Routines, _ bindings: Bindings,
-                                  _ subqueries: Subqueries)
+                                  _ context: Context)
       throws(SQLError) -> Array<Record> {
     var kept = Array<Record>()
     for record in records {
-      if try evaluate(record, filter, relations, routines, bindings,
-                      subqueries) == true {
+      if try evaluate(record, filter, context) == true {
         kept.append(record)
       }
     }
@@ -460,16 +444,13 @@ extension Catalog where Self: ~Escapable {
   /// UNKNOWN and `false` both drop, exactly as `admitted`.
   private borrowing func sift(_ outer: Array<Record>,
                               _ inner: Array<Record>, _ filter: Filter,
-                              _ relations: ScopedRelations,
-                              _ routines: Routines, _ bindings: Bindings,
-                              _ subqueries: Subqueries)
+                              _ context: Context)
       throws(SQLError) -> Array<Record> {
     var records = Array<Record>()
     for left in outer {
       for right in inner {
         let record = left.merged(with: right)
-        if try evaluate(record, filter, relations, routines, bindings,
-                        subqueries) == true {
+        if try evaluate(record, filter, context) == true {
           records.append(record)
         }
       }
@@ -501,9 +482,7 @@ extension Catalog where Self: ~Escapable {
   private borrowing func outer(_ left: Array<Record>, _ leftWidth: Int,
                                _ right: Array<Record>, _ rightWidth: Int,
                                _ on: Filter, _ kind: Join.Kind,
-                               _ relations: ScopedRelations,
-                               _ routines: Routines, _ bindings: Bindings,
-                               _ subqueries: Subqueries)
+                               _ context: Context)
       throws(SQLError) -> Array<Record> {
     let leftNulls = Record(Array(repeating: .null, count: leftWidth))
     let rightNulls = Record(Array(repeating: .null, count: rightWidth))
@@ -519,8 +498,7 @@ extension Catalog where Self: ~Escapable {
         var paired = false
         for lhs in left {
           let record = lhs.merged(with: inner)
-          if try evaluate(record, on, relations, routines, bindings,
-                          subqueries) == true {
+          if try evaluate(record, on, context) == true {
             records.append(record)
             paired = true
           }
@@ -539,8 +517,7 @@ extension Catalog where Self: ~Escapable {
       var paired = false
       for index in right.indices {
         let record = lhs.merged(with: right[index])
-        if try evaluate(record, on, relations, routines, bindings,
-                        subqueries) == true {
+        if try evaluate(record, on, context) == true {
           records.append(record)
           matched[index] = true
           paired = true
@@ -962,9 +939,6 @@ extension Catalog where Self: ~Escapable {
                                   _ keys: (left: Int, right: Int),
                                   _ filter: Filter?, _ context: Context)
       throws(SQLError) -> Array<Record> {
-    let routines = context.routines
-    let bindings = context.bindings
-    let subqueries = context.subqueries
     // A materialised CTE inner has no sort key, so it is scanned in full and
     // the equality on its `keys.right` slot is the join's truth — the same
     // probe a base relation falls back to when its key is unseekable. A pushed
@@ -976,8 +950,7 @@ extension Catalog where Self: ~Escapable {
       for index in 0 ..< cte.rows.count {
         let right = cte.record(index, ordinals)
         if let filter,
-            try evaluate(right, filter, context.relations, routines, bindings,
-                         subqueries) != true { continue }
+            try evaluate(right, filter, context) != true { continue }
         inner.append(right)
       }
       return joined(outer, inner, base, keys)
@@ -985,8 +958,7 @@ extension Catalog where Self: ~Escapable {
     guard let inner = table(named: name) else { throw .relation(name) }
     guard inner.seekable(column) else {
       return try inner.hashed(outer, ordinals, base, keys, filter, self,
-                              context.relations, routines, bindings,
-                              subqueries)
+                              context)
     }
 
     let cursor = inner.cursor()
@@ -1008,8 +980,7 @@ extension Catalog where Self: ~Escapable {
         // A pushed inner filter is applied as each candidate materialises,
         // before it can pair — an inner row it rejects joins to nothing.
         if let filter,
-            try evaluate(right, filter, context.relations, routines, bindings,
-                         subqueries) != true { continue }
+            try evaluate(right, filter, context) != true { continue }
         // Equal by the SAME rule the predicate uses — integer/integer exact,
         // mixed integer/double promoted — so a seek that scanned wide still
         // pairs exactly.
@@ -1054,10 +1025,7 @@ extension Table where Self: ~Escapable {
                                        _ keys: (left: Int, right: Int),
                                        _ filter: Filter?,
                                        _ catalog: borrowing C,
-                                       _ relations: ScopedRelations,
-                                       _ routines: Routines,
-                                       _ bindings: Bindings,
-                                       _ subqueries: Subqueries)
+                                       _ context: Context)
       throws(SQLError) -> Array<Record> where C: Catalog & ~Escapable {
     guard outer.contains(where: {
       if case .null = $0[keys.left] { false } else { true }
@@ -1068,7 +1036,7 @@ extension Table where Self: ~Escapable {
     // Seek the inner by the pushed filter's seekable conjunct, so a
     // seekable/contradictory inner filter reads few or no rows; scan the whole
     // inner when the filter has none (or when there is no filter).
-    let range = seek(filter, ordinals, cursor.count, bindings)
+    let range = seek(filter, ordinals, cursor.count, context.bindings)
     var buckets = Dictionary<Value, Array<Record>>()
     for index in range {
       guard let row = cursor.row(index) else { continue }
@@ -1076,8 +1044,7 @@ extension Table where Self: ~Escapable {
       // Apply the whole pushed filter before bucketing — a filtered inner row
       // is never a join candidate.
       if let filter,
-          try catalog.evaluate(right, filter, relations, routines, bindings,
-                               subqueries) != true { continue }
+          try catalog.evaluate(right, filter, context) != true { continue }
       if case .null = right[slot] { continue }
       buckets[bucket(right[slot]), default: Array<Record>()].append(right)
     }

--- a/Sources/SQLEngine/OutputColumn.swift
+++ b/Sources/SQLEngine/OutputColumn.swift
@@ -83,7 +83,7 @@ extension Catalog where Self: ~Escapable {
     // Pure engine: it types calls against exactly the `routines` given, seeding
     // no prelude. `import SQLStandard` adds a prelude-defaulting overload
     // (`columns(of:validate:)`). A typing path has no bindings.
-    let context = Context(routines: routines)
+    let context = Context(routines: routines).validating(validate)
     // Extend the scope with any `definition_schema.` store relation the query
     // names, so its result schema resolves the reserved relation the same as a
     // run would — SCHEMA-ONLY, so typing never triggers the row build. A
@@ -91,15 +91,14 @@ extension Catalog where Self: ~Escapable {
     // derive after a run trusts the body rather than re-checking a reachable
     // operand a data-dependent filter never reached (matching the non-derived
     // path, whose empty run never evaluates it).
-    let scope = try augment(context, for: query, rows: false,
-                            validate: validate)
+    let scope = try augment(context, for: query, rows: false)
     // Validate the whole query without executing — the same compile the run
     // path drives, resolving every arm and cross-checking a UNION's arity — so
     // a schema is returned only for a query that could actually run. `validate`
     // threads through: a `validate: false` derive after a run must NOT eager-
     // type-check a derived body in a subquery a data-dependent filter dropped,
     // matching the run's lenient compile.
-    _ = try compile(query, scope, validate: validate)
+    _ = try compile(query, scope)
     // Type-check every REACHABLE operand and call across all arms — the
     // projection, `WHERE`, and `HAVING` of each. `compile` resolves a call's
     // arguments but cannot check the routine EXISTS or that it is called with
@@ -118,7 +117,7 @@ extension Catalog where Self: ~Escapable {
     // `SELECT *` over a view derives the body's types WITHOUT re-type-checking
     // it — the view body's own reachable-operand check is gated the same as the
     // outer query's, so a `validate: false` derive faults nowhere.
-    return try columns(of: query.first, scope, validate: validate)
+    return try columns(of: query.first, scope)
   }
 
   /// The result columns `statement` would yield, named and typed, resolved
@@ -200,7 +199,7 @@ extension Catalog where Self: ~Escapable {
                                  routines: Routines,
                                  validate: Bool)
       throws(SQLError) -> Array<OutputColumn> {
-    let context = Context(routines: routines)
+    let context = Context(routines: routines).validating(validate)
     var overlay = ScopedRelations()
     for cte in ctes {
       // A name repeated in the list (case-insensitively) would silently shadow
@@ -234,7 +233,7 @@ extension Catalog where Self: ~Escapable {
       if validate {
         // `self.` escapes the shadow the `validate` Bool parameter casts over
         // the shared `validate(_:against:)` engine helper.
-        try self.validate(cte, against: context.scoping(overlay),
+        try self.validate(cte, against: context.body(overlay),
                           typecheck: true)
       }
       // Bind the CTE's schema-only self into the overlay AFTER its body is
@@ -254,10 +253,10 @@ extension Catalog where Self: ~Escapable {
     // data-dependent body expression a filter drops (`FROM (SELECT Label + 1 AS
     // x FROM K WHERE k = 0) AS d`) is TRUSTED, not rejected, matching the run.
     // `validate: true` keeps the strict schema check.
-    let base = context.scoping(overlay)
-    _ = try compile(query, base, validate: validate)
+    let base = context.body(overlay)
+    _ = try compile(query, base)
     if validate { try typecheck(query, base) }
-    return try columns(of: query.first, base, validate: validate)
+    return try columns(of: query.first, base)
   }
 
   /// The result columns of a single `select`, resolved against this catalog
@@ -269,13 +268,11 @@ extension Catalog where Self: ~Escapable {
   /// duplicates (and never drifts from) that resolution. It runs only after
   /// compilation has proved the arm resolves. `routines` are the scalar
   /// routines a call types from — its declared return type — rather than the
-  /// `.integer` default. `validate` (default `true`) rides through to any view
+  /// `.integer` default. The context's `validate` rides through to any view
   /// this arm's relations resolve, gating the view body's reachable-operand
-  /// check the same as the outer query's — a `validate: false` derive never
+  /// check the same as the outer query's — a `validate: false` context never
   /// re-type-checks a view body a run already proved runnable.
-  borrowing func columns(of select: Select, _ context: Context,
-                         visited: Set<String> = [],
-                         validate: Bool, outer: Outer? = nil)
+  borrowing func columns(of select: Select, _ context: Context)
       throws(SQLError) -> Array<OutputColumn> {
     // Bind THIS select's own FROM/JOIN derived tables (and store relations)
     // before deriving either the subquery map or the scope — a set-op ARM
@@ -284,8 +281,7 @@ extension Catalog where Self: ~Escapable {
     // subquery naming the arm's own derived alias (`WHERE Id IN (SELECT Id FROM
     // d)`) would else compile against a scope missing `d`. Schema-only, no
     // cursor; `validate` gates a derived body's own operand check.
-    let augmented = try augment(context, for: .select(select), rows: false,
-                                visited: visited, validate: validate)
+    let augmented = try augment(context, for: .select(select), rows: false)
     // A scalar subquery in the projection derives its type from its inner
     // query's single column, so build the SAME cursor-free `Resolution` map the
     // compile path's lowering reads — every nested subquery compiled ONCE for
@@ -298,18 +294,18 @@ extension Catalog where Self: ~Escapable {
     // arm-local derived alias binds it, while `subquery(of:)` REVEALS the base
     // so the subquery's OWN FROM sees no derived alias (a CTE a same-named
     // derived alias shadows resolved beneath the dropped layer).
-    let scope = try scope(of: select, augmented, visited: visited,
-                          validate: validate)
+    let scope = try scope(of: select, augmented)
     // Pass each join's PREFIX scope so an `ON`'s subquery correlates against its
     // prefix and the WHERE's against the full scope — the SAME per-occurrence
     // resolution the run path uses, so a name a WHERE subquery finds ambiguous in
     // the full scope faults HERE too (typecheck↔run parity), not silently reusing
     // an `ON` occurrence's narrower prefix.
-    let prefixes = try prefixes(of: select, augmented, visited: visited,
-                                validate: validate)
-    let plans = try subquery(of: select, augmented, visited, .caller,
-                             enclosing: scope, outer: outer,
-                             prefixes: prefixes)
+    let prefixes = try prefixes(of: select, augmented)
+    // These derivations lower under `.caller` — a schema-only type derive keys
+    // its subqueries in the caller id space regardless of an enclosing view
+    // scope the incoming context may carry.
+    let plans = try subquery(of: select, augmented.scoped(as: .caller),
+                             enclosing: scope, prefixes: prefixes)
     return try scope.columns(of: select.projection, augmented.routines,
                              subquery: plans.rest.barred)
   }
@@ -318,12 +314,10 @@ extension Catalog where Self: ~Escapable {
   /// relation resolved to schema and laid end to end in one combined ordinal
   /// space, the same layout compilation resolves a projection against. A
   /// FROM-less `SELECT <expr-list>` projects over no relation, so its scope is
-  /// empty. It reads only schemas, never a cursor. `validate` (default `true`)
+  /// empty. It reads only schemas, never a cursor. The context's `validate`
   /// rides through to each relation's `schema(of:)`, gating a view body's
   /// reachable-operand check the same as the outer query's.
-  borrowing func scope(of select: Select, _ context: Context,
-                       visited: Set<String> = [],
-                       validate: Bool)
+  borrowing func scope(of select: Select, _ context: Context)
       throws(SQLError) -> Scope {
     // Bind THIS select's own FROM/JOIN derived tables (and store relations)
     // before resolving its relations — SELECT-scoped, so a subquery select
@@ -332,16 +326,11 @@ extension Catalog where Self: ~Escapable {
     // carries the cyclic-view guard into a derived body's materialise, and
     // `validate` gates that body's own reachable-operand check the same as the
     // outer query's — a `validate: false` derive trusts a run-proven body.
-    let context =
-        try augment(context, for: .select(select), rows: false,
-                    visited: visited, validate: validate)
+    let context = try augment(context, for: .select(select), rows: false)
     guard let relation = select.from else { return Scope([]) }
-    var relations =
-        [(relation, try schema(of: relation, context, visited: visited,
-                               validate: validate))]
+    var relations = [(relation, try schema(of: relation, context))]
     for join in select.joins {
-      let joined = try schema(of: join.relation, context, visited: visited,
-                              validate: validate)
+      let joined = try schema(of: join.relation, context)
       relations.append((join.relation, joined))
     }
     return Scope(relations)
@@ -352,17 +341,12 @@ extension Catalog where Self: ~Escapable {
   /// point, never one joined LATER. A join `ON`'s subquery correlates against
   /// its prefix (so a reference to a later-joined relation faults), matching the
   /// compile path's `subquery(of:)`. Empty for a FROM-less or join-less select.
-  private borrowing func prefixes(of select: Select, _ context: Context,
-                                  visited: Set<String>,
-                                  validate: Bool)
+  private borrowing func prefixes(of select: Select, _ context: Context)
       throws(SQLError) -> Array<Scope> {
     guard let relation = select.from, !select.joins.isEmpty else { return [] }
-    var relations =
-        [(relation, try schema(of: relation, context, visited: visited,
-                               validate: validate))]
+    var relations = [(relation, try schema(of: relation, context))]
     for join in select.joins {
-      let joined = try schema(of: join.relation, context, visited: visited,
-                              validate: validate)
+      let joined = try schema(of: join.relation, context)
       relations.append((join.relation, joined))
     }
     return select.joins.indices.map { index in
@@ -381,8 +365,7 @@ extension Catalog where Self: ~Escapable {
   /// `Aggregate.fold` faults `SQLError.operand` at run. `compile` cannot catch
   /// this (no evaluating term is built), so a schema path type-checks each arm
   /// before returning metadata. It reads no cursor.
-  borrowing func typecheck(_ query: Query, _ context: Context,
-                           visited: Set<String> = [], outer: Outer? = nil)
+  borrowing func typecheck(_ query: Query, _ context: Context)
       throws(SQLError) {
     // Bind the derived tables (and store relations) THIS query names in its own
     // FROM/JOIN before type-checking its arms — SELECT-scoped, so a subquery
@@ -393,16 +376,19 @@ extension Catalog where Self: ~Escapable {
     // query's derived aliases — its type-check lowers against the base
     // `subqueryCheck` REVEALS from the augmented `context` (enclosing derived
     // aliases dropped, CTEs and store kept, a shadowed CTE preserved).
-    let context = try augment(context, for: query, rows: false,
-                              visited: visited)
+    // The type-check subtree resolves its scopes strictly (`validate: true`),
+    // as its internal `scope`/`prefixes`/`schema` calls always did — force it
+    // on regardless of the incoming context's gate (a caller reaches here only
+    // when validating).
+    let context = try augment(context.validating(true), for: query, rows: false)
     switch query {
     case let .select(select):
-      try typecheck(select, context, visited: visited, outer: outer)
+      try typecheck(select, context)
     case let .setop(_, left, right, _):
       // Both arms of a set-operation subquery correlate against the same
-      // enclosing scope, so each type-checks under the shared `outer`.
-      try typecheck(left, context, visited: visited, outer: outer)
-      try typecheck(right, context, visited: visited, outer: outer)
+      // enclosing scope, so each type-checks under the shared `context.outer`.
+      try typecheck(left, context)
+      try typecheck(right, context)
     }
   }
 
@@ -460,9 +446,7 @@ extension Catalog where Self: ~Escapable {
   /// original is checked. The arity width is always the ORIGINAL query's
   /// (cursor-free), as `subquery(of:)` records it on the compile path.
   private borrowing func subqueryCheck(of select: Select, _ context: Context,
-                                       visited: Set<String>,
                                        enclosing: Scope? = nil,
-                                       outer: Outer? = nil,
                                        prefixes: Array<Scope> = [])
       throws(SQLError) -> SubqueryCheck {
     // Every occurrence's inner-query OPERAND validation DEFERS to the
@@ -516,9 +500,9 @@ extension Catalog where Self: ~Escapable {
       select.joins[index].on.collect(subqueries: &queries)
       let within = index < prefixes.count ? prefixes[index] : enclosing
       for query in queries {
-        let nested = within.map { (outer ?? Outer()).nested(under: $0) }
-            ?? outer
-        try width(query, scalar, context, visited, nested, &widths, &types)
+        let nested = within.map { (context.outer ?? Outer()).nested(under: $0) }
+            ?? context.outer
+        try width(query, scalar, context, nested, &widths, &types)
       }
     }
     // The WHERE, `HAVING`, projection, and `ORDER BY` are walked by the
@@ -536,14 +520,16 @@ extension Catalog where Self: ~Escapable {
       }
     }
     for query in rest {
-      let nested = enclosing.map { (outer ?? Outer()).nested(under: $0) }
-          ?? outer
-      try width(query, scalar, context, visited, nested, &widths, &types)
+      let base = context.outer ?? Outer()
+      let nested = enclosing.map { base.nested(under: $0) } ?? context.outer
+      try width(query, scalar, context, nested, &widths, &types)
     }
-    // Carry THIS select's own enclosing scope `outer` so its WHERE type-check
-    // (`walk`) resolves a correlated column of THIS query against the outer,
-    // matching the run's lowering; the projection/`HAVING` walk uses `.barred`.
-    return SubqueryCheck(widths, types, deferred: deferred, outer: outer)
+    // Carry THIS select's own enclosing scope `context.outer` so its WHERE
+    // type-check (`walk`) resolves a correlated column of THIS query against
+    // the outer, matching the run's lowering; the projection/`HAVING` walk uses
+    // `.barred`.
+    return SubqueryCheck(widths, types, deferred: deferred,
+                         outer: context.outer)
   }
 
   /// Records the cursor-free width and single-column type of `query` into
@@ -551,8 +537,7 @@ extension Catalog where Self: ~Escapable {
   /// occurrence's single-column ARITY EAGERLY (reachability-independent, as the
   /// run's lowering does). Computed ONCE per distinct query at a given site.
   private borrowing func width(_ query: Query, _ scalar: Set<Query>,
-                               _ context: Context, _ visited: Set<String>,
-                               _ nested: Outer?,
+                               _ context: Context, _ nested: Outer?,
                                _ widths: inout Dictionary<Query, Int>,
                                _ types: inout Dictionary<Query, ValueType>)
       throws(SQLError) {
@@ -570,12 +555,12 @@ extension Catalog where Self: ~Escapable {
     // select:)` re-derives each reached occurrence's body strictly. Structural
     // faults (a bad inner relation/column, a UNION arity) still surface here —
     // those resolve regardless of `validate`.
-    let width =
-        try compile(query, context, visited, .caller, nested,
-                    validate: false).width
-    let derived =
-        try columns(of: query.first, context, visited: visited,
-                    validate: false, outer: nested).first?.type
+    // Lower under `.caller`, this frame's `nested` outer, and shape-only
+    // lenience (`validate: false`) — the schema pre-pass's cursor-free derive.
+    let inner =
+        context.scoped(as: .caller).with(outer: nested).validating(false)
+    let width = try compile(query, inner).width
+    let derived = try columns(of: query.first, inner).first?.type
     if widths[query] == nil {
       widths[query] = width
       types[query] = derived
@@ -609,8 +594,7 @@ extension Catalog where Self: ~Escapable {
     return .select(select.probe)
   }
 
-  private borrowing func typecheck(_ select: Select, _ context: Context,
-                                   visited: Set<String>, outer: Outer? = nil)
+  private borrowing func typecheck(_ select: Select, _ context: Context)
       throws(SQLError) {
     // This select's OWN resolution scope — the one its nested subqueries
     // CORRELATE against (`nil` for a FROM-less select, which adds no relations
@@ -619,12 +603,10 @@ extension Catalog where Self: ~Escapable {
     // (its derived aliases among them), unlike an inner subquery's own FROM,
     // which resolves against the REVEALED base below.
     let enclosing = select.from == nil
-        ? nil : try scope(of: select, context, visited: visited,
-                          validate: true)
+        ? nil : try scope(of: select, context)
     // The PREFIX scope of each join, the surface its `ON`'s subquery correlates
     // against — matching the run's `subquery(of:)`.
-    let prefixes = try prefixes(of: select, context, visited: visited,
-                               validate: true)
+    let prefixes = try prefixes(of: select, context)
     // Type-check and compile every subquery ONCE, ahead of the reachability
     // walk: the pre-pass validates each `IN`/`EXISTS` inner query (never
     // short-circuited past) and derives every scalar subquery's cursor-free
@@ -632,13 +614,11 @@ extension Catalog where Self: ~Escapable {
     // occurrence's inner-query OPERAND validation to the walk. Each nested
     // query's CORRELATION resolves against `enclosing` (a join `ON`'s against
     // its prefix) here, matching the run.
-    let subquery = try subqueryCheck(of: select, context, visited: visited,
-                                     enclosing: enclosing, outer: outer,
+    let subquery = try subqueryCheck(of: select, context, enclosing: enclosing,
                                      prefixes: prefixes)
     // Walk the query's operands reachability-aware, so an unreachable
     // `CASE`/`COALESCE` arm's subquery is left unrecorded and unchecked.
-    try walk(select, context, subquery: subquery, visited: visited,
-             outer: outer, prefixes: prefixes)
+    try walk(select, context, subquery: subquery, prefixes: prefixes)
     // Validate the inner query of each occurrence the walk REACHED — a scalar
     // or an `IN`/`EXISTS`/quantified one — in the RUN shape of ITS OWN reached
     // role: an `existential` reach the cardinality PROBE (never its select
@@ -656,10 +636,12 @@ extension Catalog where Self: ~Escapable {
     // base — the derived layers dropped, the CTEs/store (a shadowed CTE among
     // them) kept — while the correlation `outer` above still carries the
     // enclosing scope's ordinals.
-    let inner = context.revealed()
-    let nested = enclosing.map { (outer ?? Outer()).nested(under: $0) } ?? outer
+    let revealed = context.revealed()
+    let base = context.outer ?? Outer()
+    let nested = enclosing.map { base.nested(under: $0) } ?? context.outer
+    let inner = revealed.with(outer: nested)
     for reach in subquery.visited {
-      try typecheck(shape(of: reach), inner, visited: visited, outer: nested)
+      try typecheck(shape(of: reach), inner)
     }
     // Each join `ON` runs through the SAME reachability/short-circuit walk the
     // WHERE does, but PREFIX-scoped: an `ON` predicate short-circuits its
@@ -676,11 +658,11 @@ extension Catalog where Self: ~Escapable {
     for index in select.joins.indices {
       guard index < prefixes.count else { continue }
       let prefix = prefixes[index]
-      let scope = (outer ?? Outer()).nested(under: prefix)
-      let on = subquery.scoped(outer)
+      let scope = (context.outer ?? Outer()).nested(under: prefix)
+      let on = subquery.scoped(context.outer)
       try prefix.check(select.joins[index].on, context.routines, subquery: on)
       for reach in on.visited {
-        try typecheck(shape(of: reach), inner, visited: visited, outer: scope)
+        try typecheck(shape(of: reach), revealed.with(outer: scope))
       }
     }
   }
@@ -690,13 +672,11 @@ extension Catalog where Self: ~Escapable {
   /// would evaluate and RECORDING (via `subquery`) each scalar subquery it
   /// reaches, so the caller validates only the reached scalars' inner queries.
   private borrowing func walk(_ select: Select, _ context: Context,
-                              subquery: SubqueryCheck, visited: Set<String>,
-                              outer: Outer? = nil,
+                              subquery: SubqueryCheck,
                               prefixes: Array<Scope> = [])
       throws(SQLError) {
     let routines = context.routines
-    let scope = try scope(of: select, context, visited: visited,
-                          validate: true)
+    let scope = try scope(of: select, context)
     // The WHERE admits a correlated column of THIS query (`subquery`); the
     // projection, `HAVING`, and `ORDER BY` bar it (`barred`), diagnosing the
     // unsupported correlated-projection/HAVING case exactly as the run's
@@ -724,8 +704,7 @@ extension Catalog where Self: ~Escapable {
     // Structural, so it runs regardless of the WHERE/limit reachability the
     // operand type-check below tracks.
     if select.aggregates {
-      try order(grouped: select, scope, context, visited,
-                outer: outer, prefixes: prefixes)
+      try order(grouped: select, scope, context, prefixes: prefixes)
     }
     if let predicate = select.predicate {
       try scope.check(predicate, routines, subquery: subquery)
@@ -856,8 +835,7 @@ extension Catalog where Self: ~Escapable {
   /// the two paths cannot drift. It resolves only, reading no cursor; a run's
   /// operand type-check over the (structurally valid) keys stays the caller's.
   private borrowing func order(grouped select: Select, _ scope: Scope,
-                               _ context: Context, _ visited: Set<String>,
-                               outer: Outer? = nil,
+                               _ context: Context,
                                prefixes: Array<Scope> = [])
       throws(SQLError) {
     guard let clause = select.order else { return }
@@ -871,9 +849,8 @@ extension Catalog where Self: ~Escapable {
     // query (`WHERE S.k = T.k`) resolves its outer column here exactly as at
     // run, rather than compiling with no enclosing scope and faulting
     // `SQLError.column`.
-    let subquery = try subquery(of: select, context, visited, .caller,
-                                enclosing: scope, outer: outer,
-                                prefixes: prefixes).rest
+    let subquery = try subquery(of: select, context.scoped(as: .caller),
+                                enclosing: scope, prefixes: prefixes).rest
     // Collect the distinct aggregates the grouped plan folds — the projection,
     // the `HAVING`, and the `ORDER BY` sort-key expressions — then dedup by the
     // RESOLVED `Aggregation`, exactly as `group` does, so a grouped `ORDER BY`
@@ -930,9 +907,7 @@ extension Catalog where Self: ~Escapable {
   /// types WITHOUT re-checking its reachable operands, so a view whose body is
   /// data-dependent-empty — a text-arithmetic projection under a filter that
   /// matched no row — does not fault a `SELECT *` over it that already ran.
-  borrowing func schema(of relation: Relation, _ context: Context,
-                        visited: Set<String> = [],
-                        validate: Bool = true)
+  borrowing func schema(of relation: Relation, _ context: Context)
       throws(SQLError) -> Schema {
     let name = relation.name
     if let cte = context.relations[name.lowercased()] {
@@ -957,7 +932,7 @@ extension Catalog where Self: ~Escapable {
       // re-enter this view forever, so break the cycle and fall back to the
       // declared schema (every type the `.integer` default). `try?` cannot
       // catch this — the recursion overflows the stack rather than throwing.
-      guard !visited.contains(name.lowercased()) else { return base }
+      guard !context.visited.contains(name.lowercased()) else { return base }
       // Type-check the body's REACHABLE operands and calls across every arm and
       // clause — `compile` cannot check a routine EXISTS, the first-arm resolve
       // below sees only the first projection, and the outer query's walk does
@@ -970,25 +945,27 @@ extension Catalog where Self: ~Escapable {
       // <self>) AS d`) re-enters with the view already visited and faults
       // `.recursion` rather than recursing to a stack overflow — the guard
       // rides through `augment`/`materialise` into the derived body.
-      let inner = visited.union([name.lowercased()])
+      // `body([:])` enters the view-body scope with the caller's correlation
+      // stack CLEARED: a view is defined independently of its call site, so an
+      // unbound column in the DEFINITION must fault — NOT bind to an enclosing
+      // row — when the view's schema is derived from inside a correlated
+      // subquery, keeping this derivation consistent with `resolve`/`compile`.
       let overlay =
-          try augment(context.scoping([:]), for: view.query, rows: false,
-                      visited: inner, validate: validate)
-      // Gate the body's reachable-operand check on `validate`: a `validate:
-      // false` derive skips it, so a data-dependent-empty body (a text
-      // arithmetic under an unmatched filter) does not fault a `SELECT *` over
-      // the view that already ran to its (empty) result. `validate` also rides
+          try augment(context.body([:]).visiting(name), for: view.query,
+                      rows: false)
+      // Gate the body's reachable-operand check on `context.validate`: a
+      // `validate: false` derive skips it, so a data-dependent-empty body (a
+      // text arithmetic under an unmatched filter) does not fault a `SELECT *`
+      // over the view that already ran to its (empty) result. It also rides
       // into the recursive derive so a view over a view stays derive-only.
-      if validate {
-        try typecheck(view.query, overlay, visited: inner)
+      if context.validate {
+        try typecheck(view.query, overlay)
       }
       // Type off the body's first arm (the ISO rule for a UNION). Arity — the
       // body's width against the declared columns — is `compile`'s job (the
       // public entry runs it), so on a shortfall fall back to the declared
       // schema rather than re-checking it here.
-      let resolved =
-          try columns(of: view.query.first, overlay, visited: inner,
-                      validate: validate)
+      let resolved = try columns(of: view.query.first, overlay)
       guard resolved.count == base.width else { return base }
       return Schema(width: base.width, extent: base.extent, names: base.names,
                     types: resolved.map(\.type), virtuals: base.virtuals)

--- a/Tests/SQLTests/BetweenTests.swift
+++ b/Tests/SQLTests/BetweenTests.swift
@@ -383,7 +383,7 @@ struct BetweenSeekTests {
     // not scan all ten rows.
     let catalog = try sorted()
     let query = try query("SELECT Id FROM T WHERE Id BETWEEN 3 AND 7")
-    let plan = try catalog.optimise(catalog.compile(query, validate: true), [:])
+    let plan = try catalog.optimise(catalog.compile(query), [:])
     #expect(seek(plan) == 2 ..< 7)
     try catalog.expect("SELECT Id FROM T WHERE Id BETWEEN 3 AND 7",
                        yields: [[3], [4], [5], [6], [7]])
@@ -399,7 +399,7 @@ struct BetweenSeekTests {
     let catalog = try sorted()
     let comparison =
         try query("SELECT Id FROM T WHERE Id >= 3 AND Id <= 7")
-    let compiled = try catalog.compile(comparison, validate: true)
+    let compiled = try catalog.compile(comparison)
     let range = try #require(seek(catalog.optimise(compiled, [:])))
     #expect(range.lowerBound <= 2 && range.upperBound >= 7)
     try catalog.expect("SELECT Id FROM T WHERE Id BETWEEN 3 AND 7",
@@ -413,7 +413,7 @@ struct BetweenSeekTests {
     // out-of-range rows.
     let catalog = try sorted()
     let query = try query("SELECT Id FROM T WHERE Id NOT BETWEEN 3 AND 7")
-    let plan = try catalog.optimise(catalog.compile(query, validate: true), [:])
+    let plan = try catalog.optimise(catalog.compile(query), [:])
     #expect(seek(plan) == nil)
     try catalog.expect("SELECT Id FROM T WHERE Id NOT BETWEEN 3 AND 7",
                        yields: [[1], [2], [8], [9], [10]])
@@ -426,7 +426,7 @@ struct BetweenSeekTests {
     // same rows the seeked `Id BETWEEN 3 AND 7` would.
     let catalog = try sorted()
     let query = try query("SELECT Id FROM T WHERE Id + 1 BETWEEN 4 AND 8")
-    let plan = try catalog.optimise(catalog.compile(query, validate: true), [:])
+    let plan = try catalog.optimise(catalog.compile(query), [:])
     #expect(seek(plan) == nil)
     try catalog.expect("SELECT Id FROM T WHERE Id + 1 BETWEEN 4 AND 8",
                        yields: [[3], [4], [5], [6], [7]])
@@ -439,7 +439,7 @@ struct BetweenSeekTests {
     // every row whose `Id >= 3` (each row's own `Id` is its upper bound).
     let catalog = try sorted()
     let query = try query("SELECT Id FROM T WHERE Id BETWEEN 3 AND Id")
-    let plan = try catalog.optimise(catalog.compile(query, validate: true), [:])
+    let plan = try catalog.optimise(catalog.compile(query), [:])
     #expect(seek(plan) == nil)
     try catalog.expect("SELECT Id FROM T WHERE Id BETWEEN 3 AND Id",
                        yields: [[3], [4], [5], [6], [7], [8], [9], [10]])
@@ -455,7 +455,7 @@ struct BetweenSeekTests {
     // the query returns no rows and never traps.
     let catalog = try sorted()
     let query = try query("SELECT Id FROM T WHERE Id BETWEEN 10 AND 1")
-    let plan = try catalog.optimise(catalog.compile(query, validate: true), [:])
+    let plan = try catalog.optimise(catalog.compile(query), [:])
     let range = try #require(seek(plan))
     #expect(range.isEmpty)
     try catalog.empty("SELECT Id FROM T WHERE Id BETWEEN 10 AND 1")
@@ -471,7 +471,7 @@ struct BetweenSeekTests {
     let catalog = try sorted()
     let query = try query("SELECT Id FROM T WHERE Id BETWEEN :lo AND :hi")
     let bindings: Bindings = ["lo": .integer(3), "hi": .integer(7)]
-    let compiled = try catalog.compile(query, validate: true)
+    let compiled = try catalog.compile(query)
     let plan = try catalog.optimise(compiled, bindings)
     #expect(seek(plan) == 2 ..< 7)
     try catalog.expect("SELECT Id FROM T WHERE Id BETWEEN :lo AND :hi",
@@ -485,7 +485,7 @@ struct BetweenSeekTests {
     // so none passes. It seeks nothing rather than mis-seeking.
     let catalog = try sorted()
     let query = try query("SELECT Id FROM T WHERE Id BETWEEN :lo AND :hi")
-    let plan = try catalog.optimise(catalog.compile(query, validate: true),
+    let plan = try catalog.optimise(catalog.compile(query),
                                     ["lo": .integer(3)])
     #expect(seek(plan) == nil)
     try catalog.empty("SELECT Id FROM T WHERE Id BETWEEN :lo AND :hi",

--- a/Tests/SQLTests/ConcatTests.swift
+++ b/Tests/SQLTests/ConcatTests.swift
@@ -131,7 +131,7 @@ private func derived(_ text: String) throws -> ValueType {
     Issue.record("expected a single projected expression")
     throw SQLError.incomplete(expected: "one projected expression")
   }
-  let scope = try people().scope(of: select, Context(), validate: true)
+  let scope = try people().scope(of: select, Context())
   return try scope.derive(items[0].expression)
 }
 

--- a/Tests/SQLTests/DerivedTableTests.swift
+++ b/Tests/SQLTests/DerivedTableTests.swift
@@ -802,6 +802,74 @@ struct DerivedTableCorrelationTests {
   }
 }
 
+// MARK: - No correlation into an ENCLOSING row (non-LATERAL, under a subquery)
+
+/// A non-LATERAL derived table nested inside a CORRELATED subquery must NOT see
+/// the enclosing query's row either — the same no-LATERAL rule a sibling
+/// reference obeys applies outward across the enclosing subquery boundary.
+///
+/// Folding the correlation stack into `Context` made the derived-body scope
+/// inherit the enclosing subquery's `outer`, so the STRICT schema/typecheck
+/// pass bound the derived body's `T.k` to the caller's row while the lenient
+/// run shape pass recorded NO correlation for it and then FAULTED at execution
+/// — a schema/run MISMATCH. Clearing the correlation stack entering derived
+/// materialisation restores the documented no-LATERAL behaviour: the derived
+/// body cannot see `T.k`, so BOTH passes fault CONSISTENTLY.
+struct DerivedTableEnclosingCorrelationTests {
+  /// An outer `T` and an inner `S`, each with a `k` a derived body would try to
+  /// equate — so the leak, had it bound, would have compiled.
+  private func keyed() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["k": .integer]) {
+        Row(1)
+        Row(2)
+      }
+      Relation("S", ["k": .integer]) {
+        Row(1)
+      }
+    }
+  }
+
+  @Test func `a derived body under a correlated IN cannot see the outer row`()
+      throws {
+    // `… 1 IN (SELECT x FROM (SELECT 1 AS x FROM S WHERE S.k = T.k) AS d)` —
+    // the `IN` subquery correlates against `T`, but the derived body `d` is
+    // non-LATERAL, so its `T.k` is an unknown column at BOTH the schema pass
+    // and the run, never bound outward to the caller's row.
+    let sql =
+        "SELECT k FROM T " +
+        "WHERE 1 IN (SELECT x FROM " +
+        "(SELECT 1 AS x FROM S WHERE S.k = T.k) AS d)"
+    try keyed().expect(sql, fails: .column("k"))
+  }
+
+  @Test func `the schema pass faults the derived body exactly as the run does`()
+      throws {
+    // Schema ↔ run parity: the STRICT `columns(of:)` pass faults the derived
+    // body's `T.k` too, rather than binding it while the run faults — the
+    // mismatch the leak introduced.
+    let query = try parse(query:
+        "SELECT k FROM T " +
+        "WHERE 1 IN (SELECT x FROM " +
+        "(SELECT 1 AS x FROM S WHERE S.k = T.k) AS d)")
+    #expect(throws: SQLError.self) {
+      _ = try keyed().columns(of: query, validate: true)
+    }
+  }
+
+  @Test func `a non-correlated derived body under a subquery still runs`()
+      throws {
+    // Control: the SAME shape with an UNCORRELATED derived body (`S.k = 1`, no
+    // outer reference) resolves and runs — clearing the correlation stack does
+    // not disturb a legitimate derived table. `1 IN {1}` keeps every `T` row.
+    try keyed().expect(
+        "SELECT k FROM T " +
+        "WHERE 1 IN (SELECT x FROM " +
+        "(SELECT 1 AS x FROM S WHERE S.k = 1) AS d) ORDER BY k",
+        yields: [[1], [2]])
+  }
+}
+
 // MARK: - Set-operation arm scoping
 
 /// A derived table's alias is scoped to the ARM that names it: a `setop` never
@@ -2043,7 +2111,7 @@ struct DerivedTableDirectCompileTests {
     // is one column wide (`a`) — no `.relation("d")`.
     let select =
         try parse(select: "SELECT a FROM (SELECT V AS a FROM S) AS d")
-    let plan = try fixture().compile(select, validate: true)
+    let plan = try fixture().compile(select)
     #expect(plan.width == 1)
   }
 
@@ -2053,8 +2121,8 @@ struct DerivedTableDirectCompileTests {
     let select =
         try parse(select: "SELECT a FROM (SELECT V AS a FROM S) AS d")
     let catalog = try fixture()
-    let bare = try catalog.compile(select, validate: true)
-    let wrapped = try catalog.compile(.select(select), validate: true)
+    let bare = try catalog.compile(select)
+    let wrapped = try catalog.compile(.select(select))
     #expect(bare.width == wrapped.width)
   }
 
@@ -2064,8 +2132,7 @@ struct DerivedTableDirectCompileTests {
     // advertises the derived alias's projected column `a`, matching the run.
     let select =
         try parse(select: "SELECT a FROM (SELECT V AS a FROM S) AS d")
-    let columns = try fixture().columns(of: select, Context(),
-                                        validate: true)
+    let columns = try fixture().columns(of: select, Context())
     #expect(columns.map(\.name) == ["a"])
   }
 
@@ -2086,7 +2153,7 @@ struct DerivedTableDirectCompileTests {
     // is the base.
     let select =
         try parse(select: "SELECT a FROM (SELECT V AS a FROM S) AS S")
-    let plan = try fixture().compile(select, validate: true)
+    let plan = try fixture().compile(select)
     #expect(plan.width == 1)
   }
 }

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -550,13 +550,13 @@ struct EngineCodedKeyTests {
 
     let equal = try parse("SELECT Name FROM Attribute WHERE Parent = 4")
     let equalPlan =
-        try catalog.optimise(catalog.compile(equal, validate: true), [:])
+        try catalog.optimise(catalog.compile(equal), [:])
     #expect(seeks(equalPlan))
     #expect(!filters(equalPlan))
 
     let less = try parse("SELECT Name FROM Attribute WHERE Parent < 5")
     let lessPlan =
-        try catalog.optimise(catalog.compile(less, validate: true), [:])
+        try catalog.optimise(catalog.compile(less), [:])
     #expect(!seeks(lessPlan))
     #expect(filters(lessPlan))
   }
@@ -585,7 +585,7 @@ struct EngineCodedKeyTests {
       }
     }
     let query = try parse("SELECT * FROM T WHERE Id = 1")
-    let plan = try catalog.optimise(catalog.compile(query, validate: true), [:])
+    let plan = try catalog.optimise(catalog.compile(query), [:])
     #expect(seeks(plan))
   }
 
@@ -596,7 +596,7 @@ struct EngineCodedKeyTests {
       Relation("T", ["Id": .integer], sorted: "Id")
     }
     let query = try parse("SELECT * FROM T WHERE Id = 1")
-    let plan = try catalog.optimise(catalog.compile(query, validate: true), [:])
+    let plan = try catalog.optimise(catalog.compile(query), [:])
     #expect(seeks(plan))
   }
 }
@@ -798,7 +798,7 @@ struct EngineNonEquiJoinTests {
         SELECT Parent.Name, Child.Name FROM Parent
           JOIN Child ON Parent.Id < Child.Pid
         """)
-    let compiled = try catalog.compile(select, validate: true)
+    let compiled = try catalog.compile(select)
     let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(!joins(plan))
     #expect(residual(plan))
@@ -829,7 +829,7 @@ struct EngineNonEquiJoinTests {
         SELECT Parent.Name, Child.Name FROM Parent
           JOIN Child ON Child.Pid = Parent.Id AND Parent.Name < Child.Name
         """)
-    let compiled = try catalog.compile(select, validate: true)
+    let compiled = try catalog.compile(select)
     let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(joins(plan))
   }
@@ -853,7 +853,7 @@ struct EngineNonEquiJoinTests {
         SELECT Parent.Name, Child.Name FROM Parent
           JOIN Child ON Child.Pid = Parent.Id + 1
         """)
-    let compiled = try catalog.compile(select, validate: true)
+    let compiled = try catalog.compile(select)
     let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(!joins(plan))
     #expect(residual(plan))
@@ -914,7 +914,7 @@ struct EngineNonEquiJoinTests {
     let select = try parse("""
         SELECT A.k FROM A JOIN B ON (1 / A.x) = 0 AND A.k = B.k
         """)
-    let compiled = try catalog.compile(select, validate: true)
+    let compiled = try catalog.compile(select)
     let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(!joins(plan))
     #expect(residual(plan))
@@ -935,7 +935,7 @@ struct EngineNonEquiJoinTests {
     ])
     let compiled = try catalog.compile(parse("""
         SELECT A.k FROM A JOIN B ON A.k = B.k AND (1 / A.x) = 0
-        """), validate: true)
+        """))
     let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(!joins(plan))
     #expect(residual(plan))
@@ -957,7 +957,7 @@ struct EngineNonEquiJoinTests {
     ])
     let compiled = try catalog.compile(parse("""
         SELECT A.k FROM A JOIN B ON A.k = B.k AND (1 / A.x) = 0
-        """), validate: true)
+        """))
     let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(!joins(plan))
     #expect(residual(plan))
@@ -1007,7 +1007,7 @@ struct EngineNonEquiJoinTests {
     // Key pairs (1,1) with 5 < 8 kept; (2,2) with 10 < 3 dropped.
     let rows = try catalog.run(parse(text))
     #expect(rows == [[.integer(1), .integer(8)]])
-    let compiled = try catalog.compile(parse(text), validate: true)
+    let compiled = try catalog.compile(parse(text))
     let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(joins(plan))
   }
@@ -1020,7 +1020,7 @@ struct EngineNonEquiJoinTests {
         SELECT Parent.Name, Child.Name FROM Parent
           JOIN Child ON Child.Pid = Parent.Id
         """)
-    let compiled = try catalog.compile(select, validate: true)
+    let compiled = try catalog.compile(select)
     let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(joins(plan))
   }
@@ -1040,7 +1040,7 @@ struct EngineNonEquiJoinTests {
                            [[.integer(2)]] as Array<Array<Value>>),
     ])
     let text = "SELECT A.k FROM A JOIN B ON A.k < B.k WHERE (1 / A.x) = 0"
-    let compiled = try catalog.compile(parse(text), validate: true)
+    let compiled = try catalog.compile(parse(text))
     let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(separated(plan))
     #expect(residual(plan))
@@ -1106,7 +1106,7 @@ struct EngineNonEquiJoinTests {
         SELECT A.k1 FROM A
           JOIN B ON A.k1 = B.k1 AND A.k2 = B.k2 WHERE (1 / A.x) = 0
         """
-    let compiled = try catalog.compile(parse(text), validate: true)
+    let compiled = try catalog.compile(parse(text))
     let plan = try catalog.optimise(compiled.pushdown(), [:])
     // The equi key still hash-joins; the leftover match gates above it, and the
     // `WHERE` is a SEPARATE `select` above that gate, not fused with the match.
@@ -1164,7 +1164,7 @@ struct EngineNonEquiJoinTests {
         SELECT A.tag, B.note FROM A
           JOIN B ON A.k1 = B.k1 AND A.k2 = B.k2 WHERE A.tag = 'keep'
         """
-    let compiled = try catalog.compile(parse(text), validate: true)
+    let compiled = try catalog.compile(parse(text))
     let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(joins(plan))
     #expect(try catalog.run(parse(text)) == [[.text("keep"), .text("bee")]])
@@ -1187,7 +1187,7 @@ struct EngineNonEquiJoinTests {
                            [[.integer(1)]] as Array<Array<Value>>),
     ])
     let text = "SELECT A.k FROM A JOIN B ON A.k = B.k WHERE (1 / A.x) = 1"
-    let compiled = try catalog.compile(parse(text), validate: true)
+    let compiled = try catalog.compile(parse(text))
     let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(joins(plan))
     #expect(try catalog.run(parse(text)) == [[.integer(1)]])
@@ -1321,7 +1321,7 @@ struct EngineOuterJoinTests {
         SELECT Parent.Name, Child.Name FROM Parent
           LEFT JOIN Child ON Child.Pid = Parent.Id
         """)
-    let compiled = try catalog.compile(select, validate: true)
+    let compiled = try catalog.compile(select)
     let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(outers(plan))
     #expect(!joins(plan))
@@ -1569,11 +1569,192 @@ struct EngineViewTests {
     // `.scan` (a non-nil seek) and carry no `.select` over a raw scan.
     let catalog = try views()
     let select = try parse("SELECT Key, Label FROM Adults")
-    let compiled = try catalog.compile(select, validate: true)
+    let compiled = try catalog.compile(select)
     let plan = try catalog.optimise(compiled, [:])
     let sub = try #require(derived(plan))
     #expect(seeks(sub))
     #expect(!filters(sub))
+  }
+}
+
+// MARK: - A view body must not correlate against the caller's row
+
+/// A view is DEFINED independently of its call site, so its body must NOT bind
+/// an unbound column to an enclosing query's row — even when the view is used
+/// from inside a (correlated) subquery, whose compile threads its enclosing
+/// scope as the correlation stack.
+///
+/// Folding the correlation stack into `Context` made the view-body compile path
+/// inherit the caller's `outer`, so an unbound column in the view DEFINITION
+/// (`WHERE k = 1`, where `k` is NOT in the view's own FROM) wrongly bound to a
+/// caller's row when the enclosing relation happened to have a column `k`.
+/// Clearing the correlation stack entering the view-body overlay restores the
+/// fault: the view body cannot see the caller's row, so `k` is unbound at BOTH
+/// compile and run.
+struct EngineViewCorrelationTests {
+  /// An outer `Env` carrying a column `k` a leaking view body could bind to,
+  /// a source `Src` WITHOUT `k`, and a view `Bad` whose body references the
+  /// unbound `k`.
+  private func leaky() throws -> Memory {
+    let bad = try View(query: select("SELECT n FROM Src WHERE k = 1"),
+                       columns: ["n"])
+    return Memory([
+      "Env": FixtureRelation([Field(name: "k", type: .integer)],
+                               [[.integer(1)]] as Array<Array<Value>>),
+      "Src": FixtureRelation([Field(name: "n", type: .integer)],
+                             [[.integer(7)]] as Array<Array<Value>>),
+    ], views: ["Bad": bad])
+  }
+
+  @Test func `a view body under a subquery does not bind the caller's column`()
+      throws {
+    // `SELECT k FROM Env WHERE EXISTS (SELECT n FROM Bad)` — the EXISTS
+    // subquery compiles with `Env` as its enclosing scope, so the view `Bad`
+    // resolves under a non-nil correlation stack. Its body `WHERE k = 1` names
+    // `k`, absent from its own FROM (`Src`); it must fault as unbound, NOT
+    // bind to `Env.k`.
+    try leaky().expect(
+        "SELECT k FROM Env WHERE EXISTS (SELECT n FROM Bad)",
+        fails: .column("k"))
+  }
+
+  @Test func `the view faults at compile under a subquery, not only at run`()
+      throws {
+    // Schema ↔ run parity: the STRICT schema pass faults the view body's
+    // unbound `k` too, rather than binding it to the caller — the leak the fold
+    // introduced would have compiled a schema for a view that cannot run.
+    let query = try parse(
+        "SELECT k FROM Env WHERE EXISTS (SELECT n FROM Bad)")
+    #expect(throws: SQLError.self) {
+      _ = try leaky().columns(of: query, validate: true)
+    }
+  }
+
+  @Test func `a valid view under a subquery still resolves and runs`() throws {
+    // Control: a LEGITIMATE view (its body self-contained) used from a nested
+    // subquery still resolves and runs — clearing the view body's correlation
+    // stack does not disturb a well-formed view. `Good` reads `Src` (one row),
+    // so the EXISTS holds for every `Env` row.
+    let good = try View(query: select("SELECT n FROM Src"), columns: ["n"])
+    let catalog = Memory([
+      "Env": FixtureRelation([Field(name: "k", type: .integer)],
+                               [[.integer(1)], [.integer(2)]]
+                                   as Array<Array<Value>>),
+      "Src": FixtureRelation([Field(name: "n", type: .integer)],
+                             [[.integer(7)]] as Array<Array<Value>>),
+    ], views: ["Good": good])
+    try catalog.expect(
+        "SELECT k FROM Env WHERE EXISTS (SELECT n FROM Good) ORDER BY k",
+        yields: [[1], [2]])
+  }
+
+  @Test func `a genuine correlation to the caller still works`() throws {
+    // Guard: clearing the VIEW body's correlation must not break a legitimately
+    // correlated subquery. The EXISTS subquery itself references the outer
+    // `Env.k` (`Src.n = k`), a genuine correlation — it still lowers and runs
+    // per outer row. Only the `k = 1` outer row keeps the EXISTS (Src has n = 1
+    // there), so the result is that row alone.
+    let catalog = Memory([
+      "Env": FixtureRelation([Field(name: "k", type: .integer)],
+                               [[.integer(1)], [.integer(2)]]
+                                   as Array<Array<Value>>),
+      "Src": FixtureRelation([Field(name: "n", type: .integer)],
+                             [[.integer(1)]] as Array<Array<Value>>),
+    ])
+    try catalog.expect(
+        "SELECT k FROM Env WHERE EXISTS (SELECT n FROM Src WHERE n = k) " +
+        "ORDER BY k",
+        yields: [[1]])
+  }
+
+  // MARK: - schema(of:) view-body derivation must not correlate either
+
+  /// The `schema(of:)` seam — the view-body SCHEMA/type derivation `scope(of:)`
+  /// drives, resolving a `FROM <view>`'s relations to their types — entered the
+  /// view-body overlay via `scoping([:]).visiting(name)` WITHOUT clearing the
+  /// caller's correlation stack, the ONE view-body body-entry the prior round
+  /// missed. So when a view whose DEFINITION references a column absent from its
+  /// own FROM had its schema derived while under a correlated subquery whose
+  /// outer relation HAS that column, the type-derivation bound the unbound
+  /// column OUTWARD to the caller's row rather than faulting — disagreeing with
+  /// the compile/run path `resolve`/`overlay` now clear. Routing every body-
+  /// entry through `Context.body(_:)` (which appends `uncorrelated()`) closes
+  /// it: `schema(of:)` faults the unbound column, consistent with compile/run.
+
+  /// An outer `Env(k)` a leaking view PROJECTION could bind to, a source `Src`
+  /// WITHOUT `k`, and a view `Proj` whose body PROJECTS the unbound `k` — so its
+  /// SCHEMA (the projection's type) is what a leak would derive from the caller.
+  private func schemaLeak() throws -> Memory {
+    let proj = try View(query: select("SELECT k AS m FROM Src"),
+                        columns: ["m"])
+    return Memory([
+      "Env": FixtureRelation([Field(name: "k", type: .integer)],
+                               [[.integer(1)]] as Array<Array<Value>>),
+      "Src": FixtureRelation([Field(name: "n", type: .integer)],
+                             [[.integer(7)]] as Array<Array<Value>>),
+    ], views: ["Proj": proj])
+  }
+
+  /// A correlation stack whose NEAREST enclosing scope is `Env(k)` — the
+  /// context a nested subquery's schema derivation runs under, so a leaking
+  /// `schema(of:)` could bind an unbound view-projection column to `Env.k`. It
+  /// nests a scope built from `Env`'s own schema (derived off the catalog),
+  /// exactly as `compile`/`columns` thread an enclosing scope into a subquery.
+  private func enclosingEnv(_ catalog: borrowing Memory) throws -> Context {
+    let schema = try catalog.schema(of: Relation(name: "Env"), Context())
+    return Context().nesting(under: Scope([(Relation(name: "Env"), schema)]))
+  }
+
+  @Test
+  func `schema of a view under a correlated scope does not bind the caller`()
+      throws {
+    // Directly exercise the `schema(of:)` seam in ISOLATION: derive the scope
+    // of `SELECT m FROM Proj` under a correlation stack whose enclosing scope
+    // is `Env(k)`. `scope(of:)` calls `schema(of: Proj)`, which enters the
+    // view body to type its projection `k` — absent from `Proj`'s own FROM
+    // (`Src`). It must fault `k` as unbound, NOT bind it to the enclosing
+    // `Env.k`. This is the seam the run/compile path (`resolve`/`overlay`)
+    // clears elsewhere but `schema(of:)` did NOT until routed through `body`.
+    let catalog = try schemaLeak()
+    let target = try select("SELECT m FROM Proj").first
+    let context = try enclosingEnv(catalog)
+    var raised: SQLError?
+    do {
+      _ = try catalog.scope(of: target, context)
+    } catch let fault {
+      raised = fault
+    }
+    #expect(raised == .column("k"))
+  }
+
+  @Test
+  func `schema of a valid view under a correlated scope still derives`()
+      throws {
+    // Control: a well-formed view whose projection is self-contained still has
+    // its schema derived under the SAME correlated scope — clearing the schema
+    // path's correlation stack does not disturb a legitimate view. `Fine`
+    // projects `n` (in its own `Src`), so `scope(of:)` derives cleanly.
+    let fine = try View(query: select("SELECT n AS m FROM Src"),
+                        columns: ["m"])
+    let catalog = Memory([
+      "Env": FixtureRelation([Field(name: "k", type: .integer)],
+                               [[.integer(1)]] as Array<Array<Value>>),
+      "Src": FixtureRelation([Field(name: "n", type: .integer)],
+                             [[.integer(7)]] as Array<Array<Value>>),
+    ], views: ["Fine": fine])
+    let target = try select("SELECT m FROM Fine").first
+    let context = try enclosingEnv(catalog)
+    // Eager rather than `#expect(throws:)` — a borrowed `~Escapable` catalog
+    // cannot be captured by the assertion's escaping closure.
+    _ = try catalog.scope(of: target, context)
+  }
+
+  @Test func `a view projecting an unbound column faults consistently`()
+      throws {
+    // End-to-end parity control: running `SELECT m FROM Proj` (outside any
+    // correlation) faults the unbound projection `k` too, so the schema seam's
+    // fault under a correlated scope AGREES with the plain run — schema ↔ run.
+    try schemaLeak().expect("SELECT m FROM Proj", fails: .column("k"))
   }
 }
 
@@ -1982,7 +2163,7 @@ struct EnginePushdownTests {
         SELECT Child.Name FROM Parent JOIN Child ON Child.Pid = Parent.Id
           WHERE Parent.Name = 'Ada'
         """)
-    let compiled = try catalog.compile(select, validate: true)
+    let compiled = try catalog.compile(select)
     let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(pushed(plan))
   }
@@ -1995,7 +2176,7 @@ struct EnginePushdownTests {
         SELECT Child.Name FROM Parent JOIN Child ON Child.Pid = Parent.Id
           WHERE Parent.Id = 2
         """)
-    let compiled = try catalog.compile(select, validate: true)
+    let compiled = try catalog.compile(select)
     let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(seeks(plan))
     #expect(pushed(plan))
@@ -2021,7 +2202,7 @@ struct EnginePushdownTests {
     let select = try parse("""
         SELECT Name FROM T WHERE Name <> 'x' AND Age > 0 AND Id = 5
         """)
-    let compiled = try catalog.compile(select, validate: true)
+    let compiled = try catalog.compile(select)
     let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(seeks(plan))
   }
@@ -2048,7 +2229,7 @@ struct EnginePushdownTests {
         """)
 
     // The unsafe `(1 / x) = 0` residual bars the `id < 0` seek — the plan scans.
-    let compiled = try catalog.compile(select, validate: true)
+    let compiled = try catalog.compile(select)
     let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(!seeks(plan))
 
@@ -2078,7 +2259,7 @@ struct EnginePushdownTests {
         SELECT Child.Name, Parent.Name FROM Child
           JOIN Parent ON Parent.Id = Child.Pid WHERE Parent.Name <> 'zz'
         """)
-    let compiled = try catalog.compile(select, validate: true)
+    let compiled = try catalog.compile(select)
     let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(joins(plan))
 
@@ -2103,7 +2284,7 @@ struct EnginePushdownTests {
         SELECT Child.Name, Parent.Name FROM Parent
           JOIN Child ON Child.Pid = Parent.Id WHERE Parent.Name <> Child.Name
         """)
-    let compiled = try catalog.compile(select, validate: true)
+    let compiled = try catalog.compile(select)
     let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(joins(plan))
     #expect(floats(plan))
@@ -2231,7 +2412,7 @@ struct EnginePushdownTests {
     // and seeking the sorted `Alpha` arm.
     let catalog = try spanned()
     let select = try parse("SELECT Tag FROM Both WHERE Key = 2")
-    let compiled = try catalog.compile(select, validate: true)
+    let compiled = try catalog.compile(select)
     let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(injected(plan))
     #expect(seeks(plan))
@@ -2303,7 +2484,7 @@ struct EnginePushdownTests {
 
     // `A.x = 1` is nullable and precedes the unsafe division, so it is NOT
     // pushed to the `A` leaf — it floats at the product level.
-    let compiled = try catalog.compile(select, validate: true)
+    let compiled = try catalog.compile(select)
     let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(!pushed(plan))
     #expect(floats(plan))
@@ -2332,7 +2513,7 @@ struct EnginePushdownTests {
 
     // `x = 1` is nullable and precedes the unsafe division, so it is NOT
     // injected into the view — it floats above the derived leaf.
-    let compiled = try catalog.compile(select, validate: true)
+    let compiled = try catalog.compile(select)
     let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(floats(plan))
 
@@ -2362,7 +2543,7 @@ struct EnginePushdownTests {
     // `1 = :missing` is a slotless bound predicate, hence nullable; it precedes
     // the unsafe division, so it is NOT injected into the view — it floats above
     // the derived leaf.
-    let compiled = try catalog.compile(select, validate: true)
+    let compiled = try catalog.compile(select)
     let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(floats(plan))
 
@@ -2668,7 +2849,7 @@ struct EngineStreamingProductTests {
         SELECT Child.Name, Adults.Label FROM Child
           JOIN Adults ON Adults.Key = Child.Pid
         """)
-    let compiled = try catalog.compile(select, validate: true)
+    let compiled = try catalog.compile(select)
     let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(residual(plan))
   }
@@ -3274,7 +3455,7 @@ struct EngineBoundTests {
     // seeks the run rather than scanning and filtering the whole relation.
     let select = try parse("SELECT Name FROM Parent WHERE Id = :id")
     let catalog = try family()
-    let plan = try catalog.optimise(catalog.compile(select, validate: true),
+    let plan = try catalog.optimise(catalog.compile(select),
                                     ["id": .integer(2)])
     #expect(seeks(plan))
     #expect(!filters(plan))
@@ -3283,7 +3464,7 @@ struct EngineBoundTests {
   @Test func `an unbound key cannot seek and scans under the filter`() throws {
     let select = try parse("SELECT Name FROM Parent WHERE Id = :id")
     let catalog = try family()
-    let compiled = try catalog.compile(select, validate: true)
+    let compiled = try catalog.compile(select)
     let plan = try catalog.optimise(compiled, [:])
     #expect(!seeks(plan))
     #expect(filters(plan))
@@ -3295,7 +3476,7 @@ struct EngineBoundTests {
     // supplied, so a reusable view is as fast as the inlined query.
     let select = try parse("SELECT Key, Label FROM Picked")
     let catalog = try views()
-    let plan = try catalog.optimise(catalog.compile(select, validate: true),
+    let plan = try catalog.optimise(catalog.compile(select),
                                     ["id": .integer(2)])
     let sub = try #require(derived(plan))
     #expect(seeks(sub))

--- a/Tests/SQLTests/LikeTests.swift
+++ b/Tests/SQLTests/LikeTests.swift
@@ -370,7 +370,7 @@ struct LikeSafetyTests {
     // residual `.select` over the `.product`, so the whole `ON` runs per pair.
     let compiled = try mismatched().compile(query("""
         SELECT A.K FROM A JOIN B ON A.K = B.K AND A.Name LIKE 'a%' ESCAPE A.E
-        """), validate: true)
+        """))
     let plan = try mismatched().optimise(compiled.pushdown(), [:])
     #expect(!joins(plan))
     #expect(residual(plan))
@@ -400,7 +400,7 @@ struct LikeSafetyTests {
     let sql = """
         SELECT A.K FROM A JOIN B ON A.K = B.K AND A.Name LIKE 'a%' ESCAPE 'ab'
         """
-    let compiled = try mismatched().compile(query(sql), validate: true)
+    let compiled = try mismatched().compile(query(sql))
     let plan = try mismatched().optimise(compiled.pushdown(), [:])
     #expect(!joins(plan))
     #expect(residual(plan))
@@ -421,7 +421,7 @@ struct LikeSafetyTests {
     }
     let compiled = try catalog.compile(query("""
         SELECT Id FROM S WHERE Name LIKE '_%' ESCAPE '\\' AND Id = 2
-        """), validate: true)
+        """))
     let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(seeks(plan))
 
@@ -445,7 +445,7 @@ struct LikeSafetyTests {
     }
     let compiled = try catalog.compile(query("""
         SELECT Id FROM S WHERE Name LIKE 'x%' AND Id = 2
-        """), validate: true)
+        """))
     let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(seeks(plan))
     try catalog.expect("SELECT Id FROM S WHERE Name LIKE 'x%' AND Id = 2",
@@ -648,7 +648,7 @@ struct LikeParameterTests {
       Issue.record("expected a SELECT statement")
       return
     }
-    let compiled = try catalog.compile(query, validate: true)
+    let compiled = try catalog.compile(query)
     let plan = try catalog.optimise(compiled.pushdown(),
                                     ["e": .text("\\")])
     #expect(!seeks(plan))
@@ -718,7 +718,7 @@ struct LikeParameterisedTests {
     let catalog = try maybe()
     let compiled = try catalog.compile(query("""
         SELECT x FROM V WHERE 'x' LIKE :p AND (1 / y) = 0
-        """), validate: true)
+        """))
     let plan = try catalog.optimise(compiled.pushdown(), [:])
 
     // The parameterised LIKE floats above the derived leaf rather than riding

--- a/Tests/SQLTests/NullifTests.swift
+++ b/Tests/SQLTests/NullifTests.swift
@@ -103,7 +103,7 @@ private func derived(_ text: String) throws -> ValueType {
     Issue.record("expected a single projected expression")
     throw SQLError.incomplete(expected: "one projected expression")
   }
-  let scope = try people().scope(of: select, Context(), validate: true)
+  let scope = try people().scope(of: select, Context())
   return try scope.derive(items[0].expression)
 }
 


### PR DESCRIPTION
This pull request refactors how query context is managed and passed throughout the SQL engine, consolidating multiple context-related parameters into a single `Context` struct. The main changes simplify function signatures, improve maintainability, and enhance the expressiveness of the context by adding new methods and properties. The most important changes are grouped below:

**Context Struct Enhancements:**

* Expanded the `Context` struct to include additional properties such as `visited` (cyclic-view guard), `validate` (eager type-check flag), `subscope` (resolution overlay), and `outer` (correlation stack), providing a more comprehensive context for query execution and compilation.
* Added several utility methods to `Context` for deriving modified copies with updated context (e.g., `.binding`, `.visiting`, `.validating`, `.scoped`, `.nesting`, `.with`), enabling more expressive and safer context management.

**Function Signature Simplification:**

* Refactored many methods (e.g., `augment`, `materialise`, `columns`, `compile`, `typecheck`, `evaluate`) to accept a single `Context` parameter instead of multiple individual parameters for relations, routines, bindings, subqueries, visited, and validate. [[1]](diffhunk://#diff-5964aaa21770c75c337ab925e3bd75e5c5c6f18a8a438a3e45926e4430a53f90L306-R306) [[2]](diffhunk://#diff-5964aaa21770c75c337ab925e3bd75e5c5c6f18a8a438a3e45926e4430a53f90L317-R315) [[3]](diffhunk://#diff-5964aaa21770c75c337ab925e3bd75e5c5c6f18a8a438a3e45926e4430a53f90L338-R342) [[4]](diffhunk://#diff-226bbb012685b516d46f66755374ffc381bc8e2d02b7ab568199461d95cb3fc5L207-R207) [[5]](diffhunk://#diff-226bbb012685b516d46f66755374ffc381bc8e2d02b7ab568199461d95cb3fc5L304-R303) [[6]](diffhunk://#diff-226bbb012685b516d46f66755374ffc381bc8e2d02b7ab568199461d95cb3fc5L327-R325) [[7]](diffhunk://#diff-226bbb012685b516d46f66755374ffc381bc8e2d02b7ab568199461d95cb3fc5L346-R343) [[8]](diffhunk://#diff-226bbb012685b516d46f66755374ffc381bc8e2d02b7ab568199461d95cb3fc5L363-R359) [[9]](diffhunk://#diff-226bbb012685b516d46f66755374ffc381bc8e2d02b7ab568199461d95cb3fc5L391-R386) [[10]](diffhunk://#diff-226bbb012685b516d46f66755374ffc381bc8e2d02b7ab568199461d95cb3fc5L417-R414) [[11]](diffhunk://#diff-226bbb012685b516d46f66755374ffc381bc8e2d02b7ab568199461d95cb3fc5L454-R449) [[12]](diffhunk://#diff-226bbb012685b516d46f66755374ffc381bc8e2d02b7ab568199461d95cb3fc5L565-R574) [[13]](diffhunk://#diff-dfda824ffe6d1ab5fe06d21e60b7da95231ef291e4e583ffba2f7b15422ca407L151-R151) [[14]](diffhunk://#diff-dfda824ffe6d1ab5fe06d21e60b7da95231ef291e4e583ffba2f7b15422ca407L185-R185) [[15]](diffhunk://#diff-dfda824ffe6d1ab5fe06d21e60b7da95231ef291e4e583ffba2f7b15422ca407L203-R204) [[16]](diffhunk://#diff-dfda824ffe6d1ab5fe06d21e60b7da95231ef291e4e583ffba2f7b15422ca407L380-R382)

**Code Consistency and Maintainability:**

* Updated all call sites to use the new context-passing style, ensuring that context is consistently managed and reducing the risk of errors from mismatched parameters. [[1]](diffhunk://#diff-226bbb012685b516d46f66755374ffc381bc8e2d02b7ab568199461d95cb3fc5L391-R386) [[2]](diffhunk://#diff-226bbb012685b516d46f66755374ffc381bc8e2d02b7ab568199461d95cb3fc5L417-R414) [[3]](diffhunk://#diff-226bbb012685b516d46f66755374ffc381bc8e2d02b7ab568199461d95cb3fc5L454-R449) [[4]](diffhunk://#diff-226bbb012685b516d46f66755374ffc381bc8e2d02b7ab568199461d95cb3fc5L565-R574) [[5]](diffhunk://#diff-dfda824ffe6d1ab5fe06d21e60b7da95231ef291e4e583ffba2f7b15422ca407L151-R151) [[6]](diffhunk://#diff-dfda824ffe6d1ab5fe06d21e60b7da95231ef291e4e583ffba2f7b15422ca407L185-R185) [[7]](diffhunk://#diff-dfda824ffe6d1ab5fe06d21e60b7da95231ef291e4e583ffba2f7b15422ca407L203-R204) [[8]](diffhunk://#diff-dfda824ffe6d1ab5fe06d21e60b7da95231ef291e4e583ffba2f7b15422ca407L380-R382)

These changes result in a more robust and maintainable codebase, making it easier to extend context handling and reason about query execution and compilation flows.