### PR TITLE
SQLEngine: fold constant-true predicates

### DIFF
--- a/Sources/SQLEngine/Engine.swift
+++ b/Sources/SQLEngine/Engine.swift
@@ -1997,6 +1997,17 @@ extension Catalog where Self: ~Escapable {
       try .derived(name: name,
                    plan: optimise(view: name, plan, context),
                    ordinals: ordinals, seek: seek)
+    case let .select(filter, source) where filter.constant == true:
+      // A PROVABLY-always-true filter admits every row, so the select is a
+      // no-op: drop it and optimise the source alone — identical result, one
+      // fewer per-row predicate. This composes with the seek and nest cases
+      // below: a constant-true filter over a `.scan` or `.product` never
+      // reaches them, becoming just the optimised source (a plain scan or
+      // product), not a seek over a true residual or a nest with a true gate. A
+      // constant-FALSE filter is NOT folded — there is no empty-relation Plan
+      // node, so a false filter is left filtering correctly (see the deferred
+      // empty-plan follow-up).
+      try optimise(source, context)
     case let .select(filter, .scan(name, ordinals, nil)):
       try seek(filter, name, ordinals, context)
     case let .select(filter, .product(left, right)):

--- a/Sources/SQLEngine/Filter.swift
+++ b/Sources/SQLEngine/Filter.swift
@@ -694,6 +694,69 @@ extension Filter {
     case let .not(operand): operand.parameterised
     }
   }
+
+  /// This filter's PROVABLE two-valued truth INDEPENDENT of any row, binding,
+  /// or subquery — `true` when it is always TRUE, `false` when always FALSE,
+  /// and `nil` when it is not statically decidable (the CONSERVATIVE default).
+  /// A `select` treats UNKNOWN as reject, so the optimiser folds only a
+  /// definite `true` (drops the select) and never mistakes an undecidable
+  /// filter for one.
+  ///
+  /// The ONLY provable leaf is a `compare(a, op, b)` over TWO `.constant`
+  /// operands: it evaluates through the SAME `matches` three-valued primitive
+  /// the executor uses, so a NULL-bearing constant compare is UNKNOWN
+  /// (`matches` yields `nil`) and reports `nil` — NOT provably true and NOT
+  /// provably false — so a `WHERE NULL = 1` is left filtering (correctly
+  /// rejecting), never folded to true. Any other leaf reads a slot, a
+  /// `:parameter`, or a
+  /// subquery — `bound`, a `compare` with a non-constant term, `match`, `null`,
+  /// `membership`, `like`, `between`, `distinct`, `exists`, `within`,
+  /// `quantified` — so its truth is not known here and it reports `nil`. The
+  /// connectives require BOTH operands to be DEFINITE: `and`/`or` report a
+  /// definite result only when neither side is `nil` (an undecidable side makes
+  /// the whole compound `nil`), `not` flips a definite operand, and `truth`
+  /// maps a DEFINITE inner through `tested`. This is STRICTER than the Kleene
+  /// dominance the executor uses (a `false` conjunct or `true` disjunct short-
+  /// circuiting the other side): dominance is sound for COMBINING already-
+  /// evaluated results, but `constant` licenses the optimiser to SKIP a filter
+  /// entirely, and an undecidable operand reads row data and can THROW — so it
+  /// must never be dropped, and its parent can never be a compile-time
+  /// constant.
+  internal var constant: Bool? {
+    switch self {
+    case let .compare(.constant(lhs), op, .constant(rhs)):
+      // Both operands are constants: evaluate through the engine's own
+      // three-valued `matches`. A NULL on either side is UNKNOWN (`nil`) — not
+      // provably true and not provably false — so a NULL-bearing compare is
+      // never folded.
+      matches(lhs, op, rhs)
+    // A comparison against a non-constant term reads a slot or `:parameter`;
+    // its truth is not statically known.
+    case .compare, .bound, .match, .null, .membership, .like, .between,
+         .distinct, .exists, .within, .quantified:
+      nil
+    case let .and(lhs, rhs):
+      // Both operands must be DEFINITE: a compile-time constant is only sound
+      // for FOLDING when the fold skips no runtime work. An undecidable operand
+      // reads row data and can THROW (e.g. `1 / X`), so it MUST be evaluated —
+      // even a `false`/`true` sibling cannot license dropping it. The Kleene
+      // dominance that lets `matches` short-circuit already-evaluated results
+      // is UNSOUND here, where a definite `constant` authorises skipping the
+      // evaluation.
+      if let l = lhs.constant, let r = rhs.constant { l && r } else { nil }
+    case let .or(lhs, rhs):
+      // Both operands must be DEFINITE (see `.and`): a `true` disjunct cannot
+      // license dropping an undecidable sibling that reads row data and may
+      // throw — the parent is a compile-time constant only when both sides are.
+      if let l = lhs.constant, let r = rhs.constant { l || r } else { nil }
+    case let .not(operand):
+      operand.constant.map { !$0 }
+    case let .truth(inner, value, negated):
+      // `IS <truth>` is a DEFINITE two-valued test, but only when the inner's
+      // value is itself statically decided; an undecidable inner leaves `nil`.
+      inner.constant == nil ? nil : tested(inner.constant, value, negated)
+    }
+  }
 }
 
 extension Array where Element == Filter {
@@ -935,6 +998,11 @@ extension Catalog where Self: ~Escapable {
     // An unmatched left row under OUTER APPLY (`.left`) is NULL-extended by the
     // taken width, mirroring `outer(…)`'s NULL-padding of an unmatched row.
     let rightNulls = Record(Array(repeating: .null, count: ordinals.count))
+    // A LATERAL/CROSS/OUTER apply always emits `ON 1 = 1` — a PROVABLY-true
+    // predicate every merged row passes — so a constant-true `on` skips the
+    // redundant per-row `evaluate(paired, on, context)` and admits the pair
+    // directly (identical result). A non-trivial `on` still runs per row.
+    let unconditional = on.constant == true
     for record in left {
       let right = try executed(record, key, correlation, body)
       let width = right.first?.values.count ?? 0
@@ -946,7 +1014,9 @@ extension Catalog where Self: ~Escapable {
       for index in right.indices {
         let taken = instance.record(index, ordinals)
         let paired = record.merged(with: taken)
-        if try evaluate(paired, on, context) == true {
+        let admits =
+            try unconditional ? true : evaluate(paired, on, context) == true
+        if admits {
           records.append(paired)
           matched = true
         }

--- a/Tests/SQLTests/ConstantFoldTests.swift
+++ b/Tests/SQLTests/ConstantFoldTests.swift
@@ -1,0 +1,280 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQLEngine
+
+import SQLTestSupport
+
+// MARK: - Fixtures
+
+/// Parses `text` to a query, failing on any other statement.
+private func parse(query text: String) throws -> Query {
+  guard case let .select(query) = try Statement(parsing: text) else {
+    Issue.record("expected a SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return query
+}
+
+/// A single-relation catalog for the constant-fold result oracles.
+private func numbers() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("N", ["Id": .integer, "V": .text]) {
+      Row(1, "one")
+      Row(2, "two")
+      Row(3, "three")
+    }
+  }
+}
+
+/// A single-row catalog whose `X` is zero — `1 / X` throws `SQLError.divide`
+/// when evaluated, so it is the probe for whether a fold SKIPS a throwing
+/// operand it must not drop.
+private func zero() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("Z", ["X": .integer]) {
+      Row(0)
+    }
+  }
+}
+
+/// A parent `T` and child `S` keyed on `T.Id` — the LATERAL fixture whose right
+/// side VARIES per outer row, so the fold's result-equivalence is a real proof.
+private func lateral() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["Id": .integer]) {
+      Row(1)
+      Row(2)
+      Row(3)
+    }
+    Relation("S", ["k": .integer, "x": .integer]) {
+      Row(1, 100)
+      Row(1, 101)
+      Row(2, 200)
+    }
+  }
+}
+
+/// Whether `plan` reaches ANY `.select` node — a residual per-row filter. The
+/// constant-true fold eliminates a `WHERE 1 = 1` select entirely, so the
+/// optimised plan for such a query reaches none.
+private func selects(_ plan: Plan) -> Bool {
+  switch plan {
+  case .select:
+    true
+  case let .project(_, source):
+    selects(source)
+  case let .sort(_, source):
+    selects(source)
+  case let .limit(_, _, source):
+    selects(source)
+  case let .distinct(source):
+    selects(source)
+  case let .derived(_, sub, _, _):
+    selects(sub)
+  case let .aggregate(_, _, source):
+    selects(source)
+  case let .product(left, right):
+    selects(left) || selects(right)
+  case let .outer(left, right, _, _):
+    selects(left) || selects(right)
+  case let .join(source, _, _, _, _, _, _):
+    selects(source)
+  case let .apply(left, _, _, _, _, _):
+    selects(left)
+  case let .setop(_, left, right, _):
+    selects(left) || selects(right)
+  case .single, .scan:
+    false
+  }
+}
+
+// MARK: - Filter.constant unit tests
+
+/// `Filter.constant` is the SOUND, CONSERVATIVE constant-truth evaluator the
+/// optimiser folds on: `true` only when PROVABLY always TRUE, `false` only when
+/// PROVABLY always FALSE, and `nil` (do NOT fold) for anything that reads a
+/// slot, a `:parameter`, a subquery, or a NULL constant.
+struct FilterConstantTests {
+  @Test func `a constant-true compare is provably true`() {
+    #expect(Filter.compare(.constant(.integer(1)), .equal,
+                           .constant(.integer(1))).constant == true)
+  }
+
+  @Test func `a constant-false compare is provably false`() {
+    #expect(Filter.compare(.constant(.integer(1)), .equal,
+                           .constant(.integer(0))).constant == false)
+  }
+
+  @Test func `a NULL-bearing constant compare is undecidable`() {
+    // `matches` yields UNKNOWN for a NULL on either side, so `constant` is
+    // `nil` — never folded to `true`, so a `WHERE NULL = 1` keeps filtering.
+    #expect(Filter.compare(.constant(.null), .equal,
+                           .constant(.integer(1))).constant == nil)
+    #expect(Filter.compare(.constant(.integer(1)), .equal,
+                           .constant(.null)).constant == nil)
+  }
+
+  @Test func `a slot-bearing compare is undecidable`() {
+    // A comparison against a row slot is not statically known — `nil`.
+    #expect(Filter.compare(.slot(0), .equal,
+                           .constant(.integer(1))).constant == nil)
+  }
+
+  @Test func `AND folds only when BOTH operands are constant`() {
+    let t = Filter.compare(.constant(.integer(1)), .equal,
+                           .constant(.integer(1)))
+    let f = Filter.compare(.constant(.integer(1)), .equal,
+                           .constant(.integer(0)))
+    let slot = Filter.compare(.slot(0), .equal, .constant(.integer(1)))
+    #expect(Filter.and(t, t).constant == true)
+    #expect(Filter.and(t, f).constant == false)
+    // An undecidable operand can read row data and THROW, so it must be
+    // evaluated at runtime — a `false`/`true` sibling cannot license folding
+    // the compound away. Either side undecidable ⇒ the compound is undecidable.
+    #expect(Filter.and(f, slot).constant == nil)
+    #expect(Filter.and(t, slot).constant == nil)
+    #expect(Filter.and(slot, f).constant == nil)
+  }
+
+  @Test func `OR folds only when BOTH operands are constant`() {
+    let t = Filter.compare(.constant(.integer(1)), .equal,
+                           .constant(.integer(1)))
+    let f = Filter.compare(.constant(.integer(1)), .equal,
+                           .constant(.integer(0)))
+    let slot = Filter.compare(.slot(0), .equal, .constant(.integer(1)))
+    #expect(Filter.or(f, f).constant == false)
+    #expect(Filter.or(t, f).constant == true)
+    // A `true` disjunct cannot license dropping an undecidable sibling that
+    // reads row data and may throw. Either side undecidable ⇒ undecidable.
+    #expect(Filter.or(t, slot).constant == nil)
+    #expect(Filter.or(f, slot).constant == nil)
+    #expect(Filter.or(slot, t).constant == nil)
+  }
+
+  @Test func `NOT flips a definite value and preserves undecidable`() {
+    let t = Filter.compare(.constant(.integer(1)), .equal,
+                           .constant(.integer(1)))
+    let slot = Filter.compare(.slot(0), .equal, .constant(.integer(1)))
+    #expect(Filter.not(t).constant == false)
+    #expect(Filter.not(slot).constant == nil)
+  }
+}
+
+// MARK: - Optimiser fold: WHERE result equivalence + plan shape
+
+/// The optimiser drops a PROVABLY-true `WHERE` (identical result, one fewer
+/// per-row predicate) and NEVER folds a false or NULL-bearing one.
+struct ConstantSelectFoldTests {
+  @Test func `WHERE 1 = 1 yields the same rows as no WHERE`() throws {
+    // A constant-true filter admits every row: the folded query yields exactly
+    // the unfiltered result.
+    try numbers().expect("SELECT Id, V FROM N WHERE 1 = 1 ORDER BY Id",
+                         equals: "SELECT Id, V FROM N ORDER BY Id")
+  }
+
+  @Test func `WHERE 1 = 1 optimises away the select node`() throws {
+    // Plan-shape proof: the always-true select is GONE after optimisation — the
+    // fold left a plain scan, not a select over a true residual.
+    let catalog = try numbers()
+    let plan = try catalog.optimise(
+        catalog.compile(parse(query: "SELECT Id FROM N WHERE 1 = 1")), [:])
+    #expect(!selects(plan))
+  }
+
+  @Test func `a genuine WHERE keeps its select node`() throws {
+    // Contrast: a slot-bearing predicate is NOT folded, so its select
+    // survives — the fold is scoped to provable constants only.
+    let catalog = try numbers()
+    let plan = try catalog.optimise(
+        catalog.compile(parse(query: "SELECT Id FROM N WHERE Id = 2")), [:])
+    #expect(selects(plan))
+  }
+
+  @Test func `WHERE 1 = 0 still returns no rows`() throws {
+    // A constant-FALSE filter is left filtering (there is no empty-relation
+    // node) and correctly rejects every row — proving false is NOT mis-folded.
+    try numbers().empty("SELECT Id FROM N WHERE 1 = 0")
+  }
+
+  @Test func `WHERE NULL = 1 returns no rows (UNKNOWN rejects)`() throws {
+    // A NULL operand makes the compare UNKNOWN; `constant` returns `nil` for a
+    // NULL-bearing constant compare (unit-tested directly on
+    // `Filter.constant`), so it is NOT folded. `NULL` is unspellable as a bare
+    // comparison
+    // operand here — the parser accepts it only in `IS NULL` — so the SQL-level
+    // guard spells the NULL with `NULLIF(1, 1)` (a constant expression that
+    // evaluates to NULL): the compare is not a two-constant leaf, so it stays,
+    // evaluates UNKNOWN per row, and correctly rejects every row.
+    try numbers().empty("SELECT Id FROM N WHERE NULLIF(1, 1) = 1")
+  }
+
+  @Test func `WHERE 1 = NULL returns no rows (UNKNOWN rejects)`() throws {
+    try numbers().empty("SELECT Id FROM N WHERE 1 = NULLIF(1, 1)")
+  }
+
+  @Test func `an always-true OR does NOT drop a throwing operand`() throws {
+    // The reviewer case: `(1 / X) = 0` reads a row slot and, with `X = 0`,
+    // THROWS `SQLError.divide` when evaluated. The `OR 1 = 1` disjunct is
+    // constant-true, but the compound OR is NOT a compile-time constant (the
+    // left disjunct is undecidable), so the predicate is NOT folded away — it
+    // runs per row and the division-by-zero surfaces. Folding it would silently
+    // return the row.
+    try zero().expect("SELECT X FROM Z WHERE (1 / X) = 0 OR 1 = 1",
+                      fails: .divide)
+  }
+
+  @Test func `a constant-false AND still evaluates a throwing conjunct`()
+      throws {
+    // Symmetric guard: `1 = 0` is constant-false and `(1 / X) = 0` is
+    // undecidable, so the AND is undecidable (not the pre-fix definite
+    // `false`). The predicate stays and evaluates per row, raising `.divide` —
+    // no fold may classify this compound and license skipping the throwing
+    // conjunct.
+    try zero().expect("SELECT X FROM Z WHERE (1 / X) = 0 AND 1 = 0",
+                      fails: .divide)
+  }
+}
+
+// MARK: - Apply ON-skip: LATERAL result equivalence
+
+/// A LATERAL apply always emits `ON 1 = 1`; the executor skips the redundant
+/// per-row `ON` check for a constant-true predicate — the fold changes the
+/// plan/execution, never the rows.
+struct ConstantApplyFoldTests {
+  @Test func `a LATERAL ON 1 = 1 yields the known-correct rows`() throws {
+    // The SAME rows the un-folded lateral fixture produces: Id 1 → {100, 101},
+    // Id 2 → {200}, Id 3 → {} (dropped, INNER apply). The constant-true `ON`
+    // skip admits every merged row directly — identical result.
+    try lateral().expect(
+        "SELECT T.Id, d.x FROM T " +
+        "JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON 1 = 1 " +
+        "ORDER BY T.Id, d.x",
+        yields: [[1, 100], [1, 101], [2, 200]])
+  }
+
+  @Test func `a LATERAL ON does NOT skip a throwing predicate`() throws {
+    // The apply's `ON` is not always `1 = 1`: `(1 / (T.Id - 1)) = 0 OR 1 = 1`
+    // has an undecidable, throwing left disjunct, so the compound is NOT a
+    // compile-time constant and the `ON` is NOT skipped. The outer `T.Id = 1`
+    // makes the divisor zero, so the per-row `ON` evaluation raises `.divide`
+    // rather than admitting rows.
+    try lateral().expect(
+        "SELECT T.Id, d.x FROM T " +
+        "JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d " +
+        "ON (1 / (T.Id - 1)) = 0 OR 1 = 1 " +
+        "ORDER BY T.Id, d.x",
+        fails: .divide)
+  }
+
+  @Test func `a LATERAL with a real ON still filters per row`() throws {
+    // Contrast: a non-trivial `ON d.x > 100` is NOT constant-true, so it still
+    // runs per merged row and filters — the skip is scoped to provable truth.
+    try lateral().expect(
+        "SELECT T.Id, d.x FROM T " +
+        "JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON d.x > 100 " +
+        "ORDER BY T.Id, d.x",
+        yields: [[1, 101], [2, 200]])
+  }
+}


### PR DESCRIPTION
Add `Filter.constant`, a sound, conservative constant-truth evaluator that proves a filter always TRUE/FALSE only when it reads no row data — a `compare` over two `.constant` operands (through the engine's own three-valued `matches`, so a NULL-bearing compare stays undecidable) and the `and`/`or`/`not`/`truth` connectives over definite operands.

The optimiser now drops a provably-true `select` (identical result, one fewer per-row predicate), composing with the seek and nest rewrites, and the LATERAL/CROSS/OUTER apply executor skips the redundant per-row check for a constant-true `ON` (the `ON 1 = 1` every apply emits). A constant-false filter is left filtering — there is no empty-relation plan node yet.