### PR TITLE
SQLEngine: parse GROUP BY GROUPING SETS into a UNION ALL desugar

### DIFF
--- a/Sources/SQLEngine/AST.swift
+++ b/Sources/SQLEngine/AST.swift
@@ -177,18 +177,18 @@ public indirect enum Query: Hashable, Sendable {
   /// project — the result columns stay the inner setop's arm-0-named, unified
   /// ones. It is TRANSPARENT to `columns(unifying:)`, which descends to the
   /// inner setop for the result schema; only `run`/`compile` stack the row
-  /// operators over the compiled setop plan. Produced by the parser for a
-  /// trailing query-level `ORDER BY` / `OFFSET`·`FETCH` after a set-operation
-  /// chain.
+  /// operators over the compiled setop plan. Produced by the GROUPING SETS
+  /// `expand` and by the parser for a trailing query-level `ORDER BY` /
+  /// `OFFSET`·`FETCH` after a set-operation chain.
   ///
   /// `generated` is the number of GENERATED trailing columns the inner union
-  /// carries beyond the real output — hidden sort columns a producer may append
-  /// to each arm so a genuinely-unprojected sort key survives the `UNION ALL`
-  /// at equal arity. The carrier's compile TRIMS them (`real = width −
-  /// generated`), and `columns(unifying:)` drops them from the result schema.
-  /// It is a STRUCTURAL count carried on the node, never recovered by scanning
-  /// output names for a synthetic prefix; the parser's trailing-`ORDER BY`
-  /// carrier generates none (`0`).
+  /// carries beyond the real output — the hidden sort columns `expand` appends
+  /// to each arm (aliased `*gsN`) so a genuinely-unprojected aggregate sort key
+  /// survives the `UNION ALL` at equal arity. The carrier's compile TRIMS them
+  /// (`real = width − generated`), and `columns(unifying:)` drops them from the
+  /// result schema. It is a STRUCTURAL count carried out of `expand`, never
+  /// recovered by scanning output names for a synthetic prefix; the parser's
+  /// trailing-`ORDER BY` carrier generates none (`0`).
   case ordered(Query, distinct: Bool, order: Order?, limit: Limit?,
                generated: Int)
 
@@ -239,6 +239,64 @@ public indirect enum Query: Hashable, Sendable {
   }
 }
 
+/// A `GROUP BY` grouping: the ordinary key list, an explicit `GROUPING SETS`
+/// set list, or one expanded arm of such a set list.
+///
+/// The parser produces `.keys` for an ordinary `GROUP BY e, …` (empty for no
+/// grouping) and `.sets` for `GROUP BY GROUPING SETS (s, …)`. The compile and
+/// schema paths EXPAND a `.sets` into a `UNION ALL` of per-arm groupings, each
+/// arm a `.arm` grouping on ONE set's `keys` while carrying the `superset` (the
+/// union of ALL sets' keys) so an arm's lowering NULLs a projected/HAVING
+/// grouping column absent from THIS arm's set — the super-aggregate NULL —
+/// matched by RESOLVED identity, not raw AST.
+public enum Grouping: Hashable, Sendable {
+  /// `GROUP BY e, …` — the ordinary `<ordinary grouping set>` keys, in source
+  /// order (empty for no explicit grouping).
+  case keys(Array<Expression>)
+
+  /// `GROUP BY GROUPING SETS (s, …)` — one key list per set, in source order;
+  /// an empty inner list is the grand-total set `()`.
+  case sets(Array<Array<Expression>>)
+
+  /// ONE expanded arm of a `.sets` grouping — grouped on `keys` (this set's
+  /// members) while `superset` is the union of every set's keys. A grouping
+  /// column IN `superset` but absent from `keys` lowers to a super-aggregate
+  /// NULL, matched by lowered-`Term` identity in `Grouped.term`. Produced by
+  /// the shared `expand`, never by the parser.
+  case arm(keys: Array<Expression>, superset: Array<Expression>)
+
+  /// The `GROUP BY` keys this grouping evaluates over the input rows — a
+  /// `.keys` its list, a `.sets` the concatenation of all sets' keys, a `.arm`
+  /// its OWN set's keys. The reachability derive reads `isEmpty` here to
+  /// recognise a whole-result aggregate (an empty `GROUP BY`, the `()` arm), so
+  /// this stays the arm's own keys, NOT its superset.
+  public var expressions: Array<Expression> {
+    switch self {
+    case let .keys(keys):
+      keys
+    case let .sets(sets):
+      sets.reduce(into: Array<Expression>()) { $0 += $1 }
+    case let .arm(keys, _):
+      keys
+    }
+  }
+
+  /// The `GROUP BY` key expressions the subquery/aggregate COLLECTORS descend
+  /// to pre-register each nested subquery — like `expressions`, but a `.arm`
+  /// yields its `superset` (the union of every set's keys). An arm LOWERS the
+  /// superset (an absent key NULLs by resolved identity), not merely its own
+  /// set, so a subquery in an OMITTED set's key must be collected here exactly
+  /// as a present set's is; the superset subsumes the arm's own keys.
+  internal var collected: Array<Expression> {
+    switch self {
+    case .keys, .sets:
+      expressions
+    case let .arm(_, superset):
+      superset
+    }
+  }
+}
+
 /// A `SELECT` query: a projection over one relation or a chain of joins, with
 /// an optional predicate, ordering, and row limit.
 ///
@@ -269,14 +327,16 @@ public struct Select: Hashable, Sendable {
   /// The row filter, if any.
   public let predicate: Predicate?
 
-  /// The `GROUP BY` keys, in source order — empty for a query with no explicit
-  /// grouping. A query that aggregates without a `GROUP BY` (`SELECT COUNT(*)
-  /// FROM T`) leaves this empty and aggregates the whole result as a single
-  /// group. The parser produces a bare `Expression.column` per key; a general
-  /// key expression is admitted too, so a bare `NATURAL`/`USING` merged column
-  /// lowers through the join scope to its `COALESCE(left, right)` value (with
-  /// no physical ordinal), the executor grouping each key per row.
-  public let grouping: Array<Expression>
+  /// The `GROUP BY` grouping — the ordinary `<ordinary grouping set>` key list
+  /// (`.keys`, empty for a query with no explicit grouping), or a `GROUPING
+  /// SETS (…)` set list (`.sets`) the compile and schema paths expand into a
+  /// `UNION ALL` of per-arm groupings. A query that aggregates without a `GROUP
+  /// BY` (`SELECT COUNT(*) FROM T`) carries `.keys([])` and aggregates the
+  /// whole result as a single group. Each key is a bare `Expression.column` or
+  /// a general key expression, so a bare `NATURAL`/`USING` merged column lowers
+  /// through the join scope to its `COALESCE(left, right)` value (with no
+  /// physical ordinal), the executor grouping each key per row.
+  public let grouping: Grouping
 
   /// The `HAVING` filter over the grouped rows, if any — a predicate the engine
   /// applies AFTER aggregation, so it may reference the aggregates and the
@@ -292,7 +352,7 @@ public struct Select: Hashable, Sendable {
 
   public init(distinct: Bool = false, projection: Projection,
               from: Relation?, joins: Array<Join> = [],
-              predicate: Predicate? = nil, grouping: Array<Expression> = [],
+              predicate: Predicate? = nil, grouping: Grouping = .keys([]),
               having: Predicate? = nil, order: Order? = nil,
               limit: Limit? = nil) {
     self.distinct = distinct
@@ -417,7 +477,7 @@ public struct Select: Hashable, Sendable {
   ///     `Scope.order`);
   ///   - a GROUPED query resolves an output name from `Projected.name` (an
   ///     alias, else a bare column's name) — the SAME output-name set
-  ///     `Grouping.terms`/`Grouping.order` record and bind, so a grouped
+  ///     `Grouped.terms`/`Grouped.order` record and bind, so a grouped
   ///     `ORDER BY <groupcol>` naming an unaliased projected group column
   ///     resolves to that output here exactly as it does in the run, rather
   ///     than being (mis)validated as an ambiguous input column.

--- a/Sources/SQLEngine/Definition.swift
+++ b/Sources/SQLEngine/Definition.swift
@@ -625,8 +625,17 @@ extension Catalog where Self: ~Escapable {
       // check a routine exists), while an arm a short-circuit proves
       // unreachable is skipped. A view a `SELECT *` could not evaluate is not
       // advertised.
-      let resolved = try? columns(unifying: view.query, inner).map(\.column)
-      guard (try? typecheck(view.query, inner)) != nil, let resolved,
+      //
+      // EXPAND the body first (the schema path does): a `GROUP BY GROUPING
+      // SETS` body type-checks its `UNION ALL` of per-arm groupings, not the
+      // unexpanded `.sets`. An unexpanded `SELECT 1 / 0 … WHERE 1 = 0 GROUP BY
+      // GROUPING SETS ((Region), ())` reads as non-empty grouping and a
+      // constant-false `WHERE` skips its projection, so it would be advertised
+      // though the expanded `()` arm forms one group and evaluates `1 / 0`,
+      // faulting a run — the metadata must match what selecting from it does.
+      guard let body = try? view.query.expanded else { continue }
+      let resolved = try? columns(unifying: body, inner).map(\.column)
+      guard (try? typecheck(body, inner)) != nil, let resolved,
           resolved.count == view.columns.count else { continue }
       for ordinal in view.columns.indices {
         rows.append([.text(name), .text(view.columns[ordinal]),

--- a/Sources/SQLEngine/Engine.swift
+++ b/Sources/SQLEngine/Engine.swift
@@ -30,18 +30,16 @@ extension CTE {
   /// recursive-CTE seam peels through, so the run side and the schema side
   /// inspect the identical AST.
   ///
-  /// It applies `Query.unwound` (a trailing query-level `ORDER BY`/`OFFSET`·
-  /// `FETCH`/`DISTINCT` carrier peels off the setop), yielding the carrier-free
-  /// inner query paired with the peeled `Carrier`. Routing every seam through
-  /// this one form keeps the run and schema derivations in step.
-  ///
-  /// When `GROUP BY GROUPING SETS` lands, `Query.expanded` (a grouping-sets
-  /// body lowers to its `UNION ALL` arms) is re-inserted ahead of `unwound`, so
-  /// a recursive grouping-sets body canonicalises to the same expanded, unwound
-  /// shape on both sides — a one-token merge follow-up, not needed here.
+  /// It applies `Query.expanded` (a `GROUP BY GROUPING SETS` body lowers to its
+  /// `UNION ALL` arms FIRST) then `Query.unwound` (a trailing query-level
+  /// `ORDER BY`/`OFFSET`·`FETCH`/`DISTINCT` carrier peels off the setop),
+  /// yielding the carrier-free inner query paired with the peeled `Carrier`. A
+  /// recursive grouping-sets body thus canonicalises to the same expanded,
+  /// unwound shape on both sides. Routing every seam through this one form
+  /// keeps the run and schema derivations in step.
   internal var canonical: (inner: Query, carrier: Query.Carrier?) {
     get throws(SQLError) {
-      query.unwound
+      try query.expanded.unwound
     }
   }
 
@@ -169,6 +167,12 @@ extension Catalog where Self: ~Escapable {
   /// base catalog.
   internal borrowing func run(_ query: Query, _ context: Context)
       throws(SQLError) -> Array<Array<Value>> {
+    // Expand any `GROUP BY GROUPING SETS` select to its `UNION ALL` FIRST, so
+    // every downstream phase — the arm-wise run below, the compile preflight,
+    // and the derived-table materialise/augment — sees the expanded AST, and a
+    // run and a `columns(of:)` derive cannot diverge. Idempotent for a
+    // `.keys`/`.arm` select; a nested body re-enters and expands in turn.
+    let query = try query.expanded
     // A set operation runs each ARM against its OWN scope and combines the
     // results, rather than materialising both arms' derived tables into one
     // shared overlay the executor scans by name. Both arms bind their aliases
@@ -626,14 +630,20 @@ extension Catalog where Self: ~Escapable {
         }
       }
     } else {
-      let scope = try augment(context.validating(typecheck), for: cte.query,
+      // Validate the SAME expanded AST a run does: a `GROUP BY GROUPING SETS`
+      // body expands to its `UNION ALL` FIRST, so this schema-path typecheck
+      // sees the per-set arms (an empty-set grand-total arm evaluates its
+      // projection even under a `WHERE` that spares the unexpanded key list),
+      // matching the run/`compile` normalization.
+      let query = try cte.query.expanded
+      let scope = try augment(context.validating(typecheck), for: query,
                               rows: false)
-      let width = try compile(cte.query, scope).width
+      let width = try compile(query, scope).width
       guard width == cte.columns.count else {
         throw .columns(expected: width, got: cte.columns.count)
       }
       // A non-self-naming body is operand-checked whole with self NOT in scope.
-      if typecheck { try self.typecheck(cte.query, scope) }
+      if typecheck { try self.typecheck(query, scope) }
     }
   }
 
@@ -684,15 +694,21 @@ extension Catalog where Self: ~Escapable {
     // the CTE's arm nests must be TRUSTED, not eager-type-checked: a data-
     // dependent body expression a filter drops must not fault a CTE that runs
     // empty, matching the non-recursive and non-`WITH` paths.
-    let context = try augment(context.validating(false), for: cte.query,
+    // Expand a `GROUP BY GROUPING SETS` body to its `UNION ALL` FIRST — the
+    // SAME normalization `run`/`compile`/the schema `validate` apply — so the
+    // `augment` and the non-`UNION` run-once branch below see the expanded AST.
+    // Idempotent for a plain recursive `UNION` body.
+    let query = try cte.query.expanded
+    let context = try augment(context.validating(false), for: query,
                               rows: true)
-    // Peel the CANONICAL recursive shape — the SAME `canonical` (unwound) form
-    // `recurses`/`recursiveArms`, the shape validator, and the schema derive
-    // peel — off the body: the fixpoint iterates the INNER `UNION` (anchor ∪
-    // recursive) with the CTE self in scope, then the peeled `carrier` applies
-    // its row operators to the materialised RESULT. The carrier is transparent
-    // to the recursive shape (`references` descends it), so `recurses` already
-    // routed an ordered body here.
+    // Peel the CANONICAL recursive shape — the SAME `canonical` (expanded,
+    // unwound) form `recurses`/`recursiveArms`, the shape validator, and the
+    // schema derive peel — off the body: the fixpoint iterates the INNER
+    // `UNION` (anchor ∪ recursive) with the CTE self in scope, then the peeled
+    // `carrier` applies its row operators to the materialised RESULT. The
+    // carrier is transparent to the recursive shape (`references` descends it),
+    // so `recurses` already routed an ordered body here. `canonical` expands a
+    // grouping-sets body FIRST, matching the `query` `augment` sees above.
     let (body, carrier) = try cte.canonical
     guard case let .setop(.union, anchor, recursive, all) = body else {
       // A non-`UNION` recursive query runs once, but still binds under
@@ -700,7 +716,7 @@ extension Catalog where Self: ~Escapable {
       // anchor and arm get. A body naming a base relation of the CTE's own name
       // (`WITH RECURSIVE Parent(x,y,z) AS (SELECT * FROM Parent)`) would else
       // bind narrow base rows under the wider list and trap on a later read.
-      let width = try compile(cte.query, context).width
+      let width = try compile(query, context).width
       guard width == cte.columns.count else {
         throw .columns(expected: width, got: cte.columns.count)
       }
@@ -709,7 +725,7 @@ extension Catalog where Self: ~Escapable {
       // from), not the declared-name placeholder, so a caller reading the CTE
       // unifies against real types and the `unconstrained` mask while
       // addressing the CTE by its declared list.
-      let rows = try run(cte.query, context)
+      let rows = try run(query, context)
       // TRUSTED re-derive (the body already ran): `validating(false)` so an
       // unreached data-dependent operand is not eager-checked, while a genuine
       // set-operation incompatibility still faults through `merge`.
@@ -1227,6 +1243,220 @@ extension Plan {
   }
 }
 
+// MARK: - GROUPING SETS
+
+extension Query {
+  /// This query with each TOP-LEVEL `GROUP BY GROUPING SETS` select replaced by
+  /// its `UNION ALL` expansion — applied ONCE at every pipeline entry (`run`,
+  /// `compile`, `columns(of:)`), so the whole downstream (materialise, augment,
+  /// executor) sees the expanded AST and a run and a `columns(of:)` derive
+  /// cannot diverge.
+  ///
+  /// It rewrites the query's OWN selects (a bare select and each set-operation
+  /// arm), NOT the derived tables or subqueries nested within — those RE-ENTER
+  /// these same entries (`materialise`/`resolved` run and derive an inner body,
+  /// `cell` runs a scalar subquery), where they are expanded in turn — so ONE
+  /// shallow pass at each entry covers arbitrary nesting.
+  internal var expanded: Query {
+    get throws(SQLError) {
+      switch self {
+      case let .select(select):
+        if case let .sets(sets) = select.grouping {
+          return try expand(select, sets: sets)
+        }
+        return self
+      case let .setop(kind, left, right, all):
+        return .setop(kind, try left.expanded, try right.expanded, all: all)
+      case let .ordered(inner, distinct, order, limit, generated):
+        // An `ordered` carrier is produced by `expand` over an already-
+        // expanded union, so its inner is idempotent under a re-expansion;
+        // recurse for uniformity (a nested `.sets` inside is impossible —
+        // `expand` only ever wraps a `setop` of `.arm` selects). The generated
+        // trailing count rides through unchanged.
+        return .ordered(try inner.expanded, distinct: distinct, order: order,
+                        limit: limit, generated: generated)
+      }
+    }
+  }
+}
+
+/// Expands a `GROUP BY GROUPING SETS (s1, …, sn)` `select` into a `UNION ALL`
+/// of one grouped ARM per set — the SINGLE shared expansion the compile path
+/// (`compile(_ select:)`) and the schema path (`columns(unifying:)`) BOTH
+/// drive, so a run and a `columns(of:)` derive cannot diverge.
+///
+/// Each arm is the original select grouped on ONE set's `keys` while carrying
+/// the SUPERSET (the union of every set's keys) in its `.arm` grouping — so a
+/// projected/HAVING reference to a grouping column ANOTHER set groups on but
+/// THIS arm's set omits lowers to a super-aggregate NULL by RESOLVED identity
+/// (`Grouped.term`), never a per-site AST rewrite. The projection stays
+/// VERBATIM per arm: the empty set `()` builds a genuine grand-total aggregate
+/// (`group` on `[]` = ONE row), and the NULL padding types through the existing
+/// set-operation `merge` (a NULL arm constrains nothing, deferring to the arm
+/// that groups on the column). HAVING is copied into every arm (ISO: it filters
+/// each set's own groups); arms combine with `UNION ALL`, so a duplicate set
+/// keeps its rows and the grand-total row is never deduplicated.
+///
+/// The query-level `ORDER BY` / `OFFSET`/`FETCH` / `DISTINCT` ride the outer
+/// `Query.ordered` carrier over the union — a `setop` node carries no
+/// order/distinct/limit slot. The carrier resolves those row operators through
+/// the setop's OUTPUT SCOPE (`compile`/`run`), so an ORDER BY key that names an
+/// output — an alias, a bare projected column, or an ordinal — orders on that
+/// output the SAME way any `(SELECT … UNION SELECT …) ORDER BY <alias/ordinal>`
+/// does, and a duplicate output name faults `SQLError.ambiguous` there, exactly
+/// as a plain grouped query does. A generated `column N` display header is NOT
+/// a bindable output name (the scope's names are the projected aliases-or-bare
+/// columns), so `ORDER BY "column N"` faults `.column` as it does over any
+/// derived union.
+///
+/// Only an ORDER BY key that re-expresses a value the setop-output scope cannot
+/// recompute — a genuinely unprojected non-column EXPRESSION, the canonical
+/// example an aggregate (`ORDER BY MAX(x)`) the select list does not project —
+/// is MATERIALISED here as a HIDDEN trailing column in EVERY arm (so the `UNION
+/// ALL` arity stays equal). A COLUMN key is NEVER materialised: it resolves at
+/// the setop-output scope (a bare/aliased projected column to its output slot,
+/// a qualified `n.A` ≡ the projected `A` by lowered identity) or faults there,
+/// so the qualifier-presence defect that materialised `n.A` as a hidden column
+/// is gone. The compiled carrier orders on the materialised ordinal and TRIMS
+/// it through the identity projection; the carrier binds the hidden slot by
+/// POSITION, never by the generated `*gsN` name a user output could spell.
+internal func expand(_ select: Select,
+                     sets: Array<Array<Expression>>) throws(SQLError) -> Query {
+  // `GROUPING SETS ()` — an empty set LIST — has no arm to combine, so the
+  // `UNION ALL` reduce below has no seed. The parser never emits it (the
+  // grammar requires at least one set), but `Grouping.sets` is a public AST
+  // case a caller may build directly, so reject the empty list here with a
+  // syntax fault rather than letting the `arms[0]` seed trap.
+  guard !sets.isEmpty else {
+    throw .state("42601", "GROUPING SETS requires at least one set")
+  }
+  // The SUPERSET — every set's keys, flattened — threaded into each arm so an
+  // absent key NULLs by resolved identity. Compared by lowered term in
+  // `Grouped`, so a duplicate spelling here is harmless.
+  let superset = sets.reduce(into: Array<Expression>()) { $0 += $1 }
+
+  // The real projected items, as an explicit list. Both spellings the parser
+  // emits for an enumerated projection reproject: an `expressions` list
+  // verbatim, and a bare-column `columns` list lifted into `Projected`s (a
+  // grouped `SELECT Region` is well-formed — Region is a grouping key). Only a
+  // `*` (`all`) carries no explicit items and is left for the arm resolver to
+  // diagnose (a grouped `SELECT *` is ill-formed).
+  let items: Array<Projected> = switch select.projection {
+  case let .expressions(list):
+    list
+  case let .columns(columns):
+    columns.map { Projected(expression: .column($0)) }
+  case .all:
+    []
+  }
+
+  // The query-level ORDER BY keys MATERIALISED as hidden trailing columns — a
+  // sort key the setop-output scope cannot recompute over the combined union.
+  // A NON-column key (an aggregate `MAX(x)`, a computed key) the select list
+  // does not project is materialised; a projected non-column expression
+  // (`ORDER BY SUM(Qty)` where `SUM(Qty)` is a select-list item) resolves to
+  // its output slot instead.
+  //
+  // A COLUMN key is materialised only when the setop-output scope cannot
+  // resolve it — its BARE name is not a projected output. An UNQUALIFIED
+  // column whose bare name IS a projected output (`SELECT Region … ORDER BY
+  // Region`) binds that output by ISO output-alias precedence (a bare name →
+  // a select-list alias), so it is NOT materialised. A QUALIFIED column,
+  // though, references its INPUT column by identity, NOT a select alias: its
+  // bare name colliding with a DIFFERENT output's alias (`SELECT Product AS
+  // Region … ORDER BY s.Region`) must NOT be treated as that projected output
+  // — the qualified key rides the carrier's `Grouped` resolver, which either
+  // resolves it to the output it genuinely IS (rebinding to the real slot, no
+  // effect) or, when it is a grouped-but-unprojected column, orders on this
+  // hidden slot. An UNPROJECTED grouped column (`SELECT SUM(Qty) … GROUP BY
+  // GROUPING SETS ((Region)) ORDER BY Region`) has no output slot but IS
+  // orderable — the plain grouped path accepts it — so it materialises through
+  // each arm's grouped projection: an arm grouped on the column carries its
+  // value, and an arm that does NOT group on it is REJECTED by the arm's
+  // grouped resolver with the SAME grouping fault the plain form raises (a
+  // NON-grouped column faults identically). This is the aggregate case's
+  // machinery extended to columns, not a fork — the arm's `Grouped` decides
+  // grouped/non-grouped.
+  let outputs = Set(items.compactMap { $0.name?.lowercased() })
+  let hidden: Array<Expression> = (select.order?.keys ?? []).compactMap {
+    key in
+    guard case let .expression(expression) = key.sort else { return nil }
+    guard !items.contains(where: { $0.expression == expression }) else {
+      return nil
+    }
+    if case let .column(column) = expression, column.qualifier == nil,
+        outputs.contains(column.name.lowercased()) {
+      return nil
+    }
+    return expression
+  }
+
+  // Whether a carrier is needed at all: a query-level DISTINCT, ORDER BY, or
+  // row limit has no slot on the `setop` node, so it rides the outer carrier.
+  let carried =
+      select.distinct || select.order != nil || select.limit != nil
+
+  // Build one arm per set. When the carrier materialises hidden sort columns,
+  // each arm APPENDS them (aliased to synthetic names) so they survive the
+  // union at an equal arity across arms; without a carrier the projection is
+  // verbatim.
+  let names = hidden.indices.map { "*gs\($0)" }
+  let arms = sets.map { set -> Query in
+    let projection: Projection
+    if case .all = select.projection {
+      // A grouped `SELECT *` is ill-formed; keep the `.all` VERBATIM in every
+      // arm (never the carrier) so the arm's grouped resolver throws the SAME
+      // `SELECT *` fault the unwrapped form does.
+      projection = select.projection
+    } else if carried, !hidden.isEmpty {
+      let extra = hidden.indices.map {
+        Projected(expression: hidden[$0], alias: names[$0])
+      }
+      projection = .expressions(items + extra)
+    } else {
+      projection = select.projection
+    }
+    return .select(Select(projection: projection, from: select.from,
+                          joins: select.joins, predicate: select.predicate,
+                          grouping: .arm(keys: set, superset: superset),
+                          having: select.having))
+  }
+  // `sets` is non-empty (the parser requires at least one set), so `union` is
+  // set; combine with `UNION ALL` so no arm's rows are deduplicated.
+  let union = arms.dropFirst().reduce(arms[0]) {
+    .setop(.union, $0, $1, all: true)
+  }
+  // A grouped `SELECT *` is ill-formed: return the bare union of the `.all`
+  // arms (never the carrier, whose hidden trimming assumes real output items
+  // the `.all` arms do not enumerate) so the arm's grouped resolver throws the
+  // SAME `SELECT *` fault the unwrapped form does, carried or not.
+  if case .all = select.projection { return union }
+  // A SINGLE grouping set is an ordinary `GROUP BY` — there is no `UNION` for
+  // an unprojected sort key to survive, so materialise NO hidden column and
+  // add NO `ordered` carrier. Wrapping the lone `.select` arm in `.ordered`
+  // would hide a FROM-clause derived table from the query-level derived-table
+  // collection and per-arm execution, faulting `.relation` at run. Re-attach
+  // the query-level clauses to the single grouped arm and return it plain, so
+  // the ordinary `SELECT` path materialises its derived tables.
+  if sets.count == 1 {
+    return .select(Select(distinct: select.distinct,
+                          projection: select.projection, from: select.from,
+                          joins: select.joins, predicate: select.predicate,
+                          grouping: .arm(keys: sets[0], superset: superset),
+                          having: select.having, order: select.order,
+                          limit: select.limit))
+  }
+  guard carried else { return union }
+  // The query-level row operators ride the `ordered` carrier over the union.
+  // `compile`/`run` resolve them through the setop-output scope; the hidden
+  // materialised columns (if any) trail every arm at equal arity and the
+  // carrier trims them through its identity projection. `generated` carries
+  // their STRUCTURAL count out of here — the carrier recovers the real width
+  // as `width − generated`, never by scanning output names for a `*gs` prefix.
+  return .ordered(union, distinct: select.distinct, order: select.order,
+                  limit: select.limit, generated: hidden.count)
+}
+
 // MARK: - Ordered set operation
 
 /// A grouped-arm resolver a carrier caller injects: the RESOLVED grouped-space
@@ -1276,9 +1506,22 @@ extension Catalog where Self: ~Escapable {
     // operators.
     let plan = try compile(union, context)
     let cols = try columns(unifying: union, context)
+    // A GROUPING SETS expansion's arm-0 is a GROUPED `.arm` select; a plain
+    // set-operation chain's is not. For a GROUPING SETS carrier, inject a
+    // resolver that lowers the arm's projection — and any ORDER BY key — to the
+    // arm's grouped-space `Term`s, so a query-level `ORDER BY` matches a
+    // projected aggregate by RESOLVED identity (`SUM(s.Qty)` ≡ projected
+    // `SUM(Qty)`), the plain grouped `ORDER BY` path's rule. A plain arm has no
+    // grouped aggregate space and injects none.
+    let resolver: Resolver? =
+        if case .arm = union.first.grouping {
+          try projected(arm: union.first, context)
+        } else {
+          nil
+        }
     return try carried(over: plan, output: cols, arm: union.first,
                        distinct: distinct, order: order, limit: limit,
-                       generated: generated, context)
+                       generated: generated, resolver: resolver, context)
   }
 
   /// The REAL output count of an `ordered` carrier over a `width`-column set
@@ -1477,8 +1720,17 @@ extension Catalog where Self: ~Escapable {
       // resolution over the `*`-expanded output columns.
       let reals = Array(items.prefix(real))
       let folded = Set(outputs.compactMap { $0?.lowercased() })
-      let rewritten = Order(keys: try order.keys.map {
-        key throws(SQLError) -> Order.Key in
+      // A key resolving to a HIDDEN materialised slot (`real ..< width`) is
+      // bound STRUCTURALLY, by KEY INDEX → that slot, NOT by rewriting to the
+      // generated `*gsN` NAME. The hidden alias is a SPELLABLE delimited
+      // identifier a user's own output could carry (`SELECT Region AS "*gs0" …
+      // ORDER BY MAX(Qty)`), so a name rewrite would let `scope.order`'s
+      // output-alias precedence CAPTURE the hidden key onto the real `*gs0`
+      // output. Recording the slot and OVERWRITING the resolved key's `term`
+      // below binds it by position, immune to a colliding alias.
+      var materialised = Dictionary<Int, Int>()
+      let rewritten = Order(keys: try order.keys.enumerated().map {
+        (offset, key) throws(SQLError) -> Order.Key in
         guard case let .expression(expression) = key.sort else { return key }
         // A BARE unqualified column NAMING A REAL OUTPUT is left to the
         // setop-output scope's ordinary resolution, whichever carrier: it binds
@@ -1496,8 +1748,9 @@ extension Catalog where Self: ~Escapable {
         // a NON-column expression against the arm's projected terms by RESOLVED
         // identity. A key that lowers cleanly and equals a projected term
         // orders on that slot's ORDINAL — a REAL slot directly, a HIDDEN slot
-        // through its `*gsN` output name. A key `resolve` faults on is left for
-        // the setop-output scope to bind or fault, as before.
+        // bound structurally below (never through its spellable `*gsN` name). A
+        // key `resolve` faults on is left for the setop-output scope to bind or
+        // fault, as before.
         if let resolver, !bare {
           let term = try? resolver.resolve(expression)
           if let term, let slot = resolver.terms.firstIndex(of: term) {
@@ -1505,33 +1758,36 @@ extension Catalog where Self: ~Escapable {
               return Order.Key(sort: .ordinal(slot + 1),
                                ascending: key.ascending)
             }
-            return Order.Key(
-                sort: .expression(.column(Column(name: items[slot].alias!))),
-                ascending: key.ascending)
+            // The hidden slot: record it against this key's index and stand a
+            // resolvable ORDINAL placeholder (`1`, the first real output) in
+            // its place so `scope.order` yields an aligned SortKey WITHOUT
+            // trying to recompute the unprojected aggregate over the
+            // output-only scope; its `term` is overwritten to `.slot(slot)`
+            // afterward, binding the hidden column by POSITION.
+            materialised[offset] = slot
+            return Order.Key(sort: .ordinal(1), ascending: key.ascending)
           }
           return key
         }
         if resolver != nil { return key }
         // Plain set-operation carrier: a materialised key (a hidden `*gsN`
-        // item, matched by AST) orders on that hidden column.
+        // item, matched by AST) is bound structurally to that hidden slot,
+        // through the same ORDINAL-placeholder-then-overwrite the resolver path
+        // uses, so a colliding `*gsN` alias cannot capture it.
         if let slot = (real ..< width).first(where: {
           items[$0].expression == expression
         }) {
-          return Order.Key(
-              sort: .expression(.column(Column(name: items[slot].alias!))),
-              ascending: key.ascending)
+          materialised[offset] = slot
+          return Order.Key(sort: .ordinal(1), ascending: key.ascending)
         }
-        if case let .column(column) = expression {
-          // A qualified column whose bare name is an output drops its
-          // qualifier (the set-operation result carries none), so it binds that
-          // output as a bare name — resolving, or faulting `.ambiguous` on a
-          // duplicate, as the plain form. Every other column rides through.
-          if column.qualifier != nil,
-              folded.contains(column.name.lowercased()) {
-            return Order.Key(sort: .expression(.column(Column(name: column
-                                                                    .name))),
-                             ascending: key.ascending)
-          }
+        if case .column = expression {
+          // A column key — bare or qualified — rides through to `scope.order`.
+          // A bare name binds an output by ISO alias precedence (or faults
+          // `.ambiguous` on a name two outputs share). A QUALIFIED key faults
+          // there: the set-operation output carries NO range, so `R.a` /
+          // `NoSuch.a` fails resolution exactly as the derived-union
+          // equivalent does — it is NOT silently sorted by a bare output `a`
+          // after dropping an invalid qualifier.
           return key
         }
         if let index = reals.firstIndex(where: {
@@ -1544,6 +1800,16 @@ extension Catalog where Self: ~Escapable {
       })
       keys = try scope.order(rewritten, projection, names, context.routines,
                              subquery: resolution)
+      // Bind each materialised key to its HIDDEN slot by POSITION, overwriting
+      // the ordinal placeholder's resolved key: `.slot(slot)` orders on the
+      // hidden `*gsN` column directly, `column` cleared so it is an ordinary
+      // input key (NOT a select-list output — DISTINCT then rejects it, and it
+      // is trimmed by the identity projection). This never spells the hidden
+      // `*gsN` NAME, so a user output aliased identically cannot capture it.
+      for (offset, slot) in materialised {
+        keys[offset] = SortKey(term: .slot(slot),
+                               ascending: keys[offset].ascending, column: nil)
+      }
       // The carrier's ORDER BY is a NEW expression surface: `scope.order`
       // RESOLVES each key (binds a column, arity), but — like the grouped
       // path's structural resolve — does NOT type-check a key's operands or its
@@ -1621,7 +1887,14 @@ extension Select {
   /// `HAVING` alone (no `GROUP BY`, no aggregate) still aggregates — it filters
   /// the single whole-result group.
   internal var aggregates: Bool {
-    if !grouping.isEmpty || having != nil { return true }
+    let grouped = switch grouping {
+    case let .keys(keys): !keys.isEmpty
+    // A `GROUPING SETS (…)` (or one expanded arm) always aggregates — even
+    // `GROUPING SETS (())` groups the whole result — so it is grouped
+    // regardless of whether any set is non-empty.
+    case .sets, .arm: true
+    }
+    if grouped || having != nil { return true }
     switch projection {
     case .all, .columns:
       return false
@@ -1916,7 +2189,7 @@ extension Select {
     if case let .expressions(items) = projection {
       for item in items { item.expression.collect(subqueries: &queries) }
     }
-    for key in grouping { key.collect(subqueries: &queries) }
+    for key in grouping.collected { key.collect(subqueries: &queries) }
     for key in order?.keys ?? [] {
       if case let .expression(expression) = key.sort {
         expression.collect(subqueries: &queries)
@@ -1937,7 +2210,7 @@ extension Select {
     if case let .expressions(items) = projection {
       for item in items { item.expression.collect(valued: &queries) }
     }
-    for key in grouping { key.collect(valued: &queries) }
+    for key in grouping.collected { key.collect(valued: &queries) }
     for key in order?.keys ?? [] {
       if case let .expression(expression) = key.sort {
         expression.collect(valued: &queries)
@@ -1959,7 +2232,7 @@ extension Select {
     if case let .expressions(items) = projection {
       for item in items { item.expression.collect(scalar: &queries) }
     }
-    for key in grouping { key.collect(scalar: &queries) }
+    for key in grouping.collected { key.collect(scalar: &queries) }
     for key in order?.keys ?? [] {
       if case let .expression(expression) = key.sort {
         expression.collect(scalar: &queries)
@@ -1981,7 +2254,7 @@ extension Select {
     if case let .expressions(items) = projection {
       for item in items { item.expression.collect(existential: &queries) }
     }
-    for key in grouping { key.collect(existential: &queries) }
+    for key in grouping.collected { key.collect(existential: &queries) }
     for key in order?.keys ?? [] {
       if case let .expression(expression) = key.sort {
         expression.collect(existential: &queries)
@@ -2447,7 +2720,7 @@ extension Catalog where Self: ~Escapable {
   /// The `aggregate` node groups it by the keys and folds each aggregate over a
   /// group, yielding grouped records whose slots are the key values then the
   /// aggregate results. The projection, `HAVING`, and `ORDER BY` lower against
-  /// that grouped slot space through a `Grouping`, which also enforces the
+  /// that grouped slot space through a `Grouped`, which also enforces the
   /// standard rule that every non-aggregated projection/`ORDER BY` column
   /// appear in the `GROUP BY`.
   internal borrowing func group(_ select: Select, _ relation: Relation,
@@ -2537,11 +2810,21 @@ extension Catalog where Self: ~Escapable {
                                   subquery: plans.rest)
     }
 
+    // This select's grouping keys and — for ONE arm of an expanded `GROUPING
+    // SETS` — the SUPERSET (the union of every set's keys, so an absent key
+    // NULLs by resolved identity). A `.sets` never reaches here: `compile`
+    // expands it to a union of `.arm` selects before this runs.
+    let (grouping, superset): (Array<Expression>, Array<Expression>) =
+        switch select.grouping {
+        case let .keys(keys): (keys, [])
+        case let .arm(keys, superset): (keys, superset)
+        case .sets: ([], [])
+        }
     // The `GROUP BY` keys and the aggregate arguments lower to combined
     // base-ordinal terms; the aggregates are collected from the projection, the
     // `HAVING`, and the `ORDER BY` sort keys (deduplicated so the same
     // aggregate computes once).
-    let keys = try select.grouping.map { key throws(SQLError) -> Term in
+    let keys = try grouping.map { key throws(SQLError) -> Term in
       // Each key lowers through `scope.term`: a bare column a local relation
       // binds reads its combined slot; a bare `NATURAL`/`USING` merged column
       // lowers to its `COALESCE(left, right)` value (so the aggregate node
@@ -2658,21 +2941,27 @@ extension Catalog where Self: ~Escapable {
                                 $0.remapped(through: slot)
                               }, chain)
 
+    // The SUPERSET's LOWERED terms — the columns another set groups on — so an
+    // arm's projection/HAVING reference to a key THIS set omits NULLs by
+    // resolved identity (empty for an ordinary grouped query).
+    let supers = try superset.map { key throws(SQLError) -> Term in
+      try scope.term(key, context.routines, subquery: barred)
+    }
     // Lower the projection, HAVING, and ORDER BY against the grouped slot
     // space, enforcing the projection rule (every non-aggregated column must be
     // a GROUP BY key).
-    var grouping = try Grouping(scope, select.grouping, keys, aggregations,
-                                subquery: barred)
-    let projection = try grouping.terms(select.projection, context.routines,
-                                        subquery: barred)
+    var grouped = try Grouped(scope, grouping, keys, aggregations,
+                              superset: supers, subquery: barred)
+    let projection = try grouped.terms(select.projection, context.routines,
+                                       subquery: barred)
     let having: Filter? = if let clause = select.having {
-      try grouping.lower(clause, context.routines, subquery: barred)
+      try grouped.lower(clause, context.routines, subquery: barred)
     } else {
       nil
     }
     var order = if let clause = select.order {
-      try grouping.order(clause, projection, context.routines,
-                         subquery: barred)
+      try grouped.order(clause, projection, context.routines,
+                        subquery: barred)
     } else {
       Array<SortKey>()
     }
@@ -4504,6 +4793,11 @@ extension Catalog where Self: ~Escapable {
   internal borrowing func compile(_ query: Query,
                                   _ context: Context = Context())
       throws(SQLError) -> Plan {
+    // Expand any `GROUP BY GROUPING SETS` select to its `UNION ALL` FIRST — the
+    // SAME normalization `run` applies — so `compile` and a `columns(of:)`
+    // derive over the same query cannot diverge. Idempotent for a `.keys`/
+    // `.arm` select; a nested body re-enters and expands in turn.
+    let query = try query.expanded
     // Bind the derived tables (and store relations) THIS query names in its own
     // FROM/JOIN before resolving its relations — SELECT-scoped, so a subquery
     // compiled through here binds its OWN aliases (an outer statement-global
@@ -4657,7 +4951,7 @@ extension Catalog where Self: ~Escapable {
     if case let .expressions(items) = select.projection {
       for item in items { item.expression.collect(subqueries: &rest) }
     }
-    for key in select.grouping { key.collect(subqueries: &rest) }
+    for key in select.grouping.collected { key.collect(subqueries: &rest) }
     for key in select.order?.keys ?? [] {
       if case let .expression(expression) = key.sort {
         expression.collect(subqueries: &rest)
@@ -5462,6 +5756,9 @@ extension Catalog where Self: ~Escapable {
   internal borrowing func compile(_ select: Select,
                                   _ context: Context = Context())
       throws(SQLError) -> Plan {
+    // A `GROUP BY GROUPING SETS (…)` never reaches here: `Query.expanded` (run
+    // at every pipeline entry) has already rewritten it to a `UNION ALL` of
+    // `.arm` selects, so `compile(_ select:)` sees only `.keys`/`.arm`.
     // Bind THIS select's own FROM/JOIN derived tables (and store relations)
     // before resolving its relations — SELECT-scoped, so a select reaching
     // this entry DIRECTLY (a bare `compile(select)`, not through the `Query`
@@ -5490,8 +5787,11 @@ extension Catalog where Self: ~Escapable {
       // direct `Select(from: nil, …)` can, so reject it rather than silently
       // ignore the clause — a scalar projection would drop a `GROUP
       // BY`/`HAVING` otherwise.
+      let ungrouped = if case .keys([]) = select.grouping { true } else {
+        false
+      }
       guard select.joins.isEmpty, select.predicate == nil,
-          select.grouping.isEmpty, select.having == nil,
+          ungrouped, select.having == nil,
           select.order == nil, select.limit == nil else {
         throw .unsupported(
             "a WHERE, GROUP BY, HAVING, ORDER BY, OFFSET/FETCH, or JOIN " +

--- a/Sources/SQLEngine/Operator.swift
+++ b/Sources/SQLEngine/Operator.swift
@@ -617,7 +617,7 @@ extension Catalog where Self: ~Escapable {
   ///
   /// The carrier plan `ordered` builds is a stack of SINGLE-source row
   /// operators (`sort`/`distinct`/`limit`/`project`, and the `project`/`sort`
-  /// pair a materialised output key emits) OVER the compiled `union` setop.
+  /// pair a `materialised` output key emits) OVER the compiled `union` setop.
   /// The plain `execute(_:_:)` would run the setop under the ONE carrier
   /// context (`execute(.setop)` shares it across both arms), which never binds
   /// an arm's arm-local derived alias — arms are SELECT-scoped, so the query-

--- a/Sources/SQLEngine/OutputColumn.swift
+++ b/Sources/SQLEngine/OutputColumn.swift
@@ -194,6 +194,10 @@ extension Catalog where Self: ~Escapable {
   public borrowing func columns(of query: Query, routines: Routines,
                                 validate: Bool = true)
       throws(SQLError) -> Array<OutputColumn> {
+    // Expand any `GROUP BY GROUPING SETS` select to its `UNION ALL` FIRST, so
+    // the compile validation and the `columns(unifying:)` derive below see the
+    // SAME expanded AST a run does (`run ≡ columns(of:)`).
+    let query = try query.expanded
     // Pure engine: it types calls against exactly the `routines` given, seeding
     // no prelude. `import SQLStandard` adds a prelude-defaulting overload
     // (`columns(of:validate:)`). A typing path has no bindings.
@@ -318,6 +322,11 @@ extension Catalog where Self: ~Escapable {
                                  routines: Routines,
                                  validate: Bool)
       throws(SQLError) -> Array<OutputColumn> {
+    // Expand any `GROUP BY GROUPING SETS` in the trailing query to its `UNION
+    // ALL` FIRST, so this schema derive sees the SAME AST the run does: the run
+    // WITH path (`with` then `run(query:)`) normalizes there. The CTE BODIES
+    // expand within `typed`/`validate`/`contributions`.
+    let query = try query.expanded
     let context = Context(routines: routines).validating(validate)
     // Type the CTEs into a SCHEMA-ONLY overlay (`rows: false`) through the ONE
     // producer the run path also drives — `Engine.typed(ctes:in:rows:)` — so
@@ -446,6 +455,13 @@ extension Catalog where Self: ~Escapable {
       throws(SQLError) -> Array<ResolvedColumn> {
     switch query {
     case let .select(select):
+      // A `GROUP BY GROUPING SETS (…)` derives its schema through the SAME
+      // `UNION ALL` expansion the compile path uses, so the run and the derived
+      // columns cannot diverge (`run ≡ columns(of:)`): the arms' NULL-padded
+      // columns type through the set-operation `merge` exactly as the run's do.
+      if case let .sets(sets) = select.grouping {
+        return try columns(unifying: expand(select, sets: sets), context)
+      }
       return try arms(of: select, context)
     case let .ordered(inner, _, _, _, generated):
       // The `ordered` carrier is TRANSPARENT to the result schema: `ORDER BY`,
@@ -453,13 +469,13 @@ extension Catalog where Self: ~Escapable {
       // project — so the result columns are the inner setop's arm-0-named,
       // unified ones whether reached via `run`/`compile` or `columns(of:)`
       // (`run ≡ columns`). The one exception is a HIDDEN materialised sort
-      // column (a producer appends `generated` of them to every arm so an
-      // unprojected sort key survives the union at equal arity): the carrier's
-      // compile TRIMS them through the identity projection, so drop the
-      // matching trailing columns here too so the schema matches the run. The
-      // count is the STRUCTURAL `generated` the carrier carries, never a scan
-      // of the arm-0 names for a synthetic prefix — a user's delimited `AS
-      // "*gs0"` is a real output, not a generated column.
+      // column (`expand` appends `generated` of them to every arm so an
+      // unprojected `ORDER BY MAX(x)` survives the union at equal arity): the
+      // carrier's compile TRIMS them through the identity projection, so drop
+      // the matching trailing columns here too so the schema matches the run.
+      // The count is the STRUCTURAL `generated` the carrier carries, never a
+      // scan of the arm-0 names for a synthetic prefix — a user's delimited
+      // `AS "*gs0"` is a real output, not a generated column.
       let cols = try columns(unifying: inner, context)
       // Range-check `generated` against the width and take the trim width
       // through the SHARED guard the compile carrier uses (`real(trimming:of:)`
@@ -547,11 +563,6 @@ extension Catalog where Self: ~Escapable {
   /// declared width — the recursive-aware merge `kinds` wraps.
   private borrowing func contributions(of cte: CTE, _ scope: Context)
       throws(SQLError) -> Array<ResolvedColumn> {
-    // Derive types off the SAME AST a run does. (When `GROUP BY GROUPING SETS`
-    // lands, `Query.expanded` is re-inserted here so a grouping-sets body
-    // lowers to its `UNION ALL` arms FIRST, matching `run`/`compile` — a one-
-    // token merge follow-up, not needed here.)
-    let body = cte.query
     // Recognise the recursive `UNION` shape through the CANONICAL peel
     // (`recursiveArms` — unwound), the SAME recogniser the run/validate/
     // fixpoint recursive-CTE seams take (`CTE.recurses`, `fixpoint`'s
@@ -567,10 +578,13 @@ extension Catalog where Self: ~Escapable {
       // genuine incompatibility (`SELECT 'b' UNION SELECT 1`) as `.operand`
       // rather than swallowing it into the declared `.integer`: with every
       // placeholder now marked unconstrained, a trusted body that RAN carries
-      // no genuine incompat to fault, so no `try?` fallback is needed. The
-      // carrier is transparent to a non-recursive body's fold too — the
-      // `.ordered` case of `columns(unifying:)` peels it identically.
-      return try columns(unifying: body, scope)
+      // no genuine incompat to fault, so no `try?` fallback is needed. Derive
+      // types off the SAME expanded AST a run does: a `GROUP BY GROUPING SETS`
+      // body expands to its `UNION ALL` arms FIRST, so the schema fold matches
+      // `run`/`compile` (run and `columns(of:)` cannot diverge). The carrier is
+      // transparent to a non-recursive body's fold too — the `.ordered` case of
+      // `columns(unifying:)` peels it identically.
+      return try columns(unifying: cte.query.expanded, scope)
     }
     let seeds = try columns(unifying: anchor, scope)
     // The recursive arm addresses the self by the CTE's DECLARED names (`SELECT
@@ -869,7 +883,7 @@ extension Catalog where Self: ~Escapable {
     if case let .expressions(items) = select.projection {
       for item in items { item.expression.collect(subqueries: &rest) }
     }
-    for key in select.grouping { key.collect(subqueries: &rest) }
+    for key in select.grouping.collected { key.collect(subqueries: &rest) }
     for key in select.order?.keys ?? [] {
       if case let .expression(expression) = key.sort {
         expression.collect(subqueries: &rest)
@@ -1101,7 +1115,7 @@ extension Catalog where Self: ~Escapable {
       // projection run over the group's results, so EVALUATE them (`empty`) — a
       // divide, overflow, or bad routine call faults as the run would.
       if scope.constant(predicate, routines) == false {
-        if select.aggregates, select.grouping.isEmpty {
+        if select.aggregates, select.grouping.expressions.isEmpty {
           if let having = select.having {
             // HAVING filters the group BEFORE any OFFSET/FETCH limit, so
             // evaluate it UNCONDITIONALLY — a zero `FETCH` or positive `OFFSET`
@@ -1180,7 +1194,7 @@ extension Catalog where Self: ~Escapable {
     // overflow, bad-type op, or unknown/misapplied call) under `validate`
     // exactly as the run evaluates it, closing the gap where `group` lowers the
     // key structurally (no evaluation) so `compile` alone never surfaces it.
-    for expression in select.grouping {
+    for expression in select.grouping.expressions {
       _ = try scope.validate(expression, routines, subquery: barred)
     }
     if let having = select.having {
@@ -1199,7 +1213,7 @@ extension Catalog where Self: ~Escapable {
     // deduplicated result — a zero FETCH or skipping OFFSET does not spare it.
     // A false WHERE still yields no rows to dedup (handled above), so only the
     // limit-based elision is bypassed for DISTINCT.
-    let sole = select.aggregates && select.grouping.isEmpty
+    let sole = select.aggregates && select.grouping.expressions.isEmpty
     var reachable = select.distinct
     if !reachable { reachable = !drops(select.limit, single: sole) }
     if reachable, case let .expressions(items) = select.projection {
@@ -1230,10 +1244,10 @@ extension Catalog where Self: ~Escapable {
   /// out-of-range ordinal `SQLError.column`; a duplicated output name
   /// `SQLError.ambiguous`.
   ///
-  /// It rebuilds the `Grouping` `group` builds — the `GROUP BY` keys and the
+  /// It rebuilds the `Grouped` `group` builds — the `GROUP BY` keys and the
   /// aggregations collected from the projection, `HAVING`, and the `ORDER BY`
   /// sort keys, deduped by resolved `Aggregation` — then lowers the projection
-  /// and the `ORDER BY` through it, reusing `Grouping.terms`/`Grouping.order`
+  /// and the `ORDER BY` through it, reusing `Grouped.terms`/`Grouped.order`
   /// so the two paths cannot drift. It resolves only, reading no cursor; a
   /// run's operand type-check over the (structurally valid) keys stays the
   /// caller's.
@@ -1276,10 +1290,24 @@ extension Catalog where Self: ~Escapable {
         aggregations.append(aggregation)
       }
     }
+    // This select's grouping keys and — for ONE expanded `GROUPING SETS` arm —
+    // its superset, matching the run's `group`. An `.arm` never carries an
+    // `ORDER BY` (it rides the wrapper), so the superset is used here only for
+    // completeness; a `.sets` never reaches this path (it is expanded before
+    // any resolve).
+    let (grouping, superset): (Array<Expression>, Array<Expression>) =
+        switch select.grouping {
+        case let .keys(keys): (keys, [])
+        case let .arm(keys, superset): (keys, superset)
+        case .sets: ([], [])
+        }
     // The GROUP BY keys' LOWERED base-ordinal terms, so a bare `NATURAL`/
     // `USING` merged key (which binds no single ordinal) is matched by term —
     // the SAME lowering the run's `group` computes.
-    let keys = try select.grouping.map { key throws(SQLError) -> Term in
+    let keys = try grouping.map { key throws(SQLError) -> Term in
+      try scope.term(key, routines, subquery: subquery.barred)
+    }
+    let supers = try superset.map { key throws(SQLError) -> Term in
       try scope.term(key, routines, subquery: subquery.barred)
     }
     // Build the grouping and lower the projection through it to record each
@@ -1287,11 +1315,83 @@ extension Catalog where Self: ~Escapable {
     // `ORDER BY` output name resolves against — then lower the `ORDER BY`,
     // which faults a non-group column, an out-of-range ordinal, or an ambiguous
     // name.
-    var grouping = try Grouping(scope, select.grouping, keys, aggregations,
-                                subquery: subquery)
-    let projection = try grouping.terms(select.projection, routines,
-                                        subquery: subquery)
-    _ = try grouping.order(clause, projection, routines, subquery: subquery)
+    var grouped = try Grouped(scope, grouping, keys, aggregations,
+                              superset: supers, subquery: subquery)
+    let projection = try grouped.terms(select.projection, routines,
+                                       subquery: subquery)
+    _ = try grouped.order(clause, projection, routines, subquery: subquery)
+  }
+
+  /// The RESOLVED grouped-space `Term` of each of a GROUPED arm's projected
+  /// items, paired with a resolver lowering an arbitrary expression to the same
+  /// grouped space — the identity surface the `ordered` set-op carrier matches
+  /// a query-level `ORDER BY` key against, so it agrees with the plain grouped
+  /// `ORDER BY` path (both route through this ONE `Grouped`).
+  ///
+  /// The carrier over a `GROUPING SETS` expansion resolves its `ORDER BY` keys
+  /// against the union's OUTPUT scope, which cannot recompute an aggregate. To
+  /// decide whether a key is an ALREADY-PROJECTED value — so it orders on that
+  /// output rather than a synthetic hidden column — it lowers the key HERE and
+  /// matches its `Term` against these projected terms by RESOLVED identity,
+  /// general over every expression shape (a qualifier-equivalent aggregate
+  /// `SUM(s.Qty)` ≡ the projected `SUM(Qty)`), not raw AST + a `.column`-only
+  /// qualifier strip. It rebuilds the SAME `Grouped` the run's `group` and the
+  /// schema `order(grouped:)` build — the keys and the aggregations collected
+  /// from the projection, `HAVING`, and (the arm carries the materialised keys
+  /// as projected items) the sort keys, deduped by resolved `Aggregation` — so
+  /// the identity cannot drift from either. It resolves only, reads no cursor.
+  ///
+  /// `resolve` faults `SQLError.grouping` on a genuinely non-grouped reference,
+  /// which for an unprojected key the carrier catches to mean "not a projected
+  /// value, materialise it"; a projected key lowers cleanly to its output slot.
+  borrowing func projected(arm select: Select, _ context: Context)
+      throws(SQLError)
+      -> (terms: Array<Term>,
+          resolve: (Expression) throws(SQLError) -> Term) {
+    let context = try augment(context, for: .select(select), rows: false)
+    let routines = context.routines
+    let scope = try scope(of: select, context)
+    let prefixes = try prefixes(of: select, context)
+    let subquery = try subquery(of: select, context.scoped(as: .caller),
+                                enclosing: scope, prefixes: prefixes).rest
+    // The distinct aggregates the arm folds — its projection (which for a
+    // carried GROUPING SETS arm includes the materialised sort keys as extra
+    // projected items) and its `HAVING` — deduped by resolved `Aggregation`,
+    // exactly as `group` does, so a projected aggregate and a
+    // qualifier-equivalent sort key fold into ONE slot.
+    var expressions = Array<Expression>()
+    for expression in select.projection.projected {
+      expression.collect(into: &expressions)
+    }
+    if let having = select.having { having.collect(into: &expressions) }
+    var aggregations = Array<Aggregation>()
+    for expression in expressions {
+      let aggregation = try expression.aggregation(scope, routines,
+                                                   subquery: subquery)
+      if !aggregations.contains(aggregation) {
+        aggregations.append(aggregation)
+      }
+    }
+    let (grouping, superset): (Array<Expression>, Array<Expression>) =
+        switch select.grouping {
+        case let .keys(keys): (keys, [])
+        case let .arm(keys, superset): (keys, superset)
+        case .sets: ([], [])
+        }
+    let keys = try grouping.map { key throws(SQLError) -> Term in
+      try scope.term(key, routines, subquery: subquery.barred)
+    }
+    let supers = try superset.map { key throws(SQLError) -> Term in
+      try scope.term(key, routines, subquery: subquery.barred)
+    }
+    var grouped = try Grouped(scope, grouping, keys, aggregations,
+                              superset: supers, subquery: subquery)
+    let terms = try grouped.terms(select.projection, routines,
+                                  subquery: subquery)
+    let barred = subquery.barred
+    return (terms, { expression throws(SQLError) in
+      try grouped.resolve(expression, routines, subquery: barred)
+    })
   }
 
   /// Whether `limit` drops the one row a `single`-row result would yield,
@@ -1403,8 +1503,18 @@ extension Catalog where Self: ~Escapable {
       // unbound column in the DEFINITION must fault — NOT bind to an enclosing
       // row — when the view's schema is derived from inside a correlated
       // subquery, keeping this derivation consistent with `resolve`/`compile`.
+      // Derive and type-check the SAME expanded AST a run does: a `GROUP BY
+      // GROUPING SETS` body expands to its `UNION ALL` arms FIRST, so the
+      // reachability typecheck sees the per-set arms. An UNEXPANDED body would
+      // read `GROUPING SETS ((Region), ())` as non-empty `grouping.expressions`
+      // and, under a constant-false `WHERE`, short-circuit WITHOUT validating
+      // the projection — yet the expanded `()` grand-total arm still produces a
+      // group and evaluates it at run, so `columns(of:)` would ACCEPT a body
+      // (`SELECT 1 / 0 … GROUP BY GROUPING SETS ((Region), ())`) the run
+      // faults. Expanding here keeps the view schema path in step with the run.
+      let body = try view.query.expanded
       let overlay =
-          try augment(context.body([:]).visiting(name), for: view.query,
+          try augment(context.body([:]).visiting(name), for: body,
                       rows: false)
       // Gate the body's reachable-operand check on `context.validate`: a
       // `validate: false` derive skips it, so a data-dependent-empty body (a
@@ -1412,7 +1522,7 @@ extension Catalog where Self: ~Escapable {
       // over the view that already ran to its (empty) result. It also rides
       // into the recursive derive so a view over a view stays derive-only.
       if context.validate {
-        try typecheck(view.query, overlay)
+        try typecheck(body, overlay)
       }
       // Type the body's columns: their NAMES off the first arm (the ISO rule
       // for a UNION), their TYPES unified across every arm, each carrying its
@@ -1421,7 +1531,7 @@ extension Catalog where Self: ~Escapable {
       // declared columns — is `compile`'s job (the public entry runs it), so on
       // a shortfall fall back to the declared schema rather than re-checking it
       // here.
-      let resolved = try resolved(query: view.query, in: overlay)
+      let resolved = try resolved(query: body, in: overlay)
       guard resolved.count == base.width else {
         return try base.renamed(renaming)
       }

--- a/Sources/SQLEngine/Parser.swift
+++ b/Sources/SQLEngine/Parser.swift
@@ -43,7 +43,12 @@
 ///                   // the derived body may reference preceding FROM items
 /// projection     := '*' | column (',' column)*
 /// where          := WHERE predicate
-/// group          := GROUP BY expression (',' expression)*
+/// group          := GROUP BY (grouping | GROUPING SETS '(' set (',' set)* ')')
+///                   // GROUPING/SETS are context identifiers, not keywords;
+///                   // GROUPING SETS expands to a UNION ALL of per-set arms at
+///                   // compile/schema time (by resolved identity), not here
+/// grouping       := expression (',' expression)*  // ordinary grouping keys
+/// set            := '(' [expression (',' expression)*] ')'  // '()' = total
 /// having         := HAVING predicate
 /// predicate      := disjunction
 /// disjunction    := conjunction (OR conjunction)*
@@ -110,11 +115,13 @@
 internal struct Parser: ~Escapable {
   private var lexer: Lexer
   private var current: Token?
+  private var pending: Token?
 
   @_lifetime(copy lexer)
   internal init(_ lexer: consuming Lexer) throws(SQLError) {
     self.lexer = lexer
     self.current = try self.lexer.next()
+    self.pending = nil
   }
 
   // MARK: - Statement
@@ -563,7 +570,7 @@ internal struct Parser: ~Escapable {
     } else {
       nil
     }
-    let grouping = try match(.group) ? try grouping() : []
+    let grouping = try match(.group) ? try grouping() : .keys([])
     let having: Predicate? = if try match(.having) {
       try self.predicate()
     } else {
@@ -576,27 +583,80 @@ internal struct Parser: ~Escapable {
     }
     let limit = try rowLimit()
 
+    // The `GROUP BY` tail is stored as-parsed — a `.keys` ordinary key list (or
+    // none) or a `.sets` `GROUPING SETS (…)` list. A `.sets` is EXPANDED into a
+    // `UNION ALL` of per-arm groupings at compile and schema time (by RESOLVED
+    // identity, so an absent key NULLs correctly), not desugared here.
     return Select(distinct: distinct, projection: projection, from: from,
                   joins: joins, predicate: predicate, grouping: grouping,
                   having: having, order: order, limit: limit)
   }
 
-  /// Parses `BY expression (, expression)*` (the `GROUP` keyword is already
-  /// consumed) — the `GROUP BY` keys, in source order. Each key parses as a
-  /// general scalar `expression` (ISO `<ordinary grouping set>` is a value
-  /// expression), so a key may be a column, an arithmetic or `||` expression,
-  /// a function call, a `CASE`/`COALESCE`, and so on — resolved and lowered
-  /// through `scope.term` at run and validated through `scope.validate`. A
-  /// bare identifier is itself an `Expression.column`, so `GROUP BY col` is
-  /// unchanged and a bare `NATURAL`/`USING` merged key still lowers to its
-  /// coalesce value through the join scope.
-  private mutating func grouping() throws(SQLError) -> Array<Expression> {
+  /// Parses `BY <grouping element>` (the `GROUP` keyword is already consumed) —
+  /// either the ordinary `<ordinary grouping set>` key list `e (, e)*` or the
+  /// ISO `GROUP BY GROUPING SETS (s, …)` construct.
+  ///
+  /// Each ordinary key parses as a general scalar `expression` (ISO `<ordinary
+  /// grouping set>` is a value expression), so a key may be a column, an
+  /// arithmetic or `||` expression, a function call, a `CASE`/`COALESCE`, and
+  /// so on — resolved and lowered through `scope.term` at run and validated
+  /// through `scope.validate`. A bare identifier is itself an
+  /// `Expression.column`, so `GROUP BY col` is unchanged and a bare
+  /// `NATURAL`/`USING` merged key still lowers to its coalesce value through
+  /// the join scope.
+  ///
+  /// `GROUPING`/`SETS` are CONTEXT identifiers (not lexer keywords, mirroring
+  /// `CAST`/`COALESCE`), so a bare `GROUPING` immediately followed by a bare
+  /// `SETS` and a `(` opens the construct; a column named `grouping`
+  /// (delimited, or bare and NOT followed by `SETS`) stays a key. The two-token
+  /// lookahead (`secondary`) resolves the prefix before consuming either token.
+  private mutating func grouping() throws(SQLError) -> Grouping {
     try expect(.by)
+    // The construct opens on a bare `GROUPING` immediately followed by a bare
+    // `SETS` — both context identifiers, resolved by two tokens of lookahead
+    // BEFORE either is consumed, so a delimited `"grouping"` or a bare
+    // `grouping` not followed by `SETS` stays an ordinary key.
+    if case let .identifier(text) = current?.kind,
+        text.uppercased() == "GROUPING",
+        case let .identifier(next) = try secondary()?.kind,
+        next.uppercased() == "SETS" {
+      return try .sets(sets())
+    }
     var keys = Array<Expression>()
     try keys.append(expression())
     while try match(.comma) {
       try keys.append(expression())
     }
+    return .keys(keys)
+  }
+
+  /// Parses the `GROUPING SETS ( set (, set)* )` tail — the `GROUPING` and
+  /// `SETS` context identifiers are the next two tokens (confirmed by
+  /// `grouping`) — into one key list per set, in source order. At least one set
+  /// is required.
+  private mutating func sets() throws(SQLError) -> Array<Array<Expression>> {
+    _ = try advance(expecting: "GROUPING")
+    _ = try advance(expecting: "SETS")
+    try expect(.lparen)
+    var sets = try [set()]
+    while try match(.comma) {
+      try sets.append(set())
+    }
+    try expect(.rparen)
+    return sets
+  }
+
+  /// Parses one grouping set `( e, … )` or `( )` — a parenthesised list of
+  /// general grouping expressions, possibly empty (the grand-total set) — into
+  /// its key list.
+  private mutating func set() throws(SQLError) -> Array<Expression> {
+    try expect(.lparen)
+    guard !(try match(.rparen)) else { return [] }
+    var keys = try [expression()]
+    while try match(.comma) {
+      try keys.append(expression())
+    }
+    try expect(.rparen)
     return keys
   }
 
@@ -1790,20 +1850,46 @@ internal struct Parser: ~Escapable {
 
   // MARK: - Cursor
 
-  /// Consumes and returns the current token, faulting at the end of input.
+  /// The token AFTER `current` without consuming either — a second token of
+  /// lookahead, buffered in `pending` and drained by `advance` before the lexer
+  /// is next pulled. It disambiguates a two-token context prefix a single
+  /// `current` cannot (`GROUP BY GROUPING SETS`, whose `GROUPING`/`SETS` are
+  /// context identifiers, not keywords, so a bare column named `grouping`
+  /// followed by anything but `SETS` must NOT be mistaken for the construct).
+  private mutating func secondary() throws(SQLError) -> Token? {
+    if pending == nil {
+      pending = try lexer.next()
+    }
+    return pending
+  }
+
+  /// Consumes and returns the current token, faulting at the end of input. A
+  /// buffered `pending` lookahead becomes the new `current`; otherwise the
+  /// lexer is pulled.
   private mutating func advance(expecting expectation: String)
       throws(SQLError) -> Token {
     guard let token = current else {
       throw .incomplete(expected: expectation)
     }
-    current = try lexer.next()
+    if let pending {
+      current = pending
+      self.pending = nil
+    } else {
+      current = try lexer.next()
+    }
     return token
   }
 
-  /// Consumes the current token if it has `kind`, reporting whether it did.
+  /// Consumes the current token if it has `kind`, reporting whether it did. A
+  /// buffered `pending` lookahead becomes the new `current` on a match.
   private mutating func match(_ kind: Token.Kind) throws(SQLError) -> Bool {
     guard let token = current, token.kind == kind else { return false }
-    current = try lexer.next()
+    if let pending {
+      current = pending
+      self.pending = nil
+    } else {
+      current = try lexer.next()
+    }
     return true
   }
 

--- a/Sources/SQLEngine/Resolve.swift
+++ b/Sources/SQLEngine/Resolve.swift
@@ -513,7 +513,7 @@ internal final class SubqueryMemo {
 /// violation.
 ///
 /// Predicate lowering happens over escapable resolution surfaces (`Schema`,
-/// `Scope`, `Grouping`) that carry no catalog, and is shared by SCHEMA-ONLY
+/// `Scope`, `Grouped`) that carry no catalog, and is shared by SCHEMA-ONLY
 /// paths (`columns(of:)`, view resolution, arity checks) documented NOT to open
 /// a cursor. So lowering carries the sub-`Query` into the `Filter` as DATA
 /// rather than running it: `exists`/`within` build the lowered node holding the
@@ -1487,7 +1487,7 @@ internal struct SortKey {
 /// a `columns` or an `expressions` list. An alias two items share has no single
 /// term to order on — the two aliases may compute different values, so the
 /// result must not depend on select-list order — and a bare `ORDER BY` name
-/// matching it is `SQLError.ambiguous`, as the grouped `Grouping.order` does.
+/// matching it is `SQLError.ambiguous`, as the grouped `Grouped.order` does.
 private func order(_ order: Order, _ projection: Array<Term>,
                    _ names: Array<String?>,
                    term: (Expression) throws(SQLError) -> Term)
@@ -1894,7 +1894,7 @@ internal struct Scope {
   internal var merges: Array<Merged> { merged }
 
   /// The merged column named `name` (case-insensitively), or `nil` when none —
-  /// the probe `Grouping` uses to route a bare merged key to term-matching
+  /// the probe `Grouped` uses to route a bare merged key to term-matching
   /// rather than the ordinal `keys` map its `find` cannot fill.
   internal func merges(_ name: String) -> Merged? { merged(name) }
 
@@ -4363,7 +4363,7 @@ internal struct Scope {
 ///
 /// An `aggregate` node yields grouped records whose slots are the `GROUP BY`
 /// key values (slots `0 ..< keys.count`, in key order) followed by the
-/// aggregate results (slot `keys.count + j` is aggregate `j`). A `Grouping`
+/// aggregate results (slot `keys.count + j` is aggregate `j`). A `Grouped`
 /// lowers a name-addressed AST expression into that space: an aggregate call
 /// maps to its result slot; a bare column maps to its key slot ONLY when it is
 /// a `GROUP BY` key — the standard rule that a non-aggregated column must
@@ -4374,7 +4374,16 @@ internal struct Scope {
 /// The keys and aggregates resolve against the underlying `Scope`, so the same
 /// combined-ordinal resolution the source uses decides which projection columns
 /// are keys.
-internal struct Grouping {
+///
+/// For ONE arm of an expanded `GROUPING SETS`, `superset` carries the LOWERED
+/// terms of the UNION of every set's keys. A non-key column whose lowered term
+/// is in the superset is a SUPER-AGGREGATE NULL (a grouping column another set
+/// groups on but THIS arm does not) — `term` returns a typeless-NULL slot for
+/// it instead of faulting `.grouping`, so a projected/HAVING/ORDER-BY reference
+/// to it NULLs by RESOLVED identity (`n.A` ≡ `A`, case-insensitively), not raw
+/// AST. It is empty for an ordinary grouped query, whose every non-key column
+/// still faults.
+internal struct Grouped {
   private let scope: Scope
 
   /// Each BARE-column `GROUP BY` key's combined base ordinal mapped to its
@@ -4393,6 +4402,14 @@ internal struct Grouping {
   /// reference to it — groups and projects as ONE value, matched by term
   /// rather than the raw AST or an ordinal a merged column lacks.
   private let terms: Array<Term>
+
+  /// The LOWERED terms of the union of every set's keys, for ONE arm of an
+  /// expanded `GROUPING SETS` — the columns another set groups on. A non-key
+  /// reference whose lowered term is in here is a super-aggregate NULL (this
+  /// arm does not group on it, but another set does), so `term` returns a
+  /// typeless-NULL slot rather than faulting `.grouping`. Empty for an ordinary
+  /// grouped query.
+  private let superset: Array<Term>
 
   /// The number of `GROUP BY` keys — aggregate `j` sits at grouped slot
   /// `offset + j`, following the key slots.
@@ -4430,8 +4447,10 @@ internal struct Grouping {
   internal init(_ scope: Scope, _ grouping: Array<Expression>,
                 _ terms: Array<Term>,
                 _ aggregates: Array<Aggregation>,
+                superset: Array<Term> = [],
                 subquery: Resolution = .unsupported) throws(SQLError) {
     self.scope = scope
+    self.superset = superset
     var keys = Dictionary<Int, Int>(minimumCapacity: grouping.count)
     for index in grouping.indices {
       // A BARE-column grouping key a local relation binds maps its combined
@@ -4478,6 +4497,19 @@ internal struct Grouping {
     return aggregates.firstIndex(of: aggregation).map { offset + $0 }
   }
 
+  /// Lowers an `expression` to its grouped-space `Term` — the module-visible
+  /// entry to the private `term`, so a caller (the `ordered` set-op carrier)
+  /// can match an `ORDER BY` key against the projection by RESOLVED identity,
+  /// exactly as the grouped `ORDER BY` path does: a projected aggregate and a
+  /// qualifier-equivalent sort key (`SUM(Qty)` vs `SUM(s.Qty)`) lower to the
+  /// SAME grouped slot, so the carrier need not compare raw AST.
+  internal func resolve(_ expression: Expression,
+                        _ routines: Routines = [:],
+                        subquery: Resolution = .unsupported)
+      throws(SQLError) -> Term {
+    try term(expression, routines, subquery: subquery)
+  }
+
   /// Lowers a scalar `expression` to a grouped-space `Term`.
   ///
   /// An aggregate call maps to its result slot; a literal to a constant; a
@@ -4522,6 +4554,12 @@ internal struct Grouping {
     if !plain, !expression.aggregated {
       let lowered = try scope.term(expression, routines, subquery: subquery)
       if let index = terms.firstIndex(of: lowered) { return .slot(index) }
+      // A reference to a column ANOTHER set groups on but THIS arm's set omits
+      // is a SUPER-AGGREGATE NULL — matched by lowered term (so `n.A` ≡ `A`,
+      // case-insensitively), not raw AST — so it lowers to a typeless-NULL
+      // constant rather than faulting. This dissolves the qualified/unqualified
+      // and absent-key HAVING findings for a merged/general reference.
+      if superset.contains(lowered) { return .constant(.null) }
       if case let .column(column) = expression {
         throw .grouping(column.name)
       }
@@ -4538,8 +4576,14 @@ internal struct Grouping {
       // `ordinal(of:)` re-throws the genuine unknown-column `.column` fault,
       // exactly as `Scope.term` does.
       if let ordinal = try scope.find(column) {
-        guard let slot = keys[ordinal] else { throw .grouping(column.name) }
-        return .slot(slot)
+        if let slot = keys[ordinal] { return .slot(slot) }
+        // A bare column ANOTHER set groups on but THIS arm's set omits is a
+        // super-aggregate NULL — matched by its LOWERED term against the
+        // superset (so `n.A` ≡ `A`, case-insensitively), not the raw ordinal —
+        // else the standard non-grouped fault.
+        let lowered = try scope.term(expression, routines, subquery: subquery)
+        if superset.contains(lowered) { return .constant(.null) }
+        throw .grouping(column.name)
       }
       if let name = try subquery.correlate(column) { return .parameter(name) }
       return try .slot(scope.ordinal(of: column))

--- a/Tests/SQLTests/Queries/EngineWithTests.swift
+++ b/Tests/SQLTests/Queries/EngineWithTests.swift
@@ -1326,23 +1326,36 @@ struct EngineRecursiveTests {
                                           [.integer(4)]])
   }
 
-  @Test func `a recursive carrier ORDER BY of a qualified column resolves on the output`()
+  @Test func `a recursive carrier ORDER BY of a qualified column faults`()
       throws {
-    // The qualified sub-case: `p.Age` drops its qualifier (a set-operation
-    // result carries none) and binds the bare output the anchor projects, as
-    // the ordinary carrier's qualifier strip does.
+    // The recursive body is a set operation; its trailing carrier `ORDER BY`
+    // resolves against the fixpoint OUTPUT, which — like any set-operation
+    // result — exposes NO range. A QUALIFIED key `p.Age` (the anchor's `p`)
+    // therefore fails resolution, exactly as the derived-union equivalent and
+    // a plain `… UNION … ORDER BY R.a` do: the carrier lets it through to
+    // `scope.order` rather than silently dropping the qualifier to bind the
+    // bare output. The BARE `ORDER BY Age` orders the fixpoint (below).
     let people = EngineMemory([
       "People": FixtureRelation([EngineField(name: "Age", type: .integer)],
                                 [[.integer(1)]] as Array<Array<Value>>),
     ])
-    let statement = try Statement(parsing: """
+    let qualified = try Statement(parsing: """
         WITH RECURSIVE t (Age) AS (
           SELECT p.Age FROM People p WHERE p.Age = 1
           UNION ALL SELECT Age + 1 FROM t WHERE Age < 3 ORDER BY p.Age
         ) SELECT Age FROM t
         """)
-    #expect(try people.run(statement) == [[.integer(1)], [.integer(2)],
-                                          [.integer(3)]])
+    #expect(throws: SQLError.column("Age")) {
+      _ = try people.run(qualified)
+    }
+    let bare = try Statement(parsing: """
+        WITH RECURSIVE t (Age) AS (
+          SELECT p.Age FROM People p WHERE p.Age = 1
+          UNION ALL SELECT Age + 1 FROM t WHERE Age < 3 ORDER BY Age
+        ) SELECT Age FROM t
+        """)
+    #expect(try people.run(bare) == [[.integer(1)], [.integer(2)],
+                                     [.integer(3)]])
   }
 
   @Test func `a recursive carrier ORDER BY of an ordinal orders the fixpoint`()

--- a/Tests/SQLTests/Queries/GroupingKeyValidationTests.swift
+++ b/Tests/SQLTests/Queries/GroupingKeyValidationTests.swift
@@ -33,7 +33,7 @@ private func grouped(by key: Expression,
   .select(Select(projection: .expressions(
                      [Projected(expression: .aggregate(.count, of: .star))]),
                  from: Relation(name: "Orders"), predicate: predicate,
-                 grouping: [key]))
+                 grouping: .keys([key])))
 }
 
 /// The `SQLError` running `query` against `catalog` raises, or `nil`.

--- a/Tests/SQLTests/Queries/GroupingSetsTests.swift
+++ b/Tests/SQLTests/Queries/GroupingSetsTests.swift
@@ -1,0 +1,1411 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+import SQLEngine
+import SQLTestSupport
+
+// MARK: - Fixtures
+
+/// A `Sales` relation of `Region`/`Product`/`Qty` rows — two regions, two
+/// products, and a numeric to `SUM` — the groupable shape a `GROUP BY GROUPING
+/// SETS` exercises. Per-(Region, Product) sums: East/A 15 (10 + 5), East/B 20,
+/// West/A 7, West/B 3. Per-Region sums: East 35, West 10. Grand total 45.
+private func sales() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("Sales", ["Region": .text, "Product": .text, "Qty": .integer]) {
+      Row("East", "A", 10)
+      Row("East", "A", 5)
+      Row("East", "B", 20)
+      Row("West", "A", 7)
+      Row("West", "B", 3)
+    }
+  }
+}
+
+/// An `N` relation of `A`/`V` rows — a numeric grouping column and a numeric to
+/// `SUM` — for the general-expression and duplicate-set cases. Per-A sums: 1 is
+/// 150 (100 + 50), 2 is 30. Grand total 180.
+private func nums() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("N", ["A": .integer, "V": .integer]) {
+      Row(1, 100)
+      Row(1, 50)
+      Row(2, 30)
+    }
+  }
+}
+
+// MARK: - GROUPING SETS core
+
+struct GroupingSetsTests {
+  @Test func `three sets union the per-(a,b), per-a, and grand-total groupings`()
+      throws {
+    // `GROUPING SETS ((Region, Product), (Region), ())` desugars to a UNION ALL
+    // of three arms: the full grouping (both columns present), the per-Region
+    // grouping (Product a super-aggregate NULL), and the grand total (both
+    // NULL). Arm order then row order within each arm.
+    try sales().expect("""
+        SELECT Region, Product, SUM(Qty)
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region, Product), (Region), ())
+        """, yields: [
+          ["East", "A", 15], ["East", "B", 20],
+          ["West", "A", 7], ["West", "B", 3],
+          ["East", nil, 35], ["West", nil, 10],
+          [nil, nil, 45],
+        ])
+  }
+
+  @Test func `the result columns type through set-operation unification`()
+      throws {
+    // A NULL-padded column takes the SIBLING arm's type via the set-operation
+    // merge (a constant-NULL arm constrains nothing): Region and Product stay
+    // `.text` despite the arms that NULL them, and the SUM is `.integer`. The
+    // schema derive (run ≡ columns) agrees with the run above.
+    let cat = try sales()
+    let columns = try cat.columns(of: parse(query: """
+        SELECT Region, Product, SUM(Qty)
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region, Product), (Region), ())
+        """), validate: true)
+    #expect(columns == [
+      OutputColumn(name: "Region", type: .text),
+      OutputColumn(name: "Product", type: .text),
+      OutputColumn(name: "column 3", type: .integer),
+    ])
+  }
+
+  @Test func `the grand-total set is present when written and absent when not`()
+      throws {
+    // With `()` the grand-total row (both NULL, SUM 45) is emitted; without it
+    // only the per-Region rows are, so the two queries differ by exactly that
+    // one row.
+    let cat = try sales()
+    try cat.expect("""
+        SELECT Region, SUM(Qty)
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region), ())
+        """, yields: [["East", 35], ["West", 10], [nil, 45]])
+    try cat.expect("""
+        SELECT Region, SUM(Qty)
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region))
+        """, yields: [["East", 35], ["West", 10]])
+  }
+
+  @Test func `a set member may be a general grouping expression`() throws {
+    // `(A + 1)` groups on the arithmetic key — 1 → 2, 2 → 3 — exactly as a
+    // plain `GROUP BY A + 1` would, and the projected `A + 1` is kept in that
+    // arm and NULL in the grand-total arm.
+    try nums().expect("""
+        SELECT A + 1, SUM(V)
+          FROM N
+         GROUP BY GROUPING SETS ((A + 1), ())
+        """, yields: [[2, 150], [3, 30], [nil, 180]])
+  }
+
+  @Test func `HAVING filters each set's own groups`() throws {
+    // HAVING is copied into every arm, so it filters per set: over `((Region),
+    // ())` with `SUM(Qty) > 20`, the per-Region East (35) survives, West (10)
+    // is dropped, and the grand total (45) survives.
+    try sales().expect("""
+        SELECT Region, SUM(Qty)
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region), ())
+        HAVING SUM(Qty) > 20
+        """, yields: [["East", 35], [nil, 45]])
+  }
+
+  @Test func `ORDER BY orders the combined result on the outer wrapper`()
+      throws {
+    // The query-level ORDER BY rides the `ordered` carrier over the union,
+    // resolved through the setop's output scope. Ordering by Region then
+    // Product (NULLs first here) interleaves the arms into one sorted result.
+    try sales().expect("""
+        SELECT Region, Product, SUM(Qty)
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region, Product), (Region), ())
+         ORDER BY Region, Product
+        """, yields: [
+          [nil, nil, 45],
+          ["East", nil, 35], ["East", "A", 15], ["East", "B", 20],
+          ["West", nil, 10], ["West", "A", 7], ["West", "B", 3],
+        ])
+  }
+
+  @Test func `ORDER BY may name an aggregate over the combined result`() throws {
+    // An ORDER BY naming a PROJECTED aggregate (`SUM(Qty)`) resolves to that
+    // output column of the union — the setop-output scope orders on the
+    // already-computed SUM: ascending 10 (West), 35 (East), 45 (total).
+    try sales().expect("""
+        SELECT Region, SUM(Qty)
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region), ())
+         ORDER BY SUM(Qty)
+        """, yields: [["West", 10], ["East", 35], [nil, 45]])
+  }
+
+  @Test func `OFFSET and FETCH page the ordered combined result`() throws {
+    // The row limit rides the `ordered` carrier too: ordered by SUM ascending
+    // (10, 35, 45), OFFSET 1 skips West (10) and FETCH NEXT 1 takes East (35).
+    try sales().expect("""
+        SELECT Region, SUM(Qty)
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region), ())
+         ORDER BY SUM(Qty)
+         OFFSET 1 ROW FETCH NEXT 1 ROW ONLY
+        """, yields: [["East", 35]])
+  }
+
+  @Test func `a duplicate set is kept, not deduplicated`() throws {
+    // UNION ALL (not UNION) combines the arms, so a set written twice
+    // contributes its rows twice rather than collapsing.
+    try nums().expect("""
+        SELECT A, SUM(V)
+          FROM N
+         GROUP BY GROUPING SETS ((A), (A))
+        """, yields: [[1, 150], [2, 30], [1, 150], [2, 30]])
+  }
+
+  // MARK: - Findings dissolved by compile-time expansion
+
+  @Test func `the empty set yields ONE grand-total row, not one per input`()
+      throws {
+    // Finding 1: the `()` set builds a GENUINE grand-total aggregate — `group`
+    // on `[]` = ONE row over the whole result — rather than an empty `GROUP BY`
+    // the parser-desugar read as no grouping (`SELECT NULL FROM Sales`, one
+    // NULL row PER input row). Here the per-Region arm yields East/West and the
+    // `()` arm yields EXACTLY ONE `[nil]` grand-total row.
+    let cat = try sales()
+    try cat.expect("""
+        SELECT Region
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region), ())
+        """, yields: [["East"], ["West"], [nil]])
+    // run ≡ columns(of:): the derived schema agrees with the run.
+    let columns = try cat.columns(of: parse(query: """
+        SELECT Region
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region), ())
+        """), validate: true)
+    #expect(columns == [OutputColumn(name: "Region", type: .text)])
+  }
+
+  @Test func `HAVING on an absent key sees the super-aggregate NULL`() throws {
+    // Finding 2: `HAVING Region IS NULL` lowers through the SAME grouped `term`
+    // the projection does, so in the `()` arm — where Region is absent from the
+    // set — it is a super-aggregate NULL rather than a rejected non-grouped
+    // column. Only the grand-total row (Region NULL) survives; every per-Region
+    // group (Region NOT NULL) is filtered.
+    let cat = try sales()
+    try cat.expect("""
+        SELECT Region
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region), ())
+        HAVING Region IS NULL
+        """, yields: [[nil]])
+    let columns = try cat.columns(of: parse(query: """
+        SELECT Region
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region), ())
+        HAVING Region IS NULL
+        """), validate: true)
+    #expect(columns == [OutputColumn(name: "Region", type: .text)])
+  }
+
+  @Test func `ORDER BY an UNPROJECTED aggregate materialises a hidden column`()
+      throws {
+    // Finding 3: `ORDER BY MAX(Qty)` names an aggregate the select list does
+    // NOT project, so the setop-output scope cannot recompute it. The
+    // expansion MATERIALISES `MAX(Qty)` as a hidden trailing column in EVERY
+    // arm (equal arity for the UNION ALL), the carrier orders on it, and TRIMS
+    // it from the output — so the result has exactly the two projected columns.
+    // Per-Region MAX(Qty): East 20, West 7; the `()` grand-total MAX is 20.
+    // Ascending MAX orders West (7), then East (20) and the total (20) — the
+    // two 20s in arm order (per-Region East before the grand total).
+    let cat = try sales()
+    try cat.expect("""
+        SELECT Region, SUM(Qty)
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region), ())
+         ORDER BY MAX(Qty)
+        """, yields: [["West", 10], ["East", 35], [nil, 45]])
+    // The hidden MAX column is trimmed: exactly two output columns.
+    let columns = try cat.columns(of: parse(query: """
+        SELECT Region, SUM(Qty)
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region), ())
+         ORDER BY MAX(Qty)
+        """), validate: true)
+    #expect(columns == [
+      OutputColumn(name: "Region", type: .text),
+      OutputColumn(name: "column 2", type: .integer),
+    ])
+  }
+
+  @Test func `a qualified key NULLs its unqualified projection in the () arm`()
+      throws {
+    // Finding 4: `GROUPING SETS ((n.A), ())` groups on the QUALIFIED `n.A`, but
+    // the select list projects the UNQUALIFIED `A`. The absent-key NULL is
+    // matched by RESOLVED identity (the lowered term treats `n.A` ≡ `A`), so
+    // the `()` arm NULLs `A` rather than rejecting a non-grouped column — the
+    // parser's old qualifier-PRESENCE matcher failed this. Per-A rows then the
+    // grand total.
+    let cat = try nums()
+    try cat.expect("""
+        SELECT A
+          FROM N AS n
+         GROUP BY GROUPING SETS ((n.A), ())
+        """, yields: [[1], [2], [nil]])
+    let columns = try cat.columns(of: parse(query: """
+        SELECT A
+          FROM N AS n
+         GROUP BY GROUPING SETS ((n.A), ())
+        """), validate: true)
+    #expect(columns == [OutputColumn(name: "A", type: .integer)])
+  }
+
+  @Test func `ORDER BY a projected key over a key-only projection`() throws {
+    // A key-only projection (no aggregate) `SELECT Region` parses as a bare
+    // `columns` list; the `ordered` carrier resolves the ORDER BY over the
+    // union's output columns. An ORDER BY naming the ALREADY-projected key
+    // orders on that output — it is NOT materialised as a hidden column and the
+    // identity projection keeps the one real column. NULLs sort first
+    // ascending, so the `()` arm's grand-total NULL leads, then East/West.
+    let cat = try sales()
+    try cat.expect("""
+        SELECT Region
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region), ())
+         ORDER BY Region
+        """, yields: [[nil], ["East"], ["West"]])
+    // run ≡ columns(of:): exactly the one real output column, hidden trimmed.
+    let columns = try cat.columns(of: parse(query: """
+        SELECT Region
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region), ())
+         ORDER BY Region
+        """), validate: true)
+    #expect(columns == [OutputColumn(name: "Region", type: .text)])
+  }
+
+  @Test func `positional ORDER BY resolves over the wrapper`() throws {
+    // A positional `ORDER BY 1` names the first output column, resolved by the
+    // setop-output scope's ordinary ordinal ORDER BY over the union's outputs —
+    // not faulted as an input column `1`. It matches `ORDER BY Region` above.
+    try sales().expect("""
+        SELECT Region
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region), ())
+         ORDER BY 1
+        """, yields: [[nil], ["East"], ["West"]])
+  }
+
+  @Test func `ORDER BY a projected key descending over a key-only projection`()
+      throws {
+    // The DESC variant: NULLs sort last descending, so West/East lead and the
+    // grand-total NULL trails — the carrier still keeps the one real key.
+    try sales().expect("""
+        SELECT Region
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region), ())
+         ORDER BY Region DESC
+        """, yields: [["West"], ["East"], [nil]])
+  }
+
+  @Test func `ORDER BY a grouping key with a co-projected aggregate`() throws {
+    // A grouping-key ORDER BY with an aggregate co-projected: the carrier keeps
+    // both output columns and orders on the projected key. NULLs first
+    // ascending — the grand total (45) leads, then East (35), West (10).
+    try sales().expect("""
+        SELECT Region, SUM(Qty)
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region), ())
+         ORDER BY Region
+        """, yields: [[nil, 45], ["East", 35], ["West", 10]])
+  }
+
+  // MARK: - ORDER BY an unprojected grouping column (materialised hidden)
+
+  @Test func `ORDER BY an unprojected grouping column matches the plain form`()
+      throws {
+    // `Region` is a GROUP BY key but is NOT projected (only `SUM(Qty)` is), so
+    // the setop-output scope cannot bind it — yet the plain grouped path takes
+    // `ORDER BY Region` (a grouped column is orderable). The GROUPING SETS form
+    // must AGREE: `expand` materialises the unprojected grouped column as a
+    // hidden trailing column in every arm (the aggregate case's machinery), the
+    // carrier orders on it, and trims it — so the result is exactly `SUM(Qty)`,
+    // ordered by Region. Ascending Region: East 35, West 10.
+    let cat = try sales()
+    try cat.expect("""
+        SELECT SUM(Qty) FROM Sales
+         GROUP BY GROUPING SETS ((Region)) ORDER BY Region
+        """, equals: """
+        SELECT SUM(Qty) FROM Sales GROUP BY Region ORDER BY Region
+        """)
+    try cat.expect("""
+        SELECT SUM(Qty) FROM Sales
+         GROUP BY GROUPING SETS ((Region)) ORDER BY Region
+        """, yields: [[35], [10]])
+    // The hidden Region column is trimmed: exactly the one aggregate output.
+    let columns = try cat.columns(of: parse(query: """
+        SELECT SUM(Qty) FROM Sales
+         GROUP BY GROUPING SETS ((Region)) ORDER BY Region
+        """), validate: true)
+    #expect(columns == [OutputColumn(name: "column 1", type: .integer)])
+  }
+
+  @Test func `ORDER BY an unprojected key sorts the grand-total NULL per arm`()
+      throws {
+    // With a grand-total set `((Region), ())` the unprojected `Region` sort key
+    // carries the arm's own value: the per-Region arm carries East/West, the
+    // `()` arm NULLs Region (the super-aggregate NULL). Ascending Region sorts
+    // the NULL first, matching the plain grouped form's absent-key ordering (a
+    // plain grouped query cannot express the grand-total arm, so the direct
+    // oracle is the NULL placement itself). SUM: grand total 45, East 35, West
+    // 10.
+    try sales().expect("""
+        SELECT SUM(Qty) FROM Sales
+         GROUP BY GROUPING SETS ((Region), ()) ORDER BY Region
+        """, yields: [[45], [35], [10]])
+  }
+
+  @Test func `ORDER BY a non-grouped column faults like the plain form`()
+      throws {
+    // `Product` is neither projected nor a GROUP BY key of the `((Region))`
+    // arm. The plain grouped path REJECTS `ORDER BY Product` (a non-grouped,
+    // non-aggregated column). The GROUPING SETS form must fault IDENTICALLY:
+    // `expand` materialises the column into each arm's projection, and the
+    // arm's grouped resolver rejects it with the SAME grouping fault, never the
+    // old carrier's `no such column` over the setop output.
+    let cat = try sales()
+    let fault = SQLError.grouping("Product")
+    cat.expect("""
+        SELECT SUM(Qty) FROM Sales
+         GROUP BY GROUPING SETS ((Region)) ORDER BY Product
+        """, fails: fault)
+    cat.expect("""
+        SELECT SUM(Qty) FROM Sales GROUP BY Region ORDER BY Product
+        """, fails: fault)
+  }
+
+  @Test func `ORDER BY a PROJECTED grouping column is not materialised hidden`()
+      throws {
+    // The regression guard for the fix above: when the grouping column IS
+    // projected (`SELECT Region, SUM(Qty)`), `ORDER BY Region` must resolve to
+    // that EXISTING output — NOT materialise a spurious hidden column — so the
+    // schema stays the two real outputs. Ascending Region: East 35, West 10.
+    let cat = try sales()
+    try cat.expect("""
+        SELECT Region, SUM(Qty) FROM Sales
+         GROUP BY GROUPING SETS ((Region)) ORDER BY Region
+        """, yields: [["East", 35], ["West", 10]])
+    let columns = try cat.columns(of: parse(query: """
+        SELECT Region, SUM(Qty) FROM Sales
+         GROUP BY GROUPING SETS ((Region)) ORDER BY Region
+        """), validate: true)
+    #expect(columns == [
+      OutputColumn(name: "Region", type: .text),
+      OutputColumn(name: "column 2", type: .integer),
+    ])
+  }
+
+  // MARK: - SELECT * rejection (wrapped and unwrapped)
+
+  @Test func `a grouped SELECT * is rejected the same as a plain GROUP BY`()
+      throws {
+    // A grouped `SELECT *` is ill-formed (a grouped projection must be
+    // explicit). The GROUPING SETS form must reject it with the IDENTICAL fault
+    // the plain grouped query raises — the arm resolver's grouped `.all`
+    // rejection — whether or not a query-level ORDER BY carries it. `expand`
+    // keeps the `.all` verbatim in every arm and returns the bare union (never
+    // the `ordered` carrier) for a `SELECT *`, so the arm resolver throws.
+    let cat = try sales()
+    let star = SQLError.state("0A000",
+                              "SELECT * is not allowed with GROUP BY or " +
+                              "aggregates")
+    // The plain grouped `SELECT *` — the baseline fault.
+    cat.expect("SELECT * FROM Sales GROUP BY Region", fails: star)
+    // The BARE grouping-sets form (no ORDER BY / DISTINCT / limit).
+    cat.expect("""
+        SELECT * FROM Sales GROUP BY GROUPING SETS ((Region))
+        """, fails: star)
+    // The CARRIED form (a query-level ORDER BY) faults IDENTICALLY.
+    cat.expect("""
+        SELECT * FROM Sales GROUP BY GROUPING SETS ((Region)) ORDER BY Region
+        """, fails: star)
+    // run ≡ columns(of:): the schema derive faults the same, not a schema.
+    #expect(throws: star) {
+      _ = try cat.columns(of: parse(query: """
+          SELECT * FROM Sales GROUP BY GROUPING SETS ((Region)) ORDER BY Region
+          """), validate: true)
+    }
+  }
+
+  // MARK: - validate/CTE see the expanded arms
+
+  @Test func `a faulting grand-total arm faults validate and a CTE body`()
+      throws {
+    // The `()` grand-total arm emits ONE row EVEN under `WHERE 1 = 0` (the
+    // empty group still produces the grand total), so `1 / 0` IS evaluated at
+    // run and faults — the un-expanded `.sets` (where `WHERE 1 = 0` spares the
+    // projection) hid this from validation. `Query.expanded` now runs at the
+    // WITH schema path and the CTE validation entries too, so the validate path
+    // and a CTE body fault IDENTICALLY to the run.
+    let cat = try sales()
+    let sql = """
+        SELECT 1 / 0 AS x
+          FROM Sales
+         WHERE 1 = 0
+         GROUP BY GROUPING SETS ((Region), ())
+        """
+    // The run faults.
+    cat.expect(sql, fails: .divide)
+    // `columns(of:…, validate: true)` faults — before it returned a schema.
+    #expect(throws: SQLError.divide) {
+      _ = try cat.columns(of: parse(query: sql), validate: true)
+    }
+    // The same query as a CTE body faults under the schema derive too.
+    let cte = "WITH t AS (\(sql)) SELECT * FROM t"
+    #expect(throws: SQLError.divide) {
+      _ = try cat.run(Statement(parsing: cte))
+    }
+    #expect(throws: SQLError.divide) {
+      _ = try cat.columns(of: Statement(parsing: cte), validate: true)
+    }
+    // The same query as the TRAILING WITH query faults under the schema derive.
+    let trailing = "WITH u AS (SELECT 1 AS x) \(sql)"
+    #expect(throws: SQLError.divide) {
+      _ = try cat.run(Statement(parsing: trailing))
+    }
+    #expect(throws: SQLError.divide) {
+      _ = try cat.columns(of: Statement(parsing: trailing), validate: true)
+    }
+  }
+
+  @Test func `a faulting grand-total arm faults a VIEW body schema derive`()
+      throws {
+    // The VIEW schema path (`typecheck(view.query, …)`) is the finding #2 gap:
+    // reached with an UNEXPANDED body, its reachability helper sees `GROUPING
+    // SETS ((Region), ())` as non-empty `grouping.expressions`, so a
+    // constant-false `WHERE` makes it short-circuit WITHOUT validating the
+    // projection — yet the expanded `()` grand-total arm STILL emits one group
+    // at run and evaluates `1 / 0`, faulting. Expanding the body BEFORE the
+    // reachability typecheck keeps the VIEW schema derive in step with the run:
+    // `columns(of: SELECT * FROM v)` faults the SAME `.divide` the run does.
+    let cat = try Catalog {
+      Relation("Sales", ["Region": .text, "Qty": .integer]) {
+        Row("East", 10)
+        Row("West", 7)
+      }
+      try View("v", """
+          SELECT 1 / 0 FROM Sales WHERE 1 = 0
+           GROUP BY GROUPING SETS ((Region), ())
+          """, as: ["x"])
+    }
+    // The run over the view faults.
+    #expect(throws: SQLError.divide) {
+      _ = try cat.run(Statement(parsing: "SELECT * FROM v"))
+    }
+    // `columns(of: SELECT * FROM v, validate: true)` faults IDENTICALLY —
+    // before the fix it ACCEPTED the view and returned a schema.
+    #expect(throws: SQLError.divide) {
+      _ = try cat.columns(of: parse(query: "SELECT * FROM v"), validate: true)
+    }
+  }
+
+  @Test func `a genuinely dead non-GS view body still short-circuits`() throws {
+    // The parity guard: expanding the body must NOT over-reject a legitimately
+    // dead non-grouping-sets body. A `SELECT 1 / 0 FROM Sales WHERE 1 = 0` with
+    // NO aggregate forms no group under the false `WHERE`, so its projection is
+    // genuinely unreachable — `columns(of: SELECT * FROM v)` types it WITHOUT
+    // faulting, exactly as the run yields no row.
+    let cat = try Catalog {
+      Relation("Sales", ["Region": .text, "Qty": .integer]) {
+        Row("East", 10)
+      }
+      try View("v", "SELECT 1 / 0 FROM Sales WHERE 1 = 0", as: ["x"])
+    }
+    try cat.expect("SELECT * FROM v", yields: [])
+    let columns = try cat.columns(of: parse(query: "SELECT * FROM v"),
+                                  validate: true)
+    #expect(columns == [OutputColumn(name: "x", type: .integer)])
+  }
+
+  @Test func `a non-faulting grouping-sets CTE body validates and types`()
+      throws {
+    // The parity guard: a NON-faulting grouping-sets CTE body still validates
+    // and its `columns(of:)` types resolve correctly — expansion at the CTE
+    // entry must not over-reject a legal body. The body projects Region and a
+    // SUM over the two-set grouping; as a CTE the trailing `SELECT *` reports
+    // the CTE's declared columns, and the rows match the run.
+    let cat = try sales()
+    let sql = """
+        WITH t (Region, Total) AS (
+          SELECT Region, SUM(Qty)
+            FROM Sales
+           GROUP BY GROUPING SETS ((Region), ())
+        )
+        SELECT * FROM t
+        """
+    // The rows: per-Region East 35 / West 10, then the grand total 45.
+    let rows = try cat.run(Statement(parsing: sql))
+    #expect(rows == [
+      [.text("East"), .integer(35)],
+      [.text("West"), .integer(10)],
+      [.null, .integer(45)],
+    ])
+    // The schema derive validates and reports the CTE's declared columns.
+    let columns = try cat.columns(of: Statement(parsing: sql), validate: true)
+    #expect(columns == [
+      OutputColumn(name: "Region", type: .text),
+      OutputColumn(name: "Total", type: .integer),
+    ])
+  }
+
+  @Test func `a recursive CTE whose anchor is a grouping-sets shape expands`()
+      throws {
+    // The cross case the shared `CTE.canonical = query.expanded.unwound` peel
+    // enables: a RECURSIVE CTE whose anchor is a `GROUP BY GROUPING SETS`
+    // shape. `canonical` EXPANDS the anchor's `.sets` node to its `UNION ALL`
+    // FIRST, so the recursive-shape recogniser peels the resulting inner
+    // `((per-Region ∪ grand-total) ∪ recursive)` union — the SAME AST the
+    // fixpoint iterates — rather than mis-reading the unexpanded `.sets` body.
+    // The recursive arm never fires (`Total < 0` is empty), so the result is
+    // the expanded anchor: per-Region East 35 / West 10 and the grand total 45,
+    // then the trailing `ORDER BY 2` sorts on Total.
+    let cat = try sales()
+    let sql = """
+        WITH RECURSIVE t (Region, Total) AS (
+          SELECT Region, SUM(Qty)
+            FROM Sales
+           GROUP BY GROUPING SETS ((Region), ())
+          UNION ALL
+          SELECT Region, Total + 1 FROM t WHERE Total < 0
+        )
+        SELECT Region, Total FROM t ORDER BY 2
+        """
+    let rows = try cat.run(Statement(parsing: sql))
+    #expect(rows == [
+      [.text("West"), .integer(10)],
+      [.text("East"), .integer(35)],
+      [.null, .integer(45)],
+    ])
+    // run ≡ columns(of:): the schema derive peels the SAME expanded, unwound
+    // canonical shape and types the declared columns without faulting.
+    let columns = try cat.columns(of: Statement(parsing: sql), validate: true)
+    #expect(columns == [
+      OutputColumn(name: "Region", type: .text),
+      OutputColumn(name: "Total", type: .integer),
+    ])
+  }
+
+  // MARK: - Setop-output scope and ORDER BY resolution
+
+  @Test func `ORDER BY a select-list alias orders on that output`() throws {
+    // A query-level `ORDER BY total` names the select-list ALIAS `total` (the
+    // `SUM(Qty)` output), NOT a base column. The setop-output scope resolves it
+    // the SAME way a plain `SELECT … ORDER BY <alias>` does — over the union's
+    // output — rather than materialising a hidden column the grouped lowering
+    // cannot resolve. Ascending SUM: West 10, East 35.
+    let cat = try sales()
+    try cat.expect("""
+        SELECT Region, SUM(Qty) AS total
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region))
+         ORDER BY total
+        """, yields: [["West", 10], ["East", 35]])
+    // run ≡ columns(of:): the alias is the output name, not a hidden column.
+    let columns = try cat.columns(of: parse(query: """
+        SELECT Region, SUM(Qty) AS total
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region))
+         ORDER BY total
+        """), validate: true)
+    #expect(columns == [
+      OutputColumn(name: "Region", type: .text),
+      OutputColumn(name: "total", type: .integer),
+    ])
+  }
+
+  @Test func `a bare-column projection survives the ORDER BY wrapper`() throws {
+    // A key-only `SELECT Region` (a bare `columns` projection) with a
+    // query-level `ORDER BY` rides the `ordered` carrier, whose identity
+    // projection keeps the REAL output column Region — not zero columns — for
+    // every projection kind. Ascending, East before West.
+    let cat = try sales()
+    try cat.expect("""
+        SELECT Region
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region))
+         ORDER BY Region
+        """, yields: [["East"], ["West"]])
+    let columns = try cat.columns(of: parse(query: """
+        SELECT Region
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region))
+         ORDER BY Region
+        """), validate: true)
+    #expect(columns == [OutputColumn(name: "Region", type: .text)])
+  }
+
+  @Test func `duplicate output names keep their positional identity`() throws {
+    // Two outputs aliased the SAME name (`Region AS x, Product AS x`) keep
+    // their POSITIONAL identity through the union, so the 2nd output stays
+    // Product rather than collapsing onto the first `x` (Region). `ORDER BY 1`
+    // sorts on the first output. Region then Product within each Region.
+    let cat = try sales()
+    try cat.expect("""
+        SELECT Region AS x, Product AS x, SUM(Qty)
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region, Product))
+         ORDER BY 1
+        """, yields: [
+          ["East", "A", 15], ["East", "B", 20],
+          ["West", "A", 7], ["West", "B", 3],
+        ])
+    // The duplicate output name survives the carrier (as a plain query's does).
+    let columns = try cat.columns(of: parse(query: """
+        SELECT Region AS x, Product AS x, SUM(Qty)
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region, Product))
+         ORDER BY 1
+        """), validate: true)
+    #expect(columns == [
+      OutputColumn(name: "x", type: .text),
+      OutputColumn(name: "x", type: .text),
+      OutputColumn(name: "column 3", type: .integer),
+    ])
+  }
+
+  @Test func `ORDER BY a duplicate output name faults ambiguous, as plain GROUP BY`()
+      throws {
+    // A bare `ORDER BY x` over TWO outputs aliased `x` (`Region AS x, Product
+    // AS x`) rides the setop-output scope's ORDINARY ORDER BY resolution, which
+    // faults `SQLError.ambiguous` — NOT a silent order by the first `x`. The
+    // plain grouped `… GROUP BY Region, Product ORDER BY x` is the ORACLE: it
+    // faults the same `.ambiguous("x")`, so the two forms agree.
+    let cat = try sales()
+    let ambiguous = SQLError.ambiguous("x")
+    // The GROUPING SETS wrapped form faults ambiguous at run and schema derive.
+    cat.expect("""
+        SELECT Region AS x, Product AS x
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region, Product))
+         ORDER BY x
+        """, fails: ambiguous)
+    #expect(throws: ambiguous) {
+      _ = try cat.columns(of: parse(query: """
+          SELECT Region AS x, Product AS x
+            FROM Sales
+           GROUP BY GROUPING SETS ((Region, Product))
+           ORDER BY x
+          """), validate: true)
+    }
+    // The plain grouped ORACLE faults IDENTICALLY.
+    cat.expect("""
+        SELECT Region AS x, Product AS x
+          FROM Sales
+         GROUP BY Region, Product
+         ORDER BY x
+        """, fails: ambiguous)
+  }
+
+  @Test func `ORDER BY a duplicate BARE projected name faults ambiguous`()
+      throws {
+    // Two BARE (unaliased) projections resolving to the same output name — here
+    // `Region` projected twice — order by that name faults `.ambiguous` the
+    // same as the aliased case. The plain grouped form is the oracle.
+    let cat = try sales()
+    let ambiguous = SQLError.ambiguous("Region")
+    cat.expect("""
+        SELECT Region, Region
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region))
+         ORDER BY Region
+        """, fails: ambiguous)
+    cat.expect("""
+        SELECT Region, Region
+          FROM Sales
+         GROUP BY Region
+         ORDER BY Region
+        """, fails: ambiguous)
+  }
+
+  @Test func `ORDER BY 1 resolves the duplicate-name query by position`()
+      throws {
+    // Positional `ORDER BY 1` is the UNAMBIGUOUS way to order the
+    // duplicate-name query: it names the first output by position, so it
+    // resolves where the bare name faults. Region then Product ascending.
+    try sales().expect("""
+        SELECT Region AS x, Product AS x
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region, Product))
+         ORDER BY 1
+        """, yields: [
+          ["East", "A"], ["East", "B"],
+          ["West", "A"], ["West", "B"],
+        ])
+  }
+
+  @Test func `ORDER BY an unprojected aggregate still materialises after the fix`()
+      throws {
+    // Regression guard for the shared mechanism: an unprojected `ORDER BY
+    // MAX(Qty)` is neither a projected expression NOR an output name, so it is
+    // still MATERIALISED as a hidden synthetic column and ordered on. Ascending
+    // per-Region MAX(Qty): West 7, East 20.
+    try sales().expect("""
+        SELECT Region, SUM(Qty)
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region))
+         ORDER BY MAX(Qty)
+        """, yields: [["West", 10], ["East", 35]])
+  }
+
+  // MARK: - Setop-output scope dissolves the scope-less matcher
+
+  @Test func `ORDER BY a display header column N faults, as over a plain union`()
+      throws {
+    // The result-schema DISPLAY header `column N` (an unnamed output's
+    // positional name) is NOT a bindable output name — the setop-output scope
+    // names an unnamed output non-spellably, so `ORDER BY "column 2"` faults
+    // `.column`, EXACTLY as `SELECT * FROM (union) AS g ORDER BY "column N"`
+    // does over any derived union. Before, the text wrapper exposed the header
+    // as a derived-table column and WRONGLY accepted it.
+    let cat = try sales()
+    let fault = SQLError.column("column 2")
+    cat.expect("""
+        SELECT Region, SUM(Qty)
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region), ())
+         ORDER BY "column 2"
+        """, fails: fault)
+    // The plain-union ORACLE faults the same over its display header.
+    cat.expect("""
+        SELECT * FROM (
+          SELECT Region FROM Sales GROUP BY Region
+        ) AS g ORDER BY "column 1"
+        """, fails: SQLError.column("column 1"))
+  }
+
+  @Test func `ORDER BY a qualified key resolves to its projected output`()
+      throws {
+    // A qualified `ORDER BY n.Region` whose BARE name is a projected output
+    // resolves to that output through the setop-output scope (a set-operation
+    // result carries no source qualifier), the SAME as the plain grouped
+    // `ORDER BY n.Region` lowering `n.Region` to the group-key slot ≡ the
+    // projected `Region`. Before, the scope-less matcher MATERIALISED
+    // `n.Region` as a hidden `*gs0` column, and under DISTINCT that hidden
+    // column faulted `must appear in the SELECT DISTINCT list`. Now an output.
+    // The `()` arm's grand-total NULL leads ascending, then per-Region.
+    let cat = try nums()
+    try cat.expect("""
+        SELECT DISTINCT A
+          FROM N AS n
+         GROUP BY GROUPING SETS ((n.A), ())
+         ORDER BY n.A
+        """, yields: [[nil], [1], [2]])
+    let columns = try cat.columns(of: parse(query: """
+        SELECT DISTINCT A
+          FROM N AS n
+         GROUP BY GROUPING SETS ((n.A), ())
+         ORDER BY n.A
+        """), validate: true)
+    #expect(columns == [OutputColumn(name: "A", type: .integer)])
+  }
+
+  @Test func `ORDER BY a qualified non-grouped name faults like the plain form`()
+      throws {
+    // The other half of the qualified case: a qualified `ORDER BY n.Product`
+    // whose bare name is NEITHER a projected output NOR a grouping key. The
+    // plain grouped ORACLE (`GROUP BY Region ORDER BY n.Product`) faults
+    // `.grouping` — a non-grouped, non-aggregated column — NOT `.column`. The
+    // GROUPING SETS form must AGREE: `expand` materialises the column into each
+    // arm and the arm's grouped resolver rejects it with the SAME `.grouping`
+    // fault. (This assertion previously expected `.column("Product")` from the
+    // old scope-less matcher, which disagreed with the plain form — an existing
+    // assertion that encoded that divergence, now corrected to the oracle.)
+    let cat = try sales()
+    let fault = SQLError.grouping("Product")
+    cat.expect("""
+        SELECT Region
+          FROM Sales AS n
+         GROUP BY GROUPING SETS ((Region), ())
+         ORDER BY n.Product
+        """, fails: fault)
+    cat.expect("""
+        SELECT Region FROM Sales AS n GROUP BY Region ORDER BY n.Product
+        """, fails: fault)
+  }
+
+  @Test func `ORDER BY a qualified unprojected grouping column matches plain`()
+      throws {
+    // A qualified `ORDER BY n.Region` whose bare name is NOT projected but IS a
+    // grouping key: the plain grouped form ACCEPTS it (ordering on the group
+    // key). The GROUPING SETS form agrees — `expand` materialises it hidden,
+    // the carrier resolves the qualified key through the arm's grouped space to
+    // its hidden slot, orders on it, and trims it. Ascending Region: East 35,
+    // West 10.
+    let cat = try sales()
+    try cat.expect("""
+        SELECT SUM(Qty) FROM Sales AS n
+         GROUP BY GROUPING SETS ((Region)) ORDER BY n.Region
+        """, equals: """
+        SELECT SUM(Qty) FROM Sales AS n GROUP BY Region ORDER BY n.Region
+        """)
+    try cat.expect("""
+        SELECT SUM(Qty) FROM Sales AS n
+         GROUP BY GROUPING SETS ((Region)) ORDER BY n.Region
+        """, yields: [[35], [10]])
+  }
+
+  @Test func `a qualified key does not alias-match a different output by name`()
+      throws {
+    // The output named `Region` is `Product AS Region` — its RESOLVED identity
+    // is `Product`, NOT `s.Region`. A qualified `ORDER BY s.Region` references
+    // the grouped INPUT column `s.Region`, a grouping key that is NOT
+    // projected. The is-projected check must use RESOLVED IDENTITY, not the
+    // BARE name: matching `s.Region` to the alias `Region` by bare name SKIPS
+    // hidden materialisation, and the setop-output scope cannot resolve the
+    // qualified `s.Region` — so the carrier faulted (or mis-bound to Product).
+    // The qualified key routes through the arm's grouped resolver, materialises
+    // hidden, and matches the plain grouped form that sorts by the grouped
+    // `s.Region`.
+    let cat = try sales()
+    try cat.expect("""
+        SELECT Product AS Region, SUM(Qty) FROM Sales AS s
+         GROUP BY GROUPING SETS ((s.Region, Product)) ORDER BY s.Region
+        """, equals: """
+        SELECT Product AS Region, SUM(Qty) FROM Sales AS s
+         GROUP BY s.Region, Product ORDER BY s.Region
+        """)
+    // run ≡ columns(of:): the alias `Region` and the aggregate, hidden trimmed.
+    let columns = try cat.columns(of: parse(query: """
+        SELECT Product AS Region, SUM(Qty) FROM Sales AS s
+         GROUP BY GROUPING SETS ((s.Region, Product)) ORDER BY s.Region
+        """), validate: true)
+    #expect(columns == [
+      OutputColumn(name: "Region", type: .text),
+      OutputColumn(name: "column 2", type: .integer),
+    ])
+  }
+
+  @Test func `an unqualified key still binds a select alias per ISO precedence`()
+      throws {
+    // The GUARD for the fix above: the bare-name output match still applies to
+    // an UNQUALIFIED key. `ORDER BY Region` where `Region` is the select alias
+    // for `Product` binds the OUTPUT alias (ISO output-alias precedence: a bare
+    // name → a select-list alias), NOT the input column `Region`, so it sorts
+    // by the projected Product value — the plain grouped form is the oracle.
+    let cat = try sales()
+    try cat.expect("""
+        SELECT Product AS Region, SUM(Qty) FROM Sales AS s
+         GROUP BY GROUPING SETS ((s.Region, Product)) ORDER BY Region
+        """, equals: """
+        SELECT Product AS Region, SUM(Qty) FROM Sales AS s
+         GROUP BY s.Region, Product ORDER BY Region
+        """)
+  }
+
+  @Test func `DISTINCT combines with a query-level ORDER BY over the union`()
+      throws {
+    // `SELECT DISTINCT` with a query-level ORDER BY: the carrier dedups the
+    // union's rows and orders them. Over `((Region), ())` the per-Region rows
+    // (35, 10) and the grand total (45) are already distinct; ORDER BY the
+    // aggregate ascending gives West 10, East 35, total 45.
+    try sales().expect("""
+        SELECT DISTINCT Region, SUM(Qty)
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region), ())
+         ORDER BY SUM(Qty)
+        """, yields: [["West", 10], ["East", 35], [nil, 45]])
+  }
+
+  @Test func `DISTINCT rejects a hidden unprojected-aggregate sort key`()
+      throws {
+    // Under `SELECT DISTINCT`, an ORDER BY expression that is NOT in the select
+    // list is an ERROR (ISO 9075). An unprojected `ORDER BY MAX(Qty)` would be
+    // MATERIALISED as a hidden `*gsN` column, but that slot is NOT a real
+    // output — the DISTINCT check sees only the REAL outputs (`0 ..< real`), so
+    // the key is REJECTED with the same `.distinct` fault the plain grouped
+    // form raises, rather than passing as if the hidden slot were projected and
+    // rebinding the sort OUTSIDE the real projection (which crashed).
+    let cat = try sales()
+    let fault = SQLError.distinct("an expression")
+    cat.expect("""
+        SELECT DISTINCT Region
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region), ())
+         ORDER BY MAX(Qty)
+        """, fails: fault)
+    // The plain grouped ORACLE rejects the same non-selected sort key.
+    cat.expect("""
+        SELECT DISTINCT Region FROM Sales GROUP BY Region ORDER BY MAX(Qty)
+        """, fails: fault)
+    // run ≡ columns(of:): the schema derive faults identically, not a schema.
+    #expect(throws: fault) {
+      _ = try cat.columns(of: parse(query: """
+          SELECT DISTINCT Region
+            FROM Sales
+           GROUP BY GROUPING SETS ((Region), ())
+           ORDER BY MAX(Qty)
+          """), validate: true)
+    }
+  }
+
+  // MARK: - Carrier ORDER BY joins the validation walk
+
+  @Test func `validate faults an unknown routine in a carrier ORDER BY`()
+      throws {
+    // The `ordered` carrier's ORDER BY is a NEW expression surface: it must
+    // join the validation walk, else a reachable faulting sort key
+    // `columns(of:)` ACCEPTS the run raises on. An unknown routine (`ORDER BY
+    // missing(Region)`) faults `.function` at run; validate now faults
+    // IDENTICALLY over the same setop-output scope, closing the run-vs-validate
+    // gap.
+    let cat = try sales()
+    let sql = """
+        SELECT Region, SUM(Qty)
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region), ())
+         ORDER BY missing(Region)
+        """
+    let fault = SQLError.function("missing")
+    cat.expect(sql, fails: fault)
+    #expect(throws: fault) {
+      _ = try cat.columns(of: parse(query: sql), validate: true)
+    }
+  }
+
+  @Test func `validate faults an ill-typed operand in a carrier ORDER BY`()
+      throws {
+    // The operand counterpart: `ORDER BY SUM(Qty) + 'x'` mixes a number and a
+    // string, faulting `.operand` at run; validate now faults IDENTICALLY,
+    // rather than returning a schema for a query the run rejects.
+    let cat = try sales()
+    let sql = """
+        SELECT Region, SUM(Qty)
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region), ())
+         ORDER BY SUM(Qty) + 'x'
+        """
+    let fault = SQLError.operand("operands must be numeric")
+    cat.expect(sql, fails: fault)
+    #expect(throws: fault) {
+      _ = try cat.columns(of: parse(query: sql), validate: true)
+    }
+  }
+
+  @Test func `a valid carrier ORDER BY still validates and resolves`() throws {
+    // The parity guard: a VALID carrier ORDER BY expression (an already-checked
+    // call over an output) still validates and resolves its schema — the walk
+    // must not over-reject. `UPPER(Region)` orders the union by the uppercased
+    // region; the schema derive agrees with the run.
+    let cat = try sales()
+    let sql = """
+        SELECT Region, SUM(Qty)
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region), ())
+         ORDER BY UPPER(Region)
+        """
+    try cat.expect(sql, yields: [[nil, 45], ["East", 35], ["West", 10]])
+    let columns = try cat.columns(of: parse(query: sql), validate: true)
+    #expect(columns == [
+      OutputColumn(name: "Region", type: .text),
+      OutputColumn(name: "column 2", type: .integer),
+    ])
+  }
+
+  @Test func `NULLs sort first ascending over the combined union`() throws {
+    // The `()` grand-total arm NULLs Region; ascending, the NULL sorts FIRST
+    // over the whole union — the setop-output scope orders identically to a
+    // plain derived union. (DESC counterpart is covered above.)
+    try sales().expect("""
+        SELECT Region, SUM(Qty)
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region), ())
+         ORDER BY Region
+        """, yields: [[nil, 45], ["East", 35], ["West", 10]])
+  }
+
+  @Test func `a grouping-sets CTE body with an ORDER BY runs and types`()
+      throws {
+    // A GROUPING SETS body carrying a query-level ORDER BY, used as a CTE: the
+    // run and the schema derive agree (`run ≡ columns(of:)`). The CTE reports
+    // its declared columns; the body orders the union by the aggregate.
+    let cat = try sales()
+    let sql = """
+        WITH t (Region, Total) AS (
+          SELECT Region, SUM(Qty)
+            FROM Sales
+           GROUP BY GROUPING SETS ((Region), ())
+           ORDER BY SUM(Qty)
+        )
+        SELECT * FROM t
+        """
+    let rows = try cat.run(Statement(parsing: sql))
+    #expect(rows == [
+      [.text("West"), .integer(10)],
+      [.text("East"), .integer(35)],
+      [.null, .integer(45)],
+    ])
+    let columns = try cat.columns(of: Statement(parsing: sql), validate: true)
+    #expect(columns == [
+      OutputColumn(name: "Region", type: .text),
+      OutputColumn(name: "Total", type: .integer),
+    ])
+  }
+
+  @Test func `a derived table in a grouping-sets arm runs under ORDER BY`()
+      throws {
+    // The GROUPING SETS expansion is a `UNION ALL` of per-set grouped arms,
+    // each over the SAME `FROM (SELECT …) AS s` — so every arm names the
+    // derived alias `s`. Under the query-level ORDER BY carrier, the union must
+    // run PER ARM (each materialising `s` in its own scope); before, the
+    // single-context carrier execution never bound `s` and faulted
+    // `.relation`. Per-Region sums (East 15, West 7) and the grand total (22),
+    // ordered by SUM.
+    let cat = try Catalog {
+      Relation("Base", ["Region": .text, "Qty": .integer]) {
+        Row("East", 10)
+        Row("East", 5)
+        Row("West", 7)
+      }
+    }
+    try cat.expect("""
+        SELECT SUM(Qty) FROM (SELECT Region, Qty FROM Base) AS s
+         GROUP BY GROUPING SETS ((Region), ())
+         ORDER BY 1
+        """, yields: [[7], [15], [22]])
+  }
+
+  // MARK: - Subqueries in an omitted grouping set
+
+  @Test func `a subquery in an omitted set is collected for the () arm`()
+      throws {
+    // A scalar subquery in a set's key must be pre-registered for EVERY arm,
+    // not only the arms whose set includes it: an `.arm` lowers the SUPERSET
+    // (to NULL an absent key), so the `()` grand-total arm lowers `(SELECT 1)`
+    // and needs it collected. The present arm groups on the constant subquery
+    // value (one group) and projects it (1); the `()` arm NULLs the absent key.
+    let cat = try sales()
+    try cat.expect("""
+        SELECT (SELECT 1)
+          FROM Sales
+         GROUP BY GROUPING SETS (((SELECT 1)), ())
+        """, yields: [[1], [nil]])
+    // run ≡ columns(of:): the schema derive resolves the same, not a fault.
+    let columns = try cat.columns(of: parse(query: """
+        SELECT (SELECT 1)
+          FROM Sales
+         GROUP BY GROUPING SETS (((SELECT 1)), ())
+        """), validate: true)
+    #expect(columns == [OutputColumn(name: "column 1", type: .integer)])
+  }
+
+  // MARK: - Empty set list
+
+  @Test func `an empty GROUPING SETS set list is a syntax fault, not a crash`()
+      throws {
+    // `Grouping.sets` is a public AST case, so a caller may build an EMPTY set
+    // list (the parser never emits it). The expansion must reject it with a
+    // typed `SQLError` before the `UNION ALL` reduce seed (`arms[0]`) traps the
+    // process on the empty arm list.
+    let cat = try sales()
+    let empty = Select(projection: .expressions([
+      Projected(expression: .literal(.integer(1)))
+    ]), from: Relation(name: "Sales"), grouping: .sets([]))
+    let fault = SQLError.state("42601",
+                               "GROUPING SETS requires at least one set")
+    let raised: SQLError?
+    do {
+      _ = try cat.run(.select(empty))
+      raised = nil
+    } catch let error {
+      raised = error
+    }
+    #expect(raised == fault)
+    // `columns(of:)` faults the same, not a crash or a schema.
+    let columns: SQLError?
+    do {
+      _ = try cat.columns(of: .select(empty), validate: true)
+      columns = nil
+    } catch let error {
+      columns = error
+    }
+    #expect(columns == fault)
+  }
+}
+
+// MARK: - Context tokens
+
+/// A `T` relation whose columns are literally named `grouping` and `sets` — the
+/// two context identifiers — to prove they stay usable as column names.
+private func context() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["grouping": .text, "sets": .integer]) {
+      Row("x", 1)
+      Row("y", 2)
+    }
+  }
+}
+
+// MARK: - Carrier resolves by structure, not text/AST
+
+struct GroupingSetsCarrierStructureTests {
+  @Test func `a DISTINCT qualified-aggregate sort key matches the projected one`()
+      throws {
+    // `ORDER BY SUM(s.Qty)` is the SAME projected value as `SUM(Qty)` — it
+    // differs only by qualification — so the carrier matches it to that
+    // projected output by RESOLVED identity (through the arm's grouped space),
+    // never a spurious hidden sort column that DISTINCT would then reject. It
+    // must run IDENTICALLY to the plain grouped form, the oracle.
+    try sales().expect("""
+        SELECT DISTINCT SUM(Qty) FROM Sales AS s
+         GROUP BY GROUPING SETS ((Region)) ORDER BY SUM(s.Qty)
+        """, equals: """
+        SELECT DISTINCT SUM(Qty) FROM Sales AS s
+         GROUP BY Region ORDER BY SUM(s.Qty)
+        """)
+  }
+
+  @Test func `a genuinely unprojected aggregate under DISTINCT faults as plain`()
+      throws {
+    // A sort key the SELECT DISTINCT list does not project is rejected — the
+    // same `.distinct` fault the plain grouped form raises, not accepted as if
+    // its hidden materialised slot were a select-list value.
+    try sales().expect("""
+        SELECT DISTINCT Region FROM Sales AS s
+         GROUP BY GROUPING SETS ((Region)) ORDER BY MAX(Qty)
+        """, fails: .distinct("an expression"))
+    try sales().expect("""
+        SELECT DISTINCT Region FROM Sales AS s
+         GROUP BY Region ORDER BY MAX(Qty)
+        """, fails: .distinct("an expression"))
+  }
+
+  @Test func `a bare-vs-qualified column sort key still matches (regression)`()
+      throws {
+    // The pre-existing qualifier-equivalent COLUMN case keeps working under the
+    // resolved-identity match: `ORDER BY s.Region` ≡ the projected `Region`.
+    try sales().expect("""
+        SELECT Region, SUM(Qty) FROM Sales AS s
+         GROUP BY GROUPING SETS ((Region)) ORDER BY s.Region
+        """, equals: """
+        SELECT Region, SUM(Qty) FROM Sales AS s
+         GROUP BY Region ORDER BY s.Region
+        """)
+  }
+
+  @Test func `a delimited *gs0 alias is a real output, not a generated column`()
+      throws {
+    // The generated hidden-column count is STRUCTURAL (carried out of
+    // `expand`), so a user's DELIMITED alias `AS "*gs0"` — which by NAME looks
+    // like a generated `*gsN` sort column — is NOT trimmed: it is the real,
+    // only output (a PLAIN union, no grouping, so no column is ever generated).
+    try pair().expect("""
+        SELECT a AS "*gs0" FROM L UNION ALL SELECT b FROM R ORDER BY 1
+        """, yields: [[1], [2], [3], [4], [5]])
+    let cat = try pair()
+    let columns = try cat.columns(of: parse(query: """
+        SELECT a AS "*gs0" FROM L UNION ALL SELECT b FROM R ORDER BY 1
+        """), validate: true)
+    #expect(columns == [OutputColumn(name: "*gs0", type: .integer)])
+  }
+
+  @Test func `a real output aliased *gs0 does not capture the hidden sort key`()
+      throws {
+    // The unprojected `MAX(Qty)` sort key materialises a HIDDEN trailing column
+    // that `expand` aliases `*gs0`. A REAL output ALSO aliased `AS "*gs0"` by
+    // NAME collides with that synthetic alias, so binding the sort key by its
+    // `*gsN` NAME would let the setop-output scope's output-alias precedence
+    // CAPTURE the hidden key onto the real `*gs0` output — ordering by Region,
+    // not `MAX(Qty)`. The carrier binds the hidden slot STRUCTURALLY, by
+    // position, so the user's colliding alias cannot capture it: the query
+    // orders by `MAX(Qty)` exactly as the plain grouped form does. Ascending
+    // per-Region MAX(Qty): West 7, East 20 → West row then East row.
+    try sales().expect("""
+        SELECT Region AS "*gs0", SUM(Qty) FROM Sales
+         GROUP BY GROUPING SETS ((Region)) ORDER BY MAX(Qty)
+        """, equals: """
+        SELECT Region AS "*gs0", SUM(Qty) FROM Sales
+         GROUP BY Region ORDER BY MAX(Qty)
+        """)
+    try sales().expect("""
+        SELECT Region AS "*gs0", SUM(Qty) FROM Sales
+         GROUP BY GROUPING SETS ((Region)) ORDER BY MAX(Qty)
+        """, yields: [["West", 10], ["East", 35]])
+    // The `*gs0` output is the REAL Region column (hidden `MAX(Qty)` trimmed),
+    // not swallowed as a generated column — run ≡ columns(of:).
+    let cat = try sales()
+    let columns = try cat.columns(of: parse(query: """
+        SELECT Region AS "*gs0", SUM(Qty) FROM Sales
+         GROUP BY GROUPING SETS ((Region)) ORDER BY MAX(Qty)
+        """), validate: true)
+    #expect(columns == [OutputColumn(name: "*gs0", type: .text),
+                        OutputColumn(name: "column 2", type: .integer)])
+  }
+
+  @Test func `a real GROUPING SETS unprojected sort key trims its generated column`()
+      throws {
+    // A genuinely-unprojected aggregate sort key IS materialised as a generated
+    // hidden column so it survives the UNION ALL; the carrier trims it so the
+    // result is exactly the projected columns, ordered by the hidden slot. The
+    // schema (run ≡ columns) drops the generated column too.
+    let cat = try sales()
+    try cat.expect("""
+        SELECT Region FROM Sales AS s
+         GROUP BY GROUPING SETS ((Region)) ORDER BY MAX(Qty)
+        """, yields: [["West"], ["East"]])
+    let columns = try cat.columns(of: parse(query: """
+        SELECT Region FROM Sales AS s
+         GROUP BY GROUPING SETS ((Region)) ORDER BY MAX(Qty)
+        """), validate: true)
+    #expect(columns == [OutputColumn(name: "Region", type: .text)])
+  }
+
+  @Test func `an out-of-range ordinal after a materialised key faults like plain`()
+      throws {
+    // An unprojected `MAX(Qty)` sort key materialises a hidden `*gsN` column,
+    // so the inner union's width becomes 2 — but the ONLY real output is
+    // `Region`. A trailing ORDINAL must bind the REAL output arity
+    // (`0 ..< real`), NOT the grown width, so `ORDER BY MAX(Qty), 2` faults
+    // `.column("2")` exactly as the plain grouped `GROUP BY Region ORDER BY
+    // MAX(Qty), 2` does — never binding the hidden `MAX(Qty)` slot as if it
+    // were a select-list output.
+    try sales().expect("""
+        SELECT Region FROM Sales GROUP BY GROUPING SETS ((Region))
+         ORDER BY MAX(Qty), 2
+        """, fails: .column("2"))
+    try sales().expect("""
+        SELECT Region FROM Sales GROUP BY Region ORDER BY MAX(Qty), 2
+        """, fails: .column("2"))
+  }
+
+  @Test func `an out-of-range ordinal before a materialised key faults like plain`()
+      throws {
+    // The bound is ORDER-INDEPENDENT: whether the materialising `MAX(Qty)` key
+    // comes before or after the ordinal, `ORDER BY 2, MAX(Qty)` still faults
+    // `.column("2")` over the single real output, matching the plain form.
+    try sales().expect("""
+        SELECT Region FROM Sales GROUP BY GROUPING SETS ((Region))
+         ORDER BY 2, MAX(Qty)
+        """, fails: .column("2"))
+    try sales().expect("""
+        SELECT Region FROM Sales GROUP BY Region ORDER BY 2, MAX(Qty)
+        """, fails: .column("2"))
+  }
+
+  @Test func `an in-range ordinal after a materialised key binds the real output`()
+      throws {
+    // An IN-RANGE ordinal still binds the real output even when an earlier key
+    // materialised a hidden column: `ORDER BY MAX(Qty), 1` orders by `Region`
+    // (ordinal 1, the sole real output), agreeing with the plain grouped form.
+    try sales().expect("""
+        SELECT Region FROM Sales GROUP BY GROUPING SETS ((Region))
+         ORDER BY MAX(Qty), 1
+        """, equals: """
+        SELECT Region FROM Sales GROUP BY Region ORDER BY MAX(Qty), 1
+        """)
+  }
+
+  @Test func `a pure ordinal ORDER BY over a GROUPING SETS query still binds`()
+      throws {
+    // A GROUPING SETS query with NO materialised hidden column (no unprojected
+    // sort key) still resolves a positional `ORDER BY 1` over its real output —
+    // the ordinal bound is the real arity, unchanged when nothing is
+    // materialised. The grand-total NULL and the two per-Region rows, by Region
+    // ascending (NULL sorts first).
+    try sales().expect("""
+        SELECT Region FROM Sales GROUP BY GROUPING SETS ((Region), ())
+         ORDER BY 1
+        """, yields: [[nil], ["East"], ["West"]])
+  }
+
+  @Test func `a real ordinal past the first output binds a multi-output GS query`()
+      throws {
+    // When ordinal 2 IS a real output, the bound admits it: a two-output
+    // GROUPING SETS query with an unprojected-aggregate sort key materialises a
+    // hidden THIRD column, but `ORDER BY SUM(Qty), 2` binds the real second
+    // output (`SUM(Qty)`), matching the plain grouped form.
+    try sales().expect("""
+        SELECT Region, SUM(Qty) FROM Sales GROUP BY GROUPING SETS ((Region))
+         ORDER BY MAX(Qty), 2
+        """, equals: """
+        SELECT Region, SUM(Qty) FROM Sales GROUP BY Region ORDER BY MAX(Qty), 2
+        """)
+  }
+
+  @Test func `an explicit "column 1" alias is bindable, not a synthesized header`()
+      throws {
+    // A synthesized display header `column N` is non-bindable by name, but the
+    // carrier distinguishes it from an EXPLICIT delimited `AS "column 1"` by
+    // the STRUCTURAL synthesized flag, not by comparing the name text — so
+    // ordering by the explicit alias works.
+    try pair().expect("""
+        SELECT a AS "column 1" FROM L UNION ALL SELECT b FROM R
+         ORDER BY "column 1"
+        """, yields: [[1], [2], [3], [4], [5]])
+  }
+
+  @Test func `a genuinely unnamed set-op output stays ordinal-only`() throws {
+    // A computed output with no alias is a synthesized `column N` header — not
+    // bindable by that name — so it is reachable only by ordinal, exactly as a
+    // plain derived union.
+    try pair().expect("""
+        SELECT a + 0 FROM L UNION ALL SELECT b FROM R ORDER BY 1
+        """, yields: [[1], [2], [3], [4], [5]])
+    let cat = try pair()
+    cat.expect("""
+        SELECT a + 0 FROM L UNION ALL SELECT b FROM R ORDER BY "column 1"
+        """, fails: .column("column 1"))
+  }
+}
+
+// `pair` mirrors the OrderedSetOperation fixture — two single-column relations
+// `L`(a) and `R`(b) — for the carrier's plain-union structural cases above.
+private func pair() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("L", ["a": .integer]) { Row(3); Row(1); Row(2) }
+    Relation("R", ["b": .integer]) { Row(5); Row(4) }
+  }
+}
+
+struct GroupingSetsContextTokenTests {
+  @Test func `grouping and sets remain usable as column names`() throws {
+    // `GROUPING`/`SETS` are context identifiers, not lexer keywords, so a
+    // column named either — projected, and a `GROUP BY` key — parses as a plain
+    // reference. `grouping` here is NOT followed by `SETS`, so it stays a key.
+    try context().expect("""
+        SELECT grouping, sets FROM T GROUP BY grouping, sets
+        """, yields: [["x", 1], ["y", 2]])
+  }
+
+  @Test func `grouping is a plain group key when not followed by sets`() throws {
+    // A lone `GROUP BY grouping` (the context identifier not opening the
+    // construct) groups on the column, unchanged from before the construct
+    // existed.
+    try context().expect("SELECT grouping FROM T GROUP BY grouping",
+                         yields: [["x"], ["y"]])
+  }
+
+  @Test func `a single grouping set with a carrier runs over a derived table`()
+      throws {
+    // A ONE-set `GROUPING SETS ((Region))` is an ordinary `GROUP BY Region`:
+    // there is no `UNION` for a sort key to survive, so a query-level `ORDER
+    // BY` must NOT wrap the lone grouped arm in an `ordered` carrier. Doing so
+    // hid the FROM-clause derived table `s` from the query-level collection
+    // and faulted `.relation('s')` at execution. It now stays a plain grouped
+    // select, so `s` materialises and the grouped result orders.
+    let cat = try Catalog {
+      Relation("Sales", ["Region": .text]) {
+        Row("W"); Row("E"); Row("E")
+      }
+    }
+    try cat.expect("""
+        SELECT Region FROM (SELECT Region FROM Sales) AS s
+          GROUP BY GROUPING SETS ((Region)) ORDER BY Region
+        """, yields: [["E"], ["W"]])
+  }
+}

--- a/Tests/SQLTests/Queries/OrderedSetOperationTests.swift
+++ b/Tests/SQLTests/Queries/OrderedSetOperationTests.swift
@@ -470,4 +470,18 @@ struct CarrierOrderBySubqueryTests {
       try resolve()
     }
   }
+
+  @Test func `a qualified sort key over a set operation faults`() throws {
+    // The set-operation output exposes NO range, so a QUALIFIED sort key
+    // `R.a` fails resolution — the carrier lets it through to `scope.order`
+    // rather than silently dropping the qualifier to bind the bare output
+    // `a`, which hid an invalid `R.a` / `NoSuch.a` range reference. The bare
+    // `ORDER BY a` binds the output as before.
+    try pair().expect(
+        "SELECT a FROM L UNION ALL SELECT b FROM R ORDER BY R.a",
+        fails: SQLError.column("a"))
+    try pair().expect(
+        "SELECT a FROM L UNION ALL SELECT b FROM R ORDER BY a",
+        yields: [[1], [2], [3], [4], [5]])
+  }
 }

--- a/Tests/SQLTests/Queries/TableTests.swift
+++ b/Tests/SQLTests/Queries/TableTests.swift
@@ -24,7 +24,7 @@ struct TableTests {
     #expect(select.projection == .all)
     #expect(select.table == "People")
     #expect(select.predicate == nil)
-    #expect(select.grouping.isEmpty)
+    #expect(select.grouping == .keys([]))
     #expect(select.having == nil)
     #expect(select.order == nil)
     #expect(select.limit == nil)

--- a/Tests/SQLTests/Schema/DefinitionSchemaTests.swift
+++ b/Tests/SQLTests/Schema/DefinitionSchemaTests.swift
@@ -63,4 +63,25 @@ import SQLTestSupport
     #expect(names.contains([.text("A")]))
     #expect(names.contains([.text("B")]))
   }
+
+  @Test func `definition_schema.columns skips a faulting grouping-sets view`()
+      throws {
+    // The metadata builder EXPANDS a `GROUPING SETS` view body before
+    // type-checking, as the schema path does. Unexpanded, the constant-false
+    // `WHERE` reads as skipping the `1 / 0` projection; expanded, the `()` arm
+    // forms one group (a grand total) and evaluates it, faulting. The store
+    // must NOT advertise a view that selecting from would fault.
+    let bad = try parse(query: """
+        SELECT 1 / 0 AS x FROM Sales
+         WHERE 1 = 0 GROUP BY GROUPING SETS ((Region), ())
+        """)
+    let catalog = FixtureCatalog(
+        ["Sales": FixtureRelation([FixtureField(name: "Region", type: .text)],
+                                  [])],
+        views: ["v": View(query: bad, columns: ["x"])])
+    try catalog.empty("""
+        SELECT column_name FROM definition_schema.columns
+         WHERE table_name = 'v'
+        """)
+  }
 }


### PR DESCRIPTION
Implement ISO `GROUP BY GROUPING SETS (s1, …, sn)` entirely in the parser, desugaring to a `UNION ALL` of one aggregate arm per set — the same strategy `VALUES` uses, so no new AST node, executor path, or type rule is added.

Each arm is the original SELECT grouped on one set's keys, with the SELECT list rewritten per arm: a projected grouping-set column ABSENT from this arm's set becomes a super-aggregate NULL — `Expression.case([], else: nil)`, a branchless CASE whose value is NULL — aliased to the same output name, while a grouping column present in the set and every aggregate stay verbatim. This keeps every arm's projection arity identical (the UNION ALL requirement) and yields the correct super-aggregate NULLs; the constant-NULL projection is marked UNCONSTRAINED by the resolver, so the set-operation merge defers its column type to the sibling arm that does group on it (the same constant-NULL skip a COALESCE takes) — the NULL-padded columns type through existing set-op unification, not a new path.

HAVING is copied into every arm (ISO: it filters each set's own groups). The arms combine with UNION ALL, not UNION, so the grand-total `()` row is never deduplicated against a genuine all-NULL group and duplicate sets each yield a row. The query-level ORDER BY / OFFSET/FETCH / DISTINCT ride an outer wrapper `SELECT * FROM (<union all>) AS "*g"`, since a setop node carries no order/limit slot; an ORDER BY key re-expressing a projected value (an aggregate or a grouping expression the non-grouped wrapper cannot re-evaluate) is rewritten to the ordinal of its output column.

`GROUPING`/`SETS` are context identifiers, not lexer keywords (mirroring CAST/COALESCE), so a column named `grouping` or `sets` stays usable; a second token of lookahead (`pending`/`secondary`) disambiguates the `GROUPING SETS` prefix before either token is consumed.

ROLLUP, CUBE, and the GROUPING() function are deferred to later stages.