### PR TITLE
SQLEngine: lower emphasis capitals in comments

### DIFF
--- a/Sources/SQLEngine/AST+Expression.swift
+++ b/Sources/SQLEngine/AST+Expression.swift
@@ -98,11 +98,11 @@ public indirect enum Predicate: Hashable, Sendable {
   /// case.
   case membership(Expression, Array<Expression>, negated: Bool)
   /// `(l1, …, ln) <op> (r1, …, rn)` — an ISO `<row value constructor>`
-  /// comparison, both sides a row of scalar `Expression`s of EQUAL arity
+  /// comparison, both sides a row of scalar `Expression`s of equal arity
   /// (`SQLError.arity` at compile otherwise), `op` any of the six operators. It
-  /// is a FIRST-CLASS node rather than a parse-time desugar to a
+  /// is a FIRST-class node rather than a parse-time desugar to a
   /// conjunction/cascade of scalar comparisons so that each component
-  /// `Expression` is evaluated EXACTLY ONCE: the desugar duplicated a component
+  /// `Expression` is evaluated exactly once: the desugar duplicated a component
   /// across the places it appears (a `<` cascade names an earlier component in
   /// both a strict step and an equality tie-guard), so a stateful component
   /// yielded a different value each time. It keeps the ISO three-valued
@@ -112,10 +112,10 @@ public indirect enum Predicate: Hashable, Sendable {
   case rows(Array<Expression>, Comparison, Array<Expression>)
   /// `(l1, …, ln) [NOT] IN ((r1, …, rn), …)` — an ISO row-value membership, the
   /// left a `<row value constructor>` and the right a non-empty list of element
-  /// rows, each of EQUAL arity (`SQLError.arity` otherwise), `negated` marking
-  /// `NOT IN`. As `rows`, it is a FIRST-CLASS node rather than a desugar to an
-  /// OR-chain of row equalities so the left components are evaluated EXACTLY
-  /// ONCE rather than once per element row. It keeps the value-list `IN`'s
+  /// rows, each of equal arity (`SQLError.arity` otherwise), `negated` marking
+  /// `NOT IN`. As `rows`, it is a FIRST-class node rather than a desugar to an
+  /// OR-chain of row equalities so the left components are evaluated exactly
+  /// once rather than once per element row. It keeps the value-list `IN`'s
   /// three-valued semantics — a disjunction of row equalities under Kleene
   /// `OR`, a NULL component making an unmatched test UNKNOWN, `NOT IN` its
   /// negation — lowered to a `Filter.memberships`.
@@ -136,9 +136,9 @@ public indirect enum Predicate: Hashable, Sendable {
   case like(Expression, pattern: Operand, escape: Operand?, negated: Bool)
   /// `x [NOT] BETWEEN a AND b` — whether `x` is within the inclusive range
   /// `[a, b]`, or outside it when `negated`. The ISO definition is `x >= a AND
-  /// x <= b` (and `x < a OR x > b` negated), but it is a FIRST-CLASS node
-  /// rather than that expansion so the test expression `x` is evaluated EXACTLY
-  /// ONCE: the desugar duplicated `x` across both bound comparisons, testing a
+  /// x <= b` (and `x < a OR x > b` negated), but it is a FIRST-class node
+  /// rather than that expansion so the test expression `x` is evaluated exactly
+  /// once: the desugar duplicated `x` across both bound comparisons, testing a
   /// stateful `x`'s lower bound with one call and its upper with another. It
   /// keeps the ISO three-valued semantics — a NULL `x`, `a`, or `b` makes a
   /// bound UNKNOWN, excluding the row. Each bound `a` and `b` is an `Operand` —
@@ -149,7 +149,7 @@ public indirect enum Predicate: Hashable, Sendable {
   case between(Expression, Operand, Operand, negated: Bool)
   /// `a IS [NOT] DISTINCT FROM b` — the ISO null-safe comparison of `a` and
   /// `b`, `negated` marking the `IS NOT DISTINCT FROM` (null-safe equality)
-  /// spelling. It is TWO-VALUED — never UNKNOWN — treating NULL as a comparable
+  /// spelling. It is two-valued — never UNKNOWN — treating NULL as a comparable
   /// value: `a IS DISTINCT FROM b` is FALSE iff both are NULL, or both are
   /// non-NULL and equal, and TRUE otherwise (exactly one NULL, or both non-NULL
   /// and unequal). `IS NOT DISTINCT FROM` is its negation. A cross-kind pair is
@@ -157,50 +157,50 @@ public indirect enum Predicate: Hashable, Sendable {
   /// equality. Unlike `=`, a NULL operand never makes the row UNKNOWN.
   case distinct(Expression, Expression, negated: Bool)
   /// `[NOT] EXISTS (Q)` — whether the subquery `Q` yields at least one row,
-  /// `negated` marking `NOT EXISTS`. It is DEFINITELY two-valued — never
+  /// `negated` marking `NOT EXISTS`. It is definitely two-valued — never
   /// UNKNOWN — even when `Q` produces NULL-valued rows: the presence of a row
   /// is TRUE regardless of its values, so `EXISTS` tests cardinality alone. In
-  /// this first slice `Q` is UNCORRELATED — it names no column of the enclosing
-  /// query — so the engine materialises it ONCE (as a common table expression's
+  /// this first slice `Q` is uncorrelated — it names no column of the enclosing
+  /// query — so the engine materialises it once (as a common table expression's
   /// body is materialised) and the whole predicate is the definite non-empty
   /// test of that result; `negated` flips it. `Predicate` is `indirect`, so it
   /// nests the whole `Query` without boxing.
   case exists(Query, negated: Bool)
   /// `x [NOT] IN (Q)` — whether the operand `x` equals any value the subquery
-  /// `Q` yields, `negated` marking `NOT IN`. `Q` must project exactly ONE
+  /// `Q` yields, `negated` marking `NOT IN`. `Q` must project exactly one
   /// column (else `SQLError.arity`); the predicate is the three-valued
   /// membership of `x` in that column, exactly as the value-list `membership`
   /// is — a NULL `x` or a NULL element makes an otherwise-unmatched test
   /// UNKNOWN rather than FALSE, and `NOT IN` its negation (never TRUE when a
-  /// NULL element is present), while an EMPTY result is FALSE (TRUE negated).
-  /// In this first slice `Q` is UNCORRELATED (it names no enclosing column), so
-  /// the engine materialises it ONCE and folds `x = v` over the materialised
-  /// column under Kleene `OR`, the SAME three-valued core the value-list `IN`
+  /// NULL element is present), while an empty result is FALSE (TRUE negated).
+  /// In this first slice `Q` is uncorrelated (it names no enclosing column), so
+  /// the engine materialises it once and folds `x = v` over the materialised
+  /// column under Kleene `OR`, the same three-valued core the value-list `IN`
   /// uses.
   case within(Expression, Query, negated: Bool)
-  /// `x op {ANY | SOME | ALL} (Q)` — a QUANTIFIED comparison, whether `x op v`
+  /// `x op {ANY | SOME | ALL} (Q)` — a quantified comparison, whether `x op v`
   /// holds for at least one (`ANY`/`SOME`) or every (`ALL`) value `v` the
   /// subquery `Q` yields, `op` any of `= <> < <= > >=`. `Q` must project
-  /// exactly ONE column (else `SQLError.arity`). It is three-valued exactly as
-  /// `within` (`IN`) is — reusing the SAME `matches` comparison and Kleene
+  /// exactly one column (else `SQLError.arity`). It is three-valued exactly as
+  /// `within` (`IN`) is — reusing the same `matches` comparison and Kleene
   /// combine — folding `x op v` over `Q`'s column under Kleene `OR` for `any`
   /// (TRUE at the first TRUE, else UNKNOWN if any comparison is UNKNOWN through
   /// a NULL `x` or element, else FALSE) and under Kleene `AND` for `all` (FALSE
-  /// at the first FALSE, else UNKNOWN if any is UNKNOWN, else TRUE). An EMPTY
+  /// at the first FALSE, else UNKNOWN if any is UNKNOWN, else TRUE). An empty
   /// `Q` takes the fold's identity — `any` FALSE (no witness), `all` TRUE
   /// (vacuous). `= ANY` is `IN` and `<> ALL` is `NOT IN`, but the case is kept
   /// distinct for the general operator. `SOME` is a synonym for `ANY`,
-  /// normalised to `any` at parse time. In this slice `Q` is UNCORRELATED — it
+  /// normalised to `any` at parse time. In this slice `Q` is uncorrelated — it
   /// names no column of the enclosing query — so the engine materialises it
-  /// ONCE (as `within` does) and folds over that single column; correlation is
+  /// once (as `within` does) and folds over that single column; correlation is
   /// a later slice.
   case quantified(Expression, Comparison, Quantifier, Query)
   /// `p IS [NOT] <truth value>` — the ISO `<boolean test>`, whether the inner
-  /// boolean `Predicate` `p`'s THREE-VALUED result equals the `value`
+  /// boolean `Predicate` `p`'s three-valued result equals the `value`
   /// (`TRUE`/`FALSE`/`UNKNOWN`), or does not when `negated`. Unlike the other
-  /// predicates the result is DEFINITE two-valued — never itself UNKNOWN — so
+  /// predicates the result is definite two-valued — never itself UNKNOWN — so
   /// `p IS TRUE` is FALSE (not UNKNOWN) for an UNKNOWN `p`, and `p IS UNKNOWN`
-  /// TESTS for that UNKNOWN. The operand is a `Predicate` rather than an
+  /// tests for that UNKNOWN. The operand is a `Predicate` rather than an
   /// `Expression`: a boolean is a predicate to this engine — a bare boolean
   /// operand `x` bridges as the comparison `x = TRUE`, whose three-valued
   /// truth IS `x`'s boolean value (`NULL` yielding UNKNOWN) — so a boolean
@@ -237,7 +237,7 @@ public indirect enum Predicate: Hashable, Sendable {
 /// A truth value a `<boolean test>` (`Predicate.truth`) tests against — the
 /// three SQL truth values, `UNKNOWN` being the spelling the test uses for a
 /// NULL boolean (SQL spells UNKNOWN as `NULL` in a value position, but names it
-/// `UNKNOWN` in this test). `p IS TRUE`/`FALSE`/`UNKNOWN` yields a DEFINITE
+/// `UNKNOWN` in this test). `p IS TRUE`/`FALSE`/`UNKNOWN` yields a definite
 /// two-valued result, never itself UNKNOWN.
 public enum Truth: Hashable, Sendable {
   /// The truth value `TRUE`.
@@ -251,8 +251,8 @@ public enum Truth: Hashable, Sendable {
 /// The quantifier of a quantified comparison subquery `x op {ANY|ALL} (Q)`.
 ///
 /// `ANY` (and its synonym `SOME`, normalised to `any` at parse time) holds when
-/// `x op v` is TRUE for AT LEAST ONE value `v` the subquery yields; `ALL` holds
-/// when it is TRUE for EVERY value. Both are three-valued over NULLs and take
+/// `x op v` is TRUE for at least one value `v` the subquery yields; `ALL` holds
+/// when it is TRUE for every value. Both are three-valued over NULLs and take
 /// the empty-set identity of their Kleene fold — `ANY` over no rows is FALSE
 /// (OR's identity), `ALL` over no rows is TRUE (AND's identity). `x = ANY (Q)`
 /// is the `IN (Q)` special case and `x <> ALL (Q)` the `NOT IN (Q)` one, but

--- a/Sources/SQLEngine/AST.swift
+++ b/Sources/SQLEngine/AST.swift
@@ -116,14 +116,14 @@ public struct CTE: Hashable, Sendable {
     self.recursive = recursive
   }
 
-  /// The CTE's DECLARED output columns as the `ResolvedColumn` carrier — each
-  /// declared name typed `.integer` and marked UNCONSTRAINED, since the type is
-  /// a fabricated PLACEHOLDER (a materialised relation reports `.integer`; a
+  /// The CTE's declared output columns as the `ResolvedColumn` carrier — each
+  /// declared name typed `.integer` and marked unconstrained, since the type is
+  /// a fabricated placeholder (a materialised relation reports `.integer`; a
   /// CTE's rows carry no static types), NOT a genuine derivation — so a fold
   /// unifying against it defers to the other arm rather than faulting on the
-  /// placeholder. It is the FALLBACK a trusted derive falls back to when a
+  /// placeholder. It is the fallback a trusted derive falls back to when a
   /// data-dependent body a filter drops faults its type fold; the primary path
-  /// binds a CTE from its BODY-derived carrier (`kinds(of:)`), which unifies
+  /// binds a CTE from its body-derived carrier (`kinds(of:)`), which unifies
   /// the arms and carries the real `unconstrained` mask.
   internal var declared: Array<ResolvedColumn> {
     columns.map { ResolvedColumn(name: $0, type: .integer,
@@ -157,8 +157,8 @@ public enum SetOperation: Hashable, Sendable {
 /// `a UNION (b INTERSECT c)`. Without `all` a set operation removes duplicate
 /// result rows; with `all` (`ALL`) it keeps them per the operator's
 /// multiplicity rule. Every arm must project the same number of columns; the
-/// result column TYPES are unified across the arms (a mixed integer/double
-/// column widening to `double`), while their NAMES come from the first arm (the
+/// result column types are unified across the arms (a mixed integer/double
+/// column widening to `double`), while their names come from the first arm (the
 /// ISO rule).
 public indirect enum Query: Hashable, Sendable {
   /// A single `SELECT`.
@@ -173,9 +173,9 @@ public indirect enum Query: Hashable, Sendable {
   /// node). A `setop` node has no order/distinct/limit slot, so an ordered,
   /// deduplicated, or paged set operation rides this outer carrier: the row
   /// operators (`DISTINCT`, `ORDER BY`, `OFFSET`/`FETCH`) apply to the union's
-  /// combined result, resolved through the setop's OUTPUT scope, and do NOT
+  /// combined result, resolved through the setop's output scope, and do NOT
   /// project — the result columns stay the inner setop's arm-0-named, unified
-  /// ones. It is TRANSPARENT to `columns(unifying:)`, which descends to the
+  /// ones. It is transparent to `columns(unifying:)`, which descends to the
   /// inner setop for the result schema; only `run`/`compile` stack the row
   /// operators over the compiled setop plan. Produced by the GROUPING SETS
   /// `expand` and by the parser for a trailing query-level `ORDER BY` /
@@ -184,17 +184,17 @@ public indirect enum Query: Hashable, Sendable {
   /// `generated` is the number of GENERATED trailing columns the inner union
   /// carries beyond the real output — the hidden sort columns `expand` appends
   /// to each arm (aliased `*gsN`) so a genuinely-unprojected aggregate sort key
-  /// survives the `UNION ALL` at equal arity. The carrier's compile TRIMS them
+  /// survives the `UNION ALL` at equal arity. The carrier's compile trims them
   /// (`real = width − generated`), and `columns(unifying:)` drops them from the
-  /// result schema. It is a STRUCTURAL count carried out of `expand`, never
+  /// result schema. It is a structural count carried out of `expand`, never
   /// recovered by scanning output names for a synthetic prefix; the parser's
   /// trailing-`ORDER BY` carrier generates none (`0`).
   case ordered(Query, distinct: Bool, order: Order?, limit: Limit?,
                generated: Int)
 
   /// The first `SELECT` of the query — the leftmost arm, reached by descending
-  /// the left arm of each set operation. Its projection NAMES the result
-  /// columns (the ISO rule — their TYPES unify across every arm), so a `CREATE
+  /// the left arm of each set operation. Its projection names the result
+  /// columns (the ISO rule — their types unify across every arm), so a `CREATE
   /// VIEW` infers a set operation's column names from it. An `ordered` carrier
   /// is transparent — its first is its inner query's.
   public var first: Select {
@@ -229,7 +229,7 @@ public indirect enum Query: Hashable, Sendable {
     return (self, nil)
   }
 
-  /// This query's carrier-transparent CORE — its inner `setop`/`select`, an
+  /// This query's carrier-transparent core — its inner `setop`/`select`, an
   /// `ordered` carrier peeled off. A thin read over `unwound.inner` for the
   /// `if case .setop = query.core` seams that recognise a set operation whether
   /// or not it rides a carrier, so a carried union is not silently swallowed by
@@ -244,11 +244,11 @@ public indirect enum Query: Hashable, Sendable {
 ///
 /// The parser produces `.keys` for an ordinary `GROUP BY e, …` (empty for no
 /// grouping) and `.sets` for `GROUP BY GROUPING SETS (s, …)`. The compile and
-/// schema paths EXPAND a `.sets` into a `UNION ALL` of per-arm groupings, each
-/// arm a `.arm` grouping on ONE set's `keys` while carrying the `superset` (the
+/// schema paths expand a `.sets` into a `UNION ALL` of per-arm groupings, each
+/// arm a `.arm` grouping on one set's `keys` while carrying the `superset` (the
 /// union of ALL sets' keys) so an arm's lowering NULLs a projected/HAVING
-/// grouping column absent from THIS arm's set — the super-aggregate NULL —
-/// matched by RESOLVED identity, not raw AST.
+/// grouping column absent from this arm's set — the super-aggregate NULL —
+/// matched by resolved identity, not raw AST.
 public enum Grouping: Hashable, Sendable {
   /// `GROUP BY e, …` — the ordinary `<ordinary grouping set>` keys, in source
   /// order (empty for no explicit grouping).
@@ -258,7 +258,7 @@ public enum Grouping: Hashable, Sendable {
   /// an empty inner list is the grand-total set `()`.
   case sets(Array<Array<Expression>>)
 
-  /// ONE expanded arm of a `.sets` grouping — grouped on `keys` (this set's
+  /// one expanded arm of a `.sets` grouping — grouped on `keys` (this set's
   /// members) while `superset` is the union of every set's keys. A grouping
   /// column IN `superset` but absent from `keys` lowers to a super-aggregate
   /// NULL, matched by lowered-`Term` identity in `Grouped.term`. Produced by
@@ -267,7 +267,7 @@ public enum Grouping: Hashable, Sendable {
 
   /// The `GROUP BY` keys this grouping evaluates over the input rows — a
   /// `.keys` its list, a `.sets` the concatenation of all sets' keys, a `.arm`
-  /// its OWN set's keys. The reachability derive reads `isEmpty` here to
+  /// its own set's keys. The reachability derive reads `isEmpty` here to
   /// recognise a whole-result aggregate (an empty `GROUP BY`, the `()` arm), so
   /// this stays the arm's own keys, NOT its superset.
   public var expressions: Array<Expression> {
@@ -281,11 +281,11 @@ public enum Grouping: Hashable, Sendable {
     }
   }
 
-  /// The `GROUP BY` key expressions the subquery/aggregate COLLECTORS descend
+  /// The `GROUP BY` key expressions the subquery/aggregate collectors descend
   /// to pre-register each nested subquery — like `expressions`, but a `.arm`
-  /// yields its `superset` (the union of every set's keys). An arm LOWERS the
+  /// yields its `superset` (the union of every set's keys). An arm lowers the
   /// superset (an absent key NULLs by resolved identity), not merely its own
-  /// set, so a subquery in an OMITTED set's key must be collected here exactly
+  /// set, so a subquery in an omitted set's key must be collected here exactly
   /// as a present set's is; the superset subsumes the arm's own keys.
   internal var collected: Array<Expression> {
     switch self {
@@ -339,7 +339,7 @@ public struct Select: Hashable, Sendable {
   public let grouping: Grouping
 
   /// The `HAVING` filter over the grouped rows, if any — a predicate the engine
-  /// applies AFTER aggregation, so it may reference the aggregates and the
+  /// applies after aggregation, so it may reference the aggregates and the
   /// grouping columns. A `HAVING` without a `GROUP BY` filters the single
   /// whole-result group.
   public let having: Predicate?
@@ -378,9 +378,9 @@ public struct Select: Hashable, Sendable {
   /// Whether the EXISTS cardinality `probe` preserves this select's existence —
   /// so an EXISTS-only occurrence may run the probe rather than a full run.
   ///
-  /// It holds for a non-set-operation `SELECT` WITHOUT a `HAVING` that is
-  /// EITHER non-`DISTINCT` (its cardinality is the source's, independent of the
-  /// projected values) OR `DISTINCT` WITHOUT an `OFFSET`. `DISTINCT` collapses
+  /// It holds for a non-set-operation `SELECT` without a `HAVING` that is
+  /// either non-`DISTINCT` (its cardinality is the source's, independent of the
+  /// projected values) OR `DISTINCT` without an `OFFSET`. `DISTINCT` collapses
   /// a non-empty source to at least one distinct row, so `SELECT DISTINCT 1
   /// FROM S` is non-empty iff `S` is — existence is preserved by the constant
   /// projection. An `OFFSET` breaks that: it skips DISTINCT rows, so emptiness
@@ -390,10 +390,10 @@ public struct Select: Hashable, Sendable {
   /// probe-eligible.
   ///
   /// An aggregate/grouped select without a `HAVING` is probe-eligible: its
-  /// cardinality is a source-only fact the probe preserves WITHOUT the original
+  /// cardinality is a source-only fact the probe preserves without the original
   /// target (see `probe`). A whole-result aggregate (no `GROUP BY`) yields
-  /// EXACTLY ONE row regardless of the source — so EXISTS is true modulo the
-  /// limit — and a grouped one yields ONE ROW PER GROUP, so existence is the
+  /// exactly one row regardless of the source — so EXISTS is true modulo the
+  /// limit — and a grouped one yields one ROW per GROUP, so existence is the
   /// source's non-emptiness after `WHERE`. A `HAVING` is NOT eligible: group
   /// survival depends on the aggregate VALUES (which `HAVING` may reference),
   /// so cardinality is not a source-only fact and the target must run.
@@ -404,26 +404,26 @@ public struct Select: Hashable, Sendable {
 
   /// The EXISTS cardinality-probe rewrite of this select — the same
   /// FROM/`WHERE`/joins, the same `DISTINCT` quantifier, the same `GROUP BY`,
-  /// and the SAME original `OFFSET`/`FETCH`, but its projection replaced with a
+  /// and the same original `OFFSET`/`FETCH`, but its projection replaced with a
   /// cardinality-preserving target and its `ORDER BY` dropped — so a probe run
-  /// tests whether the row source yields ANY row WITHOUT evaluating the
+  /// tests whether the row source yields ANY row without evaluating the
   /// original select list or sort keys.
   ///
   /// It preserves the row source (FROM, joins, `WHERE`) and the original row
-  /// limit EXACTLY, so its cardinality matches this select's — enough for an
+  /// limit exactly, so its cardinality matches this select's — enough for an
   /// existence test that honours the original limiting: a `FETCH FIRST 0 ROWS`
   /// probes zero rows (EXISTS false) and an `OFFSET` past the end probes none
   /// (false), neither overridden by a synthetic cap. `ORDER BY` is dropped
   /// because existence is order-independent (the row count after `OFFSET`/
   /// `FETCH` does not depend on order). A FROM-less `SELECT <exprs>` always
   /// yields exactly one row and cannot carry a limit, so its probe is just
-  /// `SELECT <constant>` with NO limit — it compiles and yields one row
+  /// `SELECT <constant>` with no limit — it compiles and yields one row
   /// (EXISTS true). `DISTINCT` is retained (the caller applies the probe to a
   /// `DISTINCT` select only when it has no `OFFSET`, so `SELECT DISTINCT 1 FROM
   /// S` yields exactly one distinct row iff `S` is non-empty).
   ///
   /// The probe target is chosen to preserve cardinality without the original:
-  /// a NON-aggregate select projects the constant `1`, one row per source row;
+  /// a non-aggregate select projects the constant `1`, one row per source row;
   /// an aggregate/grouped one projects `COUNT(*)` (with the `GROUP BY` kept), a
   /// trivial always-computable aggregate whose grouping is the original's — a
   /// whole-result `COUNT(*)` yields exactly one row (even over an empty source)
@@ -441,20 +441,20 @@ public struct Select: Hashable, Sendable {
                   grouping: grouping, having: nil, order: nil, limit: limit)
   }
 
-  /// Every expression the ORDER BY sort EVALUATES over its input rows — the
-  /// direct sort-key expressions AND the projection expressions its OUTPUT
+  /// Every expression the ORDER BY sort evaluates over its input rows — the
+  /// direct sort-key expressions AND the projection expressions its output
   /// shorthands reach — the ones a reachable type-check pass must validate as
   /// it does a projected expression.
   ///
-  /// The compiled shape is `Project(Limit(Sort(input)))`: the sort is BELOW the
-  /// limit and evaluates each key over the input rows BEFORE the cap pages
+  /// The compiled shape is `Project(Limit(Sort(input)))`: the sort is below the
+  /// limit and evaluates each key over the input rows before the cap pages
   /// them, so what the sort forces to evaluate is independent of whether the
   /// projection is reachable. Each ORDER BY key resolves to the expression the
   /// sort runs, mirroring the resolver's lowering:
   ///
   ///   - a direct `.expression(e)` key over the input columns yields `e`;
-  ///   - a bare unqualified column matching a projected explicit-`AS` OUTPUT
-  ///     ALIAS resolves to that projection item's OWN expression (the ISO alias
+  ///   - a bare unqualified column matching a projected explicit-`AS` output
+  ///     alias resolves to that projection item's own expression (the ISO alias
   ///     precedence a `ORDER BY x` follows) — the term the sort recomputes
   ///     below the limit, NOT a fresh input reference;
   ///   - an `ordinal(n)` resolves to the `n`-th projection item's expression
@@ -464,19 +464,19 @@ public struct Select: Hashable, Sendable {
   /// reach (each output is a plain column slot compilation already resolves),
   /// so an ordinal or bare-name key against one contributes nothing to check.
   ///
-  /// A bare unqualified name binds to a projection OUTPUT name by the SAME rule
+  /// A bare unqualified name binds to a projection output name by the same rule
   /// the resolver's `ORDER BY` lowering uses, so the type-check and the run
   /// agree on which keys are outputs and which are input columns:
   ///
-  ///   - a NON-grouped query resolves an output name from an EXPLICIT `AS`
-  ///     ALIAS only (`Projected.alias`) — the representation-independent ISO
+  ///   - a non-grouped query resolves an output name from an explicit `AS`
+  ///     alias only (`Projected.alias`) — the representation-independent ISO
   ///     precedence a `ORDER BY x` follows, so a bare projected column (no
   ///     `AS`) introduces no output and `ORDER BY <bareName>` stays an input
   ///     reference whether the parser emitted the select list as `columns` or,
   ///     forced by a sibling `AS`, as `expressions` (mirrors non-grouped
   ///     `Scope.order`);
-  ///   - a GROUPED query resolves an output name from `Projected.name` (an
-  ///     alias, else a bare column's name) — the SAME output-name set
+  ///   - a grouped query resolves an output name from `Projected.name` (an
+  ///     alias, else a bare column's name) — the same output-name set
   ///     `Grouped.terms`/`Grouped.order` record and bind, so a grouped
   ///     `ORDER BY <groupcol>` naming an unaliased projected group column
   ///     resolves to that output here exactly as it does in the run, rather
@@ -514,7 +514,7 @@ public struct Select: Hashable, Sendable {
           expressions.append(items[position - 1].expression)
         }
       case let .expression(expression):
-        // A bare unqualified name binds a matching projection OUTPUT name
+        // A bare unqualified name binds a matching projection output name
         // before an input column (the ISO precedence), resolving to that
         // item's expression — the output surface (`output`) mirrors the
         // resolver's lowering for this query shape.
@@ -533,13 +533,13 @@ public struct Select: Hashable, Sendable {
 }
 
 /// A relation in a `FROM` or `JOIN`: a base relation named by an identifier, or
-/// a DERIVED TABLE — a parenthesised subquery `(SELECT …)` — each with an
+/// a derived TABLE — a parenthesised subquery `(SELECT …)` — each with an
 /// alias.
 ///
 /// A `named` relation's `name` is its spelling; its `alias`, when present, is
 /// the short name a qualified column reference may use in its place (`FROM
 /// TypeDef AS t`). A `derived` relation wraps a `Query`, materialised once
-/// and resolved under a MANDATORY alias — ISO requires a derived table be named
+/// and resolved under a mandatory alias — ISO requires a derived table be named
 /// (`FROM (SELECT …) AS t`) — so `alias` is always present and `name` is that
 /// alias, the key the resolution scope binds its materialised rows under.
 public struct Relation: Hashable, Sendable {
@@ -561,15 +561,15 @@ public struct Relation: Hashable, Sendable {
 
   /// The relation's explicit output column names — the ISO `AS t(c, …)` list —
   /// in ordinal order, or empty when the relation carries no list. A supplied
-  /// list positionally RENAMES the relation's real output columns (the same
+  /// list positionally renames the relation's real output columns (the same
   /// mechanism a CTE's `columns` list applies), so `FROM T AS t(c, d)` and
   /// `(SELECT x, y FROM T) AS d(a, b)` address the relation's columns by the
-  /// new names. ISO admits the list on BOTH a named relation and a derived
+  /// new names. ISO admits the list on both a named relation and a derived
   /// table, so it rides on the shared `Relation` node. Empty matches the CTE
   /// field's shape (an absent list, columns inferred from the source).
   public let columns: Array<String>
 
-  /// Whether a `LATERAL` derived table — its body may reference the PRECEDING
+  /// Whether a `LATERAL` derived table — its body may reference the preceding
   /// FROM items, so it re-evaluates per their rows (a correlated apply), rather
   /// than materialising once. Always `false` for a `named` relation and for a
   /// plain (non-`LATERAL`) derived table, which resolves independently of its
@@ -628,7 +628,7 @@ public struct Relation: Hashable, Sendable {
 /// `kind` is the inner/outer variety: `inner` (the default) keeps only matched
 /// pairs, while a `left`/`right`/`full` OUTER join additionally preserves the
 /// unmatched rows of the left, right, or both sides, NULL-extending the other
-/// side's columns. The `ON` predicate governs MATCHING alone — an unmatched
+/// side's columns. The `ON` predicate governs matching alone — an unmatched
 /// outer row is still emitted — which is distinct from a post-join `WHERE`.
 public struct Join: Hashable, Sendable {
   /// The inner/outer variety of a join.
@@ -644,24 +644,24 @@ public struct Join: Hashable, Sendable {
   }
 
   /// The ISO named-column join criterion of a `NATURAL` or `JOIN … USING`
-  /// clause — a shorthand whose join columns are resolved by NAME rather than
-  /// spelled as an `ON` predicate, and whose common columns COALESCE into ONE
+  /// clause — a shorthand whose join columns are resolved by name rather than
+  /// spelled as an `ON` predicate, and whose common columns COALESCE into one
   /// unqualified output column (ISO 9075 7.10).
   ///
   /// It is mutually exclusive with an `ON` predicate (the parser rejects a
   /// `NATURAL … ON` / `USING … ON`), and its concrete column set is known only
-  /// after SCHEMA resolution — the two sides' column names — so the engine
+  /// after schema resolution — the two sides' column names — so the engine
   /// carries the criterion here and resolves it into the equality `on`
   /// predicate and the coalesced `SELECT *` output during compilation, rather
   /// than at parse time. A join with no criterion (`nil`) is a plain `ON`/
   /// `CROSS` join.
   public enum Using: Hashable, Sendable {
-    /// `NATURAL` — the join columns are EVERY column name the two sides share
+    /// `NATURAL` — the join columns are every column name the two sides share
     /// (their case-insensitive intersection, in the left side's column order),
     /// computed at resolution. No common column degenerates to a `CROSS` join.
     case natural
-    /// `USING (c, …)` — the join columns are the NAMED ones, each of which must
-    /// name a column present in BOTH sides (else a column fault).
+    /// `USING (c, …)` — the join columns are the named ones, each of which must
+    /// name a column present in both sides (else a column fault).
     case columns(Array<String>)
   }
 
@@ -717,7 +717,7 @@ public struct Join: Hashable, Sendable {
 /// real column or one of the binding's adapter-computed columns (`Id`, an owner
 /// foreign key); the AST does not distinguish them.
 ///
-/// `Column` is `ExpressibleByStringLiteral`, splitting a literal on its LAST
+/// `Column` is `ExpressibleByStringLiteral`, splitting a literal on its last
 /// dot into qualifier and name, so a consumer may write a reference as a plain
 /// string (`"t.Name"`, `"Flags"`).
 public struct Column: Hashable, Sendable, ExpressibleByStringLiteral {
@@ -732,7 +732,7 @@ public struct Column: Hashable, Sendable, ExpressibleByStringLiteral {
     self.name = name
   }
 
-  /// Parses a reference from its dotted spelling: the text before the LAST dot
+  /// Parses a reference from its dotted spelling: the text before the last dot
   /// is the qualifier and the text after it is the name; an undotted spelling
   /// is an unqualified name.
   ///
@@ -778,13 +778,13 @@ public enum Projection: Hashable, Sendable {
   ///
   /// A `columns` projection yields each reference's name (the qualifier
   /// dropped); an `expressions` projection yields each item's inferable `name`
-  /// The per-item explicit-`AS` OUTPUT ALIASES of a projection of `count`
+  /// The per-item explicit-`AS` output aliases of a projection of `count`
   /// columns, aligned index-for-index with the lowered projection terms — an
   /// `expressions` item's `alias` (the explicit `AS`, else `nil`); a `*` or a
   /// bare-column list names none (`nil` throughout).
   ///
   /// It is the alias surface an `ORDER BY` output name resolves against, and it
-  /// is REPRESENTATION-INDEPENDENT: only an explicit `AS` introduces an
+  /// is representation-independent: only an explicit `AS` introduces an
   /// output name an `ORDER BY` may bind, so a bare projected column (`SELECT
   /// a.Name …`) contributes `nil` here whether the parser emitted it as a
   /// `columns` list or, forced by a sibling `AS`, as an `expressions` list —
@@ -845,7 +845,7 @@ public struct Projected: Hashable, Sendable {
 
   /// The output name this item contributes, or `nil` when it has none — its
   /// alias, else a bare column's name; a non-column expression with no alias
-  /// has no inferable name. It is the ONE derivation every output-name site
+  /// has no inferable name. It is the one derivation every output-name site
   /// shares: view/CTE column inference (`Projection.names()`, faulting on
   /// `nil`), the result-schema walk (substituting a positional `column N`),
   /// and an aggregate `ORDER BY`'s alias recording (recording only a `name`).
@@ -891,7 +891,7 @@ public indirect enum Expression: Hashable, Sendable {
   ///
   /// `filter`, when present, is the ISO `FILTER (WHERE <search condition>)` —
   /// the aggregate folds only the rows of the group whose predicate is TRUE (a
-  /// FALSE or UNKNOWN row is skipped), applied as a per-row gate BEFORE the
+  /// FALSE or UNKNOWN row is skipped), applied as a per-row gate before the
   /// value reaches the fold — and before the `DISTINCT` dedup, so the two
   /// compose as "filter, then dedup". It gates even `COUNT(*)`, which counts
   /// only the admitted rows.
@@ -902,7 +902,7 @@ public indirect enum Expression: Hashable, Sendable {
   /// `else` result, or `NULL` when there is no `ELSE`. The `when`s are held in
   /// source order.
   ///
-  /// Both ISO forms reduce to this searched shape: a SEARCHED `CASE WHEN cond
+  /// Both ISO forms reduce to this searched shape: a searched `CASE WHEN cond
   /// THEN r … END` carries its predicates directly, and a SIMPLE `CASE op WHEN
   /// v THEN r … END` is normalised at parse time to `WHEN op = v THEN r …`, so
   /// the engine models one conditional. The result expressions' types must
@@ -910,8 +910,8 @@ public indirect enum Expression: Hashable, Sendable {
   case `case`(Array<When>, else: Expression?)
   /// A `CAST(operand AS type)` — the ISO explicit conversion of the `operand`
   /// expression to the target `ValueType`. Unlike the widening `CASE` unifies
-  /// its arms with, a cast is a NOMINAL conversion whose static type is the
-  /// target, so the engine advertises `type` for the column and CONVERTS the
+  /// its arms with, a cast is a nominal conversion whose static type is the
+  /// target, so the engine advertises `type` for the column and converts the
   /// evaluated value to it per row (see `Value.cast(to:)`). A `NULL` operand
   /// casts to `NULL` for any target; an unconvertible value (an unparseable
   /// text-to-number, an out-of-range double-to-integer, a cross-kind pair with
@@ -919,8 +919,8 @@ public indirect enum Expression: Hashable, Sendable {
   case cast(Expression, ValueType)
   /// `COALESCE(v1, v2, …)` — the first argument whose value is non-NULL, else
   /// NULL. The ISO definition is the searched `CASE WHEN v1 IS NOT NULL THEN v1
-  /// … END`, but it is a FIRST-CLASS node rather than that expansion so each
-  /// argument is evaluated EXACTLY ONCE: the desugar re-referenced each `vi` in
+  /// … END`, but it is a FIRST-class node rather than that expansion so each
+  /// argument is evaluated exactly once: the desugar re-referenced each `vi` in
   /// both its `IS NOT NULL` guard and its `THEN`, evaluating a stateful
   /// argument twice — testing one call's value for NULL and returning a
   /// different one. The result type is the `ValueType.unified` reduction over
@@ -930,40 +930,40 @@ public indirect enum Expression: Hashable, Sendable {
   case coalesce(Array<Expression>)
   /// `NULLIF(v1, v2)` — NULL when `v1` equals `v2`, else `v1`. The ISO
   /// definition is `CASE WHEN v1 = v2 THEN NULL ELSE v1 END`, but it is a
-  /// FIRST-CLASS node rather than that expansion so `v1` is evaluated EXACTLY
-  /// ONCE: the desugar embedded `v1` in both the equality and the `ELSE`,
+  /// FIRST-class node rather than that expansion so `v1` is evaluated exactly
+  /// once: the desugar embedded `v1` in both the equality and the `ELSE`,
   /// evaluating a stateful `v1` twice — comparing one call's value to `v2` and
   /// returning a different one. The result type is `v1`'s.
   case nullif(Expression, Expression)
   /// A scalar subquery `(SELECT …)` — a nested `Query` in expression position,
-  /// yielding ONE value: its lone cell when it returns exactly one row, NULL
+  /// yielding one value: its lone cell when it returns exactly one row, NULL
   /// when it returns none, and `SQLError.cardinality` when it returns more. The
-  /// inner query must project EXACTLY ONE column (checked at compile, cursor-
+  /// inner query must project exactly one column (checked at compile, cursor-
   /// free, from its compiled width); the value's type is that column's. `Query`
   /// is `indirect`, so nesting it here composes the synthesized `Hashable`.
   ///
-  /// In this slice the subquery is UNCORRELATED — it names no column of the
-  /// enclosing query — so it runs ONCE per outer-query execution (memoised in
+  /// In this slice the subquery is uncorrelated — it names no column of the
+  /// enclosing query — so it runs once per outer-query execution (memoised in
   /// the same `Subqueries` cache an `EXISTS`/`IN (Q)` predicate uses) and its
   /// value is the same for every outer row. A reference to an outer column
   /// resolves (or faults) as any other column would; correlation is a later
   /// slice.
   case subquery(Query)
-  /// `GROUPING(a, …)` — the ISO grouping-sets function, an integer bit-VECTOR
-  /// reporting per argument whether that expression was ROLLED UP (omitted from
+  /// `GROUPING(a, …)` — the ISO grouping-sets function, an integer bit-vector
+  /// reporting per argument whether that expression was rolled up (omitted from
   /// the current result row's grouping set — bit `1`) or is a grouping key of
-  /// this set (bit `0`). The FIRST argument is the MOST-significant bit, so over
+  /// this set (bit `0`). The FIRST argument is the most-significant bit, so over
   /// the `()` arm of `GROUPING SETS ((a, b), ())` `GROUPING(a, b)` is `0b11`
   /// (`3`), and over the `(a)` arm it is `0b01` (`1`). Each argument must be a
   /// `GROUP BY` expression of some grouping set (else an error), and GROUPING is
   /// valid only in a grouped query (a `GROUP BY`, or a whole-result aggregate).
   ///
-  /// It is a FIRST-CLASS node — NOT a scalar `call(name: "GROUPING", …)`, which
+  /// It is a FIRST-class node — NOT a scalar `call(name: "GROUPING", …)`, which
   /// would fault `SQLError.function` as an unregistered routine — because it
-  /// resolves against the GROUPED scope's key membership rather than through
+  /// resolves against the grouped scope's key membership rather than through
   /// the routines: after GROUPING SETS expansion each arm knows its own
-  /// keys and the superset, so GROUPING is a COMPILE-TIME per-arm integer
-  /// CONSTANT (`Grouped.term`) and no executor path ever evaluates a `grouping`
+  /// keys and the superset, so GROUPING is a compile-TIME per-arm integer
+  /// constant (`Grouped.term`) and no executor path ever evaluates a `grouping`
   /// node — it lowers to a `Term.constant(.integer(bits))`.
   case grouping(Array<Expression>)
 }
@@ -982,7 +982,7 @@ public struct Order: Hashable, Sendable {
     /// An ISO `<sort key>` — the value a key orders on.
     ///
     /// The standard makes a sort key an arbitrary value expression over the
-    /// query's columns; SQL practice adds two shorthands that name an OUTPUT
+    /// query's columns; SQL practice adds two shorthands that name an output
     /// column of the select list rather than an input value: a 1-based
     /// `ordinal` and an output `alias`. The three cases:
     ///
@@ -993,11 +993,11 @@ public struct Order: Hashable, Sendable {
     ///   a select-list position. An out-of-range `n` faults.
     /// - `expression(e)` — `ORDER BY a + b`, `ORDER BY UPPER(Name)`, or a bare
     ///   column `ORDER BY Name` (the common case) — any value expression over
-    ///   the INPUT columns, evaluated per row.
+    ///   the input columns, evaluated per row.
     ///
-    /// An unqualified name is EITHER an output alias (`SELECT x AS y … ORDER BY
+    /// An unqualified name is either an output alias (`SELECT x AS y … ORDER BY
     /// y`) or an input column; it lowers as an `expression(.column(name))` and
-    /// the resolver prefers a matching OUTPUT alias to an input column of the
+    /// the resolver prefers a matching output alias to an input column of the
     /// same name (the ISO precedence for a bare `ORDER BY` name), falling back
     /// to the input column when no alias claims it.
     public enum Sort: Hashable, Sendable {

--- a/Sources/SQLEngine/Adapter.swift
+++ b/Sources/SQLEngine/Adapter.swift
@@ -48,7 +48,7 @@ public enum ValueType: Hashable, Sendable {
     }
   }
 
-  /// The single type a value of this type and one of `other` UNIFY to, or `nil`
+  /// The single type a value of this type and one of `other` unify to, or `nil`
   /// when they are irreconcilable — the rule a `CASE` reconciles its result
   /// types by. Like types unify to themselves; a mixed integer/double pair
   /// widens to `double` (both numeric, the integer promoted, as arithmetic and
@@ -60,22 +60,22 @@ public enum ValueType: Hashable, Sendable {
     return nil
   }
 
-  /// Whether a value of this type can convert to `target` under `CAST` for AT
-  /// LEAST ONE value — the STRUCTURAL half of `Value.cast(to:)`, the one shared
+  /// Whether a value of this type can convert to `target` under `CAST` for at
+  /// least one value — the structural half of `Value.cast(to:)`, the one shared
   /// truth both the runtime cast and the schema type-check consult so they
   /// cannot drift.
   ///
   /// A pair is castable when `Value.cast(to:)` has a conversion arm for it; an
-  /// UNSUPPORTED pair — the one that falls to `Value.cast`'s `42846` arm for
-  /// EVERY value of this kind — is not. A like-kind cast is the identity; a
+  /// unsupported pair — the one that falls to `Value.cast`'s `42846` arm for
+  /// every value of this kind — is not. A like-kind cast is the identity; a
   /// numeric pair converts (`integer` ↔ `double`); `text` bridges every kind
   /// (each type spells to and parses from text) and `blob` bridges `text`
   /// alone. The remaining cross-kind pairs — a boolean against a number or a
   /// blob, a number against a blob — have no ISO conversion.
   ///
-  /// A castable pair may still fault at RUN time on a particular value — a
+  /// A castable pair may still fault at run time on a particular value — a
   /// `text` that is not a number, a `double` past `Int` range, a `blob` that is
-  /// not UTF-8 — so a reachable good value runs; only a NEVER-castable pair is
+  /// not UTF-8 — so a reachable good value runs; only a never-castable pair is
   /// an unconditional fault the schema rejects early.
   internal func castable(to target: ValueType) -> Bool {
     switch (self, target) {
@@ -126,7 +126,7 @@ public enum Value: Hashable, Sendable {
   /// integer promoted to `Double`; a mixed integer/double arithmetic yields a
   /// double, and `/` is real division (no truncation).
   ///
-  /// INVARIANT: a `double` must be FINITE — never `inf` or NaN. NaN is unequal
+  /// invariant: a `double` must be finite — never `inf` or NaN. NaN is unequal
   /// to itself, so it would break UNION/CTE duplicate elimination and ordering;
   /// the engine's producers enforce this (a literal or arithmetic result past
   /// range faults, a routine's non-finite result is rejected), so a `Catalog`,
@@ -160,14 +160,14 @@ extension Value {
     return self
   }
 
-  /// This value CONVERTED to `type` — the ISO `CAST(… AS type)` explicit
+  /// This value converted to `type` — the ISO `CAST(… AS type)` explicit
   /// conversion, wider than the numeric-widening `coerced(to:)`.
   ///
   /// `NULL` converts to `NULL` for every target. A value already of `type`
   /// passes through. The remaining conversions form the supported matrix:
   ///
   /// - `integer` ↔ `double`: an integer widens to a double exactly; a double
-  ///   TRUNCATES toward zero to an integer (`1.9` → `1`, `-1.9` → `-1`), the
+  ///   truncates toward zero to an integer (`1.9` → `1`, `-1.9` → `-1`), the
   ///   ISO exact-numeric-from-approximate rule, faulting when the truncated
   ///   magnitude exceeds `Int` (`22003`).
   /// - number → `text`: its canonical spelling (`42`, `1.5`).
@@ -304,7 +304,7 @@ extension String {
   /// Whether this string is a SQL DECIMAL numeric spelling — an optional
   /// leading sign, a digit run, an optional `.` fraction, and an optional
   /// `e`/`E` exponent (its own optional sign then a digit run) — the same
-  /// grammar the lexer scans a numeric literal by. It admits NO Swift extension
+  /// grammar the lexer scans a numeric literal by. It admits no Swift extension
   /// `Double(_:)` accepts: no hexadecimal (`0x`, a `p` exponent), no
   /// `inf`/`infinity`/`nan`, no underscore digit groups. A CAST of a character
   /// string to a number validates its spelling against this before parsing, so
@@ -336,7 +336,7 @@ extension String {
   }
 
   /// Whether this string is a SQL INTEGER numeric spelling — an optional
-  /// leading sign then a digit run, with NO fraction, exponent, hexadecimal,
+  /// leading sign then a digit run, with no fraction, exponent, hexadecimal,
   /// underscore group, or `inf`/`nan`. A CAST of a character string to an
   /// integer validates its spelling against this before parsing, so a malformed
   /// spelling is an invalid character (`22018`) while a format-valid spelling
@@ -419,7 +419,7 @@ public protocol Catalog: ~Escapable {
 
   /// The names of every base relation the catalog holds, in any order.
   ///
-  /// Where `table(named:)` resolves ONE name, this enumerates them all — the
+  /// Where `table(named:)` resolves one name, this enumerates them all — the
   /// surface the engine's `INFORMATION_SCHEMA` overlay walks to build its
   /// `tables`/`columns` metadata. An `Array<String>` is escapable owned data,
   /// so the enumeration stays `~Escapable`-safe over a borrowed source. Every

--- a/Sources/SQLEngine/Aggregate.swift
+++ b/Sources/SQLEngine/Aggregate.swift
@@ -23,15 +23,15 @@
 /// The `function` is the standard aggregate; `argument` is the term evaluated
 /// per source record whose non-NULL values the aggregate folds, or `nil` for
 /// `COUNT(*)`, which counts rows without reading any value. The argument is in
-/// the SOURCE's slot space (the WHERE/join chain below the aggregate),
+/// the source's slot space (the WHERE/join chain below the aggregate),
 /// evaluated against each source record before the fold; the result lands in
 /// the grouped record.
 ///
-/// Two aggregations are EQUAL when they fold the same function over the same
-/// resolved argument term — the RESOLVED form column qualification has already
+/// Two aggregations are equal when they fold the same function over the same
+/// resolved argument term — the resolved form column qualification has already
 /// normalized to a slot, so `SUM(Amount)` and `SUM(Sales.Amount)` in a
 /// single-relation scope are one aggregation. Equality (not `Hashable`, since
-/// `Term` is only `Equatable`) is how the grouped path DEDUPS the aggregates
+/// `Term` is only `Equatable`) is how the grouped path dedups the aggregates
 /// collected from the projection, the `HAVING`, and the `ORDER BY` into one
 /// grouped slot each, so a qualification-equivalent aggregate written in two
 /// clauses computes once and both clauses order/read the same slot.
@@ -52,7 +52,7 @@ internal struct Aggregation: Equatable {
   /// The lowered per-row gate of an aggregate's `FILTER (WHERE …)`, or `nil`
   /// when none is written. A source record folds into the aggregate only when
   /// this filter evaluates TRUE (a FALSE or UNKNOWN row is skipped), applied
-  /// BEFORE the `distinct` dedup.
+  /// before the `distinct` dedup.
   internal let filter: Filter?
 
   internal init(function: Aggregate, argument: Term?, distinct: Bool = false,
@@ -95,7 +95,7 @@ extension Aggregation {
 /// the end so the result does not depend on row order — `AVG` then dividing by
 /// the non-NULL count as real division to an approximate-numeric double;
 /// `MIN`/`MAX` keep the least/greatest non-NULL value by the engine's typed
-/// `less`. Every aggregate but `COUNT` IGNORES NULLs — a NULL argument does not
+/// `less`. Every aggregate but `COUNT` ignores NULLs — a NULL argument does not
 /// fold — and an empty or all-NULL group yields `COUNT` `0` and the others
 /// NULL.
 private struct Accumulator {
@@ -103,15 +103,15 @@ private struct Accumulator {
   // Whether to fold each DISTINCT non-NULL value once — the ISO `DISTINCT` set
   // quantifier — tracking the values already folded in `seen`. `MIN`/`MAX`
   // honour it as a no-op (an extreme is unchanged by duplicates), so the flag
-  // is normalised OFF for them in `init`: the dedup — and the `seen` set it
+  // is normalised off for them in `init`: the dedup — and the `seen` set it
   // grows — runs only for `COUNT`/`SUM`/`AVG`, where duplicate multiplicity
-  // matters. This keeps a `MIN`/`MAX(DISTINCT x)` an O(1) STREAMING fold rather
+  // matters. This keeps a `MIN`/`MAX(DISTINCT x)` an O(1) streaming fold rather
   // than one whose memory grows with the group's distinct values for no
   // semantic gain (its result is the same as `MIN`/`MAX(x)` either way).
   private let distinct: Bool
   private var seen = Set<Value>()
   private var count = 0
-  // SUM/AVG numeric state, kept independent of row order: an exact WIDE integer
+  // SUM/AVG numeric state, kept independent of row order: an exact wide integer
   // total (`Int128`, range-checked once at the end) for the all-integer case,
   // and a parallel double total used once any operand is a double. A wide total
   // means a transient prefix overflow cannot latch a fault a later value
@@ -125,7 +125,7 @@ private struct Accumulator {
   internal init(_ function: Aggregate, distinct: Bool = false) {
     self.function = function
     // `DISTINCT` is a no-op for `MIN`/`MAX` (an extreme is unchanged by
-    // duplicates), so normalise it OFF for them: the fold never builds `seen`,
+    // duplicates), so normalise it off for them: the fold never builds `seen`,
     // staying O(1) streaming rather than O(distinct-values) memory.
     self.distinct = distinct && function != .min && function != .max
   }
@@ -144,7 +144,7 @@ private struct Accumulator {
     // fold, so an all-NULL group aggregates as an empty one.
     if case .null = value { return }
     // A double operand widens the SUM/AVG total to an approximate double, and
-    // the widen decision is order-independent: flag it from the CELL'S KIND
+    // the widen decision is order-independent: flag it from the cell'S kind
     // before the DISTINCT dedup, so a double anywhere in the group widens even
     // when it is a duplicate the dedup skips for summation. `1` and `1.0`
     // canonicalise equal, so a group mixing them dedups to one value whose kind
@@ -155,10 +155,10 @@ private struct Accumulator {
       widened = true
     }
     // Under `DISTINCT` a value already folded does not fold again — deduped on
-    // its CANONICAL form (the same normalisation a `GROUP BY` key and the
+    // its canonical form (the same normalisation a `GROUP BY` key and the
     // equality UNION use, so `1` and `1.0` count as one distinct value) — so a
     // repeated value counts, sums, and averages once. `MIN`/`MAX` normalise
-    // `distinct` OFF (an extreme is unchanged by duplicates), so this never
+    // `distinct` off (an extreme is unchanged by duplicates), so this never
     // builds `seen` for them. `COUNT(*)`'s row sentinel never reaches here (a
     // `COUNT(*)` carries no `distinct`), so every counted row still counts.
     if distinct, !seen.insert(canonical(value)).inserted { return }
@@ -246,7 +246,7 @@ private struct Accumulator {
         // AVG is real division of the numeric total over the non-NULL count,
         // yielding an approximate-numeric double — not truncating like the
         // engine's integer `/`. An empty or all-NULL group has no value, so AVG
-        // is NULL. It divides the WIDE total (the exact Int128, or the double
+        // is NULL. It divides the wide total (the exact Int128, or the double
         // total when a double widened it), so an all-integer sum outside Int
         // still averages rather than faulting like SUM's Int-bounded result.
         if count == 0 { return .null }
@@ -286,11 +286,11 @@ private func comparable(_ a: Value, _ b: Value) -> Bool {
 ///
 /// A grouped record's slots are the key values (slots `0 ..< keys.count`, in
 /// key order) followed by the aggregate results (slot `keys.count + j` is
-/// `aggregates[j]`). Groups are keyed on the EXACT canonical form of the
+/// `aggregates[j]`). Groups are keyed on the exact canonical form of the
 /// evaluated key values (`canonical` — so `1` and `1.0` fall in one group, the
 /// equality UNION and predicates use), and each group emits its
 /// FIRST-appearance original key values, in first-appearance order, so a later
-/// `ORDER BY` re-sorts deterministically. With no `keys` the whole input is ONE
+/// `ORDER BY` re-sorts deterministically. With no `keys` the whole input is one
 /// group — the degenerate whole-result aggregation (`SELECT COUNT(*) FROM T`) —
 /// which yields a single grouped record even over an empty input (`COUNT` `0`,
 /// the others NULL), the standard SQL rule.
@@ -299,7 +299,7 @@ private func comparable(_ a: Value, _ b: Value) -> Bool {
 /// same bindings the projection and the `WHERE` filter resolve against — so a
 /// `:parameter` reached from inside an aggregate's argument (a
 /// `COUNT(CASE WHEN K = :k …)`) binds to its query value rather than reading as
-/// UNBOUND. The key evaluation threads them for the same reason and to keep the
+/// unbound. The key evaluation threads them for the same reason and to keep the
 /// two evaluate sites consistent, though a `GROUP BY` key is a bare column
 /// today, so it cannot yet reach one.
 extension Catalog where Self: ~Escapable {
@@ -318,9 +318,9 @@ extension Catalog where Self: ~Escapable {
         try cells.append(evaluate(record, key, context))
       }
       let group = Record(cells)
-      // Key the group on the EXACT canonical form of its cells so `1` and `1.0`
+      // Key the group on the exact canonical form of its cells so `1` and `1.0`
       // fall in one group (the equality UNION and predicates use), while the
-      // emitted group keeps the first-appearance ORIGINAL values.
+      // emitted group keeps the first-appearance original values.
       let identity = Record(cells.map(canonical))
 
       if accumulators[identity] == nil {

--- a/Sources/SQLEngine/Aggregation.swift
+++ b/Sources/SQLEngine/Aggregation.swift
@@ -34,7 +34,7 @@ extension Expression {
   internal var aggregated: Bool {
     switch self {
     case .column, .literal, .subquery:
-      // An aggregate INSIDE a scalar subquery belongs to that subquery, not the
+      // An aggregate inside a scalar subquery belongs to that subquery, not the
       // enclosing query, so a `subquery` is not an aggregated expression here.
       false
     case .aggregate:
@@ -96,11 +96,11 @@ extension Expression {
   /// expression has no other predicate). A defined-function body is validated
   /// over its parameter schema and evaluated with only its argument record — no
   /// query bindings reach it — so a body naming a `:parameter` is rejected at
-  /// registration rather than silently evaluating that reference as UNBOUND.
+  /// registration rather than silently evaluating that reference as unbound.
   internal var bound: Bool {
     switch self {
     case .column, .literal, .aggregate, .subquery:
-      // An UNCORRELATED scalar subquery references no query binding of the
+      // An uncorrelated scalar subquery references no query binding of the
       // enclosing query (correlation is a later slice), so it is not bound.
       false
     case let .call(_, arguments):
@@ -143,7 +143,7 @@ extension Predicate.Operand {
   }
 
   /// Whether this `LIKE` operand references a query binding — an expression's
-  /// own, or the operand's OWN `:parameter`, so a defined-function body that
+  /// own, or the operand's own `:parameter`, so a defined-function body that
   /// names a `:parameter` in a `LIKE` pattern or escape is rejected at
   /// registration (see `Expression.bound`).
   internal var bound: Bool {
@@ -164,7 +164,7 @@ extension Predicate.Operand {
 }
 
 extension Predicate {
-  /// The flat list of top-level `AND`-conjuncts of this predicate in SOURCE
+  /// The flat list of top-level `AND`-conjuncts of this predicate in source
   /// ORDER (a non-`and` is a singleton). The parser leans `AND` left (`a AND b
   /// AND c` is `.and(.and(a, b), c)`), so a left-first flatten yields the
   /// conjuncts as written — the order `Scope.on` walks to bound its safe
@@ -193,7 +193,7 @@ extension Predicate {
       lhs.contains { $0.aggregated }
           || rows.contains { $0.contains { $0.aggregated } }
     case .exists:
-      // A subquery is its OWN scope, so an aggregate inside it folds over its
+      // A subquery is its own scope, so an aggregate inside it folds over its
       // group, not the enclosing one — it never makes the OUTER query an
       // aggregate one.
       false
@@ -283,7 +283,7 @@ extension Predicate {
     case let .among(lhs, rows, _):
       lhs.contains { $0.bound } || rows.contains { $0.contains { $0.bound } }
     case let .exists(query, _):
-      // A `:parameter` inside a subquery binds against the SAME run bindings
+      // A `:parameter` inside a subquery binds against the same run bindings
       // (the subquery runs under the enclosing context), so a defined-function
       // body that nests one still carries a binding to reject at registration.
       query.bound
@@ -320,12 +320,12 @@ extension Query {
     }
   }
 
-  /// The UNCORRELATED subqueries this query nests DIRECTLY — the union of every
+  /// The uncorrelated subqueries this query nests directly — the union of every
   /// arm's `Select.subqueries`, descending a set operation's arms but NOT a
-  /// nested subquery's OWN body (each subquery is run as a whole, resolving its
+  /// nested subquery's own body (each subquery is run as a whole, resolving its
   /// inner subqueries through its own `run`). The run path materialises these
   /// once, keyed by occurrence, so a set operation's every arm reads its own
-  /// `EXISTS`/`IN (Q)` result from the SAME cache.
+  /// `EXISTS`/`IN (Q)` result from the same cache.
   internal var subqueries: Array<Query> {
     switch self {
     case let .select(select): select.subqueries
@@ -337,7 +337,7 @@ extension Query {
   /// The subqueries this query nests in an `IN (Q)` position — the ones whose
   /// single COLUMN of values a run reads, so the materialiser runs each in FULL
   /// rather than as a cardinality probe. A subquery only ever an `EXISTS`
-  /// operand is absent, so its select list is never evaluated; one used by BOTH
+  /// operand is absent, so its select list is never evaluated; one used by both
   /// an `EXISTS` and an `IN` appears here (its values are needed), so its lone
   /// full materialisation serves both.
   internal var valued: Set<Query> {
@@ -348,8 +348,8 @@ extension Query {
     }
   }
 
-  /// The subqueries this query nests in a SCALAR-subquery position — the ones a
-  /// run collapses to a single VALUE (empty → NULL, one row → the cell, more →
+  /// The subqueries this query nests in a scalar-subquery position — the ones a
+  /// run collapses to a single value (empty → NULL, one row → the cell, more →
   /// `SQLError.cardinality`), distinct from a `valued` (`IN`) or `EXISTS`-probe
   /// occurrence. The materialiser reads this to decide a scalar occurrence's
   /// materialisation.
@@ -362,7 +362,7 @@ extension Query {
   }
 
   /// The subqueries this query nests in an `EXISTS (Q)` position — the ones a
-  /// run materialises as a cardinality PROBE. The SAME query may ALSO occur as
+  /// run materialises as a cardinality probe. The same query may also occur as
   /// a `valued` (`IN`) or `scalar` occurrence over identical SQL; each role is
   /// a DISTINCT cache entry (see `Role`), so the materialiser produces an
   /// existential probe entry whenever a query occurs here — never reusing a
@@ -387,13 +387,13 @@ extension Select {
     return having?.bound ?? false
   }
 
-  /// The UNCORRELATED subqueries this `SELECT` nests DIRECTLY — those in its
+  /// The uncorrelated subqueries this `SELECT` nests directly — those in its
   /// `WHERE`, each join `ON`, its `HAVING`, its projection, its `GROUP BY` key
   /// expressions, and its `ORDER BY` sort-key expressions — in appearance
-  /// order, for the `compile`/`typecheck` pre-pass to materialise ONCE.
+  /// order, for the `compile`/`typecheck` pre-pass to materialise once.
   ///
   /// It descends this select's own predicates and expressions but NOT into a
-  /// nested subquery's OWN body: each subquery is compiled/run as a whole
+  /// nested subquery's own body: each subquery is compiled/run as a whole
   /// (`compile(query)`/`run(query)`), which recurses into its inner subqueries
   /// through its own pre-pass, so gathering only the directly-nested ones keeps
   /// the walk one level and lets each subquery own its inner materialisation.
@@ -435,9 +435,9 @@ extension Select {
     return queries
   }
 
-  /// The subqueries this `SELECT` nests in a SCALAR-subquery position — the
+  /// The subqueries this `SELECT` nests in a scalar-subquery position — the
   /// same clauses `subqueries` walks, keeping only the `Expression.subquery`
-  /// queries, so a run materialises each as its collapsed single VALUE (empty →
+  /// queries, so a run materialises each as its collapsed single value (empty →
   /// NULL, one row → the cell, more → `SQLError.cardinality`), distinct from a
   /// `valued` (`IN`, full column) or `EXISTS`-probe occurrence.
   internal var scalar: Set<Query> {
@@ -459,7 +459,7 @@ extension Select {
 
   /// The subqueries this `SELECT` nests in an `EXISTS (Q)` position — the
   /// same clauses `subqueries` walks, keeping only the `exists` operands'
-  /// queries, so a run materialises each as a cardinality PROBE under its own
+  /// queries, so a run materialises each as a cardinality probe under its own
   /// `existential` key, distinct from any `valued`/`scalar` occurrence over the
   /// same SQL.
   internal var existential: Set<Query> {
@@ -480,7 +480,7 @@ extension Select {
   }
 
   /// The `Role`s `query` occupies within this `SELECT` — `scalar`, `valued`,
-  /// and/or `existential` — the SHAPES the lowered nodes carry in their
+  /// and/or `existential` — the shapes the lowered nodes carry in their
   /// `Subkey`. The same inner SQL used in more than one position occupies more
   /// than one role, so a correlated occurrence's pre-compiled plan is recorded
   /// under each, matching every lowered node that looks it up.
@@ -494,9 +494,9 @@ extension Select {
 }
 
 extension Predicate {
-  /// Collects the subqueries this predicate nests DIRECTLY into `queries` — the
+  /// Collects the subqueries this predicate nests directly into `queries` — the
   /// whole `Query` of an `exists`/`within`, and any in an operand expression,
-  /// a `CASE` guard, or an `AND`/`OR`/`NOT` — WITHOUT descending a collected
+  /// a `CASE` guard, or an `AND`/`OR`/`NOT` — without descending a collected
   /// subquery's own body (`compile`/`run` recurse into it).
   internal func collect(subqueries queries: inout Array<Query>) {
     switch self {
@@ -549,7 +549,7 @@ extension Predicate {
 
   /// Whether this predicate nests any `EXISTS`/`IN (Q)` subquery — the schema
   /// path's reachability check reads this to keep a subquery-bearing `HAVING`
-  /// from being pruned as unreachable, since its truth is decided at RUN by the
+  /// from being pruned as unreachable, since its truth is decided at run by the
   /// subquery, not statically.
   internal var subquery: Bool {
     var queries = Array<Query>()
@@ -615,7 +615,7 @@ extension Predicate {
     }
   }
 
-  /// Collects the SCALAR-subquery-position queries this predicate nests into
+  /// Collects the scalar-subquery-position queries this predicate nests into
   /// `queries` — an operand expression's own `subquery`, a `CASE` guard's, and
   /// those under `AND`/`OR`/`NOT`, mirroring `collect(subqueries:)`. An
   /// `EXISTS`/`IN (Q)`'s own `Query` is NOT a scalar occurrence — it is
@@ -761,11 +761,11 @@ extension Predicate.Operand {
 }
 
 extension Expression {
-  /// Collects the subqueries this expression nests DIRECTLY into `queries` —
+  /// Collects the subqueries this expression nests directly into `queries` —
   /// its own scalar `subquery`, and those reached through a `CASE` guard or an
   /// aggregate's argument/FILTER — recursing its call arguments, arithmetic,
   /// aggregate operand and FILTER, `CASE`, `CAST`, `COALESCE`, and `NULLIF`
-  /// sub-expressions WITHOUT descending a collected subquery's own body
+  /// sub-expressions without descending a collected subquery's own body
   /// (`compile`/`run` recurse into it). A scalar `Expression.subquery` is
   /// collected so the pre-pass compiles it (for its width and type) and the run
   /// materialises its single value.
@@ -808,7 +808,7 @@ extension Expression {
   /// Collects the `IN (Q)`-position subqueries this expression nests — reached
   /// through a `CASE` guard or an aggregate's argument/FILTER, mirroring
   /// `collect(subqueries:)`. An `EXISTS` guard contributes none (it probes),
-  /// and a SCALAR `subquery` contributes none here — its single value is read
+  /// and a scalar `subquery` contributes none here — its single value is read
   /// (`scalar`), not its column (`values`), so it is a `scalar` occurrence, not
   /// a `valued` one.
   internal func collect(valued queries: inout Set<Query>) {
@@ -844,10 +844,10 @@ extension Expression {
     }
   }
 
-  /// Collects the SCALAR-subquery-position queries this expression nests — its
+  /// Collects the scalar-subquery-position queries this expression nests — its
   /// own `subquery`, and those reached through a `CASE` guard or an aggregate's
   /// argument/FILTER, mirroring `collect(subqueries:)`. A scalar occurrence is
-  /// materialised as its collapsed single VALUE (empty → NULL, one row → the
+  /// materialised as its collapsed single value (empty → NULL, one row → the
   /// cell, more → `SQLError.cardinality`), distinct from a `valued` (`IN`) or
   /// `EXISTS`-probe occurrence.
   internal func collect(scalar queries: inout Set<Query>) {
@@ -925,9 +925,9 @@ extension Expression {
 
   /// Whether this expression nests any `EXISTS`/`IN (Q)`/scalar subquery —
   /// reached through a `CASE` guard or an aggregate's argument/FILTER, or its
-  /// own scalar `subquery`. The empty-fold reads this to VALIDATE a
+  /// own scalar `subquery`. The empty-fold reads this to validate a
   /// subquery-guarded projection or sort expression (whose selected branch a
-  /// run decides at RUN by the subquery, not statically) rather than prune it,
+  /// run decides at run by the subquery, not statically) rather than prune it,
   /// so `columns(of:)` surfaces the same fault the run would (`SELECT CASE WHEN
   /// EXISTS (Q) THEN 1 / 0 …` raises `.divide`). A subquery-free expression
   /// keeps the precise empty-fold.
@@ -956,7 +956,7 @@ extension Catalog where Self: ~Escapable {
   internal borrowing func group(_ select: Select, _ relation: Relation,
                                 _ from: Resolved, _ context: Context)
       throws(SQLError) -> Plan {
-    // The augmented `context` threads to `subquery(of:)`, which REVEALS the
+    // The augmented `context` threads to `subquery(of:)`, which reveals the
     // base — this select's and every enclosing select's derived aliases
     // dropped, the CTEs and store relations kept — before lowering a nested
     // subquery, so its FROM sees no derived alias while a CTE a same-named
@@ -966,7 +966,7 @@ extension Catalog where Self: ~Escapable {
     // in one combined ordinal space (as the non-aggregate join path does), so
     // the WHERE, keys, and aggregate arguments resolve uniformly. A LATERAL
     // join (CROSS/OUTER APPLY) is supported here too: the front half is shared
-    // with the non-aggregate path, so the apply body's OUTPUT columns land in
+    // with the non-aggregate path, so the apply body's output columns land in
     // scope for the keys, aggregate arguments, HAVING, and ORDER BY, and the
     // chain carries the correlated `apply` node the aggregate then groups.
     let (joined, relations) = try resolve(from: relation, schema: from.schema,
@@ -982,14 +982,14 @@ extension Catalog where Self: ~Escapable {
     // resolved against only the prefix already in scope (as the non-aggregate
     // path does). A `column = column` conjunct becomes a `match` hash-join key;
     // the rest is a residual the join runs as a filter.
-    // Each join's PREFIX scope — the relations available AT that join point,
-    // never one joined LATER — carries the merged columns accumulated BEFORE
+    // Each join's prefix scope — the relations available at that join point,
+    // never one joined later — carries the merged columns accumulated before
     // this join, so a chained `USING` `on` keys on the merged value.
     let prefixes = select.joins.indices.map { index in
       Scope(Array(relations[0 ... index + 1]), merged: merges[index])
     }
-    // Resolve each LATERAL join's body ONCE against the PRECEDING FROM — the
-    // FROM relation and the joins BEFORE this one (`relations[0…index]`, ONE
+    // Resolve each LATERAL join's body once against the preceding FROM — the
+    // FROM relation and the joins before this one (`relations[0…index]`, one
     // less than the prefix, which includes the join's own relation) — so a body
     // column naming a preceding relation correlates outward and the body's plan
     // is pre-compiled for the per-outer-row apply. A non-lateral join records
@@ -1010,20 +1010,20 @@ extension Catalog where Self: ~Escapable {
       laterals[index] = try lateral(body, against: preceding,
                                     columns: join.relation.columns, context)
     }
-    // Compile every nested subquery ONCE for arity/type, ahead of lowering, and
-    // discover each one's CORRELATION: a join `ON`'s against its PREFIX scope,
+    // Compile every nested subquery once for arity/type, ahead of lowering, and
+    // discover each one's correlation: a join `ON`'s against its prefix scope,
     // the WHERE against the join `scope`. Only the WHERE and join ONs admit a
-    // correlated column of THIS query; the aggregations, projection, `HAVING`,
-    // and `ORDER BY` lower under a BARRED seam. `validate` gates the eager
+    // correlated column of this query; the aggregations, projection, `HAVING`,
+    // and `ORDER BY` lower under a barred seam. `validate` gates the eager
     // type-check of a filtered-out derived body a nested subquery names, off on
-    // the RUN path, on for a schema check.
+    // the run path, on for a schema check.
     let plans = try subquery(of: select, context, enclosing: scope,
                              prefixes: prefixes)
     let barred = plans.rest.barred
     var matches = Array<Filter>()
     matches.reserveCapacity(select.joins.count)
     for index in select.joins.indices {
-      // A `NATURAL`/`USING` join's `on` is the SYNTHESIZED, already-lowered
+      // A `NATURAL`/`USING` join's `on` is the synthesized, already-lowered
       // filter (`ons[index]`, `nil` for a degenerate `NATURAL` join); a plain
       // join lowers its written `ON` against the prefix scope.
       if let on = ons[index] {
@@ -1040,8 +1040,8 @@ extension Catalog where Self: ~Escapable {
                                   subquery: plans.rest)
     }
 
-    // This select's grouping keys and — for ONE arm of an expanded `GROUPING
-    // SETS` — the SUPERSET (the union of every set's keys, so an absent key
+    // This select's grouping keys and — for one arm of an expanded `GROUPING
+    // SETS` — the superset (the union of every set's keys, so an absent key
     // NULLs by resolved identity). A `.sets` never reaches here: `compile`
     // expands it to a union of `.arm` selects before this runs.
     let (grouping, superset): (Array<Expression>, Array<Expression>) =
@@ -1059,7 +1059,7 @@ extension Catalog where Self: ~Escapable {
       // binds reads its combined slot; a bare `NATURAL`/`USING` merged column
       // lowers to its `COALESCE(left, right)` value (so the aggregate node
       // groups a `RIGHT`/`FULL` join's unmatched row by the merged value, not a
-      // NULL left column); a name NONE binds is a candidate CORRELATED
+      // NULL left column); a name none binds is a candidate correlated
       // reference (a LATERAL body grouping on a preceding column) — the
       // `barred` surface lowers it to a `Term.parameter` the apply binds per
       // outer row, admitting it only under the LATERAL `everywhere` seam and
@@ -1084,12 +1084,12 @@ extension Catalog where Self: ~Escapable {
         }
       }
     }
-    // Resolve each collected aggregate and dedup by its RESOLVED
+    // Resolve each collected aggregate and dedup by its resolved
     // `Aggregation` — function plus resolved argument term. `collect` deduped
     // only exact AST spellings, so a qualification-equivalent pair
     // (`SUM(Amount)` projected, `SUM(Sales.Amount)` in the `ORDER BY`) survived
     // as two expressions; both resolve to the same `Aggregation` in a
-    // single-relation scope, so this folds them into ONE grouped slot — the
+    // single-relation scope, so this folds them into one grouped slot — the
     // aggregate computes once and both clauses read/order that slot (which lets
     // the DISTINCT sort-key check accept it).
     var aggregations = Array<Aggregation>()
@@ -1103,7 +1103,7 @@ extension Catalog where Self: ~Escapable {
 
     // The source materialises exactly the ordinals the WHERE, the keys, and the
     // aggregate arguments read — never the projection/HAVING/ORDER, which read
-    // the GROUPED record. Pack them per relation in chain order, building the
+    // the grouped record. Pack them per relation in chain order, building the
     // combined-ordinal → slot map and each relation's leaf ordinals.
     var references = Set<Int>()
     for match in matches { match.references(into: &references) }
@@ -1113,8 +1113,8 @@ extension Catalog where Self: ~Escapable {
       aggregation.references(into: &references)
     }
     // A LATERAL apply reads its correlation's outer ordinals from the left
-    // chain's record, so those preceding-relation ordinals must be MATERIALISED
-    // (given a packed slot) even when no clause of THIS select references them
+    // chain's record, so those preceding-relation ordinals must be materialised
+    // (given a packed slot) even when no clause of this select references them
     // — else the correlation's remap through `slot` finds no slot for the outer
     // column its body names.
     for lateral in laterals {
@@ -1171,8 +1171,8 @@ extension Catalog where Self: ~Escapable {
                                 $0.remapped(through: slot)
                               }, chain)
 
-    // The SUPERSET's LOWERED terms — the columns another set groups on — so an
-    // arm's projection/HAVING reference to a key THIS set omits NULLs by
+    // The superset's lowered terms — the columns another set groups on — so an
+    // arm's projection/HAVING reference to a key this set omits NULLs by
     // resolved identity (empty for an ordinary grouped query).
     let supers = try superset.map { key throws(SQLError) -> Term in
       try scope.term(key, context.routines, subquery: barred)
@@ -1208,7 +1208,7 @@ extension Catalog where Self: ~Escapable {
 
     // The HAVING filters groups below the sort, the slot the WHERE occupies on
     // the non-aggregate path, so the shared `shaped` applies it identically —
-    // an ORDER BY key naming a COMPUTED aggregate output (`COUNT(*) * 2 AS n`)
+    // an ORDER BY key naming a computed aggregate output (`COUNT(*) * 2 AS n`)
     // then materialises once and sorts on the returned value.
     return node.shaped(distinct: select.distinct, projection: projection,
                        filter: having, order: order, limit: select.limit)
@@ -1237,7 +1237,7 @@ extension Expression {
   internal func collect(into expressions: inout Array<Expression>) {
     switch self {
     case .column, .literal, .subquery:
-      // An aggregate inside a scalar `subquery` belongs to THAT subquery's own
+      // An aggregate inside a scalar `subquery` belongs to that subquery's own
       // grouping, not the enclosing query's, so it is not collected here — the
       // subquery is compiled and run as a whole plan.
       break

--- a/Sources/SQLEngine/Carrier.swift
+++ b/Sources/SQLEngine/Carrier.swift
@@ -3,7 +3,7 @@
 
 // MARK: - Ordered set operation
 
-/// A grouped-arm resolver a carrier caller injects: the RESOLVED grouped-space
+/// A grouped-arm resolver a carrier caller injects: the resolved grouped-space
 /// `Term` of each projected item, and a closure lowering an arbitrary
 /// expression to that same space — the identity surface a query-level `ORDER
 /// BY` key matches against by resolved identity. A plain set-operation carrier
@@ -14,14 +14,14 @@ internal typealias Resolver =
 extension Catalog where Self: ~Escapable {
   /// Compiles an `ORDER BY` / `SELECT DISTINCT` / `OFFSET`·`FETCH` carried over
   /// the set-operation `union` — the `Query.ordered` carrier — into the row
-  /// operators STACKED over the union's compiled plan, resolved through the
-  /// setop's OUTPUT scope.
+  /// operators stacked over the union's compiled plan, resolved through the
+  /// setop's output scope.
   ///
   /// A `setop` node has no order/distinct/limit slot, so the query-level row
   /// operators ride this outer carrier rather than a text `SELECT * FROM
   /// (union) AS g ORDER BY …` wrapper. They resolve against a scope over the
-  /// union's OUTPUT columns — the arm-0-named, type-unified result columns —
-  /// the SAME canonical resolution any `SELECT … FROM <derived> ORDER BY
+  /// union's output columns — the arm-0-named, type-unified result columns —
+  /// the same canonical resolution any `SELECT … FROM <derived> ORDER BY
   /// <alias/ordinal/expr>` uses, so:
   ///
   ///   - an ordinal `ORDER BY n`, an output alias, or a bare projected column
@@ -29,7 +29,7 @@ extension Catalog where Self: ~Escapable {
   ///   - a generated `column N` display header is NOT among the scope's
   ///     bindable output names, so `ORDER BY "column N"` faults `.column` — as
   ///     it does over any derived union — rather than being wrongly accepted;
-  ///   - a bare name matching TWO output columns faults `SQLError.ambiguous`,
+  ///   - a bare name matching two output columns faults `SQLError.ambiguous`,
   ///     as a plain grouped query's `ORDER BY` does;
   ///   - under `DISTINCT` a key must name an output (`distinct(_:_:_:)` over
   ///     the identity projection), matching the plain-grouped rule.
@@ -41,7 +41,7 @@ extension Catalog where Self: ~Escapable {
                                   order: Order?, limit: Limit?,
                                   generated: Int,
                                   _ context: Context) throws(SQLError) -> Plan {
-    // Compile the inner union and derive its OUTPUT columns — the arm-0-named,
+    // Compile the inner union and derive its output columns — the arm-0-named,
     // type-unified result columns the carrier orders/dedups over. The plan's
     // output sits at slots `0 ..< width` (a `setop`'s output is its arm-0
     // projection), so the carrier resolves and stacks in that identity space.
@@ -50,11 +50,11 @@ extension Catalog where Self: ~Escapable {
     // operators.
     let plan = try compile(union, context)
     let cols = try columns(unifying: union, context)
-    // A GROUPING SETS expansion's arm-0 is a GROUPED `.arm` select; a plain
+    // A GROUPING SETS expansion's arm-0 is a grouped `.arm` select; a plain
     // set-operation chain's is not. For a GROUPING SETS carrier, inject a
     // resolver that lowers the arm's projection — and any ORDER BY key — to the
     // arm's grouped-space `Term`s, so a query-level `ORDER BY` matches a
-    // projected aggregate by RESOLVED identity (`SUM(s.Qty)` ≡ projected
+    // projected aggregate by resolved identity (`SUM(s.Qty)` ≡ projected
     // `SUM(Qty)`), the plain grouped `ORDER BY` path's rule. A plain arm has no
     // grouped aggregate space and injects none.
     let resolver: Resolver? =
@@ -72,13 +72,13 @@ extension Catalog where Self: ~Escapable {
   /// operation — the trim width `width − generated`, the leading real outputs
   /// with the trailing `generated` hidden materialised sort columns dropped.
   ///
-  /// `Query.ordered` is a PUBLIC AST case a caller may build with a `generated`
+  /// `Query.ordered` is a public AST case a caller may build with a `generated`
   /// count out of step with the inner union's width (the parser only ever emits
-  /// `0`, and `expand` an in-range count). A count PAST the width, or NEGATIVE,
+  /// `0`, and `expand` an in-range count). A count past the width, or negative,
   /// would make the trim width negative — the carrier's `0 ..< real` range and
-  /// per-column subscripts, and the schema path's `Array.prefix`, would TRAP
-  /// the process. Rejecting the malformed count with ONE typed internal-error
-  /// fault, read by BOTH the compile carrier (`carried`) and the schema path
+  /// per-column subscripts, and the schema path's `Array.prefix`, would trap
+  /// the process. Rejecting the malformed count with one typed internal-error
+  /// fault, read by both the compile carrier (`carried`) and the schema path
   /// (`columns(unifying:)`), keeps `run ≡ columns(of:)` on a malformed carrier.
   internal func real(trimming generated: Int, of width: Int)
       throws(SQLError) -> Int {
@@ -91,13 +91,13 @@ extension Catalog where Self: ~Escapable {
 
   /// Stacks the query-level row operators — a carried `ORDER BY` / `DISTINCT` /
   /// `OFFSET`·`FETCH` — over an already-compiled set-operation `plan`, resolved
-  /// through the setop's OUTPUT scope. `plan`'s output sits at slots
+  /// through the setop's output scope. `plan`'s output sits at slots
   /// `0 ..< output.count`, the arm-0-named, type-unified result columns
   /// (`output`); `arm` is the union's FIRST arm — its projection is the surface
   /// a projected-expression / aliased / qualified ORDER BY key matches against
   /// by AST (a plain set-op arm).
   ///
-  /// `resolver`, when INJECTED, lowers the arm's projected items to a grouped
+  /// `resolver`, when injected, lowers the arm's projected items to a grouped
   /// slot space and lowers an arbitrary expression to the same space — a
   /// resolved-identity surface a caller over a grouped arm supplies so a
   /// query-level `ORDER BY` key matches a projected aggregate by resolved
@@ -109,8 +109,8 @@ extension Catalog where Self: ~Escapable {
   /// A `setop` node has no order/distinct/limit slot, so the query-level row
   /// operators ride this outer carrier rather than a text `SELECT * FROM
   /// (union) AS g ORDER BY …` wrapper. They resolve against a scope over the
-  /// setop's OUTPUT columns — the arm-0-named, type-unified result columns —
-  /// the SAME canonical resolution any `SELECT … FROM <derived> ORDER BY
+  /// setop's output columns — the arm-0-named, type-unified result columns —
+  /// the same canonical resolution any `SELECT … FROM <derived> ORDER BY
   /// <alias/ordinal/expr>` uses.
   ///
   /// The row operators do NOT project — the result schema is the union's — so
@@ -137,7 +137,7 @@ extension Catalog where Self: ~Escapable {
     let width = cols.count
     // The union's arm-0 projection carries the real output items followed by
     // any hidden materialised sort columns (a producer aliases them `*gsN`).
-    // The REAL output count `real` is the carrier's trim width — the STRUCTURAL
+    // The REAL output count `real` is the carrier's trim width — the structural
     // `generated` count carried on the node (never a scan of the arm-0 names
     // for a `*gs` prefix, which would trim a user's delimited `AS "*gs0"`), so
     // slots `0 ..< real` are the real outputs and `real ..< width` the hidden
@@ -154,17 +154,17 @@ extension Catalog where Self: ~Escapable {
     // Range-check the `generated` count against the width and derive the trim
     // width `real` through the shared guard (see `real(trimming:of:)`), which
     // faults a malformed public-AST count rather than letting the `0 ..< real`
-    // range below or a per-column subscript TRAP. The SAME guard backs the
+    // range below or a per-column subscript trap. The same guard backs the
     // schema path (`columns(unifying:)`), so `run ≡ columns(of:)`.
     let real = try real(trimming: generated, of: width)
-    // A `generated` tail must correspond to genuine HIDDEN aliased columns — a
+    // A `generated` tail must correspond to genuine hidden aliased columns — a
     // producer's `*gsN` items, each carrying a non-nil alias. A caller may,
-    // though, build `.ordered(<2-col union>, generated: 1)` over an ORDINARY
-    // union whose trailing item is a normal projected column with NO alias, OR
+    // though, build `.ordered(<2-col union>, generated: 1)` over an ordinary
+    // union whose trailing item is a normal projected column with no alias, OR
     // `.ordered(<SELECT * union>, generated: N>0)` whose arm-0 projection is
-    // `.all` so `items` is EMPTY though `width > 0`: the hidden-name mapping's
-    // `items[real + k].alias!` below would TRAP (an unaliased item, or an
-    // absent one when `items` is short). Prove each generated tail slot HAS a
+    // `.all` so `items` is empty though `width > 0`: the hidden-name mapping's
+    // `items[real + k].alias!` below would trap (an unaliased item, or an
+    // absent one when `items` is short). Prove each generated tail slot has a
     // corresponding aliased projected item before force-unwrapping, faulting
     // the same typed internal-error the range guard raises rather than
     // crashing. (Not a `where` skip: an absent slot must fault, not pass.)
@@ -174,18 +174,18 @@ extension Catalog where Self: ~Escapable {
                      "ordered set-operation generated tail is not aliased")
       }
     }
-    // The output NAME of each REAL column — an alias, else a bare column. An
-    // unnamed output (a computed column with no `AS`) has NO bindable name: it
+    // The output name of each REAL column — an alias, else a bare column. An
+    // unnamed output (a computed column with no `AS`) has no bindable name: it
     // is reachable only by ordinal, so it takes a non-spellable synthetic name
     // (`*colN`, which a normal or delimited identifier cannot spell) rather
-    // than the positional `column N` DISPLAY header — else `ORDER BY "column
+    // than the positional `column N` display header — else `ORDER BY "column
     // N"` would wrongly bind it, where a plain derived union faults `.column`.
     //
-    // Whether an output is unnamed is the RESOLVED column's STRUCTURAL
+    // Whether an output is unnamed is the resolved column's structural
     // `synthesized` flag — set where the projection had no inferable name
     // (`Projected.name == nil`) and a positional `column N` was substituted —
     // NOT a comparison of the resolved name text to `column N`, which would
-    // mistake a user's EXPLICIT delimited `AS "column 1"` for a synthesized
+    // mistake a user's explicit delimited `AS "column 1"` for a synthesized
     // header and strip it. A named output keeps its name; a synthesized one is
     // `nil` here (not bindable). (A `SELECT *`/`TABLE` first arm names every
     // output through `cols`, never synthesized, and carries no hidden column,
@@ -193,9 +193,9 @@ extension Catalog where Self: ~Escapable {
     let outputs: Array<String?> = (0 ..< real).map {
       cols[$0].synthesized ? nil : cols[$0].name
     }
-    // The scope over the union's output. The schema names EVERY column so
+    // The scope over the union's output. The schema names every column so
     // `term` can resolve a materialised key's synthetic column: a named real
-    // output by its name, an UNNAMED real output by a non-spellable `*colN`,
+    // output by its name, an unnamed real output by a non-spellable `*colN`,
     // and each hidden materialised column by its `*gsN` alias.
     let schema = Schema(from: cols,
                         names: (0 ..< width).map {
@@ -208,26 +208,26 @@ extension Catalog where Self: ~Escapable {
     // inner query is inspected nowhere here, so the arm-0 `SELECT` stands in
     // for it uniformly.
     let scope = Scope([(Relation(derived: .select(arm), as: ""), schema)])
-    // COLLECT and RESOLVE the carrier ORDER BY's OWN nested subqueries — the
-    // SAME machinery a plain `SELECT … ORDER BY CASE WHEN EXISTS (…) …` uses
+    // collect and resolve the carrier ORDER BY's own nested subqueries — the
+    // same machinery a plain `SELECT … ORDER BY CASE WHEN EXISTS (…) …` uses
     // (`subquery(_:_:_:within:)` builds a `Resolution` recording each nested
     // query's width/type/plan against the setop-output `scope`, AND records a
-    // CORRELATED one's runtime plan into `context.subqueries` per the ROLE it
+    // correlated one's runtime plan into `context.subqueries` per the role it
     // occupies). A carried `ORDER BY` over a set operation is otherwise lowered
-    // with the DEFAULT `.unsupported` resolution, so `scope.order` REJECTS an
+    // with the DEFAULT `.unsupported` resolution, so `scope.order` rejects an
     // `EXISTS`/`IN`/scalar sort-key subquery a plain `SELECT`'s ORDER BY
     // accepts. Threading this resolution in makes a set operation's ORDER BY
     // resolve a subquery sort key identically to a plain select's; an ORDER BY
-    // position bars a NEW correlation (`.barred` inside `scope.order`), so a
+    // position bars a new correlation (`.barred` inside `scope.order`), so a
     // genuinely-unsupported case still faults exactly as it does on a SELECT.
     //
-    // `roles(of:)` classifies a subquery by the CLAUSE it occurs in, so the
+    // `roles(of:)` classifies a subquery by the clause it occurs in, so the
     // recording pass must inspect a select whose ORDER BY IS the carrier's —
     // NOT the bare `arm`, whose own ORDER BY does not carry the carrier's sort-
-    // key subqueries. Reusing `arm` there records NO runtime plan (empty
-    // roles), so a CORRELATED carrier sort-key subquery lowers to a
+    // key subqueries. Reusing `arm` there records no runtime plan (empty
+    // roles), so a correlated carrier sort-key subquery lowers to a
     // `Term.subquery`/`.parameter` yet faults "a correlated subquery plan was
-    // not compiled" at execution — where the SAME ORDER BY on a plain SELECT
+    // not compiled" at execution — where the same ORDER BY on a plain SELECT
     // records and re-executes it per row. Overlay the carrier's `order` on the
     // arm (keeping the arm's projection surface a projected-expression key
     // resolves against) so the recording sees the carrier's sort-key subqueries
@@ -248,7 +248,7 @@ extension Catalog where Self: ~Escapable {
                                   within: scope)
     // The identity projection over the REAL output slots, and the REAL output
     // names a bare ORDER BY name or a DISTINCT key binds against — alias-or-
-    // bare, `nil` for an unnamed output. `scope.order` bounds an ORDINAL key by
+    // bare, `nil` for an unnamed output. `scope.order` bounds an ordinal key by
     // this projection's COUNT, so it must be the REAL arity (`real`), NOT the
     // grown `width`.
     let projection = (0 ..< real).map(Term.slot)
@@ -259,27 +259,27 @@ extension Catalog where Self: ~Escapable {
     if let order {
       // The REAL projected items an `ORDER BY <expr>` key may match to its
       // ordinal — the arm-0 projection minus its trailing hidden `*gsN`
-      // columns. EMPTY for a `SELECT *`/`TABLE` first arm (no enumerated
+      // columns. empty for a `SELECT *`/`TABLE` first arm (no enumerated
       // projection to match), so such a key falls to the scope's ordinary
       // resolution over the `*`-expanded output columns.
       let reals = Array(items.prefix(real))
       let folded = Set(outputs.compactMap { $0?.lowercased() })
-      // A key resolving to a HIDDEN materialised slot (`real ..< width`) is
-      // bound STRUCTURALLY, by KEY INDEX → that slot, NOT by rewriting to the
-      // generated `*gsN` NAME. The hidden alias is a SPELLABLE delimited
+      // A key resolving to a hidden materialised slot (`real ..< width`) is
+      // bound structurally, by KEY index → that slot, NOT by rewriting to the
+      // generated `*gsN` name. The hidden alias is a spellable delimited
       // identifier a user's own output could carry (`SELECT Region AS "*gs0" …
       // ORDER BY MAX(Qty)`), so a name rewrite would let `scope.order`'s
-      // output-alias precedence CAPTURE the hidden key onto the real `*gs0`
-      // output. Recording the slot and OVERWRITING the resolved key's `term`
+      // output-alias precedence capture the hidden key onto the real `*gs0`
+      // output. Recording the slot and overwriting the resolved key's `term`
       // below binds it by position, immune to a colliding alias.
       var materialised = Dictionary<Int, Int>()
       let rewritten = Order(keys: try order.keys.enumerated().map {
         (offset, key) throws(SQLError) -> Order.Key in
         guard case let .expression(expression) = key.sort else { return key }
-        // A BARE unqualified column NAMING A REAL OUTPUT is left to the
+        // A bare unqualified column naming A REAL output is left to the
         // setop-output scope's ordinary resolution, whichever carrier: it binds
-        // an output alias or a bare projected column BY NAME and faults
-        // `.ambiguous` on a name TWO outputs share — the ISO precedence
+        // an output alias or a bare projected column BY name and faults
+        // `.ambiguous` on a name two outputs share — the ISO precedence
         // `scope.order` applies before a term match, which a resolved-identity
         // rewrite to an ordinal would wrongly bypass. A bare column that is NOT
         // a real output rides the resolver (when injected) to its hidden slot.
@@ -288,10 +288,10 @@ extension Catalog where Self: ~Escapable {
         } else {
           false
         }
-        // A grouped-arm caller's injected resolver: match a QUALIFIED column or
-        // a NON-column expression against the arm's projected terms by RESOLVED
+        // A grouped-arm caller's injected resolver: match a qualified column or
+        // a non-column expression against the arm's projected terms by resolved
         // identity. A key that lowers cleanly and equals a projected term
-        // orders on that slot's ORDINAL — a REAL slot directly, a HIDDEN slot
+        // orders on that slot's ordinal — a REAL slot directly, a hidden slot
         // bound structurally below (never through its spellable `*gsN` name). A
         // key `resolve` faults on is left for the setop-output scope to bind or
         // fault, as before.
@@ -303,8 +303,8 @@ extension Catalog where Self: ~Escapable {
                                ascending: key.ascending)
             }
             // The hidden slot: record it against this key's index and stand a
-            // resolvable ORDINAL placeholder (`1`, the first real output) in
-            // its place so `scope.order` yields an aligned SortKey WITHOUT
+            // resolvable ordinal placeholder (`1`, the first real output) in
+            // its place so `scope.order` yields an aligned SortKey without
             // trying to recompute the unprojected aggregate over the
             // output-only scope; its `term` is overwritten to `.slot(slot)`
             // afterward, binding the hidden column by POSITION.
@@ -316,7 +316,7 @@ extension Catalog where Self: ~Escapable {
         if resolver != nil { return key }
         // Plain set-operation carrier: a materialised key (a hidden `*gsN`
         // item, matched by AST) is bound structurally to that hidden slot,
-        // through the same ORDINAL-placeholder-then-overwrite the resolver path
+        // through the same ordinal-placeholder-then-overwrite the resolver path
         // uses, so a colliding `*gsN` alias cannot capture it.
         if let slot = (real ..< width).first(where: {
           items[$0].expression == expression
@@ -327,8 +327,8 @@ extension Catalog where Self: ~Escapable {
         if case .column = expression {
           // A column key — bare or qualified — rides through to `scope.order`.
           // A bare name binds an output by ISO alias precedence (or faults
-          // `.ambiguous` on a name two outputs share). A QUALIFIED key faults
-          // there: the set-operation output carries NO range, so `R.a` /
+          // `.ambiguous` on a name two outputs share). A qualified key faults
+          // there: the set-operation output carries no range, so `R.a` /
           // `NoSuch.a` fails resolution exactly as the derived-union
           // equivalent does — it is NOT silently sorted by a bare output `a`
           // after dropping an invalid qualifier.
@@ -344,26 +344,26 @@ extension Catalog where Self: ~Escapable {
       })
       keys = try scope.order(rewritten, projection, names, context.routines,
                              subquery: resolution)
-      // Bind each materialised key to its HIDDEN slot by POSITION, overwriting
+      // Bind each materialised key to its hidden slot by POSITION, overwriting
       // the ordinal placeholder's resolved key: `.slot(slot)` orders on the
       // hidden `*gsN` column directly, `column` cleared so it is an ordinary
       // input key (NOT a select-list output — DISTINCT then rejects it, and it
       // is trimmed by the identity projection). This never spells the hidden
-      // `*gsN` NAME, so a user output aliased identically cannot capture it.
+      // `*gsN` name, so a user output aliased identically cannot capture it.
       for (offset, slot) in materialised {
         keys[offset] = SortKey(term: .slot(slot),
                                ascending: keys[offset].ascending, column: nil)
       }
-      // The carrier's ORDER BY is a NEW expression surface: `scope.order`
-      // RESOLVES each key (binds a column, arity), but — like the grouped
+      // The carrier's ORDER BY is a new expression surface: `scope.order`
+      // resolves each key (binds a column, arity), but — like the grouped
       // path's structural resolve — does NOT type-check a key's operands or its
       // calls, so an unknown routine (`ORDER BY missing(a)`) or an ill-typed
       // operand (`ORDER BY a + 'x'`) a run raises on slipped past validate.
-      // Under `validate`, type-check each key EXPRESSION against the SAME
+      // Under `validate`, type-check each key expression against the same
       // setop-output scope it resolved over — its calls and operands as a
-      // projected expression's — so validate faults IDENTICALLY to a run. An
+      // projected expression's — so validate faults identically to a run. An
       // ordinal/output-name key carries no `.expression` to re-check. The run
-      // path compiles LENIENTLY (`validate: false`), so this never double-
+      // path compiles leniently (`validate: false`), so this never double-
       // faults there — the run surfaces the fault at execution as it did
       // before.
       if context.validate {
@@ -371,19 +371,19 @@ extension Catalog where Self: ~Escapable {
         // (`ORDER BY CASE WHEN EXISTS (…) …`), which the `scope.validate`
         // type-check below rejects under the DEFAULT `.unsupported`
         // `SubqueryCheck`. Record each nested subquery's width and type — the
-        // SAME cursor-free pre-pass `subqueryCheck(of:)` runs for a plain
+        // same cursor-free pre-pass `subqueryCheck(of:)` runs for a plain
         // SELECT's ORDER BY subqueries — so the type-check validates a subquery
         // sort key rather than faulting `.unsupported`, keeping the schema path
         // in step with the run (which resolves the same key through
         // `resolution` above).
         //
-        // Derive each subquery's width/type against the SAME setop-output
+        // Derive each subquery's width/type against the same setop-output
         // `scope` the run resolves it through (`subquery(_:_:_:within: scope)`
         // above): a carrier ORDER BY subquery may reference a set-operation
-        // OUTPUT column — an aliased output living ONLY in this scope, unseen
+        // output column — an aliased output living ONLY in this scope, unseen
         // by `context.outer` — so nesting `scope` under the outer, enclosing-
         // scope shape `subquery(_:_:_:within:)` builds, resolves it at validate
-        // EXACTLY as it does at run. Threading bare `context.outer` faulted
+        // exactly as it does at run. Threading bare `context.outer` faulted
         // `.column` on a set-op output column a run resolves, rejecting a query
         // that executes. A genuinely-unresolvable column (not a set-op output,
         // absent from the outer) still faults here as it does at run.

--- a/Sources/SQLEngine/Compilation.swift
+++ b/Sources/SQLEngine/Compilation.swift
@@ -15,16 +15,16 @@ extension Projection {
   /// The terms hold no slots, so the `single` row's empty record carries every
   /// value the projection needs.
   ///
-  /// `subquery` carries the compile-time width map of the UNCORRELATED
+  /// `subquery` carries the compile-time width map of the uncorrelated
   /// subqueries the projection nests, so an `EXISTS`/`IN (Q)` inside a scalar
   /// term lowers exactly as it does on the FROM'd path — the FROM-less scalar
-  /// select is otherwise the ONE path that would hit the default unsupported
+  /// select is otherwise the one path that would hit the default unsupported
   /// map and reject a subquery a run materialises. The `Resolution` is
   /// threaded, not run, here (see `subquery(of:)`).
   ///
-  /// A projection is a BARRED clause position, so a correlated column of THIS
+  /// A projection is a barred clause position, so a correlated column of this
   /// query has no evaluator here. `Schema.terms` bars the seam intrinsically,
-  /// so this FROM-less projection CANNOT admit correlation even when handed the
+  /// so this FROM-less projection cannot admit correlation even when handed the
   /// admitting `plans.rest` — the same cut `columns(of:)` applies on the schema
   /// path, keeping run and derive in lockstep.
   internal func scalar(_ routines: Routines = [:],
@@ -54,7 +54,7 @@ internal struct Resolved {
 
 /// The sorted, deduplicated ordinals a query references: the union of the
 /// ordinals its `projection` terms read, the columns its `filter` reads, and
-/// EVERY column its `order` keys read. The projection terms hold ordinals at
+/// every column its `order` keys read. The projection terms hold ordinals at
 /// this stage; a scalar call's arguments contribute their read ordinals too.
 private func referenced(_ projection: Array<Term>, _ filter: Filter?,
                         _ order: Array<SortKey>)
@@ -88,16 +88,16 @@ private func invert(_ ordinals: Array<Int>) -> Dictionary<Int, Int> {
 /// grouped path requires for `GROUP BY`. An ordinal or an output-alias key
 /// references a select-list output by construction (`SortKey.output`), so it
 /// satisfies the rule whatever its term computes — its value is constant across
-/// a dedup group. An ordinary INPUT expression key satisfies it when either it
+/// a dedup group. An ordinary input expression key satisfies it when either it
 /// reads a projected column — its resolved `Term` is a bare `.slot` (a plain
-/// column read) that a projected bare-slot term also reads — or it REPEATS a
+/// column read) that a projected bare-slot term also reads — or it repeats a
 /// projected select-list expression: its AST `Expression` is structurally equal
 /// to a projected one (`SELECT DISTINCT A + B AS total … ORDER BY A + B`), so
 /// the key orders on a projected distinct value and is well-defined, exactly as
 /// the alias `ORDER BY total` and the ordinal `ORDER BY 1` naming that same
 /// output are. A key ordering on any other value faults `SQLError.distinct`.
 ///
-/// The satisfying comparison is over the RESOLVED `Term`s, not the AST: a key
+/// The satisfying comparison is over the resolved `Term`s, not the AST: a key
 /// whose lowered `term` equals a projected item's lowered `term` orders on a
 /// projected value. Lowering normalizes column qualification to a slot, so a
 /// key that differs from its projected twin ONLY in qualification — `SELECT
@@ -111,7 +111,7 @@ private func invert(_ ordinals: Array<Int>) -> Dictionary<Int, Int> {
 /// `.slot` the projection reads). `keys` supplies the AST key's spelling for
 /// the fault message; each resolved order key pairs index-for-index with it.
 ///
-/// A matching INPUT key is REBOUND to the projected column it matched: this
+/// A matching input key is rebound to the projected column it matched: this
 /// returns the order keys with each satisfying input key's `column` set to the
 /// index of the projection item whose term it equals, so the DISTINCT
 /// materialisation sorts on that already-materialised projected slot rather
@@ -138,22 +138,22 @@ extension Plan {
   /// omitting each layer when its clause is absent. The `projection`, `filter`,
   /// and `order` keys are in slot space; an empty `order` omits the sort.
   ///
-  /// Without `distinct` and with no `ORDER BY` key naming a select-list OUTPUT
+  /// Without `distinct` and with no `ORDER BY` key naming a select-list output
   /// (an ordinal or an output alias), the shape is `Project(Limit(Sort(_)))`:
-  /// the row `limit` sits BELOW the projection — after `WHERE` and `ORDER BY`
+  /// the row `limit` sits below the projection — after `WHERE` and `ORDER BY`
   /// but before the select list runs. A row outside the requested page is
   /// dropped by the limit before its projection runs, so a projection that
   /// could throw (`SELECT 1 / 0 … FETCH FIRST 0 ROWS ONLY`) never evaluates for
   /// a discarded row and the query returns the documented empty page.
   ///
-  /// When an `ORDER BY` key names a select-list output over a COMPUTED
+  /// When an `ORDER BY` key names a select-list output over a computed
   /// expression (`SELECT next() AS n … ORDER BY n`), reusing the projection
   /// term as the pre-projection sort key would evaluate that expression twice
   /// — once to order, once to project — so a non-deterministic or stateful
   /// routine sorts on one set of values and returns a second, misordering the
-  /// result. `materialised` instead computes the sort-referenced outputs ONCE
+  /// result. `materialised` instead computes the sort-referenced outputs once
   /// below the sort and orders an output key by that column, then a
-  /// final projection reads those SAME values it sorted on (and computes the
+  /// final projection reads those same values it sorted on (and computes the
   /// remaining, unreferenced outputs above the cap). `shaped` takes that shape
   /// exactly when a key names an output; a pure input-key `ORDER BY` keeps the
   /// simpler `Project(Sort(_))` (its keys need input columns the materialised
@@ -175,10 +175,10 @@ extension Plan {
     }
 
     // An output key names a materialised projection column; sorting on the
-    // recomputed projection term instead would double-evaluate it (WRONG for a
+    // recomputed projection term instead would double-evaluate it (wrong for a
     // non-deterministic routine). Materialise the sort-referenced outputs once
     // below the sort, so the order reflects the returned values whenever a key
-    // does — over the FILTERED `plan`, so a HAVING/WHERE above governs.
+    // does — over the filtered `plan`, so a HAVING/WHERE above governs.
     if order.contains(where: { $0.output }) {
       return plan.materialised(distinct: distinct, projection: projection,
                                order: order, limit: limit)
@@ -194,31 +194,31 @@ extension Plan {
     return Plan.distinct(.project(projection, plan)).capped(limit: limit)
   }
 
-  /// This plan (already filtered) shaped so an `ORDER BY` key naming an OUTPUT
+  /// This plan (already filtered) shaped so an `ORDER BY` key naming an output
   /// sorts on exactly the value that output returns, computing each such output
-  /// EXACTLY ONCE — the single-evaluation shape `shaped` picks when a key
+  /// exactly once — the single-evaluation shape `shaped` picks when a key
   /// references the select list.
   ///
-  /// Only the sort-REFERENCED outputs are materialised below the sort. A `map`
+  /// Only the sort-referenced outputs are materialised below the sort. A `map`
   /// projection retains the input columns (slots `0 ..< self.slots`) and
   /// appends one materialised column per output an ORDER BY key names, then one
-  /// per ordinary INPUT sort key (an `ORDER BY a + b` over non-projected
+  /// per ordinary input sort key (an `ORDER BY a + b` over non-projected
   /// columns still needs its input terms). The sort orders by slots into that
   /// row — an output key by its materialised column, an input key by its
   /// appended (or existing input) column — so a computed output key is
   /// evaluated once and its sort value equals the value the row returns.
   ///
   /// The final projection produces each output from that row: a sort-referenced
-  /// output READS its materialised slot (never recomputed, preserving the
-  /// single evaluation), and any OTHER output computes its expression from the
+  /// output reads its materialised slot (never recomputed, preserving the
+  /// single evaluation), and any other output computes its expression from the
   /// retained input columns. Without `distinct` this final projection sits
   /// above the cap, so an unreferenced output (`SELECT x, 1 / 0 … ORDER BY x
   /// FETCH FIRST 0 ROWS`) evaluates only for rows the limit keeps — never for a
   /// dropped row, restoring the lazy `Project(Limit(_))` page the all-outputs
   /// shape regressed.
   ///
-  /// With `distinct` the dedup runs on the WHOLE projected row, so every output
-  /// (not only the sort-referenced ones) is materialised BELOW the distinct —
+  /// With `distinct` the dedup runs on the whole projected row, so every output
+  /// (not only the sort-referenced ones) is materialised below the distinct —
   /// the lazy split would dedup on a partial row. The `distinct` then dedups
   /// the projected rows and `limit` pages the deduplicated result.
   private func materialised(distinct: Bool, projection: Array<Term>,
@@ -305,13 +305,13 @@ extension Catalog where Self: ~Escapable {
                                   _ context: Context = Context())
       throws(SQLError) -> Plan {
     // Expand any `GROUP BY GROUPING SETS` select to its `UNION ALL` FIRST — the
-    // SAME normalization `run` applies — so `compile` and a `columns(of:)`
+    // same normalization `run` applies — so `compile` and a `columns(of:)`
     // derive over the same query cannot diverge. Idempotent for a `.keys`/
     // `.arm` select; a nested body re-enters and expands in turn.
     let query = try query.expanded
-    // Bind the derived tables (and store relations) THIS query names in its own
+    // Bind the derived tables (and store relations) this query names in its own
     // FROM/JOIN before resolving its relations — SELECT-scoped, so a subquery
-    // compiled through here binds its OWN aliases (an outer statement-global
+    // compiled through here binds its own aliases (an outer statement-global
     // pre-collection would leave a sibling subquery's same-named `t` bound to
     // the wrong one). Schema-only (`rows: false`): compilation reads schemas,
     // never a cursor. Idempotent when the caller already augmented (`run`).
@@ -319,20 +319,20 @@ extension Catalog where Self: ~Escapable {
     // view body under resolution that names the view faults `.recursion`.
     // A nested subquery's FROM sees base tables and enclosing CTEs, NOT this
     // query's derived aliases — so the augmented `context` threads onward and
-    // `subquery(of:)` REVEALS the base before lowering a subquery (this query's
+    // `subquery(of:)` reveals the base before lowering a subquery (this query's
     // and every enclosing query's derived aliases dropped, the CTEs and store
     // relations kept, a CTE a same-named derived alias here shadows still
     // visible). The layered overlay never overwrote the CTE, so no pre-augment
     // context is threaded. `validate` gates a derived body's eager type-check:
-    // a RUN preflight passes `false` so a data-dependent body expression an
+    // a run preflight passes `false` so a data-dependent body expression an
     // execution never evaluates is not rejected here (the outer query still
-    // faults, and a REACHED body operand still faults at run), matching the
+    // faults, and a reached body operand still faults at run), matching the
     // non-derived path; a schema check passes `true`.
     let context = try augment(context, for: query, rows: false)
     // A query-level `ORDER BY` / `DISTINCT` / `OFFSET`·`FETCH` over a set
     // operation rides the `ordered` carrier: compile the inner union, then
-    // STACK the row operators over its plan, resolved through the setop's
-    // OUTPUT scope (`ordered`). The row operators do NOT project, so the result
+    // stack the row operators over its plan, resolved through the setop's
+    // output scope (`ordered`). The row operators do NOT project, so the result
     // columns stay the union's — an identity projection over its output slots.
     if case let .ordered(inner, distinct, order, limit, generated) = query {
       return try ordered(inner, distinct: distinct, order: order,
@@ -342,11 +342,11 @@ extension Catalog where Self: ~Escapable {
       return try compile(query.first, context)
     }
 
-    // A set operation collects NO derived aliases at the query level — arms are
-    // SCOPED, so `collect(derived:)` stops at a `SELECT` — leaving the augment
+    // A set operation collects no derived aliases at the query level — arms are
+    // scoped, so `collect(derived:)` stops at a `SELECT` — leaving the augment
     // above with no arm-local bindings. But the `SELECT *` arity check resolves
-    // each arm's `*` BEFORE the recursive per-arm compile augments that arm, so
-    // augment each arm's OWN derived aliases into a PER-ARM scope first, as the
+    // each arm's `*` before the recursive per-arm compile augments that arm, so
+    // augment each arm's own derived aliases into a per-ARM scope first, as the
     // per-arm `compile`/`run` scope them: `SELECT * FROM (SELECT V FROM S) AS
     // d` resolves `d`'s width. It is per arm so the left arm's `d` never
     // leaks to the right (the arm-scoping fix); the width each check computes
@@ -356,25 +356,25 @@ extension Catalog where Self: ~Escapable {
     let width = try arity(query.first, head)
     let count = try arity(right.first, tail)
     guard count == width else { throw .arity(width, count) }
-    // Both arms of a set-operation subquery correlate against the SAME
+    // Both arms of a set-operation subquery correlate against the same
     // enclosing scope, so each lowers under the shared `context.outer`. The
-    // per-column result TYPES are UNIFIED across the arms (ISO) and CARRIED on
+    // per-column result types are unified across the arms (ISO) and carried on
     // the plan node: the `.setop` executor holds only the sub-plans, not the
-    // arm `Query`s, so it cannot fold them at run — compute them HERE, where
+    // arm `Query`s, so it cannot fold them at run — compute them here, where
     // the arm queries and scope are in hand, and coerce each arm's rows at run.
-    // The arms' OWN native column types (each arm's own unified columns —
+    // The arms' own native column types (each arm's own unified columns —
     // `types(unifying:)` folds a nested arm — the very rows `combine` coerces
-    // to this node's unified `types`) are derived BEFORE the `types` local
+    // to this node's unified `types`) are derived before the `types` local
     // shadows the deriver.
     //
-    // These three derivations are a schema-only PROBE — they compute types, not
+    // These three derivations are a schema-only probe — they compute types, not
     // the arms' real plans (those are compiled from `context` below, at
     // `compile(left/right, context)`). The type derivation lowers any nested
-    // subquery to read its width, which would RECORD a correlated inner plan
+    // subquery to read its width, which would record a correlated inner plan
     // into the shared runtime memo; that record is first-writer-wins, so a
     // later caller with a same-shaped subquery could reuse this view body's
     // plan (against the view's base) instead of its own CTE. Derive against a
-    // context carrying an ISOLATED throwaway memo — every other field (scope,
+    // context carrying an isolated throwaway memo — every other field (scope,
     // subscope, outer correlation, validate) preserved — so the probe's
     // recordings are discarded and only the real arm compiles below populate
     // the live memo.
@@ -382,11 +382,11 @@ extension Catalog where Self: ~Escapable {
     let l = try types(unifying: left, probe)
     let r = try types(unifying: right, probe)
     let types = try types(unifying: query, probe)
-    // The columns this node WIDENS — where the unified `types[c]` differs from
-    // an arm's OWN native type — so the pushdown pass (a pure Plan rewrite with
-    // no catalog) can keep a predicate over a widened column ABOVE the arms
+    // The columns this node widens — where the unified `types[c]` differs from
+    // an arm's own native type — so the pushdown pass (a pure Plan rewrite with
+    // no catalog) can keep a predicate over a widened column above the arms
     // rather than pushing it in, where an arm would test the pre-coercion
-    // value. A column differing from EITHER arm is coerced for that arm, so
+    // value. A column differing from either arm is coerced for that arm, so
     // record it; a homogeneous set operation matches both arms, leaving the
     // mask empty and the pushdown unchanged.
     let widened = Set(types.indices.filter {
@@ -396,20 +396,20 @@ extension Catalog where Self: ~Escapable {
                       all: all, types: types, widened: widened)
   }
 
-  /// The distinct UNCORRELATED subqueries `select` nests, each COMPILED ONCE
-  /// against this catalog and `context` for its column count — NEVER run — into
+  /// The distinct uncorrelated subqueries `select` nests, each compiled once
+  /// against this catalog and `context` for its column count — never run — into
   /// a `Resolution` map the predicate/projection lowering reads for arity, the
   /// seam that carries each sub-`Query` into its lowered `Filter` as data.
   ///
-  /// This is CURSOR-FREE: it drives `compile`, which resolves schemas and reads
+  /// This is cursor-free: it drives `compile`, which resolves schemas and reads
   /// the subquery's `Plan.width` without a cursor, so a schema-only path
   /// (`columns(of:)`, view resolution) that shares this lowering opens none and
   /// surfaces no data-dependent error. Every subquery in the `WHERE`, join
   /// `ON`s, `HAVING`, projection, `ORDER BY` expressions, and aggregate
   /// arguments and FILTERs is found by a syntactic walk and keyed by its own
   /// `Query` (which is `Hashable`), so lowering resolves each `EXISTS`/`IN (Q)`
-  /// against the map by identity. A subquery compiles ONCE even if it appears
-  /// twice; it RUNS at execution (see `subqueries(of:)`), UNCORRELATED so once.
+  /// against the map by identity. A subquery compiles once even if it appears
+  /// twice; it runs at execution (see `subqueries(of:)`), uncorrelated so once.
   ///
   /// `context.subscope` is the resolution context these subqueries lower under
   /// — `.caller` for a top-level compile, `.view(name)` for a view body's —
@@ -417,34 +417,34 @@ extension Catalog where Self: ~Escapable {
   /// and a top-level one over the same AST stay distinct entries (see
   /// `Subscope`).
   ///
-  /// `enclosing` is the select's OWN resolution scope — the one its nested
-  /// subqueries CORRELATE against: each nested query compiles under a fresh
+  /// `enclosing` is the select's own resolution scope — the one its nested
+  /// subqueries correlate against: each nested query compiles under a fresh
   /// `Outer` extending `context.outer` (this select's own enclosing scope, when
   /// it is itself a subquery) with `enclosing` the nearest scope, so a nested
-  /// query's inner `WHERE` column binding none of ITS relations resolves
+  /// query's inner `WHERE` column binding none of its relations resolves
   /// against the enclosing select (and outward), lowering to a synthetic
-  /// `Term.parameter` and RECORDING the correlation the lowered node carries.
-  /// The returned `Resolution` also carries `context.outer` so THIS select's
+  /// `Term.parameter` and recording the correlation the lowered node carries.
+  /// The returned `Resolution` also carries `context.outer` so this select's
   /// own columns correlate outward when it is a subquery.
   ///
-  /// `prefixes`, when supplied, gives the PREFIX scope each join `ON` lowers
+  /// `prefixes`, when supplied, gives the prefix scope each join `ON` lowers
   /// against — the FROM relation and joins `0…index`, never a relation joined
-  /// LATER — so a subquery in join `i`'s `ON` correlates against `prefixes[i]`
-  /// (the relations available AT that join point) rather than the full join
+  /// later — so a subquery in join `i`'s `ON` correlates against `prefixes[i]`
+  /// (the relations available at that join point) rather than the full join
   /// `enclosing`. A correlated reference to a later-joined relation then binds
-  /// against NONE of the prefix's relations and faults `SQLError.column`,
-  /// matching the DIRECT `ON` resolver, which already uses the prefix scope. A
+  /// against none of the prefix's relations and faults `SQLError.column`,
+  /// matching the direct `ON` resolver, which already uses the prefix scope. A
   /// non-join surface (WHERE/projection/HAVING/ORDER) correlates against
   /// `enclosing` as before.
   internal borrowing func subquery(of select: Select, _ context: Context,
                                    enclosing: Scope? = nil,
                                    prefixes: Array<Scope> = [])
       throws(SQLError) -> Plans {
-    // Resolve each SITE'S subqueries against THAT site's own scope, keyed PER
-    // OCCURRENCE: a join `i`'s `ON` against its PREFIX scope `prefixes[i]` (the
-    // relations available AT that join point), the
-    // WHERE/HAVING/projection/ORDER against the full join `enclosing`. The SAME
-    // inner SQL in both an `ON` and the WHERE is resolved TWICE — each against
+    // Resolve each site'S subqueries against that site's own scope, keyed per
+    // occurrence: a join `i`'s `ON` against its prefix scope `prefixes[i]` (the
+    // relations available at that join point), the
+    // WHERE/HAVING/projection/ORDER against the full join `enclosing`. The same
+    // inner SQL in both an `ON` and the WHERE is resolved twice — each against
     // its own site's scope — so the WHERE occurrence sees the full scope and
     // reports a genuine ambiguity rather than reusing the first `ON`
     // occurrence's narrower prefix correlation.
@@ -472,18 +472,18 @@ extension Catalog where Self: ~Escapable {
     return Plans(lowerings, remainder)
   }
 
-  /// Builds ONE lowering `Resolution` over the directly-nested `queries` of a
-  /// single SITE, resolving each against `within` — the scope THAT site's
+  /// Builds one lowering `Resolution` over the directly-nested `queries` of a
+  /// single site, resolving each against `within` — the scope that site's
   /// subqueries correlate against (a join `ON`'s prefix, or the full
   /// `enclosing` for the WHERE/HAVING/projection/ORDER). Each distinct `Query`
-  /// is compiled ONCE here; the SAME inner SQL at a DIFFERENT site is resolved
+  /// is compiled once here; the same inner SQL at a different site is resolved
   /// by that site's own call, against its own scope.
   internal borrowing func subquery(_ queries: Array<Query>, _ select: Select,
                                    _ context: Context, within: Scope?)
       throws(SQLError) -> Resolution {
     // A nested subquery's FROM resolves against base tables and enclosing CTEs,
     // NOT the enclosing SELECT's derived-table aliases (SELECT-scoped, unseen
-    // by a subquery's FROM as a base-table alias would be) — so STRIP them, the
+    // by a subquery's FROM as a base-table alias would be) — so strip them, the
     // CTEs/store relations kept, before compiling each subquery. Applied for
     // scalar, `IN`, and `EXISTS` alike (`select.subqueries` covers all three).
     let context = context.revealed()
@@ -492,10 +492,10 @@ extension Catalog where Self: ~Escapable {
     var types = Dictionary<Query, ResolvedColumn>()
     var correlations = Dictionary<Query, Correlation>()
     for query in queries where widths[query] == nil {
-      // A fresh `Outer` per nested query — its enclosing scope is THIS select
+      // A fresh `Outer` per nested query — its enclosing scope is this select
       // (nearest, `within`), stacked past this select's own enclosing scope
-      // `outer`. A FROM-less select adds no relations, but it is STILL a scope
-      // FRAME: it pushes an EMPTY `Scope` so correlation DEPTH counts this
+      // `outer`. A FROM-less select adds no relations, but it is still a scope
+      // frame: it pushes an empty `Scope` so correlation depth counts this
       // level. Its own plan runs over a `single` empty record, so a deeper
       // reference to the true outer must NOT bind as this frame's `.slot` (an
       // empty record has no such cell) — the empty frame makes that reference
@@ -506,27 +506,27 @@ extension Catalog where Self: ~Escapable {
       // The context each nested compile/derive threads: the revealed base with
       // this frame's `nested` as the enclosing correlation stack and the
       // shape-only lenience below. `unlateralized()` clears the LATERAL-body
-      // flag so a nested ORDINARY subquery within a lateral body builds its OWN
+      // flag so a nested ordinary subquery within a lateral body builds its own
       // Resolution with `everywhere: false` — the lateral everywhere-admission
       // covers ONLY the lateral body's own projection, NOT a subquery inside
       // it, so an ordinary correlated scalar-subquery projection is barred
       // exactly as it is outside a lateral body.
-      // `shaping()` DEFERS the set-operation operand-compatibility fold out of
-      // this pre-pass: it records EVERY nested subquery's width, arity, and
+      // `shaping()` defers the set-operation operand-compatibility fold out of
+      // this pre-pass: it records every nested subquery's width, arity, and
       // single-column type ahead of the reachability walk, so a `SELECT 'x'
       // UNION SELECT 1` behind a short-circuited `1 = 0 AND …` is not faulted
-      // while merely recording shape. A REACHED scalar/`IN` occurrence is re-
+      // while merely recording shape. A reached scalar/`IN` occurrence is re-
       // folded strictly on the walk's reached path; arity/resolution eager.
       let inner = context.with(outer: nested).validating(false)
           .unlateralized().shaping()
-      // A nested subquery's body derivation is SHAPE ONLY, so ALWAYS lenient
+      // A nested subquery's body derivation is shape ONLY, so ALWAYS lenient
       // (`validate: false`) — this pass exists to record the subquery's width,
       // arity, and correlation, never to validate its body. Validation of a
       // subquery's body (and the derived tables nested within it, at any depth)
       // is the reachability walk's job: `typecheck(_ select:)` re-derives each
-      // REACHED occurrence's body strictly over `subquery.visited`. Compiling a
-      // derived body THIS subquery nests with `validate: true` here would
-      // eager-type-check it BEFORE the walk decides the subquery is reached —
+      // reached occurrence's body strictly over `subquery.visited`. Compiling a
+      // derived body this subquery nests with `validate: true` here would
+      // eager-type-check it before the walk decides the subquery is reached —
       // faulting `WHERE 1 = 0 AND 1 IN (SELECT x FROM (SELECT 1 / 0 …) AS d)`,
       // whose `IN` a run short-circuits away. Structural faults (a bad inner
       // relation/column, a UNION arity) still surface — they resolve regardless
@@ -534,47 +534,47 @@ extension Catalog where Self: ~Escapable {
       let plan = try compile(query, inner)
       widths[query] = plan.width
       // A scalar subquery contributes its single-column output COLUMN — its
-      // type AND `unconstrained` mask together, UNIFIED across its
+      // type AND `unconstrained` mask together, unified across its
       // set-operation arms (a `(SELECT 1 UNION SELECT 2.5)` typing `double`, a
       // `(SELECT NULLIF('a','a'))` staying unconstrained), not read off the
       // first arm alone; a wider or an `EXISTS`/`IN (Q)` subquery still records
       // the FIRST column (harmless — only a width-1 scalar occurrence reads it,
       // and the lowering rejects a wider one). It derives cursor-free against
-      // the SAME context the width compile uses, so it matches what the run
+      // the same context the width compile uses, so it matches what the run
       // advertises.
       types[query] =
           try columns(unifying: query, inner).first
       // The correlation the nested compile discovered — the outer columns its
       // inner `WHERE`/`ON` named — carried into the lowered subquery node so
-      // the per-outer-row re-execution binds them. Empty for an UNCORRELATED
+      // the per-outer-row re-execution binds them. Empty for an uncorrelated
       // one.
       correlations[query] = nested.correlation
-      // A CORRELATED occurrence's inner PLAN was just compiled with THIS site's
+      // A correlated occurrence's inner plan was just compiled with this site's
       // enclosing scope, so its correlated columns are `Term.parameter`s bound
       // from the outer row. Stash it into the run path's `context.subqueries`
-      // memo (which survives into execution) so the evaluator RE-EXECUTES this
+      // memo (which survives into execution) so the evaluator re-executes this
       // plan per outer row rather than recompiling the inner query fresh —
       // which, with no outer scope in hand at eval, would fault on the outer
       // column. Record it under the occurrence's `PlanKey` — its `Subkey` for
-      // each ROLE this query occupies (scalar / `IN` / `EXISTS`) composed with
+      // each role this query occupies (scalar / `IN` / `EXISTS`) composed with
       // the correlation's parameter names — the same identity the lowered node
-      // looks up. The names distinguish two occurrences of IDENTICAL inner SQL
-      // under DIFFERENT outer layouts (two set-operation arms whose correlated
-      // column sits at different ordinals), so each arm's node finds ITS OWN
+      // looks up. The names distinguish two occurrences of identical inner SQL
+      // under different outer layouts (two set-operation arms whose correlated
+      // column sits at different ordinals), so each arm's node finds its own
       // plan rather than the first arm's. The `existential` role records the
-      // PROBED shape
+      // probed shape
       // (`probed`: the cardinality-only rewrite when `probable`, else the full
       // query) so the per-outer-row EXISTS re-execution tests non-emptiness
-      // WITHOUT evaluating the select list — a `1 / 0` projection never runs —
-      // exactly as the UNCORRELATED EXISTS probes. A schema-only path threads a
+      // without evaluating the select list — a `1 / 0` projection never runs —
+      // exactly as the uncorrelated EXISTS probes. A schema-only path threads a
       // throwaway memo, harmless there.
       if !nested.correlation.isEmpty {
         for role in select.roles(of: query) {
-          // Recompile the EXISTS probe LENIENTLY (`validate: false`), the SAME
+          // Recompile the EXISTS probe leniently (`validate: false`), the same
           // way the `plan` above compiled: this builds the run-time plan a
           // correlated re-execution reuses, so it must not eager-type-check a
           // filtered-out projection the per-outer-row probe never evaluates.
-          // The reachability walk validates a REACHED occurrence's probe shape
+          // The reachability walk validates a reached occurrence's probe shape
           // itself (`typecheck(shape(of: reach), …)`), so validation stays the
           // walk's, never this shape-deriving pass'.
           let recorded = try role == .existential
@@ -584,7 +584,7 @@ extension Catalog where Self: ~Escapable {
           // (line ~134), so a correlated re-execution enjoys the same seeks and
           // join placement. The pushdown's nullability analysis treats a
           // conjunct carrying a correlated `Term.parameter` as nullable, so it
-          // never rides ahead of a LATER unsafe conjunct the inner `AND` still
+          // never rides ahead of a later unsafe conjunct the inner `AND` still
           // owes.
           context.subqueries.record(plan: try recorded.pushdown(),
                                     for: Subkey(scope, query, role),
@@ -593,14 +593,14 @@ extension Catalog where Self: ~Escapable {
       }
     }
     // A LATERAL body's `Resolution` admits a correlated preceding-FROM column
-    // EVERYWHERE (`everywhere`), so its projection lowers such a column to a
+    // everywhere (`everywhere`), so its projection lowers such a column to a
     // `Term.parameter` rather than barring it — the ISO scoping a lateral body
     // gets and an ordinary subquery (`context.lateral == false`) does not.
     return Resolution(scope, widths, types, correlations,
                       outer: context.outer, everywhere: context.lateral)
   }
 
-  /// The single VALUE a SCALAR subquery `query` collapses to against this
+  /// The single value a scalar subquery `query` collapses to against this
   /// catalog and `context`: NULL when it yields no row, its lone cell when it
   /// yields exactly one, and `SQLError.cardinality` when it yields more than
   /// one (the ISO `<scalar subquery>` cardinality rule).
@@ -610,7 +610,7 @@ extension Catalog where Self: ~Escapable {
   /// and the collapse reads the first. A wider subquery never reaches here — it
   /// faulted at compile.
   ///
-  /// The evaluator calls this LAZILY, on the first reach of a scalar
+  /// The evaluator calls this lazily, on the first reach of a scalar
   /// `Term.subquery`, so an occurrence in an unreachable `CASE`/`COALESCE` arm
   /// never runs it — preserving short-circuit semantics — and memoises the
   /// result for the reached occurrence's later reads.
@@ -619,7 +619,7 @@ extension Catalog where Self: ~Escapable {
     // A scalar subquery is a nested subquery: its FROM resolves against base
     // tables and enclosing CTEs, NOT the enclosing SELECT's derived-table
     // aliases (the evaluator threads the owning plan's overlay, which binds
-    // them for the owning scan). STRIP them (CTEs/store kept), matching the
+    // them for the owning scan). strip them (CTEs/store kept), matching the
     // eager `IN`/`EXISTS` strip in `subqueries(of:)`, so a scalar subquery's
     // `FROM d` cannot scan an outer derived alias `d`.
     let context = context.revealed()
@@ -629,9 +629,9 @@ extension Catalog where Self: ~Escapable {
   }
 
   /// Whether `query`'s row source yields ANY row — the `EXISTS` cardinality
-  /// probe — WITHOUT evaluating its select list or sort keys.
+  /// probe — without evaluating its select list or sort keys.
   ///
-  /// For a `probable` `SELECT` (see `Select.probable`), it runs a PROBE query
+  /// For a `probable` `SELECT` (see `Select.probable`), it runs a probe query
   /// that keeps the FROM/`WHERE`/joins, the `DISTINCT` quantifier, the `GROUP
   /// BY`, and the SAME original `OFFSET`/`FETCH` but replaces the projection
   /// with a cardinality-preserving target and drops the `ORDER BY`, so the
@@ -643,7 +643,7 @@ extension Catalog where Self: ~Escapable {
   /// `DISTINCT` select without an `OFFSET` is probable too: `SELECT DISTINCT 1
   /// FROM S` yields exactly one distinct row iff `S` is non-empty, so the
   /// constant projection preserves existence. An aggregate/grouped select
-  /// WITHOUT a `HAVING` is probable via a `COUNT(*)` target (see
+  /// without a `HAVING` is probable via a `COUNT(*)` target (see
   /// `Select.probe`): a whole-result aggregate yields exactly one row (EXISTS
   /// true modulo the limit, even over an empty source) and a grouped one yields
   /// one row per group, so the probe preserves its cardinality without running
@@ -656,10 +656,10 @@ extension Catalog where Self: ~Escapable {
   internal borrowing func probe(_ query: Query, _ context: Context)
       throws(SQLError) -> Bool {
     // An `EXISTS` reads ONLY the probe's cardinality, never a cell, so a set-
-    // operation probe's column TYPES are irrelevant — `combine` coerces the
+    // operation probe's column types are irrelevant — `combine` coerces the
     // (discarded) rows, `.isEmpty` reads none. So run the probe under a
     // `shaping()` context, deferring the set-operation operand-compatibility
-    // fold: `EXISTS (SELECT 'x' UNION SELECT 1)` probes non-emptiness WITHOUT
+    // fold: `EXISTS (SELECT 'x' UNION SELECT 1)` probes non-emptiness without
     // faulting `SQLError.operand` on the irreconcilable arm types, matching the
     // invariant that an `EXISTS` does not constrain column type (a bare-select
     // probe folds nothing, so `shaping()` is inert for it).
@@ -672,7 +672,7 @@ extension Catalog where Self: ~Escapable {
   /// projection never evaluates) and the full `query` otherwise (a `HAVING`
   /// select, a `DISTINCT`-with-`OFFSET` one, or a set operation, whose empty
   /// test is not a source-only fact the rewrite preserves). The `probe(_:)` run
-  /// and the CORRELATED `existential` plan both compile/execute THIS shape, so
+  /// and the correlated `existential` plan both compile/execute this shape, so
   /// a correlated EXISTS probes per outer row as an uncorrelated one does.
   internal borrowing func probed(_ query: Query) -> Query {
     guard case let .select(select) = query, select.probable else {
@@ -693,13 +693,13 @@ extension Catalog where Self: ~Escapable {
   /// space from these. The returned `relations` lays the FROM relation first,
   /// then each joined one, each paired with its schema: `Scope(relations)` is
   /// the full-chain scope, `relations[0 ... index + 1]` a join's prefix scope,
-  /// and `Scope(…).width(of: .all)` the `SELECT *` width — DERIVED from the
+  /// and `Scope(…).width(of: .all)` the `SELECT *` width — derived from the
   /// merged-prepend + real-column `expansion` the scope emits, never a separate
   /// sum — every downstream derivation reads out of this one resolution.
   ///
-  /// `relations` is built INCREMENTALLY, each join resolving against the
-  /// PRECEDING FROM (`Scope` of the relations before it): a LATERAL arm's
-  /// projection may name a preceding column, so its output SHAPE depends on
+  /// `relations` is built incrementally, each join resolving against the
+  /// preceding FROM (`Scope` of the relations before it): a LATERAL arm's
+  /// projection may name a preceding column, so its output shape depends on
   /// that scope. A non-lateral join's schema is correlation-independent, so the
   /// preceding scope is harmless — the incremental order is a no-op for it. The
   /// preceding scope threads through here rather than at each call site, so the
@@ -712,9 +712,9 @@ extension Catalog where Self: ~Escapable {
     joined.reserveCapacity(joins.count)
     var relations = [(relation, schema)]
     for index in joins.indices {
-      // The PRECEDING scope carries the merged columns the joins before this
+      // The preceding scope carries the merged columns the joins before this
       // one expose (`prefix(through:)`), so a LATERAL body resolves a bare
-      // merged name to its ONE coalesced column rather than seeing the two
+      // merged name to its one coalesced column rather than seeing the two
       // physical join columns and faulting `.ambiguous`. A join before this one
       // is already resolved (its schema is in `relations`), so the merged
       // prefix is computable here.
@@ -741,7 +741,7 @@ extension Catalog where Self: ~Escapable {
         throw .named("SELECT * with no FROM")
       }
       // The FROM resolves once here; each join then resolves through the shared
-      // helper, which threads each join's PRECEDING scope into its resolve — so
+      // helper, which threads each join's preceding scope into its resolve — so
       // a LATERAL arm's body derives its projected preceding-FROM column
       // against the relations before it rather than against no scope, which
       // would fault the arity check even though the per-arm compile passes the
@@ -749,11 +749,11 @@ extension Catalog where Self: ~Escapable {
       let schema = try resolve(relation, context).schema
       let (_, relations) = try resolve(from: relation, schema: schema,
                                        joins: select.joins, context)
-      // A `SELECT *` over a `NATURAL`/`USING` join is measured at its MERGED
-      // width (each join column ONCE) through `Scope.width(of: .all)`, which
-      // DERIVES the count from the merged-prepend + real-column `expansion` the
+      // A `SELECT *` over a `NATURAL`/`USING` join is measured at its merged
+      // width (each join column once) through `Scope.width(of: .all)`, which
+      // derives the count from the merged-prepend + real-column `expansion` the
       // arm emits — the width the arm actually produces, not the raw sum of
-      // both sides, and not a parallel arithmetic that could drift (a VIRTUAL
+      // both sides, and not a parallel arithmetic that could drift (a virtual
       // `USING` constituent undercounted the old sum). So `A JOIN B USING (k)
       // UNION SELECT …` compares post-merge widths and a valid set operation is
       // not wrongly rejected. An arm with no named-column join yields an empty
@@ -777,7 +777,7 @@ extension Catalog where Self: ~Escapable {
   /// `derived` leaf — and finally a base table scans. A name none resolves is
   /// `SQLError.relation`.
   ///
-  /// A view's body compiles OUTSIDE the statement's CTE scope — never the
+  /// A view's body compiles outside the statement's CTE scope — never the
   /// caller's `ctes` — so a stored view means exactly what it was registered to
   /// mean regardless of the `WITH` a caller wraps around it. A name that IS a
   /// statement CTE has already resolved above (a CTE shadows a view, as it
@@ -785,7 +785,7 @@ extension Catalog where Self: ~Escapable {
   /// view; letting its body see the caller's CTEs would let an unrelated
   /// statement-local `WITH Parent AS …` reach into a view whose own `FROM
   /// Parent` must mean the base relation. The body's scope is instead the
-  /// `definition_schema.` overlay built from the view's OWN query, so a view
+  /// `definition_schema.` overlay built from the view's own query, so a view
   /// defined over a reserved store relation resolves; its `FROM`/`JOIN` names
   /// otherwise resolve against the base catalog (and other views) alone.
   ///
@@ -803,67 +803,67 @@ extension Catalog where Self: ~Escapable {
   /// `definition_schema.` store's `columns` builder, which compiles every view
   /// to advertise it, relies on this: a cyclic view's `try? compile` catches
   /// the fault and skips it. Compiles a LATERAL derived table's `body` against
-  /// the PRECEDING FROM `scope`, discovering its correlation and stashing the
+  /// the preceding FROM `scope`, discovering its correlation and stashing the
   /// pre-compiled plan for the per-outer-row apply to re-execute — the
   /// FROM-clause analog of a correlated subquery's compile pre-pass
   /// (`subquery(_:_:_:within:)`).
   ///
   /// The body compiles under a fresh `Outer` frame nested under `scope` (the
-  /// FROM relation and the joins BEFORE this one), so a body column naming a
-  /// preceding relation binds none of its OWN relations and resolves outward to
+  /// FROM relation and the joins before this one), so a body column naming a
+  /// preceding relation binds none of its own relations and resolves outward to
   /// a synthetic `Term.parameter`, minting a `Correlation`. The plan compile is
   /// lenient (`validate: false`), as the correlated-subquery pre-pass is — this
-  /// pass discovers the shape, and the run's per-row execution faults a REACHED
+  /// pass discovers the shape, and the run's per-row execution faults a reached
   /// operand. The plan is recorded under the occurrence's `Subkey` (this
   /// select's `subscope`, the body query, the `.lateral` role) composed with
   /// the correlation, the same identity `Plan.apply` looks up through
   /// `executed`. Returns the occurrence `Subkey` and the discovered
   /// correlation.
   ///
-  /// A lateral body's SCHEMA + VALIDATION route through the SAME derived-body
-  /// machinery a NON-LATERAL derived body uses (`materialise`, `rows: false`),
-  /// differing ONLY in the OUTER treatment: a non-lateral body CLEARS the
-  /// correlation stack (`body(_:)`, uncorrelated), while a lateral body THREADS
+  /// A lateral body's schema + validation route through the same derived-body
+  /// machinery a non-LATERAL derived body uses (`materialise`, `rows: false`),
+  /// differing ONLY in the OUTER treatment: a non-lateral body clears the
+  /// correlation stack (`body(_:)`, uncorrelated), while a lateral body threads
   /// the preceding-FROM `nested` outer so its correlated references resolve. So
   /// a lateral body inherits the revealed-base overlay (base + CTEs + store,
   /// its own alias out of scope) — a CTE stays visible in the body — AND the
   /// `validate`-gated operand/function type-check, exactly as a non-lateral
   /// body does. Under `validate: false` (a lenient run/shape pass) the body is
   /// NOT eagerly type-checked, matching the reachability-gated validation the
-  /// rest of the engine applies; a REACHED bad operand still faults at run.
+  /// rest of the engine applies; a reached bad operand still faults at run.
   internal borrowing func lateral(_ body: Query, against scope: Scope,
                                   columns renaming: Array<String>,
                                   _ context: Context)
       throws(SQLError) -> (key: Subkey, correlation: Correlation) {
     let nested = (context.outer ?? Outer()).nested(under: scope)
     // Derive the body's schema and — under `validate` — type-check its operands
-    // and functions through the SHARED derived-body path, over the revealed
-    // base (CTEs visible) with the preceding-FROM outer THREADED so a
+    // and functions through the shared derived-body path, over the revealed
+    // base (CTEs visible) with the preceding-FROM outer threaded so a
     // correlated reference resolves rather than faulting as unknown. The
     // returned schema is discarded here (`resolve`/`schema(of:)` advertises the
     // columns); this call exists to run the same validation a non-lateral body
     // gets.
     // Mark the body a LATERAL body (`lateralizing`) so its `Resolution`/
-    // `SubqueryCheck` admit a correlated preceding-FROM column EVERYWHERE,
+    // `SubqueryCheck` admit a correlated preceding-FROM column everywhere,
     // including its projection — per ISO a LATERAL body's preceding references
     // are in scope throughout, unlike an ordinary subquery whose projection
     // stays barred. The flag rides through the shared derived-body machinery to
     // the projection lowering, where a projected preceding column lowers to a
     // `Term.parameter` rather than faulting `.unsupported`.
     // Thread the derived table's explicit `AS d(a, b)` column list into the
-    // body's schema derive so this validation checks the same EXPOSED (renamed)
+    // body's schema derive so this validation checks the same exposed (renamed)
     // names `schema(of:)` advertises — its arity (`SQLError.columns`) and
     // uniqueness (`SQLError.duplicate`) run against the renamed list, so a list
     // hiding a duplicate INNER name (`SELECT T.Id AS x, T.Id AS x) AS d(a, b)`)
-    // passes at BOTH seams rather than faulting only here.
+    // passes at both seams rather than faulting only here.
     let revealed = context.revealed().with(outer: nested).lateralizing()
     _ = try materialise(body, revealed, rows: false, columns: renaming)
-    // Compile the body LENIENTLY for the per-outer-row apply plan (the shape
+    // Compile the body leniently for the per-outer-row apply plan (the shape
     // pass a correlated subquery's pre-pass runs), recording it under the
     // occurrence's key composed with the discovered correlation. It compiles
-    // over the SAME revealed base the schema/validation pass above used (base +
-    // CTEs + store, this select's derived aliases STRIPPED) with the
-    // preceding-FROM outer threaded, so a body `FROM d` cannot bind a CALLER
+    // over the same revealed base the schema/validation pass above used (base +
+    // CTEs + store, this select's derived aliases stripped) with the
+    // preceding-FROM outer threaded, so a body `FROM d` cannot bind a caller
     // derived alias `d` as a relation — the compile and the schema path resolve
     // the body's FROM identically, faulting an unknown relation consistently
     // rather than the run-only compile scanning a caller alias the schema pass
@@ -874,8 +874,8 @@ extension Catalog where Self: ~Escapable {
     context.subqueries.record(plan: try plan.pushdown(), for: key,
                               nested.correlation)
     // The per-outer-row apply re-runs this plan under the occurrence scope's
-    // RECORDED revealed overlay (`revealed(under:)`), which the run stores as
-    // `revealed().relations` for `key.scope` — the SAME revealed base compiled
+    // recorded revealed overlay (`revealed(under:)`), which the run stores as
+    // `revealed().relations` for `key.scope` — the same revealed base compiled
     // here — so execution resolves the body's `FROM` identically and a shadowed
     // CTE cannot diverge between compile and run.
     return (key, nested.correlation)
@@ -887,12 +887,12 @@ extension Catalog where Self: ~Escapable {
     let name = relation.name
     // A LATERAL derived table is not bound in the overlay — its rows are not a
     // constant relation but a correlated apply's right side, materialised per
-    // outer row. Resolve only its SCHEMA here; the join loop compiles its body
+    // outer row. Resolve only its schema here; the join loop compiles its body
     // against the preceding FROM and emits a `Plan.apply` rather than calling
     // the `leaf`, so the leaf is never reached for a lateral relation. Its
-    // output SHAPE is NOT correlation-independent (per ISO its projection may
+    // output shape is NOT correlation-independent (per ISO its projection may
     // name a preceding column), so thread the `preceding` scope — the FROM
-    // relation and the joins BEFORE this one — so a projected preceding column
+    // relation and the joins before this one — so a projected preceding column
     // types from that outer column exactly as the run lowers it.
     if relation.lateral {
       let schema = try schema(of: relation, context, preceding: preceding)
@@ -900,12 +900,12 @@ extension Catalog where Self: ~Escapable {
         .scan(name: name, ordinals: ordinals, seek: nil)
       }
     }
-    // The explicit `AS t(c, …)` list positionally renames a NAMED relation's
-    // output columns; a DERIVED table's list was applied where it materialised
+    // The explicit `AS t(c, …)` list positionally renames a named relation's
+    // output columns; a derived table's list was applied where it materialised
     // (its overlay binding carries the renamed names), so only a `.named`
-    // source renames HERE — the compile-path mirror of `schema(of:)`'s named
+    // source renames here — the compile-path mirror of `schema(of:)`'s named
     // rename, kept in parity so compile and the schema-only path resolve the
-    // SAME column names.
+    // same column names.
     let columns: Array<String> = if case .named = relation.source {
       relation.columns
     } else {
@@ -927,36 +927,36 @@ extension Catalog where Self: ~Escapable {
       if context.visited.contains(name.lowercased()) {
         throw .recursion(name)
       }
-      // The view body compiles OUTSIDE the caller's statement CTEs, but it may
+      // The view body compiles outside the caller's statement CTEs, but it may
       // still name a reserved `definition_schema.` store relation, so seed its
-      // scope with the overlay built from the view's OWN query — never the
+      // scope with the overlay built from the view's own query — never the
       // caller's `ctes` — so a view defined over a store relation resolves.
       // This covers the built-in `information_schema.` views themselves, whose
       // bodies name `definition_schema.` relations.
       //
-      // Compilation resolves only SCHEMAS (names → ordinals/types), never rows,
-      // so the overlay is built SCHEMA-ONLY: a reserved relation types from its
+      // Compilation resolves only schemas (names → ordinals/types), never rows,
+      // so the overlay is built schema-ONLY: a reserved relation types from its
       // header+types, and the row build is never triggered here. A view over
       // `definition_schema.columns` would otherwise re-enter that row builder
       // (which lists views, whose bodies name the relation again) — an
       // unbounded recursion, and the reason the introspection builder can
       // validate a view via `compile`. The rows a view over a reserved
-      // relation actually returns are supplied at EXECUTE time, where `derive`
+      // relation actually returns are supplied at execute time, where `derive`
       // rebuilds the overlay with rows and runs the sub-plan.
-      // This view name enters `visited` BEFORE its body's derived tables
+      // This view name enters `visited` before its body's derived tables
       // materialise, so a body naming this view through a derived table
       // (`FROM (SELECT * FROM <self>) AS d`) re-enters `augment`/`materialise`
       // with the view already visited and faults `.recursion` here rather than
       // recursing to a stack overflow.
       // `context.validate` threads into the view body's schema-only augment +
-      // compile so a RUN (`validate: false`) resolving `FROM <view>` does NOT
+      // compile so a run (`validate: false`) resolving `FROM <view>` does NOT
       // eager-type-check a data-dependent-empty derived body the view nests —
       // as the lenient inline run does; a schema check keeps it strict.
-      // `uncorrelated()` CLEARS the caller's correlation stack: a view is
+      // `uncorrelated()` clears the caller's correlation stack: a view is
       // defined independently of its call site, so its body must NOT correlate
       // against an enclosing row when the view is queried from inside a
       // correlated subquery. Without it an unbound column in the view
-      // DEFINITION would bind to the caller's row rather than fault.
+      // definition would bind to the caller's row rather than fault.
       let overlay =
           try augment(context.body([:]).visiting(name),
                       for: view.query, rows: false)
@@ -985,7 +985,7 @@ extension Catalog where Self: ~Escapable {
     }
   }
 
-  /// The synthesized joins and the `NATURAL`/`USING` MERGED columns (ISO 9075
+  /// The synthesized joins and the `NATURAL`/`USING` merged columns (ISO 9075
   /// 7.10) of `select`'s join chain, resolved against the already-resolved
   /// `relations` (the FROM relation first, then each joined one in source
   /// order). A chain with no named-column join returns the joins verbatim and
@@ -993,22 +993,22 @@ extension Catalog where Self: ~Escapable {
   ///
   /// Rather than rewrite the AST — an emulation every reference site,
   /// expression form, and pass ordering had to be taught — this models each
-  /// merged column ONCE as a scope entry, so the ordinary name→`Term` machinery
+  /// merged column once as a scope entry, so the ordinary name→`Term` machinery
   /// (`Scope.term`/`derive`, `Scope.terms(.all)`, `Grouping`) consumes it. The
-  /// merged column has NO physical slot: its value is `COALESCE(left, right)`
-  /// over the two PHYSICAL combined ordinals (each QUALIFIED-addressable),
+  /// merged column has no physical slot: its value is `COALESCE(left, right)`
+  /// over the two physical combined ordinals (each qualified-addressable),
   /// and a bare reference to its name resolves to that coalesce (the entry
-  /// SHADOWS its constituents), while a qualified `A.c`/`B.c` reaches its own
+  /// shadows its constituents), while a qualified `A.c`/`B.c` reaches its own
   /// side.
   ///
-  /// The fold threads a growing PREFIX `Scope` — the relations `0…index` plus
+  /// The fold threads a growing prefix `Scope` — the relations `0…index` plus
   /// the merged columns accumulated so far — so it resolves each join's common
-  /// columns THROUGH the scope, not by scanning a left array. For a `USING (c,
+  /// columns through the scope, not by scanning a left array. For a `USING (c,
   /// …)` join each `c` must resolve to exactly one left output column
-  /// (`Scope.left` — a name an accumulated plain `ON` join bound TWICE faults
+  /// (`Scope.left` — a name an accumulated plain `ON` join bound twice faults
   /// `SQLError.ambiguous`, the finding-1 trap now a construction fault) and be
   /// present on the right (else `SQLError.column`); a `NATURAL` join's are the
-  /// right schema's names the prefix's VISIBLE names share, left order (a
+  /// right schema's names the prefix's visible names share, left order (a
   /// twice-bound left name faults `.ambiguous` when keyed). The join's `on`
   /// becomes the conjunction of `left.c = right.c` — the LEFT operand a bare
   /// `.column(c)` the prefix scope lowers to its resolved term (a coalesce when
@@ -1029,7 +1029,7 @@ extension Catalog where Self: ~Escapable {
     // The synthesized `on` FILTER of each named-column join (`nil` for a plain
     // `ON`/`CROSS` join, which lowers its own written `on`, or a degenerate
     // `NATURAL` join with no shared column, an always-true `CROSS` product).
-    // It is lowered DIRECTLY here rather than re-lowered from a bare-name AST
+    // It is lowered directly here rather than re-lowered from a bare-name AST
     // predicate — a chained merged column has no unambiguous bare spelling
     // against a scope that also holds the joined-in relation's same-named
     // column — carrying the resolved LEFT term (a coalesce when `c` was already
@@ -1052,11 +1052,11 @@ extension Catalog where Self: ~Escapable {
     return (ons, merged, prefixes)
   }
 
-  /// Folds the ONE `NATURAL`/`USING` merge step of the join at `index` onto the
+  /// Folds the one `NATURAL`/`USING` merge step of the join at `index` onto the
   /// merged columns `merged` accumulated by the joins to its left, returning
   /// its synthesized `on` filter (`nil` for a plain `ON`/`CROSS` join or a
   /// shared-column-less `NATURAL` one) and the extended merged set. This is the
-  /// SINGLE place a join's merged columns are derived — `merges(over:)` folds
+  /// single place a join's merged columns are derived — `merges(over:)` folds
   /// it across the whole chain, and the incremental resolve loops
   /// (`merged(through:…)`) fold it join-by-join to build a LATERAL body's
   /// preceding scope — so no site can compute a join's merged columns a second,
@@ -1071,9 +1071,9 @@ extension Catalog where Self: ~Escapable {
   /// schema shares, in left order. Each merged column is `COALESCE(leftTerm,
   /// right.slot)` — a
   /// coalesce left when `c` was already merged, so chained/outer keying follows
-  /// the merged value — its type the MASK-AWARE unification of the two
+  /// the merged value — its type the mask-aware unification of the two
   /// constituents through the set-operation `merge(_:_:)` (a constant-NULL/
-  /// placeholder side is UNCONSTRAINED and defers to the other; two constrained
+  /// placeholder side is unconstrained and defers to the other; two constrained
   /// sides unify, an irreconcilable pair faulting `.operand`/42804), and its
   /// `on` conjunct a hash-join `match` key (pure `slot = slot`) or a residual
   /// equi `compare`.
@@ -1090,11 +1090,11 @@ extension Catalog where Self: ~Escapable {
     }
     // The joined-in relation's own spelling (its case) of a shared name, or
     // `nil` when it exposes none — probed through the joined schema's FULL
-    // addressable surface (`Schema.ordinal(of:)`, virtual-aware), so a VIRTUAL
-    // column (the fixture/adapter `Id`) a `USING (Id)` join NAMES is FOUND the
-    // SAME way the predicate path `A.Id = B.Id` resolves it, not a real-only
+    // addressable surface (`Schema.ordinal(of:)`, virtual-aware), so a virtual
+    // column (the fixture/adapter `Id`) a `USING (Id)` join names is found the
+    // same way the predicate path `A.Id = B.Id` resolves it, not a real-only
     // `names` membership that would spuriously fault `.column`. This is the
-    // EXPLICIT `USING (c, …)` probe ONLY — a `USING`-named virtual `Id` still
+    // explicit `USING (c, …)` probe ONLY — a `USING`-named virtual `Id` still
     // resolves and merges. The spelling is taken from whichever list
     // (`names`/`virtuals`) holds it.
     func right(_ name: String) -> String? {
@@ -1106,11 +1106,11 @@ extension Catalog where Self: ~Escapable {
     // The joined-in relation's own spelling of a shared REAL name, or `nil`
     // when it exposes none as a real column — the `NATURAL` common-set probe. A
     // `NATURAL` join's common set is the intersection of the two sides' REAL
-    // (`SELECT *`-visible) column names, virtuals EXCLUDED on BOTH sides: the
+    // (`SELECT *`-visible) column names, virtuals excluded on both sides: the
     // left is already real-only (`prefix.names` reads the `expansion`, never a
     // virtual), and this restricts the joined side to `joined.names` not its
-    // full virtual-aware surface. So a fixture/adapter VIRTUAL `Id` NEVER
-    // becomes a `NATURAL` common column — it participates only when EXPLICITLY
+    // full virtual-aware surface. So a fixture/adapter virtual `Id` never
+    // becomes a `NATURAL` common column — it participates only when explicitly
     // named by `USING (Id)`, matching how `*`/`NATURAL` expose the same
     // real-column set while an explicit reference resolves a virtual.
     func real(_ name: String) -> String? {
@@ -1154,16 +1154,16 @@ extension Catalog where Self: ~Escapable {
       } else {
         conjuncts.append(.compare(left.value, .equal, .slot(slot)))
       }
-      // The merged column's type is the MASK-AWARE unification of its two
-      // constituents, taken through the SAME `merge(_:_:)` machinery a
+      // The merged column's type is the mask-aware unification of its two
+      // constituents, taken through the same `merge(_:_:)` machinery a
       // set-operation arm fold uses rather than a bare `ValueType.unified` on
-      // the raw slot types: a constant-NULL/placeholder side is UNCONSTRAINED
+      // the raw slot types: a constant-NULL/placeholder side is unconstrained
       // (it places no type constraint), so the merged type defers to the
-      // CONSTRAINED side — `(SELECT NULLIF(1,1) AS k) RIGHT JOIN B USING (k)`
+      // constrained side — `(SELECT NULLIF(1,1) AS k) RIGHT JOIN B USING (k)`
       // types `k` off `B.k` rather than the left's placeholder `integer`.
-      // Both constrained unify (`int ⊕ double → double`, an IRRECONCILABLE
-      // `int ⊕ text` FAULTS `.operand`/42804, the same fault the set-op fold
-      // raises); both unconstrained stay a placeholder. The coalesce COERCES
+      // Both constrained unify (`int ⊕ double → double`, an irreconcilable
+      // `int ⊕ text` faults `.operand`/42804, the same fault the set-op fold
+      // raises); both unconstrained stay a placeholder. The coalesce coerces
       // each side to the resolved type, so a `RIGHT`/`FULL` join's
       // unmatched-side value obeys the advertised type. An irreconcilable pair
       // re-throws under the USING-specific message (the `.operand`/42804 code
@@ -1180,7 +1180,7 @@ extension Catalog where Self: ~Escapable {
       } catch {
         throw .operand("USING columns have irreconcilable types")
       }
-      // The merged column's OWN mask: unconstrained ONLY when BOTH sides were
+      // The merged column's own mask: unconstrained ONLY when both sides were
       // (`merge` narrows to `right.unconstrained` after skipping an
       // unconstrained left), so a downstream set-operation over the merged
       // column defers when neither side ever constrained it, and constrains
@@ -1192,26 +1192,26 @@ extension Catalog where Self: ~Escapable {
                                 constituents: left.constituents + [slot],
                                 unconstrained: unified.unconstrained))
     }
-    // ISO 9075 7.10 join output order: THIS join's common columns lead, then
+    // ISO 9075 7.10 join output order: this join's common columns lead, then
     // the rest of the LEFT output (recursively), then the right's rest. This
-    // join's `block` therefore PREPENDS ahead of the columns accumulated by the
+    // join's `block` therefore prepends ahead of the columns accumulated by the
     // joins to its left — so a chained `(A JOIN B USING (k)) JOIN C USING (a)`
     // exposes `[a, k, …]` (the outer `a`, then the inner `k`), not the flat
-    // fold order `[k, a, …]`. A chained `… USING (k)` over an ALREADY merged
-    // `k` DROPS the earlier entry (this `block`'s coalesce subsumes its
+    // fold order `[k, a, …]`. A chained `… USING (k)` over an already merged
+    // `k` drops the earlier entry (this `block`'s coalesce subsumes its
     // constituents plus the new right slot), so `SELECT *` still exposes `k`
-    // ONCE and at the OUTER join's position.
+    // once and at the OUTER join's position.
     let names = Set(block.map { $0.name.lowercased() })
     let next = block + merged.filter { !names.contains($0.name.lowercased()) }
     return (conjuncts.conjunction, next)
   }
 
   /// The `NATURAL`/`USING` merged columns accumulated by the joins `0..<count`
-  /// — the merged prefix a LATERAL body of the join AT `count` sees. Folds the
-  /// SAME per-join `merging` step `merges(over:)` does, over
+  /// — the merged prefix a LATERAL body of the join at `count` sees. Folds the
+  /// same per-join `merging` step `merges(over:)` does, over
   /// `relations[0...count]`
   /// (the FROM relation and the joins before `count`), so the incremental
-  /// resolve loops build each preceding scope through the ONE merge path rather
+  /// resolve loops build each preceding scope through the one merge path rather
   /// than a second, divergent construction.
   internal func merged(through count: Int,
                        over relations: Array<(Relation, Schema)>,
@@ -1225,13 +1225,13 @@ extension Catalog where Self: ~Escapable {
     return merged
   }
 
-  /// The preceding scope of the join AT `count` — the FROM relation and the
+  /// The preceding scope of the join at `count` — the FROM relation and the
   /// joins before it (`relations[0..<count + 1]`), carrying the merged columns
-  /// those joins expose (`merged(through:)`). This is the ONE constructor of a
+  /// those joins expose (`merged(through:)`). This is the one constructor of a
   /// join-prefix scope: every incremental resolve loop routes through it, so a
   /// join-prefix scope can never be built without its merged columns (the
   /// finding-1 class — a LATERAL body seeing the two physical join columns
-  /// rather than the ONE merged one).
+  /// rather than the one merged one).
   internal func prefix(through count: Int,
                        over relations: Array<(Relation, Schema)>,
                        _ joins: Array<Join>)
@@ -1252,7 +1252,7 @@ extension Catalog where Self: ~Escapable {
   /// scan carries the set of ordinals the query references on its side
   /// (projection ∪ every match ∪ filter ∪ order, reals and virtuals) so the
   /// executor materialises exactly those, in a fixed order that defines a dense
-  /// SLOT for each — slot `i` is the scan's `i`th referenced ordinal.
+  /// slot for each — slot `i` is the scan's `i`th referenced ordinal.
   ///
   /// The operators run in slot space: `compile` remaps every ordinal it lowered
   /// (the projection, the `filter`, the order column, and each join's keys)
@@ -1270,10 +1270,10 @@ extension Catalog where Self: ~Escapable {
     // A `GROUP BY GROUPING SETS (…)` never reaches here: `Query.expanded` (run
     // at every pipeline entry) has already rewritten it to a `UNION ALL` of
     // `.arm` selects, so `compile(_ select:)` sees only `.keys`/`.arm`.
-    // Bind THIS select's own FROM/JOIN derived tables (and store relations)
+    // Bind this select's own FROM/JOIN derived tables (and store relations)
     // before resolving its relations — SELECT-scoped, so a select reaching
-    // this entry DIRECTLY (a bare `compile(select)`, not through the `Query`
-    // wrapper) resolves its OWN derived aliases rather than faulting
+    // this entry directly (a bare `compile(select)`, not through the `Query`
+    // wrapper) resolves its own derived aliases rather than faulting
     // `.relation`, the same as its schema siblings `columns(of select:)`/
     // `scope(of select:)`. Schema-only (`rows: false`): compilation reads
     // schemas, never a cursor. Idempotent when the caller already augmented
@@ -1285,7 +1285,7 @@ extension Catalog where Self: ~Escapable {
     // type-check the same as the wrapper's.
     //
     // The augmented `context` threads onward to `subquery(of:)`/`group`, which
-    // REVEAL the base before lowering a nested subquery — this select's (and
+    // reveal the base before lowering a nested subquery — this select's (and
     // every enclosing select's) derived aliases dropped, the CTEs and store
     // relations kept — so a subquery's FROM sees no derived alias while a CTE
     // a same-named derived alias here shadows stays visible. The layered
@@ -1308,8 +1308,8 @@ extension Catalog where Self: ~Escapable {
             "a WHERE, GROUP BY, HAVING, ORDER BY, OFFSET/FETCH, or JOIN " +
             "requires a FROM clause")
       }
-      // A scalar projection may still nest an UNCORRELATED subquery
-      // (`SELECT CASE WHEN EXISTS (Q) …`); compile each ONCE for its width and
+      // A scalar projection may still nest an uncorrelated subquery
+      // (`SELECT CASE WHEN EXISTS (Q) …`); compile each once for its width and
       // thread the map through so the term lowers as it does on the FROM'd path
       // rather than hit the default unsupported map. The run path builds the
       // matching run-time cache from `query.subqueries` (which descends the
@@ -1317,16 +1317,16 @@ extension Catalog where Self: ~Escapable {
       // never.
       // A FROM-less select adds no relations, so its nested subqueries
       // correlate against this select's own enclosing scope `outer` unchanged;
-      // and its OWN columns (none but a projected outer reference) correlate
+      // and its own columns (none but a projected outer reference) correlate
       // outward through `outer` too. The seam is `plans.rest`; `scalar` (via
-      // `Schema.terms`) BARS it — a projection is a barred clause position — so
-      // a correlated column of THIS query is diagnosed, not lowered to a
+      // `Schema.terms`) bars it — a projection is a barred clause position — so
+      // a correlated column of this query is diagnosed, not lowered to a
       // `Term.parameter`, matching `columns(of:)`'s schema-path rejection.
       let plans = try subquery(of: select, context)
       return try select.projection.scalar(context.routines,
                                           subquery: plans.rest)
     }
-    // A LATERAL first FROM item has no PRECEDING relation to correlate against,
+    // A LATERAL first FROM item has no preceding relation to correlate against,
     // so it is meaningless (and ISO forbids it) — fault rather than resolve a
     // lateral body against nothing.
     if relation.lateral {
@@ -1358,10 +1358,10 @@ extension Catalog where Self: ~Escapable {
     }
 
     guard !select.joins.isEmpty else {
-      // Compile every nested subquery ONCE for its arity/type, ahead of
+      // Compile every nested subquery once for its arity/type, ahead of
       // lowering, into a map the WHERE/projection/ORDER BY lowering reads — and
-      // discover each one's CORRELATION against this select's single-relation
-      // scope (`enclosing`). This select's OWN columns correlate outward
+      // discover each one's correlation against this select's single-relation
+      // scope (`enclosing`). This select's own columns correlate outward
       // through `outer`.
       let enclosing = Scope([(relation, from.schema)])
       let plans = try subquery(of: select, context, enclosing: enclosing)
@@ -1370,10 +1370,10 @@ extension Catalog where Self: ~Escapable {
         filter = try from.schema.lower(predicate, in: relation,
                                        context.routines, subquery: plans.rest)
       }
-      // The projection and ORDER BY are BARRED clause positions (only the WHERE
-      // admits a correlated column of THIS query); `terms`/`order` bar the seam
+      // The projection and ORDER BY are barred clause positions (only the WHERE
+      // admits a correlated column of this query); `terms`/`order` bar the seam
       // intrinsically, so passing `plans.rest` cannot admit one. A nested
-      // subquery there still lowers with its OWN inner correlation.
+      // subquery there still lowers with its own inner correlation.
       let projection =
           try from.schema.terms(select.projection, in: relation,
                                 context.routines, subquery: plans.rest)
@@ -1413,13 +1413,13 @@ extension Catalog where Self: ~Escapable {
 
     // Resolve every joined relation and lay all relations — the FROM relation
     // first, then each joined one in source order — end to end in one combined
-    // ordinal space. The helper builds the running `relations` INCREMENTALLY
-    // and threads each join's PRECEDING FROM as its resolve scope, so a LATERAL
+    // ordinal space. The helper builds the running `relations` incrementally
+    // and threads each join's preceding FROM as its resolve scope, so a LATERAL
     // arm's schema derives against the relations before it.
     let (joined, relations) = try resolve(from: relation, schema: from.schema,
                                           joins: select.joins, context)
-    // Model each `NATURAL`/`USING` join's MERGED columns (ISO 9075 7.10) in the
-    // join SCOPE, and synthesize each named-column join's lowered `left.c =
+    // Model each `NATURAL`/`USING` join's merged columns (ISO 9075 7.10) in the
+    // join scope, and synthesize each named-column join's lowered `left.c =
     // right.c` `on` filter — a no-op yielding an empty merged set and all-`nil`
     // `ons` for a chain with none, so an ordinary compile is unchanged. The
     // scope carries the merged columns so the ordinary `terms`/`term`/order/
@@ -1439,16 +1439,16 @@ extension Catalog where Self: ~Escapable {
     // A `column = column` conjunct lowers to a `match` hash-join key; any
     // inequality or expression equality lowers to a residual the join filters.
     // The WHERE and ORDER lower against the whole chain, which legitimately
-    // sees every relation. Each join's PREFIX scope — the FROM relation and
-    // joins `0…index`, the relations available AT that join point, never one
-    // joined LATER — carries the merged columns accumulated BEFORE this join
+    // sees every relation. Each join's prefix scope — the FROM relation and
+    // joins `0…index`, the relations available at that join point, never one
+    // joined later — carries the merged columns accumulated before this join
     // (`merges[index]`), so a chained `USING` `on` keys on the merged value and
     // an `ON` subquery's bare merged operand resolves.
     let prefixes = select.joins.indices.map { index in
       Scope(Array(relations[0 ... index + 1]), merged: merges[index])
     }
-    // Resolve each LATERAL join's body ONCE against the PRECEDING FROM — the
-    // FROM relation and the joins BEFORE this one (`relations[0…index]`, ONE
+    // Resolve each LATERAL join's body once against the preceding FROM — the
+    // FROM relation and the joins before this one (`relations[0…index]`, one
     // less than the prefix, which includes the join's own relation) — so a body
     // column naming a preceding relation correlates outward and the body's plan
     // is pre-compiled for the per-outer-row apply. A non-lateral join records
@@ -1469,11 +1469,11 @@ extension Catalog where Self: ~Escapable {
       laterals[index] = try lateral(body, against: preceding,
                                     columns: join.relation.columns, context)
     }
-    // Compile every nested subquery ONCE for arity/type, ahead of lowering,
+    // Compile every nested subquery once for arity/type, ahead of lowering,
     // into a map the join ONs, WHERE, projection, and ORDER BY lowering reads —
-    // and discover each one's CORRELATION. A join `ON`'s subquery correlates
-    // against its PREFIX scope; the WHERE/projection/ORDER against the whole
-    // join `scope`. This select's OWN columns correlate outward through
+    // and discover each one's correlation. A join `ON`'s subquery correlates
+    // against its prefix scope; the WHERE/projection/ORDER against the whole
+    // join `scope`. This select's own columns correlate outward through
     // `outer`. `validate` gates a nested filtered-out derived body's eager
     // type-check.
     let plans = try subquery(of: select, context, enclosing: scope,
@@ -1481,7 +1481,7 @@ extension Catalog where Self: ~Escapable {
     var matches = Array<Filter>()
     matches.reserveCapacity(select.joins.count)
     for index in select.joins.indices {
-      // A `NATURAL`/`USING` join's `on` is the SYNTHESIZED, already-lowered
+      // A `NATURAL`/`USING` join's `on` is the synthesized, already-lowered
       // `left.c = right.c` filter (`ons[index]`, `nil` for a degenerate
       // shared-column-less `NATURAL` join — an always-true `CROSS` product);
       // a plain join lowers its written `ON` against the prefix scope.
@@ -1498,11 +1498,11 @@ extension Catalog where Self: ~Escapable {
       predicate = try scope.lower(clause, context.routines,
                                   subquery: plans.rest)
     }
-    // The projection and ORDER BY are BARRED clause positions: a correlated
-    // column of THIS query is out of the minimal (b) cut there (only its
+    // The projection and ORDER BY are barred clause positions: a correlated
+    // column of this query is out of the minimal (b) cut there (only its
     // WHERE/ON admits one), so `terms`/`order` bar the seam intrinsically and
     // it is diagnosed rather than mis-resolved. A nested subquery in the
-    // projection still lowers — its OWN inner WHERE correlation was discovered
+    // projection still lowers — its own inner WHERE correlation was discovered
     // in the pre-pass.
     let projection = try scope.terms(select.projection, context.routines,
                                      subquery: plans.rest)
@@ -1539,8 +1539,8 @@ extension Catalog where Self: ~Escapable {
     predicate?.references(into: &references)
     for key in order { key.term.references(into: &references) }
     // A LATERAL apply reads its correlation's outer ordinals from the left
-    // chain's record, so those preceding-relation ordinals must be MATERIALISED
-    // (given a packed slot) even when no clause of THIS select references them
+    // chain's record, so those preceding-relation ordinals must be materialised
+    // (given a packed slot) even when no clause of this select references them
     // — else the correlation's remap through `slot` finds no slot for the outer
     // column its body names.
     for lateral in laterals {

--- a/Sources/SQLEngine/Context.swift
+++ b/Sources/SQLEngine/Context.swift
@@ -10,7 +10,7 @@
 ///
 /// - `relations` — the in-scope relation overlay: the materialised common table
 /// expressions a `WITH` binds and any `definition_schema.` store relation the
-/// query names, keyed case-folded. The resolver consults it BEFORE the base
+/// query names, keyed case-folded. The resolver consults it before the base
 /// catalog, so a name it binds shadows a base table or view. - `routines` — the
 /// scalar functions (UDFs) a call resolves through, keyed case-folded; the
 /// engine prelude (`BITAND`) merged under the caller's. - `bindings` — the
@@ -20,7 +20,7 @@
 /// It is plain escapable data, so it needs none of the lifetime machinery the
 /// borrowed catalog does: extending the `relations` overlay for a CTE's scope,
 /// or rebinding it for a recursive step, is an ordinary value copy — the
-/// `deriving`/`scoping` helpers below. The borrowed catalog stays a SEPARATE
+/// `deriving`/`scoping` helpers below. The borrowed catalog stays a separate
 /// parameter; a `Context` never holds it (a stored `~Escapable` member cannot
 /// yield a `~Escapable` table).
 internal struct Context {
@@ -34,8 +34,8 @@ internal struct Context {
   /// The query parameter bindings.
   internal let bindings: Bindings
 
-  /// The RUN-time results of the UNCORRELATED subqueries the executing plan
-  /// nests — each `EXISTS`/`IN (Q)` subquery run ONCE and memoised by its
+  /// The run-time results of the uncorrelated subqueries the executing plan
+  /// nests — each `EXISTS`/`IN (Q)` subquery run once and memoised by its
   /// `Query`, read by the row evaluator. Empty during compilation and every
   /// schema-only path (which never opens a cursor); the `run` path populates it
   /// (see `Catalog.subqueries(of:)`) just before executing the plan.
@@ -46,7 +46,7 @@ internal struct Context {
   /// faults `SQLError.recursion` rather than resolving without end.
   internal let visited: Set<String>
 
-  /// Whether a derived table's body is EAGER type-checked at resolution. A RUN
+  /// Whether a derived table's body is eager type-checked at resolution. A run
   /// preflight, or a schema-only path after a run has proved the statement
   /// runnable, passes `false` so a data-dependent-empty body expression an
   /// execution never evaluates is not rejected; a strict schema check keeps it
@@ -60,36 +60,36 @@ internal struct Context {
   internal let subscope: Subscope
 
   /// The enclosing correlation stack a nested subquery correlates against — the
-  /// `Outer` scopes an inner `WHERE` column that binds none of ITS relations
+  /// `Outer` scopes an inner `WHERE` column that binds none of its relations
   /// resolves outward through, lowering to a synthetic `Term.parameter` and
   /// recording the correlation. `nil` at the top level (no enclosing query).
   internal let outer: Outer?
 
-  /// Whether the query being resolved is a LATERAL derived table's BODY — set
+  /// Whether the query being resolved is a LATERAL derived table's body — set
   /// only by `lateral(_:against:_:)` as it derives/compiles the body. Per ISO
   /// 9075 a `LATERAL` body's preceding-FROM references are in scope throughout
-  /// its query expression, INCLUDING the select list, so the body admits a
-  /// correlated column EVERYWHERE (not only its `WHERE`/`ON`). This flag
+  /// its query expression, including the select list, so the body admits a
+  /// correlated column everywhere (not only its `WHERE`/`ON`). This flag
   /// threads into the `Resolution`/`SubqueryCheck` the body's lowering and
   /// validation build (`everywhere`), lifting the projection-correlation bar
-  /// for the lateral body ALONE — an ordinary subquery's projection stays
+  /// for the lateral body alone — an ordinary subquery's projection stays
   /// barred (`false`).
   internal let lateral: Bool
 
-  /// Whether the query being resolved is a nested-subquery SHAPE pre-pass — the
+  /// Whether the query being resolved is a nested-subquery shape pre-pass — the
   /// cursor-free derive that records a nested subquery's width, arity, and
-  /// single-column type AHEAD of the reachability walk. Set only at the
-  /// pre-pass `inner` constructions (`shaping()`), it DEFERS a set-operation's
-  /// operand-compatibility fold: the pre-pass runs for EVERY nested subquery
+  /// single-column type ahead of the reachability walk. Set only at the
+  /// pre-pass `inner` constructions (`shaping()`), it defers a set-operation's
+  /// operand-compatibility fold: the pre-pass runs for every nested subquery
   /// before the walk decides which run, so faulting `SQLError.operand` here
   /// would reject an unreachable incompatible subquery a short-circuited
   /// `AND`/`OR` never reaches (`… WHERE 1 = 0 AND EXISTS (SELECT 'x' UNION
   /// SELECT 1)`). Arity and resolution stay eager regardless; only the operand
   /// fold defers, substituting a placeholder type (the left arm's) it discards
-  /// for an unreached occurrence and RE-CHECKS strictly for a reached
+  /// for an unreached occurrence and re-checks strictly for a reached
   /// scalar/`IN` one. Distinct from `validate` (also `false` on the top-level
-  /// run and CTE trusted paths, which MUST keep faulting), so it gates the
-  /// operand fold ALONE.
+  /// run and CTE trusted paths, which must keep faulting), so it gates the
+  /// operand fold alone.
   internal let shape: Bool
 
   /// A context over the maps and resolution scope — an empty overlay, no
@@ -115,7 +115,7 @@ internal struct Context {
     self.shape = shape
   }
 
-  /// A copy of this context with `relations` REPLACING the overlay, the same
+  /// A copy of this context with `relations` replacing the overlay, the same
   /// routines, bindings, and subquery results — the scope a phase reads after
   /// `augment` extends the overlay with the store relations a query names, or a
   /// recursive step rebinds a CTE's self.
@@ -125,17 +125,17 @@ internal struct Context {
             subscope: subscope, outer: outer, lateral: lateral, shape: shape)
   }
 
-  /// A copy of this context ENTERING a fresh body scope over `relations` — the
-  /// SINGLE derivation every view/derived-table/CTE body-entry seam routes
-  /// through, `scoping(relations)` with the enclosing correlation stack CLEARED
+  /// A copy of this context entering a fresh body scope over `relations` — the
+  /// single derivation every view/derived-table/CTE body-entry seam routes
+  /// through, `scoping(relations)` with the enclosing correlation stack cleared
   /// (`uncorrelated()`). A body scope — a view definition, a non-LATERAL
-  /// derived table, or a CTE — is resolved INDEPENDENTLY of its call site, so
+  /// derived table, or a CTE — is resolved independently of its call site, so
   /// it must NOT correlate against an enclosing query's row: an unbound column
   /// in the body must fault rather than bind outward to the caller. Folding the
   /// reset INTO body-entry makes the clear intrinsic — a future body seam that
   /// routes through `body(_:)` cannot forget to append `uncorrelated()`. A site
   /// that also guards the cyclic-view chain or gates the eager type-check
-  /// chains `visiting(_:)`/`validating(_:)` AFTER `body(_:)`.
+  /// chains `visiting(_:)`/`validating(_:)` after `body(_:)`.
   internal func body(_ relations: ScopedRelations) -> Context {
     scoping(relations).uncorrelated()
   }
@@ -151,7 +151,7 @@ internal struct Context {
     return scoping(relations)
   }
 
-  /// A copy of this context with `bindings` REPLACING the parameter bindings,
+  /// A copy of this context with `bindings` replacing the parameter bindings,
   /// the same overlay, routines, and subquery results — a correlated subquery's
   /// per-outer-row rebinding, which extends the bindings with the enclosing
   /// row's cells before re-executing its inner plan.
@@ -164,7 +164,7 @@ internal struct Context {
   /// A copy of this context carrying `subqueries` as the executing plan's
   /// materialised subquery results — the run path's extension just before it
   /// executes a compiled plan, so the row evaluator reads each subquery result
-  /// off the SAME context that threads everywhere `execute` descends.
+  /// off the same context that threads everywhere `execute` descends.
   internal func resolving(_ subqueries: Subqueries) -> Context {
     Context(relations: relations, routines: routines, bindings: bindings,
             subqueries: subqueries, visited: visited, validate: validate,
@@ -172,12 +172,12 @@ internal struct Context {
   }
 
   /// A copy of this context with every enclosing SELECT's derived-table aliases
-  /// REVEALED away — the overlay's derived layers dropped, its common table
+  /// revealed away — the overlay's derived layers dropped, its common table
   /// expressions and `definition_schema.` store relations (the base layer)
-  /// KEPT — the scope a NESTED subquery's FROM resolves against.
+  /// kept — the scope a nested subquery's FROM resolves against.
   ///
   /// A derived-table alias is SELECT-scoped: it names a relation only in its
-  /// OWN SELECT's FROM/JOIN and expressions, invisible to a nested subquery's
+  /// own SELECT's FROM/JOIN and expressions, invisible to a nested subquery's
   /// FROM exactly as a base-table alias in the enclosing FROM is (a subquery
   /// does not see the enclosing query's FROM relations; only base tables and
   /// enclosing CTEs are in its relation scope). A CTE, by contrast, is
@@ -185,14 +185,14 @@ internal struct Context {
   /// The seam that compiles/materialises a nested subquery (`subquery(of:)`,
   /// `subqueries(of:)`, `cell(of:)`, and the type-check counterparts) reveals
   /// the base so a subquery's `FROM d` cannot scan an outer derived alias `d`,
-  /// while a same-named CTE `d` the derived alias SHADOWED is resolved again
-  /// — the layered overlay never deleted it. The subquery re-augments its OWN
+  /// while a same-named CTE `d` the derived alias shadowed is resolved again
+  /// — the layered overlay never deleted it. The subquery re-augments its own
   /// derived tables into a fresh layer.
   internal func revealed() -> Context {
     scoping(relations.revealed())
   }
 
-  /// A copy of this context with `name` (folded to lower case) ADDED to the
+  /// A copy of this context with `name` (folded to lower case) added to the
   /// cyclic-view guard — the scope a view body resolves under, so a nested
   /// reference back to the view faults `SQLError.recursion` rather than
   /// resolving without end.
@@ -205,7 +205,7 @@ internal struct Context {
                    outer: outer, lateral: lateral, shape: shape)
   }
 
-  /// A copy of this context with the eager-typecheck gate set to `flag` — a RUN
+  /// A copy of this context with the eager-typecheck gate set to `flag` — a run
   /// preflight or a post-run schema-only path passes `false` to keep a
   /// data-dependent body lenient.
   internal func validating(_ flag: Bool) -> Context {
@@ -215,11 +215,11 @@ internal struct Context {
   }
 
   /// A copy of this context marking the query it resolves as a nested-subquery
-  /// SHAPE pre-pass (`shape`) — the seam the two pre-pass `inner` constructions
+  /// shape pre-pass (`shape`) — the seam the two pre-pass `inner` constructions
   /// route through, so a set operation's operand-compatibility fold defers to
   /// the reachability walk rather than faulting `SQLError.operand` while merely
   /// recording an unreached subquery's width and type. Arity and resolution
-  /// stay eager; every OTHER field is preserved.
+  /// stay eager; every other field is preserved.
   internal func shaping() -> Context {
     Context(relations: relations, routines: routines, bindings: bindings,
             subqueries: subqueries, visited: visited, validate: validate,
@@ -235,7 +235,7 @@ internal struct Context {
             subscope: subscope, outer: outer, lateral: lateral, shape: shape)
   }
 
-  /// A copy of this context whose enclosing correlation stack is EXTENDED with
+  /// A copy of this context whose enclosing correlation stack is extended with
   /// `scope` as the nearest enclosing one (`Outer.nested(under:)`, starting a
   /// fresh stack at the top level) — the scope a nested subquery correlates
   /// against, so an inner column binding none of its own relations resolves
@@ -254,24 +254,24 @@ internal struct Context {
   }
 
   /// A copy of this context marking the query it resolves as a LATERAL derived
-  /// table's BODY (`lateral`) — the SINGLE seam `lateral(_:against:_:)` routes
+  /// table's body (`lateral`) — the single seam `lateral(_:against:_:)` routes
   /// its body's schema derivation and plan compile through, so the body's
   /// `Resolution`/`SubqueryCheck` admit a correlated preceding-FROM column
-  /// EVERYWHERE, including the projection, per ISO. Every OTHER field is
+  /// everywhere, including the projection, per ISO. Every other field is
   /// preserved; the flag is scoped to the body's own lowering (a nested
-  /// NON-lateral body clears it through `body(_:)`).
+  /// non-lateral body clears it through `body(_:)`).
   internal func lateralizing() -> Context {
     Context(relations: relations, routines: routines, bindings: bindings,
             subqueries: subqueries, visited: visited, validate: validate,
             subscope: subscope, outer: outer, lateral: true, shape: shape)
   }
 
-  /// A copy of this context with the enclosing correlation stack CLEARED — the
+  /// A copy of this context with the enclosing correlation stack cleared — the
   /// scope a body that must NOT correlate against the caller's row resolves
   /// under: a view body and a non-LATERAL derived table body. Neither may see
   /// an enclosing query's columns (a view is defined independently of its call
   /// site; a derived table is uncorrelated), so an unbound column in either
-  /// must fault rather than bind outward to the caller. Every OTHER field —
+  /// must fault rather than bind outward to the caller. Every other field —
   /// the relation overlay, routines, bindings, subquery results, the visited
   /// guard, the validate gate, and the subscope — is preserved; `outer` resets
   /// to `nil` (restoring the top-level default) and the LATERAL-body flag
@@ -281,7 +281,7 @@ internal struct Context {
     with(outer: nil).unlateralized()
   }
 
-  /// A copy of this context with the LATERAL-body flag CLEARED — the reset
+  /// A copy of this context with the LATERAL-body flag cleared — the reset
   /// `uncorrelated()`/`body(_:)` fold in, and the seam a nested ordinary
   /// subquery within a lateral body compiles under, so a body that must NOT
   /// correlate against the caller (a view or a non-lateral derived table) does

--- a/Sources/SQLEngine/Decorrelation.swift
+++ b/Sources/SQLEngine/Decorrelation.swift
@@ -5,9 +5,9 @@ extension Catalog where Self: ~Escapable {
   // MARK: - Decorrelation
 
   /// Rewrites a decorrelatable correlated CROSS APPLY into a set-based inner
-  /// join — a behaviour-preserving LOGICAL pass run AFTER `pushdown` (so each
+  /// join — a behaviour-preserving logical pass run after `pushdown` (so each
   /// `.apply` body is already in `project`/`select`/`scan` canonical form) and
-  /// BEFORE `optimise`/`nest` (so the emitted `.select`-over-`.product` folds
+  /// before `optimise`/`nest` (so the emitted `.select`-over-`.product` folds
   /// to a `.join` for free). It recurses the tree structurally, leaving every
   /// node but a decorrelatable `.apply` untouched, so a plan with none is
   /// returned unchanged.
@@ -15,11 +15,11 @@ extension Catalog where Self: ~Escapable {
   /// At each `.apply(left, key, correlation, ordinals, on, kind: .inner)` it
   /// consults the pre-compiled body plan (`context.subqueries.plan(key,
   /// correlation)`, the SAME lookup `executed` uses) and, when the body is a
-  /// simple filter+project over a single base-relation scan with a purely EQUI
+  /// simple filter+project over a single base-relation scan with a purely equi
   /// correlation, rewrites the apply to `project(over left ++ taken,
   /// select(on'', product(left, scan(R))))` — the exact output geometry the
   /// correlated `applied` produces (each left row multiplied by its match
-  /// count, an unmatched left row DROPPED), which the subsequent `nest` folds
+  /// count, an unmatched left row dropped), which the subsequent `nest` folds
   /// to a hash equi-join. On ANY doubt (a non-`.inner` kind, a
   /// non-decorrelatable body, a non-equi/expression correlation, an unsafe body
   /// term, or a taken-ordinals geometry it cannot map soundly) it leaves the
@@ -28,13 +28,13 @@ extension Catalog where Self: ~Escapable {
   internal borrowing func decorrelate(_ plan: Plan, _ context: Context)
       throws(SQLError) -> Plan {
     switch plan {
-    // `.empty` is produced only by `optimise`, which runs AFTER decorrelation,
+    // `.empty` is produced only by `optimise`, which runs after decorrelation,
     // so a plan reaching here never carries one; the arm is a structural
     // no-op keeping the switch exhaustive.
     case .single, .empty, .scan, .join:
       return plan
     case let .derived(name, plan, ordinals, seek):
-      // A view body is compiled and re-executed under its OWN scope; its
+      // A view body is compiled and re-executed under its own scope; its
       // correlated applies (if any) decorrelate when it is derived/optimised,
       // not here. Recurse structurally only.
       return try .derived(name: name, plan: decorrelate(plan, context),
@@ -51,7 +51,7 @@ extension Catalog where Self: ~Escapable {
     case let .project(terms, source):
       // Decorrelate the source first (a nested apply/exists/IN inside it still
       // rewrites), then attempt to lift each top-level correlated scalar
-      // `.subquery` TERM of this projection into its own LEFT join. On any
+      // `.subquery` term of this projection into its own LEFT join. On any
       // doubt the whole `.project` is left correlated (`decorrelated(scalars:)`
       // returns `nil`), so execution is unchanged.
       let source = try decorrelate(source, context)
@@ -66,7 +66,7 @@ extension Catalog where Self: ~Escapable {
       return try .outer(decorrelate(left, context), decorrelate(right, context),
                         on: on, kind: kind)
     case let .semijoin(left, right, on, anti):
-      // A semijoin this pass ITSELF produced (from a decorrelated `EXISTS`);
+      // A semijoin this pass itself produced (from a decorrelated `EXISTS`);
       // recurse structurally into both sides so a nested correlated apply
       // inside either still rewrites, preserving the node.
       return try .semijoin(decorrelate(left, context),
@@ -111,7 +111,7 @@ extension Catalog where Self: ~Escapable {
   /// with every projection term a bare slot (G3: a filter+project over a single
   /// base relation, no aggregate/limit/distinct/setop/nested apply — none of
   /// which wear this exact shape), the correlation must be all `.slot` sources
-  /// (no `.bound` grandparent), and the `where` conjuncts must be EXACTLY one
+  /// (no `.bound` grandparent), and the `where` conjuncts must be exactly one
   /// equi correlation `correlate.inner = :param` (or the reversed order) plus
   /// safe, non-parameterised, single-relation local predicates `p_R` (G4: an
   /// unsafe or parameterised residual — a non-equi/expression correlation —
@@ -120,18 +120,18 @@ extension Catalog where Self: ~Escapable {
   /// shape).
   ///
   /// **`.inner` (CROSS APPLY).** The rewrite lays the body scan's referenced
-  /// ordinals after the left (a `.product`), then stacks TWO selects: an INNER
-  /// select carrying the WHOLE body WHERE (the correlation equality
+  /// ordinals after the left (a `.product`), then stacks two selects: an INNER
+  /// select carrying the whole body WHERE (the correlation equality
   /// `.match(correlate.outer, base + correlate.inner)` AND the local residual
   /// `p_R`) and an OUTER select carrying the apply's `on` — the apply's `on`
   /// mapped from its `left ++ taken` space into this `left ++ scan` space. The
   /// `on` is kept
-  /// SEPARATE (not folded into the body residual's conjunction) so it is
+  /// separate (not folded into the body residual's conjunction) so it is
   /// evaluated ONLY on rows the body WHERE admitted: nested selects run
   /// bottom-up, restoring the correlated order (body WHERE → drop an UNKNOWN
   /// row → `on`), so an `on` that would throw on a row the body WHERE drops
   /// never fires — matching the correlated `applied` (which never reaches the
-  /// `on` for a dropped row). It then PROJECTS the result back to the apply's
+  /// `on` for a dropped row). It then projects the result back to the apply's
   /// `left ++ taken` geometry. The equi `.match` lets `nest`/`optimise` fold
   /// the product into a hash equi-join whose NULL-key drops and match-count
   /// multiplicity mirror the per-row re-execution.
@@ -139,15 +139,15 @@ extension Catalog where Self: ~Escapable {
   /// **`.left` (OUTER APPLY).** The rewrite is a LEFT `.outer` join
   /// `outer(left, scan(R), on: match(correlate.outer, base + correlate.inner)
   /// AND residual' AND on', kind: .left)`, projected back to the apply's
-  /// `left ++ taken` geometry. The `.outer` node's `on` GOVERNS matching and
+  /// `left ++ taken` geometry. The `.outer` node's `on` governs matching and
   /// NULL-extends an unmatched left row across the taken width — exactly OUTER
-  /// APPLY. UNLIKE the inner case the `on` CANNOT be split into a select above
+  /// APPLY. unlike the inner case the `on` cannot be split into a select above
   /// the join: the LEFT join's match/NULL-extension condition IS the whole
   /// `on`, so the correlation equality, the body residual, and the apply `on`
-  /// must fold into ONE predicate evaluated together per (L, R) pair. This
+  /// must fold into one predicate evaluated together per (L, R) pair. This
   /// engine evaluates an `AND`'s RHS even for an UNKNOWN LHS, so folding an
-  /// UNSAFE apply `on` beside a nullable body residual would raise a throw for
-  /// a pair the correlated body WHERE dropped. THEREFORE `.left` decorrelates
+  /// unsafe apply `on` beside a nullable body residual would raise a throw for
+  /// a pair the correlated body WHERE dropped. therefore `.left` decorrelates
   /// ONLY when the mapped apply `on` is `safe` (non-throwing) or provably
   /// constant-true (the common `ON 1 = 1`): evaluating a `safe` `on` for an
   /// UNKNOWN-residual pair cannot throw, so the fold is result- AND throw-
@@ -163,23 +163,23 @@ extension Catalog where Self: ~Escapable {
     guard case let .project(projection, .select(filter, leaf)) = body,
         case let .scan(name, scanOrdinals, nil) = leaf,
         let base = left.slots else { return nil }
-    // The scanned `name` must be a genuine BASE relation, not a BODY-LOCAL
-    // derived alias. When the lateral body declares its OWN derived table(s) —
+    // The scanned `name` must be a genuine base relation, not a body-local
+    // derived alias. When the lateral body declares its own derived table(s) —
     // `SELECT x FROM (SELECT k, x FROM S) AS e WHERE …` — the compiled body
     // plan scans that alias (`e`), which the correlated `applied` executor
-    // MATERIALISES per execution under the body's revealed overlay. The
+    // materialises per execution under the body's revealed overlay. The
     // caller-level checks below (a CTE/store overlay entry, a view) do not see
     // `e`, so it would pass as a base relation and the rewrite would relay a
     // caller-level `scan("e")` that faults `.relation("e")` or, worse, binds a
-    // same-named OUTER base table and returns WRONG rows. Bail whenever the
-    // body query declares any derived tables of its own — the SAME
+    // same-named OUTER base table and returns wrong rows. Bail whenever the
+    // body query declares any derived tables of its own — the same
     // `collect(derived:)` the augment path uses over the body select — and
     // leave the apply correlated.
     var derivations = Array<(String, Query, Array<String>)>()
     key.query.collect(derived: &derivations)
     guard derivations.isEmpty else { return nil }
-    // The scan must also name a genuine BASE relation, not a CTE/store overlay
-    // entry or a view. A CTE `.scan` binds under the body's OWN revealed
+    // The scan must also name a genuine base relation, not a CTE/store overlay
+    // entry or a view. A CTE `.scan` binds under the body's own revealed
     // overlay (a caller derived alias of the same name shadowed) that the
     // `applied` executor restores per run; relaid into a caller-level join it
     // would re-resolve the name against the OUTER overlay and bind the wrong
@@ -197,7 +197,7 @@ extension Catalog where Self: ~Escapable {
     }
     // A taken ordinal at or beyond the projection's width is the body's virtual
     // `Id` — a LATERAL-only per-left-row row number the `applied` executor
-    // derives from THIS left row's output through a `RelationInstance`, which a
+    // derives from this left row's output through a `RelationInstance`, which a
     // set-based join (numbering over the whole relation) cannot reproduce.
     // Leave it correlated.
     guard ordinals.allSatisfy({ projection.indices.contains($0) }) else {
@@ -211,7 +211,7 @@ extension Catalog where Self: ~Escapable {
             correlation.first.map({ (name: $0.key, source: $0.value) })
         else { return nil }
 
-    // Split the body WHERE into the ONE equi correlation conjunct
+    // Split the body WHERE into the one equi correlation conjunct
     // (`correlate.inner = :parameter`) and the local residual `p_R`. Any other
     // parameterised conjunct is a non-equi/expression correlation — bail. Every
     // residual must be safe (G4: a throwing body term could fire for an inner
@@ -250,8 +250,8 @@ extension Catalog where Self: ~Escapable {
 
     switch kind {
     case .inner:
-      // The inner gate carries the WHOLE body WHERE (match key + residual) and
-      // NOTHING else — the apply's `on` is kept in a SEPARATE select ABOVE the
+      // The inner gate carries the whole body WHERE (match key + residual) and
+      // nothing else — the apply's `on` is kept in a separate select above the
       // body-filtered join rather than folded into the residual conjunction.
       // The correlated `applied` evaluates the body WHERE FIRST (dropping an
       // UNKNOWN row — a NULL-flag child) and only THEN the `on`, so an `on`
@@ -268,15 +268,15 @@ extension Catalog where Self: ~Escapable {
       let gated = mapped.constant == true ? filtered : .select(mapped, filtered)
       return .project(terms, gated)
     case .left:
-      // OUTER APPLY: a LEFT `.outer` join whose `on` GOVERNS matching and
-      // NULL-extends an unmatched left row. UNLIKE the inner case the `on`
+      // OUTER APPLY: a LEFT `.outer` join whose `on` governs matching and
+      // NULL-extends an unmatched left row. unlike the inner case the `on`
       // cannot be split into a select above the join — the LEFT join's match/
       // NULL-extension condition IS the whole `on`, so correlation + residual +
-      // apply `on` must be ONE predicate evaluated together per (L, R) pair.
+      // apply `on` must be one predicate evaluated together per (L, R) pair.
       //
-      // SAFE-`on` GATE (throw-equivalence): this engine evaluates an `AND`'s
+      // safe-`on` gate (throw-equivalence): this engine evaluates an `AND`'s
       // RHS even for an UNKNOWN LHS, so if the body residual can be UNKNOWN and
-      // the apply `on` is UNSAFE, folding them raises a throw for a pair the
+      // the apply `on` is unsafe, folding them raises a throw for a pair the
       // correlated body WHERE dropped at its own filter — a spurious throw the
       // OUTER APPLY never hits. Only decorrelate `.left` when the mapped `on`
       // is `safe` (non-throwing) or provably constant-true (`ON 1 = 1`): a
@@ -302,40 +302,40 @@ extension Catalog where Self: ~Escapable {
   /// top-level correlated `EXISTS`/`NOT EXISTS` or correlated `IN (Q)`
   /// conjuncts over an already-decorrelated `source`, or `nil` when no conjunct
   /// is decorrelatable — in which case the caller leaves the `.select`
-  /// correlated (conservative default). EVERY decorrelatable `EXISTS` becomes
-  /// its own SEMIJOIN (a `NOT EXISTS` an ANTI-join), and every decorrelatable
-  /// correlated `IN (Q)` a SEMIJOIN whose `on` ALSO carries the membership
-  /// equality; the semijoins are STACKED over the source, and the conjuncts NOT
-  /// lifted are kept in a `.select` ABOVE the stack.
+  /// correlated (conservative default). every decorrelatable `EXISTS` becomes
+  /// its own semijoin (a `NOT EXISTS` an anti-join), and every decorrelatable
+  /// correlated `IN (Q)` a semijoin whose `on` also carries the membership
+  /// equality; the semijoins are stacked over the source, and the conjuncts NOT
+  /// lifted are kept in a `.select` above the stack.
   ///
   /// An `EXISTS` is a two-valued existence test — TRUE iff the body yields a
   /// row, never UNKNOWN — so a semijoin is result-equivalent to the per-row
-  /// re-execution the `exists` evaluator does, WITHOUT the NOT-IN NULL trap (a
-  /// NULL correlation key is simply "no match", dropping a SEMI left row and
-  /// keeping an ANTI one). A POSITIVE correlated `IN (Q)` is likewise a
+  /// re-execution the `exists` evaluator does, without the NOT-IN NULL trap (a
+  /// NULL correlation key is simply "no match", dropping a semi left row and
+  /// keeping an anti one). A positive correlated `IN (Q)` is likewise a
   /// per-row test — `operand IN (Q)` is TRUE iff some inner row's projected
   /// column equals `operand` — so a semijoin whose `on` conjoins the
   /// correlation key with the membership equality `operand = projected` is
   /// result-equivalent (a NULL `operand` or projected element yields no
-  /// definite equality, so the row simply does not match — correct for POSITIVE
+  /// definite equality, so the row simply does not match — correct for positive
   /// IN, where the UNKNOWN-vs-FALSE distinction only bites NOT IN). `NOT IN`
-  /// (`negated`) is DEFERRED — it carries that NULL trap — and stays
-  /// correlated. The body must be the SAME simple filter+project over a single
+  /// (`negated`) is deferred — it carries that NULL trap — and stays
+  /// correlated. The body must be the same simple filter+project over a single
   /// base-relation scan the CROSS APPLY recogniser requires; for EXISTS the
-  /// projection CONTENT is irrelevant (existence only), while for `IN (Q)` the
-  /// projection must be EXACTLY ONE bare-slot term (the IN column). The
+  /// projection content is irrelevant (existence only), while for `IN (Q)` the
+  /// projection must be exactly one bare-slot term (the IN column). The
   /// correlation must be a single `.slot` source and the body WHERE must split
-  /// into EXACTLY one equi correlation conjunct plus safe, non-parameterised
+  /// into exactly one equi correlation conjunct plus safe, non-parameterised
   /// residual conjuncts `p_R` (an unsafe or parameterised residual — a non-equi
   /// correlation — bails, G3/G4).
   ///
-  /// **SIBLING THROW-VISIBILITY (load-bearing).** A semijoin DROPS left rows
-  /// (SEMI drops non-matching rows, ANTI drops matching rows), so a sibling
-  /// conjunct of the enclosing `AND` that is UNSAFE could be SKIPPED for a row
+  /// **sibling throw-visibility (load-bearing).** A semijoin drops left rows
+  /// (semi drops non-matching rows, anti drops matching rows), so a sibling
+  /// conjunct of the enclosing `AND` that is unsafe could be skipped for a row
   /// the semijoin drops — suppressing a throw the correlated `.select` raises
   /// (it evaluates every conjunct of the `AND` for the row before the row is
   /// dropped). This is the throw-visibility class the OUTER APPLY safe gate
-  /// guards. THEREFORE lifting proceeds ONLY when EVERY conjunct NOT lifted
+  /// guards. therefore lifting proceeds ONLY when every conjunct NOT lifted
   /// into a semijoin is `safe`; a decorrelatable exists/IN body is itself safe
   /// (a filter+project over one base scan with safe residuals, and an IN
   /// operand gated `safe` before lifting), so the lifted conjuncts add no
@@ -346,7 +346,7 @@ extension Catalog where Self: ~Escapable {
   ///
   /// The decorrelatable exists/IN conjuncts are ALL lifted, each into its own
   /// semijoin stacked over the source; the rest (a non-decorrelatable
-  /// exists/IN, a `NOT IN`, or another predicate) are the SIBLINGS the
+  /// exists/IN, a `NOT IN`, or another predicate) are the siblings the
   /// throw-visibility guard tests, kept in the `.select` above the stack. Each
   /// semijoin's output width is the source's, so every stacked semijoin sees
   /// the same source slots — the correlation-key ordinals stay valid through
@@ -354,9 +354,9 @@ extension Catalog where Self: ~Escapable {
   /// those slots.
   private borrowing func decorrelated(semijoins filter: Filter, _ source: Plan,
                                       _ context: Context) -> Plan? {
-    // Lift EVERY decorrelatable exists/IN conjunct into its own semijoin
-    // STACKED over `source`; a conjunct that is not one is kept in `remaining`
-    // (both the SIBLINGS the throw-visibility guard tests and the residual
+    // Lift every decorrelatable exists/IN conjunct into its own semijoin
+    // stacked over `source`; a conjunct that is not one is kept in `remaining`
+    // (both the siblings the throw-visibility guard tests and the residual
     // select above the stack).
     var node = source
     var remaining = Array<Filter>()
@@ -370,13 +370,13 @@ extension Catalog where Self: ~Escapable {
         lifted = true
         continue
       }
-      // A POSITIVE correlated `IN (Q)`: the operand rides the semijoin `on` as
-      // the membership equality. `NOT IN` (`negated`) is DEFERRED (its NULL
-      // trap is not a plain anti-join) and an UNCORRELATED IN (an empty
+      // A positive correlated `IN (Q)`: the operand rides the semijoin `on` as
+      // the membership equality. `NOT IN` (`negated`) is deferred (its NULL
+      // trap is not a plain anti-join) and an uncorrelated IN (an empty
       // correlation) stays as is — both fall through to `remaining`. The
       // operand must be `safe`: a per-outer-row `operand` throw fires even when
       // the inner is empty, but a semijoin never evaluates `on` for a left row
-      // with no right rows, so an unsafe operand would be SUPPRESSED — leave it
+      // with no right rows, so an unsafe operand would be suppressed — leave it
       // correlated.
       if case let .within(operand, key, correlation, false) = conjunct,
           !correlation.isEmpty, operand.safe,
@@ -390,43 +390,43 @@ extension Catalog where Self: ~Escapable {
       remaining.append(conjunct)
     }
     guard lifted else { return nil }
-    // SIBLING THROW-VISIBILITY: every conjunct NOT lifted into a semijoin must
+    // sibling throw-visibility: every conjunct NOT lifted into a semijoin must
     // be safe — a row a semijoin drops could otherwise suppress a throw the
     // correlated select raises for it. A non-decorrelatable exists/IN (or a
     // deferred `NOT IN`) is itself unsafe, so it (conservatively) blocks all
     // lifting here.
     guard remaining.allSatisfy(\.safe) else { return nil }
-    // Keep the remaining conjuncts in a `.select` ABOVE the stack. Each
+    // Keep the remaining conjuncts in a `.select` above the stack. Each
     // semijoin's width == the source's, so they and everything above still
     // address the same slots.
     return remaining.conjunction.map { .select($0, node) } ?? node
   }
 
   /// The `.semijoin` node for a correlated `EXISTS`/`NOT EXISTS` body — or a
-  /// POSITIVE correlated `IN (Q)` body when `membership` is the IN operand —
-  /// over `left`, or `nil` when the `body` is not decorrelatable — the SAME
-  /// guards the CROSS APPLY recogniser applies. `negated` selects the ANTI
+  /// positive correlated `IN (Q)` body when `membership` is the IN operand —
+  /// over `left`, or `nil` when the `body` is not decorrelatable — the same
+  /// guards the CROSS APPLY recogniser applies. `negated` selects the anti
   /// sense (only ever `false` for the IN path, `NOT IN` being deferred).
   ///
   /// The body must be `project(projection, select(where, scan(R, _, nil)))`
   /// with no body-local derived table (the body-local hazard), `R` a genuine
-  /// BASE relation (not a CTE/store overlay entry or a view), a single `.slot`
-  /// correlation source, and a `where` splitting into EXACTLY one equi
+  /// base relation (not a CTE/store overlay entry or a view), a single `.slot`
+  /// correlation source, and a `where` splitting into exactly one equi
   /// correlation conjunct plus safe, non-parameterised residual conjuncts. The
   /// correlation equality becomes a straddling `.match` (the executor's hash
   /// key), the residual shifts into combined `left ++ scan` space alongside.
   ///
-  /// For EXISTS (`membership == nil`) the projection CONTENT is irrelevant (a
+  /// For EXISTS (`membership == nil`) the projection content is irrelevant (a
   /// semijoin tests existence, taking no body column), so `on` is the
   /// correlation match AND the residual. For `IN (Q)` (`membership` the
-  /// operand) the projection must be EXACTLY ONE bare `.slot` term — the IN
+  /// operand) the projection must be exactly one bare `.slot` term — the IN
   /// column — else the shape is not decorrelatable and this bails. The
   /// membership equality `operand = .slot(base + projected)` conjoins into `on`
-  /// AFTER the correlation match (so `equikey` still picks the correlation as
+  /// after the correlation match (so `equikey` still picks the correlation as
   /// the hash key and the membership rides the whole-`on` confirm): a left row
   /// survives iff some inner row equi-matches the key AND its projected column
   /// equals the operand AND the residual holds. The `operand` addresses the
-  /// SOURCE's slots `0 ..< base`, unchanged in combined space, so used AS-IS.
+  /// source's slots `0 ..< base`, unchanged in combined space, so used AS-IS.
   private borrowing func semijoin(_ left: Plan, _ body: Plan, _ key: Subkey,
                                   _ correlation: Correlation, _ negated: Bool,
                                   membership operand: Term?,
@@ -435,16 +435,16 @@ extension Catalog where Self: ~Escapable {
         case let .scan(name, scanOrdinals, nil) = leaf,
         let base = left.slots else { return nil }
     // No body-local derived table: its per-execution alias cannot be relaid as
-    // a caller-level scan — the SAME hazard the CROSS APPLY recogniser guards.
+    // a caller-level scan — the same hazard the CROSS APPLY recogniser guards.
     var derivations = Array<(String, Query, Array<String>)>()
     key.query.collect(derived: &derivations)
     guard derivations.isEmpty else { return nil }
-    // The scan must name a genuine BASE relation, not a CTE/store overlay entry
+    // The scan must name a genuine base relation, not a CTE/store overlay entry
     // or a view — a CTE/view `.scan` re-resolves against the wrong overlay when
     // relaid at the caller level. Leave either correlated.
     guard context.relations[name.lowercased()] == nil,
         resolve(view: name) == nil else { return nil }
-    // For the IN path the projection must be EXACTLY ONE bare `.slot` — the IN
+    // For the IN path the projection must be exactly one bare `.slot` — the IN
     // column whose value the membership equality tests against the operand. A
     // multi-term or expression projection has no single membership slot, so it
     // is not decorrelatable; bail. The EXISTS path takes no body column, so its
@@ -462,7 +462,7 @@ extension Catalog where Self: ~Escapable {
             correlation.first.map({ (name: $0.key, source: $0.value) })
         else { return nil }
 
-    // Split the body WHERE into the ONE equi correlation conjunct
+    // Split the body WHERE into the one equi correlation conjunct
     // (`correlate.inner = :parameter`) and the local residual `p_R`. Any other
     // parameterised conjunct is a non-equi/expression correlation — bail. Every
     // residual must be safe (a throwing body term could fire for an inner
@@ -486,9 +486,9 @@ extension Catalog where Self: ~Escapable {
     let scan = Plan.scan(name: name, ordinals: scanOrdinals, seek: nil)
     let matched = Filter(match: outer, base + inner)
     let shifted = residual.map { $0.shifted(by: -base) }
-    // The IN membership equality `operand = projected` rides `on` AFTER the
+    // The IN membership equality `operand = projected` rides `on` after the
     // correlation match (so `equikey` still hashes on the correlation) and
-    // BEFORE the residual. The `operand` reads the source's slots `0 ..< base`,
+    // before the residual. The `operand` reads the source's slots `0 ..< base`,
     // unchanged in combined space, so it is used AS-IS; the projected body slot
     // shifts by `base`. For EXISTS there is no membership, so `on` is the match
     // plus the residual exactly as before (a `nil` operand ⇒ byte-identical).
@@ -502,37 +502,37 @@ extension Catalog where Self: ~Escapable {
     return .semijoin(left, scan, on: on, anti: negated)
   }
 
-  /// Lift every decorrelatable correlated scalar `.subquery` TERM of a
-  /// projection into its OWN LEFT `.outer` join STACKED under the projection,
+  /// Lift every decorrelatable correlated scalar `.subquery` term of a
+  /// projection into its own LEFT `.outer` join stacked under the projection,
   /// replacing the term with a coercion-preserving read of the joined column,
-  /// or `nil` when NO term is liftable — in which case the caller leaves the
+  /// or `nil` when no term is liftable — in which case the caller leaves the
   /// `.project` correlated (conservative default). A correlated scalar subquery
   /// `(SELECT v FROM R WHERE R.Id = T.fk [AND p_R])` today re-executes per
-  /// outer row; over the UNIQUE virtual `Id` key each left row matches AT MOST
-  /// ONE `R` row (a residual `p_R` can only drop the single candidate), so it
+  /// outer row; over the unique virtual `Id` key each left row matches at most
+  /// one `R` row (a residual `p_R` can only drop the single candidate), so it
   /// becomes a plain LEFT join reading `v` from the joined column.
   ///
-  /// **UNIQUENESS (load-bearing).** `join(scalar:)` decorrelates ONLY when the
+  /// **uniqueness (load-bearing).** `join(scalar:)` decorrelates ONLY when the
   /// equi correlation's inner key is the relation's virtual `Id`, at ordinal
-  /// EXACTLY `== width` (a 1-based unique row index). A non-`Id` key (an owner
+  /// exactly `== width` (a 1-based unique row index). A non-`Id` key (an owner
   /// foreign key or a coded-index key at an ordinal `> width`, or a real column
   /// `< width`) is NOT unique — many rows share it — so admitting it would
-  /// silently COLLAPSE many matches to one. The at-most-one match makes the
+  /// silently collapse many matches to one. The at-most-one match makes the
   /// `>1` cardinality throw impossible, so the LEFT join reproduces it without
   /// a MIN aggregate (which would materialise-and-group all of `R` and could
   /// throw for a group no left row reaches).
   ///
-  /// **NO SIBLING THROW HAZARD.** Unlike the semijoin/anti-join lifts (which
-  /// DROP left rows), a LEFT join drops NOTHING — every left row is emitted
-  /// exactly once — so a throwing SIBLING projection term is evaluated on
+  /// **no sibling throw hazard.** Unlike the semijoin/anti-join lifts (which
+  /// DROP left rows), a LEFT join drops nothing — every left row is emitted
+  /// exactly once — so a throwing sibling projection term is evaluated on
   /// exactly the same rows it was correlated; nothing is suppressed. The body
   /// residual is gated `safe` and the unique key makes the cardinality throw
   /// impossible, so the join reads `R` once introducing no new throw. Hence no
   /// safe-gate over the siblings is needed.
   ///
-  /// Each `.outer` appends `R`'s ordinals AFTER the running node, never
+  /// Each `.outer` appends `R`'s ordinals after the running node, never
   /// shifting slots `0 ..< base`, so an unreplaced projection term keeps its
-  /// ORIGINAL source slot verbatim and the j-th lifted scalar reads its joined
+  /// original source slot verbatim and the j-th lifted scalar reads its joined
   /// `v` at `base_j + vSlot_j` (the running slot count before that join plus
   /// `v`'s combined-space slot). The final `.project` sits atop the whole stack
   /// and re-selects, discarding the extra right columns, so the output geometry
@@ -552,11 +552,11 @@ extension Catalog where Self: ~Escapable {
                                    context)
         else { continue }
       node = outer
-      // COERCION-PRESERVING: `.coalesce([.slot(slot)], type)` applies exactly
+      // coercion-preserving: `.coalesce([.slot(slot)], type)` applies exactly
       // `Value.coerced(to: type)` to a non-NULL cell and passes NULL through —
       // byte-identical to `scalar()`'s `(value ?? .null).coerced(to: type)`. A
       // raw `.slot` would DROP the coercion (a `.double`-typed scalar over an
-      // `.integer` cell); a `.cast` is WRONG (it faults/truncates rather than
+      // `.integer` cell); a `.cast` is wrong (it faults/truncates rather than
       // widens). Use `.coalesce`.
       projected[position] = .coalesce([.slot(slot)], type: type)
       base = node.slots ?? base       // width grew by R's ordinals
@@ -568,17 +568,17 @@ extension Catalog where Self: ~Escapable {
 
   /// The LEFT `.outer` join and the combined-space slot of the joined value `v`
   /// for a correlated scalar `.subquery` body over `left`, or `nil` when the
-  /// `body` is not decorrelatable — the SAME guards the semijoin recogniser
-  /// applies PLUS the unique-`Id`-key guard.
+  /// `body` is not decorrelatable — the same guards the semijoin recogniser
+  /// applies plus the unique-`Id`-key guard.
   ///
   /// The body must be `project(projection, select(where, scan(R, _, nil)))`
-  /// with the projection EXACTLY ONE bare `.slot(v)` (the scalar's column), no
-  /// body-local derived table, `R` a genuine BASE relation, a single `.slot`
-  /// correlation source, and a `where` splitting into EXACTLY one equi
+  /// with the projection exactly one bare `.slot(v)` (the scalar's column), no
+  /// body-local derived table, `R` a genuine base relation, a single `.slot`
+  /// correlation source, and a `where` splitting into exactly one equi
   /// correlation conjunct plus safe, non-parameterised residual conjuncts
   /// `p_R`. The equi conjunct's inner scan slot must map (through the scan's
   /// referenced ordinals) to the relation ordinal `== width` AND that
-  /// width-ordinal virtual (`virtuals.first`) must be the UNIQUE `Id`, and ONLY
+  /// width-ordinal virtual (`virtuals.first`) must be the unique `Id`, and ONLY
   /// it — a non-`Id` first virtual, which the `Table.virtuals` contract
   /// permits, is not unique and must stay correlated. The correlation match
   /// becomes a straddling
@@ -591,16 +591,16 @@ extension Catalog where Self: ~Escapable {
         case let .scan(name, scanOrdinals, nil) = leaf,
         left.slots == base else { return nil }
     // No body-local derived table: its per-execution alias cannot be relaid as
-    // a caller-level scan — the SAME hazard the semijoin recogniser guards.
+    // a caller-level scan — the same hazard the semijoin recogniser guards.
     var derivations = Array<(String, Query, Array<String>)>()
     key.query.collect(derived: &derivations)
     guard derivations.isEmpty else { return nil }
-    // The scan must name a genuine BASE relation, not a CTE/store overlay entry
+    // The scan must name a genuine base relation, not a CTE/store overlay entry
     // or a view — a CTE/view `.scan` re-resolves against the wrong overlay when
     // relaid at the caller level. Leave either correlated.
     guard context.relations[name.lowercased()] == nil,
         resolve(view: name) == nil else { return nil }
-    // The projection must be EXACTLY ONE bare `.slot(v)` — the scalar's column,
+    // The projection must be exactly one bare `.slot(v)` — the scalar's column,
     // whose joined value replaces the term. A multi-term or expression
     // projection has no single value slot, so it is not decorrelatable.
     guard projection.count == 1,
@@ -612,7 +612,7 @@ extension Catalog where Self: ~Escapable {
             correlation.first.map({ (name: $0.key, source: $0.value) })
         else { return nil }
 
-    // Split the body WHERE into the ONE equi correlation conjunct
+    // Split the body WHERE into the one equi correlation conjunct
     // (`correlate.inner = :parameter`) and the local residual `p_R`. Any other
     // parameterised conjunct is a non-equi/expression correlation — bail. Every
     // residual must be safe (a throwing body term could fire for an inner row
@@ -628,7 +628,7 @@ extension Catalog where Self: ~Escapable {
       residual.append(conjunct)
     }
     guard let inner else { return nil }
-    // UNIQUENESS GUARD: the equi conjunct's inner scan slot must map to the
+    // uniqueness guard: the equi conjunct's inner scan slot must map to the
     // relation ordinal `== width` AND that width-ordinal virtual must be the
     // unique `Id` — a 1-based unique row index, and ONLY it. An ordinal `>
     // width` is another (non-unique) virtual; an ordinal `< width` is a real
@@ -652,7 +652,7 @@ extension Catalog where Self: ~Escapable {
     let matched = Filter(match: outer, base + inner)
     let shifted = residual.map { $0.shifted(by: -base) }
     let on = ([matched] + shifted).conjunction ?? matched
-    // A unique-`Id` key matches AT MOST ONE R row, so a plain LEFT join reads
+    // A unique-`Id` key matches at most one R row, so a plain LEFT join reads
     // `v` from the joined column: an unmatched left row NULL-extends (the empty
     // → NULL of the correlated scalar), a matched one reads its lone cell. `v`
     // lands at `base + vSlot` in the combined `left ++ scan` space.
@@ -660,10 +660,10 @@ extension Catalog where Self: ~Escapable {
   }
 }
 
-/// The inner-key slot of an EQUI correlation conjunct `slot = :parameter` (in
+/// The inner-key slot of an equi correlation conjunct `slot = :parameter` (in
 /// either operand order), or `nil` when `conjunct` is not that shape — a
 /// comparison of a bare slot to the correlation `parameter` under `=`. A
-/// non-`=` comparison (a NON-equi correlation), a compound operand, or a
+/// non-`=` comparison (a non-equi correlation), a compound operand, or a
 /// different parameter is not an equi correlation key and leaves the conjunct
 /// to the residual test (which bails on it as a parameterised non-equi term).
 private func equated(_ conjunct: Filter, to parameter: String) -> Int? {

--- a/Sources/SQLEngine/Definition.swift
+++ b/Sources/SQLEngine/Definition.swift
@@ -7,12 +7,12 @@
 private let kDefinitionNamespace = "definition_schema"
 
 /// A base DEFINITION_SCHEMA relation the store serves — the raw metadata the
-/// engine builds by ENUMERATING a catalog. Each carries its column schema as
-/// (name, type) pairs — the ONE source the row build and the schema-only build
+/// engine builds by enumerating a catalog. Each carries its column schema as
+/// (name, type) pairs — the one source the row build and the schema-only build
 /// (`store(_:rows:)`) share, so name and type cannot drift.
 ///
 /// These are the actual store of metadata: the `INFORMATION_SCHEMA` relations
-/// are ordinary VIEWS over them, resolved by the engine's existing view
+/// are ordinary views over them, resolved by the engine's existing view
 /// machinery. The store holds each relation's portable shape, so a view is a
 /// plain column projection — the reshaping the grammar cannot yet express in
 /// SQL (NULL literals, a `CASE` mapping) lives in the builder here, and the
@@ -40,7 +40,7 @@ internal enum Definition {
   /// The relation's column types, in order.
   internal var types: Array<ValueType> { schema.map(\.type) }
 
-  /// The relation's column schema — its (name, type) pairs, the ONE source
+  /// The relation's column schema — its (name, type) pairs, the one source
   /// `names` and `types` (and the row and schema builders) read, so the two
   /// cannot drift.
   private var schema: Array<(name: String, type: ValueType)> {
@@ -62,9 +62,9 @@ extension View {
   /// their case-folded dotted name.
   ///
   /// Where `Routines.standard` seeds the built-in scalar functions, this seeds
-  /// the built-in VIEWS: the ISO `INFORMATION_SCHEMA` relations, each a stored
+  /// the built-in views: the ISO `INFORMATION_SCHEMA` relations, each a stored
   /// `SELECT` over the `DEFINITION_SCHEMA` store. `resolve(view:)` consults
-  /// these AFTER a catalog's own views and base tables, so a source that itself
+  /// these after a catalog's own views and base tables, so a source that itself
   /// defines `information_schema.tables` shadows the built-in — the same low
   /// precedence the store's overlay held. A built-in view's body names a
   /// `definition_schema.` relation, resolved through the same overlay a user
@@ -77,7 +77,7 @@ extension View {
   /// A view over the query `text`, parsing `text` to its `SELECT` and inferring
   /// the column names from its first arm's projection — the same rule
   /// `CREATE VIEW` applies without an explicit list, so the query alone names
-  /// the columns. It TRAPS if `text` is not a single `SELECT`, or names no
+  /// the columns. It traps if `text` is not a single `SELECT`, or names no
   /// inferable columns — for a caller with a known-good literal (the engine's
   /// built-in views, a test fixture); a consumer parsing untrusted SQL uses
   /// `Statement(parsing:)` and the memberwise initializer.
@@ -117,17 +117,17 @@ extension View {
 }
 
 /// The `DEFINITION_SCHEMA` metadata store — the ISO 9075-11 base relations,
-/// built on demand from any `Catalog` by ENUMERATING it.
+/// built on demand from any `Catalog` by enumerating it.
 ///
 /// A query may name a reserved `definition_schema.` relation
 /// (`definition_schema.tables`, `definition_schema.columns`) wherever it names
-/// a base table, and the engine answers it by ENUMERATING the catalog rather
+/// a base table, and the engine answers it by enumerating the catalog rather
 /// than reading a stored relation: `store(_:rows:)` walks the catalog's
 /// `relations()`/`views()` and each relation's schema and builds the named
 /// relation's rows as an escapable `RelationInstance`. It builds no cached
 /// state, so the engine resolves a `definition_schema.` name lazily, building
 /// only the one a query references. The portable `INFORMATION_SCHEMA`
-/// relations are ordinary VIEWS over these.
+/// relations are ordinary views over these.
 ///
 /// The store is dialect-neutral: it reads only the adapter surface every
 /// `Catalog` shares, so any source gets it for free. It is built in engine core
@@ -135,9 +135,9 @@ extension View {
 /// is internal to the engine.
 extension Catalog where Self: ~Escapable {
   /// The `RelationInstance` for the reserved `definition_schema.` `relation`,
-  /// built over this catalog. When `rows` is `true` the relation is ENUMERATED
+  /// built over this catalog. When `rows` is `true` the relation is enumerated
   /// into its rows — `store` walks the catalog's `relations()`/`views()` and
-  /// each relation's schema; when `false` it vends a SCHEMA-ONLY relation
+  /// each relation's schema; when `false` it vends a schema-ONLY relation
   /// (columns + types, no rows), exactly what a lazy system table's `schema()`
   /// would.
   ///
@@ -168,7 +168,7 @@ extension Catalog where Self: ~Escapable {
   /// consults for a reserved store relation, threaded onward as the working
   /// scope.
   ///
-  /// The store sits AFTER the common table expressions and BEFORE the base
+  /// The store sits after the common table expressions and before the base
   /// catalog: a `definition_schema.` name is added only when the overlay does
   /// not already bind it (a user relation may shadow the store), and the
   /// extended map is consulted first by every resolution phase (compile,
@@ -179,30 +179,30 @@ extension Catalog where Self: ~Escapable {
   /// as an ordinary unknown relation (`SQLError.relation`).
   ///
   /// `rows` selects the build: a run passes `true` for the enumerated rows; a
-  /// typing path passes `false` for the SCHEMA-ONLY sibling, so resolving a
+  /// typing path passes `false` for the schema-ONLY sibling, so resolving a
   /// view body's types never triggers the row build (a view over
   /// `definition_schema.columns` types without the builder re-entering itself).
   /// A store relation's row build types a view's scalar-call column through the
   /// context's `routines`.
   ///
-  /// The overlay also binds every DERIVED TABLE THIS query names in its own
+  /// The overlay also binds every derived TABLE this query names in its own
   /// FROM/JOIN — a `FROM (SELECT …) AS t` — under its alias as a
   /// `RelationInstance` so the FROM/JOIN resolves it exactly as it resolves a
   /// common table expression (the `ScopedRelations` path). It binds ONLY this
   /// query's own aliases, not a nested subquery's: `augment` runs at every
   /// query level (`run`, `compile`, `typecheck`, and `materialise` each
   /// augment the query they receive), so a subquery binds its own aliases in
-  /// its OWN scope. This SELECT-scopes derived tables — unlike a
+  /// its own scope. This SELECT-scopes derived tables — unlike a
   /// statement-scoped, uniquely-named CTE — so two sibling subqueries may reuse
-  /// an alias `t` without colliding, and this query's `t` SHADOWS an outer CTE
-  /// or derived table of the same name. A derived table is UNCORRELATED in this
+  /// an alias `t` without colliding, and this query's `t` shadows an outer CTE
+  /// or derived table of the same name. A derived table is uncorrelated in this
   /// cut: its inner query
-  /// materialises ONCE, against the overlay WITHOUT its own alias (base catalog
+  /// materialises once, against the overlay without its own alias (base catalog
   /// plus the store relations and CTEs in scope, NOT its sibling FROM items),
   /// so a reference to an outer or sibling column resolves as an unknown column
   /// — LATERAL is a later feature. `rows` selects the build the same as for the
   /// store: a run materialises the inner query's rows, a typing path resolves
-  /// its OUTPUT columns to a schema-only relation (no cursor) and validates the
+  /// its output columns to a schema-only relation (no cursor) and validates the
   /// inner body, so a derived table's alias types exactly as a run's would.
   borrowing func augment(_ context: Context, for query: Query, rows: Bool)
       throws(SQLError) -> Context {
@@ -218,33 +218,33 @@ extension Catalog where Self: ~Escapable {
     var derivations = Array<(String, Query, Array<String>)>()
     query.collect(derived: &derivations)
     if derivations.isEmpty { return context.scoping(augmented) }
-    // A derived table's alias sharing a RANGE NAME with another FROM/JOIN item
-    // in THIS SELECT's own scope collides: the alias-keyed overlay holds one
-    // binding under that name, so binding the derived rows would SHADOW the
+    // A derived table's alias sharing a range name with another FROM/JOIN item
+    // in this SELECT's own scope collides: the alias-keyed overlay holds one
+    // binding under that name, so binding the derived rows would shadow the
     // sibling — `FROM T JOIN (…) AS T` resolves the base `T` scan to the
     // derived rows, and `FROM (…) AS d JOIN (…) AS d` resolves both to the
-    // later's. A duplicate RELATION alias (`FROM T AS d JOIN S AS d`) instead
-    // leaves BOTH in scope, so a shared column is `SQLError.ambiguous` — reject
-    // the same way here rather than silently shadow, faulting the ALIAS
-    // ambiguous at BOTH the schema-only path and a run, BEFORE binding the
+    // later's. A duplicate relation alias (`FROM T AS d JOIN S AS d`) instead
+    // leaves both in scope, so a shared column is `SQLError.ambiguous` — reject
+    // the same way here rather than silently shadow, faulting the alias
+    // ambiguous at both the schema-only path and a run, before binding the
     // derived rows below (so the sibling is never shadowed). The collision is a
-    // range name TWO of THIS query's own FROM/JOIN items spell where one is a
+    // range name two of this query's own FROM/JOIN items spell where one is a
     // derived alias; a named-vs-named duplicate (no derived alias) stays the
-    // lazy per-reference ambiguity. This query's own ranges are its OWN scope:
+    // lazy per-reference ambiguity. This query's own ranges are its own scope:
     // `collect(ranges:)`, `collect(sources:)`, and `collect(derived:)` all
     // stop at a `SELECT`, so a nested subquery's, a sibling subquery's, or a
-    // set-operation arm's same-named alias (a DIFFERENT SELECT's ranges) is
-    // unaffected, and a derived alias equal to an ENCLOSING query's relation is
+    // set-operation arm's same-named alias (a different SELECT's ranges) is
+    // unaffected, and a derived alias equal to an enclosing query's relation is
     // not a same-scope collision (it shadows per normal scoping).
     //
-    // The collision is counted against BOTH the EXPOSED range name and each
-    // named relation's SOURCE name. A qualified reference names an item by its
-    // range name (`alias ?? name`), but `resolve` LOOKS THE NAMED RELATION UP
-    // BY ITS SOURCE NAME in the overlay — so a derived alias `T` shadowing an
+    // The collision is counted against both the exposed range name and each
+    // named relation's source name. A qualified reference names an item by its
+    // range name (`alias ?? name`), but `resolve` looks the named relation up
+    // BY its source name in the overlay — so a derived alias `T` shadowing an
     // aliased base `T AS x` (exposed range `x`, source `T`) would bind the
     // derived rows under `T`, and the base scan for `T AS x` — keyed on `T` —
-    // would resolve to the DERIVED rows rather than the base table/CTE.
-    // Counting the source names too faults that alias BEFORE binding the
+    // would resolve to the derived rows rather than the base table/CTE.
+    // Counting the source names too faults that alias before binding the
     // derived rows, so `FROM T AS x JOIN (…) AS T` is rejected exactly as
     // `FROM T JOIN (…) AS T` is.
     var ranges = Array<String>()
@@ -259,7 +259,7 @@ extension Catalog where Self: ~Escapable {
       // >1 range: the derived alias equals another FROM/JOIN item's exposed
       // range name (a sibling derived alias, or an unaliased named relation).
       // A source-name match: the derived alias equals a named relation's
-      // SOURCE name (an aliased base `T AS x` whose exposed range is `x`) —
+      // source name (an aliased base `T AS x` whose exposed range is `x`) —
       // `resolve` keys that relation on `T`, so the derived `T` would capture
       // its scan.
       if counts[name, default: 0] > 1 || sources.contains(name) {
@@ -267,32 +267,32 @@ extension Catalog where Self: ~Escapable {
       }
     }
     // The scope every derived body resolves against: the enclosing scope with
-    // ALL derived layers REVEALED away, leaving the base (every CTE and store
+    // ALL derived layers revealed away, leaving the base (every CTE and store
     // relation). Revealing rather than a name blanket lets a self-named
-    // `(SELECT … FROM T) AS T` read the BASE `T` while a `WITH t … FROM (SELECT
-    // … FROM t) AS t` still reads the CTE `t`: the alias being DEFINED is in
-    // its derived layer this augment is BUILDING (not yet pushed), so it is out
+    // `(SELECT … FROM T) AS T` read the base `T` while a `WITH t … FROM (SELECT
+    // … FROM t) AS t` still reads the CTE `t`: the alias being defined is in
+    // its derived layer this augment is building (not yet pushed), so it is out
     // of scope in its own body, but a same-named CTE in the base is not.
-    // Revealing keeps a derived table UNCORRELATED/no-LATERAL — a sibling
+    // Revealing keeps a derived table uncorrelated/no-LATERAL — a sibling
     // `FROM` item lives in the layer being built, invisible to the revealed
     // base scope, so `FROM (…) AS a JOIN (SELECT v FROM a) AS b` faults `a`.
-    // `uncorrelated()` likewise CLEARS the enclosing correlation stack: a
-    // non-LATERAL derived body must NOT see an ENCLOSING query's row either, so
+    // `uncorrelated()` likewise clears the enclosing correlation stack: a
+    // non-LATERAL derived body must NOT see an enclosing query's row either, so
     // `… IN (SELECT x FROM (SELECT 1 AS x FROM S WHERE S.k = T.k) AS d)` faults
-    // on `T.k` — and CONSISTENTLY at both the strict schema pass and the
+    // on `T.k` — and consistently at both the strict schema pass and the
     // run, rather than the strict pass binding it while the lenient run records
-    // no correlation and then faults at execution (a schema/run MISMATCH).
+    // no correlation and then faults at execution (a schema/run mismatch).
     let scope = context.body(augmented.revealed())
     // The idempotent re-augment keys on the derivation IDENTITY, not the name.
     // The run→compile→typecheck chain each augments the query it receives, so
-    // the innermost derived layer may ALREADY bind THIS select's aliases to
-    // THIS select's derivations — the same query, materialised against the
+    // the innermost derived layer may already bind this select's aliases to
+    // this select's derivations — the same query, materialised against the
     // same revealed base scope. Skip re-materialising then (leave the layer as
     // is), so `augment` stays idempotent without re-resolving — and, on a run,
-    // a stateful body is not re-executed. A binding whose derivation DIFFERS
-    // (an ENCLOSING query's same-named derived table) is not this select's, so
-    // a fresh layer is materialised and pushed, SHADOWING the outer one — a
-    // nested subquery's `FROM t` reads ITS `t`. A self-named alias resolves the
+    // a stateful body is not re-executed. A binding whose derivation differs
+    // (an enclosing query's same-named derived table) is not this select's, so
+    // a fresh layer is materialised and pushed, shadowing the outer one — a
+    // nested subquery's `FROM t` reads its `t`. A self-named alias resolves the
     // base: the layer being pushed is not yet in scope when a body resolves.
     if derivations.allSatisfy({ augmented.derivation(of: $0.0.lowercased())
                                 == $0.1 }) {
@@ -300,13 +300,13 @@ extension Catalog where Self: ~Escapable {
     }
     // A derived table's optional `AS d(a, b)` column list renames its output
     // columns; thread it into `materialise` so the bound `RelationInstance`
-    // carries the RENAMED names — the same overlay both `resolve` and
+    // carries the renamed names — the same overlay both `resolve` and
     // `schema(of:)` read a derived table's schema back from, so the run and the
-    // schema-only paths see the renamed columns from ONE seam.
+    // schema-only paths see the renamed columns from one seam.
     // Materialise each alias's body against the revealed base scope (a
     // same-named CTE visible, the derived aliases being defined not), then push
-    // them as one derived layer that SHADOWS an outer CTE or derived alias of
-    // the same name in the scope THIS SELECT resolves its OWN references
+    // them as one derived layer that shadows an outer CTE or derived alias of
+    // the same name in the scope this SELECT resolves its own references
     // against (projection/WHERE/JOIN-ON/GROUP/HAVING).
     var layer = Dictionary<String, RelationInstance>()
     for (alias, inner, columns) in derivations {
@@ -316,8 +316,8 @@ extension Catalog where Self: ~Escapable {
     return context.scoping(augmented.pushing(layer))
   }
 
-  /// A DERIVED TABLE's `query` materialised into a `RelationInstance` bound
-  /// under its alias: its OUTPUT columns name the relation's columns (the ISO
+  /// A derived TABLE's `query` materialised into a `RelationInstance` bound
+  /// under its alias: its output columns name the relation's columns (the ISO
   /// rule — a derived table's columns are its inner query's output names),
   /// typed from the same output-schema walk a scalar subquery's width and a
   /// CTE's schema use. `rows` selects the build — a run captures the inner
@@ -326,16 +326,16 @@ extension Catalog where Self: ~Escapable {
   ///
   /// The inner query resolves against `context` (the base catalog plus the
   /// store relations and CTEs in scope), NOT its sibling FROM items. The OUTER
-  /// treatment is the CALLER's: a NON-LATERAL derived body's caller
-  /// (`augment`) enters through `context.body(…)`, CLEARING the correlation
+  /// treatment is the caller's: a non-LATERAL derived body's caller
+  /// (`augment`) enters through `context.body(…)`, clearing the correlation
   /// stack — so a reference to an outer or sibling column faults as an unknown
-  /// column (the derived table is UNCORRELATED); a LATERAL body's caller
-  /// (`lateral`) instead THREADS the preceding-FROM scope as `context.outer`,
+  /// column (the derived table is uncorrelated); a LATERAL body's caller
+  /// (`lateral`) instead threads the preceding-FROM scope as `context.outer`,
   /// so a correlated reference to a preceding relation resolves outward. This
-  /// derive is otherwise IDENTICAL for both — the same revealed-base overlay,
+  /// derive is otherwise identical for both — the same revealed-base overlay,
   /// output-schema walk, duplicate-column check, and `validate`-gated body
   /// type-check — so a lateral body inherits the CTE visibility and the
-  /// operand/function validation a non-lateral body gets. Its OWN derived
+  /// operand/function validation a non-lateral body gets. Its own derived
   /// tables (a `FROM (SELECT … FROM (…) AS x) AS y`) are augmented into `scope`
   /// FIRST — the schema derivation resolves `x` exactly as a run would — so the
   /// schema and run paths bind the same nested aliases before either reads the
@@ -343,7 +343,7 @@ extension Catalog where Self: ~Escapable {
   borrowing func materialise(_ query: Query, _ context: Context,
                              rows: Bool, columns renaming: Array<String> = [])
       throws(SQLError) -> RelationInstance {
-    // Bind the inner query's OWN derived tables (and store relations) before
+    // Bind the inner query's own derived tables (and store relations) before
     // deriving its schema — a run augments them recursively, so the schema
     // path must too, or a nested derived table's alias resolves as unknown
     // here while the run resolves it (schema/run parity). `visited` threads the
@@ -351,44 +351,44 @@ extension Catalog where Self: ~Escapable {
     // re-enters `columns`/`compile` with that view already visited, so the
     // resolver faults `.recursion` rather than recursing to a stack overflow.
     //
-    // This augment is SCHEMA-ONLY (`rows: false`), even on a run (`rows`
-    // `true`): it exists only to derive the inner query's OUTPUT schema
+    // This augment is schema-ONLY (`rows: false`), even on a run (`rows`
+    // `true`): it exists only to derive the inner query's output schema
     // (`columns(of:)` below), which reads name/schema bindings — NOT rows. The
     // single row materialisation is `run(query, context)`'s job below, and it
     // re-augments the body itself. Materialising here as well (`rows: true`)
-    // would EXECUTE a nested derived body once for the schema and AGAIN in that
+    // would execute a nested derived body once for the schema and again in that
     // run, so a stateful routine in a `FROM (SELECT tick() …)` nested a level
     // down would fire twice for one query.
     let scope = try augment(context, for: query, rows: false)
-    // The derived table's columns are its inner query's OUTPUT columns (the
-    // ISO rule): the NAMES from the FIRST arm's projection, the TYPES UNIFIED
+    // The derived table's columns are its inner query's output columns (the
+    // ISO rule): the names from the FIRST arm's projection, the types unified
     // across every set-operation arm (a mixed integer/double column widening to
     // `double`, matching the coerced values a run produces), each carrying its
     // `unconstrained` mask — resolved against the augmented `scope` so a
     // derived table over a CTE, a store relation, or a nested derived table
     // resolves.
-    // `resolved(query:in:)` REVEALS the base for the body's NESTED subqueries:
+    // `resolved(query:in:)` reveals the base for the body's nested subqueries:
     // `scope`'s derived layer shadows a CTE this body's own FROM alias names,
     // and revealing drops that layer, so a nested
     // `EXISTS (… FROM t)` reads the enclosing CTE `t` beneath — the layered
     // overlay never overwrote it, keeping schema/run parity without a
-    // pre-augment context. The caller's `validate` threads through, so a RUN's
-    // output discovery (`validate: false`) stays LENIENT — a nested derived
+    // pre-augment context. The caller's `validate` threads through, so a run's
+    // output discovery (`validate: false`) stays lenient — a nested derived
     // body's scalar a filter drops (`(SELECT Label + 1 …) … WHERE k = 0`) is
     // NOT eager-type-checked before execution, exactly as the non-derived path
     // never evaluates an unreached operand — while the strict schema path
     // (`validate: true`) still faults it.
     let derived = try resolved(query: query, in: scope)
-    // An explicit `AS d(a, b)` column list positionally RENAMES the derived
-    // table's inner output names, keeping each column's inferred TYPE and its
+    // An explicit `AS d(a, b)` column list positionally renames the derived
+    // table's inner output names, keeping each column's inferred type and its
     // `unconstrained` mask (the list names, the body types unified across the
     // arms), so `(SELECT x, y FROM T) AS d(a, b)` addresses them as `a`, `b`.
     // Its arity must match the inner output width (`SQLError.columns`, the
-    // CTE/view arity fault) — checked HERE, where the width is resolved, so a
+    // CTE/view arity fault) — checked here, where the width is resolved, so a
     // list over a `SELECT *` derived body is checked once its `*` expands.
     // Absent a list, the inner output names stand. Carrying the mask through
     // the same indexing means an all-NULL derived column (`SELECT
-    // NULLIF('a', 'a') AS x`) stays UNCONSTRAINED and unifies with any later
+    // NULLIF('a', 'a') AS x`) stays unconstrained and unifies with any later
     // typed set-operation arm order-independently: a wrapper must not change
     // set-op typing.
     let outputs: Array<ResolvedColumn>
@@ -403,12 +403,12 @@ extension Catalog where Self: ~Escapable {
                        unconstrained: derived[$0].unconstrained)
       }
     }
-    // A derived table's columns are its inner query's OUTPUT names (or the
+    // A derived table's columns are its inner query's output names (or the
     // explicit list above), so two same-named ones (`SELECT Id AS x, V AS x`,
     // or a `d(a, a)` list) leave the shadowed one unreachable through the alias
     // — exactly the case the Parser rejects for a view's or a CTE's inferred
-    // column list. Fault it the SAME way here (`SQLError.duplicate`, the
-    // "duplicate view column" fault), so it faults at BOTH the schema-only path
+    // column list. Fault it the same way here (`SQLError.duplicate`, the
+    // "duplicate view column" fault), so it faults at both the schema-only path
     // and a run rather than silently exposing the first `x`. A plain top-level
     // `SELECT Id AS x, V AS x` stays legal — the duplicate matters only where
     // the relation is named and its columns are addressed by that name (a view,
@@ -420,11 +420,11 @@ extension Catalog where Self: ~Escapable {
     }
     let captured: Array<Array<Value>>
     if rows {
-      // Resolve the inner body's relations against `visited` BEFORE running it,
+      // Resolve the inner body's relations against `visited` before running it,
       // so a body naming a view under resolution through this derived table
       // (`FROM (SELECT * FROM <self>) AS d`) faults `.recursion` rather than
-      // recursing to a stack overflow. `run` re-compiles the body WITHOUT the
-      // cyclic-view guard, so on the EXECUTE path (`derive` seeds `visited`
+      // recursing to a stack overflow. `run` re-compiles the body without the
+      // cyclic-view guard, so on the execute path (`derive` seeds `visited`
       // with the view under resolution) this guarded resolve fires — the
       // strict output discovery above no longer carries it once `validate` is
       // `false`. `validate: false` keeps it structural: the recursion guard
@@ -435,7 +435,7 @@ extension Catalog where Self: ~Escapable {
       captured = try run(query, context)
     } else {
       // The schema-only path reads no cursor. When `validate`, it still
-      // VALIDATES the whole inner body exactly as a run does — `compile`
+      // validates the whole inner body exactly as a run does — `compile`
       // resolves every arm's WHERE, joins, and projection and cross-checks a
       // UNION's arity; `typecheck` faults an ill-typed or unknown reachable
       // operand/call — so an invalid inner body (a bad column in a WHERE, or a
@@ -443,10 +443,10 @@ extension Catalog where Self: ~Escapable {
       // schema/run parity. The first-arm projection alone (`outputs` above)
       // would miss a fault outside it, advertising a schema for a derived table
       // that cannot run. When `validate` is `false` — a derive after a
-      // successful run — the body is TRUSTED, not compiled/type-checked: the
+      // successful run — the body is trusted, not compiled/type-checked: the
       // outer run already proved it runnable, and re-checking a reachable
       // operand a data-dependent filter never reached would fault a query that
-      // SUCCEEDED (`SELECT Name + 1 … WHERE Id = -1`), unlike the non-derived
+      // succeeded (`SELECT Name + 1 … WHERE Id = -1`), unlike the non-derived
       // path whose empty run never evaluates it.
       //
       // Compile/type-check from the revealed base `context` (idempotently
@@ -467,9 +467,9 @@ extension Catalog where Self: ~Escapable {
 
   /// `context` rescoped to the `definition_schema.` overlay a view's body
   /// resolves against — the reserved store relations the view `name` names in
-  /// its OWN query, each built over this catalog, the caller's CTEs DROPPED (an
+  /// its own query, each built over this catalog, the caller's CTEs dropped (an
   /// empty overlay when `name` is not a view or names none). It seeds the view
-  /// sub-plan's OPTIMISE so a view defined over a store relation resolves; it
+  /// sub-plan's optimise so a view defined over a store relation resolves; it
   /// never carries a caller's statement CTEs, so a view means what it was
   /// registered to mean. The routines and bindings ride through unchanged.
   ///
@@ -477,30 +477,30 @@ extension Catalog where Self: ~Escapable {
   /// view — so a built-in `information_schema.` view over the store re-resolves
   /// its own `definition_schema.` scan exactly as a user view would.
   ///
-  /// The augment is SCHEMA-ONLY (`rows: false`): the optimiser needs only
+  /// The augment is schema-ONLY (`rows: false`): the optimiser needs only
   /// name/schema bindings — it treats a store or derived alias as an unseekable
   /// materialised relation — NOT rows. Materialising here (`rows: true`) would
-  /// EXECUTE the view's derived-table bodies during optimisation, so a stateful
+  /// execute the view's derived-table bodies during optimisation, so a stateful
   /// or non-deterministic routine in a `FROM (SELECT tick() …)` would run once
-  /// at optimise and AGAIN at `derive`, double-consuming it. The single
+  /// at optimise and again at `derive`, double-consuming it. The single
   /// execution happens at `derive`/run.
   borrowing func overlay(_ name: String, _ context: Context)
       throws(SQLError) -> Context {
-    // `uncorrelated()` CLEARS the caller's correlation stack: a view body is
+    // `uncorrelated()` clears the caller's correlation stack: a view body is
     // resolved independently of its call site, so it must NOT correlate against
     // an enclosing row when the view is optimised from inside a correlated
     // subquery.
     let fresh = context.body([:])
     guard let view = resolve(view: name) else { return fresh }
-    // `validate: false` — this overlay is the OPTIMISER's schema-only view-body
-    // scope on the RUN path (`resolve`/`compile` already validated the body
+    // `validate: false` — this overlay is the optimiser's schema-only view-body
+    // scope on the run path (`resolve`/`compile` already validated the body
     // under the caller's `validate`), so a data-dependent-empty derived body
     // the view nests must not be re-type-checked and fault a run.
     return try augment(fresh.validating(false), for: view.query, rows: false)
   }
 
   /// The view named `name`, or `nil`, by the precedence a query name follows.
-  /// A USER view the catalog registers wins; a BASE relation of that name then
+  /// A user view the catalog registers wins; a base relation of that name then
   /// shadows a built-in `information_schema.` view (so a source that vends its
   /// own `information_schema.tables` stays reachable, and `SELECT *` reads its
   /// rows); the engine-provided `View.standard` view answers only when nothing
@@ -515,7 +515,7 @@ extension Catalog where Self: ~Escapable {
   /// the store does not shadow, then each built-in `View.standard` view a user
   /// view or base relation does not shadow (the precedence `resolve(view:)`
   /// applies). The metadata builders enumerate these so a consumer discovers
-  /// EVERY queryable view — the engine-provided `information_schema.` views are
+  /// every queryable view — the engine-provided `information_schema.` views are
   /// resolvable through `resolve(view:)`, so they belong in the catalog
   /// metadata alongside a user's own. A name resolves to its `View` with
   /// `resolve(view:)`.
@@ -592,21 +592,21 @@ extension Catalog where Self: ~Escapable {
     }
     for name in listable() {
       guard let view = resolve(view: name) else { continue }
-      // List a view's columns only if its WHOLE body validates — exactly the
+      // List a view's columns only if its whole body validates — exactly the
       // resolution a run performs, so a view a `SELECT *` could not run is not
       // advertised as queryable metadata. Validate via the REAL `compile`
       // rather than a resolve-only reimplementation of it: a hand-rolled
       // validator drifts from compile (it missed a scalar call's arguments,
       // advertising `SELECT BITAND(Missing, 1)` though the run faults on
       // `Missing`), whereas `compile` resolves every arm's WHERE, joins, GROUP
-      // BY, HAVING, ORDER BY, projection — INCLUDING each scalar call's
-      // arguments — and a UNION's arity. The view body compiles over its OWN
-      // `definition_schema.` overlay, built SCHEMA-ONLY so a view over a store
+      // BY, HAVING, ORDER BY, projection — including each scalar call's
+      // arguments — and a UNION's arity. The view body compiles over its own
+      // `definition_schema.` overlay, built schema-ONLY so a view over a store
       // relation resolves without this row builder re-entering itself.
-      // The body must compile AND its width must equal the view's DECLARED
+      // The body must compile AND its width must equal the view's declared
       // column count: `resolve` rejects a view whose declared arity differs
       // from its body's (`v(x) AS SELECT * FROM People`), so such a view cannot
-      // run and is not advertised here. `uncorrelated()` CLEARS the correlation
+      // run and is not advertised here. `uncorrelated()` clears the correlation
       // stack: a view body is defined independently of any call site, so the
       // schema-only listing must resolve it exactly as the compile path does —
       // never binding an unbound view-definition column to an enclosing row.
@@ -615,18 +615,18 @@ extension Catalog where Self: ~Escapable {
           let plan = try? compile(view.query, overlay),
           plan.width == view.columns.count else { continue }
       // The type-check and derive resolve the body under the cyclic-view guard
-      // seeded with THIS view's name.
+      // seeded with this view's name.
       let inner = overlay.visiting(name)
-      // Type the columns from the body — NAMES off the first arm, TYPES unified
+      // Type the columns from the body — names off the first arm, types unified
       // across every arm (a mixed integer/double column reporting `double`);
-      // type-check every arm's REACHABLE operands and calls too — an unknown
+      // type-check every arm's reachable operands and calls too — an unknown
       // call or a bad operand in a `WHERE`/`HAVING` or a later `UNION` arm
       // faults a run, but a first-arm resolve would miss it (`compile` cannot
       // check a routine exists), while an arm a short-circuit proves
       // unreachable is skipped. A view a `SELECT *` could not evaluate is not
       // advertised.
       //
-      // EXPAND the body first (the schema path does): a `GROUP BY GROUPING
+      // expand the body first (the schema path does): a `GROUP BY GROUPING
       // SETS` body type-checks its `UNION ALL` of per-arm groupings, not the
       // unexpanded `.sets`. An unexpanded `SELECT 1 / 0 … WHERE 1 = 0 GROUP BY
       // GROUPING SETS ((Region), ())` reads as non-empty grouping and a
@@ -649,14 +649,14 @@ extension Catalog where Self: ~Escapable {
 }
 
 extension Query {
-  /// Collects every relation name THIS query names in a `FROM`/`JOIN`, across
+  /// Collects every relation name this query names in a `FROM`/`JOIN`, across
   /// the set-operation tree and each arm, into `names` — the reserved store
   /// names among them are what `Catalog.augment` builds.
   ///
   /// It does NOT descend a nested `EXISTS`/`IN (Q)`/scalar subquery: each
   /// subquery is compiled, type-checked, and run as a whole (`compile`/
   /// `typecheck`/`run` each `augment` the query they receive), so a subquery
-  /// binds its OWN store relations in its OWN scope. Descending here would
+  /// binds its own store relations in its own scope. Descending here would
   /// instead lift a subquery's names into this query's statement-global
   /// overlay, where a sibling subquery could not rebind a same-named entry.
   func collect(into names: inout Set<String>) {
@@ -671,14 +671,14 @@ extension Query {
     }
   }
 
-  /// Collects the DERIVED TABLES a single `SELECT` arm names in its own
+  /// Collects the derived tables a single `SELECT` arm names in its own
   /// `FROM`/`JOIN` — each alias paired with its inner `Query` — into
   /// `derivations`. `Catalog.augment` materialises each once and binds it under
   /// its alias in the scope of the arm that owns it, so the resolution scope
   /// reads a derived table exactly as it reads a common table expression (see
   /// `ScopedRelations`).
   ///
-  /// It stops at a `SELECT`: a `setop` collects NOTHING here, so its two arms'
+  /// It stops at a `SELECT`: a `setop` collects nothing here, so its two arms'
   /// derived aliases never merge into one map. Each arm is augmented on its own
   /// as `compile`/`typecheck`/`scope` descend it (each `augment`s the arm it
   /// receives), so a derived alias binds only in the arm that names it — a
@@ -688,7 +688,7 @@ extension Query {
   /// the left arm.
   ///
   /// It likewise does NOT descend a nested `EXISTS`/`IN (Q)`/scalar subquery,
-  /// or a derived table's OWN inner query: derived aliases are scoped to the
+  /// or a derived table's own inner query: derived aliases are scoped to the
   /// SELECT that owns their FROM/JOIN — not a statement-scoped, uniquely-named
   /// CTE — so each subquery and each inner query `augment`s its own derived
   /// tables in its own scope (see `Catalog.augment`/`materialise`). Descending
@@ -701,9 +701,9 @@ extension Query {
     }
   }
 
-  /// Collects the RANGE NAMES a single `SELECT` arm binds in its own `FROM`/
+  /// Collects the range names a single `SELECT` arm binds in its own `FROM`/
   /// `JOIN` — the alias a qualified reference names each item by (its explicit
-  /// alias, else a named relation's spelling), duplicates KEPT — into `ranges`.
+  /// alias, else a named relation's spelling), duplicates kept — into `ranges`.
   /// `Catalog.augment` counts these to fault a derived alias that shadows a
   /// same-scope sibling. It stops at a `SELECT` as `collect(derived:)` does: a
   /// `setop` collects nothing, so each arm's ranges stay in its own scope, and
@@ -714,9 +714,9 @@ extension Query {
     }
   }
 
-  /// Collects the SOURCE NAMES a single `SELECT` arm's `FROM`/`JOIN` NAMED
+  /// Collects the source names a single `SELECT` arm's `FROM`/`JOIN` named
   /// relations carry — the identifier `resolve` keys each named relation on in
-  /// the overlay (`relation.name` for a `.named` source, IGNORING its alias),
+  /// the overlay (`relation.name` for a `.named` source, ignoring its alias),
   /// not the range name a qualified reference uses — into `sources`.
   /// `Catalog.augment` checks these too so a derived alias `T` shadowing an
   /// aliased base `T AS x` (exposed range `x`, source `T`) collides — `resolve`
@@ -740,7 +740,7 @@ extension Select {
   /// Collects the range name of this select's `FROM` and each `JOIN` item — the
   /// alias a qualified reference names it by (`relation.alias`, else the named
   /// relation's spelling), matching `Scope.admits` — into `ranges`, duplicates
-  /// KEPT so a collision counts.
+  /// kept so a collision counts.
   func collect(ranges: inout Array<String>) {
     if let from { ranges.append(from.alias ?? from.name) }
     for join in joins {
@@ -748,10 +748,10 @@ extension Select {
     }
   }
 
-  /// Collects the SOURCE NAME of this select's `FROM` and each `JOIN` NAMED
+  /// Collects the source name of this select's `FROM` and each `JOIN` named
   /// relation — the `relation.name` (`.named`'s identifier, its alias ignored)
   /// that `resolve` keys the relation on — into `sources`, a derived table's
-  /// source contributing NONE (its rows key on its alias, already a range).
+  /// source contributing none (its rows key on its alias, already a range).
   func collect(sources: inout Array<String>) {
     if let from, case .named = from.source { sources.append(from.name) }
     for join in joins {
@@ -761,9 +761,9 @@ extension Select {
     }
   }
 
-  /// Collects this select's `FROM` and `JOIN` NON-LATERAL derived tables — each
+  /// Collects this select's `FROM` and `JOIN` non-LATERAL derived tables — each
   /// alias with its inner query — into `derivations`. A LATERAL derived table
-  /// is SKIPPED: it is not materialised once as a constant relation but
+  /// is skipped: it is not materialised once as a constant relation but
   /// resolved against the preceding FROM and re-evaluated per its rows (a
   /// correlated apply), so `compile(select)` binds and executes it directly
   /// rather than through the overlay `augment` builds.

--- a/Sources/SQLEngine/Engine.swift
+++ b/Sources/SQLEngine/Engine.swift
@@ -30,7 +30,7 @@ extension Catalog where Self: ~Escapable {
   /// ordered rows as typed values.
   ///
   /// A bare `SELECT` runs as before; a `UNION` runs each arm through the same
-  /// compile/optimise/execute with the SAME `bindings` and `routines`, then
+  /// compile/optimise/execute with the same `bindings` and `routines`, then
   /// concatenates the rows in source order — `UNION ALL` keeps every row, a
   /// bare `UNION` removes whole-row duplicates (first occurrence kept). The
   /// plan is binary and mirrors the left-associative chain, so each
@@ -46,7 +46,7 @@ extension Catalog where Self: ~Escapable {
   public borrowing func run(_ query: Query, _ routines: Routines,
                             bindings: Bindings = [:])
       throws(SQLError) -> Array<Array<Value>> {
-    // The engine is PURE: it resolves calls against exactly the `routines`
+    // The engine is pure: it resolves calls against exactly the `routines`
     // given, seeding no prelude of its own. `import SQLStandard` adds a
     // prelude-defaulting overload (`run(_:bindings:)` — see `SQLStandard`),
     // so a call under that module reaches the built-ins without naming them.
@@ -65,10 +65,10 @@ extension Catalog where Self: ~Escapable {
     // run and a `columns(of:)` derive cannot diverge. Idempotent for a
     // `.keys`/`.arm` select; a nested body re-enters and expands in turn.
     let query = try query.expanded
-    // A set operation runs each ARM against its OWN scope and combines the
+    // A set operation runs each ARM against its own scope and combines the
     // results, rather than materialising both arms' derived tables into one
     // shared overlay the executor scans by name. Both arms bind their aliases
-    // in ONE map, so a right arm's `derived T` would shadow a left arm's base
+    // in one map, so a right arm's `derived T` would shadow a left arm's base
     // (or CTE) `T` at the leaf scan — the executor keys a `.scan` by name and
     // cannot tell the two `T`s apart. Running per arm scopes each arm's derived
     // tables to that arm: the left arm's `FROM T` scans the base relation and
@@ -78,12 +78,12 @@ extension Catalog where Self: ~Escapable {
     if case let .setop(kind, left, right, all) = query {
       // Validate the whole query (per-arm resolution and the cross-arm arity
       // check) exactly as a single select does, then run each arm on its own —
-      // each arm's `run` threads its OWN lazy subquery box. `validate: false` —
+      // each arm's `run` threads its own lazy subquery box. `validate: false` —
       // the preflight must not eager-type-check a derived body a data-dependent
-      // filter never reaches (execution faults only on a REACHED operand),
+      // filter never reaches (execution faults only on a reached operand),
       // matching the non-derived path.
       _ = try compile(query, context.validating(false))
-      // The result column TYPES are UNIFIED across the arms (ISO), so coerce
+      // The result column types are unified across the arms (ISO), so coerce
       // each arm's values to them — `SELECT 1 UNION SELECT 2.5` emits a
       // `double` column. The fold reads the arm queries in hand here; the
       // Plan-node path carries the same types precomputed at compile.
@@ -93,40 +93,40 @@ extension Catalog where Self: ~Escapable {
                                  types: types)
       return combined.map(\.values)
     }
-    // Thread a fresh LAZY subquery cache — a shared box — through BOTH compile
+    // Thread a fresh lazy subquery cache — a shared box — through both compile
     // and execute. The executor's row evaluator runs each nested subquery into
     // it on first reach (where the borrowing catalog IS in scope; a schema-only
-    // path never reaches it, so opens no cursor): an UNCORRELATED occurrence
-    // runs once and memoises, while a CORRELATED one re-executes per outer row
+    // path never reaches it, so opens no cursor): an uncorrelated occurrence
+    // runs once and memoises, while a correlated one re-executes per outer row
     // against the correlated bindings, bypassing the memo. Compile stashes each
-    // CORRELATED occurrence's inner PLAN here (compiled once with its enclosing
+    // correlated occurrence's inner plan here (compiled once with its enclosing
     // scope, so its correlated columns are bound `Term.parameter`s), so the
-    // evaluator re-executes THAT plan rather than recompiling the inner query
+    // evaluator re-executes that plan rather than recompiling the inner query
     // with no outer scope.
     let context = context.resolving(Subqueries())
     // Compile from the un-augmented `context` (idempotently augmented inside
     // `compile`, which reveals the base for a nested subquery) — this query's
     // derived aliases are invisible to a subquery's FROM, and a CTE a
     // same-named derived alias shadows stays visible beneath the revealed base.
-    // Compile VALIDATES the whole query (schema-only, `rows: false`) BEFORE any
+    // Compile validates the whole query (schema-only, `rows: false`) before any
     // row materialises below, so an invalid query — an unknown column resolving
-    // over a `FROM (SELECT tick() …) AS d` — faults WITHOUT ever executing the
+    // over a `FROM (SELECT tick() …) AS d` — faults without ever executing the
     // derived body's stateful routine. A materialise ahead of this compile
     // would run the body for a query that cannot run.
     //
-    // `validate: false` gates the derived-body type-check OFF: the preflight
+    // `validate: false` gates the derived-body type-check off: the preflight
     // proves the OUTER query runnable and resolves its relations, but a data-
     // dependent body expression a filter drops (`FROM (SELECT Label + 1 AS x
     // FROM K WHERE k = 0) AS d`) must NOT be rejected here — execution faults
     // ONLY on an expression a surviving row reaches, exactly as the non-derived
     // `SELECT Label + 1 FROM K WHERE k = 0` runs to zero rows. The eager body
-    // type-check stays for the EXPLICIT schema path (`columns` `validate:
+    // type-check stays for the explicit schema path (`columns` `validate:
     // true`).
     let logical = try compile(query, context.validating(false)).pushdown()
     // Now that `compile` proved the query runnable, extend the overlay with any
     // `definition_schema.` store relation the query names (resolved lazily —
-    // the overlay after the CTEs, before the base catalog) AND MATERIALISE this
-    // query's derived tables (`rows: true`, executing each body ONCE). Every
+    // the overlay after the CTEs, before the base catalog) AND materialise this
+    // query's derived tables (`rows: true`, executing each body once). Every
     // phase reads the extended map, so a reserved store relation resolves,
     // plans, and materialises exactly as a common table expression does; a
     // portable `information_schema.` view over the store resolves through the
@@ -135,16 +135,16 @@ extension Catalog where Self: ~Escapable {
     // type.
     //
     // `validate: false` — this run materialise executes each body's rows, but a
-    // NESTED derived body's schema is still derived schema-only inside
+    // nested derived body's schema is still derived schema-only inside
     // `materialise` (to name the inner alias's columns); `validate: true` there
-    // would eager-type-check a doubly-nested filtered-out body on the RUN path.
+    // would eager-type-check a doubly-nested filtered-out body on the run path.
     // The run stays lenient at every depth (the outer query already compiled,
-    // and a REACHED operand still faults at execution).
+    // and a reached operand still faults at execution).
     let augmented = try augment(context.validating(false), for: query,
                                 rows: true)
     // Record the caller's overlay under `.caller` so a subquery lowered under
     // it (even one a pushdown moved INTO a view) re-runs against the caller's
-    // relations, not the view's base. REVEAL the base first — this query's
+    // relations, not the view's base. reveal the base first — this query's
     // derived-table aliases are SELECT-scoped, invisible to a subquery's FROM,
     // while the CTEs and `definition_schema.` store relations a `.caller`
     // subquery's FROM resolves against are kept, so a subquery `FROM d` reads a
@@ -153,15 +153,15 @@ extension Catalog where Self: ~Escapable {
     augmented.subqueries.record(overlay: augmented.revealed().relations,
                                 for: .caller)
     // Rewrite each decorrelatable correlated CROSS APPLY into a set-based join
-    // BEFORE the physical `optimise`/`nest`, so the emitted `select`-over-
+    // before the physical `optimise`/`nest`, so the emitted `select`-over-
     // `product` folds to a hash equi-join. The pass reads the compiled body
     // plans recorded above into the shared subquery box; a non-decorrelatable
     // apply is left verbatim, so a plan with none is unchanged.
     let decorrelated = try decorrelate(logical, augmented)
     // A query-level `ORDER BY`/`DISTINCT`/`OFFSET`·`FETCH` over a set operation
-    // — an `ordered` carrier whose `core` is a `.setop` — optimises PER ARM,
+    // — an `ordered` carrier whose `core` is a `.setop` — optimises per ARM,
     // mirroring the view carrier path (`optimise(_:_:_:)` at the `.ordered`
-    // view seam): the generic optimiser would rewrite both arms under the SAME
+    // view seam): the generic optimiser would rewrite both arms under the same
     // carrier-level `augmented` context, which does NOT bind an arm-owned
     // derived alias (arms are SELECT-scoped), so its `seek` rewrite faults
     // `.relation` on a `FROM (SELECT …) AS d WHERE …` arm before the per-arm
@@ -177,14 +177,14 @@ extension Catalog where Self: ~Escapable {
       plan = try optimise(decorrelated, augmented)
     }
     // A query-level `ORDER BY`/`DISTINCT`/`OFFSET`·`FETCH` over a set operation
-    // — the `ordered` carrier — must run its inner union PER ARM, as the direct
-    // `run(.setop)` above does: each arm augments its OWN arm-local derived
+    // — the `ordered` carrier — must run its inner union per ARM, as the direct
+    // `run(.setop)` above does: each arm augments its own arm-local derived
     // aliases (arms are SELECT-scoped, so the query-level augment misses them)
     // before its `.scan` reads them, then the arms `combine`. Executing the
     // compiled carrier plan under the single carrier context instead would
     // never materialise an arm's derived table, faulting `.relation`. Route the
     // execute through the carrier descent, which threads the inner union's arm
-    // queries to the setop leaf and runs `arms` there — the SAME per-arm
+    // queries to the setop leaf and runs `arms` there — the same per-arm
     // machinery — leaving the sort/dedup/limit/project stack above unchanged.
     if case let .ordered(inner, _, _, _, _) = query {
       return try execute(plan, carrying: inner, augmented).map(\.values)
@@ -223,7 +223,7 @@ extension Catalog where Self: ~Escapable {
   /// the `ScopedRelations` map and runs the trailing `query` against this
   /// catalog with that map in scope.
   ///
-  /// Each CTE materialises against the base catalog plus every EARLIER CTE,
+  /// Each CTE materialises against the base catalog plus every earlier CTE,
   /// so a CTE may name one defined before it (chained CTEs); a CTE name shadows
   /// a base relation of the same name (the resolver consults the map first). A
   /// recursive CTE — one that names itself in its own query — iterates a
@@ -238,13 +238,13 @@ extension Catalog where Self: ~Escapable {
   /// different width would index out of bounds when a later query reads it. The
   /// body's width is known once it compiles (a `SELECT *` resolves its extent
   /// against the relations in scope), so its compiled `Plan.width` is checked
-  /// against the declared count BEFORE the CTE materialises — regardless of how
+  /// against the declared count before the CTE materialises — regardless of how
   /// many rows the body yields. A body filtered to zero rows still faults with
   /// `SQLError.columns`, where a per-row check would pass it through vacuously.
   internal borrowing func with(_ ctes: Array<CTE>, _ query: Query,
                                _ context: Context)
       throws(SQLError) -> Array<Array<Value>> {
-    // Type AND materialise the CTEs into the overlay through the ONE producer
+    // Type AND materialise the CTEs into the overlay through the one producer
     // (`rows: true`) the schema path also drives, then run the trailing query
     // against it — the CTE walk lives in `typed(ctes:in:rows:)`, so a per-CTE
     // step cannot be added to a run loop and forgotten on the schema one.
@@ -253,9 +253,9 @@ extension Catalog where Self: ~Escapable {
   }
 
   /// Types the common table expressions `ctes` into a `ScopedRelations` overlay
-  /// — the SINGLE statement-level CTE walk BOTH the run (`with`) and the
+  /// — the single statement-level CTE walk both the run (`with`) and the
   /// schema-only (`columns(of:with:)`) paths consume, so a per-CTE step lives
-  /// in ONE place and cannot be added to one loop and forgotten on the other.
+  /// in one place and cannot be added to one loop and forgotten on the other.
   ///
   /// It walks `ctes` in source order, binding each into the growing overlay the
   /// next resolves against (so a later CTE names one before it, and a CTE
@@ -265,30 +265,30 @@ extension Catalog where Self: ~Escapable {
   ///    would silently shadow the earlier binding, so it faults
   ///    `SQLError.redefinition` rather than overwrite (a typo in a multi-CTE
   ///    query must not change the result);
-  /// 2. validates the CTE's SHAPE and ARITY against the CTEs done so far — the
-  ///    compile-time structural check `validate` runs. This gate is the ONE
+  /// 2. validates the CTE's shape and arity against the CTEs done so far — the
+  ///    compile-time structural check `validate` runs. This gate is the one
   ///    legitimate run-vs-schema difference, and it now lives here: the run
   ///    (`rows: true`) ALWAYS validates and passes `typecheck: false` — it
-  ///    DEFERS the reachable-operand check to execution — while a schema derive
+  ///    defers the reachable-operand check to execution — while a schema derive
   ///    (`rows: false`) validates ONLY when its context's `validate` gate is
-  ///    set (a post-run `validate: false` derive TRUSTS the bodies) and then
+  ///    set (a post-run `validate: false` derive trusts the bodies) and then
   ///    strictly (`typecheck: true`), faulting an ill-typed body statically;
-  /// 3. computes the column carrier ONCE. On the run path a self-referential
+  /// 3. computes the column carrier once. On the run path a self-referential
   ///    CTE iterates a `fixpoint` (which returns both its rows and their
   ///    unified carrier); every other CTE runs its query once and re-derives
-  ///    the carrier TRUSTED (`validating(false)`, so an unreached data-
+  ///    the carrier trusted (`validating(false)`, so an unreached data-
   ///    dependent operand is not eager-checked while a genuine set-operation
   ///    incompatibility still faults through `kinds`'s `merge` fold). On the
   ///    schema path `kinds`
-  ///    derives the carrier for either kind WITHOUT iterating — its recursive
+  ///    derives the carrier for either kind without iterating — its recursive
   ///    branch (`contributions`) folds anchor ⊕ recursive the same way
   ///    `fixpoint` does;
   /// 4. binds the carrier as `RelationInstance(from:, rows:)`, with the rows
   ///    on the run path and none on the schema path. Both paths accumulate the
-  ///    overlay IDENTICALLY — same names, types, and
+  ///    overlay identically — same names, types, and
   ///    `unconstrained` mask — differing ONLY in the captured rows, which is
   ///    safe because downstream typing reads names/types/mask, never rows. The
-  ///    carrier feeds the SAME `init(from:)`, so the schema-only self and the
+  ///    carrier feeds the same `init(from:)`, so the schema-only self and the
   ///    materialised binding cannot diverge.
   internal borrowing func typed(ctes: Array<CTE>, in context: Context,
                                 rows: Bool)
@@ -300,19 +300,19 @@ extension Catalog where Self: ~Escapable {
       }
       // The scope for this CTE's body: the base catalog plus every earlier CTE,
       // over the run's routines and bindings. `body(_:)` enters this fresh
-      // statement-scoped body with the correlation stack CLEARED — a CTE is
+      // statement-scoped body with the correlation stack cleared — a CTE is
       // resolved independently of any call site (a `WITH` is statement-level,
       // so the stack is already empty here; routing through `body(_:)` keeps
       // the clear intrinsic to entering a body scope rather than incidental).
       let scope = context.body(relations)
       // The compile-time structural check, shared with the dry-run schema path
       // so a derive rejects exactly the CTEs a run rejects. It faults the
-      // recursive shape and the width mismatch BEFORE any rows materialise. The
+      // recursive shape and the width mismatch before any rows materialise. The
       // run ALWAYS validates (`typecheck: false` — it defers the operand check
       // to execution); the schema derive validates ONLY when its context's gate
-      // is set — a `validate: false` derive AFTER a run TRUSTS the bodies (the
-      // run already proved them consistent) — and then STRICTLY (`typecheck:
-      // true`). This gate is the ONE legitimate run-vs-schema difference.
+      // is set — a `validate: false` derive after a run trusts the bodies (the
+      // run already proved them consistent) — and then strictly (`typecheck:
+      // true`). This gate is the one legitimate run-vs-schema difference.
       if rows || context.validate {
         try validate(cte, against: scope, typecheck: !rows)
       }
@@ -325,19 +325,19 @@ extension Catalog where Self: ~Escapable {
           (materialised, carrier) = try fixpoint(cte, scope)
         } else {
           materialised = try run(cte.query, scope)
-          // The body already RAN, so re-derive its carrier TRUSTED — the same
+          // The body already ran, so re-derive its carrier trusted — the same
           // `kinds` call the fixpoint's non-recursive tail routes through, so
           // no inline carrier construction diverges from it.
           carrier = try kinds(of: cte, scope.validating(false))
         }
       } else {
         // The schema derive materialises no row; `kinds` types either CTE kind
-        // WITHOUT iterating (its recursive branch folds anchor ⊕ recursive the
+        // without iterating (its recursive branch folds anchor ⊕ recursive the
         // way `fixpoint` does), under the incoming validate gate.
         materialised = []
         carrier = try kinds(of: cte, scope)
       }
-      // Both routings feed the SAME carrier into `init(from:)`, so the
+      // Both routings feed the same carrier into `init(from:)`, so the
       // schema-only self and the materialised binding cannot diverge.
       relations[cte.name.lowercased()] =
           RelationInstance(from: carrier, rows: materialised)
@@ -345,31 +345,31 @@ extension Catalog where Self: ~Escapable {
     return relations
   }
 
-  /// Validates the SHAPE and declared ARITY of a single common table expression
-  /// `cte` against the base catalog plus the CTEs done so far (`ctes`), WITHOUT
+  /// Validates the shape and declared arity of a single common table expression
+  /// `cte` against the base catalog plus the CTEs done so far (`ctes`), without
   /// materialising a row — the compile-time structural check `with` runs before
   /// each CTE materialises, factored out so the dry-run result-schema path
-  /// (`columns(of:with:)`) validates a `WITH` by the SAME code a run does,
+  /// (`columns(of:with:)`) validates a `WITH` by the same code a run does,
   /// ending the divergence between the two.
   ///
   /// It reproduces, without executing, the two structural faults `with` and
   /// `fixpoint` raise:
   ///
-  /// - The RECURSIVE SHAPE. A `WITH RECURSIVE` member's recursive reference
-  /// must be its FINAL `UNION` arm — the engine's model is anchor members then
-  /// ONE recursive arm. A reference to the CTE's own name in an EARLIER arm
+  /// - The RECURSIVE shape. A `WITH RECURSIVE` member's recursive reference
+  /// must be its final `UNION` arm — the engine's model is anchor members then
+  /// one recursive arm. A reference to the CTE's own name in an earlier arm
   /// resolves against the base scope (the CTE is not in scope outside the
   /// recursive arm), so a same-named base or view is a valid seed; but with no
   /// such base/view the reference can only be a misplaced recursive arm —
   /// recursion before the final arm, or a second recursive arm — a shape the
   /// engine does not support, faulted `SQLError.unsupported`.
   ///
-  /// - The DECLARED ARITY. Each CTE body must project exactly the arity its
+  /// - The declared arity. Each CTE body must project exactly the arity its
   /// column list declares, or a later reader indexes out of bounds. The body's
-  /// width is known once it COMPILES — never opening a cursor — so the compiled
+  /// width is known once it compiles — never opening a cursor — so the compiled
   /// `Plan.width` is checked against the declared count, faulting
   /// `SQLError.columns` on a mismatch. A recursive (self-naming) CTE checks its
-  /// ANCHOR (self NOT in scope) and its RECURSIVE arm (self bound to the
+  /// anchor (self NOT in scope) and its RECURSIVE arm (self bound to the
   /// declared columns) separately, exactly as `fixpoint` does; every other CTE
   /// checks its whole body with self NOT in scope. This is why the schema path
   /// must NOT bind the CTE's self for the whole body: a `WITH RECURSIVE t(n) AS
@@ -378,28 +378,28 @@ extension Catalog where Self: ~Escapable {
   /// self-reference the run would reject.
   ///
   /// The reachable-operand type-check the schema path also wants is NOT part of
-  /// the shape/arity check the run relies on — the run DEFERS it to execution.
+  /// the shape/arity check the run relies on — the run defers it to execution.
   /// It rides in through `typecheck`: the run path passes `false` (it defers),
   /// the schema path passes `true` (it must fault an ill-typed body
   /// statically). Folding it here rather than layering it in the schema path
-  /// keeps ONE per-arm scoping for BOTH the structural check and the operand
-  /// check — a recursive CTE's ANCHOR is operand-checked against base + prior
+  /// keeps one per-arm scoping for both the structural check and the operand
+  /// check — a recursive CTE's anchor is operand-checked against base + prior
   /// CTEs (self NOT in scope, the scope the run evaluates the anchor in), NOT
   /// the CTE-self overlay, so `SELECT Name + 1 FROM People` in the anchor
-  /// faults `SQLError.operand` against the BASE `People` a run reads it
+  /// faults `SQLError.operand` against the base `People` a run reads it
   /// against, never wrongly types clean against the CTE's declared columns.
   ///
-  /// `typecheck` ALSO gates the eager type-check of a DERIVED body the CTE
+  /// `typecheck` also gates the eager type-check of a derived body the CTE
   /// body nests: the arity `augment`/`compile` below thread `validate:
   /// typecheck` so a run (`typecheck: false`) derives a `FROM (SELECT …) AS d`
-  /// LENIENTLY — a data-dependent body expression a filter drops (`FROM (SELECT
-  /// Label + 1 AS x FROM K WHERE k = 0) AS d`) is TRUSTED, not rejected, as
+  /// leniently — a data-dependent body expression a filter drops (`FROM (SELECT
+  /// Label + 1 AS x FROM K WHERE k = 0) AS d`) is trusted, not rejected, as
   /// the non-`WITH` and `WITH`-trailing paths already do — while the schema
   /// path (`typecheck: true`) keeps the strict body type-check.
   internal borrowing func validate(_ cte: CTE, against context: Context,
                                    typecheck: Bool = false)
       throws(SQLError) {
-    // Reject a misplaced recursive reference in an EARLIER arm when no
+    // Reject a misplaced recursive reference in an earlier arm when no
     // same-named base/view can seed it — the shape `with` rejects before
     // routing to the fixpoint.
     if cte.recursive,
@@ -411,10 +411,10 @@ extension Catalog where Self: ~Escapable {
                    "recursive WITH references the CTE outside its final " +
                    "UNION arm")
     }
-    // A recursive body that is a NON-UNION set operation (`EXCEPT`/`INTERSECT`)
+    // A recursive body that is a non-UNION set operation (`EXCEPT`/`INTERSECT`)
     // referencing itself has no recursive arm to iterate: `recurses` matches
     // only a `.union` core, so this body would take the run-once path and
-    // compile with the CTE self UNBOUND, faulting a generic `SQLError.relation`
+    // compile with the CTE self unbound, faulting a generic `SQLError.relation`
     // on the self reference. ISO 9075 permits recursion only through
     // `UNION [ALL]`, so fault the precise `0A000` feature diagnostic instead —
     // unless a same-named base/view seeds it (then the reference reads that
@@ -432,9 +432,9 @@ extension Catalog where Self: ~Escapable {
     // `fixpoint` does: the anchor with self NOT in scope, the recursive arm
     // with self bound to the declared columns. Every other CTE checks its whole
     // body with self NOT in scope. When `typecheck`, the reachable-operand
-    // check runs in the SAME per-arm scope each arity check uses, so the
+    // check runs in the same per-arm scope each arity check uses, so the
     // operand check shares the run's arm scoping and never types an anchor
-    // against the CTE-self overlay. `recursiveArms`/`canonical` peel the SAME
+    // against the CTE-self overlay. `recursiveArms`/`canonical` peel the same
     // canonical (unwound) shape the run's `fixpoint` and the schema
     // `contributions` do, so all three inspect the identical AST.
     if let (anchor, recursive, _) = try cte.recursiveArms {
@@ -449,20 +449,20 @@ extension Catalog where Self: ~Escapable {
       // run evaluates it in — so a text-arithmetic anchor faults against the
       // base relation, not the CTE's declared (integer) columns.
       if typecheck { try self.typecheck(anchor, scope) }
-      // Check the recursive arm's WIDTH against the declared list BEFORE any
+      // Check the recursive arm's width against the declared list before any
       // `kinds` derive — an arm degree differing from the list is the declared-
       // arity fault, and it must win in the ISO order (`expected: arm, got:
-      // declared`) on BOTH paths. A width check needs only the self's COLUMN
+      // declared`) on both paths. A width check needs only the self's COLUMN
       // COUNT, not its types, so bind the self under the placeholder-typed
       // `declared` carrier here: `kinds` would otherwise fold the arms and
-      // raise its OWN inter-arm count fault (`expected: anchor, got: arm`) in
+      // raise its own inter-arm count fault (`expected: anchor, got: arm`) in
       // the reverse order first, re-diverging the schema path from the run.
-      // Measure the arm NON-validating even on the schema path: `augment`
+      // Measure the arm non-validating even on the schema path: `augment`
       // materialises a derived body in the arm eagerly, and validating it here
       // would type-check its operands against the placeholder-typed self (the
       // `.integer` carrier), spuriously faulting a runnable arm whose self is
       // really text. Arity is structural, so the width guard still fires; the
-      // genuine recursive-arm operand type-check happens LATER, under the
+      // genuine recursive-arm operand type-check happens later, under the
       // `kinds`-rebound unified carrier where the self carries its real types.
       let sized = RelationInstance(from: cte.declared, rows: [])
       let measured = context.binding(cte.name, to: sized)
@@ -473,15 +473,15 @@ extension Catalog where Self: ~Escapable {
         throw .columns(expected: arm, got: cte.columns.count)
       }
       // Both widths match, so — ONLY on the schema path — type-check the
-      // recursive arm with the CTE self bound under the UNIFIED (anchor ⊕
-      // recursive) column carrier `kinds` derives: the SAME carrier `fixpoint`
+      // recursive arm with the CTE self bound under the unified (anchor ⊕
+      // recursive) column carrier `kinds` derives: the same carrier `fixpoint`
       // binds the iterated self under (the rows every step reads are coerced to
       // those types). Typing the self at the anchor-only types while the run
       // reads the widened unified types would let schema validation call a
       // query "valid" that the run mistypes (an integer-anchor self a widening
       // recursive arm reads as `double`); `kinds` folds it recursive-aware, so
       // a genuine irreconcilable arm pair faults here as the run's own fold
-      // rejects it. The RUN path defers this operand check to execution, so it
+      // rejects it. The run path defers this operand check to execution, so it
       // needs neither the derive nor the self binding — the width guard above
       // is the whole of its arity check. Feeding the carrier through
       // `init(from:)` means this self binding and the run-iteration one cannot
@@ -489,7 +489,7 @@ extension Catalog where Self: ~Escapable {
       if typecheck {
         let seeded = try kinds(of: cte, context.validating(typecheck))
         let empty = RelationInstance(from: seeded, rows: [])
-        // Bind the CTE self BEFORE augmenting the recursive arm, so a derived
+        // Bind the CTE self before augmenting the recursive arm, so a derived
         // body in the arm naming the CTE (`FROM (SELECT n FROM a) AS d`)
         // resolves it — `augment` materialises derived bodies eagerly, so the
         // self must be in scope by then, not bound only afterwards.
@@ -498,21 +498,21 @@ extension Catalog where Self: ~Escapable {
         // The recursive arm is operand-checked with self bound to the declared
         // columns — the schema every iteration reads the CTE under.
         try self.typecheck(recursive, probe)
-        // Validate the peeled carrier's `ORDER BY` keys the SAME way the RUN
+        // Validate the peeled carrier's `ORDER BY` keys the same way the run
         // path resolves them (`fixpoint`/`apply`): against the body's FIRST-ARM
-        // set-op OUTPUT scope, through the ordinary `SELECT * FROM <temp> ORDER
-        // BY …` machinery over an EMPTY temp of those output columns. A key
+        // set-op output scope, through the ordinary `SELECT * FROM <temp> ORDER
+        // BY …` machinery over an empty temp of those output columns. A key
         // naming a missing column or function faults here on the schema path as
         // it faults the run, closing the run-vs-validate gap where a carrier
         // `ORDER BY missing(n)` passed `columns(of:validate:true)` yet the run
         // faulted `.function('missing')` when `apply` resolved it after the
-        // fixpoint. The declared rename rides the CTE binding AFTER the
+        // fixpoint. The declared rename rides the CTE binding after the
         // carrier, so — as the run does — the carrier resolves the body's
         // output names.
         if let carrier {
           // A set operation names its output off its FIRST arm (the ISO rule),
-          // so the carrier's `ORDER BY` resolves against the ANCHOR's output
-          // NAMES — resolved with the CTE self NOT in scope, so the anchor's
+          // so the carrier's `ORDER BY` resolves against the anchor's output
+          // names — resolved with the CTE self NOT in scope, so the anchor's
           // own names/types derive without faulting `.relation` on the
           // recursive arm's self reference. (Unifying the whole `body` would
           // need the self bound to fold the recursive arm.)
@@ -522,7 +522,7 @@ extension Catalog where Self: ~Escapable {
         }
       }
     } else {
-      // Validate the SAME expanded AST a run does: a `GROUP BY GROUPING SETS`
+      // Validate the same expanded AST a run does: a `GROUP BY GROUPING SETS`
       // body expands to its `UNION ALL` FIRST, so this schema-path typecheck
       // sees the per-set arms (an empty-set grand-total arm evaluates its
       // projection even under a `WHERE` that spares the unexpanded key list),
@@ -542,7 +542,7 @@ extension Catalog where Self: ~Escapable {
   /// Evaluates a recursive `cte` to a fixpoint over this catalog with the
   /// `ctes` in scope, returning every produced row.
   ///
-  /// A recursive CTE's query is a `UNION` of an ANCHOR (its left arm) and a
+  /// A recursive CTE's query is a `UNION` of an anchor (its left arm) and a
   /// RECURSIVE arm (its right arm, which names the CTE). The
   /// anchor evaluates once — with the CTE name NOT yet bound — to seed `result`
   /// and the `working` set. Each iteration then binds the CTE name to ONLY the
@@ -560,7 +560,7 @@ extension Catalog where Self: ~Escapable {
   /// faults with `SQLError.columns` rather than trapping on a later read.
   ///
   /// The anchor and the recursive arm are each validated against
-  /// `cte.columns.count` by their compiled `Plan.width` BEFORE any rows bind
+  /// `cte.columns.count` by their compiled `Plan.width` before any rows bind
   /// under the declared columns: the loop binds `working` as a
   /// `RelationInstance` of `cte.columns`, so an arm narrower or wider than the
   /// column list — a two-column anchor under a three-column list, or a
@@ -582,22 +582,22 @@ extension Catalog where Self: ~Escapable {
     // column using even a standard routine (`BITAND(...)`) types the same
     // inside the CTE as the identical SELECT does outside it.
     // `validate: false` on every arity `compile` below — `fixpoint` is a pure
-    // RUN path (only `with` routes a self-naming CTE here), so a derived body
-    // the CTE's arm nests must be TRUSTED, not eager-type-checked: a data-
+    // run path (only `with` routes a self-naming CTE here), so a derived body
+    // the CTE's arm nests must be trusted, not eager-type-checked: a data-
     // dependent body expression a filter drops must not fault a CTE that runs
     // empty, matching the non-recursive and non-`WITH` paths.
     // Expand a `GROUP BY GROUPING SETS` body to its `UNION ALL` FIRST — the
-    // SAME normalization `run`/`compile`/the schema `validate` apply — so the
+    // same normalization `run`/`compile`/the schema `validate` apply — so the
     // `augment` and the non-`UNION` run-once branch below see the expanded AST.
     // Idempotent for a plain recursive `UNION` body.
     let query = try cte.query.expanded
     let context = try augment(context.validating(false), for: query,
                               rows: true)
-    // Peel the CANONICAL recursive shape — the SAME `canonical` (expanded,
+    // Peel the canonical recursive shape — the same `canonical` (expanded,
     // unwound) form `recurses`/`recursiveArms`, the shape validator, and the
     // schema derive peel — off the body: the fixpoint iterates the INNER
     // `UNION` (anchor ∪ recursive) with the CTE self in scope, then the peeled
-    // `carrier` applies its row operators to the materialised RESULT. The
+    // `carrier` applies its row operators to the materialised result. The
     // carrier is transparent to the recursive shape (`references` descends it),
     // so `recurses` already routed an ordered body here. `canonical` expands a
     // grouping-sets body FIRST, matching the `query` `augment` sees above.
@@ -612,13 +612,13 @@ extension Catalog where Self: ~Escapable {
       guard width == cte.columns.count else {
         throw .columns(expected: width, got: cte.columns.count)
       }
-      // The CTE exposes its body's DERIVED column types/mask under its DECLARED
+      // The CTE exposes its body's derived column types/mask under its declared
       // names (resolved with the self shadowed by the same-named base it seeds
       // from), not the declared-name placeholder, so a caller reading the CTE
       // unifies against real types and the `unconstrained` mask while
       // addressing the CTE by its declared list.
       let rows = try run(query, context)
-      // TRUSTED re-derive (the body already ran): `validating(false)` so an
+      // trusted re-derive (the body already ran): `validating(false)` so an
       // unreached data-dependent operand is not eager-checked, while a genuine
       // set-operation incompatibility still faults through `merge`.
       let carrier = try kinds(of: cte, context.validating(false))
@@ -629,7 +629,7 @@ extension Catalog where Self: ~Escapable {
     // absent) was already rejected in `with`, before routing here, so the
     // anchor is a genuine base case by this point.
 
-    // Validate the anchor's compiled width against the declared columns BEFORE
+    // Validate the anchor's compiled width against the declared columns before
     // it seeds the working set: the loop binds `working` under `cte.columns` as
     // a `RelationInstance`, so an anchor narrower than the column list — a
     // two-column `Parent` under `t(a, b, c)` — would trap when the recursive
@@ -641,20 +641,20 @@ extension Catalog where Self: ~Escapable {
       throw .columns(expected: width, got: cte.columns.count)
     }
 
-    // The CTE column CARRIER a recursive reference reads under — the ANCHOR's
+    // The CTE column carrier a recursive reference reads under — the anchor's
     // own output columns (the base case, resolved with self NOT in scope).
     // Binding the schema-only self under these — rather than a flat `.integer`
     // placeholder — types the recursive arm's self-referencing columns
     // consistently with the anchor, so the anchor/recursive fold below does not
     // spuriously merge a genuine anchor type (a `text` `column_name`) against
     // an `.integer` placeholder self column and fault. A NULL-only anchor
-    // column stays UNCONSTRAINED, so the recursive arm's typed column supplies
+    // column stays unconstrained, so the recursive arm's typed column supplies
     // the type. It defaults to `.integer`, the run's materialised-relation
     // default.
     let seeds = try columns(unifying: anchor, context)
 
     // The recursive arm compiles with the CTE name bound to the anchor's own
-    // carrier under the CTE's DECLARED names (a `SELECT x FROM t` self
+    // carrier under the CTE's declared names (a `SELECT x FROM t` self
     // reference addresses the declared `x`, not the anchor's projected name) —
     // the schema every iteration reads it under — so its width resolves too (a
     // `SELECT *` arm spans that schema). Checking it here catches a mismatch
@@ -672,10 +672,10 @@ extension Catalog where Self: ~Escapable {
       throw .columns(expected: arm, got: cte.columns.count)
     }
 
-    // The result column CARRIER unifies the ANCHOR — typed under `context`,
-    // where a same-named base/view the anchor SEEDS from resolves to that base
+    // The result column carrier unifies the anchor — typed under `context`,
+    // where a same-named base/view the anchor seeds from resolves to that base
     // (the CTE self not yet in scope) — with the RECURSIVE arm, typed under
-    // `probe` (self bound). Folding the WHOLE `cte.query` under `probe` would
+    // `probe` (self bound). Folding the whole `cte.query` under `probe` would
     // resolve the anchor's base reference against the empty self, rejecting or
     // mis-unifying a base-only column (`SELECT Age FROM People` seeding a
     // recursive `People`). So merge the two arms' own-scope columns
@@ -683,11 +683,11 @@ extension Catalog where Self: ~Escapable {
     // `SQLError.operand`.
     // `combine` never runs here (the fixpoint is hand-rolled for its `Seen`
     // dedup), so these types coerce the produced ROWS directly with
-    // `Value.coerced` — the anchored seed and each iteration's output — BEFORE
+    // `Value.coerced` — the anchored seed and each iteration's output — before
     // the dedup and append, leaving the plan tree (and the recursive self-
     // reference) untouched.
     let steps = try columns(unifying: recursive, probe)
-    // Merge column-wise, then bind under the CTE's DECLARED names (a CTE is
+    // Merge column-wise, then bind under the CTE's declared names (a CTE is
     // addressed by its declared list, never the arm's own projected name),
     // keeping each column's unified type and `unconstrained` mask. The declared
     // width is proved equal to each arm's above, so the index is in range.
@@ -721,10 +721,10 @@ extension Catalog where Self: ~Escapable {
 
       // Bind the CTE name to ONLY the previous step's output and run the
       // recursive arm against the base catalog plus the earlier CTEs. The self
-      // relation carries the UNIFIED `merged` carrier — the rows in `working`
+      // relation carries the unified `merged` carrier — the rows in `working`
       // are already coerced to those types (the anchored seed and each step
       // passes through `coerce($0, to: types)`), so the recursive arm must be
-      // TYPED to the values it reads. Typing the self under the anchor-only
+      // typed to the values it reads. Typing the self under the anchor-only
       // `seeds` would type an integer-anchor self while the coerced rows
       // already hold widened `double` values, mistyping the arm the run reads.
       let step = RelationInstance(from: merged, rows: working)
@@ -740,22 +740,22 @@ extension Catalog where Self: ~Escapable {
     }
     // Apply the peeled query-level carrier — a trailing `ORDER BY` / `OFFSET`·
     // `FETCH` / `DISTINCT` on the body's set operation — to the materialised
-    // fixpoint RESULT, reusing the ordinary `SELECT`-over-a-relation path
+    // fixpoint result, reusing the ordinary `SELECT`-over-a-relation path
     // rather than re-resolving the row operators here. A trailing carrier's
     // `generated` is always `0` (the parser materialises no hidden sort column
     // for it; only `expand` does, which never yields a recursive body), so the
     // result rows are exactly the CTE's declared columns and need no trim.
     //
     // The carrier's `ORDER BY` resolves against the body's FIRST-ARM set-op
-    // OUTPUT names — the SAME scope the non-recursive ordered-CTE body uses
+    // output names — the same scope the non-recursive ordered-CTE body uses
     // (`WITH t(n) AS (SELECT 1 AS x UNION ALL … ORDER BY x)` orders by the
     // arm-0 output `x`, not the declared `n`) — so name the temp `apply` binds
-    // under the ANCHOR's output names (a set operation names its output off its
+    // under the anchor's output names (a set operation names its output off its
     // FIRST arm, the ISO rule; the anchor resolves with the CTE self NOT in
     // scope, so its names derive without the self binding), NOT the CTE's
-    // DECLARED names (`merged`). Each column carries the run-unified `merged`
-    // TYPE the materialised rows hold. The CTE-declared rename rides the
-    // RETURNED `merged` carrier, applied AFTER the carrier at CTE consumption,
+    // declared names (`merged`). Each column carries the run-unified `merged`
+    // type the materialised rows hold. The CTE-declared rename rides the
+    // returned `merged` carrier, applied after the carrier at CTE consumption,
     // so the outer `SELECT n FROM t` still addresses `n`.
     if let carrier {
       let outputs = try columns(unifying: anchor, context)
@@ -774,10 +774,10 @@ extension Catalog where Self: ~Escapable {
   /// output names), `arm` the body's FIRST arm (the anchor).
   ///
   /// The rows are bound as a temporary relation under a non-spellable name; a
-  /// bare scan over it seeds the SHARED `carried(over:)` carrier resolver — the
-  /// SAME resolver the ordinary `ordered` set-operation path uses — so the
+  /// bare scan over it seeds the shared `carried(over:)` carrier resolver — the
+  /// same resolver the ordinary `ordered` set-operation path uses — so the
   /// carrier's `ORDER BY` resolves a projected-expression / aliased / qualified
-  /// / ordinal key against the arm-0 projection surface IDENTICALLY to the
+  /// / ordinal key against the arm-0 projection surface identically to the
   /// ordinary path, never a bare `SELECT * FROM <temp>` that re-evaluates a
   /// projected key over the column-shy temp. A trailing carrier's `generated`
   /// is always `0` (only `expand` materialises hidden sort columns, and it
@@ -789,17 +789,17 @@ extension Catalog where Self: ~Escapable {
       throws(SQLError) -> Array<Array<Value>> {
     let name = "*fixpoint"
     let temp = RelationInstance(from: columns, rows: rows)
-    // Thread ONE fresh subquery cache — a shared box — through BOTH `carried`
-    // (which resolves the carrier `ORDER BY` and, for a sort key CORRELATED to
+    // Thread one fresh subquery cache — a shared box — through both `carried`
+    // (which resolves the carrier `ORDER BY` and, for a sort key correlated to
     // the set-op output, records that key's compiled runtime plan here) AND
     // `execute` (whose row evaluator reads that recorded plan back), mirroring
     // the top-level `run`. A fresh box (not the incoming context's) isolates
     // the carrier's subquery cache from the fixpoint iterations' recorded body
-    // plans; what matters is that `carried` writes and `execute` read the SAME
+    // plans; what matters is that `carried` writes and `execute` read the same
     // box, so a correlated carrier sort key does not fault "a correlated
     // subquery plan was not compiled" on execution.
     let context = context.binding(name, to: temp).resolving(Subqueries())
-    // The base scan over the temp — its output columns ARE `columns`, the
+    // The base scan over the temp — its output columns are `columns`, the
     // setop-output scope the carrier resolves against. The shared resolver
     // stacks the row operators over it in that identity slot space.
     let scan = try compile(.select(Select(projection: .all,
@@ -813,10 +813,10 @@ extension Catalog where Self: ~Escapable {
   }
 
   /// Validates the peeled `carrier`'s `ORDER BY` keys against the body's set-op
-  /// output `columns` — an EMPTY temp of those columns — through the SAME
+  /// output `columns` — an empty temp of those columns — through the same
   /// shared `carried(over:)` resolver `apply` runs, under a validating context,
   /// so a schema-path `columns(of:validate:true)` faults a carrier `ORDER BY`
-  /// naming a missing column or function EXACTLY as the run does, closing the
+  /// naming a missing column or function exactly as the run does, closing the
   /// run-vs-validate gap. `arm` is the body's FIRST arm (the anchor), the
   /// projection surface an ordinal / projected-expression / aliased key binds
   /// against. Discards the resolved plan — only its resolution can fault.
@@ -837,7 +837,7 @@ extension Catalog where Self: ~Escapable {
   }
 }
 
-/// A row's cells COERCED to the unified column `types` — the recursive-CTE
+/// A row's cells coerced to the unified column `types` — the recursive-CTE
 /// fixpoint's row-level counterpart of `Record.coerced(to:)`, applied to each
 /// materialised `Array<Value>` row (the fixpoint works on raw rows, not the
 /// plan tree) so the anchor and every iteration carry the set-operation's

--- a/Sources/SQLEngine/Error.swift
+++ b/Sources/SQLEngine/Error.swift
@@ -81,7 +81,7 @@ public enum SQLError: Error, Hashable, Sendable {
   /// list names it; the string describes the offending projection.
   case named(String)
   /// An explicit column list — a `CREATE VIEW`'s, a `WITH` CTE's, or a derived
-  /// table's `AS t(c, …)` — does not match the query expression's DEGREE, the
+  /// table's `AS t(c, …)` — does not match the query expression's degree, the
   /// number of columns its body projects; the list must name exactly one column
   /// per projected value. ISO 9075 makes the degree the reference, so
   /// `expected` carries the body/query-expression degree and `got` the declared
@@ -132,7 +132,7 @@ public enum SQLError: Error, Hashable, Sendable {
   /// to be an output column. The string is the offending column's name.
   case distinct(String)
   /// A scalar subquery `(SELECT …)` used where at most one row is admitted
-  /// yielded MORE THAN ONE row — the ISO `<scalar subquery>` requires a
+  /// yielded more than one row — the ISO `<scalar subquery>` requires a
   /// cardinality of at most one, an empty result standing for NULL and a single
   /// row for its lone cell. A wider result cannot collapse to one value, so a
   /// run raises rather than picking one arbitrarily.

--- a/Sources/SQLEngine/Evaluation.swift
+++ b/Sources/SQLEngine/Evaluation.swift
@@ -155,9 +155,9 @@ internal func matches(_ lhs: Value, _ op: Comparison, _ rhs: Value) -> Bool? {
   }
 }
 
-/// Whether two typed values DIFFER under ISO `IS DISTINCT FROM` — the null-safe
+/// Whether two typed values differ under ISO `IS DISTINCT FROM` — the null-safe
 /// comparison, treating NULL as a comparable value. Unlike `matches`, it is
-/// TWO-VALUED (never UNKNOWN): two NULLs are the SAME (not DISTINCT), exactly
+/// two-valued (never UNKNOWN): two NULLs are the same (not DISTINCT), exactly
 /// one NULL is DISTINCT, and two non-NULLs are DISTINCT unless they are equal —
 /// a cross-kind pair being DISTINCT, as `matches` yields FALSE (`== true` is
 /// false) for cross-kind equality. `IS DISTINCT FROM` returns this; `IS NOT
@@ -171,7 +171,7 @@ internal func distinct(_ lhs: Value, _ rhs: Value) -> Bool {
 }
 
 /// The three-valued truth of an ISO row-value comparison `(l…) <op> (r…)` over
-/// two ALREADY-EVALUATED rows of EQUAL, non-empty arity — the shared fold both
+/// two already-evaluated rows of equal, non-empty arity — the shared fold both
 /// the runtime (`Filter.comparison`) and the empty-group pre-fold drive so the
 /// two agree by construction.
 ///
@@ -180,7 +180,7 @@ internal func distinct(_ lhs: Value, _ rhs: Value) -> Bool {
 /// itself), and the four ordering operators the lexicographic cascade `l0 <op>
 /// r0 OR (l0 = r0 AND (l1 <op> r1 OR …))`, right-nested from the last component
 /// inward — the innermost step carrying `op` itself (so `<=`/`>=` admit an
-/// all-equal row), every earlier step the STRICT operator (`<`/`>`) tie-guarded
+/// all-equal row), every earlier step the strict operator (`<`/`>`) tie-guarded
 /// by the componentwise equality. A NULL component makes a componentwise test
 /// UNKNOWN, propagated through the Kleene fold.
 internal func relate(_ l: Array<Value>, _ op: Comparison,
@@ -234,8 +234,8 @@ internal func or(_ lhs: Bool?, _ rhs: Bool?) -> Bool? {
 }
 
 /// The ISO `<boolean test>` mapping — a three-valued `operand` tested against a
-/// `Truth` value, negated for `IS NOT`, yielding a DEFINITE two-valued result
-/// that is NEVER itself UNKNOWN. `p IS TRUE` is `operand == true`, `IS FALSE`
+/// `Truth` value, negated for `IS NOT`, yielding a definite two-valued result
+/// that is never itself UNKNOWN. `p IS TRUE` is `operand == true`, `IS FALSE`
 /// is `operand == false`, and `IS UNKNOWN` is `operand == nil` — so an UNKNOWN
 /// operand is FALSE against `TRUE`/`FALSE` and TRUE against `UNKNOWN`. This is
 /// the shared primitive the run (`Filter.truth`) and the folds
@@ -251,7 +251,7 @@ internal func tested(_ operand: Bool?, _ value: Truth, _ negated: Bool)
 }
 
 extension Row where Self: ~Escapable {
-  /// Evaluates a SUBQUERY-FREE `filter` against this row under three-valued
+  /// Evaluates a subquery-free `filter` against this row under three-valued
   /// logic through `routines` and `bindings` — the choke point a unit test
   /// drives directly. It runs against `NoCatalog`, so a filter that reached an
   /// `EXISTS`/`IN (Q)`/scalar subquery would fault; a subquery-free one never
@@ -311,27 +311,27 @@ extension Catalog where Self: ~Escapable {
     case let .distinct(lhs, rhs, negated):
       try differs(row, lhs, rhs, negated, context)
     case let .exists(key, correlation, negated):
-      // The DEFINITE two-valued `EXISTS` non-empty test — never UNKNOWN,
-      // `negated` flipping it. The subquery runs LAZILY on this first reach (so
+      // The definite two-valued `EXISTS` non-empty test — never UNKNOWN,
+      // `negated` flipping it. The subquery runs lazily on this first reach (so
       // an `EXISTS` a short-circuited `AND`/`OR` or an unreached `CASE` arm
-      // guards never runs): an UNCORRELATED one memoises under its `Subkey`; a
-      // CORRELATED one re-runs against this row's correlated bindings,
+      // guards never runs): an uncorrelated one memoises under its `Subkey`; a
+      // correlated one re-runs against this row's correlated bindings,
       // bypassing the memo.
       try present(row, key, correlation, context) != negated
     case let .within(operand, key, correlation, negated):
-      // Fold `operand = v` over the subquery's single column under the SAME
+      // Fold `operand = v` over the subquery's single column under the same
       // three-valued membership the value-list `IN` uses. The column is
-      // materialised LAZILY on this first reach (an UNCORRELATED one memoised,
-      // a CORRELATED one re-run per row against this row's correlated
+      // materialised lazily on this first reach (an uncorrelated one memoised,
+      // a correlated one re-run per row against this row's correlated
       // bindings).
       try member(row, operand, values(row, key, correlation, context),
                  negated, context)
     case let .quantified(operand, op, quantifier, key, correlation):
-      // Fold `operand op v` over the subquery's single column with the SAME
+      // Fold `operand op v` over the subquery's single column with the same
       // `matches`/Kleene primitives `within` uses — Kleene `OR` (seeded FALSE)
       // for `any`, Kleene `AND` (seeded TRUE) for `all`. It materialises its
-      // lone column LAZILY through the SAME `values` path `within` drives: an
-      // UNCORRELATED one memoises under its `Subkey`, a CORRELATED one re-runs
+      // lone column lazily through the same `values` path `within` drives: an
+      // uncorrelated one memoises under its `Subkey`, a correlated one re-runs
       // its inner plan per outer row against this row's correlated bindings.
       try quantified(row, operand, op, quantifier,
                      values(row, key, correlation, context), context)
@@ -366,7 +366,7 @@ extension Catalog where Self: ~Escapable {
 
   /// Evaluates a lowered `operand [NOT] IN (element, …)` against `row`.
   ///
-  /// The `operand` is evaluated ONCE per row — an OR-chain of `compare`s would
+  /// The `operand` is evaluated once per row — an OR-chain of `compare`s would
   /// re-evaluate a non-idempotent operand once per element — then `operand =
   /// element` folds over the elements IN ORDER under Kleene `OR`, seeded FALSE
   /// and short-circuiting at the first TRUE (the same left-to-right visit the
@@ -389,15 +389,15 @@ extension Catalog where Self: ~Escapable {
   }
 
   /// Evaluates a lowered `operand [NOT] IN (Q)` against `row` over the
-  /// subquery's ALREADY-MATERIALISED single column `values`.
+  /// subquery's already-materialised single column `values`.
   ///
   /// It is the value-list `member` fold over constants: the `operand` is
-  /// evaluated ONCE per row, then `operand = v` folds over the materialised
+  /// evaluated once per row, then `operand = v` folds over the materialised
   /// `values` IN ORDER under Kleene `OR`, seeded FALSE and short-circuiting at
   /// the first TRUE — so a NULL operand or a NULL element keeps the ISO
-  /// three-valued result (an unmatched test is UNKNOWN, not FALSE), an EMPTY
+  /// three-valued result (an unmatched test is UNKNOWN, not FALSE), an empty
   /// `values` folds FALSE (no witness), and `NOT IN` negates that truth,
-  /// mapping UNKNOWN to itself. It reuses the SAME `matches`/`or` primitives
+  /// mapping UNKNOWN to itself. It reuses the same `matches`/`or` primitives
   /// the value-list `IN` does, so the two forms share one three-valued core.
   private borrowing func member(_ row: borrowing some Row & ~Escapable,
                                 _ operand: Term, _ values: Array<Value>,
@@ -414,11 +414,11 @@ extension Catalog where Self: ~Escapable {
 
   /// Evaluates a lowered `(l…) <op> (r…)` row-value comparison against `row`.
   ///
-  /// Each side is evaluated exactly ONCE per row into a `[Value]` — a desugar
+  /// Each side is evaluated exactly once per row into a `[Value]` — a desugar
   /// to a conjunction/cascade of scalar `compare`s re-evaluated a component
   /// once per place it appeared, so a stateful component yielded a different
   /// value each time — then the two rows fold through the shared `relate`
-  /// primitive, which reproduces the ISO three-valued truth with the SAME
+  /// primitive, which reproduces the ISO three-valued truth with the same
   /// `matches`/Kleene logic a scalar comparison uses.
   private borrowing func compare(_ row: borrowing some Row & ~Escapable,
                                  _ lhs: Array<Term>, _ op: Comparison,
@@ -436,7 +436,7 @@ extension Catalog where Self: ~Escapable {
   /// Evaluates a lowered `(l…) [NOT] IN ((r…), …)` row-value membership against
   /// `row`.
   ///
-  /// The left row is evaluated ONCE per row into a `[Value]` — as a scalar
+  /// The left row is evaluated once per row into a `[Value]` — as a scalar
   /// `member` holds its operand once, so a stateful component is read a single
   /// time rather than once per element row — then `(l…) = (r…)` folds over the
   /// element rows IN ORDER under Kleene `OR`, seeded FALSE and short-circuiting
@@ -463,15 +463,15 @@ extension Catalog where Self: ~Escapable {
   }
 
   /// Evaluates a lowered `operand op {ANY | ALL} (Q)` against `row` over the
-  /// subquery's ALREADY-MATERIALISED single column `values`.
+  /// subquery's already-materialised single column `values`.
   ///
-  /// The `operand` is evaluated ONCE per row, then `operand op v` folds over
-  /// the materialised `values` IN ORDER with the SAME `matches`/Kleene
+  /// The `operand` is evaluated once per row, then `operand op v` folds over
+  /// the materialised `values` IN ORDER with the same `matches`/Kleene
   /// primitives the value-list and `IN (Q)` `member` folds use — Kleene `OR`
   /// seeded FALSE for `any` (short-circuiting at the first TRUE), Kleene `AND`
   /// seeded TRUE for `all` (short-circuiting at the first FALSE). So a NULL
   /// `operand` or a NULL element makes an otherwise-undecided fold UNKNOWN (not
-  /// FALSE), an EMPTY `values` takes the seed — `any` FALSE (no witness), `all`
+  /// FALSE), an empty `values` takes the seed — `any` FALSE (no witness), `all`
   /// TRUE (vacuous) — and the identity falls out of the fold rather than a
   /// special case. `= ANY` reduces to the `member` `IN` fold and `<> ALL` to
   /// its negation, sharing one three-valued core with `within`.
@@ -498,12 +498,12 @@ extension Catalog where Self: ~Escapable {
 
   /// Evaluates a lowered `test [NOT] BETWEEN lower AND upper` against this row.
   ///
-  /// The `test` term is evaluated ONCE per row — an `AND`/`OR` of two
+  /// The `test` term is evaluated once per row — an `AND`/`OR` of two
   /// comparisons would re-evaluate a non-idempotent test once per bound — then
-  /// the two bounds fold against that SAME value under Kleene logic as `test >=
-  /// lower AND test <= upper`. `NOT BETWEEN` is the NEGATION of that same
+  /// the two bounds fold against that same value under Kleene logic as `test >=
+  /// lower AND test <= upper`. `NOT BETWEEN` is the negation of that same
   /// truth, NOT the `test < lower OR test > upper` expansion: with a cross-kind
-  /// bound `matches` yields FALSE for EVERY ordering operator (so `test <
+  /// bound `matches` yields FALSE for every ordering operator (so `test <
   /// lower` is not the complement of `test >= lower`), and the expansion would
   /// diverge from `NOT (test BETWEEN lower AND upper)` — e.g. `K NOT BETWEEN
   /// 'a' AND 10` must KEEP the row (the cross-kind `K >= 'a'` is FALSE, so
@@ -539,10 +539,10 @@ extension Catalog where Self: ~Escapable {
 
   /// Evaluates a lowered `lhs IS [NOT] DISTINCT FROM rhs` against this row.
   ///
-  /// It is the ISO null-safe comparison — TWO-VALUED, never UNKNOWN — treating
+  /// It is the ISO null-safe comparison — two-valued, never UNKNOWN — treating
   /// NULL as a comparable value: `distinct` yields whether the two operand
-  /// values DIFFER (both NULL are the SAME, exactly one NULL DIFFERS, two
-  /// non-NULLs DIFFER unless equal, a cross-kind pair DIFFERS). `IS DISTINCT
+  /// values differ (both NULL are the same, exactly one NULL differs, two
+  /// non-NULLs differ unless equal, a cross-kind pair differs). `IS DISTINCT
   /// FROM` reads that; `IS NOT DISTINCT FROM` (`negated`, null-safe equality)
   /// negates it. Unlike a `compare`, a NULL operand never makes the row
   /// UNKNOWN.
@@ -572,8 +572,8 @@ extension Catalog where Self: ~Escapable {
   /// Evaluates a lowered `operand [NOT] LIKE pattern [ESCAPE escape]` against
   /// this row under three-valued logic.
   ///
-  /// The operand, pattern, and optional escape are each evaluated ONCE, IN
-  /// ORDER, BEFORE the three-valued result is decided — so a faulting reached
+  /// The operand, pattern, and optional escape are each evaluated once, IN
+  /// ORDER, before the three-valued result is decided — so a faulting reached
   /// operand (`(1 / K)` with `K = 0`) surfaces its throw rather than being
   /// silently swallowed by a NULL escape. Only once all three have evaluated is
   /// the result decided: a non-NULL escape that is not a single character is
@@ -590,7 +590,7 @@ extension Catalog where Self: ~Escapable {
                               _ context: Context)
       throws(SQLError) -> Bool? {
     // Evaluate all three reached operands once, in order — a fault in any of
-    // them (a divide, an overflow) propagates HERE, before the NULL/escape
+    // them (a divide, an overflow) propagates here, before the NULL/escape
     // result below can turn it into a silent UNKNOWN.
     let subject = try evaluate(row, operand, context)
     let template = try evaluate(row, pattern, context)
@@ -641,7 +641,7 @@ private enum Atom: Equatable {
 }
 
 /// The `pattern` decoded into atoms, its escape resolved, or `nil` when the
-/// pattern is ILL-FORMED — a trailing escape with no character to escape, which
+/// pattern is ill-formed — a trailing escape with no character to escape, which
 /// matches nothing. An escape character makes the next character a `.literal`
 /// (so escaped `%`, `_`, or the escape character are literals); every other
 /// character is `%` → `.any`, `_` → `.single`, else `.literal`.
@@ -677,8 +677,8 @@ private func atoms(of pattern: Array<Character>,
 /// `escape` followed by `%`, `_`, or `escape` matches a literal `%`, `_`, or
 /// the escape character).
 ///
-/// The match is ANCHORED — the whole `text` must be consumed. It is the classic
-/// LINEAR two-pointer `LIKE` scan: a `%` is remembered (the pattern position
+/// The match is anchored — the whole `text` must be consumed. It is the classic
+/// linear two-pointer `LIKE` scan: a `%` is remembered (the pattern position
 /// after it, and the text mark it may extend to) and matching proceeds
 /// greedily; on a later mismatch the TEXT pointer is advanced past the mark and
 /// the scan resumes after the remembered `%`, rather than re-recursing. This is

--- a/Sources/SQLEngine/Filter.swift
+++ b/Sources/SQLEngine/Filter.swift
@@ -30,7 +30,7 @@ internal indirect enum Filter: Equatable, Sendable {
   /// AST's `null`, a definite two-valued test (never UNKNOWN).
   case null(Term, negated: Bool)
   /// `operand [NOT] IN (element, …)` — the lowered form of the AST's
-  /// `membership`. The operand term is held ONCE, the value list lowered to
+  /// `membership`. The operand term is held once, the value list lowered to
   /// element terms, and `negated` marks `NOT IN`. Evaluating it reads the
   /// operand exactly once per row (an OR-chain of `compare`s would re-evaluate
   /// a non-idempotent operand, once per element) and folds `operand = element`
@@ -39,24 +39,24 @@ internal indirect enum Filter: Equatable, Sendable {
   /// itself).
   case membership(Term, Array<Term>, negated: Bool)
   /// `(l1, …, ln) <op> (r1, …, rn)` — an ISO row-value comparison, both sides a
-  /// row of ordinal-addressed terms of EQUAL arity, `op` any of the six
+  /// row of ordinal-addressed terms of equal arity, `op` any of the six
   /// operators. The lowered form of the AST's `rows`. Every component term is
-  /// evaluated exactly ONCE per row into a `[Value]` (a parse-time desugar to a
+  /// evaluated exactly once per row into a `[Value]` (a parse-time desugar to a
   /// conjunction/cascade of scalar `compare`s re-evaluated a component once per
   /// place it appeared, so a stateful component yielded a different value each
-  /// time), then the runtime folds those values with the SAME `matches`
+  /// time), then the runtime folds those values with the same `matches`
   /// primitive and Kleene `AND`/`OR` a scalar comparison uses, reproducing the
   /// ISO three-valued truth: `=` is the Kleene `AND` of the componentwise
   /// equalities, `<>` its negation, and the four ordering operators the
   /// lexicographic cascade `l1 <op> r1 OR (l1 = r1 AND (l2 <op> r2 OR …))`
-  /// whose earlier steps use the STRICT operator (`<`/`>`) and whose innermost
+  /// whose earlier steps use the strict operator (`<`/`>`) and whose innermost
   /// step carries `op` itself (so `<=`/`>=` admit an all-equal row) — a NULL
   /// component making a componentwise test UNKNOWN, threaded through the fold.
   case comparison(Array<Term>, Comparison, Array<Term>)
   /// `(l1, …, ln) [NOT] IN ((r1, …, rn), …)` — an ISO row-value membership, the
   /// left a row of ordinal-addressed terms and `rows` a non-empty list of
-  /// element rows of EQUAL arity, `negated` marking `NOT IN`. The lowered form
-  /// of the AST's `among`. The left row is evaluated exactly ONCE per row into
+  /// element rows of equal arity, `negated` marking `NOT IN`. The lowered form
+  /// of the AST's `among`. The left row is evaluated exactly once per row into
   /// a `[Value]` (as a scalar `Filter.membership` holds its operand once), then
   /// `(l…) = (r…)` folds over the element rows IN ORDER under Kleene `OR`,
   /// seeded FALSE, short-circuiting at the first TRUE — each element equality
@@ -79,7 +79,7 @@ internal indirect enum Filter: Equatable, Sendable {
   /// LIKE` negating the three-valued result (UNKNOWN maps to itself).
   case like(Term, pattern: Operand, escape: Operand?, negated: Bool)
   /// `x [NOT] BETWEEN a AND b` — the lowered form of the AST's `between`. The
-  /// test term `x` is held ONCE, the two bounds `a` and `b` beside it — each an
+  /// test term `x` is held once, the two bounds `a` and `b` beside it — each an
   /// `Operand`, a `Term` evaluated per row or a run-time `:parameter` resolved
   /// from the bindings — and `negated` marks `NOT BETWEEN`. Evaluating it reads
   /// `x` once per row (an `AND`/`OR` of two comparisons would re-evaluate a
@@ -91,8 +91,8 @@ internal indirect enum Filter: Equatable, Sendable {
   /// `a IS [NOT] DISTINCT FROM b` — the lowered form of the AST's `distinct`.
   /// Both operands are plain `Term`s (no `:parameter` form is defined for this
   /// predicate) and `negated` marks the `IS NOT DISTINCT FROM` (null-safe
-  /// equality) spelling. Evaluating it is TWO-VALUED — never UNKNOWN — treating
-  /// NULL as a comparable value: the two are the SAME iff both are NULL, or
+  /// equality) spelling. Evaluating it is two-valued — never UNKNOWN — treating
+  /// NULL as a comparable value: the two are the same iff both are NULL, or
   /// both non-NULL and equal (a cross-kind pair is DISTINCT, matching
   /// `matches`'s cross-kind FALSE equality), and `IS DISTINCT FROM` is TRUE
   /// when they differ, `IS NOT DISTINCT FROM` when they are the same.
@@ -100,48 +100,48 @@ internal indirect enum Filter: Equatable, Sendable {
   /// `[NOT] EXISTS (Q)` — the lowered form of the AST's `exists`. The subquery
   /// occurrence is carried as its cache `Subkey` (its resolution scope composed
   /// with `Q`) — never run during `compile`, so a schema-only path
-  /// (`columns(of:)`, view resolution) opens no cursor. At RUN time it runs
-  /// ONCE against the borrowed catalog (memoised in a `Subqueries` cache under
-  /// the `Subkey`, since it is UNCORRELATED — one result for every outer row,
-  /// under its OWN resolution context) and the case is the DEFINITE two-valued
+  /// (`columns(of:)`, view resolution) opens no cursor. At run time it runs
+  /// once against the borrowed catalog (memoised in a `Subqueries` cache under
+  /// the `Subkey`, since it is uncorrelated — one result for every outer row,
+  /// under its own resolution context) and the case is the definite two-valued
   /// non-empty test of that result: TRUE iff `Q` yielded a row, `negated`
   /// flipping it (never UNKNOWN). It reads no cell of the outer row. An
-  /// EXISTS-only occurrence is materialised as a cardinality PROBE — its select
+  /// EXISTS-only occurrence is materialised as a cardinality probe — its select
   /// list never evaluated. A later correlated slice re-runs `Q` per outer row.
   case exists(Subkey, correlation: Correlation, negated: Bool)
   /// `x [NOT] IN (Q)` — the lowered form of the AST's `within`. The subquery
   /// occurrence is carried as its cache `Subkey` — never run during `compile` —
-  /// and its single-column arity is enforced at COMPILE from its compiled width
-  /// (`SQLError.arity`, no cursor). At RUN time `Q` executes ONCE against the
+  /// and its single-column arity is enforced at compile from its compiled width
+  /// (`SQLError.arity`, no cursor). At run time `Q` executes once against the
   /// borrowed catalog (memoised under the `Subkey` in the `Subqueries` cache,
-  /// UNCORRELATED) and the case folds `operand = v` over its lone column under
-  /// the SAME Kleene `OR` three-valued membership the value-list
+  /// uncorrelated) and the case folds `operand = v` over its lone column under
+  /// the same Kleene `OR` three-valued membership the value-list
   /// `Filter.membership` uses — a NULL operand or a NULL element making an
-  /// unmatched test UNKNOWN, an EMPTY result FALSE, and `negated` (`NOT IN`)
+  /// unmatched test UNKNOWN, an empty result FALSE, and `negated` (`NOT IN`)
   /// negating the three-valued result (UNKNOWN maps to itself). The operand
   /// `Term` is evaluated once per row.
   case within(Term, Subkey, correlation: Correlation, negated: Bool)
   /// `x op {ANY | ALL} (Q)` — the lowered form of the AST's `quantified`. The
-  /// operand term `x` is held ONCE, the comparison `op` and the `Quantifier`
+  /// operand term `x` is held once, the comparison `op` and the `Quantifier`
   /// beside it, and the subquery occurrence as its cache `Subkey` (its
   /// `.valued` role, the FULL column materialised as `within`'s is) — never
-  /// run during `compile`, its single-column arity enforced at COMPILE from the
-  /// compiled width (`SQLError.arity`, no cursor). At RUN `Q` executes ONCE
-  /// against the borrowed catalog (memoised under the `Subkey`, UNCORRELATED)
-  /// and the case folds `x op v` over its lone column with the SAME
+  /// run during `compile`, its single-column arity enforced at compile from the
+  /// compiled width (`SQLError.arity`, no cursor). At run `Q` executes once
+  /// against the borrowed catalog (memoised under the `Subkey`, uncorrelated)
+  /// and the case folds `x op v` over its lone column with the same
   /// `matches`/Kleene primitives `within` uses: Kleene `OR` for `any` (seeded
   /// FALSE), Kleene `AND` for `all` (seeded TRUE), so a NULL `x` or element
-  /// makes an otherwise-undecided fold UNKNOWN, and an EMPTY column takes the
+  /// makes an otherwise-undecided fold UNKNOWN, and an empty column takes the
   /// seed — `any` FALSE, `all` TRUE. The operand `Term` is evaluated once per
-  /// row. A CORRELATED occurrence carries the discovered `correlation` (as
-  /// `within` does) and re-runs its inner plan per outer row; an UNCORRELATED
+  /// row. A correlated occurrence carries the discovered `correlation` (as
+  /// `within` does) and re-runs its inner plan per outer row; an uncorrelated
   /// one carries an empty correlation and memoises once.
   case quantified(Term, Comparison, Quantifier, Subkey,
                   correlation: Correlation)
   /// `p IS [NOT] <truth value>` — the lowered form of the AST's `truth`. The
   /// inner boolean `Filter` is held once and evaluated to its three-valued
-  /// result, which is then MAPPED against `value` (`TRUE`/`FALSE`/`UNKNOWN`) to
-  /// a DEFINITE two-valued result — never itself UNKNOWN — and negated for `IS
+  /// result, which is then mapped against `value` (`TRUE`/`FALSE`/`UNKNOWN`) to
+  /// a definite two-valued result — never itself UNKNOWN — and negated for `IS
   /// NOT`. An UNKNOWN inner is FALSE against `TRUE`/`FALSE` but TRUE against
   /// `UNKNOWN`, so the test collapses SQL's third value to a two-valued answer.
   case truth(Filter, Truth, negated: Bool)
@@ -254,7 +254,7 @@ internal indirect enum Term: Equatable, Sendable {
   /// The cell at `slot` of the record.
   case slot(Int)
   /// A run-time `:parameter`, resolved from the engine's bindings — the lowered
-  /// form of a CORRELATED subquery's reference to an ENCLOSING query's column.
+  /// form of a correlated subquery's reference to an enclosing query's column.
   /// An outer column the inner query names binds neither locally nor as an
   /// ordinary parameter; it lowers to this synthetic name, and the
   /// per-outer-row re-execution binds it to that row's cell before running the
@@ -276,40 +276,40 @@ internal indirect enum Term: Equatable, Sendable {
   /// or `NULL` when there is none. `type` is the unification of the branch
   /// result types (the same `ValueType.unified` reduction `derive`/`validate`
   /// compute) — the type the schema advertises for the column — so the executor
-  /// COERCES the selected value to it, widening an `.integer` arm of a
+  /// coerces the selected value to it, widening an `.integer` arm of a
   /// `.double` CASE.
   case `case`(Array<(Filter, Term)>, else: Term?, type: ValueType)
   /// A `CAST(operand AS type)` — the lowered form of the AST's
-  /// `Expression.cast`. The executor evaluates the operand `Term` and CONVERTS
+  /// `Expression.cast`. The executor evaluates the operand `Term` and converts
   /// the value to `type` (`Value.cast(to:)`), so an unconvertible value faults
   /// rather than yielding a wrong one. `type` is also the term's static type —
   /// the type the schema advertises for the column.
   case cast(Term, ValueType)
   /// `COALESCE(v1, v2, …)` — the lowered form of the AST's
   /// `Expression.coalesce`. Each element term is evaluated IN ORDER exactly
-  /// ONCE, and the first whose value is non-NULL is the result, else NULL. A
+  /// once, and the first whose value is non-NULL is the result, else NULL. A
   /// desugar to a `CASE WHEN vi IS NOT NULL THEN vi …` re-evaluated each `vi`,
   /// so a stateful element yielded a different value to its guard and its
-  /// result; holding the element ONCE (as `membership` holds its operand) fixes
+  /// result; holding the element once (as `membership` holds its operand) fixes
   /// that. `type` is the unification of the element types, to which the
-  /// selected value is COERCED — the type the schema advertises.
+  /// selected value is coerced — the type the schema advertises.
   case coalesce(Array<Term>, type: ValueType)
   /// `NULLIF(a, b)` — the lowered form of the AST's `Expression.nullif`. Both
-  /// operand terms are evaluated exactly ONCE (`va`, `vb`); the result is NULL
-  /// when `va = vb` is TRUE, else the SAME `va` that was compared. A desugar to
+  /// operand terms are evaluated exactly once (`va`, `vb`); the result is NULL
+  /// when `va = vb` is TRUE, else the same `va` that was compared. A desugar to
   /// `CASE WHEN a = b THEN NULL ELSE a END` evaluated `a` twice — comparing one
-  /// value and returning another — which holding `a` ONCE fixes.
+  /// value and returning another — which holding `a` once fixes.
   case nullif(Term, Term)
   /// A scalar subquery `(SELECT …)` — the lowered form of the AST's
   /// `Expression.subquery`. The subquery occurrence is carried as its cache
   /// `Subkey` (its resolution scope composed with the inner `Query`) — never
   /// run during `compile`, so a schema-only path opens no cursor — and its
-  /// single-column arity is enforced at COMPILE from its compiled width
-  /// (`SQLError.arity`, no cursor). At RUN it runs ONCE against the borrowed
+  /// single-column arity is enforced at compile from its compiled width
+  /// (`SQLError.arity`, no cursor). At run it runs once against the borrowed
   /// catalog (memoised under the `Subkey` in the `Subqueries` cache,
-  /// UNCORRELATED), collapsing to its lone cell (empty → NULL, one row → the
+  /// uncorrelated), collapsing to its lone cell (empty → NULL, one row → the
   /// cell, more → `SQLError.cardinality`), and the case reads that collapsed
-  /// value, COERCED to `type` — the inner column's single-column type — as a
+  /// value, coerced to `type` — the inner column's single-column type — as a
   /// `CASE` coerces its selected arm. A later correlated slice re-runs it per
   /// outer row.
   case subquery(Subkey, correlation: Correlation, type: ValueType)
@@ -331,7 +331,7 @@ internal indirect enum Term: Equatable, Sendable {
 }
 
 extension Term {
-  /// Structural equality over two lowered terms — the RESOLVED form column
+  /// Structural equality over two lowered terms — the resolved form column
   /// qualification has already normalized to a slot — so a `DISTINCT` ORDER BY
   /// key can be recognised as one of the projected select-list values it must
   /// order on (see `distinct`). The compiler cannot synthesise `Equatable` for
@@ -384,7 +384,7 @@ extension Term {
     case let .slot(slot):
       slots.insert(slot)
     case .parameter:
-      // A correlated `:parameter` reads no cell of THIS row — its value comes
+      // A correlated `:parameter` reads no cell of this row — its value comes
       // from an enclosing row bound into the run's bindings — so it references
       // no slot of the current record.
       break
@@ -413,11 +413,11 @@ extension Term {
       lhs.references(into: &slots)
       rhs.references(into: &slots)
     case let .subquery(_, correlation, _):
-      // A CORRELATED scalar subquery reads the enclosing row's cells its inner
+      // A correlated scalar subquery reads the enclosing row's cells its inner
       // `WHERE` names — the correlation's `slot` outer ordinals — so those must
       // be materialised into the outer record for the per-row re-execution to
       // bind them. A `bound` source is a threaded binding, not an outer cell,
-      // so it references none. An UNCORRELATED one (empty correlation)
+      // so it references none. An uncorrelated one (empty correlation)
       // references none — its value is a single cache lookup.
       slots.formUnion(correlation.slots)
     case .grouping:
@@ -458,10 +458,10 @@ extension Term {
     case let .nullif(lhs, rhs):
       .nullif(lhs.remapped(through: slot), rhs.remapped(through: slot))
     case let .subquery(key, correlation, type):
-      // A CORRELATED scalar subquery's correlation reads OUTER ordinals; remap
+      // A correlated scalar subquery's correlation reads OUTER ordinals; remap
       // each `slot` to its packed slot so the per-row re-execution reads the
       // outer record's cell (a `bound` source is unchanged — it reads a
-      // threaded binding). An UNCORRELATED one has an empty map and is
+      // threaded binding). An uncorrelated one has an empty map and is
       // unchanged.
       .subquery(key, correlation: correlation.remapped(through: slot),
                 type: type)
@@ -488,9 +488,9 @@ extension Term {
     }
   }
 
-  /// Whether this term reads a run-time `:parameter` anywhere — a CORRELATED
+  /// Whether this term reads a run-time `:parameter` anywhere — a correlated
   /// subquery's synthetic outer binding, which may be unbound or bound to NULL,
-  /// so a comparison over it can be UNKNOWN even when it reads NO slot.
+  /// so a comparison over it can be UNKNOWN even when it reads no slot.
   /// Selection pushdown reads this (through `Filter.nullable`) so a
   /// `.compare`/`.null` over a correlated `:parameter` — a slotless `outer_id =
   /// 1` — is not moved ahead of a later unsafe conjunct the
@@ -515,11 +515,11 @@ extension Term {
     }
   }
 
-  /// Whether this term is STATICALLY a valid single-character `LIKE` escape — a
+  /// Whether this term is statically a valid single-character `LIKE` escape — a
   /// constant text value of exactly one character, the only form `Row.like`
   /// accepts without faulting. A slot, a call, or a constant that is NULL,
   /// non-text, or a text of any other length is not: its escape validity is not
-  /// known until the row runs, so it CANNOT ride below a seek or join (see
+  /// known until the row runs, so it cannot ride below a seek or join (see
   /// `Filter.safe`). Reused as the escape-safety gate; it does not decide the
   /// eval result, only the pushdown/seek classification.
   internal var escape: Bool {
@@ -556,7 +556,7 @@ extension Filter.Operand {
     }
   }
 
-  /// Whether this operand is STATICALLY a valid single-character `LIKE`
+  /// Whether this operand is statically a valid single-character `LIKE`
   /// escape — only a constant single-character text term. A `:parameter` is
   /// per-run, not a static constant, so it is NOT statically valid (it may be
   /// unbound, NULL, or the wrong length at run time) and marks the `LIKE`
@@ -620,23 +620,23 @@ extension Filter {
              rhs.remapped(through: slot),
              negated: negated)
     case let .exists(key, correlation, negated):
-      // A CORRELATED EXISTS reads the enclosing row's cells its inner `WHERE`
+      // A correlated EXISTS reads the enclosing row's cells its inner `WHERE`
       // names; remap each `slot` outer ordinal to its packed slot (a `bound`
-      // source is unchanged). An UNCORRELATED one has an empty map and passes
+      // source is unchanged). An uncorrelated one has an empty map and passes
       // its cache key through unchanged.
       .exists(key, correlation: correlation.remapped(through: slot),
               negated: negated)
     case let .within(operand, key, correlation, negated):
-      // The outer operand term reads slots; a CORRELATED subquery ALSO reads
-      // the outer cells its inner `WHERE` names, so remap both. An UNCORRELATED
+      // The outer operand term reads slots; a correlated subquery also reads
+      // the outer cells its inner `WHERE` names, so remap both. An uncorrelated
       // one carries an empty correlation.
       .within(operand.remapped(through: slot), key,
               correlation: correlation.remapped(through: slot),
               negated: negated)
     case let .quantified(operand, op, quantifier, key, correlation):
-      // As `within`: the outer operand term reads slots; a CORRELATED subquery
-      // ALSO reads the outer cells its inner `WHERE` names, so remap both. An
-      // UNCORRELATED one carries an empty correlation.
+      // As `within`: the outer operand term reads slots; a correlated subquery
+      // also reads the outer cells its inner `WHERE` names, so remap both. An
+      // uncorrelated one carries an empty correlation.
       .quantified(operand.remapped(through: slot), op, quantifier, key,
                   correlation: correlation.remapped(through: slot))
     case let .truth(inner, value, negated):
@@ -676,7 +676,7 @@ extension Filter {
   }
 
   /// `product` gated by this filter for a join `nest` that cannot fold into a
-  /// `Join`, keeping the ON `match` conjuncts as a SEPARATE inner gate below
+  /// `Join`, keeping the ON `match` conjuncts as a separate inner gate below
   /// the rest — `Select(rest, Select(match, product))`. Because evaluating
   /// `.and` does not short-circuit, folding the match into one `AND` with WHERE
   /// would, for a pair whose NULL join key makes the match UNKNOWN, still
@@ -719,10 +719,10 @@ extension Filter {
     case let .memberships(lhs, rows, _):
       lhs.allSatisfy(\.safe) && rows.allSatisfy { $0.allSatisfy(\.safe) }
     case let .like(operand, pattern, escape, _):
-      // An escape makes the predicate UNSAFE unless it is STATICALLY a valid
+      // An escape makes the predicate unsafe unless it is statically a valid
       // single-character escape: `Row.like` faults (`SQLError.argument`) on any
       // escape that does not evaluate to a one-character text — a throw
-      // INDEPENDENT of whether a pair matches, so it must not ride below a seek
+      // independent of whether a pair matches, so it must not ride below a seek
       // or join and fire on an empty product (or be dropped by a hash key). A
       // non-constant escape (a slot or call) or a constant that is NULL,
       // non-text, or the wrong length is unsafe; only a `.constant` text of
@@ -735,11 +735,11 @@ extension Filter {
       test.safe && lower.safe && upper.safe
     case let .distinct(lhs, rhs, _): lhs.safe && rhs.safe
     case .exists, .within, .quantified:
-      // A subquery predicate is NEVER safe to push below a seek or short-
-      // circuiting derived/view filter. Under LAZY materialisation the FIRST
-      // evaluation of even an UNCORRELATED occurrence RUNS the inner query,
-      // which may FAULT (`EXISTS (SELECT 1 FROM S WHERE 1 / z = 0)`); a
-      // CORRELATED one re-runs per outer row. Pushed below a short-circuiting
+      // A subquery predicate is never safe to push below a seek or short-
+      // circuiting derived/view filter. Under lazy materialisation the FIRST
+      // evaluation of even an uncorrelated occurrence runs the inner query,
+      // which may fault (`EXISTS (SELECT 1 FROM S WHERE 1 / z = 0)`); a
+      // correlated one re-runs per outer row. Pushed below a short-circuiting
       // filter — a view's `WHERE 1 = 0`, a seek — it would be evaluated for a
       // row the filter drops, raising a throw the unmoved query never reaches,
       // so it stays at the product level, run only where the outer predicate
@@ -760,7 +760,7 @@ extension Filter {
   /// operand — slotless yet not definite). Only a filter over constants alone
   /// whose leaves are all definite is TRUE/FALSE for certain. Selection
   /// pushdown must not ride a nullable conjunct below a join or into a view
-  /// when a LATER conjunct is unsafe: the evaluator's `AND` does not
+  /// when a later conjunct is unsafe: the evaluator's `AND` does not
   /// short-circuit, so the un-pushed query evaluates the later conjunct even
   /// when this one is UNKNOWN — pushing this one down drops the UNKNOWN row
   /// before the later conjunct runs, suppressing a throw the left-to-right
@@ -772,14 +772,14 @@ extension Filter {
     !slots.isEmpty || parameterised || contingent
   }
 
-  /// Whether this filter can be UNKNOWN INDEPENDENT of any slot or
+  /// Whether this filter can be UNKNOWN independent of any slot or
   /// `:parameter` — an `IN (Q)` subquery test (`Filter.within`), which is
   /// three-valued: `x IN (Q)` is UNKNOWN when `Q`'s materialised column holds a
   /// NULL and no element matches, so a slotless `1 IN (Q)` over a constant
   /// operand is still not definite. `nullable` counts it even when `slots` is
   /// empty and nothing is parameterised, keeping an `IN (Q)` conjunct off a
   /// pushdown ahead of a later unsafe conjunct the non-short-circuiting `AND`
-  /// still owes. An `EXISTS (Q)` is genuinely TWO-valued — a decided non-empty
+  /// still owes. An `EXISTS (Q)` is genuinely two-valued — a decided non-empty
   /// test, never UNKNOWN — so it is NOT contingent and stays freely pushable.
   private var contingent: Bool {
     switch self {
@@ -801,8 +801,8 @@ extension Filter {
   }
 
   /// Whether this filter compares against a run-time `:parameter` — a `.bound`
-  /// anywhere in it, a `.compare`/`.null`/`.membership`/`.distinct` whose TERM
-  /// carries a `Term.parameter` (a CORRELATED subquery's synthetic outer
+  /// anywhere in it, a `.compare`/`.null`/`.membership`/`.distinct` whose term
+  /// carries a `Term.parameter` (a correlated subquery's synthetic outer
   /// binding), a `.like` whose pattern or escape operand is a `:parameter`, or
   /// a `.between` whose test or bound carries one. Such a predicate reads no
   /// slot yet can be UNKNOWN, because the parameter may be unbound (or bound to
@@ -816,7 +816,7 @@ extension Filter {
   internal var parameterised: Bool {
     switch self {
     case .bound: true
-    // A term-bearing predicate is parameterised when a TERM carries a
+    // A term-bearing predicate is parameterised when a term carries a
     // correlated `Term.parameter` — a slotless comparison that can be UNKNOWN,
     // so it must not ride ahead of a later unsafe conjunct, the same treatment
     // `.bound` gets.
@@ -832,9 +832,9 @@ extension Filter {
           || rows.contains { $0.contains(where: \.parameterised) }
     case let .distinct(lhs, rhs, _): lhs.parameterised || rhs.parameterised
     case .match: false
-    // An UNCORRELATED subquery predicate reads no run-time `:parameter` of the
+    // An uncorrelated subquery predicate reads no run-time `:parameter` of the
     // OUTER query — the subquery runs once at run start with the same bindings
-    // — so none is parameterised for the outer row. A CORRELATED one is already
+    // — so none is parameterised for the outer row. A correlated one is already
     // NOT `safe` (it re-runs per row), so it never rides a pushdown regardless.
     case .exists, .within, .quantified: false
     case let .like(operand, pattern, escape, _):
@@ -849,15 +849,15 @@ extension Filter {
     }
   }
 
-  /// This filter's PROVABLE two-valued truth INDEPENDENT of any row, binding,
+  /// This filter's provable two-valued truth independent of any row, binding,
   /// or subquery — `true` when it is always TRUE, `false` when always FALSE,
-  /// and `nil` when it is not statically decidable (the CONSERVATIVE default).
+  /// and `nil` when it is not statically decidable (the conservative default).
   /// A `select` treats UNKNOWN as reject, so the optimiser folds only a
   /// definite `true` (drops the select) and never mistakes an undecidable
   /// filter for one.
   ///
-  /// The ONLY provable leaf is a `compare(a, op, b)` over TWO `.constant`
-  /// operands: it evaluates through the SAME `matches` three-valued primitive
+  /// The ONLY provable leaf is a `compare(a, op, b)` over two `.constant`
+  /// operands: it evaluates through the same `matches` three-valued primitive
   /// the executor uses, so a NULL-bearing constant compare is UNKNOWN
   /// (`matches` yields `nil`) and reports `nil` — NOT provably true and NOT
   /// provably false — so a `WHERE NULL = 1` is left filtering (correctly
@@ -866,14 +866,14 @@ extension Filter {
   /// subquery — `bound`, a `compare` with a non-constant term, `match`, `null`,
   /// `membership`, `like`, `between`, `distinct`, `exists`, `within`,
   /// `quantified` — so its truth is not known here and it reports `nil`. The
-  /// connectives require BOTH operands to be DEFINITE: `and`/`or` report a
+  /// connectives require both operands to be definite: `and`/`or` report a
   /// definite result only when neither side is `nil` (an undecidable side makes
   /// the whole compound `nil`), `not` flips a definite operand, and `truth`
-  /// maps a DEFINITE inner through `tested`. This is STRICTER than the Kleene
+  /// maps a definite inner through `tested`. This is stricter than the Kleene
   /// dominance the executor uses (a `false` conjunct or `true` disjunct short-
-  /// circuiting the other side): dominance is sound for COMBINING already-
-  /// evaluated results, but `constant` licenses the optimiser to SKIP a filter
-  /// entirely, and an undecidable operand reads row data and can THROW — so it
+  /// circuiting the other side): dominance is sound for combining already-
+  /// evaluated results, but `constant` licenses the optimiser to skip a filter
+  /// entirely, and an undecidable operand reads row data and can throw — so it
   /// must never be dropped, and its parent can never be a compile-time
   /// constant.
   internal var constant: Bool? {
@@ -886,29 +886,29 @@ extension Filter {
       matches(lhs, op, rhs)
     // A comparison against a non-constant term reads a slot or `:parameter`;
     // its truth is not statically known. A row comparison and row `IN` are not
-    // statically folded — CONSERVATIVE, matching `.membership`/`.between`.
+    // statically folded — conservative, matching `.membership`/`.between`.
     case .compare, .bound, .match, .null, .membership, .comparison,
          .memberships, .like, .between, .distinct, .exists, .within,
          .quantified:
       nil
     case let .and(lhs, rhs):
-      // Both operands must be DEFINITE: a compile-time constant is only sound
-      // for FOLDING when the fold skips no runtime work. An undecidable operand
-      // reads row data and can THROW (e.g. `1 / X`), so it MUST be evaluated —
+      // Both operands must be definite: a compile-time constant is only sound
+      // for folding when the fold skips no runtime work. An undecidable operand
+      // reads row data and can throw (e.g. `1 / X`), so it must be evaluated —
       // even a `false`/`true` sibling cannot license dropping it. The Kleene
       // dominance that lets `matches` short-circuit already-evaluated results
-      // is UNSOUND here, where a definite `constant` authorises skipping the
+      // is unsound here, where a definite `constant` authorises skipping the
       // evaluation.
       if let l = lhs.constant, let r = rhs.constant { l && r } else { nil }
     case let .or(lhs, rhs):
-      // Both operands must be DEFINITE (see `.and`): a `true` disjunct cannot
+      // Both operands must be definite (see `.and`): a `true` disjunct cannot
       // license dropping an undecidable sibling that reads row data and may
       // throw — the parent is a compile-time constant only when both sides are.
       if let l = lhs.constant, let r = rhs.constant { l || r } else { nil }
     case let .not(operand):
       operand.constant.map { !$0 }
     case let .truth(inner, value, negated):
-      // `IS <truth>` is a DEFINITE two-valued test, but only when the inner's
+      // `IS <truth>` is a definite two-valued test, but only when the inner's
       // value is itself statically decided; an undecidable inner leaves `nil`.
       inner.constant == nil ? nil : tested(inner.constant, value, negated)
     }
@@ -950,7 +950,7 @@ internal func value(of literal: Literal) throws(SQLError) -> Value {
 }
 
 extension Row where Self: ~Escapable {
-  /// Evaluates a SUBQUERY-FREE `term` against this row through `routines` — the
+  /// Evaluates a subquery-free `term` against this row through `routines` — the
   /// entry point for a `CREATE FUNCTION` body (which cannot nest a subquery,
   /// see `NoCatalog`) and the unit choke points. It runs against `NoCatalog`,
   /// so a term that reached a scalar `.subquery` would fault; a subquery-free
@@ -969,7 +969,7 @@ extension Catalog where Self: ~Escapable {
   /// A `slot` reads the row's cell; a `constant` is itself; an `apply` looks
   /// the function up in the routines (`SQLError.function` on a miss), evaluates
   /// its arguments, and applies it; a scalar `.subquery` materialises against
-  /// this catalog LAZILY on first reach (memoised, so an unreachable arm never
+  /// this catalog lazily on first reach (memoised, so an unreachable arm never
   /// runs it). The `borrowing` row is non-escaping — a term runs over a
   /// materialised projection record or a predicate's borrowed cursor row.
   internal borrowing func evaluate(_ row: borrowing some Row & ~Escapable,
@@ -996,13 +996,13 @@ extension Catalog where Self: ~Escapable {
       // is none. The guard is a `Filter`, so it evaluates over the same row,
       // routines, bindings, and subquery results a `WHERE` filter does — a
       // `:parameter` guard resolves against the bindings, an UNKNOWN one does
-      // not select its branch. The selected value is COERCED to the CASE's
+      // not select its branch. The selected value is coerced to the CASE's
       // unified result `type` so it matches the column type the schema
-      // advertised. A scalar subquery in an UNREACHED arm is never evaluated,
+      // advertised. A scalar subquery in an unreached arm is never evaluated,
       // so it never runs (never throws) — the lazy `.subquery` case honours it.
       try conditional(row, branches, otherwise, type, context)
     case let .cast(operand, type):
-      // Evaluate the operand and CONVERT it to the target type: NULL casts to
+      // Evaluate the operand and convert it to the target type: NULL casts to
       // NULL, an unconvertible value faults (`Value.cast(to:)`), never yielding
       // a wrong value.
       try evaluate(row, operand, context).cast(to: type)
@@ -1011,11 +1011,11 @@ extension Catalog where Self: ~Escapable {
     case let .nullif(lhs, rhs):
       try nullif(row, lhs, rhs, context)
     case let .subquery(key, correlation, type):
-      // Materialise the scalar subquery LAZILY on this first reach — an
+      // Materialise the scalar subquery lazily on this first reach — an
       // occurrence in a skipped `CASE`/`COALESCE` arm is never reached, so it
-      // never runs (never throws). COERCE the collapsed value to the inner
-      // column's type, as a `CASE` coerces its selected arm. An UNCORRELATED
-      // one memoises; a CORRELATED one re-runs against this row's correlated
+      // never runs (never throws). coerce the collapsed value to the inner
+      // column's type, as a `CASE` coerces its selected arm. An uncorrelated
+      // one memoises; a correlated one re-runs against this row's correlated
       // bindings.
       try scalar(row, key, correlation, type, context)
     case let .grouping(_, bits):
@@ -1027,11 +1027,11 @@ extension Catalog where Self: ~Escapable {
   }
 
   /// The `bindings` extended with `correlation`'s outer cells — a `slot` entry
-  /// bound to the cell at that packed ordinal of the IMMEDIATE enclosing `row`,
-  /// a `bound` entry left as the incoming binding the CONTAINING subquery
-  /// already threaded down (a NESTED correlation to a grandparent column) — the
-  /// per-outer-row binding a CORRELATED subquery re-executes under. An
-  /// UNCORRELATED occurrence has an empty correlation, so this returns the
+  /// bound to the cell at that packed ordinal of the immediate enclosing `row`,
+  /// a `bound` entry left as the incoming binding the containing subquery
+  /// already threaded down (a nested correlation to a grandparent column) — the
+  /// per-outer-row binding a correlated subquery re-executes under. An
+  /// uncorrelated occurrence has an empty correlation, so this returns the
   /// bindings unchanged.
   private borrowing func correlated(_ row: borrowing some Row & ~Escapable,
                                     _ correlation: Correlation,
@@ -1063,19 +1063,19 @@ extension Catalog where Self: ~Escapable {
     return extended
   }
 
-  /// `context` re-scoped to the RECORDED revealed overlay of the occurrence
-  /// `key`'s scope — the SAME revealed base (CTEs plus `definition_schema.`
-  /// store relations, every enclosing SELECT's derived aliases STRIPPED) the
-  /// occurrence's plan was COMPILED against. The run records it under the scope
+  /// `context` re-scoped to the recorded revealed overlay of the occurrence
+  /// `key`'s scope — the same revealed base (CTEs plus `definition_schema.`
+  /// store relations, every enclosing SELECT's derived aliases stripped) the
+  /// occurrence's plan was compiled against. The run records it under the scope
   /// (`.caller` at the top level, `.view(name)` in a view body) as
-  /// `revealed().relations`; scoping the EXECUTION context to it makes a
+  /// `revealed().relations`; scoping the execution context to it makes a
   /// re-executed body resolve its `FROM` identically to compile, so a body
   /// `.scan` binds the CTE compile chose rather than a caller derived alias of
   /// the same name the unrevealed execution overlay would carry. On a miss (no
   /// box recorded) it leaves the overlay unchanged.
   ///
   /// The predicate-subquery paths (`present`/`values`/`scalar`) and the LATERAL
-  /// apply share this ONE seam, so the body plan a `Plan.apply` re-runs
+  /// apply share this one seam, so the body plan a `Plan.apply` re-runs
   /// per left row resolves under the identical revealed overlay `lateral(_:
   /// against:_:)` used at compile — the FROM-clause and predicate correlation
   /// paths cannot diverge from it.
@@ -1084,30 +1084,30 @@ extension Catalog where Self: ~Escapable {
     context.scoping(context.subqueries.overlay(key.scope) ?? context.relations)
   }
 
-  /// The rows a CORRELATED subquery occurrence `key` yields for `row` — the
-  /// SINGLE augment-and-execute path every correlated caller (`present`,
+  /// The rows a correlated subquery occurrence `key` yields for `row` — the
+  /// single augment-and-execute path every correlated caller (`present`,
   /// `values`, `scalar`) routes through, so none can skip the augmentation or
   /// the per-row overlay. It extends `bindings` with this row's correlated
   /// values, builds the execution context from the occurrence's scope overlay
-  /// AUGMENTED with the subquery's OWN `WITH`/derived-table rows, looks up the
-  /// PRE-COMPILED plan, and executes it.
+  /// augmented with the subquery's own `WITH`/derived-table rows, looks up the
+  /// pre-compiled plan, and executes it.
   ///
   /// The precompiled plan resolves a `WITH` item or a derived table `d` — `FROM
-  /// (SELECT …) AS d` — to a `.scan("d")` the executor binds by NAME from
-  /// `context.relations`, so the rows must be MATERIALISED into the overlay
-  /// first, exactly as the UNCORRELATED `run`/`probe`/`cell` path augments the
+  /// (SELECT …) AS d` — to a `.scan("d")` the executor binds by name from
+  /// `context.relations`, so the rows must be materialised into the overlay
+  /// first, exactly as the uncorrelated `run`/`probe`/`cell` path augments the
   /// query before running it. Without this the `.scan("d")` faults
   /// `SQLError.relation("d")` (or mis-binds an outer relation of the same
-  /// name). Augmenting on top of the per-row overlay PRESERVES both the
-  /// correlation bindings and the parent overlay: `augment` only ADDS this
+  /// name). Augmenting on top of the per-row overlay preserves both the
+  /// correlation bindings and the parent overlay: `augment` only adds this
   /// query's own aliases, and `validate: false` matches the lenient run path (a
-  /// REACHED body operand still faults at execution).
+  /// reached body operand still faults at execution).
   ///
-  /// A SET OPERATION binds NO derived alias at the query level — its arms are
+  /// A SET operation binds no derived alias at the query level — its arms are
   /// SELECT-scoped, each `FROM (SELECT …) AS d` local to its own arm — so a
   /// whole-query augment misses them and an arm's `.scan("d")` would fault
   /// `.relation("d")`. When the plan is a set operation this descends the plan
-  /// and query in lockstep and augments EACH ARM's own aliases before executing
+  /// and query in lockstep and augments each ARM's own aliases before executing
   /// that arm's sub-plan, exactly as the run and view setop paths do, while the
   /// correlation bindings and parent overlay ride into every arm through the
   /// shared `context`.
@@ -1117,24 +1117,24 @@ extension Catalog where Self: ~Escapable {
       throws(SQLError) -> Array<Record> {
     let bindings = correlated(row, correlation, context.bindings)
     let context = context.binding(bindings)
-    // A REACHED correlated scalar/`IN`/quantified occurrence over a SET
-    // OPERATION strictly re-folds its arms' column types before executing the
-    // SHAPED (placeholder-typed) plan the pre-pass recorded — the pre-pass
+    // A reached correlated scalar/`IN`/quantified occurrence over a SET
+    // operation strictly re-folds its arms' column types before executing the
+    // shaped (placeholder-typed) plan the pre-pass recorded — the pre-pass
     // compiles under `.shaping()`, so an irreconcilable pair was deferred to a
-    // placeholder there; this seam runs `context` WITHOUT a shape, so the fold
+    // placeholder there; this seam runs `context` without a shape, so the fold
     // faults `.operand`/42804 exactly as the uncorrelated `run` path does,
     // firing ONLY for reached occurrences (an unreachable one never calls
-    // `executed`, so its shape deferral stands). Only a SET OPERATION has a
+    // `executed`, so its shape deferral stands). Only a SET operation has a
     // cross-arm fold to check — a plain `SELECT` subquery has no arms to unify,
     // and resolving its projection here would fault on its own correlated
     // columns (out of scope in this fold context) — so a non-setop query skips
     // it. `EXISTS`/`LATERAL` skip it too: `EXISTS` ignores column types and the
-    // recorded probe is already the shape. The fold runs ONCE per occurrence —
+    // recorded probe is already the shape. The fold runs once per occurrence —
     // memoised on the `Subkey` — so a reached incompatibility faults on the
     // FIRST reached outer row and later rows skip the redundant (pure) re-fold.
     // A set operation may ride an `ordered` carrier (`ORDER BY`/`DISTINCT`/
-    // `OFFSET`·`FETCH` over the union), so fold on the query's CARRIER-
-    // TRANSPARENT core — a bare `case .setop = key.query` would swallow the
+    // `OFFSET`·`FETCH` over the union), so fold on the query's carrier-
+    // transparent core — a bare `case .setop = key.query` would swallow the
     // `.ordered` carrier and skip a reached carried union's strict re-fold,
     // diverging run from the uncorrelated `.operand`/42804 fault.
     if key.role == .scalar || key.role == .valued,
@@ -1145,11 +1145,11 @@ extension Catalog where Self: ~Escapable {
     guard let plan = context.subqueries.plan(key, correlation) else {
       throw .named("a correlated subquery plan was not compiled")
     }
-    // A SET-OPERATION subquery augments PER ARM (arm-local derived aliases the
+    // A SET-operation subquery augments per ARM (arm-local derived aliases the
     // query-level augment misses); a single query augments the whole query
     // once. A carried union compiles to a `.shaped` plan (a project/sort/
     // distinct stack over the `.setop`), NOT a bare `.setop`, so route the
-    // per-arm execution through the SAME carrier descender `run` uses
+    // per-arm execution through the same carrier descender `run` uses
     // (`execute(_:carrying:)`) — it descends the wrapper to the setop leaf and
     // runs `arms` there — keyed on the query's core being a set operation. A
     // bare `.setop` query/plan (no carrier) descends identically: the core is
@@ -1168,15 +1168,15 @@ extension Catalog where Self: ~Escapable {
   /// re-executes the pre-compiled body (`key`/`correlation`) against that
   /// record's correlated cells, takes `ordinals` from each produced right
   /// record, concatenates it onto the left, and keeps the pair the `on`
-  /// predicate admits. `.inner` (CROSS APPLY) DROPS a left record with no
+  /// predicate admits. `.inner` (CROSS APPLY) drops a left record with no
   /// surviving right record; `.left` (OUTER APPLY) preserves it, NULL-extending
   /// the taken width (`ordinals.count` NULL cells) — the same NULL-padding a
   /// regular outer join's `outer(…)` uses for an unmatched row. A `.right` or
   /// `.full` apply makes no sense for a correlated body: rejected at compile.
   ///
-  /// The lateral body runs through the SAME `executed` path a correlated
+  /// The lateral body runs through the same `executed` path a correlated
   /// subquery does — it binds the correlation's `slot` sources from the
-  /// borrowed left `record`, augments the body's OWN aliases, and runs the
+  /// borrowed left `record`, augments the body's own aliases, and runs the
   /// pre-compiled plan — so the borrow is never retained: `executed` returns
   /// owned `Record`s, and the pair merges two owned records. The right record
   /// is the body's FULL output, so `ordinals` select the referenced columns
@@ -1187,10 +1187,10 @@ extension Catalog where Self: ~Escapable {
   /// real `width` — its resolution schema is a `RelationInstance.schema()`, so
   /// a body reference `d.Id` puts the virtual ordinal `width` into `ordinals`.
   /// The `executed` body rows hold only the REAL columns (`0 ..< width`), so
-  /// taking `right.values[width]` would trap. This wraps THIS left row's body
+  /// taking `right.values[width]` would trap. This wraps this left row's body
   /// output as a `RelationInstance` and materialises each right record through
   /// `RelationInstance.record`, so the virtual `Id` ordinal yields the 1-based
-  /// row position within this left row's output — the SAME id derivation a
+  /// row position within this left row's output — the same id derivation a
   /// non-lateral derived table's `record` produces — while a real ordinal reads
   /// its stored cell.
   internal borrowing func applied(_ left: Array<Record>, _ key: Subkey,
@@ -1199,18 +1199,18 @@ extension Catalog where Self: ~Escapable {
                                   _ kind: Join.Kind, _ context: Context)
       throws(SQLError) -> Array<Record> {
     var records = Array<Record>()
-    // Re-run the pre-compiled body under the SAME revealed overlay it was
-    // COMPILED against — the occurrence scope's recorded revealed base — so a
+    // Re-run the pre-compiled body under the same revealed overlay it was
+    // compiled against — the occurrence scope's recorded revealed base — so a
     // body `FROM e` scans the CTE `e` compile chose, not a caller derived alias
-    // `e` that shadows it in the UNREVEALED execution overlay. The `on`
+    // `e` that shadows it in the unrevealed execution overlay. The `on`
     // predicate stays on the caller `context`: it is a caller-level join
     // predicate over the merged record's ordinals, and any subquery in it
-    // scopes to its OWN recorded overlay.
+    // scopes to its own recorded overlay.
     let body = revealed(under: key, context)
     // An unmatched left row under OUTER APPLY (`.left`) is NULL-extended by the
     // taken width, mirroring `outer(…)`'s NULL-padding of an unmatched row.
     let nulls = Record(Array(repeating: .null, count: ordinals.count))
-    // A LATERAL/CROSS/OUTER apply always emits `ON 1 = 1` — a PROVABLY-true
+    // A LATERAL/CROSS/OUTER apply always emits `ON 1 = 1` — a provably-true
     // predicate every merged row passes — so a constant-true `on` skips the
     // redundant per-row `evaluate(paired, on, context)` and admits the pair
     // directly (identical result). A non-trivial `on` still runs per row.
@@ -1240,15 +1240,15 @@ extension Catalog where Self: ~Escapable {
     return records
   }
 
-  /// Executes a correlated subquery's SET-OPERATION `plan` arm by arm — the
+  /// Executes a correlated subquery's SET-operation `plan` arm by arm — the
   /// plan and its `query` descend in lockstep (compile builds `.setop(kind,
   /// compile(left), compile(right), all)` from `.setop(kind, left, right,
   /// all)`), a `.setop` node recursing into both arms and `combine`-ing the
-  /// results and a LEAF arm augmenting THAT arm's own derived aliases into
+  /// results and a leaf arm augmenting that arm's own derived aliases into
   /// `context` (rows, so its `.scan` reads them) before executing its sub-plan.
   ///
   /// `context` already carries the per-row correlation bindings and the parent
-  /// overlay, so each arm's augment ADDS only that arm's aliases and every arm
+  /// overlay, so each arm's augment adds only that arm's aliases and every arm
   /// runs under the same correlated bindings — mirroring the run and view setop
   /// per-arm augmentation for the correlated shape. Executing the arm sub-plans
   /// (not re-running the arm queries) preserves any pushed conjunct in the arm
@@ -1259,7 +1259,7 @@ extension Catalog where Self: ~Escapable {
     if case let .setop(kind, left, right, all, types, _) = plan,
         case let .setop(_, leftQuery, rightQuery, _) = query {
       // The unified column `types` the plan carries (computed at compile) drive
-      // the arm coercion `combine` applies — the SAME types every set-op path
+      // the arm coercion `combine` applies — the same types every set-op path
       // uses, so a mixed-type arm widens identically here.
       return try combine(kind, arms(left, leftQuery, context),
                          arms(right, rightQuery, context), all, types: types)
@@ -1269,24 +1269,24 @@ extension Catalog where Self: ~Escapable {
     return try execute(plan, augmented)
   }
 
-  /// The `EXISTS` non-empty result of the occurrence `key`, run LAZILY: an
-  /// UNCORRELATED one (empty `correlation`) reads the memo and, on a miss,
-  /// probes once and stores it; a CORRELATED one re-probes per outer row
+  /// The `EXISTS` non-empty result of the occurrence `key`, run lazily: an
+  /// uncorrelated one (empty `correlation`) reads the memo and, on a miss,
+  /// probes once and stores it; a correlated one re-probes per outer row
   /// against the correlated bindings, never touching the memo.
   internal borrowing func present(_ row: borrowing some Row & ~Escapable,
                                   _ key: Subkey, _ correlation: Correlation,
                                  _ context: Context)
       throws(SQLError) -> Bool {
-    // Run under the overlay the occurrence's SCOPE was lowered under — the
+    // Run under the overlay the occurrence's scope was lowered under — the
     // caller's or the view body's — not the current execution site a pushdown
     // may have moved this predicate to.
     let context = revealed(under: key, context)
-    // A CORRELATED EXISTS re-executes its PRE-COMPILED PROBE plan (correlated
+    // A correlated EXISTS re-executes its pre-compiled probe plan (correlated
     // columns are bound `Term.parameter`s; the plan is the cardinality-only
     // probed shape, so its select list — a would-fault `1 / 0` — never runs)
     // against this row's correlated bindings, testing non-empty — bypassing the
-    // memo (the result depends on the row). An UNCORRELATED one memoises and
-    // probes cardinality once, the SAME probed shape.
+    // memo (the result depends on the row). An uncorrelated one memoises and
+    // probes cardinality once, the same probed shape.
     guard correlation.isEmpty else {
       return try !executed(row, key, correlation, context).isEmpty
     }
@@ -1296,18 +1296,18 @@ extension Catalog where Self: ~Escapable {
     return present
   }
 
-  /// The `IN (Q)` single column of the occurrence `key`, materialised LAZILY:
-  /// an UNCORRELATED one reads the memo and, on a miss, runs the inner query
-  /// once and stores its lone column; a CORRELATED one re-runs per outer row
+  /// The `IN (Q)` single column of the occurrence `key`, materialised lazily:
+  /// an uncorrelated one reads the memo and, on a miss, runs the inner query
+  /// once and stores its lone column; a correlated one re-runs per outer row
   /// against the correlated bindings, bypassing the memo.
   internal borrowing func values(_ row: borrowing some Row & ~Escapable,
                                  _ key: Subkey, _ correlation: Correlation,
                                 _ context: Context)
       throws(SQLError) -> Array<Value> {
     let context = revealed(under: key, context)
-    // A CORRELATED `IN (Q)` re-executes its PRE-COMPILED inner plan against
+    // A correlated `IN (Q)` re-executes its pre-compiled inner plan against
     // this row's correlated bindings for its lone column, bypassing the memo.
-    // An UNCORRELATED one memoises and re-runs its `Query` (recompiling
+    // An uncorrelated one memoises and re-runs its `Query` (recompiling
     // resolves).
     guard correlation.isEmpty else {
       return try executed(row, key, correlation, context).map { $0.values[0] }
@@ -1318,24 +1318,24 @@ extension Catalog where Self: ~Escapable {
     return values
   }
 
-  /// The value of a scalar subquery occurrence `key`, materialised LAZILY and
-  /// MEMOISED: on the first reach it runs the inner query ONCE (where this
+  /// The value of a scalar subquery occurrence `key`, materialised lazily and
+  /// memoised: on the first reach it runs the inner query once (where this
   /// catalog is in scope) — empty → NULL, one row → its cell, more →
   /// `.cardinality`, plus any inner fault — collapsing to one value and caching
-  /// it under `key`; a later reach returns the cached value WITHOUT re-running.
+  /// it under `key`; a later reach returns the cached value without re-running.
   ///
-  /// The subquery is UNCORRELATED, so its value is row-invariant — one run per
-  /// REACHED occurrence, none for one only in a skipped arm. The value is
-  /// COERCED to the inner column's `type`, as a `CASE` coerces its taken arm.
+  /// The subquery is uncorrelated, so its value is row-invariant — one run per
+  /// reached occurrence, none for one only in a skipped arm. The value is
+  /// coerced to the inner column's `type`, as a `CASE` coerces its taken arm.
   private borrowing func scalar(_ row: borrowing some Row & ~Escapable,
                                 _ key: Subkey, _ correlation: Correlation,
                                 _ type: ValueType, _ context: Context)
       throws(SQLError) -> Value {
     let context = revealed(under: key, context)
-    // A CORRELATED scalar subquery re-executes its PRE-COMPILED inner plan per
+    // A correlated scalar subquery re-executes its pre-compiled inner plan per
     // outer row against the correlated bindings, collapsing to its lone cell
     // (empty → NULL, one row → the cell, more → `.cardinality`), bypassing the
-    // memo (its cell depends on the row). An UNCORRELATED one memoises and
+    // memo (its cell depends on the row). An uncorrelated one memoises and
     // re-runs its `Query`.
     guard correlation.isEmpty else {
       let rows = try executed(row, key, correlation, context)
@@ -1351,10 +1351,10 @@ extension Catalog where Self: ~Escapable {
   }
 
   /// Evaluates a lowered `COALESCE(v1, v2, …)` against `row` — the `elements`
-  /// visited IN ORDER exactly ONCE, returning the first whose value is
+  /// visited IN ORDER exactly once, returning the first whose value is
   /// non-NULL (coerced to the unified `type` the schema advertises), else NULL.
   ///
-  /// Each element is evaluated ONCE: a desugar to `CASE WHEN vi IS NOT NULL
+  /// Each element is evaluated once: a desugar to `CASE WHEN vi IS NOT NULL
   /// THEN vi …` evaluated each `vi` twice — its guard and its result — so a
   /// stateful element tested one value for NULL and returned another.
   /// `Value.coerced` widens the selected value to `type` (a `.integer` element
@@ -1373,7 +1373,7 @@ extension Catalog where Self: ~Escapable {
   }
 
   /// Evaluates a lowered `NULLIF(a, b)` against `row` — `a` and `b` each
-  /// evaluated ONCE — returning NULL when `a = b` is TRUE, else the SAME `va`
+  /// evaluated once — returning NULL when `a = b` is TRUE, else the same `va`
   /// that was compared.
   ///
   /// A desugar to `CASE WHEN a = b THEN NULL ELSE a END` evaluated `a` twice —
@@ -1416,11 +1416,11 @@ extension Catalog where Self: ~Escapable {
   /// against `row`.
   ///
   /// This run-path dispatch checks a routine EXISTS — an unregistered `name`
-  /// faults `SQLError.function` — but does NOT validate the call's ARITY or
-  /// its argument TYPES: it evaluates the supplied `arguments` and hands them
+  /// faults `SQLError.function` — but does NOT validate the call's arity or
+  /// its argument types: it evaluates the supplied `arguments` and hands them
   /// to the routine. That is deliberate. A run assumes the statement was
   /// already type-checked; `columns(of:validate:)` (via `Scope.call`) is the
-  /// STRICT gate that faults `SQLError.argument` on a wrong argument count or a
+  /// strict gate that faults `SQLError.argument` on a wrong argument count or a
   /// definitively-wrong argument type, so a caller wanting arity/type
   /// enforcement validates FIRST and a run trusts that check. The engine's own
   /// routines self-check inside their closures (a native `BITAND` faults on a
@@ -1428,7 +1428,7 @@ extension Catalog where Self: ~Escapable {
   /// `callAsFunction`), so a mis-shaped call over them still faults; but a host
   /// routine that does NOT self-check its count runs regardless at this site.
   /// See `RoutineArityPostureTests`, which pins the run/validate split. (The
-  /// one value the run DOES enforce here is the finite-double invariant below,
+  /// one value the run does enforce here is the finite-double invariant below,
   /// which no static type-check can see.)
   private borrowing func apply(_ row: borrowing some Row & ~Escapable,
                                _ name: String, _ arguments: Array<Term>,

--- a/Sources/SQLEngine/Function.swift
+++ b/Sources/SQLEngine/Function.swift
@@ -6,39 +6,39 @@
 ///
 /// A routine takes its arguments already evaluated to typed `Value`s (the
 /// engine evaluates each argument expression against the row first) and returns
-/// one `Value`; it is CALLED as a function — `routine(arguments)`. It
+/// one `Value`; it is called as a function — `routine(arguments)`. It
 /// declares the type of each positional `parameter` — the count is the arity —
-/// and the result `returns` type, both read to TYPE a `f(...)` call WITHOUT
+/// and the result `returns` type, both read to type a `f(...)` call without
 /// running it: the result-schema walk (`Scope.derive(_:_:)`) types a call by
 /// `returns`, the type-check walk (`Scope.validate(_:_:)`) validates each
 /// argument against `parameters`, and the `INFORMATION_SCHEMA` `data_type` a
 /// view's `GUID(...)` column reports from `returns`.
 ///
-/// A routine is one of two kinds. A NATIVE routine is a Swift closure — the
+/// A routine is one of two kinds. A native routine is a Swift closure — the
 /// shape the per-dialect decode routines (`guid`, `ret_type`, `span_type`, …)
 /// take, each a pure mapping from cell values to a cell value, registered by
-/// name and called from a projection or a predicate. A DEFINED routine —
+/// name and called from a projection or a predicate. A defined routine —
 /// `CREATE FUNCTION name(p TYPE, …) RETURNS TYPE AS expression` — carries a SQL
-/// scalar `Expression` over its named parameters, lowered ONCE at registration
+/// scalar `Expression` over its named parameters, lowered once at registration
 /// to a `Term` addressing the parameters by slot (parameter `i` is slot `i`); a
 /// call binds its evaluated arguments into a record and evaluates that term. A
-/// defined body EARLY-BINDS the routines its own calls name: it captures the
+/// defined body early-binds the routines its own calls name: it captures the
 /// `Routines` visible at its definition and resolves its nested calls through
-/// THAT environment, not the map in scope at call time — the ISO subject-
+/// that environment, not the map in scope at call time — the ISO subject-
 /// routine rule, under which a body's routine references are fixed when it is
 /// defined. A routine that cannot map its arguments throws `SQLError`; one that
 /// does not declare a result type is `.integer`, the engine's exact-numeric
 /// default.
 ///
-/// A routine also declares whether it is DETERMINISTIC — ISO SQL's
+/// A routine also declares whether it is deterministic — ISO SQL's
 /// `DETERMINISTIC` / `NOT DETERMINISTIC` characteristic: a deterministic
 /// routine returns the same value for the same arguments every time and has no
-/// side effect, so the engine may execute it at COMPILE time to fold a
+/// side effect, so the engine may execute it at compile time to fold a
 /// row-independent call (see `Resolve`'s `constant(_:_:)`). A NOT
-/// DETERMINISTIC routine — the default for a host-registered closure, which may
-/// be stateful or observe the clock — is NEVER executed at compile time: it
+/// deterministic routine — the default for a host-registered closure, which may
+/// be stateful or observe the clock — is never executed at compile time: it
 /// could return one value while types are being computed and another when the
-/// row is actually reached. The RUN path invokes any routine regardless;
+/// row is actually reached. The run path invokes any routine regardless;
 /// determinism gates only compile-time folding.
 public struct Routine: Sendable {
   /// A routine's implementation — a native Swift closure or a defined SQL
@@ -60,12 +60,12 @@ public struct Routine: Sendable {
   /// before a schema is published (see `Scope`'s `call`).
   public let parameters: Array<ValueType>
 
-  /// The number of REQUIRED leading arguments; arguments beyond it (up to
-  /// `parameters.count`) are OPTIONAL, so a call's arity may be anywhere in
+  /// The number of required leading arguments; arguments beyond it (up to
+  /// `parameters.count`) are optional, so a call's arity may be anywhere in
   /// `minimum ... parameters.count`. Defaults to `parameters.count` — all
   /// required, a fixed arity — so every fixed-arity routine is unchanged.
   /// `OVERLAY` sets it to 3 with an optional fourth `length` the routine
-  /// DEFAULTS from its once-evaluated replacement, so the parser need not
+  /// defaults from its once-evaluated replacement, so the parser need not
   /// re-reference the replacement (which would double-evaluate a
   /// non-deterministic one).
   public let minimum: Int
@@ -73,9 +73,9 @@ public struct Routine: Sendable {
   /// The declared result type, read to type a call statically.
   public let returns: ValueType
 
-  /// Whether this routine is DETERMINISTIC (ISO SQL) — same arguments yield the
+  /// Whether this routine is deterministic (ISO SQL) — same arguments yield the
   /// same value with no side effect. Only a deterministic routine is folded at
-  /// compile time (`Resolve`'s `constant(_:_:)`); a NOT DETERMINISTIC one is
+  /// compile time (`Resolve`'s `constant(_:_:)`); a NOT deterministic one is
   /// left for the run to invoke.
   public let deterministic: Bool
 
@@ -93,8 +93,8 @@ public struct Routine: Sendable {
     self.body = .native(compute)
   }
 
-  /// A DEFINED routine — the `CREATE FUNCTION name(names[i] parameters[i], …)
-  /// RETURNS returns AS expression` body, its scalar `Expression` lowered to a
+  /// A defined routine — the `CREATE FUNCTION name(names[i] parameters[i], …)
+  /// returns returns AS expression` body, its scalar `Expression` lowered to a
   /// `Term` over the parameters (parameter `i` at slot `i`) so a call evaluates
   /// it against a record of the bound argument values.
   ///
@@ -104,10 +104,10 @@ public struct Routine: Sendable {
   /// (`term` rejects it), the same way an aggregate in a projection expression
   /// does. `names.count == parameters.count` — each parameter names its type.
   ///
-  /// The declared `returns` is also ENFORCED here, statically: the body's type
+  /// The declared `returns` is also enforced here, statically: the body's type
   /// is validated over the parameter schema and must equal `returns`, else
   /// `SQLError.argument` — the same case the type-check reports an argument
-  /// contract violation with. This uses the FAULTING type-check path, not the
+  /// contract violation with. This uses the faulting type-check path, not the
   /// non-faulting derive: derive would type an unknown call by the `.integer`
   /// default and let `f() RETURNS INTEGER AS g()` pass while `g` is
   /// unregistered, then return `g`'s later-declared type. The faulting path
@@ -118,12 +118,12 @@ public struct Routine: Sendable {
   /// declared type, so a body that yields NULL on a row is unaffected — only
   /// the validated static type is contracted.
   ///
-  /// The passed `routines` are the environment the body EARLY-BINDS: it is both
+  /// The passed `routines` are the environment the body early-binds: it is both
   /// what the returns validation resolves the body's own calls against AND what
   /// the `.defined` case captures, so a nested call evaluates against exactly
   /// the map it was typed against — the two are consistent by construction.
   ///
-  /// A defined routine is NOT DETERMINISTIC: the DDL (`CREATE FUNCTION`) has no
+  /// A defined routine is NOT deterministic: the DDL (`CREATE FUNCTION`) has no
   /// `DETERMINISTIC` clause yet, so ISO's default characteristic applies and
   /// the body is never folded at compile time — the safe choice, since it may
   /// call a non-deterministic routine.
@@ -133,7 +133,7 @@ public struct Routine: Sendable {
     // A body's inputs are its declared parameters, not query bindings: it is
     // validated over the parameter schema and later evaluated against ONLY the
     // argument record, so a `:parameter` reference (reachable through a `CASE`
-    // guard) would always be UNBOUND at call time — the caller's `bindings`
+    // guard) would always be unbound at call time — the caller's `bindings`
     // never reach a routine body — and silently pick the wrong branch. Reject
     // a `.bound` anywhere in the body at registration rather than lowering it.
     if body.bound {
@@ -157,7 +157,7 @@ public struct Routine: Sendable {
   }
 
   /// Computes the cell value for the evaluated `arguments`, resolving a defined
-  /// body's own scalar calls through the environment it CAPTURED at definition.
+  /// body's own scalar calls through the environment it captured at definition.
   ///
   /// A native routine runs its closure. A defined routine binds `arguments`
   /// into a record — argument `i` at slot `i`, matching the parameter its body
@@ -166,7 +166,7 @@ public struct Routine: Sendable {
   /// calls resolve through the captured `Routines` (early binding), so a callee
   /// later redefined for queries does not change what this body computes.
   ///
-  /// A defined routine ENFORCES its arity AND its argument types here — the run
+  /// A defined routine enforces its arity AND its argument types here — the run
   /// path does not type-check a call before evaluating it, so a defined body
   /// dispatched over the wrong argument shape would otherwise misbehave:
   /// reading slot `i` of a record short an argument would trap, and a
@@ -175,7 +175,7 @@ public struct Routine: Sendable {
   /// INTEGER contract. The argument count must equal its `parameters` count,
   /// else `SQLError.argument` (the case a native routine like `BITAND` reports
   /// a bad count with); and each argument's type must equal the declared
-  /// parameter's, else the same `SQLError.argument`. A NULL argument is EXEMPT:
+  /// parameter's, else the same `SQLError.argument`. A NULL argument is exempt:
   /// NULL is not a type, it propagates through any declared type — exactly as
   /// `BITAND` returns NULL on a NULL argument and the static type-check
   /// (`Scope.call`) admits a nullable value of the declared type. A native
@@ -203,11 +203,11 @@ public struct Routine: Sendable {
 }
 
 /// An empty `Catalog` vending no relation — the stand-in for the absent catalog
-/// where the evaluator runs a subquery-FREE term.
+/// where the evaluator runs a subquery-free term.
 ///
 /// A `CREATE FUNCTION` body lowers against `Resolution.unsupported`, so its
 /// term can never nest a scalar subquery and its evaluation never needs a
-/// catalog to materialise one. Passing this empty catalog keeps ONE evaluator:
+/// catalog to materialise one. Passing this empty catalog keeps one evaluator:
 /// a term that did reach a `.subquery` would run `cell(of:)` against a catalog
 /// resolving no relation and fault, but a function body never does.
 internal struct NoCatalog: Catalog {
@@ -268,10 +268,10 @@ public struct Routines: Sendable {
   private let functions: Dictionary<String, Routine>
 
   /// The case-folded names that `registering(_:…)` refuses to bind — the
-  /// PROTECTED routines a standard-library prelude marks so a caller extending
+  /// protected routines a standard-library prelude marks so a caller extending
   /// it cannot shadow an ISO built-in and silently change what a query naming
   /// it computes. The set travels WITH the value: the empty routines and a
-  /// dictionary literal carry none (the escape hatch a prelude is BUILT
+  /// dictionary literal carry none (the escape hatch a prelude is built
   /// through), and `merging(_:)` unions both sides' sets, so protection is a
   /// property of the routines rather than a module-wide constant. The engine
   /// itself ships no built-in, so a `Routines` it builds is unprotected; the
@@ -306,7 +306,7 @@ public struct Routines: Sendable {
     self.protected = protected
   }
 
-  /// These routines with `names` (case-folded) marked PROTECTED — the seam a
+  /// These routines with `names` (case-folded) marked protected — the seam a
   /// standard-library prelude uses to declare its built-ins non-shadowable: a
   /// later `registering(_:…)` of a protected name faults SQLSTATE `42723`
   /// rather than shadow it. The engine ships no prelude, so it never calls
@@ -324,11 +324,11 @@ public struct Routines: Sendable {
 
   /// The routine `name` names, folded to lower case like every other SQL
   /// identifier, or `nil` if no registered routine bears it. There is a single
-  /// flat map with no privileged tier at LOOKUP: a prelude routine
+  /// flat map with no privileged tier at lookup: a prelude routine
   /// (`Routines.standard`) and a caller-registered one resolve through the same
-  /// lookup, so a name resolves to whatever the map binds. (A future PATH /
+  /// lookup, so a name resolves to whatever the map binds. (A future path /
   /// search-order mechanism — à la DB2 or PostgreSQL — would let a qualified
-  /// call reach a specific one across schemas.) A caller does not REACH this
+  /// call reach a specific one across schemas.) A caller does not reach this
   /// map past a standard name, though: `registering(_:…)` refuses to bind one
   /// (see `protected`), so the shadowing a lower-level `init` still permits
   /// never arises through the public extension surface.
@@ -336,7 +336,7 @@ public struct Routines: Sendable {
     functions[name.lowercased()]
   }
 
-  /// Faults if `name` (case-folded) is a protected routine of THESE routines —
+  /// Faults if `name` (case-folded) is a protected routine of these routines —
   /// the check both `registering` overloads apply before binding, so neither
   /// the closure nor the `CREATE FUNCTION` path shadows a name a prelude marked
   /// (see `protecting(_:)`). It carries SQLSTATE `42723` (duplicate function,
@@ -353,10 +353,10 @@ public struct Routines: Sendable {
   /// A copy of these routines with a routine computing `compute`, accepting
   /// `parameters` (default none), and returning `returns` (default `.integer`)
   /// bound to `name` (folded to lower case), the binding shadowing any existing
-  /// one — UNLESS `name` is a protected standard routine (`reserved(_:)`),
+  /// one — unless `name` is a protected standard routine (`reserved(_:)`),
   /// which faults rather than shadow an ISO built-in. `deterministic` declares
   /// the routine's ISO SQL characteristic and defaults to `false` (NOT
-  /// DETERMINISTIC) — the safe default for a host closure, which may be
+  /// deterministic) — the safe default for a host closure, which may be
   /// stateful or read the clock: it is not executed at compile time. Pass
   /// `true` for a pure routine to let a row-independent call fold.
   //
@@ -379,14 +379,14 @@ public struct Routines: Sendable {
     return Routines(functions, protected: protected)
   }
 
-  /// A copy of these routines with the DEFINED `function` bound to `name`
-  /// (folded to lower case), the binding shadowing any existing one — UNLESS
+  /// A copy of these routines with the defined `function` bound to `name`
+  /// (folded to lower case), the binding shadowing any existing one — unless
   /// `name` is a protected standard routine (`reserved(_:)`), which faults
   /// rather than shadow an ISO built-in — the registration a consumer performs
   /// for a parsed `CREATE FUNCTION`, mirroring a catalog registering a `CREATE
   /// VIEW`'s `View`.
   ///
-  /// The function's body is lowered to a term over its parameters HERE, so a
+  /// The function's body is lowered to a term over its parameters here, so a
   /// body naming a parameter the function does not declare faults
   /// `SQLError.column` at registration — the moment a `CREATE FUNCTION` binds —
   /// rather than at each later call, exactly as a native routine's signature is
@@ -394,15 +394,15 @@ public struct Routines: Sendable {
   /// `returns`, else `SQLError.argument` (see `Routine`'s defined initializer).
   ///
   /// Two parameters colliding under case-insensitive resolution are rejected
-  /// HERE with `SQLError.duplicate` — the later spelling — exactly as the
+  /// here with `SQLError.duplicate` — the later spelling — exactly as the
   /// parser rejects them: a lowered body resolves a name to the FIRST matching
   /// parameter (`Schema.ordinal(of:)`), so a duplicate would leave the second
   /// slot unreachable yet still required by the arity. The parser guards the
-  /// grammar path; this guards a `Function` a caller CONSTRUCTS directly and
+  /// grammar path; this guards a `Function` a caller constructs directly and
   /// registers, so neither path admits a duplicate.
   ///
-  /// The body EARLY-BINDS the routines its own calls name: it captures the
-  /// `ambient` routines OVERLAID with these routines — `ambient` merged under
+  /// The body early-binds the routines its own calls name: it captures the
+  /// `ambient` routines overlaid with these routines — `ambient` merged under
   /// the map before this registration (the prelude is the base, a caller
   /// registration shadows a like-named prelude routine) — and resolves its
   /// nested calls through that captured environment at run time, the ISO
@@ -413,15 +413,15 @@ public struct Routines: Sendable {
   /// `SELECT` would, rather than faulting at registration for a routine the
   /// query path can see. The pure engine supplies no ambient of its own —
   /// `import SQLStandard` re-defaults it (see the two-argument overload there).
-  /// A body naming its OWN registration `name` is well-defined, not recursion:
-  /// `f() AS f() + 1` REPLACING a prior `f` captures the OLD `f`, so it
-  /// computes `f_old() + 1` and terminates. With NO prior `f` and no ambient
+  /// A body naming its own registration `name` is well-defined, not recursion:
+  /// `f() AS f() + 1` replacing a prior `f` captures the old `f`, so it
+  /// computes `f_old() + 1` and terminates. With no prior `f` and no ambient
   /// `f`, the captured map lacks `f`, so the body's call is unresolved and the
   /// returns validation above faults `SQLError.function` — the
   /// unregistered-callee case, not a self-reference one. Query-level resolution
-  /// is UNCHANGED: a top-level `SELECT f()` still resolves `f` to the LATEST
+  /// is unchanged: a top-level `SELECT f()` still resolves `f` to the latest
   /// binding (a later registration shadows an earlier one); capture governs
-  /// only a body's INTERNAL calls, not which `f` a query reaches.
+  /// only a body's internal calls, not which `f` a query reaches.
   public func registering(_ name: String, _ function: Function,
                           capturing ambient: Routines)
       throws(SQLError) -> Routines {

--- a/Sources/SQLEngine/Grouped.swift
+++ b/Sources/SQLEngine/Grouped.swift
@@ -20,35 +20,35 @@
 /// combined-ordinal resolution the source uses decides which projection columns
 /// are keys.
 ///
-/// For ONE arm of an expanded `GROUPING SETS`, `superset` carries the LOWERED
+/// For one arm of an expanded `GROUPING SETS`, `superset` carries the lowered
 /// terms of the UNION of every set's keys. A non-key column whose lowered term
-/// is in the superset is a SUPER-AGGREGATE NULL (a grouping column another set
-/// groups on but THIS arm does not) — `term` returns a typeless-NULL slot for
+/// is in the superset is a super-aggregate NULL (a grouping column another set
+/// groups on but this arm does not) — `term` returns a typeless-NULL slot for
 /// it instead of faulting `.grouping`, so a projected/HAVING/ORDER-BY reference
-/// to it NULLs by RESOLVED identity (`n.A` ≡ `A`, case-insensitively), not raw
+/// to it NULLs by resolved identity (`n.A` ≡ `A`, case-insensitively), not raw
 /// AST. It is empty for an ordinary grouped query, whose every non-key column
 /// still faults.
 internal struct Grouped {
   private let scope: Scope
 
-  /// Each BARE-column `GROUP BY` key's combined base ordinal mapped to its
+  /// Each bare-column `GROUP BY` key's combined base ordinal mapped to its
   /// grouped slot — key `i` sits at grouped slot `i`. A general (non-column)
   /// key holds no ordinal entry; it matches by expression through
   /// `expressions` instead.
   private let keys: Dictionary<Int, Int>
 
-  /// Each `GROUP BY` key's LOWERED base-ordinal term, in key order — key `i`
+  /// Each `GROUP BY` key's lowered base-ordinal term, in key order — key `i`
   /// sits at grouped slot `i`. A projection/`HAVING`/`ORDER BY` expression that
-  /// lowers to a term EQUAL to a key's is that key, so a general (non-column)
+  /// lowers to a term equal to a key's is that key, so a general (non-column)
   /// key matches a semantically-identical reference whose AST differs only by
   /// qualification or case (`Orders.Amount + 1` vs `Amount + 1`), and a bare
   /// `NATURAL`/`USING` merged column — which lowers to a `COALESCE(left,
-  /// right)` term with NO single ordinal, the group key AND every bare
-  /// reference to it — groups and projects as ONE value, matched by term
+  /// right)` term with no single ordinal, the group key AND every bare
+  /// reference to it — groups and projects as one value, matched by term
   /// rather than the raw AST or an ordinal a merged column lacks.
   private let terms: Array<Term>
 
-  /// The LOWERED terms of the union of every set's keys, for ONE arm of an
+  /// The lowered terms of the union of every set's keys, for one arm of an
   /// expanded `GROUPING SETS` — the columns another set groups on. A non-key
   /// reference whose lowered term is in here is a super-aggregate NULL (this
   /// arm does not group on it, but another set does), so `term` returns a
@@ -61,11 +61,11 @@ internal struct Grouped {
   private let offset: Int
 
   /// The query's distinct aggregations, in first-appearance order — aggregate
-  /// `j` sits at grouped slot `offset + j`. Deduped by RESOLVED `Aggregation`
+  /// `j` sits at grouped slot `offset + j`. Deduped by resolved `Aggregation`
   /// (function + resolved argument term), so an aggregate expression's grouped
   /// slot is found by resolving it and matching here — a
   /// qualification-equivalent aggregate (`SUM(Amount)` vs `SUM(Sales.Amount)`)
-  /// maps to the SAME slot.
+  /// maps to the same slot.
   private let aggregates: Array<Aggregation>
 
   /// Each projected item's output name (an alias, else a bare column's name),
@@ -84,7 +84,7 @@ internal struct Grouped {
   private var ambiguous: Set<String> = []
 
   /// Builds a grouping over `scope` for the `GROUP BY` `columns` (with their
-  /// already-LOWERED base-ordinal `terms`, so a merged column's coalesce term
+  /// already-lowered base-ordinal `terms`, so a merged column's coalesce term
   /// is matched by term) and the query's distinct `aggregates` (in
   /// first-appearance order — aggregate `j` at grouped slot `columns.count +
   /// j`). The `aggregates` are already deduped by RESOLVED `Aggregation` (see
@@ -98,16 +98,16 @@ internal struct Grouped {
     self.superset = superset
     var keys = Dictionary<Int, Int>(minimumCapacity: grouping.count)
     for index in grouping.indices {
-      // A BARE-column grouping key a local relation binds maps its combined
-      // ordinal to its grouped slot. A bare `NATURAL`/`USING` MERGED column
+      // A bare-column grouping key a local relation binds maps its combined
+      // ordinal to its grouped slot. A bare `NATURAL`/`USING` merged column
       // binds no single ordinal (`find` faults `.ambiguous` over its two
       // physical sides) — its lowered `terms[index]` is a `COALESCE` matched by
-      // term, so it takes NO ordinal entry, as a general key does. A key NONE
-      // binds is a candidate CORRELATED reference (a LATERAL body grouping
+      // term, so it takes no ordinal entry, as a general key does. A key none
+      // binds is a candidate correlated reference (a LATERAL body grouping
       // on a preceding column): the correlation surface's non-recording
       // `correlated` probe distinguishes it from a genuine unknown column, and
       // it occupies grouped slot `index` as a `.parameter` key (in `group`'s
-      // keys array) with NO ordinal→slot entry — the projection reads it via
+      // keys array) with no ordinal→slot entry — the projection reads it via
       // the same correlation, never through this key dict. A genuinely unknown
       // column re-throws the `.column` fault; a barred surface diagnoses a
       // bound outer column `.unsupported`. `correlated` records nothing, so it
@@ -129,7 +129,7 @@ internal struct Grouped {
   }
 
   /// The grouped slot an aggregate `expression` resolves to (an aggregate the
-  /// query collected), or `nil` if it is not one. The expression is RESOLVED to
+  /// query collected), or `nil` if it is not one. The expression is resolved to
   /// an `Aggregation` — column qualification normalized to a slot — and matched
   /// against the collected aggregations, so `SUM(Amount)` and
   /// `SUM(Sales.Amount)` find the same slot in a single-relation scope.
@@ -144,10 +144,10 @@ internal struct Grouped {
 
   /// Lowers an `expression` to its grouped-space `Term` — the module-visible
   /// entry to the private `term`, so a caller (the `ordered` set-op carrier)
-  /// can match an `ORDER BY` key against the projection by RESOLVED identity,
+  /// can match an `ORDER BY` key against the projection by resolved identity,
   /// exactly as the grouped `ORDER BY` path does: a projected aggregate and a
   /// qualifier-equivalent sort key (`SUM(Qty)` vs `SUM(s.Qty)`) lower to the
-  /// SAME grouped slot, so the carrier need not compare raw AST.
+  /// same grouped slot, so the carrier need not compare raw AST.
   internal func resolve(_ expression: Expression,
                         _ routines: Routines = [:],
                         subquery: Resolution = .unsupported)
@@ -176,22 +176,22 @@ internal struct Grouped {
        let slot = try slot(of: expression, routines, subquery: subquery) {
       return .slot(slot)
     }
-    // A bare `NATURAL`/`USING` MERGED column and a general (non-column) key
-    // both match a `GROUP BY` key by LOWERED `Term`, not raw AST — the
+    // A bare `NATURAL`/`USING` merged column and a general (non-column) key
+    // both match a `GROUP BY` key by lowered `Term`, not raw AST — the
     // scope normalizes qualification and case away, so a projection/`HAVING`/
-    // `ORDER BY` expression that is SEMANTICALLY the key matches even when its
+    // `ORDER BY` expression that is semantically the key matches even when its
     // spelling differs (`Orders.Amount + 1` vs `Amount + 1`, `AMOUNT + 1` vs
-    // `Amount + 1`). Lower under the SAME scope the key lowered under, so a
+    // `Amount + 1`). Lower under the same scope the key lowered under, so a
     // merged column's `COALESCE(left, right)` term (which binds no single
-    // ordinal — the group key AND every bare reference are ONE value) still
+    // ordinal — the group key AND every bare reference are one value) still
     // matches. A right-only row of a `RIGHT`/`FULL` join thus groups by its
     // coalesced value, not a NULL left column.
     //
-    // A bare PLAIN column is skipped here and falls to the ordinal path below,
+    // A bare plain column is skipped here and falls to the ordinal path below,
     // which additionally distinguishes a genuine unknown column, a correlated
     // reference (a LATERAL body's `everywhere` seam), and a barred grouped
     // surface — cases a bare merged column and a general expression never
-    // reach. A merged column that matches NO key faults `.grouping`; a general
+    // reach. A merged column that matches no key faults `.grouping`; a general
     // expression that matches none falls through so its operands are each
     // checked (`Amount + 2` faults on the bare non-key `Amount`). An aggregated
     // expression (`SUM(x) + 1`) is skipped too: `scope.term` faults on an
@@ -212,8 +212,8 @@ internal struct Grouped {
     if !plain, !expression.aggregated, !expression.grouping {
       let lowered = try scope.term(expression, routines, subquery: subquery)
       if let index = terms.firstIndex(of: lowered) { return .slot(index) }
-      // A reference to a column ANOTHER set groups on but THIS arm's set omits
-      // is a SUPER-AGGREGATE NULL — matched by lowered term (so `n.A` ≡ `A`,
+      // A reference to a column another set groups on but this arm's set omits
+      // is a super-aggregate NULL — matched by lowered term (so `n.A` ≡ `A`,
       // case-insensitively), not raw AST — so it lowers to a typeless-NULL
       // constant rather than faulting. This dissolves the qualified/unqualified
       // and absent-key HAVING findings for a merged/general reference.
@@ -227,7 +227,7 @@ internal struct Grouped {
       // Resolve the column against this scope's own relations first, mirroring
       // `Scope.term`'s `.column`: a name a local relation binds must be a
       // `GROUP BY` key (the standard grouping rule), else `SQLError.grouping`.
-      // A name NONE binds is a candidate CORRELATED reference — consult the
+      // A name none binds is a candidate correlated reference — consult the
       // surface, which admits it (a `Term.parameter` the apply binds per outer
       // row) only for a LATERAL body's `everywhere` seam and diagnoses it
       // `.unsupported` on an ordinary barred grouped surface. The final
@@ -235,8 +235,8 @@ internal struct Grouped {
       // exactly as `Scope.term` does.
       if let ordinal = try scope.find(column) {
         if let slot = keys[ordinal] { return .slot(slot) }
-        // A bare column ANOTHER set groups on but THIS arm's set omits is a
-        // super-aggregate NULL — matched by its LOWERED term against the
+        // A bare column another set groups on but this arm's set omits is a
+        // super-aggregate NULL — matched by its lowered term against the
         // superset (so `n.A` ≡ `A`, case-insensitively), not the raw ordinal —
         // else the standard non-grouped fault.
         let lowered = try scope.term(expression, routines, subquery: subquery)
@@ -278,7 +278,7 @@ internal struct Grouped {
       }
       // Attach the unified result type — the same `ValueType.unified` reduction
       // `derive`/`validate` compute — over the grouped scope, so the executor
-      // COERCES the selected branch's value to the advertised column type.
+      // coerces the selected branch's value to the advertised column type.
       let type = try scope.derive(whens, otherwise, routines,
                                   subquery: subquery)
       return .case(branches, else: fallback, type: type)
@@ -288,7 +288,7 @@ internal struct Grouped {
       return try .cast(term(operand, routines, subquery: subquery), type)
     case let .coalesce(arguments):
       // Lower each argument to a grouped-space `Term` and hold them in a
-      // first-class `Term.coalesce` so each is evaluated ONCE; `type` is the
+      // first-class `Term.coalesce` so each is evaluated once; `type` is the
       // unified argument type (over the grouped scope) the value coerces to.
       var elements = Array<Term>()
       elements.reserveCapacity(arguments.count)
@@ -299,11 +299,11 @@ internal struct Grouped {
       return .coalesce(elements, type: type)
     case let .nullif(lhs, rhs):
       // Lower both operands to grouped-space `Term`s and hold them in a
-      // first-class `Term.nullif` so each is evaluated ONCE.
+      // first-class `Term.nullif` so each is evaluated once.
       return try .nullif(term(lhs, routines, subquery: subquery),
                          term(rhs, routines, subquery: subquery))
     case let .subquery(query):
-      // A scalar subquery is UNCORRELATED — row-independent, so it needs no
+      // A scalar subquery is uncorrelated — row-independent, so it needs no
       // `GROUP BY` key — and lowers to a `Term.subquery` reading its collapsed
       // value from the cache, carrying its `Subkey` and single-column type.
       return try subquery.scalar(query)
@@ -313,7 +313,7 @@ internal struct Grouped {
       // aggregate.
       throw .state("XX000", "uncollected aggregate")
     case .grouping:
-      // GROUPING is resolved to a constant at the TOP of `term` (before this
+      // GROUPING is resolved to a constant at the top of `term` (before this
       // switch), so it never reaches here — an internal inconsistency if it
       // does.
       throw .state("XX000", "unlowered GROUPING")
@@ -369,7 +369,7 @@ internal struct Grouped {
       // into the `over` payload) and the membership key for the roll-up test. It
       // is the base term, not the grouped lowering: a rolled-up column lowers to
       // the shared super-aggregate `.constant(.null)` — and a rolled-up
-      // CORRELATED key to a `.parameter` — so the grouped term identifies
+      // correlated key to a `.parameter` — so the grouped term identifies
       // neither which column it was nor that it is a key. The base term is the
       // column's arm-stable slot, so two GROUPINGs match by identity iff they
       // report on the same expressions.
@@ -377,7 +377,7 @@ internal struct Grouped {
       let bit: Int
       if terms.contains(id) {
         // A `GROUP BY` key present in this arm's set, matched by term against the
-        // arm's keys — so a CORRELATED key (a LATERAL body grouping on a
+        // arm's keys — so a correlated key (a LATERAL body grouping on a
         // preceding-FROM column, which lowers to `Term.parameter` rather than a
         // local key slot) is recognised too, not only a local slot.
         bit = 0
@@ -425,8 +425,8 @@ internal struct Grouped {
                                _ routines: Routines = [:],
                                subquery: Resolution = .unsupported)
       throws(SQLError) -> Array<Term> {
-    // A grouped projection is a BARRED clause position (see `Schema.terms`):
-    // the entry bars the seam so it cannot admit a correlated column of THIS
+    // A grouped projection is a barred clause position (see `Schema.terms`):
+    // the entry bars the seam so it cannot admit a correlated column of this
     // query.
     let subquery = subquery.barred
     switch projection {
@@ -475,12 +475,12 @@ internal struct Grouped {
   ///
   /// Each sort key resolves as, in order:
   ///
-  /// - `ordinal(n)` — the query's `n`-th projected OUTPUT column (1-based),
+  /// - `ordinal(n)` — the query's `n`-th projected output column (1-based),
   ///   resolving to that projection item's own grouped-space `Term`
   ///   (`projection[n - 1]`). An `n` outside `1 ... projection.count` faults
   ///   `SQLError.column`.
   /// - `expression(.column(name))` with an unqualified `name` — a projection
-  ///   OUTPUT alias FIRST (the standard alias ordering on an aggregate, `terms`
+  ///   output alias FIRST (the standard alias ordering on an aggregate, `terms`
   ///   recorded these), then a `GROUP BY` key column, both resolving to their
   ///   grouped `Term`. A name two projections share is `SQLError.ambiguous`, as
   ///   the non-grouped `Scope.order` reports for a shared join column.
@@ -490,7 +490,7 @@ internal struct Grouped {
   ///   keys (a bare non-key column faults `SQLError.grouping`).
   ///
   /// Because the `sort` operator now evaluates a `Term` per grouped record
-  /// rather than reading one slot, an alias over a COMPUTED expression
+  /// rather than reading one slot, an alias over a computed expression
   /// (`COUNT(*) * 2 AS Doubled`) orders correctly — its recorded grouped term
   /// recomputes from the group's key and aggregate slots — where the slot-only
   /// sort once rejected it.
@@ -502,7 +502,7 @@ internal struct Grouped {
                       _ routines: Routines = [:],
                       subquery: Resolution = .unsupported)
       throws(SQLError) -> Array<SortKey> {
-    // A grouped ORDER BY is BARRED, as the projection is (see `Schema.order`).
+    // A grouped ORDER BY is barred, as the projection is (see `Schema.order`).
     let subquery = subquery.barred
     var resolved = Array<SortKey>()
     resolved.reserveCapacity(order.keys.count)
@@ -576,20 +576,20 @@ extension Filter {
         for term in element { term.references(into: &ordinals) }
       }
     case let .exists(_, correlation, _):
-      // A CORRELATED EXISTS reads the enclosing row's cells its inner `WHERE`
+      // A correlated EXISTS reads the enclosing row's cells its inner `WHERE`
       // names — the correlation's `slot` outer ordinals — so those must be
       // materialised for the per-row re-execution (a `bound` source reads a
-      // threaded binding, not the outer record). An UNCORRELATED one names
+      // threaded binding, not the outer record). An uncorrelated one names
       // none.
       ordinals.formUnion(correlation.slots)
     case let .within(operand, _, correlation, _):
-      // The outer operand term reads ordinals; a CORRELATED subquery ALSO reads
+      // The outer operand term reads ordinals; a correlated subquery also reads
       // the outer `slot` cells its inner `WHERE` names.
       operand.references(into: &ordinals)
       ordinals.formUnion(correlation.slots)
     case let .quantified(operand, _, _, _, correlation):
-      // As `within`: the outer operand term reads ordinals; a CORRELATED
-      // subquery ALSO reads the outer `slot` cells its inner `WHERE` names.
+      // As `within`: the outer operand term reads ordinals; a correlated
+      // subquery also reads the outer `slot` cells its inner `WHERE` names.
       operand.references(into: &ordinals)
       ordinals.formUnion(correlation.slots)
     case let .like(operand, pattern, escape, _):

--- a/Sources/SQLEngine/GroupingSets.swift
+++ b/Sources/SQLEngine/GroupingSets.swift
@@ -4,16 +4,16 @@
 // MARK: - GROUPING SETS
 
 extension Query {
-  /// This query with each TOP-LEVEL `GROUP BY GROUPING SETS` select replaced by
-  /// its `UNION ALL` expansion — applied ONCE at every pipeline entry (`run`,
+  /// This query with each top-level `GROUP BY GROUPING SETS` select replaced by
+  /// its `UNION ALL` expansion — applied once at every pipeline entry (`run`,
   /// `compile`, `columns(of:)`), so the whole downstream (materialise, augment,
   /// executor) sees the expanded AST and a run and a `columns(of:)` derive
   /// cannot diverge.
   ///
-  /// It rewrites the query's OWN selects (a bare select and each set-operation
-  /// arm), NOT the derived tables or subqueries nested within — those RE-ENTER
+  /// It rewrites the query's own selects (a bare select and each set-operation
+  /// arm), NOT the derived tables or subqueries nested within — those re-enter
   /// these same entries (`materialise`/`resolved` run and derive an inner body,
-  /// `cell` runs a scalar subquery), where they are expanded in turn — so ONE
+  /// `cell` runs a scalar subquery), where they are expanded in turn — so one
   /// shallow pass at each entry covers arbitrary nesting.
   internal var expanded: Query {
     get throws(SQLError) {
@@ -39,17 +39,17 @@ extension Query {
 }
 
 /// Expands a `GROUP BY GROUPING SETS (s1, …, sn)` `select` into a `UNION ALL`
-/// of one grouped ARM per set — the SINGLE shared expansion the compile path
-/// (`compile(_ select:)`) and the schema path (`columns(unifying:)`) BOTH
+/// of one grouped ARM per set — the single shared expansion the compile path
+/// (`compile(_ select:)`) and the schema path (`columns(unifying:)`) both
 /// drive, so a run and a `columns(of:)` derive cannot diverge.
 ///
-/// Each arm is the original select grouped on ONE set's `keys` while carrying
-/// the SUPERSET (the union of every set's keys) in its `.arm` grouping — so a
-/// projected/HAVING reference to a grouping column ANOTHER set groups on but
-/// THIS arm's set omits lowers to a super-aggregate NULL by RESOLVED identity
+/// Each arm is the original select grouped on one set's `keys` while carrying
+/// the superset (the union of every set's keys) in its `.arm` grouping — so a
+/// projected/HAVING reference to a grouping column another set groups on but
+/// this arm's set omits lowers to a super-aggregate NULL by resolved identity
 /// (`Grouped.term`), never a per-site AST rewrite. The projection stays
-/// VERBATIM per arm: the empty set `()` builds a genuine grand-total aggregate
-/// (`group` on `[]` = ONE row), and the NULL padding types through the existing
+/// verbatim per arm: the empty set `()` builds a genuine grand-total aggregate
+/// (`group` on `[]` = one row), and the NULL padding types through the existing
 /// set-operation `merge` (a NULL arm constrains nothing, deferring to the arm
 /// that groups on the column). HAVING is copied into every arm (ISO: it filters
 /// each set's own groups); arms combine with `UNION ALL`, so a duplicate set
@@ -58,9 +58,9 @@ extension Query {
 /// The query-level `ORDER BY` / `OFFSET`/`FETCH` / `DISTINCT` ride the outer
 /// `Query.ordered` carrier over the union — a `setop` node carries no
 /// order/distinct/limit slot. The carrier resolves those row operators through
-/// the setop's OUTPUT SCOPE (`compile`/`run`), so an ORDER BY key that names an
+/// the setop's output scope (`compile`/`run`), so an ORDER BY key that names an
 /// output — an alias, a bare projected column, or an ordinal — orders on that
-/// output the SAME way any `(SELECT … UNION SELECT …) ORDER BY <alias/ordinal>`
+/// output the same way any `(SELECT … UNION SELECT …) ORDER BY <alias/ordinal>`
 /// does, and a duplicate output name faults `SQLError.ambiguous` there, exactly
 /// as a plain grouped query does. A generated `column N` display header is NOT
 /// a bindable output name (the scope's names are the projected aliases-or-bare
@@ -68,19 +68,19 @@ extension Query {
 /// derived union.
 ///
 /// Only an ORDER BY key that re-expresses a value the setop-output scope cannot
-/// recompute — a genuinely unprojected non-column EXPRESSION, the canonical
+/// recompute — a genuinely unprojected non-column expression, the canonical
 /// example an aggregate (`ORDER BY MAX(x)`) the select list does not project —
-/// is MATERIALISED here as a HIDDEN trailing column in EVERY arm (so the `UNION
-/// ALL` arity stays equal). A COLUMN key is NEVER materialised: it resolves at
+/// is materialised here as a hidden trailing column in every arm (so the `UNION
+/// ALL` arity stays equal). A COLUMN key is never materialised: it resolves at
 /// the setop-output scope (a bare/aliased projected column to its output slot,
 /// a qualified `n.A` ≡ the projected `A` by lowered identity) or faults there,
 /// so the qualifier-presence defect that materialised `n.A` as a hidden column
-/// is gone. The compiled carrier orders on the materialised ordinal and TRIMS
+/// is gone. The compiled carrier orders on the materialised ordinal and trims
 /// it through the identity projection; the carrier binds the hidden slot by
 /// POSITION, never by the generated `*gsN` name a user output could spell.
 internal func expand(_ select: Select,
                      sets: Array<Array<Expression>>) throws(SQLError) -> Query {
-  // `GROUPING SETS ()` — an empty set LIST — has no arm to combine, so the
+  // `GROUPING SETS ()` — an empty set list — has no arm to combine, so the
   // `UNION ALL` reduce below has no seed. The parser never emits it (the
   // grammar requires at least one set), but `Grouping.sets` is a public AST
   // case a caller may build directly, so reject the empty list here with a
@@ -88,7 +88,7 @@ internal func expand(_ select: Select,
   guard !sets.isEmpty else {
     throw .state("42601", "GROUPING SETS requires at least one set")
   }
-  // The SUPERSET — every set's keys, flattened — threaded into each arm so an
+  // The superset — every set's keys, flattened — threaded into each arm so an
   // absent key NULLs by resolved identity. Compared by lowered term in
   // `Grouped`, so a duplicate spelling here is harmless.
   let superset = sets.reduce(into: Array<Expression>()) { $0 += $1 }
@@ -108,31 +108,31 @@ internal func expand(_ select: Select,
     []
   }
 
-  // The query-level ORDER BY keys MATERIALISED as hidden trailing columns — a
+  // The query-level ORDER BY keys materialised as hidden trailing columns — a
   // sort key the setop-output scope cannot recompute over the combined union.
-  // A NON-column key (an aggregate `MAX(x)`, a computed key) the select list
+  // A non-column key (an aggregate `MAX(x)`, a computed key) the select list
   // does not project is materialised; a projected non-column expression
   // (`ORDER BY SUM(Qty)` where `SUM(Qty)` is a select-list item) resolves to
   // its output slot instead.
   //
   // A COLUMN key is materialised only when the setop-output scope cannot
-  // resolve it — its BARE name is not a projected output. An UNQUALIFIED
+  // resolve it — its bare name is not a projected output. An unqualified
   // column whose bare name IS a projected output (`SELECT Region … ORDER BY
   // Region`) binds that output by ISO output-alias precedence (a bare name →
-  // a select-list alias), so it is NOT materialised. A QUALIFIED column,
-  // though, references its INPUT column by identity, NOT a select alias: its
-  // bare name colliding with a DIFFERENT output's alias (`SELECT Product AS
+  // a select-list alias), so it is NOT materialised. A qualified column,
+  // though, references its input column by identity, NOT a select alias: its
+  // bare name colliding with a different output's alias (`SELECT Product AS
   // Region … ORDER BY s.Region`) must NOT be treated as that projected output
   // — the qualified key rides the carrier's `Grouped` resolver, which either
   // resolves it to the output it genuinely IS (rebinding to the real slot, no
   // effect) or, when it is a grouped-but-unprojected column, orders on this
-  // hidden slot. An UNPROJECTED grouped column (`SELECT SUM(Qty) … GROUP BY
+  // hidden slot. An unprojected grouped column (`SELECT SUM(Qty) … GROUP BY
   // GROUPING SETS ((Region)) ORDER BY Region`) has no output slot but IS
   // orderable — the plain grouped path accepts it — so it materialises through
   // each arm's grouped projection: an arm grouped on the column carries its
-  // value, and an arm that does NOT group on it is REJECTED by the arm's
-  // grouped resolver with the SAME grouping fault the plain form raises (a
-  // NON-grouped column faults identically). This is the aggregate case's
+  // value, and an arm that does NOT group on it is rejected by the arm's
+  // grouped resolver with the same grouping fault the plain form raises (a
+  // non-grouped column faults identically). This is the aggregate case's
   // machinery extended to columns, not a fork — the arm's `Grouped` decides
   // grouped/non-grouped.
   let outputs = Set(items.compactMap { $0.name?.lowercased() })
@@ -155,15 +155,15 @@ internal func expand(_ select: Select,
       select.distinct || select.order != nil || select.limit != nil
 
   // Build one arm per set. When the carrier materialises hidden sort columns,
-  // each arm APPENDS them (aliased to synthetic names) so they survive the
+  // each arm appends them (aliased to synthetic names) so they survive the
   // union at an equal arity across arms; without a carrier the projection is
   // verbatim.
   let names = hidden.indices.map { "*gs\($0)" }
   let arms = sets.map { set -> Query in
     let projection: Projection
     if case .all = select.projection {
-      // A grouped `SELECT *` is ill-formed; keep the `.all` VERBATIM in every
-      // arm (never the carrier) so the arm's grouped resolver throws the SAME
+      // A grouped `SELECT *` is ill-formed; keep the `.all` verbatim in every
+      // arm (never the carrier) so the arm's grouped resolver throws the same
       // `SELECT *` fault the unwrapped form does.
       projection = select.projection
     } else if carried, !hidden.isEmpty {
@@ -187,11 +187,11 @@ internal func expand(_ select: Select,
   // A grouped `SELECT *` is ill-formed: return the bare union of the `.all`
   // arms (never the carrier, whose hidden trimming assumes real output items
   // the `.all` arms do not enumerate) so the arm's grouped resolver throws the
-  // SAME `SELECT *` fault the unwrapped form does, carried or not.
+  // same `SELECT *` fault the unwrapped form does, carried or not.
   if case .all = select.projection { return union }
-  // A SINGLE grouping set is an ordinary `GROUP BY` — there is no `UNION` for
-  // an unprojected sort key to survive, so materialise NO hidden column and
-  // add NO `ordered` carrier. Wrapping the lone `.select` arm in `.ordered`
+  // A single grouping set is an ordinary `GROUP BY` — there is no `UNION` for
+  // an unprojected sort key to survive, so materialise no hidden column and
+  // add no `ordered` carrier. Wrapping the lone `.select` arm in `.ordered`
   // would hide a FROM-clause derived table from the query-level derived-table
   // collection and per-arm execution, faulting `.relation` at run. Re-attach
   // the query-level clauses to the single grouped arm and return it plain, so
@@ -209,7 +209,7 @@ internal func expand(_ select: Select,
   // `compile`/`run` resolve them through the setop-output scope; the hidden
   // materialised columns (if any) trail every arm at equal arity and the
   // carrier trims them through its identity projection. `generated` carries
-  // their STRUCTURAL count out of here — the carrier recovers the real width
+  // their structural count out of here — the carrier recovers the real width
   // as `width − generated`, never by scanning output names for a `*gs` prefix.
   return .ordered(union, distinct: select.distinct, order: select.order,
                   limit: select.limit, generated: hidden.count)

--- a/Sources/SQLEngine/Interpreter.swift
+++ b/Sources/SQLEngine/Interpreter.swift
@@ -27,7 +27,7 @@ extension Catalog where Self: ~Escapable {
       // projection evaluates its constant/call expressions against.
       return [Record([])]
     case .empty:
-      // The known-empty relation yields NO records — the optimiser proved its
+      // The known-empty relation yields no records — the optimiser proved its
       // constant-false guard admits none — so nothing above it (a project, an
       // aggregate, a join) ever sees a row, and its skipped subtree stays
       // unrun.
@@ -91,19 +91,19 @@ extension Catalog where Self: ~Escapable {
   }
 
   /// Executes the query-level `ordered` set-operation carrier `plan` over the
-  /// inner set operation `union`, routing the setop leaf through the SAME
+  /// inner set operation `union`, routing the setop leaf through the same
   /// per-arm augmentation the direct `run(.setop)` and the correlated-subquery
-  /// `arms` use — so a derived table an arm names is MATERIALISED in that arm's
+  /// `arms` use — so a derived table an arm names is materialised in that arm's
   /// own scope before its `.scan` reads it.
   ///
-  /// The carrier plan `ordered` builds is a stack of SINGLE-source row
+  /// The carrier plan `ordered` builds is a stack of single-source row
   /// operators (`sort`/`distinct`/`limit`/`project`, and the `project`/`sort`
   /// pair a `materialised` output key emits) OVER the compiled `union` setop.
-  /// The plain `execute(_:_:)` would run the setop under the ONE carrier
+  /// The plain `execute(_:_:)` would run the setop under the one carrier
   /// context (`execute(.setop)` shares it across both arms), which never binds
   /// an arm's arm-local derived alias — arms are SELECT-scoped, so the query-
   /// level augment misses them. This descends the wrapper stack unchanged,
-  /// applying EACH operator through the SAME helper `execute(_:_:)` uses, and
+  /// applying each operator through the same helper `execute(_:_:)` uses, and
   /// at the setop leaf runs `arms(_:_:_:)` — per-arm augment, per arm
   /// `execute`, shared `combine` — so the carrier's sort/dedup/limit see the
   /// fully materialised combined rows in the union's output slot space. A
@@ -144,9 +144,9 @@ extension Catalog where Self: ~Escapable {
 
   /// Sorts `rows` by the ordered `keys` — the executor's `.sort` node body,
   /// shared with the query-level `ordered` set-operation carrier so the two
-  /// sort a combined result IDENTICALLY.
+  /// sort a combined result identically.
   ///
-  /// Each key's `Term` is evaluated against every record UP FRONT — a bare slot
+  /// Each key's `Term` is evaluated against every record up front — a bare slot
   /// read, but any lowered expression (`a + b`, `UPPER(Name)`, an ordinal's or
   /// alias's select-list item) — so the comparator sorts on precomputed values.
   /// Evaluation may throw (a scalar call, a division), which a `sorted(by:)`
@@ -252,7 +252,7 @@ extension Catalog where Self: ~Escapable {
   /// slot count (needed to NULL-extend even when a side is empty).
   /// Each candidate pair is merged (left slots then right slots) and tested
   /// against `on` under three-valued logic — TRUE matches, UNKNOWN and FALSE do
-  /// not, exactly as a `WHERE` admits; `on` governs MATCHING alone, so an
+  /// not, exactly as a `WHERE` admits; `on` governs matching alone, so an
   /// unmatched preserved row is still emitted.
   ///
   ///   - `left`: every left row, in left-major order — each matched pair, then
@@ -266,12 +266,12 @@ extension Catalog where Self: ~Escapable {
   /// A `.inner` kind never reaches here — `compile` lowers an inner join
   /// through the product/join path.
   ///
-  /// FAST PATH: when `on` carries an equi `.match` conjunct straddling the two
+  /// fast path: when `on` carries an equi `.match` conjunct straddling the two
   /// sides (a left slot `< widths.left` equal to a right slot `>= widths.left`
   /// — the shape a decorrelated OUTER APPLY emits), a `.left`/`.full` join
-  /// hashes the right side by that key ONCE and probes per left row
+  /// hashes the right side by that key once and probes per left row
   /// (`bucketed`), turning the O(left × right) nested loop into O(left +
-  /// right). The probe re-checks the WHOLE `on` on each bucket candidate — the
+  /// right). The probe re-checks the whole `on` on each bucket candidate — the
   /// bucket over-groups (two large integers can share a `Double` bucket) and
   /// `on` may carry residual conjuncts beyond the key — so the surviving pairs,
   /// the NULL-extension of unmatched left rows, and (for `.full`) the left-NULL
@@ -280,24 +280,24 @@ extension Catalog where Self: ~Escapable {
   /// nested loop's UNKNOWN `.match` leaves it. A non-equi `on` (no straddling
   /// `.match`) takes the nested loop.
   ///
-  /// The fast path fires ONLY when the WHOLE `on` is `safe` (cannot throw): it
-  /// evaluates `on` for the bucket candidates alone, so it SKIPS a non-matching
-  /// or NULL-key right row ENTIRELY — never evaluating `on` for it — whereas
-  /// the nested loop evaluates the whole `on` for EVERY pair. (This is NOT
-  /// about AND short-circuiting: the evaluator IS Kleene and DOES short-circuit
+  /// The fast path fires ONLY when the whole `on` is `safe` (cannot throw): it
+  /// evaluates `on` for the bucket candidates alone, so it skips a non-matching
+  /// or NULL-key right row entirely — never evaluating `on` for it — whereas
+  /// the nested loop evaluates the whole `on` for every pair. (This is NOT
+  /// about AND short-circuiting: the evaluator IS Kleene and does short-circuit
   /// an `AND` on a FALSE left, but only on a FALSE one — an UNKNOWN or TRUE
   /// left still evaluates the right, and either side of the `on` may throw.) An
-  /// UNSAFE `on` — a straddling `.match` AND a throwing conjunct like
-  /// `(1 / B.x) = 0` — could therefore SUPPRESS a throw the nested loop raises
+  /// unsafe `on` — a straddling `.match` AND a throwing conjunct like
+  /// `(1 / B.x) = 0` — could therefore suppress a throw the nested loop raises
   /// on a skipped pair, so it falls to the nested loop below, which evaluates
   /// every pair and throws identically.
-  /// A `safe` `on` throws on NO pair, so skipping the non-bucket/NULL rows
+  /// A `safe` `on` throws on no pair, so skipping the non-bucket/NULL rows
   /// suppresses nothing. A decorrelated OUTER APPLY's `on` is safe by
   /// construction (the recogniser gates the residual and apply predicate
   /// `safe`), so it keeps the fast path.
   ///
-  /// In PRACTICE every `.match`-carrying `on` that reaches here is ALREADY
-  /// safe: the `on()` recogniser (`Resolve.swift`) forms NO `.match` unless the
+  /// In practice every `.match`-carrying `on` that reaches here is already
+  /// safe: the `on()` recogniser (`Resolve.swift`) forms no `.match` unless the
   /// whole ON is `allSatisfy(\.safe)`, and the OUTER APPLY decorrelation only
   /// folds a `.match` when its body residual and apply `on` are `safe`. This
   /// `on.safe` guard is defence-in-depth — it keeps the executor locally sound
@@ -379,14 +379,14 @@ extension Catalog where Self: ~Escapable {
   }
 
   /// The hash fast-path of a `.left`/`.full` OUTER join: the right side hashed
-  /// ONCE by `key.right` into buckets, then each left row probed by `key.left`
+  /// once by `key.right` into buckets, then each left row probed by `key.left`
   /// in O(1). Behaviour-identical to the nested loop `outer` above — same
   /// surviving pairs, same NULL-extension, same order.
   ///
   /// The right side is bucketed by its key's promoted `bucket` (a NULL key
   /// buckets nothing — it can never equi-match, exactly as the nested loop's
   /// UNKNOWN `.match` leaves it unmatched). Each left row probes its own key's
-  /// bucket, and every candidate is CONFIRMED against the WHOLE `on` — the
+  /// bucket, and every candidate is confirmed against the whole `on` — the
   /// bucket over-groups and `on` may carry residual conjuncts beyond the key —
   /// so a bucket collision or a failing residual drops the pair exactly as the
   /// nested loop's per-pair `on` test does. A left row with no confirmed pair
@@ -400,7 +400,7 @@ extension Catalog where Self: ~Escapable {
   /// key is NULL probes nothing and is NULL-extended.
   ///
   /// `key.left` is a combined-space slot (the left side is the record's
-  /// prefix), while `key.right` is the right side's OWN standalone slot — the
+  /// prefix), while `key.right` is the right side's own standalone slot — the
   /// caller maps the combined right slot down by `widths.left` before the call.
   private borrowing func bucketed(_ left: Array<Record>,
                                   _ right: Array<Record>,
@@ -428,7 +428,7 @@ extension Catalog where Self: ~Escapable {
       if case .null = value {} else {
         for index in buckets[bucket(value)] ?? [] {
           let record = lhs.merged(with: right[index])
-          // Confirm the WHOLE `on` — the bucket over-groups and `on` may carry
+          // Confirm the whole `on` — the bucket over-groups and `on` may carry
           // residual conjuncts beyond the equi key, so a collision or a failing
           // residual drops the pair, exactly as the nested loop's `on` test.
           if try evaluate(record, on, context) == true {
@@ -450,8 +450,8 @@ extension Catalog where Self: ~Escapable {
     return records
   }
 
-  /// The SEMIJOIN of `left` against `right` on `on` — an EXISTENCE
-  /// test emitting each surviving LEFT record UNCHANGED, never merged with a
+  /// The semijoin of `left` against `right` on `on` — an existence
+  /// test emitting each surviving LEFT record unchanged, never merged with a
   /// right one and never NULL-extended.
   ///
   /// `left`/`right` are the two materialised sides, `widths` each side's slot
@@ -460,39 +460,39 @@ extension Catalog where Self: ~Escapable {
   /// (left slots then right slots) ONLY to evaluate `on` in the combined space;
   /// the LEFT record alone is what a survivor emits.
   ///
-  ///   - SEMI (`anti == false`): a left row is kept iff SOME right row makes
+  ///   - semi (`anti == false`): a left row is kept iff SOME right row makes
   ///     merged `on` evaluate TRUE under three-valued logic (UNKNOWN and FALSE
-  ///     do not match, exactly as a `WHERE` admits). The scan SHORT-CIRCUITS on
-  ///     the first match, so a left row appears AT MOST ONCE regardless of how
+  ///     do not match, exactly as a `WHERE` admits). The scan short-circuits on
+  ///     the first match, so a left row appears at most once regardless of how
   ///     many right rows it matches — `EXISTS` is a decided per-row test, never
   ///     a multiplication.
-  ///   - ANTI (`anti == true`): a left row is kept iff NO right row makes `on`
+  ///   - anti (`anti == true`): a left row is kept iff no right row makes `on`
   ///     TRUE — the complement, a decorrelated `NOT EXISTS`.
   ///
   /// A NULL correlation key makes the equi `.match` UNKNOWN, so no right row
-  /// matches: SEMI drops such a left row, ANTI keeps it — `EXISTS` two-valued,
-  /// never UNKNOWN. An EMPTY right side matches nothing, so SEMI emits nothing
-  /// and ANTI emits every left row.
+  /// matches: semi drops such a left row, anti keeps it — `EXISTS` two-valued,
+  /// never UNKNOWN. An empty right side matches nothing, so semi emits nothing
+  /// and anti emits every left row.
   ///
-  /// FAST PATH: when `on` carries a straddling equi `.match` conjunct (shape
-  /// a decorrelated `EXISTS` emits, found by `equikey`) AND the WHOLE `on` is
-  /// `safe`, the right side is bucketed by its key ONCE and each left probes
-  /// its own bucket, confirming the WHOLE `on` per candidate (the bucket over-
+  /// fast path: when `on` carries a straddling equi `.match` conjunct (shape
+  /// a decorrelated `EXISTS` emits, found by `equikey`) AND the whole `on` is
+  /// `safe`, the right side is bucketed by its key once and each left probes
+  /// its own bucket, confirming the whole `on` per candidate (the bucket over-
   /// groups and `on` may carry residual conjuncts beyond the key) and short-
   /// circuiting on the first confirmed match — turning the O(left × right)
   /// nested loop into O(left + right). A NULL left key probes no bucket and so
   /// never matches, exactly as the nested loop's UNKNOWN `.match` leaves it.
   ///
-  /// The fast path fires ONLY when `on` is `safe`, for the SAME reason the
+  /// The fast path fires ONLY when `on` is `safe`, for the same reason the
   /// `.outer` executor gates its own hash path: it evaluates `on` for a left
-  /// row's matching-key bucket candidates ALONE, SKIPPING every non-bucket and
-  /// NULL-key right row, whereas the nested loop evaluates `on` for EVERY pair.
-  /// (This is NOT `AND` short-circuiting: the evaluator is Kleene and DOES
+  /// row's matching-key bucket candidates alone, skipping every non-bucket and
+  /// NULL-key right row, whereas the nested loop evaluates `on` for every pair.
+  /// (This is NOT `AND` short-circuiting: the evaluator is Kleene and does
   /// circuit an `AND` on a FALSE left, but an UNKNOWN or TRUE left still
-  /// evaluates the right, and either side may throw.) An UNSAFE `on` could
-  /// therefore SUPPRESS a throw the nested loop raises on a skipped pair, so it
+  /// evaluates the right, and either side may throw.) An unsafe `on` could
+  /// therefore suppress a throw the nested loop raises on a skipped pair, so it
   /// falls to the nested loop, which evaluates every pair and throws
-  /// identically. In PRACTICE the decorrelation only ever builds a `safe` `on`
+  /// identically. In practice the decorrelation only ever builds a `safe` `on`
   /// (its correlation `.match` and residual are gated `safe`), so this gate is
   /// defence-in-depth against a future producer.
   private borrowing func semijoin(_ left: Array<Record>,
@@ -512,22 +512,22 @@ extension Catalog where Self: ~Escapable {
     var records = Array<Record>()
     for lhs in left {
       // Short-circuit on the first right row that confirms `on` — a left row
-      // survives (SEMI) or is excluded (ANTI) by EXISTENCE alone, so it need
-      // never scan past the first match, and is emitted AT MOST ONCE.
+      // survives (semi) or is excluded (anti) by existence alone, so it need
+      // never scan past the first match, and is emitted at most once.
       var found = false
       for rhs in right where try evaluate(lhs.merged(with: rhs), on,
                                           context) == true {
         found = true
         break
       }
-      // SEMI keeps a matched left row, ANTI keeps an unmatched one — and the
+      // semi keeps a matched left row, anti keeps an unmatched one — and the
       // LEFT record alone is emitted, never the merge.
       if found != anti { records.append(lhs) }
     }
     return records
   }
 
-  /// The hash fast-path of a semijoin: the right hashed ONCE by `key.right`
+  /// The hash fast-path of a semijoin: the right hashed once by `key.right`
   /// into buckets, then each left row probed by `key.left` in O(1) and short-
   /// circuited on the first confirmed match. Behaviour-identical to the nested
   /// loop `semijoin` above — same survivors, each emitted at most once.
@@ -535,14 +535,14 @@ extension Catalog where Self: ~Escapable {
   /// The right side is bucketed by its key's promoted `bucket` (a NULL key
   /// buckets nothing — it can never equi-match, exactly as the nested loop's
   /// UNKNOWN `.match` leaves it). Each left row probes its own key's bucket and
-  /// every candidate is CONFIRMED against the WHOLE `on` — the bucket over-
+  /// every candidate is confirmed against the whole `on` — the bucket over-
   /// groups and `on` may carry residual conjuncts beyond the key — the first
   /// confirmed match deciding existence. A left row whose key is NULL probes
-  /// nothing and matches nothing. SEMI emits a matched left row (unchanged, at
-  /// most once); ANTI emits an unmatched one — the complement.
+  /// nothing and matches nothing. semi emits a matched left row (unchanged, at
+  /// most once); anti emits an unmatched one — the complement.
   ///
   /// `key.left` is a combined-space slot (the left is the record's prefix),
-  /// while `key.right` is the right's OWN standalone slot — the caller maps
+  /// while `key.right` is the right's own standalone slot — the caller maps
   /// the combined right slot down by `widths.left` before the call.
   private borrowing func bucketed(_ left: Array<Record>,
                                   _ right: Array<Record>,
@@ -564,10 +564,10 @@ extension Catalog where Self: ~Escapable {
       let value = lhs[key.left]
       var found = false
       // A NULL left key equi-matches nothing, so it probes no bucket and stays
-      // unmatched — SEMI drops it, ANTI keeps it.
+      // unmatched — semi drops it, anti keeps it.
       if case .null = value {} else {
         for index in buckets[bucket(value)] ?? [] {
-          // Confirm the WHOLE `on` — the bucket over-groups and `on` may carry
+          // Confirm the whole `on` — the bucket over-groups and `on` may carry
           // residual conjuncts beyond the equi key, so a collision or a failing
           // residual is not a match, exactly as the nested loop's `on` test.
           // The first confirmed match decides existence, so stop scanning.
@@ -584,7 +584,7 @@ extension Catalog where Self: ~Escapable {
 }
 
 /// The `(left, right)` slot pair of an equi `.match` conjunct in `on` that
-/// STRADDLES the join boundary `boundary` — one slot on the left side
+/// straddles the join boundary `boundary` — one slot on the left side
 /// (`< boundary`), the other on the right (`>= boundary`) — or `nil` when no
 /// such conjunct exists (a non-equi `on`, or a `.match` wholly on one side).
 /// The first straddling `.match` among the top-level `AND` conjuncts is the
@@ -625,17 +625,17 @@ private func limited(_ records: Array<Record>, _ count: Int?, _ offset: Int)
 ///
 /// Each side runs through the same `catalog`, `routines`, and `bindings`, so a
 /// bound parameter threads into every arm alike. A side may itself be a
-/// `setop`, and it executes with its OWN semantics first — a nested operation
+/// `setop`, and it executes with its own semantics first — a nested operation
 /// resolves before the outer node combines its result. A `Record` is `Hashable`
-/// and keys on its `canonical` values (so `1` and `1.0` are one row), the SAME
+/// and keys on its `canonical` values (so `1` and `1.0` are one row), the same
 /// whole-row equality `UNION`'s dedup uses.
 ///
 ///   - `.union`: the rows of either side, `left` followed by `right`. Without
 ///     `all` the whole-row duplicates are removed (first occurrence kept);
 ///     with `all` (`UNION ALL`) every row is kept.
-///   - `.intersect`: the rows present in BOTH sides, in left order. Without
+///   - `.intersect`: the rows present in both sides, in left order. Without
 ///     `all` each common row appears once; with `all` (`INTERSECT ALL`) it
-///     appears the LESSER of its two multiplicities.
+///     appears the lesser of its two multiplicities.
 ///   - `.except`: the rows of `left` NOT balanced by `right`, in left order.
 ///     Without `all` each left row absent from `right` appears once; with
 ///     `all` (`EXCEPT ALL`) each left row appears its left count less its right
@@ -657,15 +657,15 @@ extension Catalog where Self: ~Escapable {
 /// Combines two set-operation arms' records under `kind` and `all` — `union`
 /// keeps the rows of either, `intersect` those of both, `except` the left's not
 /// balanced by the right — the executor's `setop` node and the per-arm run path
-/// share this ONE combiner so the two agree on duplicate handling.
+/// share this one combiner so the two agree on duplicate handling.
 ///
-/// Each arm's cells are first COERCED to the unified column `types` (`Value
+/// Each arm's cells are first coerced to the unified column `types` (`Value
 /// .coerced` — the widening ISO type unification requires, so `SELECT 1 UNION
 /// SELECT 2.5` emits a `double` column), the ONE numeric widening `coerced`
-/// performs; a HOMOGENEOUS set operation's `types` matches each arm's own
+/// performs; a homogeneous set operation's `types` matches each arm's own
 /// types, so the coercion is a no-op and the result is byte-identical.
 /// `INTERSECT`/`EXCEPT` equality already canonicalises (`1` equals `1.0`), so
-/// coercion there changes only the EMITTED cells' type, never which rows match.
+/// coercion there changes only the emitted cells' type, never which rows match.
 internal func combine(_ kind: SetOperation, _ left: Array<Record>,
                       _ right: Array<Record>, _ all: Bool,
                       types: Array<ValueType>) -> Array<Record> {
@@ -719,7 +719,7 @@ private struct Multiset {
 /// The rows present in both `left` and `right` — `INTERSECT`.
 ///
 /// Without `all` each row common to both sides appears once, in left order
-/// (the first occurrence kept); with `all` it appears the LESSER of its left
+/// (the first occurrence kept); with `all` it appears the lesser of its left
 /// and right multiplicities. `right` is tallied into a `Multiset`; a left row
 /// is emitted while an occurrence remains to balance it, so the `all` count is
 /// naturally capped at the right side's — and, absent `all`, an emitted row is
@@ -741,7 +741,7 @@ private func intersected(_ left: Array<Record>, _ right: Array<Record>,
 
 /// The rows of `left` not balanced by `right` — `EXCEPT`.
 ///
-/// Without `all` each `left` row with NO match in `right` appears once, in
+/// Without `all` each `left` row with no match in `right` appears once, in
 /// left order (the first occurrence kept); with `all` each `left` row appears
 /// its left count less its right count, floored at zero. `right` is tallied
 /// into a `Multiset`: for `all` each left row cancels one right occurrence and
@@ -767,7 +767,7 @@ private func subtracted(_ left: Array<Record>, _ right: Array<Record>,
 /// occurrence of each distinct row kept and their order preserved.
 ///
 /// A `Record` is `Hashable`, so the dedup keys on the materialised row's values
-/// through the `Seen` set — the SAME whole-row equality `UNION` uses. It backs
+/// through the `Seen` set — the same whole-row equality `UNION` uses. It backs
 /// both a bare `UNION` and `SELECT DISTINCT`.
 private func deduplicated(_ records: Array<Record>) -> Array<Record> {
   var rows = Array<Record>()
@@ -817,11 +817,11 @@ extension Catalog where Self: ~Escapable {
   /// reads, in the slot order the outer scan expects (slot `i` is
   /// `ordinals[i]`).
   ///
-  /// The sub-plan runs OUTSIDE the statement's CTE scope — never the caller's
+  /// The sub-plan runs outside the statement's CTE scope — never the caller's
   /// `WITH` — so a caller's `WITH` never reaches into a stored view's body: a
   /// view's own `FROM`/`JOIN` names resolve to base relations (and other
   /// views), never to a statement-local CTE that happens to share a name. Its
-  /// scope is instead the `definition_schema.` overlay the view's OWN query
+  /// scope is instead the `definition_schema.` overlay the view's own query
   /// names (empty when it names none), so a view defined over a store relation
   /// materialises exactly as the inline query does — the same overlay the body
   /// compiled and optimised under.
@@ -831,29 +831,29 @@ extension Catalog where Self: ~Escapable {
       throws(SQLError) -> Array<Record> {
     var overlay = context.body([:])
     if let view = resolve(view: name) {
-      // EXECUTION-path materialise (`rows: true`): a nested derived body's
+      // execution-path materialise (`rows: true`): a nested derived body's
       // schema is derived schema-only inside `materialise`, so `validate:
       // false` keeps that lenient — a data-dependent-empty derived body in a
       // view body must not fault at run, matching the top-level run path. Seed
-      // the cyclic-view guard with THIS view's own name, as `resolve(view:)`
+      // the cyclic-view guard with this view's own name, as `resolve(view:)`
       // does, so a body materialising this view through a derived table (`FROM
       // (SELECT * FROM <self>) AS d`) faults `.recursion` in `materialise`
       // rather than re-running the body without end. `body([:])` enters the
-      // view-body scope with the caller's correlation stack CLEARED, so a
+      // view-body scope with the caller's correlation stack cleared, so a
       // nested derived body's schema (derived while `augment`/`materialise`
       // resolves it) cannot bind an unbound column outward to an enclosing row.
       let fresh = context.body([:]).visiting(name).validating(false)
       overlay = try augment(fresh, for: view.query, rows: true)
-      // Record the view body's OWN overlay under `.view(name)` so its LAZY
+      // Record the view body's own overlay under `.view(name)` so its lazy
       // subqueries re-run against the view's base relations, while a caller
-      // conjunct PUSHED into this body keeps its `.caller` overlay and re-runs
+      // conjunct pushed into this body keeps its `.caller` overlay and re-runs
       // against the caller's — each subquery resolving in its own textual scope
       // regardless of the execution site a pushdown lands it at. A view body
       // may nest `EXISTS`/`IN (Q)`/scalar subqueries its own plan carries,
-      // lowered under `.view(name)` — a DISJOINT id space from the `.caller`
+      // lowered under `.view(name)` — a disjoint id space from the `.caller`
       // one (see `Subscope`) — so a view-body `EXISTS (SELECT V FROM S)` over
-      // the view's OWN base and a caller's pushed one over a same-named CTE are
-      // SEPARATE occurrences. The row evaluator runs each LAZILY into the SAME
+      // the view's own base and a caller's pushed one over a same-named CTE are
+      // separate occurrences. The row evaluator runs each lazily into the same
       // shared memo box `context.subqueries` carries (kept in `overlay` via
       // `scoping`, which preserves the subqueries), so a view-body occurrence
       // memoises beside the caller's without either overwriting the other.
@@ -863,17 +863,17 @@ extension Catalog where Self: ~Escapable {
     let rows: Array<Record>
     let view = resolve(view: name)
     if let view, case .setop = view.query, case .setop = plan {
-      // A SET-OPERATION view body executes each ARM's sub-plan under an overlay
-      // AUGMENTED with THAT arm's own derived aliases. A `setop` collects NO
+      // A SET-operation view body executes each ARM's sub-plan under an overlay
+      // augmented with that arm's own derived aliases. A `setop` collects no
       // derived aliases at the query level (arms are SELECT-scoped), so the
       // overlay built above binds none; a `CREATE VIEW v AS SELECT * FROM
       // (SELECT Id FROM T) AS d UNION ALL …` would else execute an arm `.scan`
-      // over an unbound `d`. Executing the arm SUB-PLANS (not re-running the
-      // arm queries) preserves any conjunct the caller PUSHED into the view's
+      // over an unbound `d`. Executing the arm SUB-plans (not re-running the
+      // arm queries) preserves any conjunct the caller pushed into the view's
       // plan — the pushed filter lives in each arm's sub-plan — while the
       // per-arm augment binds the arm-local `d` the whole-body overlay missed.
       //
-      // Its subqueries run PER ARM inside `setop`, not here over the whole-view
+      // Its subqueries run per ARM inside `setop`, not here over the whole-view
       // overlay: an arm's direct `EXISTS`/`IN (Q)` may name that arm's own arm-
       // local derived alias, so running it demands the arm's own augment in
       // scope — the whole-view overlay binds no arm alias, so a whole-view
@@ -882,18 +882,18 @@ extension Catalog where Self: ~Escapable {
       rows = try setop(plan, view.query, overlay, name.lowercased())
     } else if let view, case .ordered = view.query,
         case .setop = view.query.core {
-      // The body is a set operation UNDER an `ordered` carrier (`… UNION …
+      // The body is a set operation under an `ordered` carrier (`… UNION …
       // ORDER BY V`), whose plan is a `.shaped` project/sort/distinct stack
-      // over the `.setop`, NOT a bare setop, so BOTH guards above failed and
+      // over the `.setop`, NOT a bare setop, so both guards above failed and
       // the arm-local derived aliases went unmaterialised (`.relation`). Pass
       // the carrier-transparent core to `setop`, which descends the wrapper —
-      // applying each row operator through the SAME executor helpers
+      // applying each row operator through the same executor helpers
       // `execute(_:carrying:)` uses — to the setop leaf where it per-arm
-      // augments. GATED on the body actually wearing a carrier, so a bare union
+      // augments. gated on the body actually wearing a carrier, so a bare union
       // view keeps the exact plan-shape dispatch above.
       rows = try setop(plan, view.query.core, overlay, name.lowercased())
     } else {
-      // A single-arm view body's subqueries run LAZILY into the shared memo box
+      // A single-arm view body's subqueries run lazily into the shared memo box
       // the `overlay` carries (recorded above under `.view(name)`), so the
       // sub-plan's row evaluator reads each result on first reach.
       rows = try execute(plan, overlay)
@@ -902,14 +902,14 @@ extension Catalog where Self: ~Escapable {
     return range.map { rows[$0].project(ordinals) }
   }
 
-  /// Executes a view body's SET-OPERATION `plan` arm by arm, each arm sub-plan
-  /// under `overlay` AUGMENTED with THAT arm's own derived aliases, combining
+  /// Executes a view body's SET-operation `plan` arm by arm, each arm sub-plan
+  /// under `overlay` augmented with that arm's own derived aliases, combining
   /// the arms under each node's operator.
   ///
   /// The `plan` tree mirrors the `query` tree (compile builds `.setop(kind,
   /// compile(left), compile(right), all)` from `.setop(kind, left, right,
   /// all)`), so this descends the two in lockstep: a `.setop` node recurses
-  /// into both arms and `combine`s the results, and a LEAF arm — a `.select`
+  /// into both arms and `combine`s the results, and a leaf arm — a `.select`
   /// query, its sub-plan any non-`setop` node — augments the arm's derived
   /// aliases into `overlay` (rows, so its `.scan` reads them) and executes the
   /// sub-plan under that arm-local scope. Executing the sub-plan (not
@@ -918,16 +918,16 @@ extension Catalog where Self: ~Escapable {
   /// overlay omitted; and each arm's `d` stays scoped to its arm (two arms may
   /// reuse `d`).
   ///
-  /// A leaf arm's DIRECT `EXISTS`/`IN (Q)`/scalar subqueries run LAZILY into
+  /// A leaf arm's direct `EXISTS`/`IN (Q)`/scalar subqueries run lazily into
   /// the shared memo box `overlay.subqueries` carries, lowered under
   /// `.view(name)` — the same scope the arm sub-plan's lowered `Filter`s
   /// compiled under — so an arm subquery resolves against the arm's own
-  /// overlay. The arm's REVEALED overlay is recorded under `.view(name)` before
+  /// overlay. The arm's revealed overlay is recorded under `.view(name)` before
   /// executing (last arm's binding wins, but arms share the same base relations
   /// a subquery's FROM reveals to; the arm-local derived layer is SELECT-scoped
   /// and invisible to a subquery's FROM, so an arm subquery naming that arm's
   /// arm-local derived alias faults `.relation` as a single arm's does). A
-  /// caller conjunct PUSHED into an arm keeps its `.caller` overlay and re-runs
+  /// caller conjunct pushed into an arm keeps its `.caller` overlay and re-runs
   /// against the caller's relations.
   private borrowing func setop(_ plan: Plan, _ query: Query, _ overlay: Context,
                                _ name: String)
@@ -936,19 +936,19 @@ extension Catalog where Self: ~Escapable {
         case let .setop(_, leftQuery, rightQuery, _) = query {
       // This node's arm queries are in hand, so the unified column `types` the
       // plan carries (computed at compile) drive the arm coercion `combine`
-      // applies — the SAME types the top-level and Plan-node paths use.
+      // applies — the same types the top-level and Plan-node paths use.
       return try combine(kind, setop(left, leftQuery, overlay, name),
                          setop(right, rightQuery, overlay, name), all,
                          types: types)
     }
     // An `ordered` view body compiles to a `.shaped` stack of single-source row
     // operators (`project`/`sort`/`distinct`/`limit`/`select`) OVER the setop,
-    // so descend the wrapper — the SAME nodes `execute(_:carrying:)` descends —
+    // so descend the wrapper — the same nodes `execute(_:carrying:)` descends —
     // applying each operator through the shared executor helpers, until the
     // `.setop` node recurses above and per-arm augments. The carrier wrapper
-    // sits ABOVE the setop, so `query` is STILL the `.setop` core here — gate
+    // sits above the setop, so `query` is still the `.setop` core here — gate
     // on that: once the setop splits into an arm (`query` a `.select`), that
-    // plan is the ARM's own sub-plan and must execute AS A UNIT under its own
+    // plan is the ARM's own sub-plan and must execute AS A unit under its own
     // augment below, NOT be walked through as a carrier wrapper (which would
     // apply the arm's projection/filter outside its arm-local scope).
     if case .setop = query {
@@ -975,7 +975,7 @@ extension Catalog where Self: ~Escapable {
       }
     }
     // A single-arm leaf (a bare `.setop` body's arm, or a carrier wrapper's
-    // innermost source once the setop above has split): augment THIS arm's own
+    // innermost source once the setop above has split): augment this arm's own
     // derived aliases and execute its sub-plan under the arm-local scope.
     let scope = try augment(overlay.validating(false), for: query, rows: true)
     scope.subqueries.record(overlay: scope.revealed().relations,
@@ -1006,25 +1006,25 @@ private func product(_ outer: Array<Record>, _ inner: Array<Record>)
 /// joined by the equality on its `keys.right` slot (`joined`). A base relation
 /// that reports `column` (the inner ordinal `keys.right` reads) seekable is
 /// sought per outer record — an index-nested loop, cheap because the seek
-/// narrows the scan; one that is NOT seekable is scanned ONCE into a hash map
+/// narrows the scan; one that is NOT seekable is scanned once into a hash map
 /// keyed by its join value and each outer record probes it in O(1) (`hashed`),
 /// rather than reading the whole inner once per outer record. Every strategy
 /// materialises a candidate over the referenced `ordinals` into inner slots `0
 /// ..< ordinals.count`, admits it only when the pushed inner `filter` (in the
-/// inner's standalone slot space) also holds — applied WHILE the inner row is
+/// inner's standalone slot space) also holds — applied while the inner row is
 /// materialised, so a filtered inner row is never paired or bucketed — keys on
 /// the inner's `keys.right` slot (`keys.right - base` in the standalone inner
 /// record), and concatenates a match (the inner's slots landing at `base` in
 /// the combined space). A NULL key joins to nothing, and every path preserves
 /// outer-major order, the inner matches in cursor order within each outer.
 ///
-/// The HASH-JOIN bucket a key falls in — a grouping key, NOT the equality. A
+/// The hash-JOIN bucket a key falls in — a grouping key, NOT the equality. A
 /// numeric value buckets by its `Double` magnitude (an `.integer` promoted), so
 /// every value equal to it under `Filter.matches` shares a bucket: `1` and
 /// `1.0`, and an integer and the double it rounds to past 2^53. A non-numeric
 /// value (text, boolean, blob, null) buckets as itself. The bucket may over-
 /// group — two distinct large integers can share a `Double` bucket — so hash
-/// probing pairs it with a RESIDUAL `matches(_,.equal,_)` check, the same exact
+/// probing pairs it with a residual `matches(_,.equal,_)` check, the same exact
 /// equality the predicate uses (integer/integer exact, mixed promoted). The
 /// seek and CTE nested-loop paths compare with `matches` directly.
 private func bucket(_ value: Value) -> Value {
@@ -1032,11 +1032,11 @@ private func bucket(_ value: Value) -> Value {
   return value
 }
 
-/// A value folded to its EXACT canonical form for duplicate elimination: a
+/// A value folded to its exact canonical form for duplicate elimination: a
 /// whole `double` exactly equal to an `Int` (`Int(exactly:)`) becomes that
 /// `.integer`, so `1.0` and `1` are the same value; every other value (a
 /// fractional double, text, boolean, blob, null) is itself. Unlike the join's
-/// promoted `bucket`, this is EXACT and transitive, so two integers stay
+/// promoted `bucket`, this is exact and transitive, so two integers stay
 /// distinct even when they round to the same double — an earlier approximate
 /// row cannot absorb two unequal exact integers. Grouping reuses it to key its
 /// groups so `1` and `1.0` fall in one group, matching UNION's dedup.
@@ -1048,7 +1048,7 @@ internal func canonical(_ value: Value) -> Value {
 }
 
 /// Tracks the rows already emitted for UNION / recursive-CTE duplicate
-/// elimination under the engine's EXACT numeric equality. A plain
+/// elimination under the engine's exact numeric equality. A plain
 /// `Set<Array<Value>>` over raw cells keeps `1` and `1.0` (and would keep both)
 /// apart; keying each row by its cells' `canonical` form — exact and transitive
 /// — dedups `1`/`1.0` while keeping distinct integers separate even when they
@@ -1058,7 +1058,7 @@ internal func canonical(_ value: Value) -> Value {
 internal struct Seen {
   private var keys = Set<Array<Value>>()
 
-  /// Records `row` and reports whether it was NEW (not a duplicate of one
+  /// Records `row` and reports whether it was new (not a duplicate of one
   /// already seen) — the `Set.insert(_:).inserted` shape the dedup sites use.
   internal mutating func insert(_ row: Array<Value>) -> Bool {
     keys.insert(row.map(canonical)).inserted
@@ -1103,7 +1103,7 @@ extension Catalog where Self: ~Escapable {
       // A NULL key equi-joins to nothing — NULL is unequal to every value,
       // itself included — so it contributes no pair and need not probe.
       if case .null = value { continue }
-      // Seek by the RAW value — the sorted key is a single-kind (integer)
+      // Seek by the raw value — the sorted key is a single-kind (integer)
       // column, and a promoted double would defeat the seek; the numeric
       // equality below still admits a mixed-kind match (a whole double past the
       // range is caught by the residual check even if the seek scanned wide).
@@ -1115,7 +1115,7 @@ extension Catalog where Self: ~Escapable {
         // before it can pair — an inner row it rejects joins to nothing.
         if let filter,
             try evaluate(right, filter, context) != true { continue }
-        // Equal by the SAME rule the predicate uses — integer/integer exact,
+        // Equal by the same rule the predicate uses — integer/integer exact,
         // mixed integer/double promoted — so a seek that scanned wide still
         // pairs exactly.
         if matches(value, .equal, right[slot]) == true {
@@ -1138,7 +1138,7 @@ extension Catalog where Self: ~Escapable {
 /// result the seek path does. An outer NULL key probes nothing.
 ///
 /// A pushed inner `filter` (in the inner's standalone slot space) is applied
-/// DURING this scan, before a row is bucketed: the inner is SEEKED by the
+/// during this scan, before a row is bucketed: the inner is seeked by the
 /// filter's seekable conjunct — `boundaries` over each conjunct, the same
 /// boundary logic the scan seek uses, mapping a slot back to its table column
 /// through `ordinals` — so a seekable/contradictory inner filter reads few or
@@ -1243,7 +1243,7 @@ extension Table where Self: ~Escapable {
 /// per outer record — as opposed to needing a hash build.
 ///
 /// A seekable column reports a boundary for a valid key; an unseekable one
-/// reports `nil`. The probe key must be a VALID one: a decoded coded-index join
+/// reports `nil`. The probe key must be a valid one: a decoded coded-index join
 /// key is 1-based and reports `nil` for the null reference `0`, so probing with
 /// `0` would misclassify a seekable coded-index column as unseekable and force
 /// a hash build even for a selective join. `1` — the least valid key — answers
@@ -1287,7 +1287,7 @@ internal func less(_ lhs: Value, _ rhs: Value) -> Bool {
   case let (.integer(lhs), .integer(rhs)): lhs < rhs
   case let (.double(lhs), .double(rhs)): lhs < rhs
   // A mixed integer/double key is numeric and ordered by magnitude — but
-  // EXACTLY, not via a lossy `Double(integer)`. Past 2^53 a promotion ties a
+  // exactly, not via a lossy `Double(integer)`. Past 2^53 a promotion ties a
   // double with two distinct integers that themselves order exactly, which
   // would make this comparator non-transitive (not a strict weak ordering);
   // the exact form breaks the tie by the integer the double denotes.
@@ -1300,7 +1300,7 @@ internal func less(_ lhs: Value, _ rhs: Value) -> Bool {
   }
 }
 
-/// Whether integer `lhs` is strictly less than double `rhs`, compared EXACTLY.
+/// Whether integer `lhs` is strictly less than double `rhs`, compared exactly.
 /// `Double(lhs) < rhs` decides it unless the two tie under promotion — then
 /// `rhs` is a whole double equal to `Double(lhs)`. If it denotes an exact `Int`
 /// the integers compare directly, so a value past 2^53 orders by its true
@@ -1314,7 +1314,7 @@ private func less(integer lhs: Int, double rhs: Double) -> Bool {
   return lhs < exact
 }
 
-/// Whether double `lhs` is strictly less than integer `rhs`, compared EXACTLY —
+/// Whether double `lhs` is strictly less than integer `rhs`, compared exactly —
 /// the mirror of `less(integer:double:)`. An out-of-`Int` tie means `lhs` lies
 /// outside `Int`, so its sign decides: a positive `lhs` (past `Int.max`) is not
 /// less than any `Int`.

--- a/Sources/SQLEngine/Operator.swift
+++ b/Sources/SQLEngine/Operator.swift
@@ -11,7 +11,7 @@
 /// slot-indexed row the adapter's borrowed cells are copied into at a leaf.
 ///
 /// The plan is *escapable and name-holding*: a `Plan` references each relation
-/// by its catalog NAME rather than by a `~Escapable` `Table` (an `indirect
+/// by its catalog name rather than by a `~Escapable` `Table` (an `indirect
 /// enum` cannot box a `~Escapable` payload), and carries the ordinals the query
 /// actually reads from it. The executor re-resolves a name to a transient
 /// table, opens its cursor, and materialises *only the referenced ordinals*
@@ -85,7 +85,7 @@ internal struct Record: Row, Hashable {
     Record(cells + other.cells)
   }
 
-  /// This record with each cell COERCED to the corresponding column `type`
+  /// This record with each cell coerced to the corresponding column `type`
   /// (`Value.coerced` — the ISO numeric widening a set operation applies to its
   /// arms' rows, promoting an `integer` cell to `double` where the unified
   /// column is `double`). A cell whose column type equals its own kind (a
@@ -101,7 +101,7 @@ internal struct Record: Row, Hashable {
 
 /// An escapable, name-holding relational operator tree.
 ///
-/// Every relation a `SELECT` names is held by its catalog NAME, not by a
+/// Every relation a `SELECT` names is held by its catalog name, not by a
 /// `~Escapable` `Table`, so the whole tree is a plain escapable `indirect
 /// enum`. The leaf `scan` carries the relation name, the ordinals the query
 /// reads from it (reals and virtuals, in materialisation order — the order that
@@ -118,14 +118,14 @@ internal indirect enum Plan {
   /// record (no slots), the row a scalar projection (`SELECT 1 + 1`) computes
   /// its expressions against.
   case single
-  /// The KNOWN-EMPTY relation of `slots` columns: it yields ZERO records over
+  /// The known-empty relation of `slots` columns: it yields zero records over
   /// exactly that combined slot width, the shape the optimiser rewrites a
-  /// PROVABLY constant-false selection into (a `WHERE 1 = 0` admits no row).
+  /// provably constant-false selection into (a `WHERE 1 = 0` admits no row).
   /// `slots` is the width of the subtree the empty replaced, so a downstream
   /// consumer that reads a side's width (`Plan.slots`, the outer/semijoin
   /// NULL-extension) mis-shapes nothing — the schema is preserved, only the
   /// rows are gone. An aggregate over it still yields its degenerate one row
-  /// (`COUNT(*)` `0`), since the empty sits BELOW the aggregate as its source.
+  /// (`COUNT(*)` `0`), since the empty sits below the aggregate as its source.
   case empty(slots: Int)
   /// A leaf over the relation `name`: its `ordinals` (defining its slots), over
   /// the seek's row range when present (else the whole relation).
@@ -158,15 +158,15 @@ internal indirect enum Plan {
   /// `keys.right` are combined-space slots, `base` the inner's first slot in
   /// that combined space, and `column` the inner ordinal `keys.right` reads
   /// (for the seek `bound`). `filter` is a single-relation predicate pushed
-  /// onto the inner — in the inner's OWN 0-based standalone slot space —
-  /// applied WHILE each inner row is materialised, so an inner row that fails
+  /// onto the inner — in the inner's own 0-based standalone slot space —
+  /// applied while each inner row is materialised, so an inner row that fails
   /// it is never paired.
   case join(Plan, name: String, ordinals: Array<Int>, base: Int,
             column: Int, keys: (left: Int, right: Int), filter: Filter?)
   /// ⟕/⟖/⟗ — the OUTER join of `left` and `right` on the `on` predicate, in
   /// combined slot space (the left's slots then the right's). Unlike an inner
   /// join, the `on` predicate is NOT distributed into the product or pushed
-  /// onto a leaf — it governs MATCHING alone, so an unmatched outer row is
+  /// onto a leaf — it governs matching alone, so an unmatched outer row is
   /// still emitted with the other side NULL-extended. `kind` selects which
   /// side's unmatched rows survive: `left` every left row, `right` every right
   /// row, `full` both — a `.inner` kind never reaches this node (an inner join
@@ -174,17 +174,17 @@ internal indirect enum Plan {
   /// nested loop that tracks matches, so it composes with an arbitrary
   /// (non-equi) `on`.
   case outer(Plan, Plan, on: Filter, kind: Join.Kind)
-  /// A SEMIJOIN of `left` against `right` on the `on` predicate — an EXISTENCE
-  /// test whose output is the LEFT side's slots ALONE. Unlike an inner or outer
+  /// A semijoin of `left` against `right` on the `on` predicate — an existence
+  /// test whose output is the LEFT side's slots alone. Unlike an inner or outer
   /// join it neither appends the right's columns nor NULL-extends: it merely
-  /// KEEPS or DROPS each left row by whether the right holds a match, so a left
+  /// keeps or drops each left row by whether the right holds a match, so a left
   /// row survives with its own width unchanged and its slot geometry preserved.
   /// `on` addresses the combined `left ++ right` slot space (the left's slots
-  /// then the right's), so a candidate is merged to EVALUATE it — but the LEFT
+  /// then the right's), so a candidate is merged to evaluate it — but the LEFT
   /// record alone is emitted. `anti` selects the sense: `false` keeps a left
   /// row iff SOME right row makes `on` TRUE (a decorrelated `EXISTS`), `true`
-  /// keeps it iff NO right row does (a decorrelated `NOT EXISTS`). A left row
-  /// emitted AT MOST ONCE regardless of its match count — the semijoin short-
+  /// keeps it iff no right row does (a decorrelated `NOT EXISTS`). A left row
+  /// emitted at most once regardless of its match count — the semijoin short-
   /// circuits on the first match, never multiplying a left row by the number of
   /// right rows it matches, exactly as `EXISTS` is a decided per-row test. The
   /// decorrelation pass emits it for a top-level correlated `EXISTS`/`NOT
@@ -196,40 +196,40 @@ internal indirect enum Plan {
   /// record of the left sub-plan it re-executes the pre-compiled body plan
   /// (looked up by `key` composed with `correlation`, whose `slot` sources bind
   /// from that left record), takes `ordinals` from each produced right record
-  /// into the combined space laid AFTER the left's slots, concatenates it onto
+  /// into the combined space laid after the left's slots, concatenates it onto
   /// the left, and keeps the pair the `on` predicate admits. INNER/CROSS APPLY
   /// (`kind` `.inner`, the only kind emitted): a left record with no surviving
-  /// right record is DROPPED. Unlike a `product`/`outer` the right side is not
+  /// right record is dropped. Unlike a `product`/`outer` the right side is not
   /// a static sub-plan — it re-runs per left row against the correlated
-  /// bindings — so the optimiser treats it as an opaque pushdown BARRIER and
+  /// bindings — so the optimiser treats it as an opaque pushdown barrier and
   /// never rebases a conjunct across it.
   case apply(Plan, key: Subkey, correlation: Correlation,
              ordinals: Array<Int>, on: Filter, kind: Join.Kind)
   /// A set operation of `kind` (`UNION`/`INTERSECT`/`EXCEPT`) over the `left`
   /// and `right` sub-plans, both yielding rows of the same width — the result
-  /// columns, whose NAMES are the first arm's and whose `types` are UNIFIED
+  /// columns, whose names are the first arm's and whose `types` are unified
   /// across the arms.
   ///
   /// `types` is the per-column unified result type (`ValueType.unified` folded
   /// over the arms — a mixed integer/double column widening to `double`), one
-  /// entry per output column. The executor COERCES each arm's cells to these
+  /// entry per output column. The executor coerces each arm's cells to these
   /// types (`Value.coerced`) before applying the operator, so `SELECT 1 UNION
   /// SELECT 2.5` yields a `double` column `[1.0, 2.5]`. It is computed at
-  /// COMPILE — where the arm queries and the resolution scope are in hand —
+  /// compile — where the arm queries and the resolution scope are in hand —
   /// because this node carries only the sub-plans, not the arm `Query`s the
   /// fold reads. A homogeneous set operation's `types` matches every arm's own
   /// types, so the coercion is a no-op and the result is byte-identical.
   ///
   /// `widened` is the output columns whose unified `types[c]` differs from an
-  /// arm's OWN native projected type — the columns the coercion actually
+  /// arm's own native projected type — the columns the coercion actually
   /// changes (a `double` unified over an `integer` arm). It is derived at
   /// compile from the unified `types` against each arm's native types and
   /// carried here so the pushdown pass — a pure Plan rewrite with no catalog —
-  /// can tell a widened column from a same-typed one WITHOUT re-typing the
+  /// can tell a widened column from a same-typed one without re-typing the
   /// arms. A predicate over a widened column must NOT push below this node into
-  /// the arms: an arm evaluates it on the PRE-coercion value, but `combine`
-  /// coerces only the arm's emitted rows AFTER the arm runs, so the pushed
-  /// predicate would test the un-widened type. A predicate over a NON-widened
+  /// the arms: an arm evaluates it on the pre-coercion value, but `combine`
+  /// coerces only the arm's emitted rows after the arm runs, so the pushed
+  /// predicate would test the un-widened type. A predicate over a non-widened
   /// column still pushes (a same-typed `UNION ALL`). Empty for a homogeneous
   /// set operation.
   ///
@@ -239,13 +239,13 @@ internal indirect enum Plan {
   /// operator keeps multiplicity: `UNION ALL` every row of both sides,
   /// `INTERSECT ALL` each common row to the lesser count, `EXCEPT ALL` each
   /// left row beyond the count the right removes. The node is binary and
-  /// mirrors the `Query` set-operation tree, so each node honours its OWN
+  /// mirrors the `Query` set-operation tree, so each node honours its own
   /// `kind`/`all`.
   case setop(SetOperation, Plan, Plan, all: Bool, types: Array<ValueType>,
              widened: Set<Int>)
   /// δ — deduplicates its `source`'s rows, keeping the first occurrence of each
   /// distinct whole row and preserving their order (`SELECT DISTINCT`). It sits
-  /// above the projection, so it dedups the projected output rows on the SAME
+  /// above the projection, so it dedups the projected output rows on the same
   /// whole-row key `UNION` uses (`Value` is `Hashable`). The plain `SELECT`
   /// (equivalently `SELECT ALL`) omits it.
   case distinct(Plan)
@@ -263,7 +263,7 @@ internal indirect enum Plan {
   case aggregate(keys: Array<Term>, aggregates: Array<Aggregation>, Plan)
   /// A row cap on its `source`'s output: skips the first `offset` records then
   /// takes at most `count` of the rest, in the source's order. It sits over the
-  /// sort/select but BELOW the projection, so it caps the ordered rows before
+  /// sort/select but below the projection, so it caps the ordered rows before
   /// the select list is evaluated — a row outside the page is never projected
   /// (a projection that could throw does not run for it). It neither reorders
   /// nor reshapes the rows, a transparent wrapper the pushdown and optimise
@@ -395,16 +395,16 @@ extension Plan {
     return .limit(count: limit.count, offset: limit.offset, self)
   }
 
-  /// Whether EXECUTING this plan cannot throw — the throw-freedom the optimiser
+  /// Whether executing this plan cannot throw — the throw-freedom the optimiser
   /// needs before it may rewrite a constant-false `select` OVER this plan into
   /// `.empty`, discarding the plan unexecuted. Executing `select(false, child)`
   /// today runs `child` (which may raise — a throwing scalar term, a `SUM`
   /// overflow, a subquery fault) and only then filters every row out; folding
-  /// to `.empty` SKIPS `child`, so it is sound ONLY when `child` raises on NO
+  /// to `.empty` skips `child`, so it is sound ONLY when `child` raises on no
   /// input, i.e. is `safe`. This is the plan-level analogue of
-  /// `Filter.safe`/`Term.safe` and is deliberately CONSERVATIVE: a shape whose
+  /// `Filter.safe`/`Term.safe` and is deliberately conservative: a shape whose
   /// throw-freedom is not certain (a `derived` view body, any
-  /// join/apply/aggregate) reports `false`, so the fold is merely MISSED —
+  /// join/apply/aggregate) reports `false`, so the fold is merely missed —
   /// never unsound. Under-folding costs a per-row
   /// predicate; over-folding would suppress a raise, so doubt resolves to
   /// `false`.
@@ -439,20 +439,20 @@ extension Plan {
     // A `derived` view body runs an arbitrary sub-plan (and augments/validates
     // its schema); a `join`/`outer`/`semijoin`/`apply` evaluates an `on`,
     // seeks, or re-executes a correlated body; an `aggregate` may overflow a
-    // `SUM` or type-fault a `MIN`/`MAX`. None is PROVABLY throw-free here, so
+    // `SUM` or type-fault a `MIN`/`MAX`. None is provably throw-free here, so
     // each reports `false` — the fold is missed, never unsound.
     case .derived, .join, .outer, .semijoin, .apply, .aggregate:
       false
     }
   }
 
-  /// Whether this plan PROVABLY yields no two equal FULL rows — every output
+  /// Whether this plan provably yields no two equal FULL rows — every output
   /// record distinct across ALL its columns — the uniqueness the optimiser
   /// needs before it may DROP a `.distinct` over this plan (a redundant dedup).
   /// This is the deduplication analogue of `safe` and is deliberately
-  /// CONSERVATIVE: a shape whose full-row distinctness is not certain reports
-  /// `false`, so the `.distinct` is merely KEPT — never unsound. Over-claiming
-  /// here would LEAK DUPLICATES (wrong results); under-claiming costs one extra
+  /// conservative: a shape whose full-row distinctness is not certain reports
+  /// `false`, so the `.distinct` is merely kept — never unsound. Over-claiming
+  /// here would leak duplicates (wrong results); under-claiming costs one extra
   /// dedup, so doubt resolves to `false`.
   internal var unique: Bool {
     switch self {
@@ -466,12 +466,12 @@ extension Plan {
       return true
     case let .setop(_, _, _, all, _, _):
       // Without `all` the set operator (UNION/INTERSECT/EXCEPT) dedups its
-      // result to distinct rows; `all` (UNION ALL, …) is a MULTISET that keeps
+      // result to distinct rows; `all` (UNION ALL, …) is a multiset that keeps
       // duplicates, so it is NOT unique.
       return !all
     case .aggregate:
-      // A grouped aggregate emits ONE row per distinct group-key combination —
-      // the key values are a PREFIX of each output record, so two output rows
+      // A grouped aggregate emits one row per distinct group-key combination —
+      // the key values are a prefix of each output record, so two output rows
       // differ in those key slots and the full rows are distinct. A no-GROUP-BY
       // aggregate emits exactly one row (its degenerate group), trivially
       // distinct. (`grouped` keys each group on its canonical key cells and
@@ -491,13 +491,13 @@ extension Plan {
       return source.unique
     case let .project(terms, source):
       // A projection preserves full-row distinctness ONLY when it is an
-      // INJECTIVE map of the source's whole row: two distinct source rows must
+      // injective map of the source's whole row: two distinct source rows must
       // stay distinct. That holds when every term is a bare slot read and the
-      // read slots COVER every source slot (`0 ..< source.slots`) — then the
+      // read slots cover every source slot (`0 ..< source.slots`) — then the
       // projected row retains all source columns (reordered/renamed, possibly
       // duplicated), so two source rows differing in ANY column still differ in
       // its retained copy. Dropping a source column, computing an expression,
-      // or an unknown source width could COLLAPSE distinct rows to an equal
+      // or an unknown source width could collapse distinct rows to an equal
       // output, so each of those keeps the projection non-unique. (In practice
       // a `.distinct` always sits over a `.project`, so this arm decides it.)
       guard let width = source.slots, source.unique else { return false }
@@ -507,10 +507,10 @@ extension Plan {
         covered.insert(slot)
       }
       return covered == Set(0 ..< width)
-    // A base `scan` is an ISO MULTISET (a duplicate row is possible, no unique
+    // A base `scan` is an ISO multiset (a duplicate row is possible, no unique
     // key is tracked); a `derived` view body runs an arbitrary sub-plan; a
-    // `product`/`join`/`outer`/`apply` can MULTIPLY rows (a fan-out pairs one
-    // row with many). None PROVABLY yields distinct full rows, so each reports
+    // `product`/`join`/`outer`/`apply` can multiply rows (a fan-out pairs one
+    // row with many). None provably yields distinct full rows, so each reports
     // `false` — the `.distinct` stays, never unsound. A `semijoin` emits each
     // left row at most once but does not deduplicate the left, so it is only as
     // unique as its left source and is conservatively `false` here.

--- a/Sources/SQLEngine/Optimisation.swift
+++ b/Sources/SQLEngine/Optimisation.swift
@@ -45,21 +45,21 @@ extension Catalog where Self: ~Escapable {
       // Optimise the view's sub-plan with the bindings so a bound predicate
       // inside the view seeks; the derived leaf itself carries no sort key, so
       // the outer query still scans its result as is. The sub-plan resolves
-      // OUTSIDE the statement's CTE scope — never a caller's `WITH` — so a view
+      // outside the statement's CTE scope — never a caller's `WITH` — so a view
       // means what it was registered to mean; its scope is the
-      // `definition_schema.` overlay its OWN query names (the same one it
+      // `definition_schema.` overlay its own query names (the same one it
       // compiled under), so a view body's store scan re-resolves.
       //
-      // A SET-OPERATION view body's arm scans an arm-local derived alias the
+      // A SET-operation view body's arm scans an arm-local derived alias the
       // whole-view overlay does not bind (arms are SELECT-scoped), so `seek`
-      // would fault `.relation` resolving it. Optimise each arm under THAT
+      // would fault `.relation` resolving it. Optimise each arm under that
       // arm's own augmented overlay — the same per-arm scope `derive`/`setop`
       // execute it under — so the arm's `d` resolves for the seek rewrite.
       try .derived(name: name,
                    plan: optimise(view: name, plan, context),
                    ordinals: ordinals, seek: seek)
     case let .select(filter, source) where filter.constant == true:
-      // A PROVABLY-always-true filter admits every row, so the select is a
+      // A provably-always-true filter admits every row, so the select is a
       // no-op: drop it and optimise the source alone — identical result, one
       // fewer per-row predicate. This composes with the seek and nest cases
       // below: a constant-true filter over a `.scan` or `.product` never
@@ -67,7 +67,7 @@ extension Catalog where Self: ~Escapable {
       // product), not a seek over a true residual or a nest with a true gate.
       try optimise(source, context)
     case let .select(filter, source) where filter.constant == false:
-      // A PROVABLY-always-false filter admits NO row, so the whole selection is
+      // A provably-always-false filter admits no row, so the whole selection is
       // the known-empty relation of the source's width — WHEN discarding the
       // source suppresses no observable throw. `emptied(filter:over:)`
       // optimises the source, then folds to `.empty` only when that source is
@@ -122,7 +122,7 @@ extension Catalog where Self: ~Escapable {
     case let .distinct(source):
       // A `distinct` dedups its source without a seek or join of its own;
       // optimise the source below it, then DROP the dedup when that optimised
-      // source PROVABLY yields distinct full rows already (`Plan.unique`) —
+      // source provably yields distinct full rows already (`Plan.unique`) —
       // DISTINCT-of-DISTINCT, DISTINCT over a set operation's deduped result,
       // or over a grouped aggregate — else rewrap and keep deduplicating.
       try deduplicated(source, context)
@@ -141,21 +141,21 @@ extension Catalog where Self: ~Escapable {
     }
   }
 
-  /// The fold of a PROVABLY constant-false `select(filter, source)` into the
+  /// The fold of a provably constant-false `select(filter, source)` into the
   /// known-empty relation, or the select left intact when the fold would change
   /// more than the (already-zero) row count.
   ///
   /// A constant-false `filter` admits no row, so the selection's result is
   /// empty — but executing `select(false, source)` today still runs `source`,
-  /// which may RAISE, before it filters every row out. Rewriting to `.empty`
-  /// skips `source` entirely, so it is sound ONLY when `source` raises on NO
-  /// input (`Plan.safe`) — else the fold would SUPPRESS a throw, a correctness
+  /// which may raise, before it filters every row out. Rewriting to `.empty`
+  /// skips `source` entirely, so it is sound ONLY when `source` raises on no
+  /// input (`Plan.safe`) — else the fold would suppress a throw, a correctness
   /// bug
   /// rather than an optimisation. The source is optimised first so its safety
   /// and width reflect the physical shape the executor would actually run (and
   /// so its own nested folds still apply on the fall-through). `.empty` carries
   /// the source's slot width so a downstream consumer mis-shapes nothing; a
-  /// source of unknown width (`slots` nil) is left filtering. On EITHER doubt
+  /// source of unknown width (`slots` nil) is left filtering. On either doubt
   /// the select stays — a constant-false filter neither seeks nor supplies a
   /// join key (`1 = 0` reads no slot), so no seek or nest rewrite is forgone.
   private borrowing func emptied(_ filter: Filter, over source: Plan,
@@ -169,18 +169,18 @@ extension Catalog where Self: ~Escapable {
   }
 
   /// The fold of a `distinct(source)` into its optimised `source` alone when
-  /// that source PROVABLY yields distinct full rows already, or the `distinct`
+  /// that source provably yields distinct full rows already, or the `distinct`
   /// left wrapping it otherwise.
   ///
   /// `SELECT DISTINCT` compiles to a `distinct` over the projected rows, but
-  /// the dedup is REDUNDANT when the source yields no duplicate full row — a
+  /// the dedup is redundant when the source yields no duplicate full row — a
   /// DISTINCT over another DISTINCT, over a set operation's already-deduped
   /// result, or over a grouped aggregate (one row per distinct group key). The
   /// source is optimised first so its `unique` reflects the physical shape the
   /// executor runs (and so its own nested folds still apply). Dropping the
-  /// `distinct` is sound ONLY when `source.unique` is PROVABLY true — a
-  /// CONSERVATIVE test resolving every doubt to `false` (keep the dedup), so a
-  /// mis-fold never LEAKS a duplicate; a missed fold costs one extra dedup.
+  /// `distinct` is sound ONLY when `source.unique` is provably true — a
+  /// conservative test resolving every doubt to `false` (keep the dedup), so a
+  /// mis-fold never leaks a duplicate; a missed fold costs one extra dedup.
   private borrowing func deduplicated(_ source: Plan, _ context: Context)
       throws(SQLError) -> Plan {
     let source = try optimise(source, context)
@@ -188,17 +188,17 @@ extension Catalog where Self: ~Escapable {
   }
 
   /// Optimises a VIEW body's sub-`plan` for the view named `name`, resolving
-  /// its scans under the view's OWN overlay rather than a caller's scope.
+  /// its scans under the view's own overlay rather than a caller's scope.
   ///
-  /// A SINGLE-arm body optimises under the whole-view overlay
-  /// (`overlay(name:)`) — the same scope it compiled under. A SET-OPERATION
-  /// body optimises each ARM under THAT arm's own augmented overlay: an arm
+  /// A single-arm body optimises under the whole-view overlay
+  /// (`overlay(name:)`) — the same scope it compiled under. A SET-operation
+  /// body optimises each ARM under that arm's own augmented overlay: an arm
   /// scans its arm-local derived alias, which the whole-view overlay does not
   /// bind (arms are SELECT-scoped), so `seek` would fault `.relation` resolving
   /// it. The `plan` tree mirrors the `query` tree, so this descends the two in
-  /// lockstep — a `.setop` node recurses into both arms, a LEAF arm augments
-  /// the arm's aliases SCHEMA-ONLY (`rows: false`, so `seek` treats them as
-  /// unseekable materialised relations by name/schema WITHOUT executing a
+  /// lockstep — a `.setop` node recurses into both arms, a leaf arm augments
+  /// the arm's aliases schema-ONLY (`rows: false`, so `seek` treats them as
+  /// unseekable materialised relations by name/schema without executing a
   /// derived body) and optimises the arm sub-plan under that arm-local scope —
   /// matching the per-arm scope `derive`/`setop` execute it under.
   private borrowing func optimise(view name: String, _ plan: Plan,
@@ -208,8 +208,8 @@ extension Catalog where Self: ~Escapable {
     guard let view = resolve(view: name) else {
       return try optimise(plan, overlay)
     }
-    // A BARE set-operation body (`view.query` itself a `.setop`) optimises its
-    // `.setop` plan per arm, EXACTLY as before — but any other plan shape (a
+    // A bare set-operation body (`view.query` itself a `.setop`) optimises its
+    // `.setop` plan per arm, exactly as before — but any other plan shape (a
     // pushed `.select` over the setop, a `.derived`, a leaf) stays on the plain
     // optimiser, whose pushdown/seek pass rebases a caller `WHERE` into each
     // arm. Preserved verbatim so a non-ordered union view's seek injection is
@@ -217,12 +217,12 @@ extension Catalog where Self: ~Escapable {
     if case .setop = view.query, case .setop = plan {
       return try optimise(plan, view.query, overlay)
     }
-    // A set operation UNDER an `ordered` carrier compiles to a `.shaped` stack
+    // A set operation under an `ordered` carrier compiles to a `.shaped` stack
     // (project/sort/distinct/limit) over the `.setop` — NOT a bare setop — so
     // its per-arm derived aliases went un-optimised (both `case .setop` guards
     // failed). Descend the carrier wrapper to the setop leaf, optimising each
     // arm under its own overlay, exactly as the execute path's carrier-aware
-    // `setop`/`execute(_:carrying:)` do. GATED on the body actually wearing a
+    // `setop`/`execute(_:carrying:)` do. gated on the body actually wearing a
     // carrier (`view.query` an `.ordered`), so a bare union view keeps the
     // plain path above and this never rewrites its pushed `.select`/seek shape.
     if case .ordered = view.query, case .setop = view.query.core {
@@ -231,8 +231,8 @@ extension Catalog where Self: ~Escapable {
     return try optimise(plan, overlay)
   }
 
-  /// Optimises a view body's SET-OPERATION `plan` arm by arm, each arm sub-plan
-  /// under `overlay` AUGMENTED with THAT arm's own derived aliases, descending
+  /// Optimises a view body's SET-operation `plan` arm by arm, each arm sub-plan
+  /// under `overlay` augmented with that arm's own derived aliases, descending
   /// the `plan` and `query` trees in lockstep (they mirror each other). A body
   /// riding an `ordered` carrier descends the `.shaped` wrapper stack first,
   /// reconstructing each row operator over its optimised source, down to the
@@ -249,7 +249,7 @@ extension Catalog where Self: ~Escapable {
     // Descend the `ordered` carrier's single-source row operators, rebuilding
     // each over its optimised source while the setop `query` core rides through
     // unchanged until the `.setop` node above splits it. The carrier wrapper
-    // sits ABOVE the setop, so `query` is STILL the `.setop` core here — gate
+    // sits above the setop, so `query` is still the `.setop` core here — gate
     // on that: once the setop has split into an arm (`query` a `.select`), the
     // plan is that ARM's own sub-plan, whose `.project`/`.select`/… must reach
     // the plain arm optimiser below (its seek/pushdown rewrite), NOT be walked
@@ -273,12 +273,12 @@ extension Catalog where Self: ~Escapable {
     }
     // Schema-only (`rows: false`): the optimiser needs the arm's derived alias
     // bound by name/schema so `seek` treats it as an unseekable materialised
-    // relation — NOT its rows. Materialising here would EXECUTE the arm's
+    // relation — NOT its rows. Materialising here would execute the arm's
     // derived body during optimisation (a stateful routine would run once here
     // and again at `derive`), so bind schema-only and let the single execution
     // happen at run.
     //
-    // `validate: false` — this is the RUN path's optimiser, matching the
+    // `validate: false` — this is the run path's optimiser, matching the
     // `overlay(name:)` above: `resolve`/`compile` already validated the view
     // body under the caller's `validate`, so an arm's data-dependent-empty
     // derived body must not be re-type-checked here and fault a run that its
@@ -317,7 +317,7 @@ extension Catalog where Self: ~Escapable {
       return .scan(name: name, ordinals: ordinals, seek: range)
     }
 
-    // Seek by one conjunct only when the OTHER — the residual, then run over
+    // Seek by one conjunct only when the other — the residual, then run over
     // just the sought run — is safe. Seeking narrows the scan, so a residual
     // that can throw would raise only on the rows the seek kept, suppressing a
     // throw the un-seeked scan owes on a skipped row: `(1 / x) = 0 AND id < 0`
@@ -360,7 +360,7 @@ private func comparison(_ filter: Filter, _ bindings: Bindings)
 }
 
 /// The seekable `(slot, lower, upper)` of a non-negated `x BETWEEN lower AND
-/// upper` whose test `x` is a `slot` and whose bounds EACH resolve to an
+/// upper` whose test `x` is a `slot` and whose bounds each resolve to an
 /// integer — a `.term` integer literal, or a `:parameter` bound to an integer
 /// in `bindings`, the same resolution `comparison` applies to a `.bound` — a
 /// two-sided run the seek reads directly off the sorted key, exactly the range
@@ -440,7 +440,7 @@ extension Table where Self: ~Escapable {
           let upper = bound(ordinals[slot], high, strict: true) else {
         return nil
       }
-      // An inverted `BETWEEN lower AND upper` (lower > upper) is a valid EMPTY
+      // An inverted `BETWEEN lower AND upper` (lower > upper) is a valid empty
       // range: the `x >= lower` partition starts after the `x <= upper` one
       // ends, so `lower > upper` here and `lower ..< upper` would trap Swift's
       // `Range(lowerBound <= upperBound)` precondition. Seek an empty run.
@@ -494,8 +494,8 @@ extension Catalog where Self: ~Escapable {
   /// table ordinal (`column`) through the inner scan's `ordinals` for the
   /// seek's `bound`. The matching conjunct is consumed; any remaining conjuncts
   /// stay as a residual `Select`. The pushed inner filter rides on the `Join`
-  /// node itself — in the inner's OWN 0-based standalone slot space, the space
-  /// it already lives in on the inner scan — so the executor applies it WHILE
+  /// node itself — in the inner's own 0-based standalone slot space, the space
+  /// it already lives in on the inner scan — so the executor applies it while
   /// materialising inner rows (before bucketing / as part of the inner scan),
   /// rather than lifting it into the residual to run after the join. Applying
   /// it during materialisation means a pair forms only when the filter holds,

--- a/Sources/SQLEngine/OutputColumn.swift
+++ b/Sources/SQLEngine/OutputColumn.swift
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 /// The result schema of a query — the columns it would yield, named and typed,
-/// WITHOUT running it.
+/// without running it.
 ///
 /// A `SELECT`'s result has a name and a type per column: `SELECT *` takes them
 /// from the relations in scope, a bare-column list from the column names, and
 /// an expression list from each item's alias (else a derived name, else a
-/// positional `column N`). `Catalog.columns(of:)` computes this by RESOLVING
+/// positional `column N`). `Catalog.columns(of:)` computes this by resolving
 /// the query — the same name → schema resolution compilation runs — but never
 /// opening a cursor, so it is safe over an empty or costly source. It is the
 /// one capability behind the `INFORMATION_SCHEMA` overlay's own headers, a
@@ -32,15 +32,15 @@ public struct OutputColumn: Hashable, Sendable {
 
 // MARK: - Resolved column
 
-/// One column of a relation body's RESOLVED output — the authoritative
+/// One column of a relation body's resolved output — the authoritative
 /// per-column descriptor a binding is built FROM as a whole, rather than
 /// re-listed field by field at each site.
 ///
 /// It wraps the body's `OutputColumn` (name + type) and carries the per-column
 /// `unconstrained` mask a set-operation type unification threads: whether every
-/// arm folded into this column projects a CONSTANT NULL, so it places NO type
+/// arm folded into this column projects a constant NULL, so it places no type
 /// constraint on a unified column (a NULL unifies with any typed arm, exactly
-/// as `COALESCE` skips a constant-NULL argument). It is the ONE per-column
+/// as `COALESCE` skips a constant-NULL argument). It is the one per-column
 /// carrier: both `resolved(query:in:)`/`columns(unifying:)` and `merge` operate
 /// on and return it, and every binding is built from it via the single
 /// `init(from:)` constructor — no site re-lists the fields, so none can drop
@@ -50,17 +50,17 @@ internal struct ResolvedColumn: Hashable, Sendable {
   internal let column: OutputColumn
 
   /// Whether every arm folded into this column so far projects a constant NULL,
-  /// so it places NO type constraint on the set-operation's unified column.
+  /// so it places no type constraint on the set-operation's unified column.
   internal let unconstrained: Bool
 
-  /// Whether this column's NAME is a SYNTHESIZED positional `column N` header
+  /// Whether this column's name is a synthesized positional `column N` header
   /// rather than an inferable output name — the projection had no alias and no
   /// bare-column name (`Projected.name == nil`), so a display header stood in.
-  /// It is the STRUCTURAL bare/unnamed fact (set where the name is fabricated),
+  /// It is the structural bare/unnamed fact (set where the name is fabricated),
   /// carried so a consumer distinguishes a synthesized header from a user's
-  /// EXPLICIT delimited `AS "column 1"` — the two are indistinguishable by NAME
+  /// explicit delimited `AS "column 1"` — the two are indistinguishable by name
   /// text but not by provenance. The left arm's flag wins a set-operation fold,
-  /// mirroring the ISO first-arm NAME rule.
+  /// mirroring the ISO first-arm name rule.
   internal let synthesized: Bool
 
   internal init(_ column: OutputColumn, unconstrained: Bool = false,
@@ -92,10 +92,10 @@ internal struct ResolvedColumn: Hashable, Sendable {
 
 /// Merges two set-operation arms' resolved columns into the fold's running
 /// column: the name is the LEFT arm's (the ISO first-arm rule), and the type is
-/// the unification of the two — SKIPPING a constant-NULL (unconstrained) arm's
-/// type, which constrains nothing. A column that is constant NULL in BOTH arms
+/// the unification of the two — skipping a constant-NULL (unconstrained) arm's
+/// type, which constrains nothing. A column that is constant NULL in both arms
 /// stays unconstrained (its type the left's, defaulting to the `.integer` a
-/// NULL column already carries); a column typed in ONE arm and NULL in the
+/// NULL column already carries); a column typed in one arm and NULL in the
 /// other takes the typed arm's type and becomes constrained; two typed arms
 /// merge through `ValueType.unified`, faulting `SQLError.operand` (SQLSTATE
 /// 42804) on an irreconcilable pair — a text beside a number, a boolean beside
@@ -107,21 +107,21 @@ internal struct ResolvedColumn: Hashable, Sendable {
 /// a discardable placeholder, marked `unconstrained` so a further enclosing
 /// fold treats it as placing no constraint. The pre-pass records this width-1
 /// type for a subquery the reachability walk has not yet decided runs; an
-/// UNREACHED occurrence's type is discarded, and a REACHED scalar/`IN` one is
-/// re-folded STRICTLY (`shape: false`) on the reached path, so a genuine
+/// unreached occurrence's type is discarded, and a reached scalar/`IN` one is
+/// re-folded strictly (`shape: false`) on the reached path, so a genuine
 /// incompatibility still faults there. Arity/resolution stay eager regardless.
 internal func merge(_ left: ResolvedColumn, _ right: ResolvedColumn,
                     shape: Bool = false)
     throws(SQLError) -> ResolvedColumn {
   let name = left.column.name
-  // The NAME (and its synthesized-header provenance) is the LEFT arm's — the
+  // The name (and its synthesized-header provenance) is the LEFT arm's — the
   // ISO first-arm rule — so a union whose first arm names a column `column N`
   // by synthesis stays synthesized (not bindable), and one whose first arm
   // names it explicitly stays a real output, regardless of the right arm.
   let synthesized = left.synthesized
-  // A constant-NULL arm constrains nothing: carry the OTHER arm's type (and,
+  // A constant-NULL arm constrains nothing: carry the other arm's type (and,
   // when both are NULL, the left's), narrowing the running unconstrained-ness
-  // to whether BOTH remaining arms are NULL.
+  // to whether both remaining arms are NULL.
   if left.unconstrained {
     return ResolvedColumn(name: name, type: right.column.type,
                           unconstrained: right.unconstrained,
@@ -177,9 +177,9 @@ extension Scope {
     // The `NATURAL`/`USING` merged columns FIRST (ISO 9075 7.10) — each named
     // by its merged name and typed by its unified coalesce type — then every
     // real column the shared `expansion` enumeration yields, resolved at its
-    // combined ordinal (name/type/mask read TOGETHER, `resolved(at:named:)`),
-    // so the schema names the SAME columns the run's `terms(.all)` projects and
-    // `width(of: .all)` counts. Each merged output is built through the SAME
+    // combined ordinal (name/type/mask read together, `resolved(at:named:)`),
+    // so the schema names the same columns the run's `terms(.all)` projects and
+    // `width(of: .all)` counts. Each merged output is built through the same
     // `resolved(named:)` the explicit `output(of:)` uses, so a `SELECT *`
     // carries the merged column's `unconstrained` mask (two constant-NULL
     // constituents leave the merged `k` unconstrained) exactly as a bare
@@ -190,9 +190,9 @@ extension Scope {
 
   /// The resolved output column a bare `column` reference yields — its own name
   /// (its spelling as written), its type, AND its `unconstrained` mask, read
-  /// TOGETHER from ONE resolution so the two cannot diverge: from the relation
-  /// that LOCALLY resolves it (`resolved(_:)` — one `find`, both fields), or,
-  /// for a name no local relation binds, from the CORRELATION `subquery`
+  /// together from one resolution so the two cannot diverge: from the relation
+  /// that locally resolves it (`resolved(_:)` — one `find`, both fields), or,
+  /// for a name no local relation binds, from the correlation `subquery`
   /// surface (`resolved(for:)` — carrying the outer column's mask, so a
   /// correlated all-NULL column stays unconstrained), mirroring the expression
   /// path's `derive`. Under a LATERAL body's admitting (`everywhere`) surface a
@@ -202,11 +202,11 @@ extension Scope {
   internal func output(of column: Column,
                        subquery: Resolution = .unsupported)
       throws(SQLError) -> ResolvedColumn {
-    // A BARE name matching a `NATURAL`/`USING` merged column (ISO 9075 7.10)
+    // A bare name matching a `NATURAL`/`USING` merged column (ISO 9075 7.10)
     // names and types from the merged column — its unified coalesce type — with
     // no physical ordinal, matching the run's `term`; a same-named physical
     // column a later plain join added faults `.ambiguous`. It carries the
-    // merged column's OWN `unconstrained` mask, so a `… USING (k) UNION SELECT
+    // merged column's own `unconstrained` mask, so a `… USING (k) UNION SELECT
     // 1` over two constant-NULL constituents defers the unified type to the
     // typed arm rather than hard-coding the merged column constrained.
     if column.qualifier == nil,
@@ -230,45 +230,45 @@ extension Scope {
   /// return type; every other expression `.integer`.
   ///
   /// It also carries the `unconstrained` mask a set-operation fold reads — a
-  /// column that places NO type constraint (a NULL unifies with any typed arm,
+  /// column that places no type constraint (a NULL unifies with any typed arm,
   /// exactly as `COALESCE` skips a constant-NULL argument). Three sources mark
-  /// it so, all read HERE from the same resolution as the type, never a
-  /// separate local-only walk: an expression that folds to a CONSTANT NULL for
-  /// every row (`null(_:)`); an expression that would dispatch an UNREGISTERED
+  /// it so, all read here from the same resolution as the type, never a
+  /// separate local-only walk: an expression that folds to a constant NULL for
+  /// every row (`null(_:)`); an expression that would dispatch an unregistered
   /// routine at ANY depth (`unresolved(_:)` — `derive` fabricates the
   /// `.integer` default for such a call, so the fold must defer rather than
   /// fault on the placeholder); and a bare-column reference resolving to an
-  /// unconstrained source column (`output(of:)` — LOCAL or CORRELATED, so an
+  /// unconstrained source column (`output(of:)` — local or correlated, so an
   /// all-NULL column referenced through a LATERAL body keeps its mask).
   internal func output(_ item: Projected, at index: Int,
                        _ routines: Routines = [:],
                        subquery: Resolution = .unsupported)
       throws(SQLError) -> ResolvedColumn {
-    // The item's inferable output NAME (`Projected.name` — an alias, else a
-    // bare column's name), or a SYNTHESIZED positional `column N` header when
-    // it has none. `synthesized` is that STRUCTURAL bare/unnamed fact — carried
+    // The item's inferable output name (`Projected.name` — an alias, else a
+    // bare column's name), or a synthesized positional `column N` header when
+    // it has none. `synthesized` is that structural bare/unnamed fact — carried
     // on the resolved column so a consumer (the `ordered` set-op carrier)
     // distinguishes this fabricated header from a user's explicit delimited
-    // `AS "column 1"`, which by NAME text is identical but is a real output.
+    // `AS "column 1"`, which by name text is identical but is a real output.
     let synthesized = item.name == nil
     let name = item.name ?? "column \(index + 1)"
-    // A projection places NO type constraint on the unified column when it
-    // folds to a CONSTANT NULL for every row (`null` — its derived literal-fix
-    // type must not shape the fold) OR when it would dispatch an UNREGISTERED
+    // A projection places no type constraint on the unified column when it
+    // folds to a constant NULL for every row (`null` — its derived literal-fix
+    // type must not shape the fold) OR when it would dispatch an unregistered
     // routine at ANY depth (`unresolved` — `derive` fabricates the `.integer`
     // default for such a call, and the fold must not fault on that
-    // placeholder). Either way mark it UNCONSTRAINED and derive its type only
+    // placeholder). Either way mark it unconstrained and derive its type only
     // for the column's advertised type, which the fold then ignores. A
     // reachable missing call still faults `SQLError.function` at the run
-    // typecheck, so this defers only the FOLD, never hides the call.
+    // typecheck, so this defers only the fold, never hides the call.
     if null(item.expression, routines)
         || unresolved(item.expression, routines) {
       let type = try derive(item.expression, routines, subquery: subquery)
       return ResolvedColumn(OutputColumn(name: name, type: type),
                             unconstrained: true, synthesized: synthesized)
     }
-    // A bare-column projection reuses the ONE column resolution — LOCAL or
-    // CORRELATED — so its type and `unconstrained` mask agree, renaming only
+    // A bare-column projection reuses the one column resolution — local or
+    // correlated — so its type and `unconstrained` mask agree, renaming only
     // its output name when the item carries an alias.
     if case let .column(column) = item.expression {
       let resolved = try output(of: column, subquery: subquery)
@@ -276,11 +276,11 @@ extension Scope {
                             unconstrained: resolved.unconstrained,
                             synthesized: synthesized)
     }
-    // A bare scalar-subquery projection reuses the subquery's OWN resolved
+    // A bare scalar-subquery projection reuses the subquery's own resolved
     // column — its type AND `unconstrained` mask — so a constant-NULL body
     // (`(SELECT NULLIF('a','a'))`) stays unconstrained in an outer
     // set-operation fold, mirroring the bare-column branch above. Only a bare
-    // `.subquery` qualifies: a subquery NESTED inside a larger expression
+    // `.subquery` qualifies: a subquery nested inside a larger expression
     // legitimately constrains, so it falls through to the generic (constrained)
     // else below.
     if case let .subquery(query) = item.expression {
@@ -289,7 +289,7 @@ extension Scope {
                             unconstrained: resolved.unconstrained,
                             synthesized: synthesized)
     }
-    // DERIVE the nominal output type: the schema reports the type a run would
+    // derive the nominal output type: the schema reports the type a run would
     // produce and never faults on an operand. Run-time operand and call
     // validation is `typecheck`'s job, reachability-aware, so a schema resolves
     // even for an expression a zero-row limit makes unreachable. A scalar

--- a/Sources/SQLEngine/Parser+Predicate.swift
+++ b/Sources/SQLEngine/Parser+Predicate.swift
@@ -29,8 +29,8 @@ extension Parser {
 
   /// Parses `NOT negation`, `[NOT] EXISTS (query)`, or a primary.
   ///
-  /// `EXISTS` is a complete predicate with NO left operand — `EXISTS (Q)` — so
-  /// it is recognised HERE, ahead of the comparison tier a left expression
+  /// `EXISTS` is a complete predicate with no left operand — `EXISTS (Q)` — so
+  /// it is recognised here, ahead of the comparison tier a left expression
   /// begins in. A prefix `NOT` before it sets the `negated` flag directly
   /// (`NOT EXISTS (Q)`) rather than wrapping it in a `.not`, symmetric with how
   /// `membership`/`between`/`like` carry their `NOT`; a prefix `NOT` before
@@ -66,8 +66,8 @@ extension Parser {
   /// constructor>` heading a row comparison or row `IN` (`(a, b) = (c, d)`), a
   /// parenthesised predicate (`(a = 1 AND b = 2)`), or the parenthesised left
   /// operand of a comparison (`(Age + 1) = 26`, where `factor` consumes the
-  /// `(expression)`). A COMMA inside the parentheses marks the row form, which
-  /// `row()` detects and COMMITS to — a row is never a valid predicate, so its
+  /// `(expression)`). A comma inside the parentheses marks the row form, which
+  /// `row()` detects and commits to — a row is never a valid predicate, so its
   /// tail errors (an arity mismatch) must propagate rather than trigger the
   /// predicate rewind. Otherwise the comparison is tried first; if it fails,
   /// the group was a predicate, so the parser rewinds to the saved lexer and
@@ -188,12 +188,12 @@ extension Parser {
   }
 
   /// Parses an ISO `<row value constructor>` — `'(' expression (','
-  /// expression)+ ')'`, at least TWO elements — returning its element
+  /// expression)+ ')'`, at least two elements — returning its element
   /// expressions, or `nil` when the current token does not open one so the
   /// caller falls through to the scalar path.
   ///
   /// A leading `(` is ambiguous between a row and a parenthesised scalar
-  /// (`(x)`), or an arithmetic group (`(a + b)`): only a COMMA inside the
+  /// (`(x)`), or an arithmetic group (`(a + b)`): only a comma inside the
   /// parentheses makes it a row. So this saves the lexer and lookahead, opens
   /// the `(`, and parses the first element; a following `,` confirms the row —
   /// it collects the rest and the `)`. Without a comma it is a scalar, so the
@@ -238,14 +238,14 @@ extension Parser {
   }
 
   /// Parses the tail of a row comparison or row `IN` whose left `<row value
-  /// constructor>` is already parsed to `left`, building the FIRST-CLASS AST
+  /// constructor>` is already parsed to `left`, building the FIRST-class AST
   /// node (`Predicate.rows` / `Predicate.among`) rather than desugaring it —
   /// each component `Expression` is held once so the lowering evaluates it
   /// exactly once per row, the correctness fix over a desugar that duplicated a
   /// component across the places a conjunction/cascade names it.
   ///
   /// A relational operator (`= <> < <= > >=`) takes a second row constructor of
-  /// EQUAL arity (else `SQLError.arity`), building `Predicate.rows(left, op,
+  /// equal arity (else `SQLError.arity`), building `Predicate.rows(left, op,
   /// right)`. An `IN` (or `NOT IN`) takes a parenthesised list of row
   /// constructors, building `Predicate.among(left, elements, negated:)`. The
   /// ISO three-valued semantics (the componentwise conjunction for `=`, the
@@ -275,7 +275,7 @@ extension Parser {
 
   /// Parses the tail of a row `[NOT] IN '(' row (',' row)* ')'` — the `IN` is
   /// already consumed — building `Predicate.among(left, elements, negated:)`
-  /// over `left` and the parsed element rows, each of EQUAL arity (else
+  /// over `left` and the parsed element rows, each of equal arity (else
   /// `SQLError.arity`) and the list non-empty. `negated` marks `NOT IN`.
   private mutating func rows(_ left: Array<Expression>, in negated: Bool)
       throws(SQLError) -> Predicate {
@@ -318,7 +318,7 @@ extension Parser {
   /// into a `membership` (value-list) or a `within` (subquery) predicate over
   /// `left`.
   ///
-  /// After the opening `(`, ONE token of lookahead disambiguates the two forms:
+  /// After the opening `(`, one token of lookahead disambiguates the two forms:
   /// a `SELECT` begins a subquery — `left [NOT] IN (query)`, the first-class
   /// `Predicate.within` (the query may itself be a `UNION`) — and anything
   /// else begins the value list, a non-empty run of comma-separated
@@ -345,7 +345,7 @@ extension Parser {
   /// `Predicate.distinct`, `negated` carrying the `IS NOT` (null-safe equality)
   /// spelling.
   ///
-  /// It is the ISO null-safe comparison of the two expressions: TWO-VALUED
+  /// It is the ISO null-safe comparison of the two expressions: two-valued
   /// (never UNKNOWN), treating NULL as a comparable value, unlike `=`. The
   /// right operand is an ordinary scalar `expression` — not an `Operand`, as no
   /// `:parameter` form is defined for this predicate.
@@ -363,7 +363,7 @@ extension Parser {
   /// range) and `x NOT BETWEEN a AND b` as its negation `x < a OR x > b`, but
   /// that expansion duplicates `x` across both bound comparisons, evaluating a
   /// stateful `x` twice — so this parses the two bounds around the `AND`
-  /// keyword and builds the first-class node the engine evaluates `x` ONCE for,
+  /// keyword and builds the first-class node the engine evaluates `x` once for,
   /// keeping the same three-valued NULL semantics (a NULL `x`, `a`, or `b`
   /// makes a bound UNKNOWN, and the row is excluded).
   ///

--- a/Sources/SQLEngine/Parser+Projection.swift
+++ b/Sources/SQLEngine/Parser+Projection.swift
@@ -100,7 +100,7 @@ extension Parser {
   /// expressions, possibly empty.
   private mutating func factor() throws(SQLError) -> Expression {
     if try match(.lparen) {
-      // ONE token of lookahead after `(` disambiguates a SCALAR SUBQUERY from a
+      // one token of lookahead after `(` disambiguates a scalar subquery from a
       // parenthesised expression: a `SELECT`, `TABLE`, or `VALUES` begins a
       // subquery — `(query)`, the first-class `Expression.subquery` (the query
       // may itself be a `UNION`) — and anything else begins a parenthesised
@@ -184,7 +184,7 @@ extension Parser {
     }
 
     // `POSITION` and `OVERLAY` are ISO string functions with a
-    // KEYWORD-separated argument syntax (`IN`; `PLACING`/`FROM`/`FOR`) rather
+    // keyword-separated argument syntax (`IN`; `PLACING`/`FROM`/`FOR`) rather
     // than the comma list an ordinary call takes, recognised case-insensitively
     // only when written bare (a delimited `"POSITION"`/`"OVERLAY"` is a
     // scalar-call name). Each desugars — the `(` already consumed — into the
@@ -307,8 +307,8 @@ extension Parser {
   /// Parses a `CASE` expression (the `CASE` is the next token) into the
   /// searched `Expression.case`, admitting both ISO forms.
   ///
-  /// A `WHEN` directly after `CASE` is the SEARCHED form — each `WHEN` a full
-  /// predicate. An expression after `CASE` is the SIMPLE form's operand — each
+  /// A `WHEN` directly after `CASE` is the searched form — each `WHEN` a full
+  /// predicate. An expression after `CASE` is the simple form's operand — each
   /// `WHEN value` is normalised to the equality `operand = value`, so both
   /// forms share one searched AST. At least one `WHEN` is required; an optional
   /// `ELSE` gives the no-branch result (absent, the result is `NULL`); the
@@ -362,7 +362,7 @@ extension Parser {
   /// v1 WHEN v2 IS NOT NULL THEN v2 … ELSE NULL END`, but that expansion
   /// re-references each `vi` in both its guard and its `THEN`, evaluating a
   /// stateful argument twice — so this builds the first-class node the engine
-  /// evaluates each argument ONCE for, inheriting the same type unification and
+  /// evaluates each argument once for, inheriting the same type unification and
   /// coercion the CASE would. At least two arguments are required — `COALESCE`
   /// of one value is the value itself and carries no meaning — else
   /// `SQLError.argument`.
@@ -384,7 +384,7 @@ extension Parser {
   /// ISO 9075 defines `NULLIF(v1, v2)` as `CASE WHEN v1 = v2 THEN NULL ELSE v1
   /// END`, but that expansion embeds `v1` in both the equality and the `ELSE`,
   /// evaluating a stateful `v1` twice — so this builds the first-class node the
-  /// engine evaluates `v1` ONCE for. It takes exactly two arguments (else
+  /// engine evaluates `v1` once for. It takes exactly two arguments (else
   /// `SQLError.argument`).
   private mutating func nullif() throws(SQLError) -> Expression {
     let left = try expression()
@@ -420,7 +420,7 @@ extension Parser {
   /// The ISO syntax separates the operands with the keywords `PLACING`, `FROM`,
   /// and an optional `FOR`, none of which begins at the expression tier, so
   /// each `expression()` stops at the next keyword. The `FOR length` is
-  /// OPTIONAL; when omitted, the call is left at THREE arguments and the
+  /// optional; when omitted, the call is left at three arguments and the
   /// routine defaults the length to the replacement's character count from the
   /// single evaluated replacement value — NOT desugared to
   /// `char_length(replacement)`, which would reference the replacement twice

--- a/Sources/SQLEngine/Parser.swift
+++ b/Sources/SQLEngine/Parser.swift
@@ -11,7 +11,7 @@
 /// view           := VIEW identifier
 ///                   ['(' identifier (',' identifier)* ')'] AS query
 /// function       := FUNCTION identifier '(' [param (',' param)*] ')'
-///                   RETURNS type AS expression
+///                   returns type AS expression
 /// param          := identifier type
 /// type           := INTEGER | INT | REAL | FLOAT | DOUBLE | VARCHAR | TEXT
 ///                 | CHAR | BOOLEAN | BOOL | BLOB | BINARY
@@ -44,7 +44,7 @@
 /// projection     := '*' | column (',' column)*
 /// where          := WHERE predicate
 /// group          := GROUP BY element (',' element)*
-///                   // the elements' grouping-set lists are CROSS-PRODUCTED
+///                   // the elements' grouping-set lists are CROSS-producted
 ///                   // into one set list; a purely ordinary clause stays plain
 ///                   // GROUP BY keys, and any ROLLUP/CUBE/GROUPING SETS makes
 ///                   // the whole clause a GROUPING SETS — a UNION ALL of
@@ -58,7 +58,7 @@
 /// set            := expression | '(' [expression (',' expression)*] ')'
 ///                   // '()' is the grand-total set; a top-level ordinary key
 ///                   // is a bare scalar expression ('(SELECT 1)' a subquery);
-///                   // ROLLUP/CUBE/GROUPING/SETS are CONTEXT identifiers, not
+///                   // ROLLUP/CUBE/GROUPING/SETS are context identifiers, not
 ///                   // keywords — ROLLUP/CUBE open only before a '(', and
 ///                   // GROUPING only before SETS
 /// having         := HAVING predicate
@@ -243,7 +243,7 @@ internal struct Parser: ~Escapable {
   /// The leading `intersection` is the seed `Query`; each `UNION`/`EXCEPT`
   /// (optionally `ALL`) folds the next `intersection` onto the right, so a
   /// same-precedence chain (`a UNION b EXCEPT c`) reads left to right.
-  /// `INTERSECT` binds TIGHTER — it lives in the inner `intersection` tier — so
+  /// `INTERSECT` binds tighter — it lives in the inner `intersection` tier — so
   /// `a UNION b INTERSECT c` parses as `a UNION (b INTERSECT c)`, the ISO
   /// precedence. `ALL` keeps duplicate rows per the operator's multiplicity; a
   /// bare operator removes them — the distinction the engine honours.
@@ -256,11 +256,11 @@ internal struct Parser: ~Escapable {
       query = try .setop(kind, query, intersection(), all: all)
     }
     // ISO 9075: an `ORDER BY` / `OFFSET`·`FETCH` after a set-operation chain
-    // applies to the WHOLE result, not the trailing arm — an individual arm
+    // applies to the whole result, not the trailing arm — an individual arm
     // needs its own parentheses to carry one. The recursive-descent parse folds
-    // that trailing tail onto the LAST arm's `select` (a `select` greedily
-    // consumes its ORDER BY/limit); LIFT it here to the query-level `ordered`
-    // carrier over the union, where it resolves through the setop's OUTPUT
+    // that trailing tail onto the last arm's `select` (a `select` greedily
+    // consumes its ORDER BY/limit); lift it here to the query-level `ordered`
+    // carrier over the union, where it resolves through the setop's output
     // scope (`Catalog.ordered`) rather than binding the last arm's columns. A
     // set operation carries no query-level `DISTINCT` in plain SQL (a bare
     // `UNION` already dedups), so only the ORDER BY and limit are lifted.
@@ -273,13 +273,13 @@ internal struct Parser: ~Escapable {
     // arm's columns rather than the intersect result named by the first arm.
     guard case .setop = query else { return query }
     // The trailing tail reaches the query level by two routes. When the last
-    // arm is a `SELECT`, that arm's greedy `select()` already CONSUMED the
-    // `ORDER BY`/limit, so it sits on the rightmost arm and is LIFTED here (and
+    // arm is a `SELECT`, that arm's greedy `select()` already consumed the
+    // `ORDER BY`/limit, so it sits on the rightmost arm and is lifted here (and
     // trimmed off the arm, so it applies once). When the last arm is a `TABLE
     // t`/`VALUES …` primary — neither carries a primary-level order (see
-    // `term`) — the tail is UNCONSUMED at this point, so parse it HERE. Either
+    // `term`) — the tail is unconsumed at this point, so parse it here. Either
     // way the tail lands on the `ordered` carrier over the union, resolved
-    // through the setop's OUTPUT scope, not the last arm's columns.
+    // through the setop's output scope, not the last arm's columns.
     let last = trailing(query)
     if last.order != nil || last.limit != nil {
       return .ordered(trim(query), distinct: false, order: last.order,
@@ -292,7 +292,7 @@ internal struct Parser: ~Escapable {
                     generated: 0)
   }
 
-  /// The RIGHTMOST arm's `Select` of a set-operation `query` — the arm the
+  /// The rightmost arm's `Select` of a set-operation `query` — the arm the
   /// recursive-descent parse folds a trailing query-level `ORDER BY`/limit
   /// onto, reached by descending each set operation's RIGHT term.
   private func trailing(_ query: Query) -> Select {
@@ -303,9 +303,9 @@ internal struct Parser: ~Escapable {
     }
   }
 
-  /// `query` with its LAST arm's `order`/`limit` cleared — the query-level tail
+  /// `query` with its last arm's `order`/`limit` cleared — the query-level tail
   /// a set-operation `query` lifted onto the `ordered` carrier, removed from
-  /// the arm that greedily parsed it so it is applied ONCE, over the union.
+  /// the arm that greedily parsed it so it is applied once, over the union.
   private func trim(_ query: Query) -> Query {
     switch query {
     case let .select(select):
@@ -344,11 +344,11 @@ internal struct Parser: ~Escapable {
   /// tiers compose over.
   ///
   /// `TABLE t` is exactly `SELECT * FROM t` (ISO 9075 `<explicit table>`): it
-  /// lowers to the SAME AST a star-projection single-relation select builds — a
+  /// lowers to the same AST a star-projection single-relation select builds — a
   /// `.all` projection over one named `Relation`, no `WHERE`/`GROUP`/`HAVING`/
   /// order/limit — so compile, execute, and the `SELECT *` column expansion all
   /// apply unchanged and it composes with `UNION`/`INTERSECT`/`EXCEPT` as a
-  /// parenthesised select would. The operand is a bare table or view NAME (the
+  /// parenthesised select would. The operand is a bare table or view name (the
   /// same `identifier` a relation names); a derived table is not admitted, as
   /// `TABLE (…)` is not an ISO form. Ordering is a select-internal clause here,
   /// so a `TABLE t ORDER BY …` tail is not accepted at this primary level — the
@@ -376,7 +376,7 @@ internal struct Parser: ~Escapable {
   ///
   /// Each parenthesised row is a tuple of scalar expressions (usually literals,
   /// but any row-independent expression is admitted, since a FROM-less `SELECT`
-  /// evaluates it over the single empty row). Every row must have EQUAL arity —
+  /// evaluates it over the single empty row). Every row must have equal arity —
   /// a mismatch is `SQLError.arity` — and there is at least one row, each with
   /// at least one element (the parser rejects an empty `VALUES ()`). The rows
   /// lower to `SELECT v, … UNION ALL SELECT v, …` in source order, so `UNION
@@ -386,7 +386,7 @@ internal struct Parser: ~Escapable {
   /// emitted as the FIRST arm's projection aliases (the ISO rule that a set
   /// operation's result columns come from its first arm) so a `SELECT column1
   /// FROM (VALUES …) AS t` names them. A per-column `ValueType` unifies across
-  /// the rows through the SAME set-operation schema derivation `UNION` uses (a
+  /// the rows through the same set-operation schema derivation `UNION` uses (a
   /// column mixing integer and double widens to double), so this parse only
   /// shapes the desugar and leaves the typing to resolution.
   private mutating func values() throws(SQLError) -> Query {
@@ -472,7 +472,7 @@ internal struct Parser: ~Escapable {
   }
 
   /// Parses the `FUNCTION` tail — `identifier '(' [param (, param)*] ')'
-  /// RETURNS type AS expression` (the `CREATE FUNCTION` is already consumed),
+  /// returns type AS expression` (the `CREATE FUNCTION` is already consumed),
   /// each `param` an `identifier type`.
   ///
   /// The parameter list is parenthesised and may be empty (`f() RETURNS …`).
@@ -596,8 +596,8 @@ internal struct Parser: ~Escapable {
     let limit = try rowLimit()
 
     // The `GROUP BY` tail is stored as-parsed — a `.keys` ordinary key list (or
-    // none) or a `.sets` `GROUPING SETS (…)` list. A `.sets` is EXPANDED into a
-    // `UNION ALL` of per-arm groupings at compile and schema time (by RESOLVED
+    // none) or a `.sets` `GROUPING SETS (…)` list. A `.sets` is expanded into a
+    // `UNION ALL` of per-arm groupings at compile and schema time (by resolved
     // identity, so an absent key NULLs correctly), not desugared here.
     return Select(distinct: distinct, projection: projection, from: from,
                   joins: joins, predicate: predicate, grouping: grouping,
@@ -605,17 +605,17 @@ internal struct Parser: ~Escapable {
   }
 
   /// Parses `BY <element> (',' <element>)*` (the `GROUP` keyword is already
-  /// consumed) — the ISO comma list of grouping ELEMENTS, cross-producted into
+  /// consumed) — the ISO comma list of grouping elements, cross-producted into
   /// one grouping-set list.
   ///
   /// Each element yields a set list (`Array<Array<Expression>>`): an ordinary
   /// key is the single-set list `[[key]]`; `ROLLUP`/`CUBE`/`GROUPING SETS`
   /// yield their expanded set lists (see `element`). The whole clause is the
-  /// PRODUCT of the elements' set lists — one result set per combination, the
+  /// product of the elements' set lists — one result set per combination, the
   /// concatenation of the chosen sets — so `GROUP BY a, ROLLUP(b, c)` crosses
   /// `[[a]]` with `[[b, c], [b], []]` into `[[a, b, c], [a, b], [a]]`.
   ///
-  /// A PURELY ordinary clause (no `ROLLUP`/`CUBE`/`GROUPING SETS`) returns
+  /// A purely ordinary clause (no `ROLLUP`/`CUBE`/`GROUPING SETS`) returns
   /// `.keys` — the plain path, so `GROUP BY a, b` stays `.keys([a, b])`. Any
   /// construct makes the whole clause `.sets`, which the shared `expand`
   /// desugars to a `UNION ALL` of per-set arms (Stage 1), so `ROLLUP`/`CUBE`
@@ -638,17 +638,17 @@ internal struct Parser: ~Escapable {
       let (sets, opens) = try element()
       construct = construct || opens
       if sets.count == 1 {
-        // A SINGLE-set element (an ordinary key, or `()`) APPENDS its keys to
+        // A single-set element (an ordinary key, or `()`) appends its keys to
         // every set so far — O(keys) per element, keeping a purely ordinary
-        // `GROUP BY a, b, …` LINEAR rather than O(n²) via `cross`. Its keys are
+        // `GROUP BY a, b, …` linear rather than O(n²) via `cross`. Its keys are
         // copied into every set, so bound the reference growth first.
         let added = product.count * sets[0].count
         guard total + added <= Limits.references else { throw overflow }
         for index in product.indices { product[index] += sets[0] }
         total += added
       } else {
-        // A MULTI-set element (a construct) needs the cross product. Bound its
-        // growth BEFORE `cross` allocates it — the set count (`sets / count`
+        // A multi-set element (a construct) needs the cross product. Bound its
+        // growth before `cross` allocates it — the set count (`sets / count`
         // also keeps the multiply from overflowing) and the reference total,
         // which the cross multiplies to `sets × total + product × expressions`.
         let expressions = references(of: sets)
@@ -664,9 +664,9 @@ internal struct Parser: ~Escapable {
     } while try match(.comma)
     // A purely ordinary clause is a single set (each element appended its keys
     // in source order) — the plain `.keys` path. An explicit `GROUP BY ()` is
-    // the exception: it resolves to a single EMPTY set, which must stay the
+    // the exception: it resolves to a single empty set, which must stay the
     // grand total `.sets([[]])`, NOT collapse to `.keys([])` — the shape an
-    // ABSENT `GROUP BY` carries, which `Select.aggregates` reads as no grouping
+    // absent `GROUP BY` carries, which `Select.aggregates` reads as no grouping
     // (one row per input row rather than one grand-total group).
     if construct || product == [[]] {
       return .sets(product)
@@ -674,17 +674,17 @@ internal struct Parser: ~Escapable {
     return .keys(product[0])
   }
 
-  /// Parses ONE grouping element into its set list, with a flag marking whether
+  /// Parses one grouping element into its set list, with a flag marking whether
   /// it is a construct (`ROLLUP`/`CUBE`/`GROUPING SETS`) rather than an
   /// ordinary set — the flag `grouping` ORs to choose `.keys` over `.sets`.
   ///
-  /// `ROLLUP`/`CUBE`/`GROUPING`/`SETS` are CONTEXT identifiers, not lexer
+  /// `ROLLUP`/`CUBE`/`GROUPING`/`SETS` are context identifiers, not lexer
   /// keywords: a bare `GROUPING` immediately followed by a bare `SETS` opens a
   /// (possibly nested) `GROUPING SETS`; a bare `ROLLUP`/`CUBE` immediately
-  /// followed by `(` opens that construct. A DELIMITED `"rollup"` (a `.quoted`,
+  /// followed by `(` opens that construct. A delimited `"rollup"` (a `.quoted`,
   /// not `.identifier`), or a bare `rollup`/`cube`/`grouping` NOT so followed,
   /// falls through to an ordinary key — so those words stay usable as column
-  /// names (ISO reserves them; a UDF named `rollup`/`cube` cannot be a BARE
+  /// names (ISO reserves them; a UDF named `rollup`/`cube` cannot be a bare
   /// grouping key, which is acceptable). The two-token lookahead (`secondary`)
   /// resolves each prefix before consuming any token.
   ///
@@ -719,8 +719,8 @@ internal struct Parser: ~Escapable {
 
   /// Parses the `GROUPING SETS '(' element (',' element)* ')'` construct — the
   /// `GROUPING` and `SETS` context identifiers are the next two tokens
-  /// (confirmed by `element`) — into ONE set list: the CONCATENATION of each
-  /// contained element's set list, in source order. Elements NEST — a member
+  /// (confirmed by `element`) — into one set list: the concatenation of each
+  /// contained element's set list, in source order. Elements nest — a member
   /// may be an ordinary set, a `ROLLUP`/`CUBE`, or another `GROUPING SETS`. At
   /// least one element is required.
   private mutating func sets() throws(SQLError) -> Array<Array<Expression>> {
@@ -733,7 +733,7 @@ internal struct Parser: ~Escapable {
       let more = try element().sets
       total += references(of: more)
       result += more
-      // Members may THEMSELVES be constructs (`GROUPING SETS (CUBE(…), …)`);
+      // Members may themselves be constructs (`GROUPING SETS (CUBE(…), …)`);
       // cap both the set count (4096, the clause-wide ceiling) and the
       // reference total so a concatenation cannot amass unboundedly before
       // `grouping`'s guard.
@@ -749,12 +749,12 @@ internal struct Parser: ~Escapable {
 
   /// Parses a `ROLLUP '(' unit (',' unit)* ')'` element (the `ROLLUP` context
   /// identifier is `current`) into its `n + 1` grouping sets — the descending
-  /// PREFIXES of the `n` units. `ROLLUP(a, b)` yields `[[a, b], [a], []]`;
+  /// prefixes of the `n` units. `ROLLUP(a, b)` yields `[[a, b], [a], []]`;
   /// `ROLLUP((a, b), c)` yields `[[a, b, c], [a, b], []]`.
   private mutating func rollup() throws(SQLError) -> Array<Array<Expression>> {
     let units = try units()
     // A ROLLUP of n units materialises n + 1 prefixes whose sizes sum to
-    // O(n²) expression references — BEFORE `grouping`'s 4096-set guard runs, so
+    // O(n²) expression references — before `grouping`'s 4096-set guard runs, so
     // a large but compact input (a 100,000-unit ROLLUP) would exhaust memory
     // rather than fault. Reject the arity here first: n + 1 sets must stay
     // within the 4096 cap, so n ≤ 4095.
@@ -775,17 +775,17 @@ internal struct Parser: ~Escapable {
   /// the `n` units. `CUBE(a, b)` yields `[[a, b], [b], [a], []]`.
   private mutating func cube() throws(SQLError) -> Array<Array<Expression>> {
     let units = try units()
-    // A CUBE of n units enumerates 2ⁿ subsets. Reject a large arity BEFORE the
+    // A CUBE of n units enumerates 2ⁿ subsets. Reject a large arity before the
     // `1 << n` shift: at n ≥ 63 it overflows `Int` (wrapping negative, then to
-    // zero at 64), silently yielding NO sets — later misreported as "requires
+    // zero at 64), silently yielding no sets — later misreported as "requires
     // at least one set" — and even a moderate n eagerly allocates
     // exponentially many arrays. 2¹² = 4096 sets is the cap.
     guard units.count <= 12 else {
       throw .state("54001",
                    "GROUP BY CUBE supports at most 12 grouping elements")
     }
-    // units.count alone is not enough: each unit is COPIED into 2ⁿ⁻¹ of the 2ⁿ
-    // subsets, so a large COMPOSITE unit `(a, a, …)` multiplies its expressions
+    // units.count alone is not enough: each unit is copied into 2ⁿ⁻¹ of the 2ⁿ
+    // subsets, so a large composite unit `(a, a, …)` multiplies its expressions
     // across them. Bound the projected expansion — 2ⁿ⁻¹ × the units' total
     // expressions — before building the subsets.
     let budget = Limits.references / (1 << max(units.count - 1, 0))
@@ -796,7 +796,7 @@ internal struct Parser: ~Escapable {
   /// Parses the `'(' [unit (',' unit)*] ')'` unit list shared by `ROLLUP`/
   /// `CUBE` (the context identifier is consumed here). Each unit is an ordinary
   /// set — a bare key or a parenthesised `(a, b)` composite that groups as one
-  /// indivisible level. An EMPTY list (`ROLLUP()`/`CUBE()`) is admitted and
+  /// indivisible level. An empty list (`ROLLUP()`/`CUBE()`) is admitted and
   /// collapses to the single empty grand-total set.
   private mutating func units() throws(SQLError) -> Array<Array<Expression>> {
     _ = try advance(expecting: "ROLLUP or CUBE")
@@ -811,7 +811,7 @@ internal struct Parser: ~Escapable {
   }
 
   /// Parses one `ROLLUP`/`CUBE` unit — an ordinary set. A leading `(` opens a
-  /// parenthesised `(a, b)` / `()` composite UNLESS it merely STARTS a scalar
+  /// parenthesised `(a, b)` / `()` composite unless it merely starts a scalar
   /// key — `(a) + 1`, `(a + b)`, or a scalar subquery `(SELECT …)`, whose own
   /// parenthesis `expression` consumes — which `composite` rewinds; otherwise
   /// the unit is a bare scalar key.
@@ -821,13 +821,13 @@ internal struct Parser: ~Escapable {
   }
 
   /// A parenthesised composite grouping set — the grand-total `()` or a comma
-  /// list `(a, b, …)` — returning its keys, or `nil` (having REWOUND the full
+  /// list `(a, b, …)` — returning its keys, or `nil` (having rewound the full
   /// parser state) when the `(` instead begins a single scalar key that merely
-  /// STARTS with a parenthesis: a parenthesised expression `(a + b)` / `(a) +
+  /// starts with a parenthesis: a parenthesised expression `(a + b)` / `(a) +
   /// 1`, or a scalar subquery `(SELECT …)`.
   ///
   /// The committing signal — an empty `()` or a top-level comma — sits an
-  /// UNBOUNDED distance past the `(` (the first key is an arbitrary
+  /// unbounded distance past the `(` (the first key is an arbitrary
   /// expression), so no fixed lookahead decides it: speculatively read past
   /// the `(`, commit to a set only on `()` or a top-level comma (the
   /// row-constructor rule), else rewind the `lexer`, `current`, AND the
@@ -855,7 +855,7 @@ internal struct Parser: ~Escapable {
     return nil
   }
 
-  /// The descending PREFIXES of a unit list — the `ROLLUP` set list. For `n`
+  /// The descending prefixes of a unit list — the `ROLLUP` set list. For `n`
   /// units it is `n + 1` sets: units `1..n` concatenated, then `1..n-1`, …,
   /// down to the empty grand-total set. An empty unit list (`ROLLUP()`) yields
   /// the single empty set `[[]]`.
@@ -871,7 +871,7 @@ internal struct Parser: ~Escapable {
     return result
   }
 
-  /// Every SUBSET of a unit list — the `CUBE` set list — enumerated
+  /// Every subset of a unit list — the `CUBE` set list — enumerated
   /// FULL-SET-FIRST by descending subset mask (bit `i` selects unit `i`, units
   /// concatenated in source order). For `n` units it is `2ⁿ` sets, the full set
   /// first and the empty grand-total set last. An empty unit list (`CUBE()`)
@@ -891,7 +891,7 @@ internal struct Parser: ~Escapable {
     return result
   }
 
-  /// The CROSS PRODUCT of two set lists — for each set on the left and each on
+  /// The CROSS product of two set lists — for each set on the left and each on
   /// the right, their concatenation — the operator that combines the successive
   /// `GROUP BY` elements. The seed `[[]]` (the single empty set) is its
   /// identity.
@@ -907,12 +907,12 @@ internal struct Parser: ~Escapable {
     return result
   }
 
-  /// The caps bounding `GROUP BY` grouping-set expansion — the SINGLE SOURCE
-  /// OF TRUTH for every artificial limit the desugar enforces, so they are
+  /// The caps bounding `GROUP BY` grouping-set expansion — the single source
+  /// of truth for every artificial limit the desugar enforces, so they are
   /// tracked and tunable in one place (every guard below cites one of these).
   /// `sets` is the most grouping sets a clause may expand to; `references` the
   /// most expression references those sets may hold in total. Both bound a
-  /// COMPACT but heavily-duplicating clause — a wide `CUBE`/`ROLLUP`, a cross
+  /// compact but heavily-duplicating clause — a wide `CUBE`/`ROLLUP`, a cross
   /// product, a concatenation — from exhausting memory. The per-construct arity
   /// guards derive from `sets`: `CUBE ≤ 12` units (2¹² = `sets`) and `ROLLUP ≤
   /// 4095` units (n + 1 ≤ `sets`) reject before the 2ⁿ / prefix expansion.
@@ -939,10 +939,10 @@ internal struct Parser: ~Escapable {
 
   // MARK: - Relation
 
-  /// Parses a relation — a named base relation/view/CTE, or a DERIVED TABLE (a
+  /// Parses a relation — a named base relation/view/CTE, or a derived TABLE (a
   /// parenthesised subquery) — with its alias.
   ///
-  /// A leading `(` is disambiguated by ONE token of lookahead: a `SELECT` after
+  /// A leading `(` is disambiguated by one token of lookahead: a `SELECT` after
   /// it begins a derived table `(SELECT …) AS t` (the query may itself be a
   /// `UNION`), so it parses `query`; anything else is a parenthesised relation
   /// `(a JOIN b)`, which this dialect does not yet accept in a relation
@@ -951,12 +951,12 @@ internal struct Parser: ~Escapable {
   /// no rewind is needed.
   ///
   /// An optional leading `LATERAL` marks the derived table lateral (ISO
-  /// `LATERAL (query)`): its body may reference the PRECEDING FROM items, so it
+  /// `LATERAL (query)`): its body may reference the preceding FROM items, so it
   /// re-evaluates per their rows. `LATERAL` introduces a derived table alone —
   /// a `(SELECT …)` must follow — so a `LATERAL` before a named relation
   /// faults.
   ///
-  /// Derived table's alias is REQUIRED (ISO): `FROM (SELECT …)` with no `AS t`
+  /// Derived table's alias is required (ISO): `FROM (SELECT …)` with no `AS t`
   /// faults. A named relation's alias is optional and may be introduced by `AS`
   /// (`TypeDef AS t`) or written directly after the name (`TypeDef t`); the
   /// latter is admitted only when the next token is a bare identifier, so a
@@ -964,9 +964,9 @@ internal struct Parser: ~Escapable {
   /// for an alias.
   ///
   /// Either alias may carry an ISO explicit output column list `'(' identifier
-  /// (, identifier)* ')'` (`AS t(c, d)`), positionally RENAMING the relation's
-  /// output columns — admitted on BOTH a derived table and a named relation.
-  /// The list's ARITY and case-insensitive UNIQUENESS are checked where the
+  /// (, identifier)* ')'` (`AS t(c, d)`), positionally renaming the relation's
+  /// output columns — admitted on both a derived table and a named relation.
+  /// The list's arity and case-insensitive uniqueness are checked where the
   /// output width is known (the schema-derivation seam), not here, so a list
   /// over a `SELECT *` derived table (whose width resolves later) parses.
   ///
@@ -987,7 +987,7 @@ internal struct Parser: ~Escapable {
       }
       let query = try query()
       try expect(.rparen)
-      // ISO requires a derived table be named, so the alias is MANDATORY — an
+      // ISO requires a derived table be named, so the alias is mandatory — an
       // `AS`-less spelling faults rather than binding an unnamed relation.
       guard try match(.as) || isName(current?.kind) else {
         guard let token = current else {
@@ -1094,11 +1094,11 @@ internal struct Parser: ~Escapable {
   /// `column = column` conjunct hash-joins, the rest a residual filter) or
   /// `USING '(' identifier (, identifier)* ')'` (the named-column shorthand,
   /// resolved into an equality `on` and a coalesced `SELECT *` at compile). A
-  /// `NATURAL` join (`natural`) takes NEITHER — its columns are the shared ones
+  /// `NATURAL` join (`natural`) takes neither — its columns are the shared ones
   /// — so a trailing `ON`/`USING` after it faults; a plain non-`CROSS` join
   /// requires exactly one of them.
   ///
-  /// A `CROSS JOIN` (`cross`) takes NO criterion — a trailing `ON`/`USING` is a
+  /// A `CROSS JOIN` (`cross`) takes no criterion — a trailing `ON`/`USING` is a
   /// syntax error, caught by leaving it unconsumed for the caller's `where`/
   /// end-of-select expectation to reject. Its `on` is a synthesized `1 = 1`,
   /// which lowers to a constant-true filter the optimiser elides, collapsing
@@ -1153,11 +1153,11 @@ internal struct Parser: ~Escapable {
   /// Parses one sort key — `(integer | expression) [ASC | DESC]`, the direction
   /// defaulting to ascending.
   ///
-  /// A BARE integer-literal sort key is an ISO output-column ORDINAL (`ORDER BY
+  /// A bare integer-literal sort key is an ISO output-column ordinal (`ORDER BY
   /// 1` names the first projected column, 1-based), never the integer constant
   /// — ordering by a constant is meaningless, so the standard reads a lone
   /// integer here as a select-list position. The key parses as a full value
-  /// `expression` unconditionally and then CLASSIFIES: an expression that is
+  /// `expression` unconditionally and then classifies: an expression that is
   /// exactly a bare integer literal becomes the ordinal, everything else stays
   /// an `expression`. This keeps `ORDER BY 1 + A` and `ORDER BY 2 * Price` the
   /// arithmetic expressions they are, and subsumes a bare column (`ORDER BY
@@ -1268,7 +1268,7 @@ internal struct Parser: ~Escapable {
 
   // MARK: - Cursor
 
-  /// The token AFTER `current` without consuming either — a second token of
+  /// The token after `current` without consuming either — a second token of
   /// lookahead, buffered in `pending` and drained by `advance` before the lexer
   /// is next pulled. It disambiguates a two-token context prefix a single
   /// `current` cannot (`GROUP BY GROUPING SETS`, whose `GROUPING`/`SETS` are

--- a/Sources/SQLEngine/Pushdown.swift
+++ b/Sources/SQLEngine/Pushdown.swift
@@ -23,7 +23,7 @@ extension Plan {
   /// `select`s the seek and nest rewrites match.
   internal func pushdown() throws(SQLError) -> Plan {
     switch self {
-    // Pushdown runs BEFORE optimise, the only producer of `.empty`, so a plan
+    // Pushdown runs before optimise, the only producer of `.empty`, so a plan
     // reaching here never carries one; the arm keeps the switch exhaustive.
     case .single, .empty, .scan, .join:
       self
@@ -39,7 +39,7 @@ extension Plan {
     case let .product(left, right):
       try .product(left.pushdown(), right.pushdown())
     case let .outer(left, right, on, kind):
-      // Push down WITHIN each side (its own joins/filters rewrite), but the
+      // Push down within each side (its own joins/filters rewrite), but the
       // outer node is a pushdown barrier: a `WHERE` conjunct above it never
       // rides into a side. Filtering a preserved side's rows before the outer
       // join is equivalent, but filtering the NULL-extended side's rows before
@@ -48,17 +48,17 @@ extension Plan {
       // over this node).
       try .outer(left.pushdown(), right.pushdown(), on: on, kind: kind)
     case let .semijoin(left, right, on, anti):
-      // Push down WITHIN each side (its own joins/filters rewrite), but the
+      // Push down within each side (its own joins/filters rewrite), but the
       // semijoin node is a pushdown barrier: a `WHERE` conjunct above it never
-      // rides into a side. The semijoin DROPS left rows by the existence test,
+      // rides into a side. The semijoin drops left rows by the existence test,
       // so filtering a side's rows before it could change which left rows
       // survive — preferring correctness, the whole `WHERE` stays above
       // (`distribute`'s default keeps it a `select` over this node). Pushdown
-      // runs BEFORE decorrelate, so this arm handles only a semijoin a nested
+      // runs before decorrelate, so this arm handles only a semijoin a nested
       // pass produced; a top-level plan never carries one at this point.
       try .semijoin(left.pushdown(), right.pushdown(), on: on, anti: anti)
     case let .apply(left, key, correlation, ordinals, on, kind):
-      // Push down WITHIN the left side (its own joins/filters rewrite), but the
+      // Push down within the left side (its own joins/filters rewrite), but the
       // apply is a pushdown barrier: its right side is not a static sub-plan
       // but a per-outer-row re-execution, so a `WHERE` conjunct above it never
       // rides into it (mirroring the `.outer` gate — `distribute`'s default
@@ -101,19 +101,19 @@ extension Plan {
   /// belongs to the right child, rebased into that child's own slot space; one
   /// straddling the boundary — or reading no slots, or able to throw when
   /// evaluated (a division or scalar call) — stays here. A `select` is a join's
-  /// `ON` gate, whose two sides straddle every boundary, and is a BARRIER for
-  /// an UNSAFE `WHERE` conjunct: `nest` folds only ONE `match` into the hash
+  /// `ON` gate, whose two sides straddle every boundary, and is a barrier for
+  /// an unsafe `WHERE` conjunct: `nest` folds only one `match` into the hash
   /// `Join`'s key, leaving every other `ON` conjunct (a match beyond that key,
   /// or a non-equi residual) as the gate's residual under the join, and the
   /// gate drops a pair its leftover conjuncts evaluate UNKNOWN or `false`
-  /// BEFORE the `WHERE` runs. So fusing a throwing `WHERE` conjunct into the
+  /// before the `WHERE` runs. So fusing a throwing `WHERE` conjunct into the
   /// gate — the `AND` not short-circuiting, still evaluating it for a pair the
   /// gate already dropped — would raise an error the separate gate suppresses,
   /// whether the leftover is a non-equi residual (`A JOIN B ON A.k < B.k WHERE
   /// (1 / A.x) = 0`, `A.k` NULL) or a second equi key (`… ON A.k1 = B.k1 AND
   /// A.k2 = B.k2 WHERE (1 / A.x) = 0`, `A.k2` NULL). Every UNSAFE `WHERE`
   /// conjunct stays a separate `select` above the gate, preserving the
-  /// `ON`-drops-before-`WHERE` ordering; a SAFE `WHERE` conjunct (which never
+  /// `ON`-drops-before-`WHERE` ordering; a safe `WHERE` conjunct (which never
   /// raises) still descends below the gate — as the product loop's ordering
   /// allows — so a safe single-relation conjunct reaches its base scan. The
   /// match keys fold down so `nest` can join under the gate. At a `derived`
@@ -137,14 +137,14 @@ extension Plan {
         // (`barrier`), when it reads no slots (e.g. `(1 / 0) = 0`, where
         // `allSatisfy` is vacuously true), when evaluating it can throw (a
         // division or scalar call, e.g. `(1 / A.x) = 0`), or when it is
-        // nullable (reads a slot, so a NULL there makes it UNKNOWN) and a LATER
+        // nullable (reads a slot, so a NULL there makes it UNKNOWN) and a later
         // conjunct is unsafe. Riding a throwing conjunct down would raise while
         // scanning a child even when the join's other side is empty; riding a
-        // safe conjunct PAST an earlier unsafe one would filter its rows before
+        // safe conjunct past an earlier unsafe one would filter its rows before
         // the unsafe one runs, suppressing a throw the left-to-right `AND` owes
         // (`(1 / A.x) = 0 AND A.x <> 0`, `A.x = 0`, on a matching pair).
         // Because the evaluator's `AND` does not short-circuit, riding a
-        // nullable conjunct BELOW a later unsafe one likewise suppresses a
+        // nullable conjunct below a later unsafe one likewise suppresses a
         // throw: the un-pushed `AND` runs the later conjunct even for the
         // UNKNOWN row, but the pushed conjunct drops that row first (`A.x = 1
         // AND (1 / B.y) = 0`, `A.x` NULL and `B.y = 0`). Only a safe
@@ -182,36 +182,36 @@ extension Plan {
           residual.append(conjunct)
         }
       }
-      // The `ON` gate is ALWAYS a DISTRIBUTION BARRIER for an UNSAFE outer
+      // The `ON` gate is ALWAYS a distribution barrier for an unsafe outer
       // `WHERE` conjunct, whether the gate is mixed (a non-equi residual) or
-      // PURE-equi (only matches). `nest` folds only ONE `match` into the hash
+      // pure-equi (only matches). `nest` folds only one `match` into the hash
       // `Join`'s key and leaves every other `ON` conjunct — a match beyond that
       // key, plus any non-equi residual — as the gate's own residual `select`
       // under the join, which drops a pair it evaluates UNKNOWN or `false`
-      // BEFORE the `WHERE` runs. Because the evaluator's `AND` does not
-      // short-circuit, FUSING a throwing `WHERE` conjunct into that gate
+      // before the `WHERE` runs. Because the evaluator's `AND` does not
+      // short-circuit, fusing a throwing `WHERE` conjunct into that gate
       // residual would evaluate it for a pair the gate has already dropped.
       // This bites a pure-equi `ON` too: `A JOIN B ON A.k1 = B.k1 AND A.k2 =
       // B.k2 WHERE (1 / A.x) = 0`, `A.k1` matching, `A.k2` NULL, `A.x` = 0 —
       // `nest` keys on `A.k1 = B.k1`, so the surviving pair reaches the
       // leftover `A.k2 = B.k2` (UNKNOWN), which should drop it; a fused `A.k2 =
-      // B.k2 AND (1 / A.x) = 0` would instead divide by zero. So every UNSAFE
-      // `WHERE` conjunct stays a SEPARATE `select` ABOVE the gate — never fused
+      // B.k2 AND (1 / A.x) = 0` would instead divide by zero. So every unsafe
+      // `WHERE` conjunct stays a separate `select` above the gate — never fused
       // with a leftover `ON` conjunct — keeping the `ON`-drops-before-`WHERE`
       // order.
       //
-      // A SAFE `WHERE` conjunct, by contrast, never raises, so pushing it below
+      // A safe `WHERE` conjunct, by contrast, never raises, so pushing it below
       // the gate can only drop rows, not suppress a throw; it still descends
       // (`matches + residual + safe`) so a safe single-relation conjunct
       // reaches its base scan as before. `distribute`'s product loop keeps it
-      // AFTER the `ON` residual, and its own barrier bars it from riding past
+      // after the `ON` residual, and its own barrier bars it from riding past
       // an unsafe `ON` conjunct — a safe `WHERE` pushed to a base scan below
       // the product does not co-locate with, nor reorder around, the gate's
       // leftover conjuncts. A safe conjunct stays above when the loop would
       // keep it at the product level anyway — mirroring that loop's ordering
       // rules so descending it never suppresses a throw the `WHERE`'s
       // non-short-circuiting `AND` owes: after ANY earlier unsafe conjunct
-      // (a `barrier`), or when it is NULLABLE and a LATER conjunct is unsafe
+      // (a `barrier`), or when it is nullable and a later conjunct is unsafe
       // (a `hazard`). The match keys still fold down beside the residual so
       // `nest` can form the join under the gate; a single-equality pure-equi
       // `ON` folds its one key and carries no leftover conjunct, so a safe
@@ -251,22 +251,22 @@ extension Plan {
   /// `union` sub-plan admits a conjunct only when every arm's projection admits
   /// it — the arms are combined, so a conjunct that cannot push into one arm
   /// must stay outside them all. The admitted conjuncts, still in the view's
-  /// OUTPUT slot space, push in through `inject`, which rebases each against
-  /// the projection it lands under — PER ARM for a union, since the arms map
-  /// the same output column to DIFFERENT body slots; the rest wrap the leaf.
+  /// output slot space, push in through `inject`, which rebases each against
+  /// the projection it lands under — per ARM for a union, since the arms map
+  /// the same output column to different body slots; the rest wrap the leaf.
   ///
-  /// The partition carries the SAME ordering barrier `distribute`'s product
+  /// The partition carries the same ordering barrier `distribute`'s product
   /// loop has: a conjunct stays `outer` — on the derived leaf, run in the `AND`
   /// chain's order — when a preceding conjunct was unsafe (`barrier`), when it
   /// is itself unsafe (a division or scalar call), when it is nullable and a
-  /// LATER conjunct is unsafe, or when the view's projection cannot admit it;
+  /// later conjunct is unsafe, or when the view's projection cannot admit it;
   /// only a safe conjunct with no unsafe predecessor — and, if nullable, no
   /// unsafe successor — pushes in. An unsafe conjunct bars every later one from
   /// riding into the view: pushing a later conjunct past it would let the view
   /// seek and drop the row before the unsafe outer conjunct runs, suppressing a
   /// throw the left-to-right `AND` owes (`(1 / x) = 0 AND x = 1` over a view
   /// whose `x` is sorted, the `x = 1` seek dropping the `x = 0` row before the
-  /// outer division raises). Symmetrically a nullable conjunct pushed BELOW a
+  /// outer division raises). Symmetrically a nullable conjunct pushed below a
   /// later unsafe one suppresses a throw: the non-short-circuiting `AND` runs
   /// the later conjunct even for the UNKNOWN row, but the injected conjunct
   /// drops that row first (`x = 1 AND (1 / y) = 0`, `x` NULL and `y = 0`).
@@ -279,7 +279,7 @@ extension Plan {
     var barrier = false
     for (index, conjunct) in conjuncts.enumerated() {
       // A nullable conjunct (reads a slot, so a NULL there makes it UNKNOWN)
-      // must also stay outer when a LATER conjunct is unsafe: the evaluator's
+      // must also stay outer when a later conjunct is unsafe: the evaluator's
       // `AND` does not short-circuit, so the un-pushed query runs the later
       // conjunct even for the UNKNOWN row, but injecting this one into the view
       // would seek or filter that row away first — suppressing a throw the
@@ -302,18 +302,18 @@ extension Plan {
     return leaf.residual(outer)
   }
 
-  /// Whether `conjunct` (in this view's OUTPUT slot space, its slots indices
+  /// Whether `conjunct` (in this view's output slot space, its slots indices
   /// into `ordinals`) can push below this sub-plan's projection.
   ///
   /// A `project` admits it when every slot it reads maps to a bare `.slot` term
   /// of the body — the `rebase` helper produces a mapping; a computed column
-  /// (call or arithmetic) has none. A `union` admits it only when EVERY arm
+  /// (call or arithmetic) has none. A `union` admits it only when every arm
   /// does — the arms are combined, so a conjunct pushable into one but not
   /// another cannot descend into any and must stay outside — AND the conjunct
-  /// references no column the set operation WIDENS: an arm coerces its cells to
-  /// the unified column type only AFTER it runs (in `combine`), so a predicate
-  /// pushed into the arm tests the PRE-coercion value, and over a widened
-  /// column that is the wrong type. Such a conjunct stays ABOVE the derived
+  /// references no column the set operation widens: an arm coerces its cells to
+  /// the unified column type only after it runs (in `combine`), so a predicate
+  /// pushed into the arm tests the pre-coercion value, and over a widened
+  /// column that is the wrong type. Such a conjunct stays above the derived
   /// leaf as a `select` on the coerced output, where it tests the unified type
   /// — the observable result then matches an un-pushed query. A same-typed
   /// column (an empty `widened`) still pushes. Anything else does not admit it.
@@ -327,7 +327,7 @@ extension Plan {
       // `derive` owes by evaluating every column of every view row.
       terms.allSatisfy(\.safe) && rebase(conjunct, ordinals) != nil
     case let .setop(_, left, right, _, _, widened):
-      // A conjunct over a column the set operation WIDENS must NOT push into
+      // A conjunct over a column the set operation widens must NOT push into
       // the arms: an arm evaluates it on the un-coerced value, but `combine`
       // coerces the arm's rows to the unified type only after the arm runs, so
       // the pushed predicate tests the wrong type. A slot the conjunct reads is
@@ -341,11 +341,11 @@ extension Plan {
     }
   }
 
-  /// This view sub-plan with `conjuncts` (in the view's OUTPUT slot space)
+  /// This view sub-plan with `conjuncts` (in the view's output slot space)
   /// pushed below its projection, each rebased into the body slots the
   /// projection it lands under reads.
   ///
-  /// For a `union` each arm rebases the conjuncts against ITS OWN projection —
+  /// For a `union` each arm rebases the conjuncts against its own projection —
   /// the same output column sits at different body slots across arms, so a
   /// single pre-rebased filter cannot serve them all; the rebase must happen
   /// per arm. `pushable` has already vetted every conjunct against every arm,
@@ -368,7 +368,7 @@ extension Plan {
     }
   }
 
-  /// `conjunct` rebased from a `derived` leaf's OUTPUT slot space into this
+  /// `conjunct` rebased from a `derived` leaf's output slot space into this
   /// projection sub-plan's body slot space, or `nil` if any slot it reads is a
   /// computed view column (not a bare `.slot` projection term) and so cannot be
   /// pushed in.

--- a/Sources/SQLEngine/RelationInstance.swift
+++ b/Sources/SQLEngine/RelationInstance.swift
@@ -13,16 +13,16 @@
 /// table resolves exactly as before. Threading escapable data sidesteps
 /// wrapping the borrowed `~Escapable` base catalog in a unifying overlay type.
 ///
-/// It is a NON-DESTRUCTIVE LAYERED scope, not a flat map. The overlay is a
+/// It is a non-destructive layered scope, not a flat map. The overlay is a
 /// stack of layers: a `base` layer holds the statement-scoped bindings — every
 /// common table expression a `WITH` materialises and every store relation a
-/// query names — and each `augment` for a SELECT PUSHES a derived layer holding
+/// query names — and each `augment` for a SELECT pushes a derived layer holding
 /// that SELECT's own `FROM (SELECT …) AS t` derived aliases. A name resolves
-/// against the INNERMOST layer that binds it, so a derived alias `t` SHADOWS a
-/// same-named CTE `t` in the base layer WITHOUT deleting it — `reveal` drops
+/// against the innermost layer that binds it, so a derived alias `t` shadows a
+/// same-named CTE `t` in the base layer without deleting it — `reveal` drops
 /// the derived layers and the CTE beneath is resolved again. This makes the
 /// CTE-overwrite class impossible: a nested subquery's FROM, a lazy scalar, and
-/// a set-op arm each resolve against the REVEALED base rather than a
+/// a set-op arm each resolve against the revealed base rather than a
 /// separately-threaded pre-augment context.
 internal struct ScopedRelations: Hashable, Sendable,
                                  ExpressibleByDictionaryLiteral {
@@ -54,7 +54,7 @@ internal struct ScopedRelations: Hashable, Sendable,
 
   /// The binding `name` resolves to — the innermost derived layer that holds
   /// it, else the base layer — or `nil` when no layer binds it. Setting binds
-  /// `name` in the INNERMOST layer (the current derived layer, else the base),
+  /// `name` in the innermost layer (the current derived layer, else the base),
   /// shadowing an outer same-named binding without deleting it; setting `nil`
   /// removes it from that layer only.
   internal subscript(name: String) -> RelationInstance? {
@@ -73,11 +73,11 @@ internal struct ScopedRelations: Hashable, Sendable,
     }
   }
 
-  /// This overlay with `derivations` PUSHED as a new derived layer — the scope
+  /// This overlay with `derivations` pushed as a new derived layer — the scope
   /// a SELECT resolves its own FROM/JOIN and expressions against, each derived
   /// alias shadowing an outer same-named CTE or derived alias without deleting
   /// it. It is idempotent on the layer's IDENTITY: pushing a layer whose
-  /// aliases and derivation queries EQUAL the innermost derived layer's (the
+  /// aliases and derivation queries equal the innermost derived layer's (the
   /// run→compile→typecheck chain re-augments the same query) is a no-op, so
   /// the stack stays bounded and a self-named alias's body still reads the
   /// base.
@@ -90,13 +90,13 @@ internal struct ScopedRelations: Hashable, Sendable,
     return copy
   }
 
-  /// This overlay with every derived layer DROPPED, leaving the base layer —
-  /// the scope a NESTED subquery's FROM resolves against. A derived alias is
-  /// SELECT-scoped: it names a relation only in its OWN SELECT's FROM/JOIN and
+  /// This overlay with every derived layer dropped, leaving the base layer —
+  /// the scope a nested subquery's FROM resolves against. A derived alias is
+  /// SELECT-scoped: it names a relation only in its own SELECT's FROM/JOIN and
   /// expressions, invisible to a nested subquery's FROM exactly as a base-table
   /// alias in the enclosing FROM is. A CTE, by contrast, is statement-scoped
   /// — visible inside a nested subquery's FROM — so the base layer stays,
-  /// REVEALING any CTE a dropped derived alias shadowed.
+  /// revealing any CTE a dropped derived alias shadowed.
   internal func revealed() -> ScopedRelations {
     var copy = self
     copy.layers = []
@@ -105,7 +105,7 @@ internal struct ScopedRelations: Hashable, Sendable,
 
   /// The derivation query bound for `name` in the innermost derived layer that
   /// holds it, else `nil` — the identity `augment` keys its per-alias
-  /// idempotence on (a binding whose `derivation` EQUALS the inner query is
+  /// idempotence on (a binding whose `derivation` equals the inner query is
   /// this SELECT's own prior pass, left rather than re-derived).
   internal func derivation(of name: String) -> Query? {
     for layer in layers.reversed() {
@@ -114,7 +114,7 @@ internal struct ScopedRelations: Hashable, Sendable,
     return nil
   }
 
-  /// Whether NO layer binds any name — an untouched overlay. The lazy-scalar
+  /// Whether no layer binds any name — an untouched overlay. The lazy-scalar
   /// path reads it to tell a cache carrying this occurrence's pre-augment scope
   /// from a bare one (a schema path's `Subqueries`), falling back to the
   /// threaded overlay for the latter.
@@ -153,7 +153,7 @@ internal struct RelationInstance: Hashable, Sendable {
   /// passes them so `information_schema` columns report their real types.
   internal let types: Array<ValueType>
 
-  /// Whether each real column places NO type constraint — every arm that fed it
+  /// Whether each real column places no type constraint — every arm that fed it
   /// projects a constant NULL, so its concrete `types` entry is a default the
   /// set-operation fold must NOT constrain against. A later reader unifying a
   /// reference to such a column treats it as an unconstrained (constant-NULL)
@@ -164,25 +164,25 @@ internal struct RelationInstance: Hashable, Sendable {
   internal let unconstrained: Array<Bool>
 
   /// The inner `Query` this binding is the materialised body of, when it is a
-  /// DERIVED TABLE's — `nil` for a common table expression's or a store
+  /// derived TABLE's — `nil` for a common table expression's or a store
   /// relation's binding. It is the derivation's IDENTITY, not merely a flag:
-  /// `augment` keys idempotence on it, so it can tell THIS query's own prior
+  /// `augment` keys idempotence on it, so it can tell this query's own prior
   /// materialisation of an alias (the run→compile double augment, or a
-  /// self-named `(SELECT … FROM T) AS T`) apart from an ENCLOSING query's
+  /// self-named `(SELECT … FROM T) AS T`) apart from an enclosing query's
   /// same-named derived binding.
   ///
   /// `augment` reads it two ways. Dropping the enclosing scope's derived
   /// bindings (any non-`nil` `derivation`) before resolving a body is what lets
-  /// a self-named `(SELECT … FROM T) AS T` read the base `T` while KEEPING a
+  /// a self-named `(SELECT … FROM T) AS T` read the base `T` while keeping a
   /// same-named CTE in scope (so `WITH t … FROM (SELECT … FROM t) AS t`
-  /// resolves the CTE). And a binding whose `derivation` EQUALS the inner query
+  /// resolves the CTE). And a binding whose `derivation` equals the inner query
   /// being materialised is this query's own prior pass, left as materialised
   /// rather than re-derived (idempotent); a binding whose `derivation` differs
   /// — or is `nil` — is an enclosing query's, and this query's alias
-  /// re-materialises over it, SHADOWING it.
+  /// re-materialises over it, shadowing it.
   internal let derivation: Query?
 
-  /// Whether this binding is a DERIVED TABLE's materialised body — as opposed
+  /// Whether this binding is a derived TABLE's materialised body — as opposed
   /// to a common table expression's or a store relation's.
   internal var derived: Bool { derivation != nil }
 
@@ -197,9 +197,9 @@ internal struct RelationInstance: Hashable, Sendable {
     self.derivation = derivation
   }
 
-  /// A relation whose columns are RESOLVED from a body — its names, types, AND
-  /// per-column `unconstrained` mask taken TOGETHER from the `carrier`, so the
-  /// arrays cannot drift and the mask threads through this ONE constructor
+  /// A relation whose columns are resolved from a body — its names, types, AND
+  /// per-column `unconstrained` mask taken together from the `carrier`, so the
+  /// arrays cannot drift and the mask threads through this one constructor
   /// rather than a per-site `unconstrained:` argument a binding could drop.
   /// `rows` are the captured (or empty, schema-only) rows and `derivation` the
   /// inner `Query` for a derived table's binding.

--- a/Sources/SQLEngine/Resolution.swift
+++ b/Sources/SQLEngine/Resolution.swift
@@ -18,23 +18,23 @@
 /// resolves is `SQLError.column`; an unqualified name both relations of a join
 /// resolve is `SQLError.ambiguous`.
 
-/// The RESOLUTION CONTEXT a subquery occurrence materialises under — the seam
-/// that keeps two AST-identical subqueries resolving under DIFFERENT overlays
-/// SEPARATE cache entries, so neither overwrites the other.
+/// The resolution context a subquery occurrence materialises under — the seam
+/// that keeps two AST-identical subqueries resolving under different overlays
+/// separate cache entries, so neither overwrites the other.
 ///
 /// An uncorrelated subquery's result depends only on the overlay it resolves
 /// against, and in this slice a subquery resolves under exactly one of two
-/// contexts: the top-level CALLER's overlay (its `WITH` CTEs), or a specific
+/// contexts: the top-level caller's overlay (its `WITH` CTEs), or a specific
 /// VIEW body's overlay (that view's own base relations, never the caller's
 /// `WITH`). A view `VN` whose body has `EXISTS (SELECT V FROM S)` over an empty
 /// base `S`, run under a caller that binds `WITH S AS (SELECT 1)`, must read
 /// the view's own (empty) `S` — not the caller's CTE — even though both spell
-/// the same AST. Keying the cache by the `Query` VALUE alone collapses the
+/// the same AST. Keying the cache by the `Query` value alone collapses the
 /// two; a `Subscope` composed into the key keeps them disjoint. The `caller`
 /// case is distinguished from every `view` case, and two distinct view names
 /// never collide (case-folded), so the caller and view spaces cannot overlap.
 ///
-/// It is reproducible at BOTH the compile site (lowering embeds it in the
+/// It is reproducible at both the compile site (lowering embeds it in the
 /// lowered `Filter`) and the matching materialise site (`run` materialises the
 /// top-level query's subqueries under `.caller`; `derive(name:)` materialises a
 /// view body's under `.view(name)`), so the key a lowered predicate reads is
@@ -48,14 +48,14 @@ internal enum Subscope: Hashable, Sendable {
   case view(String)
 }
 
-/// The ROLE a subquery occurrence materialises in — its SHAPE in the cache.
+/// The role a subquery occurrence materialises in — its shape in the cache.
 ///
-/// The SAME inner SQL can occur in three roles at once, each needing a
-/// DIFFERENT materialisation, so the role discriminates the cache entry: a
+/// The same inner SQL can occur in three roles at once, each needing a
+/// different materialisation, so the role discriminates the cache entry: a
 /// `scalar` occurrence (`Expression.subquery`) collapses to one cell
 /// (`cell(of:)`), a `valued` occurrence (`IN (SELECT …)`, `Predicate.within`)
 /// keeps the materialised rows for its value set, and an `existential`
-/// occurrence (`EXISTS (SELECT …)`) is a cardinality PROBE that never runs
+/// occurrence (`EXISTS (SELECT …)`) is a cardinality probe that never runs
 /// the select list. Keying the cache without the role collapses the three onto
 /// one entry, so an `IN` reading a scalar entry faults (no rows) and an
 /// `EXISTS` reading a scalar entry mis-reads `present` — the role keeps them
@@ -75,19 +75,19 @@ internal enum Role: Hashable, Sendable {
   case lateral
 }
 
-/// The cache identity of one collected subquery OCCURRENCE — its resolution
+/// The cache identity of one collected subquery occurrence — its resolution
 /// `context` composed with its `query` AST and its `role`.
 ///
 /// A subquery is keyed neither by its `Query` value alone (which collapses two
 /// AST-identical subqueries under different overlays — see `Subscope`)
 /// nor by a raw counter (which two independent id spaces could not keep
-/// disjoint), but by the TRIPLE: within one `Subscope`, an identical `Query`
+/// disjoint), but by the triple: within one `Subscope`, an identical `Query`
 /// resolves to an identical result, so value-discrimination is correct there;
 /// across scopes the `Subscope` keeps them separate. A caller-space key
 /// (`.caller`) and a view-space key (`.view(name)`) are unequal even for the
 /// same AST, so the two id spaces cannot collide.
 ///
-/// The `role` keeps the three materialisation SHAPES of one `(scope, query)`
+/// The `role` keeps the three materialisation shapes of one `(scope, query)`
 /// disjoint (see `Role`): a `scalar` read can never hit a `valued` or an
 /// `existential` entry and vice versa, so identical inner SQL used in more than
 /// one role no longer cross-reads the wrong entry.
@@ -98,7 +98,7 @@ internal struct Subkey: Hashable, Sendable {
   /// The subquery's AST.
   internal let query: Query
 
-  /// The role this occurrence materialises in — its cache SHAPE.
+  /// The role this occurrence materialises in — its cache shape.
   internal let role: Role
 
   internal init(_ scope: Subscope, _ query: Query, _ role: Role) {
@@ -108,25 +108,25 @@ internal struct Subkey: Hashable, Sendable {
   }
 }
 
-/// The cache identity of one CORRELATED subquery occurrence's pre-compiled plan
-/// — its occurrence `Subkey` composed with the SET OF SYNTHETIC PARAMETER NAMES
+/// The cache identity of one correlated subquery occurrence's pre-compiled plan
+/// — its occurrence `Subkey` composed with the SET of synthetic parameter names
 /// its correlation binds.
 ///
 /// The `Subkey` alone (scope + query + role) does NOT separate two occurrences
-/// of IDENTICAL inner SQL that compile under DIFFERENT outer layouts — the two
+/// of identical inner SQL that compile under different outer layouts — the two
 /// arms of a set operation, `SELECT (SELECT m FROM Src WHERE m = k) FROM Outer1
 /// UNION ALL SELECT (SELECT m FROM Src WHERE m = k) FROM Outer2` where
 /// `Outer1.k` sits at ordinal 0 and `Outer2.k` at ordinal 1. Both arms carry
-/// the SAME `Subkey` (same `.caller` scope, same AST, same role), so keying the
-/// plan memo by `Subkey` alone lets the right arm READ the LEFT arm's plan —
+/// the same `Subkey` (same `.caller` scope, same AST, same role), so keying the
+/// plan memo by `Subkey` alone lets the right arm read the LEFT arm's plan —
 /// which binds `:__correlated_0_0` while the right arm's outer row binds
 /// `:__correlated_0_1`, yielding NULL/wrong results. The correlation's
-/// PARAMETER NAMES (`:__correlated_<depth>_<ordinal>`) encode each occurrence's
-/// own outer layout and are STABLE across the ordinal remap `optimise` applies
+/// parameter names (`:__correlated_<depth>_<ordinal>`) encode each occurrence's
+/// own outer layout and are stable across the ordinal remap `optimise` applies
 /// (it rewrites the `Source` values, never the keys), so they match at the
-/// RECORD site (the pre-pass compile) and the LOOKUP site (the lowered node)
-/// while DIFFERING between the two arms. Adding them to the key gives each arm
-/// its OWN plan yet preserves legitimate SHARING: an identical occurrence under
+/// record site (the pre-pass compile) and the lookup site (the lowered node)
+/// while differing between the two arms. Adding them to the key gives each arm
+/// its own plan yet preserves legitimate sharing: an identical occurrence under
 /// an identical outer layout binds the same names and reuses the one plan.
 internal struct PlanKey: Hashable, Sendable {
   /// The occurrence's `Subkey` — scope, query, and role.
@@ -143,13 +143,13 @@ internal struct PlanKey: Hashable, Sendable {
 }
 
 /// Where a correlated synthetic parameter's per-outer-row value comes from — a
-/// cell of the IMMEDIATE enclosing row (`slot`), or an ALREADY-bound parameter
+/// cell of the immediate enclosing row (`slot`), or an already-bound parameter
 /// the containing subquery threads through (`bound`).
 ///
-/// A correlation to the subquery's IMMEDIATE enclosing query reads that outer
+/// A correlation to the subquery's immediate enclosing query reads that outer
 /// row directly: `slot` is the outer combined ordinal the re-execution binds
-/// from the current outer row. A correlation to a scope TWO OR MORE levels up
-/// (a NESTED subquery naming a grandparent column) is bound by the CONTAINING
+/// from the current outer row. A correlation to a scope two OR more levels up
+/// (a nested subquery naming a grandparent column) is bound by the containing
 /// subquery — which the bubble-up marks correlated to that same grandparent, so
 /// it re-executes and binds the parameter — and the inner occurrence only reads
 /// it back through `bindings`, so its source is `bound`: the eval leaves the
@@ -158,12 +158,12 @@ internal enum Source: Hashable, Sendable {
   /// The value is the current outer row's cell at this combined ordinal.
   case slot(Int)
   /// The value is the `COALESCE` (first non-NULL) of the current outer row's
-  /// cells at these combined ordinals, COERCED to the unified `type` — a
-  /// `NATURAL`/`USING` MERGED column of an enclosing join scope (ISO 9075
-  /// 7.10), whose value belongs to NEITHER physical side but to their coalesce,
-  /// correlated into a LATERAL body (or any nested subquery) as its ONE merged
+  /// cells at these combined ordinals, coerced to the unified `type` — a
+  /// `NATURAL`/`USING` merged column of an enclosing join scope (ISO 9075
+  /// 7.10), whose value belongs to neither physical side but to their coalesce,
+  /// correlated into a LATERAL body (or any nested subquery) as its one merged
   /// column. It reads the outer row rather than a threaded binding, exactly as
-  /// `slot`, over MORE than one cell, matching the merged column's own
+  /// `slot`, over more than one cell, matching the merged column's own
   /// `COALESCE(left, right)` value the local scope lowers.
   case coalesce(Array<Int>, ValueType)
   /// The value is already in `bindings` — threaded down by the containing
@@ -171,24 +171,24 @@ internal enum Source: Hashable, Sendable {
   case bound
 }
 
-/// The CORRELATION of a subquery occurrence — the synthetic bound parameters
+/// The correlation of a subquery occurrence — the synthetic bound parameters
 /// its inner query names, each mapped to the `Source` its per-outer-row value
 /// comes from (an immediate-enclosing-row cell, or a threaded binding).
 ///
-/// A CORRELATED subquery references a column of an enclosing query (`SELECT V
+/// A correlated subquery references a column of an enclosing query (`SELECT V
 /// FROM S WHERE S.k = T.k`, the inner `T.k` outer). This slice ships the
-/// MINIMAL (b) cut: an outer column is allowed ONLY in the inner query's
+/// minimal (b) cut: an outer column is allowed ONLY in the inner query's
 /// `WHERE`/`ON` (a comparison operand or a `WHERE`-position term), where it
 /// lowers to a synthetic `Term.parameter(name)` — reusing the run's `bindings`
-/// with NO new evaluator beyond that leaf. This map records, per synthetic
-/// name, the `Source` the per-outer-row re-execution binds it from. An EMPTY
-/// map is an UNCORRELATED occurrence, materialised once and memoised; a
-/// NON-empty one re-runs the inner plan per outer row against a `bindings`
+/// with no new evaluator beyond that leaf. This map records, per synthetic
+/// name, the `Source` the per-outer-row re-execution binds it from. An empty
+/// map is an uncorrelated occurrence, materialised once and memoised; a
+/// non-empty one re-runs the inner plan per outer row against a `bindings`
 /// extended with each named cell, bypassing the materialise cache.
 ///
-/// An outer column in the inner PROJECTION / `GROUP BY` / `HAVING` is OUT of
+/// An outer column in the inner projection / `GROUP BY` / `HAVING` is out of
 /// this cut — it needs the general (a)-style outer-row evaluator, not a bound
-/// param — so it is DIAGNOSED as unsupported rather than mis-resolved (see
+/// param — so it is diagnosed as unsupported rather than mis-resolved (see
 /// `Outer.parameter`). A column binding neither locally nor in any enclosing
 /// scope stays the ordinary unknown-column fault.
 internal typealias Correlation = Dictionary<String, Source>
@@ -231,19 +231,19 @@ extension Dictionary where Key == String, Value == Source {
   }
 }
 
-/// The ENCLOSING resolution scope a subquery lowers against for its CORRELATED
-/// columns — the scope STACK the minimal (b) correlation cut consults when an
-/// inner column binds against none of the subquery's OWN in-scope relations.
+/// The enclosing resolution scope a subquery lowers against for its correlated
+/// columns — the scope stack the minimal (b) correlation cut consults when an
+/// inner column binds against none of the subquery's own in-scope relations.
 ///
 /// A subquery resolves its columns against its own relations FIRST; a name none
-/// of them binds is a candidate CORRELATED reference to an enclosing query.
+/// of them binds is a candidate correlated reference to an enclosing query.
 /// This carries the enclosing `Scope`s, innermost last, and — as lowering
 /// reaches each such candidate — resolves it against them (nearest first),
-/// MINTS a synthetic `:parameter` name for the outer combined ordinal, and
-/// RECORDS the (name → ordinal) pair into the shared `correlation` accumulator
+/// mints a synthetic `:parameter` name for the outer combined ordinal, and
+/// records the (name → ordinal) pair into the shared `correlation` accumulator
 /// so the per-outer-row re-execution can bind that cell. It is a class so the
 /// accumulator survives the seam being copied by value down the lowering, and
-/// so the SAME occurrence lowered on the run and the schema paths accretes into
+/// so the same occurrence lowered on the run and the schema paths accretes into
 /// one map.
 ///
 /// A name no enclosing scope binds either stays the ordinary unknown-column
@@ -251,19 +251,19 @@ extension Dictionary where Key == String, Value == Source {
 /// intercepts a name the OUTER scope binds. Correlation is admitted ONLY where
 /// a synthetic bound param is a valid lowering — a `WHERE`/`ON` term — so a
 /// scope with no admitted position (a projection / `GROUP BY` / `HAVING`
-/// surface) carries no `Outer` and the outer column stays unresolved, DIAGNOSED
+/// surface) carries no `Outer` and the outer column stays unresolved, diagnosed
 /// as unsupported rather than mis-bound.
 internal final class Outer {
-  /// The enclosing scopes, OUTERMOST first — a column resolves against the
-  /// nearest enclosing (last) that binds it, matching lexical scoping. The LAST
-  /// scope is this subquery's IMMEDIATE parent; any earlier one is a
-  /// grandparent (or further) whose correlation BUBBLES UP to the containing
+  /// The enclosing scopes, outermost first — a column resolves against the
+  /// nearest enclosing (last) that binds it, matching lexical scoping. The last
+  /// scope is this subquery's immediate parent; any earlier one is a
+  /// grandparent (or further) whose correlation bubbles up to the containing
   /// subquery.
   private let scopes: Array<Scope>
 
-  /// The enclosing subquery's `Outer` — the one holding `scopes` MINUS the last
+  /// The enclosing subquery's `Outer` — the one holding `scopes` minus the last
   /// — up which a correlation to a non-immediate scope propagates, so the
-  /// CONTAINING subquery is marked correlated to that grandparent column too.
+  /// containing subquery is marked correlated to that grandparent column too.
   /// `nil` at the outermost level (a top-level select's `Outer`).
   private let parent: Outer?
 
@@ -277,37 +277,37 @@ internal final class Outer {
     self.parent = parent
   }
 
-  /// This outer scope extended with `scope` as the NEAREST enclosing one — the
+  /// This outer scope extended with `scope` as the nearest enclosing one — the
   /// stack a nested subquery lowers against, seeing its immediate parent last,
   /// with `self` as the parent so a correlation to a grandparent scope bubbles
-  /// up. The accumulator starts fresh: correlation is recorded PER occurrence,
+  /// up. The accumulator starts fresh: correlation is recorded per occurrence,
   /// not shared across sibling subqueries.
   internal func nested(under scope: Scope) -> Outer {
     Outer(scopes + [scope], parent: self)
   }
 
   /// The synthetic `:parameter` name a correlated reference to enclosing
-  /// combined `ordinal` at scope `depth` lowers to — deterministic in BOTH, so
-  /// the run and schema lowerings of the SAME occurrence mint identical names
+  /// combined `ordinal` at scope `depth` lowers to — deterministic in both, so
+  /// the run and schema lowerings of the same occurrence mint identical names
   /// and the re-execution binds them from the outer row. The `depth` (the
   /// scope-stack index the reference resolves at) disambiguates two references
-  /// from DIFFERENT enclosing scopes that share an ordinal — a `T.id`
+  /// from different enclosing scopes that share an ordinal — a `T.id`
   /// (grandparent) and a `U.u` (parent) both at combined ordinal 0 — so each
-  /// gets its OWN synthetic param and correlation entry rather than colliding
+  /// gets its own synthetic param and correlation entry rather than colliding
   /// on `:__correlated_0`. The depth is a scope-stack index, stable across the
-  /// bubble-up (a parent sees the shared prefix scope at the SAME index), so
+  /// bubble-up (a parent sees the shared prefix scope at the same index), so
   /// the binding level and the threading levels agree on the name.
   private func name(for ordinal: Int, at depth: Int) -> String {
     ":__correlated_\(depth)_\(ordinal)"
   }
 
   /// The synthetic `:parameter` name a correlated reference to a
-  /// `NATURAL`/`USING` MERGED column of enclosing scope `depth` lowers to —
+  /// `NATURAL`/`USING` merged column of enclosing scope `depth` lowers to —
   /// keyed by the merged column's LEFT constituent ordinal but in a DISTINCT
   /// namespace from `name(for:at:)`, so it cannot collide with the physical
-  /// parameter of ANY constituent slot. A LATERAL body that references BOTH the
+  /// parameter of ANY constituent slot. A LATERAL body that references both the
   /// bare merged column (this key) AND a physical constituent `A.k` (the
-  /// physical `name(for:at:)` key) thus gets TWO correlation entries, one per
+  /// physical `name(for:at:)` key) thus gets two correlation entries, one per
   /// reference, so the merged coalesce and the qualified slot each bind their
   /// own value regardless of lowering order (a shared key let one overwrite the
   /// other). The left constituent ordinal uniquely identifies the merged column
@@ -321,18 +321,18 @@ internal final class Outer {
   /// The synthetic bound-parameter name `column` correlates to, or `nil` when
   /// no enclosing scope binds it (the ordinary unknown-column fault stands).
   ///
-  /// The enclosing scopes are consulted NEAREST first (the innermost enclosing
+  /// The enclosing scopes are consulted nearest first (the innermost enclosing
   /// query shadows an outer one, as lexical scoping requires). On a match it
   /// records the correlation (see `record(_:matching:)`) and returns the name,
   /// so the caller lowers the column to a `Term.parameter`. A nearer scope that
-  /// binds the name AMBIGUOUSLY (in more than one of its relations) SHADOWS the
+  /// binds the name ambiguously (in more than one of its relations) shadows the
   /// farther ones: `correlated` faults `SQLError.ambiguous`, which propagates
   /// rather than falling through to rebind the name to a farther relation. Only
-  /// a NOT-FOUND (`nil`) keeps the walk moving outward.
+  /// a NOT-found (`nil`) keeps the walk moving outward.
   internal func parameter(for column: Column) throws(SQLError) -> String? {
     for depth in scopes.indices.reversed() {
       // A bare (unqualified) name a `NATURAL`/`USING` join of this enclosing
-      // scope MERGED (ISO 9075 7.10) correlates to its ONE coalesce value — the
+      // scope merged (ISO 9075 7.10) correlates to its one coalesce value — the
       // merged entry shadows its two physical constituents, so a LATERAL body's
       // bare `k` binds the merged column rather than faulting `.ambiguous`
       // between the two sides. Its source is the `COALESCE` of its constituent
@@ -357,17 +357,17 @@ internal final class Outer {
   /// Records the correlation of `name` — the `source` its per-outer-row value
   /// comes from — matched at enclosing-scope `depth`.
   ///
-  /// A match at the LAST scope (this subquery's immediate parent) reads that
+  /// A match at the last scope (this subquery's immediate parent) reads that
   /// outer row directly, so the source is the parent-row `source` as given (a
-  /// `slot` cell or a merged column's `coalesce`). A match at an EARLIER scope
-  /// is a correlation of the CONTAINING subquery too: it is recorded `bound`
+  /// `slot` cell or a merged column's `coalesce`). A match at an earlier scope
+  /// is a correlation of the containing subquery too: it is recorded `bound`
   /// here — the eval threads the value through `bindings` rather than reading
-  /// this subquery's own row — and the SAME `source` propagated up to `parent`
+  /// this subquery's own row — and the same `source` propagated up to `parent`
   /// (whose last scope is one level nearer), so the containing occurrence is
   /// itself marked correlated and re-executes per its enclosing row. Since a
   /// `Scope` lays relations at cumulative offsets from 0, the source's ordinals
   /// are the same in every level that shares the matched scope, so the ancestor
-  /// that owns it as its IMMEDIATE parent reads the right cells.
+  /// that owns it as its immediate parent reads the right cells.
   private func record(_ name: String, _ source: Source, matching depth: Int) {
     let immediate = depth == scopes.count - 1
     correlation[name] = immediate ? source : .bound
@@ -377,34 +377,34 @@ internal final class Outer {
   /// The value type of the enclosing column `column` names, or `nil` when no
   /// enclosing scope binds it — the static type a correlated reference
   /// contributes to the type-check surface (`validate`), so a correlated column
-  /// types as its outer column rather than a placeholder. It records NO
+  /// types as its outer column rather than a placeholder. It records no
   /// correlation (a pure type probe); the lowering's `parameter(for:)` records
   /// the binding. Like `parameter(for:)`, a nearer scope binding the name
-  /// AMBIGUOUSLY SHADOWS the farther ones — `correlated` faults
+  /// ambiguously shadows the farther ones — `correlated` faults
   /// `SQLError.ambiguous`, which propagates rather than falling through — so
-  /// the schema-derive and the run's lowering AGREE on the ambiguity.
+  /// the schema-derive and the run's lowering agree on the ambiguity.
   internal func type(for column: Column) throws(SQLError) -> ValueType? {
     try resolved(for: column).map(\.type)
   }
 
   /// The resolved enclosing column `column` names — its outer `type` AND
-  /// `unconstrained` mask read TOGETHER from the one ordinal a nearest-first
+  /// `unconstrained` mask read together from the one ordinal a nearest-first
   /// walk matches — or `nil` when no enclosing scope binds it. It walks
-  /// `scopes` NEAREST-first exactly as the type probe does (a nearer scope
-  /// shadows a farther one), records NO correlation (a pure probe), and lets an
+  /// `scopes` nearest-first exactly as the type probe does (a nearer scope
+  /// shadows a farther one), records no correlation (a pure probe), and lets an
   /// ambiguous nearer scope's `SQLError.ambiguous` propagate. `type(for:)` and
-  /// any mask reader are THIN accessors over this, so a correlated column's
+  /// any mask reader are thin accessors over this, so a correlated column's
   /// type and mask cannot diverge — the fix for a correlated all-NULL column
   /// losing its mask through the LATERAL correlation surface.
   internal func resolved(for column: Column) throws(SQLError)
       -> ResolvedColumn? {
     for scope in scopes.reversed() {
-      // A bare name an enclosing `NATURAL`/`USING` join MERGED types from the
-      // merged column's unified coalesce type (ISO 9075 7.10) — the SAME entry
+      // A bare name an enclosing `NATURAL`/`USING` join merged types from the
+      // merged column's unified coalesce type (ISO 9075 7.10) — the same entry
       // `parameter(for:)` binds — so the schema-derive and the run's lowering
       // agree on a correlated merged reference. It carries the merged column's
-      // OWN `unconstrained` mask (constrained once either constituent did, a
-      // placeholder only when BOTH were unconstrained), so an enclosing
+      // own `unconstrained` mask (constrained once either constituent did, a
+      // placeholder only when both were unconstrained), so an enclosing
       // set-operation fold over the correlated merged reference defers or
       // constrains consistently. A qualified name falls through to the physical
       // probe.
@@ -419,18 +419,18 @@ internal final class Outer {
   }
 }
 
-/// The mutable memo a `Subqueries` cache shares by REFERENCE for the
-/// UNCORRELATED subqueries it materialises LAZILY, keyed by occurrence
+/// The mutable memo a `Subqueries` cache shares by reference for the
+/// uncorrelated subqueries it materialises lazily, keyed by occurrence
 /// `Subkey`.
 ///
-/// Every subquery ROLE — scalar collapse, `IN` value set, `EXISTS` probe — is
-/// materialised LAZILY, on the FIRST evaluation of its lowered node, so an
+/// Every subquery role — scalar collapse, `IN` value set, `EXISTS` probe — is
+/// materialised lazily, on the FIRST evaluation of its lowered node, so an
 /// occurrence in an unreachable `CASE`/`COALESCE` arm or a short-circuited
 /// `AND`/`OR` never runs (never throws its inner fault) — the folded-in lazy
-/// `IN`/`EXISTS` that the earlier slice left eager. An UNCORRELATED occurrence
-/// is row-invariant, so the first reached evaluation runs it ONCE and caches
-/// the result here; every later read of the same key returns it WITHOUT
-/// re-running. A CORRELATED occurrence is NOT memoised (its result depends on
+/// `IN`/`EXISTS` that the earlier slice left eager. An uncorrelated occurrence
+/// is row-invariant, so the first reached evaluation runs it once and caches
+/// the result here; every later read of the same key returns it without
+/// re-running. A correlated occurrence is NOT memoised (its result depends on
 /// the bound outer row), so it never reads or writes this — it re-runs per
 /// outer row.
 ///
@@ -444,11 +444,11 @@ internal final class SubqueryMemo {
   /// The `IN (Q)` single-column value set memoised per valued occurrence.
   private var columns: Dictionary<Subkey, Array<Value>> = [:]
 
-  /// The RESOLUTION OVERLAY each `Subscope`'s subqueries run under — the
+  /// The resolution OVERLAY each `Subscope`'s subqueries run under — the
   /// caller's `WITH`/store overlay under `.caller`, a view body's own overlay
-  /// under `.view(name)` — recorded as each scope BEGINS executing, so the lazy
+  /// under `.view(name)` — recorded as each scope begins executing, so the lazy
   /// evaluator runs a subquery against the overlay of the scope it was
-  /// TEXTUALLY lowered under, NOT the (possibly different) overlay of the
+  /// textually lowered under, NOT the (possibly different) overlay of the
   /// execution site a predicate pushdown moved it to. A caller conjunct pushed
   /// INTO a view thus still resolves its subquery's `FROM S` against the
   /// caller's `S`, not the view's base — the correctness the disjoint
@@ -470,19 +470,19 @@ internal final class SubqueryMemo {
     columns[key] = values
   }
 
-  /// The COMPILED inner plan of each CORRELATED occurrence, keyed by its
+  /// The compiled inner plan of each correlated occurrence, keyed by its
   /// occurrence `PlanKey` (its `Subkey` composed with the parameter names its
-  /// correlation binds) — compiled ONCE (with the enclosing scope as its
+  /// correlation binds) — compiled once (with the enclosing scope as its
   /// `Outer`, so its correlated columns lowered to `Term.parameter`) by the run
-  /// path's compile and stashed here, so the evaluator RE-EXECUTES that plan
-  /// per outer row against the correlated bindings rather than RE-COMPILING the
+  /// path's compile and stashed here, so the evaluator re-executes that plan
+  /// per outer row against the correlated bindings rather than re-compiling the
   /// inner query fresh (which, with no outer scope in hand at eval, would fault
   /// on the outer column). Keying by the `PlanKey` keeps two occurrences of the
-  /// SAME inner SQL — under a `.caller` and a `.view(name)` scope, or across
-  /// two set-operation arms whose correlated column has a DIFFERENT outer
-  /// ordinal — DISJOINT, so each executes its OWN plan rather than the first
+  /// same inner SQL — under a `.caller` and a `.view(name)` scope, or across
+  /// two set-operation arms whose correlated column has a different outer
+  /// ordinal — disjoint, so each executes its own plan rather than the first
   /// occurrence's, while an identical occurrence under an identical outer
-  /// layout still SHARES. An UNCORRELATED occurrence carries none — it re-runs
+  /// layout still shares. An uncorrelated occurrence carries none — it re-runs
   /// its `Query` (recompiling resolves without an outer scope) and memoises.
   private var plans: Dictionary<PlanKey, Plan> = [:]
 
@@ -500,7 +500,7 @@ internal final class SubqueryMemo {
 
   /// The occurrence `Subkey`s whose reached correlated set-operation fold has
   /// already been strictly re-validated — a reached scalar/`IN` occurrence
-  /// folds ONCE (faulting on an irreconcilable pair the first reached outer
+  /// folds once (faulting on an irreconcilable pair the first reached outer
   /// row), then subsequent rows skip the redundant per-row re-fold.
   private var validated: Set<Subkey> = []
 
@@ -508,23 +508,23 @@ internal final class SubqueryMemo {
   internal func validate(_ key: Subkey) { validated.insert(key) }
 }
 
-/// The COMPILE-time seam that lowers an `EXISTS`/`IN (Q)` predicate WITHOUT
+/// The compile-time seam that lowers an `EXISTS`/`IN (Q)` predicate without
 /// running its subquery — the fix for the schema-path cursor-contract
 /// violation.
 ///
 /// Predicate lowering happens over escapable resolution surfaces (`Schema`,
-/// `Scope`, `Grouped`) that carry no catalog, and is shared by SCHEMA-ONLY
+/// `Scope`, `Grouped`) that carry no catalog, and is shared by schema-ONLY
 /// paths (`columns(of:)`, view resolution, arity checks) documented NOT to open
-/// a cursor. So lowering carries the sub-`Query` into the `Filter` as DATA
+/// a cursor. So lowering carries the sub-`Query` into the `Filter` as data
 /// rather than running it: `exists`/`within` build the lowered node holding the
-/// query, which executes ONCE, at RUN time (see `Subqueries`). Only the
+/// query, which executes once, at run time (see `Subqueries`). Only the
 /// single-column arity of an `IN (Q)` is decided here — from the subquery's
-/// COMPILED WIDTH, known without a cursor — so a two-column `IN` subquery
+/// compiled width, known without a cursor — so a two-column `IN` subquery
 /// faults `SQLError.arity` at compile as before, never having run.
 ///
 /// The `widths` map holds each nested `Query`'s compiled column count, built by
-/// the `compile` path (where the catalog is in scope) by COMPILING — never
-/// running — every subquery ONCE ahead of lowering. A schema-only surface with
+/// the `compile` path (where the catalog is in scope) by compiling — never
+/// running — every subquery once ahead of lowering. A schema-only surface with
 /// no catalog passes `.unsupported`, whose `width` faults, so a subquery
 /// reaching such a surface is rejected rather than mis-lowered.
 internal struct Resolution {
@@ -534,50 +534,50 @@ internal struct Resolution {
   /// view-body occurrence and a top-level one over the same AST stay distinct.
   private let scope: Subscope
 
-  /// Each nested `Query` mapped to its COMPILED column count — cursor-free; an
+  /// Each nested `Query` mapped to its compiled column count — cursor-free; an
   /// `IN (Q)` and a scalar subquery each require it be 1.
   private let widths: Dictionary<Query, Int>
 
   /// Each nested `Query` mapped to its single-column output COLUMN, derived
   /// cursor-free in the compile pre-pass — the resolved column a scalar
-  /// subquery contributes, its TYPE (the executor coerces its collapsed value
+  /// subquery contributes, its type (the executor coerces its collapsed value
   /// to it, as a `CASE` coerces its arms) AND its `unconstrained` mask
-  /// TOGETHER, so a bare scalar-subquery projection over a constant-NULL body
+  /// together, so a bare scalar-subquery projection over a constant-NULL body
   /// carries that mask into an outer set-operation fold rather than dropping
   /// it. Only a width-1 query has one, so an `EXISTS`/`IN (Q)` occurrence
   /// (whose type is irrelevant) may be absent.
   private let types: Dictionary<Query, ResolvedColumn>
 
-  /// Each nested `Query` mapped to its CORRELATION — the synthetic bound params
+  /// Each nested `Query` mapped to its correlation — the synthetic bound params
   /// its inner `WHERE`/`ON` names of an enclosing column, discovered by the
   /// pre-pass compiling the nested query under this select's scope as its
-  /// `Outer`. An UNCORRELATED nested query maps to the empty correlation (or is
+  /// `Outer`. An uncorrelated nested query maps to the empty correlation (or is
   /// absent), so its lowered node bypasses nothing; a correlated one carries
   /// its map into the lowered `Filter`/`Term` so the per-outer-row re-execution
   /// binds the named cells.
   private let correlations: Dictionary<Query, Correlation>
 
-  /// The ENCLOSING scope THIS select's OWN columns correlate against — set when
+  /// The enclosing scope this select's own columns correlate against — set when
   /// this select is itself a subquery, so a column its relations do not bind
   /// resolves against the outer query and lowers to a `Term.parameter`. `nil`
   /// for a top-level select (no enclosing scope), leaving an unbound column the
   /// ordinary fault.
   private let outer: Outer?
 
-  /// Whether this lowering surface ADMITS a correlated column — TRUE for the
+  /// Whether this lowering surface admits a correlated column — TRUE for the
   /// inner `WHERE`/`ON` (a synthetic bound param is a valid lowering there),
   /// FALSE for the projection / `GROUP BY` / `HAVING` (the minimal (b) cut has
-  /// no evaluator for an outer column there). A barred surface DIAGNOSES a
+  /// no evaluator for an outer column there). A barred surface diagnoses a
   /// correlated column as unsupported rather than mis-resolving it.
   private let admits: Bool
 
-  /// Whether the surface admits a correlated column EVERYWHERE — in the barred
+  /// Whether the surface admits a correlated column everywhere — in the barred
   /// clause positions (the projection / `GROUP BY` / `HAVING`) as well as the
   /// `WHERE`/`ON` — set ONLY when lowering a LATERAL derived table's body. Per
   /// ISO 9075 a `LATERAL` body's preceding-FROM references are in scope
-  /// throughout its query expression, INCLUDING the select list, so a lateral
+  /// throughout its query expression, including the select list, so a lateral
   /// body correlates everywhere while an ordinary subquery's projection stays
-  /// barred. When `true`, `barred` is a NO-OP — it keeps `admits`, so a
+  /// barred. When `true`, `barred` is a no-OP — it keeps `admits`, so a
   /// projected preceding column still lowers to a `Term.parameter` — and the
   /// per-outer-row apply binds it exactly as a `WHERE`-correlated one.
   private let everywhere: Bool
@@ -604,15 +604,15 @@ internal struct Resolution {
     Resolution()
   }
 
-  /// This seam with correlation BARRED — the surface a projection / `GROUP BY`
+  /// This seam with correlation barred — the surface a projection / `GROUP BY`
   /// / `HAVING` lowers under, where an outer column is out of the minimal (b)
   /// cut. It keeps the widths/types/correlations (nested subqueries there still
-  /// lower and carry their OWN inner correlation) but rejects a correlated
-  /// column of THIS query as unsupported.
+  /// lower and carry their own inner correlation) but rejects a correlated
+  /// column of this query as unsupported.
   ///
   /// A LATERAL body's surface (`everywhere`) is the exception: ISO puts the
-  /// preceding-FROM references in scope throughout the body INCLUDING the
-  /// select list, so `barred` is a NO-OP there — the projection keeps admitting
+  /// preceding-FROM references in scope throughout the body including the
+  /// select list, so `barred` is a no-OP there — the projection keeps admitting
   /// a correlated column, which lowers to a `Term.parameter` the apply binds
   /// per outer row.
   internal var barred: Resolution {
@@ -621,14 +621,14 @@ internal struct Resolution {
                       admits: false, everywhere: everywhere)
   }
 
-  /// The synthetic bound-parameter name a CORRELATED reference to `column`
+  /// The synthetic bound-parameter name a correlated reference to `column`
   /// lowers to, or `nil` when no enclosing scope binds it (the ordinary
   /// unknown-column fault stands). A `.column` lowering consults this ONLY
   /// after its own relations fail to bind the name.
   ///
   /// On a barred surface (a projection / `GROUP BY` / `HAVING`) an outer column
   /// IS out of the minimal (b) cut, so a name the enclosing scope binds is
-  /// DIAGNOSED `SQLError.unsupported` rather than mis-resolved — the same fault
+  /// diagnosed `SQLError.unsupported` rather than mis-resolved — the same fault
   /// on the run and the schema paths, keeping typecheck↔run parity.
   internal func correlate(_ column: Column) throws(SQLError) -> String? {
     guard let name = try outer?.parameter(for: column) else { return nil }
@@ -641,14 +641,14 @@ internal struct Resolution {
   }
 
   /// The resolved outer column a correlated reference to `column` contributes
-  /// to a SCHEMA derive — its `type` AND `unconstrained` mask TOGETHER — or
-  /// `nil` when no enclosing scope binds it. Every type/mask reader is a THIN
-  /// accessor over this ONE resolver, so a correlated column's type and mask
+  /// to a schema derive — its `type` AND `unconstrained` mask together — or
+  /// `nil` when no enclosing scope binds it. Every type/mask reader is a thin
+  /// accessor over this one resolver, so a correlated column's type and mask
   /// cannot diverge (the fix for a correlated all-NULL column losing its mask
   /// through the LATERAL surface).
   ///
-  /// A BARRED surface (a projection / `GROUP BY` / `HAVING` of an ORDINARY
-  /// subquery) still DIAGNOSES a bound name `SQLError.unsupported` — the SAME
+  /// A barred surface (a projection / `GROUP BY` / `HAVING` of an ordinary
+  /// subquery) still diagnoses a bound name `SQLError.unsupported` — the same
   /// fault the run's lowering raises, keeping typecheck↔run parity — so this
   /// widens nothing: a lateral body's projection (`everywhere`) admits it,
   /// while an ordinary subquery's projection faults exactly as before.
@@ -664,7 +664,7 @@ internal struct Resolution {
   }
 
   /// The correlation of the nested `query` — its synthetic outer bindings —
-  /// discovered by the pre-pass, or the empty map for an UNCORRELATED one.
+  /// discovered by the pre-pass, or the empty map for an uncorrelated one.
   private func correlation(of query: Query) -> Correlation {
     correlations[query] ?? [:]
   }
@@ -691,9 +691,9 @@ internal struct Resolution {
   }
 
   /// The static single-column type a scalar subquery `query` contributes to a
-  /// SCHEMA derive — its single-column arity enforced first (else
+  /// schema derive — its single-column arity enforced first (else
   /// `SQLError.arity`, matching the lowering), so this schema surface and the
-  /// run's lowering AGREE on both the arity fault and the type. This is the
+  /// run's lowering agree on both the arity fault and the type. This is the
   /// bare-`ValueType` path the run's `Term.subquery` lowering reads; the outer
   /// set-operation fold reads the whole column through `scalar(resolved:)`.
   internal func scalar(type query: Query) throws(SQLError) -> ValueType {
@@ -703,9 +703,9 @@ internal struct Resolution {
   }
 
   /// The single-column resolved COLUMN a scalar subquery `query` contributes to
-  /// a SCHEMA derive — its type AND `unconstrained` mask together, the arity
+  /// a schema derive — its type AND `unconstrained` mask together, the arity
   /// guard first (else `SQLError.arity`, exactly as `scalar(type:)`). A bare
-  /// scalar-subquery PROJECTION reads this so a constant-NULL body's mask
+  /// scalar-subquery projection reads this so a constant-NULL body's mask
   /// travels into an outer set-operation fold rather than being dropped by the
   /// bare-type path.
   internal func scalar(resolved query: Query)
@@ -728,8 +728,8 @@ internal struct Resolution {
   }
 
   /// Lowers `operand [NOT] IN (query)` — `operand` already lowered to a `Term`
-  /// — requiring `query` project EXACTLY ONE column (else `SQLError.arity`,
-  /// checked from the COMPILED width, so a two-column subquery faults here
+  /// — requiring `query` project exactly one column (else `SQLError.arity`,
+  /// checked from the compiled width, so a two-column subquery faults here
   /// without running), then carrying the query into the `Filter` to run at
   /// execution.
   internal func within(_ operand: Term, _ query: Query, negated: Bool)
@@ -741,13 +741,13 @@ internal struct Resolution {
   }
 
   /// Lowers `operand op {ANY | ALL} (query)` — `operand` already lowered to a
-  /// `Term` — requiring `query` project EXACTLY ONE column (else
-  /// `SQLError.arity`, from the COMPILED width, so a two-column subquery faults
-  /// here WITHOUT running), then carrying the query into the `Filter` under the
-  /// SAME `.valued` role `within` uses — the full column is materialised and
+  /// `Term` — requiring `query` project exactly one column (else
+  /// `SQLError.arity`, from the compiled width, so a two-column subquery faults
+  /// here without running), then carrying the query into the `Filter` under the
+  /// same `.valued` role `within` uses — the full column is materialised and
   /// folded per outer row — with the discovered `correlation` threaded exactly
-  /// as `within` threads it, so a CORRELATED quantified re-runs its inner plan
-  /// per outer row (an UNCORRELATED one carries an empty correlation and
+  /// as `within` threads it, so a correlated quantified re-runs its inner plan
+  /// per outer row (an uncorrelated one carries an empty correlation and
   /// memoises once), to run at execution.
   internal func quantified(_ operand: Term, _ op: Comparison,
                            _ quantifier: Quantifier, _ query: Query)
@@ -759,12 +759,12 @@ internal struct Resolution {
   }
 
   /// Lowers a scalar subquery `(query)` to a `Term.subquery` reading its
-  /// collapsed value from the run-time cache, requiring `query` project EXACTLY
-  /// ONE column (else `SQLError.arity`, from the COMPILED width, so a wider
-  /// subquery faults here WITHOUT running). The term carries the subquery's
+  /// collapsed value from the run-time cache, requiring `query` project exactly
+  /// one column (else `SQLError.arity`, from the compiled width, so a wider
+  /// subquery faults here without running). The term carries the subquery's
   /// occurrence `Subkey` — its resolution scope composed with `query` — and its
-  /// single-column TYPE, to which the executor coerces the collapsed value (the
-  /// empty → NULL and >1-row → cardinality cases are decided at RUN, in the
+  /// single-column type, to which the executor coerces the collapsed value (the
+  /// empty → NULL and >1-row → cardinality cases are decided at run, in the
   /// materialiser).
   internal func scalar(_ query: Query) throws(SQLError) -> Term {
     let width = try width(query)
@@ -775,14 +775,14 @@ internal struct Resolution {
   }
 }
 
-/// The PER-SITE lowering seams a select's pre-pass discovers — ONE `Resolution`
-/// per join `ON` (resolved against that join's PREFIX scope) and one for the
-/// REST (the WHERE, `HAVING`, projection, and `ORDER BY`, resolved against the
+/// The per-site lowering seams a select's pre-pass discovers — one `Resolution`
+/// per join `ON` (resolved against that join's prefix scope) and one for the
+/// rest (the WHERE, `HAVING`, projection, and `ORDER BY`, resolved against the
 /// full join scope).
 ///
-/// The same inner SQL in both an `ON` and the WHERE is resolved TWICE, each
-/// against its OWN site's scope, so a name the `ON`'s narrow prefix binds
-/// UNAMBIGUOUSLY yet the WHERE's full scope binds in MORE than one relation is
+/// The same inner SQL in both an `ON` and the WHERE is resolved twice, each
+/// against its own site's scope, so a name the `ON`'s narrow prefix binds
+/// unambiguously yet the WHERE's full scope binds in more than one relation is
 /// a prefix correlation in the `ON` and a genuine ambiguity in the WHERE — each
 /// per its own site, not the first occurrence's prefix (see `subquery(of:)`).
 internal struct Plans {
@@ -805,25 +805,25 @@ internal struct Plans {
   }
 }
 
-/// The RUN-time cache that runs each UNCORRELATED subquery ONCE, LAZILY on the
+/// The run-time cache that runs each uncorrelated subquery once, lazily on the
 /// first reach of its lowered node, and memoises the result — the seam that
-/// gives the row evaluator a subquery result WITHOUT itself holding the
+/// gives the row evaluator a subquery result without itself holding the
 /// borrowing catalog stored.
 ///
 /// The evaluator (a `Catalog` method, the catalog IN scope) runs a subquery
 /// itself: it reads this cache first and, on a miss, runs the inner plan and
-/// `store`s the result. An UNCORRELATED occurrence names no enclosing column,
-/// so its result is the SAME for every outer row and is memoised under its
-/// occurrence `Subkey`; a later reach returns it WITHOUT re-running. A
-/// CORRELATED occurrence's result depends on the bound outer row, so it
-/// BYPASSES this cache entirely — the evaluator re-runs its inner plan per
+/// `store`s the result. An uncorrelated occurrence names no enclosing column,
+/// so its result is the same for every outer row and is memoised under its
+/// occurrence `Subkey`; a later reach returns it without re-running. A
+/// correlated occurrence's result depends on the bound outer row, so it
+/// bypasses this cache entirely — the evaluator re-runs its inner plan per
 /// outer row against a `bindings` extended with the correlated cells (this
 /// slice does NOT memoise across distinct binding tuples — a flagged future
 /// optimisation). Every role (scalar / `IN` / `EXISTS`) is lazy, so a subquery
 /// an unreachable `CASE` arm or a short-circuited `AND`/`OR` never reaches
 /// never runs.
 internal struct Subqueries {
-  /// The shared memo of the UNCORRELATED occurrences materialised LAZILY on
+  /// The shared memo of the uncorrelated occurrences materialised lazily on
   /// first reach — a reference so every by-value copy of this cache down the
   /// evaluate tree shares the one box, keeping each materialise-once.
   private let memo: SubqueryMemo
@@ -832,39 +832,39 @@ internal struct Subqueries {
     self.memo = memo
   }
 
-  /// The memoised `EXISTS` non-empty result for the UNCORRELATED occurrence
+  /// The memoised `EXISTS` non-empty result for the uncorrelated occurrence
   /// `key`, or `nil` when it has not yet run — the evaluator probes on a miss
   /// and `store`s it.
   internal func present(cached key: Subkey) -> Bool? {
     memo.present(key)
   }
 
-  /// Records the `EXISTS` non-empty result of the UNCORRELATED occurrence
+  /// Records the `EXISTS` non-empty result of the uncorrelated occurrence
   /// `key`.
   internal func store(present value: Bool, for key: Subkey) {
     memo.store(present: value, for: key)
   }
 
-  /// The memoised `IN (Q)` single column for the UNCORRELATED occurrence `key`,
+  /// The memoised `IN (Q)` single column for the uncorrelated occurrence `key`,
   /// or `nil` when it has not yet run — the evaluator materialises on a miss
   /// and `store`s it.
   internal func values(cached key: Subkey) -> Array<Value>? {
     memo.values(key)
   }
 
-  /// Records the `IN (Q)` single-column value set of the UNCORRELATED
+  /// Records the `IN (Q)` single-column value set of the uncorrelated
   /// occurrence `key`.
   internal func store(values: Array<Value>, for key: Subkey) {
     memo.store(values: values, for: key)
   }
 
-  /// The already-collapsed value memoised for the scalar UNCORRELATED
+  /// The already-collapsed value memoised for the scalar uncorrelated
   /// occurrence `key`, or `nil` when it has not yet been evaluated.
   internal func scalar(cached key: Subkey) -> Value? {
     memo.scalar(key)
   }
 
-  /// Records `value` as the collapsed value of the scalar UNCORRELATED
+  /// Records `value` as the collapsed value of the scalar uncorrelated
   /// occurrence `key`.
   internal func store(scalar value: Value, for key: Subkey) {
     memo.store(scalar: value, for: key)
@@ -880,24 +880,24 @@ internal struct Subqueries {
   /// Records `overlay` as the resolution overlay `scope`'s subqueries run
   /// under — the caller's before executing the top-level plan, a view body's
   /// before deriving it — so a subquery lowered under `scope` re-runs against
-  /// ITS overlay even when a pushdown moved its predicate to another site.
+  /// its overlay even when a pushdown moved its predicate to another site.
   internal func record(overlay: ScopedRelations, for scope: Subscope) {
     memo.record(overlay: overlay, for: scope)
   }
 
-  /// The pre-compiled inner plan of the CORRELATED occurrence `key` under
+  /// The pre-compiled inner plan of the correlated occurrence `key` under
   /// `correlation` — compiled once with its enclosing scope so its correlated
-  /// columns are `Term.parameter` — or `nil` for an UNCORRELATED one (which
+  /// columns are `Term.parameter` — or `nil` for an uncorrelated one (which
   /// recompiles fresh per run). Keyed by the occurrence's `PlanKey` (its
   /// `Subkey` plus the correlation's parameter names), so two occurrences of
-  /// the SAME inner SQL under DIFFERENT outer layouts — two set-operation arms
-  /// whose correlated column sits at different ordinals — each find their OWN
+  /// the same inner SQL under different outer layouts — two set-operation arms
+  /// whose correlated column sits at different ordinals — each find their own
   /// plan.
   internal func plan(_ key: Subkey, _ correlation: Correlation) -> Plan? {
     memo.plan(PlanKey(key, correlation))
   }
 
-  /// Stashes `plan` as the pre-compiled inner plan of the CORRELATED occurrence
+  /// Stashes `plan` as the pre-compiled inner plan of the correlated occurrence
   /// `key` under `correlation`, for the evaluator to re-execute per outer row.
   internal func record(plan: Plan, for key: Subkey,
                        _ correlation: Correlation) {
@@ -905,7 +905,7 @@ internal struct Subqueries {
   }
 
   /// Whether the reached correlated set-operation fold of occurrence `key` has
-  /// already been strictly re-validated — so a per-row execution folds ONCE and
+  /// already been strictly re-validated — so a per-row execution folds once and
   /// skips the redundant re-fold on subsequent outer rows.
   internal func validated(_ key: Subkey) -> Bool { memo.validated(key) }
 
@@ -923,13 +923,13 @@ internal struct Subqueries {
   }
 }
 
-/// One subquery OCCURRENCE the type-check walk reached — its inner `query`
-/// and the `role` it materialises in AT THAT occurrence.
+/// One subquery occurrence the type-check walk reached — its inner `query`
+/// and the `role` it materialises in at that occurrence.
 ///
-/// The role is recorded PER OCCURRENCE (not derived from the union of every
+/// The role is recorded per occurrence (not derived from the union of every
 /// role the query occupies in the select) so the deferred type-check picks the
-/// occurrence's OWN run shape: an `existential` reach validates the EXISTS
-/// PROBE (no projection), a `scalar`/`valued` reach the original. So the SAME
+/// occurrence's own run shape: an `existential` reach validates the EXISTS
+/// probe (no projection), a `scalar`/`valued` reach the original. So the same
 /// inner SQL reached only as an `EXISTS` validates the probe even where an
 /// unreached arm has it as a scalar.
 internal struct Reach: Hashable, Sendable {
@@ -946,17 +946,17 @@ internal struct Reach: Hashable, Sendable {
   }
 }
 
-/// The mutable set of subquery OCCURRENCES the type-check walk REACHED, shared
-/// by a `SubqueryCheck` by REFERENCE.
+/// The mutable set of subquery occurrences the type-check walk reached, shared
+/// by a `SubqueryCheck` by reference.
 ///
-/// A subquery's inner-query OPERAND validation is DEFERRED to the reachability
+/// A subquery's inner-query operand validation is deferred to the reachability
 /// walk (`Scope.validate`), mirroring the lazy executor: an occurrence in an
 /// unreachable `CASE`/`COALESCE` arm or a short-circuited `AND`/`OR` leg never
 /// validates, exactly as it never runs. The walk cannot itself hold the
-/// borrowing catalog a recursive type-check needs, so as it REACHES each
+/// borrowing catalog a recursive type-check needs, so as it reaches each
 /// occurrence it records the inner query AND its role here; the catalog-bearing
-/// `typecheck` phase reads this set AFTER the walk and type-checks only the
-/// reached occurrences, each in its OWN role's shape. The box is a class so the
+/// `typecheck` phase reads this set after the walk and type-checks only the
+/// reached occurrences, each in its own role's shape. The box is a class so the
 /// reached set survives `SubqueryCheck` being copied by value down the walk —
 /// every copy shares the one box, the same way `ScalarMemo` shares the run's
 /// lazy collapse.
@@ -977,31 +977,31 @@ internal final class ReachedScalars {
 }
 
 /// The validation-side analog of `Resolution` — the seam that lets the dry-run
-/// type-check (`check`) validate the UNCORRELATED inner query an `EXISTS`/`IN
+/// type-check (`check`) validate the uncorrelated inner query an `EXISTS`/`IN
 /// (Q)` nests without itself holding the borrowing catalog.
 ///
 /// `check` runs over escapable resolution surfaces carrying no catalog, yet a
 /// subquery's inner names and routines must be validated against one for schema
 /// validation to match execution — the recurring lesson that the two must not
 /// diverge. The `typecheck` path, where the borrowing catalog and `Context`
-/// ARE in scope, builds this from the maps it fills by validating and compiling
+/// are in scope, builds this from the maps it fills by validating and compiling
 /// every subquery ahead of the `check` walk; a surface with no catalog passes
 /// `.unsupported`, which faults so a subquery reaching such a surface is
 /// rejected rather than passed unvalidated.
 ///
-/// An `EXISTS`/`IN (Q)` inner query is type-checked EAGERLY in that pre-pass
+/// An `EXISTS`/`IN (Q)` inner query is type-checked eagerly in that pre-pass
 /// (its predicate is not short-circuited past, so it always runs), as is every
-/// scalar subquery's cursor-free ARITY and TYPE derivation (TOTAL — a CASE's
+/// scalar subquery's cursor-free arity and type derivation (total — a CASE's
 /// static column type unifies all arms regardless of runtime reachability, and
-/// deriving the type of `1 / 0` yields the integer type WITHOUT dividing). A
-/// scalar subquery's inner-query OPERAND validation is instead DEFERRED: the
+/// deriving the type of `1 / 0` yields the integer type without dividing). A
+/// scalar subquery's inner-query operand validation is instead deferred: the
 /// `.subquery` case of the reachability walk records the reached query into the
 /// shared `reached` box, and the `typecheck` phase validates only those after
 /// the walk — so an unreachable arm's scalar subquery is not validated, exactly
 /// as the executor does not evaluate it.
 internal struct SubqueryCheck {
   /// Each nested `Query` mapped to its compiled column count — the map the
-  /// `typecheck` path builds by compiling every subquery ONCE, ahead of the
+  /// `typecheck` path builds by compiling every subquery once, ahead of the
   /// `check` walk. `check` reads its width to enforce a `IN (Q)`'s or a scalar
   /// subquery's single-column arity.
   private let widths: Dictionary<Query, Int>
@@ -1014,7 +1014,7 @@ internal struct SubqueryCheck {
   /// fold.
   private let types: Dictionary<Query, ValueType>
 
-  /// The scalar inner queries whose OPERAND validation is DEFERRED through the
+  /// The scalar inner queries whose operand validation is deferred through the
   /// `.subquery` case of the walk — a scalar-ONLY occurrence, recorded reached
   /// by `type`. An `IN`/`EXISTS`/quantified occurrence defers through
   /// `validate` instead (its arity/type derivation stays total), so the two
@@ -1026,21 +1026,21 @@ internal struct SubqueryCheck {
   /// reached inner queries.
   private let reached: ReachedScalars
 
-  /// The ENCLOSING scope this select's OWN columns correlate against — the
+  /// The enclosing scope this select's own columns correlate against — the
   /// validation-side analog of `Resolution.outer`, so a correlated column
   /// resolves against the outer query exactly as the run's lowering does,
   /// keeping typecheck↔run parity. `nil` for a top-level select.
   private let outer: Outer?
 
-  /// Whether this surface ADMITS a correlated column — the inner `WHERE`/`ON`
+  /// Whether this surface admits a correlated column — the inner `WHERE`/`ON`
   /// (TRUE) versus a projection / `GROUP BY` / `HAVING` (FALSE, diagnosed) —
   /// the analog of `Resolution.admits`, so validation faults the unsupported
   /// correlated-projection case exactly where the run does.
   private let admits: Bool
 
-  /// Whether the surface admits a correlated column EVERYWHERE — a LATERAL
+  /// Whether the surface admits a correlated column everywhere — a LATERAL
   /// body's validation surface, the analog of `Resolution.everywhere` — so
-  /// `barred` is a NO-OP and the projection/`HAVING` walk of a lateral body
+  /// `barred` is a no-OP and the projection/`HAVING` walk of a lateral body
   /// validates a correlated preceding column rather than faulting, matching the
   /// run's lowering (typecheck↔run parity).
   private let everywhere: Bool
@@ -1067,10 +1067,10 @@ internal struct SubqueryCheck {
     SubqueryCheck()
   }
 
-  /// This checker with correlation BARRED — the surface a projection / `GROUP
+  /// This checker with correlation barred — the surface a projection / `GROUP
   /// BY` / `HAVING` type-checks under, where an outer column is out of the (b)
   /// cut and is diagnosed rather than resolved. Mirrors `Resolution.barred` —
-  /// including the LATERAL-body exception (`everywhere`), where it is a NO-OP
+  /// including the LATERAL-body exception (`everywhere`), where it is a no-OP
   /// so the projection/`HAVING` walk keeps admitting the correlated preceding
   /// column the run's lowering binds.
   internal var barred: SubqueryCheck {
@@ -1079,11 +1079,11 @@ internal struct SubqueryCheck {
                          outer: outer, admits: false, everywhere: everywhere)
   }
 
-  /// This checker over a FRESH `reached` box, carrying `outer` — the surface a
+  /// This checker over a fresh `reached` box, carrying `outer` — the surface a
   /// join `ON` type-checks under. The `ON` shares this select's width/type
   /// derivation and its enclosing `outer` (a correlated `ON` column resolves
   /// against the containing query as the WHERE's does), but the caller runs its
-  /// reachability walk against the join's PREFIX scope (its LOCAL relations),
+  /// reachability walk against the join's prefix scope (its local relations),
   /// so a reference to a later-joined relation faults per the prefix. The fresh
   /// box keeps its reached occurrences separate for the caller to validate
   /// against that prefix.
@@ -1094,7 +1094,7 @@ internal struct SubqueryCheck {
 
   /// The outer type `column` correlates to, or `nil` when no enclosing scope
   /// binds it — the validation-side `Resolution.correlate`: it resolves against
-  /// `outer`, faulting `.unsupported` on a BARRED surface (a projection /
+  /// `outer`, faulting `.unsupported` on a barred surface (a projection /
   /// `GROUP BY` / `HAVING`) so validation rejects the unsupported
   /// correlated-projection case exactly as the run's lowering does, and returns
   /// the outer column's type so `validate` types the reference as that column.
@@ -1111,15 +1111,15 @@ internal struct SubqueryCheck {
 
   /// Asserts the inner `query` was compiled in the pre-pass — a query the
   /// surface's map holds has had its arity/type derived; one it does not
-  /// reached a catalog-less surface and is rejected — and RECORDS it reached in
-  /// `role`, so the `typecheck` phase validates its OPERANDS after the walk in
-  /// that role's shape. This is the WALK-reach point for an
+  /// reached a catalog-less surface and is rejected — and records it reached in
+  /// `role`, so the `typecheck` phase validates its operands after the walk in
+  /// that role's shape. This is the walk-reach point for an
   /// `IN`/`EXISTS`/quantified occurrence: `check` calls it only when the
   /// reachability walk arrives at the `.within`/`.exists`/`.quantified` node,
   /// so an occurrence in a skipped `CASE`/`COALESCE` arm or a short-circuited
   /// `AND`/`OR` leg is never recorded — its body is not type-checked, exactly
-  /// as the lazy executor never materialises it. A REACHED one is validated in
-  /// its OWN role's shape (an `EXISTS` reach → the probe), so a reached bad
+  /// as the lazy executor never materialises it. A reached one is validated in
+  /// its own role's shape (an `EXISTS` reach → the probe), so a reached bad
   /// body still faults (parity both directions), while an unreached arm's role
   /// never widens a reached occurrence's shape.
   internal func validate(_ query: Query, as role: Role) throws(SQLError) {
@@ -1139,16 +1139,16 @@ internal struct SubqueryCheck {
 
   /// The single-column output type `query` contributes as a scalar subquery —
   /// from the pre-pass derive — validating its single-column arity first (else
-  /// `SQLError.arity`, matching the run's lowering). This is the WALK-reached
+  /// `SQLError.arity`, matching the run's lowering). This is the walk-reached
   /// path, so a scalar occurrence whose operand validation was deferred is
-  /// recorded REACHED here, for the `typecheck` phase to validate its inner
-  /// query. The cursor-free arity/type derivation stays SEPARATE and total: the
+  /// recorded reached here, for the `typecheck` phase to validate its inner
+  /// query. The cursor-free arity/type derivation stays separate and total: the
   /// arity of an unreachable scalar was already enforced eagerly in the
   /// pre-pass (`subqueryCheck`), so a two-column subquery in a skipped arm
   /// still faults.
   internal func type(_ query: Query) throws(SQLError) -> ValueType {
-    // A DEFERRED scalar occurrence is REACHED here in the `scalar` role: record
-    // it for the `typecheck` phase to validate its inner query's OPERANDS,
+    // A deferred scalar occurrence is reached here in the `scalar` role: record
+    // it for the `typecheck` phase to validate its inner query's operands,
     // mirroring the lazy executor materialising only a reached scalar. Its
     // arity and single-column type were derived eagerly in `subqueryCheck`
     // (cursor-free, total), so this reads them exactly as an eagerly-checked
@@ -1165,9 +1165,9 @@ internal struct SubqueryCheck {
 
   /// The occurrences the walk reached — the scalar ones recorded by `type` and
   /// the `IN`/`EXISTS`/quantified ones recorded by `validate` — each paired
-  /// with the ROLE it reached in. The `typecheck` phase validates only these
+  /// with the role it reached in. The `typecheck` phase validates only these
   /// after the walk, mirroring the lazy executor's evaluation of only a reached
-  /// subquery, picking each one's RUN shape from ITS OWN reached role (an
+  /// subquery, picking each one's run shape from its own reached role (an
   /// `existential` → the EXISTS probe, a `scalar`/`valued` → the original), not
   /// from the union of every role the query occupies in the select.
   internal var visited: Set<Reach> {
@@ -1195,29 +1195,29 @@ internal func lower(_ predicate: Predicate,
   case let .null(expression, negated):
     try Filter(null: term(expression), negated: negated)
   case let .exists(query, negated):
-    // `[NOT] EXISTS (Q)`. In this first slice `Q` is UNCORRELATED, so the
-    // materialiser runs it ONCE (as a CTE body materialises) and the whole
+    // `[NOT] EXISTS (Q)`. In this first slice `Q` is uncorrelated, so the
+    // materialiser runs it once (as a CTE body materialises) and the whole
     // predicate is the definite non-empty test of that result — never UNKNOWN,
     // `negated` flipping it. A missing materialiser (a lowering surface with no
     // catalog in scope) rejects the subquery rather than mis-lower it.
     try subquery.exists(query, negated: negated)
   case let .within(expression, query, negated):
-    // `x [NOT] IN (Q)`. `Q` is UNCORRELATED here, so the materialiser runs it
-    // ONCE, checks it projects exactly ONE column (else `SQLError.arity`), and
+    // `x [NOT] IN (Q)`. `Q` is uncorrelated here, so the materialiser runs it
+    // once, checks it projects exactly one column (else `SQLError.arity`), and
     // lowers to a `Filter.within` folding `x = v` over that column under the
     // value-list `IN`'s three-valued Kleene `OR`.
     try subquery.within(term(expression), query, negated: negated)
   case let .quantified(expression, op, quantifier, query):
-    // `x op {ANY | ALL} (Q)`. `Q` is UNCORRELATED here, so the materialiser
-    // runs it ONCE, checks it projects exactly ONE column (else
+    // `x op {ANY | ALL} (Q)`. `Q` is uncorrelated here, so the materialiser
+    // runs it once, checks it projects exactly one column (else
     // `SQLError.arity`), and lowers to a `Filter.quantified` folding `x op v`
-    // over that column with the SAME `matches`/Kleene primitives `within` uses
+    // over that column with the same `matches`/Kleene primitives `within` uses
     // — Kleene `OR` for `any`, Kleene `AND` for `all`.
     try subquery.quantified(term(expression), op, quantifier, query)
   case let .membership(expression, values, negated):
     // `x IN (a, b, …)` is the disjunction `x = a OR x = b OR …` and `NOT IN`
     // its negation, lowered to a first-class `Filter.membership` that evaluates
-    // the operand ONCE per row (an OR-chain would re-evaluate a side-effecting
+    // the operand once per row (an OR-chain would re-evaluate a side-effecting
     // operand once per element) and folds the element equalities under Kleene
     // `OR`. That yields the ISO three-valued result: an unmatched test with a
     // NULL operand or a NULL element is UNKNOWN — Kleene `OR` of a FALSE and an
@@ -1226,9 +1226,9 @@ internal func lower(_ predicate: Predicate,
     try membership(term(expression), values, negated: negated, term: term)
   case let .rows(lhs, op, rhs):
     // `(l…) <op> (r…)` lowers to a first-class `Filter.comparison` — the two
-    // rows of EQUAL arity (`SQLError.arity` otherwise), each component lowered
-    // ONCE through `term`. The runtime evaluates every component exactly once
-    // per row and folds the values with the SAME `matches`/Kleene primitives a
+    // rows of equal arity (`SQLError.arity` otherwise), each component lowered
+    // once through `term`. The runtime evaluates every component exactly once
+    // per row and folds the values with the same `matches`/Kleene primitives a
     // scalar comparison uses (a componentwise Kleene `AND` for `=`, its
     // negation for `<>`, the lexicographic cascade for the ordering operators),
     // so a stateful component is read once and the ISO three-valued truth is
@@ -1237,9 +1237,9 @@ internal func lower(_ predicate: Predicate,
     try rows(lhs, op, rhs, term: term)
   case let .among(lhs, rows, negated):
     // `(l…) [NOT] IN ((r…), …)` lowers to a first-class `Filter.memberships` —
-    // the left row and a non-empty list of element rows, all of EQUAL arity
+    // the left row and a non-empty list of element rows, all of equal arity
     // (`SQLError.arity` otherwise, an empty list rejected), each component
-    // lowered ONCE through `term`. The runtime evaluates the left row once per
+    // lowered once through `term`. The runtime evaluates the left row once per
     // row and folds `(l…) = (r…)` over the element rows under Kleene `OR`, so
     // the left components are read once rather than once per element (an
     // OR-chain of row equalities would re-read them), keeping the value-list
@@ -1252,7 +1252,7 @@ internal func lower(_ predicate: Predicate,
     try like(operand, pattern, escape, negated: negated, term: term)
   case let .between(test, low, high, negated):
     // `x [NOT] BETWEEN a AND b` lowers to a first-class `Filter.between` that
-    // evaluates the test `x` ONCE per row (an `AND`/`OR` of two comparisons
+    // evaluates the test `x` once per row (an `AND`/`OR` of two comparisons
     // would re-evaluate a non-idempotent `x`, once per bound) and folds the two
     // bounds against that same value under Kleene logic — a NULL `x`, `a`, or
     // `b` making a bound UNKNOWN and excluding the row, the ISO range test.
@@ -1263,7 +1263,7 @@ internal func lower(_ predicate: Predicate,
   case let .distinct(lhs, rhs, negated):
     // `a IS [NOT] DISTINCT FROM b` lowers to a first-class `Filter.distinct`
     // over the two lowered terms — the null-safe comparison the runtime
-    // evaluates TWO-VALUED, treating NULL as a comparable value. No
+    // evaluates two-valued, treating NULL as a comparable value. No
     // `:parameter` form is defined, so both sides lower straight through
     // `term`.
     try Filter(distinct: term(lhs), term(rhs), negated: negated)
@@ -1288,7 +1288,7 @@ internal func lower(_ predicate: Predicate,
 /// first-class `Filter.membership(left, [v0, v1, …], negated:)`, each value
 /// lowered through `term`.
 ///
-/// The operand is held ONCE rather than copied into an OR-chain of `left = vi`
+/// The operand is held once rather than copied into an OR-chain of `left = vi`
 /// comparisons: that chain re-evaluated `left` per element, so a non-idempotent
 /// operand (a side-effecting scalar call) yielded a different value each
 /// element compared against. The `Filter.membership` runtime evaluates `left`
@@ -1320,9 +1320,9 @@ private func membership(_ left: Term, _ values: Array<Expression>,
 /// Lowers `(l…) <op> (r…)` to a first-class `Filter.comparison(l, op, r)`, the
 /// two rows lowered componentwise through `term`.
 ///
-/// The two rows must be of EQUAL arity (`SQLError.arity` otherwise) — a
+/// The two rows must be of equal arity (`SQLError.arity` otherwise) — a
 /// row-value comparison of unequal rows is undefined. Each component is lowered
-/// ONCE rather than duplicated into a desugared conjunction/cascade of scalar
+/// once rather than duplicated into a desugared conjunction/cascade of scalar
 /// comparisons: that desugar named a component in several places (the `<`
 /// cascade uses each earlier component in both a strict step and an equality
 /// tie-guard), so a non-idempotent component was evaluated more than once. The
@@ -1349,11 +1349,11 @@ private func rows(_ lhs: Array<Expression>, _ op: Comparison,
 /// `Filter.memberships(l, [[r…], …], negated:)`, the left row and each element
 /// row lowered componentwise through `term`.
 ///
-/// The element list must be non-empty and every element row of the SAME arity
+/// The element list must be non-empty and every element row of the same arity
 /// as the left row (`SQLError.arity` otherwise) — as with the scalar value-list
 /// `IN`, the parser rejects `IN ()`, but `Predicate.among` is public, so a
 /// caller can bypass the grammar and this lowering rejects it. The left row's
-/// components are lowered ONCE and held rather than copied into an OR-chain of
+/// components are lowered once and held rather than copied into an OR-chain of
 /// scalar row equalities: that chain re-evaluated the left components once per
 /// element row, so a non-idempotent component yielded a different value each
 /// element compared against. The `Filter.memberships` runtime evaluates the
@@ -1419,10 +1419,10 @@ private func lower(_ operand: Predicate.Operand,
 /// SELECT-list output column it names (when it names one).
 ///
 /// `term` is the value the sort evaluates per record, `ascending` its own
-/// direction. `column` records the 0-based projection column an ORDINAL or an
-/// output ALIAS names — the two forms that reference the select list by
-/// construction — and is `nil` for an ordinary INPUT expression. `shaped`
-/// materialises each projected output ONCE below the sort and orders an output
+/// direction. `column` records the 0-based projection column an ordinal or an
+/// output alias names — the two forms that reference the select list by
+/// construction — and is `nil` for an ordinary input expression. `shaped`
+/// materialises each projected output once below the sort and orders an output
 /// key by that materialised column (`slot(column)`), so a computed output is
 /// sorted on exactly the value it returns rather than recomputed by the sort.
 /// A non-deterministic or stateful routine would otherwise sort on one set of
@@ -1464,14 +1464,14 @@ internal struct SortKey {
 ///
 /// The three sort-key forms resolve as:
 ///
-/// - `ordinal(n)` names the query's `n`-th projected OUTPUT column (1-based).
+/// - `ordinal(n)` names the query's `n`-th projected output column (1-based).
 ///   It resolves to that projection item's already-lowered `Term`
-///   (`projection[n - 1]`) — the SAME expression the select list computes,
+///   (`projection[n - 1]`) — the same expression the select list computes,
 ///   re-used over the source rows the sort runs on — so a bare-column ordinal
 ///   reads its slot and a computed one (`SELECT a + b … ORDER BY 1`) recomputes
 ///   the expression. An `n` outside `1 ... projection.count` faults
 ///   `SQLError.column` (spelled as the ordinal), as an unknown column would.
-/// - `expression(.column(name))` with an unqualified `name` is EITHER an output
+/// - `expression(.column(name))` with an unqualified `name` is either an output
 ///   alias or an input column. A matching output alias wins (the ISO precedence
 ///   for a bare `ORDER BY` name), resolving to that projection item's lowered
 ///   `Term`; absent an alias, the name lowers as an ordinary input column
@@ -1482,7 +1482,7 @@ internal struct SortKey {
 /// `names` are the projection's per-item explicit-`AS` output aliases (else
 /// `nil`), aligned index-for-index with `projection`. Only an explicit `AS`
 /// introduces an alias a bare `ORDER BY` name may bind, so the surface is
-/// REPRESENTATION-INDEPENDENT — a bare projected column contributes no output
+/// representation-independent — a bare projected column contributes no output
 /// name and `ORDER BY` resolves it as an input column whether the projection is
 /// a `columns` or an `expressions` list. An alias two items share has no single
 /// term to order on — the two aliases may compute different values, so the

--- a/Sources/SQLEngine/Schema+Derivation.swift
+++ b/Sources/SQLEngine/Schema+Derivation.swift
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension Catalog where Self: ~Escapable {
-  /// The result columns `query` would yield, named and typed, resolved WITHOUT
+  /// The result columns `query` would yield, named and typed, resolved without
   /// executing it.
   ///
-  /// A union's result columns take their NAMES from the FIRST arm's projection
+  /// A union's result columns take their names from the FIRST arm's projection
   /// (the ISO rule a `UNION` follows), so a union names its result off its
-  /// leading `SELECT`, while their TYPES are UNIFIED across ALL arms (a mixed
+  /// leading `SELECT`, while their types are unified across ALL arms (a mixed
   /// integer/double column widening to `double`, an irreconcilable pair
   /// faulting). The column count matches the compiled plan's `width`; the names
   /// and types come from re-walking the projection exactly as compilation
@@ -24,25 +24,25 @@ extension Catalog where Self: ~Escapable {
   ///     `.integer`, the engine's exact-numeric default.
   ///
   /// The result columns' names come from the first arm and their types unify
-  /// across arms, but ONLY after the WHOLE query validates: `compile` resolves
+  /// across arms, but ONLY after the whole query validates: `compile` resolves
   /// every arm (each `WHERE`,
   /// join, and projection) and cross-checks a `UNION`'s arm arity, without
   /// opening a cursor. So a query whose first arm names its columns cleanly but
   /// whose `WHERE` references a missing column, or whose second `UNION` arm
-  /// mismatches the arity, faults here EXACTLY as a run would rather than
+  /// mismatches the arity, faults here exactly as a run would rather than
   /// returning headers for a query that cannot run.
   ///
   /// `routines` are the scalar functions a run would resolve against — pass the
-  /// SAME set here so a projected call `TAG(Name)` reports its declared return
+  /// same set here so a projected call `TAG(Name)` reports its declared return
   /// type rather than the `.integer` default. It defaults to none, matching a
   /// run with no custom routines.
   ///
   /// `validate` (default `true`) whole-query type-checks before deriving, so a
   /// static shape check faults an ill-typed query a run would only reach with
   /// rows — `SELECT Name + 1 …` reports `SQLError.operand`. Pass `false` when a
-  /// run has ALREADY proved the query runnable (an empty result whose headers
+  /// run has already proved the query runnable (an empty result whose headers
   /// this fills in): the data-dependent filter never reached the projection, so
-  /// re-validating the reachable `Name + 1` would fault a query that SUCCEEDED.
+  /// re-validating the reachable `Name + 1` would fault a query that succeeded.
   /// `compile` still runs either way — it resolves the relations and CTEs the
   /// derive needs and is non-faulting for a runnable query — only the operand
   /// type-check is skipped.
@@ -59,7 +59,7 @@ extension Catalog where Self: ~Escapable {
       throws(SQLError) -> Array<OutputColumn> {
     // Expand any `GROUP BY GROUPING SETS` select to its `UNION ALL` FIRST, so
     // the compile validation and the `columns(unifying:)` derive below see the
-    // SAME expanded AST a run does (`run ≡ columns(of:)`).
+    // same expanded AST a run does (`run ≡ columns(of:)`).
     let query = try query.expanded
     // Pure engine: it types calls against exactly the `routines` given, seeding
     // no prelude. `import SQLStandard` adds a prelude-defaulting overload
@@ -67,7 +67,7 @@ extension Catalog where Self: ~Escapable {
     let context = Context(routines: routines).validating(validate)
     // Extend the scope with any `definition_schema.` store relation the query
     // names, so its result schema resolves the reserved relation the same as a
-    // run would — SCHEMA-ONLY, so typing never triggers the row build. A
+    // run would — schema-ONLY, so typing never triggers the row build. A
     // derived body is validated only when `validate`: a `validate: false`
     // derive after a run trusts the body rather than re-checking a reachable
     // operand a data-dependent filter never reached (matching the non-derived
@@ -80,7 +80,7 @@ extension Catalog where Self: ~Escapable {
     // type-check a derived body in a subquery a data-dependent filter dropped,
     // matching the run's lenient compile.
     _ = try compile(query, scope)
-    // Type-check every REACHABLE operand and call across all arms — the
+    // Type-check every reachable operand and call across all arms — the
     // projection, `WHERE`, and `HAVING` of each. `compile` resolves a call's
     // arguments but cannot check the routine EXISTS or that it is called with
     // its declared arity and argument kinds, and the first-arm walk below
@@ -88,33 +88,33 @@ extension Catalog where Self: ~Escapable {
     // ill-typed call or a bad operand anywhere a run would evaluate it, and —
     // like the executor — skips an arm a `false AND`/`true OR` short-circuits,
     // so a query that runs is not rejected for an unreachable call. A caller
-    // that already RAN the query (`validate: false`) skips it: a reachable
+    // that already ran the query (`validate: false`) skips it: a reachable
     // operand a data-dependent filter never reached would otherwise fault a
     // query that produced its (empty) result.
     if validate { try typecheck(query, scope) }
-    // The result columns' NAMES come from the first arm's projection (the ISO
-    // rule a UNION follows), but their TYPES are UNIFIED across ALL arms — a
+    // The result columns' names come from the first arm's projection (the ISO
+    // rule a UNION follows), but their types are unified across ALL arms — a
     // column mixing `integer` and `double` arms widens to `double`, an
     // irreconcilable pair (text beside a number) faults `SQLError.operand` —
     // resolved against the validated scope; a scalar call types from its
     // routine's declared return type. `validate` rides through so a `SELECT *`
-    // over a view derives the body's types WITHOUT re-type-checking it — the
+    // over a view derives the body's types without re-type-checking it — the
     // view body's own reachable-operand check is gated the same as the outer
     // query's, so a `validate: false` derive faults nowhere.
     return try columns(unifying: query, scope).map(\.column)
   }
 
   /// The result columns `statement` would yield, named and typed, resolved
-  /// WITHOUT executing it — the statement-level entry that keeps a `WITH`'s CTE
+  /// without executing it — the statement-level entry that keeps a `WITH`'s CTE
   /// scope in place.
   ///
   /// A `select` derives exactly as `columns(of query:)` does. A `with` derives
-  /// its TRAILING query against the statement's common table expressions, so a
+  /// its trailing query against the statement's common table expressions, so a
   /// reference the CTEs bind — a `SELECT *` over a CTE, or a name a CTE shadows
   /// off a same-named base relation — resolves against the CTE the run did, not
   /// the base catalog: `WITH t(x) AS (SELECT 1) SELECT * FROM t` reports one
   /// column `x`, even where a base `t` of a different width exists. The scope
-  /// is SCHEMA-ONLY — each CTE contributes its declared column list (typed
+  /// is schema-ONLY — each CTE contributes its declared column list (typed
   /// `.integer`, the default a materialised relation reports) without running
   /// its body — so the derive never opens a cursor, exactly as `columns(of
   /// query:)` never does. A `create` and a `function` name no result, so each
@@ -144,11 +144,11 @@ extension Catalog where Self: ~Escapable {
   }
 
   /// The result columns the trailing `query` of a `WITH` would yield, resolved
-  /// against a SCHEMA-ONLY overlay of the `ctes` in scope.
+  /// against a schema-ONLY overlay of the `ctes` in scope.
   ///
-  /// Each CTE binds a `RelationInstance` of its DECLARED columns with no rows —
+  /// Each CTE binds a `RelationInstance` of its declared columns with no rows —
   /// the schema the run's materialised CTE resolves to (columns from the
-  /// declared list, each typed from its BODY fold and carrying its
+  /// declared list, each typed from its body fold and carrying its
   /// `unconstrained` mask, `kinds(of:)`) — laid into the overlay in source
   /// order so a later CTE, and the trailing query, resolve a name the same
   /// precedence a run applies (a CTE shadows a base relation of the same name).
@@ -161,24 +161,24 @@ extension Catalog where Self: ~Escapable {
   /// `SQLError.redefinition`, the same fault `Engine.with` raises before
   /// materialising, rather than silently shadowing the earlier binding.
   ///
-  /// When `validate`, each CTE BODY is validated before its schema is trusted
-  /// by the SAME code a run drives — `Engine.validate`, the compile-time
+  /// When `validate`, each CTE body is validated before its schema is trusted
+  /// by the same code a run drives — `Engine.validate`, the compile-time
   /// structural check `Engine.with` runs before materialising: the recursive
   /// shape (a recursive reference must be the final `UNION` arm; a
   /// self-reference in the anchor with no same-named base faults
-  /// `SQLError.unsupported`, the recursive shape a run rejects BEFORE
+  /// `SQLError.unsupported`, the recursive shape a run rejects before
   /// materialising) and the declared arity (the compiled body width against the
   /// column list, `SQLError.columns` on a mismatch — the anchor and recursive
   /// arm checked separately, self bound only in the recursive arm). The schema
   /// path also asks that helper to run its reachable-operand type-check
-  /// (`typecheck: true` — the run defers this to execution, so it stays OFF the
-  /// run path): folding it in rather than layering it here keeps ONE per-arm
-  /// scoping for both, so a recursive CTE's ANCHOR is operand-checked against
+  /// (`typecheck: true` — the run defers this to execution, so it stays off the
+  /// run path): folding it in rather than layering it here keeps one per-arm
+  /// scoping for both, so a recursive CTE's anchor is operand-checked against
   /// the base scope the run evaluates it in, NOT the CTE-self overlay. So a
   /// dry-run schema is advertised only for a `WITH` that could actually run,
   /// never for one whose body's shape or width contradicts its declared list —
   /// nor for one whose reachable operand a run would fault. When `validate` is
-  /// `false` — a derive after a successful run — the bodies are TRUSTED, not
+  /// `false` — a derive after a successful run — the bodies are trusted, not
   /// compiled: the run already proved them consistent, and re-checking a
   /// data-dependent-empty body would fault a statement that succeeded.
   private borrowing func columns(of query: Query, with ctes: Array<CTE>,
@@ -186,17 +186,17 @@ extension Catalog where Self: ~Escapable {
                                  validate: Bool)
       throws(SQLError) -> Array<OutputColumn> {
     // Expand any `GROUP BY GROUPING SETS` in the trailing query to its `UNION
-    // ALL` FIRST, so this schema derive sees the SAME AST the run does: the run
-    // WITH path (`with` then `run(query:)`) normalizes there. The CTE BODIES
+    // ALL` FIRST, so this schema derive sees the same AST the run does: the run
+    // WITH path (`with` then `run(query:)`) normalizes there. The CTE bodies
     // expand within `typed`/`validate`/`contributions`.
     let query = try query.expanded
     let context = Context(routines: routines).validating(validate)
-    // Type the CTEs into a SCHEMA-ONLY overlay (`rows: false`) through the ONE
+    // Type the CTEs into a schema-ONLY overlay (`rows: false`) through the one
     // producer the run path also drives — `Engine.typed(ctes:in:rows:)` — so
     // the redefinition guard, the shared `validate` (its `typecheck: true`
     // riding this context's `validate` gate — a `validate: false` post-run
-    // derive TRUSTS the bodies and skips it), and the per-CTE `kinds` carrier
-    // derivation all run through the SAME walk a run does. Each CTE binds its
+    // derive trusts the bodies and skips it), and the per-CTE `kinds` carrier
+    // derivation all run through the same walk a run does. Each CTE binds its
     // declared columns with no rows, laid in source order, so a later CTE and
     // the trailing query resolve a name the precedence a run applies.
     let overlay = try typed(ctes: ctes, in: context, rows: false)
@@ -209,7 +209,7 @@ extension Catalog where Self: ~Escapable {
     // the non-`WITH` path does: a `validate: false` derive after a successful
     // run must NOT eager-type-check a derived body in the trailing query — a
     // data-dependent body expression a filter drops (`FROM (SELECT Label + 1 AS
-    // x FROM K WHERE k = 0) AS d`) is TRUSTED, not rejected, matching the run.
+    // x FROM K WHERE k = 0) AS d`) is trusted, not rejected, matching the run.
     // `validate: true` keeps the strict schema check.
     let base = context.body(overlay)
     _ = try compile(query, base)
@@ -220,7 +220,7 @@ extension Catalog where Self: ~Escapable {
   /// The result columns of a single `select`, resolved against this catalog
   /// with the in-scope `ctes` — the per-arm worker `columns(of:)` drives.
   ///
-  /// This NAMES AND TYPES the projection; it does not re-validate the WHERE,
+  /// This names AND types the projection; it does not re-validate the WHERE,
   /// joins, GROUP BY, HAVING, or ORDER BY. Whole-query validation belongs to
   /// `compile` — the public `columns(of query:)` runs it — so this worker never
   /// duplicates (and never drifts from) that resolution. It runs only after
@@ -240,7 +240,7 @@ extension Catalog where Self: ~Escapable {
   /// constant NULL — the per-arm worker the set-operation fold
   /// (`columns(unifying:_:)`) drives.
   ///
-  /// This NAMES AND TYPES the projection and marks its constant-NULL columns;
+  /// This names AND types the projection and marks its constant-NULL columns;
   /// it does not re-validate the WHERE, joins, GROUP BY, HAVING, or ORDER BY.
   /// Whole-query validation belongs to `compile` — the public `columns(of
   /// query:)` runs it — so this worker never duplicates (and never drifts from)
@@ -253,32 +253,32 @@ extension Catalog where Self: ~Escapable {
   /// proved runnable.
   private borrowing func arms(of select: Select, _ context: Context)
       throws(SQLError) -> Array<ResolvedColumn> {
-    // Bind THIS select's own FROM/JOIN derived tables (and store relations)
+    // Bind this select's own FROM/JOIN derived tables (and store relations)
     // before deriving either the subquery map or the scope — a set-op ARM
     // reaches here directly (`columns(unifying: query, …)`), and the top-level
-    // augment collected NO arm-local aliases (arms are SELECT-scoped), so a
+    // augment collected no arm-local aliases (arms are SELECT-scoped), so a
     // subquery naming the arm's own derived alias (`WHERE Id IN (SELECT Id FROM
     // d)`) would else compile against a scope missing `d`. Schema-only, no
     // cursor; `validate` gates a derived body's own operand check.
     let augmented = try augment(context, for: .select(select), rows: false)
     // A scalar subquery in the projection derives its type from its inner
-    // query's single column, so build the SAME cursor-free `Resolution` map the
-    // compile path's lowering reads — every nested subquery compiled ONCE for
+    // query's single column, so build the same cursor-free `Resolution` map the
+    // compile path's lowering reads — every nested subquery compiled once for
     // its width and single-column type, each discovering its correlation
     // against this select's own scope (`enclosing`) — and pass it to the
     // projection walk so an output type for a `(SELECT …)` matches the type the
-    // run advertises. The projection walk is BARRED (a correlated column of
-    // THIS query in the projection is diagnosed, as the run's projection
-    // lowering bars it). Resolve over the AUGMENTED context so a subquery
+    // run advertises. The projection walk is barred (a correlated column of
+    // this query in the projection is diagnosed, as the run's projection
+    // lowering bars it). Resolve over the augmented context so a subquery
     // naming this select's own arm-local derived alias binds it, while
-    // `subquery(of:)` REVEALS the base so the subquery's OWN FROM sees no
+    // `subquery(of:)` reveals the base so the subquery's own FROM sees no
     // derived alias (a CTE a same-named derived alias shadows resolved beneath
     // the dropped layer).
     let scope = try scope(of: select, augmented)
-    // Pass each join's PREFIX scope so an `ON`'s subquery correlates against
-    // its prefix and the WHERE's against the full scope — the SAME
+    // Pass each join's prefix scope so an `ON`'s subquery correlates against
+    // its prefix and the WHERE's against the full scope — the same
     // per-occurrence resolution the run path uses, so a name a WHERE subquery
-    // finds ambiguous in the full scope faults HERE too (typecheck↔run parity),
+    // finds ambiguous in the full scope faults here too (typecheck↔run parity),
     // not silently reusing an `ON` occurrence's narrower prefix.
     let prefixes = try prefixes(of: select, augmented)
     // These derivations lower under `.caller` — a schema-only type derive keys
@@ -286,39 +286,39 @@ extension Catalog where Self: ~Escapable {
     // scope the incoming context may carry.
     let plans = try subquery(of: select, augmented.scoped(as: .caller),
                              enclosing: scope, prefixes: prefixes)
-    // ONE walk yields each column's name, type, AND `unconstrained` mask
+    // one walk yields each column's name, type, AND `unconstrained` mask
     // together — a constant-NULL projection or a reference to an unconstrained
-    // (LOCAL or CORRELATED) source column carries the mask through the same
+    // (local or correlated) source column carries the mask through the same
     // resolution as the type, so the two cannot diverge. The projection walk is
-    // BARRED (a correlated column of THIS query in the projection is diagnosed,
+    // barred (a correlated column of this query in the projection is diagnosed,
     // as the run's projection lowering bars it).
     return try scope.columns(of: select.projection, augmented.routines,
                              subquery: plans.rest.barred)
   }
 
-  /// The output columns of `query`, TYPE-UNIFIED across every set-operation arm
+  /// The output columns of `query`, type-unified across every set-operation arm
   /// — the ISO rule a `UNION`/`INTERSECT`/`EXCEPT` result columns follow.
   ///
   /// A bare `SELECT` types off its own projection. A `setop` node folds its two
-  /// arms column-wise: each result column takes the LEFT (first) arm's NAME
+  /// arms column-wise: each result column takes the LEFT (first) arm's name
   /// (the ISO rule — a union names its columns off its leading `SELECT`) and
-  /// the MERGE of the two arms' types (`merge` — like types pass through, a
+  /// the merge of the two arms' types (`merge` — like types pass through, a
   /// mixed integer/double pair widens to `double`, an irreconcilable pair
   /// faults `SQLError.operand`). A left-associative chain composes
-  /// automatically. A column an arm projects as a CONSTANT NULL places NO type
+  /// automatically. A column an arm projects as a constant NULL places no type
   /// constraint (a NULL unifies with any typed arm), so the fold carries the
-  /// OTHER arm's type and unconstrained-ness up unchanged, mirroring
-  /// `COALESCE`'s constant-NULL skip. The arm ARITY is proved equal by
+  /// other arm's type and unconstrained-ness up unchanged, mirroring
+  /// `COALESCE`'s constant-NULL skip. The arm arity is proved equal by
   /// `compile` before this runs, so the column-wise zip is safe.
   ///
   /// Each returned `ResolvedColumn` carries the unified column AND whether it
-  /// is constant NULL in EVERY arm folded so far — the value coercion paths
+  /// is constant NULL in every arm folded so far — the value coercion paths
   /// read the `type`, and a further enclosing fold reads `unconstrained`.
   borrowing func columns(unifying query: Query, _ context: Context)
       throws(SQLError) -> Array<ResolvedColumn> {
     switch query {
     case let .select(select):
-      // A `GROUP BY GROUPING SETS (…)` derives its schema through the SAME
+      // A `GROUP BY GROUPING SETS (…)` derives its schema through the same
       // `UNION ALL` expansion the compile path uses, so the run and the derived
       // columns cannot diverge (`run ≡ columns(of:)`): the arms' NULL-padded
       // columns type through the set-operation `merge` exactly as the run's do.
@@ -327,24 +327,24 @@ extension Catalog where Self: ~Escapable {
       }
       return try arms(of: select, context)
     case let .ordered(inner, _, _, _, generated):
-      // The `ordered` carrier is TRANSPARENT to the result schema: `ORDER BY`,
+      // The `ordered` carrier is transparent to the result schema: `ORDER BY`,
       // `DISTINCT`, and `OFFSET`/`FETCH` are row operators — they do NOT
       // project — so the result columns are the inner setop's arm-0-named,
       // unified ones whether reached via `run`/`compile` or `columns(of:)`
-      // (`run ≡ columns`). The one exception is a HIDDEN materialised sort
+      // (`run ≡ columns`). The one exception is a hidden materialised sort
       // column (`expand` appends `generated` of them to every arm so an
       // unprojected `ORDER BY MAX(x)` survives the union at equal arity): the
-      // carrier's compile TRIMS them through the identity projection, so drop
+      // carrier's compile trims them through the identity projection, so drop
       // the matching trailing columns here too so the schema matches the run.
-      // The count is the STRUCTURAL `generated` the carrier carries, never a
+      // The count is the structural `generated` the carrier carries, never a
       // scan of the arm-0 names for a synthetic prefix — a user's delimited
       // `AS "*gs0"` is a real output, not a generated column.
       let cols = try columns(unifying: inner, context)
       // Range-check `generated` against the width and take the trim width
-      // through the SHARED guard the compile carrier uses (`real(trimming:of:)`
-      // on Engine) BEFORE trimming: a public-AST count past the width makes
-      // `cols.count − generated` NEGATIVE and `Array.prefix` PRECONDITION-TRAPS
-      // the process, while a NEGATIVE count returns ALL columns untrimmed —
+      // through the shared guard the compile carrier uses (`real(trimming:of:)`
+      // on Engine) before trimming: a public-AST count past the width makes
+      // `cols.count − generated` negative and `Array.prefix` precondition-traps
+      // the process, while a negative count returns ALL columns untrimmed —
       // silently wrong and diverging from `run`, which faults the same XX000.
       // One guard, one message ⇒ `columns(of:) ≡ run` on a malformed carrier.
       let real = try real(trimming: generated, of: cols.count)
@@ -352,12 +352,12 @@ extension Catalog where Self: ~Escapable {
     case let .setop(_, left, right, _):
       let l = try columns(unifying: left, context)
       let r = try columns(unifying: right, context)
-      // A NESTED set operation's arm mismatch is faulted HERE, before the
+      // A nested set operation's arm mismatch is faulted here, before the
       // column-wise merge indexes both arms — `compile` cross-checks the
       // outer widths but the fold descends into child nodes it has not yet
       // validated, so an unguarded `r[index]` would trap rather than fault.
       guard l.count == r.count else { throw .arity(l.count, r.count) }
-      // The operand-compatibility fold DEFERS under the shape pre-pass
+      // The operand-compatibility fold defers under the shape pre-pass
       // (`context.shape`): a nested subquery's set-operation type is recorded
       // ahead of the reachability walk, so an unreached incompatible pair
       // yields a discardable placeholder rather than faulting; a reached
@@ -368,7 +368,7 @@ extension Catalog where Self: ~Escapable {
     }
   }
 
-  /// The unified column TYPES of `query`, folded across every set-operation arm
+  /// The unified column types of `query`, folded across every set-operation arm
   /// — the types each producer path coerces its arms' values to so a set
   /// operation's result carries the common column type (`SELECT 1 UNION SELECT
   /// 2.5` a `double` column). It is the type projection of
@@ -378,15 +378,15 @@ extension Catalog where Self: ~Escapable {
     try columns(unifying: query, context).map(\.type)
   }
 
-  /// The SINGLE deriver of a relation body's resolved output columns: the
-  /// columns UNIFIED across every set-operation arm (the ISO rule a
+  /// The single deriver of a relation body's resolved output columns: the
+  /// columns unified across every set-operation arm (the ISO rule a
   /// `UNION`/`INTERSECT`/`EXCEPT` follows), named off the first arm and typed
   /// across all of them, each carrying its `unconstrained` mask — the
   /// `ResolvedColumn` carrier every body-derived binding is constructed from.
   ///
   /// Every binding site that folds a body into a `RelationInstance`/`Schema` —
   /// a derived table's `materialise`, a view's schema resolution — obtains its
-  /// columns HERE, never by re-deriving the projection inline, so the
+  /// columns here, never by re-deriving the projection inline, so the
   /// per-column `unconstrained` mask threads through all of them from one place
   /// via the single `init(from:)` constructor and no site can drop it.
   borrowing func resolved(query body: Query, in context: Context)
@@ -394,9 +394,9 @@ extension Catalog where Self: ~Escapable {
     try columns(unifying: body, context)
   }
 
-  /// The column CARRIER a CTE binds under — its DECLARED column names (a CTE is
+  /// The column carrier a CTE binds under — its declared column names (a CTE is
   /// addressed by its declared list, `WITH t(x) AS …` exposes `x`, never the
-  /// body's own projected name) carrying each column's BODY-folded type (never
+  /// body's own projected name) carrying each column's body-folded type (never
   /// the `.integer` placeholder) and whether every arm feeding it projects a
   /// constant NULL, so it places no type constraint. A recursive `UNION` CTE
   /// unifies the anchor's columns (self not in scope) with the recursive arm's
@@ -404,7 +404,7 @@ extension Catalog where Self: ~Escapable {
   /// folds its own. A trusted derive (a `validate: false` body a filter drops)
   /// that faults falls back to the placeholder.
   ///
-  /// The result is always the CTE's DECLARED width (`cte.columns.count`): a
+  /// The result is always the CTE's declared width (`cte.columns.count`): a
   /// body whose fold yields a different count is reconciled to it (padding a
   /// short fold with the `.integer` default, truncating a long one), so a
   /// caller building the CTE binding from it indexes a same-length carrier
@@ -413,7 +413,7 @@ extension Catalog where Self: ~Escapable {
       throws(SQLError) -> Array<ResolvedColumn> {
     let derived = try contributions(of: cte, scope)
     let sized = reconcile(derived, to: cte.columns.count, named: cte.columns)
-    // Bind under the CTE's DECLARED names, keeping each column's body-folded
+    // Bind under the CTE's declared names, keeping each column's body-folded
     // type and `unconstrained` mask, so `WITH t(x) AS (SELECT 1 AS n)` is
     // addressed as `x` while `x` carries the body's derived type.
     return sized.indices.map {
@@ -422,27 +422,27 @@ extension Catalog where Self: ~Escapable {
     }
   }
 
-  /// The raw column carrier a CTE's body folds to, BEFORE reconciling to the
+  /// The raw column carrier a CTE's body folds to, before reconciling to the
   /// declared width — the recursive-aware merge `kinds` wraps.
   private borrowing func contributions(of cte: CTE, _ scope: Context)
       throws(SQLError) -> Array<ResolvedColumn> {
-    // Recognise the recursive `UNION` shape through the CANONICAL peel
-    // (`recursiveArms` — unwound), the SAME recogniser the run/validate/
+    // Recognise the recursive `UNION` shape through the canonical peel
+    // (`recursiveArms` — unwound), the same recogniser the run/validate/
     // fixpoint recursive-CTE seams take (`CTE.recurses`, `fixpoint`'s
     // `canonical`), so the schema derive inspects the identical AST the run
     // does — a trailing `ORDER BY`/`OFFSET`·`FETCH`/`DISTINCT` carrier peeled
     // off. Otherwise a carried recursive union would fall through to the non-
-    // recursive fold with the self UNBOUND and fault `.relation`, diverging
+    // recursive fold with the self unbound and fault `.relation`, diverging
     // from the run that iterates the fixpoint. The carrier is transparent to
     // the derived schema (its row operators do not project), so peeling it
     // yields the same columns.
     guard let (anchor, recursive, _) = try cte.recursiveArms else {
-      // A non-recursive body's carrier is its unified fold, PROPAGATING a
+      // A non-recursive body's carrier is its unified fold, propagating a
       // genuine incompatibility (`SELECT 'b' UNION SELECT 1`) as `.operand`
       // rather than swallowing it into the declared `.integer`: with every
-      // placeholder now marked unconstrained, a trusted body that RAN carries
+      // placeholder now marked unconstrained, a trusted body that ran carries
       // no genuine incompat to fault, so no `try?` fallback is needed. Derive
-      // types off the SAME expanded AST a run does: a `GROUP BY GROUPING SETS`
+      // types off the same expanded AST a run does: a `GROUP BY GROUPING SETS`
       // body expands to its `UNION ALL` arms FIRST, so the schema fold matches
       // `run`/`compile` (run and `columns(of:)` cannot diverge). The carrier is
       // transparent to a non-recursive body's fold too — the `.ordered` case of
@@ -450,7 +450,7 @@ extension Catalog where Self: ~Escapable {
       return try columns(unifying: cte.query.expanded, scope)
     }
     let seeds = try columns(unifying: anchor, scope)
-    // The recursive arm addresses the self by the CTE's DECLARED names (`SELECT
+    // The recursive arm addresses the self by the CTE's declared names (`SELECT
     // n + 1 FROM t` reads `n`), so bind the schema-only self under those names
     // carrying the anchor's derived types/mask, not the anchor's own projected
     // names. The anchor's width is proved against the declared list before this
@@ -478,7 +478,7 @@ extension Catalog where Self: ~Escapable {
   /// `contributions` reconciled to exactly `count` columns — the declared width
   /// a caller binds the CTE under. A fold that yields fewer columns is padded
   /// with a fabricated `.integer` placeholder (named from `names` where one
-  /// exists) marked UNCONSTRAINED, since it is not a genuine derivation, a
+  /// exists) marked unconstrained, since it is not a genuine derivation, a
   /// longer one truncated, so the built binding's type and unconstrained arrays
   /// always match the declared column list's length whatever a malformed body
   /// derives.
@@ -502,25 +502,25 @@ extension Catalog where Self: ~Escapable {
   /// reachable-operand check the same as the outer query's.
   borrowing func scope(of select: Select, _ context: Context)
       throws(SQLError) -> Scope {
-    // Bind THIS select's own FROM/JOIN derived tables (and store relations)
+    // Bind this select's own FROM/JOIN derived tables (and store relations)
     // before resolving its relations — SELECT-scoped, so a subquery select
     // whose schema is derived directly here (a scalar subquery's output type)
-    // resolves its OWN aliases. Schema-only: `scope` reads no cursor. `visited`
+    // resolves its own aliases. Schema-only: `scope` reads no cursor. `visited`
     // carries the cyclic-view guard into a derived body's materialise, and
     // `validate` gates that body's own reachable-operand check the same as the
     // outer query's — a `validate: false` derive trusts a run-proven body.
     let context = try augment(context, for: .select(select), rows: false)
     guard let relation = select.from else { return Scope([]) }
-    // Build the running scope INCREMENTALLY so a LATERAL join's schema derives
-    // against the PRECEDING FROM — per ISO its projection may name a preceding
+    // Build the running scope incrementally so a LATERAL join's schema derives
+    // against the preceding FROM — per ISO its projection may name a preceding
     // column, so its output shape types from that scope. A non-lateral join's
     // schema is correlation-independent, so the preceding scope is harmless.
     var relations = [(relation, try schema(of: relation, context))]
     for index in select.joins.indices {
-      // The PRECEDING scope carries the merged columns the joins before this
-      // one expose (`prefix(through:)`) — the SAME one-merge path the run's
+      // The preceding scope carries the merged columns the joins before this
+      // one expose (`prefix(through:)`) — the same one-merge path the run's
       // resolve loop threads — so a LATERAL body's schema derives its bare
-      // merged references against the ONE coalesced column rather than the two
+      // merged references against the one coalesced column rather than the two
       // physical join columns.
       let preceding =
           try prefix(through: index, over: relations, select.joins)
@@ -529,27 +529,27 @@ extension Catalog where Self: ~Escapable {
       relations.append((select.joins[index].relation, joined))
     }
     // Model the `NATURAL`/`USING` merged columns (ISO 9075 7.10) in the scope
-    // so the schema path names and types the SAME output columns the run's
+    // so the schema path names and types the same output columns the run's
     // `compile` projects — a bare merged column resolves to the coalesce type,
-    // and a `SELECT *` exposes it ONCE. Empty for a chain with no named-column
+    // and a `SELECT *` exposes it once. Empty for a chain with no named-column
     // join, so an ordinary scope is unchanged.
     let merged = try merges(over: relations, select.joins).merged
     return Scope(relations, merged: merged)
   }
 
-  /// The PREFIX scope of each join of `select` — join `index`'s prefix is the
-  /// FROM relation and joins `0…index`, the relations available AT that join
-  /// point, never one joined LATER. A join `ON`'s subquery correlates against
+  /// The prefix scope of each join of `select` — join `index`'s prefix is the
+  /// FROM relation and joins `0…index`, the relations available at that join
+  /// point, never one joined later. A join `ON`'s subquery correlates against
   /// its prefix (so a reference to a later-joined relation faults), matching
   /// the compile path's `subquery(of:)`. Empty for a FROM-less or join-less
   /// select.
   private borrowing func prefixes(of select: Select, _ context: Context)
       throws(SQLError) -> Array<Scope> {
     guard let relation = select.from, !select.joins.isEmpty else { return [] }
-    // Build the running scope INCREMENTALLY so a LATERAL join's schema derives
-    // against the PRECEDING FROM (the same reason `scope(of:)` does), the
+    // Build the running scope incrementally so a LATERAL join's schema derives
+    // against the preceding FROM (the same reason `scope(of:)` does), the
     // preceding scope carrying the joins-before's merged columns through the
-    // ONE merge path (`prefix(through:)`).
+    // one merge path (`prefix(through:)`).
     var relations = [(relation, try schema(of: relation, context))]
     for index in select.joins.indices {
       let preceding =
@@ -558,7 +558,7 @@ extension Catalog where Self: ~Escapable {
                               preceding: preceding)
       relations.append((select.joins[index].relation, joined))
     }
-    // Each join's prefix carries the merged columns accumulated BEFORE it (the
+    // Each join's prefix carries the merged columns accumulated before it (the
     // same `merges` the run's `compile` threads), so an `ON` subquery's bare
     // merged outer operand resolves the same way the run does.
     let merges = try merges(over: relations, select.joins).prefixes
@@ -568,25 +568,25 @@ extension Catalog where Self: ~Escapable {
   }
 
   /// Type-checks every operand in `query` — the projection, `WHERE`, and
-  /// `HAVING` of EVERY arm — throwing the run-time fault a bad operand would.
+  /// `HAVING` of every arm — throwing the run-time fault a bad operand would.
   ///
-  /// The result schema DERIVES each arm's projection type (unifying them across
+  /// The result schema derives each arm's projection type (unifying them across
   /// arms), but that non-faulting derive does not exercise a later arm's or a
-  /// `HAVING`'s REACHABLE-operand check — `SELECT Age FROM t UNION SELECT Name
+  /// `HAVING`'s reachable-operand check — `SELECT Age FROM t UNION SELECT Name
   /// + 1 FROM t` or `… HAVING SUM(Name) > 0` resolves its names but
   /// `Arithmetic.apply`/`Aggregate.fold` faults `SQLError.operand` at run.
   /// `compile` cannot catch this (no evaluating term is built), so a schema
   /// path type-checks each arm before returning metadata. It reads no cursor.
   borrowing func typecheck(_ query: Query, _ context: Context)
       throws(SQLError) {
-    // Bind the derived tables (and store relations) THIS query names in its own
+    // Bind the derived tables (and store relations) this query names in its own
     // FROM/JOIN before type-checking its arms — SELECT-scoped, so a subquery
-    // type-checked through here (e.g. from `subqueryCheck`) resolves its OWN
+    // type-checked through here (e.g. from `subqueryCheck`) resolves its own
     // aliases. Schema-only (`rows: false`): the type-check reads no cursor.
     // `visited` carries the cyclic-view guard into a derived body's derive.
     // A nested subquery's FROM sees base tables and enclosing CTEs, NOT this
     // query's derived aliases — its type-check lowers against the base
-    // `subqueryCheck` REVEALS from the augmented `context` (enclosing derived
+    // `subqueryCheck` reveals from the augmented `context` (enclosing derived
     // aliases dropped, CTEs and store kept, a shadowed CTE preserved).
     // The type-check subtree resolves its scopes strictly (`validate: true`),
     // as its internal `scope`/`prefixes`/`schema` calls always did — force it
@@ -605,18 +605,18 @@ extension Catalog where Self: ~Escapable {
       // The `ordered` carrier's row operators add no expression the arms carry
       // — the inner union type-checks every reachable operand of its own arms.
       try typecheck(inner, context)
-      // But the carrier's OWN `ORDER BY` keys are a NEW expression surface,
+      // But the carrier's own `ORDER BY` keys are a new expression surface,
       // validated ONLY by the carrier compile (`ordered(…)` under `validate`).
-      // A REACHED scalar/`IN` subquery whose body is an ordered set operation
+      // A reached scalar/`IN` subquery whose body is an ordered set operation
       // is first compiled in the shape pre-pass with `validating(false)`, which
-      // BYPASSES that check, and is re-validated through THIS seam — so unless
+      // bypasses that check, and is re-validated through this seam — so unless
       // the carrier's keys are validated here too, an outer `columns(of:)`
-      // ACCEPTS a reached `(… UNION … ORDER BY missing(a))` a run FAULTS
+      // accepts a reached `(… UNION … ORDER BY missing(a))` a run faults
       // (run-vs-validate divergence). Re-run the carrier compile in validate
-      // mode to validate the sort keys against the setop-output scope EXACTLY
+      // mode to validate the sort keys against the setop-output scope exactly
       // as `ordered(…)` does — the plan is discarded, only the keys' fault
       // matters. It is idempotent with the top-level `compile` (which already
-      // validated the same keys), and REACHED-only: an unreached ordered
+      // validated the same keys), and reached-only: an unreached ordered
       // subquery never enters this seam, so its bad sort key stays deferred,
       // matching the dead-scalar/dead-EXISTS posture.
       _ = try ordered(inner, distinct: distinct, order: order, limit: limit,
@@ -635,24 +635,24 @@ extension Catalog where Self: ~Escapable {
   ///   - A statically-false `WHERE` filters every row, so a `GROUP BY` forms no
   ///     group and a non-aggregate query yields no row — nothing after it is
   ///     checked. A whole-result aggregate (no `GROUP BY`) is the exception: it
-  ///     emits one empty group, so its `HAVING` and projection are EVALUATED
+  ///     emits one empty group, so its `HAVING` and projection are evaluated
   ///     over that group (`empty`) — a divide, overflow, or bad routine call
   ///     faults as a run would; an aggregate operand (zero rows) does not.
-  ///   - Otherwise the aggregate FOLDS in the projection and `HAVING` run over
+  ///   - Otherwise the aggregate folds in the projection and `HAVING` run over
   ///     the filtered rows in the group node, before `HAVING` and any limit, so
   ///     every aggregate operand is validated unconditionally (a short-circuit
   ///     or zero-row limit does not spare it).
   ///   - `HAVING` filters grouped rows before the limit: it validates
   ///     short-circuit aware, and a statically false `HAVING` (like a false
   ///     `WHERE`) leaves the projection's non-aggregate work unreachable.
-  ///   - The projection runs LAST: a limit that drops every row it would yield
+  ///   - The projection runs last: a limit that drops every row it would yield
   ///     leaves its non-aggregate work unreachable — a `FETCH FIRST 0 ROWS
   ///     ONLY`, or a positive `OFFSET` over a whole-result aggregate's sole row
-  ///     (its output type is still DERIVED for the schema, non-faulting);
+  ///     (its output type is still derived for the schema, non-faulting);
   ///     otherwise it validates fully.
-  /// A `SubqueryCheck` for a `select` — every UNCORRELATED subquery it nests
-  /// recursively TYPE-CHECKED against the SAME shape the run evaluates and
-  /// compiled for its arity ONCE, ahead of the `check` walk, into a map `check`
+  /// A `SubqueryCheck` for a `select` — every uncorrelated subquery it nests
+  /// recursively type-checked against the same shape the run evaluates and
+  /// compiled for its arity once, ahead of the `check` walk, into a map `check`
   /// reads. Validating and compiling each subquery here — where the borrowing
   /// catalog is in scope — mirrors the run path's lowering (which resolves and
   /// materialises the inner query), so schema validation matches execution: a
@@ -660,54 +660,54 @@ extension Catalog where Self: ~Escapable {
   /// single-column arity is enforced from the compiled width.
   ///
   /// An `IN (Q)` occurrence (its `Query` in `select.valued`) has its select
-  /// list READ at run, so its ORIGINAL shape is type-checked — an `IN (SELECT
+  /// list read at run, so its original shape is type-checked — an `IN (SELECT
   /// 1 / 0 FROM S)` faults `.divide` as the run does. An occurrence ONLY an
-  /// `EXISTS` operand runs through the cardinality PROBE (`Select.probe`:
+  /// `EXISTS` operand runs through the cardinality probe (`Select.probe`:
   /// constant projection, `DISTINCT` quantifier and original `OFFSET`/`FETCH`
   /// kept, `ORDER BY` dropped), which never evaluates the original select list
-  /// or sort keys — so its PROBED shape is type-checked, matching the run:
+  /// or sort keys — so its probed shape is type-checked, matching the run:
   /// `EXISTS (SELECT 1 / 0 FROM S)` does NOT fault `.divide` at validate,
-  /// exactly as it does not at run, while a bad inner RELATION or `WHERE`
-  /// (retained by the probe) still faults. A `Query` used by BOTH is in
+  /// exactly as it does not at run, while a bad inner relation or `WHERE`
+  /// (retained by the probe) still faults. A `Query` used by both is in
   /// `valued`, so its original is checked (the `IN` needs its values). The
   /// probe applies only to a `probable` `SELECT` — the shape `probe` rewrites
-  /// (a non-set-operation select WITHOUT a `HAVING` that is non-`DISTINCT` or
-  /// `DISTINCT` WITHOUT an `OFFSET`, its target the constant `1` or, for an
+  /// (a non-set-operation select without a `HAVING` that is non-`DISTINCT` or
+  /// `DISTINCT` without an `OFFSET`, its target the constant `1` or, for an
   /// aggregate/grouped one, a cardinality-preserving `COUNT(*)`); any other
   /// EXISTS-only query (a `HAVING` or set operation) runs in FULL, so its
-  /// original is checked. The arity width is always the ORIGINAL query's
+  /// original is checked. The arity width is always the original query's
   /// (cursor-free), as `subquery(of:)` records it on the compile path.
   private borrowing func subqueryCheck(of select: Select, _ context: Context,
                                        enclosing: Scope? = nil,
                                        prefixes: Array<Scope> = [])
       throws(SQLError) -> SubqueryCheck {
-    // Every occurrence's inner-query OPERAND validation DEFERS to the
+    // Every occurrence's inner-query operand validation defers to the
     // reachability walk, mirroring the lazy executor: a subquery in an
     // unreachable `CASE`/`COALESCE` arm or a short-circuited `AND`/`OR` leg is
-    // never materialised, so a THROWING operand (`1 / 0`) the type-check finds
-    // must not fault an arm the run skips. A SCALAR occurrence's operands defer
+    // never materialised, so a throwing operand (`1 / 0`) the type-check finds
+    // must not fault an arm the run skips. A scalar occurrence's operands defer
     // through the `.subquery` case of the walk (`SubqueryCheck.type` records it
     // reached), an `IN`/`EXISTS`/quantified one through the `.within`/`.exists`
-    // case (`SubqueryCheck.validate` records it) — each validated in its RUN
-    // shape after the walk: an `IN`'s ORIGINAL (its select list is read), an
-    // EXISTS-only occurrence's cardinality PROBE. A REACHED bad body still
+    // case (`SubqueryCheck.validate` records it) — each validated in its run
+    // shape after the walk: an `IN`'s original (its select list is read), an
+    // EXISTS-only occurrence's cardinality probe. A reached bad body still
     // faults (parity both directions). (A bad inner column/relation is a
-    // STRUCTURAL fault the outer `compile` already raised for EVERY subquery
+    // structural fault the outer `compile` already raised for every subquery
     // before this runs, so it never reaches here — validation and run agree on
     // it regardless of the arm.)
     // A nested subquery's FROM resolves against base tables and enclosing CTEs,
-    // NOT the enclosing SELECT's derived-table aliases — STRIP them (CTEs/store
+    // NOT the enclosing SELECT's derived-table aliases — strip them (CTEs/store
     // kept) before type-checking/compiling each subquery, mirroring the compile
     // path's strip in `subquery(of:)`, so the schema path faults an outer
     // derived alias in a subquery's FROM exactly as the run does.
     let context = context.revealed()
     let scalar = select.scalar
-    // EVERY scalar occurrence's operand check defers to the walk, keyed here
-    // INDEPENDENTLY of a co-existing `IN`/`EXISTS` twin over identical SQL. A
-    // valued/existential twin's eager arity/type derivation is TOTAL (no
+    // every scalar occurrence's operand check defers to the walk, keyed here
+    // independently of a co-existing `IN`/`EXISTS` twin over identical SQL. A
+    // valued/existential twin's eager arity/type derivation is total (no
     // `.divide` on `1 / 0`) and does not reproduce the scalar's operand fault,
-    // and — now that an `IN`/`EXISTS` materialises LAZILY — a twin may itself
-    // sit in an unreachable leg, so it cannot stand in for a REACHABLE scalar's
+    // and — now that an `IN`/`EXISTS` materialises lazily — a twin may itself
+    // sit in an unreachable leg, so it cannot stand in for a reachable scalar's
     // operand check. Deferring on `scalar` alone (not `scalar - valued`)
     // records the scalar's own `.scalar` reach in `type` even when a `.valued`
     // reach for the same query is also present — the two per-occurrence reaches
@@ -715,15 +715,15 @@ extension Catalog where Self: ~Escapable {
     let deferred = scalar
     var widths = Dictionary<Query, Int>()
     var types = Dictionary<Query, ValueType>()
-    // Derive each SITE'S subqueries' cursor-free width and single-column type
-    // against THAT site's own scope, keyed PER OCCURRENCE — a join `i`'s `ON`
-    // against its PREFIX scope `prefixes[i]` (the relations AT that point, not
-    // one joined LATER), the rest against the full `enclosing` — matching the
-    // run's `subquery(of:)`. The SAME inner SQL in an `ON` and the WHERE
-    // derives TWICE — each against its own site's scope — so a name a WHERE
-    // subquery finds ambiguous in the full scope faults HERE, not the `ON`'s
-    // narrower prefix. The OPERAND validation now DEFERS to the reachability
-    // walk for EVERY site — an `ON` runs the SAME short-circuit walk the
+    // Derive each site'S subqueries' cursor-free width and single-column type
+    // against that site's own scope, keyed per occurrence — a join `i`'s `ON`
+    // against its prefix scope `prefixes[i]` (the relations at that point, not
+    // one joined later), the rest against the full `enclosing` — matching the
+    // run's `subquery(of:)`. The same inner SQL in an `ON` and the WHERE
+    // derives twice — each against its own site's scope — so a name a WHERE
+    // subquery finds ambiguous in the full scope faults here, not the `ON`'s
+    // narrower prefix. The operand validation now defers to the reachability
+    // walk for every site — an `ON` runs the same short-circuit walk the
     // WHERE/HAVING do (`walk` calls `check` per join), so a subquery a
     // short-circuited `AND`/`OR` leg of the `ON` never reaches is unvalidated,
     // exactly as the run's join evaluator never materialises it.
@@ -738,7 +738,7 @@ extension Catalog where Self: ~Escapable {
       }
     }
     // The WHERE, `HAVING`, projection, `GROUP BY`, and `ORDER BY` are walked by
-    // the reachability phase, so their operand check DEFERS; their width and
+    // the reachability phase, so their operand check defers; their width and
     // single- column type still derive here against the full `enclosing` scope.
     var rest = Array<Query>()
     select.predicate?.collect(subqueries: &rest)
@@ -757,10 +757,10 @@ extension Catalog where Self: ~Escapable {
       let nested = enclosing.map { base.nested(under: $0) } ?? context.outer
       try width(query, scalar, context, nested, &widths, &types)
     }
-    // Carry THIS select's own enclosing scope `context.outer` so its WHERE
-    // type-check (`walk`) resolves a correlated column of THIS query against
+    // Carry this select's own enclosing scope `context.outer` so its WHERE
+    // type-check (`walk`) resolves a correlated column of this query against
     // the outer, matching the run's lowering; the projection/`HAVING` walk uses
-    // `.barred` — a NO-OP for a LATERAL body (`everywhere`), whose projection
+    // `.barred` — a no-OP for a LATERAL body (`everywhere`), whose projection
     // ISO puts the preceding references in scope for, so validation admits the
     // projected correlated column exactly as the run's lowering does.
     return SubqueryCheck(widths, types, deferred: deferred,
@@ -769,40 +769,40 @@ extension Catalog where Self: ~Escapable {
 
   /// Records the cursor-free width and single-column type of `query` into
   /// `widths`/`types` against the `nested` outer scope, and enforces a scalar
-  /// occurrence's single-column ARITY EAGERLY (reachability-independent, as the
-  /// run's lowering does). Computed ONCE per distinct query at a given site.
+  /// occurrence's single-column arity eagerly (reachability-independent, as the
+  /// run's lowering does). Computed once per distinct query at a given site.
   internal borrowing func width(_ query: Query, _ scalar: Set<Query>,
                                 _ context: Context, _ nested: Outer?,
                                 _ widths: inout Dictionary<Query, Int>,
                                 _ types: inout Dictionary<Query, ValueType>)
       throws(SQLError) {
-    // The width and single-column type derive for EVERY subquery — cursor-free
-    // and TOTAL for a clean-resolving inner query (deriving the type of `1 / 0`
-    // yields the integer type WITHOUT dividing). A distinct query at ONE site
-    // is derived once; the SAME query at ANOTHER site re-derives against ITS
+    // The width and single-column type derive for every subquery — cursor-free
+    // and total for a clean-resolving inner query (deriving the type of `1 / 0`
+    // yields the integer type without dividing). A distinct query at one site
+    // is derived once; the same query at another site re-derives against its
     // scope, so a WHERE occurrence's ambiguity still faults there. The compile
-    // is SHAPE ONLY, so LENIENT (`validate: false`): this pre-pass runs for
-    // EVERY nested subquery ahead of the reachability walk, so validating a
+    // is shape ONLY, so lenient (`validate: false`): this pre-pass runs for
+    // every nested subquery ahead of the reachability walk, so validating a
     // derived body it nests — `1 IN (SELECT x FROM (SELECT 1 / 0 …) AS d)` —
-    // would fault a subquery a short-circuited `AND`/`OR` leg drops BEFORE the
-    // walk reaches it. Validation of a REACHED subquery's body (and the derived
+    // would fault a subquery a short-circuited `AND`/`OR` leg drops before the
+    // walk reaches it. Validation of a reached subquery's body (and the derived
     // tables nested within it, at any depth) is the walk's job — `typecheck(_
     // select:)` re-derives each reached occurrence's body strictly. Structural
     // faults (a bad inner relation/column, a UNION arity) still surface here —
     // those resolve regardless of `validate`. Lower under `.caller`, this
     // frame's `nested` outer, and shape-only lenience (`validate: false`) — the
     // schema pre-pass's cursor-free derive.
-    // `shaping()` DEFERS the set-operation operand-compatibility fold: this
-    // pre-pass records EVERY nested subquery's width and single-column type
+    // `shaping()` defers the set-operation operand-compatibility fold: this
+    // pre-pass records every nested subquery's width and single-column type
     // ahead of the reachability walk, so faulting `SQLError.operand` here would
     // reject an unreachable incompatible set-operation subquery a short-
     // circuited leg never reaches. The reached scalar/`IN` re-fold below
-    // restores the strict check for an occurrence that DOES run. Arity and
+    // restores the strict check for an occurrence that does run. Arity and
     // resolution stay eager regardless.
     let inner = context.scoped(as: .caller).with(outer: nested)
         .validating(false).shaping()
     let width = try compile(query, inner).width
-    // The single-column output TYPE — UNIFIED across the subquery's set-
+    // The single-column output type — unified across the subquery's set-
     // operation arms (`(SELECT 1 UNION SELECT 2.5)` typing `double`), not the
     // first arm alone — for validation's type-check. The run/derive fold reads
     // the `unconstrained` mask via `Resolution`; validation uses the type.
@@ -811,24 +811,24 @@ extension Catalog where Self: ~Escapable {
       widths[query] = width
       types[query] = derived
     }
-    // A scalar occurrence's single-column ARITY is enforced EAGERLY,
+    // A scalar occurrence's single-column arity is enforced eagerly,
     // reachability-independent — a cursor-free width check the run's lowering
-    // also makes — so a two-column scalar subquery in an unreachable arm STILL
-    // faults `SQLError.arity`, kept SEPARATE from the deferred operand check.
+    // also makes — so a two-column scalar subquery in an unreachable arm still
+    // faults `SQLError.arity`, kept separate from the deferred operand check.
     if scalar.contains(query), width != 1 {
       throw .arity(1, width)
     }
   }
 
   /// The subquery shape a run of the reached occurrence `reach` type-checks
-  /// against — chosen from the occurrence's OWN reached ROLE, not the union of
+  /// against — chosen from the occurrence's own reached role, not the union of
   /// every role the query occupies in the select. A `scalar` reach (collapses
-  /// the cell) or a `valued` one (`IN (Q)`, its value set read) EVALUATES the
-  /// select list, so its ORIGINAL is type-checked; an `existential` reach
-  /// (`EXISTS`) runs the cardinality PROBE (`Select.probe`: constant
+  /// the cell) or a `valued` one (`IN (Q)`, its value set read) evaluates the
+  /// select list, so its original is type-checked; an `existential` reach
+  /// (`EXISTS`) runs the cardinality probe (`Select.probe`: constant
   /// projection, `ORDER BY` dropped, original `OFFSET`/`FETCH` kept), never its
-  /// select list — so its PROBED shape is checked, matching the run. So the
-  /// SAME inner SQL reached ONLY as an `EXISTS` validates the probe even where
+  /// select list — so its probed shape is checked, matching the run. So the
+  /// same inner SQL reached ONLY as an `EXISTS` validates the probe even where
   /// an unreached arm has it as a scalar. A query the probe does not rewrite (a
   /// `HAVING` or set operation) runs in FULL, so its original is checked even
   /// for an `existential` reach.
@@ -842,43 +842,43 @@ extension Catalog where Self: ~Escapable {
 
   private borrowing func typecheck(_ select: Select, _ context: Context)
       throws(SQLError) {
-    // This select's OWN resolution scope — the one its nested subqueries
-    // CORRELATE against (`nil` for a FROM-less select, which adds no relations
-    // and correlates through `outer` unchanged). Built from the UNREVEALED
+    // This select's own resolution scope — the one its nested subqueries
+    // correlate against (`nil` for a FROM-less select, which adds no relations
+    // and correlates through `outer` unchanged). Built from the unrevealed
     // `context` — correlation resolves against the enclosing scope's relations
     // (its derived aliases among them), unlike an inner subquery's own FROM,
-    // which resolves against the REVEALED base below.
+    // which resolves against the revealed base below.
     let enclosing = select.from == nil
         ? nil : try scope(of: select, context)
-    // The PREFIX scope of each join, the surface its `ON`'s subquery correlates
+    // The prefix scope of each join, the surface its `ON`'s subquery correlates
     // against — matching the run's `subquery(of:)`.
     let prefixes = try prefixes(of: select, context)
-    // Type-check and compile every subquery ONCE, ahead of the reachability
+    // Type-check and compile every subquery once, ahead of the reachability
     // walk: the pre-pass validates each `IN`/`EXISTS` inner query (never
     // short-circuited past) and derives every scalar subquery's cursor-free
-    // arity and type (TOTAL — no `.divide` on `1 / 0`), but DEFERS a scalar
-    // occurrence's inner-query OPERAND validation to the walk. Each nested
-    // query's CORRELATION resolves against `enclosing` (a join `ON`'s against
+    // arity and type (total — no `.divide` on `1 / 0`), but defers a scalar
+    // occurrence's inner-query operand validation to the walk. Each nested
+    // query's correlation resolves against `enclosing` (a join `ON`'s against
     // its prefix) here, matching the run.
     let subquery = try subqueryCheck(of: select, context, enclosing: enclosing,
                                      prefixes: prefixes)
     // Walk the query's operands reachability-aware, so an unreachable
     // `CASE`/`COALESCE` arm's subquery is left unrecorded and unchecked.
     try walk(select, context, subquery: subquery, prefixes: prefixes)
-    // Validate the inner query of each occurrence the walk REACHED — a scalar
-    // or an `IN`/`EXISTS`/quantified one — in the RUN shape of ITS OWN reached
-    // role: an `existential` reach the cardinality PROBE (never its select
-    // list), a `scalar`/`valued` reach the ORIGINAL. The shape is chosen from
+    // Validate the inner query of each occurrence the walk reached — a scalar
+    // or an `IN`/`EXISTS`/quantified one — in the run shape of its own reached
+    // role: an `existential` reach the cardinality probe (never its select
+    // list), a `scalar`/`valued` reach the original. The shape is chosen from
     // the occurrence's role, NOT the union of every role the query occupies in
-    // the select — so the SAME inner SQL reached only as an `EXISTS` validates
-    // the probe even where an UNREACHED arm has it as a scalar. Its correlated
-    // columns resolve against THIS select's scope (nearest), stacked past
+    // the select — so the same inner SQL reached only as an `EXISTS` validates
+    // the probe even where an unreached arm has it as a scalar. Its correlated
+    // columns resolve against this select's scope (nearest), stacked past
     // `outer` — mirroring the lazy executor. A reached `(SELECT 1 / 0 …)`
     // faults `.divide` here exactly as the run does, while an unreached one in
     // a skipped arm does not.
     //
     // A subquery's own FROM sees base tables and enclosing CTEs, NOT the
-    // enclosing SELECT's derived-table aliases, so recurse against the REVEALED
+    // enclosing SELECT's derived-table aliases, so recurse against the revealed
     // base — the derived layers dropped, the CTEs/store (a shadowed CTE among
     // them) kept — while the correlation `outer` above still carries the
     // enclosing scope's ordinals.
@@ -888,15 +888,15 @@ extension Catalog where Self: ~Escapable {
     let inner = revealed.with(outer: nested)
     for reach in subquery.visited {
       try typecheck(shape(of: reach), inner)
-      // The nested-subquery shape pre-pass DEFERRED a set-operation's operand-
+      // The nested-subquery shape pre-pass deferred a set-operation's operand-
       // compatibility fold (`shaping()`), so a genuine incompatibility in a
-      // subquery that ACTUALLY runs would otherwise slip through. Re-fold it
-      // STRICTLY here (`inner` carries no `shape`), so a REACHED scalar or
+      // subquery that actually runs would otherwise slip through. Re-fold it
+      // strictly here (`inner` carries no `shape`), so a reached scalar or
       // `IN`/quantified (`.valued`) occurrence with irreconcilable arm types
       // faults `SQLError.operand` exactly as before the deferral. An
       // `existential` (`EXISTS`) or `lateral` reach does NOT constrain column
       // type — its cardinality does not read the arms' unified type — so it is
-      // SKIPPED and never faults on it, reachable or not.
+      // skipped and never faults on it, reachable or not.
       switch reach.role {
       case .scalar, .valued:
         _ = try columns(unifying: reach.query, inner)
@@ -904,17 +904,17 @@ extension Catalog where Self: ~Escapable {
         break
       }
     }
-    // Each join `ON` runs through the SAME reachability/short-circuit walk the
-    // WHERE does, but PREFIX-scoped: an `ON` predicate short-circuits its
+    // Each join `ON` runs through the same reachability/short-circuit walk the
+    // WHERE does, but prefix-scoped: an `ON` predicate short-circuits its
     // `AND`/`OR` at run (`Scope.on` lowers the conjunction the join evaluator
     // steps), so a subquery a short-circuited leg never reaches is NOT
     // validated — `ON 1 = 0 AND 1 IN (SELECT 1 / 0 …)` does not fault, exactly
-    // as the join never materialises it — while a REACHED `ON` subquery IS
-    // validated (parity). The `ON`'s LOCAL scope is the join's PREFIX
-    // (`prefixes[index]`, the relations AT that point, never one joined LATER),
+    // as the join never materialises it — while a reached `ON` subquery IS
+    // validated (parity). The `ON`'s local scope is the join's prefix
+    // (`prefixes[index]`, the relations at that point, never one joined later),
     // so a correlated reference to a later-joined relation faults per that
     // prefix; its enclosing `outer` stays the select's, so a correlated `ON`
-    // subquery column resolves against THAT prefix stacked past the outer,
+    // subquery column resolves against that prefix stacked past the outer,
     // matching the run's `subquery(of:)`.
     for index in select.joins.indices {
       guard index < prefixes.count else { continue }
@@ -928,9 +928,9 @@ extension Catalog where Self: ~Escapable {
     }
   }
 
-  /// Walks the operands of `select` reachability-aware — the SAME order and
+  /// Walks the operands of `select` reachability-aware — the same order and
   /// short-circuit rules the executor applies — validating each operand a run
-  /// would evaluate and RECORDING (via `subquery`) each scalar subquery it
+  /// would evaluate and recording (via `subquery`) each scalar subquery it
   /// reaches, so the caller validates only the reached scalars' inner queries.
   private borrowing func walk(_ select: Select, _ context: Context,
                               subquery: SubqueryCheck,
@@ -938,7 +938,7 @@ extension Catalog where Self: ~Escapable {
       throws(SQLError) {
     let routines = context.routines
     let scope = try scope(of: select, context)
-    // The WHERE admits a correlated column of THIS query (`subquery`); the
+    // The WHERE admits a correlated column of this query (`subquery`); the
     // projection, `HAVING`, and `ORDER BY` bar it (`barred`), diagnosing the
     // unsupported correlated-projection/HAVING case exactly as the run's
     // lowering does.
@@ -947,7 +947,7 @@ extension Catalog where Self: ~Escapable {
     // `1 ... width` names no output column and faults `SQLError.column`
     // (spelled as the ordinal), exactly as the compile path's ordinal
     // resolution does — structural and reachability-independent, so a
-    // row-dropping limit never spares it. `orderKeys` resolves an IN-RANGE
+    // row-dropping limit never spares it. `orderKeys` resolves an IN-range
     // ordinal to its projection expression but silently drops an out-of-range
     // one, so this raises it here.
     if let clause = select.order {
@@ -959,9 +959,9 @@ extension Catalog where Self: ~Escapable {
         }
       }
     }
-    // A GROUPED `ORDER BY` sorts in the grouped slot space, so each sort key
+    // A grouped `ORDER BY` sorts in the grouped slot space, so each sort key
     // must name a `GROUP BY` key, an aggregate, or an output — resolve it
-    // through the SAME grouped lowering the run does, faulting
+    // through the same grouped lowering the run does, faulting
     // `SQLError.grouping` on a resolvable-but-non-grouped column exactly as the
     // compile path does. Structural, so it runs regardless of the WHERE/limit
     // reachability the operand type-check below tracks.
@@ -973,15 +973,15 @@ extension Catalog where Self: ~Escapable {
       // A false WHERE filters every row, so a GROUP BY forms no group and a
       // non-aggregate query yields no row — nothing after is reachable. A
       // whole-result aggregate (an aggregate projection or HAVING, no GROUP BY)
-      // still emits ONE empty group: the fold sees zero rows, so an aggregate
+      // still emits one empty group: the fold sees zero rows, so an aggregate
       // operand never evaluates (it propagates NULL), but the HAVING and
-      // projection run over the group's results, so EVALUATE them (`empty`) — a
+      // projection run over the group's results, so evaluate them (`empty`) — a
       // divide, overflow, or bad routine call faults as the run would.
       if scope.constant(predicate, routines) == false {
         if select.aggregates, select.grouping.expressions.isEmpty {
           if let having = select.having {
-            // HAVING filters the group BEFORE any OFFSET/FETCH limit, so
-            // evaluate it UNCONDITIONALLY — a zero `FETCH` or positive `OFFSET`
+            // HAVING filters the group before any OFFSET/FETCH limit, so
+            // evaluate it unconditionally — a zero `FETCH` or positive `OFFSET`
             // spares only the projection, never HAVING. It validates its
             // operands (a divide, overflow, or bad routine call faults) AND
             // yields the group's fate — a group passes only when HAVING is
@@ -991,9 +991,9 @@ extension Catalog where Self: ~Escapable {
             // A HAVING nesting an `EXISTS`/`IN (Q)` subquery is the exception:
             // `empty` cannot materialise the subquery (it carries no catalog),
             // so it folds UNKNOWN — but the subquery is row-independent and may
-            // be TRUE at RUN, keeping the group and RUNNING the projection. So
+            // be TRUE at run, keeping the group and running the projection. So
             // a subquery-bearing HAVING is NOT-definitely-empty: fall through
-            // and VALIDATE the projection, so `columns(of:)` surfaces the fault
+            // and validate the projection, so `columns(of:)` surfaces the fault
             // the run would (`SELECT 1 / 0 … HAVING EXISTS (Q)` raises
             // `.divide`). A subquery-free HAVING keeps the precise pruning.
             if !having.subquery, try scope.empty(having, routines) != true {
@@ -1004,7 +1004,7 @@ extension Catalog where Self: ~Escapable {
           // one row it would emit — a zero `FETCH` or any positive `OFFSET`. A
           // DISTINCT select is the exception: its plan is
           // `Limit(Distinct(Project(…)))`, so the projection evaluates over the
-          // empty group's row (dedup needs it) BEFORE the cap pages the
+          // empty group's row (dedup needs it) before the cap pages the
           // deduplicated result — a zero FETCH or skipping OFFSET does not
           // spare it, mirroring the main projection path below. (`||` with a
           // `borrowing self` autoclosure needs the two-statement form.)
@@ -1015,9 +1015,9 @@ extension Catalog where Self: ~Escapable {
               try scope.fold(item.expression, routines, subquery: barred)
             }
           }
-          // The lone empty group is sorted BELOW the limit — the shape is
+          // The lone empty group is sorted below the limit — the shape is
           // `Project(Limit(Sort(…)))` — so its ORDER BY keys evaluate over
-          // that group's row UNCONDITIONALLY, ahead of a limit that would drop
+          // that group's row unconditionally, ahead of a limit that would drop
           // the projection: an unknown routine or a divide faults here as a run
           // would. `orderKeys` resolves an ordinal or an output-name key to the
           // projection expression the sort recomputes below the limit, so a
@@ -1045,11 +1045,11 @@ extension Catalog where Self: ~Escapable {
     for expression in select.orderKeys {
       try scope.aggregates(in: expression, routines, subquery: barred)
     }
-    // Each GROUP BY key is EVALUATED over the input rows to form the groups,
-    // BEFORE the HAVING, the projection, and any limit — so validate every key
+    // Each GROUP BY key is evaluated over the input rows to form the groups,
+    // before the HAVING, the projection, and any limit — so validate every key
     // here, unconditionally in this reachable path (the constant-false WHERE
     // above already returned, forming no group and evaluating no key). Route
-    // each key through the SAME per-operand type-check the projection and
+    // each key through the same per-operand type-check the projection and
     // ORDER BY keys use (`validate`), so a bare `.column` key (the only shape
     // the parser yields today, a `NATURAL`/`USING` merged column among them)
     // resolves exactly as it does elsewhere — the merged binding shadowing its
@@ -1069,10 +1069,10 @@ extension Catalog where Self: ~Escapable {
     }
     // The projection runs after any limit: a limit that drops every row it
     // would yield leaves only its aggregate folds (validated above) reachable.
-    // A whole-result aggregate emits exactly ONE row, so a positive OFFSET
+    // A whole-result aggregate emits exactly one row, so a positive OFFSET
     // drops it too — not just a zero FETCH. A DISTINCT select is the exception:
     // its plan is `Limit(Distinct(Project(…)))`, so the projection evaluates
-    // over EVERY candidate row (dedup needs them) BEFORE the cap pages the
+    // over every candidate row (dedup needs them) before the cap pages the
     // deduplicated result — a zero FETCH or skipping OFFSET does not spare it.
     // A false WHERE still yields no rows to dedup (handled above), so only the
     // limit-based elision is bypassed for DISTINCT.
@@ -1084,23 +1084,23 @@ extension Catalog where Self: ~Escapable {
         _ = try scope.validate(item.expression, routines, subquery: barred)
       }
     }
-    // The sort sits BELOW the limit — the shape is `Project(Limit(Sort(…)))`
-    // — so it evaluates every ORDER BY key over the input rows BEFORE the cap
-    // pages them, INDEPENDENT of whether the projection is reachable: a limit
+    // The sort sits below the limit — the shape is `Project(Limit(Sort(…)))`
+    // — so it evaluates every ORDER BY key over the input rows before the cap
+    // pages them, independent of whether the projection is reachable: a limit
     // that drops every output row still runs the sort. So validate each key
-    // UNCONDITIONALLY — its calls, arithmetic, and column references exactly
+    // unconditionally — its calls, arithmetic, and column references exactly
     // as a projected expression's. `orderKeys` resolves an `ordinal(n)` or an
     // output-name key to the projection expression the sort recomputes below
     // the limit, so a projection term reached only through the sort is checked
     // even where the projection block above is skipped under the limit; a
-    // projection term NO sort key reaches stays correctly unchecked (the
+    // projection term no sort key reaches stays correctly unchecked (the
     // projection never runs under a row-dropping limit).
     for expression in select.orderKeys {
       _ = try scope.validate(expression, routines, subquery: barred)
     }
   }
 
-  /// Resolves a GROUPED `select`'s `ORDER BY` through the SAME grouped lowering
+  /// Resolves a grouped `select`'s `ORDER BY` through the same grouped lowering
   /// the compile path applies, so the type-check enforces the GROUP BY rules on
   /// each sort key exactly as a run does — a bare column must be a `GROUP BY`
   /// key or occur inside an aggregate, else `SQLError.grouping`; an
@@ -1122,10 +1122,10 @@ extension Catalog where Self: ~Escapable {
     let routines = context.routines
     // A grouped aggregate's argument or FILTER may nest a subquery (`ORDER BY
     // SUM(CASE WHEN EXISTS (Q) …)`), which lowering resolves against the
-    // materialised map, so build the select's subquery seam ONCE here — the
+    // materialised map, so build the select's subquery seam once here — the
     // same one the run's `group` builds — for this structural resolve to lower
-    // those aggregates exactly as the run does. It threads the SAME
-    // `enclosing`/`outer`/`prefixes` the run path passes, so a CORRELATED inner
+    // those aggregates exactly as the run does. It threads the same
+    // `enclosing`/`outer`/`prefixes` the run path passes, so a correlated inner
     // query (`WHERE S.k = T.k`) resolves its outer column here exactly as at
     // run, rather than compiling with no enclosing scope and faulting
     // `SQLError.column`.
@@ -1133,7 +1133,7 @@ extension Catalog where Self: ~Escapable {
                                 enclosing: scope, prefixes: prefixes).rest
     // Collect the distinct aggregates the grouped plan folds — the projection,
     // the `HAVING`, and the `ORDER BY` sort-key expressions — then dedup by the
-    // RESOLVED `Aggregation`, exactly as `group` does, so a grouped `ORDER BY`
+    // resolved `Aggregation`, exactly as `group` does, so a grouped `ORDER BY`
     // over an aggregate resolves against the same slot the run folds it into.
     var expressions = Array<Expression>()
     for expression in select.projection.projected {
@@ -1153,7 +1153,7 @@ extension Catalog where Self: ~Escapable {
         aggregations.append(aggregation)
       }
     }
-    // This select's grouping keys and — for ONE expanded `GROUPING SETS` arm —
+    // This select's grouping keys and — for one expanded `GROUPING SETS` arm —
     // its superset, matching the run's `group`. An `.arm` never carries an
     // `ORDER BY` (it rides the wrapper), so the superset is used here only for
     // completeness; a `.sets` never reaches this path (it is expanded before
@@ -1164,9 +1164,9 @@ extension Catalog where Self: ~Escapable {
         case let .arm(keys, superset): (keys, superset)
         case .sets: ([], [])
         }
-    // The GROUP BY keys' LOWERED base-ordinal terms, so a bare `NATURAL`/
+    // The GROUP BY keys' lowered base-ordinal terms, so a bare `NATURAL`/
     // `USING` merged key (which binds no single ordinal) is matched by term —
-    // the SAME lowering the run's `group` computes.
+    // the same lowering the run's `group` computes.
     let keys = try grouping.map { key throws(SQLError) -> Term in
       try scope.term(key, routines, subquery: subquery.barred)
     }
@@ -1185,20 +1185,20 @@ extension Catalog where Self: ~Escapable {
     _ = try grouped.order(clause, projection, routines, subquery: subquery)
   }
 
-  /// The RESOLVED grouped-space `Term` of each of a GROUPED arm's projected
+  /// The resolved grouped-space `Term` of each of a grouped arm's projected
   /// items, paired with a resolver lowering an arbitrary expression to the same
   /// grouped space — the identity surface the `ordered` set-op carrier matches
   /// a query-level `ORDER BY` key against, so it agrees with the plain grouped
-  /// `ORDER BY` path (both route through this ONE `Grouped`).
+  /// `ORDER BY` path (both route through this one `Grouped`).
   ///
   /// The carrier over a `GROUPING SETS` expansion resolves its `ORDER BY` keys
-  /// against the union's OUTPUT scope, which cannot recompute an aggregate. To
-  /// decide whether a key is an ALREADY-PROJECTED value — so it orders on that
-  /// output rather than a synthetic hidden column — it lowers the key HERE and
-  /// matches its `Term` against these projected terms by RESOLVED identity,
+  /// against the union's output scope, which cannot recompute an aggregate. To
+  /// decide whether a key is an already-projected value — so it orders on that
+  /// output rather than a synthetic hidden column — it lowers the key here and
+  /// matches its `Term` against these projected terms by resolved identity,
   /// general over every expression shape (a qualifier-equivalent aggregate
   /// `SUM(s.Qty)` ≡ the projected `SUM(Qty)`), not raw AST + a `.column`-only
-  /// qualifier strip. It rebuilds the SAME `Grouped` the run's `group` and the
+  /// qualifier strip. It rebuilds the same `Grouped` the run's `group` and the
   /// schema `order(grouped:)` build — the keys and the aggregations collected
   /// from the projection, `HAVING`, and (the arm carries the materialised keys
   /// as projected items) the sort keys, deduped by resolved `Aggregation` — so
@@ -1221,7 +1221,7 @@ extension Catalog where Self: ~Escapable {
     // carried GROUPING SETS arm includes the materialised sort keys as extra
     // projected items) and its `HAVING` — deduped by resolved `Aggregation`,
     // exactly as `group` does, so a projected aggregate and a
-    // qualifier-equivalent sort key fold into ONE slot.
+    // qualifier-equivalent sort key fold into one slot.
     var expressions = Array<Expression>()
     for expression in select.projection.projected {
       expression.collect(into: &expressions)
@@ -1278,7 +1278,7 @@ extension Catalog where Self: ~Escapable {
   /// type, not the `.integer` default. `validate` (default `true`) gates the
   /// view body's reachable-operand type-check: a `validate: false` derive (an
   /// empty result whose headers this fills) resolves the body's relations and
-  /// types WITHOUT re-checking its reachable operands, so a view whose body is
+  /// types without re-checking its reachable operands, so a view whose body is
   /// data-dependent-empty — a text-arithmetic projection under a filter that
   /// matched no row — does not fault a `SELECT *` over it that already ran.
   borrowing func schema(of relation: Relation, _ context: Context,
@@ -1286,18 +1286,18 @@ extension Catalog where Self: ~Escapable {
       throws(SQLError) -> Schema {
     let name = relation.name
     // A LATERAL derived table is not bound in the overlay (it is never
-    // materialised once as a constant), so derive its schema through the SAME
+    // materialised once as a constant), so derive its schema through the same
     // derived-body machinery a non-lateral body uses (`materialise`, `rows:
-    // false`) — over the REVEALED base (base + CTEs + store, its own alias out
+    // false`) — over the revealed base (base + CTEs + store, its own alias out
     // of scope), so a body naming a CTE resolves it, exactly as a non-lateral
     // body does.
     //
     // Per ISO a LATERAL body's preceding-FROM references are in scope
-    // throughout its query expression, INCLUDING the SELECT list, so its output
-    // SHAPE is NOT correlation-independent — a projected preceding column
+    // throughout its query expression, including the SELECT list, so its output
+    // shape is NOT correlation-independent — a projected preceding column
     // (`SELECT T.Id AS id`) types from that outer column. So the schema derive
-    // THREADS the `preceding` scope as the correlation stack (`with(outer:)`)
-    // and marks the body a lateral one (`lateralizing`), the SAME
+    // threads the `preceding` scope as the correlation stack (`with(outer:)`)
+    // and marks the body a lateral one (`lateralizing`), the same
     // revealed-base-with-outer context `compile(select)`'s `lateral` compiles
     // it under — schema, validation, and compile share it, so a projected
     // preceding column derives its type here exactly as the run lowers it to a
@@ -1312,13 +1312,13 @@ extension Catalog where Self: ~Escapable {
       return try materialise(query, scope, rows: false,
                              columns: relation.columns).schema()
     }
-    // The explicit `AS t(c, …)` list positionally renames a NAMED relation's
-    // output columns; a DERIVED table's list was already applied where it
+    // The explicit `AS t(c, …)` list positionally renames a named relation's
+    // output columns; a derived table's list was already applied where it
     // materialised (its overlay binding below carries the renamed names), so
-    // only a `.named` source renames HERE — never double-renaming a derived
+    // only a `.named` source renames here — never double-renaming a derived
     // table read back through the overlay. This is the schema-only mirror of
     // `resolve`'s named-relation rename, kept in parity so the two paths
-    // advertise the SAME column names.
+    // advertise the same column names.
     let renaming: Array<String> = if case .named = relation.source {
       relation.columns
     } else {
@@ -1327,7 +1327,7 @@ extension Catalog where Self: ~Escapable {
     if let cte = context.relations[name.lowercased()] {
       return try cte.schema().renamed(renaming)
     }
-    // A reserved store relation types through its SCHEMA-ONLY build (header +
+    // A reserved store relation types through its schema-ONLY build (header +
     // types, no rows), so resolving a view over `definition_schema.tables`/
     // `.columns` reads only the schema and never triggers the row builder.
     if let relation = Definition(name) {
@@ -1337,9 +1337,9 @@ extension Catalog where Self: ~Escapable {
       // A view's declared schema types every column `.integer`, since a view
       // stores no types; resolve the view body's own types so a `SELECT *` over
       // the view reports each column's true type. Resolving runs the
-      // RESOLVE-only worker over the view's OWN `definition_schema.` overlay,
-      // built SCHEMA-ONLY so a view over a reserved relation resolves its types
-      // without a row build. The names stay the view's DECLARED ones; only the
+      // resolve-only worker over the view's own `definition_schema.` overlay,
+      // built schema-ONLY so a view over a reserved relation resolves its types
+      // without a row build. The names stay the view's declared ones; only the
       // types come from the resolved body.
       let base = view.schema()
       // A cyclic view cannot resolve its body's types: resolving it would
@@ -1349,30 +1349,30 @@ extension Catalog where Self: ~Escapable {
       if context.visited.contains(name.lowercased()) {
         return try base.renamed(renaming)
       }
-      // Type-check the body's REACHABLE operands and calls across every arm and
+      // Type-check the body's reachable operands and calls across every arm and
       // clause — `compile` cannot check a routine EXISTS, the first-arm resolve
       // below sees only the first projection, and the outer query's walk does
       // not reach into a body. `typecheck` faults an unknown call or a bad
       // operand a `SELECT * FROM v` run would evaluate — a `WHERE`/`HAVING`, a
       // later `UNION` arm — while skipping an arm a short-circuit proves
       // unreachable.
-      // The view name enters `visited` BEFORE its body's derived tables
+      // The view name enters `visited` before its body's derived tables
       // materialise, so a derived table naming this view (`FROM (SELECT * FROM
       // <self>) AS d`) re-enters with the view already visited and faults
       // `.recursion` rather than recursing to a stack overflow — the guard
       // rides through `augment`/`materialise` into the derived body.
       // `body([:])` enters the view-body scope with the caller's correlation
-      // stack CLEARED: a view is defined independently of its call site, so an
-      // unbound column in the DEFINITION must fault — NOT bind to an enclosing
+      // stack cleared: a view is defined independently of its call site, so an
+      // unbound column in the definition must fault — NOT bind to an enclosing
       // row — when the view's schema is derived from inside a correlated
       // subquery, keeping this derivation consistent with `resolve`/`compile`.
-      // Derive and type-check the SAME expanded AST a run does: a `GROUP BY
+      // Derive and type-check the same expanded AST a run does: a `GROUP BY
       // GROUPING SETS` body expands to its `UNION ALL` arms FIRST, so the
-      // reachability typecheck sees the per-set arms. An UNEXPANDED body would
+      // reachability typecheck sees the per-set arms. An unexpanded body would
       // read `GROUPING SETS ((Region), ())` as non-empty `grouping.expressions`
-      // and, under a constant-false `WHERE`, short-circuit WITHOUT validating
+      // and, under a constant-false `WHERE`, short-circuit without validating
       // the projection — yet the expanded `()` grand-total arm still produces a
-      // group and evaluates it at run, so `columns(of:)` would ACCEPT a body
+      // group and evaluates it at run, so `columns(of:)` would accept a body
       // (`SELECT 1 / 0 … GROUP BY GROUPING SETS ((Region), ())`) the run
       // faults. Expanding here keeps the view schema path in step with the run.
       let body = try view.query.expanded
@@ -1387,8 +1387,8 @@ extension Catalog where Self: ~Escapable {
       if context.validate {
         try typecheck(body, overlay)
       }
-      // Type the body's columns: their NAMES off the first arm (the ISO rule
-      // for a UNION), their TYPES unified across every arm, each carrying its
+      // Type the body's columns: their names off the first arm (the ISO rule
+      // for a UNION), their types unified across every arm, each carrying its
       // `unconstrained` mask so an all-NULL view column unifies with any later
       // typed arm through `Schema(from:)`. Arity — the body's width against the
       // declared columns — is `compile`'s job (the public entry runs it), so on

--- a/Sources/SQLEngine/Schema.swift
+++ b/Sources/SQLEngine/Schema.swift
@@ -30,7 +30,7 @@ internal struct Schema {
   /// `Engine.outputSchema`); the engine never compares or orders on it.
   internal let types: Array<ValueType>
 
-  /// Whether each real column at its ordinal `0 ..< width` places NO type
+  /// Whether each real column at its ordinal `0 ..< width` places no type
   /// constraint — an all-arms-NULL CTE column whose concrete `types` entry is a
   /// default the set-operation fold must NOT constrain against, so a reference
   /// to it unifies with any typed arm order-independently. Aligned with `types`
@@ -55,11 +55,11 @@ internal struct Schema {
   }
 
   /// A view's resolution schema, its per-column types AND `unconstrained` mask
-  /// RESOLVED from a body `carrier` while its `names` stay the view's DECLARED
+  /// resolved from a body `carrier` while its `names` stay the view's declared
   /// ones (a view stores its own column names; only the types and mask come
   /// from the resolved body). The declared surface's `extent`/`virtuals` carry
   /// over unchanged. Taking the types and mask from the carrier as a whole
-  /// threads the per-column `unconstrained` through this ONE constructor rather
+  /// threads the per-column `unconstrained` through this one constructor rather
   /// than a loose `types.map` at the site, so an all-NULL view column unifies
   /// with any later typed set-operation arm.
   internal init(from carrier: Array<ResolvedColumn>, names: Array<String>,
@@ -70,7 +70,7 @@ internal struct Schema {
               virtuals: virtuals)
   }
 
-  /// This schema with its real column `names` positionally RENAMED to
+  /// This schema with its real column `names` positionally renamed to
   /// `columns` — the ISO `AS t(c, …)` explicit output column list — or
   /// unchanged when `columns` is empty (no list).
   ///

--- a/Sources/SQLEngine/Scope.swift
+++ b/Sources/SQLEngine/Scope.swift
@@ -21,16 +21,16 @@ extension Schema {
   }
 
   /// The ordinal `column` resolves to in `relation`, or `nil` when it is a
-  /// candidate CORRELATED reference to an enclosing scope — this relation does
+  /// candidate correlated reference to an enclosing scope — this relation does
   /// not name it — the not-found probe the single-relation `.column` lowering
   /// consults before correlating outward.
   ///
   /// The two not-found situations `ordinal(of:in:)` conflates as `.column` are
-  /// DISTINGUISHED here. A qualifier this relation does NOT answer (its alias,
+  /// distinguished here. A qualifier this relation does NOT answer (its alias,
   /// else its name), or an unqualified name it does not carry, is a genuine
   /// not-found → `nil`, so the walk correlates to the outer query. But a
-  /// qualifier this relation DOES answer, naming a column it LACKS, is a hard
-  /// `SQLError.column` that PROPAGATES: the local alias SHADOWS a same-named
+  /// qualifier this relation does answer, naming a column it lacks, is a hard
+  /// `SQLError.column` that propagates: the local alias shadows a same-named
   /// outer relation, so the miss faults against the inner relation rather than
   /// falling through to bind the outer one. This is the single-relation analog
   /// of `Scope.find`.
@@ -55,9 +55,9 @@ extension Schema {
                       _ routines: Routines = [:],
                       subquery: Resolution = .unsupported)
       throws(SQLError) -> Array<Term> {
-    // A projection is a BARRED clause position: a correlated column of THIS
+    // A projection is a barred clause position: a correlated column of this
     // query has no evaluator here (only WHERE/ON/HAVING admit one). The cut is
-    // intrinsic to the entry, so a caller CANNOT pass an admitting seam into a
+    // intrinsic to the entry, so a caller cannot pass an admitting seam into a
     // projection — the FROM-less scalar path included — keeping the run's
     // lowering and the schema `columns(of:)` derive in lockstep.
     let subquery = subquery.barred
@@ -67,7 +67,7 @@ extension Schema {
     case let .columns(columns):
       // Lower each bare column through `term`, so a name this relation does not
       // bind consults the `subquery` surface: a correlated reference on the
-      // BARRED projection surface is diagnosed unsupported (parity with the
+      // barred projection surface is diagnosed unsupported (parity with the
       // schema path) rather than faulting `SQLError.column`.
       var terms = Array<Term>()
       terms.reserveCapacity(columns.count)
@@ -97,12 +97,12 @@ extension Schema {
     switch expression {
     case let .column(column):
       // Resolve against this relation first; a name it does not bind is a
-      // candidate CORRELATED reference to the enclosing scope, lowered to a
+      // candidate correlated reference to the enclosing scope, lowered to a
       // synthetic `Term.parameter` when the outer scope binds it, else the
-      // ordinary unknown-column fault. A QUALIFIED miss on THIS relation (its
-      // alias names it, but the column is absent) is a HARD `.column` `find`
+      // ordinary unknown-column fault. A qualified miss on this relation (its
+      // alias names it, but the column is absent) is a hard `.column` `find`
       // propagates — never a fall-through to correlate a same-qualifier outer
-      // relation, which the local alias SHADOWS.
+      // relation, which the local alias shadows.
       if let ordinal = try find(column, in: relation) { return .slot(ordinal) }
       if let name = try subquery.correlate(column) { return .parameter(name) }
       return try .slot(ordinal(of: column, in: relation))
@@ -117,7 +117,7 @@ extension Schema {
       }
       // Case-fold the routine name to the SQL identifier rule the `Routines`
       // lookup uses (lowercase), so two calls that spell the same routine with
-      // different case — `UPPER(x)` and `upper(x)` — lower to an IDENTICAL
+      // different case — `UPPER(x)` and `upper(x)` — lower to an identical
       // `.apply` term. Term identity then agrees with dispatch (which folds on
       // lookup), so the DISTINCT ORDER BY guard's projected-term match, the
       // aggregate dedup, and every other term comparison stay consistent.
@@ -143,7 +143,7 @@ extension Schema {
         nil
       }
       // Attach the unified result type — the same `ValueType.unified` reduction
-      // `derive`/`validate` compute — so the executor COERCES the selected
+      // `derive`/`validate` compute — so the executor coerces the selected
       // branch's value to the type the schema advertises. Derive it against a
       // one-relation scope, this Schema's own resolution surface.
       let scope = Scope([(relation, self)])
@@ -157,7 +157,7 @@ extension Schema {
                             subquery: subquery), type)
     case let .coalesce(arguments):
       // Lower each argument to a `Term` over this relation and hold them in a
-      // first-class `Term.coalesce` so each is evaluated ONCE. `type` is the
+      // first-class `Term.coalesce` so each is evaluated once. `type` is the
       // unified argument type the selected value coerces to, derived against a
       // one-relation scope.
       var elements = Array<Term>()
@@ -171,14 +171,14 @@ extension Schema {
       return .coalesce(elements, type: type)
     case let .nullif(lhs, rhs):
       // Lower both operands to `Term`s over this relation and hold them in a
-      // first-class `Term.nullif` so each is evaluated ONCE.
+      // first-class `Term.nullif` so each is evaluated once.
       return try .nullif(term(lhs, in: relation, routines, subquery: subquery),
                          term(rhs, in: relation, routines, subquery: subquery))
     case let .subquery(query):
       // A scalar subquery lowers to a `Term.subquery` reading its collapsed
       // value from the run-time cache, carrying its occurrence `Subkey` and
       // single-column type, the single-column arity enforced from the compiled
-      // width (no cursor). The query is UNCORRELATED — it reads no cell here.
+      // width (no cursor). The query is uncorrelated — it reads no cell here.
       return try subquery.scalar(query)
     case .aggregate:
       // An aggregate has no per-row meaning — it folds over a group — so it may
@@ -186,7 +186,7 @@ extension Schema {
       throw .state("42803", "an aggregate is not allowed here")
     case .grouping:
       // GROUPING is a grouped-query construct decided by the arm's key
-      // membership; it has no meaning in this NON-grouped resolution (a scalar
+      // membership; it has no meaning in this non-grouped resolution (a scalar
       // projection, WHERE, or join ON), so it faults exactly as an aggregate
       // does. A grouped query lowers it through `Grouped.term` instead.
       throw .state("42803", "GROUPING requires a GROUP BY")
@@ -206,7 +206,7 @@ extension Schema {
                       _ routines: Routines = [:],
                       subquery: Resolution = .unsupported)
       throws(SQLError) -> Array<SortKey> {
-    // An ORDER BY is BARRED, as the projection is: a correlated column of THIS
+    // An ORDER BY is barred, as the projection is: a correlated column of this
     // query is out of the cut here, so the entry bars the seam by construction.
     let subquery = subquery.barred
     return try SQLEngine.order(order, projection, names) {
@@ -255,36 +255,36 @@ internal struct Scope {
     let offset: Int
   }
 
-  /// A `NATURAL`/`USING` MERGED column (ISO 9075 7.10) — the ONE common column
-  /// a named-column join exposes, belonging to NEITHER side. It has NO physical
+  /// A `NATURAL`/`USING` merged column (ISO 9075 7.10) — the one common column
+  /// a named-column join exposes, belonging to neither side. It has no physical
   /// slot of its own: its `value` is the `COALESCE(left, right)` over the two
-  /// PHYSICAL combined ordinals it merges (each still addressable QUALIFIED),
+  /// physical combined ordinals it merges (each still addressable qualified),
   /// and its `type` the unified coalesce type. A bare (unqualified) reference
-  /// to its `name` resolves to `value` — the merged entry SHADOWS its physical
+  /// to its `name` resolves to `value` — the merged entry shadows its physical
   /// constituents for bare lookup — while a qualified `A.c`/`B.c` never matches
   /// it and reaches its own slot.
   internal struct Merged: Sendable {
     let name: String
     let value: Term
     let type: ValueType
-    /// The two PHYSICAL combined ordinals this merged column coalesces — the
+    /// The two physical combined ordinals this merged column coalesces — the
     /// left constituent and the right one — kept so a `SELECT *` drops them
-    /// (each is exposed ONCE, via the merged `value`, not twice as itself).
+    /// (each is exposed once, via the merged `value`, not twice as itself).
     let constituents: Array<Int>
-    /// Whether the merged column places NO type constraint — TRUE only when
-    /// BOTH constituents were unconstrained (each an all-NULL/placeholder
+    /// Whether the merged column places no type constraint — TRUE only when
+    /// both constituents were unconstrained (each an all-NULL/placeholder
     /// column), so a `USING` merge of two constant-NULL sides stays a
     /// placeholder that a further enclosing set-operation fold unifies with any
-    /// typed arm; FALSE when EITHER side constrained the merged type. The
+    /// typed arm; FALSE when either side constrained the merged type. The
     /// `unconstrained` bit the set-operation `merge(_:_:)` computes, carried so
     /// a downstream `output(of:)`/correlated read reports it rather than
     /// hard-coding the merged column constrained.
     let unconstrained: Bool
 
     /// This merged column as an output `ResolvedColumn` — its `type` AND its
-    /// `unconstrained` mask carried TOGETHER, named `name` (the reference's
+    /// `unconstrained` mask carried together, named `name` (the reference's
     /// spelling for a bare `output(of:)`, else the merged column's own `name`
-    /// for a `SELECT *`). The SINGLE construction both the `SELECT *`
+    /// for a `SELECT *`). The single construction both the `SELECT *`
     /// (`outputs`) and the explicit bare `output(of:)` merged-output paths
     /// route through, so neither can drop the mask the other carries.
     internal func resolved(named name: String) -> ResolvedColumn {
@@ -304,7 +304,7 @@ internal struct Scope {
 
   /// The physical combined ordinals a merged column subsumes — the union of
   /// every `Merged.constituents` — so a `SELECT *` skips them (each is exposed
-  /// ONCE via its merged `value`).
+  /// once via its merged `value`).
   private let subsumed: Set<Int>
 
   /// Builds a scope over `relations` — the `FROM` relation first, then each
@@ -326,18 +326,18 @@ internal struct Scope {
   }
 
   /// The merged column named `name` (case-insensitively), or `nil` when none —
-  /// the entry a bare reference SHADOWS its two physical constituents with.
+  /// the entry a bare reference shadows its two physical constituents with.
   private func merged(_ name: String) -> Merged? {
     let folded = name.lowercased()
     return merged.first { $0.name.lowercased() == folded }
   }
 
-  /// The `NATURAL`/`USING` merged column a BARE `name` resolves to (ISO 9075
+  /// The `NATURAL`/`USING` merged column a bare `name` resolves to (ISO 9075
   /// 7.10), or `nil` when none is merged under that name — the binding
   /// `term`/`derive`/`output(of:)` shadow the two physical sides with.
   ///
-  /// The merged column shadows its OWN constituents, but an addressable column
-  /// of the same name a LATER PLAIN join contributed (`… USING (k) JOIN C …`, C
+  /// The merged column shadows its own constituents, but an addressable column
+  /// of the same name a later plain join contributed (`… USING (k) JOIN C …`, C
   /// carrying its own `k`) is NOT a constituent — a bare `k` now names both
   /// the merged column and that other one, so it faults `SQLError.ambiguous`
   /// rather than silently taking the merged value. A qualified `A.k`/`C.k`
@@ -345,8 +345,8 @@ internal struct Scope {
   ///
   /// The conflict scan is the FULL addressable surface (`addressable` —
   /// physical AND virtual, the same surface `ordinal(of:)` resolves against),
-  /// EXCLUDING the merged column's own physical constituents. So a merged `Id`
-  /// (a virtual join column) coexisting with a later plain join's own VIRTUAL
+  /// excluding the merged column's own physical constituents. So a merged `Id`
+  /// (a virtual join column) coexisting with a later plain join's own virtual
   /// `Id` faults `.ambiguous` just as a real conflict does — the two axes stay
   /// consistent because neither the merged bare lookup nor the ordinary one
   /// scans a partial surface.
@@ -359,9 +359,9 @@ internal struct Scope {
     return merged
   }
 
-  /// Whether the real column at `member`'s local `ordinal` is a PHYSICAL
+  /// Whether the real column at `member`'s local `ordinal` is a physical
   /// constituent a merged column subsumes — one a `SELECT *` drops, since the
-  /// merged `value` already exposes it ONCE.
+  /// merged `value` already exposes it once.
   private func subsumed(_ member: Member, _ ordinal: Int) -> Bool {
     subsumed.contains(member.offset + ordinal)
   }
@@ -376,21 +376,21 @@ internal struct Scope {
   /// rather than the ordinal `keys` map its `find` cannot fill.
   internal func merges(_ name: String) -> Merged? { merged(name) }
 
-  /// Whether the real column at combined `ordinal` is a PHYSICAL constituent a
+  /// Whether the real column at combined `ordinal` is a physical constituent a
   /// merged column subsumes — the schema-path `SELECT *` (`outputs`) drops it.
   internal func subsumes(_ ordinal: Int) -> Bool { subsumed.contains(ordinal) }
 
   // MARK: - Layout and names
 
-  /// The combined ordinals of the REAL columns a `SELECT *` emits AFTER the
+  /// The combined ordinals of the REAL columns a `SELECT *` emits after the
   /// merged block — every relation's real column at its combined ordinal, in
   /// chain order, skipping a physical constituent a merged column subsumes
-  /// (each exposed ONCE via its merged `value`). Never a virtual ordinal.
+  /// (each exposed once via its merged `value`). Never a virtual ordinal.
   ///
-  /// This is the ONE walk the `SELECT *` surfaces share, so its length and its
+  /// This is the one walk the `SELECT *` surfaces share, so its length and its
   /// membership cannot drift between them: `terms(.all)` maps each to a
   /// `.slot`, `outputs`/`names` read each column's name and type, and
-  /// `width(of: .all)` is `merged.count` plus this count — the width DERIVED
+  /// `width(of: .all)` is `merged.count` plus this count — the width derived
   /// from the same enumeration that emits the columns, not a parallel formula.
   internal var expansion: Array<Int> {
     var ordinals = Array<Int>()
@@ -403,11 +403,11 @@ internal struct Scope {
     return ordinals
   }
 
-  /// The visible (unqualified) column NAMES this scope resolves, in chain order
+  /// The visible (unqualified) column names this scope resolves, in chain order
   /// — the `NATURAL`/`USING` merged columns first, then each member's real
   /// column names skipping a physical constituent a merged column subsumes.
   /// This is the LEFT side's output-name list a `NATURAL` join intersects with
-  /// the joined-in relation to find its common columns. It reads the ONE
+  /// the joined-in relation to find its common columns. It reads the one
   /// `expansion` enumeration the `SELECT *` surfaces share, resolving each
   /// combined ordinal back to its owning relation's spelling (`name(at:)`).
   internal var names: Array<String> {
@@ -432,25 +432,25 @@ internal struct Scope {
 
   /// The LEFT-side resolution of a bare join column `name` when building a
   /// `NATURAL`/`USING` merged column: its value `Term`, its `type`, its
-  /// `unconstrained` mask, and the PHYSICAL combined ordinals it stands over.
+  /// `unconstrained` mask, and the physical combined ordinals it stands over.
   ///
-  /// The `unconstrained` mask is the CONSTITUENT'S — an earlier-merged column's
+  /// The `unconstrained` mask is the constituent'S — an earlier-merged column's
   /// own accumulated bit, else the physical column's `unconstrained(at:)` — so
   /// the `NATURAL`/`USING` type merge honors an all-NULL/placeholder left the
-  /// SAME way the set-operation fold does (a constant-NULL left constrains
+  /// same way the set-operation fold does (a constant-NULL left constrains
   /// nothing, deferring the merged type to the right).
   ///
-  /// A name an earlier join already MERGED resolves to that merged column — its
+  /// A name an earlier join already merged resolves to that merged column — its
   /// coalesce `value`, unified `type`, and constituent ordinals — so a chained
   /// `… USING (k)` keys on the merged value (a `RIGHT`/`FULL` join's left-NULL
-  /// row still joins), THROUGH the FULL ambiguity-aware bare lookup
-  /// (`merged(binding:)`): a merged entry that now COEXISTS with a physical
-  /// column of the same name a LATER PLAIN join re-introduced (`… USING (k) …
-  /// JOIN C ON … JOIN … USING (k)`, C carrying its own `k`) is AMBIGUOUS, so
+  /// row still joins), through the FULL ambiguity-aware bare lookup
+  /// (`merged(binding:)`): a merged entry that now coexists with a physical
+  /// column of the same name a later plain join re-introduced (`… USING (k) …
+  /// JOIN C ON … JOIN … USING (k)`, C carrying its own `k`) is ambiguous, so
   /// keying a later `USING` on it faults `SQLError.ambiguous` here rather than
   /// silently taking the merged value and leaving two output columns named `k`.
-  /// A name NOT yet merged must resolve to EXACTLY ONE left physical column
-  /// (`ordinal(of:)`); an accumulated-left name bound TWICE (a plain `ON` join
+  /// A name NOT yet merged must resolve to exactly one left physical column
+  /// (`ordinal(of:)`); an accumulated-left name bound twice (a plain `ON` join
   /// left two columns of that name) faults `SQLError.ambiguous` here, the
   /// finding-1 trap now a first-class fault at construction rather than a
   /// downstream crash.
@@ -487,11 +487,11 @@ internal struct Scope {
   internal func width(of projection: Projection) -> Int {
     switch projection {
     case .all:
-      // DERIVED from the ONE `expansion` walk `terms(.all)`/`outputs` emit —
+      // derived from the one `expansion` walk `terms(.all)`/`outputs` emit —
       // the merged columns plus the real columns it yields — so the width
       // cannot drift from the emitted count. A parallel `schemas.reduce(width)
-      // − subsumed.count` arithmetic UNDERCOUNTED when a merged column's
-      // constituent was VIRTUAL (a fixture/adapter `Id`): the virtual ordinal
+      // − subsumed.count` arithmetic undercounted when a merged column's
+      // constituent was virtual (a fixture/adapter `Id`): the virtual ordinal
       // is in `subsumed` but was never in the real-width sum, so subtracting it
       // dropped a real column that IS emitted.
       return merged.count + expansion.count
@@ -520,7 +520,7 @@ internal struct Scope {
     return .integer
   }
 
-  /// Whether the real column at combined `ordinal` is UNCONSTRAINED — an
+  /// Whether the real column at combined `ordinal` is unconstrained — an
   /// all-arms-NULL CTE column that places no type constraint, so a bare
   /// reference to it in a set-operation arm unifies with any typed arm order-
   /// independently (`RelationInstance.unconstrained`). A virtual ordinal
@@ -555,7 +555,7 @@ internal struct Scope {
     }
   }
 
-  /// DERIVES the nominal value type a scalar `expression` yields WITHOUT
+  /// derives the nominal value type a scalar `expression` yields without
   /// faulting on an operand: a bare column its source type, a literal its own,
   /// a standard aggregate its result domain (`COUNT`/`SUM`/`AVG` numeric,
   /// `MIN`/`MAX` the operand's type), a scalar call its routine's declared
@@ -567,24 +567,24 @@ internal struct Scope {
   /// schema resolves even for an expression a zero-row limit or a short-circuit
   /// makes unreachable (a run never evaluates it, so it cannot fault).
   ///
-  /// This is the SCHEMA surface. `validate(_:_:)` is the type-check surface: it
+  /// This is the schema surface. `validate(_:_:)` is the type-check surface: it
   /// faults exactly as a run would on a bad operand or an unknown/misused call.
   internal func derive(_ expression: Expression, _ routines: Routines = [:],
                        subquery: Resolution = .unsupported)
       throws(SQLError) -> ValueType {
     return switch expression {
     case let .column(column):
-      // A BARE name matching a `NATURAL`/`USING` merged column types from the
-      // unified coalesce `type` — the merged column has NO physical ordinal, so
+      // A bare name matching a `NATURAL`/`USING` merged column types from the
+      // unified coalesce `type` — the merged column has no physical ordinal, so
       // it is typed here rather than via `type(at:)` (a same-named physical
       // column a later plain join added faults `.ambiguous`).
       if column.qualifier == nil,
           let merged = try merged(binding: column.name) {
         merged.type
       } else if let ordinal = try find(column) {
-        // A column this scope does not bind may be a CORRELATED reference to an
+        // A column this scope does not bind may be a correlated reference to an
         // enclosing query (in an inner `WHERE`); type it as the outer column,
-        // else the ordinary column fault. A LOCALLY AMBIGUOUS name is a HARD
+        // else the ordinary column fault. A locally ambiguous name is a hard
         // error `find` propagates, never a fall-through to outer correlation.
         type(at: ordinal)
       } else if let resolved = try subquery.correlated(column) {
@@ -619,13 +619,13 @@ internal struct Scope {
            derive(rhs, routines, subquery: subquery)].contains(.double)
           ? .double : .integer
     case let .case(whens, otherwise):
-      // The result type is the unification of every REACHABLE branch result
+      // The result type is the unification of every reachable branch result
       // (and the `ELSE`) — the executor's short-circuit means an unreachable
       // branch (a constant-false guard, or any branch after a constant-true
       // one) never yields a value, so it cannot shape the column's type. The
-      // reachable result types must UNIFY; a definitively-irreconcilable clash
+      // reachable result types must unify; a definitively-irreconcilable clash
       // (text beside an integer) faults `SQLError.operand` here too, so this
-      // lowering surface and the faulting `validate` AGREE. A `CASE` always has
+      // lowering surface and the faulting `validate` agree. A `CASE` always has
       // at least one `WHEN`; when none is reachable (every guard
       // constant-false, no reachable `ELSE`) the run yields NULL, for which
       // `.integer` is the schema default.
@@ -643,7 +643,7 @@ internal struct Scope {
       try unified(arguments, routines, subquery: subquery)
     case let .nullif(lhs, rhs):
       // NULLIF yields either `v1` or NULL, so the column takes `v1`'s type —
-      // but derive BOTH operands for resolution, returning the LHS type: an
+      // but derive both operands for resolution, returning the LHS type: an
       // unresolved column faults `SQLError.column` (`NULLIF(1, Missing)`) on
       // this derive-only surface too, mirroring the `||`/arithmetic derive
       // branch rather than leaving the RHS unresolved.
@@ -653,7 +653,7 @@ internal struct Scope {
       // compile pre-pass recorded it beside the width for every subquery, so
       // `derive` reads it (enforcing the single-column arity). A surface with
       // no catalog holds none and faults, rejecting the subquery rather than
-      // mis-typing it, so this derive and the run's lowering AGREE.
+      // mis-typing it, so this derive and the run's lowering agree.
       try subquery.scalar(type: query)
     case .grouping:
       // `GROUPING(a, …)` yields an integer bit-vector; its arguments are
@@ -665,7 +665,7 @@ internal struct Scope {
   }
 
   /// The result type of `NULLIF(v1, v2)` under `derive` — `v1`'s type, deriving
-  /// BOTH operands for resolution first: NULLIF yields either `v1` or NULL, so
+  /// both operands for resolution first: NULLIF yields either `v1` or NULL, so
   /// its own RHS type does not shape the column, but an unresolved column still
   /// faults `SQLError.column`, mirroring the `||`/arithmetic derive branch. So
   /// `NULLIF(1, Missing)` faults `.column` on the derive-only paths
@@ -710,14 +710,14 @@ internal struct Scope {
   /// `SQLError.operand`; a mixed integer/double pair widens to `double`. The
   /// list is never empty (the parser requires ≥ 2 COALESCE arguments).
   ///
-  /// Only a SELECTABLE argument shapes the type. A run skips an argument
+  /// Only a selectable argument shapes the type. A run skips an argument
   /// whose value is NULL and moves on, so an argument folding to a constant
-  /// `.null` (`constant(_ expression:)`) can NEVER be the result — its type is
+  /// `.null` (`constant(_ expression:)`) can never be the result — its type is
   /// derived (an unknown column still faults) but is NOT merged, exactly as a
   /// `CASE` omits an unreachable branch's result type. And an argument that is
-  /// the definite selection (`selects(_:)` — a constant NON-NULL value, or a
+  /// the definite selection (`selects(_:)` — a constant non-NULL value, or a
   /// `COUNT` aggregate that is always non-NULL) sets the type and makes every
-  /// LATER argument unreachable — mirroring a `CASE`'s reachable-branch
+  /// later argument unreachable — mirroring a `CASE`'s reachable-branch
   /// unification and the faulting `validate`'s stop.
   private func unified(_ arguments: Array<Expression>,
                        _ routines: Routines,
@@ -742,9 +742,9 @@ internal struct Scope {
   }
 
   /// Whether `argument` is a COALESCE's definite selection — an argument the
-  /// executor's short-circuit is GUARANTEED to return, making every later
+  /// executor's short-circuit is guaranteed to return, making every later
   /// argument unreachable (neither validated nor unified). That holds when it
-  /// folds to a constant NON-NULL value (`constant(_ expression:)`), or when it
+  /// folds to a constant non-NULL value (`constant(_ expression:)`), or when it
   /// is a `COUNT` aggregate: `COUNT` alone among the aggregates always yields a
   /// row count of 0 or more, never NULL, so it always selects — while `SUM` /
   /// `MIN` / `MAX` / `AVG` are NULL over an empty group and so do NOT stop.
@@ -771,10 +771,10 @@ internal struct Scope {
   }
 
   /// The nominal type of a `CASE` under `derive` — the unification of its
-  /// REACHABLE result types, and `.integer` when no branch is reachable (the
-  /// run yields NULL). The reachable result types must UNIFY (`unified`):
+  /// reachable result types, and `.integer` when no branch is reachable (the
+  /// run yields NULL). The reachable result types must unify (`unified`):
   /// a definitively-irreconcilable pair (a text result beside an integer one)
-  /// faults `SQLError.operand`, so this lowering surface AGREES with the
+  /// faults `SQLError.operand`, so this lowering surface agrees with the
   /// faulting `validate` (`conditional`) — a mixed integer/double `CASE` still
   /// widens to `double`.
   internal func derive(_ whens: Array<When>, _ otherwise: Expression?,
@@ -799,12 +799,12 @@ internal struct Scope {
     return type ?? .integer
   }
 
-  /// The result expressions of a `CASE` the executor's short-circuit can REACH,
+  /// The result expressions of a `CASE` the executor's short-circuit can reach,
   /// in branch order: a `WHEN` whose guard is statically constant-FALSE has an
   /// unreachable result and is dropped; a `WHEN` whose guard is statically
-  /// constant-TRUE is itself reachable and keeps every EARLIER reachable branch
+  /// constant-TRUE is itself reachable and keeps every earlier reachable branch
   /// (a row an earlier row-dependent guard matches takes that branch, never
-  /// reaching this one), but makes every STRICTLY-LATER `WHEN` and the `ELSE`
+  /// reaching this one), but makes every strictly-later `WHEN` and the `ELSE`
   /// unreachable; an `ELSE` is reachable only when no guard is constant-TRUE. A
   /// guard that is not statically decidable (`constant` is `nil`) leaves its
   /// result reachable.
@@ -825,7 +825,7 @@ internal struct Scope {
 
   // MARK: - Validation
 
-  /// The value type a scalar `expression` yields, VALIDATING each operand and
+  /// The value type a scalar `expression` yields, validating each operand and
   /// call exactly as a run would fault: an aggregate or arithmetic over a
   /// non-numeric operand (`SQLError.operand`), a call to an unregistered
   /// routine (`SQLError.function`), a bad arity or argument kind
@@ -835,23 +835,23 @@ internal struct Scope {
   /// resolves column ordinals and reads no cursor, so it type-checks a query
   /// without executing it.
   ///
-  /// This is the TYPE-CHECK surface. `derive(_:_:)` is the non-faulting schema
-  /// surface, which only DERIVES the nominal output type.
+  /// This is the type-CHECK surface. `derive(_:_:)` is the non-faulting schema
+  /// surface, which only derives the nominal output type.
   internal func validate(_ expression: Expression, _ routines: Routines = [:],
                          subquery: SubqueryCheck = .unsupported)
       throws(SQLError) -> ValueType {
     switch expression {
     case let .column(column):
-      // A BARE name matching a `NATURAL`/`USING` merged column (ISO 9075 7.10)
-      // types from the unified coalesce `type` — the SAME merged-aware bare
+      // A bare name matching a `NATURAL`/`USING` merged column (ISO 9075 7.10)
+      // types from the unified coalesce `type` — the same merged-aware bare
       // lookup `term`/`derive` shadow the two physical sides with, so the
       // type-check accepts exactly the bare merged reference the run lowers (a
       // same-named physical column a later plain join added faults `.ambiguous`
       // in `merged(binding:)`). A column this scope does not bind may be a
-      // CORRELATED reference to an enclosing query (validated as the run
+      // correlated reference to an enclosing query (validated as the run
       // resolves it — a `WHERE` one types as its outer column, a
       // projection/`HAVING` one faults unsupported); else the ordinary column
-      // fault. A LOCALLY AMBIGUOUS name is a HARD error `find` propagates — not
+      // fault. A locally ambiguous name is a hard error `find` propagates — not
       // a fall-through to outer correlation.
       if column.qualifier == nil,
           let merged = try merged(binding: column.name) {
@@ -889,14 +889,14 @@ internal struct Scope {
       try subquery.type(query)
     case let .grouping(arguments):
       // `GROUPING(a, …)` yields an integer bit-vector. Validate each argument
-      // RESOLVES as a scalar (the grouped lowering additionally enforces that
+      // resolves as a scalar (the grouped lowering additionally enforces that
       // each names a `GROUP BY` expression — `SQLError.grouping` otherwise —
       // which this per-operand type-check does not duplicate), then accept.
       try grouping(over: arguments, routines, subquery: subquery)
     }
   }
 
-  /// The type of `GROUPING(a, …)` under `validate` — `.integer`, VALIDATING
+  /// The type of `GROUPING(a, …)` under `validate` — `.integer`, validating
   /// each argument resolves as a run would (an unknown column, a bad operand,
   /// or an ill-typed call inside an argument faults). The grouped lowering
   /// enforces that each argument is a `GROUP BY` expression, so this only
@@ -911,16 +911,16 @@ internal struct Scope {
     return .integer
   }
 
-  /// The result type of `COALESCE(v1, v2, …)`, validating each REACHABLE
-  /// argument as a run would fault and unifying only the SELECTABLE ones'
+  /// The result type of `COALESCE(v1, v2, …)`, validating each reachable
+  /// argument as a run would fault and unifying only the selectable ones'
   /// types (`merged`). A definitively-irreconcilable pair (a text argument
   /// beside an integer) faults `SQLError.operand`, as the column cannot be two
   /// kinds; a mixed integer/double pair widens to `double`.
   ///
-  /// The executor returns the first NON-NULL argument and never evaluates a
+  /// The executor returns the first non-NULL argument and never evaluates a
   /// later one, so an argument that is the definite selection (`selects(_:)` —
-  /// a constant NON-NULL value, or a `COUNT` aggregate that is always non-NULL)
-  /// makes every LATER argument unreachable — those are NOT validated
+  /// a constant non-NULL value, or a `COUNT` aggregate that is always non-NULL)
+  /// makes every later argument unreachable — those are NOT validated
   /// (`COALESCE(1, missing_udf())` and `COALESCE(COUNT(*), missing_udf())` both
   /// type-check), exactly as a constant-TRUE `CASE` guard makes later branches
   /// unreachable.
@@ -968,31 +968,31 @@ internal struct Scope {
     return type
   }
 
-  /// The target `type` of a `CAST`, VALIDATING `operand` for real errors
-  /// (unknown column, bad call arity, …) as a run would fault, and REJECTING a
+  /// The target `type` of a `CAST`, validating `operand` for real errors
+  /// (unknown column, bad call arity, …) as a run would fault, and rejecting a
   /// cast the runtime could never perform before advertising the target type.
   ///
-  /// A cast whose (operand type → target type) PAIR is structurally
+  /// A cast whose (operand type → target type) pair is structurally
   /// unsupported — a boolean to a number, a number to a blob — faults `42846`
-  /// for EVERY value of the operand's kind, so `SELECT CAST(TRUE AS INTEGER)`
+  /// for every value of the operand's kind, so `SELECT CAST(TRUE AS INTEGER)`
   /// would otherwise advertise an integer column though executing it
   /// unconditionally throws. `ValueType.castable(to:)` — the same structural
   /// truth the runtime cast consults — rejects that pair here, at validation.
   ///
-  /// A castable-but-VALUE-dependent pair still passes: a `text` to a number, or
+  /// A castable-but-value-dependent pair still passes: a `text` to a number, or
   /// a `blob` to `text`, is a supported pair whose fault (`22018`/`22003`)
   /// depends on the value, so a reachable good value runs — `CAST('1' AS
-  /// INTEGER)` type-checks. The exception is a CONSTANT operand that folds and
+  /// INTEGER)` type-checks. The exception is a constant operand that folds and
   /// ALWAYS fails: `CAST('abc' AS INTEGER)` is unparseable for the one value it
   /// can have, so a trial cast of the folded constant rejects it too.
   ///
   /// The constant fold runs FIRST, before the structural pair rejection: a
-  /// constant operand casts to ONE value, so its trial cast decides the cast
-  /// outright — it ALLOWS a statically-NULL operand (`CAST(CASE WHEN 1 = 0
+  /// constant operand casts to one value, so its trial cast decides the cast
+  /// outright — it allows a statically-NULL operand (`CAST(CASE WHEN 1 = 0
   /// THEN 1 END AS BLOB)` folds to `.null`, which casts to ANY target) even
-  /// where the operand's DERIVED type would make the pair structurally
-  /// unsupported, and it still REJECTS a constant that always fails. Only a
-  /// NON-constant operand, whose value is unknown at validation, falls to the
+  /// where the operand's derived type would make the pair structurally
+  /// unsupported, and it still rejects a constant that always fails. Only a
+  /// non-constant operand, whose value is unknown at validation, falls to the
   /// structural pair check.
   private func validate(cast operand: Expression, to type: ValueType,
                         _ routines: Routines,
@@ -1000,7 +1000,7 @@ internal struct Scope {
       throws(SQLError) -> ValueType {
     let source = try validate(operand, routines, subquery: subquery)
     // A constant operand casts to one value only, so its trial cast is the
-    // whole decision: it ALLOWS a folded NULL to any target and REJECTS a
+    // whole decision: it allows a folded NULL to any target and rejects a
     // spelling that always faults (`CAST('abc' AS INTEGER)`). A non-constant
     // operand folds to `nil`, so the structural pair check rejects a kind that
     // could never cast (`CAST(<boolean column> AS INTEGER)` → `42846`).
@@ -1013,11 +1013,11 @@ internal struct Scope {
     return type
   }
 
-  /// The result type of a `CASE`, validating each REACHABLE branch as a run
+  /// The result type of a `CASE`, validating each reachable branch as a run
   /// would fault and honouring the executor's short-circuit: each evaluated
   /// `WHEN` guard is a boolean predicate whose operands are validated
-  /// (`check`); only a REACHABLE result expression is validated; and the
-  /// reachable result types must UNIFY to one type (`ValueType.unified`) — a
+  /// (`check`); only a reachable result expression is validated; and the
+  /// reachable result types must unify to one type (`ValueType.unified`) — a
   /// definitively-irreconcilable pair (a text result beside an integer one)
   /// faults `SQLError.operand`, as a query cannot yield a column of two kinds.
   /// A mixed integer/double `CASE` widens to `double`.
@@ -1026,12 +1026,12 @@ internal struct Scope {
   /// later branch, so a `WHEN` whose guard is statically constant-FALSE has an
   /// unreachable result — its operands are NOT validated (`CASE WHEN 1 = 0 THEN
   /// Name + 1 ELSE 0 END` type-checks). A constant-TRUE guard is itself
-  /// reachable and KEEPS every earlier reachable branch — a row an earlier
+  /// reachable and keeps every earlier reachable branch — a row an earlier
   /// row-dependent guard matches takes that branch, never reaching the
   /// constant-TRUE one — so those earlier results are still validated (`CASE
   /// WHEN Id = 1 THEN Name + 1 WHEN 1 = 1 THEN 0 END` faults on the reachable
-  /// `Id = 1` branch's `Name + 1`); it makes only every STRICTLY-LATER guard,
-  /// result, and the `ELSE` unreachable. A REACHABLE bad operand (`WHEN Id = 1
+  /// `Id = 1` branch's `Name + 1`); it makes only every strictly-later guard,
+  /// result, and the `ELSE` unreachable. A reachable bad operand (`WHEN Id = 1
   /// THEN Name + 1`) still faults. When no branch is reachable the run yields
   /// NULL, typed `.integer` (the schema default), with no result to validate.
   private func conditional(_ whens: Array<When>, _ otherwise: Expression?,
@@ -1043,7 +1043,7 @@ internal struct Scope {
     for branch in whens {
       // The guard up to (and including) the decisive one is evaluated, so
       // validate its operands; a constant-FALSE guard's result is unreachable
-      // (skip it), a constant-TRUE one is reachable but makes every LATER
+      // (skip it), a constant-TRUE one is reachable but makes every later
       // branch unreachable — so keep the earlier results and this one, then
       // stop.
       try check(branch.when, routines, subquery: subquery)
@@ -1079,8 +1079,8 @@ internal struct Scope {
   /// in the routine's `minimum ... parameters.count` arity (a fixed-arity
   /// routine has `minimum == parameters.count`, so this is exact for it, and an
   /// optional-tail routine like `OVERLAY` admits either count); and each
-  /// SUPPLIED argument's static type must equal the declared parameter type. A
-  /// nullable column of the DECLARED
+  /// supplied argument's static type must equal the declared parameter type. A
+  /// nullable column of the declared
   /// type passes — statically it carries its declared type and a run-time NULL
   /// propagates — so only a definitively-wrong type (text where an integer is
   /// required) is rejected, mirroring a routine like `BITAND` throwing
@@ -1120,8 +1120,8 @@ internal struct Scope {
   /// The result type of `function` folded over `operand`, validating the
   /// operand as a run would fault. `COUNT` counts rows (`.integer`);
   /// `MIN`/`MAX` take the operand's own type — they compare, so any comparable
-  /// value folds. `SUM`/`AVG` fold NUMERICALLY: `SUM` yields the operand's
-  /// numeric type, `AVG` a double, so both REQUIRE a numeric operand — over
+  /// value folds. `SUM`/`AVG` fold numerically: `SUM` yields the operand's
+  /// numeric type, `AVG` a double, so both require a numeric operand — over
   /// text, boolean, or blob `Aggregate.fold` faults `SQLError.operand` on the
   /// first non-NULL value, so typing faults the same way rather than
   /// advertising `AVG(Name)` as a double or `SUM(Name)` as text for a query
@@ -1139,16 +1139,16 @@ internal struct Scope {
         throw .state("42803", "an aggregate is not allowed in a FILTER")
       }
       try check(filter, routines, subquery: subquery)
-      // A FILTER that STATICALLY cannot admit a row makes the operand
+      // A FILTER that statically cannot admit a row makes the operand
       // unreachable: the executor gates on a definite TRUE (a FALSE or UNKNOWN
-      // row is skipped, and the argument is evaluated only AFTER the gate), so
+      // row is skipped, and the argument is evaluated only after the gate), so
       // an operand behind a statically non-TRUE filter never folds. `SUM(1 / 0)
       // FILTER (WHERE 1 = 0)` thus runs to the empty result (NULL) — do NOT
       // validate the dead operand, or a fault it could never raise (a divide by
       // zero) would wrongly reject a runnable query. The aggregate is
       // statically empty, so advertise its declared/derived result type without
       // the operand's run-time-fault check (`dead(_:_:)` proves the filter
-      // ROW-INDEPENDENTLY never TRUE); a filter that could be TRUE still
+      // ROW-independently never TRUE); a filter that could be TRUE still
       // validates the operand as a bare aggregate does.
       if dead(filter, routines) {
         return try empty(function, over: operand, routines)
@@ -1181,8 +1181,8 @@ internal struct Scope {
   }
 
   /// The result type of `function` folded over `operand` when a statically
-  /// non-TRUE `FILTER` makes the fold empty — the operand is UNREACHABLE, so it
-  /// is DERIVED for its type (resolving a column) but NOT validated for a
+  /// non-TRUE `FILTER` makes the fold empty — the operand is unreachable, so it
+  /// is derived for its type (resolving a column) but NOT validated for a
   /// run-time fault it can never raise (a divide by zero, a non-numeric SUM).
   /// The empty fold yields `COUNT` `0` and every other aggregate NULL, so the
   /// type is the set-function's declared/derived one, mirroring `aggregate` but
@@ -1203,17 +1203,17 @@ internal struct Scope {
     }
   }
 
-  /// Whether `filter` is ROW-INDEPENDENTLY never TRUE — so a `FILTER`'s gate
+  /// Whether `filter` is ROW-independently never TRUE — so a `FILTER`'s gate
   /// (which admits a row only on a definite TRUE) can never admit one and the
-  /// aggregate operand behind it is UNREACHABLE. An `AND` is TRUE only when
-  /// EVERY conjunct is TRUE, so a single conjunct that is row-independently
+  /// aggregate operand behind it is unreachable. An `AND` is TRUE only when
+  /// every conjunct is TRUE, so a single conjunct that is row-independently
   /// non-TRUE kills the whole conjunction regardless of the others: flatten the
   /// top-level `Predicate.and` spine (`a AND (b AND c)` to `a, b, c` — each
   /// non-AND node one conjunct, not descending into `OR`) and prove it dead
   /// when ANY conjunct folds definitely FALSE (`constant(_:)` `false`), or is
   /// `settled` (row-independent) and folds to UNKNOWN (`constant(_:)` `nil`).
   /// This subsumes the whole-filter case (a settled-non-TRUE filter is a lone
-  /// conjunct). It stays SOUND — only a PROVABLY non-TRUE conjunct kills the
+  /// conjunct). It stays sound — only a provably non-TRUE conjunct kills the
   /// filter: a row-dependent conjunct (could be TRUE per row) or a settled-TRUE
   /// one does NOT, so those still validate the operand.
   private func dead(_ filter: Predicate, _ routines: Routines) -> Bool {
@@ -1251,9 +1251,9 @@ internal struct Scope {
     let left = try validate(lhs, routines, subquery: subquery)
     let right = try validate(rhs, routines, subquery: subquery)
     if case .concatenate = op {
-      // Both operands are validated above for their OWN errors. `||` yields
-      // text and needs two text operands — UNLESS one folds to a static NULL,
-      // in which case `Arithmetic.apply` returns NULL BEFORE it inspects EITHER
+      // Both operands are validated above for their own errors. `||` yields
+      // text and needs two text operands — unless one folds to a static NULL,
+      // in which case `Arithmetic.apply` returns NULL before it inspects either
       // kind, so the whole expression yields NULL and runs whatever the other
       // operand's type (as the CAST path admits a folded NULL to any target):
       // `(CASE WHEN 1 = 0 THEN 1 END) || 1` runs. A non-text, non-NULL pairing
@@ -1265,7 +1265,7 @@ internal struct Scope {
       return .text
     }
     // A statically-NULL operand makes the whole arithmetic NULL: `Arithmetic.apply`
-    // returns NULL before it inspects EITHER operand's kind, divides, or
+    // returns NULL before it inspects either operand's kind, divides, or
     // overflows, so the expression runs whatever the other operand's kind —
     // `NULL + 'x'`, `'x' + NULL`, and even `NULL / 0` yield NULL — mirroring the
     // concatenation path above. Skip the numeric-kind guard and the divide/
@@ -1293,7 +1293,7 @@ internal struct Scope {
 
   /// Whether `expression` folds to a static NULL — a row-independent constant
   /// NULL. A `||` with a vanishing operand yields NULL before its
-  /// `Arithmetic.apply` inspects EITHER operand's kind, so the whole expression
+  /// `Arithmetic.apply` inspects either operand's kind, so the whole expression
   /// is valid whatever the other operand's type, mirroring the CAST validation
   /// path that admits a folded NULL to any target — so a no-match `CASE` typed
   /// `.integer` that yields NULL lets `(CASE WHEN 1 = 0 THEN 1 END) || 1` run.
@@ -1323,7 +1323,7 @@ internal struct Scope {
   ///
   /// It respects the executor's short-circuit: `false AND rhs` and `true OR
   /// rhs` never evaluate `rhs` (`evaluate` returns on the left arm), so a right
-  /// arm a STATICALLY-false `AND` (or true `OR`) guards is unreachable and is
+  /// arm a statically-false `AND` (or true `OR`) guards is unreachable and is
   /// not type-checked — `WHERE 1 = 0 AND Name + 1 = 2` runs, so its schema
   /// resolves rather than faulting on the unreachable `Name + 1`.
   func check(_ predicate: Predicate,
@@ -1335,18 +1335,18 @@ internal struct Scope {
       _ = try validate(left, routines, subquery: subquery)
       _ = try validate(right, routines, subquery: subquery)
     case let .exists(query, _):
-      // Validate the inner UNCORRELATED query as the run's lowering does — it
+      // Validate the inner uncorrelated query as the run's lowering does — it
       // resolves and type-checks against the enclosing catalog, so a bad column
       // or routine inside it faults at validation, matching what a run rejects.
       // Reached in the `existential` role, so the deferred phase validates its
-      // cardinality PROBE (no select list), never the original projection.
+      // cardinality probe (no select list), never the original projection.
       try subquery.validate(query, as: .existential)
     case let .within(operand, query, _):
       // Validate the operand AND the inner query, and enforce the single-column
       // arity the lowering does (`SQLError.arity`), so schema validation
       // matches execution — the recurring lesson that the two must not diverge.
       // Reached in the `valued` role — its value set is read, so the deferred
-      // phase validates the ORIGINAL query.
+      // phase validates the original query.
       _ = try validate(operand, routines, subquery: subquery)
       try subquery.validate(query, as: .valued)
       let width = try subquery.width(query)
@@ -1355,7 +1355,7 @@ internal struct Scope {
       // As `within`: validate the operand and the inner query, and enforce the
       // single-column arity the lowering does (`SQLError.arity`), so schema
       // validation matches execution. Reached `valued` (its values are read),
-      // so the deferred phase validates the ORIGINAL query.
+      // so the deferred phase validates the original query.
       _ = try validate(operand, routines, subquery: subquery)
       try subquery.validate(query, as: .valued)
       let width = try subquery.width(query)
@@ -1376,7 +1376,7 @@ internal struct Scope {
       // may match a like-kind element), and the schema check must accept what
       // the run accepts — rejecting it here would diverge from the run.
       //
-      // The OR-chain short-circuits: a DEFINITE constant match (`x = v` folds
+      // The OR-chain short-circuits: a definite constant match (`x = v` folds
       // TRUE, both row-independent constants) makes the whole `IN` TRUE and
       // leaves every later element unreachable, so validation stops there —
       // `1 IN (1 + 0, Name + 1)` type-checks, the run matching `1 = 1 + 0`
@@ -1400,7 +1400,7 @@ internal struct Scope {
     case let .rows(lhs, _, rhs):
       // `(l…) <op> (r…)` lowers to a componentwise comparison, so type each
       // component of both rows for real errors (unknown column, bad arity, …),
-      // and enforce the EQUAL-arity rule the lowering does (`SQLError.arity`)
+      // and enforce the equal-arity rule the lowering does (`SQLError.arity`)
       // so schema validation matches execution. A cross-kind component is NOT
       // rejected — the run's `matches` yields FALSE across kinds without
       // faulting, as an `IN` element does — so the schema accepts what the run
@@ -1417,12 +1417,12 @@ internal struct Scope {
     case let .among(lhs, rows, _):
       // `(l…) [NOT] IN ((r…), …)` lowers to a disjunction of row equalities, so
       // type the left row and each element row for real errors, and enforce the
-      // non-empty list and per-row EQUAL-arity rules the lowering does. A
+      // non-empty list and per-row equal-arity rules the lowering does. A
       // cross-kind component is NOT rejected, as an `IN` element is not.
       //
       // The OR-chain short-circuits exactly as the scalar `.membership` does: a
-      // DEFINITE constant match (both the left row and an element row fold to
-      // ROW-INDEPENDENT constants whose tuple-equality `relate` yields TRUE)
+      // definite constant match (both the left row and an element row fold to
+      // ROW-independent constants whose tuple-equality `relate` yields TRUE)
       // makes the whole `IN` TRUE and leaves every later element unreachable,
       // so validation stops there — `(1, 2) IN ((1, 2), (Name + 1, 3))`
       // type-checks (the constant `(1, 2)` matches the first element before
@@ -1468,10 +1468,10 @@ internal struct Scope {
       // check accepts what the run accepts.
       //
       // It respects the executor's short-circuit — the same one `ranged`
-      // evaluates with: a DEFINITELY-FALSE lower comparison (`x >= a`) settles
+      // evaluates with: a definitely-FALSE lower comparison (`x >= a`) settles
       // the whole truth (BETWEEN FALSE, NOT BETWEEN TRUE — the latter is the
       // negation of that truth, not the divergent `x < a OR x > b` expansion),
-      // leaving `upper` unreachable for BOTH spellings, so `upper` is NOT
+      // leaving `upper` unreachable for both spellings, so `upper` is NOT
       // validated — `0 BETWEEN 1 AND (1 / 0)` type-checks, the lower `0 >= 1`
       // FALSE settling the row before the `1 / 0` upper is reached, exactly as
       // an `AND`'s constant-false left leaves its right unchecked.
@@ -1487,8 +1487,8 @@ internal struct Scope {
       if !settled { try validate(upper, routines, subquery: subquery) }
     case let .distinct(lhs, rhs, _):
       // `a IS [NOT] DISTINCT FROM b` compares both operands, so validate the
-      // two for real errors (an unknown column, a bad call). BOTH are always
-      // validated — the predicate is TWO-VALUED with no short-circuit: neither
+      // two for real errors (an unknown column, a bad call). both are always
+      // validated — the predicate is two-valued with no short-circuit: neither
       // side settles the truth without the other. A cross-kind pair is NOT
       // rejected: the run's `distinct` treats it as DISTINCT without faulting
       // (as an `IN` element does), so the schema check accepts what the run
@@ -1527,8 +1527,8 @@ internal struct Scope {
     }
   }
 
-  /// Rejects a STATICALLY-invalid `LIKE` `escape` at validation, as `Row.like`
-  /// would fault it on EVERY row: a ROW-INDEPENDENT escape expression that
+  /// Rejects a statically-invalid `LIKE` `escape` at validation, as `Row.like`
+  /// would fault it on every row: a ROW-independent escape expression that
   /// folds (`constant`) to a value that is neither NULL (a valid UNKNOWN) nor a
   /// single-character text (a non-text, or a wrong-length text) makes the query
   /// un-runnable, so reject it here with the same message and condition the run
@@ -1552,7 +1552,7 @@ internal struct Scope {
   }
 
   /// The definite truth of the equality `operand = value` when both fold to
-  /// ROW-INDEPENDENT CONSTANTS (via `constant`) — the OR-chain equality an `IN`
+  /// ROW-independent constants (via `constant`) — the OR-chain equality an `IN`
   /// element folds to — else `nil` (a side reading a row is decided per row).
   /// It folds each side through `constant` — the same `value(of:)`, arithmetic,
   /// and comparison the run evaluates a `left = element` comparison with — so a
@@ -1566,29 +1566,29 @@ internal struct Scope {
     return matches(lhs, .equal, rhs)
   }
 
-  /// The constant `Value` `expression` folds to when it is ROW-INDEPENDENT —
+  /// The constant `Value` `expression` folds to when it is ROW-independent —
   /// else `nil` (an operand a row, group, or run context decides). A literal
-  /// folds to its value; a binary folds its two operands and applies the SAME
+  /// folds to its value; a binary folds its two operands and applies the same
   /// `Arithmetic.apply(Value, Value)` the run's binary evaluation uses, so the
   /// fold matches the run exactly (and a would-be fault — a divide, an overflow
-  /// — collapses to `nil` rather than deciding a match). A ROW-INDEPENDENT call
-  /// to a DETERMINISTIC routine (every argument folds constant) folds to its
-  /// routine's value over those folded arguments — the SAME `Routine` the run
+  /// — collapses to `nil` rather than deciding a match). A ROW-independent call
+  /// to a deterministic routine (every argument folds constant) folds to its
+  /// routine's value over those folded arguments — the same `Routine` the run
   /// invokes over the same constant arguments, so the fold matches the run; an
-  /// unregistered name, a NOT DETERMINISTIC routine, a non-constant argument,
+  /// unregistered name, a NOT deterministic routine, a non-constant argument,
   /// or a throwing routine collapses to `nil`. Only a deterministic routine
   /// folds (ISO): executing a non-deterministic one here could return one value
-  /// while this compile-time walk decides reachability and a DIFFERENT one when
+  /// while this compile-time walk decides reachability and a different one when
   /// the run reaches the same call — pruning an element the run keeps. Every
   /// other expression is not statically foldable: a `column` reads a row and an
-  /// `aggregate` folds a group, so each is `nil`. A ROW-INDEPENDENT `case`
+  /// `aggregate` folds a group, so each is `nil`. A ROW-independent `case`
   /// folds too — walking the `WHEN`s in order over `constant(_ predicate:)`:
   /// the first constant-TRUE guard yields its folded result, a constant-FALSE
   /// guard is skipped, and a guard the fold cannot decide (`nil`) means the
   /// taken branch is per row, so the whole `case` is `nil`; with no
   /// constant-TRUE guard it folds the `ELSE`, or `.null` when there is none (a
-  /// no-match `CASE` yields NULL). This honours the SAME reachability
-  /// `reachable(_:_:_:)` validates with. Returning `nil` is SOUND — a caller
+  /// no-match `CASE` yields NULL). This honours the same reachability
+  /// `reachable(_:_:_:)` validates with. Returning `nil` is sound — a caller
   /// that cannot fold an element keeps considering it, never wrongly pruning a
   /// later one.
   private func constant(_ expression: Expression, _ routines: Routines)
@@ -1630,7 +1630,7 @@ internal struct Scope {
       guard let otherwise else { return .null }
       return constant(otherwise, routines)
     case let .cast(operand, type):
-      // A ROW-INDEPENDENT operand folds to its converted value — the SAME
+      // A ROW-independent operand folds to its converted value — the same
       // `Value.cast(to:)` the run applies, so the fold matches. A would-be
       // fault (an unconvertible value) collapses to `nil`, so the cast stays
       // undecided rather than deciding a match, just as a would-be-faulting
@@ -1639,14 +1639,14 @@ internal struct Scope {
       return try? value.cast(to: type)
     case let .coalesce(arguments):
       // Fold as the run evaluates it — the first argument that folds to a
-      // non-NULL value (COERCED to the unified type, as the executor's
+      // non-NULL value (coerced to the unified type, as the executor's
       // `Term.coalesce` coerces the selected value), else NULL when every
-      // argument folds NULL. An argument the fold cannot decide (`nil`) BEFORE
+      // argument folds NULL. An argument the fold cannot decide (`nil`) before
       // a decisive non-NULL one means the taken value is per row, so the whole
       // `COALESCE` is `nil`. Coercing an `.integer` selected from a COALESCE
       // that unifies to `.double` folds to `.double`, matching the advertised
       // column type — so a `.double`-typed routine over `COALESCE(1, 2.5)`
-      // folds against the SAME value the run supplies. The unified type is the
+      // folds against the same value the run supplies. The unified type is the
       // one `derive`/`unified` already reduces over the selectable arguments;
       // an irreconcilable pair (which `derive` would fault on) leaves the value
       // uncoerced (`try?` → `nil`), a no-op the executor never reaches.
@@ -1667,7 +1667,7 @@ internal struct Scope {
       }
       return matches(va, .equal, vb) == true ? .null : va
     case .column, .aggregate, .subquery, .grouping:
-      // A `subquery` is row-independent but is materialised at RUN (this
+      // A `subquery` is row-independent but is materialised at run (this
       // compile-time fold has no cache), so it is not statically foldable —
       // `nil`, like a `column` or `aggregate`. A `grouping` is constant only
       // relative to a specific grouped ARM (this AST-level fold has no arm
@@ -1676,12 +1676,12 @@ internal struct Scope {
     }
   }
 
-  /// Whether `expression` folds to a CONSTANT NULL for EVERY row — a projected
-  /// column that places NO type constraint on a set-operation's unified column,
+  /// Whether `expression` folds to a constant NULL for every row — a projected
+  /// column that places no type constraint on a set-operation's unified column,
   /// so the fold skips its (literal-fix) type exactly as `COALESCE` skips a
   /// constant-NULL argument. The projection walk (`output(_ item:)`) reads this
   /// beside its type derive, so a column's type and its `unconstrained` mask
-  /// come from ONE resolution over the SAME expression and cannot diverge.
+  /// come from one resolution over the same expression and cannot diverge.
   ///
   /// A `CASE` every reachable result of which is NULL yields NULL whichever
   /// branch runs, so it is constant NULL even when a row-dependent guard leaves
@@ -1697,24 +1697,24 @@ internal struct Scope {
     return false
   }
 
-  /// Whether evaluating `expression` would dispatch an INVALID routine call —
-  /// the tree contains, at ANY depth, a `.call(name, _)` that is UNREGISTERED
-  /// (`routines[name] == nil`) or INVALID for its routine (bad arity or a
+  /// Whether evaluating `expression` would dispatch an invalid routine call —
+  /// the tree contains, at ANY depth, a `.call(name, _)` that is unregistered
+  /// (`routines[name] == nil`) or invalid for its routine (bad arity or a
   /// definitively-wrong argument type). Such a call has no genuine return type
   /// (`derive` fabricates the declared `returns`, or the `.integer` default for
   /// a missing name), yet the run faults on it (`SQLError.function` for the
   /// missing name, `SQLError.argument` for the bad arity/type), so a projection
-  /// over it places NO type constraint on a set-operation's unified column:
-  /// mark it UNCONSTRAINED and let the fold defer to the other arm rather than
-  /// fault on the fabricated type. This is SOUND either way — if the arm is
-  /// REACHED the run dispatches it and faults, and if it is NOT reached (a
+  /// over it places no type constraint on a set-operation's unified column:
+  /// mark it unconstrained and let the fold defer to the other arm rather than
+  /// fault on the fabricated type. This is sound either way — if the arm is
+  /// reached the run dispatches it and faults, and if it is NOT reached (a
   /// zero-row limit, a filtered-out arm) the expression is never evaluated, so
   /// its fabricated type is irrelevant. Only an invalid call trips it, so a
-  /// VALID call (correct arity and argument types) stays constrained — its
+  /// valid call (correct arity and argument types) stays constrained — its
   /// declared `returns` still shapes the fold — and a genuine type mismatch
   /// still faults `SQLError.operand` (42804).
   ///
-  /// It MIRRORS `derive`'s expression arms exactly so no form escapes: a bare
+  /// It mirrors `derive`'s expression arms exactly so no form escapes: a bare
   /// call is the depth-0 case of the `.call` arm, and every composite arm
   /// recurses the same sub-expressions `derive` traverses.
   internal func unresolved(_ expression: Expression,
@@ -1726,12 +1726,12 @@ internal struct Scope {
       return false
     // `.call`: the depth-0 case (an unregistered name), OR an unregistered
     // call nested in an argument — subsuming the former bare-call special case
-    // in `output(_ item:)`. An INVALID call to an EXISTING routine (bad arity
-    // or a definitively-wrong argument type) is treated like a MISSING one:
+    // in `output(_ item:)`. An invalid call to an existing routine (bad arity
+    // or a definitively-wrong argument type) is treated like a missing one:
     // `derive` fabricates the declared `returns` for it, but the run faults
     // (`SQLError.argument`), so its type must not constrain the fold. This
     // mirrors the strict validator `call(_:over:_:)`'s arity/type guards as a
-    // NON-throwing probe.
+    // non-throwing probe.
     case let .call(name, arguments):
       guard let routine = routines[name] else { return true }
       guard (routine.minimum ... routine.parameters.count)
@@ -1753,7 +1753,7 @@ internal struct Scope {
       case .star: return false
       case let .expression(argument): return unresolved(argument, routines)
       }
-    // `.case`: `derive` unifies only the REACHABLE result expressions
+    // `.case`: `derive` unifies only the reachable result expressions
     // (`reachable`), so mirror that reach — an unregistered call in an
     // unreachable branch never runs and never shapes the type.
     case let .case(whens, otherwise):
@@ -1762,8 +1762,8 @@ internal struct Scope {
     // `.cast`: `derive` recurses the operand for its resolution.
     case let .cast(operand, _):
       return unresolved(operand, routines)
-    // `.coalesce`: `derive` (`unified`) scans only the REACHABLE prefix — it
-    // STOPS at the first argument a constant non-NULL value `selects`, so a
+    // `.coalesce`: `derive` (`unified`) scans only the reachable prefix — it
+    // stops at the first argument a constant non-NULL value `selects`, so a
     // later argument never runs nor shapes the type. Mirror that reach, else
     // `COALESCE(1, missing())` wrongly defers instead of constraining `1`.
     case let .coalesce(arguments):
@@ -1775,12 +1775,12 @@ internal struct Scope {
     // `.nullif`: `derive` (`nullif`) derives both operands.
     case let .nullif(lhs, rhs):
       return unresolved(lhs, routines) || unresolved(rhs, routines)
-    // `.subquery`: a nested scalar subquery resolves its OWN columns through
+    // `.subquery`: a nested scalar subquery resolves its own columns through
     // the memo (`scalar(resolved:)`), which already carries the unconstrained
     // mask for any unregistered call inside it — do NOT double-handle it here.
     case .subquery:
       return false
-    // `.grouping`: `derive` types it `.integer` as a LEAF (it does not derive
+    // `.grouping`: `derive` types it `.integer` as a leaf (it does not derive
     // the arguments, exactly as a `call` types from its declared return), so it
     // fabricates no routine type and constrains the fold — never unresolved.
     case .grouping:
@@ -1788,7 +1788,7 @@ internal struct Scope {
     }
   }
 
-  /// The constant `Value`s a ROW `row` folds to when EVERY component is
+  /// The constant `Value`s a ROW `row` folds to when every component is
   /// row-independent — else `nil` (any component a row/group/run decides). A
   /// row comparison and a row `IN` element fold through this so a single row-
   /// dependent component leaves the whole row undecided, matching the runtime's
@@ -1805,22 +1805,22 @@ internal struct Scope {
   }
 
   /// Folds an `IN` value list as its OR-chain of `operand = element`
-  /// equalities, honouring the executor's SHORT-CIRCUIT: the elements are
+  /// equalities, honouring the executor's short-circuit: the elements are
   /// visited in order, each mapped to its three-valued equality truth by
   /// `equality`, and the truths are OR-folded — but a definite `true` stops the
-  /// walk, since the OR-chain matches there and every LATER element is
-  /// unreachable (`Row.matches` returns on the first true arm). This is the ONE
+  /// walk, since the OR-chain matches there and every later element is
+  /// unreachable (`Row.matches` returns on the first true arm). This is the one
   /// short-circuit the `IN` type-check (`check`), constant fold (`constant`),
   /// and empty-group evaluator (`empty`) all share: each supplies the
   /// per-element `equality` its surface computes with, and every surface stops
   /// at the same element the run does.
   ///
-  /// `visit` runs on each element BEFORE its truth is taken, so a surface with
+  /// `visit` runs on each element before its truth is taken, so a surface with
   /// a per-element side effect (validation) applies it to exactly the reachable
   /// prefix. The fold seeds FALSE (an empty match is FALSE), so the returned
   /// truth is the disjunction over the visited prefix.
   ///
-  /// The element is GENERIC — a scalar value list supplies an `Expression` per
+  /// The element is generic — a scalar value list supplies an `Expression` per
   /// element, a row `IN` a whole `Array<Expression>` row — so the same
   /// short-circuit drives the scalar `.membership` and the row `.among` folds,
   /// the tuple-equality via `relate` standing in for the scalar equality.
@@ -1833,7 +1833,7 @@ internal struct Scope {
     for element in elements {
       try visit(element)
       truth = or(truth, try equality(element))
-      // A definite match makes every LATER element unreachable — the OR-chain
+      // A definite match makes every later element unreachable — the OR-chain
       // short-circuits here, exactly as the run does.
       if truth == true { break }
     }
@@ -1842,7 +1842,7 @@ internal struct Scope {
 
   /// The definite constant truth value of `predicate` when it is statically
   /// decidable — a comparison or `IS [NOT] NULL` whose operands fold to
-  /// ROW-INDEPENDENT `Value`s (via `constant(_ expression:)`: literals,
+  /// ROW-independent `Value`s (via `constant(_ expression:)`: literals,
   /// arithmetic, deterministic calls, nested `CASE`s), composed through
   /// `AND`/`OR`/`NOT`/`IN` — else `nil` (a predicate reading a column or a
   /// `:parameter` is decided per row). `check(_:_:)` reads it to skip an arm
@@ -1869,7 +1869,7 @@ internal struct Scope {
       guard let value = constant(operand, routines) else { return nil }
       return !value
     case let .null(operand, negated):
-      // A ROW-INDEPENDENT operand that folds to a concrete value is not NULL;
+      // A ROW-independent operand that folds to a concrete value is not NULL;
       // one that folds to `.null` (a NULL literal, or a deterministic routine
       // returning NULL) is NULL — matching the run. An operand the fold cannot
       // decide (`nil`) is per row, so the truth is too. This mirrors
@@ -1881,7 +1881,7 @@ internal struct Scope {
       // Fold `x IN (…)` exactly as its OR-chain of equalities folds — the same
       // primitives (`matched`/`constant`, `matches`, `membership`'s
       // short-circuit) — honouring the OR-chain's short-circuit: once a
-      // ROW-INDEPENDENT element definitely equals the constant operand the fold
+      // ROW-independent element definitely equals the constant operand the fold
       // is `true`, so a later row-dependent element (which alone would make the
       // fold per-row `nil`) is unreachable and does not spoil it —
       // `1 IN (1 + 0, Name + 1)` folds `true`. Absent a decisive match, any
@@ -1893,8 +1893,8 @@ internal struct Scope {
       return negated ? truth.map { !$0 } : truth
     case let .like(operand, pattern, escape, negated):
       // Fold `x LIKE p` when the operand, pattern, and optional escape all fold
-      // to ROW-INDEPENDENT constants — the same `constant(_ expression:)` the
-      // run's terms evaluate through — running the SAME matcher `Row.like`
+      // to ROW-independent constants — the same `constant(_ expression:)` the
+      // run's terms evaluate through — running the same matcher `Row.like`
       // does; any row-dependent operand leaves it per row (`nil`). `NOT LIKE`
       // negates the folded truth (UNKNOWN maps to itself).
       guard let truth = matched(operand, pattern, escape, routines) else {
@@ -1903,7 +1903,7 @@ internal struct Scope {
       return negated ? !truth : truth
     case let .between(test, lower, upper, negated):
       // Fold `x [NOT] BETWEEN a AND b` as `ranged` evaluates it: BETWEEN is the
-      // Kleene `x >= a AND x <= b`, and NOT BETWEEN its NEGATION (not the
+      // Kleene `x >= a AND x <= b`, and NOT BETWEEN its negation (not the
       // `x < a OR x > b` expansion, which diverges on a cross-kind bound — see
       // `ranged`). The folded `x >= a` short-circuits before the upper: a
       // definitely-FALSE one settles BETWEEN FALSE (and NOT BETWEEN TRUE)
@@ -1922,8 +1922,8 @@ internal struct Scope {
     case let .distinct(lhs, rhs, negated):
       // Fold `a IS [NOT] DISTINCT FROM b` as `differs` evaluates it: the
       // null-safe `distinct` of the two folded values, negated for `IS NOT`.
-      // It is TWO-VALUED, so when BOTH sides fold to ROW-INDEPENDENT constants
-      // the truth is DEFINITE; a row-dependent side leaves it per row (`nil`).
+      // It is two-valued, so when both sides fold to ROW-independent constants
+      // the truth is definite; a row-dependent side leaves it per row (`nil`).
       guard let lhs = constant(lhs, routines),
           let rhs = constant(rhs, routines) else {
         return nil
@@ -1932,9 +1932,9 @@ internal struct Scope {
       return negated ? !differ : differ
     case let .truth(inner, value, negated):
       // Fold `p IS [NOT] <truth value>` whenever the inner boolean is ROW-
-      // INDEPENDENT. `constant` gives its definite truth; and a `nil` from it
+      // independent. `constant` gives its definite truth; and a `nil` from it
       // over a `settled` inner (every operand a constant) is a definite UNKNOWN
-      // — NOT a per-row deferral — which `tested` maps to a DEFINITE result
+      // — NOT a per-row deferral — which `tested` maps to a definite result
       // (`p IS UNKNOWN` TRUE, `p IS TRUE` FALSE), so a constant-UNKNOWN test
       // short-circuits/type-checks as the run does rather than deferring and
       // validating an unreachable conjunct.
@@ -1942,8 +1942,8 @@ internal struct Scope {
       if folded != nil || settled(inner, routines) {
         return tested(folded, value, negated)
       }
-      // An `IS [NOT] UNKNOWN` test folds even over a ROW-DEPENDENT inner when
-      // the inner is DEFINITE (two-valued — `IS NULL`, `IS DISTINCT FROM`,
+      // An `IS [NOT] UNKNOWN` test folds even over a ROW-dependent inner when
+      // the inner is definite (two-valued — `IS NULL`, `IS DISTINCT FROM`,
       // another truth test, and their `AND`/`OR`/`NOT`, never take UNKNOWN):
       // such an inner is never the third value the test checks for, so
       // `p IS UNKNOWN` is definitely FALSE and `p IS NOT UNKNOWN` definitely
@@ -1956,8 +1956,8 @@ internal struct Scope {
       return nil
     case let .rows(lhs, op, rhs):
       // Fold `(l…) <op> (r…)` exactly as the scalar `.comparison` folds — each
-      // component of BOTH rows folds through `constant(_ expression:)`, then
-      // the folded values combine through the SHARED `relate` primitive the run
+      // component of both rows folds through `constant(_ expression:)`, then
+      // the folded values combine through the shared `relate` primitive the run
       // (`Filter.comparison`) and the empty-group pre-fold drive, so the fold
       // matches the run. A single row-dependent component (`nil`) leaves the
       // whole comparison per row (`nil`), so both `AND` arms stay reachable; an
@@ -1986,7 +1986,7 @@ internal struct Scope {
       }
       return negated ? truth.map { !$0 } : truth
     case .exists, .within, .quantified:
-      // A subquery predicate is not a ROW-INDEPENDENT constant fold — its truth
+      // A subquery predicate is not a ROW-independent constant fold — its truth
       // is decided by the materialised result at lowering time, not by folding
       // operands here — so it never folds statically; treat it as undecided
       // (per-row) so a reachability walk neither prunes nor faults on it.
@@ -1994,7 +1994,7 @@ internal struct Scope {
     }
   }
 
-  /// Whether every operand `predicate` reads folds to a ROW-INDEPENDENT
+  /// Whether every operand `predicate` reads folds to a ROW-independent
   /// constant — so its three-valued truth is fully determined at compile time.
   /// When it is and `constant(_ predicate:)` is `nil`, that `nil` is a definite
   /// UNKNOWN (a NULL propagated through constant operands), NOT a per-row
@@ -2030,15 +2030,15 @@ internal struct Scope {
     case .bound:
       false
     case let .rows(lhs, _, rhs):
-      // A row comparison is settled when EVERY component of BOTH rows folds to
-      // a ROW-INDEPENDENT constant — the row analog of `.comparison`, so a
+      // A row comparison is settled when every component of both rows folds to
+      // a ROW-independent constant — the row analog of `.comparison`, so a
       // constant-UNKNOWN row comparison (a NULL component) folds a `truth` test
       // definitely rather than deferring it.
       lhs.allSatisfy { constant($0, routines) != nil }
           && rhs.allSatisfy { constant($0, routines) != nil }
     case let .among(lhs, rows, _):
-      // A row `IN` is settled when the LEFT row and EVERY element row fold to
-      // ROW-INDEPENDENT constants — the row analog of `.membership`.
+      // A row `IN` is settled when the LEFT row and every element row fold to
+      // ROW-independent constants — the row analog of `.membership`.
       lhs.allSatisfy { constant($0, routines) != nil }
           && rows.allSatisfy { element in
             element.allSatisfy { constant($0, routines) != nil }
@@ -2050,7 +2050,7 @@ internal struct Scope {
     }
   }
 
-  /// Whether `predicate` is DEFINITE — two-valued, never evaluating to UNKNOWN,
+  /// Whether `predicate` is definite — two-valued, never evaluating to UNKNOWN,
   /// even when it reads row data. `IS [NOT] NULL`, `IS [NOT] DISTINCT FROM`,
   /// and a boolean test all collapse SQL's third value to a definite result by
   /// construction, and `AND`/`OR`/`NOT` of definite predicates stay definite. A
@@ -2062,7 +2062,7 @@ internal struct Scope {
     switch predicate {
     case .null, .distinct, .truth:
       true
-    // `EXISTS` is DEFINITELY two-valued — a non-empty test never yields UNKNOWN
+    // `EXISTS` is definitely two-valued — a non-empty test never yields UNKNOWN
     // — so it is definite, while `IN (Q)` is three-valued over NULLs (a NULL
     // element or operand makes an unmatched test UNKNOWN), so it is not.
     case .exists:
@@ -2085,9 +2085,9 @@ internal struct Scope {
   }
 
   /// The definite truth of `operand LIKE pattern [ESCAPE escape]` when the
-  /// operand, pattern, and optional escape all fold to ROW-INDEPENDENT
+  /// operand, pattern, and optional escape all fold to ROW-independent
   /// constants (via `constant(_ expression:)`), else `nil`. It folds each side
-  /// and runs the SAME `matches` the run's `Row.like` does — a NULL side is
+  /// and runs the same `matches` the run's `Row.like` does — a NULL side is
   /// UNKNOWN (`nil`), a non-text operand or pattern a definite non-match
   /// (FALSE), a bad escape collapses to `nil` (undecided) rather than faulting
   /// a compile-time reachability walk.
@@ -2123,7 +2123,7 @@ internal struct Scope {
   }
 
   /// The constant `Value` a `LIKE` pattern or escape `operand` folds to when it
-  /// is ROW-INDEPENDENT (`constant(_ expression:)`), else `nil`. A `:parameter`
+  /// is ROW-independent (`constant(_ expression:)`), else `nil`. A `:parameter`
   /// is per run — its value arrives from the bindings — so it never folds
   /// constant, exactly as a column does.
   private func constant(_ operand: Predicate.Operand, _ routines: Routines)
@@ -2137,8 +2137,8 @@ internal struct Scope {
   // MARK: - Aggregate discovery
 
   /// Validates the aggregate sub-expressions of `expression` — an aggregate's
-  /// fold runs over every row (in the aggregate node) BEFORE a `LIMIT`, so it
-  /// is reachable even under a zero-row limit — WITHOUT validating the
+  /// fold runs over every row (in the aggregate node) before a `LIMIT`, so it
+  /// is reachable even under a zero-row limit — without validating the
   /// surrounding per-result expression a run never reaches. It recurses through
   /// a binary's operands and a call's arguments to reach an aggregate, then
   /// validates it (its operand included); a bare column or literal has none.
@@ -2200,9 +2200,9 @@ internal struct Scope {
   }
 
   /// Validates the aggregate sub-expressions of `predicate` — a `HAVING`'s
-  /// aggregates are collected and FOLDED by the group node before the `HAVING`
+  /// aggregates are collected and folded by the group node before the `HAVING`
   /// filter runs, so they are reachable even in an arm the filter's
-  /// short-circuit skips. It walks EVERY arm (unlike `check`), reaching an
+  /// short-circuit skips. It walks every arm (unlike `check`), reaching an
   /// aggregate through a comparison's operands and `AND`/`OR`/`NOT`.
   func aggregates(in predicate: Predicate,
                   _ routines: Routines = [:],
@@ -2238,7 +2238,7 @@ internal struct Scope {
         }
       }
     case .exists:
-      // A subquery is its OWN scope — any aggregate inside it folds over its
+      // A subquery is its own scope — any aggregate inside it folds over its
       // group, not the enclosing one — so an `EXISTS (Q)` contributes no outer
       // aggregate to collect.
       break
@@ -2275,22 +2275,22 @@ internal struct Scope {
 
   // MARK: - Constant folding
 
-  /// Validates a whole-result aggregate's PROJECTION or SORT `expression` over
+  /// Validates a whole-result aggregate's projection or sort `expression` over
   /// the single empty group a constant-false `WHERE` leaves — the empty-fold's
   /// per-expression check, dispatching on whether the expression nests a
   /// subquery.
   ///
-  /// A subquery-FREE expression is precisely EMPTY-FOLDED (`empty`): its value
+  /// A subquery-free expression is precisely empty-folded (`empty`): its value
   /// over the empty group is evaluated exactly as a run does, pruning a
   /// statically-decided `CASE` branch (a constant-false guard's arm never
   /// folds, so it cannot fault) — the precise reachability a false-`WHERE`
   /// whole-result aggregate gives its projection.
   ///
-  /// An expression that NESTS a subquery cannot be folded: the empty group
+  /// An expression that nests a subquery cannot be folded: the empty group
   /// carries no catalog, so a `CASE WHEN EXISTS (Q) …` guard folds UNKNOWN and
   /// its arms would be pruned — but the subquery is row-independent and may be
-  /// TRUE at RUN, RUNNING the guarded arm. So VALIDATE it as a run would
-  /// (`validate`), which validates BOTH arms of a subquery-guarded `CASE` (a
+  /// TRUE at run, running the guarded arm. So validate it as a run would
+  /// (`validate`), which validates both arms of a subquery-guarded `CASE` (a
   /// `nil`-constant guard leaves both reachable), surfacing the fault the run
   /// raises — `SELECT CASE WHEN EXISTS (Q) THEN 1 / 0 … WHERE 1 = 0` faults
   /// `.divide`, matching a run that keeps the empty group and evaluates the
@@ -2310,7 +2310,7 @@ internal struct Scope {
   /// single empty group a constant-false `WHERE` leaves — the fold over zero
   /// rows: `COUNT` is 0, every other aggregate NULL, a literal itself, a binary
   /// the operator applied to its folded operands, a call the routine applied to
-  /// its folded arguments. It EVALUATES the empty group exactly as a run does,
+  /// its folded arguments. It evaluates the empty group exactly as a run does,
   /// so it raises precisely the run's fault — an unregistered routine
   /// (`SQLError.function`), a bad arity or kind (`SQLError.argument`), a divide
   /// by zero (`SQLError.divide`), an overflow (`SQLError.magnitude`) —
@@ -2345,7 +2345,7 @@ internal struct Scope {
       // Evaluate the `CASE` over the empty group exactly as a run does: the
       // first branch whose guard folds TRUE (`empty(predicate)`) yields its
       // result, else the `ELSE`, else `NULL`. A skipped branch's result never
-      // folds, so it cannot fault. The selected value is COERCED to the CASE's
+      // folds, so it cannot fault. The selected value is coerced to the CASE's
       // unified result type (`derive`), just as the executor's
       // `Row.conditional` widens it — an `.integer` arm of a CASE that unifies
       // to `.double` folds to `.double`, so the empty group matches the
@@ -2381,7 +2381,7 @@ internal struct Scope {
       return matches(va, .equal, vb) == true ? .null : va
     case .column, .subquery:
       // A bare column cannot appear over an empty group (a grouping error
-      // `compile` rejected). A scalar `subquery` is materialised at RUN (this
+      // `compile` rejected). A scalar `subquery` is materialised at run (this
       // fold carries no cache), and its value is uncorrelated — group-
       // independent — so this pre-run fold treats it as the undecided `.null`,
       // never faulting on a subquery the run would materialise cleanly.
@@ -2405,7 +2405,7 @@ internal struct Scope {
 
   /// The value a `LIKE` pattern or escape `operand` folds to over the empty
   /// group: an expression folds through `empty(_ expression:)`; a `:parameter`
-  /// is UNBOUND here — the empty-group fold carries no bindings — so it is
+  /// is unbound here — the empty-group fold carries no bindings — so it is
   /// `.null`, reading UNKNOWN exactly as a `Predicate.bound` parameter does.
   func empty(_ operand: Predicate.Operand, _ routines: Routines = [:])
       throws(SQLError) -> Value {
@@ -2443,7 +2443,7 @@ internal struct Scope {
       // without folding `1 / 0` to a `.divide` fault. Negated for `NOT IN`.
       //
       // Reject an empty list, as `check` and `lower` do — a whole-result
-      // aggregate `HAVING` over the empty group reaches this fold WITHOUT a
+      // aggregate `HAVING` over the empty group reaches this fold without a
       // prior `check` (`OutputColumn.typecheck`), so an empty list would
       // otherwise fold `false` (`true` under `NOT IN`) here while both compile
       // (`lower`) and schema (`check`) reject it. The parser rejects `IN ()`,
@@ -2459,7 +2459,7 @@ internal struct Scope {
     case let .rows(lhs, op, rhs):
       // Fold `(l…) <op> (r…)` over the empty group as `Filter.comparison`
       // evaluates it: each component folds through `empty(_ expression:)`, then
-      // the values combine with the SAME `matches`/Kleene primitives — the
+      // the values combine with the same `matches`/Kleene primitives — the
       // componentwise Kleene `AND` for `=` (its negation for `<>`), the
       // lexicographic cascade for the ordering operators. Reject an unequal
       // arity as `lower`/`check` do.
@@ -2499,8 +2499,8 @@ internal struct Scope {
       return negated ? truth.map { !$0 } : truth
     case let .like(operand, pattern, escape, negated):
       // Fold `x LIKE p` over the empty group as `Row.like` evaluates it: the
-      // operand, pattern, and optional escape are each folded ONCE, IN ORDER,
-      // BEFORE the result is decided (so a faulting reached operand surfaces
+      // operand, pattern, and optional escape are each folded once, IN ORDER,
+      // before the result is decided (so a faulting reached operand surfaces
       // its throw rather than being swallowed by a NULL escape). Then a NULL
       // operand, pattern, or escape is UNKNOWN, a non-text operand or pattern a
       // definite non-match, else the `%`/`_` matcher decides; a non-NULL escape
@@ -2530,7 +2530,7 @@ internal struct Scope {
       return negated ? truth.map { !$0 } : truth
     case let .between(test, lower, upper, negated):
       // Fold `x [NOT] BETWEEN a AND b` over the empty group as `ranged` does:
-      // BETWEEN is `x >= a AND x <= b`, and NOT BETWEEN its NEGATION (not the
+      // BETWEEN is `x >= a AND x <= b`, and NOT BETWEEN its negation (not the
       // `x < a OR x > b` expansion, which diverges on a cross-kind bound — see
       // `ranged`). The folded `x >= a` short-circuits before the upper: a
       // definitely-FALSE one settles BETWEEN FALSE (and NOT BETWEEN TRUE)
@@ -2546,7 +2546,7 @@ internal struct Scope {
     case let .distinct(lhs, rhs, negated):
       // Fold `a IS [NOT] DISTINCT FROM b` over the empty group as `differs`
       // does: the null-safe `distinct` of the two folded values, negated for
-      // `IS NOT`. It is TWO-VALUED — both operands fold to definite values, so
+      // `IS NOT`. It is two-valued — both operands fold to definite values, so
       // the truth is definite (never UNKNOWN, unlike a `=` over a NULL).
       let differ = distinct(try empty(lhs, routines), try empty(rhs, routines))
       return negated ? !differ : differ
@@ -2554,7 +2554,7 @@ internal struct Scope {
       // Fold `p IS [NOT] <truth value>` over the empty group as `Filter.truth`
       // evaluates it: `empty` yields the inner's genuine three-valued result
       // (over zero rows every side is constant, so a `nil` here is a real
-      // UNKNOWN, not a per-row deferral), which `tested` maps to a DEFINITE
+      // UNKNOWN, not a per-row deferral), which `tested` maps to a definite
       // result — never itself UNKNOWN.
       return tested(try empty(inner, routines), value, negated)
     case let .and(lhs, rhs):
@@ -2589,13 +2589,13 @@ internal struct Scope {
     return (member.relation.alias ?? member.relation.name) == qualifier
   }
 
-  /// Whether `column` is a QUALIFIED reference whose qualifier a relation of
+  /// Whether `column` is a qualified reference whose qualifier a relation of
   /// this scope answers — a qualified name a present alias (else a table name)
   /// names. An UNqualified name is FALSE (it names no one local relation to
   /// shadow an outer one), as is a qualified name no local relation answers.
   ///
   /// A qualified name a local relation answers but none of this scope binds is
-  /// a QUALIFIED MISS on that relation — the local alias SHADOWS a same-named
+  /// a qualified miss on that relation — the local alias shadows a same-named
   /// enclosing relation, so `find` faults it hard rather than correlating
   /// outward; an unadmitted qualifier is genuinely not local and correlates.
   private func shadows(_ column: Column) -> Bool {
@@ -2604,10 +2604,10 @@ internal struct Scope {
   }
 
   /// Every combined ordinal `column` addresses — the FULL addressable surface
-  /// (each admitted relation's PHYSICAL columns AND its VIRTUAL ones, through
-  /// `Schema.ordinal(of:)`), in chain order. This is the ONE bare-name scan
+  /// (each admitted relation's physical columns AND its virtual ones, through
+  /// `Schema.ordinal(of:)`), in chain order. This is the one bare-name scan
   /// every ambiguity/presence determination routes through, so no site can scan
-  /// a PARTIAL surface (real-only) and drift: a name matching more than one
+  /// a partial surface (real-only) and drift: a name matching more than one
   /// entry here is ambiguous, one present, none absent — measured over the same
   /// physical∪virtual surface `ordinal(of:)` resolves against. An unqualified
   /// `column` admits every relation; a qualified one only a relation its
@@ -2627,7 +2627,7 @@ internal struct Scope {
   /// it yields that relation's `offset` plus the local ordinal; present in more
   /// than one — an unqualified name in several relations, or a qualified name
   /// two relations share a name for — it is `SQLError.ambiguous`; in none it is
-  /// `SQLError.column`. Resolution reads the ONE full-addressable scan
+  /// `SQLError.column`. Resolution reads the one full-addressable scan
   /// (`addressable`), so it and every ambiguity/presence check measure the same
   /// physical∪virtual surface.
   internal func ordinal(of column: Column) throws(SQLError) -> Int {
@@ -2637,37 +2637,37 @@ internal struct Scope {
     return resolved
   }
 
-  /// The combined ordinal `column` resolves to as an ENCLOSING reference, or
-  /// `nil` when this scope binds it in NONE of its relations — the probe a
+  /// The combined ordinal `column` resolves to as an enclosing reference, or
+  /// `nil` when this scope binds it in none of its relations — the probe a
   /// nested subquery's `Outer` consults for a candidate correlated column. The
   /// three outcomes are DISTINCT: a name bound by exactly one relation yields
-  /// its ordinal, a name bound by NONE reports `nil` (the `Outer` walk keeps
-  /// looking outward), and a name bound by MORE than one relation of this scope
-  /// is `SQLError.ambiguous` and PROPAGATES — a nearer ambiguous scope SHADOWS
+  /// its ordinal, a name bound by none reports `nil` (the `Outer` walk keeps
+  /// looking outward), and a name bound by more than one relation of this scope
+  /// is `SQLError.ambiguous` and propagates — a nearer ambiguous scope shadows
   /// farther ones rather than falling through to rebind the name to an outer
   /// column. Only the not-found `SQLError.column` becomes `nil`; every other
   /// fault (an ambiguity or a qualifier fault) propagates. This is the
-  /// enclosing analog of `find`, which the LOCAL lowering consults for the same
+  /// enclosing analog of `find`, which the local lowering consults for the same
   /// reason.
   internal func correlated(_ column: Column) throws(SQLError) -> Int? {
     try find(column)
   }
 
   /// The combined ordinal `column` resolves to, or `nil` when it is a candidate
-  /// CORRELATED reference to an enclosing scope — the not-found probe a
-  /// `.column` lowering consults before correlating outward. FOUR outcomes stay
+  /// correlated reference to an enclosing scope — the not-found probe a
+  /// `.column` lowering consults before correlating outward. four outcomes stay
   /// DISTINCT.
   ///
   /// A name bound by exactly one relation yields its ordinal (found → bind). A
-  /// name bound by MORE than one relation is `SQLError.ambiguous`, PROPAGATED
+  /// name bound by more than one relation is `SQLError.ambiguous`, propagated
   /// (never `nil`): a local ambiguity is a hard error, not a fall-through, so
   /// `try?`-swallowing it would silently rebind an ambiguous local name to an
   /// outer column. The remaining `SQLError.column` — no relation binds the name
-  /// — splits on whether some local relation ADMITTED the qualifier: an
-  /// UNADMITTED qualifier (or an absent unqualified name) is a genuine
+  /// — splits on whether some local relation admitted the qualifier: an
+  /// unadmitted qualifier (or an absent unqualified name) is a genuine
   /// not-found → `nil`, so the walk correlates outward; a qualifier a local
-  /// relation DOES admit, naming a column it LACKS, is a QUALIFIED MISS that
-  /// PROPAGATES as a hard `.column` — the local alias SHADOWS a same-qualifier
+  /// relation does admit, naming a column it lacks, is a qualified miss that
+  /// propagates as a hard `.column` — the local alias shadows a same-qualifier
   /// enclosing relation, so it faults against the inner relation rather than
   /// falling through to bind the outer one.
   internal func find(_ column: Column) throws(SQLError) -> Int? {
@@ -2680,15 +2680,15 @@ internal struct Scope {
     }
   }
 
-  /// The resolved column a bare `column` LOCALLY names — carrying its output
-  /// name, its `type(at:)` type, and its `unconstrained(at:)` mask TOGETHER
-  /// from ONE `find` — or `nil` when this scope binds it in none of its
+  /// The resolved column a bare `column` locally names — carrying its output
+  /// name, its `type(at:)` type, and its `unconstrained(at:)` mask together
+  /// from one `find` — or `nil` when this scope binds it in none of its
   /// relations (the reference is a candidate correlated one).
   ///
-  /// INVARIANT: a column reference's type and mask (and any future per-column
-  /// attribute) are obtained from ONE resolution that traverses the SAME paths
+  /// invariant: a column reference's type and mask (and any future per-column
+  /// attribute) are obtained from one resolution that traverses the same paths
   /// — local (here), correlation (`Outer.resolved(for:)`), schema — so the two
-  /// attributes cannot diverge. The mask reader once consulted a DIFFERENT
+  /// attributes cannot diverge. The mask reader once consulted a different
   /// (local-only) path than the type reader, so a correlated all-NULL column
   /// lost its mask; folding both through the single ordinal closes that gap.
   internal func resolved(_ column: Column) throws(SQLError) -> ResolvedColumn? {
@@ -2698,7 +2698,7 @@ internal struct Scope {
   }
 
   /// The resolved column at combined `ordinal`, named `name` — its `type(at:)`
-  /// type and `unconstrained(at:)` mask read TOGETHER, so an enclosing
+  /// type and `unconstrained(at:)` mask read together, so an enclosing
   /// correlation walk (`Outer.resolved(for:)`) carries both up from the one
   /// ordinal it matched.
   internal func resolved(at ordinal: Int, named name: String)
@@ -2715,9 +2715,9 @@ internal struct Scope {
                       _ routines: Routines = [:],
                       subquery: Resolution = .unsupported) throws(SQLError)
       -> Array<Term> {
-    // A projection is a BARRED clause position (see `Schema.terms`): the entry
+    // A projection is a barred clause position (see `Schema.terms`): the entry
     // bars the seam, so no join-scope projection can admit a correlated column
-    // of THIS query.
+    // of this query.
     let subquery = subquery.barred
     switch projection {
     case .all:
@@ -2725,13 +2725,13 @@ internal struct Scope {
       // coalesce `value`, then every real column the shared `expansion`
       // enumeration yields as a `.slot` at its combined ordinal — in chain
       // order, never a virtual column, and never a physical constituent a
-      // merged column subsumes. `width(of: .all)` counts this SAME
+      // merged column subsumes. `width(of: .all)` counts this same
       // enumeration, so the emitted arity and the width cannot diverge.
       return merged.map(\.value) + expansion.map { .slot($0) }
     case let .columns(columns):
       // Lower each bare column through `term`, so a name none of this scope's
       // relations bind consults the `subquery` surface: a correlated reference
-      // on the BARRED projection surface is diagnosed unsupported (parity with
+      // on the barred projection surface is diagnosed unsupported (parity with
       // the schema path) rather than faulting `SQLError.column`.
       var terms = Array<Term>()
       terms.reserveCapacity(columns.count)
@@ -2756,22 +2756,22 @@ internal struct Scope {
       throws(SQLError) -> Term {
     switch expression {
     case let .column(column):
-      // A BARE (unqualified) name matching a `NATURAL`/`USING` merged column
-      // (ISO 9075 7.10) resolves to its ONE coalesced `value` — the merged
-      // entry SHADOWS its two physical constituents, so the name is not
-      // ambiguous between the two sides. A QUALIFIED `A.c`/`B.c` never matches
+      // A bare (unqualified) name matching a `NATURAL`/`USING` merged column
+      // (ISO 9075 7.10) resolves to its one coalesced `value` — the merged
+      // entry shadows its two physical constituents, so the name is not
+      // ambiguous between the two sides. A qualified `A.c`/`B.c` never matches
       // a (unqualified) merged column and reaches its own side below. A
-      // physical column of the same name a later PLAIN join contributed faults
+      // physical column of the same name a later plain join contributed faults
       // `.ambiguous` (`merged(binding:)`).
       if column.qualifier == nil,
           let merged = try merged(binding: column.name) {
         return merged.value
       }
       // Resolve the column against this scope's own relations first; a name
-      // none binds is a candidate CORRELATED reference — consult the enclosing
+      // none binds is a candidate correlated reference — consult the enclosing
       // scope, lowering to a synthetic `Term.parameter` bound from the outer
       // row when it resolves there, else the ordinary unknown-column fault. A
-      // LOCALLY AMBIGUOUS name (bound by more than one relation) is a HARD
+      // locally ambiguous name (bound by more than one relation) is a hard
       // error `find` propagates — never a fall-through to outer correlation
       // that would rebind it to an outer column.
       if let ordinal = try find(column) { return .slot(ordinal) }
@@ -2807,7 +2807,7 @@ internal struct Scope {
         nil
       }
       // Attach the unified result type — the same `ValueType.unified` reduction
-      // `derive`/`validate` compute — so the executor COERCES the selected
+      // `derive`/`validate` compute — so the executor coerces the selected
       // branch's value to the type the schema advertises.
       let type = try derive(whens, otherwise, routines, subquery: subquery)
       return .case(branches, else: fallback, type: type)
@@ -2817,7 +2817,7 @@ internal struct Scope {
       return try .cast(term(operand, routines, subquery: subquery), type)
     case let .coalesce(arguments):
       // Lower each argument to a combined-ordinal `Term` and hold them in a
-      // first-class `Term.coalesce` so each is evaluated ONCE; `type` is the
+      // first-class `Term.coalesce` so each is evaluated once; `type` is the
       // unified argument type the selected value coerces to.
       var elements = Array<Term>()
       elements.reserveCapacity(arguments.count)
@@ -2828,14 +2828,14 @@ internal struct Scope {
       return .coalesce(elements, type: type)
     case let .nullif(lhs, rhs):
       // Lower both operands to combined-ordinal `Term`s and hold them in a
-      // first-class `Term.nullif` so each is evaluated ONCE.
+      // first-class `Term.nullif` so each is evaluated once.
       return try .nullif(term(lhs, routines, subquery: subquery),
                          term(rhs, routines, subquery: subquery))
     case let .subquery(query):
       // A scalar subquery lowers to a `Term.subquery` reading its collapsed
       // value from the run-time cache, carrying its occurrence `Subkey` and
       // single-column type; the single-column arity is enforced from the
-      // compiled width here (no cursor). The query is UNCORRELATED, so it reads
+      // compiled width here (no cursor). The query is uncorrelated, so it reads
       // no cell of this row.
       return try subquery.scalar(query)
     case .aggregate:
@@ -2844,7 +2844,7 @@ internal struct Scope {
       throw .state("42803", "an aggregate is not allowed here")
     case .grouping:
       // GROUPING is a grouped-query construct decided by the arm's key
-      // membership; it has no meaning in this NON-grouped join resolution, so
+      // membership; it has no meaning in this non-grouped join resolution, so
       // it faults as an aggregate does. A grouped query lowers it through
       // `Grouped.term` instead.
       throw .state("42803", "GROUPING requires a GROUP BY")
@@ -2863,7 +2863,7 @@ internal struct Scope {
                       _ names: Array<String?>, _ routines: Routines = [:],
                       subquery: Resolution = .unsupported)
       throws(SQLError) -> Array<SortKey> {
-    // An ORDER BY is BARRED, as the projection is (see `Schema.order`).
+    // An ORDER BY is barred, as the projection is (see `Schema.order`).
     let subquery = subquery.barred
     return try SQLEngine.order(order, projection, names) {
       expression throws(SQLError) in
@@ -2873,16 +2873,16 @@ internal struct Scope {
 
   /// Lowers a join's `ON predicate` to the engine's `Filter` across the chain,
   /// emitting a `match` for each pure `column = column` equality — the
-  /// hash-join key `nest` folds into a physical `Join` — ONLY WHEN the WHOLE
+  /// hash-join key `nest` folds into a physical `Join` — ONLY WHEN the whole
   /// `ON` is safe, and otherwise lowering the entire conjunction as one
   /// residual.
   ///
-  /// The key is READ OFF the ALREADY-LOWERED conjunct, not by re-resolving the
+  /// The key is read off the already-lowered conjunct, not by re-resolving the
   /// AST: a conjunct whose lowered form is a `compare(.slot, .equal, .slot)` —
   /// both operands columns of the join prefix — IS the hash-join key `nest`
   /// folds into a physical `Join`, so it is rewritten to the `match(left,
   /// right)` node `nest` recognises. A conjunct that lowered to a `.parameter`
-  /// operand is a CORRELATED outer reference (`ON V.x = T.id` under an EXISTS,
+  /// operand is a correlated outer reference (`ON V.x = T.id` under an EXISTS,
   /// lowering to `compare(.slot, .equal, .parameter)`), NOT a column = column
   /// key, so it stays the residual `ON` filter — re-resolving its AST would
   /// consult only the prefix and fault `SQLError.column` on the outer column
@@ -2891,23 +2891,23 @@ internal struct Scope {
   /// an `OR`/`NOT`) lowers through `lower`, becoming a residual the join runs
   /// as a filter over the product — nested-loop semantics, correct if O(n·m).
   ///
-  /// A `match` key is extracted ONLY WHEN EVERY lowered conjunct is `safe`; if
-  /// ANY conjunct is unsafe, the whole `ON` lowers to a single residual and NO
-  /// key is hoisted. The hash join evaluates its key equality BEFORE any
+  /// A `match` key is extracted ONLY WHEN every lowered conjunct is `safe`; if
+  /// ANY conjunct is unsafe, the whole `ON` lowers to a single residual and no
+  /// key is hoisted. The hash join evaluates its key equality before any
   /// residual conjunct AND skips a NULL key (an equi `match` drops a pair whose
   /// key cell is NULL), so an extracted key changes the `ON`'s left-to-right
   /// Kleene error behaviour on two hazards, both suppressing a throw the
   /// residual `select` over the product would raise (the order the WHERE
   /// pushdown barriers preserve):
-  ///   - an UNSAFE conjunct BEFORE the key (`ON (1 / A.x) = 0 AND A.k = B.k`):
+  ///   - an unsafe conjunct before the key (`ON (1 / A.x) = 0 AND A.k = B.k`):
   ///     hoisting the key would let its non-match drop a pair before the
   ///     unsafe conjunct runs (`A.x = 0` ⇒ `SQLError.divide`);
-  ///   - a NULLABLE key BEFORE an UNSAFE conjunct (`ON A.k = B.k AND (1 / A.x)
+  ///   - a nullable key before an unsafe conjunct (`ON A.k = B.k AND (1 / A.x)
   ///     = 0`, `A.k` NULL, `A.x = 0`): the equality is UNKNOWN, so the Kleene
   ///     `AND` must still evaluate the unsafe RHS and raise — but the hash join
   ///     skips the NULL key and drops the pair before the RHS runs.
   /// The engine has no NOT NULL schema (a column surfaces as a `Value` that may
-  /// be `.null`), so it cannot prove a key operand non-nullable; EVERY equi key
+  /// be `.null`), so it cannot prove a key operand non-nullable; every equi key
   /// is treated as nullable, collapsing both hazards to the single whole-`ON`
   /// rule. An equi `column = column` is always `safe` (comparing two cells
   /// never raises), so an all-equi or otherwise all-safe `ON` still hash-joins
@@ -2921,14 +2921,14 @@ internal struct Scope {
       try lower(conjunct, routines, subquery: subquery)
     }
     // An unsafe conjunct anywhere forbids extracting ANY key: a hoisted key
-    // both skips a NULL pair before a LATER unsafe conjunct runs and drops a
-    // non-match before an EARLIER one does — either suppressing the throw the
+    // both skips a NULL pair before a later unsafe conjunct runs and drops a
+    // non-match before an earlier one does — either suppressing the throw the
     // whole-ON residual owes. Lower the entire conjunction as one residual.
     guard lowered.allSatisfy(\.safe) else { return lowered.conjunction! }
-    // Read the equi-join key off the ALREADY-LOWERED term rather than
+    // Read the equi-join key off the already-lowered term rather than
     // re-resolving the AST: a key is a `compare(.slot, .equal, .slot)` whose
-    // BOTH operands are columns of the join prefix. A conjunct that lowered to
-    // a `.parameter` operand is a CORRELATED outer reference (`V.x = :outer`),
+    // both operands are columns of the join prefix. A conjunct that lowered to
+    // a `.parameter` operand is a correlated outer reference (`V.x = :outer`),
     // NOT a column = column key, so it stays the residual `ON` filter — a
     // re-resolution of its AST would consult only the prefix and fault
     // `SQLError.column` on the outer column already lowered correctly.

--- a/Sources/SQLEngine/With.swift
+++ b/Sources/SQLEngine/With.swift
@@ -4,7 +4,7 @@
 // MARK: - WITH
 
 extension CTE {
-  /// The CTE body's CANONICAL recursive shape — the ONE recogniser every
+  /// The CTE body's canonical recursive shape — the one recogniser every
   /// recursive-CTE seam peels through, so the run side and the schema side
   /// inspect the identical AST.
   ///
@@ -52,7 +52,7 @@ extension CTE {
   /// Whether the CTE actually references itself through a recursive `UNION` arm
   /// — the test the fixpoint routing turns on, distinct from the syntactic
   /// `recursive` flag a `WITH RECURSIVE` stamps on every member. A thin read
-  /// over `recursiveArms`, so it peels the SAME canonical shape.
+  /// over `recursiveArms`, so it peels the same canonical shape.
   internal var recurses: Bool {
     get throws(SQLError) {
       try recursiveArms != nil
@@ -81,9 +81,9 @@ extension Select {
   /// Whether the select names the relation `name` (case-folded) in its `FROM`
   /// or any `JOIN`.
   ///
-  /// A relation contributes a reference by its SOURCE, not its binding name: a
+  /// A relation contributes a reference by its source, not its binding name: a
   /// `.named` relation names `name` when its identifier matches; a `.derived`
-  /// one names NOTHING through its alias — a `FROM (SELECT …) AS a` does not
+  /// one names nothing through its alias — a `FROM (SELECT …) AS a` does not
   /// reference a relation `a` — but its inner query is recursed into for the
   /// REAL `.named` references its body holds. So a recursive-CTE fixpoint
   /// detector sees a self-reference nested inside a derived body (`FROM (SELECT
@@ -97,7 +97,7 @@ extension Select {
 
 extension Relation {
   /// Whether this relation references the relation `name` (case-folded): a
-  /// `.named` relation by its identifier, a `.derived` one by RECURSING into
+  /// `.named` relation by its identifier, a `.derived` one by recursing into
   /// its inner query — the derived alias itself is not a reference.
   internal func references(_ name: String) -> Bool {
     switch source {

--- a/Sources/SQLStandard/Overlay.swift
+++ b/Sources/SQLStandard/Overlay.swift
@@ -46,8 +46,8 @@ extension Catalog where Self: ~Escapable {
 }
 
 extension Routines {
-  /// A copy of these routines with the DEFINED `function` bound to `name`, its
-  /// body EARLY-BINDING against the standard prelude overlaid with these
+  /// A copy of these routines with the defined `function` bound to `name`, its
+  /// body early-binding against the standard prelude overlaid with these
   /// routines — the prelude-defaulting counterpart of the engine's
   /// `registering(_:_:capturing:)`, so `lowbit(n) AS BITAND(n, 1)` resolves the
   /// built-in at registration exactly as a query would. Registering a protected

--- a/Sources/SQLStandard/Prelude.swift
+++ b/Sources/SQLStandard/Prelude.swift
@@ -7,19 +7,19 @@ extension Routines {
   /// The standard-library prelude — the ISO scalar built-ins the `SQLStandard`
   /// layer installs so a query reaches them without a caller registering a
   /// closure (the prelude-defaulting `run`/`columns` overloads seed it). They
-  /// are PROTECTED: a caller cannot shadow one through `registering(_:…)` (the
+  /// are protected: a caller cannot shadow one through `registering(_:…)` (the
   /// prelude marks its names via `protecting(_:)`), so a query naming a
   /// built-in always reaches the shipped one. Every member is a pure,
-  /// side-effect-free mapping and so DETERMINISTIC — a row-independent call
+  /// side-effect-free mapping and so deterministic — a row-independent call
   /// folds at compile time — and returns NULL on any NULL argument (SQL null
   /// propagation), faulting `SQLError.argument` on the wrong argument count or
   /// a value it cannot map, mirroring its declared `[parameters]`/`returns`
   /// contract the static type-check validates a call against.
   ///
-  /// The set covers the ISO scalar built-ins the grammar can already CALL
+  /// The set covers the ISO scalar built-ins the grammar can already call
   /// (`f(…)`), in two families:
   ///
-  /// - STRING: `UPPER`/`LOWER` (case fold), `CHAR_LENGTH` (with its ISO synonym
+  /// - string: `UPPER`/`LOWER` (case fold), `CHAR_LENGTH` (with its ISO synonym
   ///   `CHARACTER_LENGTH`, the same routine under both names), `SUBSTRING` (the
   ///   two-argument `SUBSTRING(text, start)` form, ISO 1-based indexing),
   ///   `TRIM` (the one-argument `TRIM(text)` form, stripping leading and
@@ -38,7 +38,7 @@ extension Routines {
   ///   portable, standards-compliant spelling (Oracle's) of a bitwise AND, an
   ///   operation ISO SQL and this grammar otherwise lack — is kept.
   ///
-  /// FOLLOW-UPS (each needs grammar or overloading this batch does not add, so
+  /// follow-ups (each needs grammar or overloading this batch does not add, so
   /// each ships in its simplest callable form now):
   /// - `SUBSTRING(text FROM start FOR length)` — the full ISO clause with a
   ///   `FROM`/`FOR` keyword syntax and an optional length — and the plain
@@ -58,7 +58,7 @@ extension Routines {
   ///   needs routine overloading, which the single-signature contract lacks.
   public static let standard: Routines = prelude.protecting(prelude.names)
 
-  /// The prelude routines UNPROTECTED — `standard` wraps this with
+  /// The prelude routines unprotected — `standard` wraps this with
   /// `protecting(_:)` so its own names cannot be shadowed. Built through the
   /// dictionary-literal escape hatch, which carries no protected names.
   private static let prelude: Routines = [
@@ -190,9 +190,9 @@ extension Routines {
     return .text(String(string.dropFirst(drop)))
   }
 
-  /// `TRIM(text)` — the string with leading and trailing SPACE characters
+  /// `TRIM(text)` — the string with leading and trailing space characters
   /// removed (the one-argument ISO form, whose implicit trim character is a
-  /// space and whose implicit specification is BOTH). A NULL argument yields
+  /// space and whose implicit specification is both). A NULL argument yields
   /// NULL; the wrong count or a non-text argument is `SQLError.argument`.
   private static func trim(_ arguments: Array<SQLEngine.Value>)
       throws(SQLError) -> SQLEngine.Value {
@@ -293,9 +293,9 @@ extension Routines {
   /// `POSITION(substring, string)` — the parser's desugaring of the ISO
   /// `POSITION(substring IN string)` — the 1-based character position of the
   /// first occurrence of `substring` in `string`, 0 when it does not occur. An
-  /// EMPTY substring occurs at position 1 (ISO): the empty string is a prefix
+  /// empty substring occurs at position 1 (ISO): the empty string is a prefix
   /// of every string, including another empty string. Matching is
-  /// character-wise and case-SENSITIVE (no case fold). A NULL argument yields
+  /// character-wise and case-sensitive (no case fold). A NULL argument yields
   /// NULL; the wrong count or a non-text argument is `SQLError.argument`.
   private static func position(_ arguments: Array<SQLEngine.Value>)
       throws(SQLError) -> SQLEngine.Value {
@@ -329,7 +329,7 @@ extension Routines {
   /// non-text `string`/`replacement`, or a non-integer `start`/`length` is
   /// `SQLError.argument`.
   ///
-  /// The 1-based `start` and the `length` are CLAMPED to the string rather than
+  /// The 1-based `start` and the `length` are clamped to the string rather than
   /// trusted, so no arithmetic traps and no slice runs out of bounds: a `start`
   /// at or before 1 begins at the first character (the `start - 1` conversion
   /// would overflow for `Int.min`, so it is not subtracted below 1), a `start`
@@ -349,10 +349,10 @@ extension Routines {
     }
     // The number of characters to remove: the explicit `FOR length` fourth
     // argument, or — when omitted — the character count of the replacement.
-    // Defaulting HERE, from the single evaluated replacement value, is what
+    // Defaulting here, from the single evaluated replacement value, is what
     // lets the parser pass only three arguments for the omitted-`FOR` form:
-    // the replacement is evaluated ONCE, so a NOT-DETERMINISTIC one
-    // (`stepper_text()`) both inserts and measures the SAME value, rather than
+    // the replacement is evaluated once, so a NOT-deterministic one
+    // (`stepper_text()`) both inserts and measures the same value, rather than
     // the parser re-referencing it as `char_length(replacement)` and
     // evaluating it a second time.
     let length: Int
@@ -373,7 +373,7 @@ extension Routines {
     // The suffix resumes `length` characters after `head`, clamped the same
     // way: a negative or zero length removes nothing (resumes at `head`), and a
     // length past the end resumes at the end. The overshoot is tested against
-    // the REMAINING capacity (`count - head`) rather than forming `head +
+    // the remaining capacity (`count - head`) rather than forming `head +
     // length`, whose sum would overflow for an `Int.max` length.
     let tail = if length <= 0 {
       head

--- a/Sources/SQLTestSupport/Fixture.swift
+++ b/Sources/SQLTestSupport/Fixture.swift
@@ -196,7 +196,7 @@ public struct FixtureTable: Table {
     // bracket into its range — and the optimiser drops the residual predicate
     // for an equality seek, returning those NULLs as false matches. Abandon
     // the seek so the engine scans and filters, preserving the predicate. An
-    // EMPTY relation has no such cell and still seeks (an empty 0 ..< 0 range).
+    // empty relation has no such cell and still seeks (an empty 0 ..< 0 range).
     if let first = relation.records.first {
       guard case .integer = first[column] else { return nil }
     }

--- a/Tests/SQLStandardTests/OverlayTests.swift
+++ b/Tests/SQLStandardTests/OverlayTests.swift
@@ -51,7 +51,7 @@ private func library() throws -> FixtureCatalog {
 
   @Test func `a defined body binds a prelude built-in via the capture seam`()
       throws {
-    // Registered against EMPTY routines, a defined body calling BITAND still
+    // Registered against empty routines, a defined body calling BITAND still
     // resolves it: the two-argument `registering(_:_:)` overload captures
     // `Routines.standard` (the relocated early-binding capture).
     guard case let .function(name, function) =

--- a/Tests/SQLTests/Expressions/BetweenTests.swift
+++ b/Tests/SQLTests/Expressions/BetweenTests.swift
@@ -26,7 +26,7 @@ private func things() throws -> FixtureCatalog {
 
 struct BetweenParsingTests {
   @Test func `BETWEEN parses to a first-class node`() throws {
-    // `x BETWEEN a AND b` is a first-class `Predicate.between` holding `x` ONCE
+    // `x BETWEEN a AND b` is a first-class `Predicate.between` holding `x` once
     // — not the re-referencing `AND` of two comparisons its ISO definition
     // names.
     let select = try parse(select: "SELECT * FROM T WHERE K BETWEEN 1 AND 10")
@@ -110,7 +110,7 @@ struct BetweenCrossKindTests {
     // is FALSE — making BETWEEN FALSE and NOT BETWEEN TRUE. `K NOT BETWEEN 'a'
     // AND 10` must therefore equal `NOT (K BETWEEN 'a' AND 10)`, NOT the
     // `K < 'a' OR K > 10` expansion whose two FALSE ordering checks would
-    // wrongly REJECT the row.
+    // wrongly reject the row.
     try things().expect(
         "SELECT Id FROM T WHERE K NOT BETWEEN 'a' AND 10",
         equals: "SELECT Id FROM T WHERE NOT (K BETWEEN 'a' AND 10)")
@@ -209,7 +209,7 @@ private final class Counter: @unchecked Sendable {
   /// The number of times `next()` has been called.
   private(set) var count = 0
 
-  /// Increments the count and returns the PREVIOUS value — the sequence `0, 1,
+  /// Increments the count and returns the previous value — the sequence `0, 1,
   /// 2, …` across successive calls.
   func next() -> Int {
     defer { count += 1 }
@@ -229,11 +229,11 @@ struct BetweenOperandTests {
 
   @Test func `the BETWEEN test expression is evaluated once`() throws {
     // `stepper()` yields 0, then 1, …; non-deterministic, so unfoldable.
-    // `stepper() BETWEEN 0 AND 0` must evaluate `stepper()` EXACTLY ONCE —
-    // yielding 0, which IS in [0, 0], so the row is KEPT. The old desugar
+    // `stepper() BETWEEN 0 AND 0` must evaluate `stepper()` exactly once —
+    // yielding 0, which IS in [0, 0], so the row is kept. The old desugar
     // duplicated the test across `stepper() >= 0 AND stepper() <= 0`, calling
-    // it twice: the lower bound saw 0 (0 >= 0) and the upper saw a DIFFERENT 1
-    // (1 <= 0 is false), wrongly DROPPING the row and calling it twice. The
+    // it twice: the lower bound saw 0 (0 >= 0) and the upper saw a different 1
+    // (1 <= 0 is false), wrongly dropping the row and calling it twice. The
     // first-class node holds the test, so the row is kept and the counter reads
     // exactly 1.
     let counter = Counter()
@@ -262,15 +262,15 @@ struct BetweenShortCircuitTests {
   @Test func `a FALSE lower bound skips the upper bound`() throws {
     // `0 BETWEEN 1 AND (1 / 0)` ≡ `0 >= 1 AND 0 <= (1 / 0)` — the lower
     // `0 >= 1` is FALSE, so Kleene `AND` is FALSE without the upper `1 / 0`.
-    // The eager form evaluated BOTH bounds and faulted `.divide` on the upper;
-    // deferring it keeps the predicate FALSE, dropping the row with NO throw.
+    // The eager form evaluated both bounds and faulted `.divide` on the upper;
+    // deferring it keeps the predicate FALSE, dropping the row with no throw.
     try one().empty("SELECT Id FROM T WHERE 0 BETWEEN 1 AND (1 / 0)")
   }
 
   @Test func `a TRUE lower bound skips the NOT BETWEEN upper`() throws {
     // `0 NOT BETWEEN 1 AND (1 / 0)` ≡ `0 < 1 OR 0 > (1 / 0)` — the lower
     // `0 < 1` is TRUE, so Kleene `OR` is TRUE without the upper `1 / 0`. The
-    // row is kept with NO throw.
+    // row is kept with no throw.
     try one().expect("SELECT Id FROM T WHERE 0 NOT BETWEEN 1 AND (1 / 0)",
                      yields: [[1]])
   }
@@ -278,7 +278,7 @@ struct BetweenShortCircuitTests {
   @Test func `the upper bound is evaluated when the lower does not settle it`()
       throws {
     // `5 BETWEEN 1 AND (1 / 0)` — the lower `5 >= 1` is TRUE, so the result
-    // hinges on the upper: the deferred `1 / 0` MUST evaluate and STILL fault,
+    // hinges on the upper: the deferred `1 / 0` must evaluate and still fault,
     // confirming the upper is not silently dropped when the lower needs it.
     try one().expect("SELECT Id FROM T WHERE 5 BETWEEN 1 AND (1 / 0)",
                      fails: .divide)
@@ -307,11 +307,11 @@ struct BetweenTypeCheckingTests {
   @Test func `a constant FALSE BETWEEN WHERE leaves the projection unreachable`()
       throws {
     // `0 BETWEEN 1 AND (1 / 0)` — the constant lower `0 >= 1` folds definitely
-    // FALSE, settling the whole BETWEEN FALSE WITHOUT folding the upper
+    // FALSE, settling the whole BETWEEN FALSE without folding the upper
     // `1 / 0`. So `constant(_ predicate:)` reports the WHERE always-FALSE, the
     // projection `Name + 1` (a `.operand` fault over the text `Name`, if
-    // reached) is unreachable, and `columns(of:validate:)` SUCCEEDS. The run
-    // drops every row before the projection, yielding no rows and NO throw.
+    // reached) is unreachable, and `columns(of:validate:)` succeeds. The run
+    // drops every row before the projection, yielding no rows and no throw.
     let text = "SELECT Name + 1 FROM T WHERE 0 BETWEEN 1 AND (1 / 0)"
     _ = try named().columns(of: parse(query: text))
     try named().empty(text)
@@ -374,9 +374,9 @@ struct BetweenSeekTests {
   @Test func `the seeked BETWEEN matches the equivalent range comparison`()
       throws {
     // The desugar `Id >= 3 AND Id <= 7` also seeks over the sorted key and
-    // returns the SAME rows — but seeks only ONE conjunct (`Id >= 3`, the run
+    // returns the same rows — but seeks only one conjunct (`Id >= 3`, the run
     // `2 ..< 10`) and residuals the other, so the first-class BETWEEN's
-    // two-sided `2 ..< 7` is the TIGHTER run. Parity is the seeked shape and
+    // two-sided `2 ..< 7` is the tighter run. Parity is the seeked shape and
     // the rows, and the BETWEEN run sits within the comparison's.
     let catalog = try sorted()
     let comparison =
@@ -431,11 +431,11 @@ struct BetweenSeekTests {
 
   @Test func `an inverted BETWEEN seeks an empty run without trapping`()
       throws {
-    // `Id BETWEEN 10 AND 1` is a valid EMPTY range (lower > upper): the
+    // `Id BETWEEN 10 AND 1` is a valid empty range (lower > upper): the
     // `Id >= 10` partition starts at index 9 and the `Id <= 1` partition ends
     // at index 1, so the raw `lower ..< upper` (9 ..< 1) would trap Swift's
     // `Range(lowerBound <= upperBound)` precondition and abort the process. The
-    // guard detects the inversion and seeks the EMPTY run `9 ..< 9` instead, so
+    // guard detects the inversion and seeks the empty run `9 ..< 9` instead, so
     // the query returns no rows and never traps.
     let catalog = try sorted()
     let query = try parse(query: "SELECT Id FROM T WHERE Id BETWEEN 10 AND 1")
@@ -448,7 +448,7 @@ struct BetweenSeekTests {
   @Test func `a parameterised BETWEEN seeks its two-sided run once bound`()
       throws {
     // `Id BETWEEN :lo AND :hi` with lo = 3, hi = 7 resolves both bounds from
-    // the bindings and seeks the SAME `2 ..< 7` run the literal `Id BETWEEN 3
+    // the bindings and seeks the same `2 ..< 7` run the literal `Id BETWEEN 3
     // AND 7` does — not a whole-table scan — so the parameterised range this
     // feature replaces does not regress against the `Id >= :lo AND Id <= :hi`
     // desugar's seek.
@@ -495,10 +495,10 @@ struct BetweenEmptyGroupTests {
       throws {
     // A constant-FALSE `WHERE` leaves a whole-result aggregate its single empty
     // group, over which the `HAVING 0 BETWEEN 1 AND (1 / 0)` folds: the
-    // constant lower `0 >= 1` is FALSE, settling BETWEEN FALSE WITHOUT folding
-    // the upper `1 / 0`. So `empty(_ predicate:)` drops the group WITHOUT a
-    // `.divide` fault, schema/type checking SUCCEEDS, and the run yields no row
-    // with NO throw.
+    // constant lower `0 >= 1` is FALSE, settling BETWEEN FALSE without folding
+    // the upper `1 / 0`. So `empty(_ predicate:)` drops the group without a
+    // `.divide` fault, schema/type checking succeeds, and the run yields no row
+    // with no throw.
     let text = """
         SELECT COUNT(*) FROM T WHERE 1 = 0
         HAVING 0 BETWEEN 1 AND (1 / 0)

--- a/Tests/SQLTests/Expressions/CaseTests.swift
+++ b/Tests/SQLTests/Expressions/CaseTests.swift
@@ -123,7 +123,7 @@ struct CaseEvaluationTests {
 
   @Test func `a mixed CASE coerces the integer branch to double`() throws {
     // The results unify to `.double`, so the schema advertises the column as
-    // double; the executor must COERCE the selected branch's value to match.
+    // double; the executor must coerce the selected branch's value to match.
     // Row 1 takes the integer THEN `1`, which widens to `.double(1.0)` rather
     // than staying `.integer(1)`; rows 2 and 3 take the double ELSE `2.5`.
     try things().expect(
@@ -181,9 +181,9 @@ struct CaseTypeUnificationTests {
     // A row-dependent guard (`Id = 2`, matched by a fixture row) keeps both the
     // text `Name` branch and the integer `0` ELSE reachable — a constant guard
     // would drop an arm and mask the clash. Lowering unifies the reachable
-    // result types just as the type check does, so the RUN faults with the same
+    // result types just as the type check does, so the run faults with the same
     // error rather than leaking a text value at a column typed by the first
-    // branch; `columns(of:)` faults identically, so the two paths AGREE.
+    // branch; `columns(of:)` faults identically, so the two paths agree.
     let text =
         "SELECT CASE WHEN Id = 2 THEN Name ELSE 0 END FROM T"
     try things().expect(text,
@@ -254,10 +254,10 @@ struct CaseReachabilityTests {
 
   @Test func `an earlier branch before a constant-true guard stays reachable`()
       throws {
-    // `WHEN 1 = 1` is constant-TRUE, but it comes AFTER the row-dependent `WHEN
+    // `WHEN 1 = 1` is constant-TRUE, but it comes after the row-dependent `WHEN
     // Id = 1`, which a row with `Id = 1` still matches — so that earlier branch
-    // is REACHABLE and its `Name + 1` (text arithmetic) must still fault. The
-    // constant-TRUE guard drops only the STRICTLY-LATER branches and the ELSE,
+    // is reachable and its `Name + 1` (text arithmetic) must still fault. The
+    // constant-TRUE guard drops only the strictly-later branches and the ELSE,
     // not the branches before it.
     let query = try parse(query: """
         SELECT CASE WHEN Id = 1 THEN Name + 1 WHEN 1 = 1 THEN 0 END AS C FROM T
@@ -292,16 +292,16 @@ struct CaseReachabilityTests {
 
 /// The schema validator folds the projection over the single empty group a
 /// constant-false `WHERE` leaves (`Scope.empty`), exactly as a run does — so a
-/// CASE there must COERCE its selected value to the unified result type, just
+/// CASE there must coerce its selected value to the unified result type, just
 /// as the executor's `Row.conditional` does, or the folded value clashes the
 /// advertised column type and a routine argument the run accepts is rejected.
 struct CaseEmptyGroupTests {
 
   /// `CASE WHEN COUNT(*) = 0 THEN COUNT(*) ELSE 2.5 END` — a mixed CASE whose
-  /// guard is NOT statically decidable (a `COUNT(*)` operand), so BOTH arms are
+  /// guard is NOT statically decidable (a `COUNT(*)` operand), so both arms are
   /// reachable and the result unifies to `.double`. Over the empty group
   /// `COUNT(*)` is `0`, so the guard folds TRUE and the integer `COUNT(*)` arm
-  /// is selected — folding to `0`, which must WIDEN to the unified `.double`.
+  /// is selected — folding to `0`, which must widen to the unified `.double`.
   private func mixed() -> Expression {
     let guard0 = Predicate.comparison(left: .aggregate(.count, of: .star),
                                       op: .equal,
@@ -324,7 +324,7 @@ struct CaseEmptyGroupTests {
     // WHERE leaves one empty group, so `columns(of:)` folds the projection and
     // dispatches the routine over the folded argument. The coerced
     // `.double(0.0)` satisfies the DOUBLE parameter — schema validation
-    // SUCCEEDS, as the run does; a raw `.integer(0)` would fault
+    // succeeds, as the run does; a raw `.integer(0)` would fault
     // `SQLError.argument`.
     let f = Function(parameters: [Function.Parameter(name: "x", type: .double)],
                      returns: .double, body: .column("x"))

--- a/Tests/SQLTests/Expressions/CastTests.swift
+++ b/Tests/SQLTests/Expressions/CastTests.swift
@@ -10,7 +10,7 @@ import SQLTestSupport
 
 /// A relation exercising `CAST`: an integer `Id`, an approximate `D`, a textual
 /// `T` (both numeric and non-numeric spellings) with a `T` row that is `NULL`
-/// so a cast of a NULL operand is covered, and a boolean `B` so a NON-constant
+/// so a cast of a NULL operand is covered, and a boolean `B` so a non-constant
 /// operand of a structurally-unsupported pair (a boolean column to an integer)
 /// is covered.
 private func things() throws -> FixtureCatalog {
@@ -84,7 +84,7 @@ struct CastNumericTests {
   }
 
   @Test func `text of overflowing magnitude to double faults`() throws {
-    // `'1e999'` PARSES to a finite-syntax spelling but its magnitude is out of
+    // `'1e999'` parses to a finite-syntax spelling but its magnitude is out of
     // range — `Double('1e999')` is `inf` — so the cast raises the numeric
     // value out-of-range fault (`22003`), matching the numeric-literal path,
     // NOT the invalid-character fault (`22018`) reserved for an unparseable
@@ -173,7 +173,7 @@ struct CastSchemaTests {
   @Test func `a structurally impossible cast is rejected at validation`()
       throws {
     // `CAST(TRUE AS INTEGER)` is a reachable projection whose (boolean →
-    // integer) pair `Value.cast(to:)` faults `42846` for EVERY value, so the
+    // integer) pair `Value.cast(to:)` faults `42846` for every value, so the
     // schema type-check rejects it rather than advertising an integer column.
     #expect(throws: SQLError.state("42846",
                                    "cannot cast boolean to integer")) {
@@ -184,14 +184,14 @@ struct CastSchemaTests {
   @Test func `a value-dependent cast passes validation`() throws {
     // A castable-but-value-dependent pair — `integer` → `double` always
     // convertible, `text` → `integer` convertible for a good spelling —
-    // type-checks and reports the target type; only a bad VALUE faults at run.
+    // type-checks and reports the target type; only a bad value faults at run.
     #expect(try things().type(of: "SELECT CAST(1 AS DOUBLE)") == .double)
     #expect(try things().type(of: "SELECT CAST('1' AS INTEGER)") == .integer)
   }
 
   @Test func `a constant cast that always fails is rejected at validation`()
       throws {
-    // `CAST('abc' AS INTEGER)` has a castable pair but a CONSTANT operand that
+    // `CAST('abc' AS INTEGER)` has a castable pair but a constant operand that
     // converts to no value, so a trial cast of the folded constant rejects it
     // at validation, not only at run.
     #expect(throws: SQLError.state("22018",
@@ -202,10 +202,10 @@ struct CastSchemaTests {
   }
 
   @Test func `a statically-NULL operand validates for any target`() throws {
-    // `CASE WHEN 1 = 0 THEN 1 END` folds to NULL, but its DERIVED type is the
+    // `CASE WHEN 1 = 0 THEN 1 END` folds to NULL, but its derived type is the
     // default `.integer`, whose (integer → blob) pair is structurally
     // unsupported. The constant fold runs FIRST, so the folded NULL trial-casts
-    // to `.blob` — a NULL casts to ANY target — and validation SUCCEEDS with a
+    // to `.blob` — a NULL casts to ANY target — and validation succeeds with a
     // blob column rather than rejecting `42846` a query the run would perform.
     let sql = "SELECT CAST(CASE WHEN 1 = 0 THEN 1 END AS BLOB)"
     let columns = try things().columns(of: parse(query: sql), validate: true)
@@ -215,7 +215,7 @@ struct CastSchemaTests {
   }
 
   @Test func `a constant unsupported cast is rejected by the trial`() throws {
-    // `CAST(TRUE AS INTEGER)` has a CONSTANT non-NULL operand, so the trial
+    // `CAST(TRUE AS INTEGER)` has a constant non-NULL operand, so the trial
     // cast of the folded `true` — no boolean-to-integer conversion — rejects it
     // `42846`, the same fault the structural check would raise.
     #expect(throws: SQLError.state("42846",
@@ -258,7 +258,7 @@ struct CastNumericFormatTests {
   }
 
   @Test func `the infinity spelling is not a SQL number`() throws {
-    // `Double('inf')` PARSES to a non-finite magnitude, but `inf` is no SQL
+    // `Double('inf')` parses to a non-finite magnitude, but `inf` is no SQL
     // numeric spelling, so it is an invalid character (`22018`) — NOT the
     // out-of-range fault (`22003`) a valid-format overflow raises.
     try things().expect("SELECT CAST('inf' AS DOUBLE)",
@@ -286,9 +286,9 @@ struct CastNumericFormatTests {
   }
 
   @Test func `a format-valid integer overflow is out of range`() throws {
-    // `'9223372036854775808'` is a VALID integer spelling — `Int.max` plus one
+    // `'9223372036854775808'` is a valid integer spelling — `Int.max` plus one
     // — so it passes the format gate and `Int(_:)` returns `nil` only for
-    // RANGE, faulting out-of-range (`22003`), NOT the invalid-character fault
+    // range, faulting out-of-range (`22003`), NOT the invalid-character fault
     // (`22018`) an unspellable text raises.
     try things().expect(
         "SELECT CAST('9223372036854775808' AS INTEGER)",

--- a/Tests/SQLTests/Expressions/CoalesceTests.swift
+++ b/Tests/SQLTests/Expressions/CoalesceTests.swift
@@ -11,7 +11,7 @@ import SQLTestSupport
 struct CoalesceTests {
   @Test func `COALESCE parses to a first-class node`() throws {
     // `COALESCE(K, 0)` is a first-class `Expression.coalesce` holding each
-    // argument ONCE — not the re-referencing `CASE` its ISO definition names.
+    // argument once — not the re-referencing `CASE` its ISO definition names.
     let select = try parse(select: "SELECT COALESCE(K, 0) FROM T")
     let expression = Expression.coalesce([.column("K"),
                                           .literal(.integer(0))])
@@ -93,9 +93,9 @@ struct CoalesceReachabilityTests {
   }
 
   @Test func `a constant NULL prefix does not stop validation`() throws {
-    // COALESCE steps PAST a NULL argument, so a later one is reachable and MUST
+    // COALESCE steps past a NULL argument, so a later one is reachable and must
     // be validated. `NULL` is not an expression literal (it is UNKNOWN, spelled
-    // only in `IS NULL`), so a DETERMINISTIC routine folding to `.null` stands
+    // only in `IS NULL`), so a deterministic routine folding to `.null` stands
     // in for the constant-NULL prefix: `missing_udf()` after it still faults
     // `.function`.
     let routines = try Routines()
@@ -123,9 +123,9 @@ struct CoalesceReachabilityTests {
 
   @Test func `a constant NULL prefix does not shape the type`() throws {
     // A run skips a NULL argument and moves on, so an argument that folds to a
-    // constant `.null` can never be returned — its DECLARED type must not unify
+    // constant `.null` can never be returned — its declared type must not unify
     // into the column, exactly as a `CASE` omits a skipped branch's result
-    // type. `null_text()` is a DETERMINISTIC routine declaring `.text` yet
+    // type. `null_text()` is a deterministic routine declaring `.text` yet
     // folding to `.null`, so `COALESCE(null_text(), 1)` can only ever yield the
     // integer `1`: merging the `.text` would clash with the `.integer` and
     // reject the query, so the constant-NULL arm's type is skipped. It
@@ -163,7 +163,7 @@ struct CoalesceReachabilityTests {
   @Test func `a SUM prefix does not stop validation`() throws {
     // Unlike COUNT, SUM is NULL over an empty group, so it is NOT a definite
     // selection — the run may fall through it — and a later argument stays
-    // reachable and MUST be validated: `missing_udf()` after `SUM(K)` still
+    // reachable and must be validated: `missing_udf()` after `SUM(K)` still
     // faults `.function`.
     #expect(throws: SQLError.function("missing_udf")) {
       _ = try nullable().columns(of:
@@ -172,7 +172,7 @@ struct CoalesceReachabilityTests {
   }
 
   @Test func `a SUM prefix falls back to a reachable later argument`() throws {
-    // The CONTROL for the COUNT stop: `COALESCE(SUM(x), 0)` still validates and
+    // The control for the COUNT stop: `COALESCE(SUM(x), 0)` still validates and
     // derives the later `0` (SUM is nullable, not a stop), unifying to
     // `.integer`, and runs — SUM over the two-row group is the sum of K.
     let text = "SELECT COALESCE(SUM(K), 0) FROM T"
@@ -184,9 +184,9 @@ struct CoalesceReachabilityTests {
 // MARK: - Constant folding
 
 /// A deterministic native routine reporting whether its single argument is a
-/// `.double` — 1 when it is, else 0. It DISTINGUISHES `.double(1.0)` from
+/// `.double` — 1 when it is, else 0. It distinguishes `.double(1.0)` from
 /// `.integer(1)`, so the constant fold's coercion of a COALESCE's selected
-/// value is OBSERVABLE through it. Its declared parameter `type` matches the
+/// value is observable through it. Its declared parameter `type` matches the
 /// COALESCE's derived type so the static arity/type check (which demands an
 /// exact match) passes.
 private func doubling(taking type: ValueType) throws -> Routines {
@@ -205,14 +205,14 @@ private func predicate(over coalesce: Expression) -> Predicate {
               op: .equal, right: .literal(.integer(1)))
 }
 
-/// The schema validator folds a ROW-INDEPENDENT `COALESCE` (via
+/// The schema validator folds a ROW-independent `COALESCE` (via
 /// `constant(_ expression:)`) to decide a `WHERE` arm's reachability, so its
-/// selected value must carry the SAME type the run's `Term.coalesce` supplies —
+/// selected value must carry the same type the run's `Term.coalesce` supplies —
 /// the unified type `derive` advertises — or the fold sees a value the run
 /// never produces. The fold coerces the selected value to that unified type,
 /// mirroring the executor (`Value.coerced`) and the sibling empty-group fold.
 ///
-/// This engine types a COALESCE by its REACHABLE prefix: a constant non-NULL
+/// This engine types a COALESCE by its reachable prefix: a constant non-NULL
 /// argument is the definite selection, so it both sets the unified type and is
 /// the folded value — the coercion is therefore the identity on the constant
 /// path, but it keeps the fold pinned to the advertised type rather than a raw
@@ -243,7 +243,7 @@ struct CoalesceConstantTests {
   }
 
   @Test func `the constant fold matches the run`() throws {
-    // The fold and the run must yield the SAME value for a ROW-INDEPENDENT
+    // The fold and the run must yield the same value for a ROW-independent
     // COALESCE. Selecting a `.double` constant yields `.double`; selecting an
     // integer constant past a NULL-folding double routine yields `.integer`
     // (the reachable prefix types it), each coerced to the derived type the run
@@ -269,7 +269,7 @@ struct CoalesceConstantTests {
 
 // MARK: - Typecheck agrees with the run
 
-/// The `WHERE` reachability fold and the run must AGREE on a ROW-INDEPENDENT
+/// The `WHERE` reachability fold and the run must agree on a ROW-independent
 /// `COALESCE`: an arm the run reaches must be type-checked, so the COALESCE's
 /// coerced fold value cannot let validation skip a projection execution runs —
 /// mirroring the CASE-coercion end-to-end shape.
@@ -290,7 +290,7 @@ struct CoalesceTypeCheckingTests {
   }
 
   @Test func `an unreachable projection is skipped`() throws {
-    // The CONTROL: `COALESCE(1, 2)` folds to the integer `1`, so `is_double`
+    // The control: `COALESCE(1, 2)` folds to the integer `1`, so `is_double`
     // reports 0 and `= 1` folds FALSE — the AND's right arm is unreachable and
     // its `Name + 1` is NOT validated, so the query type-checks. (The run
     // likewise never reaches it.)
@@ -315,7 +315,7 @@ private final class Counter: @unchecked Sendable {
   /// The number of times `next()` has been called.
   private(set) var count = 0
 
-  /// Increments the count and returns the PREVIOUS value — the sequence `0, 1,
+  /// Increments the count and returns the previous value — the sequence `0, 1,
   /// 2, …` across successive calls.
   func next() -> Int {
     defer { count += 1 }
@@ -334,12 +334,12 @@ struct CoalesceOperandTests {
   }
 
   @Test func `each COALESCE argument is evaluated once`() throws {
-    // `stepper()` yields 0, then 1, 2, …; it is NON-deterministic so the engine
+    // `stepper()` yields 0, then 1, 2, …; it is non-deterministic so the engine
     // cannot fold it. `COALESCE(stepper(), 99)` must evaluate `stepper()`
-    // EXACTLY ONCE — yielding 0, a non-NULL value it returns. The old CASE
+    // exactly once — yielding 0, a non-NULL value it returns. The old CASE
     // desugar re-referenced the argument in both its `IS NOT NULL` guard and
     // its `THEN`, calling `stepper()` twice: the guard saw 0 (non-NULL) and the
-    // THEN returned a DIFFERENT 1. The first-class node holds the argument, so
+    // THEN returned a different 1. The first-class node holds the argument, so
     // the counter reads exactly 1 and the value returned is the one tested.
     let counter = Counter()
     let routines = try Routines()

--- a/Tests/SQLTests/Expressions/ConcatTests.swift
+++ b/Tests/SQLTests/Expressions/ConcatTests.swift
@@ -76,8 +76,8 @@ struct ConcatEvaluationTests {
 
   @Test func `a statically-NULL operand concatenates as NULL`() throws {
     // `CASE WHEN 1 = 0 THEN 1 END` yields NULL yet derives `.integer` (the
-    // no-branch schema default). `||` returns NULL for a NULL operand BEFORE
-    // it inspects kinds, so this VALIDATES — the output-schema text guard
+    // no-branch schema default). `||` returns NULL for a NULL operand before
+    // it inspects kinds, so this validates — the output-schema text guard
     // admits the folded NULL rather than rejecting the `.integer` type — and
     // runs, yielding NULL; the caller need not fall back to a CASE desugar.
     try things().expect("SELECT (CASE WHEN 1 = 0 THEN 1 END) || 'x'",
@@ -85,8 +85,8 @@ struct ConcatEvaluationTests {
   }
 
   @Test func `a folded-NULL side admits a non-text other operand`() throws {
-    // `Arithmetic.apply` returns NULL before inspecting EITHER kind, so a
-    // statically-NULL side makes the whole `||` valid regardless of the OTHER
+    // `Arithmetic.apply` returns NULL before inspecting either kind, so a
+    // statically-NULL side makes the whole `||` valid regardless of the other
     // operand's type: `(CASE WHEN 1 = 0 THEN 1 END) || 1` — a folded NULL
     // beside a bare integer — validates and yields NULL rather than being
     // rejected for the integer right operand.
@@ -114,7 +114,7 @@ private func derived(_ text: String) throws -> ValueType {
 struct ConcatDerivationTests {
   @Test func `deriving a concatenation resolves both operands`() throws {
     // `derive` — the schema-only surface a `columns(of:validate:false)` and an
-    // unreachable projection take, which RESOLVES column references — must
+    // unreachable projection take, which resolves column references — must
     // derive both `||` operands, so an unresolved `Missing` faults
     // `SQLError.column` rather than the branch silently advertising a `text`
     // column, mirroring the arithmetic `.binary` derive branch.

--- a/Tests/SQLTests/Expressions/DistinctFromTests.swift
+++ b/Tests/SQLTests/Expressions/DistinctFromTests.swift
@@ -85,7 +85,7 @@ struct DistinctFromEvaluationTests {
   }
 
   @Test func `both NULL operands are NOT DISTINCT`() throws {
-    // Row 5 has both K and L NULL; two NULLs are the SAME, so `K IS NOT DISTINCT
+    // Row 5 has both K and L NULL; two NULLs are the same, so `K IS NOT DISTINCT
     // FROM L` keeps it — alongside the equal-valued row 1 — where the null-safe
     // equality `K = L` (UNKNOWN on any NULL) could never keep the both-NULL row.
     try things().expect("SELECT Id FROM T WHERE K IS NOT DISTINCT FROM L",
@@ -100,7 +100,7 @@ struct DistinctFromEvaluationTests {
   }
 
   @Test func `column against itself is null-safe`() throws {
-    // `K IS NOT DISTINCT FROM K` is TRUE on EVERY row, NULL rows included — a
+    // `K IS NOT DISTINCT FROM K` is TRUE on every row, NULL rows included — a
     // NULL equals itself under null-safe equality, where `K = K` would be
     // UNKNOWN (and drop) on the NULL-K rows 4 and 5.
     try things().expect("SELECT Id FROM T WHERE K IS NOT DISTINCT FROM K",
@@ -113,7 +113,7 @@ struct DistinctFromEvaluationTests {
 struct DistinctFromCrossKindTests {
   @Test func `a cross-kind pair is DISTINCT`() throws {
     // Integer `K` against the text `'5'` is a cross-kind pair — the engine's
-    // `matches` yields FALSE for cross-kind equality, so the two DIFFER — and
+    // `matches` yields FALSE for cross-kind equality, so the two differ — and
     // `K IS DISTINCT FROM '5'` keeps every non-NULL K (rows 1, 2, 3) and the
     // NULL Ks too (a NULL differs from a non-NULL text).
     try things().expect("SELECT Id FROM T WHERE K IS DISTINCT FROM '5'",
@@ -121,7 +121,7 @@ struct DistinctFromCrossKindTests {
   }
 
   @Test func `a cross-kind pair is never NOT DISTINCT`() throws {
-    // Its complement keeps nothing: no integer K is null-safe EQUAL to the text
+    // Its complement keeps nothing: no integer K is null-safe equal to the text
     // `'5'` (cross-kind is DISTINCT), so `K IS NOT DISTINCT FROM '5'` is FALSE
     // on every row.
     try things().empty("SELECT Id FROM T WHERE K IS NOT DISTINCT FROM '5'")
@@ -133,9 +133,9 @@ struct DistinctFromCrossKindTests {
 struct DistinctFromTwoValuedTests {
   @Test func `IS DISTINCT FROM and IS NOT DISTINCT FROM partition the rows`()
       throws {
-    // The predicate is TWO-VALUED — never UNKNOWN — so on EVERY row exactly one
+    // The predicate is two-valued — never UNKNOWN — so on every row exactly one
     // of the two spellings holds and neither is UNKNOWN. `K IS NOT DISTINCT FROM
-    // 5` keeps rows 1 and 3 (K = 5); `K IS DISTINCT FROM 5` keeps the OTHER
+    // 5` keeps rows 1 and 3 (K = 5); `K IS DISTINCT FROM 5` keeps the other
     // three — rows 2, 4, 5 — including the NULL-K rows a `=` would leave
     // UNKNOWN, so together they cover all five rows disjointly.
     try things().expect("SELECT Id FROM T WHERE K IS NOT DISTINCT FROM 5",
@@ -146,8 +146,8 @@ struct DistinctFromTwoValuedTests {
 
   @Test func `a NULL operand never makes the row UNKNOWN`() throws {
     // Contrast with `=`: `K = 5` is UNKNOWN on the NULL-K rows and drops them,
-    // so it keeps FEWER rows than `K IS NOT DISTINCT FROM 5`. The null-safe form
-    // keeps rows 1 and 3 (K = 5) and, unlike `=`, is DEFINITELY FALSE (not
+    // so it keeps fewer rows than `K IS NOT DISTINCT FROM 5`. The null-safe form
+    // keeps rows 1 and 3 (K = 5) and, unlike `=`, is definitely FALSE (not
     // UNKNOWN) on the NULL-K rows rather than erroring or admitting them.
     try things().expect("SELECT Id FROM T WHERE K = 5", yields: [[1], [3]])
     try things().expect("SELECT Id FROM T WHERE K IS NOT DISTINCT FROM 5",
@@ -186,7 +186,7 @@ struct DistinctFromFoldingTests {
 
   @Test func `a constant both-NULL folds NOT DISTINCT`() throws {
     // `NULLIF(1, 1)` folds to a constant NULL, so both operands fold NULL — the
-    // SAME — and `NULLIF(1, 1) IS DISTINCT FROM NULLIF(1, 1)` folds FALSE
+    // same — and `NULLIF(1, 1) IS DISTINCT FROM NULLIF(1, 1)` folds FALSE
     // (dropping every row) and its negation TRUE.
     try things().empty(
         "SELECT Id FROM T WHERE NULLIF(1, 1) IS DISTINCT FROM NULLIF(1, 1)")

--- a/Tests/SQLTests/Expressions/FunctionTests.swift
+++ b/Tests/SQLTests/Expressions/FunctionTests.swift
@@ -117,7 +117,7 @@ private func library() throws -> FixtureCatalog {
   @Test func `columns(of:) reports a built-in call by its declared type`() throws {
     // The schema walk types a call by its routine's `returns`, so a projected
     // built-in reports the declared header — text for UPPER, integer for
-    // CHAR_LENGTH, double for ROUND — when the standard prelude is in scope.
+    // CHAR_LENGTH, double for round — when the standard prelude is in scope.
     let query = try Statement(parsing:
         "SELECT UPPER(Text), CHAR_LENGTH(Text), ROUND(Real) FROM L")
     let typed = try library().columns(of: query, routines: .standard)
@@ -236,7 +236,7 @@ private func library() throws -> FixtureCatalog {
   @Test func `a built-in faults on a wrong-typed argument`() throws {
     // Likewise the run invokes the routine, whose own kind check faults a
     // numeric column passed to UPPER's text argument and a text column passed
-    // to MOD's integer arguments.
+    // to mod's integer arguments.
     try library().expect("SELECT UPPER(Num) FROM L WHERE Id = 1",
                          fails: .argument("UPPER requires a text argument"),
                          routines: .standard)
@@ -411,7 +411,7 @@ private func id() -> Function {
   }
 
   @Test func `a defined call with a wrong-typed argument faults at the run path`() throws {
-    // Reached through the RUN path (no prior `columns(validate:)`), the defined
+    // Reached through the run path (no prior `columns(validate:)`), the defined
     // dispatch validates each argument's type, not only the arity: `id(Name)`
     // over a TEXT column would otherwise return a `.text` value against the
     // routine's INTEGER contract; the dispatch faults it, the same
@@ -440,7 +440,7 @@ private func id() -> Function {
   }
 
   @Test func `a body naming its own unregistered name faults as unresolved`() {
-    // `f() RETURNS INTEGER AS f() + 1` with NO prior `f` captures a map without
+    // `f() RETURNS INTEGER AS f() + 1` with no prior `f` captures a map without
     // `f`, so the body's own call is unresolved: the returns validation faults
     // `SQLError.function`, the unregistered-callee case — not a self-reference
     // one. Early binding admits no recursion here; there is nothing to bind to.
@@ -453,8 +453,8 @@ private func id() -> Function {
   }
 
   @Test func `a body naming its own name over an existing one captures the old one`() throws {
-    // `f() AS f() + 1` REPLACING a prior `f` is well-defined under early
-    // binding: the new body captures the OLD `f` (the map before this
+    // `f() AS f() + 1` replacing a prior `f` is well-defined under early
+    // binding: the new body captures the old `f` (the map before this
     // registration), so it computes `f_old() + 1` and terminates — no
     // recursion. With `f_old` = 0, `f_new()` = 0 + 1 = 1.
     let existing = Function(parameters: [], returns: .integer,
@@ -470,7 +470,7 @@ private func id() -> Function {
 
   @Test func `a body calling a prelude routine registers and runs`() throws {
     // `lowbit(n INTEGER) AS BITAND(n, 1)` calls the prelude BITAND. The capture
-    // seeds `Routines.standard` under `self` — the SAME precedence the public
+    // seeds `Routines.standard` under `self` — the same precedence the public
     // run/columns compose a query's routines with — so the body resolves BITAND
     // at registration exactly as an ordinary SELECT would, rather than faulting
     // `SQLError.function("BITAND")` for a built-in the query path can reach.
@@ -518,7 +518,7 @@ private func id() -> Function {
 
   @Test func `a defined body binds its callee at definition, not at call time`() throws {
     // The round-5 root case. `g` returns INTEGER 1; `f() AS g()` captures that
-    // INTEGER `g`. Redefining `g` to a TEXT body shadows it for QUERIES, but
+    // INTEGER `g`. Redefining `g` to a TEXT body shadows it for queries, but
     // `f` closed over the old `g`, so `SELECT f()` still returns the INTEGER 1
     // — consistent with f's advertised INTEGER schema — while a top-level
     // `SELECT g()` sees the new TEXT `g` (query-level latest-wins unchanged).
@@ -540,7 +540,7 @@ private func id() -> Function {
     // A body's inputs are its declared parameters, not query bindings. `f() AS
     // CASE WHEN 1 = :p THEN 1 ELSE 0 END` reaches a `:parameter` through a CASE
     // guard, but a routine body is evaluated with only its argument record — the
-    // caller's bindings never reach it — so `:p` would always be UNBOUND and
+    // caller's bindings never reach it — so `:p` would always be unbound and
     // silently pick the ELSE branch. The registration rejects the `.bound`.
     let body =
         Expression.case([When(when: .bound(left: .literal(.integer(1)),
@@ -574,7 +574,7 @@ private func id() -> Function {
 
   @Test func `a RETURNS DOUBLE body of a mixed CASE returns a double`() throws {
     // `f(n INTEGER) RETURNS DOUBLE AS CASE WHEN n = 7 THEN 1 ELSE 2.5 END`: the
-    // body's results unify to `.double`, so it TYPES as double and the RETURNS
+    // body's results unify to `.double`, so it types as double and the returns
     // check passes. Called with N.V = 7 it takes the integer THEN `1`, which
     // the CASE coercion widens to `.double(1.0)` — the value now matches the
     // declared double return, not a bare `.integer(1)`.

--- a/Tests/SQLTests/Expressions/LikeTests.swift
+++ b/Tests/SQLTests/Expressions/LikeTests.swift
@@ -318,8 +318,8 @@ private func floats(_ plan: Plan) -> Bool {
 
 /// The `LIKE` escape's effect on `safe`, hence on pushdown/seek/join-reorder
 /// eligibility: a `.like` is `safe` (may ride below a seek or join) only when
-/// its escape is absent OR STATICALLY a single-character text constant, because
-/// `Row.like` faults on any other escape INDEPENDENTLY of whether a pair
+/// its escape is absent OR statically a single-character text constant, because
+/// `Row.like` faults on any other escape independently of whether a pair
 /// matches — so a hash join must not drop a non-matching pair (nor a seek a
 /// narrowed run) before that fault fires.
 struct LikeSafetyTests {
@@ -360,9 +360,9 @@ struct LikeSafetyTests {
     // The same `ON A.K = B.K AND A.Name LIKE 'a%' ESCAPE A.E` run against the
     // single pair (`A.K` NULL, `B.K = 2`). The equi is UNKNOWN, so the Kleene
     // `AND` does not short-circuit and evaluates the LIKE. Because the escaped
-    // LIKE is UNSAFE, no key is hoisted and the residual runs the whole `ON`
+    // LIKE is unsafe, no key is hoisted and the residual runs the whole `ON`
     // per pair, so the invalid escape faults `SQLError.argument` — where
-    // marking it safe would extract the key, drop the NULL-key pair, and HIDE
+    // marking it safe would extract the key, drop the NULL-key pair, and hide
     // the fault (return no rows).
     try mismatched().expect("""
         SELECT A.K FROM A JOIN B ON A.K = B.K AND A.Name LIKE 'a%' ESCAPE A.E
@@ -390,7 +390,7 @@ struct LikeSafetyTests {
   @Test func `a constant single-character escape is safe and may be sought`()
       throws {
     // `WHERE Name LIKE '_%' ESCAPE '\' AND Id = 2` over an Id-sorted relation:
-    // the escape is a STATIC single-character constant, so the LIKE is safe and
+    // the escape is a static single-character constant, so the LIKE is safe and
     // does not bar the seekable `Id = 2` from riding down to the base scan.
     let catalog = try Catalog {
       Relation("S", ["Id": .integer, "Name": .text], sorted: "Id") {
@@ -452,8 +452,8 @@ struct LikeBoundTests {
 
 // MARK: - Evaluation order
 
-/// The operand, pattern, and escape are each evaluated ONCE, IN ORDER, BEFORE
-/// the three-valued NULL result is decided — so a fault in a REACHED operand
+/// The operand, pattern, and escape are each evaluated once, IN ORDER, before
+/// the three-valued NULL result is decided — so a fault in a reached operand
 /// (`1 / K` with `K = 0`) surfaces rather than being swallowed by a NULL escape
 /// that an early return would have turned into a silent UNKNOWN.
 struct LikeEvaluationOrderTests {
@@ -472,9 +472,9 @@ struct LikeEvaluationOrderTests {
       throws {
     // `(1 / K) LIKE 'x' ESCAPE E` with `K = 0, E = NULL`. The operand `1 / K`
     // faults `SQLError.divide`; the executor must evaluate the reached operand
-    // BEFORE deciding the NULL-escape UNKNOWN — an early return on the NULL
+    // before deciding the NULL-escape UNKNOWN — an early return on the NULL
     // escape would silently FILTER the row (UNKNOWN) and hide the divide.
-    // ADVERSARIAL: reverting to early-return-on-NULL-escape stops this throw.
+    // adversarial: reverting to early-return-on-NULL-escape stops this throw.
     try faulting().expect(
         "SELECT Id FROM F WHERE (1 / K) LIKE 'x' ESCAPE E",
         fails: .divide)
@@ -482,7 +482,7 @@ struct LikeEvaluationOrderTests {
 
   @Test func `a NULL escape with a safe operand is a clean UNKNOWN`() throws {
     // A plain safe operand under a NULL escape is UNKNOWN — the row is excluded
-    // WITHOUT a throw, so the eval-order fix does not turn every NULL escape
+    // without a throw, so the eval-order fix does not turn every NULL escape
     // into a fault.
     try Catalog {
       Relation("F", ["Id": .integer, "Name": .text, "E": .text]) {
@@ -495,13 +495,13 @@ struct LikeEvaluationOrderTests {
 // MARK: - Static escape validation
 
 /// A statically-invalid ESCAPE (a constant that is not a single-character text)
-/// is rejected at VALIDATION (`columns(of:validate:)`), not left to fault on
+/// is rejected at validation (`columns(of:validate:)`), not left to fault on
 /// every row — `check` folds a row-independent escape and rejects a bad one.
 struct LikeEscapeValidationTests {
   @Test func `a constant multi-character escape faults validation`() throws {
     // `ESCAPE 'xy'` is a constant text of the wrong length — un-runnable — so
     // `columns(of:validate:)` rejects it at validation with the run's message.
-    // ADVERSARIAL: reverting the check drops this validation throw.
+    // adversarial: reverting the check drops this validation throw.
     let query = try parse(query:
         "SELECT Id FROM T WHERE Name LIKE 'x' ESCAPE 'xy'")
     #expect(throws:
@@ -540,7 +540,7 @@ struct LikeEscapeValidationTests {
 
 // MARK: - Matcher complexity
 
-/// The matcher is LINEAR (a two-pointer scan), not the exponential
+/// The matcher is linear (a two-pointer scan), not the exponential
 /// backtracking recursion — so a pathological pattern against a long run of
 /// its wildcard fill returns promptly rather than pegging the engine.
 struct LikeComplexityTests {
@@ -548,7 +548,7 @@ struct LikeComplexityTests {
     // `%a%a%a%a%a%a%a%b` against a long run of `a`s (no `b`) is the classic
     // ReDoS-style blowup for a per-split recursive matcher — combinatorial in
     // the number of `%` splits over the text length. The linear scan decides
-    // FALSE in O(n·m) and returns at once. ADVERSARIAL: the recursive matcher
+    // FALSE in O(n·m) and returns at once. adversarial: the recursive matcher
     // does not complete in bounded time on this input.
     let text = String(repeating: "a", count: 256)
     #expect(!matches(text, "%a%a%a%a%a%a%a%b", escape: nil))
@@ -571,7 +571,7 @@ struct LikeComplexityTests {
 struct LikeParameterTests {
   @Test func `a bound pattern matches the right rows`() throws {
     // `WHERE Name LIKE :pattern` bound to `'a%'` — rows 1 and 2 begin `a`, row
-    // 3 does not, row 4 (NULL) is UNKNOWN. ADVERSARIAL: reverting the parser
+    // 3 does not, row 4 (NULL) is UNKNOWN. adversarial: reverting the parser
     // `:param` handling makes `LIKE :pattern` fail to parse/bind.
     try names().expect("SELECT Id FROM T WHERE Name LIKE :pattern",
                        yields: [[1], [2]],
@@ -607,7 +607,7 @@ struct LikeParameterTests {
   @Test func `a bound escape is unsafe and bars a seek`() throws {
     // A `:parameter` escape is not a static single-character constant — it may
     // be unbound, NULL, or the wrong length at run time — so the escaped LIKE
-    // is UNSAFE and does not ride below a seek: the seekable `Id = 2` cannot
+    // is unsafe and does not ride below a seek: the seekable `Id = 2` cannot
     // reach the base scan beside it.
     let catalog = try Catalog {
       Relation("S", ["Id": .integer, "Name": .text], sorted: "Id") {
@@ -634,7 +634,7 @@ struct LikeParameterTests {
 /// A parameterised `LIKE` — one whose pattern or escape operand is a run-time
 /// `:parameter` — reads no slot yet can be UNKNOWN (the parameter may be
 /// unbound or bound to NULL), so `nullable` counts it and pushdown must not
-/// ride it below a LATER unsafe conjunct: the non-short-circuiting `AND` still
+/// ride it below a later unsafe conjunct: the non-short-circuiting `AND` still
 /// owes that conjunct's evaluation after an UNKNOWN left.
 struct LikeParameterisedTests {
   /// A view over a single (x = 1, y = 0) row — the derived-leaf shape the
@@ -675,7 +675,7 @@ struct LikeParameterisedTests {
 
   @Test func `a parameterised LIKE is not pushed below a later unsafe conjunct`()
       throws {
-    // `SELECT x FROM V WHERE 'x' LIKE :p AND (1 / y) = 0` with `:p` UNBOUND:
+    // `SELECT x FROM V WHERE 'x' LIKE :p AND (1 / y) = 0` with `:p` unbound:
     // the outer `AND` does not short-circuit, so on the (y = 0) row the UNKNOWN
     // LIKE still runs the division, which raises. Injecting the slotless `'x'
     // LIKE :p` into the view would drop every row first, suppressing the
@@ -696,7 +696,7 @@ struct LikeParameterisedTests {
   }
 
   @Test func `a constant LIKE is pushed below a later unsafe conjunct`() throws {
-    // CONTROL: `'x' LIKE 'y'` names no `:parameter`, so it is definite and
+    // control: `'x' LIKE 'y'` names no `:parameter`, so it is definite and
     // eligible for the normal pushdown — a non-nullable conjunct injects into
     // the view, dropping every row before the outer division runs, so the query
     // returns nothing rather than raising (the ordinary non-parameterised way).

--- a/Tests/SQLTests/Expressions/MembershipTests.swift
+++ b/Tests/SQLTests/Expressions/MembershipTests.swift
@@ -150,7 +150,7 @@ struct MembershipTypeCheckingTests {
 
   @Test func `a constant expression element prunes a later unreachable element`() throws {
     // `1 IN (1 + 0, Name + 1)` lowers to `1 = 1 + 0 OR 1 = Name + 1`; the first
-    // element is a ROW-INDEPENDENT constant expression (not a bare literal)
+    // element is a ROW-independent constant expression (not a bare literal)
     // that folds to `1`, a definite match, so the OR-chain short-circuits and
     // `Name + 1` (text arithmetic) is unreachable — the type check must fold
     // the constant element and stop rather than continuing into it, and the
@@ -164,7 +164,7 @@ struct MembershipTypeCheckingTests {
 
   @Test func `a non-matching constant expression element keeps a later element reachable`() throws {
     // `2 IN (1 + 0, Name + 1)` folds the first element to `1`, which `2` does
-    // NOT match, so `Name + 1` stays reachable — the pruning is PRECISE, not
+    // NOT match, so `Name + 1` stays reachable — the pruning is precise, not
     // over-eager — and its text arithmetic must still fault the type check,
     // matching the run, which would evaluate `2 = Name + 1` and fault.
     let query = try parse(query:
@@ -191,10 +191,10 @@ struct MembershipTypeCheckingTests {
 
   @Test func `a constant routine call element prunes a later unreachable element`() throws {
     // `1 IN (BITAND(1, 1), Name + 1)` lowers to `1 = BITAND(1, 1) OR 1 = Name
-    // + 1`; the first element is a ROW-INDEPENDENT scalar CALL — every argument
+    // + 1`; the first element is a ROW-independent scalar call — every argument
     // folds constant — so it folds to the routine's value `1`, a definite
     // match, and the OR-chain short-circuits before `Name + 1` (text
-    // arithmetic). The type check must fold the call through the SAME routine
+    // arithmetic). The type check must fold the call through the same routine
     // the run invokes and stop, and the run, matching `1 = BITAND(1, 1)` first,
     // keeps every row. (`BITAND` is a standard prelude routine, seeded like the
     // existing constant-expression tests.)
@@ -206,13 +206,13 @@ struct MembershipTypeCheckingTests {
 
   @Test func `a non-deterministic routine call is not folded when pruning`() throws {
     // `1 IN (probe(), Name + 1)` lowers to `1 = probe() OR 1 = Name + 1`.
-    // `probe` is registered NOT DETERMINISTIC (ISO's default for a host
+    // `probe` is registered NOT deterministic (ISO's default for a host
     // closure), so the schema check must NOT execute it to fold the first
     // element — a non-deterministic routine could return one value here and
     // another when the run reaches the call, wrongly pruning a later element.
     // With the call unfolded, `Name + 1` stays reachable and its text
     // arithmetic faults the type check, matching the run's guarantee. (`probe`
-    // returns `1`, which WOULD match `1` and short-circuit had it been folded —
+    // returns `1`, which would match `1` and short-circuit had it been folded —
     // proving the gate keys off the characteristic, not the value.)
     let routines = try Routines()
         .registering("probe", returns: .integer, deterministic: false) { _ in
@@ -229,8 +229,8 @@ struct MembershipTypeCheckingTests {
   }
 
   @Test func `a deterministic routine call is folded when pruning`() throws {
-    // The same query with `probe` declared DETERMINISTIC (ISO
-    // `DETERMINISTIC`): the schema check MAY fold `probe()` to `1`, a definite
+    // The same query with `probe` declared deterministic (ISO
+    // `DETERMINISTIC`): the schema check may fold `probe()` to `1`, a definite
     // match, so the OR-chain short-circuits before `Name + 1` and its text
     // arithmetic is never reached — `columns(of:)` succeeds. The ONLY change
     // from the prior test is the `deterministic` flag, so the gate keys off it.
@@ -248,7 +248,7 @@ struct MembershipTypeCheckingTests {
   @Test func `a non-matching constant routine call element keeps a later element reachable`() throws {
     // `2 IN (BITAND(1, 1), Name + 1)` folds the first element through the
     // routine to `1`, which `2` does NOT match, so `Name + 1` stays reachable
-    // — the routine fold is PRECISE, not over-eager — and its text arithmetic
+    // — the routine fold is precise, not over-eager — and its text arithmetic
     // must still fault the type check, matching the run.
     let text = "SELECT Id FROM T WHERE 2 IN (BITAND(1, 1), Name + 1)"
     let query = try parse(query: text)
@@ -278,7 +278,7 @@ struct MembershipTypeCheckingTests {
   @Test func `a non-matching constant CASE element keeps a later element reachable`() throws {
     // `2 IN (CASE WHEN 1 = 1 THEN 1 ELSE Name + 1 END, Name + 1)` folds the
     // CASE to `1`, which `2` does NOT match, so the trailing `Name + 1` stays
-    // reachable — the CASE fold is PRECISE, not over-eager — and its text
+    // reachable — the CASE fold is precise, not over-eager — and its text
     // arithmetic must still fault the type check, matching the run.
     let text = "SELECT Id FROM T WHERE 2 IN "
         + "(CASE WHEN 1 = 1 THEN 1 ELSE Name + 1 END, Name + 1)"
@@ -293,7 +293,7 @@ struct MembershipTypeCheckingTests {
 
   @Test func `a row-dependent CASE guard leaves a later element reachable`() throws {
     // `1 IN (CASE WHEN Id = 2 THEN 1 ELSE 0 END, Name + 1)` cannot fold the
-    // CASE: its guard `Id = 2` is ROW-DEPENDENT, so `constant` yields `nil` —
+    // CASE: its guard `Id = 2` is ROW-dependent, so `constant` yields `nil` —
     // the CASE is not a definite match (the run cannot guarantee it equals `1`
     // on every row) and the trailing `Name + 1` (text arithmetic) stays
     // reachable, so its text arithmetic must still fault the type check.
@@ -310,7 +310,7 @@ struct MembershipTypeCheckingTests {
 
   @Test func `a constant-expression CASE guard prunes a later unreachable element`() throws {
     // `1 IN (CASE WHEN 1 + 0 = 1 THEN 1 END, Name + 1)` lowers to `1 = <CASE>
-    // OR 1 = Name + 1`; the CASE guard `1 + 0 = 1` is ROW-INDEPENDENT but NOT
+    // OR 1 = Name + 1`; the CASE guard `1 + 0 = 1` is ROW-independent but NOT
     // bare literals — its left operand is arithmetic. Folding the guard through
     // `constant(_ expression:)` decides it TRUE, so the CASE folds to `1`, a
     // definite match, and the OR-chain short-circuits before `Name + 1` (text
@@ -328,7 +328,7 @@ struct MembershipTypeCheckingTests {
     // folds FALSE and the CASE has no ELSE, so it yields NULL — `1 = NULL` is
     // UNKNOWN, NOT a definite match — so the trailing `Name + 1` (text
     // arithmetic) stays reachable and must still fault the type check, matching
-    // the run. The pruning is PRECISE: a folded-FALSE guard prunes nothing.
+    // the run. The pruning is precise: a folded-FALSE guard prunes nothing.
     let text = "SELECT Id FROM T WHERE 1 IN "
         + "(CASE WHEN 1 + 0 = 2 THEN 1 END, Name + 1)"
     let query = try parse(query: text)
@@ -342,7 +342,7 @@ struct MembershipTypeCheckingTests {
 
   @Test func `a non-deterministic CASE guard leaves a later element reachable`() throws {
     // `1 IN (CASE WHEN probe() = 1 THEN 1 END, Name + 1)` with `probe`
-    // registered NOT DETERMINISTIC: the guard's `probe()` operand does not fold
+    // registered NOT deterministic: the guard's `probe()` operand does not fold
     // through `constant(_ expression:)` (the determinism gate), so the guard is
     // `nil`, the CASE is `nil`, and the trailing `Name + 1` (text arithmetic)
     // stays reachable and must still fault the type check. The determinism gate
@@ -365,7 +365,7 @@ struct MembershipTypeCheckingTests {
 
   @Test func `a constant-expression IS NOT NULL CASE guard prunes a later unreachable element`() throws {
     // `1 IN (CASE WHEN 1 + 0 IS NOT NULL THEN 1 END, Name + 1)`: the guard `1 +
-    // 0 IS NOT NULL` is ROW-INDEPENDENT but NOT a bare literal. Folding its
+    // 0 IS NOT NULL` is ROW-independent but NOT a bare literal. Folding its
     // operand through `constant(_ expression:)` yields the concrete value `1`,
     // which is not NULL, so `IS NOT NULL` folds TRUE — the CASE folds to `1`, a
     // definite match, and the OR-chain short-circuits before `Name + 1` (text
@@ -396,7 +396,7 @@ struct MembershipTypeCheckingTests {
     // The whole-result-aggregate empty-group HAVING fold —
     // `empty(_:Predicate)`, the surface `OutputColumn.typecheck` drives over
     // the single empty group a statically-false WHERE leaves — reaches its
-    // `.membership` arm WITHOUT a prior `check`, so it must reject an EMPTY
+    // `.membership` arm without a prior `check`, so it must reject an empty
     // list itself, as `check` and `lower` do. An empty membership otherwise
     // folds FALSE (TRUE under `NOT IN`), silently keeping the group past a list
     // both `check` and `lower` reject. The parser rejects `IN ()`, so build the
@@ -411,7 +411,7 @@ struct MembershipTypeCheckingTests {
   }
 
   /// A `SELECT Id FROM T WHERE <predicate>` built directly, so a
-  /// `Predicate.membership` with an EMPTY value list reaches the engine —
+  /// `Predicate.membership` with an empty value list reaches the engine —
   /// bypassing the parser, which rejects `IN ()`.
   private func select(where predicate: Predicate) -> Query {
     .select(Select(projection: .columns([Column(name: "Id")]),
@@ -419,9 +419,9 @@ struct MembershipTypeCheckingTests {
   }
 
   @Test func `an empty IN list faults the schema check, not a crash`() throws {
-    // `Predicate.membership` is public, so a caller can build an EMPTY list
+    // `Predicate.membership` is public, so a caller can build an empty list
     // directly, bypassing the parser's `IN ()` rejection. The lowering has no
-    // OR-chain seed for an empty list, so it FAULTS the schema check (an
+    // OR-chain seed for an empty list, so it faults the schema check (an
     // unsupported shape) rather than trapping on the force-unwrap.
     let query = select(where: .membership(.column("Id"), [], negated: false))
     let resolve = { () throws -> Array<OutputColumn> in
@@ -434,7 +434,7 @@ struct MembershipTypeCheckingTests {
   }
 
   @Test func `an empty IN list faults the run, not a crash`() throws {
-    // The same direct-AST empty list must FAULT the run's compile/lowering (the
+    // The same direct-AST empty list must fault the run's compile/lowering (the
     // OR-chain reduction) rather than crashing on the force-unwrap.
     let query = select(where: .membership(.column("Id"), [], negated: false))
     #expect(throws:
@@ -456,7 +456,7 @@ private final class Counter: @unchecked Sendable {
   /// The number of times `next()` has been called.
   private(set) var count = 0
 
-  /// Increments the count and returns the PREVIOUS value — the sequence `0, 1,
+  /// Increments the count and returns the previous value — the sequence `0, 1,
   /// 2, …` across successive calls.
   func next() -> Int {
     defer { count += 1 }
@@ -477,11 +477,11 @@ struct MembershipOperandTests {
 
   @Test func `the IN operand is evaluated once per row`() throws {
     // `stepper()` yields 0 on its first call, then 1, 2, …; it is
-    // NON-deterministic so the engine cannot fold it. Over the one row,
-    // `stepper() IN (1, 2)` must evaluate the operand EXACTLY ONCE — yielding
-    // 0 — and 0 ∉ {1, 2}, so the row is EXCLUDED. The old OR-chain lowered this
+    // non-deterministic so the engine cannot fold it. Over the one row,
+    // `stepper() IN (1, 2)` must evaluate the operand exactly once — yielding
+    // 0 — and 0 ∉ {1, 2}, so the row is excluded. The old OR-chain lowered this
     // to `stepper() = 1 OR stepper() = 2`, re-evaluating the operand: the first
-    // call yields 0 (0 ≠ 1) and the SECOND yields 2 (2 = 2), wrongly ADMITTING
+    // call yields 0 (0 ≠ 1) and the second yields 2 (2 = 2), wrongly admitting
     // the row and calling `stepper()` twice. The first-class membership filter
     // caches the operand, so the row is dropped and the counter reads exactly
     // 1.

--- a/Tests/SQLTests/Expressions/NullifTests.swift
+++ b/Tests/SQLTests/Expressions/NullifTests.swift
@@ -10,7 +10,7 @@ import SQLTestSupport
 
 struct NullifTests {
   @Test func `NULLIF parses to a first-class node`() throws {
-    // `NULLIF(K, 0)` is a first-class `Expression.nullif` holding `K` ONCE —
+    // `NULLIF(K, 0)` is a first-class `Expression.nullif` holding `K` once —
     // not the re-referencing `CASE` its ISO definition names.
     let select = try parse(select: "SELECT NULLIF(K, 0) FROM T")
     let expression = Expression.nullif(.column("K"), .literal(.integer(0)))
@@ -59,14 +59,14 @@ private func derived(_ text: String) throws -> ValueType {
   return try scope.derive(items[0].expression)
 }
 
-/// The `derive` surface RESOLVES column references without `compile`'s
-/// lowering, so `derive` alone must resolve BOTH NULLIF operands: the LHS
+/// The `derive` surface resolves column references without `compile`'s
+/// lowering, so `derive` alone must resolve both NULLIF operands: the LHS
 /// shapes the result type and the RHS resolves for its errors, exactly as the
 /// `||`/arithmetic derive branch derives both sides.
 struct NullifDerivationTests {
   @Test func `deriving NULLIF resolves the second operand`() throws {
     // `derive` — the schema-only surface a `columns(of:validate:false)` and an
-    // unreachable projection take, which RESOLVES column references — must
+    // unreachable projection take, which resolves column references — must
     // derive both `NULLIF` operands, so an unresolved RHS `Missing` faults
     // `SQLError.column` rather than the branch silently returning the LHS type,
     // mirroring the arithmetic `.binary` derive branch.
@@ -93,7 +93,7 @@ private final class Counter: @unchecked Sendable {
   /// The number of times `next()` has been called.
   private(set) var count = 0
 
-  /// Increments the count and returns the PREVIOUS value — the sequence `0, 1,
+  /// Increments the count and returns the previous value — the sequence `0, 1,
   /// 2, …` across successive calls.
   func next() -> Int {
     defer { count += 1 }
@@ -113,11 +113,11 @@ struct NullifOperandTests {
 
   @Test func `the NULLIF operand is evaluated once`() throws {
     // `stepper()` yields 0, then 1, …; non-deterministic, so unfoldable.
-    // `NULLIF(stepper(), 99)` must evaluate `stepper()` EXACTLY ONCE — yielding
-    // 0, which ≠ 99, so it returns that SAME 0. The old CASE desugar embedded
+    // `NULLIF(stepper(), 99)` must evaluate `stepper()` exactly once — yielding
+    // 0, which ≠ 99, so it returns that same 0. The old CASE desugar embedded
     // the operand in both the `= 99` equality and the `ELSE`, calling
     // `stepper()` twice: the equality compared 0 and the ELSE returned a
-    // DIFFERENT 1. The first-class node holds the operand, so the counter reads
+    // different 1. The first-class node holds the operand, so the counter reads
     // exactly 1 and the value returned is the one compared.
     let counter = Counter()
     let routines = try Routines()

--- a/Tests/SQLTests/Expressions/QuantifiedSubqueryTests.swift
+++ b/Tests/SQLTests/Expressions/QuantifiedSubqueryTests.swift
@@ -53,7 +53,7 @@ struct QuantifiedSubqueryParsingTests {
 
   @Test func `SOME parses identically to ANY`() throws {
     // `SOME` is a synonym for `ANY`, normalised to `.any` at parse time, so the
-    // two spellings produce the SAME AST.
+    // two spellings produce the same AST.
     let some =
         try parse(select: "SELECT Id FROM T WHERE K < SOME (SELECT V FROM S)")
     let any =
@@ -121,7 +121,7 @@ struct QuantifiedOrderingTests {
   }
 
   @Test func `> ALL holds for a value above the maximum`() throws {
-    // `K > ALL {10, 20}` is TRUE only above EVERY value, i.e. above the maximum
+    // `K > ALL {10, 20}` is TRUE only above every value, i.e. above the maximum
     // 20: K = 30 qualifies; K = 10 and 20 do not; K NULL is UNKNOWN.
     try fixture().expect(
         "SELECT Id FROM T WHERE K > ALL (SELECT V FROM S WHERE Flag = 1)",
@@ -210,7 +210,7 @@ struct QuantifiedNullCornerTests {
 
 struct QuantifiedArityTests {
   @Test func `a two-column quantified subquery faults at compile`() throws {
-    // A quantified comparison requires its subquery project exactly ONE column;
+    // A quantified comparison requires its subquery project exactly one column;
     // a two-column subquery is `SQLError.arity`, checked from the compiled
     // width, so it faults even though S has rows — reusing IN's arity check.
     try fixture().expect(
@@ -220,7 +220,7 @@ struct QuantifiedArityTests {
 
   @Test func `a two-column quantified subquery faults the schema check too`()
       throws {
-    // The schema path enforces the SAME single-column arity as the run.
+    // The schema path enforces the same single-column arity as the run.
     let query = try parse(query:
          "SELECT Id FROM T WHERE K < ANY (SELECT V, Flag FROM S)")
     let resolve = { () throws -> Array<OutputColumn> in
@@ -259,7 +259,7 @@ struct QuantifiedTypeCheckingTests {
 // MARK: - Correlated quantified execution
 
 /// An outer relation and an inner relation sharing a key `k`, so a quantified
-/// subquery referencing an outer column is CORRELATED: its lone column depends
+/// subquery referencing an outer column is correlated: its lone column depends
 /// on the enclosing row, forcing the per-outer-row re-execution the discovered
 /// correlation threads (rather than a once-memoised uncorrelated run).
 private func correlated() throws -> FixtureCatalog {
@@ -283,7 +283,7 @@ struct CorrelatedQuantifiedTests {
     // `Toll.k`, so the inner column is re-materialised per outer row: row
     // (10, 1) → {10} (10 = ANY → TRUE), row (20, 2) → {20, 30} (TRUE), row
     // (99, 3) → {} (FALSE). A `[:]`-correlation eval would re-run the inner
-    // query WITHOUT the outer scope and fail to bind `Toll.k`.
+    // query without the outer scope and fail to bind `Toll.k`.
     let sql = """
         SELECT x FROM Toll \
         WHERE x = ANY (SELECT i.x FROM Inn i WHERE i.k = Toll.k) \
@@ -323,8 +323,8 @@ struct CorrelatedQuantifiedTests {
   }
 
   @Test func `an uncorrelated quantified still memoises once`() throws {
-    // With NO outer reference the quantified subquery is uncorrelated — empty
-    // correlation — so it materialises its column ONCE (memoised), folded per
+    // With no outer reference the quantified subquery is uncorrelated — empty
+    // correlation — so it materialises its column once (memoised), folded per
     // outer row: `Inn.x` ∈ {10, 20, 30}, so `Toll.x = ANY {10, 20, 30}` keeps
     // rows 10 and 20 (99 is absent).
     let sql = """

--- a/Tests/SQLTests/Expressions/RowValueTests.swift
+++ b/Tests/SQLTests/Expressions/RowValueTests.swift
@@ -31,7 +31,7 @@ private func pairs() throws -> FixtureCatalog {
 
 struct RowValueParsingTests {
   @Test func `a row equality parses a first-class rows node`() throws {
-    // `(A, B) = (C, Id)` parses to the FIRST-CLASS `Predicate.rows` node
+    // `(A, B) = (C, Id)` parses to the FIRST-class `Predicate.rows` node
     // holding both rows' component expressions once — NOT a desugared
     // conjunction of scalar comparisons (which duplicated a component). The
     // componentwise semantics live in the lowering, not the AST.
@@ -83,7 +83,7 @@ struct RowValueParsingTests {
   }
 
   @Test func `a row IN parses a first-class among node`() throws {
-    // `(A, B) IN ((1, 2), (2, 2))` parses to the FIRST-CLASS `Predicate.among`
+    // `(A, B) IN ((1, 2), (2, 2))` parses to the FIRST-class `Predicate.among`
     // node holding the left row and each element row once — NOT a desugared
     // disjunction of row equalities.
     let select =
@@ -309,14 +309,14 @@ struct RowValueEvaluationTests {
 struct RowValueNullTests {
   @Test func `a NULL component makes an otherwise-equal row UNKNOWN`() throws {
     // `(1, NULL) = (1, 2)` → `1 = 1 AND NULL = 2` → TRUE AND UNKNOWN → UNKNOWN,
-    // so the row is DROPPED, not admitted. Row 4 is (A = 1, B = NULL).
+    // so the row is dropped, not admitted. Row 4 is (A = 1, B = NULL).
     try pairs().empty("SELECT Id FROM T WHERE (A, B) = (1, 2) AND Id = 4")
   }
 
   @Test func `a definite component mismatch dominates a NULL component`()
       throws {
     // `(1, NULL) = (2, 2)` → `1 = 2 AND NULL = 2` → FALSE AND UNKNOWN → FALSE,
-    // a DEFINITE non-match: the row is dropped by `=` (and would be ADMITTED by
+    // a definite non-match: the row is dropped by `=` (and would be admitted by
     // `<>`, since NOT FALSE is TRUE). Row 4 is (1, NULL).
     try pairs().empty("SELECT Id FROM T WHERE (A, B) = (2, 2) AND Id = 4")
     try pairs().expect("SELECT Id FROM T WHERE (A, B) <> (2, 2) AND Id = 4",
@@ -373,7 +373,7 @@ private final class Counter: @unchecked Sendable {
   /// The number of times `next()` has been called.
   private(set) var count = 0
 
-  /// Increments the count and returns the PREVIOUS value — the sequence `0, 1,
+  /// Increments the count and returns the previous value — the sequence `0, 1,
   /// 2, …` across successive calls.
   func next() -> Int {
     defer { count += 1 }
@@ -382,11 +382,11 @@ private final class Counter: @unchecked Sendable {
 }
 
 /// The load-bearing regression for the first-class redesign: a row-value
-/// component holding a STATEFUL call must be evaluated EXACTLY ONCE per row.
+/// component holding a stateful call must be evaluated exactly once per row.
 /// The old parse-time desugar named a component in several places — a `<`
 /// cascade uses an earlier component in both a strict step and an equality
 /// tie-guard, and a row `IN` copies the left row into each element's equality
-/// — so `stepper()` ran twice and the two calls saw DIFFERENT values (0, 1),
+/// — so `stepper()` ran twice and the two calls saw different values (0, 1),
 /// admitting or dropping the wrong rows. The first-class nodes evaluate each
 /// component once into a value the fold reuses, so the counter reads exactly 1
 /// and the truth is computed over the single value (0).
@@ -411,11 +411,11 @@ struct RowValueOnceTests {
   }
 
   @Test func `a row IN evaluates a stateful component once`() throws {
-    // Left row is `(stepper(), 0)` = `(0, 0)`. It matches NEITHER `(99, 0)` nor
+    // Left row is `(stepper(), 0)` = `(0, 0)`. It matches neither `(99, 0)` nor
     // `(1, 0)`, so no row is admitted — but ONLY if `stepper()` yields 0 in the
     // one evaluation the fold reads. The old desugar copied `stepper()` into
     // each element's equality: the first read 0 (no match against 99), the
-    // SECOND read 1, wrongly matching `(1, 0)` and admitting the row. The
+    // second read 1, wrongly matching `(1, 0)` and admitting the row. The
     // first-class node reads it once, so no row is admitted and the counter is
     // exactly 1.
     let counter = Counter()
@@ -429,7 +429,7 @@ struct RowValueOnceTests {
     // 0 < 1)` = FALSE OR (TRUE AND TRUE) = TRUE, so the row is admitted. The
     // old cascade named the first component twice (the strict `stepper() < 0`
     // and the `stepper() = 0` tie-guard): the first read 0, the second read 1,
-    // so the guard `1 = 0` was FALSE and the row was wrongly DROPPED. The
+    // so the guard `1 = 0` was FALSE and the row was wrongly dropped. The
     // first-class node reads it once, admitting the row, counter exactly 1.
     let counter = Counter()
     try one().expect("SELECT Id FROM T WHERE (stepper(), 0) < (0, 1)",
@@ -493,12 +493,12 @@ struct RowValueOnceTests {
 // MARK: - Reachability
 
 /// The type-check reachability of a row comparison and a row `IN` must match
-/// the executor's SHORT-CIRCUIT exactly as the scalar `.comparison`/
+/// the executor's short-circuit exactly as the scalar `.comparison`/
 /// `.membership` do — a constant-false row guard folds an `AND` (leaving its
 /// right arm unreachable and unvalidated), and a definite constant match in a
-/// row `IN`'s element list prunes every later element. Folding TOO MUCH would
-/// accept an invalid query, so only a ROW-INDEPENDENT (all-constant) guard that
-/// DEFINITELY settles a branch prunes it; a row-dependent guard stays reachable
+/// row `IN`'s element list prunes every later element. Folding too much would
+/// accept an invalid query, so only a ROW-independent (all-constant) guard that
+/// definitely settles a branch prunes it; a row-dependent guard stays reachable
 /// and is still validated. A text column `Name` makes `Name + 1` a REAL type
 /// fault (`operands must be numeric`) wherever it is reached.
 struct RowValueReachabilityTests {
@@ -519,7 +519,7 @@ struct RowValueReachabilityTests {
   @Test func `a constant match in a row IN prunes a later bad element`()
       throws {
     // `(1, 2) IN ((1, 2), (Name + 1, 3))`: the constant left `(1, 2)`
-    // DEFINITELY matches the first element, so `Filter.memberships`
+    // definitely matches the first element, so `Filter.memberships`
     // short-circuits and the second element's `Name + 1` (text arithmetic) is
     // unreachable — the type check must not validate it, and the run keeps
     // every row.
@@ -533,7 +533,7 @@ struct RowValueReachabilityTests {
 
   @Test func `a constant-false row guard makes the AND right arm unreachable`()
       throws {
-    // `(1, 2) = (3, 4) AND Name + 1 = 0`: the left conjunct folds DEFINITELY
+    // `(1, 2) = (3, 4) AND Name + 1 = 0`: the left conjunct folds definitely
     // FALSE (a row `=` over constants), so the executor's `AND` short-circuits
     // and `Name + 1` is unreachable — the type check must not validate it, and
     // the run yields no rows.
@@ -546,7 +546,7 @@ struct RowValueReachabilityTests {
   @Test func `a constant-false row inequality guard prunes the AND right arm`()
       throws {
     // `(1, 2) <> (1, 2) AND Name + 1 = 0`: a row `<>` over equal constants
-    // folds DEFINITELY FALSE (the negation of the all-TRUE `=`), so the `AND`
+    // folds definitely FALSE (the negation of the all-TRUE `=`), so the `AND`
     // short-circuits and `Name + 1` is unreachable and unvalidated.
     let query = try parse(query:
         "SELECT Id FROM T WHERE (1, 2) <> (1, 2) AND Name + 1 = 0")
@@ -557,7 +557,7 @@ struct RowValueReachabilityTests {
 
   @Test func `a constant-true row guard makes the OR right arm unreachable`()
       throws {
-    // `(1, 2) = (1, 2) OR Name + 1 = 0`: the left disjunct folds DEFINITELY
+    // `(1, 2) = (1, 2) OR Name + 1 = 0`: the left disjunct folds definitely
     // TRUE, so the executor's `OR` short-circuits and `Name + 1` is
     // unreachable — the type check must not validate it (mirroring the scalar
     // `1 = 1 OR …`), and the run keeps every row.
@@ -572,9 +572,9 @@ struct RowValueReachabilityTests {
   // MARK: Reachable — must still fault
 
   @Test func `no constant match in a row IN leaves a bad element reachable`() {
-    // `(1, 2) IN ((3, 4), (Name + 1, 5))`: no element DEFINITELY matches the
+    // `(1, 2) IN ((3, 4), (Name + 1, 5))`: no element definitely matches the
     // constant left, so the second element stays reachable — the pruning is
-    // PRECISE — and its `Name + 1` must still fault the type check, exactly as
+    // precise — and its `Name + 1` must still fault the type check, exactly as
     // the run would when it evaluates the second row equality.
     let query = try! parse(query:
         "SELECT Id FROM T WHERE (1, 2) IN ((3, 4), (Name + 1, 5))")
@@ -587,7 +587,7 @@ struct RowValueReachabilityTests {
   }
 
   @Test func `a constant-true row guard leaves the AND right arm reachable`() {
-    // `(1, 2) = (1, 2) AND Name + 1 = 0`: the left conjunct folds DEFINITELY
+    // `(1, 2) = (1, 2) AND Name + 1 = 0`: the left conjunct folds definitely
     // TRUE, so the `AND` does NOT short-circuit and `Name + 1` is reachable —
     // it must still fault the type check, matching the run.
     let query = try! parse(query:

--- a/Tests/SQLTests/Expressions/ScalarFunctionTests.swift
+++ b/Tests/SQLTests/Expressions/ScalarFunctionTests.swift
@@ -165,13 +165,13 @@ private final class Talker: @unchecked Sendable {
 
   @Test func `OVERLAY evaluates its replacement once without FOR`() throws {
     // With `FOR` omitted the default length is the replacement's own character
-    // count — computed by the routine from the SINGLE evaluated replacement, so
-    // the replacement is evaluated EXACTLY ONCE. `talker()` is
+    // count — computed by the routine from the single evaluated replacement, so
+    // the replacement is evaluated exactly once. `talker()` is
     // non-deterministic (unfoldable) and returns a longer string on each call;
     // evaluated once it inserts "XX" (2 long) and removes 2 characters of
     // 'abcdef' from position 2 ('bc') → "aXXdef", the counter reading 1. The
     // old desugar to `char_length(replacement)` referenced the replacement a
-    // SECOND time — inserting one value but removing the length of a DIFFERENT
+    // second time — inserting one value but removing the length of a different
     // later one — so this guards that regression.
     let counter = Talker()
     let routines = try Routines.standard
@@ -258,7 +258,7 @@ private func lower(_ text: String) throws -> Expression {
   }
 
   @Test func `OVERLAY without FOR desugars to a three-argument call`() throws {
-    // No FOR ⇒ a THREE-argument call (no synthesized `char_length(replacement)`
+    // No FOR ⇒ a three-argument call (no synthesized `char_length(replacement)`
     // fourth argument): the routine defaults the length from the once-evaluated
     // replacement, so the replacement is not referenced a second time.
     #expect(try lower("OVERLAY(Text PLACING 'ab' FROM 1)")

--- a/Tests/SQLTests/Expressions/TruthTestTests.swift
+++ b/Tests/SQLTests/Expressions/TruthTestTests.swift
@@ -75,7 +75,7 @@ struct TruthTestParsingTests {
   }
 
   @Test func `IS NULL still parses to a null node, not a truth node`() throws {
-    // The truth-value dispatch is ADDITIVE: an `IS NULL` tail is untouched, so
+    // The truth-value dispatch is additive: an `IS NULL` tail is untouched, so
     // it lowers to the existing `null` predicate rather than a `truth`.
     let select = try parse(select: "SELECT * FROM T WHERE Flag IS NULL")
     #expect(select.predicate == .null(.column("Flag"), negated: false))
@@ -117,14 +117,14 @@ struct TruthColumnEvaluationTests {
   }
 
   @Test func `IS UNKNOWN keeps only the NULL row`() throws {
-    // The UNKNOWN Flag (Id 3) is TESTED for — a definite TRUE — while the
+    // The UNKNOWN Flag (Id 3) is tested for — a definite TRUE — while the
     // definite TRUE/FALSE rows are FALSE against `IS UNKNOWN`.
     try flags().expect("SELECT Id FROM T WHERE Flag IS UNKNOWN", yields: [[3]])
   }
 
   @Test func `IS NOT TRUE keeps the FALSE and UNKNOWN rows`() throws {
     // `IS NOT TRUE` is the negation: the FALSE row (Id 2) and the UNKNOWN row
-    // (Id 3) both pass — an UNKNOWN operand is NOT TRUE, so the row is KEPT
+    // (Id 3) both pass — an UNKNOWN operand is NOT TRUE, so the row is kept
     // (the key divergence from a bare `Flag`, which drops the UNKNOWN row).
     try flags().expect("SELECT Id FROM T WHERE Flag IS NOT TRUE",
                        yields: [[2], [3]])
@@ -182,7 +182,7 @@ struct TruthComparisonEvaluationTests {
 
   @Test func `an UNKNOWN comparison IS UNKNOWN tests for that UNKNOWN`()
       throws {
-    // `A > N` is UNKNOWN for EVERY row (the NULL `N` is unordered), so `(A > N)
+    // `A > N` is UNKNOWN for every row (the NULL `N` is unordered), so `(A > N)
     // IS UNKNOWN` is a definite TRUE for every row — keeping them all — and
     // `IS TRUE` drops them all. The truth test collapses the UNKNOWN comparison
     // to a definite two-valued answer, never itself UNKNOWN.
@@ -208,7 +208,7 @@ struct TruthComparisonEvaluationTests {
 struct TruthDefiniteTests {
   @Test func `the test is definite where NOT of the operand is UNKNOWN`()
       throws {
-    // The whole point: a boolean test yields a DEFINITE two-valued result. Over
+    // The whole point: a boolean test yields a definite two-valued result. Over
     // the UNKNOWN Flag row (Id 3), `NOT (Flag = TRUE)` is UNKNOWN (dropped),
     // but `Flag IS NOT TRUE` is a definite TRUE (kept). If the test could be
     // UNKNOWN the two would agree; they diverge exactly because it cannot.
@@ -242,11 +242,11 @@ struct TruthConstantTests {
 
   @Test func `a constant-UNKNOWN IS TRUE folds FALSE and short-circuits`()
       throws {
-    // `CASE WHEN 1 = 0 THEN TRUE END` is a ROW-INDEPENDENT UNKNOWN (no
-    // reachable branch → NULL). `… IS TRUE` folds DEFINITELY FALSE, settling
-    // the `AND` false WITHOUT validating the unreachable `Name + 1 = 0` (a
+    // `CASE WHEN 1 = 0 THEN TRUE END` is a ROW-independent UNKNOWN (no
+    // reachable branch → NULL). `… IS TRUE` folds definitely FALSE, settling
+    // the `AND` false without validating the unreachable `Name + 1 = 0` (a
     // `.operand` fault over the text `Name`, if reached) — so `columns(of:)`
-    // SUCCEEDS and the run drops every row. Before the fold distinguished a
+    // succeeds and the run drops every row. Before the fold distinguished a
     // constant UNKNOWN from a per-row `nil`, the whole `AND` read
     // row-dependent, the RHS was validated, and it faulted.
     let text = "SELECT Id FROM T "
@@ -256,7 +256,7 @@ struct TruthConstantTests {
   }
 
   @Test func `a constant-UNKNOWN IS UNKNOWN folds TRUE`() throws {
-    // The same constant-UNKNOWN operand: `… IS UNKNOWN` is DEFINITELY TRUE, so
+    // The same constant-UNKNOWN operand: `… IS UNKNOWN` is definitely TRUE, so
     // the WHERE keeps every row — the fold decides it rather than deferring.
     try named().expect(
         "SELECT Id FROM T WHERE CASE WHEN 1 = 0 THEN TRUE END IS UNKNOWN",
@@ -265,11 +265,11 @@ struct TruthConstantTests {
 
   @Test func `a two-valued inner IS UNKNOWN folds FALSE though row-dependent`()
       throws {
-    // `Name IS NULL` READS a row yet is DEFINITE — an `IS NULL` test is never
-    // itself UNKNOWN — so `… IS UNKNOWN` folds DEFINITELY FALSE regardless of
-    // the rows (not just when the inner is row-INDEPENDENT), settling the `AND`
-    // false WITHOUT validating the unreachable `Name + 1 = 0`. `columns(of:)`
-    // SUCCEEDS and the run drops every row.
+    // `Name IS NULL` reads a row yet is definite — an `IS NULL` test is never
+    // itself UNKNOWN — so `… IS UNKNOWN` folds definitely FALSE regardless of
+    // the rows (not just when the inner is row-independent), settling the `AND`
+    // false without validating the unreachable `Name + 1 = 0`. `columns(of:)`
+    // succeeds and the run drops every row.
     let text = "SELECT Id FROM T "
         + "WHERE (Name IS NULL) IS UNKNOWN AND Name + 1 = 0"
     _ = try named().columns(of: parse(query: text))
@@ -278,7 +278,7 @@ struct TruthConstantTests {
 
   @Test func `a two-valued inner IS NOT UNKNOWN folds TRUE though row-dependent`()
       throws {
-    // `(Name IS NULL) IS NOT UNKNOWN` is DEFINITELY TRUE — the two-valued inner
+    // `(Name IS NULL) IS NOT UNKNOWN` is definitely TRUE — the two-valued inner
     // never takes the UNKNOWN value — so the WHERE keeps every row.
     try named().expect(
         "SELECT Id FROM T WHERE (Name IS NULL) IS NOT UNKNOWN",

--- a/Tests/SQLTests/Optimisation/ConstantFoldTests.swift
+++ b/Tests/SQLTests/Optimisation/ConstantFoldTests.swift
@@ -20,7 +20,7 @@ private func numbers() throws -> FixtureCatalog {
 }
 
 /// A single-row catalog whose `X` is zero — `1 / X` throws `SQLError.divide`
-/// when evaluated, so it is the probe for whether a fold SKIPS a throwing
+/// when evaluated, so it is the probe for whether a fold skips a throwing
 /// operand it must not drop.
 private func zero() throws -> FixtureCatalog {
   try Catalog {
@@ -31,7 +31,7 @@ private func zero() throws -> FixtureCatalog {
 }
 
 /// A parent `T` and child `S` keyed on `T.Id` — the LATERAL fixture whose right
-/// side VARIES per outer row, so the fold's result-equivalence is a real proof.
+/// side varies per outer row, so the fold's result-equivalence is a real proof.
 private func lateral() throws -> FixtureCatalog {
   try Catalog {
     Relation("T", ["Id": .integer]) {
@@ -84,7 +84,7 @@ private func selects(_ plan: Plan) -> Bool {
 }
 
 /// Whether `plan` reaches ANY `.empty` node — the known-empty relation the
-/// optimiser folds a PROVABLY constant-false selection into. Mirrors `selects`,
+/// optimiser folds a provably constant-false selection into. Mirrors `selects`,
 /// recursing every operator so a fold nested under a project/aggregate/set-op
 /// is still found.
 private func empties(_ plan: Plan) -> Bool {
@@ -124,9 +124,9 @@ private func empties(_ plan: Plan) -> Bool {
 
 // MARK: - Filter.constant unit tests
 
-/// `Filter.constant` is the SOUND, CONSERVATIVE constant-truth evaluator the
-/// optimiser folds on: `true` only when PROVABLY always TRUE, `false` only when
-/// PROVABLY always FALSE, and `nil` (do NOT fold) for anything that reads a
+/// `Filter.constant` is the sound, conservative constant-truth evaluator the
+/// optimiser folds on: `true` only when provably always TRUE, `false` only when
+/// provably always FALSE, and `nil` (do NOT fold) for anything that reads a
 /// slot, a `:parameter`, a subquery, or a NULL constant.
 struct FilterConstantTests {
   @Test func `a constant-true compare is provably true`() {
@@ -162,7 +162,7 @@ struct FilterConstantTests {
     let slot = Filter.compare(.slot(0), .equal, .constant(.integer(1)))
     #expect(Filter.and(t, t).constant == true)
     #expect(Filter.and(t, f).constant == false)
-    // An undecidable operand can read row data and THROW, so it must be
+    // An undecidable operand can read row data and throw, so it must be
     // evaluated at runtime — a `false`/`true` sibling cannot license folding
     // the compound away. Either side undecidable ⇒ the compound is undecidable.
     #expect(Filter.and(f, slot).constant == nil)
@@ -196,8 +196,8 @@ struct FilterConstantTests {
 
 // MARK: - Optimiser fold: WHERE result equivalence + plan shape
 
-/// The optimiser drops a PROVABLY-true `WHERE` (identical result, one fewer
-/// per-row predicate) and NEVER folds a false or NULL-bearing one.
+/// The optimiser drops a provably-true `WHERE` (identical result, one fewer
+/// per-row predicate) and never folds a false or NULL-bearing one.
 struct ConstantSelectFoldTests {
   @Test func `WHERE 1 = 1 yields the same rows as no WHERE`() throws {
     // A constant-true filter admits every row: the folded query yields exactly
@@ -207,7 +207,7 @@ struct ConstantSelectFoldTests {
   }
 
   @Test func `WHERE 1 = 1 optimises away the select node`() throws {
-    // Plan-shape proof: the always-true select is GONE after optimisation — the
+    // Plan-shape proof: the always-true select is gone after optimisation — the
     // fold left a plain scan, not a select over a true residual.
     let catalog = try numbers()
     let plan = try catalog.optimise(
@@ -241,7 +241,7 @@ struct ConstantSelectFoldTests {
   }
 
   @Test func `a constant-false selection preserves the output width`() throws {
-    // Schema preservation: the empty relation must advertise the SAME columns
+    // Schema preservation: the empty relation must advertise the same columns
     // as the subtree it replaced, so a two-column projection still yields
     // two-wide (zero) rows — a downstream consumer mis-shapes nothing.
     try numbers().empty("SELECT Id, V FROM N WHERE 1 = 0")
@@ -258,7 +258,7 @@ struct ConstantSelectFoldTests {
 
   @Test func `COUNT(*) over a constant-false source still yields one row`()
       throws {
-    // The bare aggregate sits ABOVE the folded select, so its source is the
+    // The bare aggregate sits above the folded select, so its source is the
     // `.empty` relation — and `grouped` over an empty input with no GROUP BY
     // still emits its degenerate one row (`COUNT` `0`), the standard SQL rule.
     // The fold must NOT collapse the aggregate itself to zero rows.
@@ -267,7 +267,7 @@ struct ConstantSelectFoldTests {
 
   @Test func `COUNT(*) over a constant-false source folds only the source`()
       throws {
-    // Plan-shape proof of the above: the `.empty` is the aggregate's SOURCE,
+    // Plan-shape proof of the above: the `.empty` is the aggregate's source,
     // the aggregate node survives above it.
     let catalog = try numbers()
     let plan = try catalog.optimise(
@@ -279,9 +279,9 @@ struct ConstantSelectFoldTests {
   @Test func `a constant-false selection over a THROWING view does not fold`()
       throws {
     // The soundness fence. `Bad`'s body evaluates `1 / X` with `X = 0`, so
-    // executing it RAISES `.divide`. Its `.derived` plan node is NOT provably
+    // executing it raises `.divide`. Its `.derived` plan node is NOT provably
     // throw-free (`Plan.safe` is `false`), so the constant-false select is NOT
-    // folded to `.empty` — folding would SKIP the view body and SUPPRESS the
+    // folded to `.empty` — folding would skip the view body and suppress the
     // throw. The plan keeps its select over the view, and running it surfaces
     // the division-by-zero exactly as the un-folded query would.
     let base = try Catalog {
@@ -318,7 +318,7 @@ struct ConstantSelectFoldTests {
 
   @Test func `an always-true OR does not drop a throwing operand`() throws {
     // The reviewer case: `(1 / X) = 0` reads a row slot and, with `X = 0`,
-    // THROWS `SQLError.divide` when evaluated. The `OR 1 = 1` disjunct is
+    // throws `SQLError.divide` when evaluated. The `OR 1 = 1` disjunct is
     // constant-true, but the compound OR is NOT a compile-time constant (the
     // left disjunct is undecidable), so the predicate is NOT folded away — it
     // runs per row and the division-by-zero surfaces. Folding it would silently
@@ -346,7 +346,7 @@ struct ConstantSelectFoldTests {
 /// plan/execution, never the rows.
 struct ConstantApplyFoldTests {
   @Test func `a LATERAL ON 1 = 1 yields the known-correct rows`() throws {
-    // The SAME rows the un-folded lateral fixture produces: Id 1 → {100, 101},
+    // The same rows the un-folded lateral fixture produces: Id 1 → {100, 101},
     // Id 2 → {200}, Id 3 → {} (dropped, INNER apply). The constant-true `ON`
     // skip admits every merged row directly — identical result.
     try lateral().expect(

--- a/Tests/SQLTests/Optimisation/DecorrelateTests.swift
+++ b/Tests/SQLTests/Optimisation/DecorrelateTests.swift
@@ -7,11 +7,11 @@ import Testing
 import SQLTestSupport
 
 /// Behaviour-preserving oracles for the CROSS APPLY → inner-join decorrelation
-/// pass. A decorrelation bug is a SILENT wrong-results bug, so every case
-/// compares the run result against the KNOWN-CORRECT multiset the correlated
+/// pass. A decorrelation bug is a silent wrong-results bug, so every case
+/// compares the run result against the known-correct multiset the correlated
 /// `applied` executor produces — same rows, same duplicates, same drops — and
-/// pins the plan shape: a decorrelatable CROSS APPLY becomes a `.join` with NO
-/// `.apply` node, and an EXCLUDED body stays an `.apply`, run correctly.
+/// pins the plan shape: a decorrelatable CROSS APPLY becomes a `.join` with no
+/// `.apply` node, and an excluded body stays an `.apply`, run correctly.
 
 
 /// Whether `plan` (or any descendant) carries a correlated `.apply` node — the
@@ -97,7 +97,7 @@ private func semijoins(_ plan: Plan) -> Bool {
 }
 
 /// Whether `plan` (or any descendant) carries a `.semijoin` node of the given
-/// `anti` sense — a SEMIJOIN (`anti == false`) or ANTI-join (`anti == true`).
+/// `anti` sense — a semijoin (`anti == false`) or anti-join (`anti == true`).
 private func semijoins(_ plan: Plan, anti wanted: Bool) -> Bool {
   switch plan {
   case let .semijoin(_, _, _, anti):
@@ -118,7 +118,7 @@ private func semijoins(_ plan: Plan, anti wanted: Bool) -> Bool {
 
 /// The number of `.semijoin` nodes `plan` (and its descendants) carries — the
 /// count of EXISTS conjuncts lifted into the stack. Two decorrelatable EXISTS
-/// of one WHERE lift into TWO stacked semijoins, so this returns 2.
+/// of one WHERE lift into two stacked semijoins, so this returns 2.
 private func semijoinCount(_ plan: Plan) -> Int {
   switch plan {
   case let .semijoin(left, right, _, _):
@@ -139,8 +139,8 @@ private func semijoinCount(_ plan: Plan) -> Int {
 
 /// The number of `.semijoin` nodes of the given `anti` sense `plan` (and its
 /// descendants) carries. Unlike `semijoins(_:anti:)`, which inspects only the
-/// FIRST semijoin it reaches, this descends THROUGH a semijoin's own left, so a
-/// stacked SEMI-over-ANTI reports one of each.
+/// FIRST semijoin it reaches, this descends through a semijoin's own left, so a
+/// stacked semi-over-anti reports one of each.
 private func semijoinCount(_ plan: Plan, anti wanted: Bool) -> Int {
   switch plan {
   case let .semijoin(left, right, _, anti):
@@ -233,7 +233,7 @@ private func membership(_ filter: Filter) -> Bool {
   }
 }
 
-/// Whether `plan` (or any descendant) carries a scalar `.subquery` TERM — the
+/// Whether `plan` (or any descendant) carries a scalar `.subquery` term — the
 /// witness a correlated (or uncorrelated) scalar subquery was NOT decorrelated
 /// into a LEFT join, the scalar analogue of `exists(in:)`/`within(in:)`. Scans
 /// the projection terms of each `.project` and the operand terms every
@@ -307,7 +307,7 @@ private func subquery(_ filter: Filter) -> Bool {
 
 extension Catalog where Self: ~Escapable {
   /// The optimised plan for `sql`, threading a shared subquery box through the
-  /// SAME compile → pushdown → decorrelate → optimise pipeline `run` uses, so a
+  /// same compile → pushdown → decorrelate → optimise pipeline `run` uses, so a
   /// plan-shape assertion sees the very plan the executor runs. The overlay is
   /// recorded and this query's derived tables are materialised exactly as `run`
   /// does, so a correlated body's plan is compiled into the box the decorrelate
@@ -324,7 +324,7 @@ extension Catalog where Self: ~Escapable {
   }
 }
 
-/// A parent `T` and a child `S` keyed on `T.Id` — Id 1 has TWO children, Id 2
+/// A parent `T` and a child `S` keyed on `T.Id` — Id 1 has two children, Id 2
 /// one, Id 3 none — the duplicate-match and no-match shapes a CROSS APPLY
 /// multiplies and drops.
 private func fixture() throws -> FixtureCatalog {
@@ -362,7 +362,7 @@ private func nullFixture() throws -> FixtureCatalog {
 
 struct DecorrelateCrossApplyTests {
   /// The canonical CROSS APPLY: a left row is multiplied by its match count and
-  /// an unmatched left row is dropped — the SAME multiset the correlated
+  /// an unmatched left row is dropped — the same multiset the correlated
   /// `applied` produces (Id 1 → {100, 101}, Id 2 → {200}, Id 3 → dropped).
   @Test func `a CROSS APPLY equi body yields the correlated multiset`() throws {
     try fixture().expect(
@@ -372,7 +372,7 @@ struct DecorrelateCrossApplyTests {
         yields: [[1, 100], [1, 101], [2, 200]])
   }
 
-  /// DUPLICATE MATCHES: Id 1 matches two inner rows and appears TWICE — the
+  /// duplicate matches: Id 1 matches two inner rows and appears twice — the
   /// join multiplies the left row by the match count, it is NOT deduped.
   @Test func `a left row matching many inner rows is multiplied not deduped`()
       throws {
@@ -380,11 +380,11 @@ struct DecorrelateCrossApplyTests {
         "SELECT T.Id FROM T " +
         "JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON 1 = 1 " +
         "ORDER BY T.Id"), .standard)
-    // Id 1 twice (two children), Id 2 once — NO dedup, NO Id 3.
+    // Id 1 twice (two children), Id 2 once — no dedup, no Id 3.
     #expect(rows == [[.integer(1)], [.integer(1)], [.integer(2)]])
   }
 
-  /// NO MATCH: Id 3 has no child, so the INNER join DROPS it — never NULL-
+  /// no match: Id 3 has no child, so the INNER join drops it — never NULL-
   /// extended, exactly as CROSS APPLY drops an unmatched left row.
   @Test func `a left row with no match is dropped`() throws {
     let rows = try fixture().run(parse(query:
@@ -428,7 +428,7 @@ struct DecorrelateCrossApplyTests {
         yields: [[1, 100], [1, 101]])
   }
 
-  /// PLAN SHAPE: the decorrelatable CROSS APPLY optimises to a `.join` with NO
+  /// plan shape: the decorrelatable CROSS APPLY optimises to a `.join` with no
   /// `.apply` node remaining — the pass fired.
   @Test func `a decorrelatable CROSS APPLY optimises to a join`() throws {
     let plan = try fixture().optimised(
@@ -438,7 +438,7 @@ struct DecorrelateCrossApplyTests {
     #expect(joins(plan))
   }
 
-  /// PLAN SHAPE: a residual `ON` and a local body predicate still decorrelate —
+  /// plan shape: a residual `ON` and a local body predicate still decorrelate —
   /// no `.apply` node survives.
   @Test func `a CROSS APPLY with ON and body predicate decorrelates`() throws {
     let plan = try fixture().optimised(
@@ -450,10 +450,10 @@ struct DecorrelateCrossApplyTests {
   }
 }
 
-// MARK: - Excluded bodies: STAY correlated, run correctly
+// MARK: - Excluded bodies: stay correlated, run correctly
 
 struct DecorrelateExclusionTests {
-  /// (a) AGGREGATE body: a `COUNT(*)` body is not a plain filter+project, so it
+  /// (a) aggregate body: a `COUNT(*)` body is not a plain filter+project, so it
   /// stays an `.apply` — and still runs correctly (Id 1 → 2, Id 2 → 1, Id 3 → 0
   /// dropped by the `ON d.n > 0`).
   @Test func `an aggregate body stays an apply and runs correctly`() throws {
@@ -466,7 +466,7 @@ struct DecorrelateExclusionTests {
     try fixture().expect(sql + " ORDER BY T.Id", yields: [[1, 2], [2, 1]])
   }
 
-  /// (b) NON-EQUI correlation: `S.k > T.Id` has no equi-key to hash on, so it
+  /// (b) non-equi correlation: `S.k > T.Id` has no equi-key to hash on, so it
   /// stays an `.apply` — and runs correctly (Id 1 matches k∈{2}? no; the child
   /// keys are 1,1,2, so `S.k > T.Id` for Id 1 → k=2 → x=200; Id 2 → none).
   @Test func `a non-equi correlation stays an apply and runs correctly`()
@@ -480,11 +480,11 @@ struct DecorrelateExclusionTests {
     try fixture().expect(sql + " ORDER BY T.Id, d.x", yields: [[1, 200]])
   }
 
-  /// (c) THROWING body term (G4): a body WHERE conjunct `1 / (S.x - 100) > 0`
+  /// (c) throwing body term (G4): a body WHERE conjunct `1 / (S.x - 100) > 0`
   /// divides by zero on the inner row `(1, 100)`. Under the per-row correlated
   /// run the divide fires only for a left row that reaches that inner row; a
   /// set-based join over the whole `S` would evaluate it for every inner row.
-  /// The recogniser LEAVES it correlated (the conjunct is unsafe), and the run
+  /// The recogniser leaves it correlated (the conjunct is unsafe), and the run
   /// still raises `.divide` exactly as the correlated path does.
   @Test func `a throwing body term stays an apply and still throws`() throws {
     let sql =
@@ -499,12 +499,12 @@ struct DecorrelateExclusionTests {
   }
 }
 
-// MARK: - Body-local derived aliases: STAY correlated (item 1)
+// MARK: - Body-local derived aliases: stay correlated (item 1)
 
 struct DecorrelateBodyDerivedTests {
-  /// A parent `T` and a child `S`, PLUS a BASE table also named `e` carrying
+  /// A parent `T` and a child `S`, plus a base table also named `e` carrying
   /// unrelated rows — so a rewrite that wrongly relaid a caller-level
-  /// `scan("e")` would bind THIS base `e` and return its rows rather than the
+  /// `scan("e")` would bind this base `e` and return its rows rather than the
   /// body's own derived `e`.
   private func shadowFixture() throws -> FixtureCatalog {
     try Catalog {
@@ -518,7 +518,7 @@ struct DecorrelateBodyDerivedTests {
         Row(1, 101)
         Row(2, 200)
       }
-      // A BASE relation named `e` whose rows must NEVER surface — the body's
+      // A base relation named `e` whose rows must never surface — the body's
       // own derived `e` shadows it. A decorrelation that relaid `scan("e")` at
       // the caller would bind these instead.
       Relation("e", ["k": .integer, "x": .integer]) {
@@ -528,7 +528,7 @@ struct DecorrelateBodyDerivedTests {
     }
   }
 
-  /// A lateral body reading its OWN derived table `e` must NOT decorrelate: the
+  /// A lateral body reading its own derived table `e` must NOT decorrelate: the
   /// compiled body plan scans the body-local alias `e`, which the correlated
   /// `applied` materialises per execution. Relaid as a caller-level `scan("e")`
   /// the rewrite would fault or bind an outer relation. The recogniser leaves
@@ -542,7 +542,7 @@ struct DecorrelateBodyDerivedTests {
   }
 
   /// The same body run: the derived `e` reads `S` (100, 101, 200), NOT the
-  /// BASE `e` (900, 901). Id 1 → {100, 101}, Id 2 → {200}, Id 3 → dropped —
+  /// base `e` (900, 901). Id 1 → {100, 101}, Id 2 → {200}, Id 3 → dropped —
   /// identical to the correlated multiset.
   @Test func `a body-local derived alias runs correctly`() throws {
     try shadowFixture().expect(
@@ -558,7 +558,7 @@ struct DecorrelateBodyDerivedTests {
 struct DecorrelateOnOrderTests {
   /// A parent `T` and a child `S` whose `flag` is NULL for one child. The body
   /// `WHERE S.k = T.Id AND S.flag = 1` drops the NULL-flag row (UNKNOWN
-  /// rejects) BEFORE any `ON` is evaluated, so an unsafe `ON` over that dropped
+  /// rejects) before any `ON` is evaluated, so an unsafe `ON` over that dropped
   /// row must never fire.
   private func flagFixture() throws -> FixtureCatalog {
     try Catalog {
@@ -573,9 +573,9 @@ struct DecorrelateOnOrderTests {
     }
   }
 
-  /// THROW ORDER: the body WHERE drops the NULL-flag child (x = 0) before the
+  /// throw ORDER: the body WHERE drops the NULL-flag child (x = 0) before the
   /// unsafe `ON (1 / d.x) = 0` is ever reached, so the correlated APPLY does
-  /// NOT throw. The decorrelated plan keeps the `ON` in a SEPARATE select ABOVE
+  /// NOT throw. The decorrelated plan keeps the `ON` in a separate select above
   /// the body-filtered join, so `ON` sees only survivors — Id 2's child x = 200
   /// — and likewise does NOT divide by the dropped x = 0 row. The result is Id
   /// 2's child (integer `1 / 200 = 0`, so the ON admits it), NOT a `.divide`.
@@ -583,7 +583,7 @@ struct DecorrelateOnOrderTests {
       throws {
     // The NULL-flag child (x = 0) is dropped by the body WHERE, so the unsafe
     // ON never divides by it. Id 2's surviving child x = 200 is admitted by the
-    // ON (`1 / 200 = 0`), so the result is [[2, 200]] — and, crucially, NO
+    // ON (`1 / 200 = 0`), so the result is [[2, 200]] — and, crucially, no
     // throw, matching the correlated APPLY.
     try flagFixture().expect(
         "SELECT T.Id, d.x FROM T " +
@@ -592,7 +592,7 @@ struct DecorrelateOnOrderTests {
         yields: [[2, 200]])
   }
 
-  /// The ON still applies to a SURVIVING row: with a safe `ON d.x > 100` the
+  /// The ON still applies to a surviving row: with a safe `ON d.x > 100` the
   /// body WHERE keeps Id 2's child (x = 200, flag 1), and the ON admits it —
   /// proving the split select did not drop the ON, only reorder it.
   @Test func `the ON still filters a surviving row after the split`() throws {
@@ -603,7 +603,7 @@ struct DecorrelateOnOrderTests {
         yields: [[2, 200]])
   }
 
-  /// The ON legitimately DROPS a surviving row: with `ON d.x > 500` Id 2's
+  /// The ON legitimately drops a surviving row: with `ON d.x > 500` Id 2's
   /// surviving child (x = 200) fails the ON, so the result is empty — the ON
   /// filters survivors exactly as the correlated per-pair ON does.
   @Test func `the ON drops a surviving row it rejects`() throws {
@@ -617,14 +617,14 @@ struct DecorrelateOnOrderTests {
 // MARK: - Adversarial throw-visibility (G4)
 
 struct DecorrelateThrowVisibilityTests {
-  /// ADVERSARIAL (soundness): a CROSS APPLY whose body WHERE divides by zero
-  /// for an inner row NO surviving left row pairs with. The child `(1, 100)`
+  /// adversarial (soundness): a CROSS APPLY whose body WHERE divides by zero
+  /// for an inner row no surviving left row pairs with. The child `(1, 100)`
   /// makes
-  /// `1 / (S.x - 100)` divide by zero, but NO left row has `Id = 1` — so the
+  /// `1 / (S.x - 100)` divide by zero, but no left row has `Id = 1` — so the
   /// per-row correlated run never binds `:outer = 1` and never reaches that
-  /// inner row, yielding NO rows and NO throw. A naive decorrelation to a join
-  /// over the whole `S` WOULD evaluate the divide on `(1, 100)` and throw
-  /// spuriously. The recogniser must LEAVE it correlated (the conjunct is
+  /// inner row, yielding no rows and no throw. A naive decorrelation to a join
+  /// over the whole `S` would evaluate the divide on `(1, 100)` and throw
+  /// spuriously. The recogniser must leave it correlated (the conjunct is
   /// unsafe), so the result stays empty with no throw — identical to the base
   /// correlated behaviour.
   @Test func `an unreachable throwing inner row is not decorrelated`() throws {
@@ -689,7 +689,7 @@ struct DecorrelateOuterJoinWidthTests {
 
   /// RIGHT JOIN forcing left NULL-extension. The lateral yields the `T ++ d`
   /// rows ([1, 100], [1, 101], [2, 200]), but `RIGHT JOIN U ON 1 = 0` matches
-  /// none of them, so every `U` row survives with the WHOLE `T ++ d` left width
+  /// none of them, so every `U` row survives with the whole `T ++ d` left width
   /// NULL. `Plan.slots` must report the project's width (2) so `U.u` lands at
   /// ordinal 2 and `T.Id`/`d.x` are NULL — not shifted into the U slot or
   /// trapped.
@@ -715,7 +715,7 @@ struct DecorrelateOuterJoinWidthTests {
         yields: [[nil, nil, 700], [nil, nil, 701]])
   }
 
-  /// FULL JOIN forcing BOTH sides' unmatched rows through. `ON 1 = 0` matches
+  /// FULL JOIN forcing both sides' unmatched rows through. `ON 1 = 0` matches
   /// nothing, so the FULL join emits every lateral `T ++ d` row right-NULL then
   /// every `U` row left-NULL — the left-NULL rows again needing the full T ++ d
   /// width so `U.u` lands at ordinal 2. Reads T.Id/d.x/U.u to pin the ordinals.
@@ -742,13 +742,13 @@ struct DecorrelateOuterJoinWidthTests {
 
 /// Behaviour-preserving oracles for the OUTER APPLY (`LEFT JOIN LATERAL`) →
 /// LEFT `.outer` join decorrelation. An OUTER APPLY NULL-extends an unmatched
-/// left row (ONCE) and multiplies a matched one by its match count — the SAME
+/// left row (once) and multiplies a matched one by its match count — the same
 /// multiset the correlated `applied` (`.left`) executor produces. Each case
 /// compares the run against that known-correct multiset and pins the plan
-/// shape: a decorrelatable OUTER APPLY becomes an `.outer` with NO `.apply`
+/// shape: a decorrelatable OUTER APPLY becomes an `.outer` with no `.apply`
 /// node.
 struct DecorrelateOuterApplyTests {
-  /// NULL-EXTENSION: Id 3 has no child, so the OUTER apply PRESERVES it
+  /// NULL-extension: Id 3 has no child, so the OUTER apply preserves it
   /// NULL-extended — Id 1 → {100, 101}, Id 2 → {200}, Id 3 → (3, NULL) — the
   /// exact multiset the correlated `.left` `applied` yields, unlike the CROSS
   /// APPLY that would drop Id 3.
@@ -760,7 +760,7 @@ struct DecorrelateOuterApplyTests {
         yields: [[1, 100], [1, 101], [2, 200], [3, nil]])
   }
 
-  /// MULTIPLICITY: Id 1 matches two inner rows and appears TWICE (matched, NOT
+  /// multiplicity: Id 1 matches two inner rows and appears twice (matched, NOT
   /// NULL-extended); it is not deduped — the LEFT join multiplies a matched
   /// left row by its match count exactly as the per-row run does.
   @Test func `a matched OUTER APPLY left row is multiplied not deduped`()
@@ -775,7 +775,7 @@ struct DecorrelateOuterApplyTests {
                      [.integer(3)]])
   }
 
-  /// NULL CORRELATION KEY: a NULL outer `Id` matches nothing (NULL ≠ NULL), so
+  /// NULL correlation KEY: a NULL outer `Id` matches nothing (NULL ≠ NULL), so
   /// the OUTER apply NULL-extends it — Id 1 → 100, the NULL-Id row → NULL. The
   /// inner NULL-keyed `(NULL, 999)` never pairs. Identical to the per-row
   /// `WHERE S.k = :outer` NULL-drop then NULL-extension.
@@ -799,8 +799,8 @@ struct DecorrelateOuterApplyTests {
         yields: [[1, 101], [2, 200], [3, nil]])
   }
 
-  /// The apply `ON` rejects EVERY pair: `ON d.x > 1000` matches no child, so
-  /// EACH left row — even Ids 1 and 2 with children — is NULL-extended, just as
+  /// The apply `ON` rejects every pair: `ON d.x > 1000` matches no child, so
+  /// each left row — even Ids 1 and 2 with children — is NULL-extended, just as
   /// Id 3 is. The correlated OUTER apply preserves every left row; the
   /// decorrelated LEFT join must too.
   @Test func `an ON rejecting every pair NULL-extends every left row`()
@@ -823,8 +823,8 @@ struct DecorrelateOuterApplyTests {
         yields: [[1, 100], [1, 101], [2, nil], [3, nil]])
   }
 
-  /// PLAN SHAPE: the decorrelatable OUTER APPLY optimises to an `.outer` join
-  /// with NO surviving `.apply` node — the pass fired.
+  /// plan shape: the decorrelatable OUTER APPLY optimises to an `.outer` join
+  /// with no surviving `.apply` node — the pass fired.
   @Test func `a decorrelatable OUTER APPLY optimises to an outer join`()
       throws {
     let plan = try fixture().optimised(
@@ -834,7 +834,7 @@ struct DecorrelateOuterApplyTests {
     #expect(outers(plan))
   }
 
-  /// PLAN SHAPE: a safe residual `ON` and a local body predicate still
+  /// plan shape: a safe residual `ON` and a local body predicate still
   /// decorrelate — no `.apply` node survives, an `.outer` node appears.
   @Test func `an OUTER APPLY with safe ON and body predicate decorrelates`()
       throws {
@@ -847,24 +847,24 @@ struct DecorrelateOuterApplyTests {
   }
 }
 
-// MARK: - OUTER APPLY excluded bodies: STAY correlated, run correctly
+// MARK: - OUTER APPLY excluded bodies: stay correlated, run correctly
 
 /// The `.left`-specific exclusions plus the shared G3 ones. The load-bearing
-/// one is the UNSAFE apply `ON`: a LEFT join cannot split its `on`, so folding
+/// one is the unsafe apply `ON`: a LEFT join cannot split its `on`, so folding
 /// an unsafe `on` beside a nullable body residual would throw for a pair the
-/// correlated body WHERE dropped — so an unsafe `on` LEAVES the apply
+/// correlated body WHERE dropped — so an unsafe `on` leaves the apply
 /// correlated (the safe-gate), running identically to the base.
 struct DecorrelateOuterApplyExclusionTests {
-  /// UNSAFE APPLY `ON` (the safe-gate, `.left`-specific): a body residual
+  /// unsafe APPLY `ON` (the safe-gate, `.left`-specific): a body residual
   /// `S.k = T.Id` can be UNKNOWN for a non-matching inner row, and the apply
   /// `ON (1 /
   /// d.x) = 0` divides by a child's `x`. `S` has a child `(2, 0)`, so `1 / d.x`
   /// divides by zero for Id 2's matched child. The correlated OUTER apply
   /// evaluates the body WHERE FIRST and reaches the `ON` only for a surviving
-  /// pair, so it DOES throw for Id 2's matched (2, 0). Folding into one LEFT-
-  /// join `on` would ALSO throw — but the recogniser cannot prove throw-
+  /// pair, so it does throw for Id 2's matched (2, 0). Folding into one LEFT-
+  /// join `on` would also throw — but the recogniser cannot prove throw-
   /// equivalence
-  /// for an unsafe `on`, so it LEAVES the apply correlated and the run throws
+  /// for an unsafe `on`, so it leaves the apply correlated and the run throws
   /// `.divide` exactly as the base.
   @Test func `an unsafe apply ON stays correlated and throws identically`()
       throws {
@@ -886,7 +886,7 @@ struct DecorrelateOuterApplyExclusionTests {
     catalog.expect(sql, fails: .divide)
   }
 
-  /// NON-EQUI correlation: `S.k > T.Id` has no equi-key to hash on, so the
+  /// non-equi correlation: `S.k > T.Id` has no equi-key to hash on, so the
   /// OUTER apply stays correlated — and runs correctly with NULL-extension. Id
   /// 1 → k > 1 → child (2, 200) → 200; Id 2 → k > 2 → none → NULL; Id 3 → none
   /// → NULL.
@@ -900,7 +900,7 @@ struct DecorrelateOuterApplyExclusionTests {
                          yields: [[1, 200], [2, nil], [3, nil]])
   }
 
-  /// BODY-LOCAL DERIVED table: the body reads its OWN derived `e` (over `S`), a
+  /// body-local derived table: the body reads its own derived `e` (over `S`), a
   /// per-execution materialised alias the set-based rewrite cannot relay. The
   /// OUTER apply stays correlated and NULL-extends Id 3 — the derived `e` reads
   /// `S` (100, 101, 200), never a same-named base relation.
@@ -915,7 +915,7 @@ struct DecorrelateOuterApplyExclusionTests {
                          yields: [[1, 100], [1, 101], [2, 200], [3, nil]])
   }
 
-  /// AGGREGATE body: a `COUNT(*)` body is not a plain filter+project, so the
+  /// aggregate body: a `COUNT(*)` body is not a plain filter+project, so the
   /// OUTER apply stays correlated — and runs correctly. Every left row is
   /// preserved (a LEFT apply), each with its child count: Id 1 → 2, Id 2 → 1,
   /// Id 3 → 0 (the aggregate over an empty group yields 0, not NULL).
@@ -932,15 +932,15 @@ struct DecorrelateOuterApplyExclusionTests {
 // MARK: - OUTER APPLY adversarial throw-visibility (G4, safe-gate)
 
 struct DecorrelateOuterApplyThrowTests {
-  /// ADVERSARIAL (soundness): an OUTER APPLY whose body WHERE divides by zero
-  /// for an inner row NO left row pairs with. `S`'s divide-by-zero row `(1,
-  /// 100)` is keyed to the ABSENT Id 1, and the body WHERE carries the UNSAFE
+  /// adversarial (soundness): an OUTER APPLY whose body WHERE divides by zero
+  /// for an inner row no left row pairs with. `S`'s divide-by-zero row `(1,
+  /// 100)` is keyed to the absent Id 1, and the body WHERE carries the unsafe
   /// term `1 / (S.x - 100) > 0`. The per-row correlated run never binds `:outer
   /// = 1`, so it never reaches that inner row — yielding Id 2 (matched (2,
   /// 200): `1 / 100 = 0`, so `> 0` false ⇒ no match ⇒ NULL-extended) and Id 3
   /// (no
-  /// child ⇒ NULL), with NO throw. A set-based join over the whole `S` WOULD
-  /// evaluate the divide on `(1, 100)` and throw. The recogniser LEAVES it
+  /// child ⇒ NULL), with no throw. A set-based join over the whole `S` would
+  /// evaluate the divide on `(1, 100)` and throw. The recogniser leaves it
   /// correlated (the body term is unsafe), so the run NULL-extends both left
   /// rows with no spurious throw — the base behaviour.
   @Test func `an unreachable throwing inner row is not decorrelated`() throws {
@@ -999,7 +999,7 @@ struct DecorrelateOuterApplyWidthTests {
   /// The lateral yields the `T ++ d` rows including Id 3's NULL-extended row,
   /// but
   /// `RIGHT JOIN U ON 1 = 0` matches none, so every `U` row survives with the
-  /// WHOLE `T ++ d` left width NULL — `U.u` at ordinal 2, `T.Id`/`d.x` NULL.
+  /// whole `T ++ d` left width NULL — `U.u` at ordinal 2, `T.Id`/`d.x` NULL.
   @Test func `a decorrelated OUTER APPLY as a RIGHT join left NULL-extends`()
       throws {
     let sql =
@@ -1019,7 +1019,7 @@ struct DecorrelateOuterApplyWidthTests {
 /// The `.outer` executor's hash fast-path must be behaviour-identical to the
 /// nested loop it replaces — same rows, same NULL-extension. A larger-ish
 /// OUTER APPLY (enough keys that the hash and nested-loop paths could diverge
-/// on bucketing or order) is compared against the KNOWN-CORRECT multiset the
+/// on bucketing or order) is compared against the known-correct multiset the
 /// correlated OUTER apply produces.
 struct DecorrelateOuterApplyHashTests {
   /// A wider parent/child so the right side hashes into several buckets. Ids
@@ -1059,23 +1059,23 @@ struct DecorrelateOuterApplyHashTests {
 
 // MARK: - OUTER join throw-visibility (fast-path safe-gate)
 
-/// An UNSAFE outer-join `on` — a straddling equi `A.k = B.k` AND a throwing
-/// conjunct like `(1 / B.x) = 0` — must FAULT on a pair the throwing term hits,
+/// An unsafe outer-join `on` — a straddling equi `A.k = B.k` AND a throwing
+/// conjunct like `(1 / B.x) = 0` — must fault on a pair the throwing term hits,
 /// never silently NULL-extend the left row. The nested-loop `.outer` executor
-/// evaluates `on` for EVERY (left, right) pair (this evaluator does NOT
+/// evaluates `on` for every (left, right) pair (this evaluator does NOT
 /// short-circuit `AND`: a `false`/UNKNOWN key term still evaluates a throwing
 /// residual), so a non-matching or NULL-key pair whose `(1 / B.x)` divides by
-/// zero raises `.divide`. The `.outer` hash fast-path would SKIP such a pair
+/// zero raises `.divide`. The `.outer` hash fast-path would skip such a pair
 /// (it probes `on` for a left row's matching-key bucket alone) and thus
-/// SUPPRESS the throw — so a `.match`-carrying `on` must never reach the fast
-/// path unless the WHOLE `on` is `safe`. TWO layers enforce this: (1) the
+/// suppress the throw — so a `.match`-carrying `on` must never reach the fast
+/// path unless the whole `on` is `safe`. two layers enforce this: (1) the
 /// `on()` recogniser (`Resolve.swift`) refuses to form ANY `.match` when the ON
 /// is not `allSatisfy(\.safe)` — so an unsafe user `A.k = B.k` stays a plain
 /// `.compare`, `equikey` finds no key, and the nested loop runs; (2) the
 /// executor's own `on.safe` gate on the fast path (this PR), defence-in-depth
 /// against a future `.match` producer that skips the recogniser's invariant.
 /// These end-to-end oracles PIN the observable invariant across both layers on
-/// a PLAIN LEFT/FULL JOIN (no APPLY).
+/// a plain LEFT/FULL JOIN (no APPLY).
 struct OuterJoinSafeGateTests {
   /// A non-matching right row (`B.k = 2 ≠ 1`, `B.x = 0`) makes the throwing
   /// conjunct `(1 / B.x) = 0` fault under the nested loop, which evaluates it
@@ -1130,10 +1130,10 @@ struct OuterJoinSafeGateTests {
         fails: .divide)
   }
 
-  /// CONTROL: a SAFE equi LEFT JOIN still takes the fast path and returns the
+  /// control: a safe equi LEFT JOIN still takes the fast path and returns the
   /// correct rows — a matched left row (multiplied by its match count), an
   /// unmatched one NULL-extended, and a NULL-key left row NULL-extended. An
-  /// added SAFE residual (`B.flag = 1`) keeps `on` safe and still filters.
+  /// added safe residual (`B.flag = 1`) keeps `on` safe and still filters.
   @Test func `a safe equi LEFT JOIN with a residual returns correct rows`()
       throws {
     let catalog = try Catalog {
@@ -1158,16 +1158,16 @@ struct OuterJoinSafeGateTests {
 
 // MARK: - Decorrelatable EXISTS → semijoin: result-equivalence + plan shape
 
-/// Behaviour-preserving oracles for the correlated `EXISTS` → SEMIJOIN and
-/// `NOT EXISTS` → ANTI-join decorrelation. A semijoin is a per-row EXISTENCE
-/// test: a left row survives AT MOST ONCE regardless of how many inner rows it
+/// Behaviour-preserving oracles for the correlated `EXISTS` → semijoin and
+/// `NOT EXISTS` → anti-join decorrelation. A semijoin is a per-row existence
+/// test: a left row survives at most once regardless of how many inner rows it
 /// matches (unlike a join, which multiplies). Every case compares the run
-/// against the KNOWN-CORRECT multiset the correlated `exists` evaluator
+/// against the known-correct multiset the correlated `exists` evaluator
 /// produces and pins the plan shape: a decorrelatable EXISTS becomes a
-/// `.semijoin` with NO residual `.exists`, an excluded one stays an `.exists`.
+/// `.semijoin` with no residual `.exists`, an excluded one stays an `.exists`.
 struct DecorrelateExistsTests {
-  /// AT-MOST-ONCE (G1): Id 1's body matches TWO inner rows, yet the left row
-  /// appears EXACTLY ONCE — a semijoin tests existence, it does NOT multiply.
+  /// at-most-once (G1): Id 1's body matches two inner rows, yet the left row
+  /// appears exactly once — a semijoin tests existence, it does NOT multiply.
   /// Id 1 and Id 2 have children (kept), Id 3 has none (dropped).
   @Test func `a left row matching many inner rows appears exactly once`()
       throws {
@@ -1177,8 +1177,8 @@ struct DecorrelateExistsTests {
         yields: [[1], [2]])
   }
 
-  /// PLAN SHAPE: the decorrelatable EXISTS optimises to a `.semijoin` (the SEMI
-  /// sense) with NO surviving `.exists` conjunct — the pass fired.
+  /// plan shape: the decorrelatable EXISTS optimises to a `.semijoin` (the semi
+  /// sense) with no surviving `.exists` conjunct — the pass fired.
   @Test func `a decorrelatable EXISTS optimises to a semijoin`() throws {
     let plan = try fixture().optimised(
         "SELECT T.Id FROM T " +
@@ -1187,8 +1187,8 @@ struct DecorrelateExistsTests {
     #expect(!exists(in: plan))
   }
 
-  /// NOT EXISTS → ANTI-join: the complement of the SEMI case — a left row
-  /// survives iff NO inner row matches. Only Id 3 (no child) survives.
+  /// NOT EXISTS → anti-join: the complement of the semi case — a left row
+  /// survives iff no inner row matches. Only Id 3 (no child) survives.
   @Test func `a NOT EXISTS yields the anti-join complement`() throws {
     try fixture().expect(
         "SELECT T.Id FROM T " +
@@ -1196,8 +1196,8 @@ struct DecorrelateExistsTests {
         yields: [[3]])
   }
 
-  /// PLAN SHAPE: a `NOT EXISTS` optimises to a `.semijoin` of the ANTI sense
-  /// (`anti == true`), NO `.exists` surviving.
+  /// plan shape: a `NOT EXISTS` optimises to a `.semijoin` of the anti sense
+  /// (`anti == true`), no `.exists` surviving.
   @Test func `a decorrelatable NOT EXISTS optimises to an anti-join`() throws {
     let plan = try fixture().optimised(
         "SELECT T.Id FROM T " +
@@ -1206,8 +1206,8 @@ struct DecorrelateExistsTests {
     #expect(!exists(in: plan))
   }
 
-  /// NULL KEY (SEMI): a left row with a NULL correlation key matches nothing
-  /// (NULL ≠ NULL), so EXISTS is FALSE and the SEMI drops it. Id 1 survives,
+  /// NULL KEY (semi): a left row with a NULL correlation key matches nothing
+  /// (NULL ≠ NULL), so EXISTS is FALSE and the semi drops it. Id 1 survives,
   /// NULL-Id row does not. The inner NULL-keyed `(NULL, 999)` never matches.
   @Test func `a NULL key makes EXISTS false and the semijoin drops the row`()
       throws {
@@ -1217,8 +1217,8 @@ struct DecorrelateExistsTests {
         yields: [[1]])
   }
 
-  /// NULL KEY (ANTI): a NULL correlation key makes NOT EXISTS TRUE,
-  /// so the ANTI-join KEEPS the NULL-Id row. Id 1 (has a child) is dropped, the
+  /// NULL KEY (anti): a NULL correlation key makes NOT EXISTS TRUE,
+  /// so the anti-join keeps the NULL-Id row. Id 1 (has a child) is dropped, the
   /// NULL-Id row survives.
   @Test func `a NULL key makes NOT EXISTS true and the anti-join keeps it`()
       throws {
@@ -1228,16 +1228,16 @@ struct DecorrelateExistsTests {
         yields: [[nil]])
   }
 
-  /// EMPTY INNER (SEMI): no inner row matches ANY left row, so EXISTS is FALSE
-  /// for all — the SEMI emits nothing.
+  /// empty INNER (semi): no inner row matches ANY left row, so EXISTS is FALSE
+  /// for all — the semi emits nothing.
   @Test func `an empty matching inner drops every SEMI left row`() throws {
     try fixture().empty(
         "SELECT T.Id FROM T " +
         "WHERE EXISTS (SELECT 1 FROM S WHERE S.k = T.Id AND S.x > 10000)")
   }
 
-  /// EMPTY INNER (ANTI): no inner row matches, so NOT EXISTS is TRUE for every
-  /// left row — the ANTI-join keeps them all.
+  /// empty INNER (anti): no inner row matches, so NOT EXISTS is TRUE for every
+  /// left row — the anti-join keeps them all.
   @Test func `an empty matching inner keeps every ANTI left row`() throws {
     try fixture().expect(
         "SELECT T.Id FROM T " +
@@ -1246,7 +1246,7 @@ struct DecorrelateExistsTests {
         yields: [[1], [2], [3]])
   }
 
-  /// DUPLICATE LEFT ROWS (SEMI): a left relation with duplicate keys preserves
+  /// duplicate LEFT ROWS (semi): a left relation with duplicate keys preserves
   /// every duplicate that passes the existence test — the semijoin filters, it
   /// does not dedup. Both copies of Id 1 survive; Id 3 (no child) drops.
   @Test func `duplicate left rows are preserved by the semijoin`() throws {
@@ -1267,7 +1267,7 @@ struct DecorrelateExistsTests {
         yields: [[1], [1]])
   }
 
-  /// DUPLICATE LEFT ROWS (ANTI): the mirror — every duplicate that FAILS the
+  /// duplicate LEFT ROWS (anti): the mirror — every duplicate that fails the
   /// existence test is preserved. Both copies of Id 3 survive, Id 1 drops.
   @Test func `duplicate left rows are preserved by the anti-join`() throws {
     let catalog = try Catalog {
@@ -1286,7 +1286,7 @@ struct DecorrelateExistsTests {
         yields: [[3], [3]])
   }
 
-  /// BODY RESIDUAL `p_R`: a safe local conjunct in the EXISTS WHERE (`S.x <
+  /// body residual `p_R`: a safe local conjunct in the EXISTS WHERE (`S.x <
   /// 200`) rides the semijoin `on` alongside the correlation key. Id 1 keeps a
   /// matching child (100 or 101 < 200), Id 2's only child (200) fails it ⇒ Id 2
   /// drops, Id 3 has none. Only Id 1 survives.
@@ -1319,7 +1319,7 @@ struct DecorrelateExistsTests {
         yields: [[2]])
   }
 
-  /// A SAFE SIBLING beside the EXISTS still decorrelates: `T.Id < 3 AND
+  /// A safe sibling beside the EXISTS still decorrelates: `T.Id < 3 AND
   /// EXISTS(...)`. Id 1 (child, < 3) survives, Id 2 (child, < 3) survives, Id 3
   /// fails the sibling. The semijoin fires (a safe sibling permits it) and the
   /// sibling stays in a `.select` above.
@@ -1334,25 +1334,25 @@ struct DecorrelateExistsTests {
   }
 }
 
-// MARK: - EXISTS that STAYS correlated, run correctly (and adversarial throws)
+// MARK: - EXISTS that stays correlated, run correctly (and adversarial throws)
 
 /// The excluded shapes: a body that is not a plain filter+project over a base
-/// scan, a non-equi correlation, an unsafe body term, an unsafe SIBLING, and an
-/// EXISTS nested in an `.or`. Each MUST stay a residual `.exists` (no
+/// scan, a non-equi correlation, an unsafe body term, an unsafe sibling, and an
+/// EXISTS nested in an `.or`. Each must stay a residual `.exists` (no
 /// `.semijoin`) and run correctly — and the two throw-visibility cases must
 /// throw exactly as the correlated plan does.
 struct DecorrelateExistsExclusionTests {
-  /// ADVERSARIAL SIBLING THROW-VISIBILITY (the step-4 guard, load-bearing): a
+  /// adversarial sibling throw-visibility (the step-4 guard, load-bearing): a
   /// sibling `(1 / T.v) = 0` divides by zero for a T row whose `v = 0`,
-  /// AND that SAME row's EXISTS is FALSE. The correlated select evaluates the
-  /// whole `AND` for the row and THROWS `.divide`. A wrongly-decorrelated plan
-  /// would let the SEMIJOIN DROP that exists-false row and HIDE the throw. So
-  /// the recogniser MUST leave it correlated (unsafe sibling) — and the run
-  /// MUST throw.
+  /// AND that same row's EXISTS is FALSE. The correlated select evaluates the
+  /// whole `AND` for the row and throws `.divide`. A wrongly-decorrelated plan
+  /// would let the semijoin DROP that exists-false row and hide the throw. So
+  /// the recogniser must leave it correlated (unsafe sibling) — and the run
+  /// must throw.
   @Test func `an unsafe sibling stays correlated and throws`() throws {
     let catalog = try Catalog {
       Relation("T", ["Id": .integer, "v": .integer]) {
-        Row(9, 0)         // v = 0 ⇒ 1 / v faults; Id 9 has NO child ⇒ EXISTS
+        Row(9, 0)         // v = 0 ⇒ 1 / v faults; Id 9 has no child ⇒ EXISTS
                           // false, so a semijoin drops it and hides the fault
       }
       Relation("S", ["k": .integer, "x": .integer]) {
@@ -1365,14 +1365,14 @@ struct DecorrelateExistsExclusionTests {
     let plan = try catalog.optimised(sql)
     #expect(!semijoins(plan))                   // NOT decorrelated
     #expect(exists(in: plan))                   // still a residual EXISTS
-    catalog.expect(sql, fails: .divide)         // and it MUST throw
+    catalog.expect(sql, fails: .divide)         // and it must throw
   }
 
-  /// ADVERSARIAL BODY THROW-VISIBILITY (G4): an EXISTS body carries an UNSAFE
+  /// adversarial body throw-visibility (G4): an EXISTS body carries an unsafe
   /// term `1 / (S.x - 100) > 0` that divides by zero for the child `(1, 100)`,
-  /// which is keyed to the ABSENT Id 1. The per-row correlated run never binds
+  /// which is keyed to the absent Id 1. The per-row correlated run never binds
   /// `:outer = 1`, so it never reaches that inner row and never throws. A
-  /// set-based semijoin over the whole `S` WOULD evaluate the divide. The
+  /// set-based semijoin over the whole `S` would evaluate the divide. The
   /// recogniser leaves it correlated (unsafe body), so the run is throw-free.
   @Test func `an unreachable throwing body row stays correlated`() throws {
     let catalog = try Catalog {
@@ -1391,12 +1391,12 @@ struct DecorrelateExistsExclusionTests {
     #expect(!semijoins(try catalog.optimised(sql)))
     #expect(exists(in: try catalog.optimised(sql)))
     // Id 2: child (2, 200) ⇒ 1 / 100 = 0 ⇒ `> 0` false ⇒ EXISTS false; Id 3:
-    // none. The Id-1 divide is never reached, so no rows and NO throw.
+    // none. The Id-1 divide is never reached, so no rows and no throw.
     let rows = try catalog.run(parse(query: sql), .standard)
     #expect(rows.isEmpty)
   }
 
-  /// NON-EQUI correlation `S.k > T.Id`: no equi key to hash on, so the EXISTS
+  /// non-equi correlation `S.k > T.Id`: no equi key to hash on, so the EXISTS
   /// stays correlated and runs correctly. Id 1 has a child with k > 1 (k = 2),
   /// Id 2 has none (only k ≤ 2), Id 3 none. Only Id 1 survives.
   @Test func `a non-equi correlation stays an exists and runs correctly`()
@@ -1409,7 +1409,7 @@ struct DecorrelateExistsExclusionTests {
     try fixture().expect(sql + " ORDER BY T.Id", yields: [[1]])
   }
 
-  /// AGGREGATE body: a `COUNT(*)` body is not a plain filter+project,
+  /// aggregate body: a `COUNT(*)` body is not a plain filter+project,
   /// so the EXISTS stays correlated. The body is always non-empty (COUNT of an
   /// empty group yields a row), so EXISTS is TRUE for every left row — kept.
   @Test func `an aggregate body stays an exists and runs correctly`() throws {
@@ -1445,7 +1445,7 @@ struct DecorrelateExistsExclusionTests {
     try fixture().expect(sql + " ORDER BY T.Id", yields: [[1], [2]])
   }
 
-  /// SETOP body: a `UNION` body is not the canonical single-scan shape, so the
+  /// setop body: a `UNION` body is not the canonical single-scan shape, so the
   /// EXISTS stays correlated — and runs correctly. Id 1, Id 2 have a matching
   /// arm; Id 3 has none.
   @Test func `a setop body stays an exists and runs correctly`() throws {
@@ -1458,7 +1458,7 @@ struct DecorrelateExistsExclusionTests {
     try fixture().expect(sql + " ORDER BY T.Id", yields: [[1], [2]])
   }
 
-  /// NESTED SUBQUERY in the body: the EXISTS body itself nests an `IN (Q)`, so
+  /// nested subquery in the body: the EXISTS body itself nests an `IN (Q)`, so
   /// its plan is not the canonical filter+project over a single scan — it stays
   /// correlated and runs correctly. Id 1, Id 2 have a child whose x is in the
   /// inner set; Id 3 has none.
@@ -1472,7 +1472,7 @@ struct DecorrelateExistsExclusionTests {
     try fixture().expect(sql + " ORDER BY T.Id", yields: [[1], [2]])
   }
 
-  /// BODY-LOCAL DERIVED table: the EXISTS body reads its OWN derived `e` (over
+  /// body-local derived table: the EXISTS body reads its own derived `e` (over
   /// `S`), a per-execution alias the set-based rewrite cannot relay. It stays
   /// correlated — and the derived `e` reads `S`, so Id 1, Id 2 are kept.
   @Test func `a body-local derived table stays an exists`() throws {
@@ -1484,7 +1484,7 @@ struct DecorrelateExistsExclusionTests {
     try fixture().expect(sql + " ORDER BY T.Id", yields: [[1], [2]])
   }
 
-  /// EXISTS INSIDE AN `.or`: an EXISTS that is NOT a top-level `AND` conjunct
+  /// EXISTS inside an `.or`: an EXISTS that is NOT a top-level `AND` conjunct
   /// (it sits under an `OR`) is left correlated — the recogniser lifts only a
   /// top-level conjunct. `T.Id = 3 OR EXISTS(...)`: Id 3 (the OR's left) and
   /// Ids 1, 2 (the EXISTS arm) survive.
@@ -1499,17 +1499,17 @@ struct DecorrelateExistsExclusionTests {
   }
 }
 
-// MARK: - Multiple decorrelatable EXISTS → STACKED semijoins
+// MARK: - Multiple decorrelatable EXISTS → stacked semijoins
 
-/// Oracles for lifting MORE THAN ONE decorrelatable EXISTS conjunct of a single
-/// WHERE. Each such conjunct becomes its OWN semijoin stacked over the source,
+/// Oracles for lifting more than one decorrelatable EXISTS conjunct of a single
+/// WHERE. Each such conjunct becomes its own semijoin stacked over the source,
 /// so the AND of independent existence tests is an AND of stacked semijoins —
-/// order-independent, at-most-once per left row. Each case pins BOTH the count
+/// order-independent, at-most-once per left row. Each case pins both the count
 /// of stacked semijoins (no residual `.exists`) AND the known-correct multiset
 /// the correlated `exists` evaluator produces.
 struct DecorrelateMultiExistsTests {
-  /// A parent `T` and TWO children `S`, `U` keyed on `T.Id`. Id 1 has a match
-  /// in BOTH, Id 2 only in `S`, Id 3 in NEITHER — the AND survives Id 1 alone,
+  /// A parent `T` and two children `S`, `U` keyed on `T.Id`. Id 1 has a match
+  /// in both, Id 2 only in `S`, Id 3 in neither — the AND survives Id 1 alone,
   /// so lifting both semijoins must drop Ids 2 and 3.
   private func twoChildFixture() throws -> FixtureCatalog {
     try Catalog {
@@ -1528,8 +1528,8 @@ struct DecorrelateMultiExistsTests {
     }
   }
 
-  /// BOTH LIFT: two decorrelatable EXISTS of one WHERE become TWO stacked
-  /// semijoins (no residual `.exists`), the result the rows matching BOTH: Id 1
+  /// both lift: two decorrelatable EXISTS of one WHERE become two stacked
+  /// semijoins (no residual `.exists`), the result the rows matching both: Id 1
   /// alone (Id 2 matches only `S`, dropped; Id 3 matches neither, dropped).
   @Test func `two decorrelatable EXISTS lift into two stacked semijoins`()
       throws {
@@ -1538,15 +1538,15 @@ struct DecorrelateMultiExistsTests {
         "WHERE EXISTS (SELECT 1 FROM S WHERE S.k = T.Id) " +
         "AND EXISTS (SELECT 1 FROM U WHERE U.k = T.Id)"
     let plan = try twoChildFixture().optimised(sql)
-    #expect(semijoinCount(plan) == 2)           // BOTH lifted
+    #expect(semijoinCount(plan) == 2)           // both lifted
     #expect(!exists(in: plan))                   // no residual EXISTS
     try twoChildFixture().expect(sql + " ORDER BY T.Id", yields: [[1]])
   }
 
-  /// AT-MOST-ONCE ACROSS THE STACK: an outer row whose BOTH bodies match MANY
-  /// inner rows appears EXACTLY ONCE — a semijoin tests existence, it does not
+  /// at-most-once across the stack: an outer row whose both bodies match many
+  /// inner rows appears exactly once — a semijoin tests existence, it does not
   /// multiply, and stacking two preserves at-most-once. Id 1 matches two `S`
-  /// rows and two `U` rows (four combinations a join would emit), yet the SEMI
+  /// rows and two `U` rows (four combinations a join would emit), yet the semi
   /// stack yields it once.
   @Test func `an outer row matching many in both bodies appears once`() throws {
     let catalog = try Catalog {
@@ -1567,14 +1567,14 @@ struct DecorrelateMultiExistsTests {
         "WHERE EXISTS (SELECT 1 FROM S WHERE S.k = T.Id) " +
         "AND EXISTS (SELECT 1 FROM U WHERE U.k = T.Id)"
     #expect(semijoinCount(try catalog.optimised(sql)) == 2)
-    // A join would emit Id 1 four times (2 × 2); the SEMI stack emits it ONCE.
+    // A join would emit Id 1 four times (2 × 2); the semi stack emits it once.
     try catalog.expect(sql, yields: [[1]])
   }
 
-  /// MIXED SENSE: `EXISTS(...) AND NOT EXISTS(...)` lifts a SEMI over `S` and
-  /// an ANTI over `U` — the complement rows. Id 1 has a child in BOTH (SEMI
-  /// keeps, ANTI drops), Id 2 in `S` only (SEMI keeps, ANTI keeps), Id 3 in
-  /// neither (SEMI drops). Only Id 2 survives both.
+  /// mixed sense: `EXISTS(...) AND NOT EXISTS(...)` lifts a semi over `S` and
+  /// an anti over `U` — the complement rows. Id 1 has a child in both (semi
+  /// keeps, anti drops), Id 2 in `S` only (semi keeps, anti keeps), Id 3 in
+  /// neither (semi drops). Only Id 2 survives both.
   @Test func `a SEMI and an ANTI in one WHERE both lift`() throws {
     let sql =
         "SELECT T.Id FROM T " +
@@ -1588,9 +1588,9 @@ struct DecorrelateMultiExistsTests {
     try twoChildFixture().expect(sql + " ORDER BY T.Id", yields: [[2]])
   }
 
-  /// A DECORRELATABLE EXISTS beside a NON-decorrelatable one (an aggregate
-  /// body): the whole select STAYS correlated. The non-decorrelatable exists is
-  /// an UNSAFE non-lifted sibling, so it blocks all lifting (no semijoin). The
+  /// A decorrelatable EXISTS beside a non-decorrelatable one (an aggregate
+  /// body): the whole select stays correlated. The non-decorrelatable exists is
+  /// an unsafe non-lifted sibling, so it blocks all lifting (no semijoin). The
   /// run is still correct: Id 1's `S` child exists AND its aggregate body
   /// always yields a row (COUNT of an empty group is 0), so Ids 1, 2 (S
   /// children) survive, Id 3 does not.
@@ -1606,18 +1606,18 @@ struct DecorrelateMultiExistsTests {
     try twoChildFixture().expect(sql + " ORDER BY T.Id", yields: [[1], [2]])
   }
 
-  /// ADVERSARIAL SIBLING THROW-VISIBILITY across TWO liftable EXISTS: an unsafe
+  /// adversarial sibling throw-visibility across two liftable EXISTS: an unsafe
   /// non-exists sibling `(1 / T.v) = 0` shares the WHERE with two
   /// decorrelatable EXISTS. A `v = 0` row whose EXISTS conjuncts do NOT all
-  /// hold makes the correlated select evaluate the whole AND and THROW
+  /// hold makes the correlated select evaluate the whole AND and throw
   /// `.divide` (the sibling is first, so it is reached before the false
-  /// EXISTS). A stack that dropped that row via a semijoin would HIDE the
-  /// throw, so the guard leaves the WHOLE select correlated (no semijoin) — and
-  /// the run MUST throw.
+  /// EXISTS). A stack that dropped that row via a semijoin would hide the
+  /// throw, so the guard leaves the whole select correlated (no semijoin) — and
+  /// the run must throw.
   @Test func `an unsafe sibling blocks all lifting and throws`() throws {
     let catalog = try Catalog {
       Relation("T", ["Id": .integer, "v": .integer]) {
-        Row(9, 0)         // v = 0 ⇒ 1 / v faults; Id 9 has NO S/U child, so its
+        Row(9, 0)         // v = 0 ⇒ 1 / v faults; Id 9 has no S/U child, so its
                           // EXISTS conjuncts are false ⇒ a stack would drop it
       }
       Relation("S", ["k": .integer, "x": .integer]) {
@@ -1635,11 +1635,11 @@ struct DecorrelateMultiExistsTests {
     let plan = try catalog.optimised(sql)
     #expect(semijoinCount(plan) == 0)            // nothing lifted (unsafe kin)
     #expect(exists(in: plan))                    // still residual EXISTS
-    catalog.expect(sql, fails: .divide)          // and it MUST throw
+    catalog.expect(sql, fails: .divide)          // and it must throw
   }
 
-  /// REGRESSION: a SINGLE decorrelatable EXISTS beside a SAFE non-exists kin
-  /// still lifts EXACTLY as before — one semijoin, the sibling kept in a
+  /// regression: a single decorrelatable EXISTS beside a safe non-exists kin
+  /// still lifts exactly as before — one semijoin, the sibling kept in a
   /// `.select` above. `T.Id < 3 AND EXISTS(over S)`: Id 1, Id 2 (S child, < 3)
   /// survive; Id 3 fails the sibling. The multi-lift path is a strict superset.
   @Test func `a single EXISTS beside a safe sibling still lifts once`() throws {
@@ -1676,12 +1676,12 @@ private func inFixture() throws -> FixtureCatalog {
   }
 }
 
-/// Behaviour-preserving oracles for the POSITIVE correlated `IN (Q)` → SEMIJOIN
+/// Behaviour-preserving oracles for the positive correlated `IN (Q)` → semijoin
 /// decorrelation. `operand IN (SELECT col FROM S WHERE S.k = :outer …)` is a
 /// per-row membership test — TRUE iff some correlated inner row's `col` equals
 /// `operand` — so it lifts to a semijoin whose `on` conjoins the correlation
-/// key with the membership equality. Like EXISTS it is AT-MOST-ONCE. Each pins
-/// BOTH the plan shape (a `.semijoin`, no residual `.within`) and the
+/// key with the membership equality. Like EXISTS it is at-most-once. Each pins
+/// both the plan shape (a `.semijoin`, no residual `.within`) and the
 /// known-correct multiset the correlated `within` evaluator produces.
 struct DecorrelateInTests {
   /// The canonical lift: `T.x IN (SELECT S.v FROM S WHERE S.k = T.Id)`. Id 1
@@ -1699,8 +1699,8 @@ struct DecorrelateInTests {
     try inFixture().expect(sql + " ORDER BY T.Id", yields: [[1]])
   }
 
-  /// AT-MOST-ONCE: an outer row whose operand matches MANY inner rows appears
-  /// EXACTLY ONCE — a semijoin tests membership, it does not multiply. Id 1's
+  /// at-most-once: an outer row whose operand matches many inner rows appears
+  /// exactly once — a semijoin tests membership, it does not multiply. Id 1's
   /// `x = 100` equals two inner values (100 appears once, but 7 keyed to Id 1
   /// twice below), yet Id 1 surfaces once.
   @Test func `an outer row matching many inner rows appears once`() throws {
@@ -1710,19 +1710,19 @@ struct DecorrelateInTests {
       }
       Relation("S", ["k": .integer, "v": .integer]) {
         Row(1, 7)
-        Row(1, 7)          // Id 1's operand equals TWO inner rows
+        Row(1, 7)          // Id 1's operand equals two inner rows
       }
     }
     let sql =
         "SELECT T.Id FROM T " +
         "WHERE T.x IN (SELECT S.v FROM S WHERE S.k = T.Id)"
     #expect(semijoinCount(try catalog.optimised(sql)) == 1)
-    // A join would emit Id 1 twice; the SEMI emits it ONCE.
+    // A join would emit Id 1 twice; the semi emits it once.
     try catalog.expect(sql, yields: [[1]])
   }
 
-  /// NULL OPERAND: `x IN (Q)` with a NULL operand is UNKNOWN (never TRUE), so
-  /// the SEMI drops the row. A NULL inner element does not falsely match a
+  /// NULL operand: `x IN (Q)` with a NULL operand is UNKNOWN (never TRUE), so
+  /// the semi drops the row. A NULL inner element does not falsely match a
   /// non-null operand either. Id 1 (x NULL) drops; Id 2 (x = 100, child 100
   /// beside a NULL child) survives — the NULL element is simply not a match.
   @Test func `a NULL operand drops and a NULL element never falsely matches`()
@@ -1745,7 +1745,7 @@ struct DecorrelateInTests {
     try catalog.expect(sql, yields: [[2]])
   }
 
-  /// BODY RESIDUAL `p_R`: a safe local conjunct in the IN subquery WHERE
+  /// body residual `p_R`: a safe local conjunct in the IN subquery WHERE
   /// (`S.v < 200`) rides the semijoin `on` alongside the correlation key and
   /// membership. Only children with `v < 200` are candidates. Id 1's x = 100
   /// equals child 100 (< 200) ⇒ kept; if the residual excluded 100 it would
@@ -1770,7 +1770,7 @@ struct DecorrelateInTests {
     try catalog.expect(sql + " ORDER BY T.Id", yields: [[1]])
   }
 
-  /// A DECORRELATED IN beside a SAFE sibling: `T.Id < 3 AND T.x IN (…)`. The IN
+  /// A decorrelated IN beside a safe sibling: `T.Id < 3 AND T.x IN (…)`. The IN
   /// lifts into a semijoin and the safe sibling stays in a `.select` above. Id
   /// 1 (< 3, x = 100 matches) survives; Id 2 (< 3, x = 999 no match) drops on
   /// value; Id 3 fails the sibling.
@@ -1786,14 +1786,14 @@ struct DecorrelateInTests {
   }
 }
 
-// MARK: - IN that STAYS correlated, run correctly
+// MARK: - IN that stays correlated, run correctly
 
-/// The excluded IN shapes: a deferred `NOT IN`, an UNCORRELATED IN, a non-equi
+/// The excluded IN shapes: a deferred `NOT IN`, an uncorrelated IN, a non-equi
 /// correlation, a non-canonical body (aggregate/limit/distinct), a body-local
-/// derived table, and an IN whose subquery projects an EXPRESSION. Each MUST
+/// derived table, and an IN whose subquery projects an expression. Each must
 /// stay a residual `.within` (no `.semijoin`) and run correctly.
 struct DecorrelateInExclusionTests {
-  /// DEFERRED `NOT IN`: the NULL trap makes it not a plain anti-join, so it is
+  /// deferred `NOT IN`: the NULL trap makes it not a plain anti-join, so it is
   /// left correlated. Over the base fixture Id 1 (x = 100 IN {100, 101}) is
   /// excluded by NOT IN; Id 2 (x = 999 NOT IN {200}) survives; Id 3 has no
   /// child so `NOT IN ()` is TRUE — kept.
@@ -1806,8 +1806,8 @@ struct DecorrelateInExclusionTests {
     try inFixture().expect(sql + " ORDER BY T.Id", yields: [[2], [3]])
   }
 
-  /// UNCORRELATED IN: `x IN (SELECT v FROM S)` has an empty correlation (v1
-  /// lifts CORRELATED IN only), so it stays a residual `.within`. The inner set
+  /// uncorrelated IN: `x IN (SELECT v FROM S)` has an empty correlation (v1
+  /// lifts correlated IN only), so it stays a residual `.within`. The inner set
   /// is {100, 101, 200}; Id 1 (x = 100) and Id 2? x = 999 not in ⇒ drop; Id 3 x
   /// = 300 not in ⇒ drop. Only Id 1 survives.
   @Test func `an uncorrelated IN stays correlated and runs correctly`() throws {
@@ -1818,7 +1818,7 @@ struct DecorrelateInExclusionTests {
     try inFixture().expect(sql + " ORDER BY T.Id", yields: [[1]])
   }
 
-  /// NON-EQUI correlation `S.k > T.Id`: no equi key to hash on, so the IN stays
+  /// non-equi correlation `S.k > T.Id`: no equi key to hash on, so the IN stays
   /// correlated. Id 1: children with k > 1 → k = 2 → v = 200; x = 100 ∉ {200} ⇒
   /// drop. Id 2: k > 2 → none ⇒ drop. Id 3: none ⇒ drop. No rows.
   @Test func `a non-equi correlation stays correlated and runs correctly`()
@@ -1831,7 +1831,7 @@ struct DecorrelateInExclusionTests {
     try inFixture().empty(sql)
   }
 
-  /// AGGREGATE body: a `SUM(S.v)` body is not a plain filter+project, so the IN
+  /// aggregate body: a `SUM(S.v)` body is not a plain filter+project, so the IN
   /// stays correlated. Id 1's children sum to 201, x = 100 ≠ 201 ⇒ drop; Id 2's
   /// sum is 200, x = 999 ≠ 200 ⇒ drop; Id 3's group is empty (SUM ⇒ NULL), IN
   /// UNKNOWN ⇒ drop. No rows.
@@ -1869,7 +1869,7 @@ struct DecorrelateInExclusionTests {
     try inFixture().expect(sql + " ORDER BY T.Id", yields: [[1]])
   }
 
-  /// BODY-LOCAL DERIVED table: the IN body reads its OWN derived `e` (over
+  /// body-local derived table: the IN body reads its own derived `e` (over
   /// `S`), a per-execution alias the set-based rewrite cannot relay. It stays
   /// correlated — the derived `e` reads `S`, so Id 1 (x = 100 ∈ {100, 101})
   /// survives; Id 2, Id 3 drop.
@@ -1882,7 +1882,7 @@ struct DecorrelateInExclusionTests {
     try inFixture().expect(sql + " ORDER BY T.Id", yields: [[1]])
   }
 
-  /// EXPRESSION projection: the IN subquery projects `S.v + 1`, not a bare
+  /// expression projection: the IN subquery projects `S.v + 1`, not a bare
   /// column, so there is no single membership slot and the IN stays correlated.
   /// Id 1's candidate values are {101, 102}; x = 100 ∉ ⇒ drop. Add an Id whose
   /// x equals a shifted value to prove it still runs: Id 4 x = 401 = 400 + 1.
@@ -1910,24 +1910,24 @@ struct DecorrelateInExclusionTests {
 
 // MARK: - IN adversarial throw-visibility (operand + sibling)
 
-/// The two throw-visibility guards specific to the IN lift: an UNSAFE operand
+/// The two throw-visibility guards specific to the IN lift: an unsafe operand
 /// (evaluated per outer row by the correlated `within`, even when the inner is
 /// empty, so a semijoin that never evaluates `on` for a no-match row would
-/// SUPPRESS its throw) and an UNSAFE non-IN sibling (the shared sibling guard).
-/// Both MUST stay correlated (no semijoin) and throw exactly as the correlated
+/// suppress its throw) and an unsafe non-IN sibling (the shared sibling guard).
+/// Both must stay correlated (no semijoin) and throw exactly as the correlated
 /// plan does.
 struct DecorrelateInThrowVisibilityTests {
-  /// UNSAFE OPERAND (load-bearing): `(1 / T.v) IN (SELECT S.v FROM S WHERE
-  /// S.k = T.Id)` with a `v = 0` row whose key has NO child. The correlated
-  /// `within` evaluates the operand `1 / 0` for that row EVEN THOUGH the inner
-  /// is empty, so it THROWS `.divide`. A semijoin never evaluates `on` for a
-  /// left row with no right rows, so it would SUPPRESS the throw — the
-  /// recogniser must leave it correlated (unsafe operand), and the run MUST
+  /// unsafe operand (load-bearing): `(1 / T.v) IN (SELECT S.v FROM S WHERE
+  /// S.k = T.Id)` with a `v = 0` row whose key has no child. The correlated
+  /// `within` evaluates the operand `1 / 0` for that row even though the inner
+  /// is empty, so it throws `.divide`. A semijoin never evaluates `on` for a
+  /// left row with no right rows, so it would suppress the throw — the
+  /// recogniser must leave it correlated (unsafe operand), and the run must
   /// throw.
   @Test func `an unsafe operand stays correlated and throws`() throws {
     let catalog = try Catalog {
       Relation("T", ["Id": .integer, "v": .integer]) {
-        Row(9, 0)          // v = 0 ⇒ 1 / v faults; Id 9 has NO child ⇒ inner
+        Row(9, 0)          // v = 0 ⇒ 1 / v faults; Id 9 has no child ⇒ inner
                            // empty, so a semijoin never confirms `on` and hides
                            // the fault
       }
@@ -1941,19 +1941,19 @@ struct DecorrelateInThrowVisibilityTests {
     let plan = try catalog.optimised(sql)
     #expect(!semijoins(plan))                    // NOT decorrelated
     #expect(within(in: plan))                    // still a residual IN
-    catalog.expect(sql, fails: .divide)          // and it MUST throw
+    catalog.expect(sql, fails: .divide)          // and it must throw
   }
 
-  /// UNSAFE SIBLING (the shared sibling guard, on the IN-lift path): a
+  /// unsafe sibling (the shared sibling guard, on the IN-lift path): a
   /// non-IN sibling `(1 / T.v) = 0` divides by zero for a `v = 0` row whose IN
   /// is FALSE. The correlated select evaluates the whole `AND` (the sibling
-  /// first) and THROWS `.divide`. A plan that lifted the IN into a semijoin and
-  /// dropped the IN-false row would HIDE the throw, so the guard leaves the
-  /// WHOLE select correlated — and the run MUST throw.
+  /// first) and throws `.divide`. A plan that lifted the IN into a semijoin and
+  /// dropped the IN-false row would hide the throw, so the guard leaves the
+  /// whole select correlated — and the run must throw.
   @Test func `an unsafe sibling stays correlated and throws`() throws {
     let catalog = try Catalog {
       Relation("T", ["Id": .integer, "x": .integer, "v": .integer]) {
-        Row(9, 100, 0)     // v = 0 ⇒ 1 / v faults; Id 9 has NO child ⇒ IN
+        Row(9, 100, 0)     // v = 0 ⇒ 1 / v faults; Id 9 has no child ⇒ IN
                            // false, so a semijoin would drop it, hide the fault
       }
       Relation("S", ["k": .integer, "v": .integer]) {
@@ -1967,15 +1967,15 @@ struct DecorrelateInThrowVisibilityTests {
     let plan = try catalog.optimised(sql)
     #expect(!semijoins(plan))                    // nothing lifted (unsafe kin)
     #expect(within(in: plan))                    // still a residual IN
-    catalog.expect(sql, fails: .divide)          // and it MUST throw
+    catalog.expect(sql, fails: .divide)          // and it must throw
   }
 }
 
 // MARK: - Decorrelatable scalar subquery → LEFT join: result + plan shape
 
 /// A parent `T` whose `fk` column points at a child `R` row by its 1-based
-/// virtual `Id` — `fk` 1 → R's row 1, `fk` 3 → R's row 3, `fk` 5 → NO R row
-/// (past the end), `fk` NULL → nothing. `R.Id` is the UNIQUE virtual key the
+/// virtual `Id` — `fk` 1 → R's row 1, `fk` 3 → R's row 3, `fk` 5 → no R row
+/// (past the end), `fk` NULL → nothing. `R.Id` is the unique virtual key the
 /// scalar `(SELECT R.v FROM R WHERE R.Id = T.fk)` decorrelates over.
 private func scalarFixture() throws -> FixtureCatalog {
   try Catalog {
@@ -1994,15 +1994,15 @@ private func scalarFixture() throws -> FixtureCatalog {
 }
 
 /// Behaviour-preserving oracles for the correlated scalar `.subquery` → LEFT
-/// join decorrelation. A scalar subquery over the UNIQUE virtual `Id` key
-/// matches AT MOST ONE inner row, so it becomes a plain LEFT join reading the
+/// join decorrelation. A scalar subquery over the unique virtual `Id` key
+/// matches at most one inner row, so it becomes a plain LEFT join reading the
 /// value from a joined column (an unmatched left row NULL-extends, the empty →
 /// NULL of the correlated scalar). Each case compares the run against the
-/// KNOWN-CORRECT multiset the correlated `scalar` evaluator produces and pins
+/// known-correct multiset the correlated `scalar` evaluator produces and pins
 /// the plan shape: a decorrelatable scalar becomes an `.outer` (LEFT) join with
-/// NO residual `.subquery` term, an excluded one stays a `.subquery`.
+/// no residual `.subquery` term, an excluded one stays a `.subquery`.
 struct DecorrelateScalarTests {
-  /// (1) 0 MATCHES → NULL: `fk` 5 and the NULL key reach no `R.Id`, so the LEFT
+  /// (1) 0 matches → NULL: `fk` 5 and the NULL key reach no `R.Id`, so the LEFT
   /// join NULL-extends and the coalesce passes the NULL through — exactly the
   /// empty → NULL the correlated scalar yields.
   @Test func `an unmatched scalar key yields NULL`() throws {
@@ -2012,7 +2012,7 @@ struct DecorrelateScalarTests {
         yields: [[nil], [nil], [100], [300]])
   }
 
-  /// (2) 1 MATCH → THE VALUE, and the plan is a LEFT `.outer` join with NO
+  /// (2) 1 match → the value, and the plan is a LEFT `.outer` join with no
   /// residual `.subquery` term — the pass fired.
   @Test func `a matched scalar key reads the joined value`() throws {
     let sql = "SELECT (SELECT R.v FROM R WHERE R.Id = T.fk) AS v FROM T"
@@ -2023,7 +2023,7 @@ struct DecorrelateScalarTests {
                                yields: [[nil], [nil], [100], [300]])
   }
 
-  /// (3) TYPE COERCION (pins the coalesce, not a raw slot): the scalar's column
+  /// (3) type coercion (pins the coalesce, not a raw slot): the scalar's column
   /// is `.double` but its cells are stored as integers, so the coalesce must
   /// widen a matched `.integer` cell to `.double` (`100` → `100.0`) and pass a
   /// NULL (an unmatched key) through unchanged — byte-identical to the scalar
@@ -2046,7 +2046,7 @@ struct DecorrelateScalarTests {
                        yields: [[Value.null], [Value.double(100.0)]])
   }
 
-  /// (4) DUPLICATE LEFT ROWS read the scalar N times: a LEFT join emits each
+  /// (4) duplicate LEFT ROWS read the scalar N times: a LEFT join emits each
   /// left row once (a unique key never multiplies), so three copies of `fk` 1
   /// each read `R.Id` 1's value — the same value three times, not deduped.
   @Test func `duplicate left rows each read the scalar`() throws {
@@ -2065,9 +2065,9 @@ struct DecorrelateScalarTests {
     try catalog.expect(sql, yields: [[100], [100], [100]])
   }
 
-  /// (5) SCALAR BESIDE A THROWING SIBLING TERM: a LEFT join drops NO row, so
+  /// (5) scalar beside A throwing sibling term: a LEFT join drops no row, so
   /// the sibling `1 / T.z` is evaluated on exactly the rows it was correlated.
-  /// The `z = 0` row makes it divide by zero, and the decorrelated plan MUST
+  /// The `z = 0` row makes it divide by zero, and the decorrelated plan must
   /// throw identically to the correlated one — nothing is suppressed.
   @Test func `a throwing sibling term throws after decorrelation`() throws {
     let catalog = try Catalog {
@@ -2090,10 +2090,10 @@ struct DecorrelateScalarTests {
     catalog.expect(sql, fails: .divide)
   }
 
-  /// (6) NON-UNIQUE KEY STAYS CORRELATED: the body keys on a REAL column
+  /// (6) non-unique KEY stays correlated: the body keys on a REAL column
   /// (`R.owner`, ordinal `< width`) rather than the unique virtual `Id`, so the
   /// uniqueness guard bails and the scalar stays a `.subquery`. The correlated
-  /// run is correct; a key matching TWO rows still throws `.cardinality`
+  /// run is correct; a key matching two rows still throws `.cardinality`
   /// per-row.
   @Test func `a non-unique real key stays correlated`() throws {
     let catalog = try Catalog {
@@ -2113,13 +2113,13 @@ struct DecorrelateScalarTests {
     try catalog.expect(sql + " ORDER BY v", yields: [[nil], [100]])
   }
 
-  /// (6b) A non-unique key that matches MANY rows still throws `.cardinality`
+  /// (6b) A non-unique key that matches many rows still throws `.cardinality`
   /// per-row under the correlated path — the scalar was correctly left
   /// correlated, preserving the >1-row fault a LEFT join could not reproduce.
   @Test func `a non-unique key matching many rows still faults`() throws {
     let catalog = try Catalog {
       Relation("T", ["fk": .integer]) {
-        Row(7)            // matches TWO owner-7 rows ⇒ cardinality
+        Row(7)            // matches two owner-7 rows ⇒ cardinality
       }
       Relation("R", ["owner": .integer, "v": .integer]) {
         Row(7, 100)
@@ -2132,8 +2132,8 @@ struct DecorrelateScalarTests {
     catalog.expect(sql, fails: .cardinality)
   }
 
-  /// (8) MULTIPLE SCALAR SUBQUERIES → two stacked LEFT joins: each replaced
-  /// term reads its OWN joined column, an unreplaced term keeps its original
+  /// (8) multiple scalar subqueries → two stacked LEFT joins: each replaced
+  /// term reads its own joined column, an unreplaced term keeps its original
   /// slot, and both values are correct. `fk1` → R.v, `fk2` → R.w over one R.
   @Test func `two scalar subqueries stack into two LEFT joins`() throws {
     let catalog = try Catalog {
@@ -2151,13 +2151,13 @@ struct DecorrelateScalarTests {
         "SELECT (SELECT R.v FROM R WHERE R.Id = T.fk1), " +
         "(SELECT R.w FROM R WHERE R.Id = T.fk2) FROM T"
     let plan = try catalog.optimised(sql)
-    #expect(!subquery(in: plan))                 // BOTH decorrelated
+    #expect(!subquery(in: plan))                 // both decorrelated
     #expect(outers(plan))
     try catalog.expect(sql + " ORDER BY 1",
                        yields: [[100, 21], [300, nil]])
   }
 
-  /// (8b) An unreplaced projection term keeps its ORIGINAL source slot as the
+  /// (8b) An unreplaced projection term keeps its original source slot as the
   /// scalar joins stack after it: `T.fk1` (source slot 0) still reads correctly
   /// beside the two decorrelated scalars whose joins append columns after it.
   @Test func `an unreplaced term keeps its slot under stacked joins`() throws {
@@ -2178,7 +2178,7 @@ struct DecorrelateScalarTests {
     try catalog.expect(sql, yields: [[1, 100, 300]])
   }
 
-  /// (9) SCALAR IN WHERE stays correlated (the v1 non-projection cut) and runs
+  /// (9) scalar IN WHERE stays correlated (the v1 non-projection cut) and runs
   /// correctly: only `fk` 1 has `R.Id = 1` with `v = 100`, so the predicate
   /// `(SELECT …) = 100` admits it alone.
   @Test func `a scalar subquery in WHERE stays correlated`() throws {
@@ -2190,13 +2190,13 @@ struct DecorrelateScalarTests {
   }
 }
 
-// MARK: - Scalar subquery excluded bodies: STAY correlated, run correctly
+// MARK: - Scalar subquery excluded bodies: stay correlated, run correctly
 
 /// The G3 exclusions the scalar recogniser shares with the semijoin/apply
 /// paths — a body that is not the canonical filter+project over a single base
 /// scan — plus the uniqueness cut. Each stays a `.subquery` and runs correctly.
 struct DecorrelateScalarExclusionTests {
-  /// (7a) AGGREGATE body: a `MAX(R.v)` body is not a bare-`.slot` projection
+  /// (7a) aggregate body: a `MAX(R.v)` body is not a bare-`.slot` projection
   /// over a plain scan, so it stays a `.subquery` — and runs correctly (fk 1 →
   /// MAX over the one matching R row).
   @Test func `an aggregate body stays a subquery`() throws {
@@ -2214,7 +2214,7 @@ struct DecorrelateScalarExclusionTests {
     try catalog.expect(sql, yields: [[100]])
   }
 
-  /// (7b) NON-EQUI correlation (`R.Id > T.fk`): no equi key to hash on, so it
+  /// (7b) non-equi correlation (`R.Id > T.fk`): no equi key to hash on, so it
   /// stays a `.subquery`. fk 2 sees R.Id ∈ {3} > 2 — one row (v = 300); a run
   /// is correct.
   @Test func `a non-equi correlation stays a subquery`() throws {
@@ -2277,7 +2277,7 @@ struct DecorrelateScalarExclusionTests {
     try catalog.expect(sql, yields: [[100]])
   }
 
-  /// (7f) BODY-LOCAL DERIVED table: the body reads its OWN derived `e` over R,
+  /// (7f) body-local derived table: the body reads its own derived `e` over R,
   /// a per-execution materialised alias the set-based rewrite cannot relay, so
   /// it stays a `.subquery` — and runs correctly.
   @Test func `a body-local derived table stays a subquery`() throws {
@@ -2309,7 +2309,7 @@ struct DecorrelateScalarExclusionTests {
     try catalog.expect(sql + " ORDER BY v", yields: [[nil], [100]])
   }
 
-  /// (10) NULL CORRELATION KEY → NULL: a NULL `fk` makes the `.match` UNKNOWN,
+  /// (10) NULL correlation KEY → NULL: a NULL `fk` makes the `.match` UNKNOWN,
   /// so the LEFT join NULL-extends and the coalesce passes NULL through —
   /// identical to the per-row `WHERE R.Id = :outer` (`:outer` NULL) empty →
   /// NULL. Decorrelated (an `.outer`) and correct.
@@ -2332,7 +2332,7 @@ struct DecorrelateScalarExclusionTests {
 // MARK: - Non-`Id` first virtual: the width-ordinal virtual is NOT unique
 
 /// A minimal `Table` whose FIRST virtual is NOT `Id` — its width-ordinal
-/// virtual is a NON-unique `Owner` — beside the standard `Id`-at-`width`
+/// virtual is a non-unique `Owner` — beside the standard `Id`-at-`width`
 /// fixture the builders always vend.
 ///
 /// The `Table.virtuals` contract permits a conformer whose first virtual is not
@@ -2342,11 +2342,11 @@ struct DecorrelateScalarExclusionTests {
 /// many rows and must raise `.cardinality`. The `FixtureCatalog` builders hard
 /// wire `Id` at `width`, so this hand-rolled adapter is the only way to model a
 /// non-`Id` width-ordinal virtual: it proves the scalar recogniser's uniqueness
-/// guard consults the virtual's NAME, not merely its ordinal.
+/// guard consults the virtual's name, not merely its ordinal.
 ///
 /// It carries one real column `v` (`width == 1`) and one virtual column (at
 /// ordinal `1`) named `virtual`. When `owners` holds a cell per row that is the
-/// virtual value — a value that MAY repeat, the many-match shape a unique `Id`
+/// virtual value — a value that may repeat, the many-match shape a unique `Id`
 /// never produces; when `owners` is empty the virtual is the 1-based `Id`.
 private struct OwnerRelation: Sendable {
   /// The real `v` cell of each row, in row order.
@@ -2357,7 +2357,7 @@ private struct OwnerRelation: Sendable {
   let virtual: String
 
   /// The virtual cell each row computes, in row order, or empty for the 1-based
-  /// `Id`. A stored cell MAY repeat, so a scalar keyed on it can match many.
+  /// `Id`. A stored cell may repeat, so a scalar keyed on it can match many.
   let owners: Array<Value>
 }
 
@@ -2385,7 +2385,7 @@ private struct OwnerCatalog: Catalog {
   func views() -> Array<String> { [] }
 }
 
-/// A `Table` with real columns `names` and ONE virtual column `virtual` at
+/// A `Table` with real columns `names` and one virtual column `virtual` at
 /// ordinal `width`. When `owners` is empty the virtual is the 1-based `Id`;
 /// when it holds a cell per row the virtual reads that cell — a value that may
 /// repeat.
@@ -2456,14 +2456,14 @@ private struct OwnerRow: SQLEngine.Row {
   }
 }
 
-/// The reviewer's scenario: a relation whose FIRST virtual is a NON-unique
+/// The reviewer's scenario: a relation whose FIRST virtual is a non-unique
 /// `Owner` (at ordinal `== width`) must NOT decorrelate a scalar keyed on it —
-/// the guard must consult the virtual's NAME, not merely its ordinal. Were it
+/// the guard must consult the virtual's name, not merely its ordinal. Were it
 /// to lift the scalar into a LEFT join, a key matching many rows would emit the
 /// values rather than raising `.cardinality`: silent corruption.
 struct DecorrelateScalarVirtualTests {
-  /// A scalar keyed on the non-`Id` width-ordinal virtual STAYS correlated: the
-  /// optimised plan keeps the `.subquery` term and gains NO `.outer` from it.
+  /// A scalar keyed on the non-`Id` width-ordinal virtual stays correlated: the
+  /// optimised plan keeps the `.subquery` term and gains no `.outer` from it.
   @Test func `a non-Id width-ordinal virtual stays correlated`() throws {
     let catalog = OwnerCatalog(
         parents: [.integer(7), .integer(9)],
@@ -2477,7 +2477,7 @@ struct DecorrelateScalarVirtualTests {
     try catalog.expect(sql + " ORDER BY v", yields: [[nil], [100]])
   }
 
-  /// When an outer row's `fk` matches MORE THAN ONE R row on the non-unique
+  /// When an outer row's `fk` matches more than one R row on the non-unique
   /// `Owner`, the correlated per-row scalar raises `.cardinality` — the fault a
   /// wrongly-lifted LEFT join would silence by emitting both values.
   @Test func `a many-match non-Id virtual raises cardinality`() throws {
@@ -2492,8 +2492,8 @@ struct DecorrelateScalarVirtualTests {
     catalog.expect(sql, fails: .cardinality)
   }
 
-  /// POSITIVE CONTROL: the SAME adapter shape keyed on a genuine `Id` virtual
-  /// (its first virtual IS `Id`) still DOES decorrelate — the guard did not
+  /// positive control: the same adapter shape keyed on a genuine `Id` virtual
+  /// (its first virtual IS `Id`) still does decorrelate — the guard did not
   /// over-tighten. The virtual here is the row's 1-based `Id`, so `fk` 1 reads
   /// R's row 1.
   @Test func `an Id width-ordinal virtual still decorrelates`() throws {

--- a/Tests/SQLTests/Optimisation/DistinctFoldTests.swift
+++ b/Tests/SQLTests/Optimisation/DistinctFoldTests.swift
@@ -8,10 +8,10 @@ import SQLTestSupport
 
 // MARK: - Fixtures
 
-/// A single-relation catalog whose `a` REPEATS across rows differing only in
+/// A single-relation catalog whose `a` repeats across rows differing only in
 /// `b` — the adversarial fixture: a `SELECT DISTINCT a` projects the whole row
-/// down to `a`, COLLAPSING two distinct rows to one value, so the `.distinct`
-/// MUST be kept or the result would leak the duplicate `a`.
+/// down to `a`, collapsing two distinct rows to one value, so the `.distinct`
+/// must be kept or the result would leak the duplicate `a`.
 private func collapsing() throws -> FixtureCatalog {
   try Catalog {
     Relation("D", ["a": .integer, "b": .integer]) {
@@ -34,7 +34,7 @@ private func numbers() throws -> FixtureCatalog {
 }
 
 /// Whether `plan` reaches ANY `.distinct` node — the dedup the optimiser drops
-/// when its source is PROVABLY distinct. Mirrors `ConstantFoldTests`'s
+/// when its source is provably distinct. Mirrors `ConstantFoldTests`'s
 /// `selects`/`empties`, recursing every operator so a `.distinct` nested under
 /// a project/aggregate/set-op arm is still found.
 private func distincts(_ plan: Plan) -> Bool {
@@ -72,17 +72,17 @@ private func distincts(_ plan: Plan) -> Bool {
 
 // MARK: - Plan.unique unit tests
 
-/// `Plan.unique` is the SOUND, CONSERVATIVE full-row-distinctness property the
-/// optimiser drops a `.distinct` on: `true` only when the plan PROVABLY yields
+/// `Plan.unique` is the sound, conservative full-row-distinctness property the
+/// optimiser drops a `.distinct` on: `true` only when the plan provably yields
 /// no two equal full rows, `false` for anything whose distinctness is not
 /// certain (a `scan` multiset, a fan-out join, an `all` set operation, or a
-/// column-dropping project). An over-claim here would LEAK duplicates.
+/// column-dropping project). An over-claim here would leak duplicates.
 struct PlanUniqueTests {
   /// A width-1 scan of `D.a` — a base relation, so NOT provably unique.
   private let scan = Plan.scan(name: "D", ordinals: [0], seek: nil)
 
   @Test func `a base scan is not unique`() {
-    // A SQL table is a MULTISET — a duplicate row is possible and no unique key
+    // A SQL table is a multiset — a duplicate row is possible and no unique key
     // is tracked — so a scan is conservatively non-unique.
     #expect(!scan.unique)
   }
@@ -129,13 +129,13 @@ struct PlanUniqueTests {
   }
 
   @Test func `a product and a join are not unique`() {
-    // A pairing operator can MULTIPLY rows — one row paired with many — so
+    // A pairing operator can multiply rows — one row paired with many — so
     // it is never provably distinct here.
     #expect(!Plan.product(Plan.distinct(scan), Plan.distinct(scan)).unique)
   }
 
   @Test func `an injective project over a unique source is unique`() {
-    // A permutation/renaming reading EVERY source slot retains all columns, so
+    // A permutation/renaming reading every source slot retains all columns, so
     // two distinct source rows stay distinct — injective. Over a `distinct`
     // source (width 1), a project reading slot 0 covers the whole row.
     let unique = Plan.distinct(scan)
@@ -143,7 +143,7 @@ struct PlanUniqueTests {
   }
 
   @Test func `a column-dropping project is not unique`() {
-    // Dropping a source column can COLLAPSE distinct rows: an aggregate of two
+    // Dropping a source column can collapse distinct rows: an aggregate of two
     // key columns projected down to the first loses the second, so two rows
     // differing only in it become equal. Not covering every source slot ⇒ not
     // unique.
@@ -151,7 +151,7 @@ struct PlanUniqueTests {
         Plan.aggregate(keys: [.slot(0), .slot(1)], aggregates: [], scan)
     #expect(grouped.unique)
     #expect(!Plan.project([.slot(0)], grouped).unique)
-    // Reading BOTH slots (a full permutation) stays unique.
+    // Reading both slots (a full permutation) stays unique.
     #expect(Plan.project([.slot(1), .slot(0)], grouped).unique)
   }
 
@@ -166,8 +166,8 @@ struct PlanUniqueTests {
 
 // MARK: - Optimiser fold: DISTINCT elimination
 
-/// The optimiser DROPS a `.distinct` whose source is PROVABLY distinct
-/// (identical result, one fewer dedup) and KEEPS it over any source that could
+/// The optimiser drops a `.distinct` whose source is provably distinct
+/// (identical result, one fewer dedup) and keeps it over any source that could
 /// hold a duplicate full row.
 struct DistinctFoldTests {
   /// The optimised plan for `sql` against `catalog`, through the full
@@ -202,17 +202,17 @@ struct DistinctFoldTests {
   }
 
   @Test func `DISTINCT over a projecting scan KEEPS the dedup`() throws {
-    // The adversarial must-KEEP case. `SELECT DISTINCT a FROM D` projects the
-    // whole (a, b) row down to `a`, which REPEATS (rows (1,10) and (1,20)), so
-    // the projection COLLAPSES two distinct rows to one value — the `.distinct`
+    // The adversarial must-keep case. `SELECT DISTINCT a FROM D` projects the
+    // whole (a, b) row down to `a`, which repeats (rows (1,10) and (1,20)), so
+    // the projection collapses two distinct rows to one value — the `.distinct`
     // is the only thing removing the duplicate. Its source is a base scan (not
-    // unique), so the fold MUST keep it.
+    // unique), so the fold must keep it.
     let catalog = try collapsing()
     #expect(distincts(try optimised(catalog, "SELECT DISTINCT a FROM D")))
   }
 
   @Test func `DISTINCT over a projecting scan actually deduplicates`() throws {
-    // The result proof behind the must-KEEP shape: `a` is `[1, 1, 2]` in the
+    // The result proof behind the must-keep shape: `a` is `[1, 1, 2]` in the
     // rows, so a correct DISTINCT yields `[1, 2]`. Removing the dedup would
     // leak the duplicate `1`, changing the row multiset.
     try collapsing().expect("SELECT DISTINCT a FROM D ORDER BY a",
@@ -221,7 +221,7 @@ struct DistinctFoldTests {
 
   @Test func `DISTINCT over a full-row scan projection KEEPS the dedup`()
       throws {
-    // Even a project reading BOTH scan columns is injective but its SOURCE (the
+    // Even a project reading both scan columns is injective but its source (the
     // scan) is a multiset — a duplicate whole row is possible — so the fold
     // keeps the dedup. The scan, not the projection, is the non-unique link.
     let catalog = try collapsing()
@@ -239,7 +239,7 @@ struct DistinctFoldTests {
       Issue.record("expected a single distinct, got \(plan)")
       return
     }
-    // Exactly ONE distinct survives: the inner is the bare scan, not a nested
+    // Exactly one distinct survives: the inner is the bare scan, not a nested
     // second distinct.
     #expect(!distincts(inner))
   }
@@ -257,7 +257,7 @@ struct DistinctFoldTests {
   }
 
   @Test func `DISTINCT over a UNION ALL KEEPS the dedup`() throws {
-    // The set-operation must-KEEP case: `UNION ALL` is a MULTISET that keeps
+    // The set-operation must-keep case: `UNION ALL` is a multiset that keeps
     // duplicates, so a `.distinct` over it is NOT redundant — the fold must
     // keep it or the duplicates leak.
     let catalog = try collapsing()

--- a/Tests/SQLTests/Queries/AggregateDistinctFilterTests.swift
+++ b/Tests/SQLTests/Queries/AggregateDistinctFilterTests.swift
@@ -59,7 +59,7 @@ struct AggregateDistinctTests {
   @Test func `DISTINCT is a no-op for MIN and MAX`() throws {
     // The least/greatest value is unchanged by duplicates, so a MIN/MAX honours
     // DISTINCT as a no-op — MIN 10, MAX 30 either way. The DISTINCT form
-    // normalises the quantifier OFF, so it never builds the `seen` dedup set
+    // normalises the quantifier off, so it never builds the `seen` dedup set
     // (an O(1) streaming fold, not O(distinct-values) memory), yet must still
     // agree cell for cell with the plain form.
     try orders().expect("""
@@ -70,7 +70,7 @@ struct AggregateDistinctTests {
   }
 
   @Test func `MIN and MAX DISTINCT agree with the plain form over duplicates`() throws {
-    // A group whose extreme values (10 and 30) are DUPLICATED many times: the
+    // A group whose extreme values (10 and 30) are duplicated many times: the
     // MIN/MAX(DISTINCT) fold does not dedup (it keeps no `seen` set), so its
     // memory does not grow with the group, and its result matches the plain
     // MIN/MAX — the extreme is the same with or without duplicates. Grouped so
@@ -109,14 +109,14 @@ struct AggregateDistinctTests {
   }
 }
 
-/// A pair of one-column relations whose values CANONICALISE across the two
+/// A pair of one-column relations whose values canonicalise across the two
 /// kinds: `Ints` holds the exact integers `Int.max` and `1`, `Reals` the double
 /// `1.0` (equal to the integer `1` under `canonical`). Two views `UNION ALL`
 /// them into a single `V` column mixing integer and double cells — `IntFirst`
 /// with the integers before the double, `RealFirst` the reverse — so a
 /// `SUM(DISTINCT …)` over either dedups `1` and `1.0` to one value while the
 /// distinct integer total (`Int.max + 1`) overflows `Int`. An int-first order
-/// must still WIDEN to the finite double a double-first order gives, the
+/// must still widen to the finite double a double-first order gives, the
 /// order-independence a skipped double duplicate must not defeat.
 private func mixed() throws -> FixtureCatalog {
   try Catalog {
@@ -149,7 +149,7 @@ struct AggregateDistinctWideningTests {
     // duplicate skipped for the sum — but it must still set the widen flag,
     // else the all-integer total Int.max + 1 overflows. Double-first: 1.0 folds
     // and widens, Int.max folds, then 1 is the skipped duplicate. Both must
-    // yield the SAME finite double.
+    // yield the same finite double.
     try mixed().expect("SELECT SUM(DISTINCT V) FROM IntFirst",
                        yields: [[widened]])
     try mixed().expect("SELECT SUM(DISTINCT V) FROM RealFirst",
@@ -232,7 +232,7 @@ struct AggregateFilterUnreachableOperandTests {
   @Test func `a constant-false FILTER makes the operand unreachable`() throws {
     // The executor evaluates the FILTER before the argument, so a definitely-
     // false gate means `1 / 0` never divides: the query validates (no fault on
-    // the dead operand) and RUNS to the empty aggregate result (NULL).
+    // the dead operand) and runs to the empty aggregate result (NULL).
     let sql = "SELECT SUM(1 / 0) FILTER (WHERE 1 = 0) FROM Orders"
     _ = try orders().columns(of: Statement(parsing: sql))
     try orders().expect(sql, yields: [[nil]])
@@ -261,7 +261,7 @@ struct AggregateFilterUnreachableOperandTests {
   }
 
   // A FILTER that folds definitely UNKNOWN — a constant NULL comparison, here
-  // `NULLIF(1, 1) = 1` whose left side folds to NULL — is treated the SAME as a
+  // `NULLIF(1, 1) = 1` whose left side folds to NULL — is treated the same as a
   // constant-false one: the executor's gate admits a row only on a definite
   // TRUE, so an UNKNOWN gate also admits no row and leaves the operand
   // unreachable. Validation matches that, so `SUM(1 / 0)` behind it validates
@@ -274,9 +274,9 @@ struct AggregateFilterUnreachableOperandTests {
     try orders().expect(sql, yields: [[nil]])
   }
 
-  // A settled-non-TRUE CONJUNCT kills the whole conjunction: an AND is TRUE
-  // only if EVERY conjunct is, so a row-independently non-TRUE conjunct means
-  // no row can pass the gate even when a SIBLING conjunct is per row. Here
+  // A settled-non-TRUE conjunct kills the whole conjunction: an AND is TRUE
+  // only if every conjunct is, so a row-independently non-TRUE conjunct means
+  // no row can pass the gate even when a sibling conjunct is per row. Here
   // `NULLIF(1, 1) = 1` folds definitely UNKNOWN (NULLIF(1,1) is NULL, NULL = 1
   // is UNKNOWN) while `Amount > 0` is per row — the filter is still dead, so
   // `SUM(1 / 0)` behind it validates and runs to NULL rather than faulting.
@@ -300,7 +300,7 @@ struct AggregateFilterUnreachableOperandTests {
   }
 
   // The proof is order-independent — the AND spine is flattened, so a
-  // settled-non-TRUE conjunct SECOND kills the filter as one first does.
+  // settled-non-TRUE conjunct second kills the filter as one first does.
   @Test func `a settled-FALSE conjunct kills the FILTER in either order`() throws {
     let sql = """
         SELECT SUM(1 / 0) FILTER (WHERE Amount > 0 AND 1 = 0) FROM Orders

--- a/Tests/SQLTests/Queries/AggregateTests.swift
+++ b/Tests/SQLTests/Queries/AggregateTests.swift
@@ -111,7 +111,7 @@ struct AggregateTests {
 
   @Test func `mixed integer/double group keys canonicalize into one group`() throws {
     // A column carrying both 1 and 1.0 — as a CTE/UNION ALL or any source can —
-    // groups them together under the engine's EXACT numeric equality (the same
+    // groups them together under the engine's exact numeric equality (the same
     // `1` = `1.0` UNION dedup uses), yielding one group of two keyed by the
     // first-appearance integer, not two one-row groups.
     let catalog = try Catalog {
@@ -293,7 +293,7 @@ struct AggregateTests {
   }
 
   @Test func `ORDER BY orders on a computed-expression alias`() throws {
-    // `Doubled` aliases a COMPUTED value; the sort now evaluates the alias's
+    // `Doubled` aliases a computed value; the sort now evaluates the alias's
     // grouped term per row — recomputing `COUNT(*) * 2` from the group's
     // aggregate slot — rather than reading a standalone slot, so ordering on a
     // computed alias works. Books 6, Games 6 (a tie, stable by group order),
@@ -428,7 +428,7 @@ struct AggregateTests {
   @Test func `an aggregate argument's CASE guard reads the query bindings`() throws {
     // `SUM(CASE WHEN Region = :target THEN Amount ELSE 0 END)` folds a CASE
     // whose guard names a `:parameter`; the execution bindings must reach the
-    // aggregate ARGUMENT the same as a projection or WHERE, or `:target` is
+    // aggregate argument the same as a projection or WHERE, or `:target` is
     // unbound, the guard is UNKNOWN for every row, the ELSE 0 always wins, and
     // the SUM collapses to 0. Bound to `East`, only the East amounts fold —
     // 10 + 20 + 40 (Toys/East is NULL, skipped) = 70 — neither 0 (the unbound

--- a/Tests/SQLTests/Queries/DerivedColumnListTests.swift
+++ b/Tests/SQLTests/Queries/DerivedColumnListTests.swift
@@ -83,7 +83,7 @@ struct DerivedColumnListExecutionTests {
   }
 
   @Test func `a derived table renames columns the inner never named`() throws {
-    // The list names the OUTPUT columns positionally regardless of the inner
+    // The list names the output columns positionally regardless of the inner
     // spelling — here the inner projects bare `x`, `y`, renamed to `a`, `b`.
     try fixture().expect(
         "SELECT b FROM (SELECT x, y FROM S) AS d(a, b) ORDER BY a",
@@ -192,9 +192,9 @@ struct ColumnListFaultTests {
 struct LateralColumnListTests {
   @Test func `a column list renames a lateral body's duplicate inner names`()
       throws {
-    // The reviewer's case: the body projects `T.Id AS x` TWICE — a duplicate
-    // INNER name the `d(a, b)` list renames positionally to the unique EXPOSED
-    // `a`, `b`. The compile-path validation in `lateral` must check the RENAMED
+    // The reviewer's case: the body projects `T.Id AS x` twice — a duplicate
+    // INNER name the `d(a, b)` list renames positionally to the unique exposed
+    // `a`, `b`. The compile-path validation in `lateral` must check the renamed
     // names, so this runs (both columns = `T.Id`) rather than faulting the
     // inner duplicate — parity with the schema pass.
     try fixture().expect(
@@ -226,9 +226,9 @@ struct LateralColumnListTests {
 
   @Test func `a lateral column list with a duplicate exposed name faults`()
       throws {
-    // A duplicate in the EXPOSED list leaves a renamed column unreachable, so
+    // A duplicate in the exposed list leaves a renamed column unreachable, so
     // it still faults `SQLError.duplicate` — the check runs against the renamed
-    // names, and here THEY collide.
+    // names, and here they collide.
     try fixture().expect(
         "SELECT d.a FROM T " +
         "JOIN LATERAL (SELECT T.Id, T.V) AS d(a, a) ON 1 = 1",

--- a/Tests/SQLTests/Queries/DerivedTableTests.swift
+++ b/Tests/SQLTests/Queries/DerivedTableTests.swift
@@ -8,7 +8,7 @@ import SQLTestSupport
 
 // MARK: - Fixture
 
-/// Two relations exercising the uncorrelated DERIVED TABLE: an outer keyed `T`
+/// Two relations exercising the uncorrelated derived TABLE: an outer keyed `T`
 /// and a source `S` whose `V` a derived table projects/aggregates, plus a `K`
 /// keyed on `T` for the JOIN case.
 private func fixture() throws -> FixtureCatalog {
@@ -159,7 +159,7 @@ struct DerivedTableExecutionTests {
   }
 
   @Test func `a derived table equals its inner query renamed`() throws {
-    // The derived table's rows ARE the inner query's rows, so selecting through
+    // The derived table's rows are the inner query's rows, so selecting through
     // the alias equals selecting the inner query directly.
     try fixture().expect(
         "SELECT a FROM (SELECT V AS a FROM S) AS t ORDER BY a",
@@ -262,11 +262,11 @@ struct DerivedTableSchemaTests {
 
 // MARK: - Duplicate derived output columns
 
-/// A derived table's columns are its inner query's OUTPUT names (the ISO rule),
+/// A derived table's columns are its inner query's output names (the ISO rule),
 /// so two same-named ones leave the shadowed column unreachable through the
 /// alias — the same case the Parser rejects for a view's or a CTE's inferred
-/// column list. A derived table faults it the SAME way (`SQLError.duplicate`),
-/// at BOTH `columns(of:)` and a run.
+/// column list. A derived table faults it the same way (`SQLError.duplicate`),
+/// at both `columns(of:)` and a run.
 struct DerivedTableDuplicateColumnTests {
   @Test func `a duplicate derived output column faults the run`() throws {
     // `(SELECT Id AS x, V AS x FROM T) AS d` exposes `x` twice; `d.x` would
@@ -290,7 +290,7 @@ struct DerivedTableDuplicateColumnTests {
   }
 
   @Test func `distinct derived output columns resolve`() throws {
-    // Control: two DIFFERENTLY named output columns resolve fine — the check
+    // Control: two differently named output columns resolve fine — the check
     // fires only on a genuine same-name collision.
     try fixture().expect(
         "SELECT d.x, d.y FROM (SELECT Id AS x, V AS y FROM T) AS d " +
@@ -301,17 +301,17 @@ struct DerivedTableDuplicateColumnTests {
 
 // MARK: - Duplicate same-scope derived aliases
 
-/// Two derived tables sharing an alias in ONE SELECT's own FROM/JOIN collide:
+/// Two derived tables sharing an alias in one SELECT's own FROM/JOIN collide:
 /// the alias-keyed overlay would rebind the earlier under the later, so both
 /// FROM items resolve to the later's rows. This matches the existing duplicate
-/// RELATION alias behavior (`FROM T AS d JOIN S AS d`, which makes a shared
+/// relation alias behavior (`FROM T AS d JOIN S AS d`, which makes a shared
 /// column `SQLError.ambiguous`) rather than silently rebinding — the collision
-/// is caught when augmenting THIS SELECT's own derived tables, so a nested or
-/// sibling subquery's same-named alias (a DIFFERENT SELECT) is unaffected.
+/// is caught when augmenting this SELECT's own derived tables, so a nested or
+/// sibling subquery's same-named alias (a different SELECT) is unaffected.
 struct DerivedTableDuplicateAliasTests {
   @Test func `duplicate derived aliases fault ambiguous at the run`() throws {
     // `(SELECT Id AS a FROM T) AS d JOIN (SELECT V AS b FROM S) AS d` — a
-    // single SELECT with two derived tables aliased `d`. Faults the ALIAS
+    // single SELECT with two derived tables aliased `d`. Faults the alias
     // ambiguous rather than letting the later derived `d(b)` rebind over the
     // earlier `d(a)`.
     try fixture().expect(
@@ -334,7 +334,7 @@ struct DerivedTableDuplicateAliasTests {
   @Test func `a duplicate base-table alias's shared column stays ambiguous`()
       throws {
     // The behavior the derived case matches: two base relations sharing the
-    // alias `d` leave BOTH in scope, so a shared column is `SQLError.ambiguous`
+    // alias `d` leave both in scope, so a shared column is `SQLError.ambiguous`
     // — the same ambiguity family the derived collision now raises.
     try fixture().expect(
         "SELECT d.Id FROM T AS d JOIN S AS d ON 1 = 1",
@@ -342,8 +342,8 @@ struct DerivedTableDuplicateAliasTests {
   }
 
   @Test func `distinct derived aliases in one SELECT both resolve`() throws {
-    // Control: two derived tables with DIFFERENT aliases in one SELECT's
-    // FROM/JOIN each resolve to their OWN columns — no collision.
+    // Control: two derived tables with different aliases in one SELECT's
+    // FROM/JOIN each resolve to their own columns — no collision.
     try fixture().expect(
         "SELECT c.a, d.b FROM (SELECT Id AS a FROM T) AS c " +
         "JOIN (SELECT V AS b FROM S) AS d ON c.a = 1 ORDER BY d.b",
@@ -353,19 +353,19 @@ struct DerivedTableDuplicateAliasTests {
 
 // MARK: - A derived alias colliding with a same-scope base relation
 
-/// A derived table's alias sharing a RANGE NAME with a BASE/named relation in
-/// the SAME SELECT's FROM/JOIN is a duplicate range name: the alias-keyed
-/// overlay binds the derived rows under that name, which would SHADOW the base
+/// A derived table's alias sharing a range name with a base/named relation in
+/// the same SELECT's FROM/JOIN is a duplicate range name: the alias-keyed
+/// overlay binds the derived rows under that name, which would shadow the base
 /// scan — `FROM T JOIN (SELECT V AS a FROM S) AS T` would resolve the base `T`
-/// to the derived rows. This is the same ambiguity family a duplicate RELATION
-/// alias (`FROM T AS d JOIN S AS d`) raises, and it faults at BOTH `columns(of:
-/// )` and a run, BEFORE binding the derived rows, so the base is never
+/// to the derived rows. This is the same ambiguity family a duplicate relation
+/// alias (`FROM T AS d JOIN S AS d`) raises, and it faults at both `columns(of:
+/// )` and a run, before binding the derived rows, so the base is never
 /// shadowed.
 struct DerivedTableBaseAliasCollisionTests {
   @Test func `a derived alias colliding with a base relation faults the run`()
       throws {
     // The reviewer's case: a derived table aliased `T` in a JOIN collides with
-    // the base `FROM T` of the same SELECT. Faults the ALIAS ambiguous rather
+    // the base `FROM T` of the same SELECT. Faults the alias ambiguous rather
     // than binding the derived `T(a)` over the base `T` scan.
     try fixture().expect(
         "SELECT a FROM T JOIN (SELECT V AS a FROM S) AS T ON 1 = 1",
@@ -404,7 +404,7 @@ struct DerivedTableBaseAliasCollisionTests {
   }
 
   @Test func `a derived alias colliding with a named alias faults`() throws {
-    // The collision is on the RANGE NAME a qualified reference uses, so a base
+    // The collision is on the range name a qualified reference uses, so a base
     // relation renamed `d` (`FROM S AS d`) collides with a derived table
     // aliased `d` too — not the base's spelling `S`.
     try fixture().expect(
@@ -414,7 +414,7 @@ struct DerivedTableBaseAliasCollisionTests {
 
   @Test func `a derived alias not colliding with any base resolves`() throws {
     // Control: a derived alias `d` that no FROM/JOIN range name shares resolves
-    // — both its OWN column (`d.a`) and the sibling base relation's (`T.V`).
+    // — both its own column (`d.a`) and the sibling base relation's (`T.V`).
     try fixture().expect(
         "SELECT d.a, T.V FROM T JOIN (SELECT V AS a FROM S) AS d " +
         "ON d.a = T.V ORDER BY T.V",
@@ -424,8 +424,8 @@ struct DerivedTableBaseAliasCollisionTests {
   @Test func `a derived alias equal to an outer relation is not a collision`()
       throws {
     // Scoping, not a same-scope collision: an EXISTS subquery's derived table
-    // aliased `T` sits in its OWN SELECT, whose only FROM range is that derived
-    // `T` — the enclosing `FROM T` is a DIFFERENT SELECT's range. The inner `T`
+    // aliased `T` sits in its own SELECT, whose only FROM range is that derived
+    // `T` — the enclosing `FROM T` is a different SELECT's range. The inner `T`
     // shadows the outer per normal scoping, so `t.a` reads the derived rows and
     // no duplicate-range fault fires.
     try fixture().expect(
@@ -437,12 +437,12 @@ struct DerivedTableBaseAliasCollisionTests {
 
   @Test func `a derived alias colliding with an aliased base's source faults`()
       throws {
-    // The base `T` is ALIASED `x`, so its EXPOSED range name is `x`, not `T` —
-    // yet `resolve` looks the named relation up by its SOURCE name `T` in the
+    // The base `T` is aliased `x`, so its exposed range name is `x`, not `T` —
+    // yet `resolve` looks the named relation up by its source name `T` in the
     // overlay. A derived table aliased `T` would bind under `T` and capture the
     // `T AS x` scan (which keys on `T`), so `x.V` fails or both sides scan the
-    // derived rows. Fault the ALIAS ambiguous on the source-name collision,
-    // BEFORE binding the derived rows.
+    // derived rows. Fault the alias ambiguous on the source-name collision,
+    // before binding the derived rows.
     try fixture().expect(
         "SELECT x.V FROM T AS x JOIN (SELECT V AS a FROM S) AS T ON 1 = 1",
         fails: .ambiguous("T"))
@@ -494,11 +494,11 @@ struct DerivedTableBaseAliasCollisionTests {
 struct DerivedTableScopingTests {
   @Test func `sibling EXISTS subqueries reuse an alias without colliding`()
       throws {
-    // Two INDEPENDENT derived tables share the alias `t` in two separate
-    // `EXISTS` subqueries, each with DIFFERENT columns (`a` from `S`, `b` from
+    // Two independent derived tables share the alias `t` in two separate
+    // `EXISTS` subqueries, each with different columns (`a` from `S`, `b` from
     // `K`). A statement-global overlay bound only the FIRST `t`, so the second
     // `EXISTS`'s `t.b` would mis-resolve to the first `t` (no `b`) and fault.
-    // SELECT-scoped, each `t` resolves to its OWN derived table: both
+    // SELECT-scoped, each `t` resolves to its own derived table: both
     // subqueries are TRUE (S has V=10, K has k=1), so every `T` row is kept.
     try fixture().expect(
         "SELECT Id FROM T " +
@@ -511,7 +511,7 @@ struct DerivedTableScopingTests {
 
   @Test func `sibling derived tables reuse an alias reading their own rows`()
       throws {
-    // Each sibling `t` reads its OWN rows: the first `EXISTS` filters `t.a` to
+    // Each sibling `t` reads its own rows: the first `EXISTS` filters `t.a` to
     // a value only `S` has (30) and the second `t.b` to one only `K` has (2),
     // so both hold and the outer query keeps its row — proof each `t` bound its
     // own materialised relation, not a shared one.
@@ -527,7 +527,7 @@ struct DerivedTableScopingTests {
   @Test func `an inner derived table shadows an outer CTE of the same name`()
       throws {
     // A CTE `t` is in scope statement-wide, but a derived table aliased `t` in
-    // an inner `FROM` SHADOWS it within that SELECT: the derived `t(a)` reads
+    // an inner `FROM` shadows it within that SELECT: the derived `t(a)` reads
     // `S`'s `V` renamed, not the CTE's single row `99`. So `SELECT a` yields
     // the three `S` values, never the CTE's `99` (no column `a`). A `WITH` is
     // a statement, so run it through the statement entry rather than the
@@ -542,17 +542,17 @@ struct DerivedTableScopingTests {
 
 // MARK: - A nested subquery's own derived alias shadows an enclosing one
 
-/// A nested subquery's OWN derived alias must SHADOW an enclosing same-named
-/// derived table, resolving its OWN body's columns rather than the outer one's.
+/// A nested subquery's own derived alias must shadow an enclosing same-named
+/// derived table, resolving its own body's columns rather than the outer one's.
 /// Idempotence keys on the derivation's IDENTITY, not its name: an enclosing
 /// query's derived `t` in scope is re-materialised over by the subquery's own
-/// `t` (a DIFFERENT inner query), while a re-augment of THIS query's SAME
+/// `t` (a different inner query), while a re-augment of this query's same
 /// derivation is left in place — and a same-named CTE stays visible.
 struct DerivedTableNestedShadowTests {
   @Test func `a nested EXISTS subquery derived alias shadows an outer one`()
       throws {
     // The outer `FROM (SELECT Id AS x FROM T) AS t` binds a derived `t` with
-    // column `x`; the `EXISTS` subquery's OWN `FROM (SELECT V AS a FROM S) AS
+    // column `x`; the `EXISTS` subquery's own `FROM (SELECT V AS a FROM S) AS
     // t` binds a derived `t` with column `a`. The subquery's `WHERE t.a = 10`
     // must resolve the INNER `t` (column `a`, a value only `S`'s 10 has), never
     // the outer `t` (column `x`). Keying idempotence on the name skipped the
@@ -568,7 +568,7 @@ struct DerivedTableNestedShadowTests {
 
   @Test func `the nested-shadow query advertises the outer schema`() throws {
     // Schema ↔ run parity: `columns(of:)` resolves the inner `t.a` too (never
-    // faulting on the outer `t`'s missing `a`), and the RESULT columns are the
+    // faulting on the outer `t`'s missing `a`), and the result columns are the
     // OUTER query's projection `x` — the enclosing derived `t`'s column.
     let query = try parse(query:
         "SELECT x FROM (SELECT Id AS x FROM T) AS t " +
@@ -579,7 +579,7 @@ struct DerivedTableNestedShadowTests {
   }
 
   @Test func `a nested EXISTS shadow reads the inner rows`() throws {
-    // The inner `t` reads ITS own rows, not the outer's: `WHERE t.a = 30`
+    // The inner `t` reads its own rows, not the outer's: `WHERE t.a = 30`
     // filters to a value only `S` has (30), so the subquery holds; had it
     // resolved the outer `t` (column `x` = the `Id`s 1, 2, 3), `t.a` would
     // fault. One outer row is kept.
@@ -592,7 +592,7 @@ struct DerivedTableNestedShadowTests {
 
   @Test func `a nested scalar subquery derived alias shadows an outer one`()
       throws {
-    // A SCALAR-subquery variant: the outer `FROM (SELECT Id AS x FROM T) AS t`
+    // A scalar-subquery variant: the outer `FROM (SELECT Id AS x FROM T) AS t`
     // binds derived `t(x)`; the projection's scalar `(SELECT MIN(t.a) FROM
     // (SELECT V AS a FROM S) AS t)` binds its OWN derived `t(a)`. The scalar's
     // `t.a` must resolve the INNER `t` (column `a`), yielding `S`'s minimum 10
@@ -610,7 +610,7 @@ struct DerivedTableNestingTests {
   @Test func `a derived table nested in a derived table resolves and runs`()
       throws {
     // `FROM (SELECT * FROM (SELECT V FROM S) AS x) AS y` — deriving `y`'s
-    // schema must FIRST bind its OWN inner derived table `x`, as the run does,
+    // schema must FIRST bind its own inner derived table `x`, as the run does,
     // or `x` resolves as unknown. Both the schema and the run resolve the
     // projected column `V` and read `S`'s rows through the two levels.
     let query =
@@ -639,8 +639,8 @@ struct DerivedTableNestingTests {
 struct DerivedTableSchemaParityTests {
   @Test func `a bad inner predicate faults the schema-only path`() throws {
     // The inner body's `WHERE Missing = 1` names an unknown column. The
-    // schema-only path (`validate: true`) compiles and type-checks the WHOLE
-    // inner body — not just the first-arm projection — so it FAULTS the unknown
+    // schema-only path (`validate: true`) compiles and type-checks the whole
+    // inner body — not just the first-arm projection — so it faults the unknown
     // column exactly as the run does, keeping schema/run parity.
     #expect(throws: SQLError.self) {
       let query = try parse(query:
@@ -671,7 +671,7 @@ struct DerivedTableSchemaParityTests {
   }
 
   @Test func `a valid inner body still advertises its schema`() throws {
-    // A derived table whose inner body has a WELL-FORMED predicate still
+    // A derived table whose inner body has a well-formed predicate still
     // reports its schema on the schema-only path — the whole-body validation
     // accepts exactly what runs, so a valid body is not rejected.
     let query = try parse(query:
@@ -686,8 +686,8 @@ struct DerivedTableSchemaParityTests {
     // A derived body whose projection `Label + 1` faults ONLY when type-checked
     // (text plus integer), guarded by `WHERE k = 0` so the run empties before
     // it evaluates. With `validate: false` — a derive after a successful run —
-    // the body is TRUSTED, so headers return WITHOUT the operand fault, exactly
-    // as the NON-derived path does (its empty run never evaluates the
+    // the body is trusted, so headers return without the operand fault, exactly
+    // as the non-derived path does (its empty run never evaluates the
     // projection). An earlier round validated the body unconditionally, so this
     // faulted `.operand` before returning headers.
     let query = try parse(query:
@@ -697,7 +697,7 @@ struct DerivedTableSchemaParityTests {
   }
 
   @Test func `validate true still faults a bad derived body`() throws {
-    // Parity with a run: with `validate: true` the SAME body still faults its
+    // Parity with a run: with `validate: true` the same body still faults its
     // ill-typed projection, so the schema path advertises no schema for a
     // derived table a run would fault once it reached the projection.
     #expect(throws: SQLError.self) {
@@ -710,18 +710,18 @@ struct DerivedTableSchemaParityTests {
 
 // MARK: - A run must not eager-type-check a derived body
 
-/// A RUN preflight (`compile`) must NOT eager-type-check a derived body: an
+/// A run preflight (`compile`) must NOT eager-type-check a derived body: an
 /// expression a data-dependent filter never reaches is lenient at run — the
-/// executor faults only on an expression a SURVIVING row evaluates, exactly as
-/// the NON-derived query does. The eager body type-check stays for the EXPLICIT
+/// executor faults only on an expression a surviving row evaluates, exactly as
+/// the non-derived query does. The eager body type-check stays for the explicit
 /// schema path (`columns(of:validate:true)`), which stays strict.
 struct DerivedTableRunLenienceTests {
   @Test func `a filtered-out ill-typed body runs to zero rows`() throws {
     // `FROM (SELECT Label + 1 AS x FROM K WHERE k = 0) AS d` — the body's text
     // arithmetic `Label + 1` faults ONLY when evaluated, but `WHERE k = 0` (no
     // `K` row has `k = 0`) empties the derived table before the projection
-    // runs. The run preflight compiles the OUTER query WITHOUT eager-type-
-    // checking the derived body, so the run returns ZERO rows rather than
+    // runs. The run preflight compiles the OUTER query without eager-type-
+    // checking the derived body, so the run returns zero rows rather than
     // faulting `.operand` — an earlier round rejected it before materialising.
     try fixture().empty(
         "SELECT * FROM (SELECT Label + 1 AS x FROM K WHERE k = 0) AS d")
@@ -736,8 +736,8 @@ struct DerivedTableRunLenienceTests {
 
   @Test func `columns validate true still faults the filtered-out body`()
       throws {
-    // The EXPLICIT schema path stays STRICT: `columns(of:validate:true)` on the
-    // SAME body still faults `.operand`, so a caller asking to validate the
+    // The explicit schema path stays strict: `columns(of:validate:true)` on the
+    // same body still faults `.operand`, so a caller asking to validate the
     // schema gets the ill-typed projection rejected even though a run empties.
     #expect(throws: SQLError.operand("operands must be numeric")) {
       let query = try parse(query:
@@ -747,9 +747,9 @@ struct DerivedTableRunLenienceTests {
   }
 
   @Test func `a reached ill-typed body still faults at run`() throws {
-    // Lenient is NOT never: a body whose `WHERE` KEEPS a row (`k = 1` matches
+    // Lenient is NOT never: a body whose `WHERE` keeps a row (`k = 1` matches
     // `K`'s first row) reaches the ill-typed `Label + 1` at run, so the
-    // executor faults `.operand` — only an UNEVALUATED expression is spared.
+    // executor faults `.operand` — only an unevaluated expression is spared.
     try fixture().expect(
         "SELECT * FROM (SELECT Label + 1 AS x FROM K WHERE k = 1) AS d",
         fails: .operand("operands must be numeric"))
@@ -760,15 +760,15 @@ struct DerivedTableRunLenienceTests {
 
 /// The `WITH` schema path (`columns(of statement:)`) must thread `validate` to
 /// its trailing query's derived tables exactly as the non-`WITH` path does: a
-/// `validate: false` derive after a successful run TRUSTS a derived body a
+/// `validate: false` derive after a successful run trusts a derived body a
 /// filter empties rather than re-type-checking it, while `validate: true` stays
 /// strict.
 struct DerivedTableWithValidateThreadingTests {
   @Test func `validate false trusts a filtered-out body in the trailing query`()
       throws {
-    // The trailing query wraps the SAME filtered-out ill-typed body under a
+    // The trailing query wraps the same filtered-out ill-typed body under a
     // `WITH`. A run empties (the body never evaluates `Label + 1`); a
-    // `validate: false` derive after that run must return the headers WITHOUT
+    // `validate: false` derive after that run must return the headers without
     // the `.operand` fault, matching the non-`WITH` path. The `WITH` path
     // re-augmented the trailing query's derived table with the DEFAULT
     // `validate: true` before this fix, so it still faulted `.operand`.
@@ -782,7 +782,7 @@ struct DerivedTableWithValidateThreadingTests {
   }
 
   @Test func `validate true still faults the trailing query's body`() throws {
-    // The EXPLICIT schema path stays STRICT under `WITH` too: `validate: true`
+    // The explicit schema path stays strict under `WITH` too: `validate: true`
     // on the same trailing-query body still faults its ill-typed projection.
     #expect(throws: SQLError.operand("operands must be numeric")) {
       let statement = try Statement(parsing:
@@ -797,7 +797,7 @@ struct DerivedTableWithValidateThreadingTests {
 
 struct DerivedTableCorrelationTests {
   @Test func `a derived table referencing an outer column faults`() throws {
-    // PR-3 is UNCORRELATED: the inner query resolves against the base catalog,
+    // PR-3 is uncorrelated: the inner query resolves against the base catalog,
     // NOT its sibling/outer FROM items, so a reference to the outer `T.Id`
     // resolves as an unknown column (no LATERAL yet).
     try fixture().expect(
@@ -816,19 +816,19 @@ struct DerivedTableCorrelationTests {
   }
 }
 
-// MARK: - No correlation into an ENCLOSING row (non-LATERAL, under a subquery)
+// MARK: - No correlation into an enclosing row (non-LATERAL, under a subquery)
 
-/// A non-LATERAL derived table nested inside a CORRELATED subquery must NOT see
+/// A non-LATERAL derived table nested inside a correlated subquery must NOT see
 /// the enclosing query's row either — the same no-LATERAL rule a sibling
 /// reference obeys applies outward across the enclosing subquery boundary.
 ///
 /// Folding the correlation stack into `Context` made the derived-body scope
-/// inherit the enclosing subquery's `outer`, so the STRICT schema/typecheck
+/// inherit the enclosing subquery's `outer`, so the strict schema/typecheck
 /// pass bound the derived body's `T.k` to the caller's row while the lenient
-/// run shape pass recorded NO correlation for it and then FAULTED at execution
-/// — a schema/run MISMATCH. Clearing the correlation stack entering derived
+/// run shape pass recorded no correlation for it and then faulted at execution
+/// — a schema/run mismatch. Clearing the correlation stack entering derived
 /// materialisation restores the documented no-LATERAL behaviour: the derived
-/// body cannot see `T.k`, so BOTH passes fault CONSISTENTLY.
+/// body cannot see `T.k`, so both passes fault consistently.
 struct DerivedTableEnclosingCorrelationTests {
   /// An outer `T` and an inner `S`, each with a `k` a derived body would try to
   /// equate — so the leak, had it bound, would have compiled.
@@ -848,7 +848,7 @@ struct DerivedTableEnclosingCorrelationTests {
       throws {
     // `… 1 IN (SELECT x FROM (SELECT 1 AS x FROM S WHERE S.k = T.k) AS d)` —
     // the `IN` subquery correlates against `T`, but the derived body `d` is
-    // non-LATERAL, so its `T.k` is an unknown column at BOTH the schema pass
+    // non-LATERAL, so its `T.k` is an unknown column at both the schema pass
     // and the run, never bound outward to the caller's row.
     let sql =
         "SELECT k FROM T " +
@@ -859,7 +859,7 @@ struct DerivedTableEnclosingCorrelationTests {
 
   @Test func `the schema pass faults the derived body exactly as the run does`()
       throws {
-    // Schema ↔ run parity: the STRICT `columns(of:)` pass faults the derived
+    // Schema ↔ run parity: the strict `columns(of:)` pass faults the derived
     // body's `T.k` too, rather than binding it while the run faults — the
     // mismatch the leak introduced.
     let query = try parse(query:
@@ -873,7 +873,7 @@ struct DerivedTableEnclosingCorrelationTests {
 
   @Test func `a non-correlated derived body under a subquery still runs`()
       throws {
-    // Control: the SAME shape with an UNCORRELATED derived body (`S.k = 1`, no
+    // Control: the same shape with an uncorrelated derived body (`S.k = 1`, no
     // outer reference) resolves and runs — clearing the correlation stack does
     // not disturb a legitimate derived table. `1 IN {1}` keeps every `T` row.
     try keyed().expect(
@@ -894,7 +894,7 @@ struct DerivedTableSetOperationScopingTests {
   @Test func `a set-op arm derived alias does not bind the other arm`()
       throws {
     // The RIGHT arm names a derived table aliased `T`; the LEFT arm's `FROM T`
-    // must resolve the BASE `T` (columns `Id`, `V`), NOT the right arm's
+    // must resolve the base `T` (columns `Id`, `V`), NOT the right arm's
     // `derived T` (whose only column is `a`). Hoisting both arms into one map
     // bound the right `T` query-wide, so `SELECT Id FROM T` faulted on the
     // unknown `Id`. Per-arm scoping keeps the base `T`, so the left arm scans
@@ -925,7 +925,7 @@ struct DerivedTableSetOperationScopingTests {
   @Test func `a set-op arm derived alias is invisible at the schema path too`()
       throws {
     // Schema ↔ run parity: `columns(of:)` derives the first (left) arm's
-    // projection against the BASE `T`, so the result column is `Id`, not the
+    // projection against the base `T`, so the result column is `Id`, not the
     // right arm's `a`.
     let query = try parse(query:
         "SELECT Id FROM T " +
@@ -937,14 +937,14 @@ struct DerivedTableSetOperationScopingTests {
 
 // MARK: - No LATERAL: sibling FROM items are invisible
 
-/// A derived table is UNCORRELATED/no-LATERAL: its inner query resolves against
+/// A derived table is uncorrelated/no-LATERAL: its inner query resolves against
 /// the enclosing OUTER scope only, so a sibling `FROM`/`JOIN` item is invisible
 /// inside it.
 struct DerivedTableSiblingVisibilityTests {
   @Test func `a derived table cannot read an earlier sibling as a relation`()
       throws {
     // `FROM (…) AS a JOIN (SELECT v FROM a) AS b` — `b`'s inner query names the
-    // SIBLING `a` as a relation. Threading the accumulating sibling map let
+    // sibling `a` as a relation. Threading the accumulating sibling map let
     // `b` read `a` as a CTE; the outer-scope-only rule now faults on the
     // unknown relation `a` (no LATERAL).
     try fixture().expect(
@@ -978,16 +978,16 @@ struct DerivedTableSiblingVisibilityTests {
 
 // MARK: - Self-named derived alias resolves the base relation in its body
 
-/// A derived alias may share the name of the BASE relation its own body
+/// A derived alias may share the name of the base relation its own body
 /// references — `(SELECT … FROM T) AS T`. Its body's `FROM T` must resolve the
-/// BASE `T`, never the derived alias itself, on BOTH the schema-only and the
+/// base `T`, never the derived alias itself, on both the schema-only and the
 /// run paths: `augment` materialises the body against the alias-free outer
-/// scope, so the run→compile double augmentation is IDEMPOTENT (the second
+/// scope, so the run→compile double augmentation is idempotent (the second
 /// pass, whose context already binds the derived `T`, still reads the base).
 struct DerivedTableSelfNamedAliasTests {
   @Test func `a derived alias resolves the base relation its body names`()
       throws {
-    // `(SELECT Id AS a FROM T) AS T` — the inner `FROM T` reads the BASE `T`
+    // `(SELECT Id AS a FROM T) AS T` — the inner `FROM T` reads the base `T`
     // (columns `Id`, `V`), projecting `Id AS a`, and the derived alias is also
     // `T`. Before the idempotent fix the schema-only augment re-materialised
     // the body against the already-bound one-column derived `T`, faulting
@@ -1009,7 +1009,7 @@ struct DerivedTableSelfNamedAliasTests {
   }
 
   @Test func `a self-named derived alias under a JOIN reads the base`() throws {
-    // A variant where the inner body references the base relation by the SAME
+    // A variant where the inner body references the base relation by the same
     // name as the alias, joined to another relation: `(SELECT Id AS k FROM T)
     // AS T` joined to `K` on the key. The inner `FROM T` still resolves the
     // base `T`, so the join pairs `K.k` with the base rows (1, 2).
@@ -1022,10 +1022,10 @@ struct DerivedTableSelfNamedAliasTests {
 
 // MARK: - Set-op SELECT * arity resolves an arm's own derived aliases
 
-/// A set operation's `SELECT *` arm resolves its OWN derived aliases for the
-/// cross-arm arity check. The top-level augment collects NO arm-local
+/// A set operation's `SELECT *` arm resolves its own derived aliases for the
+/// cross-arm arity check. The top-level augment collects no arm-local
 /// derivations (arms are scoped), so the star-arity check augments each arm's
-/// own aliases into a PER-ARM scope first — per arm, so a left arm's alias
+/// own aliases into a per-ARM scope first — per arm, so a left arm's alias
 /// never leaks to the right — matching what each arm produces at run.
 struct DerivedTableSetOperationStarTests {
   @Test func `a set-op SELECT * arm resolves its own derived table`() throws {
@@ -1066,7 +1066,7 @@ struct DerivedTableSetOperationStarTests {
   @Test func `a set-op arm star derived alias does not leak to the other arm`()
       throws {
     // No leak: the left arm's derived `d` is scoped to that arm, so the right
-    // arm's own `SELECT * FROM (…) AS d` resolves ITS own `d` — both arms name
+    // arm's own `SELECT * FROM (…) AS d` resolves its own `d` — both arms name
     // `d` for their own derived table without colliding. A one-column output
     // each, so the union runs. (`UNION ALL` keeps arm order; the right arm
     // reads `T`'s `V` values 10, 20, 30.)
@@ -1079,8 +1079,8 @@ struct DerivedTableSetOperationStarTests {
 
 // MARK: - Cyclic-view guard through derived-table materialisation
 
-/// A catalog with a CYCLIC view — `Loop`'s body reaches back to itself through
-/// a derived table — and a NON-cyclic view `Src` over the base `S`. Resolving
+/// A catalog with a cyclic view — `Loop`'s body reaches back to itself through
+/// a derived table — and a non-cyclic view `Src` over the base `S`. Resolving
 /// `Loop` must fault `.recursion`, not recurse to a stack overflow; `Src`
 /// resolves as any other view.
 private func views() throws -> FixtureCatalog {
@@ -1100,7 +1100,7 @@ private func views() throws -> FixtureCatalog {
 // MARK: - A derived alias preserves a same-named CTE (and base tables)
 
 /// Stripping a derived alias from the scope its body resolves against must drop
-/// ONLY the derived binding, KEEPING a same-named CTE (or base table): the
+/// ONLY the derived binding, keeping a same-named CTE (or base table): the
 /// alias being defined is out of scope in its own body, but an enclosing CTE of
 /// that name is visible. A blanket name-drop removed the CTE too, so a
 /// CTE-shadowing derived body faulted.
@@ -1108,7 +1108,7 @@ struct DerivedTableCTEShadowTests {
   @Test func `a derived body resolves an enclosing CTE of its own alias name`()
       throws {
     // `WITH t(x) AS (SELECT 1) SELECT * FROM (SELECT x FROM t) AS t` — the
-    // inner `FROM t` is inside the derived table ALSO aliased `t`; the alias
+    // inner `FROM t` is inside the derived table also aliased `t`; the alias
     // being defined is out of scope in its own body, so `t` resolves the CTE
     // (projecting its `x` = 1), not the derived table itself. A name-blanket
     // drop removed the CTE, faulting `.relation("t")` (or resolving a base).
@@ -1129,7 +1129,7 @@ struct DerivedTableCTEShadowTests {
 
   @Test func `a self-named derived body over a base table reads the base`()
       throws {
-    // Control (no CTE): the SAME shape over the BASE relation `T` resolves the
+    // Control (no CTE): the same shape over the base relation `T` resolves the
     // base — the body's `FROM T` reads columns `Id`, `V`, projecting `Id`, and
     // the derived alias is also `T`. Dropping only the derived binding leaves
     // the base reachable (a base table is not in the overlay), so this is the
@@ -1158,9 +1158,9 @@ struct DerivedTableCTEShadowTests {
 
 // MARK: - A CTE shadowed by a derived alias stays visible to a lazy scalar
 
-/// A LAZY scalar subquery resolves against the PRE-AUGMENT scope, exactly as
+/// A lazy scalar subquery resolves against the pre-augment scope, exactly as
 /// the eager `EXISTS`/`IN (Q)` subqueries do. For `WITH d(x) AS (…) SELECT
-/// (SELECT x FROM d) FROM (SELECT y FROM T) AS d`, the derived `d` OVERWRITES
+/// (SELECT x FROM d) FROM (SELECT y FROM T) AS d`, the derived `d` overwrites
 /// the CTE `d` in the executor's augmented overlay before the lazy scalar runs;
 /// resolving the scalar against that overlay (subscoped) could not restore the
 /// hidden CTE, faulting `.relation("d")`. Threading the pre-augment scope — the
@@ -1214,9 +1214,9 @@ struct DerivedTableCTEShadowScalarTests {
 
   @Test func `a lazy scalar over the shadowing derived alias itself works`()
       throws {
-    // Control: a scalar subquery that DOES name the shadowing derived `d`
+    // Control: a scalar subquery that does name the shadowing derived `d`
     // resolves it where intended. Here the scalar `(SELECT MAX(y) FROM e)`
-    // reads a DIFFERENT derived alias `e`, and the outer derived `d` (aliased
+    // reads a different derived alias `e`, and the outer derived `d` (aliased
     // to avoid the source `T` collision) drives the rows; the scalar collapses
     // to MAX = 3, so each of the three rows carries 3.
     let statement = try Statement(parsing:
@@ -1230,7 +1230,7 @@ struct DerivedTableCTEShadowScalarTests {
 
 // MARK: - A CTE body threads validate to its own derived tables (round 14)
 
-/// A CTE (`WITH`) body's OWN derived tables must be validated with the same
+/// A CTE (`WITH`) body's own derived tables must be validated with the same
 /// leniency the run uses: `with` validates a CTE with `typecheck: false` (defer
 /// operand checks to execution), so the CTE-body's schema-only `augment`/
 /// `compile` must derive a nested derived table with `validate: false` too — a
@@ -1239,7 +1239,7 @@ struct DerivedTableCTEShadowScalarTests {
 /// path (`typecheck: true`) keeps the eager body type-check.
 struct DerivedTableCTEBodyValidateThreadingTests {
   @Test func `a filtered-out body in a CTE runs to zero rows`() throws {
-    // The reviewer's case: the CTE `c(x)`'s body wraps the SAME filtered-out
+    // The reviewer's case: the CTE `c(x)`'s body wraps the same filtered-out
     // ill-typed derived table (`Label + 1` under `WHERE k = 0`, which drops
     // every `K` row). A run must empty rather than fault `.operand` — the CTE
     // validation threaded `typecheck: false`, so the CTE-body's derived table
@@ -1253,7 +1253,7 @@ struct DerivedTableCTEBodyValidateThreadingTests {
   }
 
   @Test func `the CTE form matches the non-derived CTE`() throws {
-    // Parity: the equivalent CTE whose body is NON-derived
+    // Parity: the equivalent CTE whose body is non-derived
     // (`SELECT Label + 1 AS x FROM K WHERE k = 0`) also runs to zero rows — the
     // filter drops every row before the projection. The derived-table wrapper
     // inside the CTE body must behave identically.
@@ -1270,9 +1270,9 @@ struct DerivedTableCTEBodyValidateThreadingTests {
   }
 
   @Test func `columns validate false returns the CTE headers`() throws {
-    // A `validate: false` derive after the run TRUSTS the CTE-body's derived
+    // A `validate: false` derive after the run trusts the CTE-body's derived
     // table rather than eager-type-checking it, so it returns the trailing
-    // query's headers WITHOUT the `.operand` fault.
+    // query's headers without the `.operand` fault.
     let statement = try Statement(parsing:
         "WITH c(x) AS (SELECT x FROM " +
         "(SELECT Label + 1 AS x FROM K WHERE k = 0) AS d) SELECT * FROM c")
@@ -1281,7 +1281,7 @@ struct DerivedTableCTEBodyValidateThreadingTests {
   }
 
   @Test func `columns validate true still faults the CTE body`() throws {
-    // The EXPLICIT schema path stays STRICT: `validate: true` threads
+    // The explicit schema path stays strict: `validate: true` threads
     // `typecheck: true` into the CTE validation, so the CTE-body's derived
     // table is eager-type-checked and its ill-typed `Label + 1` still faults
     // `.operand`.
@@ -1294,9 +1294,9 @@ struct DerivedTableCTEBodyValidateThreadingTests {
   }
 
   @Test func `a reached ill-typed body in a CTE still faults at run`() throws {
-    // Lenient is NOT never: a CTE-body derived table whose `WHERE` KEEPS a row
+    // Lenient is NOT never: a CTE-body derived table whose `WHERE` keeps a row
     // (`k = 1` matches `K`'s first row) reaches the ill-typed `Label + 1` at
-    // run, so the executor faults `.operand` — only an UNEVALUATED body is
+    // run, so the executor faults `.operand` — only an unevaluated body is
     // spared.
     let statement = try Statement(parsing:
         "WITH c(x) AS (SELECT x FROM " +
@@ -1311,15 +1311,15 @@ struct DerivedTableCTEBodyValidateThreadingTests {
 
 /// The unifying sweep found `subquery(of:)` compiled an `EXISTS`/`IN (Q)`/
 /// scalar subquery's body with the DEFAULT `validate: true`, so a filtered-out
-/// derived table NESTED in a subquery body leaked the eager type-check onto the
-/// RUN path. `compile(select)`/`group`/`subquery(of:)` now thread `validate`,
-/// so a run derives a subquery-body derived table LENIENTLY while a schema
+/// derived table nested in a subquery body leaked the eager type-check onto the
+/// run path. `compile(select)`/`group`/`subquery(of:)` now thread `validate`,
+/// so a run derives a subquery-body derived table leniently while a schema
 /// check keeps it strict.
 struct DerivedTableSubqueryBodyValidateThreadingTests {
   @Test func `a filtered-out body in an EXISTS subquery runs`() throws {
-    // The `EXISTS` subquery's body nests the SAME filtered-out ill-typed
+    // The `EXISTS` subquery's body nests the same filtered-out ill-typed
     // derived table. The subquery has no surviving row, so the `EXISTS` is
-    // FALSE and the outer query keeps no row — but it must not FAULT `.operand`
+    // FALSE and the outer query keeps no row — but it must not fault `.operand`
     // during the run preflight. Before the sweep `subquery(of:)` eager-type-
     // checked the derived body and faulted.
     try fixture().empty(
@@ -1328,7 +1328,7 @@ struct DerivedTableSubqueryBodyValidateThreadingTests {
   }
 
   @Test func `columns validate true still faults the subquery body`() throws {
-    // The EXPLICIT schema path stays STRICT: `validate: true` eager-type-checks
+    // The explicit schema path stays strict: `validate: true` eager-type-checks
     // the subquery-body's derived table, so the ill-typed `Label + 1` faults
     // `.operand`.
     #expect(throws: SQLError.operand("operands must be numeric")) {
@@ -1353,10 +1353,10 @@ struct DerivedTableSubqueryBodyValidateThreadingTests {
 
 // MARK: - A short-circuited subquery's nested derived body is not validated
 
-/// The reachability walk is the SOLE validation gate: schema/shape derivation
-/// is ALWAYS lenient (a derived body's columns/types derive WITHOUT evaluating
-/// its projection), and validation applies ONLY to nodes the walk REACHES — so
-/// a derived body nested under a SHORT-CIRCUITED subquery is not validated at
+/// The reachability walk is the sole validation gate: schema/shape derivation
+/// is ALWAYS lenient (a derived body's columns/types derive without evaluating
+/// its projection), and validation applies ONLY to nodes the walk reaches — so
+/// a derived body nested under a short-circuited subquery is not validated at
 /// ANY depth. `WHERE 1 = 0 AND 1 IN (SELECT x FROM (SELECT 1 / 0 …) AS d)`
 /// short-circuits the `IN` away, so its nested derived `d` never materialises;
 /// before the fix the schema pre-pass eager-compiled `d` with `validate: true`
@@ -1366,7 +1366,7 @@ struct DerivedTableSubqueryReachabilityGateTests {
       throws {
     // `1 = 0` short-circuits the AND, so the `IN` never materialises — the
     // nested derived `d`'s ill-typed `1 / 0` projection is unreached. The
-    // STRICT schema path must NOT fault: the walk did not reach the subquery,
+    // strict schema path must NOT fault: the walk did not reach the subquery,
     // so nothing nested under it is validated.
     let query = try parse(query:
         "SELECT V FROM S WHERE 1 = 0 AND 1 IN " +
@@ -1385,7 +1385,7 @@ struct DerivedTableSubqueryReachabilityGateTests {
   }
 
   @Test func `a reached subquery's nested derived body still faults`() throws {
-    // Parity: `1 = 1` does NOT short-circuit, so the walk REACHES the `IN` and
+    // Parity: `1 = 1` does NOT short-circuit, so the walk reaches the `IN` and
     // validates its nested derived body — the ill-typed `1 / 0` faults
     // `.divide` under the strict schema path, exactly as before the fix.
     #expect(throws: SQLError.divide) {
@@ -1409,7 +1409,7 @@ struct DerivedTableSubqueryReachabilityGateTests {
       throws {
     // Depth-independence: the ill-typed derived body is nested a derived table
     // under a subquery under a derived table. `1 = 0` short-circuits the outer
-    // `IN`, so NOTHING nested under it — at any depth — is validated.
+    // `IN`, so nothing nested under it — at any depth — is validated.
     let query = try parse(query:
         "SELECT V FROM S WHERE 1 = 0 AND 1 IN " +
         "(SELECT y FROM (SELECT x AS y FROM " +
@@ -1433,7 +1433,7 @@ struct DerivedTableSubqueryReachabilityGateTests {
 
 // MARK: - A set-operation VIEW body runs each arm with its arm-local aliases
 
-/// A view whose body is a set operation with a DERIVED TABLE in an arm: the
+/// A view whose body is a set operation with a derived TABLE in an arm: the
 /// `derive` path must run each arm with its arm-local derived aliases (as the
 /// top-level `run` does), not execute the precompiled whole-`setop` plan under
 /// an overlay that binds none.
@@ -1450,14 +1450,14 @@ private func setopViews() throws -> FixtureCatalog {
     try View("VR", "SELECT Id FROM T " +
                    "UNION ALL SELECT * FROM (SELECT Id FROM T) AS d",
              as: ["Id"])
-    // A LEFT arm whose IN subquery names the arm's ENCLOSING derived `d`. The
-    // arm's `FROM (…) AS d` is a SELECT-scoped derived alias, INVISIBLE to the
+    // A LEFT arm whose IN subquery names the arm's enclosing derived `d`. The
+    // arm's `FROM (…) AS d` is a SELECT-scoped derived alias, invisible to the
     // arm's own nested `IN` subquery's FROM — so `(SELECT Id FROM d)` faults
     // `.relation("d")` exactly as it would for a base-table alias.
     try View("VI", "SELECT Id FROM (SELECT Id FROM T) AS d " +
                    "WHERE Id IN (SELECT Id FROM d) " +
                    "UNION ALL SELECT Id FROM T", as: ["Id"])
-    // A RIGHT arm whose IN subquery names its ENCLOSING derived `d` — the same
+    // A RIGHT arm whose IN subquery names its enclosing derived `d` — the same
     // SELECT-scoped-alias fault as `VI`, in the right arm.
     try View("VJ", "SELECT Id FROM T " +
                    "UNION ALL SELECT Id FROM (SELECT Id FROM T) AS d " +
@@ -1495,8 +1495,8 @@ struct DerivedTableSetOperationViewTests {
 
   @Test func `a set-op left arm IN subquery cannot see its enclosing derived`()
       throws {
-    // The LEFT arm's `IN (SELECT Id FROM d)` names the arm's ENCLOSING derived
-    // `d`. A derived-table alias is SELECT-scoped, so it is INVISIBLE to a
+    // The LEFT arm's `IN (SELECT Id FROM d)` names the arm's enclosing derived
+    // `d`. A derived-table alias is SELECT-scoped, so it is invisible to a
     // nested subquery's FROM (as a base-table alias would be) — the subquery
     // faults `.relation("d")`, at a run.
     try setopViews().expect("SELECT Id FROM VI ORDER BY Id",
@@ -1526,11 +1526,11 @@ struct DerivedTableSetOperationViewTests {
 // MARK: - A set-op arm's scalar subquery cannot see its enclosing derived
 
 /// A set-op view whose arms carry a scalar subquery `(SELECT MAX(a) FROM d)`
-/// naming the arm's ENCLOSING derived alias `d`. A derived-table alias is
-/// SELECT-scoped, INVISIBLE to a nested scalar subquery's FROM (as a base-table
+/// naming the arm's enclosing derived alias `d`. A derived-table alias is
+/// SELECT-scoped, invisible to a nested scalar subquery's FROM (as a base-table
 /// alias would be), so the scalar faults `.relation("d")` — the same
 /// outer-derived-alias-in-subquery fault the `IN`/`EXISTS` variants raise. A
-/// scalar over a SHARED base relation stays legal.
+/// scalar over a shared base relation stays legal.
 private func setopScalarViews() throws -> FixtureCatalog {
   try Catalog {
     Relation("S", ["V": .integer]) {
@@ -1542,7 +1542,7 @@ private func setopScalarViews() throws -> FixtureCatalog {
       Row(40)
       Row(50)
     }
-    // A scalar subquery `(SELECT MAX(a) FROM d)` naming the arm's ENCLOSING
+    // A scalar subquery `(SELECT MAX(a) FROM d)` naming the arm's enclosing
     // derived `d`: the alias is SELECT-scoped, so the scalar's FROM cannot see
     // it and faults `.relation("d")` at both arms.
     try View("VMax",
@@ -1559,7 +1559,7 @@ private func setopScalarViews() throws -> FixtureCatalog {
              "FROM (SELECT V AS a FROM S) AS d " +
              "WHERE (SELECT MAX(a) FROM d) = 30",
              as: ["m"])
-    // Two arms with IDENTICAL scalar text reading a SHARED base relation `U`
+    // Two arms with identical scalar text reading a shared base relation `U`
     // (no derived alias): legal and the same value in both arms — both yield
     // MAX(U) = 50.
     try View("VShared",
@@ -1574,7 +1574,7 @@ struct DerivedTableSetOperationScalarTests {
   @Test func `a set-op arm scalar subquery cannot see its enclosing derived`()
       throws {
     // A scalar subquery `(SELECT MAX(a) FROM d)` in each arm names the arm's
-    // ENCLOSING derived `d`. The derived alias is SELECT-scoped, invisible to
+    // enclosing derived `d`. The derived alias is SELECT-scoped, invisible to
     // the scalar subquery's FROM, so it faults `.relation("d")` at a run — the
     // scalar variant of the outer-derived-alias-in-subquery fault.
     try setopScalarViews().expect("SELECT m FROM VMax",
@@ -1600,7 +1600,7 @@ struct DerivedTableSetOperationScalarTests {
   }
 
   @Test func `two arms sharing a non-arm-local scalar both yield it`() throws {
-    // Control: two arms with IDENTICAL scalar text over a SHARED relation `U`
+    // Control: two arms with identical scalar text over a shared relation `U`
     // (no arm-local `d`) each correctly yield MAX(U) = 50 — arm isolation does
     // not perturb a scalar that reads no arm-local relation.
     try setopScalarViews().expect("SELECT m FROM VShared",
@@ -1610,11 +1610,11 @@ struct DerivedTableSetOperationScalarTests {
 
 // MARK: - A set-op view's optimiser augment threads validate leniently
 
-/// Selecting from a SET-OPERATION view runs the run-path optimiser, which
+/// Selecting from a SET-operation view runs the run-path optimiser, which
 /// re-augments each leaf arm to bind its arm-local derived aliases. That
 /// per-arm augment defaulted to `validate: true`, so an arm's data-dependent-
 /// empty derived body (`Label + 1 AS x` under `WHERE k = 0`, no surviving row)
-/// was TYPE-CHECKED during optimisation and faulted `.operand` — even though
+/// was type-checked during optimisation and faulted `.operand` — even though
 /// `overlay(name:)` above and the run's materialise paths are lenient. The
 /// per-arm optimiser augment now threads `validate: false` (the optimiser needs
 /// schema/name bindings only), so a set-op view arm runs exactly as its
@@ -1635,13 +1635,13 @@ private func setopValidateViews() throws -> FixtureCatalog {
     try View("VF", "SELECT x FROM " +
                    "(SELECT Label + 1 AS x FROM K WHERE k = 0) AS d " +
                    "UNION ALL SELECT V FROM S", as: ["x"])
-    // The same filtered-out ill-typed derived table in a SINGLE-arm view — no
+    // The same filtered-out ill-typed derived table in a single-arm view — no
     // set operation, so the optimiser takes the whole-view overlay path.
     try View("VS", "SELECT x FROM " +
                    "(SELECT Label + 1 AS x FROM K WHERE k = 0) AS d",
              as: ["x"])
-    // A REACHED ill-typed arm body (`k = 2` keeps a `K` row) still faults at
-    // run — leniency spares only an UNEVALUATED expression.
+    // A reached ill-typed arm body (`k = 2` keeps a `K` row) still faults at
+    // run — leniency spares only an unevaluated expression.
     try View("VB", "SELECT x FROM " +
                    "(SELECT Label + 1 AS x FROM K WHERE k = 2) AS d " +
                    "UNION ALL SELECT V FROM S", as: ["x"])
@@ -1659,15 +1659,15 @@ struct DerivedTableSetOperationValidateTests {
   }
 
   @Test func `the set-op arm matches the single-arm view`() throws {
-    // Parity: the SINGLE-arm view over the SAME filtered-out derived body runs
+    // Parity: the single-arm view over the same filtered-out derived body runs
     // to zero rows — the optimiser's whole-view overlay was already lenient
     // (`overlay(name:)` passes `validate: false`), and the set-op arm now
-    // matches it, both running WITHOUT the `.operand` fault.
+    // matches it, both running without the `.operand` fault.
     try setopValidateViews().empty("SELECT * FROM VS")
   }
 
   @Test func `a reached ill-typed arm body still faults at run`() throws {
-    // Leniency is NOT never: the arm's `WHERE k = 2` KEEPS a `K` row, so the
+    // Leniency is NOT never: the arm's `WHERE k = 2` keeps a `K` row, so the
     // run reaches the ill-typed `Label + 1` and the executor faults `.operand`.
     try setopValidateViews().expect("SELECT * FROM VB",
                                     fails: .operand("operands must be numeric"))
@@ -1676,15 +1676,15 @@ struct DerivedTableSetOperationValidateTests {
 
 // MARK: - A derived alias is not a recursive relation reference
 
-/// The `WITH RECURSIVE` fixpoint detector inspects a relation's SOURCE, not its
+/// The `WITH RECURSIVE` fixpoint detector inspects a relation's source, not its
 /// binding name: a derived table's alias is not a recursive reference, while a
 /// genuine self-reference nested inside a derived body IS.
 struct DerivedTableRecursionReferenceTests {
   @Test func `a shadowing derived alias is not a recursive reference`() throws {
     // `WITH RECURSIVE a(n) AS (SELECT 1 UNION ALL SELECT n FROM (SELECT 2 AS n)
-    // AS a) SELECT n FROM a` — the second arm's `FROM (…) AS a` merely NAMES a
+    // AS a) SELECT n FROM a` — the second arm's `FROM (…) AS a` merely names a
     // derived table `a`; it does not reference the CTE `a`, so the CTE is NOT
-    // recursive and the arm runs ONCE (never to the recursion cap). The
+    // recursive and the arm runs once (never to the recursion cap). The
     // `UNION ALL` keeps both arms: the anchor 1, then the derived table's 2.
     let statement = try Statement(parsing:
         "WITH RECURSIVE a(n) AS " +
@@ -1701,7 +1701,7 @@ struct DerivedTableRecursionReferenceTests {
     // through the fixpoint. Detecting the nested reference is what makes the
     // recursion fire: the frontier climbs 1 → 2 → 3 and stops (`n < 3` empties
     // it), yielding 1, 2, 3. Were the nested `a` NOT seen, the arm would run
-    // ONCE against an unbound `a` and fault.
+    // once against an unbound `a` and fault.
     let statement = try Statement(parsing:
         "WITH RECURSIVE a(n) AS " +
         "(SELECT 1 UNION ALL " +
@@ -1754,10 +1754,10 @@ struct DerivedTableCyclicViewTests {
   }
 }
 
-// MARK: - Cyclic-view guard on a PLAIN FROM (no derived table)
+// MARK: - Cyclic-view guard on a plain FROM (no derived table)
 
 /// A catalog with cyclic views whose bodies name each other (and one that names
-/// itself) through a PLAIN `FROM`, not a derived table. `A` reads `B` and `B`
+/// itself) through a plain `FROM`, not a derived table. `A` reads `B` and `B`
 /// reads `A`; `Self` reads `Self`. The `Loop` fixture above cycles through a
 /// derived table (which re-enters the guard via `augment`/`materialise`); this
 /// fixture cycles through the direct `resolve(relation:)` view path, so it
@@ -1785,7 +1785,7 @@ struct CyclicViewPlainFromTests {
     // `run` compiles `SELECT * FROM A` before it executes; `resolve` enters
     // `A`'s body, whose `FROM B` enters `B`'s body, whose `FROM A` re-enters a
     // visited view and faults `.recursion` — never a stack overflow. The fault
-    // is raised at COMPILE, so no row ever materialises.
+    // is raised at compile, so no row ever materialises.
     try cyclicViews().expect("SELECT * FROM A", fails: .recursion("A"))
   }
 
@@ -1835,12 +1835,12 @@ struct CyclicViewPlainFromTests {
 // MARK: - An enclosing derived alias is invisible to a nested subquery's FROM
 
 /// A derived-table alias in the outer SELECT's FROM is SELECT-scoped: it names
-/// a relation only in the OWNING SELECT's own FROM/JOIN and expressions, NOT
+/// a relation only in the owning SELECT's own FROM/JOIN and expressions, NOT
 /// inside a nested `EXISTS`/`IN`/scalar subquery's FROM — a subquery does not
 /// see the enclosing query's FROM relations, exactly as a base-table alias in
 /// the enclosing FROM is invisible. So `FROM d` inside the subquery faults
 /// `.relation("d")` (the enclosing derived `d` is stripped), while a same-named
-/// CTE stays visible, the subquery's OWN derived table still resolves, and a
+/// CTE stays visible, the subquery's own derived table still resolves, and a
 /// correlated COLUMN reference still works (that is orthogonal to FROM scope).
 struct DerivedTableSubqueryScopeTests {
   @Test func `an EXISTS subquery FROM cannot see the enclosing derived alias`()
@@ -1866,7 +1866,7 @@ struct DerivedTableSubqueryScopeTests {
 
   @Test func `an enclosing base-table alias is invisible to the subquery too`()
       throws {
-    // The SAME fault a base-table alias `d` in the enclosing FROM raises: a
+    // The same fault a base-table alias `d` in the enclosing FROM raises: a
     // nested subquery's `FROM d` sees neither an enclosing base-table alias nor
     // an enclosing derived alias — both are SELECT-scoped range variables.
     try fixture().expect(
@@ -1919,8 +1919,8 @@ struct DerivedTableSubqueryScopeTests {
   }
 
   @Test func `a subquery's own derived table still resolves`() throws {
-    // The subquery augments its OWN derived table `e` — the strip drops only
-    // the ENCLOSING derived aliases, so `EXISTS (SELECT 1 FROM (SELECT 2 AS z)
+    // The subquery augments its own derived table `e` — the strip drops only
+    // the enclosing derived aliases, so `EXISTS (SELECT 1 FROM (SELECT 2 AS z)
     // AS e)` resolves `e` and the subquery is TRUE, keeping the outer row.
     try fixture().expect(
         "SELECT x FROM (SELECT 1 AS x) AS d " +
@@ -1929,9 +1929,9 @@ struct DerivedTableSubqueryScopeTests {
   }
 
   @Test func `an uncorrelated EXISTS over a base table still runs`() throws {
-    // Orthogonal to the derived-alias strip: a nested subquery over a BASE
+    // Orthogonal to the derived-alias strip: a nested subquery over a base
     // relation (`EXISTS (SELECT 1 FROM S)`) resolves and runs exactly as
-    // before — stripping the ENCLOSING derived aliases keeps base tables (and
+    // before — stripping the enclosing derived aliases keeps base tables (and
     // CTEs) in the subquery's FROM scope. `S` is non-empty, so every outer
     // derived row is kept.
     try fixture().expect(
@@ -1941,26 +1941,26 @@ struct DerivedTableSubqueryScopeTests {
   }
 }
 
-// MARK: - A CTE a derived BODY's own FROM shadows stays visible to its subquery
+// MARK: - A CTE a derived body's own FROM shadows stays visible to its subquery
 
 /// The schema-path analog of the round-8 CTE-not-hidden test: a derived
-/// table's BODY whose own FROM alias shadows an enclosing CTE, with a NESTED
+/// table's body whose own FROM alias shadows an enclosing CTE, with a nested
 /// subquery in that body naming the CTE. The body's schema is derived through
 /// `materialise`, which augments the body's own FROM alias OVER the CTE in its
 /// overlay — so subscoping that overlay for the nested subquery would leave the
 /// CTE unbound. The schema walk must resolve the body's nested subqueries
-/// against the PRE-augment context (CTE intact), matching the run path, so
+/// against the pre-augment context (CTE intact), matching the run path, so
 /// `columns(of:)` and a run both read the CTE inside the nested subquery.
 struct DerivedTableBodyCTEShadowSubqueryTests {
   @Test func `a body FROM alias shadows a CTE its nested subquery still reads`()
       throws {
     // `WITH t(x) AS (SELECT 1) SELECT * FROM (SELECT y FROM (SELECT 2 AS y)
     // AS t WHERE EXISTS (SELECT x FROM t)) AS d` — the outer derived body's own
-    // `FROM (SELECT 2 AS y) AS t` SHADOWS the CTE `t`, and the body's nested
+    // `FROM (SELECT 2 AS y) AS t` shadows the CTE `t`, and the body's nested
     // `EXISTS (SELECT x FROM t)` names `t` — which resolves the CTE
     // (statement-scoped, visible in a subquery), reading its `x` = 1. The CTE
     // has one row, so the EXISTS is TRUE and the body yields `y` = 2. Before
-    // the fix the schema walk's overlay OVERWROTE the CTE with the body's
+    // the fix the schema walk's overlay overwrote the CTE with the body's
     // derived `t`, so subscoping dropped it and `SELECT x FROM t` faulted.
     let statement = try Statement(parsing:
         "WITH t(x) AS (SELECT 1) " +
@@ -2002,19 +2002,19 @@ private final class Counter: @unchecked Sendable {
   }
 }
 
-/// The optimiser augments a view body SCHEMA-ONLY (`rows: false`), so it never
+/// The optimiser augments a view body schema-ONLY (`rows: false`), so it never
 /// executes a derived table's body during optimisation. A stateful routine in a
-/// view's `FROM (SELECT tick() …)` runs at `derive`/run alone — exactly ONCE
+/// view's `FROM (SELECT tick() …)` runs at `derive`/run alone — exactly once
 /// for `SELECT * FROM v`, not doubled by an optimise-time materialisation.
 struct DerivedTableViewOptimiseTests {
   @Test func `a view's stateful derived-body routine runs exactly once`()
       throws {
     // `CREATE VIEW v AS SELECT x FROM (SELECT tick() AS x FROM T) AS d` — the
-    // derived body calls the non-deterministic COUNTING routine `tick()` once
+    // derived body calls the non-deterministic counting routine `tick()` once
     // per `T` row. `T` has one row, so a single execution of the view invokes
-    // `tick()` EXACTLY once. When the optimiser materialised the derived body
+    // `tick()` exactly once. When the optimiser materialised the derived body
     // (`rows: true`) it ran the body during optimisation AND again at `derive`,
-    // so the counter read TWICE; `rows: false` binds the alias schema-only, so
+    // so the counter read twice; `rows: false` binds the alias schema-only, so
     // the single execution at run is the only invocation.
     let counter = Counter()
     let routines = try Routines()
@@ -2039,7 +2039,7 @@ struct DerivedTableViewOptimiseTests {
 
 /// A derived table's body is materialised (executed) ONLY after `compile`
 /// validates the whole query, and each level of a nested derived table runs its
-/// body EXACTLY once. A stateful `tick()` in the body records the invocations:
+/// body exactly once. A stateful `tick()` in the body records the invocations:
 /// an invalid query executes it 0×, a valid single-level derived table 1×, and
 /// a nested derived table 1× — never doubled by an output-schema-discovery
 /// materialisation ahead of the single run.
@@ -2061,11 +2061,11 @@ struct DerivedTableExecutionOnceTests {
   }
 
   @Test func `an invalid query never executes the derived body`() throws {
-    // `SELECT missing FROM (SELECT tick() AS x FROM T) AS d` FAILS during
-    // column resolution — `missing` is unknown — so it must NEVER execute the
-    // derived body's stateful `tick()`. `run` compiles/VALIDATES the whole
-    // query (schema-only) BEFORE materialising any derived rows, so the fault
-    // is raised with the body executed ZERO times. Materialising ahead of the
+    // `SELECT missing FROM (SELECT tick() AS x FROM T) AS d` fails during
+    // column resolution — `missing` is unknown — so it must never execute the
+    // derived body's stateful `tick()`. `run` compiles/validates the whole
+    // query (schema-only) before materialising any derived rows, so the fault
+    // is raised with the body executed zero times. Materialising ahead of the
     // compile would have run `tick()` for a query that cannot run.
     let (counter, routines, catalog) = try harness()
     let query =
@@ -2093,9 +2093,9 @@ struct DerivedTableExecutionOnceTests {
     // `SELECT x FROM (SELECT x FROM (SELECT tick() AS x FROM T) AS n) AS d` — a
     // derived table whose own body nests a derived table. The output-schema
     // discovery augment used to materialise (`rows: true`) the nested body once
-    // to derive `d`'s schema, then the single run materialised it AGAIN, so
-    // `tick()` fired TWICE and the query returned the SECOND value. Discovery
-    // is now schema-only (`rows: false`), so the nested body runs EXACTLY once
+    // to derive `d`'s schema, then the single run materialised it again, so
+    // `tick()` fired twice and the query returned the second value. Discovery
+    // is now schema-only (`rows: false`), so the nested body runs exactly once
     // and the query returns the first (only) value.
     let (counter, routines, catalog) = try harness()
     let query = try parse(query:
@@ -2118,8 +2118,8 @@ struct DerivedTableExecutionOnceTests {
 
 // MARK: - A view-body lazy scalar reads the view's scope, not the caller's
 
-/// A base relation `T` and a view `Count` whose body has a lazy SCALAR subquery
-/// `(SELECT COUNT(*) FROM T)` over that BASE `T`. The base has three rows, so
+/// A base relation `T` and a view `Count` whose body has a lazy scalar subquery
+/// `(SELECT COUNT(*) FROM T)` over that base `T`. The base has three rows, so
 /// the view's scalar collapses to three regardless of the caller.
 private func scopedScalarView() throws -> FixtureCatalog {
   try Catalog {
@@ -2133,15 +2133,15 @@ private func scopedScalarView() throws -> FixtureCatalog {
     Relation("One", ["V": .integer]) {
       Row(1)
     }
-    // The scalar `(SELECT COUNT(*) FROM T)` is a LAZY scalar occurrence keyed
-    // under `.view("count")`; it must resolve against the BASE `T` (count 3),
+    // The scalar `(SELECT COUNT(*) FROM T)` is a lazy scalar occurrence keyed
+    // under `.view("count")`; it must resolve against the base `T` (count 3),
     // never a caller CTE `T`.
     try View("Count", "SELECT (SELECT COUNT(*) FROM T) AS n", as: ["n"])
   }
 }
 
-/// The run-time subquery cache tracks the pre-augment relation scope PER
-/// `Subscope`, so a view-body LAZY scalar resolves under the VIEW overlay, not
+/// The run-time subquery cache tracks the pre-augment relation scope per
+/// `Subscope`, so a view-body lazy scalar resolves under the VIEW overlay, not
 /// the caller's. A single left-hand scope let a caller CTE `T` mask the view's
 /// own base `T`: `WITH T AS (…) SELECT * FROM Count` resolved the view scalar's
 /// `(SELECT COUNT(*) FROM T)` against the caller CTE `T` (five rows) instead of
@@ -2149,7 +2149,7 @@ private func scopedScalarView() throws -> FixtureCatalog {
 struct DerivedTableViewScalarScopeTests {
   @Test func `a view scalar reads the view's T not the caller CTE`() throws {
     // `WITH T AS (five distinct rows) SELECT * FROM Count` — the caller binds a
-    // CTE `T` of five rows, shadowing the base `T` in the CALLER's scope. The
+    // CTE `T` of five rows, shadowing the base `T` in the caller's scope. The
     // view `Count`'s body scalar `(SELECT COUNT(*) FROM T)` was compiled over
     // the base `T` (three rows), so it must collapse to 3, NOT the caller CTE's
     // 5. The lazy scalar now resolves under its own `.view("count")` scope (the
@@ -2174,7 +2174,7 @@ struct DerivedTableViewScalarScopeTests {
   }
 
   @Test func `a caller-scope scalar still reads the caller CTE`() throws {
-    // No regression on the `.caller` scope: a TOP-LEVEL scalar
+    // No regression on the `.caller` scope: a top-level scalar
     // `(SELECT COUNT(*) FROM T)` — textually in the caller, keyed `.caller` —
     // reads the caller CTE `T` (five rows), the scope its own occurrence ran
     // against. The per-`Subscope` map keeps the caller scalar on the caller
@@ -2190,8 +2190,8 @@ struct DerivedTableViewScalarScopeTests {
 
 // MARK: - The direct-select compile entry binds derived aliases
 
-/// The `compile(_ select:)` entry — reached DIRECTLY by a caller that already
-/// holds a `Select` (not wrapped in a `Query`) — must bind THIS select's own
+/// The `compile(_ select:)` entry — reached directly by a caller that already
+/// holds a `Select` (not wrapped in a `Query`) — must bind this select's own
 /// FROM derived aliases before resolving its relations, the same as the `Query`
 /// wrapper (`compile(.select(select))`) and `run` do. Compiling the reviewer's
 /// `SELECT a FROM (SELECT V AS a FROM S) AS d` through the bare-select entry
@@ -2229,7 +2229,7 @@ struct DerivedTableDirectCompileTests {
   }
 
   @Test func `the run yields the derived alias's rows`() throws {
-    // Run parity: the SAME SQL succeeds through `run`, projecting `a` (the `S`
+    // Run parity: the same SQL succeeds through `run`, projecting `a` (the `S`
     // values) — the direct-select entry now matches it.
     try fixture().expect(
         "SELECT a FROM (SELECT V AS a FROM S) AS d ORDER BY a",
@@ -2239,7 +2239,7 @@ struct DerivedTableDirectCompileTests {
   @Test func `a self-named direct-select derived alias reads the base`()
       throws {
     // No double-augment regression: a derived alias equal to a base relation
-    // (`(SELECT V AS a FROM S) AS S`) still reads the BASE `S` in its body —
+    // (`(SELECT V AS a FROM S) AS S`) still reads the base `S` in its body —
     // the wrapper's augment and this entry's augment key on the derivation
     // identity, so the wrapped path does not re-derive and the body's own `S`
     // is the base.
@@ -2252,8 +2252,8 @@ struct DerivedTableDirectCompileTests {
 
 // MARK: - A grouped ORDER BY aggregate subquery reads the shadowed CTE
 
-/// The last CTE-overwrite-class path: a GROUPED `ORDER BY` sorting on an
-/// aggregate over a SCALAR subquery that names a CTE a same-named derived alias
+/// The last CTE-overwrite-class path: a grouped `ORDER BY` sorting on an
+/// aggregate over a scalar subquery that names a CTE a same-named derived alias
 /// shadows. The aggregate's argument subquery is lowered through the grouped
 /// path, so its scope must reveal the base — the derived alias `d` shadows
 /// the CTE `d` non-destructively, and the subquery's `FROM d` resolves the CTE
@@ -2291,12 +2291,12 @@ struct DerivedTableGroupedOrderScalarShadowTests {
 
 // MARK: - A derived-table run stays lenient in output discovery
 
-/// The caller's `validate` flag threads through the derived-table OUTPUT
-/// DISCOVERY (the schema walk that names a derived table's columns before a
-/// run), so a derived-table RUN stays LENIENT like the surrounding non-derived
+/// The caller's `validate` flag threads through the derived-table output
+/// discovery (the schema walk that names a derived table's columns before a
+/// run), so a derived-table run stays lenient like the surrounding non-derived
 /// path: a scalar subquery a data-dependent filter drops from the result is
 /// NOT strictly validated before execution. A `WHERE k = 0` over `K` (keyed
-/// 1, 2) filters EVERY row out, so the inner `Label + 1` — a text-plus-integer
+/// 1, 2) filters every row out, so the inner `Label + 1` — a text-plus-integer
 /// operand that would fault if evaluated — never runs, exactly as the
 /// non-derived form runs to zero rows without touching it. The strict
 /// `columns(of:, validate: true)` preflight still faults, so the fix narrows
@@ -2309,7 +2309,7 @@ struct DerivedTableLenientOutputTests {
     // drops every row, so `Label + 1` never evaluates and the outer derived
     // table `d` yields zero rows. The output discovery for the run must thread
     // `validate: false` into the nested derived body, or it eager-type-checks
-    // `Label + 1` and faults BEFORE execution.
+    // `Label + 1` and faults before execution.
     try fixture().empty(
         "SELECT * FROM (SELECT (SELECT x " +
         "                      FROM (SELECT Label + 1 AS x FROM K " +
@@ -2342,7 +2342,7 @@ struct DerivedTableLenientOutputTests {
   }
 
   @Test func `the strict preflight still faults on the inner scalar`() throws {
-    // Parity: `columns(of:, validate: true)` — the EXPLICIT schema path — still
+    // Parity: `columns(of:, validate: true)` — the explicit schema path — still
     // eager-type-checks the inner body and faults on `Label + 1`, proving the
     // fix narrows to the lenient run path and does not disable validation.
     #expect(throws: SQLError.self) {
@@ -2358,12 +2358,12 @@ struct DerivedTableLenientOutputTests {
 
 // MARK: - All-NULL derived column unification
 
-/// A derived table that projects a constant-NULL column places NO type
+/// A derived table that projects a constant-NULL column places no type
 /// constraint on it, exactly as a bare constant-NULL set-operation arm does.
 /// `materialise` carries the fold's per-column unconstrained marker through the
 /// derived-table binding (and through an `AS d(a)` rename), so a transparent
 /// `(SELECT NULLIF('a','a') AS x) AS d` wrapper unifies with a later typed arm
-/// ORDER-INDEPENDENTLY rather than folding as its literal-fix type and
+/// ORDER-independently rather than folding as its literal-fix type and
 /// faulting.
 struct DerivedTableNullUnificationTests {
   @Test func `an all-NULL derived column unifies with an integer arm`()

--- a/Tests/SQLTests/Queries/EngineFunctionTests.swift
+++ b/Tests/SQLTests/Queries/EngineFunctionTests.swift
@@ -151,7 +151,7 @@ struct EngineFunctionTests {
 
 // MARK: - Defined function (CREATE FUNCTION) tests
 
-/// The routines with the DEFINED functions each `CREATE FUNCTION` in `defs`
+/// The routines with the defined functions each `CREATE FUNCTION` in `defs`
 /// registers, seeded from the standard prelude — the consumer's registration
 /// path, folding a parsed `CREATE FUNCTION` into a `Routines`.
 private func defining(_ defs: String...) throws -> Routines {
@@ -261,7 +261,7 @@ struct EngineDefinedFunctionTests {
 
   @Test func `typing reports the declared RETURNS of a defined function`() throws {
     // The result-schema walk types a `f(...)` call by the routine's declared
-    // return type without running it, so a defined function's declared RETURNS
+    // return type without running it, so a defined function's declared returns
     // is what the output column reports.
     let routines =
         try defining("CREATE FUNCTION label(n INTEGER) RETURNS TEXT AS 'x'")
@@ -284,7 +284,7 @@ struct EngineDefinedFunctionTests {
   @Test func `a defined function body referencing a query parameter faults at define`() throws {
     // A body's inputs are its declared parameters, not query bindings: a routine
     // body is evaluated with only its argument record, so a `:parameter` (here
-    // reached through a CASE guard) would always be UNBOUND and silently pick
+    // reached through a CASE guard) would always be unbound and silently pick
     // the ELSE branch. Registration rejects the `.bound`.
     #expect(throws:
         SQLError.argument("the body cannot reference a query parameter")) {
@@ -307,7 +307,7 @@ struct EngineDefinedFunctionTests {
   }
 
   @Test func `a body naming its own unregistered name faults as unresolved`() throws {
-    // `f() RETURNS INTEGER AS f() + 1` with NO prior `f` early-binds against a
+    // `f() RETURNS INTEGER AS f() + 1` with no prior `f` early-binds against a
     // map without `f`, so the body's own call is unresolved: registration
     // faults `SQLError.function` — the unregistered-callee case — not a
     // self-reference one. Early binding admits no recursion; there is nothing
@@ -318,8 +318,8 @@ struct EngineDefinedFunctionTests {
   }
 
   @Test func `a self-referential redefinition captures the prior function`() throws {
-    // `f() AS f() + 1` REPLACING a prior `f` is well-defined under early
-    // binding: the new body captures the OLD `f` and computes `f_old() + 1`,
+    // `f() AS f() + 1` replacing a prior `f` is well-defined under early
+    // binding: the new body captures the old `f` and computes `f_old() + 1`,
     // terminating. With `f_old()` = 0, `SELECT f()` returns 0 + 1 = 1.
     let routines = try defining(
         "CREATE FUNCTION f() RETURNS INTEGER AS 0",
@@ -344,7 +344,7 @@ struct EngineDefinedFunctionTests {
   }
 
   @Test func `a body calling a prelude routine registers against empty routines`() throws {
-    // Registered against EMPTY routines — NOT `defining`, which seeds the
+    // Registered against empty routines — NOT `defining`, which seeds the
     // prelude — a body calling BITAND still resolves it: registration merges
     // `Routines.standard` under the caller's routines (the run/columns
     // precedence), so `lowbit(n) AS BITAND(n, 1)` binds the built-in rather
@@ -379,7 +379,7 @@ struct EngineDefinedFunctionTests {
   @Test func `a body binds its callee at definition, not at call time`() throws {
     // The round-5 root case at the parse level. `g` returns INTEGER 1; `f() AS
     // g()` captures that INTEGER `g`. Redefining `g` to a TEXT body shadows it
-    // for QUERIES, but `f` closed over the old `g`, so `SELECT f()` still
+    // for queries, but `f` closed over the old `g`, so `SELECT f()` still
     // returns the INTEGER 1 — consistent with f's advertised INTEGER schema —
     // while `SELECT g()` sees the new TEXT `g` (query-level latest-wins holds).
     let routines = try defining(

--- a/Tests/SQLTests/Queries/EngineJoinPlanningTests.swift
+++ b/Tests/SQLTests/Queries/EngineJoinPlanningTests.swift
@@ -8,7 +8,7 @@ import SQLTestSupport
 
 // MARK: - Hash-join tests
 
-/// A join catalog whose inner `Parent` is UNSORTED (so its join key is not
+/// A join catalog whose inner `Parent` is unsorted (so its join key is not
 /// seekable and the executor hashes it) and tallies its row reads — to prove the
 /// hash build scans the inner exactly once rather than once per outer record.
 private func hashable() -> (catalog: EngineMemory, reads: EngineCounter) {
@@ -101,7 +101,7 @@ struct EngineHashJoinTests {
     // A contradictory outer WHERE prunes every `Child`, so the outer is empty
     // and no probe can match. The inner `Parent` is unsorted (unseekable), so
     // the join would hash it — but with no probes the build is pointless. The
-    // empty-outer short-circuit returns before scanning, so ZERO inner rows are
+    // empty-outer short-circuit returns before scanning, so zero inner rows are
     // read; the nested-loop path this replaced already read none for an empty
     // outer, and a large unseekable inner must not be fully scanned to answer
     // nothing.
@@ -115,11 +115,11 @@ struct EngineHashJoinTests {
   }
 
   @Test func `an all-NULL-key outer skips the hash build of an unseekable inner`() throws {
-    // The outer is NON-empty but every `Child.Pid` is NULL (a `WHERE Pid IS
+    // The outer is non-empty but every `Child.Pid` is NULL (a `WHERE Pid IS
     // NULL` keeps only the null-keyed rows), and a NULL key joins to nothing —
     // so no probe can match. The inner `Parent` is unsorted (unseekable), so the
     // join would hash it; but with no non-null probe the build is pointless. The
-    // no-probe guard returns before scanning, so ZERO inner rows are read — the
+    // no-probe guard returns before scanning, so zero inner rows are read — the
     // nested-loop path this replaced read none for an all-null outer too.
     let reads = EngineCounter()
     let parent = [
@@ -225,10 +225,10 @@ struct EngineHashJoinTests {
     // `Parent.Code` (the join key) is unseekable, so the join hashes the inner;
     // `Parent.Id` is sorted (seekable and ordered). `Child JOIN Parent ON
     // Parent.Code = Child.Code WHERE Parent.Id < 0` pushes `Parent.Id < 0` onto
-    // the inner. Applied DURING inner materialisation, that contradictory
+    // the inner. Applied during inner materialisation, that contradictory
     // seekable filter seeks the inner to an empty run — every `Id` is positive —
-    // so ZERO Parent rows are read and the query returns []. Before the fix the
-    // filter rode the residual ABOVE the join, so the whole inner was scanned and
+    // so zero Parent rows are read and the query returns []. Before the fix the
+    // filter rode the residual above the join, so the whole inner was scanned and
     // bucketed (three reads) before the filter matched none of it.
     let reads = EngineCounter()
     let parent = [

--- a/Tests/SQLTests/Queries/EngineJoinTests.swift
+++ b/Tests/SQLTests/Queries/EngineJoinTests.swift
@@ -199,7 +199,7 @@ struct EngineNonEquiJoinTests {
   }
 
   @Test func `an expression equality ON is a residual, not a hash key`() throws {
-    // `ON Child.Pid = Parent.Id + 1` equates a column with an EXPRESSION, so
+    // `ON Child.Pid = Parent.Id + 1` equates a column with an expression, so
     // it is not a bare `column = column` key: it lowers to a residual over the
     // product (nested loop), not a hash join.
     let rows = try join("""
@@ -244,10 +244,10 @@ struct EngineNonEquiJoinTests {
 
   @Test func `an unsafe ON conjunct before an equi key is preserved`() throws {
     // `ON (1 / A.x) = 0 AND A.k = B.k` over a product pair where `A.x = 0` and
-    // `A.k <> B.k`. The hash join evaluates its key equality BEFORE any
+    // `A.k <> B.k`. The hash join evaluates its key equality before any
     // residual, so hoisting `A.k = B.k` to a key would drop the non-matching
     // pair and skip the division the earlier unsafe conjunct owes. The unsafe
-    // leading conjunct bars extraction, so the WHOLE ON stays a residual over
+    // leading conjunct bars extraction, so the whole ON stays a residual over
     // the product and the division raises `SQLError.divide` rather than the
     // query returning no rows.
     let catalog = EngineMemory([
@@ -286,10 +286,10 @@ struct EngineNonEquiJoinTests {
 
   @Test func `an equi key before an unsafe residual extracts no key, planning a residual`() throws {
     // `ON A.k = B.k AND (1 / A.x) = 0` (equi FIRST) has an unsafe conjunct, so
-    // NO key is extracted and the WHOLE ON lowers to a residual over the
+    // no key is extracted and the whole ON lowers to a residual over the
     // product. A hash key would skip a NULL-key pair before the unsafe RHS ran,
     // suppressing the divide the left-to-right Kleene AND owes — so the equi
-    // must NOT hoist while an unsafe conjunct FOLLOWS it.
+    // must NOT hoist while an unsafe conjunct follows it.
     let catalog = EngineMemory([
       "A": FixtureRelation([EngineField(name: "x", type: .integer),
                      EngineField(name: "k", type: .integer)],
@@ -311,7 +311,7 @@ struct EngineNonEquiJoinTests {
     // evaluate the unsafe RHS `(1 / A.x) = 0` and raise `SQLError.divide`.
     // Extracting `A.k = B.k` to a hash key would skip the NULL key and DROP the
     // pair before the RHS ran, returning no rows — so no key is hoisted and the
-    // WHOLE ON stays a residual over the product that raises.
+    // whole ON stays a residual over the product that raises.
     let catalog = EngineMemory([
       "A": FixtureRelation([EngineField(name: "x", type: .integer),
                      EngineField(name: "k", type: .integer)],
@@ -334,7 +334,7 @@ struct EngineNonEquiJoinTests {
 
   @Test func `a definite-false ON key before an unsafe residual short-circuits without raising`() throws {
     // `ON A.k = B.k AND (1 / A.x) = 0` with `A.k = 5`, `B.k = 3` (non-NULL,
-    // definitely UNEQUAL) and `A.x = 0`. The equality is definite FALSE, so the
+    // definitely unequal) and `A.x = 0`. The equality is definite FALSE, so the
     // Kleene AND short-circuits (`false` dominates) and never evaluates the
     // unsafe RHS — no rows, no raise. Both the product+select and the residual
     // agree, distinguishing a definite-FALSE key from the UNKNOWN NULL one.
@@ -352,7 +352,7 @@ struct EngineNonEquiJoinTests {
   }
 
   @Test func `a safe non-equi before an equi still extracts the equi key`() throws {
-    // SAFE-prefix — `ON A.p < B.q AND A.k = B.k`. The leading `<` is safe
+    // safe-prefix — `ON A.p < B.q AND A.k = B.k`. The leading `<` is safe
     // (comparing two cells never raises), so it does not bar extraction: the
     // equi `A.k = B.k` still becomes a hash key beside the residual inequality.
     let catalog = EngineMemory([
@@ -392,9 +392,9 @@ struct EngineNonEquiJoinTests {
   @Test func `a nullable ON gate drops a pair before an unsafe WHERE`() throws {
     // `A JOIN B ON A.k < B.k WHERE (1 / A.x) = 0`, `A.k` NULL and `A.x` = 0.
     // The residual `ON` gate `A.k < B.k` is UNKNOWN (a NULL operand), so the
-    // pair is DROPPED at the gate and the `WHERE` never runs on it — no rows,
-    // no raise. The gate is a distribution BARRIER: the `WHERE` stays a
-    // SEPARATE `select` above the residual `ON` gate rather than fused into one
+    // pair is dropped at the gate and the `WHERE` never runs on it — no rows,
+    // no raise. The gate is a distribution barrier: the `WHERE` stays a
+    // separate `select` above the residual `ON` gate rather than fused into one
     // throwing `A.k < B.k AND (1 / A.x) = 0` over the product.
     let catalog = EngineMemory([
       "A": FixtureRelation([EngineField(name: "x", type: .integer),
@@ -412,8 +412,8 @@ struct EngineNonEquiJoinTests {
   }
 
   @Test func `a surviving ON pair still runs the unsafe WHERE`() throws {
-    // CONTROL — the same `A JOIN B ON A.k < B.k WHERE (1 / A.x) = 0`, but now
-    // `A.k` = 1 and `B.k` = 2, so the `ON` gate is TRUE and the pair PASSES it.
+    // control — the same `A JOIN B ON A.k < B.k WHERE (1 / A.x) = 0`, but now
+    // `A.k` = 1 and `B.k` = 2, so the `ON` gate is TRUE and the pair passes it.
     // The `WHERE` then runs on the surviving pair and `(1 / A.x) = 0` with
     // `A.x` = 0 raises `SQLError.divide` — the `WHERE` still applies after the
     // gate.
@@ -433,7 +433,7 @@ struct EngineNonEquiJoinTests {
 
   @Test func `a safe WHERE over a non-equi ON join returns correct rows`()
       throws {
-    // A SAFE `WHERE` over a non-equi `ON` join yields the same rows the eager
+    // A safe `WHERE` over a non-equi `ON` join yields the same rows the eager
     // product filtered by both `ON` and `WHERE` would — whether or not the safe
     // `WHERE` fuses with the gate. `ON Parent.Id < Child.Pid WHERE Child.Name
     // <> 'Orphan'` pairs each parent with a later-keyed child, then drops the
@@ -447,12 +447,12 @@ struct EngineNonEquiJoinTests {
 
   @Test func `a leftover ON match gates a pair before an unsafe WHERE`() throws {
     // `A JOIN B ON A.k1 = B.k1 AND A.k2 = B.k2 WHERE (1 / A.x) = 0`, with
-    // `A.k1` matching, `A.k2` NULL, and `A.x` = 0. `nest` folds ONE equi key
+    // `A.k1` matching, `A.k2` NULL, and `A.x` = 0. `nest` folds one equi key
     // (`A.k1 = B.k1`) into the hash `.join`, leaving `A.k2 = B.k2` as the
     // gate's own residual under the join. The surviving `k1` pair reaches that
-    // leftover match, which is UNKNOWN (a NULL `A.k2`), so the pair is DROPPED
-    // at the gate BEFORE the `WHERE` runs — no rows, no raise. The `ON` gate is
-    // a BARRIER even though it is PURE-equi: the `WHERE` stays a SEPARATE
+    // leftover match, which is UNKNOWN (a NULL `A.k2`), so the pair is dropped
+    // at the gate before the `WHERE` runs — no rows, no raise. The `ON` gate is
+    // a barrier even though it is pure-equi: the `WHERE` stays a separate
     // `select` above the leftover-match gate rather than fused into a throwing
     // `A.k2 = B.k2 AND (1 / A.x) = 0` that would divide by zero on the pair.
     let catalog = EngineMemory([
@@ -473,14 +473,14 @@ struct EngineNonEquiJoinTests {
     let compiled = try catalog.compile(parse(text))
     let plan = try catalog.optimise(compiled.pushdown(), [:])
     // The equi key still hash-joins; the leftover match gates above it, and the
-    // `WHERE` is a SEPARATE `select` above that gate, not fused with the match.
+    // `WHERE` is a separate `select` above that gate, not fused with the match.
     #expect(joined(plan))
     #expect(stacked(plan))
     #expect(try catalog.run(parse(text)).isEmpty)
   }
 
   @Test func `both ON matches passing lets the unsafe WHERE raise`() throws {
-    // CONTROL — the same two-key `ON` and unsafe `WHERE`, but now BOTH keys
+    // control — the same two-key `ON` and unsafe `WHERE`, but now both keys
     // match (`A.k2` = 5 = `B.k2`), so the pair passes the whole `ON` gate. The
     // `WHERE` then runs on the surviving pair and `(1 / A.x) = 0` with `A.x`
     // = 0 raises `SQLError.divide` — the `WHERE` still applies after the gate.
@@ -507,8 +507,8 @@ struct EngineNonEquiJoinTests {
       throws {
     // The equi fast-path is intact under the always-barrier rule: a two-key
     // pure-equi `ON` still hash-joins (one key folded, the other gating over
-    // the join) and a SAFE `WHERE` above returns the expected rows. `A.k1` and
-    // `A.k2` pick out exactly the `B` row whose BOTH keys match; the `WHERE`
+    // the join) and a safe `WHERE` above returns the expected rows. `A.k1` and
+    // `A.k2` pick out exactly the `B` row whose both keys match; the `WHERE`
     // then keeps only the tagged pair.
     let catalog = EngineMemory([
       "A": FixtureRelation([EngineField(name: "k1", type: .integer),
@@ -535,7 +535,7 @@ struct EngineNonEquiJoinTests {
   }
 
   @Test func `a single-equality ON still plans a hash join and behaves`() throws {
-    // A single-equality pure-equi `ON A.k = B.k` folds its ONE key into the
+    // A single-equality pure-equi `ON A.k = B.k` folds its one key into the
     // hash `.join` and carries no leftover conjunct, so the `WHERE` sits
     // above the join. A matching pair runs the `WHERE`; a NULL key drops the
     // pair at the join, so the `WHERE` never runs on it. `A` holds a matching
@@ -621,7 +621,7 @@ struct EngineOuterJoinTests {
   }
 
   @Test func `an ON conjunct keeps an unmatched left row a WHERE would drop`() throws {
-    // ON vs WHERE. Restricting the MATCH with `AND Child.Name = 'Amy'` keeps
+    // ON vs WHERE. Restricting the match with `AND Child.Name = 'Amy'` keeps
     // every parent — the ON governs matching alone, so a parent that now
     // matches no child is still emitted NULL-extended. Only Ada matches Amy.
     let rows = try join("""
@@ -636,7 +636,7 @@ struct EngineOuterJoinTests {
   }
 
   @Test func `the same predicate in WHERE drops the unmatched rows`() throws {
-    // Moving the predicate to a post-join WHERE filters AFTER the outer join,
+    // Moving the predicate to a post-join WHERE filters after the outer join,
     // so the NULL-extended rows (whose Child.Name is NULL) fail `= 'Amy'` and
     // drop — turning the LEFT join back to inner-like. This is the ON-vs-WHERE
     // distinction the outer join preserves.
@@ -815,7 +815,7 @@ struct EngineMultiJoinTests {
 
   @Test func `an early ON referencing a not-yet-joined relation is rejected`() throws {
     // The first join's `ON` qualifies a column with `Item`, a relation joined
-    // only LATER. Resolving the match against just the prefix — `House` and
+    // only later. Resolving the match against just the prefix — `House` and
     // `Room` — the qualifier names no relation in scope, so the query is
     // rejected (`SQLError.column`) rather than resolving `Item`'s slot from a
     // product that does not yet contain it and trapping or indexing wrong.
@@ -860,13 +860,13 @@ struct EngineMultiJoinTests {
 
 // MARK: - NATURAL and USING join tests
 
-/// A catalog of relations sharing column NAMES, so a `NATURAL`/`USING` join has
+/// A catalog of relations sharing column names, so a `NATURAL`/`USING` join has
 /// common columns to key on. `Emp(Dept, Name)` and `Team(Dept, Lead)` share
 /// `Dept`; `Lhs(K, G, A)` and `Rhs(K, G, B)` share `K` and `G`; `Solo(x)`
 /// and `Other(y)` share nothing (a `NATURAL` join over them degenerates to a
 /// product). `Team` has a `Dept` (30) no `Emp` names, and `Emp` a `Dept` (10)
 /// no `Team` names, so an outer join has an unmatched row on each side.
-/// `Bonus(Dept, Amt)` names every `Dept` (10, 20, 30), so a THIRD `USING
+/// `Bonus(Dept, Amt)` names every `Dept` (10, 20, 30), so a third `USING
 /// (Dept)` join after an outer `Emp`/`Team` one keys each surviving row —
 /// including an unmatched left/right one — on the merged `Dept`.
 private func named() throws -> FixtureCatalog {
@@ -906,7 +906,7 @@ private func named() throws -> FixtureCatalog {
 
 struct EngineNaturalUsingTests {
   @Test func `INNER USING (c) merges the column once, first, then rests`() throws {
-    // Output column list (ISO 7.10): the USING column `Dept` ONCE and FIRST,
+    // Output column list (ISO 7.10): the USING column `Dept` once and FIRST,
     // then the left's other columns (`Name`), then the right's (`Lead`). Rows
     // join on `Dept` equality — only Dept 20 matches on both sides.
     try named().expect("SELECT * FROM Emp JOIN Team USING (Dept)",
@@ -918,7 +918,7 @@ struct EngineNaturalUsingTests {
 
   @Test func `USING (c1, c2) keys on both columns`() throws {
     // The join columns `K, G` come first in order, then `Lhs`'s `A`, then
-    // `Rhs`'s `B`. Only the (1, x) row agrees on BOTH columns.
+    // `Rhs`'s `B`. Only the (1, x) row agrees on both columns.
     try named().expect("""
         SELECT * FROM Lhs JOIN Rhs USING (K, G)
         """,
@@ -1028,8 +1028,8 @@ struct EngineNaturalUsingTests {
 
   @Test func `a bare reference to a merged column resolves to the coalesced value`() throws {
     // ISO 9075 7.10: the USING/NATURAL common column is an exposed name of the
-    // join result belonging to NEITHER side, so a BARE `Dept` resolves to the
-    // ONE coalesced column — UNAMBIGUOUSLY — not to `Emp.Dept` or `Team.Dept`.
+    // join result belonging to neither side, so a bare `Dept` resolves to the
+    // one coalesced column — unambiguously — not to `Emp.Dept` or `Team.Dept`.
     try named().expect("SELECT Dept FROM Emp JOIN Team USING (Dept)",
         yields: [[20], [20]])
   }
@@ -1093,7 +1093,7 @@ struct EngineNaturalUsingTests {
   }
 
   @Test func `a bare reference to each of two merged columns resolves`() throws {
-    // A NATURAL join over two common columns exposes BOTH `K` and `G`; a bare
+    // A NATURAL join over two common columns exposes both `K` and `G`; a bare
     // reference to each resolves to its coalesced value (equal on the one
     // matched row).
     try named().expect("""
@@ -1105,7 +1105,7 @@ struct EngineNaturalUsingTests {
   @Test func `a bare reference to a shared but non-join column stays ambiguous`() throws {
     // The scoping guard (ISO 9075 7.10): ONLY the join columns are exposed.
     // `Lhs` and `Rhs` share `K` and `G`, but `USING (K)` joins on `K` alone —
-    // so bare `G`, shared yet NOT a join column, stays AMBIGUOUS between the
+    // so bare `G`, shared yet NOT a join column, stays ambiguous between the
     // two sides rather than collapsing to a merged value.
     try named().expect("""
         SELECT G FROM Lhs JOIN Rhs USING (K)
@@ -1126,7 +1126,7 @@ struct EngineNaturalUsingTests {
   // MARK: - Aliased ranges (finding 1)
 
   @Test func `an aliased FROM side resolves a USING join`() throws {
-    // The synthesized `ON` and coalesced `SELECT *` qualify by the RANGE name
+    // The synthesized `ON` and coalesced `SELECT *` qualify by the range name
     // (the alias `e`), the only name the scope admits, so `Emp AS e JOIN Team
     // USING (Dept)` resolves rather than faulting on an unqualifiable
     // `Emp.Dept`.
@@ -1166,7 +1166,7 @@ struct EngineNaturalUsingTests {
   // MARK: - Set-operation arity over the merged width (finding 2)
 
   @Test func `a UNION over a USING join measures the merged width`() throws {
-    // The `SELECT *` arm's width is the MERGED count (3 — `Dept` once), so a
+    // The `SELECT *` arm's width is the merged count (3 — `Dept` once), so a
     // 3-column second arm aligns and the UNION succeeds. Before the desugar ran
     // ahead of the arity check, the `*` measured both physical `Dept`s (4) and
     // wrongly rejected the valid set operation.
@@ -1193,7 +1193,7 @@ struct EngineNaturalUsingTests {
   // MARK: - Exposed IN and quantified outer operand (finding 3)
 
   @Test func `a bare merged reference resolves as an IN operand`() throws {
-    // The outer operand of `IN (subquery)` resolves in THIS query's scope, so
+    // The outer operand of `IN (subquery)` resolves in this query's scope, so
     // a bare merged `Dept` is exposed to the coalesced value — not left
     // ambiguous between the two physical sides.
     try named().expect("""
@@ -1217,7 +1217,7 @@ struct EngineNaturalUsingTests {
 
   @Test func `a chained USING join keys a RIGHT-only row on the merged value`() throws {
     // `Emp RIGHT JOIN Team USING (Dept)` keeps the right-only Dept 30 (left
-    // `Emp.Dept` NULL); the next `JOIN Bonus USING (Dept)` keys on the MERGED
+    // `Emp.Dept` NULL); the next `JOIN Bonus USING (Dept)` keys on the merged
     // `Dept`, so that row still joins `Bonus` (Amt 200) rather than being
     // dropped on a NULL left key.
     try named().expect("""
@@ -1231,7 +1231,7 @@ struct EngineNaturalUsingTests {
   }
 
   @Test func `a chained USING join keys a FULL join's unmatched rows on the merged value`() throws {
-    // A FULL first join keeps BOTH unmatched rows — Dept 10 (left-only) and 30
+    // A FULL first join keeps both unmatched rows — Dept 10 (left-only) and 30
     // (right-only); the chained `Bonus` join keys each on the merged `Dept`, so
     // both still join (Amt 50 and 200).
     try named().expect("""
@@ -1249,7 +1249,7 @@ struct EngineNaturalUsingTests {
 
   @Test func `a repeated USING column faults rather than crashing`() throws {
     // `USING (Dept, Dept)` names one merged column twice; the duplicate is
-    // caught BEFORE the output dictionary the merged names key would trap on,
+    // caught before the output dictionary the merged names key would trap on,
     // faulting `.duplicate` rather than aborting the process.
     try named().expect("""
         SELECT * FROM Emp JOIN Team USING (Dept, Dept)
@@ -1258,7 +1258,7 @@ struct EngineNaturalUsingTests {
   }
 
   @Test func `a NATURAL join after a plain join with two like-named columns faults`() throws {
-    // `Emp JOIN Team ON …` leaves the left side carrying TWO columns named
+    // `Emp JOIN Team ON …` leaves the left side carrying two columns named
     // `Dept`; a following `NATURAL JOIN Bonus` would merge `Dept` twice — the
     // duplicate is caught and faults `.duplicate` rather than trapping.
     try named().expect("""
@@ -1272,7 +1272,7 @@ struct EngineNaturalUsingTests {
 
   @Test func `a RIGHT join groups a bare merged column by the coalesced value`() throws {
     // The right-only Dept 30 (left `Emp.Dept` NULL) groups and projects by the
-    // MERGED value 30, not NULL — the `GROUP BY` key is the coalesced value the
+    // merged value 30, not NULL — the `GROUP BY` key is the coalesced value the
     // projection emits.
     try named().expect("""
         SELECT Dept, COUNT(*) FROM Emp RIGHT JOIN Team USING (Dept)
@@ -1301,9 +1301,9 @@ struct EngineNaturalUsingTests {
   // MARK: - Accumulated-left ambiguity (finding 1)
 
   @Test func `a USING column a plain join bound twice on the left faults`() throws {
-    // A plain `ON` join leaves the accumulated left carrying TWO columns named
+    // A plain `ON` join leaves the accumulated left carrying two columns named
     // `Dept` (`Emp.Dept` and `Team.Dept`); a following `JOIN Bonus USING
-    // (Dept)` keys `Dept` on that left — which binds it TWICE — so it faults
+    // (Dept)` keys `Dept` on that left — which binds it twice — so it faults
     // `.ambiguous` at construction rather than trapping a downstream build.
     try named().expect("""
         SELECT * FROM Emp JOIN Team ON Emp.Dept = Team.Dept
@@ -1316,7 +1316,7 @@ struct EngineNaturalUsingTests {
 
   @Test func `a qualified name a later plain join adds over a merged one resolves`() throws {
     // A `USING (Dept)` merges `Dept`; a later plain `JOIN Bonus AS C ON …`
-    // brings its OWN physical `C.Dept`. A QUALIFIED `C.Dept` names that side
+    // brings its own physical `C.Dept`. A qualified `C.Dept` names that side
     // unambiguously and resolves — never a crash — even though a bare `Dept`
     // would now be ambiguous between the merged column and `C.Dept`.
     try named().expect("""
@@ -1329,7 +1329,7 @@ struct EngineNaturalUsingTests {
   @Test func `a bare name a later plain join re-collides with a merged one faults`() throws {
     // The bare counterpart: with the merged `Dept` AND the later plain join's
     // physical `C.Dept` both in scope, a bare `Dept` names two columns and
-    // faults `.ambiguous` — surfacing at lookup, NEVER a crash.
+    // faults `.ambiguous` — surfacing at lookup, never a crash.
     try named().expect("""
         SELECT Dept FROM Emp JOIN Team USING (Dept)
         JOIN Bonus AS C ON C.Dept = Emp.Dept
@@ -1340,7 +1340,7 @@ struct EngineNaturalUsingTests {
   // MARK: - ORDER BY alias precedence over a merged key (finding 3)
 
   @Test func `ORDER BY binds a projection alias before the merged key`() throws {
-    // `SELECT Name AS Dept … ORDER BY Dept` sorts by the PROJECTED alias
+    // `SELECT Name AS Dept … ORDER BY Dept` sorts by the projected alias
     // `Name`, not the coalesced merged `Dept` key — the bare `ORDER BY` key
     // reaches the resolver's alias-first binding before the scope's merged
     // column, since there is no pre-rewrite substituting the key for the
@@ -1365,12 +1365,12 @@ struct EngineNaturalUsingTests {
         yields: [["Ann"], ["Bob"], ["Cid"]])
   }
 
-  // MARK: - Merged columns under schema VALIDATION (finding A)
+  // MARK: - Merged columns under schema validation (finding A)
 
   @Test func `a bare merged reference type-checks under validation`() throws {
     // The run lowers a bare merged `Dept` in the `WHERE` through `Scope.term`
     // to the coalesced value; `columns(of:validate:true)` — whose type-check
-    // walk validates the `WHERE` through the SAME merged-aware bare-name
+    // walk validates the `WHERE` through the same merged-aware bare-name
     // lookup — must resolve it too, not fault `.ambiguous`. The schema names
     // the projected `Name` (text) and does not throw.
     let text = """
@@ -1384,7 +1384,7 @@ struct EngineNaturalUsingTests {
   }
 
   @Test func `a bare merged reference in the projection type-checks`() throws {
-    // The merged `Dept` PROJECTED and type-checked: the schema resolves it to
+    // The merged `Dept` projected and type-checked: the schema resolves it to
     // the unified coalesce type (`integer`) rather than faulting `.ambiguous`.
     let text = "SELECT Dept FROM Emp JOIN Team USING (Dept) WHERE Dept = 20"
     let columns = try named()
@@ -1421,7 +1421,7 @@ struct EngineNaturalUsingTests {
       throws {
     // `Emp JOIN Team USING (Dept)` merges `Dept`; the plain `JOIN Bonus AS C
     // ON …` re-introduces a physical `C.Dept`, so the prefix now binds `Dept`
-    // BOTH as the merged column and as `C.Dept`. A later `JOIN X USING (Dept)`
+    // both as the merged column and as `C.Dept`. A later `JOIN X USING (Dept)`
     // resolves its common `Dept` against that prefix — ambiguous — so it
     // faults `.ambiguous` rather than silently keying on the merged value and
     // leaving two output columns named `Dept`.
@@ -1451,7 +1451,7 @@ struct EngineNaturalUsingTests {
 
   @Test func `a USING join over int and double sides unifies to double`()
       throws {
-    // `A.k integer`, `B.k double`: the merged `k` type UNIFIES to `double`,
+    // `A.k integer`, `B.k double`: the merged `k` type unifies to `double`,
     // and the coalesce coerces each side to it, so the schema advertises
     // `double` and the rows carry doubles — not a silent left `integer`.
     let catalog = try Catalog {
@@ -1528,9 +1528,9 @@ struct EngineNaturalUsingTests {
   @Test func `a USING join defers to the right when the left is unconstrained`()
       throws {
     // `(SELECT NULLIF(1, 1) AS k) AS a` — the left `k` is constant NULL, so
-    // UNCONSTRAINED (a placeholder `integer` that places no type constraint) —
+    // unconstrained (a placeholder `integer` that places no type constraint) —
     // RIGHT JOIN `B_text` whose `k` is `text`. The merged `k` types off the
-    // CONSTRAINED right (`text`) through the same mask-aware unification the
+    // constrained right (`text`) through the same mask-aware unification the
     // set-op fold takes, rather than faulting the placeholder `integer` beside
     // `text`. A right row's merged `k` is `B_text.k` (the always-NULL left
     // coalesces away). Run ≡ columns(of:).
@@ -1553,8 +1553,8 @@ struct EngineNaturalUsingTests {
 
   @Test func `a USING join defers to the left when the right is unconstrained`()
       throws {
-    // The SYMMETRIC case: the CONSTRAINED left `A_text.k` (`text`) beside an
-    // UNCONSTRAINED right `(SELECT NULLIF(1, 1) AS k)` — the merged `k` types
+    // The symmetric case: the constrained left `A_text.k` (`text`) beside an
+    // unconstrained right `(SELECT NULLIF(1, 1) AS k)` — the merged `k` types
     // off the left (`text`), and a LEFT join keeps every left row, its merged
     // `k` the left value (the always-NULL right coalesces away).
     let catalog = try Catalog {
@@ -1576,9 +1576,9 @@ struct EngineNaturalUsingTests {
 
   @Test func `a USING join of two unconstrained sides stays unconstrained`()
       throws {
-    // BOTH constituents constant NULL (unconstrained): the merged `k` stays a
+    // both constituents constant NULL (unconstrained): the merged `k` stays a
     // placeholder that places no constraint, so a further `UNION SELECT 1` over
-    // it UNIFIES to `integer` rather than faulting the placeholder beside the
+    // it unifies to `integer` rather than faulting the placeholder beside the
     // typed arm — the merged column carries its own `unconstrained` bit into
     // the enclosing set-operation fold, exactly as a bare unconstrained column
     // would.
@@ -1630,8 +1630,8 @@ struct EngineNaturalUsingTests {
 
   @Test func `a chained USING on the SAME column keeps it once at the outer position`()
       throws {
-    // A chained `… USING (Dept)` over an already-merged `Dept` DROPS the inner
-    // entry and keeps the ONE merged `Dept` at the outer join's position — so
+    // A chained `… USING (Dept)` over an already-merged `Dept` drops the inner
+    // entry and keeps the one merged `Dept` at the outer join's position — so
     // `SELECT *` still exposes `Dept` once, then the three sides' rests. Run
     // and schema agree.
     let text =
@@ -1650,8 +1650,8 @@ struct EngineNaturalUsingTests {
 
   @Test func `a LATERAL body resolves a bare USING-merged column`() throws {
     // ISO 9075 7.10: the `USING (Dept)` merged column is an output column of
-    // the join, so a LATERAL body's PRECEDING scope carries it and a bare
-    // `Dept` in the body binds the ONE coalesced column rather than faulting
+    // the join, so a LATERAL body's preceding scope carries it and a bare
+    // `Dept` in the body binds the one coalesced column rather than faulting
     // `.ambiguous` between the two physical `Dept`s. Run and schema agree.
     let text = """
         SELECT d.n FROM Emp JOIN Team USING (Dept)
@@ -1687,7 +1687,7 @@ struct EngineNaturalUsingTests {
 
   @Test func `a LATERAL body still resolves a qualified constituent column`()
       throws {
-    // A QUALIFIED `Emp.Dept` in the body never matches the merged column and
+    // A qualified `Emp.Dept` in the body never matches the merged column and
     // reaches its own physical side, correlating as an ordinary outer slot.
     let text = """
         SELECT d.n FROM Emp JOIN Team USING (Dept)
@@ -1698,7 +1698,7 @@ struct EngineNaturalUsingTests {
 
   @Test func `a LATERAL body faults an ambiguous non-merged name`() throws {
     // A plain `JOIN Bonus ON …` re-introduces a physical `Dept` beside the
-    // merged one, so a bare `Dept` in the LATERAL body now names BOTH and stays
+    // merged one, so a bare `Dept` in the LATERAL body now names both and stays
     // `.ambiguous` — the merged axis does not mask a genuine ambiguity.
     let text = """
         SELECT d.n FROM Emp JOIN Team USING (Dept)
@@ -1710,10 +1710,10 @@ struct EngineNaturalUsingTests {
 
   @Test func `a merged column and its constituent correlate independently`()
       throws {
-    // A LATERAL body of `Emp RIGHT JOIN Team USING (Dept)` projects BOTH the
+    // A LATERAL body of `Emp RIGHT JOIN Team USING (Dept)` projects both the
     // bare merged `Dept` (COALESCE) and the physical `Emp.Dept` constituent. On
     // the right-only Dept 30 row the merged `Dept` coalesces to 30 while
-    // `Emp.Dept` is NULL — each correlates through its OWN parameter identity,
+    // `Emp.Dept` is NULL — each correlates through its own parameter identity,
     // so neither read overwrites the other regardless of projection order.
     let forward = """
         SELECT m, e FROM Emp RIGHT JOIN Team USING (Dept)
@@ -1725,7 +1725,7 @@ struct EngineNaturalUsingTests {
       [20, 20],
       [30, nil],
     ])
-    // The REVERSE projection order yields the same values — the merged and the
+    // The reverse projection order yields the same values — the merged and the
     // constituent correlation keys do not collide, so lowering order is
     // irrelevant.
     let reverse = """
@@ -1743,7 +1743,7 @@ struct EngineNaturalUsingTests {
   @Test func `a SELECT star merged column carries its unconstrained mask`()
       throws {
     // Both `USING (k)` constituents are constant-NULL (`NULLIF(1, 1)`), so the
-    // merged `k` is UNCONSTRAINED — it places no type constraint. A `SELECT *`
+    // merged `k` is unconstrained — it places no type constraint. A `SELECT *`
     // must carry that mask (exactly as an explicit `SELECT k` does), so the
     // enclosing UNION unifies the merged `k` with the text arm rather than
     // faulting the first arm's integer against the text (42804).
@@ -1769,7 +1769,7 @@ struct EngineNaturalUsingTests {
 
   @Test func `a genuinely constrained USING merge still faults an irreconcilable UNION`()
       throws {
-    // Both constituents are CONSTRAINED (a bare integer `Dept` and a text
+    // Both constituents are constrained (a bare integer `Dept` and a text
     // `Lead`… no — both integer here), so the merged `Dept` is a constrained
     // integer and the text UNION arm is irreconcilable: 42804 still faults,
     // proving the mask is carried, not hard-coded unconstrained.
@@ -1780,13 +1780,13 @@ struct EngineNaturalUsingTests {
         fails: .operand("UNION arms have irreconcilable types"))
   }
 
-  // MARK: - USING/NATURAL over a VIRTUAL column (the fixture `Id`)
+  // MARK: - USING/NATURAL over a virtual column (the fixture `Id`)
 
   @Test func `USING a virtual Id present on both sides resolves and merges it`()
       throws {
-    // `Id` is a VIRTUAL column (the fixture's 1-based row index) on BOTH `Emp`
+    // `Id` is a virtual column (the fixture's 1-based row index) on both `Emp`
     // and `Team`, not a real one in `names`. `USING (Id)` must resolve it
-    // through the SAME virtual-aware `ordinal(of:)` the predicate path
+    // through the same virtual-aware `ordinal(of:)` the predicate path
     // `Emp.Id = Team.Id` uses, keying on the row index: Emp Ids 1..3, Team
     // Ids 1..2, so Ids 1 and 2 match. ISO 7.10 order exposes the merged `Id`
     // once and first, then `Emp`'s real columns, then `Team`'s.
@@ -1810,12 +1810,12 @@ struct EngineNaturalUsingTests {
 
   @Test func `NATURAL does not key on a shared virtual Id, only real columns`()
       throws {
-    // The NATURAL DECISION: the common set is the LEFT scope's `names` — the
-    // real, `SELECT *`-visible columns, NO virtual — so a virtual `Id` shared
+    // The NATURAL decision: the common set is the LEFT scope's `names` — the
+    // real, `SELECT *`-visible columns, no virtual — so a virtual `Id` shared
     // by both sides is NOT a NATURAL common column even though both sides can
-    // ADDRESS it. This is consistent with ISO, where NATURAL and `SELECT *`
-    // draw on the SAME column-name list (which the engine excludes virtuals
-    // from), while an EXPLICIT `USING (Id)` (like an explicit `A.Id = B.Id`)
+    // address it. This is consistent with ISO, where NATURAL and `SELECT *`
+    // draw on the same column-name list (which the engine excludes virtuals
+    // from), while an explicit `USING (Id)` (like an explicit `A.Id = B.Id`)
     // resolves the virtual through `ordinal(of:)`. So `Emp NATURAL JOIN Team`
     // keys on the shared REAL `Dept` alone (Dept 20 matches), NOT on the
     // virtual `Id` — the round-1 behavior is unchanged.
@@ -1828,7 +1828,7 @@ struct EngineNaturalUsingTests {
 
   @Test func `USING mixes a REAL left Id with a VIRTUAL joined Id`() throws {
     // `Coded` carries a REAL `Id` column (shadowing its own virtual); `Emp`
-    // exposes only a VIRTUAL `Id`. `USING (Id)` must resolve the LEFT through
+    // exposes only a virtual `Id`. `USING (Id)` must resolve the LEFT through
     // the real column and the RIGHT through the virtual one, keying REAL 1..3
     // against the row index 1..3.
     try virtual().expect("SELECT * FROM Coded JOIN Emp USING (Id)",
@@ -1855,12 +1855,12 @@ struct EngineNaturalUsingTests {
   @Test func `NATURAL excludes a JOINED-side virtual Id from the common set`()
       throws {
     // `Coded` has a REAL `Id` (in `names`); `Emp` exposes `Id` ONLY as a
-    // VIRTUAL column (the fixture row index), and the two share NO real column
+    // virtual column (the fixture row index), and the two share no real column
     // (`Id`/`Tag` vs `Dept`/`Name`). The `NATURAL` common set is the REAL-name
-    // intersection on BOTH sides, so the joined-side VIRTUAL `Id` must NOT
+    // intersection on both sides, so the joined-side virtual `Id` must NOT
     // match `Coded`'s real `Id` — the join degenerates to a CROSS product (its
-    // synthesized `on` empty), keeping ALL FOUR real columns unmerged and every
-    // 3x3 pairing. An EXPLICIT `USING (Id)` (the control below) still resolves
+    // synthesized `on` empty), keeping ALL four real columns unmerged and every
+    // 3x3 pairing. An explicit `USING (Id)` (the control below) still resolves
     // the virtual; NATURAL, like `SELECT *`, draws only on real names.
     try virtual().expect("SELECT * FROM Coded NATURAL JOIN Emp",
         yields: [
@@ -1905,9 +1905,9 @@ struct EngineNaturalUsingTests {
 
   @Test func `explicit USING over the real-and-virtual Id still merges (round 7)`()
       throws {
-    // CONTROL: the round-7 behavior is UNCHANGED. `Coded JOIN Emp USING (Id)`
-    // still resolves `Coded`'s REAL `Id` and `Emp`'s VIRTUAL `Id` through the
-    // virtual-aware probe and MERGES them (keys real 1..3 against the row
+    // control: the round-7 behavior is unchanged. `Coded JOIN Emp USING (Id)`
+    // still resolves `Coded`'s REAL `Id` and `Emp`'s virtual `Id` through the
+    // virtual-aware probe and merges them (keys real 1..3 against the row
     // index 1..3), a single merged `Id` first, then the remaining real columns.
     // Only NATURAL's common-set derivation changed; the explicit-USING path is
     // untouched.
@@ -1924,10 +1924,10 @@ struct EngineNaturalUsingTests {
 
   @Test func `a RIGHT USING over a virtual Id coalesces the right-only value`()
       throws {
-    // `Few` has ONE row (Id 1); `Many` has three (Ids 1..3). A RIGHT join keeps
+    // `Few` has one row (Id 1); `Many` has three (Ids 1..3). A RIGHT join keeps
     // every `Many` row: Id 1 matches, and Ids 2 and 3 are right-only with a
     // NULL-extended left `Id`. The merged `Id` = COALESCE(Few.Id, Many.Id) must
-    // show the JOINED (right) virtual value on those right-only rows, so the
+    // show the joined (right) virtual value on those right-only rows, so the
     // merged column is 1, 2, 3 — not NULL — proving the run coalesces the
     // virtual slot, not just resolves it.
     try virtual().expect("""
@@ -1936,17 +1936,17 @@ struct EngineNaturalUsingTests {
         yields: [[1], [2], [3]])
   }
 
-  // MARK: - A merged name a later plain join re-collides with on the VIRTUAL
+  // MARK: - A merged name a later plain join re-collides with on the virtual
   // axis (round 8)
 
   @Test func `a bare merged Id a later plain join's virtual Id re-collides with faults`()
       throws {
-    // `Few JOIN Many USING (Id)` merges the VIRTUAL `Id` of both sides; a later
-    // plain `JOIN Emp ON 1 = 1` brings `Emp`'s OWN addressable virtual `Id`. A
-    // bare `Id` now names BOTH the merged column and `Emp.Id`, so it faults
+    // `Few JOIN Many USING (Id)` merges the virtual `Id` of both sides; a later
+    // plain `JOIN Emp ON 1 = 1` brings `Emp`'s own addressable virtual `Id`. A
+    // bare `Id` now names both the merged column and `Emp.Id`, so it faults
     // `.ambiguous` — the merged bare lookup scans the FULL addressable surface
     // (physical AND virtual, `Scope.ordinal(of:)`'s), not a real-only one that
-    // would MISS the virtual `Emp.Id` and wrongly take the merged value. run
+    // would miss the virtual `Emp.Id` and wrongly take the merged value. run
     // and `columns(of:)` agree.
     let text = "SELECT Id FROM Few JOIN Many USING (Id) JOIN Emp ON 1 = 1"
     try virtual().expect(text, fails: .ambiguous("Id"))
@@ -1976,7 +1976,7 @@ struct EngineNaturalUsingTests {
     // 1 JOIN Coded USING (Id)` accumulates a left carrying BOTH the merged `Id`
     // and the plain-joined `Emp.Id` (virtual), so keying the final `USING (Id)`
     // on that left is ambiguous — the left resolution (`Scope.left`) routes
-    // through the SAME full-surface merged bare lookup and faults.
+    // through the same full-surface merged bare lookup and faults.
     try virtual().expect("""
         SELECT v FROM Few JOIN Many USING (Id) JOIN Emp ON 1 = 1
         JOIN Coded USING (Id)
@@ -1986,7 +1986,7 @@ struct EngineNaturalUsingTests {
 
   @Test func `qualified sides of a virtual-Id merge still resolve past a re-collision`()
       throws {
-    // With bare `Id` ambiguous, each QUALIFIED reference still reaches its own
+    // With bare `Id` ambiguous, each qualified reference still reaches its own
     // side unambiguously: `Few.Id`/`Many.Id` the merge constituents (both the
     // matched row index 1), `Emp.Id` the later plain join's virtual `Id` (the
     // three `Emp` rows' indices 1..3) — never a fault.
@@ -2000,7 +2000,7 @@ struct EngineNaturalUsingTests {
   @Test func `a bare merged name a later plain join lacks stays unambiguous`()
       throws {
     // The control: when the later plain join's relation does NOT expose the
-    // merged name, the full-surface scan finds NO non-constituent match and the
+    // merged name, the full-surface scan finds no non-constituent match and the
     // bare name resolves to the merged column — no false ambiguity. `Emp JOIN
     // Team USING (Dept)` merges `Dept`; `Other(y)` carries no `Dept`, so a bare
     // `Dept` still coalesces (only Dept 20 matches on both sides). run and
@@ -2029,12 +2029,12 @@ struct EngineNaturalUsingTests {
 
   @Test func `a virtual-Id USING SELECT * width equals its emitted arity`()
       throws {
-    // `SELECT * FROM Emp JOIN Team USING (Id)` merges the VIRTUAL `Id` of both
+    // `SELECT * FROM Emp JOIN Team USING (Id)` merges the virtual `Id` of both
     // sides. No REAL column is subsumed (both `Id`s are virtual), so the arm
-    // emits FIVE values (the merged `Id`, then `Emp`'s two real columns, then
+    // emits five values (the merged `Id`, then `Emp`'s two real columns, then
     // `Team`'s two) — and the computed `SELECT *` width must equal that count,
     // not undercount by subtracting the virtual constituents from a real-only
-    // sum. The width now DERIVES from the same enumeration `columns(of:)`
+    // sum. The width now derives from the same enumeration `columns(of:)`
     // walks, so the two agree by construction.
     let catalog = try named()
     try catalog.expect("SELECT * FROM Emp JOIN Team USING (Id)",
@@ -2050,7 +2050,7 @@ struct EngineNaturalUsingTests {
   @Test func `a set operation over a virtual-Id SELECT * matches arity 5`()
       throws {
     // The undercounted width fed the set-operation arity check, so a genuinely
-    // matching UNION was WRONGLY rejected. The left arm's `SELECT *` is arity 5
+    // matching UNION was wrongly rejected. The left arm's `SELECT *` is arity 5
     // (merged virtual `Id` + four real columns); a right arm of five columns
     // now unifies rather than faulting.
     try named().expect("""
@@ -2066,7 +2066,7 @@ struct EngineNaturalUsingTests {
 
   @Test func `a virtual-Id SELECT * set operation still faults a real arity mismatch`()
       throws {
-    // The floor: a right arm of the WRONG arity (three columns against the
+    // The floor: a right arm of the wrong arity (three columns against the
     // arm's five) still faults `.arity`, so deriving width from the enumeration
     // did not disable the check.
     try named().expect("""
@@ -2077,7 +2077,7 @@ struct EngineNaturalUsingTests {
 
   @Test func `an ORDER BY ordinal past the merged width resolves`() throws {
     // The undercounted width (3) made the `ORDER BY` ordinal bound in the
-    // type-check path (`columns(of:validate:true)`) REJECT a valid ordinal (4
+    // type-check path (`columns(of:validate:true)`) reject a valid ordinal (4
     // or 5) that names a real output column — the width there feeds the bound.
     // The width is now 5, so ordinal 5 (`Team`'s `Lead`) type-checks, and the
     // run resolves and sorts by it.
@@ -2110,9 +2110,9 @@ struct EngineNaturalUsingTests {
   }
 }
 
-/// Fixtures for the VIRTUAL-`Id` named-column join cases. `Coded` carries a
+/// Fixtures for the virtual-`Id` named-column join cases. `Coded` carries a
 /// REAL `Id` column (which shadows its own virtual `Id`), so a `USING (Id)`
-/// against `Emp`'s VIRTUAL `Id` mixes a real and a virtual constituent. `Few`
+/// against `Emp`'s virtual `Id` mixes a real and a virtual constituent. `Few`
 /// (one row) RIGHT-joined to `Many` (three rows) `USING (Id)` produces two
 /// right-only rows whose merged `Id` must coalesce to `Many`'s row index.
 private func virtual() throws -> FixtureCatalog {
@@ -2138,7 +2138,7 @@ private func virtual() throws -> FixtureCatalog {
   }
 }
 
-/// Three relations for a chained named-column join over TWO DISTINCT columns:
+/// Three relations for a chained named-column join over two DISTINCT columns:
 /// `P(k, p)` and `Q(k, a, q)` share `k`, and `Q` and `R(a, r)` share `a`, so
 /// `(P JOIN Q USING (k)) JOIN R USING (a)` merges `k` at the INNER join and `a`
 /// at the OUTER one — the ISO 7.10 output order is `[a, k, p, q, r]`. `P

--- a/Tests/SQLTests/Queries/EngineValueAndSetTests.swift
+++ b/Tests/SQLTests/Queries/EngineValueAndSetTests.swift
@@ -239,7 +239,7 @@ struct EngineUnionTests {
   @Test func `an inner UNION dedups before a trailing UNION ALL appends its arm`() throws {
     // (Lhs UNION Rhs) UNION ALL Extra. The inner UNION dedups `shared`
     // across Lhs and Rhs to one row — `a, shared, b` — and the outer UNION
-    // ALL then appends Extra's `a` WITHOUT deduplicating, so `a` recurs. A
+    // ALL then appends Extra's `a` without deduplicating, so `a` recurs. A
     // chain flattened to the trailing `all` would instead keep both copies of
     // `shared`; honouring each node's own flag keeps exactly one.
     let rows = try tags().run(parse("""
@@ -273,9 +273,9 @@ struct EngineUnionTests {
 
   @Test func `an all-NULL view column unifies with a later text arm`() throws {
     // The reviewer's VIEW all-NULL case. The view `v`'s column `x` is a constant
-    // NULL in BOTH arms, so its resolved schema marks the column UNCONSTRAINED:
+    // NULL in both arms, so its resolved schema marks the column unconstrained:
     // an enclosing `SELECT x FROM v UNION SELECT 'c'` must unify the view column
-    // with the text `'c'` arm and RUN — yielding the NULL and the text — rather
+    // with the text `'c'` arm and run — yielding the NULL and the text — rather
     // than fault integer against text. The view's schema resolution builds its
     // Schema from the body carrier through `Schema(from:)`, so the `Scope`
     // reader reports the column unconstrained and the outer fold skips its type,
@@ -291,13 +291,13 @@ struct EngineUnionTests {
   @Test func `a predicate over a widened UNION view column tests the coerced type`() throws {
     // The reviewer's precision oracle. The view `V(x)` is `SELECT x FROM A
     // UNION ALL SELECT x FROM B`, where `A.x` is the integer 9007199254740993
-    // and `B.x` is the double 9007199254740992.0. The set operation WIDENS `x`
+    // and `B.x` is the double 9007199254740992.0. The set operation widens `x`
     // to `double` (an integer arm beside a double arm), so `combine` coerces
     // the integer arm's row to double — and 9007199254740993 is NOT
     // representable as a double, rounding to 9007199254740992.0. An outer
-    // `SELECT x FROM V WHERE x = 9007199254740992` must test the COERCED value:
+    // `SELECT x FROM V WHERE x = 9007199254740992` must test the coerced value:
     // the integer arm's row becomes 9007199254740992.0, which `== 9007..92`, so
-    // BOTH rows survive. Were the predicate pushed PER ARM below the widening
+    // both rows survive. Were the predicate pushed per ARM below the widening
     // set operation, the integer arm would test 9007199254740993 == ..92
     // exactly (the pre-coercion value) and DROP its row, yielding one — the
     // unsound behaviour the `widened` gate now prevents by keeping the
@@ -825,8 +825,8 @@ private func statement<C: Catalog & ~Escapable>(_ text: String,
   try catalog.run(Statement(parsing: text))
 }
 
-/// The ISO rule that a set operation's result column TYPE is the common type
-/// across ALL arms — not the first arm's — and each arm's values are COERCED to
+/// The ISO rule that a set operation's result column type is the common type
+/// across ALL arms — not the first arm's — and each arm's values are coerced to
 /// it: a mixed `integer`/`double` column widens to `double` and its integer
 /// values promote, an irreconcilable pair faults, and a constant-NULL arm
 /// constrains nothing. Homogeneous set operations are unchanged
@@ -849,7 +849,7 @@ struct EngineSetOperationCoercionTests {
 
   @Test func `INTERSECT and EXCEPT emit the coerced double`() throws {
     // Equality already canonicalises `1` and `1.0`, so both match/subtract; the
-    // coercion makes the EMITTED cell carry the unified `double` type.
+    // coercion makes the emitted cell carry the unified `double` type.
     try roster().expect("SELECT 1 INTERSECT SELECT 1.0", yields: [[1.0]])
     try roster().expect("SELECT 2 EXCEPT SELECT 1.0", yields: [[2.0]])
   }
@@ -901,7 +901,7 @@ struct EngineSetOperationCoercionTests {
     // `types` coerce the mixed integer/double arms to a `double` column (set-op
     // unification), and the `AS d(a)` list renames that column `a` (the
     // explicit output column list). Selecting `d.a` reads the widened, coerced
-    // values under the list's name — the two features COMPOSE.
+    // values under the list's name — the two features compose.
     try roster().expect(
         "SELECT d.a FROM (SELECT 1 UNION SELECT 2.5) AS d(a) ORDER BY d.a",
         yields: [[1.0], [2.5]])
@@ -909,7 +909,7 @@ struct EngineSetOperationCoercionTests {
 
   @Test func `a constant-NULL arm does not veto the widening`() throws {
     // A `NULLIF(2, 2)` arm folds to constant NULL, so it constrains nothing (a
-    // NULL unifies with any typed arm): the OTHER arm's `double` types the
+    // NULL unifies with any typed arm): the other arm's `double` types the
     // column, its NULL row stays NULL and the double row coerces.
     try roster().expect("SELECT NULLIF(2, 2) UNION SELECT 2.5",
                               yields: [[nil], [2.5]])
@@ -952,25 +952,25 @@ struct EngineSetOperationCoercionTests {
 
 // MARK: - Correlated / lateral all-NULL column mask unification
 
-/// A column reference resolves its TYPE and its `unconstrained` mask from ONE
-/// resolution over the SAME paths — local, correlation, schema — so a
+/// A column reference resolves its type and its `unconstrained` mask from one
+/// resolution over the same paths — local, correlation, schema — so a
 /// correlated all-NULL column (referenced through a LATERAL body) keeps its
 /// mask and unifies with a typed set-operation arm, rather than losing the mask
 /// through the correlation surface and folding as a concrete type. The mask
-/// reader once walked a LOCAL-only path while the type reader was
+/// reader once walked a local-only path while the type reader was
 /// correlation-aware, so a correlated all-NULL column dropped its mask; the
-/// read-side unification closes that gap. A GENUINELY-typed correlated column
-/// stays concrete (no over-marking), and a barred ORDINARY subquery projection
+/// read-side unification closes that gap. A genuinely-typed correlated column
+/// stays concrete (no over-marking), and a barred ordinary subquery projection
 /// still faults, so the unification widens nothing.
 struct EngineCorrelatedNullUnificationTests {
   @Test func `a correlated all-NULL column unifies through a LATERAL set-op arm`()
       throws {
-    // The reviewer's case. `t`'s column `x` is a constant NULL in BOTH arms, so
-    // it is UNCONSTRAINED. The lateral body `SELECT x UNION SELECT 'c'`
+    // The reviewer's case. `t`'s column `x` is a constant NULL in both arms, so
+    // it is unconstrained. The lateral body `SELECT x UNION SELECT 'c'`
     // references the correlated `x`, whose mask must survive the correlation
     // surface so the arm is unconstrained and unifies with the text `'c'` — the
     // body yields the NULL row and the `'c'` row. Before the read-side
-    // unification the mask was read LOCAL-only, so the correlated `x` folded as
+    // unification the mask was read local-only, so the correlated `x` folded as
     // a concrete integer and the arm faulted int-vs-text.
     let rows = try statement("""
         WITH t (x) AS (SELECT NULLIF(1, 1) UNION SELECT NULLIF('a', 'a'))
@@ -982,8 +982,8 @@ struct EngineCorrelatedNullUnificationTests {
 
   @Test func `a grandparent all-NULL column unifies through a nested LATERAL arm`()
       throws {
-    // The correlation crosses TWO lateral levels: `x` (from `t`) is read in the
-    // INNERMOST lateral body's set-op arm, which correlates to a scope two
+    // The correlation crosses two lateral levels: `x` (from `t`) is read in the
+    // innermost lateral body's set-op arm, which correlates to a scope two
     // enclosing levels up. The nearest-first `Outer` walk must carry `x`'s
     // unconstrained mask up from that grandparent scope, so the innermost arm
     // still unifies the NULL with the text `'c'`.
@@ -1000,7 +1000,7 @@ struct EngineCorrelatedNullUnificationTests {
 
   @Test func `a genuinely-typed correlated column in a LATERAL arm stays concrete`()
       throws {
-    // The over-marking guard: `t`'s column `x` is a CONCRETE integer (a plain
+    // The over-marking guard: `t`'s column `x` is a concrete integer (a plain
     // `SELECT 1`), so the correlated reference must NOT be marked
     // unconstrained — the lateral arm `SELECT x UNION SELECT 'c'` then folds a
     // genuine integer against text and faults `.operand` (SQLSTATE 42804),
@@ -1017,7 +1017,7 @@ struct EngineCorrelatedNullUnificationTests {
 
   @Test func `a local all-NULL column still unifies with a text arm`() throws {
     // The local (non-correlated) all-NULL regression: `x` resolves through the
-    // LOCAL path, whose resolved lookup carries the same mask, so a bare
+    // local path, whose resolved lookup carries the same mask, so a bare
     // reference in a set-op arm unifies with the text arm and runs.
     let rows = try statement("""
         WITH t (x) AS (SELECT NULLIF(1, 1) UNION SELECT NULLIF('a', 'a'))
@@ -1037,8 +1037,8 @@ struct EngineCorrelatedNullUnificationTests {
 
   @Test func `a barred ordinary subquery projection still faults 0A000`() throws {
     // The parity guard: the read-side resolution keeps the `admits` bar, so an
-    // ORDINARY (non-lateral) correlated subquery in a projection is still
-    // DIAGNOSED `.unsupported` — the unification does not widen acceptance. The
+    // ordinary (non-lateral) correlated subquery in a projection is still
+    // diagnosed `.unsupported` — the unification does not widen acceptance. The
     // barred surface faults the same on the run and schema paths.
     let people = try roster()
     #expect(throws: SQLError.state("0A000",
@@ -1051,14 +1051,14 @@ struct EngineCorrelatedNullUnificationTests {
 // MARK: - Unconstrained-mask channel seal (per-wrapper regression matrix)
 
 /// The class-level seal: a per-column `unconstrained` mask (an all-arms-NULL
-/// column places NO type constraint, so it unifies with any set-operation arm)
-/// must travel with a column's type through EVERY channel that stores or passes
-/// a RESOLVED column's type. Three channels carry a resolved column's type — the
-/// write/bindings carrier, the read/reference lookup, and the SCALAR-SUBQUERY
-/// output memo — and each is exercised here by a matched PAIR per wrapper shape:
-/// an all-NULL driver UNION'd with a typed arm must RUN (unify → the NULL row
-/// and the typed row), while a NON-null counterpart in the SAME shape must still
-/// FAULT `.operand` (SQLSTATE 42804), so the seal marks exactly the
+/// column places no type constraint, so it unifies with any set-operation arm)
+/// must travel with a column's type through every channel that stores or passes
+/// a resolved column's type. Three channels carry a resolved column's type — the
+/// write/bindings carrier, the read/reference lookup, and the scalar-subquery
+/// output memo — and each is exercised here by a matched pair per wrapper shape:
+/// an all-NULL driver UNION'd with a typed arm must run (unify → the NULL row
+/// and the typed row), while a non-null counterpart in the same shape must still
+/// fault `.operand` (SQLSTATE 42804), so the seal marks exactly the
 /// constant-NULL columns and no others. The scalar-subquery pair is the fix for
 /// the last leaking channel: the output memo once stored a bare `ValueType`, so
 /// a scalar wrapper dropped the mask — `SELECT (SELECT NULLIF('a','a')) UNION
@@ -1078,10 +1078,10 @@ struct EngineUnconstrainedMaskSealTests {
 
   @Test func `a scalar-subquery all-NULL wrapper unifies; a typed one faults`()
       throws {
-    // THE FIX. The scalar subquery `(SELECT NULLIF('a','a'))` collapses to a
-    // constant NULL, so its resolved output column is UNCONSTRAINED — the memo
+    // the fix. The scalar subquery `(SELECT NULLIF('a','a'))` collapses to a
+    // constant NULL, so its resolved output column is unconstrained — the memo
     // now carries that mask into the outer fold, which unifies the wrapper with
-    // the integer arm and RUNS (NULL row + `1` row). A genuinely-typed wrapper
+    // the integer arm and runs (NULL row + `1` row). A genuinely-typed wrapper
     // `(SELECT 'a')` stays concrete text and faults int-vs-text.
     try roster().expect(
         "SELECT (SELECT NULLIF('a', 'a')) UNION SELECT 1",
@@ -1093,9 +1093,9 @@ struct EngineUnconstrainedMaskSealTests {
 
   @Test func `a scalar subquery over a both-NULL UNION unifies; a typed one faults`()
       throws {
-    // The scalar subquery's OWN body is a set operation both of whose arms fold
+    // The scalar subquery's own body is a set operation both of whose arms fold
     // to constant NULL, so the inner unification leaves the column
-    // unconstrained — the memo carries THAT mask out, and the outer fold unifies
+    // unconstrained — the memo carries that mask out, and the outer fold unifies
     // the wrapper with the text `'c'` arm. A typed inner UNION (`SELECT 1 UNION
     // SELECT 2`) stays a concrete integer and faults int-vs-text.
     try roster().expect("""
@@ -1124,29 +1124,29 @@ struct EngineUnconstrainedMaskSealTests {
 
 // MARK: - Placeholder-column unconstrained closure (fold defers, not faults)
 
-/// The invariant that closes two feedback classes with ONE rule: a carrier
-/// column whose type is a FABRICATED PLACEHOLDER (not a genuine derivation) is
-/// marked UNCONSTRAINED, so the set-operation `merge` fold DEFERS to the other
+/// The invariant that closes two feedback classes with one rule: a carrier
+/// column whose type is a fabricated placeholder (not a genuine derivation) is
+/// marked unconstrained, so the set-operation `merge` fold defers to the other
 /// arm rather than faulting on the placeholder — faulting ONLY on two
 /// genuinely-known irreconcilable types.
 ///
-/// Two placeholders are closed here. An UNREGISTERED routine call has no
+/// Two placeholders are closed here. An unregistered routine call has no
 /// genuine return type (the derive fabricates the `.integer` default), so its
-/// fold defers — at ANY depth, whether the call is BARE (`missing()`) or
-/// NESTED in a composite (`missing() + 0`, `COALESCE(missing(), 1)`, a `CASE`
-/// result, an argument of a registered call); the SEPARATE reachable typecheck
-/// still raises `SQLError.function` when the arm is REACHED, so a
-/// genuinely-missing routine is never hidden — only the FOLD defers. A CTE's
+/// fold defers — at ANY depth, whether the call is bare (`missing()`) or
+/// nested in a composite (`missing() + 0`, `COALESCE(missing(), 1)`, a `CASE`
+/// result, an argument of a registered call); the separate reachable typecheck
+/// still raises `SQLError.function` when the arm is reached, so a
+/// genuinely-missing routine is never hidden — only the fold defers. A CTE's
 /// declared-name carrier is likewise a placeholder, so a genuine body
-/// incompatibility (`SELECT 'b' UNION SELECT 1`) PROPAGATES `.operand`
+/// incompatibility (`SELECT 'b' UNION SELECT 1`) propagates `.operand`
 /// identically at run and at `columns(of:validate:true)`, rather than being
-/// swallowed into a phantom `.integer`. A REGISTERED-only expression carries a
+/// swallowed into a phantom `.integer`. A registered-only expression carries a
 /// genuine type and still constrains, and a literal mismatch still faults, so
 /// the deferral marks exactly the placeholders and no others.
 struct EnginePlaceholderUnconstrainedClosureTests {
   @Test func `a bare unregistered call in a reached arm still faults function`()
       throws {
-    // The unregistered `missing()` is REACHED (a FROM-less single-row arm), so
+    // The unregistered `missing()` is reached (a FROM-less single-row arm), so
     // the reachable typecheck raises `SQLError.function` — NOT `.operand`. The
     // fold deferring on the placeholder does not hide the missing routine.
     try roster().expect("SELECT missing() UNION SELECT 'x'",
@@ -1175,7 +1175,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
 
   @Test func `an unreached nested unregistered call defers and the union runs`()
       throws {
-    // The reviewer oracle: `NOPE(Name) + 0` NESTS the unregistered call in a
+    // The reviewer oracle: `NOPE(Name) + 0` nests the unregistered call in a
     // `.binary`, which the former shallow bare-call case did not catch. The
     // zero-row arm never evaluates it, so `unresolved` marks the arm
     // unconstrained and the fold defers to the text `'x'` rather than faulting
@@ -1202,7 +1202,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
     // Nested in a `COALESCE`: the FROM-less arm's `COALESCE(missing(), 1)`
     // contains the unregistered call, so `unresolved` marks it unconstrained
     // and the fold defers to the text `'x'` rather than faulting `.operand`. A
-    // FROM-less single-row arm is REACHED, so `missing()` dispatches — hence
+    // FROM-less single-row arm is reached, so `missing()` dispatches — hence
     // the run faults `.function`, proving the deferral touches only the fold.
     try roster().expect("SELECT COALESCE(missing(), 1) UNION SELECT 'x'",
                               fails: .function("missing"))
@@ -1210,7 +1210,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
 
   @Test func `a COALESCE selecting an earlier non-NULL arg constrains the fold`()
       throws {
-    // `COALESCE(1, missing())` SELECTS the constant integer `1` and never
+    // `COALESCE(1, missing())` selects the constant integer `1` and never
     // reaches `missing()` (both `unified` and the executor stop there), so the
     // left arm constrains the set-op as integer — the text `'x'` arm is
     // genuinely irreconcilable and must fault `.operand`, not defer and leave
@@ -1233,7 +1233,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
 
   @Test func `an unregistered call as a registered call argument defers`()
       throws {
-    // Nested as an ARGUMENT of a REGISTERED call: `up(missing())` — `up` is
+    // Nested as an argument of a registered call: `up(missing())` — `up` is
     // registered, but its argument dispatches the unregistered `missing()`, so
     // `unresolved`'s `.call` arm recurses the arguments and marks the arm
     // unconstrained. The FROM-less arm is reached, so the run dispatches the
@@ -1246,7 +1246,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
 
   @Test func `an unreached nested unregistered call under COALESCE runs`()
       throws {
-    // The deferral is observable as a clean RUN when the nesting arm is
+    // The deferral is observable as a clean run when the nesting arm is
     // filtered out: a zero-row `COALESCE(missing(), 1)` arm never evaluates the
     // call, so the union folds and yields only the reached text `'x'`.
     try roster().expect("""
@@ -1257,8 +1257,8 @@ struct EnginePlaceholderUnconstrainedClosureTests {
 
   @Test func `a registered-only arithmetic mismatch still faults 42804`()
       throws {
-    // The nested over-suppression guard: a REGISTERED integer-returning call in
-    // an arithmetic expression carries a GENUINE type — `unresolved` finds no
+    // The nested over-suppression guard: a registered integer-returning call in
+    // an arithmetic expression carries a genuine type — `unresolved` finds no
     // unregistered call, so the arm stays constrained and the integer result
     // beside the text `'x'` still faults `.operand`. The recursion suppresses
     // ONLY unregistered calls, never a genuine mismatch.
@@ -1271,7 +1271,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
   }
 
   @Test func `pure literal arithmetic still faults 42804 beside text`() throws {
-    // The baseline nested guard: `1 + 0` folds to a GENUINE integer with no
+    // The baseline nested guard: `1 + 0` folds to a genuine integer with no
     // call at all, so it stays constrained and faults `.operand` against the
     // text `'x'` — the recursion adds no over-suppression to a call-free tree.
     try roster().expect(
@@ -1281,7 +1281,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
 
   @Test func `a scalar subquery with an unregistered call defers via the memo`()
       throws {
-    // Subquery composition: `(SELECT NOPE())` resolves its OWN single column
+    // Subquery composition: `(SELECT NOPE())` resolves its own single column
     // through the subquery memo (`scalar(resolved:)`), which already carries
     // the unconstrained mask for the unregistered call inside — so `unresolved`
     // returns false for the outer `.subquery` and does NOT double-handle it.
@@ -1294,7 +1294,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
 
   @Test func `a registered text-returning call still constrains and faults`()
       throws {
-    // The over-suppression guard: a REGISTERED routine has a GENUINE return
+    // The over-suppression guard: a registered routine has a genuine return
     // type, so its column is NOT a placeholder and still constrains — a
     // text-returning call beside an integer arm faults `.operand`.
     let routines: Routines = [
@@ -1307,7 +1307,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
   }
 
   @Test func `a registered call unifying with a matching arm runs`() throws {
-    // The counterpart: a registered call whose genuine return type UNIFIES with
+    // The counterpart: a registered call whose genuine return type unifies with
     // the other arm folds cleanly and runs.
     let routines: Routines =
         ["tag": Routine(returns: .text, parameters: [.text]) { row in row[0] }]
@@ -1317,7 +1317,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
   }
 
   @Test func `a literal type mismatch still faults 42804`() throws {
-    // The baseline over-suppression guard: two GENUINE literal types still fold
+    // The baseline over-suppression guard: two genuine literal types still fold
     // to an irreconcilable pair and fault — the closure widens nothing.
     try roster().expect(
         "SELECT 1 UNION SELECT 'x'",
@@ -1325,8 +1325,8 @@ struct EnginePlaceholderUnconstrainedClosureTests {
   }
 
   @Test func `a genuine CTE body incompatibility faults at run`() throws {
-    // The CTE-validate case at RUN: the body `SELECT 'b' UNION SELECT 1` folds
-    // two GENUINE types (text vs integer) — irreconcilable — so the run faults
+    // The CTE-validate case at run: the body `SELECT 'b' UNION SELECT 1` folds
+    // two genuine types (text vs integer) — irreconcilable — so the run faults
     // `.operand` rather than swallowing it into the declared `.integer`
     // placeholder.
     #expect(throws: SQLError.operand("UNION arms have irreconcilable types")) {
@@ -1338,7 +1338,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
 
   @Test func `a genuine CTE body incompatibility faults at columns validate`()
       throws {
-    // The SAME case at the schema path: `columns(of:validate:true)` must ALSO
+    // The same case at the schema path: `columns(of:validate:true)` must also
     // throw `.operand` — no divergence, no phantom integer column advertised
     // for a query that cannot run.
     let statement = try Statement(parsing:
@@ -1353,13 +1353,13 @@ struct EnginePlaceholderUnconstrainedClosureTests {
 
 /// The reachability-aware deferral of a nested subquery's set-operation
 /// operand-compatibility fold. The shape pre-pass (`subquery(of:)`/`width`)
-/// records every nested subquery's width and single-column type AHEAD of the
+/// records every nested subquery's width and single-column type ahead of the
 /// walk that decides which subqueries actually run, so it must NOT fault
 /// `SQLError.operand` (SQLSTATE 42804) on an incompatible set-operation
 /// subquery a short-circuited `AND`/`OR` leg never reaches — a `… WHERE 1 = 0
 /// AND EXISTS (SELECT 'x' UNION SELECT 1)` runs and yields no rows. Deferral
-/// alone would HIDE a genuine incompatibility in a subquery that DOES run, so
-/// a REACHED scalar or `IN`/quantified occurrence is re-folded strictly on the
+/// alone would hide a genuine incompatibility in a subquery that does run, so
+/// a reached scalar or `IN`/quantified occurrence is re-folded strictly on the
 /// reached path and faults exactly as before; an `EXISTS`/`LATERAL` reach does
 /// not constrain column type and never faults on it. The top-level and CTE
 /// folds are outside the pre-pass (`shape` is `false`), so they keep faulting.
@@ -1376,7 +1376,7 @@ struct EngineDeferredSetopShapeTests {
   }
 
   @Test func `a reached EXISTS over an incompatible UNION runs`() throws {
-    // A REACHED `EXISTS` does not read the arms' unified column type — its
+    // A reached `EXISTS` does not read the arms' unified column type — its
     // cardinality probe never evaluates the select list — so it must NOT fault
     // on the incompatible pair (role `.existential`, skipped by the re-fold).
     // People has rows, so the EXISTS is present and every row projects `1`.
@@ -1395,7 +1395,7 @@ struct EngineDeferredSetopShapeTests {
   }
 
   @Test func `a reached IN over an incompatible UNION faults 42804`() throws {
-    // A REACHED `IN` reads its value set's column type (role `.valued`), so the
+    // A reached `IN` reads its value set's column type (role `.valued`), so the
     // re-fold on the reached path restores the strict operand check and the
     // incompatible UNION faults 42804 — the deferral does not hide it.
     try roster().expect("""
@@ -1404,7 +1404,7 @@ struct EngineDeferredSetopShapeTests {
   }
 
   @Test func `a reached scalar-subquery incompatible UNION faults 42804`() throws {
-    // A REACHED scalar subquery collapses to a single cell (role `.scalar`), so
+    // A reached scalar subquery collapses to a single cell (role `.scalar`), so
     // the reached re-fold checks its arms strictly and the incompatible UNION
     // faults 42804 in the comparison.
     try roster().expect("""
@@ -1414,7 +1414,7 @@ struct EngineDeferredSetopShapeTests {
 
   @Test func `a dead-branch scalar-subquery incompatible UNION runs to no rows`()
       throws {
-    // The SAME scalar subquery behind `1 = 0 AND …` is unreachable, so its
+    // The same scalar subquery behind `1 = 0 AND …` is unreachable, so its
     // operand fold defers in the pre-pass and the query runs to no rows.
     try roster().empty("""
         SELECT 1 FROM People
@@ -1444,17 +1444,17 @@ struct EngineDeferredSetopShapeTests {
 
 // MARK: - Reached-correlated set-op fold and invalid-call suppression
 
-/// The two execution-seam refinements of the deferred set-op fold. A REACHED
-/// correlated non-EXISTS subquery re-executes the SHAPED (placeholder-typed)
+/// The two execution-seam refinements of the deferred set-op fold. A reached
+/// correlated non-EXISTS subquery re-executes the shaped (placeholder-typed)
 /// plan the pre-pass recorded under `.shaping()`, so it must strict-fold its
-/// arms' column types at the EXECUTION seam (`Filter.executed`) — not from the
+/// arms' column types at the execution seam (`Filter.executed`) — not from the
 /// shaped plan — faulting `.operand` (42804) exactly as the uncorrelated run
-/// path does, and ONLY for a REACHED occurrence (an unreachable one never runs
+/// path does, and ONLY for a reached occurrence (an unreachable one never runs
 /// `executed`, so its deferral stands); an `EXISTS` reach never reads column
-/// type and does not fault. Separately, an INVALID routine call (bad arity or a
-/// definitively-wrong argument type) to an EXISTING routine is treated like a
-/// MISSING one — its fabricated declared type must NOT constrain the fold — so
-/// an invalid call in an UNREACHED arm folds away, while a VALID call's genuine
+/// type and does not fault. Separately, an invalid routine call (bad arity or a
+/// definitively-wrong argument type) to an existing routine is treated like a
+/// missing one — its fabricated declared type must NOT constrain the fold — so
+/// an invalid call in an unreached arm folds away, while a valid call's genuine
 /// return type still constrains (the over-suppression guard).
 struct EngineReachedCorrelatedSetopTests {
   @Test func `a reached correlated IN over an incompatible UNION faults 42804`()
@@ -1473,7 +1473,7 @@ struct EngineReachedCorrelatedSetopTests {
 
   @Test func `a dead-branch correlated IN over an incompatible UNION runs empty`()
       throws {
-    // The SAME correlated `IN` behind `1 = 0 AND …` is unreachable, so it never
+    // The same correlated `IN` behind `1 = 0 AND …` is unreachable, so it never
     // reaches the execution seam — its shape deferral stands and the query runs
     // to no rows.
     try roster().empty("""
@@ -1497,7 +1497,7 @@ struct EngineReachedCorrelatedSetopTests {
   }
 
   @Test func `an invalid unreached call does not constrain the fold`() throws {
-    // `tag(text) RETURNS text` called with NO argument is invalid (bad arity),
+    // `tag(text) RETURNS text` called with no argument is invalid (bad arity),
     // so it is treated like a missing call — its declared `text` return does
     // NOT constrain the fold. The invalid arm is unreached (`FETCH FIRST 0 ROWS
     // ONLY`), so the fold defers to the integer right arm and the query yields
@@ -1512,7 +1512,7 @@ struct EngineReachedCorrelatedSetopTests {
 
   @Test func `an invalid reachable call faults on its bad arity, not 42804`()
       throws {
-    // The counterpart on a VALIDATING path: `SELECT tag() UNION SELECT 1` calls
+    // The counterpart on a validating path: `SELECT tag() UNION SELECT 1` calls
     // `tag(text)` with no argument. The invalid call does not constrain the
     // fold (so no spurious 42804), but the strict `validate: true` schema path
     // catches the bad arity and faults `.argument` — NOT the operand fold. (The
@@ -1529,7 +1529,7 @@ struct EngineReachedCorrelatedSetopTests {
 
   @Test func `a valid text call still constrains the fold and faults 42804`()
       throws {
-    // The over-suppression guard: `tag('a')` is a VALID call (correct arity and
+    // The over-suppression guard: `tag('a')` is a valid call (correct arity and
     // argument type), so its declared `text` return still constrains the fold —
     // a text column beside an integer arm faults 42804. The invalid-call
     // suppression must not swallow a valid call's genuine type.

--- a/Tests/SQLTests/Queries/EngineViewAndPushdownTests.swift
+++ b/Tests/SQLTests/Queries/EngineViewAndPushdownTests.swift
@@ -95,21 +95,21 @@ struct EngineViewTests {
 
 // MARK: - A view body must not correlate against the caller's row
 
-/// A view is DEFINED independently of its call site, so its body must NOT bind
+/// A view is defined independently of its call site, so its body must NOT bind
 /// an unbound column to an enclosing query's row — even when the view is used
 /// from inside a (correlated) subquery, whose compile threads its enclosing
 /// scope as the correlation stack.
 ///
 /// Folding the correlation stack into `Context` made the view-body compile path
-/// inherit the caller's `outer`, so an unbound column in the view DEFINITION
+/// inherit the caller's `outer`, so an unbound column in the view definition
 /// (`WHERE k = 1`, where `k` is NOT in the view's own FROM) wrongly bound to a
 /// caller's row when the enclosing relation happened to have a column `k`.
 /// Clearing the correlation stack entering the view-body overlay restores the
-/// fault: the view body cannot see the caller's row, so `k` is unbound at BOTH
+/// fault: the view body cannot see the caller's row, so `k` is unbound at both
 /// compile and run.
 struct EngineViewCorrelationTests {
   /// An outer `Env` carrying a column `k` a leaking view body could bind to,
-  /// a source `Src` WITHOUT `k`, and a view `Bad` whose body references the
+  /// a source `Src` without `k`, and a view `Bad` whose body references the
   /// unbound `k`.
   private func leaky() throws -> EngineMemory {
     let bad = try View(query: select("SELECT n FROM Src WHERE k = 1"),
@@ -136,7 +136,7 @@ struct EngineViewCorrelationTests {
 
   @Test func `the view faults at compile under a subquery, not only at run`()
       throws {
-    // Schema ↔ run parity: the STRICT schema pass faults the view body's
+    // Schema ↔ run parity: the strict schema pass faults the view body's
     // unbound `k` too, rather than binding it to the caller — the leak the fold
     // introduced would have compiled a schema for a view that cannot run.
     let query = try parse(
@@ -147,7 +147,7 @@ struct EngineViewCorrelationTests {
   }
 
   @Test func `a valid view under a subquery still resolves and runs`() throws {
-    // Control: a LEGITIMATE view (its body self-contained) used from a nested
+    // Control: a legitimate view (its body self-contained) used from a nested
     // subquery still resolves and runs — clearing the view body's correlation
     // stack does not disturb a well-formed view. `Good` reads `Src` (one row),
     // so the EXISTS holds for every `Env` row.
@@ -185,21 +185,21 @@ struct EngineViewCorrelationTests {
 
   // MARK: - schema(of:) view-body derivation must not correlate either
 
-  /// The `schema(of:)` seam — the view-body SCHEMA/type derivation `scope(of:)`
+  /// The `schema(of:)` seam — the view-body schema/type derivation `scope(of:)`
   /// drives, resolving a `FROM <view>`'s relations to their types — entered the
-  /// view-body overlay via `scoping([:]).visiting(name)` WITHOUT clearing the
-  /// caller's correlation stack, the ONE view-body body-entry the prior round
-  /// missed. So when a view whose DEFINITION references a column absent from its
+  /// view-body overlay via `scoping([:]).visiting(name)` without clearing the
+  /// caller's correlation stack, the one view-body body-entry the prior round
+  /// missed. So when a view whose definition references a column absent from its
   /// own FROM had its schema derived while under a correlated subquery whose
-  /// outer relation HAS that column, the type-derivation bound the unbound
-  /// column OUTWARD to the caller's row rather than faulting — disagreeing with
+  /// outer relation has that column, the type-derivation bound the unbound
+  /// column outward to the caller's row rather than faulting — disagreeing with
   /// the compile/run path `resolve`/`overlay` now clear. Routing every body-
   /// entry through `Context.body(_:)` (which appends `uncorrelated()`) closes
   /// it: `schema(of:)` faults the unbound column, consistent with compile/run.
 
-  /// An outer `Env(k)` a leaking view PROJECTION could bind to, a source `Src`
-  /// WITHOUT `k`, and a view `Proj` whose body PROJECTS the unbound `k` — so its
-  /// SCHEMA (the projection's type) is what a leak would derive from the caller.
+  /// An outer `Env(k)` a leaking view projection could bind to, a source `Src`
+  /// without `k`, and a view `Proj` whose body projects the unbound `k` — so its
+  /// schema (the projection's type) is what a leak would derive from the caller.
   private func leaked() throws -> EngineMemory {
     let proj = try View(query: select("SELECT k AS m FROM Src"),
                         columns: ["m"])
@@ -211,7 +211,7 @@ struct EngineViewCorrelationTests {
     ], views: ["Proj": proj])
   }
 
-  /// A correlation stack whose NEAREST enclosing scope is `Env(k)` — the
+  /// A correlation stack whose nearest enclosing scope is `Env(k)` — the
   /// context a nested subquery's schema derivation runs under, so a leaking
   /// `schema(of:)` could bind an unbound view-projection column to `Env.k`. It
   /// nests a scope built from `Env`'s own schema (derived off the catalog),
@@ -224,7 +224,7 @@ struct EngineViewCorrelationTests {
   @Test
   func `schema of a view under a correlated scope does not bind the caller`()
       throws {
-    // Directly exercise the `schema(of:)` seam in ISOLATION: derive the scope
+    // Directly exercise the `schema(of:)` seam in isolation: derive the scope
     // of `SELECT m FROM Proj` under a correlation stack whose enclosing scope
     // is `Env(k)`. `scope(of:)` calls `schema(of: Proj)`, which enters the
     // view body to type its projection `k` — absent from `Proj`'s own FROM
@@ -247,7 +247,7 @@ struct EngineViewCorrelationTests {
   func `schema of a valid view under a correlated scope still derives`()
       throws {
     // Control: a well-formed view whose projection is self-contained still has
-    // its schema derived under the SAME correlated scope — clearing the schema
+    // its schema derived under the same correlated scope — clearing the schema
     // path's correlation stack does not disturb a legitimate view. `Fine`
     // projects `n` (in its own `Src`), so `scope(of:)` derives cleanly.
     let fine = try View(query: select("SELECT n AS m FROM Src"),
@@ -269,7 +269,7 @@ struct EngineViewCorrelationTests {
       throws {
     // End-to-end parity control: running `SELECT m FROM Proj` (outside any
     // correlation) faults the unbound projection `k` too, so the schema seam's
-    // fault under a correlated scope AGREES with the plain run — schema ↔ run.
+    // fault under a correlated scope agrees with the plain run — schema ↔ run.
     try leaked().expect("SELECT m FROM Proj", fails: .column("k"))
   }
 }
@@ -511,7 +511,7 @@ func residue(_ plan: Plan) -> Bool {
   }
 }
 
-/// Whether `plan` reaches a `.select` standing directly over ANOTHER `.select`
+/// Whether `plan` reaches a `.select` standing directly over another `.select`
 /// over a `.product` — the WHERE-above-a-separate-ON-gate shape the barrier
 /// preserves (the outer `select` the `WHERE`, the inner the residual `ON`
 /// gate), as opposed to one fused `.select(ON AND WHERE, product)`.
@@ -550,7 +550,7 @@ func separated(_ plan: Plan) -> Bool {
   }
 }
 
-/// Whether `plan` reaches a `.select` standing over ANOTHER `.select` over a
+/// Whether `plan` reaches a `.select` standing over another `.select` over a
 /// `.join` — the WHERE-above-a-leftover-ON-gate shape the always-barrier rule
 /// preserves for a pure-equi `ON` whose extra equi key `nest` leaves gating
 /// over the hash join (the outer `select` the `WHERE`, the inner the leftover
@@ -594,7 +594,7 @@ func stacked(_ plan: Plan) -> Bool {
 
 /// A join catalog whose inner `Child` relation tallies its row reads, plus a
 /// view `Kin` over the `Parent`/`Child` join — to prove a `WHERE` over the view
-/// prunes the join's inputs BEFORE the join runs rather than after. The counter
+/// prunes the join's inputs before the join runs rather than after. The counter
 /// rides the `Parent` relation (sorted on `Id`), so a pushed seekable key reads
 /// fewer of its rows regardless of the inner join strategy.
 private func counted() throws -> (catalog: EngineMemory, reads: EngineCounter) {
@@ -633,9 +633,9 @@ private func counted() throws -> (catalog: EngineMemory, reads: EngineCounter) {
 }
 
 /// A catalog for pushing a filter through a UNION view's arms: two relations
-/// whose shared output column `Key` sits at DIFFERENT body ordinals — `Alpha`
+/// whose shared output column `Key` sits at different body ordinals — `Alpha`
 /// has it first (sorted, so seekable), `Beta` last (unsorted) — exposed by a
-/// `Both` view as one column. A `WHERE Key = ?` over the view must rebase PER
+/// `Both` view as one column. A `WHERE Key = ?` over the view must rebase per
 /// arm (each arm maps `Key` to its own body slot), pushing below every arm's
 /// projection and seeking inside the `Alpha` arm.
 private func spanned() throws -> EngineMemory {
@@ -826,11 +826,11 @@ struct EnginePushdownTests {
   }
 
   @Test func `a spanning WHERE leaves the join path with a residual above it`() throws {
-    // `WHERE Parent.Name <> Child.Name` references BOTH joined relations, so it
+    // `WHERE Parent.Name <> Child.Name` references both joined relations, so it
     // descends no further than the product and stays as a residual. The ON
     // match must remain adjacent to the product — folded in with the spanning
     // conjunct — so `nest` still finds it and forms a `Join`, keeping the
-    // spanning predicate as a `Select` ABOVE the join rather than degrading to a
+    // spanning predicate as a `Select` above the join rather than degrading to a
     // filtered Cartesian `product`.
     let catalog = try family()
     let select = try parse("""
@@ -898,7 +898,7 @@ struct EnginePushdownTests {
   }
 
   @Test func `a throwing single-side predicate stays above the join, skips an empty product`() throws {
-    // `WHERE (1 / A.x) = 0` reads only `A`'s slot but CAN throw (division), so —
+    // `WHERE (1 / A.x) = 0` reads only `A`'s slot but can throw (division), so —
     // like a slotless throwing predicate — it must stay at the product level, not
     // ride down to `A`. `B` is empty, so the product is empty and the division is
     // never evaluated; the query returns no rows. Pushed to `A` (x = 0) it would
@@ -938,7 +938,7 @@ struct EnginePushdownTests {
     // `WHERE Parent.Name = 'nope' AND (1 / Child.x) = 0`: left-to-right, the
     // false `Parent.Name` check short-circuits before the division on the
     // matching pair (Child.x = 0). `Parent.Name = 'nope'` is a single-side inner
-    // filter that nest lifts out of the join — it must stay BEFORE the unsafe
+    // filter that nest lifts out of the join — it must stay before the unsafe
     // division in the residual, not be appended after it, or the division runs
     // first and raises. The matching Parent is named 'other', so the row is
     // excluded with no throw.
@@ -960,7 +960,7 @@ struct EnginePushdownTests {
 
   @Test func `a WHERE over a UNION view pushes into every arm's projection`() throws {
     // `Both` unions `Alpha` and `Beta`, whose shared `Key` output column sits at
-    // DIFFERING body slots. `WHERE Key = 2` must rebase PER ARM — the union root
+    // differing body slots. `WHERE Key = 2` must rebase per ARM — the union root
     // fails a single pre-rebased filter — pushing below each arm's projection
     // and seeking the sorted `Alpha` arm.
     let catalog = try spanned()
@@ -998,7 +998,7 @@ struct EnginePushdownTests {
     // `V` is `SELECT x FROM T` with `T.x` sorted and a single `x = 0` row.
     // `SELECT x FROM V WHERE (1 / x) = 0 AND x = 1`: left-to-right, the division
     // runs on the `x = 0` row and raises. The safe seekable `x = 1` must NOT push
-    // into the view past the earlier unsafe `(1 / x) = 0` — doing so would SEEK
+    // into the view past the earlier unsafe `(1 / x) = 0` — doing so would seek
     // the view (`T.x` sorted) to `x = 1`, dropping the `x = 0` row before the
     // outer division ever runs, silently returning no rows. The unsafe outer
     // conjunct is an ordering barrier, so the query raises as the un-pushed `AND`
@@ -1020,7 +1020,7 @@ struct EnginePushdownTests {
     // references a slot, so a NULL there makes it UNKNOWN — pushing it to `A`'s
     // scan would drop the A.x-NULL row before the join, so the later unsafe
     // `(1 / B.y) = 0` never runs and the throw the `AND` owes is suppressed. A
-    // nullable conjunct must NOT ride past a LATER unsafe conjunct, so `A.x = 1`
+    // nullable conjunct must NOT ride past a later unsafe conjunct, so `A.x = 1`
     // stays a product-level residual and the query raises.
     let catalog = EngineMemory([
       "A": FixtureRelation([EngineField(name: "x", type: .integer),
@@ -1054,7 +1054,7 @@ struct EnginePushdownTests {
     // row the UNKNOWN left still runs the division, which raises. Pushing the
     // nullable `x = 1` into the view would drop the x-NULL row before the outer
     // division runs, suppressing the throw. A nullable conjunct must NOT be
-    // injected past a LATER unsafe outer conjunct, so `x = 1` stays outer and
+    // injected past a later unsafe outer conjunct, so `x = 1` stays outer and
     // the query raises.
     let t = [EngineField(name: "x", type: .integer),
              EngineField(name: "y", type: .integer)]
@@ -1135,37 +1135,37 @@ struct EnginePushdownTests {
 // MARK: - Set-op view type probe must not pollute the runtime plan memo
 
 /// The set-op column-type unification `compile` derives for a `UNION`/`EXCEPT`/
-/// `INTERSECT` view body runs a SCHEMA-ONLY projection PROBE (to learn which
+/// `INTERSECT` view body runs a schema-ONLY projection probe (to learn which
 /// columns the set operation widens). That probe lowers any nested correlated
 /// subquery under the `.caller` id space and — before the fix — recorded the
-/// subquery's per-outer-row PLAN into the SHARED runtime memo. Recording is
-/// first-writer-wins, so a later CALLER whose own correlated subquery has the
-/// SAME AST and correlation (`(SELECT Val FROM S WHERE S.Id = T.Id)` over a
+/// subquery's per-outer-row plan into the shared runtime memo. Recording is
+/// first-writer-wins, so a later caller whose own correlated subquery has the
+/// same AST and correlation (`(SELECT Val FROM S WHERE S.Id = T.Id)` over a
 /// same-shaped outer `T`) reused the VIEW body's plan — resolving `S` against
-/// the view's BASE table, not the caller's own CTE `S`. The probe must derive
-/// against an ISOLATED throwaway memo so it records nothing, letting each
-/// caller resolve its subquery against its OWN base.
+/// the view's base table, not the caller's own CTE `S`. The probe must derive
+/// against an isolated throwaway memo so it records nothing, letting each
+/// caller resolve its subquery against its own base.
 private func shadowed() throws -> EngineMemory {
   try Catalog {
     // The shared driver `T`, referenced by the view body AND the caller, so the
-    // correlated subquery's outer `T.Id` binds at the SAME ordinal in both — an
+    // correlated subquery's outer `T.Id` binds at the same ordinal in both — an
     // identical `Correlation`, hence an identical plan-memo key.
     Relation("T", ["Id": .integer]) {
       Row(1)
       Row(2)
     }
-    // The BASE `S` the VIEW body's `(SELECT Val FROM S …)` resolves against —
+    // The base `S` the VIEW body's `(SELECT Val FROM S …)` resolves against —
     // `Id` at ordinal 0, `Val` at ordinal 1. A caller CTE named `S` shadows it
-    // with the columns in the OPPOSITE order (`Val` at 0, `Id` at 1), so the
+    // with the columns in the opposite order (`Val` at 0, `Id` at 1), so the
     // view's compiled plan — which projects ordinal 1 and filters ordinal 0 —
-    // reads the WRONG cells if reused against the caller's CTE: it would
+    // reads the wrong cells if reused against the caller's CTE: it would
     // project the CTE's `Id` (ordinal 1) rather than its `Val` (ordinal 0).
     Relation("S", ["Id": .integer, "Val": .integer]) {
       Row(1, 1000)
       Row(2, 2000)
     }
     // A set-operation view whose LEFT arm holds a correlated scalar subquery
-    // `(SELECT Val FROM S WHERE S.Id = T.Id)` — the SAME AST the caller uses.
+    // `(SELECT Val FROM S WHERE S.Id = T.Id)` — the same AST the caller uses.
     // Compiling its body runs the `.setop` widened-column type probe, which
     // lowers that subquery under `.caller`; the probe must NOT record its plan.
     try View("V", """
@@ -1180,11 +1180,11 @@ struct EngineSetopViewMemoTests {
   @Test func `a set-op view type probe does not capture a caller's subquery`()
       throws {
     // The caller shadows base `S` with a CTE `S` whose columns are in the
-    // OPPOSITE order (`Val, Id`) and runs the IDENTICAL correlated subquery
+    // opposite order (`Val, Id`) and runs the identical correlated subquery
     // `(SELECT Val FROM S WHERE S.Id = T.Id)` over `T`. It also references the
     // set-op view `V`, whose body compile runs the widened-type probe over the
     // same subquery AST first. With the probe isolated, the caller's subquery
-    // resolves against ITS CTE `S` at ITS ordinals, projecting `Val` ∈ {7, 8};
+    // resolves against its CTE `S` at its ordinals, projecting `Val` ∈ {7, 8};
     // a probe that polluted the shared memo would make the caller reuse the
     // view's plan (base `S` ordinals — project ordinal 1, filter ordinal 0),
     // which over the swapped CTE projects `Id` ∈ {1, 2} (or mis-filters).

--- a/Tests/SQLTests/Queries/EngineWithTests.swift
+++ b/Tests/SQLTests/Queries/EngineWithTests.swift
@@ -27,13 +27,13 @@ struct EngineWithTests {
   }
 
   @Test func `a UNION over a text CTE column folds the body type`() throws {
-    // The CTE `a` binds its body's DERIVED type (`x` is text), so the set-op
+    // The CTE `a` binds its body's derived type (`x` is text), so the set-op
     // fold unifies text against text and runs — a `.integer` declared-name
     // placeholder would wrongly fault the all-text UNION as irreconcilable.
     let text = """
         WITH a (x) AS (SELECT 'b') SELECT x FROM a UNION SELECT 'c'
         """
-    // The SCHEMA path folds the CTE column at its BODY-derived type too: it
+    // The schema path folds the CTE column at its body-derived type too: it
     // must report `x` as `.text` and NOT fault, the compile-time mirror of the
     // run.
     let columns = try family().columns(of: Statement(parsing: text))
@@ -70,7 +70,7 @@ struct EngineWithTests {
   }
 
   @Test func `a JOIN keeps distinct large integer keys unequal (exact integers)`() throws {
-    // Two integers that round to the SAME Double past 2^53 are still unequal as
+    // Two integers that round to the same Double past 2^53 are still unequal as
     // integers, so an integer/integer join must NOT pair them — the hash bucket
     // may collide, but the residual `matches` check keeps integer equality
     // exact.
@@ -84,7 +84,7 @@ struct EngineWithTests {
 
   @Test func `UNION widens a mixed integer/double column and dedups the equal rows`() throws {
     // ISO unifies the result column type across the arms — an `integer` arm and
-    // a `double` arm widen to `double`, and each arm's values are COERCED to
+    // a `double` arm widen to `double`, and each arm's values are coerced to
     // it. `1` and `1.0` then compare equal AND emit as the same coerced
     // `double`, so a bare UNION keeps one `1.0` (not the first arm's raw
     // `integer`).
@@ -96,10 +96,10 @@ struct EngineWithTests {
   }
 
   @Test func `UNION coercion collapses integers a rounded double cannot separate`() throws {
-    // The unified column is `double`, so EVERY arm's value coerces to `double`
+    // The unified column is `double`, so every arm's value coerces to `double`
     // before the dedup: `2^53 + 1` (the integer `9007199254740993`) rounds to
-    // `2^53.0` on promotion, becoming EQUAL to the double `2^53.0` — so the
-    // three arms collapse to the ONE distinct `double`, the ISO
+    // `2^53.0` on promotion, becoming equal to the double `2^53.0` — so the
+    // three arms collapse to the one distinct `double`, the ISO
     // approximate-numeric result of a mixed-type UNION.
     let rows = try statement("""
         SELECT 9007199254740992.0
@@ -228,7 +228,7 @@ struct EngineWithTests {
     // pass it through vacuously and register `a` with a three-column schema
     // over a two-column body; the trailing `SELECT z` then reads an ordinal the
     // body never projects. The body's compiled width is checked against the
-    // declared arity BEFORE materialising, regardless of the row count, so the
+    // declared arity before materialising, regardless of the row count, so the
     // mismatch faults with `SQLError.columns` rather than silently returning
     // data.
     #expect(throws: SQLError.columns(expected: 2, got: 3)) {
@@ -285,7 +285,7 @@ struct EngineWithTests {
   }
 
   @Test func `a top-level FROM a CTE still resolves to the CTE, not the base relation`() throws {
-    // The complement of `viewScoping`: at the STATEMENT level a CTE that names a
+    // The complement of `viewScoping`: at the statement level a CTE that names a
     // base relation still shadows it, so a trailing `FROM Parent` reads the CTE
     // — the scoping fix narrows only a view's body, never the statement query.
     let adults =
@@ -313,7 +313,7 @@ struct EngineWithTests {
   }
 
   @Test func `a WITH RECURSIVE whose anchor reads a same-named base is not recursive`() throws {
-    // The CTE `Parent` shares a base relation's name; only the ANCHOR reads that
+    // The CTE `Parent` shares a base relation's name; only the anchor reads that
     // base (the CTE is not in scope there), while the recursive arm reads
     // `Extra` and never names the CTE. Self-reference is detected in the arm
     // alone, so this is NOT routed through the fixpoint: the two arms materialise
@@ -335,7 +335,7 @@ struct EngineWithTests {
 
   @Test func `a recursive CTE seeds its anchor from a same-named base column`()
       throws {
-    // The anchor `SELECT Age FROM Parent` reads the BASE `Parent` — the CTE
+    // The anchor `SELECT Age FROM Parent` reads the base `Parent` — the CTE
     // self, whose sole column is `n`, is not in scope for the base case — while
     // only the recursive arm names the self. The set-op type fold must resolve
     // the anchor under the base scope; folding the whole query under the self
@@ -428,8 +428,8 @@ struct EngineRecursiveTests {
     // A trailing `ORDER BY` on a recursive body lifts to a `Query.ordered`
     // carrier over the `UNION` setop. `columns(of:)` must peel the carrier at
     // its recursive-shape recogniser (like the run's `fixpoint`) and derive the
-    // one column `n` WITHOUT faulting `.relation("t")`, while the run iterates
-    // the fixpoint to `1,2,3` — asserted TOGETHER on the SAME query so a
+    // one column `n` without faulting `.relation("t")`, while the run iterates
+    // the fixpoint to `1,2,3` — asserted together on the same query so a
     // run-vs-schema divergence cannot hide.
     let statement = try Statement(parsing: """
         WITH RECURSIVE t (n) AS (
@@ -447,12 +447,12 @@ struct EngineRecursiveTests {
   @Test func `a recursive CTE carrier ORDER BY runs a correlated sort-key subquery`()
       throws {
     // The carrier `ORDER BY` peeled off a recursive-CTE fixpoint is applied to
-    // the materialised rows through `carried(over:)`, which RECORDS a sort key
-    // CORRELATED to the set-op output (`EXISTS (… WHERE V = x)`) into the
-    // context's `Subqueries` box, and then EXECUTED — but `apply` used to
-    // execute against a FRESH empty box, so the executor found no recorded plan
+    // the materialised rows through `carried(over:)`, which records a sort key
+    // correlated to the set-op output (`EXISTS (… WHERE V = x)`) into the
+    // context's `Subqueries` box, and then executed — but `apply` used to
+    // execute against a fresh empty box, so the executor found no recorded plan
     // and faulted `a correlated subquery plan was not compiled` (wrapped as a
-    // view-column fault here). `apply` now threads ONE fresh box through BOTH
+    // view-column fault here). `apply` now threads one fresh box through both
     // `carried` and `execute`, so the recorded plan is read back and re-run.
     //
     // The fixpoint anchors at 1, then n+1 while n < 3, materialising 1,2,3. The
@@ -479,7 +479,7 @@ struct EngineRecursiveTests {
 
   @Test func `a recursive CTE carrier ORDER BY on a plain sort key still runs`()
       throws {
-    // GUARD: the memo fix must not regress a NON-correlated carrier sort key.
+    // guard: the memo fix must not regress a non-correlated carrier sort key.
     // The same fixpoint (1,2,3), ordered by the plain output column `x`
     // descending (the set-op output takes arm-0's projection name), still runs
     // and reorders — the shared fresh box carries no recorded plan here, and
@@ -502,7 +502,7 @@ struct EngineRecursiveTests {
 
   @Test func `a recursive CTE carrier ORDER BY on a missing column still faults`()
       throws {
-    // GUARD: restoring the subquery memo must NOT mask a real resolution error.
+    // guard: restoring the subquery memo must NOT mask a real resolution error.
     // A carrier `ORDER BY` naming a column that is neither the set-op output
     // nor any relation in scope still faults `SQLError.column` at run.
     let catalog = try Catalog {
@@ -538,7 +538,7 @@ struct EngineRecursiveTests {
   }
 
   @Test func `a recursive CTE with more than one recursive arm is rejected`() throws {
-    // The body has TWO self-referential arms; the engine models one anchor plus
+    // The body has two self-referential arms; the engine models one anchor plus
     // one recursive arm, so the earlier recursive arm would land in the anchor
     // (compiled with the CTE not in scope). Reject it with a clear `unsupported`
     // diagnostic rather than failing obscurely as an unresolved relation.
@@ -557,7 +557,7 @@ struct EngineRecursiveTests {
   }
 
   @Test func `a recursive reference before the final UNION arm is rejected`() throws {
-    // The self-reference (`FROM Parent`) is a MIDDLE arm and the final arm is
+    // The self-reference (`FROM Parent`) is a middle arm and the final arm is
     // non-recursive, so the recursive-arm check (which inspects the final arm)
     // sees no recursion and the CTE would take the run-once path — compiling the
     // middle `FROM Parent` against a same-named base (silently wrong) or, with
@@ -579,7 +579,7 @@ struct EngineRecursiveTests {
 
   @Test func `a recursive CTE whose anchor reads a same-named base still evaluates`() throws {
     // `Parent` intentionally shadows a base relation of the same name: the anchor
-    // `SELECT Id FROM Parent` reads the BASE (the CTE is not in scope for the
+    // `SELECT Id FROM Parent` reads the base (the CTE is not in scope for the
     // base case), seeding the recursion, while the right arm's `FROM Parent` is
     // the true self-reference. The multiple-recursive-arm guard must NOT reject
     // this — the anchor's reference resolves to an existing base relation, so it
@@ -688,7 +688,7 @@ struct EngineRecursiveTests {
     // names; the anchor's `SELECT *` compiles to a two-wide plan the fixpoint
     // would bind under the three-column schema, so the recursive arm's read of
     // the absent third ordinal would trap in `RelationInstance.record`. The
-    // anchor's compiled width is checked against the declared arity BEFORE it
+    // anchor's compiled width is checked against the declared arity before it
     // seeds the working set, so the fault surfaces as `SQLError.columns` rather
     // than a trap.
     let query = try Statement(parsing: """
@@ -710,7 +710,7 @@ struct EngineRecursiveTests {
     // would seed nothing to validate and bind the CTE under a three-column
     // schema; the recursive arm's read of the absent third ordinal would then
     // trap. The anchor's compiled width is checked against the declared arity
-    // BEFORE it seeds the working set, regardless of how many rows it produces,
+    // before it seeds the working set, regardless of how many rows it produces,
     // so the fault surfaces as `SQLError.columns`.
     let query = try Statement(parsing: """
         WITH RECURSIVE t (a, b, c) AS (
@@ -743,12 +743,12 @@ struct EngineRecursiveTests {
   }
 
   @Test func `a recursive arm that is itself a set-op folds the self at the anchor type`() throws {
-    // The recursive arm `SELECT s FROM t INTERSECT SELECT 'b'` is ITSELF a set
+    // The recursive arm `SELECT s FROM t INTERSECT SELECT 'b'` is itself a set
     // operation, so `validate`'s recursive-arm typecheck folds its self column
-    // (`s`) before `fixpoint` rebinds it. Binding the self under the ANCHOR's
+    // (`s`) before `fixpoint` rebinds it. Binding the self under the anchor's
     // derived type (`s` is text, from `SELECT 'b'`) — not a `.integer`
     // placeholder — lets text INTERSECT text unify rather than faulting a text
-    // arm against an integer self. The SCHEMA path must report `s` as `.text`
+    // arm against an integer self. The schema path must report `s` as `.text`
     // without throwing, and the run terminates yielding `b`.
     let text = """
         WITH RECURSIVE t (s) AS (
@@ -767,10 +767,10 @@ struct EngineRecursiveTests {
   @Test func `a recursive CTE widening past its anchor types the self as unified`() throws {
     // The anchor `SELECT 1` is INTEGER but the recursive arm `n + 0.5` yields
     // a DOUBLE, so the CTE column `n` unifies to `.double` — the type every row
-    // is coerced to. `fixpoint` binds the iterated self under those UNIFIED
+    // is coerced to. `fixpoint` binds the iterated self under those unified
     // types (not the anchor-only integer), so the recursive arm reads `n` at
     // the type its coerced values carry; the run yields the widened sequence
-    // and the SCHEMA path reports `n` as `.double`, the run's own result type.
+    // and the schema path reports `n` as `.double`, the run's own result type.
     let text = """
         WITH RECURSIVE t (n) AS (
           SELECT 1 AS n FROM Seed
@@ -793,8 +793,8 @@ struct EngineRecursiveTests {
     // The reviewer's parity case. Column `a` has an INTEGER anchor (`1`) but a
     // recursive arm `a + 0.5` that widens it to `.double`; the same arm calls
     // the INTEGER-declared `inc(a)` on that self column. Typing the self at the
-    // UNIFIED `.double` (the type the run coerces its rows to) makes SCHEMA
-    // validation and EXECUTION agree: both FAULT, because `inc` requires an
+    // unified `.double` (the type the run coerces its rows to) makes schema
+    // validation and execution agree: both fault, because `inc` requires an
     // integer argument and the widened self is a double. Were the self typed at
     // the anchor-only integer, schema validation would call the query "valid"
     // while the run faults — the schema-vs-execution break this fix closes. The
@@ -818,7 +818,7 @@ struct EngineRecursiveTests {
   }
 
   @Test func `an all-NULL CTE column unifies with a later text arm`() throws {
-    // The CTE `t`'s column `x` is a constant NULL in BOTH arms, so it places NO
+    // The CTE `t`'s column `x` is a constant NULL in both arms, so it places no
     // type constraint: an enclosing UNION over `SELECT x FROM t` must unify it
     // with the `'c'` arm and run, yielding the NULL and the text. The CTE fold
     // carries the per-column unconstrained marker, so a bare reference to `x`
@@ -831,7 +831,7 @@ struct EngineRecursiveTests {
   }
 
   @Test func `an all-NULL CTE column unifies regardless of arm order`() throws {
-    // The order-independence case. The arms are REVERSED from the sibling test
+    // The order-independence case. The arms are reversed from the sibling test
     // — the integer-typed NULLIF leads — so the CTE fold defaults `x`'s
     // concrete type to `.integer` rather than `.text`. Without the
     // unconstrained marker the enclosing UNION would fault `.integer` against
@@ -877,7 +877,7 @@ struct EngineRecursiveTests {
   }
 
   @Test func `an all-NULL CTE column with no outer union yields NULL`() throws {
-    // The marker changes only UNIFICATION, never the reported concrete type: a
+    // The marker changes only unification, never the reported concrete type: a
     // top-level select over the all-NULL CTE column runs and yields the NULL,
     // exactly as before.
     let rows = try statement("""
@@ -908,12 +908,12 @@ struct EngineRecursiveTests {
 
   @Test func `a recursive CTE with mismatched arm widths faults cleanly`() throws {
     // The anchor projects two columns (matching the declared list) and the
-    // recursive arm one, so the recursive-arm width check FAULTS the column-
+    // recursive arm one, so the recursive-arm width check faults the column-
     // count mismatch — the arm's one-column degree against the two-name list —
-    // rather than trap indexing the shorter arm during the fold. The RUN path
-    // and the SCHEMA (`columns(of:)`) path must report the IDENTICAL ISO-
+    // rather than trap indexing the shorter arm during the fold. The run path
+    // and the schema (`columns(of:)`) path must report the identical ISO-
     // ordered fault (`expected: arm degree, got: declared count`): the arm-
-    // width guard fires BEFORE the `kinds` derive whose inter-arm fold would
+    // width guard fires before the `kinds` derive whose inter-arm fold would
     // otherwise raise the reverse `(expected: anchor, got: arm)` order first
     // on the schema path. Assert the shared value so a future reorder cannot
     // silently re-diverge the two paths.
@@ -931,10 +931,10 @@ struct EngineRecursiveTests {
 
   @Test func `a recursive CTE anchor mismatch faults alike on both paths`()
       throws {
-    // The declared list names two columns; the ANCHOR projects one (the
+    // The declared list names two columns; the anchor projects one (the
     // recursive arm two). The anchor-width guard runs before the arm's, so both
-    // the RUN and the SCHEMA path report the anchor's one-column degree against
-    // the two-name list in the SAME ISO order — the sibling of the arm-mismatch
+    // the run and the schema path report the anchor's one-column degree against
+    // the two-name list in the same ISO order — the sibling of the arm-mismatch
     // parity, proving the declared-list guard wins whichever arm diverges.
     let text = """
         WITH RECURSIVE t (a, b) AS (SELECT 1 UNION SELECT Id, Id FROM t)
@@ -950,10 +950,10 @@ struct EngineRecursiveTests {
 
   @Test func `a no-list recursive CTE faults its arm alike on both paths`()
       throws {
-    // With NO explicit `(a, b)` list the CTE's column names come from the
-    // ANCHOR's aliases (degree 2), so `cte.columns` is populated exactly as a
+    // With no explicit `(a, b)` list the CTE's column names come from the
+    // anchor's aliases (degree 2), so `cte.columns` is populated exactly as a
     // declared list would be. The recursive arm's single column therefore hits
-    // the SAME arm-width guard, faulting `(expected: 1, got: 2)` on BOTH paths
+    // the same arm-width guard, faulting `(expected: 1, got: 2)` on both paths
     // — never reaching the `kinds`/`contributions` inter-arm throw, which is
     // consequently unreachable for a recursive CTE (its width is always checked
     // against the anchor-derived list first).
@@ -984,12 +984,12 @@ struct EngineRecursiveTests {
   @Test func `a recursive CTE with an all-NULL anchor unifies its recursive arm`()
       throws {
     // The reviewer's anchor-NULL case. The anchor `SELECT NULLIF(1, 1)` folds
-    // to a CONSTANT NULL, so the CTE column `x` is UNCONSTRAINED: the recursive
+    // to a constant NULL, so the CTE column `x` is unconstrained: the recursive
     // arm — itself a set operation `SELECT x FROM t INTERSECT SELECT 'c'` — must
-    // fold the self column against the text `'c'` WITHOUT faulting integer
+    // fold the self column against the text `'c'` without faulting integer
     // against text, exactly as a bare constant-NULL arm unifies with any typed
     // arm. Because the schema-only self and the run-iteration self bind through
-    // the SAME body-derived carrier, both carry the unconstrained mask and
+    // the same body-derived carrier, both carry the unconstrained mask and
     // cannot diverge. The recursive arm intersects the NULL row against `'c'`
     // (no match), so the fixpoint terminates at the anchor's single NULL row.
     let rows = try statement("""
@@ -1002,17 +1002,17 @@ struct EngineRecursiveTests {
 
   @Test func `a recursive arm's derived body is not typed at the placeholder self`()
       throws {
-    // The recursive arm reads the CTE self through a DERIVED body — `FROM
+    // The recursive arm reads the CTE self through a derived body — `FROM
     // (SELECT s || 'c' AS s FROM t …) AS d` — whose `s || 'c'` is well typed
-    // only when `s` is TEXT, its real (anchor-derived) type. The arm-WIDTH
+    // only when `s` is TEXT, its real (anchor-derived) type. The arm-width
     // probe binds the self under the placeholder-typed `declared` carrier
     // (`.integer`) purely to measure arity, and `augment` materialises that
     // derived body eagerly; were the probe validating, it would type `s || 'c'`
     // against the `.integer` placeholder and spuriously fault a runnable query.
-    // The probe is NON-validating, so arity is measured without typing the
+    // The probe is non-validating, so arity is measured without typing the
     // operands; the genuine arm operand check runs later under the unified
-    // text carrier and passes. The SCHEMA path must report `s` as `.text`
-    // WITHOUT throwing, agreeing with the run's terminating rows.
+    // text carrier and passes. The schema path must report `s` as `.text`
+    // without throwing, agreeing with the run's terminating rows.
     let text = """
         WITH RECURSIVE t (s) AS (
           SELECT 'b'
@@ -1030,12 +1030,12 @@ struct EngineRecursiveTests {
 
   @Test func `a genuinely mistyped recursive arm still faults on the schema path`()
       throws {
-    // The fix makes the arm-WIDTH probe non-validating, so a genuine operand
-    // fault in the recursive arm must STILL be caught — by the later `kinds`-
+    // The fix makes the arm-width probe non-validating, so a genuine operand
+    // fault in the recursive arm must still be caught — by the later `kinds`-
     // seeded typecheck under the unified carrier, not the width probe. Here the
     // arm applies `||` (text-only) to the self column `n`, whose anchor is an
     // INTEGER: the unified self is integer, so `n || 'c'` is genuine text-
-    // arithmetic-on-integer and must fault on BOTH the schema path and the run.
+    // arithmetic-on-integer and must fault on both the schema path and the run.
     let text = """
         WITH RECURSIVE t (n) AS (
           SELECT 1
@@ -1053,8 +1053,8 @@ struct EngineRecursiveTests {
 
   // MARK: - Producer CTE-shape guards
 
-  // The tier-2 unification routes both the run and the schema paths through ONE
-  // CTE walk (`Engine.typed(ctes:in:rows:)`). These pin the RUN-side shape of
+  // The tier-2 unification routes both the run and the schema paths through one
+  // CTE walk (`Engine.typed(ctes:in:rows:)`). These pin the run-side shape of
   // the historically-divergent CTE kinds — the row companions to the R/S/V
   // parity matrix in `OutputSchemaTests` — so a per-CTE regression surfaces
   // here as a wrong ROW set, not only a wrong header.
@@ -1062,9 +1062,9 @@ struct EngineRecursiveTests {
   @Test func `a chained CTE reading a prior widened column materialises doubles`()
       throws {
     // `a` is a mixed integer/double UNION widened to `.double`; `b` reads it.
-    // The run overlay carries `a`'s MATERIALISED rows coerced to the unified
+    // The run overlay carries `a`'s materialised rows coerced to the unified
     // type, so `b` reads (and the query returns) `.double` values — the same
-    // widened carrier the schema path threads with EMPTY rows.
+    // widened carrier the schema path threads with empty rows.
     let rows = try statement("""
         WITH a(x) AS (SELECT 1 UNION SELECT 2.5),
              b(y) AS (SELECT x FROM a)
@@ -1119,7 +1119,7 @@ struct EngineRecursiveTests {
 
   @Test func `an ordered recursive body equals its unordered form as a set`()
       throws {
-    // The trailing carrier does not change the fixpoint's MEMBERSHIP — the same
+    // The trailing carrier does not change the fixpoint's membership — the same
     // recursive CTE without the ORDER BY yields the same rows (here already in
     // order), so the ordered body matches the unordered one modulo ordering.
     let unordered = try seed().run(try Statement(parsing: """
@@ -1164,11 +1164,11 @@ struct EngineRecursiveTests {
   @Test func `a renaming recursive body orders by its first-arm output name`()
       throws {
     // The body's set-op output is named off its FIRST arm (`SELECT 1 AS x`), so
-    // the carrier's `ORDER BY x` resolves against that OUTPUT name `x`, not the
-    // CTE's DECLARED name `n` — EXACTLY as the non-recursive analog below does.
+    // the carrier's `ORDER BY x` resolves against that output name `x`, not the
+    // CTE's declared name `n` — exactly as the non-recursive analog below does.
     // The fixpoint temp the carrier applies over is named by the anchor's
     // output names; the CTE-declared rename rides the returned carrier, so the
-    // outer `SELECT n FROM t` still sees `n`. Assert schema AND run on the SAME
+    // outer `SELECT n FROM t` still sees `n`. Assert schema AND run on the same
     // query so a run-vs-validate divergence cannot hide.
     let statement = try Statement(parsing: """
         WITH RECURSIVE t (n) AS (
@@ -1185,8 +1185,8 @@ struct EngineRecursiveTests {
 
   @Test func `a non-recursive ordered CTE body orders by its output name`()
       throws {
-    // The non-recursive ANALOG of the renaming recursive body: `ORDER BY x`
-    // resolves against the first arm's output `x`. This is the ORACLE the
+    // The non-recursive analog of the renaming recursive body: `ORDER BY x`
+    // resolves against the first arm's output `x`. This is the oracle the
     // recursive form mirrors — the two paths must agree.
     let statement = try Statement(parsing: """
         WITH t (n) AS (SELECT 1 AS x UNION ALL SELECT 2 ORDER BY x)
@@ -1199,10 +1199,10 @@ struct EngineRecursiveTests {
 
   @Test func `a recursive carrier ORDER BY of a non-output name faults`()
       throws {
-    // `ORDER BY n` names the CTE's DECLARED name, NOT a body output (the first
+    // `ORDER BY n` names the CTE's declared name, NOT a body output (the first
     // arm projects `x`), so the carrier — which resolves against the body's
-    // OUTPUT names — faults `.column('n')` on the schema path, exactly as the
-    // RUN does when `apply` reapplies the carrier after the fixpoint (`run ≡
+    // output names — faults `.column('n')` on the schema path, exactly as the
+    // run does when `apply` reapplies the carrier after the fixpoint (`run ≡
     // columns(of:)`), and exactly as the non-recursive analog below faults.
     let statement = try Statement(parsing: """
         WITH RECURSIVE t (n) AS (
@@ -1220,7 +1220,7 @@ struct EngineRecursiveTests {
 
   @Test func `a non-recursive carrier ORDER BY of a non-output name faults`()
       throws {
-    // The non-recursive ORACLE: `ORDER BY n` (the declared name, not the first
+    // The non-recursive oracle: `ORDER BY n` (the declared name, not the first
     // arm's output `x`) faults `.column('n')`, the behaviour the recursive form
     // mirrors.
     let statement = try Statement(parsing: """
@@ -1236,9 +1236,9 @@ struct EngineRecursiveTests {
   @Test func `a recursive carrier ORDER BY validates its keys like the run`()
       throws {
     // The recursive validate path validates the carrier's ORDER BY keys against
-    // the body's output scope, the SAME check an ordinary ordered set operation
+    // the body's output scope, the same check an ordinary ordered set operation
     // gets. A carrier `ORDER BY missing(n)` — where `n` IS a body output
-    // (`SELECT 1 AS n`) — faults `.function('missing')` on BOTH the schema path
+    // (`SELECT 1 AS n`) — faults `.function('missing')` on both the schema path
     // (`columns(of:validate:true)`) AND the run (`run ≡ columns(of:)`), closing
     // the run-vs-validate gap where validate passed yet the run faulted when
     // `apply` reapplied the carrier after the fixpoint.
@@ -1277,15 +1277,15 @@ struct EngineRecursiveTests {
 
   @Test func `a recursive carrier ORDER BY of a projected expression resolves like the non-recursive analog`()
       throws {
-    // The recursive carrier now routes through the SAME `carried(over:)`
+    // The recursive carrier now routes through the same `carried(over:)`
     // resolver the ordinary ordered set-operation path uses, so a projected-
-    // EXPRESSION sort key (`Age * 1`) is matched against the first arm's
-    // projected item and orders on the MATERIALISED output column — never a
+    // expression sort key (`Age * 1`) is matched against the first arm's
+    // projected item and orders on the materialised output column — never a
     // bare `SELECT * FROM <temp>` that re-evaluates `Age * 1` over a temp
     // lacking `Age` (which faulted `.column('Age')`). The recursive fixpoint
     // runs `{1, 2, 3}` ordered ascending; its non-recursive ordered-set-op
     // analog resolves the identical key against the same projection surface
-    // WITHOUT faulting — the run≡run oracle the shared resolver guarantees.
+    // without faulting — the run≡run oracle the shared resolver guarantees.
     let people = EngineMemory([
       "People": FixtureRelation([EngineField(name: "Age", type: .integer)],
                                 [[.integer(1)]] as Array<Array<Value>>),
@@ -1298,7 +1298,7 @@ struct EngineRecursiveTests {
         """)
     #expect(try people.run(recursive) == [[.integer(1)], [.integer(2)],
                                           [.integer(3)]])
-    // The non-recursive analog resolves the SAME `Age * 1` projected-expression
+    // The non-recursive analog resolves the same `Age * 1` projected-expression
     // key against the same arm-0 surface and runs without faulting.
     let analog = try Statement(parsing: """
         SELECT Age * 1 AS m FROM People WHERE Age = 1
@@ -1310,7 +1310,7 @@ struct EngineRecursiveTests {
   @Test func `a recursive carrier ORDER BY of an aliased output resolves on the output column`()
       throws {
     // The aliased sub-case: the anchor projects `Age * 2 AS m` and the carrier
-    // orders by the ALIAS `m`, which the setop-output scope binds directly to
+    // orders by the alias `m`, which the setop-output scope binds directly to
     // the output column — the same path the ordinary carrier takes.
     let people = EngineMemory([
       "People": FixtureRelation([EngineField(name: "Age", type: .integer)],
@@ -1329,12 +1329,12 @@ struct EngineRecursiveTests {
   @Test func `a recursive carrier ORDER BY of a qualified column faults`()
       throws {
     // The recursive body is a set operation; its trailing carrier `ORDER BY`
-    // resolves against the fixpoint OUTPUT, which — like any set-operation
-    // result — exposes NO range. A QUALIFIED key `p.Age` (the anchor's `p`)
+    // resolves against the fixpoint output, which — like any set-operation
+    // result — exposes no range. A qualified key `p.Age` (the anchor's `p`)
     // therefore fails resolution, exactly as the derived-union equivalent and
     // a plain `… UNION … ORDER BY R.a` do: the carrier lets it through to
     // `scope.order` rather than silently dropping the qualifier to bind the
-    // bare output. The BARE `ORDER BY Age` orders the fixpoint (below).
+    // bare output. The bare `ORDER BY Age` orders the fixpoint (below).
     let people = EngineMemory([
       "People": FixtureRelation([EngineField(name: "Age", type: .integer)],
                                 [[.integer(1)]] as Array<Array<Value>>),
@@ -1377,9 +1377,9 @@ struct EngineRecursiveTests {
       throws {
     // ISO 9075 permits recursion only through `UNION [ALL]`. A recursive body
     // that is `EXCEPT` (not `UNION`) referencing itself has no recursive arm to
-    // iterate, so it once compiled with the self UNBOUND and faulted a generic
+    // iterate, so it once compiled with the self unbound and faulted a generic
     // `SQLError.relation('t')`. It now faults the precise `0A000` feature
-    // diagnostic on BOTH the run and the schema path.
+    // diagnostic on both the run and the schema path.
     let statement = try Statement(parsing: """
         WITH RECURSIVE t (n) AS (SELECT n FROM t EXCEPT SELECT 1)
           SELECT n FROM t
@@ -1408,7 +1408,7 @@ struct EngineRecursiveTests {
 
   @Test func `a recursive EXCEPT over a same-named base runs once, not the ISO fault`()
       throws {
-    // The reference reads a same-named BASE relation, so the body is a valid
+    // The reference reads a same-named base relation, so the body is a valid
     // run-once query, not a recursion — the `0A000` guard exempts it (as the
     // misplaced-anchor guard does). `Parent EXCEPT {2}` = {1}.
     let catalog = EngineMemory([

--- a/Tests/SQLTests/Queries/GroupingFunctionTests.swift
+++ b/Tests/SQLTests/Queries/GroupingFunctionTests.swift
@@ -23,7 +23,7 @@ private func sales() throws -> FixtureCatalog {
   }
 }
 
-/// The `SQLError` running `sql` against `catalog` raises, or `nil` — the RUN
+/// The `SQLError` running `sql` against `catalog` raises, or `nil` — the run
 /// path (`Catalog.run`), for the run ≡ schema fault agreement.
 private func running(_ sql: String,
                      _ catalog: borrowing FixtureCatalog) -> SQLError? {
@@ -35,7 +35,7 @@ private func running(_ sql: String,
   }
 }
 
-/// The `SQLError` type-checking `sql`'s schema raises, or `nil` — the SCHEMA
+/// The `SQLError` type-checking `sql`'s schema raises, or `nil` — the schema
 /// path (`columns(of:validate:true)`), for the run ≡ schema fault agreement.
 private func checking(_ sql: String,
                       _ catalog: borrowing FixtureCatalog) -> SQLError? {
@@ -53,7 +53,7 @@ struct GroupingFunctionTests {
   @Test func `a plain GROUP BY key is never rolled up, so GROUPING is 0`()
       throws {
     // A plain `GROUP BY Region` is one grouping set whose sole member is
-    // `Region`, so `Region` is present in every result row and NEVER rolled up:
+    // `Region`, so `Region` is present in every result row and never rolled up:
     // `GROUPING(Region)` is 0 for every row. Rows in first-appearance order.
     try sales().expect("""
         SELECT Region, GROUPING(Region), SUM(Qty)
@@ -87,7 +87,7 @@ struct GroupingFunctionTests {
       throws {
     // `ROLLUP(Region, Product)` is `[[Region, Product], [Region], []]`. Per
     // level, the scalar `GROUPING(Region)`/`GROUPING(Product)` and the two-arg
-    // VECTOR `GROUPING(Region, Product)` (Region the MOST-significant bit):
+    // vector `GROUPING(Region, Product)` (Region the most-significant bit):
     //   full arm  — both present: (0, 0), vector 0b00 = 0.
     //   (Region)  — Product rolled up: (0, 1), vector 0b01 = 1.
     //   ()        — both rolled up: (1, 1), vector 0b11 = 3.
@@ -113,7 +113,7 @@ struct GroupingFunctionTests {
   @Test func `CUBE(a, b) makes the two-arg vector cover all four bit patterns`()
       throws {
     // `CUBE(Region, Product)` is `[[Region, Product], [Product], [Region], []]`,
-    // so the VECTOR `GROUPING(Region, Product)` (Region the MSB) takes every
+    // so the vector `GROUPING(Region, Product)` (Region the MSB) takes every
     // value 0..3:
     //   full arm   — both present: 0b00 = 0.
     //   (Product)  — Region rolled up: 0b10 = 2.
@@ -155,7 +155,7 @@ struct GroupingFunctionTests {
     // A query-level `ORDER BY GROUPING(Region) DESC` over the `ROLLUP(Region)`
     // union sorts the grand total (GROUPING 1) ahead of the per-Region rows
     // (GROUPING 0), a secondary `Region` breaking the per-Region tie. The
-    // projected `GROUPING(Region)` (column 2) makes the sort key an OUTPUT the
+    // projected `GROUPING(Region)` (column 2) makes the sort key an output the
     // carrier matches by resolved identity.
     try sales().expect("""
         SELECT Region, GROUPING(Region), SUM(Qty)
@@ -170,9 +170,9 @@ struct GroupingFunctionTests {
   }
 
   @Test func `GROUPING of a non-grouping column faults on both paths`() throws {
-    // `Product` is in NO grouping set of `GROUP BY Region`, so `GROUPING(Product)`
+    // `Product` is in no grouping set of `GROUP BY Region`, so `GROUPING(Product)`
     // is invalid — the grouped lowering faults `SQLError.grouping` exactly as a
-    // bare non-grouped `Product` reference would, on BOTH the run and the schema
+    // bare non-grouped `Product` reference would, on both the run and the schema
     // type-check.
     let sql = """
         SELECT Region, GROUPING(Product)
@@ -199,7 +199,7 @@ struct GroupingFunctionTests {
   @Test func `GROUPING outside a grouped query faults on both paths`() throws {
     // `SELECT GROUPING(Region) FROM Sales` has no `GROUP BY` and no aggregate,
     // so it is NOT a grouped query — GROUPING has no grouping set to report
-    // against and faults `.state("42803")` on BOTH the run and the schema
+    // against and faults `.state("42803")` on both the run and the schema
     // type-check.
     let sql = "SELECT GROUPING(Region) FROM Sales"
     let fault = SQLError.state("42803", "GROUPING requires a GROUP BY")
@@ -243,7 +243,7 @@ struct GroupingFunctionTests {
 
   @Test func `a delimited GROUPING is an ordinary column, not the function`()
       throws {
-    // `GROUPING` is a CONTEXT identifier: a DELIMITED `"grouping"` is an
+    // `GROUPING` is a context identifier: a delimited `"grouping"` is an
     // ordinary column name, never the function, so a relation with a `grouping`
     // column groups and projects it plainly.
     let cat = try Catalog {

--- a/Tests/SQLTests/Queries/GroupingKeyValidationTests.swift
+++ b/Tests/SQLTests/Queries/GroupingKeyValidationTests.swift
@@ -25,7 +25,7 @@ private func shipments() throws -> FixtureCatalog {
 
 /// The AST `SELECT COUNT(*) FROM Orders GROUP BY <key>`. The parser now admits
 /// a general scalar expression as a `GROUP BY` key (see the SQL-text tests
-/// below), so an EVALUATABLE key is equally reachable from source; the AST
+/// below), so an evaluatable key is equally reachable from source; the AST
 /// builder is retained here to exercise the validation path directly with a
 /// key of any shape.
 private func grouped(by key: Expression,
@@ -63,9 +63,9 @@ private func checking(_ query: Query,
 struct GroupingKeyValidationTests {
   @Test func `an evaluatable GROUP BY key faults under validate as it does at run`()
       throws {
-    // A `GROUP BY 1 / 0` key is EVALUATED per row to form the groups, so a run
+    // A `GROUP BY 1 / 0` key is evaluated per row to form the groups, so a run
     // faults `SQLError.divide`. The schema/type-check walk must surface the
-    // SAME fault: `group` lowers the key to a term STRUCTURALLY (no
+    // same fault: `group` lowers the key to a term structurally (no
     // evaluation), so `compile` alone never raised it — the walk now routes
     // each key through the same operand type-check the projection and ORDER BY
     // keys use, closing the gap where `columns(of:validate:)` returned a silent
@@ -119,7 +119,7 @@ struct GroupingKeyValidationTests {
 
   @Test func `a constant-false WHERE spares an evaluatable GROUP BY key`()
       throws {
-    // A constant-false WHERE yields no rows, so a GROUP BY forms NO group and
+    // A constant-false WHERE yields no rows, so a GROUP BY forms no group and
     // never evaluates its key — the run does not fault, so validate must not
     // either. This mirrors the projection path's constant-false elision (a
     // false WHERE spares an unreachable `1 / 0`), which the grouping walk
@@ -138,7 +138,7 @@ struct GroupingKeyValidationTests {
   @Test func `GROUP BY groups by an arithmetic expression key`() throws {
     // `Amount + 1` — an arithmetic key over a column — groups the two distinct
     // amounts (10, 20) into their own groups, keyed on 11 and 21. The key is
-    // both PROJECTED (aliased `k`) and grouped, so it names an output column.
+    // both projected (aliased `k`) and grouped, so it names an output column.
     let sql = """
         SELECT Amount + 1 AS k, COUNT(*) FROM Orders
           GROUP BY Amount + 1 ORDER BY k
@@ -182,8 +182,8 @@ struct GroupingKeyValidationTests {
 
   @Test func `a qualified projection matches an unqualified expression key`()
       throws {
-    // `Orders.Amount + 1` (qualified) in the projection is SEMANTICALLY the
-    // unqualified `Amount + 1` grouping key — they lower to ONE term. The
+    // `Orders.Amount + 1` (qualified) in the projection is semantically the
+    // unqualified `Amount + 1` grouping key — they lower to one term. The
     // match is now by lowered term, not raw AST, so the qualified projection is
     // grouped and runs rather than faulting `SQLError.grouping`.
     let sql = """
@@ -216,7 +216,7 @@ struct GroupingKeyValidationTests {
   }
 
   @Test func `a HAVING reference matches an expression key by term`() throws {
-    // A HAVING reference to the grouped expression matches the SAME way a
+    // A HAVING reference to the grouped expression matches the same way a
     // projection does — `Orders.Amount + 1` (qualified) is the `Amount + 1`
     // key. `HAVING Orders.Amount + 1 > 15` keeps only the group keyed on 21.
     let sql = """
@@ -240,7 +240,7 @@ struct GroupingKeyValidationTests {
 
   @Test func `a genuinely different projection expression still faults`()
       throws {
-    // Term matching must NOT over-accept: `Amount + 2` is a DIFFERENT value
+    // Term matching must NOT over-accept: `Amount + 2` is a different value
     // from the `Amount + 1` key — its lowered term differs — so the bare
     // non-key `Amount` in it still faults the standard grouping rule.
     let sql = """
@@ -278,8 +278,8 @@ struct GroupingKeyValidationTests {
   @Test func `GROUP BY 1 / 0 parsed from SQL faults on both run and validate`()
       throws {
     // The round-11 payoff: the evaluatable `1 / 0` grouping key is now
-    // REACHABLE from SQL text (the parser no longer rejects a non-identifier
-    // key). Over a NON-EMPTY input it forms a group per row, evaluating the
+    // reachable from SQL text (the parser no longer rejects a non-identifier
+    // key). Over a non-empty input it forms a group per row, evaluating the
     // key and faulting `SQLError.divide` — surfaced identically by the run and
     // by `columns(of:validate:)`.
     let query = try parse(query: "SELECT COUNT(*) FROM Orders GROUP BY 1 / 0")
@@ -300,7 +300,7 @@ struct GroupingKeyValidationTests {
 
   @Test func `GROUP BY of an aggregate faults as a misplaced aggregate`()
       throws {
-    // An aggregate is not a grouping key. `GROUP BY COUNT(*)` now PARSES (an
+    // An aggregate is not a grouping key. `GROUP BY COUNT(*)` now parses (an
     // aggregate call is an expression) and faults `42803` "an aggregate is not
     // allowed here" — the same fault a nested aggregate raises elsewhere
     // (`HAVING COUNT(COUNT(*)) > 0`), not a parse error.
@@ -336,7 +336,7 @@ struct GroupingKeyValidationTests {
       throws {
     // A correlated grouping subquery keys each row on the per-row scalar it
     // yields — here `Amount` itself (10, 20) via a correlated lookup — so it
-    // forms one group per distinct value, matching the SAME correlated subquery
+    // forms one group per distinct value, matching the same correlated subquery
     // used as a projection.
     let group = """
         SELECT COUNT(*) FROM Orders o
@@ -353,8 +353,8 @@ struct GroupingKeyValidationTests {
   }
 
   @Test func `a subquery grouping key also in the projection works`() throws {
-    // The SAME scalar subquery both projected (aliased `k`) and used as the
-    // grouping key registers ONCE (its role is shared) — no double-register
+    // The same scalar subquery both projected (aliased `k`) and used as the
+    // grouping key registers once (its role is shared) — no double-register
     // or width mismatch — and groups every row into the one constant group.
     let sql = """
         SELECT (SELECT 1) AS k, COUNT(*) FROM Orders GROUP BY (SELECT 1)
@@ -367,7 +367,7 @@ struct GroupingKeyValidationTests {
   @Test func `a cardinality-violating subquery grouping key faults as it does in a projection`()
       throws {
     // A scalar subquery yielding more than one row faults
-    // `SQLError.cardinality` — the SAME fault it raises as a projection, NOT
+    // `SQLError.cardinality` — the same fault it raises as a projection, NOT
     // the generic "not supported in this position" the unregistered key raised.
     let group = try parse(query: """
         SELECT COUNT(*) FROM Orders GROUP BY (SELECT Amount FROM Orders)

--- a/Tests/SQLTests/Queries/GroupingSetsTests.swift
+++ b/Tests/SQLTests/Queries/GroupingSetsTests.swift
@@ -59,7 +59,7 @@ struct GroupingSetsTests {
 
   @Test func `the result columns type through set-operation unification`()
       throws {
-    // A NULL-padded column takes the SIBLING arm's type via the set-operation
+    // A NULL-padded column takes the sibling arm's type via the set-operation
     // merge (a constant-NULL arm constrains nothing): Region and Product stay
     // `.text` despite the arms that NULL them, and the SUM is `.integer`. The
     // schema derive (run ≡ columns) agrees with the run above.
@@ -135,7 +135,7 @@ struct GroupingSetsTests {
   }
 
   @Test func `ORDER BY may name an aggregate over the combined result`() throws {
-    // An ORDER BY naming a PROJECTED aggregate (`SUM(Qty)`) resolves to that
+    // An ORDER BY naming a projected aggregate (`SUM(Qty)`) resolves to that
     // output column of the union — the setop-output scope orders on the
     // already-computed SUM: ascending 10 (West), 35 (East), 45 (total).
     try sales().expect("""
@@ -172,11 +172,11 @@ struct GroupingSetsTests {
 
   @Test func `the empty set yields ONE grand-total row, not one per input`()
       throws {
-    // Finding 1: the `()` set builds a GENUINE grand-total aggregate — `group`
-    // on `[]` = ONE row over the whole result — rather than an empty `GROUP BY`
+    // Finding 1: the `()` set builds a genuine grand-total aggregate — `group`
+    // on `[]` = one row over the whole result — rather than an empty `GROUP BY`
     // the parser-desugar read as no grouping (`SELECT NULL FROM Sales`, one
-    // NULL row PER input row). Here the per-Region arm yields East/West and the
-    // `()` arm yields EXACTLY ONE `[nil]` grand-total row.
+    // NULL row per input row). Here the per-Region arm yields East/West and the
+    // `()` arm yields exactly one `[nil]` grand-total row.
     let cat = try sales()
     try cat.expect("""
         SELECT Region
@@ -193,7 +193,7 @@ struct GroupingSetsTests {
   }
 
   @Test func `HAVING on an absent key sees the super-aggregate NULL`() throws {
-    // Finding 2: `HAVING Region IS NULL` lowers through the SAME grouped `term`
+    // Finding 2: `HAVING Region IS NULL` lowers through the same grouped `term`
     // the projection does, so in the `()` arm — where Region is absent from the
     // set — it is a super-aggregate NULL rather than a rejected non-grouped
     // column. Only the grand-total row (Region NULL) survives; every per-Region
@@ -218,8 +218,8 @@ struct GroupingSetsTests {
       throws {
     // Finding 3: `ORDER BY MAX(Qty)` names an aggregate the select list does
     // NOT project, so the setop-output scope cannot recompute it. The
-    // expansion MATERIALISES `MAX(Qty)` as a hidden trailing column in EVERY
-    // arm (equal arity for the UNION ALL), the carrier orders on it, and TRIMS
+    // expansion materialises `MAX(Qty)` as a hidden trailing column in every
+    // arm (equal arity for the UNION ALL), the carrier orders on it, and trims
     // it from the output — so the result has exactly the two projected columns.
     // Per-Region MAX(Qty): East 20, West 7; the `()` grand-total MAX is 20.
     // Ascending MAX orders West (7), then East (20) and the total (20) — the
@@ -246,11 +246,11 @@ struct GroupingSetsTests {
 
   @Test func `a qualified key NULLs its unqualified projection in the () arm`()
       throws {
-    // Finding 4: `GROUPING SETS ((n.A), ())` groups on the QUALIFIED `n.A`, but
-    // the select list projects the UNQUALIFIED `A`. The absent-key NULL is
-    // matched by RESOLVED identity (the lowered term treats `n.A` ≡ `A`), so
+    // Finding 4: `GROUPING SETS ((n.A), ())` groups on the qualified `n.A`, but
+    // the select list projects the unqualified `A`. The absent-key NULL is
+    // matched by resolved identity (the lowered term treats `n.A` ≡ `A`), so
     // the `()` arm NULLs `A` rather than rejecting a non-grouped column — the
-    // parser's old qualifier-PRESENCE matcher failed this. Per-A rows then the
+    // parser's old qualifier-presence matcher failed this. Per-A rows then the
     // grand total.
     let cat = try nums()
     try cat.expect("""
@@ -269,7 +269,7 @@ struct GroupingSetsTests {
   @Test func `ORDER BY a projected key over a key-only projection`() throws {
     // A key-only projection (no aggregate) `SELECT Region` parses as a bare
     // `columns` list; the `ordered` carrier resolves the ORDER BY over the
-    // union's output columns. An ORDER BY naming the ALREADY-projected key
+    // union's output columns. An ORDER BY naming the already-projected key
     // orders on that output — it is NOT materialised as a hidden column and the
     // identity projection keeps the one real column. NULLs sort first
     // ascending, so the `()` arm's grand-total NULL leads, then East/West.
@@ -333,7 +333,7 @@ struct GroupingSetsTests {
     // `Region` is a GROUP BY key but is NOT projected (only `SUM(Qty)` is), so
     // the setop-output scope cannot bind it — yet the plain grouped path takes
     // `ORDER BY Region` (a grouped column is orderable). The GROUPING SETS form
-    // must AGREE: `expand` materialises the unprojected grouped column as a
+    // must agree: `expand` materialises the unprojected grouped column as a
     // hidden trailing column in every arm (the aggregate case's machinery), the
     // carrier orders on it, and trims it — so the result is exactly `SUM(Qty)`,
     // ordered by Region. Ascending Region: East 35, West 10.
@@ -374,10 +374,10 @@ struct GroupingSetsTests {
   @Test func `ORDER BY a non-grouped column faults like the plain form`()
       throws {
     // `Product` is neither projected nor a GROUP BY key of the `((Region))`
-    // arm. The plain grouped path REJECTS `ORDER BY Product` (a non-grouped,
-    // non-aggregated column). The GROUPING SETS form must fault IDENTICALLY:
+    // arm. The plain grouped path rejects `ORDER BY Product` (a non-grouped,
+    // non-aggregated column). The GROUPING SETS form must fault identically:
     // `expand` materialises the column into each arm's projection, and the
-    // arm's grouped resolver rejects it with the SAME grouping fault, never the
+    // arm's grouped resolver rejects it with the same grouping fault, never the
     // old carrier's `no such column` over the setop output.
     let cat = try sales()
     let fault = SQLError.grouping("Product")
@@ -394,7 +394,7 @@ struct GroupingSetsTests {
       throws {
     // The regression guard for the fix above: when the grouping column IS
     // projected (`SELECT Region, SUM(Qty)`), `ORDER BY Region` must resolve to
-    // that EXISTING output — NOT materialise a spurious hidden column — so the
+    // that existing output — NOT materialise a spurious hidden column — so the
     // schema stays the two real outputs. Ascending Region: East 35, West 10.
     let cat = try sales()
     try cat.expect("""
@@ -416,7 +416,7 @@ struct GroupingSetsTests {
   @Test func `a grouped SELECT * is rejected the same as a plain GROUP BY`()
       throws {
     // A grouped `SELECT *` is ill-formed (a grouped projection must be
-    // explicit). The GROUPING SETS form must reject it with the IDENTICAL fault
+    // explicit). The GROUPING SETS form must reject it with the identical fault
     // the plain grouped query raises — the arm resolver's grouped `.all`
     // rejection — whether or not a query-level ORDER BY carries it. `expand`
     // keeps the `.all` verbatim in every arm and returns the bare union (never
@@ -427,11 +427,11 @@ struct GroupingSetsTests {
                               "aggregates")
     // The plain grouped `SELECT *` — the baseline fault.
     cat.expect("SELECT * FROM Sales GROUP BY Region", fails: star)
-    // The BARE grouping-sets form (no ORDER BY / DISTINCT / limit).
+    // The bare grouping-sets form (no ORDER BY / DISTINCT / limit).
     cat.expect("""
         SELECT * FROM Sales GROUP BY GROUPING SETS ((Region))
         """, fails: star)
-    // The CARRIED form (a query-level ORDER BY) faults IDENTICALLY.
+    // The carried form (a query-level ORDER BY) faults identically.
     cat.expect("""
         SELECT * FROM Sales GROUP BY GROUPING SETS ((Region)) ORDER BY Region
         """, fails: star)
@@ -447,12 +447,12 @@ struct GroupingSetsTests {
 
   @Test func `a faulting grand-total arm faults validate and a CTE body`()
       throws {
-    // The `()` grand-total arm emits ONE row EVEN under `WHERE 1 = 0` (the
+    // The `()` grand-total arm emits one row even under `WHERE 1 = 0` (the
     // empty group still produces the grand total), so `1 / 0` IS evaluated at
     // run and faults — the un-expanded `.sets` (where `WHERE 1 = 0` spares the
     // projection) hid this from validation. `Query.expanded` now runs at the
     // WITH schema path and the CTE validation entries too, so the validate path
-    // and a CTE body fault IDENTICALLY to the run.
+    // and a CTE body fault identically to the run.
     let cat = try sales()
     let sql = """
         SELECT 1 / 0 AS x
@@ -474,7 +474,7 @@ struct GroupingSetsTests {
     #expect(throws: SQLError.divide) {
       _ = try cat.columns(of: Statement(parsing: cte), validate: true)
     }
-    // The same query as the TRAILING WITH query faults under the schema derive.
+    // The same query as the trailing WITH query faults under the schema derive.
     let trailing = "WITH u AS (SELECT 1 AS x) \(sql)"
     #expect(throws: SQLError.divide) {
       _ = try cat.run(Statement(parsing: trailing))
@@ -487,13 +487,13 @@ struct GroupingSetsTests {
   @Test func `a faulting grand-total arm faults a VIEW body schema derive`()
       throws {
     // The VIEW schema path (`typecheck(view.query, …)`) is the finding #2 gap:
-    // reached with an UNEXPANDED body, its reachability helper sees `GROUPING
+    // reached with an unexpanded body, its reachability helper sees `GROUPING
     // SETS ((Region), ())` as non-empty `grouping.expressions`, so a
-    // constant-false `WHERE` makes it short-circuit WITHOUT validating the
-    // projection — yet the expanded `()` grand-total arm STILL emits one group
-    // at run and evaluates `1 / 0`, faulting. Expanding the body BEFORE the
+    // constant-false `WHERE` makes it short-circuit without validating the
+    // projection — yet the expanded `()` grand-total arm still emits one group
+    // at run and evaluates `1 / 0`, faulting. Expanding the body before the
     // reachability typecheck keeps the VIEW schema derive in step with the run:
-    // `columns(of: SELECT * FROM v)` faults the SAME `.divide` the run does.
+    // `columns(of: SELECT * FROM v)` faults the same `.divide` the run does.
     let cat = try Catalog {
       Relation("Sales", ["Region": .text, "Qty": .integer]) {
         Row("East", 10)
@@ -508,8 +508,8 @@ struct GroupingSetsTests {
     #expect(throws: SQLError.divide) {
       _ = try cat.run(Statement(parsing: "SELECT * FROM v"))
     }
-    // `columns(of: SELECT * FROM v, validate: true)` faults IDENTICALLY —
-    // before the fix it ACCEPTED the view and returned a schema.
+    // `columns(of: SELECT * FROM v, validate: true)` faults identically —
+    // before the fix it accepted the view and returned a schema.
     #expect(throws: SQLError.divide) {
       _ = try cat.columns(of: parse(query: "SELECT * FROM v"), validate: true)
     }
@@ -518,8 +518,8 @@ struct GroupingSetsTests {
   @Test func `a genuinely dead non-GS view body still short-circuits`() throws {
     // The parity guard: expanding the body must NOT over-reject a legitimately
     // dead non-grouping-sets body. A `SELECT 1 / 0 FROM Sales WHERE 1 = 0` with
-    // NO aggregate forms no group under the false `WHERE`, so its projection is
-    // genuinely unreachable — `columns(of: SELECT * FROM v)` types it WITHOUT
+    // no aggregate forms no group under the false `WHERE`, so its projection is
+    // genuinely unreachable — `columns(of: SELECT * FROM v)` types it without
     // faulting, exactly as the run yields no row.
     let cat = try Catalog {
       Relation("Sales", ["Region": .text, "Qty": .integer]) {
@@ -535,7 +535,7 @@ struct GroupingSetsTests {
 
   @Test func `a non-faulting grouping-sets CTE body validates and types`()
       throws {
-    // The parity guard: a NON-faulting grouping-sets CTE body still validates
+    // The parity guard: a non-faulting grouping-sets CTE body still validates
     // and its `columns(of:)` types resolve correctly — expansion at the CTE
     // entry must not over-reject a legal body. The body projects Region and a
     // SUM over the two-set grouping; as a CTE the trailing `SELECT *` reports
@@ -568,9 +568,9 @@ struct GroupingSetsTests {
       throws {
     // The cross case the shared `CTE.canonical = query.expanded.unwound` peel
     // enables: a RECURSIVE CTE whose anchor is a `GROUP BY GROUPING SETS`
-    // shape. `canonical` EXPANDS the anchor's `.sets` node to its `UNION ALL`
+    // shape. `canonical` expands the anchor's `.sets` node to its `UNION ALL`
     // FIRST, so the recursive-shape recogniser peels the resulting inner
-    // `((per-Region ∪ grand-total) ∪ recursive)` union — the SAME AST the
+    // `((per-Region ∪ grand-total) ∪ recursive)` union — the same AST the
     // fixpoint iterates — rather than mis-reading the unexpanded `.sets` body.
     // The recursive arm never fires (`Total < 0` is empty), so the result is
     // the expanded anchor: per-Region East 35 / West 10 and the grand total 45,
@@ -592,7 +592,7 @@ struct GroupingSetsTests {
       [.text("East"), .integer(35)],
       [.null, .integer(45)],
     ])
-    // run ≡ columns(of:): the schema derive peels the SAME expanded, unwound
+    // run ≡ columns(of:): the schema derive peels the same expanded, unwound
     // canonical shape and types the declared columns without faulting.
     let columns = try cat.columns(of: Statement(parsing: sql), validate: true)
     #expect(columns == [
@@ -604,9 +604,9 @@ struct GroupingSetsTests {
   // MARK: - Setop-output scope and ORDER BY resolution
 
   @Test func `ORDER BY a select-list alias orders on that output`() throws {
-    // A query-level `ORDER BY total` names the select-list ALIAS `total` (the
+    // A query-level `ORDER BY total` names the select-list alias `total` (the
     // `SUM(Qty)` output), NOT a base column. The setop-output scope resolves it
-    // the SAME way a plain `SELECT … ORDER BY <alias>` does — over the union's
+    // the same way a plain `SELECT … ORDER BY <alias>` does — over the union's
     // output — rather than materialising a hidden column the grouped lowering
     // cannot resolve. Ascending SUM: West 10, East 35.
     let cat = try sales()
@@ -651,8 +651,8 @@ struct GroupingSetsTests {
   }
 
   @Test func `duplicate output names keep their positional identity`() throws {
-    // Two outputs aliased the SAME name (`Region AS x, Product AS x`) keep
-    // their POSITIONAL identity through the union, so the 2nd output stays
+    // Two outputs aliased the same name (`Region AS x, Product AS x`) keep
+    // their positional identity through the union, so the 2nd output stays
     // Product rather than collapsing onto the first `x` (Region). `ORDER BY 1`
     // sorts on the first output. Region then Product within each Region.
     let cat = try sales()
@@ -681,10 +681,10 @@ struct GroupingSetsTests {
 
   @Test func `ORDER BY a duplicate output name faults ambiguous, as plain GROUP BY`()
       throws {
-    // A bare `ORDER BY x` over TWO outputs aliased `x` (`Region AS x, Product
-    // AS x`) rides the setop-output scope's ORDINARY ORDER BY resolution, which
+    // A bare `ORDER BY x` over two outputs aliased `x` (`Region AS x, Product
+    // AS x`) rides the setop-output scope's ordinary ORDER BY resolution, which
     // faults `SQLError.ambiguous` — NOT a silent order by the first `x`. The
-    // plain grouped `… GROUP BY Region, Product ORDER BY x` is the ORACLE: it
+    // plain grouped `… GROUP BY Region, Product ORDER BY x` is the oracle: it
     // faults the same `.ambiguous("x")`, so the two forms agree.
     let cat = try sales()
     let ambiguous = SQLError.ambiguous("x")
@@ -703,7 +703,7 @@ struct GroupingSetsTests {
            ORDER BY x
           """), validate: true)
     }
-    // The plain grouped ORACLE faults IDENTICALLY.
+    // The plain grouped oracle faults identically.
     cat.expect("""
         SELECT Region AS x, Product AS x
           FROM Sales
@@ -714,7 +714,7 @@ struct GroupingSetsTests {
 
   @Test func `ORDER BY a duplicate BARE projected name faults ambiguous`()
       throws {
-    // Two BARE (unaliased) projections resolving to the same output name — here
+    // Two bare (unaliased) projections resolving to the same output name — here
     // `Region` projected twice — order by that name faults `.ambiguous` the
     // same as the aliased case. The plain grouped form is the oracle.
     let cat = try sales()
@@ -735,7 +735,7 @@ struct GroupingSetsTests {
 
   @Test func `ORDER BY 1 resolves the duplicate-name query by position`()
       throws {
-    // Positional `ORDER BY 1` is the UNAMBIGUOUS way to order the
+    // Positional `ORDER BY 1` is the unambiguous way to order the
     // duplicate-name query: it names the first output by position, so it
     // resolves where the bare name faults. Region then Product ascending.
     try sales().expect("""
@@ -752,8 +752,8 @@ struct GroupingSetsTests {
   @Test func `ORDER BY an unprojected aggregate still materialises after the fix`()
       throws {
     // Regression guard for the shared mechanism: an unprojected `ORDER BY
-    // MAX(Qty)` is neither a projected expression NOR an output name, so it is
-    // still MATERIALISED as a hidden synthetic column and ordered on. Ascending
+    // MAX(Qty)` is neither a projected expression nor an output name, so it is
+    // still materialised as a hidden synthetic column and ordered on. Ascending
     // per-Region MAX(Qty): West 7, East 20.
     try sales().expect("""
         SELECT Region, SUM(Qty)
@@ -767,12 +767,12 @@ struct GroupingSetsTests {
 
   @Test func `ORDER BY a display header column N faults, as over a plain union`()
       throws {
-    // The result-schema DISPLAY header `column N` (an unnamed output's
+    // The result-schema display header `column N` (an unnamed output's
     // positional name) is NOT a bindable output name — the setop-output scope
     // names an unnamed output non-spellably, so `ORDER BY "column 2"` faults
-    // `.column`, EXACTLY as `SELECT * FROM (union) AS g ORDER BY "column N"`
+    // `.column`, exactly as `SELECT * FROM (union) AS g ORDER BY "column N"`
     // does over any derived union. Before, the text wrapper exposed the header
-    // as a derived-table column and WRONGLY accepted it.
+    // as a derived-table column and wrongly accepted it.
     let cat = try sales()
     let fault = SQLError.column("column 2")
     cat.expect("""
@@ -781,7 +781,7 @@ struct GroupingSetsTests {
          GROUP BY GROUPING SETS ((Region), ())
          ORDER BY "column 2"
         """, fails: fault)
-    // The plain-union ORACLE faults the same over its display header.
+    // The plain-union oracle faults the same over its display header.
     cat.expect("""
         SELECT * FROM (
           SELECT Region FROM Sales GROUP BY Region
@@ -791,11 +791,11 @@ struct GroupingSetsTests {
 
   @Test func `ORDER BY a qualified key resolves to its projected output`()
       throws {
-    // A qualified `ORDER BY n.Region` whose BARE name is a projected output
+    // A qualified `ORDER BY n.Region` whose bare name is a projected output
     // resolves to that output through the setop-output scope (a set-operation
-    // result carries no source qualifier), the SAME as the plain grouped
+    // result carries no source qualifier), the same as the plain grouped
     // `ORDER BY n.Region` lowering `n.Region` to the group-key slot ≡ the
-    // projected `Region`. Before, the scope-less matcher MATERIALISED
+    // projected `Region`. Before, the scope-less matcher materialised
     // `n.Region` as a hidden `*gs0` column, and under DISTINCT that hidden
     // column faulted `must appear in the SELECT DISTINCT list`. Now an output.
     // The `()` arm's grand-total NULL leads ascending, then per-Region.
@@ -818,11 +818,11 @@ struct GroupingSetsTests {
   @Test func `ORDER BY a qualified non-grouped name faults like the plain form`()
       throws {
     // The other half of the qualified case: a qualified `ORDER BY n.Product`
-    // whose bare name is NEITHER a projected output NOR a grouping key. The
-    // plain grouped ORACLE (`GROUP BY Region ORDER BY n.Product`) faults
+    // whose bare name is neither a projected output nor a grouping key. The
+    // plain grouped oracle (`GROUP BY Region ORDER BY n.Product`) faults
     // `.grouping` — a non-grouped, non-aggregated column — NOT `.column`. The
-    // GROUPING SETS form must AGREE: `expand` materialises the column into each
-    // arm and the arm's grouped resolver rejects it with the SAME `.grouping`
+    // GROUPING SETS form must agree: `expand` materialises the column into each
+    // arm and the arm's grouped resolver rejects it with the same `.grouping`
     // fault. (This assertion previously expected `.column("Product")` from the
     // old scope-less matcher, which disagreed with the plain form — an existing
     // assertion that encoded that divergence, now corrected to the oracle.)
@@ -842,7 +842,7 @@ struct GroupingSetsTests {
   @Test func `ORDER BY a qualified unprojected grouping column matches plain`()
       throws {
     // A qualified `ORDER BY n.Region` whose bare name is NOT projected but IS a
-    // grouping key: the plain grouped form ACCEPTS it (ordering on the group
+    // grouping key: the plain grouped form accepts it (ordering on the group
     // key). The GROUPING SETS form agrees — `expand` materialises it hidden,
     // the carrier resolves the qualified key through the arm's grouped space to
     // its hidden slot, orders on it, and trims it. Ascending Region: East 35,
@@ -862,11 +862,11 @@ struct GroupingSetsTests {
 
   @Test func `a qualified key does not alias-match a different output by name`()
       throws {
-    // The output named `Region` is `Product AS Region` — its RESOLVED identity
+    // The output named `Region` is `Product AS Region` — its resolved identity
     // is `Product`, NOT `s.Region`. A qualified `ORDER BY s.Region` references
-    // the grouped INPUT column `s.Region`, a grouping key that is NOT
-    // projected. The is-projected check must use RESOLVED IDENTITY, not the
-    // BARE name: matching `s.Region` to the alias `Region` by bare name SKIPS
+    // the grouped input column `s.Region`, a grouping key that is NOT
+    // projected. The is-projected check must use resolved IDENTITY, not the
+    // bare name: matching `s.Region` to the alias `Region` by bare name skips
     // hidden materialisation, and the setop-output scope cannot resolve the
     // qualified `s.Region` — so the carrier faulted (or mis-bound to Product).
     // The qualified key routes through the arm's grouped resolver, materialises
@@ -893,9 +893,9 @@ struct GroupingSetsTests {
 
   @Test func `an unqualified key still binds a select alias per ISO precedence`()
       throws {
-    // The GUARD for the fix above: the bare-name output match still applies to
-    // an UNQUALIFIED key. `ORDER BY Region` where `Region` is the select alias
-    // for `Product` binds the OUTPUT alias (ISO output-alias precedence: a bare
+    // The guard for the fix above: the bare-name output match still applies to
+    // an unqualified key. `ORDER BY Region` where `Region` is the select alias
+    // for `Product` binds the output alias (ISO output-alias precedence: a bare
     // name → a select-list alias), NOT the input column `Region`, so it sorts
     // by the projected Product value — the plain grouped form is the oracle.
     let cat = try sales()
@@ -925,12 +925,12 @@ struct GroupingSetsTests {
   @Test func `DISTINCT rejects a hidden unprojected-aggregate sort key`()
       throws {
     // Under `SELECT DISTINCT`, an ORDER BY expression that is NOT in the select
-    // list is an ERROR (ISO 9075). An unprojected `ORDER BY MAX(Qty)` would be
-    // MATERIALISED as a hidden `*gsN` column, but that slot is NOT a real
+    // list is an error (ISO 9075). An unprojected `ORDER BY MAX(Qty)` would be
+    // materialised as a hidden `*gsN` column, but that slot is NOT a real
     // output — the DISTINCT check sees only the REAL outputs (`0 ..< real`), so
-    // the key is REJECTED with the same `.distinct` fault the plain grouped
+    // the key is rejected with the same `.distinct` fault the plain grouped
     // form raises, rather than passing as if the hidden slot were projected and
-    // rebinding the sort OUTSIDE the real projection (which crashed).
+    // rebinding the sort outside the real projection (which crashed).
     let cat = try sales()
     let fault = SQLError.distinct("an expression")
     cat.expect("""
@@ -939,7 +939,7 @@ struct GroupingSetsTests {
          GROUP BY GROUPING SETS ((Region), ())
          ORDER BY MAX(Qty)
         """, fails: fault)
-    // The plain grouped ORACLE rejects the same non-selected sort key.
+    // The plain grouped oracle rejects the same non-selected sort key.
     cat.expect("""
         SELECT DISTINCT Region FROM Sales GROUP BY Region ORDER BY MAX(Qty)
         """, fails: fault)
@@ -958,11 +958,11 @@ struct GroupingSetsTests {
 
   @Test func `validate faults an unknown routine in a carrier ORDER BY`()
       throws {
-    // The `ordered` carrier's ORDER BY is a NEW expression surface: it must
+    // The `ordered` carrier's ORDER BY is a new expression surface: it must
     // join the validation walk, else a reachable faulting sort key
-    // `columns(of:)` ACCEPTS the run raises on. An unknown routine (`ORDER BY
+    // `columns(of:)` accepts the run raises on. An unknown routine (`ORDER BY
     // missing(Region)`) faults `.function` at run; validate now faults
-    // IDENTICALLY over the same setop-output scope, closing the run-vs-validate
+    // identically over the same setop-output scope, closing the run-vs-validate
     // gap.
     let cat = try sales()
     let sql = """
@@ -981,7 +981,7 @@ struct GroupingSetsTests {
   @Test func `validate faults an ill-typed operand in a carrier ORDER BY`()
       throws {
     // The operand counterpart: `ORDER BY SUM(Qty) + 'x'` mixes a number and a
-    // string, faulting `.operand` at run; validate now faults IDENTICALLY,
+    // string, faulting `.operand` at run; validate now faults identically,
     // rather than returning a schema for a query the run rejects.
     let cat = try sales()
     let sql = """
@@ -998,7 +998,7 @@ struct GroupingSetsTests {
   }
 
   @Test func `a valid carrier ORDER BY still validates and resolves`() throws {
-    // The parity guard: a VALID carrier ORDER BY expression (an already-checked
+    // The parity guard: a valid carrier ORDER BY expression (an already-checked
     // call over an output) still validates and resolves its schema — the walk
     // must not over-reject. `UPPER(Region)` orders the union by the uppercased
     // region; the schema derive agrees with the run.
@@ -1060,9 +1060,9 @@ struct GroupingSetsTests {
   @Test func `a derived table in a grouping-sets arm runs under ORDER BY`()
       throws {
     // The GROUPING SETS expansion is a `UNION ALL` of per-set grouped arms,
-    // each over the SAME `FROM (SELECT …) AS s` — so every arm names the
+    // each over the same `FROM (SELECT …) AS s` — so every arm names the
     // derived alias `s`. Under the query-level ORDER BY carrier, the union must
-    // run PER ARM (each materialising `s` in its own scope); before, the
+    // run per ARM (each materialising `s` in its own scope); before, the
     // single-context carrier execution never bound `s` and faulted
     // `.relation`. Per-Region sums (East 15, West 7) and the grand total (22),
     // ordered by SUM.
@@ -1084,8 +1084,8 @@ struct GroupingSetsTests {
 
   @Test func `a subquery in an omitted set is collected for the () arm`()
       throws {
-    // A scalar subquery in a set's key must be pre-registered for EVERY arm,
-    // not only the arms whose set includes it: an `.arm` lowers the SUPERSET
+    // A scalar subquery in a set's key must be pre-registered for every arm,
+    // not only the arms whose set includes it: an `.arm` lowers the superset
     // (to NULL an absent key), so the `()` grand-total arm lowers `(SELECT 1)`
     // and needs it collected. The present arm groups on the constant subquery
     // value (one group) and projects it (1); the `()` arm NULLs the absent key.
@@ -1108,7 +1108,7 @@ struct GroupingSetsTests {
 
   @Test func `an empty GROUPING SETS set list is a syntax fault, not a crash`()
       throws {
-    // `Grouping.sets` is a public AST case, so a caller may build an EMPTY set
+    // `Grouping.sets` is a public AST case, so a caller may build an empty set
     // list (the parser never emits it). The expansion must reject it with a
     // typed `SQLError` before the `UNION ALL` reduce seed (`arms[0]`) traps the
     // process on the empty arm list.
@@ -1156,11 +1156,11 @@ private func context() throws -> FixtureCatalog {
 struct GroupingSetsCarrierStructureTests {
   @Test func `a DISTINCT qualified-aggregate sort key matches the projected one`()
       throws {
-    // `ORDER BY SUM(s.Qty)` is the SAME projected value as `SUM(Qty)` — it
+    // `ORDER BY SUM(s.Qty)` is the same projected value as `SUM(Qty)` — it
     // differs only by qualification — so the carrier matches it to that
-    // projected output by RESOLVED identity (through the arm's grouped space),
+    // projected output by resolved identity (through the arm's grouped space),
     // never a spurious hidden sort column that DISTINCT would then reject. It
-    // must run IDENTICALLY to the plain grouped form, the oracle.
+    // must run identically to the plain grouped form, the oracle.
     try sales().expect("""
         SELECT DISTINCT SUM(Qty) FROM Sales AS s
          GROUP BY GROUPING SETS ((Region)) ORDER BY SUM(s.Qty)
@@ -1200,10 +1200,10 @@ struct GroupingSetsCarrierStructureTests {
 
   @Test func `a delimited *gs0 alias is a real output, not a generated column`()
       throws {
-    // The generated hidden-column count is STRUCTURAL (carried out of
-    // `expand`), so a user's DELIMITED alias `AS "*gs0"` — which by NAME looks
+    // The generated hidden-column count is structural (carried out of
+    // `expand`), so a user's delimited alias `AS "*gs0"` — which by name looks
     // like a generated `*gsN` sort column — is NOT trimmed: it is the real,
-    // only output (a PLAIN union, no grouping, so no column is ever generated).
+    // only output (a plain union, no grouping, so no column is ever generated).
     try pair().expect("""
         SELECT a AS "*gs0" FROM L UNION ALL SELECT b FROM R ORDER BY 1
         """, yields: [[1], [2], [3], [4], [5]])
@@ -1216,12 +1216,12 @@ struct GroupingSetsCarrierStructureTests {
 
   @Test func `a real output aliased *gs0 does not capture the hidden sort key`()
       throws {
-    // The unprojected `MAX(Qty)` sort key materialises a HIDDEN trailing column
-    // that `expand` aliases `*gs0`. A REAL output ALSO aliased `AS "*gs0"` by
-    // NAME collides with that synthetic alias, so binding the sort key by its
-    // `*gsN` NAME would let the setop-output scope's output-alias precedence
-    // CAPTURE the hidden key onto the real `*gs0` output — ordering by Region,
-    // not `MAX(Qty)`. The carrier binds the hidden slot STRUCTURALLY, by
+    // The unprojected `MAX(Qty)` sort key materialises a hidden trailing column
+    // that `expand` aliases `*gs0`. A REAL output also aliased `AS "*gs0"` by
+    // name collides with that synthetic alias, so binding the sort key by its
+    // `*gsN` name would let the setop-output scope's output-alias precedence
+    // capture the hidden key onto the real `*gs0` output — ordering by Region,
+    // not `MAX(Qty)`. The carrier binds the hidden slot structurally, by
     // position, so the user's colliding alias cannot capture it: the query
     // orders by `MAX(Qty)` exactly as the plain grouped form does. Ascending
     // per-Region MAX(Qty): West 7, East 20 → West row then East row.
@@ -1269,7 +1269,7 @@ struct GroupingSetsCarrierStructureTests {
       throws {
     // An unprojected `MAX(Qty)` sort key materialises a hidden `*gsN` column,
     // so the inner union's width becomes 2 — but the ONLY real output is
-    // `Region`. A trailing ORDINAL must bind the REAL output arity
+    // `Region`. A trailing ordinal must bind the REAL output arity
     // (`0 ..< real`), NOT the grown width, so `ORDER BY MAX(Qty), 2` faults
     // `.column("2")` exactly as the plain grouped `GROUP BY Region ORDER BY
     // MAX(Qty), 2` does — never binding the hidden `MAX(Qty)` slot as if it
@@ -1285,7 +1285,7 @@ struct GroupingSetsCarrierStructureTests {
 
   @Test func `an out-of-range ordinal before a materialised key faults like plain`()
       throws {
-    // The bound is ORDER-INDEPENDENT: whether the materialising `MAX(Qty)` key
+    // The bound is ORDER-independent: whether the materialising `MAX(Qty)` key
     // comes before or after the ordinal, `ORDER BY 2, MAX(Qty)` still faults
     // `.column("2")` over the single real output, matching the plain form.
     try sales().expect("""
@@ -1299,7 +1299,7 @@ struct GroupingSetsCarrierStructureTests {
 
   @Test func `an in-range ordinal after a materialised key binds the real output`()
       throws {
-    // An IN-RANGE ordinal still binds the real output even when an earlier key
+    // An IN-range ordinal still binds the real output even when an earlier key
     // materialised a hidden column: `ORDER BY MAX(Qty), 1` orders by `Region`
     // (ordinal 1, the sole real output), agreeing with the plain grouped form.
     try sales().expect("""
@@ -1312,7 +1312,7 @@ struct GroupingSetsCarrierStructureTests {
 
   @Test func `a pure ordinal ORDER BY over a GROUPING SETS query still binds`()
       throws {
-    // A GROUPING SETS query with NO materialised hidden column (no unprojected
+    // A GROUPING SETS query with no materialised hidden column (no unprojected
     // sort key) still resolves a positional `ORDER BY 1` over its real output —
     // the ordinal bound is the real arity, unchanged when nothing is
     // materialised. The grand-total NULL and the two per-Region rows, by Region
@@ -1327,7 +1327,7 @@ struct GroupingSetsCarrierStructureTests {
       throws {
     // When ordinal 2 IS a real output, the bound admits it: a two-output
     // GROUPING SETS query with an unprojected-aggregate sort key materialises a
-    // hidden THIRD column, but `ORDER BY SUM(Qty), 2` binds the real second
+    // hidden third column, but `ORDER BY SUM(Qty), 2` binds the real second
     // output (`SUM(Qty)`), matching the plain grouped form.
     try sales().expect("""
         SELECT Region, SUM(Qty) FROM Sales GROUP BY GROUPING SETS ((Region))
@@ -1340,8 +1340,8 @@ struct GroupingSetsCarrierStructureTests {
   @Test func `an explicit "column 1" alias is bindable, not a synthesized header`()
       throws {
     // A synthesized display header `column N` is non-bindable by name, but the
-    // carrier distinguishes it from an EXPLICIT delimited `AS "column 1"` by
-    // the STRUCTURAL synthesized flag, not by comparing the name text — so
+    // carrier distinguishes it from an explicit delimited `AS "column 1"` by
+    // the structural synthesized flag, not by comparing the name text — so
     // ordering by the explicit alias works.
     try pair().expect("""
         SELECT a AS "column 1" FROM L UNION ALL SELECT b FROM R
@@ -1392,7 +1392,7 @@ struct GroupingSetsContextTokenTests {
 
   @Test func `a single grouping set with a carrier runs over a derived table`()
       throws {
-    // A ONE-set `GROUPING SETS ((Region))` is an ordinary `GROUP BY Region`:
+    // A one-set `GROUPING SETS ((Region))` is an ordinary `GROUP BY Region`:
     // there is no `UNION` for a sort key to survive, so a query-level `ORDER
     // BY` must NOT wrap the lone grouped arm in an `ordered` carrier. Doing so
     // hid the FROM-clause derived table `s` from the query-level collection

--- a/Tests/SQLTests/Queries/LateralTests.swift
+++ b/Tests/SQLTests/Queries/LateralTests.swift
@@ -10,7 +10,7 @@ import SQLTestSupport
 // MARK: - LATERAL execution
 
 /// A parent `T` and a child `S` keyed on `T.Id`, so a LATERAL body's right side
-/// VARIES per outer row — the proof of real correlation a once-materialised
+/// varies per outer row — the proof of real correlation a once-materialised
 /// constant relation could not produce.
 private func fixture() throws -> FixtureCatalog {
   try Catalog {
@@ -28,7 +28,7 @@ private func fixture() throws -> FixtureCatalog {
   }
 }
 
-/// A LATERAL derived table resolves its body against the PRECEDING FROM and
+/// A LATERAL derived table resolves its body against the preceding FROM and
 /// re-evaluates it per that row — a correlated apply. The right side differs per
 /// left row (impossible for a once-materialised constant), and an INNER apply
 /// drops a left row whose body yields nothing.
@@ -36,8 +36,8 @@ struct LateralExecutionTests {
   @Test func `a LATERAL body yields per-outer-row-varying rows`() throws {
     // `… JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON 1 = 1` — the
     // body's `T.Id` correlates to the preceding `T`, so `d` re-runs per `T` row
-    // over the children keyed on THAT `Id`: Id 1 → {100, 101}, Id 2 → {200},
-    // Id 3 → {} (dropped, INNER apply). The right side VARIES per left row.
+    // over the children keyed on that `Id`: Id 1 → {100, 101}, Id 2 → {200},
+    // Id 3 → {} (dropped, INNER apply). The right side varies per left row.
     try fixture().expect(
         "SELECT T.Id, d.x FROM T " +
         "JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON 1 = 1 " +
@@ -80,8 +80,8 @@ struct LateralExecutionTests {
   }
 
   @Test func `a LATERAL body advertises its output schema`() throws {
-    // A lateral body's SHAPE is correlation-independent — its projection names
-    // its OWN relation `S`, so `columns(of:)` reports the body's output column
+    // A lateral body's shape is correlation-independent — its projection names
+    // its own relation `S`, so `columns(of:)` reports the body's output column
     // `x` under `d` even though the body's WHERE correlates against `T`.
     let query = try parse(query:
         "SELECT d.x FROM T " +
@@ -93,7 +93,7 @@ struct LateralExecutionTests {
   }
 
   @Test func `a NON-lateral body still faults the preceding column`() throws {
-    // PARITY: the SAME body WITHOUT `LATERAL` still faults the unknown
+    // parity: the same body without `LATERAL` still faults the unknown
     // preceding column — the no-LATERAL rule is intact (a non-lateral body is
     // resolved independently of its call site).
     try fixture().expect(
@@ -103,7 +103,7 @@ struct LateralExecutionTests {
   }
 
   @Test func `a LATERAL first FROM item faults`() throws {
-    // A lateral derived table needs a PRECEDING FROM item; as the sole FROM
+    // A lateral derived table needs a preceding FROM item; as the sole FROM
     // relation it has nothing to correlate against, so it faults.
     try fixture().expect(
         "SELECT d.x FROM LATERAL (SELECT x FROM S) AS d",
@@ -112,7 +112,7 @@ struct LateralExecutionTests {
   }
 
   @Test func `a CTE is visible inside a LATERAL body`() throws {
-    // The lateral body resolves against the SAME scope its call site sees, so
+    // The lateral body resolves against the same scope its call site sees, so
     // an enclosing CTE `c` is visible inside it — the structural fix unified
     // the lateral body's resolution scope with the outer query's. The schema
     // pass derives the body's output column `x`, and the run correlates it per
@@ -132,7 +132,7 @@ struct LateralExecutionTests {
 
   @Test func `a bad function in a LATERAL body faults the schema check`()
       throws {
-    // PARITY: the schema pass validates the lateral body exactly as the run
+    // parity: the schema pass validates the lateral body exactly as the run
     // executes it, so an unregistered `bad` function in the body faults the
     // strict `columns(of:validate:true)` schema check with the same
     // `SQLError.function` the run raises — the schema is not advertised for a
@@ -148,9 +148,9 @@ struct LateralExecutionTests {
 
   @Test func `validate false does not eagerly fault a bad LATERAL body`()
       throws {
-    // LENIENT PARITY: with `validate: false` — the run-shape pass — the same
+    // lenient parity: with `validate: false` — the run-shape pass — the same
     // bad-function lateral body is NOT eager-checked, so deriving its headers
-    // returns the body's output column `x` WITHOUT the `.function` fault,
+    // returns the body's output column `x` without the `.function` fault,
     // matching the engine's reachability-gated validation (the strict schema
     // path faults it; the lenient one trusts it).
     let query = try parse(query:
@@ -163,7 +163,7 @@ struct LateralExecutionTests {
 
   @Test func `a LATERAL body exposes its virtual Id per left row`() throws {
     // A lateral derived table exposes the universal virtual `Id` at its real
-    // width, so `d.Id` names the 1-based position of the row WITHIN this left
+    // width, so `d.Id` names the 1-based position of the row within this left
     // row's body output — reset per outer row, exactly as a non-lateral derived
     // table's `Id` numbers its own materialised rows. Id 1 → children {100,
     // 101} → d.Id {1, 2}; Id 2 → {200} → d.Id {1}; Id 3 → {} (dropped). The
@@ -178,8 +178,8 @@ struct LateralExecutionTests {
   }
 
   @Test func `a LATERAL virtual Id matches a non-lateral derived Id`() throws {
-    // PARITY: the per-left-row `d.Id` a lateral body advertises numbers its own
-    // output the SAME way a non-lateral derived table numbers its materialised
+    // parity: the per-left-row `d.Id` a lateral body advertises numbers its own
+    // output the same way a non-lateral derived table numbers its materialised
     // rows — the FIRST left row (`T.Id` 1) has two children, so its lateral
     // `d.Id`s are 1 and 2, exactly a non-lateral `(SELECT x FROM S WHERE S.k =
     // 1) AS d`'s Ids over the same two rows.
@@ -217,13 +217,13 @@ struct LateralExecutionTests {
   }
 
   @Test func `a LATERAL body cannot see a caller derived alias`() throws {
-    // STRUCTURAL PARITY: the lateral body's PLAN compile resolves its `FROM`
-    // over the SAME revealed base the schema/validation pass does — base plus
-    // CTEs plus store, this select's derived aliases STRIPPED — so a body
-    // naming a CALLER derived alias `e` faults the unknown relation
-    // CONSISTENTLY at both the schema pass and the run, rather than the
+    // structural parity: the lateral body's plan compile resolves its `FROM`
+    // over the same revealed base the schema/validation pass does — base plus
+    // CTEs plus store, this select's derived aliases stripped — so a body
+    // naming a caller derived alias `e` faults the unknown relation
+    // consistently at both the schema pass and the run, rather than the
     // run-only compile scanning the caller's `e` while the schema pass faults.
-    // The caller reference sits in the set-operation body's LATER arm (`…
+    // The caller reference sits in the set-operation body's later arm (`…
     // UNION ALL SELECT x FROM e`), the arm the run-path shape pass
     // (`materialise`, `rows: false`) does NOT derive — so ONLY the plan compile
     // ever resolved it, the exact path the unified revealed base now closes.
@@ -242,12 +242,12 @@ struct LateralExecutionTests {
 
   @Test func `a shadowed CTE in a LATERAL body resolves the same at compile and run`()
       throws {
-    // EXECUTION/COMPILE PARITY: a CTE `e` SHADOWED by a caller derived alias
+    // execution/compile parity: a CTE `e` shadowed by a caller derived alias
     // `e` is in scope of the lateral body's `FROM e`. Compile resolves the body
-    // over the REVEALED base (CTEs plus store, this select's derived aliases
-    // STRIPPED), so it binds the CTE `e` (x = 1). The per-outer-row apply must
-    // re-run that plan under the SAME revealed overlay — else it scans the
-    // UNREVEALED caller derived alias `e` (x = 2) and yields the WRONG rows.
+    // over the revealed base (CTEs plus store, this select's derived aliases
+    // stripped), so it binds the CTE `e` (x = 1). The per-outer-row apply must
+    // re-run that plan under the same revealed overlay — else it scans the
+    // unrevealed caller derived alias `e` (x = 2) and yields the wrong rows.
     // The CTE matches `T.Id` 1, the derived alias would match `T.Id` 2, so the
     // divergence is a visible wrong row, not merely an empty result. The run
     // yields the CTE's row and `columns(of:validate: true)` agrees — schema,
@@ -274,7 +274,7 @@ struct LateralExecutionTests {
 struct OuterApplyTests {
   @Test func `OUTER APPLY NULL-extends a left row with no right rows`() throws {
     // `T.Id` 3 has no child in `S`, so the OUTER apply (`LEFT JOIN LATERAL`)
-    // PRESERVES it NULL-extended: Id 1 → {100, 101}, Id 2 → {200}, Id 3 →
+    // preserves it NULL-extended: Id 1 → {100, 101}, Id 2 → {200}, Id 3 →
     // (3, NULL) — the left row kept with a NULL right column.
     try fixture().expect(
         "SELECT T.Id, d.x FROM T " +
@@ -284,7 +284,7 @@ struct OuterApplyTests {
   }
 
   @Test func `the INNER CROSS APPLY twin drops the unmatched row`() throws {
-    // CONTRAST: the SAME body under `JOIN LATERAL` (INNER/CROSS APPLY) DROPS
+    // contrast: the same body under `JOIN LATERAL` (INNER/CROSS APPLY) drops
     // `T.Id` 3 — the drop the OUTER apply above replaces with a NULL-extended
     // row. Only 1 and 2 survive.
     try fixture().expect(
@@ -296,9 +296,9 @@ struct OuterApplyTests {
 
   @Test func `OUTER APPLY NULL-extends when the ON filters all right rows`()
       throws {
-    // A body that DOES produce rows but whose every merged pair fails the join
+    // A body that does produce rows but whose every merged pair fails the join
     // `ON` still counts as unmatched: `ON d.x > 1000` rejects every child, so
-    // EACH left row — even Ids 1 and 2 with children — is NULL-extended, just
+    // each left row — even Ids 1 and 2 with children — is NULL-extended, just
     // as Id 3 (no children) is. No pair survives, so all three preserve NULL.
     try fixture().expect(
         "SELECT T.Id, d.x FROM T " +
@@ -329,16 +329,16 @@ struct OuterApplyTests {
 // MARK: - LATERAL body projects a preceding-FROM column (ISO scoping)
 
 /// Per ISO 9075 a LATERAL derived table's preceding-FROM references are in
-/// scope throughout its query expression, INCLUDING the SELECT list — so a
-/// lateral body may PROJECT a preceding column, unlike an ordinary correlated
+/// scope throughout its query expression, including the SELECT list — so a
+/// lateral body may project a preceding column, unlike an ordinary correlated
 /// subquery (whose projection this engine bars). The bar is lifted for the
-/// LATERAL body ALONE: the body's `Resolution`/`SubqueryCheck` admit a
+/// LATERAL body alone: the body's `Resolution`/`SubqueryCheck` admit a
 /// correlated column everywhere, so a projected preceding column lowers to a
 /// `Term.parameter` the apply binds per outer row; the ordinary subquery
 /// projection bar is untouched.
 struct LateralProjectionCorrelationTests {
   @Test func `a LATERAL body projects a preceding column`() throws {
-    // `JOIN LATERAL (SELECT T.Id AS id) AS d ON 1 = 1` — the body's PROJECTION
+    // `JOIN LATERAL (SELECT T.Id AS id) AS d ON 1 = 1` — the body's projection
     // names the preceding `T.Id`, which ISO puts in scope throughout the body.
     // The strict schema path derives `id` typed from `T.Id` (`.integer`), and a
     // run yields `d.id == T.Id` for each left row — the projected preceding
@@ -358,9 +358,9 @@ struct LateralProjectionCorrelationTests {
   }
 
   @Test func `a LATERAL body projects a BARE preceding column`() throws {
-    // The BARE-COLUMN twin of the aliased case above: a LATERAL body projecting
-    // a preceding `T.Id` WITHOUT an alias collapses to `Projection.columns` —
-    // the simpler path. The schema-derive `.columns` case must consult the SAME
+    // The bare-COLUMN twin of the aliased case above: a LATERAL body projecting
+    // a preceding `T.Id` without an alias collapses to `Projection.columns` —
+    // the simpler path. The schema-derive `.columns` case must consult the same
     // lateral correlation surface the aliased expression path does, else a bare
     // preceding column faults `SQLError.column("Id")` at schema/run even though
     // the aliased form works. The strict schema path derives `Id` typed from
@@ -382,9 +382,9 @@ struct LateralProjectionCorrelationTests {
 
   @Test func `an ordinary subquery still cannot project a BARE outer column`()
       throws {
-    // The bare-column exemption is GATED on the lateral surface, not opened for
+    // The bare-column exemption is gated on the lateral surface, not opened for
     // the `.columns` path generally: an ordinary (non-lateral) derived table
-    // whose body projects a bare preceding `T.Id` STILL faults `.unsupported`
+    // whose body projects a bare preceding `T.Id` still faults `.unsupported`
     // at the strict schema check — the barred projection surface of an ordinary
     // subquery diagnoses the correlated bare column exactly as it does the
     // aliased one. This pins the exemption to the LATERAL `everywhere` surface.
@@ -397,10 +397,10 @@ struct LateralProjectionCorrelationTests {
   }
 
   @Test func `a LATERAL body projects a preceding and a body column`() throws {
-    // A MIXED projection — the preceding `T.Id AS a` beside the body's own
+    // A mixed projection — the preceding `T.Id AS a` beside the body's own
     // `x AS b` — proves a projected correlated column and a projected local
     // column coexist. The body re-runs per `T` row over the children keyed on
-    // THAT `Id`: Id 1 → {100, 101}, Id 2 → {200}, Id 3 → {} (dropped, INNER
+    // that `Id`: Id 1 → {100, 101}, Id 2 → {200}, Id 3 → {} (dropped, INNER
     // apply). `a` reads the bound preceding `T.Id`, `b` the body's own `x`.
     try fixture().expect(
         "SELECT d.a, d.b FROM T " +
@@ -412,7 +412,7 @@ struct LateralProjectionCorrelationTests {
 
   @Test func `a LATERAL body advertises a projected preceding column mixed`()
       throws {
-    // The strict schema path derives BOTH output columns of the mixed body —
+    // The strict schema path derives both output columns of the mixed body —
     // `a` typed from the preceding `T.Id`, `b` from the body's own `x` — so
     // `columns(of:validate: true)` reports the correlated projection's shape.
     let query = try parse(query:
@@ -426,8 +426,8 @@ struct LateralProjectionCorrelationTests {
   }
 
   @Test func `an ordinary subquery projection still cannot correlate`() throws {
-    // The bar lift is LATERAL-ONLY: an ordinary correlated SCALAR SUBQUERY in
-    // the projection — `SELECT (SELECT T.Id) FROM T` — STILL faults
+    // The bar lift is LATERAL-ONLY: an ordinary correlated scalar subquery in
+    // the projection — `SELECT (SELECT T.Id) FROM T` — still faults
     // `.unsupported`, since a subquery's projection is a barred clause position
     // (no evaluator for an outer column there). This pins the LATERAL-only
     // scoping — the everywhere-correlation admission is set for a LATERAL body
@@ -441,14 +441,14 @@ struct LateralProjectionCorrelationTests {
   @Test func `an ordinary nested subquery inside a LATERAL body is not lateralised`()
       throws {
     // The LATERAL everywhere-correlation admission covers ONLY the lateral
-    // body's OWN projection, NEVER a nested ordinary subquery WITHIN it. So an
+    // body's own projection, never a nested ordinary subquery within it. So an
     // ordinary correlated scalar subquery in the lateral body's projection —
     // `SELECT (SELECT T.Id) AS x` — is barred `.unsupported` at the strict
-    // schema check EXACTLY as the non-lateral twin `SELECT (SELECT T.Id) FROM T`
-    // is, since the nested subquery builds its OWN Resolution with the lateral
+    // schema check exactly as the non-lateral twin `SELECT (SELECT T.Id) FROM T`
+    // is, since the nested subquery builds its own Resolution with the lateral
     // flag cleared (`everywhere: false`). Threading the lateral flag into the
     // nested subquery instead admitted its `T.Id` everywhere and lowered it to a
-    // correlated parameter the nested subquery never wires — a WRONG, mismatched
+    // correlated parameter the nested subquery never wires — a wrong, mismatched
     // fault (`no such column 'Id'`) rather than the correct barred `.unsupported`
     // — the bug the cleared flag fixes.
     let query = try parse(query:
@@ -463,21 +463,21 @@ struct LateralProjectionCorrelationTests {
 
 // MARK: - LATERAL aggregate body correlates a preceding-FROM column
 
-/// An AGGREGATE lateral body — one that groups, projects a grouped column, or
+/// An aggregate lateral body — one that groups, projects a grouped column, or
 /// filters through `HAVING` — must resolve a preceding-FROM reference through
-/// the SAME correlation surface a non-grouped lateral body does. The grouped
+/// the same correlation surface a non-grouped lateral body does. The grouped
 /// lowering (`Grouping.term`, `Grouping.init`, and `group`'s key computation)
 /// once consulted only the local scope, so a valid apply projecting or grouping
 /// on a preceding column faulted `SQLError.column` at schema/compile instead of
 /// producing one aggregate row per left row. Threading the lateral surface
 /// through the grouped key/projection/HAVING lowering lifts the fault for a
-/// LATERAL body ALONE — the ordinary grouped-subquery bar is untouched (the
+/// LATERAL body alone — the ordinary grouped-subquery bar is untouched (the
 /// negative oracle below pins it).
 struct LateralAggregateCorrelationTests {
   @Test func `a LATERAL aggregate body projects a preceding column`() throws {
     // The reviewer's exact case: `JOIN LATERAL (SELECT T.Id AS id, COUNT(*) AS n
     // FROM S WHERE S.k = T.Id) AS d ON 1 = 1` — a whole-result aggregate body
-    // that also PROJECTS the preceding `T.Id`. The strict schema path derives
+    // that also projects the preceding `T.Id`. The strict schema path derives
     // `id` (typed from `T.Id`) and `n` (`COUNT` → integer), and a run yields one
     // row per `T` with `n` the count of `S` rows keyed on that `Id`: Id 1 → 2,
     // Id 2 → 1, Id 3 → 0 (a `COUNT` over the empty match still emits its row).
@@ -497,12 +497,12 @@ struct LateralAggregateCorrelationTests {
 
   @Test func `a LATERAL aggregate body groups on a preceding column`() throws {
     // A GROUP BY on the preceding `T.Id` — a per-invocation constant, so it forms
-    // ONE group per left row over that invocation's SOURCE rows. The grouping key
+    // one group per left row over that invocation's source rows. The grouping key
     // lowers to a `Term.parameter` the apply binds per outer row (not a slot the
     // body's own scope holds), so the schema derives and the run yields one
     // grouped row per left row WITH source rows: Id 1 → {100, 101} → n 2, Id 2 →
-    // {200} → n 1. Id 3 has NO source rows (its `WHERE` matches nothing), so its
-    // GROUP BY forms NO group — an empty body the INNER apply drops (unlike the
+    // {200} → n 1. Id 3 has no source rows (its `WHERE` matches nothing), so its
+    // GROUP BY forms no group — an empty body the INNER apply drops (unlike the
     // whole-result COUNT above, which emits one empty group per left row).
     let query = try parse(query:
         "SELECT d.id, d.n FROM T " +
@@ -540,7 +540,7 @@ struct LateralAggregateCorrelationTests {
   @Test func `an ordinary grouped subquery projection still cannot correlate`()
       throws {
     // The grouped bar lift is LATERAL-ONLY: an ordinary correlated grouped
-    // SCALAR SUBQUERY that PROJECTS an outer column — `SELECT (SELECT T.Id FROM S
+    // scalar subquery that projects an outer column — `SELECT (SELECT T.Id FROM S
     // GROUP BY S.k) FROM T` — STILL faults `.unsupported`, since a subquery's
     // grouped projection is a barred clause position. This pins the exemption on
     // the LATERAL `everywhere` surface, never opened for every grouped subquery.
@@ -568,18 +568,18 @@ struct LateralAggregateCorrelationTests {
 // MARK: - Set-op SELECT * LATERAL arm arity
 
 /// A set operation whose `SELECT *` arm is a LATERAL join must derive that
-/// arm's star arity against the PRECEDING FROM, exactly as the per-arm
+/// arm's star arity against the preceding FROM, exactly as the per-arm
 /// compile does — the arity check threads the running prefix scope so the
 /// lateral body's preceding-column reference resolves.
 struct LateralSetOperationStarTests {
   @Test func `a set-op SELECT * LATERAL arm resolves its arity with the prefix`()
       throws {
     // A LATERAL arm's star arity must derive the body's projected preceding
-    // column against the PRECEDING FROM, exactly as the per-arm compile does.
+    // column against the preceding FROM, exactly as the per-arm compile does.
     // Each arm is `SELECT * FROM T JOIN LATERAL (SELECT T.Id AS id) AS d` — two
     // columns wide (`T.Id` + `d.id`). The arity check must thread the running
     // prefix scope so `T.Id` resolves; without it the lateral body derived
-    // against NO scope and faulted the arity check even though the per-arm
+    // against no scope and faulted the arity check even though the per-arm
     // compile passes the prefix and runs. Both arms are two columns, so the
     // union's arity matches and it resolves.
     let query = try parse(query:
@@ -597,10 +597,10 @@ struct LateralSetOperationStarTests {
 
 /// A LATERAL join (CROSS/OUTER APPLY) in the FROM of an aggregate/`GROUP BY`
 /// outer query. The grouped path shares the FROM front half with the non-
-/// aggregate path, so the apply body's OUTPUT columns land in scope for the
+/// aggregate path, so the apply body's output columns land in scope for the
 /// keys, aggregate arguments, `HAVING`, and `ORDER BY`; the aggregate node
-/// then groups the apply-bearing chain. INNER apply DROPS a body-empty outer
-/// row (so it never reaches the aggregate); OUTER apply NULL-EXTENDS it (so
+/// then groups the apply-bearing chain. INNER apply drops a body-empty outer
+/// row (so it never reaches the aggregate); OUTER apply NULL-extends it (so
 /// `COUNT(*)` counts the NULL row while `COUNT(col)`/`SUM` skip it).
 struct LateralUnderAggregateTests {
   @Test func `COUNT star over a CROSS APPLY counts the surviving rows`()
@@ -624,7 +624,7 @@ struct LateralUnderAggregateTests {
 
   @Test func `GROUP BY a lateral output column groups the apply rows`()
       throws {
-    // Group by the body's OUTPUT column `d.x` — each distinct child value is
+    // Group by the body's output column `d.x` — each distinct child value is
     // its own group of one row. ORDER BY the lateral key: (100, 1), (101, 1),
     // (200, 1). Id 3 contributes no row (INNER apply), so no group for it.
     try fixture().expect(
@@ -639,7 +639,7 @@ struct LateralUnderAggregateTests {
     // LEFT JOIN LATERAL NULL-extends the body-empty Id 3, so a fourth row (all
     // `d` columns NULL) reaches the aggregate. `COUNT(*)` counts it (4);
     // `COUNT(d.x)` and `SUM(d.x)` skip the NULL (3 and 401) — the values
-    // DIFFER, pinning NULL-into-aggregate over the NULL-extended apply row.
+    // differ, pinning NULL-into-aggregate over the NULL-extended apply row.
     try fixture().expect(
         "SELECT COUNT(*) AS n FROM T " +
         "LEFT JOIN LATERAL (SELECT x FROM S WHERE S.k = T.Id) AS d ON 1 = 1",
@@ -668,8 +668,8 @@ struct LateralUnderAggregateTests {
 
   @Test func `a lateral body that itself aggregates folds under the outer`()
       throws {
-    // The body is a WHOLE-RESULT aggregate (`COUNT(*)` with no GROUP BY), which
-    // emits ONE row per outer row even for an empty match: Id 1 → 2, Id 2 → 1,
+    // The body is a whole-result aggregate (`COUNT(*)` with no GROUP BY), which
+    // emits one row per outer row even for an empty match: Id 1 → 2, Id 2 → 1,
     // Id 3 → 0. The outer `SUM(d.n)` folds them: 2 + 1 + 0 = 3.
     try fixture().expect(
         "SELECT SUM(d.n) AS s FROM T " +
@@ -700,11 +700,11 @@ struct LateralUnderAggregateTests {
 
   @Test func `a preceding column read ONLY inside the body is materialised`()
       throws {
-    // CORRELATION-SLOT SENTINEL: the preceding `T.Id` appears in NO outer
+    // correlation-slot SENTINEL: the preceding `T.Id` appears in no outer
     // clause — not the projection, keys, aggregate args, HAVING, ORDER — it
     // lives ONLY inside the body's WHERE (`S.k = T.Id`). The apply still reads
     // `T.Id` from the left record to bind the correlation, so it must be
-    // MATERIALISED (given a packed slot) even though the grouped clauses never
+    // materialised (given a packed slot) even though the grouped clauses never
     // name it; the `laterals` correlation-slot union guarantees it. `COUNT(*)`
     // is 3.
     try fixture().expect(

--- a/Tests/SQLTests/Queries/LimitTests.swift
+++ b/Tests/SQLTests/Queries/LimitTests.swift
@@ -87,7 +87,7 @@ struct LimitTests {
 
   @Test func `FETCH after ORDER BY takes the top-N in sorted order`() throws {
     // Ordered by Age ascending, ties by source order (a stable sort): Bob(25),
-    // Eve(25), Alice(30), Carol(30), Dave(40). The FETCH caps the ORDERED
+    // Eve(25), Alice(30), Carol(30), Dave(40). The FETCH caps the ordered
     // result, so it takes the two lowest ages rather than the first two rows.
     try people().expect(
         "SELECT Name FROM People ORDER BY Age FETCH FIRST 2 ROWS ONLY",
@@ -141,7 +141,7 @@ struct LimitTests {
     let catalog = try people()
     try catalog.empty("SELECT 1 / 0 FROM People FETCH FIRST 0 ROWS ONLY")
     try catalog.empty("SELECT 1 / 0 FROM People OFFSET 10 ROWS")
-    // A page that DOES admit a row still evaluates the projection (and throws),
+    // A page that does admit a row still evaluates the projection (and throws),
     // confirming the guard is the empty page, not a skipped projection.
     catalog.expect("SELECT 1 / 0 FROM People FETCH FIRST 1 ROW ONLY",
                    fails: .divide)

--- a/Tests/SQLTests/Queries/OrderByExpressionTests.swift
+++ b/Tests/SQLTests/Queries/OrderByExpressionTests.swift
@@ -40,8 +40,8 @@ private func sales() throws -> FixtureCatalog {
   }
 }
 
-/// Two relations that BOTH carry a `Name` column, joined on their `Id`s, so a
-/// bare unqualified `ORDER BY Name` is an ambiguous INPUT reference — the
+/// Two relations that both carry a `Name` column, joined on their `Id`s, so a
+/// bare unqualified `ORDER BY Name` is an ambiguous input reference — the
 /// surface for the representation-independence check.
 private func joined() throws -> FixtureCatalog {
   try Catalog {
@@ -60,8 +60,8 @@ private func joined() throws -> FixtureCatalog {
 
 // MARK: - Tests
 
-/// The generalized ISO `<sort key>`: an output ORDINAL, an arbitrary value
-/// EXPRESSION over the input columns, and an output ALIAS — the three forms an
+/// The generalized ISO `<sort key>`: an output ordinal, an arbitrary value
+/// expression over the input columns, and an output alias — the three forms an
 /// `ORDER BY` key now admits beyond a bare column.
 struct OrderByExpressionTests {
   @Test func `ORDER BY an ordinal orders on that output column`() throws {
@@ -79,7 +79,7 @@ struct OrderByExpressionTests {
   }
 
   @Test func `an ordinal names the output column, not the integer constant`() throws {
-    // A bare integer sort key is the ISO ORDINAL, never the constant `1`;
+    // A bare integer sort key is the ISO ordinal, never the constant `1`;
     // ordering on `1` therefore orders on the FIRST output column (Id), the
     // rows already in Id order, rather than treating every row as equal.
     let catalog = try people()
@@ -118,7 +118,7 @@ struct OrderByExpressionTests {
 
   @Test func `an output alias wins over an input column of the same name`() throws {
     // `Name` aliases `UPPER(Name)` here, so the bare `ORDER BY Name` binds the
-    // OUTPUT alias (the ISO precedence) rather than the input `Name` column —
+    // output alias (the ISO precedence) rather than the input `Name` column —
     // both order the rows the same alphabetically here, but the alias's value
     // (the upper-cased name) is what the output row carries.
     try people().expect("""
@@ -137,7 +137,7 @@ struct OrderByExpressionTests {
   }
 
   @Test func `ORDER BY an input column absent from the select list`() throws {
-    // A plain (non-DISTINCT) query may order on any INPUT column — `A` here —
+    // A plain (non-DISTINCT) query may order on any input column — `A` here —
     // even one the projection drops; the sort runs on the source rows before
     // the projection. A ascending: alice 1, bob 2, carol 3, dave 5.
     try people().expect("SELECT Name FROM People ORDER BY A",
@@ -148,21 +148,21 @@ struct OrderByExpressionTests {
 
   // Only an explicit `AS` alias introduces an ORDER-BY-visible output name. A
   // bare projected column contributes none, so `ORDER BY <bareName>` resolves
-  // as an INPUT column — identically whether an unrelated select-list item
+  // as an input column — identically whether an unrelated select-list item
   // forced the projection into a `columns` or an `expressions` list.
 
   @Test func `a bare ORDER BY name over a join is an ambiguous input column`() throws {
     // Both `a` and `b` carry `Name`, so the bare `ORDER BY Name` is an
-    // ambiguous INPUT reference — no explicit alias claims the name.
+    // ambiguous input reference — no explicit alias claims the name.
     try joined().expect("""
         SELECT a.Name, a.Id FROM a JOIN b ON a.Id = b.Id ORDER BY Name
         """, fails: SQLError.ambiguous("Name"))
   }
 
   @Test func `an unrelated AS does not flip a bare ORDER BY name to an output`() throws {
-    // Aliasing ONLY the SECOND item (`a.Id AS id`) forces the projection into
-    // an `expressions` list, but the first item is still a BARE `a.Name` with
-    // no explicit alias — so `ORDER BY Name` remains the same ambiguous INPUT
+    // Aliasing ONLY the second item (`a.Id AS id`) forces the projection into
+    // an `expressions` list, but the first item is still a bare `a.Name` with
+    // no explicit alias — so `ORDER BY Name` remains the same ambiguous input
     // reference as the `columns`-list form above, not a bind to the first
     // output. Semantics track the SQL, not the AST representation.
     try joined().expect("""
@@ -171,7 +171,7 @@ struct OrderByExpressionTests {
   }
 
   @Test func `ORDER BY an explicit alias still binds the projected output`() throws {
-    // An explicit `AS u` DOES introduce an output name, so `ORDER BY u` binds
+    // An explicit `AS u` does introduce an output name, so `ORDER BY u` binds
     // the projected expression (the upper-cased name), not an input column.
     try people().expect("""
         SELECT UPPER(Name) AS u FROM People ORDER BY u
@@ -180,7 +180,7 @@ struct OrderByExpressionTests {
 
   @Test func `a single-table bare ORDER BY name binds the input column`() throws {
     // One relation, one `Name`: the bare projected column introduces no output
-    // alias, so `ORDER BY Name` binds the unambiguous INPUT column.
+    // alias, so `ORDER BY Name` binds the unambiguous input column.
     try people().expect("SELECT Name FROM People ORDER BY Name",
                         yields: [["alice"], ["bob"], ["carol"], ["dave"]])
   }
@@ -222,7 +222,7 @@ struct OrderByExpressionTests {
   }
 
   @Test func `SELECT DISTINCT admits an ORDER BY repeating a projected expression`() throws {
-    // The ORDER BY REPEATS the projected `A + B` expression rather than naming
+    // The ORDER BY repeats the projected `A + B` expression rather than naming
     // its alias or ordinal. That sort key IS the projected distinct value, so
     // ordering on it is well-defined and admitted — the same result as the
     // alias `ORDER BY Total` and the ordinal `ORDER BY 1` naming that output.
@@ -233,7 +233,7 @@ struct OrderByExpressionTests {
   }
 
   @Test func `the alias and ordinal name the same DISTINCT output`() throws {
-    // `ORDER BY Total` (alias) and `ORDER BY 1` (ordinal) produce the SAME order
+    // `ORDER BY Total` (alias) and `ORDER BY 1` (ordinal) produce the same order
     // as the repeated `ORDER BY A + B` above — all three name the one projected
     // distinct value.
     try people().expect("""
@@ -261,7 +261,7 @@ struct OrderByExpressionTests {
   }
 
   @Test func `SELECT DISTINCT admits an ORDER BY differing only in qualification`() throws {
-    // The ORDER BY repeats the projected `A + 1`, but QUALIFIES the column
+    // The ORDER BY repeats the projected `A + 1`, but qualifies the column
     // (`People.A + 1`) where the projection did not (`A + 1`). The two are
     // different AST expressions, yet both LOWER to the same `Term` — the
     // column resolves to the same slot — so the sort key IS the projected
@@ -274,7 +274,7 @@ struct OrderByExpressionTests {
   }
 
   @Test func `the qualified, unqualified, alias, and ordinal DISTINCT keys agree`() throws {
-    // The qualified `People.A + 1` produces the SAME order as the unqualified
+    // The qualified `People.A + 1` produces the same order as the unqualified
     // `A + 1`, the alias `v`, and the ordinal `1` — all four name the one
     // projected distinct value (2, 3, 4, 6, ascending).
     let catalog = try people()
@@ -290,8 +290,8 @@ struct OrderByExpressionTests {
   }
 
   @Test func `SELECT DISTINCT admits a qualified ORDER BY on a bare projected column`() throws {
-    // The projected bare `A` lowers to a slot, and the QUALIFIED `People.A`
-    // key lowers to the SAME slot, so it matches the projected term and is
+    // The projected bare `A` lowers to a slot, and the qualified `People.A`
+    // key lowers to the same slot, so it matches the projected term and is
     // admitted. The distinct `A` values are 1, 2, 3, 5, ascending.
     try people().expect("SELECT DISTINCT A FROM People ORDER BY People.A",
                         yields: [[1], [2], [3], [5]])
@@ -307,9 +307,9 @@ struct OrderByExpressionTests {
 
   @Test func `SELECT DISTINCT admits a mixed-case ORDER BY repeating a projected call`() throws {
     // The ORDER BY repeats the projected `UPPER(Name)` call, but spells the
-    // routine in a DIFFERENT case (`upper` vs `UPPER`). A routine resolves by
+    // routine in a different case (`upper` vs `UPPER`). A routine resolves by
     // the case-insensitive SQL identifier rule, so both name the same routine
-    // and the two calls lower to an IDENTICAL term — the sort key IS the
+    // and the two calls lower to an identical term — the sort key IS the
     // projected distinct value and is admitted, exactly as the same-case
     // `ORDER BY UPPER(Name)`, the alias `u`, and the ordinal `1` are. The
     // distinct upper-cased names are ALICE, BOB, CAROL, DAVE, ascending.
@@ -319,7 +319,7 @@ struct OrderByExpressionTests {
   }
 
   @Test func `the same-case, mixed-case, alias, and ordinal DISTINCT call keys agree`() throws {
-    // The mixed-case `upper(Name)` produces the SAME order as the same-case
+    // The mixed-case `upper(Name)` produces the same order as the same-case
     // `UPPER(Name)`, the alias `u`, and the ordinal `1` — all four name the one
     // projected distinct value (ALICE, BOB, CAROL, DAVE, ascending).
     let catalog = try people()
@@ -335,7 +335,7 @@ struct OrderByExpressionTests {
   }
 
   @Test func `SELECT DISTINCT admits a mixed-case ORDER BY the other way round`() throws {
-    // The case folding is symmetric: a lower-case `upper(Name)` PROJECTED and
+    // The case folding is symmetric: a lower-case `upper(Name)` projected and
     // an upper-case `UPPER(Name)` in the ORDER BY lower to the same term too,
     // so this spelling is admitted as well (ALICE, BOB, CAROL, DAVE).
     try people().expect("""
@@ -344,8 +344,8 @@ struct OrderByExpressionTests {
   }
 
   @Test func `SELECT DISTINCT rejects a case-folded key that names a different routine`() throws {
-    // Case folding equates only calls of the SAME routine: `LOWER(Name)` is a
-    // DIFFERENT routine from the projected `UPPER(Name)`, so its term differs
+    // Case folding equates only calls of the same routine: `LOWER(Name)` is a
+    // different routine from the projected `UPPER(Name)`, so its term differs
     // and ordering on it under DISTINCT stays ill-defined and faults.
     try people().expect("""
         SELECT DISTINCT UPPER(Name) AS u FROM People ORDER BY LOWER(Name)
@@ -401,15 +401,15 @@ struct OrderByExpressionTests {
 
   // MARK: - Aggregate collection normalizes column qualification
 
-  // Aggregate collection dedups by the RESOLVED aggregation (function plus
+  // Aggregate collection dedups by the resolved aggregation (function plus
   // resolved argument term), not by AST spelling, so an aggregate written two
   // ways that differ ONLY in column qualification — `SUM(Amount)` projected,
-  // `SUM(Sales.Amount)` in the ORDER BY — is ONE grouped slot: the aggregate
+  // `SUM(Sales.Amount)` in the ORDER BY — is one grouped slot: the aggregate
   // computes once and both clauses read/order the same value.
 
   @Test func `SELECT DISTINCT admits an ORDER BY aggregate differing only in qualification`() throws {
     // The projected `SUM(Amount)` and the ORDER BY `SUM(Sales.Amount)` differ
-    // only in qualification; deduped by resolved form they share ONE grouped
+    // only in qualification; deduped by resolved form they share one grouped
     // slot, so the sort key IS the projected distinct value and DISTINCT admits
     // it. Distinct department sums are 60, 90, 30, ordered ascending.
     try sales().expect("""
@@ -419,7 +419,7 @@ struct OrderByExpressionTests {
   }
 
   @Test func `a DISTINCT qualified ORDER BY aggregate matches the unqualified form`() throws {
-    // The qualified `SUM(Sales.Amount)` sort key produces the SAME result as the
+    // The qualified `SUM(Sales.Amount)` sort key produces the same result as the
     // unqualified `SUM(Amount)` and the ordinal `1` — all three name the one
     // projected distinct aggregate value.
     let catalog = try sales()
@@ -438,8 +438,8 @@ struct OrderByExpressionTests {
 
   @Test func `a grouped ORDER BY qualified aggregate reuses the projected slot`() throws {
     // Non-DISTINCT: the projected `SUM(Amount)` (aliased) and the ORDER BY
-    // `SUM(Sales.Amount)` are the SAME resolved aggregation, so SUM computes
-    // ONCE into one grouped slot and the sort orders by it — the qualified and
+    // `SUM(Sales.Amount)` are the same resolved aggregation, so SUM computes
+    // once into one grouped slot and the sort orders by it — the qualified and
     // unqualified sort keys agree (60, 90, 30 by department, descending).
     let catalog = try sales()
     try catalog.expect("""
@@ -463,7 +463,7 @@ struct OrderByExpressionTests {
   }
 
   @Test func `a DISTINCT ORDER BY on a different aggregate still faults`() throws {
-    // Soundness: `SUM(Dept)` in the ORDER BY is a DIFFERENT aggregate from the
+    // Soundness: `SUM(Dept)` in the ORDER BY is a different aggregate from the
     // projected `COUNT(*)` — a different function over a different operand — so
     // it is a separate, non-projected grouped slot and ordering on it under
     // DISTINCT stays ill-defined and faults. (Its own fold over the TEXT `Dept`
@@ -485,7 +485,7 @@ struct OrderByExpressionTests {
 
   // MARK: - Type-checking the sort keys
 
-  /// The result columns `sql` advertises, resolved WITHOUT running it — the
+  /// The result columns `sql` advertises, resolved without running it — the
   /// static shape check `columns(of:)`/`.schema`/`information_schema` drive,
   /// against the standard prelude so a call like `UPPER` resolves.
   private func columns(_ catalog: borrowing FixtureCatalog, _ sql: String)
@@ -591,18 +591,18 @@ struct OrderByExpressionTests {
   // MARK: - A grouped ORDER BY output name type-checks like the run
 
   // The grouped order lowering (`Grouping.terms`/`Grouping.order`) binds a bare
-  // `ORDER BY <name>` to a grouped OUTPUT name — a projected item's
+  // `ORDER BY <name>` to a grouped output name — a projected item's
   // `Projected.name` (an alias, else an unaliased group column's own name) —
-  // before an input column. The schema/type-check path must resolve the SAME
+  // before an input column. The schema/type-check path must resolve the same
   // output-name set, so `columns(of:)`/`.schema` accept exactly the grouped
   // `ORDER BY` queries that compile and run.
 
   @Test func `columns(of:) accepts a grouped ORDER BY an unaliased group column`() throws {
     // The reported case: `a.Name` and `COUNT(*)` force an `expressions`
-    // projection, and `a.Name` is a group column with NO explicit alias. The
-    // grouped lowering binds `ORDER BY Name` to that group-column OUTPUT (its
-    // `Projected.name`), so the run ACCEPTS. Before the fix the schema path
-    // treated `Name` as an INPUT column and — both `a` and `b` carrying `Name`
+    // projection, and `a.Name` is a group column with no explicit alias. The
+    // grouped lowering binds `ORDER BY Name` to that group-column output (its
+    // `Projected.name`), so the run accepts. Before the fix the schema path
+    // treated `Name` as an input column and — both `a` and `b` carrying `Name`
     // — faulted `SQLError.ambiguous`, rejecting a query that runs. It now binds
     // the grouped output too, so `columns(of:)` accepts and the query runs.
     let catalog = try joined()
@@ -657,7 +657,7 @@ struct OrderByExpressionTests {
   }
 
   @Test func `a grouped ORDER BY over an ambiguous non-group input still faults`() throws {
-    // Soundness: `Id` is a group-column-absent INPUT column both `a` and `b`
+    // Soundness: `Id` is a group-column-absent input column both `a` and `b`
     // carry, and no projected output claims the name — so the grouped lowering
     // resolves it as an ambiguous input and faults, and the schema path agrees.
     let catalog = try joined()
@@ -676,10 +676,10 @@ struct OrderByExpressionTests {
   // MARK: - The sort validates below a row-dropping limit
 
   // The compiled shape is `Project(Limit(Sort(input)))`: the sort evaluates
-  // each ORDER BY key over the input rows BEFORE the cap pages them, so a limit
+  // each ORDER BY key over the input rows before the cap pages them, so a limit
   // that drops every output row still runs the sort. The static shape check
   // must therefore validate the sort keys — and the projection expressions an
-  // ordinal or an output-name key reaches — INDEPENDENT of whether the
+  // ordinal or an output-name key reaches — independent of whether the
   // projection is reachable under the limit.
 
   @Test func `a zero-row FETCH does not spare a bad ORDER BY expression`() throws {
@@ -717,7 +717,7 @@ struct OrderByExpressionTests {
   }
 
   @Test func `an OFFSET past the sole aggregate row does not spare a bad ORDER BY`() throws {
-    // A whole-result aggregate emits ONE row, which a positive OFFSET drops, so
+    // A whole-result aggregate emits one row, which a positive OFFSET drops, so
     // the projection is unreachable — but the sort below the limit still
     // evaluates `NOPE(Dept)`, so the shape check must reject the query.
     #expect(throws: SQLError.self) {
@@ -772,7 +772,7 @@ struct OrderByExpressionTests {
 
   // An `ORDER BY` ordinal names a 1-based SELECT-list position; one outside
   // `1 ... width` names no output column and faults `SQLError.column` (spelled
-  // as the ordinal) at run. The static shape check must raise the SAME fault
+  // as the ordinal) at run. The static shape check must raise the same fault
   // rather than drop the key and advertise a shape for a query that cannot run.
 
   @Test func `columns(of:) rejects an out-of-range ORDER BY ordinal`() throws {
@@ -824,14 +824,14 @@ struct OrderByExpressionTests {
 
   // MARK: - The schema path enforces GROUP BY rules on ORDER BY expressions
 
-  // A grouped `ORDER BY` sorts in the grouped slot space, so a sort EXPRESSION
+  // A grouped `ORDER BY` sorts in the grouped slot space, so a sort expression
   // referencing a resolvable-but-non-grouped column faults `SQLError.grouping`
   // at run (`Grouping.term`). The static shape check validates each grouped
-  // sort key through the SAME grouped lowering, so it rejects exactly the keys
+  // sort key through the same grouped lowering, so it rejects exactly the keys
   // the run does and admits exactly the ones it does.
 
   @Test func `columns(of:) rejects a grouped ORDER BY over a non-grouped column`() throws {
-    // `b.Id` is a resolvable INPUT column, but neither a `GROUP BY` key nor
+    // `b.Id` is a resolvable input column, but neither a `GROUP BY` key nor
     // inside an aggregate, so `ORDER BY b.Id + 1` faults `SQLError.grouping` at
     // run — the schema path validates it through the grouped lowering and agrees.
     let catalog = try joined()
@@ -909,8 +909,8 @@ private final class Counter: @unchecked Sendable {
   }
 }
 
-/// An `ORDER BY` key naming a COMPUTED select-list output must sort on the SAME
-/// value the row returns — the projected expression evaluated ONCE per row.
+/// An `ORDER BY` key naming a computed select-list output must sort on the same
+/// value the row returns — the projected expression evaluated once per row.
 /// Reusing the projection term as the pre-projection sort key evaluated it
 /// twice (once to order, once to project), so a non-deterministic routine
 /// sorted on one set of values and returned a second, misordering the result.
@@ -929,11 +929,11 @@ struct OrderBySingleEvaluationTests {
   }
 
   @Test func `an ordinal over a stateful output sorts on the returned value`() throws {
-    // `tick()` yields 1, 2, 3, 4 across the four rows — computed ONCE per row
+    // `tick()` yields 1, 2, 3, 4 across the four rows — computed once per row
     // when the output is materialised below the sort. `ORDER BY 1 DESC` then
     // sorts on those materialised values and returns them in that order:
     // 4, 3, 2, 1. Double-evaluation would sort on the first set (1…4) yet
-    // return an independently generated SECOND set (5…8), whose values would
+    // return an independently generated second set (5…8), whose values would
     // NOT be in descending order.
     let counter = Counter()
     let routines = try Routines()
@@ -972,7 +972,7 @@ struct OrderBySingleEvaluationTests {
 
   @Test func `a stateful output under a secondary input key is computed once`() throws {
     // A multi-key sort mixing a materialised output ordinal (primary) and an
-    // ordinary INPUT key (`Id`, secondary): the output is still computed once,
+    // ordinary input key (`Id`, secondary): the output is still computed once,
     // so the primary key sorts on the returned values (4, 3, 2, 1) and the
     // routine is invoked exactly once per row even though an input key rides
     // alongside it in the materialised sort row.
@@ -1010,15 +1010,15 @@ struct OrderBySingleEvaluationTests {
   }
 }
 
-/// Only the SORT-referenced outputs are materialised below the sort; every
-/// OTHER output is computed by the final projection ABOVE the cap. The whole
+/// Only the sort-referenced outputs are materialised below the sort; every
+/// other output is computed by the final projection above the cap. The whole
 /// select list materialised below the sort regressed the `Project(Limit(_))`
 /// page — a faulting output an ORDER BY key does NOT name (`1 / 0`) ran for a
 /// row the limit was about to drop, so an empty page faulted instead of empty.
 struct OrderByLazyProjectionTests {
   @Test func `an unreferenced output does not run for a dropped row`() throws {
     // `x` is the only sort-referenced output, so `1 / 0` is computed by the
-    // final projection ABOVE the cap — never for a row the empty page drops.
+    // final projection above the cap — never for a row the empty page drops.
     // The whole-select-list shape evaluated it below the cap and faulted.
     try people().empty("""
         SELECT Id AS x, 1 / 0 FROM People ORDER BY x FETCH FIRST 0 ROWS ONLY
@@ -1042,7 +1042,7 @@ struct OrderByLazyProjectionTests {
 }
 
 /// A grouped `ORDER BY` alias must sort on the projection column the alias
-/// NAMES — the column's INDEX — not `firstIndex(of:)` of its term. Two
+/// names — the column's index — not `firstIndex(of:)` of its term. Two
 /// projected items may share one term under distinct aliases (two calls to a
 /// `deterministic: false` routine), so a term search collapses to the first
 /// column and `ORDER BY <second alias>` misorders on the wrong output.
@@ -1079,7 +1079,7 @@ struct OrderByDuplicateAliasTests {
 
   @Test func `a grouped ORDER BY the first of two shared-term aliases sorts on it`() throws {
     // The companion: `ORDER BY p DESC` sorts on COLUMN 1, so the `p` column
-    // descends 3, 2, 1 while `q` is computed above. That the DESCENDING column
+    // descends 3, 2, 1 while `q` is computed above. That the descending column
     // moves with the named alias (2 here, 1 above) is what distinguishes the
     // two — a term search would sort both by column 1, making them identical.
     let counter = Counter()
@@ -1109,11 +1109,11 @@ struct OrderByDuplicateAliasTests {
 }
 
 /// A `SELECT DISTINCT` `ORDER BY` key accepted because its resolved term
-/// REPEATS a projected expression (not an alias or ordinal) must sort on that
-/// ALREADY-MATERIALISED projected slot — the same value the dedup and the
+/// repeats a projected expression (not an alias or ordinal) must sort on that
+/// already-materialised projected slot — the same value the dedup and the
 /// output use — rather than re-evaluating the term. Under DISTINCT the whole
 /// projection materialises once below the sort; leaving the key's `column`
-/// `nil` appended a fresh hidden column and sorted on a SECOND evaluation, so a
+/// `nil` appended a fresh hidden column and sorted on a second evaluation, so a
 /// stateful key ordered on values the returned column did not carry.
 struct OrderByDistinctExpressionTests {
   /// A four-row table whose rows are all distinct, so a per-row `tick()` under
@@ -1132,7 +1132,7 @@ struct OrderByDistinctExpressionTests {
   @Test func `a DISTINCT repeated stateful expression sorts on the returned value`() throws {
     // `tick()` is projected AND repeated in the ORDER BY. It is not an alias or
     // an ordinal, so it is admitted by the resolved-term match — and must sort
-    // on the projected slot the dedup/output use, materialised ONCE per row (1,
+    // on the projected slot the dedup/output use, materialised once per row (1,
     // 2, 3, 4). `ORDER BY tick() DESC` then returns them descending: 4, 3, 2,
     // 1. Re-evaluating the appended term would sort on an independently
     // generated second set (5…8) while returning the first, misordering the
@@ -1151,7 +1151,7 @@ struct OrderByDistinctExpressionTests {
   }
 
   @Test func `the alias and ordinal forms agree with the repeated expression`() throws {
-    // `ORDER BY n` (alias) and `ORDER BY 1` (ordinal) name the SAME projected
+    // `ORDER BY n` (alias) and `ORDER BY 1` (ordinal) name the same projected
     // slot as the repeated `ORDER BY tick()`, so all three return the stateful
     // values descending and invoke the routine exactly once per row.
     for key in ["tick()", "n", "1"] {

--- a/Tests/SQLTests/Queries/OrderedSetOperationCarrierTests.swift
+++ b/Tests/SQLTests/Queries/OrderedSetOperationCarrierTests.swift
@@ -9,7 +9,7 @@ import SQLTestSupport
 // operators (`ORDER BY`/`DISTINCT`/`OFFSET`·`FETCH`); it compiles to a
 // `.shaped` project/sort/distinct/limit stack over the `.setop`, NOT a bare
 // `.setop`. Several correlated-subquery and view seams matched `if case .setop
-// = <query>`/`if case .setop = <plan>` DIRECTLY, silently swallowing the
+// = <query>`/`if case .setop = <plan>` directly, silently swallowing the
 // carrier — a correlated ordered set-op subquery (its plan a `.shaped` stack)
 // never reached the per-arm augment, so an arm-local derived alias went
 // unmaterialised (`.relation`), and a reached irreconcilable pair skipped its
@@ -17,7 +17,7 @@ import SQLTestSupport
 // carrier-transparent core (`Query.core`) and the shared carrier descender
 // (`execute(_:carrying:)` / the view `setop` and `optimise` per-arm helpers),
 // so carrier transparency is a construction guarantee. Each test pairs the
-// ORDERED shape with its BARE (non-carrier) baseline to show the two agree.
+// ordered shape with its bare (non-carrier) baseline to show the two agree.
 
 // MARK: - Fixtures
 
@@ -38,7 +38,7 @@ private func people() throws -> FixtureCatalog {
 }
 
 /// A catalog whose view bodies are set operations — one riding an `ORDER BY`
-/// carrier, one bare — each arm naming its OWN arm-local derived table `d`, so
+/// carrier, one bare — each arm naming its own arm-local derived table `d`, so
 /// the per-arm augmentation must materialise it before the arm's scan reads it.
 private func views() throws -> FixtureCatalog {
   try Catalog {
@@ -61,9 +61,9 @@ private func views() throws -> FixtureCatalog {
 struct OrderedSetOperationCarrierTests {
   @Test func `a correlated IN over an ordered set op materialises each arm's derived table`()
       throws {
-    // GAP-A2: the correlated `IN (…)` subquery is a set operation UNDER an ORDER
+    // gap-A2: the correlated `IN (…)` subquery is a set operation under an ORDER
     // BY carrier, so its plan is a `.shaped` stack — `if case .setop = plan` was
-    // false, so it fell to the whole-query augment, which binds NO arm-local
+    // false, so it fell to the whole-query augment, which binds no arm-local
     // derived alias (a setop collects none), and arm-0's `.scan("x")` faulted
     // `.relation('x')`. It now routes through `execute(_:carrying:)`, per-arm
     // augmenting `x` before the arm scan. Alice (Age 30) matches the arm value.
@@ -77,7 +77,7 @@ struct OrderedSetOperationCarrierTests {
   @Test func `a bare correlated IN set op materialises each arm's derived table`()
       throws {
     // The non-ordered baseline (a bare `.setop` plan) already worked — the
-    // ordered form now matches it EXACTLY.
+    // ordered form now matches it exactly.
     try people().expect("""
         SELECT Id FROM People p WHERE p.Age IN
           (SELECT V FROM (SELECT 30 AS V) AS x WHERE x.V = p.Age
@@ -87,8 +87,8 @@ struct OrderedSetOperationCarrierTests {
 
   @Test func `an ordered set-op view materialises each arm's derived table`()
       throws {
-    // GAP-A3/A4: a view body that is a set operation UNDER an ORDER BY carrier
-    // compiles to a `.shaped` plan, so BOTH the view execute (`derive`) and the
+    // gap-A3/A4: a view body that is a set operation under an ORDER BY carrier
+    // compiles to a `.shaped` plan, so both the view execute (`derive`) and the
     // view optimiser (`optimise(view:)`) guards (`case .setop = view.query` and
     // `case .setop = plan`) failed and the per-arm augment was skipped —
     // arm-0's `.scan("d")` faulted `.relation('d')`. Both now descend the
@@ -100,14 +100,14 @@ struct OrderedSetOperationCarrierTests {
   @Test func `a bare set-op view materialises each arm's derived table`()
       throws {
     // The non-ordered baseline (a bare `.setop` view body) already worked; it
-    // yields the same MULTISET as the ordered form, but UNSORTED — the two arms
+    // yields the same multiset as the ordered form, but unsorted — the two arms
     // in source order: the derived `d` arm ({7, 8}) then the `S` arm ({7, 8}).
     try views().expect("SELECT * FROM bare", yields: [[7], [8], [7], [8]])
   }
 
   @Test func `a reached correlated scalar ordered set op faults on irreconcilable arms`()
       throws {
-    // GAP-A1: a REACHED correlated scalar subquery over an ordered set operation
+    // gap-A1: a reached correlated scalar subquery over an ordered set operation
     // with irreconcilable arms (text `'x'` beside integer `1`) skipped the
     // strict operand re-fold — `if case .setop = key.query` was false for the
     // `.ordered` carrier — so the run returned rows where the uncorrelated form
@@ -194,9 +194,9 @@ struct OrderedSetOperationCarrierTests {
   @Test func `a carrier ORDER BY with an uncorrelated EXISTS runs like a plain SELECT`()
       throws {
     // A carrier `ORDER BY` may nest an `EXISTS`/`IN`/scalar subquery. An
-    // UNCORRELATED one records no per-outer-row plan (its probe runs
-    // standalone), so it worked already — the set-op carrier matches the SAME
-    // ORDER BY on a PLAIN SELECT over the identical multiset (a derived table
+    // uncorrelated one records no per-outer-row plan (its probe runs
+    // standalone), so it worked already — the set-op carrier matches the same
+    // ORDER BY on a plain SELECT over the identical multiset (a derived table
     // wrapping the union). `S` is non-empty, so the `EXISTS` is TRUE for every
     // row and the sort key is a constant `0`; the secondary ordinal orders the
     // rows.
@@ -213,15 +213,15 @@ struct OrderedSetOperationCarrierTests {
 
   @Test func `a carrier ORDER BY with a correlated scalar subquery runs like a plain SELECT`()
       throws {
-    // FINDING #1: a carrier `ORDER BY` subquery that CORRELATES to the
+    // finding #1: a carrier `ORDER BY` subquery that correlates to the
     // enclosing query (`… WHERE V < p.Id`, a set operation inside an outer
-    // `IN`) resolves the correlation but recorded NO runtime plan — the
+    // `IN`) resolves the correlation but recorded no runtime plan — the
     // recording pass asked `arm.roles(of:)`, and the ARM does not carry the
-    // CARRIER's sort-key subquery, so its correlated `Subkey` lowered yet
+    // carrier's sort-key subquery, so its correlated `Subkey` lowered yet
     // faulted "a correlated subquery plan was not compiled" at execution. The
-    // carrier now records its OWN ORDER BY subqueries' plans (through a
+    // carrier now records its own ORDER BY subqueries' plans (through a
     // classifier select carrying the carrier's ORDER BY), so a correlated sort
-    // key re-executes per outer row EXACTLY as it does on a PLAIN SELECT — the
+    // key re-executes per outer row exactly as it does on a plain SELECT — the
     // inner set operation replaced by a derived table over the same multiset,
     // whose ORDER BY takes the ordinary supported correlated-subquery path.
     // `S` = {7, 8}: for `p.Id` 1 or 2 the ORDER BY count is 0 (a no-op sort),
@@ -280,14 +280,14 @@ struct OrderedSetOperationCarrierTests {
 
   @Test func `a carrier ORDER BY subquery resolves a set-op output column at validate as at run`()
       throws {
-    // FINDING (PR293): the `validate` carrier pre-pass derived each carrier
-    // ORDER BY subquery's width/type against `context.outer`, while the RUN
-    // resolved the SAME subquery against the set-operation OUTPUT scope. A
-    // carrier ORDER BY subquery referencing a set-op OUTPUT column — an aliased
+    // finding (PR293): the `validate` carrier pre-pass derived each carrier
+    // ORDER BY subquery's width/type against `context.outer`, while the run
+    // resolved the same subquery against the set-operation output scope. A
+    // carrier ORDER BY subquery referencing a set-op output column — an aliased
     // output (`Id AS Key`) living ONLY in that scope, absent from the outer —
     // therefore resolved at run yet faulted `SQLError.column("Key")` at
     // validate: a query that executes was rejected by `columns(of:, validate:
-    // true)`. The pre-pass now derives against the SAME set-op output scope
+    // true)`. The pre-pass now derives against the same set-op output scope
     // (nested under the outer), so it resolves at validate exactly as at run.
     // `S` = {7, 8} is non-empty, so the `EXISTS` sort key is a constant.
     let catalog = try people()
@@ -316,7 +316,7 @@ struct OrderedSetOperationCarrierTests {
     // The reviewer's exact shape — an `EXISTS` sort key correlating to a bare
     // set-op output column (`Id`, shared with a base relation) — already ran
     // and validated (`width` derives the projection only, and `Id` binds via
-    // the outer/base), and STILL does after the scope alignment.
+    // the outer/base), and still does after the scope alignment.
     let catalog = try people()
     let sql = """
         SELECT Id FROM People UNION ALL SELECT V FROM S
@@ -335,10 +335,10 @@ struct OrderedSetOperationCarrierTests {
 
   @Test func `a carrier ORDER BY subquery naming an unknown column still faults at run and validate`()
       throws {
-    // GUARD: the scope alignment must not OVER-WIDEN. A carrier ORDER BY
+    // guard: the scope alignment must not OVER-widen. A carrier ORDER BY
     // subquery referencing a genuinely-unresolvable column (`Zzz` — neither a
     // set-op output nor an outer/base column) still faults `SQLError.column` at
-    // BOTH run and validate.
+    // both run and validate.
     let catalog = try people()
     let sql = """
         SELECT Id AS Key FROM People UNION ALL SELECT V FROM S
@@ -359,12 +359,12 @@ struct OrderedSetOperationCarrierTests {
 
   @Test func `an ordered union over arm-local derived tables runs like the bare union`()
       throws {
-    // FINDING #1: an ORDER BY carrier over a set operation whose arms name
-    // their OWN arm-local derived tables (`d`, `e`) faulted `.relation('d')`
-    // though the SAME union WITHOUT the ORDER BY ran fine. The top-level
-    // `run(.setop)` path runs each arm PER ARM — arm-local aliases bind — but
-    // the ordered carrier fell to the GENERIC `optimise`, rewriting both arms
-    // under the ONE carrier-level context that binds no arm-owned alias, so its
+    // finding #1: an ORDER BY carrier over a set operation whose arms name
+    // their own arm-local derived tables (`d`, `e`) faulted `.relation('d')`
+    // though the same union without the ORDER BY ran fine. The top-level
+    // `run(.setop)` path runs each arm per ARM — arm-local aliases bind — but
+    // the ordered carrier fell to the generic `optimise`, rewriting both arms
+    // under the one carrier-level context that binds no arm-owned alias, so its
     // `seek` rewrite faulted `.relation('d')` before the per-arm
     // `execute(…carrying:)` could augment each arm. `run` now routes an
     // ordered-over-setop carrier through the per-arm optimiser (mirroring the
@@ -386,9 +386,9 @@ struct OrderedSetOperationCarrierTests {
 
   @Test func `a DISTINCT paged ordered union over arm-local derived tables runs`()
       throws {
-    // FINDING #1 (other carrier operators): the per-arm descent threads through
+    // finding #1 (other carrier operators): the per-arm descent threads through
     // the DISTINCT dedup and OFFSET·FETCH paging too, not only ORDER BY. Each
-    // arm carries a `WHERE` over its OWN arm-local derived table — the filter
+    // arm carries a `WHERE` over its own arm-local derived table — the filter
     // the generic optimiser's `seek` rewrite would resolve under the wrong
     // (carrier-level) scope, faulting `.relation` pre-fix. A bare `UNION`
     // dedups the two `1` arms with the `2` arm to {1, 2}; ordered, OFFSET 1
@@ -406,10 +406,10 @@ struct OrderedSetOperationCarrierTests {
 
   @Test func `an ordered union arm over a genuinely-missing relation still faults`()
       throws {
-    // FINDING #1 GUARD (no over-masking): the per-arm route must NOT swallow a
+    // finding #1 guard (no over-masking): the per-arm route must NOT swallow a
     // real missing-relation fault. An arm referencing a relation that does NOT
-    // exist (`NoSuchRel`) STILL faults `.relation('NoSuchRel')`, both with and
-    // without the ORDER BY carrier — the fix only per-arm-scopes arm-LOCAL
+    // exist (`NoSuchRel`) still faults `.relation('NoSuchRel')`, both with and
+    // without the ORDER BY carrier — the fix only per-arm-scopes arm-local
     // derived aliases; a genuinely absent relation is still unresolvable.
     let cat = try Catalog {
       Relation("Anchor", ["x": .integer]) { Row(0) }
@@ -424,15 +424,15 @@ struct OrderedSetOperationCarrierTests {
 
   @Test func `a generated count over a SELECT-star union faults not traps`()
       throws {
-    // FINDING #2: a hostile `Query.ordered(<union of two SELECT * arms>,
+    // finding #2: a hostile `Query.ordered(<union of two SELECT * arms>,
     // generated: 1)` — a PUBLIC AST case the parser never emits. A `SELECT *`
-    // arm's projection is `.all`, so the carrier's `items` list is EMPTY though
+    // arm's projection is `.all`, so the carrier's `items` list is empty though
     // the resolved `width` is > 0. The old aliased-tail check `for k in 0 ..<
-    // generated WHERE real + k < items.count` SKIPPED every slot (items empty),
+    // generated WHERE real + k < items.count` skipped every slot (items empty),
     // so the hidden-name mapping's `items[real + k].alias!` force-unwrapped an
-    // ABSENT item and TRAPPED the process. (A trap cannot be caught in-process,
-    // so this asserts the POST-fix typed fault; PRE-fix this crashed.) The
-    // carrier now requires each generated tail slot to HAVE an aliased
+    // absent item and trapped the process. (A trap cannot be caught in-process,
+    // so this asserts the post-fix typed fault; pre-fix this crashed.) The
+    // carrier now requires each generated tail slot to have an aliased
     // projected item, faulting XX000 rather than crashing.
     let cat = try Catalog {
       Relation("P", ["a": .integer, "b": .integer]) { Row(1, 2) }
@@ -454,18 +454,18 @@ struct OrderedSetOperationCarrierTests {
 
   @Test func `columns(of:) faults an out-of-range generated count not traps`()
       throws {
-    // FINDING #3: the SCHEMA path `columns(unifying:)` trimmed a carrier's
-    // hidden tail as `cols.prefix(cols.count - generated)` with NO range guard.
-    // A public-AST `generated` PAST the width makes the argument NEGATIVE and
-    // `Array.prefix` PRECONDITION-TRAPS; a NEGATIVE `generated` returns ALL
-    // columns UNTRIMMED — silently wrong and diverging from `run`, which faults
+    // finding #3: the schema path `columns(unifying:)` trimmed a carrier's
+    // hidden tail as `cols.prefix(cols.count - generated)` with no range guard.
+    // A public-AST `generated` past the width makes the argument negative and
+    // `Array.prefix` precondition-traps; a negative `generated` returns ALL
+    // columns untrimmed — silently wrong and diverging from `run`, which faults
     // XX000. The schema path now mirrors the compile-path range guard (the
-    // SHARED `real(trimming:of:)` helper), so both fault the SAME XX000. A
-    // NESTED ordered carrier (an ordered arm of an outer union) reaches
-    // `columns(unifying:)`'s `.ordered` case DIRECTLY — the whole-query compile
-    // pre-check does not guard it — so its malformed count actually TRAPPED the
+    // shared `real(trimming:of:)` helper), so both fault the same XX000. A
+    // nested ordered carrier (an ordered arm of an outer union) reaches
+    // `columns(unifying:)`'s `.ordered` case directly — the whole-query compile
+    // pre-check does not guard it — so its malformed count actually trapped the
     // schema path (`Can't take a prefix of negative length`). A trap cannot be
-    // caught in-process, so this asserts the POST-fix typed fault; PRE-fix this
+    // caught in-process, so this asserts the post-fix typed fault; pre-fix this
     // crashed the process.
     let cat = try Catalog {
       Relation("P", ["a": .integer]) { Row(1) }
@@ -473,7 +473,7 @@ struct OrderedSetOperationCarrierTests {
     let fault = SQLError.state("XX000",
                                "ordered set-operation generated count out " +
                                "of range")
-    // A nested ordered arm with a count PAST the width (1) — `cols.count −
+    // A nested ordered arm with a count past the width (1) — `cols.count −
     // 999` is negative, the schema-path `prefix` trap.
     let arm = Query.ordered(
         .select(Select(projection: .all, from: Relation(name: "P"))),
@@ -485,10 +485,10 @@ struct OrderedSetOperationCarrierTests {
     #expect(throws: fault) {
       _ = try cat.columns(of: nested, routines: [:], validate: false)
     }
-    // A top-level malformed carrier faults the SAME XX000 on BOTH paths (the
+    // A top-level malformed carrier faults the same XX000 on both paths (the
     // whole-query compile guards it before `columns(unifying:)`, and the run
-    // path's carrier guards it) — run ≡ columns(of:). A count PAST the width
-    // and a NEGATIVE count both fault.
+    // path's carrier guards it) — run ≡ columns(of:). A count past the width
+    // and a negative count both fault.
     let union = Query.setop(
         .union,
         .select(Select(projection: .all, from: Relation(name: "P"))),
@@ -506,7 +506,7 @@ struct OrderedSetOperationCarrierTests {
     }
     #expect(throws: fault) { _ = try cat.run(over) }
     #expect(throws: fault) { _ = try cat.run(under) }
-    // A VALID `generated: 0` returns the correct trimmed schema — one column.
+    // A valid `generated: 0` returns the correct trimmed schema — one column.
     let valid = Query.ordered(union, distinct: false, order: nil, limit: nil,
                               generated: 0)
     #expect(try cat.columns(of: valid, routines: [:],

--- a/Tests/SQLTests/Queries/OrderedSetOperationTests.swift
+++ b/Tests/SQLTests/Queries/OrderedSetOperationTests.swift
@@ -25,10 +25,10 @@ private func pair() throws -> FixtureCatalog {
 }
 
 // A query-level `ORDER BY` / `OFFSET`·`FETCH` after a set operation applies to
-// the WHOLE combined result — the ISO rule — carried on `Query.ordered` and
-// resolved through the setop's OUTPUT scope, not bound to the trailing arm.
+// the whole combined result — the ISO rule — carried on `Query.ordered` and
+// resolved through the setop's output scope, not bound to the trailing arm.
 // These exercise the general capability the GROUPING SETS expansion also uses,
-// over PLAIN unions.
+// over plain unions.
 struct OrderedSetOperationTests {
   @Test func `a query-level ORDER BY sorts the whole UNION ALL result`()
       throws {
@@ -59,7 +59,7 @@ struct OrderedSetOperationTests {
   }
 
   @Test func `a bare UNION dedups before the query-level ORDER BY`() throws {
-    // A bare `UNION` (no ALL) removes whole-row duplicates BEFORE the carrier's
+    // A bare `UNION` (no ALL) removes whole-row duplicates before the carrier's
     // ORDER BY sorts — `L UNION L` is the distinct rows of `L`, ordered 1, 2, 3.
     try pair().expect("""
         SELECT a FROM L UNION SELECT a FROM L ORDER BY a
@@ -67,7 +67,7 @@ struct OrderedSetOperationTests {
   }
 
   @Test func `an ORDER BY over a UNION types across the arms`() throws {
-    // The result column TYPES unify across the arms (ISO), so the sort runs over
+    // The result column types unify across the arms (ISO), so the sort runs over
     // the coerced values — a mixed integer arm and a double arm widen to double
     // and order numerically.
     let cat = try Catalog {
@@ -127,7 +127,7 @@ struct OrderedSetOperationTests {
     try cat.expect("""
         SELECT a AS x FROM L INTERSECT SELECT b AS y FROM R ORDER BY x
         """, yields: [[1], [2]])
-    // The parenthesised-then-ordered ORACLE: order the intersect result the
+    // The parenthesised-then-ordered oracle: order the intersect result the
     // same way (by the first-arm name over the combined output).
     try cat.expect("""
         SELECT a AS x FROM L INTERSECT SELECT b AS y FROM R ORDER BY x
@@ -213,10 +213,10 @@ struct OrderedSetOperationTests {
   @Test func `a query-level ORDER BY over a TABLE-arm set operation sorts`()
       throws {
     // A `TABLE t` first arm projects `.all` — the arm-0 AST projection is
-    // EMPTY — so deriving the carrier's output NAMES from those AST items
-    // (rather than the RESOLVED columns) TRAPPED on an out-of-range index. And
-    // a `TABLE`/`VALUES` LAST arm carries no primary-level order, so a trailing
-    // query-level ORDER BY was left UNCONSUMED (`unexpected trailing input`).
+    // empty — so deriving the carrier's output names from those AST items
+    // (rather than the resolved columns) trapped on an out-of-range index. And
+    // a `TABLE`/`VALUES` last arm carries no primary-level order, so a trailing
+    // query-level ORDER BY was left unconsumed (`unexpected trailing input`).
     // Both are fixed: the output names come from the resolved columns, and the
     // tail is parsed at the query level. Ordered over the combined output:
     // 1..5.
@@ -228,7 +228,7 @@ struct OrderedSetOperationTests {
   @Test func `a SELECT star first arm set operation orders by a resolved name`()
       throws {
     // The `SELECT *` first arm resolves its output columns (`a`) from the base
-    // relation; the carrier orders by the RESOLVED name `a` over the combined
+    // relation; the carrier orders by the resolved name `a` over the combined
     // union output — the same name a plain derived union would bind.
     try pair().expect("""
         SELECT * FROM L UNION ALL SELECT b FROM R ORDER BY a
@@ -247,7 +247,7 @@ struct OrderedSetOperationTests {
 
   @Test func `an out-of-range ordinal over a plain UNION faults`() throws {
     // A plain ordered set-operation carries no hidden materialised columns
-    // (`generated == 0`), so an ORDINAL past the single output faults `.column`
+    // (`generated == 0`), so an ordinal past the single output faults `.column`
     // over the union's real arity — the non-GROUPING-SETS path is unchanged by
     // the GROUPING SETS ordinal bound fix (the ordinal is bounded by the REAL
     // output width, which here IS the full width).
@@ -258,11 +258,11 @@ struct OrderedSetOperationTests {
 
   @Test func `a set operation of derived-table arms orders the whole result`()
       throws {
-    // Each arm names its OWN derived alias (`d` on the left, `e` on the right).
+    // Each arm names its own derived alias (`d` on the left, `e` on the right).
     // Arms are SELECT-scoped, so the query-level augment the carrier runs under
-    // never binds them — before, the carrier compiled ONE `setop` plan run
+    // never binds them — before, the carrier compiled one `setop` plan run
     // under the single carrier context, so an arm's `.scan d` faulted
-    // `.relation`. The carrier now runs the union PER ARM (the same machinery
+    // `.relation`. The carrier now runs the union per ARM (the same machinery
     // the direct `setop` and a correlated-subquery setop use), materialising
     // each arm's derived table in its own scope: 1 then 2.
     try pair().expect("""
@@ -310,13 +310,13 @@ struct OrderedSetOperationTests {
   }
 
   @Test func `an out-of-range generated count over a union faults`() throws {
-    // `Query.ordered` is a PUBLIC AST case; a caller may build a `generated`
+    // `Query.ordered` is a public AST case; a caller may build a `generated`
     // count out of step with the inner union's width (the parser and `expand`
-    // never do). A count PAST the width, or NEGATIVE, makes `real = width −
+    // never do). A count past the width, or negative, makes `real = width −
     // generated` negative — the carrier's `0 ..< real` range and per-column
-    // subscripts would TRAP the process. The carrier now rejects a malformed
+    // subscripts would trap the process. The carrier now rejects a malformed
     // count with a typed internal-error fault rather than trapping. Build the
-    // malformed AST directly: a ONE-column union with `generated: 2`, then a
+    // malformed AST directly: a one-column union with `generated: 2`, then a
     // negative `generated`.
     let cat = try pair()
     let union = Query.setop(
@@ -335,7 +335,7 @@ struct OrderedSetOperationTests {
     let under = Query.ordered(union, distinct: false, order: nil, limit: nil,
                               generated: -1)
     #expect(throws: fault) { _ = try cat.run(under) }
-    // An IN-RANGE `generated` (0 — no hidden columns) still compiles and runs
+    // An IN-range `generated` (0 — no hidden columns) still compiles and runs
     // the union unchanged: 1..5 over the two arms.
     let valid = Query.ordered(union, distinct: false,
                               order: Order(keys: [
@@ -348,11 +348,11 @@ struct OrderedSetOperationTests {
 
   @Test func `a generated count over an unaliased tail faults not traps`()
       throws {
-    // `Query.ordered` is a PUBLIC AST case. A caller may build a `generated: 1`
-    // over an ORDINARY two-column union whose trailing item is a NORMAL
-    // projected column with NO alias: the range guard `generated <= width`
+    // `Query.ordered` is a public AST case. A caller may build a `generated: 1`
+    // over an ordinary two-column union whose trailing item is a normal
+    // projected column with no alias: the range guard `generated <= width`
     // passes (1 ≤ 2), but the carrier's `items[real + k].alias!` force-unwrap
-    // would TRAP — the tail is not the aliased hidden `*gsN` shape a real
+    // would trap — the tail is not the aliased hidden `*gsN` shape a real
     // producer appends. The carrier now proves the generated tail is aliased
     // hidden columns before unwrapping, faulting a typed internal error rather
     // than crashing.
@@ -374,7 +374,7 @@ struct OrderedSetOperationTests {
                        from: Relation(name: "Q"))),
         all: true)
     // The trailing item (`b`, a bare column) carries no alias, so `generated:
-    // 1` over the width-2 union has an UNALIASED tail.
+    // 1` over the width-2 union has an unaliased tail.
     let over = Query.ordered(union, distinct: false, order: nil, limit: nil,
                              generated: 1)
     #expect(throws: SQLError.state("XX000",
@@ -382,7 +382,7 @@ struct OrderedSetOperationTests {
                                    "is not aliased")) {
       _ = try cat.run(over)
     }
-    // `generated: 0` over the SAME union runs unchanged — both columns of each
+    // `generated: 0` over the same union runs unchanged — both columns of each
     // arm's row, no trim, ordered ascending by the first output column.
     let valid = Query.ordered(union, distinct: false,
                               order: Order(keys: [
@@ -416,7 +416,7 @@ private func subqueried() throws -> FixtureCatalog {
 
 // A query-level `ORDER BY` over a set operation may nest an `EXISTS`/`IN`/
 // scalar subquery in a sort key, exactly as a plain `SELECT`'s ORDER BY does.
-// The carrier must COLLECT and RESOLVE those subqueries — the same machinery a
+// The carrier must collect and resolve those subqueries — the same machinery a
 // plain select's ORDER BY uses — rather than lower them under the default
 // unsupported resolution, which rejected them. These pair the union form with
 // the plain SELECT it must resolve identically to.
@@ -472,7 +472,7 @@ struct CarrierOrderBySubqueryTests {
   }
 
   @Test func `a qualified sort key over a set operation faults`() throws {
-    // The set-operation output exposes NO range, so a QUALIFIED sort key
+    // The set-operation output exposes no range, so a qualified sort key
     // `R.a` fails resolution — the carrier lets it through to `scope.order`
     // rather than silently dropping the qualifier to bind the bare output
     // `a`, which hid an invalid `R.a` / `NoSuch.a` range reference. The bare

--- a/Tests/SQLTests/Queries/RollupCubeTests.swift
+++ b/Tests/SQLTests/Queries/RollupCubeTests.swift
@@ -37,7 +37,7 @@ private func nums() throws -> FixtureCatalog {
 }
 
 /// A three-dimensional `G` relation — `A`/`B`/`C` grouping columns and a `V` to
-/// `SUM` — for the COMPOSITE-unit case `ROLLUP((A, B), C)`, where `(A, B)` is
+/// `SUM` — for the composite-unit case `ROLLUP((A, B), C)`, where `(A, B)` is
 /// one indivisible level. Rows are chosen so each level's sums are distinct.
 private func grid() throws -> FixtureCatalog {
   try Catalog {
@@ -56,7 +56,7 @@ private func grid() throws -> FixtureCatalog {
 struct RollupCubeTests {
   @Test func `ROLLUP(a, b) yields the full, per-prefix, and grand-total levels`()
       throws {
-    // `ROLLUP(Region, Product)` desugars to the descending PREFIXES of its two
+    // `ROLLUP(Region, Product)` desugars to the descending prefixes of its two
     // units — `[[Region, Product], [Region], []]` — so three arms: the full
     // grouping, the per-Region grouping (Product a super-aggregate NULL), and
     // the grand total (both NULL). Arm order, then row order within each arm
@@ -72,9 +72,9 @@ struct RollupCubeTests {
           ["East", nil, 35], ["West", nil, 10],
           [nil, nil, 45],
         ])
-    // The desugar's ORACLE: the same query written as the equivalent explicit
+    // The desugar's oracle: the same query written as the equivalent explicit
     // GROUPING SETS (Stage 1) yields identical rows — pinning both the set
-    // CONTENT and the arm ORDER of `ROLLUP`.
+    // content and the arm ORDER of `ROLLUP`.
     try sales().expect("""
         SELECT Region, Product, SUM(Qty)
           FROM Sales
@@ -96,7 +96,7 @@ struct RollupCubeTests {
   }
 
   @Test func `CUBE(a, b) yields all four subset levels, full set first`() throws {
-    // `CUBE(Region, Product)` desugars to every SUBSET of its two units,
+    // `CUBE(Region, Product)` desugars to every subset of its two units,
     // enumerated FULL-SET-FIRST by descending mask:
     // `[[Region, Product], [Product], [Region], []]`. Four arms: the full
     // grouping, the per-Product grouping (Region NULL), the per-Region grouping
@@ -112,7 +112,7 @@ struct RollupCubeTests {
           ["East", nil, 35], ["West", nil, 10],
           [nil, nil, 45],
         ])
-    // The ORACLE pins the subset-enumeration ORDER: the hand-written GROUPING
+    // The oracle pins the subset-enumeration ORDER: the hand-written GROUPING
     // SETS lists the four subsets in exactly the descending-mask order `CUBE`
     // produces (full, {Product}, {Region}, {}).
     try sales().expect("""
@@ -127,10 +127,10 @@ struct RollupCubeTests {
   }
 
   @Test func `GROUP BY a, ROLLUP(b) cross-products the elements`() throws {
-    // The whole clause is the CROSS PRODUCT of its elements: the ordinary
+    // The whole clause is the CROSS product of its elements: the ordinary
     // `Region` (`[[Region]]`) crossed with `ROLLUP(Product)`
     // (`[[Product], []]`) gives `[[Region, Product], [Region]]` — the full
-    // grouping and the per-Region subtotal, with NO grand total (Region is
+    // grouping and the per-Region subtotal, with no grand total (Region is
     // present in every set). Per-(Region, Product) then per-Region.
     try sales().expect("""
         SELECT Region, Product, SUM(Qty)
@@ -178,7 +178,7 @@ struct RollupCubeTests {
   }
 
   @Test func `ROLLUP((a, b), c) treats the composite unit as one level`() throws {
-    // A parenthesised unit `(A, B)` groups its members as ONE indivisible
+    // A parenthesised unit `(A, B)` groups its members as one indivisible
     // level. `ROLLUP((A, B), C)` desugars to `[[A, B, C], [A, B], []]` — no
     // `[A]` level, unlike `ROLLUP(A, B, C)`. Per-(A, B, C): 4 rows; per-(A, B):
     // (1,1) 30, (1,2) 30, (2,1) 40; grand total 100.
@@ -203,7 +203,7 @@ struct RollupCubeTests {
   }
 
   @Test func `an ordinary GROUP BY a, b stays the plain keys path`() throws {
-    // A clause with NO construct is unchanged — it desugars to `.keys`, the
+    // A clause with no construct is unchanged — it desugars to `.keys`, the
     // plain grouped path, so `GROUP BY Region, Product` is one group set (the
     // four per-(Region, Product) rows), NOT a set list with super-aggregate
     // arms.
@@ -252,8 +252,8 @@ struct RollupCubeTests {
 
   @Test func `a column named rollup stays a grouping key, delimited or bare`()
       throws {
-    // `ROLLUP`/`CUBE` are CONTEXT identifiers: a DELIMITED `"rollup"` (a quoted
-    // identifier, never the construct) and a BARE `rollup` NOT followed by `(`
+    // `ROLLUP`/`CUBE` are context identifiers: a delimited `"rollup"` (a quoted
+    // identifier, never the construct) and a bare `rollup` NOT followed by `(`
     // both stay ordinary keys. The construct fires only on a bare `rollup(`.
     let cat = try Catalog {
       Relation("T", ["rollup": .text, "cube": .integer]) {
@@ -303,7 +303,7 @@ struct RollupCubeTests {
 
   @Test func `ROLLUP rides the carrier for an unprojected-aggregate ORDER BY`()
       throws {
-    // A ROLLUP query with a query-level ORDER BY over an UNPROJECTED aggregate
+    // A ROLLUP query with a query-level ORDER BY over an unprojected aggregate
     // (`MAX(Qty)`, not in the select list) rides the `ordered` carrier over the
     // union — `expand` materialises the aggregate as a hidden column in every
     // arm, orders on it, and trims it. `ROLLUP(Region)` is `((Region), ())`;
@@ -326,13 +326,13 @@ struct RollupCubeTests {
   @Test func `an empty ROLLUP() and CUBE() collapse to one grand-total set`()
       throws {
     // Zero units is admitted: the empty product is the single empty grand-total
-    // set (`.sets([[]])`), so `ROLLUP()` and `CUBE()` each yield exactly ONE
+    // set (`.sets([[]])`), so `ROLLUP()` and `CUBE()` each yield exactly one
     // grand-total row — the SUM over the whole relation, 45.
     try sales().expect("SELECT SUM(Qty) FROM Sales GROUP BY ROLLUP()",
                        yields: [[45]])
     try sales().expect("SELECT SUM(Qty) FROM Sales GROUP BY CUBE()",
                        yields: [[45]])
-    // The ORACLE: `GROUPING SETS (())` — a lone grand-total set — is identical.
+    // The oracle: `GROUPING SETS (())` — a lone grand-total set — is identical.
     try sales().expect("SELECT SUM(Qty) FROM Sales GROUP BY ROLLUP()",
                        equals: """
         SELECT SUM(Qty) FROM Sales GROUP BY GROUPING SETS (())
@@ -345,10 +345,10 @@ struct RollupCubeTests {
   }
 
   @Test func `a duplicate grouping set keeps its rows, not deduplicated`() throws {
-    // ISO combines the sets with UNION ALL, so an OVERLAPPING clause keeps
+    // ISO combines the sets with UNION ALL, so an overlapping clause keeps
     // duplicate rows. `GROUP BY ROLLUP(A), A` crosses `[[A], []]` with `[[A]]`
     // into `[[A, A], [A]]` — both sets group by `A` (a repeated key is
-    // harmless), so each per-A group appears TWICE.
+    // harmless), so each per-A group appears twice.
     try nums().expect("""
         SELECT A, SUM(V) FROM N GROUP BY ROLLUP(A), A
         """, yields: [[1, 150], [2, 30], [1, 150], [2, 30]])
@@ -362,10 +362,10 @@ struct RollupCubeTests {
   @Test func `a scalar-subquery unit keeps its own parenthesis`() throws {
     // A `ROLLUP`/`CUBE` unit, or a `GROUPING SETS` member, that IS a scalar
     // subquery `(SELECT …)` must route through `expression` — the leading `(`
-    // is the SUBQUERY's, not a composite-set delimiter, so it is not stolen
+    // is the subquery's, not a composite-set delimiter, so it is not stolen
     // (which produced `expected an identifier but found 'SELECT'`). A scalar
     // subquery is a valid ordinary grouping key, so it is valid as a unit too.
-    // `(SELECT 1)` is a constant, so grouping on it forms ONE group.
+    // `(SELECT 1)` is a constant, so grouping on it forms one group.
     try sales().expect("""
         SELECT SUM(Qty) FROM Sales GROUP BY ROLLUP((SELECT 1))
         """, equals: """
@@ -381,7 +381,7 @@ struct RollupCubeTests {
     try sales().expect("""
         SELECT SUM(Qty) FROM Sales GROUP BY GROUPING SETS ((SELECT 1))
         """, equals: "SELECT SUM(Qty) FROM Sales GROUP BY (SELECT 1)")
-    // A subquery beside an ordinary key in a COMPOSITE unit still parses — the
+    // A subquery beside an ordinary key in a composite unit still parses — the
     // composite `(` is the delimiter, the inner `(SELECT …)` its own key.
     try sales().expect("""
         SELECT Region, SUM(Qty) FROM Sales
@@ -390,7 +390,7 @@ struct RollupCubeTests {
         SELECT Region, SUM(Qty) FROM Sales
           GROUP BY GROUPING SETS (((SELECT 1), Region), ())
         """)
-    // GUARD: a plain composite unit `(a, b)` is unaffected — no subquery, the
+    // guard: a plain composite unit `(a, b)` is unaffected — no subquery, the
     // `(` stays a set delimiter.
     try sales().expect("""
         SELECT Region, Product, SUM(Qty) FROM Sales
@@ -402,7 +402,7 @@ struct RollupCubeTests {
   }
 
   @Test func `a top-level parenthesised ordinary set groups its keys`() throws {
-    // The generalised grammar admits a TOP-LEVEL parenthesised composite set
+    // The generalised grammar admits a top-level parenthesised composite set
     // `(a, b)` and the grand-total `()` — which the flat `expression` path
     // could not consume (a comma list / empty parens faulted). They group
     // exactly as the bare forms.
@@ -420,9 +420,9 @@ struct RollupCubeTests {
         """, equals: """
         SELECT Region, Product, SUM(Qty) FROM Sales GROUP BY Region, Product
         """)
-    // GUARD (no regression): a top-level `(` that begins a LARGER scalar key
+    // guard (no regression): a top-level `(` that begins a larger scalar key
     // — a parenthesised expression `(A + 1)`, or a paren that merely starts an
-    // expression `(A) + 1` — is read as ONE key, NOT truncated at the `)`. The
+    // expression `(A) + 1` — is read as one key, NOT truncated at the `)`. The
     // row backtracking rewinds a single `(…)` with no top-level comma.
     try nums().expect("SELECT A + 1, SUM(V) FROM N GROUP BY (A + 1)",
                       equals: "SELECT A + 1, SUM(V) FROM N GROUP BY A + 1")
@@ -435,8 +435,8 @@ struct RollupCubeTests {
 
   @Test func `GROUP BY () is the grand total, not absent grouping`() throws {
     // `GROUP BY ()` is a single grand-total group — NOT the `.keys([])` shape
-    // an ABSENT `GROUP BY` carries, which is no grouping (one row per input
-    // row). It yields ONE row whatever the input cardinality, matching the
+    // an absent `GROUP BY` carries, which is no grouping (one row per input
+    // row). It yields one row whatever the input cardinality, matching the
     // GROUPING SETS `(())` form.
     try sales().expect("SELECT 1 FROM Sales GROUP BY ()", yields: [[1]])
     try sales().expect("""
@@ -444,7 +444,7 @@ struct RollupCubeTests {
         """, equals: """
         SELECT SUM(Qty) FROM Sales GROUP BY GROUPING SETS (())
         """)
-    // Over an EMPTY input the grand-total group still yields its one row.
+    // Over an empty input the grand-total group still yields its one row.
     let empty = try Catalog { Relation("E", ["x": .integer]) { } }
     try empty.expect("SELECT 1 FROM E GROUP BY ()", yields: [[1]])
     try empty.expect("SELECT COUNT(*) FROM E GROUP BY ()", yields: [[0]])
@@ -453,8 +453,8 @@ struct RollupCubeTests {
   @Test func `an over-large CUBE or cross product faults, not overflows`()
       throws {
     // A CUBE of 63/64 units once overflowed `1 << n` to a negative/zero mask,
-    // yielding NO sets and the misleading "requires at least one set". It now
-    // faults a program-limit error BEFORE the shift, and the whole clause's
+    // yielding no sets and the misleading "requires at least one set". It now
+    // faults a program-limit error before the shift, and the whole clause's
     // cross product is capped the same way.
     let cube = SQLError.state("54001",
                               "GROUP BY CUBE supports at most 12 grouping " +
@@ -483,7 +483,7 @@ struct RollupCubeTests {
         """, fails: SQLError.state("54001", "GROUP BY produces too many " +
                                    "grouping sets (max 4096)"))
     // A ROLLUP of n units expands to n + 1 prefixes summing to O(n²)
-    // expression references; its arity is validated BEFORE the prefixes are
+    // expression references; its arity is validated before the prefixes are
     // built, so an oversized (here 4096-unit) ROLLUP faults immediately rather
     // than materialising the quadratic structure first.
     try sales().expect(
@@ -505,7 +505,7 @@ struct RollupCubeTests {
                       equals: "SELECT SUM(V) FROM N GROUP BY CUBE(A + 1)")
     try nums().expect("SELECT SUM(V) FROM N GROUP BY GROUPING SETS ((A) + 1)",
                       equals: "SELECT SUM(V) FROM N GROUP BY (A) + 1")
-    // GUARD: a genuine composite unit `(A, V)` is still a set, not truncated.
+    // guard: a genuine composite unit `(A, V)` is still a set, not truncated.
     try nums().expect("""
         SELECT SUM(V) FROM N GROUP BY ROLLUP((A, V))
         """, equals: """
@@ -515,7 +515,7 @@ struct RollupCubeTests {
 
   @Test func `a long ordinary clause and repeated keys parse and group`()
       throws {
-    // Ordinary keys accumulate by append (linear), not O(n²) cross. The RESULT
+    // Ordinary keys accumulate by append (linear), not O(n²) cross. The result
     // is unaffected — a repeated key groups as one, key order within the set
     // does not matter, and a repeated literal collapses to one group.
     try nums().expect("SELECT A, SUM(V) FROM N GROUP BY A, A, A",
@@ -525,10 +525,10 @@ struct RollupCubeTests {
   }
 
   @Test func `a wide composite unit is bounded before expansion`() throws {
-    // units.count is capped, but a COMPOSITE unit holds arbitrarily many
+    // units.count is capped, but a composite unit holds arbitrarily many
     // expressions, and CUBE copies each unit across 2ⁿ⁻¹ subsets — so a compact
     // 12-unit CUBE whose first unit is a wide composite would materialise
-    // hundreds of millions of references. The PROJECTED expansion (references,
+    // hundreds of millions of references. The projected expansion (references,
     // not just unit count) is bounded before the subsets are built.
     func cols(_ range: Range<Int>) -> String {
       range.map { "c\($0)" }.joined(separator: ", ")

--- a/Tests/SQLTests/Queries/RoutineArityPostureTests.swift
+++ b/Tests/SQLTests/Queries/RoutineArityPostureTests.swift
@@ -8,7 +8,7 @@ import SQLTestSupport
 
 // MARK: - Routine arity/existence posture
 
-/// PINS the accepted run-vs-validate posture for a routine CALL: the bare
+/// PINS the accepted run-vs-validate posture for a routine call: the bare
 /// `run` path checks a routine EXISTS but defers arity/argument-type validation
 /// to the strict `columns(of:validate:)` gate. A caller wanting strict checks
 /// validates first; a run assumes the statement was already validated. This is
@@ -17,7 +17,7 @@ import SQLTestSupport
 /// validation rejects it — so a regression that started faulting arity at run,
 /// or stopped faulting it under validation, must break these tests.
 ///
-/// The fixture is SELF-CONTAINED: a small local catalog and a locally
+/// The fixture is self-contained: a small local catalog and a locally
 /// registered routine, disjoint from the shared `engine*` fixtures, so this
 /// suite pins the posture independently.
 @Suite struct RoutineArityPostureTests {
@@ -30,8 +30,8 @@ import SQLTestSupport
     }
   }
 
-  /// Routines with a native `tally` declaring ONE integer parameter (arity 1)
-  /// whose closure IGNORES its arguments and returns a constant. Because the
+  /// Routines with a native `tally` declaring one integer parameter (arity 1)
+  /// whose closure ignores its arguments and returns a constant. Because the
   /// closure does not self-check its argument count, a wrong-arity call reaches
   /// it and runs — isolating the run path's arity behaviour from a routine's
   /// own internal check (the standard `POSITION`/`BITAND` closures self-check,
@@ -43,7 +43,7 @@ import SQLTestSupport
   }
 
   @Test func `a wrong-arity call runs without an arity fault`() throws {
-    // `tally` declares arity 1 but is called with ZERO arguments. The run path
+    // `tally` declares arity 1 but is called with zero arguments. The run path
     // checks only that `tally` EXISTS, not its arity, and the closure ignores
     // its arguments, so the call produces its constant rather than faulting.
     let catalog = try table()
@@ -54,9 +54,9 @@ import SQLTestSupport
   }
 
   @Test func `validation faults a wrong-arity call`() throws {
-    // The SAME wrong-arity call is REJECTED by the strict validate gate: the
+    // The same wrong-arity call is rejected by the strict validate gate: the
     // declared arity is checked against the supplied argument count, faulting
-    // `.argument`. This is the gate a caller runs BEFORE a run when it wants
+    // `.argument`. This is the gate a caller runs before a run when it wants
     // arity enforced.
     let catalog = try table()
     let routines = try routines()
@@ -72,7 +72,7 @@ import SQLTestSupport
   }
 
   @Test func `an unknown routine faults on BOTH paths`() throws {
-    // EXISTENCE is checked at run, unlike arity: an unregistered routine faults
+    // existence is checked at run, unlike arity: an unregistered routine faults
     // `.function` at run AND under validation, so the distinction the posture
     // draws — existence checked, arity deferred — is explicit.
     let catalog = try table()

--- a/Tests/SQLTests/Queries/ScalarSubqueryTests.swift
+++ b/Tests/SQLTests/Queries/ScalarSubqueryTests.swift
@@ -8,10 +8,10 @@ import SQLTestSupport
 
 // MARK: - Fixture
 
-/// Two relations exercising the uncorrelated SCALAR subquery: an outer `T`
+/// Two relations exercising the uncorrelated scalar subquery: an outer `T`
 /// whose integer key `V` ranges over a known set, and an inner source `S`
-/// whose `V` a scalar subquery reduces with `MIN`/`MAX`, plus an EMPTY-able
-/// `E` (filtered to no rows) for the empty → NULL corner and a MULTI-row `M`
+/// whose `V` a scalar subquery reduces with `MIN`/`MAX`, plus an empty-able
+/// `E` (filtered to no rows) for the empty → NULL corner and a multi-row `M`
 /// (two rows) for the >1-row cardinality fault.
 private func fixture() throws -> FixtureCatalog {
   try Catalog {
@@ -122,7 +122,7 @@ struct ScalarSubqueryParsingTests {
 struct ScalarSubqueryProjectionTests {
   @Test func `a scalar subquery in the projection is the same per row`()
       throws {
-    // `(SELECT MAX(V) FROM S)` is 30 for EVERY outer row — uncorrelated, run
+    // `(SELECT MAX(V) FROM S)` is 30 for every outer row — uncorrelated, run
     // once — so each `T` row projects (Id, 30).
     try fixture().expect(
         "SELECT Id, (SELECT MAX(V) FROM S) AS m FROM T ORDER BY Id",
@@ -138,7 +138,7 @@ struct ScalarSubqueryProjectionTests {
   }
 
   @Test func `a scalar subquery types from its inner column`() throws {
-    // The scalar's TYPE is the inner projection's single-column type: `MAX(V)`
+    // The scalar's type is the inner projection's single-column type: `MAX(V)`
     // over an integer column is integer, and a text inner column makes the
     // scalar text.
     let integer = try parse(query: "SELECT (SELECT MAX(V) FROM S) AS m FROM T")
@@ -235,7 +235,7 @@ struct ScalarSubqueryCardinalityTests {
 
 struct ScalarSubqueryWidthTests {
   @Test func `a two-column scalar subquery faults at compile`() throws {
-    // A scalar subquery must project EXACTLY ONE column; a two-column inner
+    // A scalar subquery must project exactly one column; a two-column inner
     // query is `SQLError.arity`, checked cursor-free from the compiled width,
     // so it faults even though `M` has rows.
     try fixture().expect(
@@ -243,7 +243,7 @@ struct ScalarSubqueryWidthTests {
   }
 
   @Test func `a two-column scalar subquery faults the schema check`() throws {
-    // The schema path enforces the SAME single-column arity as the run —
+    // The schema path enforces the same single-column arity as the run —
     // `columns(of:)` faults exactly where a run would.
     let query = try parse(query: "SELECT (SELECT W, Name FROM M) FROM T")
     let resolve = { () throws -> Array<OutputColumn> in
@@ -284,9 +284,9 @@ struct ScalarSubqueryTypeCheckingTests {
   }
 
   @Test func `a scalar subquery select-list fault is validated`() throws {
-    // A scalar subquery EVALUATES its select list (it collapses the cell), so
-    // its ORIGINAL shape is type-checked — a `(SELECT 1 / 0 …)` faults
-    // `.divide` at BOTH validate and run, unlike the EXISTS probe.
+    // A scalar subquery evaluates its select list (it collapses the cell), so
+    // its original shape is type-checked — a `(SELECT 1 / 0 …)` faults
+    // `.divide` at both validate and run, unlike the EXISTS probe.
     let query = try parse(query: "SELECT (SELECT 1 / 0 FROM S) FROM T")
     let resolve = { () throws -> Array<OutputColumn> in
       try fixture().columns(of: query, validate: true)
@@ -304,12 +304,12 @@ struct ScalarSubqueryTypeCheckingTests {
 struct ScalarSubqueryCorrelationTests {
   @Test func `a scalar subquery naming an outer column resolves`() throws {
     // A scalar subquery referencing an OUTER column (`T.V`, not in the inner
-    // `S`'s scope) is a CORRELATED reference: it lowers to a synthetic bound
+    // `S`'s scope) is a correlated reference: it lowers to a synthetic bound
     // param bound from the outer row and the subquery re-runs per row. `T.V`
     // matches `S.V` for every row, so the scalar collapses to that value.
     let query = try parse(query:
         "SELECT (SELECT V FROM S WHERE V = T.V) FROM T")
-    // `columns(of:)` VALIDATES the correlated query — resolving the correlated
+    // `columns(of:)` validates the correlated query — resolving the correlated
     // column against the outer scope exactly as the run does — rather than
     // faulting `SQLError.column`.
     let columns = try fixture().columns(of: query, validate: true)
@@ -322,8 +322,8 @@ struct ScalarSubqueryCorrelationTests {
   @Test func `a correlated column in the inner projection is unsupported`()
       throws {
     // The minimal (b) cut admits a correlated column ONLY in the inner
-    // subquery's WHERE. One in the inner PROJECTION (`SELECT T.V …`) needs the
-    // general outer-row evaluator, so it is DIAGNOSED unsupported at BOTH
+    // subquery's WHERE. One in the inner projection (`SELECT T.V …`) needs the
+    // general outer-row evaluator, so it is diagnosed unsupported at both
     // `columns(of:)` and run rather than mis-resolved.
     let query = try parse(query: "SELECT (SELECT T.V FROM S) FROM T")
     #expect(throws: SQLError.self) {
@@ -337,11 +337,11 @@ struct ScalarSubqueryCorrelationTests {
 
   @Test func `a FROM-less correlated projection subquery is unsupported`()
       throws {
-    // A FROM-less scalar subquery in the PROJECTION that names an outer column
+    // A FROM-less scalar subquery in the projection that names an outer column
     // (`SELECT (SELECT T.Id) FROM T`) is a correlated reference in a barred
     // clause position. The cut is intrinsic to the projection entry
-    // (`Schema.terms` bars its seam), so this FROM-less projection CANNOT admit
-    // the correlation — run and `columns(of:)` REJECT it with the SAME fault,
+    // (`Schema.terms` bars its seam), so this FROM-less projection cannot admit
+    // the correlation — run and `columns(of:)` reject it with the same fault,
     // never lowering `T.Id` to a run-time `Term.parameter` that would (wrongly)
     // execute.
     let query = try parse(query: "SELECT (SELECT T.Id) FROM T")
@@ -356,8 +356,8 @@ struct ScalarSubqueryCorrelationTests {
 
   @Test func `a correlated WHERE subquery still admits and runs`() throws {
     // The parity case: a correlated column in the inner subquery's WHERE — an
-    // ADMITTING clause position, unchanged by the projection barring — still
-    // lowers `T.V` to a correlated `Term.parameter` and RUNS per outer row.
+    // admitting clause position, unchanged by the projection barring — still
+    // lowers `T.V` to a correlated `Term.parameter` and runs per outer row.
     // `(SELECT V FROM S WHERE V = T.V)` collapses to each row's own `V`, so
     // `= V` keeps every row.
     let query = try parse(query:
@@ -373,7 +373,7 @@ struct ScalarSubqueryCorrelationTests {
 
 // MARK: - Cross-role cache identity
 
-/// Identical inner SQL used in more than one ROLE at once — scalar, `IN`, and
+/// Identical inner SQL used in more than one role at once — scalar, `IN`, and
 /// `EXISTS` — must materialise under DISTINCT cache entries, so a scalar read
 /// never hits an `IN`/`EXISTS` entry and vice versa. The run-time cache keys on
 /// `(scope, query, role)`; keying without the role collapsed the three onto one
@@ -382,10 +382,10 @@ struct ScalarSubqueryCorrelationTests {
 struct ScalarSubqueryRoleTests {
   @Test func `the same SQL as a scalar and an IN filter each read their own`()
       throws {
-    // The reviewer's case: `(SELECT W FROM M WHERE W = 1)` occurs BOTH as a
+    // The reviewer's case: `(SELECT W FROM M WHERE W = 1)` occurs both as a
     // scalar projection AND as an `IN` value set — identical inner SQL. The
     // scalar yields its cell (1) for every row, and the `IN` filters `1 IN
-    // {1}` to keep every row, each from its OWN entry — no cross-read.
+    // {1}` to keep every row, each from its own entry — no cross-read.
     try fixture().expect(
         """
         SELECT (SELECT W FROM M WHERE W = 1) AS w FROM T \
@@ -397,7 +397,7 @@ struct ScalarSubqueryRoleTests {
   @Test func `the same SQL as a scalar and an EXISTS both see the row`()
       throws {
     // `(SELECT W FROM M WHERE W = 1)` occurs as a scalar AND an `EXISTS`. The
-    // EXISTS sees `present == true` (the subquery has a row) from its OWN
+    // EXISTS sees `present == true` (the subquery has a row) from its own
     // existential entry, NOT the scalar entry, so every row is kept and the
     // scalar projects its cell (1).
     try fixture().expect(
@@ -411,7 +411,7 @@ struct ScalarSubqueryRoleTests {
   @Test func `an EXISTS over identical scalar SQL with no row keeps nothing`()
       throws {
     // The scalar occurrence over an empty filter is NULL, and the EXISTS over
-    // the IDENTICAL empty SQL is FALSE (no row) — read from its own
+    // the identical empty SQL is FALSE (no row) — read from its own
     // existential entry, not the scalar's `present`. So the filter admits none.
     try fixture().empty(
         """
@@ -424,7 +424,7 @@ struct ScalarSubqueryRoleTests {
       throws {
     // All three roles over identical SQL at once: the scalar cell (1), the `IN`
     // membership (`1 IN {1}` true), and the `EXISTS` probe (has a row) each
-    // read their OWN entry, so every row is kept and projects the cell.
+    // read their own entry, so every row is kept and projects the cell.
     try fixture().expect(
         """
         SELECT (SELECT W FROM M WHERE W = 1) AS w FROM T \
@@ -436,10 +436,10 @@ struct ScalarSubqueryRoleTests {
 
   @Test func `a reachable scalar faults even with an unreachable IN twin`()
       throws {
-    // Identical inner SQL `(SELECT 1 / 0 FROM S)` occurs BOTH as a REACHABLE
-    // scalar projection AND in an UNREACHABLE `IN` leg (`1 = 1 OR …`, whose OR
-    // short-circuits past the `IN`). Now that an `IN` materialises LAZILY, the
-    // valued twin no longer runs — and its eager arity/type derivation is TOTAL
+    // Identical inner SQL `(SELECT 1 / 0 FROM S)` occurs both as a reachable
+    // scalar projection AND in an unreachable `IN` leg (`1 = 1 OR …`, whose OR
+    // short-circuits past the `IN`). Now that an `IN` materialises lazily, the
+    // valued twin no longer runs — and its eager arity/type derivation is total
     // (no `.divide`) — so it cannot stand in for the scalar's operand check. The
     // reachable scalar's own operand validation must still fault `.divide`. A
     // valued twin must NOT suppress the scalar's deferred recording.
@@ -461,7 +461,7 @@ struct ScalarSubqueryRoleTests {
 
   @Test func `a valid scalar with an unreachable IN twin validates and runs`()
       throws {
-    // The parity case: the SAME scalar-and-unreachable-IN shape with a VALID
+    // The parity case: the same scalar-and-unreachable-IN shape with a valid
     // body (`(SELECT W FROM M WHERE W = 1)`) validates AND runs — the scalar
     // cell (1) per row, the `IN` leg unreached (OR short-circuits). Proof the
     // fix defers-and-validates the reachable scalar without over-faulting.
@@ -482,7 +482,7 @@ struct ScalarSubqueryRoleTests {
 
   @Test func `a multi-row subquery faults as a scalar but succeeds as an IN`()
       throws {
-    // `(SELECT W FROM M)` yields TWO rows. As a scalar occurrence it faults
+    // `(SELECT W FROM M)` yields two rows. As a scalar occurrence it faults
     // `SQLError.cardinality`; the identical SQL as an `IN` value set is valid.
     // The scalar entry faults the run — role-correct semantics on shared SQL.
     try fixture().expect(
@@ -495,7 +495,7 @@ struct ScalarSubqueryRoleTests {
 
   @Test func `a multi-row subquery as an IN alone keeps its matching rows`()
       throws {
-    // The SAME multi-row `(SELECT W FROM M)` used ONLY as an `IN` (no scalar
+    // The same multi-row `(SELECT W FROM M)` used ONLY as an `IN` (no scalar
     // occurrence) succeeds: `M` holds {1, 2}, so `1 IN (SELECT W FROM M)` is
     // true and every `T` row is kept — proof the `IN` role materialises full.
     try fixture().expect(
@@ -506,12 +506,12 @@ struct ScalarSubqueryRoleTests {
 
 // MARK: - Lazy short-circuit materialisation
 
-/// A scalar subquery materialises LAZILY, on the first evaluation of its
+/// A scalar subquery materialises lazily, on the first evaluation of its
 /// `Term.subquery` — NOT eagerly before the plan runs — so an occurrence in an
 /// unreachable `CASE`/`COALESCE` arm never executes, honouring the engine's
 /// short-circuit and reachability semantics. A reached occurrence still runs
 /// (and enforces cardinality / surfaces an inner fault), memoised so a value
-/// over a single row is the SAME across every outer row.
+/// over a single row is the same across every outer row.
 struct ScalarSubqueryLazyTests {
   @Test func `a multi-row scalar in a skipped CASE arm never runs`() throws {
     // The reviewer's exact case: the `THEN` arm holds a multi-row scalar
@@ -528,7 +528,7 @@ struct ScalarSubqueryLazyTests {
 
   @Test func `a multi-row scalar in a reached CASE arm still faults`() throws {
     // The mirror: with the guard `1 = 1` TRUE, the arm IS selected, so the
-    // multi-row scalar DOES run and faults `.cardinality` — the reachable arm
+    // multi-row scalar does run and faults `.cardinality` — the reachable arm
     // enforces the ISO cardinality rule.
     try fixture().expect(
         "SELECT CASE WHEN 1 = 1 THEN (SELECT W FROM M) ELSE 0 END FROM T",
@@ -582,8 +582,8 @@ struct ScalarSubqueryLazyTests {
 
   @Test func `a reached single-row scalar yields its value across all rows`()
       throws {
-    // Materialise-once: a reached scalar over a SINGLE row collapses to its
-    // cell (1) and is memoised, so it reads the SAME value for every outer row
+    // Materialise-once: a reached scalar over a single row collapses to its
+    // cell (1) and is memoised, so it reads the same value for every outer row
     // — the guard `1 = 1` reaches it, and all three `T` rows project 1.
     try fixture().expect(
         """
@@ -596,7 +596,7 @@ struct ScalarSubqueryLazyTests {
   @Test func `a skipped scalar arm folds like its reachable literal`() throws {
     // The skipped-arm query yields exactly what the same CASE with the scalar
     // replaced by a never-run placeholder would — every row is the `ELSE` 0 —
-    // so the lazy skip changes nothing but WHETHER the scalar executes.
+    // so the lazy skip changes nothing but whether the scalar executes.
     try fixture().expect(
         """
         SELECT CASE WHEN 1 = 0 THEN (SELECT W FROM M) ELSE 0 END FROM T
@@ -607,20 +607,20 @@ struct ScalarSubqueryLazyTests {
 
 // MARK: - Validation ↔ run parity
 
-/// Validation (`columns(of:)`) must AGREE with execution on which scalar
-/// subqueries it faults on: a scalar occurrence's inner-query OPERAND
-/// validation is DEFERRED to the reachability walk, mirroring the lazy executor
+/// Validation (`columns(of:)`) must agree with execution on which scalar
+/// subqueries it faults on: a scalar occurrence's inner-query operand
+/// validation is deferred to the reachability walk, mirroring the lazy executor
 /// — so an occurrence in an unreachable `CASE`/`COALESCE` arm is NOT validated
-/// (it never runs), while a REACHED bad scalar still faults at validation (it
-/// would fault at run). The cursor-free ARITY/TYPE derivation stays EAGER and
-/// SEPARATE: a two-column scalar in a skipped arm still faults `.arity`.
+/// (it never runs), while a reached bad scalar still faults at validation (it
+/// would fault at run). The cursor-free arity/type derivation stays eager and
+/// separate: a two-column scalar in a skipped arm still faults `.arity`.
 struct ScalarSubqueryValidationParityTests {
   @Test func `a divide scalar in a skipped CASE arm validates and runs`()
       throws {
     // The reviewer's case: `columns(of:)` for a skipped THEN arm's throwing
-    // scalar SUCCEEDS (no `.divide`) — the operand validation defers to the
-    // reachability walk, which skips the unreachable arm — AND the query RUNS
-    // successfully, so validation and execution AGREE.
+    // scalar succeeds (no `.divide`) — the operand validation defers to the
+    // reachability walk, which skips the unreachable arm — AND the query runs
+    // successfully, so validation and execution agree.
     let query = try parse(query:
         "SELECT CASE WHEN 1 = 0 THEN (SELECT 1 / 0 FROM S) ELSE 0 END FROM T")
     let columns = try fixture().columns(of: query, validate: true)
@@ -655,9 +655,9 @@ struct ScalarSubqueryValidationParityTests {
 
   @Test func `a two-column scalar in a skipped arm still faults arity`()
       throws {
-    // ARITY stays EAGER and reachability-INDEPENDENT — the cursor-free width
-    // check is SEPARATE from the deferred operand validation — so a two-column
-    // scalar subquery in an UNREACHABLE arm STILL faults `SQLError.arity`, even
+    // arity stays eager and reachability-independent — the cursor-free width
+    // check is separate from the deferred operand validation — so a two-column
+    // scalar subquery in an unreachable arm still faults `SQLError.arity`, even
     // though its inner-query operand validation would defer.
     let query = try parse(query:
         """
@@ -673,13 +673,13 @@ struct ScalarSubqueryValidationParityTests {
   }
 
   @Test func `a bad inner column in a skipped arm faults both alike`() throws {
-    // A bad inner COLUMN is a STRUCTURAL resolution fault the COMPILE path
-    // raises for EVERY subquery — reachability-independent, unlike the operand
-    // `.divide` above — so it fires at BOTH validate and run REGARDLESS of the
+    // A bad inner COLUMN is a structural resolution fault the compile path
+    // raises for every subquery — reachability-independent, unlike the operand
+    // `.divide` above — so it fires at both validate and run regardless of the
     // arm's reachability. The run itself faults `.column` (compile resolves the
     // scalar's inner columns to build the plan), so `columns(of:)` faulting
-    // `.column` PRESERVES parity — validation rejects exactly what the executor
-    // rejects. Only the OPERAND fault (`1 / 0`) the typecheck detects and the
+    // `.column` preserves parity — validation rejects exactly what the executor
+    // rejects. Only the operand fault (`1 / 0`) the typecheck detects and the
     // lazy executor skips needed deferring; a bad column never did.
     let query = try parse(query:
         """
@@ -715,13 +715,13 @@ struct ScalarSubqueryValidationParityTests {
   }
 
   @Test func `a divide scalar in a skipped COALESCE arm validates`() throws {
-    // `COALESCE` short-circuits at the first non-NULL argument. A CONSTANT
-    // non-NULL first argument makes the second arm STATICALLY unreachable — the
+    // `COALESCE` short-circuits at the first non-NULL argument. A constant
+    // non-NULL first argument makes the second arm statically unreachable — the
     // reachability the validation walk honours — so the throwing scalar's
-    // operand validation defers and is never reached: `columns(of:)` SUCCEEDS
-    // and the query RUNS. (A non-constant first argument like a column is NOT
+    // operand validation defers and is never reached: `columns(of:)` succeeds
+    // and the query runs. (A non-constant first argument like a column is NOT
     // statically known non-NULL, so validation would treat the second arm as
-    // reachable — the walk mirrors only the STATIC short-circuit.)
+    // reachable — the walk mirrors only the static short-circuit.)
     let query = try parse(query:
         "SELECT COALESCE(1, (SELECT 1 / 0 FROM S)) FROM T")
     let columns = try fixture().columns(of: query, validate: true)
@@ -734,22 +734,22 @@ struct ScalarSubqueryValidationParityTests {
 
 // MARK: - IN/EXISTS validation ↔ run parity
 
-/// An `IN (Q)`/`EXISTS` occurrence is materialised LAZILY at run — one in a
+/// An `IN (Q)`/`EXISTS` occurrence is materialised lazily at run — one in a
 /// skipped `CASE`/`COALESCE` arm or a short-circuited `AND`/`OR` leg never
-/// runs. Its inner-query OPERAND validation must therefore DEFER to the
+/// runs. Its inner-query operand validation must therefore defer to the
 /// reachability walk, exactly as a scalar's does: an occurrence in an
-/// unreachable arm is NOT validated (matching the lazy run), while a REACHED
+/// unreachable arm is NOT validated (matching the lazy run), while a reached
 /// bad-bodied one still faults at both validate and run (parity both
-/// directions). An `IN` validates its ORIGINAL shape (its value set is read),
-/// an EXISTS-only occurrence the cardinality PROBE (its retained `WHERE` still
+/// directions). An `IN` validates its original shape (its value set is read),
+/// an EXISTS-only occurrence the cardinality probe (its retained `WHERE` still
 /// faults, its dropped select list does not).
 struct SubqueryValidationParityTests {
   @Test func `an IN in a skipped CASE arm validates and runs`() throws {
     // The reviewer's case: the `1 IN (SELECT 1 / 0 …)` sits in the ELSE arm of
     // a CASE whose `1 = 1` guard is constant TRUE, so the arm is unreachable.
     // The operand validation defers to the walk, which skips the arm —
-    // `columns(of:)` does NOT fault `.divide` — and the query RUNS, yielding
-    // the reached `0` for every row. Validation and execution AGREE.
+    // `columns(of:)` does NOT fault `.divide` — and the query runs, yielding
+    // the reached `0` for every row. Validation and execution agree.
     let sql = """
         SELECT CASE WHEN 1 = 1 THEN 0 \
                     ELSE CASE WHEN 1 IN (SELECT 1 / 0 FROM S) THEN 1 END END \
@@ -762,9 +762,9 @@ struct SubqueryValidationParityTests {
 
   @Test func `an EXISTS in a skipped CASE arm validates and runs`() throws {
     // The EXISTS mirror: `EXISTS (SELECT V FROM S WHERE 1 / 0 = 1)` — a
-    // THROWING operand the cardinality PROBE RETAINS (it keeps the `WHERE`) —
+    // throwing operand the cardinality probe retains (it keeps the `WHERE`) —
     // sits in the skipped ELSE arm. Its operand validation defers, so
-    // `columns(of:)` does NOT fault and the query RUNS the reached `0`.
+    // `columns(of:)` does NOT fault and the query runs the reached `0`.
     let sql = """
         SELECT CASE WHEN 1 = 1 THEN 0 \
                     ELSE CASE WHEN EXISTS (SELECT V FROM S WHERE 1 / 0 = 1) \
@@ -778,7 +778,7 @@ struct SubqueryValidationParityTests {
 
   @Test func `a reached bad IN faults both validate and run`() throws {
     // Parity the other way: with the guard TRUE the arm IS reached, so the walk
-    // records the `IN` and its ORIGINAL shape IS validated — `columns(of:)`
+    // records the `IN` and its original shape IS validated — `columns(of:)`
     // faults `.divide` exactly as the run does.
     let sql = """
         SELECT CASE WHEN 1 = 1 \
@@ -797,7 +797,7 @@ struct SubqueryValidationParityTests {
 
   @Test func `a reached bad EXISTS faults both validate and run`() throws {
     // The EXISTS mirror in the reached direction: the retained `WHERE`'s
-    // `1 / 0` faults `.divide` at BOTH validate and run once the arm reached.
+    // `1 / 0` faults `.divide` at both validate and run once the arm reached.
     let sql = """
         SELECT CASE WHEN 1 = 1 \
                     THEN CASE WHEN EXISTS (SELECT V FROM S WHERE 1 / 0 = 1) \
@@ -815,7 +815,7 @@ struct SubqueryValidationParityTests {
 
   @Test func `a reached IN in the WHERE still faults`() throws {
     // The plain WHERE case is not short-circuited past, so a bad-bodied `IN`
-    // there is REACHED and faults `.divide` at both validate and run — the lazy
+    // there is reached and faults `.divide` at both validate and run — the lazy
     // deferral does not weaken the always-reached position.
     let sql = "SELECT Id FROM T WHERE 1 IN (SELECT 1 / 0 FROM S)"
     let resolve = { () throws -> Array<OutputColumn> in
@@ -830,10 +830,10 @@ struct SubqueryValidationParityTests {
 
 // MARK: - Join-ON correlation prefix scope
 
-/// A `JOIN … ON` subquery correlates against the join PREFIX scope — the
-/// relations available AT that join point — not the full join, which includes
-/// relations joined LATER. A correlated reference in an EARLY `ON` to a
-/// LATER-joined relation faults `SQLError.column` exactly as a DIRECT reference
+/// A `JOIN … ON` subquery correlates against the join prefix scope — the
+/// relations available at that join point — not the full join, which includes
+/// relations joined later. A correlated reference in an early `ON` to a
+/// later-joined relation faults `SQLError.column` exactly as a direct reference
 /// in that `ON` would, rather than mis-binding a slot not present when the
 /// early join's `ON` evaluates.
 private func joins() throws -> FixtureCatalog {
@@ -859,7 +859,7 @@ private func joins() throws -> FixtureCatalog {
 struct JoinOnCorrelationPrefixTests {
   @Test func `an early ON correlating to a later join faults at run`() throws {
     // `A JOIN B ON EXISTS (SELECT 1 FROM X WHERE X.k = C.Ck) JOIN C …` names
-    // `C` in the A×B join's `ON`, but `C` joins LATER, so it is out of that
+    // `C` in the A×B join's `ON`, but `C` joins later, so it is out of that
     // join's prefix scope. The correlated reference faults `SQLError.column`
     // (spelled by its bare name, as a direct `C.Ck` there would) rather than
     // reading a slot not present when the A×B `ON` evaluates.
@@ -874,7 +874,7 @@ struct JoinOnCorrelationPrefixTests {
 
   @Test func `an early ON correlating to a later join faults the check`()
       throws {
-    // The schema path enforces the SAME prefix scope — `columns(of:)` faults
+    // The schema path enforces the same prefix scope — `columns(of:)` faults
     // `SQLError.column` exactly where the run does, keeping typecheck↔run
     // parity.
     let query = try parse(query:
@@ -909,21 +909,21 @@ struct JoinOnCorrelationPrefixTests {
 
 // MARK: - Reached-role validation shape
 
-/// The deferred type-check picks each reached occurrence's validation SHAPE
-/// from the ROLE it reached in PER OCCURRENCE — an `existential` reach
-/// validates the EXISTS cardinality PROBE (no projection), a `scalar`/`valued`
+/// The deferred type-check picks each reached occurrence's validation shape
+/// from the role it reached in per occurrence — an `existential` reach
+/// validates the EXISTS cardinality probe (no projection), a `scalar`/`valued`
 /// reach the original — NOT from the union of every role the query occupies in
-/// the select. So the SAME inner SQL reached ONLY as an `EXISTS` validates the
-/// probe even where an UNREACHED `CASE`/`COALESCE` arm has it as a scalar; the
+/// the select. So the same inner SQL reached ONLY as an `EXISTS` validates the
+/// probe even where an unreached `CASE`/`COALESCE` arm has it as a scalar; the
 /// union would mis-mark it "evaluated" and validate the original projection,
 /// faulting `.divide` on a `1 / 0` the run never evaluates.
 struct SubqueryReachedRoleShapeTests {
   @Test func `an EXISTS reach validates the probe past an unreached scalar`()
       throws {
-    // `EXISTS (SELECT 1 / 0 FROM S)` is REACHED (the WHERE runs it), so its
-    // cardinality PROBE — a constant projection dropping the `1 / 0` — is
-    // validated: no `.divide`. The IDENTICAL inner `(SELECT 1 / 0 FROM S)` also
-    // occurs as a SCALAR in the ELSE arm of a `1 = 0` CASE, which is UNREACHED,
+    // `EXISTS (SELECT 1 / 0 FROM S)` is reached (the WHERE runs it), so its
+    // cardinality probe — a constant projection dropping the `1 / 0` — is
+    // validated: no `.divide`. The identical inner `(SELECT 1 / 0 FROM S)` also
+    // occurs as a scalar in the ELSE arm of a `1 = 0` CASE, which is unreached,
     // so its original projection is NOT validated. A global role union would
     // have marked the query "evaluated" (scalar) and faulted `.divide`.
     let sql = """
@@ -939,7 +939,7 @@ struct SubqueryReachedRoleShapeTests {
 
   @Test func `a reached scalar with a bad projection still faults`() throws {
     // Parity the other way: with the CASE guard `1 = 1` the scalar arm IS
-    // reached, so the SCALAR role's ORIGINAL projection is validated — its
+    // reached, so the scalar role's original projection is validated — its
     // `1 / 0` faults `.divide` at both validate and run, unchanged by the
     // EXISTS occurrence sharing the identical inner SQL.
     let sql = """
@@ -959,12 +959,12 @@ struct SubqueryReachedRoleShapeTests {
 
 // MARK: - Join-ON short-circuit validation parity
 
-/// A join `ON` predicate short-circuits its `AND`/`OR` at RUN — the join
+/// A join `ON` predicate short-circuits its `AND`/`OR` at run — the join
 /// evaluator steps the lowered conjunction and never materialises a subquery a
-/// FALSE left conjunct settles past. So an `ON` subquery runs through the SAME
-/// reachability/short-circuit walk the WHERE/HAVING do, PREFIX-scoped: one in a
+/// FALSE left conjunct settles past. So an `ON` subquery runs through the same
+/// reachability/short-circuit walk the WHERE/HAVING do, prefix-scoped: one in a
 /// short-circuited leg is NOT eager-validated (matching the lazy run), while a
-/// REACHED `ON` subquery IS validated (parity both directions). The prefix
+/// reached `ON` subquery IS validated (parity both directions). The prefix
 /// scope is intact — a correlated `ON` column to a later-joined relation still
 /// faults.
 struct JoinOnShortCircuitValidationTests {
@@ -972,7 +972,7 @@ struct JoinOnShortCircuitValidationTests {
       throws {
     // `ON 1 = 0 AND 1 IN (SELECT 1 / 0 FROM S)` short-circuits on the constant
     // FALSE left, so the join never materialises the `1 IN (…)` — the walk
-    // skips it, `columns(of:)` does NOT fault `.divide`, and the join RUNS. The
+    // skips it, `columns(of:)` does NOT fault `.divide`, and the join runs. The
     // FALSE `ON` matches no A×S pair, so the query yields no rows.
     let sql = """
         SELECT A.a FROM A \
@@ -985,7 +985,7 @@ struct JoinOnShortCircuitValidationTests {
 
   @Test func `a reached ON subquery with a bad body still faults`() throws {
     // Parity: with the left conjunct `1 = 1` the `IN` IS reached, so its
-    // ORIGINAL is validated — its `1 / 0` faults `.divide` at both validate and
+    // original is validated — its `1 / 0` faults `.divide` at both validate and
     // run, exactly as an always-reached WHERE occurrence does.
     let sql = """
         SELECT A.a FROM A \
@@ -1002,7 +1002,7 @@ struct JoinOnShortCircuitValidationTests {
 
   @Test func `a reached EXISTS in the ON validates its probe and runs`()
       throws {
-    // A REACHED `ON` EXISTS whose retained body is CLEAN validates and runs:
+    // A reached `ON` EXISTS whose retained body is clean validates and runs:
     // its cardinality probe drops the select list, and `X` holds {1, 2}, so the
     // EXISTS is TRUE for every A×B pair — the join yields the A rows.
     let sql = """
@@ -1017,7 +1017,7 @@ struct JoinOnShortCircuitValidationTests {
   @Test func `an early ON correlating to a later join still faults`() throws {
     // Prefix-scoping is intact under the short-circuit walk: `ON 1 = 1 AND
     // EXISTS (SELECT 1 FROM X WHERE X.k = C.Ck)` names `C` in the A×B `ON`, but
-    // `C` joins LATER, out of that join's prefix — so the correlated reference
+    // `C` joins later, out of that join's prefix — so the correlated reference
     // faults `SQLError.column` at both validate and run, per batch-1/4.
     let sql = """
         SELECT A.a FROM A \
@@ -1057,11 +1057,11 @@ private func mixed() throws -> FixtureCatalog {
 
 // MARK: - Correlated plan cache occurrence identity
 
-/// The correlated per-outer-row PLAN cache keys on the full occurrence `Subkey`
+/// The correlated per-outer-row plan cache keys on the full occurrence `Subkey`
 /// (scope + query + role), not just the inner `Query`. Two occurrences of the
-/// IDENTICAL inner SQL — one under a `.caller` scope and one under a
-/// `.view(name)` body, whose correlated column resolves to a DIFFERENT ordinal
-/// — each compile and execute their OWN plan; keying by the query alone made a
+/// identical inner SQL — one under a `.caller` scope and one under a
+/// `.view(name)` body, whose correlated column resolves to a different ordinal
+/// — each compile and execute their own plan; keying by the query alone made a
 /// later occurrence reuse the first's plan (its synthetic-parameter names and
 /// resolved layout), reading the wrong outer cell.
 private func occurrences() throws -> FixtureCatalog {
@@ -1077,12 +1077,12 @@ private func occurrences() throws -> FixtureCatalog {
       Row(20)
     }
     // The view's outer relation — a leading `pad` puts its correlated column
-    // `k` at ordinal 1, a DIFFERENT ordinal from `Outer1.k`.
+    // `k` at ordinal 1, a different ordinal from `Outer1.k`.
     Relation("Outer2", ["pad": .integer, "k": .integer]) {
       Row(0, 20)
       Row(0, 30)
     }
-    // A view whose body holds the SAME correlated inner SQL the caller uses,
+    // A view whose body holds the same correlated inner SQL the caller uses,
     // over `Outer2` (correlated `k` at ordinal 1) — the `.view` occurrence.
     try View("VW", "SELECT (SELECT m FROM Src WHERE m = k) AS mm FROM Outer2",
              as: ["mm"])
@@ -1092,10 +1092,10 @@ private func occurrences() throws -> FixtureCatalog {
 struct CorrelatedPlanCacheIdentityTests {
   @Test func `identical correlated SQL under a caller and a view each hold`()
       throws {
-    // `(SELECT m FROM Src WHERE m = k)` appears BOTH in the caller (over
+    // `(SELECT m FROM Src WHERE m = k)` appears both in the caller (over
     // `Outer1`, `k` at ordinal 0) and in view `VW`'s body (over `Outer2`, `k`
     // at ordinal 1) — identical inner SQL, DISTINCT scope AND ordinal. Each
-    // occurrence runs its OWN plan: the caller yields `Outer1.k` ∈ {10, 20}
+    // occurrence runs its own plan: the caller yields `Outer1.k` ∈ {10, 20}
     // matched against `Src` → {10, 20}; the view yields `Outer2.k` ∈ {20, 30}
     // → {20, 30}. A query-only cache key would reuse the first plan (wrong
     // ordinal/parameter), so the two arms would not both resolve correctly.
@@ -1111,10 +1111,10 @@ struct CorrelatedPlanCacheIdentityTests {
 
 // MARK: - Nested correlation bubble-up
 
-/// A correlation discovered while compiling a subquery NESTED inside another
-/// subquery must BUBBLE UP to mark the CONTAINING subquery correlated. An INNER
-/// `EXISTS` naming a column of a scope TWO levels up (`T.id`, above the middle
-/// `U` query) makes the MIDDLE `EXISTS` correlated to `T` too, so it re-executes
+/// A correlation discovered while compiling a subquery nested inside another
+/// subquery must bubble up to mark the containing subquery correlated. An INNER
+/// `EXISTS` naming a column of a scope two levels up (`T.id`, above the middle
+/// `U` query) makes the middle `EXISTS` correlated to `T` too, so it re-executes
 /// per `T` row and threads the binding down — rather than being treated as
 /// uncorrelated and re-run without the `T` scope.
 private func nested() throws -> FixtureCatalog {
@@ -1124,7 +1124,7 @@ private func nested() throws -> FixtureCatalog {
       Row(2)
       Row(3)
     }
-    // A single-row source so the MIDDLE `EXISTS` over `U` is non-empty exactly
+    // A single-row source so the middle `EXISTS` over `U` is non-empty exactly
     // when its own nested `EXISTS` over `V` is — isolating the bubble-up.
     Relation("U", ["u": .integer]) {
       Row(0)
@@ -1142,7 +1142,7 @@ struct NestedCorrelationBubbleUpTests {
       throws {
     // The INNER `EXISTS (SELECT 1 FROM V WHERE V.x = T.id)` correlates to `T.id`
     // — two levels up, above the middle `U` query. The correlation bubbles up so
-    // the MIDDLE `EXISTS` is correlated to `T` and re-runs per `T` row. `V.x` ∈
+    // the middle `EXISTS` is correlated to `T` and re-runs per `T` row. `V.x` ∈
     // {2, 3}, so only `T` rows 2 and 3 satisfy the inner `EXISTS`; `U` has a
     // row, so the middle `EXISTS` mirrors the inner. Result: rows 2 and 3.
     try nested().expect(
@@ -1156,7 +1156,7 @@ struct NestedCorrelationBubbleUpTests {
   }
 
   @Test func `a two-level nested correlation validates`() throws {
-    // The schema path resolves the bubbled-up correlation the SAME as the run —
+    // The schema path resolves the bubbled-up correlation the same as the run —
     // `columns(of:)` validates the two-level correlated query rather than
     // faulting `SQLError.column` on the enclosing `T.id`.
     let query = try parse(query:
@@ -1172,12 +1172,12 @@ struct NestedCorrelationBubbleUpTests {
 
 // MARK: - Correlated scope-depth disambiguation
 
-/// A three-level nest whose INNERMOST subquery correlates to TWO enclosing
+/// A three-level nest whose innermost subquery correlates to two enclosing
 /// scopes at once — its immediate parent `U` and its grandparent `T` — where
-/// the referenced columns share the SAME combined ordinal (both 0, each its
-/// scope's sole column). Keying the synthetic parameter on the ordinal ALONE
+/// the referenced columns share the same combined ordinal (both 0, each its
+/// scope's sole column). Keying the synthetic parameter on the ordinal alone
 /// collides the two onto one binding, so both terms would read the same cell
-/// and the inner filter returns the wrong rows; keying on scope DEPTH + ordinal
+/// and the inner filter returns the wrong rows; keying on scope depth + ordinal
 /// keeps them distinct.
 private func scoped() throws -> FixtureCatalog {
   try Catalog {
@@ -1186,14 +1186,14 @@ private func scoped() throws -> FixtureCatalog {
       Row(2)
       Row(3)
     }
-    // One row, so the MIDDLE `EXISTS` over `U` is non-empty exactly when its
+    // One row, so the middle `EXISTS` over `U` is non-empty exactly when its
     // nested `EXISTS` over `V` is — its sole column `u` is 5, the value `V.y`
     // must match.
     Relation("U", ["u": .integer]) {
       Row(5)
     }
     // `V.x` matches `T.id` in {2, 3}, but only `(2, 5)` also has `V.y = U.u`
-    // (5): so only `T` row 2 satisfies BOTH correlated terms. A collided
+    // (5): so only `T` row 2 satisfies both correlated terms. A collided
     // binding (both terms reading one cell) would drop row 2 too, yielding [].
     Relation("V", ["x": .integer, "y": .integer]) {
       Row(2, 5)
@@ -1205,9 +1205,9 @@ private func scoped() throws -> FixtureCatalog {
 struct CorrelatedScopeDepthTests {
   @Test func `two same-ordinal correlations from different scopes run right`()
       throws {
-    // `V.x = T.id` correlates to the GRANDPARENT `T` (ordinal 0), `V.y = U.u`
-    // to the PARENT `U` (also ordinal 0). Depth-keyed synthetic params keep
-    // them distinct, so each term reads its OWN binding: only `T` row 2 matches
+    // `V.x = T.id` correlates to the grandparent `T` (ordinal 0), `V.y = U.u`
+    // to the parent `U` (also ordinal 0). Depth-keyed synthetic params keep
+    // them distinct, so each term reads its own binding: only `T` row 2 matches
     // (`V.x = 2 = id` AND `V.y = 5 = u`). An ordinal-only key would collide the
     // two onto `:__correlated_0`, one overwriting the other, yielding [].
     try scoped().expect(
@@ -1223,7 +1223,7 @@ struct CorrelatedScopeDepthTests {
 
   @Test func `two same-ordinal correlations from different scopes validate`()
       throws {
-    // The schema path resolves BOTH correlations the same as the run — no
+    // The schema path resolves both correlations the same as the run — no
     // `SQLError.column` on either enclosing reference.
     let query = try parse(query:
         """
@@ -1239,10 +1239,10 @@ struct CorrelatedScopeDepthTests {
 
 // MARK: - Correlated lookup ambiguity shadowing
 
-/// An `Outer` scope resolves a correlated column NEAREST enclosing scope first
+/// An `Outer` scope resolves a correlated column nearest enclosing scope first
 /// (lexical scoping). The three outcomes of a per-scope probe must stay DISTINCT
-/// — found binds, not-found keeps walking outward, and AMBIGUOUS (the name in
-/// more than one relation of a scope) SHADOWS the farther scopes by faulting
+/// — found binds, not-found keeps walking outward, and ambiguous (the name in
+/// more than one relation of a scope) shadows the farther scopes by faulting
 /// `SQLError.ambiguous`, never falling through to rebind the name to a farther
 /// relation. A `try?` that collapsed ambiguous onto not-found silently rebound
 /// a nearer-ambiguous name to an outer column.
@@ -1256,8 +1256,8 @@ private func relation(_ name: String, _ columns: Array<String>)
 struct CorrelatedAmbiguityShadowTests {
   @Test func `a nearer ambiguous scope shadows a farther one`() throws {
     // Outer `T(id)`; middle `U(id, u) JOIN V(id, v)` both expose `id`. A bare
-    // `id` correlating outward binds at the NEAREST enclosing scope — the middle
-    // — where it is AMBIGUOUS, so the lookup faults `SQLError.ambiguous` rather
+    // `id` correlating outward binds at the nearest enclosing scope — the middle
+    // — where it is ambiguous, so the lookup faults `SQLError.ambiguous` rather
     // than walking past to rebind it to the farther `T.id`.
     let outer = Outer([Scope([relation("T", ["id"])])])
         .nested(under: Scope([relation("U", ["id", "u"]),
@@ -1265,7 +1265,7 @@ struct CorrelatedAmbiguityShadowTests {
     #expect(throws: SQLError.ambiguous("id")) {
       _ = try outer.parameter(for: "id")
     }
-    // The schema-derive probe shadows identically, so validate and run AGREE.
+    // The schema-derive probe shadows identically, so validate and run agree.
     #expect(throws: SQLError.ambiguous("id")) {
       _ = try outer.type(for: "id")
     }
@@ -1284,8 +1284,8 @@ struct CorrelatedAmbiguityShadowTests {
 
   @Test func `a name absent from the nearer scope resolves outward`() throws {
     // `key` is absent from the middle `U JOIN V` but present in outer `T` — a
-    // NOT-FOUND at the nearer scope keeps the walk moving outward, so it still
-    // resolves to `T`. Only AMBIGUITY stops the walk; absence does not.
+    // NOT-found at the nearer scope keeps the walk moving outward, so it still
+    // resolves to `T`. Only ambiguity stops the walk; absence does not.
     let outer = Outer([Scope([relation("T", ["key"])])])
         .nested(under: Scope([relation("U", ["u"]),
                               relation("V", ["v"])]))
@@ -1298,8 +1298,8 @@ struct CorrelatedAmbiguityShadowTests {
 
 /// An outer `T` keyed by `k` and an inner `U` keyed by `k`, so a correlated
 /// EXISTS matches an outer row against the inner source per row — the shape
-/// exercising the per-outer-row cardinality PROBE (the correlated EXISTS must
-/// test non-emptiness WITHOUT evaluating the inner select list, exactly as the
+/// exercising the per-outer-row cardinality probe (the correlated EXISTS must
+/// test non-emptiness without evaluating the inner select list, exactly as the
 /// uncorrelated EXISTS probe does).
 private func existence() throws -> FixtureCatalog {
   try Catalog {
@@ -1319,7 +1319,7 @@ struct CorrelatedExistsProbeTests {
   @Test func `a correlated EXISTS probes without evaluating a divide`()
       throws {
     // `EXISTS (SELECT 1 / 0 FROM U WHERE U.k = T.k)` is correlated to `T.k`, so
-    // it re-runs per outer row — but through the cardinality PROBE, whose
+    // it re-runs per outer row — but through the cardinality probe, whose
     // constant projection never evaluates the `1 / 0` select list. `U.k` ∈ {1,
     // 2} matches `T` rows 1 and 2 (EXISTS TRUE, no `.divide`); row 3 matches
     // none (FALSE). The FULL plan would have evaluated `1 / 0` and faulted.
@@ -1335,7 +1335,7 @@ struct CorrelatedExistsProbeTests {
 
   @Test func `a correlated EXISTS with a normal projection still works`()
       throws {
-    // The same correlation with an ORDINARY select list runs identically — the
+    // The same correlation with an ordinary select list runs identically — the
     // probe keeps the FROM/`WHERE`, so the row source and its correlation still
     // decide existence: rows 1 and 2 match, row 3 does not.
     let sql = """
@@ -1348,9 +1348,9 @@ struct CorrelatedExistsProbeTests {
 
 // MARK: - Local ambiguity is a hard error, not outer correlation
 
-/// A correlated `.column` lowering resolves against its OWN relations FIRST,
-/// falling through to outer correlation only when the name binds NONE of them.
-/// A name bound by MORE than one local relation is LOCALLY AMBIGUOUS — a hard
+/// A correlated `.column` lowering resolves against its own relations FIRST,
+/// falling through to outer correlation only when the name binds none of them.
+/// A name bound by more than one local relation is locally ambiguous — a hard
 /// `SQLError.ambiguous`, NOT a fall-through: swallowing it into outer
 /// correlation would silently rebind an ambiguous inner name to an enclosing
 /// column of the same spelling (the wrong row value). A genuinely-not-found
@@ -1363,8 +1363,8 @@ private func ambiguity() throws -> FixtureCatalog {
       Row(1, 100)
       Row(2, 200)
     }
-    // The inner join's two relations BOTH expose `id`, so a bare `id` in the
-    // inner `WHERE` is LOCALLY ambiguous.
+    // The inner join's two relations both expose `id`, so a bare `id` in the
+    // inner `WHERE` is locally ambiguous.
     Relation("U", ["id": .integer, "u": .integer]) {
       Row(1, 5)
     }
@@ -1377,7 +1377,7 @@ private func ambiguity() throws -> FixtureCatalog {
 struct CorrelatedLocalAmbiguityTests {
   @Test func `a locally ambiguous inner name faults at run`() throws {
     // `EXISTS (SELECT 1 FROM U JOIN V ON U.u = V.v WHERE id = 1)`: `id` binds
-    // BOTH `U.id` and `V.id`, so it is a LOCAL ambiguity — a hard
+    // both `U.id` and `V.id`, so it is a local ambiguity — a hard
     // `SQLError.ambiguous("id")`, NOT a silent rebind to the outer `T.id`.
     let sql = """
         SELECT T.label FROM T \
@@ -1387,7 +1387,7 @@ struct CorrelatedLocalAmbiguityTests {
   }
 
   @Test func `a locally ambiguous inner name faults the check`() throws {
-    // The schema path faults the SAME `SQLError.ambiguous("id")`, keeping
+    // The schema path faults the same `SQLError.ambiguous("id")`, keeping
     // typecheck↔run parity — not swallowing the ambiguity into a correlation.
     let sql = """
         SELECT T.label FROM T \
@@ -1401,7 +1401,7 @@ struct CorrelatedLocalAmbiguityTests {
   }
 
   @Test func `a not-found inner name still correlates`() throws {
-    // `label` binds NONE of the inner relations (`U`, `V`), so it is a genuine
+    // `label` binds none of the inner relations (`U`, `V`), so it is a genuine
     // correlated reference to the outer `T.label` — bound per outer row. `U`
     // holds a row, so the `EXISTS` is TRUE for the `T` row whose `label` is 100
     // (row 1) and FALSE for row 2 (`label` 200).
@@ -1417,10 +1417,10 @@ struct CorrelatedLocalAmbiguityTests {
 // MARK: - Correlated parameters are nullable for pushdown
 
 /// A correlated column lowers to a `Term.parameter` whose per-outer-row value
-/// can be NULL, so a SLOTLESS comparison over it (`outer = 1`) can be UNKNOWN.
-/// Selection pushdown must treat such a conjunct as NULLABLE — the same
-/// treatment a `Filter.bound` parameter gets — so it never rides AHEAD of a
-/// LATER unsafe conjunct the non-short-circuiting inner `AND` still owes. Moving
+/// can be NULL, so a slotless comparison over it (`outer = 1`) can be UNKNOWN.
+/// Selection pushdown must treat such a conjunct as nullable — the same
+/// treatment a `Filter.bound` parameter gets — so it never rides ahead of a
+/// later unsafe conjunct the non-short-circuiting inner `AND` still owes. Moving
 /// it ahead would drop the UNKNOWN row before the unsafe conjunct (a `1 / 0`)
 /// runs, suppressing a throw the `AND` order owes.
 private func pushdown() throws -> FixtureCatalog {
@@ -1432,7 +1432,7 @@ private func pushdown() throws -> FixtureCatalog {
     Relation("P", ["j": .integer]) {
       Row(1)
     }
-    // A single `Q` row whose `y` is zero, so `(1 / Q.y) = 0` FAULTS `.divide`
+    // A single `Q` row whose `y` is zero, so `(1 / Q.y) = 0` faults `.divide`
     // when reached.
     Relation("Q", ["j": .integer, "y": .integer]) {
       Row(1, 0)
@@ -1448,7 +1448,7 @@ struct CorrelatedPushdownNullableTests {
     // `AND` (which does NOT short-circuit an UNKNOWN left) reaches `(1 / Q.y)
     // = 0` on the matching P×Q pair — a `.divide`. Treating the correlated
     // `T.k = 1` as non-nullable would let pushdown descend it below the join,
-    // dropping the pair BEFORE the divide and hiding the fault; treating it
+    // dropping the pair before the divide and hiding the fault; treating it
     // nullable (like a `.bound`) keeps it ahead of the unsafe conjunct, so the
     // divide runs and faults.
     let sql = """
@@ -1462,14 +1462,14 @@ struct CorrelatedPushdownNullableTests {
 
 // MARK: - A qualifier-shadowing local alias is a hard error, not correlation
 
-/// A QUALIFIED correlated reference resolves against its OWN relations first: a
-/// qualifier a LOCAL relation answers (its alias, else its table name) that
-/// names a column the relation LACKS is a hard `SQLError.column` — the local
-/// alias SHADOWS a same-qualifier ENCLOSING relation, so the miss faults
+/// A qualified correlated reference resolves against its own relations first: a
+/// qualifier a local relation answers (its alias, else its table name) that
+/// names a column the relation lacks is a hard `SQLError.column` — the local
+/// alias shadows a same-qualifier enclosing relation, so the miss faults
 /// against the inner relation rather than falling through to bind the outer
-/// one. Only a qualifier NO local relation answers (a genuine correlated
-/// reference) walks outward. Two shapes exercise this: a SINGLE-relation inner
-/// subquery whose alias matches an outer alias (Item 1), and a JOINED inner
+/// one. Only a qualifier no local relation answers (a genuine correlated
+/// reference) walks outward. Two shapes exercise this: a single-relation inner
+/// subquery whose alias matches an outer alias (Item 1), and a joined inner
 /// scope whose local alias matches an outer alias (Item 2).
 private func shadowing() throws -> FixtureCatalog {
   try Catalog {
@@ -1478,8 +1478,8 @@ private func shadowing() throws -> FixtureCatalog {
     Relation("T", ["v": .integer]) {
       Row(1)
     }
-    // The inner source `S` — aliased `x` inside the subquery — carries NO
-    // column `v`, so `x.v` against it is a QUALIFIED MISS on the local alias.
+    // The inner source `S` — aliased `x` inside the subquery — carries no
+    // column `v`, so `x.v` against it is a qualified miss on the local alias.
     Relation("S", ["w": .integer]) {
       Row(1)
     }
@@ -1495,7 +1495,7 @@ struct CorrelatedQualifierShadowTests {
       throws {
     // Item 1. Under outer `T AS x(v)`, the subquery `(SELECT 1 FROM S AS x
     // WHERE x.v = 1)` names `x.v` — the local alias `x` (the inner `S AS x`)
-    // answers the qualifier but LACKS `v`, a hard `.column`. It must NOT fall
+    // answers the qualifier but lacks `v`, a hard `.column`. It must NOT fall
     // through to read the outer `T AS x`'s `v`. Pre-fix the `try?` swallowed
     // the miss and correlated to the outer `x.v`, silently succeeding.
     let sql = """
@@ -1506,7 +1506,7 @@ struct CorrelatedQualifierShadowTests {
   }
 
   @Test func `a single-relation qualifier shadow faults the check`() throws {
-    // The schema path faults the SAME `SQLError.column("v")`, keeping
+    // The schema path faults the same `SQLError.column("v")`, keeping
     // typecheck↔run parity — the derive probe shadows the outer alias too.
     let sql = """
         SELECT v FROM T AS x \
@@ -1519,9 +1519,9 @@ struct CorrelatedQualifierShadowTests {
   }
 
   @Test func `a joined qualifier shadow faults, not correlates`() throws {
-    // Item 2. Under outer `T AS x(v)`, the JOINED inner scope `S AS x JOIN R
+    // Item 2. Under outer `T AS x(v)`, the joined inner scope `S AS x JOIN R
     // ON x.w = R.w` binds a local alias `x` (the inner `S`). An inner `x.v`
-    // names the local `x`, which LACKS `v` — a hard `.column` shadowing the
+    // names the local `x`, which lacks `v` — a hard `.column` shadowing the
     // outer `x`. Pre-fix the blanket `.column`→`nil` in `find` let the lookup
     // walk outward and rebind `x.v` to the OUTER row.
     let sql = """
@@ -1533,9 +1533,9 @@ struct CorrelatedQualifierShadowTests {
   }
 
   @Test func `a joined qualifier shadow faults the check`() throws {
-    // The schema path faults the SAME `SQLError.column("v")` for the joined
+    // The schema path faults the same `SQLError.column("v")` for the joined
     // shape — `Scope.find` propagates the qualified miss rather than swallowing
-    // it — so validation and run AGREE.
+    // it — so validation and run agree.
     let sql = """
         SELECT v FROM T AS x \
         WHERE EXISTS (SELECT 1 FROM S AS x JOIN R ON x.w = R.w \
@@ -1549,7 +1549,7 @@ struct CorrelatedQualifierShadowTests {
 
   @Test func `a qualifier no local relation answers still correlates`()
       throws {
-    // PARITY. A genuinely-correlated qualified reference — the qualifier `T` is
+    // parity. A genuinely-correlated qualified reference — the qualifier `T` is
     // NOT a local alias of the inner `S AS s` — still correlates to the outer
     // `T` and works: `T.v` binds the outer row (1), so `s.w = T.v` matches the
     // lone `S` row and the EXISTS is TRUE, projecting the outer `v`.
@@ -1564,12 +1564,12 @@ struct CorrelatedQualifierShadowTests {
 
 // MARK: - Per-occurrence prefix/correlation resolution
 
-/// The join-prefix correlation plan is keyed PER OCCURRENCE, not by inner SQL
-/// text. The SAME `EXISTS (SELECT … WHERE X.k = x)` in an early `JOIN … ON`
-/// (whose PREFIX exposes `x` in only ONE relation) and in the `WHERE` (whose
-/// FULL scope exposes `x` in TWO relations) resolves EACH against ITS site's
+/// The join-prefix correlation plan is keyed per occurrence, not by inner SQL
+/// text. The same `EXISTS (SELECT … WHERE X.k = x)` in an early `JOIN … ON`
+/// (whose prefix exposes `x` in only one relation) and in the `WHERE` (whose
+/// FULL scope exposes `x` in two relations) resolves each against its site's
 /// scope: the `ON` occurrence binds the prefix's lone `x`, while the `WHERE`
-/// occurrence resolves against the full scope and REJECTS the now-ambiguous `x`
+/// occurrence resolves against the full scope and rejects the now-ambiguous `x`
 /// — not reusing the first occurrence's narrower prefix binding.
 private func occurrence() throws -> FixtureCatalog {
   try Catalog {
@@ -1581,7 +1581,7 @@ private func occurrence() throws -> FixtureCatalog {
     Relation("B", ["b": .integer]) {
       Row(1)
     }
-    // A later-joined relation that ALSO exposes `x`, making a bare `x`
+    // A later-joined relation that also exposes `x`, making a bare `x`
     // ambiguous in the full `WHERE` scope.
     Relation("C", ["x": .integer]) {
       Row(1)
@@ -1607,11 +1607,11 @@ struct CorrelatedOccurrenceScopeTests {
   }
 
   @Test func `a WHERE occurrence resolves against the full scope`() throws {
-    // The IDENTICAL `EXISTS (SELECT 1 FROM X WHERE X.k = x)` also appears in the
-    // `WHERE`, AFTER `C` (which also exposes `x`) has joined. Its correlated `x`
+    // The identical `EXISTS (SELECT 1 FROM X WHERE X.k = x)` also appears in the
+    // `WHERE`, after `C` (which also exposes `x`) has joined. Its correlated `x`
     // is out of `X`'s own relation and correlates against the FULL `{A, B, C}`
-    // scope, where `x` is bound by BOTH `A` and `C` — an AMBIGUOUS enclosing
-    // reference. The correlation lookup faults `SQLError.ambiguous` per ITS
+    // scope, where `x` is bound by both `A` and `C` — an ambiguous enclosing
+    // reference. The correlation lookup faults `SQLError.ambiguous` per its
     // site (the nearer ambiguous scope shadows any farther one) rather than
     // reusing the `ON` occurrence's unambiguous prefix `A.x`.
     let sql = """
@@ -1624,7 +1624,7 @@ struct CorrelatedOccurrenceScopeTests {
   }
 
   @Test func `a WHERE occurrence faults the check per its site`() throws {
-    // The schema path resolves each occurrence per ITS site too, so the WHERE
+    // The schema path resolves each occurrence per its site too, so the WHERE
     // occurrence faults `SQLError.ambiguous("x")` at `columns(of:)` exactly as
     // the run does — typecheck↔run parity, not the first occurrence's prefix.
     let sql = """
@@ -1643,12 +1643,12 @@ struct CorrelatedOccurrenceScopeTests {
 
 // MARK: - A correlated EXISTS probe honours the outer run's lenience
 
-/// A CORRELATED `EXISTS` recompiles its cardinality PROBE per occurrence, and
+/// A correlated `EXISTS` recompiles its cardinality probe per occurrence, and
 /// that recompile must inherit the enclosing run's `validate` flag rather than
 /// silently defaulting to a strict schema check. An outer `run` (`validate:
 /// false`) proves the query runnable and must NOT eager-type-check a
 /// data-dependent-empty derived body the probe never reaches; a strict
-/// `columns(of:validate:true)` over the SAME query still faults it — parity
+/// `columns(of:validate:true)` over the same query still faults it — parity
 /// in both directions.
 private func lenient() throws -> FixtureCatalog {
   try Catalog {
@@ -1658,7 +1658,7 @@ private func lenient() throws -> FixtureCatalog {
     }
     // The inner source whose derived body projects `Label + 1` — text plus
     // integer, a `.operand` fault WHEN type-checked — under a `WHERE k = 0`
-    // that matches NO row, so a run empties the body before it ever evaluates
+    // that matches no row, so a run empties the body before it ever evaluates
     // the projection.
     Relation("S", ["k": .integer, "Label": .text]) {
       Row(5, "a")
@@ -1671,7 +1671,7 @@ struct CorrelatedExistsProbeLenienceTests {
     // `EXISTS (SELECT 1 FROM (SELECT Label + 1 AS x FROM S WHERE k = 0) AS d
     // WHERE d.x = T.id)`: the derived body's `WHERE k = 0` filters every `S`
     // row, so `Label + 1` never runs. The correlated EXISTS recompiles its
-    // PROBE per outer row; under the lenient outer run that recompile must
+    // probe per outer row; under the lenient outer run that recompile must
     // trust the filtered-out projection rather than fault `.operand`. The body
     // is empty, so the EXISTS is FALSE for the sole `T` row and the run yields
     // no rows.
@@ -1684,7 +1684,7 @@ struct CorrelatedExistsProbeLenienceTests {
   }
 
   @Test func `a strict check still faults the probe's body`() throws {
-    // Parity: a strict `columns(of:validate:true)` over the SAME query eager-
+    // Parity: a strict `columns(of:validate:true)` over the same query eager-
     // type-checks the derived body's reachable projection and faults its ill-
     // typed `Label + 1`, so the schema path advertises nothing for a query a
     // run would fault once a row reached the projection.
@@ -1705,7 +1705,7 @@ struct CorrelatedExistsProbeLenienceTests {
 
 // MARK: - FROM-less scope frame (correlation across an empty frame)
 
-/// A FROM-less SELECT is STILL a scope FRAME. The example
+/// A FROM-less SELECT is still a scope frame. The example
 /// `SELECT id FROM T WHERE (SELECT CASE WHEN EXISTS (SELECT 1 FROM S WHERE
 /// S.x = T.id) THEN 1 END) = 1` nests a FROM-less middle scalar subquery whose
 /// own body holds an `EXISTS` correlating to the OUTER `T` — a scope past the
@@ -1731,8 +1731,8 @@ struct FromlessScopeFrameTests {
   @Test func `a correlation across a FROM-less frame runs per outer row`()
       throws {
     // The middle `(SELECT CASE WHEN EXISTS (...) THEN 1 END)` is FROM-less, so
-    // its plan runs over a single EMPTY record. The inner `EXISTS`'s `T.id`
-    // names the OUTER `T`, one frame OUT past the empty FROM-less frame — so it
+    // its plan runs over a single empty record. The inner `EXISTS`'s `T.id`
+    // names the OUTER `T`, one frame out past the empty FROM-less frame — so it
     // resolves `.bound` and threads through per outer `T` row, rather than
     // binding a `.slot` of the empty record (which would trap or read wrong).
     // `S.x` ∈ {2, 3}, so the CASE is 1 for `T` rows 2 and 3.
@@ -1748,7 +1748,7 @@ struct FromlessScopeFrameTests {
 
   @Test func `a correlation across a FROM-less frame validates`() throws {
     // The schema path resolves the correlation threaded through the FROM-less
-    // frame the SAME as the run — no `SQLError.column` on the enclosing `T.id`.
+    // frame the same as the run — no `SQLError.column` on the enclosing `T.id`.
     let query = try parse(query:
         """
         SELECT id FROM T \
@@ -1765,8 +1765,8 @@ struct FromlessScopeFrameTests {
 struct ImmediateCorrelationParityTests {
   @Test func `a directly correlated EXISTS with a real FROM stays a slot`()
       throws {
-    // PARITY: the SAME inner `EXISTS (SELECT 1 FROM S WHERE S.x = T.id)` with
-    // NO FROM-less middle correlates to the IMMEDIATE enclosing `T` — one real
+    // parity: the same inner `EXISTS (SELECT 1 FROM S WHERE S.x = T.id)` with
+    // no FROM-less middle correlates to the immediate enclosing `T` — one real
     // frame out — so it resolves `.slot` and reads the outer row directly. The
     // FROM-less empty-frame rule must not over-thread this immediate case.
     // `S.x` ∈ {2, 3}, so only `T` rows 2 and 3 satisfy the EXISTS.

--- a/Tests/SQLTests/Queries/SubqueryTests.swift
+++ b/Tests/SQLTests/Queries/SubqueryTests.swift
@@ -200,7 +200,7 @@ struct InQueryNullCornerTests {
 
   @Test func `NOT IN over an empty subquery is TRUE`() throws {
     // `NOT IN (empty)` is the negation of FALSE — TRUE — so every row survives,
-    // including row 3 whose K is NULL (the NULL trap needs a NULL ELEMENT, and
+    // including row 3 whose K is NULL (the NULL trap needs a NULL element, and
     // an empty subquery has none).
     try fixture().expect(
         "SELECT Id FROM T WHERE K NOT IN (SELECT V FROM S WHERE Flag = 9)",
@@ -222,7 +222,7 @@ struct InQueryNullCornerTests {
 struct InQueryArityTests {
   @Test func `IN over a two-column subquery faults with an arity error`()
       throws {
-    // `IN (Q)` requires `Q` project exactly ONE column; a two-column subquery
+    // `IN (Q)` requires `Q` project exactly one column; a two-column subquery
     // is `SQLError.arity`, checked from the compiled width, so it faults even
     // though S has rows.
     try fixture().expect(
@@ -232,7 +232,7 @@ struct InQueryArityTests {
 
   @Test func `IN over a two-column subquery faults the schema check too`()
       throws {
-    // The schema path enforces the SAME single-column arity as the run, so
+    // The schema path enforces the same single-column arity as the run, so
     // validation matches execution.
     let query = try parse(query:
          "SELECT Id FROM T WHERE K IN (SELECT V, Flag FROM S)")
@@ -300,7 +300,7 @@ struct SubqueryTypeCheckingTests {
   @Test func `an EXISTS select-list fault is not validated`() throws {
     // The run of an EXISTS-only occurrence goes through the cardinality probe,
     // whose constant projection never evaluates the original `1 / 0` select
-    // list — so validation type-checks the PROBED shape and does NOT surface a
+    // list — so validation type-checks the probed shape and does NOT surface a
     // `.divide` the run never raises. Validation matches the run: `columns`
     // returns clean headers and the query runs, admitting every `T` row.
     let query =
@@ -314,8 +314,8 @@ struct SubqueryTypeCheckingTests {
 
   @Test func `an IN select-list fault is validated`() throws {
     // An `IN (Q)` reads the select-list column, so the run evaluates it — and
-    // validation type-checks the ORIGINAL shape, surfacing the `.divide` at
-    // BOTH validate and run, unlike the EXISTS probe.
+    // validation type-checks the original shape, surfacing the `.divide` at
+    // both validate and run, unlike the EXISTS probe.
     let query =
         try parse(query: "SELECT Id FROM T WHERE K IN (SELECT 1 / 0 FROM S)")
     let resolve = { () throws -> Array<OutputColumn> in
@@ -329,7 +329,7 @@ struct SubqueryTypeCheckingTests {
   }
 
   @Test func `an EXISTS bad inner relation is still validated`() throws {
-    // The probe RETAINS the subquery's FROM/`WHERE`, so a genuinely-bad inner
+    // The probe retains the subquery's FROM/`WHERE`, so a genuinely-bad inner
     // relation still faults validation for an EXISTS-only occurrence — only the
     // select list and sort keys are spared, not the row source.
     let query =
@@ -365,7 +365,7 @@ private func ordered() throws -> FixtureCatalog {
 // subquery shape pre-pass runs with `validating(false)`. So the reached
 // re-validation seam must validate the carrier's sort keys too — else
 // `columns(of:)` accepts a bad sort key a run faults, a run-vs-validate
-// divergence. It stays REACHED-only: an unreached ordered subquery's bad key is
+// divergence. It stays reached-only: an unreached ordered subquery's bad key is
 // deferred, matching the dead-scalar/dead-EXISTS posture.
 struct ReachedOrderedSubqueryTests {
   @Test func `a reached scalar bad sort key faults run and validate alike`()
@@ -424,7 +424,7 @@ struct ReachedOrderedSubqueryTests {
       throws {
     // The `IN` occurrence sits behind a statically-false `AND`, so the executor
     // never materialises it and the reachability walk never records it — its
-    // carrier's bad sort key is DEFERRED, matching the dead-subquery posture.
+    // carrier's bad sort key is deferred, matching the dead-subquery posture.
     let query = try parse(query: """
         SELECT a FROM L
           WHERE 1 = 0
@@ -506,7 +506,7 @@ struct OrderBySubqueryTests {
 
 struct AggregateSubqueryTests {
   @Test func `an EXISTS in an aggregate argument is materialised`() throws {
-    // The subquery in the aggregate ARGUMENT must be materialised like any
+    // The subquery in the aggregate argument must be materialised like any
     // other projection subquery. S is non-empty, so the CASE folds to K, and
     // SUM over T's non-NULL K ({10, 20, 30}) is 60.
     try fixture().expect(
@@ -601,11 +601,11 @@ struct AggregateSubqueryTests {
   @Test func `columns validates a grouped ORDER BY CORRELATED subquery`()
       throws {
     // Batch 7, Item 1: a grouped query whose ORDER BY aggregate argument nests
-    // a CORRELATED subquery (`S.V = T.K`, the inner `T.K` an outer column of the
+    // a correlated subquery (`S.V = T.K`, the inner `T.K` an outer column of the
     // grouped select). The run path's `group` gives the ORDER BY subquery
-    // lowering the enclosing scope, so it resolves `T.K` and runs; VALIDATION
-    // must thread the SAME enclosing scope, else it compiles the inner query
-    // with NO outer scope and falsely faults `SQLError.column("K")`. It must
+    // lowering the enclosing scope, so it resolves `T.K` and runs; validation
+    // must thread the same enclosing scope, else it compiles the inner query
+    // with no outer scope and falsely faults `SQLError.column("K")`. It must
     // succeed exactly as the run does.
     let query = try parse(query:
         "SELECT K FROM T GROUP BY K "
@@ -645,9 +645,9 @@ private final class Counter: @unchecked Sendable {
   }
 }
 
-/// A subquery executes at RUN time, not during `compile` — so a SCHEMA-ONLY
-/// path (`columns(of:)`) opens NO cursor and runs no inner query, and a run
-/// materialises each UNCORRELATED subquery at most ONCE.
+/// A subquery executes at run time, not during `compile` — so a schema-ONLY
+/// path (`columns(of:)`) opens no cursor and runs no inner query, and a run
+/// materialises each uncorrelated subquery at most once.
 ///
 /// This is the architectural fix: PR-1 materialised subqueries eagerly in
 /// `compile`, so asking for the headers of a query nesting an
@@ -681,11 +681,11 @@ struct SubqueryDeferralTests {
 
   @Test func `columns defers a select-list fault an EXISTS probe skips`()
       throws {
-    // The subquery's select list divides by a NON-constant zero (`Flag - 1`,
+    // The subquery's select list divides by a non-constant zero (`Flag - 1`,
     // which is 0 for S's two `Flag = 1` rows), but it is used ONLY by `EXISTS`,
     // which needs cardinality — not the projected value. `columns(of:)` returns
-    // the headers WITHOUT triggering the divide (the schema path opens no
-    // cursor), and the RUN materialises the occurrence as a cardinality PROBE
+    // the headers without triggering the divide (the schema path opens no
+    // cursor), and the run materialises the occurrence as a cardinality probe
     // that never evaluates the select list, so it does NOT fault either:
     // `EXISTS` over non-empty `S` is TRUE, every row of `T` is admitted.
     let query = try parse(query:
@@ -716,7 +716,7 @@ struct SubqueryDeferralTests {
   @Test func `an EXISTS subquery probes cardinality without its select list`()
       throws {
     // The subquery is used ONLY by `EXISTS`, which needs cardinality — not the
-    // projected value — so it materialises as a PROBE that never evaluates the
+    // projected value — so it materialises as a probe that never evaluates the
     // select list. `tick()` sits in the select list, so the probe never invokes
     // it: the counter stays 0 (not 3, not 12), and
     // `EXISTS` over non-empty `S` is still TRUE, admitting every row of `T`.
@@ -745,10 +745,10 @@ struct SubqueryDeferralTests {
 
   @Test func `a short-circuited subquery still materialises (follow-up)`()
       throws {
-    // KNOWN LIMITATION of this slice: subqueries materialise at the START of a
-    // run, so one in an arm an `AND`/`OR` short-circuit would never reach STILL
+    // known limitation of this slice: subqueries materialise at the start of a
+    // run, so one in an arm an `AND`/`OR` short-circuit would never reach still
     // executes. `1 = 0 AND EXISTS (…)` is statically FALSE, yet the subquery is
-    // materialised up front — here as an EXISTS cardinality PROBE, which never
+    // materialised up front — here as an EXISTS cardinality probe, which never
     // evaluates the select-list `tick()`, so the counter stays 0. Per-arm
     // laziness — threading a runner to the evaluation site so an unreached arm
     // skips its subquery — is a follow-up; the once-per-run materialisation
@@ -766,11 +766,11 @@ struct SubqueryDeferralTests {
 
 // MARK: - EXISTS cardinality probe
 
-/// An `EXISTS (Q)` occurrence is materialised as a cardinality PROBE — the row
-/// source is tested for ANY row WITHOUT evaluating the select list or sort
+/// An `EXISTS (Q)` occurrence is materialised as a cardinality probe — the row
+/// source is tested for ANY row without evaluating the select list or sort
 /// keys, honouring the subquery's original `OFFSET`/`FETCH` — while an `IN (Q)`
 /// occurrence materialises its single column of values. So a fault or a per-row
-/// side effect that lives in an EXISTS subquery's SELECT LIST never fires, but
+/// side effect that lives in an EXISTS subquery's SELECT list never fires, but
 /// an `IN`'s column is still read.
 struct ExistsProbeTests {
   private func fixture() throws -> FixtureCatalog {
@@ -789,10 +789,10 @@ struct ExistsProbeTests {
 
   @Test func `EXISTS over a dividing select list is safe when non-empty`()
       throws {
-    // `SELECT 1 / 0 FROM S` divides by a CONSTANT zero — a run of its select
+    // `SELECT 1 / 0 FROM S` divides by a constant zero — a run of its select
     // list would fault `.divide`. Used by `EXISTS`, it materialises as a probe
     // that never evaluates the select list, so `EXISTS` over the non-empty `S`
-    // is TRUE with NO `.divide` — every row of `T` is admitted.
+    // is TRUE with no `.divide` — every row of `T` is admitted.
     try fixture().expect("SELECT Id FROM T WHERE EXISTS (SELECT 1 / 0 FROM S)",
                          yields: [[1], [2]])
   }
@@ -823,7 +823,7 @@ struct ExistsProbeTests {
   }
 
   @Test func `IN over a dividing select list still faults`() throws {
-    // Because `IN` reads the column, a dividing select list DOES fault — the
+    // Because `IN` reads the column, a dividing select list does fault — the
     // opposite of the `EXISTS` probe — proving the two occurrences materialise
     // differently.
     try fixture().expect("SELECT Id FROM T WHERE K IN (SELECT 1 / 0 FROM S)",
@@ -840,7 +840,7 @@ struct ExistsProbeTests {
   }
 
   @Test func `EXISTS honours a FETCH FIRST 0 ROWS limit as FALSE`() throws {
-    // The probe keeps the subquery's ORIGINAL `FETCH FIRST 0 ROWS ONLY`, so the
+    // The probe keeps the subquery's original `FETCH FIRST 0 ROWS ONLY`, so the
     // row source yields zero rows and `EXISTS` is FALSE — a synthetic one-row
     // cap must NOT override the original limit. Every outer row is dropped, and
     // the dividing select list still never evaluates (no `.divide`).
@@ -875,7 +875,7 @@ struct ExistsProbeTests {
 /// A `DISTINCT` EXISTS-only subquery is probed too, provided it carries no
 /// `OFFSET`: `DISTINCT` collapses a non-empty source to at least one distinct
 /// row, so `SELECT DISTINCT 1 FROM S` is non-empty iff `S` is — the constant
-/// projection preserves existence WITHOUT evaluating the original select list.
+/// projection preserves existence without evaluating the original select list.
 /// A `DISTINCT` EXISTS WITH an `OFFSET` stays a FULL run: an offset skips
 /// distinct rows, so emptiness depends on the REAL distinct count, which the
 /// constant projection would collapse.
@@ -899,7 +899,7 @@ struct DistinctExistsProbeTests {
   @Test func `DISTINCT EXISTS over a dividing select list is safe`() throws {
     // A `DISTINCT` EXISTS without an `OFFSET` is probed — `SELECT DISTINCT 1`
     // yields one distinct row iff `S` is non-empty — so the original `1 / 0`
-    // select list never evaluates and `EXISTS` is TRUE with NO `.divide`.
+    // select list never evaluates and `EXISTS` is TRUE with no `.divide`.
     try fixture().expect(
         "SELECT Id FROM T WHERE EXISTS (SELECT DISTINCT 1 / 0 FROM S)",
         yields: [[1], [2]])
@@ -916,7 +916,7 @@ struct DistinctExistsProbeTests {
 
   @Test func `columns validates a DISTINCT EXISTS dividing select list`()
       throws {
-    // The type-check validates the SAME probed shape the run evaluates, so the
+    // The type-check validates the same probed shape the run evaluates, so the
     // `1 / 0` select list is not checked and validation is clean — matching the
     // run, which does not fault.
     let query = try parse(query:
@@ -974,12 +974,12 @@ struct DistinctExistsProbeTests {
 
 // MARK: - Aggregate EXISTS cardinality probe
 
-/// An aggregate/grouped EXISTS-only subquery WITHOUT a `HAVING` is probed too,
+/// An aggregate/grouped EXISTS-only subquery without a `HAVING` is probed too,
 /// via a cardinality/group-preserving shape whose target is a trivial
-/// `COUNT(*)` (the original target is irrelevant to existence). A WHOLE-RESULT
-/// aggregate (no `GROUP BY`) yields EXACTLY ONE row regardless of the source —
-/// even an empty one — so `EXISTS` is TRUE modulo the limit; a GROUPED one
-/// yields ONE ROW PER GROUP, so existence is the source's non-emptiness after
+/// `COUNT(*)` (the original target is irrelevant to existence). A whole-result
+/// aggregate (no `GROUP BY`) yields exactly one row regardless of the source —
+/// even an empty one — so `EXISTS` is TRUE modulo the limit; a grouped one
+/// yields one ROW per GROUP, so existence is the source's non-emptiness after
 /// `WHERE`. The probe keeps FROM/`WHERE`/`GROUP BY` and the original
 /// `OFFSET`/`FETCH` but never evaluates the original target, so `SUM(1 / 0)`
 /// does not fault. A `HAVING` subquery is NOT probed — group survival depends
@@ -1004,7 +1004,7 @@ struct AggregateExistsProbeTests {
       throws {
     // A whole-result `SUM(1 / 0)` would fault `.divide` if run. Used by an
     // EXISTS-only occurrence, it probes via `COUNT(*)`, which yields exactly
-    // one row over the non-empty `S` — so `EXISTS` is TRUE with NO `.divide`
+    // one row over the non-empty `S` — so `EXISTS` is TRUE with no `.divide`
     // and every outer row is admitted.
     try fixture().expect(
         "SELECT Id FROM T WHERE EXISTS (SELECT SUM(1 / 0) FROM S)",
@@ -1013,7 +1013,7 @@ struct AggregateExistsProbeTests {
 
   @Test func `whole-result aggregate EXISTS over an empty source is TRUE`()
       throws {
-    // A whole-result aggregate yields EXACTLY ONE row even over an empty source
+    // A whole-result aggregate yields exactly one row even over an empty source
     // (`SUM` of no rows is NULL, but it is still one row), so its probe —
     // `COUNT(*)` over the empty `S` — yields one row and `EXISTS` is TRUE. The
     // dividing target still never evaluates.
@@ -1024,7 +1024,7 @@ struct AggregateExistsProbeTests {
   }
 
   @Test func `columns validates a whole-result aggregate EXISTS`() throws {
-    // The type-check validates the SAME probed `COUNT(*)` shape the run uses,
+    // The type-check validates the same probed `COUNT(*)` shape the run uses,
     // so the `1 / 0` target is not checked — clean, matching the run.
     let query = try parse(query:
          "SELECT Id FROM T WHERE EXISTS (SELECT SUM(1 / 0) FROM S)")
@@ -1046,7 +1046,7 @@ struct AggregateExistsProbeTests {
       throws {
     // A grouped `SUM(1 / 0)` probes via `COUNT(*)` keeping the `GROUP BY`,
     // which yields one row per group — the non-empty `S` has groups, so
-    // `EXISTS` is TRUE with NO `.divide` and every outer row is admitted.
+    // `EXISTS` is TRUE with no `.divide` and every outer row is admitted.
     try fixture().expect(
         "SELECT Id FROM T "
         + "WHERE EXISTS (SELECT SUM(1 / 0) FROM S GROUP BY Flag)",
@@ -1055,8 +1055,8 @@ struct AggregateExistsProbeTests {
 
   @Test func `grouped aggregate EXISTS over an empty source is FALSE`()
       throws {
-    // A grouped aggregate yields ONE ROW PER GROUP, so an empty source has NO
-    // groups and NO rows — unlike the whole-result case — so the probe yields
+    // A grouped aggregate yields one ROW per GROUP, so an empty source has no
+    // groups and no rows — unlike the whole-result case — so the probe yields
     // nothing and `EXISTS` is FALSE. Every outer row is dropped.
     try fixture().expect(
         "SELECT Id FROM T WHERE EXISTS "
@@ -1065,7 +1065,7 @@ struct AggregateExistsProbeTests {
   }
 
   @Test func `columns validates a grouped aggregate EXISTS`() throws {
-    // The probed grouped `COUNT(*)` shape validates the SAME way the run does,
+    // The probed grouped `COUNT(*)` shape validates the same way the run does,
     // so the `1 / 0` target is not checked — clean, matching the run.
     let query = try parse(query:
         "SELECT Id FROM T WHERE EXISTS "
@@ -1094,7 +1094,7 @@ struct AggregateExistsProbeTests {
 
   @Test func `HAVING aggregate EXISTS runs a dividing aggregate`() throws {
     // Because a `HAVING` subquery is a full run, an aggregate-in-`HAVING`
-    // `1 / 0` is genuinely NEEDED to decide group survival, so it faults
+    // `1 / 0` is genuinely needed to decide group survival, so it faults
     // `.divide` — the probe was not taken.
     try fixture().expect(
         "SELECT Id FROM T WHERE EXISTS "
@@ -1103,7 +1103,7 @@ struct AggregateExistsProbeTests {
   }
 
   @Test func `aggregate EXISTS still faults a bad inner relation`() throws {
-    // The probe RETAINS the subquery's FROM/`WHERE`/`GROUP BY`, so a
+    // The probe retains the subquery's FROM/`WHERE`/`GROUP BY`, so a
     // genuinely-bad inner relation still faults — only the target is spared.
     try fixture().expect(
         "SELECT Id FROM T WHERE EXISTS (SELECT SUM(V) FROM Nope GROUP BY Flag)",
@@ -1113,7 +1113,7 @@ struct AggregateExistsProbeTests {
   @Test func `IN over an aggregate subquery still evaluates its target`()
       throws {
     // An aggregate IN subquery is unaffected by the EXISTS probe: `IN` reads
-    // the aggregate VALUE, so the target runs and a dividing one faults.
+    // the aggregate value, so the target runs and a dividing one faults.
     try fixture().expect(
         "SELECT Id FROM T WHERE K IN (SELECT SUM(1 / 0) FROM S)",
         fails: .divide)
@@ -1125,7 +1125,7 @@ struct AggregateExistsProbeTests {
 /// A reserved `definition_schema.`/`information_schema.` relation named ONLY
 /// inside a nested `EXISTS`/`IN (subquery)` is augmented into the context — the
 /// relation-name collector descends into subqueries, so the store overlay is
-/// materialised before the subquery's WIDTH compile AND its run, exactly as if
+/// materialised before the subquery's width compile AND its run, exactly as if
 /// the outer query had named it. The outer relation `T` names no reserved
 /// relation, so the coverage comes entirely from the descent.
 struct SubqueryReservedRelationTests {
@@ -1141,7 +1141,7 @@ struct SubqueryReservedRelationTests {
   @Test func `EXISTS over definition_schema.tables compiles and runs`() throws {
     // The reserved store relation is named ONLY inside the subquery. Before the
     // fix its overlay was not materialised (the collector did not descend), so
-    // the WIDTH compile faulted `SQLError.relation`. It now resolves and, since
+    // the width compile faulted `SQLError.relation`. It now resolves and, since
     // `definition_schema.tables` lists `T`, `EXISTS` is TRUE for every row.
     try fixture().expect(
         "SELECT Id FROM T "
@@ -1248,7 +1248,7 @@ struct SubqueryConditionalValidationTests {
 
 /// An outer `WHERE EXISTS/IN (Q)` conjunct that pushes INTO a simple view still
 /// resolves against the result the top-level `run` materialised: the view
-/// sub-plan INHERITS (merges) the caller's subquery cache rather than replacing
+/// sub-plan inherits (merges) the caller's subquery cache rather than replacing
 /// it with a view-body-only one. Without the merge the pushed conjunct's `Q`,
 /// keyed in the caller's cache, would be missing from the view-only cache and
 /// fault "a subquery result was not materialised".
@@ -1272,7 +1272,7 @@ struct ViewPushdownSubqueryTests {
     }
   }
 
-  /// A view whose OWN body nests an `EXISTS`, over `T` filtered by that inner
+  /// A view whose own body nests an `EXISTS`, over `T` filtered by that inner
   /// subquery — its own subquery must still resolve alongside a pushed outer
   /// one.
   private func nested() throws -> FixtureCatalog {
@@ -1289,9 +1289,9 @@ struct ViewPushdownSubqueryTests {
     }
   }
 
-  /// The INVERSE of `nested`: the view `VN`'s body has the SAME
-  /// `EXISTS (SELECT V FROM S)` but over an EMPTY base `S`, so its body filters
-  /// EVERY row out. A caller that binds a NON-empty CTE `S` must NOT leak into
+  /// The inverse of `nested`: the view `VN`'s body has the same
+  /// `EXISTS (SELECT V FROM S)` but over an empty base `S`, so its body filters
+  /// every row out. A caller that binds a non-empty CTE `S` must NOT leak into
   /// the view body — the body reads its own (empty) base.
   private func hollow() throws -> FixtureCatalog {
     try Catalog {
@@ -1299,7 +1299,7 @@ struct ViewPushdownSubqueryTests {
         Row(1, 10)
         Row(2, 20)
       }
-      // An EMPTY base `S`, so the view body's `EXISTS (SELECT V FROM S)` is
+      // An empty base `S`, so the view body's `EXISTS (SELECT V FROM S)` is
       // FALSE and filters every row.
       Relation("S", ["V": .integer, "Flag": .integer]) { }
       try View("VN", "SELECT Id, K FROM T WHERE EXISTS (SELECT V FROM S)",
@@ -1310,7 +1310,7 @@ struct ViewPushdownSubqueryTests {
   @Test func `an outer EXISTS pushed into a view resolves`() throws {
     // The outer `WHERE EXISTS (SELECT V FROM S)` conjunct pushes below `VW`'s
     // projection into its sub-plan; the pushed `Q` resolves against the result
-    // the top-level run materialised (the caller's cache, MERGED into the
+    // the top-level run materialised (the caller's cache, merged into the
     // view's), not a view-only cache that lacks it. S is non-empty, so the
     // EXISTS is TRUE and every view row survives.
     try view().expect("SELECT Id FROM VW WHERE EXISTS (SELECT V FROM S)",
@@ -1342,7 +1342,7 @@ struct ViewPushdownSubqueryTests {
 
   @Test func `a view body subquery and a pushed outer one both resolve`()
       throws {
-    // Both the view body's OWN `EXISTS` and the outer `EXISTS` pushed into it
+    // Both the view body's own `EXISTS` and the outer `EXISTS` pushed into it
     // must resolve — the two caches are layered. S is non-empty, so both are
     // TRUE and every row survives.
     try nested().expect("SELECT Id FROM VN WHERE EXISTS (SELECT V FROM S)",
@@ -1351,24 +1351,24 @@ struct ViewPushdownSubqueryTests {
 
   @Test func `a pushed outer subquery reads the caller CTE not the view base`()
       throws {
-    // Bug 1: the view body's `EXISTS (SELECT V FROM S)` reads BASE `S`
-    // (non-empty), and the caller's AST-IDENTICAL outer `EXISTS (SELECT V FROM
-    // S)` — pushed into the view — must read the caller's CTE `S`, an EMPTY
-    // relation shadowing the base. The two subqueries share a `Query` VALUE
-    // but resolve under DIFFERENT overlays: keying the run-time cache by the
+    // Bug 1: the view body's `EXISTS (SELECT V FROM S)` reads base `S`
+    // (non-empty), and the caller's AST-identical outer `EXISTS (SELECT V FROM
+    // S)` — pushed into the view — must read the caller's CTE `S`, an empty
+    // relation shadowing the base. The two subqueries share a `Query` value
+    // but resolve under different overlays: keying the run-time cache by the
     // `Query` alone (the old merge) collapsed them, so the pushed conjunct read
     // the view body's base-`S` result and wrongly kept every row. Layering the
     // caller's cache OVER the view's keeps the contexts distinct: the pushed
     // EXISTS reads the empty CTE and is FALSE, dropping every row, while the
     // view body's own EXISTS still reads base `S` and keeps them — so the
-    // result is EMPTY, NOT the base-table interpretation's two rows.
+    // result is empty, NOT the base-table interpretation's two rows.
     let statement = try Statement(parsing:
         "WITH S(V) AS (SELECT Id FROM T WHERE 1 = 0) "
         + "SELECT Id FROM VN WHERE EXISTS (SELECT V FROM S)")
     let rows = try nested().run(statement, .standard)
-    // The pushed EXISTS resolves against the EMPTY caller CTE — no rows left.
+    // The pushed EXISTS resolves against the empty caller CTE — no rows left.
     #expect(rows.isEmpty)
-    // And this DIFFERS from the base-table interpretation the collapsed cache
+    // And this differs from the base-table interpretation the collapsed cache
     // gave, proving the caches are kept distinct: reading base `S` (non-empty)
     // for the pushed EXISTS would have kept both view rows.
     let base: Array<Array<Value>> = [[.integer(1)], [.integer(2)]]
@@ -1377,22 +1377,22 @@ struct ViewPushdownSubqueryTests {
 
   @Test func `a view body subquery reads the view base not the caller CTE`()
       throws {
-    // Bug 2, the INVERSE direction: the VIEW BODY's `EXISTS (SELECT V FROM S)`
-    // resolves against the view's OWN base `S` (here EMPTY), and the caller's
-    // AST-IDENTICAL `WITH S AS (SELECT 1)` CTE must NOT leak into that body.
-    // Keying the run-time cache by the `Query` VALUE alone let the caller's
+    // Bug 2, the inverse direction: the VIEW body's `EXISTS (SELECT V FROM S)`
+    // resolves against the view's own base `S` (here empty), and the caller's
+    // AST-identical `WITH S AS (SELECT 1)` CTE must NOT leak into that body.
+    // Keying the run-time cache by the `Query` value alone let the caller's
     // (non-empty) CTE result win the merge, so the view body's own EXISTS
-    // wrongly read the CTE and kept every row. Keying by OCCURRENCE — each
+    // wrongly read the CTE and kept every row. Keying by occurrence — each
     // subquery's resolution `Subscope` composed with its AST — keeps the
     // contexts distinct: the body's `.view(vn)` EXISTS reads the empty base
     // and drops every row, while the caller's `.caller` pushed EXISTS reads the
-    // non-empty CTE and keeps them. The view filters CORRECTLY (its base `S` is
-    // empty), so the result is EMPTY.
+    // non-empty CTE and keeps them. The view filters correctly (its base `S` is
+    // empty), so the result is empty.
     let statement = try Statement(parsing:
         "WITH S(V) AS (SELECT 1) "
         + "SELECT Id FROM VN WHERE EXISTS (SELECT V FROM S)")
     let rows = try hollow().run(statement, .standard)
-    // The view body's EXISTS reads its EMPTY base `S`, filtering every row —
+    // The view body's EXISTS reads its empty base `S`, filtering every row —
     // NOT the caller's non-empty CTE, which would have kept both rows.
     #expect(rows.isEmpty)
     let leaked: Array<Array<Value>> = [[.integer(1)], [.integer(2)]]
@@ -1400,15 +1400,15 @@ struct ViewPushdownSubqueryTests {
   }
 
   @Test func `both subquery directions stay distinct`() throws {
-    // Prove distinctness BOTH ways against ONE catalog: the view body's EXISTS
-    // over base `S` and the caller's pushed EXISTS over CTE `S` read DIFFERENT
-    // results for the same AST. With base `S` NON-empty (view keeps rows) and
-    // the caller CTE EMPTY (pushed EXISTS drops rows), the result is EMPTY —
-    // only correct if each subquery reads its OWN context. A single collapsed
+    // Prove distinctness both ways against one catalog: the view body's EXISTS
+    // over base `S` and the caller's pushed EXISTS over CTE `S` read different
+    // results for the same AST. With base `S` non-empty (view keeps rows) and
+    // the caller CTE empty (pushed EXISTS drops rows), the result is empty —
+    // only correct if each subquery reads its own context. A single collapsed
     // entry (whichever won) could not give this: the caller-CTE value would
     // make the view body drop too (still empty, but for the wrong reason), so
     // this pairs with the base-`S`-empty/CTE-non-empty inverse above — together
-    // they pin BOTH directions.
+    // they pin both directions.
     let empty = try Statement(parsing:
         "WITH S(V) AS (SELECT Id FROM T WHERE 1 = 0) "
         + "SELECT Id FROM VN WHERE EXISTS (SELECT V FROM S)")
@@ -1426,13 +1426,13 @@ struct ViewPushdownSubqueryTests {
 
 // MARK: - IN (subquery) pushdown nullability
 
-/// An `IN (Q)` predicate is THREE-VALUED — UNKNOWN when its materialised
-/// subquery holds a NULL and nothing matches — so it must be treated NULLABLE
+/// An `IN (Q)` predicate is three-valued — UNKNOWN when its materialised
+/// subquery holds a NULL and nothing matches — so it must be treated nullable
 /// for predicate pushdown even when it is slotless (a constant operand): a
-/// conjunct carrying `IN (Q)` must NOT be pushed AHEAD of a later unsafe
+/// conjunct carrying `IN (Q)` must NOT be pushed ahead of a later unsafe
 /// conjunct, or pushdown would drop the UNKNOWN rows before the unsafe one runs
 /// and suppress a throw the non-short-circuiting `AND` owes. An `EXISTS (Q)` is
-/// genuinely TWO-valued (never UNKNOWN), so it stays freely pushable.
+/// genuinely two-valued (never UNKNOWN), so it stays freely pushable.
 struct InPushdownNullabilityTests {
   /// A view over bare `T` columns, and an `S` whose single column `N` holds
   /// only a NULL — so `1 IN (SELECT N FROM S)` is UNKNOWN (no match, a NULL
@@ -1455,18 +1455,18 @@ struct InPushdownNullabilityTests {
     // Bug 2: `1 IN (SELECT N FROM S)` is UNKNOWN (S.N is a lone NULL, no
     // match). Under the un-pushed semantics the non-short-circuiting `AND`
     // still evaluates `(1 / 0) = 0` for every view row, raising `.divide`.
-    // Classifying the slotless `IN (Q)` NON-nullable would let pushdown inject
+    // Classifying the slotless `IN (Q)` non-nullable would let pushdown inject
     // it into the view ahead of the unsafe division: the UNKNOWN rows would be
     // dropped inside the view before the outer `(1 / 0) = 0` ran, suppressing
-    // the throw. Treating `.within` as NULLABLE keeps the `IN` conjunct OUTER
-    // (a later conjunct is unsafe), so the division runs and the query THROWS.
+    // the throw. Treating `.within` as nullable keeps the `IN` conjunct OUTER
+    // (a later conjunct is unsafe), so the division runs and the query throws.
     try view().expect(
         "SELECT Id FROM VW WHERE 1 IN (SELECT N FROM S) AND (1 / 0) = 0",
         fails: .divide)
   }
 
   @Test func `an EXISTS conjunct still pushes into a view`() throws {
-    // `EXISTS (Q)` is TWO-valued — a decided non-empty test, never UNKNOWN —
+    // `EXISTS (Q)` is two-valued — a decided non-empty test, never UNKNOWN —
     // so it stays freely pushable. `S` is non-empty, so the pushed `EXISTS` is
     // TRUE and every view row survives; the pushdown resolves it against the
     // caller's materialised cache exactly as before.
@@ -1477,22 +1477,22 @@ struct InPushdownNullabilityTests {
 
 // MARK: - Lazy subquery pushdown safety
 
-/// A LAZY subquery (`EXISTS`/`IN`/quantified) is NEVER pushdown-`safe`: under
-/// lazy materialisation its FIRST evaluation RUNS the inner query, which may
-/// FAULT. A subquery conjunct beside a SEEKABLE conjunct must therefore NOT be
+/// A lazy subquery (`EXISTS`/`IN`/quantified) is never pushdown-`safe`: under
+/// lazy materialisation its FIRST evaluation runs the inner query, which may
+/// fault. A subquery conjunct beside a seekable conjunct must therefore NOT be
 /// classified safe and left as a residual over a seeked (narrowed) scan: the
 /// non-short-circuiting inner `AND` owes the throw for a row the seek skips, so
-/// riding the subquery below the seek SUPPRESSES that throw.
+/// riding the subquery below the seek suppresses that throw.
 ///
-/// `T` is SORTED on `Id`, so `Id < 0` is a seekable predicate over an EMPTY
-/// run; `S.z` is zero, so `1 / z` FAULTS `.divide` the moment the subquery is
+/// `T` is sorted on `Id`, so `Id < 0` is a seekable predicate over an empty
+/// run; `S.z` is zero, so `1 / z` faults `.divide` the moment the subquery is
 /// evaluated. With the subquery the LEFT conjunct (`subquery AND Id < 0`), the
 /// non-short-circuiting `AND` evaluates the subquery FIRST for every scanned
-/// row, so a correct run FAULTS. Pre-fix the subquery reported `safe`, so the
+/// row, so a correct run faults. Pre-fix the subquery reported `safe`, so the
 /// planner seeked on `Id < 0` (an empty run) and left the subquery a residual
-/// over ZERO rows — never evaluating it, wrongly returning zero rows and hiding
+/// over zero rows — never evaluating it, wrongly returning zero rows and hiding
 /// the throw. Post-fix the subquery is NOT safe, the seek keeps it above the
-/// scan, and the run FAULTS as the left-to-right `AND` owes.
+/// scan, and the run faults as the left-to-right `AND` owes.
 struct LazySubqueryPushdownSafetyTests {
   private func fixture() throws -> FixtureCatalog {
     try Catalog {
@@ -1510,7 +1510,7 @@ struct LazySubqueryPushdownSafetyTests {
   @Test func `an EXISTS conjunct is not seeked past a skipped row`() throws {
     // Pre-fix: the uncorrelated `EXISTS` reported `safe`, so it rode below the
     // `Id < 0` seek as a residual over the empty run and never evaluated —
-    // returning zero rows, SUPPRESSING the `.divide` the leading conjunct owes.
+    // returning zero rows, suppressing the `.divide` the leading conjunct owes.
     // Post-fix it is NOT safe, so the seek keeps it and the run faults.
     try fixture().expect(
         """
@@ -1542,7 +1542,7 @@ struct LazySubqueryPushdownSafetyTests {
 
   @Test func `an EXISTS still drops rows behind a short-circuiting filter`()
       throws {
-    // The safety change does NOT over-fault: with the SEEKABLE `Id < 0` the
+    // The safety change does NOT over-fault: with the seekable `Id < 0` the
     // LEFT conjunct, the non-short-circuiting `AND`'s Kleene evaluation returns
     // FALSE from the leading `Id < 0` for every row without reaching the
     // subquery, so the run yields zero rows rather than faulting — the subquery
@@ -1557,13 +1557,13 @@ struct LazySubqueryPushdownSafetyTests {
 
 // MARK: - Correlated subquery own derived tables
 
-/// A CORRELATED subquery with its OWN `WITH` item or derived table must AUGMENT
+/// A correlated subquery with its own `WITH` item or derived table must augment
 /// that own relation before executing its precompiled plan per outer row — the
 /// same augmentation the uncorrelated `run`/`probe` paths perform — so the
 /// derived/CTE relation binds during per-outer-row execution rather than
 /// faulting `SQLError.relation` (or resolving to an unintended base relation).
 struct CorrelatedOwnDerivationTests {
-  /// An outer `T(Id)` alone — the correlated subqueries below carry their OWN
+  /// An outer `T(Id)` alone — the correlated subqueries below carry their own
   /// inner derivation.
   private func fixture() throws -> FixtureCatalog {
     try Catalog {
@@ -1619,12 +1619,12 @@ struct CorrelatedOwnDerivationTests {
 
   @Test func `a correlated EXISTS setop binds each arm's derived table`()
       throws {
-    // The SET-OPERATION shape: the correlated `EXISTS` subquery is a `UNION
+    // The SET-operation shape: the correlated `EXISTS` subquery is a `UNION
     // ALL` whose LEFT arm derives its own `d` and correlates it `d.k = T.Id`,
     // and whose RIGHT arm is a bare `SELECT 2`. Pre-fix the correlated
-    // augment-and-execute augmented at the QUERY level, binding no arm-local
+    // augment-and-execute augmented at the query level, binding no arm-local
     // `d`, so the left arm's `.scan("d")` faulted `.relation("d")`; post-fix
-    // it augments EACH ARM, so `d` binds per outer row. The right arm always
+    // it augments each ARM, so `d` binds per outer row. The right arm always
     // yields a row, so the EXISTS is TRUE for every outer row.
     try fixture().expect(
         """
@@ -1637,11 +1637,11 @@ struct CorrelatedOwnDerivationTests {
 
   @Test func `a correlated IN setop keeps only the row its arm derives`()
       throws {
-    // A DISCRIMINATING setop: `Id IN (SELECT d.k … WHERE d.k = T.Id UNION ALL
+    // A discriminating setop: `Id IN (SELECT d.k … WHERE d.k = T.Id UNION ALL
     // SELECT 9)`. The right arm contributes the constant 9 (never an `Id`), so
     // the membership turns ONLY on the left arm's per-row correlated
     // derivation — `d.k` (1) is in the column iff `T.Id = 1`. So only the outer
-    // row `Id = 1` is kept, proving each arm augments its OWN `d` under the
+    // row `Id = 1` is kept, proving each arm augments its own `d` under the
     // per-row correlation rather than merely not faulting.
     try fixture().expect(
         """
@@ -1656,7 +1656,7 @@ struct CorrelatedOwnDerivationTests {
 // MARK: - HAVING subquery reachability
 
 /// A whole-result aggregate under a statically-false `WHERE` emits one empty
-/// group; its `HAVING EXISTS/IN (Q)` is evaluated over that group at RUN and
+/// group; its `HAVING EXISTS/IN (Q)` is evaluated over that group at run and
 /// can be TRUE (the subquery is row-independent), so the projection is
 /// potentially reachable. `columns(of:validate:)` must NOT prune it as
 /// unreachable — it validates the projection so the schema agrees with the run.
@@ -1665,7 +1665,7 @@ struct HavingSubqueryReachabilityTests {
   @Test func `a HAVING subquery keeps the projection reachable to validate`()
       throws {
     // `WHERE 1 = 0` empties the group, but `HAVING EXISTS (SELECT 1)` is TRUE
-    // at run, so the projection RUNS and its `1 / 0` raises `.divide`. The
+    // at run, so the projection runs and its `1 / 0` raises `.divide`. The
     // schema path must not falsely advertise clean headers: with the HAVING
     // carrying a subquery it is not-definitely-empty, so validation reaches the
     // projection and surfaces the same `.divide` the run raises.
@@ -1691,7 +1691,7 @@ struct HavingSubqueryReachabilityTests {
       throws {
     // No subquery in the HAVING, so the precise empty-group fold applies: the
     // constant-false `HAVING 1 = 0` drops the lone empty group, leaving the
-    // `1 / 0` projection unreachable — `columns` returns clean headers WITHOUT
+    // `1 / 0` projection unreachable — `columns` returns clean headers without
     // faulting, exactly as before this fix.
     let query = try parse(query:
         "SELECT 1 / 0 FROM T WHERE 1 = 0 HAVING 1 = 0")
@@ -1717,14 +1717,14 @@ struct HavingSubqueryReachabilityTests {
 
 // MARK: - Projection/sort subquery reachability
 
-/// The empty-fold analog of the HAVING carve-out, extended to PROJECTION and
-/// SORT expressions: a whole-result aggregate under a statically-false `WHERE`
+/// The empty-fold analog of the HAVING carve-out, extended to projection and
+/// sort expressions: a whole-result aggregate under a statically-false `WHERE`
 /// emits one empty group, and a projection/sort expression that nests an
 /// `EXISTS`/`IN (Q)` guard is potentially reachable — the subquery is
-/// row-independent and may keep the group at RUN. `columns(of:validate:)` must
-/// VALIDATE its subquery-guarded branches rather than prune them by the empty
+/// row-independent and may keep the group at run. `columns(of:validate:)` must
+/// validate its subquery-guarded branches rather than prune them by the empty
 /// fold (which treats the guard as UNKNOWN), so the schema agrees with the run.
-/// A subquery-FREE guarded expression keeps the precise empty-fold pruning.
+/// A subquery-free guarded expression keeps the precise empty-fold pruning.
 struct ProjectionSubqueryReachabilityTests {
   private func fixture() throws -> FixtureCatalog {
     try Catalog {
@@ -1741,8 +1741,8 @@ struct ProjectionSubqueryReachabilityTests {
   @Test func `columns validates a subquery-guarded projection CASE`() throws {
     // `WHERE 1 = 0` empties the group; the `CASE` guard `EXISTS (SELECT V FROM
     // S)` folds UNKNOWN in the empty fold, which would prune the THEN arm — but
-    // the subquery is TRUE at RUN, so the THEN arm's `1 / 0` runs. The empty
-    // fold must NOT prune a subquery-guarded branch: validation reaches BOTH
+    // the subquery is TRUE at run, so the THEN arm's `1 / 0` runs. The empty
+    // fold must NOT prune a subquery-guarded branch: validation reaches both
     // arms and surfaces the `.divide` the run raises.
     let query = try parse(query:
         "SELECT CASE WHEN EXISTS (SELECT V FROM S) THEN 1 / 0 "
@@ -1764,7 +1764,7 @@ struct ProjectionSubqueryReachabilityTests {
   @Test func `a subquery-free guarded projection CASE still prunes`() throws {
     // No subquery in the guard, so the precise empty-group fold applies: the
     // constant-false guard `1 = 0` selects the ELSE arm, leaving the `1 / 0`
-    // THEN unreachable — `columns` returns clean headers WITHOUT faulting,
+    // THEN unreachable — `columns` returns clean headers without faulting,
     // exactly as before this fix.
     let query = try parse(query:
         "SELECT CASE WHEN 1 = 0 THEN 1 / 0 ELSE COUNT(*) END "
@@ -1774,7 +1774,7 @@ struct ProjectionSubqueryReachabilityTests {
   }
 
   @Test func `columns validates a subquery-guarded sort CASE`() throws {
-    // The ORDER BY sits BELOW the limit and evaluates over the empty group's
+    // The ORDER BY sits below the limit and evaluates over the empty group's
     // row unconditionally, so a subquery-guarded sort expression is validated
     // the same as a projection one: the `EXISTS`-guarded `1 / 0` sort key
     // surfaces `.divide`, not a pruned clean header.
@@ -1790,9 +1790,9 @@ struct ProjectionSubqueryReachabilityTests {
 // MARK: - FROM-less scalar subqueries
 
 /// A FROM-less scalar `SELECT <expr-list>` whose projection nests an
-/// UNCORRELATED `EXISTS`/`IN (subquery)` compiles, validates, and runs exactly
+/// uncorrelated `EXISTS`/`IN (subquery)` compiles, validates, and runs exactly
 /// as the identical projection does with a FROM clause. The scalar lowering
-/// (`projection.scalar`) is the ONE compile path that otherwise threads the
+/// (`projection.scalar`) is the one compile path that otherwise threads the
 /// DEFAULT unsupported subquery map, so a subquery there faulted at compile
 /// before the run-time cache was ever built; the map is now threaded through so
 /// the term lowers, and `run`'s cache (built from `query.subqueries`, which
@@ -1843,7 +1843,7 @@ struct FromlessScalarSubqueryTests {
   @Test func `a scalar IN over a two-column subquery faults with arity`()
       throws {
     // The `IN (Q)` single-column arity is decided from the subquery's compiled
-    // WIDTH at compile — cursor-free — so a two-column subquery faults
+    // width at compile — cursor-free — so a two-column subquery faults
     // `SQLError.arity` on the FROM-less path exactly as on the FROM'd one.
     try fixture().expect(
         "SELECT CASE WHEN 1 IN (SELECT Id, K FROM T) THEN 1 ELSE 0 END",
@@ -1874,7 +1874,7 @@ struct FromlessScalarSubqueryTests {
   }
 
   @Test func `a plain scalar SELECT without a subquery is unaffected`() throws {
-    // A FROM-less scalar select carrying NO subquery lowers exactly as before —
+    // A FROM-less scalar select carrying no subquery lowers exactly as before —
     // the threaded map is empty and the projection is a plain constant.
     try fixture().expect("SELECT 1 + 2", yields: [[3]])
   }
@@ -1922,10 +1922,10 @@ struct FromlessScalarReservedRelationTests {
 
 // MARK: - Per-occurrence correlated plan cache
 
-/// Two outer relations whose correlated key `k` sits at DIFFERENT ordinals —
+/// Two outer relations whose correlated key `k` sits at different ordinals —
 /// `Outer1.k` at ordinal 0, `Outer2.k` at ordinal 1 — and one inner source
-/// `Src`, so the SAME scalar subquery SQL `(SELECT m FROM Src WHERE m = k)` in
-/// each arm of a `UNION ALL` compiles under a DIFFERENT outer layout: the left
+/// `Src`, so the same scalar subquery SQL `(SELECT m FROM Src WHERE m = k)` in
+/// each arm of a `UNION ALL` compiles under a different outer layout: the left
 /// arm binds `:__correlated_0_0`, the right `:__correlated_0_1`.
 private func layouts() throws -> FixtureCatalog {
   try Catalog {
@@ -1946,8 +1946,8 @@ private func layouts() throws -> FixtureCatalog {
   }
 }
 
-/// Batch 7, Item 2: identical CORRELATED inner SQL in two set-operation arms
-/// under DIFFERENT outer layouts must each execute the plan keyed to ITS OWN
+/// Batch 7, Item 2: identical correlated inner SQL in two set-operation arms
+/// under different outer layouts must each execute the plan keyed to its own
 /// correlation. Keying the plan cache by the occurrence `Subkey` alone
 /// (scope + query + role) collapses the two arms — same `.caller` scope, same
 /// AST, same `.scalar` role — so the right arm read the LEFT arm's plan (which
@@ -1971,14 +1971,14 @@ struct CorrelatedPlanOccurrenceTests {
   }
 }
 
-/// A join `ON` in a correlated subquery whose equality references an ENCLOSING
+/// A join `ON` in a correlated subquery whose equality references an enclosing
 /// column: an outer `T`, and a subquery joining `U` and `V` whose `ON`
 /// correlates `V.x` to the outer `T.Id`.
 ///
 /// `V.x` matches `T.Id` ∈ {1, 2}; `U` is a single row, so the correlated
 /// `EXISTS (SELECT 1 FROM U JOIN V ON V.x = T.Id)` is TRUE exactly for those
 /// outer rows. The uncorrelated parity `ON V.x = U.y` is a genuine
-/// column = column equi-join key (`U.y` = 2 matches `V.x` = 2), so it is STILL
+/// column = column equi-join key (`U.y` = 2 matches `V.x` = 2), so it is still
 /// extracted as the hash-join match key and the join runs.
 private func joined() throws -> FixtureCatalog {
   try Catalog {
@@ -2001,10 +2001,10 @@ private func joined() throws -> FixtureCatalog {
 struct CorrelatedJoinOnTests {
   @Test func `a correlated join ON stays the residual filter`() throws {
     // `ON V.x = T.Id` lowers to `compare(.slot, .equal, .parameter)` — a
-    // CORRELATED equality against the outer `T.Id`, not a column = column key.
+    // correlated equality against the outer `T.Id`, not a column = column key.
     // Reading the key off the lowered term leaves it the residual `ON` filter,
     // evaluated per outer `T` row (`V.x = :outer_Id`). Pre-fix the fast path
-    // re-resolved the ORIGINAL AST via `match(V.x, T.Id)`, which consults ONLY
+    // re-resolved the original AST via `match(V.x, T.Id)`, which consults ONLY
     // the join prefix (`U`, `V`) and faulted `SQLError.column("Id")` on the
     // already-lowered outer column. `V.x` ∈ {1, 2} matches `T.Id` ∈ {1, 2}.
     try joined().expect(
@@ -2022,11 +2022,11 @@ struct CorrelatedJoinOnTests {
   }
 
   @Test func `an uncorrelated join ON still extracts its equi key`() throws {
-    // PARITY: `ON V.x = U.y` is a genuine column = column equality lowering to
-    // `compare(.slot, .equal, .slot)`, so it is STILL extracted as the
+    // parity: `ON V.x = U.y` is a genuine column = column equality lowering to
+    // `compare(.slot, .equal, .slot)`, so it is still extracted as the
     // hash-join match key (see `EngineNonEquiJoinTests` for the plan-shape
     // guard). `U.y` = 2 matches `V.x` = 2, so the join is non-empty and the
-    // UNCORRELATED `EXISTS` is TRUE for EVERY outer `T` row.
+    // uncorrelated `EXISTS` is TRUE for every outer `T` row.
     try joined().expect(
         "SELECT Id FROM T WHERE EXISTS (SELECT 1 FROM U JOIN V ON V.x = U.y)",
         yields: [[1], [2], [3], [4]])

--- a/Tests/SQLTests/Queries/TableTests.swift
+++ b/Tests/SQLTests/Queries/TableTests.swift
@@ -10,7 +10,7 @@ import func SQLTestSupport.parse
 // MARK: - TABLE t
 
 /// The ISO `TABLE t` query primary is exactly `SELECT * FROM t`. These tests
-/// confirm it lowers to the SAME star-projection single-relation `Select`,
+/// confirm it lowers to the same star-projection single-relation `Select`,
 /// resolves a base table AND a view identically, and composes with the
 /// set-operation tiers as a bare `SELECT *` does.
 struct TableTests {

--- a/Tests/SQLTests/Queries/ValuesTests.swift
+++ b/Tests/SQLTests/Queries/ValuesTests.swift
@@ -136,10 +136,10 @@ struct ValuesTests {
   // MARK: - Type unification
 
   @Test func `a mixed numeric VALUES column unifies to double`() throws {
-    // VALUES desugars to a `UNION ALL`, so a column's type UNIFIES across every
+    // VALUES desugars to a `UNION ALL`, so a column's type unifies across every
     // arm through the set-operation type fold (the ISO rule a `UNION` follows),
     // NOT the first arm alone. A column mixing integer and double widens to
-    // double, and the integer arm's value is COERCED to that unified type.
+    // double, and the integer arm's value is coerced to that unified type.
     // `VALUES (1), (2.5)`'s column1 is thus a double throughout, `1.0` then
     // `2.5`, regardless of the arm order.
     let columns = try store().columns(of:

--- a/Tests/SQLTests/Schema/DefinitionSchemaTests.swift
+++ b/Tests/SQLTests/Schema/DefinitionSchemaTests.swift
@@ -44,7 +44,7 @@ import SQLTestSupport
   }
 
   @Test func `definition_schema.tables lists a cyclic view without crashing`() throws {
-    // `definition_schema.tables` enumerates relations and views by NAME without
+    // `definition_schema.tables` enumerates relations and views by name without
     // compiling their bodies, so it lists the cyclic view too — the point is it
     // does not hang or crash reaching it. Assert the catalog's own names all
     // appear (a superset check, so a later slice adding engine-provided rows
@@ -66,7 +66,7 @@ import SQLTestSupport
 
   @Test func `definition_schema.columns skips a faulting grouping-sets view`()
       throws {
-    // The metadata builder EXPANDS a `GROUPING SETS` view body before
+    // The metadata builder expands a `GROUPING SETS` view body before
     // type-checking, as the schema path does. Unexpanded, the constant-false
     // `WHERE` reads as skipping the `1 / 0` projection; expanded, the `()` arm
     // forms one group (a grand total) and evaluates it, faulting. The store

--- a/Tests/SQLTests/Schema/IntrospectionTests.swift
+++ b/Tests/SQLTests/Schema/IntrospectionTests.swift
@@ -98,7 +98,7 @@ struct IntrospectionTests {
   @Test func `a base relation shadows a same-named built-in information_schema view`() throws {
     // A base relation named for a built-in view shadows it (`resolve(view:)`
     // yields the base), so the built-in is not listed as a VIEW — the base is
-    // listed as a BASE TABLE. (The name now resolves to the base, so the store
+    // listed as a base TABLE. (The name now resolves to the base, so the store
     // relation is read directly to observe the metadata.)
     let cat = MetaCatalog([
       "information_schema.tables": MetaRelation([("x", .integer)], []),
@@ -146,7 +146,7 @@ struct IntrospectionTests {
 
   @Test func `information_schema.columns types a view defined over the overlay`() throws {
     // `Meta` reads `information_schema.tables`, whose `table_name` is text, so
-    // the builder must seed the view body's OWN introspection overlay for
+    // the builder must seed the view body's own introspection overlay for
     // `Meta`'s column to advertise the text domain, not the integer default.
     let body = try parse(query:
         "SELECT table_name FROM information_schema.tables")
@@ -200,7 +200,7 @@ struct IntrospectionTests {
   }
 
   @Test func `a view over information_schema.columns keeps its columns' kinds`() throws {
-    // A view reading `information_schema.columns` ITSELF must resolve against a
+    // A view reading `information_schema.columns` itself must resolve against a
     // schema-only seed of that relation, so its `column_name` column advertises
     // the text domain rather than falling back to the integer default.
     let body = try parse(query:
@@ -236,7 +236,7 @@ struct IntrospectionTests {
 
   @Test func `information_schema.columns hides a view whose WHERE is invalid`() throws {
     // `v`'s projection resolves, but its WHERE names a missing column, so
-    // `SELECT * FROM v` throws. The overlay validates the WHOLE body — as the
+    // `SELECT * FROM v` throws. The overlay validates the whole body — as the
     // public schema API does — and does not advertise `v` as queryable
     // metadata.
     let body = try parse(query: "SELECT Name FROM People WHERE Missing = 1")
@@ -252,7 +252,7 @@ struct IntrospectionTests {
 
   @Test func `information_schema.columns hides a view whose UNION arm is invalid`() throws {
     // The leading arm resolves, but the second names a missing column, so the
-    // whole view cannot run — the overlay must validate EVERY arm, not just the
+    // whole view cannot run — the overlay must validate every arm, not just the
     // first, and not list `u`.
     let body = try parse(query: """
         SELECT Name FROM People UNION SELECT Missing FROM People
@@ -301,10 +301,10 @@ struct IntrospectionTests {
   }
 
   @Test func `information_schema.columns hides a view whose scalar-call arg is bad`() throws {
-    // `v`'s projection is a scalar call `BITAND(Missing, 1)` whose ARGUMENT
+    // `v`'s projection is a scalar call `BITAND(Missing, 1)` whose argument
     // names a column `People` does not have, so `SELECT * FROM v` fails to
     // compile (`Scope.term` resolves `Missing` and throws `SQLError.column`). A
-    // resolve-only validator that typed a `.call` by its fallback kind WITHOUT
+    // resolve-only validator that typed a `.call` by its fallback kind without
     // visiting its arguments advertised `v` anyway; validating each view via
     // the real `compile` — which lowers a call's arguments — closes that
     // gap, so `v` is not listed. This passes through the compile-based
@@ -393,7 +393,7 @@ struct IntrospectionTests {
     // resolution now faults it `.recursion` (see cyclicViewRuns) rather than
     // hanging, so the overlay validates each view via the real `compile`
     // and does not advertise a view that could never be queried. The cycle must
-    // not hang or corrupt an UNRELATED metadata query either — `People` still
+    // not hang or corrupt an unrelated metadata query either — `People` still
     // reports normally, and the cyclic views are absent.
     let a = try parse(query: "SELECT * FROM B")
     let b = try parse(query: "SELECT * FROM A")
@@ -458,7 +458,7 @@ struct IntrospectionTests {
   }
 
   @Test func `a base relation shadows the built-in information_schema view`() throws {
-    // A catalog vending its OWN `information_schema.tables` base relation must
+    // A catalog vending its own `information_schema.tables` base relation must
     // reach it: a base relation shadows the engine's built-in view (precedence
     // user view > base table > built-in view), so `SELECT *` reads the base
     // rows, not the enumerated metadata.
@@ -514,7 +514,7 @@ struct IntrospectionTests {
 
   @Test func `a view over information_schema.tables yields the inline rows`() throws {
     // A view whose body selects from a reserved introspection relation must
-    // resolve its overlay from ITS OWN query, so selecting from the view yields
+    // resolve its overlay from its own query, so selecting from the view yields
     // exactly what the inline query does.
     let body = try parse(query: """
         SELECT table_name FROM information_schema.tables
@@ -599,7 +599,7 @@ struct IntrospectionTests {
   }
 
   @Test func `columns(of:) types a scalar call by its routine's return type`() throws {
-    // The public schema API takes the SAME routines a run would, so a projected
+    // The public schema API takes the same routines a run would, so a projected
     // `TAG(Name)` reports its declared `.text` return type, not `.integer`.
     let cat = MetaCatalog(["People": MetaRelation([("Name", .text)], [])])
     let query = try parse(query: "SELECT TAG(Name) AS t FROM People")
@@ -849,7 +849,7 @@ struct IntrospectionTests {
 
   @Test func `columns(of:) derives a schema for a zero-row-limit projection`() throws {
     // `FETCH FIRST 0 ROWS ONLY` yields no rows and the limit applies before the
-    // projection, so `Name + 1` is never evaluated; the schema DERIVES its
+    // projection, so `Name + 1` is never evaluated; the schema derives its
     // nominal type without faulting on the non-numeric operand.
     let cat = MetaCatalog(["People": MetaRelation([("Name", .text)], [])])
     #expect(try cat.columns(of: parse(query: """
@@ -922,7 +922,7 @@ struct IntrospectionTests {
         SELECT SUM(Name) AS s FROM People WHERE 1 = 0
         """))
     #expect(summed.count == 1)
-    // But a whole-result aggregate still emits ONE empty group, so a scalar
+    // But a whole-result aggregate still emits one empty group, so a scalar
     // call projecting it runs — an unregistered routine faults, as a run does.
     #expect(throws: SQLError.self) {
       let _ = try cat.columns(of: parse(query: """
@@ -995,7 +995,7 @@ struct IntrospectionTests {
         ["BAD": Routine(returns: .double, parameters: []) { _ in
           .double(.infinity)
         }]
-    // The empty group projects BAD(), a non-finite double the run rejects
+    // The empty group projects bad(), a non-finite double the run rejects
     // (SQLError.magnitude), so the schema must reject it too.
     #expect(throws: SQLError.self) {
       let _ = try cat.columns(of: parse(query: """
@@ -1155,7 +1155,7 @@ struct IntrospectionTests {
 
   @Test func `a base relation shadowed by the definition_schema store is hidden`() throws {
     // The store overlay resolves `definition_schema.tables`, so a catalog base
-    // relation of that name is unreachable; it must not be advertised as a BASE
+    // relation of that name is unreachable; it must not be advertised as a base
     // TABLE, or metadata would disagree with resolution for the reserved name.
     let cat = MetaCatalog([
       "People": MetaRelation([("Name", .text)], []),
@@ -1292,7 +1292,7 @@ struct IntrospectionTests {
   }
 
   @Test func `a view over definition_schema.tables yields the inline rows`() throws {
-    // A view whose body names the STORE relation directly — not an
+    // A view whose body names the store relation directly — not an
     // `information_schema.` view over it — resolves and runs the same as the
     // inline query: the store overlay reaches the view body's compile and
     // execution (`resolve`/`derive`), not only the top-level query.

--- a/Tests/SQLTests/Schema/OutputSchemaTests.swift
+++ b/Tests/SQLTests/Schema/OutputSchemaTests.swift
@@ -81,7 +81,7 @@ private struct SchemaTable: Table {
   }
 }
 
-/// A cursor that TRAPS on any row read — `columns(of:)` must never open it.
+/// A cursor that traps on any row read — `columns(of:)` must never open it.
 private struct SchemaCursor: Cursor {
   let relation: SchemaRelation
 
@@ -257,7 +257,7 @@ struct OutputSchemaTests {
   @Test func `a constant-NULL arm does not veto the unified type`() throws {
     // A column that folds to a constant NULL in an arm constrains nothing (a
     // NULL unifies with any typed arm), mirroring COALESCE's constant-NULL
-    // skip, so the OTHER arm's type wins — a `NULLIF(2, 2)` (constant NULL) arm
+    // skip, so the other arm's type wins — a `NULLIF(2, 2)` (constant NULL) arm
     // beside a `double` arm types the column `double`, not the NULLIF arm's
     // `integer`.
     let leading = try schema("SELECT NULLIF(2, 2) UNION SELECT 2.5")
@@ -273,8 +273,8 @@ struct OutputSchemaTests {
   @Test func `a SELECT star USING merge carries its unconstrained mask into a UNION`()
       throws {
     // Both `USING (k)` constituents are constant-NULL (`NULLIF(1, 1)`), so the
-    // merged `k` places NO type constraint. A `SELECT *` must carry that mask —
-    // routed through the SAME construction the explicit `SELECT k` uses — so
+    // merged `k` places no type constraint. A `SELECT *` must carry that mask —
+    // routed through the same construction the explicit `SELECT k` uses — so
     // the enclosing UNION unifies the merged `k` with the text arm rather than
     // faulting the first arm's integer against text.
     let star = try schema("""
@@ -284,7 +284,7 @@ struct OutputSchemaTests {
         """)
     #expect(star.count == 1)
     #expect(star[0] == ("k", .text))
-    // A genuinely CONSTRAINED merge (two integer `k` sides) still faults an
+    // A genuinely constrained merge (two integer `k` sides) still faults an
     // irreconcilable text UNION arm — the mask is carried, not hard-coded
     // unconstrained.
     #expect(throws: SQLError.self) {
@@ -311,8 +311,8 @@ struct OutputSchemaTests {
     // The crossover of the two ISO features: the `UNION` body's type fold
     // widens the mixed integer/double column to `double` (set-op unification),
     // and the `AS d(a)` list positionally renames it `a` (the explicit output
-    // column list). The rename applies AFTER the fold determines the column
-    // count and type, so the column is BOTH named `a` and typed `double`.
+    // column list). The rename applies after the fold determines the column
+    // count and type, so the column is both named `a` and typed `double`.
     let columns =
         try schema("SELECT d.a FROM (SELECT 1 UNION SELECT 2.5) AS d(a)")
     #expect(columns.count == 1)
@@ -341,11 +341,11 @@ struct OutputSchemaTests {
 
   @Test func `a data-dependent-empty view derives headers without re-validating`() throws {
     // A view whose body is a text-arithmetic projection under a filter that
-    // matches no row RUNS to zero rows: the data-dependent WHERE spares the
+    // matches no row runs to zero rows: the data-dependent WHERE spares the
     // `Name + 1` from ever evaluating. Filling in the empty result's headers
     // (`validate: false`) must resolve the view — relations, CTEs, and the
-    // body's own types — WITHOUT re-type-checking the body's reachable
-    // `Name + 1`, which a run never reached; otherwise a query that SUCCEEDED
+    // body's own types — without re-type-checking the body's reachable
+    // `Name + 1`, which a run never reached; otherwise a query that succeeded
     // reports a failure. `validate: true` (the default / `.schema`) still
     // faults, exactly as running the body over rows would.
     let definition = try View(query: {
@@ -463,7 +463,7 @@ struct OutputSchemaTests {
   }
 
   @Test func `a positive OFFSET over a whole-result aggregate spares its projection`() throws {
-    // A whole-result aggregate emits exactly ONE row, so an OFFSET of 1 skips
+    // A whole-result aggregate emits exactly one row, so an OFFSET of 1 skips
     // it — the projection is unreachable and its divide-by-zero never faults,
     // just as a zero FETCH spares it.
     let normal = try schema(
@@ -478,7 +478,7 @@ struct OutputSchemaTests {
 
   @Test func `a zero FETCH does not spare a SELECT DISTINCT projection`() throws {
     // A DISTINCT plan is `Limit(Distinct(Project(…)))`: the projection
-    // evaluates over every candidate row to dedup it BEFORE the cap pages the
+    // evaluates over every candidate row to dedup it before the cap pages the
     // result, so a zero FETCH does NOT make it unreachable. The schema must
     // fault its divide-by-zero exactly as a run would — unlike the non-distinct
     // form, whose `Project(Limit(…))` shape the zero FETCH still spares.
@@ -516,11 +516,11 @@ struct OutputSchemaTests {
   }
 
   @Test func `a zero FETCH does not spare a DISTINCT empty-group projection`() throws {
-    // A constant-false WHERE over a whole-result aggregate emits ONE empty
+    // A constant-false WHERE over a whole-result aggregate emits one empty
     // group. For a non-distinct query a zero FETCH drops that lone row, so its
     // projection is unreachable and the divide-by-zero is spared. A DISTINCT
     // query is the exception: its `Limit(Distinct(Project(…)))` plan evaluates
-    // the projection over the empty group's row (to dedup) BEFORE the cap, so
+    // the projection over the empty group's row (to dedup) before the cap, so
     // the divide-by-zero faults exactly as a run does — the empty-group gate
     // must bypass the limit elision under DISTINCT just as the main path does.
     #expect(throws: SQLError.self) {
@@ -535,8 +535,8 @@ struct OutputSchemaTests {
   }
 
   @Test func `HAVING is evaluated before a zero-FETCH limit, so its faults surface`() throws {
-    // The compiled plan applies HAVING BEFORE the OFFSET/FETCH limit, so a zero
-    // FETCH spares only the PROJECTION — HAVING still evaluates over the empty
+    // The compiled plan applies HAVING before the OFFSET/FETCH limit, so a zero
+    // FETCH spares only the projection — HAVING still evaluates over the empty
     // group. A faulting HAVING must therefore surface even under a zero FETCH.
     #expect(throws: SQLError.self) {
       try schema("SELECT COUNT(*) FROM People WHERE 1 = 0 "
@@ -551,7 +551,7 @@ struct OutputSchemaTests {
 
   @Test func `columns(of statement:) derives a WITH against its CTE scope`() throws {
     // The trailing query resolves against the statement's CTEs, schema-only:
-    // a CTE `People` SHADOWS the two-column base relation, so a `SELECT *` over
+    // a CTE `People` shadows the two-column base relation, so a `SELECT *` over
     // it names the CTE's one declared column `x`, not the base's `Name, Age`.
     let columns = try catalog().columns(of: Statement(parsing:
         "WITH People(x) AS (SELECT 1) SELECT * FROM People"))
@@ -586,12 +586,12 @@ struct OutputSchemaTests {
   }
 
   @Test func `a WITH whose body arity contradicts its list faults when validating`() throws {
-    // The CTE declares ONE column but its body projects TWO — a `SELECT *` over
+    // The CTE declares one column but its body projects two — a `SELECT *` over
     // the two-column `People`. The parser cannot catch this (a `SELECT *`'s
     // width is known only at resolution), so a run rejects it with
     // `SQLError.columns` when its compiled body width contradicts the declared
     // list. A `validate: true` derive must not advertise a schema for it, so it
-    // faults the SAME way — body/query-expression degree as `expected`, the
+    // faults the same way — body/query-expression degree as `expected`, the
     // declared list count as `got`, as `Engine.with` does — not report the one
     // trusted declared column.
     let statement = try Statement(parsing:
@@ -603,10 +603,10 @@ struct OutputSchemaTests {
 
   @Test func `a WITH's body is trusted, not compiled, when not validating`() throws {
     // `validate: false` is the post-run derive: the run already proved the
-    // bodies consistent, so the declared list is TRUSTED without compiling the
+    // bodies consistent, so the declared list is trusted without compiling the
     // body. The same arity-mismatched `WITH` that faults when validating
     // reports its one declared column here — the empty/data-dependent header
-    // path a successful run fills in. The column takes the body's DERIVED type
+    // path a successful run fills in. The column takes the body's derived type
     // (`People.Name` is text under the renamed `a`), never the `.integer`
     // placeholder.
     let statement = try Statement(parsing:
@@ -619,7 +619,7 @@ struct OutputSchemaTests {
     // A CTE whose declared arity matches its body validates cleanly and derives
     // the trailing query's schema — the body compiled, its width confirmed
     // against the declared list, and its reachable operands type-checked. The
-    // columns take the body's DERIVED types (`People` is text, integer under
+    // columns take the body's derived types (`People` is text, integer under
     // the renamed `a`, `b`), never the `.integer` placeholder.
     let statement = try Statement(parsing:
         "WITH t(a, b) AS (SELECT * FROM People) SELECT a, b FROM t")
@@ -629,11 +629,11 @@ struct OutputSchemaTests {
   }
 
   @Test func `a non-recursive CTE body cannot see its own schema-only self`() throws {
-    // A non-recursive CTE is NOT in scope within its own body — only the PRIOR
+    // A non-recursive CTE is NOT in scope within its own body — only the prior
     // CTEs and the base catalog are — so a body that names the CTE with no
     // same-named base resolves against nothing and faults `.relation`, exactly
     // as `Engine.with` does. Binding the CTE's schema-only self into its own
-    // body's scope would WRONGLY resolve it, advertising a schema for a `WITH`
+    // body's scope would wrongly resolve it, advertising a schema for a `WITH`
     // that cannot run.
     let statement = try Statement(parsing:
         "WITH t(x) AS (SELECT * FROM t) SELECT * FROM t")
@@ -644,12 +644,12 @@ struct OutputSchemaTests {
 
   @Test func `a same-named-base non-recursive CTE body resolves the base`() throws {
     // A non-recursive CTE `People` shadowing the two-column base is NOT in its
-    // OWN body's scope, so the body's `SELECT * FROM People` resolves the BASE
+    // own body's scope, so the body's `SELECT * FROM People` resolves the base
     // relation (two columns), matching its declared arity; the trailing query
     // then reads the CTE's one declared column `x`. Were the CTE's own self
     // bound in its body, the body would read the CTE (one column) and its arity
     // would contradict the declared two-column list. The columns take the
-    // body's DERIVED types (the base `People` is text, integer under the
+    // body's derived types (the base `People` is text, integer under the
     // renamed `a`, `b`), never the `.integer` placeholder.
     let statement = try Statement(parsing:
         "WITH People(a, b) AS (SELECT * FROM People) SELECT a, b FROM People")
@@ -671,7 +671,7 @@ struct OutputSchemaTests {
   }
 
   @Test func `a recursive CTE body sees its own schema-only self and resolves`() throws {
-    // A genuinely recursive CTE — its FINAL UNION arm names itself — DOES bind
+    // A genuinely recursive CTE — its final UNION arm names itself — does bind
     // its own schema-only self while its body validates, so the recursive
     // reference resolves. The anchor seeds one column, the recursive arm reads
     // the CTE, and the trailing query names the CTE's declared column `n`.
@@ -686,12 +686,12 @@ struct OutputSchemaTests {
   }
 
   @Test func `a recursive CTE self-referencing its anchor faults as a run does`() throws {
-    // The engine binds a recursive CTE's self ONLY to its FINAL UNION arm: a
-    // self-reference in the ANCHOR arm resolves against the base scope, so with
+    // The engine binds a recursive CTE's self ONLY to its final UNION arm: a
+    // self-reference in the anchor arm resolves against the base scope, so with
     // no same-named base/view it can only be a misplaced recursive arm — a
-    // shape the engine rejects `.unsupported`, BEFORE materialising. The derive
-    // now validates the CTE by the SAME `Engine.validate` a run drives, so it
-    // faults IDENTICALLY rather than advertising a schema for a `WITH` a run
+    // shape the engine rejects `.unsupported`, before materialising. The derive
+    // now validates the CTE by the same `Engine.validate` a run drives, so it
+    // faults identically rather than advertising a schema for a `WITH` a run
     // would reject.
     let statement = try Statement(parsing: """
         WITH RECURSIVE t(n) AS (
@@ -703,7 +703,7 @@ struct OutputSchemaTests {
     #expect(throws: error) {
       let _ = try catalog().columns(of: statement, validate: true)
     }
-    // The derive faults EXACTLY where a run does — the divergence the schema
+    // The derive faults exactly where a run does — the divergence the schema
     // path repeatedly drifted into is closed by reusing the engine's own check.
     #expect(throws: error) {
       let _ = try catalog().run(statement)
@@ -713,7 +713,7 @@ struct OutputSchemaTests {
   @Test func `a recursive CTE anchor is operand-checked against the base scope`() throws {
     // A recursive CTE binds its schema-only self (declared columns, typed
     // `.integer`) ONLY inside its final UNION arm; the anchor resolves against
-    // the BASE scope — the same scope a run evaluates it in. So the anchor's
+    // the base scope — the same scope a run evaluates it in. So the anchor's
     // reachable operands must be type-checked with self NOT in scope: here the
     // base `People.Name` is TEXT (the shared fixture), so the anchor `SELECT
     // Name + 1 FROM People` faults `.operand` exactly as a run's per-row
@@ -753,9 +753,9 @@ struct OutputSchemaTests {
 
 /// The outcome of typing or running a `WITH` — either the resolved result
 /// columns' `(name, kind)` pairs, or the `SQLError` a fault raised — so the
-/// three CTE entry points (a RUN, a `columns(validate: false)` derive, and a
-/// `columns(validate: true)` derive) can be compared for AGREEMENT: after the
-/// tier-2 unification they walk their CTEs through the ONE producer, so a shape
+/// three CTE entry points (a run, a `columns(validate: false)` derive, and a
+/// `columns(validate: true)` derive) can be compared for agreement: after the
+/// tier-2 unification they walk their CTEs through the one producer, so a shape
 /// must resolve to the same types on all three, or fault the same on all three.
 private enum Outcome: Equatable {
   case columns(Array<OutputColumn>)
@@ -774,21 +774,21 @@ private func outcome(_ body: () throws -> Array<OutputColumn>) -> Outcome {
 }
 
 /// The three CTE entry points' outcomes on one `WITH` — the regression fence
-/// for the tier-2 producer. `run` is the RUN path (its post-run `validate:
+/// for the tier-2 producer. `run` is the run path (its post-run `validate:
 /// false` schema, or its fault); `lenient` is `columns(validate: false)` — the
-/// TRUSTED post-run derive, which SKIPS the structural `validate` (so a
+/// trusted post-run derive, which skips the structural `validate` (so a
 /// shape/arity fault does not surface, and a recursive body reads its absent
 /// self); `strict` is `columns(validate: true)` — the full schema check.
 ///
-/// The invariant the unification preserves: RUN and STRICT are the two FULLY
-/// validating paths, so they AGREE on every shape — the producer's shared
+/// The invariant the unification preserves: run and strict are the two fully
+/// validating paths, so they agree on every shape — the producer's shared
 /// `validate` (`typecheck` differing only in whether the reachable-operand
 /// check runs at derive or execution) and shared `kinds` carrier make them so.
-/// LENIENT agrees too on any shape whose outcome does NOT depend on the skipped
+/// lenient agrees too on any shape whose outcome does NOT depend on the skipped
 /// structural check — the carrier-typing shapes (a `kinds`/`merge` fold runs
 /// regardless of the gate) and redefinition (the producer's guard is
 /// ungated) — but on a structural fault (arity, an unregistered call, a
-/// misplaced recursive arm) it TRUSTS the body and does not fault.
+/// misplaced recursive arm) it trusts the body and does not fault.
 private struct Triple {
   let run: Outcome
   let lenient: Outcome
@@ -817,9 +817,9 @@ private func pairs(_ outcome: Outcome) -> Array<(String, ValueType)>? {
 
 struct CTEProducerParityTests {
   @Test func `an all-NULL CTE column agrees across run and both derives`() throws {
-    // A constant-NULL body column is UNCONSTRAINED, typed at the `.integer`
+    // A constant-NULL body column is unconstrained, typed at the `.integer`
     // default a materialised relation reports; the run and both derives read
-    // the SAME producer carrier, so all three agree on one `.integer` column.
+    // the same producer carrier, so all three agree on one `.integer` column.
     let t = try Triple("WITH a(x) AS (SELECT NULLIF(Id, Id) FROM Parent) " +
                        "SELECT x FROM a")
     #expect(pairs(t.run).map { same($0, [("x", .integer)]) } == true)
@@ -830,8 +830,8 @@ struct CTEProducerParityTests {
   @Test func `an unregistered-call CTE body faults on the validating paths`()
       throws {
     // A call to an unregistered routine is a resolution fault the producer's
-    // shared `validate` raises the SAME on the two VALIDATING paths (RUN and
-    // STRICT). LENIENT is the trusted post-run derive: it skips `validate`, so
+    // shared `validate` raises the same on the two validating paths (run and
+    // strict). lenient is the trusted post-run derive: it skips `validate`, so
     // it does NOT fault — the pre-existing gate this test pins, not a
     // divergence the unification introduces.
     let t = try Triple("WITH a(x) AS (SELECT nope(Id) FROM Parent) " +
@@ -862,7 +862,7 @@ struct CTEProducerParityTests {
     // carrier over the `UNION` setop; the schema producer's recursive-shape
     // recogniser (`contributions`) must peel it (`body.core`) the same way the
     // run's `fixpoint` does, else it falls through to the non-recursive fold
-    // with the self UNBOUND and faults `.relation("t")` — a run-vs-schema
+    // with the self unbound and faults `.relation("t")` — a run-vs-schema
     // divergence, since the run iterates the fixpoint and yields `1,2,3`. The
     // carrier is transparent to the derived schema, so all three still agree on
     // the one integer column `n`.
@@ -895,7 +895,7 @@ struct CTEProducerParityTests {
       throws {
     // A non-recursive UNION body of an `integer` and a `double` arm folds to a
     // `.double` column on every path — the producer's `kinds` fold and the
-    // run's `run`-then-`kinds` re-derive read the SAME `merge`.
+    // run's `run`-then-`kinds` re-derive read the same `merge`.
     let t = try Triple("WITH a(x) AS (SELECT 1 UNION SELECT 2.5) " +
                        "SELECT x FROM a")
     #expect(pairs(t.run).map { same($0, [("x", .double)]) } == true)
@@ -905,7 +905,7 @@ struct CTEProducerParityTests {
 
   @Test func `a non-recursive ordered set-op CTE derives through the carrier`()
       throws {
-    // A NON-recursive UNION body under a trailing `ORDER BY` carrier still
+    // A non-recursive UNION body under a trailing `ORDER BY` carrier still
     // derives its one `.double` column on every path: the recursive-shape
     // recogniser sees a non-recursive CTE and falls through to the unifying
     // fold, whose `.ordered` case peels the carrier transparently — the
@@ -922,7 +922,7 @@ struct CTEProducerParityTests {
     // A text arm beside a numeric one has no common type, so the body fold
     // faults `.operand` (42804) — through the producer's shared `kinds`/`merge`
     // on the derives (a fold that runs regardless of the validate gate) and the
-    // run's own fold — the SAME on all three.
+    // run's own fold — the same on all three.
     let t = try Triple("WITH a(x) AS (SELECT 'b' UNION SELECT 1) " +
                        "SELECT x FROM a")
     let fault = Outcome.fault(.operand("UNION arms have irreconcilable types"))
@@ -935,7 +935,7 @@ struct CTEProducerParityTests {
       throws {
     // A three-column declared list over a two-column `SELECT *` body faults
     // `.columns` in ISO order (the compiled width, then the declared count) on
-    // the two VALIDATING paths. LENIENT trusts and reconciles to the declared
+    // the two validating paths. lenient trusts and reconciles to the declared
     // list, so it does NOT fault — the pre-existing structural gate.
     let t = try Triple("WITH a(x, y, z) AS (SELECT * FROM Parent) " +
                        "SELECT * FROM a")
@@ -947,8 +947,8 @@ struct CTEProducerParityTests {
   @Test func `an under-declared CTE arity faults on the validating paths`()
       throws {
     // The mirror of the over-declared case — a one-column list over a
-    // two-column body — `.columns(expected: 2, got: 1)` on RUN and STRICT,
-    // LENIENT trusting the body to one column.
+    // two-column body — `.columns(expected: 2, got: 1)` on run and strict,
+    // lenient trusting the body to one column.
     let t = try Triple("WITH a(x) AS (SELECT * FROM Parent) SELECT * FROM a")
     #expect(t.run == .fault(.columns(expected: 2, got: 1)))
     #expect(t.strict == t.run)
@@ -957,8 +957,8 @@ struct CTEProducerParityTests {
 
   @Test func `a misplaced recursive arm faults on the validating paths`()
       throws {
-    // A self-reference in the ANCHOR (not the final UNION arm) is the recursive
-    // shape the engine rejects `0A000` on the two VALIDATING paths. LENIENT
+    // A self-reference in the anchor (not the final UNION arm) is the recursive
+    // shape the engine rejects `0A000` on the two validating paths. lenient
     // trusts — it skips `validate`, so the body reads an absent self and faults
     // `.relation` instead; the pre-existing gate, pinned so the unification
     // cannot silently change it.
@@ -975,8 +975,8 @@ struct CTEProducerParityTests {
   }
 
   @Test func `a redefined CTE name faults identically on all paths`() throws {
-    // A case-insensitive redefinition is rejected by the producer's UNGATED
-    // guard — the SAME `.redefinition` on the run and BOTH derives, lenient
+    // A case-insensitive redefinition is rejected by the producer's ungated
+    // guard — the same `.redefinition` on the run and both derives, lenient
     // included (the guard runs before any validate gate).
     let t = try Triple("WITH a(x) AS (SELECT 1), A(y) AS (SELECT 2) " +
                        "SELECT * FROM a")
@@ -988,8 +988,8 @@ struct CTEProducerParityTests {
 
   @Test func `a chained CTE reading a prior widened column agrees`() throws {
     // The biggest risk: the run overlay grows with each prior CTE's
-    // MATERIALISED rows, the schema overlay with EMPTY rows, but both
-    // accumulate the SAME types/mask. Here `b` reads `a`'s column, widened to
+    // materialised rows, the schema overlay with empty rows, but both
+    // accumulate the same types/mask. Here `b` reads `a`'s column, widened to
     // `.double`, so all three paths agree on one `.double` column — proving it
     // threads the growing overlay identically (types, not rows) on both.
     let t = try Triple("""

--- a/Tests/SQLTests/Syntax/ParserTests.swift
+++ b/Tests/SQLTests/Syntax/ParserTests.swift
@@ -313,7 +313,7 @@ struct OrderTests {
   }
 
   @Test func `parses an integer sort key as an ordinal`() throws {
-    // A bare integer is the ISO output-column ORDINAL, not the constant.
+    // A bare integer is the ISO output-column ordinal, not the constant.
     let select = try parse(select: "SELECT A, B FROM T ORDER BY 2 DESC")
     #expect(select.order
               == Order(keys: [Order.Key(sort: .ordinal(2), ascending: false)]))
@@ -341,7 +341,7 @@ struct OrderTests {
   }
 
   @Test func `a bare integer sort key is an ordinal`() throws {
-    // Only a LONE integer literal is the output-column ordinal — the key
+    // Only a lone integer literal is the output-column ordinal — the key
     // parses as an expression and classifies to `.ordinal` when it is one.
     let select = try parse(select: "SELECT A, B FROM T ORDER BY 1")
     #expect(select.order
@@ -731,7 +731,7 @@ struct ExpressionTests {
 
   @Test func `an AS on one item flips a bare sibling into an unaliased expression`() throws {
     // Aliasing only the second item forces the whole list into `expressions`,
-    // but the bare first item carries NO alias (`alias: nil`) — so an
+    // but the bare first item carries no alias (`alias: nil`) — so an
     // `ORDER BY` output-name binding, which considers only explicit aliases,
     // treats it exactly as it would in a `columns` list.
     let select = try parse(select: "SELECT Name, Id AS id FROM T")


### PR DESCRIPTION
Remove capitalised-for-emphasis words from comments across the SQL modules, keeping capitals only where they are canonical: ISO SQL keywords (SELECT, GROUP BY, NULL, and the rest), acronyms and initialisms (ISO, SQL, AST, MSB, CTE, SQLSTATE, ASCII, ...), and code identifiers, which stay in their backticks. Emphasis capitals are visual noise that read as shouting without aiding comprehension.

The change is comment-only: it rewrites the text after `//` — leaving any backticked `Identifier` untouched — and never a line of code, so every rewritten line is byte-identical up to its comment. Scoped to the SQL modules (SQLEngine, SQLStandard, SQLTestSupport, and their tests), where the habit lived; the metadata modules, whose comments carry many ECMA-335 all-capital constants, are left for a separate pass. Build and the full test suite are unchanged.