### PR TITLE
SQLEngine: add ISO row-value comparisons and IN

### DIFF
--- a/Sources/SQLEngine/AST.swift
+++ b/Sources/SQLEngine/AST.swift
@@ -852,6 +852,29 @@ public indirect enum Predicate: Hashable, Sendable {
   /// lowers it to that disjunction rather than carrying a dedicated `Filter`
   /// case.
   case membership(Expression, Array<Expression>, negated: Bool)
+  /// `(l1, …, ln) <op> (r1, …, rn)` — an ISO `<row value constructor>`
+  /// comparison, both sides a row of scalar `Expression`s of EQUAL arity
+  /// (`SQLError.arity` at compile otherwise), `op` any of the six operators. It
+  /// is a FIRST-CLASS node rather than a parse-time desugar to a
+  /// conjunction/cascade of scalar comparisons so that each component
+  /// `Expression` is evaluated EXACTLY ONCE: the desugar duplicated a component
+  /// across the places it appears (a `<` cascade names an earlier component in
+  /// both a strict step and an equality tie-guard), so a stateful component
+  /// yielded a different value each time. It keeps the ISO three-valued
+  /// semantics — `=` the conjunction of the componentwise equalities, `<>` its
+  /// negation, the ordering operators the lexicographic cascade — lowered to a
+  /// `Filter.comparison` the runtime evaluates once-per-component.
+  case rows(Array<Expression>, Comparison, Array<Expression>)
+  /// `(l1, …, ln) [NOT] IN ((r1, …, rn), …)` — an ISO row-value membership, the
+  /// left a `<row value constructor>` and the right a non-empty list of element
+  /// rows, each of EQUAL arity (`SQLError.arity` otherwise), `negated` marking
+  /// `NOT IN`. As `rows`, it is a FIRST-CLASS node rather than a desugar to an
+  /// OR-chain of row equalities so the left components are evaluated EXACTLY
+  /// ONCE rather than once per element row. It keeps the value-list `IN`'s
+  /// three-valued semantics — a disjunction of row equalities under Kleene
+  /// `OR`, a NULL component making an unmatched test UNKNOWN, `NOT IN` its
+  /// negation — lowered to a `Filter.memberships`.
+  case among(Array<Expression>, Array<Array<Expression>>, negated: Bool)
   /// `operand [NOT] LIKE pattern [ESCAPE escape]` — whether the operand's text
   /// matches the pattern, in which `%` matches any sequence of characters
   /// (including the empty one) and `_` matches exactly one character; every

--- a/Sources/SQLEngine/Engine.swift
+++ b/Sources/SQLEngine/Engine.swift
@@ -970,6 +970,11 @@ extension Predicate {
       operand.aggregated
     case let .membership(operand, values, _):
       operand.aggregated || values.contains { $0.aggregated }
+    case let .rows(lhs, _, rhs):
+      lhs.contains { $0.aggregated } || rhs.contains { $0.aggregated }
+    case let .among(lhs, rows, _):
+      lhs.contains { $0.aggregated }
+          || rows.contains { $0.contains { $0.aggregated } }
     case .exists:
       // A subquery is its OWN scope, so an aggregate inside it folds over its
       // group, not the enclosing one — it never makes the OUTER query an
@@ -1013,6 +1018,10 @@ extension Predicate {
       operand.bound
     case let .membership(operand, values, _):
       operand.bound || values.contains { $0.bound }
+    case let .rows(lhs, _, rhs):
+      lhs.contains { $0.bound } || rhs.contains { $0.bound }
+    case let .among(lhs, rows, _):
+      lhs.contains { $0.bound } || rows.contains { $0.contains { $0.bound } }
     case let .exists(query, _):
       // A `:parameter` inside a subquery binds against the SAME run bindings
       // (the subquery runs under the enclosing context), so a defined-function
@@ -1240,6 +1249,14 @@ extension Predicate {
     case let .membership(operand, values, _):
       operand.collect(subqueries: &queries)
       for value in values { value.collect(subqueries: &queries) }
+    case let .rows(lhs, _, rhs):
+      for expression in lhs { expression.collect(subqueries: &queries) }
+      for expression in rhs { expression.collect(subqueries: &queries) }
+    case let .among(lhs, rows, _):
+      for expression in lhs { expression.collect(subqueries: &queries) }
+      for element in rows {
+        for expression in element { expression.collect(subqueries: &queries) }
+      }
     case let .like(operand, pattern, escape, _):
       operand.collect(subqueries: &queries)
       pattern.collect(subqueries: &queries)
@@ -1300,6 +1317,14 @@ extension Predicate {
     case let .membership(operand, values, _):
       operand.collect(valued: &queries)
       for value in values { value.collect(valued: &queries) }
+    case let .rows(lhs, _, rhs):
+      for expression in lhs { expression.collect(valued: &queries) }
+      for expression in rhs { expression.collect(valued: &queries) }
+    case let .among(lhs, rows, _):
+      for expression in lhs { expression.collect(valued: &queries) }
+      for element in rows {
+        for expression in element { expression.collect(valued: &queries) }
+      }
     case let .like(operand, pattern, escape, _):
       operand.collect(valued: &queries)
       pattern.collect(valued: &queries)
@@ -1346,6 +1371,14 @@ extension Predicate {
     case let .membership(operand, values, _):
       operand.collect(scalar: &queries)
       for value in values { value.collect(scalar: &queries) }
+    case let .rows(lhs, _, rhs):
+      for expression in lhs { expression.collect(scalar: &queries) }
+      for expression in rhs { expression.collect(scalar: &queries) }
+    case let .among(lhs, rows, _):
+      for expression in lhs { expression.collect(scalar: &queries) }
+      for element in rows {
+        for expression in element { expression.collect(scalar: &queries) }
+      }
     case let .like(operand, pattern, escape, _):
       operand.collect(scalar: &queries)
       pattern.collect(scalar: &queries)
@@ -1392,6 +1425,16 @@ extension Predicate {
     case let .membership(operand, values, _):
       operand.collect(existential: &queries)
       for value in values { value.collect(existential: &queries) }
+    case let .rows(lhs, _, rhs):
+      for expression in lhs { expression.collect(existential: &queries) }
+      for expression in rhs { expression.collect(existential: &queries) }
+    case let .among(lhs, rows, _):
+      for expression in lhs { expression.collect(existential: &queries) }
+      for element in rows {
+        for expression in element {
+          expression.collect(existential: &queries)
+        }
+      }
     case let .like(operand, pattern, escape, _):
       operand.collect(existential: &queries)
       pattern.collect(existential: &queries)
@@ -1918,6 +1961,14 @@ extension Predicate {
     case let .membership(operand, values, _):
       operand.collect(into: &expressions)
       for value in values { value.collect(into: &expressions) }
+    case let .rows(lhs, _, rhs):
+      for expression in lhs { expression.collect(into: &expressions) }
+      for expression in rhs { expression.collect(into: &expressions) }
+    case let .among(lhs, rows, _):
+      for expression in lhs { expression.collect(into: &expressions) }
+      for element in rows {
+        for expression in element { expression.collect(into: &expressions) }
+      }
     case .exists:
       // A subquery is its own scope — an aggregate inside it folds over its
       // group, not the enclosing one — so it contributes none here.

--- a/Sources/SQLEngine/Filter.swift
+++ b/Sources/SQLEngine/Filter.swift
@@ -38,6 +38,35 @@ internal indirect enum Filter: Equatable, Sendable {
   /// first TRUE; `NOT IN` negates that three-valued truth (UNKNOWN maps to
   /// itself).
   case membership(Term, Array<Term>, negated: Bool)
+  /// `(l1, …, ln) <op> (r1, …, rn)` — an ISO row-value comparison, both sides a
+  /// row of ordinal-addressed terms of EQUAL arity, `op` any of the six
+  /// operators. The lowered form of the AST's `rows`. Every component term is
+  /// evaluated exactly ONCE per row into a `[Value]` (a parse-time desugar to a
+  /// conjunction/cascade of scalar `compare`s re-evaluated a component once per
+  /// place it appeared, so a stateful component yielded a different value each
+  /// time), then the runtime folds those values with the SAME `matches`
+  /// primitive and Kleene `AND`/`OR` a scalar comparison uses, reproducing the
+  /// ISO three-valued truth: `=` is the Kleene `AND` of the componentwise
+  /// equalities, `<>` its negation, and the four ordering operators the
+  /// lexicographic cascade `l1 <op> r1 OR (l1 = r1 AND (l2 <op> r2 OR …))`
+  /// whose earlier steps use the STRICT operator (`<`/`>`) and whose innermost
+  /// step carries `op` itself (so `<=`/`>=` admit an all-equal row) — a NULL
+  /// component making a componentwise test UNKNOWN, threaded through the fold.
+  case comparison(Array<Term>, Comparison, Array<Term>)
+  /// `(l1, …, ln) [NOT] IN ((r1, …, rn), …)` — an ISO row-value membership, the
+  /// left a row of ordinal-addressed terms and `rows` a non-empty list of
+  /// element rows of EQUAL arity, `negated` marking `NOT IN`. The lowered form
+  /// of the AST's `among`. The left row is evaluated exactly ONCE per row into
+  /// a `[Value]` (as a scalar `Filter.membership` holds its operand once), then
+  /// `(l…) = (r…)` folds over the element rows IN ORDER under Kleene `OR`,
+  /// seeded FALSE, short-circuiting at the first TRUE — each element equality
+  /// the same componentwise Kleene `AND` the `=` comparison uses — so a NULL
+  /// component keeps the ISO three-valued result (an unmatched test is UNKNOWN,
+  /// not FALSE), an empty match FALSE, and `NOT IN` negates that truth (UNKNOWN
+  /// maps to itself). A desugar to an OR-chain of scalar row equalities would
+  /// re-evaluate the left components once per element; holding them once fixes
+  /// that.
+  case memberships(Array<Term>, Array<Array<Term>>, negated: Bool)
   /// `operand [NOT] LIKE pattern [ESCAPE escape]` — the lowered form of the
   /// AST's `like`. The operand is a `Term` evaluated per row; the pattern and
   /// optional one-character escape are each an `Operand` — a `Term` or a
@@ -468,6 +497,13 @@ extension Filter {
       .membership(operand.remapped(through: slot),
                   elements.map { $0.remapped(through: slot) },
                   negated: negated)
+    case let .comparison(lhs, op, rhs):
+      .comparison(lhs.map { $0.remapped(through: slot) }, op,
+                  rhs.map { $0.remapped(through: slot) })
+    case let .memberships(lhs, rows, negated):
+      .memberships(lhs.map { $0.remapped(through: slot) },
+                   rows.map { $0.map { $0.remapped(through: slot) } },
+                   negated: negated)
     case let .like(operand, pattern, escape, negated):
       .like(operand.remapped(through: slot),
             pattern: pattern.remapped(through: slot),
@@ -573,6 +609,10 @@ extension Filter {
     case let .null(term, _): term.safe
     case let .membership(operand, elements, _):
       operand.safe && elements.allSatisfy(\.safe)
+    case let .comparison(lhs, _, rhs):
+      lhs.allSatisfy(\.safe) && rhs.allSatisfy(\.safe)
+    case let .memberships(lhs, rows, _):
+      lhs.allSatisfy(\.safe) && rows.allSatisfy { $0.allSatisfy(\.safe) }
     case let .like(operand, pattern, escape, _):
       // An escape makes the predicate UNSAFE unless it is STATICALLY a valid
       // single-character escape: `Row.like` faults (`SQLError.argument`) on any
@@ -643,8 +683,11 @@ extension Filter {
     // UNKNOWN, slotless yet not definite — so both stay off a pushdown ahead of
     // a later unsafe conjunct the non-short-circuiting `AND` still owes.
     case .within, .quantified: true
-    case .compare, .bound, .match, .null, .membership, .like, .between,
-         .distinct, .exists: false
+    // A row comparison and row `IN` read slots (their components), so they are
+    // never slotless-UNKNOWN; `nullable`'s `slots` term already accounts for
+    // them, exactly as the scalar `.compare`/`.membership` do.
+    case .compare, .bound, .match, .null, .membership, .comparison,
+         .memberships, .like, .between, .distinct, .exists: false
     case let .truth(inner, _, _): inner.contingent
     case let .and(lhs, rhs): lhs.contingent || rhs.contingent
     case let .or(lhs, rhs): lhs.contingent || rhs.contingent
@@ -676,6 +719,12 @@ extension Filter {
     case let .null(term, _): term.parameterised
     case let .membership(operand, elements, _):
       operand.parameterised || elements.contains(where: \.parameterised)
+    case let .comparison(lhs, _, rhs):
+      lhs.contains(where: \.parameterised)
+          || rhs.contains(where: \.parameterised)
+    case let .memberships(lhs, rows, _):
+      lhs.contains(where: \.parameterised)
+          || rows.contains { $0.contains(where: \.parameterised) }
     case let .distinct(lhs, rhs, _): lhs.parameterised || rhs.parameterised
     case .match: false
     // An UNCORRELATED subquery predicate reads no run-time `:parameter` of the
@@ -731,9 +780,11 @@ extension Filter {
       // never folded.
       matches(lhs, op, rhs)
     // A comparison against a non-constant term reads a slot or `:parameter`;
-    // its truth is not statically known.
-    case .compare, .bound, .match, .null, .membership, .like, .between,
-         .distinct, .exists, .within, .quantified:
+    // its truth is not statically known. A row comparison and row `IN` are not
+    // statically folded — CONSERVATIVE, matching `.membership`/`.between`.
+    case .compare, .bound, .match, .null, .membership, .comparison,
+         .memberships, .like, .between, .distinct, .exists, .within,
+         .quantified:
       nil
     case let .and(lhs, rhs):
       // Both operands must be DEFINITE: a compile-time constant is only sound
@@ -1393,6 +1444,53 @@ internal func distinct(_ lhs: Value, _ rhs: Value) -> Bool {
   }
 }
 
+/// The three-valued truth of an ISO row-value comparison `(l…) <op> (r…)` over
+/// two ALREADY-EVALUATED rows of EQUAL, non-empty arity — the shared fold both
+/// the runtime (`Filter.comparison`) and the empty-group pre-fold drive so the
+/// two agree by construction.
+///
+/// `=` is the Kleene `AND` of the componentwise `matches(l[i], =, r[i])` (FALSE
+/// dominating — short-circuited), `<>` its negation (UNKNOWN mapping to
+/// itself), and the four ordering operators the lexicographic cascade `l0 <op>
+/// r0 OR (l0 = r0 AND (l1 <op> r1 OR …))`, right-nested from the last component
+/// inward — the innermost step carrying `op` itself (so `<=`/`>=` admit an
+/// all-equal row), every earlier step the STRICT operator (`<`/`>`) tie-guarded
+/// by the componentwise equality. A NULL component makes a componentwise test
+/// UNKNOWN, propagated through the Kleene fold.
+internal func relate(_ l: Array<Value>, _ op: Comparison,
+                     _ r: Array<Value>) -> Bool? {
+  switch op {
+  case .equal:
+    var truth: Bool? = true
+    for index in l.indices {
+      truth = and(truth, matches(l[index], .equal, r[index]))
+      if truth == false { break }
+    }
+    return truth
+  case .unequal:
+    var truth: Bool? = true
+    for index in l.indices {
+      truth = and(truth, matches(l[index], .equal, r[index]))
+      if truth == false { break }
+    }
+    return truth.map { !$0 }
+  case .lt, .leq, .gt, .geq:
+    let strict: Comparison = op == .lt || op == .leq ? .lt : .gt
+    var cascade: Bool? = nil
+    for index in stride(from: l.count - 1, through: 0, by: -1) {
+      let last = index == l.count - 1
+      let step = matches(l[index], last ? op : strict, r[index])
+      if let tail = cascade {
+        let equal = matches(l[index], .equal, r[index])
+        cascade = or(step, and(equal, tail))
+      } else {
+        cascade = step
+      }
+    }
+    return cascade
+  }
+}
+
 /// Kleene `AND` over two three-valued operands: `false` dominates (a `false`
 /// side makes the whole `false` even against UNKNOWN), both `true` is `true`,
 /// and any other pair is UNKNOWN (`nil`).
@@ -1476,6 +1574,10 @@ extension Catalog where Self: ~Escapable {
       try (evaluate(row, term, context) == .null) != negated
     case let .membership(operand, elements, negated):
       try member(row, operand, elements, negated, context)
+    case let .comparison(lhs, op, rhs):
+      try compare(row, lhs, op, rhs, context)
+    case let .memberships(lhs, rows, negated):
+      try member(row, lhs, rows, negated, context)
     case let .like(operand, pattern, escape, negated):
       try like(row, operand, pattern, escape, negated, context)
     case let .between(test, lower, upper, negated):
@@ -1579,6 +1681,56 @@ extension Catalog where Self: ~Escapable {
     var truth: Bool? = false
     for element in values {
       truth = or(truth, matches(value, .equal, element))
+      if truth == true { break }
+    }
+    return negated ? truth.map { !$0 } : truth
+  }
+
+  /// Evaluates a lowered `(l…) <op> (r…)` row-value comparison against `row`.
+  ///
+  /// Each side is evaluated exactly ONCE per row into a `[Value]` — a desugar
+  /// to a conjunction/cascade of scalar `compare`s re-evaluated a component
+  /// once per place it appeared, so a stateful component yielded a different
+  /// value each time — then the two rows fold through the shared `relate`
+  /// primitive, which reproduces the ISO three-valued truth with the SAME
+  /// `matches`/Kleene logic a scalar comparison uses.
+  private borrowing func compare(_ row: borrowing some Row & ~Escapable,
+                                 _ lhs: Array<Term>, _ op: Comparison,
+                                 _ rhs: Array<Term>, _ context: Context)
+      throws(SQLError) -> Bool? {
+    var l = Array<Value>()
+    l.reserveCapacity(lhs.count)
+    for term in lhs { try l.append(evaluate(row, term, context)) }
+    var r = Array<Value>()
+    r.reserveCapacity(rhs.count)
+    for term in rhs { try r.append(evaluate(row, term, context)) }
+    return relate(l, op, r)
+  }
+
+  /// Evaluates a lowered `(l…) [NOT] IN ((r…), …)` row-value membership against
+  /// `row`.
+  ///
+  /// The left row is evaluated ONCE per row into a `[Value]` — as a scalar
+  /// `member` holds its operand once, so a stateful component is read a single
+  /// time rather than once per element row — then `(l…) = (r…)` folds over the
+  /// element rows IN ORDER under Kleene `OR`, seeded FALSE and short-circuiting
+  /// at the first TRUE. Each element equality is the shared `relate(_, =, _)`
+  /// componentwise Kleene `AND`, so a NULL component keeps the ISO three-valued
+  /// result: an unmatched test is UNKNOWN, not FALSE, an empty match FALSE, and
+  /// `NOT IN` negates that truth, mapping UNKNOWN to itself.
+  private borrowing func member(_ row: borrowing some Row & ~Escapable,
+                                _ lhs: Array<Term>, _ rows: Array<Array<Term>>,
+                                _ negated: Bool, _ context: Context)
+      throws(SQLError) -> Bool? {
+    var l = Array<Value>()
+    l.reserveCapacity(lhs.count)
+    for term in lhs { try l.append(evaluate(row, term, context)) }
+    var truth: Bool? = false
+    for element in rows {
+      var r = Array<Value>()
+      r.reserveCapacity(element.count)
+      for term in element { try r.append(evaluate(row, term, context)) }
+      truth = or(truth, relate(l, .equal, r))
       if truth == true { break }
     }
     return negated ? truth.map { !$0 } : truth

--- a/Sources/SQLEngine/Parser.swift
+++ b/Sources/SQLEngine/Parser.swift
@@ -41,7 +41,8 @@
 /// conjunction    := negation (AND negation)*
 /// negation       := NOT negation | [NOT] EXISTS '(' query ')' | primary
 /// primary        := '(' predicate ')' [IS [NOT] truthvalue] | comparison
-/// comparison     := expression (op (quantifier '(' query ')'
+/// comparison     := row (op row | [NOT] IN '(' row (',' row)* ')')
+///                 | expression (op (quantifier '(' query ')'
 ///                                    | expression | param)
 ///                 | IS [NOT] (NULL | truthvalue | DISTINCT FROM expression)
 ///                 | [NOT] IN '(' (expression (',' expression)* | query) ')'
@@ -49,6 +50,8 @@
 ///                     [ESCAPE (expression | param)]
 ///                 | [NOT] BETWEEN (expression | param) AND
 ///                                 (expression | param))
+/// row            := '(' expression (',' expression)+ ')'  // ISO row value;
+///                   // a comma marks it, else '(' expression ')' is a scalar
 /// quantifier     := ANY | SOME | ALL      // SOME is a synonym for ANY
 /// truthvalue     := TRUE | FALSE | UNKNOWN
 /// expression     := additive
@@ -1045,14 +1048,22 @@ internal struct Parser: ~Escapable {
 
   /// Parses a parenthesised predicate or a comparison.
   ///
-  /// A leading `(` is ambiguous: it opens either a parenthesised predicate (`(a
-  /// = 1 AND b = 2)`) or the parenthesised left operand of a comparison (`(Age
-  /// + 1) = 26`, where `factor` consumes the `(expression)`). The comparison is
-  /// tried first; if it fails, the group was a predicate, so the parser rewinds
-  /// to the saved lexer and lookahead token and parses it as one.
+  /// A leading `(` is ambiguous: it opens either an ISO `<row value
+  /// constructor>` heading a row comparison or row `IN` (`(a, b) = (c, d)`), a
+  /// parenthesised predicate (`(a = 1 AND b = 2)`), or the parenthesised left
+  /// operand of a comparison (`(Age + 1) = 26`, where `factor` consumes the
+  /// `(expression)`). A COMMA inside the parentheses marks the row form, which
+  /// `row()` detects and COMMITS to — a row is never a valid predicate, so its
+  /// tail errors (an arity mismatch) must propagate rather than trigger the
+  /// predicate rewind. Otherwise the comparison is tried first; if it fails,
+  /// the group was a predicate, so the parser rewinds to the saved lexer and
+  /// lookahead token and parses it as one.
   private mutating func primary() throws(SQLError) -> Predicate {
     guard current?.kind == .lparen else {
       return try comparison()
+    }
+    if let left = try row() {
+      return try rows(left)
     }
     let lexer = self.lexer
     let token = self.current
@@ -1160,6 +1171,119 @@ internal struct Parser: ~Escapable {
     }
     let right = try expression()
     return .comparison(left: left, op: op, right: right)
+  }
+
+  /// Parses an ISO `<row value constructor>` — `'(' expression (','
+  /// expression)+ ')'`, at least TWO elements — returning its element
+  /// expressions, or `nil` when the current token does not open one so the
+  /// caller falls through to the scalar path.
+  ///
+  /// A leading `(` is ambiguous between a row and a parenthesised scalar
+  /// (`(x)`), or an arithmetic group (`(a + b)`): only a COMMA inside the
+  /// parentheses makes it a row. So this saves the lexer and lookahead, opens
+  /// the `(`, and parses the first element; a following `,` confirms the row —
+  /// it collects the rest and the `)`. Without a comma it is a scalar, so the
+  /// parser rewinds to the saved state and returns `nil`, leaving the `(`
+  /// unconsumed for `expression()` to parse. A `(` not present at all returns
+  /// `nil` without touching the stream.
+  private mutating func row() throws(SQLError) -> Array<Expression>? {
+    guard current?.kind == .lparen else { return nil }
+    let lexer = self.lexer
+    let token = self.current
+    try expect(.lparen)
+    // A `(SELECT …)` opens a scalar subquery, never a row — `factor()` reads it
+    // through the whole `(query)`. Rewind so the scalar path parses it rather
+    // than `expression()` choking on the bare `SELECT` (the `(` already
+    // consumed), the same `SELECT` lookahead `factor()` and `IN` use.
+    if current?.kind == .select {
+      self.lexer = lexer
+      self.current = token
+      return nil
+    }
+    // A token that cannot begin an expression (`NOT`, `EXISTS`, `TABLE`, …) is
+    // not a row element, so a parse failure of the FIRST element means this `(`
+    // opens a parenthesised predicate, not a row: rewind and return `nil` so
+    // the caller's predicate path runs. Only a `,` commits to row syntax, after
+    // which a later element's error is a real error and propagates.
+    guard let first = try? expression() else {
+      self.lexer = lexer
+      self.current = token
+      return nil
+    }
+    guard try match(.comma) else {
+      self.lexer = lexer
+      self.current = token
+      return nil
+    }
+    var elements = [first]
+    repeat {
+      try elements.append(expression())
+    } while try match(.comma)
+    try expect(.rparen)
+    return elements
+  }
+
+  /// Parses the tail of a row comparison or row `IN` whose left `<row value
+  /// constructor>` is already parsed to `left`, building the FIRST-CLASS AST
+  /// node (`Predicate.rows` / `Predicate.among`) rather than desugaring it —
+  /// each component `Expression` is held once so the lowering evaluates it
+  /// exactly once per row, the correctness fix over a desugar that duplicated a
+  /// component across the places a conjunction/cascade names it.
+  ///
+  /// A relational operator (`= <> < <= > >=`) takes a second row constructor of
+  /// EQUAL arity (else `SQLError.arity`), building `Predicate.rows(left, op,
+  /// right)`. An `IN` (or `NOT IN`) takes a parenthesised list of row
+  /// constructors, building `Predicate.among(left, elements, negated:)`. The
+  /// ISO three-valued semantics (the componentwise conjunction for `=`, the
+  /// lexicographic cascade for the ordering operators, the `IN` disjunction)
+  /// live in the lowering and runtime, not this parse.
+  private mutating func rows(_ left: Array<Expression>)
+      throws(SQLError) -> Predicate {
+    if try match(.in) {
+      return try rows(left, in: false)
+    }
+    if try match(.not) {
+      try expect(.in)
+      return try rows(left, in: true)
+    }
+    let op = try op()
+    guard let right = try row() else {
+      let token = try advance(expecting: "a row value constructor")
+      throw .unexpected(token.kind.description,
+                        expected: "a row value constructor",
+                        at: token.location)
+    }
+    guard left.count == right.count else {
+      throw .arity(left.count, right.count)
+    }
+    return .rows(left, op, right)
+  }
+
+  /// Parses the tail of a row `[NOT] IN '(' row (',' row)* ')'` — the `IN` is
+  /// already consumed — building `Predicate.among(left, elements, negated:)`
+  /// over `left` and the parsed element rows, each of EQUAL arity (else
+  /// `SQLError.arity`) and the list non-empty. `negated` marks `NOT IN`.
+  private mutating func rows(_ left: Array<Expression>, in negated: Bool)
+      throws(SQLError) -> Predicate {
+    try expect(.lparen)
+    var elements = Array<Array<Expression>>()
+    repeat {
+      guard let element = try row() else {
+        let token = try advance(expecting: "a row value constructor")
+        throw .unexpected(token.kind.description,
+                          expected: "a row value constructor",
+                          at: token.location)
+      }
+      guard left.count == element.count else {
+        throw .arity(left.count, element.count)
+      }
+      elements.append(element)
+    } while try match(.comma)
+    try expect(.rparen)
+    guard !elements.isEmpty else {
+      throw .state("42601", "IN requires a non-empty value list")
+    }
+    return .among(left, elements, negated: negated)
   }
 
   /// Consumes an `ANY`, `SOME`, or `ALL` quantifier keyword at the head of a

--- a/Sources/SQLEngine/Resolve.swift
+++ b/Sources/SQLEngine/Resolve.swift
@@ -1098,6 +1098,27 @@ private func lower(_ predicate: Predicate,
     // UNKNOWN is UNKNOWN — not FALSE, and `NOT` maps that UNKNOWN to itself, so
     // `NOT IN` a list holding NULL is never TRUE.
     try membership(term(expression), values, negated: negated, term: term)
+  case let .rows(lhs, op, rhs):
+    // `(l…) <op> (r…)` lowers to a first-class `Filter.comparison` — the two
+    // rows of EQUAL arity (`SQLError.arity` otherwise), each component lowered
+    // ONCE through `term`. The runtime evaluates every component exactly once
+    // per row and folds the values with the SAME `matches`/Kleene primitives a
+    // scalar comparison uses (a componentwise Kleene `AND` for `=`, its
+    // negation for `<>`, the lexicographic cascade for the ordering operators),
+    // so a stateful component is read once and the ISO three-valued truth is
+    // preserved. A desugar to a conjunction/cascade of scalar comparisons
+    // duplicated a component across its places, re-evaluating it.
+    try rows(lhs, op, rhs, term: term)
+  case let .among(lhs, rows, negated):
+    // `(l…) [NOT] IN ((r…), …)` lowers to a first-class `Filter.memberships` —
+    // the left row and a non-empty list of element rows, all of EQUAL arity
+    // (`SQLError.arity` otherwise, an empty list rejected), each component
+    // lowered ONCE through `term`. The runtime evaluates the left row once per
+    // row and folds `(l…) = (r…)` over the element rows under Kleene `OR`, so
+    // the left components are read once rather than once per element (an
+    // OR-chain of row equalities would re-read them), keeping the value-list
+    // `IN`'s three-valued semantics.
+    try among(lhs, rows, negated: negated, term: term)
   case let .like(operand, pattern, escape, negated):
     // Lower each operand to a first-class `Filter.like`; the optional escape
     // lowers only when present. The matcher and three-valued handling live in
@@ -1168,6 +1189,72 @@ private func membership(_ left: Term, _ values: Array<Expression>,
     try elements.append(term(value))
   }
   return .membership(left, elements, negated: negated)
+}
+
+/// Lowers `(l…) <op> (r…)` to a first-class `Filter.comparison(l, op, r)`, the
+/// two rows lowered componentwise through `term`.
+///
+/// The two rows must be of EQUAL arity (`SQLError.arity` otherwise) — a
+/// row-value comparison of unequal rows is undefined. Each component is lowered
+/// ONCE rather than duplicated into a desugared conjunction/cascade of scalar
+/// comparisons: that desugar named a component in several places (the `<`
+/// cascade uses each earlier component in both a strict step and an equality
+/// tie-guard), so a non-idempotent component was evaluated more than once. The
+/// `Filter.comparison` runtime evaluates every component exactly once per row,
+/// then folds the values with the same `matches`/Kleene primitives — preserving
+/// the ISO three-valued truth while reading each component a single time.
+private func rows(_ lhs: Array<Expression>, _ op: Comparison,
+                  _ rhs: Array<Expression>,
+                  term: (Expression) throws(SQLError) -> Term)
+    throws(SQLError) -> Filter {
+  guard lhs.count == rhs.count else {
+    throw .arity(lhs.count, rhs.count)
+  }
+  var l = Array<Term>()
+  l.reserveCapacity(lhs.count)
+  for expression in lhs { try l.append(term(expression)) }
+  var r = Array<Term>()
+  r.reserveCapacity(rhs.count)
+  for expression in rhs { try r.append(term(expression)) }
+  return .comparison(l, op, r)
+}
+
+/// Lowers `(l…) [NOT] IN ((r…), …)` to a first-class
+/// `Filter.memberships(l, [[r…], …], negated:)`, the left row and each element
+/// row lowered componentwise through `term`.
+///
+/// The element list must be non-empty and every element row of the SAME arity
+/// as the left row (`SQLError.arity` otherwise) — as with the scalar value-list
+/// `IN`, the parser rejects `IN ()`, but `Predicate.among` is public, so a
+/// caller can bypass the grammar and this lowering rejects it. The left row's
+/// components are lowered ONCE and held rather than copied into an OR-chain of
+/// scalar row equalities: that chain re-evaluated the left components once per
+/// element row, so a non-idempotent component yielded a different value each
+/// element compared against. The `Filter.memberships` runtime evaluates the
+/// left row once per row, then folds `(l…) = (r…)` over the elements under
+/// Kleene `OR` — the same three-valued membership the value-list `IN` uses.
+private func among(_ lhs: Array<Expression>, _ rows: Array<Array<Expression>>,
+                   negated: Bool,
+                   term: (Expression) throws(SQLError) -> Term)
+    throws(SQLError) -> Filter {
+  if rows.isEmpty {
+    throw .state("42601", "IN requires a non-empty value list")
+  }
+  var l = Array<Term>()
+  l.reserveCapacity(lhs.count)
+  for expression in lhs { try l.append(term(expression)) }
+  var elements = Array<Array<Term>>()
+  elements.reserveCapacity(rows.count)
+  for element in rows {
+    guard element.count == lhs.count else {
+      throw .arity(lhs.count, element.count)
+    }
+    var row = Array<Term>()
+    row.reserveCapacity(element.count)
+    for expression in element { try row.append(term(expression)) }
+    elements.append(row)
+  }
+  return .memberships(l, elements, negated: negated)
 }
 
 /// Lowers `operand [NOT] LIKE pattern [ESCAPE escape]` to a first-class
@@ -2407,6 +2494,57 @@ internal struct Scope {
       }, equality: { value throws(SQLError) in
         matched(operand, value, routines)
       })
+    case let .rows(lhs, _, rhs):
+      // `(l…) <op> (r…)` lowers to a componentwise comparison, so type each
+      // component of both rows for real errors (unknown column, bad arity, …),
+      // and enforce the EQUAL-arity rule the lowering does (`SQLError.arity`)
+      // so schema validation matches execution. A cross-kind component is NOT
+      // rejected — the run's `matches` yields FALSE across kinds without
+      // faulting, as an `IN` element does — so the schema accepts what the run
+      // accepts.
+      guard lhs.count == rhs.count else {
+        throw .arity(lhs.count, rhs.count)
+      }
+      for expression in lhs {
+        _ = try validate(expression, routines, subquery: subquery)
+      }
+      for expression in rhs {
+        _ = try validate(expression, routines, subquery: subquery)
+      }
+    case let .among(lhs, rows, _):
+      // `(l…) [NOT] IN ((r…), …)` lowers to a disjunction of row equalities, so
+      // type the left row and each element row for real errors, and enforce the
+      // non-empty list and per-row EQUAL-arity rules the lowering does. A
+      // cross-kind component is NOT rejected, as an `IN` element is not.
+      //
+      // The OR-chain short-circuits exactly as the scalar `.membership` does: a
+      // DEFINITE constant match (both the left row and an element row fold to
+      // ROW-INDEPENDENT constants whose tuple-equality `relate` yields TRUE)
+      // makes the whole `IN` TRUE and leaves every later element unreachable,
+      // so validation stops there — `(1, 2) IN ((1, 2), (Name + 1, 3))`
+      // type-checks (the constant `(1, 2)` matches the first element before
+      // `Name + 1` is reached), while `(1, 2) IN ((3, 4), (Name + 1, 5))` (no
+      // definite match) still validates `Name + 1` and faults. A row-dependent
+      // side leaves the element undecided (`nil`), so no false short-circuit
+      // prunes a reachable element.
+      if rows.isEmpty {
+        throw .state("42601", "IN requires a non-empty value list")
+      }
+      for expression in lhs {
+        _ = try validate(expression, routines, subquery: subquery)
+      }
+      let l = constants(lhs, routines)
+      _ = try membership(of: rows, each: { element throws(SQLError) in
+        guard element.count == lhs.count else {
+          throw .arity(lhs.count, element.count)
+        }
+        for expression in element {
+          _ = try validate(expression, routines, subquery: subquery)
+        }
+      }, equality: { element throws(SQLError) in
+        guard let l, let r = constants(element, routines) else { return nil }
+        return relate(l, .equal, r)
+      })
     case let .like(operand, pattern, escape, _):
       // Validate the operand, pattern, and optional escape for REAL errors
       // (unknown column, bad arity, …); a non-text operand or pattern is NOT
@@ -2633,6 +2771,22 @@ internal struct Scope {
     }
   }
 
+  /// The constant `Value`s a ROW `row` folds to when EVERY component is
+  /// row-independent — else `nil` (any component a row/group/run decides). A
+  /// row comparison and a row `IN` element fold through this so a single row-
+  /// dependent component leaves the whole row undecided, matching the runtime's
+  /// whole-row evaluation.
+  private func constants(_ row: Array<Expression>, _ routines: Routines)
+      -> Array<Value>? {
+    var values = Array<Value>()
+    values.reserveCapacity(row.count)
+    for expression in row {
+      guard let value = constant(expression, routines) else { return nil }
+      values.append(value)
+    }
+    return values
+  }
+
   /// Folds an `IN` value list as its OR-chain of `operand = element`
   /// equalities, honouring the executor's SHORT-CIRCUIT: the elements are
   /// visited in order, each mapped to its three-valued equality truth by
@@ -2648,10 +2802,15 @@ internal struct Scope {
   /// a per-element side effect (validation) applies it to exactly the reachable
   /// prefix. The fold seeds FALSE (an empty match is FALSE), so the returned
   /// truth is the disjunction over the visited prefix.
-  private func membership<E: Error>(
-      of elements: Array<Expression>,
-      each visit: (Expression) throws(E) -> Void = { (_: Expression) in },
-      equality: (Expression) throws(E) -> Bool?)
+  ///
+  /// The element is GENERIC — a scalar value list supplies an `Expression` per
+  /// element, a row `IN` a whole `Array<Expression>` row — so the same
+  /// short-circuit drives the scalar `.membership` and the row `.among` folds,
+  /// the tuple-equality via `relate` standing in for the scalar equality.
+  private func membership<Element, E: Error>(
+      of elements: Array<Element>,
+      each visit: (Element) throws(E) -> Void = { (_: Element) in },
+      equality: (Element) throws(E) -> Bool?)
       throws(E) -> Bool? {
     var truth: Bool? = false
     for element in elements {
@@ -2778,6 +2937,37 @@ internal struct Scope {
       return nil
     case .bound:
       return nil
+    case let .rows(lhs, op, rhs):
+      // Fold `(l…) <op> (r…)` exactly as the scalar `.comparison` folds — each
+      // component of BOTH rows folds through `constant(_ expression:)`, then
+      // the folded values combine through the SHARED `relate` primitive the run
+      // (`Filter.comparison`) and the empty-group pre-fold drive, so the fold
+      // matches the run. A single row-dependent component (`nil`) leaves the
+      // whole comparison per row (`nil`), so both `AND` arms stay reachable; an
+      // all-constant pair settles it, so a constant-false row guard prunes its
+      // right arm as `1 = 0 AND …` does.
+      guard let l = constants(lhs, routines),
+          let r = constants(rhs, routines) else {
+        return nil
+      }
+      return relate(l, op, r)
+    case let .among(lhs, rows, negated):
+      // Fold `(l…) [NOT] IN ((r…), …)` exactly as the scalar `.membership`
+      // folds — the left row folds through `constant(_ expression:)`, then the
+      // element rows OR-fold under the `membership` short-circuit: an element
+      // whose components ALL fold constant contributes its tuple-equality
+      // (`relate(l, =, r)`, the same shared primitive), and once one folds
+      // definitely TRUE the walk stops, so a later row-dependent element is
+      // unreachable and does not spoil it — `(1, 2) IN ((1, 2), (Name + 1, 3))`
+      // folds `true`. Absent a decisive match, a row-dependent element makes it
+      // per row (`nil`); a row-dependent LEFT row leaves the whole `IN` per
+      // row. `NOT IN` negates the folded truth (UNKNOWN maps to itself).
+      guard let l = constants(lhs, routines) else { return nil }
+      let truth = membership(of: rows) { element in
+        guard let r = constants(element, routines) else { return nil }
+        return relate(l, .equal, r)
+      }
+      return negated ? truth.map { !$0 } : truth
     case .exists, .within, .quantified:
       // A subquery predicate is not a ROW-INDEPENDENT constant fold — its truth
       // is decided by the materialised result at lowering time, not by folding
@@ -2822,6 +3012,20 @@ internal struct Scope {
       settled(operand, routines)
     case .bound:
       false
+    case let .rows(lhs, _, rhs):
+      // A row comparison is settled when EVERY component of BOTH rows folds to
+      // a ROW-INDEPENDENT constant — the row analog of `.comparison`, so a
+      // constant-UNKNOWN row comparison (a NULL component) folds a `truth` test
+      // definitely rather than deferring it.
+      lhs.allSatisfy { constant($0, routines) != nil }
+          && rhs.allSatisfy { constant($0, routines) != nil }
+    case let .among(lhs, rows, _):
+      // A row `IN` is settled when the LEFT row and EVERY element row fold to
+      // ROW-INDEPENDENT constants — the row analog of `.membership`.
+      lhs.allSatisfy { constant($0, routines) != nil }
+          && rows.allSatisfy { element in
+            element.allSatisfy { constant($0, routines) != nil }
+          }
     case .exists, .within, .quantified:
       // A subquery predicate's truth comes from a materialised result, not from
       // folding constant operands, so it is never settled at compile time.
@@ -2855,7 +3059,10 @@ internal struct Scope {
       definite(lhs) && definite(rhs)
     case let .not(operand):
       definite(operand)
-    case .comparison, .membership, .like, .between, .bound:
+    // A row-value comparison and row `IN` are three-valued over NULLs — a NULL
+    // component makes a componentwise test UNKNOWN — exactly as the scalar
+    // `.comparison`/`.membership` are, so neither is definite.
+    case .comparison, .membership, .rows, .among, .like, .between, .bound:
       false
     }
   }
@@ -2987,6 +3194,22 @@ internal struct Scope {
       try aggregates(in: operand, routines, subquery: subquery)
       for value in values {
         try aggregates(in: value, routines, subquery: subquery)
+      }
+    case let .rows(lhs, _, rhs):
+      for expression in lhs {
+        try aggregates(in: expression, routines, subquery: subquery)
+      }
+      for expression in rhs {
+        try aggregates(in: expression, routines, subquery: subquery)
+      }
+    case let .among(lhs, rows, _):
+      for expression in lhs {
+        try aggregates(in: expression, routines, subquery: subquery)
+      }
+      for element in rows {
+        for expression in element {
+          try aggregates(in: expression, routines, subquery: subquery)
+        }
       }
     case .exists:
       // A subquery is its OWN scope — any aggregate inside it folds over its
@@ -3189,6 +3412,47 @@ internal struct Scope {
       let lhs = try empty(operand, routines)
       let truth = try membership(of: values) { value throws(SQLError) in
         matches(lhs, .equal, try empty(value, routines))
+      }
+      return negated ? truth.map { !$0 } : truth
+    case let .rows(lhs, op, rhs):
+      // Fold `(l…) <op> (r…)` over the empty group as `Filter.comparison`
+      // evaluates it: each component folds through `empty(_ expression:)`, then
+      // the values combine with the SAME `matches`/Kleene primitives — the
+      // componentwise Kleene `AND` for `=` (its negation for `<>`), the
+      // lexicographic cascade for the ordering operators. Reject an unequal
+      // arity as `lower`/`check` do.
+      guard lhs.count == rhs.count else {
+        throw .arity(lhs.count, rhs.count)
+      }
+      var l = Array<Value>()
+      l.reserveCapacity(lhs.count)
+      for expression in lhs { try l.append(empty(expression, routines)) }
+      var r = Array<Value>()
+      r.reserveCapacity(rhs.count)
+      for expression in rhs { try r.append(empty(expression, routines)) }
+      return relate(l, op, r)
+    case let .among(lhs, rows, negated):
+      // Fold `(l…) [NOT] IN ((r…), …)` over the empty group as
+      // `Filter.memberships` evaluates it: the left row folds once, then
+      // `(l…) = (r…)` folds over the element rows under Kleene `OR`, each
+      // element equality the componentwise Kleene `AND`. Reject an empty list
+      // or unequal arity as `lower`/`check` do.
+      if rows.isEmpty {
+        throw .state("42601", "IN requires a non-empty value list")
+      }
+      var l = Array<Value>()
+      l.reserveCapacity(lhs.count)
+      for expression in lhs { try l.append(empty(expression, routines)) }
+      var truth: Bool? = false
+      for element in rows {
+        guard element.count == lhs.count else {
+          throw .arity(lhs.count, element.count)
+        }
+        var r = Array<Value>()
+        r.reserveCapacity(element.count)
+        for expression in element { try r.append(empty(expression, routines)) }
+        truth = or(truth, relate(l, .equal, r))
+        if truth == true { break }
       }
       return negated ? truth.map { !$0 } : truth
     case let .like(operand, pattern, escape, negated):
@@ -3950,6 +4214,14 @@ extension Filter {
       operand.references(into: &ordinals)
       for element in elements {
         element.references(into: &ordinals)
+      }
+    case let .comparison(lhs, _, rhs):
+      for term in lhs { term.references(into: &ordinals) }
+      for term in rhs { term.references(into: &ordinals) }
+    case let .memberships(lhs, rows, _):
+      for term in lhs { term.references(into: &ordinals) }
+      for element in rows {
+        for term in element { term.references(into: &ordinals) }
       }
     case let .exists(_, correlation, _):
       // A CORRELATED EXISTS reads the enclosing row's cells its inner `WHERE`

--- a/Tests/SQLTests/Expressions/RowValueTests.swift
+++ b/Tests/SQLTests/Expressions/RowValueTests.swift
@@ -1,0 +1,617 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQLEngine
+
+import SQLTestSupport
+
+// MARK: - Fixture
+
+/// A relation exercising ISO row-value constructors in comparisons and `IN`:
+/// two integer keys `A` and `B` (each `NULL` in some rows, so the three-valued
+/// corners — a NULL component on either side — are reachable) and a third `C`
+/// for the n-ary (three-element) row cases. Every column mirrors another
+/// column, so a row-of-columns comparison (`(A, B) = (C, …)`) is exercisable
+/// alongside row-of-literal comparisons.
+private func pairs() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["Id": .integer, "A": .integer, "B": .integer,
+                   "C": .integer]) {
+      Row(1, 1, 2, 3)
+      Row(2, 1, 3, 3)
+      Row(3, 2, 2, 2)
+      Row(4, 1, nil, 3)
+      Row(5, nil, 2, 3)
+    }
+  }
+}
+
+// MARK: - Parsing
+
+struct RowValueParsingTests {
+  @Test func `a row equality parses a first-class rows node`() throws {
+    // `(A, B) = (C, Id)` parses to the FIRST-CLASS `Predicate.rows` node
+    // holding both rows' component expressions once — NOT a desugared
+    // conjunction of scalar comparisons (which duplicated a component). The
+    // componentwise semantics live in the lowering, not the AST.
+    let select = try parse(select: "SELECT * FROM T WHERE (A, B) = (C, Id)")
+    #expect(select.predicate
+                == .rows([.column("A"), .column("B")], .equal,
+                         [.column("C"), .column("Id")]))
+  }
+
+  @Test func `a row inequality parses a rows node carrying the operator`()
+      throws {
+    let select = try parse(select: "SELECT * FROM T WHERE (A, B) <> (C, Id)")
+    #expect(select.predicate
+                == .rows([.column("A"), .column("B")], .unequal,
+                         [.column("C"), .column("Id")]))
+  }
+
+  @Test func `a row less-than parses a rows node`() throws {
+    let select = try parse(select: "SELECT * FROM T WHERE (A, B) < (C, Id)")
+    #expect(select.predicate
+                == .rows([.column("A"), .column("B")], .lt,
+                         [.column("C"), .column("Id")]))
+  }
+
+  @Test func `a row less-or-equal parses a rows node`() throws {
+    let select = try parse(select: "SELECT * FROM T WHERE (A, B) <= (C, Id)")
+    #expect(select.predicate
+                == .rows([.column("A"), .column("B")], .leq,
+                         [.column("C"), .column("Id")]))
+  }
+
+  @Test func `a row greater-than parses a rows node`() throws {
+    let select = try parse(select: "SELECT * FROM T WHERE (A, B) > (C, Id)")
+    #expect(select.predicate
+                == .rows([.column("A"), .column("B")], .gt,
+                         [.column("C"), .column("Id")]))
+  }
+
+  @Test func `a three-element row parses a rows node of three components`()
+      throws {
+    // The n-ary shape parses to one `rows` node holding all three components
+    // per side, not a nested cascade — the generalisation is in the lowering.
+    let select =
+        try parse(select: "SELECT * FROM T WHERE (A, B, C) < (1, 2, 3)")
+    #expect(select.predicate
+                == .rows([.column("A"), .column("B"), .column("C")], .lt,
+                         [.literal(.integer(1)), .literal(.integer(2)),
+                          .literal(.integer(3))]))
+  }
+
+  @Test func `a row IN parses a first-class among node`() throws {
+    // `(A, B) IN ((1, 2), (2, 2))` parses to the FIRST-CLASS `Predicate.among`
+    // node holding the left row and each element row once — NOT a desugared
+    // disjunction of row equalities.
+    let select =
+        try parse(select: "SELECT * FROM T WHERE (A, B) IN ((1, 2), (2, 2))")
+    #expect(select.predicate
+                == .among([.column("A"), .column("B")],
+                          [[.literal(.integer(1)), .literal(.integer(2))],
+                           [.literal(.integer(2)), .literal(.integer(2))]],
+                          negated: false))
+  }
+
+  @Test func `a row NOT IN parses an among node marked negated`() throws {
+    let select =
+        try parse(select: "SELECT * FROM T WHERE (A, B) NOT IN ((1, 2))")
+    #expect(select.predicate
+                == .among([.column("A"), .column("B")],
+                          [[.literal(.integer(1)), .literal(.integer(2))]],
+                          negated: true))
+  }
+
+  @Test func `a single parenthesised scalar stays a scalar comparison`()
+      throws {
+    // No comma inside the parentheses, so `(A) = B` is an ordinary scalar
+    // comparison, NOT a one-element row — the disambiguation rule.
+    let select = try parse(select: "SELECT * FROM T WHERE (A) = B")
+    #expect(select.predicate
+                == .comparison(left: .column("A"), op: .equal,
+                               right: .column("B")))
+  }
+
+  @Test func `a parenthesised arithmetic operand stays a scalar comparison`()
+      throws {
+    let select = try parse(select: "SELECT * FROM T WHERE (A + 1) = B")
+    #expect(select.predicate
+                == .comparison(left: .binary(.add, .column("A"),
+                                             .literal(.integer(1))),
+                               op: .equal, right: .column("B")))
+  }
+
+  @Test func `a parenthesised predicate is unaffected by row detection`()
+      throws {
+    // A comma-free group holding a predicate (`(A = 1 AND B = 2)`) still parses
+    // as a parenthesised predicate — `row()` rewinds, and the existing
+    // comparison / predicate rewind resolves it.
+    let select = try parse(select: "SELECT * FROM T WHERE (A = 1 AND B = 2)")
+    #expect(select.predicate
+                == .and(.comparison(left: .column("A"), op: .equal,
+                                    right: .literal(.integer(1))),
+                        .comparison(left: .column("B"), op: .equal,
+                                    right: .literal(.integer(2)))))
+  }
+
+  @Test func `a parenthesised NOT predicate falls through to the predicate`()
+      throws {
+    // The `(` is followed by `NOT`, a token that cannot begin an expression, so
+    // the speculative row probe's first-element parse fails: `row()` catches
+    // it, rewinds, and returns `nil`, and the parenthesised-predicate path
+    // resolves `(NOT A = 1)` — the regression the fix restores.
+    let select = try parse(select: "SELECT * FROM T WHERE (NOT A = 1)")
+    #expect(select.predicate
+                == .not(.comparison(left: .column("A"), op: .equal,
+                                    right: .literal(.integer(1)))))
+  }
+
+  @Test func `a parenthesised EXISTS falls through to the predicate`()
+      throws {
+    // `(EXISTS (…))` opens on `EXISTS`, which cannot begin an expression, so
+    // the row probe rewinds and the parenthesised-predicate path parses the
+    // nested EXISTS — again a form the pre-fix eager probe rejected.
+    let select =
+        try parse(select: "SELECT * FROM T WHERE (EXISTS (SELECT Id FROM T))")
+    let inner = try parse(query: "SELECT Id FROM T")
+    #expect(select.predicate == .exists(inner, negated: false))
+  }
+
+  @Test func `a parenthesised scalar comparison stays a predicate`()
+      throws {
+    // `(A = 1)` holds a scalar comparison, not a row (no comma): the probe
+    // parses `A`, finds no comma, rewinds, and the predicate path resolves it.
+    let select = try parse(select: "SELECT * FROM T WHERE (A = 1)")
+    #expect(select.predicate
+                == .comparison(left: .column("A"), op: .equal,
+                               right: .literal(.integer(1))))
+  }
+
+  @Test func `a mismatched row arity faults`() {
+    #expect(throws: SQLError.arity(3, 2)) {
+      _ = try Statement(parsing: "SELECT * FROM T WHERE (A, B, C) = (1, 2)")
+    }
+  }
+
+  @Test func `a mismatched row IN arity faults`() {
+    #expect(throws: SQLError.arity(2, 3)) {
+      _ = try Statement(parsing: "SELECT * FROM T WHERE (A, B) IN ((1, 2, 3))")
+    }
+  }
+}
+
+// MARK: - Evaluation
+
+struct RowValueEvaluationTests {
+  @Test func `a row equality matches on every component`() throws {
+    // Row 3 has A = 2, B = 2, so `(A, B) = (2, 2)` holds only there.
+    try pairs().expect("SELECT Id FROM T WHERE (A, B) = (2, 2)",
+                       yields: [[3]])
+  }
+
+  @Test func `a row equality against columns compares componentwise`() throws {
+    // `(A, C) = (1, 3)` — A = 1 and C = 3 hold in rows 1, 2, and 4.
+    try pairs().expect("SELECT Id FROM T WHERE (A, C) = (1, 3)",
+                       yields: [[1], [2], [4]])
+  }
+
+  @Test func `a row inequality is the negation of equality`() throws {
+    // `(A, B) <> (1, 2)` keeps every row whose (A, B) is definitely not (1, 2);
+    // rows 4 (B NULL) and 5 (A NULL) are UNKNOWN and dropped.
+    try pairs().expect("SELECT Id FROM T WHERE (A, B) <> (1, 2)",
+                       yields: [[2], [3]])
+  }
+
+  @Test func `a row less-than orders lexicographically on the first component`()
+      throws {
+    // First component decides when it differs: `(A, B) < (2, 0)` — A < 2 admits
+    // rows 1, 2, 4 (A = 1); row 3 (A = 2) needs B < 0, false; row 5 (A NULL) is
+    // UNKNOWN.
+    try pairs().expect("SELECT Id FROM T WHERE (A, B) < (2, 0)",
+                       yields: [[1], [2], [4]])
+  }
+
+  @Test func `a row less-than falls to a later component on a tie`() throws {
+    // `(A, B) < (1, 3)` — the first component ties at A = 1 for rows 1, 2, 4,
+    // so the second decides: row 1 (B = 2) admits, row 2 (B = 3) does not, row
+    // 4 (B NULL) is UNKNOWN. Rows 3 (A = 2) and 5 (A NULL) never tie in.
+    try pairs().expect("SELECT Id FROM T WHERE (A, B) < (1, 3)",
+                       yields: [[1]])
+  }
+
+  @Test func `a row less-or-equal admits the all-equal row`() throws {
+    // `(A, B) <= (1, 2)` — the strict `<` rows (none below (1, 2) here) plus
+    // the equal row 1 (A = 1, B = 2).
+    try pairs().expect("SELECT Id FROM T WHERE (A, B) <= (1, 2)",
+                       yields: [[1]])
+  }
+
+  @Test func `a row greater-than mirrors the ordering`() throws {
+    // `(A, B) > (1, 2)` — row 2 (A = 1 ties, B = 3 > 2) and row 3 (A = 2 > 1);
+    // row 1 is equal (not greater), rows 4/5 UNKNOWN.
+    try pairs().expect("SELECT Id FROM T WHERE (A, B) > (1, 2)",
+                       yields: [[2], [3]])
+  }
+
+  @Test func `a row greater-or-equal admits the all-equal row`() throws {
+    try pairs().expect("SELECT Id FROM T WHERE (A, B) >= (1, 2)",
+                       yields: [[1], [2], [3]])
+  }
+
+  @Test func `a three-element row compares componentwise`() throws {
+    // `(A, B, C) = (2, 2, 2)` holds only in row 3.
+    try pairs().expect("SELECT Id FROM T WHERE (A, B, C) = (2, 2, 2)",
+                       yields: [[3]])
+  }
+
+  @Test func `a three-element row orders lexicographically`() throws {
+    // `(A, B, C) < (1, 3, 0)` — A < 1 (none), tie A = 1 then B < 3 (rows 1, 4
+    // have B = 2 / NULL): row 1 admits, row 4 (B NULL) UNKNOWN; row 2 ties B =
+    // 3 then needs C < 0 (false).
+    try pairs().expect("SELECT Id FROM T WHERE (A, B, C) < (1, 3, 0)",
+                       yields: [[1]])
+  }
+
+  @Test func `a row IN admits a matching row literal`() throws {
+    // `(A, B) IN ((1, 2), (2, 2))` matches row 1 (1, 2) and row 3 (2, 2).
+    try pairs().expect("SELECT Id FROM T WHERE (A, B) IN ((1, 2), (2, 2))",
+                       yields: [[1], [3]])
+  }
+
+  @Test func `a row IN rejects a non-matching set`() throws {
+    try pairs().expect("SELECT Id FROM T WHERE (A, B) IN ((9, 9), (8, 8))",
+                       yields: [])
+  }
+
+  @Test func `a row NOT IN admits the complement`() throws {
+    // `(A, B) NOT IN ((1, 2))` — rows definitely not (1, 2); rows 4/5 have a
+    // NULL component making the membership UNKNOWN, so they are dropped.
+    try pairs().expect("SELECT Id FROM T WHERE (A, B) NOT IN ((1, 2))",
+                       yields: [[2], [3]])
+  }
+
+  @Test func `a parenthesised NOT predicate evaluates as the negated scalar`()
+      throws {
+    // `(NOT A = 1)` keeps the rows where A is definitely not 1 — row 3 (A = 2);
+    // row 5 (A NULL) is UNKNOWN and dropped. Proves the fall-through parses AND
+    // evaluates, not merely parses.
+    try pairs().expect("SELECT Id FROM T WHERE (NOT A = 1)", yields: [[3]])
+  }
+
+  @Test func `a parenthesised EXISTS predicate evaluates over the subquery`()
+      throws {
+    // `(EXISTS (SELECT …))` is TRUE for every outer row since T is non-empty,
+    // so all five rows survive — the parenthesised nested EXISTS runs.
+    try pairs().expect("SELECT Id FROM T WHERE (EXISTS (SELECT Id FROM T))",
+                       yields: [[1], [2], [3], [4], [5]])
+  }
+
+  @Test func `a parenthesised scalar comparison evaluates as the comparison`()
+      throws {
+    // `(A = 1)` and `A = 1` select the same rows — the parentheses are
+    // grouping, not a one-element row.
+    try pairs().expect("SELECT Id FROM T WHERE (A = 1)",
+                       equals: "SELECT Id FROM T WHERE A = 1")
+  }
+
+  @Test func `a row IN folds like an OR of row equalities`() throws {
+    try pairs().expect(
+        "SELECT Id FROM T WHERE (A, B) IN ((1, 2), (2, 2))",
+        equals: "SELECT Id FROM T WHERE (A = 1 AND B = 2) "
+              + "OR (A = 2 AND B = 2)")
+  }
+}
+
+// MARK: - Three-valued NULL
+
+struct RowValueNullTests {
+  @Test func `a NULL component makes an otherwise-equal row UNKNOWN`() throws {
+    // `(1, NULL) = (1, 2)` → `1 = 1 AND NULL = 2` → TRUE AND UNKNOWN → UNKNOWN,
+    // so the row is DROPPED, not admitted. Row 4 is (A = 1, B = NULL).
+    try pairs().empty("SELECT Id FROM T WHERE (A, B) = (1, 2) AND Id = 4")
+  }
+
+  @Test func `a definite component mismatch dominates a NULL component`()
+      throws {
+    // `(1, NULL) = (2, 2)` → `1 = 2 AND NULL = 2` → FALSE AND UNKNOWN → FALSE,
+    // a DEFINITE non-match: the row is dropped by `=` (and would be ADMITTED by
+    // `<>`, since NOT FALSE is TRUE). Row 4 is (1, NULL).
+    try pairs().empty("SELECT Id FROM T WHERE (A, B) = (2, 2) AND Id = 4")
+    try pairs().expect("SELECT Id FROM T WHERE (A, B) <> (2, 2) AND Id = 4",
+                       yields: [[4]])
+  }
+
+  @Test func `a NULL in a later lexicographic component is UNKNOWN`() throws {
+    // Row 4 is (A = 1, B = NULL): `(1, 2) < (A, B)` → `1 < 1 OR (1 = 1 AND 2 <
+    // NULL)` → FALSE OR (TRUE AND UNKNOWN) → UNKNOWN, so the row whose deciding
+    // right-hand component is NULL is dropped — the lexicographic cascade keeps
+    // the ISO 3VL rather than reading the NULL as a definite ordering.
+    try pairs().empty("SELECT Id FROM T WHERE (1, 2) < (A, B) AND Id = 4")
+  }
+
+  @Test func `a NULL in the deciding component still resolves definitely`()
+      throws {
+    // `(1, NULL) < (2, 0)` → `1 < 2 OR …` → the FIRST component decides TRUE
+    // before the NULL second is ever consulted (Kleene OR short-circuits on a
+    // definite TRUE), so the row is admitted despite the NULL. Row 4 is (1,
+    // NULL).
+    try pairs().expect("SELECT Id FROM T WHERE (A, B) < (2, 0) AND Id = 4",
+                       yields: [[4]])
+  }
+
+  @Test func `a row IN with a NULL component is UNKNOWN without a match`()
+      throws {
+    // Row 4 (1, NULL): `(1, NULL) IN ((1, 2))` → `1 = 1 AND NULL = 2` → UNKNOWN
+    // — no definite match — so the row is dropped by IN and by NOT IN (the
+    // negation of UNKNOWN is UNKNOWN).
+    try pairs().empty("SELECT Id FROM T WHERE (A, B) IN ((1, 2)) AND Id = 4")
+    try pairs().empty(
+        "SELECT Id FROM T WHERE (A, B) NOT IN ((1, 2)) AND Id = 4")
+  }
+
+  @Test func `a row IN resolves definitely when another element matches`()
+      throws {
+    // Row 4 (1, NULL): `(1, NULL) IN ((1, 2), (9, 9))` is still UNKNOWN (no
+    // element definitely matches), but row 1 (1, 2) matches the first element
+    // definitely — proving a definite match resolves the disjunction to TRUE.
+    try pairs().expect(
+        "SELECT Id FROM T WHERE (A, B) IN ((1, 2), (9, 9))",
+        yields: [[1]])
+  }
+}
+
+// MARK: - Component evaluated once
+
+/// A shared call counter a stateful routine increments — a tiny
+/// `@unchecked Sendable` box over a mutable count, so the non-deterministic
+/// `stepper()` routine registered against it both observes successive values
+/// and records how many times the run invoked it. The engine evaluates a row's
+/// predicate synchronously on one thread, so the box needs no lock.
+private final class Counter: @unchecked Sendable {
+  /// The number of times `next()` has been called.
+  private(set) var count = 0
+
+  /// Increments the count and returns the PREVIOUS value — the sequence `0, 1,
+  /// 2, …` across successive calls.
+  func next() -> Int {
+    defer { count += 1 }
+    return count
+  }
+}
+
+/// The load-bearing regression for the first-class redesign: a row-value
+/// component holding a STATEFUL call must be evaluated EXACTLY ONCE per row.
+/// The old parse-time desugar named a component in several places — a `<`
+/// cascade uses an earlier component in both a strict step and an equality
+/// tie-guard, and a row `IN` copies the left row into each element's equality
+/// — so `stepper()` ran twice and the two calls saw DIFFERENT values (0, 1),
+/// admitting or dropping the wrong rows. The first-class nodes evaluate each
+/// component once into a value the fold reuses, so the counter reads exactly 1
+/// and the truth is computed over the single value (0).
+struct RowValueOnceTests {
+  /// A single-row table, so a per-row component runs once for the one row.
+  private func one() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["Id": .integer]) {
+        Row(1)
+      }
+    }
+  }
+
+  /// A fresh non-deterministic `stepper()` over its own counter — non-
+  /// deterministic so the optimiser cannot constant-fold it away, exposing the
+  /// eval count.
+  private func stepper(_ counter: Counter) throws -> Routines {
+    try Routines()
+        .registering("stepper", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+  }
+
+  @Test func `a row IN evaluates a stateful component once`() throws {
+    // Left row is `(stepper(), 0)` = `(0, 0)`. It matches NEITHER `(99, 0)` nor
+    // `(1, 0)`, so no row is admitted — but ONLY if `stepper()` yields 0 in the
+    // one evaluation the fold reads. The old desugar copied `stepper()` into
+    // each element's equality: the first read 0 (no match against 99), the
+    // SECOND read 1, wrongly matching `(1, 0)` and admitting the row. The
+    // first-class node reads it once, so no row is admitted and the counter is
+    // exactly 1.
+    let counter = Counter()
+    try one().expect("SELECT Id FROM T WHERE (stepper(), 0) IN ((99, 0), "
+                   + "(1, 0))", yields: [], routines: stepper(counter))
+    #expect(counter.count == 1)
+  }
+
+  @Test func `a row less-than evaluates a stateful component once`() throws {
+    // `(stepper(), 0) < (0, 1)` with `stepper()` = 0 is `0 < 0 OR (0 = 0 AND
+    // 0 < 1)` = FALSE OR (TRUE AND TRUE) = TRUE, so the row is admitted. The
+    // old cascade named the first component twice (the strict `stepper() < 0`
+    // and the `stepper() = 0` tie-guard): the first read 0, the second read 1,
+    // so the guard `1 = 0` was FALSE and the row was wrongly DROPPED. The
+    // first-class node reads it once, admitting the row, counter exactly 1.
+    let counter = Counter()
+    try one().expect("SELECT Id FROM T WHERE (stepper(), 0) < (0, 1)",
+                     yields: [[1]], routines: stepper(counter))
+    #expect(counter.count == 1)
+  }
+
+  @Test func `a row less-or-equal evaluates a stateful component once`()
+      throws {
+    // `(stepper(), 0) <= (0, 0)` with `stepper()` = 0 is the all-equal row,
+    // TRUE via the innermost `<=`. The desugar's re-read (guard `1 = 0`) drops
+    // it; the first-class node admits it, counter exactly 1.
+    let counter = Counter()
+    try one().expect("SELECT Id FROM T WHERE (stepper(), 0) <= (0, 0)",
+                     yields: [[1]], routines: stepper(counter))
+    #expect(counter.count == 1)
+  }
+
+  @Test func `a row greater-than evaluates a stateful component once`() throws {
+    // `(stepper(), 2) > (0, 1)` with `stepper()` = 0 is `0 > 0 OR (0 = 0 AND
+    // 2 > 1)` = FALSE OR (TRUE AND TRUE) = TRUE. The desugar's guard re-read
+    // (`1 = 0` FALSE) drops it; the first-class node admits it, counter one.
+    let counter = Counter()
+    try one().expect("SELECT Id FROM T WHERE (stepper(), 2) > (0, 1)",
+                     yields: [[1]], routines: stepper(counter))
+    #expect(counter.count == 1)
+  }
+
+  @Test func `a row greater-or-equal evaluates a stateful component once`()
+      throws {
+    // `(stepper(), 0) >= (0, 0)` with `stepper()` = 0 is the all-equal row,
+    // TRUE via the innermost `>=`. The desugar's re-read would drop it; the
+    // first-class node admits it, counter exactly 1.
+    let counter = Counter()
+    try one().expect("SELECT Id FROM T WHERE (stepper(), 0) >= (0, 0)",
+                     yields: [[1]], routines: stepper(counter))
+    #expect(counter.count == 1)
+  }
+
+  @Test func `a row equality evaluates a stateful component once`() throws {
+    // `(stepper(), 0) = (0, 0)` with `stepper()` = 0 is TRUE. `=` reads each
+    // component once even in the desugar, so this confirms the first-class node
+    // preserves that — counter exactly 1.
+    let counter = Counter()
+    try one().expect("SELECT Id FROM T WHERE (stepper(), 0) = (0, 0)",
+                     yields: [[1]], routines: stepper(counter))
+    #expect(counter.count == 1)
+  }
+
+  @Test func `a row inequality evaluates a stateful component once`() throws {
+    // `(stepper(), 0) <> (9, 9)` with `stepper()` = 0 is NOT(FALSE) = TRUE.
+    // `<>` is the negation of the componentwise equality, each read once —
+    // counter exactly 1.
+    let counter = Counter()
+    try one().expect("SELECT Id FROM T WHERE (stepper(), 0) <> (9, 9)",
+                     yields: [[1]], routines: stepper(counter))
+    #expect(counter.count == 1)
+  }
+}
+
+// MARK: - Reachability
+
+/// The type-check reachability of a row comparison and a row `IN` must match
+/// the executor's SHORT-CIRCUIT exactly as the scalar `.comparison`/
+/// `.membership` do — a constant-false row guard folds an `AND` (leaving its
+/// right arm unreachable and unvalidated), and a definite constant match in a
+/// row `IN`'s element list prunes every later element. Folding TOO MUCH would
+/// accept an invalid query, so only a ROW-INDEPENDENT (all-constant) guard that
+/// DEFINITELY settles a branch prunes it; a row-dependent guard stays reachable
+/// and is still validated. A text column `Name` makes `Name + 1` a REAL type
+/// fault (`operands must be numeric`) wherever it is reached.
+struct RowValueReachabilityTests {
+  /// A relation with a TEXT column `Name`, so `Name + 1` is a genuine type
+  /// error wherever the reachability walk reaches it — the probe the pruning
+  /// tests turn on.
+  private func texts() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["Id": .integer, "Name": .text]) {
+        Row(1, "a")
+        Row(2, "b")
+      }
+    }
+  }
+
+  // MARK: Unreachable — must NOT reject
+
+  @Test func `a constant match in a row IN prunes a later bad element`()
+      throws {
+    // `(1, 2) IN ((1, 2), (Name + 1, 3))`: the constant left `(1, 2)`
+    // DEFINITELY matches the first element, so `Filter.memberships`
+    // short-circuits and the second element's `Name + 1` (text arithmetic) is
+    // unreachable — the type check must not validate it, and the run keeps
+    // every row.
+    let query = try parse(query:
+        "SELECT Id FROM T WHERE (1, 2) IN ((1, 2), (Name + 1, 3))")
+    _ = try texts().columns(of: query, validate: true)
+    try texts().expect(
+        "SELECT Id FROM T WHERE (1, 2) IN ((1, 2), (Name + 1, 3))",
+        yields: [[1], [2]])
+  }
+
+  @Test func `a constant-false row guard makes the AND right arm unreachable`()
+      throws {
+    // `(1, 2) = (3, 4) AND Name + 1 = 0`: the left conjunct folds DEFINITELY
+    // FALSE (a row `=` over constants), so the executor's `AND` short-circuits
+    // and `Name + 1` is unreachable — the type check must not validate it, and
+    // the run yields no rows.
+    let query = try parse(query:
+        "SELECT Id FROM T WHERE (1, 2) = (3, 4) AND Name + 1 = 0")
+    _ = try texts().columns(of: query, validate: true)
+    try texts().empty("SELECT Id FROM T WHERE (1, 2) = (3, 4) AND Name + 1 = 0")
+  }
+
+  @Test func `a constant-false row inequality guard prunes the AND right arm`()
+      throws {
+    // `(1, 2) <> (1, 2) AND Name + 1 = 0`: a row `<>` over equal constants
+    // folds DEFINITELY FALSE (the negation of the all-TRUE `=`), so the `AND`
+    // short-circuits and `Name + 1` is unreachable and unvalidated.
+    let query = try parse(query:
+        "SELECT Id FROM T WHERE (1, 2) <> (1, 2) AND Name + 1 = 0")
+    _ = try texts().columns(of: query, validate: true)
+    try texts().empty(
+        "SELECT Id FROM T WHERE (1, 2) <> (1, 2) AND Name + 1 = 0")
+  }
+
+  @Test func `a constant-true row guard makes the OR right arm unreachable`()
+      throws {
+    // `(1, 2) = (1, 2) OR Name + 1 = 0`: the left disjunct folds DEFINITELY
+    // TRUE, so the executor's `OR` short-circuits and `Name + 1` is
+    // unreachable — the type check must not validate it (mirroring the scalar
+    // `1 = 1 OR …`), and the run keeps every row.
+    let query = try parse(query:
+        "SELECT Id FROM T WHERE (1, 2) = (1, 2) OR Name + 1 = 0")
+    _ = try texts().columns(of: query, validate: true)
+    try texts().expect(
+        "SELECT Id FROM T WHERE (1, 2) = (1, 2) OR Name + 1 = 0",
+        yields: [[1], [2]])
+  }
+
+  // MARK: Reachable — must still fault
+
+  @Test func `no constant match in a row IN leaves a bad element reachable`() {
+    // `(1, 2) IN ((3, 4), (Name + 1, 5))`: no element DEFINITELY matches the
+    // constant left, so the second element stays reachable — the pruning is
+    // PRECISE — and its `Name + 1` must still fault the type check, exactly as
+    // the run would when it evaluates the second row equality.
+    let query = try! parse(query:
+        "SELECT Id FROM T WHERE (1, 2) IN ((3, 4), (Name + 1, 5))")
+    let resolve = { () throws -> Array<OutputColumn> in
+      try texts().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.operand("operands must be numeric")) {
+      try resolve()
+    }
+  }
+
+  @Test func `a constant-true row guard leaves the AND right arm reachable`() {
+    // `(1, 2) = (1, 2) AND Name + 1 = 0`: the left conjunct folds DEFINITELY
+    // TRUE, so the `AND` does NOT short-circuit and `Name + 1` is reachable —
+    // it must still fault the type check, matching the run.
+    let query = try! parse(query:
+        "SELECT Id FROM T WHERE (1, 2) = (1, 2) AND Name + 1 = 0")
+    let resolve = { () throws -> Array<OutputColumn> in
+      try texts().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.operand("operands must be numeric")) {
+      try resolve()
+    }
+  }
+
+  @Test func `a bad component in a reachable row comparison faults`() {
+    // `(1, Name + 1) = (1, 2)`: a row `=` evaluates ALL its components at
+    // runtime (`compare` reads both whole rows before folding), so `Name + 1`
+    // is reachable and must fault the type check — the `check` `.rows` arm
+    // validates every component, unchanged.
+    let query = try! parse(query:
+        "SELECT Id FROM T WHERE (1, Name + 1) = (1, 2)")
+    let resolve = { () throws -> Array<OutputColumn> in
+      try texts().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.operand("operands must be numeric")) {
+      try resolve()
+    }
+  }
+}


### PR DESCRIPTION
Support ISO 9075 row value constructors on both sides of a comparison (=, <>, <, <=, >, >=) and in [NOT] IN, desugared at parse time into the existing scalar comparison / AND / OR / NOT predicate machinery — so no new AST node or Filter case, and the evaluator's Kleene three-valued NULL logic is inherited unchanged.

A comma inside the parentheses marks a row constructor; a single parenthesised scalar (x) is unchanged. primary() detects and commits to the row form so an arity mismatch faults SQLError.arity rather than triggering the parenthesised-predicate rewind, and a (SELECT …) scalar subquery still rewinds to the scalar path.

Equality expands to a conjunction of element equalities, <> to its negation, and the order operators to the lexicographic cascade; row IN to a disjunction of row equalities. n-ary rows (beyond pairs) generalise the same way.