### PR TITLE
SQLEngine: add explicit CROSS JOIN

### DIFF
--- a/Sources/SQLEngine/Lexer.swift
+++ b/Sources/SQLEngine/Lexer.swift
@@ -429,6 +429,7 @@ internal struct Lexer: ~Escapable {
     case "JOIN": .join
     case "LATERAL": .lateral
     case "INNER": .inner
+    case "CROSS": .cross
     case "LEFT": .left
     case "RIGHT": .right
     case "FULL": .full

--- a/Sources/SQLEngine/Parser.swift
+++ b/Sources/SQLEngine/Parser.swift
@@ -26,8 +26,9 @@
 /// relation       := (identifier | [LATERAL] derived) [AS identifier]
 ///                   // LATERAL is legal only on a derived table in a join
 /// derived        := '(' query ')' AS identifier  // a derived table (aliased)
-/// join           := [INNER | (LEFT | RIGHT | FULL) [OUTER]] JOIN
-///                     relation ON predicate
+/// join           := ([INNER | (LEFT | RIGHT | FULL) [OUTER]] JOIN
+///                     relation ON predicate)
+///                  | (CROSS JOIN relation)  // Cartesian product, no ON/USING
 ///                   // INNER JOIN LATERAL = CROSS APPLY, LEFT = OUTER APPLY;
 ///                   // the derived body may reference preceding FROM items
 /// projection     := '*' | column (',' column)*
@@ -375,7 +376,7 @@ internal struct Parser: ~Escapable {
 
     var joins = Array<Join>()
     while let kind = try joinKind() {
-      try joins.append(join(kind))
+      try joins.append(join(kind.kind, cross: kind.cross))
     }
     let predicate: Predicate? = if try match(.where) {
       try predicate()
@@ -493,15 +494,24 @@ internal struct Parser: ~Escapable {
   }
 
   /// Parses an optional join `kind` and its `JOIN` keyword at the current
-  /// position, or `nil` when no join clause begins here.
+  /// position, or `nil` when no join clause begins here. The `cross` flag marks
+  /// a `CROSS JOIN` — an unqualified Cartesian product taking no `ON`/`USING`.
   ///
   /// A bare `JOIN` (or an explicit `INNER JOIN`) is `.inner`; `LEFT`/`RIGHT`/
   /// `FULL` introduce an outer join, each admitting an optional `OUTER` noise
-  /// word before the mandatory `JOIN`. A leading `INNER`/`LEFT`/`RIGHT`/`FULL`
-  /// commits to a join clause, so a missing `JOIN` after it faults rather than
-  /// silently ending the join chain.
-  private mutating func joinKind() throws(SQLError) -> Join.Kind? {
-    if try match(.join) { return .inner }
+  /// word before the mandatory `JOIN`; `CROSS` introduces a Cartesian product,
+  /// lowered as an `.inner` join over a synthesized always-true predicate. A
+  /// leading `INNER`/`CROSS`/`LEFT`/`RIGHT`/`FULL` commits to a join clause, so
+  /// a missing `JOIN` after it faults rather than silently ending the chain.
+  private mutating func joinKind()
+      throws(SQLError) -> (kind: Join.Kind, cross: Bool)? {
+    if try match(.join) { return (.inner, false) }
+    if try match(.cross) {
+      // `CROSS JOIN` is the Cartesian product; it carries no inner/outer word
+      // and no `ON`, and lowers as an `.inner` join over an always-true `on`.
+      try expect(.join)
+      return (.inner, true)
+    }
     let kind: Join.Kind
     if try match(.inner) {
       kind = .inner
@@ -518,18 +528,32 @@ internal struct Parser: ~Escapable {
     // carries it. Either way `JOIN` must follow.
     if kind != .inner { _ = try match(.outer) }
     try expect(.join)
-    return kind
+    return (kind, false)
   }
 
   /// Parses the join tail (the `kind` and `JOIN` keyword are already consumed):
-  /// a relation, `ON`, and an arbitrary boolean predicate — the same grammar a
-  /// `WHERE` admits, so a join relates its sides by an equality, an inequality,
-  /// an expression equality, or any `AND`/`OR`/`NOT` of comparisons. A pure
-  /// `column = column` conjunct hash-joins; the rest is a residual filter.
-  private mutating func join(_ kind: Join.Kind) throws(SQLError) -> Join {
+  /// a relation and, unless `cross`, an `ON` and an arbitrary boolean predicate
+  /// — the same grammar a `WHERE` admits, so a join relates its sides by an
+  /// equality, an inequality, an expression equality, or any `AND`/`OR`/`NOT`
+  /// of comparisons. A pure `column = column` conjunct hash-joins; the rest is
+  /// a residual filter.
+  ///
+  /// A `CROSS JOIN` (`cross`) takes NO `ON`/`USING` — a trailing `ON` is a
+  /// syntax error, caught by leaving `on` unconsumed for the caller's `where`/
+  /// end-of-select expectation to reject. Its `on` is a synthesized `1 = 1`,
+  /// which lowers to a constant-true filter the optimiser elides, collapsing
+  /// the join to a bare `.product` — the Cartesian product, equivalent to an
+  /// inner join written `ON 1 = 1`.
+  private mutating func join(_ kind: Join.Kind,
+                             cross: Bool) throws(SQLError) -> Join {
     let relation = try relation()
-    try expect(.on)
-    let on = try predicate()
+    guard cross else {
+      try expect(.on)
+      let on = try predicate()
+      return Join(relation: relation, kind: kind, on: on)
+    }
+    let on = Predicate.comparison(left: .literal(.integer(1)), op: .equal,
+                                  right: .literal(.integer(1)))
     return Join(relation: relation, kind: kind, on: on)
   }
 

--- a/Sources/SQLEngine/Token.swift
+++ b/Sources/SQLEngine/Token.swift
@@ -47,6 +47,9 @@ extension Token {
     /// may reference the preceding FROM items (a correlated apply).
     case lateral
     case inner
+    /// The `CROSS` keyword introducing a `CROSS JOIN` — the unqualified
+    /// Cartesian product of two relations, admitting no `ON`/`USING` clause.
+    case cross
     case left
     case right
     case full
@@ -152,6 +155,7 @@ extension Token.Kind {
     case .join: "JOIN"
     case .lateral: "LATERAL"
     case .inner: "INNER"
+    case .cross: "CROSS"
     case .left: "LEFT"
     case .right: "RIGHT"
     case .full: "FULL"

--- a/Tests/SQLTests/Queries/EngineCrossJoinTests.swift
+++ b/Tests/SQLTests/Queries/EngineCrossJoinTests.swift
@@ -1,0 +1,110 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQLEngine
+
+import SQLTestSupport
+
+// MARK: - Cross-join tests
+
+struct EngineCrossJoinTests {
+  @Test func `a CROSS JOIN yields every pair of the two relations`() throws {
+    // `family` has three Parent rows and four Child rows, so the Cartesian
+    // product is 3 × 4 = 12 rows — every parent paired with every child.
+    let rows = try engineJoin("SELECT * FROM Parent CROSS JOIN Child")
+    #expect(rows.count == 12)
+  }
+
+  @Test func `a CROSS JOIN yields the full product in outer-major order`() throws {
+    // The exact Cartesian product: each Parent row (outer) paired in turn with
+    // every Child row (inner), the combined columns laid Parent-then-Child.
+    let rows = try engineJoin("SELECT * FROM Parent CROSS JOIN Child")
+    let expected: Array<Array<Value>> = [
+      [.integer(1), .text("Ada"), .integer(1), .text("Ann")],
+      [.integer(1), .text("Ada"), .integer(1), .text("Amy")],
+      [.integer(1), .text("Ada"), .integer(2), .text("Bob")],
+      [.integer(1), .text("Ada"), .integer(9), .text("Orphan")],
+      [.integer(2), .text("Bee"), .integer(1), .text("Ann")],
+      [.integer(2), .text("Bee"), .integer(1), .text("Amy")],
+      [.integer(2), .text("Bee"), .integer(2), .text("Bob")],
+      [.integer(2), .text("Bee"), .integer(9), .text("Orphan")],
+      [.integer(3), .text("Cid"), .integer(1), .text("Ann")],
+      [.integer(3), .text("Cid"), .integer(1), .text("Amy")],
+      [.integer(3), .text("Cid"), .integer(2), .text("Bob")],
+      [.integer(3), .text("Cid"), .integer(9), .text("Orphan")],
+    ]
+    #expect(rows == expected)
+  }
+
+  @Test func `a CROSS JOIN equals an inner join on a true predicate`() throws {
+    // A CROSS JOIN synthesizes an always-true `ON`, so it is identical to an
+    // inner join written with an explicit `ON 1 = 1`.
+    try engineFamily().expect(
+        "SELECT * FROM Parent CROSS JOIN Child",
+        equals: "SELECT * FROM Parent JOIN Child ON 1 = 1")
+  }
+
+  @Test func `a CROSS JOIN lays the columns left-then-right`() throws {
+    // The combined row is the outer relation's columns (Parent: Id, Name)
+    // followed by the inner's (Child: Pid, Name) — the same a-then-b layout the
+    // comma product and inner join produce.
+    let rows = try engineJoin("SELECT * FROM Parent CROSS JOIN Child")
+    #expect(rows.first == [.integer(1), .text("Ada"),
+                           .integer(1), .text("Ann")])
+  }
+
+  @Test func `a CROSS JOIN composes in a chain with an inner join`() throws {
+    // `Parent CROSS JOIN Child JOIN Ordered ON …` crosses Parent with Child,
+    // then inner-joins Ordered keyed off the child's `Pid` against the ordered
+    // relation's virtual `Id`. Every (parent, child) pair whose child `Pid`
+    // names an `Ordered` row survives, gaining that row's `Label`.
+    let rows = try engineJoin("""
+        SELECT Parent.Name, Child.Name, Ordered.Label
+          FROM Parent CROSS JOIN Child
+          JOIN Ordered ON Ordered.Id = Child.Pid
+        """)
+    // Children with Pid 1 (Ann, Amy) → "first", Pid 2 (Bob) → "second"; the
+    // orphan (Pid 9) drops. Each surviving child pairs with all three parents.
+    #expect(rows.count == 9)
+    #expect(rows.allSatisfy { $0[2] == .text("first")
+                              || $0[2] == .text("second") })
+  }
+
+  @Test func `an inner join composes in a chain with a trailing CROSS JOIN`() throws {
+    // `Parent JOIN Child ON … CROSS JOIN Ordered` keeps the three matched
+    // (parent, child) pairs, then crosses each with all three `Ordered` rows —
+    // 3 × 3 = 9 rows.
+    let rows = try engineJoin("""
+        SELECT Parent.Name, Child.Name, Ordered.Label
+          FROM Parent JOIN Child ON Child.Pid = Parent.Id
+          CROSS JOIN Ordered
+        """)
+    #expect(rows.count == 9)
+  }
+
+  @Test func `a CROSS JOIN optimises to a bare product`() throws {
+    // The synthesized constant-true `ON` lowers to a filter the optimiser
+    // proves always-true and elides, so the plan collapses to a bare `.product`
+    // with no wrapping `.select` — the same plan the comma product produces.
+    let catalog = try engineFamily()
+    let select = try engineParse("SELECT * FROM Parent CROSS JOIN Child")
+    let compiled = try catalog.compile(select)
+    let plan = try catalog.optimise(compiled.pushdown(), [:])
+    #expect(engineIsProduct(plan))
+  }
+}
+
+/// Whether `plan` is a bare `.product` (optionally under a `.project`), with no
+/// intervening `.select` — the shape a CROSS JOIN collapses to once the
+/// optimiser elides its constant-true residual.
+private func engineIsProduct(_ plan: Plan) -> Bool {
+  switch plan {
+  case .product:
+    true
+  case let .project(_, source):
+    engineIsProduct(source)
+  default:
+    false
+  }
+}

--- a/Tests/SQLTests/Syntax/ParserTests.swift
+++ b/Tests/SQLTests/Syntax/ParserTests.swift
@@ -544,6 +544,30 @@ struct JoinTests {
       _ = try Statement(parsing: "SELECT * FROM A LEFT B ON a.x = b.x")
     }
   }
+
+  @Test func `a CROSS JOIN is an inner join over a constant-true ON`() throws {
+    // `CROSS JOIN` parses to an `.inner` join whose synthesized `ON` is the
+    // always-true `1 = 1`, so it shares the inner-join lowering and the
+    // optimiser elides the constant filter down to a bare product.
+    let select = try parse(select: "SELECT * FROM A CROSS JOIN B")
+    #expect(select.joins == [
+      Join(relation: Relation(name: "B"), kind: .inner,
+           on: .comparison(left: .literal(.integer(1)), op: .equal,
+                           right: .literal(.integer(1)))),
+    ])
+  }
+
+  @Test func `a CROSS JOIN with an ON faults`() {
+    #expect(throws: SQLError.self) {
+      _ = try Statement(parsing: "SELECT * FROM A CROSS JOIN B ON a.x = b.x")
+    }
+  }
+
+  @Test func `a CROSS without JOIN faults`() {
+    #expect(throws: SQLError.self) {
+      _ = try Statement(parsing: "SELECT * FROM A CROSS B")
+    }
+  }
 }
 
 // MARK: - Literals


### PR DESCRIPTION
Parse `a CROSS JOIN b` as the unqualified Cartesian product: the `CROSS` keyword followed by a mandatory `JOIN` and a relation, with no `ON`/`USING` clause (a trailing `ON` is a syntax error).

A CROSS JOIN reuses the inner-join machinery rather than adding a Plan node: `join` synthesizes an always-true `1 = 1` predicate, so the join lowers as an `.inner` `.select(on, .product(...))`. The optimiser already elides a provably constant-true filter, collapsing the join to a bare `.product` — the same plan and rows as an inner join written `ON 1 = 1`, laying the columns left-then-right.