### PR TITLE
SQLEngine: fault incomparable-type comparisons (ISO 42804)

### DIFF
--- a/Sources/SQLEngine/Carrier.swift
+++ b/Sources/SQLEngine/Carrier.swift
@@ -366,39 +366,110 @@ extension Catalog where Self: ~Escapable {
       // path compiles leniently (`validate: false`), so this never double-
       // faults there — the run surfaces the fault at execution as it did
       // before.
+      // A carrier sort key may nest a predicate or scalar subquery (`ORDER BY
+      // CASE WHEN EXISTS (…) …`). Both the validate and the comparability pass
+      // reach a scalar one through the `.subquery` case, which records it only
+      // when it is a `deferred` (scalar-position) query, so seed `deferred`
+      // with the sort keys' scalar subqueries; an `EXISTS`/`IN`/quantified
+      // reach records unconditionally. Each nested subquery's width and single-
+      // column type derive against the same setop-output `scope` the run
+      // resolves it through, nested under the outer (`nested`): a carrier ORDER
+      // BY subquery may reference a set-operation output column — an aliased
+      // output living solely in this scope, unseen by `context.outer` — so it
+      // resolves at validate exactly as it does at run.
+      let nested = (context.outer ?? Outer()).nested(under: scope)
+      var scalars = Set<Query>()
+      for key in order.keys {
+        if case let .expression(expression) = key.sort {
+          expression.collect(scalar: &scalars)
+        }
+      }
       if context.validate {
-        // A carrier ORDER BY key may nest an `EXISTS`/`IN`/scalar subquery
-        // (`ORDER BY CASE WHEN EXISTS (…) …`), which the `scope.validate`
-        // type-check below rejects under the DEFAULT `.unsupported`
-        // `SubqueryCheck`. Record each nested subquery's width and type — the
-        // same cursor-free pre-pass `subqueryCheck(of:)` runs for a plain
-        // SELECT's ORDER BY subqueries — so the type-check validates a subquery
-        // sort key rather than faulting `.unsupported`, keeping the schema path
-        // in step with the run (which resolves the same key through
-        // `resolution` above).
-        //
-        // Derive each subquery's width/type against the same setop-output
-        // `scope` the run resolves it through (`subquery(_:_:_:within: scope)`
-        // above): a carrier ORDER BY subquery may reference a set-operation
-        // output column — an aliased output living ONLY in this scope, unseen
-        // by `context.outer` — so nesting `scope` under the outer, enclosing-
-        // scope shape `subquery(_:_:_:within:)` builds, resolves it at validate
-        // exactly as it does at run. Threading bare `context.outer` faulted
-        // `.column` on a set-op output column a run resolves, rejecting a query
-        // that executes. A genuinely-unresolvable column (not a set-op output,
-        // absent from the outer) still faults here as it does at run.
-        let nested = (context.outer ?? Outer()).nested(under: scope)
+        // Record each nested subquery's width and type — the same cursor-free
+        // pre-pass `subqueryCheck(of:)` runs for a plain SELECT's ORDER BY
+        // subqueries — so the `scope.validate` type-check validates a subquery
+        // sort key rather than faulting `.unsupported`, keeping the schema
+        // path in step with the run (which resolves the same key through the
+        // `resolution` above). A genuinely-unresolvable column (not a set-op
+        // output, absent from the outer) still faults here as it does at run.
         var widths = Dictionary<Query, Int>()
         var types = Dictionary<Query, ValueType>()
         for query in subqueries {
           try self.width(query, [], context, nested, &widths, &types)
         }
-        let check = SubqueryCheck(widths, types).barred
+        let check = SubqueryCheck(widths, types, deferred: scalars).barred
         for key in rewritten.keys {
           guard case let .expression(expression) = key.sort else { continue }
           try scope.aggregates(in: expression, context.routines,
                                subquery: check)
           _ = try scope.validate(expression, context.routines, subquery: check)
+        }
+        // Type-check each reached subquery body in the carrier's nested
+        // validate scope, exactly as the plain-select validate walk does — so
+        // a carrier ORDER BY subquery whose uncorrelated body a run never
+        // materialises over an empty carrier is still type-checked, and a
+        // static incomparable comparison inside it (`EXISTS (… WHERE a.num =
+        // a.txt)`) faults 42804 here as on the plain-select equivalent. An
+        // unreached body (a short-circuited leg's subquery) was never recorded,
+        // so it is not recursed. The set-operation operand-compatibility fold
+        // the shape pre-pass deferred is re-folded strictly for a scalar/valued
+        // reach.
+        let inner = context.revealed().with(outer: nested)
+        for reach in check.visited {
+          try typecheck(shape(of: reach), inner)
+          switch reach.role {
+          case .scalar, .valued:
+            _ = try columns(unifying: reach.query, inner)
+          case .existential, .lateral:
+            break
+          }
+        }
+      } else if context.comparability {
+        // The run's comparability walk over the carrier's `ORDER BY`: hand each
+        // sort-key expression to the finder alone, so a cross-kind comparison
+        // in a key (`ORDER BY NULLIF(num, txt)`) faults 42804 while an
+        // arithmetic key (`ORDER BY txt + 1`) does not — the run never
+        // re-validates the carrier's operands. The subquery widths derive
+        // best-effort (a structural fault defers, matching the finder's own
+        // discipline) so a subquery sort key resolves rather than faulting
+        // `.unsupported`.
+        var widths = Dictionary<Query, Int>()
+        var types = Dictionary<Query, ValueType>()
+        for query in subqueries {
+          do {
+            try self.width(query, [], context, nested, &widths, &types)
+          } catch let error {
+            guard case let .state(code, _) = error,
+                code == "42804" else { continue }
+            throw error
+          }
+        }
+        let check = SubqueryCheck(widths, types, deferred: scalars).barred
+        for key in rewritten.keys {
+          guard case let .expression(expression) = key.sort else { continue }
+          try scope.comparisons(in: expression, context.routines,
+                                subquery: check)
+        }
+        // Recurse the finder into each reached predicate or scalar subquery
+        // body (`comparing()`) — the run counterpart of the validate recursion
+        // above, matching `comparability(of select:)`. An uncorrelated body a
+        // run never materialises over an empty carrier is still comparability-
+        // checked, so a cross-kind comparison inside it faults 42804 on the run
+        // as on validate. Recurse under the carrier's nested comparing scope —
+        // the sort-key subqueries correlate against the setop-output `scope`
+        // beneath the outer, the same `nested` the width pre-pass used —
+        // rethrowing only 42804 and deferring any other fault, the finder's own
+        // discipline.
+        let inner = context.revealed().with(outer: nested).comparing()
+        for reach in check.visited {
+          do {
+            try typecheck(shape(of: reach), inner)
+          } catch let error {
+            guard case let .state(code, _) = error, code == "42804" else {
+              continue
+            }
+            throw error
+          }
         }
       }
     }

--- a/Sources/SQLEngine/Context.swift
+++ b/Sources/SQLEngine/Context.swift
@@ -92,6 +92,21 @@ internal struct Context {
   /// operand fold alone.
   internal let shape: Bool
 
+  /// Whether the query being resolved is walked for comparability alone — the
+  /// run-path check that faults a statically-typed incomparable comparison
+  /// (`SQLSTATE` 42804) at compile, so the optimiser never receives a throwing
+  /// comparison to hash, reorder, or drop. Set only by `comparing()`, at the
+  /// run's post-compile comparability walk (`typecheck` in this mode), it runs
+  /// exactly the `comparable`/`character` operand checks the validate walk runs
+  /// while deferring every other operand fault to execution (an ill-typed
+  /// arithmetic operand, an unknown routine) — so a run is not rejected for a
+  /// non-comparability operand a data-dependent filter never reaches, matching
+  /// the run's lenient posture. Distinct from `validate` (a run preflight keeps
+  /// it `false`): the comparability determination is a static data-type rule
+  /// the run must honour regardless of table cardinality, so it fires even over
+  /// an empty input the run would otherwise return empty for.
+  internal let comparability: Bool
+
   /// A context over the maps and resolution scope — an empty overlay, no
   /// bindings, an empty visited guard, eager validation, the caller scope, and
   /// no enclosing correlation by default: the shape a bare top-level query with
@@ -102,7 +117,8 @@ internal struct Context {
                 subqueries: Subqueries = Subqueries(),
                 visited: Set<String> = [], validate: Bool = true,
                 subscope: Subscope = .caller, outer: Outer? = nil,
-                lateral: Bool = false, shape: Bool = false) {
+                lateral: Bool = false, shape: Bool = false,
+                comparability: Bool = false) {
     self.relations = relations
     self.routines = routines
     self.bindings = bindings
@@ -113,6 +129,7 @@ internal struct Context {
     self.outer = outer
     self.lateral = lateral
     self.shape = shape
+    self.comparability = comparability
   }
 
   /// A copy of this context with `relations` replacing the overlay, the same
@@ -122,7 +139,8 @@ internal struct Context {
   internal func scoping(_ relations: ScopedRelations) -> Context {
     Context(relations: relations, routines: routines, bindings: bindings,
             subqueries: subqueries, visited: visited, validate: validate,
-            subscope: subscope, outer: outer, lateral: lateral, shape: shape)
+            subscope: subscope, outer: outer, lateral: lateral, shape: shape,
+            comparability: comparability)
   }
 
   /// A copy of this context entering a fresh body scope over `relations` — the
@@ -158,7 +176,8 @@ internal struct Context {
   internal func binding(_ bindings: Bindings) -> Context {
     Context(relations: relations, routines: routines, bindings: bindings,
             subqueries: subqueries, visited: visited, validate: validate,
-            subscope: subscope, outer: outer, lateral: lateral, shape: shape)
+            subscope: subscope, outer: outer, lateral: lateral, shape: shape,
+            comparability: comparability)
   }
 
   /// A copy of this context carrying `subqueries` as the executing plan's
@@ -168,7 +187,8 @@ internal struct Context {
   internal func resolving(_ subqueries: Subqueries) -> Context {
     Context(relations: relations, routines: routines, bindings: bindings,
             subqueries: subqueries, visited: visited, validate: validate,
-            subscope: subscope, outer: outer, lateral: lateral, shape: shape)
+            subscope: subscope, outer: outer, lateral: lateral, shape: shape,
+            comparability: comparability)
   }
 
   /// A copy of this context with every enclosing SELECT's derived-table aliases
@@ -202,7 +222,8 @@ internal struct Context {
     return Context(relations: relations, routines: routines,
                    bindings: bindings, subqueries: subqueries,
                    visited: visited, validate: validate, subscope: subscope,
-                   outer: outer, lateral: lateral, shape: shape)
+                   outer: outer, lateral: lateral, shape: shape,
+                   comparability: comparability)
   }
 
   /// A copy of this context with the eager-typecheck gate set to `flag` — a run
@@ -211,7 +232,8 @@ internal struct Context {
   internal func validating(_ flag: Bool) -> Context {
     Context(relations: relations, routines: routines, bindings: bindings,
             subqueries: subqueries, visited: visited, validate: flag,
-            subscope: subscope, outer: outer, lateral: lateral, shape: shape)
+            subscope: subscope, outer: outer, lateral: lateral, shape: shape,
+            comparability: comparability)
   }
 
   /// A copy of this context marking the query it resolves as a nested-subquery
@@ -223,7 +245,21 @@ internal struct Context {
   internal func shaping() -> Context {
     Context(relations: relations, routines: routines, bindings: bindings,
             subqueries: subqueries, visited: visited, validate: validate,
-            subscope: subscope, outer: outer, lateral: lateral, shape: true)
+            subscope: subscope, outer: outer, lateral: lateral, shape: true,
+            comparability: comparability)
+  }
+
+  /// A copy of this context marking the query it resolves as the run's
+  /// comparability walk (`comparability`) — the post-compile pass that faults a
+  /// statically-typed incomparable comparison at compile so the optimiser never
+  /// hashes, reorders, or drops a comparison that would throw. Every other
+  /// field is preserved; the walk runs schema-only (`validate` stays as set —
+  /// the run keeps it `false`) and touches no cursor.
+  internal func comparing() -> Context {
+    Context(relations: relations, routines: routines, bindings: bindings,
+            subqueries: subqueries, visited: visited, validate: validate,
+            subscope: subscope, outer: outer, lateral: lateral, shape: shape,
+            comparability: true)
   }
 
   /// A copy of this context resolving its nested subqueries under `subscope` —
@@ -232,7 +268,8 @@ internal struct Context {
   internal func scoped(as subscope: Subscope) -> Context {
     Context(relations: relations, routines: routines, bindings: bindings,
             subqueries: subqueries, visited: visited, validate: validate,
-            subscope: subscope, outer: outer, lateral: lateral, shape: shape)
+            subscope: subscope, outer: outer, lateral: lateral, shape: shape,
+            comparability: comparability)
   }
 
   /// A copy of this context whose enclosing correlation stack is extended with
@@ -250,7 +287,8 @@ internal struct Context {
   internal func with(outer: Outer?) -> Context {
     Context(relations: relations, routines: routines, bindings: bindings,
             subqueries: subqueries, visited: visited, validate: validate,
-            subscope: subscope, outer: outer, lateral: lateral, shape: shape)
+            subscope: subscope, outer: outer, lateral: lateral, shape: shape,
+            comparability: comparability)
   }
 
   /// A copy of this context marking the query it resolves as a LATERAL derived
@@ -263,7 +301,8 @@ internal struct Context {
   internal func lateralizing() -> Context {
     Context(relations: relations, routines: routines, bindings: bindings,
             subqueries: subqueries, visited: visited, validate: validate,
-            subscope: subscope, outer: outer, lateral: true, shape: shape)
+            subscope: subscope, outer: outer, lateral: true, shape: shape,
+            comparability: comparability)
   }
 
   /// A copy of this context with the enclosing correlation stack cleared — the
@@ -289,6 +328,7 @@ internal struct Context {
   internal func unlateralized() -> Context {
     Context(relations: relations, routines: routines, bindings: bindings,
             subqueries: subqueries, visited: visited, validate: validate,
-            subscope: subscope, outer: outer, lateral: false, shape: shape)
+            subscope: subscope, outer: outer, lateral: false, shape: shape,
+            comparability: comparability)
   }
 }

--- a/Sources/SQLEngine/Definition.swift
+++ b/Sources/SQLEngine/Definition.swift
@@ -459,6 +459,15 @@ extension Catalog where Self: ~Escapable {
       if context.validate {
         _ = try compile(query, context.validating(true))
         try typecheck(query, context)
+      } else if context.comparability {
+        // The run's comparability walk: a derived body's own reachable
+        // comparisons are comparability-checked (`typecheck` in this mode)
+        // exactly as the top-level query's, so a cross-kind comparison in a
+        // body a constant-false outer fold drops — or one over an empty input
+        // materialise runs to no rows — faults at compile rather than silently
+        // returning nothing. It stays lenient (`validate: false`), so a
+        // data-dependent operand a body filter drops is still not rejected.
+        try typecheck(query, context)
       }
       captured = []
     }

--- a/Sources/SQLEngine/Engine.swift
+++ b/Sources/SQLEngine/Engine.swift
@@ -84,6 +84,13 @@ extension Catalog where Self: ~Escapable {
       // filter never reaches (execution faults only on a reached operand),
       // matching the non-derived path.
       _ = try compile(query, context.validating(false))
+      // Fault a statically-typed incomparable comparison at compile — in either
+      // arm — so the run agrees with the validate walk regardless of arm
+      // cardinality, and the optimiser never hashes, reorders, or drops a
+      // comparison that would throw at run. It runs only the comparability
+      // portion of the type-check (`Scope.comparability`), leaving every other
+      // operand fault to the arms' execution.
+      try typecheck(query, context.validating(false).comparing())
       // The result column types are unified across the arms (ISO), so coerce
       // each arm's values to them — `SELECT 1 UNION SELECT 2.5` emits a
       // `double` column. The fold reads the arm queries in hand here; the
@@ -124,6 +131,22 @@ extension Catalog where Self: ~Escapable {
     // type-check stays for the explicit schema path (`columns` `validate:
     // true`).
     let logical = try compile(query, context.validating(false)).pushdown()
+    // The compile proved the query runnable but deferred every operand fault to
+    // execution (`validate: false`), including the ISO comparability rule — a
+    // number against a string is a data-type mismatch, not a FALSE row. The run
+    // enforces that rule per reachable row through `matches`, but a comparison
+    // the optimiser hashes into disjoint buckets, pushes below an empty
+    // product, or drops with a constant-false fold is never evaluated, so its
+    // fault would silently vanish; and a comparison over an empty input is
+    // never reached at all. Walk the query now for the comparability rule alone
+    // — reachability-, NULL-, and subquery-aware, so a short-circuited leg or a
+    // NULL/subquery operand still defers — so a statically-typed cross-kind
+    // comparison faults at compile regardless of cardinality, before the
+    // optimiser (or an empty scan) can hide it, while every other operand fault
+    // stays deferred to execution. Its derived-table bodies and set-operation
+    // arms are walked through the same gate the `augment` and `typecheck`
+    // recursion carry.
+    try typecheck(query, context.validating(false).comparing())
     // Now that `compile` proved the query runnable, extend the overlay with any
     // `definition_schema.` store relation the query names (resolved lazily —
     // the overlay after the CTEs, before the base catalog) AND materialise this
@@ -818,6 +841,26 @@ extension Catalog where Self: ~Escapable {
     let scan = try compile(.select(Select(projection: .all,
                                           from: Relation(name: name))),
                            context)
+    // The fixpoint peels this carrier and runs it here under a normal (non-
+    // comparing) context, so — unlike the non-recursive run carrier the top-
+    // level `typecheck(_:comparing())` re-runs through `ordered` — its `ORDER
+    // BY` keys never reached the compile-time comparability walk: a cross-kind
+    // sort key (`ORDER BY NULLIF(n, 'x')`) over an empty fixpoint sorted no
+    // rows and returned empty rather than faulting 42804, while the schema
+    // path's `validate(carrier:)` faulted the same key — a run ≠ validate
+    // break. Preflight the carrier through the same `carried` resolver in
+    // `comparing()` mode before the materialised rows are ordered, so the
+    // finder (the carrier's `context.comparability` branch) faults a cross-kind
+    // key here as it does on the non-recursive run and the validate path. The
+    // plan is discarded — only the keys' fault matters; a fresh subquery box
+    // isolates the preflight's carrier-subquery cache from the real run below.
+    // The walk is comparability-only (`validate` stays `false`), so an
+    // arithmetic sort key (`ORDER BY n + 1`) still defers to the run — only a
+    // statically incomparable comparison faults.
+    _ = try carried(over: scan, output: columns, arm: arm,
+                    distinct: carrier.distinct, order: carrier.order,
+                    limit: carrier.limit, generated: carrier.generated,
+                    context.resolving(Subqueries()).comparing())
     let plan = try carried(over: scan, output: columns, arm: arm,
                            distinct: carrier.distinct, order: carrier.order,
                            limit: carrier.limit, generated: carrier.generated,

--- a/Sources/SQLEngine/Schema+Derivation.swift
+++ b/Sources/SQLEngine/Schema+Derivation.swift
@@ -594,8 +594,15 @@ extension Catalog where Self: ~Escapable {
     // The type-check subtree resolves its scopes strictly (`validate: true`),
     // as its internal `scope`/`prefixes`/`schema` calls always did — force it
     // on regardless of the incoming context's gate (a caller reaches here only
-    // when validating).
-    let context = try augment(context.validating(true), for: query, rows: false)
+    // when validating). The comparability walk is the exception: it runs on the
+    // run path, where a derived body resolves lenient (`validate: false`) so
+    // a data-dependent operand a filter drops is not rejected, yet its own
+    // reachable comparisons are still comparability-checked — so keep the gate
+    // off there while `augment` carries `comparability` into each derived
+    // body's resolve (`materialise`), which runs this same walk over it.
+    let context = try augment(
+        context.validating(context.comparability ? false : true),
+        for: query, rows: false)
     // A carrier's row operators add no expression the arms carry — the body
     // type-checks every reachable operand of its own arms.
     switch query.body {
@@ -607,29 +614,28 @@ extension Catalog where Self: ~Escapable {
       try typecheck(left, context)
       try typecheck(right, context)
     }
-    // Each carrier's own `ORDER BY` keys are a new expression surface,
-    // validated ONLY by the carrier compile (`ordered(…)` under `validate`). A
-    // reached scalar/`IN` subquery whose body is an ordered set operation is
-    // first compiled in the shape pre-pass with `validating(false)`, which
-    // bypasses that check, and is re-validated through this seam — so unless
-    // the carrier's keys are validated here too, an outer `columns(of:)`
-    // accepts a reached `(… UNION … ORDER BY missing(a))` a run faults (a
-    // run-vs-validate divergence). Re-run each carrier compile in validate mode
-    // over the query up to (not including) that carrier — the same inner it
-    // stacks over — to validate its sort keys against the body-output scope
-    // exactly as `ordered(…)` does — the plan is discarded, only the keys'
-    // fault matters. It is idempotent with the top-level `compile` (which
-    // already validated the same keys), and reached-only: an unreached ordered
-    // subquery never enters this seam, so its bad sort key stays deferred,
-    // matching the dead-scalar/dead-EXISTS posture. The augment above depends
-    // only on the body (carriers collect no derived table), so it is the scope
-    // each carrier resolves over.
+    // Each carrier's own `ORDER BY` keys are a new expression surface, handled
+    // only by the carrier compile (`ordered(…)`). A reached scalar/`IN`
+    // subquery whose body is an ordered set operation is first compiled in the
+    // shape pre-pass with `validating(false)`, which bypasses that surface, and
+    // is re-checked through this seam — so unless the carrier's keys are
+    // checked here too, an outer `columns(of:)` accepts a reached `(… UNION …
+    // ORDER BY missing(a))` a run faults (a run-vs-validate divergence). Re-run
+    // each carrier compile over the query up to (not including) that carrier —
+    // the same inner it stacks over — carrying this context's mode: a validate
+    // `columns(of:)` type-checks the sort keys' operands, while the run's
+    // comparability walk (this `context.comparability`) hands them to the
+    // finder alone, so a carrier `ORDER BY <cross-kind key>` faults 42804 while
+    // `ORDER BY <arithmetic>` does not. The plan is discarded, only the keys'
+    // fault matters; it is idempotent with the top-level `compile`, and
+    // reached-only. The augment above depends only on the body (carriers
+    // collect no derived table), so it is the scope each carrier resolves over.
     for (index, carrier) in query.carriers.enumerated() {
       let inner = Query(body: query.body,
                         carriers: Array(query.carriers.prefix(index)))
       _ = try ordered(inner, distinct: carrier.distinct, order: carrier.order,
                       limit: carrier.limit, generated: carrier.generated,
-                      context.validating(true))
+                      context)
     }
   }
 
@@ -841,7 +847,7 @@ extension Catalog where Self: ~Escapable {
   /// an unreached arm has it as a scalar. A query the probe does not rewrite (a
   /// `HAVING` or set operation) runs in FULL, so its original is checked even
   /// for an `existential` reach.
-  private borrowing func shape(of reach: Reach) -> Query {
+  internal borrowing func shape(of reach: Reach) -> Query {
     // The validate side of the EXISTS cardinality probe: an `existential` reach
     // checks the same probed shape the run compiles, so delegate to the single
     // `probed(_:)` source of truth (which peels an `ordered` carrier over a
@@ -853,6 +859,20 @@ extension Catalog where Self: ~Escapable {
 
   private borrowing func typecheck(_ select: Select, _ context: Context)
       throws(SQLError) {
+    // The run's comparability walk visits every reachable comparison surface of
+    // this select for the ISO comparability rule — its WHERE, join `ON`s,
+    // HAVING, projection, `GROUP BY` and `ORDER BY` keys, aggregate `FILTER`s,
+    // and the body of every reached predicate or scalar subquery — and leaves
+    // every other validate-only concern to the strict schema path. Its FROM's
+    // derived-table bodies are walked by the `augment` that resolved them
+    // (`materialise` recurses this same walk under the carried `comparability`
+    // gate), and its set-operation arms by the `typecheck(_ query:)` above, so
+    // a cross-kind comparison anywhere in the query faults at compile without
+    // the full walk's operand type-check.
+    if context.comparability {
+      try comparability(of: select, context)
+      return
+    }
     // This select's own resolution scope — the one its nested subqueries
     // correlate against (`nil` for a FROM-less select, which adds no relations
     // and correlates through `outer` unchanged). Built from the unrevealed
@@ -936,6 +956,300 @@ extension Catalog where Self: ~Escapable {
       for reach in on.visited {
         try typecheck(shape(of: reach), revealed.with(outer: scope))
       }
+    }
+  }
+
+  /// The comparison-finder over a single arm — the comparability-only
+  /// counterpart of `typecheck(_ select:)`, faulting a statically-typed
+  /// incomparable comparison (`42804`) anywhere the arm reaches one: its WHERE,
+  /// join `ON`s, HAVING, projection, `GROUP BY` keys, `ORDER BY` sort keys,
+  /// aggregate `FILTER`s, and the body of every reached predicate or scalar
+  /// subquery. So the run agrees with the validate walk regardless of table
+  /// cardinality, and the optimiser never receives a comparison that would
+  /// throw at run to hash into disjoint buckets, push below an empty product,
+  /// or drop with a constant-false fold.
+  ///
+  /// It builds the same scopes the validate `typecheck(_ select:)` builds — the
+  /// same `scope`/`prefixes`/`subqueryCheck` pre-pass, so the reachable
+  /// comparison surfaces and the reached-subquery set match — then hands
+  /// each surface to the dedicated finder (`Scope.comparisons(in:)`), which
+  /// looks only for comparison-bearing constructs and defers each one's own
+  /// resolution fault locally. Unlike the retired walk-reuse, the finder never
+  /// runs full type validation, so it cannot abort on a non-comparability fault
+  /// and skip a later reachable incomparable comparison — the leak class
+  /// (a `COALESCE` argument's arithmetic error hiding a sibling `NULLIF`'s
+  /// cross-kind equality) is closed by construction. Only a `42804` escapes; a
+  /// subquery-operand-typed placeholder, a NULL comparison, an `IS DISTINCT
+  /// FROM`, a `:parameter` operand, and an unreachable short-circuited leg each
+  /// defer, since the leaf check (`comparable`/`character`) deciding them is
+  /// the validate path's own.
+  ///
+  /// A reached subquery body recurses through this same finder (`comparing()`),
+  /// so an `EXISTS`/`IN (Q)`/quantified or scalar subquery whose uncorrelated
+  /// body a run never materialises over an empty outer — its per-row `matches`
+  /// never firing — is still comparability-checked. A correlated body's outer
+  /// column types against the enclosing scope carried here as the subquery's
+  /// `outer`, so a correlated cross-kind key faults here too; the `decorrelate`
+  /// gate stays the backstop for the residual a physical rewrite would bucket
+  /// apart.
+  private borrowing func comparability(of select: Select, _ context: Context)
+      throws(SQLError) {
+    // Resolve the same scopes the validate `typecheck(_ select:)` builds. A
+    // resolution fault here is one the preceding `compile` already surfaced, so
+    // it does not re-raise on this post-compile walk (only a 42804 escapes); it
+    // does abandon this select's walk, there being nothing left to resolve
+    // against.
+    let scope: Scope
+    let enclosing: Scope?
+    let prefixes: Array<Scope>
+    let subquery: SubqueryCheck
+    do {
+      scope = try self.scope(of: select, context)
+      enclosing = select.from == nil ? nil : scope
+      prefixes = try self.prefixes(of: select, context)
+      subquery = try subqueryCheck(of: select, context, enclosing: enclosing,
+                                   prefixes: prefixes)
+    } catch let error {
+      guard case let .state(code, _) = error, code == "42804" else { return }
+      throw error
+    }
+    // A stored VIEW this select names in its FROM or a JOIN is executed on the
+    // run path as an already-compiled plan (`validate: false`), so its body's
+    // comparisons were never comparability-checked and this outer walk treats
+    // the view as an opaque relation. Descend the finder into each reached
+    // view's body — the same recursion a derived-table body gets through
+    // `augment`/`materialise`.
+    try comparability(ofViewsIn: select, context)
+    // Find every reachable comparison in this arm's own surfaces (WHERE,
+    // HAVING, projection, GROUP BY, ORDER BY, aggregate FILTERs),
+    // reachability-aware, recording each reached predicate/scalar subquery into
+    // `subquery` for the recursion below.
+    try find(comparisonsOf: select, scope, context, subquery: subquery)
+    // Recurse the finder into each reached predicate or scalar subquery body
+    // (`comparing()`). An unreached body (a short-circuited leg's subquery) was
+    // never recorded, so it is not recursed, matching the run. Each reach is
+    // handled on its own, so a deferred fault in one body never hides a later
+    // body's incomparable comparison.
+    let revealed = context.revealed()
+    let base = context.outer ?? Outer()
+    let nested = enclosing.map { base.nested(under: $0) } ?? context.outer
+    let inner = revealed.with(outer: nested).comparing()
+    for reach in subquery.visited {
+      do {
+        try typecheck(shape(of: reach), inner)
+      } catch let error {
+        guard case let .state(code, _) = error, code == "42804" else {
+          continue
+        }
+        throw error
+      }
+    }
+    // Each join `ON` is a comparison surface, scoped to the join's prefix — a
+    // cross-kind `ON L.n = R.s` key faults here rather than hashing the two
+    // sides into disjoint buckets — and its reached subqueries recurse the same
+    // way, correlated against that prefix.
+    for index in select.joins.indices where index < prefixes.count {
+      let prefix = prefixes[index]
+      let outer = (context.outer ?? Outer()).nested(under: prefix)
+      let on = subquery.scoped(context.outer)
+      try prefix.comparisons(in: select.joins[index].on, context.routines,
+                             subquery: on)
+      for reach in on.visited {
+        do {
+          try typecheck(shape(of: reach),
+                        revealed.with(outer: outer).comparing())
+        } catch let error {
+          guard case let .state(code, _) = error, code == "42804" else {
+            continue
+          }
+          throw error
+        }
+      }
+    }
+  }
+
+  /// Hands each of `select`'s own reachable comparison surfaces to the finder,
+  /// reachability-aware — the comparability counterpart of `walk`, mirroring
+  /// exactly the surfaces `walk` reaches, so the finder faults the reachable
+  /// static 42804 the validate path faults, and no others.
+  ///
+  /// The clauses run `WHERE` → group/fold → `HAVING` → limit → projection, so a
+  /// constant-false `WHERE` (or `HAVING`) prunes everything after it, a
+  /// whole-result aggregate emits one empty group whose HAVING/projection/sort
+  /// are value-folded (`fold`/`empty`, NULL-aware — an aggregate over the empty
+  /// group is NULL, so a comparison against it is UNKNOWN, not a fault), and a
+  /// row-dropping limit leaves the projection unreachable while the aggregate
+  /// folds (checked unconditionally, `aggregatesIn`) and the below-limit sort
+  /// still run.
+  private borrowing func find(comparisonsOf select: Select, _ scope: Scope,
+                              _ context: Context, subquery: SubqueryCheck)
+      throws(SQLError) {
+    let routines = context.routines
+    // The WHERE admits a correlated column of this query; the projection,
+    // `HAVING`, GROUP BY, and `ORDER BY` bar it (`barred`).
+    let barred = subquery.barred
+    if let predicate = select.predicate {
+      try scope.comparisons(in: predicate, routines, subquery: subquery)
+      // A false WHERE filters every row, so a GROUP BY forms no group and a
+      // non-aggregate query yields no row — nothing after is reachable. A
+      // whole-result aggregate still emits one empty group: the HAVING and
+      // projection run over it, value-folded.
+      if scope.constant(predicate, routines) == false {
+        if select.aggregates, select.grouping.expressions.isEmpty {
+          if let having = select.having, !having.subquery {
+            // A subquery-free HAVING over the empty group both surfaces its own
+            // cross-kind fault (`empty`, 42804) and decides the group's fate: a
+            // group passes only when it is TRUE, so FALSE/UNKNOWN drops it and
+            // the projection is unreachable. A non-comparability fault defers,
+            // keeping the projection reachable (the run's `or: true` posture).
+            var passes: Bool? = true
+            do {
+              passes = try scope.empty(having, routines)
+            } catch let error {
+              if case let .state(code, _) = error, code == "42804" {
+                throw error
+              }
+              passes = true
+            }
+            if passes != true { return }
+          }
+          // The lone empty group's projection is unreachable when a limit drops
+          // its one row (a zero FETCH or any positive OFFSET), unless DISTINCT.
+          var reachable = select.distinct
+          if !reachable { reachable = !drops(select.limit, single: true) }
+          if reachable, case let .expressions(items) = select.projection {
+            for item in items {
+              try fold(comparisonsIn: item.expression, scope, routines,
+                                subquery: barred)
+            }
+          }
+          // The sort sits below the limit, so its keys fold over the empty
+          // group unconditionally.
+          for expression in select.orderKeys {
+            try fold(comparisonsIn: expression, scope, routines,
+                        subquery: barred)
+          }
+        }
+        return
+      }
+    }
+    // Aggregate folds run before HAVING and any limit, so their operand and
+    // FILTER comparisons are reachable unconditionally — even under a
+    // row-dropping limit that leaves the surrounding projection unreachable.
+    if case let .expressions(items) = select.projection {
+      for item in items {
+        try scope.comparisons(aggregatesIn: item.expression, routines,
+                              subquery: barred)
+      }
+    }
+    for expression in select.orderKeys {
+      try scope.comparisons(aggregatesIn: expression, routines,
+                            subquery: barred)
+    }
+    // Each GROUP BY key is evaluated over the input rows to form the groups,
+    // before HAVING, projection, and any limit — so find its comparisons
+    // unconditionally in this reachable path.
+    for expression in select.grouping.expressions {
+      try scope.comparisons(in: expression, routines, subquery: barred)
+    }
+    if let having = select.having {
+      // A HAVING aggregate is collected and folded by the group node before the
+      // filter runs, so its operand and FILTER comparisons are reachable
+      // whatever the enclosing predicate's short-circuit — a `1 = 0 AND
+      // SUM(…)`/`1 = 1 OR SUM(…)` leg the reachability walk prunes still folds.
+      // Check them unconditionally, ahead of the reachability-aware scalar
+      // walk, exactly as the projection and sort aggregates above and as the
+      // validate walk's `aggregates(in:)` does.
+      try scope.comparisons(aggregatesIn: having, routines, subquery: barred)
+      try scope.comparisons(in: having, routines, subquery: barred)
+      // A false HAVING filters every group before the projection, so the
+      // projection's non-aggregate work is unreachable.
+      if scope.constant(having, routines) == false { return }
+    }
+    // The projection runs after any limit: a limit that drops every row it
+    // would yield leaves only its aggregate folds (checked above) reachable. A
+    // single-row result (a whole-result aggregate, or a FROM-less select) is
+    // dropped by a positive OFFSET too. DISTINCT is the exception (its plan
+    // evaluates the projection before the cap pages the deduplicated result).
+    let sole = select.from == nil
+        || (select.aggregates && select.grouping.expressions.isEmpty)
+    var reachable = select.distinct
+    if !reachable { reachable = !drops(select.limit, single: sole) }
+    if reachable, case let .expressions(items) = select.projection {
+      for item in items {
+        try scope.comparisons(in: item.expression, routines, subquery: barred)
+      }
+    }
+    // The sort sits below the limit, so every ORDER BY key runs over the input
+    // rows before the cap pages them — its comparisons are checked
+    // unconditionally.
+    for expression in select.orderKeys {
+      try scope.comparisons(in: expression, routines, subquery: barred)
+    }
+  }
+
+  /// Finds the reachable comparisons in a whole-result aggregate's projection
+  /// or sort `expression` over the single empty group a constant-false `WHERE`
+  /// leaves, through the empty-group fold (`fold`/`empty`) — value-based, so an
+  /// aggregate that folds to NULL/0 reads a comparison against it as UNKNOWN
+  /// rather than a static type fault, matching the run exactly. It faults 42804
+  /// on a cross-kind non-NULL pair the fold reaches; every other fault the fold
+  /// would raise is the run's to raise at execution, so it is deferred.
+  private borrowing func fold(comparisonsIn expression: Expression,
+                              _ scope: Scope, _ routines: Routines,
+                              subquery: SubqueryCheck)
+      throws(SQLError) {
+    do {
+      try scope.fold(expression, routines, subquery: subquery)
+    } catch let error {
+      guard case let .state(code, _) = error, code == "42804" else { return }
+      throw error
+    }
+  }
+
+  /// Descends the comparability walk into each stored VIEW `select` names in
+  /// its FROM or a JOIN. A named relation resolving through `resolve(view:)` to
+  /// a registered view is executed on the run path as an already-compiled plan
+  /// (compiled `validate: false`), so its body's comparisons were never
+  /// comparability-checked and the enclosing walk treats it as an opaque
+  /// relation — the same silent hole an empty derived-table body left before it
+  /// was walked. Recursing the walk into the view's body `Query` (`typecheck`
+  /// in `comparing()` mode) faults a cross-kind comparison in the body exactly
+  /// as the derived-table recursion does, and — the body resolving through this
+  /// same walk — transitively into a view whose body names another view, a
+  /// derived table, or a subquery.
+  ///
+  /// The body resolves over its own `definition_schema.` overlay with the
+  /// caller's correlation and CTEs cleared (`body([:])`), so a view means what
+  /// it was registered to mean, independent of its call site — the same scope
+  /// `schema(of:)` derives a view's types under. A CTE, a derived alias, or a
+  /// reserved store relation of the same name resolves ahead of a view (the
+  /// `schema(of:)` precedence), so it is not treated as one here; a cyclic view
+  /// already under resolution down this chain (`visited`) is not re-entered —
+  /// the recursion would not terminate, and the cycle itself faults
+  /// `.recursion` on the compile path ahead of this walk. Only a `42804`
+  /// escapes: every other body fault stays deferred to the view's own run,
+  /// matching the derived-table and subquery-body recursions.
+  private borrowing func comparability(ofViewsIn select: Select,
+                                       _ context: Context)
+      throws(SQLError) {
+    var relations = [select.from].compactMap { $0 }
+    relations.append(contentsOf: select.joins.map(\.relation))
+    for relation in relations {
+      guard case let .named(name) = relation.source else { continue }
+      let key = name.lowercased()
+      // A CTE or derived alias in scope, or a reserved store relation, resolves
+      // ahead of a view, so it is not a stored-view reference to descend into.
+      if context.relations[key] != nil { continue }
+      if Definition(name) != nil { continue }
+      guard let view = resolve(view: name) else { continue }
+      if context.visited.contains(key) { continue }
+      // Expand a `GROUP BY GROUPING SETS` body to its `UNION ALL` arms first —
+      // the same expansion the run and `schema(of:)` walk — then recurse the
+      // comparability walk over the view body under its own uncorrelated scope,
+      // the view marked visited so a nested self-reference terminates.
+      let body = try view.query.expanded
+      try typecheck(body, context.body([:]).visiting(name))
     }
   }
 
@@ -1114,6 +1428,7 @@ extension Catalog where Self: ~Escapable {
       _ = try scope.validate(expression, routines, subquery: barred)
     }
   }
+
 
   /// Resolves a grouped `select`'s `ORDER BY` through the same grouped lowering
   /// the compile path applies, so the type-check enforces the GROUP BY rules on

--- a/Sources/SQLEngine/Scope.swift
+++ b/Sources/SQLEngine/Scope.swift
@@ -1670,6 +1670,8 @@ internal struct Scope {
       // further check.
       try check(inner, routines, subquery: subquery)
     case let .and(lhs, rhs):
+      // A connective recurses reachability-aware — the `constant` short-circuit
+      // is the run's own, so an unreached operand is not checked.
       try check(lhs, routines, subquery: subquery)
       if constant(lhs, routines) != false {
         try check(rhs, routines, subquery: subquery)
@@ -3389,5 +3391,487 @@ internal struct Scope {
           try term(expression, routines, subquery: subquery)
         }, subquery: subquery)
     return stamped(filter) { type(at: $0) }
+  }
+}
+
+// MARK: - Comparability finder
+
+/// The comparison-finder: a dedicated traversal that faults a statically-typed
+/// incomparable comparison (ISO `SQLSTATE 42804`) anywhere a query reaches one,
+/// and cannot leak a non-comparability fault by construction.
+///
+/// Unlike the strict validator (`validate`/`check`), which resolves and
+/// type-checks every operand and aborts on the first fault of any kind, the
+/// finder walks a resolved predicate or expression looking only for
+/// comparison-bearing constructs. At each comparison it invokes the same leaf
+/// `comparable`/`character` check the validator uses, resolving the operand
+/// types through `validate` but deferring that resolution's own fault locally
+/// (`deferred`): an ill-typed arithmetic operand, an unknown routine, a bad
+/// arity — every fault the run defers to execution — is swallowed at the
+/// comparison it decorates, so the traversal continues to the sibling and later
+/// comparisons rather than aborting. Only a 42804 escapes. Because each
+/// comparison's own resolution fault is caught there, no expression
+/// (a `COALESCE` arg, a `NULLIF` operand, a `CASE` result) can hide a later
+/// sibling's incomparable comparison behind an earlier one's deferred fault —
+/// the leak the walk-reuse mechanism it replaces suffered at every recursive
+/// site.
+///
+/// The traversal is reachability-aware, reusing the same short-circuit and
+/// const-fold primitives the run evaluates with (`constant`, `selects`,
+/// `stable`, `matched`, `membership`, `dead`), so a comparison an unreachable
+/// `CASE`/`COALESCE` arm or a short-circuited `AND`/`OR` leg holds is never
+/// visited — the finder faults exactly the reachable static 42804 the strict
+/// validate path faults, and no others (`run ≡ validate`).
+extension Scope {
+  /// Runs `body`, deferring every fault but the ISO comparability fault
+  /// (`SQLSTATE 42804`): resolving a comparison operand's own type may raise a
+  /// fault the run defers to execution (an ill-typed arithmetic operand, an
+  /// unknown routine, a bad cast), so swallow it and let the search continue,
+  /// while a 42804 from the leaf check propagates. Applied at each comparison,
+  /// never around a whole expression, so a deferred fault never hides a later
+  /// reachable incomparable comparison.
+  private func deferred(_ body: () throws(SQLError) -> Void)
+      throws(SQLError) {
+    do {
+      try body()
+    } catch let error {
+      guard case let .state(code, _) = error, code == "42804" else { return }
+      throw error
+    }
+  }
+
+  /// Comparability-checks a single comparison `lhs <op> rhs` — the finder's
+  /// leaf. It resolves each operand's type through `validate` (deferring that
+  /// resolution's own non-comparability fault locally) and runs the leaf
+  /// `comparable` check, so a cross-kind non-exempt pair faults 42804 while a
+  /// constant-NULL, subquery, or unresolvable-typed operand defers. The nested
+  /// comparisons of the operands themselves are found by the callers' recursion
+  /// before this runs, so a 42804 buried in an operand never rides `validate`
+  /// here — that operand's own reachable 42804 already escaped.
+  private func compare(_ lhs: Expression, _ rhs: Expression,
+                       _ routines: Routines, subquery: SubqueryCheck)
+      throws(SQLError) {
+    try deferred { () throws(SQLError) in
+      let l = try validate(lhs, routines, subquery: subquery)
+      let r = try validate(rhs, routines, subquery: subquery)
+      try comparable(lhs, l, rhs, r, routines)
+    }
+  }
+
+  /// Comparability-checks a `LIKE`'s character rule — the ISO rule its operand
+  /// and pattern are character strings. A pattern or escape that `vanishes` —
+  /// a constant-NULL one, or a `:parameter` whose value arrives from the
+  /// bindings — makes the whole predicate defer to the run: the run reads an
+  /// unbound/NULL pattern as UNKNOWN and never reaches the character fault, so
+  /// faulting the operand at compile would reject `K LIKE :p` a run keeps. A
+  /// non-NULL, non-parameter pattern reaches the character check, faulting a
+  /// non-character operand or pattern (`K LIKE 'x'` over an integer `K`) 42804
+  /// as the run's `like` does. It reads the same `vanishes` the strict
+  /// validator's `.like` does, so the finder and the validator cannot drift.
+  private func like(_ operand: Expression, _ pattern: Predicate.Operand,
+                    _ escape: Predicate.Operand?, _ routines: Routines,
+                    subquery: SubqueryCheck) throws(SQLError) {
+    guard !vanishes(pattern, routines), !vanishes(escape, routines) else {
+      return
+    }
+    try deferred { () throws(SQLError) in
+      let type = try validate(operand, routines, subquery: subquery)
+      // A constant-NULL subject short-circuits the run's `like` to UNKNOWN
+      // before its pattern-type check, so enforce no character type here —
+      // matching the run and the strict validator's subject-NULL skip. Nested
+      // comparisons in the pattern are still found by the `.like` case's own
+      // recursion above.
+      if constant(operand, routines) == .null { return }
+      try character(operand, type, routines)
+      if case let .expression(pattern) = pattern {
+        let type = try validate(pattern, routines, subquery: subquery)
+        try character(pattern, type, routines)
+      }
+    }
+  }
+
+  /// Finds every reachable comparison in a `LIKE` pattern or escape `operand`.
+  private func comparisons(in operand: Predicate.Operand,
+                           _ routines: Routines, subquery: SubqueryCheck)
+      throws(SQLError) {
+    if case let .expression(expression) = operand {
+      try comparisons(in: expression, routines, subquery: subquery)
+    }
+  }
+
+  /// Finds and comparability-checks every reachable comparison in `predicate`,
+  /// short-circuit aware — the predicate arm of the finder. Each comparison-
+  /// bearing construct (`comparison`, `membership`, `between`, `rows`, `among`,
+  /// `like`, and the implicit equality a `NULLIF` inside an operand carries) is
+  /// leaf-checked with its own resolution fault deferred; a total predicate
+  /// (`IS [NOT] NULL`, `IS [NOT] DISTINCT FROM`, `bound`) faults never but has
+  /// its operands recursed for a nested one. `EXISTS`/`IN (Q)`/quantified
+  /// record the reached subquery for the driver to recurse its body, then
+  /// their left row's operands; the subquery operand itself is exempt (its
+  /// cross-kind rows fault at run through `relate`).
+  func comparisons(in predicate: Predicate, _ routines: Routines,
+                   subquery: SubqueryCheck = .unsupported) throws(SQLError) {
+    switch predicate {
+    case let .comparison(left, _, right):
+      try comparisons(in: left, routines, subquery: subquery)
+      try comparisons(in: right, routines, subquery: subquery)
+      try compare(left, right, routines, subquery: subquery)
+    case let .bound(left, _, _):
+      // `left op :parameter` — the parameter operand is deferred to the run, so
+      // the comparison itself never faults at compile; recurse the left for a
+      // nested comparison.
+      try comparisons(in: left, routines, subquery: subquery)
+    case let .null(operand, _):
+      // `IS [NOT] NULL` is total, so recurse the operand for a nested
+      // comparison but leaf-check nothing.
+      try comparisons(in: operand, routines, subquery: subquery)
+    case let .membership(operand, values, _):
+      // `x IN (v, …)` is the OR-chain `x = v OR …`. Every element the run
+      // reaches is recursed for a nested comparison it evaluates (a `CASE`
+      // guard that self-faults); and until the OR-chain short-circuits it is
+      // also compared to the operand — the comparability the run's `member`
+      // faults 42804 on. A constant match, or a reflexive element equal to a
+      // stable operand, stops the comparison as the run's Kleene-OR does. But a
+      // reflexive match fully prunes the tail (neither recursed nor compared)
+      // only over a provably non-NULL operand (`defined`): a nullable operand
+      // makes `operand = operand` UNKNOWN, so a NULL row runs on and evaluates
+      // every later element — its comparison to the NULL operand is UNKNOWN
+      // (never 42804), but a nested comparison it carries self-faults — so
+      // the comparability stops at the reflexive element while the recursion of
+      // the later elements continues.
+      try comparisons(in: operand, routines, subquery: subquery)
+      var comparing = true
+      for value in values {
+        try comparisons(in: value, routines, subquery: subquery)
+        guard comparing else { continue }
+        try compare(operand, value, routines, subquery: subquery)
+        if value == operand && stable(operand, routines) {
+          if defined(operand) { break }
+          comparing = false
+        } else if matched(operand, value, routines) == true {
+          break
+        }
+      }
+    case let .rows(lhs, _, rhs):
+      for expression in lhs {
+        try comparisons(in: expression, routines, subquery: subquery)
+      }
+      for expression in rhs {
+        try comparisons(in: expression, routines, subquery: subquery)
+      }
+      // A componentwise comparison; an arity mismatch is a structural fault the
+      // run defers, so a mismatched pair is not leaf-checked here.
+      guard lhs.count == rhs.count else { return }
+      // The run evaluates every left component, then every right, into a
+      // `[Value]` before `relate` preflights any pair's comparability — so a
+      // component's own evaluation fault (a `1 / 0`) it raises building a row
+      // preempts every pair's 42804 (`(1, 1 / 0) = ('x', 2)` divides, it does
+      // not fault the incomparable first pair). Defer the whole componentwise
+      // pass around the operand resolution in that order, so such a fault stops
+      // it (deferred to the run) before any pair faults 42804, then compare the
+      // resolved pairs — matching the run and the strict validator's `.rows`.
+      try deferred { () throws(SQLError) in
+        let l = try lhs.map { expression throws(SQLError) in
+          try validate(expression, routines, subquery: subquery)
+        }
+        let r = try rhs.map { expression throws(SQLError) in
+          try validate(expression, routines, subquery: subquery)
+        }
+        for index in lhs.indices {
+          try comparable(lhs[index], l[index], rhs[index], r[index], routines)
+        }
+      }
+    case let .among(lhs, rows, _):
+      // `(l…) [NOT] IN ((r…), …)` is the OR-chain of row equalities, short-
+      // circuit aware exactly as the scalar `.membership`.
+      for expression in lhs {
+        try comparisons(in: expression, routines, subquery: subquery)
+      }
+      // The run's `member` evaluates the whole left row once, then each element
+      // row, before `relate` preflights any pair — so a component's own
+      // evaluation fault preempts the 42804, and an element-row fault stops the
+      // fold there (the run raises it, never reaching a later element). Defer
+      // the whole componentwise pass so a left-row fault stops it before any
+      // element is checked, and an element-row fault (thrown out of the fold)
+      // stops it before a later element faults 42804 — each deferred to the
+      // run — while a comparability 42804 propagates. The nested-comparison
+      // recursion above stays eager (a comparison a component itself carries is
+      // found regardless), matching the run's per-component evaluation.
+      try deferred { () throws(SQLError) in
+        let types = try lhs.map { expression throws(SQLError) in
+          try validate(expression, routines, subquery: subquery)
+        }
+        let l = constants(lhs, routines)
+        _ = try membership(of: rows, each: { element throws(SQLError) in
+          for expression in element {
+            try comparisons(in: expression, routines, subquery: subquery)
+          }
+          guard element.count == lhs.count else { return }
+          let r = try element.map { expression throws(SQLError) in
+            try validate(expression, routines, subquery: subquery)
+          }
+          for index in element.indices {
+            try comparable(lhs[index], types[index], element[index], r[index],
+                           routines)
+          }
+        }, equality: { element throws(SQLError) in
+          guard let l, let r = constants(element, routines) else { return nil }
+          return (try? relate(l, .equal, r)) ?? nil
+        })
+      }
+    case let .like(operand, pattern, escape, _):
+      try comparisons(in: operand, routines, subquery: subquery)
+      try comparisons(in: pattern, routines, subquery: subquery)
+      if let escape {
+        try comparisons(in: escape, routines, subquery: subquery)
+      }
+      try like(operand, pattern, escape, routines, subquery: subquery)
+    case let .between(test, lower, upper, _):
+      // `x BETWEEN a AND b` compares `x` to each bound, short-circuit aware: a
+      // definitely-FALSE lower comparison settles the truth, leaving the upper
+      // unreachable, exactly as `ranged` evaluates it.
+      try comparisons(in: test, routines, subquery: subquery)
+      try comparisons(in: lower, routines, subquery: subquery)
+      if case let .expression(low) = lower {
+        try compare(test, low, routines, subquery: subquery)
+      }
+      let settled = {
+        guard let value = constant(test, routines),
+            let low = constant(lower, routines) else {
+          return false
+        }
+        return ((try? matches(value, .geq, low)) ?? nil) == false
+      }()
+      if !settled {
+        try comparisons(in: upper, routines, subquery: subquery)
+        if case let .expression(high) = upper {
+          try compare(test, high, routines, subquery: subquery)
+        }
+      }
+    case let .distinct(lhs, rhs, _):
+      // `IS [NOT] DISTINCT FROM` is total — a cross-kind pair is DISTINCT,
+      // a fault — so recurse both operands but leaf-check nothing.
+      try comparisons(in: lhs, routines, subquery: subquery)
+      try comparisons(in: rhs, routines, subquery: subquery)
+    case let .truth(inner, _, _):
+      try comparisons(in: inner, routines, subquery: subquery)
+    case let .exists(query, _):
+      // Record the reached occurrence so the driver recurses its body; its own
+      // resolution fault (an unsupported position) defers.
+      try deferred { () throws(SQLError) in
+        try subquery.validate(query, as: .existential)
+      }
+    case let .within(lhs, query, _):
+      for expression in lhs {
+        try comparisons(in: expression, routines, subquery: subquery)
+      }
+      try deferred { () throws(SQLError) in
+        try subquery.validate(query, as: .valued)
+      }
+    case let .quantified(lhs, _, _, query):
+      for expression in lhs {
+        try comparisons(in: expression, routines, subquery: subquery)
+      }
+      try deferred { () throws(SQLError) in
+        try subquery.validate(query, as: .valued)
+      }
+    case let .and(lhs, rhs):
+      // A connective recurses reachability-aware: the `constant` short-circuit
+      // is the run's, so an unreached operand's comparisons are not visited.
+      try comparisons(in: lhs, routines, subquery: subquery)
+      if constant(lhs, routines) != false {
+        try comparisons(in: rhs, routines, subquery: subquery)
+      }
+    case let .or(lhs, rhs):
+      try comparisons(in: lhs, routines, subquery: subquery)
+      if constant(lhs, routines) != true {
+        try comparisons(in: rhs, routines, subquery: subquery)
+      }
+    case let .not(operand):
+      try comparisons(in: operand, routines, subquery: subquery)
+    }
+  }
+
+  /// Finds and comparability-checks every reachable comparison in `expression`,
+  /// short-circuit aware — the expression arm of the finder. It recurses every
+  /// sub-expression that can hold a comparison (a `binary`/`cast` operand, a
+  /// call argument, a `COALESCE`/`CASE`/aggregate sub-expression) and leaf-
+  /// checks the implicit `v1 = v2` a `NULLIF` carries. A scalar subquery
+  /// its reached occurrence for the driver to recurse its body.
+  func comparisons(in expression: Expression, _ routines: Routines,
+                   subquery: SubqueryCheck = .unsupported) throws(SQLError) {
+    switch expression {
+    case .column, .literal:
+      break
+    case let .call(_, arguments):
+      for argument in arguments {
+        try comparisons(in: argument, routines, subquery: subquery)
+      }
+    case let .binary(_, lhs, rhs):
+      try comparisons(in: lhs, routines, subquery: subquery)
+      try comparisons(in: rhs, routines, subquery: subquery)
+    case let .aggregate(_, operand, _, filter):
+      // The `FILTER` is a per-row gate evaluated over every row, so its
+      // comparisons are always reachable; the aggregand folds only when the
+      // filter can admit a row (`dead`), matching the run's gate.
+      if let filter {
+        try comparisons(in: filter, routines, subquery: subquery)
+      }
+      if case let .expression(argument) = operand,
+          !(filter.map { dead($0, routines) } ?? false) {
+        try comparisons(in: argument, routines, subquery: subquery)
+      }
+    case let .case(whens, otherwise):
+      // Reachability mirrors `conditional`/`reachable`: each guard up to (and
+      // including) a constant-TRUE one is evaluated; a constant-FALSE guard's
+      // result is unreachable; a constant-TRUE guard makes every later branch
+      // and the `ELSE` unreachable.
+      for branch in whens {
+        try comparisons(in: branch.when, routines, subquery: subquery)
+        switch constant(branch.when, routines) {
+        case false:
+          continue
+        case true:
+          try comparisons(in: branch.then, routines, subquery: subquery)
+          return
+        case nil:
+          try comparisons(in: branch.then, routines, subquery: subquery)
+        }
+      }
+      if let otherwise {
+        try comparisons(in: otherwise, routines, subquery: subquery)
+      }
+    case let .cast(operand, _):
+      try comparisons(in: operand, routines, subquery: subquery)
+    case let .coalesce(arguments):
+      // Reachability mirrors `coalesce`: a definite selection makes every later
+      // argument unreachable, so stop the walk there.
+      for argument in arguments {
+        try comparisons(in: argument, routines, subquery: subquery)
+        if selects(argument, routines) { break }
+      }
+    case let .nullif(lhs, rhs):
+      // `NULLIF(v1, v2)` is `CASE WHEN v1 = v2 THEN NULL ELSE v1`, so v1 and v2
+      // must be comparable — recurse both, then check the implicit equality.
+      try comparisons(in: lhs, routines, subquery: subquery)
+      try comparisons(in: rhs, routines, subquery: subquery)
+      try compare(lhs, rhs, routines, subquery: subquery)
+    case let .subquery(query):
+      // Record the reached scalar occurrence so the driver recurses its body;
+      // its own arity fault defers.
+      try deferred { () throws(SQLError) in
+        _ = try subquery.type(query)
+      }
+    case let .grouping(arguments):
+      for argument in arguments {
+        try comparisons(in: argument, routines, subquery: subquery)
+      }
+    }
+  }
+
+  /// Finds every reachable comparison inside the aggregate sub-expressions of
+  /// `expression`, ignoring its non-aggregate structure — mirroring
+  /// `aggregates(in:)`. An aggregate folds over the group's rows before any
+  /// `LIMIT`, so its operand and `FILTER` comparisons are reachable even when a
+  /// row-dropping limit that leaves the surrounding projection unreachable, so
+  /// the driver runs this unconditionally over the projection.
+  func comparisons(aggregatesIn expression: Expression, _ routines: Routines,
+                   subquery: SubqueryCheck = .unsupported) throws(SQLError) {
+    switch expression {
+    case .column, .literal, .subquery:
+      break
+    case .aggregate:
+      // Found an aggregate — check its own operand and FILTER comparisons.
+      try comparisons(in: expression, routines, subquery: subquery)
+    case let .call(_, arguments), let .grouping(arguments):
+      for argument in arguments {
+        try comparisons(aggregatesIn: argument, routines, subquery: subquery)
+      }
+    case let .binary(_, lhs, rhs), let .nullif(lhs, rhs):
+      try comparisons(aggregatesIn: lhs, routines, subquery: subquery)
+      try comparisons(aggregatesIn: rhs, routines, subquery: subquery)
+    case let .case(whens, otherwise):
+      for branch in whens {
+        try comparisons(aggregatesIn: branch.when, routines, subquery: subquery)
+        try comparisons(aggregatesIn: branch.then, routines, subquery: subquery)
+      }
+      if let otherwise {
+        try comparisons(aggregatesIn: otherwise, routines, subquery: subquery)
+      }
+    case let .cast(operand, _):
+      try comparisons(aggregatesIn: operand, routines, subquery: subquery)
+    case let .coalesce(arguments):
+      for argument in arguments {
+        try comparisons(aggregatesIn: argument, routines, subquery: subquery)
+      }
+    }
+  }
+
+  /// Finds every reachable comparison inside the aggregate sub-expressions of
+  /// `predicate` — a `HAVING` or `CASE` guard's aggregates fold before the
+  /// filter runs, so they are reachable whatever the filter's short-circuit
+  /// — mirroring `aggregates(in predicate:)`.
+  func comparisons(aggregatesIn predicate: Predicate, _ routines: Routines,
+                   subquery: SubqueryCheck = .unsupported) throws(SQLError) {
+    switch predicate {
+    case let .comparison(left, _, right):
+      try comparisons(aggregatesIn: left, routines, subquery: subquery)
+      try comparisons(aggregatesIn: right, routines, subquery: subquery)
+    case let .bound(left, _, _):
+      try comparisons(aggregatesIn: left, routines, subquery: subquery)
+    case let .null(operand, _):
+      try comparisons(aggregatesIn: operand, routines, subquery: subquery)
+    case let .membership(operand, values, _):
+      try comparisons(aggregatesIn: operand, routines, subquery: subquery)
+      for value in values {
+        try comparisons(aggregatesIn: value, routines, subquery: subquery)
+      }
+    case let .rows(lhs, _, rhs):
+      for expression in lhs + rhs {
+        try comparisons(aggregatesIn: expression, routines, subquery: subquery)
+      }
+    case let .among(lhs, rows, _):
+      for expression in lhs {
+        try comparisons(aggregatesIn: expression, routines, subquery: subquery)
+      }
+      for element in rows {
+        for expression in element {
+          try comparisons(aggregatesIn: expression, routines,
+                          subquery: subquery)
+        }
+      }
+    case .exists:
+      break
+    case let .within(lhs, _, _), let .quantified(lhs, _, _, _):
+      for expression in lhs {
+        try comparisons(aggregatesIn: expression, routines, subquery: subquery)
+      }
+    case let .like(operand, pattern, escape, _):
+      try comparisons(aggregatesIn: operand, routines, subquery: subquery)
+      if case let .expression(pattern) = pattern {
+        try comparisons(aggregatesIn: pattern, routines, subquery: subquery)
+      }
+      if case let .expression(escape) = escape {
+        try comparisons(aggregatesIn: escape, routines, subquery: subquery)
+      }
+    case let .between(test, lower, upper, _):
+      try comparisons(aggregatesIn: test, routines, subquery: subquery)
+      if case let .expression(lower) = lower {
+        try comparisons(aggregatesIn: lower, routines, subquery: subquery)
+      }
+      if case let .expression(upper) = upper {
+        try comparisons(aggregatesIn: upper, routines, subquery: subquery)
+      }
+    case let .distinct(lhs, rhs, _):
+      try comparisons(aggregatesIn: lhs, routines, subquery: subquery)
+      try comparisons(aggregatesIn: rhs, routines, subquery: subquery)
+    case let .truth(inner, _, _):
+      try comparisons(aggregatesIn: inner, routines, subquery: subquery)
+    case let .and(lhs, rhs), let .or(lhs, rhs):
+      try comparisons(aggregatesIn: lhs, routines, subquery: subquery)
+      try comparisons(aggregatesIn: rhs, routines, subquery: subquery)
+    case let .not(operand):
+      try comparisons(aggregatesIn: operand, routines, subquery: subquery)
+    }
   }
 }

--- a/Tests/SQLTests/Expressions/ComparabilityTests.swift
+++ b/Tests/SQLTests/Expressions/ComparabilityTests.swift
@@ -667,3 +667,825 @@ struct RowOrderComparabilityTests {
                        yields: [[1]])
   }
 }
+
+// MARK: - Compile-time comparability
+
+/// The run's comparability determination is a static data-type rule, so it
+/// faults a reachable cross-kind comparison at compile regardless of table
+/// cardinality — including over an empty input the run would otherwise return
+/// empty for, and before the optimiser can hash, reorder, or drop a comparison
+/// that would else throw. `check` (`validate: true`) already faults each of
+/// these, so the run's compile-time walk restores run ≡ validate where the
+/// run's per-row `matches` never fired.
+private func partitioned() throws -> FixtureCatalog {
+  try Catalog {
+    // A is non-empty, E is empty — so a cross-kind comparison over E is never
+    // reached by the run's per-row evaluation, the silent hole.
+    Relation("A", ["num": .integer, "txt": .text]) {
+      Row(1, "x")
+      Row(2, "y")
+    }
+    Relation("E", ["num": .integer, "txt": .text]) { }
+  }
+}
+
+struct EmptyInputComparabilityTests {
+  @Test func `a cross-kind WHERE over an empty table faults at compile`()
+      throws {
+    // The run never evaluates the WHERE over zero rows, so `matches` never
+    // faults — the compile-time comparability check must, matching validate.
+    let sql = "SELECT num FROM E WHERE E.num = E.txt"
+    let query = try parse(query: sql)
+    #expect(throws: intVsText) { try partitioned().columns(of: query) }
+    try partitioned().expect(sql, fails: intVsText)
+  }
+
+  @Test func `a cross-kind key pushed below an empty product faults`() throws {
+    // `A CROSS JOIN E` with E empty yields no rows, so a WHERE the pushdown
+    // sinks below the product (`E.num = E.txt`, single-relation over the empty
+    // side) is never evaluated — the compile check faults it regardless.
+    let sql = "SELECT A.num FROM A CROSS JOIN E WHERE E.num = E.txt"
+    let query = try parse(query: sql)
+    #expect(throws: intVsText) { try partitioned().columns(of: query) }
+    try partitioned().expect(sql, fails: intVsText)
+  }
+
+  @Test func `a cross-kind under a constant-false fold faults`() throws {
+    // `WHERE 1 = 0` folds the derived source to empty, so its body's cross-kind
+    // is never run — the compile-time walk reaches into the derived body and
+    // faults it before the fold can drop the faulting source.
+    let sql = """
+        SELECT * FROM (SELECT * FROM E WHERE E.num = E.txt) t WHERE 1 = 0
+        """
+    let query = try parse(query: sql)
+    #expect(throws: intVsText) { try partitioned().columns(of: query) }
+    try partitioned().expect(sql, fails: intVsText)
+  }
+
+  @Test func `a cross-kind in a body over an empty table faults`() throws {
+    // The derived body materialises over an empty `E` — no row reaches its
+    // WHERE at run — so only the compile-time walk over the body faults it.
+    let sql = "SELECT * FROM (SELECT * FROM E WHERE E.num = E.txt) t"
+    let query = try parse(query: sql)
+    #expect(throws: intVsText) { try partitioned().columns(of: query) }
+    try partitioned().expect(sql, fails: intVsText)
+  }
+
+  @Test func `an unreachable cross-kind still does not fault`() throws {
+    // `1 = 0 AND …` short-circuits, so its cross-kind leg is not reached —
+    // the comparability walk is reachability-aware and defers it, exactly as
+    // the run and validate both do (`A` is non-empty, so a reached fault would
+    // surface).
+    let sql = "SELECT num FROM A WHERE 1 = 0 AND A.num = A.txt"
+    _ = try partitioned().columns(of: parse(query: sql))
+    try partitioned().empty(sql)
+  }
+
+  @Test func `a reachable comparable query over an empty input still runs`()
+      throws {
+    // The compile check faults only a cross-kind pair, so a same-kind
+    // comparison over the empty `E` still runs to its (empty) result.
+    try partitioned().empty("SELECT num FROM E WHERE E.num = 1")
+  }
+}
+
+// MARK: - Compile-time comparability: reflexive membership
+
+/// The compile-time finder carries the reflexive short-circuit and its
+/// nullable-operand guard. Over the empty `E` the run's per-row `member` never
+/// fires, so only the finder catches a cross-kind comparison a later `IN`
+/// element carries — and a nullable reflexive operand must not prune the
+/// finder's recursion into those later elements (a NULL row reaches and
+/// evaluates them), while a provably non-NULL operand still prunes the tail.
+struct ReflexiveMembershipFinderTests {
+  @Test func `a nullable reflexive operand recurses a nested cross-kind`()
+      throws {
+    // `E.num IN (E.num, CASE WHEN E.num = E.txt THEN 1 END)` over empty `E`:
+    // the reflexive `E.num` is nullable (no NOT NULL flag), so the finder
+    // recurses the later `CASE` and faults its cross-kind guard `E.num = E.txt`
+    // (integer vs text) at compile — the run reaches it on a NULL-`E.num` row,
+    // and over the empty `E` only the finder can. The prune stopped at the
+    // reflexive element and missed it.
+    let sql = """
+        SELECT num FROM E \
+        WHERE E.num IN (E.num, CASE WHEN E.num = E.txt THEN 1 END)
+        """
+    let query = try parse(query: sql)
+    #expect(throws: intVsText) { try partitioned().columns(of: query) }
+    try partitioned().expect(sql, fails: intVsText)
+  }
+
+  @Test func `a provably non-null reflexive operand still prunes the tail`()
+      throws {
+    // The operand `COALESCE(E.num, 0)` is provably non-NULL, so `operand =
+    // operand` is TRUE on every row and the run short-circuits at the reflexive
+    // element, never reaching the `CASE`. The `defined` gate prunes the whole
+    // tail, so the nested cross-kind is unreachable — no fault, matching the
+    // run (empty over the empty `E`).
+    let sql = """
+        SELECT num FROM E WHERE COALESCE(E.num, 0) \
+        IN (COALESCE(E.num, 0), CASE WHEN E.num = E.txt THEN 1 END)
+        """
+    let query = try parse(query: sql)
+    _ = try partitioned().columns(of: query)
+    try partitioned().empty(sql)
+  }
+}
+
+// MARK: - Compile-time comparability: projection, grouping, sort
+
+/// A cross-kind comparison hidden in a projection, `GROUP BY` key, `ORDER BY`
+/// sort key, or aggregate `FILTER` is a surface the run never evaluates over an
+/// empty input — the projection is not computed, the fold sees no row — yet
+/// `columns(of: validate:)` faults each. The compile-time comparability walk
+/// now visits every such surface, restoring run ≡ validate where the per-row
+/// `matches` never fired.
+struct ProjectionComparabilityTests {
+  @Test func `a projection NULLIF cross-kind pair faults at compile`() throws {
+    // `NULLIF(v1, v2)` desugars to `v1 = v2`; over an empty `E` the projection
+    // is never evaluated, so only the compile walk faults it, like validate.
+    let sql = "SELECT NULLIF(E.num, E.txt) FROM E"
+    let query = try parse(query: sql)
+    #expect(throws: intVsText) { try partitioned().columns(of: query) }
+    try partitioned().expect(sql, fails: intVsText)
+  }
+
+  @Test func `a projection CASE guard cross-kind pair faults at compile`()
+      throws {
+    let sql = "SELECT CASE WHEN E.num = E.txt THEN 1 ELSE 0 END FROM E"
+    let query = try parse(query: sql)
+    #expect(throws: intVsText) { try partitioned().columns(of: query) }
+    try partitioned().expect(sql, fails: intVsText)
+  }
+
+  @Test func `an aggregate FILTER cross-kind pair faults at compile`() throws {
+    // The `FILTER (WHERE …)` gate is validated unconditionally, so a cross-kind
+    // gate over the empty group a whole-result aggregate folds faults.
+    let sql = "SELECT COUNT(*) FILTER (WHERE E.num = E.txt) FROM E"
+    let query = try parse(query: sql)
+    #expect(throws: intVsText) { try partitioned().columns(of: query) }
+    try partitioned().expect(sql, fails: intVsText)
+  }
+
+  @Test func `a GROUP BY key cross-kind pair faults at compile`() throws {
+    let sql = "SELECT COUNT(*) FROM E GROUP BY NULLIF(E.num, E.txt)"
+    let query = try parse(query: sql)
+    #expect(throws: intVsText) { try partitioned().columns(of: query) }
+    try partitioned().expect(sql, fails: intVsText)
+  }
+
+  @Test func `an ORDER BY key cross-kind pair faults at compile`() throws {
+    // The sort key is evaluated below any limit, so its comparison is checked
+    // unconditionally; over the empty `E` the sort runs no key at run.
+    let sql = "SELECT E.num FROM E ORDER BY NULLIF(E.num, E.txt)"
+    let query = try parse(query: sql)
+    #expect(throws: intVsText) { try partitioned().columns(of: query) }
+    try partitioned().expect(sql, fails: intVsText)
+  }
+
+  @Test func `a same-kind projection NULLIF still runs over an empty input`()
+      throws {
+    // A comparable NULLIF is not faulted, so the query runs to its empty
+    // result.
+    let sql = "SELECT NULLIF(E.num, 1) FROM E"
+    _ = try partitioned().columns(of: parse(query: sql))
+    try partitioned().empty(sql)
+  }
+
+  @Test func `a NULL-guarded projection CASE stays UNKNOWN, never a fault`()
+      throws {
+    // `E.txt = NULL` is a constant-NULL comparison, exempt, so the CASE guard
+    // faults neither the run nor validate.
+    let sql = "SELECT CASE WHEN E.txt = NULL THEN 1 ELSE 0 END FROM E"
+    _ = try partitioned().columns(of: parse(query: sql))
+    try partitioned().empty(sql)
+  }
+
+  @Test func `an unreachable projection under a false WHERE does not fault`()
+      throws {
+    // A projection under a constant-false WHERE is unreachable, so its
+    // cross-kind NULLIF is not checked — the query runs to its empty result
+    // even over the non-empty `A`, exactly as validate accepts it.
+    let sql = "SELECT NULLIF(A.num, A.txt) FROM A WHERE 1 = 0"
+    _ = try partitioned().columns(of: parse(query: sql))
+    try partitioned().empty(sql)
+  }
+}
+
+// MARK: - Compile-time comparability: HAVING aggregates
+
+/// A `HAVING` aggregate is collected and folded by the group node before the
+/// filter predicate runs, so its operand and `FILTER` comparisons are evaluated
+/// unconditionally — an enclosing `AND`/`OR` short-circuit that leaves the
+/// aggregate's own comparison unreachable does not spare the fold. The strict
+/// validate walk checks every `HAVING` aggregate through `aggregates(in:)`
+/// regardless of the predicate's reachability, so the run's comparability walk
+/// must too (`comparisons(aggregatesIn:)`), ahead of its reachability-aware
+/// scalar walk — else a cross-kind `HAVING 1 = 0 AND SUM(NULLIF(int, text))`
+/// silently returns empty on the run while validate faults it (`run ≡
+/// validate`). The internal reachability of the aggregate's own operand still
+/// prunes (a `CASE` arm the guard makes dead is never folded), so the
+/// unconditional check must not over-fault an unreachable operand comparison.
+struct HavingAggregateComparabilityTests {
+  @Test func `a grouped HAVING aggregate behind a false AND faults at compile`()
+      throws {
+    // `1 = 0 AND SUM(…)`: the reachability walk prunes the `SUM(…) > 0` leg,
+    // but the group node folds `SUM(NULLIF(E.num, E.txt))` before the filter —
+    // the cross-kind operand faults 42804 on both paths over the empty group.
+    let sql = """
+        SELECT COUNT(*) FROM E GROUP BY E.num \
+        HAVING 1 = 0 AND SUM(NULLIF(E.num, E.txt)) > 0
+        """
+    let query = try parse(query: sql)
+    #expect(throws: intVsText) { try partitioned().columns(of: query) }
+    try partitioned().expect(sql, fails: intVsText)
+  }
+
+  @Test func `a grouped HAVING aggregate behind a true OR faults at compile`()
+      throws {
+    // `1 = 1 OR SUM(…)`: the reachability walk prunes the OR's right leg, but
+    // the aggregate still folds before the filter, so its cross-kind operand
+    // faults on both paths.
+    let sql = """
+        SELECT COUNT(*) FROM E GROUP BY E.num \
+        HAVING 1 = 1 OR SUM(NULLIF(E.num, E.txt)) > 0
+        """
+    let query = try parse(query: sql)
+    #expect(throws: intVsText) { try partitioned().columns(of: query) }
+    try partitioned().expect(sql, fails: intVsText)
+  }
+
+  @Test func `a whole-result HAVING aggregate behind a short-circuit faults`()
+      throws {
+    // No GROUP BY: the whole-result aggregate emits one empty group whose
+    // HAVING folds its `SUM` before the filter, so the short-circuited
+    // cross-kind operand faults on both paths.
+    let sql = """
+        SELECT COUNT(*) FROM E \
+        HAVING 1 = 0 AND SUM(NULLIF(E.num, E.txt)) > 0
+        """
+    let query = try parse(query: sql)
+    #expect(throws: intVsText) { try partitioned().columns(of: query) }
+    try partitioned().expect(sql, fails: intVsText)
+  }
+
+  @Test func `a HAVING aggregate FILTER behind a short-circuit faults`()
+      throws {
+    // The `FILTER (WHERE …)` gate is evaluated as the aggregate folds, before
+    // the filter predicate, so a cross-kind gate under a short-circuited HAVING
+    // leg faults on both paths.
+    let sql = """
+        SELECT COUNT(*) FROM E GROUP BY E.num \
+        HAVING 1 = 0 AND COUNT(*) FILTER (WHERE E.num = E.txt) > 0
+        """
+    let query = try parse(query: sql)
+    #expect(throws: intVsText) { try partitioned().columns(of: query) }
+    try partitioned().expect(sql, fails: intVsText)
+  }
+
+  @Test func `a same-kind HAVING aggregate behind a short-circuit still runs`()
+      throws {
+    // The control: a comparable `SUM(NULLIF(E.num, 1))` operand is not faulted,
+    // so the short-circuited HAVING runs to the empty result on both paths.
+    let sql = """
+        SELECT COUNT(*) FROM E GROUP BY E.num \
+        HAVING 1 = 0 AND SUM(NULLIF(E.num, 1)) > 0
+        """
+    _ = try partitioned().columns(of: parse(query: sql))
+    try partitioned().empty(sql)
+  }
+
+  @Test func `an unreachable HAVING aggregate operand does not over-fault`()
+      throws {
+    // The aggregate's own operand short-circuits internally: the executor never
+    // folds the `CASE`'s dead `NULLIF` arm, so neither the run's `aggregatesIn`
+    // walk (which delegates to the reachability-aware `comparisons(in:)` at the
+    // aggregate) nor validate's `aggregates(in:)` faults it — the unconditional
+    // HAVING-aggregate check must not over-fault an unreachable operand.
+    let sql = """
+        SELECT COUNT(*) FROM E GROUP BY E.num \
+        HAVING SUM(CASE WHEN 1 = 0 THEN NULLIF(E.num, E.txt) ELSE 0 END) > 0
+        """
+    _ = try partitioned().columns(of: parse(query: sql))
+    try partitioned().empty(sql)
+  }
+}
+
+// MARK: - Per-site deferred-error suppression
+
+/// The comparability walk swallows a deferred non-comparability fault (an
+/// ill-typed arithmetic operand, an unknown routine, a bad arity) per site and
+/// continues, so it reaches every later comparison surface regardless of where
+/// such a fault sits — a single enclosing catch would let the first deferred
+/// fault abort the walk before a later incomparable comparison was checked. The
+/// run enforces only the ISO comparability rule (42804); every other operand
+/// fault stays deferred to execution, exactly as before. Validate stays
+/// stricter — its strict walk reports the first fault it reaches, an arithmetic
+/// `.operand` among them — a pre-existing, out-of-scope divergence; the point
+/// here is that the run no longer silently returns empty past a deferred fault.
+struct DeferredFaultComparabilityTests {
+  @Test func `a deferred projection fault does not hide a later comparison`()
+      throws {
+    // The reviewer's case, arithmetic-first: `E.txt + 1` is an ill-typed
+    // arithmetic operand the run defers, so the walk swallows it per site and
+    // continues to `NULLIF(E.num, E.txt)` — an integer/text comparison — which
+    // faults 42804 at run over the empty `E`, where the old single enclosing
+    // catch returned silently. Validate's strict walk faults the arithmetic
+    // first (`.operand`), so it rejects the query too, just with the stricter
+    // code — an unchanged, out-of-scope divergence.
+    let sql = "SELECT E.txt + 1, NULLIF(E.num, E.txt) FROM E"
+    try partitioned().expect(sql, fails: intVsText)
+    #expect(throws: SQLError.self) {
+      try partitioned().columns(of: parse(query: sql))
+    }
+  }
+
+  @Test func `the comparison-first order faults 42804 on both paths`() throws {
+    // With the comparison first, both walks reach it before the arithmetic: the
+    // run's comparability walk faults 42804 at the first projection item, and
+    // the strict validate walk faults the same 42804 as its first fault.
+    let sql = "SELECT NULLIF(E.num, E.txt), E.txt + 1 FROM E"
+    let query = try parse(query: sql)
+    #expect(throws: intVsText) { try partitioned().columns(of: query) }
+    try partitioned().expect(sql, fails: intVsText)
+  }
+
+  @Test func `a WHERE comparison faults past a deferred projection fault`()
+      throws {
+    // A cross-kind comparison in the WHERE coexists with an ill-typed
+    // arithmetic projection: both walks visit the WHERE first, so it faults
+    // 42804 on both the run and validate — the deferred projection fault never
+    // masks it.
+    let sql = "SELECT E.txt + 1 FROM E WHERE E.num = E.txt"
+    let query = try parse(query: sql)
+    #expect(throws: intVsText) { try partitioned().columns(of: query) }
+    try partitioned().expect(sql, fails: intVsText)
+  }
+
+  @Test func `an ORDER BY comparison faults past a deferred projection fault`()
+      throws {
+    // The projection is visited before the sort keys, so the ill-typed
+    // `E.txt + 1` projection is swallowed per site, so the walk continues to
+    // the cross-kind `ORDER BY NULLIF(E.num, E.txt)` sort key — faulting 42804
+    // at run over the empty `E`, the definitive cross-clause per-site case.
+    let sql = "SELECT E.txt + 1 FROM E ORDER BY NULLIF(E.num, E.txt)"
+    try partitioned().expect(sql, fails: intVsText)
+  }
+
+  @Test func `a deferred fault with no comparison does not fault the walk`()
+      throws {
+    // Only a 42804 escapes the comparability walk: an arithmetic operand fault
+    // with no incomparable comparison anywhere stays deferred to the run, which
+    // returns its (empty) result over `E`. Validate stays stricter and faults
+    // the arithmetic — the pre-existing, out-of-scope divergence.
+    let sql = "SELECT E.txt + 1 FROM E"
+    try partitioned().empty(sql)
+    #expect(throws: SQLError.self) {
+      try partitioned().columns(of: parse(query: sql))
+    }
+  }
+}
+
+// MARK: - Compile-time comparability: subquery bodies
+
+/// A cross-kind comparison in the body of a reached `EXISTS`/`IN (Q)`/scalar
+/// subquery is never faulted at run when its uncorrelated body does not
+/// materialise over an empty outer — the per-row `matches` never fires — yet
+/// the schema path recursively type-checks the body and faults it. The compile
+/// walk now recurses into each reached body the same way, closing that hole,
+/// while an unreached body (a short-circuited leg's subquery) still defers.
+struct SubqueryBodyComparabilityTests {
+  @Test func `a reached EXISTS body cross-kind faults at compile`() throws {
+    // `E` is empty, so the EXISTS is never evaluated and its uncorrelated body
+    // over `A` never materialises — only the compile walk, recursing into the
+    // body, faults it, matching validate.
+    let sql =
+        "SELECT E.num FROM E WHERE EXISTS (SELECT 1 FROM A WHERE A.num = A.txt)"
+    let query = try parse(query: sql)
+    #expect(throws: intVsText) { try partitioned().columns(of: query) }
+    try partitioned().expect(sql, fails: intVsText)
+  }
+
+  @Test func `a reached IN subquery body cross-kind pair faults at compile`()
+      throws {
+    let sql = """
+        SELECT E.num FROM E \
+        WHERE E.num IN (SELECT A.num FROM A WHERE A.num = A.txt)
+        """
+    let query = try parse(query: sql)
+    #expect(throws: intVsText) { try partitioned().columns(of: query) }
+    try partitioned().expect(sql, fails: intVsText)
+  }
+
+  @Test func `a reached scalar subquery body cross-kind pair faults`() throws {
+    let sql = """
+        SELECT E.num FROM E \
+        WHERE E.num = (SELECT A.num FROM A WHERE A.num = A.txt)
+        """
+    let query = try parse(query: sql)
+    #expect(throws: intVsText) { try partitioned().columns(of: query) }
+    try partitioned().expect(sql, fails: intVsText)
+  }
+
+  @Test func `an unreachable EXISTS body under a false leg does not fault`()
+      throws {
+    // `1 = 0 AND EXISTS (…)` short-circuits, so the EXISTS body is never
+    // reached — the walk records no reach, so its cross-kind body defers,
+    // exactly as the run and validate both do (`A` is non-empty, so a reached
+    // fault would surface).
+    let sql = """
+        SELECT A.num FROM A \
+        WHERE 1 = 0 AND EXISTS (SELECT 1 FROM E WHERE E.num = E.txt)
+        """
+    _ = try partitioned().columns(of: parse(query: sql))
+    try partitioned().empty(sql)
+  }
+}
+
+// MARK: - Compile-time comparability: CTE bodies
+
+/// A cross-kind comparison in a reachable `WITH` body faults at compile on both
+/// paths: the run materialises each CTE through the same `run` (hence the same
+/// compile-time comparability walk) the trailing query drives, and the schema
+/// path (`columns(of:)`) type-checks each CTE body — so a cross-kind body over
+/// an empty input, which the CTE's own per-row `matches` never reaches, still
+/// faults, keeping run ≡ validate.
+struct CTEBodyComparabilityTests {
+  @Test func `a cross-kind WITH body faults at run and validate`() throws {
+    let sql = """
+        WITH c AS (SELECT E.num FROM E WHERE E.num = E.txt) SELECT * FROM c
+        """
+    let statement = try Statement(parsing: sql)
+    #expect(throws: intVsText) { try partitioned().columns(of: statement) }
+    #expect(throws: intVsText) { _ = try partitioned().run(statement) }
+  }
+}
+
+// MARK: - Compile-time comparability: stored-view bodies
+
+/// A stored VIEW registered by name is executed on the run path as an
+/// already-compiled plan (`validate: false`), so its body's comparisons were
+/// never comparability-checked and the outer query's walk treated the view as
+/// an opaque relation. A cross-kind comparison in a view body over an empty
+/// input therefore returned no rows on the run while the schema path
+/// (`columns(of:)`) faulted the body — the same run ≠ validate hole the
+/// derived-table recursion closes. The comparability walk now descends into
+/// each reached view's body, transitively, restoring run ≡ validate.
+///
+/// `V`'s body compares an integer against text over an empty `E`; `Same`'s
+/// body is a like-kind comparison over the non-empty `A`; `Nested` names `V`,
+/// so a walk that descends must reach `V`'s cross-kind pair through it.
+private func viewed() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("A", ["num": .integer, "txt": .text]) {
+      Row(1, "x")
+      Row(2, "y")
+    }
+    Relation("E", ["num": .integer, "txt": .text]) { }
+    try View("V", "SELECT num FROM E WHERE num = txt", as: ["num"])
+    try View("Same", "SELECT num FROM A WHERE num = 1", as: ["num"])
+    try View("Nested", "SELECT num FROM V", as: ["num"])
+  }
+}
+
+struct ViewBodyComparabilityTests {
+  @Test func `a cross-kind stored-view body faults at run and validate`()
+      throws {
+    // `SELECT * FROM V` executes `V`'s compiled plan over the empty `E`, so its
+    // `num = txt` never reaches `matches` — only the walk descending into the
+    // body faults it, matching the schema path.
+    let sql = "SELECT * FROM V"
+    let query = try parse(query: sql)
+    #expect(throws: intVsText) { try viewed().columns(of: query) }
+    try viewed().expect(sql, fails: intVsText)
+  }
+
+  @Test func `a cross-kind view body faults transitively through a view`()
+      throws {
+    // `Nested` names `V`, so the descent must recurse through `Nested`'s body
+    // into `V`'s to reach the cross-kind pair.
+    let sql = "SELECT * FROM Nested"
+    let query = try parse(query: sql)
+    #expect(throws: intVsText) { try viewed().columns(of: query) }
+    try viewed().expect(sql, fails: intVsText)
+  }
+
+  @Test func `a view named in a reached subquery body faults at compile`()
+      throws {
+    // The EXISTS is reached (a bare `WHERE EXISTS`), so its body's `FROM V`
+    // is walked and `V`'s cross-kind pair faults, exactly as a cross-kind pair
+    // written directly in the subquery body would.
+    let sql = "SELECT num FROM A WHERE EXISTS (SELECT 1 FROM V)"
+    let query = try parse(query: sql)
+    #expect(throws: intVsText) { try viewed().columns(of: query) }
+    try viewed().expect(sql, fails: intVsText)
+  }
+
+  @Test func `a view under an unreachable branch does not fault`() throws {
+    // `1 = 0 AND EXISTS (…)` short-circuits, so the EXISTS body is never
+    // reached and its `FROM V` is never walked — the cross-kind body defers,
+    // exactly as a directly-written unreachable cross-kind pair does. `A` is
+    // non-empty, so a spurious descent would surface `V`'s fault.
+    let sql =
+        "SELECT num FROM A WHERE 1 = 0 AND EXISTS (SELECT 1 FROM V)"
+    _ = try viewed().columns(of: parse(query: sql))
+    try viewed().empty(sql)
+  }
+
+  @Test func `a same-kind view body still resolves and yields its rows`()
+      throws {
+    // `Same`'s body is a like-kind comparison, so the descent faults nothing
+    // and the view runs — `num = 1` selects `A`'s first row.
+    try viewed().expect("SELECT num FROM Same", yields: [[1]])
+  }
+}
+
+// MARK: - Compile-time comparability: defined-function bodies
+
+/// A `CREATE FUNCTION` scalar body is validated once at registration
+/// (`Routine.init` runs the full `Scope.validate` walk, whose `check`/`nullif`
+/// apply the comparability rule unconditionally), so a cross-kind comparison in
+/// a reachable part of the body faults 42804 eagerly at definition time — it is
+/// not a `validate: false`-deferred run-path surface. These lock that in.
+private func define(_ definition: String) throws -> Routines {
+  guard case let .function(name, function) = try Statement(parsing: definition)
+  else {
+    throw SQLError.incomplete(expected: "a CREATE FUNCTION statement")
+  }
+  return try Routines.standard.registering(name, function)
+}
+
+struct DefinedFunctionComparabilityTests {
+  @Test func `a cross-kind comparison in a function body faults at definition`()
+      throws {
+    // `a = b` compares the integer parameter against the text one — a data-type
+    // mismatch the registration-time body validation faults, before any call.
+    #expect(throws: intVsText) {
+      _ = try define("CREATE FUNCTION cmp(a INTEGER, b VARCHAR) RETURNS "
+                         + "INTEGER AS CASE WHEN a = b THEN 1 ELSE 0 END")
+    }
+  }
+
+  @Test func `a same-kind comparison in a function body defines and runs`()
+      throws {
+    // A like-kind guard defines cleanly; `cmp(N, N)` is TRUE for every row, so
+    // the projection yields `1` for both of `T`'s rows.
+    let routines =
+        try define("CREATE FUNCTION cmp(a INTEGER, b INTEGER) "
+                       + "RETURNS INTEGER AS CASE WHEN a = b THEN 1 ELSE 0 END")
+    try mixed().expect("SELECT cmp(N, N) FROM T", yields: [[1], [1]],
+                       routines: routines)
+  }
+}
+
+// MARK: - Decorrelation comparability
+
+/// A correlated subquery whose key equates a cross-kind pair (`R.name =
+/// L.age`, text against integer) must fault 42804 at run, not decorrelate into
+/// a hash/semijoin that buckets the two sides apart and silently drops every
+/// row. The decorrelation producer gates the `.match` hoist on the same
+/// `ValueType.unified` notion the run's `matches` and validate's `comparable`
+/// use: a cross-kind key bails the rewrite, leaving the correlated select to
+/// fault through `matches`; a comparable one still decorrelates.
+private func correlated() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("L", ["Id": .integer, "age": .integer]) {
+      Row(1, 10)
+      Row(2, 20)
+    }
+    Relation("R", ["Id": .integer, "name": .text, "m": .integer]) {
+      Row(1, "10", 10)
+      Row(2, "z", 99)
+    }
+  }
+}
+
+struct DecorrelationComparabilityTests {
+  @Test func `a cross-kind correlated EXISTS faults at run and validate`()
+      throws {
+    let sql =
+        "SELECT L.Id FROM L WHERE EXISTS (SELECT 1 FROM R WHERE R.name = L.age)"
+    let query = try parse(query: sql)
+    #expect(throws: textVsInt) { try correlated().columns(of: query) }
+    try correlated().expect(sql, fails: textVsInt)
+  }
+
+  @Test func `a cross-kind correlated IN faults at run`() throws {
+    // `L.age IN (SELECT R.name …)` lifts to a semijoin whose key would bucket
+    // integer against text apart; the gate leaves it to fault through
+    // `matches`.
+    try correlated().expect(
+        "SELECT L.Id FROM L WHERE L.age IN (SELECT R.name FROM R)",
+        fails: intVsText)
+  }
+
+  @Test func `a cross-kind correlated scalar subquery faults at run`() throws {
+    let sql = """
+        SELECT L.Id FROM L \
+        WHERE L.age = (SELECT R.name FROM R WHERE R.m = L.age)
+        """
+    try correlated().expect(sql, fails: intVsText)
+  }
+
+  @Test func `a same-kind correlated EXISTS still decorrelates and matches`()
+      throws {
+    // `R.m = L.age` is an integer pair, so the semijoin key still hoists: `L`
+    // age 10 finds `R.m` 10, age 20 finds none — returning the matched row.
+    try correlated().expect(
+        "SELECT L.Id FROM L WHERE EXISTS (SELECT 1 FROM R WHERE R.m = L.age)",
+        yields: [[1]])
+  }
+
+  @Test func `a same-kind correlated IN still decorrelates and matches`()
+      throws {
+    // `L.age IN (SELECT R.m …)` is an integer membership: age 10 is in {10,
+    // 99}, age 20 is not, so it still lifts to a semijoin and returns the row.
+    try correlated().expect(
+        "SELECT L.Id FROM L WHERE L.age IN (SELECT R.m FROM R)",
+        yields: [[1]])
+  }
+}
+
+// MARK: - Nested subexpressions, set-operation carriers, parameter LIKE
+
+/// The incomparable-type fault a non-character `LIKE` operand or pattern raises
+/// — the same message on the compile character check and the run's `like`.
+private let likeChar =
+    SQLError.state("42804", "LIKE requires character operands")
+
+/// A comparison nested inside a `COALESCE`/`CASE` argument, past an earlier
+/// argument whose own resolution defers (an arithmetic type error), is still
+/// found: the comparison-finder recurses each argument independently and defers
+/// each one's own fault locally, so no earlier argument can hide a later
+/// argument's incomparable comparison. (The retired walk-reuse deferred the
+/// whole expression at once, silently swallowing the nested comparison.)
+struct NestedSubexpressionComparabilityTests {
+  @Test func `a COALESCE nested NULLIF faults past a deferred arithmetic arg`()
+      throws {
+    // `E.txt + 1` is a deferred arithmetic error; the finder recurses on to the
+    // second argument's `NULLIF(E.num, E.txt)` — an integer/text comparison —
+    // faulting 42804 at run over the empty `E`, where the old single enclosing
+    // catch returned silently. Validate stays stricter, faulting the arithmetic
+    // first (the pre-existing divergence).
+    let sql = "SELECT COALESCE(E.txt + 1, NULLIF(E.num, E.txt)) FROM E"
+    try partitioned().expect(sql, fails: intVsText)
+    #expect(throws: SQLError.self) {
+      try partitioned().columns(of: parse(query: sql))
+    }
+  }
+
+  @Test func
+      `a COALESCE nested CASE guard faults past a deferred arithmetic arg`()
+      throws {
+    let sql = """
+        SELECT COALESCE(E.txt + 1, \
+        CASE WHEN E.num = E.txt THEN 1 ELSE 0 END) FROM E
+        """
+    try partitioned().expect(sql, fails: intVsText)
+  }
+
+  @Test func `a same-kind COALESCE past a deferred arithmetic arg still runs`()
+      throws {
+    // No incomparable comparison anywhere, so the deferred arithmetic stays the
+    // run's to raise — over the empty `E` it never evaluates, so the run yields
+    // its empty result.
+    let sql = "SELECT COALESCE(E.txt + 1, NULLIF(E.num, 1)) FROM E"
+    try partitioned().empty(sql)
+  }
+}
+
+/// A query-level `ORDER BY` carried over a set operation is a comparison
+/// surface the finder visits: a cross-kind sort key faults 42804 in the
+/// carrier, while a key that holds no comparison (an arithmetic one) does not —
+/// the finder checks comparisons alone and never re-validates the carrier's
+/// operands, so a run does not reject `ORDER BY txt + 1`.
+struct CarrierComparabilityTests {
+  @Test func `a cross-kind set-operation ORDER BY key faults at run`() throws {
+    // The union's output column `txt` is text; `NULLIF(txt, 1)` compares it to
+    // an integer — 42804 — in the carrier, over the empty `E`.
+    let sql = """
+        SELECT txt FROM E UNION ALL SELECT txt FROM E \
+        ORDER BY NULLIF(txt, 1)
+        """
+    try partitioned().expect(sql, fails: textVsInt)
+    #expect(throws: textVsInt) {
+      try partitioned().columns(of: parse(query: sql))
+    }
+  }
+
+  @Test func `an arithmetic set-operation ORDER BY key does not fault the run`()
+      throws {
+    // `txt + 1` is an arithmetic operand error, not a comparison, so the finder
+    // leaves it to the run — which never evaluates it over empty `E`, so the
+    // query yields its empty result. (Validate stays stricter, faulting the
+    // arithmetic — the pre-existing divergence.)
+    let sql = """
+        SELECT txt FROM E UNION ALL SELECT txt FROM E \
+        ORDER BY txt + 1
+        """
+    try partitioned().empty(sql)
+  }
+}
+
+/// A recursive CTE's query-level `ORDER BY` carrier is peeled by the fixpoint
+/// and run through `apply` under a normal context, so — unlike the non-
+/// recursive set-operation carrier the top-level walk re-runs through
+/// `ordered` — its sort keys never reached the compile-time comparability
+/// walk: a cross-kind key over an empty-anchor fixpoint sorted no rows and
+/// returned empty rather than faulting, while `columns(of: validate: true)`
+/// faulted it through the CTE's carrier validation. `apply` now preflights the
+/// carrier through the same `carried` resolver in `comparing()` mode, so a
+/// cross-kind key faults 42804 on the run as it does on the validate path —
+/// while an arithmetic key still defers to the run.
+struct RecursiveCarrierComparabilityTests {
+  @Test func `a cross-kind recursive-CTE ORDER BY key faults run and validate`()
+      throws {
+    // `r`'s anchor `SELECT num AS n FROM E` is empty, so the fixpoint sorts no
+    // rows; the carrier `NULLIF(n, 'x')` compares the integer output `n`
+    // against text — the cross-kind key the preflight faults 42804 before the
+    // (empty) sort, matching the validate path's carrier validation.
+    let sql = """
+        WITH RECURSIVE r (n) AS (\
+        SELECT num AS n FROM E \
+        UNION ALL SELECT n + 1 FROM r WHERE n < 0 \
+        ORDER BY NULLIF(n, 'x')) SELECT n FROM r
+        """
+    let statement = try Statement(parsing: sql)
+    #expect(throws: intVsText) {
+      try partitioned().columns(of: statement, validate: true)
+    }
+    #expect(throws: intVsText) { _ = try partitioned().run(statement) }
+  }
+
+  @Test func `a same-kind recursive-CTE ORDER BY key runs to its empty result`()
+      throws {
+    // `NULLIF(n, 1)` compares the integer output against an integer —
+    // comparable — so neither path faults; the empty-anchor fixpoint is empty.
+    let sql = """
+        WITH RECURSIVE r (n) AS (\
+        SELECT num AS n FROM E \
+        UNION ALL SELECT n + 1 FROM r WHERE n < 0 \
+        ORDER BY NULLIF(n, 1)) SELECT n FROM r
+        """
+    let statement = try Statement(parsing: sql)
+    _ = try partitioned().columns(of: statement, validate: true)
+    let rows = try partitioned().run(statement)
+    #expect(rows.isEmpty)
+  }
+
+  @Test func `an arithmetic recursive-CTE ORDER BY key does not fault the run`()
+      throws {
+    // `n + 1` is an arithmetic operand, not a comparison, so the comparability
+    // preflight leaves it to the run — which never evaluates it over the empty
+    // fixpoint, so the query yields its empty result. The comparability-only
+    // preflight must not over-fault a non-comparison key (it is not full
+    // validation).
+    let sql = """
+        WITH RECURSIVE r (n) AS (\
+        SELECT num AS n FROM E \
+        UNION ALL SELECT n + 1 FROM r WHERE n < 0 \
+        ORDER BY n + 1) SELECT n FROM r
+        """
+    let statement = try Statement(parsing: sql)
+    let rows = try partitioned().run(statement)
+    #expect(rows.isEmpty)
+  }
+}
+
+/// A `LIKE` whose pattern (or escape) is a `:parameter` defers its character
+/// rule to the run — the binding decides whether it faults — while a constant
+/// non-character pattern faults at compile as the run does. This holds on both
+/// the run and the validate path, so run ≡ validate.
+struct ParameterLikeComparabilityTests {
+  @Test func `an integer LIKE an unbound parameter does not fault`() throws {
+    // `A.num LIKE :p` with `:p` unbound reads the pattern as NULL — UNKNOWN,
+    // never the character fault — so it faults neither at compile nor at run,
+    // over the non-empty `A`.
+    let sql = "SELECT num FROM A WHERE A.num LIKE :p"
+    _ = try partitioned().columns(of: parse(query: sql))
+    try partitioned().empty(sql)
+  }
+
+  @Test func `an integer LIKE a NULL-bound parameter does not fault`() throws {
+    try partitioned().empty("SELECT num FROM A WHERE A.num LIKE :p",
+                            bindings: ["p": .null])
+  }
+
+  @Test func `an integer LIKE a non-character-bound parameter faults at run`()
+      throws {
+    // `:p` bound to a non-null integer is a non-character pattern, so the run's
+    // `like` faults 42804 — the dynamic residual the compile defer leaves it.
+    try partitioned().expect("SELECT num FROM A WHERE A.num LIKE :p",
+                             fails: likeChar, bindings: ["p": .integer(5)])
+  }
+
+  @Test func `an integer LIKE a constant pattern still faults at compile`()
+      throws {
+    // A constant non-null pattern is not deferred, so the finder faults the
+    // non-character operand `E.num` 42804 at compile, even over the empty `E`.
+    let sql = "SELECT num FROM E WHERE E.num LIKE 'x'"
+    let query = try parse(query: sql)
+    #expect(throws: likeChar) { try partitioned().columns(of: query) }
+    try partitioned().expect(sql, fails: likeChar)
+  }
+}

--- a/Tests/SQLTests/Expressions/LikeTests.swift
+++ b/Tests/SQLTests/Expressions/LikeTests.swift
@@ -619,13 +619,19 @@ struct LikeEvaluationOrderTests {
 
   @Test func `a faulting operand surfaces before a NULL escape UNKNOWN`()
       throws {
-    // `(1 / K) LIKE 'x' ESCAPE E` with `K = 0, E = NULL`. The operand `1 / K`
-    // faults `SQLError.divide`; the executor must evaluate the reached operand
-    // before deciding the NULL-escape UNKNOWN — an early return on the NULL
-    // escape would silently FILTER the row (UNKNOWN) and hide the divide.
-    // adversarial: reverting to early-return-on-NULL-escape stops this throw.
+    // `SUBSTRING('abc', 1 / K) LIKE 'x' ESCAPE E` with `K = 0, E = NULL`. The
+    // operand is character (`SUBSTRING` returns text, so it passes the LIKE
+    // comparability check the compile now runs on the run path), but evaluating
+    // it faults `SQLError.divide` on its `1 / K` argument; the executor must
+    // evaluate the reached operand before deciding the NULL-escape UNKNOWN — an
+    // early return on the NULL escape would silently FILTER the row (UNKNOWN)
+    // and hide the divide. adversarial: reverting to early-return-on-a-NULL
+    // escape stops this throw. (The operand must be character-typed: a non-text
+    // one — `(1 / K) LIKE …` — is now the ISO 42804 data-type mismatch the
+    // compile-time comparability check faults on both paths, before the run
+    // ever divides, so it no longer exercises the run's evaluation order.)
     try faulting().expect(
-        "SELECT Id FROM F WHERE (1 / K) LIKE 'x' ESCAPE E",
+        "SELECT Id FROM F WHERE SUBSTRING('abc', 1 / K) LIKE 'x' ESCAPE E",
         fails: .divide)
   }
 

--- a/Tests/SQLTests/Queries/ComparabilityPlanningTests.swift
+++ b/Tests/SQLTests/Queries/ComparabilityPlanningTests.swift
@@ -275,3 +275,132 @@ struct LikeNullDeterminedPlanningTests {
     try joinable().expect(sql, fails: notText, bindings: ["p": .integer(1)])
   }
 }
+
+// MARK: - A carrier sort-key subquery is comparability-checked on both paths
+
+/// A nonempty relation with an integer `num` beside a text `txt`, enough to
+/// write a cross-kind `num = txt` comparison inside a query-level carrier sort
+/// key's subquery whose uncorrelated body a run over an empty carrier never
+/// evaluates.
+private func crossable() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("A", ["num": .integer, "txt": .text]) {
+      Row(1, "x")
+      Row(2, "y")
+    }
+  }
+}
+
+/// A `Query.ordered` carrier's `ORDER BY` may nest an `EXISTS`/`IN`/scalar
+/// subquery. Its uncorrelated body a run never materialises over an empty
+/// carrier — the sort evaluates no key — so a cross-kind comparison inside that
+/// body escaped the comparison-finder (the run returned empty) and the carrier
+/// validate branch (which type-checked the keys but not the subquery bodies):
+/// both accepted a query the equivalent plain `SELECT … ORDER BY` faults 42804.
+/// The finder and the validator now recurse each reached carrier sort-key
+/// subquery body — over the set-operation carrier and the recursive-CTE
+/// fixpoint's peeled `ORDER BY` alike — so the fault surfaces on both paths, in
+/// lockstep with the plain-select form, while an unreached or comparable body
+/// still does not fault.
+struct CarrierSubqueryComparabilityTests {
+  @Test func `a cross-kind set-op carrier sort-key subquery faults on both paths`()
+      throws {
+    // The `EXISTS` body's `a.num = a.txt` is cross-kind. Over the empty carrier
+    // the run evaluated no key, so it returned rows without faulting while the
+    // carrier validate branch never checked the body — both lenient where the
+    // plain `SELECT num FROM A ORDER BY CASE WHEN EXISTS (…) …` faults. The
+    // recursion closes it: run and validate now fault 42804.
+    let sql = """
+        SELECT num FROM A UNION ALL SELECT num FROM A
+          ORDER BY CASE WHEN EXISTS (SELECT 1 FROM A a WHERE a.num = a.txt)
+                        THEN 1 ELSE 0 END
+        """
+    let query = try parse(query: sql)
+    #expect(throws: intVsText) { try crossable().columns(of: query) }
+    try crossable().expect(sql, fails: intVsText)
+  }
+
+  @Test func `a cross-kind scalar carrier sort-key subquery faults on both paths`()
+      throws {
+    // A scalar (not `EXISTS`) sort-key subquery reaches the finder through the
+    // `.subquery` case, recorded only because `deferred` is seeded with the
+    // sort keys' scalar subqueries. Its body's `a.num = a.txt` faults 42804 on
+    // both paths too.
+    let sql = """
+        SELECT num FROM A UNION ALL SELECT num FROM A
+          ORDER BY (SELECT COUNT(*) FROM A a WHERE a.num = a.txt)
+        """
+    let query = try parse(query: sql)
+    #expect(throws: intVsText) { try crossable().columns(of: query) }
+    try crossable().expect(sql, fails: intVsText)
+  }
+
+  @Test func `a cross-kind recursive-CTE carrier sort-key subquery faults on both paths`()
+      throws {
+    // The recursive-CTE fixpoint peels its trailing `ORDER BY` and applies it
+    // through the same `carried` resolver, preflighting the keys in comparing
+    // mode (`Engine.apply`) and validating them (`Engine.validate(carrier:)`).
+    // A cross-kind `EXISTS` body inside that carrier ORDER BY faults 42804 on
+    // both — the run no longer sorts the materialised rows past it.
+    let catalog = try crossable()
+    let sql = """
+        WITH RECURSIVE t(n) AS (
+          SELECT 1 AS x
+          UNION ALL
+          SELECT n + 1 FROM t WHERE n < 3
+          ORDER BY CASE WHEN EXISTS (SELECT 1 FROM A a WHERE a.num = a.txt)
+                        THEN 0 ELSE 1 END
+        ) SELECT n FROM t
+        """
+    let statement = try Statement(parsing: sql)
+    let raised: SQLError?
+    do {
+      _ = try catalog.run(statement)
+      raised = nil
+    } catch let fault {
+      raised = fault
+    }
+    #expect(raised == intVsText)
+    #expect(throws: intVsText) {
+      _ = try catalog.columns(of: try Statement(parsing: sql), validate: true)
+    }
+  }
+
+  @Test func `a comparable carrier sort-key subquery does not fault`() throws {
+    // No over-reach: the `EXISTS` body's `a.num = a.num` is like-kind, so
+    // neither path faults and the run yields all four rows.
+    let sql = """
+        SELECT num FROM A UNION ALL SELECT num FROM A
+          ORDER BY CASE WHEN EXISTS (SELECT 1 FROM A a WHERE a.num = a.num)
+                        THEN 1 ELSE 0 END
+        """
+    _ = try crossable().columns(of: parse(query: sql))
+    try crossable().expect(sql, yields: [[1], [2], [1], [2]])
+  }
+
+  @Test func `an unreached carrier sort-key subquery does not fault`() throws {
+    // No over-reach: a constant-FALSE `AND` short-circuits before the
+    // cross-kind `EXISTS`, so the subquery is never recorded and never
+    // recursed — matching the run, which never materialises it. Neither path
+    // faults.
+    let sql = """
+        SELECT num FROM A UNION ALL SELECT num FROM A
+          ORDER BY CASE WHEN 1 = 0
+                            AND EXISTS (SELECT 1 FROM A a WHERE a.num = a.txt)
+                        THEN 1 ELSE 0 END
+        """
+    _ = try crossable().columns(of: parse(query: sql))
+    try crossable().expect(sql, yields: [[1], [2], [1], [2]])
+  }
+
+  @Test func `a bare arithmetic carrier key does not fault the finder`() throws {
+    // No over-reach: a carrier key that is a bare arithmetic expression carries
+    // no comparison and no subquery, so the finder faults nothing and the run
+    // orders the rows.
+    let sql = """
+        SELECT num FROM A UNION ALL SELECT num FROM A ORDER BY num + 1
+        """
+    _ = try crossable().columns(of: parse(query: sql))
+    try crossable().expect(sql, yields: [[1], [1], [2], [2]])
+  }
+}


### PR DESCRIPTION
A comparison whose operands are of incomparable declared types — a number against a string, a boolean against a blob — used to evaluate to a definite FALSE (the `default: false` arm of `matches`), and a non-boolean bare predicand (`WHERE Age`) silently yielded no rows through its `Age = TRUE` desugar. ISO 9075 requires a comparison's operands to be comparable; an incomparable pair is a data-type mismatch, not a FALSE-valued row. Raise it as SQLSTATE 42804.

The check lives at two mirrored seams so the run and the type-check agree:

  - Runtime: `matches` (and the row-wise `relate`, and `like`) fault 42804 on a cross-kind non-null pair rather than returning FALSE, exactly as `Arithmetic.apply` faults an ill-typed arithmetic operand. This is the sole choke point every comparison funnels through — scalar `=`/`<>`/`<`/…, IN (value list and subquery), BETWEEN, LIKE, quantified ANY/ALL, row comparison, and joins — so the run enforces ISO everywhere it evaluates a reachable operand. The run path never type-checks (`validate: false`), so it must fault at evaluation, matching the arithmetic precedent.

  - Validate: `Scope.check` derives both operand types and faults 42804 when they do not unify (`ValueType.unified`), reachability- and short-circuit- aware, so `columns(of: validate: true)` faults the same reachable operand a run would. Applied to `=`/`<>`/`<`/`>`/`<=`/`>=`, IN value lists, BETWEEN, LIKE (operand and pattern must be character), row comparison, and NULLIF's implicit `v1 = v2`.

run ≡ validate: both fault the same reachable cross-kind pair with the same SQLSTATE; both defer an unreachable one (a short-circuited AND/OR leg, a data-dependent-empty body). A constant-NULL operand is exempt on both paths — the run reads a NULL comparison as UNKNOWN (never a fault), so `text = NULL` stays UNKNOWN, three-valued logic unchanged. A subquery operand's static comparability defers to the run (its single-column type may be a nominal-NULL placeholder, which would else mis-reject a `SELECT NULL` body); the run still faults a cross-kind IN/quantified subquery through `relate`.

Consequence for the bare predicand: `WHERE p`/`HAVING p`/`ON p` lowers to `p = TRUE`, so a non-boolean `p` now faults (an integer against the boolean literal is incomparable), while a genuine boolean predicand (`p = TRUE`, like-kind) still passes.

Unchanged: `IS [NOT] DISTINCT FROM` stays total — a cross-kind pair is DISTINCT, never a fault — through a dedicated non-throwing equality kernel; NULL/UNKNOWN three-valued logic; and numeric integer/double promotion, which stays comparable (`1 = 1.0`). Compile-time constant folds swallow a would-be comparability fault to an undecided `nil` (as they already do a divide or overflow), so the optimiser keeps the compare and its fault surfaces at run.

Tests: flips the former cross-kind = FALSE / non-match assertions to assert the 42804 fault on both the run and the schema path (Membership, Between, Like, ValueType, and the bare-predicand tests), and adds a ComparabilityTests parity probe over scalar/row/subquery/NULL/promotion/DISTINCT shapes.