### PR TITLE
GHA: quiet build/test output and skip XCTest to cut CI time

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -51,12 +51,11 @@ jobs:
           key: ${{ env.LLVM_CAS_CACHE_KEY }}
       - name: Run tests
         run: >-
-          swift test -v --enable-code-coverage
+          swift test --quiet --disable-xctest --enable-code-coverage
           -Xswiftc -explicit-module-build
           -Xswiftc -cache-compile-job
           -Xswiftc -cas-path
           -Xswiftc $env:SWIFT_CAS_PATH
-          -Xswiftc -Rcache-compile-job
       - name: Process Coverage Information
         run: |
           $bin = swift build --show-bin-path

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -53,22 +53,20 @@ jobs:
           key: ${{ env.LLVM_CAS_CACHE_KEY }}
       - name: Build
         run: >-
-          swift build -v
+          swift build --quiet
           -Xswiftc -explicit-module-build
           -Xswiftc -cache-compile-job
           -Xswiftc -cas-path
           -Xswiftc $env:SWIFT_CAS_PATH
-          -Xswiftc -Rcache-compile-job
         env:
           AR: llvm-ar
       - name: Run tests
         run: >-
-          swift test -v
+          swift test --quiet --disable-xctest
           -Xswiftc -explicit-module-build
           -Xswiftc -cache-compile-job
           -Xswiftc -cas-path
           -Xswiftc $env:SWIFT_CAS_PATH
-          -Xswiftc -Rcache-compile-job
       - name: Prune LLVM CAS
         if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         shell: pwsh


### PR DESCRIPTION
Drop `-v` for `--quiet` and remove the `-Rcache-compile-job` remarks so the build and test steps stop emitting per-job cache-hit noise, and add `--disable-xctest` to skip the empty XCTest run — the suite is swift-testing only.