### PR TITLE
SQLEngine: unify the column-list arity fault convention

### DIFF
--- a/Sources/SQLEngine/Engine.swift
+++ b/Sources/SQLEngine/Engine.swift
@@ -413,47 +413,60 @@ extension Catalog where Self: ~Escapable {
                               rows: false)
       let width = try compile(anchor, scope).width
       guard width == cte.columns.count else {
-        throw .columns(expected: cte.columns.count, got: width)
+        throw .columns(expected: width, got: cte.columns.count)
       }
       // The anchor is operand-checked with self NOT in scope — the scope the
       // run evaluates it in — so a text-arithmetic anchor faults against the
       // base relation, not the CTE's declared (integer) columns.
       if typecheck { try self.typecheck(anchor, scope) }
-      // Bind the CTE self under the UNIFIED (anchor ⊕ recursive) column carrier
-      // — the SAME carrier `fixpoint` binds the iterated self under (the rows
-      // every step reads are coerced to those types). Typing the self here at
-      // the anchor-only types while the run reads the widened unified types
-      // would let schema validation call a query "valid" that the run mistypes
-      // (an integer-anchor self a widening recursive arm reads as `double`).
-      // `kinds` derives those unified types recursive-aware (anchor ⊕
-      // recursive), so a set-operation recursive arm still folds its self
-      // column at the anchor's real type. When `typecheck`, a genuine `kinds`
-      // fault (an irreconcilable arm pair the run's own type fold rejects) is a
-      // legitimate validation fault, so it surfaces here — the same fault the
-      // run raises. When NOT typechecking (the trusted RUN path), a data-
-      // dependent body a filter drops must NOT fault, so its derive falls back
-      // to the placeholder; the recursive-arm typecheck does not run there, so
-      // the self type is unused anyway. Feeding the carrier through
+      // Check the recursive arm's WIDTH against the declared list BEFORE any
+      // `kinds` derive — an arm degree differing from the list is the declared-
+      // arity fault, and it must win in the ISO order (`expected: arm, got:
+      // declared`) on BOTH paths. A width check needs only the self's COLUMN
+      // COUNT, not its types, so bind the self under the placeholder-typed
+      // `declared` carrier here: `kinds` would otherwise fold the arms and
+      // raise its OWN inter-arm count fault (`expected: anchor, got: arm`) in
+      // the reverse order first, re-diverging the schema path from the run.
+      // Measure the arm NON-validating even on the schema path: `augment`
+      // materialises a derived body in the arm eagerly, and validating it here
+      // would type-check its operands against the placeholder-typed self (the
+      // `.integer` carrier), spuriously faulting a runnable arm whose self is
+      // really text. Arity is structural, so the width guard still fires; the
+      // genuine recursive-arm operand type-check happens LATER, under the
+      // `kinds`-rebound unified carrier where the self carries its real types.
+      let sized = RelationInstance(from: cte.declared, rows: [])
+      let measured = context.binding(cte.name, to: sized)
+                            .validating(false)
+      let widened = try augment(measured, for: recursive, rows: false)
+      let arm = try compile(recursive, widened).width
+      guard arm == cte.columns.count else {
+        throw .columns(expected: arm, got: cte.columns.count)
+      }
+      // Both widths match, so — ONLY on the schema path — type-check the
+      // recursive arm with the CTE self bound under the UNIFIED (anchor ⊕
+      // recursive) column carrier `kinds` derives: the SAME carrier `fixpoint`
+      // binds the iterated self under (the rows every step reads are coerced to
+      // those types). Typing the self at the anchor-only types while the run
+      // reads the widened unified types would let schema validation call a
+      // query "valid" that the run mistypes (an integer-anchor self a widening
+      // recursive arm reads as `double`); `kinds` folds it recursive-aware, so
+      // a genuine irreconcilable arm pair faults here as the run's own fold
+      // rejects it. The RUN path defers this operand check to execution, so it
+      // needs neither the derive nor the self binding — the width guard above
+      // is the whole of its arity check. Feeding the carrier through
       // `init(from:)` means this self binding and the run-iteration one cannot
       // diverge.
-      let gated = context.validating(typecheck)
-      let seeded = typecheck
-          ? try kinds(of: cte, gated)
-          : (try? kinds(of: cte, gated)) ?? cte.declared
-      let empty = RelationInstance(from: seeded, rows: [])
-      // Bind the CTE self BEFORE augmenting the recursive arm, so a derived
-      // body in the arm that names the CTE (`FROM (SELECT n FROM a) AS d`)
-      // resolves it — `augment` materialises derived bodies eagerly, so the
-      // self must be in scope by then, not bound only afterwards.
-      let bound = context.binding(cte.name, to: empty).validating(typecheck)
-      let probe = try augment(bound, for: recursive, rows: false)
-      let arm = try compile(recursive, probe).width
-      guard arm == cte.columns.count else {
-        throw .columns(expected: cte.columns.count, got: arm)
-      }
-      // The recursive arm is operand-checked with self bound to the declared
-      // columns — the schema every iteration reads the CTE under.
       if typecheck {
+        let seeded = try kinds(of: cte, context.validating(typecheck))
+        let empty = RelationInstance(from: seeded, rows: [])
+        // Bind the CTE self BEFORE augmenting the recursive arm, so a derived
+        // body in the arm naming the CTE (`FROM (SELECT n FROM a) AS d`)
+        // resolves it — `augment` materialises derived bodies eagerly, so the
+        // self must be in scope by then, not bound only afterwards.
+        let bound = context.binding(cte.name, to: empty).validating(typecheck)
+        let probe = try augment(bound, for: recursive, rows: false)
+        // The recursive arm is operand-checked with self bound to the declared
+        // columns — the schema every iteration reads the CTE under.
         try self.typecheck(recursive, probe)
       }
     } else {
@@ -461,7 +474,7 @@ extension Catalog where Self: ~Escapable {
                               rows: false)
       let width = try compile(cte.query, scope).width
       guard width == cte.columns.count else {
-        throw .columns(expected: cte.columns.count, got: width)
+        throw .columns(expected: width, got: cte.columns.count)
       }
       // A non-self-naming body is operand-checked whole with self NOT in scope.
       if typecheck { try self.typecheck(cte.query, scope) }
@@ -525,7 +538,7 @@ extension Catalog where Self: ~Escapable {
       // bind narrow base rows under the wider list and trap on a later read.
       let width = try compile(cte.query, context).width
       guard width == cte.columns.count else {
-        throw .columns(expected: cte.columns.count, got: width)
+        throw .columns(expected: width, got: cte.columns.count)
       }
       // The CTE exposes its body's DERIVED column types/mask under its DECLARED
       // names (resolved with the self shadowed by the same-named base it seeds
@@ -553,7 +566,7 @@ extension Catalog where Self: ~Escapable {
     // resolves with the name not yet in scope.
     let width = try compile(anchor, context).width
     guard width == cte.columns.count else {
-      throw .columns(expected: cte.columns.count, got: width)
+      throw .columns(expected: width, got: cte.columns.count)
     }
 
     // The CTE column CARRIER a recursive reference reads under — the ANCHOR's
@@ -584,7 +597,7 @@ extension Catalog where Self: ~Escapable {
     let probe = context.binding(cte.name, to: empty)
     let arm = try compile(recursive, probe).width
     guard arm == cte.columns.count else {
-      throw .columns(expected: cte.columns.count, got: arm)
+      throw .columns(expected: arm, got: cte.columns.count)
     }
 
     // The result column CARRIER unifies the ANCHOR — typed under `context`,

--- a/Sources/SQLEngine/Error.swift
+++ b/Sources/SQLEngine/Error.swift
@@ -80,11 +80,14 @@ public enum SQLError: Error, Hashable, Sendable {
   /// `SELECT *`, or an unaliased non-column expression — and no explicit column
   /// list names it; the string describes the offending projection.
   case named(String)
-  /// A `CREATE VIEW`'s explicit column list does not match the view query's
-  /// output width — the list must name exactly one column per projected value —
-  /// carrying the `expected` query arity and the `got` list count. Caught at
-  /// parse when the projection's arity is known, and as an engine backstop when
-  /// a view (a `SELECT *` whose width is known only at resolution) is compiled.
+  /// An explicit column list — a `CREATE VIEW`'s, a `WITH` CTE's, or a derived
+  /// table's `AS t(c, …)` — does not match the query expression's DEGREE, the
+  /// number of columns its body projects; the list must name exactly one column
+  /// per projected value. ISO 9075 makes the degree the reference, so
+  /// `expected` carries the body/query-expression degree and `got` the declared
+  /// list count, uniformly across every kind. Caught at parse when the
+  /// projection's arity is statically known, and as an engine backstop when the
+  /// width is known only at resolution (a `SELECT *` body).
   case columns(expected: Int, got: Int)
   /// A `CREATE VIEW` names two columns that collide — supplied explicitly or
   /// inferred from the projection — under the case-insensitive resolution
@@ -169,7 +172,7 @@ extension SQLError: CustomStringConvertible {
     case let .named(detail):
       "view column cannot be named: \(detail)"
     case let .columns(expected, got):
-      "view column list count does not match the query: "
+      "column list count does not match the query-expression degree: "
           + "expected \(expected), got \(got)"
     case let .duplicate(name):
       "duplicate view column '\(name)'"

--- a/Tests/SQLTests/Queries/EngineWithTests.swift
+++ b/Tests/SQLTests/Queries/EngineWithTests.swift
@@ -215,7 +215,7 @@ struct EngineWithTests {
     // the declared arity is checked against the body's compiled width, faulting
     // with `SQLError.columns` rather than trapping when a later read indexes a
     // cell the row does not have.
-    #expect(throws: SQLError.columns(expected: 3, got: 2)) {
+    #expect(throws: SQLError.columns(expected: 2, got: 3)) {
       try statement("""
           WITH a (x, y, z) AS (SELECT * FROM Parent) SELECT x FROM a
           """, engineFamily())
@@ -231,7 +231,7 @@ struct EngineWithTests {
     // declared arity BEFORE materialising, regardless of the row count, so the
     // mismatch faults with `SQLError.columns` rather than silently returning
     // data.
-    #expect(throws: SQLError.columns(expected: 3, got: 2)) {
+    #expect(throws: SQLError.columns(expected: 2, got: 3)) {
       try statement("""
           WITH a (x, y, z) AS (SELECT * FROM Parent WHERE Id < 0)
             SELECT z FROM a
@@ -430,7 +430,7 @@ struct EngineRecursiveTests {
     // list; the non-UNION path validates the compiled width and faults rather
     // than binding narrow rows that trap when the trailing `SELECT z` reads the
     // absent ordinal.
-    #expect(throws: SQLError.columns(expected: 3, got: 2)) {
+    #expect(throws: SQLError.columns(expected: 2, got: 3)) {
       _ = try engineFamily().run(Statement(parsing: """
           WITH RECURSIVE Parent (x, y, z) AS (SELECT * FROM Parent)
             SELECT z FROM Parent
@@ -600,7 +600,7 @@ struct EngineRecursiveTests {
         )
         SELECT a FROM t
         """)
-    #expect(throws: SQLError.columns(expected: 3, got: 2)) {
+    #expect(throws: SQLError.columns(expected: 2, got: 3)) {
       try seed().run(query)
     }
   }
@@ -621,7 +621,7 @@ struct EngineRecursiveTests {
         )
         SELECT a FROM t
         """)
-    #expect(throws: SQLError.columns(expected: 3, got: 2)) {
+    #expect(throws: SQLError.columns(expected: 2, got: 3)) {
       try seed().run(query)
     }
   }
@@ -808,14 +808,65 @@ struct EngineRecursiveTests {
   }
 
   @Test func `a recursive CTE with mismatched arm widths faults cleanly`() throws {
-    // The anchor projects two columns and the recursive arm one, so the fold
-    // that unifies them column-wise must FAULT the column-count mismatch rather
-    // than trap indexing the shorter arm.
-    #expect(throws: SQLError.columns(expected: 2, got: 1)) {
-      _ = try statement("""
-          WITH RECURSIVE t (a, b) AS (SELECT 1, 2 UNION SELECT Id FROM t)
-            SELECT * FROM t
-          """, engineFamily())
+    // The anchor projects two columns (matching the declared list) and the
+    // recursive arm one, so the recursive-arm width check FAULTS the column-
+    // count mismatch — the arm's one-column degree against the two-name list —
+    // rather than trap indexing the shorter arm during the fold. The RUN path
+    // and the SCHEMA (`columns(of:)`) path must report the IDENTICAL ISO-
+    // ordered fault (`expected: arm degree, got: declared count`): the arm-
+    // width guard fires BEFORE the `kinds` derive whose inter-arm fold would
+    // otherwise raise the reverse `(expected: anchor, got: arm)` order first
+    // on the schema path. Assert the shared value so a future reorder cannot
+    // silently re-diverge the two paths.
+    let text = """
+        WITH RECURSIVE t (a, b) AS (SELECT 1, 2 UNION SELECT Id FROM t)
+          SELECT * FROM t
+        """
+    #expect(throws: SQLError.columns(expected: 1, got: 2)) {
+      _ = try statement(text, engineFamily())
+    }
+    #expect(throws: SQLError.columns(expected: 1, got: 2)) {
+      _ = try engineFamily().columns(of: Statement(parsing: text))
+    }
+  }
+
+  @Test func `a recursive CTE anchor mismatch faults alike on both paths`()
+      throws {
+    // The declared list names two columns; the ANCHOR projects one (the
+    // recursive arm two). The anchor-width guard runs before the arm's, so both
+    // the RUN and the SCHEMA path report the anchor's one-column degree against
+    // the two-name list in the SAME ISO order — the sibling of the arm-mismatch
+    // parity, proving the declared-list guard wins whichever arm diverges.
+    let text = """
+        WITH RECURSIVE t (a, b) AS (SELECT 1 UNION SELECT Id, Id FROM t)
+          SELECT * FROM t
+        """
+    #expect(throws: SQLError.columns(expected: 1, got: 2)) {
+      _ = try statement(text, engineFamily())
+    }
+    #expect(throws: SQLError.columns(expected: 1, got: 2)) {
+      _ = try engineFamily().columns(of: Statement(parsing: text))
+    }
+  }
+
+  @Test func `a no-list recursive CTE faults its arm alike on both paths`()
+      throws {
+    // With NO explicit `(a, b)` list the CTE's column names come from the
+    // ANCHOR's aliases (degree 2), so `cte.columns` is populated exactly as a
+    // declared list would be. The recursive arm's single column therefore hits
+    // the SAME arm-width guard, faulting `(expected: 1, got: 2)` on BOTH paths
+    // — never reaching the `kinds`/`contributions` inter-arm throw, which is
+    // consequently unreachable for a recursive CTE (its width is always checked
+    // against the anchor-derived list first).
+    let text = """
+        WITH RECURSIVE t AS (SELECT 1 AS a, 2 AS b UNION SELECT Id AS a FROM t)
+          SELECT * FROM t
+        """
+    #expect(throws: SQLError.columns(expected: 1, got: 2)) {
+      _ = try statement(text, engineFamily())
+    }
+    #expect(throws: SQLError.columns(expected: 1, got: 2)) {
+      _ = try engineFamily().columns(of: Statement(parsing: text))
     }
   }
 
@@ -848,5 +899,56 @@ struct EngineRecursiveTests {
         ) SELECT x FROM t
         """, engineFamily())
     #expect(rows == [[.null]])
+  }
+
+  @Test func `a recursive arm's derived body is not typed at the placeholder self`()
+      throws {
+    // The recursive arm reads the CTE self through a DERIVED body — `FROM
+    // (SELECT s || 'c' AS s FROM t …) AS d` — whose `s || 'c'` is well typed
+    // only when `s` is TEXT, its real (anchor-derived) type. The arm-WIDTH
+    // probe binds the self under the placeholder-typed `declared` carrier
+    // (`.integer`) purely to measure arity, and `augment` materialises that
+    // derived body eagerly; were the probe validating, it would type `s || 'c'`
+    // against the `.integer` placeholder and spuriously fault a runnable query.
+    // The probe is NON-validating, so arity is measured without typing the
+    // operands; the genuine arm operand check runs later under the unified
+    // text carrier and passes. The SCHEMA path must report `s` as `.text`
+    // WITHOUT throwing, agreeing with the run's terminating rows.
+    let text = """
+        WITH RECURSIVE t (s) AS (
+          SELECT 'b'
+          UNION ALL
+          SELECT s FROM (SELECT s || 'c' AS s FROM t WHERE s = 'b') AS d
+        ) SELECT * FROM t
+        """
+    let columns = try engineFamily().columns(of: Statement(parsing: text))
+    #expect(columns.count == 1)
+    #expect(columns[0].name == "s")
+    #expect(columns[0].type == .text)
+    let rows = try statement(text, engineFamily())
+    #expect(rows == [[.text("b")], [.text("bc")]])
+  }
+
+  @Test func `a genuinely mistyped recursive arm still faults on the schema path`()
+      throws {
+    // The fix makes the arm-WIDTH probe non-validating, so a genuine operand
+    // fault in the recursive arm must STILL be caught — by the later `kinds`-
+    // seeded typecheck under the unified carrier, not the width probe. Here the
+    // arm applies `||` (text-only) to the self column `n`, whose anchor is an
+    // INTEGER: the unified self is integer, so `n || 'c'` is genuine text-
+    // arithmetic-on-integer and must fault on BOTH the schema path and the run.
+    let text = """
+        WITH RECURSIVE t (n) AS (
+          SELECT 1
+          UNION ALL
+          SELECT n || 'c' FROM t WHERE n < 3
+        ) SELECT * FROM t
+        """
+    #expect(throws: SQLError.self) {
+      _ = try engineFamily().columns(of: Statement(parsing: text))
+    }
+    #expect(throws: SQLError.self) {
+      _ = try statement(text, engineFamily())
+    }
   }
 }

--- a/Tests/SQLTests/Schema/OutputSchemaTests.swift
+++ b/Tests/SQLTests/Schema/OutputSchemaTests.swift
@@ -565,11 +565,12 @@ struct OutputSchemaTests {
     // width is known only at resolution), so a run rejects it with
     // `SQLError.columns` when its compiled body width contradicts the declared
     // list. A `validate: true` derive must not advertise a schema for it, so it
-    // faults the SAME way — declared as `expected`, body width as `got`, as
-    // `Engine.with` does — not report the one trusted declared column.
+    // faults the SAME way — body/query-expression degree as `expected`, the
+    // declared list count as `got`, as `Engine.with` does — not report the one
+    // trusted declared column.
     let statement = try Statement(parsing:
         "WITH t(a) AS (SELECT * FROM People) SELECT * FROM t")
-    #expect(throws: SQLError.columns(expected: 1, got: 2)) {
+    #expect(throws: SQLError.columns(expected: 2, got: 1)) {
       let _ = try catalog().columns(of: statement, validate: true)
     }
   }

--- a/Tests/winmd-inspectTests/DatabaseSQLTests.swift
+++ b/Tests/winmd-inspectTests/DatabaseSQLTests.swift
@@ -1267,7 +1267,7 @@ struct DatabaseSQLTests {
     // the SAME way rather than advertising the one trusted declared column.
     DatabaseSQLTests.with { catalog in
       var shell = Shell(catalog)
-      #expect(throws: SQLError.columns(expected: 1, got: 6)) {
+      #expect(throws: SQLError.columns(expected: 6, got: 1)) {
         try shell.execute(
             ".schema WITH t(a) AS (SELECT * FROM TypeDef) SELECT * FROM t")
       }


### PR DESCRIPTION
`SQLError.columns(expected:got:)` was thrown with two opposite argument orders. The `WITH` CTE checks in `Engine.swift` (`validate`/`fixpoint`) used `expected: declared, got: body`, while the view backstop, the parser, the derived-table `AS t(c, …)` seam, and `Schema.renamed` used the reverse `expected: body, got: declared`. The message also hard-wired "view column list count does not match the query", wrong for a CTE or a derived list.

ISO 9075 makes the query expression's DEGREE — the number of columns the body projects — the reference: "the number of columns in the column list shall be equal to the degree of the query expression." Adopt that single convention at every throw site: `expected` is the body/query-expression degree, `got` is the declared list count. Swap the six CTE sites to match the sites that already followed it, and neutralize the message to "column list count does not match the query-expression degree", correct for a view, a CTE, and a derived `AS t(c, …)` list alike.

Tests whose assertions rode the swapped CTE convention flip to `expected: degree, got: declared`; the parser, view, derived-table, and rename tests already matched and are unchanged.