### PR TITLE
WinMD: tightening the scoping on internal properties

### DIFF
--- a/Sources/WinMD/Iteration.swift
+++ b/Sources/WinMD/Iteration.swift
@@ -390,15 +390,10 @@ public struct Cursor: ~Escapable {
   }
 
   /// The open table this cursor walks.
-  ///
-  /// Exposed to the structured-query executor (`where(_: Predicate)`), which
-  /// inspects the table's schema and `Sorted` bit to decide between a binary
-  /// search and a scan, and to the SQL-engine adapter, which reads the table's
-  /// schema to describe the relation.
-  package var relation: Table { table }
+  internal var relation: Table { table }
 
   /// The borrowed storage view this cursor reads from.
-  package var backing: Storage {
+  internal var backing: Storage {
     @_lifetime(copy self)
     get { storage }
   }

--- a/Sources/WinMD/Storage.swift
+++ b/Sources/WinMD/Storage.swift
@@ -30,7 +30,7 @@ package struct Storage: ~Escapable {
   internal let guid: RawSpan
 
   /// The bitset of present tables (`TablesStream.Valid`).
-  package let valid: UInt64
+  internal let valid: UInt64
 
   /// The bitset of physically sorted tables (`TablesStream.Sorted`).
   ///
@@ -40,7 +40,7 @@ package struct Storage: ~Escapable {
   package let sorted: UInt64
 
   @_lifetime(copy bytes, copy relations, copy strings, copy blob, copy guid)
-  package init(bytes: RawSpan, relations: Span<Table>, strings: RawSpan,
+  internal init(bytes: RawSpan, relations: Span<Table>, strings: RawSpan,
                 blob: RawSpan, guid: RawSpan, valid: UInt64, sorted: UInt64) {
     self.bytes = bytes
     self.tables = relations

--- a/Sources/WinMD/Table.swift
+++ b/Sources/WinMD/Table.swift
@@ -79,7 +79,7 @@ public struct Table: Sendable {
   /// them within `Database.bytes`.
   internal let range: Range<Int>
 
-  package var number: Int { schema.number }
+  internal var number: Int { schema.number }
 
   internal init(_ schema: TableSchema.Type, rows: UInt32,
                 range: Range<Int>, wide: UInt32, stride: Int) {

--- a/Sources/winmd-inspect/Database+SQL.swift
+++ b/Sources/winmd-inspect/Database+SQL.swift
@@ -457,7 +457,7 @@ internal struct WinMDRelation: SQLEngine.Table, ~Escapable {
     // which rejects it (no real decoded key equals the huge value).
     if let key = key(for: column), value >= 1,
         value <= Int.max >> key.kind.bits, key.column == table.schema.key,
-        storage.sorted & (1 << table.number) != 0 {
+        storage.sorted & (1 << table.schema.number) != 0 {
       let encoded = (value << key.kind.bits) | key.tag
       return storage.bound(table, key.column, encoded, count, strict: strict)
     }
@@ -465,7 +465,7 @@ internal struct WinMDRelation: SQLEngine.Table, ~Escapable {
     // A real column is seekable only when it is the table's intrinsic sort key
     // and this database physically sorts the table; otherwise the engine scans.
     guard table.schema.key == column,
-        storage.sorted & (1 << table.number) != 0 else {
+        storage.sorted & (1 << table.schema.number) != 0 else {
       return nil
     }
     return storage.bound(table, column, value, count, strict: strict)


### PR DESCRIPTION
Reduce the scope of some symbols from `package` to `internal`. This improves hygiene and allows us to reduce the exposed surface.