### PR TITLE
SQLEngine: accept a bare boolean value expression as a predicate

### DIFF
--- a/Sources/SQLEngine/Parser+Predicate.swift
+++ b/Sources/SQLEngine/Parser+Predicate.swift
@@ -169,7 +169,17 @@ extension Parser {
       try expect(.in)
       return try membership(left, negated: true)
     }
-    let op = try op()
+    guard let op = try comparator() else {
+      // No comparison operator or other predicate tail follows, so `left`
+      // stands alone as an ISO `<boolean predicand>`: bridge it as the
+      // comparison `left = TRUE`, whose three-valued truth IS `left`'s
+      // boolean value (a NULL `left` reading UNKNOWN), the same desugar `x IS
+      // TRUE` uses. A non-boolean `left` compares cross-kind against the
+      // boolean literal, which the engine reads as a definite non-match
+      // exactly as the explicit `left = TRUE` does.
+      return .comparison(left: left, op: .equal,
+                         right: .literal(.boolean(true)))
+    }
     if let quantifier = try quantifier() {
       // `left op {ANY | SOME | ALL} (query)` — a quantified comparison. The
       // quantifier follows the operator, so the peek is unambiguous: it is
@@ -438,6 +448,27 @@ extension Parser {
       return .parameter(name)
     }
     return try .expression(expression())
+  }
+
+  /// Peeks a comparison operator at the head of a predicate tail, consuming
+  /// and returning it when one is present, or `nil` when the current token is
+  /// none — leaving the stream untouched so the caller can treat the left
+  /// operand as a bare `<boolean predicand>`. The non-faulting counterpart of
+  /// `op`, which a row comparison requires an operator for.
+  private mutating func comparator() throws(SQLError) -> Comparison? {
+    let comparison: Comparison? = switch current?.kind {
+    case .equal: .equal
+    case .unequal: .unequal
+    case .lt: .lt
+    case .gt: .gt
+    case .leq: .leq
+    case .geq: .geq
+    default: nil
+    }
+    if comparison != nil {
+      _ = try advance(expecting: "a comparison operator")
+    }
+    return comparison
   }
 
   /// Parses a comparison operator.

--- a/Sources/SQLEngine/Parser.swift
+++ b/Sources/SQLEngine/Parser.swift
@@ -82,7 +82,9 @@
 ///                 | [NOT] LIKE (expression | param)
 ///                     [ESCAPE (expression | param)]
 ///                 | [NOT] BETWEEN (expression | param) AND
-///                                 (expression | param))
+///                                 (expression | param)
+///                 | )  // a bare expression is an ISO <boolean predicand>,
+///                      // desugared to `expression = TRUE`
 /// row            := '(' expression (',' expression)+ ')'  // ISO row value;
 ///                   // a comma marks it, else '(' expression ')' is a scalar
 /// quantifier     := ANY | SOME | ALL      // SOME is a synonym for ANY

--- a/Tests/SQLTests/Expressions/BooleanPredicandTests.swift
+++ b/Tests/SQLTests/Expressions/BooleanPredicandTests.swift
@@ -1,0 +1,167 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQLEngine
+
+import SQLTestSupport
+
+// MARK: - Fixture
+
+/// A relation exercising a bare `<boolean value expression>` in predicate
+/// position: a nullable BOOLEAN column `Flag` covering all three truth values
+/// (TRUE, FALSE, and a NULL row whose UNKNOWN corner a bare predicand drops),
+/// beside an integer `Age` a non-boolean bare predicand reads.
+private func flags() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["Id": .integer, "Flag": .boolean, "Age": .integer]) {
+      Row(1, true, 20)
+      Row(2, false, 30)
+      Row(3, nil, 40)
+    }
+  }
+}
+
+/// The boolean predicate a bare boolean operand `x` bridges to — the comparison
+/// `x = TRUE`, whose three-valued truth IS `x`'s boolean value.
+private func boolean(_ left: Expression) -> Predicate {
+  .comparison(left: left, op: .equal, right: .literal(.boolean(true)))
+}
+
+// MARK: - Parsing
+
+struct BareBooleanPredicandParsingTests {
+  @Test func `a bare NULL predicate desugars to NULL = TRUE`() throws {
+    // A bare value expression standing alone as a predicate is an ISO `<boolean
+    // predicand>`: it bridges to the comparison `NULL = TRUE`, the same desugar
+    // `x IS TRUE` uses, whose three-valued truth is `NULL`'s (UNKNOWN).
+    let select = try parse(select: "SELECT * FROM T WHERE NULL")
+    #expect(select.predicate == boolean(.literal(.null)))
+  }
+
+  @Test func `a bare boolean column predicate desugars to column = TRUE`()
+      throws {
+    let select = try parse(select: "SELECT * FROM T WHERE Flag")
+    #expect(select.predicate == boolean(.column("Flag")))
+  }
+
+  @Test func `a bare NOT NULL wraps the bridged comparison in a NOT`() throws {
+    // The prefix `NOT` is the ordinary boolean negation `negation` consumes, so
+    // `NOT NULL` is `NOT (NULL = TRUE)` — `NOT UNKNOWN` is UNKNOWN.
+    let select = try parse(select: "SELECT * FROM T WHERE NOT NULL")
+    #expect(select.predicate == .not(boolean(.literal(.null))))
+  }
+
+  @Test func `a parenthesised bare predicand desugars through the group`()
+      throws {
+    // `(Flag)` parses as the grouped value expression `Flag`, still bridging to
+    // `Flag = TRUE`.
+    let select = try parse(select: "SELECT * FROM T WHERE (Flag)")
+    #expect(select.predicate == boolean(.column("Flag")))
+  }
+
+  @Test func `a genuinely malformed tail is not swallowed`() throws {
+    // The desugar admits only a bare value expression standing alone: a second
+    // value expression with no operator between them (`Age Age`) leaves the
+    // trailing `Age` for the statement parser to reject, rather than being
+    // swallowed by the predicand path.
+    #expect(throws: SQLError.self) {
+      try parse(select: "SELECT * FROM T WHERE Age Age")
+    }
+  }
+}
+
+// MARK: - Evaluation
+
+struct BareBooleanPredicandEvaluationTests {
+  // Fixture: Id 1 → Flag TRUE, Id 2 → Flag FALSE, Id 3 → Flag NULL (UNKNOWN).
+
+  @Test func `WHERE NULL selects no rows`() throws {
+    // `NULL = TRUE` is UNKNOWN for every row, and WHERE admits only TRUE.
+    try flags().empty("SELECT Id FROM T WHERE NULL")
+  }
+
+  @Test func `WHERE NOT NULL selects no rows`() throws {
+    // `NOT UNKNOWN` is UNKNOWN, so the negation keeps nothing either.
+    try flags().empty("SELECT Id FROM T WHERE NOT NULL")
+  }
+
+  @Test func `NULL AND a true term is UNKNOWN, selecting no rows`() throws {
+    // Kleene AND: UNKNOWN AND TRUE = UNKNOWN.
+    try flags().empty("SELECT Id FROM T WHERE NULL AND 1 = 1")
+  }
+
+  @Test func `NULL OR a true term is TRUE, selecting every row`() throws {
+    // Kleene OR: UNKNOWN OR TRUE = TRUE — TRUE dominates.
+    try flags().expect("SELECT Id FROM T WHERE NULL OR 1 = 1",
+                       yields: [[1], [2], [3]])
+  }
+
+  @Test func `NULL AND a false term is FALSE, selecting no rows`() throws {
+    // Kleene AND: UNKNOWN AND FALSE = FALSE — FALSE dominates.
+    try flags().empty("SELECT Id FROM T WHERE NULL AND 1 = 2")
+  }
+
+  @Test func `NULL OR a false term is UNKNOWN, selecting no rows`() throws {
+    // Kleene OR: UNKNOWN OR FALSE = UNKNOWN.
+    try flags().empty("SELECT Id FROM T WHERE NULL OR 1 = 2")
+  }
+
+  @Test func `a bare boolean column keeps only its TRUE rows`() throws {
+    // `Flag` bridges to `Flag = TRUE`: the FALSE row is FALSE and the NULL row
+    // UNKNOWN, so only the definite TRUE row (Id 1) passes.
+    try flags().expect("SELECT Id FROM T WHERE Flag", yields: [[1]])
+  }
+
+  @Test func `NOT of a bare boolean column keeps only its FALSE rows`() throws {
+    // `NOT (Flag = TRUE)`: the TRUE row is dropped, the FALSE row kept, and the
+    // NULL row (NOT UNKNOWN = UNKNOWN) dropped — only Id 2 passes.
+    try flags().expect("SELECT Id FROM T WHERE NOT Flag", yields: [[2]])
+  }
+
+  @Test func `a parenthesised bare NULL selects no rows`() throws {
+    try flags().empty("SELECT Id FROM T WHERE (NULL)")
+  }
+
+  @Test func `a parenthesised bare boolean column keeps its TRUE rows`()
+      throws {
+    try flags().expect("SELECT Id FROM T WHERE (Flag)", yields: [[1]])
+  }
+
+  @Test func `a bare boolean column agrees with the explicit = TRUE`() throws {
+    // The desugar's promise: the bare form is exactly `Flag = TRUE`.
+    try flags().expect("SELECT Id FROM T WHERE Flag",
+                       equals: "SELECT Id FROM T WHERE Flag = TRUE")
+  }
+
+  @Test func `a bare boolean predicand in HAVING filters the groups`() throws {
+    // A bare predicand is a predicate in every filtering position: HAVING keeps
+    // only the TRUE group.
+    try flags().expect("SELECT Flag FROM T GROUP BY Flag HAVING Flag",
+                       yields: [[true]])
+  }
+
+  @Test func `a bare NULL predicand in HAVING drops every group`() throws {
+    try flags().empty("SELECT Id FROM T GROUP BY Id HAVING NULL")
+  }
+
+  @Test func `a non-boolean bare predicand does not fault, matching = TRUE`()
+      throws {
+    // A non-boolean operand does not fault: the engine compares it cross-kind
+    // against the boolean literal, a definite non-match, exactly as the
+    // explicit `Age = TRUE` does — so both select no rows and agree.
+    try flags().empty("SELECT Id FROM T WHERE Age")
+    try flags().expect("SELECT Id FROM T WHERE Age",
+                       equals: "SELECT Id FROM T WHERE Age = TRUE")
+  }
+
+  @Test func `the run and schema paths agree on a bare predicand`() throws {
+    // `columns(of:)` (schema-only) accepts the new predicate form on the same
+    // footing the run path does — neither faults — so a `WHERE`/`HAVING` bare
+    // predicand keeps typecheck↔run parity.
+    _ = try flags().columns(of: parse(query: "SELECT Id FROM T WHERE NULL"))
+    _ = try flags().columns(of: parse(query: "SELECT Id FROM T WHERE Flag"))
+    _ = try flags().columns(of:
+        parse(query: "SELECT Flag FROM T GROUP BY Flag HAVING Flag"))
+  }
+}


### PR DESCRIPTION
ISO 9075 admits a `<boolean value expression>` (`<boolean predicand>`) standing alone as a predicate, yielding one of the three truth values TRUE/FALSE/UNKNOWN. Until now `comparison()` parsed a left expression and then required a trailing comparison operator, `IS`, `IN`, `LIKE`, or `BETWEEN`, so a bare value expression in predicate position — `WHERE NULL`, `WHERE NULL AND x`, `WHERE NOT NULL`, `WHERE flag` for a boolean column — failed to parse with "expected a comparison operator".

Make the trailing operator optional. A new peeking `comparator()` returns the comparison operator only when one is actually present, leaving the stream untouched otherwise; `comparison()` then treats a left operand with no trailing predicate form as a bare boolean predicand and bridges it to the comparison `left = TRUE` — the same desugar `x IS TRUE` already uses. That yields exactly the ISO semantics through the engine's existing three-valued logic: `flag` reads TRUE/FALSE by its value, `NULL` reads `NULL = TRUE` = UNKNOWN, and UNKNOWN threads through Kleene AND/OR/NOT and is rejected by WHERE/HAVING/ON filtering (only TRUE passes). A genuinely malformed tail (`WHERE a b`) still faults: the second expression is left as unexpected trailing input the statement parser rejects, not swallowed.

A non-boolean bare predicand does not fault; it compares cross-kind against the boolean literal — a definite non-match — exactly as the explicit `Age = TRUE` comparison the desugar mirrors already does.