### PR TITLE
WinMD: construct Filter value predicates via labeled inits

### DIFF
--- a/Sources/SQLEngine/Engine.swift
+++ b/Sources/SQLEngine/Engine.swift
@@ -2675,7 +2675,7 @@ extension Catalog where Self: ~Escapable {
     // `.match` (folded to the join key), and the residual `p_R` shifts
     // alongside into this `left ++ scan` space.
     let scan = Plan.scan(name: name, ordinals: scanOrdinals, seek: nil)
-    let matched = Filter.match(correlate.outer, base + correlate.inner)
+    let matched = Filter(match: correlate.outer, base + correlate.inner)
     let shifted = residual.map { $0.shifted(by: -base) }
     // The apply's `on` addresses the `left ++ taken` space; map it into this
     // `left ++ scan` space (taken column `base + j` becomes the scan slot `base
@@ -2923,7 +2923,7 @@ extension Catalog where Self: ~Escapable {
     // straddling `.match` (the executor's hash key), and the residual `p_R`
     // shifts alongside into this `left ++ scan` space.
     let scan = Plan.scan(name: name, ordinals: scanOrdinals, seek: nil)
-    let matched = Filter.match(outer, base + inner)
+    let matched = Filter(match: outer, base + inner)
     let shifted = residual.map { $0.shifted(by: -base) }
     // The IN membership equality `operand = projected` rides `on` AFTER the
     // correlation match (so `equikey` still hashes on the correlation) and
@@ -2933,7 +2933,8 @@ extension Catalog where Self: ~Escapable {
     // plus the residual exactly as before (a `nil` operand ⇒ byte-identical).
     var conjuncts = [matched]
     if let operand, let projected {
-      conjuncts.append(.compare(operand, .equal, .slot(base + projected)))
+      conjuncts.append(Filter(compare: operand, .equal,
+                              .slot(base + projected)))
     }
     conjuncts.append(contentsOf: shifted)
     let on = conjuncts.conjunction ?? matched
@@ -3087,7 +3088,7 @@ extension Catalog where Self: ~Escapable {
     // straddling `.match` (the executor's hash key), and the residual `p_R`
     // shifts alongside into this `left ++ scan` space.
     let scan = Plan.scan(name: name, ordinals: scanOrdinals, seek: nil)
-    let matched = Filter.match(outer, base + inner)
+    let matched = Filter(match: outer, base + inner)
     let shifted = residual.map { $0.shifted(by: -base) }
     let on = ([matched] + shifted).conjunction ?? matched
     // A unique-`Id` key matches AT MOST ONE R row, so a plain LEFT join reads

--- a/Sources/SQLEngine/Filter.swift
+++ b/Sources/SQLEngine/Filter.swift
@@ -166,6 +166,80 @@ internal indirect enum Filter: Equatable, Sendable {
   }
 }
 
+// MARK: - Leaf construction
+
+extension Filter {
+  /// The value-predicate leaf `compare(lhs, op, rhs)` — a labeled convenience
+  /// initializer so an authoring site reads `Filter(compare: lhs, op, rhs)`
+  /// rather than the bare case. A thin forward: no operand normalization.
+  internal init(compare lhs: Term, _ op: Comparison, _ rhs: Term) {
+    self = .compare(lhs, op, rhs)
+  }
+
+  /// The value-predicate leaf `match(left, right)` — a labeled convenience
+  /// initializer so an authoring site reads `Filter(match: left, right)`. A
+  /// thin forward to the case.
+  internal init(match left: Int, _ right: Int) {
+    self = .match(left, right)
+  }
+
+  /// The value-predicate leaf `null(term, negated:)` — a labeled convenience
+  /// initializer so an authoring site reads `Filter(null: term, negated:)`. A
+  /// thin forward to the case.
+  internal init(null term: Term, negated: Bool) {
+    self = .null(term, negated: negated)
+  }
+
+  /// The value-predicate leaf `membership(operand, values, negated:)` — a
+  /// labeled convenience initializer so an authoring site reads
+  /// `Filter(membership: operand, values, negated:)`. The middle value list is
+  /// unlabeled as in the case. A thin forward.
+  internal init(membership operand: Term, _ values: Array<Term>,
+                negated: Bool) {
+    self = .membership(operand, values, negated: negated)
+  }
+
+  /// The value-predicate leaf `between(test, lower, upper, negated:)` — a
+  /// labeled convenience initializer so an authoring site reads
+  /// `Filter(between: test, lower, upper, negated:)`. A thin forward.
+  internal init(between test: Term, _ lower: Operand, _ upper: Operand,
+                negated: Bool) {
+    self = .between(test, lower, upper, negated: negated)
+  }
+
+  /// The value-predicate leaf `like(operand, pattern:, escape:, negated:)` — a
+  /// labeled convenience initializer so an authoring site reads
+  /// `Filter(like: operand, pattern:, escape:, negated:)`. A thin forward.
+  internal init(like operand: Term, pattern: Operand, escape: Operand?,
+                negated: Bool) {
+    self = .like(operand, pattern: pattern, escape: escape, negated: negated)
+  }
+
+  /// The value-predicate leaf `distinct(lhs, rhs, negated:)` — a labeled
+  /// convenience initializer so an authoring site reads
+  /// `Filter(distinct: lhs, rhs, negated:)`. A thin forward.
+  internal init(distinct lhs: Term, _ rhs: Term, negated: Bool) {
+    self = .distinct(lhs, rhs, negated: negated)
+  }
+
+  /// The value-predicate leaf `comparison(lhs, op, rhs)` — a labeled
+  /// convenience initializer so a row-value authoring site reads
+  /// `Filter(comparison: lhs, op, rhs)`. A thin forward.
+  internal init(comparison lhs: Array<Term>, _ op: Comparison,
+                _ rhs: Array<Term>) {
+    self = .comparison(lhs, op, rhs)
+  }
+
+  /// The value-predicate leaf `memberships(lhs, rows, negated:)` — a labeled
+  /// convenience initializer so a row-value authoring site reads
+  /// `Filter(memberships: lhs, rows, negated:)`. The middle row list is
+  /// unlabeled as in the case. A thin forward.
+  internal init(memberships lhs: Array<Term>, _ rows: Array<Array<Term>>,
+                negated: Bool) {
+    self = .memberships(lhs, rows, negated: negated)
+  }
+}
+
 // MARK: - Terms
 
 /// The engine's ordinal-addressed scalar expression.
@@ -486,34 +560,37 @@ extension Filter {
   internal func remapped(through slot: Dictionary<Int, Int>) -> Filter {
     switch self {
     case let .compare(lhs, op, rhs):
-      .compare(lhs.remapped(through: slot), op, rhs.remapped(through: slot))
+      Filter(compare: lhs.remapped(through: slot), op,
+             rhs.remapped(through: slot))
     case let .bound(term, op, parameter):
       .bound(term.remapped(through: slot), op, parameter)
     case let .match(left, right):
-      .match(slot[left]!, slot[right]!)
+      Filter(match: slot[left]!, slot[right]!)
     case let .null(term, negated):
-      .null(term.remapped(through: slot), negated: negated)
+      Filter(null: term.remapped(through: slot), negated: negated)
     case let .membership(operand, elements, negated):
-      .membership(operand.remapped(through: slot),
-                  elements.map { $0.remapped(through: slot) },
-                  negated: negated)
+      Filter(membership: operand.remapped(through: slot),
+             elements.map { $0.remapped(through: slot) },
+             negated: negated)
     case let .comparison(lhs, op, rhs):
-      .comparison(lhs.map { $0.remapped(through: slot) }, op,
-                  rhs.map { $0.remapped(through: slot) })
+      Filter(comparison: lhs.map { $0.remapped(through: slot) }, op,
+             rhs.map { $0.remapped(through: slot) })
     case let .memberships(lhs, rows, negated):
-      .memberships(lhs.map { $0.remapped(through: slot) },
-                   rows.map { $0.map { $0.remapped(through: slot) } },
-                   negated: negated)
+      Filter(memberships: lhs.map { $0.remapped(through: slot) },
+             rows.map { $0.map { $0.remapped(through: slot) } },
+             negated: negated)
     case let .like(operand, pattern, escape, negated):
-      .like(operand.remapped(through: slot),
-            pattern: pattern.remapped(through: slot),
-            escape: escape?.remapped(through: slot), negated: negated)
+      Filter(like: operand.remapped(through: slot),
+             pattern: pattern.remapped(through: slot),
+             escape: escape?.remapped(through: slot), negated: negated)
     case let .between(test, lower, upper, negated):
-      .between(test.remapped(through: slot), lower.remapped(through: slot),
-               upper.remapped(through: slot), negated: negated)
+      Filter(between: test.remapped(through: slot),
+             lower.remapped(through: slot),
+             upper.remapped(through: slot), negated: negated)
     case let .distinct(lhs, rhs, negated):
-      .distinct(lhs.remapped(through: slot), rhs.remapped(through: slot),
-                negated: negated)
+      Filter(distinct: lhs.remapped(through: slot),
+             rhs.remapped(through: slot),
+             negated: negated)
     case let .exists(key, correlation, negated):
       // A CORRELATED EXISTS reads the enclosing row's cells its inner `WHERE`
       // names; remap each `slot` outer ordinal to its packed slot (a `bound`

--- a/Sources/SQLEngine/Resolve.swift
+++ b/Sources/SQLEngine/Resolve.swift
@@ -1063,11 +1063,11 @@ private func lower(_ predicate: Predicate,
     throws(SQLError) -> Filter {
   switch predicate {
   case let .comparison(left, op, right):
-    try .compare(term(left), op, term(right))
+    try Filter(compare: term(left), op, term(right))
   case let .bound(left, op, parameter):
     try .bound(term(left), op, parameter)
   case let .null(expression, negated):
-    try .null(term(expression), negated: negated)
+    try Filter(null: term(expression), negated: negated)
   case let .exists(query, negated):
     // `[NOT] EXISTS (Q)`. In this first slice `Q` is UNCORRELATED, so the
     // materialiser runs it ONCE (as a CTE body materialises) and the whole
@@ -1132,15 +1132,15 @@ private func lower(_ predicate: Predicate,
     // `b` making a bound UNKNOWN and excluding the row, the ISO range test.
     // Each bound lowers through the same `Operand` form a `LIKE` pattern does,
     // a `.term` or a `:parameter` name resolved from the bindings at eval.
-    try .between(term(test), lower(low, term: term), lower(high, term: term),
-                 negated: negated)
+    try Filter(between: term(test), lower(low, term: term),
+               lower(high, term: term), negated: negated)
   case let .distinct(lhs, rhs, negated):
     // `a IS [NOT] DISTINCT FROM b` lowers to a first-class `Filter.distinct`
     // over the two lowered terms — the null-safe comparison the runtime
     // evaluates TWO-VALUED, treating NULL as a comparable value. No
     // `:parameter` form is defined, so both sides lower straight through
     // `term`.
-    try .distinct(term(lhs), term(rhs), negated: negated)
+    try Filter(distinct: term(lhs), term(rhs), negated: negated)
   case let .truth(inner, value, negated):
     // `p IS [NOT] <truth value>` lowers to a first-class `Filter.truth` over
     // the lowered inner boolean filter; the three-valued-to-definite mapping
@@ -1188,7 +1188,7 @@ private func membership(_ left: Term, _ values: Array<Expression>,
   for value in values {
     try elements.append(term(value))
   }
-  return .membership(left, elements, negated: negated)
+  return Filter(membership: left, elements, negated: negated)
 }
 
 /// Lowers `(l…) <op> (r…)` to a first-class `Filter.comparison(l, op, r)`, the
@@ -1216,7 +1216,7 @@ private func rows(_ lhs: Array<Expression>, _ op: Comparison,
   var r = Array<Term>()
   r.reserveCapacity(rhs.count)
   for expression in rhs { try r.append(term(expression)) }
-  return .comparison(l, op, r)
+  return Filter(comparison: l, op, r)
 }
 
 /// Lowers `(l…) [NOT] IN ((r…), …)` to a first-class
@@ -1254,7 +1254,7 @@ private func among(_ lhs: Array<Expression>, _ rows: Array<Array<Expression>>,
     for expression in element { try row.append(term(expression)) }
     elements.append(row)
   }
-  return .memberships(l, elements, negated: negated)
+  return Filter(memberships: l, elements, negated: negated)
 }
 
 /// Lowers `operand [NOT] LIKE pattern [ESCAPE escape]` to a first-class
@@ -1272,8 +1272,8 @@ private func like(_ operand: Expression, _ pattern: Predicate.Operand,
     throws(SQLError) -> Filter {
   let escape: Filter.Operand? =
       if let escape { try lower(escape, term: term) } else { nil }
-  return try .like(term(operand), pattern: lower(pattern, term: term),
-                   escape: escape, negated: negated)
+  return try Filter(like: term(operand), pattern: lower(pattern, term: term),
+                    escape: escape, negated: negated)
 }
 
 /// Lowers a `LIKE` pattern or escape `operand` to its filter form: an
@@ -3832,7 +3832,7 @@ internal struct Scope {
     // `SQLError.column` on the outer column already lowered correctly.
     let filters = lowered.map { residual -> Filter in
       if case let .compare(.slot(left), .equal, .slot(right)) = residual {
-        return .match(left, right)
+        return Filter(match: left, right)
       }
       return residual
     }


### PR DESCRIPTION
Add thin labeled convenience initializers on `Filter` for the leaf value-predicate cases — `compare`, `match`, `null`, `membership`, `between`, `like`, `distinct`, `comparison`, and `memberships` — so an authoring site reads `Filter(compare: lhs, op, rhs)` rather than the bare `Filter.compare(...)` enum-case constructor, establishing a "construct via labeled init" convention for these leaves.

Each initializer is a pure one-line forward to its case (`self = .case(...)`), mirroring the case's exact associated-value labels (the unlabeled middle args stay unlabeled) — no canonicalization, no operand reordering, no logic — so the change is behavior-preserving. Every authoring site of an in-scope case is migrated to the init form, including the reconstructions in `Filter.remapped(through:)`, the `Predicate` lowering in `Resolve`, and the semijoin/apply builders in `Engine`. Pattern-match sites and the structural/compile-internal cases (`and`/`or`/`not`, `bound`/`truth`/`exists`/`within`/`quantified`) are left as bare cases.