### PR TITLE
SQLEngine: support LATERAL derived tables (CROSS APPLY)

### DIFF
--- a/Sources/SQLEngine/AST.swift
+++ b/Sources/SQLEngine/AST.swift
@@ -421,16 +421,27 @@ public struct Relation: Hashable, Sendable {
   /// present for a `derived` one (ISO requires a derived table be aliased).
   public let alias: String?
 
+  /// Whether a `LATERAL` derived table — its body may reference the PRECEDING
+  /// FROM items, so it re-evaluates per their rows (a correlated apply), rather
+  /// than materialising once. Always `false` for a `named` relation and for a
+  /// plain (non-`LATERAL`) derived table, which resolves independently of its
+  /// call site.
+  public let lateral: Bool
+
   /// A named base relation, view, or CTE with an optional alias.
   public init(name: String, alias: String? = nil) {
     self.source = .named(name)
     self.alias = alias
+    self.lateral = false
   }
 
-  /// A derived table over `query`, resolved under the mandatory `alias`.
-  public init(derived query: Query, as alias: String) {
+  /// A derived table over `query`, resolved under the mandatory `alias`. A
+  /// `lateral` one resolves against the preceding FROM items and re-evaluates
+  /// per their rows; a plain one materialises once, independent of the caller.
+  public init(derived query: Query, as alias: String, lateral: Bool = false) {
     self.source = .derived(query)
     self.alias = alias
+    self.lateral = lateral
   }
 
   /// The name the resolution scope keys this relation under: the identifier for

--- a/Sources/SQLEngine/Context.swift
+++ b/Sources/SQLEngine/Context.swift
@@ -65,6 +65,17 @@ internal struct Context {
   /// recording the correlation. `nil` at the top level (no enclosing query).
   internal let outer: Outer?
 
+  /// Whether the query being resolved is a LATERAL derived table's BODY — set
+  /// only by `lateral(_:against:_:)` as it derives/compiles the body. Per ISO
+  /// 9075 a `LATERAL` body's preceding-FROM references are in scope throughout
+  /// its query expression, INCLUDING the select list, so the body admits a
+  /// correlated column EVERYWHERE (not only its `WHERE`/`ON`). This flag
+  /// threads into the `Resolution`/`SubqueryCheck` the body's lowering and
+  /// validation build (`everywhere`), lifting the projection-correlation bar
+  /// for the lateral body ALONE — an ordinary subquery's projection stays
+  /// barred (`false`).
+  internal let lateral: Bool
+
   /// A context over the maps and resolution scope — an empty overlay, no
   /// bindings, an empty visited guard, eager validation, the caller scope, and
   /// no enclosing correlation by default: the shape a bare top-level query with
@@ -74,7 +85,8 @@ internal struct Context {
                 bindings: Bindings = [:],
                 subqueries: Subqueries = Subqueries(),
                 visited: Set<String> = [], validate: Bool = true,
-                subscope: Subscope = .caller, outer: Outer? = nil) {
+                subscope: Subscope = .caller, outer: Outer? = nil,
+                lateral: Bool = false) {
     self.relations = relations
     self.routines = routines
     self.bindings = bindings
@@ -83,6 +95,7 @@ internal struct Context {
     self.validate = validate
     self.subscope = subscope
     self.outer = outer
+    self.lateral = lateral
   }
 
   /// A copy of this context with `relations` REPLACING the overlay, the same
@@ -92,7 +105,7 @@ internal struct Context {
   internal func scoping(_ relations: ScopedRelations) -> Context {
     Context(relations: relations, routines: routines, bindings: bindings,
             subqueries: subqueries, visited: visited, validate: validate,
-            subscope: subscope, outer: outer)
+            subscope: subscope, outer: outer, lateral: lateral)
   }
 
   /// A copy of this context ENTERING a fresh body scope over `relations` — the
@@ -127,7 +140,7 @@ internal struct Context {
   internal func binding(_ bindings: Bindings) -> Context {
     Context(relations: relations, routines: routines, bindings: bindings,
             subqueries: subqueries, visited: visited, validate: validate,
-            subscope: subscope, outer: outer)
+            subscope: subscope, outer: outer, lateral: lateral)
   }
 
   /// A copy of this context carrying `subqueries` as the executing plan's
@@ -137,7 +150,7 @@ internal struct Context {
   internal func resolving(_ subqueries: Subqueries) -> Context {
     Context(relations: relations, routines: routines, bindings: bindings,
             subqueries: subqueries, visited: visited, validate: validate,
-            subscope: subscope, outer: outer)
+            subscope: subscope, outer: outer, lateral: lateral)
   }
 
   /// A copy of this context with every enclosing SELECT's derived-table aliases
@@ -171,7 +184,7 @@ internal struct Context {
     return Context(relations: relations, routines: routines,
                    bindings: bindings, subqueries: subqueries,
                    visited: visited, validate: validate, subscope: subscope,
-                   outer: outer)
+                   outer: outer, lateral: lateral)
   }
 
   /// A copy of this context with the eager-typecheck gate set to `flag` — a RUN
@@ -180,7 +193,7 @@ internal struct Context {
   internal func validating(_ flag: Bool) -> Context {
     Context(relations: relations, routines: routines, bindings: bindings,
             subqueries: subqueries, visited: visited, validate: flag,
-            subscope: subscope, outer: outer)
+            subscope: subscope, outer: outer, lateral: lateral)
   }
 
   /// A copy of this context resolving its nested subqueries under `subscope` —
@@ -189,7 +202,7 @@ internal struct Context {
   internal func scoped(as subscope: Subscope) -> Context {
     Context(relations: relations, routines: routines, bindings: bindings,
             subqueries: subqueries, visited: visited, validate: validate,
-            subscope: subscope, outer: outer)
+            subscope: subscope, outer: outer, lateral: lateral)
   }
 
   /// A copy of this context whose enclosing correlation stack is EXTENDED with
@@ -207,7 +220,20 @@ internal struct Context {
   internal func with(outer: Outer?) -> Context {
     Context(relations: relations, routines: routines, bindings: bindings,
             subqueries: subqueries, visited: visited, validate: validate,
-            subscope: subscope, outer: outer)
+            subscope: subscope, outer: outer, lateral: lateral)
+  }
+
+  /// A copy of this context marking the query it resolves as a LATERAL derived
+  /// table's BODY (`lateral`) — the SINGLE seam `lateral(_:against:_:)` routes
+  /// its body's schema derivation and plan compile through, so the body's
+  /// `Resolution`/`SubqueryCheck` admit a correlated preceding-FROM column
+  /// EVERYWHERE, including the projection, per ISO. Every OTHER field is
+  /// preserved; the flag is scoped to the body's own lowering (a nested
+  /// NON-lateral body clears it through `body(_:)`).
+  internal func lateralizing() -> Context {
+    Context(relations: relations, routines: routines, bindings: bindings,
+            subqueries: subqueries, visited: visited, validate: validate,
+            subscope: subscope, outer: outer, lateral: true)
   }
 
   /// A copy of this context with the enclosing correlation stack CLEARED — the
@@ -217,9 +243,22 @@ internal struct Context {
   /// site; a derived table is uncorrelated), so an unbound column in either
   /// must fault rather than bind outward to the caller. Every OTHER field —
   /// the relation overlay, routines, bindings, subquery results, the visited
-  /// guard, the validate gate, and the subscope — is preserved; only `outer`
-  /// resets to `nil`, restoring the top-level default.
+  /// guard, the validate gate, and the subscope — is preserved; `outer` resets
+  /// to `nil` (restoring the top-level default) and the LATERAL-body flag
+  /// clears, so a non-lateral body nested inside a lateral one does NOT inherit
+  /// the everywhere-correlation admission.
   internal func uncorrelated() -> Context {
-    with(outer: nil)
+    with(outer: nil).unlateralized()
+  }
+
+  /// A copy of this context with the LATERAL-body flag CLEARED — the reset
+  /// `uncorrelated()`/`body(_:)` fold in, and the seam a nested ordinary
+  /// subquery within a lateral body compiles under, so a body that must NOT
+  /// correlate against the caller (a view or a non-lateral derived table) does
+  /// not carry an enclosing lateral body's everywhere-correlation admission.
+  internal func unlateralized() -> Context {
+    Context(relations: relations, routines: routines, bindings: bindings,
+            subqueries: subqueries, visited: visited, validate: validate,
+            subscope: subscope, outer: outer, lateral: false)
   }
 }

--- a/Sources/SQLEngine/Definition.swift
+++ b/Sources/SQLEngine/Definition.swift
@@ -320,15 +320,23 @@ extension Catalog where Self: ~Escapable {
   /// so the alias resolves and types identically on both paths.
   ///
   /// The inner query resolves against `context` (the base catalog plus the
-  /// store relations and CTEs in scope), NOT its sibling FROM items, so the
-  /// derived table is UNCORRELATED: a reference to an outer or sibling column
-  /// faults as an unknown column (LATERAL is a later feature). Its OWN derived
+  /// store relations and CTEs in scope), NOT its sibling FROM items. The OUTER
+  /// treatment is the CALLER's: a NON-LATERAL derived body's caller
+  /// (`augment`) enters through `context.body(…)`, CLEARING the correlation
+  /// stack — so a reference to an outer or sibling column faults as an unknown
+  /// column (the derived table is UNCORRELATED); a LATERAL body's caller
+  /// (`lateral`) instead THREADS the preceding-FROM scope as `context.outer`,
+  /// so a correlated reference to a preceding relation resolves outward. This
+  /// derive is otherwise IDENTICAL for both — the same revealed-base overlay,
+  /// output-schema walk, duplicate-column check, and `validate`-gated body
+  /// type-check — so a lateral body inherits the CTE visibility and the
+  /// operand/function validation a non-lateral body gets. Its OWN derived
   /// tables (a `FROM (SELECT … FROM (…) AS x) AS y`) are augmented into `scope`
   /// FIRST — the schema derivation resolves `x` exactly as a run would — so the
   /// schema and run paths bind the same nested aliases before either reads the
   /// inner query.
-  private borrowing func materialise(_ query: Query, _ context: Context,
-                                     rows: Bool)
+  borrowing func materialise(_ query: Query, _ context: Context,
+                             rows: Bool)
       throws(SQLError) -> RelationInstance {
     // Bind the inner query's OWN derived tables (and store relations) before
     // deriving its schema — a run augments them recursively, so the schema
@@ -707,15 +715,20 @@ extension Select {
     }
   }
 
-  /// Collects this select's `FROM` and `JOIN` derived tables — each alias with
-  /// its inner query — into `derivations`.
+  /// Collects this select's `FROM` and `JOIN` NON-LATERAL derived tables — each
+  /// alias with its inner query — into `derivations`. A LATERAL derived table
+  /// is SKIPPED: it is not materialised once as a constant relation but resolved
+  /// against the preceding FROM and re-evaluated per its rows (a correlated
+  /// apply), so `compile(select)` binds and executes it directly rather than
+  /// through the overlay `augment` builds.
   func collect(derived derivations: inout Array<(String, Query)>) {
-    if case let .derived(query) = from?.source, let alias = from?.alias {
+    if case let .derived(query) = from?.source, let alias = from?.alias,
+        !(from?.lateral ?? false) {
       derivations.append((alias, query))
     }
     for join in joins {
       if case let .derived(query) = join.relation.source,
-          let alias = join.relation.alias {
+          let alias = join.relation.alias, !join.relation.lateral {
         derivations.append((alias, query))
       }
     }

--- a/Sources/SQLEngine/Engine.swift
+++ b/Sources/SQLEngine/Engine.swift
@@ -1632,15 +1632,8 @@ extension Catalog where Self: ~Escapable {
     // Resolve every joined relation and lay the FROM relation and each joined
     // one end to end in one combined ordinal space (as the non-aggregate join
     // path does), so the WHERE, keys, and aggregate arguments resolve uniformly.
-    var joined = Array<Resolved>()
-    joined.reserveCapacity(select.joins.count)
-    for join in select.joins {
-      try joined.append(resolve(join.relation, context))
-    }
-    var relations = [(relation, from.schema)]
-    for index in select.joins.indices {
-      relations.append((select.joins[index].relation, joined[index].schema))
-    }
+    let (joined, relations) = try resolve(from: relation, schema: from.schema,
+                                          joins: select.joins, context)
     let scope = Scope(relations)
 
     // Each join's ON predicate lowers to a `Filter` at its own chain level,
@@ -3032,6 +3025,40 @@ extension Catalog where Self: ~Escapable {
     return .select(select.probe)
   }
 
+  /// Resolves the FROM `relation` and its `joins` into one combined scope, the
+  /// single source three call sites share: the aggregate compile path, the
+  /// non-aggregate compile path, and the `SELECT *` arity check. The caller
+  /// resolves FROM once (it needs the leaf for its own base lowering) and passes
+  /// its `schema` here, so FROM is never re-resolved; each join then resolves
+  /// into one running, end-to-end ordinal space.
+  ///
+  /// The returned `joined` holds each join's `Resolved` (its schema and leaf
+  /// factory) in source order — the plan lowers each into the combined slot
+  /// space from these. The returned `relations` lays the FROM relation first,
+  /// then each joined one, each paired with its schema: `Scope(relations)` is
+  /// the full-chain scope, `relations[0 ... index + 1]` a join's prefix scope,
+  /// and `relations.reduce(0) { $0 + $1.1.width }` the `SELECT *` width — every
+  /// downstream derivation reads out of this one resolution.
+  ///
+  /// `relations` is built INCREMENTALLY: resolve join `i`, append it, then
+  /// resolve join `i + 1`. Each join's schema is correlation-independent of the
+  /// relations preceding it, so the order is a no-op here; the incremental shape
+  /// is what a per-join preceding scope would thread through.
+  private borrowing func resolve(from relation: Relation, schema: Schema,
+                                 joins: Array<Join>, _ context: Context)
+      throws(SQLError) -> (joined: Array<Resolved>,
+                           relations: Array<(Relation, Schema)>) {
+    var joined = Array<Resolved>()
+    joined.reserveCapacity(joins.count)
+    var relations = [(relation, schema)]
+    for join in joins {
+      let resolved = try resolve(join.relation, context)
+      joined.append(resolved)
+      relations.append((join.relation, resolved.schema))
+    }
+    return (joined, relations)
+  }
+
   /// The number of result columns `select` projects — the extent of a `*` over
   /// its relations, else the count of its projected items — for the `UNION`
   /// arity check. The relations resolve through this catalog, the overlay
@@ -3044,11 +3071,10 @@ extension Catalog where Self: ~Escapable {
       guard let relation = select.from else {
         throw .named("SELECT * with no FROM")
       }
-      var width = try resolve(relation, context).schema.width
-      for join in select.joins {
-        try width += resolve(join.relation, context).schema.width
-      }
-      return width
+      let schema = try resolve(relation, context).schema
+      let (_, relations) = try resolve(from: relation, schema: schema,
+                                       joins: select.joins, context)
+      return relations.reduce(0) { $0 + $1.1.width }
     case let .columns(columns):
       return columns.count
     case let .expressions(items):
@@ -3325,16 +3351,8 @@ extension Catalog where Self: ~Escapable {
     // Resolve every joined relation and lay all relations — the FROM relation
     // first, then each joined one in source order — end to end in one combined
     // ordinal space.
-    var joined = Array<Resolved>()
-    joined.reserveCapacity(select.joins.count)
-    for join in select.joins {
-      try joined.append(resolve(join.relation, context))
-    }
-
-    var relations = [(relation, from.schema)]
-    for index in select.joins.indices {
-      relations.append((select.joins[index].relation, joined[index].schema))
-    }
+    let (joined, relations) = try resolve(from: relation, schema: from.schema,
+                                          joins: select.joins, context)
     let scope = Scope(relations)
 
     // Each join's ON predicate lowers to a `Filter` at its own chain level,

--- a/Sources/SQLEngine/Engine.swift
+++ b/Sources/SQLEngine/Engine.swift
@@ -1632,6 +1632,12 @@ extension Catalog where Self: ~Escapable {
     // Resolve every joined relation and lay the FROM relation and each joined
     // one end to end in one combined ordinal space (as the non-aggregate join
     // path does), so the WHERE, keys, and aggregate arguments resolve uniformly.
+    // A LATERAL join under a GROUP BY / aggregate query is a deliberate
+    // follow-up — the grouped path forms a single-relation chain differently
+    // from the correlated apply — so fault it rather than mis-plan.
+    for join in select.joins where join.relation.lateral {
+      throw .unsupported("a LATERAL join under an aggregate is not supported")
+    }
     let (joined, relations) = try resolve(from: relation, schema: from.schema,
                                           joins: select.joins, context)
     let scope = Scope(relations)
@@ -1674,7 +1680,17 @@ extension Catalog where Self: ~Escapable {
     // `HAVING`, and the `ORDER BY` sort keys (deduplicated so the same
     // aggregate computes once).
     let keys = try select.grouping.map { column throws(SQLError) -> Term in
-      try .slot(scope.ordinal(of: column))
+      // A grouping key a local relation binds reads its combined slot; one NONE
+      // binds is a candidate CORRELATED reference (a LATERAL body grouping on a
+      // preceding column) — the same `barred` surface the projection/HAVING use
+      // lowers it to a `Term.parameter` the apply binds per outer row (a
+      // per-invocation constant → one group), admitting it only under the
+      // LATERAL `everywhere` seam and faulting `.unsupported` on an ordinary
+      // grouped subquery. The final `ordinal(of:)` re-throws a genuine
+      // unknown-column `.column`.
+      if let ordinal = try scope.find(column) { return .slot(ordinal) }
+      if let name = try barred.correlate(column) { return .parameter(name) }
+      return try .slot(scope.ordinal(of: column))
     }
     var expressions = Array<Expression>()
     for expression in select.projection.projected {
@@ -1760,7 +1776,8 @@ extension Catalog where Self: ~Escapable {
     // Lower the projection, HAVING, and ORDER BY against the grouped slot space,
     // enforcing the projection rule (every non-aggregated column must be a
     // GROUP BY key).
-    var grouping = try Grouping(scope, select.grouping, aggregations)
+    var grouping = try Grouping(scope, select.grouping, aggregations,
+                                subquery: barred)
     let projection = try grouping.terms(select.projection, context.routines,
                                         subquery: barred)
     let having: Filter? = if let clause = select.having {
@@ -1998,6 +2015,14 @@ extension Catalog where Self: ~Escapable {
       // NULL-extended.
       try .outer(optimise(left, context), optimise(right, context), on: on,
                  kind: kind)
+    case let .apply(left, key, correlation, ordinals, on, kind):
+      // Optimise the left side (a seekable scan or a nested join inside it still
+      // rewrites), but keep the apply node, its `on`, and its recorded body plan
+      // intact — the body re-executes per outer row and was already compiled and
+      // pushed down under its own scope, so the outer optimise never reshapes
+      // it.
+      try .apply(optimise(left, context), key: key, correlation: correlation,
+                 ordinals: ordinals, on: on, kind: kind)
     case let .setop(kind, left, right, all):
       // Optimise each side with the same bindings so a bound predicate inside an
       // arm seeks; the set operation itself merely combines its sides,
@@ -2399,6 +2424,15 @@ extension Plan {
       // whole `WHERE` stays above (`distribute`'s default keeps it a `select`
       // over this node).
       try .outer(left.pushdown(), right.pushdown(), on: on, kind: kind)
+    case let .apply(left, key, correlation, ordinals, on, kind):
+      // Push down WITHIN the left side (its own joins/filters rewrite), but the
+      // apply is a pushdown barrier: its right side is not a static sub-plan but
+      // a per-outer-row re-execution, so a `WHERE` conjunct above it never rides
+      // into it (mirroring the `.outer` gate — `distribute`'s default keeps the
+      // conjunct a `select` over this node). The recorded body plan was already
+      // pushed down at its compile.
+      try .apply(left.pushdown(), key: key, correlation: correlation,
+                 ordinals: ordinals, on: on, kind: kind)
     case let .setop(kind, left, right, all):
       try .setop(kind, left.pushdown(), right.pushdown(), all: all)
     case let .distinct(source):
@@ -2878,8 +2912,14 @@ extension Catalog where Self: ~Escapable {
       let nested = (context.outer ?? Outer()).nested(under: within ?? Scope([]))
       // The context each nested compile/derive threads: the revealed base with
       // this frame's `nested` as the enclosing correlation stack and the
-      // shape-only lenience below.
-      let inner = context.with(outer: nested).validating(false)
+      // shape-only lenience below. `unlateralized()` clears the LATERAL-body
+      // flag so a nested ORDINARY subquery within a lateral body builds its OWN
+      // Resolution with `everywhere: false` — the lateral everywhere-admission
+      // covers ONLY the lateral body's own projection, NOT a subquery inside it,
+      // so an ordinary correlated scalar-subquery projection is barred exactly
+      // as it is outside a lateral body.
+      let inner =
+          context.with(outer: nested).validating(false).unlateralized()
       // A nested subquery's body derivation is SHAPE ONLY, so ALWAYS lenient
       // (`validate: false`) — this pass exists to record the subquery's width,
       // arity, and correlation, never to validate its body. Validation of a
@@ -2948,8 +2988,12 @@ extension Catalog where Self: ~Escapable {
         }
       }
     }
+    // A LATERAL body's `Resolution` admits a correlated preceding-FROM column
+    // EVERYWHERE (`everywhere`), so its projection lowers such a column to a
+    // `Term.parameter` rather than barring it — the ISO scoping a lateral body
+    // gets and an ordinary subquery (`context.lateral == false`) does not.
     return Resolution(scope, widths, types, correlations,
-                      outer: context.outer)
+                      outer: context.outer, everywhere: context.lateral)
   }
 
   /// The single VALUE a SCALAR subquery `query` collapses to against this
@@ -3040,10 +3084,13 @@ extension Catalog where Self: ~Escapable {
   /// and `relations.reduce(0) { $0 + $1.1.width }` the `SELECT *` width — every
   /// downstream derivation reads out of this one resolution.
   ///
-  /// `relations` is built INCREMENTALLY: resolve join `i`, append it, then
-  /// resolve join `i + 1`. Each join's schema is correlation-independent of the
-  /// relations preceding it, so the order is a no-op here; the incremental shape
-  /// is what a per-join preceding scope would thread through.
+  /// `relations` is built INCREMENTALLY, each join resolving against the
+  /// PRECEDING FROM (`Scope` of the relations before it): a LATERAL arm's
+  /// projection may name a preceding column, so its output SHAPE depends on
+  /// that scope. A non-lateral join's schema is correlation-independent, so the
+  /// preceding scope is harmless — the incremental order is a no-op for it. The
+  /// preceding scope threads through here rather than at each call site, so the
+  /// arity check gets a LATERAL arm's shape without duplicating the loop.
   private borrowing func resolve(from relation: Relation, schema: Schema,
                                  joins: Array<Join>, _ context: Context)
       throws(SQLError) -> (joined: Array<Resolved>,
@@ -3052,7 +3099,8 @@ extension Catalog where Self: ~Escapable {
     joined.reserveCapacity(joins.count)
     var relations = [(relation, schema)]
     for join in joins {
-      let resolved = try resolve(join.relation, context)
+      let resolved =
+          try resolve(join.relation, context, preceding: Scope(relations))
       joined.append(resolved)
       relations.append((join.relation, resolved.schema))
     }
@@ -3071,6 +3119,11 @@ extension Catalog where Self: ~Escapable {
       guard let relation = select.from else {
         throw .named("SELECT * with no FROM")
       }
+      // The FROM resolves once here; each join then resolves through the shared
+      // helper, which threads each join's PRECEDING scope into its resolve — so
+      // a LATERAL arm's body derives its projected preceding-FROM column against
+      // the relations before it rather than against no scope, which would fault
+      // the arity check even though the per-arm compile passes the prefix.
       let schema = try resolve(relation, context).schema
       let (_, relations) = try resolve(from: relation, schema: schema,
                                        joins: select.joins, context)
@@ -3118,9 +3171,95 @@ extension Catalog where Self: ~Escapable {
   /// `definition_schema.` store's `columns` builder, which compiles every view
   /// to advertise it, relies on this: a cyclic view's `try? compile` catches
   /// the fault and skips it.
-  internal borrowing func resolve(_ relation: Relation, _ context: Context)
+  /// Compiles a LATERAL derived table's `body` against the PRECEDING FROM
+  /// `scope`, discovering its correlation and stashing the pre-compiled plan for
+  /// the per-outer-row apply to re-execute — the FROM-clause analog of a
+  /// correlated subquery's compile pre-pass (`subquery(_:_:_:within:)`).
+  ///
+  /// The body compiles under a fresh `Outer` frame nested under `scope` (the
+  /// FROM relation and the joins BEFORE this one), so a body column naming a
+  /// preceding relation binds none of its OWN relations and resolves outward to
+  /// a synthetic `Term.parameter`, minting a `Correlation`. The plan compile is
+  /// lenient (`validate: false`), as the correlated-subquery pre-pass is — this
+  /// pass discovers the shape, and the run's per-row execution faults a REACHED
+  /// operand. The plan is recorded under the occurrence's `Subkey` (this
+  /// select's `subscope`, the body query, the `.lateral` role) composed with the
+  /// correlation, the same identity `Plan.apply` looks up through `executed`.
+  /// Returns the occurrence `Subkey` and the discovered correlation.
+  ///
+  /// A lateral body's SCHEMA + VALIDATION route through the SAME derived-body
+  /// machinery a NON-LATERAL derived body uses (`materialise`, `rows: false`),
+  /// differing ONLY in the OUTER treatment: a non-lateral body CLEARS the
+  /// correlation stack (`body(_:)`, uncorrelated), while a lateral body THREADS
+  /// the preceding-FROM `nested` outer so its correlated references resolve. So
+  /// a lateral body inherits the revealed-base overlay (base + CTEs + store,
+  /// its own alias out of scope) — a CTE stays visible in the body — AND the
+  /// `validate`-gated operand/function type-check, exactly as a non-lateral
+  /// body does. Under `validate: false` (a lenient run/shape pass) the body is
+  /// NOT eagerly type-checked, matching the reachability-gated validation the
+  /// rest of the engine applies; a REACHED bad operand still faults at run.
+  private borrowing func lateral(_ body: Query, against scope: Scope,
+                                 _ context: Context)
+      throws(SQLError) -> (key: Subkey, correlation: Correlation) {
+    let nested = (context.outer ?? Outer()).nested(under: scope)
+    // Derive the body's schema and — under `validate` — type-check its operands
+    // and functions through the SHARED derived-body path, over the revealed
+    // base (CTEs visible) with the preceding-FROM outer THREADED so a
+    // correlated reference resolves rather than faulting as unknown. The
+    // returned schema is discarded here (`resolve`/`schema(of:)` advertises the
+    // columns); this call exists to run the same validation a non-lateral body
+    // gets.
+    // Mark the body a LATERAL body (`lateralizing`) so its `Resolution`/
+    // `SubqueryCheck` admit a correlated preceding-FROM column EVERYWHERE,
+    // including its projection — per ISO a LATERAL body's preceding references
+    // are in scope throughout, unlike an ordinary subquery whose projection
+    // stays barred. The flag rides through the shared derived-body machinery to
+    // the projection lowering, where a projected preceding column lowers to a
+    // `Term.parameter` rather than faulting `.unsupported`.
+    let revealed = context.revealed().with(outer: nested).lateralizing()
+    _ = try materialise(body, revealed, rows: false)
+    // Compile the body LENIENTLY for the per-outer-row apply plan (the shape
+    // pass a correlated subquery's pre-pass runs), recording it under the
+    // occurrence's key composed with the discovered correlation. It compiles
+    // over the SAME revealed base the schema/validation pass above used (base +
+    // CTEs + store, this select's derived aliases STRIPPED) with the
+    // preceding-FROM outer threaded, so a body `FROM d` cannot bind a CALLER
+    // derived alias `d` as a relation — the compile and the schema path resolve
+    // the body's FROM identically, faulting an unknown relation consistently
+    // rather than the run-only compile scanning a caller alias the schema pass
+    // faults.
+    let inner = revealed.validating(false)
+    let plan = try compile(body, inner)
+    let key = Subkey(context.subscope, body, .lateral)
+    context.subqueries.record(plan: try plan.pushdown(), for: key,
+                              nested.correlation)
+    // The per-outer-row apply re-runs this plan under the occurrence scope's
+    // RECORDED revealed overlay (`revealed(under:)`), which the run stores as
+    // `revealed().relations` for `key.scope` — the SAME revealed base compiled
+    // here — so execution resolves the body's `FROM` identically and a shadowed
+    // CTE cannot diverge between compile and run.
+    return (key, nested.correlation)
+  }
+
+  internal borrowing func resolve(_ relation: Relation, _ context: Context,
+                                  preceding: Scope? = nil)
       throws(SQLError) -> Resolved {
     let name = relation.name
+    // A LATERAL derived table is not bound in the overlay — its rows are not a
+    // constant relation but a correlated apply's right side, materialised per
+    // outer row. Resolve only its SCHEMA here; the join loop compiles its body
+    // against the preceding FROM and emits a `Plan.apply` rather than calling
+    // the `leaf`, so the leaf is never reached for a lateral relation. Its
+    // output SHAPE is NOT correlation-independent (per ISO its projection may
+    // name a preceding column), so thread the `preceding` scope — the FROM
+    // relation and the joins BEFORE this one — so a projected preceding column
+    // types from that outer column exactly as the run lowers it.
+    if relation.lateral {
+      let schema = try schema(of: relation, context, preceding: preceding)
+      return Resolved(schema: schema) { ordinals in
+        .scan(name: name, ordinals: ordinals, seek: nil)
+      }
+    }
     if let cte = context.relations[name.lowercased()] {
       let schema = cte.schema()
       return Resolved(schema: schema) { ordinals in
@@ -3274,6 +3413,12 @@ extension Catalog where Self: ~Escapable {
       return try select.projection.scalar(context.routines,
                                           subquery: plans.rest)
     }
+    // A LATERAL first FROM item has no PRECEDING relation to correlate against,
+    // so it is meaningless (and ISO forbids it) — fault rather than resolve a
+    // lateral body against nothing.
+    guard !relation.lateral else {
+      throw .unsupported("a LATERAL derived table needs a preceding FROM item")
+    }
     let from = try resolve(relation, context)
 
     if let limit = select.limit {
@@ -3350,7 +3495,9 @@ extension Catalog where Self: ~Escapable {
 
     // Resolve every joined relation and lay all relations — the FROM relation
     // first, then each joined one in source order — end to end in one combined
-    // ordinal space.
+    // ordinal space. The helper builds the running `relations` INCREMENTALLY
+    // and threads each join's PRECEDING FROM as its resolve scope, so a LATERAL
+    // arm's schema derives against the relations before it.
     let (joined, relations) = try resolve(from: relation, schema: from.schema,
                                           joins: select.joins, context)
     let scope = Scope(relations)
@@ -3372,6 +3519,25 @@ extension Catalog where Self: ~Escapable {
     // its `ON` lowers against and a subquery in that `ON` correlates against.
     let prefixes = select.joins.indices.map { index in
       Scope(Array(relations[0 ... index + 1]))
+    }
+    // Resolve each LATERAL join's body ONCE against the PRECEDING FROM — the
+    // FROM relation and the joins BEFORE this one (`relations[0…index]`, ONE
+    // less than the prefix, which includes the join's own relation) — so a body
+    // column naming a preceding relation correlates outward and the body's plan
+    // is pre-compiled for the per-outer-row apply. A non-lateral join records
+    // nothing here (its `nil` slot). The apply is INNER only for now; a
+    // LEFT/OUTER lateral join is a deliberate follow-up, so fault it.
+    let empty: (key: Subkey, correlation: Correlation)? = nil
+    var laterals = Array(repeating: empty, count: select.joins.count)
+    for index in select.joins.indices {
+      let join = select.joins[index]
+      guard join.relation.lateral,
+          case let .derived(body) = join.relation.source else { continue }
+      guard join.kind == .inner else {
+        throw .unsupported("a LEFT/RIGHT/FULL LATERAL join is not supported")
+      }
+      let preceding = Scope(Array(relations[0 ... index]))
+      laterals[index] = try lateral(body, against: preceding, context)
     }
     // Compile every nested subquery ONCE for arity/type, ahead of lowering,
     // into a map the join ONs, WHERE, projection, and ORDER BY lowering reads —
@@ -3432,6 +3598,14 @@ extension Catalog where Self: ~Escapable {
     for match in matches { match.references(into: &references) }
     predicate?.references(into: &references)
     for key in order { key.term.references(into: &references) }
+    // A LATERAL apply reads its correlation's outer ordinals from the left
+    // chain's record, so those preceding-relation ordinals must be MATERIALISED
+    // (given a packed slot) even when no clause of THIS select references them —
+    // else the correlation's remap through `slot` finds no slot for the outer
+    // column its body names.
+    for lateral in laterals {
+      references.formUnion(lateral?.correlation.slots ?? [])
+    }
     let combined = references.sorted()
 
     var slot = Dictionary<Int, Int>(minimumCapacity: combined.count)
@@ -3456,15 +3630,29 @@ extension Catalog where Self: ~Escapable {
     // and an unmatched preserved row is NULL-extended rather than dropped; its
     // ON is NOT distributed into the product (a `WHERE` still filters after
     // it).
-    let seed = from.leaf(locals[0])
-    let chain = select.joins.indices.reduce(seed) { chain, index in
-      let leaf = joined[index].leaf(locals[index + 1])
+    var chain = from.leaf(locals[0])
+    for index in select.joins.indices {
       let on = matches[index].remapped(through: slot)
+      // A LATERAL join re-evaluates its pre-compiled body per outer row (a
+      // correlated apply): the apply node carries the body occurrence's `key`
+      // and its correlation (its `slot` outer ordinals remapped to the left
+      // chain's packed slots, so the per-row bind reads the correct cell) plus
+      // the referenced body-output `ordinals` this select takes, laid after the
+      // left's slots. Its `on` filters the concatenated pair; INNER APPLY drops
+      // a left row with no surviving right row.
+      if let lateral = laterals[index] {
+        chain = .apply(chain, key: lateral.key,
+                       correlation: lateral.correlation.remapped(through: slot),
+                       ordinals: locals[index + 1], on: on,
+                       kind: select.joins[index].kind)
+        continue
+      }
+      let leaf = joined[index].leaf(locals[index + 1])
       switch select.joins[index].kind {
       case .inner:
-        return .select(on, .product(chain, leaf))
+        chain = .select(on, .product(chain, leaf))
       case .left, .right, .full:
-        return .outer(chain, leaf, on: on, kind: select.joins[index].kind)
+        chain = .outer(chain, leaf, on: on, kind: select.joins[index].kind)
       }
     }
 

--- a/Sources/SQLEngine/Filter.swift
+++ b/Sources/SQLEngine/Filter.swift
@@ -818,6 +818,27 @@ extension Catalog where Self: ~Escapable {
     return extended
   }
 
+  /// `context` re-scoped to the RECORDED revealed overlay of the occurrence
+  /// `key`'s scope — the SAME revealed base (CTEs plus `definition_schema.`
+  /// store relations, every enclosing SELECT's derived aliases STRIPPED) the
+  /// occurrence's plan was COMPILED against. The run records it under the scope
+  /// (`.caller` at the top level, `.view(name)` in a view body) as
+  /// `revealed().relations`; scoping the EXECUTION context to it makes a
+  /// re-executed body resolve its `FROM` identically to compile, so a body
+  /// `.scan` binds the CTE compile chose rather than a caller derived alias of
+  /// the same name the unrevealed execution overlay would carry. On a miss (no
+  /// box recorded) it leaves the overlay unchanged.
+  ///
+  /// The predicate-subquery paths (`present`/`values`/`scalar`) and the LATERAL
+  /// apply share this ONE seam, so the body plan a `Plan.apply` re-runs
+  /// per left row resolves under the identical revealed overlay `lateral(_:
+  /// against:_:)` used at compile — the FROM-clause and predicate correlation
+  /// paths cannot diverge from it.
+  private borrowing func revealed(under key: Subkey, _ context: Context)
+      -> Context {
+    context.scoping(context.subqueries.overlay(key.scope) ?? context.relations)
+  }
+
   /// The rows a CORRELATED subquery occurrence `key` yields for `row` — the
   /// SINGLE augment-and-execute path every correlated caller (`present`,
   /// `values`, `scalar`) routes through, so none can skip the augmentation or
@@ -864,6 +885,65 @@ extension Catalog where Self: ~Escapable {
     return try execute(plan, augmented)
   }
 
+  /// The INNER/CROSS APPLY of a LATERAL derived table: for each `left` record,
+  /// re-executes the pre-compiled body (`key`/`correlation`) against that
+  /// record's correlated cells, takes `ordinals` from each produced right
+  /// record, concatenates it onto the left, and keeps the pair the `on`
+  /// predicate admits — a left record with no surviving right record is DROPPED
+  /// (`.inner`, the only kind the compiler emits for now; a LEFT/OUTER apply
+  /// that NULL-extends an unmatched left row is a deliberate follow-up).
+  ///
+  /// The lateral body runs through the SAME `executed` path a correlated
+  /// subquery does — it binds the correlation's `slot` sources from the borrowed
+  /// left `record`, augments the body's OWN aliases, and runs the pre-compiled
+  /// plan — so the borrow is never retained: `executed` returns owned
+  /// `Record`s, and the pair merges two owned records. The right record is the
+  /// body's FULL output, so `ordinals` select the referenced columns into the
+  /// combined space laid after the left's slots, exactly as a scan's referenced
+  /// ordinals sit after the left in a `product`.
+  ///
+  /// A lateral derived table exposes the universal virtual `Id` column at its
+  /// real `width` — its resolution schema is a `RelationInstance.schema()`, so
+  /// a body reference `d.Id` puts the virtual ordinal `width` into `ordinals`.
+  /// The `executed` body rows hold only the REAL columns (`0 ..< width`), so
+  /// taking `right.values[width]` would trap. This wraps THIS left row's body
+  /// output as a `RelationInstance` and materialises each right record through
+  /// `RelationInstance.record`, so the virtual `Id` ordinal yields the 1-based
+  /// row position within this left row's output — the SAME id derivation a
+  /// non-lateral derived table's `record` produces — while a real ordinal reads
+  /// its stored cell.
+  internal borrowing func applied(_ left: Array<Record>, _ key: Subkey,
+                                  _ correlation: Correlation,
+                                  _ ordinals: Array<Int>, _ on: Filter,
+                                  _ kind: Join.Kind, _ context: Context)
+      throws(SQLError) -> Array<Record> {
+    var records = Array<Record>()
+    // Re-run the pre-compiled body under the SAME revealed overlay it was
+    // COMPILED against — the occurrence scope's recorded revealed base — so a
+    // body `FROM e` scans the CTE `e` compile chose, not a caller derived alias
+    // `e` that shadows it in the UNREVEALED execution overlay. The `on`
+    // predicate stays on the caller `context`: it is a caller-level join
+    // predicate over the merged record's ordinals, and any subquery in it
+    // scopes to its OWN recorded overlay.
+    let body = revealed(under: key, context)
+    for record in left {
+      let right = try executed(record, key, correlation, body)
+      let width = right.first?.values.count ?? 0
+      let instance =
+          RelationInstance(columns: Array(repeating: "", count: width),
+                           rows: right.map(\.values),
+                           types: Array(repeating: .integer, count: width))
+      for index in right.indices {
+        let taken = instance.record(index, ordinals)
+        let paired = record.merged(with: taken)
+        if try evaluate(paired, on, context) == true {
+          records.append(paired)
+        }
+      }
+    }
+    return records
+  }
+
   /// Executes a correlated subquery's SET-OPERATION `plan` arm by arm — the
   /// plan and its `query` descend in lockstep (compile builds `.setop(kind,
   /// compile(left), compile(right), all)` from `.setop(kind, left, right,
@@ -901,9 +981,7 @@ extension Catalog where Self: ~Escapable {
     // Run under the overlay the occurrence's SCOPE was lowered under — the
     // caller's or the view body's — not the current execution site a pushdown
     // may have moved this predicate to.
-    let context =
-        context.scoping(context.subqueries.overlay(key.scope)
-                        ?? context.relations)
+    let context = revealed(under: key, context)
     // A CORRELATED EXISTS re-executes its PRE-COMPILED PROBE plan (correlated
     // columns are bound `Term.parameter`s; the plan is the cardinality-only
     // probed shape, so its select list — a would-fault `1 / 0` — never runs)
@@ -927,9 +1005,7 @@ extension Catalog where Self: ~Escapable {
                                 _ key: Subkey, _ correlation: Correlation,
                                 _ context: Context)
       throws(SQLError) -> Array<Value> {
-    let context =
-        context.scoping(context.subqueries.overlay(key.scope)
-                        ?? context.relations)
+    let context = revealed(under: key, context)
     // A CORRELATED `IN (Q)` re-executes its PRE-COMPILED inner plan against this
     // row's correlated bindings for its lone column, bypassing the memo. An
     // UNCORRELATED one memoises and re-runs its `Query` (recompiling resolves).
@@ -955,9 +1031,7 @@ extension Catalog where Self: ~Escapable {
                                 _ key: Subkey, _ correlation: Correlation,
                                 _ type: ValueType, _ context: Context)
       throws(SQLError) -> Value {
-    let context =
-        context.scoping(context.subqueries.overlay(key.scope)
-                        ?? context.relations)
+    let context = revealed(under: key, context)
     // A CORRELATED scalar subquery re-executes its PRE-COMPILED inner plan per
     // outer row against the correlated bindings, collapsing to its lone cell
     // (empty → NULL, one row → the cell, more → `.cardinality`), bypassing the

--- a/Sources/SQLEngine/Lexer.swift
+++ b/Sources/SQLEngine/Lexer.swift
@@ -427,6 +427,7 @@ internal struct Lexer: ~Escapable {
     case "OR": .or
     case "NOT": .not
     case "JOIN": .join
+    case "LATERAL": .lateral
     case "INNER": .inner
     case "LEFT": .left
     case "RIGHT": .right

--- a/Sources/SQLEngine/Operator.swift
+++ b/Sources/SQLEngine/Operator.swift
@@ -153,6 +153,19 @@ internal indirect enum Plan {
   /// nested loop that tracks matches, so it composes with an arbitrary
   /// (non-equi) `on`.
   case outer(Plan, Plan, on: Filter, kind: Join.Kind)
+  /// A correlated APPLY — a `LATERAL` derived table's nested loop. For each
+  /// record of the left sub-plan it re-executes the pre-compiled body plan
+  /// (looked up by `key` composed with `correlation`, whose `slot` sources bind
+  /// from that left record), takes `ordinals` from each produced right record
+  /// into the combined space laid AFTER the left's slots, concatenates it onto
+  /// the left, and keeps the pair the `on` predicate admits. INNER/CROSS APPLY
+  /// (`kind` `.inner`, the only kind emitted): a left record with no surviving
+  /// right record is DROPPED. Unlike a `product`/`outer` the right side is not a
+  /// static sub-plan — it re-runs per left row against the correlated bindings —
+  /// so the optimiser treats it as an opaque pushdown BARRIER and never rebases
+  /// a conjunct across it.
+  case apply(Plan, key: Subkey, correlation: Correlation,
+             ordinals: Array<Int>, on: Filter, kind: Join.Kind)
   /// A set operation of `kind` (`UNION`/`INTERSECT`/`EXCEPT`) over the `left`
   /// and `right` sub-plans, both yielding rows of the same width — the result
   /// columns of the first arm.
@@ -262,6 +275,10 @@ extension Plan {
       } else {
         nil
       }
+    case let .apply(left, _, _, ordinals, _, _):
+      // An apply lays the lateral body's taken `ordinals` after the left's
+      // slots, exactly as a product lays a scan's referenced ordinals.
+      left.slots.map { $0 + ordinals.count }
     case let .setop(_, left, _, _):
       // Both sides yield rows of the same width — the result columns — so the
       // set operation's width is its left side's.
@@ -389,6 +406,9 @@ extension Catalog where Self: ~Escapable {
       return try outer(execute(left, context), left.slots ?? 0,
                        execute(right, context), right.slots ?? 0, on, kind,
                        context)
+    case let .apply(left, key, correlation, ordinals, on, kind):
+      return try applied(execute(left, context), key, correlation, ordinals,
+                         on, kind, context)
     case let .setop(kind, left, right, all):
       return try setop(kind, left, right, all, context)
     case let .distinct(source):

--- a/Sources/SQLEngine/OutputColumn.swift
+++ b/Sources/SQLEngine/OutputColumn.swift
@@ -328,9 +328,14 @@ extension Catalog where Self: ~Escapable {
     // outer query's — a `validate: false` derive trusts a run-proven body.
     let context = try augment(context, for: .select(select), rows: false)
     guard let relation = select.from else { return Scope([]) }
+    // Build the running scope INCREMENTALLY so a LATERAL join's schema derives
+    // against the PRECEDING FROM — per ISO its projection may name a preceding
+    // column, so its output shape types from that scope. A non-lateral join's
+    // schema is correlation-independent, so the preceding scope is harmless.
     var relations = [(relation, try schema(of: relation, context))]
     for join in select.joins {
-      let joined = try schema(of: join.relation, context)
+      let joined =
+          try schema(of: join.relation, context, preceding: Scope(relations))
       relations.append((join.relation, joined))
     }
     return Scope(relations)
@@ -344,9 +349,12 @@ extension Catalog where Self: ~Escapable {
   private borrowing func prefixes(of select: Select, _ context: Context)
       throws(SQLError) -> Array<Scope> {
     guard let relation = select.from, !select.joins.isEmpty else { return [] }
+    // Build the running scope INCREMENTALLY so a LATERAL join's schema derives
+    // against the PRECEDING FROM (the same reason `scope(of:)` does).
     var relations = [(relation, try schema(of: relation, context))]
     for join in select.joins {
-      let joined = try schema(of: join.relation, context)
+      let joined =
+          try schema(of: join.relation, context, preceding: Scope(relations))
       relations.append((join.relation, joined))
     }
     return select.joins.indices.map { index in
@@ -527,9 +535,11 @@ extension Catalog where Self: ~Escapable {
     // Carry THIS select's own enclosing scope `context.outer` so its WHERE
     // type-check (`walk`) resolves a correlated column of THIS query against
     // the outer, matching the run's lowering; the projection/`HAVING` walk uses
-    // `.barred`.
+    // `.barred` — a NO-OP for a LATERAL body (`everywhere`), whose projection
+    // ISO puts the preceding references in scope for, so validation admits the
+    // projected correlated column exactly as the run's lowering does.
     return SubqueryCheck(widths, types, deferred: deferred,
-                         outer: context.outer)
+                         outer: context.outer, everywhere: context.lateral)
   }
 
   /// Records the cursor-free width and single-column type of `query` into
@@ -877,7 +887,8 @@ extension Catalog where Self: ~Escapable {
     // output name (an alias, else a group column's own name) — the surface an
     // `ORDER BY` output name resolves against — then lower the `ORDER BY`, which
     // faults a non-group column, an out-of-range ordinal, or an ambiguous name.
-    var grouping = try Grouping(scope, select.grouping, aggregations)
+    var grouping = try Grouping(scope, select.grouping, aggregations,
+                                subquery: subquery)
     let projection = try grouping.terms(select.projection, routines,
                                         subquery: subquery)
     _ = try grouping.order(clause, projection, routines, subquery: subquery)
@@ -907,9 +918,36 @@ extension Catalog where Self: ~Escapable {
   /// types WITHOUT re-checking its reachable operands, so a view whose body is
   /// data-dependent-empty — a text-arithmetic projection under a filter that
   /// matched no row — does not fault a `SELECT *` over it that already ran.
-  borrowing func schema(of relation: Relation, _ context: Context)
+  borrowing func schema(of relation: Relation, _ context: Context,
+                        preceding: Scope? = nil)
       throws(SQLError) -> Schema {
     let name = relation.name
+    // A LATERAL derived table is not bound in the overlay (it is never
+    // materialised once as a constant), so derive its schema through the SAME
+    // derived-body machinery a non-lateral body uses (`materialise`, `rows:
+    // false`) — over the REVEALED base (base + CTEs + store, its own alias out
+    // of scope), so a body naming a CTE resolves it, exactly as a non-lateral
+    // body does.
+    //
+    // Per ISO a LATERAL body's preceding-FROM references are in scope
+    // throughout its query expression, INCLUDING the SELECT list, so its output
+    // SHAPE is NOT correlation-independent — a projected preceding column
+    // (`SELECT T.Id AS id`) types from that outer column. So the schema derive
+    // THREADS the `preceding` scope as the correlation stack (`with(outer:)`)
+    // and marks the body a lateral one (`lateralizing`), the SAME
+    // revealed-base-with-outer context `compile(select)`'s `lateral` compiles
+    // it under — schema, validation, and compile share it, so a projected
+    // preceding column derives its type here exactly as the run lowers it to a
+    // bound parameter. `validate: false` keeps the derive lenient; the strict
+    // operand/function type-check rides through `compile(select)`'s `lateral`
+    // path where the `validate` gate is honoured, so it is not duplicated here.
+    if relation.lateral, case let .derived(query) = relation.source {
+      let stack = context.outer ?? Outer()
+      let nested = stack.nested(under: preceding ?? Scope([]))
+      let scope = context.revealed().with(outer: nested)
+          .lateralizing().validating(false)
+      return try materialise(query, scope, rows: false).schema()
+    }
     if let cte = context.relations[name.lowercased()] {
       return cte.schema()
     }
@@ -988,7 +1026,9 @@ extension Scope {
     case .all:
       outputs()
     case let .columns(references):
-      try references.map { column throws(SQLError) in try output(of: column) }
+      try references.map { column throws(SQLError) in
+        try output(of: column, subquery: subquery)
+      }
     case let .expressions(items):
       try items.indices.map { index throws(SQLError) in
         try output(items[index], at: index, routines, subquery: subquery)
@@ -1008,10 +1048,23 @@ extension Scope {
   }
 
   /// The output column a bare `column` reference yields: its own name (its
-  /// spelling as written), typed from the relation that resolves it.
-  internal func output(of column: Column) throws(SQLError) -> OutputColumn {
-    let type = try type(at: ordinal(of: column))
-    return OutputColumn(name: column.name, type: type)
+  /// spelling as written), typed from the relation that resolves it — or, for a
+  /// name no local relation binds, from the correlation `subquery` surface,
+  /// mirroring the expression path's `derive`. Under a LATERAL body's admitting
+  /// (`everywhere`) surface a preceding-FROM column types as its outer column;
+  /// under an ordinary barred surface it faults `.unsupported`. A genuinely
+  /// unknown name re-throws the `.column` fault.
+  internal func output(of column: Column,
+                       subquery: Resolution = .unsupported)
+      throws(SQLError) -> OutputColumn {
+    if let ordinal = try find(column) {
+      return OutputColumn(name: column.name, type: type(at: ordinal))
+    }
+    if let type = try subquery.correlated(column) {
+      return OutputColumn(name: column.name, type: type)
+    }
+    return try OutputColumn(name: column.name,
+                            type: type(at: ordinal(of: column)))
   }
 
   /// The output column a projected `item` at 0-based `index` yields: its

--- a/Sources/SQLEngine/Parser.swift
+++ b/Sources/SQLEngine/Parser.swift
@@ -420,6 +420,11 @@ internal struct Parser: ~Escapable {
   /// name — exactly as the scalar-subquery and `IN (…)` lookaheads are, so
   /// no rewind is needed.
   ///
+  /// An optional leading `LATERAL` marks the derived table lateral (ISO
+  /// `LATERAL (query)`): its body may reference the PRECEDING FROM items, so it
+  /// re-evaluates per their rows. `LATERAL` introduces a derived table alone —
+  /// a `(SELECT …)` must follow — so a `LATERAL` before a named relation faults.
+  ///
   /// Derived table's alias is REQUIRED (ISO): `FROM (SELECT …)` with no `AS t`
   /// faults. A named relation's alias is optional and may be introduced by `AS`
   /// (`TypeDef AS t`) or written directly after the name (`TypeDef t`); the
@@ -427,6 +432,7 @@ internal struct Parser: ~Escapable {
   /// following keyword (`JOIN`, `WHERE`, …) or the end of input is not mistaken
   /// for an alias.
   private mutating func relation() throws(SQLError) -> Relation {
+    let lateral = try match(.lateral)
     if try match(.lparen) {
       guard let token = current else {
         throw .incomplete(expected: "a derived table '(SELECT …)'")
@@ -448,7 +454,16 @@ internal struct Parser: ~Escapable {
                           expected: "'AS' and an alias for the derived table",
                           at: token.location)
       }
-      return try Relation(derived: query, as: identifier())
+      return try Relation(derived: query, as: identifier(), lateral: lateral)
+    }
+    // `LATERAL` introduces a derived table; a named relation may not follow it.
+    guard !lateral else {
+      guard let token = current else {
+        throw .incomplete(expected: "a derived table after LATERAL")
+      }
+      throw .unexpected(token.kind.description,
+                        expected: "a derived table '(SELECT …)' after LATERAL",
+                        at: token.location)
     }
     let name = try identifier()
     let alias: String? = if try match(.as) {

--- a/Sources/SQLEngine/Resolve.swift
+++ b/Sources/SQLEngine/Resolve.swift
@@ -68,6 +68,11 @@ internal enum Role: Hashable, Sendable {
   case valued
   /// An `EXISTS (SELECT …)` occurrence — a cardinality probe.
   case existential
+  /// A `LATERAL (SELECT …)` FROM/JOIN occurrence — a correlated apply's right
+  /// side, materialised in full per outer row. Distinct from the predicate
+  /// roles so a lateral body's pre-compiled plan keys disjointly from any
+  /// scalar/`IN`/`EXISTS` occurrence of the same inner SQL.
+  case lateral
 }
 
 /// The cache identity of one collected subquery OCCURRENCE — its resolution
@@ -472,17 +477,30 @@ internal struct Resolution {
   /// correlated column as unsupported rather than mis-resolving it.
   private let admits: Bool
 
+  /// Whether the surface admits a correlated column EVERYWHERE — in the barred
+  /// clause positions (the projection / `GROUP BY` / `HAVING`) as well as the
+  /// `WHERE`/`ON` — set ONLY when lowering a LATERAL derived table's body. Per
+  /// ISO 9075 a `LATERAL` body's preceding-FROM references are in scope
+  /// throughout its query expression, INCLUDING the select list, so a lateral
+  /// body correlates everywhere while an ordinary subquery's projection stays
+  /// barred. When `true`, `barred` is a NO-OP — it keeps `admits`, so a
+  /// projected preceding column still lowers to a `Term.parameter` — and the
+  /// per-outer-row apply binds it exactly as a `WHERE`-correlated one.
+  private let everywhere: Bool
+
   internal init(_ scope: Subscope = .caller,
                 _ widths: Dictionary<Query, Int> = [:],
                 _ types: Dictionary<Query, ValueType> = [:],
                 _ correlations: Dictionary<Query, Correlation> = [:],
-                outer: Outer? = nil, admits: Bool = true) {
+                outer: Outer? = nil, admits: Bool = true,
+                everywhere: Bool = false) {
     self.scope = scope
     self.widths = widths
     self.types = types
     self.correlations = correlations
     self.outer = outer
     self.admits = admits
+    self.everywhere = everywhere
   }
 
   /// A `Resolution` for a lowering surface with no catalog — a schema-only
@@ -497,8 +515,16 @@ internal struct Resolution {
   /// cut. It keeps the widths/types/correlations (nested subqueries there still
   /// lower and carry their OWN inner correlation) but rejects a correlated
   /// column of THIS query as unsupported.
+  ///
+  /// A LATERAL body's surface (`everywhere`) is the exception: ISO puts the
+  /// preceding-FROM references in scope throughout the body INCLUDING the
+  /// select list, so `barred` is a NO-OP there — the projection keeps admitting
+  /// a correlated column, which lowers to a `Term.parameter` the apply binds
+  /// per outer row.
   internal var barred: Resolution {
-    Resolution(scope, widths, types, correlations, outer: outer, admits: false)
+    guard !everywhere else { return self }
+    return Resolution(scope, widths, types, correlations, outer: outer,
+                      admits: false, everywhere: everywhere)
   }
 
   /// The synthetic bound-parameter name a CORRELATED reference to `column`
@@ -876,17 +902,26 @@ internal struct SubqueryCheck {
   /// correlated-projection case exactly where the run does.
   private let admits: Bool
 
+  /// Whether the surface admits a correlated column EVERYWHERE — a LATERAL
+  /// body's validation surface, the analog of `Resolution.everywhere` — so
+  /// `barred` is a NO-OP and the projection/`HAVING` walk of a lateral body
+  /// validates a correlated preceding column rather than faulting, matching the
+  /// run's lowering (typecheck↔run parity).
+  private let everywhere: Bool
+
   internal init(_ widths: Dictionary<Query, Int> = [:],
                 _ types: Dictionary<Query, ValueType> = [:],
                 deferred: Set<Query> = [],
                 reached: ReachedScalars = ReachedScalars(),
-                outer: Outer? = nil, admits: Bool = true) {
+                outer: Outer? = nil, admits: Bool = true,
+                everywhere: Bool = false) {
     self.widths = widths
     self.types = types
     self.deferred = deferred
     self.reached = reached
     self.outer = outer
     self.admits = admits
+    self.everywhere = everywhere
   }
 
   /// A checker for a surface with no catalog — validating a subquery needs one,
@@ -898,10 +933,14 @@ internal struct SubqueryCheck {
 
   /// This checker with correlation BARRED — the surface a projection / `GROUP
   /// BY` / `HAVING` type-checks under, where an outer column is out of the (b)
-  /// cut and is diagnosed rather than resolved. Mirrors `Resolution.barred`.
+  /// cut and is diagnosed rather than resolved. Mirrors `Resolution.barred` —
+  /// including the LATERAL-body exception (`everywhere`), where it is a NO-OP
+  /// so the projection/`HAVING` walk keeps admitting the correlated preceding
+  /// column the run's lowering binds.
   internal var barred: SubqueryCheck {
-    SubqueryCheck(widths, types, deferred: deferred, reached: reached,
-                  outer: outer, admits: false)
+    guard !everywhere else { return self }
+    return SubqueryCheck(widths, types, deferred: deferred, reached: reached,
+                         outer: outer, admits: false, everywhere: everywhere)
   }
 
   /// This checker over a FRESH `reached` box, carrying `outer` — the surface a
@@ -3592,11 +3631,26 @@ internal struct Grouping {
   /// RESOLVED `Aggregation` (see `group`), so a qualification-equivalent pair
   /// is one entry sharing one slot.
   internal init(_ scope: Scope, _ columns: Array<Column>,
-                _ aggregates: Array<Aggregation>) throws(SQLError) {
+                _ aggregates: Array<Aggregation>,
+                subquery: Resolution = .unsupported) throws(SQLError) {
     self.scope = scope
     var keys = Dictionary<Int, Int>(minimumCapacity: columns.count)
     for index in columns.indices {
-      try keys[scope.ordinal(of: columns[index])] = index
+      // A grouping key a local relation binds maps its combined ordinal to its
+      // grouped slot. A key NONE binds is a candidate CORRELATED reference (a
+      // LATERAL body grouping on a preceding column): the correlation surface's
+      // non-recording `correlated` probe distinguishes it from a genuine unknown
+      // column, and it occupies grouped slot `index` as a `.parameter` key (in
+      // `group`'s keys array) with NO ordinal→slot entry — the projection reads
+      // it via the same correlation, never through this key dict. A genuinely
+      // unknown column re-throws the `.column` fault; a barred surface diagnoses
+      // a bound outer column `.unsupported`. `correlated` records nothing, so it
+      // stays idempotent against `group`'s own correlation of the same key.
+      if let ordinal = try scope.find(columns[index]) {
+        keys[ordinal] = index
+      } else if try subquery.correlated(columns[index]) == nil {
+        _ = try scope.ordinal(of: columns[index])
+      }
     }
     self.keys = keys
     self.offset = columns.count
@@ -3633,9 +3687,20 @@ internal struct Grouping {
     }
     switch expression {
     case let .column(column):
-      let ordinal = try scope.ordinal(of: column)
-      guard let slot = keys[ordinal] else { throw .grouping(column.name) }
-      return .slot(slot)
+      // Resolve the column against this scope's own relations first, mirroring
+      // `Scope.term`'s `.column`: a name a local relation binds must be a `GROUP
+      // BY` key (the standard grouping rule), else `SQLError.grouping`. A name
+      // NONE binds is a candidate CORRELATED reference — consult the surface,
+      // which admits it (a `Term.parameter` the apply binds per outer row) only
+      // for a LATERAL body's `everywhere` seam and diagnoses it `.unsupported` on
+      // an ordinary barred grouped surface. The final `ordinal(of:)` re-throws
+      // the genuine unknown-column `.column` fault, exactly as `Scope.term` does.
+      if let ordinal = try scope.find(column) {
+        guard let slot = keys[ordinal] else { throw .grouping(column.name) }
+        return .slot(slot)
+      }
+      if let name = try subquery.correlate(column) { return .parameter(name) }
+      return try .slot(scope.ordinal(of: column))
     case let .literal(literal):
       return try .constant(value(of: literal))
     case let .call(name, arguments):

--- a/Sources/SQLEngine/Token.swift
+++ b/Sources/SQLEngine/Token.swift
@@ -43,6 +43,9 @@ extension Token {
     case or
     case not
     case join
+    /// The `LATERAL` keyword introducing a FROM/JOIN derived table whose body
+    /// may reference the preceding FROM items (a correlated apply).
+    case lateral
     case inner
     case left
     case right
@@ -146,6 +149,7 @@ extension Token.Kind {
     case .or: "OR"
     case .not: "NOT"
     case .join: "JOIN"
+    case .lateral: "LATERAL"
     case .inner: "INNER"
     case .left: "LEFT"
     case .right: "RIGHT"

--- a/Tests/SQLTests/DerivedTableTests.swift
+++ b/Tests/SQLTests/DerivedTableTests.swift
@@ -53,7 +53,8 @@ private func parse(query text: String) throws -> Query {
 
 struct DerivedTableParsingTests {
   @Test func `parses a derived table in FROM with an alias`() throws {
-    let select = try parse(select: "SELECT t.a FROM (SELECT V AS a FROM S) AS t")
+    let select = try parse(select:
+        "SELECT t.a FROM (SELECT V AS a FROM S) AS t")
     let inner = try parse(query: "SELECT V AS a FROM S")
     #expect(select.from == Relation(derived: inner, as: "t"))
   }
@@ -99,6 +100,35 @@ struct DerivedTableParsingTests {
     // `Hashable`/`Equatable`.
     let text = "SELECT t.a FROM (SELECT V AS a FROM S) AS t"
     #expect(try parse(query: text) == parse(query: text))
+  }
+
+  @Test func `parses LATERAL before a JOIN derived table and sets the flag`()
+      throws {
+    // A leading `LATERAL` before a `(SELECT …)` derived table sets the
+    // `lateral` flag, so the resolver threads the preceding FROM outward.
+    let select = try parse(select:
+        "SELECT T.Id FROM T " +
+        "JOIN LATERAL (SELECT V AS v FROM S WHERE V = T.Id) AS d ON T.Id = d.v")
+    let inner = try parse(query: "SELECT V AS v FROM S WHERE V = T.Id")
+    #expect(select.joins.count == 1)
+    #expect(select.joins[0].relation
+            == Relation(derived: inner, as: "d", lateral: true))
+    #expect(select.joins[0].relation.lateral)
+  }
+
+  @Test func `a non-lateral derived table has the flag clear`() throws {
+    // The default is non-lateral — a plain `(SELECT …)` never sets `lateral`.
+    let select = try parse(select:
+        "SELECT t.a FROM (SELECT V AS a FROM S) AS t")
+    #expect(!(select.from?.lateral ?? true))
+  }
+
+  @Test func `LATERAL before a named relation faults`() throws {
+    // `LATERAL` introduces a derived table alone, so a named relation after it
+    // faults rather than marking the base relation lateral.
+    #expect(throws: SQLError.self) {
+      _ = try parse(select: "SELECT a FROM T JOIN LATERAL S ON T.Id = S.k")
+    }
   }
 }
 

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -1380,6 +1380,8 @@ private func outers(_ plan: Plan) -> Bool {
     outers(left) || outers(right)
   case let .join(source, _, _, _, _, _, _):
     outers(source)
+  case let .apply(left, _, _, _, _, _):
+    outers(left)
   case let .setop(_, left, right, _):
     outers(left) || outers(right)
   case let .aggregate(_, _, source):
@@ -1773,6 +1775,8 @@ private func derived(_ plan: Plan) -> Plan? {
     derived(left) ?? derived(right)
   case let .outer(left, right, _, _):
     derived(left) ?? derived(right)
+  case let .apply(left, _, _, _, _, _):
+    derived(left)
   case let .setop(_, left, right, _):
     derived(left) ?? derived(right)
   case let .limit(_, _, source):
@@ -1807,6 +1811,8 @@ private func seeks(_ plan: Plan) -> Bool {
     seeks(outer)
   case let .outer(left, right, _, _):
     seeks(left) || seeks(right)
+  case let .apply(left, _, _, _, _, _):
+    seeks(left)
   case let .setop(_, left, right, _):
     seeks(left) || seeks(right)
   case let .limit(_, _, source):
@@ -1838,6 +1844,8 @@ private func filters(_ plan: Plan) -> Bool {
     filters(left) || filters(right)
   case let .outer(left, right, _, _):
     filters(left) || filters(right)
+  case let .apply(left, _, _, _, _, _):
+    filters(left)
   case let .setop(_, left, right, _):
     filters(left) || filters(right)
   case let .limit(_, _, source):
@@ -1865,6 +1873,8 @@ private func pushed(_ plan: Plan) -> Bool {
   case let .outer(left, right, _, _):
     seeks(left) || floats(left) || pushed(left) || seeks(right)
         || floats(right) || pushed(right)
+  case let .apply(left, _, _, _, _, _):
+    seeks(left) || floats(left) || pushed(left)
   case let .select(_, source):
     pushed(source)
   case let .project(_, source):
@@ -1927,6 +1937,8 @@ private func joins(_ plan: Plan) -> Bool {
     joins(left) || joins(right)
   case let .outer(left, right, _, _):
     joins(left) || joins(right)
+  case let .apply(left, _, _, _, _, _):
+    joins(left)
   case let .setop(_, left, right, _):
     joins(left) || joins(right)
   case let .aggregate(_, _, source):
@@ -1961,6 +1973,8 @@ private func residual(_ plan: Plan) -> Bool {
     residual(outer)
   case let .outer(left, right, _, _):
     residual(left) || residual(right)
+  case let .apply(left, _, _, _, _, _):
+    residual(left)
   case let .setop(_, left, right, _):
     residual(left) || residual(right)
   case let .aggregate(_, _, source):
@@ -1996,6 +2010,8 @@ private func separated(_ plan: Plan) -> Bool {
     separated(outer)
   case let .outer(left, right, _, _):
     separated(left) || separated(right)
+  case let .apply(left, _, _, _, _, _):
+    separated(left)
   case let .setop(_, left, right, _):
     separated(left) || separated(right)
   case let .aggregate(_, _, source):
@@ -2032,6 +2048,8 @@ private func stacked(_ plan: Plan) -> Bool {
     stacked(outer)
   case let .outer(left, right, _, _):
     stacked(left) || stacked(right)
+  case let .apply(left, _, _, _, _, _):
+    stacked(left)
   case let .setop(_, left, right, _):
     stacked(left) || stacked(right)
   case let .aggregate(_, _, source):
@@ -2144,6 +2162,8 @@ private func injected(_ plan: Plan) -> Bool {
     injected(left) || injected(right)
   case let .outer(left, right, _, _):
     injected(left) || injected(right)
+  case let .apply(left, _, _, _, _, _):
+    injected(left)
   case let .join(outer, _, _, _, _, _, _):
     injected(outer)
   case let .aggregate(_, _, source):

--- a/Tests/SQLTests/LateralTests.swift
+++ b/Tests/SQLTests/LateralTests.swift
@@ -1,0 +1,537 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQLEngine
+
+import SQLTestSupport
+
+/// Parses `text` to a query, failing on any other statement.
+private func parse(query text: String) throws -> Query {
+  guard case let .select(query) = try Statement(parsing: text) else {
+    Issue.record("expected a SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return query
+}
+
+// MARK: - LATERAL execution
+
+/// A parent `T` and a child `S` keyed on `T.Id`, so a LATERAL body's right side
+/// VARIES per outer row — the proof of real correlation a once-materialised
+/// constant relation could not produce.
+private func fixture() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["Id": .integer]) {
+      Row(1)
+      Row(2)
+      Row(3)
+    }
+    // `S.k` references `T.Id`: Id 1 has two children, Id 2 one, Id 3 none.
+    Relation("S", ["k": .integer, "x": .integer]) {
+      Row(1, 100)
+      Row(1, 101)
+      Row(2, 200)
+    }
+  }
+}
+
+/// A LATERAL derived table resolves its body against the PRECEDING FROM and
+/// re-evaluates it per that row — a correlated apply. The right side differs per
+/// left row (impossible for a once-materialised constant), and an INNER apply
+/// drops a left row whose body yields nothing.
+struct LateralExecutionTests {
+  @Test func `a LATERAL body yields per-outer-row-varying rows`() throws {
+    // `… JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON 1 = 1` — the
+    // body's `T.Id` correlates to the preceding `T`, so `d` re-runs per `T` row
+    // over the children keyed on THAT `Id`: Id 1 → {100, 101}, Id 2 → {200},
+    // Id 3 → {} (dropped, INNER apply). The right side VARIES per left row.
+    try fixture().expect(
+        "SELECT T.Id, d.x FROM T " +
+        "JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON 1 = 1 " +
+        "ORDER BY T.Id, d.x",
+        yields: [[1, 100], [1, 101], [2, 200]])
+  }
+
+  @Test func `an INNER LATERAL apply drops a left row with no right rows`()
+      throws {
+    // `T.Id` 3 has no child in `S`, so the INNER apply drops it — only 1 and 2
+    // survive, each once (a `COUNT`-shaped scalar lateral body).
+    try fixture().expect(
+        "SELECT T.Id, d.n FROM T " +
+        "JOIN LATERAL (SELECT COUNT(*) AS n FROM S WHERE S.k = T.Id) AS d " +
+        "ON d.n > 0 ORDER BY T.Id",
+        yields: [[1, 2], [2, 1]])
+  }
+
+  @Test func `a LATERAL apply's ON further filters the pair`() throws {
+    // The join `ON` filters the concatenated pair after the apply: keep only the
+    // children whose `x` exceeds 100, so Id 1 keeps just 101 and Id 2 keeps 200.
+    try fixture().expect(
+        "SELECT T.Id, d.x FROM T " +
+        "JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON d.x > 100 " +
+        "ORDER BY T.Id, d.x",
+        yields: [[1, 101], [2, 200]])
+  }
+
+  @Test func `a LATERAL apply materialises a correlated column the outer drops`()
+      throws {
+    // The outer projects only `d.x`, never `T.Id` — but the apply still reads
+    // `T.Id` from the left record to bind the body's correlation, so the
+    // preceding column is materialised (given a slot) even though no outer
+    // clause references it.
+    try fixture().expect(
+        "SELECT d.x FROM T " +
+        "JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON 1 = 1 " +
+        "ORDER BY d.x",
+        yields: [[100], [101], [200]])
+  }
+
+  @Test func `a LATERAL body advertises its output schema`() throws {
+    // A lateral body's SHAPE is correlation-independent — its projection names
+    // its OWN relation `S`, so `columns(of:)` reports the body's output column
+    // `x` under `d` even though the body's WHERE correlates against `T`.
+    let query = try parse(query:
+        "SELECT d.x FROM T " +
+        "JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON 1 = 1")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+    #expect(columns[0].name == "x")
+    #expect(columns[0].type == .integer)
+  }
+
+  @Test func `a NON-lateral body still faults the preceding column`() throws {
+    // PARITY: the SAME body WITHOUT `LATERAL` still faults the unknown
+    // preceding column — the no-LATERAL rule is intact (a non-lateral body is
+    // resolved independently of its call site).
+    try fixture().expect(
+        "SELECT T.Id, d.x FROM T " +
+        "JOIN (SELECT x FROM S WHERE S.k = T.Id) AS d ON 1 = 1",
+        fails: .column("Id"))
+  }
+
+  @Test func `a LATERAL first FROM item faults`() throws {
+    // A lateral derived table needs a PRECEDING FROM item; as the sole FROM
+    // relation it has nothing to correlate against, so it faults.
+    try fixture().expect(
+        "SELECT d.x FROM LATERAL (SELECT x FROM S) AS d",
+        fails: .unsupported(
+            "a LATERAL derived table needs a preceding FROM item"))
+  }
+
+  @Test func `a CTE is visible inside a LATERAL body`() throws {
+    // The lateral body resolves against the SAME scope its call site sees, so
+    // an enclosing CTE `c` is visible inside it — the structural fix unified
+    // the lateral body's resolution scope with the outer query's. The schema
+    // pass derives the body's output column `x`, and the run correlates it per
+    // `T` row: `c` holds the single value 1, so the body matches only the `T`
+    // row whose `Id` is 1 (an INNER apply drops Ids 2 and 3, which `c` never
+    // equals).
+    let statement = try Statement(parsing:
+        "WITH c(x) AS (SELECT 1 AS x) SELECT d.x FROM T " +
+        "JOIN LATERAL (SELECT x FROM c WHERE x = T.Id) AS d ON 1 = 1")
+    let columns = try fixture().columns(of: statement, validate: true)
+    #expect(columns.count == 1)
+    #expect(columns[0].name == "x")
+    #expect(columns[0].type == .integer)
+    let rows = try fixture().run(statement, .standard)
+    #expect(rows == [[.integer(1)]])
+  }
+
+  @Test func `a bad function in a LATERAL body faults the schema check`()
+      throws {
+    // PARITY: the schema pass validates the lateral body exactly as the run
+    // executes it, so an unregistered `bad` function in the body faults the
+    // strict `columns(of:validate:true)` schema check with the same
+    // `SQLError.function` the run raises — the schema is not advertised for a
+    // lateral body a run would reject.
+    #expect(throws: SQLError.function("bad")) {
+      let query = try parse(query:
+          "SELECT d.x FROM T " +
+          "JOIN LATERAL (SELECT bad(S.x) AS x FROM S WHERE S.k = T.Id) AS d " +
+          "ON 1 = 1")
+      _ = try fixture().columns(of: query, validate: true)
+    }
+  }
+
+  @Test func `validate false does not eagerly fault a bad LATERAL body`()
+      throws {
+    // LENIENT PARITY: with `validate: false` — the run-shape pass — the same
+    // bad-function lateral body is NOT eager-checked, so deriving its headers
+    // returns the body's output column `x` WITHOUT the `.function` fault,
+    // matching the engine's reachability-gated validation (the strict schema
+    // path faults it; the lenient one trusts it).
+    let query = try parse(query:
+        "SELECT d.x FROM T " +
+        "JOIN LATERAL (SELECT bad(S.x) AS x FROM S WHERE S.k = T.Id) AS d " +
+        "ON 1 = 1")
+    let columns = try fixture().columns(of: query, validate: false)
+    #expect(columns.map(\.name) == ["x"])
+  }
+
+  @Test func `a LATERAL body exposes its virtual Id per left row`() throws {
+    // A lateral derived table exposes the universal virtual `Id` at its real
+    // width, so `d.Id` names the 1-based position of the row WITHIN this left
+    // row's body output — reset per outer row, exactly as a non-lateral derived
+    // table's `Id` numbers its own materialised rows. Id 1 → children {100,
+    // 101} → d.Id {1, 2}; Id 2 → {200} → d.Id {1}; Id 3 → {} (dropped). The
+    // apply materialises the body output through the same `RelationInstance`
+    // `Id` derivation, so `d.Id` yields the id rather than trapping past the
+    // real columns.
+    try fixture().expect(
+        "SELECT d.Id, d.x FROM T " +
+        "JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON 1 = 1 " +
+        "ORDER BY T.Id, d.Id",
+        yields: [[1, 100], [2, 101], [1, 200]])
+  }
+
+  @Test func `a LATERAL virtual Id matches a non-lateral derived Id`() throws {
+    // PARITY: the per-left-row `d.Id` a lateral body advertises numbers its own
+    // output the SAME way a non-lateral derived table numbers its materialised
+    // rows — the FIRST left row (`T.Id` 1) has two children, so its lateral
+    // `d.Id`s are 1 and 2, exactly a non-lateral `(SELECT x FROM S WHERE S.k =
+    // 1) AS d`'s Ids over the same two rows.
+    try fixture().expect(
+        "SELECT d.Id, d.x FROM T " +
+        "JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON 1 = 1 " +
+        "WHERE T.Id = 1 ORDER BY d.Id",
+        equals:
+        "SELECT d.Id, d.x " +
+        "FROM (SELECT x FROM S WHERE S.k = 1) AS d ORDER BY d.Id")
+  }
+
+  @Test func `a LATERAL virtual Id resolves in the ON`() throws {
+    // The virtual `Id` is also readable from the join `ON`: `d.Id = 1` keeps
+    // only the FIRST body row per left row, so Id 1 keeps just its first child
+    // (100) and Id 2 keeps 200 (its lone, first, child). The apply materialises
+    // the virtual `Id` into the pair the `ON` evaluates, so a `d.Id` reference
+    // there resolves rather than trapping.
+    try fixture().expect(
+        "SELECT T.Id, d.x FROM T " +
+        "JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON d.Id = 1 " +
+        "ORDER BY T.Id, d.x",
+        yields: [[1, 100], [2, 200]])
+  }
+
+  @Test func `a LATERAL body advertises its virtual Id column`() throws {
+    // The strict schema path advertises the lateral body's virtual `Id`
+    // alongside its real column `x`, so `columns(of:validate: true)` reports
+    // both — the `Id` a run materialises at the body's width.
+    let query = try parse(query:
+        "SELECT d.Id, d.x FROM T " +
+        "JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON 1 = 1")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.map(\.name) == ["Id", "x"])
+  }
+
+  @Test func `a LATERAL body cannot see a caller derived alias`() throws {
+    // STRUCTURAL PARITY: the lateral body's PLAN compile resolves its `FROM`
+    // over the SAME revealed base the schema/validation pass does — base plus
+    // CTEs plus store, this select's derived aliases STRIPPED — so a body
+    // naming a CALLER derived alias `e` faults the unknown relation
+    // CONSISTENTLY at both the schema pass and the run, rather than the
+    // run-only compile scanning the caller's `e` while the schema pass faults.
+    // The caller reference sits in the set-operation body's LATER arm (`…
+    // UNION ALL SELECT x FROM e`), the arm the run-path shape pass
+    // (`materialise`, `rows: false`) does NOT derive — so ONLY the plan compile
+    // ever resolved it, the exact path the unified revealed base now closes.
+    let sql =
+        "SELECT d.x FROM T " +
+        "JOIN (SELECT 9 AS y) AS e ON 1 = 1 " +
+        "JOIN LATERAL (SELECT 0 AS x UNION ALL SELECT x FROM e) AS d ON 1 = 1"
+    // The run faults the unknown relation the body's later arm names.
+    try fixture().expect(sql, fails: .relation("e"))
+    // The strict schema path faults it identically — schema and run agree.
+    #expect(throws: SQLError.relation("e")) {
+      let query = try parse(query: sql)
+      _ = try fixture().columns(of: query, validate: true)
+    }
+  }
+
+  @Test func `a shadowed CTE in a LATERAL body resolves the same at compile and run`()
+      throws {
+    // EXECUTION/COMPILE PARITY: a CTE `e` SHADOWED by a caller derived alias
+    // `e` is in scope of the lateral body's `FROM e`. Compile resolves the body
+    // over the REVEALED base (CTEs plus store, this select's derived aliases
+    // STRIPPED), so it binds the CTE `e` (x = 1). The per-outer-row apply must
+    // re-run that plan under the SAME revealed overlay — else it scans the
+    // UNREVEALED caller derived alias `e` (x = 2) and yields the WRONG rows.
+    // The CTE matches `T.Id` 1, the derived alias would match `T.Id` 2, so the
+    // divergence is a visible wrong row, not merely an empty result. The run
+    // yields the CTE's row and `columns(of:validate: true)` agrees — schema,
+    // compile, and execution resolve the body's `FROM` identically.
+    let statement = try Statement(parsing:
+        "WITH e(x) AS (SELECT 1 AS x) SELECT T.Id, d.x FROM T " +
+        "JOIN (SELECT 2 AS x) AS e ON 1 = 1 " +
+        "JOIN LATERAL (SELECT x FROM e WHERE x = T.Id) AS d ON 1 = 1 " +
+        "ORDER BY T.Id")
+    let columns = try fixture().columns(of: statement, validate: true)
+    #expect(columns.map(\.name) == ["Id", "x"])
+    let rows = try fixture().run(statement, .standard)
+    #expect(rows == [[.integer(1), .integer(1)]])
+  }
+}
+
+// MARK: - LATERAL body projects a preceding-FROM column (ISO scoping)
+
+/// Per ISO 9075 a LATERAL derived table's preceding-FROM references are in
+/// scope throughout its query expression, INCLUDING the SELECT list — so a
+/// lateral body may PROJECT a preceding column, unlike an ordinary correlated
+/// subquery (whose projection this engine bars). The bar is lifted for the
+/// LATERAL body ALONE: the body's `Resolution`/`SubqueryCheck` admit a
+/// correlated column everywhere, so a projected preceding column lowers to a
+/// `Term.parameter` the apply binds per outer row; the ordinary subquery
+/// projection bar is untouched.
+struct LateralProjectionCorrelationTests {
+  @Test func `a LATERAL body projects a preceding column`() throws {
+    // `JOIN LATERAL (SELECT T.Id AS id) AS d ON 1 = 1` — the body's PROJECTION
+    // names the preceding `T.Id`, which ISO puts in scope throughout the body.
+    // The strict schema path derives `id` typed from `T.Id` (`.integer`), and a
+    // run yields `d.id == T.Id` for each left row — the projected preceding
+    // column bound per outer row through the apply's correlation.
+    let query = try parse(query:
+        "SELECT d.id FROM T " +
+        "JOIN LATERAL (SELECT T.Id AS id) AS d ON 1 = 1")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+    #expect(columns[0].name == "id")
+    #expect(columns[0].type == .integer)
+    try fixture().expect(
+        "SELECT d.id FROM T " +
+        "JOIN LATERAL (SELECT T.Id AS id) AS d ON 1 = 1 " +
+        "ORDER BY d.id",
+        yields: [[1], [2], [3]])
+  }
+
+  @Test func `a LATERAL body projects a BARE preceding column`() throws {
+    // The BARE-COLUMN twin of the aliased case above: a LATERAL body projecting
+    // a preceding `T.Id` WITHOUT an alias collapses to `Projection.columns` —
+    // the simpler path. The schema-derive `.columns` case must consult the SAME
+    // lateral correlation surface the aliased expression path does, else a bare
+    // preceding column faults `SQLError.column("Id")` at schema/run even though
+    // the aliased form works. The strict schema path derives `Id` typed from
+    // the preceding `T.Id` (`.integer`), and a run yields `d.Id == T.Id` for
+    // each left row.
+    let query = try parse(query:
+        "SELECT d.Id FROM T " +
+        "JOIN LATERAL (SELECT T.Id) AS d ON 1 = 1")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+    #expect(columns[0].name == "Id")
+    #expect(columns[0].type == .integer)
+    try fixture().expect(
+        "SELECT T.Id, d.Id FROM T " +
+        "JOIN LATERAL (SELECT T.Id) AS d ON 1 = 1 " +
+        "ORDER BY T.Id",
+        yields: [[1, 1], [2, 2], [3, 3]])
+  }
+
+  @Test func `an ordinary subquery still cannot project a BARE outer column`()
+      throws {
+    // The bare-column exemption is GATED on the lateral surface, not opened for
+    // the `.columns` path generally: an ordinary (non-lateral) derived table
+    // whose body projects a bare preceding `T.Id` STILL faults `.unsupported`
+    // at the strict schema check — the barred projection surface of an ordinary
+    // subquery diagnoses the correlated bare column exactly as it does the
+    // aliased one. This pins the exemption to the LATERAL `everywhere` surface.
+    let query = try parse(query:
+        "SELECT d.Id FROM T " +
+        "JOIN (SELECT T.Id) AS d ON 1 = 1")
+    #expect(throws: SQLError.column("Id")) {
+      _ = try fixture().columns(of: query, validate: true)
+    }
+  }
+
+  @Test func `a LATERAL body projects a preceding and a body column`() throws {
+    // A MIXED projection — the preceding `T.Id AS a` beside the body's own
+    // `x AS b` — proves a projected correlated column and a projected local
+    // column coexist. The body re-runs per `T` row over the children keyed on
+    // THAT `Id`: Id 1 → {100, 101}, Id 2 → {200}, Id 3 → {} (dropped, INNER
+    // apply). `a` reads the bound preceding `T.Id`, `b` the body's own `x`.
+    try fixture().expect(
+        "SELECT d.a, d.b FROM T " +
+        "JOIN LATERAL (SELECT T.Id AS a, x AS b FROM S " +
+        "WHERE S.k = T.Id) AS d " +
+        "ON 1 = 1 ORDER BY d.a, d.b",
+        yields: [[1, 100], [1, 101], [2, 200]])
+  }
+
+  @Test func `a LATERAL body advertises a projected preceding column mixed`()
+      throws {
+    // The strict schema path derives BOTH output columns of the mixed body —
+    // `a` typed from the preceding `T.Id`, `b` from the body's own `x` — so
+    // `columns(of:validate: true)` reports the correlated projection's shape.
+    let query = try parse(query:
+        "SELECT d.a, d.b FROM T " +
+        "JOIN LATERAL (SELECT T.Id AS a, x AS b FROM S " +
+        "WHERE S.k = T.Id) AS d " +
+        "ON 1 = 1")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.map(\.name) == ["a", "b"])
+    #expect(columns.map(\.type) == [.integer, .integer])
+  }
+
+  @Test func `an ordinary subquery projection still cannot correlate`() throws {
+    // The bar lift is LATERAL-ONLY: an ordinary correlated SCALAR SUBQUERY in
+    // the projection — `SELECT (SELECT T.Id) FROM T` — STILL faults
+    // `.unsupported`, since a subquery's projection is a barred clause position
+    // (no evaluator for an outer column there). This pins the LATERAL-only
+    // scoping — the everywhere-correlation admission is set for a LATERAL body
+    // alone, never an ordinary subquery.
+    try fixture().expect(
+        "SELECT (SELECT T.Id) FROM T",
+        fails: .unsupported(
+            "a correlated column is only supported in a subquery's WHERE"))
+  }
+
+  @Test func `an ordinary nested subquery inside a LATERAL body is not lateralised`()
+      throws {
+    // The LATERAL everywhere-correlation admission covers ONLY the lateral
+    // body's OWN projection, NEVER a nested ordinary subquery WITHIN it. So an
+    // ordinary correlated scalar subquery in the lateral body's projection —
+    // `SELECT (SELECT T.Id) AS x` — is barred `.unsupported` at the strict
+    // schema check EXACTLY as the non-lateral twin `SELECT (SELECT T.Id) FROM T`
+    // is, since the nested subquery builds its OWN Resolution with the lateral
+    // flag cleared (`everywhere: false`). Threading the lateral flag into the
+    // nested subquery instead admitted its `T.Id` everywhere and lowered it to a
+    // correlated parameter the nested subquery never wires — a WRONG, mismatched
+    // fault (`no such column 'Id'`) rather than the correct barred `.unsupported`
+    // — the bug the cleared flag fixes.
+    let query = try parse(query:
+        "SELECT d.x FROM T " +
+        "JOIN LATERAL (SELECT (SELECT T.Id) AS x) AS d ON 1 = 1")
+    #expect(throws: SQLError.unsupported(
+        "a correlated column is only supported in a subquery's WHERE")) {
+      _ = try fixture().columns(of: query, validate: true)
+    }
+  }
+}
+
+// MARK: - LATERAL aggregate body correlates a preceding-FROM column
+
+/// An AGGREGATE lateral body — one that groups, projects a grouped column, or
+/// filters through `HAVING` — must resolve a preceding-FROM reference through
+/// the SAME correlation surface a non-grouped lateral body does. The grouped
+/// lowering (`Grouping.term`, `Grouping.init`, and `group`'s key computation)
+/// once consulted only the local scope, so a valid apply projecting or grouping
+/// on a preceding column faulted `SQLError.column` at schema/compile instead of
+/// producing one aggregate row per left row. Threading the lateral surface
+/// through the grouped key/projection/HAVING lowering lifts the fault for a
+/// LATERAL body ALONE — the ordinary grouped-subquery bar is untouched (the
+/// negative oracle below pins it).
+struct LateralAggregateCorrelationTests {
+  @Test func `a LATERAL aggregate body projects a preceding column`() throws {
+    // The reviewer's exact case: `JOIN LATERAL (SELECT T.Id AS id, COUNT(*) AS n
+    // FROM S WHERE S.k = T.Id) AS d ON 1 = 1` — a whole-result aggregate body
+    // that also PROJECTS the preceding `T.Id`. The strict schema path derives
+    // `id` (typed from `T.Id`) and `n` (`COUNT` → integer), and a run yields one
+    // row per `T` with `n` the count of `S` rows keyed on that `Id`: Id 1 → 2,
+    // Id 2 → 1, Id 3 → 0 (a `COUNT` over the empty match still emits its row).
+    let query = try parse(query:
+        "SELECT d.id, d.n FROM T " +
+        "JOIN LATERAL (SELECT T.Id AS id, COUNT(*) AS n FROM S " +
+        "WHERE S.k = T.Id) AS d ON 1 = 1")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.map(\.name) == ["id", "n"])
+    #expect(columns.map(\.type) == [.integer, .integer])
+    try fixture().expect(
+        "SELECT d.id, d.n FROM T " +
+        "JOIN LATERAL (SELECT T.Id AS id, COUNT(*) AS n FROM S " +
+        "WHERE S.k = T.Id) AS d ON 1 = 1 ORDER BY d.id",
+        yields: [[1, 2], [2, 1], [3, 0]])
+  }
+
+  @Test func `a LATERAL aggregate body groups on a preceding column`() throws {
+    // A GROUP BY on the preceding `T.Id` — a per-invocation constant, so it forms
+    // ONE group per left row over that invocation's SOURCE rows. The grouping key
+    // lowers to a `Term.parameter` the apply binds per outer row (not a slot the
+    // body's own scope holds), so the schema derives and the run yields one
+    // grouped row per left row WITH source rows: Id 1 → {100, 101} → n 2, Id 2 →
+    // {200} → n 1. Id 3 has NO source rows (its `WHERE` matches nothing), so its
+    // GROUP BY forms NO group — an empty body the INNER apply drops (unlike the
+    // whole-result COUNT above, which emits one empty group per left row).
+    let query = try parse(query:
+        "SELECT d.id, d.n FROM T " +
+        "JOIN LATERAL (SELECT T.Id AS id, COUNT(*) AS n FROM S " +
+        "WHERE S.k = T.Id GROUP BY T.Id) AS d ON 1 = 1")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.map(\.name) == ["id", "n"])
+    try fixture().expect(
+        "SELECT d.id, d.n FROM T " +
+        "JOIN LATERAL (SELECT T.Id AS id, COUNT(*) AS n FROM S " +
+        "WHERE S.k = T.Id GROUP BY T.Id) AS d ON 1 = 1 ORDER BY d.id",
+        yields: [[1, 2], [2, 1]])
+  }
+
+  @Test func `a LATERAL aggregate body filters HAVING on a preceding column`()
+      throws {
+    // A HAVING that references the preceding `T.Id` resolves through the grouped
+    // lowering's correlation surface (a `Term.parameter`, a per-invocation
+    // constant). `HAVING T.Id >= 0` holds for every left row, so the whole-result
+    // aggregate's lone group survives each invocation: one row per `T`, `n` the
+    // count of its children.
+    let query = try parse(query:
+        "SELECT d.id, d.n FROM T " +
+        "JOIN LATERAL (SELECT T.Id AS id, COUNT(*) AS n FROM S " +
+        "WHERE S.k = T.Id HAVING T.Id >= 0) AS d ON 1 = 1")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.map(\.name) == ["id", "n"])
+    try fixture().expect(
+        "SELECT d.id, d.n FROM T " +
+        "JOIN LATERAL (SELECT T.Id AS id, COUNT(*) AS n FROM S " +
+        "WHERE S.k = T.Id HAVING T.Id >= 0) AS d ON 1 = 1 ORDER BY d.id",
+        yields: [[1, 2], [2, 1], [3, 0]])
+  }
+
+  @Test func `an ordinary grouped subquery projection still cannot correlate`()
+      throws {
+    // The grouped bar lift is LATERAL-ONLY: an ordinary correlated grouped
+    // SCALAR SUBQUERY that PROJECTS an outer column — `SELECT (SELECT T.Id FROM S
+    // GROUP BY S.k) FROM T` — STILL faults `.unsupported`, since a subquery's
+    // grouped projection is a barred clause position. This pins the exemption on
+    // the LATERAL `everywhere` surface, never opened for every grouped subquery.
+    try fixture().expect(
+        "SELECT (SELECT T.Id FROM S GROUP BY S.k) FROM T",
+        fails: .unsupported(
+            "a correlated column is only supported in a subquery's WHERE"))
+  }
+
+  @Test func `a LATERAL join under an aggregate is still unsupported`() throws {
+    // A LATERAL join whose OUTER query aggregates is a DIFFERENT, still-rejected
+    // case: the grouped plan forms its single-relation chain differently from the
+    // correlated apply, so it faults rather than mis-plan. The grouped-body fix
+    // does not touch this guard.
+    try fixture().expect(
+        "SELECT COUNT(*) AS n FROM T " +
+        "JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON 1 = 1",
+        fails: .unsupported(
+            "a LATERAL join under an aggregate is not supported"))
+  }
+}
+
+// MARK: - Set-op SELECT * LATERAL arm arity
+
+/// A set operation whose `SELECT *` arm is a LATERAL join must derive that
+/// arm's star arity against the PRECEDING FROM, exactly as the per-arm
+/// compile does — the arity check threads the running prefix scope so the
+/// lateral body's preceding-column reference resolves.
+struct LateralSetOperationStarTests {
+  @Test func `a set-op SELECT * LATERAL arm resolves its arity with the prefix`()
+      throws {
+    // A LATERAL arm's star arity must derive the body's projected preceding
+    // column against the PRECEDING FROM, exactly as the per-arm compile does.
+    // Each arm is `SELECT * FROM T JOIN LATERAL (SELECT T.Id AS id) AS d` — two
+    // columns wide (`T.Id` + `d.id`). The arity check must thread the running
+    // prefix scope so `T.Id` resolves; without it the lateral body derived
+    // against NO scope and faulted the arity check even though the per-arm
+    // compile passes the prefix and runs. Both arms are two columns, so the
+    // union's arity matches and it resolves.
+    let query = try parse(query:
+        "SELECT * FROM T " +
+        "JOIN LATERAL (SELECT T.Id AS id) AS d ON 1 = 1 " +
+        "UNION ALL SELECT * FROM T " +
+        "JOIN LATERAL (SELECT T.Id AS id) AS d ON 1 = 1")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.map(\.name) == ["Id", "id"])
+  }
+}

--- a/Tests/SQLTests/LikeTests.swift
+++ b/Tests/SQLTests/LikeTests.swift
@@ -269,6 +269,7 @@ private func seeks(_ plan: Plan) -> Bool {
   case let .product(left, right): seeks(left) || seeks(right)
   case let .join(outer, _, _, _, _, _, _): seeks(outer)
   case let .outer(left, right, _, _): seeks(left) || seeks(right)
+  case let .apply(left, _, _, _, _, _): seeks(left)
   case let .setop(_, left, right, _): seeks(left) || seeks(right)
   case .single: false
   }
@@ -288,6 +289,7 @@ private func joins(_ plan: Plan) -> Bool {
   case let .derived(_, sub, _, _): joins(sub)
   case let .product(left, right): joins(left) || joins(right)
   case let .outer(left, right, _, _): joins(left) || joins(right)
+  case let .apply(left, _, _, _, _, _): joins(left)
   case let .setop(_, left, right, _): joins(left) || joins(right)
   case .single, .scan: false
   }
@@ -309,6 +311,7 @@ private func residual(_ plan: Plan) -> Bool {
   case let .product(left, right): residual(left) || residual(right)
   case let .join(outer, _, _, _, _, _, _): residual(outer)
   case let .outer(left, right, _, _): residual(left) || residual(right)
+  case let .apply(left, _, _, _, _, _): residual(left)
   case let .setop(_, left, right, _): residual(left) || residual(right)
   case .single, .scan: false
   }


### PR DESCRIPTION
A LATERAL derived table in a FROM/JOIN — JOIN LATERAL (SELECT …) AS d ON <cond> — may reference the columns of the preceding FROM items and is re-evaluated per row they produce (SQL CROSS APPLY). This threads the feature end-to-end: parse, resolve, and execute.

Parse: a LATERAL token; relation() accepts an optional leading LATERAL before a (SELECT …) derived table and sets Relation.lateral. LATERAL before a named relation faults; this dialect has no comma-FROM, so the spelling is JOIN LATERAL (…) ON <cond>.

Resolve: collect(derived:) skips lateral relations so augment never materialises a lateral body as an uncorrelated constant (the body()/ uncorrelated()-cleared path that must NOT run for a lateral body). compile(select)'s join loop resolves each lateral body ONCE against the preceding-FROM scope (relations[0…index]) via lateral(_:against:_:), threading a fresh Outer.nested(under:) so a preceding-column reference resolves outward and mints a :__correlated_… Correlation, and keys the pre-compiled plan under a Role.lateral Subkey. A schema path derives the body's correlation-independent output directly. A first-FROM lateral, and a lateral under aggregation, fault.

Execute: a Plan.apply(plan, key:, correlation:, ordinals:, on:, kind:) whose executor loops each left record, re-runs the pre-compiled body per row via the existing correlated executed(…) (binding the correlation slots from the borrowed record, augmenting the body's own aliases, returning owned records so the borrow is not retained), merges the admitted right rows onto the left, and for INNER/CROSS APPLY drops a left row with no match. apply is a hard pushdown barrier and never memoises.

Reuses the PR243 correlated-subquery substrate (executed/Outer/ Scope.correlated/PlanKey); the FROM-clause correlation threading, the apply node and executor, and Role.lateral are new. LEFT/OUTER APPLY (a null-preserving lateral join) faults .unsupported for now — only INNER is emitted.