### PR TITLE
Tests: parameterise tests for marginal performance improvement

### DIFF
--- a/Tests/SQLTests/Expressions/FloatTests.swift
+++ b/Tests/SQLTests/Expressions/FloatTests.swift
@@ -40,22 +40,127 @@ private func arithmetic(_ lhs: Value, _ op: Arithmetic,
                            Routines())
 }
 
+private struct Comparing: Sendable, CustomTestStringConvertible {
+  internal let name: String
+  internal let lhs: Value
+  internal let op: Comparison
+  internal let rhs: Value
+  internal let expected: Bool?
+
+  internal var testDescription: String { name }
+}
+
+private let kDoubles: Array<Comparing> = [
+  Comparing(name: "equal", lhs: .double(1.5), op: .equal,
+            rhs: .double(1.5), expected: true),
+  Comparing(name: "not equal", lhs: .double(1.5), op: .equal,
+            rhs: .double(2.5), expected: false),
+  Comparing(name: "unequal", lhs: .double(1.5), op: .unequal,
+            rhs: .double(2.5), expected: true),
+  Comparing(name: "less", lhs: .double(1.5), op: .lt,
+            rhs: .double(2.5), expected: true),
+  Comparing(name: "not less", lhs: .double(2.5), op: .lt,
+            rhs: .double(1.5), expected: false),
+  Comparing(name: "greater", lhs: .double(2.5), op: .gt,
+            rhs: .double(1.5), expected: true),
+  Comparing(name: "less or equal", lhs: .double(1.5), op: .leq,
+            rhs: .double(1.5), expected: true),
+  Comparing(name: "greater or equal", lhs: .double(2.5), op: .geq,
+            rhs: .double(2.5), expected: true),
+]
+
+private let kMixed: Array<Comparing> = [
+  Comparing(name: "integer equals double", lhs: .integer(1), op: .equal,
+            rhs: .double(1.0), expected: true),
+  Comparing(name: "double equals integer", lhs: .double(1.0), op: .equal,
+            rhs: .integer(1), expected: true),
+  Comparing(name: "unlike magnitudes", lhs: .integer(2), op: .equal,
+            rhs: .double(2.5), expected: false),
+  Comparing(name: "mixed inequality", lhs: .integer(1), op: .unequal,
+            rhs: .double(1.5), expected: true),
+  Comparing(name: "integer less than double", lhs: .integer(1), op: .lt,
+            rhs: .double(1.5), expected: true),
+  Comparing(name: "double greater than integer", lhs: .double(1.5), op: .gt,
+            rhs: .integer(1), expected: true),
+  Comparing(name: "integer not less than double", lhs: .integer(2), op: .lt,
+            rhs: .double(1.5), expected: false),
+  Comparing(name: "double less than integer", lhs: .double(0.5), op: .lt,
+            rhs: .integer(1), expected: true),
+]
+
+private struct Calculating: Sendable, CustomTestStringConvertible {
+  internal let name: String
+  internal let lhs: Value
+  internal let op: Arithmetic
+  internal let rhs: Value
+  internal let expected: Value
+
+  internal var testDescription: String { name }
+}
+
+private let kArithmetic: Array<Calculating> = [
+  Calculating(name: "double addition", lhs: .double(1.5), op: .add,
+              rhs: .double(2.0), expected: .double(3.5)),
+  Calculating(name: "double subtraction", lhs: .double(2.5), op: .subtract,
+              rhs: .double(1.0), expected: .double(1.5)),
+  Calculating(name: "double multiplication", lhs: .double(1.5), op: .multiply,
+              rhs: .double(2.0), expected: .double(3.0)),
+  Calculating(name: "real division", lhs: .double(5.0), op: .divide,
+              rhs: .double(2.0), expected: .double(2.5)),
+  Calculating(name: "mixed division", lhs: .integer(5), op: .divide,
+              rhs: .double(2.0), expected: .double(2.5)),
+  Calculating(name: "mixed multiplication", lhs: .integer(2), op: .multiply,
+              rhs: .double(1.5), expected: .double(3.0)),
+  Calculating(name: "mixed addition", lhs: .double(1.5), op: .add,
+              rhs: .integer(1), expected: .double(2.5)),
+  Calculating(name: "integer division", lhs: .integer(5), op: .divide,
+              rhs: .integer(2), expected: .integer(2)),
+]
+
+private struct Sorting: Sendable, CustomTestStringConvertible {
+  internal let name: String
+  internal let lhs: Value
+  internal let rhs: Value
+  internal let expected: Bool
+
+  internal var testDescription: String { name }
+}
+
+private let kSorting: Array<Sorting> = [
+  Sorting(name: "ascending doubles", lhs: .double(1.5), rhs: .double(2.5),
+          expected: true),
+  Sorting(name: "descending doubles", lhs: .double(2.5), rhs: .double(1.5),
+          expected: false),
+  Sorting(name: "NULL first", lhs: .null, rhs: .double(1.5), expected: true),
+  Sorting(name: "double after NULL", lhs: .double(1.5), rhs: .null,
+          expected: false),
+  Sorting(name: "integer before double", lhs: .integer(1), rhs: .double(1.5),
+          expected: true),
+  Sorting(name: "double before integer", lhs: .double(1.5), rhs: .integer(2),
+          expected: true),
+  Sorting(name: "double after integer", lhs: .double(2.5), rhs: .integer(2),
+          expected: false),
+]
+
+private struct Lowering: Sendable, CustomTestStringConvertible {
+  internal let literal: Literal
+  internal let expected: Value
+
+  internal var testDescription: String { "\(literal)" }
+}
+
+private let kLiterals: Array<Lowering> = [
+  Lowering(literal: .double(3.14), expected: .double(3.14)),
+  Lowering(literal: .integer(3), expected: .integer(3)),
+]
+
 // MARK: - Comparison
 
 @Suite
 private struct DoubleComparisonTests {
-  @Test func `like doubles compare by magnitude`() {
-    #expect(compare(.double(1.5), .equal, .double(1.5)) == true)
-    #expect(compare(.double(1.5), .equal, .double(2.5)) == false)
-    #expect(compare(.double(1.5), .unequal, .double(2.5)) == true)
-  }
-
-  @Test func `doubles order by magnitude`() {
-    #expect(compare(.double(1.5), .lt, .double(2.5)) == true)
-    #expect(compare(.double(2.5), .lt, .double(1.5)) == false)
-    #expect(compare(.double(2.5), .gt, .double(1.5)) == true)
-    #expect(compare(.double(1.5), .leq, .double(1.5)) == true)
-    #expect(compare(.double(2.5), .geq, .double(2.5)) == true)
+  @Test(arguments: kDoubles)
+  fileprivate func compares(_ test: Comparing) {
+    #expect(compare(test.lhs, test.op, test.rhs) == test.expected)
   }
 }
 
@@ -63,19 +168,9 @@ private struct DoubleComparisonTests {
 
 @Suite
 private struct MixedNumericComparisonTests {
-  @Test func `an integer equals a like-valued double — numeric, not cross-type`() {
-    // Both operands are numeric, so `1 = 1.0` is TRUE, not a cross-kind miss.
-    #expect(compare(.integer(1), .equal, .double(1.0)) == true)
-    #expect(compare(.double(1.0), .equal, .integer(1)) == true)
-    #expect(compare(.integer(2), .equal, .double(2.5)) == false)
-    #expect(compare(.integer(1), .unequal, .double(1.5)) == true)
-  }
-
-  @Test func `an integer orders against a double by magnitude`() {
-    #expect(compare(.integer(1), .lt, .double(1.5)) == true)
-    #expect(compare(.double(1.5), .gt, .integer(1)) == true)
-    #expect(compare(.integer(2), .lt, .double(1.5)) == false)
-    #expect(compare(.double(0.5), .lt, .integer(1)) == true)
+  @Test(arguments: kMixed)
+  fileprivate func compares(_ test: Comparing) {
+    #expect(compare(test.lhs, test.op, test.rhs) == test.expected)
   }
 }
 
@@ -83,34 +178,9 @@ private struct MixedNumericComparisonTests {
 
 @Suite
 private struct DoubleArithmeticTests {
-  @Test func `double arithmetic yields a double`() throws {
-    #expect(try arithmetic(.double(1.5), .add, .double(2.0)) == .double(3.5))
-    #expect(try arithmetic(.double(2.5), .subtract, .double(1.0))
-                == .double(1.5))
-    #expect(try arithmetic(.double(1.5), .multiply, .double(2.0))
-                == .double(3.0))
-  }
-
-  @Test func `double division is real, not truncated`() throws {
-    #expect(try arithmetic(.double(5.0), .divide, .double(2.0))
-                == .double(2.5))
-  }
-
-  @Test func `a mixed integer/double is numeric and yields a double`() throws {
-    // `5 / 2.0` is real division `2.5`, and `2 * 1.5` is `3.0` — the integer
-    // promotes to `Double`, so the result is approximate-numeric.
-    #expect(try arithmetic(.integer(5), .divide, .double(2.0))
-                == .double(2.5))
-    #expect(try arithmetic(.integer(2), .multiply, .double(1.5))
-                == .double(3.0))
-    #expect(try arithmetic(.double(1.5), .add, .integer(1))
-                == .double(2.5))
-  }
-
-  @Test func `an integer pair still divides as integers`() throws {
-    // The mixed-numeric widening does not touch the exact-numeric path: `5 / 2`
-    // is still `2`, not `2.5`.
-    #expect(try arithmetic(.integer(5), .divide, .integer(2)) == .integer(2))
+  @Test(arguments: kArithmetic)
+  fileprivate func calculates(_ test: Calculating) throws {
+    #expect(try arithmetic(test.lhs, test.op, test.rhs) == test.expected)
   }
 
   @Test func `a double divide by zero raises, matching the integer policy`() {
@@ -184,21 +254,9 @@ private struct DoubleNullTests {
 
 @Suite
 private struct DoubleSortTests {
-  @Test func `doubles sort ascending by magnitude, NULL first`() {
-    // `less` is the sort primitive: NULL precedes every value, and two doubles
-    // order by magnitude.
-    #expect(less(.double(1.5), .double(2.5)) == true)
-    #expect(less(.double(2.5), .double(1.5)) == false)
-    #expect(less(.null, .double(1.5)) == true)
-    #expect(less(.double(1.5), .null) == false)
-  }
-
-  @Test func `a mixed integer/double slot sorts by magnitude`() {
-    // A slot that happens to mix exact and approximate numerics still orders by
-    // magnitude rather than tying at the kind boundary.
-    #expect(less(.integer(1), .double(1.5)) == true)
-    #expect(less(.double(1.5), .integer(2)) == true)
-    #expect(less(.double(2.5), .integer(2)) == false)
+  @Test(arguments: kSorting)
+  fileprivate func sorts(_ test: Sorting) {
+    #expect(less(test.lhs, test.rhs) == test.expected)
   }
 
   @Test func `a double past Int.max still orders against Int.max, not a false tie`() {
@@ -214,13 +272,8 @@ private struct DoubleSortTests {
 
 @Suite
 private struct DoubleLiteralTests {
-  @Test func `a decimal literal lowers to a double value`() throws {
-    let lowered = try value(of: .double(3.14))
-    #expect(lowered == .double(3.14))
-  }
-
-  @Test func `an integer literal stays an integer value`() throws {
-    let lowered = try value(of: .integer(3))
-    #expect(lowered == .integer(3))
+  @Test(arguments: kLiterals)
+  fileprivate func lowers(_ test: Lowering) throws {
+    #expect(try value(of: test.literal) == test.expected)
   }
 }

--- a/Tests/SQLTests/Expressions/ScalarFunctionTests.swift
+++ b/Tests/SQLTests/Expressions/ScalarFunctionTests.swift
@@ -24,6 +24,78 @@ private func library() throws -> FixtureCatalog {
   }
 }
 
+private struct Evaluation: Sendable, CustomTestStringConvertible {
+  internal let name: String
+  internal let text: String
+  internal let expected: Array<Array<Value>>
+
+  internal var testDescription: String { name }
+}
+
+private let kPositions: Array<Evaluation> = [
+  Evaluation(name: "1-based occurrence",
+             text: "SELECT POSITION('bc' IN Text) FROM S WHERE Id = 1",
+             expected: [[.integer(2)]]),
+  Evaluation(name: "absent substring",
+             text: "SELECT POSITION('zz' IN Text) FROM S WHERE Id = 1",
+             expected: [[.integer(0)]]),
+  Evaluation(name: "empty literal substring",
+             text: "SELECT POSITION('' IN Text) FROM S WHERE Id = 1",
+             expected: [[.integer(1)]]),
+  Evaluation(name: "empty column substring",
+             text: "SELECT POSITION(Sub IN Text) FROM S WHERE Id = 3",
+             expected: [[.integer(1)]]),
+  Evaluation(name: "case-sensitive miss",
+             text: "SELECT POSITION('BC' IN Text) FROM S WHERE Id = 1",
+             expected: [[.integer(0)]]),
+  Evaluation(name: "oversized substring",
+             text: "SELECT POSITION('helloworld' IN Text) FROM S WHERE Id = 3",
+             expected: [[.integer(0)]]),
+]
+
+private let kOverlays: Array<Evaluation> = [
+  Evaluation(name: "FOR-many replacement",
+             text: "SELECT OVERLAY('abcabc' PLACING 'XY' FROM 3 FOR 2) "
+                 + "FROM S WHERE Id = 1",
+             expected: [[.text("abXYbc")]]),
+  Evaluation(name: "default replacement length",
+             text: "SELECT OVERLAY('abcabc' PLACING 'XYZ' FROM 3) "
+                 + "FROM S WHERE Id = 1",
+             expected: [[.text("abXYZc")]]),
+  Evaluation(name: "zero-length insertion",
+             text: "SELECT OVERLAY('abcabc' PLACING '--' FROM 3 FOR 0) "
+                 + "FROM S WHERE Id = 1",
+             expected: [[.text("ab--cabc")]]),
+  Evaluation(name: "column-computed span",
+             text: "SELECT OVERLAY(Text PLACING Sub FROM Start FOR Len) "
+                 + "FROM S WHERE Id = 1",
+             expected: [[.text("abbcbc")]]),
+  Evaluation(name: "zero start",
+             text: "SELECT OVERLAY('abc' PLACING 'X' FROM 0 FOR 1) "
+                 + "FROM S WHERE Id = 1",
+             expected: [[.text("Xbc")]]),
+  Evaluation(name: "minimum start",
+             text: "SELECT OVERLAY(Text PLACING 'X' FROM Start FOR 1) "
+                 + "FROM S WHERE Id = 3",
+             expected: [[.text("Xello")]]),
+  Evaluation(name: "start past end",
+             text: "SELECT OVERLAY('abc' PLACING 'XY' FROM 99 FOR 1) "
+                 + "FROM S WHERE Id = 1",
+             expected: [[.text("abcXY")]]),
+  Evaluation(name: "oversized length",
+             text: "SELECT OVERLAY('abc' PLACING 'XY' FROM 2 FOR 99) "
+                 + "FROM S WHERE Id = 1",
+             expected: [[.text("aXY")]]),
+  Evaluation(name: "negative length",
+             text: "SELECT OVERLAY('abc' PLACING 'XY' FROM 2 FOR 0 - 5) "
+                 + "FROM S WHERE Id = 1",
+             expected: [[.text("aXYbc")]]),
+  Evaluation(name: "minimum length",
+             text: "SELECT OVERLAY(Text PLACING 'X' FROM 1 FOR Len) "
+                 + "FROM S WHERE Id = 3",
+             expected: [[.text("Xhello")]]),
+]
+
 @Suite struct PositionTests {
   @Test func `POSITION declares its standard signature`() {
     #expect(Routines.standard["position"]?.returns == .integer)
@@ -31,38 +103,10 @@ private func library() throws -> FixtureCatalog {
     #expect(Routines.standard["position"]?.deterministic == true)
   }
 
-  @Test func `POSITION reports a 1-based occurrence`() throws {
-    // 'bc' first occurs at character 2 of 'abcabc'.
-    try library().expect("SELECT POSITION('bc' IN Text) FROM S WHERE Id = 1",
-                         yields: [[2]], routines: .standard)
-  }
-
-  @Test func `POSITION reports 0 when the substring is absent`() throws {
-    try library().expect("SELECT POSITION('zz' IN Text) FROM S WHERE Id = 1",
-                         yields: [[0]], routines: .standard)
-  }
-
-  @Test func `POSITION reports 1 for an empty substring`() throws {
-    // The empty string is a prefix of every string, so it occurs at 1 (ISO).
-    try library().expect("SELECT POSITION('' IN Text) FROM S WHERE Id = 1",
-                         yields: [[1]], routines: .standard)
-    // The empty-column substring over the empty string is 1 too.
-    try library().expect("SELECT POSITION(Sub IN Text) FROM S WHERE Id = 3",
-                         yields: [[1]], routines: .standard)
-  }
-
-  @Test func `POSITION is case-sensitive`() throws {
-    // 'BC' does not occur in the lower-cased 'abcabc'.
-    try library().expect("SELECT POSITION('BC' IN Text) FROM S WHERE Id = 1",
-                         yields: [[0]], routines: .standard)
-  }
-
-  @Test func `POSITION does not find an oversized substring`() throws {
-    // A needle longer than the haystack cannot occur; the length guard reports
-    // 0 rather than indexing out of bounds.
-    try library().expect("SELECT POSITION('helloworld' IN Text) FROM S "
-                             + "WHERE Id = 3",
-                         yields: [[0]], routines: .standard)
+  @Test(arguments: kPositions)
+  fileprivate func evaluates(_ test: Evaluation) throws {
+    let query = try parse(query: test.text)
+    #expect(try library().run(query, .standard) == test.expected)
   }
 
   @Test func `POSITION propagates NULL`() throws {
@@ -113,20 +157,10 @@ private final class Talker: @unchecked Sendable {
     #expect(Routines.standard["overlay"]?.deterministic == true)
   }
 
-  @Test func `OVERLAY replaces FOR-many characters`() throws {
-    // Replace 2 characters of 'abcabc' from position 3 ('ca') with 'XY'.
-    try library().expect(
-        "SELECT OVERLAY('abcabc' PLACING 'XY' FROM 3 FOR 2) FROM S "
-            + "WHERE Id = 1",
-        yields: [["abXYbc"]], routines: .standard)
-  }
-
-  @Test func `OVERLAY defaults its length to the replacement`() throws {
-    // With no FOR, ISO removes as many characters as the replacement holds:
-    // 'XYZ' is three long, so three characters of 'abcabc' from 3 ('cab') go.
-    try library().expect(
-        "SELECT OVERLAY('abcabc' PLACING 'XYZ' FROM 3) FROM S WHERE Id = 1",
-        yields: [["abXYZc"]], routines: .standard)
+  @Test(arguments: kOverlays)
+  fileprivate func evaluates(_ test: Evaluation) throws {
+    let query = try parse(query: test.text)
+    #expect(try library().run(query, .standard) == test.expected)
   }
 
   @Test func `OVERLAY evaluates its replacement once without FOR`() throws {
@@ -148,58 +182,6 @@ private final class Talker: @unchecked Sendable {
         "SELECT OVERLAY('abcdef' PLACING talker() FROM 2) FROM S WHERE Id = 1",
         yields: [["aXXdef"]], routines: routines)
     #expect(counter.count == 1)
-  }
-
-  @Test func `OVERLAY inserts when FOR is zero`() throws {
-    // A zero length removes nothing, so the replacement is inserted before the
-    // start position.
-    try library().expect(
-        "SELECT OVERLAY('abcabc' PLACING '--' FROM 3 FOR 0) FROM S "
-            + "WHERE Id = 1",
-        yields: [["ab--cabc"]], routines: .standard)
-  }
-
-  @Test func `OVERLAY over the columns replaces a computed span`() throws {
-    // 'bc' placed into 'abcabc' from Start=3 FOR Len=2 replaces 'ca'.
-    try library().expect(
-        "SELECT OVERLAY(Text PLACING Sub FROM Start FOR Len) FROM S "
-            + "WHERE Id = 1",
-        yields: [["abbcbc"]], routines: .standard)
-  }
-
-  @Test func `OVERLAY clamps a start at or before 1 to the front`() throws {
-    // A start of 0 or the extreme Int.min clamps to the first character; the
-    // Int.min case would trap on a naive `start - 1`.
-    try library().expect(
-        "SELECT OVERLAY('abc' PLACING 'X' FROM 0 FOR 1) FROM S WHERE Id = 1",
-        yields: [["Xbc"]], routines: .standard)
-    try library().expect(
-        "SELECT OVERLAY(Text PLACING 'X' FROM Start FOR 1) FROM S "
-            + "WHERE Id = 3",
-        yields: [["Xello"]], routines: .standard)
-  }
-
-  @Test func `OVERLAY clamps a start past the end to an append`() throws {
-    try library().expect(
-        "SELECT OVERLAY('abc' PLACING 'XY' FROM 99 FOR 1) FROM S "
-            + "WHERE Id = 1",
-        yields: [["abcXY"]], routines: .standard)
-  }
-
-  @Test func `OVERLAY clamps an oversized or negative length`() throws {
-    // A length past the end removes only to the end; a negative length removes
-    // nothing. The Int.min length exercises the overflow-safe capacity compare.
-    try library().expect(
-        "SELECT OVERLAY('abc' PLACING 'XY' FROM 2 FOR 99) FROM S "
-            + "WHERE Id = 1",
-        yields: [["aXY"]], routines: .standard)
-    try library().expect(
-        "SELECT OVERLAY('abc' PLACING 'XY' FROM 2 FOR 0 - 5) FROM S "
-            + "WHERE Id = 1",
-        yields: [["aXYbc"]], routines: .standard)
-    try library().expect(
-        "SELECT OVERLAY(Text PLACING 'X' FROM 1 FOR Len) FROM S WHERE Id = 3",
-        yields: [["Xhello"]], routines: .standard)
   }
 
   @Test func `OVERLAY propagates NULL`() throws {

--- a/Tests/SQLTests/Queries/EngineValueAndSetTests.swift
+++ b/Tests/SQLTests/Queries/EngineValueAndSetTests.swift
@@ -8,47 +8,42 @@ import SQLTestSupport
 
 // MARK: - NULL tests
 
+private struct Selection: Sendable, CustomTestStringConvertible {
+  internal let name: String
+  internal let text: String
+  internal let expected: Array<Array<Value>>
+
+  internal var testDescription: String { name }
+}
+
+private let kNullable: Array<Selection> = [
+  Selection(name: "IS NULL", text: "SELECT Id FROM Maybe WHERE Note IS NULL",
+            expected: [[.integer(2)], [.integer(4)]]),
+  Selection(name: "IS NOT NULL",
+            text: "SELECT Id FROM Maybe WHERE Note IS NOT NULL",
+            expected: [[.integer(1)], [.integer(3)]]),
+  Selection(name: "comparison against NULL",
+            text: "SELECT Id FROM Maybe WHERE Note = 'alpha'",
+            expected: [[.integer(1)]]),
+  Selection(name: "NOT of a NULL comparison",
+            text: "SELECT Id FROM Maybe WHERE NOT Note = 'alpha'",
+            expected: [[.integer(3)]]),
+  Selection(name: "NULL projection",
+            text: "SELECT Note FROM Maybe WHERE Id = 2", expected: [[.null]]),
+  Selection(name: "ascending NULL order",
+            text: "SELECT Id FROM Maybe ORDER BY Note ASC",
+            expected: [[.integer(2)], [.integer(4)], [.integer(1)],
+                       [.integer(3)]]),
+  Selection(name: "descending NULL order",
+            text: "SELECT Id FROM Maybe ORDER BY Note DESC",
+            expected: [[.integer(3)], [.integer(1)], [.integer(2)],
+                       [.integer(4)]]),
+]
+
 struct EngineNullTests {
-  @Test func `IS NULL admits only the NULL rows`() throws {
-    try engineNullable().expect("SELECT Id FROM Maybe WHERE Note IS NULL",
-                          yields: [[2], [4]])
-  }
-
-  @Test func `IS NOT NULL admits only the non-NULL rows`() throws {
-    let rows = try engineNullable("SELECT Id FROM Maybe WHERE Note IS NOT NULL")
-    #expect(rows == [[.integer(1)], [.integer(3)]])
-  }
-
-  @Test func `a comparison against a NULL cell is UNKNOWN and rejects`() throws {
-    // For the NULL rows (2, 4) `Note = 'alpha'` is UNKNOWN, not false, so they
-    // are not admitted; only the row whose Note equals 'alpha' survives.
-    try engineNullable().expect("SELECT Id FROM Maybe WHERE Note = 'alpha'",
-                          yields: [[1]])
-  }
-
-  @Test func `NOT of a NULL comparison stays UNKNOWN and rejects`() throws {
-    // The NULL rows are UNKNOWN; NOT UNKNOWN is UNKNOWN, so they still reject —
-    // only the non-null, non-'alpha' row survives.
-    let rows = try engineNullable("SELECT Id FROM Maybe WHERE NOT Note = 'alpha'")
-    #expect(rows == [[.integer(3)]])
-  }
-
-  @Test func `a NULL cell projects as a NULL value`() throws {
-    try engineNullable().expect("SELECT Note FROM Maybe WHERE Id = 2",
-                          yields: [[nil]])
-  }
-
-  @Test func `ORDER BY ascending sorts NULL keys first, then by value`() throws {
-    // NULL holds a stable position — first in ascending order — so the non-null
-    // notes still sort among themselves ('alpha' before 'gamma') rather than
-    // tying with the nulls and leaving the order undefined.
-    try engineNullable().expect("SELECT Id FROM Maybe ORDER BY Note ASC",
-                          yields: [[2], [4], [1], [3]])
-  }
-
-  @Test func `ORDER BY descending sorts NULL keys last`() throws {
-    try engineNullable().expect("SELECT Id FROM Maybe ORDER BY Note DESC",
-                          yields: [[3], [1], [2], [4]])
+  @Test(arguments: kNullable)
+  fileprivate func runs(_ test: Selection) throws {
+    #expect(try engineNullable(test.text) == test.expected)
   }
 
   @Test func `a NULL outer join key matches no inner row`() throws {
@@ -74,32 +69,40 @@ private func boundRun(_ text: String, _ bindings: Bindings)
   try engineFamily().run(engineParse(text), Routines(), bindings: bindings)
 }
 
+private struct Binding: Sendable, CustomTestStringConvertible {
+  internal let name: String
+  internal let text: String
+  internal let bindings: Bindings
+  internal let expected: Array<Array<Value>>
+
+  internal var testDescription: String { name }
+}
+
+private let kBindings: Array<Binding> = [
+  Binding(name: "bound integer",
+          text: "SELECT Name FROM Child WHERE Pid = :pid",
+          bindings: ["pid": .integer(1)],
+          expected: [[.text("Ann")], [.text("Amy")]]),
+  Binding(name: "bound text", text: "SELECT Id FROM Parent WHERE Name = :who",
+          bindings: ["who": .text("Bee")], expected: [[.integer(2)]]),
+  Binding(name: "unbound", text: "SELECT Name FROM Child WHERE Pid = :pid",
+          bindings: [:], expected: []),
+  Binding(name: "bound conjunction",
+          text: "SELECT Name FROM Child WHERE Pid = :pid AND Name = 'Amy'",
+          bindings: ["pid": .integer(1)], expected: [[.text("Amy")]]),
+  Binding(name: "unbound under NOT",
+          text: "SELECT Name FROM Child WHERE NOT Pid = :pid", bindings: [:],
+          expected: []),
+  Binding(name: "bound under NOT",
+          text: "SELECT Name FROM Child WHERE NOT Pid = :pid",
+          bindings: ["pid": .integer(1)],
+          expected: [[.text("Bob")], [.text("Orphan")]]),
+]
+
 struct EngineBoundTests {
-  @Test func `a bound parameter filters rows by an outer value`() throws {
-    // The child relation keyed on a bound parent id — the section primitive: a
-    // template renders an interface's methods by binding the interface key and
-    // running the child query.
-    let rows = try boundRun("SELECT Name FROM Child WHERE Pid = :pid",
-                            ["pid": .integer(1)])
-    #expect(rows == [[.text("Ann")], [.text("Amy")]])
-  }
-
-  @Test func `a bound text parameter compares against a text column`() throws {
-    let rows = try boundRun("SELECT Id FROM Parent WHERE Name = :who",
-                            ["who": .text("Bee")])
-    #expect(rows == [[.integer(2)]])
-  }
-
-  @Test func `an unbound parameter admits no row`() throws {
-    let rows = try boundRun("SELECT Name FROM Child WHERE Pid = :pid", [:])
-    #expect(rows.isEmpty)
-  }
-
-  @Test func `a bound parameter conjoined with another predicate`() throws {
-    let rows = try boundRun("""
-        SELECT Name FROM Child WHERE Pid = :pid AND Name = 'Amy'
-        """, ["pid": .integer(1)])
-    #expect(rows == [[.text("Amy")]])
+  @Test(arguments: kBindings)
+  fileprivate func runs(_ test: Binding) throws {
+    #expect(try boundRun(test.text, test.bindings) == test.expected)
   }
 
   @Test func `a correlated section runs a child query per outer row`() throws {
@@ -129,19 +132,6 @@ struct EngineBoundTests {
     #expect(sections[1].children == ["Bob"])
     #expect(sections[2].parent == "Cid")
     #expect(sections[2].children.isEmpty)
-  }
-
-  @Test func `an unbound parameter under NOT still admits no rows`() throws {
-    // A missing binding is UNKNOWN, not false; NOT preserves UNKNOWN rather
-    // than inverting it into a match, so the predicate admits nothing.
-    let rows = try boundRun("SELECT Name FROM Child WHERE NOT Pid = :pid", [:])
-    #expect(rows.isEmpty)
-  }
-
-  @Test func `a bound parameter under NOT inverts the match`() throws {
-    let rows = try boundRun("SELECT Name FROM Child WHERE NOT Pid = :pid",
-                            ["pid": .integer(1)])
-    #expect(rows == [[.text("Bob")], [.text("Orphan")]])
   }
 
   @Test func `a bound key plans a seek when its value is known`() throws {

--- a/Tests/SQLTests/Schema/ErrorTests.swift
+++ b/Tests/SQLTests/Schema/ErrorTests.swift
@@ -7,71 +7,66 @@ import Testing
 import SQLTestSupport
 
 /// A throwaway location for cases that carry one.
-private let here = SourceLocation(line: 1, column: 1, offset: 0)
+private let kHere = SourceLocation(line: 1, column: 1, offset: 0)
+
+private struct State: Sendable, CustomTestStringConvertible {
+  internal let name: String
+  internal let error: SQLError
+  internal let expected: String
+
+  internal var testDescription: String { name }
+}
+
+private let kStates: Array<State> = [
+  State(name: "undefined column", error: .column("Missing"),
+        expected: "42703"),
+  State(name: "integer magnitude overflow",
+        error: .magnitude("integer overflow"), expected: "22003"),
+  State(name: "integer literal overflow", error: .overflow("99", at: kHere),
+        expected: "22003"),
+  State(name: "division by zero", error: .divide, expected: "22012"),
+  State(name: "invalid character", error: .character("@", at: kHere),
+        expected: "42601"),
+  State(name: "unterminated token",
+        error: .unterminated("string literal", at: kHere),
+        expected: "42601"),
+  State(name: "unexpected token",
+        error: .unexpected("X", expected: "Y", at: kHere),
+        expected: "42601"),
+  State(name: "incomplete statement", error: .incomplete(expected: "Z"),
+        expected: "42601"),
+  State(name: "trailing input", error: .trailing(at: kHere),
+        expected: "42601"),
+  State(name: "unnamed projection", error: .named("SELECT *"),
+        expected: "42601"),
+  State(name: "column-count mismatch", error: .columns(expected: 2, got: 3),
+        expected: "42601"),
+  State(name: "arity mismatch", error: .arity(1, 2), expected: "42601"),
+  State(name: "undefined relation", error: .relation("Absent"),
+        expected: "42P01"),
+  State(name: "ambiguous column", error: .ambiguous("Name"),
+        expected: "42702"),
+  State(name: "duplicate column", error: .duplicate("Name"),
+        expected: "42701"),
+  State(name: "undefined function", error: .function("missing"),
+        expected: "42883"),
+  State(name: "rejected function argument", error: .argument("bad"),
+        expected: "22023"),
+  State(name: "non-numeric operand",
+        error: .operand("operands must be numeric"), expected: "42804"),
+  State(name: "unsupported shape",
+        error: .unsupported("SELECT * requires a FROM clause"),
+        expected: "SS001"),
+  State(name: "wrong statement kind",
+        error: .statement("CREATE VIEW is not a query"), expected: "SS002"),
+  State(name: "recursion", error: .recursion("loop"), expected: "SS003"),
+]
 
 @Suite
 struct SQLStateTests {
-  @Test func `an undefined column reports 42703`() {
-    #expect(SQLError.column("Missing").sqlstate == "42703")
-  }
-
-  @Test func `an integer overflow reports 22003`() {
-    #expect(SQLError.magnitude("integer overflow").sqlstate == "22003")
-    // The lexer's out-of-range literal is the same data exception.
-    #expect(SQLError.overflow("99", at: here).sqlstate == "22003")
-  }
-
-  @Test func `a division by zero reports 22012`() {
-    #expect(SQLError.divide.sqlstate == "22012")
-  }
-
-  @Test func `a syntax error reports 42601`() {
-    #expect(SQLError.character("@", at: here).sqlstate == "42601")
-    #expect(SQLError.unterminated("string literal", at: here).sqlstate
-                == "42601")
-    #expect(
-        SQLError.unexpected("X", expected: "Y", at: here).sqlstate == "42601")
-    #expect(SQLError.incomplete(expected: "Z").sqlstate == "42601")
-    #expect(SQLError.trailing(at: here).sqlstate == "42601")
-    #expect(SQLError.named("SELECT *").sqlstate == "42601")
-    #expect(SQLError.columns(expected: 2, got: 3).sqlstate == "42601")
-    #expect(SQLError.arity(1, 2).sqlstate == "42601")
-  }
-
-  @Test func `an undefined relation reports 42P01`() {
-    #expect(SQLError.relation("Absent").sqlstate == "42P01")
-  }
-
-  @Test func `an ambiguous column reports 42702`() {
-    #expect(SQLError.ambiguous("Name").sqlstate == "42702")
-  }
-
-  @Test func `a duplicate column reports 42701`() {
-    #expect(SQLError.duplicate("Name").sqlstate == "42701")
-  }
-
-  @Test func `an undefined function reports 42883`() {
-    #expect(SQLError.function("missing").sqlstate == "42883")
-  }
-
-  @Test func `a rejected function argument reports 22023`() {
-    #expect(SQLError.argument("bad").sqlstate == "22023")
-  }
-
-  @Test func `a non-numeric arithmetic operand reports 42804`() {
-    #expect(
-        SQLError.operand("operands must be numeric").sqlstate == "42804")
-  }
-
-  @Test func `an engine-specific condition reports the SwiftSQL SS class`() {
-    // Engine-specific faults with no standard ISO code squat on the
-    // implementation-defined `SS` (SwiftSQL) class rather than borrow a
-    // standard one.
-    #expect(SQLError.unsupported("SELECT * requires a FROM clause").sqlstate
-            == "SS001")
-    #expect(SQLError.statement("CREATE VIEW is not a query").sqlstate
-            == "SS002")
-    #expect(SQLError.recursion("loop").sqlstate == "SS003")
+  @Test(arguments: kStates)
+  fileprivate func reports(_ test: State) {
+    #expect(test.error.sqlstate == test.expected)
   }
 
   @Test func `.state round-trips its code and message`() {

--- a/Tests/SQLTests/Syntax/LexerTests.swift
+++ b/Tests/SQLTests/Syntax/LexerTests.swift
@@ -19,136 +19,102 @@ private func lex(_ text: String) throws -> Array<Token.Kind> {
   try tokens(text).map(\.kind)
 }
 
+private struct Lexing: Sendable, CustomTestStringConvertible {
+  internal let name: String
+  internal let text: String
+  internal let expected: Array<Token.Kind>
+
+  internal var testDescription: String { name }
+}
+
+private let kLexing: Array<Lexing> = [
+  Lexing(name: "every keyword",
+         text: "SELECT FROM WHERE ORDER BY ASC DESC AND OR NOT",
+         expected: [.select, .from, .where, .order, .by, .asc, .desc,
+                    .and, .or, .not]),
+  Lexing(name: "case-insensitive keywords", text: "select Order by",
+         expected: [.select, .order, .by]),
+  Lexing(name: "join keywords", text: "JOIN ON AS",
+         expected: [.join, .on, .as]),
+  Lexing(name: "case-insensitive join keywords", text: "join on As",
+         expected: [.join, .on, .as]),
+  Lexing(name: "NULL-test keywords", text: "IS NOT NULL is null",
+         expected: [.is, .not, .null, .is, .null]),
+  Lexing(name: "WITH-clause keywords", text: "WITH RECURSIVE",
+         expected: [.with, .recursive]),
+  Lexing(name: "case-insensitive WITH-clause keywords",
+         text: "with Recursive", expected: [.with, .recursive]),
+  Lexing(name: "row-limiting keywords and synonyms",
+         text: "OFFSET FETCH FIRST ROWS ONLY ROW NEXT",
+         expected: [.offset, .fetch, .first, .rows, .only, .rows, .first]),
+  Lexing(name: "comparison operators", text: "= <> < > <= >=",
+         expected: [.equal, .unequal, .lt, .gt, .leq, .geq]),
+  Lexing(name: "punctuation", text: "* , ( )",
+         expected: [.star, .comma, .lparen, .rparen]),
+  Lexing(name: "dotted identifier", text: "TypeDef.TypeName",
+         expected: [.identifier("TypeDef.TypeName")]),
+  Lexing(name: "integer literals", text: "0 42 1024",
+         expected: [.integer(0), .integer(42), .integer(1024)]),
+  Lexing(name: "decimal fractions", text: "3.14 1.0 0.5",
+         expected: [.decimal(3.14), .decimal(1.0), .decimal(0.5)]),
+  Lexing(name: "decimal exponents", text: "1e3 2.5e-1 6E2 1.5e+2",
+         expected: [.decimal(1e3), .decimal(2.5e-1),
+                    .decimal(6e2), .decimal(1.5e2)]),
+  Lexing(name: "bare digits remain integers", text: "7 100",
+         expected: [.integer(7), .integer(100)]),
+  Lexing(name: "fractions require a digit after the dot", text: "1.5 1.5e0",
+         expected: [.decimal(1.5), .decimal(1.5)]),
+  Lexing(name: "an e without exponent digits", text: "1e",
+         expected: [.integer(1), .identifier("e")]),
+  Lexing(name: "qualified reference", text: "Field.Flags",
+         expected: [.identifier("Field.Flags")]),
+  Lexing(name: "quoted string", text: "'Windows.Win32.Foundation'",
+         expected: [.string("Windows.Win32.Foundation")]),
+  Lexing(name: "doubled quote in a string", text: "'O''Brien'",
+         expected: [.string("O'Brien")]),
+  Lexing(name: "empty string", text: "''", expected: [.string("")]),
+  Lexing(name: "delimited identifiers",
+         text: "\"Offset\" \"select\" \"a.b\"",
+         expected: [.quoted("Offset"), .quoted("select"), .quoted("a.b")]),
+  Lexing(name: "doubled quote in a delimited identifier",
+         text: "\"a\"\"b\"", expected: [.quoted("a\"b")]),
+  Lexing(name: "tokens without whitespace", text: "a<=1",
+         expected: [.identifier("a"), .leq, .integer(1)]),
+  Lexing(name: "line comment between tokens",
+         text: "SELECT -- pick a star\n*", expected: [.select, .star]),
+  Lexing(name: "line comment at end of input",
+         text: "SELECT * -- trailing", expected: [.select, .star]),
+  Lexing(name: "block comment spanning a newline",
+         text: "SELECT /* a\n block */ *", expected: [.select, .star]),
+  Lexing(name: "block comment between tokens",
+         text: "SELECT /* star */ *", expected: [.select, .star]),
+  Lexing(name: "lone minus and slash operators", text: "a - 1 / 2",
+         expected: [.identifier("a"), .minus, .integer(1), .slash,
+                    .integer(2)]),
+  Lexing(name: "bound-parameter placeholder", text: "WHERE a = :pid",
+         expected: [.where, .identifier("a"), .equal, .parameter("pid")]),
+]
+
+private struct Fault: Sendable, CustomTestStringConvertible {
+  internal let name: String
+  internal let text: String
+
+  internal var testDescription: String { name }
+}
+
+private let kFaults: Array<Fault> = [
+  Fault(name: "decimal overflow", text: "1e9999"),
+  Fault(name: "unexpected character", text: "SELECT @ FROM T"),
+  Fault(name: "unterminated string", text: "'oops"),
+  Fault(name: "unterminated delimited identifier", text: "\"oops"),
+  Fault(name: "unterminated block comment", text: "SELECT /* oops"),
+  Fault(name: "colon without an identifier", text: "SELECT : FROM T"),
+]
+
 struct LexerTests {
-  @Test func `lexes every keyword`() throws {
-    #expect(try lex("SELECT FROM WHERE ORDER BY ASC DESC AND OR NOT")
-                == [.select, .from, .where, .order, .by, .asc, .desc,
-                    .and, .or, .not])
-  }
-
-  @Test func `lexes keywords case-insensitively`() throws {
-    #expect(try lex("select Order by") == [.select, .order, .by])
-  }
-
-  @Test func `lexes the join keywords`() throws {
-    #expect(try lex("JOIN ON AS") == [.join, .on, .as])
-  }
-
-  @Test func `lexes the join keywords case-insensitively`() throws {
-    #expect(try lex("join on As") == [.join, .on, .as])
-  }
-
-  @Test func `lexes the NULL-test keywords`() throws {
-    #expect(try lex("IS NOT NULL") == [.is, .not, .null])
-    #expect(try lex("is null") == [.is, .null])
-  }
-
-  @Test func `lexes the WITH-clause keywords`() throws {
-    #expect(try lex("WITH RECURSIVE") == [.with, .recursive])
-  }
-
-  @Test func `lexes the WITH-clause keywords case-insensitively`() throws {
-    #expect(try lex("with Recursive") == [.with, .recursive])
-  }
-
-  @Test func `lexes the row-limiting keywords`() throws {
-    #expect(try lex("OFFSET FETCH FIRST ROWS ONLY")
-                == [.offset, .fetch, .first, .rows, .only])
-    // ROW is a synonym of ROWS, and NEXT of FIRST.
-    #expect(try lex("ROW NEXT") == [.rows, .first])
-  }
-
-  @Test func `lexes the comparison operators`() throws {
-    #expect(try lex("= <> < > <= >=")
-                == [.equal, .unequal, .lt, .gt, .leq, .geq])
-  }
-
-  @Test func `lexes punctuation tokens`() throws {
-    #expect(try lex("* , ( )")
-                == [.star, .comma, .lparen, .rparen])
-  }
-
-  @Test func `lexes a dotted identifier as one token`() throws {
-    #expect(try lex("TypeDef.TypeName") == [.identifier("TypeDef.TypeName")])
-  }
-
-  @Test func `lexes integer literals`() throws {
-    #expect(try lex("0 42 1024")
-                == [.integer(0), .integer(42), .integer(1024)])
-  }
-
-  @Test func `lexes decimal literals with a fraction`() throws {
-    #expect(try lex("3.14 1.0 0.5")
-                == [.decimal(3.14), .decimal(1.0), .decimal(0.5)])
-  }
-
-  @Test func `lexes decimal literals with an exponent`() throws {
-    // A bare integer with an exponent is approximate-numeric, as is one with a
-    // signed exponent or a fraction and an exponent together.
-    #expect(try lex("1e3 2.5e-1 6E2 1.5e+2")
-                == [.decimal(1e3), .decimal(2.5e-1),
-                    .decimal(6e2), .decimal(1.5e2)])
-  }
-
-  @Test func `a bare run of digits stays an integer`() throws {
-    // Neither a `.` nor an `e` follows, so each is exact numeric.
-    #expect(try lex("7 100") == [.integer(7), .integer(100)])
-  }
-
-  @Test func `a dot fraction is taken only when a digit follows`() throws {
-    // A `.` begins a fraction only before a digit: `1.5` is one decimal, while
-    // `1.5e0` also folds the exponent in.
-    #expect(try lex("1.5") == [.decimal(1.5)])
-    #expect(try lex("1.5e0") == [.decimal(1.5)])
-  }
-
-  @Test func `an e with no exponent digit is not an exponent`() throws {
-    // `1e` has no exponent digit, so the number ends at `1` and `e` begins an
-    // identifier.
-    #expect(try lex("1e") == [.integer(1), .identifier("e")])
-  }
-
-  @Test func `a decimal literal past Double's range is an overflow`() {
-    // `Double("1e9999")` is `inf`, not nil — reject it as an overflow, like an
-    // out-of-range integer, so no `inf` enters the token stream.
-    #expect(throws: SQLError.self) { _ = try lex("1e9999") }
-  }
-
-  @Test func `a qualified reference is not read as a decimal`() throws {
-    // A qualified name begins with a letter, so it never enters the numeric
-    // scanner — `Field.Flags` is one identifier, dot and all.
-    #expect(try lex("Field.Flags") == [.identifier("Field.Flags")])
-  }
-
-  @Test func `lexes a quoted string literal`() throws {
-    #expect(try lex("'Windows.Win32.Foundation'")
-                == [.string("Windows.Win32.Foundation")])
-  }
-
-  @Test func `unescapes a doubled quote in a string`() throws {
-    #expect(try lex("'O''Brien'") == [.string("O'Brien")])
-  }
-
-  @Test func `lexes an empty string literal`() throws {
-    #expect(try lex("''") == [.string("")])
-  }
-
-  @Test func `lexes a delimited identifier verbatim`() throws {
-    // A double-quoted name is a `quoted` token, case-preserved and never a
-    // keyword — distinct from a bare identifier so a dot in it is kept.
-    #expect(try lex("\"Offset\"") == [.quoted("Offset")])
-    #expect(try lex("\"select\"") == [.quoted("select")])
-    #expect(try lex("\"a.b\"") == [.quoted("a.b")])
-  }
-
-  @Test func `unescapes a doubled quote in a delimited identifier`() throws {
-    #expect(try lex("\"a\"\"b\"") == [.quoted("a\"b")])
-  }
-
-  @Test func `lexes tokens with no separating whitespace`() throws {
-    // No whitespace required between an identifier and an operator.
-    #expect(try lex("a<=1")
-                == [.identifier("a"), .leq, .integer(1)])
+  @Test(arguments: kLexing)
+  fileprivate func lexes(_ test: Lexing) throws {
+    #expect(try lex(test.text) == test.expected)
   }
 
   @Test func `records each token's byte offset`() throws {
@@ -180,46 +146,9 @@ struct LexerTests {
     #expect(try lexer.next() == nil)
   }
 
-  @Test func `rejects an unexpected character`() {
-    #expect(throws: SQLError.self) { _ = try lex("SELECT @ FROM T") }
-  }
-
-  @Test func `rejects an unterminated string`() {
-    #expect(throws: SQLError.self) { _ = try lex("'oops") }
-  }
-
-  @Test func `rejects an unterminated delimited identifier`() {
-    #expect(throws: SQLError.self) { _ = try lex("\"oops") }
-  }
-
-  @Test func `skips a line comment between tokens`() throws {
-    #expect(try lex("SELECT -- pick a star\n*")
-                == [.select, .star])
-  }
-
-  @Test func `skips a line comment at end of input`() throws {
-    // An unterminated `--` comment at EOF is not a fault.
-    #expect(try lex("SELECT * -- trailing") == [.select, .star])
-  }
-
-  @Test func `skips a block comment spanning a newline`() throws {
-    #expect(try lex("SELECT /* a\n block */ *") == [.select, .star])
-  }
-
-  @Test func `skips a block comment between tokens on one line`() throws {
-    #expect(try lex("SELECT /* star */ *") == [.select, .star])
-  }
-
-  @Test func `lexes a lone minus and slash as operators`() throws {
-    // A single `-` or `/` is still an operator; only `--` and `/*` begin a
-    // comment.
-    #expect(try lex("a - 1 / 2")
-                == [.identifier("a"), .minus, .integer(1), .slash,
-                    .integer(2)])
-  }
-
-  @Test func `rejects an unterminated block comment`() {
-    #expect(throws: SQLError.self) { _ = try lex("SELECT /* oops") }
+  @Test(arguments: kFaults)
+  fileprivate func rejects(_ test: Fault) {
+    #expect(throws: SQLError.self) { _ = try lex(test.text) }
   }
 
   @Test func `tracks line and column across a block comment`() throws {
@@ -229,12 +158,4 @@ struct LexerTests {
     #expect(locations.map(\.column) == [1, 6])
   }
 
-  @Test func `scans a bound-parameter placeholder`() throws {
-    #expect(try lex("WHERE a = :pid")
-                == [.where, .identifier("a"), .equal, .parameter("pid")])
-  }
-
-  @Test func `rejects a colon not followed by an identifier`() {
-    #expect(throws: SQLError.self) { _ = try lex("SELECT : FROM T") }
-  }
 }

--- a/Tests/SQLTests/Syntax/ParserTests.swift
+++ b/Tests/SQLTests/Syntax/ParserTests.swift
@@ -6,6 +6,101 @@ import Testing
 
 import func SQLTestSupport.parse
 
+private struct Failure: Sendable, CustomTestStringConvertible {
+  internal let name: String
+  internal let text: String
+
+  internal var testDescription: String { name }
+}
+
+private let kBlobs: Array<Failure> = [
+  Failure(name: "odd hex digit count",
+          text: "SELECT * FROM T WHERE a = x'abc'"),
+  Failure(name: "non-hex digit", text: "SELECT * FROM T WHERE a = x'gg'"),
+  Failure(name: "unterminated blob",
+          text: "SELECT * FROM T WHERE a = x'abcd"),
+]
+
+private let kSyntax: Array<Failure> = [
+  Failure(name: "missing FROM", text: "SELECT TypeName TypeDef"),
+  Failure(name: "invalid operator", text: "SELECT * FROM T WHERE a ! 1"),
+  Failure(name: "unterminated string",
+          text: "SELECT * FROM T WHERE a = 'unterminated"),
+  Failure(name: "trailing tokens", text: "SELECT * FROM T t garbage"),
+  Failure(name: "empty projection", text: "SELECT FROM T"),
+  Failure(name: "FROM without a relation", text: "SELECT * FROM"),
+]
+
+private struct Quantifier: Sendable, CustomTestStringConvertible {
+  internal let name: String
+  internal let text: String
+  internal let distinct: Bool
+  internal let columns: Array<Column>?
+  internal let fromless: Bool
+
+  internal var testDescription: String { name }
+}
+
+private let kQuantifiers: Array<Quantifier> = [
+  Quantifier(name: "plain SELECT", text: "SELECT TypeName FROM TypeDef",
+             distinct: false, columns: nil, fromless: false),
+  Quantifier(name: "SELECT DISTINCT",
+             text: "SELECT DISTINCT TypeName FROM TypeDef", distinct: true,
+             columns: ["TypeName"], fromless: false),
+  Quantifier(name: "SELECT ALL", text: "SELECT ALL TypeName FROM TypeDef",
+             distinct: false, columns: ["TypeName"], fromless: false),
+  Quantifier(name: "case-insensitive DISTINCT",
+             text: "select distinct TypeName from TypeDef", distinct: true,
+             columns: nil, fromless: false),
+  Quantifier(name: "FROM-less DISTINCT", text: "SELECT DISTINCT 1",
+             distinct: true, columns: nil, fromless: true),
+]
+
+private struct Direction: Sendable, CustomTestStringConvertible {
+  internal let name: String
+  internal let text: String
+  internal let ascending: Bool
+
+  internal var testDescription: String { name }
+}
+
+private let kDirections: Array<Direction> = [
+  Direction(name: "implicit ascending",
+            text: "SELECT * FROM T ORDER BY TypeName", ascending: true),
+  Direction(name: "explicit ascending",
+            text: "SELECT * FROM T ORDER BY TypeName ASC", ascending: true),
+  Direction(name: "descending",
+            text: "SELECT * FROM T ORDER BY TypeName DESC", ascending: false),
+]
+
+private struct Splitting: Sendable, CustomTestStringConvertible {
+  internal let text: String
+  internal let qualifier: String?
+  internal let name: String
+
+  internal var testDescription: String { text }
+}
+
+private let kColumns: Array<Splitting> = [
+  Splitting(text: "t.Name", qualifier: "t", name: "Name"),
+  Splitting(text: "Name", qualifier: nil, name: "Name"),
+  Splitting(text: "t.a.b", qualifier: "t.a", name: "b"),
+]
+
+private struct Aliasing: Sendable, CustomTestStringConvertible {
+  internal let name: String
+  internal let text: String
+  internal let alias: String?
+
+  internal var testDescription: String { name }
+}
+
+private let kAliases: Array<Aliasing> = [
+  Aliasing(name: "bare relation", text: "SELECT * FROM TypeDef", alias: nil),
+  Aliasing(name: "AS alias", text: "SELECT * FROM TypeDef AS t", alias: "t"),
+  Aliasing(name: "implicit alias", text: "SELECT * FROM TypeDef t", alias: "t"),
+]
+
 struct ProjectionTests {
   @Test func `parses a SELECT * projection`() throws {
     let select = try parse(select: "SELECT * FROM TypeDef")
@@ -63,32 +158,16 @@ struct KeywordTests {
 }
 
 struct SetQuantifierTests {
-  @Test func `a plain SELECT is not distinct`() throws {
-    let select = try parse(select: "SELECT TypeName FROM TypeDef")
-    #expect(!select.distinct)
-  }
-
-  @Test func `SELECT DISTINCT sets the distinct flag`() throws {
-    let select = try parse(select: "SELECT DISTINCT TypeName FROM TypeDef")
-    #expect(select.distinct)
-    #expect(select.projection == .columns(["TypeName"]))
-  }
-
-  @Test func `SELECT ALL is the default, not distinct`() throws {
-    let select = try parse(select: "SELECT ALL TypeName FROM TypeDef")
-    #expect(!select.distinct)
-    #expect(select.projection == .columns(["TypeName"]))
-  }
-
-  @Test func `DISTINCT is case-insensitive`() throws {
-    let select = try parse(select: "select distinct TypeName from TypeDef")
-    #expect(select.distinct)
-  }
-
-  @Test func `DISTINCT applies to a FROM-less scalar select`() throws {
-    let select = try parse(select: "SELECT DISTINCT 1")
-    #expect(select.distinct)
-    #expect(select.from == nil)
+  @Test(arguments: kQuantifiers)
+  fileprivate func parses(_ test: Quantifier) throws {
+    let select = try parse(select: test.text)
+    #expect(select.distinct == test.distinct)
+    if let columns = test.columns {
+      #expect(select.projection == .columns(columns))
+    }
+    if test.fromless {
+      #expect(select.from == nil)
+    }
   }
 }
 
@@ -210,19 +289,11 @@ struct PredicateTests {
 }
 
 struct OrderTests {
-  @Test func `defaults ORDER BY to ascending`() throws {
-    let select = try parse(select: "SELECT * FROM T ORDER BY TypeName")
-    #expect(select.order == Order(column: "TypeName", ascending: true))
-  }
-
-  @Test func `parses an explicit ASC order`() throws {
-    let select = try parse(select: "SELECT * FROM T ORDER BY TypeName ASC")
-    #expect(select.order == Order(column: "TypeName", ascending: true))
-  }
-
-  @Test func `parses a DESC order`() throws {
-    let select = try parse(select: "SELECT * FROM T ORDER BY TypeName DESC")
-    #expect(select.order == Order(column: "TypeName", ascending: false))
+  @Test(arguments: kDirections)
+  fileprivate func parses(_ test: Direction) throws {
+    let select = try parse(select: test.text)
+    #expect(select.order
+                == Order(column: "TypeName", ascending: test.ascending))
   }
 
   @Test func `parses a comma-separated list of sort keys`() throws {
@@ -333,43 +404,20 @@ struct CompositeTests {
 }
 
 struct ColumnTests {
-  @Test func `splits a dotted column into qualifier and name`() {
-    let column = Column("t.Name")
-    #expect(column.qualifier == "t")
-    #expect(column.name == "Name")
-  }
-
-  @Test func `leaves an undotted column unqualified`() {
-    let column = Column("Name")
-    #expect(column.qualifier == nil)
-    #expect(column.name == "Name")
-  }
-
-  @Test func `splits on the last dot only`() {
-    // A two-part relation name may qualify a column — the reserved
-    // `information_schema.tables.table_name` — so the split takes the text
-    // before the LAST dot as the qualifier and the rest as the name.
-    let column = Column("t.a.b")
-    #expect(column.qualifier == "t.a")
-    #expect(column.name == "b")
+  @Test(arguments: kColumns)
+  fileprivate func splits(_ test: Splitting) {
+    let column = Column(test.text)
+    #expect(column.qualifier == test.qualifier)
+    #expect(column.name == test.name)
   }
 }
 
 struct RelationTests {
-  @Test func `parses a bare FROM relation with no alias`() throws {
-    let select = try parse(select: "SELECT * FROM TypeDef")
-    #expect(select.from == Relation(name: "TypeDef"))
+  @Test(arguments: kAliases)
+  fileprivate func parses(_ test: Aliasing) throws {
+    let select = try parse(select: test.text)
+    #expect(select.from == Relation(name: "TypeDef", alias: test.alias))
     #expect(select.joins.isEmpty)
-  }
-
-  @Test func `parses an AS alias on the FROM relation`() throws {
-    let select = try parse(select: "SELECT * FROM TypeDef AS t")
-    #expect(select.from == Relation(name: "TypeDef", alias: "t"))
-  }
-
-  @Test func `parses an implicit (AS-less) alias`() throws {
-    let select = try parse(select: "SELECT * FROM TypeDef t")
-    #expect(select.from == Relation(name: "TypeDef", alias: "t"))
   }
 
   @Test func `does not mistake a following keyword for an alias`() throws {
@@ -547,65 +595,19 @@ struct LiteralTests {
     #expect(select.projection == .columns(["x"]))
   }
 
-  @Test func `rejects a blob with an odd hex digit count`() {
+  @Test(arguments: kBlobs)
+  fileprivate func rejects(_ test: Failure) {
     #expect(throws: SQLError.self) {
-      _ = try Statement(parsing: "SELECT * FROM T WHERE a = x'abc'")
-    }
-  }
-
-  @Test func `rejects a blob with a non-hex digit`() {
-    #expect(throws: SQLError.self) {
-      _ = try Statement(parsing: "SELECT * FROM T WHERE a = x'gg'")
-    }
-  }
-
-  @Test func `rejects an unterminated blob`() {
-    #expect(throws: SQLError.self) {
-      _ = try Statement(parsing: "SELECT * FROM T WHERE a = x'abcd")
+      _ = try Statement(parsing: test.text)
     }
   }
 }
 
 struct ErrorTests {
-  @Test func `rejects a query missing FROM`() {
+  @Test(arguments: kSyntax)
+  fileprivate func rejects(_ test: Failure) {
     #expect(throws: SQLError.self) {
-      _ = try Statement(parsing: "SELECT TypeName TypeDef")
-    }
-  }
-
-  @Test func `rejects an invalid operator`() {
-    #expect(throws: SQLError.self) {
-      _ = try Statement(parsing: "SELECT * FROM T WHERE a ! 1")
-    }
-  }
-
-  @Test func `rejects an unterminated string`() {
-    #expect(throws: SQLError.self) {
-      _ = try Statement(parsing: "SELECT * FROM T WHERE a = 'unterminated")
-    }
-  }
-
-  @Test func `rejects trailing tokens`() {
-    // A bare identifier after the relation is now an implicit alias, so
-    // trailing garbage must come after a clause that admits no alias — here a
-    // second identifier past the relation's (implicit) alias.
-    #expect(throws: SQLError.self) {
-      _ = try Statement(parsing: "SELECT * FROM T t garbage")
-    }
-  }
-
-  @Test func `rejects an empty projection`() {
-    #expect(throws: SQLError.self) {
-      _ = try Statement(parsing: "SELECT FROM T")
-    }
-  }
-
-  @Test func `rejects a FROM keyword with no following relation`() {
-    // FROM is now optional, so `SELECT *` parses as a FROM-less projection (the
-    // engine rejects a `*` with no relation). A bare FROM with no relation,
-    // though, ends the input where a relation is required.
-    #expect(throws: SQLError.self) {
-      _ = try Statement(parsing: "SELECT * FROM")
+      _ = try Statement(parsing: test.text)
     }
   }
 

--- a/Tests/winmd-inspectTests/ValueDisplayTests.swift
+++ b/Tests/winmd-inspectTests/ValueDisplayTests.swift
@@ -7,13 +7,38 @@ import Testing
 
 import SQLEngine
 
+private struct Display: Sendable, CustomTestStringConvertible {
+  internal let value: Value
+  internal let expected: String
+
+  internal var testDescription: String { expected }
+}
+
+private let kBooleans: Array<Display> = [
+  Display(value: .boolean(true), expected: "TRUE"),
+  Display(value: .boolean(false), expected: "FALSE"),
+]
+
+private let kDoubles: Array<Display> = [
+  Display(value: .double(3.14), expected: "3.14"),
+  Display(value: .double(2.5), expected: "2.5"),
+  Display(value: .double(1.0), expected: "1.0"),
+  Display(value: .double(1000.0), expected: "1000.0"),
+]
+
+private let kBlobs: Array<Display> = [
+  Display(value: .blob([0x53, 0x51, 0x4c]), expected: "x'53514c'"),
+  Display(value: .blob([0x00, 0x0f, 0xab, 0xff]), expected: "x'000fabff'"),
+  Display(value: .blob([]), expected: "x''"),
+]
+
 // MARK: - Boolean
 
 @Suite
 private struct BooleanDisplayTests {
-  @Test func `a boolean renders as TRUE or FALSE`() {
-    #expect(Value.boolean(true).display == "TRUE")
-    #expect(Value.boolean(false).display == "FALSE")
+  @Test(arguments: kBooleans)
+  fileprivate func renders(_ test: Display) {
+    #expect(test.value.display == test.expected)
   }
 }
 
@@ -21,14 +46,9 @@ private struct BooleanDisplayTests {
 
 @Suite
 private struct DoubleDisplayTests {
-  @Test func `a double renders through its round-tripping description`() {
-    #expect(Value.double(3.14).display == "3.14")
-    #expect(Value.double(2.5).display == "2.5")
-  }
-
-  @Test func `a whole double keeps its .0, marking it approximate-numeric`() {
-    #expect(Value.double(1.0).display == "1.0")
-    #expect(Value.double(1000.0).display == "1000.0")
+  @Test(arguments: kDoubles)
+  fileprivate func renders(_ test: Display) {
+    #expect(test.value.display == test.expected)
   }
 }
 
@@ -36,15 +56,8 @@ private struct DoubleDisplayTests {
 
 @Suite
 private struct BlobDisplayTests {
-  @Test func `a blob renders as a lowercase-hex x'…' literal`() {
-    #expect(Value.blob([0x53, 0x51, 0x4c]).display == "x'53514c'")
-  }
-
-  @Test func `hex is lowercase and keeps a byte's leading zero`() {
-    #expect(Value.blob([0x00, 0x0f, 0xab, 0xff]).display == "x'000fabff'")
-  }
-
-  @Test func `an empty blob renders as x''`() {
-    #expect(Value.blob([]).display == "x''")
+  @Test(arguments: kBlobs)
+  fileprivate func renders(_ test: Display) {
+    #expect(test.value.display == test.expected)
   }
 }


### PR DESCRIPTION
This reduces test overhead by ~7.5%. While this is marginal due to the parallel execution of swift-testing, and the complete migration, it is worth reducing the overhead so that we can continue to grow the test suite.