### PR TITLE
SQLEngine: add ISO derived/named-relation column-list aliases

### DIFF
--- a/Sources/SQLEngine/AST.swift
+++ b/Sources/SQLEngine/AST.swift
@@ -421,6 +421,16 @@ public struct Relation: Hashable, Sendable {
   /// present for a `derived` one (ISO requires a derived table be aliased).
   public let alias: String?
 
+  /// The relation's explicit output column names — the ISO `AS t(c, …)` list —
+  /// in ordinal order, or empty when the relation carries no list. A supplied
+  /// list positionally RENAMES the relation's real output columns (the same
+  /// mechanism a CTE's `columns` list applies), so `FROM T AS t(c, d)` and
+  /// `(SELECT x, y FROM T) AS d(a, b)` address the relation's columns by the
+  /// new names. ISO admits the list on BOTH a named relation and a derived
+  /// table, so it rides on the shared `Relation` node. Empty matches the CTE
+  /// field's shape (an absent list, columns inferred from the source).
+  public let columns: Array<String>
+
   /// Whether a `LATERAL` derived table — its body may reference the PRECEDING
   /// FROM items, so it re-evaluates per their rows (a correlated apply), rather
   /// than materialising once. Always `false` for a `named` relation and for a
@@ -428,19 +438,25 @@ public struct Relation: Hashable, Sendable {
   /// call site.
   public let lateral: Bool
 
-  /// A named base relation, view, or CTE with an optional alias.
-  public init(name: String, alias: String? = nil) {
+  /// A named base relation, view, or CTE with an optional alias and an optional
+  /// explicit output column list (`FROM T AS t(c, d)`).
+  public init(name: String, alias: String? = nil,
+              columns: Array<String> = []) {
     self.source = .named(name)
     self.alias = alias
+    self.columns = columns
     self.lateral = false
   }
 
-  /// A derived table over `query`, resolved under the mandatory `alias`. A
+  /// A derived table over `query`, resolved under the mandatory `alias`, with
+  /// an optional explicit output column list (`(SELECT …) AS d(a, b)`). A
   /// `lateral` one resolves against the preceding FROM items and re-evaluates
   /// per their rows; a plain one materialises once, independent of the caller.
-  public init(derived query: Query, as alias: String, lateral: Bool = false) {
+  public init(derived query: Query, as alias: String,
+              columns: Array<String> = [], lateral: Bool = false) {
     self.source = .derived(query)
     self.alias = alias
+    self.columns = columns
     self.lateral = lateral
   }
 

--- a/Sources/SQLEngine/Definition.swift
+++ b/Sources/SQLEngine/Definition.swift
@@ -215,7 +215,7 @@ extension Catalog where Self: ~Escapable {
             store(relation, rows: rows, context.routines)
       }
     }
-    var derivations = Array<(String, Query)>()
+    var derivations = Array<(String, Query, Array<String>)>()
     query.collect(derived: &derivations)
     if derivations.isEmpty { return context.scoping(augmented) }
     // A derived table's alias sharing a RANGE NAME with another FROM/JOIN item
@@ -254,7 +254,7 @@ extension Catalog where Self: ~Escapable {
     var counts = Dictionary<String, Int>()
     for range in ranges { counts[range.lowercased(), default: 0] += 1 }
     let sources = Set(identifiers.map { $0.lowercased() })
-    for (alias, _) in derivations {
+    for (alias, _, _) in derivations {
       let name = alias.lowercased()
       // >1 range: the derived alias equals another FROM/JOIN item's exposed
       // range name (a sibling derived alias, or an unaliased named relation).
@@ -298,15 +298,20 @@ extension Catalog where Self: ~Escapable {
                                 == $0.1 }) {
       return context.scoping(augmented)
     }
+    // A derived table's optional `AS d(a, b)` column list renames its output
+    // columns; thread it into `materialise` so the bound `RelationInstance`
+    // carries the RENAMED names — the same overlay both `resolve` and
+    // `schema(of:)` read a derived table's schema back from, so the run and the
+    // schema-only paths see the renamed columns from ONE seam.
     // Materialise each alias's body against the revealed base scope (a
     // same-named CTE visible, the derived aliases being defined not), then push
     // them as one derived layer that SHADOWS an outer CTE or derived alias of
     // the same name in the scope THIS SELECT resolves its OWN references
     // against (projection/WHERE/JOIN-ON/GROUP/HAVING).
     var layer = Dictionary<String, RelationInstance>()
-    for (alias, inner) in derivations {
+    for (alias, inner, columns) in derivations {
       layer[alias.lowercased()] =
-          try materialise(inner, scope, rows: rows)
+          try materialise(inner, scope, rows: rows, columns: columns)
     }
     return context.scoping(augmented.pushing(layer))
   }
@@ -336,7 +341,7 @@ extension Catalog where Self: ~Escapable {
   /// schema and run paths bind the same nested aliases before either reads the
   /// inner query.
   borrowing func materialise(_ query: Query, _ context: Context,
-                             rows: Bool)
+                             rows: Bool, columns renaming: Array<String> = [])
       throws(SQLError) -> RelationInstance {
     // Bind the inner query's OWN derived tables (and store relations) before
     // deriving its schema — a run augments them recursively, so the schema
@@ -370,16 +375,35 @@ extension Catalog where Self: ~Escapable {
     // NOT eager-type-checked before execution, exactly as the non-derived path
     // never evaluates an unreached operand — while the strict schema path
     // (`validate: true`) still faults it.
-    let outputs = try columns(of: query.first, scope)
-    // A derived table's columns are its inner query's OUTPUT names, so two
-    // same-named ones (`SELECT Id AS x, V AS x`) leave the shadowed one
-    // unreachable through the alias — exactly the case the Parser rejects for a
-    // view's or a CTE's inferred column list. Fault it the SAME way here
-    // (`SQLError.duplicate`, the "duplicate view column" fault), so it faults
-    // at BOTH the schema-only path and a run rather than silently exposing the
-    // first `x`. A plain top-level `SELECT Id AS x, V AS x` stays legal — the
-    // duplicate matters only where the relation is named and its columns are
-    // addressed by that name (a view, a CTE, a derived table).
+    let derived = try columns(of: query.first, scope)
+    // An explicit `AS d(a, b)` column list positionally RENAMES the derived
+    // table's inner output names, keeping each column's inferred TYPE (the list
+    // names, the body types), so `(SELECT x, y FROM T) AS d(a, b)` addresses
+    // the columns as `a`, `b`. Its arity must match the inner output width
+    // (`SQLError.columns`, the CTE/view arity fault) — checked HERE, where the
+    // width is resolved, so a list over a `SELECT *` derived body is checked
+    // once its `*` expands. Absent a list, the inner output names stand.
+    let outputs: Array<OutputColumn>
+    if renaming.isEmpty {
+      outputs = derived
+    } else {
+      guard renaming.count == derived.count else {
+        throw .columns(expected: derived.count, got: renaming.count)
+      }
+      outputs = renaming.indices.map {
+        OutputColumn(name: renaming[$0], type: derived[$0].type)
+      }
+    }
+    // A derived table's columns are its inner query's OUTPUT names (or the
+    // explicit list above), so two same-named ones (`SELECT Id AS x, V AS x`,
+    // or a `d(a, a)` list) leave the shadowed one unreachable through the alias
+    // — exactly the case the Parser rejects for a view's or a CTE's inferred
+    // column list. Fault it the SAME way here (`SQLError.duplicate`, the
+    // "duplicate view column" fault), so it faults at BOTH the schema-only path
+    // and a run rather than silently exposing the first `x`. A plain top-level
+    // `SELECT Id AS x, V AS x` stays legal — the duplicate matters only where
+    // the relation is named and its columns are addressed by that name (a view,
+    // a CTE, a derived table).
     var seen = Set<String>()
     for output in outputs
         where !seen.insert(output.name.lowercased()).inserted {
@@ -649,7 +673,8 @@ extension Query {
   /// tables in its own scope (see `Catalog.augment`/`materialise`). Descending
   /// would bind those aliases into one map, where two siblings sharing an alias
   /// `t` collide and an inner `t` cannot shadow an outer.
-  func collect(derived derivations: inout Array<(String, Query)>) {
+  func collect(derived derivations:
+                   inout Array<(String, Query, Array<String>)>) {
     if case let .select(select) = self {
       select.collect(derived: &derivations)
     }
@@ -721,15 +746,16 @@ extension Select {
   /// resolved against the preceding FROM and re-evaluated per its rows (a
   /// correlated apply), so `compile(select)` binds and executes it directly
   /// rather than through the overlay `augment` builds.
-  func collect(derived derivations: inout Array<(String, Query)>) {
+  func collect(derived derivations:
+                   inout Array<(String, Query, Array<String>)>) {
     if case let .derived(query) = from?.source, let alias = from?.alias,
         !(from?.lateral ?? false) {
-      derivations.append((alias, query))
+      derivations.append((alias, query, from?.columns ?? []))
     }
     for join in joins {
       if case let .derived(query) = join.relation.source,
           let alias = join.relation.alias, !join.relation.lateral {
-        derivations.append((alias, query))
+        derivations.append((alias, query, join.relation.columns))
       }
     }
   }

--- a/Sources/SQLEngine/Engine.swift
+++ b/Sources/SQLEngine/Engine.swift
@@ -2614,7 +2614,7 @@ extension Catalog where Self: ~Escapable {
     // body query declares any derived tables of its own — the SAME
     // `collect(derived:)` the augment path uses over the body select — and
     // leave the apply correlated.
-    var derivations = Array<(String, Query)>()
+    var derivations = Array<(String, Query, Array<String>)>()
     key.query.collect(derived: &derivations)
     guard derivations.isEmpty else { return nil }
     // The scan must also name a genuine BASE relation, not a CTE/store overlay
@@ -2875,7 +2875,7 @@ extension Catalog where Self: ~Escapable {
         let base = left.slots else { return nil }
     // No body-local derived table: its per-execution alias cannot be relaid as
     // a caller-level scan — the SAME hazard the CROSS APPLY recogniser guards.
-    var derivations = Array<(String, Query)>()
+    var derivations = Array<(String, Query, Array<String>)>()
     key.query.collect(derived: &derivations)
     guard derivations.isEmpty else { return nil }
     // The scan must name a genuine BASE relation, not a CTE/store overlay entry
@@ -3030,7 +3030,7 @@ extension Catalog where Self: ~Escapable {
         left.slots == base else { return nil }
     // No body-local derived table: its per-execution alias cannot be relaid as
     // a caller-level scan — the SAME hazard the semijoin recogniser guards.
-    var derivations = Array<(String, Query)>()
+    var derivations = Array<(String, Query, Array<String>)>()
     key.query.collect(derived: &derivations)
     guard derivations.isEmpty else { return nil }
     // The scan must name a genuine BASE relation, not a CTE/store overlay entry
@@ -3983,6 +3983,7 @@ extension Catalog where Self: ~Escapable {
   /// NOT eagerly type-checked, matching the reachability-gated validation the
   /// rest of the engine applies; a REACHED bad operand still faults at run.
   private borrowing func lateral(_ body: Query, against scope: Scope,
+                                 columns renaming: Array<String>,
                                  _ context: Context)
       throws(SQLError) -> (key: Subkey, correlation: Correlation) {
     let nested = (context.outer ?? Outer()).nested(under: scope)
@@ -4000,8 +4001,14 @@ extension Catalog where Self: ~Escapable {
     // stays barred. The flag rides through the shared derived-body machinery to
     // the projection lowering, where a projected preceding column lowers to a
     // `Term.parameter` rather than faulting `.unsupported`.
+    // Thread the derived table's explicit `AS d(a, b)` column list into the
+    // body's schema derive so this validation checks the same EXPOSED (renamed)
+    // names `schema(of:)` advertises — its arity (`SQLError.columns`) and
+    // uniqueness (`SQLError.duplicate`) run against the renamed list, so a list
+    // hiding a duplicate INNER name (`SELECT T.Id AS x, T.Id AS x) AS d(a, b)`)
+    // passes at BOTH seams rather than faulting only here.
     let revealed = context.revealed().with(outer: nested).lateralizing()
-    _ = try materialise(body, revealed, rows: false)
+    _ = try materialise(body, revealed, rows: false, columns: renaming)
     // Compile the body LENIENTLY for the per-outer-row apply plan (the shape
     // pass a correlated subquery's pre-pass runs), recording it under the
     // occurrence's key composed with the discovered correlation. It compiles
@@ -4044,8 +4051,19 @@ extension Catalog where Self: ~Escapable {
         .scan(name: name, ordinals: ordinals, seek: nil)
       }
     }
+    // The explicit `AS t(c, …)` list positionally renames a NAMED relation's
+    // output columns; a DERIVED table's list was applied where it materialised
+    // (its overlay binding carries the renamed names), so only a `.named`
+    // source renames HERE — the compile-path mirror of `schema(of:)`'s named
+    // rename, kept in parity so compile and the schema-only path resolve the
+    // SAME column names.
+    let columns: Array<String> = if case .named = relation.source {
+      relation.columns
+    } else {
+      []
+    }
     if let cte = context.relations[name.lowercased()] {
-      let schema = cte.schema()
+      let schema = try cte.schema().renamed(columns)
       return Resolved(schema: schema) { ordinals in
         .scan(name: name, ordinals: ordinals, seek: nil)
       }
@@ -4103,7 +4121,7 @@ extension Catalog where Self: ~Escapable {
       guard view.columns.count == projected else {
         throw .columns(expected: projected, got: view.columns.count)
       }
-      let schema = view.schema()
+      let schema = try view.schema().renamed(columns)
       return Resolved(schema: schema) { ordinals in
         .derived(name: name, plan: plan, ordinals: ordinals, seek: nil)
       }
@@ -4112,7 +4130,7 @@ extension Catalog where Self: ~Escapable {
     guard let table = table(named: name) else {
       throw .relation(name)
     }
-    let schema = table.schema()
+    let schema = try table.schema().renamed(columns)
     return Resolved(schema: schema) { ordinals in
       .scan(name: name, ordinals: ordinals, seek: nil)
     }
@@ -4328,7 +4346,8 @@ extension Catalog where Self: ~Escapable {
         throw .state("0A000", "a RIGHT/FULL LATERAL join is not supported")
       }
       let preceding = Scope(Array(relations[0 ... index]))
-      laterals[index] = try lateral(body, against: preceding, context)
+      laterals[index] = try lateral(body, against: preceding,
+                                    columns: join.relation.columns, context)
     }
     // Compile every nested subquery ONCE for arity/type, ahead of lowering,
     // into a map the join ONs, WHERE, projection, and ORDER BY lowering reads —

--- a/Sources/SQLEngine/OutputColumn.swift
+++ b/Sources/SQLEngine/OutputColumn.swift
@@ -955,16 +955,29 @@ extension Catalog where Self: ~Escapable {
       let nested = stack.nested(under: preceding ?? Scope([]))
       let scope = context.revealed().with(outer: nested)
           .lateralizing().validating(false)
-      return try materialise(query, scope, rows: false).schema()
+      return try materialise(query, scope, rows: false,
+                             columns: relation.columns).schema()
+    }
+    // The explicit `AS t(c, …)` list positionally renames a NAMED relation's
+    // output columns; a DERIVED table's list was already applied where it
+    // materialised (its overlay binding below carries the renamed names), so
+    // only a `.named` source renames HERE — never double-renaming a derived
+    // table read back through the overlay. This is the schema-only mirror of
+    // `resolve`'s named-relation rename, kept in parity so the two paths
+    // advertise the SAME column names.
+    let renaming: Array<String> = if case .named = relation.source {
+      relation.columns
+    } else {
+      []
     }
     if let cte = context.relations[name.lowercased()] {
-      return cte.schema()
+      return try cte.schema().renamed(renaming)
     }
     // A reserved store relation types through its SCHEMA-ONLY build (header +
     // types, no rows), so resolving a view over `definition_schema.tables`/
     // `.columns` reads only the schema and never triggers the row builder.
     if let relation = Definition(name) {
-      return store(relation, rows: false).schema()
+      return try store(relation, rows: false).schema().renamed(renaming)
     }
     if let view = resolve(view: name) {
       // A view's declared schema types every column `.integer`, since a view
@@ -979,7 +992,9 @@ extension Catalog where Self: ~Escapable {
       // re-enter this view forever, so break the cycle and fall back to the
       // declared schema (every type the `.integer` default). `try?` cannot
       // catch this — the recursion overflows the stack rather than throwing.
-      if context.visited.contains(name.lowercased()) { return base }
+      if context.visited.contains(name.lowercased()) {
+        return try base.renamed(renaming)
+      }
       // Type-check the body's REACHABLE operands and calls across every arm and
       // clause — `compile` cannot check a routine EXISTS, the first-arm resolve
       // below sees only the first projection, and the outer query's walk does
@@ -1013,14 +1028,17 @@ extension Catalog where Self: ~Escapable {
       // public entry runs it), so on a shortfall fall back to the declared
       // schema rather than re-checking it here.
       let resolved = try columns(of: view.query.first, overlay)
-      guard resolved.count == base.width else { return base }
-      return Schema(width: base.width, extent: base.extent, names: base.names,
-                    types: resolved.map(\.type), virtuals: base.virtuals)
+      guard resolved.count == base.width else {
+        return try base.renamed(renaming)
+      }
+      return try Schema(width: base.width, extent: base.extent,
+                        names: base.names, types: resolved.map(\.type),
+                        virtuals: base.virtuals).renamed(renaming)
     }
     guard let table = table(named: name) else {
       throw .relation(name)
     }
-    return table.schema()
+    return try table.schema().renamed(renaming)
   }
 }
 

--- a/Sources/SQLEngine/Parser.swift
+++ b/Sources/SQLEngine/Parser.swift
@@ -463,6 +463,16 @@ internal struct Parser: ~Escapable {
   /// latter is admitted only when the next token is a bare identifier, so a
   /// following keyword (`JOIN`, `WHERE`, …) or the end of input is not mistaken
   /// for an alias.
+  ///
+  /// Either alias may carry an ISO explicit output column list `'(' identifier
+  /// (, identifier)* ')'` (`AS t(c, d)`), positionally RENAMING the relation's
+  /// output columns — admitted on BOTH a derived table and a named relation.
+  /// The list's ARITY and case-insensitive UNIQUENESS are checked where the
+  /// output width is known (the schema-derivation seam), not here, so a list
+  /// over a `SELECT *` derived table (whose width resolves later) parses.
+  ///
+  /// `relation := [LATERAL] ('(' query ')' | identifier) [[AS] alias ['('
+  /// identifier (, identifier)* ')']]`
   private mutating func relation() throws(SQLError) -> Relation {
     let lateral = try match(.lateral)
     if try match(.lparen) {
@@ -487,7 +497,9 @@ internal struct Parser: ~Escapable {
                           expected: "'AS' and an alias for the derived table",
                           at: token.location)
       }
-      return try Relation(derived: query, as: identifier(), lateral: lateral)
+      let alias = try identifier()
+      return try Relation(derived: query, as: alias,
+                          columns: names() ?? [], lateral: lateral)
     }
     // `LATERAL` introduces a derived table; a named relation may not follow it.
     if lateral {
@@ -506,7 +518,12 @@ internal struct Parser: ~Escapable {
     } else {
       nil
     }
-    return Relation(name: name, alias: alias)
+    // An explicit column list requires an alias to key the renamed columns
+    // under (`T(c, d)` with no alias is ISO-invalid); the `names()` peek only
+    // fires when an alias was taken, so a bare `T` never consumes a following
+    // grouping's `(`.
+    let columns = alias == nil ? [] : try names() ?? []
+    return Relation(name: name, alias: alias, columns: columns)
   }
 
   /// Whether `kind` begins an identifier — a bare or a delimited name — the

--- a/Sources/SQLEngine/Schema.swift
+++ b/Sources/SQLEngine/Schema.swift
@@ -43,6 +43,32 @@ internal struct Schema {
     self.virtuals = virtuals
   }
 
+  /// This schema with its real column `names` positionally RENAMED to
+  /// `columns` — the ISO `AS t(c, …)` explicit output column list — or
+  /// unchanged when `columns` is empty (no list).
+  ///
+  /// The list renames exactly the REAL columns (the `width` a `SELECT *`
+  /// exposes), leaving `virtuals` (the engine's `Id`) addressable by their own
+  /// names, so `T AS t(c, d)` renames `T`'s columns while `t.Id` still
+  /// resolves. `columns` must name exactly one column per real column
+  /// (`SQLError.columns`, the CTE/view arity fault) and be case-insensitively
+  /// unique (`SQLError.duplicate`, so a shadowed rename is not silently
+  /// unreachable) — the same rules a CTE's/view's column list obeys, applied
+  /// where the relation's resolved width is known.
+  internal func renamed(_ columns: Array<String>)
+      throws(SQLError) -> Schema {
+    guard !columns.isEmpty else { return self }
+    guard columns.count == width else {
+      throw .columns(expected: width, got: columns.count)
+    }
+    var seen = Set<String>()
+    for column in columns where !seen.insert(column.lowercased()).inserted {
+      throw .duplicate(column)
+    }
+    return Schema(width: width, extent: extent, names: columns,
+                  types: types, virtuals: virtuals)
+  }
+
   /// The ordinal of the column named `name`, or `nil` if absent.
   ///
   /// A real column resolves against `names` to an ordinal `< width`; a virtual

--- a/Tests/SQLTests/Queries/DerivedColumnListTests.swift
+++ b/Tests/SQLTests/Queries/DerivedColumnListTests.swift
@@ -1,0 +1,258 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQLEngine
+
+import SQLTestSupport
+
+// MARK: - Fixture
+
+/// A source `S` (two real columns) and a keyed `T`, exercising the ISO explicit
+/// output column list `AS name(a, b)` over a derived table and a named
+/// relation.
+private func fixture() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("S", ["x": .integer, "y": .integer]) {
+      Row(1, 10)
+      Row(2, 20)
+      Row(3, 30)
+    }
+    Relation("T", ["Id": .integer, "V": .integer]) {
+      Row(1, 100)
+      Row(2, 200)
+    }
+  }
+}
+
+// MARK: - Parsing
+
+struct DerivedColumnListParsingTests {
+  @Test func `parses a derived table column list`() throws {
+    // `(SELECT …) AS d(a, b)` carries the list on the derived Relation node.
+    let select = try parse(select:
+        "SELECT d.a FROM (SELECT x, y FROM S) AS d(a, b)")
+    let inner = try parse(query: "SELECT x, y FROM S")
+    #expect(select.from ==
+            Relation(derived: inner, as: "d", columns: ["a", "b"]))
+  }
+
+  @Test func `parses a named relation column list`() throws {
+    // `T AS x(c, d)` carries the list on the named Relation node.
+    let select = try parse(select: "SELECT x.c FROM T AS x(c, d)")
+    #expect(select.from ==
+            Relation(name: "T", alias: "x", columns: ["c", "d"]))
+  }
+
+  @Test func `parses a column list on a bare-alias derived table`() throws {
+    // The `AS` is optional, so a bare alias may still carry a column list.
+    let select = try parse(select:
+        "SELECT d.a FROM (SELECT x, y FROM S) d(a, b)")
+    let inner = try parse(query: "SELECT x, y FROM S")
+    #expect(select.from ==
+            Relation(derived: inner, as: "d", columns: ["a", "b"]))
+  }
+
+  @Test func `a column list is optional on a derived table`() throws {
+    // Absent a list, the derived Relation node carries an empty column list —
+    // the CTE field's shape for an inferred set of names.
+    let select = try parse(select: "SELECT d.a FROM (SELECT x AS a FROM S) AS d")
+    let inner = try parse(query: "SELECT x AS a FROM S")
+    #expect(select.from == Relation(derived: inner, as: "d"))
+    #expect(select.from?.columns == [])
+  }
+
+  @Test func `a column list is optional on a named relation`() throws {
+    // A bare `T` never consumes a following `(` as a column list — the peek
+    // fires only after an alias, so a plain named relation stays list-free.
+    let select = try parse(select: "SELECT V FROM T")
+    #expect(select.from == Relation(name: "T"))
+    #expect(select.from?.columns == [])
+  }
+}
+
+// MARK: - Execution: derived table
+
+struct DerivedColumnListExecutionTests {
+  @Test func `a derived table renames its columns by the list`() throws {
+    // `(SELECT x, y FROM S) AS d(a, b)` renames the inner `x`, `y` to `a`, `b`;
+    // selecting the new names yields the inner rows under them.
+    try fixture().expect(
+        "SELECT a, b FROM (SELECT x, y FROM S) AS d(a, b) ORDER BY a",
+        yields: [[1, 10], [2, 20], [3, 30]])
+  }
+
+  @Test func `a derived table renames columns the inner never named`() throws {
+    // The list names the OUTPUT columns positionally regardless of the inner
+    // spelling — here the inner projects bare `x`, `y`, renamed to `a`, `b`.
+    try fixture().expect(
+        "SELECT b FROM (SELECT x, y FROM S) AS d(a, b) ORDER BY a",
+        yields: [[10], [20], [30]])
+  }
+
+  @Test func `a qualified reference resolves the renamed column`() throws {
+    // `d.a` resolves through the alias to the renamed first column.
+    try fixture().expect(
+        "SELECT d.a, d.b FROM (SELECT x, y FROM S) AS d(a, b) ORDER BY d.a",
+        yields: [[1, 10], [2, 20], [3, 30]])
+  }
+
+  @Test func `SELECT * yields the renamed columns`() throws {
+    // A star projection over the renamed derived table exposes the new names in
+    // order — the same rows, addressed as `a`, `b`.
+    try fixture().expect(
+        "SELECT * FROM (SELECT x, y FROM S) AS d(a, b) ORDER BY a",
+        yields: [[1, 10], [2, 20], [3, 30]])
+  }
+
+  @Test func `a renamed derived table filters on the new name`() throws {
+    // A `WHERE` over the renamed column filters the materialised rows.
+    try fixture().expect(
+        "SELECT a FROM (SELECT x, y FROM S) AS d(a, b) WHERE a > 1 ORDER BY a",
+        yields: [[2], [3]])
+  }
+}
+
+// MARK: - Execution: named relation
+
+struct NamedRelationColumnListTests {
+  @Test func `a named relation renames its columns by the list`() throws {
+    // `FROM T AS x(c, d)` renames `T`'s real columns `Id`, `V` to `c`, `d`.
+    try fixture().expect(
+        "SELECT c, d FROM T AS x(c, d) ORDER BY c",
+        yields: [[1, 100], [2, 200]])
+  }
+
+  @Test func `a qualified reference resolves a named relation's rename`()
+      throws {
+    // `x.c` reads the renamed first column of the named relation.
+    try fixture().expect(
+        "SELECT x.c FROM T AS x(c, d) ORDER BY x.c",
+        yields: [[1], [2]])
+  }
+
+  @Test func `SELECT * yields a named relation's renamed columns`() throws {
+    // A star projection over the renamed named relation exposes `c`, `d` — the
+    // real columns only, never the virtual `Id`.
+    try fixture().expect(
+        "SELECT * FROM T AS x(c, d) ORDER BY c",
+        yields: [[1, 100], [2, 200]])
+  }
+
+  @Test func `a named relation's virtual Id survives a column list`() throws {
+    // The list renames only the REAL columns; the virtual `Id` stays
+    // addressable by its own name.
+    try fixture().expect(
+        "SELECT x.Id, x.c FROM T AS x(c, d) ORDER BY x.Id",
+        yields: [[1, 1], [2, 2]])
+  }
+}
+
+// MARK: - Faults
+
+struct ColumnListFaultTests {
+  @Test func `a derived table list of too few columns faults`() throws {
+    // The list must name one column per output; two outputs against a one-name
+    // list is `SQLError.columns`, the CTE/view arity fault.
+    try fixture().expect(
+        "SELECT a FROM (SELECT x, y FROM S) AS d(a)",
+        fails: .columns(expected: 2, got: 1))
+  }
+
+  @Test func `a derived table list of too many columns faults`() throws {
+    try fixture().expect(
+        "SELECT a FROM (SELECT x FROM S) AS d(a, b)",
+        fails: .columns(expected: 1, got: 2))
+  }
+
+  @Test func `a named relation list of the wrong arity faults`() throws {
+    // `T` has two real columns; a three-name list mismatches.
+    try fixture().expect(
+        "SELECT c FROM T AS x(c, d, e)",
+        fails: .columns(expected: 2, got: 3))
+  }
+
+  @Test func `a derived table list with a duplicate name faults`() throws {
+    // A repeated name (case-insensitively) leaves the shadowed column
+    // unreachable, so it faults `SQLError.duplicate`, as a CTE's does.
+    try fixture().expect(
+        "SELECT a FROM (SELECT x, y FROM S) AS d(a, A)",
+        fails: .duplicate("A"))
+  }
+
+  @Test func `a named relation list with a duplicate name faults`() throws {
+    try fixture().expect(
+        "SELECT c FROM T AS x(c, c)",
+        fails: .duplicate("c"))
+  }
+}
+
+// MARK: - Execution: LATERAL derived table
+
+struct LateralColumnListTests {
+  @Test func `a column list renames a lateral body's duplicate inner names`()
+      throws {
+    // The reviewer's case: the body projects `T.Id AS x` TWICE — a duplicate
+    // INNER name the `d(a, b)` list renames positionally to the unique EXPOSED
+    // `a`, `b`. The compile-path validation in `lateral` must check the RENAMED
+    // names, so this runs (both columns = `T.Id`) rather than faulting the
+    // inner duplicate — parity with the schema pass.
+    try fixture().expect(
+        "SELECT d.a, d.b FROM T " +
+        "JOIN LATERAL (SELECT T.Id AS x, T.Id AS x) AS d(a, b) ON 1 = 1 " +
+        "ORDER BY d.a",
+        yields: [[1, 1], [2, 2]])
+  }
+
+  @Test func `a column list renames a lateral body's distinct columns`()
+      throws {
+    // A list over DISTINCT inner columns renames them positionally, unchanged
+    // by the fix — the body projects two real columns, addressed as `a`, `b`.
+    try fixture().expect(
+        "SELECT d.a, d.b FROM T " +
+        "JOIN LATERAL (SELECT T.Id, T.V) AS d(a, b) ON 1 = 1 " +
+        "ORDER BY d.a",
+        yields: [[1, 100], [2, 200]])
+  }
+
+  @Test func `a lateral column list of the wrong arity faults`() throws {
+    // A one-name list against a two-column body mismatches —
+    // `SQLError.columns`, as the non-lateral seam faults.
+    try fixture().expect(
+        "SELECT d.a FROM T " +
+        "JOIN LATERAL (SELECT T.Id, T.V) AS d(a) ON 1 = 1",
+        fails: .columns(expected: 2, got: 1))
+  }
+
+  @Test func `a lateral column list with a duplicate exposed name faults`()
+      throws {
+    // A duplicate in the EXPOSED list leaves a renamed column unreachable, so
+    // it still faults `SQLError.duplicate` — the check runs against the renamed
+    // names, and here THEY collide.
+    try fixture().expect(
+        "SELECT d.a FROM T " +
+        "JOIN LATERAL (SELECT T.Id, T.V) AS d(a, a) ON 1 = 1",
+        fails: .duplicate("a"))
+  }
+}
+
+// MARK: - No regression
+
+struct ColumnListRegressionTests {
+  @Test func `a derived table with no list still resolves inner names`()
+      throws {
+    // The optional list is absent, so the inner projection's names stand — the
+    // pre-existing behaviour is unchanged.
+    try fixture().expect(
+        "SELECT a FROM (SELECT x AS a FROM S) AS d ORDER BY a",
+        yields: [[1], [2], [3]])
+  }
+
+  @Test func `a named relation with no list still resolves real names`()
+      throws {
+    // A plain aliased base relation keeps its own column names.
+    try fixture().expect(
+        "SELECT x.V FROM T AS x ORDER BY x.V",
+        yields: [[100], [200]])
+  }
+}

--- a/Tests/SQLTests/Schema/OutputSchemaTests.swift
+++ b/Tests/SQLTests/Schema/OutputSchemaTests.swift
@@ -199,6 +199,34 @@ struct OutputSchemaTests {
     #expect(columns[0] == ("Name", .text))
   }
 
+  @Test func `a named relation column list renames the output schema`() throws {
+    // `People AS p(who, years)` renames the real columns positionally; the
+    // result schema advertises the new names, each keeping its source type.
+    let columns = try schema("SELECT * FROM People AS p(who, years)")
+    #expect(columns.count == 2)
+    #expect(columns[0] == ("who", .text))
+    #expect(columns[1] == ("years", .integer))
+  }
+
+  @Test func `a derived table column list renames the output schema`() throws {
+    // `(SELECT Name, Age FROM People) AS d(who, years)` renames the inner
+    // outputs; the result schema reports the list's names, each inner type.
+    let columns = try schema(
+        "SELECT * FROM (SELECT Name, Age FROM People) AS d(who, years)")
+    #expect(columns.count == 2)
+    #expect(columns[0] == ("who", .text))
+    #expect(columns[1] == ("years", .integer))
+  }
+
+  @Test func `a column list arity mismatch faults the schema derivation`()
+      throws {
+    // The schema-only path checks the list's arity exactly as a run does,
+    // faulting `SQLError.columns` before advertising any headers.
+    #expect(throws: SQLError.columns(expected: 2, got: 1)) {
+      _ = try schema("SELECT * FROM People AS p(who)")
+    }
+  }
+
   @Test func `a view resolves against its registered columns`() throws {
     let definition = try View(query: {
       guard case let .select(query) =


### PR DESCRIPTION
Accept the ISO explicit output column list `AS name(a, b)` on a relation in FROM/JOIN, positionally renaming the relation's real output columns — `(SELECT x, y FROM T) AS d(a, b)` and `FROM T AS x(c, d)` both address their columns by the new names, mirroring how a CTE's `columns` list applies.

The `Relation` AST node gains an optional `columns` list (empty when absent, matching the CTE field). The parser accepts an optional parenthesised name list after the alias via the shared `names()` helper, on both a derived table and a named relation. The rename applies where a relation's output schema is computed: `materialise` (the derived table's RelationInstance the overlay binds, read back by both the compile and schema-only paths) and, for a named relation, the parity pair `resolve` and `schema(of:)` — through a shared `Schema.renamed(_:)` that overrides the real column names, checks the arity (`SQLError.columns`) and case-insensitive uniqueness (`SQLError.duplicate`), and leaves the virtual `Id` addressable. The executor is untouched (naming is positional/schema-level).