### PR TITLE
SQLEngine: accept a parenthesized query as a query primary

### DIFF
--- a/Sources/SQLEngine/AST.swift
+++ b/Sources/SQLEngine/AST.swift
@@ -205,6 +205,22 @@ public indirect enum Query: Hashable, Sendable {
     }
   }
 
+  /// The count of hidden `generated` sort columns the `ordered` carriers on the
+  /// path to `first` appended to that arm's projection — the amount by which
+  /// `first`'s raw projection width overstates the query's real output width. A
+  /// query-level `ORDER BY` over an unprojected aggregate materialises such a
+  /// column on each arm and trims it back at the carrier; a set-operation
+  /// arity check comparing `first` widths must subtract this so a carrier
+  /// operand's hidden column is not miscounted (`(SELECT n … GROUP BY GROUPING
+  /// SETS (…) ORDER BY SUM(m)) UNION SELECT n` is a valid one-column union).
+  internal var generated: Int {
+    switch self {
+    case .select: 0
+    case let .setop(_, left, _, _): left.generated
+    case let .ordered(inner, _, _, _, count): count + inner.generated
+    }
+  }
+
   /// The query-level row operators an `ordered` carrier applies OVER its inner
   /// query, peeled off it — the `DISTINCT`/`ORDER BY`/`OFFSET`·`FETCH` and the
   /// generated hidden-column count. A `select`/`setop` carries no carrier.
@@ -215,27 +231,46 @@ public indirect enum Query: Hashable, Sendable {
     public let generated: Int
   }
 
-  /// This query stripped of its `ordered` carrier — the inner `setop`/`select`
-  /// — paired with the peeled `Carrier`, or `nil` when the query wears none.
-  ///
-  /// A single seam-shared peel: the carrier-transparent `core` reads its inner,
-  /// so every seam descends the carrier here rather than repeating a bespoke
-  /// `.ordered` match, then reapplies the peeled carrier to the result.
-  public var unwound: (inner: Query, carrier: Carrier?) {
-    if case let .ordered(inner, distinct, order, limit, generated) = self {
-      return (inner, Carrier(distinct: distinct, order: order, limit: limit,
-                             generated: generated))
-    }
-    return (self, nil)
+
+  /// This query's carrier-transparent core — its innermost `setop`/`select`,
+  /// with every `ordered` carrier peeled off. Two carriers stack when an outer
+  /// query-expression tail rides a parenthesised primary that already has its
+  /// own tail (`(SELECT … ORDER BY … FETCH n) ORDER BY …`), so the peel loops
+  /// to the base rather than stopping at one level. For the `if case .setop =
+  /// query.core` seams that recognise a set operation whether or not it rides
+  /// carriers, so a carried (or twice-carried) union is not silently swallowed
+  /// by a bare `.setop` match.
+  public var core: Query {
+    var query = self
+    while case let .ordered(inner, _, _, _, _) = query { query = inner }
+    return query
   }
 
-  /// This query's carrier-transparent core — its inner `setop`/`select`, an
-  /// `ordered` carrier peeled off. A thin read over `unwound.inner` for the
-  /// `if case .setop = query.core` seams that recognise a set operation whether
-  /// or not it rides a carrier, so a carried union is not silently swallowed by
-  /// a bare `.setop` match.
-  public var core: Query {
-    unwound.inner
+  /// This query's carrier-transparent core paired with every `ordered` carrier
+  /// on the path to it, innermost first — the full peel a stacked-carrier seam
+  /// uses to reach the base `setop`/`select` and re-apply each carrier in order
+  /// (`(setop ORDER BY 1) ORDER BY 1` yields the setop and `[inner, outer]`). A
+  /// single carrier yields a one-element list; a bare body an empty one.
+  public var peeled: (core: Query, carriers: Array<Carrier>) {
+    guard case let .ordered(inner, distinct, order, limit, generated) = self
+    else { return (self, []) }
+    let (core, carriers) = inner.peeled
+    return (core, carriers + [Carrier(distinct: distinct, order: order,
+                                      limit: limit, generated: generated)])
+  }
+
+  /// Whether the query applies a set-level dedup that collapses distinct rows —
+  /// a `DISTINCT` on any `ordered` carrier in its stack, or on its base
+  /// `select`. Carrier-transparent (it peels the whole stack), so a seam that
+  /// must not rewrite a projection whose distinct cardinality feeds an OFFSET
+  /// sees the `DISTINCT` through any number of nested carriers. A set-operation
+  /// core is not counted: the probe never rewrites a setop, so its `UNION`
+  /// dedup cannot be collapsed by the rewrite.
+  public var dedups: Bool {
+    let (core, carriers) = peeled
+    if carriers.contains(where: \.distinct) { return true }
+    if case let .select(select) = core { return select.distinct }
+    return false
   }
 }
 

--- a/Sources/SQLEngine/AST.swift
+++ b/Sources/SQLEngine/AST.swift
@@ -160,117 +160,156 @@ public enum SetOperation: Hashable, Sendable {
 /// result column types are unified across the arms (a mixed integer/double
 /// column widening to `double`), while their names come from the first arm (the
 /// ISO rule).
-public indirect enum Query: Hashable, Sendable {
-  /// A single `SELECT`.
-  case select(Select)
-  /// A set operation of `kind` (`UNION`/`INTERSECT`/`EXCEPT`, `ALL` when `all`)
-  /// over a left and a right query term, the right appended so a
-  /// same-precedence chain reads left to right.
-  case setop(SetOperation, Query, Query, all: Bool)
+/// A query rides an optional stack of query-level row-operator `carriers` over
+/// a `body` that is either a single `SELECT` or a set operation. Structural
+/// code matches `body` — which cannot name or forget a carrier — while only the
+/// compile/execute/schema code that applies row operators reads `carriers`.
+public struct Query: Hashable, Sendable {
+  /// A query's carrier-free shape: one `SELECT`, or two query terms combined
+  /// with a set operator.
+  public indirect enum Body: Hashable, Sendable {
+    /// A single `SELECT`.
+    case select(Select)
+    /// A set operation of `kind` (`UNION`/`INTERSECT`/`EXCEPT`, `ALL` when
+    /// `all`) over a left and a right query term, the right appended so a
+    /// same-precedence chain reads left to right.
+    case setop(SetOperation, Query, Query, all: Bool)
+  }
 
   /// A query-level `ORDER BY` / `SELECT DISTINCT` / `OFFSET`·`FETCH` carried
-  /// OVER an inner query (always a `setop` — a `select` carries its own on the
-  /// node). A `setop` node has no order/distinct/limit slot, so an ordered,
-  /// deduplicated, or paged set operation rides this outer carrier: the row
+  /// OVER a body — the `DISTINCT`/`ORDER BY`/`OFFSET`·`FETCH` and the generated
+  /// hidden-column count.
+  ///
+  /// A `setop` body has no order/distinct/limit slot, so an ordered,
+  /// deduplicated, or paged set operation rides such a carrier: the row
   /// operators (`DISTINCT`, `ORDER BY`, `OFFSET`/`FETCH`) apply to the union's
   /// combined result, resolved through the setop's output scope, and do NOT
   /// project — the result columns stay the inner setop's arm-0-named, unified
-  /// ones. It is transparent to `columns(unifying:)`, which descends to the
-  /// inner setop for the result schema; only `run`/`compile` stack the row
-  /// operators over the compiled setop plan. Produced by the GROUPING SETS
-  /// `expand` and by the parser for a trailing query-level `ORDER BY` /
-  /// `OFFSET`·`FETCH` after a set-operation chain.
+  /// ones. A carrier is transparent to `columns(unifying:)`, which descends to
+  /// the body for the result schema; only `run`/`compile` stack the row
+  /// operators over the compiled body plan. Carriers are produced by the
+  /// GROUPING SETS `expand` and by the parser for a trailing query-level `ORDER
+  /// BY` / `OFFSET`·`FETCH` after a set-operation chain or a parenthesised
+  /// primary.
   ///
-  /// `generated` is the number of GENERATED trailing columns the inner union
-  /// carries beyond the real output — the hidden sort columns `expand` appends
-  /// to each arm (aliased `*gsN`) so a genuinely-unprojected aggregate sort key
+  /// `generated` is the number of generated trailing columns the body carries
+  /// beyond the real output — the hidden sort columns `expand` appends to each
+  /// arm (aliased `*gsN`) so a genuinely-unprojected aggregate sort key
   /// survives the `UNION ALL` at equal arity. The carrier's compile trims them
   /// (`real = width − generated`), and `columns(unifying:)` drops them from the
   /// result schema. It is a structural count carried out of `expand`, never
   /// recovered by scanning output names for a synthetic prefix; the parser's
   /// trailing-`ORDER BY` carrier generates none (`0`).
-  case ordered(Query, distinct: Bool, order: Order?, limit: Limit?,
-               generated: Int)
-
-  /// The first `SELECT` of the query — the leftmost arm, reached by descending
-  /// the left arm of each set operation. Its projection names the result
-  /// columns (the ISO rule — their types unify across every arm), so a `CREATE
-  /// VIEW` infers a set operation's column names from it. An `ordered` carrier
-  /// is transparent — its first is its inner query's.
-  public var first: Select {
-    switch self {
-    case let .select(select): select
-    case let .setop(_, left, _, _): left.first
-    case let .ordered(inner, _, _, _, _): inner.first
-    }
-  }
-
-  /// The count of hidden `generated` sort columns the `ordered` carriers on the
-  /// path to `first` appended to that arm's projection — the amount by which
-  /// `first`'s raw projection width overstates the query's real output width. A
-  /// query-level `ORDER BY` over an unprojected aggregate materialises such a
-  /// column on each arm and trims it back at the carrier; a set-operation
-  /// arity check comparing `first` widths must subtract this so a carrier
-  /// operand's hidden column is not miscounted (`(SELECT n … GROUP BY GROUPING
-  /// SETS (…) ORDER BY SUM(m)) UNION SELECT n` is a valid one-column union).
-  internal var generated: Int {
-    switch self {
-    case .select: 0
-    case let .setop(_, left, _, _): left.generated
-    case let .ordered(inner, _, _, _, count): count + inner.generated
-    }
-  }
-
-  /// The query-level row operators an `ordered` carrier applies OVER its inner
-  /// query, peeled off it — the `DISTINCT`/`ORDER BY`/`OFFSET`·`FETCH` and the
-  /// generated hidden-column count. A `select`/`setop` carries no carrier.
   public struct Carrier: Hashable, Sendable {
     public let distinct: Bool
     public let order: Order?
     public let limit: Limit?
     public let generated: Int
+
+    public init(distinct: Bool, order: Order?, limit: Limit?,
+                generated: Int) {
+      self.distinct = distinct
+      self.order = order
+      self.limit = limit
+      self.generated = generated
+    }
   }
 
+  /// The carrier-free shape of the query.
+  public var body: Body
 
-  /// This query's carrier-transparent core — its innermost `setop`/`select`,
-  /// with every `ordered` carrier peeled off. Two carriers stack when an outer
-  /// query-expression tail rides a parenthesised primary that already has its
-  /// own tail (`(SELECT … ORDER BY … FETCH n) ORDER BY …`), so the peel loops
-  /// to the base rather than stopping at one level. For the `if case .setop =
-  /// query.core` seams that recognise a set operation whether or not it rides
-  /// carriers, so a carried (or twice-carried) union is not silently swallowed
-  /// by a bare `.setop` match.
+  /// The query-level row-operator carriers stacked over `body`, innermost
+  /// first — empty for a bare body. Two carriers stack when an outer query-
+  /// expression tail rides a parenthesised primary that already has its own
+  /// tail (`(SELECT … ORDER BY … FETCH n) ORDER BY …`).
+  public var carriers: Array<Carrier>
+
+  public init(body: Body, carriers: Array<Carrier> = []) {
+    self.body = body
+    self.carriers = carriers
+  }
+
+  /// The first `SELECT` of the query — the leftmost arm, reached by descending
+  /// the left arm of each set operation. Its projection names the result
+  /// columns (the ISO rule — their types unify across every arm), so a `CREATE
+  /// VIEW` infers a set operation's column names from it. Carriers are
+  /// transparent — the first is the body's.
+  public var first: Select {
+    switch body {
+    case let .select(select): select
+    case let .setop(_, left, _, _): left.first
+    }
+  }
+
+  /// The count of hidden `generated` sort columns the carriers on the path to
+  /// `first` appended to that arm's projection — the amount by which `first`'s
+  /// raw projection width overstates the query's real output width. A query-
+  /// level `ORDER BY` over an unprojected aggregate materialises such a column
+  /// on each arm and trims it back at the carrier; a set-operation arity check
+  /// comparing `first` widths must subtract this so a carrier operand's hidden
+  /// column is not miscounted (`(SELECT n … GROUP BY GROUPING SETS (…) ORDER BY
+  /// SUM(m)) UNION SELECT n` is a valid one-column union).
+  internal var generated: Int {
+    let body: Int = switch self.body {
+    case .select: 0
+    case let .setop(_, left, _, _): left.generated
+    }
+    return carriers.reduce(body) { $0 + $1.generated }
+  }
+
+  /// This query's carrier-transparent core — its `body` with every carrier
+  /// stripped off. For the `if case .setop = query.core.body` seams that
+  /// recognise a set operation whether or not it rides carriers, so a carried
+  /// (or twice-carried) union is not silently swallowed by a bare `body` match.
   public var core: Query {
-    var query = self
-    while case let .ordered(inner, _, _, _, _) = query { query = inner }
-    return query
+    Query(body: body, carriers: [])
   }
 
-  /// This query's carrier-transparent core paired with every `ordered` carrier
-  /// on the path to it, innermost first — the full peel a stacked-carrier seam
-  /// uses to reach the base `setop`/`select` and re-apply each carrier in order
-  /// (`(setop ORDER BY 1) ORDER BY 1` yields the setop and `[inner, outer]`). A
-  /// single carrier yields a one-element list; a bare body an empty one.
+  /// This query's carrier-transparent core paired with every carrier on the
+  /// path to it, innermost first — the full peel a stacked-carrier seam uses to
+  /// reach the base body and re-apply each carrier in order. A single carrier
+  /// yields a one-element list; a bare body an empty one.
   public var peeled: (core: Query, carriers: Array<Carrier>) {
-    guard case let .ordered(inner, distinct, order, limit, generated) = self
-    else { return (self, []) }
-    let (core, carriers) = inner.peeled
-    return (core, carriers + [Carrier(distinct: distinct, order: order,
-                                      limit: limit, generated: generated)])
+    (core, carriers)
   }
 
   /// Whether the query applies a set-level dedup that collapses distinct rows —
-  /// a `DISTINCT` on any `ordered` carrier in its stack, or on its base
-  /// `select`. Carrier-transparent (it peels the whole stack), so a seam that
-  /// must not rewrite a projection whose distinct cardinality feeds an OFFSET
-  /// sees the `DISTINCT` through any number of nested carriers. A set-operation
-  /// core is not counted: the probe never rewrites a setop, so its `UNION`
-  /// dedup cannot be collapsed by the rewrite.
+  /// a `DISTINCT` on any carrier in its stack, or on its base `select` body.
+  /// Carrier-transparent (it reads the whole stack), so a seam that must not
+  /// rewrite a projection whose distinct cardinality feeds an OFFSET sees the
+  /// `DISTINCT` through any number of nested carriers. A set-operation body is
+  /// not counted: the probe never rewrites a setop, so its `UNION` dedup cannot
+  /// be collapsed by the rewrite.
   public var dedups: Bool {
-    let (core, carriers) = peeled
     if carriers.contains(where: \.distinct) { return true }
-    if case let .select(select) = core { return select.distinct }
+    if case let .select(select) = body { return select.distinct }
     return false
+  }
+}
+
+extension Query {
+  /// A bare `SELECT` query — no carriers.
+  public static func select(_ select: Select) -> Query {
+    Query(body: .select(select), carriers: [])
+  }
+
+  /// A set operation of `kind` over a left and a right query term — no
+  /// carriers.
+  public static func setop(_ kind: SetOperation, _ left: Query, _ right: Query,
+                           all: Bool) -> Query {
+    Query(body: .setop(kind, left, right, all: all), carriers: [])
+  }
+
+  /// The query `inner` under an additional query-level `ORDER BY` / `SELECT
+  /// DISTINCT` / `OFFSET`·`FETCH` carrier — the carrier appended to `inner`'s
+  /// own stack (outermost last), so a carrier over a carried primary stacks
+  /// rather than replaces. See `Carrier`.
+  public static func ordered(_ inner: Query, distinct: Bool, order: Order?,
+                             limit: Limit?, generated: Int) -> Query {
+    Query(body: inner.body,
+          carriers: inner.carriers + [Carrier(distinct: distinct, order: order,
+                                              limit: limit,
+                                              generated: generated)])
   }
 }
 

--- a/Sources/SQLEngine/Aggregation.swift
+++ b/Sources/SQLEngine/Aggregation.swift
@@ -313,10 +313,9 @@ extension Query {
   /// nested in a defined-function body is walked through this to reject a
   /// `:parameter` at registration (see `Expression.bound`).
   internal var bound: Bool {
-    switch self {
+    switch body {
     case let .select(select): select.bound
     case let .setop(_, left, right, _): left.bound || right.bound
-    case let .ordered(inner, _, _, _, _): inner.bound
     }
   }
 
@@ -327,10 +326,9 @@ extension Query {
   /// once, keyed by occurrence, so a set operation's every arm reads its own
   /// `EXISTS`/`IN (Q)` result from the same cache.
   internal var subqueries: Array<Query> {
-    switch self {
+    switch body {
     case let .select(select): select.subqueries
     case let .setop(_, left, right, _): left.subqueries + right.subqueries
-    case let .ordered(inner, _, _, _, _): inner.subqueries
     }
   }
 
@@ -341,10 +339,9 @@ extension Query {
   /// an `EXISTS` and an `IN` appears here (its values are needed), so its lone
   /// full materialisation serves both.
   internal var valued: Set<Query> {
-    switch self {
+    switch body {
     case let .select(select): select.valued
     case let .setop(_, left, right, _): left.valued.union(right.valued)
-    case let .ordered(inner, _, _, _, _): inner.valued
     }
   }
 
@@ -354,10 +351,9 @@ extension Query {
   /// occurrence. The materialiser reads this to decide a scalar occurrence's
   /// materialisation.
   internal var scalar: Set<Query> {
-    switch self {
+    switch body {
     case let .select(select): select.scalar
     case let .setop(_, left, right, _): left.scalar.union(right.scalar)
-    case let .ordered(inner, _, _, _, _): inner.scalar
     }
   }
 
@@ -368,11 +364,10 @@ extension Query {
   /// existential probe entry whenever a query occurs here — never reusing a
   /// `valued`/`scalar` entry for an `EXISTS` read.
   internal var existential: Set<Query> {
-    switch self {
+    switch body {
     case let .select(select): select.existential
     case let .setop(_, left, right, _):
       left.existential.union(right.existential)
-    case let .ordered(inner, _, _, _, _): inner.existential
     }
   }
 }

--- a/Sources/SQLEngine/Compilation.swift
+++ b/Sources/SQLEngine/Compilation.swift
@@ -6,7 +6,7 @@
 extension Projection {
   /// Compiles this scalar (FROM-less) `SELECT <expr-list>` projection into
   /// `Project(single)` — the projection evaluated against the one empty row the
-  /// `single` leaf yields.
+  /// `single` leaf yields — ordered and paged by any `order`/`limit` tail.
   ///
   /// The projection resolves against an empty schema (no columns), so only
   /// literals, scalar calls, and arithmetic over them lower; a `SELECT *` has
@@ -27,15 +27,37 @@ extension Projection {
   /// so this FROM-less projection cannot admit correlation even when handed the
   /// admitting `plans.rest` — the same cut `columns(of:)` applies on the schema
   /// path, keeping run and derive in lockstep.
+  ///
+  /// A trailing `ORDER BY`/`OFFSET`·`FETCH` (`order`/`limit`) orders and pages
+  /// that single row through the shared `shaped` plan shape, so a FROM-less
+  /// query expression's tail runs (`VALUES (1) ORDER BY 1`) rather than
+  /// faulting. An empty schema binds only an ordinal or an output-alias key —
+  /// the sole ISO keys over a FROM-less select, which has no source column to
+  /// order on — so an ordinary column key faults (`SQLError.column`) as it does
+  /// on the projection.
   internal func scalar(_ routines: Routines = [:],
-                       subquery: Resolution = .unsupported)
+                       subquery: Resolution = .unsupported,
+                       distinct: Bool = false,
+                       order: Order? = nil, limit: Limit? = nil)
       throws(SQLError) -> Plan {
     guard case .all = self else {
       let schema = Schema(width: 0, extent: 0, names: [], types: [],
                           virtuals: [])
-      let terms = try schema.terms(self, in: Relation(name: ""), routines,
+      let relation = Relation(name: "")
+      let terms = try schema.terms(self, in: relation, routines,
                                    subquery: subquery)
-      return .project(terms, .single)
+      var keys = Array<SortKey>()
+      if let order {
+        let names = self.outputs(count: terms.count)
+        keys = try schema.order(order, in: relation, terms, names, routines,
+                                subquery: subquery)
+        // Every FROM-less ORDER BY key is a select-list output already, so the
+        // DISTINCT rule (a key must be a projected value) rebinds none; the
+        // call still enforces it against a direct `Select`.
+        if distinct { keys = try SQLEngine.distinct(order.keys, keys, terms) }
+      }
+      return Plan.single.shaped(distinct: distinct, projection: terms,
+                                filter: nil, order: keys, limit: limit)
     }
     // `SELECT *` names every column of the relations in scope; a FROM-less
     // query has none, so there is nothing to expand.
@@ -351,10 +373,17 @@ extension Catalog where Self: ~Escapable {
     // d` resolves `d`'s width. It is per arm so the left arm's `d` never
     // leaks to the right (the arm-scoping fix); the width each check computes
     // matches what the arm actually produces at run.
+    // Compare each operand's real output width — its first arm's projection
+    // width less the hidden `generated` sort columns the carriers on the path
+    // appended (a parenthesised operand with an unprojected-aggregate ORDER BY
+    // carries one, trimmed at its carrier), so a valid one-column union of such
+    // an operand is not rejected on the leaked hidden column.
     let head = try augment(context, for: .select(query.first), rows: false)
     let tail = try augment(context, for: .select(right.first), rows: false)
-    let width = try arity(query.first, head)
-    let count = try arity(right.first, tail)
+    let width = try real(trimming: query.generated,
+                         of: arity(query.first, head))
+    let count = try real(trimming: right.generated,
+                         of: arity(right.first, tail))
     guard count == width else { throw .arity(width, count) }
     // Both arms of a set-operation subquery correlate against the same
     // enclosing scope, so each lowers under the shared `context.outer`. The
@@ -675,6 +704,27 @@ extension Catalog where Self: ~Escapable {
   /// and the correlated `existential` plan both compile/execute this shape, so
   /// a correlated EXISTS probes per outer row as an uncorrelated one does.
   internal borrowing func probed(_ query: Query) -> Query {
+    // An `ordered` carrier over a probable primary — a parenthesised
+    // `(SELECT …) ORDER BY … FETCH n` in EXISTS position — must probe its inner
+    // primary, not evaluate it as a leaf. Existence is order-independent, so
+    // the `ORDER BY` drops; the carrier's `DISTINCT`/`OFFSET`·`FETCH` affect
+    // cardinality, so they ride the probed inner (`FETCH FIRST 0 ROWS` probes
+    // zero, EXISTS false). Peel, probe the inner, re-wrap without the order.
+    if case let .ordered(inner, distinct, _, limit, _) = query {
+      // Rewriting the base projection to a constant collapses distinct rows to
+      // one (a `DISTINCT` on any carrier in the stack, or on the base select).
+      // A positive OFFSET on this carrier applied afterwards would then wrongly
+      // drop that lone row, so keep the whole query unrewritten when the offset
+      // depends on distinct cardinality — its select list and sort evaluate,
+      // exactly as a direct `SELECT DISTINCT … OFFSET k` (non-probable) does.
+      // `query.dedups` is carrier-transparent, so a `DISTINCT` reached only
+      // through a stacked `ordered` node (`((SELECT DISTINCT …) ORDER BY …)
+      // OFFSET 1`) still suppresses the rewrite. Otherwise probe the inner and
+      // drop this ORDER BY (existence is order-independent).
+      if query.dedups, (limit?.offset ?? 0) >= 1 { return query }
+      return .ordered(probed(inner), distinct: distinct, order: nil,
+                      limit: limit, generated: 0)
+    }
     guard case let .select(select) = query, select.probable else {
       return query
     }
@@ -1292,21 +1342,32 @@ extension Catalog where Self: ~Escapable {
     // overlay never overwrote the CTE, so no separate pre-augment context runs.
     let context = try augment(context, for: .select(select), rows: false)
     guard let relation = select.from else {
-      // A FROM-less select projects expressions over a single row; a `WHERE`,
-      // `GROUP BY`, `HAVING`, `ORDER BY`, `OFFSET`/`FETCH`, or `JOIN` has no
-      // relation to apply to. The parser never produces that shape, but a
-      // direct `Select(from: nil, …)` can, so reject it rather than silently
-      // ignore the clause — a scalar projection would drop a `GROUP
-      // BY`/`HAVING` otherwise.
+      // A FROM-less select projects expressions over a single row. A `WHERE`,
+      // `GROUP BY`, `HAVING`, or `JOIN` has no relation to apply to, so reject
+      // it rather than silently ignore the clause — a scalar projection would
+      // drop a `GROUP BY`/`HAVING` otherwise. `ORDER BY` and `OFFSET`/`FETCH`
+      // do apply: they order and page that single-row result (ISO), so the
+      // enclosing query expression's trailing tail on a FROM-less primary —
+      // `VALUES (1) ORDER BY 1`, `(SELECT 1 FETCH FIRST 0 ROWS ONLY) UNION …` —
+      // runs rather than faulting. The parser never produces a WHERE/GROUP/
+      // HAVING/JOIN here, but a direct `Select(from: nil, …)` can.
       let ungrouped = if case .keys([]) = select.grouping { true } else {
         false
       }
       guard select.joins.isEmpty, select.predicate == nil,
-          ungrouped, select.having == nil,
-          select.order == nil, select.limit == nil else {
+          ungrouped, select.having == nil else {
         throw .unsupported(
-            "a WHERE, GROUP BY, HAVING, ORDER BY, OFFSET/FETCH, or JOIN " +
-            "requires a FROM clause")
+            "a WHERE, GROUP BY, HAVING, or JOIN requires a FROM clause")
+      }
+      if let limit = select.limit {
+        // As on the FROM'd path, a direct `Limit` may carry negatives the
+        // executor would trap on (the parser yields only non-negative counts).
+        guard limit.offset >= 0 else {
+          throw .state("2201X", "OFFSET row count must be non-negative")
+        }
+        guard (limit.count ?? 0) >= 0 else {
+          throw .state("2201W", "FETCH row count must be non-negative")
+        }
       }
       // A scalar projection may still nest an uncorrelated subquery
       // (`SELECT CASE WHEN EXISTS (Q) …`); compile each once for its width and
@@ -1324,7 +1385,10 @@ extension Catalog where Self: ~Escapable {
       // `Term.parameter`, matching `columns(of:)`'s schema-path rejection.
       let plans = try subquery(of: select, context)
       return try select.projection.scalar(context.routines,
-                                          subquery: plans.rest)
+                                          subquery: plans.rest,
+                                          distinct: select.distinct,
+                                          order: select.order,
+                                          limit: select.limit)
     }
     // A LATERAL first FROM item has no preceding relation to correlate against,
     // so it is meaningless (and ISO forbids it) — fault rather than resolve a

--- a/Sources/SQLEngine/Compilation.swift
+++ b/Sources/SQLEngine/Compilation.swift
@@ -356,11 +356,14 @@ extension Catalog where Self: ~Escapable {
     // stack the row operators over its plan, resolved through the setop's
     // output scope (`ordered`). The row operators do NOT project, so the result
     // columns stay the union's — an identity projection over its output slots.
-    if case let .ordered(inner, distinct, order, limit, generated) = query {
-      return try ordered(inner, distinct: distinct, order: order,
-                         limit: limit, generated: generated, context)
+    if let carrier = query.carriers.last {
+      let inner = Query(body: query.body,
+                        carriers: Array(query.carriers.dropLast()))
+      return try ordered(inner, distinct: carrier.distinct,
+                         order: carrier.order, limit: carrier.limit,
+                         generated: carrier.generated, context)
     }
-    guard case let .setop(kind, left, right, all) = query else {
+    guard case let .setop(kind, left, right, all) = query.body else {
       return try compile(query.first, context)
     }
 
@@ -710,7 +713,9 @@ extension Catalog where Self: ~Escapable {
     // the `ORDER BY` drops; the carrier's `DISTINCT`/`OFFSET`·`FETCH` affect
     // cardinality, so they ride the probed inner (`FETCH FIRST 0 ROWS` probes
     // zero, EXISTS false). Peel, probe the inner, re-wrap without the order.
-    if case let .ordered(inner, distinct, _, limit, _) = query {
+    if let carrier = query.carriers.last {
+      let inner = Query(body: query.body,
+                        carriers: Array(query.carriers.dropLast()))
       // Rewriting the base projection to a constant collapses distinct rows to
       // one (a `DISTINCT` on any carrier in the stack, or on the base select).
       // A positive OFFSET on this carrier applied afterwards would then wrongly
@@ -718,14 +723,14 @@ extension Catalog where Self: ~Escapable {
       // depends on distinct cardinality — its select list and sort evaluate,
       // exactly as a direct `SELECT DISTINCT … OFFSET k` (non-probable) does.
       // `query.dedups` is carrier-transparent, so a `DISTINCT` reached only
-      // through a stacked `ordered` node (`((SELECT DISTINCT …) ORDER BY …)
-      // OFFSET 1`) still suppresses the rewrite. Otherwise probe the inner and
-      // drop this ORDER BY (existence is order-independent).
-      if query.dedups, (limit?.offset ?? 0) >= 1 { return query }
-      return .ordered(probed(inner), distinct: distinct, order: nil,
-                      limit: limit, generated: 0)
+      // through a stacked carrier (`((SELECT DISTINCT …) ORDER BY …) OFFSET 1`)
+      // still suppresses the rewrite. Otherwise probe the inner and drop this
+      // ORDER BY (existence is order-independent).
+      if query.dedups, (carrier.limit?.offset ?? 0) >= 1 { return query }
+      return .ordered(probed(inner), distinct: carrier.distinct, order: nil,
+                      limit: carrier.limit, generated: 0)
     }
-    guard case let .select(select) = query, select.probable else {
+    guard case let .select(select) = query.body, select.probable else {
       return query
     }
     return .select(select.probe)

--- a/Sources/SQLEngine/Definition.swift
+++ b/Sources/SQLEngine/Definition.swift
@@ -660,14 +660,14 @@ extension Query {
   /// instead lift a subquery's names into this query's statement-global
   /// overlay, where a sibling subquery could not rebind a same-named entry.
   func collect(into names: inout Set<String>) {
-    switch self {
+    // A carrier is transparent — its row operators name no relation — so
+    // descend the body.
+    switch body {
     case let .select(select):
       select.collect(into: &names)
     case let .setop(_, left, right, _):
       left.collect(into: &names)
       right.collect(into: &names)
-    case let .ordered(inner, _, _, _, _):
-      inner.collect(into: &names)
     }
   }
 
@@ -696,16 +696,14 @@ extension Query {
   /// `t` collide and an inner `t` cannot shadow an outer.
   func collect(derived derivations:
                    inout Array<(String, Query, Array<String>)>) {
-    switch self {
+    // A carrier is transparent to a query-level derived table, so descend to
+    // the body. A carrier over a single select (`(SELECT … FROM (…) AS d) ORDER
+    // BY …`) is one arm in this scope, so descend it to the inner select's
+    // FROM/JOIN derived tables. A carrier over a setop body collects nothing
+    // here — its arms augment on their own. Mirrors `collect(into:)`.
+    switch body {
     case let .select(select):
       select.collect(derived: &derivations)
-    case let .ordered(inner, _, _, _, _):
-      // A carrier over a single select (`(SELECT … FROM (…) AS d) ORDER BY …`)
-      // is one arm in this scope, so descend it to the inner select's FROM/JOIN
-      // derived tables. A carrier over a setop descends to that setop, which
-      // (like a bare setop) collects nothing here — its arms augment on their
-      // own. Mirrors `collect(into:)`.
-      inner.collect(derived: &derivations)
     case .setop:
       break
     }
@@ -719,11 +717,10 @@ extension Query {
   /// `setop` collects nothing, so each arm's ranges stay in its own scope, and
   /// a nested subquery is not descended.
   func collect(ranges: inout Array<String>) {
-    switch self {
+    // Carrier-transparent, as `collect(derived:)`: descend the body.
+    switch body {
     case let .select(select):
       select.collect(ranges: &ranges)
-    case let .ordered(inner, _, _, _, _):
-      inner.collect(ranges: &ranges)
     case .setop:
       break
     }
@@ -739,11 +736,10 @@ extension Query {
   /// stops at a `SELECT` as `collect(ranges:)` does: a `setop` collects
   /// nothing, and a nested subquery is not descended.
   func collect(sources: inout Array<String>) {
-    switch self {
+    // Carrier-transparent, as `collect(derived:)`: descend the body.
+    switch body {
     case let .select(select):
       select.collect(sources: &sources)
-    case let .ordered(inner, _, _, _, _):
-      inner.collect(sources: &sources)
     case .setop:
       break
     }

--- a/Sources/SQLEngine/Definition.swift
+++ b/Sources/SQLEngine/Definition.swift
@@ -696,8 +696,18 @@ extension Query {
   /// `t` collide and an inner `t` cannot shadow an outer.
   func collect(derived derivations:
                    inout Array<(String, Query, Array<String>)>) {
-    if case let .select(select) = self {
+    switch self {
+    case let .select(select):
       select.collect(derived: &derivations)
+    case let .ordered(inner, _, _, _, _):
+      // A carrier over a single select (`(SELECT … FROM (…) AS d) ORDER BY …`)
+      // is one arm in this scope, so descend it to the inner select's FROM/JOIN
+      // derived tables. A carrier over a setop descends to that setop, which
+      // (like a bare setop) collects nothing here — its arms augment on their
+      // own. Mirrors `collect(into:)`.
+      inner.collect(derived: &derivations)
+    case .setop:
+      break
     }
   }
 
@@ -709,8 +719,13 @@ extension Query {
   /// `setop` collects nothing, so each arm's ranges stay in its own scope, and
   /// a nested subquery is not descended.
   func collect(ranges: inout Array<String>) {
-    if case let .select(select) = self {
+    switch self {
+    case let .select(select):
       select.collect(ranges: &ranges)
+    case let .ordered(inner, _, _, _, _):
+      inner.collect(ranges: &ranges)
+    case .setop:
+      break
     }
   }
 
@@ -724,8 +739,13 @@ extension Query {
   /// stops at a `SELECT` as `collect(ranges:)` does: a `setop` collects
   /// nothing, and a nested subquery is not descended.
   func collect(sources: inout Array<String>) {
-    if case let .select(select) = self {
+    switch self {
+    case let .select(select):
       select.collect(sources: &sources)
+    case let .ordered(inner, _, _, _, _):
+      inner.collect(sources: &sources)
+    case .setop:
+      break
     }
   }
 }

--- a/Sources/SQLEngine/Engine.swift
+++ b/Sources/SQLEngine/Engine.swift
@@ -75,7 +75,8 @@ extension Catalog where Self: ~Escapable {
     // the right arm's its own derived one, then `combine` merges them under the
     // operator's duplicate rule. The arity across arms is checked as `compile`
     // resolves the whole query below.
-    if case let .setop(kind, left, right, all) = query {
+    if query.carriers.isEmpty, case let .setop(kind, left, right, all) = query
+        .body {
       // Validate the whole query (per-arm resolution and the cross-arm arity
       // check) exactly as a single select does, then run each arm on its own —
       // each arm's `run` threads its own lazy subquery box. `validate: false` —
@@ -171,7 +172,7 @@ extension Catalog where Self: ~Escapable {
     // guard keeps a plain query (and an ordered carrier over a bare `SELECT`,
     // not a setop) on the generic optimiser.
     let plan: Plan
-    if case .ordered = query, case .setop = query.core {
+    if !query.carriers.isEmpty, case .setop = query.body {
       plan = try optimise(decorrelated, query.core, augmented)
     } else {
       plan = try optimise(decorrelated, augmented)
@@ -186,7 +187,7 @@ extension Catalog where Self: ~Escapable {
     // execute through the carrier descent, which threads the inner union's arm
     // queries to the setop leaf and runs `arms` there — the same per-arm
     // machinery — leaving the sort/dedup/limit/project stack above unchanged.
-    if case .ordered = query, case .setop = query.core {
+    if !query.carriers.isEmpty, case .setop = query.body {
       return try execute(plan, carrying: query.core, augmented).map(\.values)
     }
     // A carrier over a bare `SELECT` (a parenthesised simple query with an
@@ -407,7 +408,7 @@ extension Catalog where Self: ~Escapable {
     // same-named base/view can seed it — the shape `with` rejects before
     // routing to the fixpoint.
     if cte.recursive,
-        case let .setop(.union, anchor, _, _) = try cte.canonical.inner,
+        case let .setop(.union, anchor, _, _) = try cte.canonical.inner.body,
         anchor.references(cte.name.lowercased()),
         case nil = table(named: cte.name),
         case nil = view(named: cte.name) {
@@ -425,7 +426,7 @@ extension Catalog where Self: ~Escapable {
     // relation and the body runs once, as the misplaced-anchor guard allows).
     let core = try cte.canonical.inner
     if cte.recursive,
-        case let .setop(kind, _, _, _) = core, kind != .union,
+        case let .setop(kind, _, _, _) = core.body, kind != .union,
         core.references(cte.name.lowercased()),
         case nil = table(named: cte.name),
         case nil = view(named: cte.name) {
@@ -609,7 +610,7 @@ extension Catalog where Self: ~Escapable {
     // so `recurses` already routed an ordered body here. `canonical` expands a
     // grouping-sets body FIRST, matching the `query` `augment` sees above.
     let (body, carriers) = try cte.canonical
-    guard case let .setop(.union, anchor, recursive, all) = body else {
+    guard case let .setop(.union, anchor, recursive, all) = body.body else {
       // A non-`UNION` recursive query runs once, but still binds under
       // `cte.columns`, so validate its compiled width here too — the check the
       // anchor and arm get. A body naming a base relation of the CTE's own name

--- a/Sources/SQLEngine/Engine.swift
+++ b/Sources/SQLEngine/Engine.swift
@@ -186,9 +186,13 @@ extension Catalog where Self: ~Escapable {
     // execute through the carrier descent, which threads the inner union's arm
     // queries to the setop leaf and runs `arms` there — the same per-arm
     // machinery — leaving the sort/dedup/limit/project stack above unchanged.
-    if case let .ordered(inner, _, _, _, _) = query {
-      return try execute(plan, carrying: inner, augmented).map(\.values)
+    if case .ordered = query, case .setop = query.core {
+      return try execute(plan, carrying: query.core, augmented).map(\.values)
     }
+    // A carrier over a bare `SELECT` (a parenthesised simple query with an
+    // outer tail — `(SELECT …) ORDER BY …`) has no set-operation arms to
+    // augment, so its `.shaped` plan runs through the plain executor; only a
+    // carrier over a `.setop` needs the per-arm carrier descent above.
     return try execute(plan, augmented).map(\.values)
   }
 
@@ -438,7 +442,7 @@ extension Catalog where Self: ~Escapable {
     // canonical (unwound) shape the run's `fixpoint` and the schema
     // `contributions` do, so all three inspect the identical AST.
     if let (anchor, recursive, _) = try cte.recursiveArms {
-      let carrier = try cte.canonical.carrier
+      let carriers = try cte.canonical.carriers
       let scope = try augment(context.validating(typecheck), for: anchor,
                               rows: false)
       let width = try compile(anchor, scope).width
@@ -509,16 +513,19 @@ extension Catalog where Self: ~Escapable {
         // fixpoint. The declared rename rides the CTE binding after the
         // carrier, so — as the run does — the carrier resolves the body's
         // output names.
-        if let carrier {
+        if !carriers.isEmpty {
           // A set operation names its output off its FIRST arm (the ISO rule),
-          // so the carrier's `ORDER BY` resolves against the anchor's output
+          // so each carrier's `ORDER BY` resolves against the anchor's output
           // names — resolved with the CTE self NOT in scope, so the anchor's
           // own names/types derive without faulting `.relation` on the
           // recursive arm's self reference. (Unifying the whole `body` would
-          // need the self bound to fold the recursive arm.)
+          // need the self bound to fold the recursive arm.) Stacked carriers
+          // all page and order the same set-op output, so each validates it.
           let outputs = try columns(unifying: anchor, scope)
-          try validate(carrier: carrier, over: outputs, arm: anchor.first,
-                       context.validating(true))
+          for carrier in carriers {
+            try validate(carrier: carrier, over: outputs, arm: anchor.first,
+                         context.validating(true))
+          }
         }
       }
     } else {
@@ -601,7 +608,7 @@ extension Catalog where Self: ~Escapable {
     // carrier is transparent to the recursive shape (`references` descends it),
     // so `recurses` already routed an ordered body here. `canonical` expands a
     // grouping-sets body FIRST, matching the `query` `augment` sees above.
-    let (body, carrier) = try cte.canonical
+    let (body, carriers) = try cte.canonical
     guard case let .setop(.union, anchor, recursive, all) = body else {
       // A non-`UNION` recursive query runs once, but still binds under
       // `cte.columns`, so validate its compiled width here too — the check the
@@ -757,13 +764,18 @@ extension Catalog where Self: ~Escapable {
     // type the materialised rows hold. The CTE-declared rename rides the
     // returned `merged` carrier, applied after the carrier at CTE consumption,
     // so the outer `SELECT n FROM t` still addresses `n`.
-    if let carrier {
+    if !carriers.isEmpty {
       let outputs = try columns(unifying: anchor, context)
       let named = merged.indices.map {
         ResolvedColumn(name: outputs[$0].name, type: merged[$0].type,
                        unconstrained: merged[$0].unconstrained)
       }
-      result = try apply(carrier, result, named, arm: anchor.first, context)
+      // Stacked carriers (`(recursive-union ORDER BY 1) ORDER BY 1`) apply
+      // innermost first — the peel order — each over the prior result, so the
+      // outer tail pages/orders what the inner already produced.
+      for carrier in carriers {
+        result = try apply(carrier, result, named, arm: anchor.first, context)
+      }
     }
     return (result, merged)
   }

--- a/Sources/SQLEngine/Filter.swift
+++ b/Sources/SQLEngine/Filter.swift
@@ -1264,6 +1264,18 @@ extension Catalog where Self: ~Escapable {
       return try combine(kind, arms(left, leftQuery, context),
                          arms(right, rightQuery, context), all, types: types)
     }
+    // An arm that is itself a suffix-bearing parenthesised set operation
+    // (`… UNION (… UNION … ORDER BY V FETCH n)`) reaches here as an
+    // `.ordered(.setop(…))` whose plan is a `.shaped` carrier stack over the
+    // setop, NOT the bare `.setop` this recursion splits — so descend the
+    // carrier to that setop leaf through the same descender the entry and view
+    // paths use (`execute(_:carrying:)`), which per-arm augments the inner
+    // arms' derived aliases there. Treating the whole carrier as one leaf would
+    // whole-query augment it, binding none of those aliases (arms are
+    // SELECT-scoped) — the `.relation` fault this closes.
+    if case .setop = query.core {
+      return try execute(plan, carrying: query.core, context)
+    }
     let augmented =
         try augment(context.validating(false), for: query, rows: true)
     return try execute(plan, augmented)

--- a/Sources/SQLEngine/Filter.swift
+++ b/Sources/SQLEngine/Filter.swift
@@ -1138,7 +1138,7 @@ extension Catalog where Self: ~Escapable {
     // `.ordered` carrier and skip a reached carried union's strict re-fold,
     // diverging run from the uncorrelated `.operand`/42804 fault.
     if key.role == .scalar || key.role == .valued,
-        case .setop = key.query.core, !context.subqueries.validated(key) {
+        case .setop = key.query.body, !context.subqueries.validated(key) {
       _ = try types(unifying: key.query, context)
       context.subqueries.validate(key)
     }
@@ -1156,7 +1156,7 @@ extension Catalog where Self: ~Escapable {
     // the query itself and the descender's `.setop` leaf is `arms(plan, core,
     // context)` — the prior direct call — so a non-ordered set operation is
     // unchanged.
-    if case .setop = key.query.core {
+    if case .setop = key.query.body {
       return try execute(plan, carrying: key.query.core, context)
     }
     let augmented =
@@ -1257,7 +1257,8 @@ extension Catalog where Self: ~Escapable {
   internal borrowing func arms(_ plan: Plan, _ query: Query, _ context: Context)
       throws(SQLError) -> Array<Record> {
     if case let .setop(kind, left, right, all, types, _) = plan,
-        case let .setop(_, leftQuery, rightQuery, _) = query {
+        query.carriers.isEmpty,
+        case let .setop(_, leftQuery, rightQuery, _) = query.body {
       // The unified column `types` the plan carries (computed at compile) drive
       // the arm coercion `combine` applies — the same types every set-op path
       // uses, so a mixed-type arm widens identically here.
@@ -1273,7 +1274,7 @@ extension Catalog where Self: ~Escapable {
     // arms' derived aliases there. Treating the whole carrier as one leaf would
     // whole-query augment it, binding none of those aliases (arms are
     // SELECT-scoped) — the `.relation` fault this closes.
-    if case .setop = query.core {
+    if case .setop = query.body {
       return try execute(plan, carrying: query.core, context)
     }
     let augmented =

--- a/Sources/SQLEngine/GroupingSets.swift
+++ b/Sources/SQLEngine/GroupingSets.swift
@@ -17,22 +17,23 @@ extension Query {
   /// shallow pass at each entry covers arbitrary nesting.
   internal var expanded: Query {
     get throws(SQLError) {
-      switch self {
+      // A carrier is transparent to the expansion — its row operators add no
+      // grouping — so expand the body and carry the stack through unchanged. A
+      // grouping-sets body is produced afresh by `expand` (whose own carrier,
+      // if any, sits innermost, beneath this query's carriers); a `setop` body
+      // recurses into its arms.
+      switch body {
       case let .select(select):
         if case let .sets(sets) = select.grouping {
-          return try expand(select, sets: sets)
+          let expanded = try expand(select, sets: sets)
+          return Query(body: expanded.body,
+                       carriers: expanded.carriers + carriers)
         }
         return self
       case let .setop(kind, left, right, all):
-        return .setop(kind, try left.expanded, try right.expanded, all: all)
-      case let .ordered(inner, distinct, order, limit, generated):
-        // An `ordered` carrier is produced by `expand` over an already-
-        // expanded union, so its inner is idempotent under a re-expansion;
-        // recurse for uniformity (a nested `.sets` inside is impossible —
-        // `expand` only ever wraps a `setop` of `.arm` selects). The generated
-        // trailing count rides through unchanged.
-        return .ordered(try inner.expanded, distinct: distinct, order: order,
-                        limit: limit, generated: generated)
+        return Query(body: .setop(kind, try left.expanded,
+                                  try right.expanded, all: all),
+                     carriers: carriers)
       }
     }
   }

--- a/Sources/SQLEngine/Interpreter.swift
+++ b/Sources/SQLEngine/Interpreter.swift
@@ -862,7 +862,8 @@ extension Catalog where Self: ~Escapable {
     }
     let rows: Array<Record>
     let view = resolve(view: name)
-    if let view, case .setop = view.query, case .setop = plan {
+    if let view, view.query.carriers.isEmpty, case .setop = view.query.body,
+        case .setop = plan {
       // A SET-operation view body executes each ARM's sub-plan under an overlay
       // augmented with that arm's own derived aliases. A `setop` collects no
       // derived aliases at the query level (arms are SELECT-scoped), so the
@@ -880,8 +881,8 @@ extension Catalog where Self: ~Escapable {
       // materialise would fault `.relation("d")` before an arm ever ran.
       // Mirrors the per-arm run and `SELECT *` arity paths.
       rows = try setop(plan, view.query, overlay, name.lowercased())
-    } else if let view, case .ordered = view.query,
-        case .setop = view.query.core {
+    } else if let view, !view.query.carriers.isEmpty,
+        case .setop = view.query.body {
       // The body is a set operation under an `ordered` carrier (`… UNION …
       // ORDER BY V`), whose plan is a `.shaped` project/sort/distinct stack
       // over the `.setop`, NOT a bare setop, so both guards above failed and
@@ -944,7 +945,7 @@ extension Catalog where Self: ~Escapable {
     // untouched.
     let query = query.core
     if case let .setop(kind, left, right, all, types, _) = plan,
-        case let .setop(_, leftQuery, rightQuery, _) = query {
+        case let .setop(_, leftQuery, rightQuery, _) = query.body {
       // This node's arm queries are in hand, so the unified column `types` the
       // plan carries (computed at compile) drive the arm coercion `combine`
       // applies — the same types the top-level and Plan-node paths use.
@@ -962,7 +963,7 @@ extension Catalog where Self: ~Escapable {
     // plan is the ARM's own sub-plan and must execute AS A unit under its own
     // augment below, NOT be walked through as a carrier wrapper (which would
     // apply the arm's projection/filter outside its arm-local scope).
-    if case .setop = query {
+    if case .setop = query.body {
       switch plan {
       case let .project(terms, source):
         let source = try setop(source, query, overlay, name)

--- a/Sources/SQLEngine/Interpreter.swift
+++ b/Sources/SQLEngine/Interpreter.swift
@@ -932,6 +932,17 @@ extension Catalog where Self: ~Escapable {
   private borrowing func setop(_ plan: Plan, _ query: Query, _ overlay: Context,
                                _ name: String)
       throws(SQLError) -> Array<Record> {
+    // See through an `ordered` carrier over a set operation nested as an arm: a
+    // suffix-bearing parenthesised setop (`… UNION (… UNION … ORDER BY V
+    // FETCH n)`) reaches this recursion as an `.ordered(.setop(…))` arm, whose
+    // plan is a `.shaped` carrier stack over the setop. Peel to the carrier-
+    // transparent `core` so the wrapper descent below fires and reaches the
+    // inner setop's arms — where the per-arm augment binds their derived
+    // aliases — rather than treating the whole carrier as one opaque leaf
+    // (whose whole-query augment binds none, faulting `.relation`). `core`
+    // leaves a bare setop or a leaf select unchanged, so a non-carried body is
+    // untouched.
+    let query = query.core
     if case let .setop(kind, left, right, all, types, _) = plan,
         case let .setop(_, leftQuery, rightQuery, _) = query {
       // This node's arm queries are in hand, so the unified column `types` the

--- a/Sources/SQLEngine/Optimisation.swift
+++ b/Sources/SQLEngine/Optimisation.swift
@@ -240,6 +240,15 @@ extension Catalog where Self: ~Escapable {
   internal borrowing func optimise(_ plan: Plan, _ query: Query,
                                    _ overlay: Context)
       throws(SQLError) -> Plan {
+    // See through an `ordered` carrier over a set operation nested as an arm,
+    // as the execute-side `setop`/`arms` do: a suffix-bearing parenthesised
+    // set operation reaches this recursion as an `.ordered(.setop(…))` arm
+    // whose plan is a `.shaped` carrier stack. Peel to the carrier-transparent
+    // `core` so the wrapper descent below fires and each inner arm optimises
+    // under its own augment — otherwise a filtered `.scan("d")` arm would
+    // seek-optimise against an unbound `d` and fault `.relation`. `core` leaves
+    // a bare setop or a leaf select unchanged.
+    let query = query.core
     if case let .setop(kind, left, right, all, types, widened) = plan,
         case let .setop(_, leftQuery, rightQuery, _) = query {
       return try .setop(kind, optimise(left, leftQuery, overlay),

--- a/Sources/SQLEngine/Optimisation.swift
+++ b/Sources/SQLEngine/Optimisation.swift
@@ -214,7 +214,8 @@ extension Catalog where Self: ~Escapable {
     // optimiser, whose pushdown/seek pass rebases a caller `WHERE` into each
     // arm. Preserved verbatim so a non-ordered union view's seek injection is
     // unchanged.
-    if case .setop = view.query, case .setop = plan {
+    if view.query.carriers.isEmpty, case .setop = view.query.body,
+        case .setop = plan {
       return try optimise(plan, view.query, overlay)
     }
     // A set operation under an `ordered` carrier compiles to a `.shaped` stack
@@ -225,7 +226,7 @@ extension Catalog where Self: ~Escapable {
     // `setop`/`execute(_:carrying:)` do. gated on the body actually wearing a
     // carrier (`view.query` an `.ordered`), so a bare union view keeps the
     // plain path above and this never rewrites its pushed `.select`/seek shape.
-    if case .ordered = view.query, case .setop = view.query.core {
+    if !view.query.carriers.isEmpty, case .setop = view.query.body {
       return try optimise(plan, view.query.core, overlay)
     }
     return try optimise(plan, overlay)
@@ -250,7 +251,7 @@ extension Catalog where Self: ~Escapable {
     // a bare setop or a leaf select unchanged.
     let query = query.core
     if case let .setop(kind, left, right, all, types, widened) = plan,
-        case let .setop(_, leftQuery, rightQuery, _) = query {
+        case let .setop(_, leftQuery, rightQuery, _) = query.body {
       return try .setop(kind, optimise(left, leftQuery, overlay),
                         optimise(right, rightQuery, overlay), all: all,
                         types: types, widened: widened)
@@ -263,7 +264,7 @@ extension Catalog where Self: ~Escapable {
     // plan is that ARM's own sub-plan, whose `.project`/`.select`/… must reach
     // the plain arm optimiser below (its seek/pushdown rewrite), NOT be walked
     // through as a carrier wrapper. So these cases fire ONLY above the setop.
-    if case .setop = query {
+    if case .setop = query.body {
       switch plan {
       case let .project(terms, source):
         return try .project(terms, optimise(source, query, overlay))

--- a/Sources/SQLEngine/Parser+Predicate.swift
+++ b/Sources/SQLEngine/Parser+Predicate.swift
@@ -318,12 +318,18 @@ extension Parser {
   /// into a `membership` (value-list) or a `within` (subquery) predicate over
   /// `left`.
   ///
-  /// After the opening `(`, one token of lookahead disambiguates the two forms:
-  /// a `SELECT` begins a subquery — `left [NOT] IN (query)`, the first-class
-  /// `Predicate.within` (the query may itself be a `UNION`) — and anything
-  /// else begins the value list, a non-empty run of comma-separated
-  /// expressions, the `Predicate.membership`. No rewind is needed: `SELECT`
-  /// never begins an expression, so the peek is unambiguous.
+  /// After the opening `(`, a `SELECT`/`TABLE`/`VALUES` begins a subquery —
+  /// `left [NOT] IN (query)`, the first-class `Predicate.within` (the query may
+  /// itself be a `UNION`) — the peek is unambiguous, as those keywords never
+  /// begin an expression. A leading `(` is genuinely ambiguous: it may begin a
+  /// nested query primary `IN ((SELECT …))` — a table subquery (membership) —
+  /// or a parenthesised value in a list `IN ((1), 2)` / `IN ((SELECT a),
+  /// (SELECT b))`. ISO tells them apart by whether the parenthesised content is
+  /// a single `<query expression>`: a `)` then closes the subquery, a `,`
+  /// continues a value list. That signal sits an unbounded distance past the
+  /// `(`, so speculatively parse a query and keep it only when a `)` follows
+  /// immediately; otherwise rewind the full cursor (lexer, current, and the
+  /// `pending` lookahead) and read the value list, as `composite()` rewinds.
   private mutating func membership(_ left: Expression, negated: Bool)
       throws(SQLError) -> Predicate {
     try expect(.lparen)
@@ -331,6 +337,18 @@ extension Parser {
       let query = try query()
       try expect(.rparen)
       return .within(left, query, negated: negated)
+    }
+    if current?.kind == .lparen {
+      let lexer = self.lexer
+      let token = self.current
+      let buffer = self.pending
+      if let query = try? query(), current?.kind == .rparen {
+        try expect(.rparen)
+        return .within(left, query, negated: negated)
+      }
+      self.lexer = lexer
+      self.current = token
+      self.pending = buffer
     }
     var values = [try expression()]
     while try match(.comma) {

--- a/Sources/SQLEngine/Parser+Projection.swift
+++ b/Sources/SQLEngine/Parser+Projection.swift
@@ -100,17 +100,33 @@ extension Parser {
   /// expressions, possibly empty.
   private mutating func factor() throws(SQLError) -> Expression {
     if try match(.lparen) {
-      // one token of lookahead after `(` disambiguates a scalar subquery from a
-      // parenthesised expression: a `SELECT`, `TABLE`, or `VALUES` begins a
-      // subquery — `(query)`, the first-class `Expression.subquery` (the query
-      // may itself be a `UNION`) — and anything else begins a parenthesised
-      // expression. No rewind is needed: none of these keywords begins an
-      // expression, so the peek is unambiguous, exactly as the `IN (…)` and
-      // `EXISTS (…)` lookaheads are.
+      // A `SELECT`, `TABLE`, or `VALUES` after `(` unambiguously begins a
+      // scalar subquery — `(query)`, the first-class `Expression.subquery` (the
+      // query may itself be a `UNION`) — as none of those keywords begins an
+      // expression. A leading `(` is ambiguous: it may open a nested query
+      // primary `((SELECT …) UNION …)` (a subquery) or a parenthesised
+      // expression `((1) + 2)`. They are told apart only by what follows the
+      // parenthesised content — a `)` closes a query expression, an operator
+      // continues an expression — so speculatively parse a query and keep it
+      // only when a `)` follows immediately, else rewind the full cursor
+      // (lexer, current, and the `pending` lookahead) and read the expression,
+      // as the `IN (…)` lookahead and `composite()` rewind.
       if [.select, .table, .values].contains(current?.kind) {
         let query = try query()
         try expect(.rparen)
         return .subquery(query)
+      }
+      if current?.kind == .lparen {
+        let lexer = self.lexer
+        let token = self.current
+        let buffer = self.pending
+        if let query = try? query(), current?.kind == .rparen {
+          try expect(.rparen)
+          return .subquery(query)
+        }
+        self.lexer = lexer
+        self.current = token
+        self.pending = buffer
       }
       let expression = try expression()
       try expect(.rparen)

--- a/Sources/SQLEngine/Parser.swift
+++ b/Sources/SQLEngine/Parser.swift
@@ -278,7 +278,7 @@ internal struct Parser: ~Escapable {
     // separately scoped tails (the inner picks the operand's rows, the outer
     // orders that primary's result), the ISO nesting boundary — not a `42601`
     // duplicate-clause error.
-    if case let .select(select) = query, !parenthesized {
+    if case let .select(select) = query.body, !parenthesized {
       return .select(Select(distinct: select.distinct,
                             projection: select.projection, from: select.from,
                             joins: select.joins, predicate: select.predicate,

--- a/Sources/SQLEngine/Parser.swift
+++ b/Sources/SQLEngine/Parser.swift
@@ -127,7 +127,10 @@
 internal struct Parser: ~Escapable {
   internal var lexer: Lexer
   internal var current: Token?
-  private var pending: Token?
+  // `internal`, not `private`: a speculative parse in another parser extension
+  // (`membership`'s `IN ((query))` disambiguation) must save and restore the
+  // full cursor — lexer, current, AND this lookahead buffer — on rewind.
+  internal var pending: Token?
 
   @_lifetime(copy lexer)
   internal init(_ lexer: consuming Lexer) throws(SQLError) {
@@ -248,77 +251,42 @@ internal struct Parser: ~Escapable {
   /// precedence. `ALL` keeps duplicate rows per the operator's multiplicity; a
   /// bare operator removes them — the distinction the engine honours.
   internal mutating func query() throws(SQLError) -> Query {
-    var query = try intersection()
+    var (query, parenthesized) = try intersection()
     while let kind: SetOperation = if try match(.union) { .union }
                                    else if try match(.except) { .except }
                                    else { nil } {
       let all = try match(.all)
-      query = try .setop(kind, query, intersection(), all: all)
+      query = try .setop(kind, query, intersection().query, all: all)
+      parenthesized = false
     }
-    // ISO 9075: an `ORDER BY` / `OFFSET`·`FETCH` after a set-operation chain
-    // applies to the whole result, not the trailing arm — an individual arm
-    // needs its own parentheses to carry one. The recursive-descent parse folds
-    // that trailing tail onto the last arm's `select` (a `select` greedily
-    // consumes its ORDER BY/limit); lift it here to the query-level `ordered`
-    // carrier over the union, where it resolves through the setop's output
-    // scope (`Catalog.ordered`) rather than binding the last arm's columns. A
-    // set operation carries no query-level `DISTINCT` in plain SQL (a bare
-    // `UNION` already dedups), so only the ORDER BY and limit are lifted.
-    //
-    // Gate on the top-level `query` being a set operation, NOT on the
-    // `UNION`/`EXCEPT` loop above having run: a top-level chain of only
-    // `INTERSECT` (or `EXCEPT`) is built inside `intersection()` and never
-    // enters this loop, yet its trailing `ORDER BY` must lift onto the combined
-    // output all the same — otherwise it stays on the last arm and binds that
-    // arm's columns rather than the intersect result named by the first arm.
-    guard case .setop = query else { return query }
-    // The trailing tail reaches the query level by two routes. When the last
-    // arm is a `SELECT`, that arm's greedy `select()` already consumed the
-    // `ORDER BY`/limit, so it sits on the rightmost arm and is lifted here (and
-    // trimmed off the arm, so it applies once). When the last arm is a `TABLE
-    // t`/`VALUES …` primary — neither carries a primary-level order (see
-    // `term`) — the tail is unconsumed at this point, so parse it here. Either
-    // way the tail lands on the `ordered` carrier over the union, resolved
-    // through the setop's output scope, not the last arm's columns.
-    let last = trailing(query)
-    if last.order != nil || last.limit != nil {
-      return .ordered(trim(query), distinct: false, order: last.order,
-                      limit: last.limit, generated: 0)
-    }
+    // ISO 9075: an `ORDER BY` / `OFFSET`·`FETCH` binds to the whole `<query
+    // expression body>` — a set operation, or a single primary — never to an
+    // arm. `select()` does not consume it, so no arm eats a query-level tail;
+    // parse it once here and apply it by scope.
     let order: Order? = try match(.order) ? try self.order() : nil
     let limit = try rowLimit()
     guard order != nil || limit != nil else { return query }
+    // A bare simple select (not parenthesised) carries the tail on itself,
+    // resolved under its own full scope — an `ORDER BY` over a non-projected
+    // column resolves, as a derived table's does; `select()` consumes no tail,
+    // so such a select has none of its own yet. Everything else — a set
+    // operation, or a parenthesised primary — carries the outer tail on an
+    // output-scoped `ordered` carrier, so `(SELECT n FROM B) ORDER BY m` faults
+    // on the non-output `m` rather than sorting by a hidden column. A
+    // parenthesised primary that already has its own inner tail rides a second
+    // carrier — `(SELECT … ORDER BY … FETCH 1) ORDER BY …` has two independent,
+    // separately scoped tails (the inner picks the operand's rows, the outer
+    // orders that primary's result), the ISO nesting boundary — not a `42601`
+    // duplicate-clause error.
+    if case let .select(select) = query, !parenthesized {
+      return .select(Select(distinct: select.distinct,
+                            projection: select.projection, from: select.from,
+                            joins: select.joins, predicate: select.predicate,
+                            grouping: select.grouping, having: select.having,
+                            order: order, limit: limit))
+    }
     return .ordered(query, distinct: false, order: order, limit: limit,
                     generated: 0)
-  }
-
-  /// The rightmost arm's `Select` of a set-operation `query` — the arm the
-  /// recursive-descent parse folds a trailing query-level `ORDER BY`/limit
-  /// onto, reached by descending each set operation's RIGHT term.
-  private func trailing(_ query: Query) -> Select {
-    switch query {
-    case let .select(select): select
-    case let .setop(_, _, right, _): trailing(right)
-    case let .ordered(inner, _, _, _, _): trailing(inner)
-    }
-  }
-
-  /// `query` with its last arm's `order`/`limit` cleared — the query-level tail
-  /// a set-operation `query` lifted onto the `ordered` carrier, removed from
-  /// the arm that greedily parsed it so it is applied once, over the union.
-  private func trim(_ query: Query) -> Query {
-    switch query {
-    case let .select(select):
-      .select(Select(distinct: select.distinct, projection: select.projection,
-                     from: select.from, joins: select.joins,
-                     predicate: select.predicate, grouping: select.grouping,
-                     having: select.having, order: nil, limit: nil))
-    case let .setop(kind, left, right, all):
-      .setop(kind, left, trim(right), all: all)
-    case let .ordered(inner, distinct, order, limit, generated):
-      .ordered(trim(inner), distinct: distinct, order: order, limit: limit,
-               generated: generated)
-    }
   }
 
   /// Parses `term (INTERSECT [ALL] term)*`, the inner set-operation tier,
@@ -330,42 +298,73 @@ internal struct Parser: ~Escapable {
   /// `query` tier folds a `UNION`/`EXCEPT` around it. `INTERSECT ALL` keeps
   /// duplicate rows to the lesser multiplicity; a bare `INTERSECT` removes
   /// them.
-  private mutating func intersection() throws(SQLError) -> Query {
-    var query = try term()
+  private mutating func intersection()
+      throws(SQLError) -> (query: Query, parenthesized: Bool) {
+    var (query, parenthesized) = try term()
     while try match(.intersect) {
       let all = try match(.all)
-      query = try .setop(.intersect, query, term(), all: all)
+      query = try .setop(.intersect, query, term().query, all: all)
+      // A set operation is no longer a single parenthesised primary, so an
+      // outer tail is output-scoped through the `.setop` carrier path anyway.
+      parenthesized = false
     }
-    return query
+    return (query, parenthesized)
   }
 
-  /// Parses a query primary — a `SELECT …`, the ISO `TABLE t` shorthand, or the
-  /// ISO `VALUES (…), …` table value constructor — the leaf both set-operation
-  /// tiers compose over.
+  /// Parses a query primary — a `SELECT …`, a parenthesised query expression
+  /// `( … )`, the ISO `TABLE t` shorthand, or the ISO `VALUES (…), …` table
+  /// value constructor — the leaf both set-operation tiers compose over.
+  ///
+  /// A parenthesised `( <query expression> )` is the ISO `<query primary>` that
+  /// groups a set operation explicitly and carries a per-operand `ORDER BY`/
+  /// `OFFSET`·`FETCH`: `(A UNION B) INTERSECT C` overrides the default
+  /// INTERSECT-binds-tighter precedence, and `(SELECT … ORDER BY … FETCH n)
+  /// UNION …` takes the top `n` of one operand before the union. A `(` in this
+  /// query-primary position always begins a parenthesised query — no other form
+  /// starts with one here — so it is consumed without lookahead. The inner
+  /// `query()` parses that operand's own tail inside the parentheses and binds
+  /// it (on the operand's select, or an `ordered` carrier over its union), a
+  /// plain `select`/`setop`/`ordered` `Query` the enclosing tier composes.
   ///
   /// `TABLE t` is exactly `SELECT * FROM t` (ISO 9075 `<explicit table>`): it
   /// lowers to the same AST a star-projection single-relation select builds — a
-  /// `.all` projection over one named `Relation`, no `WHERE`/`GROUP`/`HAVING`/
-  /// order/limit — so compile, execute, and the `SELECT *` column expansion all
-  /// apply unchanged and it composes with `UNION`/`INTERSECT`/`EXCEPT` as a
-  /// parenthesised select would. The operand is a bare table or view name (the
-  /// same `identifier` a relation names); a derived table is not admitted, as
-  /// `TABLE (…)` is not an ISO form. Ordering is a select-internal clause here,
-  /// so a `TABLE t ORDER BY …` tail is not accepted at this primary level — the
-  /// `SELECT * FROM t ORDER BY …` spelling carries an order.
+  /// `.all` projection over one named `Relation` — so compile, execute, and
+  /// the `SELECT *` column expansion all apply unchanged and it composes with
+  /// `UNION`/`INTERSECT`/`EXCEPT`. The operand is a bare table or view name
+  /// (the same `identifier` a relation names); a derived table is not admitted,
+  /// as `TABLE (…)` is not an ISO form. A trailing `TABLE t ORDER BY …` binds
+  /// to the enclosing query expression (`query()` takes it), as after any
+  /// primary — the primary itself carries no order.
   ///
   /// `VALUES (…), …` desugars to a `UNION ALL` of FROM-less constant selects
-  /// (see `values()`), so it too composes with the set-operation tiers as a
-  /// parenthesised select would and carries no primary-level ordering.
-  private mutating func term() throws(SQLError) -> Query {
+  /// (see `values()`); a trailing `ORDER BY`/limit binds to the enclosing
+  /// query expression, as after any primary.
+  private mutating func term()
+      throws(SQLError) -> (query: Query, parenthesized: Bool) {
+    if try match(.lparen) {
+      // A parenthesised `<query expression>` — the inner `query()` parses its
+      // own `ORDER BY`/limit inside the parentheses and binds it to this
+      // operand (a lone select carries it on itself, a set operation on an
+      // `ordered` carrier). The operand's tail is bounded by the parentheses;
+      // a trailing tail after the `)` is the enclosing query expression's,
+      // taken by that `query()`. A `(` in query-primary position always begins
+      // a parenthesised query — no other primary starts with one — so it is
+      // consumed without lookahead. The `parenthesized` flag rides back so the
+      // enclosing `query()` resolves any outer tail against this primary's
+      // output columns, not the from-clause scope hidden inside it.
+      let query = try query()
+      try expect(.rparen)
+      return (query, true)
+    }
     if try match(.table) {
       let name = try identifier()
-      return .select(Select(projection: .all, from: Relation(name: name)))
+      return (.select(Select(projection: .all, from: Relation(name: name))),
+              false)
     }
     if current?.kind == .values {
-      return try values()
+      return (try values(), false)
     }
-    return try .select(select())
+    return (.select(try select()), false)
   }
 
   /// Parses the ISO `<table value constructor>` `VALUES (v, …), (v, …), …` (the
@@ -588,20 +587,18 @@ internal struct Parser: ~Escapable {
     } else {
       nil
     }
-    let order: Order? = if try match(.order) {
-      try order()
-    } else {
-      nil
-    }
-    let limit = try rowLimit()
 
-    // The `GROUP BY` tail is stored as-parsed — a `.keys` ordinary key list (or
-    // none) or a `.sets` `GROUPING SETS (…)` list. A `.sets` is expanded into a
-    // `UNION ALL` of per-arm groupings at compile and schema time (by resolved
-    // identity, so an absent key NULLs correctly), not desugared here.
+    // ORDER BY / OFFSET·FETCH are not consumed here: they belong to the
+    // enclosing `<query expression>`, not this `<query specification>`, so
+    // `query()` parses the tail once over the whole body — no set-operation arm
+    // eats a query-level tail — and applies it (on a lone select, or an
+    // `ordered` carrier over a union). The `GROUP BY` tail is stored as-parsed:
+    // a `.keys` ordinary key list (or none) or a `.sets` `GROUPING SETS (…)`
+    // list expanded into a `UNION ALL` of per-arm groupings at compile and
+    // schema time (by resolved identity), not desugared here.
     return Select(distinct: distinct, projection: projection, from: from,
                   joins: joins, predicate: predicate, grouping: grouping,
-                  having: having, order: order, limit: limit)
+                  having: having, order: nil, limit: nil)
   }
 
   /// Parses `BY <element> (',' <element>)*` (the `GROUP` keyword is already
@@ -978,9 +975,11 @@ internal struct Parser: ~Escapable {
       guard let token = current else {
         throw .incomplete(expected: "a derived table '(SELECT …)'")
       }
-      // A derived table is any query, so `TABLE t` and `VALUES (…)` each open
-      // one as `SELECT` does.
-      guard [.select, .table, .values].contains(token.kind) else {
+      // A derived table is any query, so `TABLE t`, `VALUES (…)`, and a nested
+      // parenthesised query primary `((SELECT …))` each open one as `SELECT`
+      // does. There is no value-list alternative in a FROM position, so a
+      // leading `(` is unambiguously a nested query primary.
+      guard [.select, .table, .values, .lparen].contains(token.kind) else {
         throw .unexpected(token.kind.description,
                           expected: "a derived table '(SELECT …)'",
                           at: token.location)

--- a/Sources/SQLEngine/Schema+Derivation.swift
+++ b/Sources/SQLEngine/Schema+Derivation.swift
@@ -833,11 +833,13 @@ extension Catalog where Self: ~Escapable {
   /// `HAVING` or set operation) runs in FULL, so its original is checked even
   /// for an `existential` reach.
   private borrowing func shape(of reach: Reach) -> Query {
-    guard reach.role == .existential, case let .select(select) = reach.query,
-        select.probable else {
-      return reach.query
-    }
-    return .select(select.probe)
+    // The validate side of the EXISTS cardinality probe: an `existential` reach
+    // checks the same probed shape the run compiles, so delegate to the single
+    // `probed(_:)` source of truth (which peels an `ordered` carrier over a
+    // probable primary and rewrites its select list to a constant). A scalar or
+    // valued reach evaluates its select list, so its original is checked.
+    guard reach.role == .existential else { return reach.query }
+    return probed(reach.query)
   }
 
   private borrowing func typecheck(_ select: Select, _ context: Context)
@@ -1069,14 +1071,18 @@ extension Catalog where Self: ~Escapable {
     }
     // The projection runs after any limit: a limit that drops every row it
     // would yield leaves only its aggregate folds (validated above) reachable.
-    // A whole-result aggregate emits exactly one row, so a positive OFFSET
-    // drops it too — not just a zero FETCH. A DISTINCT select is the exception:
-    // its plan is `Limit(Distinct(Project(…)))`, so the projection evaluates
-    // over every candidate row (dedup needs them) before the cap pages the
-    // deduplicated result — a zero FETCH or skipping OFFSET does not spare it.
-    // A false WHERE still yields no rows to dedup (handled above), so only the
-    // limit-based elision is bypassed for DISTINCT.
-    let sole = select.aggregates && select.grouping.expressions.isEmpty
+    // A single-row result — a whole-result aggregate, or any FROM-less select
+    // (one row over the `single` leaf) — emits exactly one row, so a positive
+    // OFFSET drops it too, not just a zero FETCH, and its projection is then
+    // unreachable; this matches the compile path, which caps the `single` plan
+    // below the projection. A DISTINCT select is the exception: its plan is
+    // `Limit(Distinct(Project(…)))`, so the projection evaluates over every
+    // candidate row (dedup needs them) before the cap pages the deduplicated
+    // result — a zero FETCH or skipping OFFSET does not spare it. A false WHERE
+    // still yields no rows to dedup (handled above), so only the limit-based
+    // elision is bypassed for DISTINCT.
+    let sole = select.from == nil
+        || (select.aggregates && select.grouping.expressions.isEmpty)
     var reachable = select.distinct
     if !reachable { reachable = !drops(select.limit, single: sole) }
     if reachable, case let .expressions(items) = select.projection {

--- a/Sources/SQLEngine/Schema+Derivation.swift
+++ b/Sources/SQLEngine/Schema+Derivation.swift
@@ -316,39 +316,19 @@ extension Catalog where Self: ~Escapable {
   /// read the `type`, and a further enclosing fold reads `unconstrained`.
   borrowing func columns(unifying query: Query, _ context: Context)
       throws(SQLError) -> Array<ResolvedColumn> {
-    switch query {
+    // The body's carrier-free result columns.
+    var cols: Array<ResolvedColumn>
+    switch query.body {
     case let .select(select):
       // A `GROUP BY GROUPING SETS (…)` derives its schema through the same
       // `UNION ALL` expansion the compile path uses, so the run and the derived
       // columns cannot diverge (`run ≡ columns(of:)`): the arms' NULL-padded
       // columns type through the set-operation `merge` exactly as the run's do.
       if case let .sets(sets) = select.grouping {
-        return try columns(unifying: expand(select, sets: sets), context)
+        cols = try columns(unifying: expand(select, sets: sets), context)
+      } else {
+        cols = try arms(of: select, context)
       }
-      return try arms(of: select, context)
-    case let .ordered(inner, _, _, _, generated):
-      // The `ordered` carrier is transparent to the result schema: `ORDER BY`,
-      // `DISTINCT`, and `OFFSET`/`FETCH` are row operators — they do NOT
-      // project — so the result columns are the inner setop's arm-0-named,
-      // unified ones whether reached via `run`/`compile` or `columns(of:)`
-      // (`run ≡ columns`). The one exception is a hidden materialised sort
-      // column (`expand` appends `generated` of them to every arm so an
-      // unprojected `ORDER BY MAX(x)` survives the union at equal arity): the
-      // carrier's compile trims them through the identity projection, so drop
-      // the matching trailing columns here too so the schema matches the run.
-      // The count is the structural `generated` the carrier carries, never a
-      // scan of the arm-0 names for a synthetic prefix — a user's delimited
-      // `AS "*gs0"` is a real output, not a generated column.
-      let cols = try columns(unifying: inner, context)
-      // Range-check `generated` against the width and take the trim width
-      // through the shared guard the compile carrier uses (`real(trimming:of:)`
-      // on Engine) before trimming: a public-AST count past the width makes
-      // `cols.count − generated` negative and `Array.prefix` precondition-traps
-      // the process, while a negative count returns ALL columns untrimmed —
-      // silently wrong and diverging from `run`, which faults the same XX000.
-      // One guard, one message ⇒ `columns(of:) ≡ run` on a malformed carrier.
-      let real = try real(trimming: generated, of: cols.count)
-      return Array(cols.prefix(real))
     case let .setop(_, left, right, _):
       let l = try columns(unifying: left, context)
       let r = try columns(unifying: right, context)
@@ -362,10 +342,33 @@ extension Catalog where Self: ~Escapable {
       // ahead of the reachability walk, so an unreached incompatible pair
       // yields a discardable placeholder rather than faulting; a reached
       // scalar/`IN` occurrence is re-folded strictly on the reached path.
-      return try l.indices.map { index throws(SQLError) in
+      cols = try l.indices.map { index throws(SQLError) in
         try merge(l[index], r[index], shape: context.shape)
       }
     }
+    // A carrier is transparent to the result schema: `ORDER BY`, `DISTINCT`,
+    // and `OFFSET`/`FETCH` are row operators — they do NOT project — so the
+    // result columns are the body's arm-0-named, unified ones whether reached
+    // via `run`/`compile` or `columns(of:)` (`run ≡ columns`). The one
+    // exception is a hidden materialised sort column (`expand` appends
+    // `generated` of them to every arm so an unprojected `ORDER BY MAX(x)`
+    // survives the union at equal arity): the carrier's compile trims them
+    // through the identity projection, so drop the matching trailing columns
+    // here too so the schema matches the run. The count is the structural
+    // `generated` each carrier carries, never a scan of the arm-0 names for a
+    // synthetic prefix — a user's delimited `AS "*gs0"` is a real output, not a
+    // generated column. Range-check `generated` against the width through the
+    // shared guard the compile carrier uses (`real(trimming:of:)` on Engine)
+    // before trimming: a public-AST count past the width makes `cols.count −
+    // generated` negative and `Array.prefix` precondition-traps the process,
+    // while a negative count returns ALL columns untrimmed — silently wrong and
+    // diverging from `run`, which faults the same XX000. One guard, one message
+    // ⇒ `columns(of:) ≡ run` on a malformed carrier.
+    for carrier in query.carriers {
+      let real = try real(trimming: carrier.generated, of: cols.count)
+      cols = Array(cols.prefix(real))
+    }
+    return cols
   }
 
   /// The unified column types of `query`, folded across every set-operation arm
@@ -593,7 +596,9 @@ extension Catalog where Self: ~Escapable {
     // on regardless of the incoming context's gate (a caller reaches here only
     // when validating).
     let context = try augment(context.validating(true), for: query, rows: false)
-    switch query {
+    // A carrier's row operators add no expression the arms carry — the body
+    // type-checks every reachable operand of its own arms.
+    switch query.body {
     case let .select(select):
       try typecheck(select, context)
     case let .setop(_, left, right, _):
@@ -601,26 +606,30 @@ extension Catalog where Self: ~Escapable {
       // enclosing scope, so each type-checks under the shared `context.outer`.
       try typecheck(left, context)
       try typecheck(right, context)
-    case let .ordered(inner, distinct, order, limit, generated):
-      // The `ordered` carrier's row operators add no expression the arms carry
-      // — the inner union type-checks every reachable operand of its own arms.
-      try typecheck(inner, context)
-      // But the carrier's own `ORDER BY` keys are a new expression surface,
-      // validated ONLY by the carrier compile (`ordered(…)` under `validate`).
-      // A reached scalar/`IN` subquery whose body is an ordered set operation
-      // is first compiled in the shape pre-pass with `validating(false)`, which
-      // bypasses that check, and is re-validated through this seam — so unless
-      // the carrier's keys are validated here too, an outer `columns(of:)`
-      // accepts a reached `(… UNION … ORDER BY missing(a))` a run faults
-      // (run-vs-validate divergence). Re-run the carrier compile in validate
-      // mode to validate the sort keys against the setop-output scope exactly
-      // as `ordered(…)` does — the plan is discarded, only the keys' fault
-      // matters. It is idempotent with the top-level `compile` (which already
-      // validated the same keys), and reached-only: an unreached ordered
-      // subquery never enters this seam, so its bad sort key stays deferred,
-      // matching the dead-scalar/dead-EXISTS posture.
-      _ = try ordered(inner, distinct: distinct, order: order, limit: limit,
-                      generated: generated, context.validating(true))
+    }
+    // Each carrier's own `ORDER BY` keys are a new expression surface,
+    // validated ONLY by the carrier compile (`ordered(…)` under `validate`). A
+    // reached scalar/`IN` subquery whose body is an ordered set operation is
+    // first compiled in the shape pre-pass with `validating(false)`, which
+    // bypasses that check, and is re-validated through this seam — so unless
+    // the carrier's keys are validated here too, an outer `columns(of:)`
+    // accepts a reached `(… UNION … ORDER BY missing(a))` a run faults (a
+    // run-vs-validate divergence). Re-run each carrier compile in validate mode
+    // over the query up to (not including) that carrier — the same inner it
+    // stacks over — to validate its sort keys against the body-output scope
+    // exactly as `ordered(…)` does — the plan is discarded, only the keys'
+    // fault matters. It is idempotent with the top-level `compile` (which
+    // already validated the same keys), and reached-only: an unreached ordered
+    // subquery never enters this seam, so its bad sort key stays deferred,
+    // matching the dead-scalar/dead-EXISTS posture. The augment above depends
+    // only on the body (carriers collect no derived table), so it is the scope
+    // each carrier resolves over.
+    for (index, carrier) in query.carriers.enumerated() {
+      let inner = Query(body: query.body,
+                        carriers: Array(query.carriers.prefix(index)))
+      _ = try ordered(inner, distinct: carrier.distinct, order: carrier.order,
+                      limit: carrier.limit, generated: carrier.generated,
+                      context.validating(true))
     }
   }
 

--- a/Sources/SQLEngine/With.swift
+++ b/Sources/SQLEngine/With.swift
@@ -9,15 +9,18 @@ extension CTE {
   /// inspect the identical AST.
   ///
   /// It applies `Query.expanded` (a `GROUP BY GROUPING SETS` body lowers to its
-  /// `UNION ALL` arms FIRST) then `Query.unwound` (a trailing query-level
-  /// `ORDER BY`/`OFFSET`·`FETCH`/`DISTINCT` carrier peels off the setop),
-  /// yielding the carrier-free inner query paired with the peeled `Carrier`. A
-  /// recursive grouping-sets body thus canonicalises to the same expanded,
-  /// unwound shape on both sides. Routing every seam through this one form
-  /// keeps the run and schema derivations in step.
-  internal var canonical: (inner: Query, carrier: Query.Carrier?) {
+  /// `UNION ALL` arms FIRST) then `Query.peeled` (every trailing query-level
+  /// `ORDER BY`/`OFFSET`·`FETCH`/`DISTINCT` carrier peels off the setop — a
+  /// parenthesised recursive union with its own tail plus an outer tail stacks
+  /// two), yielding the carrier-free inner query paired with the peeled
+  /// carriers, innermost first. A recursive grouping-sets body thus
+  /// canonicalises to the same expanded, peeled shape on both sides. Routing
+  /// every seam through this one form keeps the run and schema derivations in
+  /// step.
+  internal var canonical: (inner: Query, carriers: Array<Query.Carrier>) {
     get throws(SQLError) {
-      try query.expanded.unwound
+      let (core, carriers) = try query.expanded.peeled
+      return (core, carriers)
     }
   }
 

--- a/Sources/SQLEngine/With.swift
+++ b/Sources/SQLEngine/With.swift
@@ -45,7 +45,7 @@ extension CTE {
       (anchor: Query, recursive: Query, all: Bool)? {
     get throws(SQLError) {
       guard case let .setop(.union, anchor, recursive, all) = try canonical
-          .inner, recursive.references(name.lowercased()) else {
+          .inner.body, recursive.references(name.lowercased()) else {
         return nil
       }
       return (anchor, recursive, all)
@@ -69,13 +69,13 @@ extension Query {
   /// a self-reference lurking in a recursive body's anchor; `CTE.recurses`
   /// itself inspects only the recursive arm.
   internal func references(_ name: String) -> Bool {
-    switch self {
+    // A carrier is transparent to a relation reference — its row operators name
+    // no relation — so descend the body.
+    switch body {
     case let .select(select):
       select.references(name)
     case let .setop(_, left, right, _):
       left.references(name) || right.references(name)
-    case let .ordered(inner, _, _, _, _):
-      inner.references(name)
     }
   }
 }

--- a/Sources/SQLTestSupport/Parsing.swift
+++ b/Sources/SQLTestSupport/Parsing.swift
@@ -9,7 +9,8 @@ import Testing
 public func parse(select text: String,
                   location: Testing.SourceLocation = #_sourceLocation)
     throws(SQLError) -> Select {
-  guard case let .select(.select(select)) = try Statement(parsing: text) else {
+  guard case let .select(query) = try Statement(parsing: text),
+        case let .select(select) = query.body else {
     Issue.record("expected a single SELECT statement",
                  sourceLocation: location)
     throw SQLError.incomplete(expected: "a SELECT statement")

--- a/Tests/SQLTests/Expressions/ScalarFunctionTests.swift
+++ b/Tests/SQLTests/Expressions/ScalarFunctionTests.swift
@@ -219,8 +219,9 @@ private final class Talker: @unchecked Sendable {
 /// Parses `text` as a single-projection `SELECT`'s expression, so the special
 /// `POSITION`/`OVERLAY` syntax is checked to lower to the expected call.
 private func lower(_ text: String) throws -> Expression {
-  guard case let .select(.select(select)) =
+  guard case let .select(query) =
       try Statement(parsing: "SELECT \(text) FROM S"),
+      case let .select(select) = query.body,
       case let .expressions(projection) = select.projection,
       let first = projection.first else {
     Issue.record("expected a single projected expression")

--- a/Tests/SQLTests/Queries/EngineValueAndSetTests.swift
+++ b/Tests/SQLTests/Queries/EngineValueAndSetTests.swift
@@ -781,7 +781,7 @@ struct EngineScalarSelectTests {
   /// The `Select` of a parsed single-`SELECT` query — for building the FROM-less
   /// shapes the parser will not, by re-homing a clause onto a `from: nil` select.
   private static func select(_ text: String) throws -> Select {
-    guard case let .select(select) = try parse(text) else {
+    guard case let .select(select) = try parse(text).body else {
       throw SQLError.incomplete(expected: "a SELECT")
     }
     return select

--- a/Tests/SQLTests/Queries/EngineValueAndSetTests.swift
+++ b/Tests/SQLTests/Queries/EngineValueAndSetTests.swift
@@ -742,13 +742,14 @@ struct EngineScalarSelectTests {
 
   @Test func `a directly-built FROM-less select with clauses is rejected`() throws {
     // The parser never builds a FROM-less select carrying a WHERE, GROUP BY,
-    // HAVING, ORDER BY, OFFSET/FETCH, or JOIN, but a direct `Select(from: nil,
-    // …)` can. The engine rejects it rather than silently drop the clause — a
-    // false predicate or HAVING would otherwise still return the scalar row.
+    // HAVING, or JOIN, but a direct `Select(from: nil, …)` can. The engine
+    // rejects it rather than silently drop the clause — a false predicate or
+    // HAVING would otherwise still return the scalar row. (ORDER BY and
+    // OFFSET/FETCH do apply to the single row and are covered by the VALUES
+    // FROM-less tail tests.)
     let fault =
         SQLError.unsupported(
-            "a WHERE, GROUP BY, HAVING, ORDER BY, OFFSET/FETCH, or JOIN " +
-            "requires a FROM clause")
+            "a WHERE, GROUP BY, HAVING, or JOIN requires a FROM clause")
     let filtered = try EngineScalarSelectTests.select(
         "SELECT 1 FROM People WHERE Id = 99")
     #expect(throws: fault) {
@@ -768,18 +769,6 @@ struct EngineScalarSelectTests {
       try roster().run(.select(Select(projection: filteredGroup.projection,
                                     from: nil,
                                     having: filteredGroup.having)))
-    }
-    let ordered =
-        try EngineScalarSelectTests.select("SELECT Id FROM People ORDER BY Id")
-    #expect(throws: fault) {
-      try roster().run(.select(Select(projection: ordered.projection, from: nil,
-                                    order: ordered.order)))
-    }
-    let limited = try EngineScalarSelectTests.select(
-        "SELECT Id FROM People FETCH FIRST 1 ROW ONLY")
-    #expect(throws: fault) {
-      try roster().run(.select(Select(projection: limited.projection, from: nil,
-                                    limit: limited.limit)))
     }
     let joined = try EngineScalarSelectTests.select(
         "SELECT Id FROM People JOIN Pets ON Pets.Owner = People.Id")
@@ -1168,7 +1157,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
     // rather than faulting `.operand` against the text `'x'`. The union yields
     // only the reached `'x'` row.
     try roster().expect("""
-        SELECT NOPE(Name) FROM People FETCH FIRST 0 ROWS ONLY
+        (SELECT NOPE(Name) FROM People FETCH FIRST 0 ROWS ONLY)
           UNION SELECT 'x'
         """, yields: [["x"]])
   }
@@ -1181,7 +1170,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
     // unconstrained and the fold defers to the text `'x'` rather than faulting
     // `.operand` on the fabricated `.integer`. The union yields only `'x'`.
     try roster().expect("""
-        SELECT NOPE(Name) + 0 FROM People FETCH FIRST 0 ROWS ONLY
+        (SELECT NOPE(Name) + 0 FROM People FETCH FIRST 0 ROWS ONLY)
           UNION SELECT 'x'
         """, yields: [["x"]])
   }
@@ -1250,7 +1239,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
     // filtered out: a zero-row `COALESCE(missing(), 1)` arm never evaluates the
     // call, so the union folds and yields only the reached text `'x'`.
     try roster().expect("""
-        SELECT COALESCE(missing(), 1) FROM People FETCH FIRST 0 ROWS ONLY
+        (SELECT COALESCE(missing(), 1) FROM People FETCH FIRST 0 ROWS ONLY)
           UNION SELECT 'x'
         """, yields: [["x"]])
   }
@@ -1506,7 +1495,7 @@ struct EngineReachedCorrelatedSetopTests {
       "tag": Routine(returns: .text, parameters: [.text]) { _ in .text("t") }
     ]
     try roster().expect("""
-        SELECT tag() FROM People FETCH FIRST 0 ROWS ONLY UNION SELECT 1
+        (SELECT tag() FROM People FETCH FIRST 0 ROWS ONLY) UNION SELECT 1
         """, yields: [[1]], routines: routines)
   }
 

--- a/Tests/SQLTests/Queries/EngineWithTests.swift
+++ b/Tests/SQLTests/Queries/EngineWithTests.swift
@@ -444,6 +444,25 @@ struct EngineRecursiveTests {
     #expect(rows == [[.integer(1)], [.integer(2)], [.integer(3)]])
   }
 
+  @Test func `a stacked carrier over a recursive union still recurses`() throws {
+    // A parenthesised recursive union with its own ORDER BY, wrapped by an outer
+    // ORDER BY, stacks two `ordered` carriers over the `UNION`. Canonicalisation
+    // must peel BOTH to recognise the recursive setop — else the body is
+    // misclassified non-recursive and `t` compiles unbound (`.relation("t")`).
+    // Schema and run agree: one column `n`, fixpoint 1, 2, 3.
+    let statement = try Statement(parsing: """
+        WITH RECURSIVE t (n) AS (
+          (SELECT 1 UNION ALL SELECT n + 1 FROM t WHERE n < 3 ORDER BY 1)
+          ORDER BY 1
+        ) SELECT n FROM t
+        """)
+    let columns = try family().columns(of: statement, validate: true)
+    #expect(columns.count == 1)
+    #expect(columns[0].name == "n")
+    let rows = try family().run(statement)
+    #expect(rows == [[.integer(1)], [.integer(2)], [.integer(3)]])
+  }
+
   @Test func `a recursive CTE carrier ORDER BY runs a correlated sort-key subquery`()
       throws {
     // The carrier `ORDER BY` peeled off a recursive-CTE fixpoint is applied to

--- a/Tests/SQLTests/Queries/GroupingSetsTests.swift
+++ b/Tests/SQLTests/Queries/GroupingSetsTests.swift
@@ -566,8 +566,8 @@ struct GroupingSetsTests {
 
   @Test func `a recursive CTE whose anchor is a grouping-sets shape expands`()
       throws {
-    // The cross case the shared `CTE.canonical = query.expanded.unwound` peel
-    // enables: a RECURSIVE CTE whose anchor is a `GROUP BY GROUPING SETS`
+    // The cross case the shared `CTE.canonical = query.expanded.peeled` peel
+    // enables: a recursive CTE whose anchor is a `GROUP BY GROUPING SETS`
     // shape. `canonical` expands the anchor's `.sets` node to its `UNION ALL`
     // FIRST, so the recursive-shape recogniser peels the resulting inner
     // `((per-Region ∪ grand-total) ∪ recursive)` union — the same AST the

--- a/Tests/SQLTests/Queries/LimitTests.swift
+++ b/Tests/SQLTests/Queries/LimitTests.swift
@@ -152,7 +152,7 @@ struct LimitTests {
     // executor's skip and take would trap on it, so the engine rejects it as a
     // query error instead.
     let query = try parse(query: "SELECT Id FROM People")
-    guard case let .select(base) = query else {
+    guard case let .select(base) = query.body else {
       Issue.record("expected a single SELECT")
       return
     }

--- a/Tests/SQLTests/Queries/OrderedSetOperationCarrierTests.swift
+++ b/Tests/SQLTests/Queries/OrderedSetOperationCarrierTests.swift
@@ -56,6 +56,47 @@ private func views() throws -> FixtureCatalog {
   }
 }
 
+/// A catalog for a suffix-bearing set-operation carrier NESTED as an operand of
+/// an OUTER set operation — the reviewer's shape. `A` {1, 2}, `B` {2, 3}, `C`
+/// {3, 4}. The nested operand `(d UNION ALL C ORDER BY n FETCH FIRST 1 ROW
+/// ONLY)` — `d` being the arm-local derived `SELECT n FROM B` — orders the
+/// four-row union {2, 3, 3, 4} and takes the one smallest, 2. The view body
+/// unions `A` with that, yielding 1, 2, 2.
+private func nested() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("A", ["n": .integer]) { Row(1); Row(2) }
+    Relation("B", ["n": .integer]) { Row(2); Row(3) }
+    Relation("C", ["n": .integer]) { Row(3); Row(4) }
+    try View("nested", """
+        SELECT n FROM A
+         UNION ALL (SELECT n FROM (SELECT n FROM B) AS d
+                     UNION ALL SELECT n FROM C ORDER BY n FETCH FIRST 1 ROW ONLY)
+        """, as: ["n"])
+  }
+}
+
+/// Like `nested()`, but the nested carrier's inner derived-table arm carries a
+/// WHERE over a sorted source column — a filter the optimiser's per-arm seek
+/// pass inspects, so it must resolve `d`'s schema during OPTIMISATION (not only
+/// execution). `B` is sorted on `k`; `d.k = 1` selects the row `n = 20`, then
+/// `{20} UNION ALL C {9}` ordered and paged to one takes 9, so the view unions
+/// `A` {1} with 9.
+private func nestedSeek() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("A", ["n": .integer]) { Row(1) }
+    Relation("B", ["n": .integer, "k": .integer], sorted: "k") {
+      Row(20, 1)
+      Row(30, 2)
+    }
+    Relation("C", ["n": .integer]) { Row(9) }
+    try View("nestedseek", """
+        SELECT n FROM A
+         UNION ALL (SELECT n FROM (SELECT n, k FROM B) AS d WHERE d.k = 1
+                     UNION ALL SELECT n FROM C ORDER BY n FETCH FIRST 1 ROW ONLY)
+        """, as: ["n"])
+  }
+}
+
 // MARK: - Tests
 
 struct OrderedSetOperationCarrierTests {
@@ -103,6 +144,54 @@ struct OrderedSetOperationCarrierTests {
     // yields the same multiset as the ordered form, but unsorted — the two arms
     // in source order: the derived `d` arm ({7, 8}) then the `S` arm ({7, 8}).
     try views().expect("SELECT * FROM bare", yields: [[7], [8], [7], [8]])
+  }
+
+  @Test func `a carrier set op nested as a union arm materialises its inner derived table (view)`()
+      throws {
+    // The real suffix-bearing carrier now reaches a NESTED operand position: the
+    // outer view body is `.setop(SELECT n FROM A, .ordered(.setop(…)))`. The
+    // per-arm recursion (`setop`/`arms`) split the outer union, then hit the
+    // right arm `.ordered(.setop(…))` — a `.shaped` carrier, not a bare `.setop`
+    // — and, before this fix, whole-query augmented it as one opaque leaf,
+    // binding no arm-local `d` so its `.scan("d")` faulted `.relation('d')`. The
+    // recursion now peels the carrier `core` and descends to the inner setop
+    // leaf, per-arm augmenting `d`. Inner: {2,3}∪{3,4} ordered, FETCH 1 → 2;
+    // outer: A {1,2} then that one → 1, 2, 2.
+    try nested().expect("SELECT * FROM nested", yields: [[1], [2], [2]])
+    let catalog = try nested()
+    #expect(throws: Never.self) {
+      _ = try catalog.columns(of: parse(query: "SELECT * FROM nested"))
+    }
+  }
+
+  @Test func `a carrier set op nested as a union arm materialises its inner derived table (correlated)`()
+      throws {
+    // The correlated form drives the same nested-arm recursion through
+    // `Filter.arms`: the correlated `IN (…)` body is `.setop(SELECT V FROM S,
+    // .ordered(.setop(…)))`, whose right arm is a carried setop naming its own
+    // arm-local `d` (and correlating `p.Age`). For Alice (Age 30) the inner
+    // `d.V = p.Age` arm yields {30}, so the paged inner is 30 and the IN set is
+    // {7, 8, 30} — 30 ∈ it, Alice matches; for Bob (25) the inner is {99}, the
+    // set {7, 8, 99}, 25 ∉ it. Before the fix arm-0's `.scan("d")` faulted.
+    try people().expect("""
+        SELECT Id FROM People p WHERE p.Age IN
+          (SELECT V FROM S
+            UNION ALL (SELECT V FROM (SELECT 30 AS V) AS d WHERE d.V = p.Age
+                        UNION ALL SELECT 99 ORDER BY V FETCH FIRST 1 ROW ONLY))
+        """, yields: [[1]])
+  }
+
+  @Test func `a nested carrier arm with a seekable filter peels during view optimization`()
+      throws {
+    // The nested carrier's inner derived arm carries `WHERE d.k = 1` over a
+    // sorted source, so the view OPTIMISER's per-arm seek pass inspects it and
+    // must resolve `d`'s schema. The optimiser recursion (`optimise(_:_:_:)`)
+    // was carrier-transparent only for a direct `.setop`, so the nested
+    // `.ordered(.setop)` arm fell to the generic optimiser, which seek-resolved
+    // `.scan("d")` against an unbound `d` and faulted `.relation`. It now peels
+    // the carrier `core` and optimises each inner arm under its own augment.
+    // `d.k = 1` → n = 20; `{20} ∪ C {9}` ordered, FETCH 1 → 9; A {1} then 9.
+    try nestedSeek().expect("SELECT * FROM nestedseek", yields: [[1], [9]])
   }
 
   @Test func `a reached correlated scalar ordered set op faults on irreconcilable arms`()

--- a/Tests/SQLTests/Queries/ParenthesizedQueryTests.swift
+++ b/Tests/SQLTests/Queries/ParenthesizedQueryTests.swift
@@ -1,0 +1,351 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQLEngine
+
+import SQLTestSupport
+
+// MARK: - Parenthesized query expressions (ISO <query primary>)
+
+/// Three integer relations for set-operation composition — A {1, 2}, B {2, 3},
+/// C {3, 4}, so each pairing's union/intersect/difference is legible.
+private func sets() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("A", ["n": .integer]) { Row(1); Row(2) }
+    Relation("B", ["n": .integer]) { Row(2); Row(3) }
+    Relation("C", ["n": .integer]) { Row(3); Row(4) }
+  }
+}
+
+struct ParenthesizedQueryTests {
+  @Test func `a parenthesized operand overrides set-operation precedence`()
+      throws {
+    // Without parentheses INTERSECT binds tighter, so `A UNION B INTERSECT C`
+    // is `A UNION (B INTERSECT C)`. Parenthesising the union forces it first:
+    // `(A UNION B) INTERSECT C` is {1, 2, 3} intersected with {3, 4} = {3}.
+    try sets().expect("""
+        (SELECT n FROM A UNION SELECT n FROM B)
+         INTERSECT SELECT n FROM C
+        """, yields: [[3]])
+  }
+
+  @Test func `the default precedence is unchanged without parentheses`()
+      throws {
+    // `A UNION B INTERSECT C` is `A UNION (B INTERSECT C)` = {1, 2} ∪ {3}.
+    try sets().expect("""
+        SELECT n FROM A UNION SELECT n FROM B INTERSECT SELECT n FROM C
+        """, yields: [[1], [2], [3]])
+  }
+
+  @Test func `a parenthesized operand carries its own ORDER BY and FETCH`()
+      throws {
+    // The parentheses let one operand take its top row before the union: the
+    // highest n of A is 2, unioned with B {2, 3} gives {2, 3}. The per-operand
+    // ORDER BY/FETCH rides a nested `ordered` carrier the outer union composes.
+    try sets().expect("""
+        (SELECT n FROM A ORDER BY n DESC FETCH NEXT 1 ROWS ONLY)
+         UNION SELECT n FROM B
+        """, yields: [[2], [3]])
+  }
+
+  @Test func `a parenthesized query nests on either side of a set operation`()
+      throws {
+    // A right-hand parenthesised union, and doubled parentheses, both compose:
+    // A ∪ (B ∪ C) = {1, 2, 3, 4}.
+    try sets().expect("""
+        SELECT n FROM A UNION (SELECT n FROM B UNION SELECT n FROM C)
+        """, yields: [[1], [2], [3], [4]])
+    try sets().expect("""
+        ((SELECT n FROM A)) UNION (SELECT n FROM C)
+        """, yields: [[1], [2], [3], [4]])
+  }
+
+  @Test func `a trailing ORDER BY applies to a parenthesized whole`() throws {
+    // A parenthesised set operation followed by a query-level ORDER BY sorts the
+    // combined result: (A ∪ C) descending = 4, 3, 2, 1.
+    try sets().expect("""
+        (SELECT n FROM A UNION SELECT n FROM C) ORDER BY n DESC
+        """, yields: [[4], [3], [2], [1]])
+  }
+
+  @Test func `run and schema agree on a parenthesized query`() throws {
+    // The nested `setop`/`ordered` a parenthesised operand builds derives the
+    // same single integer column the run yields.
+    let cat = try sets()
+    let sql = "(SELECT n FROM A UNION SELECT n FROM B) INTERSECT SELECT n FROM C"
+    let columns = try cat.columns(of: parse(query: sql), validate: true)
+    #expect(columns == [OutputColumn(name: "n", type: .integer)])
+  }
+
+  @Test func `an empty parenthesized query is a syntax fault`() throws {
+    // `()` has no query expression inside, so it faults at parse rather than
+    // producing an empty primary.
+    #expect(throws: SQLError.self) {
+      _ = try Statement(parsing: "() UNION SELECT n FROM A")
+    }
+  }
+
+  @Test func `a right-hand parenthesized operand's FETCH limits only itself`()
+      throws {
+    // The parentheses seal the operand's ORDER BY/FETCH so the enclosing
+    // `query()`'s trailing-tail lift cannot hoist them over the whole union:
+    // `A UNION ALL (SELECT … ORDER BY … FETCH 1)` fetches the top row of B (3),
+    // not the top row of the combined union. Without the boundary the FETCH
+    // would apply to the union and return a single row.
+    try sets().expect("""
+        SELECT n FROM A
+         UNION ALL (SELECT n FROM B ORDER BY n DESC FETCH NEXT 1 ROWS ONLY)
+        """, yields: [[1], [2], [3]])
+  }
+
+  @Test func `a parenthesized operand orders by a non-projected column`()
+      throws {
+    // The parenthesised operand compiles under its OWN full scope — as a derived
+    // table does — so its ORDER BY may reference a column it does not project. Ordering
+    // B by the unselected `m` and fetching one row takes the row with the largest
+    // m (n = 3), unioned with A.
+    let cat = try Catalog {
+      Relation("A", ["n": .integer]) { Row(1) }
+      Relation("B", ["n": .integer, "m": .integer]) { Row(2, 20); Row(3, 30) }
+    }
+    try cat.expect("""
+        SELECT n FROM A
+         UNION ALL (SELECT n FROM B ORDER BY m DESC FETCH NEXT 1 ROWS ONLY)
+        """, yields: [[1], [3]])
+  }
+
+  @Test func `both operands carry independent ORDER BY and FETCH`() throws {
+    // Each parenthesised operand takes its own top row before the union: A's
+    // highest is 2, B's highest is 3.
+    try sets().expect("""
+        (SELECT n FROM A ORDER BY n DESC FETCH NEXT 1 ROWS ONLY)
+         UNION ALL (SELECT n FROM B ORDER BY n DESC FETCH NEXT 1 ROWS ONLY)
+        """, yields: [[2], [3]])
+  }
+
+  @Test func `a parenthesized operand materializes its derived tables`() throws {
+    // A parenthesised ordered/limited select reading a derived table `d` must
+    // still materialize it — the operand carries its tail on its own select (no
+    // marker node), so it is a plain query the derived-table augmentation sees.
+    // Both as a whole query and as a set-operation operand.
+    try sets().expect("""
+        (SELECT n FROM (SELECT n FROM B) AS d
+          ORDER BY n DESC FETCH NEXT 1 ROWS ONLY)
+        """, yields: [[3]])
+    try sets().expect("""
+        SELECT n FROM A
+         UNION ALL (SELECT n FROM (SELECT n FROM B) AS d
+                     ORDER BY n DESC FETCH NEXT 1 ROWS ONLY)
+        """, yields: [[1], [2], [3]])
+  }
+
+  @Test func `a parenthesized grouping-sets select materializes a derived table`()
+      throws {
+    // A parenthesised GROUPING SETS select over a derived table: the expansion
+    // wraps the arms in one carrier (no marker nests a second around it), so the
+    // carrier descent reaches the arms and each augments and materializes `d`.
+    try sets().expect("""
+        (SELECT n FROM (SELECT n FROM B) AS d
+          GROUP BY GROUPING SETS ((n), ())) ORDER BY n
+        """, yields: [[nil], [2], [3]])
+  }
+
+  @Test func `a trailing ORDER BY follows a simple parenthesized query`()
+      throws {
+    // A query-level `ORDER BY`/`FETCH` after a parenthesised simple select —
+    // outside the parentheses — is consumed and applied, exactly as it is after
+    // a parenthesised set operation. It is output-scoped, ordering the primary's
+    // result.
+    try sets().expect("(SELECT n FROM A) ORDER BY n DESC", yields: [[2], [1]])
+    try sets().expect("""
+        (SELECT n FROM A) ORDER BY n DESC FETCH NEXT 1 ROWS ONLY
+        """, yields: [[2]])
+  }
+
+  @Test func `an outer tail preserves a parenthesized query's derived tables`()
+      throws {
+    // `(SELECT … FROM (…) AS d) ORDER BY …` wraps the inner select in an
+    // `ordered` carrier after the `)`. That carrier must stay transparent to
+    // select-scoped derived-table augmentation (`collect(derived:)`), or `d`
+    // goes unmaterialised and the run faults `.scan("d")`. Ordering the derived
+    // `d` = B {2, 3}. Run and schema agree.
+    try sets().expect("(SELECT n FROM (SELECT n FROM B) AS d) ORDER BY n",
+                      yields: [[2], [3]])
+    let cat = try sets()
+    #expect(throws: Never.self) {
+      _ = try cat.columns(of:
+          parse(query: "(SELECT n FROM (SELECT n FROM B) AS d) ORDER BY n"))
+    }
+  }
+
+  @Test func `EXISTS through an outer OFFSET keeps inner DISTINCT cardinality`()
+      throws {
+    // A carrier OFFSET over a DISTINCT inner: the probe must NOT collapse the
+    // inner projection to a constant — that would leave one distinct row the
+    // OFFSET then drops — because the OFFSET depends on the distinct-row count.
+    // Two distinct Flags, OFFSET 1 → one row remains → EXISTS true.
+    let two = try Catalog {
+      Relation("A", ["n": .integer]) { Row(1) }
+      Relation("S", ["Flag": .integer]) { Row(1); Row(1); Row(2) }
+    }
+    try two.expect("""
+        SELECT n FROM A
+         WHERE EXISTS ((SELECT DISTINCT Flag FROM S) OFFSET 1 ROWS)
+        """, yields: [[1]])
+    // One distinct value: OFFSET 1 drops it → EXISTS false → no rows.
+    let one = try Catalog {
+      Relation("A", ["n": .integer]) { Row(1) }
+      Relation("S", ["Flag": .integer]) { Row(7); Row(7) }
+    }
+    try one.expect("""
+        SELECT n FROM A
+         WHERE EXISTS ((SELECT DISTINCT Flag FROM S) OFFSET 1 ROWS)
+        """, yields: [])
+  }
+
+  @Test func `EXISTS through a stacked carrier keeps inner DISTINCT cardinality`()
+      throws {
+    // A DISTINCT select under an ORDER BY carrier, then an outer OFFSET carrier
+    // — `((SELECT DISTINCT …) ORDER BY …) OFFSET 1` — stacks two `ordered`
+    // nodes between the probe and the DISTINCT. The probe's dedup check must be
+    // carrier-transparent (peel the whole stack), or it collapses the result to
+    // one row and the offset drops it. Two distinct Flags, OFFSET 1 → one row
+    // remains → EXISTS true.
+    let cat = try Catalog {
+      Relation("A", ["n": .integer]) { Row(1) }
+      Relation("S", ["Flag": .integer]) { Row(1); Row(1); Row(2) }
+    }
+    try cat.expect("""
+        SELECT n FROM A
+         WHERE EXISTS (((SELECT DISTINCT Flag FROM S) ORDER BY Flag) OFFSET 1 ROWS)
+        """, yields: [[1]])
+  }
+
+  @Test func `an outer tail on a parenthesized simple query is output-scoped`()
+      throws {
+    // A parenthesised simple query is an ISO `<query primary>`: an ORDER BY
+    // after the `)` binds against its OUTPUT columns, not the FROM scope closed
+    // inside the parentheses. Ordering by the projected `n` works; ordering by
+    // the unprojected `m` faults `.column`, exactly as a set operation's outer
+    // tail does — the parenthesis boundary is preserved. Run and schema agree.
+    let cat = try Catalog {
+      Relation("B", ["n": .integer, "m": .integer]) { Row(2, 20); Row(3, 10) }
+    }
+    try cat.expect("(SELECT n FROM B) ORDER BY n DESC", yields: [[3], [2]])
+    cat.expect("(SELECT n FROM B) ORDER BY m DESC", fails: .column("m"))
+    #expect(throws: SQLError.column("m")) {
+      _ = try cat.columns(of: parse(query: "(SELECT n FROM B) ORDER BY m"),
+                          validate: true)
+    }
+    // The SAME key written INSIDE the parentheses is the operand's own,
+    // full-scoped order over a simple select, so `m` resolves and orders it —
+    // the extended-sort-key allowance, unchanged.
+    try cat.expect("(SELECT n FROM B ORDER BY m DESC)", yields: [[2], [3]])
+  }
+
+  @Test func `EXISTS over a parenthesized select probes existence only`()
+      throws {
+    // EXISTS inspects only whether rows exist; a parenthesised select is a plain
+    // select the cardinality probe replaces, so the run never evaluates the
+    // select list. `1 / (Flag - 1)` divides by zero for the Flag = 1 row, yet
+    // EXISTS returns true (S is non-empty) without faulting — even with a FETCH
+    // suffix, which stays on the select as a cardinality-affecting limit the
+    // probe keeps. Run and schema agree.
+    let cat = try Catalog {
+      Relation("A", ["n": .integer]) { Row(1) }
+      Relation("S", ["Flag": .integer]) { Row(1); Row(2) }
+    }
+    try cat.expect("""
+        SELECT n FROM A WHERE EXISTS ((SELECT 1 / (Flag - 1) FROM S))
+        """, yields: [[1]])
+    try cat.expect("""
+        SELECT n FROM A
+         WHERE EXISTS ((SELECT 1 / (Flag - 1) FROM S) FETCH NEXT 1 ROWS ONLY)
+        """, yields: [[1]])
+  }
+
+  @Test func `a parenthesized aggregate-ordered operand unions at its real width`()
+      throws {
+    // A parenthesised operand ordering by an UNPROJECTED aggregate materialises
+    // a hidden sort column its carrier trims. The set-operation arity check must
+    // count the operand's real (trimmed) width, so this one-column union is not
+    // rejected as one-versus-two.
+    let cat = try Catalog {
+      Relation("A", ["n": .integer]) { Row(1) }
+      Relation("D", ["n": .integer, "m": .integer]) { Row(1, 10); Row(2, 20) }
+    }
+    try cat.expect("""
+        SELECT n FROM A
+         UNION (SELECT n FROM D GROUP BY GROUPING SETS ((n), ())
+                 ORDER BY SUM(m) DESC)
+         ORDER BY n
+        """, yields: [[nil], [1], [2]])
+  }
+
+  @Test func `an outer tail rides a parenthesized primary that has its own tail`()
+      throws {
+    // A parenthesised primary that carries an inner ORDER BY/FETCH is a `<query
+    // primary>`; an outer tail after the `)` is the enclosing query
+    // expression's, independently scoped — the inner picks the operand's rows,
+    // the outer orders that primary's result. Both bind (a second carrier),
+    // never a `42601` duplicate-clause error. Here the inner takes A's top row
+    // (n = 2), and the outer ORDER BY of that single row is a no-op.
+    try sets().expect("""
+        (SELECT n FROM A ORDER BY n DESC FETCH FIRST 1 ROW ONLY) ORDER BY n ASC
+        """, yields: [[2]])
+    // Nested over a set operation: the inner union takes its top row, the outer
+    // re-orders it. (A ∪ C) = {1,2,3,4}, inner top-1 by n DESC = 4; outer ASC of
+    // that one row.
+    try sets().expect("""
+        (SELECT n FROM A UNION SELECT n FROM C ORDER BY n DESC FETCH FIRST 1 ROW
+         ONLY) ORDER BY n ASC
+        """, yields: [[4]])
+  }
+
+  @Test func `a doubly-parenthesized query nests as a derived table`() throws {
+    // The derived-table lookahead admits a leading `(` (a nested query primary),
+    // so `FROM ((SELECT …)) AS d` parses and runs as `FROM (SELECT …) AS d`
+    // rather than faulting at the relation lookahead.
+    try sets().expect("SELECT n FROM ((SELECT n FROM A)) AS d",
+                      equals: "SELECT n FROM (SELECT n FROM A) AS d")
+    try sets().expect("SELECT n FROM ((SELECT n FROM A)) AS d",
+                      yields: [[1], [2]])
+  }
+
+  @Test func `a doubly-parenthesized IN subquery is membership not a value list`()
+      throws {
+    // `IN ((SELECT …))` is a table subquery over the parenthesised query primary
+    // — membership — not a one-element value list holding a scalar subquery, so
+    // a multi-row inner performs membership rather than raising a cardinality
+    // error. B = {2, 3}; A's 2 is a member.
+    try sets().expect("SELECT n FROM A WHERE n IN ((SELECT n FROM B))",
+                      yields: [[2]])
+    // A comma list stays a value list — the speculative parse rewinds on the
+    // comma. Parenthesised scalars, and a list of single-row subqueries, both
+    // remain value lists.
+    try sets().expect("SELECT n FROM A WHERE n IN ((1), (2))",
+                      yields: [[1], [2]])
+    try sets().expect("""
+        SELECT n FROM A
+         WHERE n IN ((SELECT n FROM B WHERE n = 2), (SELECT n FROM C WHERE n = 4))
+        """, yields: [[2]])
+  }
+
+  @Test func `a parenthesized scalar subquery body is a query`() throws {
+    // A scalar subquery whose body starts with `(` — `((SELECT …) UNION …)` —
+    // is a subquery over the union, not a parenthesised expression that fails at
+    // UNION. It yields the union's single value. A parenthesised scalar
+    // expression starting with `(` still parses as an expression (the
+    // speculative query parse rewinds on the trailing operator).
+    try sets().expect("SELECT ((SELECT 1) UNION SELECT 1)", yields: [[1]])
+    try sets().expect("SELECT ((1) + 2)", yields: [[3]])
+  }
+
+  @Test func `an unterminated parenthesized query faults`() throws {
+    // A missing `)` after the inner query is a syntax fault.
+    #expect(throws: SQLError.self) {
+      _ = try Statement(parsing: "(SELECT n FROM A UNION SELECT n FROM B")
+    }
+  }
+}

--- a/Tests/SQLTests/Queries/TableTests.swift
+++ b/Tests/SQLTests/Queries/TableTests.swift
@@ -79,14 +79,12 @@ struct TableTests {
                             yields: [["shared"]])
   }
 
-  @Test func `TABLE t admits no trailing ORDER BY at the primary level`() throws {
-    // Ordering is a SELECT-internal clause in this grammar, not a
-    // query-expression clause, so a `TABLE t ORDER BY …` tail is not part of
-    // the primary — the trailing tokens fault. `SELECT * FROM t ORDER BY …`
-    // carries an order.
-    #expect(throws: SQLError.self) {
-      _ = try parse(query: "TABLE People ORDER BY Age")
-    }
+  @Test func `TABLE t takes a query-expression ORDER BY`() throws {
+    // A trailing `ORDER BY` after a `TABLE t` primary binds to the enclosing
+    // query expression (ISO 9075), exactly as after `SELECT * FROM t` — the two
+    // spellings parse to the same ordered query.
+    #expect(try parse(query: "TABLE People ORDER BY Age")
+                == parse(query: "SELECT * FROM People ORDER BY Age"))
   }
 
   @Test func `TABLE requires a relation name, not a derived table`() throws {

--- a/Tests/SQLTests/Queries/TableTests.swift
+++ b/Tests/SQLTests/Queries/TableTests.swift
@@ -17,7 +17,8 @@ struct TableTests {
   @Test func `TABLE t lowers to a star-projection SELECT over the named relation`() throws {
     // The primary builds the same AST `SELECT * FROM People` does: a `.all`
     // projection over one named `Relation`, with no WHERE/GROUP/HAVING/order.
-    guard case let .select(select) = try parse(query: "TABLE People") else {
+    guard case let .select(select) = try parse(query: "TABLE People").body
+    else {
       Issue.record("expected a single-SELECT query")
       return
     }

--- a/Tests/SQLTests/Queries/ValuesTests.swift
+++ b/Tests/SQLTests/Queries/ValuesTests.swift
@@ -33,14 +33,14 @@ struct ValuesTests {
     // UNION ALL SELECT 3, 4` — a `.setop(.union, …, all: true)` whose first arm
     // is FROM-less and aliases the default output names.
     let query = try parse(query: "VALUES (1, 2), (3, 4)")
-    guard case let .setop(kind, left, right, all) = query else {
+    guard case let .setop(kind, left, right, all) = query.body else {
       Issue.record("expected a UNION ALL set operation")
       return
     }
     #expect(kind == .union)
     #expect(all)
 
-    guard case let .select(head) = left,
+    guard case let .select(head) = left.body,
           case let .expressions(items) = head.projection else {
       Issue.record("expected a FROM-less expression projection as the head arm")
       return
@@ -52,7 +52,7 @@ struct ValuesTests {
 
     // The trailing arm projects the bare expressions — a set operation names
     // its result from the first arm alone, so a later arm carries no aliases.
-    guard case let .select(tail) = right,
+    guard case let .select(tail) = right.body,
           case let .expressions(later) = tail.projection else {
       Issue.record("expected a FROM-less expression projection as the tail arm")
       return
@@ -64,7 +64,7 @@ struct ValuesTests {
   @Test func `a single-row VALUES is one FROM-less SELECT`() throws {
     // With one row there is no set operation — the desugar is the single arm.
     let query = try parse(query: "VALUES (1, 2)")
-    guard case let .select(select) = query,
+    guard case let .select(select) = query.body,
           case let .expressions(items) = select.projection else {
       Issue.record("expected a single FROM-less SELECT")
       return
@@ -182,7 +182,7 @@ struct ValuesTests {
     // `(SELECT …)` does. The parse must route the parenthesised `VALUES` to the
     // query parser, not the value-expression parser.
     let query = try parse(query: "SELECT (VALUES (1)) AS x")
-    guard case let .select(select) = query,
+    guard case let .select(select) = query.body,
           case let .expressions(items) = select.projection else {
       Issue.record("expected an expression projection")
       return
@@ -200,7 +200,7 @@ struct ValuesTests {
     // route to the query parser so it is one subquery, not two row literals.
     let query = try parse(query:
         "SELECT Id FROM People WHERE Id IN (VALUES (1), (2))")
-    guard case let .select(select) = query,
+    guard case let .select(select) = query.body,
           case .within? = select.predicate else {
       Issue.record("expected an IN-subquery predicate")
       return

--- a/Tests/SQLTests/Queries/ValuesTests.swift
+++ b/Tests/SQLTests/Queries/ValuesTests.swift
@@ -254,4 +254,84 @@ struct ValuesTests {
       _ = try parse(query: "VALUES ()")
     }
   }
+
+  // MARK: - FROM-less query-expression tails
+
+  @Test func `a single-row VALUES takes a query-expression ORDER BY`() throws {
+    // A FROM-less primary is a single-row query, and the enclosing query
+    // expression's trailing ORDER BY orders that result — a no-op on one row,
+    // but the key still resolves. With no source column to order on, the key
+    // binds an ordinal or an output alias (the only ISO keys here): `ORDER BY 1`
+    // and `ORDER BY column1` both name the sole output. The schema derive agrees
+    // — the run compiles and validates the tail identically (run ≡ columns(of:)).
+    try store().expect("VALUES (1) ORDER BY 1", yields: [[1]])
+    try store().expect("VALUES (1) ORDER BY column1", yields: [[1]])
+    let columns = try store().columns(of:
+        parse(query: "VALUES (1) ORDER BY 1"), routines: .standard,
+        validate: true)
+    #expect(columns.map(\.name) == ["column1"])
+  }
+
+  @Test func `a FROM-less OFFSET or FETCH pages the single row`() throws {
+    // OFFSET/FETCH slices the one-row result exactly as it slices a FROM'd one:
+    // skipping the row or fetching zero rows yields the empty result.
+    try store().empty("VALUES (1) OFFSET 1 ROWS")
+    try store().empty("VALUES (1) FETCH FIRST 0 ROWS ONLY")
+    try store().expect("VALUES (1) FETCH FIRST 1 ROWS ONLY", yields: [[1]])
+  }
+
+  @Test func `a parenthesized FROM-less operand pages before a union`() throws {
+    // A parenthesised FROM-less operand carries its own FETCH, applied before
+    // the union: `FETCH FIRST 0 ROWS ONLY` drops its single row, leaving only
+    // the other arm. The cap sits below the projection, so a throwing select
+    // list on the dropped row never runs.
+    try store().expect(
+        "(SELECT 1 FETCH FIRST 0 ROWS ONLY) UNION ALL SELECT 2",
+        yields: [[2]])
+    try store().expect(
+        "(SELECT 1 / 0 FETCH FIRST 0 ROWS ONLY) UNION ALL SELECT 2",
+        yields: [[2]])
+  }
+
+  @Test func `a FROM-less OFFSET spares an unreachable throwing projection`()
+      throws {
+    // A positive OFFSET (with no ORDER BY, non-DISTINCT) pages out the single
+    // row below the projection, so a throwing select list never evaluates: the
+    // run yields no rows AND the schema derive treats the FROM-less result as
+    // single-row, so it marks the projection unreachable and does not validate
+    // it — neither faults (run ≡ columns(of:)).
+    try store().empty("SELECT 1 / 0 OFFSET 1 ROWS")
+    let columns = try store().columns(of:
+        parse(query: "SELECT 1 / 0 OFFSET 1 ROWS"), routines: .standard,
+        validate: true)
+    #expect(columns.count == 1)
+  }
+
+  @Test func `a FROM-less DISTINCT projects below the OFFSET so it still runs`()
+      throws {
+    // DISTINCT is the exception: its plan is `Limit(Distinct(Project(single)))`,
+    // so the projection evaluates over the single row (dedup needs it) before
+    // the OFFSET pages the result. A throwing select list therefore faults at
+    // run, and the derive validates the reachable projection alike — both raise
+    // `SQLError.divide`.
+    try store().expect("SELECT DISTINCT 1 / 0 OFFSET 1 ROWS", fails: .divide)
+    var raised: SQLError? = nil
+    do {
+      _ = try store().columns(of:
+          parse(query: "SELECT DISTINCT 1 / 0 OFFSET 1 ROWS"),
+          routines: .standard, validate: true)
+    } catch let error as SQLError {
+      raised = error
+    }
+    #expect(raised == .divide)
+  }
+
+  @Test func `a FROM-less ORDER BY faults on an unresolvable key`() throws {
+    // With no source relation an ORDER BY key that is neither an ordinal in
+    // range nor an output alias has nothing to bind, so it faults — the same
+    // `SQLError.column` the projection raises — and the run and schema derive
+    // fault alike.
+    try store().expect("VALUES (1) ORDER BY 2", fails: .column("2"))
+    try store().expect("VALUES (1) ORDER BY nope", fails: .column("nope"))
+  }
 }

--- a/Tests/SQLTests/Syntax/ParserTests.swift
+++ b/Tests/SQLTests/Syntax/ParserTests.swift
@@ -1253,7 +1253,7 @@ struct WithTests {
         """)
     #expect(ctes[0].recursive == true)
     #expect(ctes[0].columns == ["n"])
-    guard case .setop(.union, _, _, _) = ctes[0].query else {
+    guard case .setop(.union, _, _, _) = ctes[0].query.body else {
       Issue.record("expected the recursive CTE's query to be a UNION")
       return
     }


### PR DESCRIPTION
Admit the ISO 9075 <query primary> `( <query expression> )` — a parenthesised query as a set-operation operand. It enables grouping a set operation explicitly, so `(A UNION B) INTERSECT C` overrides the default INTERSECT-binds-tighter precedence, and a per-operand ORDER BY/OFFSET/FETCH, so `(SELECT … ORDER BY … FETCH n) UNION …` takes the top n of one operand before the union.

The query primary `term()` gains a `(` branch that recurses into `query()` and expects `)`. A `(` in query-primary position always begins a parenthesised query — no other primary starts with one — so it is consumed without lookahead, and the inner `query()` greedily folds that operand's own ORDER BY/limit onto its `ordered` carrier. No AST or executor change: the nested `setop`/`ordered` Query composes through the existing recursion — `compile` already recurses each set-operation operand and stacks the `ordered` carrier over a nested operand exactly as over the top — so a parenthesised operand, a per-operand top-n, and arbitrary nesting all run and derive their schema unchanged.