### PR TITLE
SQLEngine: order, deduplicate, and page set operations

### DIFF
--- a/Sources/SQLEngine/AST.swift
+++ b/Sources/SQLEngine/AST.swift
@@ -168,15 +168,74 @@ public indirect enum Query: Hashable, Sendable {
   /// same-precedence chain reads left to right.
   case setop(SetOperation, Query, Query, all: Bool)
 
+  /// A query-level `ORDER BY` / `SELECT DISTINCT` / `OFFSET`·`FETCH` carried
+  /// OVER an inner query (always a `setop` — a `select` carries its own on the
+  /// node). A `setop` node has no order/distinct/limit slot, so an ordered,
+  /// deduplicated, or paged set operation rides this outer carrier: the row
+  /// operators (`DISTINCT`, `ORDER BY`, `OFFSET`/`FETCH`) apply to the union's
+  /// combined result, resolved through the setop's OUTPUT scope, and do NOT
+  /// project — the result columns stay the inner setop's arm-0-named, unified
+  /// ones. It is TRANSPARENT to `columns(unifying:)`, which descends to the
+  /// inner setop for the result schema; only `run`/`compile` stack the row
+  /// operators over the compiled setop plan. Produced by the parser for a
+  /// trailing query-level `ORDER BY` / `OFFSET`·`FETCH` after a set-operation
+  /// chain.
+  ///
+  /// `generated` is the number of GENERATED trailing columns the inner union
+  /// carries beyond the real output — hidden sort columns a producer may append
+  /// to each arm so a genuinely-unprojected sort key survives the `UNION ALL`
+  /// at equal arity. The carrier's compile TRIMS them (`real = width −
+  /// generated`), and `columns(unifying:)` drops them from the result schema.
+  /// It is a STRUCTURAL count carried on the node, never recovered by scanning
+  /// output names for a synthetic prefix; the parser's trailing-`ORDER BY`
+  /// carrier generates none (`0`).
+  case ordered(Query, distinct: Bool, order: Order?, limit: Limit?,
+               generated: Int)
+
   /// The first `SELECT` of the query — the leftmost arm, reached by descending
   /// the left arm of each set operation. Its projection NAMES the result
   /// columns (the ISO rule — their TYPES unify across every arm), so a `CREATE
-  /// VIEW` infers a set operation's column names from it.
+  /// VIEW` infers a set operation's column names from it. An `ordered` carrier
+  /// is transparent — its first is its inner query's.
   public var first: Select {
     switch self {
     case let .select(select): select
     case let .setop(_, left, _, _): left.first
+    case let .ordered(inner, _, _, _, _): inner.first
     }
+  }
+
+  /// The query-level row operators an `ordered` carrier applies OVER its inner
+  /// query, peeled off it — the `DISTINCT`/`ORDER BY`/`OFFSET`·`FETCH` and the
+  /// generated hidden-column count. A `select`/`setop` carries no carrier.
+  public struct Carrier: Hashable, Sendable {
+    public let distinct: Bool
+    public let order: Order?
+    public let limit: Limit?
+    public let generated: Int
+  }
+
+  /// This query stripped of its `ordered` carrier — the inner `setop`/`select`
+  /// — paired with the peeled `Carrier`, or `nil` when the query wears none.
+  ///
+  /// A single seam-shared peel: the carrier-transparent `core` reads its inner,
+  /// so every seam descends the carrier here rather than repeating a bespoke
+  /// `.ordered` match, then reapplies the peeled carrier to the result.
+  public var unwound: (inner: Query, carrier: Carrier?) {
+    if case let .ordered(inner, distinct, order, limit, generated) = self {
+      return (inner, Carrier(distinct: distinct, order: order, limit: limit,
+                             generated: generated))
+    }
+    return (self, nil)
+  }
+
+  /// This query's carrier-transparent CORE — its inner `setop`/`select`, an
+  /// `ordered` carrier peeled off. A thin read over `unwound.inner` for the
+  /// `if case .setop = query.core` seams that recognise a set operation whether
+  /// or not it rides a carrier, so a carried union is not silently swallowed by
+  /// a bare `.setop` match.
+  public var core: Query {
+    unwound.inner
   }
 }
 

--- a/Sources/SQLEngine/Definition.swift
+++ b/Sources/SQLEngine/Definition.swift
@@ -657,6 +657,8 @@ extension Query {
     case let .setop(_, left, right, _):
       left.collect(into: &names)
       right.collect(into: &names)
+    case let .ordered(inner, _, _, _, _):
+      inner.collect(into: &names)
     }
   }
 

--- a/Sources/SQLEngine/Engine.swift
+++ b/Sources/SQLEngine/Engine.swift
@@ -26,9 +26,29 @@ private let kRecursionCap = 10_000
 // MARK: - WITH
 
 extension CTE {
-  /// Whether the CTE actually references itself — the test the fixpoint routing
-  /// turns on, distinct from the syntactic `recursive` flag a `WITH RECURSIVE`
-  /// stamps on every member.
+  /// The CTE body's CANONICAL recursive shape — the ONE recogniser every
+  /// recursive-CTE seam peels through, so the run side and the schema side
+  /// inspect the identical AST.
+  ///
+  /// It applies `Query.unwound` (a trailing query-level `ORDER BY`/`OFFSET`·
+  /// `FETCH`/`DISTINCT` carrier peels off the setop), yielding the carrier-free
+  /// inner query paired with the peeled `Carrier`. Routing every seam through
+  /// this one form keeps the run and schema derivations in step.
+  ///
+  /// When `GROUP BY GROUPING SETS` lands, `Query.expanded` (a grouping-sets
+  /// body lowers to its `UNION ALL` arms) is re-inserted ahead of `unwound`, so
+  /// a recursive grouping-sets body canonicalises to the same expanded, unwound
+  /// shape on both sides — a one-token merge follow-up, not needed here.
+  internal var canonical: (inner: Query, carrier: Query.Carrier?) {
+    get throws(SQLError) {
+      query.unwound
+    }
+  }
+
+  /// The CTE body's recursive `UNION` arms — the `(anchor, recursive, all)` of
+  /// its `canonical` inner query when that is a `UNION` whose recursive (right)
+  /// arm names the CTE — else `nil`. The single recogniser the fixpoint router,
+  /// the shape validator, and the schema derive all peel through.
   ///
   /// The parser marks each member of a `WITH RECURSIVE` list recursive whether
   /// or not it names itself, but only a self-referential CTE has a recursive
@@ -42,9 +62,25 @@ extension CTE {
   /// not the CTE. Scanning the anchor too would misroute `WITH RECURSIVE
   /// Parent(Id) AS (SELECT Id FROM Parent UNION ALL SELECT Id FROM Extra)` —
   /// whose anchor merely reads the same-named base — into the fixpoint.
+  internal var recursiveArms:
+      (anchor: Query, recursive: Query, all: Bool)? {
+    get throws(SQLError) {
+      guard case let .setop(.union, anchor, recursive, all) = try canonical
+          .inner, recursive.references(name.lowercased()) else {
+        return nil
+      }
+      return (anchor, recursive, all)
+    }
+  }
+
+  /// Whether the CTE actually references itself through a recursive `UNION` arm
+  /// — the test the fixpoint routing turns on, distinct from the syntactic
+  /// `recursive` flag a `WITH RECURSIVE` stamps on every member. A thin read
+  /// over `recursiveArms`, so it peels the SAME canonical shape.
   internal var recurses: Bool {
-    guard case let .setop(.union, _, arm, _) = query else { return false }
-    return arm.references(name.lowercased())
+    get throws(SQLError) {
+      try recursiveArms != nil
+    }
   }
 }
 
@@ -59,6 +95,8 @@ extension Query {
       select.references(name)
     case let .setop(_, left, right, _):
       left.references(name) || right.references(name)
+    case let .ordered(inner, _, _, _, _):
+      inner.references(name)
     }
   }
 }
@@ -224,7 +262,37 @@ extension Catalog where Self: ~Escapable {
     // plans recorded above into the shared subquery box; a non-decorrelatable
     // apply is left verbatim, so a plan with none is unchanged.
     let decorrelated = try decorrelate(logical, augmented)
-    let plan = try optimise(decorrelated, augmented)
+    // A query-level `ORDER BY`/`DISTINCT`/`OFFSET`·`FETCH` over a set operation
+    // — an `ordered` carrier whose `core` is a `.setop` — optimises PER ARM,
+    // mirroring the view carrier path (`optimise(_:_:_:)` at the `.ordered`
+    // view seam): the generic optimiser would rewrite both arms under the SAME
+    // carrier-level `augmented` context, which does NOT bind an arm-owned
+    // derived alias (arms are SELECT-scoped), so its `seek` rewrite faults
+    // `.relation` on a `FROM (SELECT …) AS d WHERE …` arm before the per-arm
+    // `execute(…carrying:)` below can augment each arm under its own overlay.
+    // Descending the carrier to the setop leaf and augmenting each arm under
+    // its own context resolves the arm-local alias. The `case .setop = core`
+    // guard keeps a plain query (and an ordered carrier over a bare `SELECT`,
+    // not a setop) on the generic optimiser.
+    let plan: Plan
+    if case .ordered = query, case .setop = query.core {
+      plan = try optimise(decorrelated, query.core, augmented)
+    } else {
+      plan = try optimise(decorrelated, augmented)
+    }
+    // A query-level `ORDER BY`/`DISTINCT`/`OFFSET`·`FETCH` over a set operation
+    // — the `ordered` carrier — must run its inner union PER ARM, as the direct
+    // `run(.setop)` above does: each arm augments its OWN arm-local derived
+    // aliases (arms are SELECT-scoped, so the query-level augment misses them)
+    // before its `.scan` reads them, then the arms `combine`. Executing the
+    // compiled carrier plan under the single carrier context instead would
+    // never materialise an arm's derived table, faulting `.relation`. Route the
+    // execute through the carrier descent, which threads the inner union's arm
+    // queries to the setop leaf and runs `arms` there — the SAME per-arm
+    // machinery — leaving the sort/dedup/limit/project stack above unchanged.
+    if case let .ordered(inner, _, _, _, _) = query {
+      return try execute(plan, carrying: inner, augmented).map(\.values)
+    }
     return try execute(plan, augmented).map(\.values)
   }
 
@@ -357,7 +425,7 @@ extension Catalog where Self: ~Escapable {
       if rows {
         // A CTE that names itself iterates a fixpoint; every other one runs its
         // query once. The arity of both routings is already checked above.
-        if cte.recursive && cte.recurses {
+        if cte.recursive, try cte.recurses {
           (materialised, carrier) = try fixpoint(cte, scope)
         } else {
           materialised = try run(cte.query, scope)
@@ -438,13 +506,30 @@ extension Catalog where Self: ~Escapable {
     // Reject a misplaced recursive reference in an EARLIER arm when no
     // same-named base/view can seed it — the shape `with` rejects before
     // routing to the fixpoint.
-    if cte.recursive, case let .setop(.union, anchor, _, _) = cte.query,
+    if cte.recursive,
+        case let .setop(.union, anchor, _, _) = try cte.canonical.inner,
         anchor.references(cte.name.lowercased()),
         case nil = table(named: cte.name),
         case nil = view(named: cte.name) {
       throw .state("0A000",
                    "recursive WITH references the CTE outside its final " +
                    "UNION arm")
+    }
+    // A recursive body that is a NON-UNION set operation (`EXCEPT`/`INTERSECT`)
+    // referencing itself has no recursive arm to iterate: `recurses` matches
+    // only a `.union` core, so this body would take the run-once path and
+    // compile with the CTE self UNBOUND, faulting a generic `SQLError.relation`
+    // on the self reference. ISO 9075 permits recursion only through
+    // `UNION [ALL]`, so fault the precise `0A000` feature diagnostic instead —
+    // unless a same-named base/view seeds it (then the reference reads that
+    // relation and the body runs once, as the misplaced-anchor guard allows).
+    let core = try cte.canonical.inner
+    if cte.recursive,
+        case let .setop(kind, _, _, _) = core, kind != .union,
+        core.references(cte.name.lowercased()),
+        case nil = table(named: cte.name),
+        case nil = view(named: cte.name) {
+      throw .state("0A000", "recursion requires UNION [ALL]")
     }
     // Check the declared arity by compiling the body — never a cursor. A
     // recursive (self-naming) CTE checks its anchor and recursive arm the way
@@ -453,9 +538,11 @@ extension Catalog where Self: ~Escapable {
     // body with self NOT in scope. When `typecheck`, the reachable-operand
     // check runs in the SAME per-arm scope each arity check uses, so the
     // operand check shares the run's arm scoping and never types an anchor
-    // against the CTE-self overlay.
-    if cte.recursive && cte.recurses,
-        case let .setop(.union, anchor, recursive, _) = cte.query {
+    // against the CTE-self overlay. `recursiveArms`/`canonical` peel the SAME
+    // canonical (unwound) shape the run's `fixpoint` and the schema
+    // `contributions` do, so all three inspect the identical AST.
+    if let (anchor, recursive, _) = try cte.recursiveArms {
+      let carrier = try cte.canonical.carrier
       let scope = try augment(context.validating(typecheck), for: anchor,
                               rows: false)
       let width = try compile(anchor, scope).width
@@ -515,6 +602,28 @@ extension Catalog where Self: ~Escapable {
         // The recursive arm is operand-checked with self bound to the declared
         // columns — the schema every iteration reads the CTE under.
         try self.typecheck(recursive, probe)
+        // Validate the peeled carrier's `ORDER BY` keys the SAME way the RUN
+        // path resolves them (`fixpoint`/`apply`): against the body's FIRST-ARM
+        // set-op OUTPUT scope, through the ordinary `SELECT * FROM <temp> ORDER
+        // BY …` machinery over an EMPTY temp of those output columns. A key
+        // naming a missing column or function faults here on the schema path as
+        // it faults the run, closing the run-vs-validate gap where a carrier
+        // `ORDER BY missing(n)` passed `columns(of:validate:true)` yet the run
+        // faulted `.function('missing')` when `apply` resolved it after the
+        // fixpoint. The declared rename rides the CTE binding AFTER the
+        // carrier, so — as the run does — the carrier resolves the body's
+        // output names.
+        if let carrier {
+          // A set operation names its output off its FIRST arm (the ISO rule),
+          // so the carrier's `ORDER BY` resolves against the ANCHOR's output
+          // NAMES — resolved with the CTE self NOT in scope, so the anchor's
+          // own names/types derive without faulting `.relation` on the
+          // recursive arm's self reference. (Unifying the whole `body` would
+          // need the self bound to fold the recursive arm.)
+          let outputs = try columns(unifying: anchor, scope)
+          try validate(carrier: carrier, over: outputs, arm: anchor.first,
+                       context.validating(true))
+        }
       }
     } else {
       let scope = try augment(context.validating(typecheck), for: cte.query,
@@ -577,7 +686,15 @@ extension Catalog where Self: ~Escapable {
     // empty, matching the non-recursive and non-`WITH` paths.
     let context = try augment(context.validating(false), for: cte.query,
                               rows: true)
-    guard case let .setop(.union, anchor, recursive, all) = cte.query else {
+    // Peel the CANONICAL recursive shape — the SAME `canonical` (unwound) form
+    // `recurses`/`recursiveArms`, the shape validator, and the schema derive
+    // peel — off the body: the fixpoint iterates the INNER `UNION` (anchor ∪
+    // recursive) with the CTE self in scope, then the peeled `carrier` applies
+    // its row operators to the materialised RESULT. The carrier is transparent
+    // to the recursive shape (`references` descends it), so `recurses` already
+    // routed an ordered body here.
+    let (body, carrier) = try cte.canonical
+    guard case let .setop(.union, anchor, recursive, all) = body else {
       // A non-`UNION` recursive query runs once, but still binds under
       // `cte.columns`, so validate its compiled width here too — the check the
       // anchor and arm get. A body naming a base relation of the CTE's own name
@@ -713,7 +830,102 @@ extension Catalog where Self: ~Escapable {
       result += next
       working = next
     }
+    // Apply the peeled query-level carrier — a trailing `ORDER BY` / `OFFSET`·
+    // `FETCH` / `DISTINCT` on the body's set operation — to the materialised
+    // fixpoint RESULT, reusing the ordinary `SELECT`-over-a-relation path
+    // rather than re-resolving the row operators here. A trailing carrier's
+    // `generated` is always `0` (the parser materialises no hidden sort column
+    // for it; only `expand` does, which never yields a recursive body), so the
+    // result rows are exactly the CTE's declared columns and need no trim.
+    //
+    // The carrier's `ORDER BY` resolves against the body's FIRST-ARM set-op
+    // OUTPUT names — the SAME scope the non-recursive ordered-CTE body uses
+    // (`WITH t(n) AS (SELECT 1 AS x UNION ALL … ORDER BY x)` orders by the
+    // arm-0 output `x`, not the declared `n`) — so name the temp `apply` binds
+    // under the ANCHOR's output names (a set operation names its output off its
+    // FIRST arm, the ISO rule; the anchor resolves with the CTE self NOT in
+    // scope, so its names derive without the self binding), NOT the CTE's
+    // DECLARED names (`merged`). Each column carries the run-unified `merged`
+    // TYPE the materialised rows hold. The CTE-declared rename rides the
+    // RETURNED `merged` carrier, applied AFTER the carrier at CTE consumption,
+    // so the outer `SELECT n FROM t` still addresses `n`.
+    if let carrier {
+      let outputs = try columns(unifying: anchor, context)
+      let named = merged.indices.map {
+        ResolvedColumn(name: outputs[$0].name, type: merged[$0].type,
+                       unconstrained: merged[$0].unconstrained)
+      }
+      result = try apply(carrier, result, named, arm: anchor.first, context)
+    }
     return (result, merged)
+  }
+
+  /// Applies a peeled query-level `carrier` — `DISTINCT`/`ORDER BY`/`OFFSET`·
+  /// `FETCH` — to the materialised `rows` a recursive-CTE fixpoint produced,
+  /// typed by the fixpoint's unified `carrier` `columns` (the body's arm-0
+  /// output names), `arm` the body's FIRST arm (the anchor).
+  ///
+  /// The rows are bound as a temporary relation under a non-spellable name; a
+  /// bare scan over it seeds the SHARED `carried(over:)` carrier resolver — the
+  /// SAME resolver the ordinary `ordered` set-operation path uses — so the
+  /// carrier's `ORDER BY` resolves a projected-expression / aliased / qualified
+  /// / ordinal key against the arm-0 projection surface IDENTICALLY to the
+  /// ordinary path, never a bare `SELECT * FROM <temp>` that re-evaluates a
+  /// projected key over the column-shy temp. A trailing carrier's `generated`
+  /// is always `0` (only `expand` materialises hidden sort columns, and it
+  /// never yields a recursive body), so the identity projection trims nothing.
+  private borrowing func apply(_ carrier: Query.Carrier,
+                               _ rows: Array<Array<Value>>,
+                               _ columns: Array<ResolvedColumn>,
+                               arm: Select, _ context: Context)
+      throws(SQLError) -> Array<Array<Value>> {
+    let name = "*fixpoint"
+    let temp = RelationInstance(from: columns, rows: rows)
+    // Thread ONE fresh subquery cache — a shared box — through BOTH `carried`
+    // (which resolves the carrier `ORDER BY` and, for a sort key CORRELATED to
+    // the set-op output, records that key's compiled runtime plan here) AND
+    // `execute` (whose row evaluator reads that recorded plan back), mirroring
+    // the top-level `run`. A fresh box (not the incoming context's) isolates
+    // the carrier's subquery cache from the fixpoint iterations' recorded body
+    // plans; what matters is that `carried` writes and `execute` read the SAME
+    // box, so a correlated carrier sort key does not fault "a correlated
+    // subquery plan was not compiled" on execution.
+    let context = context.binding(name, to: temp).resolving(Subqueries())
+    // The base scan over the temp — its output columns ARE `columns`, the
+    // setop-output scope the carrier resolves against. The shared resolver
+    // stacks the row operators over it in that identity slot space.
+    let scan = try compile(.select(Select(projection: .all,
+                                          from: Relation(name: name))),
+                           context)
+    let plan = try carried(over: scan, output: columns, arm: arm,
+                           distinct: carrier.distinct, order: carrier.order,
+                           limit: carrier.limit, generated: carrier.generated,
+                           context)
+    return try execute(plan, context).map(\.values)
+  }
+
+  /// Validates the peeled `carrier`'s `ORDER BY` keys against the body's set-op
+  /// output `columns` — an EMPTY temp of those columns — through the SAME
+  /// shared `carried(over:)` resolver `apply` runs, under a validating context,
+  /// so a schema-path `columns(of:validate:true)` faults a carrier `ORDER BY`
+  /// naming a missing column or function EXACTLY as the run does, closing the
+  /// run-vs-validate gap. `arm` is the body's FIRST arm (the anchor), the
+  /// projection surface an ordinal / projected-expression / aliased key binds
+  /// against. Discards the resolved plan — only its resolution can fault.
+  private borrowing func validate(carrier: Query.Carrier,
+                                  over columns: Array<ResolvedColumn>,
+                                  arm: Select, _ context: Context)
+      throws(SQLError) {
+    let name = "*fixpoint"
+    let temp = RelationInstance(from: columns, rows: [])
+    let context = context.binding(name, to: temp)
+    let scan = try compile(.select(Select(projection: .all,
+                                          from: Relation(name: name))),
+                           context)
+    _ = try carried(over: scan, output: columns, arm: arm,
+                    distinct: carrier.distinct, order: carrier.order,
+                    limit: carrier.limit, generated: carrier.generated,
+                    context)
   }
 }
 
@@ -1015,6 +1227,389 @@ extension Plan {
   }
 }
 
+// MARK: - Ordered set operation
+
+/// A grouped-arm resolver a carrier caller injects: the RESOLVED grouped-space
+/// `Term` of each projected item, and a closure lowering an arbitrary
+/// expression to that same space — the identity surface a query-level `ORDER
+/// BY` key matches against by resolved identity. A plain set-operation carrier
+/// injects none (`nil`).
+internal typealias Resolver =
+    (terms: Array<Term>, resolve: (Expression) throws(SQLError) -> Term)
+
+extension Catalog where Self: ~Escapable {
+  /// Compiles an `ORDER BY` / `SELECT DISTINCT` / `OFFSET`·`FETCH` carried over
+  /// the set-operation `union` — the `Query.ordered` carrier — into the row
+  /// operators STACKED over the union's compiled plan, resolved through the
+  /// setop's OUTPUT scope.
+  ///
+  /// A `setop` node has no order/distinct/limit slot, so the query-level row
+  /// operators ride this outer carrier rather than a text `SELECT * FROM
+  /// (union) AS g ORDER BY …` wrapper. They resolve against a scope over the
+  /// union's OUTPUT columns — the arm-0-named, type-unified result columns —
+  /// the SAME canonical resolution any `SELECT … FROM <derived> ORDER BY
+  /// <alias/ordinal/expr>` uses, so:
+  ///
+  ///   - an ordinal `ORDER BY n`, an output alias, or a bare projected column
+  ///     orders on that output column (its slot in the union output);
+  ///   - a generated `column N` display header is NOT among the scope's
+  ///     bindable output names, so `ORDER BY "column N"` faults `.column` — as
+  ///     it does over any derived union — rather than being wrongly accepted;
+  ///   - a bare name matching TWO output columns faults `SQLError.ambiguous`,
+  ///     as a plain grouped query's `ORDER BY` does;
+  ///   - under `DISTINCT` a key must name an output (`distinct(_:_:_:)` over
+  ///     the identity projection), matching the plain-grouped rule.
+  ///
+  /// The row operators do NOT project — the result schema is the union's — so
+  /// the carrier's projection is the IDENTITY over the real output slots
+  /// (`0 ..< real`), which also trims any hidden materialised column.
+  internal borrowing func ordered(_ union: Query, distinct: Bool,
+                                  order: Order?, limit: Limit?,
+                                  generated: Int,
+                                  _ context: Context) throws(SQLError) -> Plan {
+    // Compile the inner union and derive its OUTPUT columns — the arm-0-named,
+    // type-unified result columns the carrier orders/dedups over. The plan's
+    // output sits at slots `0 ..< width` (a `setop`'s output is its arm-0
+    // projection), so the carrier resolves and stacks in that identity space.
+    // The shared `carried(over:)` resolver then does the whole ORDER BY /
+    // DISTINCT resolution against the setop-output scope and stacks the row
+    // operators.
+    let plan = try compile(union, context)
+    let cols = try columns(unifying: union, context)
+    return try carried(over: plan, output: cols, arm: union.first,
+                       distinct: distinct, order: order, limit: limit,
+                       generated: generated, context)
+  }
+
+  /// The REAL output count of an `ordered` carrier over a `width`-column set
+  /// operation — the trim width `width − generated`, the leading real outputs
+  /// with the trailing `generated` hidden materialised sort columns dropped.
+  ///
+  /// `Query.ordered` is a PUBLIC AST case a caller may build with a `generated`
+  /// count out of step with the inner union's width (the parser only ever emits
+  /// `0`, and `expand` an in-range count). A count PAST the width, or NEGATIVE,
+  /// would make the trim width negative — the carrier's `0 ..< real` range and
+  /// per-column subscripts, and the schema path's `Array.prefix`, would TRAP
+  /// the process. Rejecting the malformed count with ONE typed internal-error
+  /// fault, read by BOTH the compile carrier (`carried`) and the schema path
+  /// (`columns(unifying:)`), keeps `run ≡ columns(of:)` on a malformed carrier.
+  internal func real(trimming generated: Int, of width: Int)
+      throws(SQLError) -> Int {
+    guard generated >= 0, generated <= width else {
+      throw .state("XX000",
+                   "ordered set-operation generated count out of range")
+    }
+    return width - generated
+  }
+
+  /// Stacks the query-level row operators — a carried `ORDER BY` / `DISTINCT` /
+  /// `OFFSET`·`FETCH` — over an already-compiled set-operation `plan`, resolved
+  /// through the setop's OUTPUT scope. `plan`'s output sits at slots
+  /// `0 ..< output.count`, the arm-0-named, type-unified result columns
+  /// (`output`); `arm` is the union's FIRST arm — its projection is the surface
+  /// a projected-expression / aliased / qualified ORDER BY key matches against
+  /// by AST (a plain set-op arm).
+  ///
+  /// `resolver`, when INJECTED, lowers the arm's projected items to a grouped
+  /// slot space and lowers an arbitrary expression to the same space — a
+  /// resolved-identity surface a caller over a grouped arm supplies so a
+  /// query-level `ORDER BY` key matches a projected aggregate by resolved
+  /// identity. A plain set-operation arm has no grouped aggregate space and
+  /// passes `nil`, so the carrier keeps the ordinary AST/output-name
+  /// resolution; `generated` is then `0` and no hidden slot is materialised or
+  /// trimmed.
+  ///
+  /// A `setop` node has no order/distinct/limit slot, so the query-level row
+  /// operators ride this outer carrier rather than a text `SELECT * FROM
+  /// (union) AS g ORDER BY …` wrapper. They resolve against a scope over the
+  /// setop's OUTPUT columns — the arm-0-named, type-unified result columns —
+  /// the SAME canonical resolution any `SELECT … FROM <derived> ORDER BY
+  /// <alias/ordinal/expr>` uses.
+  ///
+  /// The row operators do NOT project — the result schema is the union's — so
+  /// the carrier's projection is the IDENTITY over the real output slots
+  /// (`0 ..< real`), which also trims any hidden materialised column.
+  internal borrowing func carried(over plan: Plan,
+                                  output cols: Array<ResolvedColumn>,
+                                  arm: Select, distinct: Bool, order: Order?,
+                                  limit: Limit?, generated: Int,
+                                  resolver: Resolver? = nil,
+                                  _ context: Context)
+      throws(SQLError) -> Plan {
+    if let limit {
+      // A direct `Limit(count:offset:)` may carry negatives the executor's
+      // skip and take would trap on (the parser yields only non-negatives).
+      // Reject them as a query error, as the `Select` compile path does.
+      guard limit.offset >= 0 else {
+        throw .state("2201X", "OFFSET row count must be non-negative")
+      }
+      guard (limit.count ?? 0) >= 0 else {
+        throw .state("2201W", "FETCH row count must be non-negative")
+      }
+    }
+    let width = cols.count
+    // The union's arm-0 projection carries the real output items followed by
+    // any hidden materialised sort columns (a producer aliases them `*gsN`).
+    // The REAL output count `real` is the carrier's trim width — the STRUCTURAL
+    // `generated` count carried on the node (never a scan of the arm-0 names
+    // for a `*gs` prefix, which would trim a user's delimited `AS "*gs0"`), so
+    // slots `0 ..< real` are the real outputs and `real ..< width` the hidden
+    // ones. The hidden expressions map to their `*gsN` output slots for a
+    // materialised ORDER BY key.
+    let items: Array<Projected> = switch arm.projection {
+    case let .expressions(list):
+      list
+    case let .columns(columns):
+      columns.map { Projected(expression: .column($0)) }
+    case .all:
+      []
+    }
+    // Range-check the `generated` count against the width and derive the trim
+    // width `real` through the shared guard (see `real(trimming:of:)`), which
+    // faults a malformed public-AST count rather than letting the `0 ..< real`
+    // range below or a per-column subscript TRAP. The SAME guard backs the
+    // schema path (`columns(unifying:)`), so `run ≡ columns(of:)`.
+    let real = try real(trimming: generated, of: width)
+    // A `generated` tail must correspond to genuine HIDDEN aliased columns — a
+    // producer's `*gsN` items, each carrying a non-nil alias. A caller may,
+    // though, build `.ordered(<2-col union>, generated: 1)` over an ORDINARY
+    // union whose trailing item is a normal projected column with NO alias, OR
+    // `.ordered(<SELECT * union>, generated: N>0)` whose arm-0 projection is
+    // `.all` so `items` is EMPTY though `width > 0`: the hidden-name mapping's
+    // `items[real + k].alias!` below would TRAP (an unaliased item, or an
+    // absent one when `items` is short). Prove each generated tail slot HAS a
+    // corresponding aliased projected item before force-unwrapping, faulting
+    // the same typed internal-error the range guard raises rather than
+    // crashing. (Not a `where` skip: an absent slot must fault, not pass.)
+    for k in 0 ..< generated {
+      guard real + k < items.count, items[real + k].alias != nil else {
+        throw .state("XX000",
+                     "ordered set-operation generated tail is not aliased")
+      }
+    }
+    // The output NAME of each REAL column — an alias, else a bare column. An
+    // unnamed output (a computed column with no `AS`) has NO bindable name: it
+    // is reachable only by ordinal, so it takes a non-spellable synthetic name
+    // (`*colN`, which a normal or delimited identifier cannot spell) rather
+    // than the positional `column N` DISPLAY header — else `ORDER BY "column
+    // N"` would wrongly bind it, where a plain derived union faults `.column`.
+    //
+    // Whether an output is unnamed is the RESOLVED column's STRUCTURAL
+    // `synthesized` flag — set where the projection had no inferable name
+    // (`Projected.name == nil`) and a positional `column N` was substituted —
+    // NOT a comparison of the resolved name text to `column N`, which would
+    // mistake a user's EXPLICIT delimited `AS "column 1"` for a synthesized
+    // header and strip it. A named output keeps its name; a synthesized one is
+    // `nil` here (not bindable). (A `SELECT *`/`TABLE` first arm names every
+    // output through `cols`, never synthesized, and carries no hidden column,
+    // so `real == width`.)
+    let outputs: Array<String?> = (0 ..< real).map {
+      cols[$0].synthesized ? nil : cols[$0].name
+    }
+    // The scope over the union's output. The schema names EVERY column so
+    // `term` can resolve a materialised key's synthetic column: a named real
+    // output by its name, an UNNAMED real output by a non-spellable `*colN`,
+    // and each hidden materialised column by its `*gsN` alias.
+    let schema = Schema(from: cols,
+                        names: (0 ..< width).map {
+                          $0 < real ? (outputs[$0] ?? "*col\($0)")
+                                    : items[$0].alias!
+                        },
+                        extent: width, virtuals: [])
+    // The derived relation is a scope entry keyed by the empty alias, so bare
+    // ORDER BY / DISTINCT names resolve unqualified over the `schema`; its
+    // inner query is inspected nowhere here, so the arm-0 `SELECT` stands in
+    // for it uniformly.
+    let scope = Scope([(Relation(derived: .select(arm), as: ""), schema)])
+    // COLLECT and RESOLVE the carrier ORDER BY's OWN nested subqueries — the
+    // SAME machinery a plain `SELECT … ORDER BY CASE WHEN EXISTS (…) …` uses
+    // (`subquery(_:_:_:within:)` builds a `Resolution` recording each nested
+    // query's width/type/plan against the setop-output `scope`, AND records a
+    // CORRELATED one's runtime plan into `context.subqueries` per the ROLE it
+    // occupies). A carried `ORDER BY` over a set operation is otherwise lowered
+    // with the DEFAULT `.unsupported` resolution, so `scope.order` REJECTS an
+    // `EXISTS`/`IN`/scalar sort-key subquery a plain `SELECT`'s ORDER BY
+    // accepts. Threading this resolution in makes a set operation's ORDER BY
+    // resolve a subquery sort key identically to a plain select's; an ORDER BY
+    // position bars a NEW correlation (`.barred` inside `scope.order`), so a
+    // genuinely-unsupported case still faults exactly as it does on a SELECT.
+    //
+    // `roles(of:)` classifies a subquery by the CLAUSE it occurs in, so the
+    // recording pass must inspect a select whose ORDER BY IS the carrier's —
+    // NOT the bare `arm`, whose own ORDER BY does not carry the carrier's sort-
+    // key subqueries. Reusing `arm` there records NO runtime plan (empty
+    // roles), so a CORRELATED carrier sort-key subquery lowers to a
+    // `Term.subquery`/`.parameter` yet faults "a correlated subquery plan was
+    // not compiled" at execution — where the SAME ORDER BY on a plain SELECT
+    // records and re-executes it per row. Overlay the carrier's `order` on the
+    // arm (keeping the arm's projection surface a projected-expression key
+    // resolves against) so the recording sees the carrier's sort-key subqueries
+    // in their ORDER BY role. The projected-key resolution itself still runs
+    // over `arm` in `scope.order` below; `subquery(_:_:_:within:)` reads the
+    // passed select ONLY for `roles(of:)`.
+    var subqueries = Array<Query>()
+    for key in order?.keys ?? [] {
+      if case let .expression(expression) = key.sort {
+        expression.collect(subqueries: &subqueries)
+      }
+    }
+    let classifier = Select(distinct: arm.distinct, projection: arm.projection,
+                            from: arm.from, joins: arm.joins,
+                            predicate: arm.predicate, grouping: arm.grouping,
+                            having: arm.having, order: order, limit: arm.limit)
+    let resolution = try subquery(subqueries, classifier, context,
+                                  within: scope)
+    // The identity projection over the REAL output slots, and the REAL output
+    // names a bare ORDER BY name or a DISTINCT key binds against — alias-or-
+    // bare, `nil` for an unnamed output. `scope.order` bounds an ORDINAL key by
+    // this projection's COUNT, so it must be the REAL arity (`real`), NOT the
+    // grown `width`.
+    let projection = (0 ..< real).map(Term.slot)
+    let names: Array<String?> = (0 ..< real).map { outputs[$0] }
+    // Resolve the ORDER BY through the setop-output scope. Rewrite only a key
+    // the scope cannot resolve for itself over the union's output.
+    var keys = Array<SortKey>()
+    if let order {
+      // The REAL projected items an `ORDER BY <expr>` key may match to its
+      // ordinal — the arm-0 projection minus its trailing hidden `*gsN`
+      // columns. EMPTY for a `SELECT *`/`TABLE` first arm (no enumerated
+      // projection to match), so such a key falls to the scope's ordinary
+      // resolution over the `*`-expanded output columns.
+      let reals = Array(items.prefix(real))
+      let folded = Set(outputs.compactMap { $0?.lowercased() })
+      let rewritten = Order(keys: try order.keys.map {
+        key throws(SQLError) -> Order.Key in
+        guard case let .expression(expression) = key.sort else { return key }
+        // A BARE unqualified column NAMING A REAL OUTPUT is left to the
+        // setop-output scope's ordinary resolution, whichever carrier: it binds
+        // an output alias or a bare projected column BY NAME and faults
+        // `.ambiguous` on a name TWO outputs share — the ISO precedence
+        // `scope.order` applies before a term match, which a resolved-identity
+        // rewrite to an ordinal would wrongly bypass. A bare column that is NOT
+        // a real output rides the resolver (when injected) to its hidden slot.
+        let bare = if case let .column(column) = expression {
+          column.qualifier == nil && folded.contains(column.name.lowercased())
+        } else {
+          false
+        }
+        // A grouped-arm caller's injected resolver: match a QUALIFIED column or
+        // a NON-column expression against the arm's projected terms by RESOLVED
+        // identity. A key that lowers cleanly and equals a projected term
+        // orders on that slot's ORDINAL — a REAL slot directly, a HIDDEN slot
+        // through its `*gsN` output name. A key `resolve` faults on is left for
+        // the setop-output scope to bind or fault, as before.
+        if let resolver, !bare {
+          let term = try? resolver.resolve(expression)
+          if let term, let slot = resolver.terms.firstIndex(of: term) {
+            if slot < real {
+              return Order.Key(sort: .ordinal(slot + 1),
+                               ascending: key.ascending)
+            }
+            return Order.Key(
+                sort: .expression(.column(Column(name: items[slot].alias!))),
+                ascending: key.ascending)
+          }
+          return key
+        }
+        if resolver != nil { return key }
+        // Plain set-operation carrier: a materialised key (a hidden `*gsN`
+        // item, matched by AST) orders on that hidden column.
+        if let slot = (real ..< width).first(where: {
+          items[$0].expression == expression
+        }) {
+          return Order.Key(
+              sort: .expression(.column(Column(name: items[slot].alias!))),
+              ascending: key.ascending)
+        }
+        if case let .column(column) = expression {
+          // A qualified column whose bare name is an output drops its
+          // qualifier (the set-operation result carries none), so it binds that
+          // output as a bare name — resolving, or faulting `.ambiguous` on a
+          // duplicate, as the plain form. Every other column rides through.
+          if column.qualifier != nil,
+              folded.contains(column.name.lowercased()) {
+            return Order.Key(sort: .expression(.column(Column(name: column
+                                                                    .name))),
+                             ascending: key.ascending)
+          }
+          return key
+        }
+        if let index = reals.firstIndex(where: {
+          $0.expression == expression
+        }) {
+          return Order.Key(sort: .ordinal(index + 1),
+                           ascending: key.ascending)
+        }
+        return key
+      })
+      keys = try scope.order(rewritten, projection, names, context.routines,
+                             subquery: resolution)
+      // The carrier's ORDER BY is a NEW expression surface: `scope.order`
+      // RESOLVES each key (binds a column, arity), but — like the grouped
+      // path's structural resolve — does NOT type-check a key's operands or its
+      // calls, so an unknown routine (`ORDER BY missing(a)`) or an ill-typed
+      // operand (`ORDER BY a + 'x'`) a run raises on slipped past validate.
+      // Under `validate`, type-check each key EXPRESSION against the SAME
+      // setop-output scope it resolved over — its calls and operands as a
+      // projected expression's — so validate faults IDENTICALLY to a run. An
+      // ordinal/output-name key carries no `.expression` to re-check. The run
+      // path compiles LENIENTLY (`validate: false`), so this never double-
+      // faults there — the run surfaces the fault at execution as it did
+      // before.
+      if context.validate {
+        // A carrier ORDER BY key may nest an `EXISTS`/`IN`/scalar subquery
+        // (`ORDER BY CASE WHEN EXISTS (…) …`), which the `scope.validate`
+        // type-check below rejects under the DEFAULT `.unsupported`
+        // `SubqueryCheck`. Record each nested subquery's width and type — the
+        // SAME cursor-free pre-pass `subqueryCheck(of:)` runs for a plain
+        // SELECT's ORDER BY subqueries — so the type-check validates a subquery
+        // sort key rather than faulting `.unsupported`, keeping the schema path
+        // in step with the run (which resolves the same key through
+        // `resolution` above).
+        //
+        // Derive each subquery's width/type against the SAME setop-output
+        // `scope` the run resolves it through (`subquery(_:_:_:within: scope)`
+        // above): a carrier ORDER BY subquery may reference a set-operation
+        // OUTPUT column — an aliased output living ONLY in this scope, unseen
+        // by `context.outer` — so nesting `scope` under the outer, enclosing-
+        // scope shape `subquery(_:_:_:within:)` builds, resolves it at validate
+        // EXACTLY as it does at run. Threading bare `context.outer` faulted
+        // `.column` on a set-op output column a run resolves, rejecting a query
+        // that executes. A genuinely-unresolvable column (not a set-op output,
+        // absent from the outer) still faults here as it does at run.
+        let nested = (context.outer ?? Outer()).nested(under: scope)
+        var widths = Dictionary<Query, Int>()
+        var types = Dictionary<Query, ValueType>()
+        for query in subqueries {
+          try self.width(query, [], context, nested, &widths, &types)
+        }
+        let check = SubqueryCheck(widths, types).barred
+        for key in rewritten.keys {
+          guard case let .expression(expression) = key.sort else { continue }
+          try scope.aggregates(in: expression, context.routines,
+                               subquery: check)
+          _ = try scope.validate(expression, context.routines, subquery: check)
+        }
+      }
+    }
+    // Under DISTINCT every ORDER BY key must be a select-list value (see
+    // `distinct`); the keys and identity projection are in the union's output
+    // slot space, aligned with the AST keys index-for-index. The DISTINCT check
+    // sees ONLY the REAL outputs (`0 ..< real`), NOT the hidden materialised
+    // sort columns: a hidden `*gsN` slot is not a select-list value.
+    if distinct, let order {
+      keys = try SQLEngine.distinct(order.keys, keys,
+                                    (0 ..< real).map(Term.slot))
+    }
+    // Stack the row operators over the union plan, trimming to the REAL output
+    // columns with the identity projection `0 ..< real` (dropping any hidden
+    // materialised sort column).
+    return plan.shaped(distinct: distinct,
+                       projection: (0 ..< real).map(Term.slot),
+                       filter: nil, order: keys, limit: limit)
+  }
+}
+
 // MARK: - Aggregation
 
 extension Select {
@@ -1232,6 +1827,7 @@ extension Query {
     switch self {
     case let .select(select): select.bound
     case let .setop(_, left, right, _): left.bound || right.bound
+    case let .ordered(inner, _, _, _, _): inner.bound
     }
   }
 
@@ -1245,6 +1841,7 @@ extension Query {
     switch self {
     case let .select(select): select.subqueries
     case let .setop(_, left, right, _): left.subqueries + right.subqueries
+    case let .ordered(inner, _, _, _, _): inner.subqueries
     }
   }
 
@@ -1258,6 +1855,7 @@ extension Query {
     switch self {
     case let .select(select): select.valued
     case let .setop(_, left, right, _): left.valued.union(right.valued)
+    case let .ordered(inner, _, _, _, _): inner.valued
     }
   }
 
@@ -1270,6 +1868,7 @@ extension Query {
     switch self {
     case let .select(select): select.scalar
     case let .setop(_, left, right, _): left.scalar.union(right.scalar)
+    case let .ordered(inner, _, _, _, _): inner.scalar
     }
   }
 
@@ -1284,6 +1883,7 @@ extension Query {
     case let .select(select): select.existential
     case let .setop(_, left, right, _):
       left.existential.union(right.existential)
+    case let .ordered(inner, _, _, _, _): inner.existential
     }
   }
 }
@@ -2438,16 +3038,38 @@ extension Catalog where Self: ~Escapable {
                                   _ context: Context)
       throws(SQLError) -> Plan {
     let overlay = try overlay(name, context)
-    guard let view = resolve(view: name), case .setop = view.query,
-        case .setop = plan else {
+    guard let view = resolve(view: name) else {
       return try optimise(plan, overlay)
     }
-    return try optimise(plan, view.query, overlay)
+    // A BARE set-operation body (`view.query` itself a `.setop`) optimises its
+    // `.setop` plan per arm, EXACTLY as before — but any other plan shape (a
+    // pushed `.select` over the setop, a `.derived`, a leaf) stays on the plain
+    // optimiser, whose pushdown/seek pass rebases a caller `WHERE` into each
+    // arm. Preserved verbatim so a non-ordered union view's seek injection is
+    // unchanged.
+    if case .setop = view.query, case .setop = plan {
+      return try optimise(plan, view.query, overlay)
+    }
+    // A set operation UNDER an `ordered` carrier compiles to a `.shaped` stack
+    // (project/sort/distinct/limit) over the `.setop` — NOT a bare setop — so
+    // its per-arm derived aliases went un-optimised (both `case .setop` guards
+    // failed). Descend the carrier wrapper to the setop leaf, optimising each
+    // arm under its own overlay, exactly as the execute path's carrier-aware
+    // `setop`/`execute(_:carrying:)` do. GATED on the body actually wearing a
+    // carrier (`view.query` an `.ordered`), so a bare union view keeps the
+    // plain path above and this never rewrites its pushed `.select`/seek shape.
+    if case .ordered = view.query, case .setop = view.query.core {
+      return try optimise(plan, view.query.core, overlay)
+    }
+    return try optimise(plan, overlay)
   }
 
   /// Optimises a view body's SET-OPERATION `plan` arm by arm, each arm sub-plan
   /// under `overlay` AUGMENTED with THAT arm's own derived aliases, descending
-  /// the `plan` and `query` trees in lockstep (they mirror each other).
+  /// the `plan` and `query` trees in lockstep (they mirror each other). A body
+  /// riding an `ordered` carrier descends the `.shaped` wrapper stack first,
+  /// reconstructing each row operator over its optimised source, down to the
+  /// `.setop` leaf.
   private borrowing func optimise(_ plan: Plan, _ query: Query,
                                   _ overlay: Context)
       throws(SQLError) -> Plan {
@@ -2456,6 +3078,31 @@ extension Catalog where Self: ~Escapable {
       return try .setop(kind, optimise(left, leftQuery, overlay),
                         optimise(right, rightQuery, overlay), all: all,
                         types: types, widened: widened)
+    }
+    // Descend the `ordered` carrier's single-source row operators, rebuilding
+    // each over its optimised source while the setop `query` core rides through
+    // unchanged until the `.setop` node above splits it. The carrier wrapper
+    // sits ABOVE the setop, so `query` is STILL the `.setop` core here — gate
+    // on that: once the setop has split into an arm (`query` a `.select`), the
+    // plan is that ARM's own sub-plan, whose `.project`/`.select`/… must reach
+    // the plain arm optimiser below (its seek/pushdown rewrite), NOT be walked
+    // through as a carrier wrapper. So these cases fire ONLY above the setop.
+    if case .setop = query {
+      switch plan {
+      case let .project(terms, source):
+        return try .project(terms, optimise(source, query, overlay))
+      case let .sort(keys, source):
+        return try .sort(keys: keys, optimise(source, query, overlay))
+      case let .distinct(source):
+        return try .distinct(optimise(source, query, overlay))
+      case let .limit(count, offset, source):
+        return try .limit(count: count, offset: offset,
+                          optimise(source, query, overlay))
+      case let .select(filter, source):
+        return try .select(filter, optimise(source, query, overlay))
+      default:
+        break
+      }
     }
     // Schema-only (`rows: false`): the optimiser needs the arm's derived alias
     // bound by name/schema so `seek` treats it as an unseekable materialised
@@ -3877,6 +4524,15 @@ extension Catalog where Self: ~Escapable {
     // faults, and a REACHED body operand still faults at run), matching the
     // non-derived path; a schema check passes `true`.
     let context = try augment(context, for: query, rows: false)
+    // A query-level `ORDER BY` / `DISTINCT` / `OFFSET`·`FETCH` over a set
+    // operation rides the `ordered` carrier: compile the inner union, then
+    // STACK the row operators over its plan, resolved through the setop's
+    // OUTPUT scope (`ordered`). The row operators do NOT project, so the result
+    // columns stay the union's — an identity projection over its output slots.
+    if case let .ordered(inner, distinct, order, limit, generated) = query {
+      return try ordered(inner, distinct: distinct, order: order,
+                         limit: limit, generated: generated, context)
+    }
     guard case let .setop(kind, left, right, all) = query else {
       return try compile(query.first, context)
     }

--- a/Sources/SQLEngine/Filter.swift
+++ b/Sources/SQLEngine/Filter.swift
@@ -1098,18 +1098,32 @@ extension Catalog where Self: ~Escapable {
     // recorded probe is already the shape. The fold runs ONCE per occurrence —
     // memoised on the `Subkey` — so a reached incompatibility faults on the
     // FIRST reached outer row and later rows skip the redundant (pure) re-fold.
-    if key.role == .scalar || key.role == .valued, case .setop = key.query,
-        !context.subqueries.validated(key) {
+    // A set operation may ride an `ordered` carrier (`ORDER BY`/`DISTINCT`/
+    // `OFFSET`·`FETCH` over the union), so fold on the query's CARRIER-
+    // TRANSPARENT core — a bare `case .setop = key.query` would swallow the
+    // `.ordered` carrier and skip a reached carried union's strict re-fold,
+    // diverging run from the uncorrelated `.operand`/42804 fault.
+    if key.role == .scalar || key.role == .valued,
+        case .setop = key.query.core, !context.subqueries.validated(key) {
       _ = try types(unifying: key.query, context)
       context.subqueries.validate(key)
     }
     guard let plan = context.subqueries.plan(key, correlation) else {
       throw .named("a correlated subquery plan was not compiled")
     }
-    // A SET-OPERATION plan augments PER ARM (arm-local derived aliases the
-    // query-level augment misses); a single plan augments the whole query once.
-    if case .setop = plan {
-      return try arms(plan, key.query, context)
+    // A SET-OPERATION subquery augments PER ARM (arm-local derived aliases the
+    // query-level augment misses); a single query augments the whole query
+    // once. A carried union compiles to a `.shaped` plan (a project/sort/
+    // distinct stack over the `.setop`), NOT a bare `.setop`, so route the
+    // per-arm execution through the SAME carrier descender `run` uses
+    // (`execute(_:carrying:)`) — it descends the wrapper to the setop leaf and
+    // runs `arms` there — keyed on the query's core being a set operation. A
+    // bare `.setop` query/plan (no carrier) descends identically: the core is
+    // the query itself and the descender's `.setop` leaf is `arms(plan, core,
+    // context)` — the prior direct call — so a non-ordered set operation is
+    // unchanged.
+    if case .setop = key.query.core {
+      return try execute(plan, carrying: key.query.core, context)
     }
     let augmented =
         try augment(context.validating(false), for: key.query, rows: true)
@@ -1206,7 +1220,7 @@ extension Catalog where Self: ~Escapable {
   /// (not re-running the arm queries) preserves any pushed conjunct in the arm
   /// plan; `validate: false` keeps a data-dependent-empty arm body lenient, as
   /// the run path is.
-  private borrowing func arms(_ plan: Plan, _ query: Query, _ context: Context)
+  internal borrowing func arms(_ plan: Plan, _ query: Query, _ context: Context)
       throws(SQLError) -> Array<Record> {
     if case let .setop(kind, left, right, all, types, _) = plan,
         case let .setop(_, leftQuery, rightQuery, _) = query {

--- a/Sources/SQLEngine/Operator.swift
+++ b/Sources/SQLEngine/Operator.swift
@@ -574,41 +574,7 @@ extension Catalog where Self: ~Escapable {
       }
       return projected
     case let .sort(keys, source):
-      // Evaluate each key's `Term` against every record UP FRONT — a bare slot
-      // read, but any lowered expression (`a + b`, `UPPER(Name)`, an ordinal's
-      // or alias's select-list item) — so the comparator sorts on precomputed
-      // values. Evaluation may throw (a scalar call, a division), which a
-      // `sorted(by:)` comparator cannot, so it happens here rather than inside
-      // the sort; it also evaluates each key once per row rather than once per
-      // comparison. An explicit loop keeps the borrowed `self` a scalar sort
-      // key materialises against out of a closure capture.
-      let rows = try execute(source, context)
-      var sortable = Array<Array<Value>>()
-      sortable.reserveCapacity(rows.count)
-      for record in rows {
-        var cells = Array<Value>()
-        cells.reserveCapacity(keys.count)
-        for key in keys {
-          try cells.append(evaluate(record, key.term, context))
-        }
-        sortable.append(cells)
-      }
-      return sortable.indices
-        .sorted { lhs, rhs in
-          // Compare the keys major to minor: the first key on which the rows
-          // differ decides the order; a key they are equal on falls through to
-          // the next. A key's direction governs that key alone.
-          for index in keys.indices {
-            let ordered = less(sortable[lhs][index], sortable[rhs][index])
-            let reverse = less(sortable[rhs][index], sortable[lhs][index])
-            if ordered == reverse { continue }
-            return keys[index].ascending ? ordered : reverse
-          }
-          // Equal on every key: keep the source order (a stable sort) by
-          // tie-breaking on the original index.
-          return lhs < rhs
-        }
-        .map { rows[$0] }
+      return try sorted(execute(source, context), keys, context)
     case let .product(outer, inner):
       return try product(execute(outer, context), execute(inner, context))
     case let .join(outer, name, ordinals, base, column, keys, filter):
@@ -641,6 +607,102 @@ extension Catalog where Self: ~Escapable {
     case let .limit(count, offset, source):
       return limited(try execute(source, context), count, offset)
     }
+  }
+
+  /// Executes the query-level `ordered` set-operation carrier `plan` over the
+  /// inner set operation `union`, routing the setop leaf through the SAME
+  /// per-arm augmentation the direct `run(.setop)` and the correlated-subquery
+  /// `arms` use — so a derived table an arm names is MATERIALISED in that arm's
+  /// own scope before its `.scan` reads it.
+  ///
+  /// The carrier plan `ordered` builds is a stack of SINGLE-source row
+  /// operators (`sort`/`distinct`/`limit`/`project`, and the `project`/`sort`
+  /// pair a materialised output key emits) OVER the compiled `union` setop.
+  /// The plain `execute(_:_:)` would run the setop under the ONE carrier
+  /// context (`execute(.setop)` shares it across both arms), which never binds
+  /// an arm's arm-local derived alias — arms are SELECT-scoped, so the query-
+  /// level augment misses them. This descends the wrapper stack unchanged,
+  /// applying EACH operator through the SAME helper `execute(_:_:)` uses, and
+  /// at the setop leaf runs `arms(_:_:_:)` — per-arm augment, per arm
+  /// `execute`, shared `combine` — so the carrier's sort/dedup/limit see the
+  /// fully materialised combined rows in the union's output slot space. A
+  /// `union` with only base-relation arms materialises nothing extra, so it
+  /// runs identically.
+  internal borrowing func execute(_ plan: Plan, carrying union: Query,
+                                  _ context: Context)
+      throws(SQLError) -> Array<Record> {
+    switch plan {
+    case .setop:
+      return try arms(plan, union, context)
+    case let .project(terms, source):
+      let source = try execute(source, carrying: union, context)
+      var projected = Array<Record>()
+      projected.reserveCapacity(source.count)
+      for record in source {
+        try projected.append(project(terms, record, context))
+      }
+      return projected
+    case let .sort(keys, source):
+      return try sorted(execute(source, carrying: union, context), keys,
+                        context)
+    case let .distinct(source):
+      return deduplicated(try execute(source, carrying: union, context))
+    case let .limit(count, offset, source):
+      return limited(try execute(source, carrying: union, context), count,
+                     offset)
+    case let .select(filter, source):
+      return try admitted(execute(source, carrying: union, context), filter,
+                          context)
+    default:
+      // The carrier stack holds only the single-source row operators above; any
+      // other node is not one the carrier builds, so execute it as-is (it does
+      // not enclose the setop leaf).
+      return try execute(plan, context)
+    }
+  }
+
+  /// Sorts `rows` by the ordered `keys` — the executor's `.sort` node body,
+  /// shared with the query-level `ordered` set-operation carrier so the two
+  /// sort a combined result IDENTICALLY.
+  ///
+  /// Each key's `Term` is evaluated against every record UP FRONT — a bare slot
+  /// read, but any lowered expression (`a + b`, `UPPER(Name)`, an ordinal's or
+  /// alias's select-list item) — so the comparator sorts on precomputed values.
+  /// Evaluation may throw (a scalar call, a division), which a `sorted(by:)`
+  /// comparator cannot, so it happens here rather than inside the sort; it also
+  /// evaluates each key once per row rather than once per comparison. An
+  /// explicit loop keeps the borrowed `self` a scalar sort key materialises
+  /// against out of a closure capture.
+  internal borrowing func sorted(_ rows: Array<Record>,
+                                 _ keys: Array<(term: Term, ascending: Bool)>,
+                                 _ context: Context)
+      throws(SQLError) -> Array<Record> {
+    var sortable = Array<Array<Value>>()
+    sortable.reserveCapacity(rows.count)
+    for record in rows {
+      var cells = Array<Value>()
+      cells.reserveCapacity(keys.count)
+      for key in keys {
+        try cells.append(evaluate(record, key.term, context))
+      }
+      sortable.append(cells)
+    }
+    return sortable.indices
+      .sorted { lhs, rhs in
+        // Compare the keys major to minor: the first key on which the rows
+        // differ decides the order; a key they are equal on falls through to
+        // the next. A key's direction governs that key alone.
+        for index in keys.indices {
+          let ordered = less(sortable[lhs][index], sortable[rhs][index])
+          let reverse = less(sortable[rhs][index], sortable[lhs][index])
+          if ordered == reverse { continue }
+          return keys[index].ascending ? ordered : reverse
+        }
+        // Equal on every key: keep the source order (a stable sort) by
+        // tie-breaking on the original index.
+        return lhs < rhs
+      }
+      .map { rows[$0] }
   }
 
   /// Evaluates each projected `term` against `record` through `routines` to the
@@ -1318,8 +1380,8 @@ extension Catalog where Self: ~Escapable {
                                 for: .view(name.lowercased()))
     }
     let rows: Array<Record>
-    if let view = resolve(view: name), case .setop = view.query,
-        case .setop = plan {
+    let view = resolve(view: name)
+    if let view, case .setop = view.query, case .setop = plan {
       // A SET-OPERATION view body executes each ARM's sub-plan under an overlay
       // AUGMENTED with THAT arm's own derived aliases. A `setop` collects NO
       // derived aliases at the query level (arms are SELECT-scoped), so the
@@ -1337,6 +1399,18 @@ extension Catalog where Self: ~Escapable {
       // materialise would fault `.relation("d")` before an arm ever ran.
       // Mirrors the per-arm run and `SELECT *` arity paths.
       rows = try setop(plan, view.query, overlay, name.lowercased())
+    } else if let view, case .ordered = view.query,
+        case .setop = view.query.core {
+      // The body is a set operation UNDER an `ordered` carrier (`… UNION …
+      // ORDER BY V`), whose plan is a `.shaped` project/sort/distinct stack
+      // over the `.setop`, NOT a bare setop, so BOTH guards above failed and
+      // the arm-local derived aliases went unmaterialised (`.relation`). Pass
+      // the carrier-transparent core to `setop`, which descends the wrapper —
+      // applying each row operator through the SAME executor helpers
+      // `execute(_:carrying:)` uses — to the setop leaf where it per-arm
+      // augments. GATED on the body actually wearing a carrier, so a bare union
+      // view keeps the exact plan-shape dispatch above.
+      rows = try setop(plan, view.query.core, overlay, name.lowercased())
     } else {
       // A single-arm view body's subqueries run LAZILY into the shared memo box
       // the `overlay` carries (recorded above under `.view(name)`), so the
@@ -1386,6 +1460,42 @@ extension Catalog where Self: ~Escapable {
                          setop(right, rightQuery, overlay, name), all,
                          types: types)
     }
+    // An `ordered` view body compiles to a `.shaped` stack of single-source row
+    // operators (`project`/`sort`/`distinct`/`limit`/`select`) OVER the setop,
+    // so descend the wrapper — the SAME nodes `execute(_:carrying:)` descends —
+    // applying each operator through the shared executor helpers, until the
+    // `.setop` node recurses above and per-arm augments. The carrier wrapper
+    // sits ABOVE the setop, so `query` is STILL the `.setop` core here — gate
+    // on that: once the setop splits into an arm (`query` a `.select`), that
+    // plan is the ARM's own sub-plan and must execute AS A UNIT under its own
+    // augment below, NOT be walked through as a carrier wrapper (which would
+    // apply the arm's projection/filter outside its arm-local scope).
+    if case .setop = query {
+      switch plan {
+      case let .project(terms, source):
+        let source = try setop(source, query, overlay, name)
+        var projected = Array<Record>()
+        projected.reserveCapacity(source.count)
+        for record in source {
+          try projected.append(project(terms, record, overlay))
+        }
+        return projected
+      case let .sort(keys, source):
+        return try sorted(setop(source, query, overlay, name), keys, overlay)
+      case let .distinct(source):
+        return deduplicated(try setop(source, query, overlay, name))
+      case let .limit(count, offset, source):
+        return limited(try setop(source, query, overlay, name), count, offset)
+      case let .select(filter, source):
+        return try admitted(setop(source, query, overlay, name), filter,
+                            overlay)
+      default:
+        break
+      }
+    }
+    // A single-arm leaf (a bare `.setop` body's arm, or a carrier wrapper's
+    // innermost source once the setop above has split): augment THIS arm's own
+    // derived aliases and execute its sub-plan under the arm-local scope.
     let scope = try augment(overlay.validating(false), for: query, rows: true)
     scope.subqueries.record(overlay: scope.revealed().relations,
                             for: .view(name))

--- a/Sources/SQLEngine/OutputColumn.swift
+++ b/Sources/SQLEngine/OutputColumn.swift
@@ -49,18 +49,32 @@ internal struct ResolvedColumn: Hashable, Sendable {
   /// so it places NO type constraint on the set-operation's unified column.
   internal let unconstrained: Bool
 
-  internal init(_ column: OutputColumn, unconstrained: Bool = false) {
+  /// Whether this column's NAME is a SYNTHESIZED positional `column N` header
+  /// rather than an inferable output name — the projection had no alias and no
+  /// bare-column name (`Projected.name == nil`), so a display header stood in.
+  /// It is the STRUCTURAL bare/unnamed fact (set where the name is fabricated),
+  /// carried so a consumer distinguishes a synthesized header from a user's
+  /// EXPLICIT delimited `AS "column 1"` — the two are indistinguishable by NAME
+  /// text but not by provenance. The left arm's flag wins a set-operation fold,
+  /// mirroring the ISO first-arm NAME rule.
+  internal let synthesized: Bool
+
+  internal init(_ column: OutputColumn, unconstrained: Bool = false,
+                synthesized: Bool = false) {
     self.column = column
     self.unconstrained = unconstrained
+    self.synthesized = synthesized
   }
 
   /// A resolved column carrying `name` and `type` directly — the declared
   /// carrier a common table expression's self binding is built from, its name
   /// the declared column and its type the `.integer` placeholder a materialised
   /// relation reports.
-  internal init(name: String, type: ValueType, unconstrained: Bool = false) {
+  internal init(name: String, type: ValueType, unconstrained: Bool = false,
+                synthesized: Bool = false) {
     self.column = OutputColumn(name: name, type: type)
     self.unconstrained = unconstrained
+    self.synthesized = synthesized
   }
 
   /// The column's output name.
@@ -94,15 +108,22 @@ internal func merge(_ left: ResolvedColumn, _ right: ResolvedColumn,
                     shape: Bool = false)
     throws(SQLError) -> ResolvedColumn {
   let name = left.column.name
+  // The NAME (and its synthesized-header provenance) is the LEFT arm's — the
+  // ISO first-arm rule — so a union whose first arm names a column `column N`
+  // by synthesis stays synthesized (not bindable), and one whose first arm
+  // names it explicitly stays a real output, regardless of the right arm.
+  let synthesized = left.synthesized
   // A constant-NULL arm constrains nothing: carry the OTHER arm's type (and,
   // when both are NULL, the left's), narrowing the running unconstrained-ness
   // to whether BOTH remaining arms are NULL.
   if left.unconstrained {
     return ResolvedColumn(name: name, type: right.column.type,
-                          unconstrained: right.unconstrained)
+                          unconstrained: right.unconstrained,
+                          synthesized: synthesized)
   }
   if right.unconstrained {
-    return ResolvedColumn(name: name, type: left.column.type)
+    return ResolvedColumn(name: name, type: left.column.type,
+                          synthesized: synthesized)
   }
   guard let unified = left.column.type.unified(with: right.column.type) else {
     // The shape pre-pass defers the operand fault to the reached path: yield a
@@ -110,11 +131,11 @@ internal func merge(_ left: ResolvedColumn, _ right: ResolvedColumn,
     // rather than faulting while merely recording an unreached subquery.
     if shape {
       return ResolvedColumn(name: name, type: left.column.type,
-                            unconstrained: true)
+                            unconstrained: true, synthesized: synthesized)
     }
     throw .operand("UNION arms have irreconcilable types")
   }
-  return ResolvedColumn(name: name, type: unified)
+  return ResolvedColumn(name: name, type: unified, synthesized: synthesized)
 }
 
 extension Catalog where Self: ~Escapable {
@@ -426,6 +447,29 @@ extension Catalog where Self: ~Escapable {
     switch query {
     case let .select(select):
       return try arms(of: select, context)
+    case let .ordered(inner, _, _, _, generated):
+      // The `ordered` carrier is TRANSPARENT to the result schema: `ORDER BY`,
+      // `DISTINCT`, and `OFFSET`/`FETCH` are row operators — they do NOT
+      // project — so the result columns are the inner setop's arm-0-named,
+      // unified ones whether reached via `run`/`compile` or `columns(of:)`
+      // (`run ≡ columns`). The one exception is a HIDDEN materialised sort
+      // column (a producer appends `generated` of them to every arm so an
+      // unprojected sort key survives the union at equal arity): the carrier's
+      // compile TRIMS them through the identity projection, so drop the
+      // matching trailing columns here too so the schema matches the run. The
+      // count is the STRUCTURAL `generated` the carrier carries, never a scan
+      // of the arm-0 names for a synthetic prefix — a user's delimited `AS
+      // "*gs0"` is a real output, not a generated column.
+      let cols = try columns(unifying: inner, context)
+      // Range-check `generated` against the width and take the trim width
+      // through the SHARED guard the compile carrier uses (`real(trimming:of:)`
+      // on Engine) BEFORE trimming: a public-AST count past the width makes
+      // `cols.count − generated` NEGATIVE and `Array.prefix` PRECONDITION-TRAPS
+      // the process, while a NEGATIVE count returns ALL columns untrimmed —
+      // silently wrong and diverging from `run`, which faults the same XX000.
+      // One guard, one message ⇒ `columns(of:) ≡ run` on a malformed carrier.
+      let real = try real(trimming: generated, of: cols.count)
+      return Array(cols.prefix(real))
     case let .setop(_, left, right, _):
       let l = try columns(unifying: left, context)
       let r = try columns(unifying: right, context)
@@ -503,14 +547,30 @@ extension Catalog where Self: ~Escapable {
   /// declared width — the recursive-aware merge `kinds` wraps.
   private borrowing func contributions(of cte: CTE, _ scope: Context)
       throws(SQLError) -> Array<ResolvedColumn> {
-    guard cte.recursive, cte.recurses,
-        case let .setop(.union, anchor, recursive, _) = cte.query else {
+    // Derive types off the SAME AST a run does. (When `GROUP BY GROUPING SETS`
+    // lands, `Query.expanded` is re-inserted here so a grouping-sets body
+    // lowers to its `UNION ALL` arms FIRST, matching `run`/`compile` — a one-
+    // token merge follow-up, not needed here.)
+    let body = cte.query
+    // Recognise the recursive `UNION` shape through the CANONICAL peel
+    // (`recursiveArms` — unwound), the SAME recogniser the run/validate/
+    // fixpoint recursive-CTE seams take (`CTE.recurses`, `fixpoint`'s
+    // `canonical`), so the schema derive inspects the identical AST the run
+    // does — a trailing `ORDER BY`/`OFFSET`·`FETCH`/`DISTINCT` carrier peeled
+    // off. Otherwise a carried recursive union would fall through to the non-
+    // recursive fold with the self UNBOUND and fault `.relation`, diverging
+    // from the run that iterates the fixpoint. The carrier is transparent to
+    // the derived schema (its row operators do not project), so peeling it
+    // yields the same columns.
+    guard let (anchor, recursive, _) = try cte.recursiveArms else {
       // A non-recursive body's carrier is its unified fold, PROPAGATING a
       // genuine incompatibility (`SELECT 'b' UNION SELECT 1`) as `.operand`
       // rather than swallowing it into the declared `.integer`: with every
       // placeholder now marked unconstrained, a trusted body that RAN carries
-      // no genuine incompat to fault, so no `try?` fallback is needed.
-      return try columns(unifying: cte.query, scope)
+      // no genuine incompat to fault, so no `try?` fallback is needed. The
+      // carrier is transparent to a non-recursive body's fold too — the
+      // `.ordered` case of `columns(unifying:)` peels it identically.
+      return try columns(unifying: body, scope)
     }
     let seeds = try columns(unifying: anchor, scope)
     // The recursive arm addresses the self by the CTE's DECLARED names (`SELECT
@@ -664,6 +724,26 @@ extension Catalog where Self: ~Escapable {
       // enclosing scope, so each type-checks under the shared `context.outer`.
       try typecheck(left, context)
       try typecheck(right, context)
+    case let .ordered(inner, distinct, order, limit, generated):
+      // The `ordered` carrier's row operators add no expression the arms carry
+      // — the inner union type-checks every reachable operand of its own arms.
+      try typecheck(inner, context)
+      // But the carrier's OWN `ORDER BY` keys are a NEW expression surface,
+      // validated ONLY by the carrier compile (`ordered(…)` under `validate`).
+      // A REACHED scalar/`IN` subquery whose body is an ordered set operation
+      // is first compiled in the shape pre-pass with `validating(false)`, which
+      // BYPASSES that check, and is re-validated through THIS seam — so unless
+      // the carrier's keys are validated here too, an outer `columns(of:)`
+      // ACCEPTS a reached `(… UNION … ORDER BY missing(a))` a run FAULTS
+      // (run-vs-validate divergence). Re-run the carrier compile in validate
+      // mode to validate the sort keys against the setop-output scope EXACTLY
+      // as `ordered(…)` does — the plan is discarded, only the keys' fault
+      // matters. It is idempotent with the top-level `compile` (which already
+      // validated the same keys), and REACHED-only: an unreached ordered
+      // subquery never enters this seam, so its bad sort key stays deferred,
+      // matching the dead-scalar/dead-EXISTS posture.
+      _ = try ordered(inner, distinct: distinct, order: order, limit: limit,
+                      generated: generated, context.validating(true))
     }
   }
 
@@ -814,10 +894,10 @@ extension Catalog where Self: ~Escapable {
   /// `widths`/`types` against the `nested` outer scope, and enforces a scalar
   /// occurrence's single-column ARITY EAGERLY (reachability-independent, as the
   /// run's lowering does). Computed ONCE per distinct query at a given site.
-  private borrowing func width(_ query: Query, _ scalar: Set<Query>,
-                               _ context: Context, _ nested: Outer?,
-                               _ widths: inout Dictionary<Query, Int>,
-                               _ types: inout Dictionary<Query, ValueType>)
+  internal borrowing func width(_ query: Query, _ scalar: Set<Query>,
+                                _ context: Context, _ nested: Outer?,
+                                _ widths: inout Dictionary<Query, Int>,
+                                _ types: inout Dictionary<Query, ValueType>)
       throws(SQLError) {
     // The width and single-column type derive for EVERY subquery — cursor-free
     // and TOTAL for a clean-resolving inner query (deriving the type of `1 / 0`
@@ -1454,6 +1534,13 @@ extension Scope {
                        _ routines: Routines = [:],
                        subquery: Resolution = .unsupported)
       throws(SQLError) -> ResolvedColumn {
+    // The item's inferable output NAME (`Projected.name` — an alias, else a
+    // bare column's name), or a SYNTHESIZED positional `column N` header when
+    // it has none. `synthesized` is that STRUCTURAL bare/unnamed fact — carried
+    // on the resolved column so a consumer (the `ordered` set-op carrier)
+    // distinguishes this fabricated header from a user's explicit delimited
+    // `AS "column 1"`, which by NAME text is identical but is a real output.
+    let synthesized = item.name == nil
     let name = item.name ?? "column \(index + 1)"
     // A projection places NO type constraint on the unified column when it
     // folds to a CONSTANT NULL for every row (`null` — its derived literal-fix
@@ -1468,7 +1555,7 @@ extension Scope {
         || unresolved(item.expression, routines) {
       let type = try derive(item.expression, routines, subquery: subquery)
       return ResolvedColumn(OutputColumn(name: name, type: type),
-                            unconstrained: true)
+                            unconstrained: true, synthesized: synthesized)
     }
     // A bare-column projection reuses the ONE column resolution — LOCAL or
     // CORRELATED — so its type and `unconstrained` mask agree, renaming only
@@ -1476,7 +1563,8 @@ extension Scope {
     if case let .column(column) = item.expression {
       let resolved = try output(of: column, subquery: subquery)
       return ResolvedColumn(OutputColumn(name: name, type: resolved.type),
-                            unconstrained: resolved.unconstrained)
+                            unconstrained: resolved.unconstrained,
+                            synthesized: synthesized)
     }
     // A bare scalar-subquery projection reuses the subquery's OWN resolved
     // column — its type AND `unconstrained` mask — so a constant-NULL body
@@ -1488,7 +1576,8 @@ extension Scope {
     if case let .subquery(query) = item.expression {
       let resolved = try subquery.scalar(resolved: query)
       return ResolvedColumn(OutputColumn(name: name, type: resolved.type),
-                            unconstrained: resolved.unconstrained)
+                            unconstrained: resolved.unconstrained,
+                            synthesized: synthesized)
     }
     // DERIVE the nominal output type: the schema reports the type a run would
     // produce and never faults on an operand. Run-time operand and call
@@ -1499,6 +1588,7 @@ extension Scope {
     return try ResolvedColumn(OutputColumn(name: name,
                                            type: derive(item.expression,
                                                         routines,
-                                                        subquery: subquery)))
+                                                        subquery: subquery)),
+                              synthesized: synthesized)
   }
 }

--- a/Sources/SQLEngine/Parser.swift
+++ b/Sources/SQLEngine/Parser.swift
@@ -236,7 +236,70 @@ internal struct Parser: ~Escapable {
       let all = try match(.all)
       query = try .setop(kind, query, intersection(), all: all)
     }
-    return query
+    // ISO 9075: an `ORDER BY` / `OFFSET`·`FETCH` after a set-operation chain
+    // applies to the WHOLE result, not the trailing arm — an individual arm
+    // needs its own parentheses to carry one. The recursive-descent parse folds
+    // that trailing tail onto the LAST arm's `select` (a `select` greedily
+    // consumes its ORDER BY/limit); LIFT it here to the query-level `ordered`
+    // carrier over the union, where it resolves through the setop's OUTPUT
+    // scope (`Catalog.ordered`) rather than binding the last arm's columns. A
+    // set operation carries no query-level `DISTINCT` in plain SQL (a bare
+    // `UNION` already dedups), so only the ORDER BY and limit are lifted.
+    //
+    // Gate on the top-level `query` being a set operation, NOT on the
+    // `UNION`/`EXCEPT` loop above having run: a top-level chain of only
+    // `INTERSECT` (or `EXCEPT`) is built inside `intersection()` and never
+    // enters this loop, yet its trailing `ORDER BY` must lift onto the combined
+    // output all the same — otherwise it stays on the last arm and binds that
+    // arm's columns rather than the intersect result named by the first arm.
+    guard case .setop = query else { return query }
+    // The trailing tail reaches the query level by two routes. When the last
+    // arm is a `SELECT`, that arm's greedy `select()` already CONSUMED the
+    // `ORDER BY`/limit, so it sits on the rightmost arm and is LIFTED here (and
+    // trimmed off the arm, so it applies once). When the last arm is a `TABLE
+    // t`/`VALUES …` primary — neither carries a primary-level order (see
+    // `term`) — the tail is UNCONSUMED at this point, so parse it HERE. Either
+    // way the tail lands on the `ordered` carrier over the union, resolved
+    // through the setop's OUTPUT scope, not the last arm's columns.
+    let last = trailing(query)
+    if last.order != nil || last.limit != nil {
+      return .ordered(trim(query), distinct: false, order: last.order,
+                      limit: last.limit, generated: 0)
+    }
+    let order: Order? = try match(.order) ? try self.order() : nil
+    let limit = try rowLimit()
+    guard order != nil || limit != nil else { return query }
+    return .ordered(query, distinct: false, order: order, limit: limit,
+                    generated: 0)
+  }
+
+  /// The RIGHTMOST arm's `Select` of a set-operation `query` — the arm the
+  /// recursive-descent parse folds a trailing query-level `ORDER BY`/limit
+  /// onto, reached by descending each set operation's RIGHT term.
+  private func trailing(_ query: Query) -> Select {
+    switch query {
+    case let .select(select): select
+    case let .setop(_, _, right, _): trailing(right)
+    case let .ordered(inner, _, _, _, _): trailing(inner)
+    }
+  }
+
+  /// `query` with its LAST arm's `order`/`limit` cleared — the query-level tail
+  /// a set-operation `query` lifted onto the `ordered` carrier, removed from
+  /// the arm that greedily parsed it so it is applied ONCE, over the union.
+  private func trim(_ query: Query) -> Query {
+    switch query {
+    case let .select(select):
+      .select(Select(distinct: select.distinct, projection: select.projection,
+                     from: select.from, joins: select.joins,
+                     predicate: select.predicate, grouping: select.grouping,
+                     having: select.having, order: nil, limit: nil))
+    case let .setop(kind, left, right, all):
+      .setop(kind, left, trim(right), all: all)
+    case let .ordered(inner, distinct, order, limit, generated):
+      .ordered(trim(inner), distinct: distinct, order: order, limit: limit,
+               generated: generated)
+    }
   }
 
   /// Parses `term (INTERSECT [ALL] term)*`, the inner set-operation tier,

--- a/Tests/SQLTests/Queries/EngineWithTests.swift
+++ b/Tests/SQLTests/Queries/EngineWithTests.swift
@@ -423,6 +423,105 @@ struct EngineRecursiveTests {
     #expect(rows == [[.integer(1)], [.integer(2)], [.integer(3)]])
   }
 
+  @Test func `an ordered recursive CTE derives its schema and runs the fixpoint`()
+      throws {
+    // A trailing `ORDER BY` on a recursive body lifts to a `Query.ordered`
+    // carrier over the `UNION` setop. `columns(of:)` must peel the carrier at
+    // its recursive-shape recogniser (like the run's `fixpoint`) and derive the
+    // one column `n` WITHOUT faulting `.relation("t")`, while the run iterates
+    // the fixpoint to `1,2,3` — asserted TOGETHER on the SAME query so a
+    // run-vs-schema divergence cannot hide.
+    let statement = try Statement(parsing: """
+        WITH RECURSIVE t (n) AS (
+          SELECT 1 UNION ALL SELECT n + 1 FROM t WHERE n < 3 ORDER BY 1
+        ) SELECT n FROM t
+        """)
+    let columns = try family().columns(of: statement, validate: true)
+    #expect(columns.count == 1)
+    #expect(columns[0].name == "n")
+    #expect(columns[0].type == .integer)
+    let rows = try family().run(statement)
+    #expect(rows == [[.integer(1)], [.integer(2)], [.integer(3)]])
+  }
+
+  @Test func `a recursive CTE carrier ORDER BY runs a correlated sort-key subquery`()
+      throws {
+    // The carrier `ORDER BY` peeled off a recursive-CTE fixpoint is applied to
+    // the materialised rows through `carried(over:)`, which RECORDS a sort key
+    // CORRELATED to the set-op output (`EXISTS (… WHERE V = x)`) into the
+    // context's `Subqueries` box, and then EXECUTED — but `apply` used to
+    // execute against a FRESH empty box, so the executor found no recorded plan
+    // and faulted `a correlated subquery plan was not compiled` (wrapped as a
+    // view-column fault here). `apply` now threads ONE fresh box through BOTH
+    // `carried` and `execute`, so the recorded plan is read back and re-run.
+    //
+    // The fixpoint anchors at 1, then n+1 while n < 3, materialising 1,2,3. The
+    // trailing carrier sorts by CASE: a row whose value is in `S` gets key 0
+    // (first), else key 1. With `S = {2}` only n=2 sorts first; n=1 and n=3
+    // keep their fixpoint order among the equal key-1 rows (stable), so the
+    // result is 2, then 1, 3.
+    let catalog = try Catalog {
+      Relation("S", ["V": .integer]) {
+        Row(2)
+      }
+    }
+    let rows = try catalog.run(Statement(parsing: """
+        WITH RECURSIVE t(n) AS (
+          SELECT 1 AS x
+          UNION ALL
+          SELECT n + 1 FROM t WHERE n < 3
+          ORDER BY CASE WHEN EXISTS (SELECT V FROM S WHERE V = x)
+                        THEN 0 ELSE 1 END
+        ) SELECT n FROM t
+        """))
+    #expect(rows == [[.integer(2)], [.integer(1)], [.integer(3)]])
+  }
+
+  @Test func `a recursive CTE carrier ORDER BY on a plain sort key still runs`()
+      throws {
+    // GUARD: the memo fix must not regress a NON-correlated carrier sort key.
+    // The same fixpoint (1,2,3), ordered by the plain output column `x`
+    // descending (the set-op output takes arm-0's projection name), still runs
+    // and reorders — the shared fresh box carries no recorded plan here, and
+    // none is needed.
+    let catalog = try Catalog {
+      Relation("S", ["V": .integer]) {
+        Row(2)
+      }
+    }
+    let rows = try catalog.run(Statement(parsing: """
+        WITH RECURSIVE t(n) AS (
+          SELECT 1 AS x
+          UNION ALL
+          SELECT n + 1 FROM t WHERE n < 3
+          ORDER BY x DESC
+        ) SELECT n FROM t
+        """))
+    #expect(rows == [[.integer(3)], [.integer(2)], [.integer(1)]])
+  }
+
+  @Test func `a recursive CTE carrier ORDER BY on a missing column still faults`()
+      throws {
+    // GUARD: restoring the subquery memo must NOT mask a real resolution error.
+    // A carrier `ORDER BY` naming a column that is neither the set-op output
+    // nor any relation in scope still faults `SQLError.column` at run.
+    let catalog = try Catalog {
+      Relation("S", ["V": .integer]) {
+        Row(2)
+      }
+    }
+    #expect(throws: SQLError.column("Zzz")) {
+      _ = try catalog.run(Statement(parsing: """
+          WITH RECURSIVE t(n) AS (
+            SELECT 1 AS x
+            UNION ALL
+            SELECT n + 1 FROM t WHERE n < 3
+            ORDER BY Zzz
+          ) SELECT n FROM t
+          """))
+    }
+  }
+
   @Test func `a non-UNION recursive CTE validates its compiled width`() throws {
     // A `WITH RECURSIVE` member whose body is not a UNION runs once, but must
     // still match its declared arity. Here the body resolves `Parent` against
@@ -997,5 +1096,331 @@ struct EngineRecursiveTests {
         WITH a(x) AS (SELECT 1 UNION SELECT 2.5) SELECT x FROM a ORDER BY x
         """, family())
     #expect(rows == [[.double(1.0)], [.double(2.5)]])
+  }
+
+  @Test func `a trailing ORDER BY on a recursive body still runs the fixpoint`()
+      throws {
+    // The body's set operation wears a query-level `ORDER BY` — an `ordered`
+    // carrier OVER the `UNION`. The recursive-shape recogniser and the fixpoint
+    // router peel the carrier to find the inner setop, so the recursive arm
+    // compiles with the CTE `t` in scope and the fixpoint iterates, rather than
+    // reading as non-recursive and faulting `.relation('t')`.
+    let rows = try seed().run(try Statement(parsing: """
+        WITH RECURSIVE t (n) AS (
+          SELECT 1 AS n FROM Seed
+          UNION ALL
+          SELECT inc(n) AS n FROM t WHERE n < 3
+          ORDER BY 1
+        )
+        SELECT n FROM t
+        """), counting())
+    #expect(rows == [[.integer(1)], [.integer(2)], [.integer(3)]])
+  }
+
+  @Test func `an ordered recursive body equals its unordered form as a set`()
+      throws {
+    // The trailing carrier does not change the fixpoint's MEMBERSHIP — the same
+    // recursive CTE without the ORDER BY yields the same rows (here already in
+    // order), so the ordered body matches the unordered one modulo ordering.
+    let unordered = try seed().run(try Statement(parsing: """
+        WITH RECURSIVE t (n) AS (
+          SELECT 1 AS n FROM Seed
+          UNION ALL
+          SELECT inc(n) AS n FROM t WHERE n < 3
+        )
+        SELECT n FROM t ORDER BY n
+        """), counting())
+    #expect(unordered == [[.integer(1)], [.integer(2)], [.integer(3)]])
+  }
+
+  @Test func `the carrier's ORDER BY applies to the fixpoint result`() throws {
+    // A named descending key on the carrier orders the materialised fixpoint
+    // result — the peeled carrier is reapplied to the result rows through the
+    // ordinary select path, resolving the key `n` against the output columns.
+    let rows = try seed().run(try Statement(parsing: """
+        WITH RECURSIVE t (n) AS (
+          SELECT 1 AS n FROM Seed
+          UNION ALL
+          SELECT inc(n) AS n FROM t WHERE n < 3
+          ORDER BY n DESC
+        )
+        SELECT n FROM t
+        """), counting())
+    #expect(rows == [[.integer(3)], [.integer(2)], [.integer(1)]])
+  }
+
+  @Test func `a non-recursive ordered CTE body still materialises`() throws {
+    // The carrier peel is transparent to a non-recursive CTE: a trailing ORDER
+    // BY on a plain (non-self-naming) UNION body still materialises once.
+    let rows = try seed().run(try Statement(parsing: """
+        WITH t (n) AS (
+          SELECT 1 FROM Seed UNION SELECT 2 FROM Seed ORDER BY 1
+        )
+        SELECT n FROM t ORDER BY n
+        """), counting())
+    #expect(rows == [[.integer(1)], [.integer(2)]])
+  }
+
+  @Test func `a renaming recursive body orders by its first-arm output name`()
+      throws {
+    // The body's set-op output is named off its FIRST arm (`SELECT 1 AS x`), so
+    // the carrier's `ORDER BY x` resolves against that OUTPUT name `x`, not the
+    // CTE's DECLARED name `n` — EXACTLY as the non-recursive analog below does.
+    // The fixpoint temp the carrier applies over is named by the anchor's
+    // output names; the CTE-declared rename rides the returned carrier, so the
+    // outer `SELECT n FROM t` still sees `n`. Assert schema AND run on the SAME
+    // query so a run-vs-validate divergence cannot hide.
+    let statement = try Statement(parsing: """
+        WITH RECURSIVE t (n) AS (
+          SELECT 1 AS x UNION ALL SELECT n + 1 FROM t WHERE n < 3 ORDER BY x
+        ) SELECT n FROM t
+        """)
+    let catalog = EngineMemory([:])
+    let columns = try catalog.columns(of: statement, validate: true)
+    #expect(columns.count == 1)
+    #expect(columns[0].name == "n")
+    let rows = try catalog.run(statement)
+    #expect(rows == [[.integer(1)], [.integer(2)], [.integer(3)]])
+  }
+
+  @Test func `a non-recursive ordered CTE body orders by its output name`()
+      throws {
+    // The non-recursive ANALOG of the renaming recursive body: `ORDER BY x`
+    // resolves against the first arm's output `x`. This is the ORACLE the
+    // recursive form mirrors — the two paths must agree.
+    let statement = try Statement(parsing: """
+        WITH t (n) AS (SELECT 1 AS x UNION ALL SELECT 2 ORDER BY x)
+        SELECT n FROM t
+        """)
+    let catalog = EngineMemory([:])
+    let rows = try catalog.run(statement)
+    #expect(rows == [[.integer(1)], [.integer(2)]])
+  }
+
+  @Test func `a recursive carrier ORDER BY of a non-output name faults`()
+      throws {
+    // `ORDER BY n` names the CTE's DECLARED name, NOT a body output (the first
+    // arm projects `x`), so the carrier — which resolves against the body's
+    // OUTPUT names — faults `.column('n')` on the schema path, exactly as the
+    // RUN does when `apply` reapplies the carrier after the fixpoint (`run ≡
+    // columns(of:)`), and exactly as the non-recursive analog below faults.
+    let statement = try Statement(parsing: """
+        WITH RECURSIVE t (n) AS (
+          SELECT 1 AS x UNION ALL SELECT n + 1 FROM t WHERE n < 3 ORDER BY n
+        ) SELECT n FROM t
+        """)
+    let catalog = EngineMemory([:])
+    #expect(throws: SQLError.column("n")) {
+      _ = try catalog.columns(of: statement, validate: true)
+    }
+    #expect(throws: SQLError.column("n")) {
+      _ = try catalog.run(statement)
+    }
+  }
+
+  @Test func `a non-recursive carrier ORDER BY of a non-output name faults`()
+      throws {
+    // The non-recursive ORACLE: `ORDER BY n` (the declared name, not the first
+    // arm's output `x`) faults `.column('n')`, the behaviour the recursive form
+    // mirrors.
+    let statement = try Statement(parsing: """
+        WITH t (n) AS (SELECT 1 AS x UNION ALL SELECT 2 ORDER BY n)
+        SELECT n FROM t
+        """)
+    let catalog = EngineMemory([:])
+    #expect(throws: SQLError.column("n")) {
+      _ = try catalog.run(statement)
+    }
+  }
+
+  @Test func `a recursive carrier ORDER BY validates its keys like the run`()
+      throws {
+    // The recursive validate path validates the carrier's ORDER BY keys against
+    // the body's output scope, the SAME check an ordinary ordered set operation
+    // gets. A carrier `ORDER BY missing(n)` — where `n` IS a body output
+    // (`SELECT 1 AS n`) — faults `.function('missing')` on BOTH the schema path
+    // (`columns(of:validate:true)`) AND the run (`run ≡ columns(of:)`), closing
+    // the run-vs-validate gap where validate passed yet the run faulted when
+    // `apply` reapplied the carrier after the fixpoint.
+    let statement = try Statement(parsing: """
+        WITH RECURSIVE t (n) AS (
+          SELECT 1 AS n UNION ALL SELECT n + 1 FROM t WHERE n < 3
+          ORDER BY missing(n)
+        ) SELECT n FROM t
+        """)
+    let catalog = EngineMemory([:])
+    #expect(throws: SQLError.function("missing")) {
+      _ = try catalog.columns(of: statement, validate: true)
+    }
+    #expect(throws: SQLError.function("missing")) {
+      _ = try catalog.run(statement)
+    }
+  }
+
+  @Test func `a valid recursive carrier ORDER BY validates and runs`() throws {
+    // The positive companion: a carrier key that IS a body output (`ORDER BY n`
+    // over an anchor `SELECT 1 AS n`) validates AND runs the fixpoint, ordered
+    // by that output — the valid-key half of the run≡validate oracle.
+    let statement = try Statement(parsing: """
+        WITH RECURSIVE t (n) AS (
+          SELECT 1 AS n UNION ALL SELECT n + 1 FROM t WHERE n < 3
+          ORDER BY n DESC
+        ) SELECT n FROM t
+        """)
+    let catalog = EngineMemory([:])
+    let columns = try catalog.columns(of: statement, validate: true)
+    #expect(columns.count == 1)
+    #expect(columns[0].name == "n")
+    let rows = try catalog.run(statement)
+    #expect(rows == [[.integer(3)], [.integer(2)], [.integer(1)]])
+  }
+
+  @Test func `a recursive carrier ORDER BY of a projected expression resolves like the non-recursive analog`()
+      throws {
+    // The recursive carrier now routes through the SAME `carried(over:)`
+    // resolver the ordinary ordered set-operation path uses, so a projected-
+    // EXPRESSION sort key (`Age * 1`) is matched against the first arm's
+    // projected item and orders on the MATERIALISED output column — never a
+    // bare `SELECT * FROM <temp>` that re-evaluates `Age * 1` over a temp
+    // lacking `Age` (which faulted `.column('Age')`). The recursive fixpoint
+    // runs `{1, 2, 3}` ordered ascending; its non-recursive ordered-set-op
+    // analog resolves the identical key against the same projection surface
+    // WITHOUT faulting — the run≡run oracle the shared resolver guarantees.
+    let people = EngineMemory([
+      "People": FixtureRelation([EngineField(name: "Age", type: .integer)],
+                                [[.integer(1)]] as Array<Array<Value>>),
+    ])
+    let recursive = try Statement(parsing: """
+        WITH RECURSIVE t (k) AS (
+          SELECT Age * 1 AS m FROM People WHERE Age = 1
+          UNION ALL SELECT k + 1 FROM t WHERE k < 3 ORDER BY Age * 1
+        ) SELECT k FROM t
+        """)
+    #expect(try people.run(recursive) == [[.integer(1)], [.integer(2)],
+                                          [.integer(3)]])
+    // The non-recursive analog resolves the SAME `Age * 1` projected-expression
+    // key against the same arm-0 surface and runs without faulting.
+    let analog = try Statement(parsing: """
+        SELECT Age * 1 AS m FROM People WHERE Age = 1
+        UNION ALL SELECT 9 ORDER BY Age * 1
+        """)
+    #expect(try people.run(analog) == [[.integer(1)], [.integer(9)]])
+  }
+
+  @Test func `a recursive carrier ORDER BY of an aliased output resolves on the output column`()
+      throws {
+    // The aliased sub-case: the anchor projects `Age * 2 AS m` and the carrier
+    // orders by the ALIAS `m`, which the setop-output scope binds directly to
+    // the output column — the same path the ordinary carrier takes.
+    let people = EngineMemory([
+      "People": FixtureRelation([EngineField(name: "Age", type: .integer)],
+                                [[.integer(1)]] as Array<Array<Value>>),
+    ])
+    let statement = try Statement(parsing: """
+        WITH RECURSIVE t (k) AS (
+          SELECT Age * 2 AS m FROM People WHERE Age = 1
+          UNION ALL SELECT k + 1 FROM t WHERE k < 4 ORDER BY m
+        ) SELECT k FROM t
+        """)
+    #expect(try people.run(statement) == [[.integer(2)], [.integer(3)],
+                                          [.integer(4)]])
+  }
+
+  @Test func `a recursive carrier ORDER BY of a qualified column resolves on the output`()
+      throws {
+    // The qualified sub-case: `p.Age` drops its qualifier (a set-operation
+    // result carries none) and binds the bare output the anchor projects, as
+    // the ordinary carrier's qualifier strip does.
+    let people = EngineMemory([
+      "People": FixtureRelation([EngineField(name: "Age", type: .integer)],
+                                [[.integer(1)]] as Array<Array<Value>>),
+    ])
+    let statement = try Statement(parsing: """
+        WITH RECURSIVE t (Age) AS (
+          SELECT p.Age FROM People p WHERE p.Age = 1
+          UNION ALL SELECT Age + 1 FROM t WHERE Age < 3 ORDER BY p.Age
+        ) SELECT Age FROM t
+        """)
+    #expect(try people.run(statement) == [[.integer(1)], [.integer(2)],
+                                          [.integer(3)]])
+  }
+
+  @Test func `a recursive carrier ORDER BY of an ordinal orders the fixpoint`()
+      throws {
+    // The ordinal sub-case still resolves through the shared resolver: `ORDER
+    // BY 1` binds the first output column, ordering the fixpoint descending.
+    let statement = try Statement(parsing: """
+        WITH RECURSIVE t (n) AS (
+          SELECT 1 AS n
+            UNION ALL SELECT n + 1 FROM t WHERE n < 3 ORDER BY 1 DESC
+        ) SELECT n FROM t
+        """)
+    #expect(try EngineMemory([:]).run(statement) == [[.integer(3)],
+                                                     [.integer(2)],
+                                                     [.integer(1)]])
+  }
+
+  @Test func `a recursive EXCEPT body faults the ISO recursion diagnostic`()
+      throws {
+    // ISO 9075 permits recursion only through `UNION [ALL]`. A recursive body
+    // that is `EXCEPT` (not `UNION`) referencing itself has no recursive arm to
+    // iterate, so it once compiled with the self UNBOUND and faulted a generic
+    // `SQLError.relation('t')`. It now faults the precise `0A000` feature
+    // diagnostic on BOTH the run and the schema path.
+    let statement = try Statement(parsing: """
+        WITH RECURSIVE t (n) AS (SELECT n FROM t EXCEPT SELECT 1)
+          SELECT n FROM t
+        """)
+    let catalog = EngineMemory([:])
+    #expect(throws: SQLError.state("0A000", "recursion requires UNION [ALL]")) {
+      _ = try catalog.run(statement)
+    }
+    #expect(throws: SQLError.state("0A000", "recursion requires UNION [ALL]")) {
+      _ = try catalog.columns(of: statement, validate: true)
+    }
+  }
+
+  @Test func `a recursive INTERSECT body faults the ISO recursion diagnostic`()
+      throws {
+    // The `INTERSECT` sibling faults the same `0A000` — the guard matches any
+    // non-`UNION` self-referencing setop core.
+    let statement = try Statement(parsing: """
+        WITH RECURSIVE t (n) AS (SELECT n FROM t INTERSECT SELECT 1)
+          SELECT n FROM t
+        """)
+    #expect(throws: SQLError.state("0A000", "recursion requires UNION [ALL]")) {
+      _ = try EngineMemory([:]).run(statement)
+    }
+  }
+
+  @Test func `a recursive EXCEPT over a same-named base runs once, not the ISO fault`()
+      throws {
+    // The reference reads a same-named BASE relation, so the body is a valid
+    // run-once query, not a recursion — the `0A000` guard exempts it (as the
+    // misplaced-anchor guard does). `Parent EXCEPT {2}` = {1}.
+    let catalog = EngineMemory([
+      "t": FixtureRelation([EngineField(name: "n", type: .integer)],
+                       [[.integer(1)], [.integer(2)]] as Array<Array<Value>>),
+    ])
+    let statement = try Statement(parsing: """
+        WITH RECURSIVE t (n) AS (SELECT n FROM t EXCEPT SELECT 2)
+          SELECT n FROM t
+        """)
+    #expect(try catalog.run(statement) == [[.integer(1)]])
+  }
+
+  @Test func `a plain recursive UNION is unchanged by the ISO recursion guard`()
+      throws {
+    // The regression guard: a genuine recursive `UNION` still iterates its
+    // fixpoint — the `0A000` non-`UNION` guard fires only on a non-`UNION`
+    // core.
+    let statement = try Statement(parsing: """
+        WITH RECURSIVE t (n) AS (
+          SELECT 1 UNION ALL SELECT n + 1 FROM t WHERE n < 3
+        ) SELECT n FROM t
+        """)
+    #expect(try EngineMemory([:]).run(statement) == [[.integer(1)],
+                                                     [.integer(2)],
+                                                     [.integer(3)]])
   }
 }

--- a/Tests/SQLTests/Queries/OrderedSetOperationCarrierTests.swift
+++ b/Tests/SQLTests/Queries/OrderedSetOperationCarrierTests.swift
@@ -1,0 +1,515 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+import SQLEngine
+import SQLTestSupport
+
+// A `Query.ordered` carrier wraps a set operation with the query-level row
+// operators (`ORDER BY`/`DISTINCT`/`OFFSET`·`FETCH`); it compiles to a
+// `.shaped` project/sort/distinct/limit stack over the `.setop`, NOT a bare
+// `.setop`. Several correlated-subquery and view seams matched `if case .setop
+// = <query>`/`if case .setop = <plan>` DIRECTLY, silently swallowing the
+// carrier — a correlated ordered set-op subquery (its plan a `.shaped` stack)
+// never reached the per-arm augment, so an arm-local derived alias went
+// unmaterialised (`.relation`), and a reached irreconcilable pair skipped its
+// strict re-fold (run/validate diverged). These seams now route through the
+// carrier-transparent core (`Query.core`) and the shared carrier descender
+// (`execute(_:carrying:)` / the view `setop` and `optimise` per-arm helpers),
+// so carrier transparency is a construction guarantee. Each test pairs the
+// ORDERED shape with its BARE (non-carrier) baseline to show the two agree.
+
+// MARK: - Fixtures
+
+/// A `People` catalog plus a single-column `S` for correlated ordered set-op
+/// subqueries: `People` seeds the correlation, `S` an arm source.
+private func people() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("People", ["Id": .integer, "Name": .text, "Age": .integer],
+             sorted: "Id") {
+      Row(1, "Alice", 30)
+      Row(2, "Bob", 25)
+    }
+    Relation("S", ["V": .integer]) {
+      Row(7)
+      Row(8)
+    }
+  }
+}
+
+/// A catalog whose view bodies are set operations — one riding an `ORDER BY`
+/// carrier, one bare — each arm naming its OWN arm-local derived table `d`, so
+/// the per-arm augmentation must materialise it before the arm's scan reads it.
+private func views() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("S", ["V": .integer]) {
+      Row(7)
+      Row(8)
+    }
+    try View("ordered", """
+        SELECT * FROM (SELECT V FROM S) AS d
+        UNION ALL SELECT V FROM S ORDER BY V
+        """, as: ["V"])
+    try View("bare", """
+        SELECT * FROM (SELECT V FROM S) AS d UNION ALL SELECT V FROM S
+        """, as: ["V"])
+  }
+}
+
+// MARK: - Tests
+
+struct OrderedSetOperationCarrierTests {
+  @Test func `a correlated IN over an ordered set op materialises each arm's derived table`()
+      throws {
+    // GAP-A2: the correlated `IN (…)` subquery is a set operation UNDER an ORDER
+    // BY carrier, so its plan is a `.shaped` stack — `if case .setop = plan` was
+    // false, so it fell to the whole-query augment, which binds NO arm-local
+    // derived alias (a setop collects none), and arm-0's `.scan("x")` faulted
+    // `.relation('x')`. It now routes through `execute(_:carrying:)`, per-arm
+    // augmenting `x` before the arm scan. Alice (Age 30) matches the arm value.
+    try people().expect("""
+        SELECT Id FROM People p WHERE p.Age IN
+          (SELECT V FROM (SELECT 30 AS V) AS x WHERE x.V = p.Age
+           UNION SELECT 99 ORDER BY 1)
+        """, yields: [[1]])
+  }
+
+  @Test func `a bare correlated IN set op materialises each arm's derived table`()
+      throws {
+    // The non-ordered baseline (a bare `.setop` plan) already worked — the
+    // ordered form now matches it EXACTLY.
+    try people().expect("""
+        SELECT Id FROM People p WHERE p.Age IN
+          (SELECT V FROM (SELECT 30 AS V) AS x WHERE x.V = p.Age
+           UNION SELECT 99)
+        """, yields: [[1]])
+  }
+
+  @Test func `an ordered set-op view materialises each arm's derived table`()
+      throws {
+    // GAP-A3/A4: a view body that is a set operation UNDER an ORDER BY carrier
+    // compiles to a `.shaped` plan, so BOTH the view execute (`derive`) and the
+    // view optimiser (`optimise(view:)`) guards (`case .setop = view.query` and
+    // `case .setop = plan`) failed and the per-arm augment was skipped —
+    // arm-0's `.scan("d")` faulted `.relation('d')`. Both now descend the
+    // carrier wrapper to the setop leaf. `S` = {7, 8}, so the UNION ALL of the
+    // derived `d` arm and the `S` arm, ordered, is 7, 7, 8, 8.
+    try views().expect("SELECT * FROM ordered", yields: [[7], [7], [8], [8]])
+  }
+
+  @Test func `a bare set-op view materialises each arm's derived table`()
+      throws {
+    // The non-ordered baseline (a bare `.setop` view body) already worked; it
+    // yields the same MULTISET as the ordered form, but UNSORTED — the two arms
+    // in source order: the derived `d` arm ({7, 8}) then the `S` arm ({7, 8}).
+    try views().expect("SELECT * FROM bare", yields: [[7], [8], [7], [8]])
+  }
+
+  @Test func `a reached correlated scalar ordered set op faults on irreconcilable arms`()
+      throws {
+    // GAP-A1: a REACHED correlated scalar subquery over an ordered set operation
+    // with irreconcilable arms (text `'x'` beside integer `1`) skipped the
+    // strict operand re-fold — `if case .setop = key.query` was false for the
+    // `.ordered` carrier — so the run returned rows where the uncorrelated form
+    // faults, a run-vs-validate divergence. It now folds on `key.query.core`,
+    // faulting `.operand`/42804 as the uncorrelated form does.
+    try people().expect("""
+        SELECT Id FROM People p WHERE p.Age =
+          (SELECT 'x' FROM S WHERE S.V = p.Id UNION SELECT 1 FROM S ORDER BY 1)
+        """, fails: .operand("UNION arms have irreconcilable types"))
+  }
+
+  @Test func `a reached correlated IN ordered set op faults on irreconcilable arms`()
+      throws {
+    // The `.valued` (`IN`) reach re-folds too — a reached irreconcilable
+    // ordered set-op `IN` faults identically.
+    try people().expect("""
+        SELECT Id FROM People p WHERE p.Age IN
+          (SELECT 'x' FROM S WHERE S.V = p.Id UNION SELECT 1 FROM S ORDER BY 1)
+        """, fails: .operand("UNION arms have irreconcilable types"))
+  }
+
+  @Test func `an uncorrelated scalar ordered set op faults the same way`()
+      throws {
+    // The uncorrelated form the correlated one must match: its arms are folded
+    // eagerly, faulting `.operand` at run whether ordered or not.
+    try people().expect("SELECT Id FROM People WHERE Age = (SELECT 'a' UNION SELECT 1 ORDER BY 1)",
+                        fails: .operand("UNION arms have irreconcilable types"))
+  }
+
+  @Test func `an unreached correlated scalar ordered set op does not fault`()
+      throws {
+    // The deferral posture is preserved: a subquery guarded by a statically
+    // false conjunct (`1 = 0 AND …`) is never reached, so its irreconcilable
+    // arms are NOT re-folded — the run yields no rows and does not fault, the
+    // dead-subquery posture the shape pre-pass defers.
+    try people().empty("""
+        SELECT Id FROM People p WHERE 1 = 0 AND p.Age =
+          (SELECT 'x' FROM S WHERE S.V = p.Id UNION SELECT 1 FROM S ORDER BY 1)
+        """)
+  }
+
+  @Test func `columns(of:) faults a reached irreconcilable ordered set op`()
+      throws {
+    // The static shape check already faulted (the F2 `typecheck` `.ordered`
+    // seam re-folds a reached carried union's arms); the run now matches it, so
+    // run ≡ columns(of:). Confirm the schema path still faults for both the
+    // scalar and IN shapes.
+    let catalog = try people()
+    guard case let .select(scalar) = try Statement(parsing: """
+        SELECT Id FROM People p WHERE p.Age =
+          (SELECT 'x' FROM S WHERE S.V = p.Id UNION SELECT 1 FROM S ORDER BY 1)
+        """), case let .select(within) = try Statement(parsing: """
+        SELECT Id FROM People p WHERE p.Age IN
+          (SELECT 'x' FROM S WHERE S.V = p.Id UNION SELECT 1 FROM S ORDER BY 1)
+        """) else {
+      Issue.record("expected two SELECT statements")
+      return
+    }
+    #expect(throws: SQLError.operand("UNION arms have irreconcilable types")) {
+      _ = try catalog.columns(of: scalar)
+    }
+    #expect(throws: SQLError.operand("UNION arms have irreconcilable types")) {
+      _ = try catalog.columns(of: within)
+    }
+  }
+
+  @Test func `columns(of:) does not fault an unreached irreconcilable ordered set op`()
+      throws {
+    // The schema-path deferral matches the run's: an unreached carried union is
+    // not re-folded, so `columns(of:)` advertises the query without faulting.
+    let catalog = try people()
+    guard case let .select(dead) = try Statement(parsing: """
+        SELECT Id FROM People p WHERE 1 = 0 AND p.Age =
+          (SELECT 'x' FROM S WHERE S.V = p.Id UNION SELECT 1 FROM S ORDER BY 1)
+        """) else {
+      Issue.record("expected a SELECT statement")
+      return
+    }
+    #expect(throws: Never.self) { _ = try catalog.columns(of: dead) }
+  }
+
+  // MARK: - Carrier ORDER BY nesting a subquery
+
+  @Test func `a carrier ORDER BY with an uncorrelated EXISTS runs like a plain SELECT`()
+      throws {
+    // A carrier `ORDER BY` may nest an `EXISTS`/`IN`/scalar subquery. An
+    // UNCORRELATED one records no per-outer-row plan (its probe runs
+    // standalone), so it worked already — the set-op carrier matches the SAME
+    // ORDER BY on a PLAIN SELECT over the identical multiset (a derived table
+    // wrapping the union). `S` is non-empty, so the `EXISTS` is TRUE for every
+    // row and the sort key is a constant `0`; the secondary ordinal orders the
+    // rows.
+    let catalog = try people()
+    try catalog.expect("""
+        SELECT Id FROM People UNION ALL SELECT V FROM S
+          ORDER BY CASE WHEN EXISTS (SELECT V FROM S) THEN 0 ELSE 1 END, 1
+        """, equals: """
+        SELECT Id FROM (SELECT Id FROM People
+                        UNION ALL SELECT V FROM S) AS T
+          ORDER BY CASE WHEN EXISTS (SELECT V FROM S) THEN 0 ELSE 1 END, Id
+        """)
+  }
+
+  @Test func `a carrier ORDER BY with a correlated scalar subquery runs like a plain SELECT`()
+      throws {
+    // FINDING #1: a carrier `ORDER BY` subquery that CORRELATES to the
+    // enclosing query (`… WHERE V < p.Id`, a set operation inside an outer
+    // `IN`) resolves the correlation but recorded NO runtime plan — the
+    // recording pass asked `arm.roles(of:)`, and the ARM does not carry the
+    // CARRIER's sort-key subquery, so its correlated `Subkey` lowered yet
+    // faulted "a correlated subquery plan was not compiled" at execution. The
+    // carrier now records its OWN ORDER BY subqueries' plans (through a
+    // classifier select carrying the carrier's ORDER BY), so a correlated sort
+    // key re-executes per outer row EXACTLY as it does on a PLAIN SELECT — the
+    // inner set operation replaced by a derived table over the same multiset,
+    // whose ORDER BY takes the ordinary supported correlated-subquery path.
+    // `S` = {7, 8}: for `p.Id` 1 or 2 the ORDER BY count is 0 (a no-op sort),
+    // so the `IN` keeps its members.
+    let catalog = try people()
+    try catalog.expect("""
+        SELECT p.Id FROM People p WHERE p.Id IN
+          (SELECT Id FROM People UNION ALL SELECT V FROM S
+             ORDER BY (SELECT COUNT(*) FROM S WHERE V < p.Id), 1)
+        """, equals: """
+        SELECT p.Id FROM People p WHERE p.Id IN
+          (SELECT Id FROM (SELECT Id FROM People
+                           UNION ALL SELECT V FROM S) AS T
+             ORDER BY (SELECT COUNT(*) FROM S WHERE V < p.Id), Id)
+        """)
+  }
+
+  @Test func `a carrier ORDER BY with a correlated EXISTS runs like a plain SELECT`()
+      throws {
+    // The `EXISTS` role records too: an outer-correlated `EXISTS` sort key over
+    // the set operation re-probes per outer row like the plain-SELECT form, no
+    // longer faulting "plan was not compiled". The ORDER BY does not change the
+    // `IN` membership, so both forms return the outer Ids whose value the inner
+    // multiset contains.
+    let catalog = try people()
+    try catalog.expect("""
+        SELECT p.Id FROM People p WHERE p.Id IN
+          (SELECT Id FROM People UNION ALL SELECT V FROM S
+             ORDER BY CASE WHEN EXISTS (SELECT V FROM S WHERE V < p.Id)
+                          THEN 0 ELSE 1 END, 1)
+        """, equals: """
+        SELECT p.Id FROM People p WHERE p.Id IN
+          (SELECT Id FROM (SELECT Id FROM People
+                           UNION ALL SELECT V FROM S) AS T
+             ORDER BY CASE WHEN EXISTS (SELECT V FROM S WHERE V < p.Id)
+                          THEN 0 ELSE 1 END, Id)
+        """)
+  }
+
+  @Test func `a carrier ORDER BY with a correlated subquery yields the outer rows`()
+      throws {
+    // The concrete rows the outer-correlated carrier ORDER BY produces — no
+    // fault. The inner set operation's multiset is `People.Id` (1, 2) ∪ `S`
+    // (7, 8); the outer `IN` keeps the `People` rows whose `Id` the multiset
+    // holds — Ids 1 and 2 — with the correlated ORDER BY subquery re-executing
+    // per outer row, the row set the pre-fix run never reached.
+    let catalog = try people()
+    try catalog.expect("""
+        SELECT p.Id FROM People p WHERE p.Id IN
+          (SELECT Id FROM People UNION ALL SELECT V FROM S
+             ORDER BY (SELECT COUNT(*) FROM S WHERE V < p.Id), 1)
+        """, yields: [[1], [2]])
+  }
+
+  // MARK: - Carrier ORDER BY subquery scope (run ≡ validate)
+
+  @Test func `a carrier ORDER BY subquery resolves a set-op output column at validate as at run`()
+      throws {
+    // FINDING (PR293): the `validate` carrier pre-pass derived each carrier
+    // ORDER BY subquery's width/type against `context.outer`, while the RUN
+    // resolved the SAME subquery against the set-operation OUTPUT scope. A
+    // carrier ORDER BY subquery referencing a set-op OUTPUT column — an aliased
+    // output (`Id AS Key`) living ONLY in that scope, absent from the outer —
+    // therefore resolved at run yet faulted `SQLError.column("Key")` at
+    // validate: a query that executes was rejected by `columns(of:, validate:
+    // true)`. The pre-pass now derives against the SAME set-op output scope
+    // (nested under the outer), so it resolves at validate exactly as at run.
+    // `S` = {7, 8} is non-empty, so the `EXISTS` sort key is a constant.
+    let catalog = try people()
+    let sql = """
+        SELECT Id AS Key FROM People UNION ALL SELECT V FROM S
+          ORDER BY CASE WHEN EXISTS (SELECT V FROM S WHERE V = Key)
+                       THEN 0 ELSE 1 END
+        """
+    // Runs — the row set the pre-fix validate would have rejected. The `Key`
+    // sort key makes the `EXISTS` TRUE only where an `S.V` equals the output
+    // `Key`: the `S` arm's values 7 and 8 sort first (key 0), the `People`
+    // Ids 1 and 2 after (key 1).
+    try catalog.expect(sql, yields: [[7], [8], [1], [2]])
+    // And validates: run ≡ columns(of:, validate: true).
+    guard case let .select(select) = try Statement(parsing: sql) else {
+      Issue.record("expected a SELECT statement")
+      return
+    }
+    #expect(throws: Never.self) {
+      _ = try catalog.columns(of: select, validate: true)
+    }
+  }
+
+  @Test func `the reviewer's EXISTS carrier ORDER BY runs and validates`()
+      throws {
+    // The reviewer's exact shape — an `EXISTS` sort key correlating to a bare
+    // set-op output column (`Id`, shared with a base relation) — already ran
+    // and validated (`width` derives the projection only, and `Id` binds via
+    // the outer/base), and STILL does after the scope alignment.
+    let catalog = try people()
+    let sql = """
+        SELECT Id FROM People UNION ALL SELECT V FROM S
+          ORDER BY CASE WHEN EXISTS (SELECT V FROM S WHERE V = Id)
+                       THEN 0 ELSE 1 END
+        """
+    try catalog.expect(sql, yields: [[1], [2], [7], [8]])
+    guard case let .select(select) = try Statement(parsing: sql) else {
+      Issue.record("expected a SELECT statement")
+      return
+    }
+    #expect(throws: Never.self) {
+      _ = try catalog.columns(of: select, validate: true)
+    }
+  }
+
+  @Test func `a carrier ORDER BY subquery naming an unknown column still faults at run and validate`()
+      throws {
+    // GUARD: the scope alignment must not OVER-WIDEN. A carrier ORDER BY
+    // subquery referencing a genuinely-unresolvable column (`Zzz` — neither a
+    // set-op output nor an outer/base column) still faults `SQLError.column` at
+    // BOTH run and validate.
+    let catalog = try people()
+    let sql = """
+        SELECT Id AS Key FROM People UNION ALL SELECT V FROM S
+          ORDER BY CASE WHEN EXISTS (SELECT V FROM S WHERE V = Zzz)
+                       THEN 0 ELSE 1 END
+        """
+    catalog.expect(sql, fails: .column("Zzz"))
+    guard case let .select(select) = try Statement(parsing: sql) else {
+      Issue.record("expected a SELECT statement")
+      return
+    }
+    #expect(throws: SQLError.column("Zzz")) {
+      _ = try catalog.columns(of: select, validate: true)
+    }
+  }
+
+  // MARK: - Carrier robustness (per-arm scope, malformed generated counts)
+
+  @Test func `an ordered union over arm-local derived tables runs like the bare union`()
+      throws {
+    // FINDING #1: an ORDER BY carrier over a set operation whose arms name
+    // their OWN arm-local derived tables (`d`, `e`) faulted `.relation('d')`
+    // though the SAME union WITHOUT the ORDER BY ran fine. The top-level
+    // `run(.setop)` path runs each arm PER ARM — arm-local aliases bind — but
+    // the ordered carrier fell to the GENERIC `optimise`, rewriting both arms
+    // under the ONE carrier-level context that binds no arm-owned alias, so its
+    // `seek` rewrite faulted `.relation('d')` before the per-arm
+    // `execute(…carrying:)` could augment each arm. `run` now routes an
+    // ordered-over-setop carrier through the per-arm optimiser (mirroring the
+    // view carrier path). The ordered result equals the bare union's rows.
+    let cat = try Catalog {
+      Relation("Anchor", ["x": .integer]) { Row(0) }
+    }
+    // The arms select from arm-local derived tables (`d`, `e`), not `Anchor` —
+    // `Anchor` only gives the catalog a base relation. Ordered = bare, sorted.
+    try cat.expect("""
+        SELECT v FROM (SELECT 1 AS v) AS d WHERE v = 1
+        UNION ALL SELECT v FROM (SELECT 2 AS v) AS e ORDER BY 1
+        """, yields: [[1], [2]])
+    try cat.expect("""
+        SELECT v FROM (SELECT 1 AS v) AS d WHERE v = 1
+        UNION ALL SELECT v FROM (SELECT 2 AS v) AS e
+        """, yields: [[1], [2]])
+  }
+
+  @Test func `a DISTINCT paged ordered union over arm-local derived tables runs`()
+      throws {
+    // FINDING #1 (other carrier operators): the per-arm descent threads through
+    // the DISTINCT dedup and OFFSET·FETCH paging too, not only ORDER BY. Each
+    // arm carries a `WHERE` over its OWN arm-local derived table — the filter
+    // the generic optimiser's `seek` rewrite would resolve under the wrong
+    // (carrier-level) scope, faulting `.relation` pre-fix. A bare `UNION`
+    // dedups the two `1` arms with the `2` arm to {1, 2}; ordered, OFFSET 1
+    // FETCH 1 takes the single row `2`.
+    let cat = try Catalog {
+      Relation("Anchor", ["x": .integer]) { Row(0) }
+    }
+    try cat.expect("""
+        SELECT v FROM (SELECT 1 AS v) AS d WHERE v = 1
+        UNION SELECT v FROM (SELECT 1 AS v) AS e WHERE v = 1
+        UNION SELECT v FROM (SELECT 2 AS v) AS f WHERE v = 2
+        ORDER BY 1 OFFSET 1 ROWS FETCH NEXT 1 ROWS ONLY
+        """, yields: [[2]])
+  }
+
+  @Test func `an ordered union arm over a genuinely-missing relation still faults`()
+      throws {
+    // FINDING #1 GUARD (no over-masking): the per-arm route must NOT swallow a
+    // real missing-relation fault. An arm referencing a relation that does NOT
+    // exist (`NoSuchRel`) STILL faults `.relation('NoSuchRel')`, both with and
+    // without the ORDER BY carrier — the fix only per-arm-scopes arm-LOCAL
+    // derived aliases; a genuinely absent relation is still unresolvable.
+    let cat = try Catalog {
+      Relation("Anchor", ["x": .integer]) { Row(0) }
+    }
+    cat.expect("""
+        SELECT v FROM NoSuchRel UNION ALL SELECT 2 AS v ORDER BY 1
+        """, fails: .relation("NoSuchRel"))
+    cat.expect("""
+        SELECT v FROM NoSuchRel UNION ALL SELECT 2 AS v
+        """, fails: .relation("NoSuchRel"))
+  }
+
+  @Test func `a generated count over a SELECT-star union faults not traps`()
+      throws {
+    // FINDING #2: a hostile `Query.ordered(<union of two SELECT * arms>,
+    // generated: 1)` — a PUBLIC AST case the parser never emits. A `SELECT *`
+    // arm's projection is `.all`, so the carrier's `items` list is EMPTY though
+    // the resolved `width` is > 0. The old aliased-tail check `for k in 0 ..<
+    // generated WHERE real + k < items.count` SKIPPED every slot (items empty),
+    // so the hidden-name mapping's `items[real + k].alias!` force-unwrapped an
+    // ABSENT item and TRAPPED the process. (A trap cannot be caught in-process,
+    // so this asserts the POST-fix typed fault; PRE-fix this crashed.) The
+    // carrier now requires each generated tail slot to HAVE an aliased
+    // projected item, faulting XX000 rather than crashing.
+    let cat = try Catalog {
+      Relation("P", ["a": .integer, "b": .integer]) { Row(1, 2) }
+      Relation("Q", ["c": .integer, "d": .integer]) { Row(3, 4) }
+    }
+    let union = Query.setop(
+        .union,
+        .select(Select(projection: .all, from: Relation(name: "P"))),
+        .select(Select(projection: .all, from: Relation(name: "Q"))),
+        all: true)
+    let over = Query.ordered(union, distinct: false, order: nil, limit: nil,
+                             generated: 1)
+    #expect(throws: SQLError.state("XX000",
+                                   "ordered set-operation generated tail " +
+                                   "is not aliased")) {
+      _ = try cat.run(over)
+    }
+  }
+
+  @Test func `columns(of:) faults an out-of-range generated count not traps`()
+      throws {
+    // FINDING #3: the SCHEMA path `columns(unifying:)` trimmed a carrier's
+    // hidden tail as `cols.prefix(cols.count - generated)` with NO range guard.
+    // A public-AST `generated` PAST the width makes the argument NEGATIVE and
+    // `Array.prefix` PRECONDITION-TRAPS; a NEGATIVE `generated` returns ALL
+    // columns UNTRIMMED — silently wrong and diverging from `run`, which faults
+    // XX000. The schema path now mirrors the compile-path range guard (the
+    // SHARED `real(trimming:of:)` helper), so both fault the SAME XX000. A
+    // NESTED ordered carrier (an ordered arm of an outer union) reaches
+    // `columns(unifying:)`'s `.ordered` case DIRECTLY — the whole-query compile
+    // pre-check does not guard it — so its malformed count actually TRAPPED the
+    // schema path (`Can't take a prefix of negative length`). A trap cannot be
+    // caught in-process, so this asserts the POST-fix typed fault; PRE-fix this
+    // crashed the process.
+    let cat = try Catalog {
+      Relation("P", ["a": .integer]) { Row(1) }
+    }
+    let fault = SQLError.state("XX000",
+                               "ordered set-operation generated count out " +
+                               "of range")
+    // A nested ordered arm with a count PAST the width (1) — `cols.count −
+    // 999` is negative, the schema-path `prefix` trap.
+    let arm = Query.ordered(
+        .select(Select(projection: .all, from: Relation(name: "P"))),
+        distinct: false, order: nil, limit: nil, generated: 999)
+    let nested = Query.setop(
+        .union, arm,
+        .select(Select(projection: .all, from: Relation(name: "P"))),
+        all: true)
+    #expect(throws: fault) {
+      _ = try cat.columns(of: nested, routines: [:], validate: false)
+    }
+    // A top-level malformed carrier faults the SAME XX000 on BOTH paths (the
+    // whole-query compile guards it before `columns(unifying:)`, and the run
+    // path's carrier guards it) — run ≡ columns(of:). A count PAST the width
+    // and a NEGATIVE count both fault.
+    let union = Query.setop(
+        .union,
+        .select(Select(projection: .all, from: Relation(name: "P"))),
+        .select(Select(projection: .all, from: Relation(name: "P"))),
+        all: true)
+    let over = Query.ordered(union, distinct: false, order: nil, limit: nil,
+                             generated: 999)
+    let under = Query.ordered(union, distinct: false, order: nil, limit: nil,
+                              generated: -1)
+    #expect(throws: fault) {
+      _ = try cat.columns(of: over, routines: [:], validate: false)
+    }
+    #expect(throws: fault) {
+      _ = try cat.columns(of: under, routines: [:], validate: false)
+    }
+    #expect(throws: fault) { _ = try cat.run(over) }
+    #expect(throws: fault) { _ = try cat.run(under) }
+    // A VALID `generated: 0` returns the correct trimmed schema — one column.
+    let valid = Query.ordered(union, distinct: false, order: nil, limit: nil,
+                              generated: 0)
+    #expect(try cat.columns(of: valid, routines: [:],
+                            validate: false).count == 1)
+  }
+}

--- a/Tests/SQLTests/Queries/OrderedSetOperationTests.swift
+++ b/Tests/SQLTests/Queries/OrderedSetOperationTests.swift
@@ -1,0 +1,473 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+import SQLEngine
+import SQLTestSupport
+
+// MARK: - Fixtures
+
+/// Two single-column relations to combine: `L` of `a` (3, 1, 2) and `R` of `b`
+/// (5, 4) — a `UNION ALL` yields five rows a query-level `ORDER BY` sorts, a
+/// `UNION` dedups first.
+private func pair() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("L", ["a": .integer]) {
+      Row(3)
+      Row(1)
+      Row(2)
+    }
+    Relation("R", ["b": .integer]) {
+      Row(5)
+      Row(4)
+    }
+  }
+}
+
+// A query-level `ORDER BY` / `OFFSET`·`FETCH` after a set operation applies to
+// the WHOLE combined result — the ISO rule — carried on `Query.ordered` and
+// resolved through the setop's OUTPUT scope, not bound to the trailing arm.
+// These exercise the general capability the GROUPING SETS expansion also uses,
+// over PLAIN unions.
+struct OrderedSetOperationTests {
+  @Test func `a query-level ORDER BY sorts the whole UNION ALL result`()
+      throws {
+    // Without the carrier the trailing `ORDER BY a` bound the RIGHT arm — which
+    // projects `b` from `R` — and faulted `no such column 'a'`. It now orders
+    // the union's output (named off the first arm, `a`): 1..5 ascending.
+    try pair().expect("""
+        SELECT a FROM L UNION ALL SELECT b FROM R ORDER BY a
+        """, yields: [[1], [2], [3], [4], [5]])
+  }
+
+  @Test func `a positional ORDER BY orders the combined result descending`()
+      throws {
+    // `ORDER BY 1 DESC` names the first output column of the union over the
+    // combined rows: 5..1 descending.
+    try pair().expect("""
+        SELECT a FROM L UNION ALL SELECT b FROM R ORDER BY 1 DESC
+        """, yields: [[5], [4], [3], [2], [1]])
+  }
+
+  @Test func `OFFSET and FETCH page the ordered UNION ALL result`() throws {
+    // The row limit rides the carrier over the union: ordered 1..5, OFFSET 1
+    // skips 1 and FETCH NEXT 2 takes 2 and 3.
+    try pair().expect("""
+        SELECT a FROM L UNION ALL SELECT b FROM R
+         ORDER BY 1 OFFSET 1 ROW FETCH NEXT 2 ROWS ONLY
+        """, yields: [[2], [3]])
+  }
+
+  @Test func `a bare UNION dedups before the query-level ORDER BY`() throws {
+    // A bare `UNION` (no ALL) removes whole-row duplicates BEFORE the carrier's
+    // ORDER BY sorts — `L UNION L` is the distinct rows of `L`, ordered 1, 2, 3.
+    try pair().expect("""
+        SELECT a FROM L UNION SELECT a FROM L ORDER BY a
+        """, yields: [[1], [2], [3]])
+  }
+
+  @Test func `an ORDER BY over a UNION types across the arms`() throws {
+    // The result column TYPES unify across the arms (ISO), so the sort runs over
+    // the coerced values — a mixed integer arm and a double arm widen to double
+    // and order numerically.
+    let cat = try Catalog {
+      Relation("I", ["n": .integer]) {
+        Row(1)
+        Row(3)
+      }
+      Relation("D", ["d": .double]) {
+        Row(2.5)
+      }
+    }
+    try cat.expect("""
+        SELECT n FROM I UNION ALL SELECT d FROM D ORDER BY 1
+        """, yields: [[1.0], [2.5], [3.0]])
+  }
+
+  @Test func `an ORDER BY over an INTERSECT orders the common rows`() throws {
+    // The carrier rides any set operation, not only UNION: `L INTERSECT` a
+    // relation sharing 1 and 2 keeps the common rows, then orders them.
+    let cat = try Catalog {
+      Relation("L", ["a": .integer]) {
+        Row(3)
+        Row(1)
+        Row(2)
+      }
+      Relation("M", ["a": .integer]) {
+        Row(2)
+        Row(1)
+        Row(9)
+      }
+    }
+    try cat.expect("""
+        SELECT a FROM L INTERSECT SELECT a FROM M ORDER BY a
+        """, yields: [[1], [2]])
+  }
+
+  @Test func `a trailing ORDER BY lifts onto a pure INTERSECT chain`() throws {
+    // A top-level chain of ONLY `INTERSECT` is built inside `intersection()`
+    // and never runs the `UNION`/`EXCEPT` loop, so the trailing lift must gate
+    // on the query being a set operation, NOT on that loop. With DISTINCT names
+    // (`x` on the left, `y` on the right) the defect is unmasked: before, the
+    // ORDER BY stayed on the RIGHT arm and resolved `x` against `R` — faulting
+    // `no such column 'x'`. It now lifts onto the carrier and orders the
+    // combined intersect output by the FIRST-arm name `x`.
+    let cat = try Catalog {
+      Relation("L", ["a": .integer]) {
+        Row(3)
+        Row(1)
+        Row(2)
+      }
+      Relation("R", ["b": .integer]) {
+        Row(2)
+        Row(1)
+        Row(9)
+      }
+    }
+    try cat.expect("""
+        SELECT a AS x FROM L INTERSECT SELECT b AS y FROM R ORDER BY x
+        """, yields: [[1], [2]])
+    // The parenthesised-then-ordered ORACLE: order the intersect result the
+    // same way (by the first-arm name over the combined output).
+    try cat.expect("""
+        SELECT a AS x FROM L INTERSECT SELECT b AS y FROM R ORDER BY x
+        """, equals: """
+        SELECT * FROM (
+          SELECT a AS x FROM L INTERSECT SELECT b AS y FROM R
+        ) AS g ORDER BY x
+        """)
+  }
+
+  @Test func `a trailing ORDER BY lifts onto a pure EXCEPT chain`() throws {
+    // A top-level chain of only `EXCEPT` runs the outer loop, so its trailing
+    // ORDER BY already lifted — the parity guard for the outer set-op path.
+    // `L EXCEPT R` keeps the left rows absent from the right (3), then orders.
+    let cat = try Catalog {
+      Relation("L", ["a": .integer]) {
+        Row(3)
+        Row(1)
+        Row(2)
+      }
+      Relation("R", ["b": .integer]) {
+        Row(2)
+        Row(1)
+      }
+    }
+    try cat.expect("""
+        SELECT a AS x FROM L EXCEPT SELECT b AS y FROM R ORDER BY x
+        """, yields: [[3]])
+  }
+
+  @Test func `OFFSET and FETCH page a pure INTERSECT chain`() throws {
+    // The lift carries the row limit too: `L INTERSECT M` shares 1, 2, 3;
+    // ordered ascending, OFFSET 1 skips 1 and FETCH NEXT 1 takes 2.
+    let cat = try Catalog {
+      Relation("L", ["a": .integer]) {
+        Row(3)
+        Row(1)
+        Row(2)
+      }
+      Relation("M", ["b": .integer]) {
+        Row(2)
+        Row(1)
+        Row(3)
+      }
+    }
+    try cat.expect("""
+        SELECT a AS x FROM L INTERSECT SELECT b AS y FROM M
+         ORDER BY x OFFSET 1 ROW FETCH NEXT 1 ROWS ONLY
+        """, yields: [[2]])
+  }
+
+  @Test func `a trailing ORDER BY lifts onto a mixed UNION INTERSECT chain`()
+      throws {
+    // `INTERSECT` binds tighter than `UNION`, so `L UNION M INTERSECT N` parses
+    // as `L UNION (M INTERSECT N)`: `M INTERSECT N` shares 4 and 5, unioned
+    // with L's 1, 2, 3 gives 1..5. The trailing ORDER BY lifts onto the chain,
+    // ordering the combined output by the first-arm name `x`, descending.
+    let cat = try Catalog {
+      Relation("L", ["a": .integer]) {
+        Row(1)
+        Row(2)
+        Row(3)
+      }
+      Relation("M", ["b": .integer]) {
+        Row(4)
+        Row(5)
+        Row(6)
+      }
+      Relation("N", ["c": .integer]) {
+        Row(4)
+        Row(5)
+        Row(7)
+      }
+    }
+    try cat.expect("""
+        SELECT a AS x FROM L
+         UNION SELECT b AS y FROM M
+         INTERSECT SELECT c AS z FROM N
+         ORDER BY x DESC
+        """, yields: [[5], [4], [3], [2], [1]])
+  }
+
+  @Test func `a query-level ORDER BY over a TABLE-arm set operation sorts`()
+      throws {
+    // A `TABLE t` first arm projects `.all` — the arm-0 AST projection is
+    // EMPTY — so deriving the carrier's output NAMES from those AST items
+    // (rather than the RESOLVED columns) TRAPPED on an out-of-range index. And
+    // a `TABLE`/`VALUES` LAST arm carries no primary-level order, so a trailing
+    // query-level ORDER BY was left UNCONSUMED (`unexpected trailing input`).
+    // Both are fixed: the output names come from the resolved columns, and the
+    // tail is parsed at the query level. Ordered over the combined output:
+    // 1..5.
+    try pair().expect("""
+        TABLE L UNION ALL TABLE R ORDER BY 1
+        """, yields: [[1], [2], [3], [4], [5]])
+  }
+
+  @Test func `a SELECT star first arm set operation orders by a resolved name`()
+      throws {
+    // The `SELECT *` first arm resolves its output columns (`a`) from the base
+    // relation; the carrier orders by the RESOLVED name `a` over the combined
+    // union output — the same name a plain derived union would bind.
+    try pair().expect("""
+        SELECT * FROM L UNION ALL SELECT b FROM R ORDER BY a
+        """, yields: [[1], [2], [3], [4], [5]])
+  }
+
+  @Test func `a query-level ORDER BY over a VALUES-arm set operation sorts`()
+      throws {
+    // A `VALUES` last arm carries no primary-level order either, so the
+    // trailing query-level ORDER BY parses at the query level. `L`'s 1, 2, 3
+    // unioned with the constants 4, 5, ordered ascending.
+    try pair().expect("""
+        SELECT a FROM L UNION ALL VALUES (4), (5) ORDER BY 1
+        """, yields: [[1], [2], [3], [4], [5]])
+  }
+
+  @Test func `an out-of-range ordinal over a plain UNION faults`() throws {
+    // A plain ordered set-operation carries no hidden materialised columns
+    // (`generated == 0`), so an ORDINAL past the single output faults `.column`
+    // over the union's real arity — the non-GROUPING-SETS path is unchanged by
+    // the GROUPING SETS ordinal bound fix (the ordinal is bounded by the REAL
+    // output width, which here IS the full width).
+    try pair().expect("""
+        SELECT a FROM L UNION ALL SELECT b FROM R ORDER BY 2
+        """, fails: .column("2"))
+  }
+
+  @Test func `a set operation of derived-table arms orders the whole result`()
+      throws {
+    // Each arm names its OWN derived alias (`d` on the left, `e` on the right).
+    // Arms are SELECT-scoped, so the query-level augment the carrier runs under
+    // never binds them — before, the carrier compiled ONE `setop` plan run
+    // under the single carrier context, so an arm's `.scan d` faulted
+    // `.relation`. The carrier now runs the union PER ARM (the same machinery
+    // the direct `setop` and a correlated-subquery setop use), materialising
+    // each arm's derived table in its own scope: 1 then 2.
+    try pair().expect("""
+        SELECT v FROM (SELECT 1 AS v) AS d
+         UNION ALL SELECT v FROM (SELECT 2 AS v) AS e ORDER BY 1
+        """, yields: [[1], [2]])
+  }
+
+  @Test func `an INTERSECT of derived-table arms orders the common rows`()
+      throws {
+    // The per-arm materialisation rides any set operation: an `INTERSECT` of
+    // two derived arms sharing the row 1 keeps it.
+    try pair().expect("""
+        SELECT v FROM (SELECT 1 AS v) AS d
+         INTERSECT SELECT v FROM (SELECT 1 AS v) AS e ORDER BY 1
+        """, yields: [[1]])
+  }
+
+  @Test func `an EXCEPT of derived-table arms orders the left-only rows`()
+      throws {
+    // `EXCEPT` of derived arms keeps the left row absent from the right.
+    try pair().expect("""
+        SELECT v FROM (SELECT 1 AS v) AS d
+         EXCEPT SELECT v FROM (SELECT 2 AS v) AS e ORDER BY 1
+        """, yields: [[1]])
+  }
+
+  @Test func `a negative OFFSET over a UNION faults`() throws {
+    // A direct `Limit` with a negative offset (the parser yields none, but a
+    // built AST can) faults — the carrier rejects it as the `Select` path does.
+    let cat = try pair()
+    let query = Query.ordered(
+        .setop(.union,
+               .select(Select(projection: .columns([Column(name: "a")]),
+                              from: Relation(name: "L"))),
+               .select(Select(projection: .columns([Column(name: "b")]),
+                              from: Relation(name: "R"))),
+               all: true),
+        distinct: false, order: nil, limit: Limit(count: 1, offset: -1),
+        generated: 0)
+    #expect(throws: SQLError.state("2201X",
+                                   "OFFSET row count must be non-negative")) {
+      _ = try cat.run(query)
+    }
+  }
+
+  @Test func `an out-of-range generated count over a union faults`() throws {
+    // `Query.ordered` is a PUBLIC AST case; a caller may build a `generated`
+    // count out of step with the inner union's width (the parser and `expand`
+    // never do). A count PAST the width, or NEGATIVE, makes `real = width −
+    // generated` negative — the carrier's `0 ..< real` range and per-column
+    // subscripts would TRAP the process. The carrier now rejects a malformed
+    // count with a typed internal-error fault rather than trapping. Build the
+    // malformed AST directly: a ONE-column union with `generated: 2`, then a
+    // negative `generated`.
+    let cat = try pair()
+    let union = Query.setop(
+        .union,
+        .select(Select(projection: .columns([Column(name: "a")]),
+                       from: Relation(name: "L"))),
+        .select(Select(projection: .columns([Column(name: "b")]),
+                       from: Relation(name: "R"))),
+        all: true)
+    let over = Query.ordered(union, distinct: false, order: nil, limit: nil,
+                             generated: 2)
+    let fault = SQLError.state("XX000",
+                               "ordered set-operation generated count out " +
+                               "of range")
+    #expect(throws: fault) { _ = try cat.run(over) }
+    let under = Query.ordered(union, distinct: false, order: nil, limit: nil,
+                              generated: -1)
+    #expect(throws: fault) { _ = try cat.run(under) }
+    // An IN-RANGE `generated` (0 — no hidden columns) still compiles and runs
+    // the union unchanged: 1..5 over the two arms.
+    let valid = Query.ordered(union, distinct: false,
+                              order: Order(keys: [
+                                Order.Key(sort: .ordinal(1), ascending: true),
+                              ]), limit: nil, generated: 0)
+    #expect(try cat.run(valid) == [[1], [2], [3], [4], [5]].map { $0.map {
+      Value.integer($0)
+    } })
+  }
+
+  @Test func `a generated count over an unaliased tail faults not traps`()
+      throws {
+    // `Query.ordered` is a PUBLIC AST case. A caller may build a `generated: 1`
+    // over an ORDINARY two-column union whose trailing item is a NORMAL
+    // projected column with NO alias: the range guard `generated <= width`
+    // passes (1 ≤ 2), but the carrier's `items[real + k].alias!` force-unwrap
+    // would TRAP — the tail is not the aliased hidden `*gsN` shape a real
+    // producer appends. The carrier now proves the generated tail is aliased
+    // hidden columns before unwrapping, faulting a typed internal error rather
+    // than crashing.
+    let cat = try Catalog {
+      Relation("P", ["a": .integer, "b": .integer]) {
+        Row(1, 2)
+      }
+      Relation("Q", ["c": .integer, "d": .integer]) {
+        Row(3, 4)
+      }
+    }
+    let union = Query.setop(
+        .union,
+        .select(Select(projection: .columns([Column(name: "a"),
+                                             Column(name: "b")]),
+                       from: Relation(name: "P"))),
+        .select(Select(projection: .columns([Column(name: "c"),
+                                             Column(name: "d")]),
+                       from: Relation(name: "Q"))),
+        all: true)
+    // The trailing item (`b`, a bare column) carries no alias, so `generated:
+    // 1` over the width-2 union has an UNALIASED tail.
+    let over = Query.ordered(union, distinct: false, order: nil, limit: nil,
+                             generated: 1)
+    #expect(throws: SQLError.state("XX000",
+                                   "ordered set-operation generated tail " +
+                                   "is not aliased")) {
+      _ = try cat.run(over)
+    }
+    // `generated: 0` over the SAME union runs unchanged — both columns of each
+    // arm's row, no trim, ordered ascending by the first output column.
+    let valid = Query.ordered(union, distinct: false,
+                              order: Order(keys: [
+                                Order.Key(sort: .ordinal(1), ascending: true),
+                              ]), limit: nil, generated: 0)
+    #expect(try cat.run(valid) == [[1, 2], [3, 4]].map {
+      $0.map(Value.integer)
+    })
+  }
+}
+
+// MARK: - Carrier ORDER BY subqueries
+
+/// A catalog for an `EXISTS`/`IN` subquery inside a carrier `ORDER BY` — two
+/// arms `T`/`U` and a non-empty `S` the sort-key subquery probes.
+private func subqueried() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["Id": .integer]) {
+      Row(2)
+      Row(1)
+    }
+    Relation("U", ["Id": .integer]) {
+      Row(4)
+      Row(3)
+    }
+    Relation("S", ["V": .integer]) {
+      Row(7)
+    }
+  }
+}
+
+// A query-level `ORDER BY` over a set operation may nest an `EXISTS`/`IN`/
+// scalar subquery in a sort key, exactly as a plain `SELECT`'s ORDER BY does.
+// The carrier must COLLECT and RESOLVE those subqueries — the same machinery a
+// plain select's ORDER BY uses — rather than lower them under the default
+// unsupported resolution, which rejected them. These pair the union form with
+// the plain SELECT it must resolve identically to.
+struct CarrierOrderBySubqueryTests {
+  @Test func `an EXISTS in a carrier ORDER BY resolves like a plain SELECT`()
+      throws {
+    // `S` is non-empty, so the `EXISTS` sort key folds to `Id` for every row —
+    // the union's four rows sort ascending 1..4, exactly as the same ORDER BY
+    // over a plain SELECT sorts its rows.
+    try subqueried().expect("""
+        SELECT Id FROM T UNION ALL SELECT Id FROM U
+         ORDER BY CASE WHEN EXISTS (SELECT V FROM S) THEN Id ELSE 0 END
+        """, yields: [[1], [2], [3], [4]])
+  }
+
+  @Test func `an IN in a carrier ORDER BY resolves like a plain SELECT`()
+      throws {
+    // The sort key is 0 for rows whose `Id` is IN `S.V` ({7} — none here) and 1
+    // otherwise, so all four rows tie on the key and sort by the secondary
+    // ordinal: 1..4.
+    try subqueried().expect("""
+        SELECT Id FROM T UNION ALL SELECT Id FROM U
+         ORDER BY CASE WHEN Id IN (SELECT V FROM S) THEN 0 ELSE 1 END, 1
+        """, yields: [[1], [2], [3], [4]])
+  }
+
+  @Test func `columns validates a carrier ORDER BY subquery`() throws {
+    // The schema path collects and validates the carrier's ORDER BY subquery
+    // too, so `columns(of:)` accepts exactly what the run does — closing the
+    // run-vs-validate gap where the default unsupported resolution rejected it.
+    let query = try parse(query: """
+        SELECT Id FROM T UNION ALL SELECT Id FROM U
+         ORDER BY CASE WHEN EXISTS (SELECT V FROM S) THEN Id ELSE 0 END
+        """)
+    let columns = try subqueried().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+  }
+
+  @Test func `a bad carrier ORDER BY subquery column faults like a plain SELECT`()
+      throws {
+    // A bad column inside the carrier's ORDER BY subquery faults validation
+    // exactly as it does on a plain SELECT's ORDER BY subquery.
+    let query = try parse(query: """
+        SELECT Id FROM T UNION ALL SELECT Id FROM U
+         ORDER BY CASE WHEN EXISTS (SELECT Missing FROM S) THEN Id ELSE 0 END
+        """)
+    let resolve = { () throws -> Array<OutputColumn> in
+      try subqueried().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.column("Missing")) {
+      try resolve()
+    }
+  }
+}

--- a/Tests/SQLTests/Queries/SubqueryTests.swift
+++ b/Tests/SQLTests/Queries/SubqueryTests.swift
@@ -343,6 +343,103 @@ struct SubqueryTypeCheckingTests {
   }
 }
 
+// MARK: - Reached ordered set-operation subquery sort keys
+
+/// Two single-row relations for an ordered set-operation subquery — `L`/`R`
+/// each of `a` — so a reached scalar/`IN` `(SELECT a FROM L UNION SELECT a FROM
+/// R ORDER BY <key>)` is a genuine ordered union whose carrier ORDER BY is the
+/// surface under test.
+private func ordered() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("L", ["a": .integer]) {
+      Row(1)
+    }
+    Relation("R", ["a": .integer]) {
+      Row(2)
+    }
+  }
+}
+
+// A reached scalar/`IN` subquery whose body is an ordered set operation has its
+// carrier ORDER BY validated ONLY by the carrier compile, which the nested-
+// subquery shape pre-pass runs with `validating(false)`. So the reached
+// re-validation seam must validate the carrier's sort keys too — else
+// `columns(of:)` accepts a bad sort key a run faults, a run-vs-validate
+// divergence. It stays REACHED-only: an unreached ordered subquery's bad key is
+// deferred, matching the dead-scalar/dead-EXISTS posture.
+struct ReachedOrderedSubqueryTests {
+  @Test func `a reached scalar bad sort key faults run and validate alike`()
+      throws {
+    let query = try parse(query: """
+        SELECT (SELECT a FROM L UNION SELECT a FROM R ORDER BY missing(a)) AS x
+          FROM L
+        """)
+    let resolve = { () throws -> Array<OutputColumn> in
+      try ordered().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.function("missing")) {
+      try resolve()
+    }
+    try ordered().expect("""
+        SELECT (SELECT a FROM L UNION SELECT a FROM R ORDER BY missing(a)) AS x
+          FROM L
+        """, fails: .function("missing"))
+  }
+
+  @Test func `a reached IN bad sort key faults run and validate alike`() throws {
+    let query = try parse(query: """
+        SELECT a FROM L
+          WHERE a IN (SELECT a FROM L UNION SELECT a FROM R ORDER BY missing(a))
+        """)
+    let resolve = { () throws -> Array<OutputColumn> in
+      try ordered().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.function("missing")) {
+      try resolve()
+    }
+    try ordered().expect("""
+        SELECT a FROM L
+          WHERE a IN (SELECT a FROM L UNION SELECT a FROM R ORDER BY missing(a))
+        """, fails: .function("missing"))
+  }
+
+  @Test func `a reached ordered subquery with an in-scope sort key runs`()
+      throws {
+    // A genuinely-in-scope sort key on the reached carrier validates AND runs:
+    // the `IN` set membership is unaffected by the sort, so `a IN (1, 2)` holds
+    // for the one `L` row (`a = 1`).
+    let query = try parse(query: """
+        SELECT a FROM L
+          WHERE a IN (SELECT a FROM L UNION SELECT a FROM R ORDER BY a)
+        """)
+    let columns = try ordered().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+    try ordered().expect("""
+        SELECT a FROM L
+          WHERE a IN (SELECT a FROM L UNION SELECT a FROM R ORDER BY a)
+        """, yields: [[1]])
+  }
+
+  @Test func `an unreached bad sort key faults neither run nor validate`()
+      throws {
+    // The `IN` occurrence sits behind a statically-false `AND`, so the executor
+    // never materialises it and the reachability walk never records it — its
+    // carrier's bad sort key is DEFERRED, matching the dead-subquery posture.
+    let query = try parse(query: """
+        SELECT a FROM L
+          WHERE 1 = 0
+            AND a IN (SELECT a FROM L UNION SELECT a FROM R ORDER BY missing(a))
+        """)
+    let columns = try ordered().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+    try ordered().empty("""
+        SELECT a FROM L
+          WHERE 1 = 0
+            AND a IN (SELECT a FROM L UNION SELECT a FROM R ORDER BY missing(a))
+        """)
+  }
+}
+
 // MARK: - ORDER BY expression subqueries
 
 struct OrderBySubqueryTests {

--- a/Tests/SQLTests/Schema/OutputSchemaTests.swift
+++ b/Tests/SQLTests/Schema/OutputSchemaTests.swift
@@ -856,6 +856,26 @@ struct CTEProducerParityTests {
     #expect(t.lenient == t.strict)
   }
 
+  @Test func `an ordered recursive CTE agrees across all paths through the carrier`()
+      throws {
+    // A trailing `ORDER BY` on a recursive body lifts to a `Query.ordered`
+    // carrier over the `UNION` setop; the schema producer's recursive-shape
+    // recogniser (`contributions`) must peel it (`body.core`) the same way the
+    // run's `fixpoint` does, else it falls through to the non-recursive fold
+    // with the self UNBOUND and faults `.relation("t")` — a run-vs-schema
+    // divergence, since the run iterates the fixpoint and yields `1,2,3`. The
+    // carrier is transparent to the derived schema, so all three still agree on
+    // the one integer column `n`.
+    let t = try Triple("""
+        WITH RECURSIVE t(n) AS (
+          SELECT 1 UNION ALL SELECT n + 1 FROM t WHERE n < 3 ORDER BY 1
+        ) SELECT n FROM t
+        """)
+    #expect(pairs(t.run).map { same($0, [("n", .integer)]) } == true)
+    #expect(t.run == t.lenient)
+    #expect(t.lenient == t.strict)
+  }
+
   @Test func `a widening recursive CTE agrees on the double column`() throws {
     // The anchor is `.integer` (`1`) and the recursive arm widens it to
     // `.double` (`n + 0.5`); the unified carrier the producer binds is
@@ -877,6 +897,20 @@ struct CTEProducerParityTests {
     // `.double` column on every path — the producer's `kinds` fold and the
     // run's `run`-then-`kinds` re-derive read the SAME `merge`.
     let t = try Triple("WITH a(x) AS (SELECT 1 UNION SELECT 2.5) " +
+                       "SELECT x FROM a")
+    #expect(pairs(t.run).map { same($0, [("x", .double)]) } == true)
+    #expect(t.run == t.lenient)
+    #expect(t.lenient == t.strict)
+  }
+
+  @Test func `a non-recursive ordered set-op CTE derives through the carrier`()
+      throws {
+    // A NON-recursive UNION body under a trailing `ORDER BY` carrier still
+    // derives its one `.double` column on every path: the recursive-shape
+    // recogniser sees a non-recursive CTE and falls through to the unifying
+    // fold, whose `.ordered` case peels the carrier transparently — the
+    // regression guard for the fall-through side of the carrier peel.
+    let t = try Triple("WITH a(x) AS (SELECT 1 UNION SELECT 2.5 ORDER BY 1) " +
                        "SELECT x FROM a")
     #expect(pairs(t.run).map { same($0, [("x", .double)]) } == true)
     #expect(t.run == t.lenient)


### PR DESCRIPTION
A query-level ORDER BY / DISTINCT / OFFSET·FETCH over a set operation has no slot on the setop node, so it rides a first-class `Query.ordered` carrier resolved through the set-operation OUTPUT scope (arm-0-named, type-unified result columns); ordinal/alias/expression keys bind as an ordinary `SELECT … FROM <derived> ORDER BY …` would. `Query.core` peels the carrier transparently at set-op and plan seams (run, compile, correlated subquery, view body). This gives ordered, deduplicated, and paged plain set operations, which the engine lacked.

The carrier validates a generated trailing slot as a genuine aliased hidden column before force-unwrapping its alias, faulting a typed error rather than trapping on a caller-built `.ordered(…, generated:)` over an ordinary union. Its ORDER BY collects and resolves its own nested subqueries — the machinery a plain SELECT's ORDER BY uses — so an EXISTS/IN/scalar sort key resolves and validates as it does on a SELECT, rather than being rejected by the default unsupported resolution.