### PR TITLE
SQLEngine: decorrelate EXISTS into a semijoin

### DIFF
--- a/Sources/SQLEngine/Engine.swift
+++ b/Sources/SQLEngine/Engine.swift
@@ -2036,6 +2036,14 @@ extension Catalog where Self: ~Escapable {
       // NULL-extended.
       try .outer(optimise(left, context), optimise(right, context), on: on,
                  kind: kind)
+    case let .semijoin(left, right, on, anti):
+      // Optimise each side (a nested join or seekable scan inside a side still
+      // rewrites), but keep the semijoin node and its `on` intact — the `on`
+      // governs the existence test and must not fold into a product or onto
+      // a leaf, or a surviving/excluded left row would change. The executor's
+      // hash fast-path keys on the straddling equi `.match` this `on` holds.
+      try .semijoin(optimise(left, context), optimise(right, context), on: on,
+                    anti: anti)
     case let .apply(left, key, correlation, ordinals, on, kind):
       // Optimise the left side (a seekable scan or a nested join inside it
       // still rewrites), but keep the apply node, its `on`, and its recorded
@@ -2421,7 +2429,14 @@ extension Catalog where Self: ~Escapable {
       return try .derived(name: name, plan: decorrelate(plan, context),
                           ordinals: ordinals, seek: seek)
     case let .select(filter, source):
-      return try .select(filter, decorrelate(source, context))
+      // Decorrelate the source first (a nested apply/exists inside it still
+      // rewrites), then attempt to lift a top-level correlated `EXISTS`/`NOT
+      // EXISTS` conjunct of this select's filter into a semijoin. On any doubt
+      // the whole `.select` is left correlated (`decorrelated(exists:)` returns
+      // `nil`), so execution is unchanged.
+      let source = try decorrelate(source, context)
+      return decorrelated(exists: filter, source, context)
+          ?? .select(filter, source)
     case let .project(terms, source):
       return try .project(terms, decorrelate(source, context))
     case let .sort(keys, source):
@@ -2432,6 +2447,12 @@ extension Catalog where Self: ~Escapable {
     case let .outer(left, right, on, kind):
       return try .outer(decorrelate(left, context), decorrelate(right, context),
                         on: on, kind: kind)
+    case let .semijoin(left, right, on, anti):
+      // A semijoin this pass ITSELF produced (from a decorrelated `EXISTS`);
+      // recurse structurally into both sides so a nested correlated apply
+      // inside either still rewrites, preserving the node.
+      return try .semijoin(decorrelate(left, context),
+                           decorrelate(right, context), on: on, anti: anti)
     case let .apply(left, key, correlation, ordinals, on, kind):
       // Decorrelate the LEFT first (a nested apply inside it still rewrites),
       // then attempt this apply. `.inner` (CROSS APPLY) folds to an inner hash
@@ -2657,6 +2678,136 @@ extension Catalog where Self: ~Escapable {
       return nil
     }
   }
+
+  /// The semijoin rewrite of a `.select` whose `filter` carries a top-level
+  /// correlated `EXISTS`/`NOT EXISTS` conjunct over an already-decorrelated
+  /// `source`, or `nil` when no such conjunct is decorrelatable — in which case
+  /// the caller leaves the `.select` correlated (conservative default). A plain
+  /// `EXISTS` conjunct becomes a SEMIJOIN, a `NOT EXISTS` an ANTI-join, the
+  /// REMAINING conjuncts kept in a `.select` ABOVE it.
+  ///
+  /// An `EXISTS` is a two-valued existence test — TRUE iff the body yields a
+  /// row, never UNKNOWN — so a semijoin is result-equivalent to the per-row
+  /// re-execution the `exists` evaluator does, WITHOUT the NOT-IN NULL trap (a
+  /// NULL correlation key is simply "no match", dropping a SEMI left row and
+  /// keeping an ANTI one). The body must be the SAME simple filter+project over
+  /// a single base-relation scan the CROSS APPLY recogniser requires, MINUS the
+  /// projection/taken-ordinal handling: a semijoin takes NO output column from
+  /// the body (existence only), so the projection CONTENT is irrelevant — only
+  /// the scan+select shape and a `nil` seek matter. The correlation must be a
+  /// single `.slot` source and the body WHERE must split into EXACTLY one equi
+  /// correlation conjunct plus safe, non-parameterised residual conjuncts `p_R`
+  /// (an unsafe or parameterised residual — a non-equi correlation — bails, G3/
+  /// G4).
+  ///
+  /// **SIBLING THROW-VISIBILITY (load-bearing).** A semijoin DROPS left rows
+  /// (SEMI drops exists-false rows, ANTI drops exists-true rows), so a sibling
+  /// conjunct of the enclosing `AND` that is UNSAFE could be SKIPPED for a row
+  /// the semijoin drops — suppressing a throw the correlated `.select` raises
+  /// (it evaluates every conjunct of the `AND` for the row before the row is
+  /// dropped). This is the throw-visibility class the OUTER APPLY safe gate
+  /// guards. THEREFORE the exists is lifted ONLY when EVERY OTHER conjunct of
+  /// the enclosing filter is `safe`; if any sibling is unsafe the whole
+  /// `.select` stays correlated. Conservative is correct — a missed
+  /// decorrelation is a perf loss, a wrong one is silent data corruption.
+  ///
+  /// Exactly ONE exists is lifted per pass; a further decorrelatable exists in
+  /// the remaining conjuncts is picked up when the `.select` recursion re-runs
+  /// over the residual (the semijoin's output width is the source's, so the
+  /// remaining conjuncts and everything above still address the same slots).
+  private borrowing func decorrelated(exists filter: Filter, _ source: Plan,
+                                      _ context: Context) -> Plan? {
+    let conjuncts = filter.conjuncts
+    for (position, conjunct) in conjuncts.enumerated() {
+      guard case let .exists(key, correlation, negated) = conjunct else {
+        continue
+      }
+      // The remaining conjuncts — everything but this exists — are both the
+      // SIBLINGS whose safety the throw-visibility guard tests and the residual
+      // kept above the semijoin.
+      let remaining = conjuncts.enumerated()
+          .filter { $0.offset != position }
+          .map(\.element)
+      // SIBLING THROW-VISIBILITY: every OTHER conjunct of the enclosing `AND`
+      // must be safe, or lifting this exists into a row-dropping semijoin could
+      // suppress a throw the correlated select raises for a dropped row.
+      guard remaining.allSatisfy(\.safe) else { continue }
+      guard let body = context.subqueries.plan(key, correlation),
+          let node = semijoin(source, body, key, correlation, negated,
+                              context) else { continue }
+      // Keep the remaining conjuncts in a `.select` ABOVE the semijoin. The
+      // semijoin's width == the source's, so they and everything above still
+      // address the same slots.
+      return remaining.conjunction.map { .select($0, node) } ?? node
+    }
+    return nil
+  }
+
+  /// The `.semijoin` node for a correlated `EXISTS`/`NOT EXISTS` body over
+  /// `left`, or `nil` when the `body` is not decorrelatable — the SAME guards
+  /// the CROSS APPLY recogniser applies MINUS the projection handling (a
+  /// semijoin tests existence, taking no body column). `negated` selects the
+  /// ANTI sense.
+  ///
+  /// The body must be `project(_, select(where, scan(R, _, nil)))` — the
+  /// projection content is irrelevant — with no body-local derived table (the
+  /// body-local-derived hazard), `R` a genuine BASE relation (not a CTE/store
+  /// overlay entry or a view), a single `.slot` correlation source, and a
+  /// `where` splitting into EXACTLY one equi correlation conjunct plus safe,
+  /// non-parameterised residual conjuncts. The correlation equality becomes a
+  /// straddling `.match` (the executor's hash key), the residual shifts into
+  /// combined `left ++ scan` space alongside, and the two conjoin into the
+  /// semijoin's `on`.
+  private borrowing func semijoin(_ left: Plan, _ body: Plan, _ key: Subkey,
+                                  _ correlation: Correlation, _ negated: Bool,
+                                  _ context: Context) -> Plan? {
+    guard case let .project(_, .select(filter, leaf)) = body,
+        case let .scan(name, scanOrdinals, nil) = leaf,
+        let base = left.slots else { return nil }
+    // No body-local derived table: its per-execution alias cannot be relaid as
+    // a caller-level scan — the SAME hazard the CROSS APPLY recogniser guards.
+    var derivations = Array<(String, Query)>()
+    key.query.collect(derived: &derivations)
+    guard derivations.isEmpty else { return nil }
+    // The scan must name a genuine BASE relation, not a CTE/store overlay entry
+    // or a view — a CTE/view `.scan` re-resolves against the wrong overlay when
+    // relaid at the caller level. Leave either correlated.
+    guard context.relations[name.lowercased()] == nil,
+        resolve(view: name) == nil else { return nil }
+    // The correlation must be a single `.slot` source (no `.bound` parent):
+    // the outer key is that source's ordinal, already in the left's slot space.
+    guard correlation.count == 1,
+        case let (name: parameter, source: .slot(outer))? =
+            correlation.first.map({ (name: $0.key, source: $0.value) })
+        else { return nil }
+
+    // Split the body WHERE into the ONE equi correlation conjunct
+    // (`correlate.inner = :parameter`) and the local residual `p_R`. Any other
+    // parameterised conjunct is a non-equi/expression correlation — bail. Every
+    // residual must be safe (a throwing body term could fire for an inner
+    // left row reaches under set-based execution).
+    var inner: Int? = nil
+    var residual = Array<Filter>()
+    for conjunct in filter.conjuncts {
+      if inner == nil, let slot = equated(conjunct, to: parameter) {
+        inner = slot
+        continue
+      }
+      guard conjunct.safe, !conjunct.parameterised else { return nil }
+      residual.append(conjunct)
+    }
+    guard let inner else { return nil }
+
+    // The scan is relaid after the left, so the body's 0-based scan slots shift
+    // by `base` into the combined space. The correlation equality becomes a
+    // straddling `.match` (the executor's hash key), and the residual `p_R`
+    // shifts alongside into this `left ++ scan` space.
+    let scan = Plan.scan(name: name, ordinals: scanOrdinals, seek: nil)
+    let matched = Filter.match(outer, base + inner)
+    let shifted = residual.map { $0.shifted(by: -base) }
+    let on = ([matched] + shifted).conjunction ?? matched
+    return .semijoin(left, scan, on: on, anti: negated)
+  }
 }
 
 /// The inner-key slot of an EQUI correlation conjunct `slot = :parameter` (in
@@ -2752,6 +2903,16 @@ extension Plan {
       // whole `WHERE` stays above (`distribute`'s default keeps it a `select`
       // over this node).
       try .outer(left.pushdown(), right.pushdown(), on: on, kind: kind)
+    case let .semijoin(left, right, on, anti):
+      // Push down WITHIN each side (its own joins/filters rewrite), but the
+      // semijoin node is a pushdown barrier: a `WHERE` conjunct above it never
+      // rides into a side. The semijoin DROPS left rows by the existence test,
+      // so filtering a side's rows before it could change which left rows
+      // survive — preferring correctness, the whole `WHERE` stays above
+      // (`distribute`'s default keeps it a `select` over this node). Pushdown
+      // runs BEFORE decorrelate, so this arm handles only a semijoin a nested
+      // pass produced; a top-level plan never carries one at this point.
+      try .semijoin(left.pushdown(), right.pushdown(), on: on, anti: anti)
     case let .apply(left, key, correlation, ordinals, on, kind):
       // Push down WITHIN the left side (its own joins/filters rewrite), but the
       // apply is a pushdown barrier: its right side is not a static sub-plan

--- a/Sources/SQLEngine/Operator.swift
+++ b/Sources/SQLEngine/Operator.swift
@@ -154,6 +154,24 @@ internal indirect enum Plan {
   /// nested loop that tracks matches, so it composes with an arbitrary
   /// (non-equi) `on`.
   case outer(Plan, Plan, on: Filter, kind: Join.Kind)
+  /// A SEMIJOIN of `left` against `right` on the `on` predicate — an EXISTENCE
+  /// test whose output is the LEFT side's slots ALONE. Unlike an inner or outer
+  /// join it neither appends the right's columns nor NULL-extends: it merely
+  /// KEEPS or DROPS each left row by whether the right holds a match, so a left
+  /// row survives with its own width unchanged and its slot geometry preserved.
+  /// `on` addresses the combined `left ++ right` slot space (the left's slots
+  /// then the right's), so a candidate is merged to EVALUATE it — but the LEFT
+  /// record alone is emitted. `anti` selects the sense: `false` keeps a left
+  /// row iff SOME right row makes `on` TRUE (a decorrelated `EXISTS`), `true`
+  /// keeps it iff NO right row does (a decorrelated `NOT EXISTS`). A left row
+  /// emitted AT MOST ONCE regardless of its match count — the semijoin short-
+  /// circuits on the first match, never multiplying a left row by the number of
+  /// right rows it matches, exactly as `EXISTS` is a decided per-row test. The
+  /// decorrelation pass emits it for a top-level correlated `EXISTS`/`NOT
+  /// EXISTS` conjunct; the executor runs it as a nested loop (or a hash probe
+  /// when `on` carries a straddling equi key), so it composes with an arbitrary
+  /// `on`.
+  case semijoin(Plan, Plan, on: Filter, anti: Bool)
   /// A correlated APPLY — a `LATERAL` derived table's nested loop. For each
   /// record of the left sub-plan it re-executes the pre-compiled body plan
   /// (looked up by `key` composed with `correlation`, whose `slot` sources bind
@@ -277,6 +295,10 @@ extension Plan {
       } else {
         nil
       }
+    case let .semijoin(left, _, _, _):
+      // A semijoin is an existence test: it keeps or drops each left row but
+      // appends nothing, so it spans exactly the left side's slots.
+      left.slots
     case let .apply(left, _, _, ordinals, _, _):
       // An apply lays the lateral body's taken `ordinals` after the left's
       // slots, exactly as a product lays a scan's referenced ordinals.
@@ -414,6 +436,14 @@ extension Catalog where Self: ~Escapable {
       return try outer(execute(left, context), execute(right, context),
                        widths: (left: left.slots ?? 0, right: right.slots ?? 0),
                        on, kind, context)
+    case let .semijoin(left, right, on, anti):
+      // The side widths come from the sub-plans (known for a compiled plan), so
+      // the hash fast-path can map a straddling equi key's right slot into the
+      // right side's own standalone space.
+      return try semijoin(execute(left, context), execute(right, context),
+                          widths: (left: left.slots ?? 0,
+                                   right: right.slots ?? 0),
+                          on, anti: anti, context)
     case let .apply(left, key, correlation, ordinals, on, kind):
       return try applied(execute(left, context), key, correlation, ordinals,
                          on, kind, context)
@@ -688,6 +718,138 @@ extension Catalog where Self: ~Escapable {
       for index in right.indices where !matched[index] {
         records.append(nulls.left.merged(with: right[index]))
       }
+    }
+    return records
+  }
+
+  /// The SEMIJOIN of `left` against `right` on `on` — an EXISTENCE
+  /// test emitting each surviving LEFT record UNCHANGED, never merged with a
+  /// right one and never NULL-extended.
+  ///
+  /// `left`/`right` are the two materialised sides, `widths` each side's slot
+  /// count (the fast path maps the equi key's combined-space right slot down by
+  /// `widths.left` into the right side's own space). A candidate pair is merged
+  /// (left slots then right slots) ONLY to evaluate `on` in the combined space;
+  /// the LEFT record alone is what a survivor emits.
+  ///
+  ///   - SEMI (`anti == false`): a left row is kept iff SOME right row makes
+  ///     merged `on` evaluate TRUE under three-valued logic (UNKNOWN and FALSE
+  ///     do not match, exactly as a `WHERE` admits). The scan SHORT-CIRCUITS on
+  ///     the first match, so a left row appears AT MOST ONCE regardless of how
+  ///     many right rows it matches — `EXISTS` is a decided per-row test, never
+  ///     a multiplication.
+  ///   - ANTI (`anti == true`): a left row is kept iff NO right row makes `on`
+  ///     TRUE — the complement, a decorrelated `NOT EXISTS`.
+  ///
+  /// A NULL correlation key makes the equi `.match` UNKNOWN, so no right row
+  /// matches: SEMI drops such a left row, ANTI keeps it — `EXISTS` two-valued,
+  /// never UNKNOWN. An EMPTY right side matches nothing, so SEMI emits nothing
+  /// and ANTI emits every left row.
+  ///
+  /// FAST PATH: when `on` carries a straddling equi `.match` conjunct (shape
+  /// a decorrelated `EXISTS` emits, found by `equikey`) AND the WHOLE `on` is
+  /// `safe`, the right side is bucketed by its key ONCE and each left probes
+  /// its own bucket, confirming the WHOLE `on` per candidate (the bucket over-
+  /// groups and `on` may carry residual conjuncts beyond the key) and short-
+  /// circuiting on the first confirmed match — turning the O(left × right)
+  /// nested loop into O(left + right). A NULL left key probes no bucket and so
+  /// never matches, exactly as the nested loop's UNKNOWN `.match` leaves it.
+  ///
+  /// The fast path fires ONLY when `on` is `safe`, for the SAME reason the
+  /// `.outer` executor gates its own hash path: it evaluates `on` for a left
+  /// row's matching-key bucket candidates ALONE, SKIPPING every non-bucket and
+  /// NULL-key right row, whereas the nested loop evaluates `on` for EVERY pair.
+  /// (This is NOT `AND` short-circuiting: the evaluator is Kleene and DOES
+  /// circuit an `AND` on a FALSE left, but an UNKNOWN or TRUE left still
+  /// evaluates the right, and either side may throw.) An UNSAFE `on` could
+  /// therefore SUPPRESS a throw the nested loop raises on a skipped pair, so it
+  /// falls to the nested loop, which evaluates every pair and throws
+  /// identically. In PRACTICE the decorrelation only ever builds a `safe` `on`
+  /// (its correlation `.match` and residual are gated `safe`), so this gate is
+  /// defence-in-depth against a future producer.
+  private borrowing func semijoin(_ left: Array<Record>,
+                                  _ right: Array<Record>,
+                                  widths: (left: Int, right: Int),
+                                  _ on: Filter, anti: Bool,
+                                  _ context: Context)
+      throws(SQLError) -> Array<Record> {
+    if let key = equikey(on, widths.left), on.safe {
+      // `key.right` is in the combined `left ++ right` space; the right side is
+      // materialised standalone, so its own slot is `key.right - widths.left`.
+      return try bucketed(left, right,
+                          key: (key.left, key.right - widths.left),
+                          on, anti: anti, context)
+    }
+
+    var records = Array<Record>()
+    for lhs in left {
+      // Short-circuit on the first right row that confirms `on` — a left row
+      // survives (SEMI) or is excluded (ANTI) by EXISTENCE alone, so it need
+      // never scan past the first match, and is emitted AT MOST ONCE.
+      var found = false
+      for rhs in right where try evaluate(lhs.merged(with: rhs), on,
+                                          context) == true {
+        found = true
+        break
+      }
+      // SEMI keeps a matched left row, ANTI keeps an unmatched one — and the
+      // LEFT record alone is emitted, never the merge.
+      if found != anti { records.append(lhs) }
+    }
+    return records
+  }
+
+  /// The hash fast-path of a semijoin: the right hashed ONCE by `key.right`
+  /// into buckets, then each left row probed by `key.left` in O(1) and short-
+  /// circuited on the first confirmed match. Behaviour-identical to the nested
+  /// loop `semijoin` above — same survivors, each emitted at most once.
+  ///
+  /// The right side is bucketed by its key's promoted `bucket` (a NULL key
+  /// buckets nothing — it can never equi-match, exactly as the nested loop's
+  /// UNKNOWN `.match` leaves it). Each left row probes its own key's bucket and
+  /// every candidate is CONFIRMED against the WHOLE `on` — the bucket over-
+  /// groups and `on` may carry residual conjuncts beyond the key — the first
+  /// confirmed match deciding existence. A left row whose key is NULL probes
+  /// nothing and matches nothing. SEMI emits a matched left row (unchanged, at
+  /// most once); ANTI emits an unmatched one — the complement.
+  ///
+  /// `key.left` is a combined-space slot (the left is the record's prefix),
+  /// while `key.right` is the right's OWN standalone slot — the caller maps
+  /// the combined right slot down by `widths.left` before the call.
+  private borrowing func bucketed(_ left: Array<Record>,
+                                  _ right: Array<Record>,
+                                  key: (left: Int, right: Int),
+                                  _ on: Filter, anti: Bool,
+                                  _ context: Context)
+      throws(SQLError) -> Array<Record> {
+    // Bucket the right side by its key; a NULL-keyed right row equi-matches
+    // nothing, so it is never bucketed.
+    var buckets = Dictionary<Value, Array<Int>>()
+    for index in right.indices {
+      let value = right[index][key.right]
+      if case .null = value { continue }
+      buckets[bucket(value), default: Array<Int>()].append(index)
+    }
+
+    var records = Array<Record>()
+    for lhs in left {
+      let value = lhs[key.left]
+      var found = false
+      // A NULL left key equi-matches nothing, so it probes no bucket and stays
+      // unmatched — SEMI drops it, ANTI keeps it.
+      if case .null = value {} else {
+        for index in buckets[bucket(value)] ?? [] {
+          // Confirm the WHOLE `on` — the bucket over-groups and `on` may carry
+          // residual conjuncts beyond the equi key, so a collision or a failing
+          // residual is not a match, exactly as the nested loop's `on` test.
+          // The first confirmed match decides existence, so stop scanning.
+          if try evaluate(lhs.merged(with: right[index]), on, context) == true {
+            found = true
+            break
+          }
+        }
+      }
+      if found != anti { records.append(lhs) }
     }
     return records
   }

--- a/Tests/SQLTests/Expressions/LikeTests.swift
+++ b/Tests/SQLTests/Expressions/LikeTests.swift
@@ -251,6 +251,7 @@ private func seeks(_ plan: Plan) -> Bool {
   case let .product(left, right): seeks(left) || seeks(right)
   case let .join(outer, _, _, _, _, _, _): seeks(outer)
   case let .outer(left, right, _, _): seeks(left) || seeks(right)
+  case let .semijoin(left, right, _, _): seeks(left) || seeks(right)
   case let .apply(left, _, _, _, _, _): seeks(left)
   case let .setop(_, left, right, _): seeks(left) || seeks(right)
   case .single: false
@@ -271,6 +272,7 @@ private func joins(_ plan: Plan) -> Bool {
   case let .derived(_, sub, _, _): joins(sub)
   case let .product(left, right): joins(left) || joins(right)
   case let .outer(left, right, _, _): joins(left) || joins(right)
+  case let .semijoin(left, right, _, _): joins(left) || joins(right)
   case let .apply(left, _, _, _, _, _): joins(left)
   case let .setop(_, left, right, _): joins(left) || joins(right)
   case .single, .scan: false
@@ -293,6 +295,7 @@ private func residual(_ plan: Plan) -> Bool {
   case let .product(left, right): residual(left) || residual(right)
   case let .join(outer, _, _, _, _, _, _): residual(outer)
   case let .outer(left, right, _, _): residual(left) || residual(right)
+  case let .semijoin(left, right, _, _): residual(left) || residual(right)
   case let .apply(left, _, _, _, _, _): residual(left)
   case let .setop(_, left, right, _): residual(left) || residual(right)
   case .single, .scan: false

--- a/Tests/SQLTests/Optimisation/ConstantFoldTests.swift
+++ b/Tests/SQLTests/Optimisation/ConstantFoldTests.swift
@@ -70,6 +70,8 @@ private func selects(_ plan: Plan) -> Bool {
     selects(left) || selects(right)
   case let .outer(left, right, _, _):
     selects(left) || selects(right)
+  case let .semijoin(left, right, _, _):
+    selects(left) || selects(right)
   case let .join(source, _, _, _, _, _, _):
     selects(source)
   case let .apply(left, _, _, _, _, _):

--- a/Tests/SQLTests/Optimisation/DecorrelateTests.swift
+++ b/Tests/SQLTests/Optimisation/DecorrelateTests.swift
@@ -27,7 +27,7 @@ private func applies(_ plan: Plan) -> Bool {
        let .aggregate(_, _, source):
     return applies(source)
   case let .product(left, right), let .outer(left, right, _, _),
-       let .setop(_, left, right, _):
+       let .semijoin(left, right, _, _), let .setop(_, left, right, _):
     return applies(left) || applies(right)
   case .single, .scan, .join:
     return false
@@ -47,7 +47,7 @@ private func joins(_ plan: Plan) -> Bool {
        let .aggregate(_, _, source):
     return joins(source)
   case let .product(left, right), let .outer(left, right, _, _),
-       let .setop(_, left, right, _):
+       let .semijoin(left, right, _, _), let .setop(_, left, right, _):
     return joins(left) || joins(right)
   case .single, .scan, .apply:
     return false
@@ -66,9 +66,87 @@ private func outers(_ plan: Plan) -> Bool {
        let .distinct(source), let .limit(_, _, source),
        let .aggregate(_, _, source):
     return outers(source)
-  case let .product(left, right), let .setop(_, left, right, _):
+  case let .product(left, right), let .semijoin(left, right, _, _),
+       let .setop(_, left, right, _):
     return outers(left) || outers(right)
   case .single, .scan, .join, .apply:
+    return false
+  }
+}
+
+/// Whether `plan` (or a descendant) carries a `.semijoin` node — the witness a
+/// correlated `EXISTS`/`NOT EXISTS` conjunct decorrelated. `anti` distinguishes
+/// the two senses: a plain `EXISTS` yields `anti == false`, a `NOT EXISTS`
+/// `anti == true`.
+private func semijoins(_ plan: Plan) -> Bool {
+  switch plan {
+  case .semijoin:
+    return true
+  case let .derived(_, source, _, _):
+    return semijoins(source)
+  case let .select(_, source), let .project(_, source), let .sort(_, source),
+       let .distinct(source), let .limit(_, _, source),
+       let .aggregate(_, _, source):
+    return semijoins(source)
+  case let .product(left, right), let .outer(left, right, _, _),
+       let .setop(_, left, right, _):
+    return semijoins(left) || semijoins(right)
+  case .single, .scan, .join, .apply:
+    return false
+  }
+}
+
+/// Whether `plan` (or any descendant) carries a `.semijoin` node of the given
+/// `anti` sense — a SEMIJOIN (`anti == false`) or ANTI-join (`anti == true`).
+private func semijoins(_ plan: Plan, anti wanted: Bool) -> Bool {
+  switch plan {
+  case let .semijoin(_, _, _, anti):
+    return anti == wanted
+  case let .derived(_, source, _, _):
+    return semijoins(source, anti: wanted)
+  case let .select(_, source), let .project(_, source), let .sort(_, source),
+       let .distinct(source), let .limit(_, _, source),
+       let .aggregate(_, _, source):
+    return semijoins(source, anti: wanted)
+  case let .product(left, right), let .outer(left, right, _, _),
+       let .setop(_, left, right, _):
+    return semijoins(left, anti: wanted) || semijoins(right, anti: wanted)
+  case .single, .scan, .join, .apply:
+    return false
+  }
+}
+
+/// Whether `plan` (or any descendant) carries a residual correlated `.exists`
+/// conjunct in a `.select`'s filter — the witness an EXISTS was NOT rewritten
+/// (it stayed correlated). Scans every conjunct of each `.select` filter, so an
+/// EXISTS surviving beside other conjuncts (or nested in an `.or`) is caught.
+private func exists(in plan: Plan) -> Bool {
+  switch plan {
+  case let .select(filter, source):
+    return filter.conjuncts.contains { existential($0) } || exists(in: source)
+  case let .derived(_, source, _, _), let .project(_, source),
+       let .sort(_, source), let .distinct(source), let .limit(_, _, source),
+       let .aggregate(_, _, source):
+    return exists(in: source)
+  case let .product(left, right), let .outer(left, right, _, _),
+       let .semijoin(left, right, _, _), let .setop(_, left, right, _):
+    return exists(in: left) || exists(in: right)
+  case .single, .scan, .join, .apply:
+    return false
+  }
+}
+
+/// Whether `filter` is (or, through `and`/`or`/`not`, reaches) an `.exists`
+/// conjunct — a correlated `EXISTS`/`NOT EXISTS` still lowered as a predicate.
+private func existential(_ filter: Filter) -> Bool {
+  switch filter {
+  case .exists:
+    return true
+  case let .and(lhs, rhs), let .or(lhs, rhs):
+    return existential(lhs) || existential(rhs)
+  case let .not(operand):
+    return existential(operand)
+  default:
     return false
   }
 }
@@ -921,5 +999,348 @@ struct OuterJoinSafeGateTests {
         "LEFT JOIN B ON A.k = B.k AND B.flag = 1 " +
         "ORDER BY A.k",
         yields: [[nil, nil], [1, 1], [2, nil]])
+  }
+}
+
+// MARK: - Decorrelatable EXISTS → semijoin: result-equivalence + plan shape
+
+/// Behaviour-preserving oracles for the correlated `EXISTS` → SEMIJOIN and
+/// `NOT EXISTS` → ANTI-join decorrelation. A semijoin is a per-row EXISTENCE
+/// test: a left row survives AT MOST ONCE regardless of how many inner rows it
+/// matches (unlike a join, which multiplies). Every case compares the run
+/// against the KNOWN-CORRECT multiset the correlated `exists` evaluator
+/// produces and pins the plan shape: a decorrelatable EXISTS becomes a
+/// `.semijoin` with NO residual `.exists`, an excluded one stays an `.exists`.
+struct DecorrelateExistsTests {
+  /// AT-MOST-ONCE (G1): Id 1's body matches TWO inner rows, yet the left row
+  /// appears EXACTLY ONCE — a semijoin tests existence, it does NOT multiply.
+  /// Id 1 and Id 2 have children (kept), Id 3 has none (dropped).
+  @Test func `a left row matching many inner rows appears exactly once`()
+      throws {
+    try fixture().expect(
+        "SELECT T.Id FROM T " +
+        "WHERE EXISTS (SELECT 1 FROM S WHERE S.k = T.Id) ORDER BY T.Id",
+        yields: [[1], [2]])
+  }
+
+  /// PLAN SHAPE: the decorrelatable EXISTS optimises to a `.semijoin` (the SEMI
+  /// sense) with NO surviving `.exists` conjunct — the pass fired.
+  @Test func `a decorrelatable EXISTS optimises to a semijoin`() throws {
+    let plan = try fixture().optimised(
+        "SELECT T.Id FROM T " +
+        "WHERE EXISTS (SELECT 1 FROM S WHERE S.k = T.Id)")
+    #expect(semijoins(plan, anti: false))
+    #expect(!exists(in: plan))
+  }
+
+  /// NOT EXISTS → ANTI-join: the complement of the SEMI case — a left row
+  /// survives iff NO inner row matches. Only Id 3 (no child) survives.
+  @Test func `a NOT EXISTS yields the anti-join complement`() throws {
+    try fixture().expect(
+        "SELECT T.Id FROM T " +
+        "WHERE NOT EXISTS (SELECT 1 FROM S WHERE S.k = T.Id) ORDER BY T.Id",
+        yields: [[3]])
+  }
+
+  /// PLAN SHAPE: a `NOT EXISTS` optimises to a `.semijoin` of the ANTI sense
+  /// (`anti == true`), NO `.exists` surviving.
+  @Test func `a decorrelatable NOT EXISTS optimises to an anti-join`() throws {
+    let plan = try fixture().optimised(
+        "SELECT T.Id FROM T " +
+        "WHERE NOT EXISTS (SELECT 1 FROM S WHERE S.k = T.Id)")
+    #expect(semijoins(plan, anti: true))
+    #expect(!exists(in: plan))
+  }
+
+  /// NULL KEY (SEMI): a left row with a NULL correlation key matches nothing
+  /// (NULL ≠ NULL), so EXISTS is FALSE and the SEMI drops it. Id 1 survives,
+  /// NULL-Id row does not. The inner NULL-keyed `(NULL, 999)` never matches.
+  @Test func `a NULL key makes EXISTS false and the semijoin drops the row`()
+      throws {
+    try nullFixture().expect(
+        "SELECT T.Id FROM T " +
+        "WHERE EXISTS (SELECT 1 FROM S WHERE S.k = T.Id) ORDER BY T.Id",
+        yields: [[1]])
+  }
+
+  /// NULL KEY (ANTI): a NULL correlation key makes NOT EXISTS TRUE,
+  /// so the ANTI-join KEEPS the NULL-Id row. Id 1 (has a child) is dropped, the
+  /// NULL-Id row survives.
+  @Test func `a NULL key makes NOT EXISTS true and the anti-join keeps it`()
+      throws {
+    try nullFixture().expect(
+        "SELECT T.Id FROM T " +
+        "WHERE NOT EXISTS (SELECT 1 FROM S WHERE S.k = T.Id)",
+        yields: [[nil]])
+  }
+
+  /// EMPTY INNER (SEMI): no inner row matches ANY left row, so EXISTS is FALSE
+  /// for all — the SEMI emits nothing.
+  @Test func `an empty matching inner drops every SEMI left row`() throws {
+    try fixture().empty(
+        "SELECT T.Id FROM T " +
+        "WHERE EXISTS (SELECT 1 FROM S WHERE S.k = T.Id AND S.x > 10000)")
+  }
+
+  /// EMPTY INNER (ANTI): no inner row matches, so NOT EXISTS is TRUE for every
+  /// left row — the ANTI-join keeps them all.
+  @Test func `an empty matching inner keeps every ANTI left row`() throws {
+    try fixture().expect(
+        "SELECT T.Id FROM T " +
+        "WHERE NOT EXISTS (SELECT 1 FROM S WHERE S.k = T.Id AND S.x > 10000) " +
+        "ORDER BY T.Id",
+        yields: [[1], [2], [3]])
+  }
+
+  /// DUPLICATE LEFT ROWS (SEMI): a left relation with duplicate keys preserves
+  /// every duplicate that passes the existence test — the semijoin filters, it
+  /// does not dedup. Both copies of Id 1 survive; Id 3 (no child) drops.
+  @Test func `duplicate left rows are preserved by the semijoin`() throws {
+    let catalog = try Catalog {
+      Relation("T", ["Id": .integer]) {
+        Row(1)
+        Row(1)            // a duplicate left key
+        Row(3)
+      }
+      Relation("S", ["k": .integer, "x": .integer]) {
+        Row(1, 100)
+        Row(1, 101)       // Id 1 matches many; each left copy appears once
+      }
+    }
+    try catalog.expect(
+        "SELECT T.Id FROM T " +
+        "WHERE EXISTS (SELECT 1 FROM S WHERE S.k = T.Id)",
+        yields: [[1], [1]])
+  }
+
+  /// DUPLICATE LEFT ROWS (ANTI): the mirror — every duplicate that FAILS the
+  /// existence test is preserved. Both copies of Id 3 survive, Id 1 drops.
+  @Test func `duplicate left rows are preserved by the anti-join`() throws {
+    let catalog = try Catalog {
+      Relation("T", ["Id": .integer]) {
+        Row(3)
+        Row(3)            // a duplicate left key with no child
+        Row(1)
+      }
+      Relation("S", ["k": .integer, "x": .integer]) {
+        Row(1, 100)
+      }
+    }
+    try catalog.expect(
+        "SELECT T.Id FROM T " +
+        "WHERE NOT EXISTS (SELECT 1 FROM S WHERE S.k = T.Id)",
+        yields: [[3], [3]])
+  }
+
+  /// BODY RESIDUAL `p_R`: a safe local conjunct in the EXISTS WHERE (`S.x <
+  /// 200`) rides the semijoin `on` alongside the correlation key. Id 1 keeps a
+  /// matching child (100 or 101 < 200), Id 2's only child (200) fails it ⇒ Id 2
+  /// drops, Id 3 has none. Only Id 1 survives.
+  @Test func `a safe body residual filters the semijoin`() throws {
+    try fixture().expect(
+        "SELECT T.Id FROM T " +
+        "WHERE EXISTS (SELECT 1 FROM S WHERE S.k = T.Id AND S.x < 200) " +
+        "ORDER BY T.Id",
+        yields: [[1]])
+  }
+
+  /// A NULL body residual makes the match UNKNOWN — "not a match". A child with
+  /// a NULL `flag` and the body `S.flag = 1` yields UNKNOWN for that row, so it
+  /// does not satisfy EXISTS. Id 1's only child has a NULL flag ⇒ EXISTS false
+  /// ⇒ dropped; Id 2's child (flag 1) satisfies it ⇒ kept.
+  @Test func `a NULL body residual is not a match`() throws {
+    let catalog = try Catalog {
+      Relation("T", ["Id": .integer]) {
+        Row(1)
+        Row(2)
+      }
+      Relation("S", ["k": .integer, "flag": .integer]) {
+        Row(1, nil)       // flag NULL ⇒ S.flag = 1 UNKNOWN ⇒ not a match
+        Row(2, 1)         // flag 1 ⇒ a match
+      }
+    }
+    try catalog.expect(
+        "SELECT T.Id FROM T " +
+        "WHERE EXISTS (SELECT 1 FROM S WHERE S.k = T.Id AND S.flag = 1)",
+        yields: [[2]])
+  }
+
+  /// A SAFE SIBLING beside the EXISTS still decorrelates: `T.Id < 3 AND
+  /// EXISTS(...)`. Id 1 (child, < 3) survives, Id 2 (child, < 3) survives, Id 3
+  /// fails the sibling. The semijoin fires (a safe sibling permits it) and the
+  /// sibling stays in a `.select` above.
+  @Test func `a safe sibling conjunct still decorrelates`() throws {
+    let sql =
+        "SELECT T.Id FROM T " +
+        "WHERE T.Id < 3 AND EXISTS (SELECT 1 FROM S WHERE S.k = T.Id)"
+    let plan = try fixture().optimised(sql)
+    #expect(semijoins(plan, anti: false))
+    #expect(!exists(in: plan))
+    try fixture().expect(sql + " ORDER BY T.Id", yields: [[1], [2]])
+  }
+}
+
+// MARK: - EXISTS that STAYS correlated, run correctly (and adversarial throws)
+
+/// The excluded shapes: a body that is not a plain filter+project over a base
+/// scan, a non-equi correlation, an unsafe body term, an unsafe SIBLING, and an
+/// EXISTS nested in an `.or`. Each MUST stay a residual `.exists` (no
+/// `.semijoin`) and run correctly — and the two throw-visibility cases must
+/// throw exactly as the correlated plan does.
+struct DecorrelateExistsExclusionTests {
+  /// ADVERSARIAL SIBLING THROW-VISIBILITY (the step-4 guard, load-bearing): a
+  /// sibling `(1 / T.v) = 0` divides by zero for a T row whose `v = 0`,
+  /// AND that SAME row's EXISTS is FALSE. The correlated select evaluates the
+  /// whole `AND` for the row and THROWS `.divide`. A wrongly-decorrelated plan
+  /// would let the SEMIJOIN DROP that exists-false row and HIDE the throw. So
+  /// the recogniser MUST leave it correlated (unsafe sibling) — and the run
+  /// MUST throw.
+  @Test func `an unsafe sibling stays correlated and throws`() throws {
+    let catalog = try Catalog {
+      Relation("T", ["Id": .integer, "v": .integer]) {
+        Row(9, 0)         // v = 0 ⇒ 1 / v faults; Id 9 has NO child ⇒ EXISTS
+                          // false, so a semijoin drops it and hides the fault
+      }
+      Relation("S", ["k": .integer, "x": .integer]) {
+        Row(1, 100)       // keyed to Id 1, never to Id 9
+      }
+    }
+    let sql =
+        "SELECT T.Id FROM T " +
+        "WHERE (1 / T.v) = 0 AND EXISTS (SELECT 1 FROM S WHERE S.k = T.Id)"
+    let plan = try catalog.optimised(sql)
+    #expect(!semijoins(plan))                   // NOT decorrelated
+    #expect(exists(in: plan))                   // still a residual EXISTS
+    catalog.expect(sql, fails: .divide)         // and it MUST throw
+  }
+
+  /// ADVERSARIAL BODY THROW-VISIBILITY (G4): an EXISTS body carries an UNSAFE
+  /// term `1 / (S.x - 100) > 0` that divides by zero for the child `(1, 100)`,
+  /// which is keyed to the ABSENT Id 1. The per-row correlated run never binds
+  /// `:outer = 1`, so it never reaches that inner row and never throws. A
+  /// set-based semijoin over the whole `S` WOULD evaluate the divide. The
+  /// recogniser leaves it correlated (unsafe body), so the run is throw-free.
+  @Test func `an unreachable throwing body row stays correlated`() throws {
+    let catalog = try Catalog {
+      Relation("T", ["Id": .integer]) {
+        Row(2)
+        Row(3)
+      }
+      Relation("S", ["k": .integer, "x": .integer]) {
+        Row(1, 100)      // x - 100 = 0 ⇒ divide by zero, keyed to absent Id 1
+        Row(2, 200)      // safe for Id 2
+      }
+    }
+    let sql =
+        "SELECT T.Id FROM T WHERE EXISTS " +
+        "(SELECT 1 FROM S WHERE S.k = T.Id AND 1 / (S.x - 100) > 0)"
+    #expect(!semijoins(try catalog.optimised(sql)))
+    #expect(exists(in: try catalog.optimised(sql)))
+    // Id 2: child (2, 200) ⇒ 1 / 100 = 0 ⇒ `> 0` false ⇒ EXISTS false; Id 3:
+    // none. The Id-1 divide is never reached, so no rows and NO throw.
+    let rows = try catalog.run(parse(query: sql), .standard)
+    #expect(rows.isEmpty)
+  }
+
+  /// NON-EQUI correlation `S.k > T.Id`: no equi key to hash on, so the EXISTS
+  /// stays correlated and runs correctly. Id 1 has a child with k > 1 (k = 2),
+  /// Id 2 has none (only k ≤ 2), Id 3 none. Only Id 1 survives.
+  @Test func `a non-equi correlation stays an exists and runs correctly`()
+      throws {
+    let sql =
+        "SELECT T.Id FROM T " +
+        "WHERE EXISTS (SELECT 1 FROM S WHERE S.k > T.Id)"
+    #expect(!semijoins(try fixture().optimised(sql)))
+    #expect(exists(in: try fixture().optimised(sql)))
+    try fixture().expect(sql + " ORDER BY T.Id", yields: [[1]])
+  }
+
+  /// AGGREGATE body: a `COUNT(*)` body is not a plain filter+project,
+  /// so the EXISTS stays correlated. The body is always non-empty (COUNT of an
+  /// empty group yields a row), so EXISTS is TRUE for every left row — kept.
+  @Test func `an aggregate body stays an exists and runs correctly`() throws {
+    let sql =
+        "SELECT T.Id FROM T WHERE EXISTS " +
+        "(SELECT COUNT(*) FROM S WHERE S.k = T.Id)"
+    #expect(!semijoins(try fixture().optimised(sql)))
+    #expect(exists(in: try fixture().optimised(sql)))
+    try fixture().expect(sql + " ORDER BY T.Id", yields: [[1], [2], [3]])
+  }
+
+  /// LIMIT body: a `FETCH FIRST` body is not the canonical filter+project,
+  /// so the EXISTS stays correlated — and runs correctly (a body limited to one
+  /// row still exists iff a matching child exists). Id 1, Id 2 kept, Id 3 not.
+  @Test func `a limit body stays an exists and runs correctly`() throws {
+    let sql =
+        "SELECT T.Id FROM T WHERE EXISTS (SELECT x FROM S " +
+        "WHERE S.k = T.Id ORDER BY S.x FETCH FIRST 1 ROW ONLY)"
+    #expect(!semijoins(try fixture().optimised(sql)))
+    #expect(exists(in: try fixture().optimised(sql)))
+    try fixture().expect(sql + " ORDER BY T.Id", yields: [[1], [2]])
+  }
+
+  /// DISTINCT body: a `SELECT DISTINCT` body is not the canonical shape, so the
+  /// EXISTS stays correlated — and runs correctly (dedup does not change
+  /// existence). Id 1, Id 2 kept, Id 3 not.
+  @Test func `a distinct body stays an exists and runs correctly`() throws {
+    let sql =
+        "SELECT T.Id FROM T WHERE EXISTS " +
+        "(SELECT DISTINCT x FROM S WHERE S.k = T.Id)"
+    #expect(!semijoins(try fixture().optimised(sql)))
+    #expect(exists(in: try fixture().optimised(sql)))
+    try fixture().expect(sql + " ORDER BY T.Id", yields: [[1], [2]])
+  }
+
+  /// SETOP body: a `UNION` body is not the canonical single-scan shape, so the
+  /// EXISTS stays correlated — and runs correctly. Id 1, Id 2 have a matching
+  /// arm; Id 3 has none.
+  @Test func `a setop body stays an exists and runs correctly`() throws {
+    let sql =
+        "SELECT T.Id FROM T WHERE EXISTS " +
+        "(SELECT x FROM S WHERE S.k = T.Id " +
+        "UNION SELECT x FROM S WHERE S.k = T.Id)"
+    #expect(!semijoins(try fixture().optimised(sql)))
+    #expect(exists(in: try fixture().optimised(sql)))
+    try fixture().expect(sql + " ORDER BY T.Id", yields: [[1], [2]])
+  }
+
+  /// NESTED SUBQUERY in the body: the EXISTS body itself nests an `IN (Q)`, so
+  /// its plan is not the canonical filter+project over a single scan — it stays
+  /// correlated and runs correctly. Id 1, Id 2 have a child whose x is in the
+  /// inner set; Id 3 has none.
+  @Test func `a nested subquery body stays an exists and runs correctly`()
+      throws {
+    let sql =
+        "SELECT T.Id FROM T WHERE EXISTS (SELECT 1 FROM S " +
+        "WHERE S.k = T.Id AND S.x IN (SELECT x FROM S))"
+    #expect(!semijoins(try fixture().optimised(sql)))
+    #expect(exists(in: try fixture().optimised(sql)))
+    try fixture().expect(sql + " ORDER BY T.Id", yields: [[1], [2]])
+  }
+
+  /// BODY-LOCAL DERIVED table: the EXISTS body reads its OWN derived `e` (over
+  /// `S`), a per-execution alias the set-based rewrite cannot relay. It stays
+  /// correlated — and the derived `e` reads `S`, so Id 1, Id 2 are kept.
+  @Test func `a body-local derived table stays an exists`() throws {
+    let sql =
+        "SELECT T.Id FROM T WHERE EXISTS " +
+        "(SELECT 1 FROM (SELECT k FROM S) AS e WHERE e.k = T.Id)"
+    #expect(!semijoins(try fixture().optimised(sql)))
+    #expect(exists(in: try fixture().optimised(sql)))
+    try fixture().expect(sql + " ORDER BY T.Id", yields: [[1], [2]])
+  }
+
+  /// EXISTS INSIDE AN `.or`: an EXISTS that is NOT a top-level `AND` conjunct
+  /// (it sits under an `OR`) is left correlated — the recogniser lifts only a
+  /// top-level conjunct. `T.Id = 3 OR EXISTS(...)`: Id 3 (the OR's left) and
+  /// Ids 1, 2 (the EXISTS arm) survive.
+  @Test func `an EXISTS under an OR stays correlated and runs correctly`()
+      throws {
+    let sql =
+        "SELECT T.Id FROM T " +
+        "WHERE T.Id = 3 OR EXISTS (SELECT 1 FROM S WHERE S.k = T.Id)"
+    #expect(!semijoins(try fixture().optimised(sql)))
+    #expect(exists(in: try fixture().optimised(sql)))
+    try fixture().expect(sql + " ORDER BY T.Id", yields: [[1], [2], [3]])
   }
 }

--- a/Tests/SQLTests/Queries/EngineJoinTests.swift
+++ b/Tests/SQLTests/Queries/EngineJoinTests.swift
@@ -744,6 +744,8 @@ private func outers(_ plan: Plan) -> Bool {
     outers(left) || outers(right)
   case let .join(source, _, _, _, _, _, _):
     outers(source)
+  case let .semijoin(left, right, _, _):
+    outers(left) || outers(right)
   case let .apply(left, _, _, _, _, _):
     outers(left)
   case let .setop(_, left, right, _):

--- a/Tests/SQLTests/Queries/EngineViewAndPushdownTests.swift
+++ b/Tests/SQLTests/Queries/EngineViewAndPushdownTests.swift
@@ -289,6 +289,8 @@ func engineDerived(_ plan: Plan) -> Plan? {
     engineDerived(left) ?? engineDerived(right)
   case let .outer(left, right, _, _):
     engineDerived(left) ?? engineDerived(right)
+  case let .semijoin(left, right, _, _):
+    engineDerived(left) ?? engineDerived(right)
   case let .apply(left, _, _, _, _, _):
     engineDerived(left)
   case let .setop(_, left, right, _):
@@ -325,6 +327,8 @@ func engineSeeks(_ plan: Plan) -> Bool {
     engineSeeks(outer)
   case let .outer(left, right, _, _):
     engineSeeks(left) || engineSeeks(right)
+  case let .semijoin(left, right, _, _):
+    engineSeeks(left) || engineSeeks(right)
   case let .apply(left, _, _, _, _, _):
     engineSeeks(left)
   case let .setop(_, left, right, _):
@@ -358,6 +362,8 @@ func engineFilters(_ plan: Plan) -> Bool {
     engineFilters(left) || engineFilters(right)
   case let .outer(left, right, _, _):
     engineFilters(left) || engineFilters(right)
+  case let .semijoin(left, right, _, _):
+    engineFilters(left) || engineFilters(right)
   case let .apply(left, _, _, _, _, _):
     engineFilters(left)
   case let .setop(_, left, right, _):
@@ -387,6 +393,9 @@ func enginePushed(_ plan: Plan) -> Bool {
   case let .outer(left, right, _, _):
     engineSeeks(left) || engineFloats(left) || enginePushed(left) || engineSeeks(right)
         || engineFloats(right) || enginePushed(right)
+  case let .semijoin(left, right, _, _):
+    engineSeeks(left) || engineFloats(left) || enginePushed(left)
+        || engineSeeks(right) || engineFloats(right) || enginePushed(right)
   case let .apply(left, _, _, _, _, _):
     engineSeeks(left) || engineFloats(left) || enginePushed(left)
   case let .select(_, source):
@@ -451,6 +460,8 @@ func engineJoins(_ plan: Plan) -> Bool {
     engineJoins(left) || engineJoins(right)
   case let .outer(left, right, _, _):
     engineJoins(left) || engineJoins(right)
+  case let .semijoin(left, right, _, _):
+    engineJoins(left) || engineJoins(right)
   case let .apply(left, _, _, _, _, _):
     engineJoins(left)
   case let .setop(_, left, right, _):
@@ -486,6 +497,8 @@ func engineResidual(_ plan: Plan) -> Bool {
   case let .join(outer, _, _, _, _, _, _):
     engineResidual(outer)
   case let .outer(left, right, _, _):
+    engineResidual(left) || engineResidual(right)
+  case let .semijoin(left, right, _, _):
     engineResidual(left) || engineResidual(right)
   case let .apply(left, _, _, _, _, _):
     engineResidual(left)
@@ -524,6 +537,8 @@ func engineSeparated(_ plan: Plan) -> Bool {
     engineSeparated(outer)
   case let .outer(left, right, _, _):
     engineSeparated(left) || engineSeparated(right)
+  case let .semijoin(left, right, _, _):
+    engineSeparated(left) || engineSeparated(right)
   case let .apply(left, _, _, _, _, _):
     engineSeparated(left)
   case let .setop(_, left, right, _):
@@ -561,6 +576,8 @@ func engineStacked(_ plan: Plan) -> Bool {
   case let .join(outer, _, _, _, _, _, _):
     engineStacked(outer)
   case let .outer(left, right, _, _):
+    engineStacked(left) || engineStacked(right)
+  case let .semijoin(left, right, _, _):
     engineStacked(left) || engineStacked(right)
   case let .apply(left, _, _, _, _, _):
     engineStacked(left)
@@ -675,6 +692,8 @@ private func injected(_ plan: Plan) -> Bool {
   case let .product(left, right):
     injected(left) || injected(right)
   case let .outer(left, right, _, _):
+    injected(left) || injected(right)
+  case let .semijoin(left, right, _, _):
     injected(left) || injected(right)
   case let .apply(left, _, _, _, _, _):
     injected(left)


### PR DESCRIPTION
Extend the decorrelation pass, after CROSS APPLY and OUTER APPLY, to lift a top-level correlated EXISTS/NOT EXISTS conjunct into a new `.semijoin` Plan node — a SEMI (EXISTS) or ANTI (NOT EXISTS) existence test that keeps or drops each left row without appending the right's columns. A semijoin emits a left row at most once regardless of match count, so it is result-equivalent to the per-row `exists` re-execution while running as a single nested loop (or hash probe on a straddling equi key), turning O(left × right) into O(left + right).

The recogniser reuses the APPLY machinery and its guards (a plain filter+project over a single base scan, an equi correlation, safe non-parameterised body residuals, no body-local derived table), and adds a sibling throw-visibility guard: because a semijoin drops rows, it lifts an EXISTS only when every other conjunct of the enclosing filter is safe, or a dropped row could suppress a throw the correlated select raises. EXISTS is two-valued, so a NULL correlation key is simply "no match" — no NOT-IN NULL trap.