### PR TITLE
SQLEngine: pin the run-vs-validate routine posture

### DIFF
--- a/Sources/SQLEngine/Filter.swift
+++ b/Sources/SQLEngine/Filter.swift
@@ -1366,6 +1366,22 @@ extension Catalog where Self: ~Escapable {
 
   /// Resolves `name` in `routines` and applies it to its `arguments` evaluated
   /// against `row`.
+  ///
+  /// This run-path dispatch checks a routine EXISTS — an unregistered `name`
+  /// faults `SQLError.function` — but does NOT validate the call's ARITY or
+  /// its argument TYPES: it evaluates the supplied `arguments` and hands them
+  /// to the routine. That is deliberate. A run assumes the statement was
+  /// already type-checked; `columns(of:validate:)` (via `Scope.call`) is the
+  /// STRICT gate that faults `SQLError.argument` on a wrong argument count or a
+  /// definitively-wrong argument type, so a caller wanting arity/type
+  /// enforcement validates FIRST and a run trusts that check. The engine's own
+  /// routines self-check inside their closures (a native `BITAND` faults on a
+  /// bad count, a `.defined` body enforces its arity/types in
+  /// `callAsFunction`), so a mis-shaped call over them still faults; but a host
+  /// routine that does NOT self-check its count runs regardless at this site.
+  /// See `RoutineArityPostureTests`, which pins the run/validate split. (The
+  /// one value the run DOES enforce here is the finite-double invariant below,
+  /// which no static type-check can see.)
   private borrowing func apply(_ row: borrowing some Row & ~Escapable,
                                _ name: String, _ arguments: Array<Term>,
                                _ context: Context)

--- a/Tests/SQLTests/Queries/RoutineArityPostureTests.swift
+++ b/Tests/SQLTests/Queries/RoutineArityPostureTests.swift
@@ -1,0 +1,100 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQLEngine
+
+import SQLTestSupport
+
+// MARK: - Routine arity/existence posture
+
+/// PINS the accepted run-vs-validate posture for a routine CALL: the bare
+/// `run` path checks a routine EXISTS but defers arity/argument-type validation
+/// to the strict `columns(of:validate:)` gate. A caller wanting strict checks
+/// validates first; a run assumes the statement was already validated. This is
+/// deliberate engine intent — a wrong-arity call reaches a run (a native
+/// routine that does not self-check its count runs regardless), while
+/// validation rejects it — so a regression that started faulting arity at run,
+/// or stopped faulting it under validation, must break these tests.
+///
+/// The fixture is SELF-CONTAINED: a small local catalog and a locally
+/// registered routine, disjoint from the shared `engine*` fixtures, so this
+/// suite pins the posture independently.
+@Suite struct RoutineArityPostureTests {
+  /// A one-row catalog whose single INTEGER column a call projects over.
+  private func table() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["Id": .integer]) {
+        Row(1)
+      }
+    }
+  }
+
+  /// Routines with a native `tally` declaring ONE integer parameter (arity 1)
+  /// whose closure IGNORES its arguments and returns a constant. Because the
+  /// closure does not self-check its argument count, a wrong-arity call reaches
+  /// it and runs — isolating the run path's arity behaviour from a routine's
+  /// own internal check (the standard `POSITION`/`BITAND` closures self-check,
+  /// so
+  /// they would fault regardless and could not observe the run-path posture).
+  private func routines() throws(SQLError) -> Routines {
+    try Routines()
+        .registering("tally", parameters: [.integer]) { _ in .integer(42) }
+  }
+
+  @Test func `a wrong-arity call runs without an arity fault`() throws {
+    // `tally` declares arity 1 but is called with ZERO arguments. The run path
+    // checks only that `tally` EXISTS, not its arity, and the closure ignores
+    // its arguments, so the call produces its constant rather than faulting.
+    let catalog = try table()
+    let routines = try routines()
+    let query = try parse(query: "SELECT tally() FROM T WHERE Id = 1")
+    let rows = try catalog.run(query, routines)
+    #expect(rows == [[.integer(42)]])
+  }
+
+  @Test func `validation faults a wrong-arity call`() throws {
+    // The SAME wrong-arity call is REJECTED by the strict validate gate: the
+    // declared arity is checked against the supplied argument count, faulting
+    // `.argument`. This is the gate a caller runs BEFORE a run when it wants
+    // arity enforced.
+    let catalog = try table()
+    let routines = try routines()
+    let query = try parse(query: "SELECT tally() FROM T WHERE Id = 1")
+    let raised: SQLError?
+    do {
+      _ = try catalog.columns(of: query, routines: routines, validate: true)
+      raised = nil
+    } catch let fault {
+      raised = fault
+    }
+    #expect(raised == .argument("tally takes 1 arguments"))
+  }
+
+  @Test func `an unknown routine faults on BOTH paths`() throws {
+    // EXISTENCE is checked at run, unlike arity: an unregistered routine faults
+    // `.function` at run AND under validation, so the distinction the posture
+    // draws — existence checked, arity deferred — is explicit.
+    let catalog = try table()
+    let routines = try routines()
+    let query = try parse(query: "SELECT nope() FROM T WHERE Id = 1")
+
+    let ran: SQLError?
+    do {
+      _ = try catalog.run(query, routines)
+      ran = nil
+    } catch let fault {
+      ran = fault
+    }
+    #expect(ran == .function("nope"))
+
+    let validated: SQLError?
+    do {
+      _ = try catalog.columns(of: query, routines: routines, validate: true)
+      validated = nil
+    } catch let fault {
+      validated = fault
+    }
+    #expect(validated == .function("nope"))
+  }
+}


### PR DESCRIPTION
The engine draws a deliberate line at a routine call: the bare run path (the executor's `apply`) checks a routine EXISTS — faulting `SQLError.function` for an unregistered name — but does NOT validate the call's arity or argument types, whereas `columns(of:validate:)` (via `Scope.call`) is the strict gate that faults `SQLError.argument` on a bad count or a definitively-wrong argument type. A run assumes the statement was already validated; a caller wanting strict checks validates first.

This was an accepted-but-implicit posture. Pin it as documented INTENT rather than an accidental gap:

- Add `RoutineArityPostureTests`, a self-contained suite (a small local catalog and a locally registered native routine that does not self-check its count, disjoint from the shared `engine*` fixtures) that observes the split empirically: a wrong-arity call RUNS (no arity fault) while validation faults `.argument`, and an unknown routine faults `.function` on BOTH paths (existence IS checked at run).
- Expand the `apply` doc comment to state the posture and cross-reference the strict gate and the pinning test.

No behavior change: `apply` is untouched below the comment.