### PR TITLE
SQLEngine: wrap source to 80 columns

### DIFF
--- a/Sources/SQLEngine/AST.swift
+++ b/Sources/SQLEngine/AST.swift
@@ -164,8 +164,8 @@ public indirect enum Query: Hashable, Sendable {
   }
 }
 
-/// A `SELECT` query: a projection over one relation or a chain of joins, with an
-/// optional predicate, ordering, and row limit.
+/// A `SELECT` query: a projection over one relation or a chain of joins, with
+/// an optional predicate, ordering, and row limit.
 ///
 /// `from` is optional: a FROM-less `SELECT <expr-list>` yields exactly one row
 /// whose columns are the evaluated projection expressions, the standard SQL
@@ -681,9 +681,10 @@ public indirect enum Expression: Hashable, Sendable {
   case binary(Arithmetic, Expression, Expression)
   /// An aggregate function over a group of rows — `COUNT(*)`, `COUNT(x)`,
   /// `SUM(x)`, `MIN(x)`, `MAX(x)`, `AVG(x)`. Unlike a scalar `call` (evaluated
-  /// per row), an aggregate accumulates over every row of a group and yields one
-  /// value, so the engine recognises the fixed set of aggregate names at parse
-  /// time and lowers them through a dedicated mechanism rather than the routines.
+  /// per row), an aggregate accumulates over every row of a group and yields
+  /// one value, so the engine recognises the fixed set of aggregate names at
+  /// parse time and lowers them through a dedicated mechanism rather than the
+  /// routines.
   ///
   /// `distinct` is the ISO `<set quantifier>` written inside the parentheses:
   /// `DISTINCT` folds each DISTINCT input value once (`COUNT(DISTINCT x)`,
@@ -707,10 +708,10 @@ public indirect enum Expression: Hashable, Sendable {
   /// source order.
   ///
   /// Both ISO forms reduce to this searched shape: a SEARCHED `CASE WHEN cond
-  /// THEN r … END` carries its predicates directly, and a SIMPLE `CASE op WHEN v
-  /// THEN r … END` is normalised at parse time to `WHEN op = v THEN r …`, so the
-  /// engine models one conditional. The result expressions' types must unify to
-  /// one result type (see resolution).
+  /// THEN r … END` carries its predicates directly, and a SIMPLE `CASE op WHEN
+  /// v THEN r … END` is normalised at parse time to `WHEN op = v THEN r …`, so
+  /// the engine models one conditional. The result expressions' types must
+  /// unify to one result type (see resolution).
   case `case`(Array<When>, else: Expression?)
   /// A `CAST(operand AS type)` — the ISO explicit conversion of the `operand`
   /// expression to the target `ValueType`. Unlike the widening `CASE` unifies
@@ -758,9 +759,9 @@ public indirect enum Expression: Hashable, Sendable {
 /// One `WHEN predicate THEN result` branch of a `CASE` expression — the guard
 /// and the value it yields when the guard is the first TRUE one.
 public struct When: Hashable, Sendable {
-  /// The guard predicate — TRUE selects this branch (UNKNOWN and FALSE skip it).
-  /// A simple `CASE`'s `WHEN value` is normalised to the equality `operand =
-  /// value` here.
+  /// The guard predicate — TRUE selects this branch (UNKNOWN and FALSE skip
+  /// it). A simple `CASE`'s `WHEN value` is normalised to the equality `operand
+  /// = value` here.
   public let when: Predicate
 
   /// The result expression this branch yields when its guard is the first TRUE.
@@ -844,11 +845,12 @@ public indirect enum Predicate: Hashable, Sendable {
   case null(Expression, negated: Bool)
   /// `operand IN (v, …)`, or `NOT IN` when `negated` — whether the operand
   /// equals any value of the non-empty `values` list. It is ISO shorthand for a
-  /// disjunction of equalities under three-valued logic: `x IN (a, b)` is `x = a
-  /// OR x = b`, so a NULL operand or a NULL element makes an otherwise-unmatched
-  /// test UNKNOWN rather than FALSE, and `NOT IN` is the negation of that (never
-  /// TRUE when a NULL element is present). The engine lowers it to that
-  /// disjunction rather than carrying a dedicated `Filter` case.
+  /// disjunction of equalities under three-valued logic: `x IN (a, b)` is `x =
+  /// a OR x = b`, so a NULL operand or a NULL element makes an
+  /// otherwise-unmatched test UNKNOWN rather than FALSE, and `NOT IN` is the
+  /// negation of that (never TRUE when a NULL element is present). The engine
+  /// lowers it to that disjunction rather than carrying a dedicated `Filter`
+  /// case.
   case membership(Expression, Array<Expression>, negated: Bool)
   /// `operand [NOT] LIKE pattern [ESCAPE escape]` — whether the operand's text
   /// matches the pattern, in which `%` matches any sequence of characters
@@ -1118,11 +1120,11 @@ public struct Order: Hashable, Sendable {
 ///
 /// It applies to the ordered result — after `WHERE` and `ORDER BY`, but before
 /// the projection, so a row outside the page is never projected: skip the first
-/// `offset` rows, then take at most `count`. The two ISO clauses are independent
-/// — an `OFFSET` written without a `FETCH` leaves `count` `nil` (no cap, every
-/// row after the skip), and a `FETCH` without an `OFFSET` caps from the start
-/// (`offset` `0`). Both counts are non-negative; a `count` of `0` yields no rows
-/// and an `offset` past the end yields none.
+/// `offset` rows, then take at most `count`. The two ISO clauses are
+/// independent — an `OFFSET` written without a `FETCH` leaves `count` `nil` (no
+/// cap, every row after the skip), and a `FETCH` without an `OFFSET` caps from
+/// the start (`offset` `0`). Both counts are non-negative; a `count` of `0`
+/// yields no rows and an `offset` past the end yields none.
 public struct Limit: Hashable, Sendable {
   /// The greatest number of rows the result yields, or `nil` for no cap — an
   /// `OFFSET` written without a `FETCH`.

--- a/Sources/SQLEngine/Adapter.swift
+++ b/Sources/SQLEngine/Adapter.swift
@@ -113,8 +113,8 @@ public enum ValueType: Hashable, Sendable {
 /// data, not rendered text — so a client may format, compare, or re-key it. A
 /// cell may also be `null` — SQL's absent value, distinct from any integer or
 /// text, unordered and unequal to everything (itself included) — which a source
-/// yields for a column that has no value in a row (a decoded attribute that does
-/// not apply), and which a comparison evaluates under three-valued logic.
+/// yields for a column that has no value in a row (a decoded attribute that
+/// does not apply), and which a comparison evaluates under three-valued logic.
 public enum Value: Hashable, Sendable {
   /// SQL `NULL` — the absence of a value.
   case null
@@ -579,8 +579,8 @@ public protocol Cursor: ~Escapable {
 
 /// A positional view over the cells of a single row.
 ///
-/// A cell is read by ordinal as a typed `Value` — the source decides whether the
-/// ordinal names an integral or a textual cell, and a virtual ordinal (one
+/// A cell is read by ordinal as a typed `Value` — the source decides whether
+/// the ordinal names an integral or a textual cell, and a virtual ordinal (one
 /// `>= Table.width`) is computed here rather than stored. The row borrows its
 /// cursor and never escapes that borrow; the `Value` it yields is owned and
 /// escapable.

--- a/Sources/SQLEngine/Aggregate.swift
+++ b/Sources/SQLEngine/Aggregate.swift
@@ -6,16 +6,16 @@
 ///
 /// An aggregate query groups its filtered rows by the `GROUP BY` columns (or
 /// treats the whole result as one group when there is none) and folds a
-/// `COUNT`/`SUM`/`MIN`/`MAX`/`AVG` accumulator over every row of a group. Unlike
-/// a scalar function — evaluated per row through the `Routines` — an aggregate
-/// accumulates over a group, so it is a separate mechanism the engine
+/// `COUNT`/`SUM`/`MIN`/`MAX`/`AVG` accumulator over every row of a group.
+/// Unlike a scalar function — evaluated per row through the `Routines` — an
+/// aggregate accumulates over a group, so it is a separate mechanism the engine
 /// recognises by name at parse time and lowers to an `Aggregation` here, never
 /// routed through `Function.swift`.
 ///
 /// The `Aggregate` node yields one grouped `Record` per group whose slots are
-/// the group-key values (slots `0 ..< keys.count`, in key order) followed by the
-/// aggregate results (slot `keys.count + j` is aggregate `j`), the slot space
-/// the projection, the `HAVING`, and the `ORDER BY` are lowered against.
+/// the group-key values (slots `0 ..< keys.count`, in key order) followed by
+/// the aggregate results (slot `keys.count + j` is aggregate `j`), the slot
+/// space the projection, the `HAVING`, and the `ORDER BY` are lowered against.
 
 /// A lowered aggregate — the ordinal-addressed form of an AST `Expression`'s
 /// `.aggregate`, ready for the executor to fold over a group.
@@ -23,9 +23,9 @@
 /// The `function` is the standard aggregate; `argument` is the term evaluated
 /// per source record whose non-NULL values the aggregate folds, or `nil` for
 /// `COUNT(*)`, which counts rows without reading any value. The argument is in
-/// the SOURCE's slot space (the WHERE/join chain below the aggregate), evaluated
-/// against each source record before the fold; the result lands in the grouped
-/// record.
+/// the SOURCE's slot space (the WHERE/join chain below the aggregate),
+/// evaluated against each source record before the fold; the result lands in
+/// the grouped record.
 ///
 /// Two aggregations are EQUAL when they fold the same function over the same
 /// resolved argument term — the RESOLVED form column qualification has already
@@ -88,15 +88,16 @@ extension Aggregation {
 /// A running aggregate over the rows of a group — the fold's state.
 ///
 /// One accumulator per aggregate per group folds each source record's argument
-/// value in, then `value` reads off the result. `COUNT` counts rows (or non-NULL
-/// values); `SUM`/`AVG` total the non-NULL numeric values — an all-integer
-/// total stays an exact integer, any double operand widens the total to an
-/// approximate double, and the widen/overflow choice is deferred to the end so
-/// the result does not depend on row order — `AVG` then dividing by the non-NULL
-/// count as real division to an approximate-numeric double; `MIN`/`MAX` keep
-/// the least/greatest non-NULL value by the engine's typed `less`. Every
-/// aggregate but `COUNT` IGNORES NULLs — a NULL argument does not fold — and an
-/// empty or all-NULL group yields `COUNT` `0` and the others NULL.
+/// value in, then `value` reads off the result. `COUNT` counts rows (or
+/// non-NULL values); `SUM`/`AVG` total the non-NULL numeric values — an
+/// all-integer total stays an exact integer, any double operand widens the
+/// total to an approximate double, and the widen/overflow choice is deferred to
+/// the end so the result does not depend on row order — `AVG` then dividing by
+/// the non-NULL count as real division to an approximate-numeric double;
+/// `MIN`/`MAX` keep the least/greatest non-NULL value by the engine's typed
+/// `less`. Every aggregate but `COUNT` IGNORES NULLs — a NULL argument does not
+/// fold — and an empty or all-NULL group yields `COUNT` `0` and the others
+/// NULL.
 private struct Accumulator {
   private let function: Aggregate
   // Whether to fold each DISTINCT non-NULL value once — the ISO `DISTINCT` set
@@ -113,8 +114,9 @@ private struct Accumulator {
   // SUM/AVG numeric state, kept independent of row order: an exact WIDE integer
   // total (`Int128`, range-checked once at the end) for the all-integer case,
   // and a parallel double total used once any operand is a double. A wide total
-  // means a transient prefix overflow cannot latch a fault a later value undoes,
-  // and the widen decision is deferred so a double anywhere widens the group.
+  // means a transient prefix overflow cannot latch a fault a later value
+  // undoes, and the widen decision is deferred so a double anywhere widens the
+  // group.
   private var integer: Int128 = 0
   private var total = 0.0
   private var widened = false
@@ -164,9 +166,10 @@ private struct Accumulator {
     switch function {
     case .count, .min, .max:
       if function != .count {
-        // Keep the least (`MIN`) or greatest (`MAX`) value by the engine's typed
-        // comparison; the first non-NULL value seeds it, and a later value of an
-        // unorderable kind is a type error, not an order-dependent keep.
+        // Keep the least (`MIN`) or greatest (`MAX`) value by the engine's
+        // typed comparison; the first non-NULL value seeds it, and a later
+        // value of an unorderable kind is a type error, not an order-dependent
+        // keep.
         extreme = if let current = extreme {
           try keep(value, over: current)
         } else {
@@ -196,9 +199,9 @@ private struct Accumulator {
   /// the lesser for `MIN`, the greater for `MAX`, by the engine's typed `less`.
   ///
   /// - Throws: `SQLError.operand` if the two kinds have no ordering (a TEXT and
-  ///   an INTEGER, say). `less` orders neither way for such a pair, so keeping
-  ///   the first-seen value would make MIN/MAX depend on row order; a type error
-  ///   is deterministic instead.
+  /// an INTEGER, say). `less` orders neither way for such a pair, so keeping
+  /// the first-seen value would make MIN/MAX depend on row order; a type error
+  /// is deterministic instead.
   private func keep(_ candidate: Value, over extreme: Value)
       throws(SQLError) -> Value {
     guard comparable(candidate, extreme) else {
@@ -281,16 +284,16 @@ private func comparable(_ a: Value, _ b: Value) -> Bool {
 /// Groups `records` by the `keys` terms and folds each `aggregates` accumulator
 /// over every record of a group, yielding one grouped record per group.
 ///
-/// A grouped record's slots are the key values (slots `0 ..< keys.count`, in key
-/// order) followed by the aggregate results (slot `keys.count + j` is
+/// A grouped record's slots are the key values (slots `0 ..< keys.count`, in
+/// key order) followed by the aggregate results (slot `keys.count + j` is
 /// `aggregates[j]`). Groups are keyed on the EXACT canonical form of the
 /// evaluated key values (`canonical` — so `1` and `1.0` fall in one group, the
-/// equality UNION and predicates use), and each group emits its FIRST-appearance
-/// original key values, in first-appearance order, so a later `ORDER BY`
-/// re-sorts deterministically. With no `keys` the whole input
-/// is ONE group — the degenerate whole-result aggregation (`SELECT COUNT(*) FROM
-/// T`) — which yields a single grouped record even over an empty input (`COUNT`
-/// `0`, the others NULL), the standard SQL rule.
+/// equality UNION and predicates use), and each group emits its
+/// FIRST-appearance original key values, in first-appearance order, so a later
+/// `ORDER BY` re-sorts deterministically. With no `keys` the whole input is ONE
+/// group — the degenerate whole-result aggregation (`SELECT COUNT(*) FROM T`) —
+/// which yields a single grouped record even over an empty input (`COUNT` `0`,
+/// the others NULL), the standard SQL rule.
 ///
 /// The `bindings` thread through both the key and the argument evaluation — the
 /// same bindings the projection and the `WHERE` filter resolve against — so a

--- a/Sources/SQLEngine/Context.swift
+++ b/Sources/SQLEngine/Context.swift
@@ -8,14 +8,14 @@
 /// A query runs against a `~Escapable` `Catalog` (borrowed, never copied) plus
 /// this `Context` (fully owned value data):
 ///
-///   - `relations` — the in-scope relation overlay: the materialised common
-///     table expressions a `WITH` binds and any `definition_schema.` store
-///     relation the query names, keyed case-folded. The resolver consults it
-///     BEFORE the base catalog, so a name it binds shadows a base table or view.
-///   - `routines` — the scalar functions (UDFs) a call resolves through, keyed
-///     case-folded; the engine prelude (`BITAND`) merged under the caller's.
-///   - `bindings` — the query parameters, each `:name` mapped to its bound
-///     value, read by a `bound` filter and the seek planner.
+/// - `relations` — the in-scope relation overlay: the materialised common table
+/// expressions a `WITH` binds and any `definition_schema.` store relation the
+/// query names, keyed case-folded. The resolver consults it BEFORE the base
+/// catalog, so a name it binds shadows a base table or view. - `routines` — the
+/// scalar functions (UDFs) a call resolves through, keyed case-folded; the
+/// engine prelude (`BITAND`) merged under the caller's. - `bindings` — the
+/// query parameters, each `:name` mapped to its bound value, read by a `bound`
+/// filter and the seek planner.
 ///
 /// It is plain escapable data, so it needs none of the lifetime machinery the
 /// borrowed catalog does: extending the `relations` overlay for a CTE's scope,
@@ -111,21 +111,22 @@ internal struct Context {
   /// A copy of this context ENTERING a fresh body scope over `relations` — the
   /// SINGLE derivation every view/derived-table/CTE body-entry seam routes
   /// through, `scoping(relations)` with the enclosing correlation stack CLEARED
-  /// (`uncorrelated()`). A body scope — a view definition, a non-LATERAL derived
-  /// table, or a CTE — is resolved INDEPENDENTLY of its call site, so it must
-  /// NOT correlate against an enclosing query's row: an unbound column in the
-  /// body must fault rather than bind outward to the caller. Folding the reset
-  /// INTO body-entry makes the clear intrinsic — a future body seam that routes
-  /// through `body(_:)` cannot forget to append `uncorrelated()`. A site that
-  /// also guards the cyclic-view chain or gates the eager type-check chains
-  /// `visiting(_:)`/`validating(_:)` AFTER `body(_:)`.
+  /// (`uncorrelated()`). A body scope — a view definition, a non-LATERAL
+  /// derived table, or a CTE — is resolved INDEPENDENTLY of its call site, so
+  /// it must NOT correlate against an enclosing query's row: an unbound column
+  /// in the body must fault rather than bind outward to the caller. Folding the
+  /// reset INTO body-entry makes the clear intrinsic — a future body seam that
+  /// routes through `body(_:)` cannot forget to append `uncorrelated()`. A site
+  /// that also guards the cyclic-view chain or gates the eager type-check
+  /// chains `visiting(_:)`/`validating(_:)` AFTER `body(_:)`.
   internal func body(_ relations: ScopedRelations) -> Context {
     scoping(relations).uncorrelated()
   }
 
-  /// A copy of this context whose overlay binds `materialised` to `name` (folded
-  /// to lower case), the binding shadowing any existing one — the recursive
-  /// step's rebinding of a CTE's self to the previous iteration's rows.
+  /// A copy of this context whose overlay binds `materialised` to `name`
+  /// (folded to lower case), the binding shadowing any existing one — the
+  /// recursive step's rebinding of a CTE's self to the previous iteration's
+  /// rows.
   internal func binding(_ name: String, to materialised: RelationInstance)
       -> Context {
     var relations = relations

--- a/Sources/SQLEngine/Definition.swift
+++ b/Sources/SQLEngine/Definition.swift
@@ -717,10 +717,10 @@ extension Select {
 
   /// Collects this select's `FROM` and `JOIN` NON-LATERAL derived tables — each
   /// alias with its inner query — into `derivations`. A LATERAL derived table
-  /// is SKIPPED: it is not materialised once as a constant relation but resolved
-  /// against the preceding FROM and re-evaluated per its rows (a correlated
-  /// apply), so `compile(select)` binds and executes it directly rather than
-  /// through the overlay `augment` builds.
+  /// is SKIPPED: it is not materialised once as a constant relation but
+  /// resolved against the preceding FROM and re-evaluated per its rows (a
+  /// correlated apply), so `compile(select)` binds and executes it directly
+  /// rather than through the overlay `augment` builds.
   func collect(derived derivations: inout Array<(String, Query)>) {
     if case let .derived(query) = from?.source, let alias = from?.alias,
         !(from?.lateral ?? false) {

--- a/Sources/SQLEngine/Engine.swift
+++ b/Sources/SQLEngine/Engine.swift
@@ -31,17 +31,17 @@ extension CTE {
   /// stamps on every member.
   ///
   /// The parser marks each member of a `WITH RECURSIVE` list recursive whether
-  /// or not it names itself, but only a self-referential CTE has a recursive arm
-  /// to iterate; running a non-self-referential one through the fixpoint would
-  /// re-evaluate an arm that never reads the CTE, repeating its rows without end
-  /// (a `UNION ALL`) or needlessly (a `UNION`). A CTE is recursive in truth when
-  /// its recursive arm — the right member of the top-level `UNION`, the one the
-  /// fixpoint compiles with the CTE bound — names `name` in a `FROM`/`JOIN`.
-  /// The anchor is the base case, compiled with the name NOT in scope, so a
-  /// `FROM <name>` there reads a base relation of that name, not the CTE.
-  /// Scanning the anchor too would misroute `WITH RECURSIVE Parent(Id) AS
-  /// (SELECT Id FROM Parent UNION ALL SELECT Id FROM Extra)` — whose anchor
-  /// merely reads the same-named base — into the fixpoint.
+  /// or not it names itself, but only a self-referential CTE has a recursive
+  /// arm to iterate; running a non-self-referential one through the fixpoint
+  /// would re-evaluate an arm that never reads the CTE, repeating its rows
+  /// without end (a `UNION ALL`) or needlessly (a `UNION`). A CTE is recursive
+  /// in truth when its recursive arm — the right member of the top-level
+  /// `UNION`, the one the fixpoint compiles with the CTE bound — names `name`
+  /// in a `FROM`/`JOIN`. The anchor is the base case, compiled with the name
+  /// NOT in scope, so a `FROM <name>` there reads a base relation of that name,
+  /// not the CTE. Scanning the anchor too would misroute `WITH RECURSIVE
+  /// Parent(Id) AS (SELECT Id FROM Parent UNION ALL SELECT Id FROM Extra)` —
+  /// whose anchor merely reads the same-named base — into the fixpoint.
   internal var recurses: Bool {
     guard case let .setop(.union, _, arm, _) = query else { return false }
     return arm.references(name.lowercased())
@@ -106,10 +106,10 @@ extension Catalog where Self: ~Escapable {
   /// concatenates the rows in source order — `UNION ALL` keeps every row, a
   /// bare `UNION` removes whole-row duplicates (first occurrence kept). The
   /// plan is binary and mirrors the left-associative chain, so each
-  /// `UNION`/`UNION ALL` honours its own flag — `(A UNION B) UNION ALL C` dedups
-  /// `A ∪ B` before appending `C`. The result columns are the first arm's
-  /// projection (the ISO rule); each arm keeps its own `ORDER BY`, applied
-  /// before the union.
+  /// `UNION`/`UNION ALL` honours its own flag — `(A UNION B) UNION ALL C`
+  /// dedups `A ∪ B` before appending `C`. The result columns are the first
+  /// arm's projection (the ISO rule); each arm keeps its own `ORDER BY`,
+  /// applied before the union.
   ///
   /// - Throws: `SQLError.relation` if the catalog resolves no such relation,
   ///   `SQLError.column` if a referenced column is absent, `SQLError.ambiguous`
@@ -279,9 +279,9 @@ extension Catalog where Self: ~Escapable {
       // The scope for this CTE's body: the base catalog plus every earlier CTE,
       // over the run's routines and bindings. `body(_:)` enters this fresh
       // statement-scoped body with the correlation stack CLEARED — a CTE is
-      // resolved independently of any call site (a `WITH` is statement-level, so
-      // the stack is already empty here; routing through `body(_:)` keeps the
-      // clear intrinsic to entering a body scope rather than incidental).
+      // resolved independently of any call site (a `WITH` is statement-level,
+      // so the stack is already empty here; routing through `body(_:)` keeps
+      // the clear intrinsic to entering a body scope rather than incidental).
       let scope = context.body(relations)
       // Validate the CTE's SHAPE and ARITY against the CTEs done so far — the
       // compile-time structural check, shared with the dry-run schema path so a
@@ -311,45 +311,45 @@ extension Catalog where Self: ~Escapable {
   /// `cte` against the base catalog plus the CTEs done so far (`ctes`), WITHOUT
   /// materialising a row — the compile-time structural check `with` runs before
   /// each CTE materialises, factored out so the dry-run result-schema path
-  /// (`columns(of:with:)`) validates a `WITH` by the SAME code a run does, ending
-  /// the divergence between the two.
+  /// (`columns(of:with:)`) validates a `WITH` by the SAME code a run does,
+  /// ending the divergence between the two.
   ///
   /// It reproduces, without executing, the two structural faults `with` and
   /// `fixpoint` raise:
   ///
-  ///   - The RECURSIVE SHAPE. A `WITH RECURSIVE` member's recursive reference
-  ///     must be its FINAL `UNION` arm — the engine's model is anchor members
-  ///     then ONE recursive arm. A reference to the CTE's own name in an EARLIER
-  ///     arm resolves against the base scope (the CTE is not in scope outside
-  ///     the recursive arm), so a same-named base or view is a valid seed; but
-  ///     with no such base/view the reference can only be a misplaced recursive
-  ///     arm — recursion before the final arm, or a second recursive arm — a
-  ///     shape the engine does not support, faulted `SQLError.unsupported`.
+  /// - The RECURSIVE SHAPE. A `WITH RECURSIVE` member's recursive reference
+  /// must be its FINAL `UNION` arm — the engine's model is anchor members then
+  /// ONE recursive arm. A reference to the CTE's own name in an EARLIER arm
+  /// resolves against the base scope (the CTE is not in scope outside the
+  /// recursive arm), so a same-named base or view is a valid seed; but with no
+  /// such base/view the reference can only be a misplaced recursive arm —
+  /// recursion before the final arm, or a second recursive arm — a shape the
+  /// engine does not support, faulted `SQLError.unsupported`.
   ///
-  ///   - The DECLARED ARITY. Each CTE body must project exactly the arity its
-  ///     column list declares, or a later reader indexes out of bounds. The
-  ///     body's width is known once it COMPILES — never opening a cursor — so
-  ///     the compiled `Plan.width` is checked against the declared count,
-  ///     faulting `SQLError.columns` on a mismatch. A recursive (self-naming)
-  ///     CTE checks its ANCHOR (self NOT in scope) and its RECURSIVE arm (self
-  ///     bound to the declared columns) separately, exactly as `fixpoint` does;
-  ///     every other CTE checks its whole body with self NOT in scope. This is
-  ///     why the schema path must NOT bind the CTE's self for the whole body: a
-  ///     `WITH RECURSIVE t(n) AS (SELECT n FROM t UNION SELECT n FROM t)` faults
-  ///     the recursive shape here — self is not in scope in the anchor — rather
-  ///     than resolving a self-reference the run would reject.
+  /// - The DECLARED ARITY. Each CTE body must project exactly the arity its
+  /// column list declares, or a later reader indexes out of bounds. The body's
+  /// width is known once it COMPILES — never opening a cursor — so the compiled
+  /// `Plan.width` is checked against the declared count, faulting
+  /// `SQLError.columns` on a mismatch. A recursive (self-naming) CTE checks its
+  /// ANCHOR (self NOT in scope) and its RECURSIVE arm (self bound to the
+  /// declared columns) separately, exactly as `fixpoint` does; every other CTE
+  /// checks its whole body with self NOT in scope. This is why the schema path
+  /// must NOT bind the CTE's self for the whole body: a `WITH RECURSIVE t(n) AS
+  /// (SELECT n FROM t UNION SELECT n FROM t)` faults the recursive shape here —
+  /// self is not in scope in the anchor — rather than resolving a
+  /// self-reference the run would reject.
   ///
   /// The reachable-operand type-check the schema path also wants is NOT part of
   /// the shape/arity check the run relies on — the run DEFERS it to execution.
   /// It rides in through `typecheck`: the run path passes `false` (it defers),
-  /// the schema path passes `true` (it must fault an ill-typed body statically).
-  /// Folding it here rather than layering it in the schema path keeps ONE per-arm
-  /// scoping for BOTH the structural check and the operand check — a recursive
-  /// CTE's ANCHOR is operand-checked against base + prior CTEs (self NOT in
-  /// scope, the scope the run evaluates the anchor in), NOT the CTE-self overlay,
-  /// so `SELECT Name + 1 FROM People` in the anchor faults `SQLError.operand`
-  /// against the BASE `People` a run reads it against, never wrongly types clean
-  /// against the CTE's declared columns.
+  /// the schema path passes `true` (it must fault an ill-typed body
+  /// statically). Folding it here rather than layering it in the schema path
+  /// keeps ONE per-arm scoping for BOTH the structural check and the operand
+  /// check — a recursive CTE's ANCHOR is operand-checked against base + prior
+  /// CTEs (self NOT in scope, the scope the run evaluates the anchor in), NOT
+  /// the CTE-self overlay, so `SELECT Name + 1 FROM People` in the anchor
+  /// faults `SQLError.operand` against the BASE `People` a run reads it
+  /// against, never wrongly types clean against the CTE's declared columns.
   ///
   /// `typecheck` ALSO gates the eager type-check of a DERIVED body the CTE
   /// body nests: the arity `augment`/`compile` below thread `validate:
@@ -376,10 +376,10 @@ extension Catalog where Self: ~Escapable {
     // recursive (self-naming) CTE checks its anchor and recursive arm the way
     // `fixpoint` does: the anchor with self NOT in scope, the recursive arm
     // with self bound to the declared columns. Every other CTE checks its whole
-    // body with self NOT in scope. When `typecheck`, the reachable-operand check
-    // runs in the SAME per-arm scope each arity check uses, so the operand check
-    // shares the run's arm scoping and never types an anchor against the
-    // CTE-self overlay.
+    // body with self NOT in scope. When `typecheck`, the reachable-operand
+    // check runs in the SAME per-arm scope each arity check uses, so the
+    // operand check shares the run's arm scoping and never types an anchor
+    // against the CTE-self overlay.
     if cte.recursive && cte.recurses,
         case let .setop(.union, anchor, recursive, _) = cte.query {
       let scope = try augment(context.validating(typecheck), for: anchor,
@@ -388,9 +388,9 @@ extension Catalog where Self: ~Escapable {
       guard width == cte.columns.count else {
         throw .columns(expected: cte.columns.count, got: width)
       }
-      // The anchor is operand-checked with self NOT in scope — the scope the run
-      // evaluates it in — so a text-arithmetic anchor faults against the base
-      // relation, not the CTE's declared (integer) columns.
+      // The anchor is operand-checked with self NOT in scope — the scope the
+      // run evaluates it in — so a text-arithmetic anchor faults against the
+      // base relation, not the CTE's declared (integer) columns.
       if typecheck { try self.typecheck(anchor, scope) }
       let empty = RelationInstance(columns: cte.columns, rows: [],
                                    types: Array(repeating: .integer,
@@ -438,9 +438,9 @@ extension Catalog where Self: ~Escapable {
   ///
   /// A non-`UNION` recursive query has no recursive arm to iterate, so it runs
   /// once like a non-recursive CTE — its compiled width validated the same way
-  /// before it materialises, so a non-`UNION` body binding rows of a width other
-  /// than the column list (e.g. a base relation of the CTE's own name) faults
-  /// with `SQLError.columns` rather than trapping on a later read.
+  /// before it materialises, so a non-`UNION` body binding rows of a width
+  /// other than the column list (e.g. a base relation of the CTE's own name)
+  /// faults with `SQLError.columns` rather than trapping on a later read.
   ///
   /// The anchor and the recursive arm are each validated against
   /// `cte.columns.count` by their compiled `Plan.width` BEFORE any rows bind
@@ -484,8 +484,8 @@ extension Catalog where Self: ~Escapable {
     }
 
     // A misplaced recursive reference in the anchor (a same-named base/view is
-    // absent) was already rejected in `with`, before routing here, so the anchor
-    // is a genuine base case by this point.
+    // absent) was already rejected in `with`, before routing here, so the
+    // anchor is a genuine base case by this point.
 
     // Validate the anchor's compiled width against the declared columns BEFORE
     // it seeds the working set: the loop binds `working` under `cte.columns` as
@@ -556,8 +556,8 @@ extension Projection {
   /// `single` leaf yields.
   ///
   /// The projection resolves against an empty schema (no columns), so only
-  /// literals, scalar calls, and arithmetic over them lower; a `SELECT *` has no
-  /// relation to expand and a bare-column reference no column to bind, each
+  /// literals, scalar calls, and arithmetic over them lower; a `SELECT *` has
+  /// no relation to expand and a bare-column reference no column to bind, each
   /// faulting (`SQLError.column` for a column, `SQLError.unsupported` for `*`).
   /// The terms hold no slots, so the `single` row's empty record carries every
   /// value the projection needs.
@@ -584,8 +584,8 @@ extension Projection {
                                    subquery: subquery)
       return .project(terms, .single)
     }
-    // `SELECT *` names every column of the relations in scope; a FROM-less query
-    // has none, so there is nothing to expand.
+    // `SELECT *` names every column of the relations in scope; a FROM-less
+    // query has none, so there is nothing to expand.
     throw .unsupported("SELECT * requires a FROM clause")
   }
 }
@@ -1619,8 +1619,8 @@ extension Catalog where Self: ~Escapable {
   /// group, yielding grouped records whose slots are the key values then the
   /// aggregate results. The projection, `HAVING`, and `ORDER BY` lower against
   /// that grouped slot space through a `Grouping`, which also enforces the
-  /// standard rule that every non-aggregated projection/`ORDER BY` column appear
-  /// in the `GROUP BY`.
+  /// standard rule that every non-aggregated projection/`ORDER BY` column
+  /// appear in the `GROUP BY`.
   internal borrowing func group(_ select: Select, _ relation: Relation,
                                 _ from: Resolved, _ context: Context)
       throws(SQLError) -> Plan {
@@ -1629,13 +1629,13 @@ extension Catalog where Self: ~Escapable {
     // dropped, the CTEs and store relations kept — before lowering a nested
     // subquery, so its FROM sees no derived alias while a CTE a same-named
     // derived alias shadows stays visible (a grouped `ORDER BY SUM((SELECT x
-    // FROM d))` reads the CTE `d` beneath the derived `d`).
-    // Resolve every joined relation and lay the FROM relation and each joined
-    // one end to end in one combined ordinal space (as the non-aggregate join
-    // path does), so the WHERE, keys, and aggregate arguments resolve uniformly.
-    // A LATERAL join under a GROUP BY / aggregate query is a deliberate
-    // follow-up — the grouped path forms a single-relation chain differently
-    // from the correlated apply — so fault it rather than mis-plan.
+    // FROM d))` reads the CTE `d` beneath the derived `d`). Resolve every
+    // joined relation and lay the FROM relation and each joined one end to end
+    // in one combined ordinal space (as the non-aggregate join path does), so
+    // the WHERE, keys, and aggregate arguments resolve uniformly. A LATERAL
+    // join under a GROUP BY / aggregate query is a deliberate follow-up — the
+    // grouped path forms a single-relation chain differently from the
+    // correlated apply — so fault it rather than mis-plan.
     for join in select.joins where join.relation.lateral {
       throw .state("0A000",
                    "a LATERAL join under an aggregate is not supported")
@@ -1736,7 +1736,9 @@ extension Catalog where Self: ~Escapable {
     for match in matches { match.references(into: &references) }
     predicate?.references(into: &references)
     for key in keys { key.references(into: &references) }
-    for aggregation in aggregations { aggregation.references(into: &references) }
+    for aggregation in aggregations {
+      aggregation.references(into: &references)
+    }
     let combined = references.sorted()
 
     var slot = Dictionary<Int, Int>(minimumCapacity: combined.count)
@@ -1775,9 +1777,9 @@ extension Catalog where Self: ~Escapable {
                                 $0.remapped(through: slot)
                               }, chain)
 
-    // Lower the projection, HAVING, and ORDER BY against the grouped slot space,
-    // enforcing the projection rule (every non-aggregated column must be a
-    // GROUP BY key).
+    // Lower the projection, HAVING, and ORDER BY against the grouped slot
+    // space, enforcing the projection rule (every non-aggregated column must be
+    // a GROUP BY key).
     var grouping = try Grouping(scope, select.grouping, aggregations,
                                 subquery: barred)
     let projection = try grouping.terms(select.projection, context.routines,
@@ -1830,8 +1832,8 @@ extension Projection {
 
 extension Expression {
   /// Collects the distinct aggregate expressions within this expression into
-  /// `expressions`, in first-appearance order — the same aggregate written twice
-  /// computes once.
+  /// `expressions`, in first-appearance order — the same aggregate written
+  /// twice computes once.
   internal func collect(into expressions: inout Array<Expression>) {
     switch self {
     case .column, .literal, .subquery:
@@ -2018,16 +2020,16 @@ extension Catalog where Self: ~Escapable {
       try .outer(optimise(left, context), optimise(right, context), on: on,
                  kind: kind)
     case let .apply(left, key, correlation, ordinals, on, kind):
-      // Optimise the left side (a seekable scan or a nested join inside it still
-      // rewrites), but keep the apply node, its `on`, and its recorded body plan
-      // intact — the body re-executes per outer row and was already compiled and
-      // pushed down under its own scope, so the outer optimise never reshapes
-      // it.
+      // Optimise the left side (a seekable scan or a nested join inside it
+      // still rewrites), but keep the apply node, its `on`, and its recorded
+      // body plan intact — the body re-executes per outer row and was already
+      // compiled and pushed down under its own scope, so the outer optimise
+      // never reshapes it.
       try .apply(optimise(left, context), key: key, correlation: correlation,
                  ordinals: ordinals, on: on, kind: kind)
     case let .setop(kind, left, right, all):
-      // Optimise each side with the same bindings so a bound predicate inside an
-      // arm seeks; the set operation itself merely combines its sides,
+      // Optimise each side with the same bindings so a bound predicate inside
+      // an arm seeks; the set operation itself merely combines its sides,
       // preserving this node's own `kind` and `all`.
       try .setop(kind, optimise(left, context), optimise(right, context),
                  all: all)
@@ -2038,9 +2040,9 @@ extension Catalog where Self: ~Escapable {
     case let .aggregate(keys, aggregates, source):
       // An aggregate reshapes its source and has no seek or join of its own;
       // optimise its source (the WHERE/join chain below it seeks and nests as
-      // usual) and rewrap. The `HAVING`/projection sit above it as `select`s the
-      // recursion reaches through here, but their grouped-space slots never seek
-      // a base relation.
+      // usual) and rewrap. The `HAVING`/projection sit above it as `select`s
+      // the recursion reaches through here, but their grouped-space slots never
+      // seek a base relation.
       try .aggregate(keys: keys, aggregates: aggregates,
                      optimise(source, context))
     case let .limit(count, offset, source):
@@ -2211,8 +2213,8 @@ private func integer(_ operand: Filter.Operand, _ bindings: Bindings) -> Int? {
 }
 
 extension Table where Self: ~Escapable {
-  /// The boundaries `[lower, upper)` to seek for a sort-key comparison, or `nil`
-  /// if `filter` does not qualify for the seek path.
+  /// The boundaries `[lower, upper)` to seek for a sort-key comparison, or
+  /// `nil` if `filter` does not qualify for the seek path.
   ///
   /// It qualifies when `filter` is a sort-key equality or range whose operand
   /// is an integer — a literal, or a bound parameter resolved from `bindings`
@@ -2295,12 +2297,13 @@ extension Catalog where Self: ~Escapable {
   /// index-nested-loop `Join` when a `match` conjunct relates the two sides,
   /// else leaves the product (a plain nested loop) under the filter.
   ///
-  /// The inner side is a bare `Scan(inner, _, nil)`, or that scan under a pushed
-  /// single-relation filter — `Select(inner-filter, Scan(inner, _, nil))`, the
-  /// shape selection pushdown leaves when a `WHERE` conjunct references only the
-  /// joined-in relation. Either way the join folds in the scan; the pushed
-  /// filter is preserved so the joined-in relation's non-key predicate still
-  /// rides the `Join` path rather than degrading to a residual product.
+  /// The inner side is a bare `Scan(inner, _, nil)`, or that scan under a
+  /// pushed single-relation filter — `Select(inner-filter, Scan(inner, _,
+  /// nil))`, the shape selection pushdown leaves when a `WHERE` conjunct
+  /// references only the joined-in relation. Either way the join folds in the
+  /// scan; the pushed filter is preserved so the joined-in relation's non-key
+  /// predicate still rides the `Join` path rather than degrading to a residual
+  /// product.
   ///
   /// The left side's slot count is the boundary `base` in the combined slot
   /// space: a slot below it is an outer-side key, a slot at or above it an
@@ -2308,14 +2311,14 @@ extension Catalog where Self: ~Escapable {
   /// table ordinal (`column`) through the inner scan's `ordinals` for the
   /// seek's `bound`. The matching conjunct is consumed; any remaining conjuncts
   /// stay as a residual `Select`. The pushed inner filter rides on the `Join`
-  /// node itself — in the inner's OWN 0-based standalone slot space, the space it
-  /// already lives in on the inner scan — so the executor applies it WHILE
+  /// node itself — in the inner's OWN 0-based standalone slot space, the space
+  /// it already lives in on the inner scan — so the executor applies it WHILE
   /// materialising inner rows (before bucketing / as part of the inner scan),
-  /// rather than lifting it into the residual to run after the join. Applying it
-  /// during materialisation means a pair forms only when the filter holds, so it
-  /// still gates a later unsafe residual conjunct (the pushdown barrier having
-  /// kept the safe inner filter ahead of any unsafe conjunct). When the inner
-  /// side is neither shape, the product is preserved.
+  /// rather than lifting it into the residual to run after the join. Applying
+  /// it during materialisation means a pair forms only when the filter holds,
+  /// so it still gates a later unsafe residual conjunct (the pushdown barrier
+  /// having kept the safe inner filter ahead of any unsafe conjunct). When the
+  /// inner side is neither shape, the product is preserved.
   private borrowing func nest(_ filter: Filter, _ left: Plan, _ right: Plan,
                               _ context: Context)
       throws(SQLError) -> Plan {
@@ -2346,12 +2349,12 @@ extension Catalog where Self: ~Escapable {
       // The pushed inner filter stays in the inner's 0-based standalone slot
       // space and rides on the `Join` node, applied while the executor
       // materialises the inner (before bucketing / as part of the inner scan) —
-      // NOT lifted into the residual to run after the join. It is always safe and
-      // the pushdown barrier kept it ahead of any unsafe conjunct, so applying it
-      // during materialisation still gates a later unsafe residual (a pair forms
-      // only when the filter holds), without letting that conjunct throw first
-      // (`Parent.Name = 'nope' AND (1 / Child.x) = 0`, the false name excluding
-      // the row before the division runs).
+      // NOT lifted into the residual to run after the join. It is always safe
+      // and the pushdown barrier kept it ahead of any unsafe conjunct, so
+      // applying it during materialisation still gates a later unsafe residual
+      // (a pair forms only when the filter holds), without letting that
+      // conjunct throw first (`Parent.Name = 'nope' AND (1 / Child.x) = 0`, the
+      // false name excluding the row before the division runs).
       let join = try Plan.join(optimise(left, context),
                                name: inner.name, ordinals: inner.ordinals,
                                base: base,
@@ -2385,23 +2388,23 @@ private func keys(_ lhs: Int, _ rhs: Int, _ base: Int)
 // MARK: - Selection pushdown
 
 extension Plan {
-  /// Pushes each `WHERE` conjunct that references a single relation's slots down
-  /// to just above that relation's leaf, before the join/product chain folds it
-  /// in — so a relation is filtered as it is read rather than after the whole
-  /// product is formed.
+  /// Pushes each `WHERE` conjunct that references a single relation's slots
+  /// down to just above that relation's leaf, before the join/product chain
+  /// folds it in — so a relation is filtered as it is read rather than after
+  /// the whole product is formed.
   ///
-  /// `compile` leaves the `WHERE` as one `select` atop the left-deep chain, so a
-  /// join runs on unfiltered inputs. This pass descends the chain: a conjunct
+  /// `compile` leaves the `WHERE` as one `select` atop the left-deep chain, so
+  /// a join runs on unfiltered inputs. This pass descends the chain: a conjunct
   /// whose slots all fall in one relation's contiguous slot run rides down to
   /// that relation's leaf as a `select` over its `scan`/`derived`, where the
   /// seek and nest rewrites can then act on it; a conjunct spanning two
   /// relations (a residual, an `OR` across sides) stays at the level whose two
-  /// children it straddles. A conjunct over a `derived` view's output columns is
-  /// pushed INTO the view's sub-plan — its outer slot mapped back through the
-  /// view's projection to the sub-plan slot the column reads — recursing below
-  /// the view's own joins. A `union` pushes into every arm. The pass is a pure
-  /// logical rewrite; `optimise` runs after it and still sees the `select`s the
-  /// seek and nest rewrites match.
+  /// children it straddles. A conjunct over a `derived` view's output columns
+  /// is pushed INTO the view's sub-plan — its outer slot mapped back through
+  /// the view's projection to the sub-plan slot the column reads — recursing
+  /// below the view's own joins. A `union` pushes into every arm. The pass is a
+  /// pure logical rewrite; `optimise` runs after it and still sees the
+  /// `select`s the seek and nest rewrites match.
   internal func pushdown() throws(SQLError) -> Plan {
     switch self {
     case .single, .scan, .join:
@@ -2428,11 +2431,11 @@ extension Plan {
       try .outer(left.pushdown(), right.pushdown(), on: on, kind: kind)
     case let .apply(left, key, correlation, ordinals, on, kind):
       // Push down WITHIN the left side (its own joins/filters rewrite), but the
-      // apply is a pushdown barrier: its right side is not a static sub-plan but
-      // a per-outer-row re-execution, so a `WHERE` conjunct above it never rides
-      // into it (mirroring the `.outer` gate — `distribute`'s default keeps the
-      // conjunct a `select` over this node). The recorded body plan was already
-      // pushed down at its compile.
+      // apply is a pushdown barrier: its right side is not a static sub-plan
+      // but a per-outer-row re-execution, so a `WHERE` conjunct above it never
+      // rides into it (mirroring the `.outer` gate — `distribute`'s default
+      // keeps the conjunct a `select` over this node). The recorded body plan
+      // was already pushed down at its compile.
       try .apply(left.pushdown(), key: key, correlation: correlation,
                  ordinals: ordinals, on: on, kind: kind)
     case let .setop(kind, left, right, all):
@@ -2447,21 +2450,22 @@ extension Plan {
       // An aggregate reshapes rows into a fresh grouped slot space, so it is a
       // pushdown barrier: a `HAVING`/projection filter above it is in grouped
       // space and stays there (`distribute`'s default keeps it as a `select`
-      // over the aggregate), while the WHERE below it — already placed under the
-      // aggregate at compile — pushes down within the source as usual.
+      // over the aggregate), while the WHERE below it — already placed under
+      // the aggregate at compile — pushes down within the source as usual.
       try .aggregate(keys: keys, aggregates: aggregates, source.pushdown())
     case let .limit(count, offset, source):
-      // A `limit` is the outermost operator, so no `WHERE` conjunct ever reaches
-      // it to push down; it recurses transparently, its source pushed as usual.
-      // A filter must never cross it — capping before or after a filter yields
-      // different rows — and none can, since the cap sits above the projection.
+      // A `limit` is the outermost operator, so no `WHERE` conjunct ever
+      // reaches it to push down; it recurses transparently, its source pushed
+      // as usual. A filter must never cross it — capping before or after a
+      // filter yields different rows — and none can, since the cap sits above
+      // the projection.
       try .limit(count: count, offset: offset, source.pushdown())
     }
   }
 
   /// Places each of `conjuncts` as deep in the already-pushed `self` as the
-  /// slots it reads allow, wrapping the level whose children a conjunct straddles
-  /// in a residual `select`.
+  /// slots it reads allow, wrapping the level whose children a conjunct
+  /// straddles in a residual `select`.
   ///
   /// At a `product`, `left.slots` is the boundary: a conjunct entirely below it
   /// belongs to the left child and rides down; one entirely at or above it
@@ -2503,19 +2507,20 @@ extension Plan {
         // order the `AND` chain wrote — when a preceding conjunct was unsafe
         // (`barrier`), when it reads no slots (e.g. `(1 / 0) = 0`, where
         // `allSatisfy` is vacuously true), when evaluating it can throw (a
-        // division or scalar call, e.g. `(1 / A.x) = 0`), or when it is nullable
-        // (reads a slot, so a NULL there makes it UNKNOWN) and a LATER conjunct
-        // is unsafe. Riding a throwing conjunct down would raise while scanning a
-        // child even when the join's other side is empty; riding a safe conjunct
-        // PAST an earlier unsafe one would filter its rows before the unsafe one
-        // runs, suppressing a throw the left-to-right `AND` owes (`(1 / A.x) = 0
-        // AND A.x <> 0`, `A.x = 0`, on a matching pair). Because the evaluator's
-        // `AND` does not short-circuit, riding a nullable conjunct BELOW a later
-        // unsafe one likewise suppresses a throw: the un-pushed `AND` runs the
-        // later conjunct even for the UNKNOWN row, but the pushed conjunct drops
-        // that row first (`A.x = 1 AND (1 / B.y) = 0`, `A.x` NULL and `B.y = 0`).
-        // Only a safe single-relation conjunct with no unsafe predecessor — and,
-        // if nullable, no unsafe successor — rides down.
+        // division or scalar call, e.g. `(1 / A.x) = 0`), or when it is
+        // nullable (reads a slot, so a NULL there makes it UNKNOWN) and a LATER
+        // conjunct is unsafe. Riding a throwing conjunct down would raise while
+        // scanning a child even when the join's other side is empty; riding a
+        // safe conjunct PAST an earlier unsafe one would filter its rows before
+        // the unsafe one runs, suppressing a throw the left-to-right `AND` owes
+        // (`(1 / A.x) = 0 AND A.x <> 0`, `A.x = 0`, on a matching pair).
+        // Because the evaluator's `AND` does not short-circuit, riding a
+        // nullable conjunct BELOW a later unsafe one likewise suppresses a
+        // throw: the un-pushed `AND` runs the later conjunct even for the
+        // UNKNOWN row, but the pushed conjunct drops that row first (`A.x = 1
+        // AND (1 / B.y) = 0`, `A.x` NULL and `B.y = 0`). Only a safe
+        // single-relation conjunct with no unsafe predecessor — and, if
+        // nullable, no unsafe successor — rides down.
         let hazard =
             conjunct.nullable && conjuncts[(index + 1)...].contains { !$0.safe }
         if barrier || slots.isEmpty || !conjunct.safe || hazard {
@@ -2606,8 +2611,8 @@ extension Plan {
 
   /// Pushes `conjuncts` INTO this `derived` view's sub-plan, below its own
   /// projection and joins, mapping each conjunct's outer slot (a slot into the
-  /// leaf's `ordinals`, i.e. a view output column) back to the sub-plan slot the
-  /// column reads.
+  /// leaf's `ordinals`, i.e. a view output column) back to the sub-plan slot
+  /// the column reads.
   ///
   /// A view's sub-plan is `Project(terms, body)` (or a `union` of such), so an
   /// output column `ordinals[slot]` is `terms[ordinals[slot]]`. A conjunct
@@ -2617,25 +2622,25 @@ extension Plan {
   /// `union` sub-plan admits a conjunct only when every arm's projection admits
   /// it — the arms are combined, so a conjunct that cannot push into one arm
   /// must stay outside them all. The admitted conjuncts, still in the view's
-  /// OUTPUT slot space, push in through `inject`, which rebases each against the
-  /// projection it lands under — PER ARM for a union, since the arms map the
-  /// same output column to DIFFERENT body slots; the rest wrap the leaf.
+  /// OUTPUT slot space, push in through `inject`, which rebases each against
+  /// the projection it lands under — PER ARM for a union, since the arms map
+  /// the same output column to DIFFERENT body slots; the rest wrap the leaf.
   ///
-  /// The partition carries the SAME ordering barrier `distribute`'s product loop
-  /// has: a conjunct stays `outer` — on the derived leaf, run in the `AND`
-  /// chain's order — when a preceding conjunct was unsafe (`barrier`), when it is
-  /// itself unsafe (a division or scalar call), when it is nullable and a LATER
-  /// conjunct is unsafe, or when the view's projection cannot admit it; only a
-  /// safe conjunct with no unsafe predecessor — and, if nullable, no unsafe
-  /// successor — pushes in. An unsafe conjunct bars every later one from riding
-  /// into the view: pushing a later conjunct past it would let the view seek and
-  /// drop the row before the unsafe outer conjunct runs, suppressing a throw the
-  /// left-to-right `AND` owes (`(1 / x) = 0 AND x = 1` over a view whose `x` is
-  /// sorted, the `x = 1` seek dropping the `x = 0` row before the outer division
-  /// raises). Symmetrically a nullable conjunct pushed BELOW a later unsafe one
-  /// suppresses a throw: the non-short-circuiting `AND` runs the later conjunct
-  /// even for the UNKNOWN row, but the injected conjunct drops that row first
-  /// (`x = 1 AND (1 / y) = 0`, `x` NULL and `y = 0`).
+  /// The partition carries the SAME ordering barrier `distribute`'s product
+  /// loop has: a conjunct stays `outer` — on the derived leaf, run in the `AND`
+  /// chain's order — when a preceding conjunct was unsafe (`barrier`), when it
+  /// is itself unsafe (a division or scalar call), when it is nullable and a
+  /// LATER conjunct is unsafe, or when the view's projection cannot admit it;
+  /// only a safe conjunct with no unsafe predecessor — and, if nullable, no
+  /// unsafe successor — pushes in. An unsafe conjunct bars every later one from
+  /// riding into the view: pushing a later conjunct past it would let the view
+  /// seek and drop the row before the unsafe outer conjunct runs, suppressing a
+  /// throw the left-to-right `AND` owes (`(1 / x) = 0 AND x = 1` over a view
+  /// whose `x` is sorted, the `x = 1` seek dropping the `x = 0` row before the
+  /// outer division raises). Symmetrically a nullable conjunct pushed BELOW a
+  /// later unsafe one suppresses a throw: the non-short-circuiting `AND` runs
+  /// the later conjunct even for the UNKNOWN row, but the injected conjunct
+  /// drops that row first (`x = 1 AND (1 / y) = 0`, `x` NULL and `y = 0`).
   private func into(_ conjuncts: Array<Filter>) throws(SQLError) -> Plan {
     guard case let .derived(name, plan, ordinals, seek) = self else {
       return residual(conjuncts)
@@ -2644,13 +2649,13 @@ extension Plan {
     var outer = Array<Filter>()
     var barrier = false
     for (index, conjunct) in conjuncts.enumerated() {
-      // A nullable conjunct (reads a slot, so a NULL there makes it UNKNOWN) must
-      // also stay outer when a LATER conjunct is unsafe: the evaluator's `AND`
-      // does not short-circuit, so the un-pushed query runs the later conjunct
-      // even for the UNKNOWN row, but injecting this one into the view would seek
-      // or filter that row away first — suppressing a throw the left-to-right
-      // `AND` owes (`x = 1 AND (1 / y) = 0` over a view exposing `x`/`y`, `x`
-      // NULL and `y = 0`).
+      // A nullable conjunct (reads a slot, so a NULL there makes it UNKNOWN)
+      // must also stay outer when a LATER conjunct is unsafe: the evaluator's
+      // `AND` does not short-circuit, so the un-pushed query runs the later
+      // conjunct even for the UNKNOWN row, but injecting this one into the view
+      // would seek or filter that row away first — suppressing a throw the
+      // left-to-right `AND` owes (`x = 1 AND (1 / y) = 0` over a view exposing
+      // `x`/`y`, `x` NULL and `y = 0`).
       let hazard =
           conjunct.nullable && conjuncts[(index + 1)...].contains { !$0.safe }
       if barrier || !conjunct.safe || hazard
@@ -2680,11 +2685,11 @@ extension Plan {
   private func pushable(_ conjunct: Filter, _ ordinals: Array<Int>) -> Bool {
     switch self {
     case let .project(terms, _):
-      // A conjunct pushes below the projection only when every projected term is
-      // safe: pushing it filters rows before the projection runs, so a throwing
-      // term — a division or scalar call, even one the conjunct does not read —
-      // would be skipped for the filtered rows, suppressing a raise `derive`
-      // owes by evaluating every column of every view row.
+      // A conjunct pushes below the projection only when every projected term
+      // is safe: pushing it filters rows before the projection runs, so a
+      // throwing term — a division or scalar call, even one the conjunct does
+      // not read — would be skipped for the filtered rows, suppressing a raise
+      // `derive` owes by evaluating every column of every view row.
       terms.allSatisfy(\.safe) && rebase(conjunct, ordinals) != nil
     case let .setop(_, left, right, _):
       left.pushable(conjunct, ordinals) && right.pushable(conjunct, ordinals)
@@ -2699,9 +2704,9 @@ extension Plan {
   ///
   /// For a `union` each arm rebases the conjuncts against ITS OWN projection —
   /// the same output column sits at different body slots across arms, so a
-  /// single pre-rebased filter cannot serve them all; the rebase must happen per
-  /// arm. `pushable` has already vetted every conjunct against every arm, so the
-  /// per-arm `rebase` is guaranteed non-nil.
+  /// single pre-rebased filter cannot serve them all; the rebase must happen
+  /// per arm. `pushable` has already vetted every conjunct against every arm,
+  /// so the per-arm `rebase` is guaranteed non-nil.
   private func inject(_ conjuncts: Array<Filter>, _ ordinals: Array<Int>)
       throws(SQLError) -> Plan {
     switch self {
@@ -2713,7 +2718,8 @@ extension Plan {
                  right.inject(conjuncts, ordinals), all: all)
     default:
       // A view sub-plan is always a `project` (or a `union` of them); anything
-      // else keeps the conjuncts as an outer `select` rather than dropping them.
+      // else keeps the conjuncts as an outer `select` rather than dropping
+      // them.
       residual(conjuncts)
     }
   }
@@ -2724,9 +2730,9 @@ extension Plan {
   /// pushed in.
   ///
   /// Slot `s` of the leaf reads view column `ordinals[s]`, whose value is the
-  /// projection term `terms[ordinals[s]]`; the conjunct pushes in only when that
-  /// term is a bare `.slot(body)`, in which case `s` maps to `body`. Shared by
-  /// `pushable` (the non-nil check) and `inject` (the rebased value).
+  /// projection term `terms[ordinals[s]]`; the conjunct pushes in only when
+  /// that term is a bare `.slot(body)`, in which case `s` maps to `body`.
+  /// Shared by `pushable` (the non-nil check) and `inject` (the rebased value).
   private func rebase(_ conjunct: Filter, _ ordinals: Array<Int>) -> Filter? {
     guard case let .project(terms, _) = self else { return nil }
     var map = Dictionary<Int, Int>(minimumCapacity: conjunct.slots.count)
@@ -2853,11 +2859,12 @@ extension Catalog where Self: ~Escapable {
       throws(SQLError) -> Plans {
     // Resolve each SITE'S subqueries against THAT site's own scope, keyed PER
     // OCCURRENCE: a join `i`'s `ON` against its PREFIX scope `prefixes[i]` (the
-    // relations available AT that join point), the WHERE/HAVING/projection/ORDER
-    // against the full join `enclosing`. The SAME inner SQL in both an `ON` and
-    // the WHERE is resolved TWICE — each against its own site's scope — so the
-    // WHERE occurrence sees the full scope and reports a genuine ambiguity rather
-    // than reusing the first `ON` occurrence's narrower prefix correlation.
+    // relations available AT that join point), the
+    // WHERE/HAVING/projection/ORDER against the full join `enclosing`. The SAME
+    // inner SQL in both an `ON` and the WHERE is resolved TWICE — each against
+    // its own site's scope — so the WHERE occurrence sees the full scope and
+    // reports a genuine ambiguity rather than reusing the first `ON`
+    // occurrence's narrower prefix correlation.
     var lowerings = Array<Resolution>()
     lowerings.reserveCapacity(select.joins.count)
     for index in select.joins.indices {
@@ -2917,9 +2924,9 @@ extension Catalog where Self: ~Escapable {
       // shape-only lenience below. `unlateralized()` clears the LATERAL-body
       // flag so a nested ORDINARY subquery within a lateral body builds its OWN
       // Resolution with `everywhere: false` — the lateral everywhere-admission
-      // covers ONLY the lateral body's own projection, NOT a subquery inside it,
-      // so an ordinary correlated scalar-subquery projection is barred exactly
-      // as it is outside a lateral body.
+      // covers ONLY the lateral body's own projection, NOT a subquery inside
+      // it, so an ordinary correlated scalar-subquery projection is barred
+      // exactly as it is outside a lateral body.
       let inner =
           context.with(outer: nested).validating(false).unlateralized()
       // A nested subquery's body derivation is SHAPE ONLY, so ALWAYS lenient
@@ -2944,8 +2951,9 @@ extension Catalog where Self: ~Escapable {
       types[query] =
           try columns(of: query.first, inner).first?.type
       // The correlation the nested compile discovered — the outer columns its
-      // inner `WHERE`/`ON` named — carried into the lowered subquery node so the
-      // per-outer-row re-execution binds them. Empty for an UNCORRELATED one.
+      // inner `WHERE`/`ON` named — carried into the lowered subquery node so
+      // the per-outer-row re-execution binds them. Empty for an UNCORRELATED
+      // one.
       correlations[query] = nested.correlation
       // A CORRELATED occurrence's inner PLAN was just compiled with THIS site's
       // enclosing scope, so its correlated columns are `Term.parameter`s bound
@@ -3074,9 +3082,9 @@ extension Catalog where Self: ~Escapable {
   /// Resolves the FROM `relation` and its `joins` into one combined scope, the
   /// single source three call sites share: the aggregate compile path, the
   /// non-aggregate compile path, and the `SELECT *` arity check. The caller
-  /// resolves FROM once (it needs the leaf for its own base lowering) and passes
-  /// its `schema` here, so FROM is never re-resolved; each join then resolves
-  /// into one running, end-to-end ordinal space.
+  /// resolves FROM once (it needs the leaf for its own base lowering) and
+  /// passes its `schema` here, so FROM is never re-resolved; each join then
+  /// resolves into one running, end-to-end ordinal space.
   ///
   /// The returned `joined` holds each join's `Resolved` (its schema and leaf
   /// factory) in source order — the plan lowers each into the combined slot
@@ -3123,9 +3131,10 @@ extension Catalog where Self: ~Escapable {
       }
       // The FROM resolves once here; each join then resolves through the shared
       // helper, which threads each join's PRECEDING scope into its resolve — so
-      // a LATERAL arm's body derives its projected preceding-FROM column against
-      // the relations before it rather than against no scope, which would fault
-      // the arity check even though the per-arm compile passes the prefix.
+      // a LATERAL arm's body derives its projected preceding-FROM column
+      // against the relations before it rather than against no scope, which
+      // would fault the arity check even though the per-arm compile passes the
+      // prefix.
       let schema = try resolve(relation, context).schema
       let (_, relations) = try resolve(from: relation, schema: schema,
                                        joins: select.joins, context)
@@ -3160,10 +3169,10 @@ extension Catalog where Self: ~Escapable {
   /// otherwise resolve against the base catalog (and other views) alone.
   ///
   /// A view's `columns` must name exactly one column per value its query
-  /// projects, or the view's schema would let a query index past a sub-plan row.
-  /// The parser checks this whenever the projection's arity is statically known;
-  /// this is the backstop for a `SELECT *` view, whose width is known only here,
-  /// after the sub-plan compiles — a mismatch is `SQLError.columns`.
+  /// projects, or the view's schema would let a query index past a sub-plan
+  /// row. The parser checks this whenever the projection's arity is statically
+  /// known; this is the backstop for a `SELECT *` view, whose width is known
+  /// only here, after the sub-plan compiles — a mismatch is `SQLError.columns`.
   ///
   /// `visited` names the views already being resolved down this chain. A view
   /// whose body reaches back to itself — `A` over `B` over `A`, or a view over
@@ -3172,11 +3181,11 @@ extension Catalog where Self: ~Escapable {
   /// definition, reported as `.recursion` rather than hung. The
   /// `definition_schema.` store's `columns` builder, which compiles every view
   /// to advertise it, relies on this: a cyclic view's `try? compile` catches
-  /// the fault and skips it.
-  /// Compiles a LATERAL derived table's `body` against the PRECEDING FROM
-  /// `scope`, discovering its correlation and stashing the pre-compiled plan for
-  /// the per-outer-row apply to re-execute — the FROM-clause analog of a
-  /// correlated subquery's compile pre-pass (`subquery(_:_:_:within:)`).
+  /// the fault and skips it. Compiles a LATERAL derived table's `body` against
+  /// the PRECEDING FROM `scope`, discovering its correlation and stashing the
+  /// pre-compiled plan for the per-outer-row apply to re-execute — the
+  /// FROM-clause analog of a correlated subquery's compile pre-pass
+  /// (`subquery(_:_:_:within:)`).
   ///
   /// The body compiles under a fresh `Outer` frame nested under `scope` (the
   /// FROM relation and the joins BEFORE this one), so a body column naming a
@@ -3185,9 +3194,10 @@ extension Catalog where Self: ~Escapable {
   /// lenient (`validate: false`), as the correlated-subquery pre-pass is — this
   /// pass discovers the shape, and the run's per-row execution faults a REACHED
   /// operand. The plan is recorded under the occurrence's `Subkey` (this
-  /// select's `subscope`, the body query, the `.lateral` role) composed with the
-  /// correlation, the same identity `Plan.apply` looks up through `executed`.
-  /// Returns the occurrence `Subkey` and the discovered correlation.
+  /// select's `subscope`, the body query, the `.lateral` role) composed with
+  /// the correlation, the same identity `Plan.apply` looks up through
+  /// `executed`. Returns the occurrence `Subkey` and the discovered
+  /// correlation.
   ///
   /// A lateral body's SCHEMA + VALIDATION route through the SAME derived-body
   /// machinery a NON-LATERAL derived body uses (`materialise`, `rows: false`),
@@ -3354,11 +3364,11 @@ extension Catalog where Self: ~Escapable {
   /// (the projection, the `filter`, the order column, and each join's keys)
   /// through `ordinal → slot` so the records the operators address are dense
   /// arrays. The combined slot space lays the relations end to end in chain
-  /// order — relation `i`'s referenced ordinals take a contiguous slot run after
-  /// every earlier relation's — matching the merged record (each relation's
-  /// cells concatenated in order). The tree is logical: every scan is a full
-  /// `Scan(_, _, nil)`; the optimiser turns scans into seeks and each product
-  /// into a join.
+  /// order — relation `i`'s referenced ordinals take a contiguous slot run
+  /// after every earlier relation's — matching the merged record (each
+  /// relation's cells concatenated in order). The tree is logical: every scan
+  /// is a full `Scan(_, _, nil)`; the optimiser turns scans into seeks and each
+  /// product into a join.
   ///
   internal borrowing func compile(_ select: Select,
                                   _ context: Context = Context())
@@ -3387,9 +3397,10 @@ extension Catalog where Self: ~Escapable {
     guard let relation = select.from else {
       // A FROM-less select projects expressions over a single row; a `WHERE`,
       // `GROUP BY`, `HAVING`, `ORDER BY`, `OFFSET`/`FETCH`, or `JOIN` has no
-      // relation to apply to. The parser never produces that shape, but a direct
-      // `Select(from: nil, …)` can, so reject it rather than silently ignore the
-      // clause — a scalar projection would drop a `GROUP BY`/`HAVING` otherwise.
+      // relation to apply to. The parser never produces that shape, but a
+      // direct `Select(from: nil, …)` can, so reject it rather than silently
+      // ignore the clause — a scalar projection would drop a `GROUP
+      // BY`/`HAVING` otherwise.
       guard select.joins.isEmpty, select.predicate == nil,
           select.grouping.isEmpty, select.having == nil,
           select.order == nil, select.limit == nil else {
@@ -3425,9 +3436,10 @@ extension Catalog where Self: ~Escapable {
     let from = try resolve(relation, context)
 
     if let limit = select.limit {
-      // The parser yields only non-negative counts (a `-` is its own token), but
-      // a direct `Limit(count:offset:)` may carry negatives the executor's skip
-      // and take would trap on. Reject them as a query error rather than crash.
+      // The parser yields only non-negative counts (a `-` is its own token),
+      // but a direct `Limit(count:offset:)` may carry negatives the executor's
+      // skip and take would trap on. Reject them as a query error rather than
+      // crash.
       guard limit.offset >= 0 else {
         throw .state("2201X", "OFFSET row count must be non-negative")
       }
@@ -3436,8 +3448,8 @@ extension Catalog where Self: ~Escapable {
       }
     }
 
-    // An aggregate query — one with a `GROUP BY`, a `HAVING`, or an aggregate in
-    // its projection — compiles through the grouped path, which places an
+    // An aggregate query — one with a `GROUP BY`, a `HAVING`, or an aggregate
+    // in its projection — compiles through the grouped path, which places an
     // `aggregate` node above the WHERE/join chain and lowers the projection,
     // `HAVING`, and `ORDER BY` against the grouped slot space. A non-aggregate
     // query compiles exactly as before.
@@ -3449,8 +3461,8 @@ extension Catalog where Self: ~Escapable {
       // Compile every nested subquery ONCE for its arity/type, ahead of
       // lowering, into a map the WHERE/projection/ORDER BY lowering reads — and
       // discover each one's CORRELATION against this select's single-relation
-      // scope (`enclosing`). This select's OWN columns correlate outward through
-      // `outer`.
+      // scope (`enclosing`). This select's OWN columns correlate outward
+      // through `outer`.
       let enclosing = Scope([(relation, from.schema)])
       let plans = try subquery(of: select, context, enclosing: enclosing)
       var filter: Filter? = nil
@@ -3519,10 +3531,10 @@ extension Catalog where Self: ~Escapable {
     // A `column = column` conjunct lowers to a `match` hash-join key; any
     // inequality or expression equality lowers to a residual the join filters.
     // The WHERE and ORDER lower against the whole chain, which legitimately
-    // sees every relation.
-    // Each join's PREFIX scope — the FROM relation and joins `0…index`, the
-    // relations available AT that join point, never one joined LATER — the scope
-    // its `ON` lowers against and a subquery in that `ON` correlates against.
+    // sees every relation. Each join's PREFIX scope — the FROM relation and
+    // joins `0…index`, the relations available AT that join point, never one
+    // joined LATER — the scope its `ON` lowers against and a subquery in that
+    // `ON` correlates against.
     let prefixes = select.joins.indices.map { index in
       Scope(Array(relations[0 ... index + 1]))
     }
@@ -3550,8 +3562,9 @@ extension Catalog where Self: ~Escapable {
     // into a map the join ONs, WHERE, projection, and ORDER BY lowering reads —
     // and discover each one's CORRELATION. A join `ON`'s subquery correlates
     // against its PREFIX scope; the WHERE/projection/ORDER against the whole
-    // join `scope`. This select's OWN columns correlate outward through `outer`.
-    // `validate` gates a nested filtered-out derived body's eager type-check.
+    // join `scope`. This select's OWN columns correlate outward through
+    // `outer`. `validate` gates a nested filtered-out derived body's eager
+    // type-check.
     let plans = try subquery(of: select, context, enclosing: scope,
                              prefixes: prefixes)
     var matches = Array<Filter>()
@@ -3599,7 +3612,8 @@ extension Catalog where Self: ~Escapable {
     // The combined referenced ordinals — projection ∪ every match ∪ WHERE ∪
     // order — packed per relation in chain order: relation i's referenced
     // ordinals take a contiguous slot run after every earlier relation's,
-    // building the combined-ordinal → slot map and each relation's leaf ordinals.
+    // building the combined-ordinal → slot map and each relation's leaf
+    // ordinals.
     var references = Set<Int>()
     for term in projection { term.references(into: &references) }
     for match in matches { match.references(into: &references) }
@@ -3607,8 +3621,8 @@ extension Catalog where Self: ~Escapable {
     for key in order { key.term.references(into: &references) }
     // A LATERAL apply reads its correlation's outer ordinals from the left
     // chain's record, so those preceding-relation ordinals must be MATERIALISED
-    // (given a packed slot) even when no clause of THIS select references them —
-    // else the correlation's remap through `slot` finds no slot for the outer
+    // (given a packed slot) even when no clause of THIS select references them
+    // — else the correlation's remap through `slot` finds no slot for the outer
     // column its body names.
     for lateral in laterals {
       references.formUnion(lateral?.correlation.slots ?? [])

--- a/Sources/SQLEngine/Error.swift
+++ b/Sources/SQLEngine/Error.swift
@@ -70,8 +70,8 @@ public enum SQLError: Error, Hashable, Sendable {
   /// silent coercion; the string describes the fault. A NULL operand is not a
   /// fault: it propagates to a NULL result.
   case operand(String)
-  /// A binary arithmetic expression divides by zero — standard SQL raises rather
-  /// than yielding a value.
+  /// A binary arithmetic expression divides by zero — standard SQL raises
+  /// rather than yielding a value.
   case divide
   /// A binary arithmetic expression's integer result exceeds the platform `Int`
   /// — reported rather than trapped; the string describes the fault.
@@ -99,8 +99,8 @@ public enum SQLError: Error, Hashable, Sendable {
   /// columns of every arm must align — carrying the first arm's width and the
   /// offending arm's.
   case arity(Int, Int)
-  /// A query uses a construct the engine does not support in the shape given — a
-  /// `SELECT *` with no `FROM`, or a `WHERE`/`ORDER BY`/`JOIN` on a FROM-less
+  /// A query uses a construct the engine does not support in the shape given —
+  /// a `SELECT *` with no `FROM`, or a `WHERE`/`ORDER BY`/`JOIN` on a FROM-less
   /// select (which projects only expressions over a single row); the string
   /// describes it.
   case unsupported(String)
@@ -202,35 +202,34 @@ extension SQLError {
   /// characters are the class and whose last three are the subclass. Every case
   /// maps to a code, so any `SQLError` exposes one.
   ///
-  /// The codes draw on ISO/IEC 9075-2 Annex B (SQLSTATE class values) and, where
-  /// ISO leaves the subclass implementation-defined, the de-facto PostgreSQL
-  /// assignments:
+  /// The codes draw on ISO/IEC 9075-2 Annex B (SQLSTATE class values) and,
+  /// where ISO leaves the subclass implementation-defined, the de-facto
+  /// PostgreSQL assignments:
   ///
   /// - Class `42` — syntax error or access rule violation — covers the
-  ///   lexer/parser faults (`42601` syntax error), the undefined-object faults
-  ///   (`42P01` table, `42703` column, `42883` function), and the name-collision
-  ///   faults (`42702` ambiguous, `42701` duplicate). `42P01` is a PostgreSQL
-  ///   subclass; ISO itself leaves the `42` subclass implementation-defined, so
-  ///   this is a deliberate choice noted alongside `42703`/`42883`, which are
-  ///   likewise PostgreSQL subclasses on the same class.
-  /// - Class `22` — data exception — covers the value faults: `22003` numeric
-  ///   value out of range (the out-of-range integer literal and the arithmetic
-  ///   overflow), `22012` division by zero, and `22023` invalid parameter value
-  ///   (a scalar function's rejected argument).
-  /// - `42804` (datatype mismatch) is the non-numeric arithmetic operand — a
-  ///   type error at evaluation rather than a value-range fault.
-  /// - Class `SS` — the implementation-defined class this engine squats on
-  ///   (SwiftSQL) for a condition with no standard ISO code — `SS001`, a query
-  ///   shape the engine does not support (a FROM-less `SELECT *`, or a clause
-  ///   with no `FROM`), `SS002`, a statement that is not runnable as a query
-  ///   (a `CREATE VIEW`, or a malformed `WITH` member), `SS003`, a recursive
-  ///   CTE that did not reach a fixpoint within the iteration cap, `SS004`, an
-  ///   aggregate query naming a non-aggregated column absent from the `GROUP
-  ///   BY`, `SS005`, a `SELECT DISTINCT` ordering on a column absent from its
-  ///   select list, and `SS006`, a scalar subquery yielding more than one row
-  ///   (ISO's `21000` cardinality violation, kept in the engine's own class for
-  ///   uniformity with its siblings). ISO leaves classes whose first character
-  ///   is `5`–`9` or `I`–`Z` implementation-defined, so `SS` is a safe squat.
+  /// lexer/parser faults (`42601` syntax error), the undefined-object faults
+  /// (`42P01` table, `42703` column, `42883` function), and the name-collision
+  /// faults (`42702` ambiguous, `42701` duplicate). `42P01` is a PostgreSQL
+  /// subclass; ISO itself leaves the `42` subclass implementation-defined, so
+  /// this is a deliberate choice noted alongside `42703`/`42883`, which are
+  /// likewise PostgreSQL subclasses on the same class. - Class `22` — data
+  /// exception — covers the value faults: `22003` numeric value out of range
+  /// (the out-of-range integer literal and the arithmetic overflow), `22012`
+  /// division by zero, and `22023` invalid parameter value (a scalar function's
+  /// rejected argument). - `42804` (datatype mismatch) is the non-numeric
+  /// arithmetic operand — a type error at evaluation rather than a value-range
+  /// fault. - Class `SS` — the implementation-defined class this engine squats
+  /// on (SwiftSQL) for a condition with no standard ISO code — `SS001`, a query
+  /// shape the engine does not support (a FROM-less `SELECT *`, or a clause
+  /// with no `FROM`), `SS002`, a statement that is not runnable as a query (a
+  /// `CREATE VIEW`, or a malformed `WITH` member), `SS003`, a recursive CTE
+  /// that did not reach a fixpoint within the iteration cap, `SS004`, an
+  /// aggregate query naming a non-aggregated column absent from the `GROUP BY`,
+  /// `SS005`, a `SELECT DISTINCT` ordering on a column absent from its select
+  /// list, and `SS006`, a scalar subquery yielding more than one row (ISO's
+  /// `21000` cardinality violation, kept in the engine's own class for
+  /// uniformity with its siblings). ISO leaves classes whose first character is
+  /// `5`–`9` or `I`–`Z` implementation-defined, so `SS` is a safe squat.
   public var sqlstate: String {
     switch self {
     case let .state(code, _):

--- a/Sources/SQLEngine/Filter.swift
+++ b/Sources/SQLEngine/Filter.swift
@@ -143,20 +143,21 @@ internal indirect enum Filter: Equatable, Sendable {
 ///
 /// `Term` is the lowered form of the AST's name-addressed `Expression`: a slot
 /// reference (a column resolved to its slot in a record), a constant, or a call
-/// to a registered scalar function over argument terms. A projection lowers each
-/// projected expression to a `Term` the executor evaluates per record against
-/// the routines; a bare-column projection lowers to a `.slot`, so the simple
-/// path stays a plain slot read.
+/// to a registered scalar function over argument terms. A projection lowers
+/// each projected expression to a `Term` the executor evaluates per record
+/// against the routines; a bare-column projection lowers to a `.slot`, so the
+/// simple path stays a plain slot read.
 internal indirect enum Term: Equatable, Sendable {
   /// The cell at `slot` of the record.
   case slot(Int)
   /// A run-time `:parameter`, resolved from the engine's bindings — the lowered
   /// form of a CORRELATED subquery's reference to an ENCLOSING query's column.
   /// An outer column the inner query names binds neither locally nor as an
-  /// ordinary parameter; it lowers to this synthetic name, and the per-outer-row
-  /// re-execution binds it to that row's cell before running the inner plan (see
-  /// `Correlation`). An unbound name (or one bound to NULL) reads `.null`, so a
-  /// comparison against it is UNKNOWN, exactly as a `Filter.bound` operand is.
+  /// ordinary parameter; it lowers to this synthetic name, and the
+  /// per-outer-row re-execution binds it to that row's cell before running the
+  /// inner plan (see `Correlation`). An unbound name (or one bound to NULL)
+  /// reads `.null`, so a comparison against it is UNKNOWN, exactly as a
+  /// `Filter.bound` operand is.
   case parameter(String)
   /// A constant value.
   case constant(Value)
@@ -165,14 +166,15 @@ internal indirect enum Term: Equatable, Sendable {
   /// `lhs <op> rhs` — a binary arithmetic over two operand terms, the lowered
   /// form of the AST's `Expression.binary`.
   case binary(Arithmetic, Term, Term)
-  /// A `CASE` conditional — the lowered form of the AST's `Expression.case`. Each
-  /// branch is a guard `Filter` and the result `Term` it yields; the executor
-  /// evaluates the guards in order and takes the first whose three-valued value
-  /// is TRUE (UNKNOWN and FALSE skip), else the `else` term, or `NULL` when there
-  /// is none. `type` is the unification of the branch result types (the same
-  /// `ValueType.unified` reduction `derive`/`validate` compute) — the type the
-  /// schema advertises for the column — so the executor COERCES the selected
-  /// value to it, widening an `.integer` arm of a `.double` CASE.
+  /// A `CASE` conditional — the lowered form of the AST's `Expression.case`.
+  /// Each branch is a guard `Filter` and the result `Term` it yields; the
+  /// executor evaluates the guards in order and takes the first whose
+  /// three-valued value is TRUE (UNKNOWN and FALSE skip), else the `else` term,
+  /// or `NULL` when there is none. `type` is the unification of the branch
+  /// result types (the same `ValueType.unified` reduction `derive`/`validate`
+  /// compute) — the type the schema advertises for the column — so the executor
+  /// COERCES the selected value to it, widening an `.integer` arm of a
+  /// `.double` CASE.
   case `case`(Array<(Filter, Term)>, else: Term?, type: ValueType)
   /// A `CAST(operand AS type)` — the lowered form of the AST's
   /// `Expression.cast`. The executor evaluates the operand `Term` and CONVERTS
@@ -294,9 +296,9 @@ extension Term {
       // A CORRELATED scalar subquery reads the enclosing row's cells its inner
       // `WHERE` names — the correlation's `slot` outer ordinals — so those must
       // be materialised into the outer record for the per-row re-execution to
-      // bind them. A `bound` source is a threaded binding, not an outer cell, so
-      // it references none. An UNCORRELATED one (empty correlation) references
-      // none — its value is a single cache lookup.
+      // bind them. A `bound` source is a threaded binding, not an outer cell,
+      // so it references none. An UNCORRELATED one (empty correlation)
+      // references none — its value is a single cache lookup.
       slots.formUnion(correlation.slots)
     }
   }
@@ -334,8 +336,9 @@ extension Term {
     case let .subquery(key, correlation, type):
       // A CORRELATED scalar subquery's correlation reads OUTER ordinals; remap
       // each `slot` to its packed slot so the per-row re-execution reads the
-      // outer record's cell (a `bound` source is unchanged — it reads a threaded
-      // binding). An UNCORRELATED one has an empty map and is unchanged.
+      // outer record's cell (a `bound` source is unchanged — it reads a
+      // threaded binding). An UNCORRELATED one has an empty map and is
+      // unchanged.
       .subquery(key, correlation: correlation.remapped(through: slot),
                 type: type)
     }
@@ -357,11 +360,12 @@ extension Term {
 
   /// Whether this term reads a run-time `:parameter` anywhere — a CORRELATED
   /// subquery's synthetic outer binding, which may be unbound or bound to NULL,
-  /// so a comparison over it can be UNKNOWN even when it reads NO slot. Selection
-  /// pushdown reads this (through `Filter.nullable`) so a `.compare`/`.null` over
-  /// a correlated `:parameter` — a slotless `outer_id = 1` — is not moved ahead
-  /// of a later unsafe conjunct the non-short-circuiting `AND` still owes, the
-  /// same treatment a `Filter.bound` parameter already gets.
+  /// so a comparison over it can be UNKNOWN even when it reads NO slot.
+  /// Selection pushdown reads this (through `Filter.nullable`) so a
+  /// `.compare`/`.null` over a correlated `:parameter` — a slotless `outer_id =
+  /// 1` — is not moved ahead of a later unsafe conjunct the
+  /// non-short-circuiting `AND` still owes, the same treatment a `Filter.bound`
+  /// parameter already gets.
   internal var parameterised: Bool {
     switch self {
     case .parameter: true
@@ -433,11 +437,11 @@ extension Filter.Operand {
     }
   }
 
-  /// Whether this operand reads a run-time `:parameter` — a `.parameter` is
-  /// one (it may be unbound or bound to NULL, so a `LIKE` over it is UNKNOWN),
-  /// and a `.term` is one when its `Term` itself carries a correlated
-  /// `Term.parameter`. `Filter.like` folds this over its pattern and escape so a
-  /// parameterised `LIKE` stays off a pushdown below a later unsafe conjunct
+  /// Whether this operand reads a run-time `:parameter` — a `.parameter` is one
+  /// (it may be unbound or bound to NULL, so a `LIKE` over it is UNKNOWN), and
+  /// a `.term` is one when its `Term` itself carries a correlated
+  /// `Term.parameter`. `Filter.like` folds this over its pattern and escape so
+  /// a parameterised `LIKE` stays off a pushdown below a later unsafe conjunct
   /// (see `Filter.nullable`).
   internal var parameterised: Bool {
     switch self {
@@ -477,14 +481,14 @@ extension Filter {
     case let .exists(key, correlation, negated):
       // A CORRELATED EXISTS reads the enclosing row's cells its inner `WHERE`
       // names; remap each `slot` outer ordinal to its packed slot (a `bound`
-      // source is unchanged). An UNCORRELATED one has an empty map and passes its
-      // cache key through unchanged.
+      // source is unchanged). An UNCORRELATED one has an empty map and passes
+      // its cache key through unchanged.
       .exists(key, correlation: correlation.remapped(through: slot),
               negated: negated)
     case let .within(operand, key, correlation, negated):
-      // The outer operand term reads slots; a CORRELATED subquery ALSO reads the
-      // outer cells its inner `WHERE` names, so remap both. An UNCORRELATED one
-      // carries an empty correlation.
+      // The outer operand term reads slots; a CORRELATED subquery ALSO reads
+      // the outer cells its inner `WHERE` names, so remap both. An UNCORRELATED
+      // one carries an empty correlation.
       .within(operand.remapped(through: slot), key,
               correlation: correlation.remapped(through: slot),
               negated: negated)
@@ -556,11 +560,11 @@ extension Filter {
     return plan
   }
 
-  /// Whether evaluating this filter cannot throw — every term it reads is a bare
-  /// slot or a constant. Selection pushdown keeps a filter that is NOT safe at
-  /// the product level (evaluated per pair), so a division or scalar-call
-  /// predicate raises only when a pair exists — never on an empty product it
-  /// would have skipped had it stayed above the join.
+  /// Whether evaluating this filter cannot throw — every term it reads is a
+  /// bare slot or a constant. Selection pushdown keeps a filter that is NOT
+  /// safe at the product level (evaluated per pair), so a division or
+  /// scalar-call predicate raises only when a pair exists — never on an empty
+  /// product it would have skipped had it stayed above the join.
   internal var safe: Bool {
     switch self {
     case let .compare(lhs, _, rhs): lhs.safe && rhs.safe
@@ -651,23 +655,23 @@ extension Filter {
   /// Whether this filter compares against a run-time `:parameter` — a `.bound`
   /// anywhere in it, a `.compare`/`.null`/`.membership`/`.distinct` whose TERM
   /// carries a `Term.parameter` (a CORRELATED subquery's synthetic outer
-  /// binding), a `.like` whose pattern or escape operand is a `:parameter`, or a
-  /// `.between` whose test or bound carries one. Such a predicate reads no slot
-  /// yet can be UNKNOWN, because the parameter may be unbound (or bound to
+  /// binding), a `.like` whose pattern or escape operand is a `:parameter`, or
+  /// a `.between` whose test or bound carries one. Such a predicate reads no
+  /// slot yet can be UNKNOWN, because the parameter may be unbound (or bound to
   /// NULL), so `nullable` counts it even when `slots` is empty — keeping `'x'
   /// LIKE :p`, `1 BETWEEN :lo AND :hi`, or a correlated slotless `outer_id = 1`
-  /// off a pushdown below a later unsafe conjunct the non-short-circuiting `AND`
-  /// still owes.
+  /// off a pushdown below a later unsafe conjunct the non-short-circuiting
+  /// `AND` still owes.
   ///
   /// `internal` (not `private`) so `Term.parameterised` can consult a `.case`
   /// guard `Filter` for a correlated `:parameter`.
   internal var parameterised: Bool {
     switch self {
     case .bound: true
-    // A term-bearing predicate is parameterised when a TERM carries a correlated
-    // `Term.parameter` — a slotless comparison that can be UNKNOWN, so it must
-    // not ride ahead of a later unsafe conjunct, the same treatment `.bound`
-    // gets.
+    // A term-bearing predicate is parameterised when a TERM carries a
+    // correlated `Term.parameter` — a slotless comparison that can be UNKNOWN,
+    // so it must not ride ahead of a later unsafe conjunct, the same treatment
+    // `.bound` gets.
     case let .compare(lhs, _, rhs): lhs.parameterised || rhs.parameterised
     case let .null(term, _): term.parameterised
     case let .membership(operand, elements, _):
@@ -675,8 +679,8 @@ extension Filter {
     case let .distinct(lhs, rhs, _): lhs.parameterised || rhs.parameterised
     case .match: false
     // An UNCORRELATED subquery predicate reads no run-time `:parameter` of the
-    // OUTER query — the subquery runs once at run start with the same bindings —
-    // so none is parameterised for the outer row. A CORRELATED one is already
+    // OUTER query — the subquery runs once at run start with the same bindings
+    // — so none is parameterised for the outer row. A CORRELATED one is already
     // NOT `safe` (it re-runs per row), so it never rides a pushdown regardless.
     case .exists, .within, .quantified: false
     case let .like(operand, pattern, escape, _):
@@ -757,8 +761,8 @@ extension Catalog where Self: ~Escapable {
     case let .parameter(name):
       // A correlated `:parameter` reads its value from the bindings — the
       // enclosing row's cell, merged in by the per-outer-row re-execution. An
-      // unbound name reads `.null` (a comparison against it is UNKNOWN), exactly
-      // as a `Filter.bound` operand resolves an absent parameter.
+      // unbound name reads `.null` (a comparison against it is UNKNOWN),
+      // exactly as a `Filter.bound` operand resolves an absent parameter.
       context.bindings[name] ?? .null
     case let .constant(value):
       value
@@ -790,8 +794,8 @@ extension Catalog where Self: ~Escapable {
       // Materialise the scalar subquery LAZILY on this first reach — an
       // occurrence in a skipped `CASE`/`COALESCE` arm is never reached, so it
       // never runs (never throws). COERCE the collapsed value to the inner
-      // column's type, as a `CASE` coerces its selected arm. An UNCORRELATED one
-      // memoises; a CORRELATED one re-runs against this row's correlated
+      // column's type, as a `CASE` coerces its selected arm. An UNCORRELATED
+      // one memoises; a CORRELATED one re-runs against this row's correlated
       // bindings.
       try scalar(row, key, correlation, type, context)
     }
@@ -896,13 +900,13 @@ extension Catalog where Self: ~Escapable {
   /// `.full` apply makes no sense for a correlated body: rejected at compile.
   ///
   /// The lateral body runs through the SAME `executed` path a correlated
-  /// subquery does — it binds the correlation's `slot` sources from the borrowed
-  /// left `record`, augments the body's OWN aliases, and runs the pre-compiled
-  /// plan — so the borrow is never retained: `executed` returns owned
-  /// `Record`s, and the pair merges two owned records. The right record is the
-  /// body's FULL output, so `ordinals` select the referenced columns into the
-  /// combined space laid after the left's slots, exactly as a scan's referenced
-  /// ordinals sit after the left in a `product`.
+  /// subquery does — it binds the correlation's `slot` sources from the
+  /// borrowed left `record`, augments the body's OWN aliases, and runs the
+  /// pre-compiled plan — so the borrow is never retained: `executed` returns
+  /// owned `Record`s, and the pair merges two owned records. The right record
+  /// is the body's FULL output, so `ordinals` select the referenced columns
+  /// into the combined space laid after the left's slots, exactly as a scan's
+  /// referenced ordinals sit after the left in a `product`.
   ///
   /// A lateral derived table exposes the universal virtual `Id` column at its
   /// real `width` — its resolution schema is a `RelationInstance.schema()`, so
@@ -981,9 +985,9 @@ extension Catalog where Self: ~Escapable {
   }
 
   /// The `EXISTS` non-empty result of the occurrence `key`, run LAZILY: an
-  /// UNCORRELATED one (empty `correlation`) reads the memo and, on a miss, probes
-  /// once and stores it; a CORRELATED one re-probes per outer row against the
-  /// correlated bindings, never touching the memo.
+  /// UNCORRELATED one (empty `correlation`) reads the memo and, on a miss,
+  /// probes once and stores it; a CORRELATED one re-probes per outer row
+  /// against the correlated bindings, never touching the memo.
   private borrowing func present(_ row: borrowing some Row & ~Escapable,
                                  _ key: Subkey, _ correlation: Correlation,
                                  _ context: Context)
@@ -1007,18 +1011,19 @@ extension Catalog where Self: ~Escapable {
     return present
   }
 
-  /// The `IN (Q)` single column of the occurrence `key`, materialised LAZILY: an
-  /// UNCORRELATED one reads the memo and, on a miss, runs the inner query once
-  /// and stores its lone column; a CORRELATED one re-runs per outer row against
-  /// the correlated bindings, bypassing the memo.
+  /// The `IN (Q)` single column of the occurrence `key`, materialised LAZILY:
+  /// an UNCORRELATED one reads the memo and, on a miss, runs the inner query
+  /// once and stores its lone column; a CORRELATED one re-runs per outer row
+  /// against the correlated bindings, bypassing the memo.
   private borrowing func values(_ row: borrowing some Row & ~Escapable,
                                 _ key: Subkey, _ correlation: Correlation,
                                 _ context: Context)
       throws(SQLError) -> Array<Value> {
     let context = revealed(under: key, context)
-    // A CORRELATED `IN (Q)` re-executes its PRE-COMPILED inner plan against this
-    // row's correlated bindings for its lone column, bypassing the memo. An
-    // UNCORRELATED one memoises and re-runs its `Query` (recompiling resolves).
+    // A CORRELATED `IN (Q)` re-executes its PRE-COMPILED inner plan against
+    // this row's correlated bindings for its lone column, bypassing the memo.
+    // An UNCORRELATED one memoises and re-runs its `Query` (recompiling
+    // resolves).
     guard correlation.isEmpty else {
       return try executed(row, key, correlation, context).map { $0.values[0] }
     }
@@ -1195,8 +1200,8 @@ extension Arithmetic {
   private func apply(_ lhs: Int, _ rhs: Int) throws(SQLError) -> Value {
     // Report overflow rather than trap: operands are parsed literals or column
     // values that can reach the `Int` boundary (`Int.max + 1`, `Int.min / -1`),
-    // and Swift's `+`/`-`/`*`/`/` would trap — aborting the process — instead of
-    // surfacing a `SQLError`.
+    // and Swift's `+`/`-`/`*`/`/` would trap — aborting the process — instead
+    // of surfacing a `SQLError`.
     let outcome: (partialValue: Int, overflow: Bool) = switch self {
     case .add: lhs.addingReportingOverflow(rhs)
     case .subtract: lhs.subtractingReportingOverflow(rhs)
@@ -1412,14 +1417,15 @@ extension Catalog where Self: ~Escapable {
       // `negated` flipping it. The subquery runs LAZILY on this first reach (so
       // an `EXISTS` a short-circuited `AND`/`OR` or an unreached `CASE` arm
       // guards never runs): an UNCORRELATED one memoises under its `Subkey`; a
-      // CORRELATED one re-runs against this row's correlated bindings, bypassing
-      // the memo.
+      // CORRELATED one re-runs against this row's correlated bindings,
+      // bypassing the memo.
       try present(row, key, correlation, context) != negated
     case let .within(operand, key, correlation, negated):
       // Fold `operand = v` over the subquery's single column under the SAME
       // three-valued membership the value-list `IN` uses. The column is
-      // materialised LAZILY on this first reach (an UNCORRELATED one memoised, a
-      // CORRELATED one re-run per row against this row's correlated bindings).
+      // materialised LAZILY on this first reach (an UNCORRELATED one memoised,
+      // a CORRELATED one re-run per row against this row's correlated
+      // bindings).
       try member(row, operand, values(row, key, correlation, context),
                  negated, context)
     case let .quantified(operand, op, quantifier, key, correlation):

--- a/Sources/SQLEngine/Lexer.swift
+++ b/Sources/SQLEngine/Lexer.swift
@@ -225,9 +225,9 @@ internal struct Lexer: ~Escapable {
   /// `FieldLayout` declare), or a spelling outside the identifier bytes. Its
   /// text is taken verbatim and case-sensitively — never matched against the
   /// keywords — so it is a `quoted` token, distinct from a bare `identifier` so
-  /// the parser keeps a dot in it as part of the name rather than a qualifier; a
-  /// doubled quote `""` is an escaped quote, mirroring a string literal's `''`.
-  /// Faults if unclosed.
+  /// the parser keeps a dot in it as part of the name rather than a qualifier;
+  /// a doubled quote `""` is an escaped quote, mirroring a string literal's
+  /// `''`. Faults if unclosed.
   private mutating func delimited() throws(SQLError) -> Token {
     let start = location
     advance()

--- a/Sources/SQLEngine/Operator.swift
+++ b/Sources/SQLEngine/Operator.swift
@@ -11,14 +11,15 @@
 /// slot-indexed row the adapter's borrowed cells are copied into at a leaf.
 ///
 /// The plan is *escapable and name-holding*: a `Plan` references each relation
-/// by its catalog NAME rather than by a `~Escapable` `Table` (an `indirect enum`
-/// cannot box a `~Escapable` payload), and carries the ordinals the query
-/// actually reads from it. The executor re-resolves a name to a transient table,
-/// opens its cursor, and materialises *only the referenced ordinals* into a
-/// dense slot array — reals out of the cursor, virtuals (ordinals `>= width`)
-/// computed by the `Row`. Slot `i` of the record holds the cell of the scan's
-/// `i`th referenced ordinal; the operators address slots, never ordinals, so a
-/// record is a dense `Array<Value>` with no gaps and no per-row hashing.
+/// by its catalog NAME rather than by a `~Escapable` `Table` (an `indirect
+/// enum` cannot box a `~Escapable` payload), and carries the ordinals the query
+/// actually reads from it. The executor re-resolves a name to a transient
+/// table, opens its cursor, and materialises *only the referenced ordinals*
+/// into a dense slot array — reals out of the cursor, virtuals (ordinals `>=
+/// width`) computed by the `Row`. Slot `i` of the record holds the cell of the
+/// scan's `i`th referenced ordinal; the operators address slots, never
+/// ordinals, so a record is a dense `Array<Value>` with no gaps and no per-row
+/// hashing.
 
 // MARK: - Record
 
@@ -90,17 +91,17 @@ internal struct Record: Row, Hashable {
 /// An escapable, name-holding relational operator tree.
 ///
 /// Every relation a `SELECT` names is held by its catalog NAME, not by a
-/// `~Escapable` `Table`, so the whole tree is a plain escapable `indirect enum`.
-/// The leaf `scan` carries the relation name, the ordinals the query reads from
-/// it (reals and virtuals, in materialisation order — the order that defines the
-/// scan's slots), and an optional seek — the row range to read. The unary
-/// operators wrap a sub-plan: `select` keeps the records a `Filter` admits,
-/// `project` restricts and reorders to the projected slots, and `sort` orders by
-/// a typed key on a slot. `product` is the Cartesian product of two sub-plans
-/// (records merged); `join` is the index-nested-loop equi-join that seeks the
-/// inner relation per outer record rather than forming the product, the inner
-/// named and its referenced ordinals carried for the executor to re-resolve and
-/// materialise.
+/// `~Escapable` `Table`, so the whole tree is a plain escapable `indirect
+/// enum`. The leaf `scan` carries the relation name, the ordinals the query
+/// reads from it (reals and virtuals, in materialisation order — the order that
+/// defines the scan's slots), and an optional seek — the row range to read. The
+/// unary operators wrap a sub-plan: `select` keeps the records a `Filter`
+/// admits, `project` restricts and reorders to the projected slots, and `sort`
+/// orders by a typed key on a slot. `product` is the Cartesian product of two
+/// sub-plans (records merged); `join` is the index-nested-loop equi-join that
+/// seeks the inner relation per outer record rather than forming the product,
+/// the inner named and its referenced ordinals carried for the executor to
+/// re-resolve and materialise.
 internal indirect enum Plan {
   /// The single-row leaf of a FROM-less `SELECT`: it yields exactly one empty
   /// record (no slots), the row a scalar projection (`SELECT 1 + 1`) computes
@@ -132,14 +133,14 @@ internal indirect enum Plan {
   case sort(keys: Array<(term: Term, ascending: Bool)>, Plan)
   /// × — every concatenation of an outer record with an inner one.
   case product(Plan, Plan)
-  /// ⋈ — for each outer record, seeks the inner relation `name` on
-  /// `keys.right == outer[keys.left]` and concatenates each match. `keys.left`
-  /// and `keys.right` are combined-space slots, `base` the inner's first slot
-  /// in that combined space, and `column` the inner ordinal `keys.right` reads
-  /// (for the seek `bound`). `filter` is a single-relation predicate pushed onto
-  /// the inner — in the inner's OWN 0-based standalone slot space — applied WHILE
-  /// each inner row is materialised, so an inner row that fails it is never
-  /// paired.
+  /// ⋈ — for each outer record, seeks the inner relation `name` on `keys.right
+  /// == outer[keys.left]` and concatenates each match. `keys.left` and
+  /// `keys.right` are combined-space slots, `base` the inner's first slot in
+  /// that combined space, and `column` the inner ordinal `keys.right` reads
+  /// (for the seek `bound`). `filter` is a single-relation predicate pushed
+  /// onto the inner — in the inner's OWN 0-based standalone slot space —
+  /// applied WHILE each inner row is materialised, so an inner row that fails
+  /// it is never paired.
   case join(Plan, name: String, ordinals: Array<Int>, base: Int,
             column: Int, keys: (left: Int, right: Int), filter: Filter?)
   /// ⟕/⟖/⟗ — the OUTER join of `left` and `right` on the `on` predicate, in
@@ -160,10 +161,10 @@ internal indirect enum Plan {
   /// into the combined space laid AFTER the left's slots, concatenates it onto
   /// the left, and keeps the pair the `on` predicate admits. INNER/CROSS APPLY
   /// (`kind` `.inner`, the only kind emitted): a left record with no surviving
-  /// right record is DROPPED. Unlike a `product`/`outer` the right side is not a
-  /// static sub-plan — it re-runs per left row against the correlated bindings —
-  /// so the optimiser treats it as an opaque pushdown BARRIER and never rebases
-  /// a conjunct across it.
+  /// right record is DROPPED. Unlike a `product`/`outer` the right side is not
+  /// a static sub-plan — it re-runs per left row against the correlated
+  /// bindings — so the optimiser treats it as an opaque pushdown BARRIER and
+  /// never rebases a conjunct across it.
   case apply(Plan, key: Subkey, correlation: Correlation,
              ordinals: Array<Int>, on: Filter, kind: Join.Kind)
   /// A set operation of `kind` (`UNION`/`INTERSECT`/`EXCEPT`) over the `left`
@@ -186,15 +187,16 @@ internal indirect enum Plan {
   /// (equivalently `SELECT ALL`) omits it.
   case distinct(Plan)
   /// Γ — groups its `source`'s records by the `keys` terms and folds each
-  /// `aggregates` accumulator over every record of a group, yielding one grouped
-  /// record per group. The grouped record's slots are the `keys` values (slots
-  /// `0 ..< keys.count`, in key order) followed by the aggregate results (slot
-  /// `keys.count + j` is `aggregates[j]`), the slot space the projection, the
-  /// `HAVING`, and the `ORDER BY` are lowered against. With no `keys` the whole
-  /// source is one group — the degenerate `SELECT COUNT(*) FROM T` — yielding a
-  /// single grouped record even over an empty source (`COUNT` `0`, the others
-  /// NULL). It sits above the WHERE/join chain and below the projection, so it
-  /// aggregates the filtered rows and the projection reads its output.
+  /// `aggregates` accumulator over every record of a group, yielding one
+  /// grouped record per group. The grouped record's slots are the `keys` values
+  /// (slots `0 ..< keys.count`, in key order) followed by the aggregate results
+  /// (slot `keys.count + j` is `aggregates[j]`), the slot space the projection,
+  /// the `HAVING`, and the `ORDER BY` are lowered against. With no `keys` the
+  /// whole source is one group — the degenerate `SELECT COUNT(*) FROM T` —
+  /// yielding a single grouped record even over an empty source (`COUNT` `0`,
+  /// the others NULL). It sits above the WHERE/join chain and below the
+  /// projection, so it aggregates the filtered rows and the projection reads
+  /// its output.
   case aggregate(keys: Array<Term>, aggregates: Array<Aggregation>, Plan)
   /// A row cap on its `source`'s output: skips the first `offset` records then
   /// takes at most `count` of the rest, in the source's order. It sits over the
@@ -244,8 +246,8 @@ extension Plan {
   ///
   /// A scan or a derived view's width is its referenced-ordinal count; a
   /// `select` is as wide as its source; a `product` is the sum of its sides and
-  /// a `join` the sum of its outer side and the inner's referenced ordinals — so
-  /// a left-deep chain of products or joins measures correctly, letting the
+  /// a `join` the sum of its outer side and the inner's referenced ordinals —
+  /// so a left-deep chain of products or joins measures correctly, letting the
   /// nest rewrite recurse into a multi-relation chain.
   internal var slots: Int? {
     switch self {
@@ -292,8 +294,8 @@ extension Plan {
       // as its source.
       source.slots
     case let .aggregate(keys, aggregates, _):
-      // A grouped record reshapes its source into the key values followed by the
-      // aggregate results — a fresh slot space of that width.
+      // A grouped record reshapes its source into the key values followed by
+      // the aggregate results — a fresh slot space of that width.
       keys.count + aggregates.count
     default:
       nil
@@ -316,18 +318,16 @@ extension Plan {
 /// Each operator transforms the records its sub-plan yields: `scan` re-resolves
 /// the relation by name, opens its cursor, and materialises its referenced
 /// ordinals over the seek range into dense slots; `select` keeps the admitted
-/// records; `project` rebuilds each from the projected slots; `sort` orders them
-/// by its typed keys major to minor, stably and each in its own direction;
-/// `product` pairs every
-/// outer record with every inner one; `join` re-resolves the inner relation,
-/// seeks it per outer record, and concatenates the matches; `setop` runs its
-/// two sides — each with its own set-operation semantics — and combines their
-/// rows by its `kind` (`UNION`/`INTERSECT`/`EXCEPT`), deduplicating unless
-/// `all`; `distinct` deduplicates its source's whole rows (`SELECT DISTINCT`);
-/// `limit` skips the first `offset` of its source's rows then takes at most
-/// `count`.
-/// The catalog is borrowed throughout — a `~Escapable` source is never copied
-/// or stored.
+/// records; `project` rebuilds each from the projected slots; `sort` orders
+/// them by its typed keys major to minor, stably and each in its own direction;
+/// `product` pairs every outer record with every inner one; `join` re-resolves
+/// the inner relation, seeks it per outer record, and concatenates the matches;
+/// `setop` runs its two sides — each with its own set-operation semantics — and
+/// combines their rows by its `kind` (`UNION`/`INTERSECT`/`EXCEPT`),
+/// deduplicating unless `all`; `distinct` deduplicates its source's whole rows
+/// (`SELECT DISTINCT`); `limit` skips the first `offset` of its source's rows
+/// then takes at most `count`. The catalog is borrowed throughout — a
+/// `~Escapable` source is never copied or stored.
 extension Catalog where Self: ~Escapable {
   internal borrowing func execute(_ plan: Plan, _ context: Context)
       throws(SQLError) -> Array<Record> {
@@ -566,9 +566,9 @@ extension Catalog where Self: ~Escapable {
 ///
 /// A `nil` `count` is no cap — every row after the skip (an `OFFSET` without a
 /// `FETCH`). An `offset` at or past the end yields no rows; a `count` reaching
-/// past the remaining rows takes all of them. Both are non-negative, so the skip
-/// and the take never index before the start. The take is a `prefix` of the
-/// skipped slice rather than an `offset + count` bound, so a `count` near
+/// past the remaining rows takes all of them. Both are non-negative, so the
+/// skip and the take never index before the start. The take is a `prefix` of
+/// the skipped slice rather than an `offset + count` bound, so a `count` near
 /// `Int.max` caps the slice instead of overflowing.
 private func limited(_ records: Array<Record>, _ count: Int?, _ offset: Int)
     -> Array<Record> {
@@ -750,22 +750,23 @@ extension Catalog where Self: ~Escapable {
 }
 
 extension Catalog where Self: ~Escapable {
-  /// Executes a view's sub-`plan` against this catalog and re-lays each resulting
-  /// record to the referenced `ordinals` (slots into the view's columns) over the
-  /// seek's row range (the whole result when `nil`).
+  /// Executes a view's sub-`plan` against this catalog and re-lays each
+  /// resulting record to the referenced `ordinals` (slots into the view's
+  /// columns) over the seek's row range (the whole result when `nil`).
   ///
-  /// The sub-plan yields full-width view records — its columns at slots
-  /// `0 ..< columns.count`; this projects each to the `ordinals` the outer query
-  /// reads, in the slot order the outer scan expects (slot `i` is `ordinals[i]`).
+  /// The sub-plan yields full-width view records — its columns at slots `0 ..<
+  /// columns.count`; this projects each to the `ordinals` the outer query
+  /// reads, in the slot order the outer scan expects (slot `i` is
+  /// `ordinals[i]`).
   ///
   /// The sub-plan runs OUTSIDE the statement's CTE scope — never the caller's
   /// `WITH` — so a caller's `WITH` never reaches into a stored view's body: a
-  /// view's own `FROM`/`JOIN` names resolve to base relations (and other views),
-  /// never to a statement-local CTE that happens to share a name. Its scope is
-  /// instead the `definition_schema.` overlay the view's OWN query names (empty
-  /// when it names none), so a view defined over a store relation materialises
-  /// exactly as the inline query does — the same overlay the body compiled and
-  /// optimised under.
+  /// view's own `FROM`/`JOIN` names resolve to base relations (and other
+  /// views), never to a statement-local CTE that happens to share a name. Its
+  /// scope is instead the `definition_schema.` overlay the view's OWN query
+  /// names (empty when it names none), so a view defined over a store relation
+  /// materialises exactly as the inline query does — the same overlay the body
+  /// compiled and optimised under.
   internal borrowing func derive(_ name: String, _ plan: Plan,
                                  _ ordinals: Array<Int>, _ seek: Range<Int>?,
                                  _ context: Context)
@@ -775,13 +776,13 @@ extension Catalog where Self: ~Escapable {
       // EXECUTION-path materialise (`rows: true`): a nested derived body's
       // schema is derived schema-only inside `materialise`, so `validate:
       // false` keeps that lenient — a data-dependent-empty derived body in a
-      // view body must not fault at run, matching the top-level run path.
-      // Seed the cyclic-view guard with THIS view's own name, as
-      // `resolve(view:)` does, so a body materialising this view through a
-      // derived table (`FROM (SELECT * FROM <self>) AS d`) faults `.recursion`
-      // in `materialise` rather than re-running the body without end. `body([:])`
-      // enters the view-body scope with the caller's correlation stack CLEARED,
-      // so a nested derived body's schema (derived while `augment`/`materialise`
+      // view body must not fault at run, matching the top-level run path. Seed
+      // the cyclic-view guard with THIS view's own name, as `resolve(view:)`
+      // does, so a body materialising this view through a derived table (`FROM
+      // (SELECT * FROM <self>) AS d`) faults `.recursion` in `materialise`
+      // rather than re-running the body without end. `body([:])` enters the
+      // view-body scope with the caller's correlation stack CLEARED, so a
+      // nested derived body's schema (derived while `augment`/`materialise`
       // resolves it) cannot bind an unbound column outward to an enclosing row.
       let fresh = context.body([:]).visiting(name).validating(false)
       overlay = try augment(fresh, for: view.query, rows: true)
@@ -888,23 +889,24 @@ private func product(_ outer: Array<Record>, _ inner: Array<Record>)
 }
 
 /// The equi-join of `outer` against the inner relation `name`, resolved through
-/// `ctes` first then `catalog`, seeking or hashing the inner as its shape allows.
+/// `ctes` first then `catalog`, seeking or hashing the inner as its shape
+/// allows.
 ///
-/// A materialised CTE inner has no sort key, so it is scanned in full and joined
-/// by the equality on its `keys.right` slot (`joined`). A base relation that
-/// reports `column` (the inner ordinal `keys.right` reads) seekable is sought per
-/// outer record — an index-nested loop, cheap because the seek narrows the scan;
-/// one that is NOT seekable is scanned ONCE into a hash map keyed by its join
-/// value and each outer record probes it in O(1) (`hashed`), rather than reading
-/// the whole inner once per outer record. Every strategy materialises a candidate
-/// over the referenced `ordinals` into inner slots `0 ..< ordinals.count`, admits
-/// it only when the pushed inner `filter` (in the inner's standalone slot space)
-/// also holds — applied WHILE the inner row is materialised, so a filtered inner
-/// row is never paired or bucketed — keys on the inner's `keys.right` slot
-/// (`keys.right - base` in the standalone inner record), and concatenates a match
-/// (the inner's slots landing at `base` in the combined space). A NULL key joins
-/// to nothing, and every path preserves outer-major order, the inner matches in
-/// cursor order within each outer.
+/// A materialised CTE inner has no sort key, so it is scanned in full and
+/// joined by the equality on its `keys.right` slot (`joined`). A base relation
+/// that reports `column` (the inner ordinal `keys.right` reads) seekable is
+/// sought per outer record — an index-nested loop, cheap because the seek
+/// narrows the scan; one that is NOT seekable is scanned ONCE into a hash map
+/// keyed by its join value and each outer record probes it in O(1) (`hashed`),
+/// rather than reading the whole inner once per outer record. Every strategy
+/// materialises a candidate over the referenced `ordinals` into inner slots `0
+/// ..< ordinals.count`, admits it only when the pushed inner `filter` (in the
+/// inner's standalone slot space) also holds — applied WHILE the inner row is
+/// materialised, so a filtered inner row is never paired or bucketed — keys on
+/// the inner's `keys.right` slot (`keys.right - base` in the standalone inner
+/// record), and concatenates a match (the inner's slots landing at `base` in
+/// the combined space). A NULL key joins to nothing, and every path preserves
+/// outer-major order, the inner matches in cursor order within each outer.
 ///
 /// The HASH-JOIN bucket a key falls in — a grouping key, NOT the equality. A
 /// numeric value buckets by its `Double` magnitude (an `.integer` promoted), so
@@ -1029,18 +1031,18 @@ extension Catalog where Self: ~Escapable {
 /// DURING this scan, before a row is bucketed: the inner is SEEKED by the
 /// filter's seekable conjunct — `boundaries` over each conjunct, the same
 /// boundary logic the scan seek uses, mapping a slot back to its table column
-/// through `ordinals` — so a seekable/contradictory inner filter reads few or no
-/// inner rows rather than scanning the whole table; when no conjunct is seekable
-/// the whole inner scans. Each read row is then admitted only when the whole
-/// `filter` holds, so a filtered inner row is never bucketed or paired.
+/// through `ordinals` — so a seekable/contradictory inner filter reads few or
+/// no inner rows rather than scanning the whole table; when no conjunct is
+/// seekable the whole inner scans. Each read row is then admitted only when the
+/// whole `filter` holds, so a filtered inner row is never bucketed or paired.
 ///
 /// An outer with no non-null key has no probe that can match — an empty outer
 /// has no probes at all, and a NULL key joins to nothing — so no match can
 /// result; return before scanning and bucketing the inner rather than reading
 /// every inner row to answer nothing. The nested-loop path this replaces read
 /// zero inner rows for such an outer, and a selective or contradictory outer
-/// WHERE (`… WHERE key IS NULL`, or one pruning every row) must not force a full
-/// scan of a large unseekable inner.
+/// WHERE (`… WHERE key IS NULL`, or one pruning every row) must not force a
+/// full scan of a large unseekable inner.
 extension Table where Self: ~Escapable {
   fileprivate borrowing func hashed<C>(_ outer: Array<Record>,
                                        _ ordinals: Array<Int>, _ base: Int,
@@ -1133,9 +1135,9 @@ extension Table where Self: ~Escapable {
 /// A seekable column reports a boundary for a valid key; an unseekable one
 /// reports `nil`. The probe key must be a VALID one: a decoded coded-index join
 /// key is 1-based and reports `nil` for the null reference `0`, so probing with
-/// `0` would misclassify a seekable coded-index column as unseekable and force a
-/// hash build even for a selective join. `1` — the least valid key — answers for
-/// every seekable column (`Id`, an owner foreign key, a sorted key, a
+/// `0` would misclassify a seekable coded-index column as unseekable and force
+/// a hash build even for a selective join. `1` — the least valid key — answers
+/// for every seekable column (`Id`, an owner foreign key, a sorted key, a
 /// coded-index key); its value is otherwise irrelevant, since this is only a
 /// capability check (the join loop seeks with the real outer key).
 extension Table where Self: ~Escapable {

--- a/Sources/SQLEngine/OutputColumn.swift
+++ b/Sources/SQLEngine/OutputColumn.swift
@@ -129,15 +129,16 @@ extension Catalog where Self: ~Escapable {
   /// reference the CTEs bind — a `SELECT *` over a CTE, or a name a CTE shadows
   /// off a same-named base relation — resolves against the CTE the run did, not
   /// the base catalog: `WITH t(x) AS (SELECT 1) SELECT * FROM t` reports one
-  /// column `x`, even where a base `t` of a different width exists. The scope is
-  /// SCHEMA-ONLY — each CTE contributes its declared column list (typed
+  /// column `x`, even where a base `t` of a different width exists. The scope
+  /// is SCHEMA-ONLY — each CTE contributes its declared column list (typed
   /// `.integer`, the default a materialised relation reports) without running
   /// its body — so the derive never opens a cursor, exactly as `columns(of
   /// query:)` never does. A `create` and a `function` name no result, so each
   /// faults `SQLError.statement` the way running one does.
   ///
   /// `routines` and `validate` carry the meaning `columns(of query:)` gives
-  /// them; pass `validate: false` after a run has proved the statement runnable.
+  /// them; pass `validate: false` after a run has proved the statement
+  /// runnable.
   ///
   /// - Throws: the resolution faults `columns(of query:)` raises, plus
   ///   `SQLError.statement` for a `create` or a `function`.
@@ -175,26 +176,26 @@ extension Catalog where Self: ~Escapable {
   /// `SQLError.redefinition`, the same fault `Engine.with` raises before
   /// materialising, rather than silently shadowing the earlier binding.
   ///
-  /// When `validate`, each CTE BODY is validated before its schema is trusted by
-  /// the SAME code a run drives — `Engine.validate`, the compile-time structural
-  /// check `Engine.with` runs before materialising: the recursive shape (a
-  /// recursive reference must be the final `UNION` arm; a self-reference in the
-  /// anchor with no same-named base faults `SQLError.unsupported`, the recursive
-  /// shape a run rejects BEFORE materialising) and the declared arity (the
-  /// compiled body width against the column list, `SQLError.columns` on a
-  /// mismatch — the anchor and recursive arm checked separately, self bound only
-  /// in the recursive arm). The schema path also asks that helper to run its
-  /// reachable-operand type-check (`typecheck: true` — the run defers this to
-  /// execution, so it stays OFF the run path): folding it in rather than layering
-  /// it here keeps ONE per-arm scoping for both, so a recursive CTE's ANCHOR is
-  /// operand-checked against the base scope the run evaluates it in, NOT the
-  /// CTE-self overlay. So a dry-run schema is advertised only for a `WITH` that
-  /// could actually run, never for one whose body's shape or width contradicts
-  /// its declared list — nor for one whose reachable operand a run would fault.
-  /// When `validate` is `false` — a
-  /// derive after a successful run — the bodies are TRUSTED, not compiled: the
-  /// run already proved them consistent, and re-checking a data-dependent-empty
-  /// body would fault a statement that succeeded.
+  /// When `validate`, each CTE BODY is validated before its schema is trusted
+  /// by the SAME code a run drives — `Engine.validate`, the compile-time
+  /// structural check `Engine.with` runs before materialising: the recursive
+  /// shape (a recursive reference must be the final `UNION` arm; a
+  /// self-reference in the anchor with no same-named base faults
+  /// `SQLError.unsupported`, the recursive shape a run rejects BEFORE
+  /// materialising) and the declared arity (the compiled body width against the
+  /// column list, `SQLError.columns` on a mismatch — the anchor and recursive
+  /// arm checked separately, self bound only in the recursive arm). The schema
+  /// path also asks that helper to run its reachable-operand type-check
+  /// (`typecheck: true` — the run defers this to execution, so it stays OFF the
+  /// run path): folding it in rather than layering it here keeps ONE per-arm
+  /// scoping for both, so a recursive CTE's ANCHOR is operand-checked against
+  /// the base scope the run evaluates it in, NOT the CTE-self overlay. So a
+  /// dry-run schema is advertised only for a `WITH` that could actually run,
+  /// never for one whose body's shape or width contradicts its declared list —
+  /// nor for one whose reachable operand a run would fault. When `validate` is
+  /// `false` — a derive after a successful run — the bodies are TRUSTED, not
+  /// compiled: the run already proved them consistent, and re-checking a
+  /// data-dependent-empty body would fault a statement that succeeded.
   private borrowing func columns(of query: Query, with ctes: Array<CTE>,
                                  routines: Routines,
                                  validate: Bool)
@@ -203,9 +204,9 @@ extension Catalog where Self: ~Escapable {
     var overlay = ScopedRelations()
     for cte in ctes {
       // A name repeated in the list (case-insensitively) would silently shadow
-      // the earlier binding in the overlay, so reject it rather than overwrite —
-      // the same fault `Engine.with` raises before materialising, so a schema is
-      // advertised only for a `WITH` that could actually run.
+      // the earlier binding in the overlay, so reject it rather than overwrite
+      // — the same fault `Engine.with` raises before materialising, so a schema
+      // is advertised only for a `WITH` that could actually run.
       guard overlay[cte.name.lowercased()] == nil else {
         throw .redefinition(cte.name)
       }
@@ -225,11 +226,12 @@ extension Catalog where Self: ~Escapable {
       // recursive reference in the final arm resolves while a self-reference in
       // the anchor faults the recursive shape exactly as the run does. The
       // schema path adds ONE thing the run defers to execution: a
-      // reachable-operand type-check over the body — passed IN as `typecheck` so
-      // it runs in the SAME per-arm scope the shared helper computes, checking a
-      // recursive CTE's anchor against the base scope the run evaluates it in
-      // (NOT the CTE-self overlay). A `validate: false` derive skips both — the
-      // run already proved the bodies consistent — so `typecheck: false` there.
+      // reachable-operand type-check over the body — passed IN as `typecheck`
+      // so it runs in the SAME per-arm scope the shared helper computes,
+      // checking a recursive CTE's anchor against the base scope the run
+      // evaluates it in (NOT the CTE-self overlay). A `validate: false` derive
+      // skips both — the run already proved the bodies consistent — so
+      // `typecheck: false` there.
       if validate {
         // `self.` escapes the shadow the `validate` Bool parameter casts over
         // the shared `validate(_:against:)` engine helper.
@@ -237,9 +239,9 @@ extension Catalog where Self: ~Escapable {
                           typecheck: true)
       }
       // Bind the CTE's schema-only self into the overlay AFTER its body is
-      // validated — the scope a later CTE and the trailing query resolve against
-      // — exactly as `Engine.with` binds the materialised relation after running
-      // its body.
+      // validated — the scope a later CTE and the trailing query resolve
+      // against — exactly as `Engine.with` binds the materialised relation
+      // after running its body.
       overlay[cte.name.lowercased()] = declared
     }
     // Compile/type-check/derive from the base `context.scoping(overlay)`
@@ -285,21 +287,22 @@ extension Catalog where Self: ~Escapable {
     // A scalar subquery in the projection derives its type from its inner
     // query's single column, so build the SAME cursor-free `Resolution` map the
     // compile path's lowering reads — every nested subquery compiled ONCE for
-    // its width and single-column type, each discovering its correlation against
-    // this select's own scope (`enclosing`) — and pass it to the projection walk
-    // so an output type for a `(SELECT …)` matches the type the run advertises.
-    // The projection walk is BARRED (a correlated column of THIS query in the
-    // projection is diagnosed, as the run's projection lowering bars it).
-    // Resolve over the AUGMENTED context so a subquery naming this select's own
-    // arm-local derived alias binds it, while `subquery(of:)` REVEALS the base
-    // so the subquery's OWN FROM sees no derived alias (a CTE a same-named
-    // derived alias shadows resolved beneath the dropped layer).
+    // its width and single-column type, each discovering its correlation
+    // against this select's own scope (`enclosing`) — and pass it to the
+    // projection walk so an output type for a `(SELECT …)` matches the type the
+    // run advertises. The projection walk is BARRED (a correlated column of
+    // THIS query in the projection is diagnosed, as the run's projection
+    // lowering bars it). Resolve over the AUGMENTED context so a subquery
+    // naming this select's own arm-local derived alias binds it, while
+    // `subquery(of:)` REVEALS the base so the subquery's OWN FROM sees no
+    // derived alias (a CTE a same-named derived alias shadows resolved beneath
+    // the dropped layer).
     let scope = try scope(of: select, augmented)
-    // Pass each join's PREFIX scope so an `ON`'s subquery correlates against its
-    // prefix and the WHERE's against the full scope — the SAME per-occurrence
-    // resolution the run path uses, so a name a WHERE subquery finds ambiguous in
-    // the full scope faults HERE too (typecheck↔run parity), not silently reusing
-    // an `ON` occurrence's narrower prefix.
+    // Pass each join's PREFIX scope so an `ON`'s subquery correlates against
+    // its prefix and the WHERE's against the full scope — the SAME
+    // per-occurrence resolution the run path uses, so a name a WHERE subquery
+    // finds ambiguous in the full scope faults HERE too (typecheck↔run parity),
+    // not silently reusing an `ON` occurrence's narrower prefix.
     let prefixes = try prefixes(of: select, augmented)
     // These derivations lower under `.caller` — a schema-only type derive keys
     // its subqueries in the caller id space regardless of an enclosing view
@@ -344,8 +347,9 @@ extension Catalog where Self: ~Escapable {
   /// The PREFIX scope of each join of `select` — join `index`'s prefix is the
   /// FROM relation and joins `0…index`, the relations available AT that join
   /// point, never one joined LATER. A join `ON`'s subquery correlates against
-  /// its prefix (so a reference to a later-joined relation faults), matching the
-  /// compile path's `subquery(of:)`. Empty for a FROM-less or join-less select.
+  /// its prefix (so a reference to a later-joined relation faults), matching
+  /// the compile path's `subquery(of:)`. Empty for a FROM-less or join-less
+  /// select.
   private borrowing func prefixes(of select: Select, _ context: Context)
       throws(SQLError) -> Array<Scope> {
     guard let relation = select.from, !select.joins.isEmpty else { return [] }
@@ -484,10 +488,10 @@ extension Catalog where Self: ~Escapable {
     // `.divide` on `1 / 0`) and does not reproduce the scalar's operand fault,
     // and — now that an `IN`/`EXISTS` materialises LAZILY — a twin may itself
     // sit in an unreachable leg, so it cannot stand in for a REACHABLE scalar's
-    // operand check. Deferring on `scalar` alone (not `scalar - valued`) records
-    // the scalar's own `.scalar` reach in `type` even when a `.valued` reach for
-    // the same query is also present — the two per-occurrence reaches must not
-    // dedup the scalar away.
+    // operand check. Deferring on `scalar` alone (not `scalar - valued`)
+    // records the scalar's own `.scalar` reach in `type` even when a `.valued`
+    // reach for the same query is also present — the two per-occurrence reaches
+    // must not dedup the scalar away.
     let deferred = scalar
     var widths = Dictionary<Query, Int>()
     var types = Dictionary<Query, ValueType>()
@@ -514,8 +518,8 @@ extension Catalog where Self: ~Escapable {
       }
     }
     // The WHERE, `HAVING`, projection, and `ORDER BY` are walked by the
-    // reachability phase, so their operand check DEFERS; their width and single-
-    // column type still derive here against the full `enclosing` scope.
+    // reachability phase, so their operand check DEFERS; their width and
+    // single- column type still derive here against the full `enclosing` scope.
     var rest = Array<Query>()
     select.predicate?.collect(subqueries: &rest)
     select.having?.collect(subqueries: &rest)
@@ -553,20 +557,20 @@ extension Catalog where Self: ~Escapable {
       throws(SQLError) {
     // The width and single-column type derive for EVERY subquery — cursor-free
     // and TOTAL for a clean-resolving inner query (deriving the type of `1 / 0`
-    // yields the integer type WITHOUT dividing). A distinct query at ONE site is
-    // derived once; the SAME query at ANOTHER site re-derives against ITS scope,
-    // so a WHERE occurrence's ambiguity still faults there. The compile is
-    // SHAPE ONLY, so LENIENT (`validate: false`): this pre-pass runs for EVERY
-    // nested subquery ahead of the reachability walk, so validating a derived
-    // body it nests — `1 IN (SELECT x FROM (SELECT 1 / 0 …) AS d)` — would
-    // fault a subquery a short-circuited `AND`/`OR` leg drops BEFORE the walk
-    // reaches it. Validation of a REACHED subquery's body (and the derived
+    // yields the integer type WITHOUT dividing). A distinct query at ONE site
+    // is derived once; the SAME query at ANOTHER site re-derives against ITS
+    // scope, so a WHERE occurrence's ambiguity still faults there. The compile
+    // is SHAPE ONLY, so LENIENT (`validate: false`): this pre-pass runs for
+    // EVERY nested subquery ahead of the reachability walk, so validating a
+    // derived body it nests — `1 IN (SELECT x FROM (SELECT 1 / 0 …) AS d)` —
+    // would fault a subquery a short-circuited `AND`/`OR` leg drops BEFORE the
+    // walk reaches it. Validation of a REACHED subquery's body (and the derived
     // tables nested within it, at any depth) is the walk's job — `typecheck(_
     // select:)` re-derives each reached occurrence's body strictly. Structural
     // faults (a bad inner relation/column, a UNION arity) still surface here —
-    // those resolve regardless of `validate`.
-    // Lower under `.caller`, this frame's `nested` outer, and shape-only
-    // lenience (`validate: false`) — the schema pre-pass's cursor-free derive.
+    // those resolve regardless of `validate`. Lower under `.caller`, this
+    // frame's `nested` outer, and shape-only lenience (`validate: false`) — the
+    // schema pre-pass's cursor-free derive.
     let inner =
         context.scoped(as: .caller).with(outer: nested).validating(false)
     let width = try compile(query, inner).width
@@ -693,11 +697,12 @@ extension Catalog where Self: ~Escapable {
     // lowering does.
     let barred = subquery.barred
     // An `ORDER BY` ordinal names a 1-based SELECT-list position; one outside
-    // `1 ... width` names no output column and faults `SQLError.column` (spelled
-    // as the ordinal), exactly as the compile path's ordinal resolution does —
-    // structural and reachability-independent, so a row-dropping limit never
-    // spares it. `orderKeys` resolves an IN-RANGE ordinal to its projection
-    // expression but silently drops an out-of-range one, so this raises it here.
+    // `1 ... width` names no output column and faults `SQLError.column`
+    // (spelled as the ordinal), exactly as the compile path's ordinal
+    // resolution does — structural and reachability-independent, so a
+    // row-dropping limit never spares it. `orderKeys` resolves an IN-RANGE
+    // ordinal to its projection expression but silently drops an out-of-range
+    // one, so this raises it here.
     if let clause = select.order {
       let width = scope.width(of: select.projection)
       for key in clause.keys {
@@ -709,10 +714,10 @@ extension Catalog where Self: ~Escapable {
     }
     // A GROUPED `ORDER BY` sorts in the grouped slot space, so each sort key
     // must name a `GROUP BY` key, an aggregate, or an output — resolve it
-    // through the SAME grouped lowering the run does, faulting `SQLError.grouping`
-    // on a resolvable-but-non-grouped column exactly as the compile path does.
-    // Structural, so it runs regardless of the WHERE/limit reachability the
-    // operand type-check below tracks.
+    // through the SAME grouped lowering the run does, faulting
+    // `SQLError.grouping` on a resolvable-but-non-grouped column exactly as the
+    // compile path does. Structural, so it runs regardless of the WHERE/limit
+    // reachability the operand type-check below tracks.
     if select.aggregates {
       try order(grouped: select, scope, context, prefixes: prefixes)
     }
@@ -732,8 +737,9 @@ extension Catalog where Self: ~Escapable {
             // evaluate it UNCONDITIONALLY — a zero `FETCH` or positive `OFFSET`
             // spares only the projection, never HAVING. It validates its
             // operands (a divide, overflow, or bad routine call faults) AND
-            // yields the group's fate — a group passes only when HAVING is TRUE,
-            // so FALSE or UNKNOWN drops it and the projection is unreachable.
+            // yields the group's fate — a group passes only when HAVING is
+            // TRUE, so FALSE or UNKNOWN drops it and the projection is
+            // unreachable.
             //
             // A HAVING nesting an `EXISTS`/`IN (Q)` subquery is the exception:
             // `empty` cannot materialise the subquery (it carries no catalog),
@@ -835,15 +841,17 @@ extension Catalog where Self: ~Escapable {
   /// Resolves a GROUPED `select`'s `ORDER BY` through the SAME grouped lowering
   /// the compile path applies, so the type-check enforces the GROUP BY rules on
   /// each sort key exactly as a run does — a bare column must be a `GROUP BY`
-  /// key or occur inside an aggregate, else `SQLError.grouping`; an out-of-range
-  /// ordinal `SQLError.column`; a duplicated output name `SQLError.ambiguous`.
+  /// key or occur inside an aggregate, else `SQLError.grouping`; an
+  /// out-of-range ordinal `SQLError.column`; a duplicated output name
+  /// `SQLError.ambiguous`.
   ///
   /// It rebuilds the `Grouping` `group` builds — the `GROUP BY` keys and the
   /// aggregations collected from the projection, `HAVING`, and the `ORDER BY`
   /// sort keys, deduped by resolved `Aggregation` — then lowers the projection
-  /// and the `ORDER BY` through it, reusing `Grouping.terms`/`Grouping.order` so
-  /// the two paths cannot drift. It resolves only, reading no cursor; a run's
-  /// operand type-check over the (structurally valid) keys stays the caller's.
+  /// and the `ORDER BY` through it, reusing `Grouping.terms`/`Grouping.order`
+  /// so the two paths cannot drift. It resolves only, reading no cursor; a
+  /// run's operand type-check over the (structurally valid) keys stays the
+  /// caller's.
   private borrowing func order(grouped select: Select, _ scope: Scope,
                                _ context: Context,
                                prefixes: Array<Scope> = [])
@@ -885,8 +893,9 @@ extension Catalog where Self: ~Escapable {
     }
     // Build the grouping and lower the projection through it to record each
     // output name (an alias, else a group column's own name) — the surface an
-    // `ORDER BY` output name resolves against — then lower the `ORDER BY`, which
-    // faults a non-group column, an out-of-range ordinal, or an ambiguous name.
+    // `ORDER BY` output name resolves against — then lower the `ORDER BY`,
+    // which faults a non-group column, an out-of-range ordinal, or an ambiguous
+    // name.
     var grouping = try Grouping(scope, select.grouping, aggregations,
                                 subquery: subquery)
     let projection = try grouping.terms(select.projection, routines,

--- a/Sources/SQLEngine/Parser.swift
+++ b/Sources/SQLEngine/Parser.swift
@@ -104,8 +104,8 @@ internal struct Parser: ~Escapable {
   /// Parses a complete statement and asserts the input is exhausted.
   ///
   /// A leading `CREATE` selects the `CREATE VIEW`/`CREATE FUNCTION` form; a
-  /// leading `WITH` the common-table-expression form; anything else is a `query`
-  /// — a `SELECT` or a `UNION` of several.
+  /// leading `WITH` the common-table-expression form; anything else is a
+  /// `query` — a `SELECT` or a `UNION` of several.
   internal mutating func parse() throws(SQLError) -> Statement {
     let statement = switch current?.kind {
     case .create: try create()
@@ -142,8 +142,8 @@ internal struct Parser: ~Escapable {
   /// query ')'`, binding it `recursive` per the enclosing `WITH`.
   ///
   /// An explicit `(c, …)` list names the CTE's columns; absent one, the names
-  /// are inferred from the query's first arm, exactly as a view's are — the same
-  /// arity, naming, and case-insensitive uniqueness rules `columns(_:_:)`
+  /// are inferred from the query's first arm, exactly as a view's are — the
+  /// same arity, naming, and case-insensitive uniqueness rules `columns(_:_:)`
   /// applies.
   private mutating func cte(recursive: Bool) throws(SQLError) -> CTE {
     let name = try identifier()
@@ -176,8 +176,8 @@ internal struct Parser: ~Escapable {
   ///
   /// An explicit list must name exactly one column per projected value when the
   /// first arm's arity is statically known — a `.columns`/`.expressions`
-  /// projection, but not a `SELECT *`, whose width is known only at resolution —
-  /// else `SQLError.columns`. Absent a list, the names are inferred from the
+  /// projection, but not a `SELECT *`, whose width is known only at resolution
+  /// — else `SQLError.columns`. Absent a list, the names are inferred from the
   /// projection (`Projection.names()`). The final names — explicit or inferred
   /// — must be case-insensitively unique, matching `Schema.ordinal(of:)`'s
   /// resolution, or the shadowed column would be unreachable
@@ -240,8 +240,8 @@ internal struct Parser: ~Escapable {
   }
 
   /// Parses a `CREATE` statement — `CREATE VIEW …` or `CREATE FUNCTION …` (the
-  /// leading `CREATE` is the next token). The keyword after `CREATE` selects the
-  /// form.
+  /// leading `CREATE` is the next token). The keyword after `CREATE` selects
+  /// the form.
   private mutating func create() throws(SQLError) -> Statement {
     try expect(.create)
     if try match(.function) {
@@ -268,13 +268,13 @@ internal struct Parser: ~Escapable {
                                   columns: columns(explicit, query)))
   }
 
-  /// Parses the `FUNCTION` tail — `identifier '(' [param (, param)*] ')' RETURNS
-  /// type AS expression` (the `CREATE FUNCTION` is already consumed), each
-  /// `param` an `identifier type`.
+  /// Parses the `FUNCTION` tail — `identifier '(' [param (, param)*] ')'
+  /// RETURNS type AS expression` (the `CREATE FUNCTION` is already consumed),
+  /// each `param` an `identifier type`.
   ///
-  /// The parameter list is parenthesised and may be empty (`f() RETURNS …`). The
-  /// body is a single scalar `expression` over the declared parameters, so a
-  /// call binds its arguments to the parameter names and evaluates it. The
+  /// The parameter list is parenthesised and may be empty (`f() RETURNS …`).
+  /// The body is a single scalar `expression` over the declared parameters, so
+  /// a call binds its arguments to the parameter names and evaluates it. The
   /// parameter names must be case-insensitively unique — the body resolves a
   /// reference against them, and a duplicate would make the shadowed one
   /// unreachable — else `SQLError.duplicate`.
@@ -337,8 +337,8 @@ internal struct Parser: ~Escapable {
   }
 
   /// The number of values `projection` projects, or `nil` when it is not
-  /// statically known — a `SELECT *`, whose width depends on the relations it is
-  /// resolved against. A `.columns` or `.expressions` projection has a fixed
+  /// statically known — a `SELECT *`, whose width depends on the relations it
+  /// is resolved against. A `.columns` or `.expressions` projection has a fixed
   /// item count.
   private func arity(_ projection: Projection) -> Int? {
     switch projection {
@@ -353,9 +353,10 @@ internal struct Parser: ~Escapable {
 
   /// Parses a `SELECT` query.
   ///
-  /// `FROM` is optional: a FROM-less `SELECT <expr-list>` projects over a single
-  /// empty row (the standard way to compute a scalar, `SELECT 1 + 1`), and so
-  /// admits no relation, joins, `WHERE`, `ORDER BY`, or `LIMIT` to follow.
+  /// `FROM` is optional: a FROM-less `SELECT <expr-list>` projects over a
+  /// single empty row (the standard way to compute a scalar, `SELECT 1 + 1`),
+  /// and so admits no relation, joins, `WHERE`, `ORDER BY`, or `LIMIT` to
+  /// follow.
   private mutating func select() throws(SQLError) -> Select {
     try expect(.select)
     // An optional set quantifier: `DISTINCT` deduplicates the result rows;
@@ -423,7 +424,8 @@ internal struct Parser: ~Escapable {
   /// An optional leading `LATERAL` marks the derived table lateral (ISO
   /// `LATERAL (query)`): its body may reference the PRECEDING FROM items, so it
   /// re-evaluates per their rows. `LATERAL` introduces a derived table alone —
-  /// a `(SELECT …)` must follow — so a `LATERAL` before a named relation faults.
+  /// a `(SELECT …)` must follow — so a `LATERAL` before a named relation
+  /// faults.
   ///
   /// Derived table's alias is REQUIRED (ISO): `FROM (SELECT …)` with no `AS t`
   /// faults. A named relation's alias is optional and may be introduced by `AS`
@@ -477,8 +479,8 @@ internal struct Parser: ~Escapable {
   }
 
   /// Whether `kind` begins an identifier — a bare or a delimited name — the
-  /// token an optional (`AS`-less) relation alias may start with, so a following
-  /// keyword or the end of input is not mistaken for an alias.
+  /// token an optional (`AS`-less) relation alias may start with, so a
+  /// following keyword or the end of input is not mistaken for an alias.
   private func isName(_ kind: Token.Kind?) -> Bool {
     switch kind {
     case .identifier, .quoted: true
@@ -619,10 +621,10 @@ internal struct Parser: ~Escapable {
   /// integer, or decimal literal, a function call (`name(args)`), or a bare
   /// (possibly-qualified) column.
   ///
-  /// Parentheses override the precedence the cascade encodes. A function call is
-  /// an identifier immediately followed by `(`; an identifier not so followed is
-  /// a column. The arguments are a comma-separated list of expressions, possibly
-  /// empty.
+  /// Parentheses override the precedence the cascade encodes. A function call
+  /// is an identifier immediately followed by `(`; an identifier not so
+  /// followed is a column. The arguments are a comma-separated list of
+  /// expressions, possibly empty.
   private mutating func factor() throws(SQLError) -> Expression {
     if try match(.lparen) {
       // ONE token of lookahead after `(` disambiguates a SCALAR SUBQUERY from a
@@ -666,8 +668,9 @@ internal struct Parser: ~Escapable {
 
     let ident = try name()
     guard try match(.lparen) else {
-      // A delimited name is a verbatim column (a dot in it is part of the name);
-      // a bare one may be a qualified reference that `Column(_:)` splits.
+      // A delimited name is a verbatim column (a dot in it is part of the
+      // name); a bare one may be a qualified reference that `Column(_:)`
+      // splits.
       return .column(ident.quoted ? Column(name: ident.text)
                                   : Column(ident.text))
     }
@@ -794,15 +797,15 @@ internal struct Parser: ~Escapable {
     return predicate
   }
 
-  /// Parses a `CASE` expression (the `CASE` is the next token) into the searched
-  /// `Expression.case`, admitting both ISO forms.
+  /// Parses a `CASE` expression (the `CASE` is the next token) into the
+  /// searched `Expression.case`, admitting both ISO forms.
   ///
   /// A `WHEN` directly after `CASE` is the SEARCHED form — each `WHEN` a full
   /// predicate. An expression after `CASE` is the SIMPLE form's operand — each
-  /// `WHEN value` is normalised to the equality `operand = value`, so both forms
-  /// share one searched AST. At least one `WHEN` is required; an optional `ELSE`
-  /// gives the no-branch result (absent, the result is `NULL`); the whole is
-  /// closed by `END`.
+  /// `WHEN value` is normalised to the equality `operand = value`, so both
+  /// forms share one searched AST. At least one `WHEN` is required; an optional
+  /// `ELSE` gives the no-branch result (absent, the result is `NULL`); the
+  /// whole is closed by `END`.
   private mutating func conditional() throws(SQLError) -> Expression {
     try expect(.case)
     let operand: Expression? = current?.kind == .when ? nil
@@ -991,11 +994,11 @@ internal struct Parser: ~Escapable {
 
   /// Parses a parenthesised predicate or a comparison.
   ///
-  /// A leading `(` is ambiguous: it opens either a parenthesised predicate
-  /// (`(a = 1 AND b = 2)`) or the parenthesised left operand of a comparison
-  /// (`(Age + 1) = 26`, where `factor` consumes the `(expression)`). The
-  /// comparison is tried first; if it fails, the group was a predicate, so the
-  /// parser rewinds to the saved lexer and lookahead token and parses it as one.
+  /// A leading `(` is ambiguous: it opens either a parenthesised predicate (`(a
+  /// = 1 AND b = 2)`) or the parenthesised left operand of a comparison (`(Age
+  /// + 1) = 26`, where `factor` consumes the `(expression)`). The comparison is
+  /// tried first; if it fails, the group was a predicate, so the parser rewinds
+  /// to the saved lexer and lookahead token and parses it as one.
   private mutating func primary() throws(SQLError) -> Predicate {
     guard current?.kind == .lparen else {
       return try comparison()
@@ -1317,11 +1320,11 @@ internal struct Parser: ~Escapable {
   ///
   /// The two ISO clauses are independent: an `OFFSET` without a `FETCH` skips
   /// rows with no cap (`count` `nil`), a `FETCH` without an `OFFSET` caps from
-  /// the start. `ROW` and `ROWS` are interchangeable, as are `FIRST` and `NEXT`,
-  /// and the `FETCH` count defaults to `1` when omitted (`FETCH FIRST ROW
-  /// ONLY`). Both counts are non-negative integer literals; a bare or negative
-  /// spelling is not one (the lexer scans a `-` as its own token), so it faults
-  /// as any other misplaced token would.
+  /// the start. `ROW` and `ROWS` are interchangeable, as are `FIRST` and
+  /// `NEXT`, and the `FETCH` count defaults to `1` when omitted (`FETCH FIRST
+  /// ROW ONLY`). Both counts are non-negative integer literals; a bare or
+  /// negative spelling is not one (the lexer scans a `-` as its own token), so
+  /// it faults as any other misplaced token would.
   private mutating func rowLimit() throws(SQLError) -> Limit? {
     let offset: Int
     if try match(.offset) {
@@ -1358,11 +1361,12 @@ internal struct Parser: ~Escapable {
     return value
   }
 
-  /// Consumes an identifier — bare or delimited — as its text and whether it was
-  /// delimited (double-quoted). A delimited name is verbatim, so a caller
+  /// Consumes an identifier — bare or delimited — as its text and whether it
+  /// was delimited (double-quoted). A delimited name is verbatim, so a caller
   /// building a column keeps a dot in it as part of the name rather than a
   /// qualifier.
-  private mutating func name() throws(SQLError) -> (text: String, quoted: Bool) {
+  private mutating func name()
+      throws(SQLError) -> (text: String, quoted: Bool) {
     let token = try advance(expecting: "an identifier")
     switch token.kind {
     case let .identifier(text):
@@ -1376,8 +1380,8 @@ internal struct Parser: ~Escapable {
   }
 
   /// Consumes an identifier — bare or delimited — and returns its name. Callers
-  /// that name a relation, alias, or CTE take the text alone; the delimited flag
-  /// matters only where a dot could be a qualifier (`column`).
+  /// that name a relation, alias, or CTE take the text alone; the delimited
+  /// flag matters only where a dot could be a qualifier (`column`).
   private mutating func identifier() throws(SQLError) -> String {
     try name().text
   }
@@ -1385,9 +1389,9 @@ internal struct Parser: ~Escapable {
   /// Consumes an identifier and parses it as a column reference.
   ///
   /// A bare identifier's qualifying dot is part of the one token the lexer
-  /// scans, so `Column(_:)` splits it (`t.Name` → qualifier `t`, name `Name`). A
-  /// delimited identifier is verbatim, so a dot in it belongs to an unqualified
-  /// name (`"a.b"` is the column `a.b`, not `a`.`b`).
+  /// scans, so `Column(_:)` splits it (`t.Name` → qualifier `t`, name `Name`).
+  /// A delimited identifier is verbatim, so a dot in it belongs to an
+  /// unqualified name (`"a.b"` is the column `a.b`, not `a`.`b`).
   private mutating func column() throws(SQLError) -> Column {
     let ident = try name()
     return ident.quoted ? Column(name: ident.text) : Column(ident.text)

--- a/Sources/SQLEngine/Resolve.swift
+++ b/Sources/SQLEngine/Resolve.swift
@@ -120,14 +120,14 @@ internal struct Subkey: Hashable, Sendable {
 /// the SAME `Subkey` (same `.caller` scope, same AST, same role), so keying the
 /// plan memo by `Subkey` alone lets the right arm READ the LEFT arm's plan —
 /// which binds `:__correlated_0_0` while the right arm's outer row binds
-/// `:__correlated_0_1`, yielding NULL/wrong results. The correlation's PARAMETER
-/// NAMES (`:__correlated_<depth>_<ordinal>`) encode each occurrence's own outer
-/// layout and are STABLE across the ordinal remap `optimise` applies (it rewrites
-/// the `Source` values, never the keys), so they match at the RECORD site (the
-/// pre-pass compile) and the LOOKUP site (the lowered node) while DIFFERING
-/// between the two arms. Adding them to the key gives each arm its OWN plan yet
-/// preserves legitimate SHARING: an identical occurrence under an identical
-/// outer layout binds the same names and reuses the one plan.
+/// `:__correlated_0_1`, yielding NULL/wrong results. The correlation's
+/// PARAMETER NAMES (`:__correlated_<depth>_<ordinal>`) encode each occurrence's
+/// own outer layout and are STABLE across the ordinal remap `optimise` applies
+/// (it rewrites the `Source` values, never the keys), so they match at the
+/// RECORD site (the pre-pass compile) and the LOOKUP site (the lowered node)
+/// while DIFFERING between the two arms. Adding them to the key gives each arm
+/// its OWN plan yet preserves legitimate SHARING: an identical occurrence under
+/// an identical outer layout binds the same names and reuses the one plan.
 internal struct PlanKey: Hashable, Sendable {
   /// The occurrence's `Subkey` — scope, query, and role.
   private let key: Subkey
@@ -166,16 +166,16 @@ internal enum Source: Hashable, Sendable {
 /// its inner query names, each mapped to the `Source` its per-outer-row value
 /// comes from (an immediate-enclosing-row cell, or a threaded binding).
 ///
-/// A CORRELATED subquery references a column of an enclosing query
-/// (`SELECT V FROM S WHERE S.k = T.k`, the inner `T.k` outer). This slice ships
-/// the MINIMAL (b) cut: an outer column is allowed ONLY in the inner query's
+/// A CORRELATED subquery references a column of an enclosing query (`SELECT V
+/// FROM S WHERE S.k = T.k`, the inner `T.k` outer). This slice ships the
+/// MINIMAL (b) cut: an outer column is allowed ONLY in the inner query's
 /// `WHERE`/`ON` (a comparison operand or a `WHERE`-position term), where it
 /// lowers to a synthetic `Term.parameter(name)` — reusing the run's `bindings`
 /// with NO new evaluator beyond that leaf. This map records, per synthetic
-/// name, the `Source` the per-outer-row re-execution binds it from. An EMPTY map
-/// is an UNCORRELATED occurrence, materialised once and memoised; a NON-empty
-/// one re-runs the inner plan per outer row against a `bindings` extended with
-/// each named cell, bypassing the materialise cache.
+/// name, the `Source` the per-outer-row re-execution binds it from. An EMPTY
+/// map is an UNCORRELATED occurrence, materialised once and memoised; a
+/// NON-empty one re-runs the inner plan per outer row against a `bindings`
+/// extended with each named cell, bypassing the materialise cache.
 ///
 /// An outer column in the inner PROJECTION / `GROUP BY` / `HAVING` is OUT of
 /// this cut — it needs the general (a)-style outer-row evaluator, not a bound
@@ -187,8 +187,8 @@ internal typealias Correlation = Dictionary<String, Source>
 extension Dictionary where Key == String, Value == Source {
   /// This correlation with every `slot` outer ordinal remapped to its packed
   /// slot through `slot`, so a per-outer-row re-execution reads the outer
-  /// record's cell; a `bound` source is unchanged — it reads a threaded binding,
-  /// not the outer record.
+  /// record's cell; a `bound` source is unchanged — it reads a threaded
+  /// binding, not the outer record.
   internal func remapped(through slot: Dictionary<Int, Int>) -> Correlation {
     mapValues { source in
       switch source {
@@ -218,28 +218,29 @@ extension Dictionary where Key == String, Value == Source {
 /// inner column binds against none of the subquery's OWN in-scope relations.
 ///
 /// A subquery resolves its columns against its own relations FIRST; a name none
-/// of them binds is a candidate CORRELATED reference to an enclosing query. This
-/// carries the enclosing `Scope`s, innermost last, and — as lowering reaches
-/// each such candidate — resolves it against them (nearest first), MINTS a
-/// synthetic `:parameter` name for the outer combined ordinal, and RECORDS the
-/// (name → ordinal) pair into the shared `correlation` accumulator so the
-/// per-outer-row re-execution can bind that cell. It is a class so the
-/// accumulator survives the seam being copied by value down the lowering, and so
-/// the SAME occurrence lowered on the run and the schema paths accretes into one
-/// map.
+/// of them binds is a candidate CORRELATED reference to an enclosing query.
+/// This carries the enclosing `Scope`s, innermost last, and — as lowering
+/// reaches each such candidate — resolves it against them (nearest first),
+/// MINTS a synthetic `:parameter` name for the outer combined ordinal, and
+/// RECORDS the (name → ordinal) pair into the shared `correlation` accumulator
+/// so the per-outer-row re-execution can bind that cell. It is a class so the
+/// accumulator survives the seam being copied by value down the lowering, and
+/// so the SAME occurrence lowered on the run and the schema paths accretes into
+/// one map.
 ///
 /// A name no enclosing scope binds either stays the ordinary unknown-column
 /// fault (the local surface already raised `SQLError.column`); this only
-/// intercepts a name the OUTER scope binds. Correlation is admitted ONLY where a
-/// synthetic bound param is a valid lowering — a `WHERE`/`ON` term — so a scope
-/// with no admitted position (a projection / `GROUP BY` / `HAVING` surface)
-/// carries no `Outer` and the outer column stays unresolved, DIAGNOSED as
-/// unsupported rather than mis-bound.
+/// intercepts a name the OUTER scope binds. Correlation is admitted ONLY where
+/// a synthetic bound param is a valid lowering — a `WHERE`/`ON` term — so a
+/// scope with no admitted position (a projection / `GROUP BY` / `HAVING`
+/// surface) carries no `Outer` and the outer column stays unresolved, DIAGNOSED
+/// as unsupported rather than mis-bound.
 internal final class Outer {
   /// The enclosing scopes, OUTERMOST first — a column resolves against the
   /// nearest enclosing (last) that binds it, matching lexical scoping. The LAST
-  /// scope is this subquery's IMMEDIATE parent; any earlier one is a grandparent
-  /// (or further) whose correlation BUBBLES UP to the containing subquery.
+  /// scope is this subquery's IMMEDIATE parent; any earlier one is a
+  /// grandparent (or further) whose correlation BUBBLES UP to the containing
+  /// subquery.
   private let scopes: Array<Scope>
 
   /// The enclosing subquery's `Outer` — the one holding `scopes` MINUS the last
@@ -282,8 +283,8 @@ internal final class Outer {
     ":__correlated_\(depth)_\(ordinal)"
   }
 
-  /// The synthetic bound-parameter name `column` correlates to, or `nil` when no
-  /// enclosing scope binds it (the ordinary unknown-column fault stands).
+  /// The synthetic bound-parameter name `column` correlates to, or `nil` when
+  /// no enclosing scope binds it (the ordinary unknown-column fault stands).
   ///
   /// The enclosing scopes are consulted NEAREST first (the innermost enclosing
   /// query shadows an outer one, as lexical scoping requires). On a match it
@@ -310,12 +311,12 @@ internal final class Outer {
   /// outer row directly, so the source is the parent-row `slot`. A match at an
   /// EARLIER scope is a correlation of the CONTAINING subquery too: it is
   /// recorded `bound` here — the eval threads the value through `bindings`
-  /// rather than reading this subquery's own row — and propagated up to `parent`
-  /// (whose last scope is one level nearer), so the containing occurrence is
-  /// itself marked correlated and re-executes per its enclosing row. Since a
-  /// `Scope` lays relations at cumulative offsets from 0, the `ordinal` is the
-  /// same in every level that shares the matched scope, so the ancestor that
-  /// owns it as its IMMEDIATE parent reads the right cell.
+  /// rather than reading this subquery's own row — and propagated up to
+  /// `parent` (whose last scope is one level nearer), so the containing
+  /// occurrence is itself marked correlated and re-executes per its enclosing
+  /// row. Since a `Scope` lays relations at cumulative offsets from 0, the
+  /// `ordinal` is the same in every level that shares the matched scope, so the
+  /// ancestor that owns it as its IMMEDIATE parent reads the right cell.
   private func record(_ name: String, _ ordinal: Int, matching depth: Int) {
     let immediate = depth == scopes.count - 1
     correlation[name] = immediate ? .slot(ordinal) : .bound
@@ -329,8 +330,8 @@ internal final class Outer {
   /// correlation (a pure type probe); the lowering's `parameter(for:)` records
   /// the binding. Like `parameter(for:)`, a nearer scope binding the name
   /// AMBIGUOUSLY SHADOWS the farther ones — `correlated` faults
-  /// `SQLError.ambiguous`, which propagates rather than falling through — so the
-  /// schema-derive and the run's lowering AGREE on the ambiguity.
+  /// `SQLError.ambiguous`, which propagates rather than falling through — so
+  /// the schema-derive and the run's lowering AGREE on the ambiguity.
   internal func type(for column: Column) throws(SQLError) -> ValueType? {
     for scope in scopes.reversed() {
       guard let ordinal = try scope.correlated(column) else { continue }
@@ -341,17 +342,19 @@ internal final class Outer {
 }
 
 /// The mutable memo a `Subqueries` cache shares by REFERENCE for the
-/// UNCORRELATED subqueries it materialises LAZILY, keyed by occurrence `Subkey`.
+/// UNCORRELATED subqueries it materialises LAZILY, keyed by occurrence
+/// `Subkey`.
 ///
 /// Every subquery ROLE — scalar collapse, `IN` value set, `EXISTS` probe — is
 /// materialised LAZILY, on the FIRST evaluation of its lowered node, so an
 /// occurrence in an unreachable `CASE`/`COALESCE` arm or a short-circuited
 /// `AND`/`OR` never runs (never throws its inner fault) — the folded-in lazy
 /// `IN`/`EXISTS` that the earlier slice left eager. An UNCORRELATED occurrence
-/// is row-invariant, so the first reached evaluation runs it ONCE and caches the
-/// result here; every later read of the same key returns it WITHOUT re-running.
-/// A CORRELATED occurrence is NOT memoised (its result depends on the bound
-/// outer row), so it never reads or writes this — it re-runs per outer row.
+/// is row-invariant, so the first reached evaluation runs it ONCE and caches
+/// the result here; every later read of the same key returns it WITHOUT
+/// re-running. A CORRELATED occurrence is NOT memoised (its result depends on
+/// the bound outer row), so it never reads or writes this — it re-runs per
+/// outer row.
 ///
 /// It is a class so the memo survives `Subqueries` being copied by value down
 /// the evaluate tree — every copy shares the one box.
@@ -366,12 +369,12 @@ internal final class SubqueryMemo {
   /// The RESOLUTION OVERLAY each `Subscope`'s subqueries run under — the
   /// caller's `WITH`/store overlay under `.caller`, a view body's own overlay
   /// under `.view(name)` — recorded as each scope BEGINS executing, so the lazy
-  /// evaluator runs a subquery against the overlay of the scope it was TEXTUALLY
-  /// lowered under, NOT the (possibly different) overlay of the execution site a
-  /// predicate pushdown moved it to. A caller conjunct pushed INTO a view thus
-  /// still resolves its subquery's `FROM S` against the caller's `S`, not the
-  /// view's base — the correctness the disjoint `Subscope` keying and the
-  /// captured overlay together preserve.
+  /// evaluator runs a subquery against the overlay of the scope it was
+  /// TEXTUALLY lowered under, NOT the (possibly different) overlay of the
+  /// execution site a predicate pushdown moved it to. A caller conjunct pushed
+  /// INTO a view thus still resolves its subquery's `FROM S` against the
+  /// caller's `S`, not the view's base — the correctness the disjoint
+  /// `Subscope` keying and the captured overlay together preserve.
   private var overlays: Dictionary<Subscope, ScopedRelations> = [:]
 
   internal func scalar(_ key: Subkey) -> Value? { scalars[key] }
@@ -393,16 +396,16 @@ internal final class SubqueryMemo {
   /// occurrence `PlanKey` (its `Subkey` composed with the parameter names its
   /// correlation binds) — compiled ONCE (with the enclosing scope as its
   /// `Outer`, so its correlated columns lowered to `Term.parameter`) by the run
-  /// path's compile and stashed here, so the evaluator RE-EXECUTES that plan per
-  /// outer row against the correlated bindings rather than RE-COMPILING the
+  /// path's compile and stashed here, so the evaluator RE-EXECUTES that plan
+  /// per outer row against the correlated bindings rather than RE-COMPILING the
   /// inner query fresh (which, with no outer scope in hand at eval, would fault
   /// on the outer column). Keying by the `PlanKey` keeps two occurrences of the
-  /// SAME inner SQL — under a `.caller` and a `.view(name)` scope, or across two
-  /// set-operation arms whose correlated column has a DIFFERENT outer ordinal —
-  /// DISJOINT, so each executes its OWN plan rather than the first occurrence's,
-  /// while an identical occurrence under an identical outer layout still SHARES.
-  /// An UNCORRELATED occurrence carries none — it re-runs its `Query`
-  /// (recompiling resolves without an outer scope) and memoises.
+  /// SAME inner SQL — under a `.caller` and a `.view(name)` scope, or across
+  /// two set-operation arms whose correlated column has a DIFFERENT outer
+  /// ordinal — DISJOINT, so each executes its OWN plan rather than the first
+  /// occurrence's, while an identical occurrence under an identical outer
+  /// layout still SHARES. An UNCORRELATED occurrence carries none — it re-runs
+  /// its `Query` (recompiling resolves without an outer scope) and memoises.
   private var plans: Dictionary<PlanKey, Plan> = [:]
 
   internal func overlay(_ scope: Subscope) -> ScopedRelations? {
@@ -419,7 +422,8 @@ internal final class SubqueryMemo {
 }
 
 /// The COMPILE-time seam that lowers an `EXISTS`/`IN (Q)` predicate WITHOUT
-/// running its subquery — the fix for the schema-path cursor-contract violation.
+/// running its subquery — the fix for the schema-path cursor-contract
+/// violation.
 ///
 /// Predicate lowering happens over escapable resolution surfaces (`Schema`,
 /// `Scope`, `Grouping`) that carry no catalog, and is shared by SCHEMA-ONLY
@@ -428,8 +432,8 @@ internal final class SubqueryMemo {
 /// rather than running it: `exists`/`within` build the lowered node holding the
 /// query, which executes ONCE, at RUN time (see `Subqueries`). Only the
 /// single-column arity of an `IN (Q)` is decided here — from the subquery's
-/// COMPILED WIDTH, known without a cursor — so a two-column `IN` subquery faults
-/// `SQLError.arity` at compile as before, never having run.
+/// COMPILED WIDTH, known without a cursor — so a two-column `IN` subquery
+/// faults `SQLError.arity` at compile as before, never having run.
 ///
 /// The `widths` map holds each nested `Query`'s compiled column count, built by
 /// the `compile` path (where the catalog is in scope) by COMPILING — never
@@ -458,8 +462,8 @@ internal struct Resolution {
   /// its inner `WHERE`/`ON` names of an enclosing column, discovered by the
   /// pre-pass compiling the nested query under this select's scope as its
   /// `Outer`. An UNCORRELATED nested query maps to the empty correlation (or is
-  /// absent), so its lowered node bypasses nothing; a correlated one carries its
-  /// map into the lowered `Filter`/`Term` so the per-outer-row re-execution
+  /// absent), so its lowered node bypasses nothing; a correlated one carries
+  /// its map into the lowered `Filter`/`Term` so the per-outer-row re-execution
   /// binds the named cells.
   private let correlations: Dictionary<Query, Correlation>
 
@@ -529,8 +533,8 @@ internal struct Resolution {
 
   /// The synthetic bound-parameter name a CORRELATED reference to `column`
   /// lowers to, or `nil` when no enclosing scope binds it (the ordinary
-  /// unknown-column fault stands). A `.column` lowering consults this ONLY after
-  /// its own relations fail to bind the name.
+  /// unknown-column fault stands). A `.column` lowering consults this ONLY
+  /// after its own relations fail to bind the name.
   ///
   /// On a barred surface (a projection / `GROUP BY` / `HAVING`) an outer column
   /// IS out of the minimal (b) cut, so a name the enclosing scope binds is
@@ -549,8 +553,8 @@ internal struct Resolution {
   /// The outer type a correlated reference to `column` contributes to a SCHEMA
   /// derive, or `nil` when no enclosing scope binds it — the non-recording,
   /// non-faulting type probe `derive` reads so a correlated column types as its
-  /// outer column rather than faulting `SQLError.column`. A BARRED surface still
-  /// diagnoses it, so this schema surface and the run's lowering AGREE.
+  /// outer column rather than faulting `SQLError.column`. A BARRED surface
+  /// still diagnoses it, so this schema surface and the run's lowering AGREE.
   internal func correlated(_ column: Column) throws(SQLError) -> ValueType? {
     guard let type = try outer?.type(for: column) else { return nil }
     guard admits else {
@@ -664,8 +668,8 @@ internal struct Resolution {
 ///
 /// The same inner SQL in both an `ON` and the WHERE is resolved TWICE, each
 /// against its OWN site's scope, so a name the `ON`'s narrow prefix binds
-/// UNAMBIGUOUSLY yet the WHERE's full scope binds in MORE than one relation is a
-/// prefix correlation in the `ON` and a genuine ambiguity in the WHERE — each
+/// UNAMBIGUOUSLY yet the WHERE's full scope binds in MORE than one relation is
+/// a prefix correlation in the `ON` and a genuine ambiguity in the WHERE — each
 /// per its own site, not the first occurrence's prefix (see `subquery(of:)`).
 internal struct Plans {
   /// The lowering seam of each join `ON`, in join order — `on(i)` reads the
@@ -694,15 +698,16 @@ internal struct Plans {
 ///
 /// The evaluator (a `Catalog` method, the catalog IN scope) runs a subquery
 /// itself: it reads this cache first and, on a miss, runs the inner plan and
-/// `store`s the result. An UNCORRELATED occurrence names no enclosing column, so
-/// its result is the SAME for every outer row and is memoised under its
-/// occurrence `Subkey`; a later reach returns it WITHOUT re-running. A CORRELATED
-/// occurrence's result depends on the bound outer row, so it BYPASSES this cache
-/// entirely — the evaluator re-runs its inner plan per outer row against a
-/// `bindings` extended with the correlated cells (this slice does NOT memoise
-/// across distinct binding tuples — a flagged future optimisation). Every role
-/// (scalar / `IN` / `EXISTS`) is lazy, so a subquery an unreachable `CASE` arm
-/// or a short-circuited `AND`/`OR` never reaches never runs.
+/// `store`s the result. An UNCORRELATED occurrence names no enclosing column,
+/// so its result is the SAME for every outer row and is memoised under its
+/// occurrence `Subkey`; a later reach returns it WITHOUT re-running. A
+/// CORRELATED occurrence's result depends on the bound outer row, so it
+/// BYPASSES this cache entirely — the evaluator re-runs its inner plan per
+/// outer row against a `bindings` extended with the correlated cells (this
+/// slice does NOT memoise across distinct binding tuples — a flagged future
+/// optimisation). Every role (scalar / `IN` / `EXISTS`) is lazy, so a subquery
+/// an unreachable `CASE` arm or a short-circuited `AND`/`OR` never reaches
+/// never runs.
 internal struct Subqueries {
   /// The shared memo of the UNCORRELATED occurrences materialised LAZILY on
   /// first reach — a reference so every by-value copy of this cache down the
@@ -720,14 +725,15 @@ internal struct Subqueries {
     memo.present(key)
   }
 
-  /// Records the `EXISTS` non-empty result of the UNCORRELATED occurrence `key`.
+  /// Records the `EXISTS` non-empty result of the UNCORRELATED occurrence
+  /// `key`.
   internal func store(present value: Bool, for key: Subkey) {
     memo.store(present: value, for: key)
   }
 
   /// The memoised `IN (Q)` single column for the UNCORRELATED occurrence `key`,
-  /// or `nil` when it has not yet run — the evaluator materialises on a miss and
-  /// `store`s it.
+  /// or `nil` when it has not yet run — the evaluator materialises on a miss
+  /// and `store`s it.
   internal func values(cached key: Subkey) -> Array<Value>? {
     memo.values(key)
   }
@@ -751,8 +757,8 @@ internal struct Subqueries {
   }
 
   /// The resolution overlay `scope`'s subqueries run under — the overlay
-  /// recorded as `scope` began executing (see `SubqueryMemo.overlays`), or `nil`
-  /// when none was recorded (a top-level run always records `.caller`).
+  /// recorded as `scope` began executing (see `SubqueryMemo.overlays`), or
+  /// `nil` when none was recorded (a top-level run always records `.caller`).
   internal func overlay(_ scope: Subscope) -> ScopedRelations? {
     memo.overlay(scope)
   }
@@ -768,10 +774,11 @@ internal struct Subqueries {
   /// The pre-compiled inner plan of the CORRELATED occurrence `key` under
   /// `correlation` — compiled once with its enclosing scope so its correlated
   /// columns are `Term.parameter` — or `nil` for an UNCORRELATED one (which
-  /// recompiles fresh per run). Keyed by the occurrence's `PlanKey` (its `Subkey`
-  /// plus the correlation's parameter names), so two occurrences of the SAME
-  /// inner SQL under DIFFERENT outer layouts — two set-operation arms whose
-  /// correlated column sits at different ordinals — each find their OWN plan.
+  /// recompiles fresh per run). Keyed by the occurrence's `PlanKey` (its
+  /// `Subkey` plus the correlation's parameter names), so two occurrences of
+  /// the SAME inner SQL under DIFFERENT outer layouts — two set-operation arms
+  /// whose correlated column sits at different ordinals — each find their OWN
+  /// plan.
   internal func plan(_ key: Subkey, _ correlation: Correlation) -> Plan? {
     memo.plan(PlanKey(key, correlation))
   }
@@ -784,9 +791,10 @@ internal struct Subqueries {
   }
 
   /// This cache — the memo is a shared box the whole run accretes into, so a
-  /// caller cache and a view-body cache share one box, their disjoint `Subscope`
-  /// keys never colliding. The prior eager merge collapses to identity now that
-  /// every occurrence is memoised lazily against this one shared box.
+  /// caller cache and a view-body cache share one box, their disjoint
+  /// `Subscope` keys never colliding. The prior eager merge collapses to
+  /// identity now that every occurrence is memoised lazily against this one
+  /// shared box.
   internal func merged(_ other: Subqueries) -> Subqueries {
     self
   }
@@ -899,8 +907,8 @@ internal struct SubqueryCheck {
   private let outer: Outer?
 
   /// Whether this surface ADMITS a correlated column — the inner `WHERE`/`ON`
-  /// (TRUE) versus a projection / `GROUP BY` / `HAVING` (FALSE, diagnosed) — the
-  /// analog of `Resolution.admits`, so validation faults the unsupported
+  /// (TRUE) versus a projection / `GROUP BY` / `HAVING` (FALSE, diagnosed) —
+  /// the analog of `Resolution.admits`, so validation faults the unsupported
   /// correlated-projection case exactly where the run does.
   private let admits: Bool
 
@@ -960,11 +968,11 @@ internal struct SubqueryCheck {
 
   /// The outer type `column` correlates to, or `nil` when no enclosing scope
   /// binds it — the validation-side `Resolution.correlate`: it resolves against
-  /// `outer`, faulting `.unsupported` on a BARRED surface (a projection / `GROUP
-  /// BY` / `HAVING`) so validation rejects the unsupported correlated-projection
-  /// case exactly as the run's lowering does, and returns the outer column's
-  /// type so `validate` types the reference as that column. Consulted ONLY after
-  /// the local relations fail to bind the name.
+  /// `outer`, faulting `.unsupported` on a BARRED surface (a projection /
+  /// `GROUP BY` / `HAVING`) so validation rejects the unsupported
+  /// correlated-projection case exactly as the run's lowering does, and returns
+  /// the outer column's type so `validate` types the reference as that column.
+  /// Consulted ONLY after the local relations fail to bind the name.
   internal func correlated(_ column: Column) throws(SQLError) -> ValueType? {
     guard let type = try outer?.type(for: column) else { return nil }
     guard admits else {
@@ -1010,8 +1018,8 @@ internal struct SubqueryCheck {
   /// recorded REACHED here, for the `typecheck` phase to validate its inner
   /// query. The cursor-free arity/type derivation stays SEPARATE and total: the
   /// arity of an unreachable scalar was already enforced eagerly in the
-  /// pre-pass (`subqueryCheck`), so a two-column subquery in a skipped arm still
-  /// faults.
+  /// pre-pass (`subqueryCheck`), so a two-column subquery in a skipped arm
+  /// still faults.
   internal func type(_ query: Query) throws(SQLError) -> ValueType {
     // A DEFERRED scalar occurrence is REACHED here in the `scalar` role: record
     // it for the `typecheck` phase to validate its inner query's OPERANDS,
@@ -1045,8 +1053,8 @@ internal struct SubqueryCheck {
 /// each leaf's operand expressions through `term` and passing a `bound`
 /// comparison's `:parameter` through unchanged.
 ///
-/// Every predicate lowering — a single relation, a join scope, a grouped scope —
-/// shares this shape, differing only in how a leaf term resolves its columns
+/// Every predicate lowering — a single relation, a join scope, a grouped scope
+/// — shares this shape, differing only in how a leaf term resolves its columns
 /// (against one schema, a combined join space, or a grouped slot space); each
 /// caller supplies that resolution as `term`.
 private func lower(_ predicate: Predicate,
@@ -1358,8 +1366,8 @@ extension Schema {
   }
 
   /// The projected terms of `projection`, addressed by ordinal: a `*` or a
-  /// bare-column list yields one `.slot(ordinal)` per column; an expression list
-  /// lowers each expression to a term. The terms hold ordinals, which the
+  /// bare-column list yields one `.slot(ordinal)` per column; an expression
+  /// list lowers each expression to a term. The terms hold ordinals, which the
   /// engine remaps to slots after gathering the referenced ones.
   internal func terms(_ projection: Projection, in relation: Relation,
                       _ routines: Routines = [:],
@@ -1536,14 +1544,14 @@ extension Schema {
 /// A join chain lays its relations end to end: relation `i` occupies the
 /// combined ordinals `[offset_i, offset_i + extent_i)`, where `offset_i` is the
 /// sum of the `extent`s of the relations before it. Using each relation's
-/// `extent` — its real `width` plus the virtual columns it exposes — rather than
-/// its `width` keeps a relation's virtual columns (an `Id`, an owner foreign
-/// key) on its own side rather than colliding with the next relation's space. A
-/// `Scope` resolves a possibly qualified `SQLEngine.Column` into that combined
-/// space so the engine's `Filter`, projection, and order all address cells
-/// uniformly across the chain. A qualifier names a relation by its alias, else
-/// its table name; an unqualified name resolves against every relation and is
-/// ambiguous if more than one resolves it — as is a qualified name two
+/// `extent` — its real `width` plus the virtual columns it exposes — rather
+/// than its `width` keeps a relation's virtual columns (an `Id`, an owner
+/// foreign key) on its own side rather than colliding with the next relation's
+/// space. A `Scope` resolves a possibly qualified `SQLEngine.Column` into that
+/// combined space so the engine's `Filter`, projection, and order all address
+/// cells uniformly across the chain. A qualifier names a relation by its alias,
+/// else its table name; an unqualified name resolves against every relation and
+/// is ambiguous if more than one resolves it — as is a qualified name two
 /// relations share an alias or table name for (a self-join or a duplicated
 /// alias). Resolution reads only schemas, so the scope is escapable data over
 /// the relations' `Schema`s.
@@ -1652,9 +1660,9 @@ internal struct Scope {
     return switch expression {
     case let .column(column):
       // A column this scope does not bind may be a CORRELATED reference to an
-      // enclosing query (in an inner `WHERE`); type it as the outer column, else
-      // the ordinary column fault. A LOCALLY AMBIGUOUS name is a HARD error
-      // `find` propagates, never a fall-through to outer correlation.
+      // enclosing query (in an inner `WHERE`); type it as the outer column,
+      // else the ordinary column fault. A LOCALLY AMBIGUOUS name is a HARD
+      // error `find` propagates, never a fall-through to outer correlation.
       if let ordinal = try find(column) {
         type(at: ordinal)
       } else if let type = try subquery.correlated(column) {
@@ -1689,16 +1697,16 @@ internal struct Scope {
            derive(rhs, routines, subquery: subquery)].contains(.double)
           ? .double : .integer
     case let .case(whens, otherwise):
-      // The result type is the unification of every REACHABLE branch result (and
-      // the `ELSE`) — the executor's short-circuit means an unreachable branch
-      // (a constant-false guard, or any branch after a constant-true one) never
-      // yields a value, so it cannot shape the column's type. The reachable
-      // result types must UNIFY; a definitively-irreconcilable clash (text
-      // beside an integer) faults `SQLError.operand` here too, so this lowering
-      // surface and the faulting `validate` AGREE. A `CASE` always has at least
-      // one `WHEN`; when none is reachable (every guard constant-false, no
-      // reachable `ELSE`) the run yields NULL, for which `.integer` is the
-      // schema default.
+      // The result type is the unification of every REACHABLE branch result
+      // (and the `ELSE`) — the executor's short-circuit means an unreachable
+      // branch (a constant-false guard, or any branch after a constant-true
+      // one) never yields a value, so it cannot shape the column's type. The
+      // reachable result types must UNIFY; a definitively-irreconcilable clash
+      // (text beside an integer) faults `SQLError.operand` here too, so this
+      // lowering surface and the faulting `validate` AGREE. A `CASE` always has
+      // at least one `WHEN`; when none is reachable (every guard
+      // constant-false, no reachable `ELSE`) the run yields NULL, for which
+      // `.integer` is the schema default.
       try derive(whens, otherwise, routines, subquery: subquery)
     case let .cast(operand, type):
       // A cast's static type is the target type; the conversion is nominal, so
@@ -2043,12 +2051,12 @@ internal struct Scope {
 
   /// The result type of a `CASE`, validating each REACHABLE branch as a run
   /// would fault and honouring the executor's short-circuit: each evaluated
-  /// `WHEN` guard is a boolean predicate whose operands are validated (`check`);
-  /// only a REACHABLE result expression is validated; and the reachable result
-  /// types must UNIFY to one type (`ValueType.unified`) — a
+  /// `WHEN` guard is a boolean predicate whose operands are validated
+  /// (`check`); only a REACHABLE result expression is validated; and the
+  /// reachable result types must UNIFY to one type (`ValueType.unified`) — a
   /// definitively-irreconcilable pair (a text result beside an integer one)
-  /// faults `SQLError.operand`, as a query cannot yield a column of two kinds. A
-  /// mixed integer/double `CASE` widens to `double`.
+  /// faults `SQLError.operand`, as a query cannot yield a column of two kinds.
+  /// A mixed integer/double `CASE` widens to `double`.
   ///
   /// The executor takes the first TRUE guard's result and never evaluates a
   /// later branch, so a `WHEN` whose guard is statically constant-FALSE has an
@@ -2056,12 +2064,12 @@ internal struct Scope {
   /// Name + 1 ELSE 0 END` type-checks). A constant-TRUE guard is itself
   /// reachable and KEEPS every earlier reachable branch — a row an earlier
   /// row-dependent guard matches takes that branch, never reaching the
-  /// constant-TRUE one — so those earlier results are still validated (`CASE WHEN
-  /// Id = 1 THEN Name + 1 WHEN 1 = 1 THEN 0 END` faults on the reachable `Id = 1`
-  /// branch's `Name + 1`); it makes only every STRICTLY-LATER guard, result, and
-  /// the `ELSE` unreachable. A REACHABLE bad operand (`WHEN Id = 1 THEN Name +
-  /// 1`) still faults. When no branch is reachable the run yields NULL, typed
-  /// `.integer` (the schema default), with no result to validate.
+  /// constant-TRUE one — so those earlier results are still validated (`CASE
+  /// WHEN Id = 1 THEN Name + 1 WHEN 1 = 1 THEN 0 END` faults on the reachable
+  /// `Id = 1` branch's `Name + 1`); it makes only every STRICTLY-LATER guard,
+  /// result, and the `ELSE` unreachable. A REACHABLE bad operand (`WHEN Id = 1
+  /// THEN Name + 1`) still faults. When no branch is reachable the run yields
+  /// NULL, typed `.integer` (the schema default), with no result to validate.
   private func conditional(_ whens: Array<When>, _ otherwise: Expression?,
                            _ routines: Routines,
                            subquery: SubqueryCheck = .unsupported)
@@ -2071,8 +2079,9 @@ internal struct Scope {
     for branch in whens {
       // The guard up to (and including) the decisive one is evaluated, so
       // validate its operands; a constant-FALSE guard's result is unreachable
-      // (skip it), a constant-TRUE one is reachable but makes every LATER branch
-      // unreachable — so keep the earlier results and this one, then stop.
+      // (skip it), a constant-TRUE one is reachable but makes every LATER
+      // branch unreachable — so keep the earlier results and this one, then
+      // stop.
       try check(branch.when, routines, subquery: subquery)
       switch constant(branch.when, routines) {
       case false: continue
@@ -2624,18 +2633,19 @@ internal struct Scope {
     }
   }
 
-  /// Folds an `IN` value list as its OR-chain of `operand = element` equalities,
-  /// honouring the executor's SHORT-CIRCUIT: the elements are visited in order,
-  /// each mapped to its three-valued equality truth by `equality`, and the truths
-  /// are OR-folded — but a definite `true` stops the walk, since the OR-chain
-  /// matches there and every LATER element is unreachable (`Row.matches` returns
-  /// on the first true arm). This is the ONE short-circuit the `IN`
-  /// type-check (`check`), constant fold (`constant`), and empty-group evaluator
-  /// (`empty`) all share: each supplies the per-element `equality` its surface
-  /// computes with, and every surface stops at the same element the run does.
+  /// Folds an `IN` value list as its OR-chain of `operand = element`
+  /// equalities, honouring the executor's SHORT-CIRCUIT: the elements are
+  /// visited in order, each mapped to its three-valued equality truth by
+  /// `equality`, and the truths are OR-folded — but a definite `true` stops the
+  /// walk, since the OR-chain matches there and every LATER element is
+  /// unreachable (`Row.matches` returns on the first true arm). This is the ONE
+  /// short-circuit the `IN` type-check (`check`), constant fold (`constant`),
+  /// and empty-group evaluator (`empty`) all share: each supplies the
+  /// per-element `equality` its surface computes with, and every surface stops
+  /// at the same element the run does.
   ///
-  /// `visit` runs on each element BEFORE its truth is taken, so a surface with a
-  /// per-element side effect (validation) applies it to exactly the reachable
+  /// `visit` runs on each element BEFORE its truth is taken, so a surface with
+  /// a per-element side effect (validation) applies it to exactly the reachable
   /// prefix. The fold seeds FALSE (an empty match is FALSE), so the returned
   /// truth is the disjunction over the visited prefix.
   private func membership<E: Error>(
@@ -3162,10 +3172,10 @@ internal struct Scope {
     case let .membership(operand, values, negated):
       // Fold `x IN (…)` over the empty group as its OR-chain of equalities does
       // — the folded operand matched against each folded element under
-      // three-valued `OR`, honouring the OR-chain's short-circuit (`membership`):
-      // the run stops at the first TRUE comparison and never evaluates a later
-      // element, so `1 IN (1, 1 / 0)` folds `true` here without folding `1 / 0`
-      // to a `.divide` fault. Negated for `NOT IN`.
+      // three-valued `OR`, honouring the OR-chain's short-circuit
+      // (`membership`): the run stops at the first TRUE comparison and never
+      // evaluates a later element, so `1 IN (1, 1 / 0)` folds `true` here
+      // without folding `1 / 0` to a `.divide` fault. Negated for `NOT IN`.
       //
       // Reject an empty list, as `check` and `lower` do — a whole-result
       // aggregate `HAVING` over the empty group reaches this fold WITHOUT a
@@ -3312,8 +3322,9 @@ internal struct Scope {
   /// is `SQLError.ambiguous` and PROPAGATES — a nearer ambiguous scope SHADOWS
   /// farther ones rather than falling through to rebind the name to an outer
   /// column. Only the not-found `SQLError.column` becomes `nil`; every other
-  /// fault (an ambiguity or a qualifier fault) propagates. This is the enclosing
-  /// analog of `find`, which the LOCAL lowering consults for the same reason.
+  /// fault (an ambiguity or a qualifier fault) propagates. This is the
+  /// enclosing analog of `find`, which the LOCAL lowering consults for the same
+  /// reason.
   internal func correlated(_ column: Column) throws(SQLError) -> Int? {
     try find(column)
   }
@@ -3347,8 +3358,8 @@ internal struct Scope {
 
   /// The combined-ordinal projected terms: every real column of every relation
   /// for `*` (in chain order, never a virtual column) as `.slot` terms, a
-  /// bare-column list as `.slot` terms at their combined ordinals, an expression
-  /// list as lowered terms — in source order.
+  /// bare-column list as `.slot` terms at their combined ordinals, an
+  /// expression list as lowered terms — in source order.
   internal func terms(_ projection: Projection,
                       _ routines: Routines = [:],
                       subquery: Resolution = .unsupported) throws(SQLError)
@@ -3396,13 +3407,13 @@ internal struct Scope {
       throws(SQLError) -> Term {
     switch expression {
     case let .column(column):
-      // Resolve the column against this scope's own relations first; a name none
-      // binds is a candidate CORRELATED reference — consult the enclosing scope,
-      // lowering to a synthetic `Term.parameter` bound from the outer row when it
-      // resolves there, else the ordinary unknown-column fault. A LOCALLY
-      // AMBIGUOUS name (bound by more than one relation) is a HARD error `find`
-      // propagates — never a fall-through to outer correlation that would rebind
-      // it to an outer column.
+      // Resolve the column against this scope's own relations first; a name
+      // none binds is a candidate CORRELATED reference — consult the enclosing
+      // scope, lowering to a synthetic `Term.parameter` bound from the outer
+      // row when it resolves there, else the ordinary unknown-column fault. A
+      // LOCALLY AMBIGUOUS name (bound by more than one relation) is a HARD
+      // error `find` propagates — never a fall-through to outer correlation
+      // that would rebind it to an outer column.
       if let ordinal = try find(column) { return .slot(ordinal) }
       if let name = try subquery.correlate(column) { return .parameter(name) }
       return try .slot(ordinal(of: column))
@@ -3581,15 +3592,15 @@ internal struct Scope {
 /// The grouped slot space of an aggregate query — the lowering surface for the
 /// projection, `HAVING`, and `ORDER BY` that read a grouped record.
 ///
-/// An `aggregate` node yields grouped records whose slots are the `GROUP BY` key
-/// values (slots `0 ..< keys.count`, in key order) followed by the aggregate
-/// results (slot `keys.count + j` is aggregate `j`). A `Grouping` lowers a
-/// name-addressed AST expression into that space: an aggregate call maps to its
-/// result slot; a bare column maps to its key slot ONLY when it is a `GROUP BY`
-/// key — the standard rule that a non-aggregated column must appear in the
-/// `GROUP BY` (else `SQLError.grouping`). It also records each projected item's
-/// output name so an `ORDER BY` may name a projection alias, the standard way to
-/// order on an aggregate (`ORDER BY <count-alias>`).
+/// An `aggregate` node yields grouped records whose slots are the `GROUP BY`
+/// key values (slots `0 ..< keys.count`, in key order) followed by the
+/// aggregate results (slot `keys.count + j` is aggregate `j`). A `Grouping`
+/// lowers a name-addressed AST expression into that space: an aggregate call
+/// maps to its result slot; a bare column maps to its key slot ONLY when it is
+/// a `GROUP BY` key — the standard rule that a non-aggregated column must
+/// appear in the `GROUP BY` (else `SQLError.grouping`). It also records each
+/// projected item's output name so an `ORDER BY` may name a projection alias,
+/// the standard way to order on an aggregate (`ORDER BY <count-alias>`).
 ///
 /// The keys and aggregates resolve against the underlying `Scope`, so the same
 /// combined-ordinal resolution the source uses decides which projection columns
@@ -3629,10 +3640,10 @@ internal struct Grouping {
   private var ambiguous: Set<String> = []
 
   /// Builds a grouping over `scope` for the `GROUP BY` `columns` and the
-  /// query's distinct `aggregates` (in first-appearance order — aggregate `j` at
-  /// grouped slot `columns.count + j`). The `aggregates` are already deduped by
-  /// RESOLVED `Aggregation` (see `group`), so a qualification-equivalent pair
-  /// is one entry sharing one slot.
+  /// query's distinct `aggregates` (in first-appearance order — aggregate `j`
+  /// at grouped slot `columns.count + j`). The `aggregates` are already deduped
+  /// by RESOLVED `Aggregation` (see `group`), so a qualification-equivalent
+  /// pair is one entry sharing one slot.
   internal init(_ scope: Scope, _ columns: Array<Column>,
                 _ aggregates: Array<Aggregation>,
                 subquery: Resolution = .unsupported) throws(SQLError) {
@@ -3642,13 +3653,14 @@ internal struct Grouping {
       // A grouping key a local relation binds maps its combined ordinal to its
       // grouped slot. A key NONE binds is a candidate CORRELATED reference (a
       // LATERAL body grouping on a preceding column): the correlation surface's
-      // non-recording `correlated` probe distinguishes it from a genuine unknown
-      // column, and it occupies grouped slot `index` as a `.parameter` key (in
-      // `group`'s keys array) with NO ordinal→slot entry — the projection reads
-      // it via the same correlation, never through this key dict. A genuinely
-      // unknown column re-throws the `.column` fault; a barred surface diagnoses
-      // a bound outer column `.unsupported`. `correlated` records nothing, so it
-      // stays idempotent against `group`'s own correlation of the same key.
+      // non-recording `correlated` probe distinguishes it from a genuine
+      // unknown column, and it occupies grouped slot `index` as a `.parameter`
+      // key (in `group`'s keys array) with NO ordinal→slot entry — the
+      // projection reads it via the same correlation, never through this key
+      // dict. A genuinely unknown column re-throws the `.column` fault; a
+      // barred surface diagnoses a bound outer column `.unsupported`.
+      // `correlated` records nothing, so it stays idempotent against `group`'s
+      // own correlation of the same key.
       if let ordinal = try scope.find(columns[index]) {
         keys[ordinal] = index
       } else if try subquery.correlated(columns[index]) == nil {
@@ -3678,8 +3690,8 @@ internal struct Grouping {
   ///
   /// An aggregate call maps to its result slot; a literal to a constant; a
   /// `call`/`binary` recurses over its operands; a bare column maps to its key
-  /// slot only when it is a `GROUP BY` key, else it is `SQLError.grouping` — the
-  /// standard rule.
+  /// slot only when it is a `GROUP BY` key, else it is `SQLError.grouping` —
+  /// the standard rule.
   private func term(_ expression: Expression,
                     _ routines: Routines = [:],
                     subquery: Resolution = .unsupported)
@@ -3691,13 +3703,14 @@ internal struct Grouping {
     switch expression {
     case let .column(column):
       // Resolve the column against this scope's own relations first, mirroring
-      // `Scope.term`'s `.column`: a name a local relation binds must be a `GROUP
-      // BY` key (the standard grouping rule), else `SQLError.grouping`. A name
-      // NONE binds is a candidate CORRELATED reference — consult the surface,
-      // which admits it (a `Term.parameter` the apply binds per outer row) only
-      // for a LATERAL body's `everywhere` seam and diagnoses it `.unsupported` on
-      // an ordinary barred grouped surface. The final `ordinal(of:)` re-throws
-      // the genuine unknown-column `.column` fault, exactly as `Scope.term` does.
+      // `Scope.term`'s `.column`: a name a local relation binds must be a
+      // `GROUP BY` key (the standard grouping rule), else `SQLError.grouping`.
+      // A name NONE binds is a candidate CORRELATED reference — consult the
+      // surface, which admits it (a `Term.parameter` the apply binds per outer
+      // row) only for a LATERAL body's `everywhere` seam and diagnoses it
+      // `.unsupported` on an ordinary barred grouped surface. The final
+      // `ordinal(of:)` re-throws the genuine unknown-column `.column` fault,
+      // exactly as `Scope.term` does.
       if let ordinal = try scope.find(column) {
         guard let slot = keys[ordinal] else { throw .grouping(column.name) }
         return .slot(slot)
@@ -3722,7 +3735,8 @@ internal struct Grouping {
     case let .case(whens, otherwise):
       // Lower each branch's guard and result, and the `ELSE`, against the
       // grouped slot space — a bare column in any of them must be a `GROUP BY`
-      // key, an aggregate its result slot, as elsewhere in a grouped expression.
+      // key, an aggregate its result slot, as elsewhere in a grouped
+      // expression.
       var branches = Array<(Filter, Term)>()
       branches.reserveCapacity(whens.count)
       for branch in whens {
@@ -3767,7 +3781,8 @@ internal struct Grouping {
       return try subquery.scalar(query)
     case .aggregate:
       // An aggregate reaches here only when it was not collected — an internal
-      // inconsistency, since the query gathers every projection/HAVING aggregate.
+      // inconsistency, since the query gathers every projection/HAVING
+      // aggregate.
       throw .state("XX000", "uncollected aggregate")
     }
   }
@@ -3781,14 +3796,14 @@ internal struct Grouping {
     if aliases.updateValue(entry, forKey: key) != nil { ambiguous.insert(key) }
   }
 
-  /// The grouped-space projected terms, recording each item's output name for an
-  /// `ORDER BY` to name.
+  /// The grouped-space projected terms, recording each item's output name for
+  /// an `ORDER BY` to name.
   ///
   /// A `columns` projection (`SELECT Dept … GROUP BY Dept`) lowers each column
   /// as a grouped term — a `GROUP BY` key, else `SQLError.grouping`. An
   /// `expressions` projection lowers each item's expression and records its
-  /// output name (an alias, else a bare column's name) so an `ORDER BY` may name
-  /// it — the standard alias ordering on an aggregate. A `SELECT *` has no
+  /// output name (an alias, else a bare column's name) so an `ORDER BY` may
+  /// name it — the standard alias ordering on an aggregate. A `SELECT *` has no
   /// well-defined meaning over groups (which columns?), so it faults.
   internal mutating func terms(_ projection: Projection,
                                _ routines: Routines = [:],
@@ -3940,7 +3955,8 @@ extension Filter {
       // A CORRELATED EXISTS reads the enclosing row's cells its inner `WHERE`
       // names — the correlation's `slot` outer ordinals — so those must be
       // materialised for the per-row re-execution (a `bound` source reads a
-      // threaded binding, not the outer record). An UNCORRELATED one names none.
+      // threaded binding, not the outer record). An UNCORRELATED one names
+      // none.
       ordinals.formUnion(correlation.slots)
     case let .within(operand, _, correlation, _):
       // The outer operand term reads ordinals; a CORRELATED subquery ALSO reads

--- a/Sources/SQLEngine/Schema.swift
+++ b/Sources/SQLEngine/Schema.swift
@@ -4,15 +4,15 @@
 /// A relation's name-resolution surface, lifted off the live data source.
 ///
 /// Compilation resolves a column name to an ordinal, classifies a projection,
-/// and lowers a predicate using only a relation's `width`, its `extent`, and its
-/// name → ordinal map — never its `bound` seekability or its `cursor`, which the
-/// optimiser and executor re-read from the live source by name. A `Schema` is
-/// that escapable resolution surface, pure data: a base `Table` projects to one
-/// (its real `names` below `width`, its `virtuals` at and past it), and a
-/// compiled `View` projects to one too (its `columns` in projection order, no
-/// virtual column). Lifting resolution onto a `Schema` lets a join resolve a
-/// base table against a view uniformly — the two live sources need not share a
-/// type, only a schema.
+/// and lowers a predicate using only a relation's `width`, its `extent`, and
+/// its name → ordinal map — never its `bound` seekability or its `cursor`,
+/// which the optimiser and executor re-read from the live source by name. A
+/// `Schema` is that escapable resolution surface, pure data: a base `Table`
+/// projects to one (its real `names` below `width`, its `virtuals` at and past
+/// it), and a compiled `View` projects to one too (its `columns` in projection
+/// order, no virtual column). Lifting resolution onto a `Schema` lets a join
+/// resolve a base table against a view uniformly — the two live sources need
+/// not share a type, only a schema.
 internal struct Schema {
   /// The real columns — the extent of a `SELECT *` projection.
   internal let width: Int
@@ -47,9 +47,9 @@ internal struct Schema {
   ///
   /// A real column resolves against `names` to an ordinal `< width`; a virtual
   /// column resolves against `virtuals` to its ordinal `width + i`. The real
-  /// lookup wins, so a relation never hides a real column behind a virtual name.
-  /// The match is case-insensitive, as a metadata source's column names are
-  /// (`TypeName`, `Id`); a schema never carries two names differing only in
+  /// lookup wins, so a relation never hides a real column behind a virtual
+  /// name. The match is case-insensitive, as a metadata source's column names
+  /// are (`TypeName`, `Id`); a schema never carries two names differing only in
   /// case, so the match stays unambiguous.
   internal func ordinal(of name: String) -> Int? {
     let folded = name.lowercased()

--- a/Sources/SQLEngine/Token.swift
+++ b/Sources/SQLEngine/Token.swift
@@ -87,8 +87,9 @@ extension Token {
 
     // Operands.
     case identifier(String)
-    /// A delimited (double-quoted) identifier — a name taken verbatim, so unlike
-    /// a bare `identifier` a dot in it is part of the name, not a qualifier.
+    /// A delimited (double-quoted) identifier — a name taken verbatim, so
+    /// unlike a bare `identifier` a dot in it is part of the name, not a
+    /// qualifier.
     case quoted(String)
     case string(String)
     /// A bare integer literal — a run of digits with no fraction or exponent.


### PR DESCRIPTION
Reflow over-long doc/line comments at word boundaries and wrap the two over-long code lines per the coding style, bringing every SQLEngine source line to 80 columns. Behavior-preserving: comment prose and code semantics are unchanged. The copyright header and the Parser EBNF grammar block are left verbatim.