### PR TITLE
SQLEngine: desugar GROUP BY ROLLUP and CUBE to grouping sets

### DIFF
--- a/Sources/SQLEngine/Parser.swift
+++ b/Sources/SQLEngine/Parser.swift
@@ -43,12 +43,24 @@
 ///                   // the derived body may reference preceding FROM items
 /// projection     := '*' | column (',' column)*
 /// where          := WHERE predicate
-/// group          := GROUP BY (grouping | GROUPING SETS '(' set (',' set)* ')')
-///                   // GROUPING/SETS are context identifiers, not keywords;
-///                   // GROUPING SETS expands to a UNION ALL of per-set arms at
-///                   // compile/schema time (by resolved identity), not here
-/// grouping       := expression (',' expression)*  // ordinary grouping keys
-/// set            := '(' [expression (',' expression)*] ')'  // '()' = total
+/// group          := GROUP BY element (',' element)*
+///                   // the elements' grouping-set lists are CROSS-PRODUCTED
+///                   // into one set list; a purely ordinary clause stays plain
+///                   // GROUP BY keys, and any ROLLUP/CUBE/GROUPING SETS makes
+///                   // the whole clause a GROUPING SETS — a UNION ALL of
+///                   // per-set arms expanded at compile/schema time (by
+///                   // resolved identity), not here
+/// element        := set | rollup | cube | sets  // set = an ordinary set
+/// rollup         := ROLLUP '(' [unit (',' unit)*] ')'  // n+1 prefixes
+/// cube           := CUBE '(' [unit (',' unit)*] ')'    // 2ⁿ unit subsets
+/// sets           := GROUPING SETS '(' element (',' element)* ')'  // nests
+/// unit           := set  // a ROLLUP/CUBE unit is an ordinary set
+/// set            := expression | '(' [expression (',' expression)*] ')'
+///                   // '()' is the grand-total set; a top-level ordinary key
+///                   // is a bare scalar expression ('(SELECT 1)' a subquery);
+///                   // ROLLUP/CUBE/GROUPING/SETS are CONTEXT identifiers, not
+///                   // keywords — ROLLUP/CUBE open only before a '(', and
+///                   // GROUPING only before SETS
 /// having         := HAVING predicate
 /// predicate      := disjunction
 /// disjunction    := conjunction (OR conjunction)*
@@ -592,72 +604,337 @@ internal struct Parser: ~Escapable {
                   having: having, order: order, limit: limit)
   }
 
-  /// Parses `BY <grouping element>` (the `GROUP` keyword is already consumed) —
-  /// either the ordinary `<ordinary grouping set>` key list `e (, e)*` or the
-  /// ISO `GROUP BY GROUPING SETS (s, …)` construct.
+  /// Parses `BY <element> (',' <element>)*` (the `GROUP` keyword is already
+  /// consumed) — the ISO comma list of grouping ELEMENTS, cross-producted into
+  /// one grouping-set list.
   ///
-  /// Each ordinary key parses as a general scalar `expression` (ISO `<ordinary
-  /// grouping set>` is a value expression), so a key may be a column, an
-  /// arithmetic or `||` expression, a function call, a `CASE`/`COALESCE`, and
-  /// so on — resolved and lowered through `scope.term` at run and validated
-  /// through `scope.validate`. A bare identifier is itself an
-  /// `Expression.column`, so `GROUP BY col` is unchanged and a bare
-  /// `NATURAL`/`USING` merged key still lowers to its coalesce value through
-  /// the join scope.
+  /// Each element yields a set list (`Array<Array<Expression>>`): an ordinary
+  /// key is the single-set list `[[key]]`; `ROLLUP`/`CUBE`/`GROUPING SETS`
+  /// yield their expanded set lists (see `element`). The whole clause is the
+  /// PRODUCT of the elements' set lists — one result set per combination, the
+  /// concatenation of the chosen sets — so `GROUP BY a, ROLLUP(b, c)` crosses
+  /// `[[a]]` with `[[b, c], [b], []]` into `[[a, b, c], [a, b], [a]]`.
   ///
-  /// `GROUPING`/`SETS` are CONTEXT identifiers (not lexer keywords, mirroring
-  /// `CAST`/`COALESCE`), so a bare `GROUPING` immediately followed by a bare
-  /// `SETS` and a `(` opens the construct; a column named `grouping`
-  /// (delimited, or bare and NOT followed by `SETS`) stays a key. The two-token
-  /// lookahead (`secondary`) resolves the prefix before consuming either token.
+  /// A PURELY ordinary clause (no `ROLLUP`/`CUBE`/`GROUPING SETS`) returns
+  /// `.keys` — the plain path, so `GROUP BY a, b` stays `.keys([a, b])`. Any
+  /// construct makes the whole clause `.sets`, which the shared `expand`
+  /// desugars to a `UNION ALL` of per-set arms (Stage 1), so `ROLLUP`/`CUBE`
+  /// reuse that machinery verbatim.
+  ///
+  /// Each ordinary key parses as a general scalar `expression` (a column, an
+  /// arithmetic/`||` expression, a function call, a `CASE`/`COALESCE`, …),
+  /// resolved and lowered through `scope.term`; a bare identifier is itself an
+  /// `Expression.column`, so `GROUP BY col` is unchanged and a `NATURAL`/
+  /// `USING` merged key still lowers through the join scope.
   private mutating func grouping() throws(SQLError) -> Grouping {
     try expect(.by)
-    // The construct opens on a bare `GROUPING` immediately followed by a bare
-    // `SETS` — both context identifiers, resolved by two tokens of lookahead
-    // BEFORE either is consumed, so a delimited `"grouping"` or a bare
-    // `grouping` not followed by `SETS` stays an ordinary key.
+    // The grouping sets, built left to right from the single empty set (`[[]]`,
+    // the identity), and whether ANY element was a construct — the flag that
+    // chooses `.sets` over the plain `.keys` path.
+    var product: Array<Array<Expression>> = [[]]
+    var construct = false
+    var total = 0
+    repeat {
+      let (sets, opens) = try element()
+      construct = construct || opens
+      if sets.count == 1 {
+        // A SINGLE-set element (an ordinary key, or `()`) APPENDS its keys to
+        // every set so far — O(keys) per element, keeping a purely ordinary
+        // `GROUP BY a, b, …` LINEAR rather than O(n²) via `cross`. Its keys are
+        // copied into every set, so bound the reference growth first.
+        let added = product.count * sets[0].count
+        guard total + added <= Limits.references else { throw overflow }
+        for index in product.indices { product[index] += sets[0] }
+        total += added
+      } else {
+        // A MULTI-set element (a construct) needs the cross product. Bound its
+        // growth BEFORE `cross` allocates it — the set count (`sets / count`
+        // also keeps the multiply from overflowing) and the reference total,
+        // which the cross multiplies to `sets × total + product × expressions`.
+        let expressions = references(of: sets)
+        guard product.count <= Limits.sets / sets.count else {
+          throw .state("54001",
+                       "GROUP BY produces too many grouping sets (max 4096)")
+        }
+        let grown = sets.count * total + product.count * expressions
+        guard grown <= Limits.references else { throw overflow }
+        total = grown
+        product = cross(product, sets)
+      }
+    } while try match(.comma)
+    // A purely ordinary clause is a single set (each element appended its keys
+    // in source order) — the plain `.keys` path. An explicit `GROUP BY ()` is
+    // the exception: it resolves to a single EMPTY set, which must stay the
+    // grand total `.sets([[]])`, NOT collapse to `.keys([])` — the shape an
+    // ABSENT `GROUP BY` carries, which `Select.aggregates` reads as no grouping
+    // (one row per input row rather than one grand-total group).
+    if construct || product == [[]] {
+      return .sets(product)
+    }
+    return .keys(product[0])
+  }
+
+  /// Parses ONE grouping element into its set list, with a flag marking whether
+  /// it is a construct (`ROLLUP`/`CUBE`/`GROUPING SETS`) rather than an
+  /// ordinary set — the flag `grouping` ORs to choose `.keys` over `.sets`.
+  ///
+  /// `ROLLUP`/`CUBE`/`GROUPING`/`SETS` are CONTEXT identifiers, not lexer
+  /// keywords: a bare `GROUPING` immediately followed by a bare `SETS` opens a
+  /// (possibly nested) `GROUPING SETS`; a bare `ROLLUP`/`CUBE` immediately
+  /// followed by `(` opens that construct. A DELIMITED `"rollup"` (a `.quoted`,
+  /// not `.identifier`), or a bare `rollup`/`cube`/`grouping` NOT so followed,
+  /// falls through to an ordinary key — so those words stay usable as column
+  /// names (ISO reserves them; a UDF named `rollup`/`cube` cannot be a BARE
+  /// grouping key, which is acceptable). The two-token lookahead (`secondary`)
+  /// resolves each prefix before consuming any token.
+  ///
+  /// A leading `(` opens a composite ordinary set — a comma list `(a, b, …)` or
+  /// the grand-total `()` — via `composite`, which rewinds a single `(a)`, a
+  /// parenthesised expression `(a + b)` / `(a) + 1`, or a scalar subquery
+  /// `(SELECT 1)` so it reads as one ordinary key `expression`. The same
+  /// disambiguation applies at the top level and inside a `GROUPING SETS` list.
+  private mutating func element() throws(SQLError)
+      -> (sets: Array<Array<Expression>>, construct: Bool) {
     if case let .identifier(text) = current?.kind,
         text.uppercased() == "GROUPING",
         case let .identifier(next) = try secondary()?.kind,
         next.uppercased() == "SETS" {
-      return try .sets(sets())
+      return (try sets(), true)
     }
-    var keys = Array<Expression>()
-    try keys.append(expression())
-    while try match(.comma) {
-      try keys.append(expression())
+    if case let .identifier(text) = current?.kind {
+      switch text.uppercased() {
+      case "ROLLUP":
+        if try secondary()?.kind == .lparen { return (try rollup(), true) }
+      case "CUBE":
+        if try secondary()?.kind == .lparen { return (try cube(), true) }
+      default:
+        break
+      }
     }
-    return .keys(keys)
+    if let keys = try composite() {
+      return ([keys], false)
+    }
+    return ([[try expression()]], false)
   }
 
-  /// Parses the `GROUPING SETS ( set (, set)* )` tail — the `GROUPING` and
-  /// `SETS` context identifiers are the next two tokens (confirmed by
-  /// `grouping`) — into one key list per set, in source order. At least one set
-  /// is required.
+  /// Parses the `GROUPING SETS '(' element (',' element)* ')'` construct — the
+  /// `GROUPING` and `SETS` context identifiers are the next two tokens
+  /// (confirmed by `element`) — into ONE set list: the CONCATENATION of each
+  /// contained element's set list, in source order. Elements NEST — a member
+  /// may be an ordinary set, a `ROLLUP`/`CUBE`, or another `GROUPING SETS`. At
+  /// least one element is required.
   private mutating func sets() throws(SQLError) -> Array<Array<Expression>> {
     _ = try advance(expecting: "GROUPING")
     _ = try advance(expecting: "SETS")
     try expect(.lparen)
-    var sets = try [set()]
+    var result = try element().sets
+    var total = references(of: result)
     while try match(.comma) {
-      try sets.append(set())
+      let more = try element().sets
+      total += references(of: more)
+      result += more
+      // Members may THEMSELVES be constructs (`GROUPING SETS (CUBE(…), …)`);
+      // cap both the set count (4096, the clause-wide ceiling) and the
+      // reference total so a concatenation cannot amass unboundedly before
+      // `grouping`'s guard.
+      guard result.count <= Limits.sets else {
+        throw .state("54001",
+                     "GROUP BY produces too many grouping sets (max 4096)")
+      }
+      guard total <= Limits.references else { throw overflow }
     }
     try expect(.rparen)
-    return sets
+    return result
   }
 
-  /// Parses one grouping set `( e, … )` or `( )` — a parenthesised list of
-  /// general grouping expressions, possibly empty (the grand-total set) — into
-  /// its key list.
-  private mutating func set() throws(SQLError) -> Array<Expression> {
+  /// Parses a `ROLLUP '(' unit (',' unit)* ')'` element (the `ROLLUP` context
+  /// identifier is `current`) into its `n + 1` grouping sets — the descending
+  /// PREFIXES of the `n` units. `ROLLUP(a, b)` yields `[[a, b], [a], []]`;
+  /// `ROLLUP((a, b), c)` yields `[[a, b, c], [a, b], []]`.
+  private mutating func rollup() throws(SQLError) -> Array<Array<Expression>> {
+    let units = try units()
+    // A ROLLUP of n units materialises n + 1 prefixes whose sizes sum to
+    // O(n²) expression references — BEFORE `grouping`'s 4096-set guard runs, so
+    // a large but compact input (a 100,000-unit ROLLUP) would exhaust memory
+    // rather than fault. Reject the arity here first: n + 1 sets must stay
+    // within the 4096 cap, so n ≤ 4095.
+    guard units.count <= 4095 else {
+      throw .state("54001",
+                   "GROUP BY ROLLUP supports at most 4095 grouping elements")
+    }
+    // As with CUBE, a unit is copied into up to n + 1 prefixes, so a large
+    // composite unit multiplies. Bound the projected expansion — at most
+    // (n + 1) × the units' total expressions — before building the prefixes.
+    let budget = Limits.references / (units.count + 1)
+    guard references(of: units) <= budget else { throw overflow }
+    return prefixes(of: units)
+  }
+
+  /// Parses a `CUBE '(' unit (',' unit)* ')'` element (the `CUBE` context
+  /// identifier is `current`) into its `2ⁿ` grouping sets — one per subset of
+  /// the `n` units. `CUBE(a, b)` yields `[[a, b], [b], [a], []]`.
+  private mutating func cube() throws(SQLError) -> Array<Array<Expression>> {
+    let units = try units()
+    // A CUBE of n units enumerates 2ⁿ subsets. Reject a large arity BEFORE the
+    // `1 << n` shift: at n ≥ 63 it overflows `Int` (wrapping negative, then to
+    // zero at 64), silently yielding NO sets — later misreported as "requires
+    // at least one set" — and even a moderate n eagerly allocates
+    // exponentially many arrays. 2¹² = 4096 sets is the cap.
+    guard units.count <= 12 else {
+      throw .state("54001",
+                   "GROUP BY CUBE supports at most 12 grouping elements")
+    }
+    // units.count alone is not enough: each unit is COPIED into 2ⁿ⁻¹ of the 2ⁿ
+    // subsets, so a large COMPOSITE unit `(a, a, …)` multiplies its expressions
+    // across them. Bound the projected expansion — 2ⁿ⁻¹ × the units' total
+    // expressions — before building the subsets.
+    let budget = Limits.references / (1 << max(units.count - 1, 0))
+    guard references(of: units) <= budget else { throw overflow }
+    return subsets(of: units)
+  }
+
+  /// Parses the `'(' [unit (',' unit)*] ')'` unit list shared by `ROLLUP`/
+  /// `CUBE` (the context identifier is consumed here). Each unit is an ordinary
+  /// set — a bare key or a parenthesised `(a, b)` composite that groups as one
+  /// indivisible level. An EMPTY list (`ROLLUP()`/`CUBE()`) is admitted and
+  /// collapses to the single empty grand-total set.
+  private mutating func units() throws(SQLError) -> Array<Array<Expression>> {
+    _ = try advance(expecting: "ROLLUP or CUBE")
     try expect(.lparen)
     guard !(try match(.rparen)) else { return [] }
-    var keys = try [expression()]
+    var units = try [unit()]
     while try match(.comma) {
-      try keys.append(expression())
+      try units.append(unit())
     }
     try expect(.rparen)
-    return keys
+    return units
+  }
+
+  /// Parses one `ROLLUP`/`CUBE` unit — an ordinary set. A leading `(` opens a
+  /// parenthesised `(a, b)` / `()` composite UNLESS it merely STARTS a scalar
+  /// key — `(a) + 1`, `(a + b)`, or a scalar subquery `(SELECT …)`, whose own
+  /// parenthesis `expression` consumes — which `composite` rewinds; otherwise
+  /// the unit is a bare scalar key.
+  private mutating func unit() throws(SQLError) -> Array<Expression> {
+    if let keys = try composite() { return keys }
+    return [try expression()]
+  }
+
+  /// A parenthesised composite grouping set — the grand-total `()` or a comma
+  /// list `(a, b, …)` — returning its keys, or `nil` (having REWOUND the full
+  /// parser state) when the `(` instead begins a single scalar key that merely
+  /// STARTS with a parenthesis: a parenthesised expression `(a + b)` / `(a) +
+  /// 1`, or a scalar subquery `(SELECT …)`.
+  ///
+  /// The committing signal — an empty `()` or a top-level comma — sits an
+  /// UNBOUNDED distance past the `(` (the first key is an arbitrary
+  /// expression), so no fixed lookahead decides it: speculatively read past
+  /// the `(`, commit to a set only on `()` or a top-level comma (the
+  /// row-constructor rule), else rewind the `lexer`, `current`, AND the
+  /// `pending` lookahead so the caller reads one ordinary key `expression`.
+  private mutating func composite() throws(SQLError) -> Array<Expression>? {
+    guard case .lparen = current?.kind else { return nil }
+    let lexer = self.lexer
+    let token = self.current
+    let buffer = self.pending
+    try expect(.lparen)
+    if try match(.rparen) { return [] }
+    if current?.kind != .select, current?.kind != .table,
+        current?.kind != .values,
+        let first = try? expression(), try match(.comma) {
+      var keys = [first]
+      repeat {
+        try keys.append(expression())
+      } while try match(.comma)
+      try expect(.rparen)
+      return keys
+    }
+    self.lexer = lexer
+    self.current = token
+    self.pending = buffer
+    return nil
+  }
+
+  /// The descending PREFIXES of a unit list — the `ROLLUP` set list. For `n`
+  /// units it is `n + 1` sets: units `1..n` concatenated, then `1..n-1`, …,
+  /// down to the empty grand-total set. An empty unit list (`ROLLUP()`) yields
+  /// the single empty set `[[]]`.
+  private func prefixes(of units: Array<Array<Expression>>)
+      -> Array<Array<Expression>> {
+    var result = Array<Array<Expression>>()
+    var index = units.count
+    while index >= 0 {
+      result.append(units.prefix(index)
+                         .reduce(into: Array<Expression>()) { $0 += $1 })
+      index -= 1
+    }
+    return result
+  }
+
+  /// Every SUBSET of a unit list — the `CUBE` set list — enumerated
+  /// FULL-SET-FIRST by descending subset mask (bit `i` selects unit `i`, units
+  /// concatenated in source order). For `n` units it is `2ⁿ` sets, the full set
+  /// first and the empty grand-total set last. An empty unit list (`CUBE()`)
+  /// yields the single empty set `[[]]`.
+  private func subsets(of units: Array<Array<Expression>>)
+      -> Array<Array<Expression>> {
+    var result = Array<Array<Expression>>()
+    var mask = 1 << units.count
+    while mask > 0 {
+      mask -= 1
+      var keys = Array<Expression>()
+      for (index, member) in units.enumerated() where mask & (1 << index) != 0 {
+        keys += member
+      }
+      result.append(keys)
+    }
+    return result
+  }
+
+  /// The CROSS PRODUCT of two set lists — for each set on the left and each on
+  /// the right, their concatenation — the operator that combines the successive
+  /// `GROUP BY` elements. The seed `[[]]` (the single empty set) is its
+  /// identity.
+  private func cross(_ left: Array<Array<Expression>>,
+                     _ right: Array<Array<Expression>>)
+      -> Array<Array<Expression>> {
+    var result = Array<Array<Expression>>()
+    for lhs in left {
+      for rhs in right {
+        result.append(lhs + rhs)
+      }
+    }
+    return result
+  }
+
+  /// The caps bounding `GROUP BY` grouping-set expansion — the SINGLE SOURCE
+  /// OF TRUTH for every artificial limit the desugar enforces, so they are
+  /// tracked and tunable in one place (every guard below cites one of these).
+  /// `sets` is the most grouping sets a clause may expand to; `references` the
+  /// most expression references those sets may hold in total. Both bound a
+  /// COMPACT but heavily-duplicating clause — a wide `CUBE`/`ROLLUP`, a cross
+  /// product, a concatenation — from exhausting memory. The per-construct arity
+  /// guards derive from `sets`: `CUBE ≤ 12` units (2¹² = `sets`) and `ROLLUP ≤
+  /// 4095` units (n + 1 ≤ `sets`) reject before the 2ⁿ / prefix expansion.
+  private enum Limits {
+    static let sets = 4096
+    static let references = 1 << 20
+  }
+
+  /// The total expression references across a grouping-set list — the memory an
+  /// expansion materialises. Bounded by `Limits.references` (with the
+  /// `Limits.sets` count cap) at every producing site so a compact but
+  /// heavily-duplicating construct — a CUBE copying a large composite unit
+  /// across 2ⁿ⁻¹ subsets, a cross product, a concatenation — cannot allocate
+  /// unboundedly.
+  private func references(of sets: Array<Array<Expression>>) -> Int {
+    sets.reduce(0) { $0 + $1.count }
+  }
+
+  /// The program-limit fault raised when a grouping expansion would materialise
+  /// more than the budgeted `Limits.references` expression references.
+  private var overflow: SQLError {
+    .state("54001", "GROUP BY expands too many grouping expressions")
   }
 
   // MARK: - Relation

--- a/Tests/SQLTests/Queries/RollupCubeTests.swift
+++ b/Tests/SQLTests/Queries/RollupCubeTests.swift
@@ -1,0 +1,550 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+import SQLEngine
+import SQLTestSupport
+
+// MARK: - Fixtures
+
+/// A `Sales` relation of `Region`/`Product`/`Qty` rows — the same groupable
+/// shape the GROUPING SETS suite uses. Per-(Region, Product) sums: East/A 15
+/// (10 + 5), East/B 20, West/A 7, West/B 3. Per-Region sums: East 35, West 10.
+/// Per-Product sums: A 22 (10 + 5 + 7), B 23 (20 + 3). Grand total 45.
+private func sales() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("Sales", ["Region": .text, "Product": .text, "Qty": .integer]) {
+      Row("East", "A", 10)
+      Row("East", "A", 5)
+      Row("East", "B", 20)
+      Row("West", "A", 7)
+      Row("West", "B", 3)
+    }
+  }
+}
+
+/// An `N` relation of `A`/`V` rows — a numeric grouping column and a numeric to
+/// `SUM` — for the duplicate-overlap and general-key cases. Per-A sums: 1 is
+/// 150 (100 + 50), 2 is 30.
+private func nums() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("N", ["A": .integer, "V": .integer]) {
+      Row(1, 100)
+      Row(1, 50)
+      Row(2, 30)
+    }
+  }
+}
+
+/// A three-dimensional `G` relation — `A`/`B`/`C` grouping columns and a `V` to
+/// `SUM` — for the COMPOSITE-unit case `ROLLUP((A, B), C)`, where `(A, B)` is
+/// one indivisible level. Rows are chosen so each level's sums are distinct.
+private func grid() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("G", ["A": .integer, "B": .integer, "C": .integer,
+                   "V": .integer]) {
+      Row(1, 1, 1, 10)
+      Row(1, 1, 2, 20)
+      Row(1, 2, 1, 30)
+      Row(2, 1, 1, 40)
+    }
+  }
+}
+
+// MARK: - ROLLUP / CUBE
+
+struct RollupCubeTests {
+  @Test func `ROLLUP(a, b) yields the full, per-prefix, and grand-total levels`()
+      throws {
+    // `ROLLUP(Region, Product)` desugars to the descending PREFIXES of its two
+    // units — `[[Region, Product], [Region], []]` — so three arms: the full
+    // grouping, the per-Region grouping (Product a super-aggregate NULL), and
+    // the grand total (both NULL). Arm order, then row order within each arm
+    // (first-appearance). Per-(Region, Product): East/A 15, East/B 20, West/A
+    // 7, West/B 3; per-Region: East 35, West 10; grand total 45.
+    try sales().expect("""
+        SELECT Region, Product, SUM(Qty)
+          FROM Sales
+         GROUP BY ROLLUP(Region, Product)
+        """, yields: [
+          ["East", "A", 15], ["East", "B", 20],
+          ["West", "A", 7], ["West", "B", 3],
+          ["East", nil, 35], ["West", nil, 10],
+          [nil, nil, 45],
+        ])
+    // The desugar's ORACLE: the same query written as the equivalent explicit
+    // GROUPING SETS (Stage 1) yields identical rows — pinning both the set
+    // CONTENT and the arm ORDER of `ROLLUP`.
+    try sales().expect("""
+        SELECT Region, Product, SUM(Qty)
+          FROM Sales
+         GROUP BY ROLLUP(Region, Product)
+        """, equals: """
+        SELECT Region, Product, SUM(Qty)
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region, Product), (Region), ())
+        """)
+    // The clause desugars to `.sets`, not the plain `.keys` path.
+    let select = try parse(select: """
+        SELECT Region, Product, SUM(Qty)
+          FROM Sales
+         GROUP BY ROLLUP(Region, Product)
+        """)
+    let union: Bool
+    if case .sets = select.grouping { union = true } else { union = false }
+    #expect(union)
+  }
+
+  @Test func `CUBE(a, b) yields all four subset levels, full set first`() throws {
+    // `CUBE(Region, Product)` desugars to every SUBSET of its two units,
+    // enumerated FULL-SET-FIRST by descending mask:
+    // `[[Region, Product], [Product], [Region], []]`. Four arms: the full
+    // grouping, the per-Product grouping (Region NULL), the per-Region grouping
+    // (Product NULL), and the grand total. Per-Product: A 22, B 23.
+    try sales().expect("""
+        SELECT Region, Product, SUM(Qty)
+          FROM Sales
+         GROUP BY CUBE(Region, Product)
+        """, yields: [
+          ["East", "A", 15], ["East", "B", 20],
+          ["West", "A", 7], ["West", "B", 3],
+          [nil, "A", 22], [nil, "B", 23],
+          ["East", nil, 35], ["West", nil, 10],
+          [nil, nil, 45],
+        ])
+    // The ORACLE pins the subset-enumeration ORDER: the hand-written GROUPING
+    // SETS lists the four subsets in exactly the descending-mask order `CUBE`
+    // produces (full, {Product}, {Region}, {}).
+    try sales().expect("""
+        SELECT Region, Product, SUM(Qty)
+          FROM Sales
+         GROUP BY CUBE(Region, Product)
+        """, equals: """
+        SELECT Region, Product, SUM(Qty)
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region, Product), (Product), (Region), ())
+        """)
+  }
+
+  @Test func `GROUP BY a, ROLLUP(b) cross-products the elements`() throws {
+    // The whole clause is the CROSS PRODUCT of its elements: the ordinary
+    // `Region` (`[[Region]]`) crossed with `ROLLUP(Product)`
+    // (`[[Product], []]`) gives `[[Region, Product], [Region]]` — the full
+    // grouping and the per-Region subtotal, with NO grand total (Region is
+    // present in every set). Per-(Region, Product) then per-Region.
+    try sales().expect("""
+        SELECT Region, Product, SUM(Qty)
+          FROM Sales
+         GROUP BY Region, ROLLUP(Product)
+        """, yields: [
+          ["East", "A", 15], ["East", "B", 20],
+          ["West", "A", 7], ["West", "B", 3],
+          ["East", nil, 35], ["West", nil, 10],
+        ])
+    try sales().expect("""
+        SELECT Region, Product, SUM(Qty)
+          FROM Sales
+         GROUP BY Region, ROLLUP(Product)
+        """, equals: """
+        SELECT Region, Product, SUM(Qty)
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region, Product), (Region))
+        """)
+  }
+
+  @Test func `GROUPING SETS nests a ROLLUP and an ordinary set`() throws {
+    // A `GROUPING SETS` element may itself be a construct: `(ROLLUP(Region),
+    // (Product))` CONCATENATES `ROLLUP(Region)`'s `[[Region], []]` with the
+    // ordinary set `[[Product]]`, giving `[[Region], [], [Product]]` — per
+    // Region, grand total, then per Product.
+    try sales().expect("""
+        SELECT Region, Product, SUM(Qty)
+          FROM Sales
+         GROUP BY GROUPING SETS (ROLLUP(Region), (Product))
+        """, yields: [
+          ["East", nil, 35], ["West", nil, 10],
+          [nil, nil, 45],
+          [nil, "A", 22], [nil, "B", 23],
+        ])
+    try sales().expect("""
+        SELECT Region, Product, SUM(Qty)
+          FROM Sales
+         GROUP BY GROUPING SETS (ROLLUP(Region), (Product))
+        """, equals: """
+        SELECT Region, Product, SUM(Qty)
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region), (), (Product))
+        """)
+  }
+
+  @Test func `ROLLUP((a, b), c) treats the composite unit as one level`() throws {
+    // A parenthesised unit `(A, B)` groups its members as ONE indivisible
+    // level. `ROLLUP((A, B), C)` desugars to `[[A, B, C], [A, B], []]` — no
+    // `[A]` level, unlike `ROLLUP(A, B, C)`. Per-(A, B, C): 4 rows; per-(A, B):
+    // (1,1) 30, (1,2) 30, (2,1) 40; grand total 100.
+    try grid().expect("""
+        SELECT A, B, C, SUM(V)
+          FROM G
+         GROUP BY ROLLUP((A, B), C)
+        """, equals: """
+        SELECT A, B, C, SUM(V)
+          FROM G
+         GROUP BY GROUPING SETS ((A, B, C), (A, B), ())
+        """)
+    try grid().expect("""
+        SELECT A, B, C, SUM(V)
+          FROM G
+         GROUP BY ROLLUP((A, B), C)
+        """, yields: [
+          [1, 1, 1, 10], [1, 1, 2, 20], [1, 2, 1, 30], [2, 1, 1, 40],
+          [1, 1, nil, 30], [1, 2, nil, 30], [2, 1, nil, 40],
+          [nil, nil, nil, 100],
+        ])
+  }
+
+  @Test func `an ordinary GROUP BY a, b stays the plain keys path`() throws {
+    // A clause with NO construct is unchanged — it desugars to `.keys`, the
+    // plain grouped path, so `GROUP BY Region, Product` is one group set (the
+    // four per-(Region, Product) rows), NOT a set list with super-aggregate
+    // arms.
+    let select = try parse(select: """
+        SELECT Region, Product, SUM(Qty)
+          FROM Sales
+         GROUP BY Region, Product
+        """)
+    let plain: Bool
+    if case .keys = select.grouping { plain = true } else { plain = false }
+    #expect(plain)
+    try sales().expect("""
+        SELECT Region, Product, SUM(Qty)
+          FROM Sales
+         GROUP BY Region, Product
+        """, yields: [
+          ["East", "A", 15], ["East", "B", 20],
+          ["West", "A", 7], ["West", "B", 3],
+        ])
+  }
+
+  @Test func `a function-call and an arithmetic key do not misfire the construct`()
+      throws {
+    // An ordinary key is a general scalar `expression`, so a function call
+    // `UPPER(Product)` and an arithmetic `A + 1` group normally — the
+    // ROLLUP/CUBE lookahead fires ONLY on a bare `ROLLUP`/`CUBE` immediately
+    // before `(`, never on another call. `UPPER(Product)` leaves the
+    // already-upper A/B unchanged, so it matches `GROUP BY Product`; `A + 1`
+    // groups 1 → 2, 2 → 3.
+    try sales().expect("""
+        SELECT UPPER(Product), SUM(Qty)
+          FROM Sales
+         GROUP BY UPPER(Product)
+        """, equals: """
+        SELECT Product, SUM(Qty) FROM Sales GROUP BY Product
+        """)
+    try nums().expect("""
+        SELECT A + 1, SUM(V) FROM N GROUP BY A + 1
+        """, yields: [[2, 150], [3, 30]])
+    // Both stay the plain `.keys` path — no construct token appeared.
+    let select = try parse(select: "SELECT A + 1 FROM N GROUP BY A + 1")
+    let plain: Bool
+    if case .keys = select.grouping { plain = true } else { plain = false }
+    #expect(plain)
+  }
+
+  @Test func `a column named rollup stays a grouping key, delimited or bare`()
+      throws {
+    // `ROLLUP`/`CUBE` are CONTEXT identifiers: a DELIMITED `"rollup"` (a quoted
+    // identifier, never the construct) and a BARE `rollup` NOT followed by `(`
+    // both stay ordinary keys. The construct fires only on a bare `rollup(`.
+    let cat = try Catalog {
+      Relation("T", ["rollup": .text, "cube": .integer]) {
+        Row("x", 1)
+        Row("y", 2)
+      }
+    }
+    // A bare `rollup`/`cube` not followed by `(` — plain grouping keys.
+    try cat.expect("""
+        SELECT rollup, cube FROM T GROUP BY rollup, cube
+        """, yields: [["x", 1], ["y", 2]])
+    // The delimited spellings group identically.
+    try cat.expect("""
+        SELECT "rollup", "cube" FROM T GROUP BY "rollup", "cube"
+        """, yields: [["x", 1], ["y", 2]])
+    // A lone bare `rollup` key stays the plain `.keys` path.
+    let select = try parse(select: "SELECT rollup FROM T GROUP BY rollup")
+    let plain: Bool
+    if case .keys = select.grouping { plain = true } else { plain = false }
+    #expect(plain)
+  }
+
+  @Test func `run agrees with columns(of:validate:) for a ROLLUP query`() throws {
+    // run ≡ schema: the type derive over the union `.sets` matches the run.
+    // A NULL-padded column takes its sibling arm's type through the
+    // set-operation merge, so Region/Product stay `.text` and the SUM
+    // `.integer`.
+    let cat = try sales()
+    let sql = """
+        SELECT Region, Product, SUM(Qty)
+          FROM Sales
+         GROUP BY ROLLUP(Region, Product)
+        """
+    try cat.expect(sql, yields: [
+      ["East", "A", 15], ["East", "B", 20],
+      ["West", "A", 7], ["West", "B", 3],
+      ["East", nil, 35], ["West", nil, 10],
+      [nil, nil, 45],
+    ])
+    let columns = try cat.columns(of: parse(query: sql), validate: true)
+    #expect(columns == [
+      OutputColumn(name: "Region", type: .text),
+      OutputColumn(name: "Product", type: .text),
+      OutputColumn(name: "column 3", type: .integer),
+    ])
+  }
+
+  @Test func `ROLLUP rides the carrier for an unprojected-aggregate ORDER BY`()
+      throws {
+    // A ROLLUP query with a query-level ORDER BY over an UNPROJECTED aggregate
+    // (`MAX(Qty)`, not in the select list) rides the `ordered` carrier over the
+    // union — `expand` materialises the aggregate as a hidden column in every
+    // arm, orders on it, and trims it. `ROLLUP(Region)` is `((Region), ())`;
+    // per-Region MAX(Qty) East 20 / West 7, the grand-total MAX 20. Ascending
+    // MAX: West (7) → 10, then East (20) → 35 and the total (20) → 45 in arm
+    // order.
+    try sales().expect("""
+        SELECT SUM(Qty) FROM Sales
+         GROUP BY ROLLUP(Region) ORDER BY MAX(Qty)
+        """, yields: [[10], [35], [45]])
+    // The carrier trims the hidden aggregate: exactly the one projected column.
+    let cat = try sales()
+    let columns = try cat.columns(of: parse(query: """
+        SELECT SUM(Qty) FROM Sales
+         GROUP BY ROLLUP(Region) ORDER BY MAX(Qty)
+        """), validate: true)
+    #expect(columns == [OutputColumn(name: "column 1", type: .integer)])
+  }
+
+  @Test func `an empty ROLLUP() and CUBE() collapse to one grand-total set`()
+      throws {
+    // Zero units is admitted: the empty product is the single empty grand-total
+    // set (`.sets([[]])`), so `ROLLUP()` and `CUBE()` each yield exactly ONE
+    // grand-total row — the SUM over the whole relation, 45.
+    try sales().expect("SELECT SUM(Qty) FROM Sales GROUP BY ROLLUP()",
+                       yields: [[45]])
+    try sales().expect("SELECT SUM(Qty) FROM Sales GROUP BY CUBE()",
+                       yields: [[45]])
+    // The ORACLE: `GROUPING SETS (())` — a lone grand-total set — is identical.
+    try sales().expect("SELECT SUM(Qty) FROM Sales GROUP BY ROLLUP()",
+                       equals: """
+        SELECT SUM(Qty) FROM Sales GROUP BY GROUPING SETS (())
+        """)
+    // Still the `.sets` path (a construct token appeared), not plain `.keys`.
+    let select = try parse(select: "SELECT SUM(Qty) FROM Sales GROUP BY CUBE()")
+    let union: Bool
+    if case .sets = select.grouping { union = true } else { union = false }
+    #expect(union)
+  }
+
+  @Test func `a duplicate grouping set keeps its rows, not deduplicated`() throws {
+    // ISO combines the sets with UNION ALL, so an OVERLAPPING clause keeps
+    // duplicate rows. `GROUP BY ROLLUP(A), A` crosses `[[A], []]` with `[[A]]`
+    // into `[[A, A], [A]]` — both sets group by `A` (a repeated key is
+    // harmless), so each per-A group appears TWICE.
+    try nums().expect("""
+        SELECT A, SUM(V) FROM N GROUP BY ROLLUP(A), A
+        """, yields: [[1, 150], [2, 30], [1, 150], [2, 30]])
+    try nums().expect("""
+        SELECT A, SUM(V) FROM N GROUP BY ROLLUP(A), A
+        """, equals: """
+        SELECT A, SUM(V) FROM N GROUP BY GROUPING SETS ((A), (A))
+        """)
+  }
+
+  @Test func `a scalar-subquery unit keeps its own parenthesis`() throws {
+    // A `ROLLUP`/`CUBE` unit, or a `GROUPING SETS` member, that IS a scalar
+    // subquery `(SELECT …)` must route through `expression` — the leading `(`
+    // is the SUBQUERY's, not a composite-set delimiter, so it is not stolen
+    // (which produced `expected an identifier but found 'SELECT'`). A scalar
+    // subquery is a valid ordinary grouping key, so it is valid as a unit too.
+    // `(SELECT 1)` is a constant, so grouping on it forms ONE group.
+    try sales().expect("""
+        SELECT SUM(Qty) FROM Sales GROUP BY ROLLUP((SELECT 1))
+        """, equals: """
+        SELECT SUM(Qty) FROM Sales
+          GROUP BY GROUPING SETS (((SELECT 1)), ())
+        """)
+    try sales().expect("""
+        SELECT SUM(Qty) FROM Sales GROUP BY CUBE((SELECT 1))
+        """, equals: """
+        SELECT SUM(Qty) FROM Sales
+          GROUP BY GROUPING SETS (((SELECT 1)), ())
+        """)
+    try sales().expect("""
+        SELECT SUM(Qty) FROM Sales GROUP BY GROUPING SETS ((SELECT 1))
+        """, equals: "SELECT SUM(Qty) FROM Sales GROUP BY (SELECT 1)")
+    // A subquery beside an ordinary key in a COMPOSITE unit still parses — the
+    // composite `(` is the delimiter, the inner `(SELECT …)` its own key.
+    try sales().expect("""
+        SELECT Region, SUM(Qty) FROM Sales
+          GROUP BY ROLLUP(((SELECT 1), Region))
+        """, equals: """
+        SELECT Region, SUM(Qty) FROM Sales
+          GROUP BY GROUPING SETS (((SELECT 1), Region), ())
+        """)
+    // GUARD: a plain composite unit `(a, b)` is unaffected — no subquery, the
+    // `(` stays a set delimiter.
+    try sales().expect("""
+        SELECT Region, Product, SUM(Qty) FROM Sales
+          GROUP BY ROLLUP((Region, Product))
+        """, equals: """
+        SELECT Region, Product, SUM(Qty) FROM Sales
+          GROUP BY GROUPING SETS ((Region, Product), ())
+        """)
+  }
+
+  @Test func `a top-level parenthesised ordinary set groups its keys`() throws {
+    // The generalised grammar admits a TOP-LEVEL parenthesised composite set
+    // `(a, b)` and the grand-total `()` — which the flat `expression` path
+    // could not consume (a comma list / empty parens faulted). They group
+    // exactly as the bare forms.
+    try sales().expect("""
+        SELECT Region, Product, SUM(Qty) FROM Sales GROUP BY (Region, Product)
+        """, equals: """
+        SELECT Region, Product, SUM(Qty) FROM Sales GROUP BY Region, Product
+        """)
+    // `GROUP BY ()` is the grand total — equivalent to no `GROUP BY`.
+    try sales().expect("SELECT SUM(Qty) FROM Sales GROUP BY ()",
+                       equals: "SELECT SUM(Qty) FROM Sales")
+    // A composite set beside a bare key.
+    try sales().expect("""
+        SELECT Region, Product, SUM(Qty) FROM Sales GROUP BY (Region), Product
+        """, equals: """
+        SELECT Region, Product, SUM(Qty) FROM Sales GROUP BY Region, Product
+        """)
+    // GUARD (no regression): a top-level `(` that begins a LARGER scalar key
+    // — a parenthesised expression `(A + 1)`, or a paren that merely starts an
+    // expression `(A) + 1` — is read as ONE key, NOT truncated at the `)`. The
+    // row backtracking rewinds a single `(…)` with no top-level comma.
+    try nums().expect("SELECT A + 1, SUM(V) FROM N GROUP BY (A + 1)",
+                      equals: "SELECT A + 1, SUM(V) FROM N GROUP BY A + 1")
+    try nums().expect("SELECT A + 1, SUM(V) FROM N GROUP BY (A) + 1",
+                      equals: "SELECT A + 1, SUM(V) FROM N GROUP BY A + 1")
+    // A top-level scalar subquery key still parses (the `(` is the subquery's).
+    try sales().expect("SELECT SUM(Qty) FROM Sales GROUP BY (SELECT 1)",
+                       equals: "SELECT SUM(Qty) FROM Sales GROUP BY (SELECT 1)")
+  }
+
+  @Test func `GROUP BY () is the grand total, not absent grouping`() throws {
+    // `GROUP BY ()` is a single grand-total group — NOT the `.keys([])` shape
+    // an ABSENT `GROUP BY` carries, which is no grouping (one row per input
+    // row). It yields ONE row whatever the input cardinality, matching the
+    // GROUPING SETS `(())` form.
+    try sales().expect("SELECT 1 FROM Sales GROUP BY ()", yields: [[1]])
+    try sales().expect("""
+        SELECT SUM(Qty) FROM Sales GROUP BY ()
+        """, equals: """
+        SELECT SUM(Qty) FROM Sales GROUP BY GROUPING SETS (())
+        """)
+    // Over an EMPTY input the grand-total group still yields its one row.
+    let empty = try Catalog { Relation("E", ["x": .integer]) { } }
+    try empty.expect("SELECT 1 FROM E GROUP BY ()", yields: [[1]])
+    try empty.expect("SELECT COUNT(*) FROM E GROUP BY ()", yields: [[0]])
+  }
+
+  @Test func `an over-large CUBE or cross product faults, not overflows`()
+      throws {
+    // A CUBE of 63/64 units once overflowed `1 << n` to a negative/zero mask,
+    // yielding NO sets and the misleading "requires at least one set". It now
+    // faults a program-limit error BEFORE the shift, and the whole clause's
+    // cross product is capped the same way.
+    let cube = SQLError.state("54001",
+                              "GROUP BY CUBE supports at most 12 grouping " +
+                              "elements")
+    func columns(_ range: Range<Int>) -> String {
+      range.map { "c\($0)" }.joined(separator: ", ")
+    }
+    try sales().expect("SELECT 1 FROM Sales GROUP BY CUBE(\(columns(0..<63)))",
+                       fails: cube)
+    try sales().expect("SELECT 1 FROM Sales GROUP BY CUBE(\(columns(0..<64)))",
+                       fails: cube)
+    try sales().expect("SELECT 1 FROM Sales GROUP BY CUBE(\(columns(0..<13)))",
+                       fails: cube)
+    // Within the cap a CUBE still expands (Region/Product = 4 sets).
+    try sales().expect("""
+        SELECT Region, Product, SUM(Qty) FROM Sales
+          GROUP BY CUBE(Region, Product)
+        """, equals: """
+        SELECT Region, Product, SUM(Qty) FROM Sales
+          GROUP BY GROUPING SETS ((Region, Product), (Product), (Region), ())
+        """)
+    // Two maximal cubes multiply past 4096 — caught by the cross-product cap.
+    try sales().expect("""
+        SELECT 1 FROM Sales
+          GROUP BY CUBE(\(columns(0..<12))), CUBE(\(columns(12..<24)))
+        """, fails: SQLError.state("54001", "GROUP BY produces too many " +
+                                   "grouping sets (max 4096)"))
+    // A ROLLUP of n units expands to n + 1 prefixes summing to O(n²)
+    // expression references; its arity is validated BEFORE the prefixes are
+    // built, so an oversized (here 4096-unit) ROLLUP faults immediately rather
+    // than materialising the quadratic structure first.
+    try sales().expect(
+        "SELECT 1 FROM Sales GROUP BY ROLLUP(\(columns(0..<4096)))",
+        fails: SQLError.state("54001", "GROUP BY ROLLUP supports at most " +
+                              "4095 grouping elements"))
+  }
+
+  @Test func `a parenthesised unit keeps its arithmetic tail as one key`()
+      throws {
+    // `ROLLUP((A) + 1)` — the unit is the scalar key `(A) + 1`, NOT a composite
+    // set `(A)` with a stray `+ 1` (which once left `+ 1` where the construct's
+    // `)` was expected and faulted). The unit disambiguation rewinds a single
+    // `(A)`, so parens are transparent and it parses identically to the bare
+    // `A + 1` unit — at ROLLUP/CUBE units and GROUPING SETS members alike.
+    try nums().expect("SELECT SUM(V) FROM N GROUP BY ROLLUP((A) + 1)",
+                      equals: "SELECT SUM(V) FROM N GROUP BY ROLLUP(A + 1)")
+    try nums().expect("SELECT SUM(V) FROM N GROUP BY CUBE((A) + 1)",
+                      equals: "SELECT SUM(V) FROM N GROUP BY CUBE(A + 1)")
+    try nums().expect("SELECT SUM(V) FROM N GROUP BY GROUPING SETS ((A) + 1)",
+                      equals: "SELECT SUM(V) FROM N GROUP BY (A) + 1")
+    // GUARD: a genuine composite unit `(A, V)` is still a set, not truncated.
+    try nums().expect("""
+        SELECT SUM(V) FROM N GROUP BY ROLLUP((A, V))
+        """, equals: """
+        SELECT SUM(V) FROM N GROUP BY GROUPING SETS ((A, V), ())
+        """)
+  }
+
+  @Test func `a long ordinary clause and repeated keys parse and group`()
+      throws {
+    // Ordinary keys accumulate by append (linear), not O(n²) cross. The RESULT
+    // is unaffected — a repeated key groups as one, key order within the set
+    // does not matter, and a repeated literal collapses to one group.
+    try nums().expect("SELECT A, SUM(V) FROM N GROUP BY A, A, A",
+                      equals: "SELECT A, SUM(V) FROM N GROUP BY A")
+    try nums().expect("SELECT SUM(V) FROM N GROUP BY 1, 1, 1",
+                      equals: "SELECT SUM(V) FROM N GROUP BY 1")
+  }
+
+  @Test func `a wide composite unit is bounded before expansion`() throws {
+    // units.count is capped, but a COMPOSITE unit holds arbitrarily many
+    // expressions, and CUBE copies each unit across 2ⁿ⁻¹ subsets — so a compact
+    // 12-unit CUBE whose first unit is a wide composite would materialise
+    // hundreds of millions of references. The PROJECTED expansion (references,
+    // not just unit count) is bounded before the subsets are built.
+    func cols(_ range: Range<Int>) -> String {
+      range.map { "c\($0)" }.joined(separator: ", ")
+    }
+    let refs = SQLError.state("54001",
+                              "GROUP BY expands too many grouping expressions")
+    // 12 units, first a 600-column composite → 2¹¹ × ~611 references ≫ 2²⁰.
+    try sales().expect("""
+        SELECT 1 FROM Sales
+          GROUP BY CUBE((\(cols(0..<600))), \(cols(600..<611)))
+        """, fails: refs)
+    // The cross / append path is bounded too: a 12-column CUBE (4096 sets)
+    // followed by a wide composite ordinary set multiplies past the budget.
+    try sales().expect("""
+        SELECT 1 FROM Sales
+          GROUP BY CUBE(\(cols(0..<12))), (\(cols(12..<525)))
+        """, fails: refs)
+  }
+}


### PR DESCRIPTION
Generalize the GROUP BY grammar (parser only) from "ordinary key list or GROUPING SETS" to a comma list of grouping ELEMENTS, cross-producted into one set list, with ROLLUP and CUBE joining GROUPING SETS as constructs.

The clause is now `element (',' element)*`. Each element parses to a set list (Array<Array<Expression>>): an ordinary key is the single-set list `[[key]]`; ROLLUP(u1,…,un) is the n+1 descending prefixes of its units; CUBE(u1,…,un) is the 2ⁿ subsets of its units, enumerated full-set-first by descending subset mask; GROUPING SETS concatenates its (nesting) elements' set lists. The whole clause is the cross product of the elements' set lists — one result set per combination, the concatenation of the chosen sets — so `GROUP BY a, ROLLUP(b, c)` yields `[[a,b,c],[a,b],[a]]`. A ROLLUP/CUBE unit is an ordinary set: a bare key or a parenthesised `(a, b)` composite that groups as one indivisible level; an empty `ROLLUP()`/`CUBE()` collapses to the single grand-total set.

Return-type dispatch preserves the existing behavior exactly: a purely ordinary clause (no construct token) still returns `.keys`, so plain GROUP BY is byte-for-byte unchanged; any ROLLUP/CUBE/GROUPING SETS makes the whole clause `.sets`. All desugaring happens at parse time into the Stage 1 `.sets` node — expand(), the engine, and the AST are untouched, so ROLLUP/CUBE reuse the per-set-arm UNION ALL machinery verbatim.

ROLLUP/CUBE/GROUPING/SETS remain CONTEXT identifiers, not keywords: ROLLUP/CUBE open their construct only as a bare identifier immediately followed by `(` (one token of lookahead), and GROUPING only immediately before SETS (the existing two-token trick). A delimited "rollup" or a bare rollup/cube/grouping not so followed stays an ordinary key, so the words remain usable as column names; a general call key such as `UPPER(x)` never misfires the construct.