### PR TITLE
WinMD: fold a constant-false selection into a Plan.empty node

### DIFF
--- a/Sources/SQLEngine/Engine.swift
+++ b/Sources/SQLEngine/Engine.swift
@@ -2151,6 +2151,11 @@ extension Catalog where Self: ~Escapable {
     switch plan {
     case .single:
       plan
+    case .empty:
+      // The known-empty relation is already physical — no seek, join, or source
+      // to rewrite below it — so it optimises to itself (and re-optimising a
+      // folded plan is idempotent).
+      plan
     case .scan:
       plan
     case let .derived(name, plan, ordinals, seek):
@@ -2176,11 +2181,16 @@ extension Catalog where Self: ~Escapable {
       // fewer per-row predicate. This composes with the seek and nest cases
       // below: a constant-true filter over a `.scan` or `.product` never
       // reaches them, becoming just the optimised source (a plain scan or
-      // product), not a seek over a true residual or a nest with a true gate. A
-      // constant-FALSE filter is NOT folded — there is no empty-relation Plan
-      // node, so a false filter is left filtering correctly (see the deferred
-      // empty-plan follow-up).
+      // product), not a seek over a true residual or a nest with a true gate.
       try optimise(source, context)
+    case let .select(filter, source) where filter.constant == false:
+      // A PROVABLY-always-false filter admits NO row, so the whole selection is
+      // the known-empty relation of the source's width — WHEN discarding the
+      // source suppresses no observable throw. `emptied(filter:over:)`
+      // optimises the source, then folds to `.empty` only when that source is
+      // throw-free (`Plan.safe`) and its width is known, else leaves the select
+      // filtering.
+      try emptied(filter, over: source, context)
     case let .select(filter, .scan(name, ordinals, nil)):
       try seek(filter, name, ordinals, context)
     case let .select(filter, .product(left, right)):
@@ -2243,6 +2253,33 @@ extension Catalog where Self: ~Escapable {
       // the cap itself has no seek or join to rewrite.
       try .limit(count: count, offset: offset, optimise(source, context))
     }
+  }
+
+  /// The fold of a PROVABLY constant-false `select(filter, source)` into the
+  /// known-empty relation, or the select left intact when the fold would change
+  /// more than the (already-zero) row count.
+  ///
+  /// A constant-false `filter` admits no row, so the selection's result is
+  /// empty — but executing `select(false, source)` today still runs `source`,
+  /// which may RAISE, before it filters every row out. Rewriting to `.empty`
+  /// skips `source` entirely, so it is sound ONLY when `source` raises on NO
+  /// input (`Plan.safe`) — else the fold would SUPPRESS a throw, a correctness
+  /// bug
+  /// rather than an optimisation. The source is optimised first so its safety
+  /// and width reflect the physical shape the executor would actually run (and
+  /// so its own nested folds still apply on the fall-through). `.empty` carries
+  /// the source's slot width so a downstream consumer mis-shapes nothing; a
+  /// source of unknown width (`slots` nil) is left filtering. On EITHER doubt
+  /// the select stays — a constant-false filter neither seeks nor supplies a
+  /// join key (`1 = 0` reads no slot), so no seek or nest rewrite is forgone.
+  private borrowing func emptied(_ filter: Filter, over source: Plan,
+                                 _ context: Context)
+      throws(SQLError) -> Plan {
+    let source = try optimise(source, context)
+    guard source.safe, let slots = source.slots else {
+      return .select(filter, source)
+    }
+    return .empty(slots: slots)
   }
 
   /// Optimises a VIEW body's sub-`plan` for the view named `name`, resolving
@@ -2589,7 +2626,10 @@ extension Catalog where Self: ~Escapable {
   internal borrowing func decorrelate(_ plan: Plan, _ context: Context)
       throws(SQLError) -> Plan {
     switch plan {
-    case .single, .scan, .join:
+    // `.empty` is produced only by `optimise`, which runs AFTER decorrelation,
+    // so a plan reaching here never carries one; the arm is a structural
+    // no-op keeping the switch exhaustive.
+    case .single, .empty, .scan, .join:
       return plan
     case let .derived(name, plan, ordinals, seek):
       // A view body is compiled and re-executed under its OWN scope; its
@@ -3289,7 +3329,9 @@ extension Plan {
   /// `select`s the seek and nest rewrites match.
   internal func pushdown() throws(SQLError) -> Plan {
     switch self {
-    case .single, .scan, .join:
+    // Pushdown runs BEFORE optimise, the only producer of `.empty`, so a plan
+    // reaching here never carries one; the arm keeps the switch exhaustive.
+    case .single, .empty, .scan, .join:
       self
     case let .derived(name, sub, ordinals, seek):
       try .derived(name: name, plan: sub.pushdown(), ordinals: ordinals,

--- a/Sources/SQLEngine/Operator.swift
+++ b/Sources/SQLEngine/Operator.swift
@@ -118,6 +118,15 @@ internal indirect enum Plan {
   /// record (no slots), the row a scalar projection (`SELECT 1 + 1`) computes
   /// its expressions against.
   case single
+  /// The KNOWN-EMPTY relation of `slots` columns: it yields ZERO records over
+  /// exactly that combined slot width, the shape the optimiser rewrites a
+  /// PROVABLY constant-false selection into (a `WHERE 1 = 0` admits no row).
+  /// `slots` is the width of the subtree the empty replaced, so a downstream
+  /// consumer that reads a side's width (`Plan.slots`, the outer/semijoin
+  /// NULL-extension) mis-shapes nothing — the schema is preserved, only the
+  /// rows are gone. An aggregate over it still yields its degenerate one row
+  /// (`COUNT(*)` `0`), since the empty sits BELOW the aggregate as its source.
+  case empty(slots: Int)
   /// A leaf over the relation `name`: its `ordinals` (defining its slots), over
   /// the seek's row range when present (else the whole relation).
   case scan(name: String, ordinals: Array<Int>, seek: Range<Int>?)
@@ -271,6 +280,11 @@ extension Plan {
   /// declared `columns` so the view never claims a width its rows lack.
   internal var width: Int {
     switch self {
+    case let .empty(slots):
+      // The known-empty relation advertises the width of the subtree it
+      // replaced, so a view sub-plan measuring a data-empty body reads its true
+      // column count rather than the `select`'s conservative zero.
+      slots
     case let .project(terms, _):
       terms.count
     case let .setop(_, left, _, _, _, _):
@@ -309,6 +323,11 @@ extension Plan {
       // The single empty row has no slots — a FROM-less projection reads only
       // constants and calls over them, never a slot of this row.
       0
+    case let .empty(slots):
+      // The known-empty relation spans exactly the slots of the subtree it
+      // replaced — it drops the rows, never the schema — so a downstream join's
+      // NULL-extension width and a product's slot boundary stay correct.
+      slots
     case let .scan(_, ordinals, _):
       ordinals.count
     case let .derived(_, _, ordinals, _):
@@ -375,6 +394,57 @@ extension Plan {
     guard let limit else { return self }
     return .limit(count: limit.count, offset: limit.offset, self)
   }
+
+  /// Whether EXECUTING this plan cannot throw — the throw-freedom the optimiser
+  /// needs before it may rewrite a constant-false `select` OVER this plan into
+  /// `.empty`, discarding the plan unexecuted. Executing `select(false, child)`
+  /// today runs `child` (which may raise — a throwing scalar term, a `SUM`
+  /// overflow, a subquery fault) and only then filters every row out; folding
+  /// to `.empty` SKIPS `child`, so it is sound ONLY when `child` raises on NO
+  /// input, i.e. is `safe`. This is the plan-level analogue of
+  /// `Filter.safe`/`Term.safe` and is deliberately CONSERVATIVE: a shape whose
+  /// throw-freedom is not certain (a `derived` view body, any
+  /// join/apply/aggregate) reports `false`, so the fold is merely MISSED —
+  /// never unsound. Under-folding costs a per-row
+  /// predicate; over-folding would suppress a raise, so doubt resolves to
+  /// `false`.
+  internal var safe: Bool {
+    switch self {
+    case .single, .empty:
+      // A single empty row and the known-empty relation both yield their rows
+      // without evaluating anything — neither can raise.
+      true
+    case .scan:
+      // A scan reads cells and never evaluates an expression, so materialising
+      // it cannot raise; a compiled plan's scan name is already resolved.
+      true
+    case let .select(filter, source):
+      // The per-row predicate and everything below it must be throw-free.
+      filter.safe && source.safe
+    case let .project(terms, source):
+      // Every projected term is evaluated per row, so all must be safe.
+      terms.allSatisfy(\.safe) && source.safe
+    case let .sort(keys, source):
+      // Each sort key's term is evaluated per row before the comparison.
+      keys.allSatisfy { $0.term.safe } && source.safe
+    case let .product(left, right):
+      left.safe && right.safe
+    case let .setop(_, left, right, _, _, _):
+      // Combining rows never raises, so it is safe when its arms are.
+      left.safe && right.safe
+    case let .distinct(source):
+      source.safe
+    case let .limit(_, _, source):
+      source.safe
+    // A `derived` view body runs an arbitrary sub-plan (and augments/validates
+    // its schema); a `join`/`outer`/`semijoin`/`apply` evaluates an `on`,
+    // seeks, or re-executes a correlated body; an `aggregate` may overflow a
+    // `SUM` or type-fault a `MIN`/`MAX`. None is PROVABLY throw-free here, so
+    // each reports `false` — the fold is missed, never unsound.
+    case .derived, .join, .outer, .semijoin, .apply, .aggregate:
+      false
+    }
+  }
 }
 
 // MARK: - Interpreter
@@ -402,6 +472,12 @@ extension Catalog where Self: ~Escapable {
       // The FROM-less single row: one record with no cells, the source a scalar
       // projection evaluates its constant/call expressions against.
       return [Record([])]
+    case .empty:
+      // The known-empty relation yields NO records — the optimiser proved its
+      // constant-false guard admits none — so nothing above it (a project, an
+      // aggregate, a join) ever sees a row, and its skipped subtree stays
+      // unrun.
+      return []
     case let .scan(name, ordinals, seek):
       return try materialise(name, ordinals, seek, context.relations)
     case let .derived(name, source, ordinals, seek):

--- a/Tests/SQLTests/Expressions/LikeTests.swift
+++ b/Tests/SQLTests/Expressions/LikeTests.swift
@@ -254,7 +254,7 @@ private func seeks(_ plan: Plan) -> Bool {
   case let .semijoin(left, right, _, _): seeks(left) || seeks(right)
   case let .apply(left, _, _, _, _, _): seeks(left)
   case let .setop(_, left, right, _, _, _): seeks(left) || seeks(right)
-  case .single: false
+  case .single, .empty: false
   }
 }
 
@@ -275,7 +275,7 @@ private func joins(_ plan: Plan) -> Bool {
   case let .semijoin(left, right, _, _): joins(left) || joins(right)
   case let .apply(left, _, _, _, _, _): joins(left)
   case let .setop(_, left, right, _, _, _): joins(left) || joins(right)
-  case .single, .scan: false
+  case .single, .empty, .scan: false
   }
 }
 
@@ -298,7 +298,7 @@ private func residual(_ plan: Plan) -> Bool {
   case let .semijoin(left, right, _, _): residual(left) || residual(right)
   case let .apply(left, _, _, _, _, _): residual(left)
   case let .setop(_, left, right, _, _, _): residual(left) || residual(right)
-  case .single, .scan: false
+  case .single, .empty, .scan: false
   }
 }
 

--- a/Tests/SQLTests/Optimisation/ConstantFoldTests.swift
+++ b/Tests/SQLTests/Optimisation/ConstantFoldTests.swift
@@ -78,6 +78,45 @@ private func selects(_ plan: Plan) -> Bool {
     selects(left)
   case let .setop(_, left, right, _, _, _):
     selects(left) || selects(right)
+  case .single, .empty, .scan:
+    false
+  }
+}
+
+/// Whether `plan` reaches ANY `.empty` node — the known-empty relation the
+/// optimiser folds a PROVABLY constant-false selection into. Mirrors `selects`,
+/// recursing every operator so a fold nested under a project/aggregate/set-op
+/// is still found.
+private func empties(_ plan: Plan) -> Bool {
+  switch plan {
+  case .empty:
+    true
+  case let .project(_, source):
+    empties(source)
+  case let .sort(_, source):
+    empties(source)
+  case let .limit(_, _, source):
+    empties(source)
+  case let .distinct(source):
+    empties(source)
+  case let .derived(_, sub, _, _):
+    empties(sub)
+  case let .aggregate(_, _, source):
+    empties(source)
+  case let .select(_, source):
+    empties(source)
+  case let .product(left, right):
+    empties(left) || empties(right)
+  case let .outer(left, right, _, _):
+    empties(left) || empties(right)
+  case let .semijoin(left, right, _, _):
+    empties(left) || empties(right)
+  case let .join(source, _, _, _, _, _, _):
+    empties(source)
+  case let .apply(left, _, _, _, _, _):
+    empties(left)
+  case let .setop(_, left, right, _, _, _):
+    empties(left) || empties(right)
   case .single, .scan:
     false
   }
@@ -186,9 +225,79 @@ struct ConstantSelectFoldTests {
   }
 
   @Test func `WHERE 1 = 0 still returns no rows`() throws {
-    // A constant-FALSE filter is left filtering (there is no empty-relation
-    // node) and correctly rejects every row — proving false is NOT mis-folded.
+    // A constant-FALSE filter admits no row: whether folded to `.empty` (a safe
+    // scan source) or left filtering (an unsafe one), the result is no rows.
     try numbers().empty("SELECT Id FROM N WHERE 1 = 0")
+  }
+
+  @Test func `WHERE 1 = 0 over a safe scan folds to empty`() throws {
+    // Plan-shape proof: the constant-false select over a throw-free scan is
+    // rewritten to the known-empty relation — no per-row predicate survives.
+    let catalog = try numbers()
+    let plan = try catalog.optimise(
+        catalog.compile(parse(query: "SELECT Id FROM N WHERE 1 = 0")), [:])
+    #expect(empties(plan))
+    #expect(!selects(plan))
+  }
+
+  @Test func `a constant-false selection preserves the output width`() throws {
+    // Schema preservation: the empty relation must advertise the SAME columns
+    // as the subtree it replaced, so a two-column projection still yields
+    // two-wide (zero) rows — a downstream consumer mis-shapes nothing.
+    try numbers().empty("SELECT Id, V FROM N WHERE 1 = 0")
+  }
+
+  @Test func `a constant-false arm of a UNION keeps the other arm`() throws {
+    // One arm folds to `.empty` (its schema preserved so the set-op arity check
+    // holds); the other arm still yields its rows. The UNION is the live arm's
+    // rows alone — the empty arm contributes nothing but its (matching) shape.
+    try numbers().expect(
+        "SELECT Id FROM N WHERE 1 = 0 UNION SELECT Id FROM N ORDER BY Id",
+        equals: "SELECT Id FROM N ORDER BY Id")
+  }
+
+  @Test func `COUNT(*) over a constant-false source still yields one row`()
+      throws {
+    // The bare aggregate sits ABOVE the folded select, so its source is the
+    // `.empty` relation — and `grouped` over an empty input with no GROUP BY
+    // still emits its degenerate one row (`COUNT` `0`), the standard SQL rule.
+    // The fold must NOT collapse the aggregate itself to zero rows.
+    try numbers().expect("SELECT COUNT(*) FROM N WHERE 1 = 0", yields: [[0]])
+  }
+
+  @Test func `COUNT(*) over a constant-false source folds only the source`()
+      throws {
+    // Plan-shape proof of the above: the `.empty` is the aggregate's SOURCE,
+    // the aggregate node survives above it.
+    let catalog = try numbers()
+    let plan = try catalog.optimise(
+        catalog.compile(parse(query: "SELECT COUNT(*) FROM N WHERE 1 = 0"))
+            .pushdown(), [:])
+    #expect(empties(plan))
+  }
+
+  @Test func `a constant-false selection over a THROWING view does not fold`()
+      throws {
+    // The soundness fence. `Bad`'s body evaluates `1 / X` with `X = 0`, so
+    // executing it RAISES `.divide`. Its `.derived` plan node is NOT provably
+    // throw-free (`Plan.safe` is `false`), so the constant-false select is NOT
+    // folded to `.empty` — folding would SKIP the view body and SUPPRESS the
+    // throw. The plan keeps its select over the view, and running it surfaces
+    // the division-by-zero exactly as the un-folded query would.
+    let base = try Catalog {
+      Relation("Z", ["X": .integer]) {
+        Row(0)
+      }
+    }
+    let views = try Catalog {
+      try View("Bad", "SELECT 1 / X AS q FROM Z", as: ["q"])
+    }
+    let catalog = EngineMemory(base.catalog, views: views.registered)
+    let plan = try catalog.optimise(
+        catalog.compile(parse(query: "SELECT q FROM Bad WHERE 1 = 0"))
+            .pushdown(), [:])
+    #expect(!empties(plan))
+    catalog.expect("SELECT q FROM Bad WHERE 1 = 0", fails: .divide)
   }
 
   @Test func `WHERE NULL = 1 returns no rows (UNKNOWN rejects)`() throws {

--- a/Tests/SQLTests/Optimisation/DecorrelateTests.swift
+++ b/Tests/SQLTests/Optimisation/DecorrelateTests.swift
@@ -29,7 +29,7 @@ private func applies(_ plan: Plan) -> Bool {
   case let .product(left, right), let .outer(left, right, _, _),
        let .semijoin(left, right, _, _), let .setop(_, left, right, _, _, _):
     return applies(left) || applies(right)
-  case .single, .scan, .join:
+  case .single, .empty, .scan, .join:
     return false
   }
 }
@@ -49,7 +49,7 @@ private func joins(_ plan: Plan) -> Bool {
   case let .product(left, right), let .outer(left, right, _, _),
        let .semijoin(left, right, _, _), let .setop(_, left, right, _, _, _):
     return joins(left) || joins(right)
-  case .single, .scan, .apply:
+  case .single, .empty, .scan, .apply:
     return false
   }
 }
@@ -69,7 +69,7 @@ private func outers(_ plan: Plan) -> Bool {
   case let .product(left, right), let .semijoin(left, right, _, _),
        let .setop(_, left, right, _, _, _):
     return outers(left) || outers(right)
-  case .single, .scan, .join, .apply:
+  case .single, .empty, .scan, .join, .apply:
     return false
   }
 }
@@ -91,7 +91,7 @@ private func semijoins(_ plan: Plan) -> Bool {
   case let .product(left, right), let .outer(left, right, _, _),
        let .setop(_, left, right, _, _, _):
     return semijoins(left) || semijoins(right)
-  case .single, .scan, .join, .apply:
+  case .single, .empty, .scan, .join, .apply:
     return false
   }
 }
@@ -111,7 +111,7 @@ private func semijoins(_ plan: Plan, anti wanted: Bool) -> Bool {
   case let .product(left, right), let .outer(left, right, _, _),
        let .setop(_, left, right, _, _, _):
     return semijoins(left, anti: wanted) || semijoins(right, anti: wanted)
-  case .single, .scan, .join, .apply:
+  case .single, .empty, .scan, .join, .apply:
     return false
   }
 }
@@ -132,7 +132,7 @@ private func semijoinCount(_ plan: Plan) -> Int {
   case let .product(left, right), let .outer(left, right, _, _),
        let .setop(_, left, right, _, _, _):
     return semijoinCount(left) + semijoinCount(right)
-  case .single, .scan, .join, .apply:
+  case .single, .empty, .scan, .join, .apply:
     return 0
   }
 }
@@ -157,7 +157,7 @@ private func semijoinCount(_ plan: Plan, anti wanted: Bool) -> Int {
        let .setop(_, left, right, _, _, _):
     return semijoinCount(left, anti: wanted)
         + semijoinCount(right, anti: wanted)
-  case .single, .scan, .join, .apply:
+  case .single, .empty, .scan, .join, .apply:
     return 0
   }
 }
@@ -177,7 +177,7 @@ private func exists(in plan: Plan) -> Bool {
   case let .product(left, right), let .outer(left, right, _, _),
        let .semijoin(left, right, _, _), let .setop(_, left, right, _, _, _):
     return exists(in: left) || exists(in: right)
-  case .single, .scan, .join, .apply:
+  case .single, .empty, .scan, .join, .apply:
     return false
   }
 }
@@ -213,7 +213,7 @@ private func within(in plan: Plan) -> Bool {
   case let .product(left, right), let .outer(left, right, _, _),
        let .semijoin(left, right, _, _), let .setop(_, left, right, _, _, _):
     return within(in: left) || within(in: right)
-  case .single, .scan, .join, .apply:
+  case .single, .empty, .scan, .join, .apply:
     return false
   }
 }
@@ -252,7 +252,7 @@ private func subquery(in plan: Plan) -> Bool {
   case let .product(left, right), let .outer(left, right, _, _),
        let .semijoin(left, right, _, _), let .setop(_, left, right, _, _, _):
     return subquery(in: left) || subquery(in: right)
-  case .single, .scan, .join, .apply:
+  case .single, .empty, .scan, .join, .apply:
     return false
   }
 }

--- a/Tests/SQLTests/Queries/EngineJoinTests.swift
+++ b/Tests/SQLTests/Queries/EngineJoinTests.swift
@@ -752,7 +752,7 @@ private func outers(_ plan: Plan) -> Bool {
     outers(left) || outers(right)
   case let .aggregate(_, _, source):
     outers(source)
-  case .single, .scan:
+  case .single, .empty, .scan:
     false
   }
 }

--- a/Tests/SQLTests/Queries/EngineViewAndPushdownTests.swift
+++ b/Tests/SQLTests/Queries/EngineViewAndPushdownTests.swift
@@ -301,7 +301,7 @@ func engineDerived(_ plan: Plan) -> Plan? {
     engineDerived(source)
   case let .aggregate(_, _, source):
     engineDerived(source)
-  case .single, .scan, .join:
+  case .single, .empty, .scan, .join:
     nil
   }
 }
@@ -339,7 +339,7 @@ func engineSeeks(_ plan: Plan) -> Bool {
     engineSeeks(source)
   case let .aggregate(_, _, source):
     engineSeeks(source)
-  case .single:
+  case .single, .empty:
     false
   }
 }
@@ -374,7 +374,7 @@ func engineFilters(_ plan: Plan) -> Bool {
     engineFilters(source)
   case let .aggregate(_, _, source):
     engineFilters(source)
-  case .single, .scan, .join:
+  case .single, .empty, .scan, .join:
     false
   }
 }
@@ -414,7 +414,7 @@ func enginePushed(_ plan: Plan) -> Bool {
     enginePushed(source)
   case let .aggregate(_, _, source):
     enginePushed(source)
-  case .single, .scan:
+  case .single, .empty, .scan:
     false
   }
 }
@@ -468,7 +468,7 @@ func engineJoins(_ plan: Plan) -> Bool {
     engineJoins(left) || engineJoins(right)
   case let .aggregate(_, _, source):
     engineJoins(source)
-  case .single, .scan:
+  case .single, .empty, .scan:
     false
   }
 }
@@ -506,7 +506,7 @@ func engineResidual(_ plan: Plan) -> Bool {
     engineResidual(left) || engineResidual(right)
   case let .aggregate(_, _, source):
     engineResidual(source)
-  case .single, .scan:
+  case .single, .empty, .scan:
     false
   }
 }
@@ -545,7 +545,7 @@ func engineSeparated(_ plan: Plan) -> Bool {
     engineSeparated(left) || engineSeparated(right)
   case let .aggregate(_, _, source):
     engineSeparated(source)
-  case .single, .scan:
+  case .single, .empty, .scan:
     false
   }
 }
@@ -585,7 +585,7 @@ func engineStacked(_ plan: Plan) -> Bool {
     engineStacked(left) || engineStacked(right)
   case let .aggregate(_, _, source):
     engineStacked(source)
-  case .single, .scan:
+  case .single, .empty, .scan:
     false
   }
 }
@@ -701,7 +701,7 @@ private func injected(_ plan: Plan) -> Bool {
     injected(outer)
   case let .aggregate(_, _, source):
     injected(source)
-  case .single, .scan:
+  case .single, .empty, .scan:
     false
   }
 }


### PR DESCRIPTION
Add a `Plan.empty(slots:)` case — a relation of known column width but zero rows — and a SOUND optimiser fold that rewrites a provably constant-false selection (`WHERE 1 = 0`) into it.

The fold is gated on throw-freedom. Executing `select(false, child)` today runs `child` — which may raise (a throwing scalar, a SUM overflow, a view-body fault) — and only then filters every row out. Rewriting to `.empty` skips `child` entirely, so it would SUPPRESS a throw `child` owes. A new plan-level `Plan.safe` property (the analogue of `Filter.safe`/`Term.safe`) reports throw-freedom conservatively: a scan, a single/empty leaf, and the pure shape operators over safe children are safe, while a `derived` view body, any join/apply/aggregate is not PROVABLY throw-free and reports `false`. `emptied(filter:over:)` folds to `.empty` only when the optimised source is `safe` and its width is known, else leaves the select filtering — under-folding is a missed optimisation, over-folding a correctness bug, so doubt resolves to no fold.

`.empty` carries the replaced subtree's slot width, so `Plan.slots` (and thus an outer/semijoin NULL-extension) and `Plan.width` are preserved — only the rows are gone. A bare aggregate over the empty still yields its degenerate one row (`COUNT(*)` `0`), since the empty sits below the aggregate as its source.

The new case joins every exhaustive `Plan` switch — `execute`, `slots`, `width`, `optimise`, `decorrelate`, `pushdown` (the last two a structural no-op, as `.empty` is produced only by `optimise`, which runs after them) — and the test-side plan-shape helpers.

Tests cover the fold's plan shape, output-width preservation, a constant-false UNION arm, the bare-aggregate one-row rule, and the soundness fence: a constant-false selection over a THROWING view is NOT folded and the fault still surfaces at run.