### PR TITLE
SQLEngine: support OUTER APPLY (LEFT LATERAL joins)

### DIFF
--- a/Sources/SQLEngine/Engine.swift
+++ b/Sources/SQLEngine/Engine.swift
@@ -3525,16 +3525,17 @@ extension Catalog where Self: ~Escapable {
     // less than the prefix, which includes the join's own relation) — so a body
     // column naming a preceding relation correlates outward and the body's plan
     // is pre-compiled for the per-outer-row apply. A non-lateral join records
-    // nothing here (its `nil` slot). The apply is INNER only for now; a
-    // LEFT/OUTER lateral join is a deliberate follow-up, so fault it.
+    // nothing here (its `nil` slot). The apply is `.inner` (CROSS APPLY, which
+    // drops an unmatched outer row) or `.left` (OUTER APPLY, which NULL-extends
+    // one); `.right`/`.full` are nonsensical for a correlated body, so fault.
     let empty: (key: Subkey, correlation: Correlation)? = nil
     var laterals = Array(repeating: empty, count: select.joins.count)
     for index in select.joins.indices {
       let join = select.joins[index]
       guard join.relation.lateral,
           case let .derived(body) = join.relation.source else { continue }
-      guard join.kind == .inner else {
-        throw .unsupported("a LEFT/RIGHT/FULL LATERAL join is not supported")
+      guard join.kind == .inner || join.kind == .left else {
+        throw .unsupported("a RIGHT/FULL LATERAL join is not supported")
       }
       let preceding = Scope(Array(relations[0 ... index]))
       laterals[index] = try lateral(body, against: preceding, context)

--- a/Sources/SQLEngine/Filter.swift
+++ b/Sources/SQLEngine/Filter.swift
@@ -885,13 +885,15 @@ extension Catalog where Self: ~Escapable {
     return try execute(plan, augmented)
   }
 
-  /// The INNER/CROSS APPLY of a LATERAL derived table: for each `left` record,
+  /// The CROSS/OUTER APPLY of a LATERAL derived table: for each `left` record,
   /// re-executes the pre-compiled body (`key`/`correlation`) against that
   /// record's correlated cells, takes `ordinals` from each produced right
   /// record, concatenates it onto the left, and keeps the pair the `on`
-  /// predicate admits — a left record with no surviving right record is DROPPED
-  /// (`.inner`, the only kind the compiler emits for now; a LEFT/OUTER apply
-  /// that NULL-extends an unmatched left row is a deliberate follow-up).
+  /// predicate admits. `.inner` (CROSS APPLY) DROPS a left record with no
+  /// surviving right record; `.left` (OUTER APPLY) preserves it, NULL-extending
+  /// the taken width (`ordinals.count` NULL cells) — the same NULL-padding a
+  /// regular outer join's `outer(…)` uses for an unmatched row. A `.right` or
+  /// `.full` apply makes no sense for a correlated body: rejected at compile.
   ///
   /// The lateral body runs through the SAME `executed` path a correlated
   /// subquery does — it binds the correlation's `slot` sources from the borrowed
@@ -926,6 +928,9 @@ extension Catalog where Self: ~Escapable {
     // predicate over the merged record's ordinals, and any subquery in it
     // scopes to its OWN recorded overlay.
     let body = revealed(under: key, context)
+    // An unmatched left row under OUTER APPLY (`.left`) is NULL-extended by the
+    // taken width, mirroring `outer(…)`'s NULL-padding of an unmatched row.
+    let rightNulls = Record(Array(repeating: .null, count: ordinals.count))
     for record in left {
       let right = try executed(record, key, correlation, body)
       let width = right.first?.values.count ?? 0
@@ -933,12 +938,17 @@ extension Catalog where Self: ~Escapable {
           RelationInstance(columns: Array(repeating: "", count: width),
                            rows: right.map(\.values),
                            types: Array(repeating: .integer, count: width))
+      var matched = false
       for index in right.indices {
         let taken = instance.record(index, ordinals)
         let paired = record.merged(with: taken)
         if try evaluate(paired, on, context) == true {
           records.append(paired)
+          matched = true
         }
+      }
+      if !matched && kind == .left {
+        records.append(record.merged(with: rightNulls))
       }
     }
     return records

--- a/Tests/SQLTests/LateralTests.swift
+++ b/Tests/SQLTests/LateralTests.swift
@@ -272,6 +272,68 @@ struct LateralExecutionTests {
   }
 }
 
+// MARK: - OUTER APPLY (LEFT LATERAL joins)
+
+/// A `LEFT JOIN LATERAL` (T-SQL `OUTER APPLY`, ISO `LEFT JOIN LATERAL`)
+/// NULL-extends a left row whose correlated body admits no surviving pair —
+/// preserving it, unlike the `.inner` CROSS APPLY that drops it. A `.right` or
+/// `.full` LATERAL stays unsupported: the body correlates to the left, so a
+/// RIGHT/FULL apply makes no sense and faults at compile.
+struct OuterApplyTests {
+  @Test func `OUTER APPLY NULL-extends a left row with no right rows`() throws {
+    // `T.Id` 3 has no child in `S`, so the OUTER apply (`LEFT JOIN LATERAL`)
+    // PRESERVES it NULL-extended: Id 1 → {100, 101}, Id 2 → {200}, Id 3 →
+    // (3, NULL) — the left row kept with a NULL right column.
+    try fixture().expect(
+        "SELECT T.Id, d.x FROM T " +
+        "LEFT JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON 1 = 1 " +
+        "ORDER BY T.Id, d.x",
+        yields: [[1, 100], [1, 101], [2, 200], [3, nil]])
+  }
+
+  @Test func `the INNER CROSS APPLY twin drops the unmatched row`() throws {
+    // CONTRAST: the SAME body under `JOIN LATERAL` (INNER/CROSS APPLY) DROPS
+    // `T.Id` 3 — the drop the OUTER apply above replaces with a NULL-extended
+    // row. Only 1 and 2 survive.
+    try fixture().expect(
+        "SELECT T.Id, d.x FROM T " +
+        "JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON 1 = 1 " +
+        "ORDER BY T.Id, d.x",
+        yields: [[1, 100], [1, 101], [2, 200]])
+  }
+
+  @Test func `OUTER APPLY NULL-extends when the ON filters all right rows`()
+      throws {
+    // A body that DOES produce rows but whose every merged pair fails the join
+    // `ON` still counts as unmatched: `ON d.x > 1000` rejects every child, so
+    // EACH left row — even Ids 1 and 2 with children — is NULL-extended, just
+    // as Id 3 (no children) is. No pair survives, so all three preserve NULL.
+    try fixture().expect(
+        "SELECT T.Id, d.x FROM T " +
+        "LEFT JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d " +
+        "ON d.x > 1000 ORDER BY T.Id",
+        yields: [[1, nil], [2, nil], [3, nil]])
+  }
+
+  @Test func `a RIGHT LATERAL join is unsupported`() throws {
+    // A RIGHT apply is nonsensical — the body correlates to the LEFT, so there
+    // is nothing to preserve on the right. The compile guard faults it.
+    try fixture().expect(
+        "SELECT T.Id, d.x FROM T " +
+        "RIGHT JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON 1 = 1",
+        fails: .unsupported("a RIGHT/FULL LATERAL join is not supported"))
+  }
+
+  @Test func `a FULL LATERAL join is unsupported`() throws {
+    // FULL apply is nonsensical for the same reason as RIGHT — the correlated
+    // body has no independent right extent to preserve. The guard faults it.
+    try fixture().expect(
+        "SELECT T.Id, d.x FROM T " +
+        "FULL JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON 1 = 1",
+        fails: .unsupported("a RIGHT/FULL LATERAL join is not supported"))
+  }
+}
+
 // MARK: - LATERAL body projects a preceding-FROM column (ISO scoping)
 
 /// Per ISO 9075 a LATERAL derived table's preceding-FROM references are in


### PR DESCRIPTION
Allow `.left` LATERAL joins (T-SQL OUTER APPLY, ISO LEFT JOIN LATERAL) alongside the existing `.inner` (CROSS APPLY). The apply executor now NULL-extends an unmatched left row — one whose correlated body yields no row, or whose every merged pair fails the join ON — by the taken width, mirroring the regular outer join's NULL-padding; `.inner` still drops it. `.right`/`.full` LATERAL remain rejected at compile: the right side is correlated to the left, so a RIGHT/FULL apply is nonsensical.