### PR TITLE
SQLEngine: decorrelate CROSS APPLY into an inner join

### DIFF
--- a/Sources/SQLEngine/Engine.swift
+++ b/Sources/SQLEngine/Engine.swift
@@ -212,7 +212,13 @@ extension Catalog where Self: ~Escapable {
     // The shared box survives from the un-augmented compile into execution.
     augmented.subqueries.record(overlay: augmented.revealed().relations,
                                 for: .caller)
-    let plan = try optimise(logical, augmented)
+    // Rewrite each decorrelatable correlated CROSS APPLY into a set-based join
+    // BEFORE the physical `optimise`/`nest`, so the emitted `select`-over-
+    // `product` folds to a hash equi-join. The pass reads the compiled body
+    // plans recorded above into the shared subquery box; a non-decorrelatable
+    // apply is left verbatim, so a plan with none is unchanged.
+    let decorrelated = try decorrelate(logical, augmented)
+    let plan = try optimise(decorrelated, augmented)
     return try execute(plan, augmented).map(\.values)
   }
 
@@ -2379,6 +2385,250 @@ extension Catalog where Self: ~Escapable {
     return try filter.gated(over: .product(optimise(left, context),
                                            optimise(right, context)))
   }
+
+  // MARK: - Decorrelation
+
+  /// Rewrites a decorrelatable correlated CROSS APPLY into a set-based inner
+  /// join — a behaviour-preserving LOGICAL pass run AFTER `pushdown` (so each
+  /// `.apply` body is already in `project`/`select`/`scan` canonical form) and
+  /// BEFORE `optimise`/`nest` (so the emitted `.select`-over-`.product` folds
+  /// to a `.join` for free). It recurses the tree structurally, leaving every
+  /// node but a decorrelatable `.apply` untouched, so a plan with none is
+  /// returned unchanged.
+  ///
+  /// At each `.apply(left, key, correlation, ordinals, on, kind: .inner)` it
+  /// consults the pre-compiled body plan (`context.subqueries.plan(key,
+  /// correlation)`, the SAME lookup `executed` uses) and, when the body is a
+  /// simple filter+project over a single base-relation scan with a purely EQUI
+  /// correlation, rewrites the apply to `project(over left ++ taken,
+  /// select(on'', product(left, scan(R))))` — the exact output geometry the
+  /// correlated `applied` produces (each left row multiplied by its match
+  /// count, an unmatched left row DROPPED), which the subsequent `nest` folds
+  /// to a hash equi-join. On ANY doubt (a non-`.inner` kind, a
+  /// non-decorrelatable body, a non-equi/expression correlation, an unsafe body
+  /// term, or a taken-ordinals geometry it cannot map soundly) it leaves the
+  /// `.apply` verbatim, so execution is unchanged — a missed decorrelation is a
+  /// perf loss, a wrong one is silent data corruption.
+  internal borrowing func decorrelate(_ plan: Plan, _ context: Context)
+      throws(SQLError) -> Plan {
+    switch plan {
+    case .single, .scan, .join:
+      return plan
+    case let .derived(name, plan, ordinals, seek):
+      // A view body is compiled and re-executed under its OWN scope; its
+      // correlated applies (if any) decorrelate when it is derived/optimised,
+      // not here. Recurse structurally only.
+      return try .derived(name: name, plan: decorrelate(plan, context),
+                          ordinals: ordinals, seek: seek)
+    case let .select(filter, source):
+      return try .select(filter, decorrelate(source, context))
+    case let .project(terms, source):
+      return try .project(terms, decorrelate(source, context))
+    case let .sort(keys, source):
+      return try .sort(keys: keys, decorrelate(source, context))
+    case let .product(left, right):
+      return try .product(decorrelate(left, context),
+                          decorrelate(right, context))
+    case let .outer(left, right, on, kind):
+      return try .outer(decorrelate(left, context), decorrelate(right, context),
+                        on: on, kind: kind)
+    case let .apply(left, key, correlation, ordinals, on, kind):
+      // Decorrelate the LEFT first (a nested apply inside it still rewrites),
+      // then attempt this apply. `.left` (OUTER APPLY) is deferred to a later
+      // PR; only `.inner` (CROSS APPLY) is a candidate here.
+      let left = try decorrelate(left, context)
+      guard kind == .inner,
+          let body = context.subqueries.plan(key, correlation),
+          let rewritten = decorrelated(apply: left, body, key, correlation,
+                                       ordinals, on, context) else {
+        return .apply(left, key: key, correlation: correlation,
+                      ordinals: ordinals, on: on, kind: kind)
+      }
+      return rewritten
+    case let .setop(kind, left, right, all):
+      return try .setop(kind, decorrelate(left, context),
+                        decorrelate(right, context), all: all)
+    case let .distinct(source):
+      return try .distinct(decorrelate(source, context))
+    case let .aggregate(keys, aggregates, source):
+      return try .aggregate(keys: keys, aggregates: aggregates,
+                            decorrelate(source, context))
+    case let .limit(count, offset, source):
+      return try .limit(count: count, offset: offset,
+                        decorrelate(source, context))
+    }
+  }
+
+  /// The inner-join rewrite of a CROSS APPLY whose `left` is already
+  /// decorrelated, or `nil` when the apply's `body` is not decorrelatable — in
+  /// which case the caller leaves the `.apply` unchanged (conservative
+  /// default).
+  ///
+  /// The body must be `project(projection, select(where, scan(R, _, nil)))`
+  /// with every projection term a bare slot (G3: a filter+project over a single
+  /// base relation, no aggregate/limit/distinct/setop/nested apply — none of
+  /// which wear this exact shape), the correlation must be all `.slot` sources
+  /// (no `.bound` grandparent), and the `where` conjuncts must be EXACTLY one
+  /// equi correlation `innerKey = :param` (or the reversed order) plus safe,
+  /// non-parameterised, single-relation local predicates `p_R` (G4: an unsafe
+  /// or parameterised residual — a non-equi/expression correlation — bails).
+  /// The scan's `seek` must be absent (a seeked body is not the canonical
+  /// shape).
+  ///
+  /// The rewrite lays the body scan's referenced ordinals after the left (a
+  /// `.product`), then stacks TWO selects: an INNER select carrying the WHOLE
+  /// body WHERE (the correlation equality `.match(outerSlot, base + innerKey)`
+  /// AND the local residual `p_R`) and an OUTER select carrying the apply's
+  /// `on` — the apply's `on` mapped from its `left ++ taken` space into this
+  /// `left ++ scan` space. The `on` is kept SEPARATE (not folded into the body
+  /// residual's conjunction) so it is evaluated ONLY on rows the body WHERE
+  /// admitted: nested selects run bottom-up, restoring the correlated order
+  /// (body WHERE → drop an UNKNOWN row → `on`), so an `on` that would throw on
+  /// a row the body WHERE drops never fires — matching the correlated `applied`
+  /// (which never reaches the `on` for a dropped row). It then PROJECTS the
+  /// result back to the apply's `left ++ taken` geometry, so the combined
+  /// record a parent reads is byte-identical to the correlated `applied`'s. The
+  /// equi `.match` lets `nest`/`optimise` fold the product into a hash
+  /// equi-join whose NULL-key drops and match-count multiplicity mirror the
+  /// per-row re-execution.
+  private borrowing func decorrelated(apply left: Plan, _ body: Plan,
+                                      _ key: Subkey,
+                                      _ correlation: Correlation,
+                                      _ ordinals: Array<Int>, _ on: Filter,
+                                      _ context: Context) -> Plan? {
+    guard case let .project(projection, .select(filter, scan)) = body,
+        case let .scan(name, scanOrdinals, nil) = scan,
+        let base = left.slots else { return nil }
+    // The scanned `name` must be a genuine BASE relation, not a BODY-LOCAL
+    // derived alias. When the lateral body declares its OWN derived table(s) —
+    // `SELECT x FROM (SELECT k, x FROM S) AS e WHERE …` — the compiled body
+    // plan scans that alias (`e`), which the correlated `applied` executor
+    // MATERIALISES per execution under the body's revealed overlay. The
+    // caller-level checks below (a CTE/store overlay entry, a view) do not see
+    // `e`, so it would pass as a base relation and the rewrite would relay a
+    // caller-level `scan("e")` that faults `.relation("e")` or, worse, binds a
+    // same-named OUTER base table and returns WRONG rows. Bail whenever the
+    // body query declares any derived tables of its own — the SAME
+    // `collect(derived:)` the augment path uses over the body select — and
+    // leave the apply correlated.
+    var derivations = Array<(String, Query)>()
+    key.query.collect(derived: &derivations)
+    guard derivations.isEmpty else { return nil }
+    // The scan must also name a genuine BASE relation, not a CTE/store overlay
+    // entry or a view. A CTE `.scan` binds under the body's OWN revealed
+    // overlay (a caller derived alias of the same name shadowed) that the
+    // `applied` executor restores per run; relaid into a caller-level join it
+    // would re-resolve the name against the OUTER overlay and bind the wrong
+    // relation. A view `.scan` (a `.derived` after resolution) is likewise out
+    // of the single-base-relation cut. Leave either correlated.
+    guard context.relations[name.lowercased()] == nil,
+        resolve(view: name) == nil else { return nil }
+    // Every projection term must be a bare slot: a projected expression (a
+    // LATERAL-only shape over a preceding column, or any computed column) has a
+    // slot geometry the scan-relaid rewrite cannot reproduce, so bail.
+    var projected = Array<Int>()
+    for term in projection {
+      guard case let .slot(slot) = term else { return nil }
+      projected.append(slot)
+    }
+    // A taken ordinal at or beyond the projection's width is the body's virtual
+    // `Id` — a LATERAL-only per-left-row row number the `applied` executor
+    // derives from THIS left row's output through a `RelationInstance`, which a
+    // set-based join (numbering over the whole relation) cannot reproduce.
+    // Leave it correlated.
+    guard ordinals.allSatisfy({ projection.indices.contains($0) }) else {
+      return nil
+    }
+    // The correlation must be a single `.slot` source (no `.bound` grandparent
+    // this v1 decorrelates). The outer key is that source's ordinal, already in
+    // the left's combined slot space.
+    guard correlation.count == 1,
+        case let (name: parameter, source: .slot(outerKey))? =
+            correlation.first.map({ (name: $0.key, source: $0.value) })
+        else { return nil }
+
+    // Split the body WHERE into the ONE equi correlation conjunct (`innerKey =
+    // :parameter`) and the local residual `p_R`. Any other parameterised
+    // conjunct is a non-equi/expression correlation — bail. Every residual must
+    // be safe (G4: a throwing body term could fire for an inner row no left row
+    // reaches under set-based execution).
+    var innerKey: Int? = nil
+    var residual = Array<Filter>()
+    for conjunct in filter.conjuncts {
+      if innerKey == nil, let slot = equated(conjunct, to: parameter) {
+        innerKey = slot
+        continue
+      }
+      guard conjunct.safe, !conjunct.parameterised else { return nil }
+      residual.append(conjunct)
+    }
+    guard let innerKey else { return nil }
+
+    // The scan is relaid after the left, so the body's 0-based scan slots shift
+    // by `base` into the combined space. The correlation equality becomes a
+    // `.match` `nest` folds to the join key; the residual `p_R` shifts
+    // alongside. This inner gate carries the WHOLE body WHERE (match key +
+    // residual) and NOTHING else — the apply's `on` is kept ABOVE it.
+    let inner = Plan.scan(name: name, ordinals: scanOrdinals, seek: nil)
+    var gate = [Filter.match(outerKey, base + innerKey)]
+    gate.append(contentsOf: residual.map { $0.shifted(by: -base) })
+    let product = Plan.product(left, inner)
+    let filtered = gate.conjunction.map { Plan.select($0, product) } ?? product
+    // The apply's `on` addresses the `left ++ taken` space; map it into this
+    // `left ++ scan` space (taken column `base + j` becomes the scan slot `base
+    // + projected[ordinals[j]]` its projection read). Keep it in a SEPARATE
+    // select ABOVE the body-filtered join rather than folding it into the same
+    // conjunction as the body residual. The correlated `applied` evaluates the
+    // body WHERE FIRST (dropping an UNKNOWN row — a NULL-flag child) and only
+    // THEN the `on`, so an `on` that would throw on a dropped row never fires.
+    // This engine evaluates an `AND`'s RHS even for an UNKNOWN LHS, so folding
+    // `on` into the residual conjunction would evaluate it for a dropped row
+    // and raise a fault the original APPLY never hits. Nested selects evaluate
+    // bottom-up, so an OUTER `on` sees only the rows the body WHERE admitted —
+    // restoring the correlated order (body WHERE → drop → on).
+    let mapped =
+        on.remapped(through: remap(taken: ordinals, over: base, projected))
+    let gated = mapped.constant == true ? filtered : .select(mapped, filtered)
+    // Project back to the apply's exact `left ++ taken` geometry: the left's
+    // slots unchanged, then each taken column at its combined scan slot.
+    var terms = (0 ..< base).map { Term.slot($0) }
+    terms.append(contentsOf: ordinals.map { Term.slot(base + projected[$0]) })
+    return .project(terms, gated)
+  }
+}
+
+/// The inner-key slot of an EQUI correlation conjunct `slot = :parameter` (in
+/// either operand order), or `nil` when `conjunct` is not that shape — a
+/// comparison of a bare slot to the correlation `parameter` under `=`. A
+/// non-`=` comparison (a NON-equi correlation), a compound operand, or a
+/// different parameter is not an equi correlation key and leaves the conjunct
+/// to the residual test (which bails on it as a parameterised non-equi term).
+private func equated(_ conjunct: Filter, to parameter: String) -> Int? {
+  guard case let .compare(lhs, .equal, rhs) = conjunct else { return nil }
+  switch (lhs, rhs) {
+  case let (.slot(slot), .parameter(name)) where name == parameter:
+    return slot
+  case let (.parameter(name), .slot(slot)) where name == parameter:
+    return slot
+  default:
+    return nil
+  }
+}
+
+/// The slot remap from a CROSS APPLY's `left ++ taken` output space into the
+/// decorrelated `left ++ scan` space: a left slot (`< base`) is unchanged, and
+/// the `j`-th taken column (slot `base + j`, reading body-output column
+/// `ordinals[j]`) maps to the scan slot `base + projected[ordinals[j]]` its
+/// projection read. `on` is remapped through this so it addresses the relaid
+/// scan's slots rather than the apply's taken columns.
+private func remap(taken ordinals: Array<Int>, over base: Int,
+                   _ projected: Array<Int>) -> Dictionary<Int, Int> {
+  var map = Dictionary<Int, Int>(minimumCapacity: base + ordinals.count)
+  for slot in 0 ..< base { map[slot] = slot }
+  for taken in ordinals.indices {
+    map[base + taken] = base + projected[ordinals[taken]]
+  }
+  return map
 }
 
 /// The `(outerKey, innerKey)` an equality between slots `lhs` and `rhs`

--- a/Sources/SQLEngine/Operator.swift
+++ b/Sources/SQLEngine/Operator.swift
@@ -297,8 +297,16 @@ extension Plan {
       // A grouped record reshapes its source into the key values followed by
       // the aggregate results — a fresh slot space of that width.
       keys.count + aggregates.count
-    default:
-      nil
+    case let .project(terms, _):
+      // A projection's output is exactly its projected terms, so the next
+      // relation's slots begin at `terms.count` — regardless of the source's
+      // width. A decorrelated CROSS APPLY tops out in a `project`, so this is
+      // what lets it measure correctly as the left side of an outer join.
+      terms.count
+    case let .sort(_, source):
+      // A `sort` reorders rows without reshaping them, so it spans the same
+      // slots as its source.
+      source.slots
     }
   }
 

--- a/Tests/SQLTests/DecorrelateTests.swift
+++ b/Tests/SQLTests/DecorrelateTests.swift
@@ -1,0 +1,496 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQLEngine
+
+import SQLTestSupport
+
+/// Behaviour-preserving oracles for the CROSS APPLY → inner-join decorrelation
+/// pass. A decorrelation bug is a SILENT wrong-results bug, so every case
+/// compares the run result against the KNOWN-CORRECT multiset the correlated
+/// `applied` executor produces — same rows, same duplicates, same drops — and
+/// pins the plan shape: a decorrelatable CROSS APPLY becomes a `.join` with NO
+/// `.apply` node, and an EXCLUDED body stays an `.apply`, run correctly.
+
+/// Parses `text` to a query, failing on any other statement.
+private func query(_ text: String) throws -> Query {
+  guard case let .select(query) = try Statement(parsing: text) else {
+    Issue.record("expected a SELECT statement")
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return query
+}
+
+/// Whether `plan` (or any descendant) carries a correlated `.apply` node — the
+/// witness a shape was NOT decorrelated.
+private func applies(_ plan: Plan) -> Bool {
+  switch plan {
+  case .apply:
+    return true
+  case let .derived(_, source, _, _):
+    return applies(source)
+  case let .select(_, source), let .project(_, source), let .sort(_, source),
+       let .distinct(source), let .limit(_, _, source),
+       let .aggregate(_, _, source):
+    return applies(source)
+  case let .product(left, right), let .outer(left, right, _, _),
+       let .setop(_, left, right, _):
+    return applies(left) || applies(right)
+  case .single, .scan, .join:
+    return false
+  }
+}
+
+/// Whether `plan` (or any descendant) carries a `.join` node — the witness the
+/// decorrelated product folded to a hash equi-join.
+private func joins(_ plan: Plan) -> Bool {
+  switch plan {
+  case .join:
+    return true
+  case let .derived(_, source, _, _):
+    return joins(source)
+  case let .select(_, source), let .project(_, source), let .sort(_, source),
+       let .distinct(source), let .limit(_, _, source),
+       let .aggregate(_, _, source):
+    return joins(source)
+  case let .product(left, right), let .outer(left, right, _, _),
+       let .setop(_, left, right, _):
+    return joins(left) || joins(right)
+  case .single, .scan, .apply:
+    return false
+  }
+}
+
+extension Catalog where Self: ~Escapable {
+  /// The optimised plan for `sql`, threading a shared subquery box through the
+  /// SAME compile → pushdown → decorrelate → optimise pipeline `run` uses, so a
+  /// plan-shape assertion sees the very plan the executor runs. The overlay is
+  /// recorded and this query's derived tables are materialised exactly as `run`
+  /// does, so a correlated body's plan is compiled into the box the decorrelate
+  /// pass reads.
+  fileprivate borrowing func optimised(_ sql: String) throws -> Plan {
+    let parsed = try query(sql)
+    let context = Context().resolving(Subqueries())
+    let logical = try compile(parsed, context.validating(false)).pushdown()
+    let augmented = try augment(context.validating(false), for: parsed,
+                                rows: true)
+    augmented.subqueries.record(overlay: augmented.revealed().relations,
+                                for: .caller)
+    return try optimise(decorrelate(logical, augmented), augmented)
+  }
+}
+
+/// A parent `T` and a child `S` keyed on `T.Id` — Id 1 has TWO children, Id 2
+/// one, Id 3 none — the duplicate-match and no-match shapes a CROSS APPLY
+/// multiplies and drops.
+private func fixture() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["Id": .integer]) {
+      Row(1)
+      Row(2)
+      Row(3)
+    }
+    Relation("S", ["k": .integer, "x": .integer]) {
+      Row(1, 100)
+      Row(1, 101)
+      Row(2, 200)
+    }
+  }
+}
+
+/// A `T` with a NULL-keyed child in `S` — a NULL correlation key equi-joins to
+/// nothing, exactly as the per-row `WHERE S.k = :outer` (`:outer` NULL ⇒
+/// UNKNOWN) admits nothing.
+private func nullFixture() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["Id": .integer]) {
+      Row(1)
+      Row(nil)            // a NULL outer key
+    }
+    Relation("S", ["k": .integer, "x": .integer]) {
+      Row(1, 100)
+      Row(nil, 999)       // a NULL inner key — never equi-matches
+    }
+  }
+}
+
+// MARK: - Decorrelatable CROSS APPLY: result-equivalence + plan shape
+
+struct DecorrelateCrossApplyTests {
+  /// The canonical CROSS APPLY: a left row is multiplied by its match count and
+  /// an unmatched left row is dropped — the SAME multiset the correlated
+  /// `applied` produces (Id 1 → {100, 101}, Id 2 → {200}, Id 3 → dropped).
+  @Test func `a CROSS APPLY equi body yields the correlated multiset`() throws {
+    try fixture().expect(
+        "SELECT T.Id, d.x FROM T " +
+        "JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON 1 = 1 " +
+        "ORDER BY T.Id, d.x",
+        yields: [[1, 100], [1, 101], [2, 200]])
+  }
+
+  /// DUPLICATE MATCHES: Id 1 matches two inner rows and appears TWICE — the
+  /// join multiplies the left row by the match count, it is NOT deduped.
+  @Test func `a left row matching many inner rows is multiplied not deduped`()
+      throws {
+    let rows = try fixture().run(query(
+        "SELECT T.Id FROM T " +
+        "JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON 1 = 1 " +
+        "ORDER BY T.Id"), .standard)
+    // Id 1 twice (two children), Id 2 once — NO dedup, NO Id 3.
+    #expect(rows == [[.integer(1)], [.integer(1)], [.integer(2)]])
+  }
+
+  /// NO MATCH: Id 3 has no child, so the INNER join DROPS it — never NULL-
+  /// extended, exactly as CROSS APPLY drops an unmatched left row.
+  @Test func `a left row with no match is dropped`() throws {
+    let rows = try fixture().run(query(
+        "SELECT T.Id FROM T " +
+        "JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON 1 = 1"),
+        .standard)
+    #expect(!rows.contains([.integer(3)]))
+  }
+
+  /// A NULL correlation key matches nothing (NULL ≠ NULL) — the left row with a
+  /// NULL `Id` is dropped, and the inner NULL-keyed row `(NULL, 999)` never
+  /// pairs — identical to the per-row `WHERE S.k = :outer` NULL-drop.
+  @Test func `a NULL correlation key drops the left row`() throws {
+    try nullFixture().expect(
+        "SELECT T.Id, d.x FROM T " +
+        "JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON 1 = 1 " +
+        "ORDER BY T.Id",
+        yields: [[1, 100]])
+  }
+
+  /// The apply's `ON` further filters the merged pair — the residual rides the
+  /// combined-space `.select` over the join, so only children with `x > 100`
+  /// survive (Id 1 keeps 101, Id 2 keeps 200), exactly as `applied`'s per-pair
+  /// `ON` admits.
+  @Test func `the apply ON filters the decorrelated pair`() throws {
+    try fixture().expect(
+        "SELECT T.Id, d.x FROM T " +
+        "JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON d.x > 100 " +
+        "ORDER BY T.Id, d.x",
+        yields: [[1, 101], [2, 200]])
+  }
+
+  /// A safe local residual `p_R` in the body WHERE (`S.x < 200`) rides the join
+  /// alongside the correlation key — Id 1 keeps both children, Id 2 loses 200.
+  @Test func `a safe local body predicate rides the decorrelated join`()
+      throws {
+    try fixture().expect(
+        "SELECT T.Id, d.x FROM T " +
+        "JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id AND S.x < 200) AS d " +
+        "ON 1 = 1 ORDER BY T.Id, d.x",
+        yields: [[1, 100], [1, 101]])
+  }
+
+  /// PLAN SHAPE: the decorrelatable CROSS APPLY optimises to a `.join` with NO
+  /// `.apply` node remaining — the pass fired.
+  @Test func `a decorrelatable CROSS APPLY optimises to a join`() throws {
+    let plan = try fixture().optimised(
+        "SELECT T.Id, d.x FROM T " +
+        "JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON 1 = 1")
+    #expect(!applies(plan))
+    #expect(joins(plan))
+  }
+
+  /// PLAN SHAPE: a residual `ON` and a local body predicate still decorrelate —
+  /// no `.apply` node survives.
+  @Test func `a CROSS APPLY with ON and body predicate decorrelates`() throws {
+    let plan = try fixture().optimised(
+        "SELECT T.Id, d.x FROM T " +
+        "JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id AND S.x < 200) AS d " +
+        "ON d.x > 50")
+    #expect(!applies(plan))
+    #expect(joins(plan))
+  }
+}
+
+// MARK: - Excluded bodies: STAY correlated, run correctly
+
+struct DecorrelateExclusionTests {
+  /// (a) AGGREGATE body: a `COUNT(*)` body is not a plain filter+project, so it
+  /// stays an `.apply` — and still runs correctly (Id 1 → 2, Id 2 → 1, Id 3 → 0
+  /// dropped by the `ON d.n > 0`).
+  @Test func `an aggregate body stays an apply and runs correctly`() throws {
+    let sql =
+        "SELECT T.Id, d.n FROM T " +
+        "JOIN LATERAL (SELECT COUNT(*) AS n FROM S WHERE S.k = T.Id) AS d " +
+        "ON d.n > 0"
+    let plan = try fixture().optimised(sql)
+    #expect(applies(plan))                     // NOT decorrelated
+    try fixture().expect(sql + " ORDER BY T.Id", yields: [[1, 2], [2, 1]])
+  }
+
+  /// (b) NON-EQUI correlation: `S.k > T.Id` has no equi-key to hash on, so it
+  /// stays an `.apply` — and runs correctly (Id 1 matches k∈{2}? no; the child
+  /// keys are 1,1,2, so `S.k > T.Id` for Id 1 → k=2 → x=200; Id 2 → none).
+  @Test func `a non-equi correlation stays an apply and runs correctly`()
+      throws {
+    let sql =
+        "SELECT T.Id, d.x FROM T " +
+        "JOIN LATERAL (SELECT x FROM S WHERE S.k > T.Id) AS d ON 1 = 1"
+    let plan = try fixture().optimised(sql)
+    #expect(applies(plan))                     // NOT decorrelated
+    // Id 1: children with k > 1 → k=2 → x=200. Id 2: k > 2 → none. Id 3: none.
+    try fixture().expect(sql + " ORDER BY T.Id, d.x", yields: [[1, 200]])
+  }
+
+  /// (c) THROWING body term (G4): a body WHERE conjunct `1 / (S.x - 100) > 0`
+  /// divides by zero on the inner row `(1, 100)`. Under the per-row correlated
+  /// run the divide fires only for a left row that reaches that inner row; a
+  /// set-based join over the whole `S` would evaluate it for every inner row.
+  /// The recogniser LEAVES it correlated (the conjunct is unsafe), and the run
+  /// still raises `.divide` exactly as the correlated path does.
+  @Test func `a throwing body term stays an apply and still throws`() throws {
+    let sql =
+        "SELECT T.Id, d.x FROM T " +
+        "JOIN LATERAL " +
+        "(SELECT x FROM S WHERE S.k = T.Id AND 1 / (S.x - 100) > 0) AS d " +
+        "ON 1 = 1"
+    let plan = try fixture().optimised(sql)
+    #expect(applies(plan))                     // NOT decorrelated (unsafe body)
+    // The correlated run reaches the divide (Id 1's child x=100) and raises.
+    try fixture().expect(sql, fails: .divide)
+  }
+}
+
+// MARK: - Body-local derived aliases: STAY correlated (item 1)
+
+struct DecorrelateBodyDerivedTests {
+  /// A parent `T` and a child `S`, PLUS a BASE table also named `e` carrying
+  /// unrelated rows — so a rewrite that wrongly relaid a caller-level
+  /// `scan("e")` would bind THIS base `e` and return its rows rather than the
+  /// body's own derived `e`.
+  private func shadowFixture() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["Id": .integer]) {
+        Row(1)
+        Row(2)
+        Row(3)
+      }
+      Relation("S", ["k": .integer, "x": .integer]) {
+        Row(1, 100)
+        Row(1, 101)
+        Row(2, 200)
+      }
+      // A BASE relation named `e` whose rows must NEVER surface — the body's
+      // own derived `e` shadows it. A decorrelation that relaid `scan("e")` at
+      // the caller would bind these instead.
+      Relation("e", ["k": .integer, "x": .integer]) {
+        Row(1, 900)
+        Row(2, 901)
+      }
+    }
+  }
+
+  /// A lateral body reading its OWN derived table `e` must NOT decorrelate: the
+  /// compiled body plan scans the body-local alias `e`, which the correlated
+  /// `applied` materialises per execution. Relaid as a caller-level `scan("e")`
+  /// the rewrite would fault or bind an outer relation. The recogniser leaves
+  /// it correlated.
+  @Test func `a body-local derived alias stays an apply`() throws {
+    let plan = try shadowFixture().optimised(
+        "SELECT d.x FROM T " +
+        "JOIN LATERAL (SELECT x FROM (SELECT k, x FROM S) AS e " +
+        "WHERE e.k = T.Id) AS d ON 1 = 1")
+    #expect(applies(plan))                       // NOT decorrelated
+  }
+
+  /// The same body run: the derived `e` reads `S` (100, 101, 200), NOT the
+  /// BASE `e` (900, 901). Id 1 → {100, 101}, Id 2 → {200}, Id 3 → dropped —
+  /// identical to the correlated multiset.
+  @Test func `a body-local derived alias runs correctly`() throws {
+    try shadowFixture().expect(
+        "SELECT T.Id, d.x FROM T " +
+        "JOIN LATERAL (SELECT x FROM (SELECT k, x FROM S) AS e " +
+        "WHERE e.k = T.Id) AS d ON 1 = 1 ORDER BY T.Id, d.x",
+        yields: [[1, 100], [1, 101], [2, 200]])
+  }
+}
+
+// MARK: - APPLY ON behind a nullable body filter (item 2)
+
+struct DecorrelateOnOrderTests {
+  /// A parent `T` and a child `S` whose `flag` is NULL for one child. The body
+  /// `WHERE S.k = T.Id AND S.flag = 1` drops the NULL-flag row (UNKNOWN
+  /// rejects) BEFORE any `ON` is evaluated, so an unsafe `ON` over that dropped
+  /// row must never fire.
+  private func flagFixture() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["Id": .integer]) {
+        Row(1)
+        Row(2)
+      }
+      Relation("S", ["k": .integer, "x": .integer, "flag": .integer]) {
+        Row(1, 0, nil)      // flag NULL — dropped by body WHERE, x = 0 unsafe
+        Row(2, 200, 1)      // flag 1 — survives the body WHERE
+      }
+    }
+  }
+
+  /// THROW ORDER: the body WHERE drops the NULL-flag child (x = 0) before the
+  /// unsafe `ON (1 / d.x) = 0` is ever reached, so the correlated APPLY does
+  /// NOT throw. The decorrelated plan keeps the `ON` in a SEPARATE select ABOVE
+  /// the body-filtered join, so `ON` sees only survivors — Id 2's child x = 200
+  /// — and likewise does NOT divide by the dropped x = 0 row. The result is Id
+  /// 2's child (integer `1 / 200 = 0`, so the ON admits it), NOT a `.divide`.
+  @Test func `a nullable body filter drops a row before the unsafe ON`()
+      throws {
+    // The NULL-flag child (x = 0) is dropped by the body WHERE, so the unsafe
+    // ON never divides by it. Id 2's surviving child x = 200 is admitted by the
+    // ON (`1 / 200 = 0`), so the result is [[2, 200]] — and, crucially, NO
+    // throw, matching the correlated APPLY.
+    try flagFixture().expect(
+        "SELECT T.Id, d.x FROM T " +
+        "JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id AND S.flag = 1) AS d " +
+        "ON (1 / d.x) = 0 ORDER BY T.Id",
+        yields: [[2, 200]])
+  }
+
+  /// The ON still applies to a SURVIVING row: with a safe `ON d.x > 100` the
+  /// body WHERE keeps Id 2's child (x = 200, flag 1), and the ON admits it —
+  /// proving the split select did not drop the ON, only reorder it.
+  @Test func `the ON still filters a surviving row after the split`() throws {
+    try flagFixture().expect(
+        "SELECT T.Id, d.x FROM T " +
+        "JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id AND S.flag = 1) AS d " +
+        "ON d.x > 100 ORDER BY T.Id",
+        yields: [[2, 200]])
+  }
+
+  /// The ON legitimately DROPS a surviving row: with `ON d.x > 500` Id 2's
+  /// surviving child (x = 200) fails the ON, so the result is empty — the ON
+  /// filters survivors exactly as the correlated per-pair ON does.
+  @Test func `the ON drops a surviving row it rejects`() throws {
+    try flagFixture().empty(
+        "SELECT T.Id, d.x FROM T " +
+        "JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id AND S.flag = 1) AS d " +
+        "ON d.x > 500")
+  }
+}
+
+// MARK: - Adversarial throw-visibility (G4)
+
+struct DecorrelateThrowVisibilityTests {
+  /// ADVERSARIAL (soundness): a CROSS APPLY whose body WHERE divides by zero
+  /// for an inner row NO surviving left row pairs with. The child `(1, 100)`
+  /// makes
+  /// `1 / (S.x - 100)` divide by zero, but NO left row has `Id = 1` — so the
+  /// per-row correlated run never binds `:outer = 1` and never reaches that
+  /// inner row, yielding NO rows and NO throw. A naive decorrelation to a join
+  /// over the whole `S` WOULD evaluate the divide on `(1, 100)` and throw
+  /// spuriously. The recogniser must LEAVE it correlated (the conjunct is
+  /// unsafe), so the result stays empty with no throw — identical to the base
+  /// correlated behaviour.
+  @Test func `an unreachable throwing inner row is not decorrelated`() throws {
+    // T has only Id 2 and 3; S's only divide-by-zero row is keyed to Id 1.
+    let catalog = try Catalog {
+      Relation("T", ["Id": .integer]) {
+        Row(2)
+        Row(3)
+      }
+      Relation("S", ["k": .integer, "x": .integer]) {
+        Row(1, 100)      // x - 100 = 0 → divide by zero, keyed to absent Id 1
+        Row(2, 200)      // safe for Id 2
+      }
+    }
+    let sql =
+        "SELECT T.Id, d.x FROM T " +
+        "JOIN LATERAL " +
+        "(SELECT x FROM S WHERE S.k = T.Id AND 1 / (S.x - 100) > 0) AS d " +
+        "ON 1 = 1"
+    // The body carries an unsafe term, so it is NOT decorrelated.
+    #expect(applies(try catalog.optimised(sql)))
+    // Id 2 matches child (2, 200): 1 / (200 - 100) = 0, so `> 0` is false ⇒ no
+    // row; Id 3 matches nothing. The divide on the Id-1 child is never reached,
+    // so the run yields nothing and does NOT throw — the base behaviour.
+    let rows = try catalog.run(query(sql), .standard)
+    #expect(rows.isEmpty)
+  }
+}
+
+// MARK: - Decorrelated APPLY as an outer join's NULL-extended left side
+
+/// A decorrelated CROSS APPLY tops out in a `.project` that restores the
+/// apply's output geometry. When that project is the LEFT side of a RIGHT or
+/// FULL join, the outer-join executor sizes the left with `Plan.slots` to
+/// NULL-extend an unmatched right row across the FULL left width. A `.project`
+/// whose width `Plan.slots` swallowed (returning `nil` → the executor's `0`
+/// fallback) would NULL-extend with too few left slots, landing the right
+/// columns at the wrong ordinals or trapping. These oracles force exactly that
+/// NULL-extension and read the T/d slots after the outer join to prove the
+/// ordinals are not shifted.
+struct DecorrelateOuterJoinWidthTests {
+  /// A parent `T`, a child `S` keyed on `T.Id`, and an unrelated `U` — the
+  /// third relation an outer join over the decorrelated apply NULL-extends.
+  private func widthFixture() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["Id": .integer]) {
+        Row(1)
+        Row(2)
+        Row(3)
+      }
+      Relation("S", ["k": .integer, "x": .integer]) {
+        Row(1, 100)
+        Row(1, 101)
+        Row(2, 200)
+      }
+      Relation("U", ["u": .integer]) {
+        Row(700)
+        Row(701)
+      }
+    }
+  }
+
+  /// RIGHT JOIN forcing left NULL-extension. The lateral yields the `T ++ d`
+  /// rows ([1, 100], [1, 101], [2, 200]), but `RIGHT JOIN U ON 1 = 0` matches
+  /// none of them, so every `U` row survives with the WHOLE `T ++ d` left width
+  /// NULL. `Plan.slots` must report the project's width (2) so `U.u` lands at
+  /// ordinal 2 and `T.Id`/`d.x` are NULL — not shifted into the U slot or
+  /// trapped.
+  @Test func `a decorrelated apply as a RIGHT join's left NULL-extends fully`()
+      throws {
+    // The plan decorrelates (a `.join`, no surviving `.apply`) and its project
+    // is the RIGHT join's left side — the very shape whose width `Plan.slots`
+    // must measure.
+    let plan = try widthFixture().optimised(
+        "SELECT T.Id, d.x, U.u FROM T " +
+        "JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON 1 = 1 " +
+        "RIGHT JOIN U ON 1 = 0")
+    #expect(!applies(plan))
+    #expect(joins(plan))
+    // Every U row is NULL-extended across the full T ++ d left width: U.u at
+    // ordinal 2, T.Id and d.x NULL. The known-correct multiset a correlated run
+    // would produce — the RIGHT join drops the unmatched lateral rows and keeps
+    // each U row once, left NULL.
+    try widthFixture().expect(
+        "SELECT T.Id, d.x, U.u FROM T " +
+        "JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON 1 = 1 " +
+        "RIGHT JOIN U ON 1 = 0 ORDER BY U.u",
+        yields: [[nil, nil, 700], [nil, nil, 701]])
+  }
+
+  /// FULL JOIN forcing BOTH sides' unmatched rows through. `ON 1 = 0` matches
+  /// nothing, so the FULL join emits every lateral `T ++ d` row right-NULL then
+  /// every `U` row left-NULL — the left-NULL rows again needing the full T ++ d
+  /// width so `U.u` lands at ordinal 2. Reads T.Id/d.x/U.u to pin the ordinals.
+  @Test func `a decorrelated apply as a FULL join's left NULL-extends fully`()
+      throws {
+    let plan = try widthFixture().optimised(
+        "SELECT T.Id, d.x, U.u FROM T " +
+        "JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON 1 = 1 " +
+        "FULL JOIN U ON 1 = 0")
+    #expect(!applies(plan))
+    #expect(joins(plan))
+    // Left-major: the three lateral rows (U.u NULL), then the two U rows (T.Id,
+    // d.x NULL). The U columns land at ordinal 2 throughout — no shift.
+    try widthFixture().expect(
+        "SELECT T.Id, d.x, U.u FROM T " +
+        "JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON 1 = 1 " +
+        "FULL JOIN U ON 1 = 0 ORDER BY T.Id, d.x, U.u",
+        yields: [[nil, nil, 700], [nil, nil, 701],
+                 [1, 100, nil], [1, 101, nil], [2, 200, nil]])
+  }
+}


### PR DESCRIPTION
Add a behaviour-preserving `decorrelate()` logical pass, run after `pushdown` and before `optimise`/`nest`, that rewrites a correlated CROSS APPLY whose pre-compiled body is a filter+project over a single base-relation scan with a purely equi correlation into `project(select(product(left, scan)))`, which `nest` folds to a hash equi-join.

The recogniser is conservative: it fires only for `.inner` (CROSS APPLY) over a plain base relation (not a CTE/view), an all-`.slot` equi correlation, safe non-parameterised local residuals, and taken ordinals that are real projected columns (not the virtual per-left-row `Id`). Any other shape — aggregate, non-equi/expression correlation, unsafe/throwing body term, or a geometry it cannot map — is left correlated, so execution is unchanged. The rewrite reproduces the correlated `applied`'s exact output multiset (match-count multiplicity, NULL-key drops, unmatched-row drops) and geometry.