### PR TITLE
SQLEngine: add ISO NATURAL and USING joins

### DIFF
--- a/Sources/SQLEngine/AST.swift
+++ b/Sources/SQLEngine/AST.swift
@@ -210,11 +210,14 @@ public struct Select: Hashable, Sendable {
   /// The row filter, if any.
   public let predicate: Predicate?
 
-  /// The `GROUP BY` columns, in source order — empty for a query with no
-  /// explicit grouping. A query that aggregates without a `GROUP BY` (`SELECT
-  /// COUNT(*) FROM T`) leaves this empty and aggregates the whole result as a
-  /// single group.
-  public let grouping: Array<Column>
+  /// The `GROUP BY` keys, in source order — empty for a query with no explicit
+  /// grouping. A query that aggregates without a `GROUP BY` (`SELECT COUNT(*)
+  /// FROM T`) leaves this empty and aggregates the whole result as a single
+  /// group. The parser produces a bare `Expression.column` per key; a general
+  /// key expression is admitted too, so a bare `NATURAL`/`USING` merged column
+  /// lowers through the join scope to its `COALESCE(left, right)` value (with
+  /// no physical ordinal), the executor grouping each key per row.
+  public let grouping: Array<Expression>
 
   /// The `HAVING` filter over the grouped rows, if any — a predicate the engine
   /// applies AFTER aggregation, so it may reference the aggregates and the
@@ -230,7 +233,7 @@ public struct Select: Hashable, Sendable {
 
   public init(distinct: Bool = false, projection: Projection,
               from: Relation?, joins: Array<Join> = [],
-              predicate: Predicate? = nil, grouping: Array<Column> = [],
+              predicate: Predicate? = nil, grouping: Array<Expression> = [],
               having: Predicate? = nil, order: Order? = nil,
               limit: Limit? = nil) {
     self.distinct = distinct
@@ -521,19 +524,50 @@ public struct Join: Hashable, Sendable {
     case full
   }
 
+  /// The ISO named-column join criterion of a `NATURAL` or `JOIN … USING`
+  /// clause — a shorthand whose join columns are resolved by NAME rather than
+  /// spelled as an `ON` predicate, and whose common columns COALESCE into ONE
+  /// unqualified output column (ISO 9075 7.10).
+  ///
+  /// It is mutually exclusive with an `ON` predicate (the parser rejects a
+  /// `NATURAL … ON` / `USING … ON`), and its concrete column set is known only
+  /// after SCHEMA resolution — the two sides' column names — so the engine
+  /// carries the criterion here and resolves it into the equality `on`
+  /// predicate and the coalesced `SELECT *` output during compilation, rather
+  /// than at parse time. A join with no criterion (`nil`) is a plain `ON`/
+  /// `CROSS` join.
+  public enum Using: Hashable, Sendable {
+    /// `NATURAL` — the join columns are EVERY column name the two sides share
+    /// (their case-insensitive intersection, in the left side's column order),
+    /// computed at resolution. No common column degenerates to a `CROSS` join.
+    case natural
+    /// `USING (c, …)` — the join columns are the NAMED ones, each of which must
+    /// name a column present in BOTH sides (else a column fault).
+    case columns(Array<String>)
+  }
+
   /// The relation joined in.
   public let relation: Relation
 
   /// The inner/outer variety of this join.
   public let kind: Kind
 
-  /// The `ON` predicate relating the joined-in relation to those in scope.
+  /// The `ON` predicate relating the joined-in relation to those in scope. A
+  /// `NATURAL`/`USING` join (`using != nil`) carries a placeholder always-true
+  /// predicate here until compilation resolves its named columns into the real
+  /// equality `on`.
   public let on: Predicate
 
-  public init(relation: Relation, kind: Kind = .inner, on: Predicate) {
+  /// The ISO named-column criterion (`NATURAL` or `USING`), or `nil` for a
+  /// plain `ON`/`CROSS` join.
+  public let using: Using?
+
+  public init(relation: Relation, kind: Kind = .inner, on: Predicate,
+              using: Using? = nil) {
     self.relation = relation
     self.kind = kind
     self.on = on
+    self.using = using
   }
 
   /// A `column = column` equi-join over `relation` — the common shape, as the
@@ -543,6 +577,16 @@ public struct Join: Hashable, Sendable {
     self.init(relation: relation, kind: kind,
               on: .comparison(left: .column(left), op: .equal,
                               right: .column(right)))
+  }
+
+  /// A `NATURAL`/`USING` join over `relation` — the named-column criterion its
+  /// `on` predicate stands unresolved until compilation. Its `on` is a
+  /// placeholder always-true predicate the resolution replaces.
+  public init(relation: Relation, kind: Kind = .inner, using: Using) {
+    self.init(relation: relation, kind: kind,
+              on: .comparison(left: .literal(.integer(1)), op: .equal,
+                              right: .literal(.integer(1))),
+              using: using)
   }
 }
 

--- a/Sources/SQLEngine/Engine.swift
+++ b/Sources/SQLEngine/Engine.swift
@@ -1867,17 +1867,22 @@ extension Catalog where Self: ~Escapable {
     }
     let (joined, relations) = try resolve(from: relation, schema: from.schema,
                                           joins: select.joins, context)
-    let scope = Scope(relations)
+    // Model the `NATURAL`/`USING` merged columns in the scope and synthesize
+    // each named-column join's lowered `on` filter, as the non-aggregate join
+    // path does — so a bare merged column groups/projects by the coalesced
+    // value.
+    let (ons, merged, merges) = try merges(over: relations, select.joins)
+    let scope = Scope(relations, merged: merged)
 
     // Each join's ON predicate lowers to a `Filter` at its own chain level,
     // resolved against only the prefix already in scope (as the non-aggregate
     // path does). A `column = column` conjunct becomes a `match` hash-join key;
     // the rest is a residual the join runs as a filter.
     // Each join's PREFIX scope — the relations available AT that join point,
-    // never one joined LATER — the scope its `ON` lowers against and a subquery
-    // in that `ON` correlates against.
+    // never one joined LATER — carries the merged columns accumulated BEFORE
+    // this join, so a chained `USING` `on` keys on the merged value.
     let prefixes = select.joins.indices.map { index in
-      Scope(Array(relations[0 ... index + 1]))
+      Scope(Array(relations[0 ... index + 1]), merged: merges[index])
     }
     // Compile every nested subquery ONCE for arity/type, ahead of lowering, and
     // discover each one's CORRELATION: a join `ON`'s against its PREFIX scope,
@@ -1892,9 +1897,16 @@ extension Catalog where Self: ~Escapable {
     var matches = Array<Filter>()
     matches.reserveCapacity(select.joins.count)
     for index in select.joins.indices {
-      let join = select.joins[index]
-      try matches.append(prefixes[index].on(join.on, context.routines,
-                                            subquery: plans.on(index)))
+      // A `NATURAL`/`USING` join's `on` is the SYNTHESIZED, already-lowered
+      // filter (`ons[index]`, `nil` for a degenerate `NATURAL` join); a plain
+      // join lowers its written `ON` against the prefix scope.
+      if let on = ons[index] {
+        matches.append(on)
+      } else {
+        try matches.append(prefixes[index].on(select.joins[index].on,
+                                              context.routines,
+                                              subquery: plans.on(index)))
+      }
     }
     var predicate: Filter? = nil
     if let clause = select.predicate {
@@ -1906,18 +1918,18 @@ extension Catalog where Self: ~Escapable {
     // base-ordinal terms; the aggregates are collected from the projection, the
     // `HAVING`, and the `ORDER BY` sort keys (deduplicated so the same
     // aggregate computes once).
-    let keys = try select.grouping.map { column throws(SQLError) -> Term in
-      // A grouping key a local relation binds reads its combined slot; one NONE
-      // binds is a candidate CORRELATED reference (a LATERAL body grouping on a
-      // preceding column) — the same `barred` surface the projection/HAVING use
-      // lowers it to a `Term.parameter` the apply binds per outer row (a
-      // per-invocation constant → one group), admitting it only under the
-      // LATERAL `everywhere` seam and faulting `.unsupported` on an ordinary
-      // grouped subquery. The final `ordinal(of:)` re-throws a genuine
-      // unknown-column `.column`.
-      if let ordinal = try scope.find(column) { return .slot(ordinal) }
-      if let name = try barred.correlate(column) { return .parameter(name) }
-      return try .slot(scope.ordinal(of: column))
+    let keys = try select.grouping.map { key throws(SQLError) -> Term in
+      // Each key lowers through `scope.term`: a bare column a local relation
+      // binds reads its combined slot; a bare `NATURAL`/`USING` merged column
+      // lowers to its `COALESCE(left, right)` value (so the aggregate node
+      // groups a `RIGHT`/`FULL` join's unmatched row by the merged value, not a
+      // NULL left column); a name NONE binds is a candidate CORRELATED
+      // reference (a LATERAL body grouping on a preceding column) — the
+      // `barred` surface lowers it to a `Term.parameter` the apply binds per
+      // outer row, admitting it only under the LATERAL `everywhere` seam and
+      // faulting `.unsupported` on an ordinary grouped subquery, else the
+      // genuine unknown-column `.column`. A general key lowers by `term` too.
+      try scope.term(key, context.routines, subquery: barred)
     }
     var expressions = Array<Expression>()
     for expression in select.projection.projected {
@@ -2005,7 +2017,7 @@ extension Catalog where Self: ~Escapable {
     // Lower the projection, HAVING, and ORDER BY against the grouped slot
     // space, enforcing the projection rule (every non-aggregated column must be
     // a GROUP BY key).
-    var grouping = try Grouping(scope, select.grouping, aggregations,
+    var grouping = try Grouping(scope, select.grouping, keys, aggregations,
                                 subquery: barred)
     let projection = try grouping.terms(select.projection, context.routines,
                                         subquery: barred)
@@ -4175,8 +4187,9 @@ extension Catalog where Self: ~Escapable {
   /// space from these. The returned `relations` lays the FROM relation first,
   /// then each joined one, each paired with its schema: `Scope(relations)` is
   /// the full-chain scope, `relations[0 ... index + 1]` a join's prefix scope,
-  /// and `relations.reduce(0) { $0 + $1.1.width }` the `SELECT *` width — every
-  /// downstream derivation reads out of this one resolution.
+  /// and `Scope(…).width(of: .all)` the `SELECT *` width — DERIVED from the
+  /// merged-prepend + real-column `expansion` the scope emits, never a separate
+  /// sum — every downstream derivation reads out of this one resolution.
   ///
   /// `relations` is built INCREMENTALLY, each join resolving against the
   /// PRECEDING FROM (`Scope` of the relations before it): a LATERAL arm's
@@ -4192,11 +4205,19 @@ extension Catalog where Self: ~Escapable {
     var joined = Array<Resolved>()
     joined.reserveCapacity(joins.count)
     var relations = [(relation, schema)]
-    for join in joins {
+    for index in joins.indices {
+      // The PRECEDING scope carries the merged columns the joins before this
+      // one expose (`prefix(through:)`), so a LATERAL body resolves a bare
+      // merged name to its ONE coalesced column rather than seeing the two
+      // physical join columns and faulting `.ambiguous`. A join before this one
+      // is already resolved (its schema is in `relations`), so the merged
+      // prefix is computable here.
+      let preceding =
+          try prefix(through: index, over: relations, joins)
       let resolved =
-          try resolve(join.relation, context, preceding: Scope(relations))
+          try resolve(joins[index].relation, context, preceding: preceding)
       joined.append(resolved)
-      relations.append((join.relation, resolved.schema))
+      relations.append((joins[index].relation, resolved.schema))
     }
     return (joined, relations)
   }
@@ -4222,7 +4243,17 @@ extension Catalog where Self: ~Escapable {
       let schema = try resolve(relation, context).schema
       let (_, relations) = try resolve(from: relation, schema: schema,
                                        joins: select.joins, context)
-      return relations.reduce(0) { $0 + $1.1.width }
+      // A `SELECT *` over a `NATURAL`/`USING` join is measured at its MERGED
+      // width (each join column ONCE) through `Scope.width(of: .all)`, which
+      // DERIVES the count from the merged-prepend + real-column `expansion` the
+      // arm emits — the width the arm actually produces, not the raw sum of
+      // both sides, and not a parallel arithmetic that could drift (a VIRTUAL
+      // `USING` constituent undercounted the old sum). So `A JOIN B USING (k)
+      // UNION SELECT …` compares post-merge widths and a valid set operation is
+      // not wrongly rejected. An arm with no named-column join yields an empty
+      // merged set, so the width is just the real-column count.
+      let merged = try merges(over: relations, select.joins).merged
+      return Scope(relations, merged: merged).width(of: .all)
     case let .columns(columns):
       return columns.count
     case let .expressions(items):
@@ -4448,6 +4479,261 @@ extension Catalog where Self: ~Escapable {
     }
   }
 
+  /// The synthesized joins and the `NATURAL`/`USING` MERGED columns (ISO 9075
+  /// 7.10) of `select`'s join chain, resolved against the already-resolved
+  /// `relations` (the FROM relation first, then each joined one in source
+  /// order). A chain with no named-column join returns the joins verbatim and
+  /// an empty merged list, so an ordinary query is untouched.
+  ///
+  /// Rather than rewrite the AST — an emulation every reference site,
+  /// expression form, and pass ordering had to be taught — this models each
+  /// merged column ONCE as a scope entry, so the ordinary name→`Term` machinery
+  /// (`Scope.term`/`derive`, `Scope.terms(.all)`, `Grouping`) consumes it. The
+  /// merged column has NO physical slot: its value is `COALESCE(left, right)`
+  /// over the two PHYSICAL combined ordinals (each QUALIFIED-addressable),
+  /// and a bare reference to its name resolves to that coalesce (the entry
+  /// SHADOWS its constituents), while a qualified `A.c`/`B.c` reaches its own
+  /// side.
+  ///
+  /// The fold threads a growing PREFIX `Scope` — the relations `0…index` plus
+  /// the merged columns accumulated so far — so it resolves each join's common
+  /// columns THROUGH the scope, not by scanning a left array. For a `USING (c,
+  /// …)` join each `c` must resolve to exactly one left output column
+  /// (`Scope.left` — a name an accumulated plain `ON` join bound TWICE faults
+  /// `SQLError.ambiguous`, the finding-1 trap now a construction fault) and be
+  /// present on the right (else `SQLError.column`); a `NATURAL` join's are the
+  /// right schema's names the prefix's VISIBLE names share, left order (a
+  /// twice-bound left name faults `.ambiguous` when keyed). The join's `on`
+  /// becomes the conjunction of `left.c = right.c` — the LEFT operand a bare
+  /// `.column(c)` the prefix scope lowers to its resolved term (a coalesce when
+  /// `c` was already merged, so chained/outer keying is automatic) — empty for
+  /// a `NATURAL` join with no shared column, an always-true `CROSS`-equivalent
+  /// `on`. A merged column `c` = `COALESCE(leftTerm, right.slot)`, its unified
+  /// type; its constituents stay qualified-addressable. `USING (c, c)` (a
+  /// repeat in the single `common` list) faults `.duplicate` at construction.
+  internal func merges(over relations: Array<(Relation, Schema)>,
+                       _ joins: Array<Join>)
+      throws(SQLError) -> (ons: Array<Filter?>,
+                           merged: Array<Scope.Merged>,
+                           prefixes: Array<Array<Scope.Merged>>) {
+    guard joins.contains(where: { $0.using != nil }) else {
+      let empty = Array(repeating: Array<Scope.Merged>(), count: joins.count)
+      return (Array(repeating: nil, count: joins.count), [], empty)
+    }
+    // The synthesized `on` FILTER of each named-column join (`nil` for a plain
+    // `ON`/`CROSS` join, which lowers its own written `on`, or a degenerate
+    // `NATURAL` join with no shared column, an always-true `CROSS` product).
+    // It is lowered DIRECTLY here rather than re-lowered from a bare-name AST
+    // predicate — a chained merged column has no unambiguous bare spelling
+    // against a scope that also holds the joined-in relation's same-named
+    // column — carrying the resolved LEFT term (a coalesce when `c` was already
+    // merged) `= right.slot`.
+    var ons = Array<Filter?>()
+    ons.reserveCapacity(joins.count)
+    // The merged columns before each join's own relation joins — the surface
+    // that join's common-column resolution (and a LATERAL body's preceding
+    // scope) reads.
+    var prefixes = Array<Array<Scope.Merged>>()
+    prefixes.reserveCapacity(joins.count)
+    var merged = Array<Scope.Merged>()
+    for index in joins.indices {
+      prefixes.append(merged)
+      let (on, next) = try merging(join: joins[index], at: index,
+                                 over: relations, onto: merged)
+      ons.append(on)
+      merged = next
+    }
+    return (ons, merged, prefixes)
+  }
+
+  /// Folds the ONE `NATURAL`/`USING` merge step of the join at `index` onto the
+  /// merged columns `merged` accumulated by the joins to its left, returning
+  /// its synthesized `on` filter (`nil` for a plain `ON`/`CROSS` join or a
+  /// shared-column-less `NATURAL` one) and the extended merged set. This is the
+  /// SINGLE place a join's merged columns are derived — `merges(over:)` folds
+  /// it across the whole chain, and the incremental resolve loops
+  /// (`merged(through:…)`) fold it join-by-join to build a LATERAL body's
+  /// preceding scope — so no site can compute a join's merged columns a second,
+  /// divergent way.
+  ///
+  /// The LEFT scope is the relations `0…index` (the FROM relation and the joins
+  /// before this one) with the prior `merged`; the FULL scope adds the
+  /// joined-in relation, so its `range.c` right constituent resolves to a
+  /// combined ordinal. A `USING (c, …)` join's columns are the named ones (each
+  /// present on both sides, else `SQLError.column`; a repeat faults
+  /// `.duplicate`); a `NATURAL` join's are the prefix's visible names the right
+  /// schema shares, in left order. Each merged column is `COALESCE(leftTerm,
+  /// right.slot)` — a
+  /// coalesce left when `c` was already merged, so chained/outer keying follows
+  /// the merged value — its type the MASK-AWARE unification of the two
+  /// constituents through the set-operation `merge(_:_:)` (a constant-NULL/
+  /// placeholder side is UNCONSTRAINED and defers to the other; two constrained
+  /// sides unify, an irreconcilable pair faulting `.operand`/42804), and its
+  /// `on` conjunct a hash-join `match` key (pure `slot = slot`) or a residual
+  /// equi `compare`.
+  private func merging(join: Join, at index: Int,
+                       over relations: Array<(Relation, Schema)>,
+                       onto merged: Array<Scope.Merged>)
+      throws(SQLError) -> (on: Filter?, merged: Array<Scope.Merged>) {
+    let prefix = Scope(Array(relations[0 ... index]), merged: merged)
+    let scope = Scope(Array(relations[0 ... index + 1]), merged: merged)
+    let joined = relations[index + 1].1
+    let range = join.relation.alias ?? join.relation.name
+    guard let using = join.using else {
+      return (nil, merged)
+    }
+    // The joined-in relation's own spelling (its case) of a shared name, or
+    // `nil` when it exposes none — probed through the joined schema's FULL
+    // addressable surface (`Schema.ordinal(of:)`, virtual-aware), so a VIRTUAL
+    // column (the fixture/adapter `Id`) a `USING (Id)` join NAMES is FOUND the
+    // SAME way the predicate path `A.Id = B.Id` resolves it, not a real-only
+    // `names` membership that would spuriously fault `.column`. This is the
+    // EXPLICIT `USING (c, …)` probe ONLY — a `USING`-named virtual `Id` still
+    // resolves and merges. The spelling is taken from whichever list
+    // (`names`/`virtuals`) holds it.
+    func right(_ name: String) -> String? {
+      let folded = name.lowercased()
+      guard joined.ordinal(of: name) != nil else { return nil }
+      return (joined.names + joined.virtuals)
+          .first { $0.lowercased() == folded }
+    }
+    // The joined-in relation's own spelling of a shared REAL name, or `nil`
+    // when it exposes none as a real column — the `NATURAL` common-set probe. A
+    // `NATURAL` join's common set is the intersection of the two sides' REAL
+    // (`SELECT *`-visible) column names, virtuals EXCLUDED on BOTH sides: the
+    // left is already real-only (`prefix.names` reads the `expansion`, never a
+    // virtual), and this restricts the joined side to `joined.names` not its
+    // full virtual-aware surface. So a fixture/adapter VIRTUAL `Id` NEVER
+    // becomes a `NATURAL` common column — it participates only when EXPLICITLY
+    // named by `USING (Id)`, matching how `*`/`NATURAL` expose the same
+    // real-column set while an explicit reference resolves a virtual.
+    func real(_ name: String) -> String? {
+      let folded = name.lowercased()
+      return joined.names.first { $0.lowercased() == folded }
+    }
+    // The join columns in the LEFT side's order — a `NATURAL` join's the
+    // prefix's visible names the right schema shares (REAL names only, both
+    // sides), a `USING` join's the named ones (each present on both sides,
+    // virtual-aware, else `SQLError.column`).
+    let common: Array<String>
+    switch using {
+    case .natural:
+      common = prefix.names.filter { real($0) != nil }
+    case let .columns(columns):
+      for column in columns where right(column) == nil {
+        throw .column(column)
+      }
+      common = columns
+    }
+    // `USING (k, k)` — a repeat in the single `common` list — faults at
+    // construction (the eager behavior), not by trapping a dictionary init.
+    var seen = Set<String>()
+    for name in common where !seen.insert(name.lowercased()).inserted {
+      throw .duplicate(name)
+    }
+    // Each merged column and its synthesized `on` conjunct: the LEFT the
+    // prefix's resolved term for `c` (a coalesce when `c` was already merged,
+    // so a chained/outer key follows the merged value), the RIGHT the
+    // joined-in slot, the merged value their `COALESCE`, its type unified. A
+    // pure `slot = slot` conjunct lowers to the hash-join `match` key `nest`
+    // folds; a coalesced left is a residual equi `compare`.
+    var conjuncts = Array<Filter>()
+    var block = Array<Scope.Merged>()
+    for name in common {
+      let left = try prefix.left(name)
+      let target = Column(qualifier: range, name: right(name)!)
+      let slot = try scope.ordinal(of: target)
+      if case let .slot(source) = left.value {
+        conjuncts.append(Filter(match: source, slot))
+      } else {
+        conjuncts.append(.compare(left.value, .equal, .slot(slot)))
+      }
+      // The merged column's type is the MASK-AWARE unification of its two
+      // constituents, taken through the SAME `merge(_:_:)` machinery a
+      // set-operation arm fold uses rather than a bare `ValueType.unified` on
+      // the raw slot types: a constant-NULL/placeholder side is UNCONSTRAINED
+      // (it places no type constraint), so the merged type defers to the
+      // CONSTRAINED side — `(SELECT NULLIF(1,1) AS k) RIGHT JOIN B USING (k)`
+      // types `k` off `B.k` rather than the left's placeholder `integer`.
+      // Both constrained unify (`int ⊕ double → double`, an IRRECONCILABLE
+      // `int ⊕ text` FAULTS `.operand`/42804, the same fault the set-op fold
+      // raises); both unconstrained stay a placeholder. The coalesce COERCES
+      // each side to the resolved type, so a `RIGHT`/`FULL` join's
+      // unmatched-side value obeys the advertised type. An irreconcilable pair
+      // re-throws under the USING-specific message (the `.operand`/42804 code
+      // is what the caller matches), so the fault reads for the join criterion
+      // it arose from rather than the set-operation `merge` reports.
+      let unified: ResolvedColumn
+      do {
+        unified =
+            try merge(ResolvedColumn(name: name, type: left.type,
+                                     unconstrained: left.unconstrained),
+                      ResolvedColumn(name: name, type: scope.type(at: slot),
+                                     unconstrained:
+                                         scope.unconstrained(at: slot)))
+      } catch {
+        throw .operand("USING columns have irreconcilable types")
+      }
+      // The merged column's OWN mask: unconstrained ONLY when BOTH sides were
+      // (`merge` narrows to `right.unconstrained` after skipping an
+      // unconstrained left), so a downstream set-operation over the merged
+      // column defers when neither side ever constrained it, and constrains
+      // once either side did.
+      block.append(Scope.Merged(name: name,
+                                value: .coalesce([left.value, .slot(slot)],
+                                                 type: unified.type),
+                                type: unified.type,
+                                constituents: left.constituents + [slot],
+                                unconstrained: unified.unconstrained))
+    }
+    // ISO 9075 7.10 join output order: THIS join's common columns lead, then
+    // the rest of the LEFT output (recursively), then the right's rest. This
+    // join's `block` therefore PREPENDS ahead of the columns accumulated by the
+    // joins to its left — so a chained `(A JOIN B USING (k)) JOIN C USING (a)`
+    // exposes `[a, k, …]` (the outer `a`, then the inner `k`), not the flat
+    // fold order `[k, a, …]`. A chained `… USING (k)` over an ALREADY merged
+    // `k` DROPS the earlier entry (this `block`'s coalesce subsumes its
+    // constituents plus the new right slot), so `SELECT *` still exposes `k`
+    // ONCE and at the OUTER join's position.
+    let names = Set(block.map { $0.name.lowercased() })
+    let next = block + merged.filter { !names.contains($0.name.lowercased()) }
+    return (conjuncts.conjunction, next)
+  }
+
+  /// The `NATURAL`/`USING` merged columns accumulated by the joins `0..<count`
+  /// — the merged prefix a LATERAL body of the join AT `count` sees. Folds the
+  /// SAME per-join `merging` step `merges(over:)` does, over
+  /// `relations[0...count]`
+  /// (the FROM relation and the joins before `count`), so the incremental
+  /// resolve loops build each preceding scope through the ONE merge path rather
+  /// than a second, divergent construction.
+  internal func merged(through count: Int,
+                       over relations: Array<(Relation, Schema)>,
+                       _ joins: Array<Join>)
+      throws(SQLError) -> Array<Scope.Merged> {
+    var merged = Array<Scope.Merged>()
+    for index in 0 ..< count {
+      merged = try merging(join: joins[index], at: index, over: relations,
+                         onto: merged).merged
+    }
+    return merged
+  }
+
+  /// The preceding scope of the join AT `count` — the FROM relation and the
+  /// joins before it (`relations[0..<count + 1]`), carrying the merged columns
+  /// those joins expose (`merged(through:)`). This is the ONE constructor of a
+  /// join-prefix scope: every incremental resolve loop routes through it, so a
+  /// join-prefix scope can never be built without its merged columns (the
+  /// finding-1 class — a LATERAL body seeing the two physical join columns
+  /// rather than the ONE merged one).
+  internal func prefix(through count: Int,
+                       over relations: Array<(Relation, Schema)>,
+                       _ joins: Array<Join>)
+      throws(SQLError) -> Scope {
+    Scope(Array(relations[0 ..< count + 1]),
+          merged: try merged(through: count, over: relations, joins))
+  }
+
   /// Compiles `select` over this catalog into a logical operator tree in slot
   /// space.
   ///
@@ -4620,7 +4906,15 @@ extension Catalog where Self: ~Escapable {
     // arm's schema derives against the relations before it.
     let (joined, relations) = try resolve(from: relation, schema: from.schema,
                                           joins: select.joins, context)
-    let scope = Scope(relations)
+    // Model each `NATURAL`/`USING` join's MERGED columns (ISO 9075 7.10) in the
+    // join SCOPE, and synthesize each named-column join's lowered `left.c =
+    // right.c` `on` filter — a no-op yielding an empty merged set and all-`nil`
+    // `ons` for a chain with none, so an ordinary compile is unchanged. The
+    // scope carries the merged columns so the ordinary `terms`/`term`/order/
+    // `Grouping` machinery consumes them; a named-column join's `ons[index]`
+    // filter replaces its placeholder always-true `on`.
+    let (ons, merged, merges) = try merges(over: relations, select.joins)
+    let scope = Scope(relations, merged: merged)
 
     // Each join's ON predicate lowers to a `Filter` at its own chain level,
     // resolved against only the prefix already in scope plus the relation that
@@ -4635,10 +4929,11 @@ extension Catalog where Self: ~Escapable {
     // The WHERE and ORDER lower against the whole chain, which legitimately
     // sees every relation. Each join's PREFIX scope — the FROM relation and
     // joins `0…index`, the relations available AT that join point, never one
-    // joined LATER — the scope its `ON` lowers against and a subquery in that
-    // `ON` correlates against.
+    // joined LATER — carries the merged columns accumulated BEFORE this join
+    // (`merges[index]`), so a chained `USING` `on` keys on the merged value and
+    // an `ON` subquery's bare merged operand resolves.
     let prefixes = select.joins.indices.map { index in
-      Scope(Array(relations[0 ... index + 1]))
+      Scope(Array(relations[0 ... index + 1]), merged: merges[index])
     }
     // Resolve each LATERAL join's body ONCE against the PRECEDING FROM — the
     // FROM relation and the joins BEFORE this one (`relations[0…index]`, ONE
@@ -4657,7 +4952,8 @@ extension Catalog where Self: ~Escapable {
       guard join.kind == .inner || join.kind == .left else {
         throw .state("0A000", "a RIGHT/FULL LATERAL join is not supported")
       }
-      let preceding = Scope(Array(relations[0 ... index]))
+      let preceding = Scope(Array(relations[0 ... index]),
+                            merged: merges[index])
       laterals[index] = try lateral(body, against: preceding,
                                     columns: join.relation.columns, context)
     }
@@ -4673,9 +4969,17 @@ extension Catalog where Self: ~Escapable {
     var matches = Array<Filter>()
     matches.reserveCapacity(select.joins.count)
     for index in select.joins.indices {
-      let join = select.joins[index]
-      try matches.append(prefixes[index].on(join.on, context.routines,
-                                            subquery: plans.on(index)))
+      // A `NATURAL`/`USING` join's `on` is the SYNTHESIZED, already-lowered
+      // `left.c = right.c` filter (`ons[index]`, `nil` for a degenerate
+      // shared-column-less `NATURAL` join — an always-true `CROSS` product);
+      // a plain join lowers its written `ON` against the prefix scope.
+      if let on = ons[index] {
+        matches.append(on)
+      } else {
+        try matches.append(prefixes[index].on(select.joins[index].on,
+                                              context.routines,
+                                              subquery: plans.on(index)))
+      }
     }
     var predicate: Filter? = nil
     if let clause = select.predicate {

--- a/Sources/SQLEngine/Error.swift
+++ b/Sources/SQLEngine/Error.swift
@@ -89,10 +89,13 @@ public enum SQLError: Error, Hashable, Sendable {
   /// projection's arity is statically known, and as an engine backstop when the
   /// width is known only at resolution (a `SELECT *` body).
   case columns(expected: Int, got: Int)
-  /// A `CREATE VIEW` names two columns that collide — supplied explicitly or
-  /// inferred from the projection — under the case-insensitive resolution
+  /// Two columns collide under the case-insensitive resolution
   /// `Schema.ordinal(of:)` performs, so the shadowed column would be
-  /// unreachable; the string is the offending name.
+  /// unreachable — a `CREATE VIEW`'s two columns (supplied explicitly or
+  /// inferred from the projection), or a `NATURAL`/`USING` join's merged names
+  /// (`USING (k, k)`, or a `NATURAL` join whose left side already carries two
+  /// columns named `k`), which would build two output columns of one name. The
+  /// string is the offending name.
   case duplicate(String)
   /// A `WITH` list binds the same query name twice (case-insensitively), so the
   /// later definition would silently shadow the earlier; the string is the
@@ -175,7 +178,7 @@ extension SQLError: CustomStringConvertible {
       "column list count does not match the query-expression degree: "
           + "expected \(expected), got \(got)"
     case let .duplicate(name):
-      "duplicate view column '\(name)'"
+      "duplicate column '\(name)'"
     case let .redefinition(name):
       "WITH query name '\(name)' specified more than once"
     case let .arity(expected, found):

--- a/Sources/SQLEngine/Filter.swift
+++ b/Sources/SQLEngine/Filter.swift
@@ -1006,9 +1006,25 @@ extension Catalog where Self: ~Escapable {
     var extended = bindings
     for (name, source) in correlation {
       // A `bound` source is already in `bindings` (threaded by the containing
-      // subquery), so it passes through unchanged; only a `slot` reads this
-      // subquery's immediate enclosing row.
-      if case let .slot(slot) = source { extended[name] = row[slot] }
+      // subquery), so it passes through unchanged; a `slot` reads this
+      // subquery's immediate enclosing row, and a `coalesce` (a correlated
+      // `NATURAL`/`USING` merged column) reads the FIRST non-NULL of its
+      // constituent cells of that row — its ISO 7.10 merged value.
+      switch source {
+      case let .slot(slot):
+        extended[name] = row[slot]
+      case let .coalesce(slots, type):
+        var value = Value.null
+        for slot in slots {
+          let cell = row[slot]
+          if case .null = cell { continue }
+          value = cell.coerced(to: type)
+          break
+        }
+        extended[name] = value
+      case .bound:
+        break
+      }
     }
     return extended
   }

--- a/Sources/SQLEngine/Lexer.swift
+++ b/Sources/SQLEngine/Lexer.swift
@@ -429,6 +429,8 @@ internal struct Lexer: ~Escapable {
     case "OR": .or
     case "NOT": .not
     case "JOIN": .join
+    case "NATURAL": .natural
+    case "USING": .using
     case "LATERAL": .lateral
     case "INNER": .inner
     case "CROSS": .cross

--- a/Sources/SQLEngine/OutputColumn.swift
+++ b/Sources/SQLEngine/OutputColumn.swift
@@ -579,12 +579,25 @@ extension Catalog where Self: ~Escapable {
     // column, so its output shape types from that scope. A non-lateral join's
     // schema is correlation-independent, so the preceding scope is harmless.
     var relations = [(relation, try schema(of: relation, context))]
-    for join in select.joins {
-      let joined =
-          try schema(of: join.relation, context, preceding: Scope(relations))
-      relations.append((join.relation, joined))
+    for index in select.joins.indices {
+      // The PRECEDING scope carries the merged columns the joins before this
+      // one expose (`prefix(through:)`) — the SAME one-merge path the run's
+      // resolve loop threads — so a LATERAL body's schema derives its bare
+      // merged references against the ONE coalesced column rather than the two
+      // physical join columns.
+      let preceding =
+          try prefix(through: index, over: relations, select.joins)
+      let joined = try schema(of: select.joins[index].relation, context,
+                              preceding: preceding)
+      relations.append((select.joins[index].relation, joined))
     }
-    return Scope(relations)
+    // Model the `NATURAL`/`USING` merged columns (ISO 9075 7.10) in the scope
+    // so the schema path names and types the SAME output columns the run's
+    // `compile` projects — a bare merged column resolves to the coalesce type,
+    // and a `SELECT *` exposes it ONCE. Empty for a chain with no named-column
+    // join, so an ordinary scope is unchanged.
+    let merged = try merges(over: relations, select.joins).merged
+    return Scope(relations, merged: merged)
   }
 
   /// The PREFIX scope of each join of `select` — join `index`'s prefix is the
@@ -597,15 +610,23 @@ extension Catalog where Self: ~Escapable {
       throws(SQLError) -> Array<Scope> {
     guard let relation = select.from, !select.joins.isEmpty else { return [] }
     // Build the running scope INCREMENTALLY so a LATERAL join's schema derives
-    // against the PRECEDING FROM (the same reason `scope(of:)` does).
+    // against the PRECEDING FROM (the same reason `scope(of:)` does), the
+    // preceding scope carrying the joins-before's merged columns through the
+    // ONE merge path (`prefix(through:)`).
     var relations = [(relation, try schema(of: relation, context))]
-    for join in select.joins {
-      let joined =
-          try schema(of: join.relation, context, preceding: Scope(relations))
-      relations.append((join.relation, joined))
+    for index in select.joins.indices {
+      let preceding =
+          try prefix(through: index, over: relations, select.joins)
+      let joined = try schema(of: select.joins[index].relation, context,
+                              preceding: preceding)
+      relations.append((select.joins[index].relation, joined))
     }
+    // Each join's prefix carries the merged columns accumulated BEFORE it (the
+    // same `merges` the run's `compile` threads), so an `ON` subquery's bare
+    // merged outer operand resolves the same way the run does.
+    let merges = try merges(over: relations, select.joins).prefixes
     return select.joins.indices.map { index in
-      Scope(Array(relations[0 ... index + 1]))
+      Scope(Array(relations[0 ... index + 1]), merged: merges[index])
     }
   }
 
@@ -1066,6 +1087,21 @@ extension Catalog where Self: ~Escapable {
     for expression in select.orderKeys {
       try scope.aggregates(in: expression, routines, subquery: barred)
     }
+    // Each GROUP BY key is EVALUATED over the input rows to form the groups,
+    // BEFORE the HAVING, the projection, and any limit — so validate every key
+    // here, unconditionally in this reachable path (the constant-false WHERE
+    // above already returned, forming no group and evaluating no key). Route
+    // each key through the SAME per-operand type-check the projection and
+    // ORDER BY keys use (`validate`), so a bare `.column` key (the only shape
+    // the parser yields today, a `NATURAL`/`USING` merged column among them)
+    // resolves exactly as it does elsewhere — the merged binding shadowing its
+    // two sides — while an evaluatable key surfaces its fault (a divide,
+    // overflow, bad-type op, or unknown/misapplied call) under `validate`
+    // exactly as the run evaluates it, closing the gap where `group` lowers the
+    // key structurally (no evaluation) so `compile` alone never surfaces it.
+    for expression in select.grouping {
+      _ = try scope.validate(expression, routines, subquery: barred)
+    }
     if let having = select.having {
       try scope.aggregates(in: having, routines, subquery: barred)
       try scope.check(having, routines, subquery: barred)
@@ -1159,12 +1195,18 @@ extension Catalog where Self: ~Escapable {
         aggregations.append(aggregation)
       }
     }
+    // The GROUP BY keys' LOWERED base-ordinal terms, so a bare `NATURAL`/
+    // `USING` merged key (which binds no single ordinal) is matched by term —
+    // the SAME lowering the run's `group` computes.
+    let keys = try select.grouping.map { key throws(SQLError) -> Term in
+      try scope.term(key, routines, subquery: subquery.barred)
+    }
     // Build the grouping and lower the projection through it to record each
     // output name (an alias, else a group column's own name) — the surface an
     // `ORDER BY` output name resolves against — then lower the `ORDER BY`,
     // which faults a non-group column, an out-of-range ordinal, or an ambiguous
     // name.
-    var grouping = try Grouping(scope, select.grouping, aggregations,
+    var grouping = try Grouping(scope, select.grouping, keys, aggregations,
                                 subquery: subquery)
     let projection = try grouping.terms(select.projection, routines,
                                         subquery: subquery)
@@ -1334,19 +1376,25 @@ extension Scope {
     }
   }
 
-  /// The output columns of a `SELECT *` over this scope — every real column of
-  /// every relation, in chain order, named and typed from each relation's
-  /// schema (never a virtual column) and carrying its source column's
-  /// `unconstrained` mask (an all-arms-NULL CTE column stays unconstrained
-  /// through a `*` expansion) — the terms `terms(.all)` projects.
+  /// The output columns of a `SELECT *` over this scope — the merged columns
+  /// first, then the real columns the shared `expansion` enumeration emits, in
+  /// chain order, named and typed from each relation's schema (never a virtual
+  /// column) and carrying its source column's `unconstrained` mask (an
+  /// all-arms-NULL CTE column stays unconstrained through a `*` expansion) —
+  /// the terms `terms(.all)` projects.
   internal func outputs() -> Array<ResolvedColumn> {
-    schemas.flatMap { schema in
-      (0 ..< schema.width).map {
-        ResolvedColumn(OutputColumn(name: schema.names[$0],
-                                    type: schema.types[$0]),
-                       unconstrained: schema.unconstrained[$0])
-      }
-    }
+    // The `NATURAL`/`USING` merged columns FIRST (ISO 9075 7.10) — each named
+    // by its merged name and typed by its unified coalesce type — then every
+    // real column the shared `expansion` enumeration yields, resolved at its
+    // combined ordinal (name/type/mask read TOGETHER, `resolved(at:named:)`),
+    // so the schema names the SAME columns the run's `terms(.all)` projects and
+    // `width(of: .all)` counts. Each merged output is built through the SAME
+    // `resolved(named:)` the explicit `output(of:)` uses, so a `SELECT *`
+    // carries the merged column's `unconstrained` mask (two constant-NULL
+    // constituents leave the merged `k` unconstrained) exactly as a bare
+    // `SELECT k` does.
+    merges.map { $0.resolved(named: $0.name) }
+        + expansion.map { resolved(at: $0, named: name(at: $0)) }
   }
 
   /// The resolved output column a bare `column` reference yields — its own name
@@ -1363,6 +1411,17 @@ extension Scope {
   internal func output(of column: Column,
                        subquery: Resolution = .unsupported)
       throws(SQLError) -> ResolvedColumn {
+    // A BARE name matching a `NATURAL`/`USING` merged column (ISO 9075 7.10)
+    // names and types from the merged column — its unified coalesce type — with
+    // no physical ordinal, matching the run's `term`; a same-named physical
+    // column a later plain join added faults `.ambiguous`. It carries the
+    // merged column's OWN `unconstrained` mask, so a `… USING (k) UNION SELECT
+    // 1` over two constant-NULL constituents defers the unified type to the
+    // typed arm rather than hard-coding the merged column constrained.
+    if column.qualifier == nil,
+        let merged = try merged(binding: column.name) {
+      return merged.resolved(named: column.name)
+    }
     if let resolved = try resolved(column) {
       return resolved
     }

--- a/Sources/SQLEngine/Parser.swift
+++ b/Sources/SQLEngine/Parser.swift
@@ -32,8 +32,12 @@
 ///                   // LATERAL is legal only on a derived table in a join
 /// derived        := '(' query ')' AS identifier  // a derived table (aliased);
 ///                   // the query may be a SELECT, TABLE t, or VALUES (…)
-/// join           := ([INNER | (LEFT | RIGHT | FULL) [OUTER]] JOIN
-///                     relation ON predicate)
+/// join           := ([NATURAL] [INNER | (LEFT | RIGHT | FULL) [OUTER]] JOIN
+///                     relation [ON predicate | USING '(' identifier
+///                                (',' identifier)* ')'])
+///                     // ON and USING are mutually exclusive, and NATURAL bars
+///                     // both (its columns are the shared ones); a non-NATURAL
+///                     // non-CROSS join requires exactly one of ON/USING
 ///                  | (CROSS JOIN relation)  // Cartesian product, no ON/USING
 ///                   // INNER JOIN LATERAL = CROSS APPLY, LEFT = OUTER APPLY;
 ///                   // the derived body may reference preceding FROM items
@@ -488,7 +492,8 @@ internal struct Parser: ~Escapable {
 
     var joins = Array<Join>()
     while let kind = try joinKind() {
-      try joins.append(join(kind.kind, cross: kind.cross))
+      try joins.append(join(kind.kind, cross: kind.cross,
+                            natural: kind.natural))
     }
     let predicate: Predicate? = if try match(.where) {
       try predicate()
@@ -514,15 +519,18 @@ internal struct Parser: ~Escapable {
   }
 
   /// Parses `BY column (, column)*` (the `GROUP` keyword is already consumed) —
-  /// the `GROUP BY` grouping columns, in source order.
-  private mutating func grouping() throws(SQLError) -> Array<Column> {
+  /// the `GROUP BY` keys, in source order. Each key parses as a `column` and is
+  /// carried as a bare `Expression.column`; the general `Expression` element
+  /// lets a bare `NATURAL`/`USING` merged key lower to its coalesce value
+  /// through the join scope, never a parsed general expression.
+  private mutating func grouping() throws(SQLError) -> Array<Expression> {
     try expect(.by)
-    var columns = Array<Column>()
-    try columns.append(column())
+    var keys = Array<Expression>()
+    try keys.append(.column(column()))
     while try match(.comma) {
-      try columns.append(column())
+      try keys.append(.column(column()))
     }
-    return columns
+    return keys
   }
 
   // MARK: - Relation
@@ -626,22 +634,29 @@ internal struct Parser: ~Escapable {
 
   /// Parses an optional join `kind` and its `JOIN` keyword at the current
   /// position, or `nil` when no join clause begins here. The `cross` flag marks
-  /// a `CROSS JOIN` — an unqualified Cartesian product taking no `ON`/`USING`.
+  /// a `CROSS JOIN` — an unqualified Cartesian product taking no `ON`/`USING` —
+  /// and `natural` a `NATURAL` join, whose columns are the ones the two sides
+  /// share (resolved by name, so it takes no `ON`/`USING` either).
   ///
   /// A bare `JOIN` (or an explicit `INNER JOIN`) is `.inner`; `LEFT`/`RIGHT`/
   /// `FULL` introduce an outer join, each admitting an optional `OUTER` noise
   /// word before the mandatory `JOIN`; `CROSS` introduces a Cartesian product,
   /// lowered as an `.inner` join over a synthesized always-true predicate. A
-  /// leading `INNER`/`CROSS`/`LEFT`/`RIGHT`/`FULL` commits to a join clause, so
-  /// a missing `JOIN` after it faults rather than silently ending the chain.
+  /// leading `NATURAL` prefixes any of the inner/outer varieties (`NATURAL
+  /// [INNER | LEFT | RIGHT | FULL [OUTER]] JOIN`), but not `CROSS`. A leading
+  /// `NATURAL`/`INNER`/`CROSS`/`LEFT`/`RIGHT`/`FULL` commits to a join clause,
+  /// so a missing `JOIN` after it faults rather than silently ending the chain.
   private mutating func joinKind()
-      throws(SQLError) -> (kind: Join.Kind, cross: Bool)? {
-    if try match(.join) { return (.inner, false) }
-    if try match(.cross) {
+      throws(SQLError) -> (kind: Join.Kind, cross: Bool, natural: Bool)? {
+    let natural = try match(.natural)
+    if try match(.join) { return (.inner, false, natural) }
+    // `CROSS` is a product join taking no criterion, so `NATURAL CROSS` is
+    // ill-formed; reject it rather than silently drop the `NATURAL`.
+    if !natural, try match(.cross) {
       // `CROSS JOIN` is the Cartesian product; it carries no inner/outer word
       // and no `ON`, and lowers as an `.inner` join over an always-true `on`.
       try expect(.join)
-      return (.inner, true)
+      return (.inner, true, false)
     }
     let kind: Join.Kind
     if try match(.inner) {
@@ -652,6 +667,11 @@ internal struct Parser: ~Escapable {
       kind = .right
     } else if try match(.full) {
       kind = .full
+    } else if natural {
+      // A `NATURAL` with no inner/outer word is a `NATURAL [INNER] JOIN`; the
+      // mandatory `JOIN` must follow.
+      try expect(.join)
+      return (.inner, false, true)
     } else {
       return nil
     }
@@ -659,32 +679,55 @@ internal struct Parser: ~Escapable {
     // carries it. Either way `JOIN` must follow.
     if kind != .inner { _ = try match(.outer) }
     try expect(.join)
-    return (kind, false)
+    return (kind, false, natural)
   }
 
   /// Parses the join tail (the `kind` and `JOIN` keyword are already consumed):
-  /// a relation and, unless `cross`, an `ON` and an arbitrary boolean predicate
-  /// — the same grammar a `WHERE` admits, so a join relates its sides by an
-  /// equality, an inequality, an expression equality, or any `AND`/`OR`/`NOT`
-  /// of comparisons. A pure `column = column` conjunct hash-joins; the rest is
-  /// a residual filter.
+  /// a relation and its join criterion. A plain join takes exactly one of `ON
+  /// <predicate>` (an arbitrary boolean expression, the same grammar a `WHERE`
+  /// admits, so a join relates its sides by an equality, an inequality, an
+  /// expression equality, or any `AND`/`OR`/`NOT` of comparisons — a pure
+  /// `column = column` conjunct hash-joins, the rest a residual filter) or
+  /// `USING '(' identifier (, identifier)* ')'` (the named-column shorthand,
+  /// resolved into an equality `on` and a coalesced `SELECT *` at compile). A
+  /// `NATURAL` join (`natural`) takes NEITHER — its columns are the shared ones
+  /// — so a trailing `ON`/`USING` after it faults; a plain non-`CROSS` join
+  /// requires exactly one of them.
   ///
-  /// A `CROSS JOIN` (`cross`) takes NO `ON`/`USING` — a trailing `ON` is a
-  /// syntax error, caught by leaving `on` unconsumed for the caller's `where`/
+  /// A `CROSS JOIN` (`cross`) takes NO criterion — a trailing `ON`/`USING` is a
+  /// syntax error, caught by leaving it unconsumed for the caller's `where`/
   /// end-of-select expectation to reject. Its `on` is a synthesized `1 = 1`,
   /// which lowers to a constant-true filter the optimiser elides, collapsing
   /// the join to a bare `.product` — the Cartesian product, equivalent to an
   /// inner join written `ON 1 = 1`.
-  private mutating func join(_ kind: Join.Kind,
-                             cross: Bool) throws(SQLError) -> Join {
+  private mutating func join(_ kind: Join.Kind, cross: Bool,
+                             natural: Bool) throws(SQLError) -> Join {
     let relation = try relation()
-    guard cross else {
-      try expect(.on)
-      let on = try predicate()
+    if natural {
+      // A `NATURAL` join resolves its columns by name; an `ON`/`USING` after it
+      // is ill-formed (its criterion is fixed), so leave the token for the
+      // caller's clause expectation to reject.
+      return Join(relation: relation, kind: kind, using: .natural)
+    }
+    if cross {
+      let on = Predicate.comparison(left: .literal(.integer(1)), op: .equal,
+                                    right: .literal(.integer(1)))
       return Join(relation: relation, kind: kind, on: on)
     }
-    let on = Predicate.comparison(left: .literal(.integer(1)), op: .equal,
-                                  right: .literal(.integer(1)))
+    if try match(.using) {
+      // `USING` requires a parenthesised, non-empty column list; `names()`
+      // yields `nil` when no `(` follows, which is a syntax error here.
+      guard let columns = try names() else {
+        guard let token = current else {
+          throw .incomplete(expected: "'(' after USING")
+        }
+        throw .unexpected(token.kind.description, expected: "'(' after USING",
+                          at: token.location)
+      }
+      return Join(relation: relation, kind: kind, using: .columns(columns))
+    }
+    try expect(.on)
+    let on = try predicate()
     return Join(relation: relation, kind: kind, on: on)
   }
 

--- a/Sources/SQLEngine/Resolve.swift
+++ b/Sources/SQLEngine/Resolve.swift
@@ -157,6 +157,15 @@ internal struct PlanKey: Hashable, Sendable {
 internal enum Source: Hashable, Sendable {
   /// The value is the current outer row's cell at this combined ordinal.
   case slot(Int)
+  /// The value is the `COALESCE` (first non-NULL) of the current outer row's
+  /// cells at these combined ordinals, COERCED to the unified `type` — a
+  /// `NATURAL`/`USING` MERGED column of an enclosing join scope (ISO 9075
+  /// 7.10), whose value belongs to NEITHER physical side but to their coalesce,
+  /// correlated into a LATERAL body (or any nested subquery) as its ONE merged
+  /// column. It reads the outer row rather than a threaded binding, exactly as
+  /// `slot`, over MORE than one cell, matching the merged column's own
+  /// `COALESCE(left, right)` value the local scope lowers.
+  case coalesce(Array<Int>, ValueType)
   /// The value is already in `bindings` — threaded down by the containing
   /// subquery — so the eval passes it through unchanged.
   case bound
@@ -194,6 +203,8 @@ extension Dictionary where Key == String, Value == Source {
       switch source {
       case let .slot(ordinal):
         .slot(slot[ordinal]!)
+      case let .coalesce(ordinals, type):
+        .coalesce(ordinals.map { slot[$0]! }, type)
       case .bound:
         .bound
       }
@@ -201,13 +212,20 @@ extension Dictionary where Key == String, Value == Source {
   }
 
   /// The outer ordinals this correlation reads from the immediate enclosing row
-  /// — every `slot` source's ordinal, excluding the `bound` (threaded-binding)
-  /// sources — the cells that must be materialised for a per-outer-row
-  /// re-execution.
+  /// — every `slot` source's ordinal and every `coalesce` source's constituent
+  /// ordinals, excluding the `bound` (threaded-binding) sources — the cells
+  /// that must be materialised for a per-outer-row re-execution.
   internal var slots: Set<Int> {
     var slots = Set<Int>()
     for source in values {
-      if case let .slot(ordinal) = source { slots.insert(ordinal) }
+      switch source {
+      case let .slot(ordinal):
+        slots.insert(ordinal)
+      case let .coalesce(ordinals, _):
+        slots.formUnion(ordinals)
+      case .bound:
+        break
+      }
     }
     return slots
   }
@@ -283,6 +301,23 @@ internal final class Outer {
     ":__correlated_\(depth)_\(ordinal)"
   }
 
+  /// The synthetic `:parameter` name a correlated reference to a
+  /// `NATURAL`/`USING` MERGED column of enclosing scope `depth` lowers to —
+  /// keyed by the merged column's LEFT constituent ordinal but in a DISTINCT
+  /// namespace from `name(for:at:)`, so it cannot collide with the physical
+  /// parameter of ANY constituent slot. A LATERAL body that references BOTH the
+  /// bare merged column (this key) AND a physical constituent `A.k` (the
+  /// physical `name(for:at:)` key) thus gets TWO correlation entries, one per
+  /// reference, so the merged coalesce and the qualified slot each bind their
+  /// own value regardless of lowering order (a shared key let one overwrite the
+  /// other). The left constituent ordinal uniquely identifies the merged column
+  /// within a scope — each merged column stands over its own physical slots —
+  /// so it is a stable, deterministic identity across the run and schema
+  /// lowerings, as `name(for:at:)` is.
+  private func parameter(merging ordinal: Int, at depth: Int) -> String {
+    ":__merged_\(depth)_\(ordinal)"
+  }
+
   /// The synthetic bound-parameter name `column` correlates to, or `nil` when
   /// no enclosing scope binds it (the ordinary unknown-column fault stands).
   ///
@@ -296,31 +331,47 @@ internal final class Outer {
   /// a NOT-FOUND (`nil`) keeps the walk moving outward.
   internal func parameter(for column: Column) throws(SQLError) -> String? {
     for depth in scopes.indices.reversed() {
+      // A bare (unqualified) name a `NATURAL`/`USING` join of this enclosing
+      // scope MERGED (ISO 9075 7.10) correlates to its ONE coalesce value — the
+      // merged entry shadows its two physical constituents, so a LATERAL body's
+      // bare `k` binds the merged column rather than faulting `.ambiguous`
+      // between the two sides. Its source is the `COALESCE` of its constituent
+      // outer cells, coerced to its unified type, matching the merged column's
+      // own `value` the local scope lowers. A qualified `A.k`/`B.k` never
+      // matches a merged column and falls through to the physical probe.
+      if column.qualifier == nil,
+          let merged = try scopes[depth].merged(binding: column.name) {
+        let name = parameter(merging: merged.constituents[0], at: depth)
+        record(name, .coalesce(merged.constituents, merged.type),
+               matching: depth)
+        return name
+      }
       guard let ordinal = try scopes[depth].correlated(column) else { continue }
       let name = name(for: ordinal, at: depth)
-      record(name, ordinal, matching: depth)
+      record(name, .slot(ordinal), matching: depth)
       return name
     }
     return nil
   }
 
-  /// Records the correlation of `name` (the outer combined `ordinal` it reads)
-  /// matched at enclosing-scope `depth`.
+  /// Records the correlation of `name` — the `source` its per-outer-row value
+  /// comes from — matched at enclosing-scope `depth`.
   ///
   /// A match at the LAST scope (this subquery's immediate parent) reads that
-  /// outer row directly, so the source is the parent-row `slot`. A match at an
-  /// EARLIER scope is a correlation of the CONTAINING subquery too: it is
-  /// recorded `bound` here — the eval threads the value through `bindings`
-  /// rather than reading this subquery's own row — and propagated up to
-  /// `parent` (whose last scope is one level nearer), so the containing
-  /// occurrence is itself marked correlated and re-executes per its enclosing
-  /// row. Since a `Scope` lays relations at cumulative offsets from 0, the
-  /// `ordinal` is the same in every level that shares the matched scope, so the
-  /// ancestor that owns it as its IMMEDIATE parent reads the right cell.
-  private func record(_ name: String, _ ordinal: Int, matching depth: Int) {
+  /// outer row directly, so the source is the parent-row `source` as given (a
+  /// `slot` cell or a merged column's `coalesce`). A match at an EARLIER scope
+  /// is a correlation of the CONTAINING subquery too: it is recorded `bound`
+  /// here — the eval threads the value through `bindings` rather than reading
+  /// this subquery's own row — and the SAME `source` propagated up to `parent`
+  /// (whose last scope is one level nearer), so the containing occurrence is
+  /// itself marked correlated and re-executes per its enclosing row. Since a
+  /// `Scope` lays relations at cumulative offsets from 0, the source's ordinals
+  /// are the same in every level that shares the matched scope, so the ancestor
+  /// that owns it as its IMMEDIATE parent reads the right cells.
+  private func record(_ name: String, _ source: Source, matching depth: Int) {
     let immediate = depth == scopes.count - 1
-    correlation[name] = immediate ? .slot(ordinal) : .bound
-    if !immediate { parent?.record(name, ordinal, matching: depth) }
+    correlation[name] = immediate ? source : .bound
+    if !immediate { parent?.record(name, source, matching: depth) }
   }
 
   /// The value type of the enclosing column `column` names, or `nil` when no
@@ -348,6 +399,19 @@ internal final class Outer {
   internal func resolved(for column: Column) throws(SQLError)
       -> ResolvedColumn? {
     for scope in scopes.reversed() {
+      // A bare name an enclosing `NATURAL`/`USING` join MERGED types from the
+      // merged column's unified coalesce type (ISO 9075 7.10) — the SAME entry
+      // `parameter(for:)` binds — so the schema-derive and the run's lowering
+      // agree on a correlated merged reference. It carries the merged column's
+      // OWN `unconstrained` mask (constrained once either constituent did, a
+      // placeholder only when BOTH were unconstrained), so an enclosing
+      // set-operation fold over the correlated merged reference defers or
+      // constrains consistently. A qualified name falls through to the physical
+      // probe.
+      if column.qualifier == nil,
+          let merged = try scope.merged(binding: column.name) {
+        return merged.resolved(named: column.name)
+      }
       guard let ordinal = try scope.correlated(column) else { continue }
       return scope.resolved(at: ordinal, named: column.name)
     }
@@ -1713,12 +1777,64 @@ internal struct Scope {
     let offset: Int
   }
 
+  /// A `NATURAL`/`USING` MERGED column (ISO 9075 7.10) — the ONE common column
+  /// a named-column join exposes, belonging to NEITHER side. It has NO physical
+  /// slot of its own: its `value` is the `COALESCE(left, right)` over the two
+  /// PHYSICAL combined ordinals it merges (each still addressable QUALIFIED),
+  /// and its `type` the unified coalesce type. A bare (unqualified) reference
+  /// to its `name` resolves to `value` — the merged entry SHADOWS its physical
+  /// constituents for bare lookup — while a qualified `A.c`/`B.c` never matches
+  /// it and reaches its own slot.
+  internal struct Merged: Sendable {
+    let name: String
+    let value: Term
+    let type: ValueType
+    /// The two PHYSICAL combined ordinals this merged column coalesces — the
+    /// left constituent and the right one — kept so a `SELECT *` drops them
+    /// (each is exposed ONCE, via the merged `value`, not twice as itself).
+    let constituents: Array<Int>
+    /// Whether the merged column places NO type constraint — TRUE only when
+    /// BOTH constituents were unconstrained (each an all-NULL/placeholder
+    /// column), so a `USING` merge of two constant-NULL sides stays a
+    /// placeholder that a further enclosing set-operation fold unifies with any
+    /// typed arm; FALSE when EITHER side constrained the merged type. The
+    /// `unconstrained` bit the set-operation `merge(_:_:)` computes, carried so
+    /// a downstream `output(of:)`/correlated read reports it rather than
+    /// hard-coding the merged column constrained.
+    let unconstrained: Bool
+
+    /// This merged column as an output `ResolvedColumn` — its `type` AND its
+    /// `unconstrained` mask carried TOGETHER, named `name` (the reference's
+    /// spelling for a bare `output(of:)`, else the merged column's own `name`
+    /// for a `SELECT *`). The SINGLE construction both the `SELECT *`
+    /// (`outputs`) and the explicit bare `output(of:)` merged-output paths
+    /// route through, so neither can drop the mask the other carries.
+    internal func resolved(named name: String) -> ResolvedColumn {
+      ResolvedColumn(OutputColumn(name: name, type: type),
+                     unconstrained: unconstrained)
+    }
+  }
+
   private let members: Array<Member>
+
+  /// The `NATURAL`/`USING` merged columns of the join chain, in ISO 7.10 order
+  /// — a bare reference to one resolves to its coalesce `value`, and a
+  /// `SELECT *` prepends them ahead of the members' remaining physical columns.
+  /// Empty for a chain with no named-column join, so an ordinary scope is
+  /// unchanged.
+  private let merged: Array<Merged>
+
+  /// The physical combined ordinals a merged column subsumes — the union of
+  /// every `Merged.constituents` — so a `SELECT *` skips them (each is exposed
+  /// ONCE via its merged `value`).
+  private let subsumed: Set<Int>
 
   /// Builds a scope over `relations` — the `FROM` relation first, then each
   /// joined relation in source order — laying each past the previous one's
-  /// `extent`.
-  internal init(_ relations: Array<(Relation, Schema)>) {
+  /// `extent`, carrying the `NATURAL`/`USING` `merged` columns (empty for a
+  /// chain with none).
+  internal init(_ relations: Array<(Relation, Schema)>,
+                merged: Array<Merged> = []) {
     var members = Array<Member>()
     members.reserveCapacity(relations.count)
     var offset = 0
@@ -1727,6 +1843,147 @@ internal struct Scope {
       offset += schema.extent
     }
     self.members = members
+    self.merged = merged
+    self.subsumed = Set(merged.flatMap(\.constituents))
+  }
+
+  /// The merged column named `name` (case-insensitively), or `nil` when none —
+  /// the entry a bare reference SHADOWS its two physical constituents with.
+  private func merged(_ name: String) -> Merged? {
+    let folded = name.lowercased()
+    return merged.first { $0.name.lowercased() == folded }
+  }
+
+  /// The `NATURAL`/`USING` merged column a BARE `name` resolves to (ISO 9075
+  /// 7.10), or `nil` when none is merged under that name — the binding
+  /// `term`/`derive`/`output(of:)` shadow the two physical sides with.
+  ///
+  /// The merged column shadows its OWN constituents, but an addressable column
+  /// of the same name a LATER PLAIN join contributed (`… USING (k) JOIN C …`, C
+  /// carrying its own `k`) is NOT a constituent — a bare `k` now names both
+  /// the merged column and that other one, so it faults `SQLError.ambiguous`
+  /// rather than silently taking the merged value. A qualified `A.k`/`C.k`
+  /// never reaches here and stays unambiguous.
+  ///
+  /// The conflict scan is the FULL addressable surface (`addressable` —
+  /// physical AND virtual, the same surface `ordinal(of:)` resolves against),
+  /// EXCLUDING the merged column's own physical constituents. So a merged `Id`
+  /// (a virtual join column) coexisting with a later plain join's own VIRTUAL
+  /// `Id` faults `.ambiguous` just as a real conflict does — the two axes stay
+  /// consistent because neither the merged bare lookup nor the ordinary one
+  /// scans a partial surface.
+  internal func merged(binding name: String) throws(SQLError) -> Merged? {
+    guard let merged = merged(name) else { return nil }
+    for ordinal in addressable(Column(name: name))
+        where !subsumed.contains(ordinal) {
+      throw .ambiguous(name)
+    }
+    return merged
+  }
+
+  /// Whether the real column at `member`'s local `ordinal` is a PHYSICAL
+  /// constituent a merged column subsumes — one a `SELECT *` drops, since the
+  /// merged `value` already exposes it ONCE.
+  private func subsumed(_ member: Member, _ ordinal: Int) -> Bool {
+    subsumed.contains(member.offset + ordinal)
+  }
+
+  /// The `NATURAL`/`USING` merged columns, in ISO 7.10 order — the surface the
+  /// schema-path `SELECT *`/bare-column resolution (`outputs`/`output(of:)`)
+  /// reads to name and type a merged output column, matching the run's `terms`.
+  internal var merges: Array<Merged> { merged }
+
+  /// The merged column named `name` (case-insensitively), or `nil` when none —
+  /// the probe `Grouping` uses to route a bare merged key to term-matching
+  /// rather than the ordinal `keys` map its `find` cannot fill.
+  internal func merges(_ name: String) -> Merged? { merged(name) }
+
+  /// Whether the real column at combined `ordinal` is a PHYSICAL constituent a
+  /// merged column subsumes — the schema-path `SELECT *` (`outputs`) drops it.
+  internal func subsumes(_ ordinal: Int) -> Bool { subsumed.contains(ordinal) }
+
+  /// The combined ordinals of the REAL columns a `SELECT *` emits AFTER the
+  /// merged block — every relation's real column at its combined ordinal, in
+  /// chain order, skipping a physical constituent a merged column subsumes
+  /// (each exposed ONCE via its merged `value`). Never a virtual ordinal.
+  ///
+  /// This is the ONE walk the `SELECT *` surfaces share, so its length and its
+  /// membership cannot drift between them: `terms(.all)` maps each to a
+  /// `.slot`, `outputs`/`names` read each column's name and type, and
+  /// `width(of: .all)` is `merged.count` plus this count — the width DERIVED
+  /// from the same enumeration that emits the columns, not a parallel formula.
+  internal var expansion: Array<Int> {
+    var ordinals = Array<Int>()
+    for member in members {
+      for ordinal in 0 ..< member.schema.width
+          where !subsumed(member, ordinal) {
+        ordinals.append(member.offset + ordinal)
+      }
+    }
+    return ordinals
+  }
+
+  /// The visible (unqualified) column NAMES this scope resolves, in chain order
+  /// — the `NATURAL`/`USING` merged columns first, then each member's real
+  /// column names skipping a physical constituent a merged column subsumes.
+  /// This is the LEFT side's output-name list a `NATURAL` join intersects with
+  /// the joined-in relation to find its common columns. It reads the ONE
+  /// `expansion` enumeration the `SELECT *` surfaces share, resolving each
+  /// combined ordinal back to its owning relation's spelling (`name(at:)`).
+  internal var names: Array<String> {
+    merged.map(\.name) + expansion.map { name(at: $0) }
+  }
+
+  /// The (unqualified) name of the real column at combined `ordinal` — the
+  /// reverse of the chain layout, resolving `ordinal` to its owning relation
+  /// and that relation's spelling. A combined `ordinal` from `expansion` always
+  /// names a real column (`local < width`); the fallback empty string never
+  /// arises for an `expansion` ordinal. Shared by `names` and the schema-path
+  /// `SELECT *` (`outputs`), so both name the columns `expansion` emits.
+  internal func name(at ordinal: Int) -> String {
+    for member in members {
+      let local = ordinal - member.offset
+      if local >= 0, local < member.schema.width {
+        return member.schema.names[local]
+      }
+    }
+    return ""
+  }
+
+  /// The LEFT-side resolution of a bare join column `name` when building a
+  /// `NATURAL`/`USING` merged column: its value `Term`, its `type`, its
+  /// `unconstrained` mask, and the PHYSICAL combined ordinals it stands over.
+  ///
+  /// The `unconstrained` mask is the CONSTITUENT'S — an earlier-merged column's
+  /// own accumulated bit, else the physical column's `unconstrained(at:)` — so
+  /// the `NATURAL`/`USING` type merge honors an all-NULL/placeholder left the
+  /// SAME way the set-operation fold does (a constant-NULL left constrains
+  /// nothing, deferring the merged type to the right).
+  ///
+  /// A name an earlier join already MERGED resolves to that merged column — its
+  /// coalesce `value`, unified `type`, and constituent ordinals — so a chained
+  /// `… USING (k)` keys on the merged value (a `RIGHT`/`FULL` join's left-NULL
+  /// row still joins), THROUGH the FULL ambiguity-aware bare lookup
+  /// (`merged(binding:)`): a merged entry that now COEXISTS with a physical
+  /// column of the same name a LATER PLAIN join re-introduced (`… USING (k) …
+  /// JOIN C ON … JOIN … USING (k)`, C carrying its own `k`) is AMBIGUOUS, so
+  /// keying a later `USING` on it faults `SQLError.ambiguous` here rather than
+  /// silently taking the merged value and leaving two output columns named `k`.
+  /// A name NOT yet merged must resolve to EXACTLY ONE left physical column
+  /// (`ordinal(of:)`); an accumulated-left name bound TWICE (a plain `ON` join
+  /// left two columns of that name) faults `SQLError.ambiguous` here, the
+  /// finding-1 trap now a first-class fault at construction rather than a
+  /// downstream crash.
+  internal func left(_ name: String) throws(SQLError)
+      -> (value: Term, type: ValueType, unconstrained: Bool,
+          constituents: Array<Int>) {
+    if let merged = try merged(binding: name) {
+      return (merged.value, merged.type, merged.unconstrained,
+              merged.constituents)
+    }
+    let ordinal = try ordinal(of: Column(name: name))
+    return (.slot(ordinal), type(at: ordinal), unconstrained(at: ordinal),
+            [ordinal])
   }
 
   /// The combined-space base offset and extent of each relation, in chain order
@@ -1744,14 +2001,20 @@ internal struct Scope {
 
   /// The number of output columns `projection` yields over this scope — the
   /// count the lowered `terms(projection)` array carries, and the range a
-  /// 1-based `ORDER BY` ordinal must fall in. A `*` expands to every relation's
-  /// real `width` in chain order (never a virtual column); a bare-column or an
-  /// expression list is its item count. It reads only schemas, matching the
-  /// compile path's `projection.count` without lowering a term.
+  /// 1-based `ORDER BY` ordinal must fall in. A `*` counts the merged columns
+  /// plus the real columns the shared `expansion` enumeration emits (never a
+  /// virtual column); a bare-column or an expression list is its item count.
   internal func width(of projection: Projection) -> Int {
     switch projection {
     case .all:
-      return schemas.reduce(0) { $0 + $1.width }
+      // DERIVED from the ONE `expansion` walk `terms(.all)`/`outputs` emit —
+      // the merged columns plus the real columns it yields — so the width
+      // cannot drift from the emitted count. A parallel `schemas.reduce(width)
+      // − subsumed.count` arithmetic UNDERCOUNTED when a merged column's
+      // constituent was VIRTUAL (a fixture/adapter `Id`): the virtual ordinal
+      // is in `subsumed` but was never in the real-width sum, so subtracting it
+      // dropped a real column that IS emitted.
+      return merged.count + expansion.count
     case let .columns(columns):
       return columns.count
     case let .expressions(items):
@@ -1824,11 +2087,18 @@ internal struct Scope {
       throws(SQLError) -> ValueType {
     return switch expression {
     case let .column(column):
-      // A column this scope does not bind may be a CORRELATED reference to an
-      // enclosing query (in an inner `WHERE`); type it as the outer column,
-      // else the ordinary column fault. A LOCALLY AMBIGUOUS name is a HARD
-      // error `find` propagates, never a fall-through to outer correlation.
-      if let ordinal = try find(column) {
+      // A BARE name matching a `NATURAL`/`USING` merged column types from the
+      // unified coalesce `type` — the merged column has NO physical ordinal, so
+      // it is typed here rather than via `type(at:)` (a same-named physical
+      // column a later plain join added faults `.ambiguous`).
+      if column.qualifier == nil,
+          let merged = try merged(binding: column.name) {
+        merged.type
+      } else if let ordinal = try find(column) {
+        // A column this scope does not bind may be a CORRELATED reference to an
+        // enclosing query (in an inner `WHERE`); type it as the outer column,
+        // else the ordinary column fault. A LOCALLY AMBIGUOUS name is a HARD
+        // error `find` propagates, never a fall-through to outer correlation.
         type(at: ordinal)
       } else if let resolved = try subquery.correlated(column) {
         resolved.type
@@ -2072,13 +2342,21 @@ internal struct Scope {
       throws(SQLError) -> ValueType {
     switch expression {
     case let .column(column):
-      // A column this scope does not bind may be a CORRELATED reference to an
-      // enclosing query (validated exactly as the run resolves it — a `WHERE`
-      // one types as its outer column, a projection/`HAVING` one faults
-      // unsupported); else the ordinary column fault. A LOCALLY AMBIGUOUS name
-      // is a HARD error `find` propagates, never a fall-through to outer
-      // correlation.
-      if let ordinal = try find(column) {
+      // A BARE name matching a `NATURAL`/`USING` merged column (ISO 9075 7.10)
+      // types from the unified coalesce `type` — the SAME merged-aware bare
+      // lookup `term`/`derive` shadow the two physical sides with, so the
+      // type-check accepts exactly the bare merged reference the run lowers (a
+      // same-named physical column a later plain join added faults `.ambiguous`
+      // in `merged(binding:)`). A column this scope does not bind may be a
+      // CORRELATED reference to an enclosing query (validated as the run
+      // resolves it — a `WHERE` one types as its outer column, a
+      // projection/`HAVING` one faults unsupported); else the ordinary column
+      // fault. A LOCALLY AMBIGUOUS name is a HARD error `find` propagates — not
+      // a fall-through to outer correlation.
+      if column.qualifier == nil,
+          let merged = try merged(binding: column.name) {
+        merged.type
+      } else if let ordinal = try find(column) {
         type(at: ordinal)
       } else if let type = try subquery.correlated(column) {
         type
@@ -3734,21 +4012,37 @@ internal struct Scope {
     return members.contains { admits($0, column) }
   }
 
+  /// Every combined ordinal `column` addresses — the FULL addressable surface
+  /// (each admitted relation's PHYSICAL columns AND its VIRTUAL ones, through
+  /// `Schema.ordinal(of:)`), in chain order. This is the ONE bare-name scan
+  /// every ambiguity/presence determination routes through, so no site can scan
+  /// a PARTIAL surface (real-only) and drift: a name matching more than one
+  /// entry here is ambiguous, one present, none absent — measured over the same
+  /// physical∪virtual surface `ordinal(of:)` resolves against. An unqualified
+  /// `column` admits every relation; a qualified one only a relation its
+  /// qualifier names.
+  private func addressable(_ column: Column) -> Array<Int> {
+    var ordinals = Array<Int>()
+    for member in members where admits(member, column) {
+      guard let local = member.schema.ordinal(of: column.name) else { continue }
+      ordinals.append(member.offset + local)
+    }
+    return ordinals
+  }
+
   /// The combined ordinal `column` resolves to.
   ///
   /// The name resolves against every admitted relation: present in exactly one
   /// it yields that relation's `offset` plus the local ordinal; present in more
   /// than one — an unqualified name in several relations, or a qualified name
   /// two relations share a name for — it is `SQLError.ambiguous`; in none it is
-  /// `SQLError.column`.
+  /// `SQLError.column`. Resolution reads the ONE full-addressable scan
+  /// (`addressable`), so it and every ambiguity/presence check measure the same
+  /// physical∪virtual surface.
   internal func ordinal(of column: Column) throws(SQLError) -> Int {
-    var resolved: Int? = nil
-    for member in members where admits(member, column) {
-      guard let local = member.schema.ordinal(of: column.name) else { continue }
-      if resolved != nil { throw .ambiguous(column.name) }
-      resolved = member.offset + local
-    }
-    guard let resolved else { throw .column(column.name) }
+    let ordinals = addressable(column)
+    if ordinals.count > 1 { throw .ambiguous(column.name) }
+    guard let resolved = ordinals.first else { throw .column(column.name) }
     return resolved
   }
 
@@ -3836,15 +4130,13 @@ internal struct Scope {
     let subquery = subquery.barred
     switch projection {
     case .all:
-      // Every real column of every relation, at its combined ordinal — in chain
-      // order, never a virtual column of any relation.
-      var terms = Array<Term>()
-      for member in members {
-        for ordinal in 0 ..< member.schema.width {
-          terms.append(.slot(member.offset + ordinal))
-        }
-      }
-      return terms
+      // The `NATURAL`/`USING` merged columns FIRST (ISO 9075 7.10), each as its
+      // coalesce `value`, then every real column the shared `expansion`
+      // enumeration yields as a `.slot` at its combined ordinal — in chain
+      // order, never a virtual column, and never a physical constituent a
+      // merged column subsumes. `width(of: .all)` counts this SAME
+      // enumeration, so the emitted arity and the width cannot diverge.
+      return merged.map(\.value) + expansion.map { .slot($0) }
     case let .columns(columns):
       // Lower each bare column through `term`, so a name none of this scope's
       // relations bind consults the `subquery` surface: a correlated reference
@@ -3873,6 +4165,17 @@ internal struct Scope {
       throws(SQLError) -> Term {
     switch expression {
     case let .column(column):
+      // A BARE (unqualified) name matching a `NATURAL`/`USING` merged column
+      // (ISO 9075 7.10) resolves to its ONE coalesced `value` — the merged
+      // entry SHADOWS its two physical constituents, so the name is not
+      // ambiguous between the two sides. A QUALIFIED `A.c`/`B.c` never matches
+      // a (unqualified) merged column and reaches its own side below. A
+      // physical column of the same name a later PLAIN join contributed faults
+      // `.ambiguous` (`merged(binding:)`).
+      if column.qualifier == nil,
+          let merged = try merged(binding: column.name) {
+        return merged.value
+      }
       // Resolve the column against this scope's own relations first; a name
       // none binds is a candidate CORRELATED reference — consult the enclosing
       // scope, lowering to a synthetic `Term.parameter` bound from the outer
@@ -4074,9 +4377,27 @@ internal struct Scope {
 internal struct Grouping {
   private let scope: Scope
 
-  /// Each `GROUP BY` key's combined base ordinal mapped to its grouped slot —
-  /// key `i` sits at grouped slot `i`.
+  /// Each BARE-column `GROUP BY` key's combined base ordinal mapped to its
+  /// grouped slot — key `i` sits at grouped slot `i`. A general (non-column)
+  /// key holds no ordinal entry; it matches by expression through
+  /// `expressions` instead.
   private let keys: Dictionary<Int, Int>
+
+  /// Each `GROUP BY` key's source AST expression, in key order — key `i` sits
+  /// at grouped slot `i`. A projection/`HAVING`/`ORDER BY` expression EQUAL to
+  /// a general (non-column) key resolves to that key's slot. A bare column
+  /// still resolves through the ordinal `keys` map, so a qualification-
+  /// equivalent reference (`Amount` vs `Sales.Amount`) matches.
+  private let expressions: Array<Expression>
+
+  /// Each `GROUP BY` key's LOWERED base-ordinal term, in key order — key `i`
+  /// sits at grouped slot `i`. A projection/`HAVING`/`ORDER BY` expression that
+  /// lowers to a term EQUAL to a key's is that key, so a bare `NATURAL`/`USING`
+  /// merged column — which lowers to a `COALESCE(left, right)` term with NO
+  /// single ordinal, the group key AND every bare reference to it — groups and
+  /// projects as ONE value, matched by the lowered TERM rather than the AST
+  /// expression or an ordinal a merged column lacks.
+  private let terms: Array<Term>
 
   /// The number of `GROUP BY` keys — aggregate `j` sits at grouped slot
   /// `offset + j`, following the key slots.
@@ -4105,36 +4426,47 @@ internal struct Grouping {
   /// (`SQLError.ambiguous`) rather than silently picking the last projection.
   private var ambiguous: Set<String> = []
 
-  /// Builds a grouping over `scope` for the `GROUP BY` `columns` and the
-  /// query's distinct `aggregates` (in first-appearance order — aggregate `j`
-  /// at grouped slot `columns.count + j`). The `aggregates` are already deduped
-  /// by RESOLVED `Aggregation` (see `group`), so a qualification-equivalent
-  /// pair is one entry sharing one slot.
-  internal init(_ scope: Scope, _ columns: Array<Column>,
+  /// Builds a grouping over `scope` for the `GROUP BY` `columns` (with their
+  /// already-LOWERED base-ordinal `terms`, so a merged column's coalesce term
+  /// is matched by term) and the query's distinct `aggregates` (in
+  /// first-appearance order — aggregate `j` at grouped slot `columns.count +
+  /// j`). The `aggregates` are already deduped by RESOLVED `Aggregation` (see
+  /// `group`), so a qualification-equivalent pair is one entry, one slot.
+  internal init(_ scope: Scope, _ grouping: Array<Expression>,
+                _ terms: Array<Term>,
                 _ aggregates: Array<Aggregation>,
                 subquery: Resolution = .unsupported) throws(SQLError) {
     self.scope = scope
-    var keys = Dictionary<Int, Int>(minimumCapacity: columns.count)
-    for index in columns.indices {
-      // A grouping key a local relation binds maps its combined ordinal to its
-      // grouped slot. A key NONE binds is a candidate CORRELATED reference (a
-      // LATERAL body grouping on a preceding column): the correlation surface's
-      // non-recording `correlated` probe distinguishes it from a genuine
-      // unknown column, and it occupies grouped slot `index` as a `.parameter`
-      // key (in `group`'s keys array) with NO ordinal→slot entry — the
-      // projection reads it via the same correlation, never through this key
-      // dict. A genuinely unknown column re-throws the `.column` fault; a
-      // barred surface diagnoses a bound outer column `.unsupported`.
-      // `correlated` records nothing, so it stays idempotent against `group`'s
-      // own correlation of the same key.
-      if let ordinal = try scope.find(columns[index]) {
+    var keys = Dictionary<Int, Int>(minimumCapacity: grouping.count)
+    for index in grouping.indices {
+      // A BARE-column grouping key a local relation binds maps its combined
+      // ordinal to its grouped slot. A bare `NATURAL`/`USING` MERGED column
+      // binds no single ordinal (`find` faults `.ambiguous` over its two
+      // physical sides) — its lowered `terms[index]` is a `COALESCE` matched by
+      // term, so it takes NO ordinal entry, as a general key does. A key NONE
+      // binds is a candidate CORRELATED reference (a LATERAL body grouping
+      // on a preceding column): the correlation surface's non-recording
+      // `correlated` probe distinguishes it from a genuine unknown column, and
+      // it occupies grouped slot `index` as a `.parameter` key (in `group`'s
+      // keys array) with NO ordinal→slot entry — the projection reads it via
+      // the same correlation, never through this key dict. A genuinely unknown
+      // column re-throws the `.column` fault; a barred surface diagnoses a
+      // bound outer column `.unsupported`. `correlated` records nothing, so it
+      // stays idempotent against `group`'s own correlation. A general
+      // (non-column) key takes no ordinal entry; it matches by term in `term`.
+      guard case let .column(column) = grouping[index],
+          column.qualifier == nil ? scope.merges(column.name) == nil : true
+      else { continue }
+      if let ordinal = try scope.find(column) {
         keys[ordinal] = index
-      } else if try subquery.correlated(columns[index]) == nil {
-        _ = try scope.ordinal(of: columns[index])
+      } else if try subquery.correlated(column) == nil {
+        _ = try scope.ordinal(of: column)
       }
     }
     self.keys = keys
-    self.offset = columns.count
+    self.expressions = grouping
+    self.terms = terms
+    self.offset = grouping.count
     self.aggregates = aggregates
   }
 
@@ -4165,6 +4497,27 @@ internal struct Grouping {
     if case .aggregate = expression,
        let slot = try slot(of: expression, routines, subquery: subquery) {
       return .slot(slot)
+    }
+    // A bare `NATURAL`/`USING` MERGED column lowers to its `COALESCE(left,
+    // right)` value — the SAME term the `GROUP BY` key lowered to — so it
+    // matches a key by TERM (it binds no single ordinal), grouping and
+    // projecting as ONE value. A right-only row of a `RIGHT`/`FULL` join groups
+    // by its coalesced value, not a NULL left column.
+    if case let .column(column) = expression, column.qualifier == nil,
+        scope.merges(column.name) != nil {
+      let lowered = try scope.term(expression, routines, subquery: subquery)
+      guard let index = terms.firstIndex(of: lowered) else {
+        throw .grouping(column.name)
+      }
+      return .slot(index)
+    }
+    // A general (non-column) key matches by expression: a projection/`HAVING`/
+    // `ORDER BY` expression EQUAL to a `GROUP BY` key resolves to that key's
+    // grouped slot. A bare column is skipped here and falls through to the
+    // ordinal path below, which matches a qualification-equivalent reference.
+    if case .column = expression {
+    } else if let index = expressions.firstIndex(of: expression) {
+      return .slot(index)
     }
     switch expression {
     case let .column(column):

--- a/Sources/SQLEngine/Token.swift
+++ b/Sources/SQLEngine/Token.swift
@@ -49,6 +49,12 @@ extension Token {
     case or
     case not
     case join
+    /// The `NATURAL` keyword introducing a `NATURAL` join — its join columns
+    /// the ones common to both sides, resolved by name (ISO 9075 7.7).
+    case natural
+    /// The `USING` keyword introducing a `JOIN … USING (c, …)` named-column
+    /// join criterion.
+    case using
     /// The `LATERAL` keyword introducing a FROM/JOIN derived table whose body
     /// may reference the preceding FROM items (a correlated apply).
     case lateral
@@ -161,6 +167,8 @@ extension Token.Kind {
     case .or: "OR"
     case .not: "NOT"
     case .join: "JOIN"
+    case .natural: "NATURAL"
+    case .using: "USING"
     case .lateral: "LATERAL"
     case .inner: "INNER"
     case .cross: "CROSS"

--- a/Tests/SQLTests/Queries/EngineJoinTests.swift
+++ b/Tests/SQLTests/Queries/EngineJoinTests.swift
@@ -858,3 +858,1302 @@ struct EngineMultiJoinTests {
   }
 }
 
+// MARK: - NATURAL and USING join tests
+
+/// A catalog of relations sharing column NAMES, so a `NATURAL`/`USING` join has
+/// common columns to key on. `Emp(Dept, Name)` and `Team(Dept, Lead)` share
+/// `Dept`; `Lhs(K, G, A)` and `Rhs(K, G, B)` share `K` and `G`; `Solo(x)`
+/// and `Other(y)` share nothing (a `NATURAL` join over them degenerates to a
+/// product). `Team` has a `Dept` (30) no `Emp` names, and `Emp` a `Dept` (10)
+/// no `Team` names, so an outer join has an unmatched row on each side.
+/// `Bonus(Dept, Amt)` names every `Dept` (10, 20, 30), so a THIRD `USING
+/// (Dept)` join after an outer `Emp`/`Team` one keys each surviving row —
+/// including an unmatched left/right one — on the merged `Dept`.
+private func engineNamed() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("Emp", ["Dept": .integer, "Name": .text]) {
+      Row(10, "Ann")
+      Row(20, "Bob")
+      Row(20, "Cid")
+    }
+    Relation("Team", ["Dept": .integer, "Lead": .text]) {
+      Row(20, "Deb")
+      Row(30, "Eve")
+    }
+    Relation("Lhs", ["K": .integer, "G": .text, "A": .text]) {
+      Row(1, "x", "a1")
+      Row(2, "y", "a2")
+    }
+    Relation("Rhs", ["K": .integer, "G": .text, "B": .text]) {
+      Row(1, "x", "b1")
+      Row(2, "z", "b2")
+    }
+    Relation("Solo", ["x": .integer]) {
+      Row(1)
+      Row(2)
+    }
+    Relation("Other", ["y": .text]) {
+      Row("p")
+      Row("q")
+    }
+    Relation("Bonus", ["Dept": .integer, "Amt": .integer]) {
+      Row(10, 50)
+      Row(20, 100)
+      Row(30, 200)
+    }
+  }
+}
+
+struct EngineNaturalUsingTests {
+  @Test func `INNER USING (c) merges the column once, first, then rests`() throws {
+    // Output column list (ISO 7.10): the USING column `Dept` ONCE and FIRST,
+    // then the left's other columns (`Name`), then the right's (`Lead`). Rows
+    // join on `Dept` equality — only Dept 20 matches on both sides.
+    try engineNamed().expect("SELECT * FROM Emp JOIN Team USING (Dept)",
+        yields: [
+          [20, "Bob", "Deb"],
+          [20, "Cid", "Deb"],
+        ])
+  }
+
+  @Test func `USING (c1, c2) keys on both columns`() throws {
+    // The join columns `K, G` come first in order, then `Lhs`'s `A`, then
+    // `Rhs`'s `B`. Only the (1, x) row agrees on BOTH columns.
+    try engineNamed().expect("""
+        SELECT * FROM Lhs JOIN Rhs USING (K, G)
+        """,
+        yields: [[1, "x", "a1", "b1"]])
+  }
+
+  @Test func `NATURAL INNER joins on the one shared column`() throws {
+    // `Emp` and `Team` share only `Dept`, so `NATURAL JOIN` is `USING (Dept)`:
+    // the merged `Dept` first, then `Name`, then `Lead`.
+    try engineNamed().expect("SELECT * FROM Emp NATURAL JOIN Team",
+        yields: [
+          [20, "Bob", "Deb"],
+          [20, "Cid", "Deb"],
+        ])
+  }
+
+  @Test func `NATURAL with two common columns keys on both`() throws {
+    // `Lhs` and `Rhs` share `K` and `G` (in `Lhs`'s order), so the merged
+    // `K, G` come first, then `A`, then `B` — the same as `USING (K, G)`.
+    try engineNamed().expect("SELECT * FROM Lhs NATURAL JOIN Rhs",
+        yields: [[1, "x", "a1", "b1"]])
+  }
+
+  @Test func `NATURAL with no common column is a CROSS product`() throws {
+    // `Solo(x)` and `Other(y)` share nothing, so `NATURAL JOIN` degenerates
+    // to a Cartesian product (ISO), NOT a fault: every left row paired with
+    // every right row, the output being every column of both.
+    try engineNamed().expect("SELECT * FROM Solo NATURAL JOIN Other",
+        yields: [
+          [1, "p"],
+          [1, "q"],
+          [2, "p"],
+          [2, "q"],
+        ])
+  }
+
+  @Test func `LEFT OUTER USING shows the left value in the merged column`() throws {
+    // `Emp` Dept 10 has no `Team` match; a LEFT join keeps it, and the merged
+    // `Dept` = COALESCE(Emp.Dept, Team.Dept) shows the left's 10 while `Lead`
+    // NULL-extends.
+    try engineNamed().expect("""
+        SELECT * FROM Emp LEFT JOIN Team USING (Dept)
+        """,
+        yields: [
+          [10, "Ann", nil],
+          [20, "Bob", "Deb"],
+          [20, "Cid", "Deb"],
+        ])
+  }
+
+  @Test func `RIGHT OUTER USING shows the right value in the merged column`() throws {
+    // `Team` Dept 30 has no `Emp` match; a RIGHT join keeps it, and the merged
+    // `Dept` = COALESCE(Emp.Dept, Team.Dept) shows the right's 30 even though
+    // the left `Emp.Dept` is NULL there. `Name` NULL-extends.
+    try engineNamed().expect("""
+        SELECT * FROM Emp RIGHT JOIN Team USING (Dept)
+        """,
+        yields: [
+          [20, "Bob", "Deb"],
+          [20, "Cid", "Deb"],
+          [30, nil, "Eve"],
+        ])
+  }
+
+  @Test func `FULL OUTER NATURAL merges each side's unmatched value`() throws {
+    // Both unmatched rows survive: `Emp` Dept 10 (left-only, merged `Dept` =
+    // 10, `Lead` NULL) and `Team` Dept 30 (right-only, merged `Dept` = 30 via
+    // COALESCE though `Emp.Dept` is NULL, `Name` NULL).
+    try engineNamed().expect("SELECT * FROM Emp NATURAL FULL OUTER JOIN Team",
+        yields: [
+          [10, "Ann", nil],
+          [20, "Bob", "Deb"],
+          [20, "Cid", "Deb"],
+          [30, nil, "Eve"],
+        ])
+  }
+
+  @Test func `USING a column absent from one side faults`() throws {
+    // `Name` is on `Emp` but not `Team`, so `USING (Name)` names a column the
+    // right side does not resolve — a column fault.
+    try engineNamed().expect("SELECT * FROM Emp JOIN Team USING (Name)",
+        fails: .column("Name"))
+  }
+
+  @Test func `USING is case-insensitive in the column name`() throws {
+    // The join column matches case-insensitively, as the engine's identifier
+    // resolution does, so `USING (dept)` keys on `Dept`.
+    try engineNamed().expect("SELECT * FROM Emp JOIN Team USING (dept)",
+        yields: [
+          [20, "Bob", "Deb"],
+          [20, "Cid", "Deb"],
+        ])
+  }
+
+  @Test func `a qualified reference still reaches each side's own column`() throws {
+    // An explicit projection resolves columns by the ordinary rules over the
+    // synthesized `ON` join, so a qualified `Emp.Dept`/`Team.Dept` still names
+    // each side's own column (both equal on a matched row).
+    try engineNamed().expect("""
+        SELECT Emp.Dept, Team.Dept, Name FROM Emp JOIN Team USING (Dept)
+        """,
+        yields: [
+          [20, 20, "Bob"],
+          [20, 20, "Cid"],
+        ])
+  }
+
+  @Test func `a bare reference to a merged column resolves to the coalesced value`() throws {
+    // ISO 9075 7.10: the USING/NATURAL common column is an exposed name of the
+    // join result belonging to NEITHER side, so a BARE `Dept` resolves to the
+    // ONE coalesced column — UNAMBIGUOUSLY — not to `Emp.Dept` or `Team.Dept`.
+    try engineNamed().expect("SELECT Dept FROM Emp JOIN Team USING (Dept)",
+        yields: [[20], [20]])
+  }
+
+  @Test func `a bare merged reference resolves in WHERE`() throws {
+    // The exposed name resolves in a `WHERE` too — `Dept = 20` filters on the
+    // coalesced value, keeping only the matched rows.
+    try engineNamed().expect("""
+        SELECT Name FROM Emp JOIN Team USING (Dept) WHERE Dept = 20
+        """,
+        yields: [["Bob"], ["Cid"]])
+  }
+
+  @Test func `a bare merged reference resolves in ORDER BY`() throws {
+    // The exposed name resolves in an `ORDER BY` — a FULL join's rows sort by
+    // the coalesced `Dept`, the left-only (10) and right-only (30) unmatched
+    // rows ordered alongside the matched (20) ones.
+    try engineNamed().expect("""
+        SELECT Name FROM Emp NATURAL FULL OUTER JOIN Team ORDER BY Dept
+        """,
+        yields: [["Ann"], ["Bob"], ["Cid"], [nil]])
+  }
+
+  @Test func `a bare merged reference resolves in GROUP BY`() throws {
+    // The exposed name resolves as a `GROUP BY` key — the matched Dept 20 rows
+    // form one group of two.
+    try engineNamed().expect("""
+        SELECT Dept, COUNT(*) FROM Emp JOIN Team USING (Dept) GROUP BY Dept
+        """,
+        yields: [[20, 2]])
+  }
+
+  @Test func `a bare merged reference in a LEFT join yields the coalesced value`() throws {
+    // A LEFT join keeps the left-only Dept 10; the exposed bare `Dept` shows
+    // the coalesced value (the left's 10), matching the `SELECT *` merged
+    // column.
+    try engineNamed().expect("""
+        SELECT Dept FROM Emp LEFT JOIN Team USING (Dept)
+        """,
+        yields: [[10], [20], [20]])
+  }
+
+  @Test func `a bare merged reference in a RIGHT join yields the coalesced value`() throws {
+    // A RIGHT join keeps the right-only Dept 30; the exposed bare `Dept` shows
+    // the coalesced value (the right's 30) even where the left `Emp.Dept` is
+    // NULL.
+    try engineNamed().expect("""
+        SELECT Dept FROM Emp RIGHT JOIN Team USING (Dept)
+        """,
+        yields: [[20], [20], [30]])
+  }
+
+  @Test func `a bare merged reference in a FULL join yields each side's value`() throws {
+    // A FULL join keeps both unmatched rows; the exposed bare `Dept` shows the
+    // coalesced value on each — the left's 10 (right NULL) and the right's 30
+    // (left NULL).
+    try engineNamed().expect("""
+        SELECT Dept FROM Emp NATURAL FULL OUTER JOIN Team
+        """,
+        yields: [[10], [20], [20], [30]])
+  }
+
+  @Test func `a bare reference to each of two merged columns resolves`() throws {
+    // A NATURAL join over two common columns exposes BOTH `K` and `G`; a bare
+    // reference to each resolves to its coalesced value (equal on the one
+    // matched row).
+    try engineNamed().expect("""
+        SELECT K, G FROM Lhs NATURAL JOIN Rhs
+        """,
+        yields: [[1, "x"]])
+  }
+
+  @Test func `a bare reference to a shared but non-join column stays ambiguous`() throws {
+    // The scoping guard (ISO 9075 7.10): ONLY the join columns are exposed.
+    // `Lhs` and `Rhs` share `K` and `G`, but `USING (K)` joins on `K` alone —
+    // so bare `G`, shared yet NOT a join column, stays AMBIGUOUS between the
+    // two sides rather than collapsing to a merged value.
+    try engineNamed().expect("""
+        SELECT G FROM Lhs JOIN Rhs USING (K)
+        """,
+        fails: .ambiguous("G"))
+  }
+
+  @Test func `a qualified reference is not merged when its name is a join column`() throws {
+    // The exposed name is UNqualified; a qualified `Lhs.G`/`Rhs.G` still names
+    // its own side even when the sibling `K` is a join column — merging is
+    // scoped to the bare join-column name alone.
+    try engineNamed().expect("""
+        SELECT Lhs.G, Rhs.G FROM Lhs JOIN Rhs USING (K)
+        """,
+        yields: [["x", "x"], ["y", "z"]])
+  }
+
+  // MARK: - Aliased ranges (finding 1)
+
+  @Test func `an aliased FROM side resolves a USING join`() throws {
+    // The synthesized `ON` and coalesced `SELECT *` qualify by the RANGE name
+    // (the alias `e`), the only name the scope admits, so `Emp AS e JOIN Team
+    // USING (Dept)` resolves rather than faulting on an unqualifiable
+    // `Emp.Dept`.
+    try engineNamed().expect("""
+        SELECT * FROM Emp AS e JOIN Team USING (Dept)
+        """,
+        yields: [
+          [20, "Bob", "Deb"],
+          [20, "Cid", "Deb"],
+        ])
+  }
+
+  @Test func `an aliased JOINED side resolves a USING join`() throws {
+    // The joined side's references qualify by its range name (`t`) too, so
+    // `Emp JOIN Team AS t USING (Dept)` resolves.
+    try engineNamed().expect("""
+        SELECT * FROM Emp JOIN Team AS t USING (Dept)
+        """,
+        yields: [
+          [20, "Bob", "Deb"],
+          [20, "Cid", "Deb"],
+        ])
+  }
+
+  @Test func `a projection qualified by an alias resolves over a USING join`() throws {
+    // Both sides aliased: a qualified `e.Name` resolves to its side and a bare
+    // merged `Dept` to the coalesced value, all over the aliased ranges.
+    try engineNamed().expect("""
+        SELECT e.Name, Dept FROM Emp AS e JOIN Team AS t USING (Dept)
+        """,
+        yields: [
+          ["Bob", 20],
+          ["Cid", 20],
+        ])
+  }
+
+  // MARK: - Set-operation arity over the merged width (finding 2)
+
+  @Test func `a UNION over a USING join measures the merged width`() throws {
+    // The `SELECT *` arm's width is the MERGED count (3 — `Dept` once), so a
+    // 3-column second arm aligns and the UNION succeeds. Before the desugar ran
+    // ahead of the arity check, the `*` measured both physical `Dept`s (4) and
+    // wrongly rejected the valid set operation.
+    try engineNamed().expect("""
+        SELECT * FROM Emp JOIN Team USING (Dept)
+        UNION SELECT Dept, Name, Lead FROM Emp JOIN Team USING (Dept)
+        """,
+        yields: [
+          [20, "Bob", "Deb"],
+          [20, "Cid", "Deb"],
+        ])
+  }
+
+  @Test func `a UNION whose arms differ post-merge still faults arity`() throws {
+    // A genuinely mismatched set operation — a 3-wide merged `*` against a
+    // 2-column arm — still faults, measured at the merged width.
+    try engineNamed().expect("""
+        SELECT * FROM Emp JOIN Team USING (Dept)
+        UNION SELECT Dept, Name FROM Emp JOIN Team USING (Dept)
+        """,
+        fails: .arity(3, 2))
+  }
+
+  // MARK: - Exposed IN and quantified outer operand (finding 3)
+
+  @Test func `a bare merged reference resolves as an IN operand`() throws {
+    // The outer operand of `IN (subquery)` resolves in THIS query's scope, so
+    // a bare merged `Dept` is exposed to the coalesced value — not left
+    // ambiguous between the two physical sides.
+    try engineNamed().expect("""
+        SELECT Name FROM Emp JOIN Team USING (Dept)
+        WHERE Dept IN (SELECT Dept FROM Team)
+        """,
+        yields: [["Bob"], ["Cid"]])
+  }
+
+  @Test func `a bare merged reference resolves as a quantified operand`() throws {
+    // As `IN`, the `= ANY (subquery)` outer operand is exposed to the merged
+    // value.
+    try engineNamed().expect("""
+        SELECT Name FROM Emp JOIN Team USING (Dept)
+        WHERE Dept = ANY (SELECT Dept FROM Team)
+        """,
+        yields: [["Bob"], ["Cid"]])
+  }
+
+  // MARK: - Coalesced key carried into a later join (finding 4)
+
+  @Test func `a chained USING join keys a RIGHT-only row on the merged value`() throws {
+    // `Emp RIGHT JOIN Team USING (Dept)` keeps the right-only Dept 30 (left
+    // `Emp.Dept` NULL); the next `JOIN Bonus USING (Dept)` keys on the MERGED
+    // `Dept`, so that row still joins `Bonus` (Amt 200) rather than being
+    // dropped on a NULL left key.
+    try engineNamed().expect("""
+        SELECT * FROM Emp RIGHT JOIN Team USING (Dept) JOIN Bonus USING (Dept)
+        """,
+        yields: [
+          [20, "Bob", "Deb", 100],
+          [20, "Cid", "Deb", 100],
+          [30, nil, "Eve", 200],
+        ])
+  }
+
+  @Test func `a chained USING join keys a FULL join's unmatched rows on the merged value`() throws {
+    // A FULL first join keeps BOTH unmatched rows — Dept 10 (left-only) and 30
+    // (right-only); the chained `Bonus` join keys each on the merged `Dept`, so
+    // both still join (Amt 50 and 200).
+    try engineNamed().expect("""
+        SELECT * FROM Emp FULL JOIN Team USING (Dept) JOIN Bonus USING (Dept)
+        """,
+        yields: [
+          [10, "Ann", nil, 50],
+          [20, "Bob", "Deb", 100],
+          [20, "Cid", "Deb", 100],
+          [30, nil, "Eve", 200],
+        ])
+  }
+
+  // MARK: - Duplicate USING names (finding 5)
+
+  @Test func `a repeated USING column faults rather than crashing`() throws {
+    // `USING (Dept, Dept)` names one merged column twice; the duplicate is
+    // caught BEFORE the output dictionary the merged names key would trap on,
+    // faulting `.duplicate` rather than aborting the process.
+    try engineNamed().expect("""
+        SELECT * FROM Emp JOIN Team USING (Dept, Dept)
+        """,
+        fails: .duplicate("Dept"))
+  }
+
+  @Test func `a NATURAL join after a plain join with two like-named columns faults`() throws {
+    // `Emp JOIN Team ON …` leaves the left side carrying TWO columns named
+    // `Dept`; a following `NATURAL JOIN Bonus` would merge `Dept` twice — the
+    // duplicate is caught and faults `.duplicate` rather than trapping.
+    try engineNamed().expect("""
+        SELECT * FROM Emp JOIN Team ON Emp.Dept = Team.Dept
+        NATURAL JOIN Bonus
+        """,
+        fails: .duplicate("Dept"))
+  }
+
+  // MARK: - Grouping a RIGHT/FULL merged column by the merged value (finding 6)
+
+  @Test func `a RIGHT join groups a bare merged column by the coalesced value`() throws {
+    // The right-only Dept 30 (left `Emp.Dept` NULL) groups and projects by the
+    // MERGED value 30, not NULL — the `GROUP BY` key is the coalesced value the
+    // projection emits.
+    try engineNamed().expect("""
+        SELECT Dept, COUNT(*) FROM Emp RIGHT JOIN Team USING (Dept)
+        GROUP BY Dept
+        """,
+        yields: [
+          [20, 2],
+          [30, 1],
+        ])
+  }
+
+  @Test func `a FULL join groups a bare merged column by the coalesced value`() throws {
+    // Both unmatched rows group by their merged value — the left-only 10 and
+    // the right-only 30 — each its own group, not collapsed to NULL.
+    try engineNamed().expect("""
+        SELECT Dept, COUNT(*) FROM Emp FULL JOIN Team USING (Dept)
+        GROUP BY Dept
+        """,
+        yields: [
+          [10, 1],
+          [20, 2],
+          [30, 1],
+        ])
+  }
+
+  // MARK: - Accumulated-left ambiguity (finding 1)
+
+  @Test func `a USING column a plain join bound twice on the left faults`() throws {
+    // A plain `ON` join leaves the accumulated left carrying TWO columns named
+    // `Dept` (`Emp.Dept` and `Team.Dept`); a following `JOIN Bonus USING
+    // (Dept)` keys `Dept` on that left — which binds it TWICE — so it faults
+    // `.ambiguous` at construction rather than trapping a downstream build.
+    try engineNamed().expect("""
+        SELECT * FROM Emp JOIN Team ON Emp.Dept = Team.Dept
+        JOIN Bonus USING (Dept)
+        """,
+        fails: .ambiguous("Dept"))
+  }
+
+  // MARK: - A merged name a later plain join re-collides with (finding 2)
+
+  @Test func `a qualified name a later plain join adds over a merged one resolves`() throws {
+    // A `USING (Dept)` merges `Dept`; a later plain `JOIN Bonus AS C ON …`
+    // brings its OWN physical `C.Dept`. A QUALIFIED `C.Dept` names that side
+    // unambiguously and resolves — never a crash — even though a bare `Dept`
+    // would now be ambiguous between the merged column and `C.Dept`.
+    try engineNamed().expect("""
+        SELECT C.Dept FROM Emp JOIN Team USING (Dept)
+        JOIN Bonus AS C ON C.Dept = Emp.Dept
+        """,
+        yields: [[20], [20]])
+  }
+
+  @Test func `a bare name a later plain join re-collides with a merged one faults`() throws {
+    // The bare counterpart: with the merged `Dept` AND the later plain join's
+    // physical `C.Dept` both in scope, a bare `Dept` names two columns and
+    // faults `.ambiguous` — surfacing at lookup, NEVER a crash.
+    try engineNamed().expect("""
+        SELECT Dept FROM Emp JOIN Team USING (Dept)
+        JOIN Bonus AS C ON C.Dept = Emp.Dept
+        """,
+        fails: .ambiguous("Dept"))
+  }
+
+  // MARK: - ORDER BY alias precedence over a merged key (finding 3)
+
+  @Test func `ORDER BY binds a projection alias before the merged key`() throws {
+    // `SELECT Name AS Dept … ORDER BY Dept` sorts by the PROJECTED alias
+    // `Name`, not the coalesced merged `Dept` key — the bare `ORDER BY` key
+    // reaches the resolver's alias-first binding before the scope's merged
+    // column, since there is no pre-rewrite substituting the key for the
+    // coalesce. The names sort opposite to the departments, so the two orders
+    // are distinguishable: alphabetical `Ann, Bob, Cid` (by alias), not `Bob
+    // (10), Cid (20), Ann (30)` (by the merged Dept).
+    let catalog = try Catalog {
+      Relation("Emp", ["Dept": .integer, "Name": .text]) {
+        Row(30, "Ann")
+        Row(10, "Bob")
+        Row(20, "Cid")
+      }
+      Relation("Team", ["Dept": .integer, "Lead": .text]) {
+        Row(10, "L1")
+        Row(20, "L2")
+        Row(30, "L3")
+      }
+    }
+    try catalog.expect("""
+        SELECT Name AS Dept FROM Emp JOIN Team USING (Dept) ORDER BY Dept
+        """,
+        yields: [["Ann"], ["Bob"], ["Cid"]])
+  }
+
+  // MARK: - Merged columns under schema VALIDATION (finding A)
+
+  @Test func `a bare merged reference type-checks under validation`() throws {
+    // The run lowers a bare merged `Dept` in the `WHERE` through `Scope.term`
+    // to the coalesced value; `columns(of:validate:true)` — whose type-check
+    // walk validates the `WHERE` through the SAME merged-aware bare-name
+    // lookup — must resolve it too, not fault `.ambiguous`. The schema names
+    // the projected `Name` (text) and does not throw.
+    let text = """
+        SELECT Name FROM Emp JOIN Team USING (Dept) WHERE Dept = 20
+        """
+    let columns = try engineNamed()
+        .columns(of: Statement(parsing: text), validate: true)
+    #expect(columns.count == 1)
+    #expect(columns[0].name == "Name")
+    #expect(columns[0].type == .text)
+  }
+
+  @Test func `a bare merged reference in the projection type-checks`() throws {
+    // The merged `Dept` PROJECTED and type-checked: the schema resolves it to
+    // the unified coalesce type (`integer`) rather than faulting `.ambiguous`.
+    let text = "SELECT Dept FROM Emp JOIN Team USING (Dept) WHERE Dept = 20"
+    let columns = try engineNamed()
+        .columns(of: Statement(parsing: text), validate: true)
+    #expect(columns.count == 1)
+    #expect(columns[0].name == "Dept")
+    #expect(columns[0].type == .integer)
+  }
+
+  @Test func `a validated merged query agrees with the run`() throws {
+    // run ≡ columns(of:validate:true): the query the validation path accepts
+    // is the query the run executes, producing the two matched rows.
+    try engineNamed().expect("""
+        SELECT Name FROM Emp JOIN Team USING (Dept) WHERE Dept = 20
+        """,
+        yields: [["Bob"], ["Cid"]])
+  }
+
+  @Test func `a genuinely ambiguous bare name still faults under validation`()
+      throws {
+    // The scoping guard holds under validation too: bare `G`, shared by `Lhs`
+    // and `Rhs` yet NOT the `USING (K)` join column, stays `.ambiguous` — the
+    // merged-aware lookup narrows nothing that a plain shared column widens.
+    let text = "SELECT G FROM Lhs JOIN Rhs USING (K)"
+    #expect(throws: SQLError.ambiguous("G")) {
+      _ = try engineNamed()
+          .columns(of: Statement(parsing: text), validate: true)
+    }
+  }
+
+  // MARK: - A later USING over a re-collided merged name (finding B)
+
+  @Test func `a later USING on a name a plain join re-collided with faults`()
+      throws {
+    // `Emp JOIN Team USING (Dept)` merges `Dept`; the plain `JOIN Bonus AS C
+    // ON …` re-introduces a physical `C.Dept`, so the prefix now binds `Dept`
+    // BOTH as the merged column and as `C.Dept`. A later `JOIN X USING (Dept)`
+    // resolves its common `Dept` against that prefix — ambiguous — so it
+    // faults `.ambiguous` rather than silently keying on the merged value and
+    // leaving two output columns named `Dept`.
+    let catalog = try Catalog {
+      Relation("Emp", ["Dept": .integer, "Name": .text]) {
+        Row(20, "Bob")
+      }
+      Relation("Team", ["Dept": .integer, "Lead": .text]) {
+        Row(20, "Deb")
+      }
+      Relation("Bonus", ["Dept": .integer, "Amt": .integer]) {
+        Row(20, 100)
+      }
+      Relation("X", ["Dept": .integer, "Note": .text]) {
+        Row(20, "n")
+      }
+    }
+    catalog.expect("""
+        SELECT * FROM Emp JOIN Team USING (Dept)
+        JOIN Bonus AS C ON C.Dept = Emp.Dept
+        JOIN X USING (Dept)
+        """,
+        fails: .ambiguous("Dept"))
+  }
+
+  // MARK: - Incompatible USING column types (finding C)
+
+  @Test func `a USING join over int and double sides unifies to double`()
+      throws {
+    // `A.k integer`, `B.k double`: the merged `k` type UNIFIES to `double`,
+    // and the coalesce coerces each side to it, so the schema advertises
+    // `double` and the rows carry doubles — not a silent left `integer`.
+    let catalog = try Catalog {
+      Relation("A", ["k": .integer, "a": .text]) {
+        Row(1, "x")
+      }
+      Relation("B", ["k": .double, "b": .text]) {
+        Row(1.0, "y")
+      }
+    }
+    let text = "SELECT k FROM A JOIN B USING (k)"
+    let columns = try catalog.columns(of: Statement(parsing: text),
+                                      validate: true)
+    #expect(columns.count == 1)
+    #expect(columns[0].type == .double)
+    try catalog.expect(text, yields: [[1.0]])
+  }
+
+  @Test func `a RIGHT USING join coerces a right-only row to the unified type`()
+      throws {
+    // `A.k integer`, `B.k double`, RIGHT join: the right-only row's `k` (from
+    // `B`, the left `A.k` NULL) shows as a `double`, coerced to the unified
+    // merged type — not the raw right value under a schema claiming integer.
+    let catalog = try Catalog {
+      Relation("A", ["k": .integer, "a": .text]) {
+        Row(1, "x")
+      }
+      Relation("B", ["k": .double, "b": .text]) {
+        Row(1.0, "y")
+        Row(2.0, "z")
+      }
+    }
+    try catalog.expect("SELECT k FROM A RIGHT JOIN B USING (k) ORDER BY k",
+                       yields: [[1.0], [2.0]])
+  }
+
+  @Test func `a USING join over irreconcilable int and text sides faults`()
+      throws {
+    // `A.k integer`, `B.k text`: no common type, so the merged column is
+    // rejected at resolve with `.operand`/42804 — the same fault a set-op fold
+    // raises — rather than publishing an `integer` schema the coalesced text
+    // value would violate.
+    let catalog = try Catalog {
+      Relation("A", ["k": .integer, "a": .text]) {
+        Row(1, "x")
+      }
+      Relation("B", ["k": .text, "b": .text]) {
+        Row("1", "y")
+      }
+    }
+    catalog.expect("SELECT k FROM A JOIN B USING (k)",
+                   fails: .operand("USING columns have irreconcilable types"))
+  }
+
+  @Test func `a RIGHT USING join over irreconcilable sides faults too`()
+      throws {
+    // The RIGHT variant faults at resolve exactly as the plain one — the
+    // unified-type rejection precedes any row, so no schema-violating row is
+    // produced.
+    let catalog = try Catalog {
+      Relation("A", ["k": .integer, "a": .text]) {
+        Row(1, "x")
+      }
+      Relation("B", ["k": .text, "b": .text]) {
+        Row("2", "y")
+      }
+    }
+    catalog.expect("SELECT k FROM A RIGHT JOIN B USING (k)",
+                   fails: .operand("USING columns have irreconcilable types"))
+  }
+
+  // MARK: - USING type unification honors the unconstrained mask
+
+  @Test func `a USING join defers to the right when the left is unconstrained`()
+      throws {
+    // `(SELECT NULLIF(1, 1) AS k) AS a` — the left `k` is constant NULL, so
+    // UNCONSTRAINED (a placeholder `integer` that places no type constraint) —
+    // RIGHT JOIN `B_text` whose `k` is `text`. The merged `k` types off the
+    // CONSTRAINED right (`text`) through the same mask-aware unification the
+    // set-op fold takes, rather than faulting the placeholder `integer` beside
+    // `text`. A right row's merged `k` is `B_text.k` (the always-NULL left
+    // coalesces away). Run ≡ columns(of:).
+    let catalog = try Catalog {
+      Relation("B_text", ["k": .text, "b": .text]) {
+        Row("p", "b1")
+        Row("q", "b2")
+      }
+    }
+    let text = """
+        SELECT k FROM (SELECT NULLIF(1, 1) AS k) AS a
+          RIGHT JOIN B_text USING (k) ORDER BY k
+        """
+    let columns = try catalog.columns(of: Statement(parsing: text),
+                                      validate: true)
+    #expect(columns.count == 1)
+    #expect(columns[0].type == .text)
+    try catalog.expect(text, yields: [["p"], ["q"]])
+  }
+
+  @Test func `a USING join defers to the left when the right is unconstrained`()
+      throws {
+    // The SYMMETRIC case: the CONSTRAINED left `A_text.k` (`text`) beside an
+    // UNCONSTRAINED right `(SELECT NULLIF(1, 1) AS k)` — the merged `k` types
+    // off the left (`text`), and a LEFT join keeps every left row, its merged
+    // `k` the left value (the always-NULL right coalesces away).
+    let catalog = try Catalog {
+      Relation("A_text", ["k": .text, "a": .text]) {
+        Row("p", "a1")
+        Row("q", "a2")
+      }
+    }
+    let text = """
+        SELECT k FROM A_text
+          LEFT JOIN (SELECT NULLIF(1, 1) AS k) AS b USING (k) ORDER BY k
+        """
+    let columns = try catalog.columns(of: Statement(parsing: text),
+                                      validate: true)
+    #expect(columns.count == 1)
+    #expect(columns[0].type == .text)
+    try catalog.expect(text, yields: [["p"], ["q"]])
+  }
+
+  @Test func `a USING join of two unconstrained sides stays unconstrained`()
+      throws {
+    // BOTH constituents constant NULL (unconstrained): the merged `k` stays a
+    // placeholder that places no constraint, so a further `UNION SELECT 1` over
+    // it UNIFIES to `integer` rather than faulting the placeholder beside the
+    // typed arm — the merged column carries its own `unconstrained` bit into
+    // the enclosing set-operation fold, exactly as a bare unconstrained column
+    // would.
+    let catalog = try Catalog {
+      Relation("Unit", ["only": .integer]) {
+        Row(1)
+      }
+    }
+    let text = """
+        SELECT k FROM (SELECT NULLIF(1, 1) AS k FROM Unit) AS a
+          JOIN (SELECT NULLIF(1, 1) AS k FROM Unit) AS b USING (k)
+        UNION SELECT 1
+        """
+    let columns = try catalog.columns(of: Statement(parsing: text),
+                                      validate: true)
+    #expect(columns.count == 1)
+    #expect(columns[0].type == .integer)
+    // The merged `k` is NULL (both sides NULL, and a NULL key never matches),
+    // so the join yields no row; the UNION's second arm contributes `1`.
+    try catalog.expect(text, yields: [[1]])
+  }
+
+  // MARK: - ISO 7.10 output order over chained USING/NATURAL joins (hole 2)
+
+  @Test func `a chained USING on two different columns orders the outer merge first`()
+      throws {
+    // ISO 9075 7.10: each join's common columns lead, then the rest of the LEFT
+    // output, then the right. `(P JOIN Q USING (k)) JOIN R USING (a)` therefore
+    // exposes `[a, k, p, q, r]` — the OUTER `a` first, then the inner `k` (it
+    // sits within "the rest of the left"), not the flat fold order `[k, a, …]`.
+    let text = "SELECT * FROM P JOIN Q USING (k) JOIN R USING (a)"
+    try engineChained().expect(text, yields: [[7, 1, "p1", "q1", "r1"]])
+    let columns = try engineChained()
+        .columns(of: Statement(parsing: text), validate: true)
+    #expect(columns.map(\.name) == ["a", "k", "p", "q", "r"])
+  }
+
+  @Test func `a chained NATURAL join orders the outer common columns first`()
+      throws {
+    // The NATURAL variant discovers the same common columns (`k` inner, `a`
+    // outer) and lays them in the same ISO order `[a, k, …]` in both the run
+    // and the schema.
+    let text = "SELECT * FROM P NATURAL JOIN Q NATURAL JOIN R"
+    try engineChained().expect(text, yields: [[7, 1, "p1", "q1", "r1"]])
+    let columns = try engineChained()
+        .columns(of: Statement(parsing: text), validate: true)
+    #expect(columns.map(\.name) == ["a", "k", "p", "q", "r"])
+  }
+
+  @Test func `a chained USING on the SAME column keeps it once at the outer position`()
+      throws {
+    // A chained `… USING (Dept)` over an already-merged `Dept` DROPS the inner
+    // entry and keeps the ONE merged `Dept` at the outer join's position — so
+    // `SELECT *` still exposes `Dept` once, then the three sides' rests. Run
+    // and schema agree.
+    let text =
+        "SELECT * FROM Emp JOIN Team USING (Dept) JOIN Bonus USING (Dept)"
+    try engineNamed().expect(text,
+        yields: [
+          [20, "Bob", "Deb", 100],
+          [20, "Cid", "Deb", 100],
+        ])
+    let columns = try engineNamed()
+        .columns(of: Statement(parsing: text), validate: true)
+    #expect(columns.map(\.name) == ["Dept", "Name", "Lead", "Amt"])
+  }
+
+  // MARK: - Merged columns threaded into a LATERAL body (hole 1)
+
+  @Test func `a LATERAL body resolves a bare USING-merged column`() throws {
+    // ISO 9075 7.10: the `USING (Dept)` merged column is an output column of
+    // the join, so a LATERAL body's PRECEDING scope carries it and a bare
+    // `Dept` in the body binds the ONE coalesced column rather than faulting
+    // `.ambiguous` between the two physical `Dept`s. Run and schema agree.
+    let text = """
+        SELECT d.n FROM Emp JOIN Team USING (Dept)
+          JOIN LATERAL (SELECT Dept AS n) AS d ON 1 = 1
+        """
+    try engineNamed().expect(text, yields: [[20], [20]])
+    let columns = try engineNamed()
+        .columns(of: Statement(parsing: text), validate: true)
+    #expect(columns.map(\.name) == ["n"])
+  }
+
+  @Test func `a LATERAL body resolves a bare NATURAL-merged column`() throws {
+    // The NATURAL variant threads the merged column into the LATERAL body the
+    // same way `USING` does.
+    let text = """
+        SELECT d.n FROM Emp NATURAL JOIN Team
+          JOIN LATERAL (SELECT Dept AS n) AS d ON 1 = 1
+        """
+    try engineNamed().expect(text, yields: [[20], [20]])
+  }
+
+  @Test func `a LATERAL body coalesces a merged column of a RIGHT join`() throws {
+    // A RIGHT join's merged `Dept` is `COALESCE(Emp.Dept, Team.Dept)`; the
+    // right-only Dept 30 (left NULL) correlates into the body as the coalesced
+    // value 30 — a physical-left binding would have shown NULL. This exercises
+    // the `.coalesce` correlation source over the outer row's two cells.
+    let text = """
+        SELECT d.n FROM Emp RIGHT JOIN Team USING (Dept)
+          JOIN LATERAL (SELECT Dept AS n) AS d ON 1 = 1
+        """
+    try engineNamed().expect(text, yields: [[20], [20], [30]])
+  }
+
+  @Test func `a LATERAL body still resolves a qualified constituent column`()
+      throws {
+    // A QUALIFIED `Emp.Dept` in the body never matches the merged column and
+    // reaches its own physical side, correlating as an ordinary outer slot.
+    let text = """
+        SELECT d.n FROM Emp JOIN Team USING (Dept)
+          JOIN LATERAL (SELECT Emp.Dept AS n) AS d ON 1 = 1
+        """
+    try engineNamed().expect(text, yields: [[20], [20]])
+  }
+
+  @Test func `a LATERAL body faults an ambiguous non-merged name`() throws {
+    // A plain `JOIN Bonus ON …` re-introduces a physical `Dept` beside the
+    // merged one, so a bare `Dept` in the LATERAL body now names BOTH and stays
+    // `.ambiguous` — the merged axis does not mask a genuine ambiguity.
+    let text = """
+        SELECT d.n FROM Emp JOIN Team USING (Dept)
+          JOIN Bonus ON Bonus.Dept = Emp.Dept
+          JOIN LATERAL (SELECT Dept AS n) AS d ON 1 = 1
+        """
+    try engineNamed().expect(text, fails: .ambiguous("Dept"))
+  }
+
+  @Test func `a merged column and its constituent correlate independently`()
+      throws {
+    // A LATERAL body of `Emp RIGHT JOIN Team USING (Dept)` projects BOTH the
+    // bare merged `Dept` (COALESCE) and the physical `Emp.Dept` constituent. On
+    // the right-only Dept 30 row the merged `Dept` coalesces to 30 while
+    // `Emp.Dept` is NULL — each correlates through its OWN parameter identity,
+    // so neither read overwrites the other regardless of projection order.
+    let forward = """
+        SELECT m, e FROM Emp RIGHT JOIN Team USING (Dept)
+          JOIN LATERAL (SELECT Dept AS m, Emp.Dept AS e) AS d ON 1 = 1
+          ORDER BY m
+        """
+    try engineNamed().expect(forward, yields: [
+      [20, 20],
+      [20, 20],
+      [30, nil],
+    ])
+    // The REVERSE projection order yields the same values — the merged and the
+    // constituent correlation keys do not collide, so lowering order is
+    // irrelevant.
+    let reverse = """
+        SELECT m, e FROM Emp RIGHT JOIN Team USING (Dept)
+          JOIN LATERAL (SELECT Emp.Dept AS e, Dept AS m) AS d ON 1 = 1
+          ORDER BY m
+        """
+    try engineNamed().expect(reverse, yields: [
+      [20, 20],
+      [20, 20],
+      [30, nil],
+    ])
+  }
+
+  @Test func `a SELECT star merged column carries its unconstrained mask`()
+      throws {
+    // Both `USING (k)` constituents are constant-NULL (`NULLIF(1, 1)`), so the
+    // merged `k` is UNCONSTRAINED — it places no type constraint. A `SELECT *`
+    // must carry that mask (exactly as an explicit `SELECT k` does), so the
+    // enclosing UNION unifies the merged `k` with the text arm rather than
+    // faulting the first arm's integer against the text (42804).
+    let star = """
+        SELECT * FROM (SELECT NULLIF(1, 1) AS k FROM Solo) AS a
+          JOIN (SELECT NULLIF(1, 1) AS k FROM Solo) AS b USING (k)
+          UNION SELECT 'x'
+        """
+    let starred = try engineNamed()
+        .columns(of: Statement(parsing: star), validate: true)
+    #expect(starred.map(\.type) == [.text])
+    // The explicit `SELECT k` variant already resolved through `output(of:)`;
+    // it stays resolvable and agrees.
+    let explicit = """
+        SELECT k FROM (SELECT NULLIF(1, 1) AS k FROM Solo) AS a
+          JOIN (SELECT NULLIF(1, 1) AS k FROM Solo) AS b USING (k)
+          UNION SELECT 'x'
+        """
+    let named = try engineNamed()
+        .columns(of: Statement(parsing: explicit), validate: true)
+    #expect(named.map(\.type) == [.text])
+  }
+
+  @Test func `a genuinely constrained USING merge still faults an irreconcilable UNION`()
+      throws {
+    // Both constituents are CONSTRAINED (a bare integer `Dept` and a text
+    // `Lead`… no — both integer here), so the merged `Dept` is a constrained
+    // integer and the text UNION arm is irreconcilable: 42804 still faults,
+    // proving the mask is carried, not hard-coded unconstrained.
+    let text = """
+        SELECT * FROM Emp JOIN Team USING (Dept) UNION SELECT 'x', 'y', 'z'
+        """
+    try engineNamed().expect(text,
+        fails: .operand("UNION arms have irreconcilable types"))
+  }
+
+  // MARK: - USING/NATURAL over a VIRTUAL column (the fixture `Id`)
+
+  @Test func `USING a virtual Id present on both sides resolves and merges it`()
+      throws {
+    // `Id` is a VIRTUAL column (the fixture's 1-based row index) on BOTH `Emp`
+    // and `Team`, not a real one in `names`. `USING (Id)` must resolve it
+    // through the SAME virtual-aware `ordinal(of:)` the predicate path
+    // `Emp.Id = Team.Id` uses, keying on the row index: Emp Ids 1..3, Team
+    // Ids 1..2, so Ids 1 and 2 match. ISO 7.10 order exposes the merged `Id`
+    // once and first, then `Emp`'s real columns, then `Team`'s.
+    try engineNamed().expect("SELECT * FROM Emp JOIN Team USING (Id)",
+        yields: [
+          [1, 10, "Ann", 20, "Deb"],
+          [2, 20, "Bob", 30, "Eve"],
+        ])
+  }
+
+  @Test func `a bare virtual-Id USING column types integral under columns(of:)`()
+      throws {
+    // The merged virtual `Id`'s result type is derived on the schema path the
+    // run agrees with — a fixture virtual `Id` types integral.
+    let text = "SELECT Id FROM Emp JOIN Team USING (Id)"
+    let columns = try engineNamed()
+        .columns(of: Statement(parsing: text), validate: true)
+    let pairs = columns.map { ($0.name, $0.type) }
+    #expect(pairs.elementsEqual([("Id", .integer)], by: ==))
+  }
+
+  @Test func `NATURAL does not key on a shared virtual Id, only real columns`()
+      throws {
+    // The NATURAL DECISION: the common set is the LEFT scope's `names` — the
+    // real, `SELECT *`-visible columns, NO virtual — so a virtual `Id` shared
+    // by both sides is NOT a NATURAL common column even though both sides can
+    // ADDRESS it. This is consistent with ISO, where NATURAL and `SELECT *`
+    // draw on the SAME column-name list (which the engine excludes virtuals
+    // from), while an EXPLICIT `USING (Id)` (like an explicit `A.Id = B.Id`)
+    // resolves the virtual through `ordinal(of:)`. So `Emp NATURAL JOIN Team`
+    // keys on the shared REAL `Dept` alone (Dept 20 matches), NOT on the
+    // virtual `Id` — the round-1 behavior is unchanged.
+    try engineNamed().expect("SELECT * FROM Emp NATURAL JOIN Team",
+        yields: [
+          [20, "Bob", "Deb"],
+          [20, "Cid", "Deb"],
+        ])
+  }
+
+  @Test func `USING mixes a REAL left Id with a VIRTUAL joined Id`() throws {
+    // `Coded` carries a REAL `Id` column (shadowing its own virtual); `Emp`
+    // exposes only a VIRTUAL `Id`. `USING (Id)` must resolve the LEFT through
+    // the real column and the RIGHT through the virtual one, keying REAL 1..3
+    // against the row index 1..3.
+    try engineVirtual().expect("SELECT * FROM Coded JOIN Emp USING (Id)",
+        yields: [
+          [1, "c1", 10, "Ann"],
+          [2, "c2", 20, "Bob"],
+          [3, "c3", 20, "Cid"],
+        ])
+  }
+
+  @Test func `USING mixes a VIRTUAL left Id with a REAL joined Id`() throws {
+    // The reverse: `Emp` (virtual `Id`) as the FROM side, `Coded` (real `Id`)
+    // joined — the LEFT resolves the virtual, the RIGHT the real. The output
+    // exposes the merged `Id`, then `Emp`'s real columns, then `Coded`'s real
+    // ones (its real `Id` is the merged constituent, dropped from the rest).
+    try engineVirtual().expect("SELECT * FROM Emp JOIN Coded USING (Id)",
+        yields: [
+          [1, 10, "Ann", "c1"],
+          [2, 20, "Bob", "c2"],
+          [3, 20, "Cid", "c3"],
+        ])
+  }
+
+  @Test func `NATURAL excludes a JOINED-side virtual Id from the common set`()
+      throws {
+    // `Coded` has a REAL `Id` (in `names`); `Emp` exposes `Id` ONLY as a
+    // VIRTUAL column (the fixture row index), and the two share NO real column
+    // (`Id`/`Tag` vs `Dept`/`Name`). The `NATURAL` common set is the REAL-name
+    // intersection on BOTH sides, so the joined-side VIRTUAL `Id` must NOT
+    // match `Coded`'s real `Id` — the join degenerates to a CROSS product (its
+    // synthesized `on` empty), keeping ALL FOUR real columns unmerged and every
+    // 3x3 pairing. An EXPLICIT `USING (Id)` (the control below) still resolves
+    // the virtual; NATURAL, like `SELECT *`, draws only on real names.
+    try engineVirtual().expect("SELECT * FROM Coded NATURAL JOIN Emp",
+        yields: [
+          [1, "c1", 10, "Ann"],
+          [1, "c1", 20, "Bob"],
+          [1, "c1", 20, "Cid"],
+          [2, "c2", 10, "Ann"],
+          [2, "c2", 20, "Bob"],
+          [2, "c2", 20, "Cid"],
+          [3, "c3", 10, "Ann"],
+          [3, "c3", 20, "Bob"],
+          [3, "c3", 20, "Cid"],
+        ])
+    let text = "SELECT * FROM Coded NATURAL JOIN Emp"
+    let columns = try engineVirtual().columns(of: parse(query: text))
+    #expect(columns.map(\.name) == ["Id", "Tag", "Dept", "Name"])
+  }
+
+  @Test func `NATURAL excludes a LEFT-side virtual Id from the common set`()
+      throws {
+    // The symmetric case: `Emp` (virtual `Id`) is the LEFT/FROM side, `Coded`
+    // (real `Id`) the joined one. The left is already real-only
+    // (`prefix.names` never lists a virtual), so a LEFT virtual `Id` is not
+    // even a candidate — the common set stays the empty real intersection and
+    // the join is a CROSS product over all four real columns.
+    try engineVirtual().expect("SELECT * FROM Emp NATURAL JOIN Coded",
+        yields: [
+          [10, "Ann", 1, "c1"],
+          [10, "Ann", 2, "c2"],
+          [10, "Ann", 3, "c3"],
+          [20, "Bob", 1, "c1"],
+          [20, "Bob", 2, "c2"],
+          [20, "Bob", 3, "c3"],
+          [20, "Cid", 1, "c1"],
+          [20, "Cid", 2, "c2"],
+          [20, "Cid", 3, "c3"],
+        ])
+    let text = "SELECT * FROM Emp NATURAL JOIN Coded"
+    let columns = try engineVirtual().columns(of: parse(query: text))
+    #expect(columns.map(\.name) == ["Dept", "Name", "Id", "Tag"])
+  }
+
+  @Test func `explicit USING over the real-and-virtual Id still merges (round 7)`()
+      throws {
+    // CONTROL: the round-7 behavior is UNCHANGED. `Coded JOIN Emp USING (Id)`
+    // still resolves `Coded`'s REAL `Id` and `Emp`'s VIRTUAL `Id` through the
+    // virtual-aware probe and MERGES them (keys real 1..3 against the row
+    // index 1..3), a single merged `Id` first, then the remaining real columns.
+    // Only NATURAL's common-set derivation changed; the explicit-USING path is
+    // untouched.
+    try engineVirtual().expect("SELECT * FROM Coded JOIN Emp USING (Id)",
+        yields: [
+          [1, "c1", 10, "Ann"],
+          [2, "c2", 20, "Bob"],
+          [3, "c3", 20, "Cid"],
+        ])
+    let text = "SELECT * FROM Coded JOIN Emp USING (Id)"
+    let columns = try engineVirtual().columns(of: parse(query: text))
+    #expect(columns.map(\.name) == ["Id", "Tag", "Dept", "Name"])
+  }
+
+  @Test func `a RIGHT USING over a virtual Id coalesces the right-only value`()
+      throws {
+    // `Few` has ONE row (Id 1); `Many` has three (Ids 1..3). A RIGHT join keeps
+    // every `Many` row: Id 1 matches, and Ids 2 and 3 are right-only with a
+    // NULL-extended left `Id`. The merged `Id` = COALESCE(Few.Id, Many.Id) must
+    // show the JOINED (right) virtual value on those right-only rows, so the
+    // merged column is 1, 2, 3 — not NULL — proving the run coalesces the
+    // virtual slot, not just resolves it.
+    try engineVirtual().expect("""
+        SELECT Id FROM Few RIGHT JOIN Many USING (Id) ORDER BY Id
+        """,
+        yields: [[1], [2], [3]])
+  }
+
+  // MARK: - A merged name a later plain join re-collides with on the VIRTUAL
+  // axis (round 8)
+
+  @Test func `a bare merged Id a later plain join's virtual Id re-collides with faults`()
+      throws {
+    // `Few JOIN Many USING (Id)` merges the VIRTUAL `Id` of both sides; a later
+    // plain `JOIN Emp ON 1 = 1` brings `Emp`'s OWN addressable virtual `Id`. A
+    // bare `Id` now names BOTH the merged column and `Emp.Id`, so it faults
+    // `.ambiguous` — the merged bare lookup scans the FULL addressable surface
+    // (physical AND virtual, `Scope.ordinal(of:)`'s), not a real-only one that
+    // would MISS the virtual `Emp.Id` and wrongly take the merged value. run
+    // and `columns(of:)` agree.
+    let text = "SELECT Id FROM Few JOIN Many USING (Id) JOIN Emp ON 1 = 1"
+    try engineVirtual().expect(text, fails: .ambiguous("Id"))
+    #expect(throws: SQLError.ambiguous("Id")) {
+      _ = try engineVirtual().columns(of: parse(query: text))
+    }
+  }
+
+  @Test func `a bare merged Id ambiguous with a virtual one faults in the WHERE`()
+      throws {
+    // The same conflict feeds a `WHERE` predicate: with the merged `Id` AND the
+    // plain-joined `Emp.Id` (virtual) both addressable, a bare `Id` in the
+    // `WHERE` faults `.ambiguous` rather than silently keying on the merged
+    // value.
+    let text = """
+        SELECT v FROM Few JOIN Many USING (Id) JOIN Emp ON 1 = 1 WHERE Id = 1
+        """
+    try engineVirtual().expect(text, fails: .ambiguous("Id"))
+    #expect(throws: SQLError.ambiguous("Id")) {
+      _ = try engineVirtual().columns(of: parse(query: text))
+    }
+  }
+
+  @Test func `a later USING over a virtual Id a plain join re-collided with faults`()
+      throws {
+    // The conflict feeds a later `USING` key too: `… USING (Id) JOIN Emp ON 1 =
+    // 1 JOIN Coded USING (Id)` accumulates a left carrying BOTH the merged `Id`
+    // and the plain-joined `Emp.Id` (virtual), so keying the final `USING (Id)`
+    // on that left is ambiguous — the left resolution (`Scope.left`) routes
+    // through the SAME full-surface merged bare lookup and faults.
+    try engineVirtual().expect("""
+        SELECT v FROM Few JOIN Many USING (Id) JOIN Emp ON 1 = 1
+        JOIN Coded USING (Id)
+        """,
+        fails: .ambiguous("Id"))
+  }
+
+  @Test func `qualified sides of a virtual-Id merge still resolve past a re-collision`()
+      throws {
+    // With bare `Id` ambiguous, each QUALIFIED reference still reaches its own
+    // side unambiguously: `Few.Id`/`Many.Id` the merge constituents (both the
+    // matched row index 1), `Emp.Id` the later plain join's virtual `Id` (the
+    // three `Emp` rows' indices 1..3) — never a fault.
+    try engineVirtual().expect("""
+        SELECT Few.Id, Many.Id, Emp.Id FROM Few JOIN Many USING (Id)
+        JOIN Emp ON 1 = 1
+        """,
+        yields: [[1, 1, 1], [1, 1, 2], [1, 1, 3]])
+  }
+
+  @Test func `a bare merged name a later plain join lacks stays unambiguous`()
+      throws {
+    // The control: when the later plain join's relation does NOT expose the
+    // merged name, the full-surface scan finds NO non-constituent match and the
+    // bare name resolves to the merged column — no false ambiguity. `Emp JOIN
+    // Team USING (Dept)` merges `Dept`; `Other(y)` carries no `Dept`, so a bare
+    // `Dept` still coalesces (only Dept 20 matches on both sides). run and
+    // `columns(of:)` agree.
+    let catalog = try Catalog {
+      Relation("Emp", ["Dept": .integer, "Name": .text]) {
+        Row(10, "Ann")
+        Row(20, "Bob")
+        Row(20, "Cid")
+      }
+      Relation("Team", ["Dept": .integer, "Lead": .text]) {
+        Row(20, "Deb")
+        Row(30, "Eve")
+      }
+      Relation("Other", ["y": .text]) {
+        Row("p")
+      }
+    }
+    let text = "SELECT Dept FROM Emp JOIN Team USING (Dept) JOIN Other ON 1 = 1"
+    try catalog.expect(text, yields: [[20], [20]])
+    let columns = try catalog.columns(of: parse(query: text))
+    #expect(columns.map(\.name) == ["Dept"])
+  }
+
+  // MARK: - `SELECT *` arity derives from the emitted enumeration (round 9)
+
+  @Test func `a virtual-Id USING SELECT * width equals its emitted arity`()
+      throws {
+    // `SELECT * FROM Emp JOIN Team USING (Id)` merges the VIRTUAL `Id` of both
+    // sides. No REAL column is subsumed (both `Id`s are virtual), so the arm
+    // emits FIVE values (the merged `Id`, then `Emp`'s two real columns, then
+    // `Team`'s two) — and the computed `SELECT *` width must equal that count,
+    // not undercount by subtracting the virtual constituents from a real-only
+    // sum. The width now DERIVES from the same enumeration `columns(of:)`
+    // walks, so the two agree by construction.
+    let catalog = try engineNamed()
+    try catalog.expect("SELECT * FROM Emp JOIN Team USING (Id)",
+        yields: [
+          [1, 10, "Ann", 20, "Deb"],
+          [2, 20, "Bob", 30, "Eve"],
+        ])
+    let text = "SELECT * FROM Emp JOIN Team USING (Id)"
+    let columns = try catalog.columns(of: parse(query: text))
+    #expect(columns.count == 5)
+  }
+
+  @Test func `a set operation over a virtual-Id SELECT * matches arity 5`()
+      throws {
+    // The undercounted width fed the set-operation arity check, so a genuinely
+    // matching UNION was WRONGLY rejected. The left arm's `SELECT *` is arity 5
+    // (merged virtual `Id` + four real columns); a right arm of five columns
+    // now unifies rather than faulting.
+    try engineNamed().expect("""
+        SELECT * FROM Emp JOIN Team USING (Id)
+        UNION ALL SELECT 9, 99, 'z', 88, 'w'
+        """,
+        yields: [
+          [1, 10, "Ann", 20, "Deb"],
+          [2, 20, "Bob", 30, "Eve"],
+          [9, 99, "z", 88, "w"],
+        ])
+  }
+
+  @Test func `a virtual-Id SELECT * set operation still faults a real arity mismatch`()
+      throws {
+    // The floor: a right arm of the WRONG arity (three columns against the
+    // arm's five) still faults `.arity`, so deriving width from the enumeration
+    // did not disable the check.
+    try engineNamed().expect("""
+        SELECT * FROM Emp JOIN Team USING (Id) UNION ALL SELECT 1, 2, 3
+        """,
+        fails: .arity(5, 3))
+  }
+
+  @Test func `an ORDER BY ordinal past the merged width resolves`() throws {
+    // The undercounted width (3) made the `ORDER BY` ordinal bound in the
+    // type-check path (`columns(of:validate:true)`) REJECT a valid ordinal (4
+    // or 5) that names a real output column — the width there feeds the bound.
+    // The width is now 5, so ordinal 5 (`Team`'s `Lead`) type-checks, and the
+    // run resolves and sorts by it.
+    let catalog = try engineNamed()
+    let text = "SELECT * FROM Emp JOIN Team USING (Id) ORDER BY 5"
+    _ = try catalog.columns(of: parse(query: text))
+    try catalog.expect(text,
+        yields: [
+          [1, 10, "Ann", 20, "Deb"],
+          [2, 20, "Bob", 30, "Eve"],
+        ])
+  }
+
+  @Test func `a real-column USING SELECT * width is unchanged`() throws {
+    // The control: when the USING column is a REAL column (`Dept`), one real
+    // constituent per side IS subsumed, so the emitted arity is 3 (merged
+    // `Dept` + `Emp.Name` + `Team.Lead`) — unchanged by deriving width from the
+    // enumeration. `columns(of:)` reports 3 and an `ORDER BY 3` resolves while
+    // an `ORDER BY 4` faults.
+    let catalog = try engineNamed()
+    let text = "SELECT * FROM Emp JOIN Team USING (Dept)"
+    let columns = try catalog.columns(of: parse(query: text))
+    #expect(columns.count == 3)
+    try catalog.expect("\(text) ORDER BY 3",
+        yields: [
+          [20, "Bob", "Deb"],
+          [20, "Cid", "Deb"],
+        ])
+    catalog.expect("\(text) ORDER BY 4", fails: .column("4"))
+  }
+}
+
+/// Fixtures for the VIRTUAL-`Id` named-column join cases. `Coded` carries a
+/// REAL `Id` column (which shadows its own virtual `Id`), so a `USING (Id)`
+/// against `Emp`'s VIRTUAL `Id` mixes a real and a virtual constituent. `Few`
+/// (one row) RIGHT-joined to `Many` (three rows) `USING (Id)` produces two
+/// right-only rows whose merged `Id` must coalesce to `Many`'s row index.
+private func engineVirtual() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("Emp", ["Dept": .integer, "Name": .text]) {
+      Row(10, "Ann")
+      Row(20, "Bob")
+      Row(20, "Cid")
+    }
+    Relation("Coded", ["Id": .integer, "Tag": .text]) {
+      Row(1, "c1")
+      Row(2, "c2")
+      Row(3, "c3")
+    }
+    Relation("Few", ["v": .text]) {
+      Row("f1")
+    }
+    Relation("Many", ["w": .text]) {
+      Row("m1")
+      Row("m2")
+      Row("m3")
+    }
+  }
+}
+
+/// Three relations for a chained named-column join over TWO DISTINCT columns:
+/// `P(k, p)` and `Q(k, a, q)` share `k`, and `Q` and `R(a, r)` share `a`, so
+/// `(P JOIN Q USING (k)) JOIN R USING (a)` merges `k` at the INNER join and `a`
+/// at the OUTER one — the ISO 7.10 output order is `[a, k, p, q, r]`. `P
+/// NATURAL JOIN Q NATURAL JOIN R` discovers the same common columns.
+private func engineChained() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("P", ["k": .integer, "p": .text]) {
+      Row(1, "p1")
+    }
+    Relation("Q", ["k": .integer, "a": .integer, "q": .text]) {
+      Row(1, 7, "q1")
+    }
+    Relation("R", ["a": .integer, "r": .text]) {
+      Row(7, "r1")
+    }
+  }
+}
+

--- a/Tests/SQLTests/Queries/GroupingKeyValidationTests.swift
+++ b/Tests/SQLTests/Queries/GroupingKeyValidationTests.swift
@@ -1,0 +1,135 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+import SQLEngine
+import SQLStandard
+import SQLTestSupport
+
+// MARK: - Fixtures
+
+/// A two-relation catalog sharing a `Region` column so a `USING`/`NATURAL`
+/// join forms a merged column a `GROUP BY` may key on.
+private func shipments() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("Orders", ["Region": .text, "Amount": .integer]) {
+      Row("East", 10)
+      Row("West", 20)
+    }
+    Relation("Ship", ["Region": .text, "Cost": .integer]) {
+      Row("East", 5)
+      Row("West", 7)
+    }
+  }
+}
+
+/// The AST `SELECT COUNT(*) FROM Orders GROUP BY <key>`. The parser accepts
+/// only a bare column as a `GROUP BY` key (ISO extended grouping is a
+/// follow-up), so an EVALUATABLE key — the surface the `Array<Expression>`
+/// widening admits and the merged-column lowering relies on — is built by AST
+/// to exercise the validation path a future general-key parser would feed.
+private func grouped(by key: Expression,
+                     where predicate: Predicate? = nil) -> Query {
+  .select(Select(projection: .expressions(
+                     [Projected(expression: .aggregate(.count, of: .star))]),
+                 from: Relation(name: "Orders"), predicate: predicate,
+                 grouping: [key]))
+}
+
+/// The `SQLError` running `query` against `catalog` raises, or `nil`.
+private func running(_ query: Query,
+                     _ catalog: borrowing FixtureCatalog) -> SQLError? {
+  do {
+    _ = try catalog.run(query)
+    return nil
+  } catch let fault {
+    return fault
+  }
+}
+
+/// The `SQLError` type-checking `query`'s schema raises, or `nil`.
+private func checking(_ query: Query,
+                      _ catalog: borrowing FixtureCatalog) -> SQLError? {
+  do {
+    _ = try catalog.columns(of: query, validate: true)
+    return nil
+  } catch let fault {
+    return fault
+  }
+}
+
+// MARK: - Tests
+
+struct GroupingKeyValidationTests {
+  @Test func `an evaluatable GROUP BY key faults under validate as it does at run`()
+      throws {
+    // A `GROUP BY 1 / 0` key is EVALUATED per row to form the groups, so a run
+    // faults `SQLError.divide`. The schema/type-check walk must surface the
+    // SAME fault: `group` lowers the key to a term STRUCTURALLY (no
+    // evaluation), so `compile` alone never raised it — the walk now routes
+    // each key through the same operand type-check the projection and ORDER BY
+    // keys use, closing the gap where `columns(of:validate:)` returned a silent
+    // schema for a key a run would fault on.
+    let query = grouped(by: .binary(.divide, .literal(.integer(1)),
+                                    .literal(.integer(0))))
+    #expect(running(query, try shipments()) == .divide)
+    #expect(checking(query, try shipments()) == .divide)
+  }
+
+  @Test func `a bad-type GROUP BY key faults under validate as it does at run`()
+      throws {
+    // `'a' + 1` adds text to an integer — a type error the arithmetic operand
+    // check faults on. As an evaluated grouping key it faults at run, and the
+    // walk now surfaces the same fault under validate.
+    let query = grouped(by: .binary(.add, .literal(.string("a")),
+                                    .literal(.integer(1))))
+    let ran = running(query, try shipments())
+    #expect(ran != nil)
+    #expect(checking(query, try shipments()) == ran)
+  }
+
+  @Test func `a bare-column GROUP BY key still validates and runs`() throws {
+    // The common case — the only shape the parser yields today — must not be
+    // falsely rejected by the added grouping walk: a bare column resolves
+    // exactly as it does elsewhere.
+    let sql = "SELECT COUNT(*) FROM Orders GROUP BY Region"
+    let columns = try shipments().columns(of: parse(query: sql), validate: true)
+    #expect(columns.count == 1)
+    try shipments().expect(sql, yields: [[1], [1]])
+  }
+
+  @Test func `a merged USING GROUP BY key still validates and runs`() throws {
+    // A bare `NATURAL`/`USING` merged column keys on its COALESCE value; the
+    // grouping walk validates it through the same merged-aware bare lookup the
+    // run lowers it with, so it is not falsely rejected.
+    let sql = """
+        SELECT COUNT(*) FROM Orders JOIN Ship USING (Region) GROUP BY Region
+        """
+    let columns = try shipments().columns(of: parse(query: sql), validate: true)
+    #expect(columns.count == 1)
+    try shipments().expect(sql, yields: [[1], [1]])
+  }
+
+  @Test func `a merged NATURAL GROUP BY key still validates and runs`() throws {
+    let sql = "SELECT COUNT(*) FROM Orders NATURAL JOIN Ship GROUP BY Region"
+    let columns = try shipments().columns(of: parse(query: sql), validate: true)
+    #expect(columns.count == 1)
+    try shipments().expect(sql, yields: [[1], [1]])
+  }
+
+  @Test func `a constant-false WHERE spares an evaluatable GROUP BY key`()
+      throws {
+    // A constant-false WHERE yields no rows, so a GROUP BY forms NO group and
+    // never evaluates its key — the run does not fault, so validate must not
+    // either. This mirrors the projection path's constant-false elision (a
+    // false WHERE spares an unreachable `1 / 0`), which the grouping walk
+    // inherits by sitting past the same early return.
+    let query = grouped(by: .binary(.divide, .literal(.integer(1)),
+                                    .literal(.integer(0))),
+                        where: .comparison(left: .literal(.integer(1)),
+                                           op: .equal,
+                                           right: .literal(.integer(0))))
+    #expect(checking(query, try shipments()) == nil)
+    #expect(running(query, try shipments()) == nil)
+  }
+}

--- a/Tests/SQLTests/Schema/OutputSchemaTests.swift
+++ b/Tests/SQLTests/Schema/OutputSchemaTests.swift
@@ -270,6 +270,32 @@ struct OutputSchemaTests {
     #expect(trailing[0].1 == .integer)
   }
 
+  @Test func `a SELECT star USING merge carries its unconstrained mask into a UNION`()
+      throws {
+    // Both `USING (k)` constituents are constant-NULL (`NULLIF(1, 1)`), so the
+    // merged `k` places NO type constraint. A `SELECT *` must carry that mask —
+    // routed through the SAME construction the explicit `SELECT k` uses — so
+    // the enclosing UNION unifies the merged `k` with the text arm rather than
+    // faulting the first arm's integer against text.
+    let star = try schema("""
+        SELECT * FROM (SELECT NULLIF(1, 1) AS k FROM People) AS a
+          JOIN (SELECT NULLIF(1, 1) AS k FROM People) AS b USING (k)
+          UNION SELECT 'x'
+        """)
+    #expect(star.count == 1)
+    #expect(star[0] == ("k", .text))
+    // A genuinely CONSTRAINED merge (two integer `k` sides) still faults an
+    // irreconcilable text UNION arm — the mask is carried, not hard-coded
+    // unconstrained.
+    #expect(throws: SQLError.self) {
+      try catalog().columns(of: parse(query: """
+          SELECT * FROM (SELECT Age AS k FROM People) AS a
+            JOIN (SELECT Age AS k FROM People) AS b USING (k)
+            UNION SELECT 'x'
+          """))
+    }
+  }
+
   @Test func `a UNION nested in a subquery widens its column`() throws {
     // The set operation runs through the `.setop` Plan node here (a derived
     // table), which carries its unified `types` from compile — the outer

--- a/Tests/SQLTests/Syntax/ParserTests.swift
+++ b/Tests/SQLTests/Syntax/ParserTests.swift
@@ -568,6 +568,65 @@ struct JoinTests {
       _ = try Statement(parsing: "SELECT * FROM A CROSS B")
     }
   }
+
+  @Test func `parses a NATURAL JOIN as the natural criterion`() throws {
+    // `NATURAL JOIN` carries the `.natural` criterion; its columns resolve by
+    // name at compile, so the parser leaves the placeholder always-true `on`.
+    let select = try parse(select: "SELECT * FROM A NATURAL JOIN B")
+    #expect(select.joins == [
+      Join(relation: Relation(name: "B"), kind: .inner, using: .natural),
+    ])
+  }
+
+  @Test func `parses a NATURAL LEFT OUTER JOIN`() throws {
+    let select = try parse(select: "SELECT * FROM A NATURAL LEFT OUTER JOIN B")
+    #expect(select.joins == [
+      Join(relation: Relation(name: "B"), kind: .left, using: .natural),
+    ])
+  }
+
+  @Test func `parses a JOIN USING column list as the using criterion`() throws {
+    let select = try parse(select: "SELECT * FROM A JOIN B USING (x, y)")
+    #expect(select.joins == [
+      Join(relation: Relation(name: "B"), kind: .inner,
+           using: .columns(["x", "y"])),
+    ])
+  }
+
+  @Test func `parses a FULL OUTER JOIN USING`() throws {
+    let select = try parse(select: """
+        SELECT * FROM A FULL OUTER JOIN B USING (k)
+        """)
+    #expect(select.joins == [
+      Join(relation: Relation(name: "B"), kind: .full,
+           using: .columns(["k"])),
+    ])
+  }
+
+  @Test func `a NATURAL JOIN with a trailing ON faults`() {
+    #expect(throws: SQLError.self) {
+      _ = try Statement(parsing: "SELECT * FROM A NATURAL JOIN B ON a.x = b.x")
+    }
+  }
+
+  @Test func `a JOIN USING with a trailing ON faults`() {
+    #expect(throws: SQLError.self) {
+      _ = try Statement(
+          parsing: "SELECT * FROM A JOIN B USING (x) ON a.x = b.x")
+    }
+  }
+
+  @Test func `a USING without a parenthesised list faults`() {
+    #expect(throws: SQLError.self) {
+      _ = try Statement(parsing: "SELECT * FROM A JOIN B USING x")
+    }
+  }
+
+  @Test func `a NATURAL CROSS JOIN faults`() {
+    #expect(throws: SQLError.self) {
+      _ = try Statement(parsing: "SELECT * FROM A NATURAL CROSS JOIN B")
+    }
+  }
 }
 
 // MARK: - Literals


### PR DESCRIPTION
Add the ISO 9075 named-column join criteria — `NATURAL [INNER | LEFT | RIGHT | FULL [OUTER]] JOIN` and `JOIN … USING (c, …)` — to the SQL dialect, reusing the existing JOIN + ON + projection machinery rather than a new executor path.

The lexer/token gain the `NATURAL` and `USING` keywords, and the parser records the criterion on the `Join` node's new `using` field (a `.natural`/`.columns` enum) while leaving a placeholder always-true `on`. A `NATURAL`/`USING` join bars a trailing `ON` (mutually exclusive), and a plain non-`CROSS` join still requires exactly one of `ON`/`USING`.

Because the concrete join columns are known only after schema resolution (a `NATURAL` join's are the two sides' shared names), a criterion is resolved into a plain-`ON` join and a coalesced `SELECT *` at compile — in `Catalog.desugared(_:_:)`, called first by every path that consumes a select (the run's `compile`, the schema path's `arms`, the validation `typecheck`), so all three see one resolved shape. The rewrite is a no-op for a query with no named-column join, and idempotent.

The synthesized `on` is the conjunction of `left.c = right.c` over the join columns (empty for a `NATURAL` join with no shared column, which degenerates to a `CROSS` product per ISO). The coalesced `SELECT *` output (ISO 7.10) lists each join column once and first as `COALESCE(left, right)` — so a `RIGHT`/`FULL` join's unmatched row shows the joined-in value — then the left side's remaining columns, then the joined-in relation's, the join columns excluded from both; a chain folds this left to right. An explicit projection is left verbatim.

Resolve the ISO 9075 §7.10 exposed name: a BARE (unqualified) reference to a NATURAL/USING merged column now resolves to the single coalesced value the `SELECT *` path projects, rather than faulting ambiguous. An `expose(_:_:)` substitution rewrites bare join-column references (in an explicit projection, `WHERE`, `GROUP BY`, `HAVING`, `ORDER BY`) to the coalesced expression, leaving qualified `A.c`/`B.c` and non-join names untouched — so a shared-but-NOT-join column stays ambiguous — and not descending a nested subquery, which owns its own scope. Agrees with the `SELECT *` coalescing and the outer-join `COALESCE(left, right)`.