### PR TITLE
SQLEngine: add the GROUPING() grouping-sets function

### DIFF
--- a/Sources/SQLEngine/AST+Expression.swift
+++ b/Sources/SQLEngine/AST+Expression.swift
@@ -282,6 +282,13 @@ public enum Comparison: Hashable, Sendable {
 
 /// A literal operand of a comparison.
 public enum Literal: Hashable, Sendable {
+  /// The keyword `NULL` written as a value expression — SQL's absent value, of
+  /// no determinate type (ISO `<null specification>`). It lowers to a constant
+  /// NULL, so a projection of it places no type constraint on a set-operation's
+  /// unified column (it unifies with any typed arm, as `COALESCE` skips a
+  /// constant-NULL argument), and its comparisons are UNKNOWN under three-valued
+  /// logic. Distinct from the `IS NULL` predicate, which tests a value.
+  case null
   /// A single-quoted string literal, with its escapes resolved.
   case string(String)
   /// An integer literal — a bare run of digits, exact numeric.

--- a/Sources/SQLEngine/AST.swift
+++ b/Sources/SQLEngine/AST.swift
@@ -949,6 +949,23 @@ public indirect enum Expression: Hashable, Sendable {
   /// resolves (or faults) as any other column would; correlation is a later
   /// slice.
   case subquery(Query)
+  /// `GROUPING(a, …)` — the ISO grouping-sets function, an integer bit-VECTOR
+  /// reporting per argument whether that expression was ROLLED UP (omitted from
+  /// the current result row's grouping set — bit `1`) or is a grouping key of
+  /// this set (bit `0`). The FIRST argument is the MOST-significant bit, so over
+  /// the `()` arm of `GROUPING SETS ((a, b), ())` `GROUPING(a, b)` is `0b11`
+  /// (`3`), and over the `(a)` arm it is `0b01` (`1`). Each argument must be a
+  /// `GROUP BY` expression of some grouping set (else an error), and GROUPING is
+  /// valid only in a grouped query (a `GROUP BY`, or a whole-result aggregate).
+  ///
+  /// It is a FIRST-CLASS node — NOT a scalar `call(name: "GROUPING", …)`, which
+  /// would fault `SQLError.function` as an unregistered routine — because it
+  /// resolves against the GROUPED scope's key membership rather than through
+  /// the routines: after GROUPING SETS expansion each arm knows its own
+  /// keys and the superset, so GROUPING is a COMPILE-TIME per-arm integer
+  /// CONSTANT (`Grouped.term`) and no executor path ever evaluates a `grouping`
+  /// node — it lowers to a `Term.constant(.integer(bits))`.
+  case grouping(Array<Expression>)
 }
 
 /// An `ORDER BY` clause: an ordered list of sort keys, each a sort value and

--- a/Sources/SQLEngine/Aggregation.swift
+++ b/Sources/SQLEngine/Aggregation.swift
@@ -52,6 +52,42 @@ extension Expression {
       arguments.contains { $0.aggregated }
     case let .nullif(lhs, rhs):
       lhs.aggregated || rhs.aggregated
+    case let .grouping(arguments):
+      // GROUPING is not itself an aggregate; like a `call`, it is aggregated
+      // only if an argument is (a GROUP BY expression never is, so this is
+      // false in practice) — mirroring the neighbouring `call` arm.
+      arguments.contains { $0.aggregated }
+    }
+  }
+
+  /// Whether the expression nests a `GROUPING(…)` operator anywhere within it.
+  /// The grouped lowering reads this to route a GROUPING-bearing compound (a
+  /// `CASE WHEN GROUPING(x) = 1 …`, an arithmetic over it) through its
+  /// per-operand descent rather than the whole-expression key match, which
+  /// lowers through `Scope.term` — and `Scope.term` cannot resolve a GROUPING
+  /// (it faults `.state`, the operator having meaning only in the grouped
+  /// space). Mirrors `aggregated`, which carves the same path out for a nested
+  /// aggregate; a GROUPING inside a scalar subquery belongs to that subquery's
+  /// own grouped scope, so a `subquery` is not GROUPING-bearing here.
+  internal var grouping: Bool {
+    switch self {
+    case .column, .literal, .aggregate, .subquery:
+      false
+    case .grouping:
+      true
+    case let .call(_, arguments):
+      arguments.contains { $0.grouping }
+    case let .binary(_, lhs, rhs):
+      lhs.grouping || rhs.grouping
+    case let .case(whens, otherwise):
+      whens.contains { $0.when.grouping || $0.then.grouping }
+          || (otherwise?.grouping ?? false)
+    case let .cast(operand, _):
+      operand.grouping
+    case let .coalesce(arguments):
+      arguments.contains { $0.grouping }
+    case let .nullif(lhs, rhs):
+      lhs.grouping || rhs.grouping
     }
   }
 
@@ -80,6 +116,9 @@ extension Expression {
       arguments.contains { $0.bound }
     case let .nullif(lhs, rhs):
       lhs.bound || rhs.bound
+    case let .grouping(arguments):
+      // As a `call`: bound only if an argument references a query binding.
+      arguments.contains { $0.bound }
     }
   }
 }
@@ -90,6 +129,15 @@ extension Predicate.Operand {
   internal var aggregated: Bool {
     switch self {
     case let .expression(expression): expression.aggregated
+    case .parameter: false
+    }
+  }
+
+  /// Whether this `LIKE` operand nests a `GROUPING(…)` — an expression's own,
+  /// never a `:parameter` (see `Expression.grouping`).
+  internal var grouping: Bool {
+    switch self {
+    case let .expression(expression): expression.grouping
     case .parameter: false
     }
   }
@@ -170,6 +218,49 @@ extension Predicate {
       lhs.aggregated || rhs.aggregated
     case let .not(operand):
       operand.aggregated
+    }
+  }
+
+  /// Whether the predicate nests a `GROUPING(…)` anywhere within it — used to
+  /// spot a GROUPING hiding in a `CASE` guard (`CASE WHEN GROUPING(x) = 1 …`),
+  /// so the grouped lowering descends the guarded compound per operand rather
+  /// than matching it as a whole `GROUP BY` key (see `Expression.grouping`). A
+  /// subquery is its own scope, so a GROUPING inside one never makes the
+  /// enclosing predicate GROUPING-bearing.
+  internal var grouping: Bool {
+    switch self {
+    case let .comparison(left, _, right):
+      left.grouping || right.grouping
+    case let .bound(left, _, _):
+      left.grouping
+    case let .null(operand, _):
+      operand.grouping
+    case let .membership(operand, values, _):
+      operand.grouping || values.contains { $0.grouping }
+    case let .rows(lhs, _, rhs):
+      lhs.contains { $0.grouping } || rhs.contains { $0.grouping }
+    case let .among(lhs, rows, _):
+      lhs.contains { $0.grouping }
+          || rows.contains { $0.contains { $0.grouping } }
+    case .exists:
+      false
+    case let .within(operand, _, _):
+      operand.grouping
+    case let .quantified(operand, _, _, _):
+      operand.grouping
+    case let .like(operand, pattern, escape, _):
+      operand.grouping || pattern.grouping
+          || (escape?.grouping ?? false)
+    case let .between(test, lower, upper, _):
+      test.grouping || lower.grouping || upper.grouping
+    case let .distinct(lhs, rhs, _):
+      lhs.grouping || rhs.grouping
+    case let .truth(inner, _, _):
+      inner.grouping
+    case let .and(lhs, rhs), let .or(lhs, rhs):
+      lhs.grouping || rhs.grouping
+    case let .not(operand):
+      operand.grouping
     }
   }
 
@@ -707,6 +798,10 @@ extension Expression {
     case let .nullif(lhs, rhs):
       lhs.collect(subqueries: &queries)
       rhs.collect(subqueries: &queries)
+    case let .grouping(arguments):
+      // As a `call`: descend the arguments so a subquery nested in one is
+      // collected for the pre-pass.
+      for argument in arguments { argument.collect(subqueries: &queries) }
     }
   }
 
@@ -743,6 +838,9 @@ extension Expression {
     case let .nullif(lhs, rhs):
       lhs.collect(valued: &queries)
       rhs.collect(valued: &queries)
+    case let .grouping(arguments):
+      // As a `call`: descend the arguments for any `IN (Q)`-position subquery.
+      for argument in arguments { argument.collect(valued: &queries) }
     }
   }
 
@@ -781,6 +879,9 @@ extension Expression {
     case let .nullif(lhs, rhs):
       lhs.collect(scalar: &queries)
       rhs.collect(scalar: &queries)
+    case let .grouping(arguments):
+      // As a `call`: descend the arguments for any scalar-subquery position.
+      for argument in arguments { argument.collect(scalar: &queries) }
     }
   }
 
@@ -815,6 +916,10 @@ extension Expression {
     case let .nullif(lhs, rhs):
       lhs.collect(existential: &queries)
       rhs.collect(existential: &queries)
+    case let .grouping(arguments):
+      // As a `call`: descend the arguments for any `EXISTS (Q)`-position
+      // subquery.
+      for argument in arguments { argument.collect(existential: &queries) }
     }
   }
 
@@ -1158,6 +1263,11 @@ extension Expression {
     case let .nullif(lhs, rhs):
       lhs.collect(into: &expressions)
       rhs.collect(into: &expressions)
+    case let .grouping(arguments):
+      // GROUPING is not an aggregate, but — like a `call` — descend its
+      // arguments so any aggregate nested in one is collected (a GROUP BY
+      // expression never nests one, so this gathers nothing in practice).
+      for argument in arguments { argument.collect(into: &expressions) }
     }
   }
 

--- a/Sources/SQLEngine/Filter.swift
+++ b/Sources/SQLEngine/Filter.swift
@@ -908,6 +908,7 @@ extension Array where Element == Filter {
 /// The literal `literal` as a typed `Value`.
 internal func value(of literal: Literal) throws(SQLError) -> Value {
   return switch literal {
+  case .null: .null
   case let .integer(integer): .integer(integer)
   case let .string(string): .text(string)
   case let .boolean(boolean): .boolean(boolean)

--- a/Sources/SQLEngine/Filter.swift
+++ b/Sources/SQLEngine/Filter.swift
@@ -313,6 +313,21 @@ internal indirect enum Term: Equatable, Sendable {
   /// `CASE` coerces its selected arm. A later correlated slice re-runs it per
   /// outer row.
   case subquery(Subkey, correlation: Correlation, type: ValueType)
+  /// `GROUPING(a, …)` — the lowered form of the AST's `Expression.grouping`.
+  /// GROUPING is a per-arm integer bit-vector the grouped lowering already
+  /// decided (`bits`), so the executor simply yields `.integer(bits)` and it
+  /// reads no cell. The lowered argument terms (`over`) carry the operator's
+  /// identity — which grouping expressions it reports on, in the arm-stable
+  /// base scope, so a rolled-up column stays distinct from another rather than
+  /// collapsing to the shared super-aggregate NULL. A carrier resolves a
+  /// query-level `ORDER BY GROUPING(x)` against the first arm's projected terms
+  /// by `Term` identity (`Carrier`); without this dedicated case GROUPING lowered
+  /// to a bare `constant(.integer(bits))`, indistinguishable from an unrelated
+  /// projection that merely shares this arm's constant value, so the sort bound
+  /// to the wrong column. The `over` terms are identity only — never evaluated,
+  /// so `references` reads none of their slots and `remapped` leaves them (and
+  /// the settled `bits`) unchanged.
+  case grouping(over: Array<Term>, bits: Int)
 }
 
 extension Term {
@@ -352,6 +367,8 @@ extension Term {
       ll == rl && lr == rr
     case let (.subquery(lkey, lcorr, ltype), .subquery(rkey, rcorr, rtype)):
       lkey == rkey && lcorr == rcorr && ltype == rtype
+    case let (.grouping(lover, lbits), .grouping(rover, rbits)):
+      lover == rover && lbits == rbits
     default:
       false
     }
@@ -403,6 +420,10 @@ extension Term {
       // so it references none. An UNCORRELATED one (empty correlation)
       // references none — its value is a single cache lookup.
       slots.formUnion(correlation.slots)
+    case .grouping:
+      // A settled per-arm constant read from no cell; its `over` identity terms
+      // are never evaluated, so GROUPING references no slot to materialise.
+      break
     }
   }
 }
@@ -444,6 +465,10 @@ extension Term {
       // unchanged.
       .subquery(key, correlation: correlation.remapped(through: slot),
                 type: type)
+    case .grouping:
+      // A settled constant; its `over` identity terms are never read, so leave
+      // the term — and its now-stale base-scope ordinals — unchanged.
+      self
     }
   }
 
@@ -456,7 +481,9 @@ extension Term {
     switch self {
     // A `:parameter` is a bindings lookup, never a fault — safe, as
     // `Filter.Operand.parameter` is.
-    case .slot, .parameter, .constant: true
+    // GROUPING is a settled per-arm integer constant, so it never faults —
+    // safe, as a bare `constant` is.
+    case .slot, .parameter, .constant, .grouping: true
     case .apply, .binary, .case, .cast, .coalesce, .nullif, .subquery: false
     }
   }
@@ -472,7 +499,8 @@ extension Term {
   internal var parameterised: Bool {
     switch self {
     case .parameter: true
-    case .slot, .constant: false
+    // GROUPING is a settled constant reading no `:parameter`.
+    case .slot, .constant, .grouping: false
     case let .apply(_, arguments): arguments.contains(where: \.parameterised)
     case let .binary(_, lhs, rhs): lhs.parameterised || rhs.parameterised
     case let .case(branches, otherwise, _):
@@ -990,6 +1018,11 @@ extension Catalog where Self: ~Escapable {
       // one memoises; a CORRELATED one re-runs against this row's correlated
       // bindings.
       try scalar(row, key, correlation, type, context)
+    case let .grouping(_, bits):
+      // A settled per-arm bit-vector — the grouped lowering already decided it
+      // from this arm's key membership — so it yields its integer directly,
+      // reading no cell of the row. The `over` terms are identity only.
+      .integer(bits)
     }
   }
 

--- a/Sources/SQLEngine/Grouped.swift
+++ b/Sources/SQLEngine/Grouped.swift
@@ -165,6 +165,13 @@ internal struct Grouped {
                     _ routines: Routines = [:],
                     subquery: Resolution = .unsupported)
       throws(SQLError) -> Term {
+    // `GROUPING(a, …)` is a per-arm integer bit-vector decided by this arm's
+    // key membership — handled before the general lowering below (which would
+    // route it through `scope.term`, faulting `.state`), so it lowers to a
+    // `Term.grouping` carrying that value and its cross-arm identity.
+    if case let .grouping(arguments) = expression {
+      return try grouping(over: arguments, routines, subquery: subquery)
+    }
     if case .aggregate = expression,
        let slot = try slot(of: expression, routines, subquery: subquery) {
       return .slot(slot)
@@ -186,17 +193,23 @@ internal struct Grouped {
     // surface — cases a bare merged column and a general expression never
     // reach. A merged column that matches NO key faults `.grouping`; a general
     // expression that matches none falls through so its operands are each
-    // checked (`Amount + 2` faults on the bare non-key `Amount`). An
-    // AGGREGATED expression (`SUM(x) + 1`) is skipped too: `scope.term` faults
-    // on an aggregate, so it descends into the switch, which routes each
-    // aggregate to its result slot and each key operand to its grouped slot.
+    // checked (`Amount + 2` faults on the bare non-key `Amount`). An aggregated
+    // expression (`SUM(x) + 1`) is skipped too: `scope.term` faults on an
+    // aggregate, so it descends into the switch, which routes each aggregate to
+    // its result slot and each key operand to its grouped slot. A
+    // GROUPING-bearing expression (`CASE WHEN GROUPING(x) = 1 …`) is skipped
+    // for the same reason — `scope.term` faults on the GROUPING it cannot
+    // resolve — so it too descends into the switch, where the `.case`/`.binary`
+    // arms recurse through this `term` and lower the nested GROUPING to its
+    // per-arm constant. A GROUPING can never itself be a `GROUP BY` key, so
+    // skipping the key match loses no match.
     let merged = if case let .column(column) = expression {
       column.qualifier == nil && scope.merges(column.name) != nil
     } else {
       false
     }
     let plain = if case .column = expression { !merged } else { false }
-    if !plain, !expression.aggregated {
+    if !plain, !expression.aggregated, !expression.grouping {
       let lowered = try scope.term(expression, routines, subquery: subquery)
       if let index = terms.firstIndex(of: lowered) { return .slot(index) }
       // A reference to a column ANOTHER set groups on but THIS arm's set omits
@@ -299,7 +312,95 @@ internal struct Grouped {
       // inconsistency, since the query gathers every projection/HAVING
       // aggregate.
       throw .state("XX000", "uncollected aggregate")
+    case .grouping:
+      // GROUPING is resolved to a constant at the TOP of `term` (before this
+      // switch), so it never reaches here — an internal inconsistency if it
+      // does.
+      throw .state("XX000", "unlowered GROUPING")
     }
+  }
+
+  /// The `Term.grouping` `GROUPING(a, …)` yields for this arm — the integer
+  /// bit-vector `bits` (one bit per argument, the first the most significant,
+  /// `0` for a `GROUP BY` key of this arm's set and `1` for a super-aggregate a
+  /// grouping column another set groups on but this arm rolls up) paired with
+  /// the `over` identity. It reuses the grouped `term` lowering for the
+  /// membership test: an argument returns a key slot (`< offset`) for a present
+  /// key, a typeless-NULL constant for a rolled-up one (the superset path), or
+  /// faults `SQLError.grouping` for a genuine non-grouping column — which
+  /// propagates, as it must. Any other lowering (an aggregate's result slot
+  /// `>= offset`, a literal) is not a grouping expression, so it faults.
+  ///
+  /// In a plain `GROUP BY` (`superset` empty) a key lowers to a `< offset` slot
+  /// (bit `0`) and a non-key faults `.grouping`, so every GROUPING is `0` — the
+  /// standard result when no column is rolled up.
+  ///
+  /// The result is a dedicated `Term.grouping`, not a bare constant, so a
+  /// carrier can match a query-level `ORDER BY GROUPING(x)` to its projected
+  /// column by identity rather than to an unrelated projection sharing this
+  /// arm's value (see `Term.grouping`).
+  private func grouping(over arguments: Array<Expression>,
+                        _ routines: Routines = [:],
+                        subquery: Resolution = .unsupported)
+      throws(SQLError) -> Term {
+    guard !arguments.isEmpty else {
+      throw .state("42601", "GROUPING requires at least one argument")
+    }
+    // The parser rejects an over-wide GROUPING, but the `Expression.grouping`
+    // AST case is public, so a programmatically built query reaches this lowering
+    // without a parse. Enforce the representable width here too: the bit-vector
+    // is a signed `Int`, one bit per argument, so more than `Int.bitWidth - 1`
+    // arguments would shift a rolled-up vector past the sign bit to a negative
+    // value. Reject it with the same ISO 54023 (too many arguments) the parser
+    // raises, so every public query-construction path agrees.
+    guard arguments.count <= Int.bitWidth - 1 else {
+      throw .state("54023",
+                   "GROUPING supports at most \(Int.bitWidth - 1) arguments")
+    }
+    var bits = 0
+    var identity = Array<Term>()
+    identity.reserveCapacity(arguments.count)
+    for argument in arguments {
+      // Lower through the grouped `term` so a non-grouping COLUMN faults
+      // `.grouping` as it would elsewhere; the returned term is not otherwise
+      // needed — membership below is decided by the arm-stable base `id`.
+      _ = try term(argument, routines, subquery: subquery)
+      // The argument's base-scope term is both its cross-arm identity (carried
+      // into the `over` payload) and the membership key for the roll-up test. It
+      // is the base term, not the grouped lowering: a rolled-up column lowers to
+      // the shared super-aggregate `.constant(.null)` — and a rolled-up
+      // CORRELATED key to a `.parameter` — so the grouped term identifies
+      // neither which column it was nor that it is a key. The base term is the
+      // column's arm-stable slot, so two GROUPINGs match by identity iff they
+      // report on the same expressions.
+      let id = try scope.term(argument, routines, subquery: subquery)
+      let bit: Int
+      if terms.contains(id) {
+        // A `GROUP BY` key present in this arm's set, matched by term against the
+        // arm's keys — so a CORRELATED key (a LATERAL body grouping on a
+        // preceding-FROM column, which lowers to `Term.parameter` rather than a
+        // local key slot) is recognised too, not only a local slot.
+        bit = 0
+      } else if superset.contains(id) {
+        // A super-aggregate: a grouping column another set groups on but this arm
+        // omits, so it is rolled up in this result row. Decided by superset
+        // membership of the arm-stable `id` alone — not the grouped lowering's
+        // `.constant(.null)`, which a rolled-up correlated key never takes (it
+        // stays `.parameter`), so an omitted correlated key reports bit 1 rather
+        // than faulting. A literal NULL's `id` is in no superset, so it still
+        // faults below.
+        bit = 1
+      } else {
+        // A literal (NULL among them), an aggregate's result slot, or any other
+        // non-grouping term — not a valid GROUPING argument. A non-grouping
+        // column already faulted `.grouping` inside `term` above.
+        throw .state("42803",
+                     "GROUPING argument must be a GROUP BY expression")
+      }
+      bits = (bits << 1) | bit
+      identity.append(id)
+    }
+    return .grouping(over: identity, bits: bits)
   }
 
   /// Records a projected item's output `name` at projection `column` → its

--- a/Sources/SQLEngine/Parser+Projection.swift
+++ b/Sources/SQLEngine/Parser+Projection.swift
@@ -139,6 +139,14 @@ extension Parser {
       let token = try advance(expecting: "a literal")
       return .literal(.boolean(token.kind == .true))
     }
+    // The keyword `NULL` in value-expression position is the ISO `<null
+    // specification>` — the absent value. The `IS [NOT] NULL` predicate consumes
+    // its own `NULL` in the predicate parser, so a `.null` reaching here begins
+    // an expression (`SELECT NULL`, `COALESCE(NULL, x)`, `x = NULL`).
+    if current?.kind == .null {
+      _ = try advance(expecting: "a literal")
+      return .literal(.null)
+    }
 
     let ident = try name()
     guard try match(.lparen) else {

--- a/Sources/SQLEngine/Parser+Projection.swift
+++ b/Sources/SQLEngine/Parser+Projection.swift
@@ -209,6 +209,16 @@ extension Parser {
                         filter: filter)
     }
 
+    // `GROUPING(a, …)` is the ISO grouping-sets function — a first-class node,
+    // not a scalar `call` (an unregistered `GROUPING` routine would fault
+    // `.function`), recognised case-insensitively only when written bare (a
+    // delimited `"GROUPING"` is an ordinary scalar name) and followed by `(`
+    // (a bare `grouping` not before `(` stayed an ordinary column above). It
+    // takes the same comma-separated argument list a call does, and needs at
+    // least one argument; it resolves to a per-arm integer bit-vector constant
+    // at grouped lowering, so it never dispatches through the routines.
+    let grouping = !ident.quoted && ident.text.uppercased() == "GROUPING"
+
     var arguments = Array<Expression>()
     if current?.kind != .rparen {
       try arguments.append(expression())
@@ -217,6 +227,21 @@ extension Parser {
       }
     }
     try expect(.rparen)
+    if grouping {
+      guard !arguments.isEmpty else {
+        throw .state("42601", "GROUPING requires at least one argument")
+      }
+      // The result is a signed-integer bit-vector — one bit per argument, the
+      // first the most significant — so more arguments than an `Int` payload
+      // holds cannot be represented without the vector overflowing to a
+      // negative value. Reject the over-wide call at parse (ISO 54023, too many
+      // arguments) rather than lower it to a corrupt constant.
+      guard arguments.count <= Int.bitWidth - 1 else {
+        throw .state("54023",
+                     "GROUPING supports at most \(Int.bitWidth - 1) arguments")
+      }
+      return .grouping(arguments)
+    }
     return .call(name: ident.text, arguments: arguments)
   }
 

--- a/Sources/SQLEngine/Scope.swift
+++ b/Sources/SQLEngine/Scope.swift
@@ -184,6 +184,12 @@ extension Schema {
       // An aggregate has no per-row meaning — it folds over a group — so it may
       // not appear in a `WHERE`, a join `ON`, or a non-aggregate projection.
       throw .state("42803", "an aggregate is not allowed here")
+    case .grouping:
+      // GROUPING is a grouped-query construct decided by the arm's key
+      // membership; it has no meaning in this NON-grouped resolution (a scalar
+      // projection, WHERE, or join ON), so it faults exactly as an aggregate
+      // does. A grouped query lowers it through `Grouped.term` instead.
+      throw .state("42803", "GROUPING requires a GROUP BY")
     }
   }
 
@@ -649,6 +655,12 @@ internal struct Scope {
       // no catalog holds none and faults, rejecting the subquery rather than
       // mis-typing it, so this derive and the run's lowering AGREE.
       try subquery.scalar(type: query)
+    case .grouping:
+      // `GROUPING(a, …)` yields an integer bit-vector; its arguments are
+      // grouping keys the grouped lowering resolves, so — like a `call` (which
+      // types from its routine's declared return, not its arguments) — it types
+      // as `.integer` here without deriving them.
+      .integer
     }
   }
 
@@ -875,7 +887,28 @@ internal struct Scope {
       // reads that type exactly as the run's lowering does. A surface with no
       // catalog holds none and faults, rejecting the subquery unvalidated.
       try subquery.type(query)
+    case let .grouping(arguments):
+      // `GROUPING(a, …)` yields an integer bit-vector. Validate each argument
+      // RESOLVES as a scalar (the grouped lowering additionally enforces that
+      // each names a `GROUP BY` expression — `SQLError.grouping` otherwise —
+      // which this per-operand type-check does not duplicate), then accept.
+      try grouping(over: arguments, routines, subquery: subquery)
     }
+  }
+
+  /// The type of `GROUPING(a, …)` under `validate` — `.integer`, VALIDATING
+  /// each argument resolves as a run would (an unknown column, a bad operand,
+  /// or an ill-typed call inside an argument faults). The grouped lowering
+  /// enforces that each argument is a `GROUP BY` expression, so this only
+  /// checks resolvability and does not itself fault a valid GROUPING.
+  private func grouping(over arguments: Array<Expression>,
+                        _ routines: Routines,
+                        subquery: SubqueryCheck = .unsupported)
+      throws(SQLError) -> ValueType {
+    for argument in arguments {
+      _ = try validate(argument, routines, subquery: subquery)
+    }
+    return .integer
   }
 
   /// The result type of `COALESCE(v1, v2, …)`, validating each REACHABLE
@@ -1633,10 +1666,12 @@ internal struct Scope {
         return nil
       }
       return matches(va, .equal, vb) == true ? .null : va
-    case .column, .aggregate, .subquery:
+    case .column, .aggregate, .subquery, .grouping:
       // A `subquery` is row-independent but is materialised at RUN (this
       // compile-time fold has no cache), so it is not statically foldable —
-      // `nil`, like a `column` or `aggregate`.
+      // `nil`, like a `column` or `aggregate`. A `grouping` is constant only
+      // relative to a specific grouped ARM (this AST-level fold has no arm
+      // context), so it too is `nil` here — decided later by `Grouped.term`.
       return nil
     }
   }
@@ -1744,6 +1779,11 @@ internal struct Scope {
     // the memo (`scalar(resolved:)`), which already carries the unconstrained
     // mask for any unregistered call inside it — do NOT double-handle it here.
     case .subquery:
+      return false
+    // `.grouping`: `derive` types it `.integer` as a LEAF (it does not derive
+    // the arguments, exactly as a `call` types from its declared return), so it
+    // fabricates no routine type and constrains the fold — never unresolved.
+    case .grouping:
       return false
     }
   }
@@ -2139,6 +2179,13 @@ internal struct Scope {
     case let .nullif(lhs, rhs):
       try aggregates(in: lhs, routines, subquery: subquery)
       try aggregates(in: rhs, routines, subquery: subquery)
+    case let .grouping(arguments):
+      // GROUPING is not itself an aggregate, but — like a `call` — recurse its
+      // arguments so any aggregate they nest is validated (an aggregate is not
+      // a valid GROUPING argument, but the walk mirrors the neighbouring arms).
+      for argument in arguments {
+        try aggregates(in: argument, routines, subquery: subquery)
+      }
     }
   }
 
@@ -2339,6 +2386,20 @@ internal struct Scope {
       // independent — so this pre-run fold treats it as the undecided `.null`,
       // never faulting on a subquery the run would materialise cleanly.
       return .null
+    case let .grouping(arguments):
+      // This fold only ever runs over the single empty group a constant-false
+      // WHERE leaves — the grand total, which forms no grouping key, so every
+      // GROUPING argument is rolled up. GROUPING is therefore the all-ones
+      // bit-vector here, exactly the value the run's grouped lowering yields for
+      // an arm with no keys. Returning a placeholder `0` instead would pick the
+      // wrong `CASE` branch, so a reachability fold could drop the faulting arm
+      // a run keeps (`CASE WHEN GROUPING(x) = 1 THEN 1 / 0 ELSE 0` folds to the
+      // ELSE and misses the divide the grand-total group raises). Build the
+      // vector the same iterative way the grouped lowering does, so a 63-column
+      // GROUPING lands on `Int.max` rather than overflowing.
+      var bits = 0
+      for _ in arguments { bits = (bits << 1) | 1 }
+      return .integer(bits)
     }
   }
 
@@ -2781,6 +2842,12 @@ internal struct Scope {
       // An aggregate has no per-row meaning — it folds over a group — so it may
       // not appear in a `WHERE`, a join `ON`, or a non-aggregate projection.
       throw .state("42803", "an aggregate is not allowed here")
+    case .grouping:
+      // GROUPING is a grouped-query construct decided by the arm's key
+      // membership; it has no meaning in this NON-grouped join resolution, so
+      // it faults as an aggregate does. A grouped query lowers it through
+      // `Grouped.term` instead.
+      throw .state("42803", "GROUPING requires a GROUP BY")
     }
   }
 

--- a/Sources/SQLEngine/Scope.swift
+++ b/Sources/SQLEngine/Scope.swift
@@ -536,6 +536,11 @@ internal struct Scope {
   /// for. Shared by both the schema and type-check surfaces.
   private func type(of literal: Literal) -> ValueType {
     switch literal {
+    // A bare `NULL` has no determinate type; the projection walk marks a
+    // constant-NULL column `unconstrained` (so it unifies with any typed arm),
+    // and this nominal placeholder is only its advertised type where no other
+    // arm constrains it — `.integer`, as a result-less `CASE` defaults.
+    case .null: .integer
     case .string: .text
     case .integer: .integer
     case .double: .double
@@ -765,16 +770,21 @@ internal struct Scope {
                        subquery: Resolution = .unsupported)
       throws(SQLError) -> ValueType {
     let results = reachable(whens, otherwise, routines)
-    if results.isEmpty { return .integer }
-    var type = try derive(results[0], routines, subquery: subquery)
-    for result in results.dropFirst() {
+    // A constant-NULL result places no type constraint (a NULL unifies with any
+    // arm), so it is skipped in the fold — mirroring COALESCE and the faulting
+    // `validate` (`conditional`) — and an all-NULL (or empty) CASE takes the
+    // `.integer` placeholder, which the projection walk marks unconstrained.
+    var type: ValueType?
+    for result in results {
+      if case .some(.null) = constant(result, routines) { continue }
       let next = try derive(result, routines, subquery: subquery)
-      guard let unified = type.unified(with: next) else {
+      guard let running = type else { type = next; continue }
+      guard let unified = running.unified(with: next) else {
         throw .operand("CASE results have irreconcilable types")
       }
       type = unified
     }
-    return type
+    return type ?? .integer
   }
 
   /// The result expressions of a `CASE` the executor's short-circuit can REACH,
@@ -1012,16 +1022,22 @@ internal struct Scope {
       if decided { break }
     }
     if !decided, let otherwise { results.append(otherwise) }
-    if results.isEmpty { return .integer }
-    var type = try validate(results[0], routines, subquery: subquery)
-    for result in results.dropFirst() {
+    // A result that folds to a constant NULL places no type constraint — a NULL
+    // unifies with any arm — so it is validated for its own errors but skipped
+    // in the type fold, exactly as COALESCE skips a constant-NULL argument. With
+    // every reachable result constant NULL (or none), the CASE is unconstrained
+    // and takes the `.integer` placeholder.
+    var type: ValueType?
+    for result in results {
       let next = try validate(result, routines, subquery: subquery)
-      guard let unified = type.unified(with: next) else {
+      if case .some(.null) = constant(result, routines) { continue }
+      guard let running = type else { type = next; continue }
+      guard let unified = running.unified(with: next) else {
         throw .operand("CASE results have irreconcilable types")
       }
       type = unified
     }
-    return type
+    return type ?? .integer
   }
 
   /// The result type of the scalar routine `name` called over `arguments`,
@@ -1054,6 +1070,13 @@ internal struct Scope {
     }
     for (argument, expected) in zip(arguments, routine.parameters) {
       let type = try validate(argument, routines, subquery: subquery)
+      // A statically-NULL argument fits any parameter type: run-time dispatch
+      // accepts NULL for every declared type and returns NULL, so a bare NULL
+      // (whose nominal type is the `.integer` placeholder) must not fault a call
+      // over a non-integer parameter — `UPPER(NULL)` type-checks and runs. A
+      // nullable column is not statically NULL (`constant` is `nil`), so its
+      // declared type is still enforced.
+      if case .some(.null) = constant(argument, routines) { continue }
       guard type == expected else {
         throw .argument("\(name) requires \(expected.domain) arguments")
       }
@@ -1207,6 +1230,17 @@ internal struct Scope {
         throw .operand("|| operands must be text")
       }
       return .text
+    }
+    // A statically-NULL operand makes the whole arithmetic NULL: `Arithmetic.apply`
+    // returns NULL before it inspects EITHER operand's kind, divides, or
+    // overflows, so the expression runs whatever the other operand's kind —
+    // `NULL + 'x'`, `'x' + NULL`, and even `NULL / 0` yield NULL — mirroring the
+    // concatenation path above. Skip the numeric-kind guard and the divide/
+    // overflow folds, and take the numeric result type (the placeholder integer
+    // when the other operand is non-numeric; the column is unconstrained anyway,
+    // since it folds to NULL).
+    if vanishing(lhs, routines) || vanishing(rhs, routines) {
+      return left == .double || right == .double ? .double : .integer
     }
     guard left.numeric, right.numeric else {
       throw .operand("operands must be numeric")
@@ -1613,8 +1647,18 @@ internal struct Scope {
   /// constant-NULL argument. The projection walk (`output(_ item:)`) reads this
   /// beside its type derive, so a column's type and its `unconstrained` mask
   /// come from ONE resolution over the SAME expression and cannot diverge.
+  ///
+  /// A `CASE` every reachable result of which is NULL yields NULL whichever
+  /// branch runs, so it is constant NULL even when a row-dependent guard leaves
+  /// the whole-expression `constant` fold undecided (`nil`) — `CASE WHEN Id = 1
+  /// THEN NULL ELSE NULL END` is unconstrained, so it unifies with a text arm in
+  /// a set operation rather than hard-typing the placeholder integer.
   internal func null(_ expression: Expression, _ routines: Routines) -> Bool {
     if case .some(.null) = constant(expression, routines) { return true }
+    if case let .case(whens, otherwise) = expression {
+      return reachable(whens, otherwise, routines)
+          .allSatisfy { null($0, routines) }
+    }
     return false
   }
 

--- a/Tests/SQLTests/Expressions/NullLiteralTests.swift
+++ b/Tests/SQLTests/Expressions/NullLiteralTests.swift
@@ -1,0 +1,137 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQLEngine
+import SQLStandard
+
+import SQLTestSupport
+
+// MARK: - NULL value expression
+
+struct NullLiteralTests {
+  @Test func `NULL in value position parses to a literal`() throws {
+    // The keyword `NULL` written where a value expression is expected is the ISO
+    // `<null specification>` — a `Literal.null`, distinct from the `IS NULL`
+    // predicate that tests a value.
+    let select = try parse(select: "SELECT NULL FROM T")
+    #expect(select.projection
+                == .expressions([Projected(expression: .literal(.null))]))
+  }
+
+  @Test func `SELECT NULL yields NULL, typed as the placeholder integer`()
+      throws {
+    // A bare NULL has no determinate type; its column is unconstrained and takes
+    // the `.integer` placeholder where nothing else constrains it, and every row
+    // projects the absent value.
+    #expect(try nullable().type(of: "SELECT NULL FROM T") == .integer)
+    try nullable().expect("SELECT NULL FROM T", yields: [[nil], [nil]])
+  }
+
+  @Test func `a NULL arm of a UNION unifies with the typed arm`() throws {
+    // A constant-NULL projection places no type constraint, so the set-operation
+    // fold carries the other arm's type: `SELECT NULL UNION SELECT Name` is a
+    // text column, its NULL row preserved.
+    #expect(try nullable().type(of: """
+        SELECT NULL FROM T WHERE Id = 1
+         UNION SELECT Name FROM T WHERE Id = 1
+        """) == .text)
+    try nullable().expect("""
+        SELECT NULL FROM T WHERE Id = 1
+         UNION SELECT Name FROM T WHERE Id = 2
+        """, yields: [[nil], ["b"]])
+  }
+
+  @Test func `a NULL CASE result is type-neutral and unifies with a typed arm`()
+      throws {
+    // A `THEN NULL` (or `ELSE NULL`) places no type constraint on the CASE — the
+    // NULL unifies with any arm — so the result type is the typed arm's, exactly
+    // as COALESCE skips a constant-NULL argument.
+    #expect(try nullable().type(of: """
+        SELECT CASE WHEN Id = 1 THEN NULL ELSE Name END FROM T
+        """) == .text)
+    try nullable().expect("""
+        SELECT CASE WHEN Id = 1 THEN NULL ELSE Name END FROM T
+        """, yields: [[nil], ["b"]])
+  }
+
+  @Test func `an all-NULL CASE is unconstrained, taking the placeholder`()
+      throws {
+    // Every reachable result constant NULL leaves the CASE unconstrained; it
+    // takes the `.integer` placeholder and yields NULL for every row.
+    #expect(try nullable().type(of: """
+        SELECT CASE WHEN Id = 1 THEN NULL ELSE NULL END FROM T
+        """) == .integer)
+    try nullable().expect("""
+        SELECT CASE WHEN Id = 1 THEN NULL ELSE NULL END FROM T
+        """, yields: [[nil], [nil]])
+  }
+
+  @Test func `COALESCE over a NULL literal skips it`() throws {
+    // A NULL literal argument is a constant NULL COALESCE skips, so `COALESCE(NULL,
+    // Name)` is the text column and returns each row's Name.
+    #expect(try nullable().type(of: "SELECT COALESCE(NULL, Name) FROM T")
+                == .text)
+    try nullable().expect("SELECT COALESCE(NULL, Name) FROM T",
+                        yields: [["a"], ["b"]])
+  }
+
+  @Test func `a comparison against NULL is UNKNOWN, selecting no row`() throws {
+    // `K = NULL` is UNKNOWN for every row under three-valued logic (ISO), so it
+    // filters everything — the reason `IS NULL` exists. The NULL is a value
+    // expression here, not the `IS NULL` predicate.
+    try nullable().empty("SELECT Id FROM T WHERE K = NULL")
+  }
+
+  @Test func `IS NULL still tests a value, unaffected by the NULL literal`()
+      throws {
+    // The `IS NULL` predicate consumes its own `NULL`, so it keeps testing the
+    // operand: row 2's `K` is absent.
+    try nullable().expect("SELECT Id FROM T WHERE K IS NULL", yields: [[2]])
+  }
+
+  @Test func `NULL propagates through arithmetic`() throws {
+    // A NULL operand makes the arithmetic NULL; the column is numeric.
+    try nullable().expect("SELECT NULL + 1 FROM T WHERE Id = 1", yields: [[nil]])
+  }
+
+  @Test func `a NULL literal fits a non-integer routine parameter`() throws {
+    // UPPER declares a text parameter. A bare NULL's placeholder integer type
+    // must not fault schema validation, since dispatch accepts NULL for any
+    // declared type and returns NULL — validate and run must agree.
+    let cat = try nullable()
+    let sql = "SELECT UPPER(NULL) FROM T"
+    _ = try cat.columns(of: parse(query: sql), routines: .standard)
+    try cat.expect(sql, yields: [[nil], [nil]])
+  }
+
+  @Test func `a row-dependent all-NULL CASE is unconstrained in a UNION`()
+      throws {
+    // Every reachable result is NULL, so the CASE yields NULL whichever branch a
+    // row takes — even though the `Id = 1` guard is row-dependent (the
+    // whole-expression fold is undecided). The column is therefore unconstrained
+    // and unifies with the text arm rather than faulting integer-versus-text.
+    let sql = """
+        SELECT CASE WHEN Id = 1 THEN NULL ELSE NULL END FROM T WHERE Id = 1
+         UNION SELECT Name FROM T WHERE Id = 2
+        """
+    #expect(try nullable().type(of: sql) == .text)
+    try nullable().expect(sql, yields: [[nil], ["b"]])
+  }
+
+  @Test func `a NULL operand short-circuits mixed-kind arithmetic`() throws {
+    // `Arithmetic.apply` returns NULL before inspecting operand kinds, dividing,
+    // or overflowing, so a statically-NULL operand makes the whole expression
+    // NULL whatever the other operand — schema validation must agree with the
+    // run rather than fault on the non-numeric operand or the zero divisor. This
+    // covers both orders, a non-numeric partner, and the short-circuited divide.
+    let cat = try nullable()
+    for sql in ["SELECT NULL + 'x' FROM T WHERE Id = 1",
+                "SELECT 'x' + NULL FROM T WHERE Id = 1",
+                "SELECT NULL * Name FROM T WHERE Id = 1",
+                "SELECT NULL / 0 FROM T WHERE Id = 1"] {
+      _ = try cat.columns(of: parse(query: sql), validate: true)
+      try cat.expect(sql, yields: [[nil]])
+    }
+  }
+}

--- a/Tests/SQLTests/Optimisation/DecorrelateTests.swift
+++ b/Tests/SQLTests/Optimisation/DecorrelateTests.swift
@@ -275,7 +275,9 @@ private func subquery(_ term: Term) -> Bool {
   case let .case(branches, otherwise, _):
     return branches.contains { subquery($0.0) || subquery($0.1) }
         || otherwise.map { subquery($0) } ?? false
-  case .slot, .parameter, .constant:
+  case .slot, .parameter, .constant, .grouping:
+    // A GROUPING lowers to a settled per-arm constant; its `over` identity terms
+    // are never evaluated, so it reaches no runtime scalar subquery.
     return false
   }
 }

--- a/Tests/SQLTests/Queries/GroupingFunctionTests.swift
+++ b/Tests/SQLTests/Queries/GroupingFunctionTests.swift
@@ -1,0 +1,466 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+import SQLEngine
+import SQLStandard
+import SQLTestSupport
+
+// MARK: - Fixtures
+
+/// A `Sales` relation of `Region`/`Product`/`Qty` rows. Per-(Region, Product):
+/// East/A 10, East/B 20, West/A 7, West/B 3. Per-Region: East 30, West 10.
+/// Per-Product: A 17, B 23. Grand total 40. Each level's SUM is distinct, so a
+/// row's grouping set is legible from its values.
+private func sales() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("Sales", ["Region": .text, "Product": .text, "Qty": .integer]) {
+      Row("East", "A", 10)
+      Row("East", "B", 20)
+      Row("West", "A", 7)
+      Row("West", "B", 3)
+    }
+  }
+}
+
+/// The `SQLError` running `sql` against `catalog` raises, or `nil` — the RUN
+/// path (`Catalog.run`), for the run ≡ schema fault agreement.
+private func running(_ sql: String,
+                     _ catalog: borrowing FixtureCatalog) -> SQLError? {
+  do {
+    _ = try catalog.run(parse(query: sql))
+    return nil
+  } catch let fault {
+    return fault
+  }
+}
+
+/// The `SQLError` type-checking `sql`'s schema raises, or `nil` — the SCHEMA
+/// path (`columns(of:validate:true)`), for the run ≡ schema fault agreement.
+private func checking(_ sql: String,
+                      _ catalog: borrowing FixtureCatalog) -> SQLError? {
+  do {
+    _ = try catalog.columns(of: parse(query: sql), validate: true)
+    return nil
+  } catch let fault {
+    return fault
+  }
+}
+
+// MARK: - GROUPING()
+
+struct GroupingFunctionTests {
+  @Test func `a plain GROUP BY key is never rolled up, so GROUPING is 0`()
+      throws {
+    // A plain `GROUP BY Region` is one grouping set whose sole member is
+    // `Region`, so `Region` is present in every result row and NEVER rolled up:
+    // `GROUPING(Region)` is 0 for every row. Rows in first-appearance order.
+    try sales().expect("""
+        SELECT Region, GROUPING(Region), SUM(Qty)
+          FROM Sales
+         GROUP BY Region
+        """, yields: [
+          ["East", 0, 30],
+          ["West", 0, 10],
+        ])
+  }
+
+  @Test func `GROUPING SETS ((a), ()) reports 0 for the key arm, 1 for the total`()
+      throws {
+    // `GROUPING SETS ((Region), ())` is two arms. The `(Region)` arm groups on
+    // `Region` (present → `GROUPING(Region)` = 0); the `()` grand-total arm
+    // rolls `Region` up (it is in the superset but not this set → the projected
+    // `Region` is a super-aggregate NULL, `GROUPING(Region)` = 1). Arm order:
+    // the `(Region)` rows first, then the total.
+    try sales().expect("""
+        SELECT Region, GROUPING(Region), SUM(Qty)
+          FROM Sales
+         GROUP BY GROUPING SETS ((Region), ())
+        """, yields: [
+          ["East", 0, 30],
+          ["West", 0, 10],
+          [nil, 1, 40],
+        ])
+  }
+
+  @Test func `ROLLUP(a, b) reports per-level bits and a first-arg-MSB vector`()
+      throws {
+    // `ROLLUP(Region, Product)` is `[[Region, Product], [Region], []]`. Per
+    // level, the scalar `GROUPING(Region)`/`GROUPING(Product)` and the two-arg
+    // VECTOR `GROUPING(Region, Product)` (Region the MOST-significant bit):
+    //   full arm  — both present: (0, 0), vector 0b00 = 0.
+    //   (Region)  — Product rolled up: (0, 1), vector 0b01 = 1.
+    //   ()        — both rolled up: (1, 1), vector 0b11 = 3.
+    // So the vector takes 0, 1, 3 — never 2 (Region cannot be rolled up while
+    // Product is kept in a ROLLUP prefix).
+    try sales().expect("""
+        SELECT Region, Product,
+               GROUPING(Region), GROUPING(Product),
+               GROUPING(Region, Product), SUM(Qty)
+          FROM Sales
+         GROUP BY ROLLUP(Region, Product)
+        """, yields: [
+          ["East", "A", 0, 0, 0, 10],
+          ["East", "B", 0, 0, 0, 20],
+          ["West", "A", 0, 0, 0, 7],
+          ["West", "B", 0, 0, 0, 3],
+          ["East", nil, 0, 1, 1, 30],
+          ["West", nil, 0, 1, 1, 10],
+          [nil, nil, 1, 1, 3, 40],
+        ])
+  }
+
+  @Test func `CUBE(a, b) makes the two-arg vector cover all four bit patterns`()
+      throws {
+    // `CUBE(Region, Product)` is `[[Region, Product], [Product], [Region], []]`,
+    // so the VECTOR `GROUPING(Region, Product)` (Region the MSB) takes every
+    // value 0..3:
+    //   full arm   — both present: 0b00 = 0.
+    //   (Product)  — Region rolled up: 0b10 = 2.
+    //   (Region)   — Product rolled up: 0b01 = 1.
+    //   ()         — both rolled up: 0b11 = 3.
+    try sales().expect("""
+        SELECT Region, Product, GROUPING(Region, Product), SUM(Qty)
+          FROM Sales
+         GROUP BY CUBE(Region, Product)
+        """, yields: [
+          ["East", "A", 0, 10],
+          ["East", "B", 0, 20],
+          ["West", "A", 0, 7],
+          ["West", "B", 0, 3],
+          [nil, "A", 2, 17],
+          [nil, "B", 2, 23],
+          ["East", nil, 1, 30],
+          ["West", nil, 1, 10],
+          [nil, nil, 3, 40],
+        ])
+  }
+
+  @Test func `GROUPING filters super-aggregate rows in HAVING`() throws {
+    // `HAVING GROUPING(Region) = 1` keeps only the rows where `Region` is rolled
+    // up — the grand total of `ROLLUP(Region)` (`[[Region], []]`), NOT the
+    // per-Region rows (whose `GROUPING(Region)` is 0). HAVING lowers per arm, so
+    // each arm's constant GROUPING decides its group's fate.
+    try sales().expect("""
+        SELECT Region, SUM(Qty)
+          FROM Sales
+         GROUP BY ROLLUP(Region)
+        HAVING GROUPING(Region) = 1
+        """, yields: [
+          [nil, 40],
+        ])
+  }
+
+  @Test func `GROUPING orders the super-aggregate rows in ORDER BY`() throws {
+    // A query-level `ORDER BY GROUPING(Region) DESC` over the `ROLLUP(Region)`
+    // union sorts the grand total (GROUPING 1) ahead of the per-Region rows
+    // (GROUPING 0), a secondary `Region` breaking the per-Region tie. The
+    // projected `GROUPING(Region)` (column 2) makes the sort key an OUTPUT the
+    // carrier matches by resolved identity.
+    try sales().expect("""
+        SELECT Region, GROUPING(Region), SUM(Qty)
+          FROM Sales
+         GROUP BY ROLLUP(Region)
+         ORDER BY GROUPING(Region) DESC, Region
+        """, yields: [
+          [nil, 1, 40],
+          ["East", 0, 30],
+          ["West", 0, 10],
+        ])
+  }
+
+  @Test func `GROUPING of a non-grouping column faults on both paths`() throws {
+    // `Product` is in NO grouping set of `GROUP BY Region`, so `GROUPING(Product)`
+    // is invalid — the grouped lowering faults `SQLError.grouping` exactly as a
+    // bare non-grouped `Product` reference would, on BOTH the run and the schema
+    // type-check.
+    let sql = """
+        SELECT Region, GROUPING(Product)
+          FROM Sales
+         GROUP BY Region
+        """
+    #expect(running(sql, try sales()) == .grouping("Product"))
+    #expect(checking(sql, try sales()) == .grouping("Product"))
+  }
+
+  @Test func `GROUPING of a literal NULL faults on both paths`() throws {
+    // A literal NULL is not a `GROUP BY` expression. It lowers to a constant
+    // NULL — the same value a rolled-up super-aggregate takes — so the roll-up
+    // test must decide membership by the argument's superset identity, not the
+    // NULL value: NULL is in no set's superset, so it faults `.state("42803")`
+    // rather than counting as a rolled-up bit, on the run and the schema paths.
+    let sql = "SELECT GROUPING(NULL) FROM Sales GROUP BY ROLLUP(Region)"
+    let fault = SQLError.state("42803",
+                               "GROUPING argument must be a GROUP BY expression")
+    #expect(running(sql, try sales()) == fault)
+    #expect(checking(sql, try sales()) == fault)
+  }
+
+  @Test func `GROUPING outside a grouped query faults on both paths`() throws {
+    // `SELECT GROUPING(Region) FROM Sales` has no `GROUP BY` and no aggregate,
+    // so it is NOT a grouped query — GROUPING has no grouping set to report
+    // against and faults `.state("42803")` on BOTH the run and the schema
+    // type-check.
+    let sql = "SELECT GROUPING(Region) FROM Sales"
+    let fault = SQLError.state("42803", "GROUPING requires a GROUP BY")
+    #expect(running(sql, try sales()) == fault)
+    #expect(checking(sql, try sales()) == fault)
+  }
+
+  @Test func `run agrees with columns(of:validate:) typing GROUPING as integer`()
+      throws {
+    // run ≡ schema: a valid GROUPING query validates and its schema types the
+    // GROUPING output as an INTEGER column (an unaliased expression names
+    // `column N`). Region takes its `.text` type through the set-operation
+    // merge; the SUM and the GROUPING are `.integer`.
+    let cat = try sales()
+    let sql = """
+        SELECT Region, GROUPING(Region), SUM(Qty)
+          FROM Sales
+         GROUP BY ROLLUP(Region)
+        """
+    try cat.expect(sql, yields: [
+      ["East", 0, 30],
+      ["West", 0, 10],
+      [nil, 1, 40],
+    ])
+    let columns = try cat.columns(of: parse(query: sql), validate: true)
+    #expect(columns == [
+      OutputColumn(name: "Region", type: .text),
+      OutputColumn(name: "column 2", type: .integer),
+      OutputColumn(name: "column 3", type: .integer),
+    ])
+  }
+
+  @Test func `GROUPING needs at least one argument`() throws {
+    // ISO `GROUPING` takes one or more grouping expressions; a bare `GROUPING()`
+    // is a syntax fault the parser raises before any grouped lowering.
+    let fault = SQLError.state("42601",
+                               "GROUPING requires at least one argument")
+    #expect(running("SELECT GROUPING() FROM Sales GROUP BY Region",
+                    try sales()) == fault)
+  }
+
+  @Test func `a delimited GROUPING is an ordinary column, not the function`()
+      throws {
+    // `GROUPING` is a CONTEXT identifier: a DELIMITED `"grouping"` is an
+    // ordinary column name, never the function, so a relation with a `grouping`
+    // column groups and projects it plainly.
+    let cat = try Catalog {
+      Relation("T", ["grouping": .text, "n": .integer]) {
+        Row("x", 1)
+        Row("y", 2)
+      }
+    }
+    try cat.expect("""
+        SELECT "grouping", SUM(n) FROM T GROUP BY "grouping"
+        """, yields: [["x", 1], ["y", 2]])
+  }
+
+  @Test func `GROUPING nested in a CASE resolves to its per-arm bit`() throws {
+    // The canonical labelling idiom nests GROUPING inside a `CASE` guard rather
+    // than projecting it bare: `CASE WHEN GROUPING(Region) = 1 THEN 'Total'`
+    // names the grand-total row. The grouped lowering must descend the compound
+    // and resolve the nested GROUPING to its per-arm constant — a bare column in
+    // the guard once faulted `.state` because the whole `CASE` was matched as a
+    // `GROUP BY` key through the non-grouped scope. Over `ROLLUP(Region)` the
+    // per-Region arms take the ELSE (their `Region`), the total arm the THEN.
+    try sales().expect("""
+        SELECT CASE WHEN GROUPING(Region) = 1 THEN 'Total' ELSE Region END,
+               SUM(Qty)
+          FROM Sales
+         GROUP BY ROLLUP(Region)
+        """, yields: [
+          ["East", 30],
+          ["West", 10],
+          ["Total", 40],
+        ])
+  }
+
+  @Test func `a constant-false WHERE keeps the empty group's arm GROUPING bits`()
+      throws {
+    // A constant-false `WHERE` leaves the `()` grand-total arm its single empty
+    // group, whose `GROUPING(Region)` is 1 (nothing is grouped, so Region is
+    // rolled up). The run evaluates that group's `CASE`, takes the `THEN`, and
+    // faults on the divide; the schema's empty-group fold must yield the same
+    // all-ones bit-vector so it too takes the `THEN` and surfaces the divide,
+    // rather than a placeholder 0 that would fold to the `ELSE` and accept a
+    // query the run rejects. Run and schema must agree on the fault.
+    let sql = """
+        SELECT CASE WHEN GROUPING(Region) = 1 THEN 1 / 0 ELSE 0 END
+          FROM Sales
+         WHERE 1 = 0
+         GROUP BY GROUPING SETS ((Region), ())
+        """
+    #expect(running(sql, try sales()) == .divide)
+    #expect(checking(sql, try sales()) == .divide)
+  }
+
+  @Test func `the empty-group GROUPING fold does not prune a safe branch`()
+      throws {
+    // The dual of the divide case: a `GROUPING(Region) = 0` guard is false over
+    // the grand-total arm (Region is rolled up, so the bit is 1), so the run
+    // takes the harmless `ELSE` and never divides. The empty-group fold, folding
+    // the same all-ones GROUPING, must likewise select the `ELSE` — it must not
+    // conservatively validate both branches and reject the query on the
+    // unreachable `THEN`. The `()` arm yields its lone row; the `(Region)` arm
+    // forms no group under the false WHERE.
+    try sales().expect("""
+        SELECT CASE WHEN GROUPING(Region) = 0 THEN 1 / 0 ELSE 0 END
+          FROM Sales
+         WHERE 1 = 0
+         GROUP BY GROUPING SETS ((Region), ())
+        """, yields: [
+          [0],
+        ])
+  }
+
+  @Test func `ORDER BY GROUPING binds past a projection sharing its value`()
+      throws {
+    // A query-level ORDER BY over the grouping-set union resolves its key
+    // against the first arm's projected terms by identity. GROUPING lowers to a
+    // dedicated term, not a bare constant, so `ORDER BY GROUPING(Region)` binds
+    // to the GROUPING column even when an earlier projection (the literal 0)
+    // lowers to the same first-arm constant 0 — the grand-total row (GROUPING 1)
+    // must sort first. A bare-constant lowering matched the literal instead, so
+    // every row sorted on 0 and the total stayed last.
+    try sales().expect("""
+        SELECT 0, GROUPING(Region), SUM(Qty)
+          FROM Sales
+         GROUP BY ROLLUP(Region)
+         ORDER BY GROUPING(Region) DESC
+        """, yields: [
+          [0, 1, 40],
+          [0, 0, 30],
+          [0, 0, 10],
+        ])
+  }
+
+  @Test func `ORDER BY tells two GROUPINGs apart under a leading empty set`()
+      throws {
+    // The identity carried is each GROUPING's arguments in the arm-stable base
+    // scope, not the grouped-space lowering — which collapses a rolled-up column
+    // to the shared super-aggregate NULL. Under `GROUPING SETS ((), …)` the
+    // carrier resolves against the leading `()` arm, where both Region and
+    // Product are rolled up; only the base-scope identity keeps `GROUPING(Region)`
+    // and `GROUPING(Product)` distinct, so `ORDER BY GROUPING(Product) DESC,
+    // GROUPING(Region) DESC` sorts on the intended keys: the Product-rolled-up
+    // rows (Product bit 1) first, the grand total (both 1) ahead of the
+    // Region-only rows within them, then the Region-rolled-up rows.
+    try sales().expect("""
+        SELECT GROUPING(Region), GROUPING(Product), SUM(Qty)
+          FROM Sales
+         GROUP BY GROUPING SETS ((), (Region), (Product))
+         ORDER BY GROUPING(Product) DESC, GROUPING(Region) DESC
+        """, yields: [
+          [1, 1, 40],
+          [0, 1, 30],
+          [0, 1, 10],
+          [1, 0, 17],
+          [1, 0, 23],
+        ])
+  }
+
+  @Test func `GROUPING rejects more arguments than the bit-vector holds`()
+      throws {
+    // GROUPING lowers to a signed-integer bit-vector, one bit per argument, so
+    // it admits at most `Int.bitWidth - 1` (63) arguments — 63 fits, 64 would
+    // overflow the payload to a negative value, so the parser rejects it with
+    // ISO 54023 (too many arguments) before any lowering.
+    let width = Int.bitWidth - 1
+    let ok = Array(repeating: "Region", count: width).joined(separator: ", ")
+    let over = Array(repeating: "Region", count: width + 1)
+        .joined(separator: ", ")
+    #expect(running("SELECT GROUPING(\(ok)) FROM Sales GROUP BY Region",
+                    try sales()) == nil)
+    let fault = SQLError.state("54023",
+                               "GROUPING supports at most \(width) arguments")
+    #expect(running("SELECT GROUPING(\(over)) FROM Sales GROUP BY Region",
+                    try sales()) == fault)
+  }
+
+  @Test func `the grouped lowering rejects an over-wide GROUPING built by AST`()
+      throws {
+    // The parser guard does not cover a query built through the public
+    // `Expression.grouping` AST case directly — the grouped lowering must reject
+    // an over-wide vector too, on every entry point, or the bit-shifts overflow
+    // the signed payload to a negative value. Build a 64-argument GROUPING with
+    // no parse and confirm the run and schema paths both fault ISO 54023, while
+    // the 63-argument boundary resolves (it is a plain key, GROUPING 0).
+    let width = Int.bitWidth - 1
+    let region = Expression.column(Column(name: "Region"))
+    func grouped(_ count: Int) -> Query {
+      .select(Select(projection: .expressions([
+                       Projected(expression: .grouping(Array(repeating: region,
+                                                             count: count)))]),
+                     from: Relation(name: "Sales"),
+                     grouping: .keys([region])))
+    }
+    let cat = try sales()
+    let over = grouped(width + 1)
+    let fault = SQLError.state("54023",
+                               "GROUPING supports at most \(width) arguments")
+    #expect(throws: fault) { _ = try cat.run(over) }
+    #expect(throws: fault) { _ = try cat.columns(of: over, validate: true) }
+    // The constant-false grand-total fold shares the same lowering, so it is
+    // rejected ahead of the empty-group bit-vector it would otherwise overflow.
+    let folded = Query.select(
+        Select(projection: .expressions([
+                 Projected(expression: .grouping(Array(repeating: region,
+                                                       count: width + 1)))]),
+               from: Relation(name: "Sales"),
+               predicate: .comparison(left: .literal(.integer(1)), op: .equal,
+                                      right: .literal(.integer(0))),
+               grouping: .sets([[region], []])))
+    #expect(throws: fault) { _ = try cat.columns(of: folded, validate: true) }
+    #expect(throws: fault) { _ = try cat.run(folded) }
+    #expect(throws: Never.self) { _ = try cat.run(grouped(width)) }
+  }
+
+  @Test func `GROUPING recognises a correlated key in a LATERAL body`() throws {
+    // Inside a LATERAL aggregate body, the grouping key from the preceding FROM
+    // (`T.Id`) lowers to a correlated `Term.parameter`, not a local key slot —
+    // yet it is this arm's `GROUP BY` key. Present-key membership is matched by
+    // lowered term against the arm's keys, so `GROUPING(T.Id)` reports bit 0
+    // rather than faulting as a non-grouping argument.
+    let cat = try Catalog {
+      Relation("T", ["Id": .integer]) { Row(1); Row(2) }
+      Relation("S", ["k": .integer]) { Row(1); Row(1); Row(2) }
+    }
+    try cat.expect("""
+        SELECT d.g, d.n
+          FROM T
+          JOIN LATERAL (SELECT GROUPING(T.Id) AS g, COUNT(*) AS n
+                          FROM S WHERE S.k = T.Id GROUP BY T.Id) AS d ON 1 = 1
+        """, yields: [
+          [0, 2],
+          [0, 1],
+        ])
+  }
+
+  @Test func `GROUPING rolls up an omitted correlated key in a LATERAL body`()
+      throws {
+    // Under `GROUP BY ROLLUP(T.Id)` in a LATERAL body, the `()` arm rolls the
+    // correlated key up. A rolled-up correlated key lowers to `Term.parameter`,
+    // not the super-aggregate NULL a local rolled-up key takes, so roll-up
+    // membership is decided by the arm's superset identity rather than the
+    // lowered value: `GROUPING(T.Id)` reports bit 1 for the `()` arm and 0 for
+    // the `(T.Id)` arm.
+    let cat = try Catalog {
+      Relation("T", ["Id": .integer]) { Row(1); Row(2) }
+      Relation("S", ["k": .integer]) { Row(1); Row(1); Row(2) }
+    }
+    try cat.expect("""
+        SELECT d.g, d.n
+          FROM T
+          JOIN LATERAL (SELECT GROUPING(T.Id) AS g, COUNT(*) AS n
+                          FROM S WHERE S.k = T.Id
+                         GROUP BY ROLLUP(T.Id)) AS d ON 1 = 1
+        """, yields: [
+          [0, 2],
+          [1, 2],
+          [0, 1],
+          [1, 1],
+        ])
+  }
+}


### PR DESCRIPTION
Implement the ISO SQL GROUPING() function (GROUPING SETS Stage 3). Given one or more grouping expressions, GROUPING(a, ...) returns an integer bit vector reporting, per argument, whether that expression was rolled up in the current result row's grouping set (bit 1) or is a grouping key of this set (bit 0). The first argument is the most-significant bit, so over the () arm of GROUPING SETS ((a, b), ()) GROUPING(a, b) is 0b11 = 3 and over the (a) arm it is 0b01 = 1.

GROUPING is a first-class Expression node (`case grouping(Array<Expression>)`), not a scalar call("GROUPING", ...): an unregistered call would fault SQLError.function in the validate/dispatch paths, and — unlike a routine — GROUPING resolves against the grouped scope's key membership rather than through the routines. Making it a dedicated case turned every exhaustive Expression switch non-exhaustive, so the compiler enumerated each site to handle.

After GROUPING SETS expansion each arm is a grouped SELECT whose Grouped scope knows this arm's keys and the superset (the lowered terms of every set's keys). GROUPING is therefore a compile-time per-arm integer constant: Grouped.term lowers each argument through the existing grouped membership — a key returns a slot below the key-count offset (bit 0), a rolled-up column returns the super-aggregate typeless-NULL constant (bit 1), and a genuine non-grouping column faults SQLError.grouping — assembles the bits MSB-first, and emits one Term.constant(.integer(bits)). No executor or physical Term path changed: a grouping node either lowers to a constant or faults before execution. Outside a grouped query the non-grouped term lowerings fault SQLState 42803, and GROUPING is typed .integer everywhere.