### PR TITLE
SQLEngine: refresh the parser grammar comment for LATERAL

### DIFF
--- a/Sources/SQLEngine/Parser.swift
+++ b/Sources/SQLEngine/Parser.swift
@@ -23,10 +23,13 @@
 /// select         := SELECT [DISTINCT | ALL] projection
 ///                   [FROM relation (join)*
 ///                    [where] [group] [having] [order] [limit]]
-/// relation       := (identifier | derived) [AS identifier]
+/// relation       := (identifier | [LATERAL] derived) [AS identifier]
+///                   // LATERAL is legal only on a derived table in a join
 /// derived        := '(' query ')' AS identifier  // a derived table (aliased)
 /// join           := [INNER | (LEFT | RIGHT | FULL) [OUTER]] JOIN
 ///                     relation ON predicate
+///                   // INNER JOIN LATERAL = CROSS APPLY, LEFT = OUTER APPLY;
+///                   // the derived body may reference preceding FROM items
 /// projection     := '*' | column (',' column)*
 /// where          := WHERE predicate
 /// group          := GROUP BY column (',' column)*
@@ -40,7 +43,8 @@
 ///                                    | expression | param)
 ///                 | IS [NOT] (NULL | truthvalue | DISTINCT FROM expression)
 ///                 | [NOT] IN '(' (expression (',' expression)* | query) ')'
-///                 | [NOT] LIKE expression [ESCAPE expression]
+///                 | [NOT] LIKE (expression | param)
+///                     [ESCAPE (expression | param)]
 ///                 | [NOT] BETWEEN (expression | param) AND
 ///                                 (expression | param))
 /// quantifier     := ANY | SOME | ALL      // SOME is a synonym for ANY


### PR DESCRIPTION
Realign the EBNF grammar block with what the parser accepts today: document the optional LATERAL before a derived table in a join (INNER = CROSS APPLY, LEFT = OUTER APPLY) and note the LIKE pattern and ESCAPE each admit a bound :param operand, as BETWEEN already does. Comment-only; no code changes.