### PR TITLE
WinMD: unify set-operation column types and coerce arm values

### DIFF
--- a/Sources/SQLEngine/AST.swift
+++ b/Sources/SQLEngine/AST.swift
@@ -116,15 +116,18 @@ public struct CTE: Hashable, Sendable {
     self.recursive = recursive
   }
 
-  /// The CTE's DECLARED output columns as the `ResolvedColumn` carrier its self
-  /// binding is built from — each declared name typed `.integer`, the
-  /// placeholder a materialised relation reports (a CTE's rows carry no static
-  /// types). Every self binding (the `with` install, the recursive
-  /// `validate`/`fixpoint` probes, the fixpoint step, the schema-path binding)
-  /// is constructed from THIS, so all bind the same carrier through one
-  /// constructor.
+  /// The CTE's DECLARED output columns as the `ResolvedColumn` carrier — each
+  /// declared name typed `.integer` and marked UNCONSTRAINED, since the type is
+  /// a fabricated PLACEHOLDER (a materialised relation reports `.integer`; a
+  /// CTE's rows carry no static types), NOT a genuine derivation — so a fold
+  /// unifying against it defers to the other arm rather than faulting on the
+  /// placeholder. It is the FALLBACK a trusted derive falls back to when a
+  /// data-dependent body a filter drops faults its type fold; the primary path
+  /// binds a CTE from its BODY-derived carrier (`kinds(of:)`), which unifies
+  /// the arms and carries the real `unconstrained` mask.
   internal var declared: Array<ResolvedColumn> {
-    columns.map { ResolvedColumn(name: $0, type: .integer) }
+    columns.map { ResolvedColumn(name: $0, type: .integer,
+                                 unconstrained: true) }
   }
 }
 
@@ -153,8 +156,10 @@ public enum SetOperation: Hashable, Sendable {
 /// so the arms read in source order, while `a UNION b INTERSECT c` binds as
 /// `a UNION (b INTERSECT c)`. Without `all` a set operation removes duplicate
 /// result rows; with `all` (`ALL`) it keeps them per the operator's
-/// multiplicity rule. Every arm must project the same number of columns, and
-/// the result columns are the FIRST arm's projection (the ISO rule).
+/// multiplicity rule. Every arm must project the same number of columns; the
+/// result column TYPES are unified across the arms (a mixed integer/double
+/// column widening to `double`), while their NAMES come from the first arm (the
+/// ISO rule).
 public indirect enum Query: Hashable, Sendable {
   /// A single `SELECT`.
   case select(Select)
@@ -164,9 +169,9 @@ public indirect enum Query: Hashable, Sendable {
   case setop(SetOperation, Query, Query, all: Bool)
 
   /// The first `SELECT` of the query — the leftmost arm, reached by descending
-  /// the left arm of each set operation. Its projection names the result
-  /// columns (the ISO rule), so a `CREATE VIEW` infers a set operation's
-  /// columns from it.
+  /// the left arm of each set operation. Its projection NAMES the result
+  /// columns (the ISO rule — their TYPES unify across every arm), so a `CREATE
+  /// VIEW` infers a set operation's column names from it.
   public var first: Select {
     switch self {
     case let .select(select): select

--- a/Sources/SQLEngine/Context.swift
+++ b/Sources/SQLEngine/Context.swift
@@ -76,6 +76,22 @@ internal struct Context {
   /// barred (`false`).
   internal let lateral: Bool
 
+  /// Whether the query being resolved is a nested-subquery SHAPE pre-pass — the
+  /// cursor-free derive that records a nested subquery's width, arity, and
+  /// single-column type AHEAD of the reachability walk. Set only at the
+  /// pre-pass `inner` constructions (`shaping()`), it DEFERS a set-operation's
+  /// operand-compatibility fold: the pre-pass runs for EVERY nested subquery
+  /// before the walk decides which run, so faulting `SQLError.operand` here
+  /// would reject an unreachable incompatible subquery a short-circuited
+  /// `AND`/`OR` never reaches (`… WHERE 1 = 0 AND EXISTS (SELECT 'x' UNION
+  /// SELECT 1)`). Arity and resolution stay eager regardless; only the operand
+  /// fold defers, substituting a placeholder type (the left arm's) it discards
+  /// for an unreached occurrence and RE-CHECKS strictly for a reached
+  /// scalar/`IN` one. Distinct from `validate` (also `false` on the top-level
+  /// run and CTE trusted paths, which MUST keep faulting), so it gates the
+  /// operand fold ALONE.
+  internal let shape: Bool
+
   /// A context over the maps and resolution scope — an empty overlay, no
   /// bindings, an empty visited guard, eager validation, the caller scope, and
   /// no enclosing correlation by default: the shape a bare top-level query with
@@ -86,7 +102,7 @@ internal struct Context {
                 subqueries: Subqueries = Subqueries(),
                 visited: Set<String> = [], validate: Bool = true,
                 subscope: Subscope = .caller, outer: Outer? = nil,
-                lateral: Bool = false) {
+                lateral: Bool = false, shape: Bool = false) {
     self.relations = relations
     self.routines = routines
     self.bindings = bindings
@@ -96,6 +112,7 @@ internal struct Context {
     self.subscope = subscope
     self.outer = outer
     self.lateral = lateral
+    self.shape = shape
   }
 
   /// A copy of this context with `relations` REPLACING the overlay, the same
@@ -105,7 +122,7 @@ internal struct Context {
   internal func scoping(_ relations: ScopedRelations) -> Context {
     Context(relations: relations, routines: routines, bindings: bindings,
             subqueries: subqueries, visited: visited, validate: validate,
-            subscope: subscope, outer: outer, lateral: lateral)
+            subscope: subscope, outer: outer, lateral: lateral, shape: shape)
   }
 
   /// A copy of this context ENTERING a fresh body scope over `relations` — the
@@ -141,7 +158,7 @@ internal struct Context {
   internal func binding(_ bindings: Bindings) -> Context {
     Context(relations: relations, routines: routines, bindings: bindings,
             subqueries: subqueries, visited: visited, validate: validate,
-            subscope: subscope, outer: outer, lateral: lateral)
+            subscope: subscope, outer: outer, lateral: lateral, shape: shape)
   }
 
   /// A copy of this context carrying `subqueries` as the executing plan's
@@ -151,7 +168,7 @@ internal struct Context {
   internal func resolving(_ subqueries: Subqueries) -> Context {
     Context(relations: relations, routines: routines, bindings: bindings,
             subqueries: subqueries, visited: visited, validate: validate,
-            subscope: subscope, outer: outer, lateral: lateral)
+            subscope: subscope, outer: outer, lateral: lateral, shape: shape)
   }
 
   /// A copy of this context with every enclosing SELECT's derived-table aliases
@@ -185,7 +202,7 @@ internal struct Context {
     return Context(relations: relations, routines: routines,
                    bindings: bindings, subqueries: subqueries,
                    visited: visited, validate: validate, subscope: subscope,
-                   outer: outer, lateral: lateral)
+                   outer: outer, lateral: lateral, shape: shape)
   }
 
   /// A copy of this context with the eager-typecheck gate set to `flag` — a RUN
@@ -194,7 +211,19 @@ internal struct Context {
   internal func validating(_ flag: Bool) -> Context {
     Context(relations: relations, routines: routines, bindings: bindings,
             subqueries: subqueries, visited: visited, validate: flag,
-            subscope: subscope, outer: outer, lateral: lateral)
+            subscope: subscope, outer: outer, lateral: lateral, shape: shape)
+  }
+
+  /// A copy of this context marking the query it resolves as a nested-subquery
+  /// SHAPE pre-pass (`shape`) — the seam the two pre-pass `inner` constructions
+  /// route through, so a set operation's operand-compatibility fold defers to
+  /// the reachability walk rather than faulting `SQLError.operand` while merely
+  /// recording an unreached subquery's width and type. Arity and resolution
+  /// stay eager; every OTHER field is preserved.
+  internal func shaping() -> Context {
+    Context(relations: relations, routines: routines, bindings: bindings,
+            subqueries: subqueries, visited: visited, validate: validate,
+            subscope: subscope, outer: outer, lateral: lateral, shape: true)
   }
 
   /// A copy of this context resolving its nested subqueries under `subscope` —
@@ -203,7 +232,7 @@ internal struct Context {
   internal func scoped(as subscope: Subscope) -> Context {
     Context(relations: relations, routines: routines, bindings: bindings,
             subqueries: subqueries, visited: visited, validate: validate,
-            subscope: subscope, outer: outer, lateral: lateral)
+            subscope: subscope, outer: outer, lateral: lateral, shape: shape)
   }
 
   /// A copy of this context whose enclosing correlation stack is EXTENDED with
@@ -221,7 +250,7 @@ internal struct Context {
   internal func with(outer: Outer?) -> Context {
     Context(relations: relations, routines: routines, bindings: bindings,
             subqueries: subqueries, visited: visited, validate: validate,
-            subscope: subscope, outer: outer, lateral: lateral)
+            subscope: subscope, outer: outer, lateral: lateral, shape: shape)
   }
 
   /// A copy of this context marking the query it resolves as a LATERAL derived
@@ -234,7 +263,7 @@ internal struct Context {
   internal func lateralizing() -> Context {
     Context(relations: relations, routines: routines, bindings: bindings,
             subqueries: subqueries, visited: visited, validate: validate,
-            subscope: subscope, outer: outer, lateral: true)
+            subscope: subscope, outer: outer, lateral: true, shape: shape)
   }
 
   /// A copy of this context with the enclosing correlation stack CLEARED — the
@@ -260,6 +289,6 @@ internal struct Context {
   internal func unlateralized() -> Context {
     Context(relations: relations, routines: routines, bindings: bindings,
             subqueries: subqueries, visited: visited, validate: validate,
-            subscope: subscope, outer: outer, lateral: false)
+            subscope: subscope, outer: outer, lateral: false, shape: shape)
   }
 }

--- a/Sources/SQLEngine/Definition.swift
+++ b/Sources/SQLEngine/Definition.swift
@@ -360,13 +360,16 @@ extension Catalog where Self: ~Escapable {
     // run, so a stateful routine in a `FROM (SELECT tick() …)` nested a level
     // down would fire twice for one query.
     let scope = try augment(context, for: query, rows: false)
-    // The derived table's columns are its inner query's OUTPUT columns (the ISO
-    // rule) — the FIRST arm's projection, the same arm the result-schema walk
-    // and a CTE's declared list resolve against — typed against the augmented
-    // `scope` so a derived table over a CTE, a store relation, or a nested
-    // derived table resolves. `columns(of:)` REVEALS the base for the body's
-    // NESTED subqueries: `scope`'s derived layer shadows a CTE this body's own
-    // FROM alias names, and revealing drops that layer, so a nested
+    // The derived table's columns are its inner query's OUTPUT columns (the
+    // ISO rule): the NAMES from the FIRST arm's projection, the TYPES UNIFIED
+    // across every set-operation arm (a mixed integer/double column widening to
+    // `double`, matching the coerced values a run produces), each carrying its
+    // `unconstrained` mask — resolved against the augmented `scope` so a
+    // derived table over a CTE, a store relation, or a nested derived table
+    // resolves.
+    // `resolved(query:in:)` REVEALS the base for the body's NESTED subqueries:
+    // `scope`'s derived layer shadows a CTE this body's own FROM alias names,
+    // and revealing drops that layer, so a nested
     // `EXISTS (… FROM t)` reads the enclosing CTE `t` beneath — the layered
     // overlay never overwrote it, keeping schema/run parity without a
     // pre-augment context. The caller's `validate` threads through, so a RUN's
@@ -377,12 +380,17 @@ extension Catalog where Self: ~Escapable {
     // (`validate: true`) still faults it.
     let derived = try resolved(query: query, in: scope)
     // An explicit `AS d(a, b)` column list positionally RENAMES the derived
-    // table's inner output names, keeping each column's inferred TYPE (the list
-    // names, the body types), so `(SELECT x, y FROM T) AS d(a, b)` addresses
-    // the columns as `a`, `b`. Its arity must match the inner output width
-    // (`SQLError.columns`, the CTE/view arity fault) — checked HERE, where the
-    // width is resolved, so a list over a `SELECT *` derived body is checked
-    // once its `*` expands. Absent a list, the inner output names stand.
+    // table's inner output names, keeping each column's inferred TYPE and its
+    // `unconstrained` mask (the list names, the body types unified across the
+    // arms), so `(SELECT x, y FROM T) AS d(a, b)` addresses them as `a`, `b`.
+    // Its arity must match the inner output width (`SQLError.columns`, the
+    // CTE/view arity fault) — checked HERE, where the width is resolved, so a
+    // list over a `SELECT *` derived body is checked once its `*` expands.
+    // Absent a list, the inner output names stand. Carrying the mask through
+    // the same indexing means an all-NULL derived column (`SELECT
+    // NULLIF('a', 'a') AS x`) stays UNCONSTRAINED and unifies with any later
+    // typed set-operation arm order-independently: a wrapper must not change
+    // set-op typing.
     let outputs: Array<ResolvedColumn>
     if renaming.isEmpty {
       outputs = derived
@@ -391,7 +399,8 @@ extension Catalog where Self: ~Escapable {
         throw .columns(expected: derived.count, got: renaming.count)
       }
       outputs = renaming.indices.map {
-        ResolvedColumn(name: renaming[$0], type: derived[$0].type)
+        ResolvedColumn(name: renaming[$0], type: derived[$0].type,
+                       unconstrained: derived[$0].unconstrained)
       }
     }
     // A derived table's columns are its inner query's OUTPUT names (or the
@@ -608,14 +617,16 @@ extension Catalog where Self: ~Escapable {
       // The type-check and derive resolve the body under the cyclic-view guard
       // seeded with THIS view's name.
       let inner = overlay.visiting(name)
-      // Type the columns from the body's first arm; type-check every arm's
-      // REACHABLE operands and calls too — an unknown call or a bad operand in
-      // a `WHERE`/`HAVING` or a later `UNION` arm faults a run, but the
-      // first-arm resolve would miss it (`compile` cannot check a routine
-      // exists), while an arm a short-circuit proves unreachable is skipped. A
-      // view a `SELECT *` could not evaluate is not advertised.
-      guard (try? typecheck(view.query, inner)) != nil,
-          let resolved = try? columns(of: view.query.first, inner),
+      // Type the columns from the body — NAMES off the first arm, TYPES unified
+      // across every arm (a mixed integer/double column reporting `double`);
+      // type-check every arm's REACHABLE operands and calls too — an unknown
+      // call or a bad operand in a `WHERE`/`HAVING` or a later `UNION` arm
+      // faults a run, but a first-arm resolve would miss it (`compile` cannot
+      // check a routine exists), while an arm a short-circuit proves
+      // unreachable is skipped. A view a `SELECT *` could not evaluate is not
+      // advertised.
+      let resolved = try? columns(unifying: view.query, inner).map(\.column)
+      guard (try? typecheck(view.query, inner)) != nil, let resolved,
           resolved.count == view.columns.count else { continue }
       for ordinal in view.columns.indices {
         rows.append([.text(name), .text(view.columns[ordinal]),

--- a/Sources/SQLEngine/Engine.swift
+++ b/Sources/SQLEngine/Engine.swift
@@ -149,8 +149,14 @@ extension Catalog where Self: ~Escapable {
       // filter never reaches (execution faults only on a REACHED operand),
       // matching the non-derived path.
       _ = try compile(query, context.validating(false))
+      // The result column TYPES are UNIFIED across the arms (ISO), so coerce
+      // each arm's values to them — `SELECT 1 UNION SELECT 2.5` emits a
+      // `double` column. The fold reads the arm queries in hand here; the
+      // Plan-node path carries the same types precomputed at compile.
+      let types = try types(unifying: query, context.validating(false))
       let combined = try combine(kind, run(left, context).map(Record.init),
-                                 run(right, context).map(Record.init), all)
+                                 run(right, context).map(Record.init), all,
+                                 types: types)
       return combined.map(\.values)
     }
     // Thread a fresh LAZY subquery cache — a shared box — through BOTH compile
@@ -299,14 +305,31 @@ extension Catalog where Self: ~Escapable {
       // does not reference itself — runs its query once. Each resolves against
       // the base catalog plus the CTEs done so far. The arity of both routings
       // is already checked by `validate` above.
+      // Bind the CTE under its BODY's derived column carrier, not a `.integer`
+      // placeholder: a caller reading the CTE (a set operation over its column)
+      // unifies against the real types AND the `unconstrained` mask, so `WITH
+      // a(x) AS (SELECT 'b') SELECT x FROM a UNION SELECT 'c'` folds text
+      // against text and runs, and an all-NULL CTE column unifies with any
+      // typed arm. Both routings feed the SAME carrier into `init(from:)`, so
+      // the schema-only self and materialised binding cannot diverge.
       let rows: Array<Array<Value>>
+      let carrier: Array<ResolvedColumn>
       if cte.recursive && cte.recurses {
-        rows = try fixpoint(cte, scope)
+        (rows, carrier) = try fixpoint(cte, scope)
       } else {
         rows = try run(cte.query, scope)
+        // The body already RAN and produced its rows, so re-derive its carrier
+        // TRUSTED — `validating(false)` so the derive does NOT eager-operand-
+        // check a data-dependent expression a filter dropped (`SELECT Label + 1
+        // … WHERE k = 0`, `Label` text), never evaluated, never a run fault.
+        // `kinds` binds the DECLARED names with the body-folded types/mask. A
+        // GENUINE set-operation incompatibility (`SELECT 'b' UNION SELECT 1`)
+        // still faults through the unconditional `merge` fold, matching the run
+        // — a reachable type error already faulted at `run` above.
+        carrier = try kinds(of: cte, scope.validating(false))
       }
       relations[cte.name.lowercased()] =
-          RelationInstance(from: cte.declared, rows: rows)
+          RelationInstance(from: carrier, rows: rows)
     }
     return try run(query, context.body(relations))
   }
@@ -396,7 +419,28 @@ extension Catalog where Self: ~Escapable {
       // run evaluates it in — so a text-arithmetic anchor faults against the
       // base relation, not the CTE's declared (integer) columns.
       if typecheck { try self.typecheck(anchor, scope) }
-      let empty = RelationInstance(from: cte.declared, rows: [])
+      // Bind the CTE self under the UNIFIED (anchor ⊕ recursive) column carrier
+      // — the SAME carrier `fixpoint` binds the iterated self under (the rows
+      // every step reads are coerced to those types). Typing the self here at
+      // the anchor-only types while the run reads the widened unified types
+      // would let schema validation call a query "valid" that the run mistypes
+      // (an integer-anchor self a widening recursive arm reads as `double`).
+      // `kinds` derives those unified types recursive-aware (anchor ⊕
+      // recursive), so a set-operation recursive arm still folds its self
+      // column at the anchor's real type. When `typecheck`, a genuine `kinds`
+      // fault (an irreconcilable arm pair the run's own type fold rejects) is a
+      // legitimate validation fault, so it surfaces here — the same fault the
+      // run raises. When NOT typechecking (the trusted RUN path), a data-
+      // dependent body a filter drops must NOT fault, so its derive falls back
+      // to the placeholder; the recursive-arm typecheck does not run there, so
+      // the self type is unused anyway. Feeding the carrier through
+      // `init(from:)` means this self binding and the run-iteration one cannot
+      // diverge.
+      let gated = context.validating(typecheck)
+      let seeded = typecheck
+          ? try kinds(of: cte, gated)
+          : (try? kinds(of: cte, gated)) ?? cte.declared
+      let empty = RelationInstance(from: seeded, rows: [])
       // Bind the CTE self BEFORE augmenting the recursive arm, so a derived
       // body in the arm that names the CTE (`FROM (SELECT n FROM a) AS d`)
       // resolves it — `augment` materialises derived bodies eagerly, so the
@@ -457,7 +501,8 @@ extension Catalog where Self: ~Escapable {
   /// itself); the recursive arm compiles with the name bound to `cte.columns`,
   /// the schema it reads.
   internal borrowing func fixpoint(_ cte: CTE, _ context: Context)
-      throws(SQLError) -> Array<Array<Value>> {
+      throws(SQLError) -> (rows: Array<Array<Value>>,
+                           carrier: Array<ResolvedColumn>) {
     // Extend the scope with any `definition_schema.` store relation the CTE's
     // body names, so the fixpoint's width-check compiles resolve a reserved
     // relation as the body's own run does. The routines ride in: this store
@@ -482,7 +527,17 @@ extension Catalog where Self: ~Escapable {
       guard width == cte.columns.count else {
         throw .columns(expected: cte.columns.count, got: width)
       }
-      return try run(cte.query, context)
+      // The CTE exposes its body's DERIVED column types/mask under its DECLARED
+      // names (resolved with the self shadowed by the same-named base it seeds
+      // from), not the declared-name placeholder, so a caller reading the CTE
+      // unifies against real types and the `unconstrained` mask while
+      // addressing the CTE by its declared list.
+      let rows = try run(cte.query, context)
+      // TRUSTED re-derive (the body already ran): `validating(false)` so an
+      // unreached data-dependent operand is not eager-checked, while a genuine
+      // set-operation incompatibility still faults through `merge`.
+      let carrier = try kinds(of: cte, context.validating(false))
+      return (rows, carrier)
     }
 
     // A misplaced recursive reference in the anchor (a same-named base/view is
@@ -501,23 +556,72 @@ extension Catalog where Self: ~Escapable {
       throw .columns(expected: cte.columns.count, got: width)
     }
 
-    // The recursive arm compiles with the CTE name bound to `cte.columns` — the
-    // schema every iteration reads it under — so its width resolves too (a
+    // The CTE column CARRIER a recursive reference reads under — the ANCHOR's
+    // own output columns (the base case, resolved with self NOT in scope).
+    // Binding the schema-only self under these — rather than a flat `.integer`
+    // placeholder — types the recursive arm's self-referencing columns
+    // consistently with the anchor, so the anchor/recursive fold below does not
+    // spuriously merge a genuine anchor type (a `text` `column_name`) against
+    // an `.integer` placeholder self column and fault. A NULL-only anchor
+    // column stays UNCONSTRAINED, so the recursive arm's typed column supplies
+    // the type. It defaults to `.integer`, the run's materialised-relation
+    // default.
+    let seeds = try columns(unifying: anchor, context)
+
+    // The recursive arm compiles with the CTE name bound to the anchor's own
+    // carrier under the CTE's DECLARED names (a `SELECT x FROM t` self
+    // reference addresses the declared `x`, not the anchor's projected name) —
+    // the schema every iteration reads it under — so its width resolves too (a
     // `SELECT *` arm spans that schema). Checking it here catches a mismatch
-    // even when the arm is filtered to zero rows in every iteration.
-    let empty = RelationInstance(from: cte.declared, rows: [])
+    // even when the arm is filtered to zero rows in every iteration. It is
+    // typed under the anchor's own `seeds`, so the arm's self columns carry the
+    // base-case types, not a flat `.integer`.
+    let declared = seeds.indices.map {
+      ResolvedColumn(name: cte.columns[$0], type: seeds[$0].type,
+                     unconstrained: seeds[$0].unconstrained)
+    }
+    let empty = RelationInstance(from: declared, rows: [])
     let probe = context.binding(cte.name, to: empty)
     let arm = try compile(recursive, probe).width
     guard arm == cte.columns.count else {
       throw .columns(expected: cte.columns.count, got: arm)
     }
 
+    // The result column CARRIER unifies the ANCHOR — typed under `context`,
+    // where a same-named base/view the anchor SEEDS from resolves to that base
+    // (the CTE self not yet in scope) — with the RECURSIVE arm, typed under
+    // `probe` (self bound). Folding the WHOLE `cte.query` under `probe` would
+    // resolve the anchor's base reference against the empty self, rejecting or
+    // mis-unifying a base-only column (`SELECT Age FROM People` seeding a
+    // recursive `People`). So merge the two arms' own-scope columns
+    // column-wise: an irreconcilable pair (text beside a number) faults
+    // `SQLError.operand`.
+    // `combine` never runs here (the fixpoint is hand-rolled for its `Seen`
+    // dedup), so these types coerce the produced ROWS directly with
+    // `Value.coerced` — the anchored seed and each iteration's output — BEFORE
+    // the dedup and append, leaving the plan tree (and the recursive self-
+    // reference) untouched.
+    let steps = try columns(unifying: recursive, probe)
+    // Merge column-wise, then bind under the CTE's DECLARED names (a CTE is
+    // addressed by its declared list, never the arm's own projected name),
+    // keeping each column's unified type and `unconstrained` mask. The declared
+    // width is proved equal to each arm's above, so the index is in range.
+    let unified = try seeds.indices.map { index throws(SQLError) in
+      try merge(seeds[index], steps[index])
+    }
+    let merged = unified.indices.map {
+      ResolvedColumn(name: cte.columns[$0], type: unified[$0].type,
+                     unconstrained: unified[$0].unconstrained)
+    }
+    let types = merged.map(\.type)
+
     // The anchor seeds the result and the working set, the CTE name not yet in
     // scope (the anchor is the base case, which does not reference itself). A
     // bare `UNION` dedups the seed exactly as it dedups an iteration's rows —
     // duplicate anchor rows collapse to their first occurrence — while `UNION
-    // ALL` keeps every anchor row.
-    let anchored = try run(anchor, context)
+    // ALL` keeps every anchor row. Each seed row is coerced to the unified
+    // column types before it is dedup'd or seeds the working set.
+    let anchored = try run(anchor, context).map { coerce($0, to: types) }
     var seen = Seen()
     var result = all ? anchored
                      : anchored.filter { seen.insert($0) }
@@ -531,9 +635,16 @@ extension Catalog where Self: ~Escapable {
       }
 
       // Bind the CTE name to ONLY the previous step's output and run the
-      // recursive arm against the base catalog plus the earlier CTEs.
-      let step = RelationInstance(from: cte.declared, rows: working)
+      // recursive arm against the base catalog plus the earlier CTEs. The self
+      // relation carries the UNIFIED `merged` carrier — the rows in `working`
+      // are already coerced to those types (the anchored seed and each step
+      // passes through `coerce($0, to: types)`), so the recursive arm must be
+      // TYPED to the values it reads. Typing the self under the anchor-only
+      // `seeds` would type an integer-anchor self while the coerced rows
+      // already hold widened `double` values, mistyping the arm the run reads.
+      let step = RelationInstance(from: merged, rows: working)
       let produced = try run(recursive, context.binding(cte.name, to: step))
+          .map { coerce($0, to: types) }
 
       var next = Array<Array<Value>>()
       for row in produced where all || seen.insert(row) {
@@ -542,8 +653,21 @@ extension Catalog where Self: ~Escapable {
       result += next
       working = next
     }
-    return result
+    return (result, merged)
   }
+}
+
+/// A row's cells COERCED to the unified column `types` — the recursive-CTE
+/// fixpoint's row-level counterpart of `Record.coerced(to:)`, applied to each
+/// materialised `Array<Value>` row (the fixpoint works on raw rows, not the
+/// plan tree) so the anchor and every iteration carry the set-operation's
+/// unified column types. `Value.coerced` widens an `integer` cell to `double`
+/// where the unified column is `double` and passes every other cell through, so
+/// a homogeneous recursive CTE's rows are unchanged. `types` matches the row
+/// width (the arity `fixpoint` proved equal against the declared columns).
+private func coerce(_ row: Array<Value>, to types: Array<ValueType>)
+    -> Array<Value> {
+  row.indices.map { row[$0].coerced(to: types[$0]) }
 }
 
 // MARK: - Compilation
@@ -2095,12 +2219,13 @@ extension Catalog where Self: ~Escapable {
       // never reshapes it.
       try .apply(optimise(left, context), key: key, correlation: correlation,
                  ordinals: ordinals, on: on, kind: kind)
-    case let .setop(kind, left, right, all):
+    case let .setop(kind, left, right, all, types, widened):
       // Optimise each side with the same bindings so a bound predicate inside
       // an arm seeks; the set operation itself merely combines its sides,
-      // preserving this node's own `kind` and `all`.
+      // preserving this node's own `kind`, `all`, unified column `types`, and
+      // `widened` mask.
       try .setop(kind, optimise(left, context), optimise(right, context),
-                 all: all)
+                 all: all, types: types, widened: widened)
     case let .distinct(source):
       // A `distinct` dedups its source without a seek or join of its own;
       // optimise the source below it and rewrap.
@@ -2151,10 +2276,11 @@ extension Catalog where Self: ~Escapable {
   private borrowing func optimise(_ plan: Plan, _ query: Query,
                                   _ overlay: Context)
       throws(SQLError) -> Plan {
-    if case let .setop(kind, left, right, all) = plan,
+    if case let .setop(kind, left, right, all, types, widened) = plan,
         case let .setop(_, leftQuery, rightQuery, _) = query {
       return try .setop(kind, optimise(left, leftQuery, overlay),
-                        optimise(right, rightQuery, overlay), all: all)
+                        optimise(right, rightQuery, overlay), all: all,
+                        types: types, widened: widened)
     }
     // Schema-only (`rows: false`): the optimiser needs the arm's derived alias
     // bound by name/schema so `seek` treats it as an unseekable materialised
@@ -2518,9 +2644,10 @@ extension Catalog where Self: ~Escapable {
                       ordinals: ordinals, on: on, kind: kind)
       }
       return rewritten
-    case let .setop(kind, left, right, all):
+    case let .setop(kind, left, right, all, types, widened):
       return try .setop(kind, decorrelate(left, context),
-                        decorrelate(right, context), all: all)
+                        decorrelate(right, context), all: all, types: types,
+                        widened: widened)
     case let .distinct(source):
       return try .distinct(decorrelate(source, context))
     case let .aggregate(keys, aggregates, source):
@@ -3203,8 +3330,9 @@ extension Plan {
       // was already pushed down at its compile.
       try .apply(left.pushdown(), key: key, correlation: correlation,
                  ordinals: ordinals, on: on, kind: kind)
-    case let .setop(kind, left, right, all):
-      try .setop(kind, left.pushdown(), right.pushdown(), all: all)
+    case let .setop(kind, left, right, all, types, widened):
+      try .setop(kind, left.pushdown(), right.pushdown(), all: all,
+                 types: types, widened: widened)
     case let .distinct(source):
       // A `distinct` sits above the projection, so no `WHERE` conjunct reaches
       // it to push down; it recurses transparently. A filter must never cross a
@@ -3445,8 +3573,14 @@ extension Plan {
   /// of the body — the `rebase` helper produces a mapping; a computed column
   /// (call or arithmetic) has none. A `union` admits it only when EVERY arm
   /// does — the arms are combined, so a conjunct pushable into one but not
-  /// another cannot descend into any and must stay outside. Anything else does
-  /// not admit it.
+  /// another cannot descend into any and must stay outside — AND the conjunct
+  /// references no column the set operation WIDENS: an arm coerces its cells to
+  /// the unified column type only AFTER it runs (in `combine`), so a predicate
+  /// pushed into the arm tests the PRE-coercion value, and over a widened
+  /// column that is the wrong type. Such a conjunct stays ABOVE the derived
+  /// leaf as a `select` on the coerced output, where it tests the unified type
+  /// — the observable result then matches an un-pushed query. A same-typed
+  /// column (an empty `widened`) still pushes. Anything else does not admit it.
   private func pushable(_ conjunct: Filter, _ ordinals: Array<Int>) -> Bool {
     switch self {
     case let .project(terms, _):
@@ -3456,8 +3590,16 @@ extension Plan {
       // not read — would be skipped for the filtered rows, suppressing a raise
       // `derive` owes by evaluating every column of every view row.
       terms.allSatisfy(\.safe) && rebase(conjunct, ordinals) != nil
-    case let .setop(_, left, right, _):
-      left.pushable(conjunct, ordinals) && right.pushable(conjunct, ordinals)
+    case let .setop(_, left, right, _, _, widened):
+      // A conjunct over a column the set operation WIDENS must NOT push into
+      // the arms: an arm evaluates it on the un-coerced value, but `combine`
+      // coerces the arm's rows to the unified type only after the arm runs, so
+      // the pushed predicate tests the wrong type. A slot the conjunct reads is
+      // a view-output slot, `ordinals[slot]` its output column — the same index
+      // `widened` records — so keep the conjunct outer when any is widened.
+      !conjunct.slots.contains { widened.contains(ordinals[$0]) }
+          && left.pushable(conjunct, ordinals)
+          && right.pushable(conjunct, ordinals)
     default:
       false
     }
@@ -3478,9 +3620,10 @@ extension Plan {
     case let .project(terms, body):
       try .project(terms,
                    body.distribute(conjuncts.map { rebase($0, ordinals)! }))
-    case let .setop(kind, left, right, all):
+    case let .setop(kind, left, right, all, types, widened):
       try .setop(kind, left.inject(conjuncts, ordinals),
-                 right.inject(conjuncts, ordinals), all: all)
+                 right.inject(conjuncts, ordinals), all: all, types: types,
+                 widened: widened)
     default:
       // A view sub-plan is always a `project` (or a `union` of them); anything
       // else keeps the conjuncts as an outer `select` rather than dropping
@@ -3573,9 +3716,43 @@ extension Catalog where Self: ~Escapable {
     let count = try arity(right.first, tail)
     guard count == width else { throw .arity(width, count) }
     // Both arms of a set-operation subquery correlate against the SAME
-    // enclosing scope, so each lowers under the shared `context.outer`.
+    // enclosing scope, so each lowers under the shared `context.outer`. The
+    // per-column result TYPES are UNIFIED across the arms (ISO) and CARRIED on
+    // the plan node: the `.setop` executor holds only the sub-plans, not the
+    // arm `Query`s, so it cannot fold them at run — compute them HERE, where
+    // the arm queries and scope are in hand, and coerce each arm's rows at run.
+    // The arms' OWN native column types (each arm's own unified columns —
+    // `types(unifying:)` folds a nested arm — the very rows `combine` coerces
+    // to this node's unified `types`) are derived BEFORE the `types` local
+    // shadows the deriver.
+    //
+    // These three derivations are a schema-only PROBE — they compute types, not
+    // the arms' real plans (those are compiled from `context` below, at
+    // `compile(left/right, context)`). The type derivation lowers any nested
+    // subquery to read its width, which would RECORD a correlated inner plan
+    // into the shared runtime memo; that record is first-writer-wins, so a
+    // later caller with a same-shaped subquery could reuse this view body's
+    // plan (against the view's base) instead of its own CTE. Derive against a
+    // context carrying an ISOLATED throwaway memo — every other field (scope,
+    // subscope, outer correlation, validate) preserved — so the probe's
+    // recordings are discarded and only the real arm compiles below populate
+    // the live memo.
+    let probe = context.resolving(Subqueries())
+    let l = try types(unifying: left, probe)
+    let r = try types(unifying: right, probe)
+    let types = try types(unifying: query, probe)
+    // The columns this node WIDENS — where the unified `types[c]` differs from
+    // an arm's OWN native type — so the pushdown pass (a pure Plan rewrite with
+    // no catalog) can keep a predicate over a widened column ABOVE the arms
+    // rather than pushing it in, where an arm would test the pre-coercion
+    // value. A column differing from EITHER arm is coerced for that arm, so
+    // record it; a homogeneous set operation matches both arms, leaving the
+    // mask empty and the pushdown unchanged.
+    let widened = Set(types.indices.filter {
+      types[$0] != l[$0] || types[$0] != r[$0]
+    })
     return try .setop(kind, compile(left, context), compile(right, context),
-                      all: all)
+                      all: all, types: types, widened: widened)
   }
 
   /// The distinct UNCORRELATED subqueries `select` nests, each COMPILED ONCE
@@ -3670,7 +3847,7 @@ extension Catalog where Self: ~Escapable {
     let context = context.revealed()
     let scope = context.subscope
     var widths = Dictionary<Query, Int>()
-    var types = Dictionary<Query, ValueType>()
+    var types = Dictionary<Query, ResolvedColumn>()
     var correlations = Dictionary<Query, Correlation>()
     for query in queries where widths[query] == nil {
       // A fresh `Outer` per nested query — its enclosing scope is THIS select
@@ -3692,8 +3869,14 @@ extension Catalog where Self: ~Escapable {
       // covers ONLY the lateral body's own projection, NOT a subquery inside
       // it, so an ordinary correlated scalar-subquery projection is barred
       // exactly as it is outside a lateral body.
-      let inner =
-          context.with(outer: nested).validating(false).unlateralized()
+      // `shaping()` DEFERS the set-operation operand-compatibility fold out of
+      // this pre-pass: it records EVERY nested subquery's width, arity, and
+      // single-column type ahead of the reachability walk, so a `SELECT 'x'
+      // UNION SELECT 1` behind a short-circuited `1 = 0 AND …` is not faulted
+      // while merely recording shape. A REACHED scalar/`IN` occurrence is re-
+      // folded strictly on the walk's reached path; arity/resolution eager.
+      let inner = context.with(outer: nested).validating(false)
+          .unlateralized().shaping()
       // A nested subquery's body derivation is SHAPE ONLY, so ALWAYS lenient
       // (`validate: false`) — this pass exists to record the subquery's width,
       // arity, and correlation, never to validate its body. Validation of a
@@ -3708,13 +3891,17 @@ extension Catalog where Self: ~Escapable {
       // of `validate`. The type derivation below is already lenient.
       let plan = try compile(query, inner)
       widths[query] = plan.width
-      // A scalar subquery contributes its single-column output type; a wider or
-      // an `EXISTS`/`IN (Q)` subquery still records the FIRST column's type
-      // (harmless — only a width-1 scalar occurrence reads it, and the lowering
-      // rejects a wider one). It derives cursor-free against the SAME context
-      // the width compile uses, so it matches what the run advertises.
+      // A scalar subquery contributes its single-column output COLUMN — its
+      // type AND `unconstrained` mask together, UNIFIED across its
+      // set-operation arms (a `(SELECT 1 UNION SELECT 2.5)` typing `double`, a
+      // `(SELECT NULLIF('a','a'))` staying unconstrained), not read off the
+      // first arm alone; a wider or an `EXISTS`/`IN (Q)` subquery still records
+      // the FIRST column (harmless — only a width-1 scalar occurrence reads it,
+      // and the lowering rejects a wider one). It derives cursor-free against
+      // the SAME context the width compile uses, so it matches what the run
+      // advertises.
       types[query] =
-          try columns(of: query.first, inner).first?.type
+          try columns(unifying: query, inner).first
       // The correlation the nested compile discovered — the outer columns its
       // inner `WHERE`/`ON` named — carried into the lowered subquery node so
       // the per-outer-row re-execution binds them. Empty for an UNCORRELATED
@@ -3826,7 +4013,15 @@ extension Catalog where Self: ~Escapable {
   /// select list as a run would anyway.
   internal borrowing func probe(_ query: Query, _ context: Context)
       throws(SQLError) -> Bool {
-    return try !run(probed(query), context).isEmpty
+    // An `EXISTS` reads ONLY the probe's cardinality, never a cell, so a set-
+    // operation probe's column TYPES are irrelevant — `combine` coerces the
+    // (discarded) rows, `.isEmpty` reads none. So run the probe under a
+    // `shaping()` context, deferring the set-operation operand-compatibility
+    // fold: `EXISTS (SELECT 'x' UNION SELECT 1)` probes non-emptiness WITHOUT
+    // faulting `SQLError.operand` on the irreconcilable arm types, matching the
+    // invariant that an `EXISTS` does not constrain column type (a bare-select
+    // probe folds nothing, so `shaping()` is inert for it).
+    return try !run(probed(query), context.shaping()).isEmpty
   }
 
   /// The cardinality-only shape of `query` an `EXISTS` tests for non-emptiness:

--- a/Sources/SQLEngine/Filter.swift
+++ b/Sources/SQLEngine/Filter.swift
@@ -1067,6 +1067,26 @@ extension Catalog where Self: ~Escapable {
       throws(SQLError) -> Array<Record> {
     let bindings = correlated(row, correlation, context.bindings)
     let context = context.binding(bindings)
+    // A REACHED correlated scalar/`IN`/quantified occurrence over a SET
+    // OPERATION strictly re-folds its arms' column types before executing the
+    // SHAPED (placeholder-typed) plan the pre-pass recorded — the pre-pass
+    // compiles under `.shaping()`, so an irreconcilable pair was deferred to a
+    // placeholder there; this seam runs `context` WITHOUT a shape, so the fold
+    // faults `.operand`/42804 exactly as the uncorrelated `run` path does,
+    // firing ONLY for reached occurrences (an unreachable one never calls
+    // `executed`, so its shape deferral stands). Only a SET OPERATION has a
+    // cross-arm fold to check — a plain `SELECT` subquery has no arms to unify,
+    // and resolving its projection here would fault on its own correlated
+    // columns (out of scope in this fold context) — so a non-setop query skips
+    // it. `EXISTS`/`LATERAL` skip it too: `EXISTS` ignores column types and the
+    // recorded probe is already the shape. The fold runs ONCE per occurrence —
+    // memoised on the `Subkey` — so a reached incompatibility faults on the
+    // FIRST reached outer row and later rows skip the redundant (pure) re-fold.
+    if key.role == .scalar || key.role == .valued, case .setop = key.query,
+        !context.subqueries.validated(key) {
+      _ = try types(unifying: key.query, context)
+      context.subqueries.validate(key)
+    }
     guard let plan = context.subqueries.plan(key, correlation) else {
       throw .named("a correlated subquery plan was not compiled")
     }
@@ -1172,10 +1192,13 @@ extension Catalog where Self: ~Escapable {
   /// the run path is.
   private borrowing func arms(_ plan: Plan, _ query: Query, _ context: Context)
       throws(SQLError) -> Array<Record> {
-    if case let .setop(kind, left, right, all) = plan,
+    if case let .setop(kind, left, right, all, types, _) = plan,
         case let .setop(_, leftQuery, rightQuery, _) = query {
+      // The unified column `types` the plan carries (computed at compile) drive
+      // the arm coercion `combine` applies — the SAME types every set-op path
+      // uses, so a mixed-type arm widens identically here.
       return try combine(kind, arms(left, leftQuery, context),
-                         arms(right, rightQuery, context), all)
+                         arms(right, rightQuery, context), all, types: types)
     }
     let augmented =
         try augment(context.validating(false), for: query, rows: true)

--- a/Sources/SQLEngine/Operator.swift
+++ b/Sources/SQLEngine/Operator.swift
@@ -84,6 +84,17 @@ internal struct Record: Row, Hashable {
   internal func merged(with other: Record) -> Record {
     Record(cells + other.cells)
   }
+
+  /// This record with each cell COERCED to the corresponding column `type`
+  /// (`Value.coerced` — the ISO numeric widening a set operation applies to its
+  /// arms' rows, promoting an `integer` cell to `double` where the unified
+  /// column is `double`). A cell whose column type equals its own kind (a
+  /// homogeneous set operation) passes through unchanged, so this is a no-op
+  /// except at a widening column. `types` matches the record's width (the arm
+  /// arity `compile` proved equal).
+  internal func coerced(to types: Array<ValueType>) -> Record {
+    Record(cells.indices.map { cells[$0].coerced(to: types[$0]) })
+  }
 }
 
 // MARK: - Plan
@@ -187,7 +198,31 @@ internal indirect enum Plan {
              ordinals: Array<Int>, on: Filter, kind: Join.Kind)
   /// A set operation of `kind` (`UNION`/`INTERSECT`/`EXCEPT`) over the `left`
   /// and `right` sub-plans, both yielding rows of the same width — the result
-  /// columns of the first arm.
+  /// columns, whose NAMES are the first arm's and whose `types` are UNIFIED
+  /// across the arms.
+  ///
+  /// `types` is the per-column unified result type (`ValueType.unified` folded
+  /// over the arms — a mixed integer/double column widening to `double`), one
+  /// entry per output column. The executor COERCES each arm's cells to these
+  /// types (`Value.coerced`) before applying the operator, so `SELECT 1 UNION
+  /// SELECT 2.5` yields a `double` column `[1.0, 2.5]`. It is computed at
+  /// COMPILE — where the arm queries and the resolution scope are in hand —
+  /// because this node carries only the sub-plans, not the arm `Query`s the
+  /// fold reads. A homogeneous set operation's `types` matches every arm's own
+  /// types, so the coercion is a no-op and the result is byte-identical.
+  ///
+  /// `widened` is the output columns whose unified `types[c]` differs from an
+  /// arm's OWN native projected type — the columns the coercion actually
+  /// changes (a `double` unified over an `integer` arm). It is derived at
+  /// compile from the unified `types` against each arm's native types and
+  /// carried here so the pushdown pass — a pure Plan rewrite with no catalog —
+  /// can tell a widened column from a same-typed one WITHOUT re-typing the
+  /// arms. A predicate over a widened column must NOT push below this node into
+  /// the arms: an arm evaluates it on the PRE-coercion value, but `combine`
+  /// coerces only the arm's emitted rows AFTER the arm runs, so the pushed
+  /// predicate would test the un-widened type. A predicate over a NON-widened
+  /// column still pushes (a same-typed `UNION ALL`). Empty for a homogeneous
+  /// set operation.
   ///
   /// Without `all` the result is the distinct rows the operator selects — the
   /// rows of either (`UNION`), of both (`INTERSECT`), or of the left not in the
@@ -197,7 +232,8 @@ internal indirect enum Plan {
   /// left row beyond the count the right removes. The node is binary and
   /// mirrors the `Query` set-operation tree, so each node honours its OWN
   /// `kind`/`all`.
-  case setop(SetOperation, Plan, Plan, all: Bool)
+  case setop(SetOperation, Plan, Plan, all: Bool, types: Array<ValueType>,
+             widened: Set<Int>)
   /// δ — deduplicates its `source`'s rows, keeping the first occurrence of each
   /// distinct whole row and preserving their order (`SELECT DISTINCT`). It sits
   /// above the projection, so it dedups the projected output rows on the SAME
@@ -237,7 +273,7 @@ extension Plan {
     switch self {
     case let .project(terms, _):
       terms.count
-    case let .setop(_, left, _, _):
+    case let .setop(_, left, _, _, _, _):
       left.width
     case let .distinct(source):
       // A `distinct` dedups rows without reshaping them, so it is as wide as
@@ -303,7 +339,7 @@ extension Plan {
       // An apply lays the lateral body's taken `ordinals` after the left's
       // slots, exactly as a product lays a scan's referenced ordinals.
       left.slots.map { $0 + ordinals.count }
-    case let .setop(_, left, _, _):
+    case let .setop(_, left, _, _, _, _):
       // Both sides yield rows of the same width — the result columns — so the
       // set operation's width is its left side's.
       left.slots
@@ -447,8 +483,8 @@ extension Catalog where Self: ~Escapable {
     case let .apply(left, key, correlation, ordinals, on, kind):
       return try applied(execute(left, context), key, correlation, ordinals,
                          on, kind, context)
-    case let .setop(kind, left, right, all):
-      return try setop(kind, left, right, all, context)
+    case let .setop(kind, left, right, all, types, _):
+      return try setop(kind, left, right, all, types, context)
     case let .distinct(source):
       return deduplicated(try execute(source, context))
     case let .aggregate(keys, aggregates, source):
@@ -915,9 +951,14 @@ private func limited(_ records: Array<Record>, _ count: Int?, _ offset: Int)
 extension Catalog where Self: ~Escapable {
   fileprivate borrowing func setop(_ kind: SetOperation, _ left: Plan,
                                    _ right: Plan, _ all: Bool,
+                                   _ types: Array<ValueType>,
                                    _ context: Context)
       throws(SQLError) -> Array<Record> {
-    try combine(kind, execute(left, context), execute(right, context), all)
+    // `types` is the compile-time unified per-column type — this node carries
+    // no arm `Query`, so it cannot fold them here; `combine` coerces each arm's
+    // rows to them before applying the operator.
+    try combine(kind, execute(left, context), execute(right, context), all,
+                types: types)
   }
 }
 
@@ -925,8 +966,19 @@ extension Catalog where Self: ~Escapable {
 /// keeps the rows of either, `intersect` those of both, `except` the left's not
 /// balanced by the right — the executor's `setop` node and the per-arm run path
 /// share this ONE combiner so the two agree on duplicate handling.
+///
+/// Each arm's cells are first COERCED to the unified column `types` (`Value
+/// .coerced` — the widening ISO type unification requires, so `SELECT 1 UNION
+/// SELECT 2.5` emits a `double` column), the ONE numeric widening `coerced`
+/// performs; a HOMOGENEOUS set operation's `types` matches each arm's own
+/// types, so the coercion is a no-op and the result is byte-identical.
+/// `INTERSECT`/`EXCEPT` equality already canonicalises (`1` equals `1.0`), so
+/// coercion there changes only the EMITTED cells' type, never which rows match.
 internal func combine(_ kind: SetOperation, _ left: Array<Record>,
-                      _ right: Array<Record>, _ all: Bool) -> Array<Record> {
+                      _ right: Array<Record>, _ all: Bool,
+                      types: Array<ValueType>) -> Array<Record> {
+  let left = left.map { $0.coerced(to: types) }
+  let right = right.map { $0.coerced(to: types) }
   switch kind {
   case .union:
     let combined = left + right
@@ -1176,10 +1228,14 @@ extension Catalog where Self: ~Escapable {
   private borrowing func setop(_ plan: Plan, _ query: Query, _ overlay: Context,
                                _ name: String)
       throws(SQLError) -> Array<Record> {
-    if case let .setop(kind, left, right, all) = plan,
+    if case let .setop(kind, left, right, all, types, _) = plan,
         case let .setop(_, leftQuery, rightQuery, _) = query {
+      // This node's arm queries are in hand, so the unified column `types` the
+      // plan carries (computed at compile) drive the arm coercion `combine`
+      // applies — the SAME types the top-level and Plan-node paths use.
       return try combine(kind, setop(left, leftQuery, overlay, name),
-                         setop(right, rightQuery, overlay, name), all)
+                         setop(right, rightQuery, overlay, name), all,
+                         types: types)
     }
     let scope = try augment(overlay.validating(false), for: query, rows: true)
     scope.subqueries.record(overlay: scope.revealed().relations,

--- a/Sources/SQLEngine/OutputColumn.swift
+++ b/Sources/SQLEngine/OutputColumn.swift
@@ -32,27 +32,35 @@ public struct OutputColumn: Hashable, Sendable {
 /// per-column descriptor a binding is built FROM as a whole, rather than
 /// re-listed field by field at each site.
 ///
-/// It wraps the body's `OutputColumn` (name + type) today. It exists as a
-/// struct so a future per-column attribute (a nullability/unconstrained mask a
-/// set-operation type unification carries) is added HERE, in ONE place, and
-/// threads through every binding via the single `init(from:)` constructor — no
-/// site re-lists the fields, so none can drop the new attribute. Every
-/// relation-body binding derives an `Array<ResolvedColumn>` via
-/// `resolved(query:in:)` and is constructed from it.
+/// It wraps the body's `OutputColumn` (name + type) and carries the per-column
+/// `unconstrained` mask a set-operation type unification threads: whether every
+/// arm folded into this column projects a CONSTANT NULL, so it places NO type
+/// constraint on a unified column (a NULL unifies with any typed arm, exactly
+/// as `COALESCE` skips a constant-NULL argument). It is the ONE per-column
+/// carrier: both `resolved(query:in:)`/`columns(unifying:)` and `merge` operate
+/// on and return it, and every binding is built from it via the single
+/// `init(from:)` constructor — no site re-lists the fields, so none can drop
+/// the mask.
 internal struct ResolvedColumn: Hashable, Sendable {
   /// The column's output name and value type.
   internal let column: OutputColumn
 
-  internal init(_ column: OutputColumn) {
+  /// Whether every arm folded into this column so far projects a constant NULL,
+  /// so it places NO type constraint on the set-operation's unified column.
+  internal let unconstrained: Bool
+
+  internal init(_ column: OutputColumn, unconstrained: Bool = false) {
     self.column = column
+    self.unconstrained = unconstrained
   }
 
   /// A resolved column carrying `name` and `type` directly — the declared
   /// carrier a common table expression's self binding is built from, its name
   /// the declared column and its type the `.integer` placeholder a materialised
   /// relation reports.
-  internal init(name: String, type: ValueType) {
+  internal init(name: String, type: ValueType, unconstrained: Bool = false) {
     self.column = OutputColumn(name: name, type: type)
+    self.unconstrained = unconstrained
   }
 
   /// The column's output name.
@@ -62,14 +70,64 @@ internal struct ResolvedColumn: Hashable, Sendable {
   internal var type: ValueType { column.type }
 }
 
+/// Merges two set-operation arms' resolved columns into the fold's running
+/// column: the name is the LEFT arm's (the ISO first-arm rule), and the type is
+/// the unification of the two — SKIPPING a constant-NULL (unconstrained) arm's
+/// type, which constrains nothing. A column that is constant NULL in BOTH arms
+/// stays unconstrained (its type the left's, defaulting to the `.integer` a
+/// NULL column already carries); a column typed in ONE arm and NULL in the
+/// other takes the typed arm's type and becomes constrained; two typed arms
+/// merge through `ValueType.unified`, faulting `SQLError.operand` (SQLSTATE
+/// 42804) on an irreconcilable pair — a text beside a number, a boolean beside
+/// a number — the same fault a `COALESCE`/`CASE` raises on irreconcilable
+/// result types.
+///
+/// `shape` (default `false`) is the nested-subquery pre-pass mode: on an
+/// irreconcilable pair it does NOT fault but substitutes the LEFT arm's type as
+/// a discardable placeholder, marked `unconstrained` so a further enclosing
+/// fold treats it as placing no constraint. The pre-pass records this width-1
+/// type for a subquery the reachability walk has not yet decided runs; an
+/// UNREACHED occurrence's type is discarded, and a REACHED scalar/`IN` one is
+/// re-folded STRICTLY (`shape: false`) on the reached path, so a genuine
+/// incompatibility still faults there. Arity/resolution stay eager regardless.
+internal func merge(_ left: ResolvedColumn, _ right: ResolvedColumn,
+                    shape: Bool = false)
+    throws(SQLError) -> ResolvedColumn {
+  let name = left.column.name
+  // A constant-NULL arm constrains nothing: carry the OTHER arm's type (and,
+  // when both are NULL, the left's), narrowing the running unconstrained-ness
+  // to whether BOTH remaining arms are NULL.
+  if left.unconstrained {
+    return ResolvedColumn(name: name, type: right.column.type,
+                          unconstrained: right.unconstrained)
+  }
+  if right.unconstrained {
+    return ResolvedColumn(name: name, type: left.column.type)
+  }
+  guard let unified = left.column.type.unified(with: right.column.type) else {
+    // The shape pre-pass defers the operand fault to the reached path: yield a
+    // discardable placeholder (the left arm's type, marked unconstrained)
+    // rather than faulting while merely recording an unreached subquery.
+    if shape {
+      return ResolvedColumn(name: name, type: left.column.type,
+                            unconstrained: true)
+    }
+    throw .operand("UNION arms have irreconcilable types")
+  }
+  return ResolvedColumn(name: name, type: unified)
+}
+
 extension Catalog where Self: ~Escapable {
   /// The result columns `query` would yield, named and typed, resolved WITHOUT
   /// executing it.
   ///
-  /// The result columns are the FIRST arm's projection (the ISO rule a `UNION`
-  /// follows), so a union names its result off its leading `SELECT`. The column
-  /// count matches the compiled plan's `width`; the names and types come from
-  /// re-walking the projection exactly as compilation resolves it:
+  /// A union's result columns take their NAMES from the FIRST arm's projection
+  /// (the ISO rule a `UNION` follows), so a union names its result off its
+  /// leading `SELECT`, while their TYPES are UNIFIED across ALL arms (a mixed
+  /// integer/double column widening to `double`, an irreconcilable pair
+  /// faulting). The column count matches the compiled plan's `width`; the names
+  /// and types come from re-walking the projection exactly as compilation
+  /// resolves it:
   ///
   ///   - `SELECT *` — every real column of every relation in scope, in chain
   ///     order (never a virtual column), named and typed from each relation's
@@ -81,8 +139,9 @@ extension Catalog where Self: ~Escapable {
   ///     source type and a literal its own; every other expression is reported
   ///     `.integer`, the engine's exact-numeric default.
   ///
-  /// The result columns come from the first arm's projection, but ONLY after
-  /// the WHOLE query validates: `compile` resolves every arm (each `WHERE`,
+  /// The result columns' names come from the first arm and their types unify
+  /// across arms, but ONLY after the WHOLE query validates: `compile` resolves
+  /// every arm (each `WHERE`,
   /// join, and projection) and cross-checks a `UNION`'s arm arity, without
   /// opening a cursor. So a query whose first arm names its columns cleanly but
   /// whose `WHERE` references a missing column, or whose second `UNION` arm
@@ -145,13 +204,16 @@ extension Catalog where Self: ~Escapable {
     // operand a data-dependent filter never reached would otherwise fault a
     // query that produced its (empty) result.
     if validate { try typecheck(query, scope) }
-    // The result columns are the first arm's projection (the ISO rule a UNION
-    // follows), resolved against the validated scope; a scalar call types from
-    // its routine's declared return type. `validate` rides through so a
-    // `SELECT *` over a view derives the body's types WITHOUT re-type-checking
-    // it — the view body's own reachable-operand check is gated the same as the
-    // outer query's, so a `validate: false` derive faults nowhere.
-    return try columns(of: query.first, scope)
+    // The result columns' NAMES come from the first arm's projection (the ISO
+    // rule a UNION follows), but their TYPES are UNIFIED across ALL arms — a
+    // column mixing `integer` and `double` arms widens to `double`, an
+    // irreconcilable pair (text beside a number) faults `SQLError.operand` —
+    // resolved against the validated scope; a scalar call types from its
+    // routine's declared return type. `validate` rides through so a `SELECT *`
+    // over a view derives the body's types WITHOUT re-type-checking it — the
+    // view body's own reachable-operand check is gated the same as the outer
+    // query's, so a `validate: false` derive faults nowhere.
+    return try columns(unifying: query, scope).map(\.column)
   }
 
   /// The result columns `statement` would yield, named and typed, resolved
@@ -198,7 +260,8 @@ extension Catalog where Self: ~Escapable {
   ///
   /// Each CTE binds a `RelationInstance` of its DECLARED columns with no rows —
   /// the schema the run's materialised CTE resolves to (columns from the
-  /// declared list, every type `.integer`) — laid into the overlay in source
+  /// declared list, each typed from its BODY fold and carrying its
+  /// `unconstrained` mask, `kinds(of:)`) — laid into the overlay in source
   /// order so a later CTE, and the trailing query, resolve a name the same
   /// precedence a run applies (a CTE shadows a base relation of the same name).
   /// The `definition_schema.` store augment then extends this overlay for the
@@ -244,11 +307,6 @@ extension Catalog where Self: ~Escapable {
       guard overlay[cte.name.lowercased()] == nil else {
         throw .redefinition(cte.name)
       }
-      // The CTE's schema-only self — its declared columns, no rows, every type
-      // `.integer` (the default a materialised relation reports) — bound into
-      // the recursive arm's operand check and, after validation, into the
-      // overlay a later CTE and the trailing query resolve against.
-      let binding = RelationInstance(from: cte.declared, rows: [])
       // Validate the body's SHAPE and ARITY against the scope of the PRIOR CTEs
       // by the SAME code a run uses — `Engine.validate` — so a schema is not
       // advertised for a `WITH` a run would reject, and this path never again
@@ -269,11 +327,21 @@ extension Catalog where Self: ~Escapable {
         try self.validate(cte, against: context.body(overlay),
                           typecheck: true)
       }
+      // The CTE's schema-only self — its declared columns, no rows, and its
+      // BODY-DERIVED column carrier (never the declared-name `.integer`
+      // placeholder), derived under the SAME body scope `validate` uses (the
+      // PRIOR CTEs in `overlay`, self not in scope) so the trailing query's
+      // set-op fold reads a CTE column at its real type rather than spuriously
+      // merging an `.integer` placeholder against a text arm and faulting. The
+      // carrier's `unconstrained` mask threads through `init(from:)`, so an
+      // all-NULL CTE column unifies with any later typed arm.
+      let derived = try kinds(of: cte, context.body(overlay))
       // Bind the CTE's schema-only self into the overlay AFTER its body is
       // validated — the scope a later CTE and the trailing query resolve
       // against — exactly as `Engine.with` binds the materialised relation
       // after running its body.
-      overlay[cte.name.lowercased()] = binding
+      overlay[cte.name.lowercased()] =
+          RelationInstance(from: derived, rows: [])
     }
     // Compile/type-check/derive from the base `context.scoping(overlay)`
     // (idempotently augmented within each, which pushes the trailing query's
@@ -289,7 +357,7 @@ extension Catalog where Self: ~Escapable {
     let base = context.body(overlay)
     _ = try compile(query, base)
     if validate { try typecheck(query, base) }
-    return try columns(of: query.first, base)
+    return try columns(unifying: query, base).map(\.column)
   }
 
   /// The result columns of a single `select`, resolved against this catalog
@@ -307,9 +375,30 @@ extension Catalog where Self: ~Escapable {
   /// re-type-checks a view body a run already proved runnable.
   borrowing func columns(of select: Select, _ context: Context)
       throws(SQLError) -> Array<OutputColumn> {
+    try arms(of: select, context).map(\.column)
+  }
+
+  /// The output columns of a single set-operation `select` arm — each carried
+  /// as a `ResolvedColumn` recording whether its projected expression is a
+  /// constant NULL — the per-arm worker the set-operation fold
+  /// (`columns(unifying:_:)`) drives.
+  ///
+  /// This NAMES AND TYPES the projection and marks its constant-NULL columns;
+  /// it does not re-validate the WHERE, joins, GROUP BY, HAVING, or ORDER BY.
+  /// Whole-query validation belongs to `compile` — the public `columns(of
+  /// query:)` runs it — so this worker never duplicates (and never drifts from)
+  /// that resolution. It runs only after compilation has proved the arm
+  /// resolves. `routines` are the scalar routines a call types from — its
+  /// declared return type — rather than the `.integer` default. The context's
+  /// `validate` rides through to any view this arm's relations resolve, gating
+  /// the view body's reachable-operand check the same as the outer query's — a
+  /// `validate: false` context never re-type-checks a view body a run already
+  /// proved runnable.
+  private borrowing func arms(of select: Select, _ context: Context)
+      throws(SQLError) -> Array<ResolvedColumn> {
     // Bind THIS select's own FROM/JOIN derived tables (and store relations)
     // before deriving either the subquery map or the scope — a set-op ARM
-    // reaches here directly (`columns(of query.first, …)`), and the top-level
+    // reaches here directly (`columns(unifying: query, …)`), and the top-level
     // augment collected NO arm-local aliases (arms are SELECT-scoped), so a
     // subquery naming the arm's own derived alias (`WHERE Id IN (SELECT Id FROM
     // d)`) would else compile against a scope missing `d`. Schema-only, no
@@ -340,23 +429,167 @@ extension Catalog where Self: ~Escapable {
     // scope the incoming context may carry.
     let plans = try subquery(of: select, augmented.scoped(as: .caller),
                              enclosing: scope, prefixes: prefixes)
+    // ONE walk yields each column's name, type, AND `unconstrained` mask
+    // together — a constant-NULL projection or a reference to an unconstrained
+    // (LOCAL or CORRELATED) source column carries the mask through the same
+    // resolution as the type, so the two cannot diverge. The projection walk is
+    // BARRED (a correlated column of THIS query in the projection is diagnosed,
+    // as the run's projection lowering bars it).
     return try scope.columns(of: select.projection, augmented.routines,
                              subquery: plans.rest.barred)
   }
 
+  /// The output columns of `query`, TYPE-UNIFIED across every set-operation arm
+  /// — the ISO rule a `UNION`/`INTERSECT`/`EXCEPT` result columns follow.
+  ///
+  /// A bare `SELECT` types off its own projection. A `setop` node folds its two
+  /// arms column-wise: each result column takes the LEFT (first) arm's NAME
+  /// (the ISO rule — a union names its columns off its leading `SELECT`) and
+  /// the MERGE of the two arms' types (`merge` — like types pass through, a
+  /// mixed integer/double pair widens to `double`, an irreconcilable pair
+  /// faults `SQLError.operand`). A left-associative chain composes
+  /// automatically. A column an arm projects as a CONSTANT NULL places NO type
+  /// constraint (a NULL unifies with any typed arm), so the fold carries the
+  /// OTHER arm's type and unconstrained-ness up unchanged, mirroring
+  /// `COALESCE`'s constant-NULL skip. The arm ARITY is proved equal by
+  /// `compile` before this runs, so the column-wise zip is safe.
+  ///
+  /// Each returned `ResolvedColumn` carries the unified column AND whether it
+  /// is constant NULL in EVERY arm folded so far — the value coercion paths
+  /// read the `type`, and a further enclosing fold reads `unconstrained`.
+  borrowing func columns(unifying query: Query, _ context: Context)
+      throws(SQLError) -> Array<ResolvedColumn> {
+    switch query {
+    case let .select(select):
+      return try arms(of: select, context)
+    case let .setop(_, left, right, _):
+      let l = try columns(unifying: left, context)
+      let r = try columns(unifying: right, context)
+      // A NESTED set operation's arm mismatch is faulted HERE, before the
+      // column-wise merge indexes both arms — `compile` cross-checks the
+      // outer widths but the fold descends into child nodes it has not yet
+      // validated, so an unguarded `r[index]` would trap rather than fault.
+      guard l.count == r.count else { throw .arity(l.count, r.count) }
+      // The operand-compatibility fold DEFERS under the shape pre-pass
+      // (`context.shape`): a nested subquery's set-operation type is recorded
+      // ahead of the reachability walk, so an unreached incompatible pair
+      // yields a discardable placeholder rather than faulting; a reached
+      // scalar/`IN` occurrence is re-folded strictly on the reached path.
+      return try l.indices.map { index throws(SQLError) in
+        try merge(l[index], r[index], shape: context.shape)
+      }
+    }
+  }
+
+  /// The unified column TYPES of `query`, folded across every set-operation arm
+  /// — the types each producer path coerces its arms' values to so a set
+  /// operation's result carries the common column type (`SELECT 1 UNION SELECT
+  /// 2.5` a `double` column). It is the type projection of
+  /// `columns(unifying:_:)`, resolved against `context`.
+  borrowing func types(unifying query: Query, _ context: Context)
+      throws(SQLError) -> Array<ValueType> {
+    try columns(unifying: query, context).map(\.type)
+  }
+
   /// The SINGLE deriver of a relation body's resolved output columns: the
-  /// FIRST arm's projection (the ISO rule a `UNION` follows), named and typed
-  /// against `context`, wrapped as the `ResolvedColumn` carrier every
-  /// body-derived binding is constructed from.
+  /// columns UNIFIED across every set-operation arm (the ISO rule a
+  /// `UNION`/`INTERSECT`/`EXCEPT` follows), named off the first arm and typed
+  /// across all of them, each carrying its `unconstrained` mask — the
+  /// `ResolvedColumn` carrier every body-derived binding is constructed from.
   ///
   /// Every binding site that folds a body into a `RelationInstance`/`Schema` —
   /// a derived table's `materialise`, a view's schema resolution — obtains its
-  /// columns HERE, never by re-deriving the projection inline, so a future
-  /// per-column attribute on `ResolvedColumn` threads through all of them from
-  /// one place.
+  /// columns HERE, never by re-deriving the projection inline, so the
+  /// per-column `unconstrained` mask threads through all of them from one place
+  /// via the single `init(from:)` constructor and no site can drop it.
   borrowing func resolved(query body: Query, in context: Context)
       throws(SQLError) -> Array<ResolvedColumn> {
-    try columns(of: body.first, context).map(ResolvedColumn.init)
+    try columns(unifying: body, context)
+  }
+
+  /// The column CARRIER a CTE binds under — its DECLARED column names (a CTE is
+  /// addressed by its declared list, `WITH t(x) AS …` exposes `x`, never the
+  /// body's own projected name) carrying each column's BODY-folded type (never
+  /// the `.integer` placeholder) and whether every arm feeding it projects a
+  /// constant NULL, so it places no type constraint. A recursive `UNION` CTE
+  /// unifies the anchor's columns (self not in scope) with the recursive arm's
+  /// (self bound to the anchor's types), mirroring `fixpoint`; any other body
+  /// folds its own. A trusted derive (a `validate: false` body a filter drops)
+  /// that faults falls back to the placeholder.
+  ///
+  /// The result is always the CTE's DECLARED width (`cte.columns.count`): a
+  /// body whose fold yields a different count is reconciled to it (padding a
+  /// short fold with the `.integer` default, truncating a long one), so a
+  /// caller building the CTE binding from it indexes a same-length carrier
+  /// whatever the (possibly malformed) body derives.
+  borrowing func kinds(of cte: CTE, _ scope: Context)
+      throws(SQLError) -> Array<ResolvedColumn> {
+    let derived = try contributions(of: cte, scope)
+    let sized = reconcile(derived, to: cte.columns.count, named: cte.columns)
+    // Bind under the CTE's DECLARED names, keeping each column's body-folded
+    // type and `unconstrained` mask, so `WITH t(x) AS (SELECT 1 AS n)` is
+    // addressed as `x` while `x` carries the body's derived type.
+    return sized.indices.map {
+      ResolvedColumn(name: cte.columns[$0], type: sized[$0].type,
+                     unconstrained: sized[$0].unconstrained)
+    }
+  }
+
+  /// The raw column carrier a CTE's body folds to, BEFORE reconciling to the
+  /// declared width — the recursive-aware merge `kinds` wraps.
+  private borrowing func contributions(of cte: CTE, _ scope: Context)
+      throws(SQLError) -> Array<ResolvedColumn> {
+    guard cte.recursive, cte.recurses,
+        case let .setop(.union, anchor, recursive, _) = cte.query else {
+      // A non-recursive body's carrier is its unified fold, PROPAGATING a
+      // genuine incompatibility (`SELECT 'b' UNION SELECT 1`) as `.operand`
+      // rather than swallowing it into the declared `.integer`: with every
+      // placeholder now marked unconstrained, a trusted body that RAN carries
+      // no genuine incompat to fault, so no `try?` fallback is needed.
+      return try columns(unifying: cte.query, scope)
+    }
+    let seeds = try columns(unifying: anchor, scope)
+    // The recursive arm addresses the self by the CTE's DECLARED names (`SELECT
+    // n + 1 FROM t` reads `n`), so bind the schema-only self under those names
+    // carrying the anchor's derived types/mask, not the anchor's own projected
+    // names. The anchor's width is proved against the declared list before this
+    // runs, so the index is in range.
+    let named = seeds.indices.map { index -> ResolvedColumn in
+      guard index < cte.columns.count else { return seeds[index] }
+      return ResolvedColumn(name: cte.columns[index], type: seeds[index].type,
+                            unconstrained: seeds[index].unconstrained)
+    }
+    let empty = RelationInstance(from: named, rows: [])
+    let steps = try columns(unifying: recursive,
+                            scope.binding(cte.name, to: empty))
+    // A malformed recursive CTE whose anchor and recursive arms project
+    // differing widths would trap indexing `steps[index]`; fault cleanly on the
+    // mismatch instead, the same column-count fault a declared-arity mismatch
+    // raises.
+    guard seeds.count == steps.count else {
+      throw .columns(expected: seeds.count, got: steps.count)
+    }
+    return try seeds.indices.map { index throws(SQLError) in
+      try merge(seeds[index], steps[index])
+    }
+  }
+
+  /// `contributions` reconciled to exactly `count` columns — the declared width
+  /// a caller binds the CTE under. A fold that yields fewer columns is padded
+  /// with a fabricated `.integer` placeholder (named from `names` where one
+  /// exists) marked UNCONSTRAINED, since it is not a genuine derivation, a
+  /// longer one truncated, so the built binding's type and unconstrained arrays
+  /// always match the declared column list's length whatever a malformed body
+  /// derives.
+  private borrowing func reconcile(_ carrier: Array<ResolvedColumn>,
+                                   to count: Int, named names: Array<String>)
+      -> Array<ResolvedColumn> {
+    guard carrier.count != count else { return carrier }
+    return (0 ..< count).map { index in
+      if index < carrier.count { return carrier[index] }
+      let name = index < names.count ? names[index] : "column \(index + 1)"
+      return ResolvedColumn(name: name, type: .integer, unconstrained: true)
+    }
   }
 
   /// The name-resolution scope of `select` — its FROM relation and each joined
@@ -415,14 +648,13 @@ extension Catalog where Self: ~Escapable {
   /// Type-checks every operand in `query` — the projection, `WHERE`, and
   /// `HAVING` of EVERY arm — throwing the run-time fault a bad operand would.
   ///
-  /// The result schema types only the FIRST arm's projection (the ISO rule), so
-  /// a later set-operation arm's or a `HAVING`'s operand-type error would
-  /// otherwise go unadvertised — `SELECT Age FROM t UNION SELECT Name + 1 FROM
-  /// t` or `…
-  /// HAVING SUM(Name) > 0` resolves its names but `Arithmetic.apply`/
-  /// `Aggregate.fold` faults `SQLError.operand` at run. `compile` cannot catch
-  /// this (no evaluating term is built), so a schema path type-checks each arm
-  /// before returning metadata. It reads no cursor.
+  /// The result schema DERIVES each arm's projection type (unifying them across
+  /// arms), but that non-faulting derive does not exercise a later arm's or a
+  /// `HAVING`'s REACHABLE-operand check — `SELECT Age FROM t UNION SELECT Name
+  /// + 1 FROM t` or `… HAVING SUM(Name) > 0` resolves its names but
+  /// `Arithmetic.apply`/`Aggregate.fold` faults `SQLError.operand` at run.
+  /// `compile` cannot catch this (no evaluating term is built), so a schema
+  /// path type-checks each arm before returning metadata. It reads no cursor.
   borrowing func typecheck(_ query: Query, _ context: Context)
       throws(SQLError) {
     // Bind the derived tables (and store relations) THIS query names in its own
@@ -617,10 +849,21 @@ extension Catalog where Self: ~Escapable {
     // those resolve regardless of `validate`. Lower under `.caller`, this
     // frame's `nested` outer, and shape-only lenience (`validate: false`) — the
     // schema pre-pass's cursor-free derive.
-    let inner =
-        context.scoped(as: .caller).with(outer: nested).validating(false)
+    // `shaping()` DEFERS the set-operation operand-compatibility fold: this
+    // pre-pass records EVERY nested subquery's width and single-column type
+    // ahead of the reachability walk, so faulting `SQLError.operand` here would
+    // reject an unreachable incompatible set-operation subquery a short-
+    // circuited leg never reaches. The reached scalar/`IN` re-fold below
+    // restores the strict check for an occurrence that DOES run. Arity and
+    // resolution stay eager regardless.
+    let inner = context.scoped(as: .caller).with(outer: nested)
+        .validating(false).shaping()
     let width = try compile(query, inner).width
-    let derived = try columns(of: query.first, inner).first?.type
+    // The single-column output TYPE — UNIFIED across the subquery's set-
+    // operation arms (`(SELECT 1 UNION SELECT 2.5)` typing `double`), not the
+    // first arm alone — for validation's type-check. The run/derive fold reads
+    // the `unconstrained` mask via `Resolution`; validation uses the type.
+    let derived = try columns(unifying: query, inner).first?.type
     if widths[query] == nil {
       widths[query] = width
       types[query] = derived
@@ -702,6 +945,21 @@ extension Catalog where Self: ~Escapable {
     let inner = revealed.with(outer: nested)
     for reach in subquery.visited {
       try typecheck(shape(of: reach), inner)
+      // The nested-subquery shape pre-pass DEFERRED a set-operation's operand-
+      // compatibility fold (`shaping()`), so a genuine incompatibility in a
+      // subquery that ACTUALLY runs would otherwise slip through. Re-fold it
+      // STRICTLY here (`inner` carries no `shape`), so a REACHED scalar or
+      // `IN`/quantified (`.valued`) occurrence with irreconcilable arm types
+      // faults `SQLError.operand` exactly as before the deferral. An
+      // `existential` (`EXISTS`) or `lateral` reach does NOT constrain column
+      // type — its cardinality does not read the arms' unified type — so it is
+      // SKIPPED and never faults on it, reachable or not.
+      switch reach.role {
+      case .scalar, .valued:
+        _ = try columns(unifying: reach.query, inner)
+      case .existential, .lateral:
+        break
+      }
     }
     // Each join `ON` runs through the SAME reachability/short-circuit walk the
     // WHERE does, but PREFIX-scoped: an `ON` predicate short-circuits its
@@ -1069,10 +1327,13 @@ extension Catalog where Self: ~Escapable {
       if context.validate {
         try typecheck(view.query, overlay)
       }
-      // Type off the body's first arm (the ISO rule for a UNION). Arity — the
-      // body's width against the declared columns — is `compile`'s job (the
-      // public entry runs it), so on a shortfall fall back to the declared
-      // schema rather than re-checking it here.
+      // Type the body's columns: their NAMES off the first arm (the ISO rule
+      // for a UNION), their TYPES unified across every arm, each carrying its
+      // `unconstrained` mask so an all-NULL view column unifies with any later
+      // typed arm through `Schema(from:)`. Arity — the body's width against the
+      // declared columns — is `compile`'s job (the public entry runs it), so on
+      // a shortfall fall back to the declared schema rather than re-checking it
+      // here.
       let resolved = try resolved(query: view.query, in: overlay)
       guard resolved.count == base.width else {
         return try base.renamed(renaming)
@@ -1094,7 +1355,7 @@ extension Scope {
   internal func columns(of projection: Projection,
                         _ routines: Routines = [:],
                         subquery: Resolution = .unsupported)
-      throws(SQLError) -> Array<OutputColumn> {
+      throws(SQLError) -> Array<ResolvedColumn> {
     return switch projection {
     case .all:
       outputs()
@@ -1111,33 +1372,41 @@ extension Scope {
 
   /// The output columns of a `SELECT *` over this scope — every real column of
   /// every relation, in chain order, named and typed from each relation's
-  /// schema (never a virtual column) — the terms `terms(.all)` projects.
-  internal func outputs() -> Array<OutputColumn> {
+  /// schema (never a virtual column) and carrying its source column's
+  /// `unconstrained` mask (an all-arms-NULL CTE column stays unconstrained
+  /// through a `*` expansion) — the terms `terms(.all)` projects.
+  internal func outputs() -> Array<ResolvedColumn> {
     schemas.flatMap { schema in
       (0 ..< schema.width).map {
-        OutputColumn(name: schema.names[$0], type: schema.types[$0])
+        ResolvedColumn(OutputColumn(name: schema.names[$0],
+                                    type: schema.types[$0]),
+                       unconstrained: schema.unconstrained[$0])
       }
     }
   }
 
-  /// The output column a bare `column` reference yields: its own name (its
-  /// spelling as written), typed from the relation that resolves it — or, for a
-  /// name no local relation binds, from the correlation `subquery` surface,
-  /// mirroring the expression path's `derive`. Under a LATERAL body's admitting
-  /// (`everywhere`) surface a preceding-FROM column types as its outer column;
-  /// under an ordinary barred surface it faults `.unsupported`. A genuinely
-  /// unknown name re-throws the `.column` fault.
+  /// The resolved output column a bare `column` reference yields — its own name
+  /// (its spelling as written), its type, AND its `unconstrained` mask, read
+  /// TOGETHER from ONE resolution so the two cannot diverge: from the relation
+  /// that LOCALLY resolves it (`resolved(_:)` — one `find`, both fields), or,
+  /// for a name no local relation binds, from the CORRELATION `subquery`
+  /// surface (`resolved(for:)` — carrying the outer column's mask, so a
+  /// correlated all-NULL column stays unconstrained), mirroring the expression
+  /// path's `derive`. Under a LATERAL body's admitting (`everywhere`) surface a
+  /// preceding-FROM column types as its outer column; under an ordinary barred
+  /// surface it faults `.unsupported`. A genuinely unknown name re-throws the
+  /// `.column` fault.
   internal func output(of column: Column,
                        subquery: Resolution = .unsupported)
-      throws(SQLError) -> OutputColumn {
-    if let ordinal = try find(column) {
-      return OutputColumn(name: column.name, type: type(at: ordinal))
+      throws(SQLError) -> ResolvedColumn {
+    if let resolved = try resolved(column) {
+      return resolved
     }
-    if let type = try subquery.correlated(column) {
-      return OutputColumn(name: column.name, type: type)
+    if let resolved = try subquery.correlated(column) {
+      return resolved
     }
-    return try OutputColumn(name: column.name,
-                            type: type(at: ordinal(of: column)))
+    let ordinal = try ordinal(of: column)
+    return resolved(at: ordinal, named: column.name)
   }
 
   /// The output column a projected `item` at 0-based `index` yields: its
@@ -1145,18 +1414,67 @@ extension Scope {
   /// name), else a positional `column N` (1-based). A bare column carries its
   /// source type and a literal its own; a scalar call its routine's declared
   /// return type; every other expression `.integer`.
+  ///
+  /// It also carries the `unconstrained` mask a set-operation fold reads — a
+  /// column that places NO type constraint (a NULL unifies with any typed arm,
+  /// exactly as `COALESCE` skips a constant-NULL argument). Three sources mark
+  /// it so, all read HERE from the same resolution as the type, never a
+  /// separate local-only walk: an expression that folds to a CONSTANT NULL for
+  /// every row (`null(_:)`); an expression that would dispatch an UNREGISTERED
+  /// routine at ANY depth (`unresolved(_:)` — `derive` fabricates the
+  /// `.integer` default for such a call, so the fold must defer rather than
+  /// fault on the placeholder); and a bare-column reference resolving to an
+  /// unconstrained source column (`output(of:)` — LOCAL or CORRELATED, so an
+  /// all-NULL column referenced through a LATERAL body keeps its mask).
   internal func output(_ item: Projected, at index: Int,
                        _ routines: Routines = [:],
                        subquery: Resolution = .unsupported)
-      throws(SQLError) -> OutputColumn {
+      throws(SQLError) -> ResolvedColumn {
     let name = item.name ?? "column \(index + 1)"
+    // A projection places NO type constraint on the unified column when it
+    // folds to a CONSTANT NULL for every row (`null` — its derived literal-fix
+    // type must not shape the fold) OR when it would dispatch an UNREGISTERED
+    // routine at ANY depth (`unresolved` — `derive` fabricates the `.integer`
+    // default for such a call, and the fold must not fault on that
+    // placeholder). Either way mark it UNCONSTRAINED and derive its type only
+    // for the column's advertised type, which the fold then ignores. A
+    // reachable missing call still faults `SQLError.function` at the run
+    // typecheck, so this defers only the FOLD, never hides the call.
+    if null(item.expression, routines)
+        || unresolved(item.expression, routines) {
+      let type = try derive(item.expression, routines, subquery: subquery)
+      return ResolvedColumn(OutputColumn(name: name, type: type),
+                            unconstrained: true)
+    }
+    // A bare-column projection reuses the ONE column resolution — LOCAL or
+    // CORRELATED — so its type and `unconstrained` mask agree, renaming only
+    // its output name when the item carries an alias.
+    if case let .column(column) = item.expression {
+      let resolved = try output(of: column, subquery: subquery)
+      return ResolvedColumn(OutputColumn(name: name, type: resolved.type),
+                            unconstrained: resolved.unconstrained)
+    }
+    // A bare scalar-subquery projection reuses the subquery's OWN resolved
+    // column — its type AND `unconstrained` mask — so a constant-NULL body
+    // (`(SELECT NULLIF('a','a'))`) stays unconstrained in an outer
+    // set-operation fold, mirroring the bare-column branch above. Only a bare
+    // `.subquery` qualifies: a subquery NESTED inside a larger expression
+    // legitimately constrains, so it falls through to the generic (constrained)
+    // else below.
+    if case let .subquery(query) = item.expression {
+      let resolved = try subquery.scalar(resolved: query)
+      return ResolvedColumn(OutputColumn(name: name, type: resolved.type),
+                            unconstrained: resolved.unconstrained)
+    }
     // DERIVE the nominal output type: the schema reports the type a run would
     // produce and never faults on an operand. Run-time operand and call
     // validation is `typecheck`'s job, reachability-aware, so a schema resolves
     // even for an expression a zero-row limit makes unreachable. A scalar
-    // subquery derives its single-column type from the `subquery` map.
-    return try OutputColumn(name: name,
-                            type: derive(item.expression, routines,
-                                         subquery: subquery))
+    // subquery derives its single-column type from the `subquery` map. Any
+    // other expression carries a genuine type, so it is constrained.
+    return try ResolvedColumn(OutputColumn(name: name,
+                                           type: derive(item.expression,
+                                                        routines,
+                                                        subquery: subquery)))
   }
 }

--- a/Sources/SQLEngine/RelationInstance.swift
+++ b/Sources/SQLEngine/RelationInstance.swift
@@ -153,6 +153,16 @@ internal struct RelationInstance: Hashable, Sendable {
   /// passes them so `information_schema` columns report their real types.
   internal let types: Array<ValueType>
 
+  /// Whether each real column places NO type constraint — every arm that fed it
+  /// projects a constant NULL, so its concrete `types` entry is a default the
+  /// set-operation fold must NOT constrain against. A later reader unifying a
+  /// reference to such a column treats it as an unconstrained (constant-NULL)
+  /// arm, exactly as `COALESCE` skips a constant-NULL argument, so an all-NULL
+  /// CTE column unifies with any typed arm regardless of arm order. Aligned
+  /// with `types` (one flag per real column); all-`false` for a store relation
+  /// or a derived table, whose columns carry genuine types.
+  internal let unconstrained: Array<Bool>
+
   /// The inner `Query` this binding is the materialised body of, when it is a
   /// DERIVED TABLE's — `nil` for a common table expression's or a store
   /// relation's binding. It is the derivation's IDENTITY, not merely a flag:
@@ -177,22 +187,28 @@ internal struct RelationInstance: Hashable, Sendable {
   internal var derived: Bool { derivation != nil }
 
   internal init(columns: Array<String>, rows: Array<Array<Value>>,
-                types: Array<ValueType>, derivation: Query? = nil) {
+                types: Array<ValueType>, unconstrained: Array<Bool>? = nil,
+                derivation: Query? = nil) {
     self.columns = columns
     self.rows = rows
     self.types = types
+    self.unconstrained =
+        unconstrained ?? Array(repeating: false, count: columns.count)
     self.derivation = derivation
   }
 
-  /// A relation whose columns are RESOLVED from a body — its names and types
-  /// taken TOGETHER from the `carrier`, so the two arrays cannot drift and a
-  /// future per-column attribute on `ResolvedColumn` threads through this ONE
-  /// constructor. `rows` are the captured (or empty, schema-only) rows and
-  /// `derivation` the inner `Query` for a derived table's binding.
+  /// A relation whose columns are RESOLVED from a body — its names, types, AND
+  /// per-column `unconstrained` mask taken TOGETHER from the `carrier`, so the
+  /// arrays cannot drift and the mask threads through this ONE constructor
+  /// rather than a per-site `unconstrained:` argument a binding could drop.
+  /// `rows` are the captured (or empty, schema-only) rows and `derivation` the
+  /// inner `Query` for a derived table's binding.
   internal init(from carrier: Array<ResolvedColumn>,
                 rows: Array<Array<Value>>, derivation: Query? = nil) {
     self.init(columns: carrier.map(\.name), rows: rows,
-              types: carrier.map(\.type), derivation: derivation)
+              types: carrier.map(\.type),
+              unconstrained: carrier.map(\.unconstrained),
+              derivation: derivation)
   }
 
   /// The real column count — the extent of a `SELECT *`.
@@ -206,7 +222,7 @@ internal struct RelationInstance: Hashable, Sendable {
   /// virtual `Id` at `width`.
   internal func schema() -> Schema {
     Schema(width: width, extent: extent, names: columns,
-           types: types, virtuals: ["Id"])
+           types: types, unconstrained: unconstrained, virtuals: ["Id"])
   }
 
   /// The record for the row at `index`, materialising the referenced `ordinals`

--- a/Sources/SQLEngine/Resolve.swift
+++ b/Sources/SQLEngine/Resolve.swift
@@ -333,9 +333,23 @@ internal final class Outer {
   /// `SQLError.ambiguous`, which propagates rather than falling through — so
   /// the schema-derive and the run's lowering AGREE on the ambiguity.
   internal func type(for column: Column) throws(SQLError) -> ValueType? {
+    try resolved(for: column).map(\.type)
+  }
+
+  /// The resolved enclosing column `column` names — its outer `type` AND
+  /// `unconstrained` mask read TOGETHER from the one ordinal a nearest-first
+  /// walk matches — or `nil` when no enclosing scope binds it. It walks
+  /// `scopes` NEAREST-first exactly as the type probe does (a nearer scope
+  /// shadows a farther one), records NO correlation (a pure probe), and lets an
+  /// ambiguous nearer scope's `SQLError.ambiguous` propagate. `type(for:)` and
+  /// any mask reader are THIN accessors over this, so a correlated column's
+  /// type and mask cannot diverge — the fix for a correlated all-NULL column
+  /// losing its mask through the LATERAL correlation surface.
+  internal func resolved(for column: Column) throws(SQLError)
+      -> ResolvedColumn? {
     for scope in scopes.reversed() {
       guard let ordinal = try scope.correlated(column) else { continue }
-      return scope.type(at: ordinal)
+      return scope.resolved(at: ordinal, named: column.name)
     }
     return nil
   }
@@ -419,6 +433,15 @@ internal final class SubqueryMemo {
   internal func record(plan: Plan, for key: PlanKey) {
     if plans[key] == nil { plans[key] = plan }
   }
+
+  /// The occurrence `Subkey`s whose reached correlated set-operation fold has
+  /// already been strictly re-validated — a reached scalar/`IN` occurrence
+  /// folds ONCE (faulting on an irreconcilable pair the first reached outer
+  /// row), then subsequent rows skip the redundant per-row re-fold.
+  private var validated: Set<Subkey> = []
+
+  internal func validated(_ key: Subkey) -> Bool { validated.contains(key) }
+  internal func validate(_ key: Subkey) { validated.insert(key) }
 }
 
 /// The COMPILE-time seam that lowers an `EXISTS`/`IN (Q)` predicate WITHOUT
@@ -451,12 +474,15 @@ internal struct Resolution {
   /// `IN (Q)` and a scalar subquery each require it be 1.
   private let widths: Dictionary<Query, Int>
 
-  /// Each nested `Query` mapped to its single-column output TYPE, derived
-  /// cursor-free in the compile pre-pass — the static type a scalar subquery
-  /// contributes (the executor coerces its collapsed value to it, as a `CASE`
-  /// coerces its arms). Only a width-1 query has one, so an `EXISTS`/`IN (Q)`
-  /// occurrence (whose type is irrelevant) may be absent.
-  private let types: Dictionary<Query, ValueType>
+  /// Each nested `Query` mapped to its single-column output COLUMN, derived
+  /// cursor-free in the compile pre-pass — the resolved column a scalar
+  /// subquery contributes, its TYPE (the executor coerces its collapsed value
+  /// to it, as a `CASE` coerces its arms) AND its `unconstrained` mask
+  /// TOGETHER, so a bare scalar-subquery projection over a constant-NULL body
+  /// carries that mask into an outer set-operation fold rather than dropping
+  /// it. Only a width-1 query has one, so an `EXISTS`/`IN (Q)` occurrence
+  /// (whose type is irrelevant) may be absent.
+  private let types: Dictionary<Query, ResolvedColumn>
 
   /// Each nested `Query` mapped to its CORRELATION — the synthetic bound params
   /// its inner `WHERE`/`ON` names of an enclosing column, discovered by the
@@ -494,7 +520,7 @@ internal struct Resolution {
 
   internal init(_ scope: Subscope = .caller,
                 _ widths: Dictionary<Query, Int> = [:],
-                _ types: Dictionary<Query, ValueType> = [:],
+                _ types: Dictionary<Query, ResolvedColumn> = [:],
                 _ correlations: Dictionary<Query, Correlation> = [:],
                 outer: Outer? = nil, admits: Bool = true,
                 everywhere: Bool = false) {
@@ -550,19 +576,27 @@ internal struct Resolution {
     return name
   }
 
-  /// The outer type a correlated reference to `column` contributes to a SCHEMA
-  /// derive, or `nil` when no enclosing scope binds it — the non-recording,
-  /// non-faulting type probe `derive` reads so a correlated column types as its
-  /// outer column rather than faulting `SQLError.column`. A BARRED surface
-  /// still diagnoses it, so this schema surface and the run's lowering AGREE.
-  internal func correlated(_ column: Column) throws(SQLError) -> ValueType? {
-    guard let type = try outer?.type(for: column) else { return nil }
+  /// The resolved outer column a correlated reference to `column` contributes
+  /// to a SCHEMA derive — its `type` AND `unconstrained` mask TOGETHER — or
+  /// `nil` when no enclosing scope binds it. Every type/mask reader is a THIN
+  /// accessor over this ONE resolver, so a correlated column's type and mask
+  /// cannot diverge (the fix for a correlated all-NULL column losing its mask
+  /// through the LATERAL surface).
+  ///
+  /// A BARRED surface (a projection / `GROUP BY` / `HAVING` of an ORDINARY
+  /// subquery) still DIAGNOSES a bound name `SQLError.unsupported` — the SAME
+  /// fault the run's lowering raises, keeping typecheck↔run parity — so this
+  /// widens nothing: a lateral body's projection (`everywhere`) admits it,
+  /// while an ordinary subquery's projection faults exactly as before.
+  internal func correlated(_ column: Column) throws(SQLError)
+      -> ResolvedColumn? {
+    guard let resolved = try outer?.resolved(for: column) else { return nil }
     guard admits else {
       throw .state("0A000",
                    "a correlated column is only supported in a subquery's " +
                    "WHERE")
     }
-    return type
+    return resolved
   }
 
   /// The correlation of the nested `query` — its synthetic outer bindings —
@@ -580,22 +614,38 @@ internal struct Resolution {
     return width
   }
 
-  /// The single-column output type `query` contributes as a scalar subquery.
-  /// The compile pre-pass records it beside the width for every subquery, so a
-  /// scalar occurrence reads it; a surface with no catalog holds none and
-  /// faults, rejecting the subquery rather than mis-typing it.
-  private func output(_ query: Query) throws(SQLError) -> ValueType {
-    guard let type = types[query] else {
+  /// The single-column output COLUMN `query` contributes as a scalar subquery —
+  /// its type AND `unconstrained` mask together. The compile pre-pass records
+  /// it beside the width for every subquery, so a scalar occurrence reads it; a
+  /// surface with no catalog holds none and faults, rejecting the subquery
+  /// rather than mis-typing it.
+  private func output(_ query: Query) throws(SQLError) -> ResolvedColumn {
+    guard let resolved = types[query] else {
       throw .state("0A000", "a subquery is not supported in this position")
     }
-    return type
+    return resolved
   }
 
   /// The static single-column type a scalar subquery `query` contributes to a
   /// SCHEMA derive — its single-column arity enforced first (else
   /// `SQLError.arity`, matching the lowering), so this schema surface and the
-  /// run's lowering AGREE on both the arity fault and the type.
+  /// run's lowering AGREE on both the arity fault and the type. This is the
+  /// bare-`ValueType` path the run's `Term.subquery` lowering reads; the outer
+  /// set-operation fold reads the whole column through `scalar(resolved:)`.
   internal func scalar(type query: Query) throws(SQLError) -> ValueType {
+    let width = try width(query)
+    guard width == 1 else { throw .arity(1, width) }
+    return try output(query).type
+  }
+
+  /// The single-column resolved COLUMN a scalar subquery `query` contributes to
+  /// a SCHEMA derive — its type AND `unconstrained` mask together, the arity
+  /// guard first (else `SQLError.arity`, exactly as `scalar(type:)`). A bare
+  /// scalar-subquery PROJECTION reads this so a constant-NULL body's mask
+  /// travels into an outer set-operation fold rather than being dropped by the
+  /// bare-type path.
+  internal func scalar(resolved query: Query)
+      throws(SQLError) -> ResolvedColumn {
     let width = try width(query)
     guard width == 1 else { throw .arity(1, width) }
     return try output(query)
@@ -657,7 +707,7 @@ internal struct Resolution {
     guard width == 1 else { throw .arity(1, width) }
     return try .subquery(Subkey(scope, query, .scalar),
                          correlation: correlation(of: query),
-                         type: output(query))
+                         type: output(query).type)
   }
 }
 
@@ -790,6 +840,15 @@ internal struct Subqueries {
     memo.record(plan: plan, for: PlanKey(key, correlation))
   }
 
+  /// Whether the reached correlated set-operation fold of occurrence `key` has
+  /// already been strictly re-validated — so a per-row execution folds ONCE and
+  /// skips the redundant re-fold on subsequent outer rows.
+  internal func validated(_ key: Subkey) -> Bool { memo.validated(key) }
+
+  /// Records that occurrence `key`'s reached set-operation fold has been
+  /// strictly re-validated.
+  internal func validate(_ key: Subkey) { memo.validate(key) }
+
   /// This cache — the memo is a shared box the whole run accretes into, so a
   /// caller cache and a view-body cache share one box, their disjoint
   /// `Subscope` keys never colliding. The prior eager merge collapses to
@@ -883,9 +942,12 @@ internal struct SubqueryCheck {
   /// subquery's single-column arity.
   private let widths: Dictionary<Query, Int>
 
-  /// Each nested `Query` mapped to its single-column output TYPE, derived by
-  /// the `typecheck` pre-pass — the type a scalar subquery reports to the
-  /// result schema (`validate`/`derive`), matching the lowering's `Resolution`.
+  /// Each nested `Query` mapped to its single-column output COLUMN, derived by
+  /// the `typecheck` pre-pass — the type AND `unconstrained` mask a scalar
+  /// subquery reports to the result schema (`validate`/`derive`), matching the
+  /// lowering's `Resolution`. The mask lets a bare scalar-subquery projection
+  /// over a constant-NULL body stay unconstrained in an outer set-operation
+  /// fold.
   private let types: Dictionary<Query, ValueType>
 
   /// The scalar inner queries whose OPERAND validation is DEFERRED through the
@@ -1715,6 +1777,22 @@ internal struct Scope {
     return .integer
   }
 
+  /// Whether the real column at combined `ordinal` is UNCONSTRAINED — an
+  /// all-arms-NULL CTE column that places no type constraint, so a bare
+  /// reference to it in a set-operation arm unifies with any typed arm order-
+  /// independently (`RelationInstance.unconstrained`). A virtual ordinal
+  /// (`Id`, a foreign key) or an out-of-range one carries a genuine type and is
+  /// constrained, so it reports `false` — mirroring `type(at:)`'s dispatch.
+  internal func unconstrained(at ordinal: Int) -> Bool {
+    for member in members {
+      let local = ordinal - member.offset
+      guard local >= 0, local < member.schema.extent else { continue }
+      return local < member.schema.width
+          && member.schema.unconstrained[local]
+    }
+    return false
+  }
+
   /// The value type of a `literal` operand — the domain of the value it stands
   /// for. Shared by both the schema and type-check surfaces.
   private func type(of literal: Literal) -> ValueType {
@@ -1752,8 +1830,8 @@ internal struct Scope {
       // error `find` propagates, never a fall-through to outer correlation.
       if let ordinal = try find(column) {
         type(at: ordinal)
-      } else if let type = try subquery.correlated(column) {
-        type
+      } else if let resolved = try subquery.correlated(column) {
+        resolved.type
       } else {
         try type(at: ordinal(of: column))
       }
@@ -2771,6 +2849,103 @@ internal struct Scope {
     }
   }
 
+  /// Whether `expression` folds to a CONSTANT NULL for EVERY row — a projected
+  /// column that places NO type constraint on a set-operation's unified column,
+  /// so the fold skips its (literal-fix) type exactly as `COALESCE` skips a
+  /// constant-NULL argument. The projection walk (`output(_ item:)`) reads this
+  /// beside its type derive, so a column's type and its `unconstrained` mask
+  /// come from ONE resolution over the SAME expression and cannot diverge.
+  internal func null(_ expression: Expression, _ routines: Routines) -> Bool {
+    if case .some(.null) = constant(expression, routines) { return true }
+    return false
+  }
+
+  /// Whether evaluating `expression` would dispatch an INVALID routine call —
+  /// the tree contains, at ANY depth, a `.call(name, _)` that is UNREGISTERED
+  /// (`routines[name] == nil`) or INVALID for its routine (bad arity or a
+  /// definitively-wrong argument type). Such a call has no genuine return type
+  /// (`derive` fabricates the declared `returns`, or the `.integer` default for
+  /// a missing name), yet the run faults on it (`SQLError.function` for the
+  /// missing name, `SQLError.argument` for the bad arity/type), so a projection
+  /// over it places NO type constraint on a set-operation's unified column:
+  /// mark it UNCONSTRAINED and let the fold defer to the other arm rather than
+  /// fault on the fabricated type. This is SOUND either way — if the arm is
+  /// REACHED the run dispatches it and faults, and if it is NOT reached (a
+  /// zero-row limit, a filtered-out arm) the expression is never evaluated, so
+  /// its fabricated type is irrelevant. Only an invalid call trips it, so a
+  /// VALID call (correct arity and argument types) stays constrained — its
+  /// declared `returns` still shapes the fold — and a genuine type mismatch
+  /// still faults `SQLError.operand` (42804).
+  ///
+  /// It MIRRORS `derive`'s expression arms exactly so no form escapes: a bare
+  /// call is the depth-0 case of the `.call` arm, and every composite arm
+  /// recurses the same sub-expressions `derive` traverses.
+  internal func unresolved(_ expression: Expression,
+                           _ routines: Routines) -> Bool {
+    switch expression {
+    // `.column`/`.literal`: no call, so never unresolved — mirroring
+    // `derive`'s leaf arms, which fabricate no routine type.
+    case .column, .literal:
+      return false
+    // `.call`: the depth-0 case (an unregistered name), OR an unregistered
+    // call nested in an argument — subsuming the former bare-call special case
+    // in `output(_ item:)`. An INVALID call to an EXISTING routine (bad arity
+    // or a definitively-wrong argument type) is treated like a MISSING one:
+    // `derive` fabricates the declared `returns` for it, but the run faults
+    // (`SQLError.argument`), so its type must not constrain the fold. This
+    // mirrors the strict validator `call(_:over:_:)`'s arity/type guards as a
+    // NON-throwing probe.
+    case let .call(name, arguments):
+      guard let routine = routines[name] else { return true }
+      guard (routine.minimum ... routine.parameters.count)
+          .contains(arguments.count) else { return true }
+      if arguments.contains(where: { unresolved($0, routines) }) { return true }
+      for (argument, expected) in zip(arguments, routine.parameters) {
+        guard let type = try? derive(argument, routines) else { return true }
+        if type != expected { return true }
+      }
+      return false
+    // `.binary` (arithmetic AND `||`): both derive arms derive both operands.
+    case let .binary(_, lhs, rhs):
+      return unresolved(lhs, routines) || unresolved(rhs, routines)
+    // `.aggregate`: `derive` recurses only the operand (a `.star` counts
+    // rows, deriving nothing); the `filter` is a `Predicate`, not shaping the
+    // derived type.
+    case let .aggregate(_, operand, _, _):
+      switch operand {
+      case .star: return false
+      case let .expression(argument): return unresolved(argument, routines)
+      }
+    // `.case`: `derive` unifies only the REACHABLE result expressions
+    // (`reachable`), so mirror that reach — an unregistered call in an
+    // unreachable branch never runs and never shapes the type.
+    case let .case(whens, otherwise):
+      return reachable(whens, otherwise, routines)
+          .contains { unresolved($0, routines) }
+    // `.cast`: `derive` recurses the operand for its resolution.
+    case let .cast(operand, _):
+      return unresolved(operand, routines)
+    // `.coalesce`: `derive` (`unified`) scans only the REACHABLE prefix — it
+    // STOPS at the first argument a constant non-NULL value `selects`, so a
+    // later argument never runs nor shapes the type. Mirror that reach, else
+    // `COALESCE(1, missing())` wrongly defers instead of constraining `1`.
+    case let .coalesce(arguments):
+      for argument in arguments {
+        if unresolved(argument, routines) { return true }
+        if selects(argument, routines) { break }
+      }
+      return false
+    // `.nullif`: `derive` (`nullif`) derives both operands.
+    case let .nullif(lhs, rhs):
+      return unresolved(lhs, routines) || unresolved(rhs, routines)
+    // `.subquery`: a nested scalar subquery resolves its OWN columns through
+    // the memo (`scalar(resolved:)`), which already carries the unconstrained
+    // mask for any unregistered call inside it — do NOT double-handle it here.
+    case .subquery:
+      return false
+    }
+  }
+
   /// The constant `Value`s a ROW `row` folds to when EVERY component is
   /// row-independent — else `nil` (any component a row/group/run decides). A
   /// row comparison and a row `IN` element fold through this so a single row-
@@ -3618,6 +3793,33 @@ internal struct Scope {
       if shadows(column) { throw error }
       return nil
     }
+  }
+
+  /// The resolved column a bare `column` LOCALLY names — carrying its output
+  /// name, its `type(at:)` type, and its `unconstrained(at:)` mask TOGETHER
+  /// from ONE `find` — or `nil` when this scope binds it in none of its
+  /// relations (the reference is a candidate correlated one).
+  ///
+  /// INVARIANT: a column reference's type and mask (and any future per-column
+  /// attribute) are obtained from ONE resolution that traverses the SAME paths
+  /// — local (here), correlation (`Outer.resolved(for:)`), schema — so the two
+  /// attributes cannot diverge. The mask reader once consulted a DIFFERENT
+  /// (local-only) path than the type reader, so a correlated all-NULL column
+  /// lost its mask; folding both through the single ordinal closes that gap.
+  internal func resolved(_ column: Column) throws(SQLError) -> ResolvedColumn? {
+    guard let ordinal = try find(column) else { return nil }
+    return ResolvedColumn(name: column.name, type: type(at: ordinal),
+                          unconstrained: unconstrained(at: ordinal))
+  }
+
+  /// The resolved column at combined `ordinal`, named `name` — its `type(at:)`
+  /// type and `unconstrained(at:)` mask read TOGETHER, so an enclosing
+  /// correlation walk (`Outer.resolved(for:)`) carries both up from the one
+  /// ordinal it matched.
+  internal func resolved(at ordinal: Int, named name: String)
+      -> ResolvedColumn {
+    ResolvedColumn(name: name, type: type(at: ordinal),
+                   unconstrained: unconstrained(at: ordinal))
   }
 
   /// The combined-ordinal projected terms: every real column of every relation

--- a/Sources/SQLEngine/Schema.swift
+++ b/Sources/SQLEngine/Schema.swift
@@ -30,30 +30,44 @@ internal struct Schema {
   /// `Engine.outputSchema`); the engine never compares or orders on it.
   internal let types: Array<ValueType>
 
+  /// Whether each real column at its ordinal `0 ..< width` places NO type
+  /// constraint — an all-arms-NULL CTE column whose concrete `types` entry is a
+  /// default the set-operation fold must NOT constrain against, so a reference
+  /// to it unifies with any typed arm order-independently. Aligned with `types`
+  /// (`unconstrained.count == width`); all-`false` for a base table, a view, or
+  /// any relation whose columns carry genuine types.
+  internal let unconstrained: Array<Bool>
+
   /// The virtual column names at their ordinals `width ..< extent` — virtual
   /// `i` sits at ordinal `width + i`. A view supplies none.
   internal let virtuals: Array<String>
 
   internal init(width: Int, extent: Int, names: Array<String>,
-                types: Array<ValueType>, virtuals: Array<String>) {
+                types: Array<ValueType>, unconstrained: Array<Bool>? = nil,
+                virtuals: Array<String>) {
     self.width = width
     self.extent = extent
     self.names = names
     self.types = types
+    self.unconstrained =
+        unconstrained ?? Array(repeating: false, count: width)
     self.virtuals = virtuals
   }
 
-  /// A view's resolution schema, its per-column types RESOLVED from a body
-  /// `carrier` while its `names` stay the view's DECLARED ones (a view stores
-  /// its own column names; only the types come from the resolved body). The
-  /// declared surface's `extent`/`virtuals` carry over unchanged. Taking the
-  /// types from the carrier as a whole means a future per-column attribute on
-  /// `ResolvedColumn` threads through this ONE constructor rather than a loose
-  /// `types.map` at the site.
+  /// A view's resolution schema, its per-column types AND `unconstrained` mask
+  /// RESOLVED from a body `carrier` while its `names` stay the view's DECLARED
+  /// ones (a view stores its own column names; only the types and mask come
+  /// from the resolved body). The declared surface's `extent`/`virtuals` carry
+  /// over unchanged. Taking the types and mask from the carrier as a whole
+  /// threads the per-column `unconstrained` through this ONE constructor rather
+  /// than a loose `types.map` at the site, so an all-NULL view column unifies
+  /// with any later typed set-operation arm.
   internal init(from carrier: Array<ResolvedColumn>, names: Array<String>,
                 extent: Int, virtuals: Array<String>) {
     self.init(width: names.count, extent: extent, names: names,
-              types: carrier.map(\.type), virtuals: virtuals)
+              types: carrier.map(\.type),
+              unconstrained: carrier.map(\.unconstrained),
+              virtuals: virtuals)
   }
 
   /// This schema with its real column `names` positionally RENAMED to
@@ -79,7 +93,8 @@ internal struct Schema {
       throw .duplicate(column)
     }
     return Schema(width: width, extent: extent, names: columns,
-                  types: types, virtuals: virtuals)
+                  types: types, unconstrained: unconstrained,
+                  virtuals: virtuals)
   }
 
   /// The ordinal of the column named `name`, or `nil` if absent.

--- a/Tests/SQLTests/Expressions/LikeTests.swift
+++ b/Tests/SQLTests/Expressions/LikeTests.swift
@@ -253,7 +253,7 @@ private func seeks(_ plan: Plan) -> Bool {
   case let .outer(left, right, _, _): seeks(left) || seeks(right)
   case let .semijoin(left, right, _, _): seeks(left) || seeks(right)
   case let .apply(left, _, _, _, _, _): seeks(left)
-  case let .setop(_, left, right, _): seeks(left) || seeks(right)
+  case let .setop(_, left, right, _, _, _): seeks(left) || seeks(right)
   case .single: false
   }
 }
@@ -274,7 +274,7 @@ private func joins(_ plan: Plan) -> Bool {
   case let .outer(left, right, _, _): joins(left) || joins(right)
   case let .semijoin(left, right, _, _): joins(left) || joins(right)
   case let .apply(left, _, _, _, _, _): joins(left)
-  case let .setop(_, left, right, _): joins(left) || joins(right)
+  case let .setop(_, left, right, _, _, _): joins(left) || joins(right)
   case .single, .scan: false
   }
 }
@@ -297,7 +297,7 @@ private func residual(_ plan: Plan) -> Bool {
   case let .outer(left, right, _, _): residual(left) || residual(right)
   case let .semijoin(left, right, _, _): residual(left) || residual(right)
   case let .apply(left, _, _, _, _, _): residual(left)
-  case let .setop(_, left, right, _): residual(left) || residual(right)
+  case let .setop(_, left, right, _, _, _): residual(left) || residual(right)
   case .single, .scan: false
   }
 }

--- a/Tests/SQLTests/Optimisation/ConstantFoldTests.swift
+++ b/Tests/SQLTests/Optimisation/ConstantFoldTests.swift
@@ -76,7 +76,7 @@ private func selects(_ plan: Plan) -> Bool {
     selects(source)
   case let .apply(left, _, _, _, _, _):
     selects(left)
-  case let .setop(_, left, right, _):
+  case let .setop(_, left, right, _, _, _):
     selects(left) || selects(right)
   case .single, .scan:
     false

--- a/Tests/SQLTests/Optimisation/DecorrelateTests.swift
+++ b/Tests/SQLTests/Optimisation/DecorrelateTests.swift
@@ -27,7 +27,7 @@ private func applies(_ plan: Plan) -> Bool {
        let .aggregate(_, _, source):
     return applies(source)
   case let .product(left, right), let .outer(left, right, _, _),
-       let .semijoin(left, right, _, _), let .setop(_, left, right, _):
+       let .semijoin(left, right, _, _), let .setop(_, left, right, _, _, _):
     return applies(left) || applies(right)
   case .single, .scan, .join:
     return false
@@ -47,7 +47,7 @@ private func joins(_ plan: Plan) -> Bool {
        let .aggregate(_, _, source):
     return joins(source)
   case let .product(left, right), let .outer(left, right, _, _),
-       let .semijoin(left, right, _, _), let .setop(_, left, right, _):
+       let .semijoin(left, right, _, _), let .setop(_, left, right, _, _, _):
     return joins(left) || joins(right)
   case .single, .scan, .apply:
     return false
@@ -67,7 +67,7 @@ private func outers(_ plan: Plan) -> Bool {
        let .aggregate(_, _, source):
     return outers(source)
   case let .product(left, right), let .semijoin(left, right, _, _),
-       let .setop(_, left, right, _):
+       let .setop(_, left, right, _, _, _):
     return outers(left) || outers(right)
   case .single, .scan, .join, .apply:
     return false
@@ -89,7 +89,7 @@ private func semijoins(_ plan: Plan) -> Bool {
        let .aggregate(_, _, source):
     return semijoins(source)
   case let .product(left, right), let .outer(left, right, _, _),
-       let .setop(_, left, right, _):
+       let .setop(_, left, right, _, _, _):
     return semijoins(left) || semijoins(right)
   case .single, .scan, .join, .apply:
     return false
@@ -109,7 +109,7 @@ private func semijoins(_ plan: Plan, anti wanted: Bool) -> Bool {
        let .aggregate(_, _, source):
     return semijoins(source, anti: wanted)
   case let .product(left, right), let .outer(left, right, _, _),
-       let .setop(_, left, right, _):
+       let .setop(_, left, right, _, _, _):
     return semijoins(left, anti: wanted) || semijoins(right, anti: wanted)
   case .single, .scan, .join, .apply:
     return false
@@ -130,7 +130,7 @@ private func semijoinCount(_ plan: Plan) -> Int {
        let .aggregate(_, _, source):
     return semijoinCount(source)
   case let .product(left, right), let .outer(left, right, _, _),
-       let .setop(_, left, right, _):
+       let .setop(_, left, right, _, _, _):
     return semijoinCount(left) + semijoinCount(right)
   case .single, .scan, .join, .apply:
     return 0
@@ -154,7 +154,7 @@ private func semijoinCount(_ plan: Plan, anti wanted: Bool) -> Int {
        let .aggregate(_, _, source):
     return semijoinCount(source, anti: wanted)
   case let .product(left, right), let .outer(left, right, _, _),
-       let .setop(_, left, right, _):
+       let .setop(_, left, right, _, _, _):
     return semijoinCount(left, anti: wanted)
         + semijoinCount(right, anti: wanted)
   case .single, .scan, .join, .apply:
@@ -175,7 +175,7 @@ private func exists(in plan: Plan) -> Bool {
        let .aggregate(_, _, source):
     return exists(in: source)
   case let .product(left, right), let .outer(left, right, _, _),
-       let .semijoin(left, right, _, _), let .setop(_, left, right, _):
+       let .semijoin(left, right, _, _), let .setop(_, left, right, _, _, _):
     return exists(in: left) || exists(in: right)
   case .single, .scan, .join, .apply:
     return false
@@ -211,7 +211,7 @@ private func within(in plan: Plan) -> Bool {
        let .aggregate(_, _, source):
     return within(in: source)
   case let .product(left, right), let .outer(left, right, _, _),
-       let .semijoin(left, right, _, _), let .setop(_, left, right, _):
+       let .semijoin(left, right, _, _), let .setop(_, left, right, _, _, _):
     return within(in: left) || within(in: right)
   case .single, .scan, .join, .apply:
     return false
@@ -250,7 +250,7 @@ private func subquery(in plan: Plan) -> Bool {
        let .aggregate(_, _, source):
     return subquery(in: source)
   case let .product(left, right), let .outer(left, right, _, _),
-       let .semijoin(left, right, _, _), let .setop(_, left, right, _):
+       let .semijoin(left, right, _, _), let .setop(_, left, right, _, _, _):
     return subquery(in: left) || subquery(in: right)
   case .single, .scan, .join, .apply:
     return false

--- a/Tests/SQLTests/Queries/DerivedTableTests.swift
+++ b/Tests/SQLTests/Queries/DerivedTableTests.swift
@@ -2355,3 +2355,53 @@ struct DerivedTableLenientOutputTests {
     }
   }
 }
+
+// MARK: - All-NULL derived column unification
+
+/// A derived table that projects a constant-NULL column places NO type
+/// constraint on it, exactly as a bare constant-NULL set-operation arm does.
+/// `materialise` carries the fold's per-column unconstrained marker through the
+/// derived-table binding (and through an `AS d(a)` rename), so a transparent
+/// `(SELECT NULLIF('a','a') AS x) AS d` wrapper unifies with a later typed arm
+/// ORDER-INDEPENDENTLY rather than folding as its literal-fix type and
+/// faulting.
+struct DerivedTableNullUnificationTests {
+  @Test func `an all-NULL derived column unifies with an integer arm`()
+      throws {
+    // `x` is a constant NULL, so the enclosing UNION must treat it as
+    // unconstrained and unify it with the `1` arm — the reviewer's case, which
+    // faulted before the marker survived the derived-table binding.
+    try fixture().expect(
+        "SELECT x FROM (SELECT NULLIF('a', 'a') AS x) AS d UNION SELECT 1",
+        yields: [[nil], [1]])
+  }
+
+  @Test func `an all-NULL derived column unifies regardless of arm order`()
+      throws {
+    // The order-independence case: the integer arm leads. Without the marker
+    // the derived column would fold as its literal-fix type and fault; the
+    // marker unifies it either way.
+    try fixture().expect(
+        "SELECT 1 AS n UNION SELECT x FROM (SELECT NULLIF('a', 'a') AS x) AS d",
+        yields: [[1], [nil]])
+  }
+
+  @Test func `an all-NULL derived column unifies through an AS d(a) rename`()
+      throws {
+    // The crux: the unconstrained marker must survive the positional
+    // column-list rename, so `d(a)` over a constant-NULL body still unifies
+    // with the `1` arm rather than taking a concrete literal-fix type.
+    try fixture().expect(
+        "SELECT a FROM (SELECT NULLIF('a', 'a') AS x) AS d(a) UNION SELECT 1",
+        yields: [[nil], [1]])
+  }
+
+  @Test func `a concrete derived column still types normally`() throws {
+    // The regression guard: a genuinely text derived column must NOT be
+    // over-marked as unconstrained, so a UNION with an integer arm still faults
+    // on the irreconcilable text/integer pair.
+    try fixture().expect(
+        "SELECT x FROM (SELECT 'a' AS x) AS d UNION SELECT 1",
+        fails: .operand("UNION arms have irreconcilable types"))
+  }
+}

--- a/Tests/SQLTests/Queries/EngineJoinTests.swift
+++ b/Tests/SQLTests/Queries/EngineJoinTests.swift
@@ -748,7 +748,7 @@ private func outers(_ plan: Plan) -> Bool {
     outers(left) || outers(right)
   case let .apply(left, _, _, _, _, _):
     outers(left)
-  case let .setop(_, left, right, _):
+  case let .setop(_, left, right, _, _, _):
     outers(left) || outers(right)
   case let .aggregate(_, _, source):
     outers(source)

--- a/Tests/SQLTests/Queries/EngineValueAndSetTests.swift
+++ b/Tests/SQLTests/Queries/EngineValueAndSetTests.swift
@@ -271,6 +271,56 @@ struct EngineUnionTests {
     #expect(rows == [[.text("a")], [.text("shared")], [.text("b")]])
   }
 
+  @Test func `an all-NULL view column unifies with a later text arm`() throws {
+    // The reviewer's VIEW all-NULL case. The view `v`'s column `x` is a constant
+    // NULL in BOTH arms, so its resolved schema marks the column UNCONSTRAINED:
+    // an enclosing `SELECT x FROM v UNION SELECT 'c'` must unify the view column
+    // with the text `'c'` arm and RUN — yielding the NULL and the text — rather
+    // than fault integer against text. The view's schema resolution builds its
+    // Schema from the body carrier through `Schema(from:)`, so the `Scope`
+    // reader reports the column unconstrained and the outer fold skips its type,
+    // exactly as it skips a fresh constant-NULL arm.
+    let view = try View(query: engineSelect("""
+        SELECT NULLIF(1, 1) AS x UNION SELECT NULLIF('b', 'b')
+        """), columns: ["x"])
+    let catalog = EngineMemory(engineTags().catalog, views: ["V": view])
+    let rows = try catalog.run(engineParse("SELECT x FROM V UNION SELECT 'c'"))
+    #expect(rows == [[.null], [.text("c")]])
+  }
+
+  @Test func `a predicate over a widened UNION view column tests the coerced type`() throws {
+    // The reviewer's precision oracle. The view `V(x)` is `SELECT x FROM A
+    // UNION ALL SELECT x FROM B`, where `A.x` is the integer 9007199254740993
+    // and `B.x` is the double 9007199254740992.0. The set operation WIDENS `x`
+    // to `double` (an integer arm beside a double arm), so `combine` coerces
+    // the integer arm's row to double — and 9007199254740993 is NOT
+    // representable as a double, rounding to 9007199254740992.0. An outer
+    // `SELECT x FROM V WHERE x = 9007199254740992` must test the COERCED value:
+    // the integer arm's row becomes 9007199254740992.0, which `== 9007..92`, so
+    // BOTH rows survive. Were the predicate pushed PER ARM below the widening
+    // set operation, the integer arm would test 9007199254740993 == ..92
+    // exactly (the pre-coercion value) and DROP its row, yielding one — the
+    // unsound behaviour the `widened` gate now prevents by keeping the
+    // predicate above the arms, on the coerced output.
+    let integers = [EngineField(name: "x", type: .integer)]
+    let doubles = [EngineField(name: "x", type: .double)]
+    let a = [[Value.integer(9007199254740993)]]
+    let b = [[Value.double(9007199254740992.0)]]
+    let base = EngineMemory([
+      "A": FixtureRelation(integers, a),
+      "B": FixtureRelation(doubles, b),
+    ])
+    let view = try View(query: engineSelect("""
+        SELECT x FROM A UNION ALL SELECT x FROM B
+        """), columns: ["x"])
+    let memory = EngineMemory(base.catalog, views: ["V": view])
+    let rows = try memory.run(engineParse("""
+        SELECT x FROM V WHERE x = 9007199254740992
+        """))
+    #expect(rows == [[.double(9007199254740992.0)],
+                     [.double(9007199254740992.0)]])
+  }
+
   @Test func `a bound parameter threads into every arm of a UNION`() throws {
     // Both arms key on the same `:pid`; the binding reaches each alike, so the
     // union is the parent's children drawn from two queries over the relation.
@@ -762,5 +812,733 @@ struct EngineScalarSelectTests {
     // exactly as before.
     try enginePeople().expect("SELECT Name FROM People WHERE Id = 1",
                         yields: [["Alice"]])
+  }
+}
+
+// MARK: - ISO set-operation type unification and value coercion tests
+
+/// Parses `text` to a statement and runs it against `catalog` — for the `WITH`
+/// shapes the query-only `run` overload will not take.
+private func statement<C: Catalog & ~Escapable>(_ text: String,
+                                                _ catalog: borrowing C)
+    throws -> Array<Array<Value>> {
+  try catalog.run(Statement(parsing: text))
+}
+
+/// The ISO rule that a set operation's result column TYPE is the common type
+/// across ALL arms — not the first arm's — and each arm's values are COERCED to
+/// it: a mixed `integer`/`double` column widens to `double` and its integer
+/// values promote, an irreconcilable pair faults, and a constant-NULL arm
+/// constrains nothing. Homogeneous set operations are unchanged
+/// (byte-identical).
+struct EngineSetOperationCoercionTests {
+  @Test func `UNION widens a mixed integer/double column and coerces its values`() throws {
+    // The unified column type is `double`, so the `integer` arm's `1` coerces
+    // to `1.0` and the result column is `double` throughout.
+    try enginePeople().expect("SELECT 1 UNION SELECT 2.5",
+                              yields: [[1.0], [2.5]])
+    try enginePeople().expect("SELECT 1 UNION ALL SELECT 2.5",
+                              yields: [[1.0], [2.5]])
+  }
+
+  @Test func `UNION dedups numerically-equal rows to the coerced double`() throws {
+    // `1` coerces to `1.0`, equal to the double arm's `1.0`, so the bare UNION
+    // keeps one — the emitted `double`.
+    try enginePeople().expect("SELECT 1 UNION SELECT 1.0", yields: [[1.0]])
+  }
+
+  @Test func `INTERSECT and EXCEPT emit the coerced double`() throws {
+    // Equality already canonicalises `1` and `1.0`, so both match/subtract; the
+    // coercion makes the EMITTED cell carry the unified `double` type.
+    try enginePeople().expect("SELECT 1 INTERSECT SELECT 1.0", yields: [[1.0]])
+    try enginePeople().expect("SELECT 2 EXCEPT SELECT 1.0", yields: [[2.0]])
+  }
+
+  @Test func `a UNION of irreconcilable column types faults`() throws {
+    // A text arm beside a number, or a boolean beside a number, has no common
+    // type — the fold faults `SQLError.operand` (SQLSTATE 42804).
+    try enginePeople().expect(
+        "SELECT 1 UNION SELECT 'x'",
+        fails: .operand("UNION arms have irreconcilable types"))
+    try enginePeople().expect(
+        "SELECT TRUE UNION SELECT 1",
+        fails: .operand("UNION arms have irreconcilable types"))
+  }
+
+  @Test func `a nested-arm UNION arity mismatch faults not traps`() throws {
+    // The outer widths match (both 2), so the outer check passes; the fold
+    // then descends into the left child `SELECT 1, 2 UNION SELECT 3` whose
+    // arms differ (2 vs 1) — the fold's own guard faults `.arity` rather than
+    // trapping on an out-of-bounds column index.
+    try enginePeople().expect("SELECT 1, 2 UNION SELECT 3 UNION SELECT 4, 5",
+                              fails: .arity(2, 1))
+  }
+
+  @Test func `a chained 3-arm UNION widens across every arm`() throws {
+    // The left-associative chain folds pairwise, so the trailing `double`
+    // widens the whole column and every value coerces.
+    try enginePeople().expect("SELECT 1 UNION SELECT 2 UNION SELECT 3.5",
+                              yields: [[1.0], [2.0], [3.5]])
+  }
+
+  @Test func `a chained UNION with an incompatible tail faults`() throws {
+    try enginePeople().expect(
+        "SELECT 1 UNION SELECT 2 UNION SELECT 'x'",
+        fails: .operand("UNION arms have irreconcilable types"))
+  }
+
+  @Test func `a UNION nested in a subquery carries its coerced types`() throws {
+    // The derived table runs through the `.setop` Plan node, whose carried
+    // `types` (computed at compile) coerce each arm's rows — the outer
+    // `SELECT *` reads the widened `double` column.
+    try enginePeople().expect("SELECT * FROM (SELECT 1 UNION SELECT 2.5) AS d",
+                              yields: [[1.0], [2.5]])
+  }
+
+  @Test func `a column list over a UNION body renames the widened column`()
+      throws {
+    // The crossover of the two ISO features: the `.setop` Plan node's carried
+    // `types` coerce the mixed integer/double arms to a `double` column (set-op
+    // unification), and the `AS d(a)` list renames that column `a` (the
+    // explicit output column list). Selecting `d.a` reads the widened, coerced
+    // values under the list's name — the two features COMPOSE.
+    try enginePeople().expect(
+        "SELECT d.a FROM (SELECT 1 UNION SELECT 2.5) AS d(a) ORDER BY d.a",
+        yields: [[1.0], [2.5]])
+  }
+
+  @Test func `a constant-NULL arm does not veto the widening`() throws {
+    // A `NULLIF(2, 2)` arm folds to constant NULL, so it constrains nothing (a
+    // NULL unifies with any typed arm): the OTHER arm's `double` types the
+    // column, its NULL row stays NULL and the double row coerces.
+    try enginePeople().expect("SELECT NULLIF(2, 2) UNION SELECT 2.5",
+                              yields: [[nil], [2.5]])
+    // A typed integer arm beside a constant-NULL arm keeps the `integer`
+    // column.
+    try enginePeople().expect("SELECT 1 UNION SELECT NULLIF(2, 2)",
+                              yields: [[1], [nil]])
+  }
+
+  @Test func `a recursive CTE widens an integer anchor to a double arm`() throws {
+    // The anchor is `integer` and the recursive arm `double`; the unified
+    // column is `double`, so the anchor's `1` coerces to `1.0` and every
+    // iteration's value carries the widened type (v1b — the fixpoint coerces
+    // its rows).
+    let rows = try statement("""
+        WITH RECURSIVE t (n) AS (
+          SELECT 1 UNION ALL SELECT n + 0.5 FROM t WHERE n < 3
+        ) SELECT n FROM t
+        """, enginePeople())
+    #expect(rows == [[.double(1.0)], [.double(1.5)], [.double(2.0)],
+                     [.double(2.5)], [.double(3.0)]])
+  }
+
+  @Test func `a homogeneous UNION is byte-identical (no coercion)`() throws {
+    // Every arm the same type — the coercion is a no-op, so the result is
+    // exactly what the pre-unification engine produced.
+    try enginePeople().expect(
+        "SELECT Age FROM People UNION SELECT Age FROM People",
+        yields: [[30], [25], [40]])
+  }
+
+  @Test func `a homogeneous INTERSECT/EXCEPT is byte-identical`() throws {
+    try enginePeople().expect(
+        "SELECT Age FROM People INTERSECT SELECT Age FROM People",
+        yields: [[30], [25], [40]])
+    try enginePeople().empty(
+        "SELECT Age FROM People EXCEPT SELECT Age FROM People")
+  }
+}
+
+// MARK: - Correlated / lateral all-NULL column mask unification
+
+/// A column reference resolves its TYPE and its `unconstrained` mask from ONE
+/// resolution over the SAME paths — local, correlation, schema — so a
+/// correlated all-NULL column (referenced through a LATERAL body) keeps its
+/// mask and unifies with a typed set-operation arm, rather than losing the mask
+/// through the correlation surface and folding as a concrete type. The mask
+/// reader once walked a LOCAL-only path while the type reader was
+/// correlation-aware, so a correlated all-NULL column dropped its mask; the
+/// read-side unification closes that gap. A GENUINELY-typed correlated column
+/// stays concrete (no over-marking), and a barred ORDINARY subquery projection
+/// still faults, so the unification widens nothing.
+struct EngineCorrelatedNullUnificationTests {
+  @Test func `a correlated all-NULL column unifies through a LATERAL set-op arm`()
+      throws {
+    // The reviewer's case. `t`'s column `x` is a constant NULL in BOTH arms, so
+    // it is UNCONSTRAINED. The lateral body `SELECT x UNION SELECT 'c'`
+    // references the correlated `x`, whose mask must survive the correlation
+    // surface so the arm is unconstrained and unifies with the text `'c'` — the
+    // body yields the NULL row and the `'c'` row. Before the read-side
+    // unification the mask was read LOCAL-only, so the correlated `x` folded as
+    // a concrete integer and the arm faulted int-vs-text.
+    let rows = try statement("""
+        WITH t (x) AS (SELECT NULLIF(1, 1) UNION SELECT NULLIF('a', 'a'))
+          SELECT y FROM t
+          JOIN LATERAL (SELECT x UNION SELECT 'c') AS d (y) ON 1 = 1
+        """, engineFamily())
+    #expect(rows == [[.null], [.text("c")]])
+  }
+
+  @Test func `a grandparent all-NULL column unifies through a nested LATERAL arm`()
+      throws {
+    // The correlation crosses TWO lateral levels: `x` (from `t`) is read in the
+    // INNERMOST lateral body's set-op arm, which correlates to a scope two
+    // enclosing levels up. The nearest-first `Outer` walk must carry `x`'s
+    // unconstrained mask up from that grandparent scope, so the innermost arm
+    // still unifies the NULL with the text `'c'`.
+    let rows = try statement("""
+        WITH t (x) AS (SELECT NULLIF(1, 1) UNION SELECT NULLIF('a', 'a'))
+          SELECT z FROM t
+          JOIN LATERAL (
+            SELECT y FROM (SELECT 1 AS one) AS u
+            JOIN LATERAL (SELECT x UNION SELECT 'c') AS d (y) ON 1 = 1
+          ) AS e (z) ON 1 = 1
+        """, engineFamily())
+    #expect(rows == [[.null], [.text("c")]])
+  }
+
+  @Test func `a genuinely-typed correlated column in a LATERAL arm stays concrete`()
+      throws {
+    // The over-marking guard: `t`'s column `x` is a CONCRETE integer (a plain
+    // `SELECT 1`), so the correlated reference must NOT be marked
+    // unconstrained — the lateral arm `SELECT x UNION SELECT 'c'` then folds a
+    // genuine integer against text and faults `.operand` (SQLSTATE 42804),
+    // exactly as an irreconcilable local pair does. This proves the mask is
+    // not spuriously set for every correlated column.
+    #expect(throws: SQLError.operand("UNION arms have irreconcilable types")) {
+      _ = try statement("""
+          WITH t (x) AS (SELECT 1)
+            SELECT y FROM t
+            JOIN LATERAL (SELECT x UNION SELECT 'c') AS d (y) ON 1 = 1
+          """, engineFamily())
+    }
+  }
+
+  @Test func `a local all-NULL column still unifies with a text arm`() throws {
+    // The local (non-correlated) all-NULL regression: `x` resolves through the
+    // LOCAL path, whose resolved lookup carries the same mask, so a bare
+    // reference in a set-op arm unifies with the text arm and runs.
+    let rows = try statement("""
+        WITH t (x) AS (SELECT NULLIF(1, 1) UNION SELECT NULLIF('a', 'a'))
+          SELECT x FROM t UNION SELECT 'c'
+        """, engineFamily())
+    #expect(rows == [[.null], [.text("c")]])
+  }
+
+  @Test func `a homogeneous UNION still runs unchanged`() throws {
+    // The unification is a no-op for a genuinely-typed homogeneous set
+    // operation — the result is exactly what the pre-unification engine
+    // produced.
+    try enginePeople().expect(
+        "SELECT Age FROM People UNION SELECT Age FROM People",
+        yields: [[30], [25], [40]])
+  }
+
+  @Test func `a barred ordinary subquery projection still faults 0A000`() throws {
+    // The parity guard: the read-side resolution keeps the `admits` bar, so an
+    // ORDINARY (non-lateral) correlated subquery in a projection is still
+    // DIAGNOSED `.unsupported` — the unification does not widen acceptance. The
+    // barred surface faults the same on the run and schema paths.
+    let people = try enginePeople()
+    #expect(throws: SQLError.state("0A000",
+        "a correlated column is only supported in a subquery's WHERE")) {
+      _ = try people.run(engineParse("SELECT (SELECT P.Age) FROM People AS P"))
+    }
+  }
+}
+
+// MARK: - Unconstrained-mask channel seal (per-wrapper regression matrix)
+
+/// The class-level seal: a per-column `unconstrained` mask (an all-arms-NULL
+/// column places NO type constraint, so it unifies with any set-operation arm)
+/// must travel with a column's type through EVERY channel that stores or passes
+/// a RESOLVED column's type. Three channels carry a resolved column's type — the
+/// write/bindings carrier, the read/reference lookup, and the SCALAR-SUBQUERY
+/// output memo — and each is exercised here by a matched PAIR per wrapper shape:
+/// an all-NULL driver UNION'd with a typed arm must RUN (unify → the NULL row
+/// and the typed row), while a NON-null counterpart in the SAME shape must still
+/// FAULT `.operand` (SQLSTATE 42804), so the seal marks exactly the
+/// constant-NULL columns and no others. The scalar-subquery pair is the fix for
+/// the last leaking channel: the output memo once stored a bare `ValueType`, so
+/// a scalar wrapper dropped the mask — `SELECT (SELECT NULLIF('a','a')) UNION
+/// SELECT 1` was wrongly rejected while the unwrapped form ran.
+struct EngineUnconstrainedMaskSealTests {
+  @Test func `a bare all-NULL arm unifies with a typed arm; a typed one faults`()
+      throws {
+    // The baseline channel — a bare projected expression folding to constant
+    // NULL is unconstrained, so it unifies; a typed literal constrains and
+    // faults int-vs-text.
+    try enginePeople().expect("SELECT NULLIF('a', 'a') UNION SELECT 1",
+                              yields: [[nil], [1]])
+    try enginePeople().expect(
+        "SELECT 'a' UNION SELECT 1",
+        fails: .operand("UNION arms have irreconcilable types"))
+  }
+
+  @Test func `a scalar-subquery all-NULL wrapper unifies; a typed one faults`()
+      throws {
+    // THE FIX. The scalar subquery `(SELECT NULLIF('a','a'))` collapses to a
+    // constant NULL, so its resolved output column is UNCONSTRAINED — the memo
+    // now carries that mask into the outer fold, which unifies the wrapper with
+    // the integer arm and RUNS (NULL row + `1` row). A genuinely-typed wrapper
+    // `(SELECT 'a')` stays concrete text and faults int-vs-text.
+    try enginePeople().expect(
+        "SELECT (SELECT NULLIF('a', 'a')) UNION SELECT 1",
+        yields: [[nil], [1]])
+    try enginePeople().expect(
+        "SELECT (SELECT 'a') UNION SELECT 1",
+        fails: .operand("UNION arms have irreconcilable types"))
+  }
+
+  @Test func `a scalar subquery over a both-NULL UNION unifies; a typed one faults`()
+      throws {
+    // The scalar subquery's OWN body is a set operation both of whose arms fold
+    // to constant NULL, so the inner unification leaves the column
+    // unconstrained — the memo carries THAT mask out, and the outer fold unifies
+    // the wrapper with the text `'c'` arm. A typed inner UNION (`SELECT 1 UNION
+    // SELECT 2`) stays a concrete integer and faults int-vs-text.
+    try enginePeople().expect("""
+        SELECT (SELECT NULLIF(1, 1) UNION SELECT NULLIF('a', 'a'))
+          UNION SELECT 'c'
+        """, yields: [[nil], ["c"]])
+    try enginePeople().expect(
+        "SELECT (SELECT 1 UNION SELECT 2) UNION SELECT 'c'",
+        fails: .operand("UNION arms have irreconcilable types"))
+  }
+
+  @Test func `a derived-table all-NULL column unifies; a typed one faults`()
+      throws {
+    // The derived-table channel: the derived body's column `x` folds to constant
+    // NULL, so its resolved schema marks it unconstrained; a bare reference in
+    // the outer set-op arm unifies with the integer `1`. A typed derived column
+    // (`SELECT 'a' AS x`) stays concrete text and faults int-vs-text.
+    try enginePeople().expect("""
+        SELECT x FROM (SELECT NULLIF('a', 'a') AS x) AS d UNION SELECT 1
+        """, yields: [[nil], [1]])
+    try enginePeople().expect(
+        "SELECT x FROM (SELECT 'a' AS x) AS d UNION SELECT 1",
+        fails: .operand("UNION arms have irreconcilable types"))
+  }
+}
+
+// MARK: - Placeholder-column unconstrained closure (fold defers, not faults)
+
+/// The invariant that closes two feedback classes with ONE rule: a carrier
+/// column whose type is a FABRICATED PLACEHOLDER (not a genuine derivation) is
+/// marked UNCONSTRAINED, so the set-operation `merge` fold DEFERS to the other
+/// arm rather than faulting on the placeholder — faulting ONLY on two
+/// genuinely-known irreconcilable types.
+///
+/// Two placeholders are closed here. An UNREGISTERED routine call has no
+/// genuine return type (the derive fabricates the `.integer` default), so its
+/// fold defers — at ANY depth, whether the call is BARE (`missing()`) or
+/// NESTED in a composite (`missing() + 0`, `COALESCE(missing(), 1)`, a `CASE`
+/// result, an argument of a registered call); the SEPARATE reachable typecheck
+/// still raises `SQLError.function` when the arm is REACHED, so a
+/// genuinely-missing routine is never hidden — only the FOLD defers. A CTE's
+/// declared-name carrier is likewise a placeholder, so a genuine body
+/// incompatibility (`SELECT 'b' UNION SELECT 1`) PROPAGATES `.operand`
+/// identically at run and at `columns(of:validate:true)`, rather than being
+/// swallowed into a phantom `.integer`. A REGISTERED-only expression carries a
+/// genuine type and still constrains, and a literal mismatch still faults, so
+/// the deferral marks exactly the placeholders and no others.
+struct EnginePlaceholderUnconstrainedClosureTests {
+  @Test func `a bare unregistered call in a reached arm still faults function`()
+      throws {
+    // The unregistered `missing()` is REACHED (a FROM-less single-row arm), so
+    // the reachable typecheck raises `SQLError.function` — NOT `.operand`. The
+    // fold deferring on the placeholder does not hide the missing routine.
+    try enginePeople().expect("SELECT missing() UNION SELECT 'x'",
+                              fails: .function("missing"))
+  }
+
+  @Test func `a bare unregistered call on the right side still faults function`()
+      throws {
+    // The right-side variant: the fold defers on the placeholder either way,
+    // and the reachable typecheck raises `.function` when the arm is reached.
+    try enginePeople().expect("SELECT 1 UNION SELECT missing()",
+                              fails: .function("missing"))
+  }
+
+  @Test func `an unreached unregistered-call arm defers and the union runs`()
+      throws {
+    // The zero-row arm skips the unregistered `NOPE(Name)` — never reached, so
+    // no `.function` fault — while its placeholder type defers in the fold
+    // rather than faulting `.operand` against the text `'x'`. The union yields
+    // only the reached `'x'` row.
+    try enginePeople().expect("""
+        SELECT NOPE(Name) FROM People FETCH FIRST 0 ROWS ONLY
+          UNION SELECT 'x'
+        """, yields: [["x"]])
+  }
+
+  @Test func `an unreached nested unregistered call defers and the union runs`()
+      throws {
+    // The reviewer oracle: `NOPE(Name) + 0` NESTS the unregistered call in a
+    // `.binary`, which the former shallow bare-call case did not catch. The
+    // zero-row arm never evaluates it, so `unresolved` marks the arm
+    // unconstrained and the fold defers to the text `'x'` rather than faulting
+    // `.operand` on the fabricated `.integer`. The union yields only `'x'`.
+    try enginePeople().expect("""
+        SELECT NOPE(Name) + 0 FROM People FETCH FIRST 0 ROWS ONLY
+          UNION SELECT 'x'
+        """, yields: [["x"]])
+  }
+
+  @Test func `a reached nested unregistered call still faults function`()
+      throws {
+    // The reached counterpart: over the non-empty `People` the arm evaluates
+    // `NOPE(Name) + 0`, dispatching the missing routine — so the reachable
+    // typecheck raises `SQLError.function` (the name folded to `nope`), NOT
+    // `.operand`. Deferring the fold does not hide the missing routine even
+    // when it is nested.
+    try enginePeople().expect("""
+        SELECT NOPE(Name) + 0 FROM People UNION SELECT 'x'
+        """, fails: .function("nope"))
+  }
+
+  @Test func `an unregistered call inside COALESCE defers`() throws {
+    // Nested in a `COALESCE`: the FROM-less arm's `COALESCE(missing(), 1)`
+    // contains the unregistered call, so `unresolved` marks it unconstrained
+    // and the fold defers to the text `'x'` rather than faulting `.operand`. A
+    // FROM-less single-row arm is REACHED, so `missing()` dispatches — hence
+    // the run faults `.function`, proving the deferral touches only the fold.
+    try enginePeople().expect("SELECT COALESCE(missing(), 1) UNION SELECT 'x'",
+                              fails: .function("missing"))
+  }
+
+  @Test func `a COALESCE selecting an earlier non-NULL arg constrains the fold`()
+      throws {
+    // `COALESCE(1, missing())` SELECTS the constant integer `1` and never
+    // reaches `missing()` (both `unified` and the executor stop there), so the
+    // left arm constrains the set-op as integer — the text `'x'` arm is
+    // genuinely irreconcilable and must fault `.operand`, not defer and leave
+    // the integer `1` cell uncoerced against text.
+    try enginePeople().expect(
+        "SELECT COALESCE(1, missing()) UNION ALL SELECT 'x'",
+        fails: .operand("UNION arms have irreconcilable types"))
+  }
+
+  @Test func `an unregistered call inside a CASE result defers in the fold`()
+      throws {
+    // Nested in a reachable `CASE` result: the arm's `CASE WHEN 1 = 1 THEN
+    // missing() END` reaches the `missing()` branch, so `unresolved` (via the
+    // reachable-branch mirror of `derive`) marks it unconstrained. The arm is
+    // reached, so the run dispatches `missing()` and faults `.function`.
+    try enginePeople().expect("""
+        SELECT CASE WHEN 1 = 1 THEN missing() END UNION SELECT 'x'
+        """, fails: .function("missing"))
+  }
+
+  @Test func `an unregistered call as a registered call argument defers`()
+      throws {
+    // Nested as an ARGUMENT of a REGISTERED call: `up(missing())` — `up` is
+    // registered, but its argument dispatches the unregistered `missing()`, so
+    // `unresolved`'s `.call` arm recurses the arguments and marks the arm
+    // unconstrained. The FROM-less arm is reached, so the run dispatches the
+    // inner `missing()` and faults `.function`.
+    let routines: Routines =
+        ["up": Routine(returns: .text, parameters: [.text]) { row in row[0] }]
+    try enginePeople().expect("SELECT up(missing()) UNION SELECT 'x'",
+                              fails: .function("missing"), routines: routines)
+  }
+
+  @Test func `an unreached nested unregistered call under COALESCE runs`()
+      throws {
+    // The deferral is observable as a clean RUN when the nesting arm is
+    // filtered out: a zero-row `COALESCE(missing(), 1)` arm never evaluates the
+    // call, so the union folds and yields only the reached text `'x'`.
+    try enginePeople().expect("""
+        SELECT COALESCE(missing(), 1) FROM People FETCH FIRST 0 ROWS ONLY
+          UNION SELECT 'x'
+        """, yields: [["x"]])
+  }
+
+  @Test func `a registered-only arithmetic mismatch still faults 42804`()
+      throws {
+    // The nested over-suppression guard: a REGISTERED integer-returning call in
+    // an arithmetic expression carries a GENUINE type — `unresolved` finds no
+    // unregistered call, so the arm stays constrained and the integer result
+    // beside the text `'x'` still faults `.operand`. The recursion suppresses
+    // ONLY unregistered calls, never a genuine mismatch.
+    let routines: Routines =
+        ["one": Routine(returns: .integer, parameters: []) { _ in .integer(1) }]
+    try enginePeople().expect("SELECT one() + 0 UNION SELECT 'x'",
+                              fails: .operand(
+                                  "UNION arms have irreconcilable types"),
+                              routines: routines)
+  }
+
+  @Test func `pure literal arithmetic still faults 42804 beside text`() throws {
+    // The baseline nested guard: `1 + 0` folds to a GENUINE integer with no
+    // call at all, so it stays constrained and faults `.operand` against the
+    // text `'x'` — the recursion adds no over-suppression to a call-free tree.
+    try enginePeople().expect(
+        "SELECT 1 + 0 UNION SELECT 'x'",
+        fails: .operand("UNION arms have irreconcilable types"))
+  }
+
+  @Test func `a scalar subquery with an unregistered call defers via the memo`()
+      throws {
+    // Subquery composition: `(SELECT NOPE())` resolves its OWN single column
+    // through the subquery memo (`scalar(resolved:)`), which already carries
+    // the unconstrained mask for the unregistered call inside — so `unresolved`
+    // returns false for the outer `.subquery` and does NOT double-handle it.
+    // The outer fold defers to the text `'x'`; the FROM-less subquery arm is
+    // reached, so the run dispatches `NOPE` (folded to `nope`) and faults
+    // `.function`.
+    try enginePeople().expect("SELECT (SELECT NOPE()) UNION SELECT 'x'",
+                              fails: .function("nope"))
+  }
+
+  @Test func `a registered text-returning call still constrains and faults`()
+      throws {
+    // The over-suppression guard: a REGISTERED routine has a GENUINE return
+    // type, so its column is NOT a placeholder and still constrains — a
+    // text-returning call beside an integer arm faults `.operand`.
+    let routines: Routines = [
+      "tag": Routine(returns: .text, parameters: [.text]) { _ in .text("t") }
+    ]
+    try enginePeople().expect("SELECT tag(Name) FROM People UNION SELECT 1",
+                              fails: .operand(
+                                  "UNION arms have irreconcilable types"),
+                              routines: routines)
+  }
+
+  @Test func `a registered call unifying with a matching arm runs`() throws {
+    // The counterpart: a registered call whose genuine return type UNIFIES with
+    // the other arm folds cleanly and runs.
+    let routines: Routines =
+        ["tag": Routine(returns: .text, parameters: [.text]) { row in row[0] }]
+    try enginePeople().expect("""
+        SELECT tag(Name) FROM People WHERE Id = 1 UNION SELECT 'x'
+        """, yields: [["Alice"], ["x"]], routines: routines)
+  }
+
+  @Test func `a literal type mismatch still faults 42804`() throws {
+    // The baseline over-suppression guard: two GENUINE literal types still fold
+    // to an irreconcilable pair and fault — the closure widens nothing.
+    try enginePeople().expect(
+        "SELECT 1 UNION SELECT 'x'",
+        fails: .operand("UNION arms have irreconcilable types"))
+  }
+
+  @Test func `a genuine CTE body incompatibility faults at run`() throws {
+    // The CTE-validate case at RUN: the body `SELECT 'b' UNION SELECT 1` folds
+    // two GENUINE types (text vs integer) — irreconcilable — so the run faults
+    // `.operand` rather than swallowing it into the declared `.integer`
+    // placeholder.
+    #expect(throws: SQLError.operand("UNION arms have irreconcilable types")) {
+      _ = try statement(
+          "WITH a(x) AS (SELECT 'b' UNION SELECT 1) SELECT x FROM a",
+          engineFamily())
+    }
+  }
+
+  @Test func `a genuine CTE body incompatibility faults at columns validate`()
+      throws {
+    // The SAME case at the schema path: `columns(of:validate:true)` must ALSO
+    // throw `.operand` — no divergence, no phantom integer column advertised
+    // for a query that cannot run.
+    let statement = try Statement(parsing:
+        "WITH a(x) AS (SELECT 'b' UNION SELECT 1) SELECT x FROM a")
+    #expect(throws: SQLError.operand("UNION arms have irreconcilable types")) {
+      _ = try engineFamily().columns(of: statement, validate: true)
+    }
+  }
+}
+
+// MARK: - Deferred set-op operand fold in the nested-subquery shape pre-pass
+
+/// The reachability-aware deferral of a nested subquery's set-operation
+/// operand-compatibility fold. The shape pre-pass (`subquery(of:)`/`width`)
+/// records every nested subquery's width and single-column type AHEAD of the
+/// walk that decides which subqueries actually run, so it must NOT fault
+/// `SQLError.operand` (SQLSTATE 42804) on an incompatible set-operation
+/// subquery a short-circuited `AND`/`OR` leg never reaches — a `… WHERE 1 = 0
+/// AND EXISTS (SELECT 'x' UNION SELECT 1)` runs and yields no rows. Deferral
+/// alone would HIDE a genuine incompatibility in a subquery that DOES run, so
+/// a REACHED scalar or `IN`/quantified occurrence is re-folded strictly on the
+/// reached path and faults exactly as before; an `EXISTS`/`LATERAL` reach does
+/// not constrain column type and never faults on it. The top-level and CTE
+/// folds are outside the pre-pass (`shape` is `false`), so they keep faulting.
+struct EngineDeferredSetopShapeTests {
+  @Test func `a dead-branch EXISTS over an incompatible UNION runs to no rows`()
+      throws {
+    // The reviewer oracle: the `EXISTS` is short-circuited by `1 = 0 AND …`, so
+    // the incompatible `SELECT 'x' UNION SELECT 1` is never reached — the shape
+    // pre-pass defers its operand fold rather than faulting 42804, and the
+    // query runs to no rows.
+    try enginePeople().empty("""
+        SELECT 1 FROM People WHERE 1 = 0 AND EXISTS (SELECT 'x' UNION SELECT 1)
+        """)
+  }
+
+  @Test func `a reached EXISTS over an incompatible UNION runs`() throws {
+    // A REACHED `EXISTS` does not read the arms' unified column type — its
+    // cardinality probe never evaluates the select list — so it must NOT fault
+    // on the incompatible pair (role `.existential`, skipped by the re-fold).
+    // People has rows, so the EXISTS is present and every row projects `1`.
+    try enginePeople().expect("""
+        SELECT 1 FROM People WHERE EXISTS (SELECT 'x' UNION SELECT 1)
+        """, yields: Array(repeating: [1], count: 5))
+  }
+
+  @Test func `a dead-branch IN over an incompatible UNION runs to no rows`()
+      throws {
+    // The `IN` is unreachable behind `1 = 0 AND …`, so its incompatible UNION
+    // defers in the shape pre-pass and the query runs to no rows.
+    try enginePeople().empty("""
+        SELECT 1 FROM People WHERE 1 = 0 AND Age IN (SELECT 'a' UNION SELECT 1)
+        """)
+  }
+
+  @Test func `a reached IN over an incompatible UNION faults 42804`() throws {
+    // A REACHED `IN` reads its value set's column type (role `.valued`), so the
+    // re-fold on the reached path restores the strict operand check and the
+    // incompatible UNION faults 42804 — the deferral does not hide it.
+    try enginePeople().expect("""
+        SELECT 1 FROM People WHERE Age IN (SELECT 'a' UNION SELECT 1)
+        """, fails: .operand("UNION arms have irreconcilable types"))
+  }
+
+  @Test func `a reached scalar-subquery incompatible UNION faults 42804`() throws {
+    // A REACHED scalar subquery collapses to a single cell (role `.scalar`), so
+    // the reached re-fold checks its arms strictly and the incompatible UNION
+    // faults 42804 in the comparison.
+    try enginePeople().expect("""
+        SELECT 1 FROM People WHERE Age = (SELECT 'a' UNION SELECT 1)
+        """, fails: .operand("UNION arms have irreconcilable types"))
+  }
+
+  @Test func `a dead-branch scalar-subquery incompatible UNION runs to no rows`()
+      throws {
+    // The SAME scalar subquery behind `1 = 0 AND …` is unreachable, so its
+    // operand fold defers in the pre-pass and the query runs to no rows.
+    try enginePeople().empty("""
+        SELECT 1 FROM People
+          WHERE 1 = 0 AND Age = (SELECT 'a' UNION SELECT 1)
+        """)
+  }
+
+  @Test func `a top-level incompatible UNION still faults 42804`() throws {
+    // The top level is not a shape pre-pass (`shape` is `false`), so its
+    // operand fold still faults — the deferral is scoped to nested subqueries.
+    try enginePeople().expect(
+        "SELECT 'x' UNION SELECT 1",
+        fails: .operand("UNION arms have irreconcilable types"))
+  }
+
+  @Test func `a compatible CTE body under an incompatible-looking outer runs`()
+      throws {
+    // A compatible CTE body unified against a matching outer arm runs — the
+    // deferral changes nothing for a query that folds cleanly. A `WITH` is a
+    // statement, so it runs through the statement overload.
+    let rows = try statement(
+        "WITH a(x) AS (SELECT 'b') SELECT x FROM a UNION SELECT 'c'",
+        enginePeople())
+    #expect(rows == [[.text("b")], [.text("c")]])
+  }
+}
+
+// MARK: - Reached-correlated set-op fold and invalid-call suppression
+
+/// The two execution-seam refinements of the deferred set-op fold. A REACHED
+/// correlated non-EXISTS subquery re-executes the SHAPED (placeholder-typed)
+/// plan the pre-pass recorded under `.shaping()`, so it must strict-fold its
+/// arms' column types at the EXECUTION seam (`Filter.executed`) — not from the
+/// shaped plan — faulting `.operand` (42804) exactly as the uncorrelated run
+/// path does, and ONLY for a REACHED occurrence (an unreachable one never runs
+/// `executed`, so its deferral stands); an `EXISTS` reach never reads column
+/// type and does not fault. Separately, an INVALID routine call (bad arity or a
+/// definitively-wrong argument type) to an EXISTING routine is treated like a
+/// MISSING one — its fabricated declared type must NOT constrain the fold — so
+/// an invalid call in an UNREACHED arm folds away, while a VALID call's genuine
+/// return type still constrains (the over-suppression guard).
+struct EngineReachedCorrelatedSetopTests {
+  @Test func `a reached correlated IN over an incompatible UNION faults 42804`()
+      throws {
+    // The correlated `IN` subquery unions a text left arm (correlated `d.k =
+    // People.Id`) with an integer right arm. Reached for every outer row, its
+    // shaped plan is strict-folded at the execution seam and the irreconcilable
+    // pair faults 42804 on the first reached row — the correlated occurrence no
+    // longer coerces to the placeholder type and silently passes.
+    try enginePeople().expect("""
+        SELECT Id FROM People WHERE 1 IN ( \
+        SELECT 'x' FROM (SELECT 1 AS k) AS d WHERE d.k = People.Id \
+        UNION SELECT 1)
+        """, fails: .operand("UNION arms have irreconcilable types"))
+  }
+
+  @Test func `a dead-branch correlated IN over an incompatible UNION runs empty`()
+      throws {
+    // The SAME correlated `IN` behind `1 = 0 AND …` is unreachable, so it never
+    // reaches the execution seam — its shape deferral stands and the query runs
+    // to no rows.
+    try enginePeople().empty("""
+        SELECT Id FROM People WHERE 1 = 0 AND 1 IN ( \
+        SELECT 'x' FROM (SELECT 1 AS k) AS d WHERE d.k = People.Id \
+        UNION SELECT 1)
+        """)
+  }
+
+  @Test func `a reached correlated EXISTS over an incompatible UNION runs`()
+      throws {
+    // A reached correlated `EXISTS` (role `.existential`) ignores its arms'
+    // column types — the execution seam skips the strict fold — so the
+    // incompatible pair does not fault. The right arm always yields a row, so
+    // the EXISTS is present for every outer row and each projects its `Id`.
+    try enginePeople().expect("""
+        SELECT Id FROM People WHERE EXISTS ( \
+        SELECT 'x' FROM (SELECT 1 AS k) AS d WHERE d.k = People.Id \
+        UNION SELECT 1)
+        """, yields: [[1], [2], [3], [4], [5]])
+  }
+
+  @Test func `an invalid unreached call does not constrain the fold`() throws {
+    // `tag(text) RETURNS text` called with NO argument is invalid (bad arity),
+    // so it is treated like a missing call — its declared `text` return does
+    // NOT constrain the fold. The invalid arm is unreached (`FETCH FIRST 0 ROWS
+    // ONLY`), so the fold defers to the integer right arm and the query yields
+    // it alone rather than faulting 42804 in the dead left arm.
+    let routines: Routines = [
+      "tag": Routine(returns: .text, parameters: [.text]) { _ in .text("t") }
+    ]
+    try enginePeople().expect("""
+        SELECT tag() FROM People FETCH FIRST 0 ROWS ONLY UNION SELECT 1
+        """, yields: [[1]], routines: routines)
+  }
+
+  @Test func `an invalid reachable call faults on its bad arity, not 42804`()
+      throws {
+    // The counterpart on a VALIDATING path: `SELECT tag() UNION SELECT 1` calls
+    // `tag(text)` with no argument. The invalid call does not constrain the
+    // fold (so no spurious 42804), but the strict `validate: true` schema path
+    // catches the bad arity and faults `.argument` — NOT the operand fold. (The
+    // lenient run path does not validate arity, so it does not fault there.)
+    let routines: Routines = [
+      "tag": Routine(returns: .text, parameters: [.text]) { _ in .text("t") }
+    ]
+    let statement = try Statement(parsing: "SELECT tag() UNION SELECT 1")
+    #expect(throws: SQLError.argument("tag takes 1 arguments")) {
+      _ = try enginePeople().columns(of: statement, routines: routines,
+                                     validate: true)
+    }
+  }
+
+  @Test func `a valid text call still constrains the fold and faults 42804`()
+      throws {
+    // The over-suppression guard: `tag('a')` is a VALID call (correct arity and
+    // argument type), so its declared `text` return still constrains the fold —
+    // a text column beside an integer arm faults 42804. The invalid-call
+    // suppression must not swallow a valid call's genuine type.
+    let routines: Routines = [
+      "tag": Routine(returns: .text, parameters: [.text]) { _ in .text("t") }
+    ]
+    try enginePeople().expect("""
+        SELECT tag('a') FROM People UNION SELECT 1
+        """, fails: .operand("UNION arms have irreconcilable types"),
+        routines: routines)
   }
 }

--- a/Tests/SQLTests/Queries/EngineViewAndPushdownTests.swift
+++ b/Tests/SQLTests/Queries/EngineViewAndPushdownTests.swift
@@ -293,7 +293,7 @@ func engineDerived(_ plan: Plan) -> Plan? {
     engineDerived(left) ?? engineDerived(right)
   case let .apply(left, _, _, _, _, _):
     engineDerived(left)
-  case let .setop(_, left, right, _):
+  case let .setop(_, left, right, _, _, _):
     engineDerived(left) ?? engineDerived(right)
   case let .limit(_, _, source):
     engineDerived(source)
@@ -331,7 +331,7 @@ func engineSeeks(_ plan: Plan) -> Bool {
     engineSeeks(left) || engineSeeks(right)
   case let .apply(left, _, _, _, _, _):
     engineSeeks(left)
-  case let .setop(_, left, right, _):
+  case let .setop(_, left, right, _, _, _):
     engineSeeks(left) || engineSeeks(right)
   case let .limit(_, _, source):
     engineSeeks(source)
@@ -366,7 +366,7 @@ func engineFilters(_ plan: Plan) -> Bool {
     engineFilters(left) || engineFilters(right)
   case let .apply(left, _, _, _, _, _):
     engineFilters(left)
-  case let .setop(_, left, right, _):
+  case let .setop(_, left, right, _, _, _):
     engineFilters(left) || engineFilters(right)
   case let .limit(_, _, source):
     engineFilters(source)
@@ -406,7 +406,7 @@ func enginePushed(_ plan: Plan) -> Bool {
     enginePushed(source)
   case let .derived(_, sub, _, _):
     enginePushed(sub)
-  case let .setop(_, left, right, _):
+  case let .setop(_, left, right, _, _, _):
     enginePushed(left) || enginePushed(right)
   case let .limit(_, _, source):
     enginePushed(source)
@@ -464,7 +464,7 @@ func engineJoins(_ plan: Plan) -> Bool {
     engineJoins(left) || engineJoins(right)
   case let .apply(left, _, _, _, _, _):
     engineJoins(left)
-  case let .setop(_, left, right, _):
+  case let .setop(_, left, right, _, _, _):
     engineJoins(left) || engineJoins(right)
   case let .aggregate(_, _, source):
     engineJoins(source)
@@ -502,7 +502,7 @@ func engineResidual(_ plan: Plan) -> Bool {
     engineResidual(left) || engineResidual(right)
   case let .apply(left, _, _, _, _, _):
     engineResidual(left)
-  case let .setop(_, left, right, _):
+  case let .setop(_, left, right, _, _, _):
     engineResidual(left) || engineResidual(right)
   case let .aggregate(_, _, source):
     engineResidual(source)
@@ -541,7 +541,7 @@ func engineSeparated(_ plan: Plan) -> Bool {
     engineSeparated(left) || engineSeparated(right)
   case let .apply(left, _, _, _, _, _):
     engineSeparated(left)
-  case let .setop(_, left, right, _):
+  case let .setop(_, left, right, _, _, _):
     engineSeparated(left) || engineSeparated(right)
   case let .aggregate(_, _, source):
     engineSeparated(source)
@@ -581,7 +581,7 @@ func engineStacked(_ plan: Plan) -> Bool {
     engineStacked(left) || engineStacked(right)
   case let .apply(left, _, _, _, _, _):
     engineStacked(left)
-  case let .setop(_, left, right, _):
+  case let .setop(_, left, right, _, _, _):
     engineStacked(left) || engineStacked(right)
   case let .aggregate(_, _, source):
     engineStacked(source)
@@ -675,7 +675,7 @@ private func spanned() throws -> EngineMemory {
 /// arm's body, the per-arm rebase this fix enables.
 private func injected(_ plan: Plan) -> Bool {
   switch plan {
-  case let .setop(_, left, right, _):
+  case let .setop(_, left, right, _, _, _):
     (engineSeeks(left) || engineFloats(left)) && (engineSeeks(right) || engineFloats(right))
   case let .select(_, source):
     injected(source)
@@ -1129,6 +1129,72 @@ struct EnginePushdownTests {
     // The UNKNOWN-ON pair (A.k NULL) is dropped by the match gate before the
     // division runs, so the query returns rows rather than raising.
     #expect(try catalog.run(select) == [])
+  }
+}
+
+// MARK: - Set-op view type probe must not pollute the runtime plan memo
+
+/// The set-op column-type unification `compile` derives for a `UNION`/`EXCEPT`/
+/// `INTERSECT` view body runs a SCHEMA-ONLY projection PROBE (to learn which
+/// columns the set operation widens). That probe lowers any nested correlated
+/// subquery under the `.caller` id space and — before the fix — recorded the
+/// subquery's per-outer-row PLAN into the SHARED runtime memo. Recording is
+/// first-writer-wins, so a later CALLER whose own correlated subquery has the
+/// SAME AST and correlation (`(SELECT Val FROM S WHERE S.Id = T.Id)` over a
+/// same-shaped outer `T`) reused the VIEW body's plan — resolving `S` against
+/// the view's BASE table, not the caller's own CTE `S`. The probe must derive
+/// against an ISOLATED throwaway memo so it records nothing, letting each
+/// caller resolve its subquery against its OWN base.
+private func setopMemo() throws -> EngineMemory {
+  try Catalog {
+    // The shared driver `T`, referenced by the view body AND the caller, so the
+    // correlated subquery's outer `T.Id` binds at the SAME ordinal in both — an
+    // identical `Correlation`, hence an identical plan-memo key.
+    Relation("T", ["Id": .integer]) {
+      Row(1)
+      Row(2)
+    }
+    // The BASE `S` the VIEW body's `(SELECT Val FROM S …)` resolves against —
+    // `Id` at ordinal 0, `Val` at ordinal 1. A caller CTE named `S` shadows it
+    // with the columns in the OPPOSITE order (`Val` at 0, `Id` at 1), so the
+    // view's compiled plan — which projects ordinal 1 and filters ordinal 0 —
+    // reads the WRONG cells if reused against the caller's CTE: it would
+    // project the CTE's `Id` (ordinal 1) rather than its `Val` (ordinal 0).
+    Relation("S", ["Id": .integer, "Val": .integer]) {
+      Row(1, 1000)
+      Row(2, 2000)
+    }
+    // A set-operation view whose LEFT arm holds a correlated scalar subquery
+    // `(SELECT Val FROM S WHERE S.Id = T.Id)` — the SAME AST the caller uses.
+    // Compiling its body runs the `.setop` widened-column type probe, which
+    // lowers that subquery under `.caller`; the probe must NOT record its plan.
+    try View("V", """
+        SELECT (SELECT Val FROM S WHERE S.Id = T.Id) AS c FROM T
+          UNION ALL
+        SELECT 0 AS c FROM T
+        """, as: ["c"])
+  }
+}
+
+struct EngineSetopViewMemoTests {
+  @Test func `a set-op view type probe does not capture a caller's subquery`()
+      throws {
+    // The caller shadows base `S` with a CTE `S` whose columns are in the
+    // OPPOSITE order (`Val, Id`) and runs the IDENTICAL correlated subquery
+    // `(SELECT Val FROM S WHERE S.Id = T.Id)` over `T`. It also references the
+    // set-op view `V`, whose body compile runs the widened-type probe over the
+    // same subquery AST first. With the probe isolated, the caller's subquery
+    // resolves against ITS CTE `S` at ITS ordinals, projecting `Val` ∈ {7, 8};
+    // a probe that polluted the shared memo would make the caller reuse the
+    // view's plan (base `S` ordinals — project ordinal 1, filter ordinal 0),
+    // which over the swapped CTE projects `Id` ∈ {1, 2} (or mis-filters).
+    let rows = try setopMemo().run(Statement(parsing:
+        """
+        WITH S (Val, Id) AS (SELECT 7, 1 UNION ALL SELECT 8, 2)
+          SELECT (SELECT Val FROM S WHERE S.Id = T.Id) AS c
+            FROM T JOIN V ON V.c = 0 GROUP BY T.Id ORDER BY c
+        """))
+    #expect(rows == [[.integer(7)], [.integer(8)]])
   }
 }
 

--- a/Tests/SQLTests/Queries/EngineWithTests.swift
+++ b/Tests/SQLTests/Queries/EngineWithTests.swift
@@ -26,6 +26,24 @@ struct EngineWithTests {
     #expect(rows == [[.text("Bee")], [.text("Cid")]])
   }
 
+  @Test func `a UNION over a text CTE column folds the body type`() throws {
+    // The CTE `a` binds its body's DERIVED type (`x` is text), so the set-op
+    // fold unifies text against text and runs — a `.integer` declared-name
+    // placeholder would wrongly fault the all-text UNION as irreconcilable.
+    let text = """
+        WITH a (x) AS (SELECT 'b') SELECT x FROM a UNION SELECT 'c'
+        """
+    // The SCHEMA path folds the CTE column at its BODY-derived type too: it
+    // must report `x` as `.text` and NOT fault, the compile-time mirror of the
+    // run.
+    let columns = try engineFamily().columns(of: Statement(parsing: text))
+    #expect(columns.count == 1)
+    #expect(columns[0].name == "x")
+    #expect(columns[0].type == .text)
+    let rows = try statement(text, engineFamily())
+    #expect(rows == [[.text("b")], [.text("c")]])
+  }
+
   @Test func `a JOIN matches an integer key to an equal double key`() throws {
     // The optimized join paths (hash bucket, seek/final check, CTE nested loop)
     // must use the same mixed-numeric equality a predicate does: `1` and `1.0`
@@ -64,40 +82,47 @@ struct EngineWithTests {
     #expect(rows.isEmpty)
   }
 
-  @Test func `UNION deduplicates numerically-equal rows across kinds`() throws {
-    // `1` and `1.0` are the same numeric value, so UNION keeps one — the first
-    // arm's — not both; the dedup uses the numeric equality, not raw `Value`.
+  @Test func `UNION widens a mixed integer/double column and dedups the equal rows`() throws {
+    // ISO unifies the result column type across the arms — an `integer` arm and
+    // a `double` arm widen to `double`, and each arm's values are COERCED to
+    // it. `1` and `1.0` then compare equal AND emit as the same coerced
+    // `double`, so a bare UNION keeps one `1.0` (not the first arm's raw
+    // `integer`).
     #expect(try statement("SELECT 1 UNION SELECT 1.0", engineFamily())
-            == [[.integer(1)]])
-    // UNION ALL keeps every row.
+            == [[.double(1.0)]])
+    // UNION ALL keeps every row, each coerced to the unified `double`.
     #expect(try statement("SELECT 1 UNION ALL SELECT 1.0", engineFamily())
-            == [[.integer(1)], [.double(1.0)]])
+            == [[.double(1.0)], [.double(1.0)]])
   }
 
-  @Test func `UNION dedup keeps distinct integers a rounded double sits between`() throws {
-    // Dedup is EXACT: `2^53.0` equals the integer `2^53` (folds to it), but NOT
-    // the integer `2^53 + 1`. So an earlier approximate row must not absorb
-    // both distinct integers — the `2^53 + 1` row survives regardless of order.
+  @Test func `UNION coercion collapses integers a rounded double cannot separate`() throws {
+    // The unified column is `double`, so EVERY arm's value coerces to `double`
+    // before the dedup: `2^53 + 1` (the integer `9007199254740993`) rounds to
+    // `2^53.0` on promotion, becoming EQUAL to the double `2^53.0` — so the
+    // three arms collapse to the ONE distinct `double`, the ISO
+    // approximate-numeric result of a mixed-type UNION.
     let rows = try statement("""
         SELECT 9007199254740992.0
           UNION SELECT 9007199254740992
           UNION SELECT 9007199254740993
         """, engineFamily())
-    #expect(rows == [[.double(9007199254740992.0)],
-                     [.integer(9007199254740993)]])
+    #expect(rows == [[.double(9007199254740992.0)]])
   }
 
-  @Test func `ORDER BY orders mixed integer/double keys by magnitude`() throws {
+  @Test func `ORDER BY orders a widened mixed integer/double column by magnitude`() throws {
+    // The CTE column unifies to `double`, so its integer arm coerces — `3`
+    // emits as `3.0` — and the ordering runs over the widened values.
     let rows = try statement("""
         WITH a (x) AS (SELECT 3 UNION ALL SELECT 1.5) SELECT x FROM a ORDER BY x
         """, engineFamily())
-    #expect(rows == [[.double(1.5)], [.integer(3)]])
+    #expect(rows == [[.double(1.5)], [.double(3.0)]])
   }
 
-  @Test func `ORDER BY over mixed keys past 2^53 stays a total order`() throws {
-    // A double ties two distinct integers under promotion; the comparator must
-    // stay a strict weak ordering (transitive), keeping the larger integer last
-    // rather than misordering it ahead of the smaller via the stable tie-break.
+  @Test func `ORDER BY over a widened mixed column past 2^53 stays a total order`() throws {
+    // The column unifies to `double`, so every arm coerces — the two distinct
+    // integers past 2^53 both round to `2^53.0` under the widening, ordering
+    // stays a strict weak ordering, and the greatest value is the coerced
+    // `double`.
     let rows = try statement("""
         WITH a (x) AS (SELECT 9007199254740993
                        UNION ALL SELECT 9007199254740993.0
@@ -105,7 +130,7 @@ struct EngineWithTests {
           SELECT x FROM a ORDER BY x
         """, engineFamily())
     #expect(rows.count == 3)
-    #expect(rows.last == [.integer(9007199254740993)])
+    #expect(rows.last == [.double(9007199254740992.0)])
   }
 
   @Test func `a CTE infers its columns and filters on them`() throws {
@@ -306,6 +331,28 @@ struct EngineWithTests {
         SELECT Id FROM Parent
         """, catalog)
     #expect(rows == [[.integer(1)], [.integer(2)], [.integer(3)]])
+  }
+
+  @Test func `a recursive CTE seeds its anchor from a same-named base column`()
+      throws {
+    // The anchor `SELECT Age FROM Parent` reads the BASE `Parent` — the CTE
+    // self, whose sole column is `n`, is not in scope for the base case — while
+    // only the recursive arm names the self. The set-op type fold must resolve
+    // the anchor under the base scope; folding the whole query under the self
+    // binding rejects the base-only `Age` (absent from the CTE's `(n)`), so a
+    // valid query would trap or fault before running.
+    let catalog = EngineMemory([
+      "Parent": FixtureRelation([EngineField(name: "Age", type: .integer)],
+                         [[.integer(29)]] as Array<Array<Value>>),
+    ])
+    let rows = try statement("""
+        WITH RECURSIVE Parent (n) AS (
+          SELECT Age FROM Parent
+          UNION ALL SELECT n + 1 FROM Parent WHERE n < 31
+        )
+        SELECT n FROM Parent ORDER BY n
+        """, catalog)
+    #expect(rows == [[.integer(29)], [.integer(30)], [.integer(31)]])
   }
 }
 
@@ -594,5 +641,212 @@ struct EngineRecursiveTests {
     #expect(throws: SQLError.recursion("c")) {
       try seed().run(query, counting())
     }
+  }
+
+  @Test func `a recursive arm that is itself a set-op folds the self at the anchor type`() throws {
+    // The recursive arm `SELECT s FROM t INTERSECT SELECT 'b'` is ITSELF a set
+    // operation, so `validate`'s recursive-arm typecheck folds its self column
+    // (`s`) before `fixpoint` rebinds it. Binding the self under the ANCHOR's
+    // derived type (`s` is text, from `SELECT 'b'`) — not a `.integer`
+    // placeholder — lets text INTERSECT text unify rather than faulting a text
+    // arm against an integer self. The SCHEMA path must report `s` as `.text`
+    // without throwing, and the run terminates yielding `b`.
+    let text = """
+        WITH RECURSIVE t (s) AS (
+          SELECT 'b' UNION SELECT s FROM t INTERSECT SELECT 'b'
+        )
+        SELECT s FROM t
+        """
+    let columns = try engineFamily().columns(of: Statement(parsing: text))
+    #expect(columns.count == 1)
+    #expect(columns[0].name == "s")
+    #expect(columns[0].type == .text)
+    let rows = try statement(text, engineFamily())
+    #expect(rows == [[.text("b")]])
+  }
+
+  @Test func `a recursive CTE widening past its anchor types the self as unified`() throws {
+    // The anchor `SELECT 1` is INTEGER but the recursive arm `n + 0.5` yields
+    // a DOUBLE, so the CTE column `n` unifies to `.double` — the type every row
+    // is coerced to. `fixpoint` binds the iterated self under those UNIFIED
+    // types (not the anchor-only integer), so the recursive arm reads `n` at
+    // the type its coerced values carry; the run yields the widened sequence
+    // and the SCHEMA path reports `n` as `.double`, the run's own result type.
+    let text = """
+        WITH RECURSIVE t (n) AS (
+          SELECT 1 AS n FROM Seed
+          UNION ALL
+          SELECT n + 0.5 AS n FROM t WHERE n < 3
+        )
+        SELECT n FROM t
+        """
+    let columns = try seed().columns(of: Statement(parsing: text),
+                                     routines: [:])
+    #expect(columns.count == 1)
+    #expect(columns[0].name == "n")
+    #expect(columns[0].type == .double)
+    let rows = try seed().run(Statement(parsing: text))
+    #expect(rows == [[.double(1.0)], [.double(1.5)], [.double(2.0)],
+                     [.double(2.5)], [.double(3.0)]])
+  }
+
+  @Test func `a widening CTE's schema and run agree on an integer routine self`() throws {
+    // The reviewer's parity case. Column `a` has an INTEGER anchor (`1`) but a
+    // recursive arm `a + 0.5` that widens it to `.double`; the same arm calls
+    // the INTEGER-declared `inc(a)` on that self column. Typing the self at the
+    // UNIFIED `.double` (the type the run coerces its rows to) makes SCHEMA
+    // validation and EXECUTION agree: both FAULT, because `inc` requires an
+    // integer argument and the widened self is a double. Were the self typed at
+    // the anchor-only integer, schema validation would call the query "valid"
+    // while the run faults — the schema-vs-execution break this fix closes. The
+    // fault case differs by path (static `.argument` vs the routine's own
+    // `.argument`), so assert each throws an `SQLError`.
+    let text = """
+        WITH RECURSIVE t (a, b) AS (
+          SELECT 1 AS a, 1 AS b FROM Seed
+          UNION ALL
+          SELECT a + 0.5 AS a, inc(a) AS b FROM t WHERE a < 3
+        )
+        SELECT a, b FROM t
+        """
+    #expect(throws: SQLError.self) {
+      _ = try seed().columns(of: Statement(parsing: text),
+                             routines: counting())
+    }
+    #expect(throws: SQLError.self) {
+      _ = try seed().run(Statement(parsing: text), counting())
+    }
+  }
+
+  @Test func `an all-NULL CTE column unifies with a later text arm`() throws {
+    // The CTE `t`'s column `x` is a constant NULL in BOTH arms, so it places NO
+    // type constraint: an enclosing UNION over `SELECT x FROM t` must unify it
+    // with the `'c'` arm and run, yielding the NULL and the text. The CTE fold
+    // carries the per-column unconstrained marker, so a bare reference to `x`
+    // unifies like a fresh constant-NULL arm.
+    let rows = try statement("""
+        WITH t (x) AS (SELECT NULLIF('b', 'b') UNION SELECT NULLIF(1, 1))
+          SELECT x FROM t UNION SELECT 'c'
+        """, engineFamily())
+    #expect(rows == [[.null], [.text("c")]])
+  }
+
+  @Test func `an all-NULL CTE column unifies regardless of arm order`() throws {
+    // The order-independence case. The arms are REVERSED from the sibling test
+    // — the integer-typed NULLIF leads — so the CTE fold defaults `x`'s
+    // concrete type to `.integer` rather than `.text`. Without the
+    // unconstrained marker the enclosing UNION would fault `.integer` against
+    // the `'c'` text arm (the literal-fix regression); the marker unifies it
+    // either way.
+    let rows = try statement("""
+        WITH t (x) AS (SELECT NULLIF(1, 1) UNION SELECT NULLIF('b', 'b'))
+          SELECT x FROM t UNION SELECT 'c'
+        """, engineFamily())
+    #expect(rows == [[.null], [.text("c")]])
+  }
+
+  @Test func `a three-arm all-NULL CTE column unifies in either order`() throws {
+    // A three-arm all-NULL chain stays unconstrained through every merge, so
+    // the enclosing UNION unifies it with the text arm — both the integer-first
+    // and the text-first orderings yield the same {NULL, 'c'}.
+    let forward = try statement("""
+        WITH t (x) AS (SELECT NULLIF(1, 1) UNION SELECT NULLIF('a', 'a')
+                       UNION SELECT NULLIF('b', 'b'))
+          SELECT x FROM t UNION SELECT 'c'
+        """, engineFamily())
+    #expect(forward == [[.null], [.text("c")]])
+    let reversed = try statement("""
+        WITH t (x) AS (SELECT NULLIF('b', 'b') UNION SELECT NULLIF('a', 'a')
+                       UNION SELECT NULLIF(1, 1))
+          SELECT x FROM t UNION SELECT 'c'
+        """, engineFamily())
+    #expect(reversed == [[.null], [.text("c")]])
+  }
+
+  @Test func `an all-NULL CTE column unifies beside a widening pair`() throws {
+    // Column `a` is all-NULL (unconstrained) while column `b` genuinely widens
+    // an integer arm to a double. The enclosing UNION unifies `a` with the text
+    // arm and `b`'s double with the integer arm — `a` yields NULLs, `b` the
+    // coerced doubles.
+    let rows = try statement("""
+        WITH t (a, b) AS (SELECT NULLIF(1, 1), 1
+                          UNION SELECT NULLIF('x', 'x'), 2.5)
+          SELECT a, b FROM t UNION SELECT 'c', 3
+        """, engineFamily())
+    #expect(Set(rows) == [[.null, .double(1.0)], [.null, .double(2.5)],
+                          [.text("c"), .double(3.0)]])
+  }
+
+  @Test func `an all-NULL CTE column with no outer union yields NULL`() throws {
+    // The marker changes only UNIFICATION, never the reported concrete type: a
+    // top-level select over the all-NULL CTE column runs and yields the NULL,
+    // exactly as before.
+    let rows = try statement("""
+        WITH t (x) AS (SELECT NULLIF(1, 1) UNION SELECT NULLIF('b', 'b'))
+          SELECT x FROM t
+        """, engineFamily())
+    #expect(rows == [[.null]])
+  }
+
+  @Test func `an all-NULL CTE column filters through IS NULL`() throws {
+    // `x` is NULL, so `x IS NULL` is TRUE and keeps the row.
+    let rows = try statement("""
+        WITH t (x) AS (SELECT NULLIF(1, 1) UNION SELECT NULLIF('b', 'b'))
+          SELECT x FROM t WHERE x IS NULL
+        """, engineFamily())
+    #expect(rows == [[.null]])
+  }
+
+  @Test func `an all-NULL CTE column compared to a value drops the row`() throws {
+    // `NULL = 'c'` is UNKNOWN under three-valued logic, so the row is filtered
+    // and the result is empty.
+    let rows = try statement("""
+        WITH t (x) AS (SELECT NULLIF(1, 1) UNION SELECT NULLIF('b', 'b'))
+          SELECT x FROM t WHERE x = 'c'
+        """, engineFamily())
+    #expect(rows.isEmpty)
+  }
+
+  @Test func `a recursive CTE with mismatched arm widths faults cleanly`() throws {
+    // The anchor projects two columns and the recursive arm one, so the fold
+    // that unifies them column-wise must FAULT the column-count mismatch rather
+    // than trap indexing the shorter arm.
+    #expect(throws: SQLError.columns(expected: 2, got: 1)) {
+      _ = try statement("""
+          WITH RECURSIVE t (a, b) AS (SELECT 1, 2 UNION SELECT Id FROM t)
+            SELECT * FROM t
+          """, engineFamily())
+    }
+  }
+
+  @Test func `a CTE whose body is narrower than its declared list faults`() throws {
+    // The declared list names two columns and the body projects one, so the CTE
+    // faults the declared-arity mismatch cleanly — never binding a narrow body
+    // under the wider list to trap a later reader. The width check reports the
+    // compiled body width against the declared list count.
+    #expect(throws: SQLError.columns(expected: 1, got: 2)) {
+      _ = try statement("""
+          WITH t (a, b) AS (SELECT 1) SELECT a FROM t
+          """, engineFamily())
+    }
+  }
+
+  @Test func `a recursive CTE with an all-NULL anchor unifies its recursive arm`()
+      throws {
+    // The reviewer's anchor-NULL case. The anchor `SELECT NULLIF(1, 1)` folds
+    // to a CONSTANT NULL, so the CTE column `x` is UNCONSTRAINED: the recursive
+    // arm — itself a set operation `SELECT x FROM t INTERSECT SELECT 'c'` — must
+    // fold the self column against the text `'c'` WITHOUT faulting integer
+    // against text, exactly as a bare constant-NULL arm unifies with any typed
+    // arm. Because the schema-only self and the run-iteration self bind through
+    // the SAME body-derived carrier, both carry the unconstrained mask and
+    // cannot diverge. The recursive arm intersects the NULL row against `'c'`
+    // (no match), so the fixpoint terminates at the anchor's single NULL row.
+    let rows = try statement("""
+        WITH RECURSIVE t (x) AS (
+          SELECT NULLIF(1, 1) UNION SELECT x FROM t INTERSECT SELECT 'c'
+        ) SELECT x FROM t
+        """, engineFamily())
+    #expect(rows == [[.null]])
   }
 }

--- a/Tests/SQLTests/Schema/OutputSchemaTests.swift
+++ b/Tests/SQLTests/Schema/OutputSchemaTests.swift
@@ -227,6 +227,72 @@ struct OutputSchemaTests {
     }
   }
 
+  @Test func `a UNION widens a mixed integer/double column to double`() throws {
+    // ISO unifies the result column type across the arms — an `integer` arm and
+    // a `double` arm widen to `double` (the name still the first arm's).
+    let columns = try schema("SELECT 1 UNION SELECT 2.5")
+    #expect(columns.count == 1)
+    #expect(columns[0] == ("column 1", .double))
+  }
+
+  @Test func `a chained UNION widens across every arm`() throws {
+    // A left-associative 3-arm chain folds its types pairwise, so a `double`
+    // tail widens the whole column even where the leading arms are `integer`.
+    let columns = try schema("SELECT 1 UNION SELECT 2 UNION SELECT 3.5")
+    #expect(columns.count == 1)
+    #expect(columns[0] == ("column 1", .double))
+  }
+
+  @Test func `a UNION of irreconcilable column types faults`() throws {
+    // A text arm beside a number has no common type, so the fold faults
+    // `SQLError.operand` (SQLSTATE 42804) rather than typing off the first arm.
+    #expect(throws: SQLError.self) {
+      try catalog().columns(of: parse(query: "SELECT 1 UNION SELECT 'x'"))
+    }
+    #expect(throws: SQLError.self) {
+      try catalog().columns(of: parse(query: "SELECT TRUE UNION SELECT 1"))
+    }
+  }
+
+  @Test func `a constant-NULL arm does not veto the unified type`() throws {
+    // A column that folds to a constant NULL in an arm constrains nothing (a
+    // NULL unifies with any typed arm), mirroring COALESCE's constant-NULL
+    // skip, so the OTHER arm's type wins — a `NULLIF(2, 2)` (constant NULL) arm
+    // beside a `double` arm types the column `double`, not the NULLIF arm's
+    // `integer`.
+    let leading = try schema("SELECT NULLIF(2, 2) UNION SELECT 2.5")
+    #expect(leading.count == 1)
+    #expect(leading[0].1 == .double)
+    // A typed arm beside a trailing constant-NULL arm keeps the typed arm's
+    // type.
+    let trailing = try schema("SELECT 1 UNION SELECT NULLIF(2, 2)")
+    #expect(trailing.count == 1)
+    #expect(trailing[0].1 == .integer)
+  }
+
+  @Test func `a UNION nested in a subquery widens its column`() throws {
+    // The set operation runs through the `.setop` Plan node here (a derived
+    // table), which carries its unified `types` from compile — the outer
+    // `SELECT *` reports the widened `double` column.
+    let columns =
+        try schema("SELECT * FROM (SELECT 1 UNION SELECT 2.5) AS d")
+    #expect(columns.count == 1)
+    #expect(columns[0].1 == .double)
+  }
+
+  @Test func `a column list over a UNION body names and widens the column`()
+      throws {
+    // The crossover of the two ISO features: the `UNION` body's type fold
+    // widens the mixed integer/double column to `double` (set-op unification),
+    // and the `AS d(a)` list positionally renames it `a` (the explicit output
+    // column list). The rename applies AFTER the fold determines the column
+    // count and type, so the column is BOTH named `a` and typed `double`.
+    let columns =
+        try schema("SELECT d.a FROM (SELECT 1 UNION SELECT 2.5) AS d(a)")
+    #expect(columns.count == 1)
+    #expect(columns[0] == ("a", .double))
+  }
+
   @Test func `a view resolves against its registered columns`() throws {
     let definition = try View(query: {
       guard case let .select(query) =
@@ -513,22 +579,26 @@ struct OutputSchemaTests {
     // bodies consistent, so the declared list is TRUSTED without compiling the
     // body. The same arity-mismatched `WITH` that faults when validating
     // reports its one declared column here — the empty/data-dependent header
-    // path a successful run fills in.
+    // path a successful run fills in. The column takes the body's DERIVED type
+    // (`People.Name` is text under the renamed `a`), never the `.integer`
+    // placeholder.
     let statement = try Statement(parsing:
         "WITH t(a) AS (SELECT * FROM People) SELECT * FROM t")
     let columns = try catalog().columns(of: statement, validate: false)
-    #expect(same(columns.map { ($0.name, $0.type) }, [("a", .integer)]))
+    #expect(same(columns.map { ($0.name, $0.type) }, [("a", .text)]))
   }
 
   @Test func `a well-formed WITH validates and derives its trailing schema`() throws {
     // A CTE whose declared arity matches its body validates cleanly and derives
     // the trailing query's schema — the body compiled, its width confirmed
-    // against the declared list, and its reachable operands type-checked.
+    // against the declared list, and its reachable operands type-checked. The
+    // columns take the body's DERIVED types (`People` is text, integer under
+    // the renamed `a`, `b`), never the `.integer` placeholder.
     let statement = try Statement(parsing:
         "WITH t(a, b) AS (SELECT * FROM People) SELECT a, b FROM t")
     let columns = try catalog().columns(of: statement, validate: true)
     #expect(same(columns.map { ($0.name, $0.type) },
-                 [("a", .integer), ("b", .integer)]))
+                 [("a", .text), ("b", .integer)]))
   }
 
   @Test func `a non-recursive CTE body cannot see its own schema-only self`() throws {
@@ -551,12 +621,14 @@ struct OutputSchemaTests {
     // relation (two columns), matching its declared arity; the trailing query
     // then reads the CTE's one declared column `x`. Were the CTE's own self
     // bound in its body, the body would read the CTE (one column) and its arity
-    // would contradict the declared two-column list.
+    // would contradict the declared two-column list. The columns take the
+    // body's DERIVED types (the base `People` is text, integer under the
+    // renamed `a`, `b`), never the `.integer` placeholder.
     let statement = try Statement(parsing:
         "WITH People(a, b) AS (SELECT * FROM People) SELECT a, b FROM People")
     let columns = try catalog().columns(of: statement, validate: true)
     #expect(same(columns.map { ($0.name, $0.type) },
-                 [("a", .integer), ("b", .integer)]))
+                 [("a", .text), ("b", .integer)]))
   }
 
   @Test func `a WITH with a duplicate CTE name faults with redefinition`() throws {


### PR DESCRIPTION
A UNION/INTERSECT/EXCEPT typed its result column off the FIRST arm alone and coerced no values, so `SELECT 1 UNION SELECT 2.5` yielded an integer-typed `[1, 2.5]`. ISO requires the result column type be the COMMON type across every arm, with each arm's values coerced to it — a `double` column `[1.0, 2.5]`.

Derive the result column types by folding `ValueType.unified` across the set-operation tree column-wise (names still from the first arm), faulting `SQLError.operand` (42804) on an irreconcilable pair and skipping a constant-NULL arm as COALESCE does. Coerce each arm's values to the unified types at every producer path: the top-level run, the `.setop` plan node (which now carries the compile-time `types`), the view per-arm path, and the recursive-CTE fixpoint (row-level coercion, plan tree untouched). `Value.coerced` is a no-op except integer→double, so a homogeneous set operation is byte-identical.

Redirect every derived-schema site — the query/statement/WITH/view/ derived-table/scalar-subquery type derives — to the fold. Update the mixed-numeric UNION/CTE tests whose premises assumed first-arm typing.

Compose with the ISO explicit output column list (`AS d(a, b)`): the across-arm type fold determines the column count and types, then the positional `Schema.renamed` list overrides the NAMES on it, at the derived-table `materialise` and view schema-derive seams. A renamed derived table over a mixed-type set-op body thus takes the list's names and the unified types — `SELECT d.a FROM (SELECT 1 UNION SELECT 2.5) AS d(a)` names the column `a`, types it `double`, and yields `[1.0], [2.5]`.