### PR TITLE
SQLEngine: row-valued IN and quantified subquery predicates

### DIFF
--- a/Sources/SQLEngine/AST+Expression.swift
+++ b/Sources/SQLEngine/AST+Expression.swift
@@ -166,35 +166,40 @@ public indirect enum Predicate: Hashable, Sendable {
   /// test of that result; `negated` flips it. `Predicate` is `indirect`, so it
   /// nests the whole `Query` without boxing.
   case exists(Query, negated: Bool)
-  /// `x [NOT] IN (Q)` — whether the operand `x` equals any value the subquery
-  /// `Q` yields, `negated` marking `NOT IN`. `Q` must project exactly one
-  /// column (else `SQLError.arity`); the predicate is the three-valued
-  /// membership of `x` in that column, exactly as the value-list `membership`
-  /// is — a NULL `x` or a NULL element makes an otherwise-unmatched test
-  /// UNKNOWN rather than FALSE, and `NOT IN` its negation (never TRUE when a
-  /// NULL element is present), while an empty result is FALSE (TRUE negated).
-  /// In this first slice `Q` is uncorrelated (it names no enclosing column), so
-  /// the engine materialises it once and folds `x = v` over the materialised
-  /// column under Kleene `OR`, the same three-valued core the value-list `IN`
-  /// uses.
-  case within(Expression, Query, negated: Bool)
-  /// `x op {ANY | SOME | ALL} (Q)` — a quantified comparison, whether `x op v`
-  /// holds for at least one (`ANY`/`SOME`) or every (`ALL`) value `v` the
-  /// subquery `Q` yields, `op` any of `= <> < <= > >=`. `Q` must project
-  /// exactly one column (else `SQLError.arity`). It is three-valued exactly as
-  /// `within` (`IN`) is — reusing the same `matches` comparison and Kleene
-  /// combine — folding `x op v` over `Q`'s column under Kleene `OR` for `any`
-  /// (TRUE at the first TRUE, else UNKNOWN if any comparison is UNKNOWN through
-  /// a NULL `x` or element, else FALSE) and under Kleene `AND` for `all` (FALSE
-  /// at the first FALSE, else UNKNOWN if any is UNKNOWN, else TRUE). An empty
-  /// `Q` takes the fold's identity — `any` FALSE (no witness), `all` TRUE
-  /// (vacuous). `= ANY` is `IN` and `<> ALL` is `NOT IN`, but the case is kept
-  /// distinct for the general operator. `SOME` is a synonym for `ANY`,
-  /// normalised to `any` at parse time. In this slice `Q` is uncorrelated — it
-  /// names no column of the enclosing query — so the engine materialises it
-  /// once (as `within` does) and folds over that single column; correlation is
-  /// a later slice.
-  case quantified(Expression, Comparison, Quantifier, Query)
+  /// `(l1, …, ln) [NOT] IN (Q)` — whether the left `<row value constructor>`
+  /// equals any row the subquery `Q` yields, `negated` marking `NOT IN`. The
+  /// left is a row of one or more `Expression`s (a bare `x IN (Q)` is the
+  /// one-arity case, its left `[x]`); `Q` must project exactly as many columns
+  /// as the row has degree (else `SQLError.arity`, checked from the compiled
+  /// width). The predicate is the three-valued disjunction of row equalities
+  /// `(l…) = (r…)` over `Q`'s rows under Kleene `OR` — each row equality the
+  /// componentwise Kleene `AND` the row comparison `rows` uses, degenerating to
+  /// the scalar `x = v` at arity one, exactly as the value-list `membership`/
+  /// `among` do. So a NULL component makes an otherwise-unmatched test UNKNOWN
+  /// rather than FALSE, an empty `Q` folds FALSE (no witness), and `NOT IN`
+  /// negates that truth — never TRUE when a candidate comparison is UNKNOWN and
+  /// none is TRUE (the NULL trap). In this slice `Q` is uncorrelated (it names
+  /// no enclosing column), so the engine materialises its rows once and folds
+  /// over them.
+  case within(Array<Expression>, Query, negated: Bool)
+  /// `(l1, …, ln) op {ANY | SOME | ALL} (Q)` — a quantified comparison, whether
+  /// `(l…) op r` holds for at least one (`ANY`/`SOME`) or every (`ALL`) row `r`
+  /// the subquery `Q` yields, `op` any of `= <> < <= > >=`. The left is a row
+  /// of one or more `Expression`s (a bare `x op ANY (Q)` is the one-arity case,
+  /// its left `[x]`); `Q` must project exactly as many columns as the row has
+  /// degree (else `SQLError.arity`). It folds the row comparison `(l…) op r`
+  /// — the same componentwise-`=`/lexicographic-ordering three-valued relation
+  /// `rows` uses, degenerating to the scalar `x op v` at arity one — over `Q`'s
+  /// rows under Kleene `OR` for `any` (TRUE at the first TRUE, else UNKNOWN if
+  /// any comparison is UNKNOWN through a NULL component, else FALSE) and under
+  /// Kleene `AND` for `all` (FALSE at the first FALSE, else UNKNOWN if any is
+  /// UNKNOWN, else TRUE). An empty `Q` takes the fold's identity — `any` FALSE
+  /// (no witness), `all` TRUE (vacuous). `= ANY` is `within` and `<> ALL` its
+  /// `NOT IN`, but the case is kept distinct for the operator. `SOME` is
+  /// a synonym for `ANY`, normalised to `any` at parse time. In this slice `Q`
+  /// is uncorrelated — the engine materialises its rows once and folds over
+  /// them; correlation is a later slice.
+  case quantified(Array<Expression>, Comparison, Quantifier, Query)
   /// `p IS [NOT] <truth value>` — the ISO `<boolean test>`, whether the inner
   /// boolean `Predicate` `p`'s three-valued result equals the `value`
   /// (`TRUE`/`FALSE`/`UNKNOWN`), or does not when `negated`. Unlike the other

--- a/Sources/SQLEngine/Aggregation.swift
+++ b/Sources/SQLEngine/Aggregation.swift
@@ -197,14 +197,10 @@ extension Predicate {
       // group, not the enclosing one — it never makes the OUTER query an
       // aggregate one.
       false
-    case let .within(operand, _, _):
-      // Only the OUTER operand can hold an enclosing-group aggregate; the
-      // subquery is its own scope.
-      operand.aggregated
-    case let .quantified(operand, _, _, _):
-      // As `within`: only the OUTER operand can hold an enclosing-group
+    case let .within(lhs, _, _), let .quantified(lhs, _, _, _):
+      // Only the OUTER left-row components can hold an enclosing-group
       // aggregate; the subquery is its own scope.
-      operand.aggregated
+      lhs.contains { $0.aggregated }
     case let .like(operand, pattern, escape, _):
       operand.aggregated || pattern.aggregated
           || (escape?.aggregated ?? false)
@@ -244,10 +240,8 @@ extension Predicate {
           || rows.contains { $0.contains { $0.grouping } }
     case .exists:
       false
-    case let .within(operand, _, _):
-      operand.grouping
-    case let .quantified(operand, _, _, _):
-      operand.grouping
+    case let .within(lhs, _, _), let .quantified(lhs, _, _, _):
+      lhs.contains { $0.grouping }
     case let .like(operand, pattern, escape, _):
       operand.grouping || pattern.grouping
           || (escape?.grouping ?? false)
@@ -287,10 +281,10 @@ extension Predicate {
       // (the subquery runs under the enclosing context), so a defined-function
       // body that nests one still carries a binding to reject at registration.
       query.bound
-    case let .within(operand, query, _):
-      operand.bound || query.bound
-    case let .quantified(operand, _, _, query):
-      operand.bound || query.bound
+    case let .within(lhs, query, _):
+      lhs.contains { $0.bound } || query.bound
+    case let .quantified(lhs, _, _, query):
+      lhs.contains { $0.bound } || query.bound
     case let .like(operand, pattern, escape, _):
       operand.bound || pattern.bound || (escape?.bound ?? false)
     case let .between(test, lower, upper, _):
@@ -497,11 +491,11 @@ extension Predicate {
     switch self {
     case let .exists(query, _):
       queries.append(query)
-    case let .within(operand, query, _):
-      operand.collect(subqueries: &queries)
+    case let .within(lhs, query, _):
+      for expression in lhs { expression.collect(subqueries: &queries) }
       queries.append(query)
-    case let .quantified(operand, _, _, query):
-      operand.collect(subqueries: &queries)
+    case let .quantified(lhs, _, _, query):
+      for expression in lhs { expression.collect(subqueries: &queries) }
       queries.append(query)
     case let .comparison(left, _, right):
       left.collect(subqueries: &queries)
@@ -562,14 +556,18 @@ extension Predicate {
       // An `EXISTS` operand's values are never read — it materialises as a
       // cardinality probe — so it is NOT a valued occurrence.
       break
-    case let .within(operand, query, _):
-      operand.collect(valued: &queries)
+    case let .within(lhs, query, _):
+      // A row-valued `IN (Q)` (the scalar `x IN (Q)` its one-arity case) reads
+      // the subquery's full ROWS — folding the row equality over every one — so
+      // it materialises FULL under the `.valued` role, never a cardinality
+      // probe.
+      for expression in lhs { expression.collect(valued: &queries) }
       queries.insert(query)
-    case let .quantified(operand, _, _, query):
-      // A quantified comparison reads the subquery's full COLUMN — folding `x
-      // op v` over every value — so it materialises FULL under the `.valued`
-      // role, exactly as `IN (Q)` does, never a cardinality probe.
-      operand.collect(valued: &queries)
+    case let .quantified(lhs, _, _, query):
+      // A quantified comparison reads the subquery's full ROWS too, folding the
+      // row comparison over every one, so it is a `.valued` occurrence as
+      // `within` is.
+      for expression in lhs { expression.collect(valued: &queries) }
       queries.insert(query)
     case let .comparison(left, _, right):
       left.collect(valued: &queries)
@@ -619,12 +617,10 @@ extension Predicate {
     switch self {
     case .exists:
       break
-    case let .within(operand, _, _):
-      operand.collect(scalar: &queries)
-    case let .quantified(operand, _, _, _):
-      // As `within`: the quantified subquery is `valued`, not scalar; only the
-      // outer operand's own subqueries are descended.
-      operand.collect(scalar: &queries)
+    case let .within(lhs, _, _), let .quantified(lhs, _, _, _):
+      // The `IN`/quantified subquery is `valued`, not scalar; only the outer
+      // left-row components' own subqueries are descended.
+      for expression in lhs { expression.collect(scalar: &queries) }
     case let .comparison(left, _, right):
       left.collect(scalar: &queries)
       right.collect(scalar: &queries)
@@ -673,12 +669,10 @@ extension Predicate {
     switch self {
     case let .exists(query, _):
       queries.insert(query)
-    case let .within(operand, _, _):
-      operand.collect(existential: &queries)
-    case let .quantified(operand, _, _, _):
-      // A quantified subquery is `valued` (its full column is read), not an
-      // existential probe; only the outer operand is descended here.
-      operand.collect(existential: &queries)
+    case let .within(lhs, _, _), let .quantified(lhs, _, _, _):
+      // The `IN`/quantified subquery is `valued` (its full rows are read), not
+      // an existential probe; only the outer left-row components are descended.
+      for expression in lhs { expression.collect(existential: &queries) }
     case let .comparison(left, _, right):
       left.collect(existential: &queries)
       right.collect(existential: &queries)
@@ -1324,13 +1318,10 @@ extension Predicate {
       // A subquery is its own scope — an aggregate inside it folds over its
       // group, not the enclosing one — so it contributes none here.
       break
-    case let .within(operand, _, _):
-      // Only the OUTER operand may hold an enclosing-group aggregate.
-      operand.collect(into: &expressions)
-    case let .quantified(operand, _, _, _):
-      // As `within`: only the OUTER operand may hold an enclosing-group
+    case let .within(lhs, _, _), let .quantified(lhs, _, _, _):
+      // Only the OUTER left-row components may hold an enclosing-group
       // aggregate.
-      operand.collect(into: &expressions)
+      for expression in lhs { expression.collect(into: &expressions) }
     case let .like(operand, pattern, escape, _):
       operand.collect(into: &expressions)
       pattern.collect(into: &expressions)

--- a/Sources/SQLEngine/Decorrelation.swift
+++ b/Sources/SQLEngine/Decorrelation.swift
@@ -370,15 +370,18 @@ extension Catalog where Self: ~Escapable {
         lifted = true
         continue
       }
-      // A positive correlated `IN (Q)`: the operand rides the semijoin `on` as
-      // the membership equality. `NOT IN` (`negated`) is deferred (its NULL
-      // trap is not a plain anti-join) and an uncorrelated IN (an empty
+      // A positive correlated scalar `IN (Q)`: the operand rides the semijoin
+      // `on` as the membership equality. `NOT IN` (`negated`) is deferred (its
+      // NULL trap is not a plain anti-join) and an uncorrelated IN (an empty
       // correlation) stays as is — both fall through to `remaining`. The
       // operand must be `safe`: a per-outer-row `operand` throw fires even when
-      // the inner is empty, but a semijoin never evaluates `on` for a left row
-      // with no right rows, so an unsafe operand would be suppressed — leave it
-      // correlated.
-      if case let .within(operand, key, correlation, false) = conjunct,
+      // inner is empty, but a semijoin never evaluates `on` for a left row with
+      // no right rows, so an unsafe operand would be suppressed — leave it
+      // correlated. Only the one-arity (scalar) row decorrelates through the
+      // single membership equality; a wider row `(a, b) IN (Q)` is left
+      // correlated in this slice.
+      if case let .within(operands, key, correlation, false) = conjunct,
+          operands.count == 1, let operand = operands.first,
           !correlation.isEmpty, operand.safe,
           let body = context.subqueries.plan(key, correlation),
           let next = semijoin(node, body, key, correlation, false,

--- a/Sources/SQLEngine/Evaluation.swift
+++ b/Sources/SQLEngine/Evaluation.swift
@@ -318,23 +318,23 @@ extension Catalog where Self: ~Escapable {
       // correlated one re-runs against this row's correlated bindings,
       // bypassing the memo.
       try present(row, key, correlation, context) != negated
-    case let .within(operand, key, correlation, negated):
-      // Fold `operand = v` over the subquery's single column under the same
-      // three-valued membership the value-list `IN` uses. The column is
-      // materialised lazily on this first reach (an uncorrelated one memoised,
-      // a correlated one re-run per row against this row's correlated
-      // bindings).
-      try member(row, operand, values(row, key, correlation, context),
-                 negated, context)
-    case let .quantified(operand, op, quantifier, key, correlation):
-      // Fold `operand op v` over the subquery's single column with the same
-      // `matches`/Kleene primitives `within` uses — Kleene `OR` (seeded FALSE)
-      // for `any`, Kleene `AND` (seeded TRUE) for `all`. It materialises its
-      // lone column lazily through the same `values` path `within` drives: an
-      // uncorrelated one memoises under its `Subkey`, a correlated one re-runs
-      // its inner plan per outer row against this row's correlated bindings.
-      try quantified(row, operand, op, quantifier,
-                     values(row, key, correlation, context), context)
+    case let .within(lhs, key, correlation, negated):
+      // Fold the row equality `(l…) = (r…)` over the subquery's rows under the
+      // same Kleene `OR` three-valued membership the value-list row `IN`
+      // (`memberships`) uses — degenerating to the scalar `x = v` at arity one.
+      // The rows are materialised lazily on this first reach (an uncorrelated
+      // one memoised, a correlated one re-run per row against this row's
+      // correlated bindings).
+      try member(row, lhs, tuples(row, key, correlation, context), negated,
+                 context)
+    case let .quantified(lhs, op, quantifier, key, correlation):
+      // Fold the row comparison `(l…) op r` over the subquery's rows with the
+      // same `relate`/Kleene primitives `within` uses — Kleene `OR` (seeded
+      // FALSE) for `any`, Kleene `AND` (seeded TRUE) for `all` — degenerating
+      // to the scalar `x op v` at arity one. The rows are materialised lazily
+      // through the same `tuples` path `within` drives.
+      try quantified(row, lhs, op, quantifier,
+                     tuples(row, key, correlation, context), context)
     case let .truth(inner, value, negated):
       try tested(evaluate(row, inner, context), value, negated)
     case let .and(lhs, rhs):
@@ -382,30 +382,6 @@ extension Catalog where Self: ~Escapable {
     var truth: Bool? = false
     for element in elements {
       let element = try evaluate(row, element, context)
-      truth = or(truth, matches(value, .equal, element))
-      if truth == true { break }
-    }
-    return negated ? truth.map { !$0 } : truth
-  }
-
-  /// Evaluates a lowered `operand [NOT] IN (Q)` against `row` over the
-  /// subquery's already-materialised single column `values`.
-  ///
-  /// It is the value-list `member` fold over constants: the `operand` is
-  /// evaluated once per row, then `operand = v` folds over the materialised
-  /// `values` IN ORDER under Kleene `OR`, seeded FALSE and short-circuiting at
-  /// the first TRUE — so a NULL operand or a NULL element keeps the ISO
-  /// three-valued result (an unmatched test is UNKNOWN, not FALSE), an empty
-  /// `values` folds FALSE (no witness), and `NOT IN` negates that truth,
-  /// mapping UNKNOWN to itself. It reuses the same `matches`/`or` primitives
-  /// the value-list `IN` does, so the two forms share one three-valued core.
-  private borrowing func member(_ row: borrowing some Row & ~Escapable,
-                                _ operand: Term, _ values: Array<Value>,
-                                _ negated: Bool, _ context: Context)
-      throws(SQLError) -> Bool? {
-    let value = try evaluate(row, operand, context)
-    var truth: Bool? = false
-    for element in values {
       truth = or(truth, matches(value, .equal, element))
       if truth == true { break }
     }
@@ -462,28 +438,60 @@ extension Catalog where Self: ~Escapable {
     return negated ? truth.map { !$0 } : truth
   }
 
-  /// Evaluates a lowered `operand op {ANY | ALL} (Q)` against `row` over the
-  /// subquery's already-materialised single column `values`.
+  /// Evaluates a lowered `(l…) [NOT] IN (Q)` against `row` over the subquery's
+  /// already-materialised full rows `tuples`.
   ///
-  /// The `operand` is evaluated once per row, then `operand op v` folds over
-  /// the materialised `values` IN ORDER with the same `matches`/Kleene
-  /// primitives the value-list and `IN (Q)` `member` folds use — Kleene `OR`
-  /// seeded FALSE for `any` (short-circuiting at the first TRUE), Kleene `AND`
-  /// seeded TRUE for `all` (short-circuiting at the first FALSE). So a NULL
-  /// `operand` or a NULL element makes an otherwise-undecided fold UNKNOWN (not
-  /// FALSE), an empty `values` takes the seed — `any` FALSE (no witness), `all`
-  /// TRUE (vacuous) — and the identity falls out of the fold rather than a
-  /// special case. `= ANY` reduces to the `member` `IN` fold and `<> ALL` to
-  /// its negation, sharing one three-valued core with `within`.
-  private borrowing func quantified(_ row: borrowing some Row & ~Escapable,
-                                    _ operand: Term, _ op: Comparison,
-                                    _ quantifier: Quantifier,
-                                    _ values: Array<Value>, _ context: Context)
+  /// It is the value-list row `member` fold over the subquery's rows: the left
+  /// row is evaluated once per row into a `[Value]` (as `memberships` holds it
+  /// once), then the row equality `(l…) = (r…)` — the shared componentwise
+  /// `relate(_, =, _)` Kleene `AND` — folds over `tuples` IN ORDER under Kleene
+  /// `OR`, seeded FALSE and short-circuiting at the first TRUE. So a NULL left
+  /// component or subquery component keeps the ISO three-valued result (an
+  /// unmatched test is UNKNOWN, not FALSE), an empty `tuples` folds FALSE (no
+  /// witness), and `NOT IN` negates that truth, mapping UNKNOWN to itself — the
+  /// row NULL trap. It reuses the same `relate`/`or` primitives the value-list
+  /// row `IN` does, so the two forms share one three-valued core.
+  private borrowing func member(_ row: borrowing some Row & ~Escapable,
+                                _ lhs: Array<Term>,
+                                _ tuples: Array<Array<Value>>,
+                                _ negated: Bool, _ context: Context)
       throws(SQLError) -> Bool? {
-    let value = try evaluate(row, operand, context)
+    var l = Array<Value>()
+    l.reserveCapacity(lhs.count)
+    for term in lhs { try l.append(evaluate(row, term, context)) }
+    var truth: Bool? = false
+    for element in tuples {
+      truth = or(truth, relate(l, .equal, element))
+      if truth == true { break }
+    }
+    return negated ? truth.map { !$0 } : truth
+  }
+
+  /// Evaluates a lowered `(l…) op {ANY | ALL} (Q)` against `row` over the
+  /// subquery's already-materialised full rows `tuples`.
+  ///
+  /// The left row is evaluated once per row into a `[Value]`, then the row
+  /// comparison `(l…) op r` — the shared `relate` three-valued relation
+  /// (componentwise Kleene `AND` for `=`, its negation for `<>`, the
+  /// lexicographic cascade for the ordering operators) — folds over `tuples` IN
+  /// ORDER with the same Kleene primitives the `member` `IN` fold uses: Kleene
+  /// `OR` seeded FALSE for `any` (short-circuiting at the first TRUE), Kleene
+  /// `AND` seeded TRUE for `all` (short-circuiting at the first FALSE). So a
+  /// NULL component makes an otherwise-undecided fold UNKNOWN, and an empty
+  /// `tuples` takes the seed — `any` FALSE (no witness), `all` TRUE (vacuous).
+  /// `= ANY` reduces to the `member` row `IN` fold and `<> ALL` to its inverse.
+  private borrowing func quantified(_ row: borrowing some Row & ~Escapable,
+                                    _ lhs: Array<Term>, _ op: Comparison,
+                                    _ quantifier: Quantifier,
+                                    _ tuples: Array<Array<Value>>,
+                                    _ context: Context)
+      throws(SQLError) -> Bool? {
+    var l = Array<Value>()
+    l.reserveCapacity(lhs.count)
+    for term in lhs { try l.append(evaluate(row, term, context)) }
     var truth: Bool? = quantifier == .any ? false : true
-    for element in values {
-      let matched = matches(value, op, element)
+    for element in tuples {
+      let matched = relate(l, op, element)
       switch quantifier {
       case .any:
         truth = or(truth, matched)

--- a/Sources/SQLEngine/Filter.swift
+++ b/Sources/SQLEngine/Filter.swift
@@ -109,34 +109,40 @@ internal indirect enum Filter: Equatable, Sendable {
   /// EXISTS-only occurrence is materialised as a cardinality probe — its select
   /// list never evaluated. A later correlated slice re-runs `Q` per outer row.
   case exists(Subkey, correlation: Correlation, negated: Bool)
-  /// `x [NOT] IN (Q)` — the lowered form of the AST's `within`. The subquery
-  /// occurrence is carried as its cache `Subkey` — never run during `compile` —
-  /// and its single-column arity is enforced at compile from its compiled width
-  /// (`SQLError.arity`, no cursor). At run time `Q` executes once against the
-  /// borrowed catalog (memoised under the `Subkey` in the `Subqueries` cache,
-  /// uncorrelated) and the case folds `operand = v` over its lone column under
-  /// the same Kleene `OR` three-valued membership the value-list
-  /// `Filter.membership` uses — a NULL operand or a NULL element making an
-  /// unmatched test UNKNOWN, an empty result FALSE, and `negated` (`NOT IN`)
-  /// negating the three-valued result (UNKNOWN maps to itself). The operand
-  /// `Term` is evaluated once per row.
-  case within(Term, Subkey, correlation: Correlation, negated: Bool)
-  /// `x op {ANY | ALL} (Q)` — the lowered form of the AST's `quantified`. The
-  /// operand term `x` is held once, the comparison `op` and the `Quantifier`
-  /// beside it, and the subquery occurrence as its cache `Subkey` (its
-  /// `.valued` role, the FULL column materialised as `within`'s is) — never
-  /// run during `compile`, its single-column arity enforced at compile from the
-  /// compiled width (`SQLError.arity`, no cursor). At run `Q` executes once
-  /// against the borrowed catalog (memoised under the `Subkey`, uncorrelated)
-  /// and the case folds `x op v` over its lone column with the same
-  /// `matches`/Kleene primitives `within` uses: Kleene `OR` for `any` (seeded
-  /// FALSE), Kleene `AND` for `all` (seeded TRUE), so a NULL `x` or element
-  /// makes an otherwise-undecided fold UNKNOWN, and an empty column takes the
-  /// seed — `any` FALSE, `all` TRUE. The operand `Term` is evaluated once per
-  /// row. A correlated occurrence carries the discovered `correlation` (as
-  /// `within` does) and re-runs its inner plan per outer row; an uncorrelated
+  /// `(l1, …, ln) [NOT] IN (Q)` — the lowered form of the AST's `within`. The
+  /// left row is a list of ordinal-addressed terms (a bare `x IN (Q)` lowering
+  /// to the one-element `[x]`) and the subquery occurrence is carried as its
+  /// cache `Subkey` under the `.valued` role (its FULL rows materialised) —
+  /// never run during `compile`, its row-arity-equals-width rule enforced at
+  /// compile from the compiled width (`SQLError.arity`, no cursor). At run time
+  /// `Q` executes once against the borrowed catalog (its rows memoised under
+  /// the `Subkey` in the `Subqueries` cache, uncorrelated) and the case folds
+  /// the row equality `(l…) = (r…)` over its rows under the same Kleene `OR`
+  /// three-valued membership the value-list `Filter.memberships` uses — each
+  /// row equality the shared componentwise `relate(_, =, _)`, degenerating to
+  /// the scalar `x = v` at arity one — so a NULL component makes an unmatched
+  /// test UNKNOWN, an empty result FALSE, and `negated` (`NOT IN`) negates that
+  /// truth (UNKNOWN maps to itself — the NULL trap). The left row's terms are
+  /// evaluated once per row. A correlated occurrence carries the discovered
+  /// `correlation` and re-runs its inner plan per outer row; an uncorrelated
   /// one carries an empty correlation and memoises once.
-  case quantified(Term, Comparison, Quantifier, Subkey,
+  case within(Array<Term>, Subkey, correlation: Correlation, negated: Bool)
+  /// `(l1, …, ln) op {ANY | ALL} (Q)` — the lowered form of the AST's
+  /// `quantified`. The left row of terms (a bare `x op ANY (Q)` lowering to
+  /// `[x]`), the comparison `op`, and the `Quantifier` are held beside the
+  /// subquery occurrence's cache `Subkey` (its `.valued` role, the FULL rows
+  /// materialised as `within`'s are) — never run during `compile`, its
+  /// row-arity-equals-width rule enforced at compile (`SQLError.arity`, no
+  /// cursor). At run `Q` executes once against the borrowed catalog (memoised
+  /// under the `Subkey`, uncorrelated) and the case folds the row comparison
+  /// `(l…) op r` — the shared `relate` three-valued relation, degenerating to
+  /// the scalar `x op v` at arity one — over its rows: Kleene `OR` for `any`
+  /// (seeded FALSE), Kleene `AND` for `all` (seeded TRUE), so a NULL component
+  /// makes an otherwise-undecided fold UNKNOWN, and an empty result takes the
+  /// seed — `any` FALSE, `all` TRUE. The left row's terms are evaluated once
+  /// per row. A correlated occurrence carries the discovered `correlation` and
+  /// re-runs its inner plan per outer row; an uncorrelated one memoises once.
+  case quantified(Array<Term>, Comparison, Quantifier, Subkey,
                   correlation: Correlation)
   /// `p IS [NOT] <truth value>` — the lowered form of the AST's `truth`. The
   /// inner boolean `Filter` is held once and evaluated to its three-valued
@@ -626,18 +632,18 @@ extension Filter {
       // its cache key through unchanged.
       .exists(key, correlation: correlation.remapped(through: slot),
               negated: negated)
-    case let .within(operand, key, correlation, negated):
-      // The outer operand term reads slots; a correlated subquery also reads
-      // the outer cells its inner `WHERE` names, so remap both. An uncorrelated
-      // one carries an empty correlation.
-      .within(operand.remapped(through: slot), key,
+    case let .within(lhs, key, correlation, negated):
+      // The left row's terms read slots; a correlated subquery also reads the
+      // outer cells its inner `WHERE` names, so remap both. An uncorrelated one
+      // carries an empty correlation.
+      .within(lhs.map { $0.remapped(through: slot) }, key,
               correlation: correlation.remapped(through: slot),
               negated: negated)
-    case let .quantified(operand, op, quantifier, key, correlation):
-      // As `within`: the outer operand term reads slots; a correlated subquery
-      // also reads the outer cells its inner `WHERE` names, so remap both. An
+    case let .quantified(lhs, op, quantifier, key, correlation):
+      // As `within`: the left row's terms read slots and a correlated subquery
+      // reads the outer cells its inner `WHERE` names, so remap both. An
       // uncorrelated one carries an empty correlation.
-      .quantified(operand.remapped(through: slot), op, quantifier, key,
+      .quantified(lhs.map { $0.remapped(through: slot) }, op, quantifier, key,
                   correlation: correlation.remapped(through: slot))
     case let .truth(inner, value, negated):
       .truth(inner.remapped(through: slot), value, negated: negated)
@@ -1309,26 +1315,29 @@ extension Catalog where Self: ~Escapable {
     return present
   }
 
-  /// The `IN (Q)` single column of the occurrence `key`, materialised lazily:
-  /// an uncorrelated one reads the memo and, on a miss, runs the inner query
-  /// once and stores its lone column; a correlated one re-runs per outer row
-  /// against the correlated bindings, bypassing the memo.
-  internal borrowing func values(_ row: borrowing some Row & ~Escapable,
+  /// The full rows of the `IN (Q)`/quantified subquery occurrence `key`,
+  /// materialised lazily: an uncorrelated one reads the memo and, on a miss,
+  /// runs the inner query once and stores all its rows; a correlated one
+  /// re-runs per outer row against the correlated bindings, bypassing the memo.
+  /// `run` already yields `Array<Value>` rows, so this keeps every column — the
+  /// scalar `x IN (Q)` is the one-column case folded the same way
+  /// (`relate([x], =, [v])` is `matches(x, =, v)`), so one materialiser serves
+  /// both.
+  internal borrowing func tuples(_ row: borrowing some Row & ~Escapable,
                                  _ key: Subkey, _ correlation: Correlation,
                                 _ context: Context)
-      throws(SQLError) -> Array<Value> {
+      throws(SQLError) -> Array<Array<Value>> {
     let context = revealed(under: key, context)
-    // A correlated `IN (Q)` re-executes its pre-compiled inner plan against
-    // this row's correlated bindings for its lone column, bypassing the memo.
-    // An uncorrelated one memoises and re-runs its `Query` (recompiling
-    // resolves).
+    // A correlated row-valued subquery re-executes its pre-compiled inner plan
+    // against this row's correlated bindings for its full rows, bypassing the
+    // memo. An uncorrelated one memoises and re-runs its `Query`.
     guard correlation.isEmpty else {
-      return try executed(row, key, correlation, context).map { $0.values[0] }
+      return try executed(row, key, correlation, context).map { $0.values }
     }
-    if let cached = context.subqueries.values(cached: key) { return cached }
-    let values = try run(key.query, context).map { $0[0] }
-    context.subqueries.store(values: values, for: key)
-    return values
+    if let cached = context.subqueries.tuples(cached: key) { return cached }
+    let tuples = try run(key.query, context)
+    context.subqueries.store(tuples: tuples, for: key)
+    return tuples
   }
 
   /// The value of a scalar subquery occurrence `key`, materialised lazily and

--- a/Sources/SQLEngine/Grouped.swift
+++ b/Sources/SQLEngine/Grouped.swift
@@ -582,15 +582,15 @@ extension Filter {
       // threaded binding, not the outer record). An uncorrelated one names
       // none.
       ordinals.formUnion(correlation.slots)
-    case let .within(operand, _, correlation, _):
-      // The outer operand term reads ordinals; a correlated subquery also reads
+    case let .within(lhs, _, correlation, _):
+      // The left row's terms read ordinals; a correlated subquery also reads
       // the outer `slot` cells its inner `WHERE` names.
-      operand.references(into: &ordinals)
+      for term in lhs { term.references(into: &ordinals) }
       ordinals.formUnion(correlation.slots)
-    case let .quantified(operand, _, _, _, correlation):
-      // As `within`: the outer operand term reads ordinals; a correlated
-      // subquery also reads the outer `slot` cells its inner `WHERE` names.
-      operand.references(into: &ordinals)
+    case let .quantified(lhs, _, _, _, correlation):
+      // As `within`: the left row's terms read ordinals and a correlated
+      // subquery reads the outer `slot` cells its inner `WHERE` names.
+      for term in lhs { term.references(into: &ordinals) }
       ordinals.formUnion(correlation.slots)
     case let .like(operand, pattern, escape, _):
       operand.references(into: &ordinals)

--- a/Sources/SQLEngine/Parser+Predicate.swift
+++ b/Sources/SQLEngine/Parser+Predicate.swift
@@ -209,7 +209,9 @@ extension Parser {
       try expect(.lparen)
       let query = try query()
       try expect(.rparen)
-      return .quantified(left, op, quantifier, query)
+      // A bare scalar left is the one-arity row `[left]` —
+      // `within`/`quantified` carry a row of one or more components.
+      return .quantified([left], op, quantifier, query)
     }
     if case let .parameter(name) = current?.kind {
       _ = try advance(expecting: "a parameter")
@@ -276,13 +278,17 @@ extension Parser {
   /// exactly once per row, the correctness fix over a desugar that duplicated a
   /// component across the places a conjunction/cascade names it.
   ///
-  /// A relational operator (`= <> < <= > >=`) takes a second row constructor of
+  /// A relational operator (`= <> < <= > >=`) takes either a `{ANY|SOME|ALL}
+  /// (query)` quantifier tail — building `Predicate.quantified(left, op,
+  /// quantifier, query)` over the row left — or a second row constructor of
   /// equal arity (else `SQLError.arity`), building `Predicate.rows(left, op,
   /// right)`. An `IN` (or `NOT IN`) takes a parenthesised list of row
-  /// constructors, building `Predicate.among(left, elements, negated:)`. The
-  /// ISO three-valued semantics (the componentwise conjunction for `=`, the
-  /// lexicographic cascade for the ordering operators, the `IN` disjunction)
-  /// live in the lowering and runtime, not this parse.
+  /// constructors — building `Predicate.among(left, elements, negated:)` — or,
+  /// when a subquery follows the `(`, a table subquery, building
+  /// `Predicate.within(left, query, negated:)` over the row left. The ISO
+  /// three-valued semantics (the componentwise conjunction for `=`, the
+  /// lexicographic cascade for the ordering operators, the `IN` disjunction,
+  /// the quantified fold) live in the lowering and runtime, not this parse.
   private mutating func rows(_ left: Array<Expression>)
       throws(SQLError) -> Predicate {
     if try match(.in) {
@@ -293,6 +299,16 @@ extension Parser {
       return try rows(left, in: true)
     }
     let op = try op()
+    if let quantifier = try quantifier() {
+      // `(l…) op {ANY | SOME | ALL} (query)` — a row-valued quantified
+      // comparison. The quantifier follows the operator, so the peek is
+      // unambiguous — it is never a right row. The subquery is parenthesised as
+      // the scalar quantified comparison and `IN (Q)` are.
+      try expect(.lparen)
+      let query = try query()
+      try expect(.rparen)
+      return .quantified(left, op, quantifier, query)
+    }
     guard let right = try row() else {
       let token = try advance(expecting: "a row value constructor")
       throw .unexpected(token.kind.description,
@@ -305,13 +321,43 @@ extension Parser {
     return .rows(left, op, right)
   }
 
-  /// Parses the tail of a row `[NOT] IN '(' row (',' row)* ')'` — the `IN` is
-  /// already consumed — building `Predicate.among(left, elements, negated:)`
-  /// over `left` and the parsed element rows, each of equal arity (else
-  /// `SQLError.arity`) and the list non-empty. `negated` marks `NOT IN`.
+  /// Parses the tail of a row `[NOT] IN '(' … ')'` — the `IN` is already
+  /// consumed — as either a table subquery (`Predicate.within` over the row
+  /// left) or a value list of row constructors (`Predicate.among`), `negated`
+  /// marking `NOT IN`.
+  ///
+  /// After the opening `(`, a `SELECT`/`TABLE`/`VALUES` begins a subquery — the
+  /// peek is unambiguous, as those keywords never begin a row element. A
+  /// leading `(` is genuinely ambiguous: it may begin a nested query primary
+  /// `IN ((SELECT …))` — a table subquery — or the first row of a value list
+  /// `IN ((1, 2), (3, 4))`. ISO tells them apart by whether the parenthesised
+  /// content is a single `<query expression>`: a `)` then closes the subquery,
+  /// a `,` continues a value list. That signal sits an unbounded distance past
+  /// the `(`, so speculatively parse a query and keep it only when a `)`
+  /// follows immediately; otherwise rewind the full cursor (lexer, current, and
+  /// the `pending` lookahead) and read the value list, exactly as the scalar
+  /// `membership` disambiguates. Each value-list element is a row constructor
+  /// of equal arity (else `SQLError.arity`) and the list is non-empty.
   private mutating func rows(_ left: Array<Expression>, in negated: Bool)
       throws(SQLError) -> Predicate {
     try expect(.lparen)
+    if [.select, .table, .values].contains(current?.kind) {
+      let query = try query()
+      try expect(.rparen)
+      return .within(left, query, negated: negated)
+    }
+    if current?.kind == .lparen {
+      let lexer = self.lexer
+      let token = self.current
+      let buffer = self.pending
+      if let query = try? query(), current?.kind == .rparen {
+        try expect(.rparen)
+        return .within(left, query, negated: negated)
+      }
+      self.lexer = lexer
+      self.current = token
+      self.pending = buffer
+    }
     var elements = Array<Array<Expression>>()
     repeat {
       guard let element = try row() else {
@@ -368,7 +414,7 @@ extension Parser {
     if [.select, .table, .values].contains(current?.kind) {
       let query = try query()
       try expect(.rparen)
-      return .within(left, query, negated: negated)
+      return .within([left], query, negated: negated)
     }
     if current?.kind == .lparen {
       let lexer = self.lexer
@@ -376,7 +422,7 @@ extension Parser {
       let buffer = self.pending
       if let query = try? query(), current?.kind == .rparen {
         try expect(.rparen)
-        return .within(left, query, negated: negated)
+        return .within([left], query, negated: negated)
       }
       self.lexer = lexer
       self.current = token

--- a/Sources/SQLEngine/Parser.swift
+++ b/Sources/SQLEngine/Parser.swift
@@ -74,7 +74,8 @@
 /// conjunction    := negation (AND negation)*
 /// negation       := NOT negation | [NOT] EXISTS '(' query ')' | primary
 /// primary        := '(' predicate ')' [IS [NOT] truthvalue] | comparison
-/// comparison     := row (op row | [NOT] IN '(' row (',' row)* ')')
+/// comparison     := row (op (quantifier '(' query ')' | row)
+///                        | [NOT] IN '(' (row (',' row)* | query) ')')
 ///                 | expression (op (quantifier '(' query ')'
 ///                                    | expression | param)
 ///                 | IS [NOT] (NULL | truthvalue | DISTINCT FROM expression)

--- a/Sources/SQLEngine/Resolution.swift
+++ b/Sources/SQLEngine/Resolution.swift
@@ -441,8 +441,10 @@ internal final class SubqueryMemo {
   private var scalars: Dictionary<Subkey, Value> = [:]
   /// The `EXISTS` non-empty result memoised per existential occurrence.
   private var probes: Dictionary<Subkey, Bool> = [:]
-  /// The `IN (Q)` single-column value set memoised per valued occurrence.
-  private var columns: Dictionary<Subkey, Array<Value>> = [:]
+  /// The `IN (Q)`/quantified subquery's FULL rows memoised per valued
+  /// occurrence — every column, so a scalar `x IN (Q)` (one column) and a row
+  /// `(a, b) IN (Q)` share the one materialisation.
+  private var tuples: Dictionary<Subkey, Array<Array<Value>>> = [:]
 
   /// The resolution OVERLAY each `Subscope`'s subqueries run under — the
   /// caller's `WITH`/store overlay under `.caller`, a view body's own overlay
@@ -465,9 +467,9 @@ internal final class SubqueryMemo {
     probes[key] = value
   }
 
-  internal func values(_ key: Subkey) -> Array<Value>? { columns[key] }
-  internal func store(values: Array<Value>, for key: Subkey) {
-    columns[key] = values
+  internal func tuples(_ key: Subkey) -> Array<Array<Value>>? { tuples[key] }
+  internal func store(tuples: Array<Array<Value>>, for key: Subkey) {
+    self.tuples[key] = tuples
   }
 
   /// The compiled inner plan of each correlated occurrence, keyed by its
@@ -727,34 +729,42 @@ internal struct Resolution {
                    correlation: correlation(of: query), negated: negated)
   }
 
-  /// Lowers `operand [NOT] IN (query)` — `operand` already lowered to a `Term`
-  /// — requiring `query` project exactly one column (else `SQLError.arity`,
-  /// checked from the compiled width, so a two-column subquery faults here
-  /// without running), then carrying the query into the `Filter` to run at
-  /// execution.
-  internal func within(_ operand: Term, _ query: Query, negated: Bool)
+  /// Lowers `(l…) [NOT] IN (query)` — the left row already lowered to
+  /// `operands` (a bare `x IN (query)` lowering to `[x]`) — requiring
+  /// `query` project exactly as many columns as the row has degree (else
+  /// `SQLError.arity`, checked from the compiled width, so a mis-arity subquery
+  /// faults here without running), then carrying the query into the `Filter`
+  /// under the `.valued` role (its full rows materialised and folded per outer
+  /// row) with the discovered `correlation` threaded so a correlated occurrence
+  /// re-runs its inner plan per outer row.
+  internal func within(_ operands: Array<Term>, _ query: Query, negated: Bool)
       throws(SQLError) -> Filter {
     let width = try width(query)
-    guard width == 1 else { throw .arity(1, width) }
-    return .within(operand, Subkey(scope, query, .valued),
+    guard width == operands.count else {
+      throw .arity(operands.count, width)
+    }
+    return .within(operands, Subkey(scope, query, .valued),
                    correlation: correlation(of: query), negated: negated)
   }
 
-  /// Lowers `operand op {ANY | ALL} (query)` — `operand` already lowered to a
-  /// `Term` — requiring `query` project exactly one column (else
-  /// `SQLError.arity`, from the compiled width, so a two-column subquery faults
-  /// here without running), then carrying the query into the `Filter` under the
-  /// same `.valued` role `within` uses — the full column is materialised and
-  /// folded per outer row — with the discovered `correlation` threaded exactly
-  /// as `within` threads it, so a correlated quantified re-runs its inner plan
-  /// per outer row (an uncorrelated one carries an empty correlation and
-  /// memoises once), to run at execution.
-  internal func quantified(_ operand: Term, _ op: Comparison,
+  /// Lowers `(l…) op {ANY | ALL} (query)` — the left row already lowered to
+  /// `operands` (a bare `x op ANY (query)` lowering to `[x]`) — requiring
+  /// `query` project exactly as many columns as the row has degree (else
+  /// `SQLError.arity`, from the compiled width), then carrying the query into
+  /// the `Filter` under the same `.valued` role `within` uses (its full rows
+  /// materialised and folded per outer row) with the discovered `correlation`
+  /// threaded as `within` threads it, so a correlated quantified re-runs its
+  /// inner plan per outer row (an uncorrelated one carries an empty correlation
+  /// and memoises once).
+  internal func quantified(_ operands: Array<Term>, _ op: Comparison,
                            _ quantifier: Quantifier, _ query: Query)
       throws(SQLError) -> Filter {
     let width = try width(query)
-    guard width == 1 else { throw .arity(1, width) }
-    return .quantified(operand, op, quantifier, Subkey(scope, query, .valued),
+    guard width == operands.count else {
+      throw .arity(operands.count, width)
+    }
+    return .quantified(operands, op, quantifier,
+                       Subkey(scope, query, .valued),
                        correlation: correlation(of: query))
   }
 
@@ -845,17 +855,17 @@ internal struct Subqueries {
     memo.store(present: value, for: key)
   }
 
-  /// The memoised `IN (Q)` single column for the uncorrelated occurrence `key`,
-  /// or `nil` when it has not yet run — the evaluator materialises on a miss
-  /// and `store`s it.
-  internal func values(cached key: Subkey) -> Array<Value>? {
-    memo.values(key)
+  /// The memoised FULL rows of the `IN (Q)`/quantified subquery uncorrelated
+  /// occurrence `key`, or `nil` when it has not yet run — the evaluator
+  /// materialises on a miss and `store`s them.
+  internal func tuples(cached key: Subkey) -> Array<Array<Value>>? {
+    memo.tuples(key)
   }
 
-  /// Records the `IN (Q)` single-column value set of the uncorrelated
+  /// Records the FULL rows of the `IN (Q)`/quantified subquery uncorrelated
   /// occurrence `key`.
-  internal func store(values: Array<Value>, for key: Subkey) {
-    memo.store(values: values, for: key)
+  internal func store(tuples: Array<Array<Value>>, for key: Subkey) {
+    memo.store(tuples: tuples, for: key)
   }
 
   /// The already-collapsed value memoised for the scalar uncorrelated
@@ -1201,19 +1211,24 @@ internal func lower(_ predicate: Predicate,
     // `negated` flipping it. A missing materialiser (a lowering surface with no
     // catalog in scope) rejects the subquery rather than mis-lower it.
     try subquery.exists(query, negated: negated)
-  case let .within(expression, query, negated):
-    // `x [NOT] IN (Q)`. `Q` is uncorrelated here, so the materialiser runs it
-    // once, checks it projects exactly one column (else `SQLError.arity`), and
-    // lowers to a `Filter.within` folding `x = v` over that column under the
-    // value-list `IN`'s three-valued Kleene `OR`.
-    try subquery.within(term(expression), query, negated: negated)
-  case let .quantified(expression, op, quantifier, query):
-    // `x op {ANY | ALL} (Q)`. `Q` is uncorrelated here, so the materialiser
-    // runs it once, checks it projects exactly one column (else
-    // `SQLError.arity`), and lowers to a `Filter.quantified` folding `x op v`
-    // over that column with the same `matches`/Kleene primitives `within` uses
-    // — Kleene `OR` for `any`, Kleene `AND` for `all`.
-    try subquery.quantified(term(expression), op, quantifier, query)
+  case let .within(expressions, query, negated):
+    // `(l…) [NOT] IN (Q)` (a bare `x IN (Q)` its one-arity case). `Q` is
+    // uncorrelated here, so the materialiser runs it once, checks it projects
+    // as many columns as the row has degree (else `SQLError.arity`), and lowers
+    // to a `Filter.within` folding the row equality `(l…) = (r…)` over `Q`'s
+    // rows under the value-list row `IN`'s three-valued Kleene `OR`. Each left
+    // component is lowered once through `term`.
+    try subquery.within(terms(of: expressions, lowering: term), query,
+                        negated: negated)
+  case let .quantified(expressions, op, quantifier, query):
+    // `(l…) op {ANY | ALL} (Q)` (a bare `x op ANY (Q)` its one-arity case). `Q`
+    // is uncorrelated here, so the materialiser runs it once, checks it
+    // projects as many columns as the row has degree (else `SQLError.arity`),
+    // and lowers to a `Filter.quantified` folding the row comparison `(l…) op
+    // r` over `Q`'s rows with the same `relate`/Kleene primitives — Kleene `OR`
+    // for `any`, Kleene `AND` for `all`. Each left component lowers via `term`.
+    try subquery.quantified(terms(of: expressions, lowering: term),
+                            op, quantifier, query)
   case let .membership(expression, values, negated):
     // `x IN (a, b, …)` is the disjunction `x = a OR x = b OR …` and `NOT IN`
     // its negation, lowered to a first-class `Filter.membership` that evaluates
@@ -1309,12 +1324,22 @@ private func membership(_ left: Term, _ values: Array<Expression>,
   if values.isEmpty {
     throw .state("42601", "IN requires a non-empty value list")
   }
-  var elements = Array<Term>()
-  elements.reserveCapacity(values.count)
-  for value in values {
-    try elements.append(term(value))
-  }
-  return Filter(membership: left, elements, negated: negated)
+  return try Filter(membership: left, terms(of: values, lowering: term),
+                    negated: negated)
+}
+
+/// Lowers a list of `expressions` componentwise through `term` into an array of
+/// `Term`s, each lowered exactly once — the shared component lowering the
+/// value-list `IN`, the row-value comparison, row `IN`, and the row-valued
+/// subquery predicates all draw on, so a component resolves the same way and
+/// once wherever it appears.
+private func terms(of expressions: Array<Expression>,
+                   lowering term: (Expression) throws(SQLError) -> Term)
+    throws(SQLError) -> Array<Term> {
+  var lowered = Array<Term>()
+  lowered.reserveCapacity(expressions.count)
+  for expression in expressions { try lowered.append(term(expression)) }
+  return lowered
 }
 
 /// Lowers `(l…) <op> (r…)` to a first-class `Filter.comparison(l, op, r)`, the
@@ -1336,13 +1361,8 @@ private func rows(_ lhs: Array<Expression>, _ op: Comparison,
   guard lhs.count == rhs.count else {
     throw .arity(lhs.count, rhs.count)
   }
-  var l = Array<Term>()
-  l.reserveCapacity(lhs.count)
-  for expression in lhs { try l.append(term(expression)) }
-  var r = Array<Term>()
-  r.reserveCapacity(rhs.count)
-  for expression in rhs { try r.append(term(expression)) }
-  return Filter(comparison: l, op, r)
+  return try Filter(comparison: terms(of: lhs, lowering: term), op,
+                    terms(of: rhs, lowering: term))
 }
 
 /// Lowers `(l…) [NOT] IN ((r…), …)` to a first-class
@@ -1366,19 +1386,14 @@ private func among(_ lhs: Array<Expression>, _ rows: Array<Array<Expression>>,
   if rows.isEmpty {
     throw .state("42601", "IN requires a non-empty value list")
   }
-  var l = Array<Term>()
-  l.reserveCapacity(lhs.count)
-  for expression in lhs { try l.append(term(expression)) }
+  let l = try terms(of: lhs, lowering: term)
   var elements = Array<Array<Term>>()
   elements.reserveCapacity(rows.count)
   for element in rows {
     guard element.count == lhs.count else {
       throw .arity(lhs.count, element.count)
     }
-    var row = Array<Term>()
-    row.reserveCapacity(element.count)
-    for expression in element { try row.append(term(expression)) }
-    elements.append(row)
+    try elements.append(terms(of: element, lowering: term))
   }
   return Filter(memberships: l, elements, negated: negated)
 }

--- a/Sources/SQLEngine/Scope.swift
+++ b/Sources/SQLEngine/Scope.swift
@@ -1341,25 +1341,35 @@ internal struct Scope {
       // Reached in the `existential` role, so the deferred phase validates its
       // cardinality probe (no select list), never the original projection.
       try subquery.validate(query, as: .existential)
-    case let .within(operand, query, _):
-      // Validate the operand AND the inner query, and enforce the single-column
-      // arity the lowering does (`SQLError.arity`), so schema validation
-      // matches execution — the recurring lesson that the two must not diverge.
-      // Reached in the `valued` role — its value set is read, so the deferred
-      // phase validates the original query.
-      _ = try validate(operand, routines, subquery: subquery)
+    case let .within(lhs, query, _):
+      // `(l…) [NOT] IN (Q)` (a bare `x IN (Q)` its one-arity case): validate
+      // each left component AND the inner query, and enforce the
+      // row-arity-equals-width rule the lowering does (`SQLError.arity`), so
+      // schema validation matches execution — the recurring lesson that the
+      // two must not diverge. Reached in the `valued` role (its rows are read),
+      // so the deferred phase validates the original query. A cross-kind
+      // component is NOT rejected — the run's `relate`/`matches` yields FALSE
+      // across kinds without faulting, as an `IN` element does — so the schema
+      // accepts what the run accepts; an irreconcilable set-operation subquery
+      // still faults through its own union type fold.
+      for expression in lhs {
+        _ = try validate(expression, routines, subquery: subquery)
+      }
       try subquery.validate(query, as: .valued)
       let width = try subquery.width(query)
-      guard width == 1 else { throw .arity(1, width) }
-    case let .quantified(operand, _, _, query):
-      // As `within`: validate the operand and the inner query, and enforce the
-      // single-column arity the lowering does (`SQLError.arity`), so schema
-      // validation matches execution. Reached `valued` (its values are read),
-      // so the deferred phase validates the original query.
-      _ = try validate(operand, routines, subquery: subquery)
+      guard width == lhs.count else { throw .arity(lhs.count, width) }
+    case let .quantified(lhs, _, _, query):
+      // As `within`: validate each left component and the inner query, and
+      // enforce the row-arity-equals-subquery-width rule the lowering does
+      // (`SQLError.arity`), so schema validation matches execution. Reached
+      // `valued` (its rows are read), so the deferred phase validates the
+      // original query.
+      for expression in lhs {
+        _ = try validate(expression, routines, subquery: subquery)
+      }
       try subquery.validate(query, as: .valued)
       let width = try subquery.width(query)
-      guard width == 1 else { throw .arity(1, width) }
+      guard width == lhs.count else { throw .arity(lhs.count, width) }
     case .bound:
       // `left op :parameter` with no binding — the schema default `[:]` —
       // yields UNKNOWN without evaluating the left term, so a run just produces
@@ -2068,8 +2078,8 @@ internal struct Scope {
     case .exists:
       true
     // A quantified comparison is three-valued over NULLs exactly as `IN (Q)` —
-    // a NULL element or operand makes an undecided fold UNKNOWN — so it is not
-    // definite either.
+    // a NULL component makes an undecided fold UNKNOWN — so it is not definite
+    // either.
     case .within, .quantified:
       false
     case let .and(lhs, rhs), let .or(lhs, rhs):
@@ -2242,14 +2252,12 @@ internal struct Scope {
       // group, not the enclosing one — so an `EXISTS (Q)` contributes no outer
       // aggregate to collect.
       break
-    case let .within(operand, _, _):
-      // Only the OUTER operand may hold an enclosing-group aggregate; the
-      // subquery is its own scope, so it is not walked here.
-      try aggregates(in: operand, routines, subquery: subquery)
-    case let .quantified(operand, _, _, _):
-      // As `within`: only the OUTER operand may hold an enclosing-group
-      // aggregate; the subquery is its own scope.
-      try aggregates(in: operand, routines, subquery: subquery)
+    case let .within(lhs, _, _), let .quantified(lhs, _, _, _):
+      // Only the OUTER left-row components may hold an enclosing-group
+      // aggregate; the subquery is its own scope, so it is not walked here.
+      for expression in lhs {
+        try aggregates(in: expression, routines, subquery: subquery)
+      }
     case let .like(operand, pattern, escape, _):
       try aggregates(in: operand, routines, subquery: subquery)
       try aggregates(in: pattern, routines, subquery: subquery)

--- a/Tests/SQLTests/Expressions/QuantifiedSubqueryTests.swift
+++ b/Tests/SQLTests/Expressions/QuantifiedSubqueryTests.swift
@@ -28,7 +28,7 @@ struct QuantifiedSubqueryParsingTests {
         try parse(select: "SELECT Id FROM T WHERE K = ANY (SELECT V FROM S)")
     let inner = try parse(query: "SELECT V FROM S")
     #expect(select.predicate
-                == .quantified(.column("K"), .equal, .any, inner))
+                == .quantified([.column("K")], .equal, .any, inner))
   }
 
   @Test func `parses <> ALL over a subquery`() throws {
@@ -36,7 +36,7 @@ struct QuantifiedSubqueryParsingTests {
         try parse(select: "SELECT Id FROM T WHERE K <> ALL (SELECT V FROM S)")
     let inner = try parse(query: "SELECT V FROM S")
     #expect(select.predicate
-                == .quantified(.column("K"), .unequal, .all, inner))
+                == .quantified([.column("K")], .unequal, .all, inner))
   }
 
   @Test func `parses each comparison operator with a quantifier`() throws {
@@ -47,7 +47,7 @@ struct QuantifiedSubqueryParsingTests {
     for (spelling, op) in cases {
       let select = try parse(select:
           "SELECT Id FROM T WHERE K \(spelling) ANY (SELECT V FROM S)")
-      #expect(select.predicate == .quantified(.column("K"), op, .any, inner))
+      #expect(select.predicate == .quantified([.column("K")], op, .any, inner))
     }
   }
 
@@ -60,7 +60,7 @@ struct QuantifiedSubqueryParsingTests {
         try parse(select: "SELECT Id FROM T WHERE K < ANY (SELECT V FROM S)")
     #expect(some.predicate == any.predicate)
     let inner = try parse(query: "SELECT V FROM S")
-    #expect(some.predicate == .quantified(.column("K"), .lt, .any, inner))
+    #expect(some.predicate == .quantified([.column("K")], .lt, .any, inner))
   }
 
   @Test func `parses a quantified comparison over a UNION subquery`() throws {
@@ -70,7 +70,7 @@ struct QuantifiedSubqueryParsingTests {
     let select = try parse(select: text)
     let inner = try parse(query: "SELECT V FROM S UNION SELECT V FROM N")
     #expect(select.predicate
-                == .quantified(.column("K"), .gt, .all, inner))
+                == .quantified([.column("K")], .gt, .all, inner))
   }
 }
 

--- a/Tests/SQLTests/Queries/RowSubqueryTests.swift
+++ b/Tests/SQLTests/Queries/RowSubqueryTests.swift
@@ -1,0 +1,353 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQLEngine
+
+import SQLTestSupport
+
+// MARK: - Fixture
+
+/// Relations exercising the row-valued `IN (subquery)` and quantified-subquery
+/// predicates: an outer `T2` whose two-column row `(A, B)` reaches the
+/// three-valued corners (row 4 has a NULL component); a non-NULL inner `P`
+/// filtered to empty or non-empty by `Flag`; a NULL-bearing inner `QN` (one row
+/// has a NULL component, so the row NULL trap is reachable); and a `R2` whose
+/// text `Name` column makes a UNION subquery irreconcilable.
+private func rowfixture() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T2", ["Id": .integer, "A": .integer, "B": .integer]) {
+      Row(1, 10, 100)
+      Row(2, 20, 200)
+      Row(3, 10, 999)
+      Row(4, nil, 100)
+      Row(5, 30, 300)
+      Row(6, 5, 50)
+    }
+    Relation("P", ["X": .integer, "Y": .integer, "Flag": .integer]) {
+      Row(10, 100, 1)
+      Row(20, 200, 1)
+      Row(50, 500, 0)
+    }
+    Relation("QN", ["X": .integer, "Y": .integer]) {
+      Row(10, 100)
+      Row(20, nil)
+    }
+    Relation("R2", ["Id2": .integer, "Name": .text]) {
+      Row(1, "a")
+    }
+  }
+}
+
+// MARK: - Parsing
+
+struct RowSubqueryParsingTests {
+  @Test func `parses a row IN over a subquery`() throws {
+    let select = try parse(select:
+        "SELECT Id FROM T2 WHERE (A, B) IN (SELECT X, Y FROM P)")
+    let inner = try parse(query: "SELECT X, Y FROM P")
+    #expect(select.predicate
+                == .within([.column("A"), .column("B")], inner,
+                           negated: false))
+  }
+
+  @Test func `parses a row NOT IN over a subquery`() throws {
+    let select = try parse(select:
+        "SELECT Id FROM T2 WHERE (A, B) NOT IN (SELECT X, Y FROM P)")
+    let inner = try parse(query: "SELECT X, Y FROM P")
+    #expect(select.predicate
+                == .within([.column("A"), .column("B")], inner,
+                           negated: true))
+  }
+
+  @Test func `a row IN over a value list still parses as among`() throws {
+    // The subquery lookahead only takes the subquery arm on a leading SELECT (or
+    // a parenthesised query); an ordinary value list of rows stays a `.among`.
+    let select = try parse(select:
+        "SELECT Id FROM T2 WHERE (A, B) IN ((10, 100), (20, 200))")
+    #expect(select.predicate
+                == .among([.column("A"), .column("B")],
+                          [[.literal(.integer(10)), .literal(.integer(100))],
+                           [.literal(.integer(20)), .literal(.integer(200))]],
+                          negated: false))
+  }
+
+  @Test func `parses a row IN over a parenthesised subquery`() throws {
+    // A leading `(` after `IN (` is ambiguous: a nested query primary here, told
+    // apart by the `)` that immediately follows the parsed query.
+    let select = try parse(select:
+        "SELECT Id FROM T2 WHERE (A, B) IN ((SELECT X, Y FROM P))")
+    let inner = try parse(query: "(SELECT X, Y FROM P)")
+    #expect(select.predicate
+                == .within([.column("A"), .column("B")], inner,
+                           negated: false))
+  }
+
+  @Test func `parses a row quantified subquery`() throws {
+    let select = try parse(select:
+        "SELECT Id FROM T2 WHERE (A, B) = ANY (SELECT X, Y FROM P)")
+    let inner = try parse(query: "SELECT X, Y FROM P")
+    #expect(select.predicate
+                == .quantified([.column("A"), .column("B")], .equal, .any,
+                               inner))
+  }
+
+  @Test func `SOME normalises to ANY in a row quantified subquery`() throws {
+    let select = try parse(select:
+        "SELECT Id FROM T2 WHERE (A, B) <> SOME (SELECT X, Y FROM P)")
+    let inner = try parse(query: "SELECT X, Y FROM P")
+    #expect(select.predicate
+                == .quantified([.column("A"), .column("B")], .unequal, .any,
+                               inner))
+  }
+
+  @Test func `parses a row comparison against a row still as rows`() throws {
+    // The op-then-row path is unchanged when no quantifier follows the operator.
+    let select = try parse(select:
+        "SELECT Id FROM T2 WHERE (A, B) = (10, 100)")
+    #expect(select.predicate
+                == .rows([.column("A"), .column("B")], .equal,
+                         [.literal(.integer(10)), .literal(.integer(100))]))
+  }
+}
+
+// MARK: - Row IN (subquery) execution
+
+struct RowInQueryEvaluationTests {
+  @Test func `a row IN over a subquery admits the matching rows`() throws {
+    // P filtered to Flag = 1 yields {(10, 100), (20, 200)}: T2 rows 1 and 2
+    // match componentwise; 3 (B differs), 5, 6 do not; 4 (A NULL) is UNKNOWN.
+    try rowfixture().expect(
+        "SELECT Id FROM T2 WHERE (A, B) IN (SELECT X, Y FROM P WHERE Flag = 1)",
+        yields: [[1], [2]])
+  }
+
+  @Test func `a row NOT IN over a subquery admits the complement`() throws {
+    // The negation over the non-NULL, non-UNKNOWN rows: 3, 5, 6. Row 4's NULL
+    // component leaves the membership UNKNOWN, so NOT IN drops it too.
+    try rowfixture().expect(
+        "SELECT Id FROM T2 WHERE (A, B) NOT IN "
+        + "(SELECT X, Y FROM P WHERE Flag = 1)",
+        yields: [[3], [5], [6]])
+  }
+
+  @Test func `a NULL left component makes the row IN UNKNOWN`() throws {
+    // Row 4 is (NULL, 100): `(NULL, 100) = (10, 100)` is `UNKNOWN AND TRUE` =
+    // UNKNOWN, `= (20, 200)` is `UNKNOWN AND FALSE` = FALSE, so the disjunction
+    // is `UNKNOWN OR FALSE` = UNKNOWN — dropped by IN and by NOT IN alike.
+    try rowfixture().empty(
+        "SELECT Id FROM T2 WHERE (A, B) IN "
+        + "(SELECT X, Y FROM P WHERE Flag = 1) AND Id = 4")
+    try rowfixture().empty(
+        "SELECT Id FROM T2 WHERE (A, B) NOT IN "
+        + "(SELECT X, Y FROM P WHERE Flag = 1) AND Id = 4")
+  }
+
+  @Test func `a row IN folds like the value-list row IN`() throws {
+    // The subquery yielding {(10, 100), (20, 200)} matches exactly the value
+    // list of the same rows — the two share one three-valued membership core.
+    try rowfixture().expect(
+        "SELECT Id FROM T2 WHERE (A, B) IN "
+        + "(SELECT X, Y FROM P WHERE Flag = 1)",
+        equals:
+        "SELECT Id FROM T2 WHERE (A, B) IN ((10, 100), (20, 200))")
+  }
+
+  @Test func `a row IN over an empty subquery is FALSE`() throws {
+    // An empty subquery has no witness row, so `(A, B) IN (empty)` is FALSE for
+    // every outer row.
+    try rowfixture().empty(
+        "SELECT Id FROM T2 WHERE (A, B) IN (SELECT X, Y FROM P WHERE Flag = 9)")
+  }
+
+  @Test func `a row NOT IN over an empty subquery is TRUE`() throws {
+    // `NOT IN (empty)` is the negation of FALSE — TRUE — so every row survives,
+    // including row 4 whose A is NULL (the NULL trap needs a NULL candidate row,
+    // and an empty subquery has none).
+    try rowfixture().expect(
+        "SELECT Id FROM T2 WHERE (A, B) NOT IN "
+        + "(SELECT X, Y FROM P WHERE Flag = 9)",
+        yields: [[1], [2], [3], [4], [5], [6]])
+  }
+}
+
+// MARK: - The NULL corners (subquery components)
+
+struct RowInQueryNullCornerTests {
+  @Test func `a row present in a NULL-bearing subquery is TRUE`() throws {
+    // QN is {(10, 100), (20, NULL)}; `(10, 100) IN (…)` finds the definite
+    // `(10, 100)` match, so it is TRUE regardless of the NULL-bearing row.
+    try rowfixture().expect(
+        "SELECT Id FROM T2 WHERE (A, B) IN (SELECT X, Y FROM QN) AND Id = 1",
+        yields: [[1]])
+  }
+
+  @Test func `an unmatched row against a NULL-bearing subquery is UNKNOWN`()
+      throws {
+    // Row 2 is (20, 200): `= (10, 100)` FALSE, `= (20, NULL)` is
+    // `TRUE AND UNKNOWN` = UNKNOWN, so the disjunction is UNKNOWN, not FALSE —
+    // the row is not admitted by IN.
+    try rowfixture().empty(
+        "SELECT Id FROM T2 WHERE (A, B) IN (SELECT X, Y FROM QN) AND Id = 2")
+  }
+
+  @Test func `a row NOT IN a NULL-bearing subquery is UNKNOWN (the trap)`()
+      throws {
+    // Row 2 (20, 200): the membership is UNKNOWN (the NULL component of the
+    // `(20, NULL)` candidate), so `NOT IN` negates UNKNOWN to UNKNOWN — never
+    // TRUE when a candidate comparison is UNKNOWN and none is TRUE — so the row
+    // is dropped, the row-valued NULL trap.
+    try rowfixture().empty(
+        "SELECT Id FROM T2 WHERE (A, B) NOT IN (SELECT X, Y FROM QN) AND Id = 2")
+  }
+}
+
+// MARK: - Row quantified subquery execution
+
+struct RowQuantifiedEvaluationTests {
+  @Test func `= ANY over a subquery is the row IN`() throws {
+    // ISO: `(l…) = ANY (Q)` is `(l…) IN (Q)`.
+    try rowfixture().expect(
+        "SELECT Id FROM T2 WHERE (A, B) = ANY "
+        + "(SELECT X, Y FROM P WHERE Flag = 1)",
+        equals:
+        "SELECT Id FROM T2 WHERE (A, B) IN (SELECT X, Y FROM P WHERE Flag = 1)")
+  }
+
+  @Test func `<> ALL over a subquery is the row NOT IN`() throws {
+    // ISO: `(l…) <> ALL (Q)` is `(l…) NOT IN (Q)` — both fold the same NULL
+    // trap over row 4.
+    try rowfixture().expect(
+        "SELECT Id FROM T2 WHERE (A, B) <> ALL "
+        + "(SELECT X, Y FROM P WHERE Flag = 1)",
+        equals:
+        "SELECT Id FROM T2 WHERE (A, B) NOT IN "
+        + "(SELECT X, Y FROM P WHERE Flag = 1)")
+  }
+
+  @Test func `< ALL compares rows lexicographically`() throws {
+    // P = {(10, 100), (20, 200)}; `< ALL` is strictly below the lexicographic
+    // minimum (10, 100). Only row 6 (5, 50) qualifies; row 1 (10, 100) is not
+    // strictly below itself, and row 4's NULL leaves it UNKNOWN.
+    try rowfixture().expect(
+        "SELECT Id FROM T2 WHERE (A, B) < ALL "
+        + "(SELECT X, Y FROM P WHERE Flag = 1)",
+        yields: [[6]])
+  }
+
+  @Test func `> ANY compares rows lexicographically`() throws {
+    // `> ANY` is strictly above at least one row — above the minimum (10, 100).
+    // Rows 2, 3, 5 qualify; row 1 equals the minimum, row 6 is below it, and
+    // row 4's NULL leaves both comparisons UNKNOWN.
+    try rowfixture().expect(
+        "SELECT Id FROM T2 WHERE (A, B) > ANY "
+        + "(SELECT X, Y FROM P WHERE Flag = 1)",
+        yields: [[2], [3], [5]])
+  }
+
+  @Test func `ANY over an empty subquery is FALSE`() throws {
+    // The fold's identity: `ANY` over no rows has no witness — FALSE for every
+    // outer row.
+    try rowfixture().empty(
+        "SELECT Id FROM T2 WHERE (A, B) = ANY "
+        + "(SELECT X, Y FROM P WHERE Flag = 9)")
+  }
+
+  @Test func `ALL over an empty subquery is TRUE`() throws {
+    // The fold's identity: `ALL` over no rows is vacuously TRUE for every outer
+    // row, including row 4 whose A is NULL (no candidate row is evaluated).
+    try rowfixture().expect(
+        "SELECT Id FROM T2 WHERE (A, B) <> ALL "
+        + "(SELECT X, Y FROM P WHERE Flag = 9)",
+        yields: [[1], [2], [3], [4], [5], [6]])
+  }
+}
+
+// MARK: - Arity
+
+struct RowSubqueryArityTests {
+  @Test func `a row IN over a mis-arity subquery faults`() throws {
+    // The row's degree (2) must equal the subquery's result degree; a one-column
+    // subquery is `SQLError.arity`, checked from the compiled width, so it
+    // faults even though P has rows.
+    try rowfixture().expect(
+        "SELECT Id FROM T2 WHERE (A, B) IN (SELECT X FROM P)",
+        fails: .arity(2, 1))
+  }
+
+  @Test func `a row quantified mis-arity subquery faults`() throws {
+    try rowfixture().expect(
+        "SELECT Id FROM T2 WHERE (A, B) = ANY (SELECT X FROM P)",
+        fails: .arity(2, 1))
+  }
+
+  @Test func `a row IN mis-arity subquery faults the schema check too`()
+      throws {
+    // The schema path enforces the same row-arity-equals-width rule as the run,
+    // so validation matches execution (run ≡ columns(of:)).
+    let query = try parse(query:
+        "SELECT Id FROM T2 WHERE (A, B) IN (SELECT X FROM P)")
+    let resolve = { () throws -> Array<OutputColumn> in
+      try rowfixture().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.arity(2, 1)) {
+      try resolve()
+    }
+  }
+}
+
+// MARK: - Type checking (run ≡ validate)
+
+struct RowSubqueryTypeCheckingTests {
+  @Test func `columns validates a row IN over a subquery`() throws {
+    let query = try parse(query:
+        "SELECT Id FROM T2 WHERE (A, B) IN (SELECT X, Y FROM P)")
+    let columns = try rowfixture().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+  }
+
+  @Test func `columns validates a row quantified subquery`() throws {
+    let query = try parse(query:
+        "SELECT Id FROM T2 WHERE (A, B) >= ALL (SELECT X, Y FROM P)")
+    let columns = try rowfixture().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+  }
+
+  @Test func `a bad inner column faults the schema check`() throws {
+    // The inner query is type-checked too, so an unknown column inside it faults
+    // validation exactly as a run would reject it.
+    let query = try parse(query:
+        "SELECT Id FROM T2 WHERE (A, B) IN (SELECT X, Missing FROM P)")
+    let resolve = { () throws -> Array<OutputColumn> in
+      try rowfixture().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.column("Missing")) {
+      try resolve()
+    }
+  }
+
+  @Test func `an irreconcilable UNION subquery faults`() throws {
+    // The subquery's own set-operation type fold reuses the existing machinery:
+    // the second column pairs an integer (P.Y) with a text (R2.Name), which the
+    // UNION arms cannot unify — `SQLError.operand` (SQLSTATE 42804) — faulting
+    // the row IN at run.
+    try rowfixture().expect(
+        "SELECT Id FROM T2 WHERE (A, B) IN "
+        + "(SELECT X, Y FROM P UNION SELECT Id2, Name FROM R2)",
+        fails: .operand("UNION arms have irreconcilable types"))
+  }
+
+  @Test func `an irreconcilable UNION subquery faults the schema check too`()
+      throws {
+    // The same irreconcilable UNION faults validation, so run ≡ columns(of:).
+    let query = try parse(query:
+        "SELECT Id FROM T2 WHERE (A, B) IN "
+        + "(SELECT X, Y FROM P UNION SELECT Id2, Name FROM R2)")
+    let resolve = { () throws -> Array<OutputColumn> in
+      try rowfixture().columns(of: query, validate: true)
+    }
+    #expect(throws: SQLError.operand("UNION arms have irreconcilable types")) {
+      try resolve()
+    }
+  }
+}

--- a/Tests/SQLTests/Queries/SubqueryTests.swift
+++ b/Tests/SQLTests/Queries/SubqueryTests.swift
@@ -42,14 +42,14 @@ struct SubqueryParsingTests {
     let select =
         try parse(select: "SELECT Id FROM T WHERE K IN (SELECT V FROM S)")
     let inner = try parse(query: "SELECT V FROM S")
-    #expect(select.predicate == .within(.column("K"), inner, negated: false))
+    #expect(select.predicate == .within([.column("K")], inner, negated: false))
   }
 
   @Test func `parses NOT IN over a subquery`() throws {
     let select =
         try parse(select: "SELECT Id FROM T WHERE K NOT IN (SELECT V FROM S)")
     let inner = try parse(query: "SELECT V FROM S")
-    #expect(select.predicate == .within(.column("K"), inner, negated: true))
+    #expect(select.predicate == .within([.column("K")], inner, negated: true))
   }
 
   @Test func `IN over a value list still parses as membership`() throws {
@@ -66,7 +66,7 @@ struct SubqueryParsingTests {
     let text = "SELECT Id FROM T WHERE K IN (SELECT V FROM S WHERE Flag = 1)"
     let select = try parse(select: text)
     let inner = try parse(query: "SELECT V FROM S WHERE Flag = 1")
-    #expect(select.predicate == .within(.column("K"), inner, negated: false))
+    #expect(select.predicate == .within([.column("K")], inner, negated: false))
   }
 
   @Test func `parses EXISTS over a UNION subquery`() throws {


### PR DESCRIPTION
Admit a row-valued left in the subquery predicates: `(a, b) [NOT] IN (SELECT x, y …)` and `(a, b) op {ANY | SOME | ALL} (SELECT x, y …)`, the ISO 9075 row forms alongside the existing scalar `x IN (Q)` / `x op ANY (Q)` and the row-vs-list `(a, b) IN ((1, 2), …)`.

Generalise `Predicate.within` and `Predicate.quantified` to carry an `Array<Expression>` left rather than a single `Expression`, so a scalar is just the one-element row — no parallel row cases, and every lowering/derivation seam folds over the components. The parser's row path recognises a `[NOT] IN (subquery)` / `op quantifier (subquery)` tail after a `(a, b)` row left, telling a subquery from a value list by the same `SELECT`/`TABLE`/`VALUES` lookahead the scalar membership uses.

Semantics are the ISO three-valued row rules: row equality is the component-wise Kleene AND, `IN` the Kleene OR-fold of row-equality over the subquery's rows, `NOT IN` its negation (so a NULL-bearing candidate with no match is UNKNOWN, not TRUE — the NULL trap); `ANY`/`ALL` OR/AND-fold `(row) op (row)` with `<`/`>` lexicographic and the empty-subquery identities (ANY → FALSE, ALL → TRUE). The row degree must equal the subquery's output width (`SQLError.arity`) and the components type-unify pairwise, both enforced on the run and the schema (`columns(of:)`) paths alike.