### PR TITLE
SQLEngine: decorrelate OUTER APPLY into a LEFT join

### DIFF
--- a/Sources/SQLEngine/Engine.swift
+++ b/Sources/SQLEngine/Engine.swift
@@ -2357,7 +2357,7 @@ extension Catalog where Self: ~Escapable {
     let conjuncts = filter.conjuncts
     for index in conjuncts.indices {
       guard case let .match(lhs, rhs) = conjuncts[index],
-          let (leftKey, rightKey) = keys(lhs, rhs, base) else {
+          let key = keys(lhs, rhs, base) else {
         continue
       }
 
@@ -2375,8 +2375,8 @@ extension Catalog where Self: ~Escapable {
       let join = try Plan.join(optimise(left, context),
                                name: inner.name, ordinals: inner.ordinals,
                                base: base,
-                               column: inner.ordinals[rightKey - base],
-                               keys: (left: leftKey, right: rightKey),
+                               column: inner.ordinals[key.inner - base],
+                               keys: (left: key.outer, right: key.inner),
                                filter: inner.filter)
       guard let predicate = residual.conjunction else { return join }
       return .select(predicate, join)
@@ -2434,13 +2434,15 @@ extension Catalog where Self: ~Escapable {
                         on: on, kind: kind)
     case let .apply(left, key, correlation, ordinals, on, kind):
       // Decorrelate the LEFT first (a nested apply inside it still rewrites),
-      // then attempt this apply. `.left` (OUTER APPLY) is deferred to a later
-      // PR; only `.inner` (CROSS APPLY) is a candidate here.
+      // then attempt this apply. `.inner` (CROSS APPLY) folds to an inner hash
+      // join; `.left` (OUTER APPLY) folds to a LEFT `.outer` join. A `.right`/
+      // `.full` apply does not exist (rejected at compile), so any other kind
+      // is left verbatim.
       let left = try decorrelate(left, context)
-      guard kind == .inner,
+      guard kind == .inner || kind == .left,
           let body = context.subqueries.plan(key, correlation),
           let rewritten = decorrelated(apply: left, body, key, correlation,
-                                       ordinals, on, context) else {
+                                       ordinals, on, kind, context) else {
         return .apply(left, key: key, correlation: correlation,
                       ordinals: ordinals, on: on, kind: kind)
       }
@@ -2459,45 +2461,67 @@ extension Catalog where Self: ~Escapable {
     }
   }
 
-  /// The inner-join rewrite of a CROSS APPLY whose `left` is already
-  /// decorrelated, or `nil` when the apply's `body` is not decorrelatable — in
-  /// which case the caller leaves the `.apply` unchanged (conservative
-  /// default).
+  /// The join rewrite of a CROSS APPLY (`.inner`) or OUTER APPLY (`.left`)
+  /// whose `left` is already decorrelated, or `nil` when the apply's `body` is
+  /// not decorrelatable — in which case the caller leaves the `.apply`
+  /// unchanged (conservative default). An `.inner` apply becomes an inner hash
+  /// join; a `.left` apply becomes a LEFT `.outer` join.
   ///
   /// The body must be `project(projection, select(where, scan(R, _, nil)))`
   /// with every projection term a bare slot (G3: a filter+project over a single
   /// base relation, no aggregate/limit/distinct/setop/nested apply — none of
   /// which wear this exact shape), the correlation must be all `.slot` sources
   /// (no `.bound` grandparent), and the `where` conjuncts must be EXACTLY one
-  /// equi correlation `innerKey = :param` (or the reversed order) plus safe,
-  /// non-parameterised, single-relation local predicates `p_R` (G4: an unsafe
-  /// or parameterised residual — a non-equi/expression correlation — bails).
+  /// equi correlation `correlate.inner = :param` (or the reversed order) plus
+  /// safe, non-parameterised, single-relation local predicates `p_R` (G4: an
+  /// unsafe or parameterised residual — a non-equi/expression correlation —
+  /// bails).
   /// The scan's `seek` must be absent (a seeked body is not the canonical
   /// shape).
   ///
-  /// The rewrite lays the body scan's referenced ordinals after the left (a
-  /// `.product`), then stacks TWO selects: an INNER select carrying the WHOLE
-  /// body WHERE (the correlation equality `.match(outerSlot, base + innerKey)`
-  /// AND the local residual `p_R`) and an OUTER select carrying the apply's
-  /// `on` — the apply's `on` mapped from its `left ++ taken` space into this
-  /// `left ++ scan` space. The `on` is kept SEPARATE (not folded into the body
-  /// residual's conjunction) so it is evaluated ONLY on rows the body WHERE
-  /// admitted: nested selects run bottom-up, restoring the correlated order
-  /// (body WHERE → drop an UNKNOWN row → `on`), so an `on` that would throw on
-  /// a row the body WHERE drops never fires — matching the correlated `applied`
-  /// (which never reaches the `on` for a dropped row). It then PROJECTS the
-  /// result back to the apply's `left ++ taken` geometry, so the combined
-  /// record a parent reads is byte-identical to the correlated `applied`'s. The
-  /// equi `.match` lets `nest`/`optimise` fold the product into a hash
-  /// equi-join whose NULL-key drops and match-count multiplicity mirror the
-  /// per-row re-execution.
+  /// **`.inner` (CROSS APPLY).** The rewrite lays the body scan's referenced
+  /// ordinals after the left (a `.product`), then stacks TWO selects: an INNER
+  /// select carrying the WHOLE body WHERE (the correlation equality
+  /// `.match(correlate.outer, base + correlate.inner)` AND the local residual
+  /// `p_R`) and an OUTER select carrying the apply's `on` — the apply's `on`
+  /// mapped from its `left ++ taken` space into this `left ++ scan` space. The
+  /// `on` is kept
+  /// SEPARATE (not folded into the body residual's conjunction) so it is
+  /// evaluated ONLY on rows the body WHERE admitted: nested selects run
+  /// bottom-up, restoring the correlated order (body WHERE → drop an UNKNOWN
+  /// row → `on`), so an `on` that would throw on a row the body WHERE drops
+  /// never fires — matching the correlated `applied` (which never reaches the
+  /// `on` for a dropped row). It then PROJECTS the result back to the apply's
+  /// `left ++ taken` geometry. The equi `.match` lets `nest`/`optimise` fold
+  /// the product into a hash equi-join whose NULL-key drops and match-count
+  /// multiplicity mirror the per-row re-execution.
+  ///
+  /// **`.left` (OUTER APPLY).** The rewrite is a LEFT `.outer` join
+  /// `outer(left, scan(R), on: match(correlate.outer, base + correlate.inner)
+  /// AND residual' AND on', kind: .left)`, projected back to the apply's
+  /// `left ++ taken` geometry. The `.outer` node's `on` GOVERNS matching and
+  /// NULL-extends an unmatched left row across the taken width — exactly OUTER
+  /// APPLY. UNLIKE the inner case the `on` CANNOT be split into a select above
+  /// the join: the LEFT join's match/NULL-extension condition IS the whole
+  /// `on`, so the correlation equality, the body residual, and the apply `on`
+  /// must fold into ONE predicate evaluated together per (L, R) pair. This
+  /// engine evaluates an `AND`'s RHS even for an UNKNOWN LHS, so folding an
+  /// UNSAFE apply `on` beside a nullable body residual would raise a throw for
+  /// a pair the correlated body WHERE dropped. THEREFORE `.left` decorrelates
+  /// ONLY when the mapped apply `on` is `safe` (non-throwing) or provably
+  /// constant-true (the common `ON 1 = 1`): evaluating a `safe` `on` for an
+  /// UNKNOWN-residual pair cannot throw, so the fold is result- AND throw-
+  /// equivalent. An unsafe apply `on` leaves the `.apply` correlated. The equi
+  /// `match` conjunct lets the `.outer` executor's hash fast-path probe by the
+  /// key, mirroring the inner join's NULL-key drop and multiplicity.
   private borrowing func decorrelated(apply left: Plan, _ body: Plan,
                                       _ key: Subkey,
                                       _ correlation: Correlation,
                                       _ ordinals: Array<Int>, _ on: Filter,
+                                      _ kind: Join.Kind,
                                       _ context: Context) -> Plan? {
-    guard case let .project(projection, .select(filter, scan)) = body,
-        case let .scan(name, scanOrdinals, nil) = scan,
+    guard case let .project(projection, .select(filter, leaf)) = body,
+        case let .scan(name, scanOrdinals, nil) = leaf,
         let base = left.slots else { return nil }
     // The scanned `name` must be a genuine BASE relation, not a BODY-LOCAL
     // derived alias. When the lateral body declares its OWN derived table(s) —
@@ -2543,57 +2567,95 @@ extension Catalog where Self: ~Escapable {
     // this v1 decorrelates). The outer key is that source's ordinal, already in
     // the left's combined slot space.
     guard correlation.count == 1,
-        case let (name: parameter, source: .slot(outerKey))? =
+        case let (name: parameter, source: .slot(outer))? =
             correlation.first.map({ (name: $0.key, source: $0.value) })
         else { return nil }
 
-    // Split the body WHERE into the ONE equi correlation conjunct (`innerKey =
-    // :parameter`) and the local residual `p_R`. Any other parameterised
-    // conjunct is a non-equi/expression correlation — bail. Every residual must
-    // be safe (G4: a throwing body term could fire for an inner row no left row
-    // reaches under set-based execution).
-    var innerKey: Int? = nil
+    // Split the body WHERE into the ONE equi correlation conjunct
+    // (`correlate.inner = :parameter`) and the local residual `p_R`. Any other
+    // parameterised conjunct is a non-equi/expression correlation — bail. Every
+    // residual must be safe (G4: a throwing body term could fire for an inner
+    // row no left row reaches under set-based execution).
+    var inner: Int? = nil
     var residual = Array<Filter>()
     for conjunct in filter.conjuncts {
-      if innerKey == nil, let slot = equated(conjunct, to: parameter) {
-        innerKey = slot
+      if inner == nil, let slot = equated(conjunct, to: parameter) {
+        inner = slot
         continue
       }
       guard conjunct.safe, !conjunct.parameterised else { return nil }
       residual.append(conjunct)
     }
-    guard let innerKey else { return nil }
+    guard let inner else { return nil }
+    // The correlation key pair: `outer` the source's ordinal (in the left's
+    // combined slot space), `inner` the equi conjunct's body slot.
+    let correlate = (outer: outer, inner: inner)
 
     // The scan is relaid after the left, so the body's 0-based scan slots shift
     // by `base` into the combined space. The correlation equality becomes a
-    // `.match` `nest` folds to the join key; the residual `p_R` shifts
-    // alongside. This inner gate carries the WHOLE body WHERE (match key +
-    // residual) and NOTHING else — the apply's `on` is kept ABOVE it.
-    let inner = Plan.scan(name: name, ordinals: scanOrdinals, seek: nil)
-    var gate = [Filter.match(outerKey, base + innerKey)]
-    gate.append(contentsOf: residual.map { $0.shifted(by: -base) })
-    let product = Plan.product(left, inner)
-    let filtered = gate.conjunction.map { Plan.select($0, product) } ?? product
+    // `.match` (folded to the join key), and the residual `p_R` shifts
+    // alongside into this `left ++ scan` space.
+    let scan = Plan.scan(name: name, ordinals: scanOrdinals, seek: nil)
+    let matched = Filter.match(correlate.outer, base + correlate.inner)
+    let shifted = residual.map { $0.shifted(by: -base) }
     // The apply's `on` addresses the `left ++ taken` space; map it into this
     // `left ++ scan` space (taken column `base + j` becomes the scan slot `base
-    // + projected[ordinals[j]]` its projection read). Keep it in a SEPARATE
-    // select ABOVE the body-filtered join rather than folding it into the same
-    // conjunction as the body residual. The correlated `applied` evaluates the
-    // body WHERE FIRST (dropping an UNKNOWN row — a NULL-flag child) and only
-    // THEN the `on`, so an `on` that would throw on a dropped row never fires.
-    // This engine evaluates an `AND`'s RHS even for an UNKNOWN LHS, so folding
-    // `on` into the residual conjunction would evaluate it for a dropped row
-    // and raise a fault the original APPLY never hits. Nested selects evaluate
-    // bottom-up, so an OUTER `on` sees only the rows the body WHERE admitted —
-    // restoring the correlated order (body WHERE → drop → on).
+    // + projected[ordinals[j]]` its projection read).
     let mapped =
         on.remapped(through: remap(taken: ordinals, over: base, projected))
-    let gated = mapped.constant == true ? filtered : .select(mapped, filtered)
     // Project back to the apply's exact `left ++ taken` geometry: the left's
     // slots unchanged, then each taken column at its combined scan slot.
     var terms = (0 ..< base).map { Term.slot($0) }
     terms.append(contentsOf: ordinals.map { Term.slot(base + projected[$0]) })
-    return .project(terms, gated)
+
+    switch kind {
+    case .inner:
+      // The inner gate carries the WHOLE body WHERE (match key + residual) and
+      // NOTHING else — the apply's `on` is kept in a SEPARATE select ABOVE the
+      // body-filtered join rather than folded into the residual conjunction.
+      // The correlated `applied` evaluates the body WHERE FIRST (dropping an
+      // UNKNOWN row — a NULL-flag child) and only THEN the `on`, so an `on`
+      // that would throw on a dropped row never fires. This engine evaluates an
+      // `AND`'s RHS even for an UNKNOWN LHS, so folding `on` into the residual
+      // conjunction would evaluate it for a dropped row and raise a fault the
+      // original APPLY never hits. Nested selects evaluate bottom-up, so an
+      // OUTER `on` sees only the rows the body WHERE admitted — restoring the
+      // correlated order (body WHERE → drop → on). The `.match` lets
+      // `nest`/`optimise` fold the product into a hash equi-join.
+      let product = Plan.product(left, scan)
+      let gate = ([matched] + shifted).conjunction
+      let filtered = gate.map { Plan.select($0, product) } ?? product
+      let gated = mapped.constant == true ? filtered : .select(mapped, filtered)
+      return .project(terms, gated)
+    case .left:
+      // OUTER APPLY: a LEFT `.outer` join whose `on` GOVERNS matching and
+      // NULL-extends an unmatched left row. UNLIKE the inner case the `on`
+      // cannot be split into a select above the join — the LEFT join's match/
+      // NULL-extension condition IS the whole `on`, so correlation + residual +
+      // apply `on` must be ONE predicate evaluated together per (L, R) pair.
+      //
+      // SAFE-`on` GATE (throw-equivalence): this engine evaluates an `AND`'s
+      // RHS even for an UNKNOWN LHS, so if the body residual can be UNKNOWN and
+      // the apply `on` is UNSAFE, folding them raises a throw for a pair the
+      // correlated body WHERE dropped at its own filter — a spurious throw the
+      // OUTER APPLY never hits. Only decorrelate `.left` when the mapped `on`
+      // is `safe` (non-throwing) or provably constant-true (`ON 1 = 1`): a
+      // `safe` `on` for an UNKNOWN-residual pair cannot throw, so the fold is
+      // result- AND throw-equivalent. An unsafe apply `on` bails — the caller
+      // leaves the `.apply` correlated.
+      guard mapped.safe || mapped.constant == true else { return nil }
+      let condition =
+          mapped.constant == true ? [matched] + shifted
+                                  : [matched] + shifted + [mapped]
+      // `condition` always holds the `match` conjunct, so it is never empty.
+      let clause = condition.conjunction ?? matched
+      let outer = Plan.outer(left, scan, on: clause, kind: .left)
+      return .project(terms, outer)
+    default:
+      // `.right`/`.full` do not exist as apply kinds (rejected at compile); the
+      // caller already gates on `.inner`/`.left`, so this is unreachable.
+      return nil
+    }
   }
 }
 
@@ -2631,7 +2693,7 @@ private func remap(taken ordinals: Array<Int>, over base: Int,
   return map
 }
 
-/// The `(outerKey, innerKey)` an equality between slots `lhs` and `rhs`
+/// The `(outer, inner)` key pair an equality between slots `lhs` and `rhs`
 /// relates across the boundary `base`, or `nil` if both fall on one side.
 ///
 /// Exactly one slot must be below `base` (the outer key) and the other at or

--- a/Sources/SQLEngine/Filter.swift
+++ b/Sources/SQLEngine/Filter.swift
@@ -997,7 +997,7 @@ extension Catalog where Self: ~Escapable {
     let body = revealed(under: key, context)
     // An unmatched left row under OUTER APPLY (`.left`) is NULL-extended by the
     // taken width, mirroring `outer(…)`'s NULL-padding of an unmatched row.
-    let rightNulls = Record(Array(repeating: .null, count: ordinals.count))
+    let nulls = Record(Array(repeating: .null, count: ordinals.count))
     // A LATERAL/CROSS/OUTER apply always emits `ON 1 = 1` — a PROVABLY-true
     // predicate every merged row passes — so a constant-true `on` skips the
     // redundant per-row `evaluate(paired, on, context)` and admits the pair
@@ -1022,7 +1022,7 @@ extension Catalog where Self: ~Escapable {
         }
       }
       if !matched && kind == .left {
-        records.append(record.merged(with: rightNulls))
+        records.append(record.merged(with: nulls))
       }
     }
     return records

--- a/Sources/SQLEngine/Operator.swift
+++ b/Sources/SQLEngine/Operator.swift
@@ -411,9 +411,9 @@ extension Catalog where Self: ~Escapable {
       // The side widths come from the sub-plans (known for a compiled plan),
       // so an unmatched row NULL-extends to the right width even when a side
       // yields no rows to read a width off.
-      return try outer(execute(left, context), left.slots ?? 0,
-                       execute(right, context), right.slots ?? 0, on, kind,
-                       context)
+      return try outer(execute(left, context), execute(right, context),
+                       widths: (left: left.slots ?? 0, right: right.slots ?? 0),
+                       on, kind, context)
     case let .apply(left, key, correlation, ordinals, on, kind):
       return try applied(execute(left, context), key, correlation, ordinals,
                          on, kind, context)
@@ -490,8 +490,8 @@ extension Catalog where Self: ~Escapable {
   /// tracking matches so an unmatched preserved row is emitted with the other
   /// side NULL-extended.
   ///
-  /// `left`/`right` are the two materialised sides and `leftWidth`/`rightWidth`
-  /// each side's slot count (needed to NULL-extend even when a side is empty).
+  /// `left`/`right` are the two materialised sides and `widths` each side's
+  /// slot count (needed to NULL-extend even when a side is empty).
   /// Each candidate pair is merged (left slots then right slots) and tested
   /// against `on` under three-valued logic — TRUE matches, UNKNOWN and FALSE do
   /// not, exactly as a `WHERE` admits; `on` governs MATCHING alone, so an
@@ -507,13 +507,65 @@ extension Catalog where Self: ~Escapable {
   ///
   /// A `.inner` kind never reaches here — `compile` lowers an inner join
   /// through the product/join path.
-  private borrowing func outer(_ left: Array<Record>, _ leftWidth: Int,
-                               _ right: Array<Record>, _ rightWidth: Int,
+  ///
+  /// FAST PATH: when `on` carries an equi `.match` conjunct straddling the two
+  /// sides (a left slot `< widths.left` equal to a right slot `>= widths.left`
+  /// — the shape a decorrelated OUTER APPLY emits), a `.left`/`.full` join
+  /// hashes the right side by that key ONCE and probes per left row
+  /// (`bucketed`), turning the O(left × right) nested loop into O(left +
+  /// right). The probe re-checks the WHOLE `on` on each bucket candidate — the
+  /// bucket over-groups (two large integers can share a `Double` bucket) and
+  /// `on` may carry residual conjuncts beyond the key — so the surviving pairs,
+  /// the NULL-extension of unmatched left rows, and (for `.full`) the left-NULL
+  /// of never-matched right rows are byte-identical to the nested-loop below. A
+  /// NULL key buckets/probes nothing, so it stays unmatched exactly as the
+  /// nested loop's UNKNOWN `.match` leaves it. A non-equi `on` (no straddling
+  /// `.match`) takes the nested loop.
+  ///
+  /// The fast path fires ONLY when the WHOLE `on` is `safe` (cannot throw): it
+  /// evaluates `on` for the bucket candidates alone, so it SKIPS a non-matching
+  /// or NULL-key right row ENTIRELY — never evaluating `on` for it — whereas
+  /// the nested loop evaluates the whole `on` for EVERY pair. (This is NOT
+  /// about AND short-circuiting: the evaluator IS Kleene and DOES short-circuit
+  /// an `AND` on a FALSE left, but only on a FALSE one — an UNKNOWN or TRUE
+  /// left still evaluates the right, and either side of the `on` may throw.) An
+  /// UNSAFE `on` — a straddling `.match` AND a throwing conjunct like
+  /// `(1 / B.x) = 0` — could therefore SUPPRESS a throw the nested loop raises
+  /// on a skipped pair, so it falls to the nested loop below, which evaluates
+  /// every pair and throws identically.
+  /// A `safe` `on` throws on NO pair, so skipping the non-bucket/NULL rows
+  /// suppresses nothing. A decorrelated OUTER APPLY's `on` is safe by
+  /// construction (the recogniser gates the residual and apply predicate
+  /// `safe`), so it keeps the fast path.
+  ///
+  /// In PRACTICE every `.match`-carrying `on` that reaches here is ALREADY
+  /// safe: the `on()` recogniser (`Resolve.swift`) forms NO `.match` unless the
+  /// whole ON is `allSatisfy(\.safe)`, and the OUTER APPLY decorrelation only
+  /// folds a `.match` when its body residual and apply `on` are `safe`. This
+  /// `on.safe` guard is defence-in-depth — it keeps the executor locally sound
+  /// without relying on that distant invariant, so a future `.match` producer
+  /// cannot silently suppress a throw here.
+  private borrowing func outer(_ left: Array<Record>,
+                               _ right: Array<Record>,
+                               widths: (left: Int, right: Int),
                                _ on: Filter, _ kind: Join.Kind,
                                _ context: Context)
       throws(SQLError) -> Array<Record> {
-    let leftNulls = Record(Array(repeating: .null, count: leftWidth))
-    let rightNulls = Record(Array(repeating: .null, count: rightWidth))
+    let nulls =
+        (left: Record(Array(repeating: .null, count: widths.left)),
+         right: Record(Array(repeating: .null, count: widths.right)))
+
+    // The hash fast-path applies to the left-preserving kinds (`.left`/`.full`)
+    // whose loop is left-major; a straddling equi `.match` conjunct gives the
+    // probe key. `.right` keeps its own right-major nested loop above.
+    if (kind == .left || kind == .full),
+        let key = equikey(on, widths.left), on.safe {
+      // `key.right` is in the combined `left ++ right` space; the right side is
+      // materialised standalone, so its own slot is `key.right - widths.left`.
+      return try bucketed(left, right,
+                          key: (key.left, key.right - widths.left),
+                          on, kind, nulls, context)
+    }
 
     // A `right` join preserves the right side, so it drives the loop
     // right-major and NULL-extends the left. The `on` filter stays in the same
@@ -531,7 +583,7 @@ extension Catalog where Self: ~Escapable {
             paired = true
           }
         }
-        if !paired { records.append(leftNulls.merged(with: inner)) }
+        if !paired { records.append(nulls.left.merged(with: inner)) }
       }
       return records
     }
@@ -554,7 +606,7 @@ extension Catalog where Self: ~Escapable {
       // An unmatched left row is preserved (right NULL) for a `left` or `full`
       // join — the left side is preserved in both.
       if !paired {
-        records.append(lhs.merged(with: rightNulls))
+        records.append(lhs.merged(with: nulls.right))
       }
     }
 
@@ -562,11 +614,103 @@ extension Catalog where Self: ~Escapable {
     // NULL).
     if kind == .full {
       for index in right.indices where !matched[index] {
-        records.append(leftNulls.merged(with: right[index]))
+        records.append(nulls.left.merged(with: right[index]))
       }
     }
     return records
   }
+
+  /// The hash fast-path of a `.left`/`.full` OUTER join: the right side hashed
+  /// ONCE by `key.right` into buckets, then each left row probed by `key.left`
+  /// in O(1). Behaviour-identical to the nested loop `outer` above — same
+  /// surviving pairs, same NULL-extension, same order.
+  ///
+  /// The right side is bucketed by its key's promoted `bucket` (a NULL key
+  /// buckets nothing — it can never equi-match, exactly as the nested loop's
+  /// UNKNOWN `.match` leaves it unmatched). Each left row probes its own key's
+  /// bucket, and every candidate is CONFIRMED against the WHOLE `on` — the
+  /// bucket over-groups and `on` may carry residual conjuncts beyond the key —
+  /// so a bucket collision or a failing residual drops the pair exactly as the
+  /// nested loop's per-pair `on` test does. A left row with no confirmed pair
+  /// is NULL-extended (right NULL), preserving it. For `.full`, a right row no
+  /// left row confirmed is emitted left-NULL after the left-major pass,
+  /// mirroring the nested loop's `matched` tracking.
+  ///
+  /// The iteration is left-major and, within a left row, walks the bucket in
+  /// the order rows were inserted (right-cursor order), so the emitted order
+  /// matches the nested loop's left-major/right-order pass. A left row whose
+  /// key is NULL probes nothing and is NULL-extended.
+  ///
+  /// `key.left` is a combined-space slot (the left side is the record's
+  /// prefix), while `key.right` is the right side's OWN standalone slot — the
+  /// caller maps the combined right slot down by `widths.left` before the call.
+  private borrowing func bucketed(_ left: Array<Record>,
+                                  _ right: Array<Record>,
+                                  key: (left: Int, right: Int),
+                                  _ on: Filter, _ kind: Join.Kind,
+                                  _ nulls: (left: Record, right: Record),
+                                  _ context: Context)
+      throws(SQLError) -> Array<Record> {
+    // Bucket the right side by its key, remembering each row's index so a
+    // `.full` join can emit the never-matched right rows left-NULL afterwards.
+    var buckets = Dictionary<Value, Array<Int>>()
+    for index in right.indices {
+      let value = right[index][key.right]
+      if case .null = value { continue }
+      buckets[bucket(value), default: Array<Int>()].append(index)
+    }
+
+    var records = Array<Record>()
+    var matched = Array(repeating: false, count: right.count)
+    for lhs in left {
+      let value = lhs[key.left]
+      var paired = false
+      // A NULL left key equi-matches nothing, so it probes no bucket and stays
+      // unmatched — the `guard` skips straight to the NULL-extension below.
+      if case .null = value {} else {
+        for index in buckets[bucket(value)] ?? [] {
+          let record = lhs.merged(with: right[index])
+          // Confirm the WHOLE `on` — the bucket over-groups and `on` may carry
+          // residual conjuncts beyond the equi key, so a collision or a failing
+          // residual drops the pair, exactly as the nested loop's `on` test.
+          if try evaluate(record, on, context) == true {
+            records.append(record)
+            matched[index] = true
+            paired = true
+          }
+        }
+      }
+      if !paired { records.append(lhs.merged(with: nulls.right)) }
+    }
+
+    // A `.full` join also preserves every right row no left row confirmed.
+    if kind == .full {
+      for index in right.indices where !matched[index] {
+        records.append(nulls.left.merged(with: right[index]))
+      }
+    }
+    return records
+  }
+}
+
+/// The `(left, right)` slot pair of an equi `.match` conjunct in `on` that
+/// STRADDLES the join boundary `boundary` — one slot on the left side
+/// (`< boundary`), the other on the right (`>= boundary`) — or `nil` when no
+/// such conjunct exists (a non-equi `on`, or a `.match` wholly on one side).
+/// The first straddling `.match` among the top-level `AND` conjuncts is the
+/// hash key; any further conjuncts ride the whole-`on` confirm the probe
+/// applies.
+private func equikey(_ on: Filter, _ boundary: Int)
+    -> (left: Int, right: Int)? {
+  for conjunct in on.conjuncts {
+    guard case let .match(lhs, rhs) = conjunct else { continue }
+    switch (lhs < boundary, rhs < boundary) {
+    case (true, false): return (lhs, rhs)
+    case (false, true): return (rhs, lhs)
+    default: continue
+    }
+  }
+  return nil
 }
 
 /// Caps `records` to at most `count` rows after skipping the first `offset`, in

--- a/Tests/SQLTests/Optimisation/DecorrelateTests.swift
+++ b/Tests/SQLTests/Optimisation/DecorrelateTests.swift
@@ -54,6 +54,25 @@ private func joins(_ plan: Plan) -> Bool {
   }
 }
 
+/// Whether `plan` (or any descendant) carries an `.outer` node — the witness an
+/// OUTER APPLY (`.left`) decorrelated to a LEFT `.outer` join.
+private func outers(_ plan: Plan) -> Bool {
+  switch plan {
+  case .outer:
+    return true
+  case let .derived(_, source, _, _):
+    return outers(source)
+  case let .select(_, source), let .project(_, source), let .sort(_, source),
+       let .distinct(source), let .limit(_, _, source),
+       let .aggregate(_, _, source):
+    return outers(source)
+  case let .product(left, right), let .setop(_, left, right, _):
+    return outers(left) || outers(right)
+  case .single, .scan, .join, .apply:
+    return false
+  }
+}
+
 extension Catalog where Self: ~Escapable {
   /// The optimised plan for `sql`, threading a shared subquery box through the
   /// SAME compile → pushdown → decorrelate → optimise pipeline `run` uses, so a
@@ -484,5 +503,423 @@ struct DecorrelateOuterJoinWidthTests {
         "FULL JOIN U ON 1 = 0 ORDER BY T.Id, d.x, U.u",
         yields: [[nil, nil, 700], [nil, nil, 701],
                  [1, 100, nil], [1, 101, nil], [2, 200, nil]])
+  }
+}
+
+// MARK: - Decorrelatable OUTER APPLY (`.left`): result-equivalence + plan shape
+
+/// Behaviour-preserving oracles for the OUTER APPLY (`LEFT JOIN LATERAL`) →
+/// LEFT `.outer` join decorrelation. An OUTER APPLY NULL-extends an unmatched
+/// left row (ONCE) and multiplies a matched one by its match count — the SAME
+/// multiset the correlated `applied` (`.left`) executor produces. Each case
+/// compares the run against that known-correct multiset and pins the plan
+/// shape: a decorrelatable OUTER APPLY becomes an `.outer` with NO `.apply`
+/// node.
+struct DecorrelateOuterApplyTests {
+  /// NULL-EXTENSION: Id 3 has no child, so the OUTER apply PRESERVES it
+  /// NULL-extended — Id 1 → {100, 101}, Id 2 → {200}, Id 3 → (3, NULL) — the
+  /// exact multiset the correlated `.left` `applied` yields, unlike the CROSS
+  /// APPLY that would drop Id 3.
+  @Test func `an OUTER APPLY NULL-extends an unmatched left row`() throws {
+    try fixture().expect(
+        "SELECT T.Id, d.x FROM T " +
+        "LEFT JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON 1 = 1 " +
+        "ORDER BY T.Id, d.x",
+        yields: [[1, 100], [1, 101], [2, 200], [3, nil]])
+  }
+
+  /// MULTIPLICITY: Id 1 matches two inner rows and appears TWICE (matched, NOT
+  /// NULL-extended); it is not deduped — the LEFT join multiplies a matched
+  /// left row by its match count exactly as the per-row run does.
+  @Test func `a matched OUTER APPLY left row is multiplied not deduped`()
+      throws {
+    let rows = try fixture().run(parse(query:
+        "SELECT T.Id FROM T " +
+        "LEFT JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON 1 = 1 " +
+        "ORDER BY T.Id"), .standard)
+    // Id 1 twice (two children, matched — no NULL row), Id 2 once, Id 3 once
+    // (NULL-extended). The left row is preserved, matched rows not deduped.
+    #expect(rows == [[.integer(1)], [.integer(1)], [.integer(2)],
+                     [.integer(3)]])
+  }
+
+  /// NULL CORRELATION KEY: a NULL outer `Id` matches nothing (NULL ≠ NULL), so
+  /// the OUTER apply NULL-extends it — Id 1 → 100, the NULL-Id row → NULL. The
+  /// inner NULL-keyed `(NULL, 999)` never pairs. Identical to the per-row
+  /// `WHERE S.k = :outer` NULL-drop then NULL-extension.
+  @Test func `a NULL correlation key NULL-extends the left row`() throws {
+    try nullFixture().expect(
+        "SELECT T.Id, d.x FROM T " +
+        "LEFT JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON 1 = 1 " +
+        "ORDER BY d.x",
+        yields: [[nil, nil], [1, 100]])
+  }
+
+  /// The apply's `ON` (safe) still governs matching: `ON d.x > 100` rejects Id
+  /// 1's child 100 and Id 2's child 200 stays (`200 > 100`), so Id 1 keeps only
+  /// 101, Id 2 keeps 200, and Id 3 (no child) NULL-extends — every left row
+  /// preserved, exactly as the correlated OUTER apply's per-pair `ON`.
+  @Test func `a safe apply ON governs the decorrelated match`() throws {
+    try fixture().expect(
+        "SELECT T.Id, d.x FROM T " +
+        "LEFT JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d " +
+        "ON d.x > 100 ORDER BY T.Id, d.x",
+        yields: [[1, 101], [2, 200], [3, nil]])
+  }
+
+  /// The apply `ON` rejects EVERY pair: `ON d.x > 1000` matches no child, so
+  /// EACH left row — even Ids 1 and 2 with children — is NULL-extended, just as
+  /// Id 3 is. The correlated OUTER apply preserves every left row; the
+  /// decorrelated LEFT join must too.
+  @Test func `an ON rejecting every pair NULL-extends every left row`()
+      throws {
+    try fixture().expect(
+        "SELECT T.Id, d.x FROM T " +
+        "LEFT JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d " +
+        "ON d.x > 1000 ORDER BY T.Id",
+        yields: [[1, nil], [2, nil], [3, nil]])
+  }
+
+  /// A safe local body predicate `p_R` (`S.x < 200`) folds into the LEFT join's
+  /// `on`: Id 1 keeps both children, Id 2 loses its only child (200) and
+  /// NULL-extends, Id 3 NULL-extends — the multiset the per-row run produces.
+  @Test func `a safe local body predicate folds into the outer join`() throws {
+    try fixture().expect(
+        "SELECT T.Id, d.x FROM T " +
+        "LEFT JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id AND S.x < 200) " +
+        "AS d ON 1 = 1 ORDER BY T.Id, d.x",
+        yields: [[1, 100], [1, 101], [2, nil], [3, nil]])
+  }
+
+  /// PLAN SHAPE: the decorrelatable OUTER APPLY optimises to an `.outer` join
+  /// with NO surviving `.apply` node — the pass fired.
+  @Test func `a decorrelatable OUTER APPLY optimises to an outer join`()
+      throws {
+    let plan = try fixture().optimised(
+        "SELECT T.Id, d.x FROM T " +
+        "LEFT JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON 1 = 1")
+    #expect(!applies(plan))
+    #expect(outers(plan))
+  }
+
+  /// PLAN SHAPE: a safe residual `ON` and a local body predicate still
+  /// decorrelate — no `.apply` node survives, an `.outer` node appears.
+  @Test func `an OUTER APPLY with safe ON and body predicate decorrelates`()
+      throws {
+    let plan = try fixture().optimised(
+        "SELECT T.Id, d.x FROM T " +
+        "LEFT JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id AND S.x < 200) " +
+        "AS d ON d.x > 50")
+    #expect(!applies(plan))
+    #expect(outers(plan))
+  }
+}
+
+// MARK: - OUTER APPLY excluded bodies: STAY correlated, run correctly
+
+/// The `.left`-specific exclusions plus the shared G3 ones. The load-bearing
+/// one is the UNSAFE apply `ON`: a LEFT join cannot split its `on`, so folding
+/// an unsafe `on` beside a nullable body residual would throw for a pair the
+/// correlated body WHERE dropped — so an unsafe `on` LEAVES the apply
+/// correlated (the safe-gate), running identically to the base.
+struct DecorrelateOuterApplyExclusionTests {
+  /// UNSAFE APPLY `ON` (the safe-gate, `.left`-specific): a body residual
+  /// `S.k = T.Id` can be UNKNOWN for a non-matching inner row, and the apply
+  /// `ON (1 /
+  /// d.x) = 0` divides by a child's `x`. `S` has a child `(2, 0)`, so `1 / d.x`
+  /// divides by zero for Id 2's matched child. The correlated OUTER apply
+  /// evaluates the body WHERE FIRST and reaches the `ON` only for a surviving
+  /// pair, so it DOES throw for Id 2's matched (2, 0). Folding into one LEFT-
+  /// join `on` would ALSO throw — but the recogniser cannot prove throw-
+  /// equivalence
+  /// for an unsafe `on`, so it LEAVES the apply correlated and the run throws
+  /// `.divide` exactly as the base.
+  @Test func `an unsafe apply ON stays correlated and throws identically`()
+      throws {
+    let catalog = try Catalog {
+      Relation("T", ["Id": .integer]) {
+        Row(1)
+        Row(2)
+      }
+      Relation("S", ["k": .integer, "x": .integer]) {
+        Row(1, 100)
+        Row(2, 0)          // 1 / 0 → divide by zero for Id 2's matched child
+      }
+    }
+    let sql =
+        "SELECT T.Id, d.x FROM T " +
+        "LEFT JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d " +
+        "ON (1 / d.x) = 0"
+    #expect(applies(try catalog.optimised(sql)))   // NOT decorrelated
+    catalog.expect(sql, fails: .divide)
+  }
+
+  /// NON-EQUI correlation: `S.k > T.Id` has no equi-key to hash on, so the
+  /// OUTER apply stays correlated — and runs correctly with NULL-extension. Id
+  /// 1 → k > 1 → child (2, 200) → 200; Id 2 → k > 2 → none → NULL; Id 3 → none
+  /// → NULL.
+  @Test func `a non-equi correlation stays an apply and NULL-extends`()
+      throws {
+    let sql =
+        "SELECT T.Id, d.x FROM T " +
+        "LEFT JOIN LATERAL (SELECT x FROM S WHERE S.k > T.Id) AS d ON 1 = 1"
+    #expect(applies(try fixture().optimised(sql)))   // NOT decorrelated
+    try fixture().expect(sql + " ORDER BY T.Id, d.x",
+                         yields: [[1, 200], [2, nil], [3, nil]])
+  }
+
+  /// BODY-LOCAL DERIVED table: the body reads its OWN derived `e` (over `S`), a
+  /// per-execution materialised alias the set-based rewrite cannot relay. The
+  /// OUTER apply stays correlated and NULL-extends Id 3 — the derived `e` reads
+  /// `S` (100, 101, 200), never a same-named base relation.
+  @Test func `a body-local derived table stays an apply and NULL-extends`()
+      throws {
+    let sql =
+        "SELECT T.Id, d.x FROM T " +
+        "LEFT JOIN LATERAL (SELECT x FROM (SELECT k, x FROM S) AS e " +
+        "WHERE e.k = T.Id) AS d ON 1 = 1"
+    #expect(applies(try fixture().optimised(sql)))   // NOT decorrelated
+    try fixture().expect(sql + " ORDER BY T.Id, d.x",
+                         yields: [[1, 100], [1, 101], [2, 200], [3, nil]])
+  }
+
+  /// AGGREGATE body: a `COUNT(*)` body is not a plain filter+project, so the
+  /// OUTER apply stays correlated — and runs correctly. Every left row is
+  /// preserved (a LEFT apply), each with its child count: Id 1 → 2, Id 2 → 1,
+  /// Id 3 → 0 (the aggregate over an empty group yields 0, not NULL).
+  @Test func `an aggregate body stays an apply and runs correctly`() throws {
+    let sql =
+        "SELECT T.Id, d.n FROM T LEFT JOIN LATERAL " +
+        "(SELECT COUNT(*) AS n FROM S WHERE S.k = T.Id) AS d ON 1 = 1"
+    #expect(applies(try fixture().optimised(sql)))   // NOT decorrelated
+    try fixture().expect(sql + " ORDER BY T.Id",
+                         yields: [[1, 2], [2, 1], [3, 0]])
+  }
+}
+
+// MARK: - OUTER APPLY adversarial throw-visibility (G4, safe-gate)
+
+struct DecorrelateOuterApplyThrowTests {
+  /// ADVERSARIAL (soundness): an OUTER APPLY whose body WHERE divides by zero
+  /// for an inner row NO left row pairs with. `S`'s divide-by-zero row `(1,
+  /// 100)` is keyed to the ABSENT Id 1, and the body WHERE carries the UNSAFE
+  /// term `1 / (S.x - 100) > 0`. The per-row correlated run never binds `:outer
+  /// = 1`, so it never reaches that inner row — yielding Id 2 (matched (2,
+  /// 200): `1 / 100 = 0`, so `> 0` false ⇒ no match ⇒ NULL-extended) and Id 3
+  /// (no
+  /// child ⇒ NULL), with NO throw. A set-based join over the whole `S` WOULD
+  /// evaluate the divide on `(1, 100)` and throw. The recogniser LEAVES it
+  /// correlated (the body term is unsafe), so the run NULL-extends both left
+  /// rows with no spurious throw — the base behaviour.
+  @Test func `an unreachable throwing inner row is not decorrelated`() throws {
+    let catalog = try Catalog {
+      Relation("T", ["Id": .integer]) {
+        Row(2)
+        Row(3)
+      }
+      Relation("S", ["k": .integer, "x": .integer]) {
+        Row(1, 100)      // x - 100 = 0 → divide by zero, keyed to absent Id 1
+        Row(2, 200)      // safe for Id 2
+      }
+    }
+    let sql =
+        "SELECT T.Id, d.x FROM T " +
+        "LEFT JOIN LATERAL " +
+        "(SELECT x FROM S WHERE S.k = T.Id AND 1 / (S.x - 100) > 0) AS d " +
+        "ON 1 = 1"
+    #expect(applies(try catalog.optimised(sql)))   // NOT decorrelated
+    // Id 2: child (2, 200) → 1 / 100 = 0 → `> 0` false ⇒ no match ⇒ NULL. Id 3:
+    // no child ⇒ NULL. The divide on the Id-1 child is never reached ⇒ no
+    // throw.
+    let rows = try catalog.run(parse(query: sql + " ORDER BY T.Id"), .standard)
+    #expect(rows == [[.integer(2), .null], [.integer(3), .null]])
+  }
+}
+
+// MARK: - Decorrelated OUTER APPLY as an outer join's NULL-extended left side
+
+/// A decorrelated OUTER APPLY tops out in a `.project` (over an `.outer`) that
+/// restores the apply's output geometry. As the LEFT of a further RIGHT/FULL
+/// join, `Plan.slots` must measure that project's width so an unmatched right
+/// row NULL-extends across the FULL left width — the same `Plan.slots`
+/// exhaustiveness the CROSS APPLY case relies on.
+struct DecorrelateOuterApplyWidthTests {
+  private func widthFixture() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["Id": .integer]) {
+        Row(1)
+        Row(2)
+        Row(3)
+      }
+      Relation("S", ["k": .integer, "x": .integer]) {
+        Row(1, 100)
+        Row(1, 101)
+        Row(2, 200)
+      }
+      Relation("U", ["u": .integer]) {
+        Row(700)
+        Row(701)
+      }
+    }
+  }
+
+  /// RIGHT JOIN forcing left NULL-extension over a decorrelated OUTER APPLY.
+  /// The lateral yields the `T ++ d` rows including Id 3's NULL-extended row,
+  /// but
+  /// `RIGHT JOIN U ON 1 = 0` matches none, so every `U` row survives with the
+  /// WHOLE `T ++ d` left width NULL — `U.u` at ordinal 2, `T.Id`/`d.x` NULL.
+  @Test func `a decorrelated OUTER APPLY as a RIGHT join left NULL-extends`()
+      throws {
+    let sql =
+        "SELECT T.Id, d.x, U.u FROM T " +
+        "LEFT JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON 1 = 1 " +
+        "RIGHT JOIN U ON 1 = 0"
+    let plan = try widthFixture().optimised(sql)
+    #expect(!applies(plan))
+    #expect(outers(plan))
+    try widthFixture().expect(sql + " ORDER BY U.u",
+                              yields: [[nil, nil, 700], [nil, nil, 701]])
+  }
+}
+
+// MARK: - OUTER APPLY hash fast-path equivalence
+
+/// The `.outer` executor's hash fast-path must be behaviour-identical to the
+/// nested loop it replaces — same rows, same NULL-extension. A larger-ish
+/// OUTER APPLY (enough keys that the hash and nested-loop paths could diverge
+/// on bucketing or order) is compared against the KNOWN-CORRECT multiset the
+/// correlated OUTER apply produces.
+struct DecorrelateOuterApplyHashTests {
+  /// A wider parent/child so the right side hashes into several buckets. Ids
+  /// 1..5 each key children; Id 4 has none (NULL-extended), Id 5 has two. The
+  /// decorrelated LEFT join's hash fast-path must yield the same multiset the
+  /// correlated OUTER apply does: each matched left row multiplied, each
+  /// unmatched one NULL-extended once.
+  @Test func `the hash fast-path yields the correlated OUTER APPLY multiset`()
+      throws {
+    let catalog = try Catalog {
+      Relation("T", ["Id": .integer]) {
+        Row(1)
+        Row(2)
+        Row(3)
+        Row(4)
+        Row(5)
+      }
+      Relation("S", ["k": .integer, "x": .integer]) {
+        Row(1, 10)
+        Row(2, 20)
+        Row(3, 30)
+        Row(5, 50)
+        Row(5, 51)          // Id 5 has two children (multiplied)
+      }
+    }
+    let sql =
+        "SELECT T.Id, d.x FROM T " +
+        "LEFT JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON 1 = 1 " +
+        "ORDER BY T.Id, d.x"
+    // The hash path fired (an `.outer`, no `.apply`).
+    #expect(!applies(try catalog.optimised(sql)))
+    #expect(outers(try catalog.optimised(sql)))
+    try catalog.expect(sql, yields: [[1, 10], [2, 20], [3, 30], [4, nil],
+                                     [5, 50], [5, 51]])
+  }
+}
+
+// MARK: - OUTER join throw-visibility (fast-path safe-gate)
+
+/// An UNSAFE outer-join `on` — a straddling equi `A.k = B.k` AND a throwing
+/// conjunct like `(1 / B.x) = 0` — must FAULT on a pair the throwing term hits,
+/// never silently NULL-extend the left row. The nested-loop `.outer` executor
+/// evaluates `on` for EVERY (left, right) pair (this evaluator does NOT
+/// short-circuit `AND`: a `false`/UNKNOWN key term still evaluates a throwing
+/// residual), so a non-matching or NULL-key pair whose `(1 / B.x)` divides by
+/// zero raises `.divide`. The `.outer` hash fast-path would SKIP such a pair
+/// (it probes `on` for a left row's matching-key bucket alone) and thus
+/// SUPPRESS the throw — so a `.match`-carrying `on` must never reach the fast
+/// path unless the WHOLE `on` is `safe`. TWO layers enforce this: (1) the
+/// `on()` recogniser (`Resolve.swift`) refuses to form ANY `.match` when the ON
+/// is not `allSatisfy(\.safe)` — so an unsafe user `A.k = B.k` stays a plain
+/// `.compare`, `equikey` finds no key, and the nested loop runs; (2) the
+/// executor's own `on.safe` gate on the fast path (this PR), defence-in-depth
+/// against a future `.match` producer that skips the recogniser's invariant.
+/// These end-to-end oracles PIN the observable invariant across both layers on
+/// a PLAIN LEFT/FULL JOIN (no APPLY).
+struct OuterJoinSafeGateTests {
+  /// A non-matching right row (`B.k = 2 ≠ 1`, `B.x = 0`) makes the throwing
+  /// conjunct `(1 / B.x) = 0` fault under the nested loop, which evaluates it
+  /// for that pair. The unsafe `on` never forms a `.match`, so the nested loop
+  /// runs and raises `.divide` — never NULL-extending `A`.
+  @Test func `an unsafe LEFT JOIN on faults on a non-matching pair`() throws {
+    let catalog = try Catalog {
+      Relation("A", ["k": .integer]) {
+        Row(1)
+      }
+      Relation("B", ["k": .integer, "x": .integer]) {
+        Row(2, 0)           // non-matching key (2 ≠ 1), x = 0 ⇒ 1 / 0 faults
+      }
+    }
+    catalog.expect(
+        "SELECT A.k FROM A LEFT JOIN B ON (1 / B.x) = 0 AND A.k = B.k",
+        fails: .divide)
+  }
+
+  /// A NULL-key right row (`B.k` NULL, `B.x = 0`) would be skipped by the fast
+  /// path (a NULL key buckets/probes nothing), but the nested loop the unsafe
+  /// `on` takes evaluates its throwing conjunct. It must raise `.divide`, not
+  /// NULL-extend `A`.
+  @Test func `an unsafe LEFT JOIN on faults on a NULL-key pair`() throws {
+    let catalog = try Catalog {
+      Relation("A", ["k": .integer]) {
+        Row(1)
+      }
+      Relation("B", ["k": .integer, "x": .integer]) {
+        Row(nil, 0)         // NULL key a fast path would skip; x = 0 ⇒ 1 / 0
+      }
+    }
+    catalog.expect(
+        "SELECT A.k FROM A LEFT JOIN B ON (1 / B.x) = 0 AND A.k = B.k",
+        fails: .divide)
+  }
+
+  /// A FULL join shares the same left-major fast path, so its unsafe `on` must
+  /// fault identically — the recogniser forms no `.match`, the nested loop
+  /// evaluates the non-matching pair, and it raises `.divide`.
+  @Test func `an unsafe FULL JOIN on faults on a non-matching pair`() throws {
+    let catalog = try Catalog {
+      Relation("A", ["k": .integer]) {
+        Row(1)
+      }
+      Relation("B", ["k": .integer, "x": .integer]) {
+        Row(2, 0)           // non-matching key, x = 0 ⇒ 1 / 0 faults
+      }
+    }
+    catalog.expect(
+        "SELECT A.k FROM A FULL JOIN B ON (1 / B.x) = 0 AND A.k = B.k",
+        fails: .divide)
+  }
+
+  /// CONTROL: a SAFE equi LEFT JOIN still takes the fast path and returns the
+  /// correct rows — a matched left row (multiplied by its match count), an
+  /// unmatched one NULL-extended, and a NULL-key left row NULL-extended. An
+  /// added SAFE residual (`B.flag = 1`) keeps `on` safe and still filters.
+  @Test func `a safe equi LEFT JOIN with a residual returns correct rows`()
+      throws {
+    let catalog = try Catalog {
+      Relation("A", ["k": .integer]) {
+        Row(1)              // matches two B rows, one of which fails B.flag = 1
+        Row(2)              // matches no live B row ⇒ NULL-extended
+        Row(nil)            // NULL key ⇒ NULL-extended
+      }
+      Relation("B", ["k": .integer, "flag": .integer]) {
+        Row(1, 1)           // A.k = 1 kept (flag = 1)
+        Row(1, 0)           // A.k = 1 dropped (flag ≠ 1)
+        Row(2, 0)           // A.k = 2 dropped (flag ≠ 1) ⇒ 2 NULL-extends
+      }
+    }
+    try catalog.expect(
+        "SELECT A.k, B.flag FROM A " +
+        "LEFT JOIN B ON A.k = B.k AND B.flag = 1 " +
+        "ORDER BY A.k",
+        yields: [[nil, nil], [1, 1], [2, nil]])
   }
 }


### PR DESCRIPTION
Extend the decorrelation pass to rewrite a correlated OUTER APPLY (`.left` apply) into a LEFT `.outer` join, building on the CROSS APPLY (`.inner`) rewrite. The recogniser reuses every existing guard (single base relation, no body-local derived tables, equi correlation, all-slot projection, safe residuals) and adds a LEFT-specific safe-`on` gate: because a LEFT join's `on` defines the match/NULL-extension condition and cannot be split above the join, the correlation, residual, and apply `on` must fold into one predicate. This engine evaluates an AND's RHS even for an UNKNOWN LHS, so an unsafe apply `on` folded beside a nullable residual could throw for a pair the correlated body WHERE dropped -- so `.left` decorrelates only when the mapped `on` is safe or provably constant-true, leaving it correlated otherwise.

Add a hash fast-path to the `.outer` executor: when `on` carries a straddling equi `.match` conjunct, hash the right side by the key once and probe per left row (O(n+m)), confirming the whole `on` per candidate and NULL-extending misses -- behaviour-identical to the nested loop, and the asymptotic win the apply-to-outer rewrite needs.

Oracles compare the decorrelated result against the correlated OUTER APPLY multiset: NULL-extension, multiplicity, NULL keys, stays-apply cases (unsafe on / non-equi / body-local derived / aggregate), an adversarial unreachable-throw case, the outer-join-width case, and hash-path equivalence.