### PR TITLE
SQLEngine: cover the trailing tail on a TABLE / VALUES primary

### DIFF
--- a/Sources/SQLEngine/Parser.swift
+++ b/Sources/SQLEngine/Parser.swift
@@ -19,15 +19,22 @@
 /// cte            := identifier ['(' identifier (',' identifier)* ')']
 ///                   AS '(' query ')'
 /// query          := intersection ((UNION | EXCEPT) [ALL] intersection)*
+///                   [order] [limit]
+///                   // the trailing ORDER BY / OFFSET·FETCH binds to the whole
+///                   // query expression, never to a primary: a lone select, a
+///                   // TABLE t, or a VALUES (…) each takes it the same way (a
+///                   // set operation and a parenthesised primary ride an
+///                   // output-scoped carrier, a bare select its full scope)
 /// intersection   := term (INTERSECT [ALL] term)*
 /// term           := select | TABLE identifier | values
-///                   // TABLE t = SELECT * FROM t
+///                   // TABLE t = SELECT * FROM t; none of these primaries
+///                   // consumes a trailing tail — `query` does, above
 /// values         := VALUES tuple (',' tuple)*  // ISO table value constructor;
 ///                   // desugars to a UNION ALL of FROM-less constant SELECTs
 /// tuple          := '(' expression (',' expression)* ')'
 /// select         := SELECT [DISTINCT | ALL] projection
 ///                   [FROM relation (join)*
-///                    [where] [group] [having] [order] [limit]]
+///                    [where] [group] [having]]
 /// relation       := (identifier | [LATERAL] derived) [AS identifier]
 ///                   // LATERAL is legal only on a derived table in a join
 /// derived        := '(' query ')' AS identifier  // a derived table (aliased);

--- a/Tests/SQLTests/Queries/TableTests.swift
+++ b/Tests/SQLTests/Queries/TableTests.swift
@@ -134,6 +134,45 @@ struct TableTests {
     try scalars().expect("SELECT V FROM Vals WHERE V IN (TABLE Ids)",
                                yields: [[1], [3]])
   }
+
+  // MARK: - TABLE t with a trailing tail (ORDER BY / OFFSET / FETCH)
+
+  // A trailing tail binds to the enclosing query expression, not to the `TABLE`
+  // primary — the same way it binds after `SELECT * FROM t`. These confirm it
+  // across every position `TABLE` composes in: standalone, a set-operation
+  // operand, a derived table, a scalar subquery, and an IN-subquery.
+
+  @Test func `a standalone TABLE t tail runs as SELECT star with the tail`()
+      throws {
+    try roster().expect("TABLE People ORDER BY Age",
+                              equals: "SELECT * FROM People ORDER BY Age")
+    try roster().expect(
+        "TABLE People ORDER BY Id DESC FETCH FIRST 2 ROWS ONLY",
+        equals: "SELECT * FROM People ORDER BY Id DESC FETCH FIRST 2 ROWS ONLY")
+  }
+
+  @Test func `a parenthesized TABLE operand carries its tail before a union`()
+      throws {
+    // The parentheses bound the operand's own ORDER BY/FETCH so it takes its
+    // top row before the union: the highest Tag of Lhs is `shared`, then Rhs.
+    try tags().expect("""
+        (TABLE Lhs ORDER BY Tag DESC FETCH FIRST 1 ROW ONLY)
+         UNION ALL TABLE Rhs
+        """, yields: [["shared"], ["shared"], ["b"]])
+  }
+
+  @Test func `a TABLE t tail composes in a derived table and subquery`()
+      throws {
+    // A `TABLE` primary with a trailing tail composes as a derived table, a
+    // scalar subquery, and an IN-subquery.
+    try tags().expect("SELECT Tag FROM (TABLE Lhs ORDER BY Tag) AS d",
+                            yields: [["a"], ["shared"]])
+    try scalars().expect("SELECT (TABLE One ORDER BY N) FROM One",
+                               yields: [[42]])
+    try scalars().expect(
+        "SELECT V FROM Vals WHERE V IN (TABLE Ids ORDER BY Key)",
+        yields: [[1], [3]])
+  }
 }
 
 /// A catalog for the scalar-subquery and IN-subquery `(TABLE …)` forms: `One`

--- a/Tests/SQLTests/Queries/ValuesTests.swift
+++ b/Tests/SQLTests/Queries/ValuesTests.swift
@@ -334,4 +334,40 @@ struct ValuesTests {
     try store().expect("VALUES (1) ORDER BY 2", fails: .column("2"))
     try store().expect("VALUES (1) ORDER BY nope", fails: .column("nope"))
   }
+
+  // MARK: - VALUES with a trailing tail (ORDER BY / OFFSET / FETCH)
+
+  @Test func `a standalone multi-row VALUES takes a query-expression tail`()
+      throws {
+    // A trailing ORDER BY / OFFSET·FETCH after a `VALUES (…), …` binds to the
+    // enclosing query expression (the multi-row constructor is a `UNION ALL`,
+    // so the tail rides an output-scoped carrier) — ordering/paging the rows.
+    try store().expect("VALUES (3), (1), (2) ORDER BY 1",
+                       yields: [[1], [2], [3]])
+    try store().expect("VALUES (3), (1), (2) ORDER BY 1 OFFSET 1 ROWS",
+                       yields: [[2], [3]])
+  }
+
+  @Test func `a parenthesized VALUES operand carries its tail before a union`()
+      throws {
+    // Parenthesised, a VALUES operand takes its own ORDER BY/FETCH before the
+    // union: the smallest of {3, 1} is 1, then the second constructor's 9.
+    try store().expect("""
+        (VALUES (3), (1) ORDER BY 1 FETCH FIRST 1 ROW ONLY)
+         UNION ALL VALUES (9)
+        """, yields: [[1], [9]])
+  }
+
+  @Test func `a VALUES tail composes in a derived table and subquery`()
+      throws {
+    // A `VALUES` primary with a trailing tail composes as a derived table, a
+    // scalar subquery, and an IN-subquery.
+    try store().expect(
+        "SELECT column1 FROM (VALUES (3), (1), (2) ORDER BY 1) AS t",
+        yields: [[1], [2], [3]])
+    try store().expect("SELECT (VALUES (5) ORDER BY 1) AS x", yields: [[5]])
+    try roster().expect(
+        "SELECT Id FROM People WHERE Id IN (VALUES (3), (1) ORDER BY 1)",
+        yields: [[1], [3]])
+  }
 }


### PR DESCRIPTION
A trailing ORDER BY / OFFSET-FETCH binds to the whole query expression, never to a <query primary>, so `TABLE t` and `VALUES (…)` take one exactly as a lone `SELECT` does — a set operation or a parenthesised primary through an output-scoped carrier, a bare primary in its own scope. The behaviour was already correct (the query-level tail path handles every primary uniformly); this fills the missing coverage and corrects the grammar doc-comment, which still listed `[order] [limit]` on `select` after they moved to the query tier.

Move `[order] [limit]` from the `select` production to `query` in the grammar comment — they are consumed once at the query-expression level, `select()` takes none — and note on `term` that no primary consumes the tail.

Add tests for a trailing tail on a standalone `TABLE t` and a multi-row `VALUES`, on a parenthesised `TABLE`/`VALUES` set-operation operand (its own top row before the union), and inside a derived table, a scalar subquery, and an IN-subquery — each running, and for `TABLE` matching the `SELECT * FROM t` spelling.