### PR TITLE
SQLEngine: add the ISO `TABLE t` query primary

### DIFF
--- a/Sources/SQLEngine/Lexer.swift
+++ b/Sources/SQLEngine/Lexer.swift
@@ -408,6 +408,7 @@ internal struct Lexer: ~Escapable {
     case "FUNCTION": .function
     case "RETURNS": .returns
     case "SELECT": .select
+    case "TABLE": .table
     case "DISTINCT": .distinct
     case "FROM": .from
     case "WHERE": .where

--- a/Sources/SQLEngine/Parser.swift
+++ b/Sources/SQLEngine/Parser.swift
@@ -19,7 +19,8 @@
 /// cte            := identifier ['(' identifier (',' identifier)* ')']
 ///                   AS '(' query ')'
 /// query          := intersection ((UNION | EXCEPT) [ALL] intersection)*
-/// intersection   := select (INTERSECT [ALL] select)*
+/// intersection   := term (INTERSECT [ALL] term)*
+/// term           := select | TABLE identifier   // TABLE t = SELECT * FROM t
 /// select         := SELECT [DISTINCT | ALL] projection
 ///                   [FROM relation (join)*
 ///                    [where] [group] [having] [order] [limit]]
@@ -226,22 +227,43 @@ internal struct Parser: ~Escapable {
     return query
   }
 
-  /// Parses `select (INTERSECT [ALL] select)*`, the inner set-operation tier,
+  /// Parses `term (INTERSECT [ALL] term)*`, the inner set-operation tier,
   /// left-associative.
   ///
-  /// The leading `SELECT` is the seed `Query`; each `INTERSECT` (optionally
-  /// `ALL`) folds the next `SELECT` onto the right. `INTERSECT` binds tighter
+  /// The leading `term` is the seed `Query`; each `INTERSECT` (optionally
+  /// `ALL`) folds the next `term` onto the right. `INTERSECT` binds tighter
   /// than `UNION`/`EXCEPT`, so this tier is fully consumed before the outer
   /// `query` tier folds a `UNION`/`EXCEPT` around it. `INTERSECT ALL` keeps
   /// duplicate rows to the lesser multiplicity; a bare `INTERSECT` removes
   /// them.
   private mutating func intersection() throws(SQLError) -> Query {
-    var query = try Query.select(select())
+    var query = try term()
     while try match(.intersect) {
       let all = try match(.all)
-      query = try .setop(.intersect, query, .select(select()), all: all)
+      query = try .setop(.intersect, query, term(), all: all)
     }
     return query
+  }
+
+  /// Parses a query primary — a `SELECT …` or the ISO `TABLE t` shorthand — the
+  /// leaf both set-operation tiers compose over.
+  ///
+  /// `TABLE t` is exactly `SELECT * FROM t` (ISO 9075 `<explicit table>`): it
+  /// lowers to the SAME AST a star-projection single-relation select builds — a
+  /// `.all` projection over one named `Relation`, no `WHERE`/`GROUP`/`HAVING`/
+  /// order/limit — so compile, execute, and the `SELECT *` column expansion all
+  /// apply unchanged and it composes with `UNION`/`INTERSECT`/`EXCEPT` as a
+  /// parenthesised select would. The operand is a bare table or view NAME (the
+  /// same `identifier` a relation names); a derived table is not admitted, as
+  /// `TABLE (…)` is not an ISO form. Ordering is a select-internal clause here,
+  /// so a `TABLE t ORDER BY …` tail is not accepted at this primary level — the
+  /// `SELECT * FROM t ORDER BY …` spelling carries an order.
+  private mutating func term() throws(SQLError) -> Query {
+    guard try match(.table) else {
+      return try .select(select())
+    }
+    let name = try identifier()
+    return .select(Select(projection: .all, from: Relation(name: name)))
   }
 
   /// Parses a `CREATE` statement — `CREATE VIEW …` or `CREATE FUNCTION …` (the
@@ -444,7 +466,8 @@ internal struct Parser: ~Escapable {
       guard let token = current else {
         throw .incomplete(expected: "a derived table '(SELECT …)'")
       }
-      guard token.kind == .select else {
+      // A derived table is any query, so `TABLE t` opens one as `SELECT` does.
+      guard [.select, .table].contains(token.kind) else {
         throw .unexpected(token.kind.description,
                           expected: "a derived table '(SELECT …)'",
                           at: token.location)
@@ -656,12 +679,12 @@ internal struct Parser: ~Escapable {
   private mutating func factor() throws(SQLError) -> Expression {
     if try match(.lparen) {
       // ONE token of lookahead after `(` disambiguates a SCALAR SUBQUERY from a
-      // parenthesised expression: a `SELECT` begins a subquery — `(query)`, the
-      // first-class `Expression.subquery` (the query may itself be a `UNION`) —
-      // and anything else begins a parenthesised expression. No rewind is
-      // needed: `SELECT` never begins an expression, so the peek is
+      // parenthesised expression: a `SELECT` or `TABLE` begins a subquery —
+      // `(query)`, the first-class `Expression.subquery` (the query may itself
+      // be a `UNION`) — and anything else begins a parenthesised expression. No
+      // rewind is needed: neither keyword begins an expression, so the peek is
       // unambiguous, exactly as the `IN (…)` and `EXISTS (…)` lookaheads are.
-      if current?.kind == .select {
+      if [.select, .table].contains(current?.kind) {
         let query = try query()
         try expect(.rparen)
         return .subquery(query)
@@ -1166,7 +1189,7 @@ internal struct Parser: ~Escapable {
   private mutating func membership(_ left: Expression, negated: Bool)
       throws(SQLError) -> Predicate {
     try expect(.lparen)
-    if current?.kind == .select {
+    if [.select, .table].contains(current?.kind) {
       let query = try query()
       try expect(.rparen)
       return .within(left, query, negated: negated)

--- a/Sources/SQLEngine/Token.swift
+++ b/Sources/SQLEngine/Token.swift
@@ -22,6 +22,9 @@ extension Token {
     case function
     case returns
     case select
+    /// The `TABLE` keyword introducing the `TABLE t` query primary — the ISO
+    /// shorthand for `SELECT * FROM t`.
+    case table
     case distinct
     case from
     case `where`
@@ -134,6 +137,7 @@ extension Token.Kind {
     case .function: "FUNCTION"
     case .returns: "RETURNS"
     case .select: "SELECT"
+    case .table: "TABLE"
     case .distinct: "DISTINCT"
     case .from: "FROM"
     case .where: "WHERE"

--- a/Tests/SQLTests/Queries/TableTests.swift
+++ b/Tests/SQLTests/Queries/TableTests.swift
@@ -1,0 +1,158 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQLEngine
+
+import SQLTestSupport
+import func SQLTestSupport.parse
+
+// MARK: - TABLE t
+
+/// The ISO `TABLE t` query primary is exactly `SELECT * FROM t`. These tests
+/// confirm it lowers to the SAME star-projection single-relation `Select`,
+/// resolves a base table AND a view identically, and composes with the
+/// set-operation tiers as a bare `SELECT *` does.
+struct TableTests {
+  @Test func `TABLE t lowers to a star-projection SELECT over the named relation`() throws {
+    // The primary builds the same AST `SELECT * FROM People` does: a `.all`
+    // projection over one named `Relation`, with no WHERE/GROUP/HAVING/order.
+    guard case let .select(select) = try parse(query: "TABLE People") else {
+      Issue.record("expected a single-SELECT query")
+      return
+    }
+    #expect(select.projection == .all)
+    #expect(select.table == "People")
+    #expect(select.predicate == nil)
+    #expect(select.grouping.isEmpty)
+    #expect(select.having == nil)
+    #expect(select.order == nil)
+    #expect(select.limit == nil)
+    #expect(select.joins.isEmpty)
+  }
+
+  @Test func `TABLE t parses the same AST as SELECT star FROM t`() throws {
+    let table = try parse(query: "TABLE People")
+    let star = try parse(query: "SELECT * FROM People")
+    #expect(table == star)
+  }
+
+  @Test func `TABLE t yields every row and column of SELECT star FROM t`() throws {
+    try enginePeople().expect("TABLE People", equals: "SELECT * FROM People")
+  }
+
+  @Test func `TABLE t yields the full row/column set`() throws {
+    try enginePeople().expect("TABLE People", yields: [
+      [1, "Alice", 30],
+      [2, "Bob", 25],
+      [3, "Carol", 30],
+      [4, "Dave", 40],
+      [5, "Eve", 25],
+    ])
+  }
+
+  @Test func `TABLE over a view resolves as the view relation`() throws {
+    // `Adults` is a registered view; `TABLE Adults` resolves it by name exactly
+    // as `SELECT * FROM Adults` does, exposing the view's Key/Label columns.
+    try engineViews().expect("TABLE Adults", equals: "SELECT * FROM Adults")
+    try engineViews().expect("TABLE Adults", yields: [[2, "Bee"], [3, "Cid"]])
+  }
+
+  @Test func `TABLE a UNION TABLE b composes with a set operation`() throws {
+    // Each arm is a `TABLE` primary; the UNION merges and dedups the shared row
+    // exactly as the two-SELECT spelling does.
+    try engineTags().expect("TABLE Lhs UNION TABLE Rhs",
+                            equals: "SELECT * FROM Lhs UNION SELECT * FROM Rhs")
+    try engineTags().expect("TABLE Lhs UNION TABLE Rhs",
+                            yields: [["a"], ["shared"], ["b"]])
+  }
+
+  @Test func `a TABLE primary mixes with a SELECT arm across a set operation`() throws {
+    // The primary composes on either side of the operator, so one arm may be a
+    // `TABLE` and the other a `SELECT`.
+    try engineTags().expect("TABLE Lhs UNION ALL SELECT Tag FROM Rhs",
+                            yields: [["a"], ["shared"], ["shared"], ["b"]])
+  }
+
+  @Test func `TABLE composes at the tighter INTERSECT tier`() throws {
+    try engineTags().expect("TABLE Lhs INTERSECT TABLE Rhs",
+                            yields: [["shared"]])
+  }
+
+  @Test func `TABLE t admits no trailing ORDER BY at the primary level`() throws {
+    // Ordering is a SELECT-internal clause in this grammar, not a
+    // query-expression clause, so a `TABLE t ORDER BY …` tail is not part of
+    // the primary — the trailing tokens fault. `SELECT * FROM t ORDER BY …`
+    // carries an order.
+    #expect(throws: SQLError.self) {
+      _ = try parse(query: "TABLE People ORDER BY Age")
+    }
+  }
+
+  @Test func `TABLE requires a relation name, not a derived table`() throws {
+    // `TABLE (…)` is not an ISO form; the operand is a bare table/view name, so
+    // a parenthesised subquery in its place faults.
+    #expect(throws: SQLError.self) {
+      _ = try parse(query: "TABLE (SELECT * FROM People)")
+    }
+  }
+
+  // MARK: - (TABLE …) in a query position
+
+  // A parenthesised query — a derived table, a scalar subquery, or an
+  // IN-subquery — may open with `TABLE` exactly as it opens with `SELECT`,
+  // since `TABLE t` is itself a query. Each form parses and runs identically to
+  // its `(SELECT * FROM t)` spelling.
+
+  @Test func `a (TABLE t) derived table parses and runs as (SELECT star FROM t)`() throws {
+    // `FROM (TABLE People) AS d` is a derived table whose body is the `TABLE`
+    // primary; it selects the same rows the `(SELECT * FROM People)` body does.
+    _ = try parse(query: "SELECT * FROM (TABLE People) AS d")
+    try enginePeople().expect(
+        "SELECT * FROM (TABLE People) AS d",
+        equals: "SELECT * FROM (SELECT * FROM People) AS d")
+    try enginePeople().expect("SELECT d.Name FROM (TABLE People) AS d",
+                              yields: [["Alice"], ["Bob"], ["Carol"],
+                                       ["Dave"], ["Eve"]])
+  }
+
+  @Test func `a (TABLE t) scalar subquery parses and runs as (SELECT star FROM t)`() throws {
+    // `One` is one row of one column, so `(TABLE One)` is a valid scalar
+    // subquery — it yields that single cell, exactly as `(SELECT * FROM One)`.
+    _ = try parse(query: "SELECT (TABLE One) FROM One")
+    try engineScalars().expect("SELECT (TABLE One) FROM One",
+                               equals: "SELECT (SELECT * FROM One) FROM One")
+    try engineScalars().expect("SELECT (TABLE One) FROM One", yields: [[42]])
+  }
+
+  @Test func `an x IN (TABLE t) subquery parses and runs as IN (SELECT star FROM t)`() throws {
+    // `Ids` is a single column, so `Tag IN (TABLE Ids)` is a valid IN-subquery,
+    // membership over that column exactly as `IN (SELECT * FROM Ids)`.
+    _ = try parse(query: "SELECT V FROM Vals WHERE V IN (TABLE Ids)")
+    try engineScalars().expect(
+        "SELECT V FROM Vals WHERE V IN (TABLE Ids)",
+        equals: "SELECT V FROM Vals WHERE V IN (SELECT * FROM Ids)")
+    try engineScalars().expect("SELECT V FROM Vals WHERE V IN (TABLE Ids)",
+                               yields: [[1], [3]])
+  }
+}
+
+/// A catalog for the scalar-subquery and IN-subquery `(TABLE …)` forms: `One`
+/// is one row of one column (a valid scalar subquery), `Ids` is a single column
+/// (a valid IN-subquery), and `Vals` is the probe relation the IN filters.
+func engineScalars() throws -> EngineMemory {
+  try Catalog {
+    Relation("One", ["N": .integer]) {
+      Row(42)
+    }
+    Relation("Ids", ["Key": .integer]) {
+      Row(1)
+      Row(3)
+    }
+    Relation("Vals", ["V": .integer]) {
+      Row(1)
+      Row(2)
+      Row(3)
+    }
+  }
+}


### PR DESCRIPTION
`TABLE t` is the ISO 9075 shorthand for `SELECT * FROM t`. Recognise it at the query-primary tier (the leaf both set-operation tiers compose over), lowering it to the SAME AST a star-projection single-relation select builds: a `.all` projection over one named `Relation`, no WHERE/GROUP/HAVING/order/ limit. Reusing that select leaves compile, execute, and `SELECT *` column expansion unchanged, and it composes with UNION/INTERSECT/EXCEPT exactly as a bare `SELECT *` arm does.

The operand is a bare table or view name; a derived table is not admitted, as `TABLE (…)` is not an ISO form. Ordering stays a select-internal clause here, so no trailing ORDER BY attaches at the primary level.