### PR TITLE
SQLTests,SQLTestSupport: extract shared helpers

### DIFF
--- a/Sources/SQLTestSupport/Expect.swift
+++ b/Sources/SQLTestSupport/Expect.swift
@@ -22,37 +22,34 @@ import Testing
 /// caller's, and runs through the engine's public `Catalog.run`, so the
 /// framework needs no `@testable` import.
 
-/// Parses `sql` to a `Query`, trapping on any other statement.
-private func query(_ sql: String) throws(SQLError) -> Query {
-  guard case let .select(query) = try Statement(parsing: sql) else {
-    throw SQLError.incomplete(expected: "a SELECT statement")
-  }
-  return query
-}
-
 extension Catalog where Self: ~Escapable {
   /// Runs `sql` against this catalog through the given routines and bindings.
   private borrowing func run(_ sql: String, routines: Routines,
                              bindings: Bindings)
       throws(SQLError) -> Array<Array<Value>> {
-    try run(query(sql), routines, bindings: bindings)
+    try run(parse(query: sql), routines, bindings: bindings)
   }
 
   /// Checks `sql` run against this catalog yields exactly `rows`, each row a
   /// list of Swift literals lifted into `Value`s.
   public borrowing func expect(_ sql: String,
-      yields rows: Array<Array<(any ValueConvertible)?>>,
-      routines: Routines = .standard, bindings: Bindings = [:],
-      location: Testing.SourceLocation = #_sourceLocation) throws {
+                               yields rows: Array<Array<(any ValueConvertible)?>>,
+                               routines: Routines = .standard,
+                               bindings: Bindings = [:],
+                               location: Testing.SourceLocation =
+                                  #_sourceLocation)
+      throws {
     let expected = rows.map { $0.map { $0?.value ?? .null } }
     let actual = try run(sql, routines: routines, bindings: bindings)
     #expect(actual == expected, sourceLocation: location)
   }
 
   /// Checks `sql` run against this catalog yields no rows.
-  public borrowing func empty(_ sql: String,
-      routines: Routines = .standard, bindings: Bindings = [:],
-      location: Testing.SourceLocation = #_sourceLocation) throws {
+  public borrowing func empty(_ sql: String, routines: Routines = .standard,
+                              bindings: Bindings = [:],
+                              location: Testing.SourceLocation =
+                                  #_sourceLocation)
+      throws {
     let actual = try run(sql, routines: routines, bindings: bindings)
     #expect(actual.isEmpty, sourceLocation: location)
   }
@@ -79,8 +76,11 @@ extension Catalog where Self: ~Escapable {
   /// Checks two queries run against this catalog yield the same rows — the
   /// seek / scan (or hash / seek) equivalence idiom.
   public borrowing func expect(_ lhs: String, equals rhs: String,
-      routines: Routines = .standard, bindings: Bindings = [:],
-      location: Testing.SourceLocation = #_sourceLocation) throws {
+                               routines: Routines = .standard,
+                               bindings: Bindings = [:],
+                               location: Testing.SourceLocation =
+                                  #_sourceLocation)
+      throws {
     let left = try run(lhs, routines: routines, bindings: bindings)
     let right = try run(rhs, routines: routines, bindings: bindings)
     #expect(left == right, sourceLocation: location)

--- a/Sources/SQLTestSupport/Fixture.swift
+++ b/Sources/SQLTestSupport/Fixture.swift
@@ -82,8 +82,7 @@ public struct FixtureRelation: Sendable {
   /// materialise fewer rows.
   public let counter: FixtureCounter?
 
-  public init(_ fields: Array<FixtureField>,
-              _ records: Array<Array<Value>>,
+  public init(_ fields: Array<FixtureField>, _ records: Array<Array<Value>>,
               sorted: Int? = nil, coded: Int? = nil,
               counter: FixtureCounter? = nil) {
     self.fields = fields

--- a/Sources/SQLTestSupport/Fixtures.swift
+++ b/Sources/SQLTestSupport/Fixtures.swift
@@ -1,0 +1,43 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import SQLEngine
+
+/// A nullable integer and text fixture shared by expression tests whose result
+/// type and NULL fallthrough depend on the same two rows.
+public func nullable() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["Id": .integer, "K": .integer, "Name": .text]) {
+      Row(1, 10, "a")
+      Row(2, nil, "b")
+    }
+  }
+}
+
+/// An empty `People(Name TEXT)` relation for schema-only expression derivation.
+public func derivation() -> FixtureCatalog {
+  FixtureCatalog(
+    ["People": FixtureRelation([FixtureField(name: "Name", type: .text)], [])])
+}
+
+/// The common outer, inner, and NULL-bearing relations used by membership and
+/// quantified subquery tests.
+public func subqueries() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["Id": .integer, "K": .integer]) {
+      Row(1, 10)
+      Row(2, 20)
+      Row(3, nil)
+      Row(4, 30)
+    }
+    Relation("S", ["V": .integer, "Flag": .integer]) {
+      Row(10, 1)
+      Row(20, 1)
+      Row(99, 0)
+    }
+    Relation("N", ["V": .integer]) {
+      Row(2)
+      Row(nil)
+    }
+  }
+}

--- a/Sources/SQLTestSupport/Parsing.swift
+++ b/Sources/SQLTestSupport/Parsing.swift
@@ -1,0 +1,44 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import SQLEngine
+import Testing
+
+/// Parses `text` as a single, non-compound `SELECT`, recording a test issue
+/// before rejecting any other statement or compound-query shape.
+public func parse(select text: String,
+                  location: Testing.SourceLocation = #_sourceLocation)
+    throws(SQLError) -> Select {
+  guard case let .select(.select(select)) = try Statement(parsing: text) else {
+    Issue.record("expected a single SELECT statement",
+                 sourceLocation: location)
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return select
+}
+
+/// Parses `text` as a query, recording a test issue before rejecting a
+/// non-query statement.
+public func parse(query text: String,
+                  location: Testing.SourceLocation = #_sourceLocation)
+    throws(SQLError) -> Query {
+  guard case let .select(query) = try Statement(parsing: text) else {
+    Issue.record("expected a SELECT statement", sourceLocation: location)
+    throw SQLError.incomplete(expected: "a SELECT statement")
+  }
+  return query
+}
+
+extension FixtureCatalog {
+  /// Resolves the single output type of `sql`, recording an issue if it does
+  /// not project exactly one column.
+  public borrowing func type(of sql: String, routines: Routines = [:],
+                             location: Testing.SourceLocation =
+                                 #_sourceLocation)
+      throws(SQLError) -> ValueType {
+    let columns = try columns(of: parse(query: sql, location: location),
+                              routines: routines)
+    #expect(columns.count == 1, sourceLocation: location)
+    return columns[0].type
+  }
+}

--- a/Tests/SQLTests/Expressions/BetweenTests.swift
+++ b/Tests/SQLTests/Expressions/BetweenTests.swift
@@ -22,15 +22,6 @@ private func things() throws -> FixtureCatalog {
   }
 }
 
-/// Parses `text` and returns its `Select`, failing on any other shape.
-private func parse(select text: String) throws -> Select {
-  guard case let .select(.select(select)) = try Statement(parsing: text) else {
-    Issue.record("expected a single SELECT statement")
-    throw SQLError.incomplete(expected: "a SELECT statement")
-  }
-  return select
-}
-
 // MARK: - Parsing
 
 struct BetweenParsingTests {
@@ -303,15 +294,6 @@ struct BetweenShortCircuitTests {
 
 // MARK: - Typecheck short-circuit
 
-/// Parses `text` to a `Query`, failing on any other shape.
-private func query(_ text: String) throws -> Query {
-  guard case let .select(query) = try Statement(parsing: text) else {
-    Issue.record("expected a SELECT statement")
-    throw SQLError.incomplete(expected: "a SELECT statement")
-  }
-  return query
-}
-
 struct BetweenTypeCheckingTests {
   /// A relation with a text `Name`, so `Name + 1` is a reachable operand fault.
   private func named() throws -> FixtureCatalog {
@@ -331,7 +313,7 @@ struct BetweenTypeCheckingTests {
     // reached) is unreachable, and `columns(of:validate:)` SUCCEEDS. The run
     // drops every row before the projection, yielding no rows and NO throw.
     let text = "SELECT Name + 1 FROM T WHERE 0 BETWEEN 1 AND (1 / 0)"
-    _ = try named().columns(of: query(text))
+    _ = try named().columns(of: parse(query: text))
     try named().empty(text)
   }
 }
@@ -382,7 +364,7 @@ struct BetweenSeekTests {
     // `> 7` at index 7) — exactly the range `Id >= 3 AND Id <= 7` would seek,
     // not scan all ten rows.
     let catalog = try sorted()
-    let query = try query("SELECT Id FROM T WHERE Id BETWEEN 3 AND 7")
+    let query = try parse(query: "SELECT Id FROM T WHERE Id BETWEEN 3 AND 7")
     let plan = try catalog.optimise(catalog.compile(query), [:])
     #expect(seek(plan) == 2 ..< 7)
     try catalog.expect("SELECT Id FROM T WHERE Id BETWEEN 3 AND 7",
@@ -398,7 +380,7 @@ struct BetweenSeekTests {
     // the rows, and the BETWEEN run sits within the comparison's.
     let catalog = try sorted()
     let comparison =
-        try query("SELECT Id FROM T WHERE Id >= 3 AND Id <= 7")
+        try parse(query: "SELECT Id FROM T WHERE Id >= 3 AND Id <= 7")
     let compiled = try catalog.compile(comparison)
     let range = try #require(seek(catalog.optimise(compiled, [:])))
     #expect(range.lowerBound <= 2 && range.upperBound >= 7)
@@ -412,7 +394,8 @@ struct BetweenSeekTests {
     // contiguous seek — so it scans under the residual and returns the
     // out-of-range rows.
     let catalog = try sorted()
-    let query = try query("SELECT Id FROM T WHERE Id NOT BETWEEN 3 AND 7")
+    let query = try parse(query:
+        "SELECT Id FROM T WHERE Id NOT BETWEEN 3 AND 7")
     let plan = try catalog.optimise(catalog.compile(query), [:])
     #expect(seek(plan) == nil)
     try catalog.expect("SELECT Id FROM T WHERE Id NOT BETWEEN 3 AND 7",
@@ -425,7 +408,8 @@ struct BetweenSeekTests {
     // so it does not qualify for the seek; it scans and filters, admitting the
     // same rows the seeked `Id BETWEEN 3 AND 7` would.
     let catalog = try sorted()
-    let query = try query("SELECT Id FROM T WHERE Id + 1 BETWEEN 4 AND 8")
+    let query = try parse(query:
+        "SELECT Id FROM T WHERE Id + 1 BETWEEN 4 AND 8")
     let plan = try catalog.optimise(catalog.compile(query), [:])
     #expect(seek(plan) == nil)
     try catalog.expect("SELECT Id FROM T WHERE Id + 1 BETWEEN 4 AND 8",
@@ -438,7 +422,7 @@ struct BetweenSeekTests {
     // integer literal, so it does not qualify for the seek; it scans and admits
     // every row whose `Id >= 3` (each row's own `Id` is its upper bound).
     let catalog = try sorted()
-    let query = try query("SELECT Id FROM T WHERE Id BETWEEN 3 AND Id")
+    let query = try parse(query: "SELECT Id FROM T WHERE Id BETWEEN 3 AND Id")
     let plan = try catalog.optimise(catalog.compile(query), [:])
     #expect(seek(plan) == nil)
     try catalog.expect("SELECT Id FROM T WHERE Id BETWEEN 3 AND Id",
@@ -454,7 +438,7 @@ struct BetweenSeekTests {
     // guard detects the inversion and seeks the EMPTY run `9 ..< 9` instead, so
     // the query returns no rows and never traps.
     let catalog = try sorted()
-    let query = try query("SELECT Id FROM T WHERE Id BETWEEN 10 AND 1")
+    let query = try parse(query: "SELECT Id FROM T WHERE Id BETWEEN 10 AND 1")
     let plan = try catalog.optimise(catalog.compile(query), [:])
     let range = try #require(seek(plan))
     #expect(range.isEmpty)
@@ -469,7 +453,8 @@ struct BetweenSeekTests {
     // feature replaces does not regress against the `Id >= :lo AND Id <= :hi`
     // desugar's seek.
     let catalog = try sorted()
-    let query = try query("SELECT Id FROM T WHERE Id BETWEEN :lo AND :hi")
+    let query = try parse(query:
+        "SELECT Id FROM T WHERE Id BETWEEN :lo AND :hi")
     let bindings: Bindings = ["lo": .integer(3), "hi": .integer(7)]
     let compiled = try catalog.compile(query)
     let plan = try catalog.optimise(compiled, bindings)
@@ -484,7 +469,8 @@ struct BetweenSeekTests {
     // `between` — which reads the unbound `:hi` as NULL, UNKNOWN for every row,
     // so none passes. It seeks nothing rather than mis-seeking.
     let catalog = try sorted()
-    let query = try query("SELECT Id FROM T WHERE Id BETWEEN :lo AND :hi")
+    let query = try parse(query:
+        "SELECT Id FROM T WHERE Id BETWEEN :lo AND :hi")
     let plan = try catalog.optimise(catalog.compile(query),
                                     ["lo": .integer(3)])
     #expect(seek(plan) == nil)
@@ -517,7 +503,7 @@ struct BetweenEmptyGroupTests {
         SELECT COUNT(*) FROM T WHERE 1 = 0
         HAVING 0 BETWEEN 1 AND (1 / 0)
         """
-    _ = try numbers().columns(of: query(text))
+    _ = try numbers().columns(of: parse(query: text))
     try numbers().empty(text)
   }
 }

--- a/Tests/SQLTests/Expressions/CaseTests.swift
+++ b/Tests/SQLTests/Expressions/CaseTests.swift
@@ -23,15 +23,6 @@ private func things() throws -> FixtureCatalog {
 
 // MARK: - Parsing
 
-/// Parses `text` and returns its `Select`, failing on any other shape.
-private func parse(select text: String) throws -> Select {
-  guard case let .select(.select(select)) = try Statement(parsing: text) else {
-    Issue.record("expected a single SELECT statement")
-    throw SQLError.incomplete(expected: "a SELECT statement")
-  }
-  return select
-}
-
 struct CaseParsingTests {
   @Test func `parses a searched CASE`() throws {
     let select = try parse(select: """
@@ -161,34 +152,20 @@ struct CaseEvaluationTests {
 // MARK: - Type unification
 
 struct CaseTypeUnificationTests {
-  private func parse(_ text: String) throws -> Query {
-    guard case let .select(query) = try Statement(parsing: text) else {
-      Issue.record("expected a SELECT statement")
-      throw SQLError.incomplete(expected: "a SELECT statement")
-    }
-    return query
-  }
-
-  /// The single output column type of a one-column query's schema.
-  private func type(of text: String) throws -> ValueType {
-    let columns = try things().columns(of: parse(text))
-    #expect(columns.count == 1)
-    return columns[0].type
-  }
-
   @Test func `like result types unify to that type`() throws {
-    #expect(try type(of: "SELECT CASE WHEN K = 1 THEN K ELSE 0 END AS C FROM T")
+    #expect(try things().type(
+        of: "SELECT CASE WHEN K = 1 THEN K ELSE 0 END AS C FROM T")
                 == .integer)
   }
 
   @Test func `mixed integer and double results widen to double`() throws {
-    #expect(try type(of:
+    #expect(try things().type(of:
         "SELECT CASE WHEN K = 1 THEN 1 ELSE 2.5 END AS C FROM T") == .double)
   }
 
   @Test func `irreconcilable result types fault`() throws {
     // An integer result beside a text result cannot yield one column type.
-    let query = try parse(
+    let query = try parse(query:
         "SELECT CASE WHEN K = 1 THEN 1 ELSE Name END AS C FROM T")
     let resolve = { () throws -> Array<OutputColumn> in
       try things().columns(of: query)
@@ -212,7 +189,7 @@ struct CaseTypeUnificationTests {
     try things().expect(text,
         fails: .operand("CASE results have irreconcilable types"))
     let resolve = { () throws -> Array<OutputColumn> in
-      try things().columns(of: parse(text))
+      try things().columns(of: parse(query: text))
     }
     #expect(throws:
         SQLError.operand("CASE results have irreconcilable types")) {
@@ -228,19 +205,12 @@ struct CaseTypeUnificationTests {
 /// so its operands are not validated; once an earlier guard is constant-TRUE
 /// every later branch and the `ELSE` are unreachable too.
 struct CaseReachabilityTests {
-  private func parse(_ text: String) throws -> Query {
-    guard case let .select(query) = try Statement(parsing: text) else {
-      Issue.record("expected a SELECT statement")
-      throw SQLError.incomplete(expected: "a SELECT statement")
-    }
-    return query
-  }
 
   @Test func `a constant-false guard's bad result is unreachable`() throws {
     // `1 = 0` is statically false, so `Name + 1` (text arithmetic) is never
     // evaluated — the type check validates the reachable `ELSE 0` only and the
     // column types as its integer.
-    let query = try parse(
+    let query = try parse(query:
         "SELECT CASE WHEN 1 = 0 THEN Name + 1 ELSE 0 END AS C FROM T")
     let columns = try things().columns(of: query, validate: true)
     #expect(columns.count == 1)
@@ -258,7 +228,7 @@ struct CaseReachabilityTests {
   @Test func `a reachable bad result still faults`() throws {
     // `Id = 1` is per-row, not statically false, so `Name + 1` IS reachable and
     // the text arithmetic must still fault.
-    let query = try parse(
+    let query = try parse(query:
         "SELECT CASE WHEN Id = 1 THEN Name + 1 ELSE 0 END AS C FROM T")
     let resolve = { () throws -> Array<OutputColumn> in
       try things().columns(of: query, validate: true)
@@ -274,7 +244,7 @@ struct CaseReachabilityTests {
     // `WHEN 1 = 1 THEN Name + 1` is unreachable — its operands are not
     // validated, so the type check passes and the column types as the first
     // result's integer.
-    let query = try parse("""
+    let query = try parse(query: """
         SELECT CASE WHEN 1 = 1 THEN 0 WHEN 1 = 1 THEN Name + 1 END AS C FROM T
         """)
     let columns = try things().columns(of: query, validate: true)
@@ -289,7 +259,7 @@ struct CaseReachabilityTests {
     // is REACHABLE and its `Name + 1` (text arithmetic) must still fault. The
     // constant-TRUE guard drops only the STRICTLY-LATER branches and the ELSE,
     // not the branches before it.
-    let query = try parse("""
+    let query = try parse(query: """
         SELECT CASE WHEN Id = 1 THEN Name + 1 WHEN 1 = 1 THEN 0 END AS C FROM T
         """)
     let resolve = { () throws -> Array<OutputColumn> in
@@ -305,7 +275,7 @@ struct CaseReachabilityTests {
     // The earlier reachable `THEN Name` (text) and the constant-TRUE guard's
     // `THEN 0` (integer) both shape the column, so their irreconcilable types
     // must be reported rather than the constant-TRUE branch's alone winning.
-    let query = try parse("""
+    let query = try parse(query: """
         SELECT CASE WHEN Id = 1 THEN Name WHEN 1 = 1 THEN 0 END AS C FROM T
         """)
     let resolve = { () throws -> Array<OutputColumn> in
@@ -326,13 +296,6 @@ struct CaseReachabilityTests {
 /// as the executor's `Row.conditional` does, or the folded value clashes the
 /// advertised column type and a routine argument the run accepts is rejected.
 struct CaseEmptyGroupTests {
-  private func parse(_ text: String) throws -> Query {
-    guard case let .select(query) = try Statement(parsing: text) else {
-      Issue.record("expected a SELECT statement")
-      throw SQLError.incomplete(expected: "a SELECT statement")
-    }
-    return query
-  }
 
   /// `CASE WHEN COUNT(*) = 0 THEN COUNT(*) ELSE 2.5 END` — a mixed CASE whose
   /// guard is NOT statically decidable (a `COUNT(*)` operand), so BOTH arms are
@@ -366,7 +329,7 @@ struct CaseEmptyGroupTests {
     let f = Function(parameters: [Function.Parameter(name: "x", type: .double)],
                      returns: .double, body: .column("x"))
     let routines = try Routines().registering("f", f)
-    let query = try parse("""
+    let query = try parse(query: """
         SELECT f(CASE WHEN COUNT(*) = 0 THEN COUNT(*) ELSE 2.5 END) AS C
           FROM T WHERE 1 = 0
         """)

--- a/Tests/SQLTests/Expressions/CastTests.swift
+++ b/Tests/SQLTests/Expressions/CastTests.swift
@@ -26,15 +26,6 @@ private func things() throws -> FixtureCatalog {
 
 // MARK: - Parsing
 
-/// Parses `text` and returns its `Select`, failing on any other shape.
-private func parse(select text: String) throws -> Select {
-  guard case let .select(.select(select)) = try Statement(parsing: text) else {
-    Issue.record("expected a single SELECT statement")
-    throw SQLError.incomplete(expected: "a SELECT statement")
-  }
-  return select
-}
-
 struct CastParsingTests {
   @Test func `parses a CAST to a typed conversion`() throws {
     let select = try parse(select: "SELECT CAST(Id AS DOUBLE) FROM C")
@@ -157,26 +148,14 @@ struct CastValueTests {
 // MARK: - Schema and column
 
 struct CastSchemaTests {
-  private func parse(_ text: String) throws -> Query {
-    guard case let .select(query) = try Statement(parsing: text) else {
-      Issue.record("expected a SELECT statement")
-      throw SQLError.incomplete(expected: "a SELECT statement")
-    }
-    return query
-  }
-
-  /// The single output column type of a one-column query's schema.
-  private func type(of text: String) throws -> ValueType {
-    let columns = try things().columns(of: parse(text))
-    #expect(columns.count == 1)
-    return columns[0].type
-  }
-
   @Test func `the schema reports the target type`() throws {
     // The cast's static type is the target, whatever the operand's own type.
-    #expect(try type(of: "SELECT CAST(Id AS DOUBLE) AS V FROM C") == .double)
-    #expect(try type(of: "SELECT CAST(D AS INTEGER) AS V FROM C") == .integer)
-    #expect(try type(of: "SELECT CAST(Id AS TEXT) AS V FROM C") == .text)
+    #expect(try things().type(of: "SELECT CAST(Id AS DOUBLE) AS V FROM C")
+                == .double)
+    #expect(try things().type(of: "SELECT CAST(D AS INTEGER) AS V FROM C")
+                == .integer)
+    #expect(try things().type(of: "SELECT CAST(Id AS TEXT) AS V FROM C")
+                == .text)
   }
 
   @Test func `casting over a column converts each row`() throws {
@@ -198,7 +177,7 @@ struct CastSchemaTests {
     // schema type-check rejects it rather than advertising an integer column.
     #expect(throws: SQLError.state("42846",
                                    "cannot cast boolean to integer")) {
-      _ = try things().columns(of: parse("SELECT CAST(TRUE AS INTEGER)"))
+      _ = try things().columns(of: parse(query: "SELECT CAST(TRUE AS INTEGER)"))
     }
   }
 
@@ -206,8 +185,8 @@ struct CastSchemaTests {
     // A castable-but-value-dependent pair — `integer` → `double` always
     // convertible, `text` → `integer` convertible for a good spelling —
     // type-checks and reports the target type; only a bad VALUE faults at run.
-    #expect(try type(of: "SELECT CAST(1 AS DOUBLE)") == .double)
-    #expect(try type(of: "SELECT CAST('1' AS INTEGER)") == .integer)
+    #expect(try things().type(of: "SELECT CAST(1 AS DOUBLE)") == .double)
+    #expect(try things().type(of: "SELECT CAST('1' AS INTEGER)") == .integer)
   }
 
   @Test func `a constant cast that always fails is rejected at validation`()
@@ -217,7 +196,8 @@ struct CastSchemaTests {
     // at validation, not only at run.
     #expect(throws: SQLError.state("22018",
                                    "cannot cast 'abc' to integer")) {
-      _ = try things().columns(of: parse("SELECT CAST('abc' AS INTEGER)"))
+      let query = try parse(query: "SELECT CAST('abc' AS INTEGER)")
+      _ = try things().columns(of: query)
     }
   }
 
@@ -228,7 +208,7 @@ struct CastSchemaTests {
     // to `.blob` — a NULL casts to ANY target — and validation SUCCEEDS with a
     // blob column rather than rejecting `42846` a query the run would perform.
     let sql = "SELECT CAST(CASE WHEN 1 = 0 THEN 1 END AS BLOB)"
-    let columns = try things().columns(of: parse(sql), validate: true)
+    let columns = try things().columns(of: parse(query: sql), validate: true)
     #expect(columns.count == 1)
     #expect(columns[0].type == .blob)
     try things().expect(sql, yields: [[nil]])
@@ -240,7 +220,7 @@ struct CastSchemaTests {
     // `42846`, the same fault the structural check would raise.
     #expect(throws: SQLError.state("42846",
                                    "cannot cast boolean to integer")) {
-      _ = try things().columns(of: parse("SELECT CAST(TRUE AS INTEGER)"),
+      _ = try things().columns(of: parse(query: "SELECT CAST(TRUE AS INTEGER)"),
                                validate: true)
     }
   }
@@ -252,7 +232,8 @@ struct CastSchemaTests {
     // without a value to trial.
     #expect(throws: SQLError.state("42846",
                                    "cannot cast boolean to integer")) {
-      _ = try things().columns(of: parse("SELECT CAST(B AS INTEGER) FROM C"),
+      let query = try parse(query: "SELECT CAST(B AS INTEGER) FROM C")
+      _ = try things().columns(of: query,
                                validate: true)
     }
   }
@@ -261,7 +242,7 @@ struct CastSchemaTests {
     // `CAST('1' AS INTEGER)` is a castable pair whose fault depends on the
     // value, so it type-checks as an integer column even after the reorder —
     // the trial cast of the constant `'1'` succeeds.
-    #expect(try type(of: "SELECT CAST('1' AS INTEGER)") == .integer)
+    #expect(try things().type(of: "SELECT CAST('1' AS INTEGER)") == .integer)
   }
 }
 

--- a/Tests/SQLTests/Expressions/CoalesceTests.swift
+++ b/Tests/SQLTests/Expressions/CoalesceTests.swift
@@ -6,40 +6,6 @@ import Testing
 
 import SQLTestSupport
 
-// MARK: - Fixture
-
-/// A relation exercising `COALESCE`: a nullable integer `K` and a text `Name`,
-/// so a NULL fallthrough and a type unification are reachable.
-private func things() throws -> FixtureCatalog {
-  try Catalog {
-    Relation("T", ["Id": .integer, "K": .integer, "Name": .text]) {
-      Row(1, 10, "a")
-      Row(2, nil, "b")
-    }
-  }
-}
-
-/// Parses `text` and returns its `Select`, failing on any other shape.
-private func parse(select text: String) throws -> Select {
-  guard case let .select(.select(select)) = try Statement(parsing: text) else {
-    Issue.record("expected a single SELECT statement")
-    throw SQLError.incomplete(expected: "a SELECT statement")
-  }
-  return select
-}
-
-/// The single output column type of a one-column query's schema.
-private func type(of text: String, _ routines: Routines = [:])
-    throws -> ValueType {
-  guard case let .select(query) = try Statement(parsing: text) else {
-    Issue.record("expected a SELECT statement")
-    throw SQLError.incomplete(expected: "a SELECT statement")
-  }
-  let columns = try things().columns(of: query, routines: routines)
-  #expect(columns.count == 1)
-  return columns[0].type
-}
-
 // MARK: - COALESCE
 
 struct CoalesceTests {
@@ -54,24 +20,25 @@ struct CoalesceTests {
   }
 
   @Test func `takes the first non-NULL argument`() throws {
-    try things().expect("SELECT COALESCE(K, K, 3) FROM T WHERE K IS NULL",
+    try nullable().expect("SELECT COALESCE(K, K, 3) FROM T WHERE K IS NULL",
                         yields: [[3]])
   }
 
   @Test func `an earlier non-NULL argument wins`() throws {
-    try things().expect("SELECT COALESCE(K, 99) FROM T WHERE Id = 1",
+    try nullable().expect("SELECT COALESCE(K, 99) FROM T WHERE Id = 1",
                         yields: [[10]])
   }
 
   @Test func `all-NULL arguments yield NULL`() throws {
-    try things().expect("SELECT COALESCE(K, K) FROM T WHERE K IS NULL",
+    try nullable().expect("SELECT COALESCE(K, K) FROM T WHERE K IS NULL",
                         yields: [[nil]])
   }
 
   @Test func `mixed integer and double arguments widen to double`() throws {
     // The arguments unify like a CASE's results — the integer widens.
-    #expect(try type(of: "SELECT COALESCE(K, 2.5) AS C FROM T") == .double)
-    try things().expect("SELECT COALESCE(K, 2.5) FROM T",
+    #expect(try nullable().type(of: "SELECT COALESCE(K, 2.5) AS C FROM T")
+                == .double)
+    try nullable().expect("SELECT COALESCE(K, 2.5) FROM T",
                         yields: [[10.0], [2.5]])
   }
 
@@ -90,21 +57,12 @@ struct CoalesceTests {
     }
     #expect(throws:
         SQLError.operand("COALESCE arguments have irreconcilable types")) {
-      _ = try things().columns(of: query)
+      _ = try nullable().columns(of: query)
     }
   }
 }
 
 // MARK: - Argument reachability
-
-/// Parses `text` to a `Query`, failing on any other shape.
-private func query(_ text: String) throws -> Query {
-  guard case let .select(query) = try Statement(parsing: text) else {
-    Issue.record("expected a SELECT statement")
-    throw SQLError.incomplete(expected: "a SELECT statement")
-  }
-  return query
-}
 
 struct CoalesceReachabilityTests {
   @Test func `a constant non-NULL prefix leaves a later argument unreachable`()
@@ -114,22 +72,24 @@ struct CoalesceReachabilityTests {
     // on — so the typecheck, mirroring that short-circuit, must NOT validate
     // the unreachable call. `columns(of:)` succeeds and the run yields the `1`.
     let text = "SELECT COALESCE(1, missing_udf()) FROM T"
-    _ = try things().columns(of: query(text))
-    try things().expect(text, yields: [[1], [1]])
+    _ = try nullable().columns(of: parse(query: text))
+    try nullable().expect(text, yields: [[1], [1]])
   }
 
   @Test func `a constant non-NULL prefix determines the column type`() throws {
     // The reachable prefix (the constant `1`) shapes the column — an integer —
     // exactly as a constant-TRUE CASE guard's branch does; the unreachable text
     // argument does not unify into it.
-    #expect(try type(of: "SELECT COALESCE(1, missing_udf()) AS C FROM T")
+    #expect(try nullable().type(
+        of: "SELECT COALESCE(1, missing_udf()) AS C FROM T")
                 == .integer)
   }
 
   @Test func `a bad operand after a constant prefix is unreachable`() throws {
     // `Name + 1` over the text `Name` would fault `.operand` if reached, but
     // the constant `1` selects first, so it is unreachable and not validated.
-    _ = try things().columns(of: query("SELECT COALESCE(1, Name + 1) FROM T"))
+    let query = try parse(query: "SELECT COALESCE(1, Name + 1) FROM T")
+    _ = try nullable().columns(of: query)
   }
 
   @Test func `a constant NULL prefix does not stop validation`() throws {
@@ -143,8 +103,8 @@ struct CoalesceReachabilityTests {
           .null
         }
     #expect(throws: SQLError.function("missing_udf")) {
-      _ = try things().columns(of:
-          query("SELECT COALESCE(nought(), missing_udf()) FROM T"),
+      _ = try nullable().columns(of:
+          parse(query: "SELECT COALESCE(nought(), missing_udf()) FROM T"),
           routines: routines)
     }
   }
@@ -156,8 +116,8 @@ struct CoalesceReachabilityTests {
     // `.function` (both integer-typed, so the fault is the unknown call, not a
     // type clash).
     #expect(throws: SQLError.function("missing_udf")) {
-      _ = try things().columns(of:
-          query("SELECT COALESCE(K, missing_udf()) FROM T"))
+      _ = try nullable().columns(of:
+          parse(query: "SELECT COALESCE(K, missing_udf()) FROM T"))
     }
   }
 
@@ -175,9 +135,9 @@ struct CoalesceReachabilityTests {
           .null
         }
     let text = "SELECT COALESCE(null_text(), 1) FROM T"
-    _ = try things().columns(of: query(text), routines: routines)
-    #expect(try type(of: text, routines) == .integer)
-    try things().expect(text, yields: [[1], [1]], routines: routines)
+    _ = try nullable().columns(of: parse(query: text), routines: routines)
+    #expect(try nullable().type(of: text, routines: routines) == .integer)
+    try nullable().expect(text, yields: [[1], [1]], routines: routines)
   }
 
   @Test func `a COUNT prefix leaves a later argument unreachable`() throws {
@@ -188,14 +148,15 @@ struct CoalesceReachabilityTests {
     // validate the unreachable call. `columns(of:)` succeeds over the
     // whole-result group and the run yields the count (2).
     let text = "SELECT COALESCE(COUNT(*), missing_udf()) FROM T"
-    _ = try things().columns(of: query(text))
-    try things().expect(text, yields: [[2]])
+    _ = try nullable().columns(of: parse(query: text))
+    try nullable().expect(text, yields: [[2]])
   }
 
   @Test func `a COUNT prefix determines the column type`() throws {
     // The reachable prefix (`COUNT(*)`) shapes the column — an integer — and
     // the unreachable later argument does not unify into it.
-    #expect(try type(of: "SELECT COALESCE(COUNT(*), missing_udf()) AS C FROM T")
+    #expect(try nullable().type(
+        of: "SELECT COALESCE(COUNT(*), missing_udf()) AS C FROM T")
                 == .integer)
   }
 
@@ -205,8 +166,8 @@ struct CoalesceReachabilityTests {
     // reachable and MUST be validated: `missing_udf()` after `SUM(K)` still
     // faults `.function`.
     #expect(throws: SQLError.function("missing_udf")) {
-      _ = try things().columns(of:
-          query("SELECT COALESCE(SUM(K), missing_udf()) FROM T"))
+      _ = try nullable().columns(of:
+          parse(query: "SELECT COALESCE(SUM(K), missing_udf()) FROM T"))
     }
   }
 
@@ -215,8 +176,8 @@ struct CoalesceReachabilityTests {
     // derives the later `0` (SUM is nullable, not a stop), unifying to
     // `.integer`, and runs — SUM over the two-row group is the sum of K.
     let text = "SELECT COALESCE(SUM(K), 0) FROM T"
-    #expect(try type(of: text) == .integer)
-    try things().expect(text, yields: [[10]])
+    #expect(try nullable().type(of: text) == .integer)
+    try nullable().expect(text, yields: [[10]])
   }
 }
 
@@ -323,7 +284,7 @@ struct CoalesceTypeCheckingTests {
           WHERE is_double(COALESCE(2.5, 1)) = 1 AND Id = 1
         """
     #expect(throws: SQLError.operand("operands must be numeric")) {
-      _ = try things().columns(of: query(text),
+      _ = try nullable().columns(of: parse(query: text),
                                routines: doubling(taking: .double))
     }
   }
@@ -337,7 +298,7 @@ struct CoalesceTypeCheckingTests {
         SELECT Name + 1 AS C FROM T
           WHERE is_double(COALESCE(1, 2)) = 1 AND Id = 1
         """
-    let columns = try things().columns(of: query(text),
+    let columns = try nullable().columns(of: parse(query: text),
                                        routines: doubling(taking: .integer))
     #expect(columns.count == 1)
   }

--- a/Tests/SQLTests/Expressions/ConcatTests.swift
+++ b/Tests/SQLTests/Expressions/ConcatTests.swift
@@ -19,15 +19,6 @@ private func things() throws -> FixtureCatalog {
   }
 }
 
-/// Parses `text` and returns its `Select`, failing on any other shape.
-private func parse(select text: String) throws -> Select {
-  guard case let .select(.select(select)) = try Statement(parsing: text) else {
-    Issue.record("expected a single SELECT statement")
-    throw SQLError.incomplete(expected: "a SELECT statement")
-  }
-  return select
-}
-
 // MARK: - Parsing
 
 struct ConcatParsingTests {
@@ -106,21 +97,6 @@ struct ConcatEvaluationTests {
 
 // MARK: - Derivation
 
-/// Parses `text` to a `Query`, failing on any other shape.
-private func query(_ text: String) throws -> Query {
-  guard case let .select(query) = try Statement(parsing: text) else {
-    Issue.record("expected a SELECT statement")
-    throw SQLError.incomplete(expected: "a SELECT statement")
-  }
-  return query
-}
-
-/// A `People` catalog with a text `Name` — the base for a derive-level test.
-private func people() -> FixtureCatalog {
-  FixtureCatalog(
-    ["People": FixtureRelation([FixtureField(name: "Name", type: .text)], [])])
-}
-
 /// The type `derive` reports for the sole projected expression of `text`, over
 /// a `People` scope — the schema-only derive surface (`scope(of:)` reads no
 /// cursor and skips `compile`), so `derive` alone resolves the operands.
@@ -131,7 +107,7 @@ private func derived(_ text: String) throws -> ValueType {
     Issue.record("expected a single projected expression")
     throw SQLError.incomplete(expected: "one projected expression")
   }
-  let scope = try people().scope(of: select, Context())
+  let scope = try derivation().scope(of: select, Context())
   return try scope.derive(items[0].expression)
 }
 

--- a/Tests/SQLTests/Expressions/DistinctFromTests.swift
+++ b/Tests/SQLTests/Expressions/DistinctFromTests.swift
@@ -25,15 +25,6 @@ private func things() throws -> FixtureCatalog {
   }
 }
 
-/// Parses `text` and returns its `Select`, failing on any other shape.
-private func parse(select text: String) throws -> Select {
-  guard case let .select(.select(select)) = try Statement(parsing: text) else {
-    Issue.record("expected a single SELECT statement")
-    throw SQLError.incomplete(expected: "a SELECT statement")
-  }
-  return select
-}
-
 // MARK: - Parsing
 
 struct DistinctFromParsingTests {

--- a/Tests/SQLTests/Expressions/LikeTests.swift
+++ b/Tests/SQLTests/Expressions/LikeTests.swift
@@ -24,15 +24,6 @@ private func names() throws -> FixtureCatalog {
 
 // MARK: - Parsing
 
-/// Parses `text` and returns its `Select`, failing on any other shape.
-private func parse(select text: String) throws -> Select {
-  guard case let .select(.select(select)) = try Statement(parsing: text) else {
-    Issue.record("expected a single SELECT statement")
-    throw SQLError.incomplete(expected: "a SELECT statement")
-  }
-  return select
-}
-
 struct LikeParsingTests {
   @Test func `parses a LIKE pattern`() throws {
     let select = try parse(select: "SELECT * FROM T WHERE Name LIKE 'a%'")
@@ -222,27 +213,18 @@ struct LikeThreeValuedTests {
 // MARK: - Type checking
 
 struct LikeTypeCheckingTests {
-  /// Parses `text` to a query, failing on any other statement.
-  private func parse(_ text: String) throws -> Query {
-    guard case let .select(query) = try Statement(parsing: text) else {
-      Issue.record("expected a SELECT statement")
-      throw SQLError.incomplete(expected: "a SELECT statement")
-    }
-    return query
-  }
-
   @Test func `a non-text operand does not fault the schema check`() throws {
     // `K` is an integer column, but `K LIKE '10'` does NOT fault the schema
     // check: the run yields a definite FALSE without faulting (the cross-kind
     // rule), so the check must accept what the run accepts.
-    let query = try parse("SELECT Id FROM T WHERE K LIKE '10'")
+    let query = try parse(query: "SELECT Id FROM T WHERE K LIKE '10'")
     _ = try names().columns(of: query, validate: true)
   }
 
   @Test func `a bad operand expression faults the schema check`() throws {
     // The operand and pattern are still validated for REAL errors: `Name + 1`
     // is text arithmetic, which faults exactly as a run would.
-    let query = try parse("SELECT Id FROM T WHERE Name + 1 LIKE 'a%'")
+    let query = try parse(query: "SELECT Id FROM T WHERE Name + 1 LIKE 'a%'")
     let resolve = { () throws -> Array<OutputColumn> in
       try names().columns(of: query, validate: true)
     }
@@ -356,22 +338,13 @@ struct LikeSafetyTests {
     }
   }
 
-  /// Parses `text` to a query, failing on any other statement.
-  private func query(_ text: String) throws -> Query {
-    guard case let .select(query) = try Statement(parsing: text) else {
-      Issue.record("expected a SELECT statement")
-      throw SQLError.incomplete(expected: "a SELECT statement")
-    }
-    return query
-  }
-
   @Test func `a non-constant escape is unsafe and bars ON key extraction`()
       throws {
     // `ON A.K = B.K AND A.Name LIKE 'a%' ESCAPE A.E`, `A.E` a multi-character
     // slot — an escape that faults regardless of the pair. Unsafe, it bars the
     // equi from becoming a hash key: `nest` forms no `.join`, the level is a
     // residual `.select` over the `.product`, so the whole `ON` runs per pair.
-    let compiled = try mismatched().compile(query("""
+    let compiled = try mismatched().compile(parse(query: """
         SELECT A.K FROM A JOIN B ON A.K = B.K AND A.Name LIKE 'a%' ESCAPE A.E
         """))
     let plan = try mismatched().optimise(compiled.pushdown(), [:])
@@ -403,7 +376,7 @@ struct LikeSafetyTests {
     let sql = """
         SELECT A.K FROM A JOIN B ON A.K = B.K AND A.Name LIKE 'a%' ESCAPE 'ab'
         """
-    let compiled = try mismatched().compile(query(sql))
+    let compiled = try mismatched().compile(parse(query: sql))
     let plan = try mismatched().optimise(compiled.pushdown(), [:])
     #expect(!joins(plan))
     #expect(residual(plan))
@@ -422,7 +395,7 @@ struct LikeSafetyTests {
         Row(2, "xyz")
       }
     }
-    let compiled = try catalog.compile(query("""
+    let compiled = try catalog.compile(parse(query: """
         SELECT Id FROM S WHERE Name LIKE '_%' ESCAPE '\\' AND Id = 2
         """))
     let plan = try catalog.optimise(compiled.pushdown(), [:])
@@ -446,7 +419,7 @@ struct LikeSafetyTests {
         Row(2, "xyz")
       }
     }
-    let compiled = try catalog.compile(query("""
+    let compiled = try catalog.compile(parse(query: """
         SELECT Id FROM S WHERE Name LIKE 'x%' AND Id = 2
         """))
     let plan = try catalog.optimise(compiled.pushdown(), [:])
@@ -522,20 +495,12 @@ struct LikeEvaluationOrderTests {
 /// is rejected at VALIDATION (`columns(of:validate:)`), not left to fault on
 /// every row — `check` folds a row-independent escape and rejects a bad one.
 struct LikeEscapeValidationTests {
-  /// Parses `text` to a query, failing on any other statement.
-  private func query(_ text: String) throws -> Query {
-    guard case let .select(query) = try Statement(parsing: text) else {
-      Issue.record("expected a SELECT statement")
-      throw SQLError.incomplete(expected: "a SELECT statement")
-    }
-    return query
-  }
-
   @Test func `a constant multi-character escape faults validation`() throws {
     // `ESCAPE 'xy'` is a constant text of the wrong length — un-runnable — so
     // `columns(of:validate:)` rejects it at validation with the run's message.
     // ADVERSARIAL: reverting the check drops this validation throw.
-    let query = try query("SELECT Id FROM T WHERE Name LIKE 'x' ESCAPE 'xy'")
+    let query = try parse(query:
+        "SELECT Id FROM T WHERE Name LIKE 'x' ESCAPE 'xy'")
     #expect(throws:
         SQLError.argument("LIKE ESCAPE must be a single character")) {
       try names().columns(of: query, validate: true)
@@ -545,7 +510,8 @@ struct LikeEscapeValidationTests {
   @Test func `a constant non-text escape faults validation`() throws {
     // `ESCAPE 1` is a constant integer — never a valid escape — so it too is
     // rejected at validation rather than faulting per row.
-    let query = try query("SELECT Id FROM T WHERE Name LIKE 'x' ESCAPE 1")
+    let query = try parse(query:
+        "SELECT Id FROM T WHERE Name LIKE 'x' ESCAPE 1")
     #expect(throws:
         SQLError.argument("LIKE ESCAPE must be a single character")) {
       try names().columns(of: query, validate: true)
@@ -554,7 +520,8 @@ struct LikeEscapeValidationTests {
 
   @Test func `a valid single-character escape validates`() throws {
     // `ESCAPE '\'` is a valid single-character constant, so it validates.
-    let query = try query("SELECT Id FROM T WHERE Name LIKE 'x' ESCAPE '\\'")
+    let query = try parse(query:
+        "SELECT Id FROM T WHERE Name LIKE 'x' ESCAPE '\\'")
     _ = try names().columns(of: query, validate: true)
   }
 
@@ -562,7 +529,8 @@ struct LikeEscapeValidationTests {
     // A column escape is per row and cannot be checked statically, so
     // validation accepts it (the run validates it) — here `Name` stands in as
     // a non-constant escape term.
-    let query = try query("SELECT Id FROM T WHERE Name LIKE 'x' ESCAPE Name")
+    let query = try parse(query:
+        "SELECT Id FROM T WHERE Name LIKE 'x' ESCAPE Name")
     _ = try names().columns(of: query, validate: true)
   }
 }
@@ -678,15 +646,6 @@ struct LikeParameterisedTests {
     }
   }
 
-  /// Parses `text` to a query, failing on any other statement.
-  private func query(_ text: String) throws -> Query {
-    guard case let .select(query) = try Statement(parsing: text) else {
-      Issue.record("expected a SELECT statement")
-      throw SQLError.incomplete(expected: "a SELECT statement")
-    }
-    return query
-  }
-
   @Test func `a parameterised LIKE is nullable`() throws {
     // A `.like` whose pattern operand is a `:parameter` reads no slot yet is
     // nullable — the pattern may be unbound or NULL, making the LIKE UNKNOWN.
@@ -719,7 +678,7 @@ struct LikeParameterisedTests {
     // LIKE :p` into the view would drop every row first, suppressing the
     // throw — so a parameterised LIKE is nullable and must stay outer.
     let catalog = try maybe()
-    let compiled = try catalog.compile(query("""
+    let compiled = try catalog.compile(parse(query: """
         SELECT x FROM V WHERE 'x' LIKE :p AND (1 / y) = 0
         """))
     let plan = try catalog.optimise(compiled.pushdown(), [:])

--- a/Tests/SQLTests/Expressions/MembershipTests.swift
+++ b/Tests/SQLTests/Expressions/MembershipTests.swift
@@ -25,15 +25,6 @@ private func members() throws -> FixtureCatalog {
 
 // MARK: - Parsing
 
-/// Parses `text` and returns its `Select`, failing on any other shape.
-private func parse(select text: String) throws -> Select {
-  guard case let .select(.select(select)) = try Statement(parsing: text) else {
-    Issue.record("expected a single SELECT statement")
-    throw SQLError.incomplete(expected: "a SELECT statement")
-  }
-  return select
-}
-
 struct MembershipParsingTests {
   @Test func `parses an IN value list`() throws {
     let select = try parse(select: "SELECT * FROM T WHERE K IN (1, 2, 3)")
@@ -122,23 +113,14 @@ struct MembershipEvaluationTests {
 // MARK: - Type checking
 
 struct MembershipTypeCheckingTests {
-  /// Parses `text` to a query, failing on any other statement.
-  private func parse(_ text: String) throws -> Query {
-    guard case let .select(query) = try Statement(parsing: text) else {
-      Issue.record("expected a SELECT statement")
-      throw SQLError.incomplete(expected: "a SELECT statement")
-    }
-    return query
-  }
-
   @Test func `a cross-kind element does not fault the schema check`() throws {
     // `K` is an integer column and `'x'` is a text element, but the schema
     // check does NOT reject it: the lowered `K = 'x'` comparison yields FALSE
     // at runtime via `Row.matches` without faulting, so the row still runs and
     // may match the like-kind `10` element. The check must accept what the run
     // accepts — so `K IN (10, 'x')` types exactly as `K IN (10)`.
-    let mixed = try parse("SELECT Id FROM T WHERE K IN (10, 'x')")
-    let plain = try parse("SELECT Id FROM T WHERE K IN (10)")
+    let mixed = try parse(query: "SELECT Id FROM T WHERE K IN (10, 'x')")
+    let plain = try parse(query: "SELECT Id FROM T WHERE K IN (10)")
     let columns = try members().columns(of: mixed)
     #expect(columns == (try members().columns(of: plain)))
     // The run keeps the `K = 10` row: the text arm silently non-matches.
@@ -149,7 +131,7 @@ struct MembershipTypeCheckingTests {
   @Test func `a numeric element of the other numeric kind is admitted`() throws {
     // An integer operand and a double element are comparable (both numeric), so
     // the schema check passes and the run matches by magnitude.
-    let query = try parse("SELECT Id FROM T WHERE K IN (10.0, 20.0)")
+    let query = try parse(query: "SELECT Id FROM T WHERE K IN (10.0, 20.0)")
     _ = try members().columns(of: query)
     try members().expect("SELECT Id FROM T WHERE K IN (10.0, 20.0)",
                          yields: [[1], [2]])
@@ -160,7 +142,7 @@ struct MembershipTypeCheckingTests {
     // disjunct is a definite constant match, so the OR-chain short-circuits and
     // `Name + 1` (text arithmetic) is unreachable — the type check does not
     // validate it, and the query runs (matching every row).
-    let query = try parse("SELECT Id FROM T WHERE 1 IN (1, Name + 1)")
+    let query = try parse(query: "SELECT Id FROM T WHERE 1 IN (1, Name + 1)")
     _ = try members().columns(of: query, validate: true)
     try members().expect("SELECT Id FROM T WHERE 1 IN (1, Name + 1)",
                          yields: [[1], [2], [3], [4]])
@@ -173,7 +155,8 @@ struct MembershipTypeCheckingTests {
     // `Name + 1` (text arithmetic) is unreachable — the type check must fold
     // the constant element and stop rather than continuing into it, and the
     // run, matching `1 = 1 + 0` first, keeps every row.
-    let query = try parse("SELECT Id FROM T WHERE 1 IN (1 + 0, Name + 1)")
+    let query = try parse(query:
+        "SELECT Id FROM T WHERE 1 IN (1 + 0, Name + 1)")
     _ = try members().columns(of: query, validate: true)
     try members().expect("SELECT Id FROM T WHERE 1 IN (1 + 0, Name + 1)",
                          yields: [[1], [2], [3], [4]])
@@ -184,7 +167,8 @@ struct MembershipTypeCheckingTests {
     // NOT match, so `Name + 1` stays reachable — the pruning is PRECISE, not
     // over-eager — and its text arithmetic must still fault the type check,
     // matching the run, which would evaluate `2 = Name + 1` and fault.
-    let query = try parse("SELECT Id FROM T WHERE 2 IN (1 + 0, Name + 1)")
+    let query = try parse(query:
+        "SELECT Id FROM T WHERE 2 IN (1 + 0, Name + 1)")
     let resolve = { () throws -> Array<OutputColumn> in
       try members().columns(of: query, validate: true)
     }
@@ -196,7 +180,7 @@ struct MembershipTypeCheckingTests {
   @Test func `no definite match leaves a bad element reachable`() throws {
     // `2 IN (1, Name + 1)` never definitely matches `1`, so `Name + 1` is
     // reachable and its text arithmetic must still fault the type check.
-    let query = try parse("SELECT Id FROM T WHERE 2 IN (1, Name + 1)")
+    let query = try parse(query: "SELECT Id FROM T WHERE 2 IN (1, Name + 1)")
     let resolve = { () throws -> Array<OutputColumn> in
       try members().columns(of: query, validate: true)
     }
@@ -215,7 +199,7 @@ struct MembershipTypeCheckingTests {
     // keeps every row. (`BITAND` is a standard prelude routine, seeded like the
     // existing constant-expression tests.)
     let text = "SELECT Id FROM T WHERE 1 IN (BITAND(1, 1), Name + 1)"
-    let query = try parse(text)
+    let query = try parse(query: text)
     _ = try members().columns(of: query, validate: true)
     try members().expect(text, yields: [[1], [2], [3], [4]])
   }
@@ -235,7 +219,7 @@ struct MembershipTypeCheckingTests {
           .integer(1)
         }
     let text = "SELECT Id FROM T WHERE 1 IN (probe(), Name + 1)"
-    let query = try parse(text)
+    let query = try parse(query: text)
     let resolve = { () throws -> Array<OutputColumn> in
       try members().columns(of: query, routines: routines, validate: true)
     }
@@ -255,7 +239,7 @@ struct MembershipTypeCheckingTests {
           .integer(1)
         }
     let text = "SELECT Id FROM T WHERE 1 IN (probe(), Name + 1)"
-    let query = try parse(text)
+    let query = try parse(query: text)
     _ = try members().columns(of: query, routines: routines, validate: true)
     try members().expect(text, yields: [[1], [2], [3], [4]],
                          routines: routines)
@@ -267,7 +251,7 @@ struct MembershipTypeCheckingTests {
     // — the routine fold is PRECISE, not over-eager — and its text arithmetic
     // must still fault the type check, matching the run.
     let text = "SELECT Id FROM T WHERE 2 IN (BITAND(1, 1), Name + 1)"
-    let query = try parse(text)
+    let query = try parse(query: text)
     let resolve = { () throws -> Array<OutputColumn> in
       try members().columns(of: query, validate: true)
     }
@@ -286,7 +270,7 @@ struct MembershipTypeCheckingTests {
     // the run, matching `1 = <CASE>` first, keeps every row.
     let text = "SELECT Id FROM T WHERE 1 IN "
         + "(CASE WHEN 1 = 1 THEN 1 ELSE Name + 1 END, Name + 1)"
-    let query = try parse(text)
+    let query = try parse(query: text)
     _ = try members().columns(of: query, validate: true)
     try members().expect(text, yields: [[1], [2], [3], [4]])
   }
@@ -298,7 +282,7 @@ struct MembershipTypeCheckingTests {
     // arithmetic must still fault the type check, matching the run.
     let text = "SELECT Id FROM T WHERE 2 IN "
         + "(CASE WHEN 1 = 1 THEN 1 ELSE Name + 1 END, Name + 1)"
-    let query = try parse(text)
+    let query = try parse(query: text)
     let resolve = { () throws -> Array<OutputColumn> in
       try members().columns(of: query, validate: true)
     }
@@ -315,7 +299,7 @@ struct MembershipTypeCheckingTests {
     // reachable, so its text arithmetic must still fault the type check.
     let text = "SELECT Id FROM T WHERE 1 IN "
         + "(CASE WHEN Id = 2 THEN 1 ELSE 0 END, Name + 1)"
-    let query = try parse(text)
+    let query = try parse(query: text)
     let resolve = { () throws -> Array<OutputColumn> in
       try members().columns(of: query, validate: true)
     }
@@ -334,7 +318,7 @@ struct MembershipTypeCheckingTests {
     // the run, matching `1 = <CASE>` first, keeps every row.
     let text = "SELECT Id FROM T WHERE 1 IN "
         + "(CASE WHEN 1 + 0 = 1 THEN 1 END, Name + 1)"
-    let query = try parse(text)
+    let query = try parse(query: text)
     _ = try members().columns(of: query, validate: true)
     try members().expect(text, yields: [[1], [2], [3], [4]])
   }
@@ -347,7 +331,7 @@ struct MembershipTypeCheckingTests {
     // the run. The pruning is PRECISE: a folded-FALSE guard prunes nothing.
     let text = "SELECT Id FROM T WHERE 1 IN "
         + "(CASE WHEN 1 + 0 = 2 THEN 1 END, Name + 1)"
-    let query = try parse(text)
+    let query = try parse(query: text)
     let resolve = { () throws -> Array<OutputColumn> in
       try members().columns(of: query, validate: true)
     }
@@ -370,7 +354,7 @@ struct MembershipTypeCheckingTests {
         }
     let text = "SELECT Id FROM T WHERE 1 IN "
         + "(CASE WHEN probe() = 1 THEN 1 END, Name + 1)"
-    let query = try parse(text)
+    let query = try parse(query: text)
     let resolve = { () throws -> Array<OutputColumn> in
       try members().columns(of: query, routines: routines, validate: true)
     }
@@ -388,7 +372,7 @@ struct MembershipTypeCheckingTests {
     // arithmetic). This exercises the generalised `.null` predicate fold.
     let text = "SELECT Id FROM T WHERE 1 IN "
         + "(CASE WHEN 1 + 0 IS NOT NULL THEN 1 END, Name + 1)"
-    let query = try parse(text)
+    let query = try parse(query: text)
     _ = try members().columns(of: query, validate: true)
     try members().expect(text, yields: [[1], [2], [3], [4]])
   }
@@ -399,7 +383,7 @@ struct MembershipTypeCheckingTests {
     // whose HAVING `1 IN (1, 1 / 0)` the schema path (`columns(of:)`) folds. The
     // OR-chain short-circuits on the literal `1 = 1`, so `1 / 0` is unreachable
     // and must not fault `.divide` — the schema resolves and the query runs.
-    let query = try parse(
+    let query = try parse(query:
         "SELECT COUNT(*) FROM T WHERE 1 = 0 HAVING 1 IN (1, 1 / 0)")
     let columns = try members().columns(of: query)
     #expect(columns.count == 1)

--- a/Tests/SQLTests/Expressions/NullifTests.swift
+++ b/Tests/SQLTests/Expressions/NullifTests.swift
@@ -6,49 +6,6 @@ import Testing
 
 import SQLTestSupport
 
-// MARK: - Fixture
-
-/// A relation exercising `NULLIF`: a nullable integer `K` and a text `Name`, so
-/// a NULL result and a first-argument type are both reachable.
-private func things() throws -> FixtureCatalog {
-  try Catalog {
-    Relation("T", ["Id": .integer, "K": .integer, "Name": .text]) {
-      Row(1, 10, "a")
-      Row(2, nil, "b")
-    }
-  }
-}
-
-/// Parses `text` and returns its `Select`, failing on any other shape.
-private func parse(select text: String) throws -> Select {
-  guard case let .select(.select(select)) = try Statement(parsing: text) else {
-    Issue.record("expected a single SELECT statement")
-    throw SQLError.incomplete(expected: "a SELECT statement")
-  }
-  return select
-}
-
-/// Parses `text` to a `Query`, failing on any other shape.
-private func query(_ text: String) throws -> Query {
-  guard case let .select(query) = try Statement(parsing: text) else {
-    Issue.record("expected a SELECT statement")
-    throw SQLError.incomplete(expected: "a SELECT statement")
-  }
-  return query
-}
-
-/// The single output column type of a one-column query's schema.
-private func type(of text: String, _ routines: Routines = [:])
-    throws -> ValueType {
-  guard case let .select(query) = try Statement(parsing: text) else {
-    Issue.record("expected a SELECT statement")
-    throw SQLError.incomplete(expected: "a SELECT statement")
-  }
-  let columns = try things().columns(of: query, routines: routines)
-  #expect(columns.count == 1)
-  return columns[0].type
-}
-
 // MARK: - NULLIF
 
 struct NullifTests {
@@ -62,20 +19,21 @@ struct NullifTests {
   }
 
   @Test func `equal arguments yield NULL`() throws {
-    try things().expect("SELECT NULLIF(1, 1)", yields: [[nil]])
+    try nullable().expect("SELECT NULLIF(1, 1)", yields: [[nil]])
   }
 
   @Test func `unequal integer arguments yield the first`() throws {
-    try things().expect("SELECT NULLIF(1, 2)", yields: [[1]])
+    try nullable().expect("SELECT NULLIF(1, 2)", yields: [[1]])
   }
 
   @Test func `unequal text arguments yield the first`() throws {
-    try things().expect("SELECT NULLIF('a', 'b')", yields: [["a"]])
+    try nullable().expect("SELECT NULLIF('a', 'b')", yields: [["a"]])
   }
 
   @Test func `the column type is the first argument's`() throws {
     // The NULL result imposes no type; the ELSE (the first argument) types it.
-    #expect(try type(of: "SELECT NULLIF(Name, 'x') AS C FROM T") == .text)
+    #expect(try nullable().type(of: "SELECT NULLIF(Name, 'x') AS C FROM T")
+                == .text)
   }
 
   @Test func `rejects a single argument`() {
@@ -87,12 +45,6 @@ struct NullifTests {
 
 // MARK: - Derivation resolves both operands
 
-/// A `People` catalog with a text `Name` — the base for a derive-level test.
-private func people() -> FixtureCatalog {
-  FixtureCatalog(
-    ["People": FixtureRelation([FixtureField(name: "Name", type: .text)], [])])
-}
-
 /// The type `derive` reports for the sole projected expression of `text`, over
 /// a `People` scope — the schema-only derive surface (`scope(of:)` reads no
 /// cursor and skips `compile`), so `derive` alone resolves the operands.
@@ -103,7 +55,7 @@ private func derived(_ text: String) throws -> ValueType {
     Issue.record("expected a single projected expression")
     throw SQLError.incomplete(expected: "one projected expression")
   }
-  let scope = try people().scope(of: select, Context())
+  let scope = try derivation().scope(of: select, Context())
   return try scope.derive(items[0].expression)
 }
 

--- a/Tests/SQLTests/Expressions/QuantifiedSubqueryTests.swift
+++ b/Tests/SQLTests/Expressions/QuantifiedSubqueryTests.swift
@@ -15,44 +15,10 @@ import SQLTestSupport
 /// `Flag` used to filter the inner query to empty or to non-empty. `N` holds a
 /// single NULL-bearing column for the NULL-element corners.
 private func fixture() throws -> FixtureCatalog {
-  try Catalog {
-    Relation("T", ["Id": .integer, "K": .integer]) {
-      Row(1, 10)
-      Row(2, 20)
-      Row(3, nil)
-      Row(4, 30)
-    }
-    Relation("S", ["V": .integer, "Flag": .integer]) {
-      Row(10, 1)
-      Row(20, 1)
-      Row(99, 0)
-    }
-    // A relation whose single column holds a NULL, for the NULL-element
-    // corners — `V` is `{2, NULL}`.
-    Relation("N", ["V": .integer]) {
-      Row(2)
-      Row(nil)
-    }
-  }
+  try subqueries()
 }
 
-/// Parses `text` and returns its `Select`, failing on any other shape.
-private func parse(select text: String) throws -> Select {
-  guard case let .select(.select(select)) = try Statement(parsing: text) else {
-    Issue.record("expected a single SELECT statement")
-    throw SQLError.incomplete(expected: "a SELECT statement")
-  }
-  return select
-}
 
-/// Parses `text` to a query, failing on any other statement.
-private func parse(query text: String) throws -> Query {
-  guard case let .select(query) = try Statement(parsing: text) else {
-    Issue.record("expected a SELECT statement")
-    throw SQLError.incomplete(expected: "a SELECT statement")
-  }
-  return query
-}
 
 // MARK: - Parsing
 
@@ -79,8 +45,8 @@ struct QuantifiedSubqueryParsingTests {
       ("<", .lt), ("<=", .leq), (">", .gt), (">=", .geq),
     ]
     for (spelling, op) in cases {
-      let select = try parse(
-          select: "SELECT Id FROM T WHERE K \(spelling) ANY (SELECT V FROM S)")
+      let select = try parse(select:
+          "SELECT Id FROM T WHERE K \(spelling) ANY (SELECT V FROM S)")
       #expect(select.predicate == .quantified(.column("K"), op, .any, inner))
     }
   }
@@ -255,8 +221,8 @@ struct QuantifiedArityTests {
   @Test func `a two-column quantified subquery faults the schema check too`()
       throws {
     // The schema path enforces the SAME single-column arity as the run.
-    let query = try parse(
-        query: "SELECT Id FROM T WHERE K < ANY (SELECT V, Flag FROM S)")
+    let query = try parse(query:
+         "SELECT Id FROM T WHERE K < ANY (SELECT V, Flag FROM S)")
     let resolve = { () throws -> Array<OutputColumn> in
       try fixture().columns(of: query, validate: true)
     }
@@ -270,8 +236,8 @@ struct QuantifiedArityTests {
 
 struct QuantifiedTypeCheckingTests {
   @Test func `columns validates a quantified query matching the run`() throws {
-    let query = try parse(
-        query: "SELECT Id FROM T WHERE K < ANY (SELECT V FROM S)")
+    let query = try parse(query:
+         "SELECT Id FROM T WHERE K < ANY (SELECT V FROM S)")
     let columns = try fixture().columns(of: query, validate: true)
     #expect(columns.count == 1)
   }
@@ -279,8 +245,8 @@ struct QuantifiedTypeCheckingTests {
   @Test func `a bad inner column faults the schema check`() throws {
     // The inner query is type-checked too, so an unknown column inside it
     // faults validation exactly as a run would reject it.
-    let query = try parse(
-        query: "SELECT Id FROM T WHERE K > ALL (SELECT Missing FROM S)")
+    let query = try parse(query:
+         "SELECT Id FROM T WHERE K > ALL (SELECT Missing FROM S)")
     let resolve = { () throws -> Array<OutputColumn> in
       try fixture().columns(of: query, validate: true)
     }

--- a/Tests/SQLTests/Expressions/TruthTestTests.swift
+++ b/Tests/SQLTests/Expressions/TruthTestTests.swift
@@ -24,15 +24,6 @@ private func flags() throws -> FixtureCatalog {
   }
 }
 
-/// Parses `text` and returns its `Select`, failing on any other shape.
-private func parse(select text: String) throws -> Select {
-  guard case let .select(.select(select)) = try Statement(parsing: text) else {
-    Issue.record("expected a single SELECT statement")
-    throw SQLError.incomplete(expected: "a SELECT statement")
-  }
-  return select
-}
-
 /// The boolean predicate a bare boolean operand `x` bridges to — the comparison
 /// `x = TRUE`, whose three-valued truth IS `x`'s boolean value — the inner
 /// `Predicate` a column truth test wraps.
@@ -238,15 +229,6 @@ struct TruthDefiniteTests {
 
 // MARK: - Constant folding
 
-/// Parses `text` to a `Query`, failing on any other shape.
-private func query(_ text: String) throws -> Query {
-  guard case let .select(query) = try Statement(parsing: text) else {
-    Issue.record("expected a SELECT statement")
-    throw SQLError.incomplete(expected: "a SELECT statement")
-  }
-  return query
-}
-
 struct TruthConstantTests {
   /// A relation with a text `Name`, so `Name + 1` is a reachable operand fault.
   private func named() throws -> FixtureCatalog {
@@ -269,7 +251,7 @@ struct TruthConstantTests {
     // row-dependent, the RHS was validated, and it faulted.
     let text = "SELECT Id FROM T "
         + "WHERE CASE WHEN 1 = 0 THEN TRUE END IS TRUE AND Name + 1 = 0"
-    _ = try named().columns(of: query(text))
+    _ = try named().columns(of: parse(query: text))
     try named().empty(text)
   }
 
@@ -290,7 +272,7 @@ struct TruthConstantTests {
     // SUCCEEDS and the run drops every row.
     let text = "SELECT Id FROM T "
         + "WHERE (Name IS NULL) IS UNKNOWN AND Name + 1 = 0"
-    _ = try named().columns(of: query(text))
+    _ = try named().columns(of: parse(query: text))
     try named().empty(text)
   }
 

--- a/Tests/SQLTests/Optimisation/ConstantFoldTests.swift
+++ b/Tests/SQLTests/Optimisation/ConstantFoldTests.swift
@@ -8,15 +8,6 @@ import SQLTestSupport
 
 // MARK: - Fixtures
 
-/// Parses `text` to a query, failing on any other statement.
-private func parse(query text: String) throws -> Query {
-  guard case let .select(query) = try Statement(parsing: text) else {
-    Issue.record("expected a SELECT statement")
-    throw SQLError.incomplete(expected: "a SELECT statement")
-  }
-  return query
-}
-
 /// A single-relation catalog for the constant-fold result oracles.
 private func numbers() throws -> FixtureCatalog {
   try Catalog {

--- a/Tests/SQLTests/Optimisation/DecorrelateTests.swift
+++ b/Tests/SQLTests/Optimisation/DecorrelateTests.swift
@@ -13,14 +13,6 @@ import SQLTestSupport
 /// pins the plan shape: a decorrelatable CROSS APPLY becomes a `.join` with NO
 /// `.apply` node, and an EXCLUDED body stays an `.apply`, run correctly.
 
-/// Parses `text` to a query, failing on any other statement.
-private func query(_ text: String) throws -> Query {
-  guard case let .select(query) = try Statement(parsing: text) else {
-    Issue.record("expected a SELECT statement")
-    throw SQLError.incomplete(expected: "a SELECT statement")
-  }
-  return query
-}
 
 /// Whether `plan` (or any descendant) carries a correlated `.apply` node — the
 /// witness a shape was NOT decorrelated.
@@ -70,7 +62,7 @@ extension Catalog where Self: ~Escapable {
   /// does, so a correlated body's plan is compiled into the box the decorrelate
   /// pass reads.
   fileprivate borrowing func optimised(_ sql: String) throws -> Plan {
-    let parsed = try query(sql)
+    let parsed = try parse(query: sql)
     let context = Context().resolving(Subqueries())
     let logical = try compile(parsed, context.validating(false)).pushdown()
     let augmented = try augment(context.validating(false), for: parsed,
@@ -133,7 +125,7 @@ struct DecorrelateCrossApplyTests {
   /// join multiplies the left row by the match count, it is NOT deduped.
   @Test func `a left row matching many inner rows is multiplied not deduped`()
       throws {
-    let rows = try fixture().run(query(
+    let rows = try fixture().run(parse(query:
         "SELECT T.Id FROM T " +
         "JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON 1 = 1 " +
         "ORDER BY T.Id"), .standard)
@@ -144,7 +136,7 @@ struct DecorrelateCrossApplyTests {
   /// NO MATCH: Id 3 has no child, so the INNER join DROPS it — never NULL-
   /// extended, exactly as CROSS APPLY drops an unmatched left row.
   @Test func `a left row with no match is dropped`() throws {
-    let rows = try fixture().run(query(
+    let rows = try fixture().run(parse(query:
         "SELECT T.Id FROM T " +
         "JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON 1 = 1"),
         .standard)
@@ -406,7 +398,7 @@ struct DecorrelateThrowVisibilityTests {
     // Id 2 matches child (2, 200): 1 / (200 - 100) = 0, so `> 0` is false ⇒ no
     // row; Id 3 matches nothing. The divide on the Id-1 child is never reached,
     // so the run yields nothing and does NOT throw — the base behaviour.
-    let rows = try catalog.run(query(sql), .standard)
+    let rows = try catalog.run(parse(query: sql), .standard)
     #expect(rows.isEmpty)
   }
 }

--- a/Tests/SQLTests/Queries/DerivedTableTests.swift
+++ b/Tests/SQLTests/Queries/DerivedTableTests.swift
@@ -31,23 +31,7 @@ private func fixture() throws -> FixtureCatalog {
   }
 }
 
-/// Parses `text` and returns its `Select`, failing on any other shape.
-private func parse(select text: String) throws -> Select {
-  guard case let .select(.select(select)) = try Statement(parsing: text) else {
-    Issue.record("expected a single SELECT statement")
-    throw SQLError.incomplete(expected: "a SELECT statement")
-  }
-  return select
-}
 
-/// Parses `text` to a query, failing on any other statement.
-private func parse(query text: String) throws -> Query {
-  guard case let .select(query) = try Statement(parsing: text) else {
-    Issue.record("expected a SELECT statement")
-    throw SQLError.incomplete(expected: "a SELECT statement")
-  }
-  return query
-}
 
 // MARK: - Parsing
 

--- a/Tests/SQLTests/Queries/EngineTestSupport.swift
+++ b/Tests/SQLTests/Queries/EngineTestSupport.swift
@@ -251,11 +251,7 @@ func engineSelect(_ text: String) throws -> Query {
 
 /// Parses `text` to a query, failing on any other statement.
 func engineParse(_ text: String) throws -> Query {
-  guard case let .select(query) = try Statement(parsing: text) else {
-    Issue.record("expected a SELECT statement")
-    throw SQLError.incomplete(expected: "a SELECT statement")
-  }
-  return query
+  try parse(query: text)
 }
 
 /// Runs `text` against the single-relation `People` catalog.
@@ -292,4 +288,3 @@ func engineNullable(_ text: String) throws -> Array<Array<Value>> {
 func engineLineage(_ text: String) throws -> Array<Array<Value>> {
   try engineLineage().run(engineParse(text))
 }
-

--- a/Tests/SQLTests/Queries/LateralTests.swift
+++ b/Tests/SQLTests/Queries/LateralTests.swift
@@ -6,14 +6,6 @@ import Testing
 
 import SQLTestSupport
 
-/// Parses `text` to a query, failing on any other statement.
-private func parse(query text: String) throws -> Query {
-  guard case let .select(query) = try Statement(parsing: text) else {
-    Issue.record("expected a SELECT statement")
-    throw SQLError.incomplete(expected: "a SELECT statement")
-  }
-  return query
-}
 
 // MARK: - LATERAL execution
 

--- a/Tests/SQLTests/Queries/LimitTests.swift
+++ b/Tests/SQLTests/Queries/LimitTests.swift
@@ -35,17 +35,6 @@ private func blocks() throws -> FixtureCatalog {
   }
 }
 
-// MARK: - Helpers
-
-/// Parses `text` to a query, failing on any other statement.
-private func parse(_ text: String) throws -> Query {
-  guard case let .select(query) = try Statement(parsing: text) else {
-    Issue.record("expected a SELECT statement")
-    throw SQLError.incomplete(expected: "a SELECT statement")
-  }
-  return query
-}
-
 // MARK: - Tests
 
 struct LimitTests {
@@ -162,7 +151,8 @@ struct LimitTests {
     // The parser cannot spell a negative count, but a direct `Limit` can — the
     // executor's skip and take would trap on it, so the engine rejects it as a
     // query error instead.
-    guard case let .select(base) = try parse("SELECT Id FROM People") else {
+    let query = try parse(query: "SELECT Id FROM People")
+    guard case let .select(base) = query else {
       Issue.record("expected a single SELECT")
       return
     }

--- a/Tests/SQLTests/Queries/ScalarSubqueryTests.swift
+++ b/Tests/SQLTests/Queries/ScalarSubqueryTests.swift
@@ -38,23 +38,7 @@ private func fixture() throws -> FixtureCatalog {
   }
 }
 
-/// Parses `text` and returns its `Select`, failing on any other shape.
-private func parse(select text: String) throws -> Select {
-  guard case let .select(.select(select)) = try Statement(parsing: text) else {
-    Issue.record("expected a single SELECT statement")
-    throw SQLError.incomplete(expected: "a SELECT statement")
-  }
-  return select
-}
 
-/// Parses `text` to a query, failing on any other statement.
-private func parse(query text: String) throws -> Query {
-  guard case let .select(query) = try Statement(parsing: text) else {
-    Issue.record("expected a SELECT statement")
-    throw SQLError.incomplete(expected: "a SELECT statement")
-  }
-  return query
-}
 
 // MARK: - Parsing
 
@@ -73,8 +57,8 @@ struct ScalarSubqueryParsingTests {
   }
 
   @Test func `parses a scalar subquery as a comparison operand`() throws {
-    let select = try parse(
-        select: "SELECT Id FROM T WHERE V = (SELECT MIN(V) FROM S)")
+    let select = try parse(select:
+        "SELECT Id FROM T WHERE V = (SELECT MIN(V) FROM S)")
     let inner = try parse(query: "SELECT MIN(V) FROM S")
     #expect(select.predicate
                 == .comparison(left: .column("V"), op: .equal,

--- a/Tests/SQLTests/Queries/SubqueryTests.swift
+++ b/Tests/SQLTests/Queries/SubqueryTests.swift
@@ -14,50 +14,10 @@ import SQLTestSupport
 /// `V` holds a `NULL` (so `IN (SELECT V …)` sees a NULL element) and a `Flag`
 /// used to filter the inner query to empty or to non-empty.
 private func fixture() throws -> FixtureCatalog {
-  try Catalog {
-    Relation("T", ["Id": .integer, "K": .integer]) {
-      Row(1, 10)
-      Row(2, 20)
-      Row(3, nil)
-      Row(4, 30)
-    }
-    Relation("S", ["V": .integer, "Flag": .integer]) {
-      Row(10, 1)
-      Row(20, 1)
-      Row(99, 0)
-    }
-    // A relation whose single column holds a NULL, for the `IN (…, NULL)`
-    // corners — `V` is `{2, NULL}` when filtered to its first two rows.
-    Relation("N", ["V": .integer]) {
-      Row(2)
-      Row(nil)
-    }
-  }
+  try subqueries()
 }
 
-/// Parses `text` and returns its `Select`, failing on any other shape.
-private func parse(select text: String) throws -> Select {
-  guard case let .select(.select(select)) = try Statement(parsing: text) else {
-    Issue.record("expected a single SELECT statement")
-    throw SQLError.incomplete(expected: "a SELECT statement")
-  }
-  return select
-}
 
-/// Parses `text` to a query, failing on any other statement.
-private func parse(query text: String) throws -> Query {
-  guard case let .select(query) = try Statement(parsing: text) else {
-    Issue.record("expected a SELECT statement")
-    throw SQLError.incomplete(expected: "a SELECT statement")
-  }
-  return query
-}
-
-/// Parses `text` to a `Statement` — the shape `Catalog.run(_:_:)` takes when a
-/// test asserts on invocation side effects rather than on rows alone.
-private func parse(statement text: String) throws -> Statement {
-  try Statement(parsing: text)
-}
 
 // MARK: - Parsing
 
@@ -274,8 +234,8 @@ struct InQueryArityTests {
       throws {
     // The schema path enforces the SAME single-column arity as the run, so
     // validation matches execution.
-    let query = try parse(
-        query: "SELECT Id FROM T WHERE K IN (SELECT V, Flag FROM S)")
+    let query = try parse(query:
+         "SELECT Id FROM T WHERE K IN (SELECT V, Flag FROM S)")
     let resolve = { () throws -> Array<OutputColumn> in
       try fixture().columns(of: query, validate: true)
     }
@@ -305,8 +265,8 @@ struct SubqueryTypeCheckingTests {
   @Test func `a bad inner column faults the schema check`() throws {
     // The inner query is type-checked too, so an unknown column inside it
     // faults validation exactly as a run would reject it.
-    let query = try parse(
-        query: "SELECT Id FROM T WHERE EXISTS (SELECT Missing FROM S)")
+    let query = try parse(query:
+         "SELECT Id FROM T WHERE EXISTS (SELECT Missing FROM S)")
     let resolve = { () throws -> Array<OutputColumn> in
       try fixture().columns(of: query, validate: true)
     }
@@ -319,8 +279,8 @@ struct SubqueryTypeCheckingTests {
       throws {
     // An unregistered routine inside the subquery faults validation as the run
     // would (`SQLError.function`).
-    let query = try parse(
-        query: "SELECT Id FROM T WHERE K IN (SELECT nope(V) FROM S)")
+    let query = try parse(query:
+         "SELECT Id FROM T WHERE K IN (SELECT nope(V) FROM S)")
     let resolve = { () throws -> Array<OutputColumn> in
       try fixture().columns(of: query, validate: true)
     }
@@ -613,8 +573,8 @@ struct SubqueryDeferralTests {
     // never invoked, so the counter stays at 0 — proving compile opens no
     // cursor on `S`.
     let counter = Counter()
-    let query = try parse(
-        query: "SELECT Id FROM T WHERE EXISTS (SELECT tick() FROM S)")
+    let query = try parse(query:
+         "SELECT Id FROM T WHERE EXISTS (SELECT tick() FROM S)")
     let columns =
         try fixture().columns(of: query, routines: routines(counter),
                               validate: true)
@@ -631,8 +591,8 @@ struct SubqueryDeferralTests {
     // cursor), and the RUN materialises the occurrence as a cardinality PROBE
     // that never evaluates the select list, so it does NOT fault either:
     // `EXISTS` over non-empty `S` is TRUE, every row of `T` is admitted.
-    let query = try parse(
-        query: "SELECT Id FROM T WHERE EXISTS (SELECT 1 / (Flag - 1) FROM S)")
+    let query = try parse(query:
+         "SELECT Id FROM T WHERE EXISTS (SELECT 1 / (Flag - 1) FROM S)")
     let columns = try fixture().columns(of: query, validate: true)
     #expect(columns.count == 1)
     // The run does NOT surface the divide — the EXISTS probe never evaluates
@@ -647,8 +607,8 @@ struct SubqueryDeferralTests {
     // arity is decided from the compiled width, never by running the inner
     // query, so `tick()` stays uninvoked.
     let counter = Counter()
-    let query = try parse(
-        query: "SELECT Id FROM T WHERE K IN (SELECT tick() FROM S)")
+    let query = try parse(query:
+         "SELECT Id FROM T WHERE K IN (SELECT tick() FROM S)")
     let columns =
         try fixture().columns(of: query, routines: routines(counter),
                               validate: true)
@@ -665,7 +625,7 @@ struct SubqueryDeferralTests {
     // `EXISTS` over non-empty `S` is still TRUE, admitting every row of `T`.
     let counter = Counter()
     let statement =
-        try parse(statement:
+        try Statement(parsing:
             "SELECT Id FROM T WHERE EXISTS (SELECT tick() FROM S)")
     let rows = try fixture().run(statement, routines(counter))
     let expected: Array<Array<Value>> =
@@ -680,7 +640,7 @@ struct SubqueryDeferralTests {
     // not once per (outer row × S row).
     let counter = Counter()
     let statement =
-        try parse(statement:
+        try Statement(parsing:
             "SELECT Id FROM T WHERE K IN (SELECT tick() FROM S)")
     _ = try fixture().run(statement, routines(counter))
     #expect(counter.count == 3)
@@ -699,7 +659,7 @@ struct SubqueryDeferralTests {
     // behaviour so the follow-up flips it deliberately.
     let counter = Counter()
     let statement =
-        try parse(statement:
+        try Statement(parsing:
             "SELECT Id FROM T WHERE 1 = 0 AND EXISTS (SELECT tick() FROM S)")
     let rows = try fixture().run(statement, routines(counter))
     #expect(rows.isEmpty)
@@ -862,8 +822,8 @@ struct DistinctExistsProbeTests {
     // The type-check validates the SAME probed shape the run evaluates, so the
     // `1 / 0` select list is not checked and validation is clean — matching the
     // run, which does not fault.
-    let query = try parse(
-        query: "SELECT Id FROM T WHERE EXISTS (SELECT DISTINCT 1 / 0 FROM S)")
+    let query = try parse(query:
+         "SELECT Id FROM T WHERE EXISTS (SELECT DISTINCT 1 / 0 FROM S)")
     let columns = try fixture().columns(of: query, validate: true)
     #expect(columns.count == 1)
   }
@@ -969,8 +929,8 @@ struct AggregateExistsProbeTests {
   @Test func `columns validates a whole-result aggregate EXISTS`() throws {
     // The type-check validates the SAME probed `COUNT(*)` shape the run uses,
     // so the `1 / 0` target is not checked — clean, matching the run.
-    let query = try parse(
-        query: "SELECT Id FROM T WHERE EXISTS (SELECT SUM(1 / 0) FROM S)")
+    let query = try parse(query:
+         "SELECT Id FROM T WHERE EXISTS (SELECT SUM(1 / 0) FROM S)")
     let columns = try fixture().columns(of: query, validate: true)
     #expect(columns.count == 1)
   }
@@ -1305,7 +1265,7 @@ struct ViewPushdownSubqueryTests {
     // EXISTS reads the empty CTE and is FALSE, dropping every row, while the
     // view body's own EXISTS still reads base `S` and keeps them — so the
     // result is EMPTY, NOT the base-table interpretation's two rows.
-    let statement = try parse(statement:
+    let statement = try Statement(parsing:
         "WITH S(V) AS (SELECT Id FROM T WHERE 1 = 0) "
         + "SELECT Id FROM VN WHERE EXISTS (SELECT V FROM S)")
     let rows = try nested().run(statement, .standard)
@@ -1331,7 +1291,7 @@ struct ViewPushdownSubqueryTests {
     // and drops every row, while the caller's `.caller` pushed EXISTS reads the
     // non-empty CTE and keeps them. The view filters CORRECTLY (its base `S` is
     // empty), so the result is EMPTY.
-    let statement = try parse(statement:
+    let statement = try Statement(parsing:
         "WITH S(V) AS (SELECT 1) "
         + "SELECT Id FROM VN WHERE EXISTS (SELECT V FROM S)")
     let rows = try hollow().run(statement, .standard)
@@ -1352,14 +1312,14 @@ struct ViewPushdownSubqueryTests {
     // make the view body drop too (still empty, but for the wrong reason), so
     // this pairs with the base-`S`-empty/CTE-non-empty inverse above — together
     // they pin BOTH directions.
-    let empty = try parse(statement:
+    let empty = try Statement(parsing:
         "WITH S(V) AS (SELECT Id FROM T WHERE 1 = 0) "
         + "SELECT Id FROM VN WHERE EXISTS (SELECT V FROM S)")
     #expect(try nested().run(empty, .standard).isEmpty)
     // Caller CTE non-empty: the pushed EXISTS is TRUE and the view body's own
     // EXISTS (base `S` non-empty) is TRUE too, so every row survives — the
     // caller's CTE result did NOT collapse the view body's base read.
-    let full = try parse(statement:
+    let full = try Statement(parsing:
         "WITH S(V) AS (SELECT 1) "
         + "SELECT Id FROM VN WHERE EXISTS (SELECT V FROM S)")
     let kept: Array<Array<Value>> = [[.integer(1)], [.integer(2)]]

--- a/Tests/SQLTests/Schema/DefinitionSchemaTests.swift
+++ b/Tests/SQLTests/Schema/DefinitionSchemaTests.swift
@@ -5,17 +5,6 @@ import Testing
 import SQLEngine
 import SQLTestSupport
 
-// MARK: - Helpers
-
-/// Parses `text` to a query, failing on any other statement.
-private func parse(_ text: String) throws -> Query {
-  guard case let .select(query) = try Statement(parsing: text) else {
-    Issue.record("expected a SELECT statement")
-    throw SQLError.incomplete(expected: "a SELECT statement")
-  }
-  return query
-}
-
 // MARK: - Tests
 
 @Suite struct DefinitionSchemaTests {
@@ -37,8 +26,8 @@ private func parse(_ text: String) throws -> Query {
     // `.recursion` instead, which the builder's `try? compile` catches so it
     // skips the cyclic view. The store must not hang or crash, and an unrelated
     // base relation still reports.
-    let a = try parse("SELECT * FROM B")
-    let b = try parse("SELECT * FROM A")
+    let a = try parse(query: "SELECT * FROM B")
+    let b = try parse(query: "SELECT * FROM A")
     let catalog = FixtureCatalog(
         ["People": FixtureRelation([FixtureField(name: "Name", type: .text)],
                                    [])],
@@ -60,14 +49,14 @@ private func parse(_ text: String) throws -> Query {
     // does not hang or crash reaching it. Assert the catalog's own names all
     // appear (a superset check, so a later slice adding engine-provided rows
     // does not break this).
-    let a = try parse("SELECT * FROM B")
-    let b = try parse("SELECT * FROM A")
+    let a = try parse(query: "SELECT * FROM B")
+    let b = try parse(query: "SELECT * FROM A")
     let catalog = FixtureCatalog(
         ["People": FixtureRelation([FixtureField(name: "Name", type: .text)],
                                    [])],
         views: ["A": View(query: a, columns: ["x"]),
                 "B": View(query: b, columns: ["y"])])
-    let names = try catalog.run(parse("""
+    let names = try catalog.run(parse(query: """
         SELECT table_name FROM definition_schema.tables
         """))
     #expect(names.contains([.text("People")]))

--- a/Tests/SQLTests/Schema/IntrospectionTests.swift
+++ b/Tests/SQLTests/Schema/IntrospectionTests.swift
@@ -36,24 +36,15 @@ private func catalog() throws -> MetaCatalog {
     "People": MetaRelation([("Name", .text), ("Age", .integer)],
                            [[.text("Ann"), .integer(30)]]),
     "Widget": MetaRelation([("Label", .text)], [[.text("cog")]]),
-  ], views: ["Adults": View(query: try parse("SELECT Name FROM People"),
+  ], views: ["Adults": View(query: try parse(query: "SELECT Name FROM People"),
                             columns: ["Name"])])
 }
 
 // MARK: - Helpers
 
-/// Parses `text` to a query, failing on any other statement.
-private func parse(_ text: String) throws -> Query {
-  guard case let .select(query) = try Statement(parsing: text) else {
-    Issue.record("expected a SELECT statement")
-    throw SQLError.incomplete(expected: "a SELECT statement")
-  }
-  return query
-}
-
 /// Runs `text` against the introspection `catalog`, yielding the result rows.
 private func run(_ text: String) throws -> Array<Array<Value>> {
-  try catalog().run(parse(text))
+  try catalog().run(parse(query: text))
 }
 
 // MARK: - Tests
@@ -112,7 +103,7 @@ struct IntrospectionTests {
     let cat = MetaCatalog([
       "information_schema.tables": MetaRelation([("x", .integer)], []),
     ])
-    let rows = try cat.run(parse("""
+    let rows = try cat.run(parse(query: """
         SELECT table_type FROM definition_schema.tables
          WHERE table_name = 'information_schema.tables'
         """))
@@ -157,11 +148,12 @@ struct IntrospectionTests {
     // `Meta` reads `information_schema.tables`, whose `table_name` is text, so
     // the builder must seed the view body's OWN introspection overlay for
     // `Meta`'s column to advertise the text domain, not the integer default.
-    let body = try parse("SELECT table_name FROM information_schema.tables")
+    let body = try parse(query:
+        "SELECT table_name FROM information_schema.tables")
     let meta = MetaCatalog(
         ["People": MetaRelation([("Name", .text)], [])],
         views: ["Meta": View(query: body, columns: ["Label"])])
-    let rows = try meta.run(parse("""
+    let rows = try meta.run(parse(query: """
         SELECT data_type FROM information_schema.columns
          WHERE table_name = 'Meta'
         """))
@@ -190,17 +182,17 @@ struct IntrospectionTests {
     // `People` is both a base relation and a view; `resolve` picks the
     // view, so the overlay lists the name once as a VIEW and reports the view's
     // columns — never a base row `SELECT *` can no longer reach.
-    let body = try parse("SELECT Name FROM Widget")
+    let body = try parse(query: "SELECT Name FROM Widget")
     let cat = MetaCatalog(
         ["People": MetaRelation([("Age", .integer)], []),
          "Widget": MetaRelation([("Name", .text)], [])],
         views: ["People": View(query: body, columns: ["Name"])])
-    let tables = try cat.run(parse("""
+    let tables = try cat.run(parse(query: """
         SELECT table_type FROM information_schema.tables
          WHERE table_name = 'People'
         """))
     #expect(tables == [[.text("VIEW")]])
-    let cols = try cat.run(parse("""
+    let cols = try cat.run(parse(query: """
         SELECT column_name FROM information_schema.columns
          WHERE table_name = 'People'
         """))
@@ -211,11 +203,12 @@ struct IntrospectionTests {
     // A view reading `information_schema.columns` ITSELF must resolve against a
     // schema-only seed of that relation, so its `column_name` column advertises
     // the text domain rather than falling back to the integer default.
-    let body = try parse("SELECT column_name FROM information_schema.columns")
+    let body = try parse(query:
+        "SELECT column_name FROM information_schema.columns")
     let cat = MetaCatalog(
         ["People": MetaRelation([("Name", .text)], [])],
         views: ["c": View(query: body, columns: ["name"])])
-    let rows = try cat.run(parse("""
+    let rows = try cat.run(parse(query: """
         SELECT data_type FROM information_schema.columns
          WHERE table_name = 'c'
         """))
@@ -227,13 +220,14 @@ struct IntrospectionTests {
     // columns overlay must not re-enter itself through `B`'s resolution of `A`
     // — it terminates (rather than overflowing), and the schema-only seed rides
     // through so `B`'s column keeps `column_name`'s text kind.
-    let a = try parse("SELECT column_name FROM information_schema.columns")
-    let b = try parse("SELECT a FROM A")
+    let a = try parse(query:
+        "SELECT column_name FROM information_schema.columns")
+    let b = try parse(query: "SELECT a FROM A")
     let cat = MetaCatalog(
         ["People": MetaRelation([("Name", .text)], [])],
         views: ["A": View(query: a, columns: ["a"]),
                 "B": View(query: b, columns: ["b"])])
-    let rows = try cat.run(parse("""
+    let rows = try cat.run(parse(query: """
         SELECT column_name, data_type FROM information_schema.columns
          WHERE table_name = 'B'
         """))
@@ -245,11 +239,11 @@ struct IntrospectionTests {
     // `SELECT * FROM v` throws. The overlay validates the WHOLE body — as the
     // public schema API does — and does not advertise `v` as queryable
     // metadata.
-    let body = try parse("SELECT Name FROM People WHERE Missing = 1")
+    let body = try parse(query: "SELECT Name FROM People WHERE Missing = 1")
     let cat = MetaCatalog(
         ["People": MetaRelation([("Name", .text)], [])],
         views: ["v": View(query: body, columns: ["Name"])])
-    let rows = try cat.run(parse("""
+    let rows = try cat.run(parse(query: """
         SELECT column_name FROM information_schema.columns
          WHERE table_name = 'v'
         """))
@@ -260,13 +254,13 @@ struct IntrospectionTests {
     // The leading arm resolves, but the second names a missing column, so the
     // whole view cannot run — the overlay must validate EVERY arm, not just the
     // first, and not list `u`.
-    let body = try parse("""
+    let body = try parse(query: """
         SELECT Name FROM People UNION SELECT Missing FROM People
         """)
     let cat = MetaCatalog(
         ["People": MetaRelation([("Name", .text)], [])],
         views: ["u": View(query: body, columns: ["Name"])])
-    let rows = try cat.run(parse("""
+    let rows = try cat.run(parse(query: """
         SELECT column_name FROM information_schema.columns
          WHERE table_name = 'u'
         """))
@@ -277,7 +271,7 @@ struct IntrospectionTests {
     // The join's ON names a column `People` does not have, so `SELECT * FROM v`
     // fails to compile — the overlay validates each join's ON, not just the
     // projection, and does not list `v`.
-    let body = try parse("""
+    let body = try parse(query: """
         SELECT People.Name FROM People
           JOIN Pet ON People.Missing = Pet.Id
         """)
@@ -285,7 +279,7 @@ struct IntrospectionTests {
         ["People": MetaRelation([("Name", .text)], []),
          "Pet": MetaRelation([("Id", .integer)], [])],
         views: ["v": View(query: body, columns: ["Name"])])
-    let rows = try cat.run(parse("""
+    let rows = try cat.run(parse(query: """
         SELECT column_name FROM information_schema.columns
          WHERE table_name = 'v'
         """))
@@ -295,11 +289,11 @@ struct IntrospectionTests {
   @Test func `information_schema.columns hides a view whose GROUP BY is invalid`() throws {
     // GROUP BY names a missing column, so `SELECT * FROM v` fails to compile —
     // the overlay validates the grouping, not just the projection.
-    let body = try parse("SELECT Name FROM People GROUP BY Missing")
+    let body = try parse(query: "SELECT Name FROM People GROUP BY Missing")
     let cat = MetaCatalog(
         ["People": MetaRelation([("Name", .text)], [])],
         views: ["v": View(query: body, columns: ["Name"])])
-    let rows = try cat.run(parse("""
+    let rows = try cat.run(parse(query: """
         SELECT column_name FROM information_schema.columns
          WHERE table_name = 'v'
         """))
@@ -315,11 +309,11 @@ struct IntrospectionTests {
     // the real `compile` — which lowers a call's arguments — closes that
     // gap, so `v` is not listed. This passes through the compile-based
     // validation, not a hand-added argument check.
-    let body = try parse("SELECT BITAND(Missing, 1) AS x FROM People")
+    let body = try parse(query: "SELECT BITAND(Missing, 1) AS x FROM People")
     let cat = MetaCatalog(
         ["People": MetaRelation([("Name", .text)], [])],
         views: ["v": View(query: body, columns: ["x"])])
-    let rows = try cat.run(parse("""
+    let rows = try cat.run(parse(query: """
         SELECT column_name FROM information_schema.columns
          WHERE table_name = 'v'
         """))
@@ -330,13 +324,13 @@ struct IntrospectionTests {
     // HAVING names a column that is neither a GROUP BY key nor aggregated, so
     // `SELECT * FROM v` fails to compile — the overlay validates the HAVING
     // too.
-    let body = try parse("""
+    let body = try parse(query: """
         SELECT Name FROM People GROUP BY Name HAVING Missing > 0
         """)
     let cat = MetaCatalog(
         ["People": MetaRelation([("Name", .text)], [])],
         views: ["v": View(query: body, columns: ["Name"])])
-    let rows = try cat.run(parse("""
+    let rows = try cat.run(parse(query: """
         SELECT column_name FROM information_schema.columns
          WHERE table_name = 'v'
         """))
@@ -347,13 +341,13 @@ struct IntrospectionTests {
     // `w`'s WHERE is invalid and `v` reads `w`; `SELECT * FROM v` fails because
     // `w` cannot run, so the overlay validates the nested body and lists
     // neither.
-    let w = try parse("SELECT Name FROM People WHERE Missing = 1")
-    let v = try parse("SELECT Name FROM w")
+    let w = try parse(query: "SELECT Name FROM People WHERE Missing = 1")
+    let v = try parse(query: "SELECT Name FROM w")
     let cat = MetaCatalog(
         ["People": MetaRelation([("Name", .text)], [])],
         views: ["w": View(query: w, columns: ["Name"]),
                 "v": View(query: v, columns: ["Name"])])
-    let listed = try cat.run(parse("""
+    let listed = try cat.run(parse(query: """
         SELECT table_name FROM information_schema.columns
          WHERE table_name = 'v'
         """))
@@ -365,13 +359,13 @@ struct IntrospectionTests {
     // faults and `SELECT * FROM v` cannot run; the nested resolution must
     // propagate that mismatch, not mask it with `w`'s declared schema, so `v`
     // is not listed.
-    let w = try parse("SELECT Name, Age FROM People")
-    let v = try parse("SELECT x FROM w")
+    let w = try parse(query: "SELECT Name, Age FROM People")
+    let v = try parse(query: "SELECT x FROM w")
     let cat = MetaCatalog(
         ["People": MetaRelation([("Name", .text), ("Age", .integer)], [])],
         views: ["w": View(query: w, columns: ["x"]),
                 "v": View(query: v, columns: ["x"])])
-    let rows = try cat.run(parse("""
+    let rows = try cat.run(parse(query: """
         SELECT table_name FROM information_schema.columns
          WHERE table_name = 'v'
         """))
@@ -383,11 +377,11 @@ struct IntrospectionTests {
     // projects two, so `resolve` faults `SELECT * FROM v`. The builder
     // compares the compiled body width to the declared count, so `v` is not
     // listed.
-    let body = try parse("SELECT * FROM People")
+    let body = try parse(query: "SELECT * FROM People")
     let cat = MetaCatalog(
         ["People": MetaRelation([("Name", .text), ("Age", .integer)], [])],
         views: ["v": View(query: body, columns: ["x"])])
-    let rows = try cat.run(parse("""
+    let rows = try cat.run(parse(query: """
         SELECT column_name FROM information_schema.columns
          WHERE table_name = 'v'
         """))
@@ -401,18 +395,18 @@ struct IntrospectionTests {
     // and does not advertise a view that could never be queried. The cycle must
     // not hang or corrupt an UNRELATED metadata query either — `People` still
     // reports normally, and the cyclic views are absent.
-    let a = try parse("SELECT * FROM B")
-    let b = try parse("SELECT * FROM A")
+    let a = try parse(query: "SELECT * FROM B")
+    let b = try parse(query: "SELECT * FROM A")
     let cat = MetaCatalog(
         ["People": MetaRelation([("Name", .text)], [])],
         views: ["A": View(query: a, columns: ["x"]),
                 "B": View(query: b, columns: ["y"])])
-    let people = try cat.run(parse("""
+    let people = try cat.run(parse(query: """
         SELECT column_name, data_type FROM information_schema.columns
          WHERE table_name = 'People'
         """))
     #expect(people == [[.text("Name"), .text("character varying")]])
-    let cyclic = try cat.run(parse("""
+    let cyclic = try cat.run(parse(query: """
         SELECT column_name FROM information_schema.columns
          WHERE table_name = 'A' OR table_name = 'B'
         """))
@@ -425,13 +419,13 @@ struct IntrospectionTests {
     // crash, not an `SQLError`). The cycle guard threaded through
     // `compile`/`resolve` now reports `.recursion` instead — the same
     // definition-does-not-terminate condition a runaway recursive CTE raises.
-    let a = try parse("SELECT * FROM B")
-    let b = try parse("SELECT * FROM A")
+    let a = try parse(query: "SELECT * FROM B")
+    let b = try parse(query: "SELECT * FROM A")
     let cat = MetaCatalog([:],
         views: ["A": View(query: a, columns: ["x"]),
                 "B": View(query: b, columns: ["y"])])
     #expect(throws: SQLError.recursion("A")) {
-      let _ = try cat.run(parse("SELECT * FROM A"))
+      let _ = try cat.run(parse(query: "SELECT * FROM A"))
     }
   }
 
@@ -472,7 +466,8 @@ struct IntrospectionTests {
       "information_schema.tables":
           MetaRelation([("x", .integer)], [[.integer(7)]]),
     ])
-    let rows = try cat.run(parse("SELECT * FROM information_schema.tables"))
+    let query = try parse(query: "SELECT * FROM information_schema.tables")
+    let rows = try cat.run(query)
     #expect(rows == [[.integer(7)]])
   }
 
@@ -486,7 +481,7 @@ struct IntrospectionTests {
   }
 
   @Test func `columns(of:) resolves an information_schema relation's headers`() throws {
-    let query = try parse("SELECT * FROM information_schema.tables")
+    let query = try parse(query: "SELECT * FROM information_schema.tables")
     let columns = try catalog().columns(of: query)
     #expect(columns.map(\.name) == ["table_catalog", "table_schema",
                                     "table_name", "table_type"])
@@ -521,7 +516,7 @@ struct IntrospectionTests {
     // A view whose body selects from a reserved introspection relation must
     // resolve its overlay from ITS OWN query, so selecting from the view yields
     // exactly what the inline query does.
-    let body = try parse("""
+    let body = try parse(query: """
         SELECT table_name FROM information_schema.tables
           WHERE table_type = 'BASE TABLE' ORDER BY table_name
         """)
@@ -531,13 +526,13 @@ struct IntrospectionTests {
     ], views: ["meta": View(query: body, columns: ["table_name"])])
     let inline = try source.run(body)
     let viewed =
-        try source.run(parse("SELECT table_name FROM meta"))
+        try source.run(parse(query: "SELECT table_name FROM meta"))
     #expect(viewed == inline)
     #expect(viewed == [[.text("People")], [.text("Widget")]])
   }
 
   @Test func `a view over information_schema.columns yields the inline rows`() throws {
-    let body = try parse("""
+    let body = try parse(query: """
         SELECT column_name, data_type FROM information_schema.columns
           WHERE table_name = 'People'
           ORDER BY column_name
@@ -547,7 +542,7 @@ struct IntrospectionTests {
     ], views: ["cols": View(query: body,
                             columns: ["column_name", "data_type"])])
     let inline = try source.run(body)
-    let viewed = try source.run(parse("""
+    let viewed = try source.run(parse(query: """
         SELECT column_name, data_type FROM cols ORDER BY column_name
         """))
     #expect(viewed == inline)
@@ -562,7 +557,7 @@ struct IntrospectionTests {
     // integer, `table_name`/`data_type` text — not a synthesized all-integer
     // schema.
     let columns =
-        try catalog().columns(of: parse("""
+        try catalog().columns(of: parse(query: """
             SELECT * FROM information_schema.columns
             """))
     let typed = Dictionary(uniqueKeysWithValues:
@@ -578,7 +573,7 @@ struct IntrospectionTests {
     // — so resolving the body's kinds is what reports the `.text` here rather
     // than the integer default.
     let columns =
-        try catalog().columns(of: parse("SELECT * FROM Adults"))
+        try catalog().columns(of: parse(query: "SELECT * FROM Adults"))
     #expect(columns == [OutputColumn(name: "Name", type: .text)])
   }
 
@@ -589,14 +584,14 @@ struct IntrospectionTests {
     // advertises `character varying`, not the `.integer` default a call fell to
     // before routines declared a return type. The run carries `TAG`, so its
     // return type reaches the store builder's view typing.
-    let body = try parse("SELECT TAG(Name) AS iid FROM People")
+    let body = try parse(query: "SELECT TAG(Name) AS iid FROM People")
     let cat = MetaCatalog(
         ["People": MetaRelation([("Name", .text)], [])],
         views: ["v": View(query: body, columns: ["iid"])])
     let routines =
         try Routines().registering("tag", returns: .text,
                                    parameters: [.text]) { _ in .text("x") }
-    let rows = try cat.run(parse("""
+    let rows = try cat.run(parse(query: """
         SELECT column_name, data_type FROM information_schema.columns
          WHERE table_name = 'v'
         """), routines)
@@ -607,7 +602,7 @@ struct IntrospectionTests {
     // The public schema API takes the SAME routines a run would, so a projected
     // `TAG(Name)` reports its declared `.text` return type, not `.integer`.
     let cat = MetaCatalog(["People": MetaRelation([("Name", .text)], [])])
-    let query = try parse("SELECT TAG(Name) AS t FROM People")
+    let query = try parse(query: "SELECT TAG(Name) AS t FROM People")
     let routines =
         try Routines().registering("tag", returns: .text,
                                    parameters: [.text]) { _ in .text("x") }
@@ -622,7 +617,7 @@ struct IntrospectionTests {
     // The unknown `NOPE` is in the WHERE, invisible to the first-arm projection
     // walk; the whole-query inventory faults it, exactly as a run would.
     let cat = MetaCatalog(["People": MetaRelation([("Name", .text)], [])])
-    let query = try parse("SELECT Name FROM People WHERE NOPE(Name) = 1")
+    let query = try parse(query: "SELECT Name FROM People WHERE NOPE(Name) = 1")
     #expect(throws: SQLError.self) { let _ = try cat.columns(of: query) }
   }
 
@@ -633,7 +628,7 @@ struct IntrospectionTests {
       "People": MetaRelation([("Name", .text)], []),
       "Pet": MetaRelation([("Species", .text)], []),
     ])
-    let query = try parse("""
+    let query = try parse(query: """
         SELECT Name FROM People UNION SELECT NOPE(Species) FROM Pet
         """)
     #expect(throws: SQLError.self) { let _ = try cat.columns(of: query) }
@@ -643,7 +638,7 @@ struct IntrospectionTests {
     // `w` projects `TAG(Name)`; `SELECT * FROM w` must report `t` as the
     // routine's declared `.text`, so schema resolution threads the return map
     // across the view boundary rather than dropping it to `.integer`.
-    let body = try parse("SELECT TAG(Name) AS t FROM People")
+    let body = try parse(query: "SELECT TAG(Name) AS t FROM People")
     let cat = MetaCatalog(
         ["People": MetaRelation([("Name", .text)], [])],
         views: ["w": View(query: body, columns: ["t"])])
@@ -651,7 +646,7 @@ struct IntrospectionTests {
         try Routines().registering("tag", returns: .text,
                                    parameters: [.text]) { _ in .text("x") }
     let typed =
-        try cat.columns(of: parse("SELECT * FROM w"), routines: routines)
+        try cat.columns(of: parse(query: "SELECT * FROM w"), routines: routines)
     #expect(typed == [OutputColumn(name: "t", type: .text)])
   }
 
@@ -659,12 +654,12 @@ struct IntrospectionTests {
     // `SELECT * FROM v` names no call, but v's body calls the unregistered
     // `NOPE` in its WHERE — a clause the view-boundary first-arm walk misses.
     // The body's call inventory must fault, as `SELECT * FROM v` would at run.
-    let body = try parse("SELECT Name FROM People WHERE NOPE(Name) = 1")
+    let body = try parse(query: "SELECT Name FROM People WHERE NOPE(Name) = 1")
     let cat = MetaCatalog(
         ["People": MetaRelation([("Name", .text)], [])],
         views: ["v": View(query: body, columns: ["Name"])])
     #expect(throws: SQLError.self) {
-      let _ = try cat.columns(of: parse("SELECT * FROM v"))
+      let _ = try cat.columns(of: parse(query: "SELECT * FROM v"))
     }
   }
 
@@ -673,7 +668,8 @@ struct IntrospectionTests {
     // non-NULL text row, so the schema faults rather than typing `.integer`.
     let cat = MetaCatalog(["People": MetaRelation([("Name", .text)], [])])
     #expect(throws: SQLError.self) {
-      let _ = try cat.columns(of: parse("SELECT Name + 1 AS x FROM People"))
+      let query = try parse(query: "SELECT Name + 1 AS x FROM People")
+      let _ = try cat.columns(of: query)
     }
   }
 
@@ -682,29 +678,29 @@ struct IntrospectionTests {
     // so `SUM(Name)`/`AVG(Name)` fault rather than typing text/double.
     let cat = MetaCatalog(["People": MetaRelation([("Name", .text)], [])])
     #expect(throws: SQLError.self) {
-      let _ = try cat.columns(of: parse("SELECT SUM(Name) FROM People"))
+      let _ = try cat.columns(of: parse(query: "SELECT SUM(Name) FROM People"))
     }
     #expect(throws: SQLError.self) {
-      let _ = try cat.columns(of: parse("SELECT AVG(Name) FROM People"))
+      let _ = try cat.columns(of: parse(query: "SELECT AVG(Name) FROM People"))
     }
   }
 
   @Test func `columns(of:) types numeric aggregates and arithmetic`() throws {
     let cat = MetaCatalog(["T": MetaRelation(
         [("Name", .text), ("Age", .integer), ("Score", .double)], [])])
-    #expect(try cat.columns(of: parse("SELECT SUM(Age) AS x FROM T"))
+    #expect(try cat.columns(of: parse(query: "SELECT SUM(Age) AS x FROM T"))
                 == [OutputColumn(name: "x", type: .integer)])
-    #expect(try cat.columns(of: parse("SELECT SUM(Score) AS x FROM T"))
+    #expect(try cat.columns(of: parse(query: "SELECT SUM(Score) AS x FROM T"))
                 == [OutputColumn(name: "x", type: .double)])
-    #expect(try cat.columns(of: parse("SELECT AVG(Age) AS x FROM T"))
+    #expect(try cat.columns(of: parse(query: "SELECT AVG(Age) AS x FROM T"))
                 == [OutputColumn(name: "x", type: .double)])
-    #expect(try cat.columns(of: parse("SELECT Age + 1 AS x FROM T"))
+    #expect(try cat.columns(of: parse(query: "SELECT Age + 1 AS x FROM T"))
                 == [OutputColumn(name: "x", type: .integer)])
-    #expect(try cat.columns(of: parse("SELECT Age + Score AS x FROM T"))
+    #expect(try cat.columns(of: parse(query: "SELECT Age + Score AS x FROM T"))
                 == [OutputColumn(name: "x", type: .double)])
     // MIN/MAX compare rather than fold, so they keep the operand's own type —
     // even a non-numeric one.
-    #expect(try cat.columns(of: parse("SELECT MIN(Name) AS x FROM T"))
+    #expect(try cat.columns(of: parse(query: "SELECT MIN(Name) AS x FROM T"))
                 == [OutputColumn(name: "x", type: .text)])
   }
 
@@ -714,7 +710,7 @@ struct IntrospectionTests {
     let cat = MetaCatalog(["People":
         MetaRelation([("Name", .text), ("Age", .integer)], [])])
     #expect(throws: SQLError.self) {
-      let _ = try cat.columns(of: parse("""
+      let _ = try cat.columns(of: parse(query: """
           SELECT Age FROM People UNION SELECT Name + 1 FROM People
           """))
     }
@@ -725,7 +721,7 @@ struct IntrospectionTests {
     // it; the whole-query type-check faults it, as a run would.
     let cat = MetaCatalog(["People": MetaRelation([("Name", .text)], [])])
     #expect(throws: SQLError.self) {
-      let _ = try cat.columns(of: parse("""
+      let _ = try cat.columns(of: parse(query: """
           SELECT Name FROM People GROUP BY Name HAVING SUM(Name) > 0
           """))
     }
@@ -735,7 +731,7 @@ struct IntrospectionTests {
     let cat = MetaCatalog(["People":
         MetaRelation([("Name", .text), ("Age", .integer)], [])])
     #expect(throws: SQLError.self) {
-      let _ = try cat.columns(of: parse("""
+      let _ = try cat.columns(of: parse(query: """
           SELECT Age FROM People WHERE Name + 1 = 2
           """))
     }
@@ -744,10 +740,10 @@ struct IntrospectionTests {
   @Test func `columns(of:) types a valid later arm and HAVING`() throws {
     let cat = MetaCatalog(["People":
         MetaRelation([("Name", .text), ("Age", .integer)], [])])
-    #expect(try cat.columns(of: parse("""
+    #expect(try cat.columns(of: parse(query: """
         SELECT Age FROM People UNION SELECT Age + 1 FROM People
         """)) == [OutputColumn(name: "Age", type: .integer)])
-    #expect(try cat.columns(of: parse("""
+    #expect(try cat.columns(of: parse(query: """
         SELECT Name FROM People GROUP BY Name HAVING SUM(Age) > 0
         """)) == [OutputColumn(name: "Name", type: .text)])
   }
@@ -755,13 +751,13 @@ struct IntrospectionTests {
   @Test func `information_schema.columns hides a view with a bad HAVING operand`() throws {
     // The view's HAVING folds `SUM(Name)` over text — a run faults — so the
     // view is not advertised, though its projection types cleanly.
-    let body = try parse("""
+    let body = try parse(query: """
         SELECT Name FROM People GROUP BY Name HAVING SUM(Name) > 0
         """)
     let cat = MetaCatalog(
         ["People": MetaRelation([("Name", .text)], [])],
         views: ["v": View(query: body, columns: ["Name"])])
-    let rows = try cat.run(parse("""
+    let rows = try cat.run(parse(query: """
         SELECT column_name FROM information_schema.columns
          WHERE table_name = 'v'
         """))
@@ -772,14 +768,14 @@ struct IntrospectionTests {
     // `1 = 0` is constantly false, so the executor never evaluates `Name + 1`;
     // the schema resolves rather than faulting on the unreachable arm.
     let cat = MetaCatalog(["People": MetaRelation([("Name", .text)], [])])
-    #expect(try cat.columns(of: parse("""
+    #expect(try cat.columns(of: parse(query: """
         SELECT Name FROM People WHERE 1 = 0 AND Name + 1 = 2
         """)) == [OutputColumn(name: "Name", type: .text)])
   }
 
   @Test func `columns(of:) skips an arm a constant-true OR short-circuits`() throws {
     let cat = MetaCatalog(["People": MetaRelation([("Name", .text)], [])])
-    #expect(try cat.columns(of: parse("""
+    #expect(try cat.columns(of: parse(query: """
         SELECT Name FROM People WHERE 1 = 1 OR Name + 1 = 2
         """)) == [OutputColumn(name: "Name", type: .text)])
   }
@@ -790,25 +786,25 @@ struct IntrospectionTests {
     let cat = MetaCatalog(["People":
         MetaRelation([("Name", .text), ("Age", .integer)], [])])
     #expect(throws: SQLError.self) {
-      let _ = try cat.columns(of: parse("""
+      let _ = try cat.columns(of: parse(query: """
           SELECT Name FROM People WHERE 1 = 1 AND Name + 1 = 2
           """))
     }
     #expect(throws: SQLError.self) {
-      let _ = try cat.columns(of: parse("""
+      let _ = try cat.columns(of: parse(query: """
           SELECT Name FROM People WHERE Age = 0 AND Name + 1 = 2
           """))
     }
   }
 
   @Test func `information_schema.columns lists a view with a short-circuited arm`() throws {
-    let body = try parse("""
+    let body = try parse(query: """
         SELECT Name FROM People WHERE 1 = 0 AND Name + 1 = 2
         """)
     let cat = MetaCatalog(
         ["People": MetaRelation([("Name", .text)], [])],
         views: ["v": View(query: body, columns: ["Name"])])
-    let rows = try cat.run(parse("""
+    let rows = try cat.run(parse(query: """
         SELECT column_name FROM information_schema.columns
          WHERE table_name = 'v'
         """))
@@ -820,10 +816,10 @@ struct IntrospectionTests {
     // never evaluates it and the query runs — the schema resolves, and call
     // validation rides the same short-circuit-aware walk as operand checking.
     let cat = MetaCatalog(["People": MetaRelation([("Name", .text)], [])])
-    #expect(try cat.columns(of: parse("""
+    #expect(try cat.columns(of: parse(query: """
         SELECT Name FROM People WHERE 1 = 0 AND NOPE(Name) = 1
         """)) == [OutputColumn(name: "Name", type: .text)])
-    #expect(try cat.columns(of: parse("""
+    #expect(try cat.columns(of: parse(query: """
         SELECT Name FROM People WHERE 1 = 1 OR NOPE(Name) = 1
         """)) == [OutputColumn(name: "Name", type: .text)])
   }
@@ -831,20 +827,20 @@ struct IntrospectionTests {
   @Test func `columns(of:) still faults on a reachable unknown call`() throws {
     let cat = MetaCatalog(["People": MetaRelation([("Name", .text)], [])])
     #expect(throws: SQLError.self) {
-      let _ = try cat.columns(of: parse("""
+      let _ = try cat.columns(of: parse(query: """
           SELECT Name FROM People WHERE 1 = 1 AND NOPE(Name) = 1
           """))
     }
   }
 
   @Test func `information_schema.columns lists a view with an unreachable call`() throws {
-    let body = try parse("""
+    let body = try parse(query: """
         SELECT Name FROM People WHERE 1 = 0 AND NOPE(Name) = 1
         """)
     let cat = MetaCatalog(
         ["People": MetaRelation([("Name", .text)], [])],
         views: ["v": View(query: body, columns: ["Name"])])
-    let rows = try cat.run(parse("""
+    let rows = try cat.run(parse(query: """
         SELECT column_name FROM information_schema.columns
          WHERE table_name = 'v'
         """))
@@ -856,7 +852,7 @@ struct IntrospectionTests {
     // projection, so `Name + 1` is never evaluated; the schema DERIVES its
     // nominal type without faulting on the non-numeric operand.
     let cat = MetaCatalog(["People": MetaRelation([("Name", .text)], [])])
-    #expect(try cat.columns(of: parse("""
+    #expect(try cat.columns(of: parse(query: """
         SELECT Name + 1 AS x FROM People FETCH FIRST 0 ROWS ONLY
         """)) == [OutputColumn(name: "x", type: .integer)])
   }
@@ -865,20 +861,20 @@ struct IntrospectionTests {
     // A non-zero limit projects rows, so the operand is reachable and faults.
     let cat = MetaCatalog(["People": MetaRelation([("Name", .text)], [])])
     #expect(throws: SQLError.self) {
-      let _ = try cat.columns(of: parse("""
+      let _ = try cat.columns(of: parse(query: """
           SELECT Name + 1 AS x FROM People FETCH FIRST 2 ROWS ONLY
           """))
     }
   }
 
   @Test func `information_schema.columns lists a zero-row-limit view`() throws {
-    let body = try parse("""
+    let body = try parse(query: """
         SELECT Name + 1 AS x FROM People FETCH FIRST 0 ROWS ONLY
         """)
     let cat = MetaCatalog(
         ["People": MetaRelation([("Name", .text)], [])],
         views: ["v": View(query: body, columns: ["x"])])
-    let rows = try cat.run(parse("""
+    let rows = try cat.run(parse(query: """
         SELECT column_name, data_type FROM information_schema.columns
          WHERE table_name = 'v'
         """))
@@ -892,11 +888,11 @@ struct IntrospectionTests {
     let cat = MetaCatalog(["People":
         MetaRelation([("Name", .text), ("Age", .integer)], [])])
     #expect(throws: SQLError.self) {
-      let _ = try cat.columns(of: parse("""
+      let _ = try cat.columns(of: parse(query: """
           SELECT SUM(Name) FROM People FETCH FIRST 0 ROWS ONLY
           """))
     }
-    #expect(try cat.columns(of: parse("""
+    #expect(try cat.columns(of: parse(query: """
         SELECT SUM(Age) AS x FROM People FETCH FIRST 0 ROWS ONLY
         """)) == [OutputColumn(name: "x", type: .integer)])
   }
@@ -906,10 +902,10 @@ struct IntrospectionTests {
     // the executor skips the guarded arm; the schema resolves rather than
     // faulting on the unreachable operand or call.
     let cat = MetaCatalog(["People": MetaRelation([("Name", .text)], [])])
-    #expect(try cat.columns(of: parse("""
+    #expect(try cat.columns(of: parse(query: """
         SELECT Name FROM People WHERE 1 IS NULL AND Name + 1 = 2
         """)) == [OutputColumn(name: "Name", type: .text)])
-    #expect(try cat.columns(of: parse("""
+    #expect(try cat.columns(of: parse(query: """
         SELECT Name FROM People WHERE 1 IS NOT NULL OR NOPE(Name) = 1
         """)) == [OutputColumn(name: "Name", type: .text)])
   }
@@ -918,18 +914,18 @@ struct IntrospectionTests {
     // `WHERE 1 = 0` filters every row before projecting, so `Name + 1` is
     // unreachable and the schema resolves.
     let cat = MetaCatalog(["People": MetaRelation([("Name", .text)], [])])
-    #expect(try cat.columns(of: parse("""
+    #expect(try cat.columns(of: parse(query: """
         SELECT Name + 1 AS x FROM People WHERE 1 = 0
         """)) == [OutputColumn(name: "x", type: .integer)])
     // An aggregate folds zero rows, so its text operand is never evaluated.
-    let summed = try cat.columns(of: parse("""
+    let summed = try cat.columns(of: parse(query: """
         SELECT SUM(Name) AS s FROM People WHERE 1 = 0
         """))
     #expect(summed.count == 1)
     // But a whole-result aggregate still emits ONE empty group, so a scalar
     // call projecting it runs — an unregistered routine faults, as a run does.
     #expect(throws: SQLError.self) {
-      let _ = try cat.columns(of: parse("""
+      let _ = try cat.columns(of: parse(query: """
           SELECT NOPE(COUNT(*)) AS x FROM People WHERE 1 = 0
           """))
     }
@@ -939,46 +935,46 @@ struct IntrospectionTests {
     let cat = MetaCatalog(["People": MetaRelation([("Age", .integer)], [])])
     // A false HAVING drops the empty group before the projection, so its call
     // is unreachable — the query returns an empty result and types cleanly.
-    #expect(try cat.columns(of: parse("""
+    #expect(try cat.columns(of: parse(query: """
         SELECT NOPE(COUNT(*)) AS x FROM People WHERE 1 = 0 HAVING 1 = 0
         """)) == [OutputColumn(name: "x", type: .integer)])
     // A true HAVING keeps the empty group, so the projection's call runs.
     #expect(throws: SQLError.self) {
-      let _ = try cat.columns(of: parse("""
+      let _ = try cat.columns(of: parse(query: """
           SELECT NOPE(COUNT(*)) AS x FROM People WHERE 1 = 0 HAVING 1 = 1
           """))
     }
     // COUNT is 0 over the empty group, so COUNT(*) / 0 is a real divide.
     #expect(throws: SQLError.self) {
-      let _ = try cat.columns(of: parse("""
+      let _ = try cat.columns(of: parse(query: """
           SELECT COUNT(*) / 0 AS x FROM People WHERE 1 = 0
           """))
     }
     // Every other aggregate is NULL, so SUM(Age) / 0 propagates NULL, no fault.
-    #expect(try cat.columns(of: parse("""
+    #expect(try cat.columns(of: parse(query: """
         SELECT SUM(Age) / 0 AS x FROM People WHERE 1 = 0
         """)) == [OutputColumn(name: "x", type: .integer)])
     // A literal fault in the projection beside an aggregate still runs.
     #expect(throws: SQLError.self) {
-      let _ = try cat.columns(of: parse("""
+      let _ = try cat.columns(of: parse(query: """
           SELECT COUNT(*) AS c, 1 / 0 AS x FROM People WHERE 1 = 0
           """))
     }
     // A registered routine runs over the empty group, so a wrong-arity call
     // (BITAND takes two) faults as the run would.
     #expect(throws: SQLError.self) {
-      let _ = try cat.columns(of: parse("""
+      let _ = try cat.columns(of: parse(query: """
           SELECT BITAND(COUNT(*)) AS x FROM People WHERE 1 = 0
           """))
     }
     // A HAVING false over the empty group (COUNT is 0) drops it, so a faulting
     // projection is never reached — the query returns no rows, types cleanly.
-    #expect(try cat.columns(of: parse("""
+    #expect(try cat.columns(of: parse(query: """
         SELECT 1 / 0 AS x FROM People WHERE 1 = 0 HAVING COUNT(*) = 1
         """)).count == 1)
     // A HAVING true over the empty group keeps it, so the projection runs.
     #expect(throws: SQLError.self) {
-      let _ = try cat.columns(of: parse("""
+      let _ = try cat.columns(of: parse(query: """
           SELECT 1 / 0 AS x FROM People WHERE 1 = 0 HAVING COUNT(*) = 0
           """))
     }
@@ -988,7 +984,7 @@ struct IntrospectionTests {
     let cat = MetaCatalog(["People": MetaRelation([("Age", .integer)], [])])
     // With no binding, `... = :p` yields UNKNOWN without evaluating the left,
     // so the divide never runs — the query returns no rows and types cleanly.
-    #expect(try cat.columns(of: parse("""
+    #expect(try cat.columns(of: parse(query: """
         SELECT COUNT(*) AS c FROM People WHERE 1 = 0 HAVING COUNT(*) / 0 = :p
         """)).count == 1)
   }
@@ -1002,7 +998,7 @@ struct IntrospectionTests {
     // The empty group projects BAD(), a non-finite double the run rejects
     // (SQLError.magnitude), so the schema must reject it too.
     #expect(throws: SQLError.self) {
-      let _ = try cat.columns(of: parse("""
+      let _ = try cat.columns(of: parse(query: """
           SELECT BAD() AS x FROM People WHERE 1 = 0 HAVING 1 = 1
           """), routines: routines)
     }
@@ -1014,12 +1010,15 @@ struct IntrospectionTests {
     // COUNT evaluates its operand per row to test non-NULL, so a bad operand
     // (or an unknown call) faults; a valid operand counts as integer.
     #expect(throws: SQLError.self) {
-      let _ = try cat.columns(of: parse("SELECT COUNT(Name + 1) FROM People"))
+      let query = try parse(query: "SELECT COUNT(Name + 1) FROM People")
+      let _ = try cat.columns(of: query)
     }
     #expect(throws: SQLError.self) {
-      let _ = try cat.columns(of: parse("SELECT COUNT(NOPE(Name)) FROM People"))
+      let query = try parse(query: "SELECT COUNT(NOPE(Name)) FROM People")
+      let _ = try cat.columns(of: query)
     }
-    #expect(try cat.columns(of: parse("SELECT COUNT(Age) AS c FROM People"))
+    let query = try parse(query: "SELECT COUNT(Age) AS c FROM People")
+    #expect(try cat.columns(of: query)
                 == [OutputColumn(name: "c", type: .integer)])
   }
 
@@ -1028,11 +1027,11 @@ struct IntrospectionTests {
     // is unreachable and the schema resolves — but an aggregate fold, which the
     // group node runs before HAVING, is still validated.
     let cat = MetaCatalog(["People": MetaRelation([("Name", .text)], [])])
-    #expect(try cat.columns(of: parse("""
+    #expect(try cat.columns(of: parse(query: """
         SELECT Name + 1 AS x FROM People GROUP BY Name HAVING 1 = 0
         """)) == [OutputColumn(name: "x", type: .integer)])
     #expect(throws: SQLError.self) {
-      let _ = try cat.columns(of: parse("""
+      let _ = try cat.columns(of: parse(query: """
           SELECT SUM(Name) FROM People GROUP BY Name HAVING 1 = 0
           """))
     }
@@ -1045,11 +1044,11 @@ struct IntrospectionTests {
     let cat = MetaCatalog(["People":
         MetaRelation([("Name", .text), ("Age", .integer)], [])])
     #expect(throws: SQLError.self) {
-      let _ = try cat.columns(of: parse("""
+      let _ = try cat.columns(of: parse(query: """
           SELECT Name FROM People GROUP BY Name HAVING 1 = 0 AND SUM(Name) > 0
           """))
     }
-    #expect(try cat.columns(of: parse("""
+    #expect(try cat.columns(of: parse(query: """
         SELECT Name FROM People GROUP BY Name HAVING 1 = 0 AND SUM(Age) > 0
         """)) == [OutputColumn(name: "Name", type: .text)])
   }
@@ -1057,10 +1056,10 @@ struct IntrospectionTests {
   @Test func `columns(of:) rejects a statically-known division by zero`() throws {
     let cat = MetaCatalog(["People": MetaRelation([("Age", .integer)], [])])
     #expect(throws: SQLError.divide) {
-      let _ = try cat.columns(of: parse("SELECT 1 / 0 AS x FROM People"))
+      let _ = try cat.columns(of: parse(query: "SELECT 1 / 0 AS x FROM People"))
     }
     // A non-literal divisor is data-dependent, so it is not rejected.
-    #expect(try cat.columns(of: parse("SELECT 1 / Age AS x FROM People"))
+    #expect(try cat.columns(of: parse(query: "SELECT 1 / Age AS x FROM People"))
                 == [OutputColumn(name: "x", type: .integer)])
   }
 
@@ -1070,14 +1069,14 @@ struct IntrospectionTests {
     // SELECT at once); the schema rejects it rather than advertise a column.
     #expect(throws: SQLError.self) {
       let _ = try cat.columns(of:
-          parse("SELECT 9223372036854775807 + 1 AS x FROM People"))
+          parse(query: "SELECT 9223372036854775807 + 1 AS x FROM People"))
     }
     #expect(throws: SQLError.self) {
       let _ = try cat.columns(of:
-          parse("SELECT 1e308 * 1e308 AS x FROM People"))
+          parse(query: "SELECT 1e308 * 1e308 AS x FROM People"))
     }
     // A non-literal operand is data-dependent, so it is not rejected.
-    #expect(try cat.columns(of: parse("SELECT Age + 1 AS x FROM People"))
+    #expect(try cat.columns(of: parse(query: "SELECT Age + 1 AS x FROM People"))
                 == [OutputColumn(name: "x", type: .integer)])
   }
 
@@ -1086,7 +1085,7 @@ struct IntrospectionTests {
     // without evaluating the left term, so the query runs (no rows) and the
     // schema resolves rather than faulting on the text arithmetic.
     let cat = MetaCatalog(["People": MetaRelation([("Name", .text)], [])])
-    #expect(try cat.columns(of: parse("""
+    #expect(try cat.columns(of: parse(query: """
         SELECT Name FROM People WHERE Name + 1 = :p
         """)) == [OutputColumn(name: "Name", type: .text)])
   }
@@ -1096,7 +1095,7 @@ struct IntrospectionTests {
     // faults; typing recurses into the arguments, as a run would.
     let cat = MetaCatalog(["People": MetaRelation([("Name", .text)], [])])
     #expect(throws: SQLError.self) {
-      let _ = try cat.columns(of: parse("""
+      let _ = try cat.columns(of: parse(query: """
           SELECT BITAND(Name + 1, 1) FROM People
           """))
     }
@@ -1104,7 +1103,7 @@ struct IntrospectionTests {
 
   @Test func `columns(of:) types a call over valid arguments`() throws {
     let cat = MetaCatalog(["People": MetaRelation([("Age", .integer)], [])])
-    #expect(try cat.columns(of: parse("""
+    #expect(try cat.columns(of: parse(query: """
         SELECT BITAND(Age, 1) AS b FROM People
         """)) == [OutputColumn(name: "b", type: .integer)])
   }
@@ -1116,7 +1115,7 @@ struct IntrospectionTests {
     // must reject it rather than advertise an integer column no row produces.
     let cat = MetaCatalog(["People": MetaRelation([("Name", .text)], [])])
     #expect(throws: SQLError.self) {
-      let _ = try cat.columns(of: parse("""
+      let _ = try cat.columns(of: parse(query: """
           SELECT BITAND(Name, 1) AS x FROM People
           """))
     }
@@ -1128,7 +1127,7 @@ struct IntrospectionTests {
     // rejects it rather than typing an integer column.
     let cat = MetaCatalog(["People": MetaRelation([("Age", .integer)], [])])
     #expect(throws: SQLError.self) {
-      let _ = try cat.columns(of: parse("""
+      let _ = try cat.columns(of: parse(query: """
           SELECT BITAND(Age) AS x FROM People
           """))
     }
@@ -1139,7 +1138,7 @@ struct IntrospectionTests {
     // definition_schema.columns even when a recursive CTE names the store
     // directly — the cached CTE store entry is seeded with the routine returns,
     // so `BITAND(...)` types inside the CTE as it does outside it.
-    let body = try parse("SELECT BITAND(Age, 1) AS b FROM People")
+    let body = try parse(query: "SELECT BITAND(Age, 1) AS b FROM People")
     let cat = MetaCatalog(
         ["People": MetaRelation([("Age", .integer)], [])],
         views: ["v": View(query: body, columns: ["b"])])
@@ -1162,7 +1161,7 @@ struct IntrospectionTests {
       "People": MetaRelation([("Name", .text)], []),
       "definition_schema.tables": MetaRelation([("x", .integer)], []),
     ])
-    let rows = try cat.run(parse("""
+    let rows = try cat.run(parse(query: """
         SELECT table_name FROM information_schema.tables ORDER BY table_name
         """))
     // `People` and the two built-in views — but NOT the shadowed reserved base.
@@ -1177,11 +1176,11 @@ struct IntrospectionTests {
     // `v` projects `NOPE(Name)`; `NOPE` is not registered, so `SELECT * FROM v`
     // faults at run. `compile` lowers the call without checking the routine, so
     // the unknown function surfaces at typing — the view is not listed.
-    let body = try parse("SELECT NOPE(Name) AS x FROM People")
+    let body = try parse(query: "SELECT NOPE(Name) AS x FROM People")
     let cat = MetaCatalog(
         ["People": MetaRelation([("Name", .text)], [])],
         views: ["v": View(query: body, columns: ["x"])])
-    let rows = try cat.run(parse("""
+    let rows = try cat.run(parse(query: """
         SELECT column_name FROM information_schema.columns
          WHERE table_name = 'v'
         """))
@@ -1192,11 +1191,11 @@ struct IntrospectionTests {
     // The unknown `NOPE` is in the WHERE, not the projection, so the first-arm
     // type walk never sees it — only the whole-body call inventory does, and a
     // run of `SELECT * FROM v` would fault `SQLError.function`.
-    let body = try parse("SELECT Name FROM People WHERE NOPE(Name) = 1")
+    let body = try parse(query: "SELECT Name FROM People WHERE NOPE(Name) = 1")
     let cat = MetaCatalog(
         ["People": MetaRelation([("Name", .text)], [])],
         views: ["v": View(query: body, columns: ["Name"])])
-    let rows = try cat.run(parse("""
+    let rows = try cat.run(parse(query: """
         SELECT column_name FROM information_schema.columns
          WHERE table_name = 'v'
         """))
@@ -1206,13 +1205,13 @@ struct IntrospectionTests {
   @Test func `information_schema.columns hides a view whose later arm calls unknown`() throws {
     // The first arm types cleanly; the unknown `NOPE` is in the second UNION
     // arm, which the first-arm walk never types — the inventory spans arms.
-    let body = try parse("""
+    let body = try parse(query: """
         SELECT Name FROM People UNION SELECT NOPE(Name) FROM People
         """)
     let cat = MetaCatalog(
         ["People": MetaRelation([("Name", .text)], [])],
         views: ["v": View(query: body, columns: ["Name"])])
-    let rows = try cat.run(parse("""
+    let rows = try cat.run(parse(query: """
         SELECT column_name FROM information_schema.columns
          WHERE table_name = 'v'
         """))
@@ -1222,11 +1221,12 @@ struct IntrospectionTests {
   @Test func `information_schema.columns lists a view whose predicate calls known`() throws {
     // The gate rejects only an UNKNOWN routine — a registered one in the WHERE
     // (`BITAND`, the standard prelude) leaves the view advertised.
-    let body = try parse("SELECT Name FROM People WHERE BITAND(1, 1) = 1")
+    let body = try parse(query:
+        "SELECT Name FROM People WHERE BITAND(1, 1) = 1")
     let cat = MetaCatalog(
         ["People": MetaRelation([("Name", .text)], [])],
         views: ["v": View(query: body, columns: ["Name"])])
-    let rows = try cat.run(parse("""
+    let rows = try cat.run(parse(query: """
         SELECT column_name FROM information_schema.columns
          WHERE table_name = 'v'
         """))
@@ -1296,7 +1296,7 @@ struct IntrospectionTests {
     // `information_schema.` view over it — resolves and runs the same as the
     // inline query: the store overlay reaches the view body's compile and
     // execution (`resolve`/`derive`), not only the top-level query.
-    let body = try parse("""
+    let body = try parse(query: """
         SELECT table_name FROM definition_schema.tables
           WHERE table_type = 'BASE TABLE' ORDER BY table_name
         """)
@@ -1305,7 +1305,7 @@ struct IntrospectionTests {
       "Widget": MetaRelation([("Label", .text)]),
     ], views: ["meta": View(query: body, columns: ["table_name"])])
     let inline = try source.run(body)
-    let viewed = try source.run(parse("""
+    let viewed = try source.run(parse(query: """
         SELECT table_name FROM meta ORDER BY table_name
         """))
     #expect(viewed == inline)
@@ -1313,7 +1313,7 @@ struct IntrospectionTests {
   }
 
   @Test func `a view over definition_schema.columns yields the inline rows`() throws {
-    let body = try parse("""
+    let body = try parse(query: """
         SELECT column_name, data_type FROM definition_schema.columns
           WHERE table_name = 'People'
           ORDER BY column_name
@@ -1323,7 +1323,7 @@ struct IntrospectionTests {
     ], views: ["cols": View(query: body,
                             columns: ["column_name", "data_type"])])
     let inline = try source.run(body)
-    let viewed = try source.run(parse("""
+    let viewed = try source.run(parse(query: """
         SELECT column_name, data_type FROM cols ORDER BY column_name
         """))
     #expect(viewed == inline)

--- a/Tests/SQLTests/Schema/OutputSchemaTests.swift
+++ b/Tests/SQLTests/Schema/OutputSchemaTests.swift
@@ -5,6 +5,8 @@ import Testing
 @testable import SQLEngine
 import SQLStandard
 
+import func SQLTestSupport.parse
+
 // MARK: - In-memory adapter
 
 /// A typed in-memory relation — a column name/kind list and rows — for the
@@ -113,18 +115,9 @@ private func catalog() -> SchemaCatalog {
 
 // MARK: - Helpers
 
-/// Parses `text` to a query, failing on any other statement.
-private func parse(_ text: String) throws -> Query {
-  guard case let .select(query) = try Statement(parsing: text) else {
-    Issue.record("expected a SELECT statement")
-    throw SQLError.incomplete(expected: "a SELECT statement")
-  }
-  return query
-}
-
 /// The `(name, kind)` pairs of a query's resolved result schema.
 private func schema(_ text: String) throws -> Array<(String, ValueType)> {
-  let columns = try catalog().columns(of: parse(text))
+  let columns = try catalog().columns(of: parse(query: text))
   return columns.map { ($0.name, $0.type) }
 }
 
@@ -217,7 +210,7 @@ struct OutputSchemaTests {
     let source = SchemaCatalog([
       "People": SchemaRelation([("Name", .text), ("Age", .integer)]),
     ], views: ["Named": definition])
-    let query = try parse("SELECT * FROM Named")
+    let query = try parse(query: "SELECT * FROM Named")
     let columns = try source.columns(of: query)
     // A view's columns are its registered names; its kinds are resolved from
     // the view body, so `Label` (over the `.text` `Name`) reports `.text`
@@ -245,7 +238,7 @@ struct OutputSchemaTests {
     let source = SchemaCatalog([
       "People": SchemaRelation([("Name", .text), ("Age", .integer)]),
     ], views: ["Empty": definition])
-    let query = try parse("SELECT * FROM Empty")
+    let query = try parse(query: "SELECT * FROM Empty")
     // `validate: false` derives the header without re-validating the body.
     let derived = try source.columns(of: query, validate: false)
     #expect(derived.count == 1)
@@ -259,14 +252,14 @@ struct OutputSchemaTests {
 
   @Test func `an unknown relation faults exactly as compilation would`() throws {
     #expect(throws: SQLError.self) {
-      let _ = try catalog().columns(of: parse("SELECT * FROM Absent"))
+      let _ = try catalog().columns(of: parse(query: "SELECT * FROM Absent"))
     }
   }
 
   @Test func `an unknown column faults exactly as compilation would`() throws {
     #expect(throws: SQLError.self) {
       let _ =
-          try catalog().columns(of: parse("SELECT Absent FROM People"))
+          try catalog().columns(of: parse(query: "SELECT Absent FROM People"))
     }
   }
 
@@ -281,7 +274,7 @@ struct OutputSchemaTests {
     // The projection names a real column, so a first-arm-only walk would return
     // a schema; the whole-query validation resolves the WHERE too and faults as
     // a run would.
-    let query = try parse("SELECT Name FROM People WHERE Missing = 1")
+    let query = try parse(query: "SELECT Name FROM People WHERE Missing = 1")
     let resolve = { () throws -> Array<OutputColumn> in
       try catalog().columns(of: query)
     }
@@ -292,7 +285,7 @@ struct OutputSchemaTests {
     // The first arm projects one column and the second two — a run would fault
     // with `SQLError.arity`, so the schema resolution must too rather than name
     // the result off the first arm.
-    let query = try parse("""
+    let query = try parse(query: """
         SELECT Name FROM People UNION SELECT Species, Legs FROM Pet
         """)
     let resolve = { () throws -> Array<OutputColumn> in

--- a/Tests/SQLTests/Syntax/ParserTests.swift
+++ b/Tests/SQLTests/Syntax/ParserTests.swift
@@ -4,15 +4,7 @@
 import Testing
 @testable import SQLEngine
 
-/// Parses `text` and returns its `Select`, failing the test on any other shape
-/// — a non-`SELECT` statement, or a `UNION` of several selects.
-private func parse(select text: String) throws -> Select {
-  guard case let .select(.select(select)) = try Statement(parsing: text) else {
-    Issue.record("expected a single SELECT statement")
-    throw SQLError.incomplete(expected: "a SELECT statement")
-  }
-  return select
-}
+import func SQLTestSupport.parse
 
 struct ProjectionTests {
   @Test func `parses a SELECT * projection`() throws {
@@ -1019,15 +1011,6 @@ struct CreateFunctionTests {
 }
 
 // MARK: - UNION
-
-/// Parses `text` and returns its `Query`, failing on any other statement shape.
-private func parse(query text: String) throws -> Query {
-  guard case let .select(query) = try Statement(parsing: text) else {
-    Issue.record("expected a SELECT statement")
-    throw SQLError.incomplete(expected: "a SELECT statement")
-  }
-  return query
-}
 
 struct UnionTests {
   @Test func `parses UNION into a deduplicating union of two selects`() throws {


### PR DESCRIPTION
Reduce duplication by hoisting shared helps from `SQLTests` into `SQLTestSupport` and remove those which no longer are adding value (e.g. are simply relabelling parameters).