### PR TITLE
WinMD: unify the CTE resolution walk into one producer

### DIFF
--- a/Sources/SQLEngine/Engine.swift
+++ b/Sources/SQLEngine/Engine.swift
@@ -280,11 +280,57 @@ extension Catalog where Self: ~Escapable {
   internal borrowing func with(_ ctes: Array<CTE>, _ query: Query,
                                _ context: Context)
       throws(SQLError) -> Array<Array<Value>> {
+    // Type AND materialise the CTEs into the overlay through the ONE producer
+    // (`rows: true`) the schema path also drives, then run the trailing query
+    // against it — the CTE walk lives in `typed(ctes:in:rows:)`, so a per-CTE
+    // step cannot be added to a run loop and forgotten on the schema one.
+    let relations = try typed(ctes: ctes, in: context, rows: true)
+    return try run(query, context.body(relations))
+  }
+
+  /// Types the common table expressions `ctes` into a `ScopedRelations` overlay
+  /// — the SINGLE statement-level CTE walk BOTH the run (`with`) and the
+  /// schema-only (`columns(of:with:)`) paths consume, so a per-CTE step lives
+  /// in ONE place and cannot be added to one loop and forgotten on the other.
+  ///
+  /// It walks `ctes` in source order, binding each into the growing overlay the
+  /// next resolves against (so a later CTE names one before it, and a CTE
+  /// shadows a same-named base relation). Per CTE it:
+  ///
+  /// 1. rejects a case-insensitive redefinition — a name repeated in the list
+  ///    would silently shadow the earlier binding, so it faults
+  ///    `SQLError.redefinition` rather than overwrite (a typo in a multi-CTE
+  ///    query must not change the result);
+  /// 2. validates the CTE's SHAPE and ARITY against the CTEs done so far — the
+  ///    compile-time structural check `validate` runs. This gate is the ONE
+  ///    legitimate run-vs-schema difference, and it now lives here: the run
+  ///    (`rows: true`) ALWAYS validates and passes `typecheck: false` — it
+  ///    DEFERS the reachable-operand check to execution — while a schema derive
+  ///    (`rows: false`) validates ONLY when its context's `validate` gate is
+  ///    set (a post-run `validate: false` derive TRUSTS the bodies) and then
+  ///    strictly (`typecheck: true`), faulting an ill-typed body statically;
+  /// 3. computes the column carrier ONCE. On the run path a self-referential
+  ///    CTE iterates a `fixpoint` (which returns both its rows and their
+  ///    unified carrier); every other CTE runs its query once and re-derives
+  ///    the carrier TRUSTED (`validating(false)`, so an unreached data-
+  ///    dependent operand is not eager-checked while a genuine set-operation
+  ///    incompatibility still faults through `kinds`'s `merge` fold). On the
+  ///    schema path `kinds`
+  ///    derives the carrier for either kind WITHOUT iterating — its recursive
+  ///    branch (`contributions`) folds anchor ⊕ recursive the same way
+  ///    `fixpoint` does;
+  /// 4. binds the carrier as `RelationInstance(from:, rows:)`, with the rows
+  ///    on the run path and none on the schema path. Both paths accumulate the
+  ///    overlay IDENTICALLY — same names, types, and
+  ///    `unconstrained` mask — differing ONLY in the captured rows, which is
+  ///    safe because downstream typing reads names/types/mask, never rows. The
+  ///    carrier feeds the SAME `init(from:)`, so the schema-only self and the
+  ///    materialised binding cannot diverge.
+  internal borrowing func typed(ctes: Array<CTE>, in context: Context,
+                                rows: Bool)
+      throws(SQLError) -> ScopedRelations {
     var relations = ScopedRelations()
     for cte in ctes {
-      // A query name repeated in the list (case-insensitively) would silently
-      // shadow the earlier binding in `relations`, so reject it rather than
-      // overwrite — a typo in a multi-CTE query must not change the result.
       guard relations[cte.name.lowercased()] == nil else {
         throw .redefinition(cte.name)
       }
@@ -295,43 +341,44 @@ extension Catalog where Self: ~Escapable {
       // so the stack is already empty here; routing through `body(_:)` keeps
       // the clear intrinsic to entering a body scope rather than incidental).
       let scope = context.body(relations)
-      // Validate the CTE's SHAPE and ARITY against the CTEs done so far — the
-      // compile-time structural check, shared with the dry-run schema path so a
-      // derive rejects exactly the CTEs a run rejects. It faults the recursive
-      // shape and the width mismatch here, BEFORE any rows materialise.
-      try validate(cte, against: scope)
-      // A CTE that names itself iterates a fixpoint; every other one — a
-      // non-recursive CTE, or one a `WITH RECURSIVE` marks recursive but which
-      // does not reference itself — runs its query once. Each resolves against
-      // the base catalog plus the CTEs done so far. The arity of both routings
-      // is already checked by `validate` above.
-      // Bind the CTE under its BODY's derived column carrier, not a `.integer`
-      // placeholder: a caller reading the CTE (a set operation over its column)
-      // unifies against the real types AND the `unconstrained` mask, so `WITH
-      // a(x) AS (SELECT 'b') SELECT x FROM a UNION SELECT 'c'` folds text
-      // against text and runs, and an all-NULL CTE column unifies with any
-      // typed arm. Both routings feed the SAME carrier into `init(from:)`, so
-      // the schema-only self and materialised binding cannot diverge.
-      let rows: Array<Array<Value>>
-      let carrier: Array<ResolvedColumn>
-      if cte.recursive && cte.recurses {
-        (rows, carrier) = try fixpoint(cte, scope)
-      } else {
-        rows = try run(cte.query, scope)
-        // The body already RAN and produced its rows, so re-derive its carrier
-        // TRUSTED — `validating(false)` so the derive does NOT eager-operand-
-        // check a data-dependent expression a filter dropped (`SELECT Label + 1
-        // … WHERE k = 0`, `Label` text), never evaluated, never a run fault.
-        // `kinds` binds the DECLARED names with the body-folded types/mask. A
-        // GENUINE set-operation incompatibility (`SELECT 'b' UNION SELECT 1`)
-        // still faults through the unconditional `merge` fold, matching the run
-        // — a reachable type error already faulted at `run` above.
-        carrier = try kinds(of: cte, scope.validating(false))
+      // The compile-time structural check, shared with the dry-run schema path
+      // so a derive rejects exactly the CTEs a run rejects. It faults the
+      // recursive shape and the width mismatch BEFORE any rows materialise. The
+      // run ALWAYS validates (`typecheck: false` — it defers the operand check
+      // to execution); the schema derive validates ONLY when its context's gate
+      // is set — a `validate: false` derive AFTER a run TRUSTS the bodies (the
+      // run already proved them consistent) — and then STRICTLY (`typecheck:
+      // true`). This gate is the ONE legitimate run-vs-schema difference.
+      if rows || context.validate {
+        try validate(cte, against: scope, typecheck: !rows)
       }
+      let materialised: Array<Array<Value>>
+      let carrier: Array<ResolvedColumn>
+      if rows {
+        // A CTE that names itself iterates a fixpoint; every other one runs its
+        // query once. The arity of both routings is already checked above.
+        if cte.recursive && cte.recurses {
+          (materialised, carrier) = try fixpoint(cte, scope)
+        } else {
+          materialised = try run(cte.query, scope)
+          // The body already RAN, so re-derive its carrier TRUSTED — the same
+          // `kinds` call the fixpoint's non-recursive tail routes through, so
+          // no inline carrier construction diverges from it.
+          carrier = try kinds(of: cte, scope.validating(false))
+        }
+      } else {
+        // The schema derive materialises no row; `kinds` types either CTE kind
+        // WITHOUT iterating (its recursive branch folds anchor ⊕ recursive the
+        // way `fixpoint` does), under the incoming validate gate.
+        materialised = []
+        carrier = try kinds(of: cte, scope)
+      }
+      // Both routings feed the SAME carrier into `init(from:)`, so the
+      // schema-only self and the materialised binding cannot diverge.
       relations[cte.name.lowercased()] =
-          RelationInstance(from: carrier, rows: rows)
+          RelationInstance(from: carrier, rows: materialised)
     }
-    return try run(query, context.body(relations))
+    return relations
   }
 
   /// Validates the SHAPE and declared ARITY of a single common table expression

--- a/Sources/SQLEngine/OutputColumn.swift
+++ b/Sources/SQLEngine/OutputColumn.swift
@@ -298,51 +298,15 @@ extension Catalog where Self: ~Escapable {
                                  validate: Bool)
       throws(SQLError) -> Array<OutputColumn> {
     let context = Context(routines: routines).validating(validate)
-    var overlay = ScopedRelations()
-    for cte in ctes {
-      // A name repeated in the list (case-insensitively) would silently shadow
-      // the earlier binding in the overlay, so reject it rather than overwrite
-      // — the same fault `Engine.with` raises before materialising, so a schema
-      // is advertised only for a `WITH` that could actually run.
-      guard overlay[cte.name.lowercased()] == nil else {
-        throw .redefinition(cte.name)
-      }
-      // Validate the body's SHAPE and ARITY against the scope of the PRIOR CTEs
-      // by the SAME code a run uses — `Engine.validate` — so a schema is not
-      // advertised for a `WITH` a run would reject, and this path never again
-      // drifts from the engine's recursive-shape and arity rules. It binds the
-      // CTE's self only inside the recursive arm (never the whole body), so a
-      // recursive reference in the final arm resolves while a self-reference in
-      // the anchor faults the recursive shape exactly as the run does. The
-      // schema path adds ONE thing the run defers to execution: a
-      // reachable-operand type-check over the body — passed IN as `typecheck`
-      // so it runs in the SAME per-arm scope the shared helper computes,
-      // checking a recursive CTE's anchor against the base scope the run
-      // evaluates it in (NOT the CTE-self overlay). A `validate: false` derive
-      // skips both — the run already proved the bodies consistent — so
-      // `typecheck: false` there.
-      if validate {
-        // `self.` escapes the shadow the `validate` Bool parameter casts over
-        // the shared `validate(_:against:)` engine helper.
-        try self.validate(cte, against: context.body(overlay),
-                          typecheck: true)
-      }
-      // The CTE's schema-only self — its declared columns, no rows, and its
-      // BODY-DERIVED column carrier (never the declared-name `.integer`
-      // placeholder), derived under the SAME body scope `validate` uses (the
-      // PRIOR CTEs in `overlay`, self not in scope) so the trailing query's
-      // set-op fold reads a CTE column at its real type rather than spuriously
-      // merging an `.integer` placeholder against a text arm and faulting. The
-      // carrier's `unconstrained` mask threads through `init(from:)`, so an
-      // all-NULL CTE column unifies with any later typed arm.
-      let derived = try kinds(of: cte, context.body(overlay))
-      // Bind the CTE's schema-only self into the overlay AFTER its body is
-      // validated — the scope a later CTE and the trailing query resolve
-      // against — exactly as `Engine.with` binds the materialised relation
-      // after running its body.
-      overlay[cte.name.lowercased()] =
-          RelationInstance(from: derived, rows: [])
-    }
+    // Type the CTEs into a SCHEMA-ONLY overlay (`rows: false`) through the ONE
+    // producer the run path also drives — `Engine.typed(ctes:in:rows:)` — so
+    // the redefinition guard, the shared `validate` (its `typecheck: true`
+    // riding this context's `validate` gate — a `validate: false` post-run
+    // derive TRUSTS the bodies and skips it), and the per-CTE `kinds` carrier
+    // derivation all run through the SAME walk a run does. Each CTE binds its
+    // declared columns with no rows, laid in source order, so a later CTE and
+    // the trailing query resolve a name the precedence a run applies.
+    let overlay = try typed(ctes: ctes, in: context, rows: false)
     // Compile/type-check/derive from the base `context.scoping(overlay)`
     // (idempotently augmented within each, which pushes the trailing query's
     // derived layer and reveals the base for a nested subquery), so a nested

--- a/Tests/SQLTests/Queries/EngineWithTests.swift
+++ b/Tests/SQLTests/Queries/EngineWithTests.swift
@@ -951,4 +951,51 @@ struct EngineRecursiveTests {
       _ = try statement(text, engineFamily())
     }
   }
+
+  // MARK: - Producer CTE-shape guards
+
+  // The tier-2 unification routes both the run and the schema paths through ONE
+  // CTE walk (`Engine.typed(ctes:in:rows:)`). These pin the RUN-side shape of
+  // the historically-divergent CTE kinds — the row companions to the R/S/V
+  // parity matrix in `OutputSchemaTests` — so a per-CTE regression surfaces
+  // here as a wrong ROW set, not only a wrong header.
+
+  @Test func `a chained CTE reading a prior widened column materialises doubles`()
+      throws {
+    // `a` is a mixed integer/double UNION widened to `.double`; `b` reads it.
+    // The run overlay carries `a`'s MATERIALISED rows coerced to the unified
+    // type, so `b` reads (and the query returns) `.double` values — the same
+    // widened carrier the schema path threads with EMPTY rows.
+    let rows = try statement("""
+        WITH a(x) AS (SELECT 1 UNION SELECT 2.5),
+             b(y) AS (SELECT x FROM a)
+          SELECT y FROM b ORDER BY y
+        """, engineFamily())
+    #expect(rows == [[.double(1.0)], [.double(2.5)]])
+  }
+
+  @Test func `a widening recursive CTE materialises every step as a double`()
+      throws {
+    // An integer anchor and a `+ 0.5` recursive arm widen the column to
+    // `.double`; the fixpoint coerces the seed AND each iteration's rows to
+    // the unified type, so the whole result is `.double` — the run counterpart
+    // of the schema derive's `.double` header.
+    let rows = try statement("""
+        WITH RECURSIVE t(n) AS (
+          SELECT 1 UNION ALL SELECT n + 0.5 FROM t WHERE n < 2
+        ) SELECT n FROM t ORDER BY n
+        """, engineFamily())
+    #expect(rows == [[.double(1.0)], [.double(1.5)], [.double(2.0)]])
+  }
+
+  @Test func `a mixed integer double non-recursive CTE coerces its rows`()
+      throws {
+    // A non-recursive UNION body widened to `.double`: the run coerces each
+    // arm's values to the unified type before binding, so `1` materialises as
+    // `1.0` — the producer's carrier and the run's rows agree on the type.
+    let rows = try statement("""
+        WITH a(x) AS (SELECT 1 UNION SELECT 2.5) SELECT x FROM a ORDER BY x
+        """, engineFamily())
+    #expect(rows == [[.double(1.0)], [.double(2.5)]])
+  }
 }

--- a/Tests/SQLTests/Schema/OutputSchemaTests.swift
+++ b/Tests/SQLTests/Schema/OutputSchemaTests.swift
@@ -722,3 +722,223 @@ struct OutputSchemaTests {
     #expect(columns[0].name == "n")
   }
 }
+
+// MARK: - CTE producer run/schema parity
+
+/// The outcome of typing or running a `WITH` — either the resolved result
+/// columns' `(name, kind)` pairs, or the `SQLError` a fault raised — so the
+/// three CTE entry points (a RUN, a `columns(validate: false)` derive, and a
+/// `columns(validate: true)` derive) can be compared for AGREEMENT: after the
+/// tier-2 unification they walk their CTEs through the ONE producer, so a shape
+/// must resolve to the same types on all three, or fault the same on all three.
+private enum Outcome: Equatable {
+  case columns(Array<OutputColumn>)
+  case fault(SQLError)
+}
+
+/// Runs `body` and captures its outcome — the resolved columns, or the fault.
+private func outcome(_ body: () throws -> Array<OutputColumn>) -> Outcome {
+  do {
+    return .columns(try body())
+  } catch let error as SQLError {
+    return .fault(error)
+  } catch {
+    return .fault(.state("XX000", "\(error)"))
+  }
+}
+
+/// The three CTE entry points' outcomes on one `WITH` — the regression fence
+/// for the tier-2 producer. `run` is the RUN path (its post-run `validate:
+/// false` schema, or its fault); `lenient` is `columns(validate: false)` — the
+/// TRUSTED post-run derive, which SKIPS the structural `validate` (so a
+/// shape/arity fault does not surface, and a recursive body reads its absent
+/// self); `strict` is `columns(validate: true)` — the full schema check.
+///
+/// The invariant the unification preserves: RUN and STRICT are the two FULLY
+/// validating paths, so they AGREE on every shape — the producer's shared
+/// `validate` (`typecheck` differing only in whether the reachable-operand
+/// check runs at derive or execution) and shared `kinds` carrier make them so.
+/// LENIENT agrees too on any shape whose outcome does NOT depend on the skipped
+/// structural check — the carrier-typing shapes (a `kinds`/`merge` fold runs
+/// regardless of the gate) and redefinition (the producer's guard is
+/// ungated) — but on a structural fault (arity, an unregistered call, a
+/// misplaced recursive arm) it TRUSTS the body and does not fault.
+private struct Triple {
+  let run: Outcome
+  let lenient: Outcome
+  let strict: Outcome
+
+  init(_ text: String) throws {
+    let statement = try Statement(parsing: text)
+    run = outcome {
+      _ = try engineFamily().run(statement)
+      return try engineFamily().columns(of: statement, validate: false)
+    }
+    lenient = outcome {
+      try engineFamily().columns(of: statement, validate: false)
+    }
+    strict = outcome {
+      try engineFamily().columns(of: statement, validate: true)
+    }
+  }
+}
+
+/// The `(name, kind)` pairs of an `Outcome`'s columns, or `nil` for a fault.
+private func pairs(_ outcome: Outcome) -> Array<(String, ValueType)>? {
+  guard case let .columns(columns) = outcome else { return nil }
+  return columns.map { ($0.name, $0.type) }
+}
+
+struct CTEProducerParityTests {
+  @Test func `an all-NULL CTE column agrees across run and both derives`() throws {
+    // A constant-NULL body column is UNCONSTRAINED, typed at the `.integer`
+    // default a materialised relation reports; the run and both derives read
+    // the SAME producer carrier, so all three agree on one `.integer` column.
+    let t = try Triple("WITH a(x) AS (SELECT NULLIF(Id, Id) FROM Parent) " +
+                       "SELECT x FROM a")
+    #expect(pairs(t.run).map { same($0, [("x", .integer)]) } == true)
+    #expect(t.run == t.lenient)
+    #expect(t.lenient == t.strict)
+  }
+
+  @Test func `an unregistered-call CTE body faults on the validating paths`()
+      throws {
+    // A call to an unregistered routine is a resolution fault the producer's
+    // shared `validate` raises the SAME on the two VALIDATING paths (RUN and
+    // STRICT). LENIENT is the trusted post-run derive: it skips `validate`, so
+    // it does NOT fault — the pre-existing gate this test pins, not a
+    // divergence the unification introduces.
+    let t = try Triple("WITH a(x) AS (SELECT nope(Id) FROM Parent) " +
+                       "SELECT x FROM a")
+    #expect(t.run == .fault(.function("nope")))
+    #expect(t.strict == t.run)
+    #expect(pairs(t.lenient).map { same($0, [("x", .integer)]) } == true)
+  }
+
+  @Test func `a recursive self-referencing CTE agrees across all paths`() throws {
+    // A genuine recursive CTE (its final UNION arm names itself) types its
+    // declared column off the anchor ⊕ recursive fold on every path — the
+    // schema derive through `kinds`/`contributions`, the run through
+    // `fixpoint` — so all three agree on one integer column `n`.
+    let t = try Triple("""
+        WITH RECURSIVE t(n) AS (
+          SELECT 1 UNION SELECT n + 1 FROM t WHERE n < 3
+        ) SELECT n FROM t
+        """)
+    #expect(pairs(t.run).map { same($0, [("n", .integer)]) } == true)
+    #expect(t.run == t.lenient)
+    #expect(t.lenient == t.strict)
+  }
+
+  @Test func `a widening recursive CTE agrees on the double column`() throws {
+    // The anchor is `.integer` (`1`) and the recursive arm widens it to
+    // `.double` (`n + 0.5`); the unified carrier the producer binds is
+    // `.double` on every path, so all three agree — the run coerces its rows
+    // to it, the derives type the declared column at it.
+    let t = try Triple("""
+        WITH RECURSIVE t(n) AS (
+          SELECT 1 UNION SELECT n + 0.5 FROM t WHERE n < 3
+        ) SELECT n FROM t
+        """)
+    #expect(pairs(t.run).map { same($0, [("n", .double)]) } == true)
+    #expect(t.run == t.lenient)
+    #expect(t.lenient == t.strict)
+  }
+
+  @Test func `a mixed integer double set-op CTE agrees on the widened column`()
+      throws {
+    // A non-recursive UNION body of an `integer` and a `double` arm folds to a
+    // `.double` column on every path — the producer's `kinds` fold and the
+    // run's `run`-then-`kinds` re-derive read the SAME `merge`.
+    let t = try Triple("WITH a(x) AS (SELECT 1 UNION SELECT 2.5) " +
+                       "SELECT x FROM a")
+    #expect(pairs(t.run).map { same($0, [("x", .double)]) } == true)
+    #expect(t.run == t.lenient)
+    #expect(t.lenient == t.strict)
+  }
+
+  @Test func `an irreconcilable set-op CTE faults identically on all paths`()
+      throws {
+    // A text arm beside a numeric one has no common type, so the body fold
+    // faults `.operand` (42804) — through the producer's shared `kinds`/`merge`
+    // on the derives (a fold that runs regardless of the validate gate) and the
+    // run's own fold — the SAME on all three.
+    let t = try Triple("WITH a(x) AS (SELECT 'b' UNION SELECT 1) " +
+                       "SELECT x FROM a")
+    let fault = Outcome.fault(.operand("UNION arms have irreconcilable types"))
+    #expect(t.run == fault)
+    #expect(t.lenient == fault)
+    #expect(t.strict == fault)
+  }
+
+  @Test func `an over-declared CTE arity faults on the validating paths`()
+      throws {
+    // A three-column declared list over a two-column `SELECT *` body faults
+    // `.columns` in ISO order (the compiled width, then the declared count) on
+    // the two VALIDATING paths. LENIENT trusts and reconciles to the declared
+    // list, so it does NOT fault — the pre-existing structural gate.
+    let t = try Triple("WITH a(x, y, z) AS (SELECT * FROM Parent) " +
+                       "SELECT * FROM a")
+    #expect(t.run == .fault(.columns(expected: 2, got: 3)))
+    #expect(t.strict == t.run)
+    #expect(pairs(t.lenient)?.count == 3)
+  }
+
+  @Test func `an under-declared CTE arity faults on the validating paths`()
+      throws {
+    // The mirror of the over-declared case — a one-column list over a
+    // two-column body — `.columns(expected: 2, got: 1)` on RUN and STRICT,
+    // LENIENT trusting the body to one column.
+    let t = try Triple("WITH a(x) AS (SELECT * FROM Parent) SELECT * FROM a")
+    #expect(t.run == .fault(.columns(expected: 2, got: 1)))
+    #expect(t.strict == t.run)
+    #expect(pairs(t.lenient)?.count == 1)
+  }
+
+  @Test func `a misplaced recursive arm faults on the validating paths`()
+      throws {
+    // A self-reference in the ANCHOR (not the final UNION arm) is the recursive
+    // shape the engine rejects `0A000` on the two VALIDATING paths. LENIENT
+    // trusts — it skips `validate`, so the body reads an absent self and faults
+    // `.relation` instead; the pre-existing gate, pinned so the unification
+    // cannot silently change it.
+    let t = try Triple("""
+        WITH RECURSIVE t(n) AS (
+          SELECT n FROM t UNION SELECT n FROM t
+        ) SELECT n FROM t
+        """)
+    let shape = Outcome.fault(.state("0A000",
+        "recursive WITH references the CTE outside its final UNION arm"))
+    #expect(t.run == shape)
+    #expect(t.strict == shape)
+    #expect(t.lenient == .fault(.relation("t")))
+  }
+
+  @Test func `a redefined CTE name faults identically on all paths`() throws {
+    // A case-insensitive redefinition is rejected by the producer's UNGATED
+    // guard — the SAME `.redefinition` on the run and BOTH derives, lenient
+    // included (the guard runs before any validate gate).
+    let t = try Triple("WITH a(x) AS (SELECT 1), A(y) AS (SELECT 2) " +
+                       "SELECT * FROM a")
+    let fault = Outcome.fault(.redefinition("A"))
+    #expect(t.run == fault)
+    #expect(t.lenient == fault)
+    #expect(t.strict == fault)
+  }
+
+  @Test func `a chained CTE reading a prior widened column agrees`() throws {
+    // The biggest risk: the run overlay grows with each prior CTE's
+    // MATERIALISED rows, the schema overlay with EMPTY rows, but both
+    // accumulate the SAME types/mask. Here `b` reads `a`'s column, widened to
+    // `.double`, so all three paths agree on one `.double` column — proving it
+    // threads the growing overlay identically (types, not rows) on both.
+    let t = try Triple("""
+        WITH a(x) AS (SELECT 1 UNION SELECT 2.5),
+             b(y) AS (SELECT x FROM a)
+          SELECT y FROM b
+        """)
+    #expect(pairs(t.run).map { same($0, [("y", .double)]) } == true)
+    #expect(t.run == t.lenient)
+    #expect(t.lenient == t.strict)
+  }
+}


### PR DESCRIPTION
The engine typed each common table expression along TWO parallel statement-level loops — the RUN path in `Engine.with` and the schema-only path in `columns(of:with:)` — that called the same per-CTE helpers but sequenced the redefinition guard, `validate`, and the carrier derivation independently. Tier-1 unified the per-column derivation; the LOOP stayed split, the structural seam that regrew per-CTE bugs through PR280 (add a step to one loop, forget the other).

Introduce one producer, `Catalog.typed(ctes:in:rows:)`, that walks the CTEs ONCE and returns the accumulated `ScopedRelations` overlay both paths consume. Per CTE it rejects a redefinition, runs the shared `validate` (with `typecheck: !rows` — the run defers the reachable- operand check to execution, the schema derive keeps it strict — the ONE legitimate run-vs-schema difference, now in one place), derives the column carrier once (a self-referential CTE through `fixpoint` on the run path, `kinds`/`contributions` on the schema path; every other CTE through `run`+`kinds` or `kinds`), and binds
`RelationInstance(from: carrier, rows: rows ? materialised : [])`. Both paths accumulate the overlay identically — same names, types, and `unconstrained` mask, differing only in the captured rows, which downstream typing never reads. `Engine.with` and `columns(of:with:)` each collapse to a `typed(ctes:)` call plus the outer query.

The run always validates; the schema derive validates only under its context's `validate` gate (a post-run `validate: false` derive trusts the bodies), so `typed` gates the check on `rows || context.validate`, preserving both loops' exact behavior. PR282's recursive `validate` is called unchanged — the arm-width probe stays non-validating and the ISO fault order is untouched.

Add a run/schema/strict parity matrix (`CTEProducerParityTests`) over the historically-divergent shapes — all-NULL, unregistered call, recursive self, recursive widening, mixed set-op arms, irreconcilable arms, over/under-declared arity, misplaced recursive arm, redefinition, and a chained CTE reading a prior widened column — pinning that the two validating paths agree on every shape and the trusted derive agrees wherever its outcome does not depend on the skipped structural check. The values are computed empirically against the engine, so the matrix encodes current behavior. No existing assertion changes.