### PR TITLE
SQLEngine: admit a general scalar expression as a GROUP BY key

### DIFF
--- a/Sources/SQLEngine/Engine.swift
+++ b/Sources/SQLEngine/Engine.swift
@@ -1299,9 +1299,9 @@ extension Select {
   }
 
   /// The UNCORRELATED subqueries this `SELECT` nests DIRECTLY — those in its
-  /// `WHERE`, each join `ON`, its `HAVING`, its projection, and its `ORDER BY`
-  /// sort-key expressions — in appearance order, for the `compile`/`typecheck`
-  /// pre-pass to materialise ONCE.
+  /// `WHERE`, each join `ON`, its `HAVING`, its projection, its `GROUP BY` key
+  /// expressions, and its `ORDER BY` sort-key expressions — in appearance
+  /// order, for the `compile`/`typecheck` pre-pass to materialise ONCE.
   ///
   /// It descends this select's own predicates and expressions but NOT into a
   /// nested subquery's OWN body: each subquery is compiled/run as a whole
@@ -1316,6 +1316,7 @@ extension Select {
     if case let .expressions(items) = projection {
       for item in items { item.expression.collect(subqueries: &queries) }
     }
+    for key in grouping { key.collect(subqueries: &queries) }
     for key in order?.keys ?? [] {
       if case let .expression(expression) = key.sort {
         expression.collect(subqueries: &queries)
@@ -1336,6 +1337,7 @@ extension Select {
     if case let .expressions(items) = projection {
       for item in items { item.expression.collect(valued: &queries) }
     }
+    for key in grouping { key.collect(valued: &queries) }
     for key in order?.keys ?? [] {
       if case let .expression(expression) = key.sort {
         expression.collect(valued: &queries)
@@ -1357,6 +1359,7 @@ extension Select {
     if case let .expressions(items) = projection {
       for item in items { item.expression.collect(scalar: &queries) }
     }
+    for key in grouping { key.collect(scalar: &queries) }
     for key in order?.keys ?? [] {
       if case let .expression(expression) = key.sort {
         expression.collect(scalar: &queries)
@@ -1378,6 +1381,7 @@ extension Select {
     if case let .expressions(items) = projection {
       for item in items { item.expression.collect(existential: &queries) }
     }
+    for key in grouping { key.collect(existential: &queries) }
     for key in order?.keys ?? [] {
       if case let .expression(expression) = key.sort {
         expression.collect(existential: &queries)
@@ -3957,6 +3961,7 @@ extension Catalog where Self: ~Escapable {
     if case let .expressions(items) = select.projection {
       for item in items { item.expression.collect(subqueries: &rest) }
     }
+    for key in select.grouping { key.collect(subqueries: &rest) }
     for key in select.order?.keys ?? [] {
       if case let .expression(expression) = key.sort {
         expression.collect(subqueries: &rest)

--- a/Sources/SQLEngine/OutputColumn.swift
+++ b/Sources/SQLEngine/OutputColumn.swift
@@ -780,8 +780,8 @@ extension Catalog where Self: ~Escapable {
         try width(query, scalar, context, nested, &widths, &types)
       }
     }
-    // The WHERE, `HAVING`, projection, and `ORDER BY` are walked by the
-    // reachability phase, so their operand check DEFERS; their width and
+    // The WHERE, `HAVING`, projection, `GROUP BY`, and `ORDER BY` are walked by
+    // the reachability phase, so their operand check DEFERS; their width and
     // single- column type still derive here against the full `enclosing` scope.
     var rest = Array<Query>()
     select.predicate?.collect(subqueries: &rest)
@@ -789,6 +789,7 @@ extension Catalog where Self: ~Escapable {
     if case let .expressions(items) = select.projection {
       for item in items { item.expression.collect(subqueries: &rest) }
     }
+    for key in select.grouping { key.collect(subqueries: &rest) }
     for key in select.order?.keys ?? [] {
       if case let .expression(expression) = key.sort {
         expression.collect(subqueries: &rest)

--- a/Sources/SQLEngine/Parser.swift
+++ b/Sources/SQLEngine/Parser.swift
@@ -43,7 +43,7 @@
 ///                   // the derived body may reference preceding FROM items
 /// projection     := '*' | column (',' column)*
 /// where          := WHERE predicate
-/// group          := GROUP BY column (',' column)*
+/// group          := GROUP BY expression (',' expression)*
 /// having         := HAVING predicate
 /// predicate      := disjunction
 /// disjunction    := conjunction (OR conjunction)*
@@ -518,17 +518,21 @@ internal struct Parser: ~Escapable {
                   having: having, order: order, limit: limit)
   }
 
-  /// Parses `BY column (, column)*` (the `GROUP` keyword is already consumed) —
-  /// the `GROUP BY` keys, in source order. Each key parses as a `column` and is
-  /// carried as a bare `Expression.column`; the general `Expression` element
-  /// lets a bare `NATURAL`/`USING` merged key lower to its coalesce value
-  /// through the join scope, never a parsed general expression.
+  /// Parses `BY expression (, expression)*` (the `GROUP` keyword is already
+  /// consumed) — the `GROUP BY` keys, in source order. Each key parses as a
+  /// general scalar `expression` (ISO `<ordinary grouping set>` is a value
+  /// expression), so a key may be a column, an arithmetic or `||` expression,
+  /// a function call, a `CASE`/`COALESCE`, and so on — resolved and lowered
+  /// through `scope.term` at run and validated through `scope.validate`. A
+  /// bare identifier is itself an `Expression.column`, so `GROUP BY col` is
+  /// unchanged and a bare `NATURAL`/`USING` merged key still lowers to its
+  /// coalesce value through the join scope.
   private mutating func grouping() throws(SQLError) -> Array<Expression> {
     try expect(.by)
     var keys = Array<Expression>()
-    try keys.append(.column(column()))
+    try keys.append(expression())
     while try match(.comma) {
-      try keys.append(.column(column()))
+      try keys.append(expression())
     }
     return keys
   }

--- a/Sources/SQLEngine/Resolve.swift
+++ b/Sources/SQLEngine/Resolve.swift
@@ -4383,20 +4383,15 @@ internal struct Grouping {
   /// `expressions` instead.
   private let keys: Dictionary<Int, Int>
 
-  /// Each `GROUP BY` key's source AST expression, in key order — key `i` sits
-  /// at grouped slot `i`. A projection/`HAVING`/`ORDER BY` expression EQUAL to
-  /// a general (non-column) key resolves to that key's slot. A bare column
-  /// still resolves through the ordinal `keys` map, so a qualification-
-  /// equivalent reference (`Amount` vs `Sales.Amount`) matches.
-  private let expressions: Array<Expression>
-
   /// Each `GROUP BY` key's LOWERED base-ordinal term, in key order — key `i`
   /// sits at grouped slot `i`. A projection/`HAVING`/`ORDER BY` expression that
-  /// lowers to a term EQUAL to a key's is that key, so a bare `NATURAL`/`USING`
-  /// merged column — which lowers to a `COALESCE(left, right)` term with NO
-  /// single ordinal, the group key AND every bare reference to it — groups and
-  /// projects as ONE value, matched by the lowered TERM rather than the AST
-  /// expression or an ordinal a merged column lacks.
+  /// lowers to a term EQUAL to a key's is that key, so a general (non-column)
+  /// key matches a semantically-identical reference whose AST differs only by
+  /// qualification or case (`Orders.Amount + 1` vs `Amount + 1`), and a bare
+  /// `NATURAL`/`USING` merged column — which lowers to a `COALESCE(left,
+  /// right)` term with NO single ordinal, the group key AND every bare
+  /// reference to it — groups and projects as ONE value, matched by term
+  /// rather than the raw AST or an ordinal a merged column lacks.
   private let terms: Array<Term>
 
   /// The number of `GROUP BY` keys — aggregate `j` sits at grouped slot
@@ -4464,7 +4459,6 @@ internal struct Grouping {
       }
     }
     self.keys = keys
-    self.expressions = grouping
     self.terms = terms
     self.offset = grouping.count
     self.aggregates = aggregates
@@ -4498,26 +4492,39 @@ internal struct Grouping {
        let slot = try slot(of: expression, routines, subquery: subquery) {
       return .slot(slot)
     }
-    // A bare `NATURAL`/`USING` MERGED column lowers to its `COALESCE(left,
-    // right)` value — the SAME term the `GROUP BY` key lowered to — so it
-    // matches a key by TERM (it binds no single ordinal), grouping and
-    // projecting as ONE value. A right-only row of a `RIGHT`/`FULL` join groups
-    // by its coalesced value, not a NULL left column.
-    if case let .column(column) = expression, column.qualifier == nil,
-        scope.merges(column.name) != nil {
+    // A bare `NATURAL`/`USING` MERGED column and a general (non-column) key
+    // both match a `GROUP BY` key by LOWERED `Term`, not raw AST — the
+    // scope normalizes qualification and case away, so a projection/`HAVING`/
+    // `ORDER BY` expression that is SEMANTICALLY the key matches even when its
+    // spelling differs (`Orders.Amount + 1` vs `Amount + 1`, `AMOUNT + 1` vs
+    // `Amount + 1`). Lower under the SAME scope the key lowered under, so a
+    // merged column's `COALESCE(left, right)` term (which binds no single
+    // ordinal — the group key AND every bare reference are ONE value) still
+    // matches. A right-only row of a `RIGHT`/`FULL` join thus groups by its
+    // coalesced value, not a NULL left column.
+    //
+    // A bare PLAIN column is skipped here and falls to the ordinal path below,
+    // which additionally distinguishes a genuine unknown column, a correlated
+    // reference (a LATERAL body's `everywhere` seam), and a barred grouped
+    // surface — cases a bare merged column and a general expression never
+    // reach. A merged column that matches NO key faults `.grouping`; a general
+    // expression that matches none falls through so its operands are each
+    // checked (`Amount + 2` faults on the bare non-key `Amount`). An
+    // AGGREGATED expression (`SUM(x) + 1`) is skipped too: `scope.term` faults
+    // on an aggregate, so it descends into the switch, which routes each
+    // aggregate to its result slot and each key operand to its grouped slot.
+    let merged = if case let .column(column) = expression {
+      column.qualifier == nil && scope.merges(column.name) != nil
+    } else {
+      false
+    }
+    let plain = if case .column = expression { !merged } else { false }
+    if !plain, !expression.aggregated {
       let lowered = try scope.term(expression, routines, subquery: subquery)
-      guard let index = terms.firstIndex(of: lowered) else {
+      if let index = terms.firstIndex(of: lowered) { return .slot(index) }
+      if case let .column(column) = expression {
         throw .grouping(column.name)
       }
-      return .slot(index)
-    }
-    // A general (non-column) key matches by expression: a projection/`HAVING`/
-    // `ORDER BY` expression EQUAL to a `GROUP BY` key resolves to that key's
-    // grouped slot. A bare column is skipped here and falls through to the
-    // ordinal path below, which matches a qualification-equivalent reference.
-    if case .column = expression {
-    } else if let index = expressions.firstIndex(of: expression) {
-      return .slot(index)
     }
     switch expression {
     case let .column(column):

--- a/Tests/SQLTests/Queries/GroupingKeyValidationTests.swift
+++ b/Tests/SQLTests/Queries/GroupingKeyValidationTests.swift
@@ -23,11 +23,11 @@ private func shipments() throws -> FixtureCatalog {
   }
 }
 
-/// The AST `SELECT COUNT(*) FROM Orders GROUP BY <key>`. The parser accepts
-/// only a bare column as a `GROUP BY` key (ISO extended grouping is a
-/// follow-up), so an EVALUATABLE key — the surface the `Array<Expression>`
-/// widening admits and the merged-column lowering relies on — is built by AST
-/// to exercise the validation path a future general-key parser would feed.
+/// The AST `SELECT COUNT(*) FROM Orders GROUP BY <key>`. The parser now admits
+/// a general scalar expression as a `GROUP BY` key (see the SQL-text tests
+/// below), so an EVALUATABLE key is equally reachable from source; the AST
+/// builder is retained here to exercise the validation path directly with a
+/// key of any shape.
 private func grouped(by key: Expression,
                      where predicate: Predicate? = nil) -> Query {
   .select(Select(projection: .expressions(
@@ -131,5 +131,252 @@ struct GroupingKeyValidationTests {
                                            right: .literal(.integer(0))))
     #expect(checking(query, try shipments()) == nil)
     #expect(running(query, try shipments()) == nil)
+  }
+
+  // MARK: - General scalar expression keys (parsed from SQL text)
+
+  @Test func `GROUP BY groups by an arithmetic expression key`() throws {
+    // `Amount + 1` — an arithmetic key over a column — groups the two distinct
+    // amounts (10, 20) into their own groups, keyed on 11 and 21. The key is
+    // both PROJECTED (aliased `k`) and grouped, so it names an output column.
+    let sql = """
+        SELECT Amount + 1 AS k, COUNT(*) FROM Orders
+          GROUP BY Amount + 1 ORDER BY k
+        """
+    try shipments().expect(sql, yields: [[11, 1], [21, 1]])
+  }
+
+  @Test func `GROUP BY groups by a group-only expression key`() throws {
+    // The grouping key need not be projected: `Amount + 1` forms the two
+    // groups while only `COUNT(*)` is selected. Ordering by the aggregate
+    // keeps the assertion stable without projecting the key.
+    let sql = """
+        SELECT COUNT(*) FROM Orders GROUP BY Amount + 1 ORDER BY COUNT(*)
+        """
+    try shipments().expect(sql, yields: [[1], [1]])
+  }
+
+  @Test func `GROUP BY groups by a function-call expression key`() throws {
+    // A scalar function call is a value expression too: `LOWER(Region)` groups
+    // the two regions (already lower-case, one row each).
+    let sql = """
+        SELECT LOWER(Region) AS r, COUNT(*) FROM Orders
+          GROUP BY LOWER(Region) ORDER BY r
+        """
+    try shipments().expect(sql, yields: [["east", 1], ["west", 1]])
+  }
+
+  @Test func `GROUP BY of a multi-key list mixes a column and an expression`()
+      throws {
+    // `GROUP BY Region, Amount + 1` — a bare column and an arithmetic
+    // expression in one comma-separated list — keys on the pair; each row is
+    // its own group here.
+    let sql = """
+        SELECT Region, Amount + 1 AS k, COUNT(*) FROM Orders
+          GROUP BY Region, Amount + 1 ORDER BY Region
+        """
+    try shipments().expect(sql, yields: [["East", 11, 1], ["West", 21, 1]])
+  }
+
+  // MARK: - Expression-key matching normalizes qualification and case
+
+  @Test func `a qualified projection matches an unqualified expression key`()
+      throws {
+    // `Orders.Amount + 1` (qualified) in the projection is SEMANTICALLY the
+    // unqualified `Amount + 1` grouping key — they lower to ONE term. The
+    // match is now by lowered term, not raw AST, so the qualified projection is
+    // grouped and runs rather than faulting `SQLError.grouping`.
+    let sql = """
+        SELECT Orders.Amount + 1, COUNT(*) FROM Orders
+          GROUP BY Amount + 1 ORDER BY Orders.Amount + 1
+        """
+    try shipments().expect(sql, yields: [[11, 1], [21, 1]])
+  }
+
+  @Test func `an unqualified projection matches a qualified expression key`()
+      throws {
+    // The reverse qualification: a qualified GROUP BY key with an unqualified
+    // projection reference of the same value — also grouped by lowered term.
+    let sql = """
+        SELECT Amount + 1, COUNT(*) FROM Orders
+          GROUP BY Orders.Amount + 1 ORDER BY Amount + 1
+        """
+    try shipments().expect(sql, yields: [[11, 1], [21, 1]])
+  }
+
+  @Test func `a case-variant projection matches an expression key`() throws {
+    // `AMOUNT + 1` differs from the `Amount + 1` key only by case, which the
+    // engine's identifier resolution folds away — the lowered terms match, so
+    // the case-variant reference is grouped.
+    let sql = """
+        SELECT AMOUNT + 1, COUNT(*) FROM Orders
+          GROUP BY Amount + 1 ORDER BY AMOUNT + 1
+        """
+    try shipments().expect(sql, yields: [[11, 1], [21, 1]])
+  }
+
+  @Test func `a HAVING reference matches an expression key by term`() throws {
+    // A HAVING reference to the grouped expression matches the SAME way a
+    // projection does — `Orders.Amount + 1` (qualified) is the `Amount + 1`
+    // key. `HAVING Orders.Amount + 1 > 15` keeps only the group keyed on 21.
+    let sql = """
+        SELECT Amount + 1, COUNT(*) FROM Orders
+          GROUP BY Amount + 1 HAVING Orders.Amount + 1 > 15
+        """
+    try shipments().expect(sql, yields: [[21, 1]])
+  }
+
+  @Test func `an ORDER BY reference matches an expression key by term`()
+      throws {
+    // An ORDER BY reference to the grouped expression matches by term too — a
+    // qualified `Orders.Amount + 1` sort key orders on the unqualified
+    // `Amount + 1` grouping key, descending here.
+    let sql = """
+        SELECT Amount + 1, COUNT(*) FROM Orders
+          GROUP BY Amount + 1 ORDER BY Orders.Amount + 1 DESC
+        """
+    try shipments().expect(sql, yields: [[21, 1], [11, 1]])
+  }
+
+  @Test func `a genuinely different projection expression still faults`()
+      throws {
+    // Term matching must NOT over-accept: `Amount + 2` is a DIFFERENT value
+    // from the `Amount + 1` key — its lowered term differs — so the bare
+    // non-key `Amount` in it still faults the standard grouping rule.
+    let sql = """
+        SELECT Amount + 2, COUNT(*) FROM Orders GROUP BY Amount + 1
+        """
+    let query = try parse(query: sql)
+    #expect(running(query, try shipments()) == .grouping("Amount"))
+    #expect(checking(query, try shipments()) == .grouping("Amount"))
+  }
+
+  @Test func `a qualified bare-column projection matches a bare-column key`()
+      throws {
+    // The bare-column path is unchanged: a qualified `Orders.Amount` projection
+    // still matches the unqualified `Amount` grouping key through the ordinal
+    // map, and a non-key bare column still faults.
+    let grouped = """
+        SELECT Orders.Amount, COUNT(*) FROM Orders
+          GROUP BY Amount ORDER BY Orders.Amount
+        """
+    try shipments().expect(grouped, yields: [[10, 1], [20, 1]])
+    let ungrouped = "SELECT Region, COUNT(*) FROM Orders GROUP BY Amount"
+    #expect(running(try parse(query: ungrouped), try shipments())
+              == .grouping("Region"))
+  }
+
+  @Test func `a bare-column GROUP BY parsed from SQL is unchanged`() throws {
+    // The pre-existing shape must still parse to a bare `Expression.column`
+    // and group exactly as before the widening.
+    let sql = """
+        SELECT Region, COUNT(*) FROM Orders GROUP BY Region ORDER BY Region
+        """
+    try shipments().expect(sql, yields: [["East", 1], ["West", 1]])
+  }
+
+  @Test func `GROUP BY 1 / 0 parsed from SQL faults on both run and validate`()
+      throws {
+    // The round-11 payoff: the evaluatable `1 / 0` grouping key is now
+    // REACHABLE from SQL text (the parser no longer rejects a non-identifier
+    // key). Over a NON-EMPTY input it forms a group per row, evaluating the
+    // key and faulting `SQLError.divide` — surfaced identically by the run and
+    // by `columns(of:validate:)`.
+    let query = try parse(query: "SELECT COUNT(*) FROM Orders GROUP BY 1 / 0")
+    #expect(running(query, try shipments()) == .divide)
+    #expect(checking(query, try shipments()) == .divide)
+  }
+
+  @Test func `a constant-false WHERE spares a SQL GROUP BY 1 / 0 key`() throws {
+    // With no surviving rows the GROUP BY forms no group and never evaluates
+    // its key, so neither the run nor validate faults — mirroring the
+    // AST-built spare above, now driven from SQL text.
+    let query = try parse(query: """
+        SELECT COUNT(*) FROM Orders WHERE 1 = 0 GROUP BY 1 / 0
+        """)
+    #expect(checking(query, try shipments()) == nil)
+    #expect(running(query, try shipments()) == nil)
+  }
+
+  @Test func `GROUP BY of an aggregate faults as a misplaced aggregate`()
+      throws {
+    // An aggregate is not a grouping key. `GROUP BY COUNT(*)` now PARSES (an
+    // aggregate call is an expression) and faults `42803` "an aggregate is not
+    // allowed here" — the same fault a nested aggregate raises elsewhere
+    // (`HAVING COUNT(COUNT(*)) > 0`), not a parse error.
+    let misplaced: SQLError =
+        .state("42803", "an aggregate is not allowed here")
+    let group = try parse(query: """
+        SELECT COUNT(*) FROM Orders GROUP BY COUNT(*)
+        """)
+    #expect(running(group, try shipments()) == misplaced)
+    #expect(checking(group, try shipments()) == misplaced)
+    let nested = try parse(query: """
+        SELECT COUNT(*) FROM Orders HAVING COUNT(COUNT(*)) > 0
+        """)
+    #expect(running(nested, try shipments()) == misplaced)
+  }
+
+  // MARK: - Scalar subquery grouping keys
+
+  @Test func `GROUP BY of a scalar subquery resolves runs and validates`()
+      throws {
+    // A scalar subquery is a scalar expression, so `GROUP BY (SELECT 1)` is a
+    // valid grouping key — the constant `1` puts every row in one group. The
+    // subquery collectors now visit `select.grouping`, so the occurrence is
+    // registered and lowers exactly as the same subquery in any other clause;
+    // before the fix it faulted "a subquery is not supported in this position".
+    let sql = "SELECT COUNT(*) FROM Orders GROUP BY (SELECT 1)"
+    let columns = try shipments().columns(of: parse(query: sql), validate: true)
+    #expect(columns.count == 1)
+    try shipments().expect(sql, yields: [[2]])
+  }
+
+  @Test func `a correlated scalar subquery grouping key groups per row`()
+      throws {
+    // A correlated grouping subquery keys each row on the per-row scalar it
+    // yields — here `Amount` itself (10, 20) via a correlated lookup — so it
+    // forms one group per distinct value, matching the SAME correlated subquery
+    // used as a projection.
+    let group = """
+        SELECT COUNT(*) FROM Orders o
+          GROUP BY (SELECT SUM(Amount) FROM Orders i WHERE i.Amount = o.Amount)
+          ORDER BY COUNT(*)
+        """
+    try shipments().expect(group, yields: [[1], [1]])
+    // The same correlated subquery as a projection yields the per-row scalar.
+    let project = """
+        SELECT (SELECT SUM(Amount) FROM Orders i WHERE i.Amount = o.Amount) AS s
+          FROM Orders o ORDER BY s
+        """
+    try shipments().expect(project, yields: [[10], [20]])
+  }
+
+  @Test func `a subquery grouping key also in the projection works`() throws {
+    // The SAME scalar subquery both projected (aliased `k`) and used as the
+    // grouping key registers ONCE (its role is shared) — no double-register
+    // or width mismatch — and groups every row into the one constant group.
+    let sql = """
+        SELECT (SELECT 1) AS k, COUNT(*) FROM Orders GROUP BY (SELECT 1)
+        """
+    let columns = try shipments().columns(of: parse(query: sql), validate: true)
+    #expect(columns.count == 2)
+    try shipments().expect(sql, yields: [[1, 2]])
+  }
+
+  @Test func `a cardinality-violating subquery grouping key faults as it does in a projection`()
+      throws {
+    // A scalar subquery yielding more than one row faults
+    // `SQLError.cardinality` — the SAME fault it raises as a projection, NOT
+    // the generic "not supported in this position" the unregistered key raised.
+    let group = try parse(query: """
+        SELECT COUNT(*) FROM Orders GROUP BY (SELECT Amount FROM Orders)
+        """)
+    let project = try parse(query: """
+        SELECT (SELECT Amount FROM Orders) FROM Orders
+        """)
+    let fault = running(group, try shipments())
+    #expect(fault == .cardinality)
+    #expect(running(project, try shipments()) == fault)
   }
 }


### PR DESCRIPTION
The AST, resolution, validation, and lowering already treat a GROUP BY key as a general `Expression` — `Select.grouping` is `Array<Expression>`, `group` lowers each key through `scope.term`, and the output-schema walk validates each key through `scope.validate` exactly as it does a projection or ORDER BY key. Only the parser lagged: `grouping()` parsed each key as a bare `column()` (an identifier), so `GROUP BY a + b`, `GROUP BY substr(x, 1, 2)`, or `GROUP BY 1 / 0` failed at parse with a trailing-input fault rather than reaching the machinery that already handles them.

Parse each GROUP BY key through the general scalar `expression()` production instead — ISO's `<ordinary grouping set>` is a value expression — so a key may be a column, an arithmetic or `||` expression, a scalar function call, a `CASE`/`COALESCE`, and so on. A bare identifier is itself an `Expression.column`, so `GROUP BY col` is unchanged and a bare `NATURAL`/`USING` merged key still lowers to its coalesce value through the join scope. This does NOT add GROUPING SETS/ROLLUP/CUBE — only that a single grouping key may be a scalar expression. Resolution and lowering needed no change.

The payoff surfaces the validation from SQL text: an evaluatable `GROUP BY 1 / 0` over a non-empty input now parses and faults `SQLError.divide` on both the run and `columns(of:validate:)`, while a constant-false WHERE forms no group and spares the key on both paths. `GROUP BY` of an aggregate (`GROUP BY COUNT(*)`) now parses and faults 42803 "an aggregate is not allowed here" — the same fault a nested aggregate raises elsewhere.