### PR TITLE
WinMD: stylistic adjustments to WinMD tables

### DIFF
--- a/Sources/WinMD/RowLayout.swift
+++ b/Sources/WinMD/RowLayout.swift
@@ -23,12 +23,12 @@ extension Field {
 /// fields preceding it. These offsets are a compile-time property of a schema;
 /// the wide indices of a particular database shift them by the width bitset at
 /// read time.
-internal func offsets<let N: Int>(_ fields: InlineArray<N, Field>)
+internal func offsets<let N: Int>(of fields: InlineArray<N, Field>)
     -> InlineArray<N, Int> {
-  InlineArray<N, Int> { i in
+  InlineArray<N, Int> { index in
     var offset = 0
-    for j in 0 ..< i {
-      offset = offset + fields[j].width
+    for position in 0 ..< index {
+      offset = offset + fields[position].width
     }
     return offset
   }

--- a/Sources/WinMD/Tables/Assembly.swift
+++ b/Sources/WinMD/Tables/Assembly.swift
@@ -24,7 +24,7 @@ private let _fields: InlineArray<_, Field> = [
   Field(name: "Culture", type: .index(.heap(.string))),
 ]
 
-private let _offsets = offsets(_fields)
+private let offsets = WinMD.offsets(of: _fields)
 
 extension Metadata.Tables {
 /// See §II.22.2.
@@ -36,7 +36,7 @@ public enum Assembly: TableSchema {
   }
 
   public static func offset(_ i: Int) -> Int {
-    _offsets[i]
+    offsets[i]
   }
 }
 }

--- a/Sources/WinMD/Tables/AssemblyOS.swift
+++ b/Sources/WinMD/Tables/AssemblyOS.swift
@@ -12,7 +12,7 @@ private let _fields: InlineArray<_, Field> = [
   Field(name: "OSMinorVersion", type: .constant(4)),
 ]
 
-private let _offsets = offsets(_fields)
+private let offsets = WinMD.offsets(of: _fields)
 
 extension Metadata.Tables {
 public enum AssemblyOS: TableSchema {
@@ -23,7 +23,7 @@ public enum AssemblyOS: TableSchema {
   }
 
   public static func offset(_ i: Int) -> Int {
-    _offsets[i]
+    offsets[i]
   }
 }
 }

--- a/Sources/WinMD/Tables/AssemblyProcessor.swift
+++ b/Sources/WinMD/Tables/AssemblyProcessor.swift
@@ -8,7 +8,7 @@ private let _fields: InlineArray<_, Field> = [
   Field(name: "Processor", type: .constant(4)),
 ]
 
-private let _offsets = offsets(_fields)
+private let offsets = WinMD.offsets(of: _fields)
 
 extension Metadata.Tables {
 /// See §II.22.4.
@@ -20,7 +20,7 @@ public enum AssemblyProcessor: TableSchema {
   }
 
   public static func offset(_ i: Int) -> Int {
-    _offsets[i]
+    offsets[i]
   }
 }
 }

--- a/Sources/WinMD/Tables/AssemblyRef.swift
+++ b/Sources/WinMD/Tables/AssemblyRef.swift
@@ -24,7 +24,7 @@ private let _fields: InlineArray<_, Field> = [
   Field(name: "HashValue", type: .index(.heap(.blob))),
 ]
 
-private let _offsets = offsets(_fields)
+private let offsets = WinMD.offsets(of: _fields)
 
 extension Metadata.Tables {
 /// See §II.22.5.
@@ -36,7 +36,7 @@ public enum AssemblyRef: TableSchema {
   }
 
   public static func offset(_ i: Int) -> Int {
-    _offsets[i]
+    offsets[i]
   }
 }
 }

--- a/Sources/WinMD/Tables/AssemblyRefOS.swift
+++ b/Sources/WinMD/Tables/AssemblyRefOS.swift
@@ -14,7 +14,7 @@ private let _fields: InlineArray<_, Field> = [
   Field(name: "AssemblyRef", type: .index(.simple(Metadata.Tables.AssemblyRef.self))),
 ]
 
-private let _offsets = offsets(_fields)
+private let offsets = WinMD.offsets(of: _fields)
 
 extension Metadata.Tables {
 /// See §II.22.3.
@@ -26,7 +26,7 @@ public enum AssemblyRefOS: TableSchema {
   }
 
   public static func offset(_ i: Int) -> Int {
-    _offsets[i]
+    offsets[i]
   }
 }
 }

--- a/Sources/WinMD/Tables/AssemblyRefProcessor.swift
+++ b/Sources/WinMD/Tables/AssemblyRefProcessor.swift
@@ -10,7 +10,7 @@ private let _fields: InlineArray<_, Field> = [
   Field(name: "AssemblyRef", type: .index(.simple(Metadata.Tables.AssemblyRef.self))),
 ]
 
-private let _offsets = offsets(_fields)
+private let offsets = WinMD.offsets(of: _fields)
 
 extension Metadata.Tables {
 /// See §II.22.7.
@@ -22,7 +22,7 @@ public enum AssemblyRefProcessor: TableSchema {
   }
 
   public static func offset(_ i: Int) -> Int {
-    _offsets[i]
+    offsets[i]
   }
 }
 }

--- a/Sources/WinMD/Tables/ClassLayout.swift
+++ b/Sources/WinMD/Tables/ClassLayout.swift
@@ -12,7 +12,7 @@ private let _fields: InlineArray<_, Field> = [
   Field(name: "Parent", type: .index(.simple(Metadata.Tables.TypeDef.self))),
 ]
 
-private let _offsets = offsets(_fields)
+private let offsets = WinMD.offsets(of: _fields)
 
 extension Metadata.Tables {
 /// See §II.22.8.
@@ -27,7 +27,7 @@ public enum ClassLayout: TableSchema {
   }
 
   public static func offset(_ i: Int) -> Int {
-    _offsets[i]
+    offsets[i]
   }
 }
 }

--- a/Sources/WinMD/Tables/Constant.swift
+++ b/Sources/WinMD/Tables/Constant.swift
@@ -13,7 +13,7 @@ private let _fields: InlineArray<_, Field> = [
   Field(name: "Value", type: .index(.heap(.blob))),
 ]
 
-private let _offsets = offsets(_fields)
+private let offsets = WinMD.offsets(of: _fields)
 
 extension Metadata.Tables {
 /// See §II.22.9.
@@ -28,7 +28,7 @@ public enum Constant: TableSchema {
   }
 
   public static func offset(_ i: Int) -> Int {
-    _offsets[i]
+    offsets[i]
   }
 }
 }

--- a/Sources/WinMD/Tables/CustomAttribute.swift
+++ b/Sources/WinMD/Tables/CustomAttribute.swift
@@ -12,7 +12,7 @@ private let _fields: InlineArray<_, Field> = [
   Field(name: "Value", type: .index(.heap(.blob))),
 ]
 
-private let _offsets = offsets(_fields)
+private let offsets = WinMD.offsets(of: _fields)
 
 extension Metadata.Tables {
 /// See §II.22.10.
@@ -27,7 +27,7 @@ public enum CustomAttribute: TableSchema {
   }
 
   public static func offset(_ i: Int) -> Int {
-    _offsets[i]
+    offsets[i]
   }
 }
 }

--- a/Sources/WinMD/Tables/DeclSecurity.swift
+++ b/Sources/WinMD/Tables/DeclSecurity.swift
@@ -12,7 +12,7 @@ private let _fields: InlineArray<_, Field> = [
   Field(name: "PermissionSet", type: .index(.heap(.blob))),
 ]
 
-private let _offsets = offsets(_fields)
+private let offsets = WinMD.offsets(of: _fields)
 
 extension Metadata.Tables {
 /// See §II.22.11.
@@ -27,7 +27,7 @@ public enum DeclSecurity: TableSchema {
   }
 
   public static func offset(_ i: Int) -> Int {
-    _offsets[i]
+    offsets[i]
   }
 }
 }

--- a/Sources/WinMD/Tables/EventDef.swift
+++ b/Sources/WinMD/Tables/EventDef.swift
@@ -12,7 +12,7 @@ private let _fields: InlineArray<_, Field> = [
   Field(name: "EventType", type: .index(.coded(TypeDefOrRef.self)))
 ]
 
-private let _offsets = offsets(_fields)
+private let offsets = WinMD.offsets(of: _fields)
 
 extension Metadata.Tables {
 /// See §II.22.13.
@@ -24,7 +24,7 @@ public enum EventDef: TableSchema {
   }
 
   public static func offset(_ i: Int) -> Int {
-    _offsets[i]
+    offsets[i]
   }
 }
 }

--- a/Sources/WinMD/Tables/EventMap.swift
+++ b/Sources/WinMD/Tables/EventMap.swift
@@ -10,7 +10,7 @@ private let _fields: InlineArray<_, Field> = [
   Field(name: "EventList", type: .index(.simple(Metadata.Tables.EventDef.self))),
 ]
 
-private let _offsets = offsets(_fields)
+private let offsets = WinMD.offsets(of: _fields)
 
 extension Metadata.Tables {
 /// See §II.22.12.
@@ -22,7 +22,7 @@ public enum EventMap: TableSchema {
   }
 
   public static func offset(_ i: Int) -> Int {
-    _offsets[i]
+    offsets[i]
   }
 }
 }

--- a/Sources/WinMD/Tables/ExportedType.swift
+++ b/Sources/WinMD/Tables/ExportedType.swift
@@ -16,7 +16,7 @@ private let _fields: InlineArray<_, Field> = [
   Field(name: "Implementation", type: .index(.coded(Implementation.self))),
 ]
 
-private let _offsets = offsets(_fields)
+private let offsets = WinMD.offsets(of: _fields)
 
 extension Metadata.Tables {
 /// See §II.22.14.
@@ -28,7 +28,7 @@ public enum ExportedType: TableSchema {
   }
 
   public static func offset(_ i: Int) -> Int {
-    _offsets[i]
+    offsets[i]
   }
 }
 }

--- a/Sources/WinMD/Tables/FieldDef.swift
+++ b/Sources/WinMD/Tables/FieldDef.swift
@@ -12,7 +12,7 @@ private let _fields: InlineArray<_, Field> = [
   Field(name: "Signature", type: .index(.heap(.blob))),
 ]
 
-private let _offsets = offsets(_fields)
+private let offsets = WinMD.offsets(of: _fields)
 
 extension Metadata.Tables {
 /// See §II.22.15.
@@ -24,7 +24,7 @@ public enum FieldDef: TableSchema {
   }
 
   public static func offset(_ i: Int) -> Int {
-    _offsets[i]
+    offsets[i]
   }
 }
 }

--- a/Sources/WinMD/Tables/FieldLayout.swift
+++ b/Sources/WinMD/Tables/FieldLayout.swift
@@ -10,7 +10,7 @@ private let _fields: InlineArray<_, Field> = [
   Field(name: "Column", type: .index(.simple(Metadata.Tables.FieldDef.self))),
 ]
 
-private let _offsets = offsets(_fields)
+private let offsets = WinMD.offsets(of: _fields)
 
 extension Metadata.Tables {
 /// See §II.22.16.
@@ -25,7 +25,7 @@ public enum FieldLayout: TableSchema {
   }
 
   public static func offset(_ i: Int) -> Int {
-    _offsets[i]
+    offsets[i]
   }
 }
 }

--- a/Sources/WinMD/Tables/FieldMarshal.swift
+++ b/Sources/WinMD/Tables/FieldMarshal.swift
@@ -10,7 +10,7 @@ private let _fields: InlineArray<_, Field> = [
   Field(name: "NativeType", type: .index(.heap(.blob))),
 ]
 
-private let _offsets = offsets(_fields)
+private let offsets = WinMD.offsets(of: _fields)
 
 extension Metadata.Tables {
 /// See §II.22.17.
@@ -25,7 +25,7 @@ public enum FieldMarshal: TableSchema {
   }
 
   public static func offset(_ i: Int) -> Int {
-    _offsets[i]
+    offsets[i]
   }
 }
 }

--- a/Sources/WinMD/Tables/FieldRVA.swift
+++ b/Sources/WinMD/Tables/FieldRVA.swift
@@ -10,7 +10,7 @@ private let _fields: InlineArray<_, Field> = [
   Field(name: "Column", type: .index(.simple(Metadata.Tables.FieldDef.self))),
 ]
 
-private let _offsets = offsets(_fields)
+private let offsets = WinMD.offsets(of: _fields)
 
 extension Metadata.Tables {
 /// See §II.22.18.
@@ -25,7 +25,7 @@ public enum FieldRVA: TableSchema {
   }
 
   public static func offset(_ i: Int) -> Int {
-    _offsets[i]
+    offsets[i]
   }
 }
 }

--- a/Sources/WinMD/Tables/File.swift
+++ b/Sources/WinMD/Tables/File.swift
@@ -12,7 +12,7 @@ private let _fields: InlineArray<_, Field> = [
   Field(name: "HashValue", type: .index(.heap(.blob))),
 ]
 
-private let _offsets = offsets(_fields)
+private let offsets = WinMD.offsets(of: _fields)
 
 extension Metadata.Tables {
 /// See §II.22.19.
@@ -24,7 +24,7 @@ public enum File: TableSchema {
   }
 
   public static func offset(_ i: Int) -> Int {
-    _offsets[i]
+    offsets[i]
   }
 }
 }

--- a/Sources/WinMD/Tables/GenericParam.swift
+++ b/Sources/WinMD/Tables/GenericParam.swift
@@ -14,7 +14,7 @@ private let _fields: InlineArray<_, Field> = [
   Field(name: "Name", type: .index(.heap(.string))),
 ]
 
-private let _offsets = offsets(_fields)
+private let offsets = WinMD.offsets(of: _fields)
 
 extension Metadata.Tables {
 /// See §II.22.20.
@@ -29,7 +29,7 @@ public enum GenericParam: TableSchema {
   }
 
   public static func offset(_ i: Int) -> Int {
-    _offsets[i]
+    offsets[i]
   }
 }
 }

--- a/Sources/WinMD/Tables/GenericParamConstraint.swift
+++ b/Sources/WinMD/Tables/GenericParamConstraint.swift
@@ -10,7 +10,7 @@ private let _fields: InlineArray<_, Field> = [
   Field(name: "Constraint", type: .index(.coded(TypeDefOrRef.self))),
 ]
 
-private let _offsets = offsets(_fields)
+private let offsets = WinMD.offsets(of: _fields)
 
 extension Metadata.Tables {
 /// See §II.22.21.
@@ -25,7 +25,7 @@ public enum GenericParamConstraint: TableSchema {
   }
 
   public static func offset(_ i: Int) -> Int {
-    _offsets[i]
+    offsets[i]
   }
 }
 }

--- a/Sources/WinMD/Tables/ImplMap.swift
+++ b/Sources/WinMD/Tables/ImplMap.swift
@@ -14,7 +14,7 @@ private let _fields: InlineArray<_, Field> = [
   Field(name: "ImportScope", type: .index(.simple(Metadata.Tables.ModuleRef.self))),
 ]
 
-private let _offsets = offsets(_fields)
+private let offsets = WinMD.offsets(of: _fields)
 
 extension Metadata.Tables {
 /// See §II.22.22.
@@ -29,7 +29,7 @@ public enum ImplMap: TableSchema {
   }
 
   public static func offset(_ i: Int) -> Int {
-    _offsets[i]
+    offsets[i]
   }
 }
 }

--- a/Sources/WinMD/Tables/InterfaceImpl.swift
+++ b/Sources/WinMD/Tables/InterfaceImpl.swift
@@ -10,7 +10,7 @@ private let _fields: InlineArray<_, Field> = [
   Field(name: "Interface", type: .index(.coded(TypeDefOrRef.self))),
 ]
 
-private let _offsets = offsets(_fields)
+private let offsets = WinMD.offsets(of: _fields)
 
 extension Metadata.Tables {
 /// See §II.22.23.
@@ -25,7 +25,7 @@ public enum InterfaceImpl: TableSchema {
   }
 
   public static func offset(_ i: Int) -> Int {
-    _offsets[i]
+    offsets[i]
   }
 }
 }

--- a/Sources/WinMD/Tables/ManifestResource.swift
+++ b/Sources/WinMD/Tables/ManifestResource.swift
@@ -14,7 +14,7 @@ private let _fields: InlineArray<_, Field> = [
   Field(name: "Implementation", type: .index(.coded(Implementation.self))),
 ]
 
-private let _offsets = offsets(_fields)
+private let offsets = WinMD.offsets(of: _fields)
 
 extension Metadata.Tables {
 /// See §II.22.24.
@@ -26,7 +26,7 @@ public enum ManifestResource: TableSchema {
   }
 
   public static func offset(_ i: Int) -> Int {
-    _offsets[i]
+    offsets[i]
   }
 }
 }

--- a/Sources/WinMD/Tables/MemberRef.swift
+++ b/Sources/WinMD/Tables/MemberRef.swift
@@ -12,7 +12,7 @@ private let _fields: InlineArray<_, Field> = [
   Field(name: "Signature", type: .index(.heap(.blob))),
 ]
 
-private let _offsets = offsets(_fields)
+private let offsets = WinMD.offsets(of: _fields)
 
 extension Metadata.Tables {
 /// See §II.22.25.
@@ -24,7 +24,7 @@ public enum MemberRef: TableSchema {
   }
 
   public static func offset(_ i: Int) -> Int {
-    _offsets[i]
+    offsets[i]
   }
 }
 }

--- a/Sources/WinMD/Tables/MethodDef.swift
+++ b/Sources/WinMD/Tables/MethodDef.swift
@@ -18,7 +18,7 @@ private let _fields: InlineArray<_, Field> = [
   Field(name: "ParamList", type: .index(.simple(Metadata.Tables.Param.self))),
 ]
 
-private let _offsets = offsets(_fields)
+private let offsets = WinMD.offsets(of: _fields)
 
 extension Metadata.Tables {
 /// See §II.22.26.
@@ -30,7 +30,7 @@ public enum MethodDef: TableSchema {
   }
 
   public static func offset(_ i: Int) -> Int {
-    _offsets[i]
+    offsets[i]
   }
 }
 }

--- a/Sources/WinMD/Tables/MethodImpl.swift
+++ b/Sources/WinMD/Tables/MethodImpl.swift
@@ -12,7 +12,7 @@ private let _fields: InlineArray<_, Field> = [
   Field(name: "MethodDeclaration", type: .index(.coded(MethodDefOrRef.self))),
 ]
 
-private let _offsets = offsets(_fields)
+private let offsets = WinMD.offsets(of: _fields)
 
 extension Metadata.Tables {
 /// See §II.22.27.
@@ -27,7 +27,7 @@ public enum MethodImpl: TableSchema {
   }
 
   public static func offset(_ i: Int) -> Int {
-    _offsets[i]
+    offsets[i]
   }
 }
 }

--- a/Sources/WinMD/Tables/MethodSemantics.swift
+++ b/Sources/WinMD/Tables/MethodSemantics.swift
@@ -12,7 +12,7 @@ private let _fields: InlineArray<_, Field> = [
   Field(name: "Association", type: .index(.coded(HasSemantics.self))),
 ]
 
-private let _offsets = offsets(_fields)
+private let offsets = WinMD.offsets(of: _fields)
 
 extension Metadata.Tables {
 /// See §II.22.28.
@@ -27,7 +27,7 @@ public enum MethodSemantics: TableSchema {
   }
 
   public static func offset(_ i: Int) -> Int {
-    _offsets[i]
+    offsets[i]
   }
 }
 }

--- a/Sources/WinMD/Tables/MethodSpec.swift
+++ b/Sources/WinMD/Tables/MethodSpec.swift
@@ -10,7 +10,7 @@ private let _fields: InlineArray<_, Field> = [
   Field(name: "Instantiation", type: .index(.heap(.blob))),
 ]
 
-private let _offsets = offsets(_fields)
+private let offsets = WinMD.offsets(of: _fields)
 
 extension Metadata.Tables {
 /// See §II.22.29.
@@ -22,7 +22,7 @@ public enum MethodSpec: TableSchema {
   }
 
   public static func offset(_ i: Int) -> Int {
-    _offsets[i]
+    offsets[i]
   }
 }
 }

--- a/Sources/WinMD/Tables/Module.swift
+++ b/Sources/WinMD/Tables/Module.swift
@@ -18,7 +18,7 @@ private let _fields: InlineArray<_, Field> = [
   Field(name: "EncBaseId", type: .index(.heap(.guid))),
 ]
 
-private let _offsets = offsets(_fields)
+private let offsets = WinMD.offsets(of: _fields)
 
 extension Metadata.Tables {
 /// See §II.22.30.
@@ -30,7 +30,7 @@ public enum Module: TableSchema {
   }
 
   public static func offset(_ i: Int) -> Int {
-    _offsets[i]
+    offsets[i]
   }
 }
 }

--- a/Sources/WinMD/Tables/ModuleRef.swift
+++ b/Sources/WinMD/Tables/ModuleRef.swift
@@ -8,7 +8,7 @@ private let _fields: InlineArray<_, Field> = [
   Field(name: "Name", type: .index(.heap(.string))),
 ]
 
-private let _offsets = offsets(_fields)
+private let offsets = WinMD.offsets(of: _fields)
 
 extension Metadata.Tables {
 /// See §II.22.31.
@@ -20,7 +20,7 @@ public enum ModuleRef: TableSchema {
   }
 
   public static func offset(_ i: Int) -> Int {
-    _offsets[i]
+    offsets[i]
   }
 }
 }

--- a/Sources/WinMD/Tables/NestedClass.swift
+++ b/Sources/WinMD/Tables/NestedClass.swift
@@ -10,7 +10,7 @@ private let _fields: InlineArray<_, Field> = [
   Field(name: "EnclosingClass", type: .index(.simple(Metadata.Tables.TypeDef.self))),
 ]
 
-private let _offsets = offsets(_fields)
+private let offsets = WinMD.offsets(of: _fields)
 
 extension Metadata.Tables {
 /// See §II.22.32.
@@ -25,7 +25,7 @@ public enum NestedClass: TableSchema {
   }
 
   public static func offset(_ i: Int) -> Int {
-    _offsets[i]
+    offsets[i]
   }
 }
 }

--- a/Sources/WinMD/Tables/Param.swift
+++ b/Sources/WinMD/Tables/Param.swift
@@ -12,7 +12,7 @@ private let _fields: InlineArray<_, Field> = [
   Field(name: "Name", type: .index(.heap(.string))),
 ]
 
-private let _offsets = offsets(_fields)
+private let offsets = WinMD.offsets(of: _fields)
 
 extension Metadata.Tables {
 /// See §II.22.33.
@@ -24,7 +24,7 @@ public enum Param: TableSchema {
   }
 
   public static func offset(_ i: Int) -> Int {
-    _offsets[i]
+    offsets[i]
   }
 }
 }

--- a/Sources/WinMD/Tables/PropertyDef.swift
+++ b/Sources/WinMD/Tables/PropertyDef.swift
@@ -12,7 +12,7 @@ private let _fields: InlineArray<_, Field> = [
   Field(name: "Type", type: .index(.heap(.blob))),
 ]
 
-private let _offsets = offsets(_fields)
+private let offsets = WinMD.offsets(of: _fields)
 
 extension Metadata.Tables {
 /// See §II.22.34.
@@ -24,7 +24,7 @@ public enum PropertyDef: TableSchema {
   }
 
   public static func offset(_ i: Int) -> Int {
-    _offsets[i]
+    offsets[i]
   }
 }
 }

--- a/Sources/WinMD/Tables/PropertyMap.swift
+++ b/Sources/WinMD/Tables/PropertyMap.swift
@@ -10,7 +10,7 @@ private let _fields: InlineArray<_, Field> = [
   Field(name: "PropertyList", type: .index(.simple(Metadata.Tables.PropertyDef.self))),
 ]
 
-private let _offsets = offsets(_fields)
+private let offsets = WinMD.offsets(of: _fields)
 
 extension Metadata.Tables {
 /// See §II.22.35.
@@ -22,7 +22,7 @@ public enum PropertyMap: TableSchema {
   }
 
   public static func offset(_ i: Int) -> Int {
-    _offsets[i]
+    offsets[i]
   }
 }
 }

--- a/Sources/WinMD/Tables/StandAloneSig.swift
+++ b/Sources/WinMD/Tables/StandAloneSig.swift
@@ -8,7 +8,7 @@ private let _fields: InlineArray<_, Field> = [
   Field(name: "Signature", type: .index(.heap(.blob))),
 ]
 
-private let _offsets = offsets(_fields)
+private let offsets = WinMD.offsets(of: _fields)
 
 extension Metadata.Tables {
 /// See §II.22.36.
@@ -20,7 +20,7 @@ public enum StandAloneSig: TableSchema {
   }
 
   public static func offset(_ i: Int) -> Int {
-    _offsets[i]
+    offsets[i]
   }
 }
 }

--- a/Sources/WinMD/Tables/TypeDef.swift
+++ b/Sources/WinMD/Tables/TypeDef.swift
@@ -18,7 +18,7 @@ private let _fields: InlineArray<_, Field> = [
   Field(name: "MethodList", type: .index(.simple(Metadata.Tables.MethodDef.self))),
 ]
 
-private let _offsets = offsets(_fields)
+private let offsets = WinMD.offsets(of: _fields)
 
 extension Metadata.Tables {
 /// See §II.22.37.
@@ -30,7 +30,7 @@ public enum TypeDef: TableSchema {
   }
 
   public static func offset(_ i: Int) -> Int {
-    _offsets[i]
+    offsets[i]
   }
 }
 }

--- a/Sources/WinMD/Tables/TypeRef.swift
+++ b/Sources/WinMD/Tables/TypeRef.swift
@@ -12,7 +12,7 @@ private let _fields: InlineArray<_, Field> = [
   Field(name: "TypeNamespace", type: .index(.heap(.string))),
 ]
 
-private let _offsets = offsets(_fields)
+private let offsets = WinMD.offsets(of: _fields)
 
 extension Metadata.Tables {
 /// See §II.22.38.
@@ -24,7 +24,7 @@ public enum TypeRef: TableSchema {
   }
 
   public static func offset(_ i: Int) -> Int {
-    _offsets[i]
+    offsets[i]
   }
 }
 }

--- a/Sources/WinMD/Tables/TypeSpec.swift
+++ b/Sources/WinMD/Tables/TypeSpec.swift
@@ -8,7 +8,7 @@ private let _fields: InlineArray<_, Field> = [
   Field(name: "Signature", type: .index(.heap(.blob))),
 ]
 
-private let _offsets = offsets(_fields)
+private let offsets = WinMD.offsets(of: _fields)
 
 extension Metadata.Tables {
 /// See §II.22.39.
@@ -20,7 +20,7 @@ public enum TypeSpec: TableSchema {
   }
 
   public static func offset(_ i: Int) -> Int {
-    _offsets[i]
+    offsets[i]
   }
 }
 }


### PR DESCRIPTION
Resignature `WinMD.offsets(_:)` to `WinMD.offsets(of:)` and use that to bind to a local `offsets`. This removes some unnecessary underscoring. Ideally, we would do the same for `_fields`.