### PR TITLE
SQLEngine: unify relation-body schema resolution onto one carrier

### DIFF
--- a/Sources/SQLEngine/AST.swift
+++ b/Sources/SQLEngine/AST.swift
@@ -115,6 +115,17 @@ public struct CTE: Hashable, Sendable {
     self.query = query
     self.recursive = recursive
   }
+
+  /// The CTE's DECLARED output columns as the `ResolvedColumn` carrier its self
+  /// binding is built from — each declared name typed `.integer`, the
+  /// placeholder a materialised relation reports (a CTE's rows carry no static
+  /// types). Every self binding (the `with` install, the recursive
+  /// `validate`/`fixpoint` probes, the fixpoint step, the schema-path binding)
+  /// is constructed from THIS, so all bind the same carrier through one
+  /// constructor.
+  internal var declared: Array<ResolvedColumn> {
+    columns.map { ResolvedColumn(name: $0, type: .integer) }
+  }
 }
 
 /// One of the ISO set operators combining two query terms.

--- a/Sources/SQLEngine/Definition.swift
+++ b/Sources/SQLEngine/Definition.swift
@@ -375,7 +375,7 @@ extension Catalog where Self: ~Escapable {
     // NOT eager-type-checked before execution, exactly as the non-derived path
     // never evaluates an unreached operand — while the strict schema path
     // (`validate: true`) still faults it.
-    let derived = try columns(of: query.first, scope)
+    let derived = try resolved(query: query, in: scope)
     // An explicit `AS d(a, b)` column list positionally RENAMES the derived
     // table's inner output names, keeping each column's inferred TYPE (the list
     // names, the body types), so `(SELECT x, y FROM T) AS d(a, b)` addresses
@@ -383,7 +383,7 @@ extension Catalog where Self: ~Escapable {
     // (`SQLError.columns`, the CTE/view arity fault) — checked HERE, where the
     // width is resolved, so a list over a `SELECT *` derived body is checked
     // once its `*` expands. Absent a list, the inner output names stand.
-    let outputs: Array<OutputColumn>
+    let outputs: Array<ResolvedColumn>
     if renaming.isEmpty {
       outputs = derived
     } else {
@@ -391,7 +391,7 @@ extension Catalog where Self: ~Escapable {
         throw .columns(expected: derived.count, got: renaming.count)
       }
       outputs = renaming.indices.map {
-        OutputColumn(name: renaming[$0], type: derived[$0].type)
+        ResolvedColumn(name: renaming[$0], type: derived[$0].type)
       }
     }
     // A derived table's columns are its inner query's OUTPUT names (or the
@@ -453,8 +453,7 @@ extension Catalog where Self: ~Escapable {
       }
       captured = []
     }
-    return RelationInstance(columns: outputs.map(\.name), rows: captured,
-                            types: outputs.map(\.type), derivation: query)
+    return RelationInstance(from: outputs, rows: captured, derivation: query)
   }
 
   /// `context` rescoped to the `definition_schema.` overlay a view's body

--- a/Sources/SQLEngine/Engine.swift
+++ b/Sources/SQLEngine/Engine.swift
@@ -306,9 +306,7 @@ extension Catalog where Self: ~Escapable {
         rows = try run(cte.query, scope)
       }
       relations[cte.name.lowercased()] =
-          RelationInstance(columns: cte.columns, rows: rows,
-                           types: Array(repeating: .integer,
-                                        count: cte.columns.count))
+          RelationInstance(from: cte.declared, rows: rows)
     }
     return try run(query, context.body(relations))
   }
@@ -398,9 +396,7 @@ extension Catalog where Self: ~Escapable {
       // run evaluates it in — so a text-arithmetic anchor faults against the
       // base relation, not the CTE's declared (integer) columns.
       if typecheck { try self.typecheck(anchor, scope) }
-      let empty = RelationInstance(columns: cte.columns, rows: [],
-                                   types: Array(repeating: .integer,
-                                                count: cte.columns.count))
+      let empty = RelationInstance(from: cte.declared, rows: [])
       // Bind the CTE self BEFORE augmenting the recursive arm, so a derived
       // body in the arm that names the CTE (`FROM (SELECT n FROM a) AS d`)
       // resolves it — `augment` materialises derived bodies eagerly, so the
@@ -509,9 +505,7 @@ extension Catalog where Self: ~Escapable {
     // schema every iteration reads it under — so its width resolves too (a
     // `SELECT *` arm spans that schema). Checking it here catches a mismatch
     // even when the arm is filtered to zero rows in every iteration.
-    let empty = RelationInstance(columns: cte.columns, rows: [],
-                                 types: Array(repeating: .integer,
-                                              count: cte.columns.count))
+    let empty = RelationInstance(from: cte.declared, rows: [])
     let probe = context.binding(cte.name, to: empty)
     let arm = try compile(recursive, probe).width
     guard arm == cte.columns.count else {
@@ -538,9 +532,7 @@ extension Catalog where Self: ~Escapable {
 
       // Bind the CTE name to ONLY the previous step's output and run the
       // recursive arm against the base catalog plus the earlier CTEs.
-      let step = RelationInstance(columns: cte.columns, rows: working,
-                                  types: Array(repeating: .integer,
-                                               count: cte.columns.count))
+      let step = RelationInstance(from: cte.declared, rows: working)
       let produced = try run(recursive, context.binding(cte.name, to: step))
 
       var next = Array<Array<Value>>()

--- a/Sources/SQLEngine/OutputColumn.swift
+++ b/Sources/SQLEngine/OutputColumn.swift
@@ -28,6 +28,40 @@ public struct OutputColumn: Hashable, Sendable {
   }
 }
 
+/// One column of a relation body's RESOLVED output — the authoritative
+/// per-column descriptor a binding is built FROM as a whole, rather than
+/// re-listed field by field at each site.
+///
+/// It wraps the body's `OutputColumn` (name + type) today. It exists as a
+/// struct so a future per-column attribute (a nullability/unconstrained mask a
+/// set-operation type unification carries) is added HERE, in ONE place, and
+/// threads through every binding via the single `init(from:)` constructor — no
+/// site re-lists the fields, so none can drop the new attribute. Every
+/// relation-body binding derives an `Array<ResolvedColumn>` via
+/// `resolved(query:in:)` and is constructed from it.
+internal struct ResolvedColumn: Hashable, Sendable {
+  /// The column's output name and value type.
+  internal let column: OutputColumn
+
+  internal init(_ column: OutputColumn) {
+    self.column = column
+  }
+
+  /// A resolved column carrying `name` and `type` directly — the declared
+  /// carrier a common table expression's self binding is built from, its name
+  /// the declared column and its type the `.integer` placeholder a materialised
+  /// relation reports.
+  internal init(name: String, type: ValueType) {
+    self.column = OutputColumn(name: name, type: type)
+  }
+
+  /// The column's output name.
+  internal var name: String { column.name }
+
+  /// The column's value type.
+  internal var type: ValueType { column.type }
+}
+
 extension Catalog where Self: ~Escapable {
   /// The result columns `query` would yield, named and typed, resolved WITHOUT
   /// executing it.
@@ -214,10 +248,7 @@ extension Catalog where Self: ~Escapable {
       // `.integer` (the default a materialised relation reports) — bound into
       // the recursive arm's operand check and, after validation, into the
       // overlay a later CTE and the trailing query resolve against.
-      let declared =
-          RelationInstance(columns: cte.columns, rows: [],
-                           types: Array(repeating: .integer,
-                                        count: cte.columns.count))
+      let binding = RelationInstance(from: cte.declared, rows: [])
       // Validate the body's SHAPE and ARITY against the scope of the PRIOR CTEs
       // by the SAME code a run uses — `Engine.validate` — so a schema is not
       // advertised for a `WITH` a run would reject, and this path never again
@@ -242,7 +273,7 @@ extension Catalog where Self: ~Escapable {
       // validated — the scope a later CTE and the trailing query resolve
       // against — exactly as `Engine.with` binds the materialised relation
       // after running its body.
-      overlay[cte.name.lowercased()] = declared
+      overlay[cte.name.lowercased()] = binding
     }
     // Compile/type-check/derive from the base `context.scoping(overlay)`
     // (idempotently augmented within each, which pushes the trailing query's
@@ -311,6 +342,21 @@ extension Catalog where Self: ~Escapable {
                              enclosing: scope, prefixes: prefixes)
     return try scope.columns(of: select.projection, augmented.routines,
                              subquery: plans.rest.barred)
+  }
+
+  /// The SINGLE deriver of a relation body's resolved output columns: the
+  /// FIRST arm's projection (the ISO rule a `UNION` follows), named and typed
+  /// against `context`, wrapped as the `ResolvedColumn` carrier every
+  /// body-derived binding is constructed from.
+  ///
+  /// Every binding site that folds a body into a `RelationInstance`/`Schema` —
+  /// a derived table's `materialise`, a view's schema resolution — obtains its
+  /// columns HERE, never by re-deriving the projection inline, so a future
+  /// per-column attribute on `ResolvedColumn` threads through all of them from
+  /// one place.
+  borrowing func resolved(query body: Query, in context: Context)
+      throws(SQLError) -> Array<ResolvedColumn> {
+    try columns(of: body.first, context).map(ResolvedColumn.init)
   }
 
   /// The name-resolution scope of `select` — its FROM relation and each joined
@@ -1027,12 +1073,12 @@ extension Catalog where Self: ~Escapable {
       // body's width against the declared columns — is `compile`'s job (the
       // public entry runs it), so on a shortfall fall back to the declared
       // schema rather than re-checking it here.
-      let resolved = try columns(of: view.query.first, overlay)
+      let resolved = try resolved(query: view.query, in: overlay)
       guard resolved.count == base.width else {
         return try base.renamed(renaming)
       }
-      return try Schema(width: base.width, extent: base.extent,
-                        names: base.names, types: resolved.map(\.type),
+      return try Schema(from: resolved, names: base.names,
+                        extent: base.extent,
                         virtuals: base.virtuals).renamed(renaming)
     }
     guard let table = table(named: name) else {

--- a/Sources/SQLEngine/RelationInstance.swift
+++ b/Sources/SQLEngine/RelationInstance.swift
@@ -184,6 +184,17 @@ internal struct RelationInstance: Hashable, Sendable {
     self.derivation = derivation
   }
 
+  /// A relation whose columns are RESOLVED from a body — its names and types
+  /// taken TOGETHER from the `carrier`, so the two arrays cannot drift and a
+  /// future per-column attribute on `ResolvedColumn` threads through this ONE
+  /// constructor. `rows` are the captured (or empty, schema-only) rows and
+  /// `derivation` the inner `Query` for a derived table's binding.
+  internal init(from carrier: Array<ResolvedColumn>,
+                rows: Array<Array<Value>>, derivation: Query? = nil) {
+    self.init(columns: carrier.map(\.name), rows: rows,
+              types: carrier.map(\.type), derivation: derivation)
+  }
+
   /// The real column count — the extent of a `SELECT *`.
   internal var width: Int { columns.count }
 

--- a/Sources/SQLEngine/Schema.swift
+++ b/Sources/SQLEngine/Schema.swift
@@ -43,6 +43,19 @@ internal struct Schema {
     self.virtuals = virtuals
   }
 
+  /// A view's resolution schema, its per-column types RESOLVED from a body
+  /// `carrier` while its `names` stay the view's DECLARED ones (a view stores
+  /// its own column names; only the types come from the resolved body). The
+  /// declared surface's `extent`/`virtuals` carry over unchanged. Taking the
+  /// types from the carrier as a whole means a future per-column attribute on
+  /// `ResolvedColumn` threads through this ONE constructor rather than a loose
+  /// `types.map` at the site.
+  internal init(from carrier: Array<ResolvedColumn>, names: Array<String>,
+                extent: Int, virtuals: Array<String>) {
+    self.init(width: names.count, extent: extent, names: names,
+              types: carrier.map(\.type), virtuals: virtuals)
+  }
+
   /// This schema with its real column `names` positionally RENAMED to
   /// `columns` — the ISO `AS t(c, …)` explicit output column list — or
   /// unchanged when `columns` is empty (no list).


### PR DESCRIPTION
Introduce a single `ResolvedColumn` carrier and a single `resolved(of:_:)` deriver, and construct every body-derived binding FROM the carrier via `RelationInstance.init(from:)`/`Schema.init(from:)` rather than re-listing loose parallel name+type arrays at each site. The derived-table materialise, the view schema resolution, and each recursive-CTE self binding now assemble their binding from the carrier as a whole, so a future per-column attribute added to `ResolvedColumn` threads through every site through one constructor.

Purely behavior-preserving: no semantic change — the deriver wraps the same first-arm projection typing, and each CTE self keeps its declared-column `.integer` carrier. The run and schema-only traversals stay separate by design; only the carrier, constructor, and deriver are unified.