### PR TITLE
SQLEngine tests: rename engine* fixtures to single words

### DIFF
--- a/Tests/SQLTests/Queries/EngineCrossJoinTests.swift
+++ b/Tests/SQLTests/Queries/EngineCrossJoinTests.swift
@@ -12,14 +12,14 @@ struct EngineCrossJoinTests {
   @Test func `a CROSS JOIN yields every pair of the two relations`() throws {
     // `family` has three Parent rows and four Child rows, so the Cartesian
     // product is 3 × 4 = 12 rows — every parent paired with every child.
-    let rows = try engineJoin("SELECT * FROM Parent CROSS JOIN Child")
+    let rows = try join("SELECT * FROM Parent CROSS JOIN Child")
     #expect(rows.count == 12)
   }
 
   @Test func `a CROSS JOIN yields the full product in outer-major order`() throws {
     // The exact Cartesian product: each Parent row (outer) paired in turn with
     // every Child row (inner), the combined columns laid Parent-then-Child.
-    let rows = try engineJoin("SELECT * FROM Parent CROSS JOIN Child")
+    let rows = try join("SELECT * FROM Parent CROSS JOIN Child")
     let expected: Array<Array<Value>> = [
       [.integer(1), .text("Ada"), .integer(1), .text("Ann")],
       [.integer(1), .text("Ada"), .integer(1), .text("Amy")],
@@ -40,7 +40,7 @@ struct EngineCrossJoinTests {
   @Test func `a CROSS JOIN equals an inner join on a true predicate`() throws {
     // A CROSS JOIN synthesizes an always-true `ON`, so it is identical to an
     // inner join written with an explicit `ON 1 = 1`.
-    try engineFamily().expect(
+    try family().expect(
         "SELECT * FROM Parent CROSS JOIN Child",
         equals: "SELECT * FROM Parent JOIN Child ON 1 = 1")
   }
@@ -49,7 +49,7 @@ struct EngineCrossJoinTests {
     // The combined row is the outer relation's columns (Parent: Id, Name)
     // followed by the inner's (Child: Pid, Name) — the same a-then-b layout the
     // comma product and inner join produce.
-    let rows = try engineJoin("SELECT * FROM Parent CROSS JOIN Child")
+    let rows = try join("SELECT * FROM Parent CROSS JOIN Child")
     #expect(rows.first == [.integer(1), .text("Ada"),
                            .integer(1), .text("Ann")])
   }
@@ -59,7 +59,7 @@ struct EngineCrossJoinTests {
     // then inner-joins Ordered keyed off the child's `Pid` against the ordered
     // relation's virtual `Id`. Every (parent, child) pair whose child `Pid`
     // names an `Ordered` row survives, gaining that row's `Label`.
-    let rows = try engineJoin("""
+    let rows = try join("""
         SELECT Parent.Name, Child.Name, Ordered.Label
           FROM Parent CROSS JOIN Child
           JOIN Ordered ON Ordered.Id = Child.Pid
@@ -75,7 +75,7 @@ struct EngineCrossJoinTests {
     // `Parent JOIN Child ON … CROSS JOIN Ordered` keeps the three matched
     // (parent, child) pairs, then crosses each with all three `Ordered` rows —
     // 3 × 3 = 9 rows.
-    let rows = try engineJoin("""
+    let rows = try join("""
         SELECT Parent.Name, Child.Name, Ordered.Label
           FROM Parent JOIN Child ON Child.Pid = Parent.Id
           CROSS JOIN Ordered
@@ -87,23 +87,23 @@ struct EngineCrossJoinTests {
     // The synthesized constant-true `ON` lowers to a filter the optimiser
     // proves always-true and elides, so the plan collapses to a bare `.product`
     // with no wrapping `.select` — the same plan the comma product produces.
-    let catalog = try engineFamily()
-    let select = try engineParse("SELECT * FROM Parent CROSS JOIN Child")
+    let catalog = try family()
+    let select = try parse("SELECT * FROM Parent CROSS JOIN Child")
     let compiled = try catalog.compile(select)
     let plan = try catalog.optimise(compiled.pushdown(), [:])
-    #expect(engineIsProduct(plan))
+    #expect(product(plan))
   }
 }
 
 /// Whether `plan` is a bare `.product` (optionally under a `.project`), with no
 /// intervening `.select` — the shape a CROSS JOIN collapses to once the
 /// optimiser elides its constant-true residual.
-private func engineIsProduct(_ plan: Plan) -> Bool {
+private func product(_ plan: Plan) -> Bool {
   switch plan {
   case .product:
     true
   case let .project(_, source):
-    engineIsProduct(source)
+    product(source)
   default:
     false
   }

--- a/Tests/SQLTests/Queries/EngineFunctionTests.swift
+++ b/Tests/SQLTests/Queries/EngineFunctionTests.swift
@@ -28,43 +28,43 @@ private func routines() -> Routines {
 }
 
 /// Runs `text` against the `People` catalog through the demonstration routines.
-func engineFunctionRun(_ text: String) throws -> Array<Array<Value>> {
-  try enginePeople().run(engineParse(text), routines())
+func functions(_ text: String) throws -> Array<Array<Value>> {
+  try roster().run(parse(text), routines())
 }
 
 struct EngineFunctionTests {
   @Test func `a registered function projects over a column`() throws {
-    let rows = try engineFunctionRun("SELECT upper(Name) FROM People WHERE Id = 1")
+    let rows = try functions("SELECT upper(Name) FROM People WHERE Id = 1")
     #expect(rows == [[.text("ALICE")]])
   }
 
   @Test func `a function projects beside a bare column`() throws {
     let rows =
-        try engineFunctionRun("SELECT Id, upper(Name) FROM People WHERE Id = 3")
+        try functions("SELECT Id, upper(Name) FROM People WHERE Id = 3")
     #expect(rows == [[.integer(3), .text("CAROL")]])
   }
 
   @Test func `a function takes more than one column argument`() throws {
-    let rows = try engineFunctionRun("SELECT add(Id, Age) FROM People WHERE Id = 2")
+    let rows = try functions("SELECT add(Id, Age) FROM People WHERE Id = 2")
     // Bob: Id 2 + Age 25 = 27.
     #expect(rows == [[.integer(27)]])
   }
 
   @Test func `a function takes a literal argument`() throws {
-    let rows = try engineFunctionRun("SELECT add(Id, 100) FROM People WHERE Id = 4")
+    let rows = try functions("SELECT add(Id, 100) FROM People WHERE Id = 4")
     #expect(rows == [[.integer(104)]])
   }
 
   @Test func `a function call nests another function call`() throws {
     let rows =
-        try engineFunctionRun("SELECT add(add(Id, 1), Age) FROM People WHERE Id = 5")
+        try functions("SELECT add(add(Id, 1), Age) FROM People WHERE Id = 5")
     // Eve: (5 + 1) + 25 = 31.
     #expect(rows == [[.integer(31)]])
   }
 
   @Test func `an unregistered function is reported`() throws {
     #expect(throws: SQLError.function("missing")) {
-      try engineFunctionRun("SELECT missing(Name) FROM People")
+      try functions("SELECT missing(Name) FROM People")
     }
   }
 
@@ -73,14 +73,14 @@ struct EngineFunctionTests {
     // routine, whose own kind check faults an INTEGER passed to the text
     // built-in UPPER.
     #expect(throws: SQLError.argument("UPPER requires a text argument")) {
-      try engineFunctionRun("SELECT upper(Id) FROM People WHERE Id = 1")
+      try functions("SELECT upper(Id) FROM People WHERE Id = 1")
     }
   }
 
   @Test func `a function call resolves its name case-insensitively`() throws {
     // The built-in `UPPER` resolves through the seeded prelude; the natural SQL
     // spelling UPPER resolves to it, as table and column identifiers do.
-    let rows = try engineFunctionRun("SELECT UPPER(Name) FROM People WHERE Id = 1")
+    let rows = try functions("SELECT UPPER(Name) FROM People WHERE Id = 1")
     #expect(rows == [[.text("ALICE")]])
   }
 
@@ -88,9 +88,9 @@ struct EngineFunctionTests {
     // BITAND ships in the prelude (`Routines.standard`): `routines()` never
     // registers it, yet the call resolves through the seeded prelude and folds
     // case-insensitively. 12 & 10 = 8; 6 & 3 = 2.
-    #expect(try engineFunctionRun("SELECT BITAND(12, 10) FROM People WHERE Id = 1")
+    #expect(try functions("SELECT BITAND(12, 10) FROM People WHERE Id = 1")
             == [[.integer(8)]])
-    #expect(try engineFunctionRun("SELECT bitand(6, 3) FROM People WHERE Id = 1")
+    #expect(try functions("SELECT bitand(6, 3) FROM People WHERE Id = 1")
             == [[.integer(2)]])
   }
 
@@ -98,10 +98,10 @@ struct EngineFunctionTests {
     // The wrong argument count is a function-argument fault (`.argument`), not
     // `.arity` — whose message is the UNION column-count mismatch.
     #expect(throws: SQLError.argument("BITAND takes two arguments")) {
-      try engineFunctionRun("SELECT BITAND(1) FROM People WHERE Id = 1")
+      try functions("SELECT BITAND(1) FROM People WHERE Id = 1")
     }
     #expect(throws: SQLError.argument("BITAND requires integer arguments")) {
-      try engineFunctionRun("SELECT BITAND('a', 1) FROM People WHERE Id = 1")
+      try functions("SELECT BITAND('a', 1) FROM People WHERE Id = 1")
     }
   }
 
@@ -129,8 +129,8 @@ struct EngineFunctionTests {
          "TAG": Routine(returns: .text, parameters: [.text]) {
           _ in .text("upper")
         }]
-    let query = try engineParse("SELECT tag(Name) FROM People WHERE Id = 1")
-    let rows = try enginePeople().run(query, routines)
+    let query = try parse("SELECT tag(Name) FROM People WHERE Id = 1")
+    let rows = try roster().run(query, routines)
     #expect(rows == [[.text("lower")]])
   }
 
@@ -138,13 +138,13 @@ struct EngineFunctionTests {
     // The documented contract: a predicate may call a registered function;
     // `upper(Name) = 'ALICE'` decodes the column before comparing.
     let rows =
-        try engineFunctionRun("SELECT Id FROM People WHERE upper(Name) = 'ALICE'")
+        try functions("SELECT Id FROM People WHERE upper(Name) = 'ALICE'")
     #expect(rows == [[.integer(1)]])
   }
 
   @Test func `a predicate compares a function result to an integer`() throws {
     let rows =
-        try engineFunctionRun("SELECT Name FROM People WHERE add(Id, 10) = 12")
+        try functions("SELECT Name FROM People WHERE add(Id, 10) = 12")
     #expect(rows == [[.text("Bob")]])
   }
 }
@@ -172,7 +172,7 @@ struct EngineDefinedFunctionTests {
         try defining("CREATE FUNCTION twice(n INTEGER) RETURNS INTEGER "
                          + "AS n + n")
     let rows =
-        try enginePeople().run(engineParse("SELECT twice(Age) FROM People WHERE Id = 1"),
+        try roster().run(parse("SELECT twice(Age) FROM People WHERE Id = 1"),
                          routines)
     // Alice's Age is 30; twice(30) = 60.
     #expect(rows == [[.integer(60)]])
@@ -183,7 +183,7 @@ struct EngineDefinedFunctionTests {
         try defining("CREATE FUNCTION span(lo INTEGER, hi INTEGER) "
                          + "RETURNS INTEGER AS hi - lo")
     let rows =
-        try enginePeople().run(engineParse("SELECT span(Id, Age) FROM People WHERE Id = 4"),
+        try roster().run(parse("SELECT span(Id, Age) FROM People WHERE Id = 4"),
                          routines)
     // Dave: Id 4, Age 40; span(4, 40) = 36.
     #expect(rows == [[.integer(36)]])
@@ -193,7 +193,7 @@ struct EngineDefinedFunctionTests {
     let routines =
         try defining("CREATE FUNCTION inc(n INTEGER) RETURNS INTEGER AS n + 1")
     let rows =
-        try enginePeople().run(engineParse("SELECT Id, inc(Age) FROM People WHERE Id = 2"),
+        try roster().run(parse("SELECT Id, inc(Age) FROM People WHERE Id = 2"),
                          routines)
     // Bob: Id 2, Age 25; inc(25) = 26.
     #expect(rows == [[.integer(2), .integer(26)]])
@@ -203,7 +203,7 @@ struct EngineDefinedFunctionTests {
     let routines =
         try defining("CREATE FUNCTION inc(n INTEGER) RETURNS INTEGER AS n + 1")
     let rows =
-        try enginePeople().run(engineParse("SELECT Name FROM People WHERE inc(Age) = 31"),
+        try roster().run(parse("SELECT Name FROM People WHERE inc(Age) = 31"),
                          routines)
     // Alice and Carol are 30; inc(30) = 31.
     #expect(rows == [[.text("Alice")], [.text("Carol")]])
@@ -213,7 +213,7 @@ struct EngineDefinedFunctionTests {
     let routines =
         try defining("CREATE FUNCTION answer() RETURNS INTEGER AS 40 + 2")
     let rows =
-        try enginePeople().run(engineParse("SELECT answer() FROM People WHERE Id = 1"),
+        try roster().run(parse("SELECT answer() FROM People WHERE Id = 1"),
                          routines)
     #expect(rows == [[.integer(42)]])
   }
@@ -228,7 +228,7 @@ struct EngineDefinedFunctionTests {
         Row(1, nil)
       }
     }
-    let rows = try catalog.run(engineParse("SELECT inc(V) FROM N WHERE Id = 1"),
+    let rows = try catalog.run(parse("SELECT inc(V) FROM N WHERE Id = 1"),
                                routines)
     #expect(rows == [[.null]])
   }
@@ -242,7 +242,7 @@ struct EngineDefinedFunctionTests {
         try defining("CREATE FUNCTION twice(n INTEGER) RETURNS INTEGER "
                          + "AS n + n")
     #expect(throws: SQLError.argument("twice takes 1 arguments")) {
-      try enginePeople().columns(of: engineParse("SELECT twice(Id, Age) FROM People"),
+      try roster().columns(of: parse("SELECT twice(Id, Age) FROM People"),
                            routines: routines)
     }
   }
@@ -254,7 +254,7 @@ struct EngineDefinedFunctionTests {
         try defining("CREATE FUNCTION twice(n INTEGER) RETURNS INTEGER "
                          + "AS n + n")
     #expect(throws: SQLError.argument("twice requires integer arguments")) {
-      try enginePeople().columns(of: engineParse("SELECT twice(Name) FROM People"),
+      try roster().columns(of: parse("SELECT twice(Name) FROM People"),
                            routines: routines)
     }
   }
@@ -266,7 +266,7 @@ struct EngineDefinedFunctionTests {
     let routines =
         try defining("CREATE FUNCTION label(n INTEGER) RETURNS TEXT AS 'x'")
     let columns =
-        try enginePeople().columns(of: engineParse("SELECT label(Id) AS L FROM People"),
+        try roster().columns(of: parse("SELECT label(Id) AS L FROM People"),
                              routines: routines)
     #expect(columns.count == 1)
     #expect(columns[0] == OutputColumn(name: "L", type: .text))
@@ -300,7 +300,7 @@ struct EngineDefinedFunctionTests {
         "CREATE FUNCTION inc(n INTEGER) RETURNS INTEGER AS n + 1",
         "CREATE FUNCTION inc(n INTEGER) RETURNS INTEGER AS n + 100")
     let rows =
-        try enginePeople().run(engineParse("SELECT inc(Age) FROM People WHERE Id = 1"),
+        try roster().run(parse("SELECT inc(Age) FROM People WHERE Id = 1"),
                          routines)
     // Alice's Age is 30; the shadowing inc adds 100 → 130.
     #expect(rows == [[.integer(130)]])
@@ -325,7 +325,7 @@ struct EngineDefinedFunctionTests {
         "CREATE FUNCTION f() RETURNS INTEGER AS 0",
         "CREATE FUNCTION f() RETURNS INTEGER AS f() + 1")
     let rows =
-        try enginePeople().run(engineParse("SELECT f() FROM People WHERE Id = 1"),
+        try roster().run(parse("SELECT f() FROM People WHERE Id = 1"),
                          routines)
     #expect(rows == [[.integer(1)]])
   }
@@ -337,7 +337,7 @@ struct EngineDefinedFunctionTests {
         "CREATE FUNCTION g(n INTEGER) RETURNS INTEGER AS n + 1",
         "CREATE FUNCTION f(n INTEGER) RETURNS INTEGER AS g(n) + 1")
     let rows =
-        try enginePeople().run(engineParse("SELECT f(Age) FROM People WHERE Id = 1"),
+        try roster().run(parse("SELECT f(Age) FROM People WHERE Id = 1"),
                          routines)
     // Alice's Age is 30; g(30) = 31, f(30) = g(30) + 1 = 32.
     #expect(rows == [[.integer(32)]])
@@ -355,12 +355,12 @@ struct EngineDefinedFunctionTests {
     else { throw SQLError.incomplete(expected: "a CREATE FUNCTION statement") }
     let routines = try Routines().registering(name, function)
     let rows =
-        try enginePeople().run(engineParse("SELECT lowbit(Age) FROM People WHERE Id = 1"),
+        try roster().run(parse("SELECT lowbit(Age) FROM People WHERE Id = 1"),
                          routines)
     // Alice's Age is 30; BITAND(30, 1) = 0 (30 is even).
     #expect(rows == [[.integer(0)]])
     let odd =
-        try enginePeople().run(engineParse("SELECT lowbit(Id) FROM People WHERE Id = 3"),
+        try roster().run(parse("SELECT lowbit(Id) FROM People WHERE Id = 3"),
                          routines)
     // Id 3 is odd; BITAND(3, 1) = 1.
     #expect(odd == [[.integer(1)]])
@@ -387,11 +387,11 @@ struct EngineDefinedFunctionTests {
         "CREATE FUNCTION f() RETURNS INTEGER AS g()",
         "CREATE FUNCTION g() RETURNS TEXT AS 'x'")
     let captured =
-        try enginePeople().run(engineParse("SELECT f() FROM People WHERE Id = 1"),
+        try roster().run(parse("SELECT f() FROM People WHERE Id = 1"),
                          routines)
     #expect(captured == [[.integer(1)]])
     let latest =
-        try enginePeople().run(engineParse("SELECT g() FROM People WHERE Id = 1"),
+        try roster().run(parse("SELECT g() FROM People WHERE Id = 1"),
                          routines)
     #expect(latest == [[.text("x")]])
   }

--- a/Tests/SQLTests/Queries/EngineJoinPlanningTests.swift
+++ b/Tests/SQLTests/Queries/EngineJoinPlanningTests.swift
@@ -47,7 +47,7 @@ struct EngineHashJoinTests {
     // Four outer children probe the map, but the inner is read only three times
     // — its row count — not twelve (once per outer).
     let (catalog, reads) = hashable()
-    let rows = try catalog.run(engineParse("""
+    let rows = try catalog.run(parse("""
         SELECT Child.Kid, Parent.Name FROM Child
           JOIN Parent ON Parent.Id = Child.Pid
         """))
@@ -86,7 +86,7 @@ struct EngineHashJoinTests {
       "Attribute": FixtureRelation(attribute, attributes, coded: 0,
                                    counter: reads),
     ])
-    let rows = try catalog.run(engineParse("""
+    let rows = try catalog.run(parse("""
         SELECT Attribute.Name FROM Type
           JOIN Attribute ON Attribute.Parent = Type.Id
         """))
@@ -106,7 +106,7 @@ struct EngineHashJoinTests {
     // outer, and a large unseekable inner must not be fully scanned to answer
     // nothing.
     let (catalog, reads) = hashable()
-    let rows = try catalog.run(engineParse("""
+    let rows = try catalog.run(parse("""
         SELECT Child.Kid, Parent.Name FROM Child
           JOIN Parent ON Parent.Id = Child.Pid WHERE Child.Pid < 0
         """))
@@ -143,7 +143,7 @@ struct EngineHashJoinTests {
       "Parent": FixtureRelation(parent, parents, counter: reads),
       "Child": FixtureRelation(child, children),
     ])
-    let rows = try catalog.run(engineParse("""
+    let rows = try catalog.run(parse("""
         SELECT Child.Kid, Parent.Name FROM Child
           JOIN Parent ON Parent.Id = Child.Pid WHERE Child.Pid IS NULL
         """))
@@ -155,11 +155,11 @@ struct EngineHashJoinTests {
     // The sorted `Parent` seeks; its unsorted twin hashes. Both inner orderings
     // must agree — the hash preserves the seek path's outer-major, inner-cursor
     // order.
-    let seek = try engineJoin("""
+    let seek = try join("""
         SELECT Parent.Name, Child.Name FROM Child
           JOIN Parent ON Parent.Id = Child.Pid
         """)
-    let hash = try engineJoin("""
+    let hash = try join("""
         SELECT P.Name, Child.Name FROM Child
           JOIN ParentUnsorted AS P ON P.Id = Child.Pid
         """)
@@ -175,7 +175,7 @@ struct EngineHashJoinTests {
     // The unsorted twin forces the hash path. Without an ORDER BY the result
     // must be outer-major (each child in scan order), and a bucket's inner rows
     // in the inner's cursor order — exactly the nested loop's order.
-    let forced = try engineJoin("""
+    let forced = try join("""
         SELECT Child.Name, P.Name FROM Child
           JOIN ParentUnsorted AS P ON P.Id = Child.Pid
         """)
@@ -211,7 +211,7 @@ struct EngineHashJoinTests {
       "Parent": FixtureRelation(parent, parents),
       "Child": FixtureRelation(child, children),
     ])
-    let rows = try catalog.run(engineParse("""
+    let rows = try catalog.run(parse("""
         SELECT Child.Name, Parent.Name FROM Child
           JOIN Parent ON Parent.Id = Child.Pid
         """))
@@ -254,7 +254,7 @@ struct EngineHashJoinTests {
       "Parent": FixtureRelation(parent, parents, sorted: 0, counter: reads),
       "Child": FixtureRelation(child, children),
     ])
-    let rows = try catalog.run(engineParse("""
+    let rows = try catalog.run(parse("""
         SELECT Child.Kid, Parent.Id FROM Child
           JOIN Parent ON Parent.Code = Child.Code WHERE Parent.Id < 0
         """))
@@ -271,21 +271,21 @@ struct EngineStreamingProductTests {
     // inner here is the `Adults` VIEW (a `derived` leaf), so nest cannot fire
     // and the level stays a `select` over a `product` — the shape the streaming
     // executor fuses.
-    let catalog = try engineViews()
-    let select = try engineParse("""
+    let catalog = try gallery()
+    let select = try parse("""
         SELECT Child.Name, Adults.Label FROM Child
           JOIN Adults ON Adults.Key = Child.Pid
         """)
     let compiled = try catalog.compile(select)
     let plan = try catalog.optimise(compiled.pushdown(), [:])
-    #expect(engineResidual(plan))
+    #expect(residue(plan))
   }
 
   @Test func `the streamed product filters row by row to the right rows`() throws {
     // `Adults` is Parent rows with Id >= 2 (Key 2 → Bee, 3 → Cid); only the
     // child whose Pid equals a Key survives — Bob (Pid 2) against Bee.
-    let catalog = try engineViews()
-    let rows = try catalog.run(engineParse("""
+    let catalog = try gallery()
+    let rows = try catalog.run(parse("""
         SELECT Child.Name, Adults.Label FROM Child
           JOIN Adults ON Adults.Key = Child.Pid
         """))
@@ -296,9 +296,9 @@ struct EngineStreamingProductTests {
     // Cross the two inputs by hand — every child paired with every adult in
     // outer-major order — and keep the pairs the ON equality admits. The fused
     // streaming operator must yield exactly this, in this order.
-    let catalog = try engineViews()
-    let children = try catalog.run(engineParse("SELECT Name, Pid FROM Child"))
-    let adults = try catalog.run(engineParse("SELECT Label, Key FROM Adults"))
+    let catalog = try gallery()
+    let children = try catalog.run(parse("SELECT Name, Pid FROM Child"))
+    let adults = try catalog.run(parse("SELECT Label, Key FROM Adults"))
 
     var eager = Array<Array<Value>>()
     for child in children {
@@ -307,7 +307,7 @@ struct EngineStreamingProductTests {
       }
     }
 
-    let streamed = try catalog.run(engineParse("""
+    let streamed = try catalog.run(parse("""
         SELECT Child.Name, Adults.Label FROM Child
           JOIN Adults ON Adults.Key = Child.Pid
         """))
@@ -325,7 +325,7 @@ struct EngineStreamingProductTests {
       [.integer(2), .text("Bob")],
       [.null, .text("Nobody")],
     ] as Array<Array<Value>>
-    let adults = try View(query: engineSelect("""
+    let adults = try View(query: select("""
         SELECT Id, Name FROM Base WHERE Id >= 2
         """), columns: ["Key", "Label"])
     let base = [
@@ -340,7 +340,7 @@ struct EngineStreamingProductTests {
       "Child": FixtureRelation(child, children),
       "Base": FixtureRelation(base, bases, sorted: 0),
     ], views: ["Adults": adults])
-    let rows = try catalog.run(engineParse("""
+    let rows = try catalog.run(parse("""
         SELECT Child.Name, Adults.Label FROM Child
           JOIN Adults ON Adults.Key = Child.Pid
         """))

--- a/Tests/SQLTests/Queries/EngineJoinTests.swift
+++ b/Tests/SQLTests/Queries/EngineJoinTests.swift
@@ -10,7 +10,7 @@ import SQLTestSupport
 
 struct EngineJoinTests {
   @Test func `a join on a foreign key pairs each child with its parent`() throws {
-    let rows = try engineJoin("""
+    let rows = try join("""
         SELECT * FROM Parent JOIN Child ON Child.Pid = Parent.Id
         """)
     // The orphan child (Pid 9) and the childless parent (Cid) drop out.
@@ -22,7 +22,7 @@ struct EngineJoinTests {
   }
 
   @Test func `a qualified projection selects across both relations`() throws {
-    try engineFamily().expect("""
+    try family().expect("""
         SELECT Parent.Name, Child.Name FROM Parent
           JOIN Child ON Child.Pid = Parent.Id
         """,
@@ -32,7 +32,7 @@ struct EngineJoinTests {
   @Test func `a join keys off the inner relation's virtual Id`() throws {
     // `Ordered` has no stored key; its identity is its 1-based `Id`. The
     // child's `Pid` joins to that virtual column.
-    let rows = try engineJoin("""
+    let rows = try join("""
         SELECT Ordered.Label, Child.Name FROM Child
           JOIN Ordered ON Ordered.Id = Child.Pid
         """)
@@ -53,7 +53,7 @@ struct EngineJoinTests {
     // Were the inner laid at the outer's `width` (or at a base collapsed to 0
     // by a `1 << 32` reserve on a 32-bit host), `Child.Pid` would land on the
     // outer `Id`'s ordinal and the join's cells would corrupt one another.
-    let rows = try engineJoin("""
+    let rows = try join("""
         SELECT Ordered.Id, Child.Name FROM Ordered
           JOIN Child ON Child.Pid = Ordered.Id
         """)
@@ -66,7 +66,7 @@ struct EngineJoinTests {
   }
 
   @Test func `a WHERE spans both relations`() throws {
-    try engineFamily().expect("""
+    try family().expect("""
         SELECT Child.Name FROM Parent JOIN Child ON Child.Pid = Parent.Id
           WHERE Parent.Name = 'Ada' AND Child.Name = 'Amy'
         """,
@@ -74,7 +74,7 @@ struct EngineJoinTests {
   }
 
   @Test func `ORDER BY orders across the join`() throws {
-    try engineFamily().expect("""
+    try family().expect("""
         SELECT Child.Name FROM Parent JOIN Child ON Child.Pid = Parent.Id
           ORDER BY Child.Name ASC
         """,
@@ -83,13 +83,13 @@ struct EngineJoinTests {
 
   @Test func `an unqualified name in both relations is ambiguous`() throws {
     #expect(throws: SQLError.ambiguous("Name")) {
-      try engineJoin("SELECT Name FROM Parent JOIN Child ON Child.Pid = Parent.Id")
+      try join("SELECT Name FROM Parent JOIN Child ON Child.Pid = Parent.Id")
     }
   }
 
   @Test func `a self-join's shared table name makes a qualified name ambiguous`() throws {
     #expect(throws: SQLError.ambiguous("Id")) {
-      try engineJoin("""
+      try join("""
           SELECT Parent.Name FROM Parent JOIN Parent ON Parent.Id = Parent.Id
           """)
     }
@@ -99,14 +99,14 @@ struct EngineJoinTests {
     // `x.Pid` resolves by column (the Child side only); `x.Name` is on both,
     // so the shared alias is ambiguous rather than binding silently to outer.
     #expect(throws: SQLError.ambiguous("Name")) {
-      try engineJoin("""
+      try join("""
           SELECT x.Name FROM Parent AS x JOIN Child AS x ON x.Pid = x.Pid
           """)
     }
   }
 
   @Test func `a parent with no matching child contributes no rows`() throws {
-    let rows = try engineJoin("""
+    let rows = try join("""
         SELECT Parent.Name, Child.Name FROM Parent
           JOIN Child ON Child.Pid = Parent.Id
           WHERE Parent.Name = 'Cid'
@@ -118,11 +118,11 @@ struct EngineJoinTests {
     // The join seeks `Child.Pid = Parent.Id` when the inner relation is
     // seekable on the key, and scans it otherwise. Both inner orderings — the
     // sorted `Parent` and its unsorted twin used as the inner — must agree.
-    let seek = try engineJoin("""
+    let seek = try join("""
         SELECT Parent.Name, Child.Name FROM Child
           JOIN Parent ON Parent.Id = Child.Pid ORDER BY Child.Name ASC
         """)
-    let scan = try engineJoin("""
+    let scan = try join("""
         SELECT P.Name, Child.Name FROM Child
           JOIN ParentUnsorted AS P ON P.Id = Child.Pid ORDER BY Child.Name ASC
         """)
@@ -142,7 +142,7 @@ struct EngineNonEquiJoinTests {
     // `ON Parent.Id < Child.Pid` is a pure inequality — no equi conjunct —
     // so it is a nested loop: for each parent, every child whose Pid exceeds
     // its Id, in outer-major order.
-    let rows = try engineJoin("""
+    let rows = try join("""
         SELECT Parent.Name, Child.Name FROM Parent
           JOIN Child ON Parent.Id < Child.Pid
         """)
@@ -157,15 +157,15 @@ struct EngineNonEquiJoinTests {
   @Test func `a pure inequality ON plans a residual product, not a hash join`() throws {
     // No `column = column` conjunct, so `nest` cannot form a `.join`; the level
     // stays a `.select` over a `.product` — the nested-loop shape.
-    let catalog = try engineFamily()
-    let select = try engineParse("""
+    let catalog = try family()
+    let select = try parse("""
         SELECT Parent.Name, Child.Name FROM Parent
           JOIN Child ON Parent.Id < Child.Pid
         """)
     let compiled = try catalog.compile(select)
     let plan = try catalog.optimise(compiled.pushdown(), [:])
-    #expect(!engineJoins(plan))
-    #expect(engineResidual(plan))
+    #expect(!joined(plan))
+    #expect(residue(plan))
   }
 
   @Test func `a mixed ON hashes the equi conjunct and filters the residual`() throws {
@@ -173,7 +173,7 @@ struct EngineNonEquiJoinTests {
     // each child to its parent; the residual inequality beside the key then
     // keeps only pairs whose child name sorts before 'B' — dropping Bob, the
     // sole B-name.
-    let rows = try engineJoin("""
+    let rows = try join("""
         SELECT Parent.Name, Child.Name FROM Parent
           JOIN Child ON Child.Pid = Parent.Id AND Child.Name < 'B'
         """)
@@ -188,21 +188,21 @@ struct EngineNonEquiJoinTests {
     // The `column = column` conjunct becomes a `.join`; the inequality
     // survives as a residual `.select` over it — the equi fast-path still
     // triggers.
-    let catalog = try engineFamily()
-    let select = try engineParse("""
+    let catalog = try family()
+    let select = try parse("""
         SELECT Parent.Name, Child.Name FROM Parent
           JOIN Child ON Child.Pid = Parent.Id AND Parent.Name < Child.Name
         """)
     let compiled = try catalog.compile(select)
     let plan = try catalog.optimise(compiled.pushdown(), [:])
-    #expect(engineJoins(plan))
+    #expect(joined(plan))
   }
 
   @Test func `an expression equality ON is a residual, not a hash key`() throws {
     // `ON Child.Pid = Parent.Id + 1` equates a column with an EXPRESSION, so
     // it is not a bare `column = column` key: it lowers to a residual over the
     // product (nested loop), not a hash join.
-    let rows = try engineJoin("""
+    let rows = try join("""
         SELECT Parent.Name, Child.Name FROM Parent
           JOIN Child ON Child.Pid = Parent.Id + 1
         """)
@@ -212,30 +212,30 @@ struct EngineNonEquiJoinTests {
   }
 
   @Test func `an expression equality ON plans a residual product`() throws {
-    let catalog = try engineFamily()
-    let select = try engineParse("""
+    let catalog = try family()
+    let select = try parse("""
         SELECT Parent.Name, Child.Name FROM Parent
           JOIN Child ON Child.Pid = Parent.Id + 1
         """)
     let compiled = try catalog.compile(select)
     let plan = try catalog.optimise(compiled.pushdown(), [:])
-    #expect(!engineJoins(plan))
-    #expect(engineResidual(plan))
+    #expect(!joined(plan))
+    #expect(residue(plan))
   }
 
   @Test func `a non-equi ON equals the eager product filtered`() throws {
     // The nested-loop join over an inequality must yield exactly the eager
     // cross product filtered by the same predicate, in outer-major order.
-    let catalog = try engineFamily()
-    let parents = try catalog.run(engineParse("SELECT Name, Id FROM Parent"))
-    let children = try catalog.run(engineParse("SELECT Name, Pid FROM Child"))
+    let catalog = try family()
+    let parents = try catalog.run(parse("SELECT Name, Id FROM Parent"))
+    let children = try catalog.run(parse("SELECT Name, Pid FROM Child"))
     var expected = Array<Array<Value>>()
     for parent in parents {
       for child in children where less(parent[1], child[1]) {
         expected.append([parent[0], child[0]])
       }
     }
-    let rows = try catalog.run(engineParse("""
+    let rows = try catalog.run(parse("""
         SELECT Parent.Name, Child.Name FROM Parent
           JOIN Child ON Parent.Id < Child.Pid
         """))
@@ -258,7 +258,7 @@ struct EngineNonEquiJoinTests {
                     [[.integer(2)]] as Array<Array<Value>>),
     ])
     #expect(throws: SQLError.divide) {
-      _ = try catalog.run(engineParse("""
+      _ = try catalog.run(parse("""
           SELECT A.k FROM A JOIN B ON (1 / A.x) = 0 AND A.k = B.k
           """))
     }
@@ -275,13 +275,13 @@ struct EngineNonEquiJoinTests {
       "B": FixtureRelation([EngineField(name: "k", type: .integer)],
                     [[.integer(2)]] as Array<Array<Value>>),
     ])
-    let select = try engineParse("""
+    let select = try parse("""
         SELECT A.k FROM A JOIN B ON (1 / A.x) = 0 AND A.k = B.k
         """)
     let compiled = try catalog.compile(select)
     let plan = try catalog.optimise(compiled.pushdown(), [:])
-    #expect(!engineJoins(plan))
-    #expect(engineResidual(plan))
+    #expect(!joined(plan))
+    #expect(residue(plan))
   }
 
   @Test func `an equi key before an unsafe residual extracts no key, planning a residual`() throws {
@@ -297,12 +297,12 @@ struct EngineNonEquiJoinTests {
       "B": FixtureRelation([EngineField(name: "k", type: .integer)],
                     [[.integer(2)]] as Array<Array<Value>>),
     ])
-    let compiled = try catalog.compile(engineParse("""
+    let compiled = try catalog.compile(parse("""
         SELECT A.k FROM A JOIN B ON A.k = B.k AND (1 / A.x) = 0
         """))
     let plan = try catalog.optimise(compiled.pushdown(), [:])
-    #expect(!engineJoins(plan))
-    #expect(engineResidual(plan))
+    #expect(!joined(plan))
+    #expect(residue(plan))
   }
 
   @Test func `a nullable ON key before an unsafe residual raises`() throws {
@@ -319,14 +319,14 @@ struct EngineNonEquiJoinTests {
       "B": FixtureRelation([EngineField(name: "k", type: .integer)],
                     [[.integer(2)]] as Array<Array<Value>>),
     ])
-    let compiled = try catalog.compile(engineParse("""
+    let compiled = try catalog.compile(parse("""
         SELECT A.k FROM A JOIN B ON A.k = B.k AND (1 / A.x) = 0
         """))
     let plan = try catalog.optimise(compiled.pushdown(), [:])
-    #expect(!engineJoins(plan))
-    #expect(engineResidual(plan))
+    #expect(!joined(plan))
+    #expect(residue(plan))
     #expect(throws: SQLError.divide) {
-      _ = try catalog.run(engineParse("""
+      _ = try catalog.run(parse("""
           SELECT A.k FROM A JOIN B ON A.k = B.k AND (1 / A.x) = 0
           """))
     }
@@ -345,7 +345,7 @@ struct EngineNonEquiJoinTests {
       "B": FixtureRelation([EngineField(name: "k", type: .integer)],
                     [[.integer(3)]] as Array<Array<Value>>),
     ])
-    let rows = try catalog.run(engineParse("""
+    let rows = try catalog.run(parse("""
         SELECT A.k FROM A JOIN B ON A.k = B.k AND (1 / A.x) = 0
         """))
     #expect(rows.isEmpty)
@@ -369,24 +369,24 @@ struct EngineNonEquiJoinTests {
         SELECT A.k, B.q FROM A JOIN B ON A.p < B.q AND A.k = B.k
         """
     // Key pairs (1,1) with 5 < 8 kept; (2,2) with 10 < 3 dropped.
-    let rows = try catalog.run(engineParse(text))
+    let rows = try catalog.run(parse(text))
     #expect(rows == [[.integer(1), .integer(8)]])
-    let compiled = try catalog.compile(engineParse(text))
+    let compiled = try catalog.compile(parse(text))
     let plan = try catalog.optimise(compiled.pushdown(), [:])
-    #expect(engineJoins(plan))
+    #expect(joined(plan))
   }
 
   @Test func `a pure equi ON still plans a hash join`() throws {
     // The equi fast-path is unchanged: an all-`column = column` ON extracts
     // its key and folds into a `.join`.
-    let catalog = try engineFamily()
-    let select = try engineParse("""
+    let catalog = try family()
+    let select = try parse("""
         SELECT Parent.Name, Child.Name FROM Parent
           JOIN Child ON Child.Pid = Parent.Id
         """)
     let compiled = try catalog.compile(select)
     let plan = try catalog.optimise(compiled.pushdown(), [:])
-    #expect(engineJoins(plan))
+    #expect(joined(plan))
   }
 
   @Test func `a nullable ON gate drops a pair before an unsafe WHERE`() throws {
@@ -404,11 +404,11 @@ struct EngineNonEquiJoinTests {
                            [[.integer(2)]] as Array<Array<Value>>),
     ])
     let text = "SELECT A.k FROM A JOIN B ON A.k < B.k WHERE (1 / A.x) = 0"
-    let compiled = try catalog.compile(engineParse(text))
+    let compiled = try catalog.compile(parse(text))
     let plan = try catalog.optimise(compiled.pushdown(), [:])
-    #expect(engineSeparated(plan))
-    #expect(engineResidual(plan))
-    #expect(try catalog.run(engineParse(text)).isEmpty)
+    #expect(separated(plan))
+    #expect(residue(plan))
+    #expect(try catalog.run(parse(text)).isEmpty)
   }
 
   @Test func `a surviving ON pair still runs the unsafe WHERE`() throws {
@@ -425,7 +425,7 @@ struct EngineNonEquiJoinTests {
                            [[.integer(2)]] as Array<Array<Value>>),
     ])
     #expect(throws: SQLError.divide) {
-      _ = try catalog.run(engineParse("""
+      _ = try catalog.run(parse("""
           SELECT A.k FROM A JOIN B ON A.k < B.k WHERE (1 / A.x) = 0
           """))
     }
@@ -438,7 +438,7 @@ struct EngineNonEquiJoinTests {
     // `WHERE` fuses with the gate. `ON Parent.Id < Child.Pid WHERE Child.Name
     // <> 'Orphan'` pairs each parent with a later-keyed child, then drops the
     // Orphan child.
-    let rows = try engineJoin("""
+    let rows = try join("""
         SELECT Parent.Name, Child.Name FROM Parent
           JOIN Child ON Parent.Id < Child.Pid WHERE Child.Name <> 'Orphan'
         """)
@@ -470,13 +470,13 @@ struct EngineNonEquiJoinTests {
         SELECT A.k1 FROM A
           JOIN B ON A.k1 = B.k1 AND A.k2 = B.k2 WHERE (1 / A.x) = 0
         """
-    let compiled = try catalog.compile(engineParse(text))
+    let compiled = try catalog.compile(parse(text))
     let plan = try catalog.optimise(compiled.pushdown(), [:])
     // The equi key still hash-joins; the leftover match gates above it, and the
     // `WHERE` is a SEPARATE `select` above that gate, not fused with the match.
-    #expect(engineJoins(plan))
-    #expect(engineStacked(plan))
-    #expect(try catalog.run(engineParse(text)).isEmpty)
+    #expect(joined(plan))
+    #expect(stacked(plan))
+    #expect(try catalog.run(parse(text)).isEmpty)
   }
 
   @Test func `both ON matches passing lets the unsafe WHERE raise`() throws {
@@ -496,7 +496,7 @@ struct EngineNonEquiJoinTests {
                              as Array<Array<Value>>),
     ])
     #expect(throws: SQLError.divide) {
-      _ = try catalog.run(engineParse("""
+      _ = try catalog.run(parse("""
           SELECT A.k1 FROM A
             JOIN B ON A.k1 = B.k1 AND A.k2 = B.k2 WHERE (1 / A.x) = 0
           """))
@@ -528,10 +528,10 @@ struct EngineNonEquiJoinTests {
         SELECT A.tag, B.note FROM A
           JOIN B ON A.k1 = B.k1 AND A.k2 = B.k2 WHERE A.tag = 'keep'
         """
-    let compiled = try catalog.compile(engineParse(text))
+    let compiled = try catalog.compile(parse(text))
     let plan = try catalog.optimise(compiled.pushdown(), [:])
-    #expect(engineJoins(plan))
-    #expect(try catalog.run(engineParse(text)) == [[.text("keep"), .text("bee")]])
+    #expect(joined(plan))
+    #expect(try catalog.run(parse(text)) == [[.text("keep"), .text("bee")]])
   }
 
   @Test func `a single-equality ON still plans a hash join and behaves`() throws {
@@ -551,10 +551,10 @@ struct EngineNonEquiJoinTests {
                            [[.integer(1)]] as Array<Array<Value>>),
     ])
     let text = "SELECT A.k FROM A JOIN B ON A.k = B.k WHERE (1 / A.x) = 1"
-    let compiled = try catalog.compile(engineParse(text))
+    let compiled = try catalog.compile(parse(text))
     let plan = try catalog.optimise(compiled.pushdown(), [:])
-    #expect(engineJoins(plan))
-    #expect(try catalog.run(engineParse(text)) == [[.integer(1)]])
+    #expect(joined(plan))
+    #expect(try catalog.run(parse(text)) == [[.integer(1)]])
   }
 }
 
@@ -564,7 +564,7 @@ struct EngineOuterJoinTests {
   @Test func `a LEFT JOIN preserves an unmatched left row, right NULL`() throws {
     // Every parent survives; Cid, with no child, emits once with the child
     // columns NULL — the NULL-extension. Matched parents emit each pair.
-    let rows = try engineJoin("""
+    let rows = try join("""
         SELECT Parent.Name, Child.Name FROM Parent
           LEFT JOIN Child ON Child.Pid = Parent.Id
         """)
@@ -578,11 +578,11 @@ struct EngineOuterJoinTests {
 
   @Test func `LEFT OUTER JOIN is the same as LEFT JOIN`() throws {
     // The `OUTER` noise word is optional and changes nothing.
-    let terse = try engineJoin("""
+    let terse = try join("""
         SELECT Parent.Name, Child.Name FROM Parent
           LEFT JOIN Child ON Child.Pid = Parent.Id
         """)
-    let verbose = try engineJoin("""
+    let verbose = try join("""
         SELECT Parent.Name, Child.Name FROM Parent
           LEFT OUTER JOIN Child ON Child.Pid = Parent.Id
         """)
@@ -592,7 +592,7 @@ struct EngineOuterJoinTests {
   @Test func `a RIGHT JOIN preserves an unmatched right row, left NULL`() throws {
     // Every child survives, right-major; the Orphan (Pid 9) has no parent and
     // emits once with the parent columns NULL.
-    let rows = try engineJoin("""
+    let rows = try join("""
         SELECT Parent.Name, Child.Name FROM Parent
           RIGHT JOIN Child ON Child.Pid = Parent.Id
         """)
@@ -607,7 +607,7 @@ struct EngineOuterJoinTests {
   @Test func `a FULL JOIN preserves the unmatched rows of both sides`() throws {
     // The left-major pairs and the childless Cid (right NULL), then the
     // parentless Orphan (left NULL) — both sides' unmatched rows survive.
-    let rows = try engineJoin("""
+    let rows = try join("""
         SELECT Parent.Name, Child.Name FROM Parent
           FULL JOIN Child ON Child.Pid = Parent.Id
         """)
@@ -624,7 +624,7 @@ struct EngineOuterJoinTests {
     // ON vs WHERE. Restricting the MATCH with `AND Child.Name = 'Amy'` keeps
     // every parent — the ON governs matching alone, so a parent that now
     // matches no child is still emitted NULL-extended. Only Ada matches Amy.
-    let rows = try engineJoin("""
+    let rows = try join("""
         SELECT Parent.Name, Child.Name FROM Parent
           LEFT JOIN Child ON Child.Pid = Parent.Id AND Child.Name = 'Amy'
         """)
@@ -640,7 +640,7 @@ struct EngineOuterJoinTests {
     // so the NULL-extended rows (whose Child.Name is NULL) fail `= 'Amy'` and
     // drop — turning the LEFT join back to inner-like. This is the ON-vs-WHERE
     // distinction the outer join preserves.
-    let rows = try engineJoin("""
+    let rows = try join("""
         SELECT Parent.Name, Child.Name FROM Parent
           LEFT JOIN Child ON Child.Pid = Parent.Id WHERE Child.Name = 'Amy'
         """)
@@ -650,7 +650,7 @@ struct EngineOuterJoinTests {
   @Test func `a WHERE IS NULL over a LEFT join finds the unmatched rows`() throws {
     // The anti-join idiom: a LEFT join then `WHERE Child.Name IS NULL` keeps
     // only the parents with no child — Cid.
-    let rows = try engineJoin("""
+    let rows = try join("""
         SELECT Parent.Name FROM Parent
           LEFT JOIN Child ON Child.Pid = Parent.Id WHERE Child.Name IS NULL
         """)
@@ -662,7 +662,7 @@ struct EngineOuterJoinTests {
     // pairs each parent with the children below it, and NULL-extends a parent
     // that dominates none. Child Pids are 1,1,2,9. Ada(1) > none; Bee(2) >
     // Pid 1 (Ann, Amy); Cid(3) > Pids 1,1,2 (Ann, Amy, Bob).
-    let rows = try engineJoin("""
+    let rows = try join("""
         SELECT Parent.Name, Child.Name FROM Parent
           LEFT JOIN Child ON Parent.Id > Child.Pid
         """)
@@ -680,22 +680,22 @@ struct EngineOuterJoinTests {
     // The ON must stay on the outer node — never distributed into a product or
     // nested into a hash join — or an unmatched row would be dropped. So the
     // plan reaches an `.outer` node and NOT a `.join`.
-    let catalog = try engineFamily()
-    let select = try engineParse("""
+    let catalog = try family()
+    let select = try parse("""
         SELECT Parent.Name, Child.Name FROM Parent
           LEFT JOIN Child ON Child.Pid = Parent.Id
         """)
     let compiled = try catalog.compile(select)
     let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(outers(plan))
-    #expect(!engineJoins(plan))
+    #expect(!joined(plan))
   }
 
   @Test func `an inner join then a LEFT join preserves the middle unmatched`() throws {
     // A mixed chain: House JOIN Room (inner) then LEFT JOIN Item. The empty
     // Attic (no item) survives the LEFT join NULL-extended, while the inner
     // House-Room pairs are formed first.
-    let rows = try engineLineage("""
+    let rows = try lineage("""
         SELECT House.House, Room.Room, Item.Item FROM House
           JOIN Room ON Room.Hid = House.Id
           LEFT JOIN Item ON Item.Rid = Room.Id
@@ -711,7 +711,7 @@ struct EngineOuterJoinTests {
   @Test func `an empty right side NULL-extends every left row`() throws {
     // With no child matching, a LEFT join still emits every parent, right
     // NULL — the width comes from the plan, not from a right row.
-    let rows = try engineJoin("""
+    let rows = try join("""
         SELECT Parent.Name, Child.Name FROM Parent
           LEFT JOIN Child ON Child.Pid = 999
         """)
@@ -761,7 +761,7 @@ private func outers(_ plan: Plan) -> Bool {
 
 struct EngineMultiJoinTests {
   @Test func `a three-relation chain joins across two foreign keys`() throws {
-    let rows = try engineLineage("""
+    let rows = try lineage("""
         SELECT House.House, Room.Room, Item.Item FROM House
           JOIN Room ON Room.Hid = House.Id
           JOIN Item ON Item.Rid = Room.Id
@@ -779,7 +779,7 @@ struct EngineMultiJoinTests {
     // Walking the chain the other way: `Item` is the outer scan, and both inner
     // relations are seeked on their sorted `Id` — the multi-way nest rewrite
     // turning every `Select`-over-`Product` level into an index-nested loop.
-    let rows = try engineLineage("""
+    let rows = try lineage("""
         SELECT Item.Item, Room.Room, House.House FROM Item
           JOIN Room ON Room.Id = Item.Rid
           JOIN House ON House.Id = Room.Hid
@@ -792,7 +792,7 @@ struct EngineMultiJoinTests {
   }
 
   @Test func `a WHERE filters across a three-relation chain`() throws {
-    try engineLineage().expect("""
+    try lineage().expect("""
         SELECT Item.Item FROM House
           JOIN Room ON Room.Hid = House.Id
           JOIN Item ON Item.Rid = Room.Id
@@ -805,7 +805,7 @@ struct EngineMultiJoinTests {
     // `Id` sits in both `House` and `Room`; across the chain it resolves in more
     // than one relation, so an unqualified reference is ambiguous.
     #expect(throws: SQLError.ambiguous("Id")) {
-      try engineLineage("""
+      try lineage("""
           SELECT Id FROM House
             JOIN Room ON Room.Hid = House.Id
             JOIN Item ON Item.Rid = Room.Id
@@ -820,7 +820,7 @@ struct EngineMultiJoinTests {
     // rejected (`SQLError.column`) rather than resolving `Item`'s slot from a
     // product that does not yet contain it and trapping or indexing wrong.
     #expect(throws: SQLError.column("Rid")) {
-      try engineLineage("""
+      try lineage("""
           SELECT House.House FROM House
             JOIN Room ON Item.Rid = House.Id
             JOIN Item ON Item.Rid = Room.Id
@@ -832,7 +832,7 @@ struct EngineMultiJoinTests {
     // Each `ON` references only the prefix it resolves against, so the whole
     // chain compiles and runs — mirroring `chain`, which the prefix-scope fix
     // leaves unchanged.
-    let rows = try engineLineage("""
+    let rows = try lineage("""
         SELECT House.House, Room.Room, Item.Item FROM House
           JOIN Room ON Room.Hid = House.Id
           JOIN Item ON Item.Rid = Room.Id
@@ -849,7 +849,7 @@ struct EngineMultiJoinTests {
     // `{Author, Book}` even though `Sale` — joined only later — also carries a
     // `Code`. Resolving the match against the prefix binds it; resolving against
     // the whole chain would see two `Code`s and report `SQLError.ambiguous`.
-    try engineShared().expect("""
+    try shared().expect("""
         SELECT Author.Aid, Book.Bid, Sale.Code FROM Author
           JOIN Book ON Code = Book.Aid
           JOIN Sale ON Sale.Sid = Book.Bid
@@ -869,7 +869,7 @@ struct EngineMultiJoinTests {
 /// `Bonus(Dept, Amt)` names every `Dept` (10, 20, 30), so a THIRD `USING
 /// (Dept)` join after an outer `Emp`/`Team` one keys each surviving row —
 /// including an unmatched left/right one — on the merged `Dept`.
-private func engineNamed() throws -> FixtureCatalog {
+private func named() throws -> FixtureCatalog {
   try Catalog {
     Relation("Emp", ["Dept": .integer, "Name": .text]) {
       Row(10, "Ann")
@@ -909,7 +909,7 @@ struct EngineNaturalUsingTests {
     // Output column list (ISO 7.10): the USING column `Dept` ONCE and FIRST,
     // then the left's other columns (`Name`), then the right's (`Lead`). Rows
     // join on `Dept` equality — only Dept 20 matches on both sides.
-    try engineNamed().expect("SELECT * FROM Emp JOIN Team USING (Dept)",
+    try named().expect("SELECT * FROM Emp JOIN Team USING (Dept)",
         yields: [
           [20, "Bob", "Deb"],
           [20, "Cid", "Deb"],
@@ -919,7 +919,7 @@ struct EngineNaturalUsingTests {
   @Test func `USING (c1, c2) keys on both columns`() throws {
     // The join columns `K, G` come first in order, then `Lhs`'s `A`, then
     // `Rhs`'s `B`. Only the (1, x) row agrees on BOTH columns.
-    try engineNamed().expect("""
+    try named().expect("""
         SELECT * FROM Lhs JOIN Rhs USING (K, G)
         """,
         yields: [[1, "x", "a1", "b1"]])
@@ -928,7 +928,7 @@ struct EngineNaturalUsingTests {
   @Test func `NATURAL INNER joins on the one shared column`() throws {
     // `Emp` and `Team` share only `Dept`, so `NATURAL JOIN` is `USING (Dept)`:
     // the merged `Dept` first, then `Name`, then `Lead`.
-    try engineNamed().expect("SELECT * FROM Emp NATURAL JOIN Team",
+    try named().expect("SELECT * FROM Emp NATURAL JOIN Team",
         yields: [
           [20, "Bob", "Deb"],
           [20, "Cid", "Deb"],
@@ -938,7 +938,7 @@ struct EngineNaturalUsingTests {
   @Test func `NATURAL with two common columns keys on both`() throws {
     // `Lhs` and `Rhs` share `K` and `G` (in `Lhs`'s order), so the merged
     // `K, G` come first, then `A`, then `B` — the same as `USING (K, G)`.
-    try engineNamed().expect("SELECT * FROM Lhs NATURAL JOIN Rhs",
+    try named().expect("SELECT * FROM Lhs NATURAL JOIN Rhs",
         yields: [[1, "x", "a1", "b1"]])
   }
 
@@ -946,7 +946,7 @@ struct EngineNaturalUsingTests {
     // `Solo(x)` and `Other(y)` share nothing, so `NATURAL JOIN` degenerates
     // to a Cartesian product (ISO), NOT a fault: every left row paired with
     // every right row, the output being every column of both.
-    try engineNamed().expect("SELECT * FROM Solo NATURAL JOIN Other",
+    try named().expect("SELECT * FROM Solo NATURAL JOIN Other",
         yields: [
           [1, "p"],
           [1, "q"],
@@ -959,7 +959,7 @@ struct EngineNaturalUsingTests {
     // `Emp` Dept 10 has no `Team` match; a LEFT join keeps it, and the merged
     // `Dept` = COALESCE(Emp.Dept, Team.Dept) shows the left's 10 while `Lead`
     // NULL-extends.
-    try engineNamed().expect("""
+    try named().expect("""
         SELECT * FROM Emp LEFT JOIN Team USING (Dept)
         """,
         yields: [
@@ -973,7 +973,7 @@ struct EngineNaturalUsingTests {
     // `Team` Dept 30 has no `Emp` match; a RIGHT join keeps it, and the merged
     // `Dept` = COALESCE(Emp.Dept, Team.Dept) shows the right's 30 even though
     // the left `Emp.Dept` is NULL there. `Name` NULL-extends.
-    try engineNamed().expect("""
+    try named().expect("""
         SELECT * FROM Emp RIGHT JOIN Team USING (Dept)
         """,
         yields: [
@@ -987,7 +987,7 @@ struct EngineNaturalUsingTests {
     // Both unmatched rows survive: `Emp` Dept 10 (left-only, merged `Dept` =
     // 10, `Lead` NULL) and `Team` Dept 30 (right-only, merged `Dept` = 30 via
     // COALESCE though `Emp.Dept` is NULL, `Name` NULL).
-    try engineNamed().expect("SELECT * FROM Emp NATURAL FULL OUTER JOIN Team",
+    try named().expect("SELECT * FROM Emp NATURAL FULL OUTER JOIN Team",
         yields: [
           [10, "Ann", nil],
           [20, "Bob", "Deb"],
@@ -999,14 +999,14 @@ struct EngineNaturalUsingTests {
   @Test func `USING a column absent from one side faults`() throws {
     // `Name` is on `Emp` but not `Team`, so `USING (Name)` names a column the
     // right side does not resolve — a column fault.
-    try engineNamed().expect("SELECT * FROM Emp JOIN Team USING (Name)",
+    try named().expect("SELECT * FROM Emp JOIN Team USING (Name)",
         fails: .column("Name"))
   }
 
   @Test func `USING is case-insensitive in the column name`() throws {
     // The join column matches case-insensitively, as the engine's identifier
     // resolution does, so `USING (dept)` keys on `Dept`.
-    try engineNamed().expect("SELECT * FROM Emp JOIN Team USING (dept)",
+    try named().expect("SELECT * FROM Emp JOIN Team USING (dept)",
         yields: [
           [20, "Bob", "Deb"],
           [20, "Cid", "Deb"],
@@ -1017,7 +1017,7 @@ struct EngineNaturalUsingTests {
     // An explicit projection resolves columns by the ordinary rules over the
     // synthesized `ON` join, so a qualified `Emp.Dept`/`Team.Dept` still names
     // each side's own column (both equal on a matched row).
-    try engineNamed().expect("""
+    try named().expect("""
         SELECT Emp.Dept, Team.Dept, Name FROM Emp JOIN Team USING (Dept)
         """,
         yields: [
@@ -1030,14 +1030,14 @@ struct EngineNaturalUsingTests {
     // ISO 9075 7.10: the USING/NATURAL common column is an exposed name of the
     // join result belonging to NEITHER side, so a BARE `Dept` resolves to the
     // ONE coalesced column — UNAMBIGUOUSLY — not to `Emp.Dept` or `Team.Dept`.
-    try engineNamed().expect("SELECT Dept FROM Emp JOIN Team USING (Dept)",
+    try named().expect("SELECT Dept FROM Emp JOIN Team USING (Dept)",
         yields: [[20], [20]])
   }
 
   @Test func `a bare merged reference resolves in WHERE`() throws {
     // The exposed name resolves in a `WHERE` too — `Dept = 20` filters on the
     // coalesced value, keeping only the matched rows.
-    try engineNamed().expect("""
+    try named().expect("""
         SELECT Name FROM Emp JOIN Team USING (Dept) WHERE Dept = 20
         """,
         yields: [["Bob"], ["Cid"]])
@@ -1047,7 +1047,7 @@ struct EngineNaturalUsingTests {
     // The exposed name resolves in an `ORDER BY` — a FULL join's rows sort by
     // the coalesced `Dept`, the left-only (10) and right-only (30) unmatched
     // rows ordered alongside the matched (20) ones.
-    try engineNamed().expect("""
+    try named().expect("""
         SELECT Name FROM Emp NATURAL FULL OUTER JOIN Team ORDER BY Dept
         """,
         yields: [["Ann"], ["Bob"], ["Cid"], [nil]])
@@ -1056,7 +1056,7 @@ struct EngineNaturalUsingTests {
   @Test func `a bare merged reference resolves in GROUP BY`() throws {
     // The exposed name resolves as a `GROUP BY` key — the matched Dept 20 rows
     // form one group of two.
-    try engineNamed().expect("""
+    try named().expect("""
         SELECT Dept, COUNT(*) FROM Emp JOIN Team USING (Dept) GROUP BY Dept
         """,
         yields: [[20, 2]])
@@ -1066,7 +1066,7 @@ struct EngineNaturalUsingTests {
     // A LEFT join keeps the left-only Dept 10; the exposed bare `Dept` shows
     // the coalesced value (the left's 10), matching the `SELECT *` merged
     // column.
-    try engineNamed().expect("""
+    try named().expect("""
         SELECT Dept FROM Emp LEFT JOIN Team USING (Dept)
         """,
         yields: [[10], [20], [20]])
@@ -1076,7 +1076,7 @@ struct EngineNaturalUsingTests {
     // A RIGHT join keeps the right-only Dept 30; the exposed bare `Dept` shows
     // the coalesced value (the right's 30) even where the left `Emp.Dept` is
     // NULL.
-    try engineNamed().expect("""
+    try named().expect("""
         SELECT Dept FROM Emp RIGHT JOIN Team USING (Dept)
         """,
         yields: [[20], [20], [30]])
@@ -1086,7 +1086,7 @@ struct EngineNaturalUsingTests {
     // A FULL join keeps both unmatched rows; the exposed bare `Dept` shows the
     // coalesced value on each — the left's 10 (right NULL) and the right's 30
     // (left NULL).
-    try engineNamed().expect("""
+    try named().expect("""
         SELECT Dept FROM Emp NATURAL FULL OUTER JOIN Team
         """,
         yields: [[10], [20], [20], [30]])
@@ -1096,7 +1096,7 @@ struct EngineNaturalUsingTests {
     // A NATURAL join over two common columns exposes BOTH `K` and `G`; a bare
     // reference to each resolves to its coalesced value (equal on the one
     // matched row).
-    try engineNamed().expect("""
+    try named().expect("""
         SELECT K, G FROM Lhs NATURAL JOIN Rhs
         """,
         yields: [[1, "x"]])
@@ -1107,7 +1107,7 @@ struct EngineNaturalUsingTests {
     // `Lhs` and `Rhs` share `K` and `G`, but `USING (K)` joins on `K` alone —
     // so bare `G`, shared yet NOT a join column, stays AMBIGUOUS between the
     // two sides rather than collapsing to a merged value.
-    try engineNamed().expect("""
+    try named().expect("""
         SELECT G FROM Lhs JOIN Rhs USING (K)
         """,
         fails: .ambiguous("G"))
@@ -1117,7 +1117,7 @@ struct EngineNaturalUsingTests {
     // The exposed name is UNqualified; a qualified `Lhs.G`/`Rhs.G` still names
     // its own side even when the sibling `K` is a join column — merging is
     // scoped to the bare join-column name alone.
-    try engineNamed().expect("""
+    try named().expect("""
         SELECT Lhs.G, Rhs.G FROM Lhs JOIN Rhs USING (K)
         """,
         yields: [["x", "x"], ["y", "z"]])
@@ -1130,7 +1130,7 @@ struct EngineNaturalUsingTests {
     // (the alias `e`), the only name the scope admits, so `Emp AS e JOIN Team
     // USING (Dept)` resolves rather than faulting on an unqualifiable
     // `Emp.Dept`.
-    try engineNamed().expect("""
+    try named().expect("""
         SELECT * FROM Emp AS e JOIN Team USING (Dept)
         """,
         yields: [
@@ -1142,7 +1142,7 @@ struct EngineNaturalUsingTests {
   @Test func `an aliased JOINED side resolves a USING join`() throws {
     // The joined side's references qualify by its range name (`t`) too, so
     // `Emp JOIN Team AS t USING (Dept)` resolves.
-    try engineNamed().expect("""
+    try named().expect("""
         SELECT * FROM Emp JOIN Team AS t USING (Dept)
         """,
         yields: [
@@ -1154,7 +1154,7 @@ struct EngineNaturalUsingTests {
   @Test func `a projection qualified by an alias resolves over a USING join`() throws {
     // Both sides aliased: a qualified `e.Name` resolves to its side and a bare
     // merged `Dept` to the coalesced value, all over the aliased ranges.
-    try engineNamed().expect("""
+    try named().expect("""
         SELECT e.Name, Dept FROM Emp AS e JOIN Team AS t USING (Dept)
         """,
         yields: [
@@ -1170,7 +1170,7 @@ struct EngineNaturalUsingTests {
     // 3-column second arm aligns and the UNION succeeds. Before the desugar ran
     // ahead of the arity check, the `*` measured both physical `Dept`s (4) and
     // wrongly rejected the valid set operation.
-    try engineNamed().expect("""
+    try named().expect("""
         SELECT * FROM Emp JOIN Team USING (Dept)
         UNION SELECT Dept, Name, Lead FROM Emp JOIN Team USING (Dept)
         """,
@@ -1183,7 +1183,7 @@ struct EngineNaturalUsingTests {
   @Test func `a UNION whose arms differ post-merge still faults arity`() throws {
     // A genuinely mismatched set operation — a 3-wide merged `*` against a
     // 2-column arm — still faults, measured at the merged width.
-    try engineNamed().expect("""
+    try named().expect("""
         SELECT * FROM Emp JOIN Team USING (Dept)
         UNION SELECT Dept, Name FROM Emp JOIN Team USING (Dept)
         """,
@@ -1196,7 +1196,7 @@ struct EngineNaturalUsingTests {
     // The outer operand of `IN (subquery)` resolves in THIS query's scope, so
     // a bare merged `Dept` is exposed to the coalesced value — not left
     // ambiguous between the two physical sides.
-    try engineNamed().expect("""
+    try named().expect("""
         SELECT Name FROM Emp JOIN Team USING (Dept)
         WHERE Dept IN (SELECT Dept FROM Team)
         """,
@@ -1206,7 +1206,7 @@ struct EngineNaturalUsingTests {
   @Test func `a bare merged reference resolves as a quantified operand`() throws {
     // As `IN`, the `= ANY (subquery)` outer operand is exposed to the merged
     // value.
-    try engineNamed().expect("""
+    try named().expect("""
         SELECT Name FROM Emp JOIN Team USING (Dept)
         WHERE Dept = ANY (SELECT Dept FROM Team)
         """,
@@ -1220,7 +1220,7 @@ struct EngineNaturalUsingTests {
     // `Emp.Dept` NULL); the next `JOIN Bonus USING (Dept)` keys on the MERGED
     // `Dept`, so that row still joins `Bonus` (Amt 200) rather than being
     // dropped on a NULL left key.
-    try engineNamed().expect("""
+    try named().expect("""
         SELECT * FROM Emp RIGHT JOIN Team USING (Dept) JOIN Bonus USING (Dept)
         """,
         yields: [
@@ -1234,7 +1234,7 @@ struct EngineNaturalUsingTests {
     // A FULL first join keeps BOTH unmatched rows — Dept 10 (left-only) and 30
     // (right-only); the chained `Bonus` join keys each on the merged `Dept`, so
     // both still join (Amt 50 and 200).
-    try engineNamed().expect("""
+    try named().expect("""
         SELECT * FROM Emp FULL JOIN Team USING (Dept) JOIN Bonus USING (Dept)
         """,
         yields: [
@@ -1251,7 +1251,7 @@ struct EngineNaturalUsingTests {
     // `USING (Dept, Dept)` names one merged column twice; the duplicate is
     // caught BEFORE the output dictionary the merged names key would trap on,
     // faulting `.duplicate` rather than aborting the process.
-    try engineNamed().expect("""
+    try named().expect("""
         SELECT * FROM Emp JOIN Team USING (Dept, Dept)
         """,
         fails: .duplicate("Dept"))
@@ -1261,7 +1261,7 @@ struct EngineNaturalUsingTests {
     // `Emp JOIN Team ON …` leaves the left side carrying TWO columns named
     // `Dept`; a following `NATURAL JOIN Bonus` would merge `Dept` twice — the
     // duplicate is caught and faults `.duplicate` rather than trapping.
-    try engineNamed().expect("""
+    try named().expect("""
         SELECT * FROM Emp JOIN Team ON Emp.Dept = Team.Dept
         NATURAL JOIN Bonus
         """,
@@ -1274,7 +1274,7 @@ struct EngineNaturalUsingTests {
     // The right-only Dept 30 (left `Emp.Dept` NULL) groups and projects by the
     // MERGED value 30, not NULL — the `GROUP BY` key is the coalesced value the
     // projection emits.
-    try engineNamed().expect("""
+    try named().expect("""
         SELECT Dept, COUNT(*) FROM Emp RIGHT JOIN Team USING (Dept)
         GROUP BY Dept
         """,
@@ -1287,7 +1287,7 @@ struct EngineNaturalUsingTests {
   @Test func `a FULL join groups a bare merged column by the coalesced value`() throws {
     // Both unmatched rows group by their merged value — the left-only 10 and
     // the right-only 30 — each its own group, not collapsed to NULL.
-    try engineNamed().expect("""
+    try named().expect("""
         SELECT Dept, COUNT(*) FROM Emp FULL JOIN Team USING (Dept)
         GROUP BY Dept
         """,
@@ -1305,7 +1305,7 @@ struct EngineNaturalUsingTests {
     // `Dept` (`Emp.Dept` and `Team.Dept`); a following `JOIN Bonus USING
     // (Dept)` keys `Dept` on that left — which binds it TWICE — so it faults
     // `.ambiguous` at construction rather than trapping a downstream build.
-    try engineNamed().expect("""
+    try named().expect("""
         SELECT * FROM Emp JOIN Team ON Emp.Dept = Team.Dept
         JOIN Bonus USING (Dept)
         """,
@@ -1319,7 +1319,7 @@ struct EngineNaturalUsingTests {
     // brings its OWN physical `C.Dept`. A QUALIFIED `C.Dept` names that side
     // unambiguously and resolves — never a crash — even though a bare `Dept`
     // would now be ambiguous between the merged column and `C.Dept`.
-    try engineNamed().expect("""
+    try named().expect("""
         SELECT C.Dept FROM Emp JOIN Team USING (Dept)
         JOIN Bonus AS C ON C.Dept = Emp.Dept
         """,
@@ -1330,7 +1330,7 @@ struct EngineNaturalUsingTests {
     // The bare counterpart: with the merged `Dept` AND the later plain join's
     // physical `C.Dept` both in scope, a bare `Dept` names two columns and
     // faults `.ambiguous` — surfacing at lookup, NEVER a crash.
-    try engineNamed().expect("""
+    try named().expect("""
         SELECT Dept FROM Emp JOIN Team USING (Dept)
         JOIN Bonus AS C ON C.Dept = Emp.Dept
         """,
@@ -1376,7 +1376,7 @@ struct EngineNaturalUsingTests {
     let text = """
         SELECT Name FROM Emp JOIN Team USING (Dept) WHERE Dept = 20
         """
-    let columns = try engineNamed()
+    let columns = try named()
         .columns(of: Statement(parsing: text), validate: true)
     #expect(columns.count == 1)
     #expect(columns[0].name == "Name")
@@ -1387,7 +1387,7 @@ struct EngineNaturalUsingTests {
     // The merged `Dept` PROJECTED and type-checked: the schema resolves it to
     // the unified coalesce type (`integer`) rather than faulting `.ambiguous`.
     let text = "SELECT Dept FROM Emp JOIN Team USING (Dept) WHERE Dept = 20"
-    let columns = try engineNamed()
+    let columns = try named()
         .columns(of: Statement(parsing: text), validate: true)
     #expect(columns.count == 1)
     #expect(columns[0].name == "Dept")
@@ -1397,7 +1397,7 @@ struct EngineNaturalUsingTests {
   @Test func `a validated merged query agrees with the run`() throws {
     // run ≡ columns(of:validate:true): the query the validation path accepts
     // is the query the run executes, producing the two matched rows.
-    try engineNamed().expect("""
+    try named().expect("""
         SELECT Name FROM Emp JOIN Team USING (Dept) WHERE Dept = 20
         """,
         yields: [["Bob"], ["Cid"]])
@@ -1410,7 +1410,7 @@ struct EngineNaturalUsingTests {
     // merged-aware lookup narrows nothing that a plain shared column widens.
     let text = "SELECT G FROM Lhs JOIN Rhs USING (K)"
     #expect(throws: SQLError.ambiguous("G")) {
-      _ = try engineNamed()
+      _ = try named()
           .columns(of: Statement(parsing: text), validate: true)
     }
   }
@@ -1610,8 +1610,8 @@ struct EngineNaturalUsingTests {
     // exposes `[a, k, p, q, r]` — the OUTER `a` first, then the inner `k` (it
     // sits within "the rest of the left"), not the flat fold order `[k, a, …]`.
     let text = "SELECT * FROM P JOIN Q USING (k) JOIN R USING (a)"
-    try engineChained().expect(text, yields: [[7, 1, "p1", "q1", "r1"]])
-    let columns = try engineChained()
+    try chained().expect(text, yields: [[7, 1, "p1", "q1", "r1"]])
+    let columns = try chained()
         .columns(of: Statement(parsing: text), validate: true)
     #expect(columns.map(\.name) == ["a", "k", "p", "q", "r"])
   }
@@ -1622,8 +1622,8 @@ struct EngineNaturalUsingTests {
     // outer) and lays them in the same ISO order `[a, k, …]` in both the run
     // and the schema.
     let text = "SELECT * FROM P NATURAL JOIN Q NATURAL JOIN R"
-    try engineChained().expect(text, yields: [[7, 1, "p1", "q1", "r1"]])
-    let columns = try engineChained()
+    try chained().expect(text, yields: [[7, 1, "p1", "q1", "r1"]])
+    let columns = try chained()
         .columns(of: Statement(parsing: text), validate: true)
     #expect(columns.map(\.name) == ["a", "k", "p", "q", "r"])
   }
@@ -1636,12 +1636,12 @@ struct EngineNaturalUsingTests {
     // and schema agree.
     let text =
         "SELECT * FROM Emp JOIN Team USING (Dept) JOIN Bonus USING (Dept)"
-    try engineNamed().expect(text,
+    try named().expect(text,
         yields: [
           [20, "Bob", "Deb", 100],
           [20, "Cid", "Deb", 100],
         ])
-    let columns = try engineNamed()
+    let columns = try named()
         .columns(of: Statement(parsing: text), validate: true)
     #expect(columns.map(\.name) == ["Dept", "Name", "Lead", "Amt"])
   }
@@ -1657,8 +1657,8 @@ struct EngineNaturalUsingTests {
         SELECT d.n FROM Emp JOIN Team USING (Dept)
           JOIN LATERAL (SELECT Dept AS n) AS d ON 1 = 1
         """
-    try engineNamed().expect(text, yields: [[20], [20]])
-    let columns = try engineNamed()
+    try named().expect(text, yields: [[20], [20]])
+    let columns = try named()
         .columns(of: Statement(parsing: text), validate: true)
     #expect(columns.map(\.name) == ["n"])
   }
@@ -1670,7 +1670,7 @@ struct EngineNaturalUsingTests {
         SELECT d.n FROM Emp NATURAL JOIN Team
           JOIN LATERAL (SELECT Dept AS n) AS d ON 1 = 1
         """
-    try engineNamed().expect(text, yields: [[20], [20]])
+    try named().expect(text, yields: [[20], [20]])
   }
 
   @Test func `a LATERAL body coalesces a merged column of a RIGHT join`() throws {
@@ -1682,7 +1682,7 @@ struct EngineNaturalUsingTests {
         SELECT d.n FROM Emp RIGHT JOIN Team USING (Dept)
           JOIN LATERAL (SELECT Dept AS n) AS d ON 1 = 1
         """
-    try engineNamed().expect(text, yields: [[20], [20], [30]])
+    try named().expect(text, yields: [[20], [20], [30]])
   }
 
   @Test func `a LATERAL body still resolves a qualified constituent column`()
@@ -1693,7 +1693,7 @@ struct EngineNaturalUsingTests {
         SELECT d.n FROM Emp JOIN Team USING (Dept)
           JOIN LATERAL (SELECT Emp.Dept AS n) AS d ON 1 = 1
         """
-    try engineNamed().expect(text, yields: [[20], [20]])
+    try named().expect(text, yields: [[20], [20]])
   }
 
   @Test func `a LATERAL body faults an ambiguous non-merged name`() throws {
@@ -1705,7 +1705,7 @@ struct EngineNaturalUsingTests {
           JOIN Bonus ON Bonus.Dept = Emp.Dept
           JOIN LATERAL (SELECT Dept AS n) AS d ON 1 = 1
         """
-    try engineNamed().expect(text, fails: .ambiguous("Dept"))
+    try named().expect(text, fails: .ambiguous("Dept"))
   }
 
   @Test func `a merged column and its constituent correlate independently`()
@@ -1720,7 +1720,7 @@ struct EngineNaturalUsingTests {
           JOIN LATERAL (SELECT Dept AS m, Emp.Dept AS e) AS d ON 1 = 1
           ORDER BY m
         """
-    try engineNamed().expect(forward, yields: [
+    try named().expect(forward, yields: [
       [20, 20],
       [20, 20],
       [30, nil],
@@ -1733,7 +1733,7 @@ struct EngineNaturalUsingTests {
           JOIN LATERAL (SELECT Emp.Dept AS e, Dept AS m) AS d ON 1 = 1
           ORDER BY m
         """
-    try engineNamed().expect(reverse, yields: [
+    try named().expect(reverse, yields: [
       [20, 20],
       [20, 20],
       [30, nil],
@@ -1752,7 +1752,7 @@ struct EngineNaturalUsingTests {
           JOIN (SELECT NULLIF(1, 1) AS k FROM Solo) AS b USING (k)
           UNION SELECT 'x'
         """
-    let starred = try engineNamed()
+    let starred = try named()
         .columns(of: Statement(parsing: star), validate: true)
     #expect(starred.map(\.type) == [.text])
     // The explicit `SELECT k` variant already resolved through `output(of:)`;
@@ -1762,7 +1762,7 @@ struct EngineNaturalUsingTests {
           JOIN (SELECT NULLIF(1, 1) AS k FROM Solo) AS b USING (k)
           UNION SELECT 'x'
         """
-    let named = try engineNamed()
+    let named = try named()
         .columns(of: Statement(parsing: explicit), validate: true)
     #expect(named.map(\.type) == [.text])
   }
@@ -1776,7 +1776,7 @@ struct EngineNaturalUsingTests {
     let text = """
         SELECT * FROM Emp JOIN Team USING (Dept) UNION SELECT 'x', 'y', 'z'
         """
-    try engineNamed().expect(text,
+    try named().expect(text,
         fails: .operand("UNION arms have irreconcilable types"))
   }
 
@@ -1790,7 +1790,7 @@ struct EngineNaturalUsingTests {
     // `Emp.Id = Team.Id` uses, keying on the row index: Emp Ids 1..3, Team
     // Ids 1..2, so Ids 1 and 2 match. ISO 7.10 order exposes the merged `Id`
     // once and first, then `Emp`'s real columns, then `Team`'s.
-    try engineNamed().expect("SELECT * FROM Emp JOIN Team USING (Id)",
+    try named().expect("SELECT * FROM Emp JOIN Team USING (Id)",
         yields: [
           [1, 10, "Ann", 20, "Deb"],
           [2, 20, "Bob", 30, "Eve"],
@@ -1802,7 +1802,7 @@ struct EngineNaturalUsingTests {
     // The merged virtual `Id`'s result type is derived on the schema path the
     // run agrees with — a fixture virtual `Id` types integral.
     let text = "SELECT Id FROM Emp JOIN Team USING (Id)"
-    let columns = try engineNamed()
+    let columns = try named()
         .columns(of: Statement(parsing: text), validate: true)
     let pairs = columns.map { ($0.name, $0.type) }
     #expect(pairs.elementsEqual([("Id", .integer)], by: ==))
@@ -1819,7 +1819,7 @@ struct EngineNaturalUsingTests {
     // resolves the virtual through `ordinal(of:)`. So `Emp NATURAL JOIN Team`
     // keys on the shared REAL `Dept` alone (Dept 20 matches), NOT on the
     // virtual `Id` — the round-1 behavior is unchanged.
-    try engineNamed().expect("SELECT * FROM Emp NATURAL JOIN Team",
+    try named().expect("SELECT * FROM Emp NATURAL JOIN Team",
         yields: [
           [20, "Bob", "Deb"],
           [20, "Cid", "Deb"],
@@ -1831,7 +1831,7 @@ struct EngineNaturalUsingTests {
     // exposes only a VIRTUAL `Id`. `USING (Id)` must resolve the LEFT through
     // the real column and the RIGHT through the virtual one, keying REAL 1..3
     // against the row index 1..3.
-    try engineVirtual().expect("SELECT * FROM Coded JOIN Emp USING (Id)",
+    try virtual().expect("SELECT * FROM Coded JOIN Emp USING (Id)",
         yields: [
           [1, "c1", 10, "Ann"],
           [2, "c2", 20, "Bob"],
@@ -1844,7 +1844,7 @@ struct EngineNaturalUsingTests {
     // joined — the LEFT resolves the virtual, the RIGHT the real. The output
     // exposes the merged `Id`, then `Emp`'s real columns, then `Coded`'s real
     // ones (its real `Id` is the merged constituent, dropped from the rest).
-    try engineVirtual().expect("SELECT * FROM Emp JOIN Coded USING (Id)",
+    try virtual().expect("SELECT * FROM Emp JOIN Coded USING (Id)",
         yields: [
           [1, 10, "Ann", "c1"],
           [2, 20, "Bob", "c2"],
@@ -1862,7 +1862,7 @@ struct EngineNaturalUsingTests {
     // synthesized `on` empty), keeping ALL FOUR real columns unmerged and every
     // 3x3 pairing. An EXPLICIT `USING (Id)` (the control below) still resolves
     // the virtual; NATURAL, like `SELECT *`, draws only on real names.
-    try engineVirtual().expect("SELECT * FROM Coded NATURAL JOIN Emp",
+    try virtual().expect("SELECT * FROM Coded NATURAL JOIN Emp",
         yields: [
           [1, "c1", 10, "Ann"],
           [1, "c1", 20, "Bob"],
@@ -1875,7 +1875,7 @@ struct EngineNaturalUsingTests {
           [3, "c3", 20, "Cid"],
         ])
     let text = "SELECT * FROM Coded NATURAL JOIN Emp"
-    let columns = try engineVirtual().columns(of: parse(query: text))
+    let columns = try virtual().columns(of: parse(query: text))
     #expect(columns.map(\.name) == ["Id", "Tag", "Dept", "Name"])
   }
 
@@ -1886,7 +1886,7 @@ struct EngineNaturalUsingTests {
     // (`prefix.names` never lists a virtual), so a LEFT virtual `Id` is not
     // even a candidate — the common set stays the empty real intersection and
     // the join is a CROSS product over all four real columns.
-    try engineVirtual().expect("SELECT * FROM Emp NATURAL JOIN Coded",
+    try virtual().expect("SELECT * FROM Emp NATURAL JOIN Coded",
         yields: [
           [10, "Ann", 1, "c1"],
           [10, "Ann", 2, "c2"],
@@ -1899,7 +1899,7 @@ struct EngineNaturalUsingTests {
           [20, "Cid", 3, "c3"],
         ])
     let text = "SELECT * FROM Emp NATURAL JOIN Coded"
-    let columns = try engineVirtual().columns(of: parse(query: text))
+    let columns = try virtual().columns(of: parse(query: text))
     #expect(columns.map(\.name) == ["Dept", "Name", "Id", "Tag"])
   }
 
@@ -1911,14 +1911,14 @@ struct EngineNaturalUsingTests {
     // index 1..3), a single merged `Id` first, then the remaining real columns.
     // Only NATURAL's common-set derivation changed; the explicit-USING path is
     // untouched.
-    try engineVirtual().expect("SELECT * FROM Coded JOIN Emp USING (Id)",
+    try virtual().expect("SELECT * FROM Coded JOIN Emp USING (Id)",
         yields: [
           [1, "c1", 10, "Ann"],
           [2, "c2", 20, "Bob"],
           [3, "c3", 20, "Cid"],
         ])
     let text = "SELECT * FROM Coded JOIN Emp USING (Id)"
-    let columns = try engineVirtual().columns(of: parse(query: text))
+    let columns = try virtual().columns(of: parse(query: text))
     #expect(columns.map(\.name) == ["Id", "Tag", "Dept", "Name"])
   }
 
@@ -1930,7 +1930,7 @@ struct EngineNaturalUsingTests {
     // show the JOINED (right) virtual value on those right-only rows, so the
     // merged column is 1, 2, 3 — not NULL — proving the run coalesces the
     // virtual slot, not just resolves it.
-    try engineVirtual().expect("""
+    try virtual().expect("""
         SELECT Id FROM Few RIGHT JOIN Many USING (Id) ORDER BY Id
         """,
         yields: [[1], [2], [3]])
@@ -1949,9 +1949,9 @@ struct EngineNaturalUsingTests {
     // would MISS the virtual `Emp.Id` and wrongly take the merged value. run
     // and `columns(of:)` agree.
     let text = "SELECT Id FROM Few JOIN Many USING (Id) JOIN Emp ON 1 = 1"
-    try engineVirtual().expect(text, fails: .ambiguous("Id"))
+    try virtual().expect(text, fails: .ambiguous("Id"))
     #expect(throws: SQLError.ambiguous("Id")) {
-      _ = try engineVirtual().columns(of: parse(query: text))
+      _ = try virtual().columns(of: parse(query: text))
     }
   }
 
@@ -1964,9 +1964,9 @@ struct EngineNaturalUsingTests {
     let text = """
         SELECT v FROM Few JOIN Many USING (Id) JOIN Emp ON 1 = 1 WHERE Id = 1
         """
-    try engineVirtual().expect(text, fails: .ambiguous("Id"))
+    try virtual().expect(text, fails: .ambiguous("Id"))
     #expect(throws: SQLError.ambiguous("Id")) {
-      _ = try engineVirtual().columns(of: parse(query: text))
+      _ = try virtual().columns(of: parse(query: text))
     }
   }
 
@@ -1977,7 +1977,7 @@ struct EngineNaturalUsingTests {
     // and the plain-joined `Emp.Id` (virtual), so keying the final `USING (Id)`
     // on that left is ambiguous — the left resolution (`Scope.left`) routes
     // through the SAME full-surface merged bare lookup and faults.
-    try engineVirtual().expect("""
+    try virtual().expect("""
         SELECT v FROM Few JOIN Many USING (Id) JOIN Emp ON 1 = 1
         JOIN Coded USING (Id)
         """,
@@ -1990,7 +1990,7 @@ struct EngineNaturalUsingTests {
     // side unambiguously: `Few.Id`/`Many.Id` the merge constituents (both the
     // matched row index 1), `Emp.Id` the later plain join's virtual `Id` (the
     // three `Emp` rows' indices 1..3) — never a fault.
-    try engineVirtual().expect("""
+    try virtual().expect("""
         SELECT Few.Id, Many.Id, Emp.Id FROM Few JOIN Many USING (Id)
         JOIN Emp ON 1 = 1
         """,
@@ -2036,7 +2036,7 @@ struct EngineNaturalUsingTests {
     // not undercount by subtracting the virtual constituents from a real-only
     // sum. The width now DERIVES from the same enumeration `columns(of:)`
     // walks, so the two agree by construction.
-    let catalog = try engineNamed()
+    let catalog = try named()
     try catalog.expect("SELECT * FROM Emp JOIN Team USING (Id)",
         yields: [
           [1, 10, "Ann", 20, "Deb"],
@@ -2053,7 +2053,7 @@ struct EngineNaturalUsingTests {
     // matching UNION was WRONGLY rejected. The left arm's `SELECT *` is arity 5
     // (merged virtual `Id` + four real columns); a right arm of five columns
     // now unifies rather than faulting.
-    try engineNamed().expect("""
+    try named().expect("""
         SELECT * FROM Emp JOIN Team USING (Id)
         UNION ALL SELECT 9, 99, 'z', 88, 'w'
         """,
@@ -2069,7 +2069,7 @@ struct EngineNaturalUsingTests {
     // The floor: a right arm of the WRONG arity (three columns against the
     // arm's five) still faults `.arity`, so deriving width from the enumeration
     // did not disable the check.
-    try engineNamed().expect("""
+    try named().expect("""
         SELECT * FROM Emp JOIN Team USING (Id) UNION ALL SELECT 1, 2, 3
         """,
         fails: .arity(5, 3))
@@ -2081,7 +2081,7 @@ struct EngineNaturalUsingTests {
     // or 5) that names a real output column — the width there feeds the bound.
     // The width is now 5, so ordinal 5 (`Team`'s `Lead`) type-checks, and the
     // run resolves and sorts by it.
-    let catalog = try engineNamed()
+    let catalog = try named()
     let text = "SELECT * FROM Emp JOIN Team USING (Id) ORDER BY 5"
     _ = try catalog.columns(of: parse(query: text))
     try catalog.expect(text,
@@ -2097,7 +2097,7 @@ struct EngineNaturalUsingTests {
     // `Dept` + `Emp.Name` + `Team.Lead`) — unchanged by deriving width from the
     // enumeration. `columns(of:)` reports 3 and an `ORDER BY 3` resolves while
     // an `ORDER BY 4` faults.
-    let catalog = try engineNamed()
+    let catalog = try named()
     let text = "SELECT * FROM Emp JOIN Team USING (Dept)"
     let columns = try catalog.columns(of: parse(query: text))
     #expect(columns.count == 3)
@@ -2115,7 +2115,7 @@ struct EngineNaturalUsingTests {
 /// against `Emp`'s VIRTUAL `Id` mixes a real and a virtual constituent. `Few`
 /// (one row) RIGHT-joined to `Many` (three rows) `USING (Id)` produces two
 /// right-only rows whose merged `Id` must coalesce to `Many`'s row index.
-private func engineVirtual() throws -> FixtureCatalog {
+private func virtual() throws -> FixtureCatalog {
   try Catalog {
     Relation("Emp", ["Dept": .integer, "Name": .text]) {
       Row(10, "Ann")
@@ -2143,7 +2143,7 @@ private func engineVirtual() throws -> FixtureCatalog {
 /// `(P JOIN Q USING (k)) JOIN R USING (a)` merges `k` at the INNER join and `a`
 /// at the OUTER one — the ISO 7.10 output order is `[a, k, p, q, r]`. `P
 /// NATURAL JOIN Q NATURAL JOIN R` discovers the same common columns.
-private func engineChained() throws -> FixtureCatalog {
+private func chained() throws -> FixtureCatalog {
   try Catalog {
     Relation("P", ["k": .integer, "p": .text]) {
       Row(1, "p1")

--- a/Tests/SQLTests/Queries/EngineSingleRelationTests.swift
+++ b/Tests/SQLTests/Queries/EngineSingleRelationTests.swift
@@ -10,69 +10,69 @@ import SQLTestSupport
 
 struct EngineProjectionTests {
   @Test func `SELECT * yields every real column and excludes the virtual Id`() throws {
-    let rows = try engineRun("SELECT * FROM People WHERE Id = 1")
+    let rows = try answer("SELECT * FROM People WHERE Id = 1")
     // Three real columns; `Id` is virtual and never in `*`.
     #expect(rows == [[.integer(1), .text("Alice"), .integer(30)]])
   }
 
   @Test func `SELECT names yields the named columns in order`() throws {
-    try enginePeople().expect("SELECT Name, Id FROM People WHERE Id = 2",
+    try roster().expect("SELECT Name, Id FROM People WHERE Id = 2",
                         yields: [["Bob", 2]])
   }
 
   @Test func `a named projection may include the virtual Id column`() throws {
-    let rows = try engineRun("SELECT Id, Name FROM People WHERE Name = 'Carol'")
+    let rows = try answer("SELECT Id, Name FROM People WHERE Name = 'Carol'")
     // Carol is the third row; her 1-based `Id` is 3.
     #expect(rows == [[.integer(3), .text("Carol")]])
   }
 
   @Test func `an unknown column is reported`() throws {
     #expect(throws: SQLError.column("Missing")) {
-      try engineRun("SELECT Missing FROM People")
+      try answer("SELECT Missing FROM People")
     }
   }
 
   @Test func `an unknown relation is reported`() throws {
-    try enginePeople().expect("SELECT * FROM Absent", fails: .relation("Absent"))
+    try roster().expect("SELECT * FROM Absent", fails: .relation("Absent"))
   }
 }
 
 struct EngineFilterTests {
   @Test func `equality on a text column`() throws {
-    try enginePeople().expect("SELECT Id FROM People WHERE Name = 'Carol'",
+    try roster().expect("SELECT Id FROM People WHERE Name = 'Carol'",
                         yields: [[3]])
   }
 
   @Test func `a range on the sorted column`() throws {
-    try enginePeople().expect("SELECT Id FROM People WHERE Id >= 4",
+    try roster().expect("SELECT Id FROM People WHERE Id >= 4",
                         yields: [[4], [5]])
   }
 
   @Test func `an AND of a seekable conjunct and a residual`() throws {
-    let rows = try engineRun("SELECT Name FROM People WHERE Id > 1 AND Age = 30")
+    let rows = try answer("SELECT Name FROM People WHERE Id > 1 AND Age = 30")
     #expect(rows == [[.text("Carol")]])
   }
 
   @Test func `an OR scans and admits either side`() throws {
     let rows =
-        try engineRun("SELECT Id FROM People WHERE Id = 1 OR Name = 'Eve'")
+        try answer("SELECT Id FROM People WHERE Id = 1 OR Name = 'Eve'")
     #expect(rows == [[.integer(1)], [.integer(5)]])
   }
 
   @Test func `a NOT scans and negates`() throws {
-    try enginePeople().expect("SELECT Id FROM People WHERE NOT Age = 30",
+    try roster().expect("SELECT Id FROM People WHERE NOT Age = 30",
                         yields: [[2], [4], [5]])
   }
 
   @Test func `a filter on the virtual Id column`() throws {
-    try enginePeople().expect("SELECT Name FROM People WHERE Id = 4",
+    try roster().expect("SELECT Name FROM People WHERE Id = 4",
                         yields: [["Dave"]])
   }
 }
 
 struct EngineOrderTests {
   @Test func `ORDER BY ascending on an integer column`() throws {
-    let rows = try engineRun("SELECT Id FROM People ORDER BY Age ASC")
+    let rows = try answer("SELECT Id FROM People ORDER BY Age ASC")
     // Ages: Bob 25, Eve 25, Alice 30, Carol 30, Dave 40 — a stable sort keeps
     // the scan order within an equal-key group.
     #expect(rows == [[.integer(2)], [.integer(5)], [.integer(1)],
@@ -80,7 +80,7 @@ struct EngineOrderTests {
   }
 
   @Test func `ORDER BY descending on a text column`() throws {
-    let rows = try engineRun("SELECT Name FROM People ORDER BY Name DESC")
+    let rows = try answer("SELECT Name FROM People ORDER BY Name DESC")
     #expect(rows == [[.text("Eve")], [.text("Dave")], [.text("Carol")],
                      [.text("Bob")], [.text("Alice")]])
   }
@@ -89,7 +89,7 @@ struct EngineOrderTests {
 struct EngineCompoundOrderTests {
   @Test func `a single-key ORDER BY still orders as before`() throws {
     // The one-key case is unchanged: ages ascending, ties kept in scan order.
-    let rows = try engineRun("SELECT Id FROM People ORDER BY Age ASC")
+    let rows = try answer("SELECT Id FROM People ORDER BY Age ASC")
     #expect(rows == [[.integer(2)], [.integer(5)], [.integer(1)],
                      [.integer(3)], [.integer(4)]])
   }
@@ -97,7 +97,7 @@ struct EngineCompoundOrderTests {
   @Test func `two keys order by the first, then the second`() throws {
     // Age ascending, ties by Name ascending: {Bob,Eve} at 25 → Bob, Eve;
     // {Alice,Carol} at 30 → Alice, Carol; then Dave.
-    let rows = try engineRun("SELECT Name FROM People ORDER BY Age, Name")
+    let rows = try answer("SELECT Name FROM People ORDER BY Age, Name")
     #expect(rows == [[.text("Bob")], [.text("Eve")], [.text("Alice")],
                      [.text("Carol")], [.text("Dave")]])
   }
@@ -106,7 +106,7 @@ struct EngineCompoundOrderTests {
     // Age descending, ties by Name ascending: Dave(40); Alice, Carol (30);
     // Bob, Eve (25).
     let rows =
-        try engineRun("SELECT Name FROM People ORDER BY Age DESC, Name ASC")
+        try answer("SELECT Name FROM People ORDER BY Age DESC, Name ASC")
     #expect(rows == [[.text("Dave")], [.text("Alice")], [.text("Carol")],
                      [.text("Bob")], [.text("Eve")]])
   }
@@ -115,7 +115,7 @@ struct EngineCompoundOrderTests {
     // Age ascending leaves {Bob,Eve} and {Alice,Carol} tied; a DESC Name key
     // reorders each pair against the scan order (Eve before Bob, Carol before
     // Alice) — proof the second key, not the input order, settles the ties.
-    let rows = try engineRun("SELECT Name FROM People ORDER BY Age ASC, Name DESC")
+    let rows = try answer("SELECT Name FROM People ORDER BY Age ASC, Name DESC")
     #expect(rows == [[.text("Eve")], [.text("Bob")], [.text("Carol")],
                      [.text("Alice")], [.text("Dave")]])
   }
@@ -124,7 +124,7 @@ struct EngineCompoundOrderTests {
     // Class ascending, Score ascending, Name ascending. Class A: Bob(70), then
     // the 80s by Name — Ada, Mel, Yan. Class B: both 90, by Name — Amy, Zed.
     let rows =
-        try engineGrades("SELECT Id FROM Grade ORDER BY Class, Score, Name")
+        try grades("SELECT Id FROM Grade ORDER BY Class, Score, Name")
     #expect(rows == [[.integer(6)], [.integer(3)], [.integer(5)],
                      [.integer(2)], [.integer(4)], [.integer(1)]])
   }
@@ -132,7 +132,7 @@ struct EngineCompoundOrderTests {
   @Test func `a compound ORDER BY is stable across all keys`() throws {
     // Class and Score alone leave the three Class-A/Score-80 rows tied; with no
     // further key the sort keeps their scan order — Yan(2), Ada(3), Mel(5).
-    let rows = try engineGrades("SELECT Id FROM Grade ORDER BY Class, Score")
+    let rows = try grades("SELECT Id FROM Grade ORDER BY Class, Score")
     #expect(rows == [[.integer(6)], [.integer(2)], [.integer(3)],
                      [.integer(5)], [.integer(1)], [.integer(4)]])
   }
@@ -140,7 +140,7 @@ struct EngineCompoundOrderTests {
   @Test func `FETCH takes the top-N of a compound order`() throws {
     // Age descending, ties by Name ascending, then the first two rows: Dave(40)
     // and the lower-named of the 30s, Alice.
-    try enginePeople().expect("""
+    try roster().expect("""
         SELECT Name FROM People
           ORDER BY Age DESC, Name ASC FETCH FIRST 2 ROWS ONLY
         """,
@@ -149,7 +149,7 @@ struct EngineCompoundOrderTests {
 
   @Test func `OFFSET then FETCH pages into a compound order`() throws {
     // The full compound order is Dave, Alice, Carol, Bob, Eve; skip 1, take 2.
-    try enginePeople().expect("""
+    try roster().expect("""
         SELECT Name FROM People
           ORDER BY Age DESC, Name ASC OFFSET 1 ROWS FETCH NEXT 2 ROWS ONLY
         """,
@@ -162,7 +162,7 @@ struct EngineProjectionPushdownTests {
     // The relation has ten columns; the query reads only C0 (filter, project),
     // C5 (project), and C8 (order). The leaf materialises just those, but the
     // result is exactly as if every column were copied.
-    try engineWide().expect("""
+    try wide().expect("""
         SELECT C5, C0 FROM Wide WHERE C0 >= 10 ORDER BY C8 DESC
         """,
         yields: [[35, 30], [25, 20], [15, 10]])
@@ -173,11 +173,11 @@ struct EngineSeekTests {
   @Test func `the seek path and the scan path return identical results`() throws {
     // `Id >= 2` seeks the sorted column; the same selection by `Name` (which
     // `bound` reports unseekable) scans. Both must yield the same rows.
-    let seek = try engineRun("SELECT Id FROM People WHERE Id >= 2 AND Id <= 4")
+    let seek = try answer("SELECT Id FROM People WHERE Id >= 2 AND Id <= 4")
     #expect(seek == [[.integer(2)], [.integer(3)], [.integer(4)]])
 
     let scan =
-        try engineRun("SELECT Id FROM People WHERE Name >= 'Bob' AND Name <= 'Dave'")
+        try answer("SELECT Id FROM People WHERE Name >= 'Bob' AND Name <= 'Dave'")
     #expect(scan == seek)
   }
 }
@@ -205,7 +205,7 @@ struct EngineCodedKeyTests {
     // `Id` is `< 5` (td1, td2, td4) — never the other-tag rows (other-a, -b,
     // -c), which decode to NULL. Before the fix the raw boundary
     // `0 ..< bound(5)` seeked the low raw run, sweeping in the interleaved NULLs.
-    let rows = try engineAttributes("SELECT Name FROM Attribute WHERE Parent < 5")
+    let rows = try attributes("SELECT Name FROM Attribute WHERE Parent < 5")
     #expect(rows == [[.text("td1")], [.text("td2")], [.text("td4")]])
   }
 
@@ -213,8 +213,8 @@ struct EngineCodedKeyTests {
     // The seek path (`Parent < 5`) must equal a filter that cannot seek at all
     // (`Name < 'z'` over the same rows, restricted to the tagged ones) — i.e.
     // the range yields exactly the rows a full scan-and-filter would.
-    let seek = try engineAttributes("SELECT Name FROM Attribute WHERE Parent < 5")
-    let scan = try engineAttributes("""
+    let seek = try attributes("SELECT Name FROM Attribute WHERE Parent < 5")
+    let scan = try attributes("""
         SELECT Name FROM Attribute WHERE Parent < 5 AND Name < 'z'
         """)
     #expect(seek == scan)
@@ -224,7 +224,7 @@ struct EngineCodedKeyTests {
     // Equality is always seekable — the exact coded run brackets exactly the
     // rows that decode to the value, and a join rechecks — so `Parent = 4`
     // returns just td4.
-    let rows = try engineAttributes("SELECT Name FROM Attribute WHERE Parent = 4")
+    let rows = try attributes("SELECT Name FROM Attribute WHERE Parent = 4")
     #expect(rows == [[.text("td4")]])
   }
 
@@ -236,7 +236,7 @@ struct EngineCodedKeyTests {
     // residual recheck, leaking the null-reference row. The fix returns `nil`
     // for a non-positive decoded Id, so the query scans and filters, and the
     // decoded `NULL` correctly fails `= 0`.
-    let rows = try engineAttributes("SELECT Name FROM Attribute WHERE Parent = 0")
+    let rows = try attributes("SELECT Name FROM Attribute WHERE Parent = 0")
     #expect(rows.isEmpty)
   }
 
@@ -252,26 +252,26 @@ struct EngineCodedKeyTests {
     // value — and admits nothing.
     let alias = (1 << 62) + 6
     let rows =
-        try engineAttributes("SELECT Name FROM Attribute WHERE Parent = \(alias)")
+        try attributes("SELECT Name FROM Attribute WHERE Parent = \(alias)")
     #expect(rows.isEmpty)
   }
 
   @Test func `an equality plans a seek, a range plans a scan-and-filter`() throws {
     // The plan shape proves the gate directly: equality reaches a seeked scan
     // with no residual filter; a range reaches a raw scan under a filter.
-    let catalog = engineAttributes()
+    let catalog = attributes()
 
-    let equal = try engineParse("SELECT Name FROM Attribute WHERE Parent = 4")
+    let equal = try parse("SELECT Name FROM Attribute WHERE Parent = 4")
     let equalPlan =
         try catalog.optimise(catalog.compile(equal), [:])
-    #expect(engineSeeks(equalPlan))
-    #expect(!engineFilters(equalPlan))
+    #expect(sought(equalPlan))
+    #expect(!filters(equalPlan))
 
-    let less = try engineParse("SELECT Name FROM Attribute WHERE Parent < 5")
+    let less = try parse("SELECT Name FROM Attribute WHERE Parent < 5")
     let lessPlan =
         try catalog.optimise(catalog.compile(less), [:])
-    #expect(!engineSeeks(lessPlan))
-    #expect(engineFilters(lessPlan))
+    #expect(!sought(lessPlan))
+    #expect(filters(lessPlan))
   }
 
   @Test func `a sorted key with a leading NULL does not seek it into an equality`() throws {
@@ -297,9 +297,9 @@ struct EngineCodedKeyTests {
         Row(2)
       }
     }
-    let query = try engineParse("SELECT * FROM T WHERE Id = 1")
+    let query = try parse("SELECT * FROM T WHERE Id = 1")
     let plan = try catalog.optimise(catalog.compile(query), [:])
-    #expect(engineSeeks(plan))
+    #expect(sought(plan))
   }
 
   @Test func `an empty sorted fixture still plans a seek`() throws {
@@ -308,20 +308,20 @@ struct EngineCodedKeyTests {
     let catalog = try Catalog {
       Relation("T", ["Id": .integer], sorted: "Id")
     }
-    let query = try engineParse("SELECT * FROM T WHERE Id = 1")
+    let query = try parse("SELECT * FROM T WHERE Id = 1")
     let plan = try catalog.optimise(catalog.compile(query), [:])
-    #expect(engineSeeks(plan))
+    #expect(sought(plan))
   }
 }
 
 struct EngineQualifierTests {
   @Test func `a qualifier matching the alias resolves the column`() throws {
-    try enginePeople().expect("SELECT p.Name FROM People AS p WHERE Id = 1",
+    try roster().expect("SELECT p.Name FROM People AS p WHERE Id = 1",
                         yields: [["Alice"]])
   }
 
   @Test func `a qualifier matching the table name resolves the column`() throws {
-    try enginePeople().expect("SELECT People.Name FROM People WHERE Id = 1",
+    try roster().expect("SELECT People.Name FROM People WHERE Id = 1",
                         yields: [["Alice"]])
   }
 
@@ -329,7 +329,7 @@ struct EngineQualifierTests {
     // `x` names neither the alias `p` nor the table `People`; a single-relation
     // query rejects it rather than dropping the qualifier and binding `Name`.
     #expect(throws: SQLError.column("Name")) {
-      try engineRun("SELECT x.Name FROM People AS p")
+      try answer("SELECT x.Name FROM People AS p")
     }
   }
 
@@ -350,7 +350,7 @@ struct EngineQualifierTests {
     // The reviewer's case: `Child.Name` against `FROM Parent` must not resolve
     // to `Parent`'s `Name`; the qualifier names a relation not in scope.
     #expect(throws: SQLError.column("Name")) {
-      try engineJoin("SELECT Child.Name FROM Parent")
+      try join("SELECT Child.Name FROM Parent")
     }
   }
 }

--- a/Tests/SQLTests/Queries/EngineTestSupport.swift
+++ b/Tests/SQLTests/Queries/EngineTestSupport.swift
@@ -24,7 +24,7 @@ typealias EngineMemory = FixtureCatalog
 // MARK: - Fixtures
 
 /// The single-relation catalog: a `People` relation sorted on its `Id` column.
-func enginePeople() throws -> EngineMemory {
+func roster() throws -> EngineMemory {
   try Catalog {
     Relation("People", ["Id": .integer, "Name": .text, "Age": .integer],
              sorted: "Id") {
@@ -42,7 +42,7 @@ func enginePeople() throws -> EngineMemory {
 /// Class, Score, Name` needs the third key to settle rows the first two leave
 /// equal. The rows are stored out of every non-`Id` order, so a sort is never a
 /// no-op.
-func engineGrades() throws -> EngineMemory {
+func grades() throws -> EngineMemory {
   try Catalog {
     Relation("Grade", ["Id": .integer, "Class": .text, "Score": .integer,
                        "Name": .text], sorted: "Id") {
@@ -70,7 +70,7 @@ func engineGrades() throws -> EngineMemory {
 /// The `Parent` column is seekable-but-unordered, so it is built directly as a
 /// `FixtureRelation` with `coded: 0` — the seekable-unordered marker the fluent
 /// `Relation` (whose only marker is `sorted:`) does not spell.
-func engineAttributes() -> EngineMemory {
+func attributes() -> EngineMemory {
   let fields = [
     EngineField(name: "Parent", type: .integer),
     EngineField(name: "Name", type: .text),
@@ -101,7 +101,7 @@ func engineAttributes() -> EngineMemory {
 ///
 /// The ten columns and four rows are generated, so it is built directly as a
 /// `FixtureRelation` rather than a literal-per-row fluent `Relation`.
-func engineWide() -> EngineMemory {
+func wide() -> EngineMemory {
   let fields = (0 ..< 10).map { EngineField(name: "C\($0)", type: .integer) }
   let records = (0 ..< 4).map { row in
     (0 ..< 10).map { Value.integer(row * 10 + $0) }
@@ -113,7 +113,7 @@ func engineWide() -> EngineMemory {
 /// `ParentUnsorted` (same rows, no seekable column), and a `Child` relation
 /// whose `Pid` is a foreign key to a parent `Id`. The `Ordered` relation has no
 /// stored key — a join on it keys off its virtual `Id`.
-func engineFamily() throws -> EngineMemory {
+func family() throws -> EngineMemory {
   try Catalog {
     Relation("Parent", ["Id": .integer, "Name": .text], sorted: "Id") {
       Row(1, "Ada")
@@ -144,7 +144,7 @@ func engineFamily() throws -> EngineMemory {
 /// (a single-relation projection over `Parent`) and `Pairs` (a projection over
 /// the `Parent`/`Child` foreign-key join). A view is queried like a table, and
 /// `Pairs` proves a view whose definition is itself a join.
-func engineViews() throws -> EngineMemory {
+func gallery() throws -> EngineMemory {
   // Registered over the `family` relations, so the view bodies resolve their
   // `Parent`/`Child` against the same base tables the other join tests use.
   let catalog = try Catalog {
@@ -161,12 +161,12 @@ func engineViews() throws -> EngineMemory {
     try View("Picked", "SELECT Id, Name FROM Parent WHERE Id = :id",
              as: ["Key", "Label"])
   }
-  return EngineMemory(try engineFamily().catalog, views: catalog.registered)
+  return EngineMemory(try family().catalog, views: catalog.registered)
 }
 
 /// A catalog with NULL cells: a `Maybe` relation whose `Note` text column is
 /// `NULL` in some rows, to exercise three-valued comparison and `IS [NOT] NULL`.
-func engineNullable() throws -> EngineMemory {
+func sparse() throws -> EngineMemory {
   try Catalog {
     Relation("Maybe", ["Id": .integer, "Note": .text]) {
       Row(1, "alpha")
@@ -179,7 +179,7 @@ func engineNullable() throws -> EngineMemory {
 
 /// The null-key join catalog: a `Parent` sorted on `Id` and a `Child` one of
 /// whose foreign keys is `NULL`, to prove a `NULL` join key matches nothing.
-func engineNullableKeys() throws -> EngineMemory {
+func orphans() throws -> EngineMemory {
   try Catalog {
     Relation("Parent", ["Id": .integer, "Name": .text], sorted: "Id") {
       Row(1, "Ada")
@@ -196,7 +196,7 @@ func engineNullableKeys() throws -> EngineMemory {
 /// A three-level catalog for multi-way joins: `House` → `Room` → `Item`, each
 /// child carrying a foreign key to its parent's `Id`. `House` and `Room` are
 /// sorted on `Id`, so a join keyed on `Id` seeks; `Item` is unsorted and scans.
-func engineLineage() throws -> EngineMemory {
+func lineage() throws -> EngineMemory {
   try Catalog {
     Relation("House", ["Id": .integer, "House": .text], sorted: "Id") {
       Row(1, "Burrow")
@@ -227,7 +227,7 @@ func engineLineage() throws -> EngineMemory {
 /// Resolving the match against the prefix binds `Code` unambiguously; resolving
 /// it against the whole chain would (wrongly) see `Code` in two relations and
 /// report `SQLError.ambiguous`.
-func engineShared() throws -> EngineMemory {
+func shared() throws -> EngineMemory {
   try Catalog {
     Relation("Author", ["Aid": .integer, "Code": .integer], sorted: "Aid") {
       Row(1, 10)
@@ -245,46 +245,46 @@ func engineShared() throws -> EngineMemory {
 }
 
 /// Parses `text` to a query, failing on any other statement.
-func engineSelect(_ text: String) throws -> Query {
-  try engineParse(text)
+func select(_ text: String) throws -> Query {
+  try parse(text)
 }
 
 /// Parses `text` to a query, failing on any other statement.
-func engineParse(_ text: String) throws -> Query {
+func parse(_ text: String) throws -> Query {
   try parse(query: text)
 }
 
 /// Runs `text` against the single-relation `People` catalog.
-func engineRun(_ text: String) throws -> Array<Array<Value>> {
-  try enginePeople().run(engineParse(text))
+func answer(_ text: String) throws -> Array<Array<Value>> {
+  try roster().run(parse(text))
 }
 
 /// Runs `text` against the compound-ordering `Grade` catalog.
-func engineGrades(_ text: String) throws -> Array<Array<Value>> {
-  try engineGrades().run(engineParse(text))
+func grades(_ text: String) throws -> Array<Array<Value>> {
+  try grades().run(parse(text))
 }
 
 /// Runs `text` against the coded-key `Attribute` catalog.
-func engineAttributes(_ text: String) throws -> Array<Array<Value>> {
-  try engineAttributes().run(engineParse(text))
+func attributes(_ text: String) throws -> Array<Array<Value>> {
+  try attributes().run(parse(text))
 }
 
 /// Runs `text` against the join `family` catalog.
-func engineJoin(_ text: String) throws -> Array<Array<Value>> {
-  try engineFamily().run(engineParse(text))
+func join(_ text: String) throws -> Array<Array<Value>> {
+  try family().run(parse(text))
 }
 
 /// Runs `text` against the view catalog.
-func engineView(_ text: String) throws -> Array<Array<Value>> {
-  try engineViews().run(engineParse(text))
+func view(_ text: String) throws -> Array<Array<Value>> {
+  try gallery().run(parse(text))
 }
 
-/// Runs `text` against the nullable `Maybe` catalog.
-func engineNullable(_ text: String) throws -> Array<Array<Value>> {
-  try engineNullable().run(engineParse(text))
+/// Runs `text` against the sparse `Maybe` catalog.
+func sparse(_ text: String) throws -> Array<Array<Value>> {
+  try sparse().run(parse(text))
 }
 
 /// Runs `text` against the three-level `lineage` catalog.
-func engineLineage(_ text: String) throws -> Array<Array<Value>> {
-  try engineLineage().run(engineParse(text))
+func lineage(_ text: String) throws -> Array<Array<Value>> {
+  try lineage().run(parse(text))
 }

--- a/Tests/SQLTests/Queries/EngineValueAndSetTests.swift
+++ b/Tests/SQLTests/Queries/EngineValueAndSetTests.swift
@@ -43,14 +43,14 @@ private let kNullable: Array<Selection> = [
 struct EngineNullTests {
   @Test(arguments: kNullable)
   fileprivate func runs(_ test: Selection) throws {
-    #expect(try engineNullable(test.text) == test.expected)
+    #expect(try sparse(test.text) == test.expected)
   }
 
   @Test func `a NULL outer join key matches no inner row`() throws {
     // The child with a NULL foreign key is the outer row; a NULL key equi-joins
     // to nothing, so it contributes no pair — `Parent` is sorted, so the inner
     // is seeked and the NULL key is skipped before probing.
-    let rows = try engineNullableKeys().run(engineParse("""
+    let rows = try orphans().run(parse("""
         SELECT Child.Name, Parent.Name FROM Child
           JOIN Parent ON Parent.Id = Child.Pid
         """))
@@ -66,7 +66,7 @@ struct EngineNullTests {
 /// Runs `text` against the `family` catalog with the given parameter bindings.
 private func boundRun(_ text: String, _ bindings: Bindings)
     throws -> Array<Array<Value>> {
-  try engineFamily().run(engineParse(text), Routines(), bindings: bindings)
+  try family().run(parse(text), Routines(), bindings: bindings)
 }
 
 private struct Binding: Sendable, CustomTestStringConvertible {
@@ -110,9 +110,9 @@ struct EngineBoundTests {
     // yields the parents; for each, the child query is re-run with the parent's
     // key bound, producing that parent's children — exactly an interface →
     // methods expansion.
-    let catalog = try engineFamily()
-    let parents = try catalog.run(engineParse("SELECT Id, Name FROM Parent"))
-    let query = try engineParse("SELECT Name FROM Child WHERE Pid = :pid")
+    let catalog = try family()
+    let parents = try catalog.run(parse("SELECT Id, Name FROM Parent"))
+    let query = try parse("SELECT Name FROM Child WHERE Pid = :pid")
 
     var sections = Array<(parent: String, children: Array<String>)>()
     for parent in parents {
@@ -137,34 +137,34 @@ struct EngineBoundTests {
   @Test func `a bound key plans a seek when its value is known`() throws {
     // Parent is sorted on Id; with `:id` bound the planner resolves it and
     // seeks the run rather than scanning and filtering the whole relation.
-    let select = try engineParse("SELECT Name FROM Parent WHERE Id = :id")
-    let catalog = try engineFamily()
+    let select = try parse("SELECT Name FROM Parent WHERE Id = :id")
+    let catalog = try family()
     let plan = try catalog.optimise(catalog.compile(select),
                                     ["id": .integer(2)])
-    #expect(engineSeeks(plan))
-    #expect(!engineFilters(plan))
+    #expect(sought(plan))
+    #expect(!filters(plan))
   }
 
   @Test func `an unbound key cannot seek and scans under the filter`() throws {
-    let select = try engineParse("SELECT Name FROM Parent WHERE Id = :id")
-    let catalog = try engineFamily()
+    let select = try parse("SELECT Name FROM Parent WHERE Id = :id")
+    let catalog = try family()
     let compiled = try catalog.compile(select)
     let plan = try catalog.optimise(compiled, [:])
-    #expect(!engineSeeks(plan))
-    #expect(engineFilters(plan))
+    #expect(!sought(plan))
+    #expect(filters(plan))
   }
 
   @Test func `a bound key inside a view seeks when its parameter is supplied`() throws {
     // A parameterized view (`… WHERE Id = :id` over sorted Parent): the bound
     // key seeks inside the view's sub-plan rather than scanning it once :id is
     // supplied, so a reusable view is as fast as the inlined query.
-    let select = try engineParse("SELECT Key, Label FROM Picked")
-    let catalog = try engineViews()
+    let select = try parse("SELECT Key, Label FROM Picked")
+    let catalog = try gallery()
     let plan = try catalog.optimise(catalog.compile(select),
                                     ["id": .integer(2)])
-    let sub = try #require(engineDerived(plan))
-    #expect(engineSeeks(sub))
-    #expect(!engineFilters(sub))
+    let sub = try #require(derived(plan))
+    #expect(sought(sub))
+    #expect(!filters(sub))
   }
 }
 
@@ -178,7 +178,7 @@ struct EngineBoundTests {
 ///
 /// The relations are `Lhs`/`Rhs` rather than `Left`/`Right`, now that the
 /// latter are reserved outer-join keywords.
-func engineTags() -> EngineMemory {
+func tags() -> EngineMemory {
   let fields = [EngineField(name: "Tag", type: .text)]
   let left = [
     [.text("a")],
@@ -202,14 +202,14 @@ struct EngineUnionTests {
   @Test func `UNION removes whole-row duplicates, keeping the first occurrence`() throws {
     // People's Age repeats (30 for Alice and Carol, 25 for Bob and Eve); a
     // UNION of the relation with itself collapses every duplicate row.
-    let rows = try enginePeople().run(engineParse("""
+    let rows = try roster().run(parse("""
         SELECT Age FROM People UNION SELECT Age FROM People
         """))
     #expect(rows == [[.integer(30)], [.integer(25)], [.integer(40)]])
   }
 
   @Test func `UNION ALL keeps every row of every arm in source order`() throws {
-    let rows = try enginePeople().run(engineParse("""
+    let rows = try roster().run(parse("""
         SELECT Age FROM People UNION ALL SELECT Age FROM People
         """))
     let ages = [30, 25, 30, 40, 25].map { Value.integer($0) }
@@ -217,7 +217,7 @@ struct EngineUnionTests {
   }
 
   @Test func `a UNION across two relations of matching arity merges and dedups`() throws {
-    let rows = try engineTags().run(engineParse("""
+    let rows = try tags().run(parse("""
         SELECT Tag FROM Lhs UNION SELECT Tag FROM Rhs
         """))
     // `shared` appears in both arms but survives once, first occurrence kept.
@@ -225,7 +225,7 @@ struct EngineUnionTests {
   }
 
   @Test func `a UNION ALL across two relations keeps the shared row twice`() throws {
-    let rows = try engineTags().run(engineParse("""
+    let rows = try tags().run(parse("""
         SELECT Tag FROM Lhs UNION ALL SELECT Tag FROM Rhs
         """))
     #expect(rows == [
@@ -242,7 +242,7 @@ struct EngineUnionTests {
     // ALL then appends Extra's `a` WITHOUT deduplicating, so `a` recurs. A
     // chain flattened to the trailing `all` would instead keep both copies of
     // `shared`; honouring each node's own flag keeps exactly one.
-    let rows = try engineTags().run(engineParse("""
+    let rows = try tags().run(parse("""
         SELECT Tag FROM Lhs UNION SELECT Tag FROM Rhs
           UNION ALL SELECT Tag FROM Extra
         """))
@@ -256,18 +256,18 @@ struct EngineUnionTests {
 
   @Test func `a UNION of arms projecting differing column counts is rejected`() throws {
     #expect(throws: SQLError.arity(1, 2)) {
-      try enginePeople().run(engineParse("""
+      try roster().run(parse("""
           SELECT Id FROM People UNION SELECT Id, Name FROM People
           """))
     }
   }
 
   @Test func `a view defined as a UNION resolves and queries`() throws {
-    let both = try View(query: engineSelect("""
+    let both = try View(query: select("""
         SELECT Tag FROM Lhs UNION SELECT Tag FROM Rhs
         """), columns: ["Tag"])
-    let catalog = EngineMemory(engineTags().catalog, views: ["Both": both])
-    let rows = try catalog.run(engineParse("SELECT Tag FROM Both"))
+    let catalog = EngineMemory(tags().catalog, views: ["Both": both])
+    let rows = try catalog.run(parse("SELECT Tag FROM Both"))
     #expect(rows == [[.text("a")], [.text("shared")], [.text("b")]])
   }
 
@@ -280,11 +280,11 @@ struct EngineUnionTests {
     // Schema from the body carrier through `Schema(from:)`, so the `Scope`
     // reader reports the column unconstrained and the outer fold skips its type,
     // exactly as it skips a fresh constant-NULL arm.
-    let view = try View(query: engineSelect("""
+    let view = try View(query: select("""
         SELECT NULLIF(1, 1) AS x UNION SELECT NULLIF('b', 'b')
         """), columns: ["x"])
-    let catalog = EngineMemory(engineTags().catalog, views: ["V": view])
-    let rows = try catalog.run(engineParse("SELECT x FROM V UNION SELECT 'c'"))
+    let catalog = EngineMemory(tags().catalog, views: ["V": view])
+    let rows = try catalog.run(parse("SELECT x FROM V UNION SELECT 'c'"))
     #expect(rows == [[.null], [.text("c")]])
   }
 
@@ -310,11 +310,11 @@ struct EngineUnionTests {
       "A": FixtureRelation(integers, a),
       "B": FixtureRelation(doubles, b),
     ])
-    let view = try View(query: engineSelect("""
+    let view = try View(query: select("""
         SELECT x FROM A UNION ALL SELECT x FROM B
         """), columns: ["x"])
     let memory = EngineMemory(base.catalog, views: ["V": view])
-    let rows = try memory.run(engineParse("""
+    let rows = try memory.run(parse("""
         SELECT x FROM V WHERE x = 9007199254740992
         """))
     #expect(rows == [[.double(9007199254740992.0)],
@@ -324,7 +324,7 @@ struct EngineUnionTests {
   @Test func `a bound parameter threads into every arm of a UNION`() throws {
     // Both arms key on the same `:pid`; the binding reaches each alike, so the
     // union is the parent's children drawn from two queries over the relation.
-    let rows = try engineFamily().run(engineParse("""
+    let rows = try family().run(parse("""
         SELECT Name FROM Child WHERE Pid = :pid
           UNION ALL SELECT Name FROM Child WHERE Pid = :pid
         """), Routines(), bindings: ["pid": .integer(1)])
@@ -360,7 +360,7 @@ struct EngineIntersectExceptTests {
   @Test func `INTERSECT keeps the distinct rows present in both arms`() throws {
     // `2` and `3` occur in both A and B; the distinct INTERSECT keeps each
     // once, in A's (left) order, and drops A-only `1`/`4` and B-only `5`.
-    let rows = try multiset().run(engineParse("""
+    let rows = try multiset().run(parse("""
         SELECT N FROM A INTERSECT SELECT N FROM B
         """))
     #expect(rows == [[.integer(2)], [.integer(3)]])
@@ -369,7 +369,7 @@ struct EngineIntersectExceptTests {
   @Test func `INTERSECT ALL keeps each common row to the lesser multiplicity`() throws {
     // A holds `2` thrice and B twice, so INTERSECT ALL keeps `min(3, 2)` = two;
     // `3` is once in each, so one — every occurrence in A's order.
-    let rows = try multiset().run(engineParse("""
+    let rows = try multiset().run(parse("""
         SELECT N FROM A INTERSECT ALL SELECT N FROM B
         """))
     #expect(rows == [[.integer(2)], [.integer(2)], [.integer(3)]])
@@ -378,7 +378,7 @@ struct EngineIntersectExceptTests {
   @Test func `EXCEPT keeps the distinct left rows absent from the right`() throws {
     // A's distinct rows not in B are `1` and `4`; `2`/`3` are removed (present
     // in B), first occurrence order preserved.
-    let rows = try multiset().run(engineParse("""
+    let rows = try multiset().run(parse("""
         SELECT N FROM A EXCEPT SELECT N FROM B
         """))
     #expect(rows == [[.integer(1)], [.integer(4)]])
@@ -388,7 +388,7 @@ struct EngineIntersectExceptTests {
     // A: 1,1,2,2,2,3,4. B removes one `2` per its two copies (leaving one `2`)
     // and its one `3` (leaving none); `1` (twice) and `4` are untouched — every
     // survivor in A's order.
-    let rows = try multiset().run(engineParse("""
+    let rows = try multiset().run(parse("""
         SELECT N FROM A EXCEPT ALL SELECT N FROM B
         """))
     #expect(rows == [
@@ -401,10 +401,10 @@ struct EngineIntersectExceptTests {
 
   @Test func `INTERSECT binds tighter than UNION`() throws {
     // `A UNION B INTERSECT C` is `A UNION (B INTERSECT C)` per ISO precedence.
-    // Here the reused `engineTags()` relations give `B INTERSECT C` = `Rhs INTERSECT
+    // Here the reused `tags()` relations give `B INTERSECT C` = `Rhs INTERSECT
     // Extra`: Rhs is {shared, b}, Extra is {a}, so the intersection is empty
     // and the whole result is just Lhs's distinct rows.
-    let rows = try engineTags().run(engineParse("""
+    let rows = try tags().run(parse("""
         SELECT Tag FROM Lhs
           UNION SELECT Tag FROM Rhs
           INTERSECT SELECT Tag FROM Extra
@@ -417,7 +417,7 @@ struct EngineIntersectExceptTests {
     // {a, shared, b}; EXCEPT Extra ({a}) removes `a`, leaving {shared, b}. A
     // right-associative reading — `A UNION (B EXCEPT C)` — would instead keep
     // `a` (from Lhs), so the result proves the left grouping.
-    let rows = try engineTags().run(engineParse("""
+    let rows = try tags().run(parse("""
         SELECT Tag FROM Lhs
           UNION SELECT Tag FROM Rhs
           EXCEPT SELECT Tag FROM Extra
@@ -427,7 +427,7 @@ struct EngineIntersectExceptTests {
 
   @Test func `INTERSECT of arms projecting differing column counts is rejected`() throws {
     #expect(throws: SQLError.arity(1, 2)) {
-      try enginePeople().run(engineParse("""
+      try roster().run(parse("""
           SELECT Id FROM People INTERSECT SELECT Id, Name FROM People
           """))
     }
@@ -435,18 +435,18 @@ struct EngineIntersectExceptTests {
 
   @Test func `EXCEPT of arms projecting differing column counts is rejected`() throws {
     #expect(throws: SQLError.arity(2, 1)) {
-      try enginePeople().run(engineParse("""
+      try roster().run(parse("""
           SELECT Id, Name FROM People EXCEPT SELECT Id FROM People
           """))
     }
   }
 
   @Test func `a view defined as an EXCEPT resolves and queries`() throws {
-    let diff = try View(query: engineSelect("""
+    let diff = try View(query: select("""
         SELECT N FROM A EXCEPT SELECT N FROM B
         """), columns: ["N"])
     let catalog = EngineMemory(multiset().catalog, views: ["Diff": diff])
-    let rows = try catalog.run(engineParse("SELECT N FROM Diff"))
+    let rows = try catalog.run(parse("SELECT N FROM Diff"))
     #expect(rows == [[.integer(1)], [.integer(4)]])
   }
 }
@@ -457,17 +457,17 @@ struct EngineDistinctTests {
   @Test func `DISTINCT removes duplicate rows, keeping the first occurrence`() throws {
     // People's Age repeats (30 for Alice and Carol, 25 for Bob and Eve);
     // DISTINCT collapses each duplicate to its first appearance, in row order.
-    try enginePeople().expect("SELECT DISTINCT Age FROM People",
+    try roster().expect("SELECT DISTINCT Age FROM People",
                         yields: [[30], [25], [40]])
   }
 
   @Test func `a plain SELECT keeps every duplicate row`() throws {
-    try enginePeople().expect("SELECT Age FROM People",
+    try roster().expect("SELECT Age FROM People",
                         yields: [[30], [25], [30], [40], [25]])
   }
 
   @Test func `SELECT ALL is the plain, non-deduplicating select`() throws {
-    try enginePeople().expect("SELECT ALL Age FROM People",
+    try roster().expect("SELECT ALL Age FROM People",
                         yields: [[30], [25], [30], [40], [25]])
   }
 
@@ -475,14 +475,14 @@ struct EngineDistinctTests {
     // Grade's (Class, Score) pairs repeat — (A, 80) three times, (B, 90)
     // twice — while a single column would over-collapse. DISTINCT keeps one of
     // each distinct pair, first occurrence in row order.
-    try engineGrades().expect("SELECT DISTINCT Class, Score FROM Grade",
+    try grades().expect("SELECT DISTINCT Class, Score FROM Grade",
                         yields: [["B", 90], ["A", 80], ["A", 70]])
   }
 
   @Test func `DISTINCT dedups rows a projection maps together`() throws {
     // Bob (25) and Eve (25), Alice (30) and Carol (30) share an Age; projecting
     // Age alone collapses each pair even though their other columns differ.
-    try enginePeople().expect("SELECT DISTINCT Age FROM People WHERE Age < 40",
+    try roster().expect("SELECT DISTINCT Age FROM People WHERE Age < 40",
                         yields: [[30], [25]])
   }
 
@@ -490,7 +490,7 @@ struct EngineDistinctTests {
     // DISTINCT is a per-SELECT quantifier: it dedups the LEFT arm alone (its
     // repeated Ages collapse to 30, 25, 40), then the UNION ALL appends the
     // right arm's rows without deduplicating across the arms.
-    try enginePeople().expect("""
+    try roster().expect("""
         SELECT DISTINCT Age FROM People
           UNION ALL SELECT Age FROM People WHERE Id = 1
         """, yields: [[30], [25], [40], [30]])
@@ -499,14 +499,14 @@ struct EngineDistinctTests {
   @Test func `DISTINCT combines with ORDER BY, ordering the deduplicated rows`() throws {
     // The distinct Ages, then ascending: dedup keeps 30, 25, 40; ORDER BY sorts
     // them 25, 30, 40.
-    try enginePeople().expect("SELECT DISTINCT Age FROM People ORDER BY Age",
+    try roster().expect("SELECT DISTINCT Age FROM People ORDER BY Age",
                         yields: [[25], [30], [40]])
   }
 
   @Test func `DISTINCT dedups before OFFSET/FETCH pages the result`() throws {
     // Three distinct Ages ordered 25, 30, 40; FETCH FIRST 2 pages the
     // deduplicated, ordered rows — proving the cap sits above the dedup.
-    try enginePeople().expect("""
+    try roster().expect("""
         SELECT DISTINCT Age FROM People ORDER BY Age FETCH FIRST 2 ROWS ONLY
         """, yields: [[25], [30]])
   }
@@ -515,22 +515,22 @@ struct EngineDistinctTests {
     // Grouping People by Age yields one row per distinct Age (25, 30, 40), each
     // with its COUNT; projecting only the COUNT leaves 2, 2, 1 — DISTINCT then
     // collapses the two 2s to one.
-    try enginePeople().expect("""
+    try roster().expect("""
         SELECT DISTINCT COUNT(*) FROM People GROUP BY Age
         """, yields: [[2], [1]])
   }
 
   @Test func `a view defined with DISTINCT deduplicates when queried`() throws {
-    let ages = try View(query: engineSelect("SELECT DISTINCT Age FROM People"),
+    let ages = try View(query: select("SELECT DISTINCT Age FROM People"),
                         columns: ["Age"])
-    let catalog = EngineMemory(try enginePeople().catalog, views: ["Ages": ages])
+    let catalog = EngineMemory(try roster().catalog, views: ["Ages": ages])
     try catalog.expect("SELECT Age FROM Ages", yields: [[30], [25], [40]])
   }
 
   @Test func `DISTINCT ordering on a non-projected column faults`() throws {
     // Name is not in the DISTINCT output, so after dedup each Age stands for
     // several Names — the order is ill-defined; the standard rejects it.
-    try enginePeople().expect("SELECT DISTINCT Age FROM People ORDER BY Name",
+    try roster().expect("SELECT DISTINCT Age FROM People ORDER BY Name",
                         fails: .distinct("Name"))
   }
 
@@ -538,7 +538,7 @@ struct EngineDistinctTests {
     // Age is a select-list column, so ordering (and paging) on it is well
     // defined: the deduplicated Ages sort 25, 30, 40, and OFFSET 1 drops the
     // first.
-    try enginePeople().expect("""
+    try roster().expect("""
         SELECT DISTINCT Age FROM People ORDER BY Age
           OFFSET 1 ROWS FETCH FIRST 2 ROWS ONLY
         """, yields: [[30], [40]])
@@ -547,7 +547,7 @@ struct EngineDistinctTests {
   @Test func `DISTINCT over a join rejects a hidden ORDER BY key`() throws {
     // Child.Name is not projected, so ordering the deduplicated Parent.Name
     // rows on it is ill-defined across the two joined relations.
-    try engineFamily().expect("""
+    try family().expect("""
         SELECT DISTINCT Parent.Name FROM Parent
           JOIN Child ON Child.Pid = Parent.Id ORDER BY Child.Name
         """, fails: .distinct("Name"))
@@ -561,7 +561,7 @@ struct EngineDistinctTests {
     // The output is only COUNT(*); Age is the grouping key but not projected,
     // so ordering (and paging) on it after dedup is ill-defined — the same rule
     // the non-aggregate path enforces, in grouped-slot space.
-    try enginePeople().expect("""
+    try roster().expect("""
         SELECT DISTINCT COUNT(*) FROM People GROUP BY Age ORDER BY Age
         """, fails: .distinct("Age"))
   }
@@ -570,7 +570,7 @@ struct EngineDistinctTests {
     // The counts per Age are 2, 2, 1; DISTINCT collapses the two 2s, leaving
     // {1, 2}. Ordering on the projected alias `c` is well defined — ascending
     // yields 1, 2.
-    try enginePeople().expect("""
+    try roster().expect("""
         SELECT DISTINCT COUNT(*) AS c FROM People GROUP BY Age ORDER BY c
         """, yields: [[1], [2]])
   }
@@ -582,39 +582,39 @@ struct EngineArithmeticTests {
   @Test func `literal arithmetic evaluates over a row`() throws {
     // One row of `People` drives the projection; the value is the same for each,
     // and `Id = 1` selects exactly one.
-    try enginePeople().expect("SELECT 2 + 3 FROM People WHERE Id = 1", yields: [[5]])
+    try roster().expect("SELECT 2 + 3 FROM People WHERE Id = 1", yields: [[5]])
   }
 
   @Test func `multiplication binds tighter than addition`() throws {
-    try enginePeople().expect("SELECT 2 + 3 * 4 FROM People WHERE Id = 1",
+    try roster().expect("SELECT 2 + 3 * 4 FROM People WHERE Id = 1",
                         yields: [[14]])
   }
 
   @Test func `parentheses override precedence`() throws {
-    try enginePeople().expect("SELECT (2 + 3) * 4 FROM People WHERE Id = 1",
+    try roster().expect("SELECT (2 + 3) * 4 FROM People WHERE Id = 1",
                         yields: [[20]])
   }
 
   @Test func `subtraction and division are left-associative`() throws {
     // (20 - 5) - 3 = 12, not 20 - (5 - 3) = 18; (100 / 5) / 2 = 10.
-    let difference = try engineRun("SELECT 20 - 5 - 3 FROM People WHERE Id = 1")
+    let difference = try answer("SELECT 20 - 5 - 3 FROM People WHERE Id = 1")
     #expect(difference == [[.integer(12)]])
-    let quotient = try engineRun("SELECT 100 / 5 / 2 FROM People WHERE Id = 1")
+    let quotient = try answer("SELECT 100 / 5 / 2 FROM People WHERE Id = 1")
     #expect(quotient == [[.integer(10)]])
   }
 
   @Test func `integer division truncates`() throws {
-    try enginePeople().expect("SELECT 7 / 2 FROM People WHERE Id = 1", yields: [[3]])
+    try roster().expect("SELECT 7 / 2 FROM People WHERE Id = 1", yields: [[3]])
   }
 
   @Test func `arithmetic over a column computes per row`() throws {
-    let rows = try engineRun("SELECT Age + 1 FROM People WHERE Id = 2")
+    let rows = try answer("SELECT Age + 1 FROM People WHERE Id = 2")
     // Bob's Age is 25; 25 + 1 = 26.
     #expect(rows == [[.integer(26)]])
   }
 
   @Test func `arithmetic mixes columns and a function call`() throws {
-    let rows = try engineFunctionRun("SELECT add(Id, 1) * 10 FROM People WHERE Id = 3")
+    let rows = try functions("SELECT add(Id, 1) * 10 FROM People WHERE Id = 3")
     // Carol: (3 + 1) * 10 = 40.
     #expect(rows == [[.integer(40)]])
   }
@@ -622,13 +622,13 @@ struct EngineArithmeticTests {
   @Test func `a NULL operand propagates to a NULL result`() throws {
     // `Note` is NULL for row 2; `Id + Note` mixes a present integer with a NULL,
     // so the whole expression is NULL rather than a fault.
-    try engineNullable().expect("SELECT Id + Note FROM Maybe WHERE Id = 2",
+    try sparse().expect("SELECT Id + Note FROM Maybe WHERE Id = 2",
                           yields: [[nil]])
   }
 
   @Test func `division by zero faults`() throws {
     #expect(throws: SQLError.divide) {
-      try engineRun("SELECT Id / 0 FROM People WHERE Id = 1")
+      try answer("SELECT Id / 0 FROM People WHERE Id = 1")
     }
   }
 
@@ -636,10 +636,10 @@ struct EngineArithmeticTests {
     // `Int.max + 1` and a multiply past the boundary report overflow as a
     // `SQLError` rather than trapping (and aborting) the process.
     #expect(throws: SQLError.magnitude("integer overflow")) {
-      try engineRun("SELECT 9223372036854775807 + 1 FROM People WHERE Id = 1")
+      try answer("SELECT 9223372036854775807 + 1 FROM People WHERE Id = 1")
     }
     #expect(throws: SQLError.magnitude("integer overflow")) {
-      try engineRun("SELECT 9223372036854775807 * 2 FROM People WHERE Id = 1")
+      try answer("SELECT 9223372036854775807 * 2 FROM People WHERE Id = 1")
     }
   }
 
@@ -647,23 +647,23 @@ struct EngineArithmeticTests {
     // `(Age + 1)` is the grouped left operand of the comparison, not a predicate
     // group; it matches Dave (40 + 1 = 41). A leading `(` no longer forces a
     // predicate-group parse.
-    let matched = try engineRun("SELECT Id FROM People WHERE (Age + 1) = 41")
+    let matched = try answer("SELECT Id FROM People WHERE (Age + 1) = 41")
     #expect(matched == [[.integer(4)]])
     // A grouped expression works before `IS NULL` too; `Id + 1` is never NULL.
-    let none = try engineRun("SELECT Id FROM People WHERE (Id + 1) IS NULL")
+    let none = try answer("SELECT Id FROM People WHERE (Id + 1) IS NULL")
     #expect(none.isEmpty)
   }
 
   @Test func `a text operand faults as a type error`() throws {
     #expect(throws: SQLError.operand("operands must be numeric")) {
-      try engineRun("SELECT Name + 1 FROM People WHERE Id = 1")
+      try answer("SELECT Name + 1 FROM People WHERE Id = 1")
     }
   }
 
   @Test func `arithmetic in a predicate filters rows`() throws {
     // `Age + 1 = 26` holds for everyone aged 25 (Bob and Eve); the arithmetic
     // is evaluated per row on the WHERE side too.
-    try enginePeople().expect("SELECT Name FROM People WHERE Age + 1 = 26",
+    try roster().expect("SELECT Name FROM People WHERE Age + 1 = 26",
                         yields: [["Bob"], ["Eve"]])
   }
 }
@@ -674,50 +674,50 @@ struct EngineScalarSelectTests {
   @Test func `a FROM-less literal yields exactly one row`() throws {
     // No relation, so the projection runs against a single empty row; the
     // catalog is never consulted for a table.
-    try enginePeople().expect("SELECT 42", yields: [[42]])
+    try roster().expect("SELECT 42", yields: [[42]])
   }
 
   @Test func `a FROM-less arithmetic computes a scalar`() throws {
-    try enginePeople().expect("SELECT 1 + 1", yields: [[2]])
+    try roster().expect("SELECT 1 + 1", yields: [[2]])
   }
 
   @Test func `FROM-less arithmetic honours precedence`() throws {
-    try enginePeople().expect("SELECT 2 + 3 * 4", yields: [[14]])
+    try roster().expect("SELECT 2 + 3 * 4", yields: [[14]])
   }
 
   @Test func `a FROM-less multi-column projection yields one row of each value`() throws {
-    try enginePeople().expect("SELECT 1, 2, 3", yields: [[1, 2, 3]])
+    try roster().expect("SELECT 1, 2, 3", yields: [[1, 2, 3]])
   }
 
   @Test func `a FROM-less projection mixes text and integer expressions`() throws {
-    try enginePeople().expect("SELECT 'x', 10 / 2", yields: [["x", 5]])
+    try roster().expect("SELECT 'x', 10 / 2", yields: [["x", 5]])
   }
 
   @Test func `a FROM-less scalar call evaluates against the single row`() throws {
-    let rows = try engineFunctionRun("SELECT add(40, 2)")
+    let rows = try functions("SELECT add(40, 2)")
     #expect(rows == [[.integer(42)]])
   }
 
   @Test func `a boolean literal lowers to its truth value`() throws {
-    try enginePeople().expect("SELECT TRUE, FALSE", yields: [[true, false]])
+    try roster().expect("SELECT TRUE, FALSE", yields: [[true, false]])
   }
 
   @Test func `a hex blob literal lowers to its bytes`() throws {
     // The `x'53514c'` literal lexes, parses, and lowers to the three-byte
     // blob `SQL`, projected as a `Value.blob`.
-    try enginePeople().expect("SELECT x'53514c'",
+    try roster().expect("SELECT x'53514c'",
                         yields: [[[0x53, 0x51, 0x4c] as Array<UInt8>]])
   }
 
   @Test func `a boolean operand faults as a non-numeric type error`() throws {
     // Neither boolean nor blob is numeric, so arithmetic over either faults
     // exactly as text does — the type-checker rejects any non-numeric operand.
-    try enginePeople().expect("SELECT TRUE + 1",
+    try roster().expect("SELECT TRUE + 1",
                         fails: .operand("operands must be numeric"))
   }
 
   @Test func `a blob operand faults as a non-numeric type error`() throws {
-    try enginePeople().expect("SELECT x'00' + 1",
+    try roster().expect("SELECT x'00' + 1",
                         fails: .operand("operands must be numeric"))
   }
 
@@ -726,18 +726,18 @@ struct EngineScalarSelectTests {
     // function returning it; `nothing` yields NULL for the single row.
     let routines: Routines =
         ["nothing": Routine(parameters: []) { _ in .null }]
-    let rows = try enginePeople().run(engineParse("SELECT nothing()"), routines)
+    let rows = try roster().run(parse("SELECT nothing()"), routines)
     #expect(rows == [[.null]])
   }
 
   @Test func `a FROM-less SELECT * is rejected — no relation to expand`() throws {
     #expect(throws: SQLError.unsupported("SELECT * requires a FROM clause")) {
-      try engineRun("SELECT *")
+      try answer("SELECT *")
     }
   }
 
   @Test func `a FROM-less bare column is rejected — no column to bind`() throws {
-    try enginePeople().expect("SELECT Name", fails: .column("Name"))
+    try roster().expect("SELECT Name", fails: .column("Name"))
   }
 
   @Test func `a directly-built FROM-less select with clauses is rejected`() throws {
@@ -752,39 +752,39 @@ struct EngineScalarSelectTests {
     let filtered = try EngineScalarSelectTests.select(
         "SELECT 1 FROM People WHERE Id = 99")
     #expect(throws: fault) {
-      try enginePeople().run(.select(Select(projection: filtered.projection,
+      try roster().run(.select(Select(projection: filtered.projection,
                                     from: nil,
                                     predicate: filtered.predicate)))
     }
     let grouped = try EngineScalarSelectTests.select(
         "SELECT Id FROM People GROUP BY Id")
     #expect(throws: fault) {
-      try enginePeople().run(.select(Select(projection: grouped.projection, from: nil,
+      try roster().run(.select(Select(projection: grouped.projection, from: nil,
                                     grouping: grouped.grouping)))
     }
     let filteredGroup = try EngineScalarSelectTests.select(
         "SELECT Id FROM People GROUP BY Id HAVING COUNT(*) > 0")
     #expect(throws: fault) {
-      try enginePeople().run(.select(Select(projection: filteredGroup.projection,
+      try roster().run(.select(Select(projection: filteredGroup.projection,
                                     from: nil,
                                     having: filteredGroup.having)))
     }
     let ordered =
         try EngineScalarSelectTests.select("SELECT Id FROM People ORDER BY Id")
     #expect(throws: fault) {
-      try enginePeople().run(.select(Select(projection: ordered.projection, from: nil,
+      try roster().run(.select(Select(projection: ordered.projection, from: nil,
                                     order: ordered.order)))
     }
     let limited = try EngineScalarSelectTests.select(
         "SELECT Id FROM People FETCH FIRST 1 ROW ONLY")
     #expect(throws: fault) {
-      try enginePeople().run(.select(Select(projection: limited.projection, from: nil,
+      try roster().run(.select(Select(projection: limited.projection, from: nil,
                                     limit: limited.limit)))
     }
     let joined = try EngineScalarSelectTests.select(
         "SELECT Id FROM People JOIN Pets ON Pets.Owner = People.Id")
     #expect(throws: fault) {
-      try enginePeople().run(.select(Select(projection: joined.projection, from: nil,
+      try roster().run(.select(Select(projection: joined.projection, from: nil,
                                     joins: joined.joins)))
     }
   }
@@ -792,7 +792,7 @@ struct EngineScalarSelectTests {
   /// The `Select` of a parsed single-`SELECT` query — for building the FROM-less
   /// shapes the parser will not, by re-homing a clause onto a `from: nil` select.
   private static func select(_ text: String) throws -> Select {
-    guard case let .select(select) = try engineParse(text) else {
+    guard case let .select(select) = try parse(text) else {
       throw SQLError.incomplete(expected: "a SELECT")
     }
     return select
@@ -801,7 +801,7 @@ struct EngineScalarSelectTests {
   @Test func `a FROM-less arm of a UNION combines with a FROM arm`() throws {
     // Both arms project one integer column; the FROM-less arm contributes its
     // single computed row, deduplicating against the People ages.
-    let rows = try enginePeople().run(engineParse("""
+    let rows = try roster().run(parse("""
         SELECT 100 UNION ALL SELECT Age FROM People WHERE Id = 1
         """))
     #expect(rows == [[.integer(100)], [.integer(30)]])
@@ -810,7 +810,7 @@ struct EngineScalarSelectTests {
   @Test func `an existing SELECT … FROM … query is unaffected`() throws {
     // The FROM-optional grammar leaves a normal query parsing and running
     // exactly as before.
-    try enginePeople().expect("SELECT Name FROM People WHERE Id = 1",
+    try roster().expect("SELECT Name FROM People WHERE Id = 1",
                         yields: [["Alice"]])
   }
 }
@@ -835,32 +835,32 @@ struct EngineSetOperationCoercionTests {
   @Test func `UNION widens a mixed integer/double column and coerces its values`() throws {
     // The unified column type is `double`, so the `integer` arm's `1` coerces
     // to `1.0` and the result column is `double` throughout.
-    try enginePeople().expect("SELECT 1 UNION SELECT 2.5",
+    try roster().expect("SELECT 1 UNION SELECT 2.5",
                               yields: [[1.0], [2.5]])
-    try enginePeople().expect("SELECT 1 UNION ALL SELECT 2.5",
+    try roster().expect("SELECT 1 UNION ALL SELECT 2.5",
                               yields: [[1.0], [2.5]])
   }
 
   @Test func `UNION dedups numerically-equal rows to the coerced double`() throws {
     // `1` coerces to `1.0`, equal to the double arm's `1.0`, so the bare UNION
     // keeps one — the emitted `double`.
-    try enginePeople().expect("SELECT 1 UNION SELECT 1.0", yields: [[1.0]])
+    try roster().expect("SELECT 1 UNION SELECT 1.0", yields: [[1.0]])
   }
 
   @Test func `INTERSECT and EXCEPT emit the coerced double`() throws {
     // Equality already canonicalises `1` and `1.0`, so both match/subtract; the
     // coercion makes the EMITTED cell carry the unified `double` type.
-    try enginePeople().expect("SELECT 1 INTERSECT SELECT 1.0", yields: [[1.0]])
-    try enginePeople().expect("SELECT 2 EXCEPT SELECT 1.0", yields: [[2.0]])
+    try roster().expect("SELECT 1 INTERSECT SELECT 1.0", yields: [[1.0]])
+    try roster().expect("SELECT 2 EXCEPT SELECT 1.0", yields: [[2.0]])
   }
 
   @Test func `a UNION of irreconcilable column types faults`() throws {
     // A text arm beside a number, or a boolean beside a number, has no common
     // type — the fold faults `SQLError.operand` (SQLSTATE 42804).
-    try enginePeople().expect(
+    try roster().expect(
         "SELECT 1 UNION SELECT 'x'",
         fails: .operand("UNION arms have irreconcilable types"))
-    try enginePeople().expect(
+    try roster().expect(
         "SELECT TRUE UNION SELECT 1",
         fails: .operand("UNION arms have irreconcilable types"))
   }
@@ -870,19 +870,19 @@ struct EngineSetOperationCoercionTests {
     // then descends into the left child `SELECT 1, 2 UNION SELECT 3` whose
     // arms differ (2 vs 1) — the fold's own guard faults `.arity` rather than
     // trapping on an out-of-bounds column index.
-    try enginePeople().expect("SELECT 1, 2 UNION SELECT 3 UNION SELECT 4, 5",
+    try roster().expect("SELECT 1, 2 UNION SELECT 3 UNION SELECT 4, 5",
                               fails: .arity(2, 1))
   }
 
   @Test func `a chained 3-arm UNION widens across every arm`() throws {
     // The left-associative chain folds pairwise, so the trailing `double`
     // widens the whole column and every value coerces.
-    try enginePeople().expect("SELECT 1 UNION SELECT 2 UNION SELECT 3.5",
+    try roster().expect("SELECT 1 UNION SELECT 2 UNION SELECT 3.5",
                               yields: [[1.0], [2.0], [3.5]])
   }
 
   @Test func `a chained UNION with an incompatible tail faults`() throws {
-    try enginePeople().expect(
+    try roster().expect(
         "SELECT 1 UNION SELECT 2 UNION SELECT 'x'",
         fails: .operand("UNION arms have irreconcilable types"))
   }
@@ -891,7 +891,7 @@ struct EngineSetOperationCoercionTests {
     // The derived table runs through the `.setop` Plan node, whose carried
     // `types` (computed at compile) coerce each arm's rows — the outer
     // `SELECT *` reads the widened `double` column.
-    try enginePeople().expect("SELECT * FROM (SELECT 1 UNION SELECT 2.5) AS d",
+    try roster().expect("SELECT * FROM (SELECT 1 UNION SELECT 2.5) AS d",
                               yields: [[1.0], [2.5]])
   }
 
@@ -902,7 +902,7 @@ struct EngineSetOperationCoercionTests {
     // unification), and the `AS d(a)` list renames that column `a` (the
     // explicit output column list). Selecting `d.a` reads the widened, coerced
     // values under the list's name — the two features COMPOSE.
-    try enginePeople().expect(
+    try roster().expect(
         "SELECT d.a FROM (SELECT 1 UNION SELECT 2.5) AS d(a) ORDER BY d.a",
         yields: [[1.0], [2.5]])
   }
@@ -911,11 +911,11 @@ struct EngineSetOperationCoercionTests {
     // A `NULLIF(2, 2)` arm folds to constant NULL, so it constrains nothing (a
     // NULL unifies with any typed arm): the OTHER arm's `double` types the
     // column, its NULL row stays NULL and the double row coerces.
-    try enginePeople().expect("SELECT NULLIF(2, 2) UNION SELECT 2.5",
+    try roster().expect("SELECT NULLIF(2, 2) UNION SELECT 2.5",
                               yields: [[nil], [2.5]])
     // A typed integer arm beside a constant-NULL arm keeps the `integer`
     // column.
-    try enginePeople().expect("SELECT 1 UNION SELECT NULLIF(2, 2)",
+    try roster().expect("SELECT 1 UNION SELECT NULLIF(2, 2)",
                               yields: [[1], [nil]])
   }
 
@@ -928,7 +928,7 @@ struct EngineSetOperationCoercionTests {
         WITH RECURSIVE t (n) AS (
           SELECT 1 UNION ALL SELECT n + 0.5 FROM t WHERE n < 3
         ) SELECT n FROM t
-        """, enginePeople())
+        """, roster())
     #expect(rows == [[.double(1.0)], [.double(1.5)], [.double(2.0)],
                      [.double(2.5)], [.double(3.0)]])
   }
@@ -936,16 +936,16 @@ struct EngineSetOperationCoercionTests {
   @Test func `a homogeneous UNION is byte-identical (no coercion)`() throws {
     // Every arm the same type — the coercion is a no-op, so the result is
     // exactly what the pre-unification engine produced.
-    try enginePeople().expect(
+    try roster().expect(
         "SELECT Age FROM People UNION SELECT Age FROM People",
         yields: [[30], [25], [40]])
   }
 
   @Test func `a homogeneous INTERSECT/EXCEPT is byte-identical`() throws {
-    try enginePeople().expect(
+    try roster().expect(
         "SELECT Age FROM People INTERSECT SELECT Age FROM People",
         yields: [[30], [25], [40]])
-    try enginePeople().empty(
+    try roster().empty(
         "SELECT Age FROM People EXCEPT SELECT Age FROM People")
   }
 }
@@ -976,7 +976,7 @@ struct EngineCorrelatedNullUnificationTests {
         WITH t (x) AS (SELECT NULLIF(1, 1) UNION SELECT NULLIF('a', 'a'))
           SELECT y FROM t
           JOIN LATERAL (SELECT x UNION SELECT 'c') AS d (y) ON 1 = 1
-        """, engineFamily())
+        """, family())
     #expect(rows == [[.null], [.text("c")]])
   }
 
@@ -994,7 +994,7 @@ struct EngineCorrelatedNullUnificationTests {
             SELECT y FROM (SELECT 1 AS one) AS u
             JOIN LATERAL (SELECT x UNION SELECT 'c') AS d (y) ON 1 = 1
           ) AS e (z) ON 1 = 1
-        """, engineFamily())
+        """, family())
     #expect(rows == [[.null], [.text("c")]])
   }
 
@@ -1011,7 +1011,7 @@ struct EngineCorrelatedNullUnificationTests {
           WITH t (x) AS (SELECT 1)
             SELECT y FROM t
             JOIN LATERAL (SELECT x UNION SELECT 'c') AS d (y) ON 1 = 1
-          """, engineFamily())
+          """, family())
     }
   }
 
@@ -1022,7 +1022,7 @@ struct EngineCorrelatedNullUnificationTests {
     let rows = try statement("""
         WITH t (x) AS (SELECT NULLIF(1, 1) UNION SELECT NULLIF('a', 'a'))
           SELECT x FROM t UNION SELECT 'c'
-        """, engineFamily())
+        """, family())
     #expect(rows == [[.null], [.text("c")]])
   }
 
@@ -1030,7 +1030,7 @@ struct EngineCorrelatedNullUnificationTests {
     // The unification is a no-op for a genuinely-typed homogeneous set
     // operation — the result is exactly what the pre-unification engine
     // produced.
-    try enginePeople().expect(
+    try roster().expect(
         "SELECT Age FROM People UNION SELECT Age FROM People",
         yields: [[30], [25], [40]])
   }
@@ -1040,10 +1040,10 @@ struct EngineCorrelatedNullUnificationTests {
     // ORDINARY (non-lateral) correlated subquery in a projection is still
     // DIAGNOSED `.unsupported` — the unification does not widen acceptance. The
     // barred surface faults the same on the run and schema paths.
-    let people = try enginePeople()
+    let people = try roster()
     #expect(throws: SQLError.state("0A000",
         "a correlated column is only supported in a subquery's WHERE")) {
-      _ = try people.run(engineParse("SELECT (SELECT P.Age) FROM People AS P"))
+      _ = try people.run(parse("SELECT (SELECT P.Age) FROM People AS P"))
     }
   }
 }
@@ -1069,9 +1069,9 @@ struct EngineUnconstrainedMaskSealTests {
     // The baseline channel — a bare projected expression folding to constant
     // NULL is unconstrained, so it unifies; a typed literal constrains and
     // faults int-vs-text.
-    try enginePeople().expect("SELECT NULLIF('a', 'a') UNION SELECT 1",
+    try roster().expect("SELECT NULLIF('a', 'a') UNION SELECT 1",
                               yields: [[nil], [1]])
-    try enginePeople().expect(
+    try roster().expect(
         "SELECT 'a' UNION SELECT 1",
         fails: .operand("UNION arms have irreconcilable types"))
   }
@@ -1083,10 +1083,10 @@ struct EngineUnconstrainedMaskSealTests {
     // now carries that mask into the outer fold, which unifies the wrapper with
     // the integer arm and RUNS (NULL row + `1` row). A genuinely-typed wrapper
     // `(SELECT 'a')` stays concrete text and faults int-vs-text.
-    try enginePeople().expect(
+    try roster().expect(
         "SELECT (SELECT NULLIF('a', 'a')) UNION SELECT 1",
         yields: [[nil], [1]])
-    try enginePeople().expect(
+    try roster().expect(
         "SELECT (SELECT 'a') UNION SELECT 1",
         fails: .operand("UNION arms have irreconcilable types"))
   }
@@ -1098,11 +1098,11 @@ struct EngineUnconstrainedMaskSealTests {
     // unconstrained — the memo carries THAT mask out, and the outer fold unifies
     // the wrapper with the text `'c'` arm. A typed inner UNION (`SELECT 1 UNION
     // SELECT 2`) stays a concrete integer and faults int-vs-text.
-    try enginePeople().expect("""
+    try roster().expect("""
         SELECT (SELECT NULLIF(1, 1) UNION SELECT NULLIF('a', 'a'))
           UNION SELECT 'c'
         """, yields: [[nil], ["c"]])
-    try enginePeople().expect(
+    try roster().expect(
         "SELECT (SELECT 1 UNION SELECT 2) UNION SELECT 'c'",
         fails: .operand("UNION arms have irreconcilable types"))
   }
@@ -1113,10 +1113,10 @@ struct EngineUnconstrainedMaskSealTests {
     // NULL, so its resolved schema marks it unconstrained; a bare reference in
     // the outer set-op arm unifies with the integer `1`. A typed derived column
     // (`SELECT 'a' AS x`) stays concrete text and faults int-vs-text.
-    try enginePeople().expect("""
+    try roster().expect("""
         SELECT x FROM (SELECT NULLIF('a', 'a') AS x) AS d UNION SELECT 1
         """, yields: [[nil], [1]])
-    try enginePeople().expect(
+    try roster().expect(
         "SELECT x FROM (SELECT 'a' AS x) AS d UNION SELECT 1",
         fails: .operand("UNION arms have irreconcilable types"))
   }
@@ -1149,7 +1149,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
     // The unregistered `missing()` is REACHED (a FROM-less single-row arm), so
     // the reachable typecheck raises `SQLError.function` — NOT `.operand`. The
     // fold deferring on the placeholder does not hide the missing routine.
-    try enginePeople().expect("SELECT missing() UNION SELECT 'x'",
+    try roster().expect("SELECT missing() UNION SELECT 'x'",
                               fails: .function("missing"))
   }
 
@@ -1157,7 +1157,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
       throws {
     // The right-side variant: the fold defers on the placeholder either way,
     // and the reachable typecheck raises `.function` when the arm is reached.
-    try enginePeople().expect("SELECT 1 UNION SELECT missing()",
+    try roster().expect("SELECT 1 UNION SELECT missing()",
                               fails: .function("missing"))
   }
 
@@ -1167,7 +1167,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
     // no `.function` fault — while its placeholder type defers in the fold
     // rather than faulting `.operand` against the text `'x'`. The union yields
     // only the reached `'x'` row.
-    try enginePeople().expect("""
+    try roster().expect("""
         SELECT NOPE(Name) FROM People FETCH FIRST 0 ROWS ONLY
           UNION SELECT 'x'
         """, yields: [["x"]])
@@ -1180,7 +1180,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
     // zero-row arm never evaluates it, so `unresolved` marks the arm
     // unconstrained and the fold defers to the text `'x'` rather than faulting
     // `.operand` on the fabricated `.integer`. The union yields only `'x'`.
-    try enginePeople().expect("""
+    try roster().expect("""
         SELECT NOPE(Name) + 0 FROM People FETCH FIRST 0 ROWS ONLY
           UNION SELECT 'x'
         """, yields: [["x"]])
@@ -1193,7 +1193,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
     // typecheck raises `SQLError.function` (the name folded to `nope`), NOT
     // `.operand`. Deferring the fold does not hide the missing routine even
     // when it is nested.
-    try enginePeople().expect("""
+    try roster().expect("""
         SELECT NOPE(Name) + 0 FROM People UNION SELECT 'x'
         """, fails: .function("nope"))
   }
@@ -1204,7 +1204,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
     // and the fold defers to the text `'x'` rather than faulting `.operand`. A
     // FROM-less single-row arm is REACHED, so `missing()` dispatches — hence
     // the run faults `.function`, proving the deferral touches only the fold.
-    try enginePeople().expect("SELECT COALESCE(missing(), 1) UNION SELECT 'x'",
+    try roster().expect("SELECT COALESCE(missing(), 1) UNION SELECT 'x'",
                               fails: .function("missing"))
   }
 
@@ -1215,7 +1215,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
     // left arm constrains the set-op as integer — the text `'x'` arm is
     // genuinely irreconcilable and must fault `.operand`, not defer and leave
     // the integer `1` cell uncoerced against text.
-    try enginePeople().expect(
+    try roster().expect(
         "SELECT COALESCE(1, missing()) UNION ALL SELECT 'x'",
         fails: .operand("UNION arms have irreconcilable types"))
   }
@@ -1226,7 +1226,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
     // missing() END` reaches the `missing()` branch, so `unresolved` (via the
     // reachable-branch mirror of `derive`) marks it unconstrained. The arm is
     // reached, so the run dispatches `missing()` and faults `.function`.
-    try enginePeople().expect("""
+    try roster().expect("""
         SELECT CASE WHEN 1 = 1 THEN missing() END UNION SELECT 'x'
         """, fails: .function("missing"))
   }
@@ -1240,7 +1240,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
     // inner `missing()` and faults `.function`.
     let routines: Routines =
         ["up": Routine(returns: .text, parameters: [.text]) { row in row[0] }]
-    try enginePeople().expect("SELECT up(missing()) UNION SELECT 'x'",
+    try roster().expect("SELECT up(missing()) UNION SELECT 'x'",
                               fails: .function("missing"), routines: routines)
   }
 
@@ -1249,7 +1249,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
     // The deferral is observable as a clean RUN when the nesting arm is
     // filtered out: a zero-row `COALESCE(missing(), 1)` arm never evaluates the
     // call, so the union folds and yields only the reached text `'x'`.
-    try enginePeople().expect("""
+    try roster().expect("""
         SELECT COALESCE(missing(), 1) FROM People FETCH FIRST 0 ROWS ONLY
           UNION SELECT 'x'
         """, yields: [["x"]])
@@ -1264,7 +1264,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
     // ONLY unregistered calls, never a genuine mismatch.
     let routines: Routines =
         ["one": Routine(returns: .integer, parameters: []) { _ in .integer(1) }]
-    try enginePeople().expect("SELECT one() + 0 UNION SELECT 'x'",
+    try roster().expect("SELECT one() + 0 UNION SELECT 'x'",
                               fails: .operand(
                                   "UNION arms have irreconcilable types"),
                               routines: routines)
@@ -1274,7 +1274,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
     // The baseline nested guard: `1 + 0` folds to a GENUINE integer with no
     // call at all, so it stays constrained and faults `.operand` against the
     // text `'x'` — the recursion adds no over-suppression to a call-free tree.
-    try enginePeople().expect(
+    try roster().expect(
         "SELECT 1 + 0 UNION SELECT 'x'",
         fails: .operand("UNION arms have irreconcilable types"))
   }
@@ -1288,7 +1288,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
     // The outer fold defers to the text `'x'`; the FROM-less subquery arm is
     // reached, so the run dispatches `NOPE` (folded to `nope`) and faults
     // `.function`.
-    try enginePeople().expect("SELECT (SELECT NOPE()) UNION SELECT 'x'",
+    try roster().expect("SELECT (SELECT NOPE()) UNION SELECT 'x'",
                               fails: .function("nope"))
   }
 
@@ -1300,7 +1300,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
     let routines: Routines = [
       "tag": Routine(returns: .text, parameters: [.text]) { _ in .text("t") }
     ]
-    try enginePeople().expect("SELECT tag(Name) FROM People UNION SELECT 1",
+    try roster().expect("SELECT tag(Name) FROM People UNION SELECT 1",
                               fails: .operand(
                                   "UNION arms have irreconcilable types"),
                               routines: routines)
@@ -1311,7 +1311,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
     // the other arm folds cleanly and runs.
     let routines: Routines =
         ["tag": Routine(returns: .text, parameters: [.text]) { row in row[0] }]
-    try enginePeople().expect("""
+    try roster().expect("""
         SELECT tag(Name) FROM People WHERE Id = 1 UNION SELECT 'x'
         """, yields: [["Alice"], ["x"]], routines: routines)
   }
@@ -1319,7 +1319,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
   @Test func `a literal type mismatch still faults 42804`() throws {
     // The baseline over-suppression guard: two GENUINE literal types still fold
     // to an irreconcilable pair and fault — the closure widens nothing.
-    try enginePeople().expect(
+    try roster().expect(
         "SELECT 1 UNION SELECT 'x'",
         fails: .operand("UNION arms have irreconcilable types"))
   }
@@ -1332,7 +1332,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
     #expect(throws: SQLError.operand("UNION arms have irreconcilable types")) {
       _ = try statement(
           "WITH a(x) AS (SELECT 'b' UNION SELECT 1) SELECT x FROM a",
-          engineFamily())
+          family())
     }
   }
 
@@ -1344,7 +1344,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
     let statement = try Statement(parsing:
         "WITH a(x) AS (SELECT 'b' UNION SELECT 1) SELECT x FROM a")
     #expect(throws: SQLError.operand("UNION arms have irreconcilable types")) {
-      _ = try engineFamily().columns(of: statement, validate: true)
+      _ = try family().columns(of: statement, validate: true)
     }
   }
 }
@@ -1370,7 +1370,7 @@ struct EngineDeferredSetopShapeTests {
     // the incompatible `SELECT 'x' UNION SELECT 1` is never reached — the shape
     // pre-pass defers its operand fold rather than faulting 42804, and the
     // query runs to no rows.
-    try enginePeople().empty("""
+    try roster().empty("""
         SELECT 1 FROM People WHERE 1 = 0 AND EXISTS (SELECT 'x' UNION SELECT 1)
         """)
   }
@@ -1380,7 +1380,7 @@ struct EngineDeferredSetopShapeTests {
     // cardinality probe never evaluates the select list — so it must NOT fault
     // on the incompatible pair (role `.existential`, skipped by the re-fold).
     // People has rows, so the EXISTS is present and every row projects `1`.
-    try enginePeople().expect("""
+    try roster().expect("""
         SELECT 1 FROM People WHERE EXISTS (SELECT 'x' UNION SELECT 1)
         """, yields: Array(repeating: [1], count: 5))
   }
@@ -1389,7 +1389,7 @@ struct EngineDeferredSetopShapeTests {
       throws {
     // The `IN` is unreachable behind `1 = 0 AND …`, so its incompatible UNION
     // defers in the shape pre-pass and the query runs to no rows.
-    try enginePeople().empty("""
+    try roster().empty("""
         SELECT 1 FROM People WHERE 1 = 0 AND Age IN (SELECT 'a' UNION SELECT 1)
         """)
   }
@@ -1398,7 +1398,7 @@ struct EngineDeferredSetopShapeTests {
     // A REACHED `IN` reads its value set's column type (role `.valued`), so the
     // re-fold on the reached path restores the strict operand check and the
     // incompatible UNION faults 42804 — the deferral does not hide it.
-    try enginePeople().expect("""
+    try roster().expect("""
         SELECT 1 FROM People WHERE Age IN (SELECT 'a' UNION SELECT 1)
         """, fails: .operand("UNION arms have irreconcilable types"))
   }
@@ -1407,7 +1407,7 @@ struct EngineDeferredSetopShapeTests {
     // A REACHED scalar subquery collapses to a single cell (role `.scalar`), so
     // the reached re-fold checks its arms strictly and the incompatible UNION
     // faults 42804 in the comparison.
-    try enginePeople().expect("""
+    try roster().expect("""
         SELECT 1 FROM People WHERE Age = (SELECT 'a' UNION SELECT 1)
         """, fails: .operand("UNION arms have irreconcilable types"))
   }
@@ -1416,7 +1416,7 @@ struct EngineDeferredSetopShapeTests {
       throws {
     // The SAME scalar subquery behind `1 = 0 AND …` is unreachable, so its
     // operand fold defers in the pre-pass and the query runs to no rows.
-    try enginePeople().empty("""
+    try roster().empty("""
         SELECT 1 FROM People
           WHERE 1 = 0 AND Age = (SELECT 'a' UNION SELECT 1)
         """)
@@ -1425,7 +1425,7 @@ struct EngineDeferredSetopShapeTests {
   @Test func `a top-level incompatible UNION still faults 42804`() throws {
     // The top level is not a shape pre-pass (`shape` is `false`), so its
     // operand fold still faults — the deferral is scoped to nested subqueries.
-    try enginePeople().expect(
+    try roster().expect(
         "SELECT 'x' UNION SELECT 1",
         fails: .operand("UNION arms have irreconcilable types"))
   }
@@ -1437,7 +1437,7 @@ struct EngineDeferredSetopShapeTests {
     // statement, so it runs through the statement overload.
     let rows = try statement(
         "WITH a(x) AS (SELECT 'b') SELECT x FROM a UNION SELECT 'c'",
-        enginePeople())
+        roster())
     #expect(rows == [[.text("b")], [.text("c")]])
   }
 }
@@ -1464,7 +1464,7 @@ struct EngineReachedCorrelatedSetopTests {
     // shaped plan is strict-folded at the execution seam and the irreconcilable
     // pair faults 42804 on the first reached row — the correlated occurrence no
     // longer coerces to the placeholder type and silently passes.
-    try enginePeople().expect("""
+    try roster().expect("""
         SELECT Id FROM People WHERE 1 IN ( \
         SELECT 'x' FROM (SELECT 1 AS k) AS d WHERE d.k = People.Id \
         UNION SELECT 1)
@@ -1476,7 +1476,7 @@ struct EngineReachedCorrelatedSetopTests {
     // The SAME correlated `IN` behind `1 = 0 AND …` is unreachable, so it never
     // reaches the execution seam — its shape deferral stands and the query runs
     // to no rows.
-    try enginePeople().empty("""
+    try roster().empty("""
         SELECT Id FROM People WHERE 1 = 0 AND 1 IN ( \
         SELECT 'x' FROM (SELECT 1 AS k) AS d WHERE d.k = People.Id \
         UNION SELECT 1)
@@ -1489,7 +1489,7 @@ struct EngineReachedCorrelatedSetopTests {
     // column types — the execution seam skips the strict fold — so the
     // incompatible pair does not fault. The right arm always yields a row, so
     // the EXISTS is present for every outer row and each projects its `Id`.
-    try enginePeople().expect("""
+    try roster().expect("""
         SELECT Id FROM People WHERE EXISTS ( \
         SELECT 'x' FROM (SELECT 1 AS k) AS d WHERE d.k = People.Id \
         UNION SELECT 1)
@@ -1505,7 +1505,7 @@ struct EngineReachedCorrelatedSetopTests {
     let routines: Routines = [
       "tag": Routine(returns: .text, parameters: [.text]) { _ in .text("t") }
     ]
-    try enginePeople().expect("""
+    try roster().expect("""
         SELECT tag() FROM People FETCH FIRST 0 ROWS ONLY UNION SELECT 1
         """, yields: [[1]], routines: routines)
   }
@@ -1522,7 +1522,7 @@ struct EngineReachedCorrelatedSetopTests {
     ]
     let statement = try Statement(parsing: "SELECT tag() UNION SELECT 1")
     #expect(throws: SQLError.argument("tag takes 1 arguments")) {
-      _ = try enginePeople().columns(of: statement, routines: routines,
+      _ = try roster().columns(of: statement, routines: routines,
                                      validate: true)
     }
   }
@@ -1536,7 +1536,7 @@ struct EngineReachedCorrelatedSetopTests {
     let routines: Routines = [
       "tag": Routine(returns: .text, parameters: [.text]) { _ in .text("t") }
     ]
-    try enginePeople().expect("""
+    try roster().expect("""
         SELECT tag('a') FROM People UNION SELECT 1
         """, fails: .operand("UNION arms have irreconcilable types"),
         routines: routines)

--- a/Tests/SQLTests/Queries/EngineViewAndPushdownTests.swift
+++ b/Tests/SQLTests/Queries/EngineViewAndPushdownTests.swift
@@ -12,7 +12,7 @@ struct EngineViewTests {
   @Test func `a view resolves and queries like a table`() throws {
     // `SELECT * FROM Adults` runs the view's `SELECT Id, Name FROM Parent
     // WHERE Id >= 2`, exposing the columns as `Key`/`Label`.
-    let rows = try engineView("SELECT * FROM Adults")
+    let rows = try view("SELECT * FROM Adults")
     #expect(rows == [
       [.integer(2), .text("Bee")],
       [.integer(3), .text("Cid")],
@@ -20,23 +20,23 @@ struct EngineViewTests {
   }
 
   @Test func `a projection over a view selects the view's columns by name`() throws {
-    try engineViews().expect("SELECT Label FROM Adults", yields: [["Bee"], ["Cid"]])
+    try gallery().expect("SELECT Label FROM Adults", yields: [["Bee"], ["Cid"]])
   }
 
   @Test func `a WHERE over a view filters its rows`() throws {
-    try engineViews().expect("SELECT Label FROM Adults WHERE Key = 3",
+    try gallery().expect("SELECT Label FROM Adults WHERE Key = 3",
                        yields: [["Cid"]])
   }
 
   @Test func `an ORDER BY over a view orders its rows`() throws {
-    try engineViews().expect("SELECT Label FROM Adults ORDER BY Label DESC",
+    try gallery().expect("SELECT Label FROM Adults ORDER BY Label DESC",
                        yields: [["Cid"], ["Bee"]])
   }
 
   @Test func `a view whose definition is a join resolves and queries`() throws {
     // `Pairs` denormalises the `Parent`/`Child` foreign-key join; querying it
     // runs the inner join and exposes its two columns as `Parent`/`Kid`.
-    let rows = try engineView("SELECT * FROM Pairs")
+    let rows = try view("SELECT * FROM Pairs")
     #expect(rows == [
       [.text("Ada"), .text("Ann")],
       [.text("Ada"), .text("Amy")],
@@ -45,13 +45,13 @@ struct EngineViewTests {
   }
 
   @Test func `a projection and filter over a join view selects across its columns`() throws {
-    try engineViews().expect("SELECT Kid FROM Pairs WHERE Parent = 'Ada'",
+    try gallery().expect("SELECT Kid FROM Pairs WHERE Parent = 'Ada'",
                        yields: [["Ann"], ["Amy"]])
   }
 
   @Test func `an unknown column of a view is reported`() throws {
     #expect(throws: SQLError.column("Missing")) {
-      try engineView("SELECT Missing FROM Adults")
+      try view("SELECT Missing FROM Adults")
     }
   }
 
@@ -59,21 +59,21 @@ struct EngineViewTests {
     // `Parent` is two columns wide, but the view declares three. A `SELECT *`
     // has no statically known arity, so the parser admits the list; the engine
     // catches the mismatch at resolution rather than indexing past a row.
-    let star = try View(query: engineSelect("SELECT * FROM Parent"),
+    let star = try View(query: select("SELECT * FROM Parent"),
                         columns: ["a", "b", "c"])
-    let catalog = EngineMemory(try engineFamily().catalog, views: ["Star": star])
+    let catalog = EngineMemory(try family().catalog, views: ["Star": star])
     #expect(throws: SQLError.columns(expected: 2, got: 3)) {
-      try catalog.run(engineParse("SELECT a FROM Star"))
+      try catalog.run(parse("SELECT a FROM Star"))
     }
   }
 
   @Test func `a SELECT * view whose explicit list matches the width resolves`() throws {
     // The same `SELECT *` view declared with the right number of columns
     // resolves and queries — the backstop passes the well-formed view through.
-    let star = try View(query: engineSelect("SELECT * FROM Parent"),
+    let star = try View(query: select("SELECT * FROM Parent"),
                         columns: ["a", "b"])
-    let catalog = EngineMemory(try engineFamily().catalog, views: ["Star": star])
-    let rows = try catalog.run(engineParse("SELECT b FROM Star WHERE a = 1"))
+    let catalog = EngineMemory(try family().catalog, views: ["Star": star])
+    let rows = try catalog.run(parse("SELECT b FROM Star WHERE a = 1"))
     #expect(rows == [[.text("Ada")]])
   }
 
@@ -83,13 +83,13 @@ struct EngineViewTests {
     // scanning under a `Select`. Compile and optimise an outer query over the
     // view and inspect the `.derived` leaf: its sub-plan must reach a seeked
     // `.scan` (a non-nil seek) and carry no `.select` over a raw scan.
-    let catalog = try engineViews()
-    let select = try engineParse("SELECT Key, Label FROM Adults")
+    let catalog = try gallery()
+    let select = try parse("SELECT Key, Label FROM Adults")
     let compiled = try catalog.compile(select)
     let plan = try catalog.optimise(compiled, [:])
-    let sub = try #require(engineDerived(plan))
-    #expect(engineSeeks(sub))
-    #expect(!engineFilters(sub))
+    let sub = try #require(derived(plan))
+    #expect(sought(sub))
+    #expect(!filters(sub))
   }
 }
 
@@ -112,7 +112,7 @@ struct EngineViewCorrelationTests {
   /// a source `Src` WITHOUT `k`, and a view `Bad` whose body references the
   /// unbound `k`.
   private func leaky() throws -> EngineMemory {
-    let bad = try View(query: engineSelect("SELECT n FROM Src WHERE k = 1"),
+    let bad = try View(query: select("SELECT n FROM Src WHERE k = 1"),
                        columns: ["n"])
     return EngineMemory([
       "Env": FixtureRelation([EngineField(name: "k", type: .integer)],
@@ -139,7 +139,7 @@ struct EngineViewCorrelationTests {
     // Schema ↔ run parity: the STRICT schema pass faults the view body's
     // unbound `k` too, rather than binding it to the caller — the leak the fold
     // introduced would have compiled a schema for a view that cannot run.
-    let query = try engineParse(
+    let query = try parse(
         "SELECT k FROM Env WHERE EXISTS (SELECT n FROM Bad)")
     #expect(throws: SQLError.self) {
       _ = try leaky().columns(of: query, validate: true)
@@ -151,7 +151,7 @@ struct EngineViewCorrelationTests {
     // subquery still resolves and runs — clearing the view body's correlation
     // stack does not disturb a well-formed view. `Good` reads `Src` (one row),
     // so the EXISTS holds for every `Env` row.
-    let good = try View(query: engineSelect("SELECT n FROM Src"), columns: ["n"])
+    let good = try View(query: select("SELECT n FROM Src"), columns: ["n"])
     let catalog = EngineMemory([
       "Env": FixtureRelation([EngineField(name: "k", type: .integer)],
                                [[.integer(1)], [.integer(2)]]
@@ -201,7 +201,7 @@ struct EngineViewCorrelationTests {
   /// WITHOUT `k`, and a view `Proj` whose body PROJECTS the unbound `k` — so its
   /// SCHEMA (the projection's type) is what a leak would derive from the caller.
   private func leaked() throws -> EngineMemory {
-    let proj = try View(query: engineSelect("SELECT k AS m FROM Src"),
+    let proj = try View(query: select("SELECT k AS m FROM Src"),
                         columns: ["m"])
     return EngineMemory([
       "Env": FixtureRelation([EngineField(name: "k", type: .integer)],
@@ -232,7 +232,7 @@ struct EngineViewCorrelationTests {
     // `Env.k`. This is the seam the run/compile path (`resolve`/`overlay`)
     // clears elsewhere but `schema(of:)` did NOT until routed through `body`.
     let catalog = try leaked()
-    let target = try engineSelect("SELECT m FROM Proj").first
+    let target = try select("SELECT m FROM Proj").first
     let context = try enclosing(catalog)
     var raised: SQLError?
     do {
@@ -250,7 +250,7 @@ struct EngineViewCorrelationTests {
     // its schema derived under the SAME correlated scope — clearing the schema
     // path's correlation stack does not disturb a legitimate view. `Fine`
     // projects `n` (in its own `Src`), so `scope(of:)` derives cleanly.
-    let fine = try View(query: engineSelect("SELECT n AS m FROM Src"),
+    let fine = try View(query: select("SELECT n AS m FROM Src"),
                         columns: ["m"])
     let catalog = EngineMemory([
       "Env": FixtureRelation([EngineField(name: "k", type: .integer)],
@@ -258,7 +258,7 @@ struct EngineViewCorrelationTests {
       "Src": FixtureRelation([EngineField(name: "n", type: .integer)],
                              [[.integer(7)]] as Array<Array<Value>>),
     ], views: ["Fine": fine])
-    let target = try engineSelect("SELECT m FROM Fine").first
+    let target = try select("SELECT m FROM Fine").first
     let context = try enclosing(catalog)
     // Eager rather than `#expect(throws:)` — a borrowed `~Escapable` catalog
     // cannot be captured by the assertion's escaping closure.
@@ -275,70 +275,70 @@ struct EngineViewCorrelationTests {
 }
 
 /// The sub-plan of the first `.derived` leaf reachable from `plan`, or `nil`.
-func engineDerived(_ plan: Plan) -> Plan? {
+func derived(_ plan: Plan) -> Plan? {
   switch plan {
   case let .derived(_, sub, _, _):
     sub
   case let .select(_, source):
-    engineDerived(source)
+    derived(source)
   case let .project(_, source):
-    engineDerived(source)
+    derived(source)
   case let .sort(_, source):
-    engineDerived(source)
+    derived(source)
   case let .product(left, right):
-    engineDerived(left) ?? engineDerived(right)
+    derived(left) ?? derived(right)
   case let .outer(left, right, _, _):
-    engineDerived(left) ?? engineDerived(right)
+    derived(left) ?? derived(right)
   case let .semijoin(left, right, _, _):
-    engineDerived(left) ?? engineDerived(right)
+    derived(left) ?? derived(right)
   case let .apply(left, _, _, _, _, _):
-    engineDerived(left)
+    derived(left)
   case let .setop(_, left, right, _, _, _):
-    engineDerived(left) ?? engineDerived(right)
+    derived(left) ?? derived(right)
   case let .limit(_, _, source):
-    engineDerived(source)
+    derived(source)
   case let .distinct(source):
-    engineDerived(source)
+    derived(source)
   case let .aggregate(_, _, source):
-    engineDerived(source)
+    derived(source)
   case .single, .empty, .scan, .join:
     nil
   }
 }
 
 /// Whether `plan` reaches a `.scan` carrying a non-nil seek.
-func engineSeeks(_ plan: Plan) -> Bool {
+func sought(_ plan: Plan) -> Bool {
   switch plan {
   case let .scan(_, _, seek):
     seek != nil
   case let .select(_, source):
-    engineSeeks(source)
+    sought(source)
   case let .project(_, source):
-    engineSeeks(source)
+    sought(source)
   case let .sort(_, source):
-    engineSeeks(source)
+    sought(source)
   case let .derived(_, sub, _, _):
-    engineSeeks(sub)
+    sought(sub)
   case let .product(left, right):
-    engineSeeks(left) || engineSeeks(right)
+    sought(left) || sought(right)
   case let .join(outer, _, _, _, _, _, _):
     // A pushed-down key seeks the join's OUTER leaf, so a seek can live inside
     // the join rather than only atop a bare scan.
-    engineSeeks(outer)
+    sought(outer)
   case let .outer(left, right, _, _):
-    engineSeeks(left) || engineSeeks(right)
+    sought(left) || sought(right)
   case let .semijoin(left, right, _, _):
-    engineSeeks(left) || engineSeeks(right)
+    sought(left) || sought(right)
   case let .apply(left, _, _, _, _, _):
-    engineSeeks(left)
+    sought(left)
   case let .setop(_, left, right, _, _, _):
-    engineSeeks(left) || engineSeeks(right)
+    sought(left) || sought(right)
   case let .limit(_, _, source):
-    engineSeeks(source)
+    sought(source)
   case let .distinct(source):
-    engineSeeks(source)
+    sought(source)
   case let .aggregate(_, _, source):
-    engineSeeks(source)
+    sought(source)
   case .single, .empty:
     false
   }
@@ -346,34 +346,34 @@ func engineSeeks(_ plan: Plan) -> Bool {
 
 /// Whether `plan` wraps a raw (unseeked) `.scan` in a `.select` — the
 /// un-optimised shape the fix eliminates from a view's sub-plan.
-func engineFilters(_ plan: Plan) -> Bool {
+func filters(_ plan: Plan) -> Bool {
   switch plan {
   case .select(_, .scan(_, _, nil)):
     true
   case let .select(_, source):
-    engineFilters(source)
+    filters(source)
   case let .project(_, source):
-    engineFilters(source)
+    filters(source)
   case let .sort(_, source):
-    engineFilters(source)
+    filters(source)
   case let .derived(_, sub, _, _):
-    engineFilters(sub)
+    filters(sub)
   case let .product(left, right):
-    engineFilters(left) || engineFilters(right)
+    filters(left) || filters(right)
   case let .outer(left, right, _, _):
-    engineFilters(left) || engineFilters(right)
+    filters(left) || filters(right)
   case let .semijoin(left, right, _, _):
-    engineFilters(left) || engineFilters(right)
+    filters(left) || filters(right)
   case let .apply(left, _, _, _, _, _):
-    engineFilters(left)
+    filters(left)
   case let .setop(_, left, right, _, _, _):
-    engineFilters(left) || engineFilters(right)
+    filters(left) || filters(right)
   case let .limit(_, _, source):
-    engineFilters(source)
+    filters(source)
   case let .distinct(source):
-    engineFilters(source)
+    filters(source)
   case let .aggregate(_, _, source):
-    engineFilters(source)
+    filters(source)
   case .single, .empty, .scan, .join:
     false
   }
@@ -383,37 +383,37 @@ func engineFilters(_ plan: Plan) -> Bool {
 /// the shape selection pushdown produces (a `.select` or a seeked `.scan` inside
 /// a join's outer operand or a product's arm), as opposed to a `WHERE` left
 /// floating atop the whole chain.
-func enginePushed(_ plan: Plan) -> Bool {
+func pushed(_ plan: Plan) -> Bool {
   switch plan {
   case let .join(outer, _, _, _, _, _, _):
-    engineSeeks(outer) || engineFloats(outer) || enginePushed(outer)
+    sought(outer) || floating(outer) || pushed(outer)
   case let .product(left, right):
-    engineSeeks(left) || engineFloats(left) || enginePushed(left) || engineSeeks(right)
-        || engineFloats(right) || enginePushed(right)
+    sought(left) || floating(left) || pushed(left) || sought(right)
+        || floating(right) || pushed(right)
   case let .outer(left, right, _, _):
-    engineSeeks(left) || engineFloats(left) || enginePushed(left) || engineSeeks(right)
-        || engineFloats(right) || enginePushed(right)
+    sought(left) || floating(left) || pushed(left) || sought(right)
+        || floating(right) || pushed(right)
   case let .semijoin(left, right, _, _):
-    engineSeeks(left) || engineFloats(left) || enginePushed(left)
-        || engineSeeks(right) || engineFloats(right) || enginePushed(right)
+    sought(left) || floating(left) || pushed(left)
+        || sought(right) || floating(right) || pushed(right)
   case let .apply(left, _, _, _, _, _):
-    engineSeeks(left) || engineFloats(left) || enginePushed(left)
+    sought(left) || floating(left) || pushed(left)
   case let .select(_, source):
-    enginePushed(source)
+    pushed(source)
   case let .project(_, source):
-    enginePushed(source)
+    pushed(source)
   case let .sort(_, source):
-    enginePushed(source)
+    pushed(source)
   case let .derived(_, sub, _, _):
-    enginePushed(sub)
+    pushed(sub)
   case let .setop(_, left, right, _, _, _):
-    enginePushed(left) || enginePushed(right)
+    pushed(left) || pushed(right)
   case let .limit(_, _, source):
-    enginePushed(source)
+    pushed(source)
   case let .distinct(source):
-    enginePushed(source)
+    pushed(source)
   case let .aggregate(_, _, source):
-    enginePushed(source)
+    pushed(source)
   case .single, .empty, .scan:
     false
   }
@@ -421,18 +421,18 @@ func enginePushed(_ plan: Plan) -> Bool {
 
 /// Whether `plan` is (or reaches through unary operators) a `.select` — a filter
 /// standing over a source.
-func engineFloats(_ plan: Plan) -> Bool {
+func floating(_ plan: Plan) -> Bool {
   switch plan {
   case .select:
     true
   case let .project(_, source):
-    engineFloats(source)
+    floating(source)
   case let .sort(_, source):
-    engineFloats(source)
+    floating(source)
   case let .derived(_, sub, _, _):
-    engineFloats(sub)
+    floating(sub)
   case let .limit(_, _, source):
-    engineFloats(source)
+    floating(source)
   default:
     false
   }
@@ -440,34 +440,34 @@ func engineFloats(_ plan: Plan) -> Bool {
 
 /// Whether `plan` reaches a `.join` node — the index-nested-loop/hash join path,
 /// as opposed to a residual `.product` filtered by the ON predicate.
-func engineJoins(_ plan: Plan) -> Bool {
+func joined(_ plan: Plan) -> Bool {
   switch plan {
   case .join:
     true
   case let .select(_, source):
-    engineJoins(source)
+    joined(source)
   case let .project(_, source):
-    engineJoins(source)
+    joined(source)
   case let .sort(_, source):
-    engineJoins(source)
+    joined(source)
   case let .limit(_, _, source):
-    engineJoins(source)
+    joined(source)
   case let .distinct(source):
-    engineJoins(source)
+    joined(source)
   case let .derived(_, sub, _, _):
-    engineJoins(sub)
+    joined(sub)
   case let .product(left, right):
-    engineJoins(left) || engineJoins(right)
+    joined(left) || joined(right)
   case let .outer(left, right, _, _):
-    engineJoins(left) || engineJoins(right)
+    joined(left) || joined(right)
   case let .semijoin(left, right, _, _):
-    engineJoins(left) || engineJoins(right)
+    joined(left) || joined(right)
   case let .apply(left, _, _, _, _, _):
-    engineJoins(left)
+    joined(left)
   case let .setop(_, left, right, _, _, _):
-    engineJoins(left) || engineJoins(right)
+    joined(left) || joined(right)
   case let .aggregate(_, _, source):
-    engineJoins(source)
+    joined(source)
   case .single, .empty, .scan:
     false
   }
@@ -476,36 +476,36 @@ func engineJoins(_ plan: Plan) -> Bool {
 /// Whether `plan` reaches a `.select` standing directly over a `.product` — the
 /// residual product-under-select the streaming path fuses and filters row by
 /// row rather than materialising whole.
-func engineResidual(_ plan: Plan) -> Bool {
+func residue(_ plan: Plan) -> Bool {
   switch plan {
   case .select(_, .product):
     true
   case let .select(_, source):
-    engineResidual(source)
+    residue(source)
   case let .project(_, source):
-    engineResidual(source)
+    residue(source)
   case let .sort(_, source):
-    engineResidual(source)
+    residue(source)
   case let .limit(_, _, source):
-    engineResidual(source)
+    residue(source)
   case let .distinct(source):
-    engineResidual(source)
+    residue(source)
   case let .derived(_, sub, _, _):
-    engineResidual(sub)
+    residue(sub)
   case let .product(left, right):
-    engineResidual(left) || engineResidual(right)
+    residue(left) || residue(right)
   case let .join(outer, _, _, _, _, _, _):
-    engineResidual(outer)
+    residue(outer)
   case let .outer(left, right, _, _):
-    engineResidual(left) || engineResidual(right)
+    residue(left) || residue(right)
   case let .semijoin(left, right, _, _):
-    engineResidual(left) || engineResidual(right)
+    residue(left) || residue(right)
   case let .apply(left, _, _, _, _, _):
-    engineResidual(left)
+    residue(left)
   case let .setop(_, left, right, _, _, _):
-    engineResidual(left) || engineResidual(right)
+    residue(left) || residue(right)
   case let .aggregate(_, _, source):
-    engineResidual(source)
+    residue(source)
   case .single, .empty, .scan:
     false
   }
@@ -515,36 +515,36 @@ func engineResidual(_ plan: Plan) -> Bool {
 /// over a `.product` — the WHERE-above-a-separate-ON-gate shape the barrier
 /// preserves (the outer `select` the `WHERE`, the inner the residual `ON`
 /// gate), as opposed to one fused `.select(ON AND WHERE, product)`.
-func engineSeparated(_ plan: Plan) -> Bool {
+func separated(_ plan: Plan) -> Bool {
   switch plan {
   case .select(_, .select(_, .product)):
     true
   case let .select(_, source):
-    engineSeparated(source)
+    separated(source)
   case let .project(_, source):
-    engineSeparated(source)
+    separated(source)
   case let .sort(_, source):
-    engineSeparated(source)
+    separated(source)
   case let .limit(_, _, source):
-    engineSeparated(source)
+    separated(source)
   case let .distinct(source):
-    engineSeparated(source)
+    separated(source)
   case let .derived(_, sub, _, _):
-    engineSeparated(sub)
+    separated(sub)
   case let .product(left, right):
-    engineSeparated(left) || engineSeparated(right)
+    separated(left) || separated(right)
   case let .join(outer, _, _, _, _, _, _):
-    engineSeparated(outer)
+    separated(outer)
   case let .outer(left, right, _, _):
-    engineSeparated(left) || engineSeparated(right)
+    separated(left) || separated(right)
   case let .semijoin(left, right, _, _):
-    engineSeparated(left) || engineSeparated(right)
+    separated(left) || separated(right)
   case let .apply(left, _, _, _, _, _):
-    engineSeparated(left)
+    separated(left)
   case let .setop(_, left, right, _, _, _):
-    engineSeparated(left) || engineSeparated(right)
+    separated(left) || separated(right)
   case let .aggregate(_, _, source):
-    engineSeparated(source)
+    separated(source)
   case .single, .empty, .scan:
     false
   }
@@ -555,36 +555,36 @@ func engineSeparated(_ plan: Plan) -> Bool {
 /// preserves for a pure-equi `ON` whose extra equi key `nest` leaves gating
 /// over the hash join (the outer `select` the `WHERE`, the inner the leftover
 /// match), as opposed to one fused `.select(match AND WHERE, join)`.
-func engineStacked(_ plan: Plan) -> Bool {
+func stacked(_ plan: Plan) -> Bool {
   switch plan {
   case .select(_, .select(_, .join)):
     true
   case let .select(_, source):
-    engineStacked(source)
+    stacked(source)
   case let .project(_, source):
-    engineStacked(source)
+    stacked(source)
   case let .sort(_, source):
-    engineStacked(source)
+    stacked(source)
   case let .limit(_, _, source):
-    engineStacked(source)
+    stacked(source)
   case let .distinct(source):
-    engineStacked(source)
+    stacked(source)
   case let .derived(_, sub, _, _):
-    engineStacked(sub)
+    stacked(sub)
   case let .product(left, right):
-    engineStacked(left) || engineStacked(right)
+    stacked(left) || stacked(right)
   case let .join(outer, _, _, _, _, _, _):
-    engineStacked(outer)
+    stacked(outer)
   case let .outer(left, right, _, _):
-    engineStacked(left) || engineStacked(right)
+    stacked(left) || stacked(right)
   case let .semijoin(left, right, _, _):
-    engineStacked(left) || engineStacked(right)
+    stacked(left) || stacked(right)
   case let .apply(left, _, _, _, _, _):
-    engineStacked(left)
+    stacked(left)
   case let .setop(_, left, right, _, _, _):
-    engineStacked(left) || engineStacked(right)
+    stacked(left) || stacked(right)
   case let .aggregate(_, _, source):
-    engineStacked(source)
+    stacked(source)
   case .single, .empty, .scan:
     false
   }
@@ -620,7 +620,7 @@ private func counted() throws -> (catalog: EngineMemory, reads: EngineCounter) {
     [.integer(3), .text("Cody")],
   ] as Array<Array<Value>>
 
-  let kin = try View(query: engineSelect("""
+  let kin = try View(query: select("""
       SELECT Parent.Id, Parent.Name, Child.Kid FROM Parent
         JOIN Child ON Child.Pid = Parent.Id
       """), columns: ["Key", "Name", "Kid"])
@@ -661,7 +661,7 @@ private func spanned() throws -> EngineMemory {
   // Arm 1 projects Alpha.Key (body slot 0, seekable) then Tag; arm 2 projects
   // Beta.Key (body slot 1, unseekable) then Tag — the same output `Key` at
   // differing body slots.
-  let both = try View(query: engineSelect("""
+  let both = try View(query: select("""
       SELECT Key, Tag FROM Alpha UNION ALL SELECT Key, Tag FROM Beta
       """), columns: ["Key", "Tag"])
   return EngineMemory([
@@ -676,7 +676,7 @@ private func spanned() throws -> EngineMemory {
 private func injected(_ plan: Plan) -> Bool {
   switch plan {
   case let .setop(_, left, right, _, _, _):
-    (engineSeeks(left) || engineFloats(left)) && (engineSeeks(right) || engineFloats(right))
+    (sought(left) || floating(left)) && (sought(right) || floating(right))
   case let .select(_, source):
     injected(source)
   case let .project(_, source):
@@ -711,28 +711,28 @@ struct EnginePushdownTests {
     // `WHERE Parent.Name = 'Ada'` references only the outer relation, so it
     // pushes to the Parent leaf inside the join rather than filtering the whole
     // product afterwards — `pushed` sees a filter within the join's outer.
-    let catalog = try engineFamily()
-    let select = try engineParse("""
+    let catalog = try family()
+    let select = try parse("""
         SELECT Child.Name FROM Parent JOIN Child ON Child.Pid = Parent.Id
           WHERE Parent.Name = 'Ada'
         """)
     let compiled = try catalog.compile(select)
     let plan = try catalog.optimise(compiled.pushdown(), [:])
-    #expect(enginePushed(plan))
+    #expect(pushed(plan))
   }
 
   @Test func `pushdown down a seekable outer key seeks that leaf inside the join`() throws {
     // `WHERE Parent.Id = 2` is seekable; pushed to the Parent leaf it becomes a
     // seek inside the join's outer, not a scan-then-filter atop the product.
-    let catalog = try engineFamily()
-    let select = try engineParse("""
+    let catalog = try family()
+    let select = try parse("""
         SELECT Child.Name FROM Parent JOIN Child ON Child.Pid = Parent.Id
           WHERE Parent.Id = 2
         """)
     let compiled = try catalog.compile(select)
     let plan = try catalog.optimise(compiled.pushdown(), [:])
-    #expect(engineSeeks(plan))
-    #expect(enginePushed(plan))
+    #expect(sought(plan))
+    #expect(pushed(plan))
   }
 
   @Test func `a trailing seekable conjunct survives a rebuilt three-term AND`() throws {
@@ -752,12 +752,12 @@ struct EnginePushdownTests {
         [.text("b"), .integer(2), .integer(6)],
       ] as Array<Array<Value>>, sorted: 2),
     ])
-    let select = try engineParse("""
+    let select = try parse("""
         SELECT Name FROM T WHERE Name <> 'x' AND Age > 0 AND Id = 5
         """)
     let compiled = try catalog.compile(select)
     let plan = try catalog.optimise(compiled.pushdown(), [:])
-    #expect(engineSeeks(plan))
+    #expect(sought(plan))
   }
 
   @Test func `a seekable conjunct grouped after an unsafe one does not bypass its throw`() throws {
@@ -777,14 +777,14 @@ struct EnginePushdownTests {
         [.integer(0), .text("a"), .integer(5)],
       ] as Array<Array<Value>>, sorted: 2),
     ])
-    let select = try engineParse("""
+    let select = try parse("""
         SELECT id FROM T WHERE (1 / x) = 0 AND (name <> 'z' AND id < 0)
         """)
 
     // The unsafe `(1 / x) = 0` residual bars the `id < 0` seek — the plan scans.
     let compiled = try catalog.compile(select)
     let plan = try catalog.optimise(compiled.pushdown(), [:])
-    #expect(!engineSeeks(plan))
+    #expect(!sought(plan))
 
     // …and the scan raises the division rather than seeking past the empty run.
     #expect(throws: SQLError.self) {
@@ -794,7 +794,7 @@ struct EnginePushdownTests {
 
   @Test func `pushdown preserves the join's result`() throws {
     // The pushed plan must return exactly the un-pushed join's rows.
-    try engineFamily().expect("""
+    try family().expect("""
         SELECT Child.Name FROM Parent JOIN Child ON Child.Pid = Parent.Id
           WHERE Parent.Name = 'Ada'
         """,
@@ -807,18 +807,18 @@ struct EnginePushdownTests {
     // join folds it in. `nest` must look through that pushed filter and still
     // form a `Join` — not fall back to a residual product filtered by the ON
     // predicate (O(left × filtered-right)).
-    let catalog = try engineFamily()
-    let select = try engineParse("""
+    let catalog = try family()
+    let select = try parse("""
         SELECT Child.Name, Parent.Name FROM Child
           JOIN Parent ON Parent.Id = Child.Pid WHERE Parent.Name <> 'zz'
         """)
     let compiled = try catalog.compile(select)
     let plan = try catalog.optimise(compiled.pushdown(), [:])
-    #expect(engineJoins(plan))
+    #expect(joined(plan))
 
     // …and it returns the correct rows: every child with a matching parent,
     // the joined-in predicate keeping all of them (no parent is named 'zz').
-    try engineFamily().expect("""
+    try family().expect("""
         SELECT Child.Name, Parent.Name FROM Child
           JOIN Parent ON Parent.Id = Child.Pid WHERE Parent.Name <> 'zz'
         """,
@@ -832,19 +832,19 @@ struct EnginePushdownTests {
     // conjunct — so `nest` still finds it and forms a `Join`, keeping the
     // spanning predicate as a `Select` ABOVE the join rather than degrading to a
     // filtered Cartesian `product`.
-    let catalog = try engineFamily()
-    let select = try engineParse("""
+    let catalog = try family()
+    let select = try parse("""
         SELECT Child.Name, Parent.Name FROM Parent
           JOIN Child ON Child.Pid = Parent.Id WHERE Parent.Name <> Child.Name
         """)
     let compiled = try catalog.compile(select)
     let plan = try catalog.optimise(compiled.pushdown(), [:])
-    #expect(engineJoins(plan))
-    #expect(engineFloats(plan))
+    #expect(joined(plan))
+    #expect(floating(plan))
 
     // …and it returns the join's rows filtered by the spanning predicate: every
     // matched pair survives, none sharing a name across the two relations.
-    try engineFamily().expect("""
+    try family().expect("""
         SELECT Child.Name, Parent.Name FROM Parent
           JOIN Child ON Child.Pid = Parent.Id WHERE Parent.Name <> Child.Name
         """,
@@ -856,13 +856,13 @@ struct EnginePushdownTests {
     // view's sub-plan and seek Parent to the single matching row before joining,
     // so only that parent's rows are read — not the whole relation.
     let (culled, pruned) = try counted()
-    let rows = try culled.run(engineParse("SELECT Kid FROM Kin WHERE Key = 2"))
+    let rows = try culled.run(parse("SELECT Kid FROM Kin WHERE Key = 2"))
     #expect(rows == [[.text("Bob")]])
 
     // The un-pushed baseline: the same view with no `WHERE` reads every parent
     // row — three.
     let (whole, full) = try counted()
-    _ = try whole.run(engineParse("SELECT Kid FROM Kin"))
+    _ = try whole.run(parse("SELECT Kid FROM Kin"))
     #expect(full.reads == 3)
 
     // Pushed, the seek reads the one matching parent — a single row.
@@ -872,10 +872,10 @@ struct EnginePushdownTests {
   @Test func `the pushed view result matches the unfiltered view filtered late`() throws {
     // Running the view then filtering must agree with the pushed plan.
     let (catalog, _) = try counted()
-    let all = try catalog.run(engineParse("SELECT Key, Kid FROM Kin"))
+    let all = try catalog.run(parse("SELECT Key, Kid FROM Kin"))
     let culled = all.filter { $0[0] == .integer(2) }.map { [$0[1]] }
     let filtered =
-        try catalog.run(engineParse("SELECT Kid FROM Kin WHERE Key = 2"))
+        try catalog.run(parse("SELECT Kid FROM Kin WHERE Key = 2"))
     #expect(filtered == culled)
   }
 
@@ -891,7 +891,7 @@ struct EnginePushdownTests {
       "B": FixtureRelation([EngineField(name: "y", type: .integer)],
                     [] as Array<Array<Value>>),
     ])
-    let rows = try catalog.run(engineParse("""
+    let rows = try catalog.run(parse("""
         SELECT A.x FROM A JOIN B ON A.x = B.y WHERE (1 / 0) = 0
         """))
     #expect(rows.isEmpty)
@@ -909,7 +909,7 @@ struct EnginePushdownTests {
       "B": FixtureRelation([EngineField(name: "y", type: .integer)],
                     [] as Array<Array<Value>>),
     ])
-    let rows = try catalog.run(engineParse("""
+    let rows = try catalog.run(parse("""
         SELECT A.x FROM A JOIN B ON A.x = B.y WHERE (1 / A.x) = 0
         """))
     #expect(rows.isEmpty)
@@ -928,7 +928,7 @@ struct EnginePushdownTests {
                     [[.integer(0)]] as Array<Array<Value>>),
     ])
     #expect(throws: SQLError.self) {
-      _ = try catalog.run(engineParse("""
+      _ = try catalog.run(parse("""
           SELECT A.x FROM A JOIN B ON A.x = B.y WHERE (1 / A.x) = 0 AND A.x <> 0
           """))
     }
@@ -951,7 +951,7 @@ struct EnginePushdownTests {
                          [[.integer(1), .text("other")]]
                              as Array<Array<Value>>),
     ])
-    let rows = try catalog.run(engineParse("""
+    let rows = try catalog.run(parse("""
         SELECT Child.x FROM Child JOIN Parent ON Parent.Id = Child.Pid
           WHERE Parent.Name = 'nope' AND (1 / Child.x) = 0
         """))
@@ -964,11 +964,11 @@ struct EnginePushdownTests {
     // fails a single pre-rebased filter — pushing below each arm's projection
     // and seeking the sorted `Alpha` arm.
     let catalog = try spanned()
-    let select = try engineParse("SELECT Tag FROM Both WHERE Key = 2")
+    let select = try parse("SELECT Tag FROM Both WHERE Key = 2")
     let compiled = try catalog.compile(select)
     let plan = try catalog.optimise(compiled.pushdown(), [:])
     #expect(injected(plan))
-    #expect(engineSeeks(plan))
+    #expect(sought(plan))
 
     // …and the rows are exactly the union filtered late: `a2` from Alpha and
     // `b2` from Beta.
@@ -986,11 +986,11 @@ struct EnginePushdownTests {
     let t = [EngineField(name: "id", type: .integer),
              EngineField(name: "z", type: .integer)]
     let rows = [[.integer(0), .integer(0)]] as Array<Array<Value>>
-    let view = try View(query: engineSelect("SELECT id, 1 / z FROM T"),
+    let view = try View(query: select("SELECT id, 1 / z FROM T"),
                         columns: ["id", "q"])
     let catalog = EngineMemory(["T": FixtureRelation(t, rows)], views: ["V": view])
     #expect(throws: SQLError.self) {
-      _ = try catalog.run(engineParse("SELECT id FROM V WHERE id <> 0"))
+      _ = try catalog.run(parse("SELECT id FROM V WHERE id <> 0"))
     }
   }
 
@@ -1005,11 +1005,11 @@ struct EnginePushdownTests {
     // would.
     let t = [EngineField(name: "x", type: .integer)]
     let rows = [[.integer(0)]] as Array<Array<Value>>
-    let view = try View(query: engineSelect("SELECT x FROM T"), columns: ["x"])
+    let view = try View(query: select("SELECT x FROM T"), columns: ["x"])
     let catalog = EngineMemory(["T": FixtureRelation(t, rows, sorted: 0)],
                          views: ["V": view])
     #expect(throws: SQLError.self) {
-      _ = try catalog.run(engineParse("SELECT x FROM V WHERE (1 / x) = 0 AND x = 1"))
+      _ = try catalog.run(parse("SELECT x FROM V WHERE (1 / x) = 0 AND x = 1"))
     }
   }
 
@@ -1030,7 +1030,7 @@ struct EnginePushdownTests {
                      EngineField(name: "k", type: .integer)],
                     [[.integer(0), .integer(0)]] as Array<Array<Value>>),
     ])
-    let select = try engineParse("""
+    let select = try parse("""
         SELECT A.x FROM A JOIN B ON A.k = B.k
           WHERE A.x = 1 AND (1 / B.y) = 0
         """)
@@ -1039,8 +1039,8 @@ struct EnginePushdownTests {
     // pushed to the `A` leaf — it floats at the product level.
     let compiled = try catalog.compile(select)
     let plan = try catalog.optimise(compiled.pushdown(), [:])
-    #expect(!enginePushed(plan))
-    #expect(engineFloats(plan))
+    #expect(!pushed(plan))
+    #expect(floating(plan))
 
     // …and the query raises rather than silently dropping the row.
     #expect(throws: SQLError.self) {
@@ -1059,16 +1059,16 @@ struct EnginePushdownTests {
     let t = [EngineField(name: "x", type: .integer),
              EngineField(name: "y", type: .integer)]
     let rows = [[.null, .integer(0)]] as Array<Array<Value>>
-    let view = try View(query: engineSelect("SELECT x, y FROM T"),
+    let view = try View(query: select("SELECT x, y FROM T"),
                         columns: ["x", "y"])
     let catalog = EngineMemory(["T": FixtureRelation(t, rows)], views: ["V": view])
-    let select = try engineParse("SELECT x FROM V WHERE x = 1 AND (1 / y) = 0")
+    let select = try parse("SELECT x FROM V WHERE x = 1 AND (1 / y) = 0")
 
     // `x = 1` is nullable and precedes the unsafe division, so it is NOT
     // injected into the view — it floats above the derived leaf.
     let compiled = try catalog.compile(select)
     let plan = try catalog.optimise(compiled.pushdown(), [:])
-    #expect(engineFloats(plan))
+    #expect(floating(plan))
 
     // …and the query raises rather than silently dropping the row.
     #expect(throws: SQLError.self) {
@@ -1088,17 +1088,17 @@ struct EnginePushdownTests {
     let t = [EngineField(name: "x", type: .integer),
              EngineField(name: "y", type: .integer)]
     let rows = [[.integer(1), .integer(0)]] as Array<Array<Value>>
-    let view = try View(query: engineSelect("SELECT x, y FROM T"),
+    let view = try View(query: select("SELECT x, y FROM T"),
                         columns: ["x", "y"])
     let catalog = EngineMemory(["T": FixtureRelation(t, rows)], views: ["V": view])
-    let select = try engineParse("SELECT x FROM V WHERE 1 = :missing AND (1 / y) = 0")
+    let select = try parse("SELECT x FROM V WHERE 1 = :missing AND (1 / y) = 0")
 
     // `1 = :missing` is a slotless bound predicate, hence nullable; it precedes
     // the unsafe division, so it is NOT injected into the view — it floats above
     // the derived leaf.
     let compiled = try catalog.compile(select)
     let plan = try catalog.optimise(compiled.pushdown(), [:])
-    #expect(engineFloats(plan))
+    #expect(floating(plan))
 
     // …and the query raises rather than silently dropping the row.
     #expect(throws: SQLError.self) {
@@ -1121,10 +1121,10 @@ struct EnginePushdownTests {
                         [.integer(0), .null]] as Array<Array<Value>>),
       "T": FixtureRelation([EngineField(name: "k", type: .integer)],
                     [[.integer(1)]] as Array<Array<Value>>),
-    ], views: ["V": try View(query: engineSelect("SELECT k FROM T"),
+    ], views: ["V": try View(query: select("SELECT k FROM T"),
                              columns: ["k"])])
     let select =
-        try engineParse("SELECT A.x FROM A JOIN V ON A.k = V.k WHERE (1 / A.x) = 0")
+        try parse("SELECT A.x FROM A JOIN V ON A.k = V.k WHERE (1 / A.x) = 0")
 
     // The UNKNOWN-ON pair (A.k NULL) is dropped by the match gate before the
     // division runs, so the query returns rows rather than raising.

--- a/Tests/SQLTests/Queries/EngineWithTests.swift
+++ b/Tests/SQLTests/Queries/EngineWithTests.swift
@@ -22,7 +22,7 @@ struct EngineWithTests {
     let rows = try statement("""
         WITH adults (Key, Label) AS (SELECT Id, Name FROM Parent WHERE Id >= 2)
           SELECT Label FROM adults
-        """, engineFamily())
+        """, family())
     #expect(rows == [[.text("Bee")], [.text("Cid")]])
   }
 
@@ -36,11 +36,11 @@ struct EngineWithTests {
     // The SCHEMA path folds the CTE column at its BODY-derived type too: it
     // must report `x` as `.text` and NOT fault, the compile-time mirror of the
     // run.
-    let columns = try engineFamily().columns(of: Statement(parsing: text))
+    let columns = try family().columns(of: Statement(parsing: text))
     #expect(columns.count == 1)
     #expect(columns[0].name == "x")
     #expect(columns[0].type == .text)
-    let rows = try statement(text, engineFamily())
+    let rows = try statement(text, family())
     #expect(rows == [[.text("b")], [.text("c")]])
   }
 
@@ -52,7 +52,7 @@ struct EngineWithTests {
     let rows = try statement("""
         WITH a (x) AS (SELECT 1), b (x) AS (SELECT 1.0)
           SELECT * FROM a JOIN b ON a.x = b.x
-        """, engineFamily())
+        """, family())
     #expect(rows == [[.integer(1), .double(1.0)]])
   }
 
@@ -65,7 +65,7 @@ struct EngineWithTests {
         WITH a (x) AS (SELECT 9007199254740993),
              b (x) AS (SELECT 9007199254740993.0)
           SELECT a.x FROM a JOIN b ON a.x = b.x
-        """, engineFamily())
+        """, family())
     #expect(rows == [[.integer(9007199254740993)]])
   }
 
@@ -78,7 +78,7 @@ struct EngineWithTests {
         WITH a (x) AS (SELECT 9007199254740992),
              b (x) AS (SELECT 9007199254740993)
           SELECT a.x FROM a JOIN b ON a.x = b.x
-        """, engineFamily())
+        """, family())
     #expect(rows.isEmpty)
   }
 
@@ -88,10 +88,10 @@ struct EngineWithTests {
     // it. `1` and `1.0` then compare equal AND emit as the same coerced
     // `double`, so a bare UNION keeps one `1.0` (not the first arm's raw
     // `integer`).
-    #expect(try statement("SELECT 1 UNION SELECT 1.0", engineFamily())
+    #expect(try statement("SELECT 1 UNION SELECT 1.0", family())
             == [[.double(1.0)]])
     // UNION ALL keeps every row, each coerced to the unified `double`.
-    #expect(try statement("SELECT 1 UNION ALL SELECT 1.0", engineFamily())
+    #expect(try statement("SELECT 1 UNION ALL SELECT 1.0", family())
             == [[.double(1.0)], [.double(1.0)]])
   }
 
@@ -105,7 +105,7 @@ struct EngineWithTests {
         SELECT 9007199254740992.0
           UNION SELECT 9007199254740992
           UNION SELECT 9007199254740993
-        """, engineFamily())
+        """, family())
     #expect(rows == [[.double(9007199254740992.0)]])
   }
 
@@ -114,7 +114,7 @@ struct EngineWithTests {
     // emits as `3.0` — and the ordering runs over the widened values.
     let rows = try statement("""
         WITH a (x) AS (SELECT 3 UNION ALL SELECT 1.5) SELECT x FROM a ORDER BY x
-        """, engineFamily())
+        """, family())
     #expect(rows == [[.double(1.5)], [.double(3.0)]])
   }
 
@@ -128,7 +128,7 @@ struct EngineWithTests {
                        UNION ALL SELECT 9007199254740993.0
                        UNION ALL SELECT 9007199254740992)
           SELECT x FROM a ORDER BY x
-        """, engineFamily())
+        """, family())
     #expect(rows.count == 3)
     #expect(rows.last == [.double(9007199254740992.0)])
   }
@@ -137,7 +137,7 @@ struct EngineWithTests {
     let rows = try statement("""
         WITH grown AS (SELECT Id, Name FROM Parent)
           SELECT Name FROM grown WHERE Id = 3
-        """, engineFamily())
+        """, family())
     #expect(rows == [[.text("Cid")]])
   }
 
@@ -148,7 +148,7 @@ struct EngineWithTests {
         WITH a (Id, Name) AS (SELECT Id, Name FROM Parent WHERE Id >= 2),
              b (Who) AS (SELECT Name FROM a WHERE Id = 3)
           SELECT Who FROM b
-        """, engineFamily())
+        """, family())
     #expect(rows == [[.text("Cid")]])
   }
 
@@ -158,7 +158,7 @@ struct EngineWithTests {
     let rows = try statement("""
         WITH Parent (Id, Name) AS (SELECT Id, Name FROM Parent WHERE Id = 1)
           SELECT Name FROM Parent
-        """, engineFamily())
+        """, family())
     #expect(rows == [[.text("Ada")]])
   }
 
@@ -169,7 +169,7 @@ struct EngineWithTests {
         WITH kids (Pid, Kid) AS (SELECT Pid, Name FROM Child)
           SELECT Parent.Name, kids.Kid FROM Parent
             JOIN kids ON kids.Pid = Parent.Id
-        """, engineFamily())
+        """, family())
     #expect(rows == [
       [.text("Ada"), .text("Ann")],
       [.text("Ada"), .text("Amy")],
@@ -181,7 +181,7 @@ struct EngineWithTests {
     let rows = try statement("""
         WITH a (Tag) AS (SELECT Name FROM Parent)
           SELECT Id, Tag FROM a WHERE Id = 2
-        """, engineFamily())
+        """, family())
     #expect(rows == [[.integer(2), .text("Bee")]])
   }
 
@@ -189,7 +189,7 @@ struct EngineWithTests {
     #expect(throws: SQLError.columns(expected: 2, got: 1)) {
       try statement("""
           WITH a (x) AS (SELECT Id, Name FROM Parent) SELECT x FROM a
-          """, engineFamily())
+          """, family())
     }
   }
 
@@ -197,7 +197,7 @@ struct EngineWithTests {
     #expect(throws: SQLError.column("Missing")) {
       try statement("""
           WITH a (Id) AS (SELECT Id FROM Parent) SELECT Missing FROM a
-          """, engineFamily())
+          """, family())
     }
   }
 
@@ -205,7 +205,7 @@ struct EngineWithTests {
     let rows = try statement("""
         WITH both (Tag) AS (SELECT Tag FROM Lhs UNION SELECT Tag FROM Rhs)
           SELECT Tag FROM both
-        """, engineTags())
+        """, tags())
     #expect(rows == [[.text("a")], [.text("shared")], [.text("b")]])
   }
 
@@ -218,7 +218,7 @@ struct EngineWithTests {
     #expect(throws: SQLError.columns(expected: 2, got: 3)) {
       try statement("""
           WITH a (x, y, z) AS (SELECT * FROM Parent) SELECT x FROM a
-          """, engineFamily())
+          """, family())
     }
   }
 
@@ -236,7 +236,7 @@ struct EngineWithTests {
           WITH a (x, y, z) AS (SELECT * FROM Parent WHERE Id < 0)
             SELECT z FROM a
             UNION SELECT 99 AS z FROM Parent WHERE Id = 1
-          """, engineFamily())
+          """, family())
     }
   }
 
@@ -249,7 +249,7 @@ struct EngineWithTests {
           WITH a (x) AS (SELECT Id FROM Parent),
                A (x) AS (SELECT Id FROM Parent)
             SELECT x FROM a
-          """, engineFamily())
+          """, family())
     }
   }
 
@@ -263,7 +263,7 @@ struct EngineWithTests {
           SELECT Parent.Name, kids.Kid FROM Parent
             JOIN kids ON kids.Pid = Parent.Id
             WHERE kids.Kid = 'Amy'
-        """, engineFamily())
+        """, family())
     #expect(rows == [[.text("Ada"), .text("Amy")]])
   }
 
@@ -275,8 +275,8 @@ struct EngineWithTests {
     // caller's CTEs threaded into the view body, `Adults`'s `FROM Parent` would
     // bind to the CTE and the query would return `99`.
     let adults =
-        try View(query: engineSelect("SELECT Id FROM Parent"), columns: ["Id"])
-    let catalog = EngineMemory(try engineFamily().catalog, views: ["Adults": adults])
+        try View(query: select("SELECT Id FROM Parent"), columns: ["Id"])
+    let catalog = EngineMemory(try family().catalog, views: ["Adults": adults])
     let rows = try statement("""
         WITH Parent (Id) AS (SELECT 99 AS Id FROM Parent WHERE Id = 1)
           SELECT Id FROM Adults
@@ -289,8 +289,8 @@ struct EngineWithTests {
     // base relation still shadows it, so a trailing `FROM Parent` reads the CTE
     // — the scoping fix narrows only a view's body, never the statement query.
     let adults =
-        try View(query: engineSelect("SELECT Id FROM Parent"), columns: ["Id"])
-    let catalog = EngineMemory(try engineFamily().catalog, views: ["Adults": adults])
+        try View(query: select("SELECT Id FROM Parent"), columns: ["Id"])
+    let catalog = EngineMemory(try family().catalog, views: ["Adults": adults])
     let rows = try statement("""
         WITH Parent (Id) AS (SELECT 99 AS Id FROM Parent WHERE Id = 1)
           SELECT Id FROM Parent
@@ -308,7 +308,7 @@ struct EngineWithTests {
           SELECT 1 AS n FROM Extra UNION ALL SELECT 2 AS n FROM Extra
         )
         SELECT n FROM a
-        """, engineTags())
+        """, tags())
     #expect(rows == [[.integer(1)], [.integer(2)]])
   }
 
@@ -431,7 +431,7 @@ struct EngineRecursiveTests {
     // than binding narrow rows that trap when the trailing `SELECT z` reads the
     // absent ordinal.
     #expect(throws: SQLError.columns(expected: 2, got: 3)) {
-      _ = try engineFamily().run(Statement(parsing: """
+      _ = try family().run(Statement(parsing: """
           WITH RECURSIVE Parent (x, y, z) AS (SELECT * FROM Parent)
             SELECT z FROM Parent
           """))
@@ -505,7 +505,7 @@ struct EngineRecursiveTests {
     // not a base table: the anchor `SELECT id FROM v` resolves to the view (the
     // CTE is not in scope for the base case), and the right arm is the true
     // self-reference. The guard must accept a view seed as well as a table.
-    let view = try View(query: engineSelect("SELECT Id FROM Parent"), columns: ["id"])
+    let view = try View(query: select("SELECT Id FROM Parent"), columns: ["id"])
     let catalog = EngineMemory([
       "Parent": FixtureRelation([EngineField(name: "Id", type: .integer)],
                          [[.integer(1)]] as Array<Array<Value>>),
@@ -657,11 +657,11 @@ struct EngineRecursiveTests {
         )
         SELECT s FROM t
         """
-    let columns = try engineFamily().columns(of: Statement(parsing: text))
+    let columns = try family().columns(of: Statement(parsing: text))
     #expect(columns.count == 1)
     #expect(columns[0].name == "s")
     #expect(columns[0].type == .text)
-    let rows = try statement(text, engineFamily())
+    let rows = try statement(text, family())
     #expect(rows == [[.text("b")]])
   }
 
@@ -727,7 +727,7 @@ struct EngineRecursiveTests {
     let rows = try statement("""
         WITH t (x) AS (SELECT NULLIF('b', 'b') UNION SELECT NULLIF(1, 1))
           SELECT x FROM t UNION SELECT 'c'
-        """, engineFamily())
+        """, family())
     #expect(rows == [[.null], [.text("c")]])
   }
 
@@ -741,7 +741,7 @@ struct EngineRecursiveTests {
     let rows = try statement("""
         WITH t (x) AS (SELECT NULLIF(1, 1) UNION SELECT NULLIF('b', 'b'))
           SELECT x FROM t UNION SELECT 'c'
-        """, engineFamily())
+        """, family())
     #expect(rows == [[.null], [.text("c")]])
   }
 
@@ -753,13 +753,13 @@ struct EngineRecursiveTests {
         WITH t (x) AS (SELECT NULLIF(1, 1) UNION SELECT NULLIF('a', 'a')
                        UNION SELECT NULLIF('b', 'b'))
           SELECT x FROM t UNION SELECT 'c'
-        """, engineFamily())
+        """, family())
     #expect(forward == [[.null], [.text("c")]])
     let reversed = try statement("""
         WITH t (x) AS (SELECT NULLIF('b', 'b') UNION SELECT NULLIF('a', 'a')
                        UNION SELECT NULLIF(1, 1))
           SELECT x FROM t UNION SELECT 'c'
-        """, engineFamily())
+        """, family())
     #expect(reversed == [[.null], [.text("c")]])
   }
 
@@ -772,7 +772,7 @@ struct EngineRecursiveTests {
         WITH t (a, b) AS (SELECT NULLIF(1, 1), 1
                           UNION SELECT NULLIF('x', 'x'), 2.5)
           SELECT a, b FROM t UNION SELECT 'c', 3
-        """, engineFamily())
+        """, family())
     #expect(Set(rows) == [[.null, .double(1.0)], [.null, .double(2.5)],
                           [.text("c"), .double(3.0)]])
   }
@@ -784,7 +784,7 @@ struct EngineRecursiveTests {
     let rows = try statement("""
         WITH t (x) AS (SELECT NULLIF(1, 1) UNION SELECT NULLIF('b', 'b'))
           SELECT x FROM t
-        """, engineFamily())
+        """, family())
     #expect(rows == [[.null]])
   }
 
@@ -793,7 +793,7 @@ struct EngineRecursiveTests {
     let rows = try statement("""
         WITH t (x) AS (SELECT NULLIF(1, 1) UNION SELECT NULLIF('b', 'b'))
           SELECT x FROM t WHERE x IS NULL
-        """, engineFamily())
+        """, family())
     #expect(rows == [[.null]])
   }
 
@@ -803,7 +803,7 @@ struct EngineRecursiveTests {
     let rows = try statement("""
         WITH t (x) AS (SELECT NULLIF(1, 1) UNION SELECT NULLIF('b', 'b'))
           SELECT x FROM t WHERE x = 'c'
-        """, engineFamily())
+        """, family())
     #expect(rows.isEmpty)
   }
 
@@ -823,10 +823,10 @@ struct EngineRecursiveTests {
           SELECT * FROM t
         """
     #expect(throws: SQLError.columns(expected: 1, got: 2)) {
-      _ = try statement(text, engineFamily())
+      _ = try statement(text, family())
     }
     #expect(throws: SQLError.columns(expected: 1, got: 2)) {
-      _ = try engineFamily().columns(of: Statement(parsing: text))
+      _ = try family().columns(of: Statement(parsing: text))
     }
   }
 
@@ -842,10 +842,10 @@ struct EngineRecursiveTests {
           SELECT * FROM t
         """
     #expect(throws: SQLError.columns(expected: 1, got: 2)) {
-      _ = try statement(text, engineFamily())
+      _ = try statement(text, family())
     }
     #expect(throws: SQLError.columns(expected: 1, got: 2)) {
-      _ = try engineFamily().columns(of: Statement(parsing: text))
+      _ = try family().columns(of: Statement(parsing: text))
     }
   }
 
@@ -863,10 +863,10 @@ struct EngineRecursiveTests {
           SELECT * FROM t
         """
     #expect(throws: SQLError.columns(expected: 1, got: 2)) {
-      _ = try statement(text, engineFamily())
+      _ = try statement(text, family())
     }
     #expect(throws: SQLError.columns(expected: 1, got: 2)) {
-      _ = try engineFamily().columns(of: Statement(parsing: text))
+      _ = try family().columns(of: Statement(parsing: text))
     }
   }
 
@@ -878,7 +878,7 @@ struct EngineRecursiveTests {
     #expect(throws: SQLError.columns(expected: 1, got: 2)) {
       _ = try statement("""
           WITH t (a, b) AS (SELECT 1) SELECT a FROM t
-          """, engineFamily())
+          """, family())
     }
   }
 
@@ -897,7 +897,7 @@ struct EngineRecursiveTests {
         WITH RECURSIVE t (x) AS (
           SELECT NULLIF(1, 1) UNION SELECT x FROM t INTERSECT SELECT 'c'
         ) SELECT x FROM t
-        """, engineFamily())
+        """, family())
     #expect(rows == [[.null]])
   }
 
@@ -921,11 +921,11 @@ struct EngineRecursiveTests {
           SELECT s FROM (SELECT s || 'c' AS s FROM t WHERE s = 'b') AS d
         ) SELECT * FROM t
         """
-    let columns = try engineFamily().columns(of: Statement(parsing: text))
+    let columns = try family().columns(of: Statement(parsing: text))
     #expect(columns.count == 1)
     #expect(columns[0].name == "s")
     #expect(columns[0].type == .text)
-    let rows = try statement(text, engineFamily())
+    let rows = try statement(text, family())
     #expect(rows == [[.text("b")], [.text("bc")]])
   }
 
@@ -945,10 +945,10 @@ struct EngineRecursiveTests {
         ) SELECT * FROM t
         """
     #expect(throws: SQLError.self) {
-      _ = try engineFamily().columns(of: Statement(parsing: text))
+      _ = try family().columns(of: Statement(parsing: text))
     }
     #expect(throws: SQLError.self) {
-      _ = try statement(text, engineFamily())
+      _ = try statement(text, family())
     }
   }
 
@@ -970,7 +970,7 @@ struct EngineRecursiveTests {
         WITH a(x) AS (SELECT 1 UNION SELECT 2.5),
              b(y) AS (SELECT x FROM a)
           SELECT y FROM b ORDER BY y
-        """, engineFamily())
+        """, family())
     #expect(rows == [[.double(1.0)], [.double(2.5)]])
   }
 
@@ -984,7 +984,7 @@ struct EngineRecursiveTests {
         WITH RECURSIVE t(n) AS (
           SELECT 1 UNION ALL SELECT n + 0.5 FROM t WHERE n < 2
         ) SELECT n FROM t ORDER BY n
-        """, engineFamily())
+        """, family())
     #expect(rows == [[.double(1.0)], [.double(1.5)], [.double(2.0)]])
   }
 
@@ -995,7 +995,7 @@ struct EngineRecursiveTests {
     // `1.0` — the producer's carrier and the run's rows agree on the type.
     let rows = try statement("""
         WITH a(x) AS (SELECT 1 UNION SELECT 2.5) SELECT x FROM a ORDER BY x
-        """, engineFamily())
+        """, family())
     #expect(rows == [[.double(1.0)], [.double(2.5)]])
   }
 }

--- a/Tests/SQLTests/Queries/TableTests.swift
+++ b/Tests/SQLTests/Queries/TableTests.swift
@@ -38,11 +38,11 @@ struct TableTests {
   }
 
   @Test func `TABLE t yields every row and column of SELECT star FROM t`() throws {
-    try enginePeople().expect("TABLE People", equals: "SELECT * FROM People")
+    try roster().expect("TABLE People", equals: "SELECT * FROM People")
   }
 
   @Test func `TABLE t yields the full row/column set`() throws {
-    try enginePeople().expect("TABLE People", yields: [
+    try roster().expect("TABLE People", yields: [
       [1, "Alice", 30],
       [2, "Bob", 25],
       [3, "Carol", 30],
@@ -54,28 +54,28 @@ struct TableTests {
   @Test func `TABLE over a view resolves as the view relation`() throws {
     // `Adults` is a registered view; `TABLE Adults` resolves it by name exactly
     // as `SELECT * FROM Adults` does, exposing the view's Key/Label columns.
-    try engineViews().expect("TABLE Adults", equals: "SELECT * FROM Adults")
-    try engineViews().expect("TABLE Adults", yields: [[2, "Bee"], [3, "Cid"]])
+    try gallery().expect("TABLE Adults", equals: "SELECT * FROM Adults")
+    try gallery().expect("TABLE Adults", yields: [[2, "Bee"], [3, "Cid"]])
   }
 
   @Test func `TABLE a UNION TABLE b composes with a set operation`() throws {
     // Each arm is a `TABLE` primary; the UNION merges and dedups the shared row
     // exactly as the two-SELECT spelling does.
-    try engineTags().expect("TABLE Lhs UNION TABLE Rhs",
+    try tags().expect("TABLE Lhs UNION TABLE Rhs",
                             equals: "SELECT * FROM Lhs UNION SELECT * FROM Rhs")
-    try engineTags().expect("TABLE Lhs UNION TABLE Rhs",
+    try tags().expect("TABLE Lhs UNION TABLE Rhs",
                             yields: [["a"], ["shared"], ["b"]])
   }
 
   @Test func `a TABLE primary mixes with a SELECT arm across a set operation`() throws {
     // The primary composes on either side of the operator, so one arm may be a
     // `TABLE` and the other a `SELECT`.
-    try engineTags().expect("TABLE Lhs UNION ALL SELECT Tag FROM Rhs",
+    try tags().expect("TABLE Lhs UNION ALL SELECT Tag FROM Rhs",
                             yields: [["a"], ["shared"], ["shared"], ["b"]])
   }
 
   @Test func `TABLE composes at the tighter INTERSECT tier`() throws {
-    try engineTags().expect("TABLE Lhs INTERSECT TABLE Rhs",
+    try tags().expect("TABLE Lhs INTERSECT TABLE Rhs",
                             yields: [["shared"]])
   }
 
@@ -108,10 +108,10 @@ struct TableTests {
     // `FROM (TABLE People) AS d` is a derived table whose body is the `TABLE`
     // primary; it selects the same rows the `(SELECT * FROM People)` body does.
     _ = try parse(query: "SELECT * FROM (TABLE People) AS d")
-    try enginePeople().expect(
+    try roster().expect(
         "SELECT * FROM (TABLE People) AS d",
         equals: "SELECT * FROM (SELECT * FROM People) AS d")
-    try enginePeople().expect("SELECT d.Name FROM (TABLE People) AS d",
+    try roster().expect("SELECT d.Name FROM (TABLE People) AS d",
                               yields: [["Alice"], ["Bob"], ["Carol"],
                                        ["Dave"], ["Eve"]])
   }
@@ -120,19 +120,19 @@ struct TableTests {
     // `One` is one row of one column, so `(TABLE One)` is a valid scalar
     // subquery — it yields that single cell, exactly as `(SELECT * FROM One)`.
     _ = try parse(query: "SELECT (TABLE One) FROM One")
-    try engineScalars().expect("SELECT (TABLE One) FROM One",
+    try scalars().expect("SELECT (TABLE One) FROM One",
                                equals: "SELECT (SELECT * FROM One) FROM One")
-    try engineScalars().expect("SELECT (TABLE One) FROM One", yields: [[42]])
+    try scalars().expect("SELECT (TABLE One) FROM One", yields: [[42]])
   }
 
   @Test func `an x IN (TABLE t) subquery parses and runs as IN (SELECT star FROM t)`() throws {
     // `Ids` is a single column, so `Tag IN (TABLE Ids)` is a valid IN-subquery,
     // membership over that column exactly as `IN (SELECT * FROM Ids)`.
     _ = try parse(query: "SELECT V FROM Vals WHERE V IN (TABLE Ids)")
-    try engineScalars().expect(
+    try scalars().expect(
         "SELECT V FROM Vals WHERE V IN (TABLE Ids)",
         equals: "SELECT V FROM Vals WHERE V IN (SELECT * FROM Ids)")
-    try engineScalars().expect("SELECT V FROM Vals WHERE V IN (TABLE Ids)",
+    try scalars().expect("SELECT V FROM Vals WHERE V IN (TABLE Ids)",
                                yields: [[1], [3]])
   }
 }
@@ -140,7 +140,7 @@ struct TableTests {
 /// A catalog for the scalar-subquery and IN-subquery `(TABLE …)` forms: `One`
 /// is one row of one column (a valid scalar subquery), `Ids` is a single column
 /// (a valid IN-subquery), and `Vals` is the probe relation the IN filters.
-func engineScalars() throws -> EngineMemory {
+func scalars() throws -> EngineMemory {
   try Catalog {
     Relation("One", ["N": .integer]) {
       Row(42)

--- a/Tests/SQLTests/Queries/ValuesTests.swift
+++ b/Tests/SQLTests/Queries/ValuesTests.swift
@@ -169,7 +169,7 @@ struct ValuesTests {
   }
 
   @Test func `VALUES mixes with a TABLE arm across a UNION ALL`() throws {
-    try enginePeople().expect(
+    try roster().expect(
         "SELECT Age FROM People WHERE Id = 1 UNION ALL VALUES (99)",
         yields: [[30], [99]])
   }
@@ -205,7 +205,7 @@ struct ValuesTests {
       Issue.record("expected an IN-subquery predicate")
       return
     }
-    try enginePeople().expect(
+    try roster().expect(
         "SELECT Id FROM People WHERE Id IN (VALUES (1), (2))",
         yields: [[1], [2]])
   }
@@ -214,7 +214,7 @@ struct ValuesTests {
     // `= ANY (VALUES (…), (…))` compares against the constructor's rows — the
     // quantified path always parses a parenthesised query, so a `VALUES`
     // primary composes there as `(SELECT …)` does.
-    try enginePeople().expect(
+    try roster().expect(
         "SELECT Id FROM People WHERE Age = ANY (VALUES (30), (40))",
         yields: [[1], [3], [4]])
   }

--- a/Tests/SQLTests/Schema/OutputSchemaTests.swift
+++ b/Tests/SQLTests/Schema/OutputSchemaTests.swift
@@ -797,14 +797,14 @@ private struct Triple {
   init(_ text: String) throws {
     let statement = try Statement(parsing: text)
     run = outcome {
-      _ = try engineFamily().run(statement)
-      return try engineFamily().columns(of: statement, validate: false)
+      _ = try family().run(statement)
+      return try family().columns(of: statement, validate: false)
     }
     lenient = outcome {
-      try engineFamily().columns(of: statement, validate: false)
+      try family().columns(of: statement, validate: false)
     }
     strict = outcome {
-      try engineFamily().columns(of: statement, validate: true)
+      try family().columns(of: statement, validate: true)
     }
   }
 }


### PR DESCRIPTION
The SQL test-fixture and plan-predicate helpers carried an `engine` prefix that made every name a camelCase compound (`engineFamily`, `enginePeople`, `engineSeeks`, ...), the largest remaining offender against the single-word / labeled-argument naming convention. The enclosing `Engine*Tests` context already conveys "engine", so the prefix added nothing.

Drop the prefix throughout, mapping each helper to a single evocative word: the catalogs (`family`, `grades`, `attributes`, `wide`, `gallery`, `sparse`, `orphans`, `lineage`, `shared`, `tags`, `scalars`, `named`, `virtual`, `chained`), the query runners (`answer`, `select`, `parse`, `join`, `view`, `functions`) and the plan-shape predicates (`derived`, `sought`, `filters`, `pushed`, `floating`, `joined`, `residue`, `separated`, `stacked`, `product`).

Where the obvious single word already named a distinct symbol in the shared `SQLTestSupport` fixtures or a file-local helper, a fitting synonym keeps the two apart: the People catalog is `roster` and its runner `answer` (a file-local `run` and the shared `parse` labels stay untouched); the null-hole catalog is `sparse` (the public `nullable()` fixture keeps that name); the registered-view catalog is `gallery` (a file-local `views()` keeps its); and the cross-file plan predicates are `sought`/`floating`/`joined`/`residue` so they do not clash with the file-private `seeks`/`floats`/`joins`/`residual` in the expression tests. `engineNullableKeys` becomes `orphans`.

Pure mechanical rename: no fixture data, assertion or test count changes.