### PR TITLE
SQLEngine: bound parser recursion depth, faulting 54001

### DIFF
--- a/Sources/SQLEngine/Parser+Predicate.swift
+++ b/Sources/SQLEngine/Parser+Predicate.swift
@@ -6,7 +6,10 @@ extension Parser {
 
   /// Parses a predicate at the lowest precedence (`OR`).
   internal mutating func predicate() throws(SQLError) -> Predicate {
-    try disjunction()
+    depth += 1
+    defer { depth -= 1 }
+    guard depth <= Limits.nesting else { throw overrun }
+    return try disjunction()
   }
 
   /// Parses `conjunction (OR conjunction)*`, left-associative.
@@ -36,16 +39,35 @@ extension Parser {
   /// `membership`/`between`/`like` carry their `NOT`; a prefix `NOT` before
   /// anything else is the ordinary boolean negation.
   private mutating func negation() throws(SQLError) -> Predicate {
-    if try match(.not) {
+    // Consume a prefix `NOT` run iteratively rather than recursing per `NOT`,
+    // so an attacker-controlled `NOT NOT … x` cannot overrun the native stack.
+    // The run is bounded by `Limits.nesting` — each `NOT` also stacks a `.not`
+    // AST node that compile/execute later recurse over, so an unbounded run
+    // would just move the overrun downstream — faulting `overrun` (54001) past
+    // the limit. The `NOT` adjacent to an `EXISTS` folds into its `negated`
+    // flag (as before); the remaining run wraps the operand in that many
+    // `.not`s.
+    var nots = 0
+    while try match(.not) {
       if try match(.exists) {
-        return try exists(negated: true)
+        return negate(try exists(negated: true), nots)
       }
-      return try .not(negation())
+      nots += 1
+      guard nots <= Limits.nesting else { throw overrun }
     }
     if try match(.exists) {
-      return try exists(negated: false)
+      return negate(try exists(negated: false), nots)
     }
-    return try primary()
+    return negate(try primary(), nots)
+  }
+
+  /// `base` wrapped in `count` boolean negations — the `.not` chain a prefix
+  /// `NOT` run builds, applied without recursion so its length is bounded by
+  /// the caller's `Limits.nesting` guard, not the native stack.
+  private func negate(_ base: Predicate, _ count: Int) -> Predicate {
+    var result = base
+    for _ in 0 ..< count { result = .not(result) }
+    return result
   }
 
   /// Parses the `(query)` tail of `[NOT] EXISTS (query)` — the `EXISTS` is

--- a/Sources/SQLEngine/Parser+Projection.swift
+++ b/Sources/SQLEngine/Parser+Projection.swift
@@ -45,7 +45,10 @@ extension Parser {
 
   /// Parses a scalar expression at the lowest arithmetic precedence (`+` `-`).
   internal mutating func expression() throws(SQLError) -> Expression {
-    try additive()
+    depth += 1
+    defer { depth -= 1 }
+    guard depth <= Limits.nesting else { throw overrun }
+    return try additive()
   }
 
   /// Parses `multiplicative (('+' | '-' | '||') multiplicative)*`,

--- a/Sources/SQLEngine/Parser.swift
+++ b/Sources/SQLEngine/Parser.swift
@@ -132,11 +132,31 @@ internal struct Parser: ~Escapable {
   // full cursor — lexer, current, AND this lookahead buffer — on rewind.
   internal var pending: Token?
 
+  /// The current query/predicate/expression nesting depth, bounded by
+  /// `Limits.nesting` so pathologically nested input faults `54001` (`overrun`)
+  /// rather than overrunning the native stack. Only nesting counts: `query`,
+  /// `predicate`, and `expression` each raise it on entry (paired with a
+  /// `defer` that lowers it), and every construct that recurses on nesting — a
+  /// parenthesised query/predicate/expression, a subquery, a `CASE`, a nested
+  /// `GROUPING SETS` — descends through one of those (or the grouping
+  /// `element`). A bare chain (`a OR b …`, `a UNION b …`) iterates rather than
+  /// recurses, so it adds no depth. `internal`, not `private`: the `predicate`
+  /// and `expression` heads live in other parser extension files.
+  internal var depth = 0
+
   @_lifetime(copy lexer)
   internal init(_ lexer: consuming Lexer) throws(SQLError) {
     self.lexer = lexer
     self.current = try self.lexer.next()
     self.pending = nil
+  }
+
+  /// The `54001` (statement too complex) fault raised when `depth` passes
+  /// `Limits.nesting`. Each nesting head registers its `defer` to lower `depth`
+  /// before guarding, so the fault unwinds with the counter balanced — a
+  /// speculative parse (`try? query()`) that hits it leaves `depth` intact.
+  internal var overrun: SQLError {
+    .state("54001", "query nesting is too deep (limit \(Limits.nesting))")
   }
 
   // MARK: - Statement
@@ -251,6 +271,9 @@ internal struct Parser: ~Escapable {
   /// precedence. `ALL` keeps duplicate rows per the operator's multiplicity; a
   /// bare operator removes them — the distinction the engine honours.
   internal mutating func query() throws(SQLError) -> Query {
+    depth += 1
+    defer { depth -= 1 }
+    guard depth <= Limits.nesting else { throw overrun }
     var (query, parenthesized) = try intersection()
     while let kind: SetOperation = if try match(.union) { .union }
                                    else if try match(.except) { .except }
@@ -692,6 +715,12 @@ internal struct Parser: ~Escapable {
   /// disambiguation applies at the top level and inside a `GROUPING SETS` list.
   private mutating func element() throws(SQLError)
       -> (sets: Array<Array<Expression>>, construct: Bool) {
+    // A nested `GROUPING SETS (GROUPING SETS (…))` recurses `element`→`sets`→
+    // `element` without passing through query/predicate/expression, so it needs
+    // its own depth guard against a stack overrun.
+    depth += 1
+    defer { depth -= 1 }
+    guard depth <= Limits.nesting else { throw overrun }
     if case let .identifier(text) = current?.kind,
         text.uppercased() == "GROUPING",
         case let .identifier(next) = try secondary()?.kind,
@@ -904,18 +933,22 @@ internal struct Parser: ~Escapable {
     return result
   }
 
-  /// The caps bounding `GROUP BY` grouping-set expansion — the single source
-  /// of truth for every artificial limit the desugar enforces, so they are
-  /// tracked and tunable in one place (every guard below cites one of these).
-  /// `sets` is the most grouping sets a clause may expand to; `references` the
-  /// most expression references those sets may hold in total. Both bound a
-  /// compact but heavily-duplicating clause — a wide `CUBE`/`ROLLUP`, a cross
-  /// product, a concatenation — from exhausting memory. The per-construct arity
-  /// guards derive from `sets`: `CUBE ≤ 12` units (2¹² = `sets`) and `ROLLUP ≤
-  /// 4095` units (n + 1 ≤ `sets`) reject before the 2ⁿ / prefix expansion.
-  private enum Limits {
+  /// The parser's artificial caps — the single source of truth for every
+  /// tunable limit, tracked in one place (every guard cites one). `sets` is the
+  /// most grouping sets a `GROUP BY` may expand to; `references` the most
+  /// expression references those sets may hold in total: both bound a compact
+  /// but heavily-duplicating clause — a wide `CUBE`/`ROLLUP`, a cross product,
+  /// a concatenation — from exhausting memory, and the per-construct arity
+  /// guards derive from `sets` (`CUBE ≤ 12` units, 2¹² = `sets`; `ROLLUP ≤
+  /// 4095` units, n + 1 ≤ `sets`). `nesting` is the deepest
+  /// query/predicate/expression nesting the parser accepts before an `overrun`
+  /// (`54001`) fault, set well below the depth at which native recursion
+  /// overruns a conventional thread stack (~10 KB of frames per level in a
+  /// debug build) yet far above any real query.
+  internal enum Limits {
     static let sets = 4096
     static let references = 1 << 20
+    static let nesting = 32
   }
 
   /// The total expression references across a grouping-set list — the memory an

--- a/Tests/SQLTests/Syntax/ParserDepthTests.swift
+++ b/Tests/SQLTests/Syntax/ParserDepthTests.swift
@@ -1,0 +1,58 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQLEngine
+import func SQLTestSupport.parse
+
+// MARK: - Parser recursion-depth guard
+
+/// Pathologically nested input faults `54001` (statement too complex) at the
+/// depth guard rather than overrunning the native stack. The guard trips at the
+/// nesting limit, so input nested far past it recurses only ~limit frames
+/// before faulting — the deep cases here parse to a clean fault, never a crash.
+struct ParserDepthTests {
+  private func sqlstate(parsing sql: String) -> String? {
+    do { _ = try parse(query: sql); return nil }
+    catch let error as SQLError { return error.sqlstate }
+    catch { return nil }
+  }
+
+  @Test func `deeply nested input faults 54001, not a stack overrun`() throws {
+    // One case per recursion cycle the guard bounds: expression parentheses,
+    // predicate parentheses, a nested subquery, and nested GROUPING SETS. A
+    // thousand levels each — far past the limit — so a missing guard would
+    // crash the process rather than fault.
+    let deep = 1000
+    let opens = String(repeating: "(", count: deep)
+    let closes = String(repeating: ")", count: deep)
+    #expect(sqlstate(parsing: "SELECT \(opens)1\(closes)") == "54001")
+    #expect(sqlstate(parsing: "SELECT 1 FROM t WHERE \(opens)1 = 1\(closes)")
+            == "54001")
+    #expect(sqlstate(parsing: "SELECT * FROM \(opens)SELECT 1\(closes) AS d")
+            == "54001")
+    #expect(sqlstate(parsing: "SELECT a FROM t GROUP BY "
+            + String(repeating: "GROUPING SETS (", count: deep) + "a" + closes)
+            == "54001")
+    // A prefix `NOT` run is parsed iteratively, but each `NOT` stacks a `.not`
+    // node compile/execute later recurse over, so it is bounded the same way: a
+    // thousand `NOT`s fault rather than build a stack-overflowing predicate.
+    #expect(sqlstate(parsing: "SELECT 1 FROM t WHERE "
+            + String(repeating: "NOT ", count: deep) + "1 = 1") == "54001")
+  }
+
+  @Test func `a modestly nested query parses without tripping the limit`()
+      throws {
+    // A handful of nesting levels — well under the limit — parses normally, so
+    // the guard never bites a real query. A flat chain iterates rather than
+    // recurses, so its length costs no depth.
+    _ = try parse(query: "SELECT " + String(repeating: "(", count: 10) + "1"
+                         + String(repeating: ")", count: 10))
+    _ = try parse(query:
+        "SELECT * FROM (SELECT * FROM (SELECT 1) AS a) AS b")
+    _ = try parse(query: "SELECT 1 FROM t WHERE ((1 = 1 AND 2 = 2) OR (3 = 3))")
+    _ = try parse(query:
+        "SELECT 1 FROM t WHERE x IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)")
+    _ = try parse(query: "SELECT 1 FROM t WHERE NOT NOT NOT 1 = 1")
+  }
+}


### PR DESCRIPTION
Deeply nested input — parenthesised expressions/predicates/queries, nested subqueries, or nested GROUPING SETS — recursed the descent parser without a bound, overrunning the native stack (SIGBUS) rather than reporting an error. A depth counter, raised on entry to each construct that recurses on nesting (`query`, `predicate`, `expression`, and the GROUPING SETS `element`) and lowered by a paired defer, faults 54001 (statement too complex) once nesting passes a fixed limit. The guard trips before native recursion, so input nested far past the limit recurses only ~limit frames — a thousand-level query faults cleanly instead of crashing.

Only nesting counts: those four heads cover every cycle that recurses on input depth, and each parenthesis, subquery, CASE, or nested GROUPING SETS descends through one of them. A flat chain (`a OR b OR …`, `a UNION b …`) iterates rather than recurses, so its length costs no depth. The limit (32) sits well below the depth at which the frames overrun a conventional thread stack (measured ~10 KB per level in a debug build) yet far above any real query, which never nests more than a handful deep.