### PR TITLE
prefer positive-form conditions

### DIFF
--- a/Sources/SQLEngine/Aggregate.swift
+++ b/Sources/SQLEngine/Aggregate.swift
@@ -228,7 +228,7 @@ private struct Accumulator {
       case .count:
         return .integer(count)
       case .sum:
-        guard count != 0 else { return .null }
+        if count == 0 { return .null }
         if widened {
           guard total.isFinite else {
             throw .magnitude("double result is not finite")
@@ -246,7 +246,7 @@ private struct Accumulator {
         // is NULL. It divides the WIDE total (the exact Int128, or the double
         // total when a double widened it), so an all-integer sum outside Int
         // still averages rather than faulting like SUM's Int-bounded result.
-        guard count != 0 else { return .null }
+        if count == 0 { return .null }
         let sum: Double = widened ? total : Double(integer)
         let average = sum / Double(count)
         guard average.isFinite else {

--- a/Sources/SQLEngine/Definition.swift
+++ b/Sources/SQLEngine/Definition.swift
@@ -217,7 +217,7 @@ extension Catalog where Self: ~Escapable {
     }
     var derivations = Array<(String, Query)>()
     query.collect(derived: &derivations)
-    guard !derivations.isEmpty else { return context.scoping(augmented) }
+    if derivations.isEmpty { return context.scoping(augmented) }
     // A derived table's alias sharing a RANGE NAME with another FROM/JOIN item
     // in THIS SELECT's own scope collides: the alias-keyed overlay holds one
     // binding under that name, so binding the derived rows would SHADOW the

--- a/Sources/SQLEngine/Engine.swift
+++ b/Sources/SQLEngine/Engine.swift
@@ -726,7 +726,7 @@ extension Plan {
     // non-deterministic routine). Materialise the sort-referenced outputs once
     // below the sort, so the order reflects the returned values whenever a key
     // does — over the FILTERED `plan`, so a HAVING/WHERE above governs.
-    guard !order.contains(where: { $0.output }) else {
+    if order.contains(where: { $0.output }) {
       return plan.materialised(distinct: distinct, projection: projection,
                                order: order, limit: limit)
     }
@@ -3275,7 +3275,7 @@ extension Catalog where Self: ~Escapable {
       // stack overflow, not an `SQLError`). `visited` names the views already
       // being resolved down this chain; re-encountering one is a cyclic
       // definition, reported as `.recursion` rather than hung.
-      guard !context.visited.contains(name.lowercased()) else {
+      if context.visited.contains(name.lowercased()) {
         throw .recursion(name)
       }
       // The view body compiles OUTSIDE the caller's statement CTEs, but it may
@@ -3418,7 +3418,7 @@ extension Catalog where Self: ~Escapable {
     // A LATERAL first FROM item has no PRECEDING relation to correlate against,
     // so it is meaningless (and ISO forbids it) — fault rather than resolve a
     // lateral body against nothing.
-    guard !relation.lateral else {
+    if relation.lateral {
       throw .state("42601",
                    "a LATERAL derived table needs a preceding FROM item")
     }

--- a/Sources/SQLEngine/Filter.swift
+++ b/Sources/SQLEngine/Filter.swift
@@ -807,7 +807,7 @@ extension Catalog where Self: ~Escapable {
   private borrowing func correlated(_ row: borrowing some Row & ~Escapable,
                                     _ correlation: Correlation,
                                     _ bindings: Bindings) -> Bindings {
-    guard !correlation.isEmpty else { return bindings }
+    if correlation.isEmpty { return bindings }
     var extended = bindings
     for (name, source) in correlation {
       // A `bound` source is already in `bindings` (threaded by the containing
@@ -1208,7 +1208,7 @@ extension Arithmetic {
     // integers is an unreachable operand fault.
     case .concatenate: throw .operand("|| operands must be text")
     }
-    guard !outcome.overflow else { throw .magnitude("integer overflow") }
+    if outcome.overflow { throw .magnitude("integer overflow") }
     return .integer(outcome.partialValue)
   }
 
@@ -1577,7 +1577,7 @@ extension Catalog where Self: ~Escapable {
     let value = try evaluate(row, test, context)
     let low = try evaluate(row, lower, context)
     let above = matches(value, .geq, low)
-    guard above != false else { return negated }
+    if above == false { return negated }
     let high = try evaluate(row, upper, context)
     let within = and(above, matches(value, .leq, high))
     return negated ? within.map { !$0 } : within

--- a/Sources/SQLEngine/Function.swift
+++ b/Sources/SQLEngine/Function.swift
@@ -136,7 +136,7 @@ public struct Routine: Sendable {
     // guard) would always be UNBOUND at call time — the caller's `bindings`
     // never reach a routine body — and silently pick the wrong branch. Reject
     // a `.bound` anywhere in the body at registration rather than lowering it.
-    guard !body.bound else {
+    if body.bound {
       throw .argument("the body cannot reference a query parameter")
     }
     let schema = Schema(width: names.count, extent: names.count,
@@ -344,7 +344,7 @@ public struct Routines: Sendable {
   /// no semantic case models a reserved-name fault, and `.function`'s message
   /// ("no such function") would misdescribe the condition.
   private func reserved(_ name: String) throws(SQLError) {
-    guard !protected.contains(name.lowercased()) else {
+    if protected.contains(name.lowercased()) {
       throw .state("42723", "'\(name)' is a standard routine and "
                        + "cannot be redefined")
     }

--- a/Sources/SQLEngine/OutputColumn.swift
+++ b/Sources/SQLEngine/OutputColumn.swift
@@ -970,7 +970,7 @@ extension Catalog where Self: ~Escapable {
       // re-enter this view forever, so break the cycle and fall back to the
       // declared schema (every type the `.integer` default). `try?` cannot
       // catch this — the recursion overflows the stack rather than throwing.
-      guard !context.visited.contains(name.lowercased()) else { return base }
+      if context.visited.contains(name.lowercased()) { return base }
       // Type-check the body's REACHABLE operands and calls across every arm and
       // clause — `compile` cannot check a routine EXISTS, the first-arm resolve
       // below sees only the first projection, and the outer query's walk does

--- a/Sources/SQLEngine/Parser.swift
+++ b/Sources/SQLEngine/Parser.swift
@@ -457,7 +457,7 @@ internal struct Parser: ~Escapable {
       return try Relation(derived: query, as: identifier(), lateral: lateral)
     }
     // `LATERAL` introduces a derived table; a named relation may not follow it.
-    guard !lateral else {
+    if lateral {
       guard let token = current else {
         throw .incomplete(expected: "a derived table after LATERAL")
       }
@@ -1341,7 +1341,7 @@ internal struct Parser: ~Escapable {
       cap = nil
     }
 
-    guard offset != 0 || cap != nil else { return nil }
+    if offset == 0 && cap == nil { return nil }
     return Limit(count: cap, offset: offset)
   }
 

--- a/Sources/SQLEngine/RelationInstance.swift
+++ b/Sources/SQLEngine/RelationInstance.swift
@@ -83,7 +83,7 @@ internal struct ScopedRelations: Hashable, Sendable,
   /// base.
   internal func pushing(_ derivations: Dictionary<String, RelationInstance>)
       -> ScopedRelations {
-    guard !derivations.isEmpty else { return self }
+    if derivations.isEmpty { return self }
     if layers.last == derivations { return self }
     var copy = self
     copy.layers.append(derivations)

--- a/Sources/SQLEngine/Resolve.swift
+++ b/Sources/SQLEngine/Resolve.swift
@@ -522,7 +522,7 @@ internal struct Resolution {
   /// a correlated column, which lowers to a `Term.parameter` the apply binds
   /// per outer row.
   internal var barred: Resolution {
-    guard !everywhere else { return self }
+    if everywhere { return self }
     return Resolution(scope, widths, types, correlations, outer: outer,
                       admits: false, everywhere: everywhere)
   }
@@ -940,7 +940,7 @@ internal struct SubqueryCheck {
   /// so the projection/`HAVING` walk keeps admitting the correlated preceding
   /// column the run's lowering binds.
   internal var barred: SubqueryCheck {
-    guard !everywhere else { return self }
+    if everywhere { return self }
     return SubqueryCheck(widths, types, deferred: deferred, reached: reached,
                          outer: outer, admits: false, everywhere: everywhere)
   }
@@ -989,7 +989,7 @@ internal struct SubqueryCheck {
   /// body still faults (parity both directions), while an unreached arm's role
   /// never widens a reached occurrence's shape.
   internal func validate(_ query: Query, as role: Role) throws(SQLError) {
-    guard widths[query] != nil else {
+    if widths[query] == nil {
       throw .state("0A000", "a subquery is not supported in this position")
     }
     reached.reach(query, as: role)
@@ -1151,7 +1151,7 @@ private func membership(_ left: Term, _ values: Array<Expression>,
                         negated: Bool,
                         term: (Expression) throws(SQLError) -> Term)
     throws(SQLError) -> Filter {
-  guard !values.isEmpty else {
+  if values.isEmpty {
     throw .state("42601", "IN requires a non-empty value list")
   }
   var elements = Array<Term>()
@@ -1795,7 +1795,7 @@ internal struct Scope {
         // be returned, so its type must not shape the column.
         continue
       }
-      guard !selects(argument, routines) else {
+      if selects(argument, routines) {
         // A definite selection: merge its type and stop, as every later
         // argument is unreachable.
         return try merged(type, next)
@@ -1846,7 +1846,7 @@ internal struct Scope {
                        subquery: Resolution = .unsupported)
       throws(SQLError) -> ValueType {
     let results = reachable(whens, otherwise, routines)
-    guard !results.isEmpty else { return .integer }
+    if results.isEmpty { return .integer }
     var type = try derive(results[0], routines, subquery: subquery)
     for result in results.dropFirst() {
       let next = try derive(result, routines, subquery: subquery)
@@ -1971,7 +1971,7 @@ internal struct Scope {
         // never be returned, so its type must not shape the column.
         continue
       }
-      guard !selects(argument, routines) else {
+      if selects(argument, routines) {
         // A definite selection: merge its type and stop, as every later
         // argument is unreachable and unvalidated.
         return try merged(type, next)
@@ -2082,7 +2082,7 @@ internal struct Scope {
       if decided { break }
     }
     if !decided, let otherwise { results.append(otherwise) }
-    guard !results.isEmpty else { return .integer }
+    if results.isEmpty { return .integer }
     var type = try validate(results[0], routines, subquery: subquery)
     for result in results.dropFirst() {
       let next = try validate(result, routines, subquery: subquery)
@@ -2149,7 +2149,7 @@ internal struct Scope {
     // it may not itself contain an aggregate (ISO forbids an aggregate in a
     // filter's search condition, as it has no per-row meaning).
     if let filter {
-      guard !filter.aggregated else {
+      if filter.aggregated {
         throw .state("42803", "an aggregate is not allowed in a FILTER")
       }
       try check(filter, routines, subquery: subquery)
@@ -2389,7 +2389,7 @@ internal struct Scope {
       // no seed), so reject it here too — the parser rejects `IN ()`, but a
       // caller can build `.membership(_, [], …)` directly, so this validation
       // faults on that shape rather than typing it as an always-false chain.
-      guard !values.isEmpty else {
+      if values.isEmpty {
         throw .state("42601", "IN requires a non-empty value list")
       }
       _ = try validate(operand, routines, subquery: subquery)
@@ -3173,7 +3173,7 @@ internal struct Scope {
       // otherwise fold `false` (`true` under `NOT IN`) here while both compile
       // (`lower`) and schema (`check`) reject it. The parser rejects `IN ()`,
       // but a caller can build `.membership(_, [], …)` directly.
-      guard !values.isEmpty else {
+      if values.isEmpty {
         throw .state("42601", "IN requires a non-empty value list")
       }
       let lhs = try empty(operand, routines)
@@ -3281,7 +3281,7 @@ internal struct Scope {
   /// enclosing relation, so `find` faults it hard rather than correlating
   /// outward; an unadmitted qualifier is genuinely not local and correlates.
   private func shadows(_ column: Column) -> Bool {
-    guard column.qualifier != nil else { return false }
+    if column.qualifier == nil { return false }
     return members.contains { admits($0, column) }
   }
 
@@ -3340,7 +3340,7 @@ internal struct Scope {
       return try ordinal(of: column)
     } catch let error {
       guard case .column = error else { throw error }
-      guard !shadows(column) else { throw error }
+      if shadows(column) { throw error }
       return nil
     }
   }

--- a/Sources/SQLStandard/Prelude.swift
+++ b/Sources/SQLStandard/Prelude.swift
@@ -283,10 +283,10 @@ extension Routines {
         case let .integer(b) = arguments[1] else {
       throw .argument("MOD requires integer arguments")
     }
-    guard b != 0 else { throw .divide }
+    if b == 0 { throw .divide }
     // `a % -1` is mathematically 0, but `Int.min % -1` overflows the implied
     // division and traps, so a divisor of -1 short-circuits to that 0.
-    guard b != -1 else { return .integer(0) }
+    if b == -1 { return .integer(0) }
     return .integer(a % b)
   }
 
@@ -308,7 +308,7 @@ extension Routines {
       throw .argument("POSITION requires text arguments")
     }
     // The empty substring is a prefix of every string, so it occurs at 1.
-    guard !substring.isEmpty else { return .integer(1) }
+    if substring.isEmpty { return .integer(1) }
     // Character-wise search over the Unicode scalars `CHAR_LENGTH` counts, so
     // the reported position is a 1-based character index, not a byte offset.
     let haystack = Array(string), needle = Array(substring)

--- a/Sources/WinMD/Attribute.swift
+++ b/Sources/WinMD/Attribute.swift
@@ -155,7 +155,7 @@ internal struct AttributeDecoder: ~Escapable {
   /// name or value.
   internal mutating func string() throws(WinMDError) -> String? {
     guard position < bytes.byteCount else { throw .BadImageFormat }
-    guard bytes.read(at: position, as: UInt8.self) != 0xff else {
+    if bytes.read(at: position, as: UInt8.self) == 0xff {
       position = position + 1
       return nil
     }

--- a/Sources/WinMD/Iteration.swift
+++ b/Sources/WinMD/Iteration.swift
@@ -164,14 +164,14 @@ public struct Tuple: ~Escapable {
     switch type(of: column) {
     case let .index(.simple(schema)):
       let index = self[column]
-      guard index != 0 else { return nil }
+      if index == 0 { return nil }
       guard let tuple = try storage.tuple(index - 1, of: schema) else {
         throw .BadImageFormat
       }
       return tuple
     case let .index(.coded(coded)):
       let value: any CodedIndex = coded.init(rawValue: self[column])
-      guard value.row != 0 else { return nil }
+      if value.row == 0 { return nil }
       guard value.tag < coded.tables.count,
           let schema = coded.tables[value.tag]
       else { throw .BadImageFormat }

--- a/Sources/WinMD/PhysicalSchema.swift
+++ b/Sources/WinMD/PhysicalSchema.swift
@@ -41,7 +41,7 @@ extension PhysicalSchema {
       // A reserved tag names no table, so it contributes no rows to the width.
       guard let table = tables[tag] else { continue }
       // An absent target table has no rows, so it cannot force a wide index.
-      guard valid & (1 << table.number) != 0 else { continue }
+      if valid & (1 << table.number) == 0 { continue }
       // A present table forces the full 32-bit index once its row count reaches
       // the range; below it the compressed width suffices.
       if rows(of: table.number) >= range { return 4 }

--- a/Sources/WinMD/Storage.swift
+++ b/Sources/WinMD/Storage.swift
@@ -59,7 +59,7 @@ package struct Storage: ~Escapable {
     // `tables` is dense and ordered by table number, so a present table's
     // slot is the number of present tables below it: the population count of
     // the lower bits of `Valid` (the same slot the row counts are read from).
-    guard valid & (1 << Schema.number) != 0 else {
+    if valid & (1 << Schema.number) == 0 {
       throw .TableNotFound
     }
     let slot = (valid & ((1 << Schema.number) - 1)).nonzeroBitCount
@@ -78,7 +78,7 @@ package struct Storage: ~Escapable {
   @_lifetime(copy self)
   internal func tuple(_ row: Int, of schema: TableSchema.Type)
       throws(WinMDError) -> Tuple? {
-    guard valid & (1 << schema.number) != 0 else { return nil }
+    if valid & (1 << schema.number) == 0 { return nil }
     let slot = (valid & ((1 << schema.number) - 1)).nonzeroBitCount
     let table = tables[slot]
     guard row >= 0, row < Int(table.rows) else { return nil }
@@ -94,7 +94,7 @@ package struct Storage: ~Escapable {
   /// signature names against a borrowed `Storage` rather than a `Database`.
   @_lifetime(copy self)
   package func resolve(_ reference: TypeDefOrRef) throws(WinMDError) -> Tuple? {
-    guard reference.row != 0 else { return nil }
+    if reference.row == 0 { return nil }
     guard reference.tag < TypeDefOrRef.tables.count,
         let schema = TypeDefOrRef.tables[reference.tag] else {
       throw .BadImageFormat
@@ -117,7 +117,7 @@ package struct Storage: ~Escapable {
                             in schema: TableSchema.Type,
                             by column: Int)
       throws(WinMDError) -> Filter<Cursor> {
-    guard valid & (1 << schema.number) != 0 else {
+    if valid & (1 << schema.number) == 0 {
       throw .TableNotFound
     }
     let slot = (valid & ((1 << schema.number) - 1)).nonzeroBitCount

--- a/Sources/WinMD/TablesStream.swift
+++ b/Sources/WinMD/TablesStream.swift
@@ -80,7 +80,7 @@ public struct TablesStream: ~Escapable {
     var offset = base + 24 + Valid.nonzeroBitCount * MemoryLayout<UInt32>.size
 
     for schema in kRegisteredTables {
-      guard Valid & (1 << schema.number) != 0 else { continue }
+      if Valid & (1 << schema.number) == 0 { continue }
 
       let records = catalog.rows(of: schema.number)
 

--- a/Sources/WinMDSynthesis/Decode.swift
+++ b/Sources/WinMDSynthesis/Decode.swift
@@ -85,7 +85,7 @@ public struct Dialect: Sendable {
   /// `` `in` `` — matching the escaped spelling a `VAR` use of the same
   /// parameter produces, so declaration and use agree.
   public func generics(_ names: Array<String>) -> String? {
-    guard !names.isEmpty else { return nil }
+    if names.isEmpty { return nil }
     return generic.open + names.map(escape).joined(separator: ", ")
         + generic.close
   }
@@ -466,7 +466,7 @@ extension SignatureType {
     // An unresolved base (e.g. a TypeSpec with no identity) decodes to the
     // opaque pointer; a generic over it is meaningless, so degrade to that
     // opaque pointer rather than emit `UnsafeMutableRawPointer<…>`.
-    guard base != dialect.opaque else { return base }
+    if base == dialect.opaque { return base }
     // Strip the CLR arity suffix, THEN escape the base identifier: the full
     // `Foo``1` never matches a keyword, so a keyword base (`protocol``1`) must
     // be escaped after the strip, not before, to spell `` `protocol`<…> ``.

--- a/Sources/winmd-inspect/Database+SQL.swift
+++ b/Sources/winmd-inspect/Database+SQL.swift
@@ -871,7 +871,7 @@ extension WinMD.Storage {
     }
     let position = param[sequence]
     let origin = owner(of: parameter - 1, link)
-    guard origin != 0 else { return nil }
+    if origin == 0 { return nil }
     let methods = WinMD.Cursor(copy self, link.parent)
     guard let method = methods[origin - 1],
         let row = Row<Metadata.Tables.MethodDef>(method),

--- a/Sources/winmd-inspect/Language.swift
+++ b/Sources/winmd-inspect/Language.swift
@@ -90,7 +90,7 @@ internal struct Language: Sendable {
     var wellKnown = Dictionary<String, String>()
     for line in text.split(whereSeparator: \.isNewline) {
       let trimmed = String(line).trimmed
-      guard !trimmed.isEmpty, !trimmed.hasPrefix("#") else { continue }
+      if trimmed.isEmpty || trimmed.hasPrefix("#") { continue }
       let key = trimmed.prefix { !$0.isWhitespace }
       let value = trimmed[key.endIndex...].trimmed
       switch key {

--- a/Sources/winmd-inspect/Shell.swift
+++ b/Sources/winmd-inspect/Shell.swift
@@ -63,7 +63,7 @@ internal struct Schema: Metacommand {
   }
 
   internal func execute(against shell: inout Shell) throws {
-    guard !query.isEmpty else { throw Shell.MetaError.unknown(Schema.spelling) }
+    if query.isEmpty { throw Shell.MetaError.unknown(Schema.spelling) }
     // Route through the statement-level, CTE-aware derive with `validate:
     // true`: it types a `SELECT`/`UNION` AND a `WITH` (the CTE scope kept in
     // place) and faults a `CREATE VIEW`, so `.schema` describes every runnable
@@ -113,7 +113,7 @@ internal struct Read: Metacommand {
   }
 
   internal func execute(against shell: inout Shell) throws {
-    guard !path.isEmpty else { throw Shell.MetaError.unknown(Read.spelling) }
+    if path.isEmpty { throw Shell.MetaError.unknown(Read.spelling) }
     try shell.read(path)
   }
 }
@@ -182,7 +182,7 @@ internal struct Bind: Metacommand {
   }
 
   internal func execute(against shell: inout Shell) throws {
-    guard !name.isEmpty else { throw Shell.MetaError.unknown(Bind.spelling) }
+    if name.isEmpty { throw Shell.MetaError.unknown(Bind.spelling) }
     if let value {
       shell.bindings[name] = value
       note("bound :\(name) = \(value.display)")
@@ -216,7 +216,7 @@ internal struct Render: Metacommand {
   }
 
   internal func execute(against shell: inout Shell) throws {
-    guard !interface.isEmpty, !template.isEmpty else {
+    if interface.isEmpty || template.isEmpty {
       throw Shell.MetaError.unknown(Render.spelling)
     }
     print(try shell.render(interface, template: template))
@@ -256,7 +256,7 @@ internal struct Template: Metacommand {
   }
 
   internal func execute(against shell: inout Shell) throws {
-    guard !name.isEmpty else { throw Shell.MetaError.unknown(Template.spelling) }
+    if name.isEmpty { throw Shell.MetaError.unknown(Template.spelling) }
     shell.templates[name] = body
     note("defined template \(name)")
   }
@@ -674,7 +674,7 @@ internal struct Shell: ~Escapable {
   private borrowing func declarations(of id: Value, _ routines: Routines,
                                       search: Array<String>) throws
       -> Array<String> {
-    guard session.storage.opened("GenericParam") != nil else { return [] }
+    if session.storage.opened("GenericParam") == nil { return [] }
     let clause =
         try Shell.select(Shell.query(named: "generics", search: search))
     let declared = try session.run(clause, routines, bindings: ["parent": id])

--- a/Tests/WinMDTests/ResolveTests.swift
+++ b/Tests/WinMDTests/ResolveTests.swift
@@ -154,7 +154,7 @@ struct ResolveTests {
     // `Database.resolve(_:)`'s body, against an in-memory storage: the tag guard
     // must reject the reference rather than trap on `TypeDefOrRef.tables[tag]`.
     #expect(throws: WinMDError.BadImageFormat) {
-      guard reference.row != 0 else { return }
+      if reference.row == 0 { return }
       guard reference.tag < TypeDefOrRef.tables.count,
           let schema = TypeDefOrRef.tables[reference.tag]
       else { throw WinMDError.BadImageFormat }
@@ -309,7 +309,7 @@ struct ResolveTests {
     // admits the reference, but the out-of-range row makes `storage.tuple` return
     // nil, which must be surfaced as a malformed image.
     #expect(throws: WinMDError.BadImageFormat) {
-      guard reference.row != 0 else { return }
+      if reference.row == 0 { return }
       guard reference.tag < TypeDefOrRef.tables.count,
           let schema = TypeDefOrRef.tables[reference.tag]
       else { throw WinMDError.BadImageFormat }
@@ -398,7 +398,7 @@ struct ResolveTests {
     // admits the reference, but the absent target table makes `storage.tuple`
     // return nil, which must be surfaced as a malformed image.
     #expect(throws: WinMDError.BadImageFormat) {
-      guard reference.row != 0 else { return }
+      if reference.row == 0 { return }
       guard reference.tag < TypeDefOrRef.tables.count,
           let schema = TypeDefOrRef.tables[reference.tag]
       else { throw WinMDError.BadImageFormat }


### PR DESCRIPTION
Rewrite guard-bail-on-negation sites as an `if` on the de-negated positive condition, so the exit reads off the affirmative form rather than a doubled negative. Behaviour is unchanged: `guard C else { EXIT }` and `if !C { EXIT }` are identical when C is a negation. A cross-cutting sweep across SQLEngine, WinMD, WinMDSynthesis, winmd-inspect, SQLStandard, and the WinMD tests. Only simple early-exit guards on a negated condition were touched; guard-let/case bindings, already-positive guards, and compound conditions that read worse de-negated were left.