### PR TITLE
SQLEngine: map unsupported faults to precise SQLSTATE codes

### DIFF
--- a/Sources/SQLEngine/Engine.swift
+++ b/Sources/SQLEngine/Engine.swift
@@ -368,8 +368,9 @@ extension Catalog where Self: ~Escapable {
         anchor.references(cte.name.lowercased()),
         case nil = table(named: cte.name),
         case nil = view(named: cte.name) {
-      throw .unsupported(
-          "recursive WITH references the CTE outside its final UNION arm")
+      throw .state("0A000",
+                   "recursive WITH references the CTE outside its final " +
+                   "UNION arm")
     }
     // Check the declared arity by compiling the body — never a cursor. A
     // recursive (self-naming) CTE checks its anchor and recursive arm the way
@@ -1636,7 +1637,8 @@ extension Catalog where Self: ~Escapable {
     // follow-up — the grouped path forms a single-relation chain differently
     // from the correlated apply — so fault it rather than mis-plan.
     for join in select.joins where join.relation.lateral {
-      throw .unsupported("a LATERAL join under an aggregate is not supported")
+      throw .state("0A000",
+                   "a LATERAL join under an aggregate is not supported")
     }
     let (joined, relations) = try resolve(from: relation, schema: from.schema,
                                           joins: select.joins, context)
@@ -1876,7 +1878,7 @@ extension Expression {
                             subquery: Resolution = .unsupported)
       throws(SQLError) -> Aggregation {
     guard case let .aggregate(function, operand, distinct, filter) = self else {
-      throw .unsupported("expected an aggregate")
+      throw .state("XX000", "expected an aggregate")
     }
     let argument: Term? = switch operand {
     case .star:
@@ -3417,7 +3419,8 @@ extension Catalog where Self: ~Escapable {
     // so it is meaningless (and ISO forbids it) — fault rather than resolve a
     // lateral body against nothing.
     guard !relation.lateral else {
-      throw .unsupported("a LATERAL derived table needs a preceding FROM item")
+      throw .state("42601",
+                   "a LATERAL derived table needs a preceding FROM item")
     }
     let from = try resolve(relation, context)
 
@@ -3425,8 +3428,11 @@ extension Catalog where Self: ~Escapable {
       // The parser yields only non-negative counts (a `-` is its own token), but
       // a direct `Limit(count:offset:)` may carry negatives the executor's skip
       // and take would trap on. Reject them as a query error rather than crash.
-      guard limit.offset >= 0, (limit.count ?? 0) >= 0 else {
-        throw .unsupported("OFFSET and FETCH row counts must be non-negative")
+      guard limit.offset >= 0 else {
+        throw .state("2201X", "OFFSET row count must be non-negative")
+      }
+      guard (limit.count ?? 0) >= 0 else {
+        throw .state("2201W", "FETCH row count must be non-negative")
       }
     }
 
@@ -3535,7 +3541,7 @@ extension Catalog where Self: ~Escapable {
       guard join.relation.lateral,
           case let .derived(body) = join.relation.source else { continue }
       guard join.kind == .inner || join.kind == .left else {
-        throw .unsupported("a RIGHT/FULL LATERAL join is not supported")
+        throw .state("0A000", "a RIGHT/FULL LATERAL join is not supported")
       }
       let preceding = Scope(Array(relations[0 ... index]))
       laterals[index] = try lateral(body, against: preceding, context)

--- a/Sources/SQLEngine/Parser.swift
+++ b/Sources/SQLEngine/Parser.swift
@@ -763,7 +763,7 @@ internal struct Parser: ~Escapable {
       throws(SQLError) -> (operand: Aggregand, distinct: Bool) {
     if try match(.star) {
       guard aggregate == .count else {
-        throw .unsupported("only COUNT admits a '*' operand")
+        throw .state("42601", "only COUNT admits a '*' operand")
       }
       try expect(.rparen)
       return (.star, false)

--- a/Sources/SQLEngine/Resolve.swift
+++ b/Sources/SQLEngine/Resolve.swift
@@ -539,8 +539,9 @@ internal struct Resolution {
   internal func correlate(_ column: Column) throws(SQLError) -> String? {
     guard let name = try outer?.parameter(for: column) else { return nil }
     guard admits else {
-      throw .unsupported(
-          "a correlated column is only supported in a subquery's WHERE")
+      throw .state("0A000",
+                   "a correlated column is only supported in a subquery's " +
+                   "WHERE")
     }
     return name
   }
@@ -553,8 +554,9 @@ internal struct Resolution {
   internal func correlated(_ column: Column) throws(SQLError) -> ValueType? {
     guard let type = try outer?.type(for: column) else { return nil }
     guard admits else {
-      throw .unsupported(
-          "a correlated column is only supported in a subquery's WHERE")
+      throw .state("0A000",
+                   "a correlated column is only supported in a subquery's " +
+                   "WHERE")
     }
     return type
   }
@@ -569,7 +571,7 @@ internal struct Resolution {
   /// none — a subquery reaching a catalog-less lowering surface.
   private func width(_ query: Query) throws(SQLError) -> Int {
     guard let width = widths[query] else {
-      throw .unsupported("a subquery is not supported in this position")
+      throw .state("0A000", "a subquery is not supported in this position")
     }
     return width
   }
@@ -580,7 +582,7 @@ internal struct Resolution {
   /// faults, rejecting the subquery rather than mis-typing it.
   private func output(_ query: Query) throws(SQLError) -> ValueType {
     guard let type = types[query] else {
-      throw .unsupported("a subquery is not supported in this position")
+      throw .state("0A000", "a subquery is not supported in this position")
     }
     return type
   }
@@ -966,8 +968,9 @@ internal struct SubqueryCheck {
   internal func correlated(_ column: Column) throws(SQLError) -> ValueType? {
     guard let type = try outer?.type(for: column) else { return nil }
     guard admits else {
-      throw .unsupported(
-          "a correlated column is only supported in a subquery's WHERE")
+      throw .state("0A000",
+                   "a correlated column is only supported in a subquery's " +
+                   "WHERE")
     }
     return type
   }
@@ -987,7 +990,7 @@ internal struct SubqueryCheck {
   /// never widens a reached occurrence's shape.
   internal func validate(_ query: Query, as role: Role) throws(SQLError) {
     guard widths[query] != nil else {
-      throw .unsupported("a subquery is not supported in this position")
+      throw .state("0A000", "a subquery is not supported in this position")
     }
     reached.reach(query, as: role)
   }
@@ -995,7 +998,7 @@ internal struct SubqueryCheck {
   /// The column count `query` projects — from the pre-pass compile.
   internal func width(_ query: Query) throws(SQLError) -> Int {
     guard let width = widths[query] else {
-      throw .unsupported("a subquery is not supported in this position")
+      throw .state("0A000", "a subquery is not supported in this position")
     }
     return width
   }
@@ -1021,7 +1024,7 @@ internal struct SubqueryCheck {
     let width = try width(query)
     guard width == 1 else { throw .arity(1, width) }
     guard let type = types[query] else {
-      throw .unsupported("a subquery is not supported in this position")
+      throw .state("0A000", "a subquery is not supported in this position")
     }
     return type
   }
@@ -1149,7 +1152,7 @@ private func membership(_ left: Term, _ values: Array<Expression>,
                         term: (Expression) throws(SQLError) -> Term)
     throws(SQLError) -> Filter {
   guard !values.isEmpty else {
-    throw .unsupported("IN requires a non-empty value list")
+    throw .state("42601", "IN requires a non-empty value list")
   }
   var elements = Array<Term>()
   elements.reserveCapacity(values.count)
@@ -1490,7 +1493,7 @@ extension Schema {
     case .aggregate:
       // An aggregate has no per-row meaning — it folds over a group — so it may
       // not appear in a `WHERE`, a join `ON`, or a non-aggregate projection.
-      throw .unsupported("an aggregate is not allowed here")
+      throw .state("42803", "an aggregate is not allowed here")
     }
   }
 
@@ -2147,7 +2150,7 @@ internal struct Scope {
     // filter's search condition, as it has no per-row meaning).
     if let filter {
       guard !filter.aggregated else {
-        throw .unsupported("an aggregate is not allowed in a FILTER")
+        throw .state("42803", "an aggregate is not allowed in a FILTER")
       }
       try check(filter, routines, subquery: subquery)
       // A FILTER that STATICALLY cannot admit a row makes the operand
@@ -2387,7 +2390,7 @@ internal struct Scope {
       // caller can build `.membership(_, [], …)` directly, so this validation
       // faults on that shape rather than typing it as an always-false chain.
       guard !values.isEmpty else {
-        throw .unsupported("IN requires a non-empty value list")
+        throw .state("42601", "IN requires a non-empty value list")
       }
       _ = try validate(operand, routines, subquery: subquery)
       _ = try membership(of: values, each: { value throws(SQLError) in
@@ -3171,7 +3174,7 @@ internal struct Scope {
       // (`lower`) and schema (`check`) reject it. The parser rejects `IN ()`,
       // but a caller can build `.membership(_, [], …)` directly.
       guard !values.isEmpty else {
-        throw .unsupported("IN requires a non-empty value list")
+        throw .state("42601", "IN requires a non-empty value list")
       }
       let lhs = try empty(operand, routines)
       let truth = try membership(of: values) { value throws(SQLError) in
@@ -3467,7 +3470,7 @@ internal struct Scope {
     case .aggregate:
       // An aggregate has no per-row meaning — it folds over a group — so it may
       // not appear in a `WHERE`, a join `ON`, or a non-aggregate projection.
-      throw .unsupported("an aggregate is not allowed here")
+      throw .state("42803", "an aggregate is not allowed here")
     }
   }
 
@@ -3765,7 +3768,7 @@ internal struct Grouping {
     case .aggregate:
       // An aggregate reaches here only when it was not collected — an internal
       // inconsistency, since the query gathers every projection/HAVING aggregate.
-      throw .unsupported("uncollected aggregate")
+      throw .state("XX000", "uncollected aggregate")
     }
   }
 
@@ -3797,7 +3800,8 @@ internal struct Grouping {
     let subquery = subquery.barred
     switch projection {
     case .all:
-      throw .unsupported("SELECT * is not allowed with GROUP BY or aggregates")
+      throw .state("0A000",
+                   "SELECT * is not allowed with GROUP BY or aggregates")
     case let .columns(columns):
       var terms = Array<Term>()
       terms.reserveCapacity(columns.count)

--- a/Tests/SQLTests/EngineTests.swift
+++ b/Tests/SQLTests/EngineTests.swift
@@ -4499,7 +4499,7 @@ struct EngineRecursiveTests {
         )
         SELECT n FROM c
         """)
-    #expect(throws: SQLError.unsupported(
+    #expect(throws: SQLError.state("0A000",
         "recursive WITH references the CTE outside its final UNION arm")) {
       _ = try seed().run(query, counting())
     }
@@ -4520,7 +4520,7 @@ struct EngineRecursiveTests {
         )
         SELECT Id FROM Parent
         """)
-    #expect(throws: SQLError.unsupported(
+    #expect(throws: SQLError.state("0A000",
         "recursive WITH references the CTE outside its final UNION arm")) {
       _ = try seed().run(query, counting())
     }

--- a/Tests/SQLTests/ErrorTests.swift
+++ b/Tests/SQLTests/ErrorTests.swift
@@ -4,6 +4,8 @@
 import Testing
 @testable import SQLEngine
 
+import SQLTestSupport
+
 /// A throwaway location for cases that carry one.
 private let here = SourceLocation(line: 1, column: 1, offset: 0)
 
@@ -83,5 +85,93 @@ struct SQLStateTests {
     let error = SQLError.column("Missing")
     #expect(error.message == error.description)
     #expect(error.message == "no such column 'Missing'")
+  }
+}
+
+/// A small relation for driving real queries whose faults were reclassified off
+/// the generic `.unsupported` (`SS001`) onto precise ISO SQLSTATE codes. These
+/// pin the mapping end-to-end — a query raises, and its `.sqlstate` is the
+/// intended code — rather than only the `SQLError` case in isolation.
+private func table() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["Id": .integer]) {
+      Row(1)
+      Row(2)
+    }
+  }
+}
+
+/// Runs `sql` against `catalog` and returns the SQLSTATE it raises, or `nil` if
+/// the run succeeds. Eager rather than `#expect(throws:)`'d — a borrowed
+/// `~Escapable` catalog cannot cross an escaping closure.
+private func sqlstate(_ sql: String, _ catalog: borrowing FixtureCatalog)
+    -> String? {
+  do {
+    guard case let .select(query) = try Statement(parsing: sql) else {
+      return nil
+    }
+    _ = try catalog.run(query)
+    return nil
+  } catch let fault {
+    return fault.sqlstate
+  }
+}
+
+@Suite("reclassified SQLSTATE")
+struct ReclassifiedSQLStateTests {
+  @Test func `an empty IN list reports 42601`() throws {
+    // A `Predicate.membership` with an empty list, built directly to bypass the
+    // parser's `IN ()` rejection, is a syntax error rather than a generic
+    // unsupported shape.
+    let empty = Query.select(Select(projection: .columns([Column(name: "Id")]),
+                                    from: Relation(name: "T"),
+                                    predicate: .membership(.column("Id"), [],
+                                                           negated: false)))
+    let catalog = try table()
+    let raised: SQLError?
+    do {
+      _ = try catalog.run(empty)
+      raised = nil
+    } catch let fault {
+      raised = fault
+    }
+    #expect(raised?.sqlstate == "42601")
+  }
+
+  @Test func `an aggregate in a WHERE reports 42803`() throws {
+    #expect(sqlstate("SELECT Id FROM T WHERE COUNT(*) > 1 GROUP BY Id",
+                     try table()) == "42803")
+  }
+
+  @Test func `a negative OFFSET reports 2201X`() throws {
+    // The parser cannot spell a negative count, so drive it through a direct
+    // `Limit` the executor would otherwise trap on.
+    let select = Select(projection: .columns([Column(name: "Id")]),
+                        from: Relation(name: "T"),
+                        limit: Limit(count: 1, offset: -1))
+    let negative = Query.select(select)
+    let catalog = try table()
+    let raised: SQLError?
+    do {
+      _ = try catalog.run(negative)
+      raised = nil
+    } catch let fault {
+      raised = fault
+    }
+    #expect(raised?.sqlstate == "2201X")
+  }
+
+  @Test func `a RIGHT LATERAL join reports 0A000`() throws {
+    let catalog = try Catalog {
+      Relation("T", ["Id": .integer]) {
+        Row(1)
+      }
+      Relation("S", ["k": .integer, "x": .integer]) {
+        Row(1, 100)
+      }
+    }
+    #expect(sqlstate("SELECT T.Id, d.x FROM T RIGHT JOIN LATERAL " +
+                     "(SELECT x FROM S WHERE S.k = T.Id) AS d ON 1 = 1",
+                     catalog) == "0A000")
   }
 }

--- a/Tests/SQLTests/LateralTests.swift
+++ b/Tests/SQLTests/LateralTests.swift
@@ -115,7 +115,7 @@ struct LateralExecutionTests {
     // relation it has nothing to correlate against, so it faults.
     try fixture().expect(
         "SELECT d.x FROM LATERAL (SELECT x FROM S) AS d",
-        fails: .unsupported(
+        fails: .state("42601",
             "a LATERAL derived table needs a preceding FROM item"))
   }
 
@@ -321,7 +321,7 @@ struct OuterApplyTests {
     try fixture().expect(
         "SELECT T.Id, d.x FROM T " +
         "RIGHT JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON 1 = 1",
-        fails: .unsupported("a RIGHT/FULL LATERAL join is not supported"))
+        fails: .state("0A000", "a RIGHT/FULL LATERAL join is not supported"))
   }
 
   @Test func `a FULL LATERAL join is unsupported`() throws {
@@ -330,7 +330,7 @@ struct OuterApplyTests {
     try fixture().expect(
         "SELECT T.Id, d.x FROM T " +
         "FULL JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON 1 = 1",
-        fails: .unsupported("a RIGHT/FULL LATERAL join is not supported"))
+        fails: .state("0A000", "a RIGHT/FULL LATERAL join is not supported"))
   }
 }
 
@@ -442,7 +442,7 @@ struct LateralProjectionCorrelationTests {
     // alone, never an ordinary subquery.
     try fixture().expect(
         "SELECT (SELECT T.Id) FROM T",
-        fails: .unsupported(
+        fails: .state("0A000",
             "a correlated column is only supported in a subquery's WHERE"))
   }
 
@@ -462,7 +462,7 @@ struct LateralProjectionCorrelationTests {
     let query = try parse(query:
         "SELECT d.x FROM T " +
         "JOIN LATERAL (SELECT (SELECT T.Id) AS x) AS d ON 1 = 1")
-    #expect(throws: SQLError.unsupported(
+    #expect(throws: SQLError.state("0A000",
         "a correlated column is only supported in a subquery's WHERE")) {
       _ = try fixture().columns(of: query, validate: true)
     }
@@ -554,7 +554,7 @@ struct LateralAggregateCorrelationTests {
     // the LATERAL `everywhere` surface, never opened for every grouped subquery.
     try fixture().expect(
         "SELECT (SELECT T.Id FROM S GROUP BY S.k) FROM T",
-        fails: .unsupported(
+        fails: .state("0A000",
             "a correlated column is only supported in a subquery's WHERE"))
   }
 
@@ -566,7 +566,7 @@ struct LateralAggregateCorrelationTests {
     try fixture().expect(
         "SELECT COUNT(*) AS n FROM T " +
         "JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON 1 = 1",
-        fails: .unsupported(
+        fails: .state("0A000",
             "a LATERAL join under an aggregate is not supported"))
   }
 }

--- a/Tests/SQLTests/LimitTests.swift
+++ b/Tests/SQLTests/LimitTests.swift
@@ -166,17 +166,17 @@ struct LimitTests {
       Issue.record("expected a single SELECT")
       return
     }
-    let fault =
-        SQLError.unsupported("OFFSET and FETCH row counts must be non-negative")
     let catalog = try people()
     let negativeOffset = Select(projection: base.projection, from: base.from,
                                 limit: Limit(count: 1, offset: -1))
-    #expect(throws: fault) {
+    #expect(throws:
+        SQLError.state("2201X", "OFFSET row count must be non-negative")) {
       try catalog.run(.select(negativeOffset))
     }
     let negativeCount = Select(projection: base.projection, from: base.from,
                                limit: Limit(count: -1))
-    #expect(throws: fault) {
+    #expect(throws:
+        SQLError.state("2201W", "FETCH row count must be non-negative")) {
       try catalog.run(.select(negativeCount))
     }
   }

--- a/Tests/SQLTests/MembershipTests.swift
+++ b/Tests/SQLTests/MembershipTests.swift
@@ -421,7 +421,7 @@ struct MembershipTypeTests {
     // fold from the compile-path guard.
     let having = Predicate.membership(.literal(.integer(1)), [], negated: true)
     #expect(throws:
-        SQLError.unsupported("IN requires a non-empty value list")) {
+        SQLError.state("42601", "IN requires a non-empty value list")) {
       _ = try Scope([]).empty(having)
     }
   }
@@ -444,7 +444,7 @@ struct MembershipTypeTests {
       try members().columns(of: query, validate: true)
     }
     #expect(throws:
-        SQLError.unsupported("IN requires a non-empty value list")) {
+        SQLError.state("42601", "IN requires a non-empty value list")) {
       try resolve()
     }
   }
@@ -454,7 +454,7 @@ struct MembershipTypeTests {
     // OR-chain reduction) rather than crashing on the force-unwrap.
     let query = select(where: .membership(.column("Id"), [], negated: false))
     #expect(throws:
-        SQLError.unsupported("IN requires a non-empty value list")) {
+        SQLError.state("42601", "IN requires a non-empty value list")) {
       _ = try members().run(query)
     }
   }

--- a/Tests/SQLTests/OutputSchemaTests.swift
+++ b/Tests/SQLTests/OutputSchemaTests.swift
@@ -578,7 +578,7 @@ struct OutputSchemaTests {
           SELECT n FROM t UNION SELECT n FROM t
         ) SELECT n FROM t
         """)
-    let error = SQLError.unsupported(
+    let error = SQLError.state("0A000",
         "recursive WITH references the CTE outside its final UNION arm")
     #expect(throws: error) {
       let _ = try catalog().columns(of: statement, validate: true)

--- a/Tests/SQLTests/ScalarSubqueryTests.swift
+++ b/Tests/SQLTests/ScalarSubqueryTests.swift
@@ -347,7 +347,7 @@ struct ScalarSubqueryCorrelationTests {
     }
     try fixture().expect(
         "SELECT (SELECT T.V FROM S) FROM T",
-        fails: .unsupported(
+        fails: .state("0A000",
             "a correlated column is only supported in a subquery's WHERE"))
   }
 
@@ -366,7 +366,7 @@ struct ScalarSubqueryCorrelationTests {
     }
     try fixture().expect(
         "SELECT (SELECT T.Id) FROM T",
-        fails: .unsupported(
+        fails: .state("0A000",
             "a correlated column is only supported in a subquery's WHERE"))
   }
 


### PR DESCRIPTION
Many faults threw the generic .unsupported (SQLSTATE SS001) though they are really invalid queries, engine invariants, or specific feature gaps ISO codes precisely. Reclassify via the .state(code, message) passthrough: invalid syntax/semantics to class 42 (42601 syntax, 42803 misplaced aggregate), a bad row count to class 22 (splitting the OFFSET/FETCH guard into 2201X and 2201W), unreachable invariants to XX000, and valid-but- unimplemented shapes (correlation, LATERAL, out-of-arm recursion) to 0A000. The two genuinely FROM-less shapes keep .unsupported / SS001.