### PR TITLE
Tests: homogenise test and suite names

### DIFF
--- a/Tests/SQLTests/Expressions/BetweenTests.swift
+++ b/Tests/SQLTests/Expressions/BetweenTests.swift
@@ -312,7 +312,7 @@ private func query(_ text: String) throws -> Query {
   return query
 }
 
-struct BetweenTypecheckTests {
+struct BetweenTypeCheckingTests {
   /// A relation with a text `Name`, so `Name + 1` is a reachable operand fault.
   private func named() throws -> FixtureCatalog {
     try Catalog {

--- a/Tests/SQLTests/Expressions/CaseTests.swift
+++ b/Tests/SQLTests/Expressions/CaseTests.swift
@@ -160,7 +160,7 @@ struct CaseEvaluationTests {
 
 // MARK: - Type unification
 
-struct CaseTypeTests {
+struct CaseTypeUnificationTests {
   private func parse(_ text: String) throws -> Query {
     guard case let .select(query) = try Statement(parsing: text) else {
       Issue.record("expected a SELECT statement")

--- a/Tests/SQLTests/Expressions/CoalesceTests.swift
+++ b/Tests/SQLTests/Expressions/CoalesceTests.swift
@@ -132,7 +132,7 @@ struct CoalesceReachabilityTests {
     _ = try things().columns(of: query("SELECT COALESCE(1, Name + 1) FROM T"))
   }
 
-  @Test func `a constant NULL prefix does NOT stop validation`() throws {
+  @Test func `a constant NULL prefix does not stop validation`() throws {
     // COALESCE steps PAST a NULL argument, so a later one is reachable and MUST
     // be validated. `NULL` is not an expression literal (it is UNKNOWN, spelled
     // only in `IS NULL`), so a DETERMINISTIC routine folding to `.null` stands
@@ -149,7 +149,7 @@ struct CoalesceReachabilityTests {
     }
   }
 
-  @Test func `a non-constant prefix does NOT stop validation`() throws {
+  @Test func `a non-constant prefix does not stop validation`() throws {
     // A row-dependent argument (`K`, a nullable integer) is not a definite
     // selection — the run may fall through it — so a later argument is
     // reachable and validated: `missing_udf()` after `K` still faults
@@ -161,7 +161,7 @@ struct CoalesceReachabilityTests {
     }
   }
 
-  @Test func `a constant NULL prefix does NOT shape the type`() throws {
+  @Test func `a constant NULL prefix does not shape the type`() throws {
     // A run skips a NULL argument and moves on, so an argument that folds to a
     // constant `.null` can never be returned — its DECLARED type must not unify
     // into the column, exactly as a `CASE` omits a skipped branch's result
@@ -199,7 +199,7 @@ struct CoalesceReachabilityTests {
                 == .integer)
   }
 
-  @Test func `a SUM prefix does NOT stop validation`() throws {
+  @Test func `a SUM prefix does not stop validation`() throws {
     // Unlike COUNT, SUM is NULL over an empty group, so it is NOT a definite
     // selection — the run may fall through it — and a later argument stays
     // reachable and MUST be validated: `missing_udf()` after `SUM(K)` still
@@ -312,7 +312,7 @@ struct CoalesceConstantTests {
 /// `COALESCE`: an arm the run reaches must be type-checked, so the COALESCE's
 /// coerced fold value cannot let validation skip a projection execution runs —
 /// mirroring the CASE-coercion end-to-end shape.
-struct CoalesceTypecheckTests {
+struct CoalesceTypeCheckingTests {
   @Test func `a reachable projection is type-checked`() throws {
     // `WHERE is_double(COALESCE(2.5, 1)) = 1 AND …` — the COALESCE selects the
     // `.double` constant, so `is_double` reports 1 and the guard folds TRUE:

--- a/Tests/SQLTests/Expressions/FloatTests.swift
+++ b/Tests/SQLTests/Expressions/FloatTests.swift
@@ -42,7 +42,7 @@ private func arithmetic(_ lhs: Value, _ op: Arithmetic,
 
 // MARK: - Comparison
 
-@Suite("DOUBLE comparison")
+@Suite
 private struct DoubleComparisonTests {
   @Test func `like doubles compare by magnitude`() {
     #expect(compare(.double(1.5), .equal, .double(1.5)) == true)
@@ -61,8 +61,8 @@ private struct DoubleComparisonTests {
 
 // MARK: - Mixed integer/double
 
-@Suite("mixed integer/double comparison")
-private struct MixedComparisonTests {
+@Suite
+private struct MixedNumericComparisonTests {
   @Test func `an integer equals a like-valued double — numeric, not cross-type`() {
     // Both operands are numeric, so `1 = 1.0` is TRUE, not a cross-kind miss.
     #expect(compare(.integer(1), .equal, .double(1.0)) == true)
@@ -81,7 +81,7 @@ private struct MixedComparisonTests {
 
 // MARK: - Arithmetic
 
-@Suite("DOUBLE arithmetic")
+@Suite
 private struct DoubleArithmeticTests {
   @Test func `double arithmetic yields a double`() throws {
     #expect(try arithmetic(.double(1.5), .add, .double(2.0)) == .double(3.5))
@@ -167,7 +167,7 @@ private struct DoubleArithmeticTests {
 
 // MARK: - NULL
 
-@Suite("DOUBLE NULL propagation")
+@Suite
 private struct DoubleNullTests {
   @Test func `a NULL operand is UNKNOWN in a comparison`() {
     #expect(compare(.double(1.5), .equal, .null) == nil)
@@ -182,7 +182,7 @@ private struct DoubleNullTests {
 
 // MARK: - Sort
 
-@Suite("DOUBLE sort ordering")
+@Suite
 private struct DoubleSortTests {
   @Test func `doubles sort ascending by magnitude, NULL first`() {
     // `less` is the sort primitive: NULL precedes every value, and two doubles
@@ -212,7 +212,7 @@ private struct DoubleSortTests {
 
 // MARK: - Literal
 
-@Suite("DOUBLE literal parsing")
+@Suite
 private struct DoubleLiteralTests {
   @Test func `a decimal literal lowers to a double value`() throws {
     let lowered = try value(of: .double(3.14))

--- a/Tests/SQLTests/Expressions/LikeTests.swift
+++ b/Tests/SQLTests/Expressions/LikeTests.swift
@@ -221,7 +221,7 @@ struct LikeThreeValuedTests {
 
 // MARK: - Type checking
 
-struct LikeTypeTests {
+struct LikeTypeCheckingTests {
   /// Parses `text` to a query, failing on any other statement.
   private func parse(_ text: String) throws -> Query {
     guard case let .select(query) = try Statement(parsing: text) else {

--- a/Tests/SQLTests/Expressions/MembershipTests.swift
+++ b/Tests/SQLTests/Expressions/MembershipTests.swift
@@ -121,7 +121,7 @@ struct MembershipEvaluationTests {
 
 // MARK: - Type checking
 
-struct MembershipTypeTests {
+struct MembershipTypeCheckingTests {
   /// Parses `text` to a query, failing on any other statement.
   private func parse(_ text: String) throws -> Query {
     guard case let .select(query) = try Statement(parsing: text) else {

--- a/Tests/SQLTests/Expressions/QuantifiedSubqueryTests.swift
+++ b/Tests/SQLTests/Expressions/QuantifiedSubqueryTests.swift
@@ -268,7 +268,7 @@ struct QuantifiedArityTests {
 
 // MARK: - Type checking
 
-struct QuantifiedTypeTests {
+struct QuantifiedTypeCheckingTests {
   @Test func `columns validates a quantified query matching the run`() throws {
     let query = try parse(
         query: "SELECT Id FROM T WHERE K < ANY (SELECT V FROM S)")

--- a/Tests/SQLTests/Expressions/ValueTypeTests.swift
+++ b/Tests/SQLTests/Expressions/ValueTypeTests.swift
@@ -33,8 +33,8 @@ private func compare(_ cell: Value, _ op: Comparison,
 
 // MARK: - Boolean
 
-@Suite("BOOLEAN value type")
-private struct BooleanTests {
+@Suite
+private struct BooleanValueTests {
   @Test func `false orders before true`() {
     #expect(compare(.boolean(false), .lt, .boolean(true)) == true)
     #expect(compare(.boolean(true), .lt, .boolean(false)) == false)
@@ -59,8 +59,8 @@ private struct BooleanTests {
 
 // MARK: - Blob
 
-@Suite("BLOB value type")
-private struct BlobTests {
+@Suite
+private struct BlobValueTests {
   @Test func `like blobs compare by byte equality`() {
     #expect(compare(.blob([0x53, 0x51, 0x4c]), .equal,
                     .blob([0x53, 0x51, 0x4c])) == true)
@@ -92,8 +92,8 @@ private struct BlobTests {
 
 // MARK: - Cross-type
 
-@Suite("cross-type comparison")
-private struct CrossTypeTests {
+@Suite
+private struct CrossTypeComparisonTests {
   @Test func `unlike types never match — no coercion`() {
     // Every non-null cross-type pair falls to the switch's `default: false`.
     #expect(compare(.boolean(true), .equal, .integer(1)) == false)

--- a/Tests/SQLTests/Optimisation/ConstantFoldTests.swift
+++ b/Tests/SQLTests/Optimisation/ConstantFoldTests.swift
@@ -122,7 +122,7 @@ struct FilterConstantTests {
                            .constant(.integer(1))).constant == nil)
   }
 
-  @Test func `AND folds only when BOTH operands are constant`() {
+  @Test func `AND folds only when both operands are constant`() {
     let t = Filter.compare(.constant(.integer(1)), .equal,
                            .constant(.integer(1)))
     let f = Filter.compare(.constant(.integer(1)), .equal,
@@ -138,7 +138,7 @@ struct FilterConstantTests {
     #expect(Filter.and(slot, f).constant == nil)
   }
 
-  @Test func `OR folds only when BOTH operands are constant`() {
+  @Test func `OR folds only when both operands are constant`() {
     let t = Filter.compare(.constant(.integer(1)), .equal,
                            .constant(.integer(1)))
     let f = Filter.compare(.constant(.integer(1)), .equal,
@@ -214,7 +214,7 @@ struct ConstantSelectFoldTests {
     try numbers().empty("SELECT Id FROM N WHERE 1 = NULLIF(1, 1)")
   }
 
-  @Test func `an always-true OR does NOT drop a throwing operand`() throws {
+  @Test func `an always-true OR does not drop a throwing operand`() throws {
     // The reviewer case: `(1 / X) = 0` reads a row slot and, with `X = 0`,
     // THROWS `SQLError.divide` when evaluated. The `OR 1 = 1` disjunct is
     // constant-true, but the compound OR is NOT a compile-time constant (the
@@ -254,7 +254,7 @@ struct ConstantApplyFoldTests {
         yields: [[1, 100], [1, 101], [2, 200]])
   }
 
-  @Test func `a LATERAL ON does NOT skip a throwing predicate`() throws {
+  @Test func `a LATERAL ON does not skip a throwing predicate`() throws {
     // The apply's `ON` is not always `1 = 1`: `(1 / (T.Id - 1)) = 0 OR 1 = 1`
     // has an undecidable, throwing left disjunct, so the compound is NOT a
     // compile-time constant and the `ON` is NOT skipped. The outer `T.Id = 1`

--- a/Tests/SQLTests/Queries/OrderByExpressionTests.swift
+++ b/Tests/SQLTests/Queries/OrderByExpressionTests.swift
@@ -1025,14 +1025,14 @@ struct OrderByLazyProjectionTests {
         """)
   }
 
-  @Test func `an unreferenced output IS computed for a surviving row`() throws {
+  @Test func `an unreferenced output is computed for a surviving row`() throws {
     // A non-empty page: `y` (unreferenced by the sort) computes correctly for
     // each surviving row, so the lazy split still returns the right values.
     try people().expect("SELECT Id AS x, Id * 2 AS y FROM People ORDER BY x",
                         yields: [[1, 2], [2, 4], [3, 6], [4, 8]])
   }
 
-  @Test func `an unreferenced faulting output STILL faults for a surviving row`() throws {
+  @Test func `an unreferenced faulting output still faults for a surviving row`() throws {
     // The laziness is a page skip, not a licence to drop a fault: with rows
     // surviving the cap the unreferenced `1 / 0` must still evaluate and fault.
     try people().expect("""

--- a/Tests/SQLTests/Queries/ScalarSubqueryTests.swift
+++ b/Tests/SQLTests/Queries/ScalarSubqueryTests.swift
@@ -273,7 +273,7 @@ struct ScalarSubqueryWidthTests {
 
 // MARK: - Type checking
 
-struct ScalarSubqueryTypeTests {
+struct ScalarSubqueryTypeCheckingTests {
   @Test func `columns validates a scalar-subquery query`() throws {
     let query = try parse(query: "SELECT (SELECT MAX(V) FROM S) FROM T")
     let columns = try fixture().columns(of: query, validate: true)

--- a/Tests/SQLTests/Queries/SubqueryTests.swift
+++ b/Tests/SQLTests/Queries/SubqueryTests.swift
@@ -287,7 +287,7 @@ struct InQueryArityTests {
 
 // MARK: - Type checking
 
-struct SubqueryTypeTests {
+struct SubqueryTypeCheckingTests {
   @Test func `columns validates a query using EXISTS`() throws {
     let query =
         try parse(query: "SELECT Id FROM T WHERE EXISTS (SELECT V FROM S)")

--- a/Tests/SQLTests/Schema/ErrorTests.swift
+++ b/Tests/SQLTests/Schema/ErrorTests.swift
@@ -9,7 +9,7 @@ import SQLTestSupport
 /// A throwaway location for cases that carry one.
 private let here = SourceLocation(line: 1, column: 1, offset: 0)
 
-@Suite("SQLSTATE")
+@Suite
 struct SQLStateTests {
   @Test func `an undefined column reports 42703`() {
     #expect(SQLError.column("Missing").sqlstate == "42703")
@@ -117,7 +117,7 @@ private func sqlstate(_ sql: String, _ catalog: borrowing FixtureCatalog)
   }
 }
 
-@Suite("reclassified SQLSTATE")
+@Suite
 struct ReclassifiedSQLStateTests {
   @Test func `an empty IN list reports 42601`() throws {
     // A `Predicate.membership` with an empty list, built directly to bypass the

--- a/Tests/winmd-inspectTests/ValueDisplayTests.swift
+++ b/Tests/winmd-inspectTests/ValueDisplayTests.swift
@@ -9,7 +9,7 @@ import SQLEngine
 
 // MARK: - Boolean
 
-@Suite("BOOLEAN display")
+@Suite
 private struct BooleanDisplayTests {
   @Test func `a boolean renders as TRUE or FALSE`() {
     #expect(Value.boolean(true).display == "TRUE")
@@ -19,7 +19,7 @@ private struct BooleanDisplayTests {
 
 // MARK: - Double
 
-@Suite("DOUBLE display")
+@Suite
 private struct DoubleDisplayTests {
   @Test func `a double renders through its round-tripping description`() {
     #expect(Value.double(3.14).display == "3.14")
@@ -34,7 +34,7 @@ private struct DoubleDisplayTests {
 
 // MARK: - Blob
 
-@Suite("BLOB display")
+@Suite
 private struct BlobDisplayTests {
   @Test func `a blob renders as a lowercase-hex x'…' literal`() {
     #expect(Value.blob([0x53, 0x51, 0x4c]).display == "x'53514c'")


### PR DESCRIPTION
Use consistent naming for the tests and suites.